### PR TITLE
Settle pending turns when providers exit before turn start

### DIFF
--- a/apps/host-daemon/src/app.test.ts
+++ b/apps/host-daemon/src/app.test.ts
@@ -3,11 +3,13 @@ import os from "node:os";
 import path from "node:path";
 import type { AgentRuntime, AgentRuntimeOptions } from "@bb/agent-runtime";
 import {
+  threadScope,
   turnScope,
   type PendingInteractionCreate,
   type ToolCallRequest,
 } from "@bb/domain";
 import {
+  hostDaemonEventBatchRequestSchema,
   hostDaemonInteractiveInterruptRequestSchema,
   type HostDaemonInteractiveRequestResponse,
 } from "@bb/host-daemon-contract";
@@ -830,6 +832,74 @@ describe("createHostDaemonApp", () => {
         },
         "Unexpected provider process exited with stderr",
       );
+    } finally {
+      await app.daemon.shutdown("test");
+    }
+  });
+
+  it("posts a failure event when a provider exits before turn/started", async () => {
+    const { app, fetchRecorder, runtimeOptions } = await createAppFixture();
+    try {
+      const workspacePath = await makeTempDir(
+        "bb-host-daemon-app-pending-turn-exit-",
+      );
+      await app.connection.start();
+      await app.runtimeManager.ensureEnvironment({
+        environmentId: "env-app-pending-turn-exit",
+        workspacePath,
+      });
+      const options = runtimeOptions.current;
+      if (!options?.onProcessExit) {
+        throw new Error("Expected process exit callback to be captured");
+      }
+
+      options.onProcessExit({
+        providerId: "claude-code",
+        threads: [
+          {
+            threadId: "thr_pending_turn_exit",
+            activeTurnId: null,
+            pendingTurnStart: true,
+            providerThreadId: "provider-pending-turn-exit",
+          },
+        ],
+        code: 1,
+        expected: false,
+        signal: null,
+        stderr: null,
+      });
+
+      await vi.waitFor(() => {
+        expect(
+          fetchRecorder.requests.filter(
+            (request) => request.pathname === "/internal/session/events",
+          ),
+        ).toHaveLength(1);
+      });
+      const eventRequest = fetchRecorder.requests.find(
+        (request) => request.pathname === "/internal/session/events",
+      );
+      const payload = hostDaemonEventBatchRequestSchema.parse(
+        JSON.parse(eventRequest?.body ?? "{}"),
+      );
+      expect(payload).toEqual({
+        sessionId: "session-app-test",
+        eventGroups: [
+          {
+            threadId: "thr_pending_turn_exit",
+            events: [
+              {
+                type: "system/error",
+                threadId: "thr_pending_turn_exit",
+                scope: threadScope(),
+                code: "provider_process_exited",
+                message:
+                  'Provider "claude-code" exited unexpectedly with code 1',
+              },
+            ],
+          },
+        ],
+      });
     } finally {
       await app.daemon.shutdown("test");
     }

--- a/apps/host-daemon/src/app.test.ts
+++ b/apps/host-daemon/src/app.test.ts
@@ -810,6 +810,7 @@ describe("createHostDaemonApp", () => {
           {
             threadId: "thr_provider_exit_log",
             activeTurnId: null,
+            pendingTurnStart: false,
             providerThreadId: null,
           },
         ],
@@ -868,6 +869,7 @@ describe("createHostDaemonApp", () => {
           {
             threadId: request.threadId,
             activeTurnId: request.turnId,
+            pendingTurnStart: false,
             providerThreadId: request.providerThreadId,
           },
         ],

--- a/apps/host-daemon/src/runtime-manager.test.ts
+++ b/apps/host-daemon/src/runtime-manager.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import type { AgentRuntime, AgentRuntimeOptions } from "@bb/agent-runtime";
 import type { ThreadEvent } from "@bb/domain";
-import { turnScope } from "@bb/domain";
+import { threadScope, turnScope } from "@bb/domain";
 import type { HostDaemonInjectedSkillSource } from "@bb/host-daemon-contract";
 import type { HostWatcher } from "@bb/host-watcher";
 import {
@@ -1767,7 +1767,12 @@ describe("RuntimeManager", () => {
     onProcessExit?.({
       providerId: "fake",
       threads: [
-        { threadId: "thread-1", activeTurnId: null, providerThreadId: null },
+        {
+          threadId: "thread-1",
+          activeTurnId: null,
+          pendingTurnStart: false,
+          providerThreadId: null,
+        },
       ],
       code: 1,
       expected: false,
@@ -1806,7 +1811,12 @@ describe("RuntimeManager", () => {
     onProcessExit?.({
       providerId: "fake-alpha",
       threads: [
-        { threadId: "thread-a", activeTurnId: null, providerThreadId: null },
+        {
+          threadId: "thread-a",
+          activeTurnId: null,
+          pendingTurnStart: false,
+          providerThreadId: null,
+        },
       ],
       code: 1,
       expected: false,
@@ -1868,6 +1878,7 @@ describe("RuntimeManager", () => {
         {
           threadId: "thread-1",
           activeTurnId: "turn-1",
+          pendingTurnStart: false,
           providerThreadId: "provider-1",
         },
       ],
@@ -1956,6 +1967,7 @@ describe("RuntimeManager", () => {
         {
           threadId: "thread-idle",
           activeTurnId: null,
+          pendingTurnStart: false,
           providerThreadId: "provider-idle",
         },
       ],
@@ -1966,6 +1978,67 @@ describe("RuntimeManager", () => {
     });
 
     expect(emittedEvents).toEqual([]);
+  });
+
+  it("emits a thread failure when a provider exits before turn/started", async () => {
+    const emittedEvents: Array<{
+      environmentId: string;
+      event: ThreadEvent;
+    }> = [];
+    const runtime = createFakeRuntime();
+    let onProcessExit:
+      | NonNullable<AgentRuntimeOptions["onProcessExit"]>
+      | undefined;
+    const manager = new RuntimeManager({
+      provisionWorkspace: createProvisionWorkspaceMock(
+        "/tmp/env-pending-turn-exit",
+      ).mockResolvedValue(createFakeWorkspace("/tmp/env-pending-turn-exit")),
+      createRuntime: vi.fn((options) => {
+        onProcessExit = options.onProcessExit;
+        return runtime;
+      }),
+      onEvent: (event) => {
+        emittedEvents.push(event);
+      },
+    });
+
+    await manager.ensureEnvironment({
+      environmentId: "env-pending-turn-exit",
+      workspacePath: "/tmp/env-pending-turn-exit",
+    });
+    if (!onProcessExit) {
+      throw new Error("Expected runtime callbacks to be captured");
+    }
+
+    onProcessExit({
+      providerId: "claude-code",
+      threads: [
+        {
+          threadId: "thread-pending",
+          activeTurnId: null,
+          pendingTurnStart: true,
+          providerThreadId: "provider-pending",
+        },
+      ],
+      code: 1,
+      expected: false,
+      signal: null,
+      stderr: "provider failed before acknowledging the turn",
+    });
+
+    expect(emittedEvents).toEqual([
+      {
+        environmentId: "env-pending-turn-exit",
+        event: {
+          type: "system/error",
+          threadId: "thread-pending",
+          scope: threadScope(),
+          code: "provider_process_exited",
+          message: 'Provider "claude-code" exited unexpectedly with code 1',
+          detail: "stderr:\nprovider failed before acknowledging the turn",
+        },
+      },
+    ]);
   });
 
   it("does not emit failure events for expected provider exits", async () => {
@@ -2013,6 +2086,7 @@ describe("RuntimeManager", () => {
         {
           threadId: "thread-1",
           activeTurnId: "turn-1",
+          pendingTurnStart: false,
           providerThreadId: "provider-1",
         },
       ],

--- a/apps/host-daemon/src/runtime-manager.ts
+++ b/apps/host-daemon/src/runtime-manager.ts
@@ -15,7 +15,7 @@ import type {
   ThreadEvent,
   WorkspaceProvisionType,
 } from "@bb/domain";
-import { turnScope } from "@bb/domain";
+import { threadScope, turnScope } from "@bb/domain";
 import type {
   HostDaemonActiveThread,
   HostDaemonEnvironmentChange,
@@ -1191,9 +1191,10 @@ export class RuntimeManager {
   /**
    * Synthesizes failure events for threads that were mid-turn when their
    * provider process died, from the runtime's final per-thread snapshot.
-   * Threads without an active turn need no synthesized events: in-flight
-   * RPCs fail through the command result path, and idle resident threads
-   * simply resume on their next turn.
+   * A process can also die after a turn request is sent but before the
+   * provider emits turn/started. That request has already made the server
+   * thread active, so synthesize a thread-scoped error to settle it instead
+   * of waiting for the live-command timeout.
    */
   private buildUnexpectedProviderExitEvents(
     info: AgentRuntimeProcessExitInfo,
@@ -1203,7 +1204,21 @@ export class RuntimeManager {
     const events: ThreadEvent[] = [];
 
     for (const thread of info.threads) {
-      if (thread.activeTurnId === null || thread.providerThreadId === null) {
+      if (thread.activeTurnId === null) {
+        if (thread.pendingTurnStart) {
+          events.push({
+            type: "system/error",
+            threadId: thread.threadId,
+            scope: threadScope(),
+            code: "provider_process_exited",
+            message,
+            ...(detail ? { detail } : {}),
+          });
+        }
+        continue;
+      }
+
+      if (thread.providerThreadId === null) {
         continue;
       }
 

--- a/apps/host-daemon/test/command/thread-dispatch.test.ts
+++ b/apps/host-daemon/test/command/thread-dispatch.test.ts
@@ -1710,6 +1710,7 @@ describe("thread command dispatch", () => {
       threads: [
         {
           activeTurnId: null,
+          pendingTurnStart: false,
           providerThreadId: "provider-1",
           threadId: "thread-1",
         },

--- a/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
@@ -1846,7 +1846,7 @@ rl.on("line", (line) => {
     await runtime.shutdown();
   });
 
-  it("rejects pending sendRequest when provider dies mid-turn", async () => {
+  it("reports a pending turn when the provider exits after acknowledging turn/start", async () => {
     const crashDuringTurnScript = join(tmpDir, "crash-during-turn.cjs");
     writeFileSync(
       crashDuringTurnScript,
@@ -1865,7 +1865,8 @@ rl.on("line", (line) => {
             params: { threadId: msg.params?.threadId, providerThreadId: "prov-mid" }
           }) + "\\n");
         } else if (msg.method === "turn/start") {
-          // Don't respond — just crash
+          process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: {} }) + "\\n");
+          // Acknowledge the request, then exit before emitting turn/started.
           setTimeout(() => process.exit(77), 50);
         }
       });`,
@@ -1891,15 +1892,16 @@ rl.on("line", (line) => {
       options: fullRuntimeOptions,
     });
 
-    // runTurn sends the request but the provider crashes without responding
-    await expect(
-      runtime.runTurn({
-        clientRequestId: "creq_222222224y",
-        threadId: "t1",
-        input: [promptTextInput({ text: "hi" })],
-        options: fullRuntimeOptions,
-      }),
-    ).rejects.toThrow(/exited unexpectedly/i);
+    await runtime.runTurn({
+      clientRequestId: "creq_222222224y",
+      threadId: "t1",
+      input: [promptTextInput({ text: "hi" })],
+      options: fullRuntimeOptions,
+    });
+    await waitForRuntimeState({
+      label: "provider process exit callback",
+      predicate: () => exitInfo.mock.calls.length === 1,
+    });
     expect(exitInfo).toHaveBeenCalledWith(
       expect.objectContaining({
         threads: [

--- a/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
@@ -72,6 +72,7 @@ describe("createAgentRuntime process lifecycle", () => {
       bridgeBundleDir: undefined,
       captureThreadExitState: (threadId) => ({
         activeTurnId: null,
+        pendingTurnStart: false,
         providerThreadId:
           identityRegistry.getProviderThreadId(threadId) ?? null,
         threadId,
@@ -1870,6 +1871,7 @@ rl.on("line", (line) => {
       });`,
     );
 
+    const exitInfo = vi.fn<NonNullable<AgentRuntimeOptions["onProcessExit"]>>();
     const runtime = createAgentRuntimeWithAdapters({
       workspacePath: tmpDir,
       onEvent: () => {},
@@ -1877,6 +1879,7 @@ rl.on("line", (line) => {
         contentItems: [{ type: "inputText", text: "ok" }],
         success: true,
       }),
+      onProcessExit: exitInfo,
       adapterFactory: () => createFakeAdapter(crashDuringTurnScript),
     });
 
@@ -1897,6 +1900,18 @@ rl.on("line", (line) => {
         options: fullRuntimeOptions,
       }),
     ).rejects.toThrow(/exited unexpectedly/i);
+    expect(exitInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threads: [
+          expect.objectContaining({
+            activeTurnId: null,
+            pendingTurnStart: true,
+            providerThreadId: "prov-mid",
+            threadId: "t1",
+          }),
+        ],
+      }),
+    );
     await runtime.shutdown();
   });
 

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -349,6 +349,7 @@ function createAgentRuntimeInternal(
       options.bridgeNodeExecutablePath ?? process.execPath,
     captureThreadExitState: (threadId) => ({
       activeTurnId: turnState.getActiveTurnId(threadId),
+      pendingTurnStart: pendingTurnStartThreadIds.has(threadId),
       providerThreadId:
         threadIdentityRegistry.getProviderThreadId(threadId) ?? null,
       threadId,

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -56,8 +56,9 @@ export type AgentRuntimeSkillRoot =
 
 /**
  * Final per-thread state snapshot taken when a provider process exits,
- * captured before the runtime clears the thread's state. This is the only
- * way consumers can see which turn a crashed thread was running.
+ * captured before the runtime clears the thread's state. This is the only way
+ * consumers can distinguish an idle session from a crashed active turn or a
+ * turn request awaiting its first provider lifecycle event.
  */
 export interface AgentRuntimeProcessExitThreadState {
   activeTurnId: string | null;

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -61,6 +61,7 @@ export type AgentRuntimeSkillRoot =
  */
 export interface AgentRuntimeProcessExitThreadState {
   activeTurnId: string | null;
+  pendingTurnStart: boolean;
   providerThreadId: string | null;
   threadId: string;
 }

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -36,7 +36,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 115 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 116 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1056,6 +1056,9 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
+  // Version 116 reports provider exits that happen while a turn start is
+  // pending. Older daemons can leave the server thread active until the live
+  // command timeout, so enrolled machines must update before handling turns.
   // Version 115 settles zero-work provider prompts with a complete synthetic
   // turn lifecycle. Older daemons can leave locally handled prompts active
   // indefinitely, so enrolled machines must update for reliable completion.
@@ -1064,8 +1067,8 @@ describe("host-daemon command schemas", () => {
   // against its Pi provider ladder, so enrolled machines must not run that
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
-  it("uses protocol version 115 for zero-work provider turn completion", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(115);
+  it("uses protocol version 116 for pending turn-start exit reconciliation", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(116);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {


### PR DESCRIPTION
## Problem

When a user submits a turn, the server persists `client/turn/requested` and
marks the thread active before the provider emits `turn/started`.

A provider can acknowledge the `turn/start` RPC and then exit before emitting
that first lifecycle event. At that point the command has succeeded, so there
is no command failure to reconcile, but `activeTurnId` is still null. Existing
provider-exit handling treated the thread like an idle resident session and
emitted nothing, leaving it visibly **Working** with no provider process alive.

## Lifecycle contract

The runtime now includes its existing `pendingTurnStart` state in the final
per-thread snapshot captured before process-exit cleanup. On an unexpected
provider exit, the host daemon applies these rules:

1. An active turn follows the existing turn-scoped completion and error path.
2. A pending turn start with no active turn emits the existing thread-scoped
   `provider_process_exited` error.
3. An idle session emits nothing.
4. An expected process exit emits nothing.

The server already treats `provider_process_exited` as `run.failed`, so the
thread moves from `active` to `error`, pending interactions are interrupted,
and parent-thread notification behavior remains consistent with other failed
turns.

## Relationship to #1432

#1432 settles prompts when a provider returns a terminal signal without first
starting a turn. This PR covers the complementary case where the provider
process disappears and no terminal signal can arrive.

## Safety and non-goals

- The behavior is provider-independent, although the reported failure was
  observed with Claude Code.
- It relies on an actual unexpected process exit; it does not add an inactivity
  timeout, watchdog, or general stuck-turn reconciler.
- `pendingTurnStart` is set before dispatch and cleared by `turn/started`,
  `turn/completed`, a terminal provider error, command failure cleanup, or
  thread cleanup. This distinguishes the vulnerable window from an idle
  resident session.
- No persisted event schema or database model changes are required.

## Wire compatibility

`HOST_DAEMON_PROTOCOL_VERSION` is bumped to **116** because an updated daemon
can now emit a failure event for a pre-`turn/started` process exit.

## Verification

- Real child-process regression: `turn/start` succeeds, the provider exits
  before `turn/started`, and the exit snapshot retains
  `pendingTurnStart: true`.
- Host-daemon event construction and event transport are covered.
- Server ingestion confirms `provider_process_exited` transitions an active
  thread to `error` and preserves parent-notification behavior.
- `@bb/agent-runtime`: 941 tests passed across 46 files.
- `@bb/host-daemon`: 548 tests passed across 46 files.
- `@bb/host-daemon-contract`: 49 tests passed across 3 files.
- `@bb/server`: 1,471 tests passed across 162 files.
- Turbo typechecks passed for all four packages above.
- Prettier and `git diff --check` passed.

Jonathan Borgwing authored the original diagnosis and implementation. The
rebased branch preserves both original commits and credits Jonathan on the
post-ack regression hardening commit.
