### PR TITLE
Restore provider-specific composer selections

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -184,7 +184,7 @@ describe("ModelReasoningPicker", () => {
     ).toBe("");
   });
 
-  it("previews another provider's models without committing the provider", async () => {
+  it("commits a provider tab immediately and keeps its models selectable", async () => {
     const { onSelectedProviderChange, onModelChange } = renderPicker();
 
     fireEvent.click(
@@ -196,18 +196,18 @@ describe("ModelReasoningPicker", () => {
 
     fireEvent.click(screen.getByTitle("Claude Code"));
 
+    expect(onSelectedProviderChange).toHaveBeenCalledWith("claude-code");
     expect(await screen.findByText("Opus 4.7")).not.toBeNull();
     expect(screen.getAllByText("5.5")).toHaveLength(1);
-    expect(onSelectedProviderChange).not.toHaveBeenCalled();
     expect(onModelChange).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByText("Opus 4.7"));
 
-    expect(onSelectedProviderChange).toHaveBeenCalledWith("claude-code");
+    expect(onSelectedProviderChange).toHaveBeenCalledTimes(1);
     expect(onModelChange).toHaveBeenCalledWith("claude-opus-4-7");
   });
 
-  it("previews provider models on the compose-selected host", async () => {
+  it("loads provider models on the compose-selected host", async () => {
     renderPicker({ providerRouting: { hostId: "host-remote" } });
 
     fireEvent.click(

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -186,7 +186,7 @@ interface ModelReasoningPickerProps {
   providerRouting?: SystemProvidersQuery;
   providerOptions: readonly PickerOption<string>[];
   selectedProviderId: string;
-  /** Omit to render the provider as locked (tabs hidden, can't preview). */
+  /** Omit to render the provider as locked (tabs hidden, can't switch). */
   onSelectedProviderChange?: (value: string) => void;
   hasMultipleProviders: boolean;
   // Model state
@@ -199,9 +199,9 @@ interface ModelReasoningPickerProps {
   modelLoadError?: SystemExecutionOptionsModelLoadError | null;
   onModelChange: (value: string) => void;
   /**
-   * Optional case-normaliser for raw model names returned by a previewed
-   * provider. The picker itself drops the brand prefix at render — callers
-   * only need to pass this when the preview API returns un-cased ids.
+   * Optional case-normaliser for raw model names returned during a provider
+   * handoff. The picker itself drops the brand prefix at render — callers only
+   * need to pass this when the provider API returns un-cased ids.
    */
   formatModelLabel?: (displayName: string) => string;
   // Reasoning state — supported efforts are per-model, so callers derive
@@ -284,9 +284,9 @@ export function ModelReasoningPicker({
   const listboxId = `${navId}-listbox`;
   const optionDomId = (index: number) => `${navId}-opt-${index}`;
 
-  // While the popover is open, the user can browse other providers without
-  // committing. `previewProviderId` tracks which provider tab is active;
-  // null means "showing the committed provider".
+  // A controlled parent may need one render to apply a provider-tab change.
+  // Keep showing the clicked provider's cached/querying catalog during that
+  // handoff so the tab responds immediately without flashing the old models.
   const [previewProviderId, setPreviewProviderId] = useState<string | null>(
     null,
   );
@@ -350,9 +350,8 @@ export function ModelReasoningPicker({
     ? (selectedReasoningOption?.label ?? null)
     : null;
 
-  // Preview other providers without committing. Shares its cache key with the
-  // committed `useSystemExecutionOptions` call in the caller's hook so
-  // committing is a cache hit, not a refetch.
+  // Shares its cache key with the committed `useSystemExecutionOptions` call
+  // in the caller's hook, so the controlled-provider handoff is a cache hit.
   const isPreviewing =
     previewProviderId !== null && previewProviderId !== selectedProviderId;
   const previewQuery = useSystemExecutionOptions({
@@ -535,17 +534,11 @@ export function ModelReasoningPicker({
 
   const handleModelSelect = useCallback(
     (model: string) => {
-      // Commit the previewed provider if it differs from the current one.
-      // Preview is only reachable when the picker is unlocked, so onChange
-      // is guaranteed to be set when isPreviewing is true.
-      if (isPreviewing) {
-        onSelectedProviderChange?.(previewProviderId!);
-      }
       onModelChange(model);
       setMoreModelsOpen(false);
       setPreviewProviderId(null);
     },
-    [isPreviewing, onModelChange, onSelectedProviderChange, previewProviderId],
+    [onModelChange],
   );
 
   // Scope Cmd+Shift+M and the cycle chords to one composer of the focused pane.
@@ -642,11 +635,10 @@ export function ModelReasoningPicker({
   );
   const handleReasoningSelect = useCallback(
     (level: ReasoningLevel) => {
-      // While previewing, the listed levels are the previewed provider's, so
-      // picking one commits that provider's default model at the chosen level —
-      // symmetric with picking one of its models.
+      // A controlled parent that has not rendered the provider change yet
+      // still needs a concrete model when the user immediately picks one of
+      // the new provider's reasoning levels.
       if (isPreviewing && previewDefaultModel) {
-        onSelectedProviderChange?.(previewProviderId!);
         onModelChange(previewDefaultModel.model);
       }
       onReasoningChange(level);
@@ -655,14 +647,7 @@ export function ModelReasoningPicker({
       setPreviewProviderId(null);
       setMoreModelsOpen(false);
     },
-    [
-      isPreviewing,
-      previewDefaultModel,
-      previewProviderId,
-      onModelChange,
-      onReasoningChange,
-      onSelectedProviderChange,
-    ],
+    [isPreviewing, previewDefaultModel, onModelChange, onReasoningChange],
   );
 
   const handleFooterActionClick = useCallback(() => {
@@ -871,15 +856,14 @@ export function ModelReasoningPicker({
                   title={provider.label}
                   onClick={() => {
                     if (provider.value !== activeProviderId) {
+                      onSelectedProviderChange?.(provider.value);
                       setPreviewProviderId(
                         provider.value === selectedProviderId
                           ? null
                           : provider.value,
                       );
-                      // The new tab lists a different provider's models, so drop
-                      // the query and highlight from the previous tab. (Committing
-                      // a provider closes the popover, where resetBrowseState
-                      // clears these anyway.)
+                      // The new tab lists a different provider's models, so
+                      // drop the query and highlight from the previous tab.
                       setSearchQuery("");
                       setActiveIndex(-1);
                     }

--- a/apps/app/src/hooks/thread-creation-options/persisted-selection-fields.ts
+++ b/apps/app/src/hooks/thread-creation-options/persisted-selection-fields.ts
@@ -1,4 +1,4 @@
-import { useAtom } from "jotai";
+import { atom, useAtom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import { atomFamily } from "jotai-family";
 import { useCallback } from "react";
@@ -16,6 +16,7 @@ const REASONING_STORAGE_KEY = "bb.promptbox.reasoning";
 const PERMISSION_MODE_STORAGE_KEY = "bb.promptbox.permission-mode";
 const ENVIRONMENT_STORAGE_KEY = "bb.promptbox.environment";
 const PROVIDER_STORAGE_KEY = "bb.promptbox.provider";
+const PROVIDER_SELECTION_STORAGE_VERSION = "1";
 
 export type StoredServiceTier = "" | ServiceTier;
 export type StoredReasoningLevel = "" | ReasoningLevel;
@@ -85,11 +86,58 @@ const providerIdAtom = atomWithStorage<string>(
   rawStringLocalStorage,
   { getOnInit: true },
 );
-const modelAtom = atomWithStorage<string>(
-  MODEL_STORAGE_KEY,
-  "",
-  rawStringLocalStorage,
-  { getOnInit: true },
+const emptyModelAtom = atom("");
+const emptyReasoningLevelAtom = atom<StoredReasoningLevel>("");
+
+function getProviderSelectionStorageKey(
+  storageKey: string,
+  providerId: string,
+): string {
+  return `${storageKey}-${encodeURIComponent(providerId.trim())}-${PROVIDER_SELECTION_STORAGE_VERSION}`;
+}
+
+function getLegacyProviderSelection(
+  providerId: string,
+  storageKey: string,
+): string | null {
+  if (typeof window === "undefined") return null;
+  if (window.localStorage.getItem(PROVIDER_STORAGE_KEY) !== providerId) {
+    return null;
+  }
+  return window.localStorage.getItem(storageKey);
+}
+
+function createProviderModelStorage(providerId: string) {
+  return createLocalStorageSyncStorage<string>({
+    parse: (storedValue, initialValue) =>
+      storedValue ??
+      getLegacyProviderSelection(providerId, MODEL_STORAGE_KEY) ??
+      initialValue,
+    serialize: (value) => value,
+  });
+}
+
+function createProviderReasoningStorage(providerId: string) {
+  return createLocalStorageSyncStorage<StoredReasoningLevel>({
+    parse: (storedValue, initialValue) => {
+      const value =
+        storedValue ??
+        getLegacyProviderSelection(providerId, REASONING_STORAGE_KEY);
+      return value !== null && isStoredReasoningLevel(value)
+        ? value
+        : initialValue;
+    },
+    serialize: (value) => value,
+  });
+}
+
+const modelAtomFamily = atomFamily((providerId: string) =>
+  atomWithStorage<string>(
+    getProviderSelectionStorageKey(MODEL_STORAGE_KEY, providerId),
+    "",
+    createProviderModelStorage(providerId),
+    { getOnInit: true },
+  ),
 );
 const serviceTierAtom = atomWithStorage<StoredServiceTier>(
   SERVICE_TIER_STORAGE_KEY,
@@ -97,28 +145,31 @@ const serviceTierAtom = atomWithStorage<StoredServiceTier>(
   createLocalStorageEnumStorage(isStoredServiceTier),
   { getOnInit: true },
 );
-const reasoningLevelAtom = atomWithStorage<StoredReasoningLevel>(
-  REASONING_STORAGE_KEY,
-  "",
-  createLocalStorageEnumStorage(isStoredReasoningLevel),
-  { getOnInit: true },
+const reasoningLevelAtomFamily = atomFamily((providerId: string) =>
+  atomWithStorage<StoredReasoningLevel>(
+    getProviderSelectionStorageKey(REASONING_STORAGE_KEY, providerId),
+    "",
+    createProviderReasoningStorage(providerId),
+    { getOnInit: true },
+  ),
 );
 // Legacy preference migration: "workspace-write" maps onto the same workspace
 // sandbox as "accept-edits", so the user's stored intent carries forward.
 // Legacy "readonly" (and any other unknown value) is dropped rather than
 // reinterpreted — localStorage is untrusted, and a read-only preference must
 // never silently become a writable mode.
-const permissionModePreferenceStorage = createLocalStorageSyncStorage<StoredPermissionMode>({
-  parse: (storedValue, initialValue) => {
-    if (storedValue === "workspace-write") {
-      return "accept-edits";
-    }
-    return storedValue !== null && isStoredPermissionMode(storedValue)
-      ? storedValue
-      : initialValue;
-  },
-  serialize: (value) => value,
-});
+const permissionModePreferenceStorage =
+  createLocalStorageSyncStorage<StoredPermissionMode>({
+    parse: (storedValue, initialValue) => {
+      if (storedValue === "workspace-write") {
+        return "accept-edits";
+      }
+      return storedValue !== null && isStoredPermissionMode(storedValue)
+        ? storedValue
+        : initialValue;
+    },
+    serialize: (value) => value,
+  });
 
 const permissionModeAtom = atomWithStorage<StoredPermissionMode>(
   PERMISSION_MODE_STORAGE_KEY,
@@ -145,15 +196,27 @@ export function usePromptBoxProviderPreference(): PersistedStringSelectionField 
   const [value, setAtomValue] = useAtom(providerIdAtom);
   const setValue = useCallback(
     (nextValue: string) => {
+      if (nextValue !== value && typeof window !== "undefined") {
+        // Once the provider changes, the legacy unscoped values no longer have
+        // a trustworthy owner. The caller saves the current pair under its
+        // provider-scoped keys before changing this value.
+        window.localStorage.removeItem(MODEL_STORAGE_KEY);
+        window.localStorage.removeItem(REASONING_STORAGE_KEY);
+      }
       setAtomValue(nextValue);
     },
-    [setAtomValue],
+    [setAtomValue, value],
   );
   return { setValue, value };
 }
 
-export function usePromptBoxModelPreference(): PersistedStringSelectionField {
-  const [value, setAtomValue] = useAtom(modelAtom);
+export function usePromptBoxModelPreference(
+  providerId: string,
+): PersistedStringSelectionField {
+  const selectionAtom = providerId
+    ? modelAtomFamily(providerId)
+    : emptyModelAtom;
+  const [value, setAtomValue] = useAtom(selectionAtom);
   const setValue = useCallback(
     (nextValue: string) => {
       setAtomValue(nextValue);
@@ -174,8 +237,13 @@ export function usePromptBoxServiceTierPreference(): PersistedServiceTierSelecti
   return { setValue, value };
 }
 
-export function usePromptBoxReasoningLevelPreference(): PersistedReasoningLevelSelectionField {
-  const [value, setAtomValue] = useAtom(reasoningLevelAtom);
+export function usePromptBoxReasoningLevelPreference(
+  providerId: string,
+): PersistedReasoningLevelSelectionField {
+  const selectionAtom = providerId
+    ? reasoningLevelAtomFamily(providerId)
+    : emptyReasoningLevelAtom;
+  const [value, setAtomValue] = useAtom(selectionAtom);
   const setValue = useCallback(
     (nextValue: StoredReasoningLevel) => {
       setAtomValue(nextValue);

--- a/apps/app/src/hooks/thread-creation-options/persisted-selection-fields.ts
+++ b/apps/app/src/hooks/thread-creation-options/persisted-selection-fields.ts
@@ -1,4 +1,4 @@
-import { atom, useAtom } from "jotai";
+import { atom, useAtom, useStore } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import { atomFamily } from "jotai-family";
 import { useCallback } from "react";
@@ -45,6 +45,12 @@ export interface PersistedReasoningLevelSelectionField {
 export interface PersistedPermissionModeSelectionField {
   setValue: StoredPermissionModeSetter;
   value: StoredPermissionMode;
+}
+
+export interface PromptBoxProviderModelReasoningPreference {
+  providerId: string;
+  model: string;
+  reasoningLevel: ReasoningLevel;
 }
 
 function isReasoningLevel(value: string): value is ReasoningLevel {
@@ -251,6 +257,20 @@ export function usePromptBoxReasoningLevelPreference(
     [setAtomValue],
   );
   return { setValue, value };
+}
+
+export function useSetPromptBoxProviderModelReasoningPreference(): (
+  preference: PromptBoxProviderModelReasoningPreference,
+) => void {
+  const store = useStore();
+  return useCallback(
+    ({ providerId, model, reasoningLevel }) => {
+      if (providerId.length === 0) return;
+      store.set(modelAtomFamily(providerId), model);
+      store.set(reasoningLevelAtomFamily(providerId), reasoningLevel);
+    },
+    [store],
+  );
 }
 
 export function usePromptBoxPermissionModePreference(): PersistedPermissionModeSelectionField {

--- a/apps/app/src/hooks/useThreadCreationOptions.test.tsx
+++ b/apps/app/src/hooks/useThreadCreationOptions.test.tsx
@@ -128,10 +128,11 @@ function providerExecutionOptionsResponse(
         displayName: `${modelPrefix} default`,
         description: "",
         supportedReasoningEfforts: [
+          { reasoningEffort: "low", description: "" },
           { reasoningEffort: "medium", description: "" },
           { reasoningEffort: "high", description: "" },
         ],
-        defaultReasoningEffort: isProjectProvider ? "high" : "medium",
+        defaultReasoningEffort: isProjectProvider ? "high" : "low",
         isDefault: true,
       },
       {
@@ -233,6 +234,29 @@ afterEach(() => {
 });
 
 describe("useThreadCreationOptions", () => {
+  it("uses the medium product default for providers without reasoning history", async () => {
+    vi.mocked(sdk.system.executionOptions).mockImplementation(async (args) =>
+      providerExecutionOptionsResponse(args?.providerId),
+    );
+    const { result } = renderHook(
+      () => useThreadCreationOptions({ scope: "new-thread" }),
+      { wrapper: createQueryClientTestHarness().wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe("global-default");
+      expect(result.current.reasoningLevel).toBe("medium");
+    });
+
+    act(() => {
+      result.current.setSelectedProviderId(PROJECT_PROVIDER_ID);
+    });
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe("project-default");
+      expect(result.current.reasoningLevel).toBe("medium");
+    });
+  });
+
   it("applies a fork provider, model, and reasoning seed atomically", async () => {
     window.localStorage.setItem("bb.promptbox.provider", GLOBAL_PROVIDER_ID);
     vi.mocked(sdk.system.executionOptions).mockImplementation(async (args) =>
@@ -301,7 +325,7 @@ describe("useThreadCreationOptions", () => {
     });
     await waitFor(() => {
       expect(result.current.selectedModel).toBe("project-default");
-      expect(result.current.reasoningLevel).toBe("high");
+      expect(result.current.reasoningLevel).toBe("medium");
     });
     expect(window.localStorage.getItem("bb.promptbox.model")).toBeNull();
 
@@ -341,7 +365,7 @@ describe("useThreadCreationOptions", () => {
     await waitFor(() => {
       expect(result.current.selectedProviderId).toBe(PROJECT_PROVIDER_ID);
       expect(result.current.selectedModel).toBe("project-default");
-      expect(result.current.reasoningLevel).toBe("high");
+      expect(result.current.reasoningLevel).toBe("medium");
     });
 
     act(() => {
@@ -413,7 +437,7 @@ describe("useThreadCreationOptions", () => {
 
     await waitFor(() => {
       expect(result.current.selectedModel).toBe("project-default");
-      expect(result.current.reasoningLevel).toBe("high");
+      expect(result.current.reasoningLevel).toBe("medium");
     });
     act(() => {
       result.current.setSelectedModel("project-remembered");

--- a/apps/app/src/hooks/useThreadCreationOptions.test.tsx
+++ b/apps/app/src/hooks/useThreadCreationOptions.test.tsx
@@ -233,6 +233,54 @@ afterEach(() => {
 });
 
 describe("useThreadCreationOptions", () => {
+  it("applies a fork provider, model, and reasoning seed atomically", async () => {
+    window.localStorage.setItem("bb.promptbox.provider", GLOBAL_PROVIDER_ID);
+    vi.mocked(sdk.system.executionOptions).mockImplementation(async (args) =>
+      providerExecutionOptionsResponse(args?.providerId),
+    );
+    const { result } = renderHook(
+      () => useThreadCreationOptions({ scope: "new-thread" }),
+      { wrapper: createQueryClientTestHarness().wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe("global-default");
+    });
+    act(() => {
+      result.current.setSelectedModel("global-remembered");
+      result.current.setReasoningLevel("medium");
+    });
+    act(() => {
+      result.current.setProviderModelReasoning({
+        providerId: PROJECT_PROVIDER_ID,
+        model: "project-remembered",
+        reasoningLevel: "high",
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedProviderId).toBe(PROJECT_PROVIDER_ID);
+      expect(result.current.selectedModel).toBe("project-remembered");
+      expect(result.current.reasoningLevel).toBe("high");
+    });
+
+    act(() => {
+      result.current.setSelectedProviderId(GLOBAL_PROVIDER_ID);
+    });
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe("global-remembered");
+      expect(result.current.reasoningLevel).toBe("medium");
+    });
+
+    act(() => {
+      result.current.setSelectedProviderId(PROJECT_PROVIDER_ID);
+    });
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe("project-remembered");
+      expect(result.current.reasoningLevel).toBe("high");
+    });
+  });
+
   it("migrates legacy model preferences without leaking them to another provider", async () => {
     window.localStorage.setItem("bb.promptbox.provider", GLOBAL_PROVIDER_ID);
     window.localStorage.setItem("bb.promptbox.model", "global-remembered");

--- a/apps/app/src/hooks/useThreadCreationOptions.test.tsx
+++ b/apps/app/src/hooks/useThreadCreationOptions.test.tsx
@@ -113,6 +113,43 @@ function executionOptionsResponse(): SystemExecutionOptionsResponse {
   };
 }
 
+function providerExecutionOptionsResponse(
+  providerId: string | undefined,
+): SystemExecutionOptionsResponse {
+  const base = executionOptionsResponse();
+  const isProjectProvider = providerId === PROJECT_PROVIDER_ID;
+  const modelPrefix = isProjectProvider ? "project" : "global";
+  return {
+    ...base,
+    models: [
+      {
+        id: `${modelPrefix}-default`,
+        model: `${modelPrefix}-default`,
+        displayName: `${modelPrefix} default`,
+        description: "",
+        supportedReasoningEfforts: [
+          { reasoningEffort: "medium", description: "" },
+          { reasoningEffort: "high", description: "" },
+        ],
+        defaultReasoningEffort: isProjectProvider ? "high" : "medium",
+        isDefault: true,
+      },
+      {
+        id: `${modelPrefix}-remembered`,
+        model: `${modelPrefix}-remembered`,
+        displayName: `${modelPrefix} remembered`,
+        description: "",
+        supportedReasoningEfforts: [
+          { reasoningEffort: "medium", description: "" },
+          { reasoningEffort: "high", description: "" },
+        ],
+        defaultReasoningEffort: "medium",
+        isDefault: false,
+      },
+    ],
+  };
+}
+
 function claudeExecutionOptionsResponse(): SystemExecutionOptionsResponse {
   return {
     providers: [
@@ -196,6 +233,155 @@ afterEach(() => {
 });
 
 describe("useThreadCreationOptions", () => {
+  it("migrates legacy model preferences without leaking them to another provider", async () => {
+    window.localStorage.setItem("bb.promptbox.provider", GLOBAL_PROVIDER_ID);
+    window.localStorage.setItem("bb.promptbox.model", "global-remembered");
+    window.localStorage.setItem("bb.promptbox.reasoning", "medium");
+    vi.mocked(sdk.system.executionOptions).mockImplementation(async (args) =>
+      providerExecutionOptionsResponse(args?.providerId),
+    );
+    const { result } = renderHook(
+      () => useThreadCreationOptions({ scope: "new-thread" }),
+      { wrapper: createQueryClientTestHarness().wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe("global-remembered");
+    });
+    act(() => {
+      result.current.setSelectedProviderId(PROJECT_PROVIDER_ID);
+    });
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe("project-default");
+      expect(result.current.reasoningLevel).toBe("high");
+    });
+    expect(window.localStorage.getItem("bb.promptbox.model")).toBeNull();
+
+    act(() => {
+      result.current.setSelectedProviderId(GLOBAL_PROVIDER_ID);
+    });
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe("global-remembered");
+      expect(result.current.reasoningLevel).toBe("medium");
+    });
+  });
+
+  it("restores each provider's model and reasoning selection", async () => {
+    window.localStorage.setItem("bb.promptbox.provider", GLOBAL_PROVIDER_ID);
+    vi.mocked(sdk.system.executionOptions).mockImplementation(async (args) =>
+      providerExecutionOptionsResponse(args?.providerId),
+    );
+    const { wrapper } = createQueryClientTestHarness();
+    const { result, unmount } = renderHook(
+      () => useThreadCreationOptions({ scope: "new-thread" }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe("global-default");
+      expect(result.current.reasoningLevel).toBe("medium");
+    });
+
+    act(() => {
+      result.current.setSelectedModel("global-remembered");
+      result.current.setReasoningLevel("medium");
+    });
+    act(() => {
+      result.current.setSelectedProviderId(PROJECT_PROVIDER_ID);
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedProviderId).toBe(PROJECT_PROVIDER_ID);
+      expect(result.current.selectedModel).toBe("project-default");
+      expect(result.current.reasoningLevel).toBe("high");
+    });
+
+    act(() => {
+      result.current.setSelectedModel("project-remembered");
+      result.current.setReasoningLevel("medium");
+    });
+    act(() => {
+      result.current.setSelectedProviderId(GLOBAL_PROVIDER_ID);
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe("global-remembered");
+      expect(result.current.reasoningLevel).toBe("medium");
+    });
+
+    act(() => {
+      result.current.setSelectedProviderId(PROJECT_PROVIDER_ID);
+    });
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe("project-remembered");
+      expect(result.current.reasoningLevel).toBe("medium");
+    });
+
+    unmount();
+    const reloaded = renderHook(
+      () => useThreadCreationOptions({ scope: "new-thread" }),
+      { wrapper: createQueryClientTestHarness().wrapper },
+    );
+    await waitFor(() => {
+      expect(reloaded.result.current.selectedProviderId).toBe(
+        PROJECT_PROVIDER_ID,
+      );
+      expect(reloaded.result.current.selectedModel).toBe("project-remembered");
+      expect(reloaded.result.current.reasoningLevel).toBe("medium");
+    });
+    act(() => {
+      reloaded.result.current.setSelectedProviderId(GLOBAL_PROVIDER_ID);
+    });
+    await waitFor(() => {
+      expect(reloaded.result.current.selectedModel).toBe("global-remembered");
+      expect(reloaded.result.current.reasoningLevel).toBe("medium");
+    });
+  });
+
+  it("keeps provider selections local in component-local composers", async () => {
+    vi.mocked(sdk.system.executionOptions).mockImplementation(async (args) =>
+      providerExecutionOptionsResponse(args?.providerId),
+    );
+    const { wrapper } = createQueryClientTestHarness();
+    const { result } = renderHook(
+      () =>
+        useThreadCreationOptions({
+          scope: "component-local",
+          initialProviderId: GLOBAL_PROVIDER_ID,
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe("global-default");
+    });
+    act(() => {
+      result.current.setSelectedModel("global-remembered");
+      result.current.setReasoningLevel("medium");
+    });
+    act(() => {
+      result.current.setSelectedProviderId(PROJECT_PROVIDER_ID);
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe("project-default");
+      expect(result.current.reasoningLevel).toBe("high");
+    });
+    act(() => {
+      result.current.setSelectedModel("project-remembered");
+      result.current.setReasoningLevel("medium");
+    });
+    act(() => {
+      result.current.setSelectedProviderId(GLOBAL_PROVIDER_ID);
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedModel).toBe("global-remembered");
+      expect(result.current.reasoningLevel).toBe("medium");
+    });
+    expect(window.localStorage.getItem("bb.promptbox.model")).toBeNull();
+  });
+
   it("preserves a model's nested provider route for the picker", async () => {
     const response = executionOptionsResponse();
     const firstModel = response.models[0];

--- a/apps/app/src/hooks/useThreadCreationOptions.ts
+++ b/apps/app/src/hooks/useThreadCreationOptions.ts
@@ -67,6 +67,11 @@ type ReasoningLevelSelectionSetter = (value: ReasoningLevel) => void;
 type PermissionModeSelectionSetter = (value: PermissionMode) => void;
 type ClearSelectionHandler = () => void;
 
+interface ProviderModelReasoningSelection {
+  model: string;
+  reasoningLevel: ReasoningLevel;
+}
+
 export interface UseThreadCreationOptionsResult<TExecutionInputSources> {
   executionOptionsRouting: SystemProvidersQuery;
   selectedProviderId: string;
@@ -163,12 +168,8 @@ export function useThreadCreationOptions(
   } = options ?? {};
   const { setValue: setStoredProviderId, value: storedProviderId } =
     usePromptBoxProviderPreference();
-  const { setValue: setStoredSelectedModel, value: storedSelectedModel } =
-    usePromptBoxModelPreference();
   const { setValue: setStoredServiceTier, value: storedServiceTier } =
     usePromptBoxServiceTierPreference();
-  const { setValue: setStoredReasoningLevel, value: storedReasoningLevel } =
-    usePromptBoxReasoningLevelPreference();
   const { setValue: setStoredPermissionMode, value: storedPermissionMode } =
     usePromptBoxPermissionModePreference();
   const {
@@ -191,6 +192,11 @@ export function useThreadCreationOptions(
         initialServiceTier,
       }),
     );
+  const localProviderSelectionsRef = useRef<
+    Map<string, ProviderModelReasoningSelection>
+  >(new Map());
+  const [localProvidersUsingDefaults, setLocalProvidersUsingDefaults] =
+    useState<ReadonlySet<string>>(() => new Set());
   const touchedThreadFieldsRef = useRef<Set<ThreadPromptField>>(new Set());
   const threadResetKeyRef = useRef<string | number | null | undefined>(
     resetKey,
@@ -242,15 +248,9 @@ export function useThreadCreationOptions(
   const selectedProviderIdBeforeConnectedFallback = usesStoredCreateSelections
     ? storedProviderId || renderedThreadSelections.selectedProviderId
     : renderedThreadSelections.selectedProviderId;
-  const rawSelectedModel = usesStoredCreateSelections
-    ? storedSelectedModel || renderedThreadSelections.selectedModel
-    : renderedThreadSelections.selectedModel;
   const rawServiceTier = usesStoredCreateSelections
     ? storedServiceTier || renderedThreadSelections.serviceTier
     : renderedThreadSelections.serviceTier;
-  const rawReasoningLevel = usesStoredCreateSelections
-    ? storedReasoningLevel || renderedThreadSelections.reasoningLevel
-    : renderedThreadSelections.reasoningLevel;
   const rawPermissionMode = usesStoredCreateSelections
     ? storedPermissionMode || renderedThreadSelections.permissionMode
     : renderedThreadSelections.permissionMode;
@@ -326,6 +326,29 @@ export function useThreadCreationOptions(
     }
     return providers[0]?.id ?? "";
   }, [providers, rawSelectedProviderId]);
+
+  const { setValue: setStoredSelectedModel, value: storedSelectedModel } =
+    usePromptBoxModelPreference(effectiveProviderId);
+  const { setValue: setStoredReasoningLevel, value: storedReasoningLevel } =
+    usePromptBoxReasoningLevelPreference(effectiveProviderId);
+  const effectiveProviderMatchesInitialProvider =
+    effectiveProviderId.length > 0 &&
+    effectiveProviderId === renderedThreadSelections.selectedProviderId;
+  const rawSelectedModel = usesStoredCreateSelections
+    ? storedSelectedModel ||
+      (effectiveProviderMatchesInitialProvider
+        ? renderedThreadSelections.selectedModel
+        : "")
+    : renderedThreadSelections.selectedModel;
+  const preferredReasoningLevel: ReasoningLevel | undefined =
+    usesStoredCreateSelections
+      ? storedReasoningLevel ||
+        (effectiveProviderMatchesInitialProvider
+          ? initialReasoningLevel
+          : undefined)
+      : localProvidersUsingDefaults.has(effectiveProviderId)
+        ? undefined
+        : renderedThreadSelections.reasoningLevel;
 
   const selectedProviderInfo = useMemo(
     () => providers.find((p) => p.id === effectiveProviderId),
@@ -558,17 +581,25 @@ export function useThreadCreationOptions(
     [rawServiceTier, supportsServiceTier],
   );
   const reasoningLevel = useMemo(() => {
+    const preferredLevel =
+      preferredReasoningLevel ??
+      activeModel?.defaultReasoningEffort ??
+      "medium";
     if (reasoningOptions.length === 0) {
-      return rawReasoningLevel;
+      return preferredLevel;
     }
     // Carry the user's previous reasoning level across model switches when
     // the new model supports it; otherwise pick the closest supported level
     // (tie-break upward). See reconcileReasoningLevel in @bb/domain for the policy.
     return reconcileReasoningLevel(
-      rawReasoningLevel,
+      preferredLevel,
       reasoningOptions.map((option) => option.value),
     );
-  }, [rawReasoningLevel, reasoningOptions]);
+  }, [
+    activeModel?.defaultReasoningEffort,
+    preferredReasoningLevel,
+    reasoningOptions,
+  ]);
 
   const permissionMode = resolvePermissionModeSelection({
     rawPermissionMode,
@@ -640,6 +671,8 @@ export function useThreadCreationOptions(
     if (threadResetKeyRef.current !== resetKey) {
       threadResetKeyRef.current = resetKey;
       touchedThreadFieldsRef.current = new Set();
+      localProviderSelectionsRef.current = new Map();
+      setLocalProvidersUsingDefaults(new Set());
       setThreadSelections(nextThreadSelections);
       return;
     }
@@ -656,21 +689,51 @@ export function useThreadCreationOptions(
     (value: string) => {
       touchedThreadFieldsRef.current.add("selectedProviderId");
       if (usesStoredCreateSelections) {
+        if (effectiveProviderId.length > 0) {
+          // Materialize legacy/current defaults under the provider being left
+          // before the provider setter retires the old unscoped storage keys.
+          setStoredSelectedModel(selectedModel);
+          setStoredReasoningLevel(reasoningLevel);
+        }
         setStoredProviderId(value);
         return;
       }
-      setThreadSelections((currentSelections) =>
-        updateThreadPromptSelections({
-          currentSelections,
-          field: "selectedProviderId",
-          value,
-        }),
-      );
-      // Don't eagerly reset the model here — the effect that watches
-      // derived values will fall back to the default if the current
-      // selection isn't in the new provider's model list.
+      touchedThreadFieldsRef.current.add("selectedModel");
+      touchedThreadFieldsRef.current.add("reasoningLevel");
+      if (effectiveProviderId.length > 0) {
+        localProviderSelectionsRef.current.set(effectiveProviderId, {
+          model: selectedModel,
+          reasoningLevel,
+        });
+      }
+      const rememberedSelection = localProviderSelectionsRef.current.get(value);
+      setLocalProvidersUsingDefaults((current) => {
+        const next = new Set(current);
+        if (rememberedSelection) {
+          next.delete(value);
+        } else {
+          next.add(value);
+        }
+        return next;
+      });
+      setThreadSelections((currentSelections) => ({
+        ...currentSelections,
+        selectedProviderId: value,
+        selectedModel: rememberedSelection?.model ?? "",
+        reasoningLevel:
+          rememberedSelection?.reasoningLevel ??
+          currentSelections.reasoningLevel,
+      }));
     },
-    [setStoredProviderId, usesStoredCreateSelections],
+    [
+      effectiveProviderId,
+      reasoningLevel,
+      selectedModel,
+      setStoredReasoningLevel,
+      setStoredSelectedModel,
+      setStoredProviderId,
+      usesStoredCreateSelections,
+    ],
   );
 
   const setSelectedModel = useCallback(
@@ -680,15 +743,28 @@ export function useThreadCreationOptions(
         setStoredSelectedModel(value);
         return;
       }
-      setThreadSelections((currentSelections) =>
-        updateThreadPromptSelections({
-          currentSelections,
-          field: "selectedModel",
-          value,
-        }),
-      );
+      setLocalProvidersUsingDefaults((current) => {
+        if (!current.has(effectiveProviderId)) return current;
+        const next = new Set(current);
+        next.delete(effectiveProviderId);
+        return next;
+      });
+      localProviderSelectionsRef.current.set(effectiveProviderId, {
+        model: value,
+        reasoningLevel,
+      });
+      setThreadSelections((currentSelections) => ({
+        ...currentSelections,
+        selectedModel: value,
+        reasoningLevel,
+      }));
     },
-    [setStoredSelectedModel, usesStoredCreateSelections],
+    [
+      effectiveProviderId,
+      reasoningLevel,
+      setStoredSelectedModel,
+      usesStoredCreateSelections,
+    ],
   );
   const setServiceTier = useCallback(
     (value: ServiceTier | undefined) => {
@@ -714,6 +790,16 @@ export function useThreadCreationOptions(
         setStoredReasoningLevel(value);
         return;
       }
+      setLocalProvidersUsingDefaults((current) => {
+        if (!current.has(effectiveProviderId)) return current;
+        const next = new Set(current);
+        next.delete(effectiveProviderId);
+        return next;
+      });
+      localProviderSelectionsRef.current.set(effectiveProviderId, {
+        model: selectedModel,
+        reasoningLevel: value,
+      });
       setThreadSelections((currentSelections) =>
         updateThreadPromptSelections({
           currentSelections,
@@ -722,7 +808,12 @@ export function useThreadCreationOptions(
         }),
       );
     },
-    [setStoredReasoningLevel, usesStoredCreateSelections],
+    [
+      effectiveProviderId,
+      selectedModel,
+      setStoredReasoningLevel,
+      usesStoredCreateSelections,
+    ],
   );
   const setPermissionMode = useCallback(
     (value: PermissionMode) => {

--- a/apps/app/src/hooks/useThreadCreationOptions.ts
+++ b/apps/app/src/hooks/useThreadCreationOptions.ts
@@ -593,10 +593,7 @@ export function useThreadCreationOptions(
     [rawServiceTier, supportsServiceTier],
   );
   const reasoningLevel = useMemo(() => {
-    const preferredLevel =
-      preferredReasoningLevel ??
-      activeModel?.defaultReasoningEffort ??
-      "medium";
+    const preferredLevel = preferredReasoningLevel ?? "medium";
     if (reasoningOptions.length === 0) {
       return preferredLevel;
     }
@@ -607,11 +604,7 @@ export function useThreadCreationOptions(
       preferredLevel,
       reasoningOptions.map((option) => option.value),
     );
-  }, [
-    activeModel?.defaultReasoningEffort,
-    preferredReasoningLevel,
-    reasoningOptions,
-  ]);
+  }, [preferredReasoningLevel, reasoningOptions]);
 
   const permissionMode = resolvePermissionModeSelection({
     rawPermissionMode,

--- a/apps/app/src/hooks/useThreadCreationOptions.ts
+++ b/apps/app/src/hooks/useThreadCreationOptions.ts
@@ -35,6 +35,7 @@ import {
   usePromptBoxProviderPreference,
   usePromptBoxReasoningLevelPreference,
   usePromptBoxServiceTierPreference,
+  useSetPromptBoxProviderModelReasoningPreference,
 } from "./thread-creation-options/persisted-selection-fields";
 import {
   buildExecutionInputSources,
@@ -67,15 +68,24 @@ type ReasoningLevelSelectionSetter = (value: ReasoningLevel) => void;
 type PermissionModeSelectionSetter = (value: PermissionMode) => void;
 type ClearSelectionHandler = () => void;
 
-interface ProviderModelReasoningSelection {
+interface ModelReasoningSelection {
   model: string;
   reasoningLevel: ReasoningLevel;
 }
+
+export interface ProviderModelReasoningSelection extends ModelReasoningSelection {
+  providerId: string;
+}
+
+type ProviderModelReasoningSelectionSetter = (
+  selection: ProviderModelReasoningSelection,
+) => void;
 
 export interface UseThreadCreationOptionsResult<TExecutionInputSources> {
   executionOptionsRouting: SystemProvidersQuery;
   selectedProviderId: string;
   setSelectedProviderId: StringSelectionSetter;
+  setProviderModelReasoning: ProviderModelReasoningSelectionSetter;
   providerOptions: PickerOption<string>[];
   hasMultipleProviders: boolean;
   selectedProviderDisplayName: string;
@@ -168,6 +178,8 @@ export function useThreadCreationOptions(
   } = options ?? {};
   const { setValue: setStoredProviderId, value: storedProviderId } =
     usePromptBoxProviderPreference();
+  const setStoredProviderModelReasoning =
+    useSetPromptBoxProviderModelReasoningPreference();
   const { setValue: setStoredServiceTier, value: storedServiceTier } =
     usePromptBoxServiceTierPreference();
   const { setValue: setStoredPermissionMode, value: storedPermissionMode } =
@@ -193,7 +205,7 @@ export function useThreadCreationOptions(
       }),
     );
   const localProviderSelectionsRef = useRef<
-    Map<string, ProviderModelReasoningSelection>
+    Map<string, ModelReasoningSelection>
   >(new Map());
   const [localProvidersUsingDefaults, setLocalProvidersUsingDefaults] =
     useState<ReadonlySet<string>>(() => new Set());
@@ -736,6 +748,69 @@ export function useThreadCreationOptions(
     ],
   );
 
+  const setProviderModelReasoning = useCallback(
+    ({
+      providerId,
+      model,
+      reasoningLevel: nextReasoningLevel,
+    }: ProviderModelReasoningSelection) => {
+      touchedThreadFieldsRef.current.add("selectedProviderId");
+      touchedThreadFieldsRef.current.add("selectedModel");
+      touchedThreadFieldsRef.current.add("reasoningLevel");
+      if (usesStoredCreateSelections) {
+        if (
+          effectiveProviderId.length > 0 &&
+          effectiveProviderId !== providerId
+        ) {
+          setStoredSelectedModel(selectedModel);
+          setStoredReasoningLevel(reasoningLevel);
+        }
+        setStoredProviderModelReasoning({
+          providerId,
+          model,
+          reasoningLevel: nextReasoningLevel,
+        });
+        setStoredProviderId(providerId);
+        return;
+      }
+      if (
+        effectiveProviderId.length > 0 &&
+        effectiveProviderId !== providerId
+      ) {
+        localProviderSelectionsRef.current.set(effectiveProviderId, {
+          model: selectedModel,
+          reasoningLevel,
+        });
+      }
+      localProviderSelectionsRef.current.set(providerId, {
+        model,
+        reasoningLevel: nextReasoningLevel,
+      });
+      setLocalProvidersUsingDefaults((current) => {
+        if (!current.has(providerId)) return current;
+        const next = new Set(current);
+        next.delete(providerId);
+        return next;
+      });
+      setThreadSelections((currentSelections) => ({
+        ...currentSelections,
+        selectedProviderId: providerId,
+        selectedModel: model,
+        reasoningLevel: nextReasoningLevel,
+      }));
+    },
+    [
+      effectiveProviderId,
+      reasoningLevel,
+      selectedModel,
+      setStoredProviderId,
+      setStoredProviderModelReasoning,
+      setStoredReasoningLevel,
+      setStoredSelectedModel,
+      usesStoredCreateSelections,
+    ],
+  );
+
   const setSelectedModel = useCallback(
     (value: string) => {
       touchedThreadFieldsRef.current.add("selectedModel");
@@ -869,6 +944,7 @@ export function useThreadCreationOptions(
     executionOptionsRouting,
     selectedProviderId: effectiveProviderId,
     setSelectedProviderId,
+    setProviderModelReasoning,
     providerOptions,
     hasMultipleProviders,
     selectedProviderDisplayName:

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -1023,6 +1023,7 @@ export function RootComposeView() {
     executionOptionsRouting,
     selectedProviderId,
     setSelectedProviderId,
+    setProviderModelReasoning,
     providerOptions,
     hasMultipleProviders,
     selectedProviderComposerActions,
@@ -1185,9 +1186,7 @@ export function RootComposeView() {
     }
     if (nextForkSeed !== null && nextHandoffSeed === null) {
       setForkSeed(nextForkSeed);
-      setSelectedProviderId(nextForkSeed.providerId);
-      setSelectedModel(nextForkSeed.model);
-      setReasoningLevel(nextForkSeed.reasoningLevel);
+      setProviderModelReasoning(nextForkSeed);
       setPermissionMode(nextForkSeed.permissionMode);
       setServiceTier(nextForkSeed.serviceTier);
     }
@@ -1213,9 +1212,7 @@ export function RootComposeView() {
     seedHandoffPrompt,
     setEnvironmentSelectionValue,
     setPermissionMode,
-    setReasoningLevel,
-    setSelectedModel,
-    setSelectedProviderId,
+    setProviderModelReasoning,
     setRootComposeProjectId,
     setServiceTier,
   ]);


### PR DESCRIPTION
## Summary

- commit provider changes as soon as a composer provider tab is selected
- persist model and reasoning preferences independently for each provider
- restore prior provider selections, or use the provider catalog defaults when no history exists
- retain equivalent in-memory history for component-local/plugin composers without changing root-composer preferences
- migrate the existing unscoped model/reasoning preferences without leaking them to a newly selected provider

## Testing

- `pnpm exec turbo run test typecheck --filter=@bb/app --force`
- 332 test files passed, 2,505 tests passed

Closes #1288