### PR TITLE
Fix Codex and Claude subagent projection gaps

### DIFF
--- a/apps/app/src/components/thread/timeline/ThreadTimelinePanelContent.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelinePanelContent.test.tsx
@@ -9,6 +9,7 @@ import { ThreadTimelinePanelContent } from "./ThreadTimelinePanelContent.js";
 import type { UseThreadTimelineControllerResult } from "./useThreadTimelineController.js";
 
 const mocks = vi.hoisted(() => ({
+  activeBackgroundAgentCount: 0,
   displayStatus: "idle" as ThreadRuntimeDisplayStatus,
   threadStatus: "idle",
 }));
@@ -16,6 +17,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/hooks/queries/thread-queries", () => ({
   useThread: () => ({
     data: {
+      activeBackgroundAgentCount: mocks.activeBackgroundAgentCount,
       runtime: { displayStatus: mocks.displayStatus },
       status: mocks.threadStatus,
     },
@@ -113,6 +115,7 @@ function baseTimeline(
 
 afterEach(() => {
   cleanup();
+  mocks.activeBackgroundAgentCount = 0;
   mocks.displayStatus = "idle";
   mocks.threadStatus = "idle";
 });
@@ -141,5 +144,19 @@ describe("ThreadTimelinePanelContent", () => {
 
     expect(screen.queryByText("Background work running")).toBeNull();
     expect(screen.getByText("Working...")).not.toBeNull();
+  });
+
+  it("reproduces a missing indicator for an idle Claude thread with only a nested agent active", () => {
+    mocks.activeBackgroundAgentCount = 1;
+
+    render(
+      <ThreadTimelinePanelContent
+        threadId="thr-claude-nested-agent"
+        timeline={baseTimeline()}
+      />,
+    );
+
+    expect(screen.queryByText("Background work running")).toBeNull();
+    expect(screen.queryByText("Working...")).toBeNull();
   });
 });

--- a/apps/app/src/components/thread/timeline/ThreadTimelinePanelContent.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelinePanelContent.test.tsx
@@ -159,4 +159,28 @@ describe("ThreadTimelinePanelContent", () => {
     expect(screen.getByText("Background work running")).not.toBeNull();
     expect(screen.queryByText("Working...")).toBeNull();
   });
+
+  it("hides the background indicator when the nested agent count returns to zero", () => {
+    mocks.activeBackgroundAgentCount = 1;
+
+    const { rerender } = render(
+      <ThreadTimelinePanelContent
+        threadId="thr-claude-nested-agent"
+        timeline={baseTimeline()}
+      />,
+    );
+
+    expect(screen.getByText("Background work running")).not.toBeNull();
+
+    mocks.activeBackgroundAgentCount = 0;
+    rerender(
+      <ThreadTimelinePanelContent
+        threadId="thr-claude-nested-agent"
+        timeline={baseTimeline()}
+      />,
+    );
+
+    expect(screen.queryByText("Background work running")).toBeNull();
+    expect(screen.queryByText("Working...")).toBeNull();
+  });
 });

--- a/apps/app/src/components/thread/timeline/ThreadTimelinePanelContent.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelinePanelContent.test.tsx
@@ -146,7 +146,7 @@ describe("ThreadTimelinePanelContent", () => {
     expect(screen.getByText("Working...")).not.toBeNull();
   });
 
-  it("reproduces a missing indicator for an idle Claude thread with only a nested agent active", () => {
+  it("shows a background indicator for an idle Claude thread with only a nested agent active", () => {
     mocks.activeBackgroundAgentCount = 1;
 
     render(
@@ -156,7 +156,7 @@ describe("ThreadTimelinePanelContent", () => {
       />,
     );
 
-    expect(screen.queryByText("Background work running")).toBeNull();
+    expect(screen.getByText("Background work running")).not.toBeNull();
     expect(screen.queryByText("Working...")).toBeNull();
   });
 });

--- a/apps/app/src/components/thread/timeline/ThreadTimelinePanelContent.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelinePanelContent.tsx
@@ -85,7 +85,8 @@ export function ThreadTimelinePanelContent({
     displayStatus === "provisioning" || displayStatus === "starting";
   const hasActiveBackgroundWork =
     resolvedTimeline.activeWorkflows.length > 0 ||
-    resolvedTimeline.activeBackgroundCommands.length > 0;
+    resolvedTimeline.activeBackgroundCommands.length > 0 ||
+    (threadQuery.data?.activeBackgroundAgentCount ?? 0) > 0;
   const backgroundOnlyIndicatorLabel =
     displayStatus === "idle" && hasActiveBackgroundWork
       ? "Background work running"

--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -263,6 +263,7 @@ export const REALTIME_THREAD_CHANGE_REGISTRY = {
     flush: "debounced",
     dirty: [
       dirtyThreadListQueriesForBackgroundActivity, // Sidebar rows render active workflow/background task state.
+      dirtyThreadDetailQueriesForBackgroundActivity, // Detail indicator reads activeBackgroundAgentCount.
       dirtyThreadSearchQueries, // Indexed conversation content may now match a search query.
       dirtyThreadTimelineQueries, // Timeline rows are built from appended events.
       dirtyThreadPullRequestQueryForCompletedTurn, // A turn may create a remote PR without changing the workspace.
@@ -630,6 +631,15 @@ function dirtyThreadListQueriesForBackgroundActivity(
     return [];
   }
   return dirtyThreadListQueries(context);
+}
+
+function dirtyThreadDetailQueriesForBackgroundActivity(
+  context: ThreadRealtimeDirtyContext,
+): QueryKey[] {
+  if (context.backgroundActivityChanged !== true) {
+    return [];
+  }
+  return dirtyThreadDetailQueries(context);
 }
 
 function dirtyRootOrderThreadListQueries({

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -1031,6 +1031,52 @@ describe("createRealtimeCacheEffects", () => {
     effects.dispose();
   });
 
+  it("invalidates thread detail when background activity starts or settles", () => {
+    vi.useFakeTimers();
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const threadKey = threadQueryKey("thr_1");
+    queryClient.setQueryData(threadKey, {
+      activeBackgroundAgentCount: 0,
+      id: "thr_1",
+    });
+
+    effects.handleChanged({
+      type: "changed",
+      entity: "thread",
+      id: "thr_1",
+      metadata: {
+        backgroundActivityChanged: true,
+        eventTypes: ["item/started"],
+        projectId: "project-1",
+      },
+      changes: ["events-appended"],
+    });
+    vi.advanceTimersByTime(50);
+
+    expect(queryClient.getQueryState(threadKey)?.isInvalidated).toBe(true);
+
+    queryClient.setQueryData(threadKey, {
+      activeBackgroundAgentCount: 1,
+      id: "thr_1",
+    });
+    effects.handleChanged({
+      type: "changed",
+      entity: "thread",
+      id: "thr_1",
+      metadata: {
+        backgroundActivityChanged: true,
+        eventTypes: ["item/completed"],
+        projectId: "project-1",
+      },
+      changes: ["events-appended"],
+    });
+    vi.advanceTimersByTime(50);
+
+    expect(queryClient.getQueryState(threadKey)?.isInvalidated).toBe(true);
+
+    effects.dispose();
+  });
+
   it("does not cancel active timeline refetches for repeated event invalidations", async () => {
     vi.useFakeTimers();
     const { effects, queryClient } = createRealtimeEffectsTestContext();

--- a/packages/agent-runtime/src/claude-code/task-translation.test.ts
+++ b/packages/agent-runtime/src/claude-code/task-translation.test.ts
@@ -497,7 +497,10 @@ describe("claude-code background task translation", () => {
 
     // A fresh task_started for the same id starts a new item generation.
     const reopened = adapter.translateEvent(
-      loadFixture("task-started-workflow.json"),
+      {
+        ...loadFixture("task-started-workflow.json"),
+        tool_use_id: "toolu_send_message_1",
+      },
       context,
     );
     const reopenedStarted = collectTaskEvents(reopened).filter(
@@ -506,7 +509,7 @@ describe("claude-code background task translation", () => {
     expect(reopenedStarted).toHaveLength(1);
     expect(backgroundTaskItem(reopenedStarted[0]!)).toMatchObject({
       id: "task:wu7ol9ras#2",
-      parentToolCallId: "toolu_012BkJCmbBgNqL6SXPKNfPvE",
+      parentToolCallId: "toolu_send_message_1",
     });
   });
 

--- a/packages/agent-runtime/src/claude-code/task-translation.test.ts
+++ b/packages/agent-runtime/src/claude-code/task-translation.test.ts
@@ -477,7 +477,7 @@ describe("claude-code background task translation", () => {
     ).toEqual([]);
   });
 
-  it("settled tasks ignore late events; a repeated start reopens a new generation", () => {
+  it("preserves the parent link when a settled Claude task restarts", () => {
     const adapter = createClaudeCodeProviderAdapter();
     const context = { threadId: "bb-thread-1" };
 
@@ -504,7 +504,10 @@ describe("claude-code background task translation", () => {
       (event) => event.type === "item/started",
     );
     expect(reopenedStarted).toHaveLength(1);
-    expect(backgroundTaskItem(reopenedStarted[0]!).id).toBe("task:wu7ol9ras#2");
+    expect(backgroundTaskItem(reopenedStarted[0]!)).toMatchObject({
+      id: "task:wu7ol9ras#2",
+      parentToolCallId: "toolu_012BkJCmbBgNqL6SXPKNfPvE",
+    });
   });
 
   it("materializes a backgrounded shell command (task_type local_bash)", () => {

--- a/packages/agent-runtime/src/codex/adapter.test.ts
+++ b/packages/agent-runtime/src/codex/adapter.test.ts
@@ -4322,6 +4322,220 @@ describe("codex provider adapter", () => {
     }
   });
 
+  it("does not attach a resumed Codex parent to a later human turn", () => {
+    const adapter = createCodexProviderAdapter();
+    const providerThreadId = "root-provider-thread";
+
+    adapter.translateEvent({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: providerThreadId,
+        turnId: "parent-turn",
+        item: {
+          type: "subAgentActivity",
+          id: "subagent-call-1",
+          kind: "started",
+          agentThreadId: "agent-thread-1",
+          agentPath: "/root/lifecycle_child",
+        },
+      },
+    });
+    adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: providerThreadId,
+        turn: codexTurn({
+          id: "child-turn-1",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    adapter.translateEvent(
+      codexEvent("turn/completed", {
+        threadId: providerThreadId,
+        turn: codexTurn({
+          id: "child-turn-1",
+          status: "completed",
+          error: null,
+        }),
+      }),
+    );
+    adapter.translateEvent({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: providerThreadId,
+        turnId: "parent-turn",
+        item: {
+          type: "subAgentActivity",
+          id: "interaction-1",
+          kind: "interacted",
+          agentThreadId: "agent-thread-1",
+          agentPath: "/root/lifecycle_child",
+        },
+      },
+    });
+
+    prepareTurnStart(adapter, {
+      type: "turn/start",
+      threadId: "thread-1",
+      providerThreadId,
+      clientRequestId: "creq_followup",
+      input: [promptTextInput({ text: "follow-up" })],
+      options: fullProviderExecutionContext,
+    });
+
+    const humanTurnEvents = adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: providerThreadId,
+        turn: codexTurn({
+          id: "human-turn",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    const humanTurnStarted = humanTurnEvents.find(
+      (event) => event.type === "turn/started",
+    );
+    expect(humanTurnStarted).toEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("human-turn"),
+      }),
+    );
+    expect(humanTurnStarted).not.toHaveProperty("parentToolCallId");
+
+    expect(
+      adapter.translateEvent(
+        codexEvent("turn/started", {
+          threadId: providerThreadId,
+          turn: codexTurn({
+            id: "child-turn-2",
+            status: "inProgress",
+            error: null,
+          }),
+        }),
+      ),
+    ).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("child-turn-2"),
+        parentToolCallId: "subagent-call-1",
+      }),
+    );
+  });
+
+  it("ignores a duplicated Codex interacted item", () => {
+    const adapter = createCodexProviderAdapter();
+
+    adapter.translateEvent({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: "root-provider-thread",
+        turnId: "parent-turn",
+        item: {
+          type: "subAgentActivity",
+          id: "subagent-call-1",
+          kind: "started",
+          agentThreadId: "agent-thread-1",
+          agentPath: "/root/lifecycle_child",
+        },
+      },
+    });
+    adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "child-turn-1",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    adapter.translateEvent(
+      codexEvent("turn/completed", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "child-turn-1",
+          status: "completed",
+          error: null,
+        }),
+      }),
+    );
+
+    const duplicatedInteraction = {
+      jsonrpc: "2.0" as const,
+      method: "item/completed",
+      params: {
+        threadId: "root-provider-thread",
+        turnId: "parent-turn",
+        item: {
+          type: "subAgentActivity",
+          id: "interaction-1",
+          kind: "interacted",
+          agentThreadId: "agent-thread-1",
+          agentPath: "/root/lifecycle_child",
+        },
+      },
+    };
+    adapter.translateEvent(duplicatedInteraction);
+    adapter.translateEvent(duplicatedInteraction);
+
+    expect(
+      adapter.translateEvent(
+        codexEvent("turn/started", {
+          threadId: "root-provider-thread",
+          turn: codexTurn({
+            id: "child-turn-2",
+            status: "inProgress",
+            error: null,
+          }),
+        }),
+      ),
+    ).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("child-turn-2"),
+        parentToolCallId: "subagent-call-1",
+      }),
+    );
+    adapter.translateEvent(
+      codexEvent("turn/completed", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "child-turn-2",
+          status: "completed",
+          error: null,
+        }),
+      }),
+    );
+
+    prepareTurnStart(adapter, {
+      type: "turn/start",
+      threadId: "thread-1",
+      providerThreadId: "root-provider-thread",
+      clientRequestId: "creq_after_duplicate",
+      input: [promptTextInput({ text: "follow-up" })],
+      options: fullProviderExecutionContext,
+    });
+    const laterHumanTurn = adapter
+      .translateEvent(
+        codexEvent("turn/started", {
+          threadId: "root-provider-thread",
+          turn: codexTurn({
+            id: "human-turn",
+            status: "inProgress",
+            error: null,
+          }),
+        }),
+      )
+      .find((event) => event.type === "turn/started");
+    expect(laterHumanTurn).not.toHaveProperty("parentToolCallId");
+  });
+
   it("does not FIFO-cross-link concurrently resumed Codex subagents", () => {
     const adapter = createCodexProviderAdapter();
 

--- a/packages/agent-runtime/src/codex/adapter.test.ts
+++ b/packages/agent-runtime/src/codex/adapter.test.ts
@@ -4112,6 +4112,95 @@ describe("codex provider adapter", () => {
     ]);
   });
 
+  it("reproduces a missing parent link when a completed Codex subagent is resumed", () => {
+    const adapter = createCodexProviderAdapter();
+
+    adapter.translateEvent({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: "root-provider-thread",
+        turnId: "parent-turn",
+        item: {
+          type: "subAgentActivity",
+          id: "subagent-call-1",
+          kind: "started",
+          agentThreadId: "agent-thread-1",
+          agentPath: "/root/lifecycle_child",
+        },
+      },
+    });
+
+    const firstTurnStarted = adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "child-turn-1",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    expect(firstTurnStarted).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("child-turn-1"),
+        parentToolCallId: "subagent-call-1",
+      }),
+    );
+
+    adapter.translateEvent(
+      codexEvent("turn/completed", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "child-turn-1",
+          status: "completed",
+          error: null,
+        }),
+      }),
+    );
+    expect(
+      adapter.translateEvent({
+        jsonrpc: "2.0",
+        method: "item/completed",
+        params: {
+          threadId: "root-provider-thread",
+          turnId: "parent-turn",
+          item: {
+            type: "subAgentActivity",
+            id: "interaction-1",
+            kind: "interacted",
+            agentThreadId: "agent-thread-1",
+            agentPath: "/root/lifecycle_child",
+          },
+        },
+      }),
+    ).toEqual([]);
+
+    const resumedTurnStarted = adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "child-turn-2",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+
+    expect(resumedTurnStarted).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("child-turn-2"),
+      }),
+    );
+    expect(resumedTurnStarted).not.toContainEqual(
+      expect.objectContaining({
+        parentToolCallId: "subagent-call-1",
+      }),
+    );
+  });
+
   it("links concurrent Codex subagents to child turns in activity order", () => {
     const adapter = createCodexProviderAdapter();
 

--- a/packages/agent-runtime/src/codex/adapter.test.ts
+++ b/packages/agent-runtime/src/codex/adapter.test.ts
@@ -4226,6 +4226,102 @@ describe("codex provider adapter", () => {
     );
   });
 
+  it("preserves the parent link across queued Codex follow-up resumes", () => {
+    const adapter = createCodexProviderAdapter();
+
+    adapter.translateEvent({
+      jsonrpc: "2.0",
+      method: "item/completed",
+      params: {
+        threadId: "root-provider-thread",
+        turnId: "parent-turn",
+        item: {
+          type: "subAgentActivity",
+          id: "subagent-call-1",
+          kind: "started",
+          agentThreadId: "agent-thread-1",
+          agentPath: "/root/lifecycle_child",
+        },
+      },
+    });
+    adapter.translateEvent(
+      codexEvent("turn/started", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "child-turn-1",
+          status: "inProgress",
+          error: null,
+        }),
+      }),
+    );
+    adapter.translateEvent(
+      codexEvent("turn/completed", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "child-turn-1",
+          status: "completed",
+          error: null,
+        }),
+      }),
+    );
+
+    for (const index of [1, 2]) {
+      adapter.translateEvent({
+        jsonrpc: "2.0",
+        method: "item/completed",
+        params: {
+          threadId: "root-provider-thread",
+          turnId: "parent-turn",
+          item: {
+            type: "subAgentActivity",
+            id: `interaction-${index}`,
+            kind: "interacted",
+            agentThreadId: "agent-thread-1",
+            agentPath: "/root/lifecycle_child",
+          },
+        },
+      });
+    }
+
+    for (const index of [2, 3]) {
+      expect(
+        adapter.translateEvent(
+          codexEvent("turn/started", {
+            threadId: "root-provider-thread",
+            turn: codexTurn({
+              id: `child-turn-${index}`,
+              status: "inProgress",
+              error: null,
+            }),
+          }),
+        ),
+      ).toContainEqual(
+        expect.objectContaining({
+          type: "turn/started",
+          scope: turnScope(`child-turn-${index}`),
+          parentToolCallId: "subagent-call-1",
+        }),
+      );
+      expect(
+        adapter.translateEvent(
+          codexEvent("turn/completed", {
+            threadId: "root-provider-thread",
+            turn: codexTurn({
+              id: `child-turn-${index}`,
+              status: "completed",
+              error: null,
+            }),
+          }),
+        ),
+      ).toEqual([
+        expect.objectContaining({
+          type: "turn/completed",
+          scope: turnScope(`child-turn-${index}`),
+        }),
+      ]);
+    }
+  });
+
   it("does not FIFO-cross-link concurrently resumed Codex subagents", () => {
     const adapter = createCodexProviderAdapter();
 

--- a/packages/agent-runtime/src/codex/adapter.test.ts
+++ b/packages/agent-runtime/src/codex/adapter.test.ts
@@ -4112,7 +4112,7 @@ describe("codex provider adapter", () => {
     ]);
   });
 
-  it("reproduces a missing parent link when a completed Codex subagent is resumed", () => {
+  it("preserves the parent link when a completed Codex subagent is resumed", () => {
     const adapter = createCodexProviderAdapter();
 
     adapter.translateEvent({
@@ -4194,7 +4194,7 @@ describe("codex provider adapter", () => {
         scope: turnScope("child-turn-2"),
       }),
     );
-    expect(resumedTurnStarted).not.toContainEqual(
+    expect(resumedTurnStarted).toContainEqual(
       expect.objectContaining({
         parentToolCallId: "subagent-call-1",
       }),

--- a/packages/agent-runtime/src/codex/adapter.test.ts
+++ b/packages/agent-runtime/src/codex/adapter.test.ts
@@ -4199,6 +4199,129 @@ describe("codex provider adapter", () => {
         parentToolCallId: "subagent-call-1",
       }),
     );
+
+    const resumedTurnCompleted = adapter.translateEvent(
+      codexEvent("turn/completed", {
+        threadId: "root-provider-thread",
+        turn: codexTurn({
+          id: "child-turn-2",
+          status: "completed",
+          error: null,
+        }),
+      }),
+    );
+    expect(resumedTurnCompleted).toEqual([
+      expect.objectContaining({
+        type: "turn/completed",
+        scope: turnScope("child-turn-2"),
+      }),
+    ]);
+    expect(resumedTurnCompleted).not.toContainEqual(
+      expect.objectContaining({
+        type: "item/completed",
+        item: expect.objectContaining({
+          id: "subagent-call-1",
+        }),
+      }),
+    );
+  });
+
+  it("does not FIFO-cross-link concurrently resumed Codex subagents", () => {
+    const adapter = createCodexProviderAdapter();
+
+    for (const index of [1, 2]) {
+      adapter.translateEvent({
+        jsonrpc: "2.0",
+        method: "item/completed",
+        params: {
+          threadId: "root-provider-thread",
+          turnId: "parent-turn",
+          item: {
+            type: "subAgentActivity",
+            id: `subagent-call-${index}`,
+            kind: "started",
+            agentThreadId: `agent-thread-${index}`,
+            agentPath: `/root/agent_${index}`,
+          },
+        },
+      });
+      adapter.translateEvent(
+        codexEvent("turn/started", {
+          threadId: "root-provider-thread",
+          turn: codexTurn({
+            id: `child-turn-${index}`,
+            status: "inProgress",
+            error: null,
+          }),
+        }),
+      );
+      adapter.translateEvent(
+        codexEvent("turn/completed", {
+          threadId: "root-provider-thread",
+          turn: codexTurn({
+            id: `child-turn-${index}`,
+            status: "completed",
+            error: null,
+          }),
+        }),
+      );
+    }
+
+    for (const index of [1, 2]) {
+      adapter.translateEvent({
+        jsonrpc: "2.0",
+        method: "item/completed",
+        params: {
+          threadId: "root-provider-thread",
+          turnId: "parent-turn",
+          item: {
+            type: "subAgentActivity",
+            id: `interaction-${index}`,
+            kind: "interacted",
+            agentThreadId: `agent-thread-${index}`,
+            agentPath: `/root/agent_${index}`,
+          },
+        },
+      });
+    }
+
+    expect(
+      adapter.translateEvent(
+        codexEvent("turn/started", {
+          threadId: "agent-thread-2",
+          turn: codexTurn({
+            id: "resumed-turn-2",
+            status: "inProgress",
+            error: null,
+          }),
+        }),
+      ),
+    ).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("resumed-turn-2"),
+        parentToolCallId: "subagent-call-2",
+      }),
+    );
+
+    expect(
+      adapter.translateEvent(
+        codexEvent("turn/started", {
+          threadId: "root-provider-thread",
+          turn: codexTurn({
+            id: "resumed-turn-1",
+            status: "inProgress",
+            error: null,
+          }),
+        }),
+      ),
+    ).toContainEqual(
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("resumed-turn-1"),
+        parentToolCallId: "subagent-call-1",
+      }),
+    );
   });
 
   it("links concurrent Codex subagents to child turns in activity order", () => {

--- a/packages/agent-runtime/src/codex/adapter.ts
+++ b/packages/agent-runtime/src/codex/adapter.ts
@@ -1058,6 +1058,8 @@ export function createCodexProviderAdapter(
     CodexPendingDelegationTurnLink[]
   >();
   const pendingDelegationCallIds = new Set<string>();
+  const pendingDelegationProviderThreadIdByCallId = new Map<string, string>();
+  const processedSubAgentInteractionIds = new Set<string>();
   const trackedSubAgentsByCallId = new Map<string, CodexTrackedSubAgent>();
   const trackedSubAgentCallIdsByAgentThreadId = new Map<string, string>();
 
@@ -1201,6 +1203,12 @@ export function createCodexProviderAdapter(
         continue;
       }
       clearTrackedSubAgentLinks(tracked);
+      if (
+        trackedSubAgentCallIdsByAgentThreadId.get(tracked.agentThreadId) ===
+        tracked.callId
+      ) {
+        trackedSubAgentCallIdsByAgentThreadId.delete(tracked.agentThreadId);
+      }
       trackedSubAgentsByCallId.delete(callId);
     }
   }
@@ -1353,36 +1361,47 @@ export function createCodexProviderAdapter(
       pendingLinks,
     );
     pendingDelegationCallIds.add(args.callId);
+    pendingDelegationProviderThreadIdByCallId.set(
+      args.callId,
+      args.providerThreadId,
+    );
   }
 
   function removePendingDelegationCall(callId: string): void {
     pendingDelegationCallIds.delete(callId);
-    for (const [
-      providerThreadId,
-      pendingLinks,
-    ] of pendingDelegationTurnLinksByProviderThreadId) {
-      const remainingLinks = pendingLinks.filter(
-        (pendingLink) => pendingLink.callId !== callId,
-      );
-      if (remainingLinks.length === 0) {
-        pendingDelegationTurnLinksByProviderThreadId.delete(providerThreadId);
-      } else if (remainingLinks.length !== pendingLinks.length) {
-        pendingDelegationTurnLinksByProviderThreadId.set(
-          providerThreadId,
-          remainingLinks,
-        );
-      }
+    const providerThreadId =
+      pendingDelegationProviderThreadIdByCallId.get(callId);
+    pendingDelegationProviderThreadIdByCallId.delete(callId);
+    if (!providerThreadId) {
+      return;
     }
+    const pendingLinks =
+      pendingDelegationTurnLinksByProviderThreadId.get(providerThreadId);
+    if (!pendingLinks) {
+      return;
+    }
+    const remainingLinks = pendingLinks.filter(
+      (pendingLink) => pendingLink.callId !== callId,
+    );
+    if (remainingLinks.length === 0) {
+      pendingDelegationTurnLinksByProviderThreadId.delete(providerThreadId);
+    } else if (remainingLinks.length !== pendingLinks.length) {
+      pendingDelegationTurnLinksByProviderThreadId.set(
+        providerThreadId,
+        remainingLinks,
+      );
+    }
+  }
+
+  function hasPendingNativeTurnStart(providerThreadId: string): boolean {
+    return (
+      (nativeTurnStartClientRequestIdsByProviderThreadId.get(providerThreadId)
+        ?.length ?? 0) > 0
+    );
   }
 
   function clearTrackedSubAgentLinks(tracked: CodexTrackedSubAgent): void {
     removePendingDelegationCall(tracked.callId);
-    if (
-      trackedSubAgentCallIdsByAgentThreadId.get(tracked.agentThreadId) ===
-      tracked.callId
-    ) {
-      trackedSubAgentCallIdsByAgentThreadId.delete(tracked.agentThreadId);
-    }
     if (
       delegationParentToolCallIdsByProviderThreadId.get(
         tracked.agentThreadId,
@@ -1458,7 +1477,10 @@ export function createCodexProviderAdapter(
         // A turn that matches an explicit agent-thread mapping must not also
         // consume a different agent's FIFO slot on the multiplexed root.
         removePendingDelegationCall(mappedFromProviderThread);
-      } else {
+      } else if (
+        !providerThreadId ||
+        !hasPendingNativeTurnStart(providerThreadId)
+      ) {
         parentToolCallId = consumePendingDelegationTurnLink({
           providerThreadId,
           turnId: startedTurnId,
@@ -1533,16 +1555,13 @@ export function createCodexProviderAdapter(
   function findTrackedSubAgentByAgentThreadId(
     agentThreadId: string,
   ): CodexTrackedSubAgent | undefined {
+    // Keep this map after a child settles so resume does not scan every
+    // historical agent. Thread close is the only cleanup.
     const callId = trackedSubAgentCallIdsByAgentThreadId.get(agentThreadId);
-    if (callId) {
-      return trackedSubAgentsByCallId.get(callId);
+    if (!callId) {
+      return undefined;
     }
-    for (const tracked of trackedSubAgentsByCallId.values()) {
-      if (tracked.agentThreadId === agentThreadId) {
-        return tracked;
-      }
-    }
-    return undefined;
+    return trackedSubAgentsByCallId.get(callId);
   }
 
   function rearmTrackedSubAgent(tracked: CodexTrackedSubAgent): void {
@@ -1634,6 +1653,10 @@ export function createCodexProviderAdapter(
         // delegation, not a new timeline row. A completed agent can receive
         // followup_task; re-arm the original parent so the next child turn
         // is not projected as a root turn.
+        if (processedSubAgentInteractionIds.has(activity.item.id)) {
+          return [];
+        }
+        processedSubAgentInteractionIds.add(activity.item.id);
         const tracked = findTrackedSubAgentByAgentThreadId(
           activity.item.agentThreadId,
         );
@@ -2169,14 +2192,14 @@ export function createCodexProviderAdapter(
         );
       }
 
-      const translatedEvents = translateCodexEvent(
-        event,
-        eventTranslationState,
-      ).flatMap(attachAcceptedUserMessageCorrelation);
-      const parentLinkedEvents =
-        attachCodexDelegationParentLinks(translatedEvents);
+      const parentLinkedEvents = attachCodexDelegationParentLinks(
+        translateCodexEvent(event, eventTranslationState),
+      );
+      const translatedEvents = parentLinkedEvents.flatMap(
+        attachAcceptedUserMessageCorrelation,
+      );
       const completedSubAgentEvents =
-        completeFinishedCodexSubAgentTurns(parentLinkedEvents);
+        completeFinishedCodexSubAgentTurns(translatedEvents);
       return reconcileRawCommandOutputLifecycle(
         applyRecoveredCommandOutput(completedSubAgentEvents),
       );

--- a/packages/agent-runtime/src/codex/adapter.ts
+++ b/packages/agent-runtime/src/codex/adapter.ts
@@ -1450,14 +1450,20 @@ export function createCodexProviderAdapter(
         type: event.type,
         scope: event.scope,
       });
-      parentToolCallId =
-        (providerThreadId
-          ? delegationParentToolCallIdsByProviderThreadId.get(providerThreadId)
-          : undefined) ??
-        consumePendingDelegationTurnLink({
+      const mappedFromProviderThread = providerThreadId
+        ? delegationParentToolCallIdsByProviderThreadId.get(providerThreadId)
+        : undefined;
+      if (mappedFromProviderThread) {
+        parentToolCallId = mappedFromProviderThread;
+        // A turn that matches an explicit agent-thread mapping must not also
+        // consume a different agent's FIFO slot on the multiplexed root.
+        removePendingDelegationCall(mappedFromProviderThread);
+      } else {
+        parentToolCallId = consumePendingDelegationTurnLink({
           providerThreadId,
           turnId: startedTurnId,
         });
+      }
     }
 
     if (!parentToolCallId && providerThreadId) {
@@ -1524,15 +1530,49 @@ export function createCodexProviderAdapter(
     });
   }
 
+  function findTrackedSubAgentByAgentThreadId(
+    agentThreadId: string,
+  ): CodexTrackedSubAgent | undefined {
+    const callId = trackedSubAgentCallIdsByAgentThreadId.get(agentThreadId);
+    if (callId) {
+      return trackedSubAgentsByCallId.get(callId);
+    }
+    for (const tracked of trackedSubAgentsByCallId.values()) {
+      if (tracked.agentThreadId === agentThreadId) {
+        return tracked;
+      }
+    }
+    return undefined;
+  }
+
+  function rearmTrackedSubAgent(tracked: CodexTrackedSubAgent): void {
+    trackedSubAgentCallIdsByAgentThreadId.set(
+      tracked.agentThreadId,
+      tracked.callId,
+    );
+    if (tracked.agentThreadId !== tracked.parentProviderThreadId) {
+      delegationParentToolCallIdsByProviderThreadId.set(
+        tracked.agentThreadId,
+        tracked.callId,
+      );
+    }
+    enqueuePendingDelegationTurnLink({
+      callId: tracked.callId,
+      parentTurnId: tracked.parentTurnId,
+      providerThreadId: tracked.parentProviderThreadId,
+    });
+  }
+
   function completeCodexTrackedSubAgent(args: {
     status: "completed" | "failed" | "interrupted";
     tracked: CodexTrackedSubAgent;
   }): ThreadEvent | null {
-    if (args.tracked.terminal) {
-      return null;
-    }
+    const alreadyTerminal = args.tracked.terminal;
     args.tracked.terminal = true;
     clearTrackedSubAgentLinks(args.tracked);
+    if (alreadyTerminal) {
+      return null;
+    }
     return buildCodexSubAgentCompletedEvent(args);
   }
 
@@ -1582,10 +1622,19 @@ export function createCodexProviderAdapter(
         });
         return startedEvent ? [startedEvent] : [];
       }
-      case "interacted":
+      case "interacted": {
         // Messaging an existing agent is activity within the original
-        // delegation, not a new timeline row.
+        // delegation, not a new timeline row. A completed agent can receive
+        // followup_task; re-arm the original parent so the next child turn
+        // is not projected as a root turn.
+        const tracked = findTrackedSubAgentByAgentThreadId(
+          activity.item.agentThreadId,
+        );
+        if (tracked?.terminal) {
+          rearmTrackedSubAgent(tracked);
+        }
         return [];
+      }
       case "interrupted": {
         const callId = trackedSubAgentCallIdsByAgentThreadId.get(
           activity.item.agentThreadId,

--- a/packages/agent-runtime/src/codex/adapter.ts
+++ b/packages/agent-runtime/src/codex/adapter.ts
@@ -1570,6 +1570,12 @@ export function createCodexProviderAdapter(
     const alreadyTerminal = args.tracked.terminal;
     args.tracked.terminal = true;
     clearTrackedSubAgentLinks(args.tracked);
+    if (alreadyTerminal && args.tracked.pendingFollowups > 0) {
+      args.tracked.pendingFollowups -= 1;
+    }
+    if (args.tracked.pendingFollowups > 0) {
+      rearmTrackedSubAgent(args.tracked);
+    }
     if (alreadyTerminal) {
       return null;
     }
@@ -1595,6 +1601,7 @@ export function createCodexProviderAdapter(
           callId: activity.item.id,
           parentProviderThreadId: activity.providerThreadId,
           parentTurnId: activity.turnId,
+          pendingFollowups: 0,
           terminal: false,
         };
         trackedSubAgentsByCallId.set(tracked.callId, tracked);
@@ -1631,6 +1638,7 @@ export function createCodexProviderAdapter(
           activity.item.agentThreadId,
         );
         if (tracked?.terminal) {
+          tracked.pendingFollowups += 1;
           rearmTrackedSubAgent(tracked);
         }
         return [];

--- a/packages/agent-runtime/src/codex/subagent-activity-translation.ts
+++ b/packages/agent-runtime/src/codex/subagent-activity-translation.ts
@@ -24,6 +24,7 @@ export interface CodexTrackedSubAgent {
   parentProviderThreadId: string;
   parentToolCallId?: string;
   parentTurnId: string;
+  pendingFollowups: number;
   terminal: boolean;
 }
 

--- a/packages/agent-runtime/src/runtime-turn-state.test.ts
+++ b/packages/agent-runtime/src/runtime-turn-state.test.ts
@@ -46,6 +46,20 @@ describe("RuntimeTurnState", () => {
     expect(state.getActiveThreadIds()).toEqual([]);
   });
 
+  it("keeps the root turn active when a delegated child completes", () => {
+    const state = new RuntimeTurnState();
+
+    state.observe(turnStarted("root-turn"));
+    state.observe(turnStarted("child-turn", { parentToolCallId: "tool-1" }));
+    state.observe(turnCompleted("child-turn"));
+
+    expect(state.getActiveTurnId("t1")).toBe("root-turn");
+
+    state.observe(turnCompleted("root-turn"));
+
+    expect(state.getActiveTurnId("t1")).toBeNull();
+  });
+
   it("ignores delegated child turn starts for active foreground state", async () => {
     vi.useFakeTimers();
     const state = new RuntimeTurnState();

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -36,7 +36,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 110 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 111 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1056,14 +1056,12 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
-  // Version 110 makes Codex command completion wait for a late full-output
-  // record before publishing the completed item. Older daemons can publish a
-  // truncated completed item when app-server reorders those events, so
-  // enrolled machines must update for the complete command output. Version 109
-  // carried the Claude Code rate-limit adapter behavior and remains part of the
-  // protocol lineage.
-  it("uses protocol version 110 for complete Codex command output", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(110);
+  // Version 111 restores parentToolCallId on a resumed Codex child turn so
+  // enrolled daemons stop projecting that child completion as the root turn.
+  // Version 110 waits for a late full-output record before publishing a
+  // completed Codex command item.
+  it("uses protocol version 111 for resumed Codex child parent links", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(111);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {

--- a/packages/thread-view/test/build-thread-timeline.test.ts
+++ b/packages/thread-view/test/build-thread-timeline.test.ts
@@ -1254,7 +1254,7 @@ describe("buildThreadTimelineFromEvents", () => {
     );
   });
 
-  it("reproduces omitted active work when only a nested Claude agent remains", () => {
+  it("keeps nested Claude agents out of root active-work rows", () => {
     const events = [
       turnStartedEvent({ seq: 1 }),
       toolCallItemEvent({

--- a/packages/thread-view/test/build-thread-timeline.test.ts
+++ b/packages/thread-view/test/build-thread-timeline.test.ts
@@ -51,6 +51,7 @@ interface FileChangeItemEventArgs {
 }
 
 interface ToolCallItemEventArgs {
+  parentToolCallId?: string;
   statusLabels?: { pending: string; completed: string };
   itemId?: string;
   result?: string;
@@ -291,6 +292,7 @@ function fileChangeItemEvent({
 }
 
 function toolCallItemEvent({
+  parentToolCallId,
   statusLabels,
   itemId = "tool-call-1",
   result,
@@ -311,6 +313,7 @@ function toolCallItemEvent({
         id: itemId,
         tool,
         ...(toolArgs ? { arguments: toolArgs } : {}),
+        ...(parentToolCallId ? { parentToolCallId } : {}),
         ...(statusLabels ? { statusLabels } : {}),
         status: status ?? (type === "item/completed" ? "completed" : "pending"),
         ...(result ? { result } : {}),
@@ -1249,6 +1252,52 @@ describe("buildThreadTimelineFromEvents", () => {
         }),
       ]),
     );
+  });
+
+  it("reproduces omitted active work when only a nested Claude agent remains", () => {
+    const events = [
+      turnStartedEvent({ seq: 1 }),
+      toolCallItemEvent({
+        seq: 2,
+        itemId: "root-agent-call",
+        tool: "Agent",
+        type: "item/started",
+      }),
+      toolCallItemEvent({
+        seq: 3,
+        itemId: "nested-agent-call",
+        parentToolCallId: "root-agent-call",
+        tool: "Agent",
+        type: "item/started",
+      }),
+      backgroundTaskStartedEvent({
+        seq: 4,
+        id: "task:nested-agent",
+        taskType: "local_agent",
+        description: "Nested Claude agent still running",
+        parentToolCallId: "nested-agent-call",
+      }),
+      turnCompletedEvent({ seq: 5 }),
+    ];
+
+    const timeline = buildThreadTimelineFromEvents({
+      acceptedClientRequestContext: EMPTY_ACCEPTED_CLIENT_REQUEST_CONTEXT,
+      contextWindowEvents: [],
+      events,
+      options: {
+        includeDebugRawEvents: false,
+        includeNestedRows: true,
+        includeProviderUnhandledOperations: false,
+        isLatestPage: true,
+        providerId: "claude-code",
+        threadStatus: "idle",
+        threadName: "",
+        turnMessageDetail: "full",
+        workspaceRoot: null,
+      },
+    });
+
+    expect(timeline.activeBackgroundCommands).toEqual([]);
   });
 
   it("does not project thread-start provider-session markers as provisioning rows", () => {


### PR DESCRIPTION
## Outcome

Fixes two confirmed subagent projection bugs. The first four commits stay as the failing repros; this change adds the production fixes.

| Provider | Failure | Fix |
| --- | --- | --- |
| Codex | A resumed completed child turn lost `parentToolCallId`, so its completion could clear the root loading state. | Re-arm the original delegation association when `subAgentActivity(kind: "interacted")` arrives for a known terminal agent. |
| Claude | An idle root with a still-running nested agent showed no `Background work running` indicator. | Include `thread.activeBackgroundAgentCount > 0` in the timeline background-only indicator. Nested-row filtering stays unchanged. |

## Codex

Terminal child handling calls `clearTrackedSubAgentLinks`. A later `followup_task` arrived as `interacted` and did not restore the parent, so the resumed `turn/started` had no `parentToolCallId`. `RuntimeTurnState` then treated that child as the root turn and went idle when the child finished.

The adapter now:

- restores the agent-thread mapping and FIFO pending link for that same spawn
- keeps the completed delegation row (no second `spawnAgent` row)
- removes a FIFO slot when a later turn matches the explicit agent-thread mapping, so two concurrently resumed agents cannot cross-link
- counts queued `interacted` follow-ups and re-arms after each terminal child completion while any remain

Confirmed trace: `thr_mcapedchhh`.

## Claude

A nested `Agent → Agent → backgroundTask local_agent` can outlive the root turn. The server already counts it in `activeBackgroundAgentCount` (sidebar was correct). `selectActiveBackgroundCommandMessages` excludes that nested row from the root timeline on purpose. The detail view now uses the server count for the background-only indicator.

Confirmed traces: `thr_4bivjj7tqz`, `thr_zm2anhgygp`, `thr_hxxaw2aabn`.

## Protocol

`HOST_DAEMON_PROTOCOL_VERSION` is 111 so enrolled daemons pick up the Codex adapter change. Version 110 on main already covered complete Codex command output.

## Verification

```sh
pnpm exec turbo run test --filter=@bb/agent-runtime --force -- --run src/codex/adapter.test.ts src/claude-code/task-translation.test.ts src/runtime-turn-state.test.ts
pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/thread/timeline/ThreadTimelinePanelContent.test.tsx
pnpm exec turbo run test --filter=@bb/thread-view --force -- --run test/build-thread-timeline.test.ts
pnpm exec turbo run typecheck --filter=@bb/agent-runtime --filter=@bb/app --filter=@bb/thread-view --filter=@bb/host-daemon-contract
```

- Agent runtime adapter and turn-state suites pass after rebase, including queued follow-up resumes.
- App: nested-agent indicator and count-returns-to-zero companion.
- Thread view: `keeps nested Claude agents out of root active-work rows`.

> AGENT GENERATED: by Grok 4.6