### PR TITLE
Fix Claude Code update handling

### DIFF
--- a/apps/app/src/components/provider-cli/provider-cli-install.test.tsx
+++ b/apps/app/src/components/provider-cli/provider-cli-install.test.tsx
@@ -15,7 +15,10 @@ import {
   hostProviderCliStatusQueryKey,
 } from "@/hooks/queries/query-keys";
 import type { ProviderCliActionableIssue } from "./provider-cli-install";
-import { useProviderCliInstallRunner } from "./provider-cli-install";
+import {
+  buildProviderCliIssue,
+  useProviderCliInstallRunner,
+} from "./provider-cli-install";
 import {
   registerProviderCliInstallQueryClient,
   resetProviderCliInstallStoreForTests,
@@ -138,6 +141,26 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+});
+
+describe("buildProviderCliIssue", () => {
+  it("keeps an external update visible when bb cannot apply it", () => {
+    const actionable = issueForProvider("claudeCode");
+    const issue = buildProviderCliIssue({
+      provider: "claudeCode",
+      status: {
+        ...actionable.status,
+        installSource: "external",
+        installAction: null,
+      },
+    });
+
+    expect(issue).toMatchObject({
+      provider: "claudeCode",
+      action: null,
+      title: "Claude Code update available",
+    });
+  });
 });
 
 describe("useProviderCliInstallRunner", () => {

--- a/apps/app/src/components/provider-cli/provider-cli-install.tsx
+++ b/apps/app/src/components/provider-cli/provider-cli-install.tsx
@@ -84,9 +84,6 @@ export function buildProviderCliIssue(
   }
 
   if (status.needsUpdate) {
-    if (status.installAction === null) {
-      return null;
-    }
     const description = `${status.currentVersion ?? "Installed version unknown"} -> ${status.latestVersion ?? "latest"}`;
     const fingerprint = [
       provider,

--- a/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
@@ -126,6 +126,21 @@ function makeUpdateIssue(args: {
   };
 }
 
+function makeManualUpdateIssue(args: {
+  provider: "codex" | "claudeCode";
+}): ProviderCliIssue {
+  const issue = makeUpdateIssue(args);
+  return {
+    ...issue,
+    action: null,
+    status: {
+      ...issue.status,
+      installSource: "external",
+      installAction: null,
+    },
+  };
+}
+
 function makeMachine(args: {
   host: Host;
   issues?: ProviderCliIssue[];
@@ -515,5 +530,29 @@ describe("UpdatesSettingsSection", () => {
       hostId: "host_2",
       issue: homelabIssue,
     });
+  });
+
+  it("shows an external Claude installation as a manual update without an update button", () => {
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    const host = makeHost({ id: "host_1", name: "workstation" });
+    const issue = makeManualUpdateIssue({ provider: "claudeCode" });
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        machines: [makeMachine({ host, issues: [issue] })],
+        actionableCount: 1,
+        hasAttention: true,
+      }),
+    );
+
+    renderSection();
+
+    expect(screen.getByText("Update manually")).toBeDefined();
+    expect(screen.getByText("1 update needs manual action")).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Update" })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Update all/ })).toBeNull();
   });
 });

--- a/apps/app/src/components/settings/UpdatesSettingsSection.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.tsx
@@ -406,6 +406,13 @@ function providerRowState({
   if (issue === null) {
     return null;
   }
+  if (issue.action === null) {
+    return {
+      label: "Update manually",
+      rowTone: issue.status.versionUnsupported ? "destructive" : "attention",
+      statusTone: issue.status.versionUnsupported ? "destructive" : "attention",
+    };
+  }
   if (issue.status.versionUnsupported) {
     return {
       label: "Update needed",
@@ -663,6 +670,14 @@ export function UpdatesSettingsSection() {
     const jobKey = providerCliJobKey(hostId, issue.provider);
     return runningJobKey !== jobKey && !queuedJobKeys.has(jobKey);
   });
+  const manualIssueCount = inventory.machines.reduce(
+    (count, machine) =>
+      count +
+      machine.issues.filter(
+        (issue) => issue.status.installed && !hasProviderCliAction(issue),
+      ).length,
+    0,
+  );
 
   const strandedMachines = inventory.machines.filter(
     (machine) => machine.canRetryDaemonUpdate,
@@ -724,9 +739,11 @@ export function UpdatesSettingsSection() {
             ? `Checking ${checkingMachines} ${checkingMachines === 1 ? "machine" : "machines"}…`
             : activeInstallCount > 0
               ? `${activeInstallCount} ${activeInstallCount === 1 ? "update" : "updates"} in progress`
-              : actionableIssues.length === 0
-                ? `${inventory.machines.length} ${inventory.machines.length === 1 ? "machine" : "machines"}, all in sync`
-                : null;
+              : manualIssueCount > 0
+                ? `${manualIssueCount} ${manualIssueCount === 1 ? "update needs" : "updates need"} manual action`
+                : actionableIssues.length === 0
+                  ? `${inventory.machines.length} ${inventory.machines.length === 1 ? "machine" : "machines"}, all in sync`
+                  : null;
 
   return (
     <>

--- a/apps/cli/src/__tests__/command-output/updates.test.ts
+++ b/apps/cli/src/__tests__/command-output/updates.test.ts
@@ -196,4 +196,25 @@ describe("bb updates command output", () => {
       "Everything is up to date.",
     ]);
   });
+
+  it("bb updates reports but does not apply manual provider updates", async () => {
+    const status = providerStatus({ codexNeedsUpdate: true });
+    status.codex.installAction = null;
+    stubServerApi({
+      "v1.system.version.$get": vi.fn(async () => version),
+      "v1.hosts.$get": vi.fn(async () => hosts),
+      "v1.hosts.:id.provider-clis.status.$get": vi.fn(async () => status),
+    });
+
+    await runCommand(["updates"], register);
+    expect(collectLogPayloads(vi.mocked(console.log)).join("\n")).toContain(
+      "update manually",
+    );
+
+    vi.mocked(console.log).mockClear();
+    await runCommand(["updates", "apply"], register);
+    expect(collectLogPayloads(vi.mocked(console.log))).toEqual([
+      "No updates bb can apply. Run bb updates status for manual updates.",
+    ]);
+  });
 });

--- a/apps/cli/src/commands/updates.ts
+++ b/apps/cli/src/commands/updates.ts
@@ -33,7 +33,11 @@ interface MachineUpdatesEntry {
 function providerStateLabel(status: ProviderCliStatus): string {
   if (!status.installed) return "not installed";
   if (status.versionUnsupported) return "update needed";
-  if (status.needsUpdate) return "update available";
+  if (status.needsUpdate) {
+    return status.installAction === null
+      ? "update manually"
+      : "update available";
+  }
   return "up to date";
 }
 
@@ -215,7 +219,24 @@ export function registerUpdatesCommands(
         const targets = actionableTargets(entries);
         if (targets.length === 0) {
           if (outputJson(opts, { results: [] })) return;
-          console.log("Everything is up to date.");
+          const hasManualUpdates = entries.some(
+            (entry) =>
+              entry.providerStatus !== null &&
+              MANAGED_PROVIDERS.some((provider) => {
+                const status = entry.providerStatus?.[provider];
+                return (
+                  status !== undefined &&
+                  status.installed &&
+                  status.needsUpdate &&
+                  status.installAction === null
+                );
+              }),
+          );
+          console.log(
+            hasManualUpdates
+              ? "No updates bb can apply. Run bb updates status for manual updates."
+              : "Everything is up to date.",
+          );
           return;
         }
 

--- a/apps/host-daemon/src/command-dispatch.test.ts
+++ b/apps/host-daemon/src/command-dispatch.test.ts
@@ -237,6 +237,32 @@ function createProviderCliInstallEventStream(
   });
 }
 
+function claudeCodeStatus(args: {
+  currentVersion: string;
+  latestVersion: string;
+}): ProviderCliStatus {
+  return {
+    displayName: "Claude Code",
+    executableName: "claude",
+    executablePath: "/Users/me/.local/bin/claude",
+    installed: true,
+    installSource: "external",
+    currentVersion: args.currentVersion,
+    latestVersion: args.latestVersion,
+    minimumSupportedVersion: null,
+    npmPackageName: "@anthropic-ai/claude-code",
+    npmGlobalPackageVersion: null,
+    installAction: {
+      kind: "update",
+      label: "Update",
+      commandKind: "exec",
+      command: "claude update",
+    },
+    needsUpdate: args.currentVersion !== args.latestVersion,
+    versionUnsupported: false,
+  };
+}
+
 describe("dispatchCommand", () => {
   it("flushes buffered events before reporting thread.stop success", async () => {
     const runtime = createRuntime();
@@ -1181,6 +1207,23 @@ describe("dispatchCommand", () => {
       const streamProviderCliInstall = vi.fn(() =>
         createProviderCliInstallEventStream(testCase.events),
       );
+      const getProviderCliStatusForProvider =
+        testCase.provider === "claudeCode"
+          ? vi
+              .fn()
+              .mockResolvedValueOnce(
+                claudeCodeStatus({
+                  currentVersion: "2.1.220",
+                  latestVersion: "2.1.227",
+                }),
+              )
+              .mockResolvedValueOnce(
+                claudeCodeStatus({
+                  currentVersion: "2.1.227",
+                  latestVersion: "2.1.227",
+                }),
+              )
+          : undefined;
 
       const result = await dispatchOnlineRpcCommand(
         {
@@ -1197,6 +1240,9 @@ describe("dispatchCommand", () => {
           fetchProjectAttachment: async () => {
             throw new Error("Unexpected project attachment fetch");
           },
+          ...(getProviderCliStatusForProvider === undefined
+            ? {}
+            : { getProviderCliStatusForProvider }),
           runtimeManager: manager,
           streamProviderCliInstall,
           threadStorageRootPath: "/tmp/bb-thread-storage",
@@ -1210,6 +1256,92 @@ describe("dispatchCommand", () => {
       ).resolves.toBe(runtime);
       expect(createRuntimeSpy).toHaveBeenCalledTimes(1);
     }
+  });
+
+  it("reports a successful Claude update command as failed when the active executable stays old", async () => {
+    const dataDir = await makeTempDir("bb-command-dispatch-provider-cli-");
+    const runtime = createRuntime();
+    const manager = new RuntimeManager({
+      createRuntime: () => runtime,
+      dataDir,
+      provisionWorkspace: async () => createWorkspace(),
+    });
+    const getProviderCliStatusForProvider = vi
+      .fn()
+      .mockResolvedValueOnce(
+        claudeCodeStatus({
+          currentVersion: "2.1.220",
+          latestVersion: "2.1.227",
+        }),
+      )
+      .mockResolvedValueOnce(
+        claudeCodeStatus({
+          currentVersion: "2.1.220",
+          latestVersion: "2.1.227",
+        }),
+      );
+
+    const result = await dispatchOnlineRpcCommand(
+      {
+        type: "provider_cli.install",
+        provider: "claudeCode",
+        actionKind: "update",
+      },
+      {
+        dataDir,
+        eventSink: {
+          emit: vi.fn(),
+          flush: vi.fn(async () => undefined),
+        },
+        fetchProjectAttachment: async () => {
+          throw new Error("Unexpected project attachment fetch");
+        },
+        getProviderCliStatusForProvider,
+        runtimeManager: manager,
+        streamProviderCliInstall: () =>
+          createProviderCliInstallEventStream([
+            {
+              type: "started",
+              provider: "claudeCode",
+              command: "claude update",
+            },
+            {
+              type: "output",
+              provider: "claudeCode",
+              stream: "stdout",
+              text: "Successfully updated from 2.1.220 to version 2.1.227\n",
+            },
+            {
+              type: "completed",
+              provider: "claudeCode",
+              exitCode: 0,
+              signal: null,
+              success: true,
+            },
+          ]),
+        threadStorageRootPath: "/tmp/bb-thread-storage",
+      },
+    );
+
+    expect(getProviderCliStatusForProvider).toHaveBeenCalledTimes(2);
+    expect(result.events).toEqual([
+      expect.objectContaining({ type: "started" }),
+      expect.objectContaining({ type: "output" }),
+      expect.objectContaining({
+        type: "error",
+        provider: "claudeCode",
+        message: expect.stringContaining(
+          "still reports 2.1.220 (expected 2.1.227)",
+        ),
+      }),
+      {
+        type: "completed",
+        provider: "claudeCode",
+        exitCode: 0,
+        signal: null,
+        success: false,
+      },
+    ]);
   });
 
   // Regression: a thread.start whose freshly staged skill catalog differed

--- a/apps/host-daemon/src/command-dispatch.ts
+++ b/apps/host-daemon/src/command-dispatch.ts
@@ -1,6 +1,7 @@
 import {
   providerCliInstallEventSchema,
   type ProviderCliInstallEvent,
+  type ProviderCliStatus,
   HostDaemonCommand,
   HostDaemonCommandResult,
   HostDaemonOnlineRpcCommand,
@@ -8,6 +9,7 @@ import {
   HostDaemonOnlineRpcResult,
   HostDaemonSettledCommandType,
 } from "@bb/host-daemon-contract";
+import semver from "semver";
 import {
   CommandDispatchError,
   defaultListModels,
@@ -60,6 +62,7 @@ import { getProviderUsage } from "./provider-usage.js";
 import {
   getKnownAcpAgentsStatus,
   getProviderCliStatus,
+  getProviderCliStatusForProvider as inspectProviderCliStatusForProvider,
   ProviderCliInstallInProgressError,
   streamProviderCliInstall,
 } from "./provider-cli-health.js";
@@ -171,6 +174,61 @@ async function readProviderCliInstallEvents(
   return events;
 }
 
+async function tryGetProviderCliStatusForProvider(
+  provider: CommandOf<"provider_cli.install">["provider"],
+  options: CommandDispatchOptions,
+  env: NodeJS.ProcessEnv,
+): Promise<ProviderCliStatus | null> {
+  try {
+    if (options.getProviderCliStatusForProvider !== undefined) {
+      return await options.getProviderCliStatusForProvider(provider);
+    }
+    return await inspectProviderCliStatusForProvider(provider, { env });
+  } catch {
+    return null;
+  }
+}
+
+function verifyClaudeCodeUpdateEvents(args: {
+  before: ProviderCliStatus;
+  after: ProviderCliStatus | null;
+  events: ProviderCliInstallEvent[];
+}): ProviderCliInstallEvent[] {
+  const completedIndex = args.events.findIndex(
+    (event) => event.type === "completed" && event.success,
+  );
+  const expectedVersion = args.before.latestVersion;
+  const actualVersion = args.after?.currentVersion ?? null;
+  if (
+    completedIndex === -1 ||
+    expectedVersion === null ||
+    (actualVersion !== null &&
+      semver.valid(actualVersion) !== null &&
+      semver.valid(expectedVersion) !== null &&
+      semver.gte(actualVersion, expectedVersion))
+  ) {
+    return args.events;
+  }
+
+  const executable =
+    args.after?.executablePath ??
+    args.before.executablePath ??
+    args.before.executableName;
+  const message = `Claude Code's update command exited successfully, but ${executable} still reports ${actualVersion ?? "an unknown version"} (expected ${expectedVersion}). The executable may be pinned by PATH or managed by another installer. Run \`claude doctor\` on this machine and update the installation it reports.`;
+  const verifiedEvents = [...args.events];
+  const completedEvent = verifiedEvents[completedIndex];
+  if (completedEvent?.type !== "completed") {
+    return args.events;
+  }
+  verifiedEvents[completedIndex] = { ...completedEvent, success: false };
+  verifiedEvents.splice(completedIndex, 0, {
+    type: "error",
+    provider: "claudeCode",
+    message,
+  });
+  return verifiedEvents;
+}
+
 async function installProviderCliOnHost(
   command: CommandOf<"provider_cli.install">,
   options: CommandDispatchOptions,
@@ -179,15 +237,38 @@ async function installProviderCliOnHost(
     const env = providerCliEnvFromShellEnv(
       options.runtimeManager.getShellEnv(),
     );
+    const claudeCodeStatusBefore =
+      command.provider === "claudeCode" && command.actionKind === "update"
+        ? await tryGetProviderCliStatusForProvider(
+            command.provider,
+            options,
+            env,
+          )
+        : null;
     const streamInstall =
       options.streamProviderCliInstall ?? streamProviderCliInstall;
-    const events = await readProviderCliInstallEvents(
+    let events = await readProviderCliInstallEvents(
       streamInstall({
         provider: command.provider,
         actionKind: command.actionKind,
         env,
       }),
     );
+    if (
+      claudeCodeStatusBefore !== null &&
+      events.some((event) => event.type === "completed" && event.success)
+    ) {
+      const claudeCodeStatusAfter = await tryGetProviderCliStatusForProvider(
+        command.provider,
+        options,
+        env,
+      );
+      events = verifyClaudeCodeUpdateEvents({
+        before: claudeCodeStatusBefore,
+        after: claudeCodeStatusAfter,
+        events,
+      });
+    }
     if (
       shouldInvalidateProviderMaintenanceRuntimeAfterProviderCliInstall({
         command,

--- a/apps/host-daemon/src/provider-cli-health.test.ts
+++ b/apps/host-daemon/src/provider-cli-health.test.ts
@@ -271,10 +271,11 @@ function installMissingClaudeCommands(
   runner.setSpawnError("claude", ["--version"], "spawn claude ENOENT");
   runner.setSuccess(
     "npm",
-    ["view", "@anthropic-ai/claude-code", "version"],
-    "2.1.148\n",
+    ["view", "@anthropic-ai/claude-code", "dist-tags", "--json"],
+    JSON.stringify({ latest: "2.1.148", stable: "2.1.140" }),
   );
   installNpmStateCommands(runner, CLAUDE_CODE_DEFINITION, "/usr/local", null);
+  runner.setSpawnError("claude", ["doctor"], "spawn claude ENOENT");
 }
 
 function installMissingCursorCommands(
@@ -314,14 +315,50 @@ function installOutdatedExternalClaudeCommands(
   runner.setSuccess("claude", ["--version"], "2.1.147 (Claude Code)\n");
   runner.setSuccess(
     "npm",
-    ["view", "@anthropic-ai/claude-code", "version"],
-    "2.1.148\n",
+    ["view", "@anthropic-ai/claude-code", "dist-tags", "--json"],
+    JSON.stringify({ latest: "2.1.148", stable: "2.1.140" }),
   );
   installNpmStateCommands(
     runner,
     CLAUDE_CODE_DEFINITION,
     "/Users/me/.npm-global",
     "2.1.147",
+  );
+  runner.setSuccess(
+    "claude",
+    ["doctor"],
+    [
+      "Running: npm-global (2.1.147)",
+      "Path: /opt/homebrew/bin/claude",
+      "Auto-update channel: latest",
+    ].join("\n"),
+  );
+}
+
+function installOutdatedNativeClaudeCommands(
+  runner: FakeProviderCliCommandRunner,
+): void {
+  runner.setSuccess("which", ["claude"], "/Users/me/.local/bin/claude\n");
+  runner.setSuccess("claude", ["--version"], "2.1.147 (Claude Code)\n");
+  runner.setSuccess(
+    "npm",
+    ["view", "@anthropic-ai/claude-code", "dist-tags", "--json"],
+    JSON.stringify({ latest: "2.1.148", stable: "2.1.140" }),
+  );
+  installNpmStateCommands(
+    runner,
+    CLAUDE_CODE_DEFINITION,
+    "/Users/me/.npm-global",
+    null,
+  );
+  runner.setSuccess(
+    "claude",
+    ["doctor"],
+    [
+      "Running: native (2.1.147)",
+      "Path: /Users/me/.local/share/claude/versions/2.1.147",
+      "Auto-update channel: latest",
+    ].join("\n"),
   );
 }
 
@@ -332,14 +369,23 @@ function installCurrentClaudeCommands(
   runner.setSuccess("claude", ["--version"], "2.1.148 (Claude Code)\n");
   runner.setSuccess(
     "npm",
-    ["view", "@anthropic-ai/claude-code", "version"],
-    "2.1.148\n",
+    ["view", "@anthropic-ai/claude-code", "dist-tags", "--json"],
+    JSON.stringify({ latest: "2.1.148", stable: "2.1.140" }),
   );
   installNpmStateCommands(
     runner,
     CLAUDE_CODE_DEFINITION,
     "/opt/homebrew",
     "2.1.148",
+  );
+  runner.setSuccess(
+    "claude",
+    ["doctor"],
+    [
+      "Running: npm-global (2.1.148)",
+      "Path: /opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe",
+      "Auto-update channel: latest",
+    ].join("\n"),
   );
 }
 
@@ -519,9 +565,25 @@ describe("provider CLI health", () => {
     });
   });
 
-  it("offers a self-update action when the active executable is external", async () => {
+  it("does not offer to update an npm install from a different global prefix", async () => {
     const runner = new FakeProviderCliCommandRunner();
     installOutdatedExternalClaudeCommands(runner);
+
+    const status = await inspectProviderCli({
+      definition: CLAUDE_CODE_DEFINITION,
+      runner,
+      nodePlatform: "darwin",
+    });
+
+    expect(status.installed).toBe(true);
+    expect(status.installSource).toBe("external");
+    expect(status.needsUpdate).toBe(true);
+    expect(status.installAction).toBeNull();
+  });
+
+  it("offers a self-update action for a native Claude Code install", async () => {
+    const runner = new FakeProviderCliCommandRunner();
+    installOutdatedNativeClaudeCommands(runner);
 
     const status = await inspectProviderCli({
       definition: CLAUDE_CODE_DEFINITION,
@@ -538,6 +600,39 @@ describe("provider CLI health", () => {
       commandKind: "exec",
       command: "claude update",
     });
+  });
+
+  it("uses Claude Code's stable release channel when checking for updates", async () => {
+    const runner = new FakeProviderCliCommandRunner();
+    runner.setSuccess("which", ["claude"], "/Users/me/.local/bin/claude\n");
+    runner.setSuccess("claude", ["--version"], "2.1.220 (Claude Code)\n");
+    runner.setSuccess(
+      "npm",
+      ["view", "@anthropic-ai/claude-code", "dist-tags", "--json"],
+      JSON.stringify({ latest: "2.1.227", stable: "2.1.220" }),
+    );
+    installNpmStateCommands(
+      runner,
+      CLAUDE_CODE_DEFINITION,
+      "/Users/me/.npm-global",
+      null,
+    );
+    runner.setSuccess(
+      "claude",
+      ["doctor"],
+      ["Running: native (2.1.220)", "Auto-update channel: stable"].join("\n"),
+    );
+
+    const status = await inspectProviderCli({
+      definition: CLAUDE_CODE_DEFINITION,
+      runner,
+      nodePlatform: "darwin",
+    });
+
+    expect(status.currentVersion).toBe("2.1.220");
+    expect(status.latestVersion).toBe("2.1.220");
+    expect(status.needsUpdate).toBe(false);
+    expect(status.installAction).toBeNull();
   });
 
   it("does not report an update when the CLI version matches npm latest", async () => {
@@ -574,7 +669,7 @@ describe("provider CLI health", () => {
     expect(status.cursor.installed).toBe(true);
     expect(runner.commandLines()).toContain("npm view @openai/codex version");
     expect(runner.commandLines()).toContain(
-      "npm view @anthropic-ai/claude-code version",
+      "npm view @anthropic-ai/claude-code dist-tags --json",
     );
     expect(runner.commandLines()).toContain("which cursor-agent");
     expect(runner.commandLines()).not.toContain("npm view cursor version");

--- a/apps/host-daemon/src/provider-cli-health.ts
+++ b/apps/host-daemon/src/provider-cli-health.ts
@@ -18,6 +18,7 @@ import type { HostDaemonLogger } from "./logger.js";
 import { ensureNodePtySpawnHelperExecutable } from "./terminals/terminal-manager.js";
 
 const COMMAND_CHECK_TIMEOUT_MS = 5_000;
+const CLAUDE_DOCTOR_TIMEOUT_MS = 10_000;
 const NPM_VIEW_TIMEOUT_MS = 15_000;
 const NPM_INSTALL_STATE_TIMEOUT_MS = 5_000;
 const CLAUDE_CODE_INSTALL_SCRIPT_URL = "https://claude.ai/install.sh";
@@ -43,6 +44,24 @@ const npmGlobalListResponseSchema = z
       .default({}),
   })
   .passthrough();
+
+const npmDistTagsSchema = z
+  .object({
+    latest: z.string().min(1),
+    stable: z.string().min(1).optional(),
+  })
+  .passthrough();
+
+type ClaudeCodeInstallMethod =
+  | "native"
+  | "npm-global"
+  | "package-manager"
+  | "unknown";
+
+interface ClaudeCodeDoctorStatus {
+  installMethod: ClaudeCodeInstallMethod;
+  updateChannel: "latest" | "stable";
+}
 
 export interface ProviderCliDefinition {
   key: ProviderCliKey;
@@ -179,9 +198,11 @@ interface ResolveProviderCliInstallSourceArgs {
 interface BuildInstallActionArgs {
   definition: ProviderCliDefinition;
   installed: boolean;
+  installSource: ProviderCliInstallSource;
   needsUpdate: boolean;
   versionUnsupported: boolean;
   nodePlatform: NodeJS.Platform;
+  claudeCodeDoctorStatus: ClaudeCodeDoctorStatus | null;
 }
 
 interface CreateCommandResultArgs {
@@ -375,6 +396,58 @@ function parseNpmGlobalPackageVersion(
   }
 }
 
+function parseNpmDistTagVersion(
+  text: string,
+  channel: "latest" | "stable",
+): string | null {
+  const trimmedText = text.trim();
+  if (trimmedText.length === 0) {
+    return null;
+  }
+
+  try {
+    const parsed = npmDistTagsSchema.safeParse(JSON.parse(trimmedText));
+    if (!parsed.success) {
+      return null;
+    }
+    const version =
+      channel === "stable"
+        ? (parsed.data.stable ?? parsed.data.latest)
+        : parsed.data.latest;
+    return extractVersion(version);
+  } catch {
+    return null;
+  }
+}
+
+function parseClaudeCodeDoctorStatus(
+  text: string,
+): ClaudeCodeDoctorStatus | null {
+  const runningMatch = /^Running:\s+([^\s(]+)/mu.exec(text);
+  const channelMatch = /^Auto-update channel:\s+(latest|stable)\s*$/mu.exec(
+    text,
+  );
+  const rawInstallMethod = runningMatch?.[1];
+  const rawUpdateChannel = channelMatch?.[1];
+  if (
+    !rawInstallMethod ||
+    (rawUpdateChannel !== "latest" && rawUpdateChannel !== "stable")
+  ) {
+    return null;
+  }
+
+  const installMethod: ClaudeCodeInstallMethod =
+    rawInstallMethod === "native" || rawInstallMethod === "npm-global"
+      ? rawInstallMethod
+      : ["homebrew", "winget", "apt", "dnf", "apk"].includes(rawInstallMethod)
+        ? "package-manager"
+        : "unknown";
+  return {
+    installMethod,
+    updateChannel: rawUpdateChannel,
+  };
+}
+
 function needsProviderCliUpdate(args: NeedsProviderCliUpdateArgs): boolean {
   if (!args.installed || !args.currentVersion || !args.latestVersion) {
     return false;
@@ -521,9 +594,11 @@ function resolveExecutablePathStatus(whichResult: ProviderCliCommandResult): {
 function buildInstallAction({
   definition,
   installed,
+  installSource,
   needsUpdate,
   versionUnsupported,
   nodePlatform,
+  claudeCodeDoctorStatus,
 }: BuildInstallActionArgs): ProviderCliInstallAction | null {
   if (!installed) {
     const command = installActionCommand(definition, nodePlatform);
@@ -534,7 +609,13 @@ function buildInstallAction({
       command: command.displayCommand,
     };
   }
-  if (needsUpdate) {
+  const canRunUpdate =
+    definition.key !== "claudeCode" ||
+    claudeCodeDoctorStatus?.installMethod === "native" ||
+    (installSource === "npmGlobal" &&
+      (claudeCodeDoctorStatus === null ||
+        claudeCodeDoctorStatus.installMethod === "npm-global"));
+  if (needsUpdate && canRunUpdate) {
     const command = definition.updateCommand;
     return {
       kind: "update",
@@ -543,7 +624,7 @@ function buildInstallAction({
       command: command.displayCommand,
     };
   }
-  if (versionUnsupported) {
+  if (versionUnsupported && canRunUpdate) {
     const command = definition.updateCommand;
     return {
       kind: "update",
@@ -687,6 +768,7 @@ export async function inspectProviderCli({
     latestResult,
     npmPrefixResult,
     npmListResult,
+    claudeDoctorResult,
   ] = await Promise.all([
     runner.run({
       command: "which",
@@ -702,7 +784,10 @@ export async function inspectProviderCli({
       ? Promise.resolve(null)
       : runner.run({
           command: npmCommand,
-          args: ["view", npmPackageName, "version"],
+          args:
+            definition.key === "claudeCode"
+              ? ["view", npmPackageName, "dist-tags", "--json"]
+              : ["view", npmPackageName, "version"],
           timeoutMs: NPM_VIEW_TIMEOUT_MS,
         }),
     runner.run({
@@ -717,6 +802,13 @@ export async function inspectProviderCli({
           args: ["list", "-g", npmPackageName, "--depth=0", "--json"],
           timeoutMs: NPM_INSTALL_STATE_TIMEOUT_MS,
         }),
+    definition.key === "claudeCode"
+      ? runner.run({
+          command: definition.executableName,
+          args: ["doctor"],
+          timeoutMs: CLAUDE_DOCTOR_TIMEOUT_MS,
+        })
+      : Promise.resolve(null),
   ]);
 
   const { executablePath, installed } = resolveExecutableInstallStatus(
@@ -726,10 +818,21 @@ export async function inspectProviderCli({
   const currentVersion = isSuccessfulCommand(versionResult)
     ? extractVersion(`${versionResult.stdout}\n${versionResult.stderr}`)
     : null;
-  const latestVersion =
-    latestResult !== null && isSuccessfulCommand(latestResult)
-      ? extractVersion(`${latestResult.stdout}\n${latestResult.stderr}`)
+  const claudeCodeDoctorStatus =
+    claudeDoctorResult !== null && isSuccessfulCommand(claudeDoctorResult)
+      ? parseClaudeCodeDoctorStatus(
+          `${claudeDoctorResult.stdout}\n${claudeDoctorResult.stderr}`,
+        )
       : null;
+  const latestVersion =
+    latestResult === null || !isSuccessfulCommand(latestResult)
+      ? null
+      : definition.key === "claudeCode"
+        ? parseNpmDistTagVersion(
+            `${latestResult.stdout}\n${latestResult.stderr}`,
+            claudeCodeDoctorStatus?.updateChannel ?? "latest",
+          )
+        : extractVersion(`${latestResult.stdout}\n${latestResult.stderr}`);
   const npmGlobalPrefix = isSuccessfulCommand(npmPrefixResult)
     ? firstOutputLine(npmPrefixResult.stdout)
     : null;
@@ -759,9 +862,11 @@ export async function inspectProviderCli({
   const installAction = buildInstallAction({
     definition,
     installed,
+    installSource,
     needsUpdate,
     versionUnsupported,
     nodePlatform,
+    claudeCodeDoctorStatus,
   });
 
   return {

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -36,7 +36,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 104 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 105 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1056,12 +1056,12 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
-  // Version 104 makes terminal.close idempotent in the daemon. An enrolled
-  // daemon on an older build silently ignores a close for a terminal missing
-  // from its in-memory map, leaving the server row running and the panel tab
-  // impossible to close, so enrolled machines must update for the new behavior.
-  it("uses protocol version 104 for idempotent terminal closes", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(104);
+  // Version 105 makes Claude Code update status respect the active release
+  // channel and installation manager. Older daemons can keep advertising an
+  // update their active executable will never apply, so enrolled machines must
+  // update for the new behavior.
+  it("uses protocol version 105 for Claude Code update status", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(105);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {


### PR DESCRIPTION
## Summary

- respect Claude Code’s configured stable/latest release channel when checking versions
- only offer managed updates for native or matching npm-global installs, while surfacing external installs as manual updates
- verify that a successful update command actually advances the active executable and report actionable failures otherwise
- bump the host-daemon protocol for the changed provider status semantics

## Test plan

- `pnpm exec turbo run test --filter=@bb/host-daemon --filter=@bb/app --filter=@bb/cli --force`
- `pnpm exec turbo run test --filter=@bb/host-daemon-contract --force`
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon --filter=@bb/app --filter=@bb/cli --filter=@bb/host-daemon-contract`

Fixes #1331

> AGENT GENERATED: by GPT-5.6