### PR TITLE
Fix terminal reconnect cleanup and slash command ranking

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -3125,6 +3125,14 @@ describe("PromptBoxInternal command typeahead navigation", () => {
       commandSuggestions: [
         {
           kind: "command",
+          name: "plugin:plan",
+          source: "skill",
+          origin: "user",
+          description: null,
+          argumentHint: null,
+        },
+        {
+          kind: "command",
           name: "planner",
           source: "skill",
           origin: "user",
@@ -3171,7 +3179,7 @@ describe("PromptBoxInternal command typeahead navigation", () => {
       within(menu)
         .getAllByRole("button")
         .map((button) => button.textContent),
-    ).toEqual(["plan", "plan-b", "planner", "planning-doc"]);
+    ).toEqual(["plan", "plan-b", "plugin:plan", "planner", "planning-doc"]);
     expect(
       within(menu)
         .getAllByText(/^(User commands|Skills)$/)

--- a/apps/app/src/components/promptbox/mentions/command-suggestion-order.test.ts
+++ b/apps/app/src/components/promptbox/mentions/command-suggestion-order.test.ts
@@ -111,6 +111,12 @@ describe("orderCommandSuggestions", () => {
     ).toEqual(["ottonomous:review", "review-pr"]);
   });
 
+  it("ranks a literal command above a namespaced skill's bare alias", () => {
+    expect(
+      orderedNames([skill("plugin:plan"), userCommand("plan")], "plan"),
+    ).toEqual(["plan", "plugin:plan"]);
+  });
+
   it("falls back to section order when several sections match exactly", () => {
     expect(orderedNames([userCommand("plan"), skill("plan")], "plan")).toEqual([
       "plan",

--- a/apps/app/src/components/promptbox/mentions/types.ts
+++ b/apps/app/src/components/promptbox/mentions/types.ts
@@ -135,19 +135,24 @@ function commandSuggestionSearchNames(
 }
 
 /**
- * How directly the query names a command. Lower wins: the whole name, then a
- * name prefix, then a row that only matched through its description or argument
- * hint. An empty query prefix-matches everything, so it ranks every row alike.
+ * How directly the query names a command. Lower wins: the whole canonical
+ * name, then a namespaced skill's bare alias, then a name prefix, then a row
+ * that only matched through its description or argument hint. An empty query
+ * prefix-matches everything, so it ranks every row alike.
  */
 function commandSuggestionMatchRank(
   suggestion: ComposerCommandSuggestion,
   normalizedQuery: string,
 ): number {
-  const names = commandSuggestionSearchNames(suggestion);
-  if (names.includes(normalizedQuery)) {
+  const canonicalName = suggestion.name.toLowerCase();
+  if (canonicalName === normalizedQuery) {
     return 0;
   }
-  return names.some((name) => name.startsWith(normalizedQuery)) ? 1 : 2;
+  const names = commandSuggestionSearchNames(suggestion);
+  if (names.includes(normalizedQuery)) {
+    return 1;
+  }
+  return names.some((name) => name.startsWith(normalizedQuery)) ? 2 : 3;
 }
 
 /**

--- a/apps/app/src/hooks/useCommandSuggestions.test.ts
+++ b/apps/app/src/hooks/useCommandSuggestions.test.ts
@@ -93,24 +93,7 @@ describe("commandSuggestionMatchesQuery", () => {
     expect(commandSuggestionMatchesQuery(pluginSkill, "deploy")).toBe(false);
   });
 
-  it("ranks a namespaced skill by its direct name without another fetch", () => {
-    const names = filterCommandSuggestions(
-      [
-        { ...pluginSkill, name: "alpha-review-notes" },
-        { ...pluginSkill, name: "ottonomous:review" },
-        { ...pluginSkill, name: "zeta-review" },
-      ],
-      "review",
-    ).map((suggestion) => suggestion.name);
-
-    expect(names).toEqual([
-      "ottonomous:review",
-      "alpha-review-notes",
-      "zeta-review",
-    ]);
-  });
-
-  it("keeps menu sections primary when matches are equally direct", () => {
+  it("filters without taking ownership of suggestion ordering", () => {
     const names = filterCommandSuggestions(
       [
         {
@@ -120,52 +103,16 @@ describe("commandSuggestionMatchesQuery", () => {
           origin: "user",
         },
         { ...pluginSkill, name: "deploy-helper" },
-      ],
-      "deploy",
-    ).map((suggestion) => suggestion.name);
-
-    expect(names).toEqual(["deploy-helper", "deploy-service"]);
-  });
-
-  it("ranks a user-command name prefix above a skill matched by description", () => {
-    const names = filterCommandSuggestions(
-      [
         {
           ...pluginSkill,
           name: "review-helper",
           description: "Contains deploy guidance",
         },
-        {
-          ...pluginSkill,
-          name: "deploy-service",
-          source: "command",
-          origin: "user",
-        },
+        { ...pluginSkill, name: "review-helper", description: null },
       ],
       "deploy",
     ).map((suggestion) => suggestion.name);
 
-    expect(names).toEqual(["deploy-service", "review-helper"]);
-  });
-
-  it("ranks an exact user-command name above skills from an earlier section", () => {
-    const names = filterCommandSuggestions(
-      [
-        {
-          ...pluginSkill,
-          name: "deploy-review",
-          description: "Contains deploy guidance",
-        },
-        {
-          ...pluginSkill,
-          name: "deploy",
-          source: "command",
-          origin: "user",
-        },
-      ],
-      "deploy",
-    ).map((suggestion) => suggestion.name);
-
-    expect(names).toEqual(["deploy", "deploy-review"]);
+    expect(names).toEqual(["deploy-service", "deploy-helper", "review-helper"]);
   });
 });

--- a/apps/app/src/hooks/useCommandSuggestions.ts
+++ b/apps/app/src/hooks/useCommandSuggestions.ts
@@ -1,8 +1,6 @@
 import { useMemo } from "react";
 import type { PromptMentionCommandTrigger } from "@bb/domain";
 import {
-  compareCommandSuggestions,
-  orderCommandSuggestions,
   toProviderCommandSuggestion,
   type ProviderCommandSuggestion,
 } from "@/components/promptbox/mentions/types";
@@ -70,18 +68,18 @@ export function commandSuggestionMatchesQuery(
     .includes(query);
 }
 
+/**
+ * Filter the cached catalog without changing its order. PromptBoxInternal owns
+ * the single relevance-ordering pass because it has the query under the caret.
+ */
 export function filterCommandSuggestions(
   suggestions: readonly ProviderCommandSuggestion[],
   query: string,
 ): ProviderCommandSuggestion[] {
   const normalizedQuery = query.toLowerCase();
-  return suggestions
-    .filter((suggestion) =>
-      commandSuggestionMatchesQuery(suggestion, normalizedQuery),
-    )
-    .sort((left, right) =>
-      compareCommandSuggestions(left, right, normalizedQuery),
-    );
+  return suggestions.filter((suggestion) =>
+    commandSuggestionMatchesQuery(suggestion, normalizedQuery),
+  );
 }
 
 export function promptActionCommandSuggestions({
@@ -195,9 +193,9 @@ export function useCommandSuggestions(
         ),
       trimmedQuery,
     );
-    return orderCommandSuggestions(
-      mergeCommandSuggestions(promptActionSuggestions, discoveredSuggestions),
-      trimmedQuery,
+    return mergeCommandSuggestions(
+      promptActionSuggestions,
+      discoveredSuggestions,
     );
   }, [
     commandsQuery.data?.commands,

--- a/apps/server/src/services/terminals/terminal-session-lifecycle.ts
+++ b/apps/server/src/services/terminals/terminal-session-lifecycle.ts
@@ -517,7 +517,7 @@ export class TerminalSessionLifecycle {
       TerminalSessionRow
     >({
       onFail: (pending, error) =>
-        this.finalizeFailedTerminalClose(pending, error),
+        this.finalizeTimedOutTerminalClose(pending, error),
       timeoutMs: closeTimeoutMs,
       timeoutError: terminalTimeoutError(
         "terminal_close_timeout",
@@ -973,13 +973,13 @@ export class TerminalSessionLifecycle {
         },
       );
       if (!sent) {
+        this.disconnectDaemonSessionTerminals({
+          daemonSessionId: current.daemonSessionId,
+        });
         this.rejectPendingClose(
           current.id,
           new ApiError(502, "host_disconnected", "Host is not connected"),
         );
-        this.disconnectDaemonSessionTerminals({
-          daemonSessionId: current.daemonSessionId,
-        });
       }
     }
     try {
@@ -1757,10 +1757,16 @@ export class TerminalSessionLifecycle {
     }
   }
 
-  private finalizeFailedTerminalClose(
+  private finalizeTimedOutTerminalClose(
     pending: PendingTerminalCloseKey,
     error: Error,
   ): void {
+    if (
+      !(error instanceof ApiError) ||
+      error.body.code !== "terminal_close_timeout"
+    ) {
+      return;
+    }
     // A normal daemon close force-kills after two seconds; the server waits
     // five seconds for terminal.exited. If that acknowledgement never arrives,
     // keeping the row daemon-owned makes every client rediscover an unclosable
@@ -1784,21 +1790,17 @@ export class TerminalSessionLifecycle {
       return;
     }
 
-    const code =
-      error instanceof ApiError ? error.body.code : "terminal_close_failed";
-    const message =
-      error instanceof ApiError ? error.body.message : error.message;
     this.options.logger.warn(
       {
         err: error,
         sessionId: pending.daemonSessionId,
         terminalId: pending.terminalId,
       },
-      "Finalized terminal after close acknowledgement failed",
+      "Finalized terminal after close acknowledgement timed out",
     );
     this.notifyExitedTerminalSession({
-      code,
-      message,
+      code: error.body.code,
+      message: error.body.message,
       session: exited,
     });
   }

--- a/apps/server/test/public/public-terminals.test.ts
+++ b/apps/server/test/public/public-terminals.test.ts
@@ -1755,12 +1755,14 @@ describe("public terminal routes", () => {
     const response = await responsePromise;
 
     expect(response.status).toBe(200);
-    expect(terminalSessionSchema.parse(await readJson(response))).toMatchObject({
-      id: stored.id,
-      closeReason: "user",
-      exitCode: null,
-      status: "exited",
-    });
+    expect(terminalSessionSchema.parse(await readJson(response))).toMatchObject(
+      {
+        id: stored.id,
+        closeReason: "user",
+        exitCode: null,
+        status: "exited",
+      },
+    );
     expect(
       getTerminalSessionForThread(fixture.harness.db, {
         terminalId: stored.id,
@@ -1770,6 +1772,81 @@ describe("public terminal routes", () => {
       closeReason: "user",
       daemonSessionId: null,
       exitCode: null,
+      status: "exited",
+    });
+  });
+
+  it("keeps an undeliverable terminal close available for reconnect cleanup", async () => {
+    const fixture = await createTerminalRouteFixture();
+    harnesses.push(fixture.harness);
+    const stored = createTerminalSession(fixture.harness.db, {
+      cols: 80,
+      daemonSessionId: fixture.session.id,
+      environmentId: fixture.environment.id,
+      hostId: fixture.host.id,
+      initialCwd: "/tmp/terminal-workspace",
+      rows: 24,
+      status: "running",
+      threadId: fixture.thread.id,
+      title: "zsh",
+    });
+    fixture.harness.hub.unregisterDaemon(fixture.session.id);
+
+    const response = await fixture.harness.app.request(
+      `/api/v1/terminals/${stored.id}/close`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ mode: "force", reason: "user" }),
+      },
+    );
+
+    expect(response.status).toBe(502);
+    expect(apiErrorSchema.parse(await readJson(response))).toMatchObject({
+      code: "host_disconnected",
+    });
+    expect(
+      getTerminalSessionForThread(fixture.harness.db, {
+        terminalId: stored.id,
+        threadId: fixture.thread.id,
+      }),
+    ).toMatchObject({
+      closeReason: null,
+      daemonSessionId: null,
+      status: "disconnected",
+    });
+
+    const replacementSession = seedSession(
+      fixture.harness.deps,
+      fixture.host.id,
+    );
+    const replacementSocket = createFakeDaemonSocket();
+    onDaemonSocketOpen(fixture.harness.deps, {
+      hostId: fixture.host.id,
+      sessionId: replacementSession.id,
+      socket: replacementSocket,
+    });
+
+    expect(await waitForDaemonMessage(replacementSocket)).toEqual({
+      type: "connect-shares.replace",
+      generation: 0,
+      ports: [],
+    });
+    await expect(
+      waitForDaemonMessage(replacementSocket, 1),
+    ).resolves.toMatchObject({
+      type: "terminal.close",
+      terminalId: stored.id,
+      reason: "daemon-disconnect",
+    });
+    expect(
+      getTerminalSessionForThread(fixture.harness.db, {
+        terminalId: stored.id,
+        threadId: fixture.thread.id,
+      }),
+    ).toMatchObject({
+      closeReason: "daemon-disconnect",
+      daemonSessionId: null,
       status: "exited",
     });
   });


### PR DESCRIPTION
## Summary

- preserve disconnected terminal rows when a close request cannot reach the daemon, allowing reconnect cleanup to stop the resident PTY
- rank canonical slash-command names ahead of namespaced skill aliases
- keep PromptBoxInternal as the single suggestion-ordering owner and remove two redundant sorting passes

Follow-up to #1353 and #1354.

## Testing

- server terminal route tests: 36 passed
- focused app tests: 99 passed
- Turbo typechecks for @bb/server and @bb/app
- Turbo lint for @bb/server and @bb/app (0 errors; existing warnings remain)

> AGENT GENERATED: by GPT-5