### PR TITLE
Inject the bb CLI into every automation script run

### DIFF
--- a/packages/bb-app/src/launcher.ts
+++ b/packages/bb-app/src/launcher.ts
@@ -2419,7 +2419,14 @@ function createServerEnv(args: CreateServerEnvArgs): NodeJS.ProcessEnv {
     // The daemon bundle holds the bb CLI. Server-side features that shell out
     // — script automations put it on the script's PATH — otherwise have no way
     // to find it: bb lives in the bundle directory, which is on no shell PATH.
-    // Matches createDaemonEnv, which has always passed this through.
+    // BB_CLI_DIR matches createDaemonEnv, which has always passed it through.
+    //
+    // BB_CLI is set rather than inherited on purpose. Launching bb-app from an
+    // agent shell brings that shell's BB_CLI along, pointing at whichever
+    // install spawned it. That binary can be older than this bundle and still
+    // answer `--version`, so an inherited value would quietly win over the
+    // bundle actually being run.
+    BB_CLI: join(args.context.daemonBundleDir, "bb"),
     BB_CLI_DIR: args.context.daemonBundleDir,
     BB_DATA_DIR: args.context.dataDir,
     BB_HOST_DAEMON_PORT: String(args.context.daemonPort),

--- a/packages/bb-app/src/launcher.ts
+++ b/packages/bb-app/src/launcher.ts
@@ -2416,6 +2416,11 @@ function createServerEnv(args: CreateServerEnvArgs): NodeJS.ProcessEnv {
     ...args.env,
     BB_APP_VERSION: args.context.appVersion,
     [APP_SURFACE_ENV_NAME]: APP_SURFACE_WEB,
+    // The daemon bundle holds the bb CLI. Server-side features that shell out
+    // — script automations put it on the script's PATH — otherwise have no way
+    // to find it: bb lives in the bundle directory, which is on no shell PATH.
+    // Matches createDaemonEnv, which has always passed this through.
+    BB_CLI_DIR: args.context.daemonBundleDir,
     BB_DATA_DIR: args.context.dataDir,
     BB_HOST_DAEMON_PORT: String(args.context.daemonPort),
     BB_SERVER_PORT: String(args.context.serverPort),

--- a/plugins/automations/skills/automations/SKILL.md
+++ b/plugins/automations/skills/automations/SKILL.md
@@ -71,9 +71,12 @@ BB_SERVER_URL          The bb server API base URL
 BB_PROJECT_ID          The automation's project
 BB_AUTOMATION_ID       The automation id
 BB_AUTOMATION_RUN_ID   This run id
+BB_CLI                 Absolute path to the bb CLI, when it could be resolved
 ```
 
-`BB_ENVIRONMENT_ID` and `BB_HOST_DAEMON_PORT` are intentionally not injected by the plugin. The plugin resolves `bb` and prepends its directory to `PATH` so scripts can call the CLI.
+`BB_ENVIRONMENT_ID` and `BB_HOST_DAEMON_PORT` are intentionally not injected by the plugin. The plugin resolves `bb` and prepends its directory to `PATH` so scripts can call the CLI. It looks at `BB_CLI`, then `BB_CLI_DIR`, then `PATH`, then the common macOS install paths.
+
+If `bb` cannot be found, the script still runs. The run output starts with a `[bb] warning:` line, and a script that calls `bb` fails on that line rather than before its first line.
 
 Managing:
 

--- a/plugins/automations/src/automations.test.ts
+++ b/plugins/automations/src/automations.test.ts
@@ -692,26 +692,44 @@ describe("bb CLI injection for script runs", () => {
     );
   });
 
-  it("still falls back to PATH and the macOS locations", () => {
-    expect(bbBinaryCandidates({})).toEqual([
-      "bb",
+  it("expands PATH itself so every candidate is absolute", () => {
+    // The resolved value is handed to scripts as BB_CLI, which is documented
+    // as absolute; a bare "bb" would re-resolve if a script edits PATH.
+    expect(bbBinaryCandidates({ PATH: "/usr/bin:/opt/tools" })).toEqual([
+      "/usr/bin/bb",
+      "/opt/tools/bb",
       "/opt/homebrew/bin/bb",
       "/usr/local/bin/bb",
     ]);
-    // Blank env vars are ignored rather than becoming a "/bb" candidate.
-    expect(bbBinaryCandidates({ BB_CLI: "  ", BB_CLI_DIR: "" })).toEqual([
-      "bb",
+    expect(
+      bbBinaryCandidates({ PATH: "/usr/bin" }).every((c) => c.startsWith("/")),
+    ).toBe(true);
+  });
+
+  it("drops entries that would resolve against the wrong directory", () => {
+    // An empty PATH entry means the cwd, which for a script run is the
+    // automation scripts directory — a `bb` dropped there is not the CLI.
+    expect(bbBinaryCandidates({ PATH: "/usr/bin::/bin" })).toEqual([
+      "/usr/bin/bb",
+      "/bin/bb",
       "/opt/homebrew/bin/bb",
       "/usr/local/bin/bb",
     ]);
+    // Blank or relative env pointers are skipped, not resolved against cwd.
+    expect(
+      bbBinaryCandidates({ BB_CLI: "  ", BB_CLI_DIR: "", PATH: "" }),
+    ).toEqual(["/opt/homebrew/bin/bb", "/usr/local/bin/bb"]);
+    expect(
+      bbBinaryCandidates({ BB_CLI: "./bb", BB_CLI_DIR: "rel/dir", PATH: "" }),
+    ).toEqual(["/opt/homebrew/bin/bb", "/usr/local/bin/bb"]);
   });
 
   it("prepends bb's directory to PATH only when it is absolute", () => {
     expect(scriptPathEnv("/daemon/bundle/bb", "/usr/bin:/bin")).toBe(
       "/daemon/bundle:/usr/bin:/bin",
     );
-    // A bare "bb" is already on PATH; dirname() would be "." and would put the
-    // scripts directory ahead of the system PATH.
+    // Guard against a relative path ever reaching here: dirname() would be "."
+    // and would put the scripts directory ahead of the system PATH.
     expect(scriptPathEnv("bb", "/usr/bin:/bin")).toBe("/usr/bin:/bin");
     expect(scriptPathEnv(null, "/usr/bin:/bin")).toBe("/usr/bin:/bin");
     expect(scriptPathEnv("/daemon/bundle/bb", undefined)).toBe(

--- a/plugins/automations/src/automations.test.ts
+++ b/plugins/automations/src/automations.test.ts
@@ -30,8 +30,10 @@ import {
   validateOnceDefinition,
 } from "./schedule-helpers.js";
 import {
+  bbBinaryCandidates,
   isWakeAgentSuppressed,
   mapScriptResultToRun,
+  scriptPathEnv,
 } from "./script-runner.js";
 import { sweepDueAutomations } from "./sweep.js";
 import { createAutomationService } from "./service.js";
@@ -673,6 +675,48 @@ describe("automation service", () => {
     } finally {
       await rm(pluginDataDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("bb CLI injection for script runs", () => {
+  it("prefers the env pointers over PATH and macOS install locations", () => {
+    expect(
+      bbBinaryCandidates({
+        BB_CLI: "/daemon/bundle/bb",
+        BB_CLI_DIR: "/other/dir",
+      })[0],
+    ).toBe("/daemon/bundle/bb");
+    // The server process gets BB_CLI_DIR, not BB_CLI, from the launcher.
+    expect(bbBinaryCandidates({ BB_CLI_DIR: "/daemon/bundle" })[0]).toBe(
+      "/daemon/bundle/bb",
+    );
+  });
+
+  it("still falls back to PATH and the macOS locations", () => {
+    expect(bbBinaryCandidates({})).toEqual([
+      "bb",
+      "/opt/homebrew/bin/bb",
+      "/usr/local/bin/bb",
+    ]);
+    // Blank env vars are ignored rather than becoming a "/bb" candidate.
+    expect(bbBinaryCandidates({ BB_CLI: "  ", BB_CLI_DIR: "" })).toEqual([
+      "bb",
+      "/opt/homebrew/bin/bb",
+      "/usr/local/bin/bb",
+    ]);
+  });
+
+  it("prepends bb's directory to PATH only when it is absolute", () => {
+    expect(scriptPathEnv("/daemon/bundle/bb", "/usr/bin:/bin")).toBe(
+      "/daemon/bundle:/usr/bin:/bin",
+    );
+    // A bare "bb" is already on PATH; dirname() would be "." and would put the
+    // scripts directory ahead of the system PATH.
+    expect(scriptPathEnv("bb", "/usr/bin:/bin")).toBe("/usr/bin:/bin");
+    expect(scriptPathEnv(null, "/usr/bin:/bin")).toBe("/usr/bin:/bin");
+    expect(scriptPathEnv("/daemon/bundle/bb", undefined)).toBe(
+      "/daemon/bundle",
+    );
   });
 });
 

--- a/plugins/automations/src/script-runner.ts
+++ b/plugins/automations/src/script-runner.ts
@@ -1,7 +1,8 @@
 import { execFile } from "node:child_process";
-import { dirname, isAbsolute, join } from "node:path";
+import { constants } from "node:fs";
+import { delimiter, dirname, isAbsolute, join } from "node:path";
 import { promisify } from "node:util";
-import { mkdir } from "node:fs/promises";
+import { access, mkdir, stat } from "node:fs/promises";
 import {
   AUTOMATION_SCRIPT_TIMEOUT_MAX_MS,
   type AutomationScriptInterpreter,
@@ -34,28 +35,59 @@ async function commandWorks(command: string, args: string[]): Promise<boolean> {
 /**
  * Ordered places to look for the bb CLI, most authoritative first.
  *
- * The env vars come before PATH because the server process does not reliably
- * inherit a PATH containing bb — on a packaged install bb lives in the daemon
- * bundle directory, which is not on any shell PATH. `BB_CLI` (absolute path to
- * the binary) and `BB_CLI_DIR` (the directory holding it) are the two
- * documented pointers; see packages/config/src/env-vars.ts.
+ * Every candidate is an absolute path. The resolved value is handed to scripts
+ * as `BB_CLI`, which is documented as an absolute path, and a script is free to
+ * rewrite `PATH` before it runs `"$BB_CLI"` — a bare `bb` would then resolve to
+ * a different binary, or to none. Expanding `PATH` here rather than letting the
+ * shell do it also keeps the probe and the script on the same executable.
  *
- * The trailing absolute paths are macOS-only install locations and are kept as
- * a last resort. Relying on them alone is what left Linux hosts with no way to
- * resolve bb at all.
+ * The env vars come before `PATH` because the server process does not reliably
+ * inherit a `PATH` containing bb: on a packaged install bb lives in the daemon
+ * bundle directory, which is on no shell `PATH`. `BB_CLI` (the binary) and
+ * `BB_CLI_DIR` (its directory) are the two documented pointers; see
+ * packages/config/src/env-vars.ts. Relative values are skipped rather than
+ * resolved against the process cwd, which has nothing to do with either.
+ *
+ * The trailing paths are macOS-only install locations, kept as a last resort.
+ * Relying on them alone is what left Linux hosts unable to resolve bb at all.
  */
 export function bbBinaryCandidates(env: NodeJS.ProcessEnv): string[] {
   const candidates: string[] = [];
+  const pushIfAbsolute = (candidate: string): void => {
+    if (isAbsolute(candidate)) {
+      candidates.push(candidate);
+    }
+  };
   const fromCli = env.BB_CLI?.trim();
   if (fromCli !== undefined && fromCli.length > 0) {
-    candidates.push(fromCli);
+    pushIfAbsolute(fromCli);
   }
   const fromCliDir = env.BB_CLI_DIR?.trim();
   if (fromCliDir !== undefined && fromCliDir.length > 0) {
-    candidates.push(join(fromCliDir, "bb"));
+    pushIfAbsolute(join(fromCliDir, "bb"));
   }
-  candidates.push("bb", "/opt/homebrew/bin/bb", "/usr/local/bin/bb");
+  // Empty PATH entries mean "the current directory". Scripts run inside the
+  // automation scripts directory, so honouring one would let a file named `bb`
+  // dropped next to a script stand in for the CLI.
+  for (const entry of (env.PATH ?? "").split(delimiter)) {
+    const trimmed = entry.trim();
+    if (trimmed.length > 0) {
+      pushIfAbsolute(join(trimmed, "bb"));
+    }
+  }
+  candidates.push("/opt/homebrew/bin/bb", "/usr/local/bin/bb");
   return candidates;
+}
+
+async function isExecutableFile(candidate: string): Promise<boolean> {
+  try {
+    const stats = await stat(candidate);
+    if (!stats.isFile()) return false;
+    await access(candidate, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -63,12 +95,17 @@ export function bbBinaryCandidates(env: NodeJS.ProcessEnv): string[] {
  * than throwing: injection is a convenience for scripts that call `bb`, not a
  * precondition for running one. Failing the whole automation here meant a
  * script that never mentions bb still died before its first line.
+ *
+ * Candidates are stat-ed before being executed. Expanding `PATH` makes the list
+ * long, and spawning a process per entry — each with its own timeout — would
+ * make a host without bb pay seconds on every run.
  */
 export async function resolveBbBinary(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<string | null> {
   if (resolvedBbPath !== null) return resolvedBbPath;
   for (const candidate of bbBinaryCandidates(env)) {
+    if (!(await isExecutableFile(candidate))) continue;
     if (await commandWorks(candidate, ["--version"])) {
       resolvedBbPath = candidate;
       return candidate;
@@ -80,10 +117,9 @@ export async function resolveBbBinary(
 /**
  * PATH for a script run, with bb's directory prepended when it is known.
  *
- * A bare `bb` resolved off PATH is deliberately not prepended: `dirname("bb")`
- * is ".", and prepending "." would put the automation scripts directory ahead
- * of the system PATH, letting a file named `git` or `node` sitting next to a
- * script shadow the real binary.
+ * The absolute-path guard is belt and braces: bbBinaryCandidates only yields
+ * absolute paths, so a relative one would mean dirname() could return ".",
+ * putting the automation scripts directory ahead of the system PATH.
  */
 export function scriptPathEnv(
   bbPath: string | null,
@@ -94,7 +130,7 @@ export function scriptPathEnv(
     return basePath;
   }
   const bbDir = dirname(bbPath);
-  return basePath.length > 0 ? `${bbDir}:${basePath}` : bbDir;
+  return basePath.length > 0 ? `${bbDir}${delimiter}${basePath}` : bbDir;
 }
 
 export function isWakeAgentSuppressed(output: string): boolean {

--- a/plugins/automations/src/script-runner.ts
+++ b/plugins/automations/src/script-runner.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { dirname } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 import { promisify } from "node:util";
 import { mkdir } from "node:fs/promises";
 import {
@@ -18,6 +18,10 @@ const SCRIPT_OUTPUT_MAX_BYTES = 1024 * 1024;
 
 let resolvedBbPath: string | null = null;
 
+/** Warning prepended to a script's output when bb could not be injected. */
+export const BB_NOT_INJECTED_WARNING =
+  "[bb] warning: could not locate the bb CLI, so `bb` is not on PATH for this script.";
+
 async function commandWorks(command: string, args: string[]): Promise<boolean> {
   try {
     await execFileAsync(command, args, { timeout: 5_000 });
@@ -27,16 +31,70 @@ async function commandWorks(command: string, args: string[]): Promise<boolean> {
   }
 }
 
-export async function resolveBbBinary(): Promise<string> {
+/**
+ * Ordered places to look for the bb CLI, most authoritative first.
+ *
+ * The env vars come before PATH because the server process does not reliably
+ * inherit a PATH containing bb — on a packaged install bb lives in the daemon
+ * bundle directory, which is not on any shell PATH. `BB_CLI` (absolute path to
+ * the binary) and `BB_CLI_DIR` (the directory holding it) are the two
+ * documented pointers; see packages/config/src/env-vars.ts.
+ *
+ * The trailing absolute paths are macOS-only install locations and are kept as
+ * a last resort. Relying on them alone is what left Linux hosts with no way to
+ * resolve bb at all.
+ */
+export function bbBinaryCandidates(env: NodeJS.ProcessEnv): string[] {
+  const candidates: string[] = [];
+  const fromCli = env.BB_CLI?.trim();
+  if (fromCli !== undefined && fromCli.length > 0) {
+    candidates.push(fromCli);
+  }
+  const fromCliDir = env.BB_CLI_DIR?.trim();
+  if (fromCliDir !== undefined && fromCliDir.length > 0) {
+    candidates.push(join(fromCliDir, "bb"));
+  }
+  candidates.push("bb", "/opt/homebrew/bin/bb", "/usr/local/bin/bb");
+  return candidates;
+}
+
+/**
+ * Locate the bb CLI so it can be put on a script's PATH. Returns null rather
+ * than throwing: injection is a convenience for scripts that call `bb`, not a
+ * precondition for running one. Failing the whole automation here meant a
+ * script that never mentions bb still died before its first line.
+ */
+export async function resolveBbBinary(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string | null> {
   if (resolvedBbPath !== null) return resolvedBbPath;
-  const candidates = ["bb", "/opt/homebrew/bin/bb", "/usr/local/bin/bb"];
-  for (const candidate of candidates) {
+  for (const candidate of bbBinaryCandidates(env)) {
     if (await commandWorks(candidate, ["--version"])) {
       resolvedBbPath = candidate;
       return candidate;
     }
   }
-  throw new Error("bb CLI not found on PATH or in common install locations");
+  return null;
+}
+
+/**
+ * PATH for a script run, with bb's directory prepended when it is known.
+ *
+ * A bare `bb` resolved off PATH is deliberately not prepended: `dirname("bb")`
+ * is ".", and prepending "." would put the automation scripts directory ahead
+ * of the system PATH, letting a file named `git` or `node` sitting next to a
+ * script shadow the real binary.
+ */
+export function scriptPathEnv(
+  bbPath: string | null,
+  inheritedPath: string | undefined,
+): string {
+  const basePath = inheritedPath ?? "";
+  if (bbPath === null || !isAbsolute(bbPath)) {
+    return basePath;
+  }
+  const bbDir = dirname(bbPath);
+  return basePath.length > 0 ? `${bbDir}:${basePath}` : bbDir;
 }
 
 export function isWakeAgentSuppressed(output: string): boolean {
@@ -161,6 +219,23 @@ export async function executeStoredScript(args: {
   const interpreter = args.interpreter ?? resolveDefaultInterpreter(args.scriptFile);
   const command = resolveInterpreterCommand(interpreter);
   const bbPath = await resolveBbBinary();
+  // A script that never calls bb must still run, so an unresolved CLI only
+  // costs the PATH injection and leaves a note in the captured output.
+  const warning = bbPath === null ? `${BB_NOT_INJECTED_WARNING}\n` : "";
+  const scriptEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...(args.env ?? {}),
+    PATH: scriptPathEnv(bbPath, process.env.PATH),
+    BB_SERVER_URL: args.serverUrl,
+    BB_PROJECT_ID: args.projectId,
+    BB_AUTOMATION_ID: args.automationId,
+    BB_AUTOMATION_RUN_ID: args.runId,
+  };
+  // Scripts are told where bb is the same way agent shells are, so `"$BB_CLI"`
+  // works even when the directory is already on PATH.
+  if (bbPath !== null) {
+    scriptEnv.BB_CLI = bbPath;
+  }
   const cwd = scriptsRoot(args.pluginDataDir);
   await mkdir(cwd, { recursive: true });
   try {
@@ -168,26 +243,18 @@ export async function executeStoredScript(args: {
       cwd,
       timeout: Math.min(args.timeoutMs, AUTOMATION_SCRIPT_TIMEOUT_MAX_MS),
       maxBuffer: SCRIPT_OUTPUT_MAX_BYTES,
-      env: {
-        ...process.env,
-        ...(args.env ?? {}),
-        PATH: `${dirname(bbPath)}:${process.env.PATH ?? ""}`,
-        BB_SERVER_URL: args.serverUrl,
-        BB_PROJECT_ID: args.projectId,
-        BB_AUTOMATION_ID: args.automationId,
-        BB_AUTOMATION_RUN_ID: args.runId,
-      },
+      env: scriptEnv,
     });
     return {
       exitCode: 0,
-      output: combinedOutput(result.stdout, result.stderr),
+      output: `${warning}${combinedOutput(result.stdout, result.stderr)}`,
       timedOut: false,
     };
   } catch (error) {
     const err = error as ExecFileError;
     return {
       exitCode: exitCodeFromError(err),
-      output: combinedOutput(err.stdout ?? "", err.stderr ?? ""),
+      output: `${warning}${combinedOutput(err.stdout ?? "", err.stderr ?? "")}`,
       timedOut: err.killed === true && err.signal === "SIGTERM",
     };
   }


### PR DESCRIPTION
Script automations failed on this host with `bb CLI not found on PATH or in common install locations` — even when the script never called `bb`. A scheduled merge that only used `gh` and `jq` died before its first line.

## Two bugs

**1. The server had no pointer to the bb CLI.** `createServerEnv` never passed `BB_CLI_DIR`, though `createDaemonEnv` always has. bb lives in the daemon bundle directory, which is on no shell PATH, and `resolveBbBinary` only tried bare `bb` plus `/opt/homebrew/bin/bb` and `/usr/local/bin/bb`. On Linux nothing resolved. On macOS it worked only if a stray `/usr/local/bin/bb` happened to exist.

Observed on the live server process — no `BB_CLI`, no `BB_CLI_DIR`, and no bundle directory on `PATH`:

```
BB_APP_VERSION=0.36.0  BB_DATA_DIR=/home/sawyer/.bb  BB_HOST_DAEMON_PORT=38887 ...
```

**2. Failing to resolve was fatal.** `resolveBbBinary` threw, and `executeStoredScript` called it before spawning anything. Injection is a convenience for scripts that call `bb`, not a precondition for running one.

## The fix

- `createServerEnv` passes `BB_CLI_DIR`, matching `createDaemonEnv`.
- `resolveBbBinary` consults `BB_CLI`, then `BB_CLI_DIR`, then `PATH`, then the macOS paths, and returns `null` instead of throwing.
- An unresolved CLI now costs only the injection. The script runs and its output opens with `[bb] warning: ...`, so a script that does call `bb` fails on that line with its own output intact.
- Scripts also receive `BB_CLI`, matching how agent shells are set up.

## Latent PATH bug fixed along the way

When bb resolved off `PATH` as the bare name `bb`, `dirname("bb")` is `"."` — so the old code prepended `.` to `PATH`. The script cwd is the automation scripts directory, so a file named `git` or `node` next to a script would have shadowed the real binary. Only absolute paths are prepended now.

## Testing

- New unit tests for candidate ordering and the PATH construction, including the `"."` case.
- Verified end to end against the real binary: a script now reports `bb on PATH -> /home/sawyer/projects/bb/apps/host-daemon/dist/bb`, `bb --version -> 0.36.0`, `BB_CLI -> ...`.
- Verified degradation with bb unreachable: exit 0, output `[bb] warning: ...` followed by `the real work ran`.
- `turbo run typecheck test` passes for `bb-plugin-automations` (61) and `bb-app` (64).
- One `@bb/server` test fails locally (`internal-skill-trees`, a 0644-vs-0664 file-mode assertion). Confirmed identical on a clean tree — pre-existing and umask-dependent.

No `HOST_DAEMON_PROTOCOL_VERSION` bump: nothing on the server/daemon wire changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)