### PR TITLE
Add pnpm dev:stop command

### DIFF
--- a/docs/debugging-and-qa.md
+++ b/docs/debugging-and-qa.md
@@ -15,7 +15,7 @@ Use `scripts/bb-dev-app` when validating changes in the desktop dev app or helpi
 - `scripts/bb-dev-app current` restarts the dev server on the current branch.
 - `scripts/bb-dev-app main` fetches `origin/main`, fast-forwards `main`, and launches the dev server from this checkout.
 - `scripts/bb-dev-app branch <branch>` switches to a local branch, or creates it from `origin/<branch>`, then launches the dev server.
-- `scripts/bb-dev-app stop` stops the launcher-managed dev server and desktop.
+- `pnpm dev:stop` runs `scripts/bb-dev-app stop` to stop the launcher-managed dev server and desktop.
 - `scripts/bb-dev-app logs dev` and `scripts/bb-dev-app logs desktop` follow logs.
 
 By default the launcher starts only the dev server (web frontend, server, host daemon) and prints the URL without opening a browser. Pass `--open` to open the browser after startup. Pass `--desktop` (e.g. `scripts/bb-dev-app current --desktop`) to also launch the Electron desktop shell — only do this when the user is testing a desktop-only change.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cloud:dev": "node --conditions=source --import tsx scripts/bb-cloud-dev.mjs",
     "dev:desktop": "scripts/bb-dev-app current --desktop",
     "dev:status": "scripts/bb-dev-app status",
+    "dev:stop": "scripts/bb-dev-app stop",
     "dev:restart": "cross-env NODE_ENV=development node --conditions=source --import tsx packages/scripts/src/commands/request-dev-restart.ts both",
     "dev:restart-server": "cross-env NODE_ENV=development node --conditions=source --import tsx packages/scripts/src/commands/request-dev-restart.ts server",
     "dev:restart-host-daemon": "cross-env NODE_ENV=development node --conditions=source --import tsx packages/scripts/src/commands/request-dev-restart.ts host-daemon",


### PR DESCRIPTION
## Summary

- add a root `pnpm dev:stop` command that runs `scripts/bb-dev-app stop`
- document the new alias in the local dev QA guide

## Verification

- `git diff --check`
- `pnpm exec prettier package.json docs/debugging-and-qa.md --check`
- confirmed `pnpm run` lists `dev:stop` with the expected command