### PR TITLE
Fix stale file previews during slow workspace scans

### DIFF
--- a/apps/host-daemon/src/watch-manager.test.ts
+++ b/apps/host-daemon/src/watch-manager.test.ts
@@ -147,6 +147,79 @@ function createFakeHostWatcher(
 }
 
 describe("WatchManager", () => {
+  it("starts watching before initial workspace fingerprints finish", async () => {
+    const workspace = createFakeWorkspace("/tmp/env-watch");
+    const localFingerprint = createDeferred<GetLocalStateFingerprintResult>();
+    workspace.getLocalStateFingerprint.mockImplementationOnce(
+      () => localFingerprint.promise,
+    );
+    const { hostWatcher, watchWorkspace } = createFakeHostWatcher();
+    const manager = new WatchManager({
+      hostWatcher,
+      provisionWorkspace: vi.fn(async () => workspace),
+    });
+
+    await manager.replaceWatchSet({
+      generation: 1,
+      workspaceTargets: [
+        {
+          environmentId: "env-watch",
+          workspaceContext: {
+            workspacePath: "/tmp/env-watch",
+            workspaceProvisionType: "unmanaged",
+          },
+        },
+      ],
+      threadStorageTargets: [],
+    });
+
+    expect(watchWorkspace).toHaveBeenCalledTimes(1);
+    expect(workspace.getLocalStateFingerprint).toHaveBeenCalledTimes(1);
+
+    localFingerprint.resolve("local:/tmp/env-watch:initial");
+    await vi.waitFor(() => {
+      expect(workspace.getSharedGitRefsFingerprint).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("reconciles live content when the workspace watcher becomes ready", async () => {
+    let watchWorkspaceArgs: WatchWorkspaceArgs | undefined;
+    const workspace = createFakeWorkspace("/tmp/env-watch");
+    const { hostWatcher } = createFakeHostWatcher({
+      watchWorkspaceImplementation: (args) => {
+        watchWorkspaceArgs = args;
+        return () => undefined;
+      },
+    });
+    const onWorkspaceStatusChanged = vi.fn();
+    const manager = new WatchManager({
+      hostWatcher,
+      provisionWorkspace: vi.fn(async () => workspace),
+      onWorkspaceStatusChanged,
+    });
+
+    await manager.replaceWatchSet({
+      generation: 1,
+      workspaceTargets: [
+        {
+          environmentId: "env-watch",
+          workspaceContext: {
+            workspacePath: "/tmp/env-watch",
+            workspaceProvisionType: "unmanaged",
+          },
+        },
+      ],
+      threadStorageTargets: [],
+    });
+
+    watchWorkspaceArgs?.onReady();
+
+    expect(onWorkspaceStatusChanged).toHaveBeenCalledWith({
+      changeKinds: ["work-status-changed"],
+      environmentId: "env-watch",
+    });
+  });
+
   it("starts workspace watches from snapshots and stops removed targets", async () => {
     const stopWatchingStatus = vi.fn(() => undefined);
     let watchWorkspaceArgs: WatchWorkspaceArgs | undefined;
@@ -245,6 +318,11 @@ describe("WatchManager", () => {
       ],
       threadStorageTargets: [],
     });
+    await vi.waitFor(() => {
+      expect(workspace.getLocalStateFingerprint).toHaveBeenCalledTimes(1);
+    });
+    workspace.getLocalStateFingerprint.mockClear();
+    workspace.setLocalStateFingerprintError(new Error("status too large"));
 
     watchWorkspaceArgs?.onChange({
       changedPaths: ["/tmp/env-watch/README.md"],
@@ -259,6 +337,7 @@ describe("WatchManager", () => {
       changeKinds: ["work-status-changed"],
       environmentId: "env-watch",
     });
+    expect(workspace.getLocalStateFingerprint).not.toHaveBeenCalled();
   });
 
   it("refreshes workspace metadata when a plain workspace becomes a git repository", async () => {
@@ -678,10 +757,14 @@ describe("WatchManager", () => {
       threadStorageTargets: [],
     });
 
+    await vi.waitFor(() => {
+      expect(workspace.getLocalStateFingerprint).toHaveBeenCalledTimes(1);
+    });
+    workspace.getLocalStateFingerprint.mockClear();
     workspace.setLocalStateFingerprintError(new Error("workspace vanished"));
     watchWorkspaceArgs?.onChange({
-      changedPaths: ["/tmp/env-watch/README.md"],
-      changeKinds: ["workspace-content-changed"],
+      changedPaths: ["/tmp/env-watch/.git/index"],
+      changeKinds: ["workspace-git-changed"],
       kind: "workspace-status-changed",
       environmentId: "env-watch",
     });
@@ -701,8 +784,8 @@ describe("WatchManager", () => {
     workspace.setLocalStateFingerprintError(null);
     workspace.setLocalStateFingerprint("local:/tmp/env-watch:changed");
     watchWorkspaceArgs?.onChange({
-      changedPaths: ["/tmp/env-watch/src/index.ts"],
-      changeKinds: ["workspace-content-changed"],
+      changedPaths: ["/tmp/env-watch/.git/index"],
+      changeKinds: ["workspace-git-changed"],
       kind: "workspace-status-changed",
       environmentId: "env-watch",
     });

--- a/apps/host-daemon/src/watch-manager.ts
+++ b/apps/host-daemon/src/watch-manager.ts
@@ -244,13 +244,18 @@ export class WatchManager {
           workspaceContext: target.workspaceContext,
         }),
       );
-      const watchState = await this.createWorkspaceWatchState(workspace);
       const entry: WorkspaceWatchEntry = {
         stopWatchingStatus: STOP_WATCHING,
         target,
-        watchState,
+        watchState: {
+          lastLocalFingerprint: null,
+          lastSharedRefsFingerprint: null,
+          pendingKinds: new Set(),
+          processing: null,
+        },
         workspace,
       };
+      this.workspaceEntries.set(target.environmentId, entry);
       entry.stopWatchingStatus = this.hostWatcher.watchWorkspace({
         environmentId: target.environmentId,
         workspacePath: workspace.path,
@@ -260,12 +265,22 @@ export class WatchManager {
             entry,
           });
         },
+        // Parcel subscriptions are established asynchronously. Reconcile once
+        // the workspace-root subscription is live so an edit made between the
+        // initial preview fetch and watcher readiness cannot remain stale.
+        onReady: () => {
+          this.queueWorkspaceWatchChange({
+            changeKinds: ["workspace-content-changed"],
+            entry,
+          });
+        },
         onWatchError: (error) => {
           this.options.onWorkspaceStatusWatchError?.({ error });
         },
       });
-      this.workspaceEntries.set(target.environmentId, entry);
+      void this.initializeWorkspaceWatchFingerprints(entry);
     } catch (error) {
+      this.workspaceEntries.delete(target.environmentId);
       this.options.onWorkspaceStatusWatchError?.({
         error: {
           environmentId: target.environmentId,
@@ -280,36 +295,49 @@ export class WatchManager {
     }
   }
 
-  private async createWorkspaceWatchState(
-    workspace: HostWorkspace,
-  ): Promise<WorkspaceWatchState> {
-    if (!workspace.isGitRepo) {
-      return {
-        lastLocalFingerprint: null,
-        lastSharedRefsFingerprint: null,
-        pendingKinds: new Set(),
-        processing: null,
-      };
+  private async initializeWorkspaceWatchFingerprints(
+    entry: WorkspaceWatchEntry,
+  ): Promise<void> {
+    if (!entry.workspace.isGitRepo) {
+      return;
     }
-
-    const [lastLocalFingerprint, lastSharedRefsFingerprint] = await Promise.all(
-      [
-        workspace.getLocalStateFingerprint(),
-        workspace.getSharedGitRefsFingerprint(),
-      ],
-    );
-    return {
-      lastLocalFingerprint,
-      lastSharedRefsFingerprint,
-      pendingKinds: new Set(),
-      processing: null,
-    };
+    try {
+      const [lastLocalFingerprint, lastSharedRefsFingerprint] =
+        await Promise.all([
+          entry.workspace.getLocalStateFingerprint(),
+          entry.workspace.getSharedGitRefsFingerprint(),
+        ]);
+      if (this.workspaceEntries.get(entry.target.environmentId) !== entry) {
+        return;
+      }
+      entry.watchState.lastLocalFingerprint = lastLocalFingerprint;
+      entry.watchState.lastSharedRefsFingerprint = lastSharedRefsFingerprint;
+    } catch (error) {
+      if (this.workspaceEntries.get(entry.target.environmentId) !== entry) {
+        return;
+      }
+      this.reportWorkspaceWatchError(entry, error);
+    }
   }
 
   private queueWorkspaceWatchChange(args: {
     changeKinds: readonly WorkspaceStatusWatchChangeKind[];
     entry: WorkspaceWatchEntry;
   }): void {
+    if (
+      this.workspaceEntries.get(args.entry.target.environmentId) !== args.entry
+    ) {
+      return;
+    }
+    if (args.changeKinds.includes("workspace-content-changed")) {
+      // The filesystem event itself is sufficient evidence that live content
+      // is stale. Notify before any Git fingerprint work: large diffs can make
+      // status/numstat slow or fail, but previews must still refresh.
+      this.options.onWorkspaceStatusChanged?.({
+        changeKinds: ["work-status-changed"],
+        environmentId: args.entry.target.environmentId,
+      });
+    }
     for (const changeKind of args.changeKinds) {
       args.entry.watchState.pendingKinds.add(changeKind);
     }
@@ -348,22 +376,13 @@ export class WatchManager {
         ) {
           await this.refreshGitWorkspaceMetadata(args.entry);
         }
-        // A real workspace file event must reach live content consumers even
-        // when the git-status summary is unchanged. For example, replacing one
-        // line with another repeatedly produces the same path/status/numstat
-        // fingerprint, but open file previews and diffs still need to refetch.
         const workspaceContentChanged = pendingKinds.includes(
           "workspace-content-changed",
         );
-        if (!args.entry.workspace.isGitRepo) {
-          if (workspaceContentChanged) {
-            changeKinds.push("work-status-changed");
-          }
-        } else {
+        if (args.entry.workspace.isGitRepo && !workspaceContentChanged) {
           const nextLocalFingerprint =
             await args.entry.workspace.getLocalStateFingerprint();
           if (
-            workspaceContentChanged ||
             args.entry.watchState.lastLocalFingerprint !== nextLocalFingerprint
           ) {
             args.entry.watchState.lastLocalFingerprint = nextLocalFingerprint;
@@ -394,18 +413,25 @@ export class WatchManager {
         environmentId: args.entry.target.environmentId,
       });
     } catch (error) {
-      this.options.onWorkspaceStatusWatchError?.({
-        error: {
-          environmentId: args.entry.target.environmentId,
-          kind: "workspace-watch-error",
-          message:
-            error instanceof Error
-              ? toErrorMessage(error)
-              : "Unknown workspace watch error",
-          rootPath: args.entry.target.workspaceContext.workspacePath,
-        },
-      });
+      this.reportWorkspaceWatchError(args.entry, error);
     }
+  }
+
+  private reportWorkspaceWatchError(
+    entry: WorkspaceWatchEntry,
+    error: unknown,
+  ): void {
+    this.options.onWorkspaceStatusWatchError?.({
+      error: {
+        environmentId: entry.target.environmentId,
+        kind: "workspace-watch-error",
+        message:
+          error instanceof Error
+            ? toErrorMessage(error)
+            : "Unknown workspace watch error",
+        rootPath: entry.target.workspaceContext.workspacePath,
+      },
+    });
   }
 
   private async refreshGitWorkspaceMetadata(

--- a/packages/host-watcher/src/host-watcher-types.ts
+++ b/packages/host-watcher/src/host-watcher-types.ts
@@ -72,6 +72,7 @@ export interface WatchWorkspaceArgs {
   environmentId: string;
   workspacePath: string;
   onChange: (event: WorkspaceObservedChange) => void;
+  onReady: () => void;
   onWatchError: (error: WorkspaceWatchError) => void;
 }
 

--- a/packages/host-watcher/src/parcel-host-watcher.ts
+++ b/packages/host-watcher/src/parcel-host-watcher.ts
@@ -132,6 +132,7 @@ function watchWorkspace(args: WatchWorkspaceArgs): () => Promise<void> {
         environmentId: args.environmentId,
       });
     },
+    onReady: args.onReady,
     onWatchError: (error) => {
       args.onWatchError({
         kind: "workspace-watch-error",

--- a/packages/host-watcher/src/root-subscription.ts
+++ b/packages/host-watcher/src/root-subscription.ts
@@ -22,6 +22,8 @@ export interface RootSubscriptionArgs {
   maxRetryDelayMs: number;
   /** Non-error event batch delivered by the live subscription. */
   onEvents: (events: ParcelWatcherEventBatch) => void;
+  /** Invoked after the underlying filesystem subscription is established. */
+  onReady?: () => void;
   /**
    * Dropped FSEvents detected. Invoked once when the drop is observed and again
    * after the subscription is re-established, so callers can rescan both the
@@ -198,6 +200,8 @@ export class RootSubscription {
       if (this.recoveryPending) {
         this.recoveryPending = false;
         this.args.onDroppedEvents();
+      } else {
+        this.args.onReady?.();
       }
     } catch (error) {
       if (this.disposed) {

--- a/packages/host-watcher/src/watch-status-types.ts
+++ b/packages/host-watcher/src/watch-status-types.ts
@@ -27,5 +27,6 @@ export type WorkspaceStatusWatchErrorCallback = (
 
 export interface WorkspaceStatusWatchArgs {
   onChange: WorkspaceStatusChangeCallback;
+  onReady?: () => void;
   onWatchError: WorkspaceStatusWatchErrorCallback;
 }

--- a/packages/host-watcher/src/watch-status.ts
+++ b/packages/host-watcher/src/watch-status.ts
@@ -17,6 +17,7 @@ export function watchWorkspaceStatus(
   const watcher = createWorkspaceStatusWatcher({
     cwd,
     onChange: args.onChange,
+    onReady: args.onReady,
     onWatchError: args.onWatchError,
   });
   watcher.start();

--- a/packages/host-watcher/src/workspace-status-watcher.ts
+++ b/packages/host-watcher/src/workspace-status-watcher.ts
@@ -25,10 +25,10 @@ const WORKSPACE_STATUS_WATCH_DEBOUNCE_MS = 75;
 const WORKSPACE_STATUS_WATCH_MAX_WAIT_MS = 500;
 const WORKSPACE_STATUS_WATCH_RETRY_DELAY_MS = 250;
 const WORKSPACE_STATUS_WATCH_MAX_RETRY_DELAY_MS = 30_000;
-// Setup runs `git` (ignore discovery, metadata resolution). When a worktree is
-// deleted out from under us, that git command fails every time, so without a
-// cap we re-spawn git forever. Give up after a bounded number of attempts; the
-// server recreates this watch (resetting the count) when the watch set changes.
+// Metadata setup runs `git`. When a worktree is deleted out from under us,
+// that command fails every time, so without a cap we re-spawn git forever.
+// Give up after a bounded number of attempts; the server recreates this watch
+// (resetting the count) when the watch set changes.
 const WORKSPACE_STATUS_WATCH_MAX_SETUP_RETRY_ATTEMPTS = 10;
 const WORKSPACE_ROOT_ALWAYS_IGNORED_PATHS = [".git"];
 const WORKSPACE_ROOT_IGNORE_STATUS_TIMEOUT_MS = 5_000;
@@ -160,10 +160,6 @@ export class WorkspaceStatusWatcher {
   private metadataRetryAttempt = 0;
   private metadataStartRetryTimer: ReturnType<typeof setTimeout> | null = null;
   private gitWorkspacePromotion: Promise<void> | null = null;
-  private workspaceRootRetryAttempt = 0;
-  private workspaceRootStartRetryTimer: ReturnType<typeof setTimeout> | null =
-    null;
-  private workspaceRootSetupWarned = false;
   private readonly subscriptions = new Map<string, RootSubscription>();
   private readonly changeScheduler;
 
@@ -209,10 +205,6 @@ export class WorkspaceStatusWatcher {
       clearTimeout(this.metadataStartRetryTimer);
       this.metadataStartRetryTimer = null;
     }
-    if (this.workspaceRootStartRetryTimer !== null) {
-      clearTimeout(this.workspaceRootStartRetryTimer);
-      this.workspaceRootStartRetryTimer = null;
-    }
     await Promise.all(
       [...this.subscriptions.values()].map((subscription) =>
         subscription.dispose(),
@@ -244,42 +236,10 @@ export class WorkspaceStatusWatcher {
     rootPath: string,
     error: unknown,
   ): void {
-    if (this.workspaceRootSetupWarned) {
-      return;
-    }
-    this.workspaceRootSetupWarned = true;
     this.args.onWatchError({
       message: `Workspace root ignore discovery failed: ${toWatchErrorMessage(error)}`,
       rootPath,
     });
-  }
-
-  private scheduleWorkspaceRootWatchRetry(rootPath: string): void {
-    if (this.disposed || this.workspaceRootStartRetryTimer !== null) {
-      return;
-    }
-    if (
-      this.workspaceRootRetryAttempt >=
-      WORKSPACE_STATUS_WATCH_MAX_SETUP_RETRY_ATTEMPTS
-    ) {
-      this.args.onWatchError({
-        message: `Workspace root watch setup failed ${this.workspaceRootRetryAttempt} times (the worktree may have been deleted); giving up until the watch is reconfigured`,
-        rootPath,
-      });
-      return;
-    }
-    this.workspaceRootRetryAttempt += 1;
-    this.workspaceRootStartRetryTimer = setTimeout(
-      () => {
-        this.workspaceRootStartRetryTimer = null;
-        this.startWorkspaceRootWatchSubscription(rootPath);
-      },
-      calculateExponentialBackoffDelay({
-        attempt: this.workspaceRootRetryAttempt,
-        baseDelayMs: this.args.retryDelayMs,
-        maxDelayMs: this.args.maxRetryDelayMs,
-      }),
-    );
   }
 
   private startWorkspaceRootWatchSubscription(rootPath: string): void {
@@ -300,15 +260,20 @@ export class WorkspaceStatusWatcher {
       if (this.disposed) {
         return;
       }
-      this.workspaceRootRetryAttempt = 0;
-      this.workspaceRootSetupWarned = false;
       this.startWatchSubscription(spec);
     } catch (error) {
       if (this.disposed) {
         return;
       }
       this.reportWorkspaceRootSetupError(rootPath, error);
-      this.scheduleWorkspaceRootWatchRetry(rootPath);
+      // Ignore discovery is an optimization, not a correctness gate. Keep the
+      // workspace live with the mandatory `.git` exclusion even when Git is
+      // too slow or its metadata is temporarily unavailable.
+      this.startWatchSubscription({
+        kind: "workspace-root",
+        options: { ignore: [...WORKSPACE_ROOT_ALWAYS_IGNORED_PATHS] },
+        rootPath,
+      });
     }
   }
 
@@ -324,6 +289,7 @@ export class WorkspaceStatusWatcher {
       onEvents: (events) => {
         this.handleWorkspaceEvents(spec, events);
       },
+      onReady: spec.kind === "workspace-root" ? this.args.onReady : undefined,
       onDroppedEvents: () => {
         // Dropped events are recoverable for workspace status: conservatively
         // mark the whole spec changed so consumers re-read current state.
@@ -479,6 +445,7 @@ export function createWorkspaceStatusWatcher(
     maxRetryDelayMs: WORKSPACE_STATUS_WATCH_MAX_RETRY_DELAY_MS,
     maxWaitMs: WORKSPACE_STATUS_WATCH_MAX_WAIT_MS,
     onChange: args.onChange,
+    onReady: args.onReady,
     onWatchError: args.onWatchError,
     retryDelayMs: WORKSPACE_STATUS_WATCH_RETRY_DELAY_MS,
   });

--- a/packages/host-watcher/test/watch-status.test.ts
+++ b/packages/host-watcher/test/watch-status.test.ts
@@ -455,15 +455,20 @@ describe.sequential("watchWorkspaceStatus", () => {
     const { emitWorkspaceRootEvents, ready, watchWorkspaceStatus } =
       await importWatchWorkspaceStatusWithManualWorkspaceEvents(repoPath);
     const calls: number[] = [];
+    const onReady = vi.fn();
     const stopWatching = watchWorkspaceStatus(repoPath, {
       onChange: () => {
         calls.push(Date.now());
       },
+      onReady,
       onWatchError: ignoreWatchError,
     });
 
     try {
       await ready;
+      await vi.waitFor(() => {
+        expect(onReady).toHaveBeenCalledTimes(1);
+      });
       emitWorkspaceRootEvents([
         {
           path: path.join(repoPath, "README.md"),
@@ -735,7 +740,7 @@ describe.sequential("watchWorkspaceStatus", () => {
     }
   });
 
-  it("reports and retries when Git ignored directory discovery fails", async () => {
+  it("falls back to a live root watch when Git ignored directory discovery fails", async () => {
     const repoPath = await initRepo();
     await fs.rm(path.join(repoPath, ".git"), { force: true, recursive: true });
     await fs.writeFile(
@@ -744,10 +749,13 @@ describe.sequential("watchWorkspaceStatus", () => {
       "utf8",
     );
     const subscribedRoots: string[] = [];
+    const subscribedOptions: Array<ParcelWatcherSubscribeOptions | undefined> =
+      [];
     const mockSubscribe = async (
       ...watchArgs: ParcelWatcherSubscribeArgs
     ): Promise<ParcelWatcherSubscribeResult> => {
       subscribedRoots.push(watchArgs[0]);
+      subscribedOptions.push(watchArgs[2]);
       return createMockWatcherSubscription();
     };
     vi.spyOn(parcelWatcher, "subscribe").mockImplementation(mockSubscribe);
@@ -765,13 +773,19 @@ describe.sequential("watchWorkspaceStatus", () => {
         1,
         WATCH_TEST_TIMEOUT_MS,
       );
-      await ensureCallCountStays(() => subscribedRoots.length, 0, 600);
+      await waitForCallCount(
+        () => subscribedRoots.length,
+        1,
+        WATCH_TEST_TIMEOUT_MS,
+      );
 
       const ignoreDiscoveryErrors = watchErrors.filter((error) =>
         error.includes("Workspace root ignore discovery failed:"),
       );
       expect(ignoreDiscoveryErrors).toHaveLength(1);
       expect(ignoreDiscoveryErrors[0]).toContain(normalizeWatchPath(repoPath));
+      expect(subscribedRoots).toEqual([normalizeWatchPath(repoPath)]);
+      expect(subscribedOptions[0]?.ignore).toEqual([".git"]);
     } finally {
       await stopWatching();
     }


### PR DESCRIPTION
## Summary

- install workspace watchers before asynchronous Git fingerprint initialization
- reconcile workspace-derived queries once the root filesystem subscription is ready
- emit content-change invalidations without waiting for status/numstat
- fall back to a `.git`-only ignore set when ignored-directory discovery fails

## Root cause

File preview refreshes depend on `work-status-changed`. The host daemon previously computed the full local Git fingerprint before installing the watcher and again before emitting each notification. Large dirty workspaces could make that scan take several seconds: 1,000 untracked files reproduced at about 5.3 seconds, and 5,000 at about 10.1 seconds. Edits during startup were missed, and scan failures suppressed an already-known content change.

## Before / after

Before, watcher startup and content refresh were gated on potentially slow Git status work. After, the watcher starts first, readiness triggers a conservative reconciliation, and content changes invalidate live workspace views immediately. Git fingerprints remain best-effort for metadata-only deduplication.

## Tests

- `pnpm exec turbo run typecheck --filter=@bb/host-daemon --filter=@bb/host-watcher`
- `pnpm exec turbo run test --filter=@bb/host-daemon --force` (514 tests)
- `pnpm exec turbo run test --filter=@bb/host-watcher --force` (39 tests)
- `git diff --check`