### PR TITLE
Carry the tagline in the unfurl title as well as the card

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -82,9 +82,7 @@ export const Route = createFileRoute("/")({
     meta: [
       { title: SITE_TITLE },
       { name: "description", content: SITE_DESCRIPTION },
-      // Unfurl title is just "bb": the card image already carries the
-      // tagline, and platforms print the title right next to the image.
-      ...unfurlMeta("bb", OG_DESCRIPTION, "/"),
+      ...unfurlMeta(SITE_TITLE, OG_DESCRIPTION, "/"),
       { name: "theme-color", content: "#ffffff" },
     ],
     links: [


### PR DESCRIPTION
Follow-up to #1341. `og:title` / `twitter:title` change from `bb` to `bb: the IDE that builds itself`.

"bb" alone said nothing in the places platforms show only the title — X's overlay on the card, Slack's link text, and any client where the image is slow or blocked. Every comparable tool (Cursor, Zed, Warp, Linear, Replit, Raycast) ships "Name — tagline" there.

The card image is unchanged. Verified on a production build: `og:title` and `twitter:title` render the new value, everything else identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)