### PR TITLE
Fix landing page metadata title

### DIFF
--- a/apps/web/src/landing/site.ts
+++ b/apps/web/src/landing/site.ts
@@ -36,6 +36,6 @@ export function downloadMacosHref(placement: CtaPlacement): string {
   return `${DOWNLOAD_MACOS_REDIRECT_PATH}?placement=${placement}`;
 }
 
-export const SITE_TITLE = "bb: the IDE for loop-driven development";
+export const SITE_TITLE = "bb: the IDE that builds itself";
 export const SITE_DESCRIPTION =
   "bb can control, customize, and automate itself, laying the groundwork for your own software factory. Fully open source and local-first, with Claude Code, Codex, Cursor, Pi, OpenCode, Grok, omp, and Hermes.";


### PR DESCRIPTION
## Summary

- update the landing page title to match the current “The IDE that builds itself” hero
- keep the browser title and Open Graph title aligned through the shared `SITE_TITLE` constant

## Testing

- `pnpm exec turbo run typecheck build --filter=@bb/web`