### PR TITLE
feat(desktop): add local build-and-install script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ output.txt
 .codex
 .hermes/plans/
 .otto/
+.bb/
 
 # turborepo
 .turbo

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -82,6 +82,28 @@ machines with no keychain identity (or with `CSC_IDENTITY_AUTO_DISCOVERY=false`,
 as CI sets for workflow-artifact-only builds), artifacts remain unsigned and
 macOS shows the normal Gatekeeper warning on first launch.
 
+## Local install
+
+Build a stable desktop release, produce a `.dmg`, and replace `/Applications/bb.app`
+with the freshly built bundle:
+
+```bash
+pnpm desktop:install
+```
+
+This is macOS Apple Silicon only. The script installs workspace dependencies when
+needed, builds via `desktop:dist:local` (no publish), and copies from
+`apps/desktop/release/mac-arm64/bb.app`. The `.dmg` remains under
+`apps/desktop/release/` for sharing or testing. Unsigned local builds may still
+show Gatekeeper on first launch.
+
+Options:
+
+```bash
+scripts/desktop-build-install.sh --skip-build   # install existing release artifacts
+scripts/desktop-build-install.sh --no-quit      # skip quitting a running bb app
+```
+
 ## Releasing
 
 `bb-app` and `@bb/desktop` versions are LOCKED in lockstep. The desktop package

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -11,6 +11,7 @@
     "build": "node scripts/build.mjs",
     "clean": "rimraf dist release",
     "desktop:build": "pnpm run build && node scripts/run-electron-builder.mjs --mac --arm64 --publish always",
+    "desktop:dist:local": "pnpm run prepare-runtime && pnpm run build && node scripts/run-electron-builder.mjs --mac --arm64 --publish never",
     "desktop:version-feed": "tsx scripts/generate-version-feed.mts",
     "dev": "pnpm run prepare-runtime && pnpm run build && node --conditions=source --import tsx scripts/run-electron-dev.mjs",
     "dist": "pnpm run prepare-runtime && pnpm run desktop:build",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "cli:prepare": "pnpm exec turbo run build --filter=@bb/scripts --filter=@bb/cli --output-logs=none --log-prefix=none --summarize=false",
     "ensure-native-modules": "node scripts/ensure-native-modules.mjs",
     "dev": "node scripts/ensure-native-modules.mjs && cross-env NODE_ENV=development dotenv -c development -- node --conditions=source --import tsx packages/scripts/src/commands/run-dev.ts",
+    "desktop:install": "scripts/desktop-build-install.sh",
     "dev:desktop": "scripts/bb-dev-app current --desktop",
     "dev:status": "scripts/bb-dev-app status",
     "dev:restart": "cross-env NODE_ENV=development node --conditions=source --import tsx packages/scripts/src/commands/request-dev-restart.ts both",

--- a/scripts/desktop-build-install.sh
+++ b/scripts/desktop-build-install.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(dirname -- "${script_dir}")"
+DESKTOP_DIR="${REPO_ROOT}/apps/desktop"
+RELEASE_DIR="${DESKTOP_DIR}/release"
+APP_NAME="bb"
+APP_BUNDLE_NAME="${APP_NAME}.app"
+INSTALL_PATH="/Applications/${APP_BUNDLE_NAME}"
+PACKAGED_APP_PATH="${RELEASE_DIR}/mac-arm64/${APP_BUNDLE_NAME}"
+
+SKIP_BUILD=0
+NO_QUIT=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/desktop-build-install.sh [--skip-build] [--no-quit]
+
+Builds the stable macOS desktop app (including a .dmg), then replaces
+/Applications/bb.app with the freshly built bundle.
+
+Options:
+  --skip-build  Install from existing apps/desktop/release artifacts only
+  --no-quit     Skip quitting a running bb app before replacing the install
+EOF
+}
+
+log() {
+  printf '[desktop-install] %s\n' "$*" >&2
+}
+
+die() {
+  log "ERROR: $*"
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
+}
+
+parse_args() {
+  while (($# > 0)); do
+    case "$1" in
+      --skip-build)
+        SKIP_BUILD=1
+        ;;
+      --no-quit)
+        NO_QUIT=1
+        ;;
+      -h | --help)
+        usage
+        exit 0
+        ;;
+      *)
+        die "Unknown argument: $1"
+        ;;
+    esac
+    shift
+  done
+}
+
+assert_platform() {
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    die "This script only runs on macOS"
+  fi
+  if [[ "$(uname -m)" != "arm64" ]]; then
+    die "This script only supports Apple Silicon (arm64)"
+  fi
+}
+
+assert_node_version() {
+  require_command node
+  node - <<'NODE' || die "Node >=22.19.0 is required"
+const [major, minor, patch] = process.versions.node.split(".").map(Number);
+const ok =
+  major > 22 ||
+  (major === 22 && (minor > 19 || (minor === 19 && patch >= 0)));
+if (!ok) {
+  process.exit(1);
+}
+NODE
+}
+
+ensure_dependencies() {
+  if [[ ! -x "${REPO_ROOT}/node_modules/.bin/turbo" ]]; then
+    log "Installing workspace dependencies"
+    pnpm -C "${REPO_ROOT}" install --frozen-lockfile
+  fi
+
+  log "Checking native Node modules"
+  node "${REPO_ROOT}/scripts/ensure-native-modules.mjs"
+
+  if ! (cd "${DESKTOP_DIR}" && node -e "require('electron')" >/dev/null 2>&1); then
+    local electron_install
+    electron_install="$(
+      find "${REPO_ROOT}/node_modules/.pnpm" -path '*/node_modules/electron/install.js' -type f -print -quit
+    )"
+    [[ -n "${electron_install}" ]] || die "Could not find Electron install.js"
+    log "Installing Electron runtime"
+    node "${electron_install}"
+  fi
+}
+
+build_desktop() {
+  log "Building desktop artifacts"
+  pnpm -C "${REPO_ROOT}" exec turbo run desktop:dist:local \
+    --filter=@bb/desktop \
+    --force \
+    --output-logs=new-only
+}
+
+read_desktop_version() {
+  node - "${DESKTOP_DIR}/package.json" <<'NODE'
+const fs = require("node:fs");
+const packageJsonPath = process.argv[2];
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+if (typeof packageJson.version !== "string" || packageJson.version.length === 0) {
+  process.exit(1);
+}
+process.stdout.write(packageJson.version);
+NODE
+}
+
+resolve_dmg_path() {
+  local version="$1"
+  local dmg_path="${RELEASE_DIR}/${APP_NAME}-${version}-arm64.dmg"
+  [[ -f "${dmg_path}" ]] || die "DMG not found at ${dmg_path}"
+  printf '%s\n' "${dmg_path}"
+}
+
+assert_packaged_app() {
+  [[ -d "${PACKAGED_APP_PATH}" ]] || die "Packaged app not found at ${PACKAGED_APP_PATH}"
+}
+
+quit_running_app() {
+  if [[ "${NO_QUIT}" -eq 1 ]]; then
+    return 0
+  fi
+
+  if ! pgrep -xq "${APP_NAME}"; then
+    return 0
+  fi
+
+  log "Quitting running ${APP_NAME}"
+  osascript -e "tell application \"${APP_NAME}\" to quit" >/dev/null 2>&1 || true
+
+  local elapsed=0
+  while pgrep -xq "${APP_NAME}" && ((elapsed < 10)); do
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+
+  if pgrep -xq "${APP_NAME}"; then
+    log "App still running; sending SIGTERM"
+    pkill -x "${APP_NAME}" || true
+    sleep 1
+  fi
+
+  if pgrep -xq "${APP_NAME}"; then
+    die "Could not quit running ${APP_NAME}; close it manually and retry"
+  fi
+}
+
+install_app() {
+  if [[ -d "${INSTALL_PATH}" ]]; then
+    log "Removing existing install at ${INSTALL_PATH}"
+    rm -rf "${INSTALL_PATH}"
+  fi
+
+  log "Installing ${APP_BUNDLE_NAME} to /Applications"
+  ditto "${PACKAGED_APP_PATH}" "${INSTALL_PATH}"
+}
+
+main() {
+  parse_args "$@"
+  assert_platform
+  assert_node_version
+  require_command pnpm
+  require_command ditto
+  require_command osascript
+
+  if [[ "${SKIP_BUILD}" -eq 0 ]]; then
+    ensure_dependencies
+    build_desktop
+  fi
+
+  local version dmg_path
+  version="$(read_desktop_version)" || die "Could not read apps/desktop/package.json version"
+  assert_packaged_app
+  dmg_path="$(resolve_dmg_path "${version}")"
+
+  quit_running_app
+  install_app
+
+  log "Installed ${INSTALL_PATH}"
+  log "DMG artifact: ${dmg_path}"
+}
+
+main "$@"

--- a/turbo.json
+++ b/turbo.json
@@ -177,6 +177,19 @@
         "*"
       ]
     },
+    "@bb/desktop#desktop:dist:local": {
+      "dependsOn": [
+        "bb-app#build",
+        "@bb/desktop#build"
+      ],
+      "cache": false,
+      "outputs": [
+        "release/**"
+      ],
+      "passThroughEnv": [
+        "*"
+      ]
+    },
     "@bb/desktop#smoke:packaged": {
       "cache": false,
       "outputs": [],


### PR DESCRIPTION
## Summary
- Add `pnpm desktop:install` to build a stable macOS desktop release (including a `.dmg`) and replace `/Applications/bb.app` from the unpacked bundle
- Add `desktop:dist:local` for local packaging without GitHub publish
- Add `scripts/desktop-build-install.sh` with dependency bootstrap, quit/replace install flow, and `--skip-build` / `--no-quit` flags

## Test plan
- [ ] On macOS arm64 with a clean worktree, run `pnpm desktop:install` and confirm deps install, DMG is produced under `apps/desktop/release/`, and `/Applications/bb.app` is updated
- [ ] Re-run with `bb` open and confirm the running app is quit and replaced
- [ ] Run `scripts/desktop-build-install.sh --skip-build` with existing release artifacts and confirm install succeeds without rebuilding


Made with [Cursor](https://cursor.com)