### PR TITLE
Prioritize exact user-command matches in slash command suggestions

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -3116,6 +3116,83 @@ describe("PromptBoxInternal command typeahead navigation", () => {
       name: "interview",
     });
   });
+
+  it("hoists an exactly-named user command above the skills section", async () => {
+    // Suggestions arrive in section order (skills first), the way the server
+    // hands them back — the exact-match hoist is PromptBoxInternal's job, so
+    // every composer that renders through it gets the same order.
+    const { changes, promptBoxRef } = renderPromptBox("/plan", {
+      commandSuggestions: [
+        {
+          kind: "command",
+          name: "planner",
+          source: "skill",
+          origin: "user",
+          description: null,
+          argumentHint: null,
+        },
+        {
+          kind: "command",
+          name: "planning-doc",
+          source: "skill",
+          origin: "user",
+          description: null,
+          argumentHint: null,
+        },
+        {
+          kind: "command",
+          name: "plan",
+          source: "command",
+          origin: "user",
+          description: null,
+          argumentHint: null,
+        },
+        {
+          kind: "command",
+          name: "plan-b",
+          source: "command",
+          origin: "user",
+          description: null,
+          argumentHint: null,
+        },
+      ],
+    });
+
+    await focusPromptEnd(promptBoxRef);
+    const sectionLabel = await screen.findByText("User commands");
+    const menu = sectionLabel.closest(".overflow-hidden");
+    if (!(menu instanceof HTMLElement)) {
+      throw new Error("Expected command menu");
+    }
+    // The exact match leads, and its section stays whole rather than splitting
+    // around the skills — one header per section keeps rendered order equal to
+    // the array Arrow/Enter walk.
+    expect(
+      within(menu)
+        .getAllByRole("button")
+        .map((button) => button.textContent),
+    ).toEqual(["plan", "plan-b", "planner", "planning-doc"]);
+    expect(
+      within(menu)
+        .getAllByText(/^(User commands|Skills)$/)
+        .map((label) => label.textContent),
+    ).toEqual(["User commands", "Skills"]);
+
+    await waitFor(() =>
+      expect(
+        within(menu).getByRole("button", { name: "plan" }).className,
+      ).toContain("bg-state-active"),
+    );
+
+    fireEvent.keyDown(getPromptEditorElement(), { key: "Enter" });
+
+    await waitFor(() => expect(latestValue(changes)).toBe("/plan "));
+    expect(latestChange(changes)?.mentions[0]?.resource).toMatchObject({
+      kind: "command",
+      name: "plan",
+      source: "command",
+    });
+  });
 });
 
 describe("voice recording escape", () => {

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -24,7 +24,7 @@ import {
   type Ref,
 } from "react";
 import {
-  orderCommandSuggestionsBySection,
+  orderCommandSuggestions,
   type ActiveTrigger,
   type CommandMenuState,
   type ComposerCommandSuggestion,
@@ -1952,9 +1952,13 @@ export function PromptBoxInternal({
       isError: commandError,
       isLoadingMore: commandIsLoadingMore,
     });
+  // Ranked against the query the user can actually see in the composer, so the
+  // exact-name match this ordering hoists is the one the caret spells out.
+  const activeCommandQuery =
+    activeTrigger?.kind === "command" ? activeTrigger.query : "";
   const orderedCommandSuggestions = useMemo(
-    () => orderCommandSuggestionsBySection(commandSuggestions),
-    [commandSuggestions],
+    () => orderCommandSuggestions(commandSuggestions, activeCommandQuery),
+    [activeCommandQuery, commandSuggestions],
   );
   // The suggestion list driving keyboard nav + Enter/Tab apply for whichever
   // trigger is active. Empty when no trigger is open. Memoized so the keyboard

--- a/apps/app/src/components/promptbox/mentions/MentionMenu.tsx
+++ b/apps/app/src/components/promptbox/mentions/MentionMenu.tsx
@@ -212,9 +212,10 @@ function getMentionKey(item: PromptMentionSuggestion, index: number): string {
 }
 
 // Command sections use the shared `providerCommandSection` mapping from
-// @bb/server-contract. PromptBoxInternal orders the flat suggestions with the
-// matching section rank before that same array reaches rendering, keyboard
-// navigation, and apply; the menu only adds human-readable labels.
+// @bb/server-contract. PromptBoxInternal runs `orderCommandSuggestions` — which
+// hoists exact name matches and hands back contiguous sections — before that
+// same array reaches rendering, keyboard navigation, and apply; the menu only
+// adds human-readable labels.
 type CommandSectionKind = ProviderCommandSection;
 
 function getCommandSectionKind(

--- a/apps/app/src/components/promptbox/mentions/command-suggestion-order.test.ts
+++ b/apps/app/src/components/promptbox/mentions/command-suggestion-order.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  orderCommandSuggestions,
+  type ComposerCommandSuggestion,
+} from "./types";
+
+function skill(name: string): ComposerCommandSuggestion {
+  return {
+    kind: "command",
+    name,
+    source: "skill",
+    origin: "user",
+    description: null,
+    argumentHint: null,
+  };
+}
+
+function userCommand(name: string): ComposerCommandSuggestion {
+  return {
+    kind: "command",
+    name,
+    source: "command",
+    origin: "user",
+    description: null,
+    argumentHint: null,
+  };
+}
+
+function projectCommand(name: string): ComposerCommandSuggestion {
+  return {
+    kind: "command",
+    name,
+    source: "command",
+    origin: "project",
+    description: null,
+    argumentHint: null,
+  };
+}
+
+function orderedNames(
+  suggestions: readonly ComposerCommandSuggestion[],
+  query: string,
+): string[] {
+  return orderCommandSuggestions(suggestions, query).map(
+    (suggestion) => suggestion.name,
+  );
+}
+
+describe("orderCommandSuggestions", () => {
+  it("keeps section order when nothing matches the query exactly", () => {
+    expect(
+      orderedNames(
+        [userCommand("plan"), skill("planner"), projectCommand("plan-review")],
+        "pla",
+      ),
+    ).toEqual(["planner", "plan-review", "plan"]);
+  });
+
+  it("hoists an exact user-command match above every non-exact match", () => {
+    expect(
+      orderedNames(
+        [skill("planner"), skill("planning-doc"), userCommand("plan")],
+        "plan",
+      ),
+    ).toEqual(["plan", "planner", "planning-doc"]);
+  });
+
+  it("keeps each section contiguous so rendering cannot reshuffle rows", () => {
+    // `plan-b` shares the hoisted command's section: the menu renders one
+    // header per section, so it has to follow `plan` in the flat array the
+    // composer walks for Arrow/Enter rather than trailing the skills.
+    expect(
+      orderedNames(
+        [skill("planner"), userCommand("plan-b"), userCommand("plan")],
+        "plan",
+      ),
+    ).toEqual(["plan", "plan-b", "planner"]);
+  });
+
+  it("treats a namespaced skill's bare name as an exact match", () => {
+    expect(
+      orderedNames(
+        [projectCommand("review-pr"), skill("ottonomous:review")],
+        "review",
+      ),
+    ).toEqual(["ottonomous:review", "review-pr"]);
+  });
+
+  it("falls back to section order when several sections match exactly", () => {
+    expect(orderedNames([userCommand("plan"), skill("plan")], "plan")).toEqual([
+      "plan",
+      "plan",
+    ]);
+    expect(
+      orderCommandSuggestions([userCommand("plan"), skill("plan")], "plan").map(
+        (suggestion) => suggestion.source,
+      ),
+    ).toEqual(["skill", "command"]);
+  });
+
+  it("ignores query whitespace and casing when detecting an exact match", () => {
+    expect(
+      orderedNames([skill("planner"), userCommand("plan")], "  PLAN "),
+    ).toEqual(["plan", "planner"]);
+  });
+
+  it("leaves pure section order for an empty query", () => {
+    expect(
+      orderedNames(
+        [userCommand("plan"), projectCommand("ship"), skill("planner")],
+        "",
+      ),
+    ).toEqual(["planner", "ship", "plan"]);
+  });
+});

--- a/apps/app/src/components/promptbox/mentions/command-suggestion-order.test.ts
+++ b/apps/app/src/components/promptbox/mentions/command-suggestion-order.test.ts
@@ -4,13 +4,16 @@ import {
   type ComposerCommandSuggestion,
 } from "./types";
 
-function skill(name: string): ComposerCommandSuggestion {
+function skill(
+  name: string,
+  description: string | null = null,
+): ComposerCommandSuggestion {
   return {
     kind: "command",
     name,
     source: "skill",
     origin: "user",
-    description: null,
+    description,
     argumentHint: null,
   };
 }
@@ -47,13 +50,35 @@ function orderedNames(
 }
 
 describe("orderCommandSuggestions", () => {
-  it("keeps section order when nothing matches the query exactly", () => {
+  it("keeps section order when every row matches the query as directly", () => {
     expect(
       orderedNames(
         [userCommand("plan"), skill("planner"), projectCommand("plan-review")],
         "pla",
       ),
     ).toEqual(["planner", "plan-review", "plan"]);
+  });
+
+  it("hoists a user-command name prefix above description-only matches", () => {
+    // `/pla` names the `plan` command more directly than skills that only
+    // mention "plan" in prose, so the partial query gets the same treatment as
+    // the full one.
+    expect(
+      orderedNames(
+        [
+          skill("sprint", "Plan a sprint"),
+          skill("scope", "Planning helper"),
+          userCommand("plan"),
+        ],
+        "pla",
+      ),
+    ).toEqual(["plan", "sprint", "scope"]);
+  });
+
+  it("ranks an exact match above a prefix match from an earlier section", () => {
+    expect(
+      orderedNames([skill("planner"), userCommand("plan")], "plan"),
+    ).toEqual(["plan", "planner"]);
   });
 
   it("hoists an exact user-command match above every non-exact match", () => {

--- a/apps/app/src/components/promptbox/mentions/types.ts
+++ b/apps/app/src/components/promptbox/mentions/types.ts
@@ -135,63 +135,53 @@ function commandSuggestionSearchNames(
 }
 
 /**
- * Relevance order for a lowercased, trimmed query. Typing a command's whole
- * name is an unambiguous request for that command, so an exact name match
- * outranks every non-exact match no matter which section it lives in — a `/plan`
- * user command must not sit below skills that merely mention "plan". Matches of
- * equal quality keep the `PROVIDER_COMMAND_SECTIONS` order, and within a section
- * a name-prefix match beats a description-only match. An empty query ties every
- * row, leaving pure section order.
+ * How directly the query names a command. Lower wins: the whole name, then a
+ * name prefix, then a row that only matched through its description or argument
+ * hint. An empty query prefix-matches everything, so it ranks every row alike.
+ */
+function commandSuggestionMatchRank(
+  suggestion: ComposerCommandSuggestion,
+  normalizedQuery: string,
+): number {
+  const names = commandSuggestionSearchNames(suggestion);
+  if (names.includes(normalizedQuery)) {
+    return 0;
+  }
+  return names.some((name) => name.startsWith(normalizedQuery)) ? 1 : 2;
+}
+
+/**
+ * Relevance order for a lowercased, trimmed query. How directly the query names
+ * a command outranks which section that command lives in: typing `/plan` in full
+ * is an unambiguous request for the `plan` user command, and even a partial
+ * `/pla` names it more directly than a skill that merely mentions "plan" in its
+ * description. Matches of equal quality keep the `PROVIDER_COMMAND_SECTIONS`
+ * order, so an empty query — which prefix-matches every row — leaves pure
+ * section order.
  */
 export function compareCommandSuggestions(
   left: ComposerCommandSuggestion,
   right: ComposerCommandSuggestion,
   normalizedQuery: string,
 ): number {
-  const leftExact = isExactCommandNameMatch(left, normalizedQuery);
-  const rightExact = isExactCommandNameMatch(right, normalizedQuery);
-  if (leftExact !== rightExact) {
-    return leftExact ? -1 : 1;
-  }
-
-  const bySection = compareCommandSuggestionSections(left, right);
-  if (bySection !== 0) {
-    return bySection;
-  }
-
-  const leftPrefix = hasCommandNamePrefixMatch(left, normalizedQuery);
-  const rightPrefix = hasCommandNamePrefixMatch(right, normalizedQuery);
-  if (leftPrefix !== rightPrefix) {
-    return leftPrefix ? -1 : 1;
-  }
-  return 0;
-}
-
-function isExactCommandNameMatch(
-  suggestion: ComposerCommandSuggestion,
-  normalizedQuery: string,
-): boolean {
-  return commandSuggestionSearchNames(suggestion).includes(normalizedQuery);
-}
-
-function hasCommandNamePrefixMatch(
-  suggestion: ComposerCommandSuggestion,
-  normalizedQuery: string,
-): boolean {
-  return commandSuggestionSearchNames(suggestion).some((name) =>
-    name.startsWith(normalizedQuery),
-  );
+  const byMatch =
+    commandSuggestionMatchRank(left, normalizedQuery) -
+    commandSuggestionMatchRank(right, normalizedQuery);
+  return byMatch !== 0
+    ? byMatch
+    : compareCommandSuggestionSections(left, right);
 }
 
 /**
  * Put the flat command list in the exact order the menu renders it: ranked by
  * {@link compareCommandSuggestions}, then collapsed so every section's rows are
- * contiguous, ordered by where that section first appears. The collapse is what
- * keeps hoisting an exact match honest — the menu groups by section as it
- * renders, so a section whose rows were scattered through the flat list would
- * paint them in a different order than the composer walks them. The composer
- * uses this exact array for keyboard navigation and Enter/Tab apply, so visual
- * grouping must never be the first place ordering happens.
+ * contiguous, ordered by where that section first appears — which puts each
+ * section under its own best match. The collapse is what keeps hoisting a strong
+ * match honest: the menu groups by section as it renders, so a section whose
+ * rows were scattered through the flat list would paint them in a different
+ * order than the composer walks them. The composer uses this exact array for
+ * keyboard navigation and Enter/Tab apply, so visual grouping must never be the
+ * first place ordering happens.
  */
 export function orderCommandSuggestions(
   suggestions: readonly ComposerCommandSuggestion[],

--- a/apps/app/src/components/promptbox/mentions/types.ts
+++ b/apps/app/src/components/promptbox/mentions/types.ts
@@ -1,7 +1,9 @@
 import {
+  providerCommandSection,
   providerCommandSectionRank,
   type ProviderCommand,
   type ProviderCommandOrigin,
+  type ProviderCommandSection,
   type ProviderCommandSource,
 } from "@bb/server-contract";
 import type { PromptMentionCommandTrigger } from "@bb/domain";
@@ -109,7 +111,7 @@ export function toProviderCommandSuggestion(
 /** Every row the command typeahead menu can render. */
 export type ComposerCommandSuggestion = ProviderCommandSuggestion;
 
-export function compareCommandSuggestionSections(
+function compareCommandSuggestionSections(
   left: ComposerCommandSuggestion,
   right: ComposerCommandSuggestion,
 ): number {
@@ -117,14 +119,103 @@ export function compareCommandSuggestionSections(
 }
 
 /**
- * Put the flat command list in the same section order the menu renders. The
- * composer uses this exact array for keyboard navigation and Enter/Tab apply,
- * so visual grouping must never be the first place section ordering happens.
+ * The names a query can address a command by. A namespaced skill
+ * (`ottonomous:review`) also answers to its trailing segment, so typing the
+ * bare name still counts as naming that skill.
  */
-export function orderCommandSuggestionsBySection(
+function commandSuggestionSearchNames(
+  suggestion: ComposerCommandSuggestion,
+): string[] {
+  const name = suggestion.name.toLowerCase();
+  if (suggestion.source !== "skill") {
+    return [name];
+  }
+  const separatorIndex = name.lastIndexOf(":");
+  return separatorIndex < 0 ? [name] : [name, name.slice(separatorIndex + 1)];
+}
+
+/**
+ * Relevance order for a lowercased, trimmed query. Typing a command's whole
+ * name is an unambiguous request for that command, so an exact name match
+ * outranks every non-exact match no matter which section it lives in — a `/plan`
+ * user command must not sit below skills that merely mention "plan". Matches of
+ * equal quality keep the `PROVIDER_COMMAND_SECTIONS` order, and within a section
+ * a name-prefix match beats a description-only match. An empty query ties every
+ * row, leaving pure section order.
+ */
+export function compareCommandSuggestions(
+  left: ComposerCommandSuggestion,
+  right: ComposerCommandSuggestion,
+  normalizedQuery: string,
+): number {
+  const leftExact = isExactCommandNameMatch(left, normalizedQuery);
+  const rightExact = isExactCommandNameMatch(right, normalizedQuery);
+  if (leftExact !== rightExact) {
+    return leftExact ? -1 : 1;
+  }
+
+  const bySection = compareCommandSuggestionSections(left, right);
+  if (bySection !== 0) {
+    return bySection;
+  }
+
+  const leftPrefix = hasCommandNamePrefixMatch(left, normalizedQuery);
+  const rightPrefix = hasCommandNamePrefixMatch(right, normalizedQuery);
+  if (leftPrefix !== rightPrefix) {
+    return leftPrefix ? -1 : 1;
+  }
+  return 0;
+}
+
+function isExactCommandNameMatch(
+  suggestion: ComposerCommandSuggestion,
+  normalizedQuery: string,
+): boolean {
+  return commandSuggestionSearchNames(suggestion).includes(normalizedQuery);
+}
+
+function hasCommandNamePrefixMatch(
+  suggestion: ComposerCommandSuggestion,
+  normalizedQuery: string,
+): boolean {
+  return commandSuggestionSearchNames(suggestion).some((name) =>
+    name.startsWith(normalizedQuery),
+  );
+}
+
+/**
+ * Put the flat command list in the exact order the menu renders it: ranked by
+ * {@link compareCommandSuggestions}, then collapsed so every section's rows are
+ * contiguous, ordered by where that section first appears. The collapse is what
+ * keeps hoisting an exact match honest — the menu groups by section as it
+ * renders, so a section whose rows were scattered through the flat list would
+ * paint them in a different order than the composer walks them. The composer
+ * uses this exact array for keyboard navigation and Enter/Tab apply, so visual
+ * grouping must never be the first place ordering happens.
+ */
+export function orderCommandSuggestions(
   suggestions: readonly ComposerCommandSuggestion[],
+  query: string,
 ): ComposerCommandSuggestion[] {
-  return [...suggestions].sort(compareCommandSuggestionSections);
+  const normalizedQuery = query.trim().toLowerCase();
+  const ranked = [...suggestions].sort((left, right) =>
+    compareCommandSuggestions(left, right, normalizedQuery),
+  );
+
+  const bySection = new Map<
+    ProviderCommandSection,
+    ComposerCommandSuggestion[]
+  >();
+  for (const suggestion of ranked) {
+    const section = providerCommandSection(suggestion);
+    const existing = bySection.get(section);
+    if (existing) {
+      existing.push(suggestion);
+      continue;
+    }
+    bySection.set(section, [suggestion]);
+  }
+  return [...bySection.values()].flat();
 }
 
 /**

--- a/apps/app/src/hooks/useCommandSuggestions.test.ts
+++ b/apps/app/src/hooks/useCommandSuggestions.test.ts
@@ -110,12 +110,33 @@ describe("commandSuggestionMatchesQuery", () => {
     ]);
   });
 
-  it("keeps menu sections primary when ranking prefix matches", () => {
+  it("keeps menu sections primary when ranking non-exact matches", () => {
     const names = filterCommandSuggestions(
       [
         {
           ...pluginSkill,
           name: "review-helper",
+          description: "Contains deploy guidance",
+        },
+        {
+          ...pluginSkill,
+          name: "deploy-service",
+          source: "command",
+          origin: "user",
+        },
+      ],
+      "deploy",
+    ).map((suggestion) => suggestion.name);
+
+    expect(names).toEqual(["review-helper", "deploy-service"]);
+  });
+
+  it("ranks an exact user-command name above skills from an earlier section", () => {
+    const names = filterCommandSuggestions(
+      [
+        {
+          ...pluginSkill,
+          name: "deploy-review",
           description: "Contains deploy guidance",
         },
         {
@@ -128,6 +149,6 @@ describe("commandSuggestionMatchesQuery", () => {
       "deploy",
     ).map((suggestion) => suggestion.name);
 
-    expect(names).toEqual(["review-helper", "deploy"]);
+    expect(names).toEqual(["deploy", "deploy-review"]);
   });
 });

--- a/apps/app/src/hooks/useCommandSuggestions.test.ts
+++ b/apps/app/src/hooks/useCommandSuggestions.test.ts
@@ -110,7 +110,24 @@ describe("commandSuggestionMatchesQuery", () => {
     ]);
   });
 
-  it("keeps menu sections primary when ranking non-exact matches", () => {
+  it("keeps menu sections primary when matches are equally direct", () => {
+    const names = filterCommandSuggestions(
+      [
+        {
+          ...pluginSkill,
+          name: "deploy-service",
+          source: "command",
+          origin: "user",
+        },
+        { ...pluginSkill, name: "deploy-helper" },
+      ],
+      "deploy",
+    ).map((suggestion) => suggestion.name);
+
+    expect(names).toEqual(["deploy-helper", "deploy-service"]);
+  });
+
+  it("ranks a user-command name prefix above a skill matched by description", () => {
     const names = filterCommandSuggestions(
       [
         {
@@ -128,7 +145,7 @@ describe("commandSuggestionMatchesQuery", () => {
       "deploy",
     ).map((suggestion) => suggestion.name);
 
-    expect(names).toEqual(["review-helper", "deploy-service"]);
+    expect(names).toEqual(["deploy-service", "review-helper"]);
   });
 
   it("ranks an exact user-command name above skills from an earlier section", () => {

--- a/apps/app/src/hooks/useCommandSuggestions.ts
+++ b/apps/app/src/hooks/useCommandSuggestions.ts
@@ -1,8 +1,8 @@
 import { useMemo } from "react";
 import type { PromptMentionCommandTrigger } from "@bb/domain";
 import {
-  compareCommandSuggestionSections,
-  orderCommandSuggestionsBySection,
+  compareCommandSuggestions,
+  orderCommandSuggestions,
   toProviderCommandSuggestion,
   type ProviderCommandSuggestion,
 } from "@/components/promptbox/mentions/types";
@@ -70,17 +70,6 @@ export function commandSuggestionMatchesQuery(
     .includes(query);
 }
 
-function commandSuggestionSearchNames(
-  suggestion: ProviderCommandSuggestion,
-): string[] {
-  const name = suggestion.name.toLowerCase();
-  if (suggestion.source !== "skill") {
-    return [name];
-  }
-  const separatorIndex = name.lastIndexOf(":");
-  return separatorIndex < 0 ? [name] : [name, name.slice(separatorIndex + 1)];
-}
-
 export function filterCommandSuggestions(
   suggestions: readonly ProviderCommandSuggestion[],
   query: string,
@@ -90,19 +79,9 @@ export function filterCommandSuggestions(
     .filter((suggestion) =>
       commandSuggestionMatchesQuery(suggestion, normalizedQuery),
     )
-    .sort((left, right) => {
-      const bySection = compareCommandSuggestionSections(left, right);
-      if (bySection !== 0) {
-        return bySection;
-      }
-      const leftPrefix = commandSuggestionSearchNames(left).some((name) =>
-        name.startsWith(normalizedQuery),
-      );
-      const rightPrefix = commandSuggestionSearchNames(right).some((name) =>
-        name.startsWith(normalizedQuery),
-      );
-      return leftPrefix === rightPrefix ? 0 : leftPrefix ? -1 : 1;
-    });
+    .sort((left, right) =>
+      compareCommandSuggestions(left, right, normalizedQuery),
+    );
 }
 
 export function promptActionCommandSuggestions({
@@ -216,8 +195,9 @@ export function useCommandSuggestions(
         ),
       trimmedQuery,
     );
-    return orderCommandSuggestionsBySection(
+    return orderCommandSuggestions(
       mergeCommandSuggestions(promptActionSuggestions, discoveredSuggestions),
+      trimmedQuery,
     );
   }, [
     commandsQuery.data?.commands,


### PR DESCRIPTION
Fixes #1306

## Problem

The slash command typeahead sorted purely by menu section (`agent-command` → `skill` → `project-command` → `user-command`). Typing `/plan` — the full name of a user command — put every skill that merely mentions "plan" above it, so the exact match sat at the bottom of the list and Enter/Tab applied an unrelated skill. Query relevance only broke ties *within* a section, so it could never rescue a command from a section that sorts late.

## Fix

`orderCommandSuggestions` (formerly `orderCommandSuggestionsBySection`) now takes the active query and ranks in two steps:

1. **Match quality outranks section.** One ladder for how directly the query names a command: whole name → name prefix → matched only through description/argument hint. So `/plan` puts the `plan` user command first, and `/pla` does too, ahead of skills that only mention "plan" in prose. Matches of equal quality keep the existing `PROVIDER_COMMAND_SECTIONS` order, and an empty query prefix-matches everything, leaving today's pure section order untouched. Namespaced skills (`ottonomous:review`) count `review` as naming them, matching the existing prefix-ranking rule.
2. **Collapse sections so their rows are contiguous**, ordered by first appearance — each section lands under its own best match. This is what keeps the hoist honest: `MentionMenu` renders one header per section, so a section whose rows were scattered through the flat list would paint in a different order than the composer walks for Arrow/Enter. Hoisting `plan` therefore brings its "User commands" header to the top with the rest of that section behind it, rather than splitting the section into two headers.

`PromptBoxInternal` ranks against the query under the caret and is the single place every composer's command list is ordered before it reaches rendering, keyboard navigation, and apply — so the follow-up composer, new-thread composer, embedded chat, root compose view, and plugin composer all get the same behavior. `useCommandSuggestions` shares the same comparator so its pre-ordered output agrees.

## Acceptance criteria

- ✅ Exact user-command match appears before non-exact matches from other sections
- ✅ Exact match is the initial keyboard selection (selection resets to index 0 on every query change)
- ✅ Keyboard navigation order matches visible order (guaranteed by the contiguous-section collapse)
- ✅ Other results stay under their existing section labels, one header each
- ✅ Consistent across every composer, since all of them render through `PromptBoxInternal`

Prefix ranking across sections goes slightly beyond the issue's wording, which asked only about exact matches — without it `/pla` still reproduces the original complaint.

## Testing

- New `command-suggestion-order.test.ts` covers the exact and prefix hoists, section contiguity, equal-quality section fallback, namespaced skills, casing/whitespace, and the unchanged empty-query order.
- New `PromptBoxInternal` test renders `/plan` with suggestions in server order and asserts the rendered row order, one header per section, that `plan` is the highlighted row, and that Enter applies it. Reverting the three source files to `main` while keeping that test reproduces the bug: rows render `planner, planning-doc, plan, plan-b`.
- `pnpm exec turbo run typecheck --filter=@bb/app` and the full `@bb/app` suite (2530 tests) pass; lint warning count unchanged from baseline.

> AGENT GENERATED: by Claude Opus 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)