### PR TITLE
Fix new-thread panel tab creation

### DIFF
--- a/apps/app/src/views/RootComposeSecondaryContent.test.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.test.tsx
@@ -113,15 +113,18 @@ vi.mock("@/components/secondary-panel/ThreadSecondaryPanel", async () => {
     browserDeck,
     isOpen,
     renderAsDrawer,
+    showNewTabButton,
   }: {
     browserDeck?: ReactNode;
     isOpen: boolean;
     renderAsDrawer: boolean;
+    showNewTabButton?: boolean;
   }) =>
     React.createElement(
       "section",
       {
         "data-open": String(isOpen),
+        "data-show-new-tab-button": String(showNewTabButton),
         "data-testid": renderAsDrawer
           ? "drawer-secondary-panel"
           : "inline-secondary-panel",
@@ -230,6 +233,19 @@ afterEach(() => {
 });
 
 describe("RootComposeSecondaryContent desktop layout", () => {
+  it("always offers a new tab from the new-thread right panel", () => {
+    renderRootCompose({
+      isCompactViewport: false,
+      isSecondaryPanelOpen: true,
+    });
+
+    expect(
+      screen
+        .getByTestId("inline-secondary-panel")
+        .getAttribute("data-show-new-tab-button"),
+    ).toBe("true");
+  });
+
   it("marks the root compose top strip as a macOS window drag region", () => {
     setMacosDesktopChrome();
 

--- a/apps/app/src/views/RootComposeSecondaryContent.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.tsx
@@ -73,6 +73,7 @@ type RootSecondaryPanelProps = Omit<
   | "isConversationCollapsed"
   | "onToggleConversationCollapse"
   | "renderAsDrawer"
+  | "showNewTabButton"
 > & {
   renderBrowserDeck?: (args: {
     canShowNativeBrowserView: boolean;
@@ -260,6 +261,7 @@ export function RootComposeSecondaryContent({
           renderAsDrawer={false}
           isConversationCollapsed={false}
           onToggleConversationCollapse={noopToggleConversationCollapse}
+          showNewTabButton
           // In the split-workspace host, panes' panels share one PanelGroup,
           // so each pane's Panel needs its own layout identity (see the prop
           // doc).
@@ -285,6 +287,7 @@ export function RootComposeSecondaryContent({
       renderAsDrawer={true}
       isConversationCollapsed={false}
       onToggleConversationCollapse={noopToggleConversationCollapse}
+      showNewTabButton
     />
   ) : null;
   const hostedPanelModel = useMemo<PaneSecondaryPanelViewModel>(

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -3526,7 +3526,6 @@ export function RootComposeView() {
             showConversationCollapseControl: false,
             showGitDiffTab: false,
             showInfoTab: false,
-            showNewTabButton: false,
             inlinePanelToggle: panelTogglePlacement.inlinePanelToggle,
             onClose: closeSecondaryPanel,
             onCollapse: closeSecondaryPanel,


### PR DESCRIPTION
## Summary

- restore the new-tab button in the new-thread right panel
- enforce the control for both desktop and compact panel layouts
- add regression coverage for the root compose panel contract

## Verification

- `pnpm exec turbo run test --filter=@bb/app --force -- src/views/RootComposeSecondaryContent.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app`

> AGENT GENERATED: by GPT-5