### PR TITLE
Fix React #185 in split thread views

### DIFF
--- a/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
@@ -7,7 +7,8 @@ import {
   render,
   screen,
 } from "@testing-library/react";
-import type { ReactNode } from "react";
+import { Profiler, startTransition, type ReactNode } from "react";
+import { flushSync } from "react-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   resetPluginSlotStoreForTest,
@@ -258,6 +259,44 @@ beforeEach(() => {
 });
 
 describe("FollowUpPromptBox", () => {
+  it("does not commit an unchanged measurement while a height update is pending", () => {
+    const onRender = vi.fn();
+    render(
+      <Profiler id="follow-up-prompt-box" onRender={onRender}>
+        <FollowUpPromptBox
+          {...createFollowUpPromptBoxProps({ kind: "ready" })}
+          stack={<div data-testid="measured-stack">Stack</div>}
+        />
+      </Profiler>,
+    );
+    const stackElement = screen.getByTestId("measured-stack").parentElement;
+    if (!stackElement) throw new Error("Expected measured composer stack");
+    Object.defineProperty(stackElement, "offsetHeight", {
+      configurable: true,
+      value: 24,
+    });
+    let commitsAfterSynchronousSignal = -1;
+    const resizeEntries = [
+      { contentRect: { height: 24 } } as ResizeObserverEntry,
+    ];
+
+    act(() => {
+      startTransition(() => {
+        resizeObserverCallback?.(resizeEntries, {} as ResizeObserver);
+      });
+      flushSync(() => {
+        resizeObserverCallback?.(resizeEntries, {} as ResizeObserver);
+      });
+      commitsAfterSynchronousSignal = onRender.mock.calls.length;
+    });
+
+    expect(commitsAfterSynchronousSignal).toBe(1);
+    expect(onRender).toHaveBeenCalledTimes(2);
+    expect(onRender.mock.calls[0]?.[1]).toBe("mount");
+    expect(onRender.mock.calls[1]?.[1]).toBe("update");
+    expect(screen.getByTestId("prompt-box").dataset.minHeight).toBe("76");
+  });
+
   it("includes expanding plugin banners in measured stack compensation", () => {
     setPluginSlotRegistrations("measured-banner", {
       homepageSections: [],
@@ -300,17 +339,25 @@ describe("FollowUpPromptBox", () => {
     expect(screen.getByText("Expandable plugin banner")).toBeTruthy();
     const promptBox = screen.getByTestId("prompt-box");
     const initialMinHeight = Number(promptBox.getAttribute("data-min-height"));
+    const stackElement = screen
+      .getByText("Expandable plugin banner")
+      .closest("[data-bb-plugin-root]")?.parentElement;
+    if (!stackElement) throw new Error("Expected measured composer stack");
+    Object.defineProperty(stackElement, "offsetHeight", {
+      configurable: true,
+      value: 24,
+    });
 
     act(() => {
       resizeObserverCallback?.(
-        [{ contentRect: { height: 24 } } as ResizeObserverEntry],
+        [{ contentRect: { height: 999 } } as ResizeObserverEntry],
         {} as ResizeObserver,
       );
+      resizeObserverCallback?.([], {} as ResizeObserver);
     });
 
-    expect(Number(promptBox.getAttribute("data-min-height"))).toBeLessThan(
-      initialMinHeight,
-    );
+    expect(initialMinHeight).toBe(100);
+    expect(promptBox.getAttribute("data-min-height")).toBe("76");
   });
 
   it("renders plugin banners above native stack content", () => {

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -538,7 +538,16 @@ function FollowUpPromptBoxWithComposer({
     ],
   );
   const stackRef = useRef<HTMLDivElement>(null);
+  const lastStackHeightRef = useRef(0);
   const [stackHeight, setStackHeight] = useState(0);
+  const measureStackHeight = useCallback(() => {
+    const element = stackRef.current;
+    if (!element) return;
+    const measured = element.offsetHeight;
+    if (lastStackHeightRef.current === measured) return;
+    lastStackHeightRef.current = measured;
+    setStackHeight(measured);
+  }, []);
   // Measure the stack synchronously after every render. useLayoutEffect runs
   // post-DOM-commit and pre-paint, so when a React commit adds the banner
   // (e.g. workspace status arrives and the git section becomes non-empty),
@@ -547,26 +556,17 @@ function FollowUpPromptBoxWithComposer({
   // browser paints. Without this, the banner appears at 32px while the
   // textarea is still 100px for one frame — the timeline visibly shifts up
   // then back down as the elastic compensation catches up.
-  useLayoutEffect(() => {
-    const element = stackRef.current;
-    if (!element) return;
-    const measured = element.offsetHeight;
-    setStackHeight((prev) => (prev === measured ? prev : measured));
-  }, [stack]);
+  useLayoutEffect(measureStackHeight, [measureStackHeight, stack]);
   // ResizeObserver catches changes that happen outside a React render —
   // banner sections expanding via CSS animation, window resize affecting
   // markdown line-wrapping inside the stack, etc.
   useEffect(() => {
     const element = stackRef.current;
     if (!element || typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (!entry) return;
-      setStackHeight(entry.contentRect.height);
-    });
+    const observer = new ResizeObserver(measureStackHeight);
     observer.observe(element);
     return () => observer.disconnect();
-  }, []);
+  }, [measureStackHeight]);
   // The elastic pre-size keeps the prompt area's total height constant as the
   // stack (context banner + queued messages) mounts/unmounts so the timeline
   // doesn't shift. Callers that need the main-thread prompt height should pass

--- a/apps/app/src/components/secondary-panel/BrowserTabDeck.stories.tsx
+++ b/apps/app/src/components/secondary-panel/BrowserTabDeck.stories.tsx
@@ -137,7 +137,7 @@ function BrowserTabStage({ tab, threadId, width }: BrowserTabStageProps) {
       <ThreadSecondaryPanel
         activeTab={tab}
         canUseGitUi={false}
-        defaultMergeBaseBranch="main"
+        requestedMergeBaseBranch="main"
         environmentId={undefined}
         fileTabs={fileTabs}
         fileTabContent={

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.stories.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.stories.tsx
@@ -211,7 +211,7 @@ function ShellRow({
           <ThreadSecondaryPanel
             activeTab={createStoryFixedPanelTab(panel)}
             canUseGitUi={canUseGitUi}
-            defaultMergeBaseBranch="main"
+            requestedMergeBaseBranch="main"
             environmentId={undefined}
             isOpen
             metadataContent={<RepresentativeInfoContent />}
@@ -332,7 +332,7 @@ function FileTabsShellInner({
       <ThreadSecondaryPanel
         activeTab={activeTab}
         canUseGitUi
-        defaultMergeBaseBranch="main"
+        requestedMergeBaseBranch="main"
         environmentId={undefined}
         isOpen
         metadataContent={<RepresentativeInfoContent />}
@@ -439,7 +439,7 @@ function TerminalTabsShellInner({
       <ThreadSecondaryPanel
         activeTab={activeTab}
         canUseGitUi
-        defaultMergeBaseBranch="main"
+        requestedMergeBaseBranch="main"
         environmentId={undefined}
         isOpen
         metadataContent={<RepresentativeInfoContent />}

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -269,7 +269,10 @@ export interface ThreadSecondaryPanelProps {
   onPanelChange: (panel: ThreadSecondaryPanelTab) => void;
   onCollapse: () => void;
   onClose: () => void;
+  onClearPendingGitDiffIntent?: () => void;
   onOpenNewTab: () => void;
+  pendingGitDiffCommitSha?: string | null;
+  pendingGitDiffScrollPath?: string | null;
   workspaceRootPath?: string | null;
   onOpenFileInEditor?: (path: string) => void;
   onOpenFilePreview?: (path: string) => void;
@@ -343,7 +346,10 @@ export function ThreadSecondaryPanel({
   onPanelChange,
   onCollapse,
   onClose,
+  onClearPendingGitDiffIntent,
   onOpenNewTab,
+  pendingGitDiffCommitSha,
+  pendingGitDiffScrollPath,
   workspaceRootPath,
   onOpenFileInEditor,
   onOpenFilePreview,
@@ -466,6 +472,9 @@ export function ThreadSecondaryPanel({
     environmentId,
     isDiffPanelActive,
     defaultMergeBaseBranch,
+    onClearPendingGitDiffIntent,
+    pendingGitDiffCommitSha,
+    pendingGitDiffScrollPath,
   });
   // Share the diff tab's table of contents with the body: React Query dedupes
   // this against GitDiffTabContent's own fetch (same key), so the toolbar reads
@@ -817,9 +826,11 @@ export function ThreadSecondaryPanel({
             target={gitDiffTarget}
             isDiffPanelActive={isDiffPanelActive}
             gitDiffViewOptions={gitDiffViewOptions}
+            onClearPendingGitDiffIntent={onClearPendingGitDiffIntent}
             onOpenFileInEditor={onOpenFileInEditor}
             onOpenFilePreview={onOpenFilePreview}
             onSelectionAddToChat={onSelectionAddToChat}
+            pendingGitDiffScrollPath={pendingGitDiffScrollPath}
             workspaceRootPath={workspaceRootPath}
           />
         ) : (

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -212,7 +212,7 @@ export function resolveSecondaryPanelHideControl() {
 export interface ThreadSecondaryPanelProps {
   activeTab: SecondaryFixedPanelTab | null;
   canUseGitUi: boolean;
-  defaultMergeBaseBranch?: string;
+  requestedMergeBaseBranch?: string;
   environmentId?: string;
   metadataContent: ReactNode;
   fileTabs?: SecondaryPanelFileTab[];
@@ -325,7 +325,7 @@ function resolveActiveFixedPanel({
 export function ThreadSecondaryPanel({
   activeTab,
   canUseGitUi,
-  defaultMergeBaseBranch,
+  requestedMergeBaseBranch,
   environmentId,
   metadataContent,
   fileTabs,
@@ -471,7 +471,7 @@ export function ThreadSecondaryPanel({
   } = useGitDiffPanelState({
     environmentId,
     isDiffPanelActive,
-    defaultMergeBaseBranch,
+    requestedMergeBaseBranch,
     onClearPendingGitDiffIntent,
     pendingGitDiffCommitSha,
     pendingGitDiffScrollPath,

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanelNewTab.stories.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanelNewTab.stories.tsx
@@ -538,7 +538,7 @@ function NewTabPanelStory({
       <ThreadSecondaryPanel
         activeTab={activeTab}
         canUseGitUi
-        defaultMergeBaseBranch="main"
+        requestedMergeBaseBranch="main"
         environmentId={ENVIRONMENT_ID}
         fileTabs={fileTabs}
         fileTabContent={content}

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
@@ -1,5 +1,4 @@
-import { useCallback, useEffect, type ReactNode } from "react";
-import { useAtomValue, useSetAtom } from "jotai";
+import { useEffect, type ReactNode } from "react";
 import type { WorkspaceDiffTarget } from "@bb/domain";
 import type { MarkdownLinkRouting } from "@/components/ui/markdown-link-routing.js";
 import { Skeleton } from "@bb/shared-ui/skeleton";
@@ -27,7 +26,6 @@ import { DiffFilesPanel } from "./git-diff/DiffFilesPanel";
 import { clearDiffFileCardStates } from "./git-diff/diffFilesStore";
 import { buildGitDiffIdentity } from "./git-diff/gitDiffPanelHelpers";
 import { useDiffFileContentsRequester } from "./git-diff/useDiffFileContentsRequester";
-import { pendingGitDiffScrollPathAtom } from "./threadSecondaryPanelAtoms";
 import {
   SecondaryPanelFilePreview,
   ThreadStorageFilePreview,
@@ -46,9 +44,11 @@ export interface GitDiffTabContentProps {
   target: WorkspaceDiffTarget | undefined;
   isDiffPanelActive: boolean;
   gitDiffViewOptions: Record<string, string | boolean | number>;
+  onClearPendingGitDiffIntent?: () => void;
   onOpenFileInEditor?: (path: string) => void;
   onOpenFilePreview?: (path: string) => void;
   onSelectionAddToChat?: (text: string) => void;
+  pendingGitDiffScrollPath?: string | null;
   workspaceRootPath?: string | null;
 }
 
@@ -145,9 +145,11 @@ export function GitDiffTabContent({
   target,
   isDiffPanelActive,
   gitDiffViewOptions,
+  onClearPendingGitDiffIntent,
   onOpenFileInEditor,
   onOpenFilePreview,
   onSelectionAddToChat,
+  pendingGitDiffScrollPath,
   workspaceRootPath,
 }: GitDiffTabContentProps) {
   const isQueryEnabled =
@@ -177,16 +179,6 @@ export function GitDiffTabContent({
     target,
     mergeBaseRef,
   });
-
-  // A file opened from the info tab / prompt banner sets this path;
-  // useGitDiffPanelState resets the diff to all-changes so the file is in the
-  // slice, and the panel scrolls it into view, then clears the request here.
-  const pendingGitDiffScrollPath = useAtomValue(pendingGitDiffScrollPathAtom);
-  const setPendingGitDiffScrollPath = useSetAtom(pendingGitDiffScrollPathAtom);
-  const clearPendingGitDiffScrollPath = useCallback(
-    () => setPendingGitDiffScrollPath(null),
-    [setPendingGitDiffScrollPath],
-  );
 
   // Drop per-card UI state belonging to any other diff slice once a new target
   // / environment resolves, so collapse defaults are re-derived fresh rather
@@ -288,7 +280,7 @@ export function GitDiffTabContent({
       filePathRoot={workspaceRootPath}
       isPlaceholderData={isDiffFilesPlaceholder}
       scrollToPath={pendingGitDiffScrollPath}
-      onScrolledToPath={clearPendingGitDiffScrollPath}
+      onScrolledToPath={onClearPendingGitDiffIntent}
       onOpenFileInEditor={onOpenFileInEditor}
       onOpenFilePreview={onOpenFilePreview}
       onRequestFileContents={onRequestFileContents}

--- a/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanel.test.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanel.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Provider as JotaiProvider } from "jotai";
+import { useEffect, useRef, useState } from "react";
+import { expect, it, vi } from "vitest";
+import { shouldSyncSelectedMergeBaseBranch } from "./useEnvironmentMergeBase";
+import { useGitDiffPanel } from "./useGitDiffPanel";
+
+const requestedBranches = vi.hoisted(
+  () => new Map<string, string | undefined>(),
+);
+
+vi.mock("../../../hooks/queries/environment-queries", () => ({
+  useEnvironmentMergeBaseBranches: (
+    environmentId: string,
+    options?: { selectedBranch?: string },
+  ) => {
+    requestedBranches.set(environmentId, options?.selectedBranch);
+    return { data: undefined, isFetching: false };
+  },
+}));
+
+const noop = () => undefined;
+
+function MergeBaseOwner({
+  environmentId,
+  persistedBranch,
+}: {
+  environmentId: string;
+  persistedBranch: string;
+}) {
+  const stateKeyRef = useRef<string | undefined>(undefined);
+  const syncCountRef = useRef(0);
+  const { selectedMergeBaseBranch, setSelectedMergeBaseBranch } =
+    useGitDiffPanel({
+      activeSecondaryTab: null,
+      clearActiveFileTabs: noop,
+      environmentId,
+      mergeBaseBranchOptionsEnabled: true,
+      setThreadSecondaryPanel: noop,
+    });
+
+  useEffect(() => {
+    if (
+      !shouldSyncSelectedMergeBaseBranch({
+        previousStateKey: stateKeyRef.current,
+        nextStateKey: environmentId,
+        persistedMergeBaseBranch: persistedBranch,
+        selectedMergeBaseBranch,
+        updatePending: false,
+      })
+    ) {
+      return;
+    }
+    syncCountRef.current += 1;
+    if (syncCountRef.current > 10) {
+      throw new Error("Merge-base owner did not settle independently");
+    }
+    stateKeyRef.current = environmentId;
+    setSelectedMergeBaseBranch(persistedBranch);
+  }, [
+    environmentId,
+    persistedBranch,
+    selectedMergeBaseBranch,
+    setSelectedMergeBaseBranch,
+  ]);
+
+  return (
+    <output data-testid={environmentId}>
+      {selectedMergeBaseBranch ?? "unset"}
+    </output>
+  );
+}
+
+function TwoOwnerHarness() {
+  const [leftBranch, setLeftBranch] = useState("main");
+  return (
+    <JotaiProvider>
+      <MergeBaseOwner environmentId="env-left" persistedBranch={leftBranch} />
+      <MergeBaseOwner environmentId="env-right" persistedBranch="release" />
+      <button type="button" onClick={() => setLeftBranch("feature-left")}>
+        Change left branch
+      </button>
+    </JotaiProvider>
+  );
+}
+
+it("keeps simultaneous merge-base owners and queries independent", async () => {
+  requestedBranches.clear();
+  render(<TwoOwnerHarness />);
+
+  await waitFor(() => {
+    expect(screen.getByTestId("env-left").textContent).toBe("main");
+    expect(screen.getByTestId("env-right").textContent).toBe("release");
+  });
+  expect(requestedBranches.get("env-left")).toBe("main");
+  expect(requestedBranches.get("env-right")).toBe("release");
+
+  fireEvent.click(screen.getByRole("button", { name: "Change left branch" }));
+
+  await waitFor(() => {
+    expect(screen.getByTestId("env-left").textContent).toBe("feature-left");
+    expect(requestedBranches.get("env-left")).toBe("feature-left");
+  });
+  expect(screen.getByTestId("env-right").textContent).toBe("release");
+  expect(requestedBranches.get("env-right")).toBe("release");
+});

--- a/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanel.test.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanel.test.tsx
@@ -107,12 +107,12 @@ function useMergeBaseOwner(environment: Environment, threadId: string) {
     updateEnvironment,
   });
   const diffState = useGitDiffPanelState({
-    defaultMergeBaseBranch: effectiveMergeBaseBranch,
     environmentId: environment.id,
     isDiffPanelActive: true,
     onClearPendingGitDiffIntent: panel.clearPendingGitDiffIntent,
     pendingGitDiffCommitSha: panel.pendingGitDiffCommitSha,
     pendingGitDiffScrollPath: panel.pendingGitDiffScrollPath,
+    requestedMergeBaseBranch: effectiveMergeBaseBranch,
   });
   return { ...diffState, ...panel, effectiveMergeBaseBranch };
 }

--- a/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanel.test.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanel.test.tsx
@@ -1,108 +1,243 @@
 // @vitest-environment jsdom
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { Provider as JotaiProvider } from "jotai";
-import { useEffect, useRef, useState } from "react";
-import { expect, it, vi } from "vitest";
-import { shouldSyncSelectedMergeBaseBranch } from "./useEnvironmentMergeBase";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { Environment } from "@bb/domain";
+import { StrictMode, useState, type ReactNode } from "react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { useUpdateEnvironment } from "@/hooks/mutations/environment-mutations";
+import { useEnvironmentMergeBase } from "./useEnvironmentMergeBase";
 import { useGitDiffPanel } from "./useGitDiffPanel";
+import { useGitDiffPanelState } from "./useGitDiffPanelState";
 
-const requestedBranches = vi.hoisted(
-  () => new Map<string, string | undefined>(),
-);
+interface MergeBaseBranchRequest {
+  environmentId: string;
+  selectedBranch?: string;
+}
+
+const mergeBaseBranchRequests = vi.hoisted((): MergeBaseBranchRequest[] => []);
 
 vi.mock("../../../hooks/queries/environment-queries", () => ({
   useEnvironmentMergeBaseBranches: (
     environmentId: string,
     options?: { selectedBranch?: string },
   ) => {
-    requestedBranches.set(environmentId, options?.selectedBranch);
+    mergeBaseBranchRequests.push({
+      environmentId,
+      selectedBranch: options?.selectedBranch,
+    });
     return { data: undefined, isFetching: false };
   },
+  useEnvironmentWorkStatus: () => ({
+    data: {
+      outcome: "available",
+      workspace: {
+        mergeBase: {
+          commits: [
+            { sha: "sha-left", shortSha: "sha-lef", subject: "Left commit" },
+            {
+              sha: "sha-right",
+              shortSha: "sha-rig",
+              subject: "Right commit",
+            },
+          ],
+        },
+        workingTree: { files: [] },
+      },
+    },
+  }),
 }));
 
 const noop = () => undefined;
 
-function MergeBaseOwner({
-  environmentId,
-  persistedBranch,
-}: {
-  environmentId: string;
-  persistedBranch: string;
-}) {
-  const stateKeyRef = useRef<string | undefined>(undefined);
-  const syncCountRef = useRef(0);
-  const { selectedMergeBaseBranch, setSelectedMergeBaseBranch } =
-    useGitDiffPanel({
-      activeSecondaryTab: null,
-      clearActiveFileTabs: noop,
-      environmentId,
-      mergeBaseBranchOptionsEnabled: true,
-      setThreadSecondaryPanel: noop,
-    });
+function makeEnvironment(id: string, mergeBaseBranch: string): Environment {
+  return {
+    baseBranch: null,
+    branchName: `bb/${id}`,
+    createdAt: 1,
+    defaultBranch: "main",
+    hostId: "host-1",
+    id,
+    name: null,
+    isGitRepo: true,
+    isWorktree: true,
+    managed: true,
+    mergeBaseBranch,
+    path: `/tmp/${id}`,
+    projectId: "project-1",
+    status: "ready",
+    updatedAt: 1,
+    workspaceProvisionType: "managed-worktree",
+  };
+}
 
-  useEffect(() => {
-    if (
-      !shouldSyncSelectedMergeBaseBranch({
-        previousStateKey: stateKeyRef.current,
-        nextStateKey: environmentId,
-        persistedMergeBaseBranch: persistedBranch,
-        selectedMergeBaseBranch,
-        updatePending: false,
-      })
-    ) {
-      return;
-    }
-    syncCountRef.current += 1;
-    if (syncCountRef.current > 10) {
-      throw new Error("Merge-base owner did not settle independently");
-    }
-    stateKeyRef.current = environmentId;
-    setSelectedMergeBaseBranch(persistedBranch);
-  }, [
-    environmentId,
-    persistedBranch,
-    selectedMergeBaseBranch,
-    setSelectedMergeBaseBranch,
-  ]);
-
+function TestRoot({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          mutations: { retry: false },
+          queries: { retry: false },
+        },
+      }),
+  );
   return (
-    <output data-testid={environmentId}>
-      {selectedMergeBaseBranch ?? "unset"}
-    </output>
+    <StrictMode>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </StrictMode>
   );
 }
 
-function TwoOwnerHarness() {
-  const [leftBranch, setLeftBranch] = useState("main");
-  return (
-    <JotaiProvider>
-      <MergeBaseOwner environmentId="env-left" persistedBranch={leftBranch} />
-      <MergeBaseOwner environmentId="env-right" persistedBranch="release" />
-      <button type="button" onClick={() => setLeftBranch("feature-left")}>
-        Change left branch
-      </button>
-    </JotaiProvider>
-  );
+function useMergeBaseOwner(environment: Environment, threadId: string) {
+  const updateEnvironment = useUpdateEnvironment();
+  const panel = useGitDiffPanel({
+    activeSecondaryTab: null,
+    clearActiveFileTabs: noop,
+    defaultMergeBaseBranch:
+      environment.mergeBaseBranch ?? environment.defaultBranch ?? undefined,
+    environmentId: environment.id,
+    mergeBaseBranchOptionsEnabled: true,
+    setThreadSecondaryPanel: noop,
+    threadId,
+  });
+  const { effectiveMergeBaseBranch } = useEnvironmentMergeBase({
+    environment,
+    selectedMergeBaseBranch: panel.selectedMergeBaseBranch,
+    setSelectedMergeBaseBranch: panel.setSelectedMergeBaseBranch,
+    updateEnvironment,
+  });
+  const diffState = useGitDiffPanelState({
+    defaultMergeBaseBranch: effectiveMergeBaseBranch,
+    environmentId: environment.id,
+    isDiffPanelActive: true,
+    onClearPendingGitDiffIntent: panel.clearPendingGitDiffIntent,
+    pendingGitDiffCommitSha: panel.pendingGitDiffCommitSha,
+    pendingGitDiffScrollPath: panel.pendingGitDiffScrollPath,
+  });
+  return { ...diffState, ...panel, effectiveMergeBaseBranch };
 }
 
-it("keeps simultaneous merge-base owners and queries independent", async () => {
-  requestedBranches.clear();
-  render(<TwoOwnerHarness />);
+beforeEach(() => {
+  mergeBaseBranchRequests.length = 0;
+});
+
+afterEach(cleanup);
+
+it("keeps production merge-base owners independent through close and reopen", async () => {
+  const leftEnvironment = makeEnvironment("env-left", "main");
+  const rightEnvironment = makeEnvironment("env-right", "release");
+  const left = renderHook(() => useMergeBaseOwner(leftEnvironment, "left"), {
+    wrapper: TestRoot,
+  });
+  const right = renderHook(() => useMergeBaseOwner(rightEnvironment, "right"), {
+    wrapper: TestRoot,
+  });
 
   await waitFor(() => {
-    expect(screen.getByTestId("env-left").textContent).toBe("main");
-    expect(screen.getByTestId("env-right").textContent).toBe("release");
+    expect(left.result.current.effectiveMergeBaseBranch).toBe("main");
+    expect(right.result.current.effectiveMergeBaseBranch).toBe("release");
   });
-  expect(requestedBranches.get("env-left")).toBe("main");
-  expect(requestedBranches.get("env-right")).toBe("release");
 
-  fireEvent.click(screen.getByRole("button", { name: "Change left branch" }));
+  right.unmount();
+  expect(left.result.current.effectiveMergeBaseBranch).toBe("main");
 
+  const reopenedRight = renderHook(
+    () => useMergeBaseOwner(rightEnvironment, "right"),
+    { wrapper: TestRoot },
+  );
   await waitFor(() => {
-    expect(screen.getByTestId("env-left").textContent).toBe("feature-left");
-    expect(requestedBranches.get("env-left")).toBe("feature-left");
+    expect(left.result.current.effectiveMergeBaseBranch).toBe("main");
+    expect(reopenedRight.result.current.effectiveMergeBaseBranch).toBe(
+      "release",
+    );
   });
-  expect(screen.getByTestId("env-right").textContent).toBe("release");
-  expect(requestedBranches.get("env-right")).toBe("release");
+
+  expect(
+    mergeBaseBranchRequests
+      .filter(({ environmentId }) => environmentId === "env-left")
+      .every(({ selectedBranch }) => selectedBranch === "main"),
+  ).toBe(true);
+  expect(
+    mergeBaseBranchRequests
+      .filter(({ environmentId }) => environmentId === "env-right")
+      .every(({ selectedBranch }) => selectedBranch === "release"),
+  ).toBe(true);
+});
+
+it("never queries a new environment with the previous environment branch", async () => {
+  const environmentA = makeEnvironment("env-a", "branch-a");
+  const environmentB = makeEnvironment("env-b", "branch-b");
+  const owner = renderHook(
+    ({ environment }) => useMergeBaseOwner(environment, "switching"),
+    { initialProps: { environment: environmentA }, wrapper: TestRoot },
+  );
+  await waitFor(() =>
+    expect(owner.result.current.effectiveMergeBaseBranch).toBe("branch-a"),
+  );
+
+  mergeBaseBranchRequests.length = 0;
+  owner.rerender({ environment: environmentB });
+
+  await waitFor(() =>
+    expect(owner.result.current.effectiveMergeBaseBranch).toBe("branch-b"),
+  );
+  const environmentBRequests = mergeBaseBranchRequests.filter(
+    ({ environmentId }) => environmentId === "env-b",
+  );
+  expect(environmentBRequests.length).toBeGreaterThan(0);
+  expect(
+    environmentBRequests.every(
+      ({ selectedBranch }) => selectedBranch === "branch-b",
+    ),
+  ).toBe(true);
+});
+
+it("does not revive an unconsumed file intent after navigating away and back", () => {
+  const environmentA = makeEnvironment("env-a", "branch-a");
+  const environmentB = makeEnvironment("env-b", "branch-b");
+  const owner = renderHook(
+    ({ environment, threadId }) => useMergeBaseOwner(environment, threadId),
+    {
+      initialProps: { environment: environmentA, threadId: "thread-a" },
+      wrapper: TestRoot,
+    },
+  );
+
+  act(() => owner.result.current.openDiffFile("left.ts"));
+  expect(owner.result.current.pendingGitDiffScrollPath).toBe("left.ts");
+
+  owner.rerender({ environment: environmentB, threadId: "thread-b" });
+  expect(owner.result.current.pendingGitDiffScrollPath).toBeNull();
+
+  owner.rerender({ environment: environmentA, threadId: "thread-a" });
+  expect(owner.result.current.pendingGitDiffScrollPath).toBeNull();
+});
+
+it("keeps delayed file and commit intents with the owner that requested them", async () => {
+  const left = renderHook(
+    () => useMergeBaseOwner(makeEnvironment("env-left", "main"), "left"),
+    { wrapper: TestRoot },
+  );
+  const right = renderHook(
+    () => useMergeBaseOwner(makeEnvironment("env-right", "release"), "right"),
+    { wrapper: TestRoot },
+  );
+
+  act(() => left.result.current.openDiffFile("left.ts"));
+  expect(left.result.current.pendingGitDiffScrollPath).toBe("left.ts");
+  expect(right.result.current.pendingGitDiffScrollPath).toBeNull();
+
+  act(() => right.result.current.clearPendingGitDiffIntent());
+  expect(left.result.current.pendingGitDiffScrollPath).toBe("left.ts");
+
+  act(() => left.result.current.clearPendingGitDiffIntent());
+  expect(left.result.current.pendingGitDiffScrollPath).toBeNull();
+
+  act(() => left.result.current.openCommitDiff("sha-left"));
+  await waitFor(() => {
+    expect(left.result.current.gitDiffSelectValue).toBe("sha-left");
+    expect(left.result.current.pendingGitDiffCommitSha).toBeNull();
+  });
+  expect(right.result.current.gitDiffSelectValue).toBe("all");
+  expect(right.result.current.pendingGitDiffCommitSha).toBeNull();
 });

--- a/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanel.ts
+++ b/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanel.ts
@@ -1,12 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useSetAtom } from "jotai";
 import { useEnvironmentMergeBaseBranches } from "../../../hooks/queries/environment-queries";
 import type { SecondaryFixedPanelTab } from "@/lib/fixed-panel-tabs-state";
 import type { ThreadSecondaryPanel as ThreadSecondaryPanelTab } from "@/lib/thread-secondary-panel";
-import {
-  pendingGitDiffCommitShaAtom,
-  pendingGitDiffScrollPathAtom,
-} from "../threadSecondaryPanelAtoms";
 
 type ThreadSecondaryPanelSetter = (
   panel: ThreadSecondaryPanelTab | null,
@@ -19,7 +14,27 @@ interface UseGitDiffPanelParams {
   environmentId?: string;
   mergeBaseBranchOptionsEnabled?: boolean;
   setThreadSecondaryPanel: ThreadSecondaryPanelSetter;
+  threadId: string;
 }
+
+interface SelectedMergeBaseBranchState {
+  branch?: string;
+  environmentId?: string;
+}
+
+type PendingGitDiffIntent =
+  | {
+      environmentId?: string;
+      kind: "commit";
+      sha: string;
+      threadId: string;
+    }
+  | {
+      environmentId?: string;
+      kind: "file";
+      path: string;
+      threadId: string;
+    };
 
 export function useGitDiffPanel({
   activeSecondaryTab,
@@ -28,11 +43,45 @@ export function useGitDiffPanel({
   environmentId,
   mergeBaseBranchOptionsEnabled = false,
   setThreadSecondaryPanel,
+  threadId,
 }: UseGitDiffPanelParams) {
-  const [selectedMergeBaseBranch, setSelectedMergeBaseBranch] =
-    useState<string>();
-  const setPendingGitDiffScrollPath = useSetAtom(pendingGitDiffScrollPathAtom);
-  const setPendingGitDiffCommitSha = useSetAtom(pendingGitDiffCommitShaAtom);
+  const [selectedMergeBaseBranchState, setSelectedMergeBaseBranchState] =
+    useState<SelectedMergeBaseBranchState>({ environmentId });
+  const selectedMergeBaseBranch =
+    selectedMergeBaseBranchState.environmentId === environmentId
+      ? selectedMergeBaseBranchState.branch
+      : undefined;
+  const setSelectedMergeBaseBranch = useCallback(
+    (branch: string | undefined) => {
+      setSelectedMergeBaseBranchState({ branch, environmentId });
+    },
+    [environmentId],
+  );
+  const [pendingGitDiffIntent, setPendingGitDiffIntent] =
+    useState<PendingGitDiffIntent | null>(null);
+  const currentPendingGitDiffIntent =
+    pendingGitDiffIntent !== null &&
+    pendingGitDiffIntent.environmentId === environmentId &&
+    pendingGitDiffIntent.threadId === threadId
+      ? pendingGitDiffIntent
+      : null;
+  const pendingGitDiffCommitSha =
+    currentPendingGitDiffIntent?.kind === "commit"
+      ? currentPendingGitDiffIntent.sha
+      : null;
+  const pendingGitDiffScrollPath =
+    currentPendingGitDiffIntent?.kind === "file"
+      ? currentPendingGitDiffIntent.path
+      : null;
+  const clearPendingGitDiffIntent = useCallback(() => {
+    setPendingGitDiffIntent((current) =>
+      current !== null &&
+      current.environmentId === environmentId &&
+      current.threadId === threadId
+        ? null
+        : current,
+    );
+  }, [environmentId, threadId]);
   const [mergeBaseBranchSearchQuery, setMergeBaseBranchSearchQuery] =
     useState("");
   const requestedMergeBaseBranch =
@@ -80,9 +129,9 @@ export function useGitDiffPanel({
   );
 
   useEffect(() => {
-    setSelectedMergeBaseBranch(undefined);
     setMergeBaseBranchSearchQuery("");
-  }, [environmentId, setSelectedMergeBaseBranch]);
+    setPendingGitDiffIntent(null);
+  }, [environmentId, threadId]);
 
   const openThreadSecondaryPanel = useCallback(
     (panel: ThreadSecondaryPanelTab) => {
@@ -102,23 +151,24 @@ export function useGitDiffPanel({
   const openDiffFile = useCallback(
     (path: string) => {
       clearActiveFileTabs();
-      setPendingGitDiffScrollPath(path);
+      setPendingGitDiffIntent({ environmentId, kind: "file", path, threadId });
       openThreadDiffPanel();
     },
-    [clearActiveFileTabs, openThreadDiffPanel, setPendingGitDiffScrollPath],
+    [clearActiveFileTabs, environmentId, openThreadDiffPanel, threadId],
   );
 
   const openCommitDiff = useCallback(
     (sha: string) => {
       clearActiveFileTabs();
-      setPendingGitDiffCommitSha(sha);
+      setPendingGitDiffIntent({ environmentId, kind: "commit", sha, threadId });
       openThreadDiffPanel();
     },
-    [clearActiveFileTabs, openThreadDiffPanel, setPendingGitDiffCommitSha],
+    [clearActiveFileTabs, environmentId, openThreadDiffPanel, threadId],
   );
 
   return {
     closeThreadSecondaryPanel,
+    clearPendingGitDiffIntent,
     isLoadingMergeBaseBranchOptions,
     mergeBaseBranchOptions,
     mergeBaseBranchOptionsTruncated,
@@ -127,6 +177,9 @@ export function useGitDiffPanel({
     openDiffFile,
     openThreadDiffPanel,
     openThreadSecondaryPanel,
+    pendingGitDiffCommitSha,
+    pendingGitDiffScrollPath,
+    requestedMergeBaseBranch,
     selectedMergeBaseBranch,
     selectedMergeBaseBranchRef,
     setMergeBaseBranchSearchQuery,

--- a/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanel.ts
+++ b/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanel.ts
@@ -1,12 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useAtomValue, useSetAtom } from "jotai";
+import { useSetAtom } from "jotai";
 import { useEnvironmentMergeBaseBranches } from "../../../hooks/queries/environment-queries";
 import type { SecondaryFixedPanelTab } from "@/lib/fixed-panel-tabs-state";
 import type { ThreadSecondaryPanel as ThreadSecondaryPanelTab } from "@/lib/thread-secondary-panel";
 import {
   pendingGitDiffCommitShaAtom,
   pendingGitDiffScrollPathAtom,
-  selectedMergeBaseBranchAtom,
 } from "../threadSecondaryPanelAtoms";
 
 type ThreadSecondaryPanelSetter = (
@@ -30,8 +29,8 @@ export function useGitDiffPanel({
   mergeBaseBranchOptionsEnabled = false,
   setThreadSecondaryPanel,
 }: UseGitDiffPanelParams) {
-  const selectedMergeBaseBranch = useAtomValue(selectedMergeBaseBranchAtom);
-  const setSelectedMergeBaseBranch = useSetAtom(selectedMergeBaseBranchAtom);
+  const [selectedMergeBaseBranch, setSelectedMergeBaseBranch] =
+    useState<string>();
   const setPendingGitDiffScrollPath = useSetAtom(pendingGitDiffScrollPathAtom);
   const setPendingGitDiffCommitSha = useSetAtom(pendingGitDiffCommitShaAtom);
   const [mergeBaseBranchSearchQuery, setMergeBaseBranchSearchQuery] =
@@ -120,7 +119,6 @@ export function useGitDiffPanel({
 
   return {
     closeThreadSecondaryPanel,
-    defaultMergeBaseBranch,
     isLoadingMergeBaseBranchOptions,
     mergeBaseBranchOptions,
     mergeBaseBranchOptionsTruncated,

--- a/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanelState.ts
+++ b/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanelState.ts
@@ -4,7 +4,6 @@ import { useEnvironmentWorkStatus } from "../../../hooks/queries/environment-que
 import {
   pendingGitDiffCommitShaAtom,
   pendingGitDiffScrollPathAtom,
-  selectedMergeBaseBranchAtom,
 } from "../threadSecondaryPanelAtoms";
 import { type GitDiffSelectionOption } from "../ThreadSecondaryPanel";
 import {
@@ -38,7 +37,6 @@ export function useGitDiffPanelState({
   isDiffPanelActive,
   defaultMergeBaseBranch,
 }: UseGitDiffPanelStateParams) {
-  const selectedMergeBaseBranch = useAtomValue(selectedMergeBaseBranchAtom);
   const pendingGitDiffScrollPath = useAtomValue(pendingGitDiffScrollPathAtom);
   const setPendingGitDiffScrollPath = useSetAtom(pendingGitDiffScrollPathAtom);
   const pendingGitDiffCommitSha = useAtomValue(pendingGitDiffCommitShaAtom);
@@ -46,8 +44,7 @@ export function useGitDiffPanelState({
   const [selectedGitDiffSelection, setSelectedGitDiffSelection] =
     useState<GitDiffSelectionValue>(null);
 
-  const effectiveMergeBaseBranch =
-    selectedMergeBaseBranch ?? defaultMergeBaseBranch;
+  const effectiveMergeBaseBranch = defaultMergeBaseBranch;
   const gitDiffTarget = useMemo(
     () =>
       buildGitDiffTarget(selectedGitDiffSelection, effectiveMergeBaseBranch),

--- a/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanelState.ts
+++ b/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanelState.ts
@@ -1,10 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useAtomValue, useSetAtom } from "jotai";
 import { useEnvironmentWorkStatus } from "../../../hooks/queries/environment-queries";
-import {
-  pendingGitDiffCommitShaAtom,
-  pendingGitDiffScrollPathAtom,
-} from "../threadSecondaryPanelAtoms";
 import { type GitDiffSelectionOption } from "../ThreadSecondaryPanel";
 import {
   ALL_GIT_DIFF_SELECTION,
@@ -18,6 +13,9 @@ interface UseGitDiffPanelStateParams {
   environmentId?: string;
   isDiffPanelActive: boolean;
   defaultMergeBaseBranch?: string;
+  onClearPendingGitDiffIntent?: () => void;
+  pendingGitDiffCommitSha?: string | null;
+  pendingGitDiffScrollPath?: string | null;
 }
 
 /**
@@ -36,27 +34,24 @@ export function useGitDiffPanelState({
   environmentId,
   isDiffPanelActive,
   defaultMergeBaseBranch,
+  onClearPendingGitDiffIntent,
+  pendingGitDiffCommitSha,
+  pendingGitDiffScrollPath,
 }: UseGitDiffPanelStateParams) {
-  const pendingGitDiffScrollPath = useAtomValue(pendingGitDiffScrollPathAtom);
-  const setPendingGitDiffScrollPath = useSetAtom(pendingGitDiffScrollPathAtom);
-  const pendingGitDiffCommitSha = useAtomValue(pendingGitDiffCommitShaAtom);
-  const setPendingGitDiffCommitSha = useSetAtom(pendingGitDiffCommitShaAtom);
   const [selectedGitDiffSelection, setSelectedGitDiffSelection] =
     useState<GitDiffSelectionValue>(null);
 
-  const effectiveMergeBaseBranch = defaultMergeBaseBranch;
   const gitDiffTarget = useMemo(
-    () =>
-      buildGitDiffTarget(selectedGitDiffSelection, effectiveMergeBaseBranch),
-    [effectiveMergeBaseBranch, selectedGitDiffSelection],
+    () => buildGitDiffTarget(selectedGitDiffSelection, defaultMergeBaseBranch),
+    [defaultMergeBaseBranch, selectedGitDiffSelection],
   );
   const { data: gitDiffWorkspaceStatus } = useEnvironmentWorkStatus(
     environmentId ?? "",
-    effectiveMergeBaseBranch,
+    defaultMergeBaseBranch,
     {
       enabled:
         Boolean(environmentId) &&
-        Boolean(effectiveMergeBaseBranch) &&
+        Boolean(defaultMergeBaseBranch) &&
         isDiffPanelActive,
     },
   );
@@ -71,20 +66,11 @@ export function useGitDiffPanelState({
     setSelectedGitDiffSelection(null);
   }, [environmentId]);
 
-  useEffect(() => {
-    setPendingGitDiffScrollPath(null);
-  }, [environmentId, setPendingGitDiffScrollPath]);
-
-  useEffect(() => {
-    setPendingGitDiffCommitSha(null);
-  }, [environmentId, setPendingGitDiffCommitSha]);
-
   // --- Reset the diff to all-changes when an open-file intent arrives
   // (openDiffFile) so the opened file is in the slice. The scroll consumer
   // (DiffFilesPanel) clears `pendingGitDiffScrollPath` once it scrolls the file
-  // into view; that clear is also what lets re-opening the same path re-fire
-  // this effect — jotai primitive atoms bail on Object.is, so a repeat write of
-  // an uncleared path would be a no-op. ---
+  // into view. Clearing the intent also lets re-opening the same path re-fire
+  // this effect. ---
 
   useEffect(() => {
     if (pendingGitDiffScrollPath) {
@@ -97,9 +83,9 @@ export function useGitDiffPanelState({
   useEffect(() => {
     if (pendingGitDiffCommitSha) {
       setSelectedGitDiffSelection(pendingGitDiffCommitSha);
-      setPendingGitDiffCommitSha(null);
+      onClearPendingGitDiffIntent?.();
     }
-  }, [pendingGitDiffCommitSha, setPendingGitDiffCommitSha]);
+  }, [onClearPendingGitDiffIntent, pendingGitDiffCommitSha]);
 
   const hasUncommittedChanges =
     (workspaceStatus?.workingTree.files.length ?? 0) > 0;

--- a/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanelState.ts
+++ b/apps/app/src/components/secondary-panel/git-diff/useGitDiffPanelState.ts
@@ -12,19 +12,19 @@ import {
 interface UseGitDiffPanelStateParams {
   environmentId?: string;
   isDiffPanelActive: boolean;
-  defaultMergeBaseBranch?: string;
+  requestedMergeBaseBranch?: string;
   onClearPendingGitDiffIntent?: () => void;
   pendingGitDiffCommitSha?: string | null;
   pendingGitDiffScrollPath?: string | null;
 }
 
 /**
- * Owns the diff tab's *target selection* — the merge-base branch and the chosen
- * selection (all changes / committed changes / uncommitted changes / a specific
- * commit) — and the derived {@link buildGitDiffTarget} that the TOC + patch
- * fetches key on. The diff body ({@link GitDiffTabContent}) and the per-file
- * cards do all diff fetching, parsing, virtualization, and collapse state
- * themselves; this hook holds none of that. It reacts to the info-tab /
+ * Owns the diff tab's *target selection* — the requested merge-base branch and
+ * the chosen selection (all changes / committed changes / uncommitted changes /
+ * a specific commit) — and the derived {@link buildGitDiffTarget} that the TOC +
+ * patch fetches key on. The diff body ({@link GitDiffTabContent}) and the
+ * per-file cards do all diff fetching, parsing, virtualization, and collapse
+ * state themselves; this hook holds none of that. It reacts to the info-tab /
  * prompt-banner intents (`pendingGitDiffCommitSha` to scope to a commit,
  * `pendingGitDiffScrollPath` to reset the diff to all-changes so the opened file
  * is in the slice) and resets a stale selection when the workspace's commit list
@@ -33,7 +33,7 @@ interface UseGitDiffPanelStateParams {
 export function useGitDiffPanelState({
   environmentId,
   isDiffPanelActive,
-  defaultMergeBaseBranch,
+  requestedMergeBaseBranch,
   onClearPendingGitDiffIntent,
   pendingGitDiffCommitSha,
   pendingGitDiffScrollPath,
@@ -42,16 +42,17 @@ export function useGitDiffPanelState({
     useState<GitDiffSelectionValue>(null);
 
   const gitDiffTarget = useMemo(
-    () => buildGitDiffTarget(selectedGitDiffSelection, defaultMergeBaseBranch),
-    [defaultMergeBaseBranch, selectedGitDiffSelection],
+    () =>
+      buildGitDiffTarget(selectedGitDiffSelection, requestedMergeBaseBranch),
+    [requestedMergeBaseBranch, selectedGitDiffSelection],
   );
   const { data: gitDiffWorkspaceStatus } = useEnvironmentWorkStatus(
     environmentId ?? "",
-    defaultMergeBaseBranch,
+    requestedMergeBaseBranch,
     {
       enabled:
         Boolean(environmentId) &&
-        Boolean(defaultMergeBaseBranch) &&
+        Boolean(requestedMergeBaseBranch) &&
         isDiffPanelActive,
     },
   );

--- a/apps/app/src/components/secondary-panel/threadSecondaryPanelAtoms.ts
+++ b/apps/app/src/components/secondary-panel/threadSecondaryPanelAtoms.ts
@@ -116,9 +116,3 @@ export function getThreadConversationCollapsedAtom(
     ? threadConversationCollapsedAtomFamily(threadId)
     : disabledThreadConversationCollapsedAtom;
 }
-
-/** Set by openDiffFile (prompt banner), consumed by useGitDiffPanelState to reset the diff to all-changes so the opened file is in the slice. */
-export const pendingGitDiffScrollPathAtom = atom<string | null>(null);
-
-/** Set by openCommitDiff (info tab Commits row), consumed by useGitDiffPanelState to scope the diff to a commit. */
-export const pendingGitDiffCommitShaAtom = atom<string | null>(null);

--- a/apps/app/src/components/secondary-panel/threadSecondaryPanelAtoms.ts
+++ b/apps/app/src/components/secondary-panel/threadSecondaryPanelAtoms.ts
@@ -117,9 +117,6 @@ export function getThreadConversationCollapsedAtom(
     : disabledThreadConversationCollapsedAtom;
 }
 
-/** User-selected merge-base branch override. Read by prompt banner + diff panel + git-action dialog. */
-export const selectedMergeBaseBranchAtom = atom<string | undefined>(undefined);
-
 /** Set by openDiffFile (prompt banner), consumed by useGitDiffPanelState to reset the diff to all-changes so the opened file is in the slice. */
 export const pendingGitDiffScrollPathAtom = atom<string | null>(null);
 

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -953,7 +953,6 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
     resolveEnvironmentMergeBaseBranch(environment);
   const {
     closeThreadSecondaryPanel,
-    defaultMergeBaseBranch: resolvedDefaultMergeBaseBranch,
     isLoadingMergeBaseBranchOptions,
     mergeBaseBranchOptions,
     mergeBaseRemoteBranchOptions,
@@ -2536,7 +2535,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
           secondaryPanel={{
             activeTab: activeFixedSecondaryTab,
             canUseGitUi,
-            defaultMergeBaseBranch: resolvedDefaultMergeBaseBranch,
+            defaultMergeBaseBranch: requestedMergeBaseBranch,
             environmentId: thread.environmentId ?? undefined,
             workspaceRootPath: environment?.path,
             fileTabs,

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -952,6 +952,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
   const environmentMergeBaseBranch =
     resolveEnvironmentMergeBaseBranch(environment);
   const {
+    clearPendingGitDiffIntent,
     closeThreadSecondaryPanel,
     isLoadingMergeBaseBranchOptions,
     mergeBaseBranchOptions,
@@ -960,6 +961,9 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
     openDiffFile: openPersistedDiffFile,
     openThreadDiffPanel: openPersistedDiffPanel,
     openThreadSecondaryPanel: openPersistedSecondaryPanel,
+    pendingGitDiffCommitSha,
+    pendingGitDiffScrollPath,
+    requestedMergeBaseBranch,
     selectedMergeBaseBranch,
     selectedMergeBaseBranchRef,
     setMergeBaseBranchSearchQuery,
@@ -973,6 +977,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
       : undefined,
     mergeBaseBranchOptionsEnabled: hasRequestedMergeBaseOptions,
     setThreadSecondaryPanel: setThreadSecondaryPanelForSurface,
+    threadId,
   });
   const {
     closePanel: closeSecondaryPanel,
@@ -1479,8 +1484,6 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
     syncedOrderedSecondaryFileTabs,
     terminalsById,
   ]);
-  const requestedMergeBaseBranch =
-    selectedMergeBaseBranch ?? environmentMergeBaseBranch;
   const workStatusQuery = useEnvironmentWorkStatus(
     thread?.environmentId,
     requestedMergeBaseBranch,
@@ -2552,11 +2555,14 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
             isOpen: isSecondaryPanelOpen,
             onClose: closeSecondaryPanel,
             onCollapse: closeSecondaryPanel,
+            onClearPendingGitDiffIntent: clearPendingGitDiffIntent,
             onOpenFileInEditor: handleOpenFileInEditor,
             onFileTabReorder: reorderFileTab,
             onOpenNewTab: handleOpenNewTab,
             onOpenFilePreview: handleOpenFilePreview,
             onSelectionAddToChat: handleSelectionAddToChat,
+            pendingGitDiffCommitSha,
+            pendingGitDiffScrollPath,
             onPanelFocus: handleSecondaryPanelFocus,
             onPanelChange: handleSecondaryPanelChange,
             showGitDiffTab: canUseGitUi,

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -2538,7 +2538,6 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
           secondaryPanel={{
             activeTab: activeFixedSecondaryTab,
             canUseGitUi,
-            defaultMergeBaseBranch: requestedMergeBaseBranch,
             environmentId: thread.environmentId ?? undefined,
             workspaceRootPath: environment?.path,
             fileTabs,
@@ -2563,6 +2562,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
             onSelectionAddToChat: handleSelectionAddToChat,
             pendingGitDiffCommitSha,
             pendingGitDiffScrollPath,
+            requestedMergeBaseBranch,
             onPanelFocus: handleSecondaryPanelFocus,
             onPanelChange: handleSecondaryPanelChange,
             showGitDiffTab: canUseGitUi,


### PR DESCRIPTION
Fixes #1246.
Fixes #1250.

## What changed

- Keep the selected merge-base branch local to each thread view instead of sharing it across split panes.
- Keep pending file and commit diff actions with the pane that requested them.
- Deduplicate composer stack-height measurements before scheduling React state updates.

## Why

Split panes could have different merge-base branches while reading and writing the same global selection. Each pane then restored its own value, causing the values to alternate and the panes to rerender until React threw error #185 and blanked the route.

## Verification

- Full @bb/app suite: 326 files, 2,456 tests passed.
- Turbo typecheck passed for @bb/app.
- Regression tests cover two simultaneous merge-base owners, environment changes, delayed pane-local diff actions, and stale-action cleanup.
- Installable bb-app tarball smoke test passed.
- Packaged browser QA passed on the affected thread: initial split, two close/reopen cycles, and persisted split reload. Both panes and composers remained visible, with no React #185 or merge-base request loop.
