### PR TITLE
Show pushed PRs in thread sidebar

### DIFF
--- a/apps/app/src/components/sidebar/ThreadRow.test.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.test.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from "react";
 import { createStore, Provider } from "jotai";
 import type { ThreadListEntry } from "@bb/domain";
 import type { PluginComposerThreadRowStatus } from "@bb/plugin-sdk";
+import type { EnvironmentPullRequestResponse } from "@bb/server-contract";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ThreadRow, type ThreadRowOptions } from "./ThreadRow";
 import { SidebarThreadTitleMentionResourcesProvider } from "./SidebarThreadTitleMentions";
@@ -24,6 +25,19 @@ import {
 import { splitLayoutAtom } from "@/lib/split-layout/atoms";
 import { SPLIT_LAYOUT_STORAGE_KEY } from "@/lib/split-layout/persistence";
 import { NO_COLLAPSED_CHILD_ACTIVITY } from "@/lib/thread-activity";
+
+const { mockUseEnvironmentPullRequest } = vi.hoisted(() => ({
+  mockUseEnvironmentPullRequest: vi.fn<
+    () => { data: EnvironmentPullRequestResponse | undefined }
+  >(() => ({ data: undefined })),
+}));
+
+vi.mock("@/hooks/queries/environment-queries", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@/hooks/queries/environment-queries")
+  >()),
+  useEnvironmentPullRequest: mockUseEnvironmentPullRequest,
+}));
 
 vi.mock("@/hooks/useThreadSplitsEnabled", () => ({
   useThreadSplitsEnabled: () => true,
@@ -225,6 +239,8 @@ function renderSplitThreadRow({
 
 afterEach(() => {
   cleanup();
+  mockUseEnvironmentPullRequest.mockReset();
+  mockUseEnvironmentPullRequest.mockReturnValue({ data: undefined });
   resetPluginThreadRowStatusesForTest();
   // The layout is tab-scoped, so it lands in both stores (createTabScopedStorage).
   window.localStorage.removeItem(SPLIT_LAYOUT_STORAGE_KEY);
@@ -1206,6 +1222,65 @@ describe("ThreadRow", () => {
 
     expect(screen.getByLabelText("Unread thread succeeded")).not.toBeNull();
     expect(container.querySelector('[data-icon="CircleCheck"]')).toBeNull();
+  });
+
+  it("shows GitHub for an unread successful thread with a pull request", () => {
+    mockUseEnvironmentPullRequest.mockReturnValue({
+      data: {
+        outcome: "available",
+        pullRequest: {
+          number: 412,
+          title: "Ship the sidebar indicator",
+          url: "https://github.com/get-bb/bb/pull/412",
+          state: "open",
+          baseRefName: "main",
+          headRefName: "codex/sidebar-pr-indicator",
+          updatedAt: "2026-08-11T12:00:00.000Z",
+          checks: {
+            state: "passing",
+            totalCount: 1,
+            passedCount: 1,
+            failedCount: 0,
+            pendingCount: 0,
+          },
+          review: { state: "none", reviewRequestCount: 0 },
+          mergeability: {
+            state: "mergeable",
+            mergeStateStatus: "CLEAN",
+            mergeable: "MERGEABLE",
+          },
+          attention: "ready_to_merge",
+        },
+      },
+    });
+    const { container, rerenderThreadRow } = renderThreadRow({
+      thread: createThread({
+        environmentId: "env_test",
+        status: "idle",
+        lastReadAt: 1_000,
+        latestAttentionAt: 2_000,
+      }),
+    });
+
+    expect(
+      screen.getByLabelText("Pull request pushed to GitHub"),
+    ).not.toBeNull();
+    expect(container.querySelector('[data-icon="Github"]')).not.toBeNull();
+    expect(screen.queryByLabelText("Unread thread succeeded")).toBeNull();
+    expect(mockUseEnvironmentPullRequest).toHaveBeenCalledOnce();
+    expect(mockUseEnvironmentPullRequest).toHaveBeenCalledWith("env_test");
+
+    rerenderThreadRow(
+      createThread({
+        environmentId: "env_test",
+        status: "idle",
+        lastReadAt: 2_000,
+        latestAttentionAt: 2_000,
+      }),
+    );
+
+    expect(screen.queryByLabelText("Pull request pushed to GitHub")).toBeNull();
+    expect(mockUseEnvironmentPullRequest).toHaveBeenCalledOnce();
   });
 
   it("switches directly from working to the settled done dot after finishing", () => {

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -73,6 +73,10 @@ import { AppCommandShortcutPill } from "@/components/commands/AppCommandShortcut
 import { useThreadTitleDisplayText } from "@/components/thread/ThreadTitleMentions";
 import { pluginIconName } from "@/components/plugin/PluginIcon";
 import { usePluginThreadRowStatus } from "@/lib/plugin-thread-row-status";
+import {
+  getEnvironmentPullRequestFromResponse,
+  useEnvironmentPullRequest,
+} from "@/hooks/queries/environment-queries";
 
 interface ThreadRowBaseOptions {
   depth: number;
@@ -411,7 +415,35 @@ export function CollapsedThreadStatusGlyph({
 }
 type ThreadTrailingIndicatorProps = ThreadStatusGlyphProps & {
   pluginStatus: PluginComposerThreadRowStatus | null;
+  unreadPullRequestEnvironmentId: string | null;
 };
+
+function UnreadPullRequestIndicator({
+  environmentId,
+  fallback,
+}: {
+  environmentId: string;
+  fallback: ReactNode;
+}) {
+  const query = useEnvironmentPullRequest(environmentId);
+  const pullRequest = getEnvironmentPullRequestFromResponse(query.data);
+
+  if (pullRequest === null) {
+    return fallback;
+  }
+
+  return (
+    <Icon
+      name="Github"
+      className={cn(
+        "pointer-events-none shrink-0",
+        COARSE_POINTER_ICON_SIZE_CLASS,
+        SIDEBAR_SUCCESS_STATUS_COLOR_CLASS,
+      )}
+      aria-label="Pull request pushed to GitHub"
+    />
+  );
+}
 
 interface ThreadTrailingIndicatorResolution {
   accessibleLabel: string | null;
@@ -441,6 +473,7 @@ function resolveThreadTrailingIndicatorStatus(
 
 function ThreadTrailingIndicator({
   pluginStatus,
+  unreadPullRequestEnvironmentId,
   ...statusProps
 }: ThreadTrailingIndicatorProps) {
   const { indicatorKind, pluginStatusIsVisible } =
@@ -458,7 +491,19 @@ function ThreadTrailingIndicator({
         COARSE_POINTER_GLYPH_BOX_CLASS,
       )}
     >
-      {pluginStatusIsVisible && pluginStatus ? (
+      {indicatorKind === "unread-success" &&
+      unreadPullRequestEnvironmentId !== null ? (
+        <UnreadPullRequestIndicator
+          environmentId={unreadPullRequestEnvironmentId}
+          fallback={
+            pluginStatusIsVisible && pluginStatus ? (
+              <PluginThreadRowStatusIndicator status={pluginStatus} />
+            ) : (
+              <ThreadStatusGlyph {...statusProps} />
+            )
+          }
+        />
+      ) : pluginStatusIsVisible && pluginStatus ? (
         <PluginThreadRowStatusIndicator status={pluginStatus} />
       ) : (
         <ThreadStatusGlyph {...statusProps} />
@@ -695,6 +740,9 @@ function ThreadRowComponent({
                 ) : (
                   <ThreadTrailingIndicator
                     {...trailingIndicatorState}
+                    unreadPullRequestEnvironmentId={
+                      threadUnreadSuccess ? thread.environmentId : null
+                    }
                     hideIdleDraftLabel={
                       !hasHiddenChildren && trailingIndicatorKind === "draft"
                     }


### PR DESCRIPTION
## What changed

- Show a GitHub icon in the thread sidebar when an unread completed thread has an associated pull request.
- Keep the existing success indicator when no pull request is associated.
- Stop the pull-request lookup and remove the icon once the thread is read.

## Why

Completed coding threads can be waiting on review after pushing a PR, but the generic success dot does not distinguish that handoff. The GitHub mark makes the review-ready state visible without keeping stale decoration after the thread is opened.

## Validation

- `pnpm exec turbo run test --filter=@bb/app --force` (336 files, 2543 tests)
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app`
- `pnpm exec prettier --check apps/app/src/components/sidebar/ThreadRow.tsx apps/app/src/components/sidebar/ThreadRow.test.tsx`

> AGENT GENERATED: by GPT-5.6 Codex
