### PR TITLE
Prevent New project tooltip after picker dismissal

### DIFF
--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -509,7 +509,7 @@ function getSectionMutationErrorMessage(
   return getMutationErrorMessage({ error, fallbackMessage });
 }
 
-function ProjectListSectionIconButton({
+export function ProjectListSectionIconButton({
   ariaLabel,
   disabled = false,
   icon,
@@ -519,6 +519,14 @@ function ProjectListSectionIconButton({
   const handleClick = useCallback<MouseEventHandler<HTMLButtonElement>>(
     (event) => {
       event.stopPropagation();
+      // A native or in-app picker can return focus to the element that opened
+      // it. Radix then reads that restored focus as keyboard navigation and
+      // reopens the tooltip after a pointer-triggered picker is dismissed.
+      // Drop pointer focus before opening the picker; keyboard/assistive clicks
+      // have detail=0 and retain focus for navigation.
+      if (event.detail > 0) {
+        event.currentTarget.blur();
+      }
       onClick();
     },
     [onClick],

--- a/apps/app/src/components/sidebar/ProjectListSectionHeader.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectListSectionHeader.test.tsx
@@ -1,18 +1,68 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@bb/shared-ui/tooltip";
 import { createStore, Provider } from "jotai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { NO_COLLAPSED_CHILD_ACTIVITY } from "@/lib/thread-activity";
 import { splitLayoutAtom } from "@/lib/split-layout/atoms";
 import { SPLIT_LAYOUT_STORAGE_KEY } from "@/lib/split-layout/persistence";
-import { TopLevelSidebarSection } from "./ProjectList";
+import {
+  ProjectListSectionIconButton,
+  TopLevelSidebarSection,
+} from "./ProjectList";
 
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
   window.localStorage.removeItem(SPLIT_LAYOUT_STORAGE_KEY);
   window.sessionStorage.removeItem(SPLIT_LAYOUT_STORAGE_KEY);
+});
+
+describe("ProjectListSectionIconButton", () => {
+  it("drops pointer focus before a section action opens a picker", () => {
+    let triggerWasFocused = true;
+    render(
+      <TooltipProvider>
+        <ProjectListSectionIconButton
+          ariaLabel="New project"
+          icon={<span aria-hidden>+</span>}
+          title="New project"
+          onClick={() => {
+            triggerWasFocused =
+              document.activeElement ===
+              screen.getByRole("button", { name: "New project" });
+          }}
+        />
+      </TooltipProvider>,
+    );
+    const trigger = screen.getByRole("button", { name: "New project" });
+    trigger.focus();
+
+    fireEvent.click(trigger, { detail: 1 });
+
+    expect(triggerWasFocused).toBe(false);
+    expect(document.activeElement).not.toBe(trigger);
+  });
+
+  it("retains section-action focus for keyboard activation", () => {
+    render(
+      <TooltipProvider>
+        <ProjectListSectionIconButton
+          ariaLabel="New project"
+          icon={<span aria-hidden>+</span>}
+          title="New project"
+          onClick={vi.fn()}
+        />
+      </TooltipProvider>,
+    );
+    const trigger = screen.getByRole("button", { name: "New project" });
+    trigger.focus();
+
+    fireEvent.click(trigger, { detail: 0 });
+
+    expect(document.activeElement).toBe(trigger);
+  });
 });
 
 describe("TopLevelSidebarSection", () => {


### PR DESCRIPTION
## Summary

- clear pointer-acquired focus before sidebar section actions open a picker
- prevent Radix from treating native-dialog focus restoration as keyboard navigation
- preserve focus for keyboard and assistive activation
- add regression coverage for pointer and keyboard activation

## Verification

- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/sidebar/ProjectListSectionHeader.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (passes with existing warnings)