### PR TITLE
fix: don't show missing provider CLIs as updates in the sidebar badge

### DIFF
--- a/apps/app/src/components/sidebar/SidebarUpdatesBadge.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarUpdatesBadge.test.tsx
@@ -52,6 +52,34 @@ function providerIssue(
   };
 }
 
+function missingInstallIssue(
+  provider: ProviderCliKey,
+  displayName: string,
+): ProviderCliIssue {
+  return {
+    provider,
+    status: {
+      displayName,
+      executableName: provider,
+      executablePath: null,
+      installed: false,
+      installSource: "notInstalled",
+      currentVersion: null,
+      latestVersion: "1.1.0",
+      minimumSupportedVersion: null,
+      npmPackageName: `@example/${provider}`,
+      npmGlobalPackageVersion: null,
+      installAction: null,
+      needsUpdate: false,
+      versionUnsupported: false,
+    },
+    action: null,
+    title: `${displayName} CLI not installed`,
+    description: `Install ${displayName} so bb can start ${displayName} sessions.`,
+    fingerprint: `${provider}:missing:1.1.0`,
+  };
+}
+
 function host(id: string): Host {
   return {
     id,
@@ -135,6 +163,37 @@ describe("SidebarUpdatesBadge", () => {
         .getByTestId("sidebar-updates-badge-providers")
         .getAttribute("aria-label"),
     ).toBe("Claude Code update available");
+  });
+
+  it("renders no provider chip when a CLI is not installed", () => {
+    renderBadge({
+      machines: [
+        machine({
+          issues: [missingInstallIssue("claudeCode", "Claude Code")],
+        }),
+      ],
+    });
+
+    expect(
+      screen.queryByTestId("sidebar-updates-badge-providers"),
+    ).toBeNull();
+    expect(screen.queryByTestId("sidebar-updates-badge-bb")).toBeNull();
+  });
+
+  it("still shows the bb chip when the only provider issue is a missing CLI", () => {
+    renderBadge({
+      appUpdateAvailable: true,
+      machines: [
+        machine({
+          issues: [missingInstallIssue("codex", "Codex")],
+        }),
+      ],
+    });
+
+    expect(screen.getByTestId("sidebar-updates-badge-bb")).toBeTruthy();
+    expect(
+      screen.queryByTestId("sidebar-updates-badge-providers"),
+    ).toBeNull();
   });
 
   it("renders one mark per provider in a stable order when the same CLI is stale on several machines", () => {

--- a/apps/app/src/components/sidebar/SidebarUpdatesBadge.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarUpdatesBadge.test.tsx
@@ -174,9 +174,7 @@ describe("SidebarUpdatesBadge", () => {
       ],
     });
 
-    expect(
-      screen.queryByTestId("sidebar-updates-badge-providers"),
-    ).toBeNull();
+    expect(screen.queryByTestId("sidebar-updates-badge-providers")).toBeNull();
     expect(screen.queryByTestId("sidebar-updates-badge-bb")).toBeNull();
   });
 
@@ -191,9 +189,7 @@ describe("SidebarUpdatesBadge", () => {
     });
 
     expect(screen.getByTestId("sidebar-updates-badge-bb")).toBeTruthy();
-    expect(
-      screen.queryByTestId("sidebar-updates-badge-providers"),
-    ).toBeNull();
+    expect(screen.queryByTestId("sidebar-updates-badge-providers")).toBeNull();
   });
 
   it("renders one mark per provider in a stable order when the same CLI is stale on several machines", () => {

--- a/apps/app/src/components/sidebar/SidebarUpdatesBadge.tsx
+++ b/apps/app/src/components/sidebar/SidebarUpdatesBadge.tsx
@@ -57,6 +57,10 @@ interface StaleProvider {
  * protocol) and the agent CLIs, which carry their own brand marks so it is
  * clear which agent is stale without hovering. Both chips open the
  * consolidated Settings → Updates view.
+ *
+ * A CLI that is not installed at all is not an update and gets no chip here:
+ * there is no installed version to stale against, and the Settings → Updates
+ * page already surfaces the install prompt for it.
  */
 export function SidebarUpdatesBadge({ onNavigate }: SidebarUpdatesBadgeProps) {
   const inventory = useUpdateInventory();
@@ -70,9 +74,14 @@ export function SidebarUpdatesBadge({ onNavigate }: SidebarUpdatesBadgeProps) {
     stuckDaemonCount;
 
   // One mark per provider, even when the same CLI is stale on several machines.
+  // Missing CLIs are install prompts, not updates: skip them so the chip never
+  // claims an update is available for a CLI that isn't installed.
   const staleProvidersByKey = new Map<ProviderCliKey, StaleProvider>();
   for (const machine of inventory.machines) {
     for (const issue of machine.issues) {
+      if (!issue.status.installed) {
+        continue;
+      }
       if (!staleProvidersByKey.has(issue.provider)) {
         staleProvidersByKey.set(issue.provider, {
           provider: issue.provider,


### PR DESCRIPTION
## What's wrong

The small chip in the sidebar footer's bottom-right corner advertised an **update available** for Claude Code even on machines where Claude Code was never installed. Clicking it just opened the Updates page, where the row actually said "Not installed" with an Install button — there was no update to apply at all. Codex behaved the same way.

## Why

The daemon correctly reports `needsUpdate: false` when a CLI isn't installed — the confusion was purely in the UI. The badge builds its "stale agent" marks from every provider issue the Updates page surfaces, and "X CLI not installed" is one of those issues. So a missing CLI (an install prompt) was rendered as a brand chip labeled "X update available".

## The fix

The sidebar badge now only counts provider issues where the CLI is actually installed and stale (`needsUpdate` or `versionUnsupported`). Missing CLIs no longer produce an update chip.

Nothing else changes: Settings → Updates still shows the "Not installed" row with its Install action, which is the right place for it. The bb-app/desktop update chip is unaffected.

## Tests

Added two cases to `SidebarUpdatesBadge.test.tsx`:
- a missing CLI alone renders no badge chips at all
- a missing CLI alongside a real bb update still shows the bb chip, but no provider chip

Full `@bb/app` suite passes (325 files, 2453 tests), typecheck clean.
