### PR TITLE
Handle Claude doctor failures safely

### DIFF
--- a/apps/app/src/components/provider-cli/provider-cli-install.test.tsx
+++ b/apps/app/src/components/provider-cli/provider-cli-install.test.tsx
@@ -161,6 +161,22 @@ describe("buildProviderCliIssue", () => {
       title: "Claude Code update available",
     });
   });
+
+  it("describes an update without inventing a target for an unknown channel", () => {
+    const actionable = issueForProvider("claudeCode");
+    const issue = buildProviderCliIssue({
+      provider: "claudeCode",
+      status: {
+        ...actionable.status,
+        latestVersion: null,
+      },
+    });
+
+    expect(issue).toMatchObject({
+      description: "1.0.0; newer release available",
+      title: "Claude Code update available",
+    });
+  });
 });
 
 describe("useProviderCliInstallRunner", () => {

--- a/apps/app/src/components/provider-cli/provider-cli-install.tsx
+++ b/apps/app/src/components/provider-cli/provider-cli-install.tsx
@@ -84,7 +84,11 @@ export function buildProviderCliIssue(
   }
 
   if (status.needsUpdate) {
-    const description = `${status.currentVersion ?? "Installed version unknown"} -> ${status.latestVersion ?? "latest"}`;
+    const currentVersion = status.currentVersion ?? "Installed version unknown";
+    const description =
+      status.latestVersion === null
+        ? `${currentVersion}; newer release available`
+        : `${currentVersion} -> ${status.latestVersion}`;
     const fingerprint = [
       provider,
       "outdated",

--- a/apps/host-daemon/src/command-dispatch.test.ts
+++ b/apps/host-daemon/src/command-dispatch.test.ts
@@ -239,7 +239,7 @@ function createProviderCliInstallEventStream(
 
 function claudeCodeStatus(args: {
   currentVersion: string;
-  latestVersion: string;
+  latestVersion: string | null;
 }): ProviderCliStatus {
   return {
     displayName: "Claude Code",
@@ -258,9 +258,63 @@ function claudeCodeStatus(args: {
       commandKind: "exec",
       command: "claude update",
     },
-    needsUpdate: args.currentVersion !== args.latestVersion,
+    needsUpdate:
+      args.latestVersion === null || args.currentVersion !== args.latestVersion,
     versionUnsupported: false,
   };
+}
+
+async function runSuccessfulClaudeCodeUpdateVerification(args: {
+  before: ProviderCliStatus;
+  after: ProviderCliStatus;
+}) {
+  const dataDir = await makeTempDir("bb-command-dispatch-provider-cli-");
+  const manager = new RuntimeManager({
+    dataDir,
+    createRuntime,
+    provisionWorkspace: async () => createWorkspace(),
+  });
+  const getProviderCliStatusForProvider = vi
+    .fn()
+    .mockResolvedValueOnce(args.before)
+    .mockResolvedValueOnce(args.after);
+  const events: ProviderCliInstallEvent[] = [
+    {
+      type: "started",
+      provider: "claudeCode",
+      command: "claude update",
+    },
+    {
+      type: "completed",
+      provider: "claudeCode",
+      exitCode: 0,
+      signal: null,
+      success: true,
+    },
+  ];
+  const result = await dispatchOnlineRpcCommand(
+    {
+      type: "provider_cli.install",
+      provider: "claudeCode",
+      actionKind: "update",
+    },
+    {
+      dataDir,
+      eventSink: {
+        emit: vi.fn(),
+        flush: vi.fn(async () => undefined),
+      },
+      fetchProjectAttachment: async () => {
+        throw new Error("Unexpected project attachment fetch");
+      },
+      getProviderCliStatusForProvider,
+      runtimeManager: manager,
+      streamProviderCliInstall: () =>
+        createProviderCliInstallEventStream(events),
+      threadStorageRootPath: "/tmp/bb-thread-storage",
+    },
+  );
+  return { events, getProviderCliStatusForProvider, result };
 }
 
 describe("dispatchCommand", () => {
@@ -1332,6 +1386,55 @@ describe("dispatchCommand", () => {
         provider: "claudeCode",
         message: expect.stringContaining(
           "still reports 2.1.220 (expected 2.1.227)",
+        ),
+      }),
+      {
+        type: "completed",
+        provider: "claudeCode",
+        exitCode: 0,
+        signal: null,
+        success: false,
+      },
+    ]);
+  });
+
+  it("accepts a Claude update that advances when the release channel is unknown", async () => {
+    const verification = await runSuccessfulClaudeCodeUpdateVerification({
+      before: claudeCodeStatus({
+        currentVersion: "2.1.69",
+        latestVersion: null,
+      }),
+      after: claudeCodeStatus({
+        currentVersion: "2.1.221",
+        latestVersion: null,
+      }),
+    });
+
+    expect(verification.getProviderCliStatusForProvider).toHaveBeenCalledTimes(
+      2,
+    );
+    expect(verification.result).toEqual({ events: verification.events });
+  });
+
+  it("rejects a Claude update that does not advance when the release channel is unknown", async () => {
+    const verification = await runSuccessfulClaudeCodeUpdateVerification({
+      before: claudeCodeStatus({
+        currentVersion: "2.1.69",
+        latestVersion: null,
+      }),
+      after: claudeCodeStatus({
+        currentVersion: "2.1.69",
+        latestVersion: null,
+      }),
+    });
+
+    expect(verification.result.events).toEqual([
+      expect.objectContaining({ type: "started" }),
+      expect.objectContaining({
+        type: "error",
+        provider: "claudeCode",
+        message: expect.stringContaining(
+          "still reports 2.1.69 (expected a version newer than 2.1.69)",
         ),
       }),
       {

--- a/apps/host-daemon/src/command-dispatch.ts
+++ b/apps/host-daemon/src/command-dispatch.ts
@@ -198,15 +198,31 @@ function verifyClaudeCodeUpdateEvents(args: {
     (event) => event.type === "completed" && event.success,
   );
   const expectedVersion = args.before.latestVersion;
+  const previousVersion = args.before.currentVersion;
   const actualVersion = args.after?.currentVersion ?? null;
-  if (
-    completedIndex === -1 ||
-    expectedVersion === null ||
-    (actualVersion !== null &&
-      semver.valid(actualVersion) !== null &&
-      semver.valid(expectedVersion) !== null &&
-      semver.gte(actualVersion, expectedVersion))
-  ) {
+  if (completedIndex === -1) {
+    return args.events;
+  }
+
+  const validExpectedVersion =
+    expectedVersion === null ? null : semver.valid(expectedVersion);
+  const validPreviousVersion =
+    previousVersion === null ? null : semver.valid(previousVersion);
+  const validActualVersion =
+    actualVersion === null ? null : semver.valid(actualVersion);
+  const hasKnownTarget = validExpectedVersion !== null;
+  const canVerifyAdvancement =
+    expectedVersion === null && validPreviousVersion !== null;
+  if (!hasKnownTarget && !canVerifyAdvancement) {
+    return args.events;
+  }
+  const updateVerified =
+    validActualVersion !== null &&
+    (validExpectedVersion !== null
+      ? semver.gte(validActualVersion, validExpectedVersion)
+      : validPreviousVersion !== null &&
+        semver.gt(validActualVersion, validPreviousVersion));
+  if (updateVerified) {
     return args.events;
   }
 
@@ -214,7 +230,10 @@ function verifyClaudeCodeUpdateEvents(args: {
     args.after?.executablePath ??
     args.before.executablePath ??
     args.before.executableName;
-  const message = `Claude Code's update command exited successfully, but ${executable} still reports ${actualVersion ?? "an unknown version"} (expected ${expectedVersion}). The executable may be pinned by PATH or managed by another installer. Run \`claude doctor\` on this machine and update the installation it reports.`;
+  const expectation = hasKnownTarget
+    ? `expected ${validExpectedVersion}`
+    : `expected a version newer than ${validPreviousVersion}`;
+  const message = `Claude Code's update command exited successfully, but ${executable} still reports ${actualVersion ?? "an unknown version"} (${expectation}). The executable may be pinned by PATH or managed by another installer. Run \`claude doctor\` on this machine and update the installation it reports.`;
   const verifiedEvents = [...args.events];
   const completedEvent = verifiedEvents[completedIndex];
   if (completedEvent?.type !== "completed") {

--- a/apps/host-daemon/src/provider-cli-health.test.ts
+++ b/apps/host-daemon/src/provider-cli-health.test.ts
@@ -602,6 +602,106 @@ describe("provider CLI health", () => {
     });
   });
 
+  it("keeps the native update action when an older Claude doctor requires a TTY", async () => {
+    const runner = new FakeProviderCliCommandRunner();
+    runner.setSuccess("which", ["claude"], "/Users/me/.local/bin/claude\n");
+    runner.setSuccess("claude", ["--version"], "2.1.69 (Claude Code)\n");
+    runner.setSuccess(
+      "npm",
+      ["view", "@anthropic-ai/claude-code", "dist-tags", "--json"],
+      JSON.stringify({ latest: "2.1.228", stable: "2.1.221" }),
+    );
+    installNpmStateCommands(
+      runner,
+      CLAUDE_CODE_DEFINITION,
+      "/Users/me/.npm-global",
+      null,
+    );
+    runner.setExit(
+      "claude",
+      ["doctor"],
+      1,
+      "Raw mode is not supported on the current process.stdin",
+    );
+
+    const status = await inspectProviderCli({
+      definition: CLAUDE_CODE_DEFINITION,
+      runner,
+      nodePlatform: "darwin",
+    });
+
+    expect(status.installSource).toBe("external");
+    expect(status.currentVersion).toBe("2.1.69");
+    expect(status.latestVersion).toBeNull();
+    expect(status.needsUpdate).toBe(true);
+    expect(status.installAction).toEqual({
+      kind: "update",
+      label: "Update",
+      commandKind: "exec",
+      command: "claude update",
+    });
+  });
+
+  it("does not infer an arbitrary external Claude install is native when doctor fails", async () => {
+    const runner = new FakeProviderCliCommandRunner();
+    runner.setSuccess("which", ["claude"], "/opt/homebrew/bin/claude\n");
+    runner.setSuccess("claude", ["--version"], "2.1.69 (Claude Code)\n");
+    runner.setSuccess(
+      "npm",
+      ["view", "@anthropic-ai/claude-code", "dist-tags", "--json"],
+      JSON.stringify({ latest: "2.1.228", stable: "2.1.221" }),
+    );
+    installNpmStateCommands(
+      runner,
+      CLAUDE_CODE_DEFINITION,
+      "/Users/me/.npm-global",
+      null,
+    );
+    runner.setExit("claude", ["doctor"], 1, "doctor failed");
+
+    const status = await inspectProviderCli({
+      definition: CLAUDE_CODE_DEFINITION,
+      runner,
+      nodePlatform: "darwin",
+    });
+
+    expect(status.needsUpdate).toBe(true);
+    expect(status.installAction).toBeNull();
+  });
+
+  it("does not default an unknown Claude release channel to latest", async () => {
+    const runner = new FakeProviderCliCommandRunner();
+    runner.setSuccess(
+      "which",
+      ["claude"],
+      "/Users/me/.npm-global/bin/claude\n",
+    );
+    runner.setSuccess("claude", ["--version"], "2.1.221 (Claude Code)\n");
+    runner.setSuccess(
+      "npm",
+      ["view", "@anthropic-ai/claude-code", "dist-tags", "--json"],
+      JSON.stringify({ latest: "2.1.228", stable: "2.1.221" }),
+    );
+    installNpmStateCommands(
+      runner,
+      CLAUDE_CODE_DEFINITION,
+      "/Users/me/.npm-global",
+      "2.1.221",
+    );
+    runner.setExit("claude", ["doctor"], 1, "doctor failed");
+
+    const status = await inspectProviderCli({
+      definition: CLAUDE_CODE_DEFINITION,
+      runner,
+      nodePlatform: "darwin",
+    });
+
+    expect(status.installSource).toBe("npmGlobal");
+    expect(status.latestVersion).toBeNull();
+    expect(status.needsUpdate).toBe(false);
+    expect(status.installAction).toBeNull();
+  });
+
   it("uses Claude Code's stable release channel when checking for updates", async () => {
     const runner = new FakeProviderCliCommandRunner();
     runner.setSuccess("which", ["claude"], "/Users/me/.local/bin/claude\n");

--- a/apps/host-daemon/src/provider-cli-health.ts
+++ b/apps/host-daemon/src/provider-cli-health.ts
@@ -59,8 +59,13 @@ type ClaudeCodeInstallMethod =
   | "unknown";
 
 interface ClaudeCodeDoctorStatus {
-  installMethod: ClaudeCodeInstallMethod;
-  updateChannel: "latest" | "stable";
+  installMethod: ClaudeCodeInstallMethod | null;
+  updateChannel: "latest" | "stable" | null;
+}
+
+interface ClaudeCodeDistTagVersions {
+  latest: string;
+  stable: string | null;
 }
 
 export interface ProviderCliDefinition {
@@ -198,6 +203,7 @@ interface ResolveProviderCliInstallSourceArgs {
 interface BuildInstallActionArgs {
   definition: ProviderCliDefinition;
   installed: boolean;
+  executablePath: string | null;
   installSource: ProviderCliInstallSource;
   needsUpdate: boolean;
   versionUnsupported: boolean;
@@ -396,10 +402,9 @@ function parseNpmGlobalPackageVersion(
   }
 }
 
-function parseNpmDistTagVersion(
+function parseClaudeCodeDistTagVersions(
   text: string,
-  channel: "latest" | "stable",
-): string | null {
+): ClaudeCodeDistTagVersions | null {
   const trimmedText = text.trim();
   if (trimmedText.length === 0) {
     return null;
@@ -410,42 +415,77 @@ function parseNpmDistTagVersion(
     if (!parsed.success) {
       return null;
     }
-    const version =
-      channel === "stable"
-        ? (parsed.data.stable ?? parsed.data.latest)
-        : parsed.data.latest;
-    return extractVersion(version);
+    const latest = extractVersion(parsed.data.latest);
+    if (latest === null) {
+      return null;
+    }
+    return {
+      latest,
+      stable:
+        parsed.data.stable === undefined
+          ? latest
+          : extractVersion(parsed.data.stable),
+    };
   } catch {
     return null;
   }
 }
 
-function parseClaudeCodeDoctorStatus(
-  text: string,
-): ClaudeCodeDoctorStatus | null {
+function parseClaudeCodeDoctorStatus(text: string): ClaudeCodeDoctorStatus {
   const runningMatch = /^Running:\s+([^\s(]+)/mu.exec(text);
   const channelMatch = /^Auto-update channel:\s+(latest|stable)\s*$/mu.exec(
     text,
   );
   const rawInstallMethod = runningMatch?.[1];
   const rawUpdateChannel = channelMatch?.[1];
-  if (
-    !rawInstallMethod ||
-    (rawUpdateChannel !== "latest" && rawUpdateChannel !== "stable")
-  ) {
-    return null;
-  }
-
-  const installMethod: ClaudeCodeInstallMethod =
-    rawInstallMethod === "native" || rawInstallMethod === "npm-global"
+  const installMethod: ClaudeCodeInstallMethod | null = rawInstallMethod
+    ? rawInstallMethod === "native" || rawInstallMethod === "npm-global"
       ? rawInstallMethod
       : ["homebrew", "winget", "apt", "dnf", "apk"].includes(rawInstallMethod)
         ? "package-manager"
-        : "unknown";
+        : "unknown"
+    : null;
   return {
     installMethod,
-    updateChannel: rawUpdateChannel,
+    updateChannel:
+      rawUpdateChannel === "latest" || rawUpdateChannel === "stable"
+        ? rawUpdateChannel
+        : null,
   };
+}
+
+function resolveClaudeCodeVersionStatus(args: {
+  installed: boolean;
+  currentVersion: string | null;
+  distTags: ClaudeCodeDistTagVersions | null;
+  updateChannel: ClaudeCodeDoctorStatus["updateChannel"];
+}): { latestVersion: string | null; needsUpdate: boolean } {
+  const latestVersion =
+    args.updateChannel === null || args.distTags === null
+      ? null
+      : args.distTags[args.updateChannel];
+  if (args.updateChannel !== null) {
+    return {
+      latestVersion,
+      needsUpdate: needsProviderCliUpdate({
+        installed: args.installed,
+        currentVersion: args.currentVersion,
+        latestVersion,
+      }),
+    };
+  }
+
+  // Without an effective channel, an update is only certain when both possible
+  // targets are newer. Keep the target version unknown so a stable install is
+  // never advertised or verified against the latest release by accident.
+  const definitelyNeedsUpdate =
+    args.installed &&
+    args.currentVersion !== null &&
+    args.distTags !== null &&
+    args.distTags.stable !== null &&
+    semver.gt(args.distTags.latest, args.currentVersion) &&
+    semver.gt(args.distTags.stable, args.currentVersion);
+  return { latestVersion: null, needsUpdate: definitelyNeedsUpdate };
 }
 
 function needsProviderCliUpdate(args: NeedsProviderCliUpdateArgs): boolean {
@@ -562,6 +602,23 @@ function resolveProviderCliInstallSource({
     : "external";
 }
 
+function isDefaultClaudeCodeNativeExecutablePath(
+  executablePath: string | null,
+  nodePlatform: NodeJS.Platform,
+): boolean {
+  if (executablePath === null) {
+    return false;
+  }
+  const normalizedPath = executablePath.replace(/\\/gu, "/");
+  if (normalizedPath.endsWith("/.local/bin/claude")) {
+    return true;
+  }
+  return (
+    nodePlatform === "win32" &&
+    normalizedPath.endsWith("/.local/bin/claude.exe")
+  );
+}
+
 function resolveExecutableInstallStatus(
   whichResult: ProviderCliCommandResult,
   versionResult: ProviderCliCommandResult,
@@ -594,6 +651,7 @@ function resolveExecutablePathStatus(whichResult: ProviderCliCommandResult): {
 function buildInstallAction({
   definition,
   installed,
+  executablePath,
   installSource,
   needsUpdate,
   versionUnsupported,
@@ -609,12 +667,19 @@ function buildInstallAction({
       command: command.displayCommand,
     };
   }
+  const claudeCodeInstallMethod = claudeCodeDoctorStatus?.installMethod ?? null;
+  const hasNativeClaudeCodeFallback =
+    definition.key === "claudeCode" &&
+    claudeCodeInstallMethod === null &&
+    installSource === "external" &&
+    isDefaultClaudeCodeNativeExecutablePath(executablePath, nodePlatform);
   const canRunUpdate =
     definition.key !== "claudeCode" ||
-    claudeCodeDoctorStatus?.installMethod === "native" ||
+    claudeCodeInstallMethod === "native" ||
+    hasNativeClaudeCodeFallback ||
     (installSource === "npmGlobal" &&
-      (claudeCodeDoctorStatus === null ||
-        claudeCodeDoctorStatus.installMethod === "npm-global"));
+      (claudeCodeInstallMethod === null ||
+        claudeCodeInstallMethod === "npm-global"));
   if (needsUpdate && canRunUpdate) {
     const command = definition.updateCommand;
     return {
@@ -819,20 +884,34 @@ export async function inspectProviderCli({
     ? extractVersion(`${versionResult.stdout}\n${versionResult.stderr}`)
     : null;
   const claudeCodeDoctorStatus =
-    claudeDoctorResult !== null && isSuccessfulCommand(claudeDoctorResult)
+    claudeDoctorResult !== null
       ? parseClaudeCodeDoctorStatus(
           `${claudeDoctorResult.stdout}\n${claudeDoctorResult.stderr}`,
         )
       : null;
+  const claudeCodeDistTags =
+    definition.key === "claudeCode" &&
+    latestResult !== null &&
+    isSuccessfulCommand(latestResult)
+      ? parseClaudeCodeDistTagVersions(
+          `${latestResult.stdout}\n${latestResult.stderr}`,
+        )
+      : null;
+  const claudeCodeVersionStatus =
+    definition.key === "claudeCode"
+      ? resolveClaudeCodeVersionStatus({
+          installed,
+          currentVersion,
+          distTags: claudeCodeDistTags,
+          updateChannel: claudeCodeDoctorStatus?.updateChannel ?? null,
+        })
+      : null;
   const latestVersion =
-    latestResult === null || !isSuccessfulCommand(latestResult)
-      ? null
-      : definition.key === "claudeCode"
-        ? parseNpmDistTagVersion(
-            `${latestResult.stdout}\n${latestResult.stderr}`,
-            claudeCodeDoctorStatus?.updateChannel ?? "latest",
-          )
-        : extractVersion(`${latestResult.stdout}\n${latestResult.stderr}`);
+    claudeCodeVersionStatus === null
+      ? latestResult !== null && isSuccessfulCommand(latestResult)
+        ? extractVersion(`${latestResult.stdout}\n${latestResult.stderr}`)
+        : null
+      : claudeCodeVersionStatus.latestVersion;
   const npmGlobalPrefix = isSuccessfulCommand(npmPrefixResult)
     ? firstOutputLine(npmPrefixResult.stdout)
     : null;
@@ -849,11 +928,9 @@ export async function inspectProviderCli({
     npmGlobalPrefix,
     nodePlatform,
   });
-  const needsUpdate = needsProviderCliUpdate({
-    installed,
-    currentVersion,
-    latestVersion,
-  });
+  const needsUpdate =
+    claudeCodeVersionStatus?.needsUpdate ??
+    needsProviderCliUpdate({ installed, currentVersion, latestVersion });
   const versionUnsupported = isProviderCliVersionUnsupported({
     installed,
     currentVersion,
@@ -862,6 +939,7 @@ export async function inspectProviderCli({
   const installAction = buildInstallAction({
     definition,
     installed,
+    executablePath,
     installSource,
     needsUpdate,
     versionUnsupported,

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -36,7 +36,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 105 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 106 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1056,12 +1056,12 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
-  // Version 105 makes Claude Code update status respect the active release
-  // channel and installation manager. Older daemons can keep advertising an
-  // update their active executable will never apply, so enrolled machines must
-  // update for the new behavior.
-  it("uses protocol version 105 for Claude Code update status", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(105);
+  // Version 106 preserves an unknown Claude Code release channel when doctor
+  // cannot report it and recovers native update actions for standard installs.
+  // Older daemons can verify stable against latest or hide the managed update,
+  // so enrolled machines must update for the corrected status behavior.
+  it("uses protocol version 106 for Claude Code status fixes", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(106);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {


### PR DESCRIPTION
## Summary

- Follow up on review findings from #1367 by preserving managed native updates when older `claude doctor` versions fail outside a TTY.
- Keep an unavailable Claude release channel unknown instead of defaulting stable installations to `latest`; only report a definite update when both possible channels are newer.
- Verify unknown-target updates by requiring the installed version to advance, and present the unknown target accurately in the app.
- Bump the host-daemon protocol to 106 so enrolled machines receive the corrected status and action behavior.

## Testing

- `pnpm exec turbo run test --filter=@bb/host-daemon --filter=@bb/app --filter=@bb/host-daemon-contract --force` (3,141 tests)
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon --filter=@bb/app --filter=@bb/host-daemon-contract`
- `git diff --check`

> AGENT GENERATED: by GPT-5