### PR TITLE
Show context window usage for ACP clients

### DIFF
--- a/apps/server/test/internal/internal-event-append-ownership.test.ts
+++ b/apps/server/test/internal/internal-event-append-ownership.test.ts
@@ -7,6 +7,7 @@ import {
   type HostDaemonEventEnvelope,
 } from "@bb/host-daemon-contract";
 import { describe, expect, it } from "vitest";
+import { buildThreadTimeline } from "../../src/services/threads/timeline.js";
 import {
   internalAuthHeaders,
   waitForQueuedCommand,
@@ -73,6 +74,52 @@ function setupEventRoute(args: SeedEventRouteArgs = {}) {
 }
 
 describe("internal event append ownership", () => {
+  it("stores thread-scoped ACP context usage for the timeline display", async () => {
+    const { harness, session, thread } = await setupEventRoute();
+    try {
+      const response = await postEventBatch({
+        harness,
+        sessionId: session.id,
+        events: [
+          {
+            threadId: thread.id,
+            event: {
+              type: "thread/contextWindowUsage/updated",
+              threadId: thread.id,
+              providerThreadId: "acp-session-1",
+              scope: threadScope(),
+              contextWindowUsage: {
+                usedTokens: 24_000,
+                modelContextWindow: 128_000,
+                estimated: false,
+              },
+            },
+          },
+        ],
+      });
+
+      expect(response.status).toBe(200);
+      expect(
+        buildThreadTimeline(harness.db, thread, {
+          eventBudget: 1_000_000,
+          includeProviderUnhandledOperations: true,
+          maxInlineOutputChars: null,
+          maxSeq: 1,
+          page: {
+            kind: "latest",
+            segmentLimit: Number.MAX_SAFE_INTEGER,
+          },
+        }).contextWindowUsage,
+      ).toEqual({
+        usedTokens: 24_000,
+        modelContextWindow: 128_000,
+        estimated: false,
+      });
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
   it("assigns server-owned sequences and returns accepted event indexes", async () => {
     const { environment, harness, session, thread } = await setupEventRoute();
     try {

--- a/packages/agent-runtime/src/acp/adapter.test.ts
+++ b/packages/agent-runtime/src/acp/adapter.test.ts
@@ -627,6 +627,88 @@ describe("acp adapter event translation", () => {
     ]);
   });
 
+  it("translates ACP usage updates into exact context-window usage", () => {
+    const adapter = createAdapter();
+    startTurn(adapter);
+
+    expect(
+      adapter.translateEvent(
+        updateNotification({
+          sessionUpdate: "usage_update",
+          used: 32_768,
+          size: 200_000,
+          cost: { amount: 0.42, currency: "USD" },
+        }),
+        THREAD_CONTEXT,
+      ),
+    ).toEqual([
+      {
+        type: "thread/contextWindowUsage/updated",
+        threadId: "",
+        providerThreadId: "",
+        scope: turnScope("turn-1"),
+        contextWindowUsage: {
+          usedTokens: 32_768,
+          modelContextWindow: 200_000,
+          estimated: false,
+        },
+      },
+    ]);
+  });
+
+  it("reports ACP usage before a turn without creating a synthetic turn", () => {
+    const adapter = createAdapter();
+
+    expect(
+      adapter.translateEvent(
+        updateNotification({
+          sessionUpdate: "usage_update",
+          used: 65_536,
+          size: 1_000_000,
+        }),
+        THREAD_CONTEXT,
+      ),
+    ).toEqual([
+      {
+        type: "thread/contextWindowUsage/updated",
+        threadId: "",
+        providerThreadId: "",
+        scope: threadScope(),
+        contextWindowUsage: {
+          usedTokens: 65_536,
+          modelContextWindow: 1_000_000,
+          estimated: false,
+        },
+      },
+    ]);
+  });
+
+  it("ignores malformed ACP usage updates", () => {
+    const adapter = createAdapter();
+    startTurn(adapter);
+
+    expect(
+      adapter.translateEvent(
+        updateNotification({
+          sessionUpdate: "usage_update",
+          used: -1,
+          size: 200_000,
+        }),
+        THREAD_CONTEXT,
+      ),
+    ).toEqual([]);
+    expect(
+      adapter.translateEvent(
+        updateNotification({
+          sessionUpdate: "usage_update",
+          used: 1,
+          size: "200000",
+        }),
+        THREAD_CONTEXT,
+      ),
+    ).toEqual([]);
+  });
+
   it("accumulates thought chunks into a reasoning item", () => {
     const adapter = createAdapter();
     startTurn(adapter);

--- a/packages/agent-runtime/src/acp/adapter.ts
+++ b/packages/agent-runtime/src/acp/adapter.ts
@@ -106,6 +106,7 @@ import {
   acpAgentThoughtChunkUpdateSchema,
   acpPlanUpdateSchema,
   acpToolCallUpdateEventSchema,
+  acpUsageUpdateSchema,
   extractAcpContentText,
   type AcpSessionUpdate,
   type AcpStopReason,
@@ -990,6 +991,28 @@ export function createAcpProviderAdapter(
           plan,
         });
         return events;
+      }
+
+      case "usage_update": {
+        const parsed = acpUsageUpdateSchema.safeParse(update);
+        if (!parsed.success) {
+          return [];
+        }
+        return [
+          {
+            type: "thread/contextWindowUsage/updated",
+            threadId: UNSTAMPED_THREAD_ID,
+            providerThreadId: "",
+            scope: state.currentTurnId
+              ? turnScope(state.currentTurnId)
+              : threadScope(),
+            contextWindowUsage: {
+              usedTokens: parsed.data.used,
+              modelContextWindow: parsed.data.size,
+              estimated: false,
+            },
+          },
+        ];
       }
 
       default:

--- a/packages/agent-runtime/src/acp/bridge/bridge.test.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.test.ts
@@ -1615,6 +1615,73 @@ describe("acp bridge", () => {
     startedProviderThreadIds.push(first.providerThreadId);
   });
 
+  it("ignores load-time context usage for a different session", async () => {
+    const first = await startThread({
+      envVars: { FAKE_ACP_LOAD_SESSION: "1" },
+    });
+    await stopThread(first.providerThreadId);
+    startedProviderThreadIds.pop();
+
+    const resumeId = sendRequest("thread/resume", {
+      threadId: first.bbThreadId,
+      providerThreadId: first.providerThreadId,
+      cwd: workspaceDir,
+      agent: { command: process.execPath, args: [FAKE_AGENT_PATH] },
+      permissionMode: "full",
+      permissionEscalation: null,
+      workspaceWriteRoots: [workspaceDir],
+      envVars: {
+        FAKE_ACP_LOAD_SESSION: "1",
+        FAKE_ACP_USAGE_ON_LOAD: "1",
+        FAKE_ACP_USAGE_SESSION_ID: "different-session",
+      },
+    });
+    const response = await waitForResponse(resumeId);
+    expect(response.result).toEqual({
+      providerThreadId: first.providerThreadId,
+    });
+    expect(notifications("acp/update")).toEqual([]);
+    startedProviderThreadIds.push(first.providerThreadId);
+  });
+
+  it("discards load-time context usage when session/load fails", async () => {
+    const first = await startThread({
+      envVars: { FAKE_ACP_LOAD_SESSION: "1" },
+    });
+    await stopThread(first.providerThreadId);
+    startedProviderThreadIds.pop();
+
+    const resumeId = sendRequest("thread/resume", {
+      threadId: first.bbThreadId,
+      providerThreadId: first.providerThreadId,
+      cwd: workspaceDir,
+      agent: { command: process.execPath, args: [FAKE_AGENT_PATH] },
+      permissionMode: "full",
+      permissionEscalation: null,
+      workspaceWriteRoots: [workspaceDir],
+      envVars: {
+        FAKE_ACP_FAIL_LOAD: "1",
+        FAKE_ACP_USAGE_ON_LOAD: "1",
+      },
+    });
+    const response = await waitForResponse(resumeId);
+    const result = response.result;
+    if (
+      typeof result !== "object" ||
+      result === null ||
+      Array.isArray(result) ||
+      typeof result.providerThreadId !== "string"
+    ) {
+      throw new Error("thread/resume did not return a providerThreadId");
+    }
+    expect(result.providerThreadId).not.toBe(first.providerThreadId);
+    expect(notifications("acp/update")).toEqual([]);
+    expect(notifications("acp/warning").at(-1)?.params).toMatchObject({
+      threadId: first.bbThreadId,
+    });
+    startedProviderThreadIds.push(result.providerThreadId);
+  });
+
   it("re-applies ACP-native reasoning after session/load resume", async () => {
     const first = await startThread({
       envVars: {

--- a/packages/agent-runtime/src/acp/bridge/bridge.test.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.test.ts
@@ -1580,6 +1580,41 @@ describe("acp bridge", () => {
     startedProviderThreadIds.push(first.providerThreadId);
   });
 
+  it("forwards context usage reported during session/load", async () => {
+    const first = await startThread({
+      envVars: { FAKE_ACP_LOAD_SESSION: "1" },
+    });
+    await stopThread(first.providerThreadId);
+    startedProviderThreadIds.pop();
+
+    const resumeId = sendRequest("thread/resume", {
+      threadId: first.bbThreadId,
+      providerThreadId: first.providerThreadId,
+      cwd: workspaceDir,
+      agent: { command: process.execPath, args: [FAKE_AGENT_PATH] },
+      permissionMode: "full",
+      permissionEscalation: null,
+      workspaceWriteRoots: [workspaceDir],
+      envVars: {
+        FAKE_ACP_LOAD_SESSION: "1",
+        FAKE_ACP_USAGE_ON_LOAD: "1",
+      },
+    });
+    const response = await waitForResponse(resumeId);
+    expect(response.result).toEqual({
+      providerThreadId: first.providerThreadId,
+    });
+    expect(notifications("acp/update").at(-1)?.params).toEqual({
+      threadId: first.bbThreadId,
+      update: {
+        sessionUpdate: "usage_update",
+        used: 24_000,
+        size: 128_000,
+      },
+    });
+    startedProviderThreadIds.push(first.providerThreadId);
+  });
+
   it("re-applies ACP-native reasoning after session/load resume", async () => {
     const first = await startThread({
       envVars: {

--- a/packages/agent-runtime/src/acp/bridge/bridge.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.ts
@@ -1726,11 +1726,14 @@ function handleAgentNotification(
   if (method !== "session/update") {
     return;
   }
-  if (session.loading || session.stopping) {
+  if (session.stopping) {
     return;
   }
   const parsed = acpSessionNotificationParamsSchema.safeParse(params);
   if (!parsed.success) {
+    return;
+  }
+  if (session.loading && parsed.data.update.sessionUpdate !== "usage_update") {
     return;
   }
   sendNotification(ACP_UPDATE_METHOD, {

--- a/packages/agent-runtime/src/acp/bridge/bridge.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.ts
@@ -68,8 +68,10 @@ import {
   acpRequestPermissionParamsSchema,
   acpSessionNewResultSchema,
   acpSessionNotificationParamsSchema,
+  acpUsageUpdateSchema,
   type AcpConfigStateResult,
   type AcpSessionModels,
+  type AcpUsageUpdate,
   acpStopReasonSchema,
   acpWriteTextFileParamsSchema,
   type AcpContentBlock,
@@ -126,6 +128,8 @@ interface AcpThreadSession {
   promptActive: boolean;
   queuedInputs: PromptInput[][];
   loading: boolean;
+  loadingSessionId: string | undefined;
+  pendingLoadUsageUpdate: AcpUsageUpdate | undefined;
   stopping: boolean;
   /** Resolves when the in-flight bb turn loop fully settles. */
   turnSettled: Promise<void> | undefined;
@@ -1509,6 +1513,8 @@ async function startAgentSession(
     promptActive: false,
     queuedInputs: [],
     loading: false,
+    loadingSessionId: undefined,
+    pendingLoadUsageUpdate: undefined,
     stopping: false,
     turnSettled: undefined,
     pendingPermissions: new Set(),
@@ -1543,6 +1549,8 @@ async function startAgentSession(
     let loadedModels: AcpSessionModels | undefined;
     if (request.kind === "resume" && supportsLoadSession) {
       session.loading = true;
+      session.loadingSessionId = request.params.providerThreadId;
+      session.pendingLoadUsageUpdate = undefined;
       try {
         const configState = await connection.request({
           method: "session/load",
@@ -1558,12 +1566,16 @@ async function startAgentSession(
         sessionId = request.params.providerThreadId;
       } catch {
         sessionId = undefined;
-      } finally {
         session.loading = false;
+        session.loadingSessionId = undefined;
+        session.pendingLoadUsageUpdate = undefined;
       }
     }
 
     if (sessionId === undefined) {
+      session.loading = false;
+      session.loadingSessionId = undefined;
+      session.pendingLoadUsageUpdate = undefined;
       const newSession = await connection.request({
         method: "session/new",
         params: { cwd: params.cwd, mcpServers },
@@ -1593,6 +1605,16 @@ async function startAgentSession(
         modelSelection: params.modelSelection,
         nativeReasoning: params.nativeReasoning,
       });
+      const loadUsageUpdate = session.pendingLoadUsageUpdate;
+      session.loading = false;
+      session.loadingSessionId = undefined;
+      session.pendingLoadUsageUpdate = undefined;
+      if (loadUsageUpdate) {
+        sendNotification(ACP_UPDATE_METHOD, {
+          threadId: session.bbThreadId,
+          update: loadUsageUpdate,
+        });
+      }
     }
 
     session.providerThreadId = sessionId;
@@ -1733,7 +1755,22 @@ function handleAgentNotification(
   if (!parsed.success) {
     return;
   }
-  if (session.loading && parsed.data.update.sessionUpdate !== "usage_update") {
+  if (session.loading) {
+    if (
+      parsed.data.sessionId === session.loadingSessionId &&
+      parsed.data.update.sessionUpdate === "usage_update"
+    ) {
+      const usageUpdate = acpUsageUpdateSchema.safeParse(parsed.data.update);
+      if (usageUpdate.success) {
+        session.pendingLoadUsageUpdate = usageUpdate.data;
+      }
+    }
+    return;
+  }
+  if (
+    session.providerThreadId !== "" &&
+    parsed.data.sessionId !== session.providerThreadId
+  ) {
     return;
   }
   sendNotification(ACP_UPDATE_METHOD, {

--- a/packages/agent-runtime/src/acp/bridge/fake-acp-agent.mjs
+++ b/packages/agent-runtime/src/acp/bridge/fake-acp-agent.mjs
@@ -9,6 +9,7 @@
  *
  * Env knobs (passed by tests through thread/start envVars):
  * - FAKE_ACP_LOAD_SESSION=1  → advertise + accept session/load
+ * - FAKE_ACP_USAGE_ON_LOAD=1 → report context usage during session/load
  * - FAKE_ACP_MODEL_CONFIG=1  → advertise a model configOptions select
  * - FAKE_ACP_MODELS_FIELD=1  → advertise legacy ACP models state
  * - FAKE_ACP_THOUGHT_LEVEL_CONFIG=1
@@ -33,6 +34,7 @@ import { createInterface } from "node:readline";
 import { appendFileSync, writeFileSync } from "node:fs";
 
 const loadSession = process.env.FAKE_ACP_LOAD_SESSION === "1";
+const usageOnLoad = process.env.FAKE_ACP_USAGE_ON_LOAD === "1";
 const modelConfig = process.env.FAKE_ACP_MODEL_CONFIG === "1";
 const modelsField = process.env.FAKE_ACP_MODELS_FIELD === "1";
 const thoughtLevelConfig = process.env.FAKE_ACP_THOUGHT_LEVEL_CONFIG === "1";
@@ -90,11 +92,11 @@ function send(message) {
   process.stdout.write(JSON.stringify(message) + "\n");
 }
 
-function notifyUpdate(update) {
+function notifyUpdate(update, targetSessionId = sessionId) {
   send({
     jsonrpc: "2.0",
     method: "session/update",
-    params: { sessionId, update },
+    params: { sessionId: targetSessionId, update },
   });
 }
 
@@ -372,6 +374,12 @@ async function handleMessage(message) {
       }
       if (loadSession) {
         captureMcpServers(message);
+        if (usageOnLoad) {
+          notifyUpdate(
+            { sessionUpdate: "usage_update", used: 24_000, size: 128_000 },
+            message.params?.sessionId,
+          );
+        }
         send({ jsonrpc: "2.0", id: message.id, result: configState() });
       } else {
         send({

--- a/packages/agent-runtime/src/acp/bridge/fake-acp-agent.mjs
+++ b/packages/agent-runtime/src/acp/bridge/fake-acp-agent.mjs
@@ -9,7 +9,10 @@
  *
  * Env knobs (passed by tests through thread/start envVars):
  * - FAKE_ACP_LOAD_SESSION=1  → advertise + accept session/load
+ * - FAKE_ACP_FAIL_LOAD=1     → advertise session/load, then fail it
  * - FAKE_ACP_USAGE_ON_LOAD=1 → report context usage during session/load
+ * - FAKE_ACP_USAGE_SESSION_ID
+ *                            → override the usage notification session id
  * - FAKE_ACP_MODEL_CONFIG=1  → advertise a model configOptions select
  * - FAKE_ACP_MODELS_FIELD=1  → advertise legacy ACP models state
  * - FAKE_ACP_THOUGHT_LEVEL_CONFIG=1
@@ -33,8 +36,10 @@
 import { createInterface } from "node:readline";
 import { appendFileSync, writeFileSync } from "node:fs";
 
-const loadSession = process.env.FAKE_ACP_LOAD_SESSION === "1";
+const failLoad = process.env.FAKE_ACP_FAIL_LOAD === "1";
+const loadSession = process.env.FAKE_ACP_LOAD_SESSION === "1" || failLoad;
 const usageOnLoad = process.env.FAKE_ACP_USAGE_ON_LOAD === "1";
+const usageSessionId = process.env.FAKE_ACP_USAGE_SESSION_ID;
 const modelConfig = process.env.FAKE_ACP_MODEL_CONFIG === "1";
 const modelsField = process.env.FAKE_ACP_MODELS_FIELD === "1";
 const thoughtLevelConfig = process.env.FAKE_ACP_THOUGHT_LEVEL_CONFIG === "1";
@@ -48,7 +53,7 @@ const authMethods = (process.env.FAKE_ACP_AUTH_METHODS ?? "")
   .split(",")
   .map((method) => method.trim())
   .filter(Boolean);
-const sessionId = `fake-sess-${process.pid}`;
+const newSessionId = `fake-sess-${process.pid}`;
 const fakeModels = [
   { value: "fake/default", name: "Fake Default" },
   { value: "fake/strong", name: "Fake Strong" },
@@ -59,6 +64,7 @@ let nextAgentRequestId = 1000;
 let selectedModel = "fake/default";
 let selectedEffort = "none";
 let authenticatedMethod = null;
+let activeSessionId = newSessionId;
 const pendingClientRequests = new Map();
 let currentMcpServers = [];
 
@@ -92,7 +98,7 @@ function send(message) {
   process.stdout.write(JSON.stringify(message) + "\n");
 }
 
-function notifyUpdate(update, targetSessionId = sessionId) {
+function notifyUpdate(update, targetSessionId = activeSessionId) {
   send({
     jsonrpc: "2.0",
     method: "session/update",
@@ -232,7 +238,7 @@ async function handlePrompt(message) {
     let outcome = "cancelled";
     try {
       const result = await requestClient("session/request_permission", {
-        sessionId,
+        sessionId: activeSessionId,
         toolCall: {
           toolCallId: "perm-tool-1",
           title: "Run rm",
@@ -256,7 +262,7 @@ async function handlePrompt(message) {
   } else if (text.includes("write-file")) {
     try {
       await requestClient("fs/write_text_file", {
-        sessionId,
+        sessionId: activeSessionId,
         path: process.env.FAKE_ACP_WRITE_PATH,
         content: "hello from agent\n",
       });
@@ -359,11 +365,12 @@ async function handleMessage(message) {
         return;
       }
       captureMcpServers(message);
+      activeSessionId = newSessionId;
       send({
         jsonrpc: "2.0",
         id: message.id,
         result: {
-          sessionId,
+          sessionId: newSessionId,
           ...configState(),
         },
       });
@@ -377,10 +384,19 @@ async function handleMessage(message) {
         if (usageOnLoad) {
           notifyUpdate(
             { sessionUpdate: "usage_update", used: 24_000, size: 128_000 },
-            message.params?.sessionId,
+            usageSessionId ?? message.params?.sessionId,
           );
         }
-        send({ jsonrpc: "2.0", id: message.id, result: configState() });
+        if (failLoad) {
+          send({
+            jsonrpc: "2.0",
+            id: message.id,
+            error: { code: -32000, message: "session/load failed" },
+          });
+        } else {
+          activeSessionId = message.params?.sessionId;
+          send({ jsonrpc: "2.0", id: message.id, result: configState() });
+        }
       } else {
         send({
           jsonrpc: "2.0",

--- a/packages/agent-runtime/src/acp/visibility.ts
+++ b/packages/agent-runtime/src/acp/visibility.ts
@@ -31,6 +31,7 @@ const NORMALIZED_ACP_UPDATE_KINDS = new Set<string>([
   "tool_call",
   "tool_call_update",
   "plan",
+  "usage_update",
 ]);
 
 // Update kinds the agent may legitimately send but BB intentionally does not
@@ -41,7 +42,6 @@ const NOISE_ACP_UPDATE_KINDS = new Set<string>([
   "current_mode_update",
   "config_option_update",
   "session_info_update",
-  "usage_update",
 ]);
 
 interface AcpMethodRawEvent {

--- a/packages/agent-runtime/src/acp/wire.ts
+++ b/packages/agent-runtime/src/acp/wire.ts
@@ -155,6 +155,14 @@ export const acpPlanUpdateSchema = z
   })
   .passthrough();
 
+export const acpUsageUpdateSchema = z
+  .object({
+    sessionUpdate: z.literal("usage_update"),
+    used: z.number().int().nonnegative(),
+    size: z.number().int().nonnegative(),
+  })
+  .passthrough();
+
 const acpOtherSessionUpdateSchema = z
   .object({
     sessionUpdate: z.string(),
@@ -166,6 +174,7 @@ export const acpSessionUpdateSchema = z.union([
   acpAgentThoughtChunkUpdateSchema,
   acpToolCallUpdateEventSchema,
   acpPlanUpdateSchema,
+  acpUsageUpdateSchema,
   acpOtherSessionUpdateSchema,
 ]);
 export type AcpSessionUpdate = z.infer<typeof acpSessionUpdateSchema>;

--- a/packages/agent-runtime/src/acp/wire.ts
+++ b/packages/agent-runtime/src/acp/wire.ts
@@ -162,6 +162,7 @@ export const acpUsageUpdateSchema = z
     size: z.number().int().nonnegative(),
   })
   .passthrough();
+export type AcpUsageUpdate = z.infer<typeof acpUsageUpdateSchema>;
 
 const acpOtherSessionUpdateSchema = z
   .object({

--- a/packages/domain/src/thread-event-scope.ts
+++ b/packages/domain/src/thread-event-scope.ts
@@ -119,7 +119,11 @@ export const threadEventScopeDefinitionByType = {
       "Terminal task state can arrive turns after the spawning turn completed; thread scope avoids appending into a closed turn's sequence range.",
   },
   "thread/tokenUsage/updated": { policy: "turn" },
-  "thread/contextWindowUsage/updated": { policy: "turn" },
+  "thread/contextWindowUsage/updated": {
+    policy: "thread-or-turn",
+    rationale:
+      "Context usage is session state; providers can report it before, during, or after a turn.",
+  },
   "turn/plan/updated": { policy: "turn" },
   "turn/diff/updated": { policy: "turn" },
   "provider/error": {

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -36,7 +36,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 94 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 95 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1051,10 +1051,10 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
-  // Version 94 adds Cursor skill scopes to the delete command contract.
-  // An older daemon rejects these scopes, so it must update before deletion.
-  it("uses protocol version 94 for Cursor skill scopes", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(94);
+  // Version 95 lets ACP sessions send context-window usage outside a turn.
+  // An older daemon omits these events, so it must update before connecting.
+  it("uses protocol version 95 for ACP context-window usage", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(95);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {


### PR DESCRIPTION
## Summary

- parse stable ACP `usage_update` notifications
- translate exact `used` and `size` values into BB context-window events
- preserve usage reports during session restore and before the first turn
- increment the host-daemon protocol version for the new event behavior

## Root cause

The ACP bridge forwarded `usage_update` as an untyped session update. The adapter classified it as noise, so the server never received a context-window event. The bridge also discarded all session updates during `session/load`.

## Validation

- reproduced the issue with a failing ACP adapter test: valid usage returned no events
- ACP, domain, and host-daemon contract tests pass: 1,032 tests
- server tests pass: 1,391 tests
- focused server ingest and timeline test passes
- affected package type checks pass
- host-daemon and server builds pass

Closes #1111