### PR TITLE
Fix terminal stealing new thread focus

### DIFF
--- a/apps/app/src/components/secondary-panel/NewTabFileSearch.test.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabFileSearch.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render } from "@testing-library/react";
+import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { POINTER_COARSE_QUERY } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import { NewTabFileSearch } from "./NewTabFileSearch";
@@ -41,39 +41,70 @@ function mockPointerCoarse(matches: boolean) {
   }));
 }
 
-function renderFileSearch() {
+function renderFileSearch({
+  autoFocus,
+  onAutoFocusHandled = () => undefined,
+}: {
+  autoFocus: boolean;
+  onAutoFocusHandled?: () => void;
+}) {
   render(
     <NewTabFileSearch
+      autoFocus={autoFocus}
       projectId="proj_1"
       environmentId="env_1"
       currentThreadId="thr_1"
-      focusRequest={0}
       idleActions={null}
+      onAutoFocusHandled={onAutoFocusHandled}
       onSelect={() => {}}
     />,
   );
 }
 
 describe("NewTabFileSearch", () => {
-  it("does not autofocus the search input on coarse pointers", () => {
-    mockPointerCoarse(true);
-    const focusSpy = vi
-      .spyOn(HTMLInputElement.prototype, "focus")
-      .mockImplementation(() => {});
-
-    renderFileSearch();
-
-    expect(focusSpy).not.toHaveBeenCalled();
-  });
-
-  it("autofocuses the search input on fine pointers", () => {
+  it("does not autofocus when passively remounted", () => {
     mockPointerCoarse(false);
     const focusSpy = vi
       .spyOn(HTMLInputElement.prototype, "focus")
       .mockImplementation(() => {});
 
-    renderFileSearch();
+    renderFileSearch({ autoFocus: false });
+
+    expect(focusSpy).not.toHaveBeenCalled();
+  });
+
+  it("consumes an explicit request without focusing on coarse pointers", () => {
+    mockPointerCoarse(true);
+    const focusSpy = vi
+      .spyOn(HTMLInputElement.prototype, "focus")
+      .mockImplementation(() => {});
+    const onAutoFocusHandled = vi.fn();
+
+    renderFileSearch({ autoFocus: true, onAutoFocusHandled });
+
+    expect(focusSpy).not.toHaveBeenCalled();
+    expect(onAutoFocusHandled).toHaveBeenCalledTimes(1);
+  });
+
+  it("autofocuses for an explicit request and consumes it", () => {
+    mockPointerCoarse(false);
+    const focusSpy = vi
+      .spyOn(HTMLInputElement.prototype, "focus")
+      .mockImplementation(() => {});
+    const onAutoFocusHandled = vi.fn();
+    let nextFrame: FrameRequestCallback | undefined;
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      nextFrame = callback;
+      return 1;
+    });
+
+    renderFileSearch({ autoFocus: true, onAutoFocusHandled });
 
     expect(focusSpy).toHaveBeenCalledTimes(1);
+    expect(onAutoFocusHandled).toHaveBeenCalledTimes(1);
+
+    act(() => nextFrame?.(0));
+
+    expect(focusSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/app/src/components/secondary-panel/NewTabFileSearch.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabFileSearch.tsx
@@ -57,9 +57,10 @@ export interface NewTabFileSearchProps {
   environmentId: string | null;
   hostId?: string | null;
   currentThreadId: string;
-  focusRequest: number;
+  autoFocus: boolean;
   idleActions: ReactNode;
   initialQuery?: string;
+  onAutoFocusHandled: () => void;
   onSelect: (selection: FileSearchSelection) => void;
   recentItemsThreadId?: string | null;
   showFileSearch?: boolean;
@@ -494,15 +495,17 @@ export function NewTabFileSearch({
   environmentId,
   hostId,
   currentThreadId,
-  focusRequest,
+  autoFocus,
   idleActions,
   initialQuery = "",
+  onAutoFocusHandled,
   onSelect,
   recentItemsThreadId,
   showFileSearch = true,
 }: NewTabFileSearchProps) {
   const quickOpenShortcut = useAppCommandShortcut("file.quickOpen");
   const inputRef = useRef<HTMLInputElement>(null);
+  const focusFrameRef = useRef<number | null>(null);
   const listboxId = useId();
   const isPointerCoarse = usePointerCoarse();
   const [query, setQuery] = useState(initialQuery);
@@ -576,8 +579,27 @@ export function NewTabFileSearch({
     [activeIndex, navigableEntries],
   );
 
+  useEffect(
+    () => () => {
+      if (focusFrameRef.current !== null) {
+        cancelAnimationFrame(focusFrameRef.current);
+      }
+    },
+    [],
+  );
+
   useEffect(() => {
-    if (isPointerCoarse) return;
+    if (!autoFocus) return;
+
+    if (focusFrameRef.current !== null) {
+      cancelAnimationFrame(focusFrameRef.current);
+      focusFrameRef.current = null;
+    }
+
+    if (isPointerCoarse) {
+      onAutoFocusHandled();
+      return;
+    }
 
     // Focus synchronously, then again on the next frame to win the focus race
     // against the panel/tab content mounting in the same commit, which can
@@ -586,11 +608,15 @@ export function NewTabFileSearch({
     // content is briefly wider than the panel, and a scroll there would shift the
     // whole panel content sideways.
     inputRef.current?.focus({ preventScroll: true });
-    const frame = requestAnimationFrame(() => {
+    focusFrameRef.current = requestAnimationFrame(() => {
+      focusFrameRef.current = null;
       inputRef.current?.focus({ preventScroll: true });
     });
-    return () => cancelAnimationFrame(frame);
-  }, [focusRequest, isPointerCoarse]);
+    // Consume the request immediately so a later passive remount does not
+    // interpret the previous explicit open as another focus request. The frame
+    // has separate unmount cleanup so this state update does not cancel it.
+    onAutoFocusHandled();
+  }, [autoFocus, isPointerCoarse, onAutoFocusHandled]);
 
   useEffect(() => {
     setActiveIndex(navigableEntries.length > 0 ? 0 : -1);

--- a/apps/app/src/components/secondary-panel/NewTabPage.test.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabPage.test.tsx
@@ -15,9 +15,10 @@ describe("NewTabPage", () => {
   it("uses the themeable sidebar surface on the new-thread panel", () => {
     const { container } = render(
       <NewTabPage
+        autoFocus={false}
         currentThreadId=""
         environmentId={null}
-        focusRequest={0}
+        onAutoFocusHandled={() => undefined}
         onSelect={() => undefined}
         projectId={undefined}
       />,

--- a/apps/app/src/components/secondary-panel/NewTabPage.tsx
+++ b/apps/app/src/components/secondary-panel/NewTabPage.tsx
@@ -21,11 +21,12 @@ export interface NewTabPageProps extends NewTabPageFileSearchProps {
  * overlays that can be occluded by native browser/webview surfaces.
  */
 export function NewTabPage({
+  autoFocus,
   currentThreadId,
   environmentId,
   hostId,
-  focusRequest,
   initialQuery,
+  onAutoFocusHandled,
   onOpenBrowser,
   onSelect,
   onStartTerminal,
@@ -41,7 +42,7 @@ export function NewTabPage({
         environmentId={environmentId}
         hostId={hostId}
         currentThreadId={currentThreadId}
-        focusRequest={focusRequest}
+        autoFocus={autoFocus}
         idleActions={
           <NewTabActions
             onOpenBrowser={onOpenBrowser}
@@ -50,6 +51,7 @@ export function NewTabPage({
           />
         }
         initialQuery={initialQuery}
+        onAutoFocusHandled={onAutoFocusHandled}
         onSelect={onSelect}
         recentItemsThreadId={recentItemsThreadId}
         showFileSearch={showFileSearch}

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanelNewTab.stories.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanelNewTab.stories.tsx
@@ -393,11 +393,12 @@ function SeededNewTabPage({
 
   return (
     <NewTabPage
+      autoFocus={false}
       projectId={projectId}
       environmentId={ENVIRONMENT_ID}
       currentThreadId={currentThreadId}
-      focusRequest={0}
       initialQuery={initialQuery}
+      onAutoFocusHandled={() => undefined}
       onSelect={onSelect}
       onOpenBrowser={onOpenBrowser}
       onStartTerminal={onStartTerminal}

--- a/apps/app/src/components/thread/terminal/ThreadTerminalContent.test.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalContent.test.tsx
@@ -6,7 +6,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ThreadTerminalContent } from "./ThreadTerminalContent";
 import type { ThreadTerminalController } from "./useThreadTerminalController";
 
-const threadTerminalView = vi.hoisted(() => vi.fn(() => null));
+const threadTerminalView = vi.hoisted(() =>
+  vi.fn((_props: { autoFocus: boolean; isPanelOpen: boolean }) => null),
+);
 
 vi.mock("./ThreadTerminalView", () => ({
   ThreadTerminalView: threadTerminalView,
@@ -62,16 +64,23 @@ afterEach(() => {
 describe("ThreadTerminalContent", () => {
   it("does not mount the terminal view until the panel opens", () => {
     const rendered = render(
-      <ThreadTerminalContent controller={controller(false)} />,
+      <ThreadTerminalContent
+        autoFocus={false}
+        controller={controller(false)}
+      />,
     );
 
     expect(threadTerminalView).not.toHaveBeenCalled();
     expect(rendered.container.firstChild).toBeNull();
 
     rendered.rerender(
-      <ThreadTerminalContent controller={controller(true)} />,
+      <ThreadTerminalContent autoFocus controller={controller(true)} />,
     );
 
     expect(threadTerminalView).toHaveBeenCalledOnce();
+    expect(threadTerminalView.mock.calls[0]?.[0]).toMatchObject({
+      autoFocus: true,
+      isPanelOpen: true,
+    });
   });
 });

--- a/apps/app/src/components/thread/terminal/ThreadTerminalContent.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalContent.tsx
@@ -6,7 +6,9 @@ import { ThreadTerminalView } from "./ThreadTerminalView";
 import type { ThreadTerminalController } from "./useThreadTerminalController";
 
 interface ThreadTerminalContentProps {
+  autoFocus?: boolean;
   controller: ThreadTerminalController;
+  onAutoFocusHandled?: () => void;
   onOpenLink?: MarkdownPreviewLinkHandler;
   onSelectionAddToChat?: (text: string) => void;
 }
@@ -55,7 +57,9 @@ function getInactiveTerminalContent({
 }
 
 export function ThreadTerminalContent({
+  autoFocus = false,
   controller,
+  onAutoFocusHandled,
   onOpenLink,
   onSelectionAddToChat,
 }: ThreadTerminalContentProps) {
@@ -126,7 +130,9 @@ export function ThreadTerminalContent({
 
   return (
     <ThreadTerminalView
+      autoFocus={autoFocus}
       isPanelOpen={controller.isPanelOpen}
+      onAutoFocusHandled={onAutoFocusHandled}
       onOpenLink={onOpenLink}
       onSelectionAddToChat={onSelectionAddToChat}
       onSessionChange={controller.handleActiveTerminalSessionChange}

--- a/apps/app/src/components/thread/terminal/ThreadTerminalPanel.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalPanel.tsx
@@ -6,9 +6,11 @@ import {
 } from "./useThreadTerminalController";
 
 interface ThreadTerminalPanelProps {
+  autoFocus?: boolean;
   canCreateTerminal: boolean;
   isPanelOpen: boolean;
   isPanelPersistedOpen: boolean;
+  onAutoFocusHandled?: () => void;
   onOpenLink?: MarkdownPreviewLinkHandler;
   onSelectionAddToChat?: (text: string) => void;
   panelStateId?: string;
@@ -16,9 +18,11 @@ interface ThreadTerminalPanelProps {
 }
 
 export function ThreadTerminalPanel({
+  autoFocus = false,
   canCreateTerminal,
   isPanelOpen,
   isPanelPersistedOpen,
+  onAutoFocusHandled,
   onOpenLink,
   onSelectionAddToChat,
   panelStateId,
@@ -40,7 +44,9 @@ export function ThreadTerminalPanel({
     >
       <div className="min-h-0 flex-1 overflow-hidden bg-sidebar">
         <ThreadTerminalContent
+          autoFocus={autoFocus}
           controller={terminalController}
+          onAutoFocusHandled={onAutoFocusHandled}
           onOpenLink={onOpenLink}
           onSelectionAddToChat={onSelectionAddToChat}
         />

--- a/apps/app/src/components/thread/terminal/ThreadTerminalView.test.ts
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalView.test.ts
@@ -8,11 +8,80 @@ import {
   forwardTerminalData,
   loadOptionalTerminalWebglAddon,
   loadTerminalWebglRenderer,
+  shouldFocusTerminalAfterAsyncMount,
   TERMINAL_ALLOW_PROPOSED_API,
   TERMINAL_FONT_FAMILY,
   TERMINAL_UNICODE_VERSION,
   writeTerminalOutput,
 } from "./ThreadTerminalView";
+
+describe("terminal async mount focus", () => {
+  it("preserves focus that moved to the composer while xterm loaded", () => {
+    expect(
+      shouldFocusTerminalAfterAsyncMount({
+        currentFocusIsAvailable: true,
+        hasExplicitFocusRequest: false,
+        focusMovedDuringMount: true,
+        isPanelOpen: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not let an explicit request override a newer focus target", () => {
+    expect(
+      shouldFocusTerminalAfterAsyncMount({
+        currentFocusIsAvailable: true,
+        hasExplicitFocusRequest: true,
+        focusMovedDuringMount: true,
+        isPanelOpen: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("focuses an opened terminal when focus stayed on its trigger", () => {
+    expect(
+      shouldFocusTerminalAfterAsyncMount({
+        currentFocusIsAvailable: true,
+        hasExplicitFocusRequest: true,
+        focusMovedDuringMount: false,
+        isPanelOpen: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("preserves a composer that was focused before xterm started mounting", () => {
+    expect(
+      shouldFocusTerminalAfterAsyncMount({
+        currentFocusIsAvailable: true,
+        hasExplicitFocusRequest: false,
+        focusMovedDuringMount: false,
+        isPanelOpen: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("focuses the terminal when its initiating trigger unmounted", () => {
+    expect(
+      shouldFocusTerminalAfterAsyncMount({
+        currentFocusIsAvailable: false,
+        hasExplicitFocusRequest: false,
+        focusMovedDuringMount: true,
+        isPanelOpen: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("does not focus a terminal after its panel closes", () => {
+    expect(
+      shouldFocusTerminalAfterAsyncMount({
+        currentFocusIsAvailable: false,
+        hasExplicitFocusRequest: true,
+        focusMovedDuringMount: false,
+        isPanelOpen: false,
+      }),
+    ).toBe(false);
+  });
+});
 
 describe("terminal output encoding", () => {
   it("splits large paste input at the wire limit without losing UTF-8 bytes", () => {

--- a/apps/app/src/components/thread/terminal/ThreadTerminalView.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalView.tsx
@@ -38,6 +38,28 @@ const TERMINAL_SELECTION_DRAG_DIRECTION_THRESHOLD_PX = 4;
 
 type TerminalFitScheduler = () => void;
 
+interface ShouldFocusTerminalAfterAsyncMountArgs {
+  currentFocusIsAvailable: boolean;
+  hasExplicitFocusRequest: boolean;
+  focusMovedDuringMount: boolean;
+  isPanelOpen: boolean;
+}
+
+export function shouldFocusTerminalAfterAsyncMount({
+  currentFocusIsAvailable,
+  hasExplicitFocusRequest,
+  focusMovedDuringMount,
+  isPanelOpen,
+}: ShouldFocusTerminalAfterAsyncMountArgs): boolean {
+  if (!isPanelOpen) {
+    return false;
+  }
+  if (focusMovedDuringMount && currentFocusIsAvailable) {
+    return false;
+  }
+  return hasExplicitFocusRequest || !currentFocusIsAvailable;
+}
+
 interface WebglRendererAddon extends ITerminalAddon {
   onContextLoss: (listener: () => void) => IDisposable;
 }
@@ -154,7 +176,9 @@ function buildTerminalTheme(): ITheme {
 }
 
 interface ThreadTerminalViewProps {
+  autoFocus: boolean;
   isPanelOpen: boolean;
+  onAutoFocusHandled?: () => void;
   onOpenLink?: MarkdownPreviewLinkHandler;
   onSelectionAddToChat?: (text: string) => void;
   onSessionChange?: (session: TerminalSession) => void;
@@ -458,7 +482,9 @@ function handleTerminalServerMessage({
 }
 
 export function ThreadTerminalView({
+  autoFocus,
   isPanelOpen,
+  onAutoFocusHandled,
   onOpenLink,
   onSelectionAddToChat,
   onSessionChange,
@@ -484,6 +510,10 @@ export function ThreadTerminalView({
     onTitleChange,
   );
   const onUserInputRef = useRef<(() => void) | undefined>(onUserInput);
+  const onAutoFocusHandledRef = useRef<(() => void) | undefined>(
+    onAutoFocusHandled,
+  );
+  const autoFocusRef = useRef(autoFocus);
   const isPanelOpenRef = useRef(isPanelOpen);
   const sessionStatusRef = useRef<TerminalSession["status"]>(session.status);
   const sessionRef = useRef(session);
@@ -501,9 +531,11 @@ export function ThreadTerminalView({
   const effectiveOnOpenLink = onOpenLink ?? handleOpenLinkByPreference;
   const onOpenLinkRef = useRef<MarkdownPreviewLinkHandler>(effectiveOnOpenLink);
 
+  autoFocusRef.current = autoFocus;
   isPanelOpenRef.current = isPanelOpen;
   sessionStatusRef.current = session.status;
   sessionRef.current = session;
+  onAutoFocusHandledRef.current = onAutoFocusHandled;
   onOpenLinkRef.current = effectiveOnOpenLink;
   onSessionChangeRef.current = onSessionChange;
   onTitleChangeRef.current = onTitleChange;
@@ -583,6 +615,8 @@ export function ThreadTerminalView({
     if (!container) {
       return;
     }
+
+    const activeElementAtMount = document.activeElement;
 
     let disposed = false;
     let transport: TerminalWebSocketTransport | null = null;
@@ -679,8 +713,24 @@ export function ThreadTerminalView({
       };
       fitTerminal();
       scheduleFitRef.current = scheduleFit;
-      if (isPanelOpenRef.current) {
+      const currentActiveElement = document.activeElement;
+      // A terminal can mount after either an explicit terminal action or a
+      // passive panel swap during navigation. Only the explicit action may
+      // replace an existing focus owner, and neither path may override focus
+      // that moved elsewhere while xterm's modules were loading.
+      if (
+        shouldFocusTerminalAfterAsyncMount({
+          currentFocusIsAvailable:
+            currentActiveElement !== null &&
+            currentActiveElement !== document.body &&
+            currentActiveElement.isConnected,
+          hasExplicitFocusRequest: autoFocusRef.current,
+          focusMovedDuringMount: currentActiveElement !== activeElementAtMount,
+          isPanelOpen: isPanelOpenRef.current,
+        })
+      ) {
         terminal.focus();
+        onAutoFocusHandledRef.current?.();
       }
 
       const activeTerminal = terminal;
@@ -815,12 +865,16 @@ export function ThreadTerminalView({
   }, [reportTerminalSelection, session.id, session.threadId]);
 
   useEffect(() => {
-    if (!isPanelOpen) {
+    if (!isPanelOpen || !autoFocus) {
       return;
     }
-    terminalRef.current?.focus();
+    const terminal = terminalRef.current;
+    if (terminal !== null) {
+      terminal.focus();
+      onAutoFocusHandledRef.current?.();
+    }
     scheduleFitRef.current?.();
-  }, [isPanelOpen]);
+  }, [autoFocus, isPanelOpen]);
 
   useEffect(() => {
     const terminal = terminalRef.current;

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -2112,7 +2112,11 @@ export function RootComposeView() {
     () => new Map(terminalSessions.map((session) => [session.id, session])),
     [terminalSessions],
   );
-  const [newTabFocusRequest, setNewTabFocusRequest] = useState(0);
+  const [shouldAutoFocusNewTab, setShouldAutoFocusNewTab] = useState(false);
+  const handleNewTabAutoFocusHandled = useCallback(
+    () => setShouldAutoFocusNewTab(false),
+    [],
+  );
   const [browserAddressFocusRequest, setBrowserAddressFocusRequest] =
     useState<BrowserAddressFocusRequest | null>(null);
   const { threadPanelActions: rootPanelThreadPanelActions } = usePluginSlots();
@@ -2463,7 +2467,7 @@ export function RootComposeView() {
   const handleOpenNewTab = useCallback(() => {
     openTab({ kind: "new-tab" });
     openCompactDrawer();
-    setNewTabFocusRequest((current) => current + 1);
+    setShouldAutoFocusNewTab(true);
   }, [openCompactDrawer, openTab]);
   useAppCommandHandler("panel.newTab", () => {
     if (!isFocusedPane) return false;
@@ -3006,11 +3010,12 @@ export function RootComposeView() {
       />
     ) : isNewTabActive ? (
       <NewTabPage
+        autoFocus={shouldAutoFocusNewTab}
         projectId={isProjectless ? undefined : projectId}
         environmentId={rootPanelEnvironmentId}
         hostId={rootProjectHostId}
         currentThreadId={rootPanelThreadId ?? ""}
-        focusRequest={newTabFocusRequest}
+        onAutoFocusHandled={handleNewTabAutoFocusHandled}
         onSelect={handleSelectFileSearchResult}
         recentItemsThreadId={ROOT_COMPOSE_FIXED_PANEL_STATE_ID}
         onOpenBrowser={rootPanelThreadId ? handleOpenBrowser : undefined}

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -1976,6 +1976,13 @@ export function RootComposeView() {
     ROOT_COMPOSE_FIXED_PANEL_STATE_ID,
     null,
   );
+  // Route-driven panel remounts are passive. Explicit terminal actions keep
+  // this request pending until the asynchronously mounted xterm handles it.
+  const [shouldAutoFocusTerminal, setShouldAutoFocusTerminal] = useState(false);
+  const handleTerminalAutoFocusHandled = useCallback(
+    () => setShouldAutoFocusTerminal(false),
+    [],
+  );
   const removeFixedTerminalTab = useRemoveFixedRightTerminalTab(
     ROOT_COMPOSE_FIXED_PANEL_STATE_ID,
     null,
@@ -2514,6 +2521,7 @@ export function RootComposeView() {
     void createTerminal
       .then((session) => {
         closeTab(newTab.id);
+        setShouldAutoFocusTerminal(true);
         setActiveFixedTerminal(session.id);
         openCompactDrawer();
       })
@@ -2542,6 +2550,7 @@ export function RootComposeView() {
   });
   const handleActivateTerminalTab = useCallback(
     (terminalId: string) => {
+      setShouldAutoFocusTerminal(true);
       setActiveFixedTerminal(terminalId);
       openCompactDrawer();
     },
@@ -2985,9 +2994,11 @@ export function RootComposeView() {
   const fileTabContent: ReactNode =
     activeTerminalId && rootPanelTerminalTarget ? (
       <ThreadTerminalPanel
+        autoFocus={shouldAutoFocusTerminal}
         canCreateTerminal={canCreateRootTerminal}
         isPanelOpen={isSecondaryPanelOpen}
         isPanelPersistedOpen={isPersistedSecondaryPanelOpen}
+        onAutoFocusHandled={handleTerminalAutoFocusHandled}
         onOpenLink={handleOpenPanelLink}
         onSelectionAddToChat={handleRootPanelSelectionAddToChat}
         panelStateId={ROOT_COMPOSE_FIXED_PANEL_STATE_ID}

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -491,6 +491,13 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
     threadId,
     threadId,
   );
+  // Route-driven panel remounts are passive. Explicit terminal actions keep
+  // this request pending until the asynchronously mounted xterm handles it.
+  const [shouldAutoFocusTerminal, setShouldAutoFocusTerminal] = useState(false);
+  const handleTerminalAutoFocusHandled = useCallback(
+    () => setShouldAutoFocusTerminal(false),
+    [],
+  );
   const removeFixedTerminalTab = useRemoveFixedRightTerminalTab(
     threadId,
     threadId,
@@ -1222,6 +1229,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
       })
       .then((session) => {
         closeTab(newTab.id);
+        setShouldAutoFocusTerminal(true);
         setActiveFixedTerminal(session.id);
         openCompactDrawer();
       })
@@ -1248,6 +1256,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
   });
   const handleActivateTerminalTab = useCallback(
     (terminalId: string) => {
+      setShouldAutoFocusTerminal(true);
       setActiveFixedTerminal(terminalId);
       openCompactDrawer();
     },
@@ -2406,9 +2415,11 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
   });
   const fileTabContent = activeTerminalId ? (
     <ThreadTerminalPanel
+      autoFocus={shouldAutoFocusTerminal}
       canCreateTerminal={canCreateTerminal}
       isPanelOpen={isSecondaryPanelOpen}
       isPanelPersistedOpen={isPersistedSecondaryPanelOpen}
+      onAutoFocusHandled={handleTerminalAutoFocusHandled}
       onOpenLink={handleOpenTimelineLink}
       onSelectionAddToChat={handleSelectionAddToChat}
       target={{ kind: "thread", threadId: thread.id }}

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -576,7 +576,11 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
   });
   const [hasRequestedMergeBaseOptions, setHasRequestedMergeBaseOptions] =
     useState(false);
-  const [newTabFocusRequest, setNewTabFocusRequest] = useState(0);
+  const [shouldAutoFocusNewTab, setShouldAutoFocusNewTab] = useState(false);
+  const handleNewTabAutoFocusHandled = useCallback(
+    () => setShouldAutoFocusNewTab(false),
+    [],
+  );
   const [browserAddressFocusRequest, setBrowserAddressFocusRequest] =
     useState<BrowserAddressFocusRequest | null>(null);
   const shouldLoadThreadStorageFiles = thread !== undefined;
@@ -1187,7 +1191,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
   const handleOpenNewTab = useCallback(() => {
     openNewTab();
     openCompactDrawer();
-    setNewTabFocusRequest((current) => current + 1);
+    setShouldAutoFocusNewTab(true);
   }, [openCompactDrawer, openNewTab]);
   useAppCommandHandler("panel.newTab", () => {
     if (!isFocused) return false;
@@ -2426,10 +2430,11 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
     />
   ) : isNewTabActive ? (
     <NewTabPage
+      autoFocus={shouldAutoFocusNewTab}
       projectId={projectId ?? undefined}
       environmentId={thread.environmentId ?? null}
       currentThreadId={thread.id}
-      focusRequest={newTabFocusRequest}
+      onAutoFocusHandled={handleNewTabAutoFocusHandled}
       onSelect={handleSelectFileSearchResult}
       onOpenBrowser={handleOpenBrowser}
       onStartTerminal={canCreateTerminal ? handleStartTerminal : undefined}


### PR DESCRIPTION
## Summary

- distinguish passive terminal and new-tab panel remounts from explicit focus requests
- preserve composer or newer user focus while xterm initializes asynchronously
- retain autofocus for explicit terminal creation, terminal tab activation, and new-tab opens
- consume new-tab autofocus requests so later passive remounts stay inert
- cover both terminal focus race orderings plus passive and explicit new-tab focus behavior

## Testing

- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/secondary-panel/NewTabFileSearch.test.tsx src/components/secondary-panel/NewTabPage.test.tsx src/components/thread/terminal/ThreadTerminalView.test.ts src/components/thread/terminal/ThreadTerminalContent.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app --force`
- `pnpm exec turbo run lint --filter=@bb/app --force` (0 errors; 141 existing warnings)

Fixes #1160