### PR TITLE
Speed up iOS Safari drawer interactions

### DIFF
--- a/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
@@ -278,7 +278,11 @@ describe("FollowUpPromptBox", () => {
     });
     let commitsAfterSynchronousSignal = -1;
     const resizeEntries = [
-      { contentRect: { height: 24 } } as ResizeObserverEntry,
+      {
+        target: stackElement,
+        borderBoxSize: [{ blockSize: 24 }],
+        contentRect: { height: 999 },
+      } as unknown as ResizeObserverEntry,
     ];
 
     act(() => {
@@ -351,7 +355,13 @@ describe("FollowUpPromptBox", () => {
 
     act(() => {
       resizeObserverCallback?.(
-        [{ contentRect: { height: 999 } } as ResizeObserverEntry],
+        [
+          {
+            target: stackElement,
+            borderBoxSize: [{ blockSize: 24 }],
+            contentRect: { height: 999 },
+          } as unknown as ResizeObserverEntry,
+        ],
         {} as ResizeObserver,
       );
       resizeObserverCallback?.([], {} as ResizeObserver);

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -641,33 +641,36 @@ function FollowUpPromptBoxWithComposer({
   const stackRef = useRef<HTMLDivElement>(null);
   const lastStackHeightRef = useRef(0);
   const [stackHeight, setStackHeight] = useState(0);
-  const measureStackHeight = useCallback(() => {
-    const element = stackRef.current;
-    if (!element) return;
-    const measured = element.offsetHeight;
+  const applyStackHeight = useCallback((measured: number) => {
     if (lastStackHeightRef.current === measured) return;
     lastStackHeightRef.current = measured;
     setStackHeight(measured);
   }, []);
-  // Measure the stack synchronously after every render. useLayoutEffect runs
-  // post-DOM-commit and pre-paint, so when a React commit adds the banner
-  // (e.g. workspace status arrives and the git section becomes non-empty),
-  // we read the new stack height and the resulting `setStackHeight` triggers
-  // a synchronous re-render that updates the textarea's minHeight before the
-  // browser paints. Without this, the banner appears at 32px while the
-  // textarea is still 100px for one frame — the timeline visibly shifts up
-  // then back down as the elastic compensation catches up.
-  useLayoutEffect(measureStackHeight, [measureStackHeight, stack]);
-  // ResizeObserver catches changes that happen outside a React render —
-  // banner sections expanding via CSS animation, window resize affecting
-  // markdown line-wrapping inside the stack, etc.
+
+  // Take one initial border-box measurement before paint. Later measurements
+  // use ResizeObserver's supplied border-box size, which avoids a synchronous
+  // offsetHeight read after each timeline or composer render.
+  useLayoutEffect(() => {
+    const element = stackRef.current;
+    if (element) {
+      applyStackHeight(element.offsetHeight);
+    }
+  }, [applyStackHeight]);
+
   useEffect(() => {
     const element = stackRef.current;
     if (!element || typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(measureStackHeight);
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries.find((candidate) => candidate.target === element);
+      if (!entry) return;
+      const borderBoxSize = Array.isArray(entry.borderBoxSize)
+        ? entry.borderBoxSize[0]
+        : entry.borderBoxSize;
+      applyStackHeight(borderBoxSize?.blockSize ?? entry.contentRect.height);
+    });
     observer.observe(element);
     return () => observer.disconnect();
-  }, [measureStackHeight]);
+  }, [applyStackHeight]);
   // The elastic pre-size keeps the prompt area's total height constant as the
   // stack (context banner + queued messages) mounts/unmounts so the timeline
   // doesn't shift. Callers that need the main-thread prompt height should pass

--- a/apps/app/src/components/secondary-panel/useDrawerPanelRealization.ts
+++ b/apps/app/src/components/secondary-panel/useDrawerPanelRealization.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useState } from "react";
+
+// vaul keeps a closing drawer mounted for its ~500ms exit transition and
+// tears it down afterwards. The grace must outlast that teardown so the
+// panel never unmounts mid-slide, and so a quick reopen finds the panel
+// still mounted and skips the mount cost entirely.
+const DRAWER_PANEL_TEARDOWN_GRACE_MS = 700;
+// Realization normally happens when the entrance animation ends. The
+// fallback covers environments where that event never fires (reduced
+// motion, jsdom).
+const DRAWER_PANEL_REALIZE_FALLBACK_MS = 700;
+
+/**
+ * Defers the mount of a bottom drawer's heavy panel until the sheet's
+ * entrance animation has finished. vaul mounts drawer children synchronously
+ * inside the opening tap; on an iPhone the secondary panel's mount plus its
+ * style resolution cost ~430 ms of main-thread time, which froze the
+ * slide-in (see the iOS drawer performance recording behind this change).
+ * A light skeleton rides the entrance instead, and the real panel mounts one
+ * settle callback later, while the sheet is at rest.
+ *
+ * The caller invokes `realizePanel` from its drawer settle callback and
+ * swaps `isPanelRealized ? panel : skeleton` in the drawer body.
+ */
+export function useDrawerPanelRealization({
+  isDrawerOpen,
+  rendersAsDrawer,
+}: {
+  isDrawerOpen: boolean;
+  rendersAsDrawer: boolean;
+}): { isPanelRealized: boolean; realizePanel: () => void } {
+  const [isPanelRealized, setIsPanelRealized] = useState(false);
+  const realizePanel = useCallback(() => setIsPanelRealized(true), []);
+
+  useEffect(() => {
+    if (!rendersAsDrawer) {
+      return;
+    }
+    if (isDrawerOpen) {
+      const timeout = window.setTimeout(
+        () => setIsPanelRealized(true),
+        DRAWER_PANEL_REALIZE_FALLBACK_MS,
+      );
+      return () => window.clearTimeout(timeout);
+    }
+    const timeout = window.setTimeout(
+      () => setIsPanelRealized(false),
+      DRAWER_PANEL_TEARDOWN_GRACE_MS,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [isDrawerOpen, rendersAsDrawer]);
+
+  // A wide viewport renders the panel inline; the drawer flag only has
+  // meaning while the drawer branch renders.
+  return { isPanelRealized: rendersAsDrawer && isPanelRealized, realizePanel };
+}

--- a/apps/app/src/components/sidebar/SidebarWindowedItems.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarWindowedItems.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sidebarMocks = vi.hoisted(() => ({
+  scrollElementRef: { current: null as HTMLDivElement | null },
+}));
+
+vi.mock("@/components/ui/sidebar.js", () => ({
+  useSidebarContentElementRef: () => sidebarMocks.scrollElementRef,
+}));
+
+import { SidebarWindowedItems } from "./SidebarWindowedItems";
+
+beforeEach(() => {
+  const scrollElement = document.createElement("div");
+  Object.defineProperty(scrollElement, "clientHeight", {
+    configurable: true,
+    value: 500,
+  });
+  sidebarMocks.scrollElementRef.current = scrollElement;
+
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+    function (this: HTMLElement) {
+      if (this === scrollElement) {
+        return new DOMRect(0, 0, 300, 500);
+      }
+      if (this.hasAttribute("data-sidebar-windowed-item")) {
+        return new DOMRect(0, 1_000, 300, 30);
+      }
+      return new DOMRect();
+    },
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  sidebarMocks.scrollElementRef.current = null;
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("SidebarWindowedItems", () => {
+  it("windows a short list when every item is outside the viewport margin", () => {
+    render(
+      <SidebarWindowedItems
+        itemKeys={["first", "second", "third"]}
+        estimateRows={() => 1}
+        getNavigationEntries={(index) => [
+          { projectId: "proj_test", threadId: `thr_${index}` },
+        ]}
+        renderItem={(index) => (
+          <span data-testid={`real-item-${index}`}>Real item {index}</span>
+        )}
+      />,
+    );
+
+    expect(screen.queryByTestId("real-item-0")).toBeNull();
+    expect(
+      document.querySelectorAll("[data-sidebar-windowed-item]"),
+    ).toHaveLength(3);
+    expect(
+      document.querySelectorAll("[data-sidebar-windowed-nav]"),
+    ).toHaveLength(3);
+  });
+});

--- a/apps/app/src/components/sidebar/SidebarWindowedItems.tsx
+++ b/apps/app/src/components/sidebar/SidebarWindowedItems.tsx
@@ -15,12 +15,9 @@ import {
   type SidebarWindowedNavigationEntry,
 } from "./sidebarThreadShortcuts";
 
-// Below this count the windowing bookkeeping costs more than the rows it
-// could skip, so short lists render exactly as before.
-const WINDOW_MIN_ITEMS = 8;
 // Items within this distance of the scrollport stay mounted, so scrolling
 // promotes rows before they become visible.
-const WINDOW_VIEWPORT_MARGIN_PX = 480;
+const WINDOW_VIEWPORT_MARGIN_PX = 240;
 // Fallback placeholder row height until a real row height has been measured.
 const DEFAULT_ROW_HEIGHT_PX = 30;
 
@@ -83,8 +80,11 @@ export function SidebarWindowedItems({
   renderItem,
 }: SidebarWindowedItemsProps) {
   const scrollElementRef = useSidebarContentElementRef();
+  // A sidebar can contain many short sibling lists. Rendering each short list
+  // in full makes their aggregate offscreen subtree large, so every non-empty
+  // list participates in the shared-scrollport window.
   const windowingEnabled =
-    itemKeys.length >= WINDOW_MIN_ITEMS && scrollElementRef !== null;
+    itemKeys.length > 0 && scrollElementRef !== null;
 
   const [realizedKeys, setRealizedKeys] = useState<ReadonlySet<string>>(
     EMPTY_KEY_SET,
@@ -224,7 +224,7 @@ export function SidebarWindowedItems({
 
     const observer = new IntersectionObserver(
       (entries) => {
-        // Scroll-driven promotion runs 480px ahead of the viewport, so it
+        // Scroll-driven promotion runs 240px ahead of the viewport, so it
         // can afford to be interruptible: a transition lets React slice the
         // row mounts across frames instead of blocking the scroll.
         startTransition(() =>

--- a/apps/app/src/components/thread/timeline/conversation-message-overflow.test.tsx
+++ b/apps/app/src/components/thread/timeline/conversation-message-overflow.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useRef } from "react";
+import { useOverflowMeasurement } from "./conversation-message-overflow";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function OverflowProbe({ name }: { name: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const measurement = useOverflowMeasurement({
+    elementRef: ref,
+    enabled: true,
+    measurementKey: name,
+  });
+  return (
+    <div ref={ref} data-testid={name} data-measurement={measurement} />
+  );
+}
+
+describe("useOverflowMeasurement", () => {
+  it("shares one observer and batches measurements for all rows", () => {
+    let observerCallback: ResizeObserverCallback | null = null;
+    const observe = vi.fn();
+    const unobserve = vi.fn();
+    const disconnect = vi.fn();
+    const constructorSpy = vi.fn();
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          constructorSpy();
+          observerCallback = callback;
+        }
+        observe = observe;
+        unobserve = unobserve;
+        disconnect = disconnect;
+      },
+    );
+
+    render(
+      <>
+        <OverflowProbe name="first" />
+        <OverflowProbe name="second" />
+      </>,
+    );
+
+    const first = screen.getByTestId("first");
+    const second = screen.getByTestId("second");
+    Object.defineProperties(first, {
+      scrollHeight: { configurable: true, value: 80 },
+      clientHeight: { configurable: true, value: 20 },
+      scrollWidth: { configurable: true, value: 20 },
+      clientWidth: { configurable: true, value: 20 },
+    });
+    Object.defineProperties(second, {
+      scrollHeight: { configurable: true, value: 20 },
+      clientHeight: { configurable: true, value: 20 },
+      scrollWidth: { configurable: true, value: 20 },
+      clientWidth: { configurable: true, value: 20 },
+    });
+
+    act(() => {
+      observerCallback?.(
+        [
+          { target: first } as unknown as ResizeObserverEntry,
+          { target: second } as unknown as ResizeObserverEntry,
+        ],
+        {} as ResizeObserver,
+      );
+    });
+
+    expect(constructorSpy).toHaveBeenCalledOnce();
+    expect(observe).toHaveBeenCalledTimes(2);
+    expect(first.dataset.measurement).toBe("overflowing");
+    expect(second.dataset.measurement).toBe("fits");
+  });
+});

--- a/apps/app/src/components/thread/timeline/conversation-message-overflow.tsx
+++ b/apps/app/src/components/thread/timeline/conversation-message-overflow.tsx
@@ -9,6 +9,79 @@ interface UseOverflowMeasurementArgs {
 
 type OverflowMeasurement = "unmeasured" | "fits" | "overflowing";
 
+type OverflowMeasurementListener = (
+  measurement: Exclude<OverflowMeasurement, "unmeasured">,
+) => void;
+
+const overflowListenersByElement = new Map<
+  HTMLElement,
+  Set<OverflowMeasurementListener>
+>();
+let sharedOverflowResizeObserver: ResizeObserver | null = null;
+
+function readOverflowMeasurement(
+  element: HTMLElement,
+): Exclude<OverflowMeasurement, "unmeasured"> {
+  return element.scrollHeight > element.clientHeight + 1 ||
+    element.scrollWidth > element.clientWidth + 1
+    ? "overflowing"
+    : "fits";
+}
+
+function measureOverflowElements(elements: readonly HTMLElement[]): void {
+  // Complete every layout read before any listener can schedule a React
+  // update. This prevents one row's write from invalidating the next row's
+  // measurement.
+  const results = elements.map((element) => ({
+    element,
+    measurement: readOverflowMeasurement(element),
+  }));
+  for (const { element, measurement } of results) {
+    for (const listener of overflowListenersByElement.get(element) ?? []) {
+      listener(measurement);
+    }
+  }
+}
+
+function getSharedOverflowResizeObserver(): ResizeObserver {
+  sharedOverflowResizeObserver ??= new ResizeObserver((entries) => {
+    const connectedElements: HTMLElement[] = [];
+    for (const entry of entries) {
+      if (entry.target instanceof HTMLElement && entry.target.isConnected) {
+        connectedElements.push(entry.target);
+      }
+    }
+    measureOverflowElements(connectedElements);
+  });
+  return sharedOverflowResizeObserver;
+}
+
+function observeOverflow(
+  element: HTMLElement,
+  listener: OverflowMeasurementListener,
+): () => void {
+  let listeners = overflowListenersByElement.get(element);
+  if (!listeners) {
+    listeners = new Set();
+    overflowListenersByElement.set(element, listeners);
+    getSharedOverflowResizeObserver().observe(element);
+  }
+  listeners.add(listener);
+
+  return () => {
+    const currentListeners = overflowListenersByElement.get(element);
+    currentListeners?.delete(listener);
+    if (currentListeners?.size === 0) {
+      overflowListenersByElement.delete(element);
+      sharedOverflowResizeObserver?.unobserve?.(element);
+      if (overflowListenersByElement.size === 0) {
+        sharedOverflowResizeObserver?.disconnect?.();
+        sharedOverflowResizeObserver = null;
+      }
+    }
+  };
+}
+
 interface ConversationMessageOverflowToggleLabels {
   collapsed: string;
   expanded: string;
@@ -50,29 +123,22 @@ export function useOverflowMeasurement({
       return;
     }
 
-    const measure = () => {
+    const applyMeasurement: OverflowMeasurementListener = (nextMeasurement) => {
       // ResizeObserver still fires after the observed node detaches (e.g. when
       // an expandable row swaps the collapsed preview for the expanded body).
       // A detached node reports scroll/client size 0, which would flip the
       // measurement to "fits" and unexpand the row mid-click. Treat detached
       // nodes as "no new information" — the last connected measurement stands.
       if (!element.isConnected) return;
-      setMeasurement(
-        element.scrollHeight > element.clientHeight + 1 ||
-          element.scrollWidth > element.clientWidth + 1
-          ? "overflowing"
-          : "fits",
-      );
+      setMeasurement(nextMeasurement);
     };
-    measure();
+    applyMeasurement(readOverflowMeasurement(element));
 
     if (typeof ResizeObserver === "undefined") {
       return;
     }
 
-    const resizeObserver = new ResizeObserver(measure);
-    resizeObserver.observe(element);
-    return () => resizeObserver.disconnect();
+    return observeOverflow(element, applyMeasurement);
   }, [elementRef, enabled, measurementKey]);
 
   return measurement;

--- a/apps/app/src/components/thread/timeline/useStickyBottomScroll.test.tsx
+++ b/apps/app/src/components/thread/timeline/useStickyBottomScroll.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useStickyBottomScroll } from "./useStickyBottomScroll";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function StickyScrollProbe({ contentKey }: { contentKey: string }) {
+  const sticky = useStickyBottomScroll<HTMLDivElement>({
+    contentKey,
+    streaming: true,
+  });
+  return (
+    <div
+      ref={sticky.ref}
+      data-testid="scroll"
+      onScroll={sticky.onScroll}
+      onWheel={sticky.onWheel}
+    />
+  );
+}
+
+describe("useStickyBottomScroll", () => {
+  it("uses a cached maximum offset in the scroll handler", () => {
+    vi.stubGlobal("ResizeObserver", undefined);
+    const { getByTestId, rerender } = render(
+      <StickyScrollProbe contentKey="first" />,
+    );
+    const scroll = getByTestId("scroll");
+    let layoutReads = 0;
+    let scrollTop = 0;
+    Object.defineProperties(scroll, {
+      scrollHeight: {
+        configurable: true,
+        get: () => {
+          layoutReads += 1;
+          return 120;
+        },
+      },
+      clientHeight: {
+        configurable: true,
+        get: () => {
+          layoutReads += 1;
+          return 20;
+        },
+      },
+      scrollTop: {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value: number) => {
+          scrollTop = value;
+        },
+      },
+    });
+
+    rerender(<StickyScrollProbe contentKey="second" />);
+    expect(scrollTop).toBe(100);
+    layoutReads = 0;
+
+    scrollTop = 20;
+    fireEvent.wheel(scroll);
+    fireEvent.scroll(scroll);
+
+    expect(layoutReads).toBe(0);
+    rerender(<StickyScrollProbe contentKey="third" />);
+    expect(scrollTop).toBe(20);
+  });
+});

--- a/apps/app/src/components/thread/timeline/useStickyBottomScroll.ts
+++ b/apps/app/src/components/thread/timeline/useStickyBottomScroll.ts
@@ -39,15 +39,11 @@ function getMaxScrollOffset(element: HTMLElement): number {
   return Math.max(0, element.scrollHeight - element.clientHeight);
 }
 
-function isNearBottom(element: HTMLElement): boolean {
-  return (
-    getMaxScrollOffset(element) - element.scrollTop <=
-    STICKY_BOTTOM_THRESHOLD_PX
-  );
-}
-
-function scrollToBottom(element: HTMLElement, smooth: boolean): void {
-  const top = getMaxScrollOffset(element);
+function scrollToBottom(
+  element: HTMLElement,
+  top: number,
+  smooth: boolean,
+): void {
   if (smooth) {
     element.scrollTo({ top, behavior: "smooth" });
   } else {
@@ -66,6 +62,26 @@ export function useStickyBottomScroll<TElement extends HTMLElement>({
   const lastScrollAtRef = useRef(0);
   const isFirstScrollRef = useRef(true);
   const wasStreamingRef = useRef(streaming);
+  const maxScrollOffsetRef = useRef(0);
+
+  const refreshMaxScrollOffset = useCallback((element: TElement): number => {
+    const nextOffset = getMaxScrollOffset(element);
+    maxScrollOffsetRef.current = nextOffset;
+    return nextOffset;
+  }, []);
+
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+    refreshMaxScrollOffset(element);
+    if (typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(() => {
+      refreshMaxScrollOffset(element);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [refreshMaxScrollOffset]);
 
   useEffect(() => {
     const wasStreaming = wasStreamingRef.current;
@@ -89,10 +105,10 @@ export function useStickyBottomScroll<TElement extends HTMLElement>({
     const smooth =
       !isFirstScrollRef.current &&
       now - lastScrollAtRef.current >= SMOOTH_SCROLL_MIN_GAP_MS;
-    scrollToBottom(element, smooth);
+    scrollToBottom(element, refreshMaxScrollOffset(element), smooth);
     lastScrollAtRef.current = now;
     isFirstScrollRef.current = false;
-  }, [contentKey, streaming]);
+  }, [contentKey, refreshMaxScrollOffset, streaming]);
 
   const markUserScrollIntent = useCallback(() => {
     userScrollIntentUntilRef.current =
@@ -108,7 +124,13 @@ export function useStickyBottomScroll<TElement extends HTMLElement>({
   }, []);
 
   const onScroll = useCallback<UIEventHandler<TElement>>((event) => {
-    if (isNearBottom(event.currentTarget)) {
+    // `scrollHeight` and `clientHeight` force layout in WebKit. Cache their
+    // difference on content and box-size changes, then read only scrollTop in
+    // this high-frequency handler.
+    if (
+      maxScrollOffsetRef.current - event.currentTarget.scrollTop <=
+      STICKY_BOTTOM_THRESHOLD_PX
+    ) {
       shouldStickToBottomRef.current = true;
       return;
     }

--- a/apps/app/src/components/ui/sidebar.test.tsx
+++ b/apps/app/src/components/ui/sidebar.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { renderToString } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
@@ -15,7 +15,18 @@ import {
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  vi.useRealTimers();
 });
+
+// Matches SIDEBAR_MOBILE_DRAG_SETTLE_MS: the deferred mobile open and close
+// flip React state only after the slide transition window has elapsed.
+const MOBILE_TOGGLE_SETTLE_MS = 220;
+
+function settleMobileToggle() {
+  act(() => {
+    vi.advanceTimersByTime(MOBILE_TOGGLE_SETTLE_MS);
+  });
+}
 
 function createTouch(clientX: number, clientY: number): Touch {
   return { identifier: 1, clientX, clientY } as Touch;
@@ -157,7 +168,8 @@ function getMobilePanel(): HTMLElement | null {
 }
 
 describe("mobile sidebar persistence", () => {
-  it("keeps closed drawer content mounted but inert and hidden from input", () => {
+  it("keeps closed drawer content mounted, inert, and offscreen", () => {
+    vi.useFakeTimers();
     render(
       <CompactViewportOverrideProvider isCompactViewport>
         <SidebarProvider>
@@ -178,37 +190,176 @@ describe("mobile sidebar persistence", () => {
     expect(closedPanel?.textContent).toContain("Sidebar content");
     expect(closedPanel?.dataset.state).toBe("closed");
     expect(closedPanel?.hasAttribute("inert")).toBe(true);
+    expect(closedPanel?.className).not.toContain("invisible");
 
     const inset = document.querySelector('[data-sidebar="inset"]');
     expect(inset?.hasAttribute("inert")).toBe(false);
 
     fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
 
+    // The open is also deferred: the slide-in starts from inline styles
+    // while React state stays closed, then the commit lands after settle.
+    const openingPanel = getMobilePanel();
+    expect(openingPanel?.dataset.state).toBe("closed");
+    // jsdom normalizes the "-0%" the helper writes to "0%".
+    expect(openingPanel?.style.translate).toBe("0%");
+    settleMobileToggle();
+
     const openPanel = getMobilePanel();
     expect(openPanel?.dataset.state).toBe("open");
     expect(openPanel?.hasAttribute("inert")).toBe(false);
 
-    // The open drawer is modal: every sibling of the panel goes inert so
-    // Tab cannot reach outside controls, while the backdrop stays live for
-    // dismissal.
+    // The open drawer is modal WITHOUT marking siblings inert: an `inert`
+    // flip on the content inset forces a style re-resolution of that whole
+    // subtree (~hundreds of ms on a long timeline in WebKit). The backdrop
+    // blocks pointer input and the keydown trap owns Tab instead.
     const panelParent = openPanel?.parentElement;
     const backdrop = screen.getByTestId("sidebar-mobile-backdrop");
     for (const sibling of panelParent?.children ?? []) {
-      if (sibling === openPanel || sibling === backdrop) {
-        expect(sibling.hasAttribute("inert")).toBe(false);
-      } else {
-        expect(sibling.hasAttribute("inert")).toBe(true);
-      }
+      expect(sibling.hasAttribute("inert")).toBe(false);
     }
-    expect(inset?.hasAttribute("inert")).toBe(true);
+    expect(inset?.hasAttribute("inert")).toBe(false);
 
+    // Backdrop dismissal starts the slide-out immediately (inline settle
+    // styles) and flips React state only after the settle window, so the
+    // exit animation never waits on the close commit's style recalc.
     fireEvent.click(backdrop);
+    const closingPanel = getMobilePanel();
+    expect(closingPanel?.dataset.state).toBe("open");
+    expect(closingPanel?.style.translate).toBe("-100%");
+
+    settleMobileToggle();
 
     const reclosedPanel = getMobilePanel();
     expect(reclosedPanel?.dataset.state).toBe("closed");
     expect(reclosedPanel?.hasAttribute("inert")).toBe(true);
     expect(reclosedPanel?.textContent).toContain("Sidebar content");
     expect(inset?.hasAttribute("inert")).toBe(false);
+  });
+
+  it("keeps the pinned trigger interactive and closes on a second press", () => {
+    vi.useFakeTimers();
+    render(
+      <CompactViewportOverrideProvider isCompactViewport>
+        <SidebarProvider>
+          <Sidebar>Sidebar content</Sidebar>
+          <SidebarInset>Main content</SidebarInset>
+          {/* Mirrors AppLayout's SidebarTriggerOverlay: a sibling of the
+              panel, pinned above it. */}
+          <div data-testid="trigger-overlay">
+            <SidebarTrigger />
+          </div>
+        </SidebarProvider>
+      </CompactViewportOverrideProvider>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Toggle Sidebar" });
+    const overlay = screen.getByTestId("trigger-overlay");
+
+    fireEvent.click(trigger);
+    settleMobileToggle();
+    expect(getMobilePanel()?.dataset.state).toBe("open");
+    // The overlay must stay interactive while the drawer is open so a
+    // second press can close it.
+    expect(overlay.hasAttribute("inert")).toBe(false);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.click(trigger);
+    // The state flip defers past the slide-out; the panel is already moving.
+    expect(getMobilePanel()?.dataset.state).toBe("open");
+    expect(getMobilePanel()?.style.translate).toBe("-100%");
+
+    settleMobileToggle();
+    expect(getMobilePanel()?.dataset.state).toBe("closed");
+    expect(getMobilePanel()?.hasAttribute("inert")).toBe(true);
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+
+    // A third press reopens (deferred like every open).
+    fireEvent.click(trigger);
+    settleMobileToggle();
+    expect(getMobilePanel()?.dataset.state).toBe("open");
+  });
+
+  it("traps Tab between the trigger and the open drawer", () => {
+    vi.useFakeTimers();
+    render(
+      <CompactViewportOverrideProvider isCompactViewport>
+        <SidebarProvider>
+          <Sidebar>
+            <button type="button">Sidebar row</button>
+          </Sidebar>
+          <SidebarInset>
+            <button type="button">Inset action</button>
+          </SidebarInset>
+          <div data-testid="trigger-overlay">
+            <SidebarTrigger />
+          </div>
+        </SidebarProvider>
+      </CompactViewportOverrideProvider>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Toggle Sidebar" });
+    const row = screen.getByRole("button", { name: "Sidebar row" });
+    const insetAction = screen.getByRole("button", { name: "Inset action" });
+
+    fireEvent.click(trigger);
+    settleMobileToggle();
+    expect(getMobilePanel()?.dataset.state).toBe("open");
+
+    act(() => trigger.focus());
+    fireEvent.keyDown(trigger, { key: "Tab" });
+    expect(document.activeElement).toBe(row);
+
+    fireEvent.keyDown(row, { key: "Tab" });
+    expect(document.activeElement).toBe(trigger);
+
+    fireEvent.keyDown(trigger, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(row);
+
+    // Focus that escaped into the (non-inert) inset is recaptured by the
+    // next Tab instead of walking the app behind the modal drawer.
+    act(() => insetAction.focus());
+    fireEvent.keyDown(insetAction, { key: "Tab" });
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("moves focus only when a focus-visible trigger opens the drawer", () => {
+    vi.useFakeTimers();
+    render(
+      <CompactViewportOverrideProvider isCompactViewport>
+        <SidebarProvider>
+          <Sidebar>Sidebar content</Sidebar>
+          <SidebarInset>
+            <SidebarTrigger />
+            Main content
+          </SidebarInset>
+        </SidebarProvider>
+      </CompactViewportOverrideProvider>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Toggle Sidebar" });
+    const panel = getMobilePanel();
+    if (!panel) throw new Error("Expected mobile sidebar panel");
+    const focusSpy = vi.spyOn(panel, "focus");
+
+    fireEvent.click(trigger);
+    settleMobileToggle();
+    expect(focusSpy).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("sidebar-mobile-backdrop"));
+    settleMobileToggle();
+    trigger.focus();
+    const matches = trigger.matches.bind(trigger);
+    vi.spyOn(trigger, "matches").mockImplementation((selector) =>
+      selector === '[data-sidebar="trigger"]:focus-visible'
+        ? true
+        : matches(selector),
+    );
+    fireEvent.click(trigger);
+    settleMobileToggle();
+
+    expect(focusSpy).toHaveBeenCalledOnce();
+    expect(document.activeElement).toBe(panel);
   });
 });
 

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -26,7 +26,11 @@ const SIDEBAR_MOBILE_SWIPE_OPEN_FLING_MIN_RATIO = 0.12;
 const SIDEBAR_MOBILE_SWIPE_OPEN_FLING_VELOCITY_PX_PER_SEC = 450;
 const SIDEBAR_MOBILE_DRAG_SETTLE_MS = 220;
 const SIDEBAR_MOBILE_DRAG_SETTLE_EASING = "cubic-bezier(0.32, 0.72, 0, 1)";
-const SIDEBAR_MOBILE_PANEL_SETTLE_TRANSITION = `transform ${SIDEBAR_MOBILE_DRAG_SETTLE_MS}ms ${SIDEBAR_MOBILE_DRAG_SETTLE_EASING}`;
+// The panel moves on the `translate` property, matching Tailwind v4's
+// `-translate-x-full` utilities. Inline motion styles MUST use the same
+// property: an inline `transform` does not interpolate against the class
+// `translate`, so a slide written as `transform` silently snaps.
+const SIDEBAR_MOBILE_PANEL_SETTLE_TRANSITION = `translate ${SIDEBAR_MOBILE_DRAG_SETTLE_MS}ms ${SIDEBAR_MOBILE_DRAG_SETTLE_EASING}`;
 const SIDEBAR_MOBILE_BACKDROP_SETTLE_TRANSITION = `opacity ${SIDEBAR_MOBILE_DRAG_SETTLE_MS}ms ${SIDEBAR_MOBILE_DRAG_SETTLE_EASING}`;
 const SIDEBAR_MOBILE_WHEEL_SWIPE_OPEN_DISTANCE_PX = 90;
 const SIDEBAR_MOBILE_WHEEL_SWIPE_RESET_MS = 250;
@@ -36,13 +40,13 @@ const SIDEBAR_MOBILE_DRAG_CLOSE_RATIO = 0.25;
 const SIDEBAR_MOBILE_DRAG_CLOSE_FLING_VELOCITY_PX_PER_SEC = 450;
 // The transitions below must match SIDEBAR_MOBILE_DRAG_SETTLE_MS /
 // SIDEBAR_MOBILE_DRAG_SETTLE_EASING; Tailwind arbitrary values cannot
-// interpolate the constants. The `visibility` leg keeps the closed panel out
-// of paint and hit-testing: it flips to hidden only after the slide-out
-// transform finishes, and back to visible immediately on open.
+// interpolate the constants. Keep the translated panel style-ready while it
+// is closed. WebKit otherwise rebuilds its style and accessibility subtrees
+// when `visibility` flips during every open.
 const SIDEBAR_MOBILE_PANEL_TRANSITION_CLASS =
-  "[transition:transform_220ms_cubic-bezier(0.32,0.72,0,1),visibility_0s_linear_0s] data-[state=closed]:[transition:transform_220ms_cubic-bezier(0.32,0.72,0,1),visibility_0s_linear_220ms]";
+  "[transition:translate_220ms_cubic-bezier(0.32,0.72,0,1)]";
 const SIDEBAR_MOBILE_BACKDROP_TRANSITION_CLASS =
-  "[transition:opacity_220ms_cubic-bezier(0.32,0.72,0,1),visibility_0s_linear_0s] data-[state=closed]:[transition:opacity_220ms_cubic-bezier(0.32,0.72,0,1),visibility_0s_linear_220ms]";
+  "[transition:opacity_220ms_cubic-bezier(0.32,0.72,0,1)]";
 const SIDEBAR_GROUP_LABEL_BASE_CLASS =
   "duration-200 flex shrink-0 items-center rounded-md px-1 text-xs font-medium text-sidebar-foreground/75 outline-none ring-sidebar-ring transition-[margin,opa] ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0";
 const SIDEBAR_GROUP_LABEL_COLLAPSED_CLASS =
@@ -102,14 +106,12 @@ function getSidebarMobileMotionNodes(): {
   };
 }
 
-function getSidebarMobilePanelTransform(
+function getSidebarMobilePanelTranslate(
   progress: number,
   side: "left" | "right",
 ): string {
   const hiddenPercent = (1 - progress) * 100;
-  return side === "left"
-    ? `translate3d(-${hiddenPercent}%, 0, 0)`
-    : `translate3d(${hiddenPercent}%, 0, 0)`;
+  return side === "left" ? `-${hiddenPercent}%` : `${hiddenPercent}%`;
 }
 
 function applySidebarMobileDragStyles({
@@ -124,7 +126,7 @@ function applySidebarMobileDragStyles({
 
   if (panel !== null) {
     panel.setAttribute("data-vaul-animate", "false");
-    panel.style.transform = getSidebarMobilePanelTransform(progress, side);
+    panel.style.translate = getSidebarMobilePanelTranslate(progress, side);
     panel.style.transition = settling
       ? SIDEBAR_MOBILE_PANEL_SETTLE_TRANSITION
       : "none";
@@ -150,7 +152,7 @@ function clearSidebarMobileDragStyles() {
 
   if (panel !== null) {
     panel.removeAttribute("data-vaul-animate");
-    panel.style.transform = "";
+    panel.style.translate = "";
     panel.style.transition = "";
   }
 
@@ -350,6 +352,8 @@ type SidebarContext = {
   setOpen: (open: boolean) => void;
   openMobile: boolean;
   setOpenMobile: (open: boolean) => void;
+  openMobileSidebar: () => void;
+  closeMobileSidebar: () => void;
   suppressMobileOpenAnimation: boolean;
   setSuppressMobileOpenAnimation: (suppress: boolean) => void;
   suppressMobileCloseAnimation: boolean;
@@ -402,11 +406,13 @@ function useOptionalIsSidebarShowing() {
  * Stable callback that closes the mobile sidebar drawer. Every navigation
  * triggered from inside the sidebar must call this so the destination view is
  * revealed on compact viewports; on wider viewports the drawer state is
- * already closed and the call is a no-op.
+ * already closed and the call is a no-op. The close starts the slide-out
+ * transition immediately and defers the React state flip until the panel is
+ * offscreen, so the exit animation survives the commit's style recalculation.
  */
 function useCloseMobileSidebar() {
-  const { setOpenMobile } = useSidebar();
-  return React.useCallback(() => setOpenMobile(false), [setOpenMobile]);
+  const { closeMobileSidebar } = useSidebar();
+  return closeMobileSidebar;
 }
 
 const SidebarProvider = React.forwardRef<
@@ -435,6 +441,76 @@ const SidebarProvider = React.forwardRef<
       React.useState(false);
     const [suppressMobileCloseAnimation, setSuppressMobileCloseAnimation] =
       React.useState(false);
+    const mobileSettleTimeoutRef = React.useRef<number | null>(null);
+
+    const clearMobileSettleTimeout = React.useCallback(() => {
+      if (mobileSettleTimeoutRef.current !== null) {
+        window.clearTimeout(mobileSettleTimeoutRef.current);
+        mobileSettleTimeoutRef.current = null;
+      }
+    }, []);
+
+    const openMobileRef = React.useRef(openMobile);
+    React.useEffect(() => {
+      openMobileRef.current = openMobile;
+    }, [openMobile]);
+
+    // Stable identity: sidebar rows close the drawer on navigation, and an
+    // unstable callback would re-render every memoized row on each toggle.
+    // Reads the open state through a ref instead of closing over it.
+    const closeMobileSidebar = React.useCallback(() => {
+      if (!openMobileRef.current || mobileSettleTimeoutRef.current !== null) {
+        return;
+      }
+
+      // Start the compositor transition while React state stays open. The
+      // close commit (panel `inert`, data-state flips) then pays its style
+      // recalculation after the panel has moved offscreen instead of
+      // consuming the whole transition window.
+      applySidebarMobileDragStyles({ progress: 0, settling: true });
+      mobileSettleTimeoutRef.current = window.setTimeout(() => {
+        mobileSettleTimeoutRef.current = null;
+        flushSync(() => {
+          setSuppressMobileOpenAnimation(false);
+          setSuppressMobileCloseAnimation(true);
+          setOpenMobile(false);
+        });
+        clearSidebarMobileDragAttributes();
+      }, SIDEBAR_MOBILE_DRAG_SETTLE_MS);
+    }, []);
+
+    // The symmetric deferred open. The persistent panel already holds its
+    // full content, so the compositor can slide it in before React knows the
+    // drawer is open. The open commit (panel `inert` removal, data-state
+    // flips) then pays its style recalculation — ~280 ms on iOS Safari for a
+    // large sidebar — after the slide instead of blocking its first frame.
+    // The panel stays `inert` and the backdrop passes taps through until the
+    // commit lands one settle window later.
+    const openMobileSidebar = React.useCallback(() => {
+      if (openMobileRef.current || mobileSettleTimeoutRef.current !== null) {
+        return;
+      }
+
+      applySidebarMobileDragStyles({ progress: 1, settling: true });
+      mobileSettleTimeoutRef.current = window.setTimeout(() => {
+        mobileSettleTimeoutRef.current = null;
+        flushSync(() => {
+          // The panel already sits at the open transform; suppressing the
+          // open animation keeps the commit from replaying the slide.
+          setSuppressMobileOpenAnimation(true);
+          setSuppressMobileCloseAnimation(false);
+          setOpenMobile(true);
+        });
+        clearSidebarMobileDragAttributes();
+      }, SIDEBAR_MOBILE_DRAG_SETTLE_MS);
+    }, []);
+
+    React.useEffect(
+      () => () => {
+        clearMobileSettleTimeout();
+      },
+      [clearMobileSettleTimeout],
+    );
 
     React.useEffect(() => {
       if (openMobile) {
@@ -460,10 +536,22 @@ const SidebarProvider = React.forwardRef<
 
     // Helper to toggle the sidebar.
     const toggleSidebar = React.useCallback(() => {
-      return isCompactViewport
-        ? setOpenMobile((open) => !open)
-        : setOpen((open) => !open);
-    }, [isCompactViewport, setOpen, setOpenMobile]);
+      if (!isCompactViewport) {
+        setOpen((open) => !open);
+        return;
+      }
+      if (openMobile) {
+        closeMobileSidebar();
+        return;
+      }
+      openMobileSidebar();
+    }, [
+      closeMobileSidebar,
+      isCompactViewport,
+      openMobile,
+      openMobileSidebar,
+      setOpen,
+    ]);
 
     // We add a state so that we can do data-state="expanded" or "collapsed".
     // This makes it easier to style the sidebar with Tailwind classes.
@@ -477,6 +565,8 @@ const SidebarProvider = React.forwardRef<
         isCompactViewport,
         openMobile,
         setOpenMobile,
+        openMobileSidebar,
+        closeMobileSidebar,
         suppressMobileOpenAnimation,
         setSuppressMobileOpenAnimation,
         suppressMobileCloseAnimation,
@@ -490,6 +580,8 @@ const SidebarProvider = React.forwardRef<
         isCompactViewport,
         openMobile,
         setOpenMobile,
+        openMobileSidebar,
+        closeMobileSidebar,
         suppressMobileOpenAnimation,
         setSuppressMobileOpenAnimation,
         suppressMobileCloseAnimation,
@@ -559,6 +651,7 @@ const Sidebar = React.forwardRef<
       state,
       openMobile,
       setOpenMobile,
+      closeMobileSidebar,
       suppressMobileOpenAnimation,
       setSuppressMobileOpenAnimation,
       suppressMobileCloseAnimation,
@@ -586,12 +679,8 @@ const Sidebar = React.forwardRef<
     >(() => {
       if (shouldSuppressMobileCloseAnimation) {
         return {
-          transform:
-            side === "left"
-              ? "translate3d(-100%, 0, 0)"
-              : "translate3d(100%, 0, 0)",
+          translate: side === "left" ? "-100%" : "100%",
           transition: "none",
-          visibility: "hidden",
         };
       }
 
@@ -605,7 +694,6 @@ const Sidebar = React.forwardRef<
           opacity: 0,
           pointerEvents: "none",
           transition: "none",
-          visibility: "hidden",
         };
       }
 
@@ -631,9 +719,9 @@ const Sidebar = React.forwardRef<
     if (isCompactViewport) {
       // The mobile drawer stays mounted across open/close (#1261). Closing
       // translates the panel off-screen instead of unmounting it, so a
-      // reopen replays no mount work. While closed the panel is `inert` and
-      // `visibility: hidden` (after the slide-out finishes), so it takes no
-      // paint or hit-testing work and cannot trap focus or taps.
+      // reopen replays no mount work. While closed the translated panel is
+      // `inert`, so it cannot trap focus or taps. It stays style-ready because
+      // a visibility flip makes WebKit rebuild the subtree during every open.
       return (
         <SidebarMobilePanel
           ref={ref}
@@ -641,6 +729,7 @@ const Sidebar = React.forwardRef<
           variant={variant}
           open={openMobile}
           onOpenChange={handleOpenMobileChange}
+          onDismiss={closeMobileSidebar}
           suppressOpenAnimation={suppressMobileOpenAnimation}
           panelMotionStyle={mobilePanelMotionStyle}
           backdropStyle={mobileBackdropStyle}
@@ -745,17 +834,55 @@ interface SidebarMobilePanelProps extends React.ComponentProps<"div"> {
   variant: "sidebar" | "floating" | "inset";
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  // Deferred close: starts the slide-out transition immediately and flips the
+  // React state after the settle window. Backdrop taps and Escape use this;
+  // the drag paths call `onOpenChange(false)` directly because their panel is
+  // already at the closed transform when they settle.
+  onDismiss: () => void;
   suppressOpenAnimation: boolean;
   panelMotionStyle?: React.CSSProperties;
   backdropStyle?: React.CSSProperties;
 }
 
+const SIDEBAR_MOBILE_TAB_STOP_SELECTOR = [
+  "a[href]",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
+/**
+ * The open drawer's Tab cycle: the pinned sidebar trigger(s) outside the
+ * panel, then every focusable inside the panel. The trigger stays in the
+ * cycle because it remains interactive while the drawer is open (a second
+ * press closes it).
+ */
+function getSidebarMobileTabStops(panel: HTMLElement): HTMLElement[] {
+  const doc = panel.ownerDocument;
+  const triggerStops = Array.from(
+    doc.querySelectorAll('[data-sidebar="trigger"]'),
+  ).filter((element) => !panel.contains(element));
+  const panelStops = Array.from(
+    panel.querySelectorAll(SIDEBAR_MOBILE_TAB_STOP_SELECTOR),
+  );
+  return [...triggerStops, ...panelStops].filter(
+    (element): element is HTMLElement =>
+      element instanceof HTMLElement &&
+      !element.matches(":disabled") &&
+      !element.hasAttribute("hidden") &&
+      element.getAttribute("aria-hidden") !== "true" &&
+      element.closest("[inert]") === null,
+  );
+}
+
 /**
  * The persistent mobile sidebar drawer. Unlike the previous vaul drawer it
- * never unmounts its children: closing translates the panel off-screen, then
- * a delayed `visibility: hidden` plus `inert` take it out of paint,
- * hit-testing, focus order, and the accessibility tree. Reopening therefore
- * replays no mount cost (#1261).
+ * never unmounts its children: closing translates the panel off-screen, while
+ * `inert` takes it out of hit-testing, focus order, and the accessibility
+ * tree. Reopening therefore replays no mount cost or visibility-driven style
+ * rebuild (#1261).
  *
  * The DOM contract the swipe-open code in SidebarInset relies on is kept:
  * `[data-sidebar="panel"][data-vaul-drawer-direction]` selects the panel,
@@ -772,6 +899,7 @@ const SidebarMobilePanel = React.forwardRef<
       variant,
       open,
       onOpenChange,
+      onDismiss,
       suppressOpenAnimation,
       panelMotionStyle,
       backdropStyle,
@@ -831,50 +959,86 @@ const SidebarMobilePanel = React.forwardRef<
         document.activeElement instanceof HTMLElement
           ? document.activeElement
           : null;
-      panelRef.current?.focus({ preventScroll: true });
+      // A touch-opened drawer does not need DOM focus. On iOS, focusing this
+      // newly interactive subtree can synchronously rebuild style and the
+      // accessibility tree for hundreds of milliseconds. Keyboard and
+      // assistive-technology activation leave the trigger focus-visible, so
+      // keep the modal focus move for those paths.
+      const shouldMoveFocus =
+        previouslyFocused?.matches(
+          '[data-sidebar="trigger"]:focus-visible',
+        ) ?? false;
+      if (shouldMoveFocus) {
+        panelRef.current?.focus({ preventScroll: true });
+      }
 
+      // The drawer is modal, but its siblings must NOT be marked `inert`:
+      // toggling `inert` on the content inset forces WebKit (and Blink) to
+      // re-resolve computed style for that entire subtree, which on a long
+      // thread timeline costs hundreds of milliseconds per open/close. The
+      // backdrop already blocks pointer input, `aria-modal` scopes assistive
+      // technology, and this Tab trap owns keyboard focus, so no attribute
+      // flip has to touch the large subtree. The pinned sidebar trigger
+      // stays interactive on purpose: a second press closes the drawer.
       const handleKeyDown = (event: KeyboardEvent) => {
-        if (event.key === "Escape" && !event.defaultPrevented) {
-          onOpenChange(false);
+        if (event.defaultPrevented) {
+          return;
+        }
+        if (event.key === "Escape") {
+          onDismiss();
+          return;
+        }
+        if (event.key !== "Tab") {
+          return;
+        }
+        const panel = panelRef.current;
+        const shell = panel?.parentElement ?? null;
+        if (panel === null || shell === null) {
+          return;
+        }
+        const doc = panel.ownerDocument;
+        const active = doc.activeElement;
+        // Portalled surfaces (row context menus under document.body) manage
+        // their own focus; the trap only arbitrates Tab inside the app shell.
+        if (active !== null && active !== doc.body && !shell.contains(active)) {
+          return;
+        }
+        const stops = getSidebarMobileTabStops(panel);
+        if (stops.length === 0) {
+          return;
+        }
+        event.preventDefault();
+        const direction = event.shiftKey ? -1 : 1;
+        const activeIndex =
+          active instanceof HTMLElement ? stops.indexOf(active) : -1;
+        // Focus can silently fail on a hidden stop; walk until one takes.
+        for (let step = 1; step <= stops.length; step += 1) {
+          const nextIndex =
+            activeIndex === -1
+              ? (event.shiftKey ? stops.length - step : step - 1)
+              : (((activeIndex + direction * step) % stops.length) +
+                  stops.length) %
+                stops.length;
+          const candidate = stops[nextIndex];
+          candidate?.focus({ preventScroll: true });
+          if (doc.activeElement === candidate) {
+            return;
+          }
         }
       };
       window.addEventListener("keydown", handleKeyDown);
 
-      // The drawer is modal: while it is open, every sibling of the panel
-      // (the inset, the pinned trigger overlay, and any other app chrome at
-      // that level) leaves focus order and hit-testing, so Tab cannot escape
-      // the drawer. Portalled popovers (row context menus) render under
-      // document.body, so they stay interactive. Attribute writes rather
-      // than the `inert` property, so the state is observable in tests.
-      const container = panelRef.current?.parentElement ?? null;
-      const inertedSiblings: HTMLElement[] = [];
-      if (container) {
-        for (const sibling of container.children) {
-          if (
-            sibling === panelRef.current ||
-            sibling === backdropRef.current ||
-            !(sibling instanceof HTMLElement) ||
-            sibling.hasAttribute("inert")
-          ) {
-            continue;
-          }
-          sibling.setAttribute("inert", "");
-          inertedSiblings.push(sibling);
-        }
-      }
-
       return () => {
         window.removeEventListener("keydown", handleKeyDown);
-        for (const sibling of inertedSiblings) {
-          sibling.removeAttribute("inert");
-        }
         const active = document.activeElement;
         if (active instanceof HTMLElement && panelRef.current?.contains(active)) {
           active.blur();
-          previouslyFocused?.focus({ preventScroll: true });
+          if (shouldMoveFocus) {
+            previouslyFocused?.focus({ preventScroll: true });
+          }
         }
       };
-    }, [open, onOpenChange]);
+    }, [open, onDismiss]);
 
     React.useEffect(
       () => () => {
@@ -1196,12 +1360,12 @@ const SidebarMobilePanel = React.forwardRef<
           data-testid="sidebar-mobile-backdrop"
           data-state={open ? "open" : "closed"}
           className={cn(
-            "fixed inset-0 z-40 bg-black/80",
+            "fixed inset-0 z-40 bg-black/80 will-change-[opacity]",
             SIDEBAR_MOBILE_BACKDROP_TRANSITION_CLASS,
-            "data-[state=closed]:invisible data-[state=closed]:pointer-events-none data-[state=closed]:opacity-0",
+            "data-[state=closed]:pointer-events-none data-[state=closed]:opacity-0",
           )}
           style={{ ...suppressedOpenTransitionStyle, ...backdropStyle }}
-          onClick={() => onOpenChange(false)}
+          onClick={onDismiss}
         />
         <div
           ref={setPanelRef}
@@ -1224,9 +1388,8 @@ const SidebarMobilePanel = React.forwardRef<
             // initial containing block, so it reads the shell unit directly.
             // touch-pan-y hands horizontal touch moves to the drag-to-close
             // handler while leaving vertical list scrolling native.
-            "group fixed inset-y-0 z-40 flex h-(--bb-shell-height) w-(--sidebar-width-mobile) touch-pan-y flex-col bg-sidebar text-sidebar-foreground outline-none",
+            "group fixed inset-y-0 z-40 flex h-(--bb-shell-height) w-(--sidebar-width-mobile) touch-pan-y flex-col bg-sidebar text-sidebar-foreground outline-none will-change-[translate]",
             SIDEBAR_MOBILE_PANEL_TRANSITION_CLASS,
-            "data-[state=closed]:invisible",
             side === "left"
               ? "left-0 data-[state=closed]:-translate-x-full"
               : "right-0 data-[state=closed]:translate-x-full",
@@ -1295,6 +1458,7 @@ const SidebarInset = React.forwardRef<
     isCompactViewport,
     openMobile,
     setOpenMobile,
+    openMobileSidebar,
     setSuppressMobileOpenAnimation,
     setSuppressMobileCloseAnimation,
   } = useSidebar();
@@ -1743,9 +1907,9 @@ const SidebarInset = React.forwardRef<
       }
 
       clearWheelSwipe();
-      setOpenMobile(true);
+      openMobileSidebar();
     },
-    [clearWheelSwipe, isCompactViewport, openMobile, setOpenMobile],
+    [clearWheelSwipe, isCompactViewport, openMobile, openMobileSidebar],
   );
 
   React.useEffect(() => {

--- a/apps/app/src/views/RootComposeSecondaryContent.test.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import type { ComponentProps, ReactNode } from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
 import {
@@ -349,18 +349,33 @@ describe("RootComposeSecondaryContent desktop layout", () => {
   });
 
   it("leaves the panel group alone while the root panel renders as a drawer", () => {
-    const view = renderRootCompose({
-      isCompactViewport: true,
-      isSecondaryPanelOpen: false,
-    });
+    vi.useFakeTimers();
+    try {
+      const view = renderRootCompose({
+        isCompactViewport: true,
+        isSecondaryPanelOpen: false,
+      });
 
-    expect(panelGroupState.setLayout).not.toHaveBeenCalled();
+      expect(panelGroupState.setLayout).not.toHaveBeenCalled();
 
-    view.rerenderWith({ isSecondaryPanelOpen: true });
+      view.rerenderWith({ isSecondaryPanelOpen: true });
 
-    expect(panelGroupState.setLayout).not.toHaveBeenCalled();
-    expect(
-      screen.getByTestId("drawer-secondary-panel").getAttribute("data-open"),
-    ).toBe("true");
+      expect(panelGroupState.setLayout).not.toHaveBeenCalled();
+      // The panel mounts only after the drawer settles; a skeleton fills
+      // the sheet during the entrance so the mount cannot block it. The
+      // fallback timer stands in for the animation-end signal here.
+      expect(screen.queryByTestId("drawer-secondary-panel")).toBeNull();
+      expect(
+        screen.queryByTestId("drawer-panel-loading-skeleton"),
+      ).not.toBeNull();
+      act(() => {
+        vi.advanceTimersByTime(700);
+      });
+      expect(
+        screen.getByTestId("drawer-secondary-panel").getAttribute("data-open"),
+      ).toBe("true");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/app/src/views/RootComposeSecondaryContent.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.tsx
@@ -17,7 +17,9 @@ import {
 import { ResponsiveDrawerShell } from "@bb/shared-ui/responsive-overlay";
 import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { ThreadSecondaryPanel } from "@/components/secondary-panel/ThreadSecondaryPanel";
+import { useDrawerPanelRealization } from "@/components/secondary-panel/useDrawerPanelRealization";
 import { secondaryPanelWidthPercentAtom } from "@/components/secondary-panel/threadSecondaryPanelAtoms";
+import { Skeleton } from "@bb/shared-ui/skeleton";
 import { PANEL_COLLAPSE_TRANSITION_CLASS } from "@/components/secondary-panel/panelTransitionTokens";
 import { PAGE_SHELL_CONTENT_STYLE } from "@/components/ui/page-shell-content-style.js";
 import { dispatchBrowserViewBoundsSync } from "@/lib/browser-view-bounds-sync";
@@ -88,6 +90,19 @@ interface RootComposeSecondaryContentProps {
 
 function noopToggleConversationCollapse(): void {}
 
+function DrawerPanelLoadingSkeleton() {
+  return (
+    <div
+      data-testid="drawer-panel-loading-skeleton"
+      className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden p-4"
+    >
+      <Skeleton className="h-8 w-40 rounded-md" />
+      <Skeleton className="h-24 w-full rounded-md" />
+      <Skeleton className="h-24 w-full rounded-md" />
+    </div>
+  );
+}
+
 export function RootComposeSecondaryContent({
   children,
   contentClassName,
@@ -114,6 +129,10 @@ export function RootComposeSecondaryContent({
   }, [persistedSecondaryWidthPercent]);
   const [isCompactDrawerContentSettled, setIsCompactDrawerContentSettled] =
     useState(false);
+  const { isPanelRealized, realizePanel } = useDrawerPanelRealization({
+    isDrawerOpen: isSecondaryPanelOpen,
+    rendersAsDrawer: renderAsDrawer,
+  });
   const [desktopInfo] = useState(getBbDesktopInfo);
   const usesDesktopChrome = shouldUseMacosDesktopChrome(desktopInfo);
   // A bounded pane below a horizontal split is not part of the native window
@@ -198,11 +217,12 @@ export function RootComposeSecondaryContent({
             stateAfterSync.renderAsDrawer
           ) {
             setIsCompactDrawerContentSettled(true);
+            realizePanel();
           }
         },
       );
     },
-    [cancelCompactDrawerContentSettleFrame],
+    [cancelCompactDrawerContentSettleFrame, realizePanel],
   );
 
   const canShowNativeBrowserView = renderAsDrawer
@@ -382,7 +402,14 @@ export function RootComposeSecondaryContent({
           repositionInputs={false}
         >
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-            {drawerSecondaryPanelContent}
+            {/* The panel mounts after the sheet settles: mounting it inside
+                the opening tap costs hundreds of milliseconds of style
+                resolution on iOS and freezes the slide-in. */}
+            {isPanelRealized ? (
+              drawerSecondaryPanelContent
+            ) : (
+              <DrawerPanelLoadingSkeleton />
+            )}
           </div>
         </ResponsiveDrawerShell>
       ) : null}

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -442,6 +442,13 @@ function expectBrowserDeckVisibility(canShowNativeBrowserView: boolean) {
   ).toBe(String(canShowNativeBrowserView));
 }
 
+// Before the compact drawer settles, the whole secondary panel (deck
+// included) stays unmounted so its mount cost cannot block the entrance
+// animation; a skeleton fills the sheet instead.
+function expectDrawerPanelNotRealized() {
+  expect(screen.queryByTestId("browser-deck")).toBeNull();
+}
+
 function scheduleCompactDrawerSettleFrame() {
   const callback = drawerShellState.onContentAnimationEnd;
   if (callback === undefined) {
@@ -561,14 +568,14 @@ describe("ThreadDetailSecondaryContent compact drawer settling", () => {
       threadId: "thread-1",
     });
 
-    expectBrowserDeckVisibility(false);
+    expectDrawerPanelNotRealized();
 
     order.push("animationEnd:true");
     scheduleCompactDrawerSettleFrame();
 
     expect(frames.requestAnimationFrame).toHaveBeenCalledTimes(1);
     expect(dispatchBrowserViewBoundsSync).not.toHaveBeenCalled();
-    expectBrowserDeckVisibility(false);
+    expectDrawerPanelNotRealized();
 
     act(() => {
       frames.flushAll();
@@ -608,7 +615,7 @@ describe("ThreadDetailSecondaryContent compact drawer settling", () => {
 
     expect(frames.requestAnimationFrame).not.toHaveBeenCalled();
     expect(dispatchBrowserViewBoundsSync).not.toHaveBeenCalled();
-    expectBrowserDeckVisibility(false);
+    expectDrawerPanelNotRealized();
   });
 
   it("does not schedule a stale open callback after the compact drawer closes", () => {
@@ -626,7 +633,7 @@ describe("ThreadDetailSecondaryContent compact drawer settling", () => {
 
     expect(frames.requestAnimationFrame).not.toHaveBeenCalled();
     expect(dispatchBrowserViewBoundsSync).not.toHaveBeenCalled();
-    expectBrowserDeckVisibility(false);
+    expectDrawerPanelNotRealized();
   });
 
   it("cancels a pending compact drawer settle rAF when the drawer closes", () => {
@@ -651,7 +658,7 @@ describe("ThreadDetailSecondaryContent compact drawer settling", () => {
     });
 
     expect(dispatchBrowserViewBoundsSync).not.toHaveBeenCalled();
-    expectBrowserDeckVisibility(false);
+    expectDrawerPanelNotRealized();
   });
 
   it("cancels a pending compact drawer settle rAF when the thread changes", () => {
@@ -676,7 +683,7 @@ describe("ThreadDetailSecondaryContent compact drawer settling", () => {
     });
 
     expect(dispatchBrowserViewBoundsSync).not.toHaveBeenCalled();
-    expectBrowserDeckVisibility(false);
+    expectDrawerPanelNotRealized();
   });
 
   it("cancels a pending compact drawer settle rAF on compact-to-wide transition", () => {

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -20,6 +20,7 @@ import { DETAIL_GRID_CLASS } from "@/components/ui/detail-card.js";
 import { useAtomValue } from "jotai";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { ThreadSecondaryPanel } from "@/components/secondary-panel/ThreadSecondaryPanel";
+import { useDrawerPanelRealization } from "@/components/secondary-panel/useDrawerPanelRealization";
 import {
   secondaryPanelWidthPercentAtom,
 } from "@/components/secondary-panel/threadSecondaryPanelAtoms";
@@ -126,6 +127,10 @@ function ThreadDetailSecondaryContentBody({
     canCollapseConversation && isConversationCollapsed;
   const [isCompactDrawerContentSettled, setIsCompactDrawerContentSettled] =
     useState(false);
+  const { isPanelRealized, realizePanel } = useDrawerPanelRealization({
+    isDrawerOpen: isSecondaryPanelOpen,
+    rendersAsDrawer: renderAsDrawer,
+  });
   const compactDrawerContentSettleFrameRef = useRef<number | null>(null);
   const compactDrawerContentSettleGenerationRef = useRef(0);
   const compactDrawerContentSettleStateRef = useRef({
@@ -206,11 +211,12 @@ function ThreadDetailSecondaryContentBody({
             stateAfterSync.renderAsDrawer
           ) {
             setIsCompactDrawerContentSettled(true);
+            realizePanel();
           }
         },
       );
     },
-    [cancelCompactDrawerContentSettleFrame],
+    [cancelCompactDrawerContentSettleFrame, realizePanel],
   );
   const canShowNativeBrowserView = renderAsDrawer
     ? isSecondaryPanelOpen && isCompactDrawerContentSettled
@@ -453,7 +459,14 @@ function ThreadDetailSecondaryContentBody({
           repositionInputs={false}
         >
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-            {drawerSecondaryPanelContent}
+            {/* The panel mounts after the sheet settles: mounting it inside
+                the opening tap costs hundreds of milliseconds of style
+                resolution on iOS and freezes the slide-in. */}
+            {isPanelRealized ? (
+              drawerSecondaryPanelContent
+            ) : (
+              <ThreadMetadataLoadingSkeleton />
+            )}
           </div>
         </ResponsiveDrawerShell>
       ) : null}


### PR DESCRIPTION
## Summary

- move mobile sidebar open and close state updates after their compositor transitions
- keep the sidebar trigger active and contain keyboard focus without changing the large background subtree
- use one translate property for Tailwind and drag motion to prevent animation snaps
- window every sidebar list and remove forced layout reads from prompt and timeline hot paths
- defer heavy right-panel content until the bottom-sheet entrance finishes

## Root cause

WebKit recalculated styles for large subtrees when inert, visibility, and drawer state changed inside tap handlers. These recalculations took about 280 ms and blocked the first animation frame. The right-panel sheet also mounted its full content inside the opening tap.

The updated paths start each compositor animation first. React applies the expensive state change after the panel reaches its resting position.

## Measured impact

- sidebar touch taps fell from about 280 ms to 0-2 ms in WebKit
- right-panel open taps fell from 325-370 ms to about 2 ms in WebKit
- Chrome and WebKit both keep the trigger active, close on a second press, and reopen correctly

## Validation

- `pnpm exec turbo run typecheck test build --filter=@bb/app`
- 336 test files passed
- 2,537 tests passed
- production build passed

