### PR TITLE
Fix inherited thread storage root

### DIFF
--- a/apps/host-daemon/src/app.ts
+++ b/apps/host-daemon/src/app.ts
@@ -225,7 +225,7 @@ export async function createHostDaemonApp(
   const threadStorageRootPath = await ensureThreadStorageRoot(
     options.dataDir,
     options.threadStorageRootPath
-      ? { env: { BB_THREAD_STORAGE: options.threadStorageRootPath } }
+      ? { configuredRoot: options.threadStorageRootPath }
       : {},
   );
   const dataDirSkillsRootPath = await ensureDataDirSkillsRootPath(

--- a/apps/host-daemon/src/thread-storage-root.test.ts
+++ b/apps/host-daemon/src/thread-storage-root.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   ensureThreadStorageRoot,
   threadStorageRootPath,
@@ -16,6 +16,7 @@ async function makeTempDir(prefix: string): Promise<string> {
 }
 
 afterEach(async () => {
+  vi.unstubAllEnvs();
   await Promise.all(
     tempDirs.splice(0).map(async (dir) => {
       await fs.rm(dir, { force: true, recursive: true });
@@ -27,19 +28,31 @@ describe("thread storage root", () => {
   it("creates the shared thread-storage directory under the host data dir", async () => {
     const dataDir = await makeTempDir("bb-thread-storage-root-");
 
-    const rootPath = await ensureThreadStorageRoot(dataDir, { env: {} });
+    const rootPath = await ensureThreadStorageRoot(dataDir);
     const stats = await fs.stat(rootPath);
 
-    expect(rootPath).toBe(threadStorageRootPath(dataDir, { env: {} }));
+    expect(rootPath).toBe(threadStorageRootPath(dataDir));
     expect(stats.isDirectory()).toBe(true);
   });
 
-  it("uses BB_THREAD_STORAGE when provided", async () => {
+  it("ignores a parent agent thread's ambient storage path", async () => {
+    const dataDir = await makeTempDir("bb-thread-storage-root-data-");
+    const parentStorageRoot = await makeTempDir(
+      "bb-thread-storage-root-parent-",
+    );
+    vi.stubEnv("BB_THREAD_STORAGE", path.join(parentStorageRoot, "thr_parent"));
+
+    const rootPath = await ensureThreadStorageRoot(dataDir);
+
+    expect(rootPath).toBe(path.join(dataDir, "thread-storage"));
+  });
+
+  it("uses an explicitly configured root", async () => {
     const dataDir = await makeTempDir("bb-thread-storage-root-data-");
     const configuredRoot = await makeTempDir("bb-thread-storage-root-env-");
 
     const rootPath = await ensureThreadStorageRoot(dataDir, {
-      env: { BB_THREAD_STORAGE: configuredRoot },
+      configuredRoot,
     });
 
     expect(rootPath).toBe(configuredRoot);

--- a/apps/host-daemon/src/thread-storage-root.ts
+++ b/apps/host-daemon/src/thread-storage-root.ts
@@ -2,16 +2,14 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 interface ThreadStorageRootPathOptions {
-  env?: NodeJS.ProcessEnv;
+  configuredRoot?: string;
 }
-
-const THREAD_STORAGE_ENV_VAR = "BB_THREAD_STORAGE";
 
 export function threadStorageRootPath(
   dataDir: string,
   options: ThreadStorageRootPathOptions = {},
 ): string {
-  const configuredRoot = (options.env ?? process.env)[THREAD_STORAGE_ENV_VAR];
+  const configuredRoot = options.configuredRoot;
   if (configuredRoot && configuredRoot.trim().length > 0) {
     return path.resolve(configuredRoot);
   }

--- a/packages/bb-app/src/launcher.ts
+++ b/packages/bb-app/src/launcher.ts
@@ -1297,13 +1297,11 @@ export async function resolveBbAppRuntimeState(
   });
   const config = await readManagedConfig({ dataDir: initialContext.dataDir });
   const envFile = await readManagedEnvFile({ dataDir: initialContext.dataDir });
-  const managedEnv = stripThreadContextEnv(
-    applyManagedConfigEnv({
-      config,
-      envFile,
-      env: initialEnv,
-    }),
-  );
+  const managedEnv = applyManagedConfigEnv({
+    config,
+    envFile,
+    env: initialEnv,
+  });
 
   if (args.serverUrlMode === "local") {
     const localEnv = { ...managedEnv };
@@ -2448,12 +2446,12 @@ function createServerEnv(args: CreateServerEnvArgs): NodeJS.ProcessEnv {
   };
 }
 
-function createDaemonEnv(
+export function createDaemonEnv(
   context: BbAppStartContext,
   autoJoinEnv: NodeJS.ProcessEnv,
 ): NodeJS.ProcessEnv {
   return {
-    ...autoJoinEnv,
+    ...stripThreadContextEnv(autoJoinEnv),
     BB_APP_VERSION: context.appVersion,
     BB_BRIDGE_DIR: context.daemonBundleDir,
     BB_CLI_DIR: context.daemonBundleDir,
@@ -2489,7 +2487,7 @@ function createHostDaemonOnlyEnv(
   args: CreateHostDaemonOnlyEnvArgs,
 ): NodeJS.ProcessEnv {
   return {
-    ...args.env,
+    ...stripThreadContextEnv(args.env),
     BB_APP_VERSION: args.context.appVersion,
     BB_BRIDGE_DIR: args.context.daemonBundleDir,
     BB_CLI_DIR: args.context.daemonBundleDir,
@@ -2583,7 +2581,7 @@ export async function createHostDaemonJoinEnv(
   };
 }
 
-async function runBundledCliCommand(
+export async function runBundledCliCommand(
   args: RunBundledCliCommandArgs,
 ): Promise<number> {
   // Prefer the daemon-injected absolute CLI when present so packaged `bb`
@@ -3257,7 +3255,7 @@ export async function runBbApp(
   });
   const sharedEnv = createSharedEnv({
     context,
-    env: runtime.env,
+    env: stripThreadContextEnv(runtime.env),
   });
 
   process.stdout.write(`\n  ${bold("bb")}\n\n`);

--- a/packages/bb-app/src/launcher.ts
+++ b/packages/bb-app/src/launcher.ts
@@ -64,6 +64,7 @@ import {
   resolveDataDirDatabasePath,
   resolvePortFromEnv,
   resolveProdDataDir,
+  stripThreadContextEnv,
 } from "@bb/config/runtime";
 import { z } from "zod";
 
@@ -1296,20 +1297,24 @@ export async function resolveBbAppRuntimeState(
   });
   const config = await readManagedConfig({ dataDir: initialContext.dataDir });
   const envFile = await readManagedEnvFile({ dataDir: initialContext.dataDir });
-  const managedEnv = applyManagedConfigEnv({
-    config,
-    envFile,
-    env: initialEnv,
-  });
-
-  if (args.serverUrlMode === "local") {
-    const localEnv = { ...managedEnv };
-    const localServerEnv = createServerBaseEnv({
+  const managedEnv = stripThreadContextEnv(
+    applyManagedConfigEnv({
       config,
       envFile,
       env: initialEnv,
-      serverBindHostOverride: args.options.serverBindHost,
-    });
+    }),
+  );
+
+  if (args.serverUrlMode === "local") {
+    const localEnv = { ...managedEnv };
+    const localServerEnv = stripThreadContextEnv(
+      createServerBaseEnv({
+        config,
+        envFile,
+        env: initialEnv,
+        serverBindHostOverride: args.options.serverBindHost,
+      }),
+    );
     delete localEnv.BB_SERVER_URL;
     delete localServerEnv.BB_SERVER_URL;
     return {
@@ -1341,12 +1346,14 @@ export async function resolveBbAppRuntimeState(
       homeDir: args.homeDir,
     }),
     env: finalEnv,
-    serverEnv: createServerBaseEnv({
-      config,
-      envFile,
-      env: initialEnv,
-      serverBindHostOverride: args.options.serverBindHost,
-    }),
+    serverEnv: stripThreadContextEnv(
+      createServerBaseEnv({
+        config,
+        envFile,
+        env: initialEnv,
+        serverBindHostOverride: args.options.serverBindHost,
+      }),
+    ),
   };
 }
 

--- a/packages/bb-app/test/index.test.ts
+++ b/packages/bb-app/test/index.test.ts
@@ -775,6 +775,30 @@ describe("bb-app launcher", () => {
     expect(runtime.serverEnv.BB_SERVER_BIND_HOST).toBe("0.0.0.0");
   });
 
+  it("strips parent thread context from production child processes", async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "bb-app-thread-context-"));
+    const runtime = await resolveBbAppRuntimeState({
+      entrypointUrl: pathToFileURL("/repo/packages/bb-app/dist/bb-app.js").href,
+      env: {
+        BB_DATA_DIR: dataDir,
+        BB_ENVIRONMENT_ID: "env_parent",
+        BB_PROJECT_ID: "proj_parent",
+        BB_THREAD_ID: "thr_parent",
+        BB_THREAD_STORAGE: "/home/tester/.bb/thread-storage/thr_parent",
+      },
+      homeDir: "/home/tester",
+      options: { help: false },
+      serverUrlMode: "local",
+    });
+
+    for (const env of [runtime.env, runtime.serverEnv]) {
+      expect(env.BB_ENVIRONMENT_ID).toBeUndefined();
+      expect(env.BB_THREAD_ID).toBeUndefined();
+      expect(env.BB_THREAD_STORAGE).toBeUndefined();
+      expect(env.BB_PROJECT_ID).toBe("proj_parent");
+    }
+  });
+
   it("rejects an invalid server bind host before launcher startup", async () => {
     const dataDir = mkdtempSync(join(tmpdir(), "bb-app-invalid-bind-host-"));
 

--- a/packages/bb-app/test/index.test.ts
+++ b/packages/bb-app/test/index.test.ts
@@ -31,8 +31,10 @@ import {
 } from "../src/index.js";
 import {
   completeFullStackSupervision,
+  createDaemonEnv,
   createHostDaemonJoinEnv,
   readBbAppPackageVersion,
+  runBundledCliCommand,
   superviseFullStackProcesses,
   terminateManagedFullStackProcesses,
   waitForHostDaemonStatus,
@@ -775,7 +777,7 @@ describe("bb-app launcher", () => {
     expect(runtime.serverEnv.BB_SERVER_BIND_HOST).toBe("0.0.0.0");
   });
 
-  it("strips parent thread context from production child processes", async () => {
+  it("strips parent thread context from the production server without stripping the CLI", async () => {
     const dataDir = mkdtempSync(join(tmpdir(), "bb-app-thread-context-"));
     const runtime = await resolveBbAppRuntimeState({
       entrypointUrl: pathToFileURL("/repo/packages/bb-app/dist/bb-app.js").href,
@@ -791,12 +793,36 @@ describe("bb-app launcher", () => {
       serverUrlMode: "local",
     });
 
-    for (const env of [runtime.env, runtime.serverEnv]) {
-      expect(env.BB_ENVIRONMENT_ID).toBeUndefined();
-      expect(env.BB_THREAD_ID).toBeUndefined();
-      expect(env.BB_THREAD_STORAGE).toBeUndefined();
-      expect(env.BB_PROJECT_ID).toBe("proj_parent");
-    }
+    expect(runtime.serverEnv.BB_ENVIRONMENT_ID).toBeUndefined();
+    expect(runtime.serverEnv.BB_THREAD_ID).toBeUndefined();
+    expect(runtime.serverEnv.BB_THREAD_STORAGE).toBeUndefined();
+    expect(runtime.serverEnv.BB_PROJECT_ID).toBe("proj_parent");
+
+    const daemonEnv = createDaemonEnv(runtime.context, runtime.env);
+    expect(daemonEnv.BB_ENVIRONMENT_ID).toBeUndefined();
+    expect(daemonEnv.BB_THREAD_ID).toBeUndefined();
+    expect(daemonEnv.BB_THREAD_STORAGE).toBeUndefined();
+    expect(daemonEnv.BB_PROJECT_ID).toBe("proj_parent");
+
+    expect(runtime.env.BB_ENVIRONMENT_ID).toBe("env_parent");
+    expect(runtime.env.BB_THREAD_ID).toBe("thr_parent");
+    expect(runtime.env.BB_THREAD_STORAGE).toBe(
+      "/home/tester/.bb/thread-storage/thr_parent",
+    );
+
+    const cliThreadIdPath = join(dataDir, "cli-thread-id.txt");
+    const exitCode = await runBundledCliCommand({
+      args: [
+        "-e",
+        "require('node:fs').writeFileSync(process.argv[1], process.env.BB_THREAD_ID ?? 'missing')",
+        cliThreadIdPath,
+      ],
+      context: runtime.context,
+      env: { ...runtime.env, BB_CLI: process.execPath },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(readFileSync(cliThreadIdPath, "utf8")).toBe("thr_parent");
   });
 
   it("rejects an invalid server bind host before launcher startup", async () => {

--- a/packages/config/src/runtime.ts
+++ b/packages/config/src/runtime.ts
@@ -92,7 +92,7 @@ const DEV_SERVER_PORT_BASE = 19_000;
 const DEV_HOST_DAEMON_PORT_BASE = 27_000;
 const DEV_CLOUD_PORT_BASE = 35_000;
 const DEV_CLOUD_WORKER_PORT_BASE = 43_000;
-const DEV_PROCESS_STRIPPED_ENV_KEYS: readonly string[] = [
+const THREAD_CONTEXT_ENV_KEYS: readonly string[] = [
   "BB_ENVIRONMENT_ID",
   "BB_THREAD_ID",
   "BB_THREAD_STORAGE",
@@ -304,11 +304,23 @@ export function resolvePortFromEnv(args: ResolvePortFromEnvArgs): number {
   });
 }
 
-export function toDevProcessEnv(args: DevProcessEnvArgs): NodeJS.ProcessEnv {
-  const env = { ...args.baseEnv };
-  for (const key of DEV_PROCESS_STRIPPED_ENV_KEYS) {
+/**
+ * Remove context that bb injects into an agent shell for one specific thread.
+ * Long-lived server and daemon processes must never adopt that identity or the
+ * thread-specific storage directory as process-wide configuration.
+ */
+export function stripThreadContextEnv(
+  baseEnv: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const env = { ...baseEnv };
+  for (const key of THREAD_CONTEXT_ENV_KEYS) {
     delete env[key];
   }
+  return env;
+}
+
+export function toDevProcessEnv(args: DevProcessEnvArgs): NodeJS.ProcessEnv {
+  const env = stripThreadContextEnv(args.baseEnv);
   const inheritedSkillsRootPaths = resolveInheritedDevSkillsRootPaths({
     homeDir: args.config.homeDir,
     repoRoot: args.config.repoRoot,


### PR DESCRIPTION
## Summary

- strip per-thread context only from long-lived production server and daemon environments while preserving it for the bundled `bb` CLI
- make the host daemon derive its shared thread-storage root from its data directory unless an explicit programmatic override is supplied
- add production-launcher, CLI-context, and host-daemon regressions for an inherited parent `BB_THREAD_STORAGE`

## Confirmed mechanism

Commit `1688734bb1bfdb26a844f868bf7f3d07ab9b0c2b` made the server derive per-host thread paths from the host session data directory instead of ambient `BB_THREAD_STORAGE`, but the daemon still adopted ambient `BB_THREAD_STORAGE` as its global root. When bb starts with a parent thread's environment, the daemon root narrows to the parent thread directory while the server sends a sibling worker path. `requireConfinedPath` correctly rejects that sibling as escaping the narrowed root.

The standalone QA launcher and dev launcher already strip this context. The production launcher did not. This PR fixes both layers: production child processes are sanitized and the daemon no longer treats ambient per-thread context as global configuration.

## Reproduction

I ran the issue's exact `pathprobe` workflow with Claude Haiku from a real bb-managed worktree:

| Build and launch | Result |
| --- | --- |
| Signed Desktop 0.37.0 artifact, clean environment | succeeded: `{"r":"ok"}` |
| Signed Desktop auto-update 0.36.0 → 0.37.0, same isolated data/profile and managed-worktree origin | succeeded before and after: `{"r":"ok"}` |
| npm `bb-app@0.37.0`, clean environment | succeeded: `{"r":"ok"}` |
| npm `bb-app@0.36.0`, clean environment | succeeded: `{"r":"ok"}` |
| Signed Desktop 0.37.0 launched by the reporter's agent via `open -a` with inherited thread context | failed with the exact `Thread storage path escapes the storage root` log |
| npm `bb-app@0.37.0` with the same inherited context | failed identically |
| npm `bb-app@0.36.0` with the same inherited context | failed identically |
| This PR with the same inherited context and existing 0.37 data | succeeded: `{"r":"ok"}` |

The reporter subsequently reconstructed the timeline and confirmed both the failing and passing runs were on 0.37.0. The failing instance was installed and launched with `open -a` by a detached script started from a bb agent shell, which propagated that thread's environment into Desktop. The passing instance was cleanly relaunched by the built-in updater. This matches the controlled matrix exactly: the split is contaminated agent launch versus clean updater launch, not 0.36.0 versus 0.37.0.

The divergence was introduced by commit `1688734bb1bfdb26a844f868bf7f3d07ab9b0c2b` (`Inject global app skills into agent runtimes`): the server began deriving storage from the host session data directory while the daemon still adopted ambient `BB_THREAD_STORAGE`. The confinement check predates that commit. No commit in the 0.36.0..0.37.0 range introduced this failure.

Users do not need to roll back: fully quit the contaminated Desktop instance and relaunch it from Finder, Dock, the updater, or another environment without thread-scoped `BB_*` variables.

## Verification

- `pnpm exec turbo run test --filter=@bb/host-daemon --force` — 537 passed
- `pnpm exec turbo run test --filter=bb-app --filter=@bb/config --force` — 171 passed
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon --filter=bb-app --filter=@bb/config`
- the host-daemon regression fails with the ambient lookup restored, receiving the parent thread path instead of `<dataDir>/thread-storage`
- the production launcher test executes the bundled CLI child path and verifies that CLI thread context is retained while server/daemon context is removed

No `HOST_DAEMON_PROTOCOL_VERSION` bump is needed because no server/daemon message or RPC contract changes.

Fixes #1366

> AGENT GENERATED: by GPT-5.6




