### PR TITLE
Enable plugins when installed

### DIFF
--- a/apps/server/src/services/plugins/plugin-registration.ts
+++ b/apps/server/src/services/plugins/plugin-registration.ts
@@ -236,7 +236,7 @@ export function createPluginRegistration(context: PluginRegistrationContext) {
           activeArtifactId: args.activeArtifactId ?? null,
           rootDir: args.rootDir,
           version: manifest.version,
-          enabled: existing?.enabled ?? true,
+          enabled: true,
         });
         const row = getInstalledPlugin(deps.db, manifest.id);
         if (row) {

--- a/apps/server/test/services/plugins/plugin-service.test.ts
+++ b/apps/server/test/services/plugins/plugin-service.test.ts
@@ -589,6 +589,26 @@ describe("plugin service", () => {
     const enabled = await service.setEnabled("switchable", true);
     expect(enabled?.status).toBe("running");
   });
+
+  it("enables a disabled path plugin when it is reinstalled", async () => {
+    const rootDir = await writePlugin(workDir, {
+      name: "bb-plugin-reinstalled",
+      serverSource: `export default function plugin() {}`,
+    });
+    await service.install(rootDir);
+    expect(await service.setEnabled("reinstalled", false)).toMatchObject({
+      enabled: false,
+      status: "disabled",
+    });
+
+    const reinstalled = await service.install(rootDir);
+
+    expect(reinstalled).toMatchObject({
+      enabled: true,
+      status: "running",
+    });
+    expect(service.getApi("reinstalled")).toBeDefined();
+  });
 });
 
 describe("plugins-changed broadcast", () => {


### PR DESCRIPTION
## Summary

- enable every successful plugin install, including reinstalls of disabled path plugins
- add regression coverage proving reinstallation activates the plugin runtime

## Testing

- pnpm exec turbo run test --filter=@bb/server -- test/services/plugins/plugin-service.test.ts
- pnpm exec turbo run typecheck --filter=@bb/server