### PR TITLE
Fix stale terminal tabs that cannot be closed

### DIFF
--- a/apps/app/src/components/secondary-panel/terminalPanelTabs.test.ts
+++ b/apps/app/src/components/secondary-panel/terminalPanelTabs.test.ts
@@ -306,6 +306,42 @@ describe("terminalPanelTabs", () => {
     expect(nextState.secondary.activeTabId).toBeNull();
   });
 
+  it("removes a disconnected terminal without disturbing the active file tab", () => {
+    const terminalTab = createTerminalFixedPanelTab({
+      terminalId: "term_disconnected",
+    });
+    const activeFileTab = createHostFilePreviewFixedPanelTab({
+      environmentId: "env_1",
+      tab: {
+        lineRange: null,
+        path: "/workspace/proposal.md",
+      },
+      threadId: "thr_1",
+    });
+    const state = createEmptyFixedPanelTabsState({
+      secondary: {
+        activeTabId: activeFileTab.id,
+        isOpen: true,
+        tabs: [terminalTab, activeFileTab],
+      },
+    });
+
+    const nextState = syncTerminalTabsInFixedPanelState({
+      retainedTerminalId: null,
+      state,
+      terminalSessions: [
+        terminalSession({
+          id: "term_disconnected",
+          status: "disconnected",
+          title: "zsh",
+        }),
+      ],
+    });
+
+    expect(nextState.secondary.tabs).toEqual([activeFileTab]);
+    expect(nextState.secondary.activeTabId).toBe(activeFileTab.id);
+  });
+
   it("keeps fixed panel state identity when terminal tabs already match", () => {
     const terminalTab = createTerminalFixedPanelTab({ terminalId: "term_1" });
     const state = createEmptyFixedPanelTabsState({

--- a/apps/host-daemon/src/terminals/terminal-manager.test.ts
+++ b/apps/host-daemon/src/terminals/terminal-manager.test.ts
@@ -1195,6 +1195,25 @@ describe("TerminalManager", () => {
     expect(harness.runtime.shutdown).toHaveBeenCalledTimes(1);
   });
 
+  it("acknowledges closing a terminal that is already gone", async () => {
+    const harness = createHarness();
+
+    await harness.manager.handleMessage({
+      type: "terminal.close",
+      terminalId: "term-missing",
+      reason: "user",
+    });
+
+    expect(harness.messages).toEqual([
+      {
+        type: "terminal.exited",
+        terminalId: "term-missing",
+        exitCode: null,
+        closeReason: "user",
+      },
+    ]);
+  });
+
   it("force kills and cleans up a terminal when node-pty never emits exit", async () => {
     vi.useFakeTimers();
     const harness = createHarnessWithOptions({

--- a/apps/host-daemon/src/terminals/terminal-manager.ts
+++ b/apps/host-daemon/src/terminals/terminal-manager.ts
@@ -704,7 +704,21 @@ export class TerminalManager {
 
   private closeTerminal(args: CloseTerminalArgs): void {
     const session = this.sessions.get(args.terminalId);
-    if (!session || session.closeReason !== null) {
+    if (!session) {
+      // Close is idempotent across the server/daemon boundary. The server can
+      // still have a running row after the daemon has already forgotten the
+      // PTY (for example, when an earlier exit message was lost). A silent
+      // return leaves that row running forever because the server is waiting
+      // for this acknowledgement before it completes the close request.
+      this.options.sendMessage({
+        type: "terminal.exited",
+        terminalId: args.terminalId,
+        exitCode: null,
+        closeReason: args.reason,
+      });
+      return;
+    }
+    if (session.closeReason !== null) {
       return;
     }
     session.closeReason = args.reason;

--- a/apps/server/src/services/terminals/terminal-session-lifecycle.ts
+++ b/apps/server/src/services/terminals/terminal-session-lifecycle.ts
@@ -91,6 +91,7 @@ interface PendingTerminalRpcKey extends PendingRpcKey {
 }
 
 interface PendingTerminalCloseKey extends PendingRpcKey {
+  closeReason: TerminalSessionCloseReason;
   daemonSessionId: string;
   terminalId: string;
 }
@@ -511,7 +512,12 @@ export class TerminalSessionLifecycle {
         "Timed out attaching terminal session",
       ),
     });
-    this.pendingCloses = new PendingRpcRegistry({
+    this.pendingCloses = new PendingRpcRegistry<
+      PendingTerminalCloseKey,
+      TerminalSessionRow
+    >({
+      onFail: (pending, error) =>
+        this.finalizeFailedTerminalClose(pending, error),
       timeoutMs: closeTimeoutMs,
       timeoutError: terminalTimeoutError(
         "terminal_close_timeout",
@@ -952,6 +958,7 @@ export class TerminalSessionLifecycle {
     }
 
     const pending = this.pendingCloses.claim({
+      closeReason: args.payload.reason,
       daemonSessionId: current.daemonSessionId,
       rpcKey: terminalRpcKey(current.daemonSessionId, current.id, current.id),
       terminalId: current.id,
@@ -975,7 +982,22 @@ export class TerminalSessionLifecycle {
         });
       }
     }
-    return toTerminalSession(await pending.promise);
+    try {
+      return toTerminalSession(await pending.promise);
+    } catch (error) {
+      // The close-failure hook may already have finalized the daemon-owned row
+      // after the acknowledgement window elapsed. Return that converged state
+      // so clients remove the tab instead of surfacing a failure for a close
+      // the server has now made authoritative.
+      const finalized = getTerminalById(this.options.db, current.id);
+      if (
+        finalized?.status === "exited" &&
+        finalized.closeReason === args.payload.reason
+      ) {
+        return toTerminalSession(finalized);
+      }
+      throw error;
+    }
   }
 
   private finishTerminalCloseWithoutDaemon(args: {
@@ -1733,6 +1755,52 @@ export class TerminalSessionLifecycle {
         session: toTerminalSession(session),
       });
     }
+  }
+
+  private finalizeFailedTerminalClose(
+    pending: PendingTerminalCloseKey,
+    error: Error,
+  ): void {
+    // A normal daemon close force-kills after two seconds; the server waits
+    // five seconds for terminal.exited. If that acknowledgement never arrives,
+    // keeping the row daemon-owned makes every client rediscover an unclosable
+    // terminal forever. Honor the completed force-close window and converge
+    // server state even when the daemon response was lost or the daemon forgot
+    // the PTY before receiving the request.
+    const exited = updateTerminalSession(this.options.db, {
+      scope: {
+        daemonSessionId: pending.daemonSessionId,
+        kind: "daemon",
+        statuses: DAEMON_OWNED_TERMINAL_STATUSES,
+        terminalId: pending.terminalId,
+      },
+      update: {
+        closeReason: pending.closeReason,
+        exitCode: null,
+        kind: "exit",
+      },
+    });
+    if (!exited) {
+      return;
+    }
+
+    const code =
+      error instanceof ApiError ? error.body.code : "terminal_close_failed";
+    const message =
+      error instanceof ApiError ? error.body.message : error.message;
+    this.options.logger.warn(
+      {
+        err: error,
+        sessionId: pending.daemonSessionId,
+        terminalId: pending.terminalId,
+      },
+      "Finalized terminal after close acknowledgement failed",
+    );
+    this.notifyExitedTerminalSession({
+      code,
+      message,
+      session: exited,
+    });
   }
 
   private rejectPendingClose(terminalId: string, error: Error): void {

--- a/apps/server/test/helpers/test-app.ts
+++ b/apps/server/test/helpers/test-app.ts
@@ -47,6 +47,7 @@ export interface RunningTestServer extends TestAppHarness {
 
 export type TestAppHarnessConfigOverrides = Partial<ServerRuntimeConfig> & {
   appVersionService?: AppVersionService;
+  terminalCloseTimeoutMs?: number;
 };
 
 export const testLogger = {
@@ -95,7 +96,8 @@ export function createTestDaemonHostKey(
 export async function createTestAppHarness(
   overrides: TestAppHarnessConfigOverrides = {},
 ): Promise<TestAppHarness> {
-  const { appVersionService, ...configOverrides } = overrides;
+  const { appVersionService, terminalCloseTimeoutMs, ...configOverrides } =
+    overrides;
   const dataDir = await mkdtemp(join(tmpdir(), "bb-server-test-"));
   const db = initDb(":memory:");
   const hub = new NotificationHubImpl();
@@ -148,6 +150,9 @@ export async function createTestAppHarness(
   };
   const terminalSessions = new TerminalSessionLifecycle({
     attachTimeoutMs: 50,
+    ...(terminalCloseTimeoutMs === undefined
+      ? {}
+      : { closeTimeoutMs: terminalCloseTimeoutMs }),
     config,
     db,
     hub,

--- a/apps/server/test/public/public-terminals.test.ts
+++ b/apps/server/test/public/public-terminals.test.ts
@@ -177,6 +177,7 @@ interface PendingTerminalOpen {
 
 interface CreateTerminalRouteFixtureArgs {
   environmentStatus?: EnvironmentStatus;
+  terminalCloseTimeoutMs?: number;
 }
 
 function createFakeDaemonSocket(): FakeDaemonSocket {
@@ -238,7 +239,11 @@ async function waitForDaemonMessage(
 async function createTerminalRouteFixture(
   args: CreateTerminalRouteFixtureArgs = {},
 ): Promise<TerminalRouteFixture> {
-  const harness = await createTestAppHarness();
+  const harness = await createTestAppHarness(
+    args.terminalCloseTimeoutMs === undefined
+      ? {}
+      : { terminalCloseTimeoutMs: args.terminalCloseTimeoutMs },
+  );
   const seeded = seedHostSession(harness.deps, { id: "terminal-host" });
   const { project } = seedProjectWithSource(harness.deps, {
     hostId: seeded.host.id,
@@ -1714,6 +1719,59 @@ describe("public terminal routes", () => {
         status: "exited",
       },
     );
+  });
+
+  it("completes a terminal close when its daemon acknowledgement times out", async () => {
+    const fixture = await createTerminalRouteFixture({
+      terminalCloseTimeoutMs: 50,
+    });
+    harnesses.push(fixture.harness);
+    const stored = createTerminalSession(fixture.harness.db, {
+      cols: 80,
+      daemonSessionId: fixture.session.id,
+      environmentId: fixture.environment.id,
+      hostId: fixture.host.id,
+      initialCwd: "/tmp/terminal-workspace",
+      rows: 24,
+      status: "running",
+      threadId: fixture.thread.id,
+      title: "zsh",
+    });
+
+    const responsePromise = fixture.harness.app.request(
+      `/api/v1/terminals/${stored.id}/close`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ mode: "force", reason: "user" }),
+      },
+    );
+
+    await expect(waitForDaemonMessage(fixture.socket)).resolves.toMatchObject({
+      type: "terminal.close",
+      terminalId: stored.id,
+      reason: "user",
+    });
+    const response = await responsePromise;
+
+    expect(response.status).toBe(200);
+    expect(terminalSessionSchema.parse(await readJson(response))).toMatchObject({
+      id: stored.id,
+      closeReason: "user",
+      exitCode: null,
+      status: "exited",
+    });
+    expect(
+      getTerminalSessionForThread(fixture.harness.db, {
+        terminalId: stored.id,
+        threadId: fixture.thread.id,
+      }),
+    ).toMatchObject({
+      closeReason: "user",
+      daemonSessionId: null,
+      exitCode: null,
+      status: "exited",
+    });
   });
 
   it("does not close a dirty terminal unless force mode is requested", async () => {

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -36,7 +36,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 103 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 104 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1056,10 +1056,12 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
-  // Version 103 timestamps pull request checks so the server can collapse
-  // superseded runs without relying on GitHub's unstable rollup array order.
-  it("uses protocol version 103 for timestamped pull request checks", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(103);
+  // Version 104 makes terminal.close idempotent in the daemon. An enrolled
+  // daemon on an older build silently ignores a close for a terminal missing
+  // from its in-memory map, leaving the server row running and the panel tab
+  // impossible to close, so enrolled machines must update for the new behavior.
+  it("uses protocol version 104 for idempotent terminal closes", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(104);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {


### PR DESCRIPTION
## Summary

- make daemon terminal closes idempotent by acknowledging terminals already absent from memory
- reconcile daemon-owned terminal rows to exited when close acknowledgement fails or times out
- return the reconciled terminal state to clients so panel tab synchronization removes the stale tab
- bump the host-daemon protocol version and add daemon, server, contract, and app regression coverage

## Why

If the server still recorded a terminal as running after the daemon had forgotten its PTY, the daemon silently ignored terminal.close. The server timed out without changing persisted state, and terminal synchronization kept restoring the tab indefinitely.

## Testing

- 25 host-daemon terminal manager tests
- 35 server public terminal route tests
- 12 app terminal tab synchronization tests
- 35 host-daemon contract tests
- Turbo typechecks for @bb/app, @bb/server, @bb/host-daemon, and @bb/host-daemon-contract

Closes #1252