### PR TITLE
Make required Codex updates prominent

### DIFF
--- a/apps/app/src/components/promptbox/NewThreadPromptBox.stories.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.stories.tsx
@@ -14,10 +14,8 @@ import type {
   PromptBoxAction,
 } from "@/components/promptbox/PromptBoxInternal";
 import { AUTOMATION_PROMPT_ACTION } from "@/components/promptbox/PromptBoxActionsMenu";
-import { PromptStackCard } from "@/components/promptbox/banner/PromptStackCard";
+import { CodexCliVersionBanner } from "@/components/promptbox/banner/CodexCliVersionBanner";
 import type { PickerOption } from "@/components/pickers/OptionPicker";
-import { Button } from "@bb/shared-ui/button";
-import { Icon } from "@bb/shared-ui/icon";
 import { StoryCard, StoryRow } from "../../../.ladle/story-card";
 import { ModelPickerStoryQueryProvider } from "../../../.ladle/model-picker-query-provider";
 import {
@@ -152,36 +150,6 @@ interface PromptStageProps {
 
 function PromptStage({ children }: PromptStageProps) {
   return <div className="mx-auto w-full max-w-[760px]">{children}</div>;
-}
-
-function UnsupportedCodexCliBanner() {
-  return (
-    <PromptStackCard
-      ariaLabel="Codex update needed"
-      className="overflow-hidden"
-    >
-      <div className="flex min-h-8 max-w-full items-center gap-2 px-2.5 py-1 text-xs text-muted-foreground">
-        <Icon
-          name="Info"
-          className="size-3.5 shrink-0 text-subtle-foreground"
-          aria-hidden
-        />
-        <span className="min-w-0 flex-1 truncate">
-          Update Codex to start this thread. Installed 0.135.0; required 0.136.0
-          or newer.
-        </span>
-        <Button
-          type="button"
-          size="sm"
-          variant="outline"
-          className="h-6 shrink-0 px-2 text-xs"
-          onClick={noop}
-        >
-          Update
-        </Button>
-      </div>
-    </PromptStackCard>
-  );
 }
 
 function DefaultRow() {
@@ -321,6 +289,7 @@ function UnsupportedCodexCliRow() {
         onSubmit={noop}
         isSubmitting={false}
         disabled
+        autoFocus={false}
         zenModeStorageKey="bb.story.new-thread.unsupported-codex-cli"
         history={baseHistory}
         typeahead={makeTypeahead()}
@@ -328,7 +297,15 @@ function UnsupportedCodexCliRow() {
         promptActions={promptActions}
         modeConfig={{
           ...baseModeConfig,
-          banner: <UnsupportedCodexCliBanner />,
+          banner: (
+            <CodexCliVersionBanner
+              currentVersion="0.135.0"
+              minimumSupportedVersion="0.136.0"
+              canUpdate
+              updating={false}
+              onUpdate={noop}
+            />
+          ),
         }}
         project={baseProject}
         execution={baseExecution}

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -172,6 +172,8 @@ export interface NewThreadPromptBoxUIProps {
   promptBoxRef?: Ref<PromptBoxHandle>;
   isSubmitting: boolean;
   disabled: boolean;
+  /** Whether the editor should take passive focus when it mounts. */
+  autoFocus?: boolean;
   /** Active root-composer binding for plugin composer hooks and customizations. */
   pluginComposerHost?: PluginComposerHost | null;
   textEffects?: readonly ComposerTextEffectSource[];
@@ -225,6 +227,7 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
   promptBoxRef: externalPromptBoxRef,
   isSubmitting,
   disabled,
+  autoFocus,
   pluginComposerHost,
   textEffects,
   zenModeStorageKey,
@@ -332,6 +335,7 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
               disabled,
               title: submitTitle,
             }}
+            autoFocus={autoFocus}
             zenMode={{
               layout: "root-compose",
               storageKey: zenModeStorageKey,

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -935,6 +935,23 @@ describe("PromptBoxInternal controlled value sync", () => {
     }
   });
 
+  it("releases passive editor focus when autofocus becomes blocked", async () => {
+    const restoreMatchMedia = mockPointerCoarse(false);
+    try {
+      const baseProps = createPromptBoxProps();
+      const view = render(<PromptBoxInternal {...baseProps} />);
+
+      await waitForPromptFocus();
+      view.rerender(<PromptBoxInternal {...baseProps} autoFocus={false} />);
+
+      await waitFor(() =>
+        expect(document.activeElement).not.toBe(getPromptEditorElement()),
+      );
+    } finally {
+      restoreMatchMedia();
+    }
+  });
+
   it("does not honor focus-end requests on coarse pointers", async () => {
     const restoreMatchMedia = mockPointerCoarse(true);
     try {

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -340,6 +340,11 @@ export interface PromptBoxInternalProps {
   onChange: (value: string, mentionRanges: PromptTextMention[]) => void;
   onSubmit: () => void;
   placeholder?: string;
+  /**
+   * Whether the editor should take passive focus when it mounts or its history
+   * scope changes. Explicit clicks and focus commands remain available.
+   */
+  autoFocus?: boolean;
   className?: string;
   /** Plugin-owned whole-draft paint sources, in deterministic composition order. */
   textEffects?: readonly ComposerTextEffectSource[];
@@ -1090,6 +1095,7 @@ export function PromptBoxInternal({
   onChange,
   onSubmit,
   placeholder = "Ask anything. @ to mention files, folders, or sections",
+  autoFocus = true,
   className,
   textEffects,
   onComposerLayoutChange,
@@ -1731,8 +1737,14 @@ export function PromptBoxInternal({
   }, [editor, editorEnterKeyHint, effectivePlaceholder]);
 
   useEffect(() => {
-    if (shouldAvoidSoftKeyboardAutofocus) return;
     if (!editor) return;
+    if (!autoFocus) {
+      if (editor.view.dom.contains(document.activeElement)) {
+        blurPromptEditor(editor);
+      }
+      return;
+    }
+    if (shouldAvoidSoftKeyboardAutofocus) return;
 
     const focusEditor = () => {
       if (editor.isDestroyed) return;
@@ -1748,6 +1760,7 @@ export function PromptBoxInternal({
     const handle = window.requestAnimationFrame(focusEditor);
     return () => window.cancelAnimationFrame(handle);
   }, [
+    autoFocus,
     editor,
     focusScopeKey,
     scheduleRevealEditorSelection,

--- a/apps/app/src/components/promptbox/banner/CodexCliVersionBanner.test.tsx
+++ b/apps/app/src/components/promptbox/banner/CodexCliVersionBanner.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CodexCliVersionBanner } from "./CodexCliVersionBanner";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CodexCliVersionBanner", () => {
+  it("presents the blocking update as an attention alert with a direct action", () => {
+    const onUpdate = vi.fn();
+    render(
+      <CodexCliVersionBanner
+        currentVersion="0.135.0"
+        minimumSupportedVersion="0.136.0"
+        canUpdate
+        updating={false}
+        onUpdate={onUpdate}
+      />,
+    );
+
+    const region = screen.getByRole("region", {
+      name: "Codex update required",
+    });
+    expect(region.className).toContain("bg-surface-attention");
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Update Codex before starting a thread. Installed 0.135.0; version 0.136.0 or newer is required.",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Update Codex" }));
+    expect(onUpdate).toHaveBeenCalledOnce();
+  });
+
+  it("shows update progress without repeating an ambiguous version fallback", () => {
+    render(
+      <CodexCliVersionBanner
+        currentVersion="0.135.0"
+        minimumSupportedVersion={null}
+        canUpdate
+        updating
+        onUpdate={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Installed 0.135.0; a newer version is required.",
+    );
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Updating…",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+});

--- a/apps/app/src/components/promptbox/banner/CodexCliVersionBanner.tsx
+++ b/apps/app/src/components/promptbox/banner/CodexCliVersionBanner.tsx
@@ -1,0 +1,86 @@
+import { Button } from "@bb/shared-ui/button";
+import { Icon } from "@bb/shared-ui/icon";
+import { PromptStackCard } from "@/components/promptbox/banner/PromptStackCard";
+
+interface CodexCliVersionBannerProps {
+  currentVersion: string | null;
+  minimumSupportedVersion: string | null;
+  canUpdate: boolean;
+  updating: boolean;
+  onUpdate: () => void;
+}
+
+function versionRequirementCopy(
+  currentVersion: string | null,
+  minimumSupportedVersion: string | null,
+): string {
+  if (currentVersion !== null && minimumSupportedVersion !== null) {
+    return `Installed ${currentVersion}; version ${minimumSupportedVersion} or newer is required.`;
+  }
+  if (currentVersion !== null) {
+    return `Installed ${currentVersion}; a newer version is required.`;
+  }
+  if (minimumSupportedVersion !== null) {
+    return `Version ${minimumSupportedVersion} or newer is required.`;
+  }
+  return "A newer version is required.";
+}
+
+/**
+ * Blocking update state for the new-thread composer. This is intentionally
+ * more prominent than passive prompt context: the composer cannot submit until
+ * the user resolves it.
+ */
+export function CodexCliVersionBanner({
+  currentVersion,
+  minimumSupportedVersion,
+  canUpdate,
+  updating,
+  onUpdate,
+}: CodexCliVersionBannerProps) {
+  return (
+    <PromptStackCard
+      ariaLabel="Codex update required"
+      className="overflow-hidden border-attention/50 bg-surface-attention shadow-sm"
+    >
+      <div
+        role="alert"
+        className="flex min-h-14 max-w-full items-center gap-3 px-3 py-2.5"
+      >
+        <span
+          className="flex size-8 shrink-0 items-center justify-center rounded-full bg-attention/15 text-warning-text ring-1 ring-attention/25"
+          aria-hidden
+        >
+          <Icon name="AlertTriangle" className="size-4" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold text-foreground">
+            Codex update required
+          </p>
+          <p className="mt-0.5 text-xs leading-relaxed text-muted-foreground">
+            Update Codex before starting a thread.{" "}
+            {versionRequirementCopy(currentVersion, minimumSupportedVersion)}
+          </p>
+        </div>
+        {canUpdate ? (
+          <Button
+            type="button"
+            size="sm"
+            className="h-8 shrink-0 px-3"
+            disabled={updating}
+            onClick={onUpdate}
+          >
+            {updating ? (
+              <>
+                <Icon name="Spinner" className="animate-spin" />
+                Updating…
+              </>
+            ) : (
+              "Update Codex"
+            )}
+          </Button>
+        ) : null}
+      </div>
+    </PromptStackCard>
+  );
+}

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -29,12 +29,11 @@ import {
   NewThreadPromptBox,
   type NewThreadProjectConfig,
 } from "@/components/promptbox/NewThreadPromptBox";
-import { PromptStackCard } from "@/components/promptbox/banner/PromptStackCard";
+import { CodexCliVersionBanner } from "@/components/promptbox/banner/CodexCliVersionBanner";
 import {
   buildProviderCliIssue,
   hasProviderCliAction,
   useProviderCliInstallRunner,
-  type ProviderCliActionableIssue,
 } from "@/components/provider-cli/provider-cli-install";
 import { providerCliJobKey } from "@/components/provider-cli/provider-cli-install-store";
 import { withAutomationPromptAction } from "@/components/promptbox/PromptBoxActionsMenu";
@@ -726,56 +725,6 @@ export function LegacyProjectComposeRedirect({
         Loading…
       </p>
     </PageShell>
-  );
-}
-
-interface CodexCliVersionBannerProps {
-  currentVersion: string | null;
-  minimumSupportedVersion: string | null;
-  issue: ProviderCliActionableIssue | null;
-  updating: boolean;
-  onUpdate: () => void;
-}
-
-function CodexCliVersionBanner({
-  currentVersion,
-  minimumSupportedVersion,
-  issue,
-  updating,
-  onUpdate,
-}: CodexCliVersionBannerProps) {
-  const minimumVersion = minimumSupportedVersion ?? "a newer version";
-  const versionCopy = currentVersion
-    ? `Installed ${currentVersion}; required ${minimumVersion} or newer.`
-    : `Required ${minimumVersion} or newer.`;
-  return (
-    <PromptStackCard
-      ariaLabel="Codex update needed"
-      className="overflow-hidden"
-    >
-      <div className="flex min-h-8 max-w-full items-center gap-2 px-2.5 py-1 text-xs text-muted-foreground">
-        <Icon
-          name="Info"
-          className="size-3.5 shrink-0 text-subtle-foreground"
-          aria-hidden
-        />
-        <span className="min-w-0 flex-1 truncate">
-          Update Codex to start this thread. {versionCopy}
-        </span>
-        {issue ? (
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            className="h-6 shrink-0 px-2 text-xs"
-            disabled={updating}
-            onClick={onUpdate}
-          >
-            {updating ? "Updating" : issue.action.label}
-          </Button>
-        ) : null}
-      </div>
-    </PromptStackCard>
   );
 }
 
@@ -3229,12 +3178,13 @@ export function RootComposeView() {
   // Focus the composer once it mounts in place of the welcome screen.
   useEffect(() => {
     if (!startedComposing) return;
+    if (isCodexCliVersionBlocked) return;
     if (isPointerCoarse) return;
     const handle = window.requestAnimationFrame(() => {
       promptBoxRef.current?.focusEnd();
     });
     return () => window.cancelAnimationFrame(handle);
-  }, [isPointerCoarse, startedComposing]);
+  }, [isCodexCliVersionBlocked, isPointerCoarse, startedComposing]);
   const [machineSetupTarget, setMachineSetupTarget] =
     useState<ProjectMachineSetupDialogTarget | null>(null);
   const currentProjectName = currentProject?.name ?? null;
@@ -3427,7 +3377,7 @@ export function RootComposeView() {
       <CodexCliVersionBanner
         currentVersion={codexCliStatus.currentVersion}
         minimumSupportedVersion={codexCliStatus.minimumSupportedVersion}
-        issue={codexCliIssue}
+        canUpdate={codexCliIssue !== null}
         updating={
           composeHostId !== null &&
           (runningJobKey === providerCliJobKey(composeHostId, "codex") ||
@@ -3487,6 +3437,7 @@ export function RootComposeView() {
       textEffects={promptTextEffects}
       isSubmitting={createThread.isPending}
       disabled={isSubmitDisabled}
+      autoFocus={!isCodexCliVersionBlocked}
       zenModeStorageKey={rootComposeZenModeStorageKey}
       history={historyConfig}
       typeahead={typeaheadConfig}


### PR DESCRIPTION
## Summary

- replace the passive unsupported-Codex strip with an attention-styled blocking alert and explicit Update Codex action
- suppress passive composer autofocus while the update blocker is active so the caret does not compete for attention
- reuse the production banner in Ladle and cover alert, progress, copy, and focus behavior

## Test plan

- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run test --filter=@bb/app --force (2,502 tests)
- pnpm exec turbo run lint --filter=@bb/app
- visually verified the Ladle state in light and dark themes at wide and narrow widths