### PR TITLE
Add shift selection for bulk thread deletion

### DIFF
--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -53,6 +53,7 @@ import {
   useIndexedAppCommandHandlers,
 } from "@/components/commands/AppCommandProvider";
 import { useRouteState } from "@/hooks/useRouteState";
+import { SidebarThreadSelectionProvider } from "./SidebarThreadSelection";
 
 const NEW_THREAD_PANE_CONTENT = { kind: "new-thread" } as const;
 
@@ -300,18 +301,20 @@ export function AppSidebar({
           splitEnabled={threadSplitsEnabled}
           toolsRoutePath={toolsRoutePath}
         />
-        <SidebarContent>
-          {threadListProvider ? (
-            <PluginThreadList
-              slot={threadListProvider}
-              builtInFallback={builtInThreadList}
-              searchQuery={threadSearch.query}
-              onNavigate={threadSearch.onExternalThreadOpen}
-            />
-          ) : (
-            builtInThreadList
-          )}
-        </SidebarContent>
+        <SidebarThreadSelectionProvider>
+          <SidebarContent>
+            {threadListProvider ? (
+              <PluginThreadList
+                slot={threadListProvider}
+                builtInFallback={builtInThreadList}
+                searchQuery={threadSearch.query}
+                onNavigate={threadSearch.onExternalThreadOpen}
+              />
+            ) : (
+              builtInThreadList
+            )}
+          </SidebarContent>
+        </SidebarThreadSelectionProvider>
         <SidebarFooter className="relative">
           <OverflowFade placement="above" tone="sidebar" size="sm" />
           {/* The footer holds a variable number of plugin action buttons, so a

--- a/apps/app/src/components/sidebar/SidebarThreadSelection.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarThreadSelection.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  SidebarThreadSelectionProvider,
+  useSidebarThreadSelection,
+} from "./SidebarThreadSelection";
+
+const { requestDeleteMany } = vi.hoisted(() => ({
+  requestDeleteMany: vi.fn(),
+}));
+
+vi.mock("@/components/thread/ThreadActionsProvider", () => ({
+  useThreadActions: () => ({ requestDeleteMany }),
+}));
+
+function SelectionRow({ id }: { id: string }) {
+  const selection = useSidebarThreadSelection();
+  return (
+    <button
+      type="button"
+      data-sidebar-thread-id={id}
+      onClick={(event) => selection.handleThreadClick(event, id)}
+    >
+      {id}
+    </button>
+  );
+}
+
+function renderSelection() {
+  render(
+    <div data-sidebar="sidebar">
+      <SidebarThreadSelectionProvider>
+        <SelectionRow id="thread-1" />
+        <SelectionRow id="thread-2" />
+        <SelectionRow id="thread-3" />
+      </SidebarThreadSelectionProvider>
+    </div>,
+  );
+}
+
+describe("SidebarThreadSelectionProvider", () => {
+  afterEach(() => {
+    cleanup();
+    requestDeleteMany.mockReset();
+  });
+
+  it("selects a range, clears it on a normal click, and deletes it", () => {
+    renderSelection();
+
+    fireEvent.click(screen.getByRole("button", { name: "thread-1" }));
+    fireEvent.click(screen.getByRole("button", { name: "thread-3" }), {
+      shiftKey: true,
+    });
+
+    expect(screen.getByText("3 selected")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "thread-1" }));
+    expect(screen.queryByText("3 selected")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "thread-3" }), {
+      shiftKey: true,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(requestDeleteMany).toHaveBeenCalledWith(
+      ["thread-1", "thread-2", "thread-3"],
+      expect.any(Function),
+    );
+    expect(screen.getByText("3 selected")).toBeDefined();
+
+    act(() => requestDeleteMany.mock.calls[0]?.[1]());
+    expect(screen.queryByText("3 selected")).toBeNull();
+  });
+});

--- a/apps/app/src/components/sidebar/SidebarThreadSelection.tsx
+++ b/apps/app/src/components/sidebar/SidebarThreadSelection.tsx
@@ -1,0 +1,132 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
+import { Button } from "@bb/shared-ui/button";
+import { Icon } from "@bb/shared-ui/icon";
+import { useThreadActions } from "@/components/thread/ThreadActionsProvider";
+
+interface SidebarThreadSelectionContextValue {
+  handleThreadClick(event: MouseEvent<HTMLElement>, threadId: string): boolean;
+  selectedThreadIds: ReadonlySet<string>;
+}
+
+const EMPTY_SELECTION = new Set<string>();
+
+const SidebarThreadSelectionContext =
+  createContext<SidebarThreadSelectionContextValue>({
+    handleThreadClick: () => false,
+    selectedThreadIds: EMPTY_SELECTION,
+  });
+
+export function useSidebarThreadSelection(): SidebarThreadSelectionContextValue {
+  return useContext(SidebarThreadSelectionContext);
+}
+
+export function SidebarThreadSelectionProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const { requestDeleteMany } = useThreadActions();
+  const [selectedThreadIds, setSelectedThreadIds] =
+    useState<Set<string>>(EMPTY_SELECTION);
+  const anchorThreadIdRef = useRef<string | null>(null);
+
+  function clear() {
+    anchorThreadIdRef.current = null;
+    setSelectedThreadIds(EMPTY_SELECTION);
+  }
+
+  const handleThreadClick = useCallback(
+    (event: MouseEvent<HTMLElement>, threadId: string): boolean => {
+      if (!event.shiftKey) {
+        anchorThreadIdRef.current = threadId;
+        setSelectedThreadIds((current) =>
+          current.size ? EMPTY_SELECTION : current,
+        );
+        return false;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+
+      const rows = event.currentTarget
+        .closest('[data-sidebar="sidebar"]')
+        ?.querySelectorAll<HTMLElement>("[data-sidebar-thread-id]");
+      const visibleThreadIds = Array.from(
+        rows ?? [],
+        (row) => row.dataset.sidebarThreadId!,
+      );
+      const anchorId = anchorThreadIdRef.current ?? threadId;
+      anchorThreadIdRef.current = anchorId;
+      const anchorIndex = visibleThreadIds.indexOf(anchorId);
+      const targetIndex = visibleThreadIds.indexOf(threadId);
+      const selectedRange =
+        anchorIndex < 0 || targetIndex < 0
+          ? [threadId]
+          : visibleThreadIds.slice(
+              Math.min(anchorIndex, targetIndex),
+              Math.max(anchorIndex, targetIndex) + 1,
+            );
+      setSelectedThreadIds(
+        (current) => new Set([...current, ...selectedRange]),
+      );
+      return true;
+    },
+    [],
+  );
+
+  const value = useMemo<SidebarThreadSelectionContextValue>(
+    () => ({
+      handleThreadClick,
+      selectedThreadIds,
+    }),
+    [handleThreadClick, selectedThreadIds],
+  );
+
+  return (
+    <SidebarThreadSelectionContext.Provider value={value}>
+      {children}
+      {selectedThreadIds.size ? (
+        <div className="shrink-0 px-2 pb-2 group-data-[collapsible=icon]:hidden">
+          <div
+            role="toolbar"
+            aria-label="Selected thread actions"
+            className="flex h-10 items-center gap-1 rounded-lg border border-sidebar-border bg-sidebar-accent/90 p-1 pl-3 shadow-sm backdrop-blur-sm"
+          >
+            <span className="min-w-0 flex-1 truncate text-xs font-medium text-sidebar-accent-foreground">
+              {selectedThreadIds.size} selected
+            </span>
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              aria-label="Clear selection"
+              className="size-8 text-muted-foreground hover:text-sidebar-foreground"
+              onClick={clear}
+            >
+              <Icon name="X" className="size-3.5" />
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="destructive"
+              className="h-8 gap-1.5 px-2.5"
+              onClick={() => requestDeleteMany([...selectedThreadIds], clear)}
+            >
+              <Icon name="Trash2" className="size-3.5" />
+              Delete
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </SidebarThreadSelectionContext.Provider>
+  );
+}

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -73,6 +73,7 @@ import { AppCommandShortcutPill } from "@/components/commands/AppCommandShortcut
 import { useThreadTitleDisplayText } from "@/components/thread/ThreadTitleMentions";
 import { pluginIconName } from "@/components/plugin/PluginIcon";
 import { usePluginThreadRowStatus } from "@/lib/plugin-thread-row-status";
+import { useSidebarThreadSelection } from "./SidebarThreadSelection";
 
 interface ThreadRowBaseOptions {
   depth: number;
@@ -484,7 +485,9 @@ function ThreadRowComponent({
   );
   const shortcut = useSidebarThreadShortcut(thread.id);
   const pluginThreadRowStatus = usePluginThreadRowStatus(thread.id);
-  const showActive = isActive;
+  const threadSelection = useSidebarThreadSelection();
+  const isBatchSelected = threadSelection.selectedThreadIds.has(thread.id);
+  const showActive = isActive && threadSelection.selectedThreadIds.size === 0;
   const hasPendingInteraction = thread.hasPendingInteraction;
   const threadRuntimeBusy = isRuntimeBusyThread(thread);
   const threadWorkflowActive = hasActiveWorkflowActivity(thread);
@@ -592,9 +595,11 @@ function ThreadRowComponent({
     options.isCompact
       ? COARSE_POINTER_COMPACT_ROW_HEIGHT_CLASS
       : COARSE_POINTER_ROW_HEIGHT_CLASS,
-    showActive
-      ? SIDEBAR_ROW_SELECTED_STATE_CLASS
-      : SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
+    isBatchSelected
+      ? `${SIDEBAR_ROW_SELECTED_STATE_CLASS} shadow-[inset_2px_0_0_var(--sidebar-foreground)]`
+      : showActive
+        ? SIDEBAR_ROW_SELECTED_STATE_CLASS
+        : SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
     // Subtle open-in-split tint, weaker than the active-row treatment. The
     // focused pane's thread is already the active row, so this only marks the
     // other open panes; hover still wins over it.
@@ -621,7 +626,9 @@ function ThreadRowComponent({
         to={getThreadRoutePath({ projectId, threadId: thread.id })}
         data-sidebar-thread-shortcut-target=""
         data-sidebar-thread-id={thread.id}
+        aria-label={isBatchSelected ? `${linkLabel} (selected)` : linkLabel}
         onClick={(event) => {
+          if (threadSelection.handleThreadClick(event, thread.id)) return;
           // Selecting a thread/agent row restores its conversation without
           // disturbing any other thread's collapsed conversation state.
           setConversationCollapsed(false);
@@ -635,7 +642,6 @@ function ThreadRowComponent({
           }
           onProjectSelect?.();
         }}
-        aria-label={linkLabel}
         aria-keyshortcuts={shortcut?.ariaKeyshortcuts}
         className="absolute inset-0 rounded-md outline-none ring-sidebar-ring focus-visible:ring-2"
       />

--- a/apps/app/src/components/thread/ThreadActionsProvider.tsx
+++ b/apps/app/src/components/thread/ThreadActionsProvider.tsx
@@ -42,6 +42,10 @@ import {
   ThreadDeleteDialog,
   type ThreadDeleteDialogTarget,
 } from "@/components/dialogs/ThreadDeleteDialog";
+import {
+  ConfirmDeleteDialog,
+  ConfirmDeleteDialogContent,
+} from "@/components/dialogs/ConfirmDeleteDialog";
 import { ArchivedThreadToastTitle } from "@/components/thread/ArchivedThreadToastTitle";
 import { destroyPersistedBrowserViewsForThread } from "@/components/secondary-panel/browserViewVisibilityCoordinator";
 import { getThreadReadToggleAction } from "@/components/sidebar/threadReadState";
@@ -52,6 +56,10 @@ export interface ThreadActionsContextValue {
   archiveThreadAndChildren: (thread: Thread) => void;
   requestRename: (thread: Thread) => void;
   requestDelete: (thread: Thread) => void;
+  requestDeleteMany: (
+    threadIds: readonly string[],
+    onComplete: () => void,
+  ) => void;
   unarchiveThread: (thread: Thread) => void;
   togglePin: (thread: Thread) => void;
   toggleRead: (thread: Thread) => void;
@@ -120,13 +128,20 @@ export function ThreadActionsProvider({
   const { mutate: pinMutate } = pinThread;
   const { mutate: unpinMutate } = unpinThread;
   const { mutate: deleteMutate } = deleteThread;
+  const { mutateAsync: deleteMutateAsync } = deleteThread;
   const { mutate: updateMutate } = updateThread;
 
   const renameDialog = useDialogState<ThreadRenameDialogTarget>();
   const deleteDialog = useDialogState<ThreadDeleteDialogTarget>();
+  const bulkDeleteDialog = useDialogState<{
+    onComplete: () => void;
+    threadIds: readonly string[];
+  }>();
 
   const { onClose: closeRenameDialog, onOpen: openRenameDialog } = renameDialog;
   const { onClose: closeDeleteDialog, onOpen: openDeleteDialog } = deleteDialog;
+  const { onClose: closeBulkDeleteDialog, onOpen: openBulkDeleteDialog } =
+    bulkDeleteDialog;
 
   useEffect(() => {
     return () => {
@@ -134,17 +149,6 @@ export function ThreadActionsProvider({
       threadActionContextAbortRef.current = null;
     };
   }, []);
-
-  const navigateAwayIfViewing = useCallback(
-    (thread: Thread) => {
-      if (viewedThreadIdRef.current === thread.id) {
-        // Push (not replace) so the back button still returns the user to the
-        // archived/deleted thread's URL if they want to re-open it.
-        navigate(getRootComposeRoutePath());
-      }
-    },
-    [navigate],
-  );
 
   // Single place that reconciles the URL after archive/delete closed panes.
   // When a valid pane survives, replace-navigate to it (but only when focus
@@ -241,6 +245,24 @@ export function ThreadActionsProvider({
     };
   }
 
+  const finishThreadDeletes = useCallback(
+    (threadIds: readonly string[]) => {
+      for (const threadId of threadIds) {
+        destroyPersistedBrowserViewsForThread({
+          desktopBrowser: getDesktopBrowserApi(),
+          threadId,
+        });
+      }
+      syncNavigationAfterClose(closePanesForThreads(threadIds), () => {
+        const viewed = viewedThreadIdRef.current;
+        if (viewed && threadIds.includes(viewed)) {
+          navigate(getRootComposeRoutePath());
+        }
+      });
+    },
+    [closePanesForThreads, navigate, syncNavigationAfterClose],
+  );
+
   const performDelete = useCallback(
     ({
       childThreadsConfirmed,
@@ -251,27 +273,13 @@ export function ThreadActionsProvider({
         { id: thread.id, childThreadsConfirmed },
         {
           onSuccess: () => {
-            destroyPersistedBrowserViewsForThread({
-              desktopBrowser: getDesktopBrowserApi(),
-              threadId: thread.id,
-            });
             closeDialog();
-            // In a split, close the pane holding this thread and move the URL
-            // to the surviving focused pane; single pane falls through to the
-            // navigate-away.
-            syncNavigationAfterClose(closePanesForThreads([thread.id]), () =>
-              navigateAwayIfViewing(thread),
-            );
+            finishThreadDeletes([thread.id]);
           },
         },
       );
     },
-    [
-      closePanesForThreads,
-      deleteMutate,
-      navigateAwayIfViewing,
-      syncNavigationAfterClose,
-    ],
+    [deleteMutate, finishThreadDeletes],
   );
 
   const requestDelete = useCallback(
@@ -301,6 +309,38 @@ export function ThreadActionsProvider({
     },
     [closeDeleteDialog, performDelete],
   );
+
+  const requestDeleteMany = useCallback(
+    (threadIds: readonly string[], onComplete: () => void) =>
+      openBulkDeleteDialog({ onComplete, threadIds }),
+    [openBulkDeleteDialog],
+  );
+
+  const confirmDeleteMany = useCallback(async () => {
+    const target = bulkDeleteDialog.target;
+    if (!target) return;
+
+    const deletedThreadIds: string[] = [];
+    for (const threadId of target.threadIds) {
+      try {
+        await deleteMutateAsync({ id: threadId, childThreadsConfirmed: true });
+      } catch {
+        break;
+      }
+      deletedThreadIds.push(threadId);
+    }
+    closeBulkDeleteDialog();
+    target.onComplete();
+    finishThreadDeletes(deletedThreadIds);
+  }, [
+    bulkDeleteDialog.target,
+    closeBulkDeleteDialog,
+    deleteMutateAsync,
+    finishThreadDeletes,
+  ]);
+
+  const bulkDeleteCount = bulkDeleteDialog.target?.threadIds.length ?? 0;
+  const bulkDeleteLabel = `${bulkDeleteCount} thread${bulkDeleteCount === 1 ? "" : "s"}`;
 
   const unarchiveThreadAction = useCallback(
     (thread: Thread) => {
@@ -410,6 +450,7 @@ export function ThreadActionsProvider({
     () => ({
       requestRename,
       requestDelete,
+      requestDeleteMany,
       archiveThreadAndChildren: archiveThreadAndChildrenAction,
       unarchiveThread: unarchiveThreadAction,
       togglePin,
@@ -419,6 +460,7 @@ export function ThreadActionsProvider({
       archiveThreadAndChildrenAction,
       requestRename,
       requestDelete,
+      requestDeleteMany,
       togglePin,
       toggleRead,
       unarchiveThreadAction,
@@ -440,6 +482,21 @@ export function ThreadActionsProvider({
         onOpenChange={deleteDialog.onOpenChange}
         onDelete={confirmDelete}
       />
+      <ConfirmDeleteDialog
+        open={bulkDeleteDialog.target !== null}
+        onOpenChange={bulkDeleteDialog.onOpenChange}
+      >
+        {bulkDeleteDialog.target ? (
+          <ConfirmDeleteDialogContent
+            title={`Delete ${bulkDeleteLabel}?`}
+            description="Any child threads will be deleted too. This action cannot be undone."
+            confirmLabel={`Delete ${bulkDeleteLabel}`}
+            pending={deleteThread.isPending}
+            onConfirm={() => void confirmDeleteMany()}
+            onCancel={closeBulkDeleteDialog}
+          />
+        ) : null}
+      </ConfirmDeleteDialog>
     </ThreadActionsContext.Provider>
   );
 }


### PR DESCRIPTION
## Summary

- add Shift-click range selection to the sidebar thread list
- show selected threads with a compact highlight and bulk action bar, without checkboxes
- confirm and delete every selected thread, including child threads, while preserving pane, browser-view, and navigation cleanup
- clear the selection and navigate normally when a thread is clicked without Shift

## Screenshots

### Shift-selected threads

![Three sidebar threads selected with the bulk delete action bar](https://raw.githubusercontent.com/MateoCerquetella/bb/pr-assets-shift-select-delete-threads/shift-selection.png)

### Bulk delete confirmation

![Confirmation dialog for deleting three selected threads](https://raw.githubusercontent.com/MateoCerquetella/bb/pr-assets-shift-select-delete-threads/bulk-delete-confirmation.png)

## Validation

- `pnpm exec turbo run test --filter=@bb/app -- src/components/sidebar/ThreadRow.test.tsx src/components/sidebar/SidebarThreadSelection.test.tsx` — 65 passed
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` — 0 errors (141 existing warnings)
- verified Shift selection, the selected-thread toolbar, and normal-click deselection in the running app
