### PR TITLE
Cut hidden and redundant thread-detail query refetches on realtime events

### DIFF
--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -393,6 +393,7 @@ export const REALTIME_ENVIRONMENT_CHANGE_REGISTRY = {
     dirty: [
       dirtyEnvironmentRefDerivedWorkspaceStateQueries, // Only cached ref-derived workspace queries need refresh.
       dirtyEnvironmentBranchListQueries, // Refs can add/remove/rename branch options.
+      dirtyEnvironmentPullRequestQueries, // A commit/push moves the PR head; content-only edits do not.
     ],
   },
   "thread-storage-changed": {
@@ -825,15 +826,24 @@ function dirtyEnvironmentWorkspaceStateQueries(
   removeEnvironmentDiffPatchQueries(context);
 }
 
+// Deliberately NOT part of the work-status handler: work-status-changed fires
+// for every workspace content edit during an agent turn, and the PR lookup is
+// a `gh` shell-out that content edits cannot affect. Refs moving (commit,
+// push) is the local signal that can change PR state; remote-only changes are
+// covered by the turn-completed invalidation, the pending-checks poll, and
+// stale-aware focus refetches.
+function dirtyEnvironmentPullRequestQueries({
+  environmentId,
+}: EnvironmentRealtimeDirtyContext): QueryKey[] {
+  return [environmentPullRequestQueryKey(environmentId)];
+}
+
 function dirtyEnvironmentLiveWorkspaceStateQueries({
   environmentId,
   queryClient,
 }: EnvironmentRealtimeDirtyContext): void {
   queryClient.invalidateQueries({
     queryKey: environmentWorkStatusQueryKeyPrefix(environmentId),
-  });
-  queryClient.invalidateQueries({
-    queryKey: environmentPullRequestQueryKey(environmentId),
   });
   queryClient.invalidateQueries({
     queryKey: environmentFilePreviewQueryKeyPrefix(environmentId),

--- a/apps/app/src/hooks/queries/environment-queries.test.tsx
+++ b/apps/app/src/hooks/queries/environment-queries.test.tsx
@@ -163,7 +163,7 @@ describe("useEnvironmentPullRequest", () => {
     ).toBe(false);
   });
 
-  it("refetches stale pull request data on mount and always refetches on window focus", async () => {
+  it("refetches stale pull request data on mount and on window focus", async () => {
     const { wrapper, queryClient } = createQueryClientTestHarness();
     vi.mocked(sdk.environments.pullRequest).mockResolvedValue(
       pullRequestResponse(pullRequestFixture),
@@ -182,7 +182,8 @@ describe("useEnvironmentPullRequest", () => {
     expect(query?.options).toEqual(
       expect.objectContaining({
         refetchOnMount: true,
-        refetchOnWindowFocus: "always",
+        // Stale-aware focus refetch keeps the settled-PR stale tier effective.
+        refetchOnWindowFocus: true,
         refetchInterval: expect.any(Function),
         staleTime: expect.any(Function),
       }),

--- a/apps/app/src/hooks/queries/environment-queries.ts
+++ b/apps/app/src/hooks/queries/environment-queries.ts
@@ -192,7 +192,11 @@ export function useEnvironmentPullRequest(
       }),
     enabled,
     refetchOnMount: true,
-    refetchOnWindowFocus: "always",
+    // Stale-aware, not "always": the lookup shells out to `gh` on the server,
+    // and the settled-PR stale tier exists to keep merged/closed PRs from
+    // paying that on every window focus. Open PRs still refetch on focus once
+    // past the short stale tier.
+    refetchOnWindowFocus: true,
     refetchInterval: (query) =>
       getEnvironmentPullRequestRefetchInterval(
         getEnvironmentPullRequestFromResponse(query.state.data),

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -464,6 +464,72 @@ describe("createRealtimeCacheEffects", () => {
     },
   );
 
+  it("refetches the active pull request lookup when git refs change", async () => {
+    vi.useFakeTimers();
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const pullRequestKey = environmentPullRequestQueryKey("env-1");
+    const nextPullRequest = {
+      outcome: "available",
+      pullRequest: { number: 42 },
+    };
+    const pullRequestQueryFn = vi.fn(async () => nextPullRequest);
+    queryClient.setQueryData(pullRequestKey, { outcome: "absent" });
+    const pullRequestObserver = new QueryObserver(queryClient, {
+      queryFn: pullRequestQueryFn,
+      queryKey: pullRequestKey,
+      staleTime: Infinity,
+    });
+    const unsubscribePullRequest = pullRequestObserver.subscribe(() => {});
+    pullRequestQueryFn.mockClear();
+
+    effects.handleChanged({
+      type: "changed",
+      entity: "environment",
+      id: "env-1",
+      changes: ["git-refs-changed"],
+    });
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(pullRequestQueryFn).toHaveBeenCalledTimes(1);
+    expect(queryClient.getQueryData(pullRequestKey)).toEqual(nextPullRequest);
+
+    unsubscribePullRequest();
+    effects.dispose();
+  });
+
+  it("does not refetch the pull request lookup for content-only work-status changes", async () => {
+    vi.useFakeTimers();
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const pullRequestKey = environmentPullRequestQueryKey("env-1");
+    const pullRequestQueryFn = vi.fn(async () => ({
+      outcome: "absent" as const,
+    }));
+    queryClient.setQueryData(pullRequestKey, { outcome: "absent" });
+    const pullRequestObserver = new QueryObserver(queryClient, {
+      queryFn: pullRequestQueryFn,
+      queryKey: pullRequestKey,
+      staleTime: Infinity,
+    });
+    const unsubscribePullRequest = pullRequestObserver.subscribe(() => {});
+    pullRequestQueryFn.mockClear();
+
+    effects.handleChanged({
+      type: "changed",
+      entity: "environment",
+      id: "env-1",
+      changes: ["work-status-changed"],
+    });
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(pullRequestQueryFn).not.toHaveBeenCalled();
+    expect(
+      queryClient.getQueryState(pullRequestKey)?.isInvalidated,
+    ).toBe(false);
+
+    unsubscribePullRequest();
+    effects.dispose();
+  });
+
   it("invalidates cached thread search results when environment metadata changes", () => {
     vi.useFakeTimers();
     const { effects, queryClient } = createRealtimeEffectsTestContext();

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -5,6 +5,7 @@ import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { dispatchBrowserViewBoundsSync } from "@/lib/browser-view-bounds-sync";
+import { useThreads } from "@/hooks/queries/thread-queries";
 import { ThreadDetailSecondaryContent } from "./ThreadDetailSecondaryContent";
 import {
   DefaultPaneContextProvider,
@@ -42,7 +43,7 @@ vi.mock("@/components/ui/sidebar.js", () => ({
 }));
 
 vi.mock("@/hooks/queries/thread-queries", () => ({
-  useThreads: () => ({ data: [] }),
+  useThreads: vi.fn(),
 }));
 
 vi.mock("jotai", async (importOriginal) => ({
@@ -462,6 +463,44 @@ afterEach(() => {
 beforeEach(() => {
   publishedHostedPanel = null;
   vi.mocked(dispatchBrowserViewBoundsSync).mockReset();
+  vi.mocked(useThreads).mockReturnValue({ data: [] } as unknown as ReturnType<
+    typeof useThreads
+  >);
+});
+
+describe("ThreadDetailSecondaryContent hidden-panel queries", () => {
+  it.each([
+    ["compact drawer", true],
+    ["wide panel", false],
+  ] as const)(
+    "gates the forks mirror query on %s visibility",
+    (_label, isCompactViewport) => {
+      const view = renderThreadDetail({
+        isCompactViewport,
+        isSecondaryPanelOpen: false,
+        renderBrowserDeck: createBrowserDeckRenderer(),
+        threadId: "thread-1",
+      });
+
+      expect(vi.mocked(useThreads)).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          originKind: "fork",
+          sourceThreadId: "thread-1",
+        }),
+        { enabled: false },
+      );
+
+      view.rerenderWith({ isSecondaryPanelOpen: true });
+
+      expect(vi.mocked(useThreads)).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          originKind: "fork",
+          sourceThreadId: "thread-1",
+        }),
+        { enabled: true },
+      );
+    },
+  );
 });
 
 describe("ThreadDetailSecondaryContent compact drawer settling", () => {

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -254,13 +254,18 @@ function ThreadDetailSecondaryContentBody({
   }, [isConversationCollapsedActive, isSecondaryPanelOpen, renderAsDrawer]);
 
   // Mirror ForksRow's query (deduped by react-query) so the visibility gate
-  // accounts for the lazily-fetched Forks row.
-  const forksQuery = useThreads({
-    projectId: stableMetadata.thread.projectId,
-    sourceThreadId: stableMetadata.thread.id,
-    originKind: "fork",
-    archived: false,
-  });
+  // accounts for the lazily-fetched Forks row. Only while the panel/drawer is
+  // open: the result only picks the metadata placeholder, and a closed panel
+  // must not pay a thread-list refetch on every realtime list invalidation.
+  const forksQuery = useThreads(
+    {
+      projectId: stableMetadata.thread.projectId,
+      sourceThreadId: stableMetadata.thread.id,
+      originKind: "fork",
+      archived: false,
+    },
+    { enabled: isSecondaryPanelOpen },
+  );
   const hasForks = (forksQuery.data?.length ?? 0) > 0;
 
   const metadataContent = useMemo(

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -583,7 +583,13 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
   );
   const [browserAddressFocusRequest, setBrowserAddressFocusRequest] =
     useState<BrowserAddressFocusRequest | null>(null);
-  const shouldLoadThreadStorageFiles = thread !== undefined;
+  // Every consumer of the storage file list lives in the secondary
+  // panel/drawer (metadata storage section, storage browser, storage-tab
+  // pruning), so a closed panel must not pay realtime-driven refetches.
+  // Timeline storage links still resolve while closed: the link handler
+  // falls back to an on-demand refetch when the storage root is unknown.
+  const shouldLoadThreadStorageFiles =
+    thread !== undefined && isSecondaryPanelOpen;
   const {
     isThreadStorageFilesLoading,
     refetchThreadStorageFiles,


### PR DESCRIPTION
## Summary

Follow-up #2 from the issue #1269 diagnosis (the first fix is PR #1281). This change removes hidden-query refetch work in the thread detail view and removes redundant pull-request lookups on all viewports.

- Invalidate the environment pull-request query on `git-refs-changed`, not on every `work-status-changed` event.
- Make the pull-request focus refetch stale-aware instead of `"always"`.
- Gate the forks mirror query and the thread-storage file list on secondary panel visibility.

## Re-verification of the reported finding

The task premise said the view-level `useEnvironmentWorkStatus` and `useEnvironmentPullRequest` queries feed only hidden surfaces on a compact viewport. That premise is not correct. The composer context banner (`ThreadPromptContextBanner`) consumes both queries, and the composer is visible on every viewport, including mobile:

- The changed-files tally and the checkout label come from the work-status query (`ThreadDetailView.tsx` → `workspaceChangedFilesSection`, `threadCheckoutDisplay`).
- The PR pill and the merge/ready actions come from the pull-request query (`ThreadDetailPromptArea.tsx` → `pullRequestSection`).
- The header git actions (`useThreadGitActions`) also read the work status on every viewport.

The `@container promptbox` rules in `app.css` hide only labels at narrow widths, not the banner. A visibility gate on these two queries would blank visible mobile UI and would also break the desktop banner when the panel is closed. So these two queries keep their current `enabled` condition, and this PR attacks the actual waste instead: the invalidation and refetch cadence, plus the queries that truly have no visible consumer while hidden.

## Root cause and fixes

**1. The PR lookup ran on every workspace content edit.** `dirtyEnvironmentLiveWorkspaceStateQueries` invalidated the PR query on every `work-status-changed` event. The host daemon emits that event for any workspace content change, and the client debounce is only 250 ms, so an active agent turn triggered a `gh` shell-out on the server per edit batch. A content-only edit cannot change PR state. The PR query now invalidates on `git-refs-changed` (commit or push moves the PR head). Remote-only changes stay covered by three existing paths: the `turn/completed` invalidation from #1025, the 5 s pending-checks poll from #251, and stale-aware focus refetches. This also improves freshness for a mid-turn push, which previously did not invalidate the PR query at all (a push moves refs, not the work status). In-app merge/ready/draft actions invalidate the query directly through `invalidateEnvironmentActionQueries`, unchanged.

**2. Focus refetch ignored the stale tiers.** `refetchOnWindowFocus: "always"` (#248) defeated the deliberate settled-PR stale tier (1 h for merged/closed PRs, #251 era). Every app switch on a phone paid a `gh` shell-out through the Connect tunnel, even for a merged PR. The refetch is now stale-aware (`true`): open PRs still refetch on focus after the 30 s tier; settled PRs stop paying. This keeps the #248 intent for the states that can still change.

**3. Two panel-only queries ran while hidden.** Same class as the #1214 outline fix:

- The forks mirror query in `ThreadDetailSecondaryContent` (`useThreads` with `originKind: "fork"`) refetched on every realtime thread-list invalidation while the panel or drawer was closed. It now enables only while the panel is open. Its only consumer is the metadata placeholder decision inside the panel.
- The thread-storage file list in `ThreadDetailView` refetched on every `thread-storage-changed` and `environment-changed` event while closed. All consumers live in the panel (metadata storage section, storage browser, storage-tab pruning). Timeline storage links still resolve while closed because the link handler already falls back to an on-demand `refetch()` when the storage root is unknown, and `refetch()` bypasses `enabled`.

Both fixes follow the existing precedent in the same file: `useThreadTerminals` was already gated on `isSecondaryPanelOpen`.

## Audit (scope item 2)

I checked every query family the hot realtime paths invalidate (`events-appended`, `turn/completed`, `status-changed`, `work-status-changed`) against its visibility on a compact viewport:

| Query | Hidden while invalidated? | Result |
| --- | --- | --- |
| Thread timeline windows | No — main view | OK |
| Sidebar thread lists | No — the mobile sidebar drawer unmounts when closed (vaul portal) | OK |
| Forks mirror (`ThreadDetailSecondaryContent`) | Yes | Fixed here |
| Thread-storage file list (`ThreadDetailView`) | Yes | Fixed here |
| Thread search | No — enabled only with a query string | OK |
| Prompt history | No — composer is visible | OK |
| Environment diff TOC / file previews | No — already gated (`isDiffPanelActive`, tab-active) | OK |
| Thread terminals | No — already gated on panel open | OK |
| Conversation outline (TOC) | No — fixed by #1214 | OK |
| Parent-thread subset | No — enabled only after the picker opens | OK |
| Plugin sidebar PR rows | No — per-mounted-row by design | OK |

Follow-up candidates, not changed here:

- `useEnvironmentWorkStatus` keeps `staleTime: 0` plus per-edit invalidation because the visible changed-files tally must track edits. If the mobile composer ever drops the tally, this query becomes gateable on compact viewports.
- The #1269 memory lists timeline re-render amplifiers (un-virtualized timeline, per-message document listeners). Those are render-cost items, not query items, and stay tracked there.

## Request-count effect (reasoned, not device-measured)

I did not run a phone A/B capture for this change. The arithmetic from the invalidation paths: during an active turn that edits files, the previous behavior issued one PR lookup (server-side `gh` shell-out) per 250 ms-debounced `work-status-changed` batch, plus one per window focus regardless of PR state. After this change, a turn issues PR lookups only on ref moves (commits/pushes) and once at turn completion. For a turn with N edit batches and C commits, that is C + 1 lookups instead of ~N + C + 1, and settled-PR focus refetches drop to zero. The forks and storage queries drop to zero requests while the drawer is closed.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app --force` — 326 files, 2469 tests passed
- `pnpm exec turbo run lint --filter=@bb/app` — 0 errors (141 pre-existing warnings; the one in a touched file reproduces on main)
- `git diff --check` — clean

New regression coverage, in the #1214 compact-pane pattern:

- `realtime-cache-effects.test.ts`: a content-only `work-status-changed` event does not refetch or invalidate an active PR query; a `git-refs-changed` event refetches it.
- `ThreadDetailSecondaryContent.test.tsx`: the forks mirror query is disabled while the compact drawer (and the wide panel) is closed, and enables when it opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
