### PR TITLE
fix: add tooltips to queued message actions

### DIFF
--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -280,10 +280,11 @@ describe("QueuedMessagesList", () => {
     ).toBe("collapsed");
   });
 
-  it("uses hover-revealed icon actions on desktop and an overflow menu on mobile widths", () => {
-    const { container, getByRole } = renderQueuedMessages([
-      makeQueuedMessage("q_one", "First queued message"),
-    ]);
+  it("uses labeled hover-revealed icon actions on desktop and an overflow menu on mobile widths", async () => {
+    const { container, findByRole, getByRole, queryByRole } =
+      renderQueuedMessages([
+        makeQueuedMessage("q_one", "First queued message"),
+      ]);
 
     const sendButton = getByRole("button", {
       name: "Send queued message 1 now",
@@ -315,6 +316,19 @@ describe("QueuedMessagesList", () => {
     expect(
       container.querySelector('[data-icon="DragDropVertical"]'),
     ).not.toBeNull();
+
+    for (const [button, label] of [
+      [sendButton, "Send now"],
+      [editButton, "Edit"],
+      [deleteButton, "Delete"],
+    ] as const) {
+      fireEvent.focus(button);
+      expect((await findByRole("tooltip")).textContent).toBe(label);
+      fireEvent.blur(button);
+      await waitFor(() => {
+        expect(queryByRole("tooltip")).toBeNull();
+      });
+    }
   });
 
   it("replaces the edited row with the real inline composer", () => {

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -728,63 +728,80 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
           </span>
         ) : (
           <>
-            <div
-              data-queued-message-actions=""
-              className={cn(
-                QUEUED_MESSAGE_ACTION_TAKEOVER_CLASS,
-                "pointer-events-none absolute right-2.5 top-1/2 hidden -translate-y-1/2 items-center gap-0.5 rounded-md opacity-0 transition-opacity duration-[120ms] ease-out md:flex",
-                "group-hover/row:pointer-events-auto group-hover/row:opacity-100",
-                "group-focus-within/row:pointer-events-auto group-focus-within/row:opacity-100",
-              )}
-            >
-              <Button
-                type="button"
-                size="icon"
-                variant="ghost"
+            <TooltipProvider delayDuration={300}>
+              <div
+                data-queued-message-actions=""
                 className={cn(
-                  "shrink-0 text-muted-foreground",
-                  compact ? "size-7" : "size-8",
+                  QUEUED_MESSAGE_ACTION_TAKEOVER_CLASS,
+                  "pointer-events-none absolute right-2.5 top-1/2 hidden -translate-y-1/2 items-center gap-0.5 rounded-md opacity-0 transition-opacity duration-[120ms] ease-out md:flex",
+                  "group-hover/row:pointer-events-auto group-hover/row:opacity-100",
+                  "group-focus-within/row:pointer-events-auto group-focus-within/row:opacity-100",
                 )}
-                disabled={actionDisabled || sendDisabled}
-                onClick={() => onSendImmediately(queuedMessage.id)}
-                aria-label={`Send queued message ${index + 1} now`}
               >
-                <Icon name="Sent" className="size-4" aria-hidden />
-              </Button>
-              <Button
-                type="button"
-                size="icon"
-                variant="ghost"
-                className={cn(
-                  "shrink-0 text-muted-foreground",
-                  compact ? "size-7" : "size-8",
-                )}
-                disabled={actionDisabled}
-                onClick={() =>
-                  onEdit({
-                    queuedMessageId: queuedMessage.id,
-                    queuedMessageIndex: index,
-                  })
-                }
-                aria-label={`Edit queued message ${index + 1}`}
-              >
-                <Icon name="Edit" className="size-4" aria-hidden />
-              </Button>
-              <Button
-                type="button"
-                size="icon"
-                variant="ghost"
-                className={cn(
-                  "shrink-0 text-muted-foreground hover:text-destructive",
-                  compact ? "size-7" : "size-8",
-                )}
-                disabled={actionDisabled}
-                onClick={() => onDelete(queuedMessage.id)}
-                aria-label={`Delete queued message ${index + 1}`}
-              >
-                <Icon name="Trash2" className="size-4" aria-hidden />
-              </Button>
-            </div>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="ghost"
+                      className={cn(
+                        "shrink-0 text-muted-foreground",
+                        compact ? "size-7" : "size-8",
+                      )}
+                      disabled={actionDisabled || sendDisabled}
+                      onClick={() => onSendImmediately(queuedMessage.id)}
+                      aria-label={`Send queued message ${index + 1} now`}
+                    >
+                      <Icon name="Sent" className="size-4" aria-hidden />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Send now</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="ghost"
+                      className={cn(
+                        "shrink-0 text-muted-foreground",
+                        compact ? "size-7" : "size-8",
+                      )}
+                      disabled={actionDisabled}
+                      onClick={() =>
+                        onEdit({
+                          queuedMessageId: queuedMessage.id,
+                          queuedMessageIndex: index,
+                        })
+                      }
+                      aria-label={`Edit queued message ${index + 1}`}
+                    >
+                      <Icon name="Edit" className="size-4" aria-hidden />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Edit</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      size="icon"
+                      variant="ghost"
+                      className={cn(
+                        "shrink-0 text-muted-foreground hover:text-destructive",
+                        compact ? "size-7" : "size-8",
+                      )}
+                      disabled={actionDisabled}
+                      onClick={() => onDelete(queuedMessage.id)}
+                      aria-label={`Delete queued message ${index + 1}`}
+                    >
+                      <Icon name="Trash2" className="size-4" aria-hidden />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Delete</TooltipContent>
+                </Tooltip>
+              </div>
+            </TooltipProvider>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button


### PR DESCRIPTION
## Summary

- add pointer tooltips to the desktop queued-message actions
- reuse the Send now, Edit, and Delete labels from the mobile menu
- cover all three tooltip labels in the queued messages component test

## Testing

- pnpm exec vitest run --config vitest.config.ts src/components/promptbox/banner/QueuedMessagesList.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app

Closes #1184