### PR TITLE
Fix GitHub PR sync for repos without issues

### DIFF
--- a/plugins/github/package.json
+++ b/plugins/github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bb-plugin-github",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Browse GitHub issues and pull requests in BB, then send them to agents.",
   "private": true,
   "license": "MIT",

--- a/plugins/github/server.test.ts
+++ b/plugins/github/server.test.ts
@@ -3,6 +3,7 @@ import { defineRpcContract } from "@bb/plugin-sdk";
 import type { PluginRpcClient, PluginRpcHandlers } from "@bb/plugin-sdk";
 import { createFakePluginHost } from "@bb/plugin-sdk/testing";
 import {
+  fetchRepoItems,
   githubRpcContract,
   parsePaginatedGhApi,
   validateGithubCliArgs,
@@ -77,6 +78,44 @@ function assertGithubFrontendInference(
 }
 
 describe("GitHub RPC contract", () => {
+  it("keeps pull requests when a repository has GitHub Issues disabled", async () => {
+    const calls: string[][] = [];
+    const openPulls = JSON.stringify([
+      {
+        number: 17,
+        title: "Keep syncing pull requests",
+        state: "OPEN",
+        author: { login: "octocat" },
+        labels: [{ name: "bug" }],
+        assignees: [],
+        url: "https://github.com/acme/widgets/pull/17",
+        body: "",
+        updatedAt: "2026-08-10T00:00:00Z",
+      },
+    ]);
+
+    const items = await fetchRepoItems(async (args) => {
+      calls.push(args);
+      if (args[0] === "issue") {
+        throw new Error(
+          "gh issue list failed: the 'acme/widgets' repository has disabled Issues",
+        );
+      }
+      return args.includes("open") ? openPulls : "[]";
+    }, "acme/widgets");
+
+    expect(calls).toHaveLength(4);
+    expect(calls.filter(([kind]) => kind === "pr")).toHaveLength(2);
+    expect(items).toEqual([
+      expect.objectContaining({
+        repo: "acme/widgets",
+        number: 17,
+        kind: "pr",
+        title: "Keep syncing pull requests",
+      }),
+    ]);
+  });
+
   it("flattens every paginated GitHub API page", () => {
     expect(
       parsePaginatedGhApi(

--- a/plugins/github/server.ts
+++ b/plugins/github/server.ts
@@ -273,6 +273,20 @@ interface CachedItem {
   updatedAt: string;
 }
 
+interface GhListEntry {
+  number?: unknown;
+  title?: unknown;
+  state?: unknown;
+  author?: { login?: unknown };
+  labels?: Array<{ name?: unknown }>;
+  assignees?: Array<{ login?: unknown }>;
+  url?: unknown;
+  body?: unknown;
+  updatedAt?: unknown;
+}
+
+type GhRunner = (args: string[]) => Promise<string>;
+
 interface ThreadLink {
   kind: "issue" | "pr";
   repo: string;
@@ -374,6 +388,68 @@ export function validateGithubCliArgs(argv: string[]): string | null {
       : `Invalid repository "${arg}"; expected owner/repo.`;
   }
   return null;
+}
+
+function toItems(raw: string, repo: string, kind: "issue" | "pr"): CachedItem[] {
+  const entries = JSON.parse(raw) as GhListEntry[];
+  return entries
+    .filter(
+      (entry): entry is GhListEntry & { number: number } =>
+        typeof entry?.number === "number",
+    )
+    .map((entry) => ({
+      repo,
+      number: entry.number,
+      kind,
+      title: String(entry.title ?? ""),
+      state: String(entry.state ?? "OPEN"),
+      author: String(entry.author?.login ?? ""),
+      labels: (entry.labels ?? []).map((label) => String(label?.name ?? "")),
+      assignees: (entry.assignees ?? []).map((user) => String(user?.login ?? "")),
+      url: String(entry.url ?? ""),
+      body: typeof entry.body === "string" ? entry.body : "",
+      updatedAt: String(entry.updatedAt ?? ""),
+    }));
+}
+
+// Open items plus a page of recently-closed ones, so the Closed filter has
+// something to show without a live gh call per view.
+export async function fetchRepoItems(
+  gh: GhRunner,
+  repo: string,
+): Promise<CachedItem[]> {
+  const fields = "number,title,state,author,labels,assignees,url,body,updatedAt";
+  // A repo with GitHub Issues disabled must not abort the whole sync —
+  // PRs still exist and should be cached.
+  const ghIssuesTolerant = (args: string[]) =>
+    gh(args).catch((error: unknown) => {
+      if (String(error).toLowerCase().includes("disabled issues")) return "[]";
+      throw error;
+    });
+  const [openIssues, closedIssues, openPrs, closedPrs] = await Promise.all([
+    ghIssuesTolerant([
+      "issue", "list", "-R", repo, "--state", "open",
+      "--limit", String(ISSUE_PAGE), "--json", fields,
+    ]),
+    ghIssuesTolerant([
+      "issue", "list", "-R", repo, "--state", "closed",
+      "--limit", String(CLOSED_ISSUE_PAGE), "--json", fields,
+    ]),
+    gh([
+      "pr", "list", "-R", repo, "--state", "open",
+      "--limit", String(PR_PAGE), "--json", fields,
+    ]),
+    gh([
+      "pr", "list", "-R", repo, "--state", "closed",
+      "--limit", String(CLOSED_PR_PAGE), "--json", fields,
+    ]),
+  ]);
+  return [
+    ...toItems(openIssues, repo, "issue"),
+    ...toItems(closedIssues, repo, "issue"),
+    ...toItems(openPrs, repo, "pr"),
+    ...toItems(closedPrs, repo, "pr"),
+  ];
 }
 
 export default async function plugin(bb: BbPluginApi) {
@@ -576,74 +652,6 @@ export default async function plugin(bb: BbPluginApi) {
     return row === undefined ? null : rowToItem(row);
   }
 
-  interface GhListEntry {
-    number?: unknown;
-    title?: unknown;
-    state?: unknown;
-    author?: { login?: unknown };
-    labels?: Array<{ name?: unknown }>;
-    assignees?: Array<{ login?: unknown }>;
-    url?: unknown;
-    body?: unknown;
-    updatedAt?: unknown;
-  }
-
-  function toItems(raw: string, repo: string, kind: "issue" | "pr"): CachedItem[] {
-    const entries = JSON.parse(raw) as GhListEntry[];
-    return entries
-      .filter((entry) => typeof entry?.number === "number")
-      .map((entry) => ({
-        repo,
-        number: entry.number as number,
-        kind,
-        title: String(entry.title ?? ""),
-        state: String(entry.state ?? "OPEN"),
-        author: String(entry.author?.login ?? ""),
-        labels: (entry.labels ?? []).map((label) => String(label?.name ?? "")),
-        assignees: (entry.assignees ?? []).map((user) => String(user?.login ?? "")),
-        url: String(entry.url ?? ""),
-        body: typeof entry.body === "string" ? entry.body : "",
-        updatedAt: String(entry.updatedAt ?? ""),
-      }));
-  }
-
-  // Open items plus a page of recently-closed ones, so the Closed filter has
-  // something to show without a live gh call per view.
-  async function syncRepo(repo: string): Promise<CachedItem[]> {
-    const fields = "number,title,state,author,labels,assignees,url,body,updatedAt";
-    // A repo with GitHub Issues disabled must not abort the whole sync —
-    // PRs still exist and should be cached.
-    const ghIssuesTolerant = (args: string[]) =>
-      gh(args).catch((error: unknown) => {
-        if (String(error).includes("disabled issues")) return "[]";
-        throw error;
-      });
-    const [openIssues, closedIssues, openPrs, closedPrs] = await Promise.all([
-      ghIssuesTolerant([
-        "issue", "list", "-R", repo, "--state", "open",
-        "--limit", String(ISSUE_PAGE), "--json", fields,
-      ]),
-      ghIssuesTolerant([
-        "issue", "list", "-R", repo, "--state", "closed",
-        "--limit", String(CLOSED_ISSUE_PAGE), "--json", fields,
-      ]),
-      gh([
-        "pr", "list", "-R", repo, "--state", "open",
-        "--limit", String(PR_PAGE), "--json", fields,
-      ]),
-      gh([
-        "pr", "list", "-R", repo, "--state", "closed",
-        "--limit", String(CLOSED_PR_PAGE), "--json", fields,
-      ]),
-    ]);
-    return [
-      ...toItems(openIssues, repo, "issue"),
-      ...toItems(closedIssues, repo, "issue"),
-      ...toItems(openPrs, repo, "pr"),
-      ...toItems(closedPrs, repo, "pr"),
-    ];
-  }
-
   function replaceRepoRows(repo: string, items: CachedItem[]): void {
     const insert = db.prepare(
       `INSERT INTO items (repo, number, kind, title, state, author, labels, assignees, url, body, updated_at)
@@ -693,7 +701,7 @@ export default async function plugin(bb: BbPluginApi) {
     let total = 0;
     for (const { repo } of repos) {
       try {
-        const items = await syncRepo(repo);
+        const items = await fetchRepoItems(gh, repo);
         replaceRepoRows(repo, items);
         total += items.length;
       } catch (error) {
@@ -1287,7 +1295,7 @@ export default async function plugin(bb: BbPluginApi) {
       const match = stdout.trim().match(/\/issues\/(\d+)\s*$/);
       const number = match !== null ? Number(match[1]) : null;
       try {
-        replaceRepoRows(input.repo, await syncRepo(input.repo));
+        replaceRepoRows(input.repo, await fetchRepoItems(gh, input.repo));
         bb.realtime.publish("data-changed", {});
       } catch {
         // creation succeeded; the next scheduled sync will pick it up


### PR DESCRIPTION
## Summary

- bump the bundled GitHub plugin to 0.2.1 so the disabled-Issues sync fix is released as a new plugin version
- extract repository item fetching into a testable boundary and tolerate case variations in the GitHub CLI error
- add regression coverage proving pull requests remain available when both issue-list requests fail because Issues are disabled

## Testing

- `pnpm exec turbo run test --filter=bb-plugin-github --force`
- `pnpm exec turbo run typecheck --filter=bb-plugin-github --force`
- `pnpm exec turbo run build --filter=bb-plugin-github`

Closes #1267