### PR TITLE
fix(agent-runtime): recover when ACP steer has no active turn

### DIFF
--- a/packages/agent-runtime/src/acp/bridge/bridge.test.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.test.ts
@@ -1535,6 +1535,40 @@ describe("acp bridge", () => {
     expect(response.error?.message).toMatch(/No active turn/);
   });
 
+  it("closes the turn when session/prompt fails in-protocol", async () => {
+    const { bbThreadId, providerThreadId } = await startThread();
+    const turnId = sendRequest("turn/start", {
+      threadId: providerThreadId,
+      input: [{ type: "text", text: "prompt-error", mentions: [] }],
+    });
+    await waitForResponse(turnId);
+
+    const completed = await waitForTurnCompleted();
+    expect(completed.params).toEqual({
+      threadId: bbThreadId,
+      stopReason: "refusal",
+    });
+    expect(
+      notifications("error").some(
+        (entry) =>
+          entry.params &&
+          typeof entry.params === "object" &&
+          "message" in entry.params &&
+          String(entry.params.message).includes("simulated prompt failure"),
+      ),
+    ).toBe(true);
+
+    // After a failed prompt the turn is closed, so a late steer is rejected
+    // rather than queued into a zombie active turn.
+    const steerId = sendRequest("turn/steer", {
+      threadId: providerThreadId,
+      expectedTurnId: "turn-1",
+      input: [{ type: "text", text: "late", mentions: [] }],
+    });
+    const steerResponse = await waitForResponse(steerId);
+    expect(steerResponse.error?.message).toMatch(/No active turn/);
+  });
+
   it("cancels the active turn on thread/stop", async () => {
     const { bbThreadId, providerThreadId } = await startThread();
     const turnId = sendRequest("turn/start", {

--- a/packages/agent-runtime/src/acp/bridge/bridge.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.ts
@@ -1670,6 +1670,15 @@ function runTurn(session: AcpThreadSession, firstInput: PromptInput[]): void {
             message: error instanceof Error ? error.message : String(error),
           });
         }
+        // Always close the bb turn when the prompt fails. Leaving the turn
+        // open (promptActive=false, no acp/turn/completed) makes the server
+        // keep steering into "No active turn to steer" failures.
+        if (!session.stopping) {
+          sendNotification(ACP_TURN_COMPLETED_METHOD, {
+            threadId: session.bbThreadId,
+            stopReason: session.connection.exited ? "cancelled" : "refusal",
+          });
+        }
         return;
       }
 

--- a/packages/agent-runtime/src/acp/bridge/fake-acp-agent.mjs
+++ b/packages/agent-runtime/src/acp/bridge/fake-acp-agent.mjs
@@ -265,6 +265,16 @@ async function handlePrompt(message) {
   } else if (text.includes("hang")) {
     // Stay pending until the client sends session/cancel.
     return;
+  } else if (text.includes("prompt-error")) {
+    if (activePromptId === message.id) {
+      activePromptId = null;
+      send({
+        jsonrpc: "2.0",
+        id: message.id,
+        error: { code: -32000, message: "simulated prompt failure" },
+      });
+    }
+    return;
   } else if (text.includes("die")) {
     process.exit(7);
   } else if (text.includes("slow")) {

--- a/packages/agent-runtime/src/runtime.lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.lifecycle.test.ts
@@ -994,6 +994,114 @@ rl.on("line", (line) => {
       await runtime.shutdown();
     });
 
+    it("treats provider 'No active turn to steer' rejections as stale", async () => {
+      const events: ThreadEvent[] = [];
+      const rejectSteerScriptPath = join(tmpDir, "reject-steer-provider.cjs");
+      writeFileSync(
+        rejectSteerScriptPath,
+        `
+const readline = require("node:readline");
+
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+}
+
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: { ok: true } });
+    return;
+  }
+  if (message.method === "thread/start") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: { providerThreadId: "prov-reject-steer" },
+    });
+    send({
+      jsonrpc: "2.0",
+      method: "thread/identity",
+      params: {
+        threadId: message.params.threadId,
+        providerThreadId: "prov-reject-steer",
+      },
+    });
+    return;
+  }
+  if (message.method === "turn/start") {
+    const threadId = message.params.threadId;
+    send({ jsonrpc: "2.0", id: message.id, result: { ok: true } });
+    send({
+      jsonrpc: "2.0",
+      method: "turn/started",
+      params: { threadId, turnId: "turn-1" },
+    });
+    return;
+  }
+  if (message.method === "turn/steer") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      error: { code: -32000, message: "No active turn to steer" },
+    });
+    return;
+  }
+  if (message.id !== undefined) {
+    send({ jsonrpc: "2.0", id: message.id, result: { ok: true } });
+  }
+});
+`,
+      );
+
+      const runtime = createAgentRuntimeWithAdapters({
+        workspacePath: tmpDir,
+        onEvent: (event) => events.push(event),
+        onToolCall: async () => ({
+          contentItems: [{ type: "inputText", text: "ok" }],
+          success: true,
+        }),
+        adapterFactory: () => createFakeAdapter(rejectSteerScriptPath),
+      });
+
+      await runtime.startThread({
+        environmentId: "env-1",
+        threadId: "t1",
+        projectId: "p1",
+        providerId: "fake",
+        options: fullRuntimeOptions,
+      });
+      await runtime.runTurn({
+        clientRequestId: "creq_222222224a",
+        threadId: "t1",
+        input: [promptTextInput({ text: "first" })],
+        options: fullRuntimeOptions,
+      });
+      await waitForThreadTurnStarted({
+        events,
+        providerId: "fake",
+        runtime,
+        threadId: "t1",
+        turnId: "turn-1",
+      });
+
+      await expect(
+        runtime.steerTurn({
+          clientRequestId: "creq_222222224b",
+          threadId: "t1",
+          expectedTurnId: "turn-1",
+          input: [promptTextInput({ text: "steer after bridge idle" })],
+          options: fullRuntimeOptions,
+        }),
+      ).resolves.toEqual({
+        status: "stale",
+        activeTurnId: null,
+      });
+      expect(runtime.getActiveTurnId("t1")).toBeNull();
+
+      await runtime.shutdown();
+    });
+
     it("keeps the provider running after thread stop", async () => {
       const events: ThreadEvent[] = [];
       const adapter = createFakeAdapter(scriptPath);

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -734,6 +734,24 @@ function createAgentRuntimeInternal(
     return message.includes("no archived rollout found for thread id");
   }
 
+  /**
+   * ACP (and similar) bridges reject turn/steer when their local prompt has
+   * already finished. That can race with bb still observing an active turn
+   * (completion notification not processed yet, or a prompt error that left
+   * the turn open). Map those rejections to stale so host-daemon can fall
+   * back to a new turn instead of failing turn.submit.
+   */
+  function isUnsteerableActiveTurnError(error: unknown): boolean {
+    if (!(error instanceof Error)) {
+      return false;
+    }
+    const message = error.message;
+    return (
+      message.includes("No active turn to steer") ||
+      message.includes("No active ACP session")
+    );
+  }
+
   async function archiveOrUnarchiveThread(
     args: ArchiveOrUnarchiveThreadArgs,
   ): Promise<void> {
@@ -1503,16 +1521,35 @@ function createAgentRuntimeInternal(
             plan: proc.adapter.buildCommandPlan(adapterCommand),
             providerId: pid,
           });
-          await sendCommand({
-            proc,
-            message: cmd,
-            resultSchema: ignoredJsonRpcResultSchema,
-            recovery: {
-              providerId: pid,
-              providerThreadId: adapterCommand.providerThreadId,
-              threadId,
-            },
-          });
+          try {
+            await sendCommand({
+              proc,
+              message: cmd,
+              resultSchema: ignoredJsonRpcResultSchema,
+              recovery: {
+                providerId: pid,
+                providerThreadId: adapterCommand.providerThreadId,
+                threadId,
+              },
+            });
+          } catch (error) {
+            if (isUnsteerableActiveTurnError(error)) {
+              options.onStderr?.(
+                `Steer for thread "${threadId}" on turn "${expectedTurnId}" was rejected (${error instanceof Error ? error.message : String(error)}); treating as stale.`,
+              );
+              // Bridge no longer has a prompt; drop local active-turn tracking
+              // so a follow-up auto/steer send can start cleanly if completion
+              // events are also lagging.
+              if (turnState.getActiveTurnId(threadId) === expectedTurnId) {
+                turnState.clearThread(threadId);
+              }
+              return {
+                status: "stale",
+                activeTurnId: turnState.getActiveTurnId(threadId),
+              };
+            }
+            throw error;
+          }
           emitAcceptedCommandEvents({
             command: adapterCommand,
             proc,


### PR DESCRIPTION
## Summary
- Treat ACP bridge `No active turn to steer` / `No active ACP session` rejections as **stale** so host-daemon falls back to a new turn instead of failing `turn.submit` (seen on Grok/ACP harness threads).
- Emit `acp/turn/completed` when `session/prompt` fails so the server turn does not stay open after the bridge prompt ends.

## Test plan
- [x] `vitest` `@bb/agent-runtime` lifecycle + ACP bridge tests (79 passed)
- [ ] Smoke: on an `acp-grok` thread mid-turn, send a follow-up after the prompt has ended; message should start a new turn rather than `Command turn.submit failed`