### PR TITLE
Prevent duplicate projects for the same local folder

### DIFF
--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -1,8 +1,9 @@
 import path from "node:path";
 import {
   countProjectSources,
-  createProject,
+  findOrCreateProjectByLocalPathSource,
   getPersonalProject,
+  getPublicProjectByLocalPathSource,
   createProjectSource,
   deleteProjectSource,
   getProjectSourceByHost,
@@ -355,11 +356,22 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
       requireNonDestroyedHostWithStatus(deps, source.hostId);
       assertUsableHostId(deps, { hostId: source.hostId });
     }
+    const existingProject = getPublicProjectByLocalPathSource(deps.db, source);
+    if (existingProject) {
+      return context.json(
+        buildProjectResponses(deps, existingProject.id)[0],
+        201,
+      );
+    }
     const gitRemoteUrl = await inspectProjectGitRemoteBestEffort(deps, source);
-    const { project } = createProject(deps.db, deps.hub, {
-      name: payload.name,
-      source,
-    });
+    const { project } = findOrCreateProjectByLocalPathSource(
+      deps.db,
+      deps.hub,
+      {
+        name: payload.name,
+        source,
+      },
+    );
     if (gitRemoteUrl !== null) {
       setProjectGitRemoteUrlIfMissing(
         deps.db,

--- a/apps/server/test/public/public-projects-local-host.test.ts
+++ b/apps/server/test/public/public-projects-local-host.test.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { describe, expect, it } from "vitest";
-import { setExperiments } from "@bb/db";
+import { listPublicProjects, setExperiments } from "@bb/db";
 import { defaultExperiments } from "@bb/domain";
 import {
   reportQueuedCommandSuccess,
@@ -27,6 +27,49 @@ const projectResponseSchema = z.object({
 });
 
 describe("public project local host routes", () => {
+  it("returns the existing project when its local folder is added again", async () => {
+    await withTestHarness(async (harness) => {
+      const offlinePrimary = seedHost(harness.deps, {
+        id: "host-duplicate-project",
+      });
+      seedPrimaryHost(harness.deps, offlinePrimary.id);
+
+      const create = (name: string, path: string) =>
+        harness.app.request("/api/v1/projects", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            name,
+            source: {
+              type: "local_path",
+              hostId: offlinePrimary.id,
+              path,
+            },
+          }),
+        });
+
+      const firstResponse = await create(
+        "Original Project",
+        "/tmp/duplicate-project",
+      );
+      const repeatedResponse = await create(
+        "Duplicate Project",
+        "/tmp/duplicate-project/",
+      );
+
+      expect(firstResponse.status).toBe(201);
+      expect(repeatedResponse.status).toBe(201);
+      const firstProject = projectResponseSchema.parse(
+        await readJson(firstResponse),
+      );
+      const repeatedProject = projectResponseSchema.parse(
+        await readJson(repeatedResponse),
+      );
+      expect(repeatedProject.id).toBe(firstProject.id);
+      expect(listPublicProjects(harness.db)).toHaveLength(1);
+    });
+  });
+
   it("creates projects and local sources when inspection is unavailable", async () => {
     await withTestHarness(async (harness) => {
       const offlinePrimary = seedHost(harness.deps, {

--- a/apps/server/test/public/public-projects-local-host.test.ts
+++ b/apps/server/test/public/public-projects-local-host.test.ts
@@ -1,17 +1,23 @@
 import { z } from "zod";
 import { describe, expect, it } from "vitest";
-import { listPublicProjects, setExperiments } from "@bb/db";
-import { defaultExperiments } from "@bb/domain";
+import {
+  ensurePersonalProject,
+  listPublicProjects,
+  setExperiments,
+} from "@bb/db";
+import { defaultExperiments, PERSONAL_PROJECT_ID } from "@bb/domain";
 import {
   reportQueuedCommandSuccess,
   waitForQueuedCommand,
 } from "../helpers/commands.js";
 import { readJson } from "../helpers/json.js";
 import {
+  seedEnvironment,
   seedHost,
   seedHostSession,
   seedPrimaryHost,
   seedProjectWithSource,
+  seedThread,
 } from "../helpers/seed.js";
 import { withTestHarness } from "../helpers/test-app.js";
 
@@ -27,6 +33,48 @@ const projectResponseSchema = z.object({
 });
 
 describe("public project local host routes", () => {
+  it("creates a project when a personal thread already uses its folder", async () => {
+    await withTestHarness(async (harness) => {
+      const offlinePrimary = seedHost(harness.deps, {
+        id: "host-personal-folder-project",
+      });
+      seedPrimaryHost(harness.deps, offlinePrimary.id);
+      // Threads created without a selected project belong to Personal. After
+      // changing directories, their target path is stored as an environment.
+      ensurePersonalProject(harness.db);
+      const personalEnvironment = seedEnvironment(harness.deps, {
+        hostId: offlinePrimary.id,
+        projectId: PERSONAL_PROJECT_ID,
+        path: "/tmp/personal-thread-folder",
+      });
+      seedThread(harness.deps, {
+        projectId: PERSONAL_PROJECT_ID,
+        environmentId: personalEnvironment.id,
+        status: "idle",
+      });
+
+      const response = await harness.app.request("/api/v1/projects", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          name: "Personal Thread Folder",
+          source: {
+            type: "local_path",
+            hostId: offlinePrimary.id,
+            path: "/tmp/personal-thread-folder",
+          },
+        }),
+      });
+
+      expect(response.status).toBe(201);
+      const project = projectResponseSchema.parse(await readJson(response));
+      expect(project.id).not.toBe(PERSONAL_PROJECT_ID);
+      expect(listPublicProjects(harness.db)).toEqual([
+        expect.objectContaining({ id: project.id }),
+      ]);
+    });
+  });
+
   it("returns the existing project when its local folder is added again", async () => {
     await withTestHarness(async (harness) => {
       const offlinePrimary = seedHost(harness.deps, {

--- a/packages/db/src/data/index.ts
+++ b/packages/db/src/data/index.ts
@@ -1,8 +1,10 @@
 export {
   createProject,
   ensurePersonalProject,
+  findOrCreateProjectByLocalPathSource,
   getPersonalProject,
   getProject,
+  getPublicProjectByLocalPathSource,
   listProjects,
   listPublicProjects,
   markProjectDeleted,
@@ -13,6 +15,7 @@ export {
 } from "./projects.js";
 export type {
   CreateProjectInput,
+  CreateProjectLocalPathSourceInput,
   ProjectRow,
   MarkProjectDeletedArgs,
   ReorderProjectArgs,

--- a/packages/db/src/data/projects.ts
+++ b/packages/db/src/data/projects.ts
@@ -106,6 +106,77 @@ function getPublicProjectForMutation(
   );
 }
 
+function getPublicProjectWithLocalPathSource(
+  db: DbQueryConnection,
+  source: CreateProjectLocalPathSourceInput,
+) {
+  return (
+    db
+      .select({ project: projects, source: projectSources })
+      .from(projects)
+      .innerJoin(projectSources, eq(projectSources.projectId, projects.id))
+      .where(
+        and(
+          publicProjectFilter(),
+          eq(projectSources.type, source.type),
+          eq(projectSources.hostId, source.hostId),
+          eq(projectSources.path, source.path),
+        ),
+      )
+      .orderBy(asc(projects.sortKey), asc(projects.id))
+      .limit(1)
+      .get() ?? null
+  );
+}
+
+export function getPublicProjectByLocalPathSource(
+  db: DbQueryConnection,
+  source: CreateProjectLocalPathSourceInput,
+): ProjectRow | null {
+  return getPublicProjectWithLocalPathSource(db, source)?.project ?? null;
+}
+
+function insertProject(tx: DbTransaction, input: CreateProjectInput) {
+  const now = Date.now();
+  const projectId = createProjectId();
+  const sourceId = createProjectSourceId();
+  const lastProject = getLastPublicProject(tx);
+  const sortKey = lastProject
+    ? createOrderKeyAfter({ previousKey: lastProject.sortKey })
+    : createOrderKeyBetween({ previousKey: null, nextKey: null });
+  const project = tx
+    .insert(projects)
+    .values({
+      id: projectId,
+      name: input.name,
+      sortKey,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning()
+    .get();
+  const source = tx
+    .insert(projectSources)
+    .values({
+      id: sourceId,
+      projectId,
+      type: input.source.type,
+      hostId: input.source.hostId,
+      path: input.source.path,
+      isDefault: true,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning()
+    .get();
+  return { project, source };
+}
+
+function notifyProjectCreated(notifier: DbNotifier, projectId: string): void {
+  notifier.notifyProject(projectId, ["project-created"]);
+  notifier.notifyProject(projectId, ["project-sources-changed"]);
+}
+
 function resolveProjectNeighbor(
   db: DbQueryConnection,
   args: ResolveProjectNeighborArgs,
@@ -125,45 +196,30 @@ export function createProject(
   notifier: DbNotifier,
   input: CreateProjectInput,
 ) {
-  const now = Date.now();
-  const projectId = createProjectId();
-  const sourceId = createProjectSourceId();
+  const { project, source } = db.transaction((tx) => insertProject(tx, input));
+  notifyProjectCreated(notifier, project.id);
+  return { project, source: toProjectSource(source) };
+}
 
-  const { project, source } = db.transaction((tx) => {
-    const lastProject = getLastPublicProject(tx);
-    const sortKey = lastProject
-      ? createOrderKeyAfter({ previousKey: lastProject.sortKey })
-      : createOrderKeyBetween({ previousKey: null, nextKey: null });
-    const p = tx
-      .insert(projects)
-      .values({
-        id: projectId,
-        name: input.name,
-        sortKey,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .returning()
-      .get();
-    const s = tx
-      .insert(projectSources)
-      .values({
-        id: sourceId,
-        projectId,
-        type: input.source.type,
-        hostId: input.source.hostId,
-        path: input.source.path,
-        isDefault: true,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .returning()
-      .get();
-    return { project: p, source: s };
-  });
+export function findOrCreateProjectByLocalPathSource(
+  db: DbConnection,
+  notifier: DbNotifier,
+  input: CreateProjectInput,
+) {
+  const { created, project, source } = db.transaction(
+    (tx) => {
+      const existing = getPublicProjectWithLocalPathSource(tx, input.source);
+      if (existing) {
+        return { created: false, ...existing };
+      }
+      return { created: true, ...insertProject(tx, input) };
+    },
+    { behavior: "immediate" },
+  );
 
-  notifier.notifyProject(projectId, ["project-created"]);
-  notifier.notifyProject(projectId, ["project-sources-changed"]);
+  if (created) {
+    notifyProjectCreated(notifier, project.id);
+  }
   return { project, source: toProjectSource(source) };
 }
 

--- a/packages/db/test/data/projects.test.ts
+++ b/packages/db/test/data/projects.test.ts
@@ -6,6 +6,7 @@ import { noopNotifier } from "../../src/notifier.js";
 import {
   createProject,
   ensurePersonalProject,
+  findOrCreateProjectByLocalPathSource,
   getProject,
   listProjects,
   listPublicProjects,
@@ -26,6 +27,58 @@ function setup() {
 }
 
 describe("projects", () => {
+  it("returns the existing project when the same host path is added again", () => {
+    const { db, host } = setup();
+    const first = findOrCreateProjectByLocalPathSource(db, noopNotifier, {
+      name: "first-name",
+      source: {
+        type: "local_path",
+        hostId: host.id,
+        path: "/tmp/same-project",
+      },
+    });
+
+    const repeated = findOrCreateProjectByLocalPathSource(db, noopNotifier, {
+      name: "second-name",
+      source: {
+        type: "local_path",
+        hostId: host.id,
+        path: "/tmp/same-project",
+      },
+    });
+
+    expect(repeated).toEqual(first);
+    expect(listPublicProjects(db)).toEqual([first.project]);
+  });
+
+  it("allows the same path on different hosts", () => {
+    const { db, host } = setup();
+    const otherHost = upsertHost(db, noopNotifier, {
+      name: "other-projects-host",
+      type: "persistent",
+    });
+
+    const first = findOrCreateProjectByLocalPathSource(db, noopNotifier, {
+      name: "first-host-project",
+      source: {
+        type: "local_path",
+        hostId: host.id,
+        path: "/tmp/shared-path",
+      },
+    });
+    const second = findOrCreateProjectByLocalPathSource(db, noopNotifier, {
+      name: "second-host-project",
+      source: {
+        type: "local_path",
+        hostId: otherHost.id,
+        path: "/tmp/shared-path",
+      },
+    });
+
+    expect(second.project.id).not.toBe(first.project.id);
+    expect(listPublicProjects(db)).toHaveLength(2);
+  });
+
   it("sets a git remote anchor only while it is missing", () => {
     const { db, host } = setup();
     const { project } = createProject(db, noopNotifier, {


### PR DESCRIPTION
## Summary

- return the existing active project when Add Project receives the same normalized host path
- skip redundant host inspection for known projects and serialize the final lookup/create transaction to close concurrent request races
- preserve distinct project identity when the same path string belongs to different machines
- verify that a no-project thread using the folder through the Personal project does not block project creation

## Tests

- pnpm exec turbo run test --filter=@bb/db -- test/data/projects.test.ts
- pnpm exec turbo run test --filter=@bb/server -- test/public/public-projects-local-host.test.ts
- pnpm exec turbo run typecheck --filter=@bb/db
- pnpm exec turbo run typecheck --filter=@bb/server

Closes #1194