### PR TITLE
Add Discord link to website footer

### DIFF
--- a/apps/web/src/landing/analytics.ts
+++ b/apps/web/src/landing/analytics.ts
@@ -21,6 +21,10 @@ export type LandingEvent =
       properties: { placement: CtaPlacement };
     }
   | {
+      name: "landing_discord_clicked";
+      properties: { placement: CtaPlacement };
+    }
+  | {
       name: "landing_cli_command_copied";
       properties: { placement: CtaPlacement; command: string };
     }

--- a/apps/web/src/landing/cta.tsx
+++ b/apps/web/src/landing/cta.tsx
@@ -5,7 +5,12 @@ import type { FormEvent, ReactNode } from "react";
 
 import { trackLandingEvent } from "./analytics";
 import type { CtaPlacement } from "./site";
-import { GITHUB_URL, SUBSCRIBE_PATH, downloadMacosHref } from "./site";
+import {
+  DISCORD_URL,
+  GITHUB_URL,
+  SUBSCRIBE_PATH,
+  downloadMacosHref,
+} from "./site";
 
 /* Marketing CTAs shared by the landing page and the changelog. */
 
@@ -34,6 +39,25 @@ export function GitHubLink({ placement, className, children }: CtaLinkProps) {
       onClick={() =>
         trackLandingEvent({
           name: "landing_github_clicked",
+          properties: { placement },
+        })
+      }
+    >
+      {children}
+    </a>
+  );
+}
+
+export function DiscordLink({ placement, className, children }: CtaLinkProps) {
+  return (
+    <a
+      className={className}
+      href={DISCORD_URL}
+      target="_blank"
+      rel="noreferrer"
+      onClick={() =>
+        trackLandingEvent({
+          name: "landing_discord_clicked",
           properties: { placement },
         })
       }

--- a/apps/web/src/landing/site.ts
+++ b/apps/web/src/landing/site.ts
@@ -1,4 +1,5 @@
 export const GITHUB_URL = "https://github.com/get-bb/bb";
+export const DISCORD_URL = "https://discord.gg/kvBU6tJhcJ";
 export const DOWNLOAD_MACOS_FALLBACK_URL =
   "https://github.com/get-bb/bb/releases/tag/desktop-latest";
 export const DOWNLOAD_MACOS_RELEASE_ASSET_BASE_URL =

--- a/apps/web/src/routes/changelog.tsx
+++ b/apps/web/src/routes/changelog.tsx
@@ -10,7 +10,12 @@ import { initAnalytics } from "../landing/analytics";
 import type { Release, ReleaseBlock } from "../landing/changelog";
 import { RELEASE_META, parseChangelog } from "../landing/changelog";
 import { ChangelogInline } from "../landing/changelog-inline";
-import { DownloadLink, EmailSignup, GitHubLink } from "../landing/cta";
+import {
+  DiscordLink,
+  DownloadLink,
+  EmailSignup,
+  GitHubLink,
+} from "../landing/cta";
 import { DASHBOARD_PATH } from "../lib/connect-return-to";
 import interWoff2 from "@fontsource-variable/inter/files/inter-latin-wght-normal.woff2?url";
 import landingCss from "../landing/landing.css?url";
@@ -223,6 +228,8 @@ function ChangelogPage() {
         <span>bb is free and open source (MIT)</span>
         <span>
           <GitHubLink placement="footer">GitHub</GitHubLink>
+          {" · "}
+          <DiscordLink placement="footer">Discord</DiscordLink>
           {" · "}
           <DownloadLink placement="footer">Download</DownloadLink>
         </span>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -35,7 +35,12 @@ import bbIcon from "../assets/bb-icon.png";
 import hermesAvatar from "../assets/hermes-avatar.jpg";
 import vscodeIcon from "../assets/vscode.png";
 import { RELEASE_META, parseChangelog } from "../landing/changelog";
-import { DownloadLink, EmailSignup, GitHubLink } from "../landing/cta";
+import {
+  DiscordLink,
+  DownloadLink,
+  EmailSignup,
+  GitHubLink,
+} from "../landing/cta";
 import { DASHBOARD_PATH } from "../lib/connect-return-to";
 import {
   ClaudeIcon,
@@ -1786,6 +1791,8 @@ function LandingPage() {
           <a href="/changelog">Changelog</a>
           {" · "}
           <GitHubLink placement="footer">GitHub</GitHubLink>
+          {" · "}
+          <DiscordLink placement="footer">Discord</DiscordLink>
           {" · "}
           <DownloadLink placement="footer">Download</DownloadLink>
         </span>


### PR DESCRIPTION
## Summary

- add a Discord link to the home and changelog footers
- track Discord footer clicks through the landing-page analytics
- use the existing Discord invite URL

## Tests

- pnpm exec turbo run typecheck --filter=@bb/web
- pnpm exec turbo run build --filter=@bb/web