### PR TITLE
Fix drawer tap-through and stale sticky-scroll cache

### DIFF
--- a/apps/app/src/components/thread/timeline/TimelineDetailScroll.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineDetailScroll.tsx
@@ -100,7 +100,10 @@ export function TimelineDetailScroll({
           aria-hidden
           className="-mb-px h-px w-full"
         />
-        {children}
+        {/* Content-only height changes (image loads, disclosure toggles)
+            never resize the scroll port; this wrapper gives the sticky
+            hook's ResizeObserver a box that tracks them. */}
+        <div ref={sticky.contentRef}>{children}</div>
         <div
           ref={overflow.bottomSentinelRef}
           aria-hidden

--- a/apps/app/src/components/thread/timeline/useStickyBottomScroll.test.tsx
+++ b/apps/app/src/components/thread/timeline/useStickyBottomScroll.test.tsx
@@ -20,7 +20,9 @@ function StickyScrollProbe({ contentKey }: { contentKey: string }) {
       data-testid="scroll"
       onScroll={sticky.onScroll}
       onWheel={sticky.onWheel}
-    />
+    >
+      <div ref={sticky.contentRef} data-testid="content" />
+    </div>
   );
 }
 
@@ -68,5 +70,84 @@ describe("useStickyBottomScroll", () => {
     expect(layoutReads).toBe(0);
     rerender(<StickyScrollProbe contentKey="third" />);
     expect(scrollTop).toBe(20);
+  });
+
+  it("refreshes the cached maximum when only the content grows", () => {
+    // The scroll port has a fixed box, so a content-only growth (an image
+    // load, a disclosure toggle) fires no resize on it. The hook must
+    // observe the content wrapper too, or the stale maximum re-sticks a
+    // user who sits at the OLD bottom.
+    const observed: Element[] = [];
+    let fireResize: (() => void) | undefined;
+    class StubResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        fireResize = () => callback([], this as unknown as ResizeObserver);
+      }
+      observe(element: Element) {
+        observed.push(element);
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("ResizeObserver", StubResizeObserver);
+
+    const { getByTestId, rerender } = render(
+      <StickyScrollProbe contentKey="first" />,
+    );
+    const scroll = getByTestId("scroll");
+    expect(observed).toContain(scroll);
+    expect(observed).toContain(getByTestId("content"));
+
+    let scrollHeight = 120;
+    let scrollTop = 0;
+    Object.defineProperties(scroll, {
+      scrollHeight: {
+        configurable: true,
+        get: () => scrollHeight,
+      },
+      clientHeight: {
+        configurable: true,
+        get: () => 20,
+      },
+      scrollTop: {
+        configurable: true,
+        get: () => scrollTop,
+        set: (value: number) => {
+          scrollTop = value;
+        },
+      },
+      // Deterministic smooth-scroll target; jsdom does not implement it.
+      scrollTo: {
+        configurable: true,
+        value: (options: ScrollToOptions) => {
+          scrollTop = options.top ?? 0;
+        },
+      },
+    });
+
+    rerender(<StickyScrollProbe contentKey="second" />);
+    expect(scrollTop).toBe(100);
+
+    // The user scrolls up; stickiness disengages.
+    scrollTop = 40;
+    fireEvent.wheel(scroll);
+    fireEvent.scroll(scroll);
+
+    // Content grows to a 200px maximum; the wrapper observer refreshes the
+    // cache. Scrolling back to the stale bottom (100) must NOT re-stick.
+    scrollHeight = 220;
+    fireResize?.();
+    scrollTop = 100;
+    fireEvent.wheel(scroll);
+    fireEvent.scroll(scroll);
+    rerender(<StickyScrollProbe contentKey="third" />);
+    expect(scrollTop).toBe(100);
+
+    // Scrolling to the real bottom re-sticks, so the next tick follows.
+    scrollTop = 200;
+    fireEvent.scroll(scroll);
+    scrollHeight = 260;
+    rerender(<StickyScrollProbe contentKey="fourth" />);
+    expect(scrollTop).toBe(240);
   });
 });

--- a/apps/app/src/components/thread/timeline/useStickyBottomScroll.ts
+++ b/apps/app/src/components/thread/timeline/useStickyBottomScroll.ts
@@ -10,6 +10,13 @@ import {
 } from "react";
 
 export interface StickyBottomScrollBinding<TElement extends HTMLElement> {
+  /**
+   * Attach to an element that wraps the scrolled content. The scroll port's
+   * box is fixed, so content-only height changes (an image load, a
+   * disclosure toggle) never fire its ResizeObserver; observing the wrapper
+   * keeps the cached maximum offset fresh for those changes too.
+   */
+  contentRef: RefObject<HTMLDivElement | null>;
   onPointerDown: PointerEventHandler<TElement>;
   onScroll: UIEventHandler<TElement>;
   onTouchMove: TouchEventHandler<TElement>;
@@ -56,6 +63,7 @@ export function useStickyBottomScroll<TElement extends HTMLElement>({
   streaming,
 }: UseStickyBottomScrollArgs): StickyBottomScrollBinding<TElement> {
   const scrollRef = useRef<TElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const shouldStickToBottomRef = useRef(true);
   const pointerScrollIntentRef = useRef(false);
   const userScrollIntentUntilRef = useRef(0);
@@ -80,6 +88,12 @@ export function useStickyBottomScroll<TElement extends HTMLElement>({
       refreshMaxScrollOffset(element);
     });
     observer.observe(element);
+    // The port only resizes with the viewport; the content wrapper resizes
+    // when the content itself grows or shrinks. Both feed the same cache.
+    const content = contentRef.current;
+    if (content) {
+      observer.observe(content);
+    }
     return () => observer.disconnect();
   }, [refreshMaxScrollOffset]);
 
@@ -156,6 +170,7 @@ export function useStickyBottomScroll<TElement extends HTMLElement>({
   }, [onPointerEnd, streaming]);
 
   return {
+    contentRef,
     onPointerDown,
     onScroll,
     onTouchMove: markUserScrollIntent,

--- a/apps/app/src/components/ui/sidebar.test.tsx
+++ b/apps/app/src/components/ui/sidebar.test.tsx
@@ -237,6 +237,45 @@ describe("mobile sidebar persistence", () => {
     expect(inset?.hasAttribute("inert")).toBe(false);
   });
 
+  it("blocks tap-through with the backdrop during the deferred open", () => {
+    vi.useFakeTimers();
+    render(
+      <CompactViewportOverrideProvider isCompactViewport>
+        <SidebarProvider>
+          <Sidebar>Sidebar content</Sidebar>
+          <SidebarInset>
+            <SidebarTrigger />
+            Main content
+          </SidebarInset>
+        </SidebarProvider>
+      </CompactViewportOverrideProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
+
+    // React state stays closed for the settle window, so the class-driven
+    // backdrop state still reads pointer-events-none while the panel is
+    // still `inert`. The inline override must intercept taps immediately,
+    // or a rapid second tap falls through onto the page below.
+    const backdrop = screen.getByTestId("sidebar-mobile-backdrop");
+    expect(getMobilePanel()?.dataset.state).toBe("closed");
+    expect(backdrop.style.pointerEvents).toBe("auto");
+
+    // A tap the backdrop absorbs mid-slide must not cancel the open; the
+    // settle guard swallows the dismiss.
+    fireEvent.click(backdrop);
+    settleMobileToggle();
+    expect(getMobilePanel()?.dataset.state).toBe("open");
+    // The commit clears the override; the open-state class owns taps now.
+    expect(backdrop.style.pointerEvents).toBe("");
+
+    fireEvent.click(backdrop);
+    settleMobileToggle();
+    expect(getMobilePanel()?.dataset.state).toBe("closed");
+    // No stale override may keep the closed backdrop interactive.
+    expect(backdrop.style.pointerEvents).not.toBe("auto");
+  });
+
   it("keeps the pinned trigger interactive and closes on a second press", () => {
     vi.useFakeTimers();
     render(

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -138,6 +138,11 @@ function applySidebarMobileDragStyles({
     backdrop.style.transition = settling
       ? SIDEBAR_MOBILE_BACKDROP_SETTLE_TRANSITION
       : "none";
+    // The deferred open keeps data-state="closed" (pointer-events-none)
+    // until the settle commit, while the panel is still `inert` — without
+    // this inline override a rapid second tap during the slide-in falls
+    // through both layers onto the page below.
+    backdrop.style.pointerEvents = progress > 0 ? "auto" : "";
   }
 }
 
@@ -160,6 +165,7 @@ function clearSidebarMobileDragStyles() {
     backdrop.removeAttribute("data-vaul-animate");
     backdrop.style.opacity = "";
     backdrop.style.transition = "";
+    backdrop.style.pointerEvents = "";
   }
 }
 
@@ -484,8 +490,9 @@ const SidebarProvider = React.forwardRef<
     // drawer is open. The open commit (panel `inert` removal, data-state
     // flips) then pays its style recalculation — ~280 ms on iOS Safari for a
     // large sidebar — after the slide instead of blocking its first frame.
-    // The panel stays `inert` and the backdrop passes taps through until the
-    // commit lands one settle window later.
+    // The panel stays `inert` until the commit lands one settle window
+    // later; the drag helper puts inline pointer-events on the backdrop so
+    // taps during the slide land on the backdrop, not the page below.
     const openMobileSidebar = React.useCallback(() => {
       if (openMobileRef.current || mobileSettleTimeoutRef.current !== null) {
         return;


### PR DESCRIPTION
Follow-up to #1356. This fixes findings 1 and 2 from the SlopCop review of that PR.

## Backdrop tap-through during the deferred open

The deferred mobile open starts the slide 220 ms before the React state commit. In that window the panel is `inert` and the backdrop class still reads `pointer-events-none`, so a rapid second tap fell through to the page below the drawer. `applySidebarMobileDragStyles` now writes inline `pointer-events: auto` on the backdrop whenever the panel is on screen. The clear helper and the state commit remove the override, so the class-driven state owns pointer input again after settle. A tap the backdrop absorbs mid-slide does not cancel the open; the settle guard swallows the dismiss.

## Stale sticky-bottom scroll cache

`useStickyBottomScroll` caches the maximum scroll offset and refreshes it from a `ResizeObserver` on the scroll port. The port box is fixed, so content-only height changes (an image load, a disclosure toggle) never fired the observer. The stale cache could re-stick a user at the old bottom, or block the re-stick at the real bottom. The hook now exposes a `contentRef`, and `TimelineDetailScroll` wraps its children in a div bound to it. The observer watches both boxes and feeds the same cache.

## Tests

- `sidebar.test.tsx`: the backdrop intercepts taps during the deferred open, the absorbed tap does not cancel the open, and no stale override survives the close.
- `useStickyBottomScroll.test.tsx`: a content-only growth refreshes the cache, the old bottom does not re-stick, and the real bottom does.

`turbo run test --filter=@bb/app`: 2539 tests pass. Typecheck passes.

> AGENT GENERATED: by Claude Fable 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)