### PR TITLE
Fix expanding long user messages

### DIFF
--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.test.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import type { ThreadListEntry } from "@bb/domain";
 import { afterEach, describe, expect, it } from "vitest";
 import { MemoryRouter } from "react-router-dom";
@@ -11,6 +11,7 @@ import {
   type MessageDirectiveRegistry,
 } from "@/components/ui/markdown-message-directives";
 import { ConversationMessageContent } from "./ConversationMessageContent";
+import { USER_MESSAGE_CHAR_CAP } from "./conversation-message-limits";
 
 afterEach(cleanup);
 
@@ -141,6 +142,45 @@ describe("ConversationMessageContent assistant thread mentions", () => {
     });
     expect(mentionLink.getAttribute("href")).toBe("/threads/thr_xpxxt2ipz8");
     expect(screen.queryByText("@thread", { exact: false })).toBeNull();
+  });
+});
+
+describe("ConversationMessageContent long user messages", () => {
+  it("renders the complete message after expanding a capped preview", () => {
+    const hiddenTail = "FULL_MESSAGE_TAIL";
+    const text = `${"a".repeat(USER_MESSAGE_CHAR_CAP)}\n\n${hiddenTail}`;
+
+    render(
+      <MemoryRouter>
+        <RouteNavigationProvider>
+          <ConversationMessageContent
+            role="user"
+            attachments={null}
+            childOrigin={null}
+            initiator="user"
+            mentions={[]}
+            senderThreadId={null}
+            senderThreadTitle={null}
+            senderIsPluginSideChat={false}
+            systemMessageKind="unlabeled"
+            systemMessageSubject={null}
+            text={text}
+            turnRequest={{ kind: "message", status: "accepted" }}
+          />
+        </RouteNavigationProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText(hiddenTail)).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+
+    expect(screen.getByText(hiddenTail)).not.toBeNull();
+    expect(screen.queryByText("[truncated]")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show less" }));
+
+    expect(screen.queryByText(hiddenTail)).toBeNull();
   });
 });
 

--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
@@ -256,25 +256,25 @@ function CollapsibleMessageText({
 
   const [isExpanded, setIsExpanded] = useState(false);
   const bodyRef = useRef<HTMLDivElement>(null);
-  // Cap before rendering so a megabyte paste can't dominate window-resize
-  // reflow. Unlike the prior plain-text path we hand the whole capped body to
-  // the markdown renderer and clamp it visually (markdown block content doesn't
-  // line-clamp cleanly), rather than slicing it by line per collapse state.
-  const isTruncated = bodyText.length > USER_MESSAGE_CHAR_CAP;
-  const cappedBody = isTruncated
-    ? bodyText.slice(0, USER_MESSAGE_CHAR_CAP)
-    : bodyText;
-  // Rebase mentions onto the prefix-stripped, char-capped body so their offsets
-  // index into the exact string handed to the markdown renderer (a mention
-  // straddling the cap is dropped, clipping the body to just before it).
+  // Keep collapsed previews bounded so a megabyte paste cannot dominate the
+  // initial timeline render. Expanding is an explicit request for the complete
+  // message, so only then hand the full body to the markdown renderer.
+  const exceedsCollapsedRenderCap = bodyText.length > USER_MESSAGE_CHAR_CAP;
+  const renderedBodyText =
+    !isExpanded && exceedsCollapsedRenderCap
+      ? bodyText.slice(0, USER_MESSAGE_CHAR_CAP)
+      : bodyText;
+  // Rebase mentions onto the prefix-stripped body currently being rendered. A
+  // mention straddling the collapsed cap is omitted from the preview and
+  // restored when the complete body is rendered after expansion.
   const body = useMemo(
     () =>
       clipMentionTextToVisibleRange({
         mentions,
         rangeStart: bodyOffset,
-        text: cappedBody,
+        text: renderedBodyText,
       }),
-    [mentions, bodyOffset, cappedBody],
+    [mentions, bodyOffset, renderedBodyText],
   );
   const promptMentions = useMemo<MarkdownPromptMentions>(
     () => ({
@@ -304,7 +304,8 @@ function CollapsibleMessageText({
     enabled: !isExpanded,
     measurementKey: body.text,
   });
-  const showToggle = isExpanded || isOverflowing;
+  const showToggle =
+    isExpanded || exceedsCollapsedRenderCap || isOverflowing;
 
   return (
     <>
@@ -332,9 +333,6 @@ function CollapsibleMessageText({
           threadMentions={rawThreadMentions}
           linkRouting={linkRouting}
         />
-        {isExpanded && isTruncated ? (
-          <span className="text-muted-foreground">[truncated]</span>
-        ) : null}
       </div>
       {showToggle ? (
         <ConversationMessageOverflowToggle


### PR DESCRIPTION
## Summary

- keep the collapsed long-message preview capped for initial rendering
- render the complete user message after Show more is selected
- restore mentions beyond the preview cap and remove the misleading truncated marker
- add regression coverage for expanding and collapsing capped messages

## Testing

- `pnpm exec turbo run test --filter=@bb/app --force -- ConversationMessageContent.test.tsx`