### PR TITLE
Improve git diff review with inline comments and stats

### DIFF
--- a/apps/app/src/components/git-diff/GitDiffCardBody.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCardBody.tsx
@@ -16,6 +16,7 @@ import type {
 import { FileDiff as DiffView } from "@pierre/diffs/react";
 import { useIntersectionObserver } from "usehooks-ts";
 import { Button } from "@bb/shared-ui/button";
+import type { DiffCommentDraftTarget } from "@/lib/prompt-draft";
 import { usePierreLineSelectionActions } from "./PierreLineSelectionActions.js";
 import {
   getWrappedImageIndex,
@@ -611,6 +612,10 @@ interface GitDiffCardRawDiffBodyProps {
   fileDiff: ParsedGitDiffFile;
   fileDiffOptions: Record<string, string | boolean | number>;
   onSelectionAddToChat?: (text: string) => void;
+  onSubmitDiffComment?: (
+    comment: string,
+    target: DiffCommentDraftTarget,
+  ) => void;
 }
 
 type DiffPatchDisplayStyle = "unified" | "split";
@@ -1117,9 +1122,11 @@ function GitDiffCardRawDiffBody({
   fileDiff,
   fileDiffOptions,
   onSelectionAddToChat,
+  onSubmitDiffComment,
 }: GitDiffCardRawDiffBodyProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const displayStyle = getDiffPatchDisplayStyle(fileDiffOptions);
+  const filePath = normalizeGitDiffPath(fileDiff.name) ?? fileDiff.name;
   const buildSelectionText = useCallback(
     (range: SelectedLineRange) =>
       buildDiffLineSelectionText({ displayStyle, fileDiff, range }),
@@ -1138,18 +1145,27 @@ function GitDiffCardRawDiffBody({
     buildFallbackSelectionText,
     buildSelectionText,
     containerRef,
-    enabled: onSelectionAddToChat !== undefined,
+    diffComment:
+      onSubmitDiffComment === undefined
+        ? undefined
+        : { filePath, onSubmit: onSubmitDiffComment },
+    enabled:
+      onSelectionAddToChat !== undefined || onSubmitDiffComment !== undefined,
     onSelectionAddToChat,
   });
   const options = useMemo<FileDiffOptions<undefined>>(
     () => ({
       ...fileDiffOptions,
-      enableGutterUtility: onSelectionAddToChat !== undefined,
-      enableLineSelection: onSelectionAddToChat !== undefined,
+      enableGutterUtility:
+        onSelectionAddToChat !== undefined || onSubmitDiffComment !== undefined,
+      enableLineSelection:
+        onSelectionAddToChat !== undefined || onSubmitDiffComment !== undefined,
       lineHoverHighlight:
-        onSelectionAddToChat === undefined ? "disabled" : "number",
+        onSelectionAddToChat === undefined && onSubmitDiffComment === undefined
+          ? "disabled"
+          : "number",
       onGutterUtilityClick:
-        onSelectionAddToChat === undefined
+        onSelectionAddToChat === undefined && onSubmitDiffComment === undefined
           ? undefined
           : lineSelectionActions.onGutterUtilityClick,
       onLineSelectionChange: lineSelectionActions.onLineSelectionChange,
@@ -1163,6 +1179,7 @@ function GitDiffCardRawDiffBody({
       lineSelectionActions.onLineSelectionEnd,
       lineSelectionActions.onLineSelectionStart,
       onSelectionAddToChat,
+      onSubmitDiffComment,
     ],
   );
   return (
@@ -1177,6 +1194,16 @@ function GitDiffCardRawDiffBody({
         <DiffView
           fileDiff={fileDiff}
           options={options}
+          lineAnnotations={
+            lineSelectionActions.commentAnnotation === null
+              ? undefined
+              : [lineSelectionActions.commentAnnotation]
+          }
+          renderAnnotation={
+            lineSelectionActions.commentInput === null
+              ? undefined
+              : () => lineSelectionActions.commentInput
+          }
           selectedLines={lineSelectionActions.selectedRange}
         />
       </div>
@@ -1192,6 +1219,10 @@ interface GitDiffCardSvgBodyProps {
   fileDiffLabel: string;
   fileDiffOptions: Record<string, string | boolean | number>;
   onSelectionAddToChat?: (text: string) => void;
+  onSubmitDiffComment?: (
+    comment: string,
+    target: DiffCommentDraftTarget,
+  ) => void;
 }
 
 function GitDiffCardSvgBody({
@@ -1201,6 +1232,7 @@ function GitDiffCardSvgBody({
   fileDiffLabel,
   fileDiffOptions,
   onSelectionAddToChat,
+  onSubmitDiffComment,
 }: GitDiffCardSvgBodyProps) {
   return displayMode === "preview" ? (
     <GitDiffCardImageBody
@@ -1213,6 +1245,7 @@ function GitDiffCardSvgBody({
       fileDiff={fileDiff}
       fileDiffOptions={fileDiffOptions}
       onSelectionAddToChat={onSelectionAddToChat}
+      onSubmitDiffComment={onSubmitDiffComment}
     />
   );
 }
@@ -1227,6 +1260,10 @@ export interface GitDiffCardBodyProps {
    */
   reservesCollapseGutter: boolean;
   onSelectionAddToChat?: (text: string) => void;
+  onSubmitDiffComment?: (
+    comment: string,
+    target: DiffCommentDraftTarget,
+  ) => void;
 }
 
 /**
@@ -1244,6 +1281,7 @@ export function GitDiffCardBody({
   svgDisplayMode,
   reservesCollapseGutter,
   onSelectionAddToChat,
+  onSubmitDiffComment,
 }: GitDiffCardBodyProps) {
   const {
     bodySentinelRef,
@@ -1300,12 +1338,14 @@ export function GitDiffCardBody({
           fileDiffLabel={fileDiffLabel}
           fileDiffOptions={fileDiffOptions}
           onSelectionAddToChat={onSelectionAddToChat}
+          onSubmitDiffComment={onSubmitDiffComment}
         />
       ) : (
         <GitDiffCardRawDiffBody
           fileDiff={enrichedFileDiff}
           fileDiffOptions={fileDiffOptions}
           onSelectionAddToChat={onSelectionAddToChat}
+          onSubmitDiffComment={onSubmitDiffComment}
         />
       )}
     </div>

--- a/apps/app/src/components/git-diff/PierreLineSelectionActions.test.tsx
+++ b/apps/app/src/components/git-diff/PierreLineSelectionActions.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useRef } from "react";
+import type { DiffCommentDraftTarget } from "@/lib/prompt-draft";
+import {
+  usePierreLineSelectionActions,
+  type PierreDiffCommentOptions,
+} from "./PierreLineSelectionActions";
+
+afterEach(() => {
+  cleanup();
+});
+
+function useTestLineSelectionActions(diffComment: PierreDiffCommentOptions) {
+  const containerRef = useRef<HTMLElement>(null);
+  return usePierreLineSelectionActions({
+    buildSelectionText: () => "selected lines",
+    containerRef,
+    diffComment,
+    enabled: true,
+  });
+}
+
+describe("usePierreLineSelectionActions", () => {
+  it("opens an inline annotation when a line selection ends", () => {
+    const onSubmit =
+      vi.fn<(comment: string, target: DiffCommentDraftTarget) => void>();
+    const { result } = renderHook(() =>
+      useTestLineSelectionActions({
+        filePath: "src/file.ts",
+        onSubmit,
+      }),
+    );
+
+    act(() => {
+      result.current.onLineSelectionStart({ start: 11, end: 11 });
+      result.current.onLineSelectionChange({ start: 11, end: 7 });
+      result.current.onLineSelectionEnd({ start: 11, end: 7 });
+    });
+
+    expect(result.current.commentAnnotation).toEqual({
+      lineNumber: 11,
+      side: "additions",
+    });
+
+    render(result.current.commentInput);
+    expect(screen.getByText("Lines 7–11")).toBeTruthy();
+    expect(screen.getByRole("textbox", { name: "Diff comment" })).toBeTruthy();
+  });
+
+  it("submits the selected file and ordered line range, then clears the annotation", () => {
+    const onSubmit =
+      vi.fn<(comment: string, target: DiffCommentDraftTarget) => void>();
+    const { result } = renderHook(() =>
+      useTestLineSelectionActions({
+        filePath: "src/file.ts",
+        onSubmit,
+      }),
+    );
+
+    act(() => {
+      result.current.onLineSelectionEnd({ start: 11, end: 7 });
+    });
+    render(result.current.commentInput);
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Diff comment" }), {
+      target: { value: "Use the shared helper." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Comment/ }));
+
+    expect(onSubmit).toHaveBeenCalledWith("Use the shared helper.", {
+      filePath: "src/file.ts",
+      startLine: 7,
+      endLine: 11,
+    });
+    expect(result.current.commentAnnotation).toBeNull();
+    expect(result.current.commentInput).toBeNull();
+  });
+});

--- a/apps/app/src/components/git-diff/PierreLineSelectionActions.tsx
+++ b/apps/app/src/components/git-diff/PierreLineSelectionActions.tsx
@@ -8,7 +8,9 @@ import {
   type ReactNode,
   type RefObject,
 } from "react";
-import type { SelectedLineRange } from "@pierre/diffs";
+import type { DiffLineAnnotation, SelectedLineRange } from "@pierre/diffs";
+import { Button } from "@bb/shared-ui/button";
+import { Textarea } from "@bb/shared-ui/textarea";
 import {
   anchorPointFromMouseEvent,
   selectionAnchorFromPointerRelease,
@@ -17,6 +19,7 @@ import {
   type SelectionAnchorPoint,
   type SelectionAnchorSide,
 } from "@/components/thread/timeline/SelectableMessageProse.js";
+import type { DiffCommentDraftTarget } from "@/lib/prompt-draft";
 import { TimelineSelectionMenu } from "@/components/thread/timeline/TimelineSelectionMenu.js";
 
 const LINE_SELECTION_MENU_INLINE_OFFSET_PX = 72;
@@ -26,6 +29,11 @@ let documentPointerReleaseAnchor: SelectionAnchor | null = null;
 
 export type PierreLineSelectionAnchorPoint = SelectionAnchorPoint;
 
+export interface PierreDiffCommentOptions {
+  filePath: string;
+  onSubmit: (comment: string, target: DiffCommentDraftTarget) => void;
+}
+
 export interface UsePierreLineSelectionActionsArgs {
   buildFallbackSelectionText?: (args: {
     containerElement: HTMLElement | null;
@@ -33,6 +41,7 @@ export interface UsePierreLineSelectionActionsArgs {
   }) => string | null;
   buildSelectionText: (range: SelectedLineRange) => string | null;
   containerRef: RefObject<HTMLElement | null>;
+  diffComment?: PierreDiffCommentOptions;
   enabled: boolean;
   onSelectionAddToChat?: (text: string) => void;
   resolveAnchorPoint?: (args: {
@@ -44,6 +53,8 @@ export interface UsePierreLineSelectionActionsArgs {
 }
 
 export interface PierreLineSelectionActions {
+  commentAnnotation: DiffLineAnnotation | null;
+  commentInput: ReactNode;
   menu: ReactNode;
   onLineSelectionChange: (range: SelectedLineRange | null) => void;
   onLineSelectionEnd: (range: SelectedLineRange | null) => void;
@@ -53,6 +64,76 @@ export interface PierreLineSelectionActions {
   onPointerMoveCapture: (event: ReactPointerEvent<HTMLElement>) => void;
   onPointerUpCapture: (event: ReactPointerEvent<HTMLElement>) => void;
   selectedRange: SelectedLineRange | null;
+}
+
+function InlineDiffCommentInput({
+  onCancel,
+  onSubmit,
+  range,
+}: {
+  onCancel: () => void;
+  onSubmit: (comment: string) => void;
+  range: SelectedLineRange;
+}) {
+  const [text, setText] = useState("");
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const startLine = Math.min(range.start, range.end);
+  const endLine = Math.max(range.start, range.end);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  return (
+    <div
+      className="border-y border-border bg-background px-6 py-4 font-sans text-foreground"
+      data-diff-comment-input="true"
+    >
+      <form
+        className="flex flex-col gap-2"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const comment = text.trim();
+          if (comment.length === 0) {
+            return;
+          }
+          onSubmit(comment);
+        }}
+      >
+        <div className="font-mono text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Lines {startLine}–{endLine}
+        </div>
+        <Textarea
+          ref={inputRef}
+          aria-label="Diff comment"
+          rows={4}
+          value={text}
+          onChange={(event) => setText(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+              event.preventDefault();
+              event.currentTarget.form?.requestSubmit();
+            }
+          }}
+          placeholder="Add a comment for the AI"
+          className="min-h-24 resize-y bg-background text-sm"
+        />
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            variant="secondary"
+            size="sm"
+            disabled={text.trim().length === 0}
+          >
+            Comment <span aria-hidden="true">↵</span>
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
 }
 
 function fallbackAnchorPoint(
@@ -284,6 +365,7 @@ export function usePierreLineSelectionActions({
   buildFallbackSelectionText,
   buildSelectionText,
   containerRef,
+  diffComment,
   enabled,
   onSelectionAddToChat,
   resolveAnchorPoint,
@@ -296,6 +378,8 @@ export function usePierreLineSelectionActions({
   );
   const [activeSelection, setActiveSelection] =
     useState<MessageProseSelection | null>(null);
+  const [inlineCommentRange, setInlineCommentRange] =
+    useState<SelectedLineRange | null>(null);
   const pointerStartPointRef = useRef<SelectionAnchorPoint | null>(null);
   const lastPointerReleaseAnchorRef = useRef<SelectionAnchor | null>(null);
   const lastLineSelectionAnchorRef = useRef<SelectionAnchor | null>(null);
@@ -453,6 +537,7 @@ export function usePierreLineSelectionActions({
     setActiveRange(null);
     setPreviewRange(null);
     setActiveSelection(null);
+    setInlineCommentRange(null);
     currentLineRangeRef.current = null;
     pointerStartPointRef.current = null;
     lastPointerReleaseAnchorRef.current = null;
@@ -463,19 +548,48 @@ export function usePierreLineSelectionActions({
     documentPointerReleaseAnchor = null;
   }, []);
 
+  const getSelectionText = useCallback(
+    (range: SelectedLineRange) =>
+      (
+        buildSelectionText(range) ??
+        buildFallbackSelectionText?.({
+          containerElement: containerRef.current,
+          range,
+        }) ??
+        ""
+      ).trim(),
+    [buildFallbackSelectionText, buildSelectionText, containerRef],
+  );
+
+  const handleOpenInlineComment = useCallback(
+    (range: SelectedLineRange) => {
+      if (diffComment === undefined) {
+        return;
+      }
+      if (getSelectionText(range) === "") {
+        dismissSelection();
+        return;
+      }
+      currentLineRangeRef.current = range;
+      setActiveRange(range);
+      setPreviewRange(range);
+      setActiveSelection(null);
+      setInlineCommentRange(range);
+    },
+    [diffComment, dismissSelection, getSelectionText],
+  );
+
   const handleGutterUtilityClick = useCallback(
     (range: SelectedLineRange) => {
       if (!enabled) {
         return;
       }
+      if (diffComment !== undefined) {
+        handleOpenInlineComment(range);
+        return;
+      }
       const containerElement = containerRef.current;
-      const selectionText =
-        buildSelectionText(range) ??
-        buildFallbackSelectionText?.({
-          containerElement,
-          range,
-        }) ??
-        "";
+      const selectionText = getSelectionText(range);
       const pointerAnchor =
         lastLineSelectionAnchorRef.current ??
         lastPointerReleaseAnchorRef.current ??
@@ -522,6 +636,7 @@ export function usePierreLineSelectionActions({
         setActiveRange(null);
         setPreviewRange(null);
         setActiveSelection(null);
+        setInlineCommentRange(null);
         currentLineRangeRef.current = null;
         return;
       }
@@ -532,10 +647,11 @@ export function usePierreLineSelectionActions({
       setActiveSelection(selection);
     },
     [
-      buildFallbackSelectionText,
-      buildSelectionText,
       containerRef,
+      diffComment,
       enabled,
+      getSelectionText,
+      handleOpenInlineComment,
       resolveAnchorPoint,
     ],
   );
@@ -551,6 +667,7 @@ export function usePierreLineSelectionActions({
       lineSelectionStartRangeRef.current = range;
       setActiveRange(null);
       setActiveSelection(null);
+      setInlineCommentRange(null);
       setPreviewRange(range);
     },
     [enabled],
@@ -591,8 +708,11 @@ export function usePierreLineSelectionActions({
         lastLineSelectionAnchorRef.current = pointerAnchor;
       }
       setPreviewRange(range);
+      if (range !== null && diffComment !== undefined) {
+        handleOpenInlineComment(range);
+      }
     },
-    [enabled],
+    [diffComment, enabled, handleOpenInlineComment],
   );
 
   const handleSelectionAddToChat = useCallback(
@@ -601,6 +721,21 @@ export function usePierreLineSelectionActions({
       dismissSelection();
     },
     [dismissSelection, onSelectionAddToChat],
+  );
+
+  const handleSubmitDiffComment = useCallback(
+    (comment: string) => {
+      if (diffComment === undefined || inlineCommentRange === null) {
+        return;
+      }
+      diffComment.onSubmit(comment, {
+        filePath: diffComment.filePath,
+        startLine: Math.min(inlineCommentRange.start, inlineCommentRange.end),
+        endLine: Math.max(inlineCommentRange.start, inlineCommentRange.end),
+      });
+      dismissSelection();
+    },
+    [diffComment, dismissSelection, inlineCommentRange],
   );
 
   const menu = useMemo(
@@ -626,6 +761,28 @@ export function usePierreLineSelectionActions({
   );
 
   return {
+    commentAnnotation:
+      inlineCommentRange === null
+        ? null
+        : {
+            lineNumber: Math.max(
+              inlineCommentRange.start,
+              inlineCommentRange.end,
+            ),
+            side:
+              inlineCommentRange.endSide ??
+              inlineCommentRange.side ??
+              "additions",
+          },
+    commentInput:
+      inlineCommentRange === null ? null : (
+        <InlineDiffCommentInput
+          key={`${inlineCommentRange.start}:${inlineCommentRange.end}:${inlineCommentRange.side ?? ""}:${inlineCommentRange.endSide ?? ""}`}
+          onCancel={dismissSelection}
+          onSubmit={handleSubmitDiffComment}
+          range={inlineCommentRange}
+        />
+      ),
     menu,
     onGutterUtilityClick: handleGutterUtilityClick,
     onLineSelectionChange: handleLineSelectionChange,

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -82,6 +82,7 @@ import type { AppShortcutPresentation } from "@/lib/app-keybindings";
 import { TabPill } from "@/components/ui/tab-pill";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
 import { dispatchBrowserViewBoundsSync } from "@/lib/browser-view-bounds-sync";
+import type { DiffCommentDraftTarget } from "@/lib/prompt-draft";
 export type {
   GitDiffDisplayMode,
   GitDiffSelectionOption,
@@ -274,6 +275,10 @@ export interface ThreadSecondaryPanelProps {
   onOpenFileInEditor?: (path: string) => void;
   onOpenFilePreview?: (path: string) => void;
   onSelectionAddToChat?: (text: string) => void;
+  onSubmitDiffComment?: (
+    comment: string,
+    target: DiffCommentDraftTarget,
+  ) => void;
   /**
    * When true the conversation pane is collapsed: this panel expands to fill
    * the content area (its max size is lifted). Always false in the
@@ -348,6 +353,7 @@ export function ThreadSecondaryPanel({
   onOpenFileInEditor,
   onOpenFilePreview,
   onSelectionAddToChat,
+  onSubmitDiffComment,
   isConversationCollapsed,
   onToggleConversationCollapse,
   renderAsDrawer,
@@ -820,6 +826,7 @@ export function ThreadSecondaryPanel({
             onOpenFileInEditor={onOpenFileInEditor}
             onOpenFilePreview={onOpenFilePreview}
             onSelectionAddToChat={onSelectionAddToChat}
+            onSubmitDiffComment={onSubmitDiffComment}
             workspaceRootPath={workspaceRootPath}
           />
         ) : (

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
@@ -22,6 +22,7 @@ import type {
   FilePreviewLineRange,
   WorkspaceFilePreviewStatusLabel,
 } from "@/lib/file-preview";
+import type { DiffCommentDraftTarget } from "@/lib/prompt-draft";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { DiffFilesPanel } from "./git-diff/DiffFilesPanel";
 import { clearDiffFileCardStates } from "./git-diff/diffFilesStore";
@@ -49,6 +50,10 @@ export interface GitDiffTabContentProps {
   onOpenFileInEditor?: (path: string) => void;
   onOpenFilePreview?: (path: string) => void;
   onSelectionAddToChat?: (text: string) => void;
+  onSubmitDiffComment?: (
+    comment: string,
+    target: DiffCommentDraftTarget,
+  ) => void;
   workspaceRootPath?: string | null;
 }
 
@@ -148,6 +153,7 @@ export function GitDiffTabContent({
   onOpenFileInEditor,
   onOpenFilePreview,
   onSelectionAddToChat,
+  onSubmitDiffComment,
   workspaceRootPath,
 }: GitDiffTabContentProps) {
   const isQueryEnabled =
@@ -293,6 +299,7 @@ export function GitDiffTabContent({
       onOpenFilePreview={onOpenFilePreview}
       onRequestFileContents={onRequestFileContents}
       onSelectionAddToChat={onSelectionAddToChat}
+      onSubmitDiffComment={onSubmitDiffComment}
     />
   );
 }

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
@@ -30,6 +30,7 @@ import { FilePathLink } from "@/components/ui/file-path-link.js";
 import { Skeleton } from "@bb/shared-ui/skeleton";
 import type { DiffPatchState } from "@/hooks/queries/use-environment-diff-patches";
 import { cn } from "@bb/shared-ui/lib/utils";
+import type { DiffCommentDraftTarget } from "@/lib/prompt-draft";
 
 /**
  * Build the file label for a TOC entry. Renames/copies read as `old -> new`;
@@ -135,6 +136,10 @@ export interface DiffFileCardProps {
   onOpenFilePreview?: (path: string) => void;
   onRequestFileContents?: RequestDiffFileContents;
   onSelectionAddToChat?: (text: string) => void;
+  onSubmitDiffComment?: (
+    comment: string,
+    target: DiffCommentDraftTarget,
+  ) => void;
 }
 
 /**
@@ -184,6 +189,7 @@ function areDiffFileCardPropsEqual(
     previous.onOpenFilePreview === next.onOpenFilePreview &&
     previous.onRequestFileContents === next.onRequestFileContents &&
     previous.onSelectionAddToChat === next.onSelectionAddToChat &&
+    previous.onSubmitDiffComment === next.onSubmitDiffComment &&
     arePatchStatesEqual(previous.patchState, next.patchState)
   );
 }
@@ -286,6 +292,7 @@ export const DiffFileCard = memo(function DiffFileCard({
   onOpenFilePreview,
   onRequestFileContents,
   onSelectionAddToChat,
+  onSubmitDiffComment,
 }: DiffFileCardProps) {
   const headerModel = useMemo(() => buildDiffEntryHeaderModel(entry), [entry]);
   // The single file's patch, parsed only once it has loaded. The patch hook
@@ -409,6 +416,7 @@ export const DiffFileCard = memo(function DiffFileCard({
           onOpenFilePreview={onOpenFilePreview}
           onRequestFileContents={onRequestFileContents}
           onSelectionAddToChat={onSelectionAddToChat}
+          onSubmitDiffComment={onSubmitDiffComment}
           binaryImagePreviewState={
             shouldDirectlyPreviewBinaryImage
               ? binaryImagePreviewState
@@ -432,6 +440,10 @@ interface DiffFileCardBodyProps {
   onOpenFilePreview?: (path: string) => void;
   onRequestFileContents?: RequestDiffFileContents;
   onSelectionAddToChat?: (text: string) => void;
+  onSubmitDiffComment?: (
+    comment: string,
+    target: DiffCommentDraftTarget,
+  ) => void;
   binaryImagePreviewState?: BinaryImagePreviewState;
 }
 
@@ -492,6 +504,7 @@ function DiffFileCardBody({
   onOpenFilePreview,
   onRequestFileContents,
   onSelectionAddToChat,
+  onSubmitDiffComment,
   binaryImagePreviewState,
 }: DiffFileCardBodyProps) {
   if (binaryImagePreviewState !== undefined) {
@@ -603,6 +616,7 @@ function DiffFileCardBody({
       onOpenFilePreview={onOpenFilePreview}
       onRequestFileContents={onRequestFileContents}
       onSelectionAddToChat={onSelectionAddToChat}
+      onSubmitDiffComment={onSubmitDiffComment}
     />
   );
 }
@@ -617,6 +631,10 @@ interface DiffFileCardRenderedBodyProps {
   onOpenFilePreview?: (path: string) => void;
   onRequestFileContents?: RequestDiffFileContents;
   onSelectionAddToChat?: (text: string) => void;
+  onSubmitDiffComment?: (
+    comment: string,
+    target: DiffCommentDraftTarget,
+  ) => void;
 }
 
 /**
@@ -636,6 +654,7 @@ function DiffFileCardRenderedBody({
   onOpenFilePreview,
   onRequestFileContents,
   onSelectionAddToChat,
+  onSubmitDiffComment,
 }: DiffFileCardRenderedBodyProps) {
   const bodyState = useGitDiffCardBody({
     fileDiff: parsedFile,
@@ -652,6 +671,7 @@ function DiffFileCardRenderedBody({
         svgDisplayMode={svgDisplayMode}
         reservesCollapseGutter
         onSelectionAddToChat={onSelectionAddToChat}
+        onSubmitDiffComment={onSubmitDiffComment}
       />
       {truncated ? (
         <div className={DIFF_FILE_CARD_NOTICE_CLASS}>

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFilesPanel.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFilesPanel.tsx
@@ -4,6 +4,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import type { DiffFileEntry, DiffPatchEntry } from "@bb/server-contract";
 import type { WorkspaceDiffTarget } from "@bb/domain";
 import type { RequestDiffFileContents } from "@/components/git-diff/GitDiffCardBody";
+import type { DiffCommentDraftTarget } from "@/lib/prompt-draft";
 import {
   type DiffPatchState,
   type LoadDiffPatchPath,
@@ -62,6 +63,10 @@ export interface DiffFilesPanelProps {
   onOpenFilePreview?: (path: string) => void;
   onRequestFileContents?: RequestDiffFileContents;
   onSelectionAddToChat?: (text: string) => void;
+  onSubmitDiffComment?: (
+    comment: string,
+    target: DiffCommentDraftTarget,
+  ) => void;
 }
 
 /**
@@ -87,6 +92,7 @@ export function DiffFilesPanel({
   onOpenFilePreview,
   onRequestFileContents,
   onSelectionAddToChat,
+  onSubmitDiffComment,
 }: DiffFilesPanelProps) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const { requestPaths, getPatchState, retry, loadPath, seedInitialPatches } =
@@ -227,6 +233,7 @@ export function DiffFilesPanel({
                 onOpenFilePreview={onOpenFilePreview}
                 onRequestFileContents={onRequestFileContents}
                 onSelectionAddToChat={onSelectionAddToChat}
+                onSubmitDiffComment={onSubmitDiffComment}
               />
             </div>
           );
@@ -252,6 +259,10 @@ interface DiffFileRowProps {
   onOpenFilePreview?: (path: string) => void;
   onRequestFileContents?: RequestDiffFileContents;
   onSelectionAddToChat?: (text: string) => void;
+  onSubmitDiffComment?: (
+    comment: string,
+    target: DiffCommentDraftTarget,
+  ) => void;
 }
 
 function DiffFileRow({
@@ -267,6 +278,7 @@ function DiffFileRow({
   onOpenFilePreview,
   onRequestFileContents,
   onSelectionAddToChat,
+  onSubmitDiffComment,
 }: DiffFileRowProps) {
   const stateAtom = useMemo(
     () => diffFileCardStateAtomFamily({ diffIdentity, path: entry.path }),
@@ -305,6 +317,7 @@ function DiffFileRow({
       onOpenFilePreview={onOpenFilePreview}
       onRequestFileContents={onRequestFileContents}
       onSelectionAddToChat={onSelectionAddToChat}
+      onSubmitDiffComment={onSubmitDiffComment}
     />
   );
 }

--- a/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
@@ -36,6 +36,10 @@ vi.mock("@/hooks/useThreadSplitsEnabled", () => ({
   useThreadSplitsEnabled: () => false,
 }));
 
+vi.mock("@/hooks/queries/environment-queries", () => ({
+  useEnvironmentWorkStatus: () => ({ data: undefined }),
+}));
+
 vi.mock("@/hooks/mutations/environment-mutations", () => ({
   useArchiveEnvironmentThreads: () => ({
     isPending: false,

--- a/apps/app/src/components/sidebar/ThreadDiffStatsLabel.tsx
+++ b/apps/app/src/components/sidebar/ThreadDiffStatsLabel.tsx
@@ -1,0 +1,73 @@
+import { formatCompactDiffCount, formatDiffCount } from "@bb/thread-view";
+import { cn } from "@bb/shared-ui/lib/utils";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
+import { useEnvironmentWorkStatus } from "@/hooks/queries/environment-queries";
+import { selectWorkspaceChangedFilesSection } from "@/components/workspace/workspace-change-summary";
+
+interface ThreadDiffStatsLabelProps {
+  className?: string;
+  environmentId: string | null;
+}
+
+interface ThreadEnvironmentDiffStatsLabelProps {
+  className?: string;
+  environmentId: string;
+}
+
+export function ThreadDiffStatsLabel({
+  className,
+  environmentId,
+}: ThreadDiffStatsLabelProps) {
+  if (environmentId === null) return null;
+
+  return (
+    <ThreadEnvironmentDiffStatsLabel
+      className={className}
+      environmentId={environmentId}
+    />
+  );
+}
+
+function ThreadEnvironmentDiffStatsLabel({
+  className,
+  environmentId,
+}: ThreadEnvironmentDiffStatsLabelProps) {
+  const { data } = useEnvironmentWorkStatus(environmentId);
+  const workspaceStatus =
+    data?.outcome === "available" ? data.workspace : undefined;
+  const changedFilesSection =
+    selectWorkspaceChangedFilesSection(workspaceStatus);
+  const added = changedFilesSection?.stats.insertions ?? 0;
+  const removed = changedFilesSection?.stats.deletions ?? 0;
+
+  if (changedFilesSection === null || (added === 0 && removed === 0)) {
+    return null;
+  }
+
+  const addedLabel = formatDiffCount(added);
+  const removedLabel = formatDiffCount(removed);
+  const summaryLabel = `+${addedLabel} -${removedLabel} lines changed`;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className={cn(
+            "shrink-0 whitespace-nowrap font-mono text-xs",
+            className,
+          )}
+          aria-label={`+${addedLabel} lines added, -${removedLabel} lines removed`}
+          data-sidebar-thread-diff-stats=""
+        >
+          <span className="text-diff-added">
+            +{formatCompactDiffCount(added)}
+          </span>{" "}
+          <span className="text-diff-removed">
+            -{formatCompactDiffCount(removed)}
+          </span>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top">{summaryLabel}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/app/src/components/sidebar/ThreadRow.test.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.test.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from "react";
 import { createStore, Provider } from "jotai";
 import type { ThreadListEntry } from "@bb/domain";
 import type { PluginComposerThreadRowStatus } from "@bb/plugin-sdk";
+import { TooltipProvider } from "@bb/shared-ui/tooltip";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ThreadRow, type ThreadRowOptions } from "./ThreadRow";
 import { SidebarThreadTitleMentionResourcesProvider } from "./SidebarThreadTitleMentions";
@@ -27,6 +28,34 @@ import { NO_COLLAPSED_CHILD_ACTIVITY } from "@/lib/thread-activity";
 
 vi.mock("@/hooks/useThreadSplitsEnabled", () => ({
   useThreadSplitsEnabled: () => true,
+}));
+
+vi.mock("@/hooks/queries/environment-queries", () => ({
+  useEnvironmentWorkStatus: (environmentId: string | null) => ({
+    data:
+      environmentId === null
+        ? undefined
+        : {
+            outcome: "available",
+            workspace: {
+              workingTree: {
+                state: "modified",
+                hasUncommittedChanges: true,
+                files: [
+                  {
+                    path: "src/example.ts",
+                    status: "M",
+                    insertions: 1_234,
+                    deletions: 12_345,
+                  },
+                ],
+                insertions: 1_234,
+                deletions: 12_345,
+              },
+              mergeBase: null,
+            },
+          },
+  }),
 }));
 
 vi.mock("@/components/thread/ThreadActionsMenu", () => ({
@@ -116,17 +145,19 @@ function ThreadRowTestHarness({
 
   return (
     <MemoryRouter>
-      <SidebarThreadShortcutKeysContext.Provider value={shortcutKeys}>
-        <ThreadRow
-          projectId={thread.projectId}
-          thread={thread}
-          isActive={isActive}
-          hasComposerDraft={hasComposerDraft}
-          options={options}
-          displayTitle={displayTitle}
-          accessibleTitle={accessibleTitle}
-        />
-      </SidebarThreadShortcutKeysContext.Provider>
+      <TooltipProvider>
+        <SidebarThreadShortcutKeysContext.Provider value={shortcutKeys}>
+          <ThreadRow
+            projectId={thread.projectId}
+            thread={thread}
+            isActive={isActive}
+            hasComposerDraft={hasComposerDraft}
+            options={options}
+            displayTitle={displayTitle}
+            accessibleTitle={accessibleTitle}
+          />
+        </SidebarThreadShortcutKeysContext.Provider>
+      </TooltipProvider>
     </MemoryRouter>
   );
 }
@@ -229,6 +260,21 @@ afterEach(() => {
 });
 
 describe("ThreadRow", () => {
+  it("renders compact added and removed line counts", () => {
+    renderThreadRow({
+      thread: createThread({
+        environmentId: "env_test",
+      }),
+    });
+
+    const stats = screen.getByLabelText(
+      "+1,234 lines added, -12,345 lines removed",
+    );
+    expect(stats.textContent).toBe("+1.2k -12k");
+    expect(stats.classList.contains("ml-auto")).toBe(true);
+    expect(stats.classList.contains("text-right")).toBe(true);
+  });
+
   const splitWorkingCases: Array<{
     label: string;
     pluginStatus?: PluginComposerThreadRowStatus;

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -73,6 +73,7 @@ import { AppCommandShortcutPill } from "@/components/commands/AppCommandShortcut
 import { useThreadTitleDisplayText } from "@/components/thread/ThreadTitleMentions";
 import { pluginIconName } from "@/components/plugin/PluginIcon";
 import { usePluginThreadRowStatus } from "@/lib/plugin-thread-row-status";
+import { ThreadDiffStatsLabel } from "./ThreadDiffStatsLabel";
 
 interface ThreadRowBaseOptions {
   depth: number;
@@ -643,6 +644,10 @@ function ThreadRowComponent({
         <span className="min-w-0 truncate" title={labelTitle}>
           <SidebarThreadTitle title={visibleTitle} />
         </span>
+        <ThreadDiffStatsLabel
+          environmentId={thread.environmentId}
+          className="ml-auto text-right"
+        />
         {parentOptions && hasChildren ? (
           <SidebarChildToggleChevron
             isCollapsed={isParentCollapsed}

--- a/apps/app/src/components/sidebar/ThreadSearchResultRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadSearchResultRow.tsx
@@ -25,6 +25,7 @@ import {
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { ThreadStatusGlyph } from "./ThreadRow";
+import { ThreadDiffStatsLabel } from "./ThreadDiffStatsLabel";
 import { isSidebarThreadTitleMatch } from "./sidebarThreadSearch";
 import { usePromptDraftHasInput } from "@/hooks/usePromptDraftStorage";
 import {
@@ -220,6 +221,10 @@ function ThreadSearchResultRowComponent({
             <Icon name="Folder" className="size-3.5 shrink-0" aria-hidden />
           ) : null}
           <span className="min-w-0 truncate">{metadataText}</span>
+          <ThreadDiffStatsLabel
+            environmentId={thread.environmentId}
+            className="ml-auto"
+          />
         </span>
       </span>
       {indicatorKind !== "none" ? (

--- a/apps/app/src/lib/prompt-draft.test.ts
+++ b/apps/app/src/lib/prompt-draft.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { PromptMentionResource } from "@bb/domain";
 import {
+  appendDiffCommentToDraft,
   appendQuoteAndAttachmentsToDraft,
   appendQuoteToDraftText,
   emptyPromptDraftState,
@@ -337,6 +338,70 @@ describe("appendQuoteToDraftText", () => {
 
     expect(next.mentions).toEqual([mention]);
     expect(next.text.startsWith(text)).toBe(true);
+  });
+});
+
+describe("appendDiffCommentToDraft", () => {
+  it("adds a workspace file mention and line range to an empty draft", () => {
+    const next = appendDiffCommentToDraft(
+      emptyPromptDraftState(),
+      "Use a helper.",
+      {
+        filePath: "src/file.ts",
+        startLine: 12,
+        endLine: 14,
+      },
+    );
+
+    expect(next.text).toBe("@src/file.ts (lines 12-14)\nUse a helper.");
+    expect(next.mentions).toEqual([
+      {
+        start: 0,
+        end: "@src/file.ts".length,
+        resource: {
+          kind: "path",
+          source: "workspace",
+          entryKind: "file",
+          path: "src/file.ts",
+          label: "src/file.ts",
+        },
+      },
+    ]);
+  });
+
+  it("appends comments without changing existing mention offsets", () => {
+    const resource: PromptMentionResource = {
+      kind: "thread",
+      threadId: "thr_parent",
+      label: "Parent thread",
+    };
+    const base = {
+      text: "@thread",
+      mentions: [{ start: 0, end: 7, resource }],
+      attachments: [],
+    };
+
+    const next = appendDiffCommentToDraft(base, "Check this path.", {
+      filePath: "README.md",
+      startLine: 1,
+      endLine: 1,
+    });
+
+    expect(next.text).toBe("@thread\n\n@README.md (line 1)\nCheck this path.");
+    expect(next.mentions[0]).toEqual(base.mentions[0]);
+    expect(next.mentions[1]?.start).toBe("@thread\n\n".length);
+  });
+
+  it("ignores blank comments or file paths", () => {
+    const base = emptyPromptDraftState();
+    const target = { filePath: "src/file.ts", startLine: 1, endLine: 1 };
+    expect(appendDiffCommentToDraft(base, "  ", target)).toBe(base);
+    expect(
+      appendDiffCommentToDraft(base, "Comment", {
+        ...target,
+        filePath: " ",
+      }),
+    ).toBe(base);
   });
 });
 

--- a/apps/app/src/lib/prompt-draft.ts
+++ b/apps/app/src/lib/prompt-draft.ts
@@ -1,5 +1,6 @@
 import {
   promptTextMentionSchema,
+  type PromptMentionResource,
   type PromptInput,
   type PromptTextMention,
 } from "@bb/domain";
@@ -125,6 +126,64 @@ export function appendQuoteAndAttachmentsToDraft(
   }
 
   return { ...quotedState, attachments: mergedAttachments };
+}
+
+export interface DiffCommentDraftTarget {
+  filePath: string;
+  startLine: number;
+  endLine: number;
+}
+
+function formatDiffCommentLineReference({
+  startLine,
+  endLine,
+}: DiffCommentDraftTarget): string {
+  return startLine === endLine
+    ? ` (line ${startLine})`
+    : ` (lines ${startLine}-${endLine})`;
+}
+
+/**
+ * Append a diff comment and its workspace-file mention to the thread draft.
+ * The file mention uses the same offset contract as the prompt editor, so the
+ * composer renders it as a file pill and keeps the line reference visible.
+ */
+export function appendDiffCommentToDraft(
+  state: PromptDraftState,
+  comment: string,
+  target: DiffCommentDraftTarget,
+): PromptDraftState {
+  const trimmedComment = comment.trim();
+  const filePath = target.filePath.trim();
+  if (trimmedComment === "" || filePath === "") {
+    return state;
+  }
+
+  const separator = state.text.length > 0 ? "\n\n" : "";
+  const fileReference = `@${filePath}`;
+  const lineReference = formatDiffCommentLineReference(target);
+  const nextText = `${state.text}${separator}${fileReference}${lineReference}\n${trimmedComment}`;
+  const mentionStart = state.text.length + separator.length;
+  const fileResource: PromptMentionResource = {
+    kind: "path",
+    source: "workspace",
+    entryKind: "file",
+    path: filePath,
+    label: filePath,
+  };
+
+  return {
+    ...state,
+    text: nextText,
+    mentions: [
+      ...state.mentions,
+      {
+        start: mentionStart,
+        end: mentionStart + fileReference.length,
+        resource: fileResource,
+      },
+    ],
+  };
 }
 
 export function isPromptDraftEmpty(draft: PromptDraftState): boolean {

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -97,7 +97,11 @@ import {
 } from "@/components/workspace/workspace-change-summary";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { getMutationErrorMessage } from "@/lib/mutation-errors";
-import type { PromptDraftAttachment } from "@/lib/prompt-draft";
+import {
+  appendDiffCommentToDraft,
+  type PromptDraftAttachment,
+  type DiffCommentDraftTarget,
+} from "@/lib/prompt-draft";
 import { createLocalStorageEnumStorage } from "@/lib/browser-storage";
 import {
   getProjectComposeRoutePath,
@@ -895,6 +899,8 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
     threadId: thread?.id ?? "",
   });
   const addQuoteToComposer = selectionPromptDraft.addQuote;
+  const getCurrentPromptDraft = selectionPromptDraft.getCurrent;
+  const setPromptDraft = selectionPromptDraft.setDraft;
   // Desktop quote actions keep their existing focus handoff. Mobile web does
   // not focus inputs programmatically; see PromptBoxInternal.
   const [composerFocusRequestNonce, setComposerFocusRequestNonce] = useState(0);
@@ -914,6 +920,16 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
       setComposerFocusRequestNonce((nonce) => nonce + 1);
     },
     [addQuoteToComposer, dismissCompactKeyboard],
+  );
+  const handleSubmitDiffComment = useCallback(
+    (comment: string, target: DiffCommentDraftTarget) => {
+      const currentDraft = getCurrentPromptDraft();
+      const nextDraft = appendDiffCommentToDraft(currentDraft, comment, target);
+      if (nextDraft !== currentDraft) {
+        setPromptDraft(nextDraft);
+      }
+    },
+    [getCurrentPromptDraft, setPromptDraft],
   );
   const sendSideChatMessageToMain =
     useCallback<ThreadTimelineSendToMainMessageHandler>(
@@ -2558,6 +2574,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
             onOpenNewTab: handleOpenNewTab,
             onOpenFilePreview: handleOpenFilePreview,
             onSelectionAddToChat: handleSelectionAddToChat,
+            onSubmitDiffComment: handleSubmitDiffComment,
             onPanelFocus: handleSecondaryPanelFocus,
             onPanelChange: handleSecondaryPanelChange,
             showGitDiffTab: canUseGitUi,

--- a/packages/thread-view/src/format-helpers.ts
+++ b/packages/thread-view/src/format-helpers.ts
@@ -80,6 +80,45 @@ export function formatDiffCount(value: number): string {
 }
 
 /**
+ * Formats unit-suffixed diff counts with two significant digits. Values below
+ * one thousand remain exact (for example, `999`, `1.1k`, or `12M`).
+ */
+export function formatCompactDiffCount(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) return "0";
+
+  const roundedValue = Math.round(value);
+  if (roundedValue < 1_000) return String(roundedValue);
+
+  const units = [
+    { divisor: 1_000_000_000_000, suffix: "T" },
+    { divisor: 1_000_000_000, suffix: "B" },
+    { divisor: 1_000_000, suffix: "M" },
+    { divisor: 1_000, suffix: "k" },
+  ] as const;
+  for (const [index, { divisor, suffix }] of units.entries()) {
+    if (roundedValue < divisor) continue;
+    const scaled = roundedValue / divisor;
+    const digitsBeforeDecimal = Math.floor(Math.log10(scaled)) + 1;
+    const decimalPlaces = 2 - digitsBeforeDecimal;
+    const roundingFactor = 10 ** Math.max(0, -decimalPlaces);
+    const roundedScaled =
+      decimalPlaces < 0
+        ? Math.round(scaled / roundingFactor) * roundingFactor
+        : Number(scaled.toFixed(decimalPlaces));
+    if (roundedScaled >= 1_000 && index > 0) {
+      return `1${units[index - 1]!.suffix}`;
+    }
+    const formattedScaled =
+      decimalPlaces < 0
+        ? String(roundedScaled)
+        : roundedScaled.toFixed(decimalPlaces).replace(/\.0+$/u, "");
+    return `${formattedScaled}${suffix}`;
+  }
+
+  return String(roundedValue);
+}
+
+/**
  * Renders an added/removed line tally as plain text (e.g. `+1,000 -42`).
  * With `hideZero`, sides equal to 0 are dropped — `{ added: 0, removed: 2 }`
  * becomes `"-2"` and `{ added: 0, removed: 0 }` becomes `""`.

--- a/packages/thread-view/src/index.ts
+++ b/packages/thread-view/src/index.ts
@@ -20,6 +20,7 @@ export {
 export {
   capitalize,
   durationToCompactString,
+  formatCompactDiffCount,
   formatDiffCount,
   formatDiffStatsText,
 } from "./format-helpers.js";
@@ -36,10 +37,7 @@ export type {
 } from "./timeline-row-title.js";
 export { THREAD_TIMELINE_EXCLUDED_EVENT_TYPES } from "./timeline-noise-events.js";
 export { extractShellCommandFromString } from "./tool-call-parsing.js";
-export {
-  getFileChangeAction,
-  isPatchMetadataLine,
-} from "./file-change-summary.js";
+export { getFileChangeAction, isPatchMetadataLine } from "./file-change-summary.js";
 export type { FileChangeAction } from "./file-change-summary.js";
 export {
   buildThreadTimelineFromEvents,

--- a/packages/thread-view/test/format-helpers.test.ts
+++ b/packages/thread-view/test/format-helpers.test.ts
@@ -2,11 +2,32 @@ import { describe, expect, it } from "vitest";
 import {
   capitalize,
   durationToCompactString,
+  formatCompactDiffCount,
   getFirstStringField,
   getMessageStartedAt,
   messageId,
   plural,
 } from "../src/format-helpers.js";
+
+describe("formatCompactDiffCount", () => {
+  it("keeps counts below one thousand exact", () => {
+    expect(formatCompactDiffCount(0)).toBe("0");
+    expect(formatCompactDiffCount(999)).toBe("999");
+  });
+
+  it("rounds larger counts to two significant digits", () => {
+    expect(formatCompactDiffCount(1_100)).toBe("1.1k");
+    expect(formatCompactDiffCount(1_234)).toBe("1.2k");
+    expect(formatCompactDiffCount(12_345)).toBe("12k");
+    expect(formatCompactDiffCount(123_456)).toBe("120k");
+    expect(formatCompactDiffCount(1_234_567)).toBe("1.2M");
+    expect(formatCompactDiffCount(1_234_567_890)).toBe("1.2B");
+  });
+
+  it("carries rounded thousands into millions", () => {
+    expect(formatCompactDiffCount(999_500)).toBe("1M");
+  });
+});
 
 describe("durationToCompactString", () => {
   it("returns undefined for undefined input", () => {


### PR DESCRIPTION
## Summary

- Improve the right-side git and diff review experience.
- Add inline comments for selected diff lines and append them to the thread composer with file and line references.
- Show compact insertion and deletion counts in thread lists and search results.

## Why

Diff review needs a direct way to give the AI context about selected lines without losing the file or line range. Compact diff statistics also make changed threads easier to scan.

## Validation

- PASS: changed app tests via Turbo — 4 files, 97 tests.
- PASS: `@bb/thread-view` format-helper tests via Turbo — 14 tests.
- Full app tests: 321 suites and 2,443 tests passed; 4 suites are blocked by upstream missing `@xterm/addon-unicode11`.
- Typecheck: `@bb/thread-view` passes; app typecheck is blocked by the same missing `@xterm/addon-unicode11` and `@xterm/addon-webgl` modules.
