### PR TITLE
Ask for a Product Hunt vote in the hero on launch day

### DIFF
--- a/apps/web/src/landing/analytics.ts
+++ b/apps/web/src/landing/analytics.ts
@@ -31,6 +31,10 @@ export type LandingEvent =
   | {
       name: "landing_email_subscribed";
       properties: { placement: CtaPlacement };
+    }
+  | {
+      name: "landing_product_hunt_clicked";
+      properties: { placement: CtaPlacement };
     };
 
 let client: PostHog | null = null;

--- a/apps/web/src/landing/cta.tsx
+++ b/apps/web/src/landing/cta.tsx
@@ -1,4 +1,7 @@
-import { CheckmarkCircle02Icon } from "@hugeicons/core-free-icons";
+import {
+  ArrowRight01Icon,
+  CheckmarkCircle02Icon,
+} from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { useState } from "react";
 import type { FormEvent, ReactNode } from "react";
@@ -8,6 +11,7 @@ import type { CtaPlacement } from "./site";
 import {
   DISCORD_URL,
   GITHUB_URL,
+  PRODUCT_HUNT_URL,
   SUBSCRIBE_PATH,
   downloadMacosHref,
 } from "./site";
@@ -63,6 +67,31 @@ export function DiscordLink({ placement, className, children }: CtaLinkProps) {
       }
     >
       {children}
+    </a>
+  );
+}
+
+/** Launch-day announcement pill, in the same shape as the release-notes
+ *  callout it replaces. This is bb's own markup rather than Product Hunt's
+ *  embed, so it inherits the page's type and color and can ask for the vote
+ *  outright. */
+export function ProductHuntCallout({ placement }: { placement: CtaPlacement }) {
+  return (
+    <a
+      className="updates-callout ph-callout"
+      href={PRODUCT_HUNT_URL}
+      target="_blank"
+      rel="noreferrer"
+      onClick={() =>
+        trackLandingEvent({
+          name: "landing_product_hunt_clicked",
+          properties: { placement },
+        })
+      }
+    >
+      <span className="updates-label ph-callout-label">Today</span>
+      <span className="updates-title">Vote for bb on Product Hunt</span>
+      <HugeiconsIcon icon={ArrowRight01Icon} className="updates-arrow" />
     </a>
   );
 }

--- a/apps/web/src/landing/landing.css
+++ b/apps/web/src/landing/landing.css
@@ -38,6 +38,11 @@
   --add: oklch(0.4 0.13 163); /* --diff-added */
   --del: oklch(0.4 0.17 28); /* --diff-removed */
   --spark: oklch(0.55 0.14 50); /* --warning-text */
+  /* Product Hunt orange (#FF6154 ≈ oklch(0.68 0.19 27)), pulled down in
+     lightness and chroma. At full saturation it is the only neon on an
+     otherwise achromatic page and reads as a foreign badge; this keeps the
+     hue recognisable while sitting inside the ink ramp. */
+  --ph: oklch(0.58 0.15 32);
   --radius: 0.5rem;
   --font-sans:
     "Inter Variable", "Inter Fallback", Inter, -apple-system,
@@ -459,6 +464,29 @@ code,
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Both pills end in the same Hugeicons chevron. The glyph is drawn with ~4px of
+   slack inside its own box, so the box gaps lie: negative margins pull that
+   slack back out and let the chevron sit against the text it belongs to,
+   rather than stranded between the text and the pill's edge. */
+.updates-arrow {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  margin-left: -4px;
+  margin-right: -4px;
+}
+
+/* Launch-day variant of the announcement pill: the release-notes pill exactly,
+   with the chip warmed to Product Hunt's orange. The chip is the only thing
+   that changes, so the two read as the same component in the same slot. */
+.ph-callout-label {
+  background: var(--ph);
+}
+
+.ph-callout:hover {
+  border-color: color-mix(in oklab, var(--ph) 45%, var(--bg));
 }
 
 /* Scroll reveal: sections start hidden only once JS marks them pending,
@@ -2692,6 +2720,12 @@ html.js .mock[data-construct]:not(.constructing):not(.constructed) {
 
   .updates-label {
     display: none;
+  }
+
+  /* The launch pill keeps its chip. "Today" is the urgency, and without it the
+     line loses the one thing that makes it worth interrupting the hero for. */
+  .ph-callout-label {
+    display: inline;
   }
 }
 

--- a/apps/web/src/landing/site.ts
+++ b/apps/web/src/landing/site.ts
@@ -11,6 +11,17 @@ export const DOWNLOAD_MACOS_REDIRECT_PATH = "/download/macos";
 export const SUBSCRIBE_PATH = "/api/subscribe";
 export const CLI_COMMAND = "npx bb-app@latest";
 
+/** Launch-day switch. While this is true the hero's announcement pill asks for
+ *  a Product Hunt vote instead of linking to the latest release. Flip it to
+ *  false after the launch and the changelog callout comes back — nothing else
+ *  needs to change. */
+export const PRODUCT_HUNT_LAUNCH_ACTIVE = true;
+
+/** The Product Hunt launch page. The UTM parameters are the ones Product Hunt
+ *  issued with the embed, kept so they can attribute the traffic back. */
+export const PRODUCT_HUNT_URL =
+  "https://www.producthunt.com/products/bb?utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-bb";
+
 /** Where on the page a CTA lives, for click-through comparison. */
 export type CtaPlacement =
   | "nav"

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -40,6 +40,7 @@ import {
   DownloadLink,
   EmailSignup,
   GitHubLink,
+  ProductHuntCallout,
 } from "../landing/cta";
 import { DASHBOARD_PATH } from "../lib/connect-return-to";
 import {
@@ -53,7 +54,12 @@ import {
   PiIcon,
 } from "../landing/icons";
 import type { CtaPlacement } from "../landing/site";
-import { CLI_COMMAND, SITE_DESCRIPTION, SITE_TITLE } from "../landing/site";
+import {
+  CLI_COMMAND,
+  PRODUCT_HUNT_LAUNCH_ACTIVE,
+  SITE_DESCRIPTION,
+  SITE_TITLE,
+} from "../landing/site";
 import interWoff2 from "@fontsource-variable/inter/files/inter-latin-wght-normal.woff2?url";
 import landingCss from "../landing/landing.css?url";
 
@@ -1689,11 +1695,17 @@ function LandingPage() {
       </nav>
 
       <header className="hero">
-        <a className="updates-callout" href={LATEST_RELEASE_URL}>
-          <span className="updates-label">New</span>
-          <span className="updates-title">{LATEST_RELEASE_META.headline}</span>
-          <span aria-hidden="true">→</span>
-        </a>
+        {PRODUCT_HUNT_LAUNCH_ACTIVE ? (
+          <ProductHuntCallout placement="hero" />
+        ) : (
+          <a className="updates-callout" href={LATEST_RELEASE_URL}>
+            <span className="updates-label">New</span>
+            <span className="updates-title">
+              {LATEST_RELEASE_META.headline}
+            </span>
+            <ChevronRight className="updates-arrow" />
+          </a>
+        )}
         <h1>The IDE that builds itself</h1>
         <p className="sub">
           bb can control, customize, and automate itself, laying the groundwork


### PR DESCRIPTION
The hero's announcement pill normally links to the latest release. While `PRODUCT_HUNT_LAUNCH_ACTIVE` is true it asks for a Product Hunt vote instead.

`[Today] Vote for bb on Product Hunt ›`

## Why not the embed badge

Product Hunt's embed is a 250x54 image with its own typeface, its own slate-blue palette, and its own border. Dropping it into an editorial layout reads as a foreign object. This is bb's own markup, so it inherits the page's type and color, and it can ask for the vote outright instead of just saying "find us on Product Hunt".

## Design notes

- The chip carries the urgency (**Today**) and the copy carries the ask, so neither repeats the other and there is no clause to truncate on a phone.
- The chip is the only thing separating this from the release-notes pill, so the two read as the same component in the same slot.
- Its orange is Product Hunt's `#FF6154`, pulled down in lightness and chroma to `oklch(0.58 0.15 32)`. At full strength it is the only neon on a page built from a zero-chroma ink ramp.
- Both pills now end in the Hugeicons chevron rather than a literal `→` character, so the swap is invisible when the flag flips. The chevron carries ~4px of slack inside its own box, so negative inline margins pull that back out and keep it against the text it belongs to.

## Turning it off

Set `PRODUCT_HUNT_LAUNCH_ACTIVE = false` in `apps/web/src/landing/site.ts`. The changelog callout comes back and nothing else changes. The release-notes branch stays compiled and typechecked while the flag is on, so it cannot rot.

## Testing

- `turbo run typecheck test build --filter=@bb/web` all pass.
- Verified in a browser at 1280px, 390px, and 360px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
