### PR TITLE
Avoid full keyboard settings row rerenders

### DIFF
--- a/apps/app/src/components/settings/KeyboardSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/KeyboardSettingsSection.test.tsx
@@ -363,23 +363,36 @@ describe("KeyboardSettingsSection", () => {
     rerender(<KeyboardSettingsSection />);
     expect(testState.metadataCalls.size).toBe(0);
 
+    testState.metadataCalls.clear();
+    testState.recorderButtonCalls.clear();
     testState.keyboardPending = true;
     rerender(<KeyboardSettingsSection />);
-    expect(testState.metadataCalls.size).toBe(0);
+    expect([...testState.metadataCalls.keys()]).toEqual(["thread.new"]);
+    expect(testState.recorderButtonCalls.size).toBe(0);
     expect(recorder.matches(":disabled")).toBe(true);
     expect(recorder.hasAttribute("disabled")).toBe(false);
+    expect(recorder.closest('[aria-busy="true"]')?.className).toContain(
+      "opacity-50",
+    );
+    expect(
+      screen
+        .getByRole("button", { name: /^Record shortcut for Search threads/u })
+        .closest('[aria-busy="true"]'),
+    ).toBeNull();
     expect(recorder.closest("fieldset")?.className).toContain(
       "[&:disabled_button:not([disabled])]:opacity-100",
     );
 
+    testState.metadataCalls.clear();
     testState.keyboardPending = false;
     testState.keybindingOverrides = structuredClone(assignedOverrides);
     testState.defaultKeybindings = structuredClone(
       testState.defaultKeybindings,
     );
     rerender(<KeyboardSettingsSection />);
-    expect(testState.metadataCalls.size).toBe(0);
+    expect([...testState.metadataCalls.keys()]).toEqual(["thread.new"]);
     expect(recorder.matches(":disabled")).toBe(false);
+    expect(recorder.closest('[aria-busy="true"]')).toBeNull();
     expect(recorder.closest("fieldset")?.className).not.toContain(
       "[&:disabled_button:not([disabled])]:opacity-100",
     );

--- a/apps/app/src/components/settings/KeyboardSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/KeyboardSettingsSection.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -8,11 +9,16 @@ import {
   within,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { defaultAppSettings, type AppDefaultKeybindings } from "@bb/domain";
+import {
+  defaultAppSettings,
+  type AppCommandId,
+  type AppDefaultKeybindings,
+  type AppKeybindingOverrides,
+} from "@bb/domain";
 import { KeyboardSettingsSection } from "./KeyboardSettingsSection";
 
-const testState = vi.hoisted(() => ({
-  defaultKeybindings: [
+const testState = vi.hoisted(() => {
+  const defaultKeybindings = [
     {
       command: "thread.new",
       desktopOnly: false,
@@ -112,18 +118,31 @@ const testState = vi.hoisted(() => ({
         none: ["modalOpen", "editableFocus"],
       },
     },
-  ] as AppDefaultKeybindings,
-  generalMutate: vi.fn(),
-  isDesktop: false,
-  mutate: vi.fn(),
-}));
+  ] as AppDefaultKeybindings;
+  return {
+    defaultKeybindings,
+    generalMutate: vi.fn(),
+    initialDefaultKeybindings: defaultKeybindings,
+    isDesktop: false,
+    keybindingOverrides: [] as AppKeybindingOverrides,
+    keyboardPending: false,
+    metadataCalls: new Map<AppCommandId, number>(),
+    mutate:
+      vi.fn<
+        (
+          overrides: AppKeybindingOverrides,
+          options: { onError(): void },
+        ) => void
+      >(),
+  };
+});
 
 vi.mock("@/hooks/queries/system-queries", () => ({
   useSystemConfig: () => ({
     data: {
       defaultKeybindings: testState.defaultKeybindings,
       generalSettings: defaultAppSettings,
-      keybindingOverrides: [],
+      keybindingOverrides: testState.keybindingOverrides,
     },
   }),
 }));
@@ -134,10 +153,27 @@ vi.mock("@/hooks/mutations/settings-mutations", () => ({
     mutate: testState.generalMutate,
   }),
   useUpdateKeyboardSettings: () => ({
-    isPending: false,
+    isPending: testState.keyboardPending,
     mutate: testState.mutate,
   }),
 }));
+
+vi.mock("@/lib/app-command-metadata", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/app-command-metadata")>();
+  return {
+    ...actual,
+    // Each row reads its metadata while rendering, making this a focused
+    // render probe without adding test-only props to the production component.
+    getAppCommandMetadata: (command: AppCommandId) => {
+      testState.metadataCalls.set(
+        command,
+        (testState.metadataCalls.get(command) ?? 0) + 1,
+      );
+      return actual.getAppCommandMetadata(command);
+    },
+  };
+});
 
 vi.mock("@/lib/bb-desktop", () => ({
   getBbDesktopInfo: () => (testState.isDesktop ? {} : null),
@@ -147,7 +183,11 @@ afterEach(() => {
   cleanup();
   vi.clearAllMocks();
   vi.restoreAllMocks();
+  testState.defaultKeybindings = testState.initialDefaultKeybindings;
   testState.isDesktop = false;
+  testState.keybindingOverrides = [];
+  testState.keyboardPending = false;
+  testState.metadataCalls.clear();
 });
 
 describe("KeyboardSettingsSection", () => {
@@ -265,6 +305,135 @@ describe("KeyboardSettingsSection", () => {
       ],
       expect.objectContaining({ onError: expect.any(Function) }),
     );
+  });
+
+  it("renders only rows whose presentation changes during a settings transaction", () => {
+    const { rerender } = render(<KeyboardSettingsSection />);
+    const recorder = screen.getByRole("button", {
+      name: "Record shortcut for New thread, current shortcut Ctrl + Shift + O",
+    });
+
+    testState.metadataCalls.clear();
+    fireEvent.click(recorder);
+    expect(testState.metadataCalls.get("thread.new")).toBeGreaterThan(0);
+    expect(testState.metadataCalls.has("thread.jump.1")).toBe(false);
+
+    testState.metadataCalls.clear();
+    fireEvent.keyDown(recorder, {
+      key: "U",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+    expect(testState.metadataCalls.get("thread.new")).toBeGreaterThan(0);
+    expect(testState.metadataCalls.has("thread.jump.1")).toBe(false);
+
+    const assignedOverrides = testState.mutate.mock.lastCall?.[0];
+    if (assignedOverrides === undefined) {
+      throw new Error("Expected shortcut assignment mutation");
+    }
+
+    testState.metadataCalls.clear();
+    testState.keybindingOverrides = structuredClone(assignedOverrides);
+    testState.defaultKeybindings = structuredClone(
+      testState.defaultKeybindings,
+    );
+    rerender(<KeyboardSettingsSection />);
+    expect(testState.metadataCalls.size).toBe(0);
+
+    testState.keyboardPending = true;
+    rerender(<KeyboardSettingsSection />);
+    expect(testState.metadataCalls.size).toBe(0);
+    expect(recorder.matches(":disabled")).toBe(true);
+
+    testState.keyboardPending = false;
+    testState.keybindingOverrides = structuredClone(assignedOverrides);
+    testState.defaultKeybindings = structuredClone(
+      testState.defaultKeybindings,
+    );
+    rerender(<KeyboardSettingsSection />);
+    expect(testState.metadataCalls.size).toBe(0);
+    expect(recorder.matches(":disabled")).toBe(false);
+
+    testState.metadataCalls.clear();
+    testState.keybindingOverrides = [
+      ...assignedOverrides,
+      {
+        command: "thread.jump.1",
+        shortcut: {
+          key: "2",
+          mod: true,
+          meta: false,
+          control: false,
+          alt: false,
+          shift: true,
+        },
+      },
+    ];
+    rerender(<KeyboardSettingsSection />);
+    expect([...testState.metadataCalls.keys()]).toEqual(["thread.jump.1"]);
+    expect(
+      screen.getByRole("button", {
+        name: "Record shortcut for Open thread 1, current shortcut Ctrl + Shift + 2",
+      }),
+    ).toBeDefined();
+  });
+
+  it("updates conflict warnings on another customized row", () => {
+    render(<KeyboardSettingsSection />);
+    const newThreadRecorder = screen.getByRole("button", {
+      name: "Record shortcut for New thread, current shortcut Ctrl + Shift + O",
+    });
+    fireEvent.click(newThreadRecorder);
+    fireEvent.keyDown(newThreadRecorder, {
+      key: "U",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    const jumpRecorder = screen.getByRole("button", {
+      name: "Record shortcut for Open thread 1, current shortcut Ctrl + Shift + 1",
+    });
+    fireEvent.click(jumpRecorder);
+    fireEvent.keyDown(jumpRecorder, {
+      key: "U",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    expect(screen.getByText(/Also used by Open thread 1\./u)).toBeDefined();
+    expect(screen.getByText(/Also used by New thread\./u)).toBeDefined();
+    expect(testState.mutate.mock.lastCall?.[0]).toHaveLength(2);
+  });
+
+  it("rolls reset-all draft state back when the mutation fails", () => {
+    render(<KeyboardSettingsSection />);
+    const recorder = screen.getByRole("button", {
+      name: "Record shortcut for New thread, current shortcut Ctrl + Shift + O",
+    });
+    fireEvent.click(recorder);
+    fireEvent.keyDown(recorder, {
+      key: "U",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset all" }));
+    expect(testState.mutate.mock.lastCall?.[0]).toEqual([]);
+    expect(
+      screen.getByRole("button", {
+        name: "Record shortcut for New thread, current shortcut Ctrl + Shift + O",
+      }),
+    ).toBeDefined();
+
+    const rollback = testState.mutate.mock.lastCall?.[1].onError;
+    if (rollback === undefined) throw new Error("Expected rollback handler");
+    act(() => rollback());
+
+    expect(
+      screen.getByRole("button", {
+        name: "Record shortcut for New thread, current shortcut Ctrl + Shift + U",
+      }),
+    ).toBeDefined();
   });
 
   it("shows web and desktop defaults without OS-specific groups", () => {

--- a/apps/app/src/components/settings/KeyboardSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/KeyboardSettingsSection.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 
+import { createElement, type ComponentProps } from "react";
 import {
   act,
   cleanup,
@@ -127,6 +128,7 @@ const testState = vi.hoisted(() => {
     keybindingOverrides: [] as AppKeybindingOverrides,
     keyboardPending: false,
     metadataCalls: new Map<AppCommandId, number>(),
+    recorderButtonCalls: new Map<string, number>(),
     mutate:
       vi.fn<
         (
@@ -158,6 +160,26 @@ vi.mock("@/hooks/mutations/settings-mutations", () => ({
   }),
 }));
 
+vi.mock("@bb/shared-ui/button", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@bb/shared-ui/button")>();
+  return {
+    ...actual,
+    Button: (props: ComponentProps<typeof actual.Button>) => {
+      const label = props["aria-label"];
+      if (
+        typeof label === "string" &&
+        label.startsWith("Record shortcut for ")
+      ) {
+        testState.recorderButtonCalls.set(
+          label,
+          (testState.recorderButtonCalls.get(label) ?? 0) + 1,
+        );
+      }
+      return createElement(actual.Button, props);
+    },
+  };
+});
+
 vi.mock("@/lib/app-command-metadata", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("@/lib/app-command-metadata")>();
@@ -188,6 +210,7 @@ afterEach(() => {
   testState.keybindingOverrides = [];
   testState.keyboardPending = false;
   testState.metadataCalls.clear();
+  testState.recorderButtonCalls.clear();
 });
 
 describe("KeyboardSettingsSection", () => {
@@ -394,6 +417,7 @@ describe("KeyboardSettingsSection", () => {
       name: "Record shortcut for Open thread 1, current shortcut Ctrl + Shift + 1",
     });
     fireEvent.click(jumpRecorder);
+    testState.recorderButtonCalls.clear();
     fireEvent.keyDown(jumpRecorder, {
       key: "U",
       ctrlKey: true,
@@ -403,6 +427,16 @@ describe("KeyboardSettingsSection", () => {
     expect(screen.getByText(/Also used by Open thread 1\./u)).toBeDefined();
     expect(screen.getByText(/Also used by New thread\./u)).toBeDefined();
     expect(testState.mutate.mock.lastCall?.[0]).toHaveLength(2);
+    expect(
+      [...testState.recorderButtonCalls.keys()].filter((label) =>
+        label.includes("New thread"),
+      ),
+    ).toEqual([]);
+    expect(
+      [...testState.recorderButtonCalls.keys()].filter((label) =>
+        label.includes("Open thread 1"),
+      ),
+    ).toHaveLength(1);
   });
 
   it("rolls reset-all draft state back when the mutation fails", () => {

--- a/apps/app/src/components/settings/KeyboardSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/KeyboardSettingsSection.test.tsx
@@ -367,6 +367,10 @@ describe("KeyboardSettingsSection", () => {
     rerender(<KeyboardSettingsSection />);
     expect(testState.metadataCalls.size).toBe(0);
     expect(recorder.matches(":disabled")).toBe(true);
+    expect(recorder.hasAttribute("disabled")).toBe(false);
+    expect(recorder.closest("fieldset")?.className).toContain(
+      "[&:disabled_button:not([disabled])]:opacity-100",
+    );
 
     testState.keyboardPending = false;
     testState.keybindingOverrides = structuredClone(assignedOverrides);
@@ -376,6 +380,9 @@ describe("KeyboardSettingsSection", () => {
     rerender(<KeyboardSettingsSection />);
     expect(testState.metadataCalls.size).toBe(0);
     expect(recorder.matches(":disabled")).toBe(false);
+    expect(recorder.closest("fieldset")?.className).not.toContain(
+      "[&:disabled_button:not([disabled])]:opacity-100",
+    );
 
     testState.metadataCalls.clear();
     testState.keybindingOverrides = [

--- a/apps/app/src/components/settings/KeyboardSettingsSection.tsx
+++ b/apps/app/src/components/settings/KeyboardSettingsSection.tsx
@@ -619,7 +619,13 @@ export function KeyboardSettingsSection() {
         />
         {/* Native disabled propagation keeps pending state out of every row. */}
         <fieldset
-          className="m-0 min-w-0 space-y-5 border-0 p-0"
+          className={cn(
+            "m-0 min-w-0 space-y-5 border-0 p-0",
+            // Preserve the interaction lock without visually flashing every
+            // otherwise-enabled row while a shortcut mutation is pending.
+            isKeyboardSettingsPending &&
+              "[&:disabled_button:not([disabled])]:opacity-100",
+          )}
           disabled={disabled}
         >
           {visibleGroups.map((group) => (

--- a/apps/app/src/components/settings/KeyboardSettingsSection.tsx
+++ b/apps/app/src/components/settings/KeyboardSettingsSection.tsx
@@ -1,4 +1,12 @@
-import { useMemo, useState, type KeyboardEvent } from "react";
+import {
+  memo,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
 import {
   defaultAppSettings,
   type AppCommandId,
@@ -161,31 +169,42 @@ function ShortcutRecorder({
 }
 
 interface KeyboardCommandRowProps {
-  command: AppCommandId;
-  defaults: AppDefaultKeybindings;
-  disabled: boolean;
-  isDesktop: boolean;
+  model: KeyboardCommandRowModel;
   onChange(command: AppCommandId, shortcut: AppShortcut | null): void;
   onReset(command: AppCommandId): void;
   onRecordingChange(command: AppCommandId | null): void;
+  platform: string;
+  recording: boolean;
+}
+
+interface KeyboardCommandRowModel {
+  // Keep every value read while rendering a row in this model so the memo
+  // comparison can safely ignore whole-config identity churn.
+  availableOnClient: boolean;
+  command: AppCommandId;
+  conflicts: readonly AppCommandId[];
+  customized: boolean;
+  desktopDefaultShortcut: AppShortcut | null;
+  desktopOnly: boolean;
+  shortcut: AppShortcut | null;
+  webDefaultShortcut: AppShortcut | null;
+}
+
+interface BuildKeyboardCommandRowModelArgs {
+  command: AppCommandId;
+  defaults: AppDefaultKeybindings;
+  isDesktop: boolean;
   overrides: AppKeybindingOverrides;
-  recordingCommand: AppCommandId | null;
   platform: string;
 }
 
-function KeyboardCommandRow({
+function buildKeyboardCommandRowModel({
   command,
   defaults,
-  disabled,
   isDesktop,
-  onChange,
-  onReset,
-  onRecordingChange,
   overrides,
   platform,
-  recordingCommand,
-}: KeyboardCommandRowProps) {
-  const metadata = getAppCommandMetadata(command);
+}: BuildKeyboardCommandRowModelArgs): KeyboardCommandRowModel {
   const shortcut = getCommandShortcut(
     defaults,
     overrides,
@@ -217,19 +236,6 @@ function KeyboardCommandRow({
     isDesktop,
     platform,
   );
-  const splitDefaults =
-    webDefaultShortcut !== null &&
-    desktopDefaultShortcut !== null &&
-    !areAppShortcutsEqual(webDefaultShortcut, desktopDefaultShortcut)
-      ? [
-          { label: "Web", shortcut: webDefaultShortcut },
-          { label: "Desktop", shortcut: desktopDefaultShortcut },
-        ]
-      : null;
-  const sharedDefaultShortcut =
-    splitDefaults === null
-      ? (webDefaultShortcut ?? desktopDefaultShortcut)
-      : null;
   const desktopOnly =
     commandBindings.length > 0 &&
     commandBindings.every((binding) => binding.desktopOnly);
@@ -237,100 +243,202 @@ function KeyboardCommandRow({
     ? getShortcutConflicts(defaults, overrides, command, isDesktop, platform)
     : [];
 
+  return {
+    availableOnClient,
+    command,
+    conflicts,
+    customized,
+    desktopDefaultShortcut,
+    desktopOnly,
+    shortcut,
+    webDefaultShortcut,
+  };
+}
+
+function areNullableAppShortcutsEqual(
+  left: AppShortcut | null,
+  right: AppShortcut | null,
+): boolean {
   return (
-    <div className="flex flex-col gap-2 py-3 first:pt-0 last:pb-0 sm:flex-row sm:items-center sm:gap-5">
-      <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-center gap-1.5">
-          <p className="text-sm text-foreground">{metadata.label}</p>
-          {desktopOnly ? <SettingsBadge>Desktop</SettingsBadge> : null}
-          {customized ? <SettingsBadge>Custom</SettingsBadge> : null}
-        </div>
-        <p className="mt-0.5 text-xs leading-snug text-subtle-foreground/75">
-          {metadata.description}
-        </p>
-        {splitDefaults !== null || sharedDefaultShortcut !== null ? (
-          <div
-            aria-label={`${splitDefaults === null ? "Default shortcut" : "Default shortcuts"} for ${metadata.label}`}
-            className="mt-1.5 flex flex-wrap items-center gap-1.5"
-          >
-            <span className="text-xs text-subtle-foreground/75">
-              {splitDefaults === null ? "Default:" : "Defaults:"}
-            </span>
-            {sharedDefaultShortcut !== null ? (
-              <AppCommandShortcutPill
-                ariaHidden={false}
-                className={SETTINGS_DEFAULT_SHORTCUT_CLASS}
-                shortcut={presentShortcut(sharedDefaultShortcut, platform)}
-              />
-            ) : (
-              splitDefaults?.map((entry) => (
-                <span
-                  className="inline-flex items-stretch overflow-hidden rounded border border-border text-foreground"
-                  key={entry.label}
-                >
-                  <span className="inline-flex items-center bg-muted/40 px-1.5 text-2xs leading-none text-subtle-foreground">
-                    {entry.label}
-                  </span>
-                  <AppCommandShortcutPill
-                    ariaHidden={false}
-                    className={SETTINGS_SEGMENTED_DEFAULT_SHORTCUT_CLASS}
-                    shortcut={presentShortcut(entry.shortcut, platform)}
-                  />
-                </span>
-              ))
-            )}
-          </div>
-        ) : null}
-        {conflicts.length > 0 ? (
-          <p className="mt-1 text-xs text-warning-text">
-            Also used by{" "}
-            {conflicts
-              .map((candidate) => getAppCommandMetadata(candidate).label)
-              .join(", ")}
-            . Context determines which command runs.
-          </p>
-        ) : null}
-      </div>
-      <div className="flex shrink-0 items-start justify-end gap-1">
-        <ShortcutRecorder
-          command={command}
-          disabled={disabled || !availableOnClient}
-          onChange={(next) => onChange(command, next)}
-          onRecordingChange={onRecordingChange}
-          recording={recordingCommand === command}
-          shortcut={shortcut}
-        />
-        <Button
-          aria-label={`Clear shortcut for ${metadata.label}`}
-          className="size-7"
-          disabled={disabled || !availableOnClient || shortcut === null}
-          onClick={() => onChange(command, null)}
-          size="icon"
-          type="button"
-          variant="ghost"
-        >
-          <Icon name="X" className="size-3.5" />
-        </Button>
-        <Button
-          aria-label={`Reset shortcut for ${metadata.label}`}
-          className="size-7"
-          disabled={disabled || !availableOnClient || !customized}
-          onClick={() => onReset(command)}
-          size="icon"
-          type="button"
-          variant="ghost"
-        >
-          <Icon name="RotateCcw" className="size-3.5" />
-        </Button>
-      </div>
-    </div>
+    left === right ||
+    (left !== null && right !== null && areAppShortcutsEqual(left, right))
   );
 }
+
+function areCommandListsEqual(
+  left: readonly AppCommandId[],
+  right: readonly AppCommandId[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((command, index) => command === right[index])
+  );
+}
+
+function areKeyboardCommandRowModelsEqual(
+  left: KeyboardCommandRowModel,
+  right: KeyboardCommandRowModel,
+): boolean {
+  return (
+    left.command === right.command &&
+    left.availableOnClient === right.availableOnClient &&
+    left.customized === right.customized &&
+    left.desktopOnly === right.desktopOnly &&
+    areNullableAppShortcutsEqual(left.shortcut, right.shortcut) &&
+    areNullableAppShortcutsEqual(
+      left.webDefaultShortcut,
+      right.webDefaultShortcut,
+    ) &&
+    areNullableAppShortcutsEqual(
+      left.desktopDefaultShortcut,
+      right.desktopDefaultShortcut,
+    ) &&
+    areCommandListsEqual(left.conflicts, right.conflicts)
+  );
+}
+
+const KeyboardCommandRow = memo(
+  function KeyboardCommandRow({
+    model,
+    onChange,
+    onReset,
+    onRecordingChange,
+    platform,
+    recording,
+  }: KeyboardCommandRowProps) {
+    const {
+      availableOnClient,
+      command,
+      conflicts,
+      customized,
+      desktopDefaultShortcut,
+      desktopOnly,
+      shortcut,
+      webDefaultShortcut,
+    } = model;
+    const metadata = getAppCommandMetadata(command);
+    const splitDefaults =
+      webDefaultShortcut !== null &&
+      desktopDefaultShortcut !== null &&
+      !areAppShortcutsEqual(webDefaultShortcut, desktopDefaultShortcut)
+        ? [
+            { label: "Web", shortcut: webDefaultShortcut },
+            { label: "Desktop", shortcut: desktopDefaultShortcut },
+          ]
+        : null;
+    const sharedDefaultShortcut =
+      splitDefaults === null
+        ? (webDefaultShortcut ?? desktopDefaultShortcut)
+        : null;
+
+    return (
+      <div className="flex flex-col gap-2 py-3 first:pt-0 last:pb-0 sm:flex-row sm:items-center sm:gap-5">
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <p className="text-sm text-foreground">{metadata.label}</p>
+            {desktopOnly ? <SettingsBadge>Desktop</SettingsBadge> : null}
+            {customized ? <SettingsBadge>Custom</SettingsBadge> : null}
+          </div>
+          <p className="mt-0.5 text-xs leading-snug text-subtle-foreground/75">
+            {metadata.description}
+          </p>
+          {splitDefaults !== null || sharedDefaultShortcut !== null ? (
+            <div
+              aria-label={`${splitDefaults === null ? "Default shortcut" : "Default shortcuts"} for ${metadata.label}`}
+              className="mt-1.5 flex flex-wrap items-center gap-1.5"
+            >
+              <span className="text-xs text-subtle-foreground/75">
+                {splitDefaults === null ? "Default:" : "Defaults:"}
+              </span>
+              {sharedDefaultShortcut !== null ? (
+                <AppCommandShortcutPill
+                  ariaHidden={false}
+                  className={SETTINGS_DEFAULT_SHORTCUT_CLASS}
+                  shortcut={presentShortcut(sharedDefaultShortcut, platform)}
+                />
+              ) : (
+                splitDefaults?.map((entry) => (
+                  <span
+                    className="inline-flex items-stretch overflow-hidden rounded border border-border text-foreground"
+                    key={entry.label}
+                  >
+                    <span className="inline-flex items-center bg-muted/40 px-1.5 text-2xs leading-none text-subtle-foreground">
+                      {entry.label}
+                    </span>
+                    <AppCommandShortcutPill
+                      ariaHidden={false}
+                      className={SETTINGS_SEGMENTED_DEFAULT_SHORTCUT_CLASS}
+                      shortcut={presentShortcut(entry.shortcut, platform)}
+                    />
+                  </span>
+                ))
+              )}
+            </div>
+          ) : null}
+          {conflicts.length > 0 ? (
+            <p className="mt-1 text-xs text-warning-text">
+              Also used by{" "}
+              {conflicts
+                .map((candidate) => getAppCommandMetadata(candidate).label)
+                .join(", ")}
+              . Context determines which command runs.
+            </p>
+          ) : null}
+        </div>
+        <div className="flex shrink-0 items-start justify-end gap-1">
+          <ShortcutRecorder
+            command={command}
+            disabled={!availableOnClient}
+            onChange={(next) => onChange(command, next)}
+            onRecordingChange={onRecordingChange}
+            recording={recording}
+            shortcut={shortcut}
+          />
+          <Button
+            aria-label={`Clear shortcut for ${metadata.label}`}
+            className="size-7"
+            disabled={!availableOnClient || shortcut === null}
+            onClick={() => onChange(command, null)}
+            size="icon"
+            type="button"
+            variant="ghost"
+          >
+            <Icon name="X" className="size-3.5" />
+          </Button>
+          <Button
+            aria-label={`Reset shortcut for ${metadata.label}`}
+            className="size-7"
+            disabled={!availableOnClient || !customized}
+            onClick={() => onReset(command)}
+            size="icon"
+            type="button"
+            variant="ghost"
+          >
+            <Icon name="RotateCcw" className="size-3.5" />
+          </Button>
+        </div>
+      </div>
+    );
+  },
+  function areKeyboardCommandRowPropsEqual(left, right) {
+    return (
+      left.onChange === right.onChange &&
+      left.onReset === right.onReset &&
+      left.onRecordingChange === right.onRecordingChange &&
+      left.platform === right.platform &&
+      left.recording === right.recording &&
+      areKeyboardCommandRowModelsEqual(left.model, right.model)
+    );
+  },
+);
 
 export function KeyboardSettingsSection() {
   const systemConfig = useSystemConfig();
   const updateGeneralSettings = useUpdateGeneralSettings();
-  const updateKeyboardSettings = useUpdateKeyboardSettings();
+  const {
+    isPending: isKeyboardSettingsPending,
+    mutate: mutateKeyboardSettings,
+  } = useUpdateKeyboardSettings();
   const isDesktop = getBbDesktopInfo() !== null;
   const platform = browserPlatform();
   const generalSettings =
@@ -350,6 +458,28 @@ export function KeyboardSettingsSection() {
   );
   const [search, setSearch] = useState("");
 
+  const commandRowModels = useMemo(
+    () =>
+      new Map(
+        APP_COMMAND_GROUPS.flatMap((group) =>
+          group.commands.map(
+            ({ command }) =>
+              [
+                command,
+                buildKeyboardCommandRowModel({
+                  command,
+                  defaults,
+                  isDesktop,
+                  overrides,
+                  platform,
+                }),
+              ] as const,
+          ),
+        ),
+      ),
+    [defaults, isDesktop, overrides, platform],
+  );
+
   const visibleGroups = useMemo(() => {
     const query = search.trim().toLowerCase();
     if (query.length === 0) return APP_COMMAND_GROUPS;
@@ -364,35 +494,67 @@ export function KeyboardSettingsSection() {
     });
   }, [search]);
 
-  function updateCommand(command: AppCommandId, shortcut: AppShortcut | null) {
-    const previous = overrides;
-    const next = setCommandShortcutOverride(
+  const latestSettingsRef = useRef({
+    defaults,
+    isDesktop,
+    overrides,
+    platform,
+    serverOverridesKey,
+  });
+  // The stable row dispatcher must read the latest committed draft while
+  // preserving one shared mutation owner for serialized writes and rollback.
+  useLayoutEffect(() => {
+    latestSettingsRef.current = {
       defaults,
-      overrides,
-      command,
-      shortcut,
       isDesktop,
+      overrides,
       platform,
-    );
-    setDraft({ sourceKey: serverOverridesKey, value: next });
-    updateKeyboardSettings.mutate(next, {
-      onError: () =>
-        setDraft({ sourceKey: serverOverridesKey, value: previous }),
-    });
-  }
+      serverOverridesKey,
+    };
+  }, [defaults, isDesktop, overrides, platform, serverOverridesKey]);
 
-  function resetCommand(command: AppCommandId) {
-    const previous = overrides;
-    const next = resetCommandShortcutOverride(overrides, command);
-    setDraft({ sourceKey: serverOverridesKey, value: next });
-    updateKeyboardSettings.mutate(next, {
-      onError: () =>
-        setDraft({ sourceKey: serverOverridesKey, value: previous }),
-    });
-  }
+  const updateCommand = useCallback(
+    (command: AppCommandId, shortcut: AppShortcut | null) => {
+      const current = latestSettingsRef.current;
+      const previous = current.overrides;
+      const next = setCommandShortcutOverride(
+        current.defaults,
+        current.overrides,
+        command,
+        shortcut,
+        current.isDesktop,
+        current.platform,
+      );
+      setDraft({ sourceKey: current.serverOverridesKey, value: next });
+      mutateKeyboardSettings(next, {
+        onError: () =>
+          setDraft({
+            sourceKey: current.serverOverridesKey,
+            value: previous,
+          }),
+      });
+    },
+    [mutateKeyboardSettings],
+  );
 
-  const disabled =
-    systemConfig.data === undefined || updateKeyboardSettings.isPending;
+  const resetCommand = useCallback(
+    (command: AppCommandId) => {
+      const current = latestSettingsRef.current;
+      const previous = current.overrides;
+      const next = resetCommandShortcutOverride(current.overrides, command);
+      setDraft({ sourceKey: current.serverOverridesKey, value: next });
+      mutateKeyboardSettings(next, {
+        onError: () =>
+          setDraft({
+            sourceKey: current.serverOverridesKey,
+            value: previous,
+          }),
+      });
+    },
+    [mutateKeyboardSettings],
+  );
+
+  const disabled = systemConfig.data === undefined || isKeyboardSettingsPending;
   const hasOverrides = overrides.length > 0;
 
   return (
@@ -403,7 +565,7 @@ export function KeyboardSettingsSection() {
           onClick={() => {
             const previous = overrides;
             setDraft({ sourceKey: serverOverridesKey, value: [] });
-            updateKeyboardSettings.mutate([], {
+            mutateKeyboardSettings([], {
               onError: () =>
                 setDraft({ sourceKey: serverOverridesKey, value: previous }),
             });
@@ -443,35 +605,41 @@ export function KeyboardSettingsSection() {
           placeholder="Search shortcuts"
           value={search}
         />
-        {visibleGroups.map((group) => (
-          <section key={group.label}>
-            <h3 className="mb-2 text-xs font-medium text-subtle-foreground">
-              {group.label}
-            </h3>
-            <div className="divide-y divide-border">
-              {group.commands.map((metadata) => (
-                <KeyboardCommandRow
-                  command={metadata.command}
-                  defaults={defaults}
-                  disabled={disabled}
-                  isDesktop={isDesktop}
-                  key={metadata.command}
-                  onChange={updateCommand}
-                  onRecordingChange={setRecordingCommand}
-                  onReset={resetCommand}
-                  overrides={overrides}
-                  platform={platform}
-                  recordingCommand={recordingCommand}
-                />
-              ))}
-            </div>
-          </section>
-        ))}
-        {visibleGroups.length === 0 ? (
-          <p className="py-6 text-center text-sm text-subtle-foreground">
-            No shortcuts match “{search}”.
-          </p>
-        ) : null}
+        {/* Native disabled propagation keeps pending state out of every row. */}
+        <fieldset
+          className="m-0 min-w-0 space-y-5 border-0 p-0"
+          disabled={disabled}
+        >
+          {visibleGroups.map((group) => (
+            <section key={group.label}>
+              <h3 className="mb-2 text-xs font-medium text-subtle-foreground">
+                {group.label}
+              </h3>
+              <div className="divide-y divide-border">
+                {group.commands.map((metadata) => {
+                  const model = commandRowModels.get(metadata.command);
+                  if (model === undefined) return null;
+                  return (
+                    <KeyboardCommandRow
+                      key={metadata.command}
+                      model={model}
+                      onChange={updateCommand}
+                      onReset={resetCommand}
+                      onRecordingChange={setRecordingCommand}
+                      platform={platform}
+                      recording={recordingCommand === metadata.command}
+                    />
+                  );
+                })}
+              </div>
+            </section>
+          ))}
+          {visibleGroups.length === 0 ? (
+            <p className="py-6 text-center text-sm text-subtle-foreground">
+              No shortcuts match “{search}”.
+            </p>
+          ) : null}
+        </fieldset>
       </div>
     </SettingsSection>
   );

--- a/apps/app/src/components/settings/KeyboardSettingsSection.tsx
+++ b/apps/app/src/components/settings/KeyboardSettingsSection.tsx
@@ -74,99 +74,121 @@ function presentShortcut(
   };
 }
 
+function areNullableAppShortcutsEqual(
+  left: AppShortcut | null,
+  right: AppShortcut | null,
+): boolean {
+  return (
+    left === right ||
+    (left !== null && right !== null && areAppShortcutsEqual(left, right))
+  );
+}
+
 interface ShortcutRecorderProps {
   command: AppCommandId;
   disabled: boolean;
-  onChange(shortcut: AppShortcut): void;
+  onChange(command: AppCommandId, shortcut: AppShortcut): void;
   onRecordingChange(command: AppCommandId | null): void;
   recording: boolean;
   shortcut: AppShortcut | null;
 }
 
-function ShortcutRecorder({
-  command,
-  disabled,
-  onChange,
-  onRecordingChange,
-  recording,
-  shortcut,
-}: ShortcutRecorderProps) {
-  const platform = browserPlatform();
-  const [error, setError] = useState<string | null>(null);
-  const shortcutPresentation =
-    shortcut === null ? null : presentShortcut(shortcut, platform);
-  const formattedShortcut = shortcutPresentation?.label ?? "unassigned";
+const ShortcutRecorder = memo(
+  function ShortcutRecorder({
+    command,
+    disabled,
+    onChange,
+    onRecordingChange,
+    recording,
+    shortcut,
+  }: ShortcutRecorderProps) {
+    const platform = browserPlatform();
+    const [error, setError] = useState<string | null>(null);
+    const shortcutPresentation =
+      shortcut === null ? null : presentShortcut(shortcut, platform);
+    const formattedShortcut = shortcutPresentation?.label ?? "unassigned";
 
-  function handleKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
-    if (!recording) return;
-    event.preventDefault();
-    event.stopPropagation();
-    if (event.key === "Escape") {
+    function handleKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
+      if (!recording) return;
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.key === "Escape") {
+        setError(null);
+        onRecordingChange(null);
+        return;
+      }
+      const next = appShortcutFromInput(event, platform);
+      if (next === null) {
+        setError("Press a non-modifier key.");
+        return;
+      }
+      if (!canAssignAppShortcut(command, next)) {
+        setError("Use Command, Control, or Alt with a key.");
+        return;
+      }
       setError(null);
+      onChange(command, next);
       onRecordingChange(null);
-      return;
     }
-    const next = appShortcutFromInput(event, platform);
-    if (next === null) {
-      setError("Press a non-modifier key.");
-      return;
-    }
-    if (!canAssignAppShortcut(command, next)) {
-      setError("Use Command, Control, or Alt with a key.");
-      return;
-    }
-    setError(null);
-    onChange(next);
-    onRecordingChange(null);
-  }
 
-  return (
-    <div className="flex flex-col items-end gap-1">
-      <Button
-        aria-label={
-          recording
-            ? `Recording shortcut for ${getAppCommandMetadata(command).label}. Press keys or Escape to cancel.`
-            : `Record shortcut for ${getAppCommandMetadata(command).label}, current shortcut ${formattedShortcut}`
-        }
-        aria-pressed={recording}
-        className={cn(
-          "h-7 min-w-24 px-2 text-xs",
-          recording && "border-ring text-foreground",
-        )}
-        disabled={disabled}
-        onBlur={() => {
-          setError(null);
-          onRecordingChange(null);
-        }}
-        onClick={() => {
-          if (recording) return;
-          setError(null);
-          onRecordingChange(command);
-        }}
-        onKeyDown={handleKeyDown}
-        size="sm"
-        type="button"
-        variant="outline"
-      >
-        {recording ? (
-          "Press keys"
-        ) : shortcutPresentation === null ? (
-          "Unassigned"
-        ) : (
-          <AppCommandShortcutPill
-            className={SETTINGS_SHORTCUT_PILL_CLASS}
-            shortcut={shortcutPresentation}
-          />
-        )}
-      </Button>
-      {error ? (
-        <p className="text-xs text-destructive" role="alert">
-          {error}
-        </p>
-      ) : null}
-    </div>
-  );
-}
+    return (
+      <div className="flex flex-col items-end gap-1">
+        <Button
+          aria-label={
+            recording
+              ? `Recording shortcut for ${getAppCommandMetadata(command).label}. Press keys or Escape to cancel.`
+              : `Record shortcut for ${getAppCommandMetadata(command).label}, current shortcut ${formattedShortcut}`
+          }
+          aria-pressed={recording}
+          className={cn(
+            "h-7 min-w-24 px-2 text-xs",
+            recording && "border-ring text-foreground",
+          )}
+          disabled={disabled}
+          onBlur={() => {
+            setError(null);
+            onRecordingChange(null);
+          }}
+          onClick={() => {
+            if (recording) return;
+            setError(null);
+            onRecordingChange(command);
+          }}
+          onKeyDown={handleKeyDown}
+          size="sm"
+          type="button"
+          variant="outline"
+        >
+          {recording ? (
+            "Press keys"
+          ) : shortcutPresentation === null ? (
+            "Unassigned"
+          ) : (
+            <AppCommandShortcutPill
+              className={SETTINGS_SHORTCUT_PILL_CLASS}
+              shortcut={shortcutPresentation}
+            />
+          )}
+        </Button>
+        {error ? (
+          <p className="text-xs text-destructive" role="alert">
+            {error}
+          </p>
+        ) : null}
+      </div>
+    );
+  },
+  function areShortcutRecorderPropsEqual(left, right) {
+    return (
+      left.command === right.command &&
+      left.disabled === right.disabled &&
+      left.onChange === right.onChange &&
+      left.onRecordingChange === right.onRecordingChange &&
+      left.recording === right.recording &&
+      areNullableAppShortcutsEqual(left.shortcut, right.shortcut)
+    );
+  },
+);
 
 interface KeyboardCommandRowProps {
   model: KeyboardCommandRowModel;
@@ -253,16 +275,6 @@ function buildKeyboardCommandRowModel({
     shortcut,
     webDefaultShortcut,
   };
-}
-
-function areNullableAppShortcutsEqual(
-  left: AppShortcut | null,
-  right: AppShortcut | null,
-): boolean {
-  return (
-    left === right ||
-    (left !== null && right !== null && areAppShortcutsEqual(left, right))
-  );
 }
 
 function areCommandListsEqual(
@@ -389,7 +401,7 @@ const KeyboardCommandRow = memo(
           <ShortcutRecorder
             command={command}
             disabled={!availableOnClient}
-            onChange={(next) => onChange(command, next)}
+            onChange={onChange}
             onRecordingChange={onRecordingChange}
             recording={recording}
             shortcut={shortcut}

--- a/apps/app/src/components/settings/KeyboardSettingsSection.tsx
+++ b/apps/app/src/components/settings/KeyboardSettingsSection.tsx
@@ -195,6 +195,7 @@ interface KeyboardCommandRowProps {
   onChange(command: AppCommandId, shortcut: AppShortcut | null): void;
   onReset(command: AppCommandId): void;
   onRecordingChange(command: AppCommandId | null): void;
+  pending: boolean;
   platform: string;
   recording: boolean;
 }
@@ -315,6 +316,7 @@ const KeyboardCommandRow = memo(
     onChange,
     onReset,
     onRecordingChange,
+    pending,
     platform,
     recording,
   }: KeyboardCommandRowProps) {
@@ -344,7 +346,13 @@ const KeyboardCommandRow = memo(
         : null;
 
     return (
-      <div className="flex flex-col gap-2 py-3 first:pt-0 last:pb-0 sm:flex-row sm:items-center sm:gap-5">
+      <div
+        aria-busy={pending || undefined}
+        className={cn(
+          "flex flex-col gap-2 py-3 first:pt-0 last:pb-0 sm:flex-row sm:items-center sm:gap-5",
+          pending && "opacity-50",
+        )}
+      >
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-1.5">
             <p className="text-sm text-foreground">{metadata.label}</p>
@@ -437,6 +445,7 @@ const KeyboardCommandRow = memo(
       left.onChange === right.onChange &&
       left.onReset === right.onReset &&
       left.onRecordingChange === right.onRecordingChange &&
+      left.pending === right.pending &&
       left.platform === right.platform &&
       left.recording === right.recording &&
       areKeyboardCommandRowModelsEqual(left.model, right.model)
@@ -469,6 +478,7 @@ export function KeyboardSettingsSection() {
     null,
   );
   const [search, setSearch] = useState("");
+  const pendingCommandRef = useRef<AppCommandId | null>(null);
 
   const commandRowModels = useMemo(
     () =>
@@ -537,6 +547,7 @@ export function KeyboardSettingsSection() {
         current.isDesktop,
         current.platform,
       );
+      pendingCommandRef.current = command;
       setDraft({ sourceKey: current.serverOverridesKey, value: next });
       mutateKeyboardSettings(next, {
         onError: () =>
@@ -554,6 +565,7 @@ export function KeyboardSettingsSection() {
       const current = latestSettingsRef.current;
       const previous = current.overrides;
       const next = resetCommandShortcutOverride(current.overrides, command);
+      pendingCommandRef.current = command;
       setDraft({ sourceKey: current.serverOverridesKey, value: next });
       mutateKeyboardSettings(next, {
         onError: () =>
@@ -566,6 +578,9 @@ export function KeyboardSettingsSection() {
     [mutateKeyboardSettings],
   );
 
+  const pendingCommand = isKeyboardSettingsPending
+    ? pendingCommandRef.current
+    : null;
   const disabled = systemConfig.data === undefined || isKeyboardSettingsPending;
   const hasOverrides = overrides.length > 0;
 
@@ -576,6 +591,7 @@ export function KeyboardSettingsSection() {
           disabled={disabled || !hasOverrides}
           onClick={() => {
             const previous = overrides;
+            pendingCommandRef.current = null;
             setDraft({ sourceKey: serverOverridesKey, value: [] });
             mutateKeyboardSettings([], {
               onError: () =>
@@ -617,7 +633,7 @@ export function KeyboardSettingsSection() {
           placeholder="Search shortcuts"
           value={search}
         />
-        {/* Native disabled propagation keeps pending state out of every row. */}
+        {/* Native disabled propagation keeps pending state out of unrelated rows. */}
         <fieldset
           className={cn(
             "m-0 min-w-0 space-y-5 border-0 p-0",
@@ -644,6 +660,7 @@ export function KeyboardSettingsSection() {
                       onChange={updateCommand}
                       onReset={resetCommand}
                       onRecordingChange={setRecordingCommand}
+                      pending={pendingCommand === metadata.command}
                       platform={platform}
                       recording={recordingCommand === metadata.command}
                     />


### PR DESCRIPTION
## Summary
- derive row-specific keyboard command view models and memoize rows by their visible state
- give each shortcut recorder its own semantic memo boundary and the stable shared dispatcher
- keep one shared mutation owner for draft, optimistic mutation, rollback, and cross-window behavior
- propagate global mutation pending state through a fieldset instead of row props
- add regression coverage for row and recorder isolation, cache/refetch identity churn, conflicts, cross-window updates, pending state, and reset-all rollback

## Render verification
- before: 255 row renders for one record/assign/clear/reset flow (51 rows x 5), with no interaction remounts
- after: 55 row renders (51 initial plus 4 updates to the edited row only)
- an unchanged recorder now also bails out when its row rerenders for a conflict-warning update

## Validation
- pnpm exec turbo run test --filter=@bb/app --force (2,480 tests on the base optimization)
- focused final tests: 19 passed
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run build --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app (0 errors; existing warnings only)