### PR TITLE
Suppress Claude command lifecycle debug events

### DIFF
--- a/packages/agent-runtime/src/claude-code/adapter.test.ts
+++ b/packages/agent-runtime/src/claude-code/adapter.test.ts
@@ -5632,4 +5632,24 @@ describe("claude-code provider adapter", () => {
     const events = adapter.translateEvent(loadFixture("system-init.json"));
     expect(events).toMatchObject([]);
   });
+
+  it("ignores Claude command lifecycle events", () => {
+    const adapter = createClaudeCodeProviderAdapter();
+    const events = adapter.translateEvent({
+      jsonrpc: "2.0",
+      method: "sdk/message",
+      params: {
+        threadId: "thread-1",
+        message: {
+          type: "command_lifecycle",
+          command_uuid: "command-1",
+          state: "started",
+          uuid: "message-1",
+          session_id: "session-1",
+        },
+      },
+    });
+
+    expect(events).toEqual([]);
+  });
 });

--- a/packages/agent-runtime/src/claude-code/visibility.ts
+++ b/packages/agent-runtime/src/claude-code/visibility.ts
@@ -94,6 +94,10 @@ interface ClaudeUnknownSdkRawEvent {
   sdkType?: string;
 }
 
+interface ClaudeCommandLifecycleRawEvent {
+  kind: "sdk/command_lifecycle";
+}
+
 interface ClaudeAssistantRawEvent {
   contentTypes: ClaudeMessageContentType[];
   kind: "sdk/assistant";
@@ -151,6 +155,7 @@ interface ClaudeSimpleStreamRawEvent {
 
 type ClaudeRawEvent =
   | ClaudeAssistantRawEvent
+  | ClaudeCommandLifecycleRawEvent
   | ClaudeErrorRawEvent
   | ClaudeNonSdkRawEvent
   | ClaudeRateLimitRawEvent
@@ -298,6 +303,9 @@ function parseClaudeRawEvent(event: JsonRpcMessage): ClaudeRawEvent {
         ),
       };
 
+    case "command_lifecycle":
+      return { kind: "sdk/command_lifecycle" };
+
     case "rate_limit_event":
       return { kind: "sdk/rate_limit_event" };
 
@@ -422,6 +430,11 @@ function describeParsedClaudeRawEvent(
       }
       return { kind, coverage: "unknown" };
     }
+
+    // Internal command queue telemetry used by remote Claude surfaces for
+    // lifecycle acknowledgements. It has no transcript or turn semantics.
+    case "sdk/command_lifecycle":
+      return { kind: "sdk/command_lifecycle", coverage: "noise" };
 
     case "sdk/user": {
       const kind = toClaudeMessageKind("sdk/user", event.contentTypes);

--- a/packages/agent-runtime/src/provider-visibility.test.ts
+++ b/packages/agent-runtime/src/provider-visibility.test.ts
@@ -93,6 +93,28 @@ describe("provider visibility raw events", () => {
     });
   });
 
+  it("classifies Claude command lifecycle events as noise", () => {
+    expect(
+      claudeCodeVisibilityMetadata.describeRawEvent({
+        jsonrpc: "2.0",
+        method: "sdk/message",
+        params: {
+          threadId: "thread-1",
+          message: {
+            type: "command_lifecycle",
+            command_uuid: "command-1",
+            state: "started",
+            uuid: "message-1",
+            session_id: "session-1",
+          },
+        },
+      } satisfies JsonRpcMessage),
+    ).toEqual({
+      kind: "sdk/command_lifecycle",
+      coverage: "noise",
+    });
+  });
+
   it("classifies Claude thinking token system events as noise", () => {
     expect(
       claudeCodeVisibilityMetadata.describeRawEvent({


### PR DESCRIPTION
## Summary

- recognize Claude `command_lifecycle` SDK telemetry explicitly
- classify the internal lifecycle acknowledgement as noise instead of persisting `provider/unhandled` rows
- cover both raw visibility classification and adapter translation

## Test plan

- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime`
- `pnpm exec turbo run test --filter=@bb/agent-runtime --force -- --run src/provider-visibility.test.ts src/claude-code/adapter.test.ts` (151 passed)

## Additional validation

The full agent-runtime suite reached 877 passing tests. The unrelated `runtime.process-lifecycle` stderr-tail assertion failed and reproduced when run in isolation.