### PR TITLE
fix: correct plugin composer banner spacing

### DIFF
--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -286,7 +286,7 @@ function FollowUpPromptBoxStackOnly({
     <PluginComposerViewProvider value={composerView}>
       <PluginComposerHostProvider value={pluginComposerHost ?? null}>
         <div data-promptbox-shell="" className="space-y-2">
-          <div className="space-y-2">
+          <div className="grid gap-2">
             {composerScope ? <PluginComposerBanners /> : null}
             {stack}
           </div>
@@ -793,7 +793,7 @@ function FollowUpPromptBoxWithComposer({
             data-promptbox-shell=""
             className="space-y-2"
           >
-            <div ref={stackRef} className="space-y-2">
+            <div ref={stackRef} className="grid gap-2">
               {composerScope ? <PluginComposerBanners /> : null}
               {stack}
             </div>

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -310,7 +310,7 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
       <PluginComposerViewProvider value={composerView}>
         <PluginComposerHostProvider value={pluginComposerHost ?? null}>
           {modeConfig.banner || pluginComposerHost ? (
-            <div className="mb-2 space-y-2">
+            <div className="mb-2 grid gap-2">
               {modeConfig.banner}
               {pluginComposerHost ? <PluginComposerBanners /> : null}
             </div>

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -1543,7 +1543,7 @@ export function ThreadDetailPromptArea({
 
   const bottomContent =
     activePendingInteraction && !shouldHideComposer ? (
-      <div className="space-y-2">
+      <div className="grid gap-2">
         {activePromptMode ? activePromptModeCard : null}
         {goal ? activeGoalCard : null}
         <PluginComposerHostProvider value={normalPluginComposerHost}>


### PR DESCRIPTION
## Summary

- use gap-based grid stacks so `display: contents` plugin mounts receive vertical spacing
- keep plugin banners consistently spaced in follow-up, new-thread, and pending-interaction composers

## Visual verification

- before: two plugin composer banners touch with a measured 0 px gap

<img width="1456" height="480" alt="before" src="https://github.com/user-attachments/assets/35308556-dac9-417c-a999-045d2e338b30" />


- after: the same banners have the intended 8 CSS px gap

<img width="1456" height="496" alt="after" src="https://github.com/user-attachments/assets/8a5ee802-c584-4993-9738-95a83db2f3fc" />



## Test plan

- verified the new-thread composer in the live source-built app
- confirmed 0 px spacing on `main` and 8 px spacing on this branch
- confirmed no browser page errors


