### PR TITLE
Flatten CSS in the Vite dev pipeline

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -136,6 +136,7 @@
     "bb-plugin-automations": "workspace:*",
     "eslint": "^9.39.3",
     "eslint-plugin-react-hooks": "^7.0.1",
+    "lightningcss": "^1.32.0",
     "mdast-util-to-hast": "^13.2.1",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.3.0",

--- a/apps/app/vite.dev.config.ts
+++ b/apps/app/vite.dev.config.ts
@@ -9,6 +9,12 @@ const devWebSocketBrowserHostPortDefine = JSON.stringify(
 
 export default defineConfig({
   ...sharedViteConfig,
+  // Match the production CSS pipeline in dev. In particular, this lowers
+  // Tailwind's nested conditional rules for Safari versions that parse
+  // color-mix() but do not reliably apply nested @supports declarations.
+  css: {
+    transformer: "lightningcss",
+  },
   define: {
     // Connect directly to the server in dev because Vite's WS proxy does not
     // handle upstream server restarts reliably.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -396,6 +396,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.39.3(jiti@2.7.0))
+      lightningcss:
+        specifier: ^1.32.0
+        version: 1.32.0
       mdast-util-to-hast:
         specifier: ^13.2.1
         version: 13.2.1


### PR DESCRIPTION
## Summary

- use Vite Lightning CSS transformation in development to match production CSS lowering
- declare Lightning CSS as a direct app development dependency
- flatten Tailwind generated nested conditional declarations for older Safari versions

## Why

Tailwind emits derived theme tokens as nested `@supports` declarations. Production lowers those declarations, but the Vite dev server previously sent them to the browser as nested CSS. Safari versions that support `color-mix()` but mishandle nested conditional declarations then kept fallback ink-colored borders, making the development app look unthemed.

## Verification

- started the standalone Vite dev server and inspected `/src/app.css`; the theme `@supports` rule is top-level
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run build --filter=@bb/app`