### PR TITLE
Fix iPad landscape sidebar safe-area overlap

### DIFF
--- a/apps/app/src/components/ui/sidebar.test.tsx
+++ b/apps/app/src/components/ui/sidebar.test.tsx
@@ -133,6 +133,24 @@ describe("SidebarTrigger", () => {
   });
 });
 
+describe("Sidebar", () => {
+  it("keeps regular viewport content inside the safe area", () => {
+    render(
+      <CompactViewportOverrideProvider isCompactViewport={false}>
+        <SidebarProvider>
+          <Sidebar>Sidebar content</Sidebar>
+        </SidebarProvider>
+      </CompactViewportOverrideProvider>,
+    );
+
+    const sidebar = screen
+      .getByText("Sidebar content")
+      .closest('[data-sidebar="sidebar"]');
+
+    expect(sidebar?.className).toContain("pt-[env(safe-area-inset-top)]");
+  });
+});
+
 describe("mobile sidebar text-selection arbitration", () => {
   it("opens from a right swipe that starts over selectable message prose", () => {
     renderSelectableSwipeHarness();

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -710,7 +710,7 @@ const Sidebar = React.forwardRef<
         >
           <div
             data-sidebar="sidebar"
-            className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
+            className="flex h-full w-full flex-col bg-sidebar pt-[env(safe-area-inset-top)] pr-[env(safe-area-inset-right)] pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)] group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
           >
             {children}
           </div>


### PR DESCRIPTION
## Summary

- apply all four safe-area insets to the regular sidebar inner shell, matching the compact drawer
- keep the fixed sidebar toggle and sidebar content on the same safe-area origin in iPadOS landscape
- add a regular-viewport regression test for the top safe-area inset

## Validation

- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app --force (328 files, 2,477 tests)
- pnpm exec turbo run build --filter=@bb/app
- confirmed fixed in an iPadOS standalone PWA in landscape

Fixes #1140