### PR TITLE
Fix PR lookup for renamed fork upstreams

### DIFF
--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -36,7 +36,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 97 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 98 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1051,11 +1051,11 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
-  // Version 97 suppresses Codex raw response completion notifications. An
-  // older daemon emits them as provider/unhandled, so it must update before
-  // connecting.
-  it("uses protocol version 97 for Codex raw response completion noise", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(97);
+  // Version 98 resolves pull requests through differently named upstream fork
+  // branches. An older daemon can incorrectly report those PRs as absent, so it
+  // must update before connecting.
+  it("uses protocol version 98 for qualified upstream PR lookup", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(98);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {

--- a/packages/host-workspace/src/git-host.ts
+++ b/packages/host-workspace/src/git-host.ts
@@ -44,7 +44,6 @@ const GH_PR_VIEW_JSON_FIELDS = [
   "mergeStateStatus",
   "mergeable",
 ].join(",");
-const GH_REPO_VIEW_JSON_FIELDS = "nameWithOwner";
 
 interface GetPullRequestForCurrentBranchArgs {
   cwd: string;
@@ -60,6 +59,7 @@ export type GitHostPullRequestAction =
 
 interface RunPullRequestActionForCurrentBranchArgs {
   cwd: string;
+  localBranch: string;
   action: GitHostPullRequestAction;
 }
 
@@ -290,14 +290,16 @@ function getMergeMethodFlag(method: GitHostPullRequestMergeMethod): string {
 
 function buildPullRequestActionArgs(
   action: GitHostPullRequestAction,
+  selector: string | null,
 ): string[] {
+  const target = selector ? [selector] : [];
   switch (action.operation) {
     case "ready":
-      return ["pr", "ready"];
+      return ["pr", "ready", ...target];
     case "draft":
-      return ["pr", "ready", "--undo"];
+      return ["pr", "ready", ...target, "--undo"];
     case "merge":
-      return ["pr", "merge", getMergeMethodFlag(action.method)];
+      return ["pr", "merge", ...target, getMergeMethodFlag(action.method)];
   }
 }
 
@@ -375,6 +377,11 @@ type PullRequestTargetLookup =
   | { outcome: "upstream-branch"; selector: string }
   | Extract<GitHostPullRequestLookup, { outcome: "unavailable" }>;
 
+interface GitRemoteRepository {
+  host: string;
+  owner: string;
+}
+
 function ghCommandUnavailable(
   ghArgs: string[],
   error: unknown,
@@ -425,17 +432,90 @@ function gitUpstreamLookupUnavailable(
   };
 }
 
+function escapeGitConfigRegexp(value: string): string {
+  return value.replace(/[\\^$.*+?()[\]{}|]/gu, "\\$&");
+}
+
+function parseNullTerminatedGitConfig(stdout: string): Map<string, string> {
+  const values = new Map<string, string>();
+  for (const record of stdout.split("\0")) {
+    const separator = record.indexOf("\n");
+    if (separator <= 0) continue;
+    const key = record.slice(0, separator);
+    if (!values.has(key)) {
+      values.set(key, record.slice(separator + 1));
+    }
+  }
+  return values;
+}
+
+const GIT_REMOTE_OWNER_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9-]*$/u;
+const GIT_REMOTE_REPOSITORY_PATTERN = /^[a-zA-Z0-9._-]+$/u;
+
+/**
+ * Parse a GitHub-style remote locally. The URL is never passed to `gh`: Git
+ * config is workspace-controlled, while `gh` inherits the user's auth tokens.
+ */
+function parseGitRemoteRepository(
+  remoteUrl: string,
+): GitRemoteRepository | null {
+  const trimmed = remoteUrl.trim();
+  let host: string;
+  let repositoryPath: string;
+
+  if (trimmed.includes("://")) {
+    let url: URL;
+    try {
+      url = new URL(trimmed);
+    } catch {
+      return null;
+    }
+    if (!["git:", "http:", "https:", "ssh:"].includes(url.protocol)) {
+      return null;
+    }
+    host = url.hostname;
+    repositoryPath = url.pathname;
+  } else {
+    const scpStyle = /^(?:[^@/:\s]+@)?([^/:\s]+):(.+)$/u.exec(trimmed);
+    if (!scpStyle?.[1] || !scpStyle[2]) {
+      return null;
+    }
+    host = scpStyle[1];
+    repositoryPath = scpStyle[2];
+  }
+
+  const pathSegments = repositoryPath
+    .replace(/^\/+|\/+$/gu, "")
+    .replace(/\.git$/u, "")
+    .split("/");
+  const owner = pathSegments[0] ?? "";
+  const repository = pathSegments[1] ?? "";
+  if (
+    !host ||
+    pathSegments.length !== 2 ||
+    !GIT_REMOTE_OWNER_PATTERN.test(owner) ||
+    !GIT_REMOTE_REPOSITORY_PATTERN.test(repository) ||
+    repository === "." ||
+    repository === ".."
+  ) {
+    return null;
+  }
+  return { host: host.toLowerCase(), owner };
+}
+
 async function getPullRequestTarget(
   args: GetPullRequestForCurrentBranchArgs,
 ): Promise<PullRequestTargetLookup> {
-  const localRef = `refs/heads/${args.localBranch}`;
-  let upstreamResult: GitCommandResult;
+  const branchConfigPrefix = `branch.${args.localBranch}`;
+  const escapedBranch = escapeGitConfigRegexp(args.localBranch);
+  let configResult: GitCommandResult;
   try {
-    upstreamResult = await runGit(
+    configResult = await runGit(
       [
-        "for-each-ref",
-        "--format=%(refname)%00%(upstream:remotename)%00%(upstream:remoteref)",
-        localRef,
+        "config",
+        "--null",
+        "--get-regexp",
+        `^(branch\\.${escapedBranch}\\.(remote|merge)|remote\\..*\\.url)$`,
       ],
       {
         cwd: args.cwd,
@@ -449,20 +529,16 @@ async function getPullRequestTarget(
       error instanceof Error ? error.message : "",
     );
   }
-  if (upstreamResult.exitCode !== 0) {
+  if (configResult.exitCode !== 0 && configResult.exitCode !== 1) {
     return gitUpstreamLookupUnavailable(
       "Could not inspect the current branch's configured upstream",
-      upstreamResult.stderr.trim(),
+      configResult.stderr.trim(),
     );
   }
 
-  const upstreamEntry = upstreamResult.stdout
-    .trimEnd()
-    .split("\n")
-    .map((line) => line.split("\0"))
-    .find(([ref]) => ref === localRef);
-  const remote = upstreamEntry?.[1] ?? "";
-  const remoteRef = upstreamEntry?.[2] ?? "";
+  const config = parseNullTerminatedGitConfig(configResult.stdout);
+  const remote = config.get(`${branchConfigPrefix}.remote`) ?? "";
+  const remoteRef = config.get(`${branchConfigPrefix}.merge`) ?? "";
   const remoteBranchPrefix = "refs/heads/";
   if (!remote || remote === "." || !remoteRef.startsWith(remoteBranchPrefix)) {
     return { outcome: "current-branch" };
@@ -473,69 +549,29 @@ async function getPullRequestTarget(
     return { outcome: "current-branch" };
   }
 
-  let remoteUrlResult: GitCommandResult;
-  try {
-    remoteUrlResult = await runGit(["remote", "get-url", remote], {
-      cwd: args.cwd,
-      allowFailure: true,
-      timeoutMs: GIT_UPSTREAM_LOOKUP_TIMEOUT_MS,
-    });
-  } catch (error) {
+  const originRepository = parseGitRemoteRepository(
+    config.get("remote.origin.url") ?? "",
+  );
+  const upstreamRepository = parseGitRemoteRepository(
+    config.get(`remote.${remote}.url`) ?? "",
+  );
+  if (!originRepository || !upstreamRepository) {
     return gitUpstreamLookupUnavailable(
-      `Could not resolve URL for Git remote ${remote}`,
-      error instanceof Error ? error.message : "",
+      "Could not safely resolve the configured upstream repository",
+      "origin and upstream must use supported GitHub remote URLs",
     );
   }
-  const remoteUrl = remoteUrlResult.stdout.trim();
-  if (remoteUrlResult.exitCode !== 0 || !remoteUrl) {
-    return gitUpstreamLookupUnavailable(
-      `Could not resolve URL for Git remote ${remote}`,
-      remoteUrlResult.stderr.trim(),
-    );
-  }
-
-  const repoViewArgs = [
-    "repo",
-    "view",
-    remoteUrl,
-    "--json",
-    GH_REPO_VIEW_JSON_FIELDS,
-  ];
-  let repoViewStdout: string;
-  try {
-    ({ stdout: repoViewStdout } = await execFileAsync("gh", repoViewArgs, {
-      cwd: args.cwd,
-      encoding: "utf8",
-      env: sanitizeInheritedChildProcessEnv({ env: process.env }),
-      timeout: GH_PR_VIEW_TIMEOUT_MS,
-      maxBuffer: GH_PR_VIEW_MAX_BUFFER_BYTES,
-    }));
-  } catch (error) {
-    return ghCommandUnavailable(repoViewArgs, error);
-  }
-
-  let nameWithOwner: string | null = null;
-  try {
-    const repoView = asObject(JSON.parse(repoViewStdout));
-    nameWithOwner = repoView ? getString(repoView, "nameWithOwner") : null;
-  } catch {
-    // Handled by the unavailable result below.
-  }
-  const repositoryParts = nameWithOwner?.split("/") ?? [];
-  if (
-    repositoryParts.length !== 2 ||
-    !repositoryParts[0] ||
-    !repositoryParts[1]
-  ) {
+  if (originRepository.host !== upstreamRepository.host) {
     return {
       outcome: "unavailable",
-      message: "gh repo view returned unparseable output",
+      message:
+        "Configured upstream remote host does not match the origin GitHub host",
     };
   }
 
   return {
     outcome: "upstream-branch",
-    selector: `${repositoryParts[0]}:${upstreamBranch}`,
+    selector: `${upstreamRepository.owner}:${upstreamBranch}`,
   };
 }
 
@@ -543,8 +579,10 @@ async function getPullRequestTarget(
  * Detect the open/most-relevant GitHub pull request for the branch checked out
  * in `cwd` by shelling out to the host `gh` CLI. Bare `gh pr view` correctly
  * resolves the configured upstream owner, but combines it with the local branch
- * name. When Git tracks a differently named upstream branch, resolve the
- * upstream remote owner and pass the fully qualified `owner:branch` selector.
+ * name. When Git tracks a differently named upstream branch, parse the owner
+ * locally from a same-host upstream and pass the fully qualified
+ * `owner:branch` selector. Configured URLs are never passed to `gh`, which
+ * inherits user auth tokens.
  *
  * Never throws: a branch with no PR is `outcome: "none"`, while every lookup
  * failure (`gh` not installed, not authenticated, no GitHub remote, a timeout,
@@ -590,15 +628,21 @@ export async function getPullRequestForCurrentBranch(
 }
 
 /**
- * Mutate the GitHub pull request for the branch checked out in `cwd`. Omitting
- * a positional target lets `gh` honor a fork branch's configured upstream.
- * Unlike pull-request detection, mutation failures are meaningful and are
- * surfaced to the caller.
+ * Mutate the GitHub pull request for the branch checked out in `cwd`. Uses the
+ * same qualified upstream target as detection when the tracked branch has a
+ * different name. Mutation failures are meaningful and surface to the caller.
  */
 export async function runPullRequestActionForCurrentBranch(
   args: RunPullRequestActionForCurrentBranchArgs,
 ): Promise<void> {
-  const ghArgs = buildPullRequestActionArgs(args.action);
+  const target = await getPullRequestTarget(args);
+  if (target.outcome === "unavailable") {
+    throw new WorkspaceError("git_host_command_failed", target.message);
+  }
+  const ghArgs = buildPullRequestActionArgs(
+    args.action,
+    target.outcome === "upstream-branch" ? target.selector : null,
+  );
   try {
     await execFileAsync("gh", ghArgs, {
       cwd: args.cwd,

--- a/packages/host-workspace/src/git-host.ts
+++ b/packages/host-workspace/src/git-host.ts
@@ -549,6 +549,13 @@ async function getPullRequestTarget(
     return { outcome: "current-branch" };
   }
 
+  // Managed worktrees intentionally track the base branch on origin so Git
+  // can report ahead/behind state. That is not the PR head: a pushed PR still
+  // uses the managed local branch name, which bare `gh pr view` resolves.
+  if (remote === "origin") {
+    return { outcome: "current-branch" };
+  }
+
   const originRepository = parseGitRemoteRepository(
     config.get("remote.origin.url") ?? "",
   );
@@ -569,6 +576,16 @@ async function getPullRequestTarget(
     };
   }
 
+  // A differently named branch on an alias of the origin repository is base
+  // or integration tracking, not a fork PR head. Only substitute the tracked
+  // branch when the remote belongs to another GitHub owner.
+  if (
+    originRepository.owner.toLowerCase() ===
+    upstreamRepository.owner.toLowerCase()
+  ) {
+    return { outcome: "current-branch" };
+  }
+
   return {
     outcome: "upstream-branch",
     selector: `${upstreamRepository.owner}:${upstreamBranch}`,
@@ -579,10 +596,11 @@ async function getPullRequestTarget(
  * Detect the open/most-relevant GitHub pull request for the branch checked out
  * in `cwd` by shelling out to the host `gh` CLI. Bare `gh pr view` correctly
  * resolves the configured upstream owner, but combines it with the local branch
- * name. When Git tracks a differently named upstream branch, parse the owner
- * locally from a same-host upstream and pass the fully qualified
- * `owner:branch` selector. Configured URLs are never passed to `gh`, which
- * inherits user auth tokens.
+ * name. When Git tracks a differently named branch on a different-owner fork,
+ * parse the owner locally from a same-host upstream and pass the fully
+ * qualified `owner:branch` selector. Base-branch tracking on origin continues
+ * to use the managed local branch name. Configured URLs are never passed to
+ * `gh`, which inherits user auth tokens.
  *
  * Never throws: a branch with no PR is `outcome: "none"`, while every lookup
  * failure (`gh` not installed, not authenticated, no GitHub remote, a timeout,

--- a/packages/host-workspace/src/git-host.ts
+++ b/packages/host-workspace/src/git-host.ts
@@ -11,12 +11,13 @@ import {
   gitHostPullRequestSchema,
 } from "@bb/domain";
 import { sanitizeInheritedChildProcessEnv } from "@bb/process-utils";
-import { WorkspaceError } from "./git.js";
+import { runGit, type GitCommandResult, WorkspaceError } from "./git.js";
 
 const execFileAsync = promisify(execFile);
 
 /** `gh` is a network round-trip; cap it so it never blocks a status poll. */
 const GH_PR_VIEW_TIMEOUT_MS = 10_000;
+const GIT_UPSTREAM_LOOKUP_TIMEOUT_MS = 10_000;
 
 /**
  * Explicit stdout cap rather than Node's 1 MB execFile default. The selected
@@ -43,9 +44,11 @@ const GH_PR_VIEW_JSON_FIELDS = [
   "mergeStateStatus",
   "mergeable",
 ].join(",");
+const GH_REPO_VIEW_JSON_FIELDS = "nameWithOwner";
 
 interface GetPullRequestForCurrentBranchArgs {
   cwd: string;
+  localBranch: string;
 }
 
 export type GitHostPullRequestMergeMethod = "merge" | "squash" | "rebase";
@@ -367,6 +370,36 @@ export type GitHostPullRequestLookup =
 /** `gh pr view` stderr for a branch that genuinely has no pull request. */
 const GH_NO_PULL_REQUEST_PATTERN = /no pull requests found for branch/iu;
 
+type PullRequestTargetLookup =
+  | { outcome: "current-branch" }
+  | { outcome: "upstream-branch"; selector: string }
+  | Extract<GitHostPullRequestLookup, { outcome: "unavailable" }>;
+
+function ghCommandUnavailable(
+  ghArgs: string[],
+  error: unknown,
+): Extract<GitHostPullRequestLookup, { outcome: "unavailable" }> {
+  const execError = getExecFileException(error);
+  if (execError?.code === "ENOENT") {
+    return { outcome: "unavailable", message: "GitHub CLI is not available" };
+  }
+  if (execError?.killed) {
+    return {
+      outcome: "unavailable",
+      message: `gh ${ghArgs.slice(0, 2).join(" ")} timed out after ${GH_PR_VIEW_TIMEOUT_MS}ms`,
+    };
+  }
+  const detail =
+    trimGhOutput(execError?.stderr) ||
+    trimGhOutput(execError?.stdout) ||
+    (error instanceof Error ? error.message : "");
+  const command = `gh ${ghArgs.slice(0, 2).join(" ")}`;
+  return {
+    outcome: "unavailable",
+    message: detail ? `${command} failed: ${detail}` : `${command} failed`,
+  };
+}
+
 /**
  * Classify a failed `gh pr view` invocation. Only the "no pull requests
  * found" answer is genuine absence; everything else (gh missing, auth
@@ -379,30 +412,139 @@ function classifyPullRequestViewError(
   if (GH_NO_PULL_REQUEST_PATTERN.test(trimGhOutput(execError?.stderr))) {
     return { outcome: "none" };
   }
-  if (execError?.code === "ENOENT") {
-    return { outcome: "unavailable", message: "GitHub CLI is not available" };
-  }
-  if (execError?.killed) {
-    return {
-      outcome: "unavailable",
-      message: `gh pr view timed out after ${GH_PR_VIEW_TIMEOUT_MS}ms`,
-    };
-  }
-  const detail =
-    trimGhOutput(execError?.stderr) ||
-    trimGhOutput(execError?.stdout) ||
-    (error instanceof Error ? error.message : "");
+  return ghCommandUnavailable(["pr", "view"], error);
+}
+
+function gitUpstreamLookupUnavailable(
+  message: string,
+  detail: string,
+): Extract<GitHostPullRequestLookup, { outcome: "unavailable" }> {
   return {
     outcome: "unavailable",
-    message: detail ? `gh pr view failed: ${detail}` : "gh pr view failed",
+    message: detail ? `${message}: ${detail}` : message,
+  };
+}
+
+async function getPullRequestTarget(
+  args: GetPullRequestForCurrentBranchArgs,
+): Promise<PullRequestTargetLookup> {
+  const localRef = `refs/heads/${args.localBranch}`;
+  let upstreamResult: GitCommandResult;
+  try {
+    upstreamResult = await runGit(
+      [
+        "for-each-ref",
+        "--format=%(refname)%00%(upstream:remotename)%00%(upstream:remoteref)",
+        localRef,
+      ],
+      {
+        cwd: args.cwd,
+        allowFailure: true,
+        timeoutMs: GIT_UPSTREAM_LOOKUP_TIMEOUT_MS,
+      },
+    );
+  } catch (error) {
+    return gitUpstreamLookupUnavailable(
+      "Could not inspect the current branch's configured upstream",
+      error instanceof Error ? error.message : "",
+    );
+  }
+  if (upstreamResult.exitCode !== 0) {
+    return gitUpstreamLookupUnavailable(
+      "Could not inspect the current branch's configured upstream",
+      upstreamResult.stderr.trim(),
+    );
+  }
+
+  const upstreamEntry = upstreamResult.stdout
+    .trimEnd()
+    .split("\n")
+    .map((line) => line.split("\0"))
+    .find(([ref]) => ref === localRef);
+  const remote = upstreamEntry?.[1] ?? "";
+  const remoteRef = upstreamEntry?.[2] ?? "";
+  const remoteBranchPrefix = "refs/heads/";
+  if (!remote || remote === "." || !remoteRef.startsWith(remoteBranchPrefix)) {
+    return { outcome: "current-branch" };
+  }
+
+  const upstreamBranch = remoteRef.slice(remoteBranchPrefix.length);
+  if (!upstreamBranch || upstreamBranch === args.localBranch) {
+    return { outcome: "current-branch" };
+  }
+
+  let remoteUrlResult: GitCommandResult;
+  try {
+    remoteUrlResult = await runGit(["remote", "get-url", remote], {
+      cwd: args.cwd,
+      allowFailure: true,
+      timeoutMs: GIT_UPSTREAM_LOOKUP_TIMEOUT_MS,
+    });
+  } catch (error) {
+    return gitUpstreamLookupUnavailable(
+      `Could not resolve URL for Git remote ${remote}`,
+      error instanceof Error ? error.message : "",
+    );
+  }
+  const remoteUrl = remoteUrlResult.stdout.trim();
+  if (remoteUrlResult.exitCode !== 0 || !remoteUrl) {
+    return gitUpstreamLookupUnavailable(
+      `Could not resolve URL for Git remote ${remote}`,
+      remoteUrlResult.stderr.trim(),
+    );
+  }
+
+  const repoViewArgs = [
+    "repo",
+    "view",
+    remoteUrl,
+    "--json",
+    GH_REPO_VIEW_JSON_FIELDS,
+  ];
+  let repoViewStdout: string;
+  try {
+    ({ stdout: repoViewStdout } = await execFileAsync("gh", repoViewArgs, {
+      cwd: args.cwd,
+      encoding: "utf8",
+      env: sanitizeInheritedChildProcessEnv({ env: process.env }),
+      timeout: GH_PR_VIEW_TIMEOUT_MS,
+      maxBuffer: GH_PR_VIEW_MAX_BUFFER_BYTES,
+    }));
+  } catch (error) {
+    return ghCommandUnavailable(repoViewArgs, error);
+  }
+
+  let nameWithOwner: string | null = null;
+  try {
+    const repoView = asObject(JSON.parse(repoViewStdout));
+    nameWithOwner = repoView ? getString(repoView, "nameWithOwner") : null;
+  } catch {
+    // Handled by the unavailable result below.
+  }
+  const repositoryParts = nameWithOwner?.split("/") ?? [];
+  if (
+    repositoryParts.length !== 2 ||
+    !repositoryParts[0] ||
+    !repositoryParts[1]
+  ) {
+    return {
+      outcome: "unavailable",
+      message: "gh repo view returned unparseable output",
+    };
+  }
+
+  return {
+    outcome: "upstream-branch",
+    selector: `${repositoryParts[0]}:${upstreamBranch}`,
   };
 }
 
 /**
  * Detect the open/most-relevant GitHub pull request for the branch checked out
- * in `cwd` by shelling out to the host `gh` CLI. The command deliberately has
- * no positional branch target: `gh` can then follow the branch's configured
- * upstream remote, which is required when the PR head belongs to a fork.
+ * in `cwd` by shelling out to the host `gh` CLI. Bare `gh pr view` correctly
+ * resolves the configured upstream owner, but combines it with the local branch
+ * name. When Git tracks a differently named upstream branch, resolve the
+ * upstream remote owner and pass the fully qualified `owner:branch` selector.
  *
  * Never throws: a branch with no PR is `outcome: "none"`, while every lookup
  * failure (`gh` not installed, not authenticated, no GitHub remote, a timeout,
@@ -414,19 +556,26 @@ function classifyPullRequestViewError(
 export async function getPullRequestForCurrentBranch(
   args: GetPullRequestForCurrentBranchArgs,
 ): Promise<GitHostPullRequestLookup> {
+  const target = await getPullRequestTarget(args);
+  if (target.outcome === "unavailable") {
+    return target;
+  }
+  const ghArgs = [
+    "pr",
+    "view",
+    ...(target.outcome === "upstream-branch" ? [target.selector] : []),
+    "--json",
+    GH_PR_VIEW_JSON_FIELDS,
+  ];
   let stdout: string;
   try {
-    ({ stdout } = await execFileAsync(
-      "gh",
-      ["pr", "view", "--json", GH_PR_VIEW_JSON_FIELDS],
-      {
-        cwd: args.cwd,
-        encoding: "utf8",
-        env: sanitizeInheritedChildProcessEnv({ env: process.env }),
-        timeout: GH_PR_VIEW_TIMEOUT_MS,
-        maxBuffer: GH_PR_VIEW_MAX_BUFFER_BYTES,
-      },
-    ));
+    ({ stdout } = await execFileAsync("gh", ghArgs, {
+      cwd: args.cwd,
+      encoding: "utf8",
+      env: sanitizeInheritedChildProcessEnv({ env: process.env }),
+      timeout: GH_PR_VIEW_TIMEOUT_MS,
+      maxBuffer: GH_PR_VIEW_MAX_BUFFER_BYTES,
+    }));
   } catch (error) {
     return classifyPullRequestViewError(error);
   }

--- a/packages/host-workspace/src/workspace.ts
+++ b/packages/host-workspace/src/workspace.ts
@@ -720,7 +720,11 @@ export class Workspace {
         "Cannot update pull request from a detached workspace",
       );
     }
-    return runPullRequestActionForCurrentBranch({ cwd: this.path, action });
+    return runPullRequestActionForCurrentBranch({
+      cwd: this.path,
+      localBranch: branch,
+      action,
+    });
   }
 
   async getStatus(options: StatusOptions = {}): Promise<WorkspaceStatus> {

--- a/packages/host-workspace/src/workspace.ts
+++ b/packages/host-workspace/src/workspace.ts
@@ -704,7 +704,10 @@ export class Workspace {
     if (!branch) {
       return { outcome: "none" };
     }
-    return getPullRequestForCurrentBranch({ cwd: this.path });
+    return getPullRequestForCurrentBranch({
+      cwd: this.path,
+      localBranch: branch,
+    });
   }
 
   async runPullRequestAction(

--- a/packages/host-workspace/test/git-host-upstream.test.ts
+++ b/packages/host-workspace/test/git-host-upstream.test.ts
@@ -1,0 +1,209 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runGit } from "../src/git.js";
+import { Workspace } from "../src/workspace.js";
+
+const execFileAsync = promisify(execFile);
+const tempDirs: string[] = [];
+
+const localBranch = "bb/review-github-issue-1235-thr_test";
+const forkRemote = "review-fork";
+const upstreamBranch = "per-turn-permission-escalation";
+const forkRemoteUrl = "git@github.com:fork-owner/bb.git";
+const qualifiedUpstream = `fork-owner:${upstreamBranch}`;
+
+function pullRequestJson(): string {
+  return JSON.stringify({
+    number: 1236,
+    title: "Apply execution settings without replacing sessions",
+    state: "OPEN",
+    url: "https://github.com/acme/bb/pull/1236",
+    isDraft: false,
+    baseRefName: "main",
+    headRefName: upstreamBranch,
+    updatedAt: "2026-08-10T12:30:00Z",
+    statusCheckRollup: [],
+    reviewDecision: null,
+    reviewRequests: [],
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+}
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempDirs.push(directory);
+  return directory;
+}
+
+async function createTrackedForkWorkspace(): Promise<string> {
+  const workspacePath = await makeTempDir("bb-pr-upstream-workspace-");
+  await runGit(["init", "-b", localBranch], { cwd: workspacePath });
+  await runGit(["config", "user.name", "BB Tests"], { cwd: workspacePath });
+  await runGit(["config", "user.email", "bb@example.com"], {
+    cwd: workspacePath,
+  });
+  await fs.writeFile(path.join(workspacePath, "README.md"), "test\n", "utf8");
+  await runGit(["add", "README.md"], { cwd: workspacePath });
+  await runGit(["commit", "-m", "Initial commit"], { cwd: workspacePath });
+  await runGit(["remote", "add", "origin", "git@github.com:acme/bb.git"], {
+    cwd: workspacePath,
+  });
+  await runGit(["remote", "add", forkRemote, forkRemoteUrl], {
+    cwd: workspacePath,
+  });
+  await runGit(
+    ["update-ref", `refs/remotes/${forkRemote}/${upstreamBranch}`, "HEAD"],
+    { cwd: workspacePath },
+  );
+  await runGit(
+    [
+      "branch",
+      "--set-upstream-to",
+      `${forkRemote}/${upstreamBranch}`,
+      localBranch,
+    ],
+    { cwd: workspacePath },
+  );
+  return workspacePath;
+}
+
+async function installFakeGh(mode: "found" | "none" | "auth"): Promise<{
+  logPath: string;
+}> {
+  const binPath = await makeTempDir("bb-pr-upstream-bin-");
+  const logPath = path.join(binPath, "gh.log");
+  const ghPath = path.join(binPath, "gh");
+  await fs.writeFile(
+    ghPath,
+    [
+      "#!/bin/sh",
+      "first=1",
+      'for argument in "$@"; do',
+      '  if [ "$first" -eq 0 ]; then printf "\\t" >> "$TEST_GH_LOG"; fi',
+      '  printf "%s" "$argument" >> "$TEST_GH_LOG"',
+      "  first=0",
+      "done",
+      'printf "\\n" >> "$TEST_GH_LOG"',
+      'if [ "$TEST_GH_MODE" = "auth" ]; then',
+      '  printf "%s\\n" "gh: To get started with GitHub CLI, please run: gh auth login" >&2',
+      "  exit 4",
+      "fi",
+      'if [ "$1" = "repo" ] && [ "$2" = "view" ]; then',
+      '  printf "%s\\n" \'{"nameWithOwner":"fork-owner/bb"}\'',
+      "  exit 0",
+      "fi",
+      'if [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = "$TEST_GH_QUALIFIED_HEAD" ]; then',
+      '  if [ "$TEST_GH_MODE" = "none" ]; then',
+      '    printf "no pull requests found for branch \\"%s\\"\\n" "$3" >&2',
+      "    exit 1",
+      "  fi",
+      '  printf "%s\\n" "$TEST_GH_PR_JSON"',
+      "  exit 0",
+      "fi",
+      'printf "unexpected gh arguments: %s\\n" "$*" >&2',
+      "exit 2",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  await fs.chmod(ghPath, 0o755);
+
+  vi.stubEnv("TEST_GH_LOG", logPath);
+  vi.stubEnv("TEST_GH_MODE", mode);
+  vi.stubEnv("TEST_GH_QUALIFIED_HEAD", qualifiedUpstream);
+  vi.stubEnv("TEST_GH_PR_JSON", pullRequestJson());
+  vi.stubEnv("PATH", `${binPath}${path.delimiter}${process.env.PATH ?? ""}`);
+  return { logPath };
+}
+
+async function readGhCalls(logPath: string): Promise<string[][]> {
+  return (await fs.readFile(logPath, "utf8"))
+    .trim()
+    .split("\n")
+    .map((line) => line.split("\t"));
+}
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await Promise.all(
+    tempDirs
+      .splice(0)
+      .map((directory) => fs.rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("pull request lookup for differently named upstream branches", () => {
+  it("qualifies the real tracked fork branch instead of the managed local branch", async () => {
+    const workspacePath = await createTrackedForkWorkspace();
+    const { logPath } = await installFakeGh("found");
+
+    await expect(
+      new Workspace(workspacePath).getPullRequest(),
+    ).resolves.toMatchObject({
+      outcome: "found",
+      pullRequest: {
+        number: 1236,
+        headRefName: upstreamBranch,
+      },
+    });
+
+    const calls = await readGhCalls(logPath);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toEqual([
+      "repo",
+      "view",
+      forkRemoteUrl,
+      "--json",
+      "nameWithOwner",
+    ]);
+    expect(calls[1]?.slice(0, 4)).toEqual([
+      "pr",
+      "view",
+      qualifiedUpstream,
+      "--json",
+    ]);
+  });
+
+  it("returns none when gh genuinely finds no PR for the qualified upstream", async () => {
+    const workspacePath = await createTrackedForkWorkspace();
+    await installFakeGh("none");
+
+    await expect(
+      new Workspace(workspacePath).getPullRequest(),
+    ).resolves.toEqual({ outcome: "none" });
+  });
+
+  it("keeps an auth failure distinct from a genuine no-PR result", async () => {
+    const workspacePath = await createTrackedForkWorkspace();
+    await installFakeGh("auth");
+
+    await expect(
+      new Workspace(workspacePath).getPullRequest(),
+    ).resolves.toEqual({
+      outcome: "unavailable",
+      message: expect.stringContaining("gh auth login"),
+    });
+  });
+
+  it("returns unavailable when gh is not installed", async () => {
+    const workspacePath = await createTrackedForkWorkspace();
+    const binPath = await makeTempDir("bb-pr-upstream-no-gh-");
+    const { stdout } = await execFileAsync("which", ["git"], {
+      encoding: "utf8",
+    });
+    await fs.symlink(stdout.trim(), path.join(binPath, "git"));
+    vi.stubEnv("PATH", binPath);
+
+    await expect(
+      new Workspace(workspacePath).getPullRequest(),
+    ).resolves.toEqual({
+      outcome: "unavailable",
+      message: "GitHub CLI is not available",
+    });
+  });
+});

--- a/packages/host-workspace/test/git-host-upstream.test.ts
+++ b/packages/host-workspace/test/git-host-upstream.test.ts
@@ -74,6 +74,28 @@ async function createTrackedForkWorkspace(
   return workspacePath;
 }
 
+async function createManagedBaseTrackedWorkspace(): Promise<string> {
+  const workspacePath = await makeTempDir("bb-pr-base-upstream-workspace-");
+  await runGit(["init", "-b", localBranch], { cwd: workspacePath });
+  await runGit(["config", "user.name", "BB Tests"], { cwd: workspacePath });
+  await runGit(["config", "user.email", "bb@example.com"], {
+    cwd: workspacePath,
+  });
+  await fs.writeFile(path.join(workspacePath, "README.md"), "test\n", "utf8");
+  await runGit(["add", "README.md"], { cwd: workspacePath });
+  await runGit(["commit", "-m", "Initial commit"], { cwd: workspacePath });
+  await runGit(["remote", "add", "origin", "git@github.com:acme/bb.git"], {
+    cwd: workspacePath,
+  });
+  await runGit(["update-ref", "refs/remotes/origin/main", "HEAD"], {
+    cwd: workspacePath,
+  });
+  await runGit(["branch", "--set-upstream-to", "origin/main", localBranch], {
+    cwd: workspacePath,
+  });
+  return workspacePath;
+}
+
 async function installFakeGh(mode: "found" | "none" | "auth"): Promise<{
   logPath: string;
 }> {
@@ -146,6 +168,38 @@ afterEach(async () => {
 });
 
 describe("pull request lookup for differently named upstream branches", () => {
+  it("uses the managed local branch when it tracks the origin base branch", async () => {
+    const workspacePath = await createManagedBaseTrackedWorkspace();
+    const { logPath } = await installFakeGh("found");
+    const workspace = new Workspace(workspacePath);
+
+    await expect(workspace.getPullRequest()).resolves.toMatchObject({
+      outcome: "found",
+      pullRequest: { number: 1236 },
+    });
+    await workspace.runPullRequestAction({ operation: "ready" });
+
+    const calls = await readGhCalls(logPath);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.slice(0, 3)).toEqual(["pr", "view", "--json"]);
+    expect(calls[1]).toEqual(["pr", "ready"]);
+  });
+
+  it("uses the local branch when a differently named remote aliases origin", async () => {
+    const workspacePath = await createTrackedForkWorkspace(
+      "git@github.com:acme/bb.git",
+    );
+    const { logPath } = await installFakeGh("found");
+
+    await expect(
+      new Workspace(workspacePath).getPullRequest(),
+    ).resolves.toMatchObject({ outcome: "found" });
+
+    const calls = await readGhCalls(logPath);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.slice(0, 3)).toEqual(["pr", "view", "--json"]);
+  });
+
   it("qualifies the real tracked fork branch instead of the managed local branch", async () => {
     const workspacePath = await createTrackedForkWorkspace();
     const { logPath } = await installFakeGh("found");

--- a/packages/host-workspace/test/git-host-upstream.test.ts
+++ b/packages/host-workspace/test/git-host-upstream.test.ts
@@ -40,7 +40,9 @@ async function makeTempDir(prefix: string): Promise<string> {
   return directory;
 }
 
-async function createTrackedForkWorkspace(): Promise<string> {
+async function createTrackedForkWorkspace(
+  remoteUrl = forkRemoteUrl,
+): Promise<string> {
   const workspacePath = await makeTempDir("bb-pr-upstream-workspace-");
   await runGit(["init", "-b", localBranch], { cwd: workspacePath });
   await runGit(["config", "user.name", "BB Tests"], { cwd: workspacePath });
@@ -53,7 +55,7 @@ async function createTrackedForkWorkspace(): Promise<string> {
   await runGit(["remote", "add", "origin", "git@github.com:acme/bb.git"], {
     cwd: workspacePath,
   });
-  await runGit(["remote", "add", forkRemote, forkRemoteUrl], {
+  await runGit(["remote", "add", forkRemote, remoteUrl], {
     cwd: workspacePath,
   });
   await runGit(
@@ -93,16 +95,15 @@ async function installFakeGh(mode: "found" | "none" | "auth"): Promise<{
       '  printf "%s\\n" "gh: To get started with GitHub CLI, please run: gh auth login" >&2',
       "  exit 4",
       "fi",
-      'if [ "$1" = "repo" ] && [ "$2" = "view" ]; then',
-      '  printf "%s\\n" \'{"nameWithOwner":"fork-owner/bb"}\'',
-      "  exit 0",
-      "fi",
-      'if [ "$1" = "pr" ] && [ "$2" = "view" ] && [ "$3" = "$TEST_GH_QUALIFIED_HEAD" ]; then',
+      'if [ "$1" = "pr" ] && [ "$2" = "view" ]; then',
       '  if [ "$TEST_GH_MODE" = "none" ]; then',
       '    printf "no pull requests found for branch \\"%s\\"\\n" "$3" >&2',
       "    exit 1",
       "  fi",
       '  printf "%s\\n" "$TEST_GH_PR_JSON"',
+      "  exit 0",
+      "fi",
+      'if [ "$1" = "pr" ] && { [ "$2" = "ready" ] || [ "$2" = "merge" ]; }; then',
       "  exit 0",
       "fi",
       'printf "unexpected gh arguments: %s\\n" "$*" >&2',
@@ -115,17 +116,24 @@ async function installFakeGh(mode: "found" | "none" | "auth"): Promise<{
 
   vi.stubEnv("TEST_GH_LOG", logPath);
   vi.stubEnv("TEST_GH_MODE", mode);
-  vi.stubEnv("TEST_GH_QUALIFIED_HEAD", qualifiedUpstream);
   vi.stubEnv("TEST_GH_PR_JSON", pullRequestJson());
   vi.stubEnv("PATH", `${binPath}${path.delimiter}${process.env.PATH ?? ""}`);
   return { logPath };
 }
 
 async function readGhCalls(logPath: string): Promise<string[][]> {
-  return (await fs.readFile(logPath, "utf8"))
-    .trim()
-    .split("\n")
-    .map((line) => line.split("\t"));
+  try {
+    return (await fs.readFile(logPath, "utf8"))
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => line.split("\t"));
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
 }
 
 afterEach(async () => {
@@ -153,19 +161,71 @@ describe("pull request lookup for differently named upstream branches", () => {
     });
 
     const calls = await readGhCalls(logPath);
-    expect(calls).toHaveLength(2);
-    expect(calls[0]).toEqual([
-      "repo",
-      "view",
-      forkRemoteUrl,
-      "--json",
-      "nameWithOwner",
-    ]);
-    expect(calls[1]?.slice(0, 4)).toEqual([
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.slice(0, 4)).toEqual([
       "pr",
       "view",
       qualifiedUpstream,
       "--json",
+    ]);
+  });
+
+  it("never passes an untrusted upstream URL to gh", async () => {
+    const workspacePath = await createTrackedForkWorkspace(
+      "https://httpbin.org/fork-owner/bb.git",
+    );
+    const { logPath } = await installFakeGh("found");
+    vi.stubEnv("GH_ENTERPRISE_TOKEN", "dummy-enterprise-token");
+
+    await expect(
+      new Workspace(workspacePath).getPullRequest(),
+    ).resolves.toEqual({
+      outcome: "unavailable",
+      message:
+        "Configured upstream remote host does not match the origin GitHub host",
+    });
+    expect(await readGhCalls(logPath)).toEqual([]);
+  });
+
+  it("uses a changed remote URL on the next lookup", async () => {
+    const workspacePath = await createTrackedForkWorkspace();
+    const { logPath } = await installFakeGh("found");
+    const workspace = new Workspace(workspacePath);
+
+    await expect(workspace.getPullRequest()).resolves.toMatchObject({
+      outcome: "found",
+    });
+    await runGit(
+      ["remote", "set-url", forkRemote, "git@github.com:other-owner/bb.git"],
+      { cwd: workspacePath },
+    );
+    await expect(workspace.getPullRequest()).resolves.toMatchObject({
+      outcome: "found",
+    });
+
+    const calls = await readGhCalls(logPath);
+    expect(calls.map((call) => call[2])).toEqual([
+      qualifiedUpstream,
+      `other-owner:${upstreamBranch}`,
+    ]);
+  });
+
+  it("uses the qualified upstream target for ready, draft, and merge actions", async () => {
+    const workspacePath = await createTrackedForkWorkspace();
+    const { logPath } = await installFakeGh("found");
+    const workspace = new Workspace(workspacePath);
+
+    await workspace.runPullRequestAction({ operation: "ready" });
+    await workspace.runPullRequestAction({ operation: "draft" });
+    await workspace.runPullRequestAction({
+      operation: "merge",
+      method: "squash",
+    });
+
+    expect(await readGhCalls(logPath)).toEqual([
+      ["pr", "ready", qualifiedUpstream],
+      ["pr", "ready", qualifiedUpstream, "--undo"],
+      ["pr", "merge", qualifiedUpstream, "--squash"],
     ]);
   });
 

--- a/packages/host-workspace/test/git-host.test.ts
+++ b/packages/host-workspace/test/git-host.test.ts
@@ -263,14 +263,23 @@ describe("runPullRequestActionForCurrentBranch", () => {
 });
 
 describe("getPullRequestForCurrentBranch", () => {
+  const lookupArgs = {
+    cwd: "/tmp/workspace",
+    localBranch: "bb/pr-lookup",
+  };
+
   function mockGhStdout(stdout: string): void {
     execFileMock.mockImplementation(
       (
-        _file: string,
+        file: string,
         _args: readonly string[],
         _options: object,
         callback: (error: Error | null, stdout: string, stderr: string) => void,
       ) => {
+        if (file === "git") {
+          callback(null, `refs/heads/${lookupArgs.localBranch}\0\0\0\n`, "");
+          return;
+        }
         callback(null, stdout, "");
       },
     );
@@ -279,19 +288,25 @@ describe("getPullRequestForCurrentBranch", () => {
   function mockGhFailure(error: Error): void {
     execFileMock.mockImplementation(
       (
-        _file: string,
+        file: string,
         _args: readonly string[],
         _options: object,
-        callback: (error: Error) => void,
+        callback: (
+          error: Error | null,
+          stdout?: string,
+          stderr?: string,
+        ) => void,
       ) => {
+        if (file === "git") {
+          callback(null, `refs/heads/${lookupArgs.localBranch}\0\0\0\n`, "");
+          return;
+        }
         callback(error);
       },
     );
   }
 
-  const lookupArgs = { cwd: "/tmp/workspace" };
-
-  it("lets gh resolve the current branch through its configured upstream", async () => {
+  it("uses bare gh lookup when the branch has no differently named upstream", async () => {
     mockGhStdout(ghJson());
     await expect(
       getPullRequestForCurrentBranch(lookupArgs),
@@ -333,8 +348,7 @@ describe("getPullRequestForCurrentBranch", () => {
     mockGhFailure(
       Object.assign(new Error("gh exited 4"), {
         code: 4,
-        stderr:
-          "gh: To get started with GitHub CLI, please run: gh auth login",
+        stderr: "gh: To get started with GitHub CLI, please run: gh auth login",
       }),
     );
     const result = await getPullRequestForCurrentBranch(lookupArgs);

--- a/packages/host-workspace/test/git-host.test.ts
+++ b/packages/host-workspace/test/git-host.test.ts
@@ -180,14 +180,23 @@ describe("parseGitHostPullRequest", () => {
 });
 
 describe("runPullRequestActionForCurrentBranch", () => {
+  const actionArgs = {
+    cwd: "/tmp/workspace",
+    localBranch: "bb/pr-action",
+  };
+
   function mockGhSuccess(): void {
     execFileMock.mockImplementation(
       (
-        _file: string,
+        file: string,
         _args: readonly string[],
         _options: object,
         callback: (error: Error | null, stdout: string, stderr: string) => void,
       ) => {
+        if (file === "git") {
+          callback(null, "", "");
+          return;
+        }
         callback(null, "", "");
       },
     );
@@ -217,7 +226,7 @@ describe("runPullRequestActionForCurrentBranch", () => {
       mockGhSuccess();
 
       await runPullRequestActionForCurrentBranch({
-        cwd: "/tmp/workspace",
+        ...actionArgs,
         action,
       });
 
@@ -241,18 +250,26 @@ describe("runPullRequestActionForCurrentBranch", () => {
     });
     execFileMock.mockImplementation(
       (
-        _file: string,
+        file: string,
         _args: readonly string[],
         _options: object,
-        callback: (error: Error) => void,
+        callback: (
+          error: Error | null,
+          stdout?: string,
+          stderr?: string,
+        ) => void,
       ) => {
+        if (file === "git") {
+          callback(null, "", "");
+          return;
+        }
         callback(error);
       },
     );
 
     await expect(
       runPullRequestActionForCurrentBranch({
-        cwd: "/tmp/workspace",
+        ...actionArgs,
         action: { operation: "ready" },
       }),
     ).rejects.toMatchObject({
@@ -277,7 +294,7 @@ describe("getPullRequestForCurrentBranch", () => {
         callback: (error: Error | null, stdout: string, stderr: string) => void,
       ) => {
         if (file === "git") {
-          callback(null, `refs/heads/${lookupArgs.localBranch}\0\0\0\n`, "");
+          callback(null, "", "");
           return;
         }
         callback(null, stdout, "");
@@ -298,7 +315,7 @@ describe("getPullRequestForCurrentBranch", () => {
         ) => void,
       ) => {
         if (file === "git") {
-          callback(null, `refs/heads/${lookupArgs.localBranch}\0\0\0\n`, "");
+          callback(null, "", "");
           return;
         }
         callback(error);


### PR DESCRIPTION
## Summary

- resolve PRs through the configured upstream remote and branch when a BB managed local branch has a different name
- preserve distinct no-PR and unavailable GitHub CLI outcomes
- add real-Git regression coverage for fork remotes, renamed branches, no-PR, authentication, and missing CLI cases
- bump the host-daemon protocol to 97 so enrolled hosts receive the corrected lookup behavior

## Validation

- pnpm exec turbo run test --filter=@bb/host-workspace --force
- pnpm exec turbo run test --filter=@bb/host-daemon-contract --force
- pnpm exec turbo run typecheck --filter=@bb/host-workspace
- pnpm exec turbo run typecheck --filter=@bb/host-daemon-contract --filter=@bb/host-daemon
- live read-only lookup against env_yikdjjfryt resolved get-bb/bb#1236