### PR TITLE
Recover file browser after worktree provisioning

### DIFF
--- a/apps/app/src/hooks/cache-owners/query-cache.ts
+++ b/apps/app/src/hooks/cache-owners/query-cache.ts
@@ -19,6 +19,7 @@ import {
   environmentDiffPatchQueryKeyPrefix,
   environmentFilePreviewQueryKeyPrefix,
   environmentMergeBaseBranchesQueryKeyPrefix,
+  environmentPathsQueryKeyPrefix,
   environmentPullRequestQueryKey,
   environmentQueryKey,
   environmentWorkStatusQueryKey,
@@ -372,6 +373,7 @@ export function getEnvironmentWorkspaceStateInvalidationQueryKeys({
     environmentPullRequestQueryKey(environmentId),
     environmentDiffFilesQueryKeyPrefix(environmentId),
     environmentFilePreviewQueryKeyPrefix(environmentId),
+    environmentPathsQueryKeyPrefix(environmentId),
   ];
 }
 

--- a/apps/app/src/hooks/queries/query-helpers.test.ts
+++ b/apps/app/src/hooks/queries/query-helpers.test.ts
@@ -455,7 +455,7 @@ describe("resolveEnvironmentMergeBaseBranchesPlaceholder", () => {
 });
 
 describe("getEnvironmentWorkspaceStateInvalidationQueryKeys", () => {
-  it("targets workspace-derived status and the observer-backed diff TOC, but never the observer-less patch cache", () => {
+  it("targets observer-backed workspace queries, but never the observer-less patch cache", () => {
     const queryKeys = getEnvironmentWorkspaceStateInvalidationQueryKeys({
       environmentId: "env-1",
     });
@@ -465,6 +465,7 @@ describe("getEnvironmentWorkspaceStateInvalidationQueryKeys", () => {
       ["environmentPullRequest", "env-1"],
       ["environmentDiffFiles", "env-1"],
       ["environmentFilePreview", "env-1"],
+      ["environmentPaths", "env-1"],
     ]);
     // The patch cache is observer-less; invalidation is a no-op for it, so it
     // must be evicted (removeEnvironmentDiffPatchQueries) rather than appearing

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -12,6 +12,7 @@ import {
   archivedThreadsListQueryKey,
   environmentDiffFilesQueryKey,
   environmentDiffPatchQueryKey,
+  environmentPathsQueryKey,
   environmentPullRequestQueryKey,
   environmentWorkStatusQueryKey,
   hostPathExistenceQueryKey,
@@ -950,6 +951,58 @@ describe("createRealtimeCacheEffects", () => {
     expect(queryClient.getQueryData(defaultOptionsKey)).toEqual(nextDefaults);
 
     unsubscribeDefaultOptions();
+    effects.dispose();
+  });
+
+  it("retries an active environment path query when the environment becomes ready", async () => {
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const pathsKey = environmentPathsQueryKey(
+      "env-1",
+      "",
+      1_000,
+      true,
+      true,
+    );
+    const readyResponse = {
+      paths: [
+        {
+          kind: "file" as const,
+          name: "README.md",
+          path: "README.md",
+          positions: [],
+          score: 0,
+        },
+      ],
+      truncated: false,
+    };
+    const pathsQueryFn = vi
+      .fn<() => Promise<typeof readyResponse>>()
+      .mockRejectedValueOnce(new Error("Environment unavailable"))
+      .mockResolvedValue(readyResponse);
+    const pathsObserver = new QueryObserver(queryClient, {
+      queryKey: pathsKey,
+      queryFn: pathsQueryFn,
+      staleTime: Infinity,
+    });
+    const unsubscribePaths = pathsObserver.subscribe(() => {});
+
+    await vi.waitFor(() => {
+      expect(pathsObserver.getCurrentResult().isError).toBe(true);
+    });
+
+    effects.handleChanged({
+      type: "changed",
+      entity: "environment",
+      id: "env-1",
+      changes: ["status-changed"],
+    });
+
+    await vi.waitFor(() => {
+      expect(pathsQueryFn).toHaveBeenCalledTimes(2);
+      expect(queryClient.getQueryData(pathsKey)).toEqual(readyResponse);
+    });
+
+    unsubscribePaths();
     effects.dispose();
   });
 


### PR DESCRIPTION
## Summary

- invalidate environment path-list queries when environment workspace state changes
- retry an active failed file-browser request when provisioning reaches ready
- cover the provisioning 409 recovery path and invalidation contract

## Verification

- pnpm exec turbo run test --filter=@bb/app --force -- src/hooks/realtime-cache-effects.test.ts src/hooks/queries/query-helpers.test.ts
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app
- git diff --check

Closes #1222