### PR TITLE
Keep voice retries on the transcription model

### DIFF
--- a/apps/server/src/services/ai/voice-transcription.ts
+++ b/apps/server/src/services/ai/voice-transcription.ts
@@ -125,6 +125,7 @@ async function transcribeWithCodexHostDaemon(
     "base64",
   );
   const prompt = trimPrompt(args.prompt) ?? "";
+  const transcriptionModel = `${modelInfo.provider}/${modelInfo.modelId}`;
   const transcription = await inferenceCompleteWithFallback(deps, {
     ...INFERENCE_POLICY.voiceTranscription,
     complete: async (model, attemptPrompt, timeoutMs) => {
@@ -144,8 +145,9 @@ async function transcribeWithCodexHostDaemon(
       });
       return { text: result.text };
     },
+    fallbackModel: transcriptionModel,
     label: "Voice transcription",
-    primaryModel: `${modelInfo.provider}/${modelInfo.modelId}`,
+    primaryModel: transcriptionModel,
     prompt,
     schema: voiceTranscriptionSchema,
   }).catch((error: Error) => error);

--- a/apps/server/test/ai/voice-transcription.test.ts
+++ b/apps/server/test/ai/voice-transcription.test.ts
@@ -58,8 +58,8 @@ async function createCodexTranscriptionHarness({
   handle,
 }: CreateCodexTranscriptionHarnessArgs): Promise<CodexTranscriptionHarness> {
   const harness = await createTestAppHarness({
-    inferenceFallbackModel: "codex/gpt-4o-transcribe-fallback",
-    transcriptionModel: "codex/gpt-4o-mini-transcribe",
+    inferenceFallbackModel: "codex/gpt-5.4-mini",
+    transcriptionModel: "codex/gpt-transcribe",
   });
   const { host, session } = seedHostSession(harness.deps);
   const responder = registerHostRpcResponder(harness, {
@@ -116,7 +116,7 @@ describe("voice transcription", () => {
     }
   });
 
-  it("switches to the fallback model after Codex service unavailability", async () => {
+  it("retries with the transcription model after Codex service unavailability", async () => {
     let requestCount = 0;
     const harness = await createCodexTranscriptionHarness({
       handle(request) {
@@ -144,12 +144,12 @@ describe("voice transcription", () => {
       ).resolves.toBe("hello world");
       expect(harness.requests).toHaveLength(2);
       expect(harness.requests[0]?.command).toMatchObject({
-        model: "gpt-4o-mini-transcribe",
+        model: "gpt-transcribe",
         timeoutMs: 10_000,
         type: "codex.voice.transcribe",
       });
       expect(harness.requests[1]?.command).toMatchObject({
-        model: "gpt-4o-transcribe-fallback",
+        model: "gpt-transcribe",
         timeoutMs: 10_000,
         type: "codex.voice.transcribe",
       });


### PR DESCRIPTION
## Summary

- retry transient Codex voice failures with the configured transcription model
- prevent the general inference fallback from reaching the audio transcription API
- cover the production `gpt-transcribe` / `gpt-5.4-mini` model split in the regression test

## Context

`inferenceCompleteWithFallback` defaults an omitted fallback to `BB_INFERENCE_FALLBACK`. The voice path overrode only the primary model, so its second attempt sent the general text fallback to `codex.voice.transcribe`.

The voice path now explicitly supplies `BB_TRANSCRIPTION` for both attempts while preserving service-unavailable, rate-limit, and timeout retries.

## Testing

- `pnpm exec turbo run typecheck --filter=@bb/server`
- `pnpm exec turbo run test --filter=@bb/server --force -- test/ai/voice-transcription.test.ts`