### PR TITLE
Serve compressed plugin frontend assets

### DIFF
--- a/apps/server/src/asset-content-encoding.ts
+++ b/apps/server/src/asset-content-encoding.ts
@@ -1,0 +1,56 @@
+interface AssetEncodingCandidate {
+  encoding: string;
+}
+
+function acceptedEncodingQuality(
+  acceptEncodingHeader: string | undefined,
+  encoding: string,
+): number {
+  if (acceptEncodingHeader === undefined) {
+    return 0;
+  }
+  let wildcardQuality = 0;
+  for (const part of acceptEncodingHeader.split(",")) {
+    const [rawName, ...rawParams] = part.trim().split(";");
+    const name = rawName?.trim().toLowerCase();
+    const qParam = rawParams
+      .map((param) => param.trim().toLowerCase())
+      .find((param) => param.startsWith("q="));
+    const quality =
+      qParam === undefined
+        ? 1
+        : Number.isNaN(Number(qParam.slice(2)))
+          ? 1
+          : Number(qParam.slice(2));
+    if (name === encoding) {
+      return quality;
+    }
+    if (name === "*") {
+      wildcardQuality = quality;
+    }
+  }
+  return wildcardQuality;
+}
+
+/** Rank supported encodings by the client's q-values, preserving server order on ties. */
+export function rankAcceptedAssetEncodings<
+  Candidate extends AssetEncodingCandidate,
+>(
+  acceptEncodingHeader: string | undefined,
+  candidates: readonly Candidate[],
+): Candidate[] {
+  return candidates
+    .map((candidate, index) => ({
+      candidate,
+      index,
+      quality: acceptedEncodingQuality(
+        acceptEncodingHeader,
+        candidate.encoding,
+      ),
+    }))
+    .filter((candidate) => candidate.quality > 0)
+    .sort(
+      (left, right) => right.quality - left.quality || left.index - right.index,
+    )
+    .map(({ candidate }) => candidate);
+}

--- a/apps/server/src/routes/plugins.ts
+++ b/apps/server/src/routes/plugins.ts
@@ -14,6 +14,10 @@ import type {
 } from "../services/plugins/plugin-service.js";
 import type { PluginMentionTrigger } from "../services/plugins/plugin-api.js";
 import { PluginSettingsValidationError } from "../services/plugins/plugin-settings.js";
+import {
+  createAppAssetCompressionCache,
+  type AppAssetCompressionCache,
+} from "../services/plugins/app-asset-compression-cache.js";
 import { rankAcceptedAssetEncodings } from "../asset-content-encoding.js";
 import {
   pluginApplyUpdateRequestSchema,
@@ -34,6 +38,7 @@ type WireAuthProblem = BrowserRequestProblem | { status: 401; error: string };
 const compressBrotli = promisify(brotliCompress);
 const compressGzip = promisify(gzip);
 const MIN_COMPRESSED_APP_ASSET_BYTES = 1_024;
+const MAX_CACHED_APP_ASSETS = 64;
 const APP_ASSET_ENCODINGS = [
   {
     encoding: "br",
@@ -55,12 +60,18 @@ const APP_ASSET_ENCODINGS = [
 async function appAssetResponse(
   context: Context,
   bytes: Buffer,
-  headers: { cacheControl: string; contentType: string },
+  args: {
+    assetKey: string;
+    cache: AppAssetCompressionCache;
+    cacheControl: string;
+    contentHash: string;
+    contentType: string;
+  },
 ): Promise<Response> {
   const responseHeaders: Record<string, string> = {
-    "cache-control": headers.cacheControl,
+    "cache-control": args.cacheControl,
     "content-length": String(bytes.length),
-    "content-type": headers.contentType,
+    "content-type": args.contentType,
   };
   if (bytes.length < MIN_COMPRESSED_APP_ASSET_BYTES) {
     return context.body(new Uint8Array(bytes), 200, responseHeaders);
@@ -75,7 +86,12 @@ async function appAssetResponse(
     return context.body(new Uint8Array(bytes), 200, responseHeaders);
   }
 
-  const compressed = await candidate.compress(bytes);
+  const compressed = await args.cache.getOrCreate({
+    assetKey: args.assetKey,
+    compress: () => candidate.compress(bytes),
+    encoding: candidate.encoding,
+    hash: args.contentHash,
+  });
   responseHeaders["content-encoding"] = candidate.encoding;
   responseHeaders["content-length"] = String(compressed.length);
   return context.body(new Uint8Array(compressed), 200, responseHeaders);
@@ -173,6 +189,10 @@ export function registerPluginRoutes(
   deps: PluginRoutesDeps,
   plugins: PluginService,
 ): void {
+  const appAssetCompressionCache = createAppAssetCompressionCache(
+    MAX_CACHED_APP_ASSETS,
+  );
+
   app.get("/plugins", (context) => context.json({ plugins: plugins.list() }));
 
   // Fast metadata for the bb CLI's help/proxy path and the app's
@@ -320,8 +340,11 @@ export function registerPluginRoutes(
         ? "public, max-age=31536000, immutable"
         : "no-store";
     return appAssetResponse(context, bytes, {
+      assetKey: `${context.req.param("id")}:${spec.kind}`,
+      cache: appAssetCompressionCache,
       contentType: spec.contentType,
       cacheControl,
+      contentHash: asset.hash,
     });
   });
 

--- a/apps/server/src/routes/plugins.ts
+++ b/apps/server/src/routes/plugins.ts
@@ -1,5 +1,7 @@
 import { timingSafeEqual } from "node:crypto";
 import { readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import { brotliCompress, constants as zlibConstants, gzip } from "node:zlib";
 import type { Context, Hono } from "hono";
 import type { ServerRuntimeConfig } from "../types.js";
 import {
@@ -12,6 +14,7 @@ import type {
 } from "../services/plugins/plugin-service.js";
 import type { PluginMentionTrigger } from "../services/plugins/plugin-api.js";
 import { PluginSettingsValidationError } from "../services/plugins/plugin-settings.js";
+import { rankAcceptedAssetEncodings } from "../asset-content-encoding.js";
 import {
   pluginApplyUpdateRequestSchema,
   pluginInstallRequestSchema,
@@ -27,6 +30,56 @@ export interface PluginRoutesDeps {
 }
 
 type WireAuthProblem = BrowserRequestProblem | { status: 401; error: string };
+
+const compressBrotli = promisify(brotliCompress);
+const compressGzip = promisify(gzip);
+const MIN_COMPRESSED_APP_ASSET_BYTES = 1_024;
+const APP_ASSET_ENCODINGS = [
+  {
+    encoding: "br",
+    compress: (bytes: Buffer) =>
+      compressBrotli(bytes, {
+        params: {
+          // Compression happens in the request path, so use a moderate level
+          // rather than the slower quality 10 used for build-time sidecars.
+          [zlibConstants.BROTLI_PARAM_QUALITY]: 6,
+        },
+      }),
+  },
+  {
+    encoding: "gzip",
+    compress: (bytes: Buffer) => compressGzip(bytes),
+  },
+] as const;
+
+async function appAssetResponse(
+  context: Context,
+  bytes: Buffer,
+  headers: { cacheControl: string; contentType: string },
+): Promise<Response> {
+  const responseHeaders: Record<string, string> = {
+    "cache-control": headers.cacheControl,
+    "content-length": String(bytes.length),
+    "content-type": headers.contentType,
+  };
+  if (bytes.length < MIN_COMPRESSED_APP_ASSET_BYTES) {
+    return context.body(new Uint8Array(bytes), 200, responseHeaders);
+  }
+
+  responseHeaders.vary = "Accept-Encoding";
+  const candidate = rankAcceptedAssetEncodings(
+    context.req.header("accept-encoding"),
+    APP_ASSET_ENCODINGS,
+  )[0];
+  if (candidate === undefined) {
+    return context.body(new Uint8Array(bytes), 200, responseHeaders);
+  }
+
+  const compressed = await candidate.compress(bytes);
+  responseHeaders["content-encoding"] = candidate.encoding;
+  responseHeaders["content-length"] = String(compressed.length);
+  return context.body(new Uint8Array(compressed), 200, responseHeaders);
+}
 
 function parsePluginMentionTrigger(
   value: string | undefined,
@@ -266,9 +319,9 @@ export function registerPluginRoutes(
       context.req.query("h") === asset.hash
         ? "public, max-age=31536000, immutable"
         : "no-store";
-    return context.body(new Uint8Array(bytes), 200, {
-      "content-type": spec.contentType,
-      "cache-control": cacheControl,
+    return appAssetResponse(context, bytes, {
+      contentType: spec.contentType,
+      cacheControl,
     });
   });
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -134,6 +134,8 @@ const INSTALL_MACHINE_SCRIPT_PATH = fileURLToPath(
 );
 const THREAD_EVENT_WAIT_PATH_PATTERN =
   /^\/api\/v1\/threads\/[^/]+\/events\/wait$/u;
+const PLUGIN_APP_ASSET_PATH_PATTERN =
+  /^\/api\/v1\/plugins\/[^/]+\/assets\/app\.(?:js|css)$/u;
 const PRECOMPRESSED_STATIC_FILES = [
   { encoding: "br", extension: ".br" },
   { encoding: "gzip", extension: ".gz" },
@@ -294,7 +296,16 @@ export function createApp(
       },
     }),
   );
-  app.use("*", compress());
+  const compressResponse = compress();
+  app.use("*", (context, next) => {
+    // Plugin JS/CSS negotiates Brotli and gzip itself and caches immutable
+    // variants. Letting this outer middleware transform an identity fallback
+    // would also ignore explicit q=0 values in Hono's current parser.
+    if (PLUGIN_APP_ASSET_PATH_PATTERN.test(context.req.path)) {
+      return next();
+    }
+    return compressResponse(context, next);
+  });
   app.onError((error) => errorToResponse(error, deps.logger));
   app.get("/health", (context) => context.json({ ok: true }));
   app.get("/install.sh", async (context) => {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -73,6 +73,7 @@ import {
 } from "./services/plugin-catalog/plugin-catalog-service.js";
 import { callHostRetryableOnlineRpc } from "./services/hosts/online-rpc.js";
 import { browserRequestProblem } from "./browser-request-guard.js";
+import { rankAcceptedAssetEncodings } from "./asset-content-encoding.js";
 
 export type CloseWebSockets = () => Promise<void>;
 type NodeWebSocketServer = ReturnType<typeof createNodeWebSocket>["wss"];
@@ -170,36 +171,6 @@ function createStaticResponseHeaders(args: StaticResponseHeadersArgs): Headers {
   return headers;
 }
 
-function acceptedEncodingQuality(
-  acceptEncodingHeader: string | undefined,
-  encoding: string,
-): number {
-  if (acceptEncodingHeader === undefined) {
-    return 0;
-  }
-  let wildcardQuality = 0;
-  for (const part of acceptEncodingHeader.split(",")) {
-    const [rawName, ...rawParams] = part.trim().split(";");
-    const name = rawName?.trim().toLowerCase();
-    const qParam = rawParams
-      .map((param) => param.trim().toLowerCase())
-      .find((param) => param.startsWith("q="));
-    const quality =
-      qParam === undefined
-        ? 1
-        : Number.isNaN(Number(qParam.slice(2)))
-          ? 1
-          : Number(qParam.slice(2));
-    if (name === encoding) {
-      return quality;
-    }
-    if (name === "*") {
-      wildcardQuality = quality;
-    }
-  }
-  return wildcardQuality;
-}
-
 function canServePrecompressedStaticFile(contentType: string): boolean {
   return (
     contentType.startsWith("text/") ||
@@ -225,20 +196,10 @@ async function findPrecompressedStaticFile(args: {
     return null;
   }
 
-  const candidates = PRECOMPRESSED_STATIC_FILES.map((candidate, index) => ({
-    ...candidate,
-    index,
-    quality: acceptedEncodingQuality(
-      args.acceptEncodingHeader,
-      candidate.encoding,
-    ),
-  }))
-    .filter((candidate) => candidate.quality > 0)
-    .sort(
-      (left, right) => right.quality - left.quality || left.index - right.index,
-    );
-
-  for (const candidate of candidates) {
+  for (const candidate of rankAcceptedAssetEncodings(
+    args.acceptEncodingHeader,
+    PRECOMPRESSED_STATIC_FILES,
+  )) {
     const encodedFilePath = `${args.filePath}${candidate.extension}`;
     try {
       const encodedStat = await stat(encodedFilePath);

--- a/apps/server/src/services/plugins/app-asset-compression-cache.ts
+++ b/apps/server/src/services/plugins/app-asset-compression-cache.ts
@@ -1,0 +1,61 @@
+interface CachedAppAssetEncodings {
+  hash: string;
+  variants: Map<string, Promise<Buffer>>;
+}
+
+export interface AppAssetCompressionCache {
+  getOrCreate(args: {
+    assetKey: string;
+    compress: () => Promise<Buffer>;
+    encoding: string;
+    hash: string;
+  }): Promise<Buffer>;
+}
+
+/**
+ * Bounded LRU of encoded plugin asset variants. Promises enter the cache
+ * before compression finishes so parallel requests share one zlib operation;
+ * a changed content hash replaces every variant for that asset.
+ */
+export function createAppAssetCompressionCache(
+  maxEntries: number,
+): AppAssetCompressionCache {
+  const entries = new Map<string, CachedAppAssetEncodings>();
+
+  return {
+    getOrCreate(args) {
+      let entry = entries.get(args.assetKey);
+      if (entry === undefined || entry.hash !== args.hash) {
+        entry = { hash: args.hash, variants: new Map() };
+        entries.set(args.assetKey, entry);
+      } else {
+        // Re-insert to mark this asset as most recently used.
+        entries.delete(args.assetKey);
+        entries.set(args.assetKey, entry);
+      }
+
+      const cached = entry.variants.get(args.encoding);
+      if (cached !== undefined) {
+        return cached;
+      }
+
+      let compression: Promise<Buffer>;
+      compression = args.compress().catch((error: unknown) => {
+        if (entry.variants.get(args.encoding) === compression) {
+          entry.variants.delete(args.encoding);
+        }
+        throw error;
+      });
+      entry.variants.set(args.encoding, compression);
+
+      while (entries.size > maxEntries) {
+        const oldestKey = entries.keys().next().value;
+        if (oldestKey === undefined) {
+          break;
+        }
+        entries.delete(oldestKey);
+      }
+      return compression;
+    },
+  };
+}

--- a/apps/server/test/services/plugins/app-asset-compression-cache.test.ts
+++ b/apps/server/test/services/plugins/app-asset-compression-cache.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { createAppAssetCompressionCache } from "../../../src/services/plugins/app-asset-compression-cache.js";
+
+describe("plugin app asset compression cache", () => {
+  it("deduplicates variants, resets changed hashes, and evicts old assets", async () => {
+    const cache = createAppAssetCompressionCache(1);
+    let compressionCount = 0;
+    const get = (assetKey: string, hash: string, encoding = "br") =>
+      cache.getOrCreate({
+        assetKey,
+        compress: async () => {
+          compressionCount += 1;
+          return Buffer.from(`compressed-${compressionCount}`);
+        },
+        encoding,
+        hash,
+      });
+
+    const [first, concurrent] = await Promise.all([
+      get("plugin:js", "hash-1"),
+      get("plugin:js", "hash-1"),
+    ]);
+    expect(concurrent).toEqual(first);
+    expect(await get("plugin:js", "hash-1")).toEqual(first);
+    expect(compressionCount).toBe(1);
+
+    const gzip = await get("plugin:js", "hash-1", "gzip");
+    expect(gzip).not.toEqual(first);
+    expect(compressionCount).toBe(2);
+
+    const changed = await get("plugin:js", "hash-2");
+    expect(changed).not.toEqual(first);
+    expect(compressionCount).toBe(3);
+
+    await get("other:js", "hash-1");
+    await get("plugin:js", "hash-2");
+    expect(compressionCount).toBe(5);
+  });
+
+  it("retries a failed compression instead of caching its rejection", async () => {
+    const cache = createAppAssetCompressionCache(1);
+    let attempts = 0;
+    const get = () =>
+      cache.getOrCreate({
+        assetKey: "plugin:js",
+        compress: async () => {
+          attempts += 1;
+          if (attempts === 1) {
+            throw new Error("compression failed");
+          }
+          return Buffer.from("compressed");
+        },
+        encoding: "br",
+        hash: "hash-1",
+      });
+
+    await expect(get()).rejects.toThrow("compression failed");
+    await expect(get()).resolves.toEqual(Buffer.from("compressed"));
+    expect(attempts).toBe(2);
+  });
+});

--- a/apps/server/test/services/plugins/plugin-app-bundle.test.ts
+++ b/apps/server/test/services/plugins/plugin-app-bundle.test.ts
@@ -5,6 +5,7 @@ import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
 import type { AddressInfo } from "node:net";
 import { join } from "node:path";
 import { promisify } from "node:util";
+import { brotliDecompressSync, gunzipSync } from "node:zlib";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { upsertInstalledPlugin } from "@bb/db";
 import { PLUGIN_SDK_MAJOR, PLUGIN_SDK_VERSION } from "@bb/domain";
@@ -59,6 +60,9 @@ const SERVER_SOURCE = `export default function plugin(bb: any) { bb.log.info("lo
 // Minimal real frontend entry: the automatic JSX transform exercises the
 // react/jsx-runtime shim, and the utility class exercises the Tailwind pass.
 const APP_SOURCE = `export default function App() {\n  return <div className="line-clamp-2">hi</div>;\n}\n`;
+const COMPRESSIBLE_APP_SOURCE = `const payload = ${JSON.stringify(
+  "compressible plugin bundle payload ".repeat(200),
+)};\nexport default function App() {\n  return <div className="line-clamp-2" data-payload={payload}>hi</div>;\n}\n`;
 
 async function writeAppPluginFixture(
   rootDir: string,
@@ -107,7 +111,10 @@ describe("plugin app bundles (build policy, inventory, asset routes)", () => {
 
   it("builds path installs at install time and serves hash-cached assets", async () => {
     const rootDir = join(harness.config.dataDir, "fixtures", "bb-plugin-appy");
-    await writeAppPluginFixture(rootDir, { name: "bb-plugin-appy" });
+    await writeAppPluginFixture(rootDir, {
+      name: "bb-plugin-appy",
+      appSource: COMPRESSIBLE_APP_SOURCE,
+    });
 
     const entry = await harness.pluginService.installPath(rootDir);
     expect(entry.status).toBe("running");
@@ -135,7 +142,41 @@ describe("plugin app bundles (build policy, inventory, asset routes)", () => {
     expect(js.headers.get("cache-control")).toBe(
       "public, max-age=31536000, immutable",
     );
-    expect(await js.text()).toContain("__bbPluginRuntime");
+    const jsText = await js.text();
+    expect(jsText).toContain("__bbPluginRuntime");
+    expect(js.headers.get("content-encoding")).toBeNull();
+    expect(js.headers.get("content-length")).toBe(
+      String(Buffer.byteLength(jsText)),
+    );
+
+    const brotliJs = await harness.app.request(`${BASE}${bundle.jsUrl}`, {
+      headers: { "accept-encoding": "br, gzip" },
+    });
+    expect(brotliJs.headers.get("content-encoding")).toBe("br");
+    expect(
+      brotliJs.headers
+        .get("vary")
+        ?.split(",")
+        .map((value) => value.trim()),
+    ).toContain("Accept-Encoding");
+    expect(brotliJs.headers.get("cache-control")).toBe(
+      "public, max-age=31536000, immutable",
+    );
+    const brotliJsBytes = Buffer.from(await brotliJs.arrayBuffer());
+    expect(brotliJsBytes.length).toBeLessThan(Buffer.byteLength(jsText));
+    expect(brotliDecompressSync(brotliJsBytes).toString()).toBe(jsText);
+
+    // HEAD carries the representation headers a GET would have returned,
+    // without transferring the compressed body.
+    const brotliJsHead = await harness.app.request(`${BASE}${bundle.jsUrl}`, {
+      method: "HEAD",
+      headers: { "accept-encoding": "br, gzip" },
+    });
+    expect(brotliJsHead.headers.get("content-encoding")).toBe("br");
+    expect(brotliJsHead.headers.get("content-length")).toBe(
+      String(brotliJsBytes.length),
+    );
+    expect((await brotliJsHead.arrayBuffer()).byteLength).toBe(0);
 
     const css = await harness.app.request(`${BASE}${bundle.cssUrl}`);
     expect(css.status).toBe(200);
@@ -157,6 +198,14 @@ describe("plugin app bundles (build policy, inventory, asset routes)", () => {
     );
     // And no utility rule sits in the utilities layer outside that scope.
     expect(cssText).not.toMatch(/@layer utilities \{\s*\./);
+
+    const gzipCss = await harness.app.request(`${BASE}${bundle.cssUrl}`, {
+      headers: { "accept-encoding": "br;q=0, gzip;q=1" },
+    });
+    expect(gzipCss.headers.get("content-encoding")).toBe("gzip");
+    const gzipCssBytes = Buffer.from(await gzipCss.arrayBuffer());
+    expect(gzipCssBytes.length).toBeLessThan(Buffer.byteLength(cssText));
+    expect(gunzipSync(gzipCssBytes).toString()).toBe(cssText);
 
     // Wrong/absent hash still serves current bytes, but uncached.
     const staleHash = await harness.app.request(

--- a/apps/server/test/services/plugins/plugin-app-bundle.test.ts
+++ b/apps/server/test/services/plugins/plugin-app-bundle.test.ts
@@ -166,6 +166,13 @@ describe("plugin app bundles (build policy, inventory, asset routes)", () => {
     expect(brotliJsBytes.length).toBeLessThan(Buffer.byteLength(jsText));
     expect(brotliDecompressSync(brotliJsBytes).toString()).toBe(jsText);
 
+    const rejectedCompression = await harness.app.request(
+      `${BASE}${bundle.jsUrl}`,
+      { headers: { "accept-encoding": "br;q=0, gzip;q=0" } },
+    );
+    expect(rejectedCompression.headers.get("content-encoding")).toBeNull();
+    expect(await rejectedCompression.text()).toBe(jsText);
+
     // HEAD carries the representation headers a GET would have returned,
     // without transferring the compressed body.
     const brotliJsHead = await harness.app.request(`${BASE}${bundle.jsUrl}`, {


### PR DESCRIPTION
## Summary

- explicitly negotiate Brotli and gzip for plugin app.js and app.css responses
- preserve immutable/no-store caching while adding Vary, Content-Encoding, and exact Content-Length headers
- cache compressed variants in a bounded per-asset LRU and deduplicate concurrent compression work
- share Accept-Encoding quality ranking with the core static asset path
- cover Brotli JavaScript, gzip CSS, rejected encodings, decompressed body integrity, HEAD/GET header parity, and cache lifecycle behavior

## Investigation

The issue reproduction uses curl -I, which sends HEAD. Hono's global compression middleware intentionally skips HEAD, explaining the missing header there. A real GET on current main is gzip-compressed, but unlike core hashed assets it cannot negotiate Brotli.

This change owns compression explicitly at the plugin asset-serving boundary. That closes the real transfer-size gap and also makes HEAD advertise the same representation headers as GET. Plugin app asset paths bypass the outer Hono compression middleware so explicitly rejected encodings remain rejected.

## Validation

- pnpm exec turbo run typecheck --filter=@bb/server
- focused plugin/static asset tests: 16 passed
- full server suite: 159 files, 1,393 tests passed
- Prettier and git diff checks passed

Fixes #1092