### PR TITLE
Add macOS agent completion notifications

### DIFF
--- a/apps/app/src/components/layout/AppLayout.root-compose-project.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.root-compose-project.test.tsx
@@ -2,7 +2,7 @@
 
 import { cleanup, render, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppLayout } from "./AppLayout";
 
@@ -10,6 +10,7 @@ const ROOT_COMPOSE_PROJECT_ID_STORAGE_KEY = "bb.root-compose.project-id";
 
 const mockUseThread = vi.hoisted(() => vi.fn());
 const mockUseThreadDetailBootstrap = vi.hoisted(() => vi.fn());
+const mockGetBbDesktopInfo = vi.hoisted(() => vi.fn());
 
 vi.mock("@/components/sidebar/AppSidebar", () => ({
   AppSidebar: () => <aside data-testid="app-sidebar" />,
@@ -78,7 +79,7 @@ vi.mock("@/lib/bb-desktop", () => ({
   MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS: "",
   MACOS_WINDOW_DRAG_CLASS: "",
   MACOS_WINDOW_NO_DRAG_CLASS: "",
-  getBbDesktopInfo: () => null,
+  getBbDesktopInfo: () => mockGetBbDesktopInfo(),
   shouldReserveMacosTrafficLights: () => false,
   shouldUseMacosDesktopChrome: () => false,
 }));
@@ -145,6 +146,7 @@ vi.mock("@/hooks/queries/thread-queries", () => ({
 describe("AppLayout root compose project preference", () => {
   beforeEach(() => {
     window.localStorage.clear();
+    mockGetBbDesktopInfo.mockReturnValue(null);
     mockUseThread.mockReturnValue({
       data: {
         id: "thr_opened",
@@ -190,5 +192,54 @@ describe("AppLayout root compose project preference", () => {
     expect(
       window.localStorage.getItem(ROOT_COMPOSE_PROJECT_ID_STORAGE_KEY),
     ).toBe("proj_last_run");
+  });
+
+  it("handles desktop thread requests with in-app router navigation", async () => {
+    const openThreadListeners = new Set<
+      (request: { projectId: string | null; threadId: string }) => void
+    >();
+    mockGetBbDesktopInfo.mockReturnValue({
+      onOpenThread(
+        listener: (request: {
+          projectId: string | null;
+          threadId: string;
+        }) => void,
+      ) {
+        openThreadListeners.add(listener);
+        return () => openThreadListeners.delete(listener);
+      },
+    });
+
+    function RouteProbe() {
+      return <div data-testid="route-path">{useLocation().pathname}</div>;
+    }
+
+    const rendered = render(
+      <MemoryRouter initialEntries={["/"]}>
+        <AppLayout>
+          <RouteProbe />
+        </AppLayout>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(openThreadListeners.size).toBe(1));
+    for (const listener of openThreadListeners) {
+      listener({ projectId: "proj_opened", threadId: "thr_opened" });
+    }
+
+    await waitFor(() => {
+      expect(rendered.getByTestId("route-path").textContent).toBe(
+        "/projects/proj_opened/threads/thr_opened",
+      );
+    });
+
+    for (const listener of openThreadListeners) {
+      listener({ projectId: null, threadId: "thr_personal" });
+    }
+    await waitFor(() => {
+      expect(rendered.getByTestId("route-path").textContent).toBe(
+        "/threads/thr_personal",
+      );
+    });
   });
 });

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAtom, useStore } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import { Link, matchPath, useLocation, useNavigate } from "react-router-dom";
+import { PERSONAL_PROJECT_ID } from "@bb/domain";
 import type { ProjectResponse } from "@bb/server-contract";
 import { Icon } from "@bb/shared-ui/icon";
 import { RESOURCE_ROUTE_LABEL_EVENT } from "@bb/shared-ui/resource-list";
@@ -453,6 +454,20 @@ export function AppLayout({ children }: AppLayoutProps) {
     toolsBackRoutePath,
     toolsRoutePath,
   } = useAppSettingsRouteMemory();
+  useEffect(() => {
+    const desktop = getBbDesktopInfo();
+    if (desktop?.onOpenThread === undefined) {
+      return;
+    }
+    return desktop.onOpenThread((request) => {
+      void navigate(
+        getThreadRoutePath({
+          projectId: request.projectId ?? PERSONAL_PROJECT_ID,
+          threadId: request.threadId,
+        }),
+      );
+    });
+  }, [navigate]);
   useEffect(
     () =>
       wsManager.onThreadOpen((signal) => {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -32,6 +32,7 @@
     "@bb/config": "workspace:*",
     "@bb/desktop-contract": "workspace:*",
     "@bb/domain": "workspace:*",
+    "@bb/sdk": "workspace:*",
     "@bb/server-contract": "workspace:*",
     "@bb/tsconfig": "workspace:*",
     "@types/node": "^24.9.0",

--- a/apps/desktop/scripts/build.mjs
+++ b/apps/desktop/scripts/build.mjs
@@ -44,6 +44,7 @@ const commonOptions = {
 await Promise.all([
   build({
     ...commonOptions,
+    conditions: ["source"],
     entryPoints: [resolve(packageRoot, "src", "main.ts")],
     external: ["electron"],
     format: "cjs",

--- a/apps/desktop/src/desktop-authenticated-websocket.ts
+++ b/apps/desktop/src/desktop-authenticated-websocket.ts
@@ -1,0 +1,90 @@
+import type { BbRealtimeSocket, BbRealtimeSocketFactory } from "@bb/sdk";
+
+interface CreateDesktopAuthenticatedWebsocketFactoryArgs {
+  headers(url: string): Promise<Record<string, string> | undefined>;
+}
+
+interface ElectronNodeWebSocketConstructor {
+  new (url: string, options?: WebSocketInit): WebSocket;
+}
+
+function openElectronNodeWebSocket(
+  url: string,
+  headers: Record<string, string> | undefined,
+): WebSocket {
+  // Electron's Node runtime supports Undici's WebSocketInit extension, while
+  // Electron's ambient DOM declaration exposes only the browser overload.
+  const WebSocketWithHeaders = WebSocket as ElectronNodeWebSocketConstructor;
+  return new WebSocketWithHeaders(url, headers ? { headers } : undefined);
+}
+
+export function createDesktopAuthenticatedWebsocketFactory(
+  args: CreateDesktopAuthenticatedWebsocketFactoryArgs,
+): BbRealtimeSocketFactory {
+  return (url) => {
+    let socket: WebSocket | null = null;
+    let closed = false;
+    let closeEmitted = false;
+
+    const emitClose = (): void => {
+      if (closeEmitted) {
+        return;
+      }
+      closeEmitted = true;
+      adapter.onclose?.();
+    };
+    const adapter: BbRealtimeSocket = {
+      close() {
+        if (closed) {
+          return;
+        }
+        closed = true;
+        if (socket === null) {
+          emitClose();
+          return;
+        }
+        socket.close();
+      },
+      onclose: null,
+      onerror: null,
+      onmessage: null,
+      onopen: null,
+      get readyState() {
+        return (
+          socket?.readyState ??
+          (closed ? WebSocket.CLOSED : WebSocket.CONNECTING)
+        );
+      },
+      send(data) {
+        if (socket === null) {
+          throw new Error("WebSocket opened before authentication completed");
+        }
+        socket.send(data);
+      },
+    };
+
+    void args.headers(url).then(
+      (headers) => {
+        if (closed) {
+          return;
+        }
+        socket = openElectronNodeWebSocket(url, headers);
+        socket.onopen = () => adapter.onopen?.();
+        socket.onmessage = (event) => adapter.onmessage?.({ data: event.data });
+        socket.onclose = emitClose;
+        socket.onerror = () => adapter.onerror?.();
+      },
+      () => {
+        if (closed) {
+          return;
+        }
+        adapter.onerror?.();
+        if (!closed) {
+          adapter.close();
+        }
+      },
+    );
+
+    return adapter;
+  };
+}

--- a/apps/desktop/src/desktop-completion-notifications.ts
+++ b/apps/desktop/src/desktop-completion-notifications.ts
@@ -1,0 +1,324 @@
+import { PERSONAL_PROJECT_ID, type Thread } from "@bb/domain";
+import type { BbRealtimeConnectionEvent, ThreadRealtimeEvent } from "@bb/sdk";
+
+export const COMPLETION_NOTIFICATION_SETTLE_MS = 300;
+export const COMPLETION_NOTIFICATION_RETRY_MS = 1_000;
+export const COMPLETION_NOTIFICATION_TITLE_MAX_LENGTH = 80;
+
+const COMPLETION_NOTIFICATION_TITLE_SUFFIX = ": has finished";
+
+export interface DesktopCompletionNotification {
+  outcome: "completed" | "failed";
+  projectId: string | null;
+  threadId: string;
+  title: string;
+}
+
+export interface DesktopCompletionNotificationWatcher {
+  stop(): void;
+}
+
+export function formatDesktopCompletionNotificationTitle(
+  threadTitle: string,
+): string {
+  const maxThreadTitleLength =
+    COMPLETION_NOTIFICATION_TITLE_MAX_LENGTH -
+    COMPLETION_NOTIFICATION_TITLE_SUFFIX.length;
+  const characters = Array.from(threadTitle);
+  const displayTitle =
+    characters.length > maxThreadTitleLength
+      ? `${characters.slice(0, maxThreadTitleLength - 1).join("")}…`
+      : threadTitle;
+  return `${displayTitle}${COMPLETION_NOTIFICATION_TITLE_SUFFIX}`;
+}
+
+export type DesktopCompletionThread = Pick<
+  Thread,
+  | "id"
+  | "latestAttentionAt"
+  | "parentThreadId"
+  | "projectId"
+  | "status"
+  | "title"
+  | "titleFallback"
+>;
+
+interface CreateDesktopCompletionNotificationWatcherArgs {
+  fetchThread(
+    threadId: string,
+    signal: AbortSignal,
+  ): Promise<DesktopCompletionThread | null>;
+  listThreads(signal: AbortSignal): Promise<readonly DesktopCompletionThread[]>;
+  notify(notification: DesktopCompletionNotification): void;
+  subscribeToConnection(
+    listener: (event: BbRealtimeConnectionEvent) => void,
+  ): () => void;
+  subscribeToThreadChanges(
+    listener: (event: ThreadRealtimeEvent) => void,
+  ): () => void;
+  warn(message: string): void;
+}
+
+interface ResolveDesktopCompletionNotificationArgs {
+  candidate: boolean;
+  current: DesktopCompletionThread;
+  previous: DesktopCompletionThread | undefined;
+}
+
+export function formatDesktopCompletionThreadUrl(
+  appUrl: string,
+  completion: Pick<DesktopCompletionNotification, "projectId" | "threadId">,
+): string {
+  const url = new URL(appUrl);
+  const threadPath = `threads/${encodeURIComponent(completion.threadId)}`;
+  url.pathname =
+    completion.projectId === null
+      ? `/${threadPath}`
+      : `/projects/${encodeURIComponent(completion.projectId)}/${threadPath}`;
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
+function threadDisplayTitle(thread: DesktopCompletionThread): string {
+  const title = thread.title?.trim();
+  if (title) {
+    return title;
+  }
+  const fallback = thread.titleFallback?.trim();
+  if (fallback) {
+    return fallback;
+  }
+  return `Thread ${thread.id.slice(0, 8)}`;
+}
+
+function isSettledRootThread(thread: DesktopCompletionThread): boolean {
+  return (
+    thread.parentThreadId === null &&
+    (thread.status === "idle" || thread.status === "error")
+  );
+}
+
+export function resolveDesktopCompletionNotification({
+  candidate,
+  current,
+  previous,
+}: ResolveDesktopCompletionNotificationArgs): DesktopCompletionNotification | null {
+  if (!isSettledRootThread(current)) {
+    return null;
+  }
+  const completedSincePreviousSnapshot =
+    previous !== undefined &&
+    !isSettledRootThread(previous) &&
+    current.latestAttentionAt > previous.latestAttentionAt;
+  if (!candidate && !completedSincePreviousSnapshot) {
+    return null;
+  }
+  return {
+    outcome: current.status === "error" ? "failed" : "completed",
+    projectId:
+      current.projectId === PERSONAL_PROJECT_ID ? null : current.projectId,
+    threadId: current.id,
+    title: threadDisplayTitle(current),
+  };
+}
+
+function isCompletionCandidate(event: ThreadRealtimeEvent): boolean {
+  const eventTypes = event.metadata?.eventTypes;
+  return (
+    event.id !== undefined &&
+    eventTypes?.includes("system/thread/interrupted") !== true &&
+    (eventTypes?.includes("turn/completed") === true ||
+      eventTypes?.includes("system/error") === true)
+  );
+}
+
+function threadMap(
+  threads: readonly DesktopCompletionThread[],
+): Map<string, DesktopCompletionThread> {
+  return new Map(threads.map((thread) => [thread.id, thread]));
+}
+
+export function createDesktopCompletionNotificationWatcher(
+  args: CreateDesktopCompletionNotificationWatcherArgs,
+): DesktopCompletionNotificationWatcher {
+  const abortController = new AbortController();
+  const completionCandidates = new Set<string>();
+  const lastNotifiedAttentionAt = new Map<string, number>();
+  const refreshTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const refreshVersions = new Map<string, number>();
+  let knownThreads: Map<string, DesktopCompletionThread> | null = null;
+  let reconcileShouldNotify = false;
+  let reconcileTimer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+  let workQueue = Promise.resolve();
+
+  function warn(action: string, error: unknown): void {
+    const message = error instanceof Error ? error.message : String(error);
+    args.warn(`${action}: ${message}`);
+  }
+
+  function enqueue(work: () => Promise<void>): void {
+    workQueue = workQueue
+      .then(async () => {
+        if (!stopped) {
+          await work();
+        }
+      })
+      .catch((error: unknown) => {
+        if (!stopped) {
+          warn("Completion notification reconciliation failed", error);
+        }
+      });
+  }
+
+  function notifyOnce(
+    current: DesktopCompletionThread,
+    previous: DesktopCompletionThread | undefined,
+    candidate: boolean,
+  ): void {
+    const notification = resolveDesktopCompletionNotification({
+      candidate,
+      current,
+      previous,
+    });
+    if (notification === null) {
+      return;
+    }
+    const lastNotified = lastNotifiedAttentionAt.get(current.id);
+    if (
+      lastNotified !== undefined &&
+      current.latestAttentionAt <= lastNotified
+    ) {
+      return;
+    }
+    lastNotifiedAttentionAt.set(current.id, current.latestAttentionAt);
+    args.notify(notification);
+  }
+
+  function scheduleThreadRefresh(threadId: string, delayMs: number): void {
+    const existingTimer = refreshTimers.get(threadId);
+    if (existingTimer !== undefined) {
+      clearTimeout(existingTimer);
+    }
+    const version = refreshVersions.get(threadId) ?? 0;
+    const timer = setTimeout(() => {
+      refreshTimers.delete(threadId);
+      enqueue(() => refreshThread(threadId, version));
+    }, delayMs);
+    refreshTimers.set(threadId, timer);
+  }
+
+  async function refreshThread(
+    threadId: string,
+    expectedVersion: number,
+  ): Promise<void> {
+    try {
+      const current = await args.fetchThread(threadId, abortController.signal);
+      if (stopped) {
+        return;
+      }
+      const latestVersion = refreshVersions.get(threadId) ?? 0;
+      if (latestVersion !== expectedVersion) {
+        scheduleThreadRefresh(threadId, 0);
+        return;
+      }
+      const previous = knownThreads?.get(threadId);
+      if (current === null) {
+        knownThreads?.delete(threadId);
+      } else {
+        knownThreads ??= new Map();
+        knownThreads.set(threadId, current);
+        notifyOnce(current, previous, completionCandidates.has(threadId));
+      }
+      completionCandidates.delete(threadId);
+    } catch (error) {
+      if (stopped || abortController.signal.aborted) {
+        return;
+      }
+      warn(`Could not refresh completion state for ${threadId}`, error);
+      scheduleThreadRefresh(threadId, COMPLETION_NOTIFICATION_RETRY_MS);
+    }
+  }
+
+  function scheduleReconcile(
+    notifyTransitions: boolean,
+    delayMs: number,
+  ): void {
+    reconcileShouldNotify ||= notifyTransitions;
+    if (reconcileTimer !== null) {
+      clearTimeout(reconcileTimer);
+    }
+    reconcileTimer = setTimeout(() => {
+      reconcileTimer = null;
+      const shouldNotify = reconcileShouldNotify;
+      reconcileShouldNotify = false;
+      enqueue(() => reconcileThreads(shouldNotify));
+    }, delayMs);
+  }
+
+  async function reconcileThreads(notifyTransitions: boolean): Promise<void> {
+    try {
+      const current = threadMap(await args.listThreads(abortController.signal));
+      if (stopped) {
+        return;
+      }
+      const previous = knownThreads;
+      knownThreads = current;
+      if (!notifyTransitions || previous === null) {
+        return;
+      }
+      for (const thread of current.values()) {
+        notifyOnce(thread, previous.get(thread.id), false);
+      }
+    } catch (error) {
+      if (stopped || abortController.signal.aborted) {
+        return;
+      }
+      warn("Could not reconcile completion notification state", error);
+      scheduleReconcile(notifyTransitions, COMPLETION_NOTIFICATION_RETRY_MS);
+    }
+  }
+
+  const unsubscribeThreadChanges = args.subscribeToThreadChanges((event) => {
+    if (stopped || event.id === undefined) {
+      return;
+    }
+    const candidate = isCompletionCandidate(event);
+    if (!candidate && !event.changes.includes("status-changed")) {
+      return;
+    }
+    const threadId = event.id;
+    refreshVersions.set(threadId, (refreshVersions.get(threadId) ?? 0) + 1);
+    if (candidate) {
+      completionCandidates.add(threadId);
+    }
+    scheduleThreadRefresh(threadId, COMPLETION_NOTIFICATION_SETTLE_MS);
+  });
+  const unsubscribeConnection = args.subscribeToConnection((event) => {
+    if (!stopped && event.state === "connected") {
+      scheduleReconcile(event.reconnected, 0);
+    }
+  });
+
+  return {
+    stop(): void {
+      if (stopped) {
+        return;
+      }
+      stopped = true;
+      abortController.abort();
+      unsubscribeThreadChanges();
+      unsubscribeConnection();
+      if (reconcileTimer !== null) {
+        clearTimeout(reconcileTimer);
+        reconcileTimer = null;
+      }
+      for (const timer of refreshTimers.values()) {
+        clearTimeout(timer);
+      }
+      refreshTimers.clear();
+      completionCandidates.clear();
+    },
+  };
+}

--- a/apps/desktop/src/desktop-window-command-ipc.ts
+++ b/apps/desktop/src/desktop-window-command-ipc.ts
@@ -2,6 +2,7 @@
 // by the trusted React renderer.
 
 export const BB_DESKTOP_OPEN_NEW_TAB_CHANNEL = "bb-desktop:open-new-tab";
+export const BB_DESKTOP_OPEN_THREAD_CHANNEL = "bb-desktop:open-thread";
 export const BB_DESKTOP_APP_COMMAND_CHANNEL = "bb-desktop:app-command";
 export const BB_DESKTOP_GET_WINDOW_STATE_CHANNEL =
   "bb-desktop:get-window-state";

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -9,6 +9,7 @@ import {
   nativeImage,
   nativeTheme,
   net,
+  Notification,
   safeStorage,
   session,
   shell,
@@ -33,6 +34,7 @@ import {
   systemConfigResponseSchema,
   type ClientMessage,
 } from "@bb/server-contract";
+import { BbHttpError, createNodeBbSdk, type BbSdk } from "@bb/sdk";
 import { z } from "zod";
 import {
   assertPathExists,
@@ -135,6 +137,7 @@ import {
   BB_DESKTOP_CLOSE_WINDOW_RESPONSE_CHANNEL,
   BB_DESKTOP_GET_WINDOW_STATE_CHANNEL,
   BB_DESKTOP_OPEN_NEW_TAB_CHANNEL,
+  BB_DESKTOP_OPEN_THREAD_CHANNEL,
   BB_DESKTOP_WINDOW_STATE_CHANGED_CHANNEL,
   CLOSE_WINDOW_REQUEST_TIMEOUT_MS,
 } from "./desktop-window-command-ipc.js";
@@ -146,6 +149,14 @@ import { resolveDesktopBrowserAppCommand } from "./desktop-browser-shortcuts.js"
 import { registerDesktopBrowserIpc } from "./desktop-browser-main-ipc.js";
 import { ensurePackagedMacOsUserShellPath } from "./desktop-shell-path.js";
 import { clearPackagedSessionHttpCache } from "./desktop-session-cache.js";
+import { createDesktopAuthenticatedWebsocketFactory } from "./desktop-authenticated-websocket.js";
+import {
+  createDesktopCompletionNotificationWatcher,
+  formatDesktopCompletionNotificationTitle,
+  formatDesktopCompletionThreadUrl,
+  type DesktopCompletionNotification,
+  type DesktopCompletionNotificationWatcher,
+} from "./desktop-completion-notifications.js";
 import { resolveDesktopReloadShortcut } from "./desktop-reload-shortcut.js";
 import {
   createLogTailer,
@@ -299,8 +310,11 @@ let logViewerPreloadPath: string | null = null;
 let logViewerTailer: LogTailer | null = null;
 let logViewerWindow: BrowserWindow | null = null;
 let systemConfigSync: SystemConfigSync | null = null;
+let completionNotificationWatcher: DesktopCompletionNotificationWatcher | null =
+  null;
 let systemConfigRefreshToken = 0;
 let refreshRemoteSystemConfig: (() => void) | null = null;
+const visibleCompletionNotifications = new Set<Notification>();
 const applicationWindowWebContentsIds = new Set<number>();
 let bbAppLoaded = false;
 let stoppingForQuit = false;
@@ -772,6 +786,127 @@ function formatRealtimeUrl(serverUrl: string): string {
   return url.toString();
 }
 
+function createCompletionNotificationSdk(serverUrl: string): BbSdk {
+  const authenticatedFetch: typeof fetch = (input, init) =>
+    net.fetch(input as string | Request, {
+      ...init,
+      credentials: "include",
+    });
+  return createNodeBbSdk({
+    baseUrl: serverUrl,
+    fetch: authenticatedFetch,
+    websocket: createDesktopAuthenticatedWebsocketFactory({
+      async headers() {
+        const cookies = await session.defaultSession.cookies.get({
+          url: serverUrl,
+        });
+        const cookieHeader = cookies
+          .map((cookie) => `${cookie.name}=${cookie.value}`)
+          .join("; ");
+        return cookieHeader.length > 0 ? { Cookie: cookieHeader } : undefined;
+      },
+    }),
+  });
+}
+
+function focusApplicationFromNotification(
+  completion: DesktopCompletionNotification,
+): void {
+  app.focus({ steal: true });
+  if (
+    desktopWindowFactory?.sendToFirstWindow(BB_DESKTOP_OPEN_THREAD_CHANNEL, {
+      projectId: completion.projectId,
+      threadId: completion.threadId,
+    }) === true
+  ) {
+    return;
+  }
+
+  const threadUrl =
+    currentWindowUrl === null
+      ? null
+      : formatDesktopCompletionThreadUrl(currentWindowUrl, completion);
+  void createApplicationWindow({
+    initialUrl: threadUrl,
+    stateKey: null,
+  }).catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    createDesktopLogger().warn(
+      `[desktop] could not open completed thread: ${message}`,
+    );
+  });
+}
+
+function showCompletionNotification(
+  completion: DesktopCompletionNotification,
+): void {
+  if (process.platform !== "darwin" || !Notification.isSupported()) {
+    return;
+  }
+  const notification = new Notification({
+    sound: "Glass",
+    subtitle: "Click to view session.",
+    title: formatDesktopCompletionNotificationTitle(completion.title),
+  });
+  const release = (): void => {
+    visibleCompletionNotifications.delete(notification);
+  };
+  notification.once("click", () => {
+    focusApplicationFromNotification(completion);
+  });
+  notification.once("close", release);
+  notification.once("failed", (_event, error) => {
+    release();
+    createDesktopLogger().warn(
+      `[desktop] could not show completion notification: ${error}`,
+    );
+  });
+  visibleCompletionNotifications.add(notification);
+  while (visibleCompletionNotifications.size > 100) {
+    const oldest = visibleCompletionNotifications.values().next().value;
+    if (oldest === undefined) {
+      break;
+    }
+    visibleCompletionNotifications.delete(oldest);
+  }
+  notification.show();
+}
+
+function stopCompletionNotificationWatcher(): void {
+  completionNotificationWatcher?.stop();
+  completionNotificationWatcher = null;
+}
+
+function startCompletionNotificationWatcher(serverUrl: string): void {
+  stopCompletionNotificationWatcher();
+  if (process.platform !== "darwin") {
+    return;
+  }
+  const logger = createDesktopLogger();
+  const sdk = createCompletionNotificationSdk(serverUrl);
+  completionNotificationWatcher = createDesktopCompletionNotificationWatcher({
+    async fetchThread(threadId, signal) {
+      try {
+        return await sdk.threads.get({ signal, threadId });
+      } catch (error) {
+        if (error instanceof BbHttpError && error.status === 404) {
+          return null;
+        }
+        throw error;
+      }
+    },
+    listThreads: (signal) => sdk.threads.list({ archived: false, signal }),
+    notify: showCompletionNotification,
+    subscribeToConnection: (callback) =>
+      sdk.subscribe({ callback, event: "realtime:connection" }),
+    subscribeToThreadChanges: (callback) =>
+      sdk.subscribe({ callback, event: "thread:changed" }),
+    warn(message) {
+      logger.warn(`[desktop] ${message}`);
+    },
+  });
+}
+
 async function fetchSystemConfig(args: FetchSystemConfigArgs) {
   const response = await args.fetchImpl(formatApiUrl(args));
   if (!response.ok) {
@@ -925,11 +1060,13 @@ function createRemoteSystemConfigSync(serverUrl: string): SystemConfigSync {
 function stopSystemConfigSync(): void {
   systemConfigSync?.stop();
   systemConfigSync = null;
+  stopCompletionNotificationWatcher();
 }
 
 function startSystemConfigSync(serverUrl: string): void {
   systemConfigSync?.stop();
   systemConfigSync = createSystemConfigSync(serverUrl);
+  startCompletionNotificationWatcher(serverUrl);
   void refreshSystemConfig({ fetchImpl: fetch, serverUrl });
 }
 
@@ -937,6 +1074,7 @@ function startSystemConfigSync(serverUrl: string): void {
 function startRemoteSystemConfigSync(serverUrl: string): void {
   systemConfigSync?.stop();
   systemConfigSync = createRemoteSystemConfigSync(serverUrl);
+  startCompletionNotificationWatcher(serverUrl);
 }
 
 function registerApplicationWindow(browserWindow: DesktopBrowserWindow): void {
@@ -1132,6 +1270,7 @@ async function applyServerTarget(): Promise<void> {
   // flight would otherwise still read itself as current while this switch
   // runs, and its local-server fallback would undo the switch.
   connectSessionRenewal?.stop();
+  stopCompletionNotificationWatcher();
   serverTargetGeneration += 1;
   const generation = serverTargetGeneration;
   const isCurrent = (): boolean => serverTargetGeneration === generation;

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -6,6 +6,7 @@ import {
   bbDesktopBrowserSnapshotSchema,
   bbDesktopBrowserStateSchema,
   bbDesktopInfoSchema,
+  bbDesktopOpenThreadRequestSchema,
   bbDesktopWindowStateSchema,
   type BbDesktopApi,
   type BbDesktopAppCommandHandler,
@@ -21,6 +22,7 @@ import {
   type BbDesktopInfoChangeHandler,
   type BbDesktopInfoUnsubscribe,
   type BbDesktopOpenNewTabHandler,
+  type BbDesktopOpenThreadHandler,
   type BbDesktopTheme,
   type BbDesktopWindowState,
   type BbDesktopWindowStateChangeHandler,
@@ -54,6 +56,7 @@ import {
   BB_DESKTOP_CLOSE_WINDOW_RESPONSE_CHANNEL,
   BB_DESKTOP_GET_WINDOW_STATE_CHANNEL,
   BB_DESKTOP_OPEN_NEW_TAB_CHANNEL,
+  BB_DESKTOP_OPEN_THREAD_CHANNEL,
   BB_DESKTOP_WINDOW_STATE_CHANGED_CHANNEL,
 } from "./desktop-window-command-ipc.js";
 import {
@@ -163,6 +166,7 @@ const browserSnapshotListeners = new Set<BbDesktopBrowserSnapshotHandler>();
 const closeWindowRequestListeners =
   new Set<BbDesktopCloseWindowRequestHandler>();
 const openNewTabListeners = new Set<BbDesktopOpenNewTabHandler>();
+const openThreadListeners = new Set<BbDesktopOpenThreadHandler>();
 
 function normalizeSpellcheckWord(word: string): string | null {
   const normalized = word.trim();
@@ -320,6 +324,12 @@ const bbDesktopApi: BbDesktopApi = {
       openNewTabListeners.delete(listener);
     };
   },
+  onOpenThread(listener): BbDesktopInfoUnsubscribe {
+    openThreadListeners.add(listener);
+    return () => {
+      openThreadListeners.delete(listener);
+    };
+  },
   onAppCommand(listener): BbDesktopInfoUnsubscribe {
     appCommandListeners.add(listener);
     return () => {
@@ -354,6 +364,14 @@ ipcRenderer.on(
 ipcRenderer.on(BB_DESKTOP_OPEN_NEW_TAB_CHANNEL, () => {
   for (const listener of openNewTabListeners) {
     listener();
+  }
+});
+
+ipcRenderer.on(BB_DESKTOP_OPEN_THREAD_CHANNEL, (_event, payload: unknown) => {
+  const parsed = bbDesktopOpenThreadRequestSchema.safeParse(payload);
+  if (!parsed.success) return;
+  for (const listener of openThreadListeners) {
+    listener(parsed.data);
   }
 });
 

--- a/apps/desktop/test/desktop-authenticated-websocket.test.ts
+++ b/apps/desktop/test/desktop-authenticated-websocket.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface FakeWebSocketInstance {
+  emit(event: "close" | "error" | "message" | "open", data?: unknown): void;
+  options: WebSocketInit | undefined;
+  sent: string[];
+}
+
+const fakeWebSockets: FakeWebSocketInstance[] = [];
+
+class FakeWebSocket implements FakeWebSocketInstance {
+  static readonly CLOSED = 3;
+  static readonly CONNECTING = 0;
+  readonly sent: string[] = [];
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onopen: (() => void) | null = null;
+  readyState = FakeWebSocket.CONNECTING;
+
+  constructor(
+    readonly url: string,
+    options?: WebSocketInit,
+  ) {
+    this.options = options;
+    fakeWebSockets.push(this);
+  }
+
+  readonly options: WebSocketInit | undefined;
+
+  close(): void {
+    if (this.readyState === FakeWebSocket.CLOSED) {
+      return;
+    }
+    this.readyState = FakeWebSocket.CLOSED;
+    this.emit("close");
+  }
+
+  emit(event: "close" | "error" | "message" | "open", data?: unknown): void {
+    if (event === "close") {
+      this.onclose?.();
+    } else if (event === "error") {
+      this.onerror?.();
+    } else if (event === "message") {
+      this.onmessage?.({ data });
+    } else {
+      this.onopen?.();
+    }
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+}
+
+beforeEach(() => {
+  vi.stubGlobal("WebSocket", FakeWebSocket);
+});
+
+import { createDesktopAuthenticatedWebsocketFactory } from "../src/desktop-authenticated-websocket.js";
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  reject(error: Error): void;
+  resolve(value: T): void;
+} {
+  let rejectPromise: (error: Error) => void = () => {};
+  let resolvePromise: (value: T) => void = () => {};
+  const promise = new Promise<T>((resolve, reject) => {
+    rejectPromise = reject;
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    reject: rejectPromise,
+    resolve: resolvePromise,
+  };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+afterEach(() => {
+  fakeWebSockets.length = 0;
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("desktop authenticated WebSocket", () => {
+  it("opens with headers resolved for that connection", async () => {
+    const headers = deferred<Record<string, string> | undefined>();
+    const resolveHeaders = vi.fn(() => headers.promise);
+    const socket = createDesktopAuthenticatedWebsocketFactory({
+      headers: resolveHeaders,
+    })("wss://bb.test/ws");
+    const onopen = vi.fn();
+    const onmessage = vi.fn();
+    socket.onopen = onopen;
+    socket.onmessage = onmessage;
+
+    expect(socket.readyState).toBe(0);
+    expect(resolveHeaders).toHaveBeenCalledWith("wss://bb.test/ws");
+    expect(fakeWebSockets).toHaveLength(0);
+
+    headers.resolve({ Cookie: "bb_session=fresh" });
+    await flushMicrotasks();
+
+    const delegate = fakeWebSockets[0];
+    expect(delegate?.options).toEqual({
+      headers: { Cookie: "bb_session=fresh" },
+    });
+    delegate?.emit("open");
+    expect(onopen).toHaveBeenCalledOnce();
+    delegate?.emit("message", "thread changed");
+    expect(onmessage).toHaveBeenCalledWith({ data: "thread changed" });
+
+    socket.send("subscribe");
+    expect(delegate?.sent).toEqual(["subscribe"]);
+  });
+
+  it("closes without opening while header resolution is pending", async () => {
+    const headers = deferred<Record<string, string> | undefined>();
+    const socket = createDesktopAuthenticatedWebsocketFactory({
+      headers: () => headers.promise,
+    })("wss://bb.test/ws");
+    const onclose = vi.fn();
+    socket.onclose = onclose;
+
+    socket.close();
+    headers.resolve({ Cookie: "bb_session=late" });
+    await flushMicrotasks();
+
+    expect(onclose).toHaveBeenCalledOnce();
+    expect(socket.readyState).toBe(3);
+    expect(fakeWebSockets).toHaveLength(0);
+  });
+
+  it("reports header resolution failure as an error and close", async () => {
+    const headers = deferred<Record<string, string> | undefined>();
+    const socket = createDesktopAuthenticatedWebsocketFactory({
+      headers: () => headers.promise,
+    })("wss://bb.test/ws");
+    const onclose = vi.fn();
+    const onerror = vi.fn(() => socket.close());
+    socket.onclose = onclose;
+    socket.onerror = onerror;
+
+    headers.reject(new Error("cookie store unavailable"));
+    await flushMicrotasks();
+
+    expect(onerror).toHaveBeenCalledOnce();
+    expect(onclose).toHaveBeenCalledOnce();
+    expect(fakeWebSockets).toHaveLength(0);
+  });
+});

--- a/apps/desktop/test/desktop-completion-notifications.test.ts
+++ b/apps/desktop/test/desktop-completion-notifications.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PERSONAL_PROJECT_ID } from "@bb/domain";
+import type { BbRealtimeConnectionEvent, ThreadRealtimeEvent } from "@bb/sdk";
+import {
+  COMPLETION_NOTIFICATION_TITLE_MAX_LENGTH,
+  COMPLETION_NOTIFICATION_SETTLE_MS,
+  createDesktopCompletionNotificationWatcher,
+  formatDesktopCompletionNotificationTitle,
+  formatDesktopCompletionThreadUrl,
+  resolveDesktopCompletionNotification,
+  type DesktopCompletionNotification,
+  type DesktopCompletionThread,
+} from "../src/desktop-completion-notifications.js";
+
+function makeThread(
+  overrides: Partial<DesktopCompletionThread> &
+    Pick<DesktopCompletionThread, "id">,
+): DesktopCompletionThread {
+  return {
+    latestAttentionAt: 100,
+    parentThreadId: null,
+    projectId: "project-1",
+    status: "idle",
+    title: "Fix search",
+    titleFallback: null,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("formatDesktopCompletionNotificationTitle", () => {
+  it("appends the completion copy to ordinary thread titles", () => {
+    expect(formatDesktopCompletionNotificationTitle("Fix search")).toBe(
+      "Fix search: has finished",
+    );
+  });
+
+  it("truncates long thread titles while preserving the completion suffix", () => {
+    const title = formatDesktopCompletionNotificationTitle("A".repeat(200));
+
+    expect(title).toHaveLength(COMPLETION_NOTIFICATION_TITLE_MAX_LENGTH);
+    expect(title).toBe(`${"A".repeat(65)}…: has finished`);
+  });
+});
+
+describe("resolveDesktopCompletionNotification", () => {
+  it("notifies for a realtime completion candidate without surfacing history", () => {
+    const current = makeThread({
+      id: "just-completed",
+      projectId: PERSONAL_PROJECT_ID,
+      title: null,
+      titleFallback: "Ship notifications",
+    });
+
+    expect(
+      resolveDesktopCompletionNotification({
+        candidate: false,
+        current,
+        previous: undefined,
+      }),
+    ).toBeNull();
+    expect(
+      resolveDesktopCompletionNotification({
+        candidate: true,
+        current,
+        previous: undefined,
+      }),
+    ).toEqual({
+      outcome: "completed",
+      projectId: null,
+      threadId: "just-completed",
+      title: "Ship notifications",
+    });
+  });
+
+  it("reconciles a known running root that completed while disconnected", () => {
+    expect(
+      resolveDesktopCompletionNotification({
+        candidate: false,
+        current: makeThread({
+          id: "thread-1",
+          latestAttentionAt: 101,
+          status: "idle",
+        }),
+        previous: makeThread({
+          id: "thread-1",
+          latestAttentionAt: 100,
+          status: "active",
+        }),
+      }),
+    ).toEqual({
+      outcome: "completed",
+      projectId: "project-1",
+      threadId: "thread-1",
+      title: "Fix search",
+    });
+  });
+
+  it("does not mistake read-state attention for a completion", () => {
+    expect(
+      resolveDesktopCompletionNotification({
+        candidate: false,
+        current: makeThread({ id: "thread-1", latestAttentionAt: 101 }),
+        previous: makeThread({ id: "thread-1", latestAttentionAt: 100 }),
+      }),
+    ).toBeNull();
+  });
+
+  it("reports failed roots and ignores child or still-active threads", () => {
+    expect(
+      resolveDesktopCompletionNotification({
+        candidate: true,
+        current: makeThread({ id: "failed", status: "error" }),
+        previous: undefined,
+      }),
+    ).toMatchObject({ outcome: "failed", threadId: "failed" });
+    expect(
+      resolveDesktopCompletionNotification({
+        candidate: true,
+        current: makeThread({ id: "child", parentThreadId: "root" }),
+        previous: undefined,
+      }),
+    ).toBeNull();
+    expect(
+      resolveDesktopCompletionNotification({
+        candidate: true,
+        current: makeThread({ id: "queued", status: "active" }),
+        previous: undefined,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("createDesktopCompletionNotificationWatcher", () => {
+  it("uses typed realtime completion events to fetch only the affected thread", async () => {
+    vi.useFakeTimers();
+    let threadListener = (_event: ThreadRealtimeEvent): void => undefined;
+    const notifications: DesktopCompletionNotification[] = [];
+    const fetchThread = vi.fn(async (_threadId: string, _signal: AbortSignal) =>
+      makeThread({ id: "thread-1", latestAttentionAt: 101 }),
+    );
+    const listThreads = vi.fn(async () => []);
+    const watcher = createDesktopCompletionNotificationWatcher({
+      fetchThread,
+      listThreads,
+      notify: (notification) => notifications.push(notification),
+      subscribeToConnection: () => () => undefined,
+      subscribeToThreadChanges(listener) {
+        threadListener = listener;
+        return () => {
+          threadListener = () => undefined;
+        };
+      },
+      warn: vi.fn(),
+    });
+
+    threadListener({
+      type: "changed",
+      entity: "thread",
+      id: "thread-1",
+      changes: ["status-changed"],
+      metadata: { eventTypes: ["turn/completed"] },
+    });
+    await vi.advanceTimersByTimeAsync(COMPLETION_NOTIFICATION_SETTLE_MS);
+
+    expect(fetchThread).toHaveBeenCalledOnce();
+    expect(fetchThread.mock.calls[0]?.[0]).toBe("thread-1");
+    expect(listThreads).not.toHaveBeenCalled();
+    expect(notifications).toEqual([
+      {
+        outcome: "completed",
+        projectId: "project-1",
+        threadId: "thread-1",
+        title: "Fix search",
+      },
+    ]);
+    watcher.stop();
+  });
+
+  it("reconciles known running threads after the SDK reconnects", async () => {
+    vi.useFakeTimers();
+    let connectionListener = (_event: BbRealtimeConnectionEvent): void =>
+      undefined;
+    let threads: DesktopCompletionThread[] = [
+      makeThread({ id: "thread-1", status: "active" }),
+    ];
+    const notifications: DesktopCompletionNotification[] = [];
+    const watcher = createDesktopCompletionNotificationWatcher({
+      fetchThread: async () => null,
+      listThreads: async () => threads,
+      notify: (notification) => notifications.push(notification),
+      subscribeToConnection(listener) {
+        connectionListener = listener;
+        return () => {
+          connectionListener = () => undefined;
+        };
+      },
+      subscribeToThreadChanges: () => () => undefined,
+      warn: vi.fn(),
+    });
+
+    connectionListener({
+      state: "connected",
+      reconnected: false,
+      reconnectDelayMs: null,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(notifications).toEqual([]);
+
+    threads = [
+      makeThread({
+        id: "thread-1",
+        latestAttentionAt: 101,
+        status: "idle",
+      }),
+    ];
+    connectionListener({
+      state: "connected",
+      reconnected: true,
+      reconnectDelayMs: null,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toMatchObject({ threadId: "thread-1" });
+    watcher.stop();
+  });
+});
+
+describe("formatDesktopCompletionThreadUrl", () => {
+  it("opens ordinary project threads at their canonical route", () => {
+    expect(
+      formatDesktopCompletionThreadUrl("https://remote.example/?old=1#stale", {
+        projectId: "project one",
+        threadId: "thread/two",
+      }),
+    ).toBe(
+      "https://remote.example/projects/project%20one/threads/thread%2Ftwo",
+    );
+  });
+
+  it("opens personal threads at their projectless route", () => {
+    expect(
+      formatDesktopCompletionThreadUrl("http://127.0.0.1:38886", {
+        projectId: null,
+        threadId: "thread-1",
+      }),
+    ).toBe("http://127.0.0.1:38886/threads/thread-1");
+  });
+});

--- a/apps/desktop/test/preload-browser-api.test.ts
+++ b/apps/desktop/test/preload-browser-api.test.ts
@@ -36,6 +36,7 @@ import {
   BB_DESKTOP_CLOSE_WINDOW_RESPONSE_CHANNEL,
   BB_DESKTOP_GET_WINDOW_STATE_CHANNEL,
   BB_DESKTOP_OPEN_NEW_TAB_CHANNEL,
+  BB_DESKTOP_OPEN_THREAD_CHANNEL,
   BB_DESKTOP_WINDOW_STATE_CHANGED_CHANNEL,
 } from "../src/desktop-window-command-ipc.js";
 import { BB_DESKTOP_SPELLCHECK_GLOBAL_NAME } from "../src/desktop-spellcheck-contract.js";
@@ -349,6 +350,10 @@ describe("desktop preload browser API", () => {
     const snapshots: BbDesktopBrowserSnapshot[] = [];
     let closeWindowRequestCount = 0;
     let openNewTabCount = 0;
+    const openThreads: Array<{
+      projectId: string | null;
+      threadId: string;
+    }> = [];
     const appCommands: AppCommandId[] = [];
     const windowStates: BbDesktopWindowState[] = [];
     const state: BbDesktopBrowserState = {
@@ -386,6 +391,9 @@ describe("desktop preload browser API", () => {
     });
     api.onOpenNewTab?.(() => {
       openNewTabCount += 1;
+    });
+    api.onOpenThread?.((request) => {
+      openThreads.push(request);
     });
     api.onAppCommand?.((command) => {
       appCommands.push(command);
@@ -443,6 +451,14 @@ describe("desktop preload browser API", () => {
       payload: null,
     });
     emitIpcPayload({
+      channel: BB_DESKTOP_OPEN_THREAD_CHANNEL,
+      payload: { projectId: "proj_a", threadId: "" },
+    });
+    emitIpcPayload({
+      channel: BB_DESKTOP_OPEN_THREAD_CHANNEL,
+      payload: { projectId: "proj_a", threadId: "thr_a" },
+    });
+    emitIpcPayload({
       channel: BB_DESKTOP_APP_COMMAND_CHANNEL,
       payload: "not-a-command",
     });
@@ -462,6 +478,7 @@ describe("desktop preload browser API", () => {
     expect(windowStates).toEqual([{ isFullScreen: true }]);
     expect(closeWindowRequestCount).toBe(1);
     expect(openNewTabCount).toBe(1);
+    expect(openThreads).toEqual([{ projectId: "proj_a", threadId: "thr_a" }]);
     expect(appCommands).toEqual(["thread.new"]);
     expect(electronMock.sendCalls).toContainEqual({
       channel: BB_DESKTOP_CLOSE_WINDOW_RESPONSE_CHANNEL,

--- a/packages/desktop-contract/src/info.ts
+++ b/packages/desktop-contract/src/info.ts
@@ -49,6 +49,18 @@ export type BbDesktopWindowStateChangeHandler = (
 export type BbDesktopOpenNewTabHandler = () => void;
 export type BbDesktopAppCommandHandler = (command: AppCommandId) => void;
 export type BbDesktopCloseWindowRequestHandler = () => boolean;
+export const bbDesktopOpenThreadRequestSchema = z
+  .object({
+    projectId: z.string().min(1).nullable(),
+    threadId: z.string().min(1),
+  })
+  .strict();
+export type BbDesktopOpenThreadRequest = z.infer<
+  typeof bbDesktopOpenThreadRequestSchema
+>;
+export type BbDesktopOpenThreadHandler = (
+  request: BbDesktopOpenThreadRequest,
+) => void;
 
 export interface BbDesktopApi extends BbDesktopInfo {
   /**
@@ -80,6 +92,8 @@ export interface BbDesktopApi extends BbDesktopInfo {
    * panel new-tab page. Optional for desktop shells that predate this command.
    */
   onOpenNewTab?(listener: BbDesktopOpenNewTabHandler): BbDesktopInfoUnsubscribe;
+  /** Subscribe to native desktop requests to navigate to a thread in-app. */
+  onOpenThread?(listener: BbDesktopOpenThreadHandler): BbDesktopInfoUnsubscribe;
   /** Subscribe to native menu commands that are executed by the renderer. */
   onAppCommand?(listener: BbDesktopAppCommandHandler): BbDesktopInfoUnsubscribe;
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -564,6 +564,9 @@ importers:
       '@bb/domain':
         specifier: workspace:*
         version: link:../../packages/domain
+      '@bb/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
       '@bb/server-contract':
         specifier: workspace:*
         version: link:../../packages/server-contract


### PR DESCRIPTION
## Summary

- add native macOS notifications when a root agent finishes successfully or fails
- display `<thread>: has finished` with a `Click to view session.` subtitle and the macOS `Glass` alert sound
- truncate long thread titles to an 80-character notification-title limit while preserving the completion suffix
- run the watcher in Electron's main process so notifications continue while BB is running with every window closed
- use the typed BB SDK realtime subscription and reconnect lifecycle instead of duplicating the server WebSocket protocol
- support local, Connect, and custom remote servers by using Electron's authenticated session for HTTP requests and refreshing its cookie header before each WebSocket connection attempt
- use Electron 41's Node-global WebSocket header support, with no direct `ws` dependency in the desktop package and no SDK modifications
- baseline existing threads at startup, reconcile durable thread state after reconnects, and suppress historical, child-agent, interrupted, queued-continuation, and duplicate alerts
- navigate notification clicks through typed main-to-preload-to-renderer IPC and React Router, so an existing BB window changes threads without reloading; create a window directly at the thread when none is open


## Open Questions
- Was it a design decision to actively not use `@bb/sdk` in the desktop package? If so I can reimplement without this dep
- This is built to be the smallest production change possible. That said: I didn't add any settings. Is this something you'd want?
- Multi-platform support or nah?