### PR TITLE
Fix duplicate mobile sidebar close animation

### DIFF
--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -16,11 +16,8 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from "@/components/ui/sidebar.js";
-import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { ThreadTitleMentionResourcesProvider } from "@/components/thread/ThreadTitleMentions";
 import { AppCommandShortcutHint } from "@/components/commands/AppCommandShortcutHint";
-import { SettingsSidebar } from "@/components/settings/SettingsSidebar";
-import { ToolsSidebar } from "@/components/tools/ToolsSidebar";
 import { ToolsHubExperimentProvider } from "@/components/tools/tools-experiment-context";
 import {
   resolveAutomationBreadcrumbs,
@@ -79,6 +76,7 @@ import { IframeDragGuardOverlay } from "@/lib/iframe-drag-guard";
 import { dispatchBrowserViewBoundsSync } from "@/lib/browser-view-bounds-sync";
 import { useFaviconBadge } from "@/lib/favicon-color-preference";
 import { shouldShowFaviconAttentionDot } from "./faviconAttentionDot";
+import { AppLayoutSidebar } from "./AppLayoutSidebar";
 import {
   useAppCommandHandler,
   useAppCommandShortcut,
@@ -834,29 +832,21 @@ export function AppLayout({ children }: AppLayoutProps) {
               providerRef={providerRef}
               style={sidebarProviderStyle}
             >
-              {isGlobalSettingsView ? (
-                <SettingsSidebar
-                  onResizeMouseDown={handleResizeMouseDown}
-                  isResizing={isSidebarResizing}
-                  showTopReserve={true}
-                  appRoutePath={appRoutePath}
-                />
-              ) : isGlobalToolsView ? (
-                <ToolsSidebar
-                  onResizeMouseDown={handleResizeMouseDown}
-                  isResizing={isSidebarResizing}
-                  showTopReserve={true}
-                  appRoutePath={toolsBackRoutePath}
-                />
-              ) : (
-                <AppSidebar
-                  onResizeMouseDown={handleResizeMouseDown}
-                  isResizing={isSidebarResizing}
-                  showTopReserve={true}
-                  settingsRoutePath={settingsRoutePath}
-                  toolsRoutePath={toolsHubEnabled ? toolsRoutePath : undefined}
-                />
-              )}
+              <AppLayoutSidebar
+                mode={
+                  isGlobalSettingsView
+                    ? "settings"
+                    : isGlobalToolsView
+                      ? "tools"
+                      : "app"
+                }
+                onResizeMouseDown={handleResizeMouseDown}
+                isResizing={isSidebarResizing}
+                appRoutePath={appRoutePath}
+                settingsRoutePath={settingsRoutePath}
+                toolsBackRoutePath={toolsBackRoutePath}
+                toolsRoutePath={toolsHubEnabled ? toolsRoutePath : undefined}
+              />
               <SidebarInset>
                 <div
                   ref={contentShellRef}

--- a/apps/app/src/components/layout/AppLayoutSidebar.test.tsx
+++ b/apps/app/src/components/layout/AppLayoutSidebar.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
+import {
+  SidebarProvider,
+  SidebarTrigger,
+  useCloseMobileSidebar,
+} from "@/components/ui/sidebar";
+import {
+  AppLayoutSidebar,
+  type AppLayoutSidebarMode,
+} from "./AppLayoutSidebar";
+
+vi.mock("@/components/sidebar/AppSidebar", async () => {
+  const { Sidebar } = await vi.importActual<
+    typeof import("@/components/ui/sidebar")
+  >("@/components/ui/sidebar");
+  return {
+    AppSidebar: () => <Sidebar>App sidebar</Sidebar>,
+  };
+});
+
+vi.mock("@/components/settings/SettingsSidebar", async () => {
+  const { Sidebar } = await vi.importActual<
+    typeof import("@/components/ui/sidebar")
+  >("@/components/ui/sidebar");
+  return {
+    SettingsSidebar: () => <Sidebar>Settings sidebar</Sidebar>,
+  };
+});
+
+vi.mock("@/components/tools/ToolsSidebar", async () => {
+  const { Sidebar } = await vi.importActual<
+    typeof import("@/components/ui/sidebar")
+  >("@/components/ui/sidebar");
+  return {
+    ToolsSidebar: () => <Sidebar>Tools sidebar</Sidebar>,
+  };
+});
+
+const MOBILE_TOGGLE_SETTLE_MS = 220;
+
+function settleMobileToggle() {
+  act(() => {
+    vi.advanceTimersByTime(MOBILE_TOGGLE_SETTLE_MS);
+  });
+}
+
+function getMobilePanel(): HTMLElement {
+  const panel = document.querySelector('[data-sidebar="panel"]');
+  if (!(panel instanceof HTMLElement)) {
+    throw new Error("Expected the mobile sidebar panel");
+  }
+  return panel;
+}
+
+function SidebarModeHarness() {
+  const [mode, setMode] = useState<AppLayoutSidebarMode>("app");
+  const closeMobileSidebar = useCloseMobileSidebar();
+  const navigate = (nextMode: AppLayoutSidebarMode) => {
+    closeMobileSidebar();
+    setMode(nextMode);
+  };
+
+  return (
+    <>
+      <button type="button" onClick={() => navigate("settings")}>
+        Navigate to settings
+      </button>
+      <button type="button" onClick={() => navigate("app")}>
+        Navigate back to app
+      </button>
+      <AppLayoutSidebar
+        mode={mode}
+        onResizeMouseDown={() => {}}
+        isResizing={false}
+        appRoutePath="/"
+        settingsRoutePath="/settings"
+        toolsBackRoutePath="/"
+      />
+      <SidebarTrigger />
+    </>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("AppLayoutSidebar mobile mode transitions", () => {
+  it("waits for the current drawer to close before swapping sidebar modes", () => {
+    vi.useFakeTimers();
+    render(
+      <CompactViewportOverrideProvider isCompactViewport>
+        <SidebarProvider>
+          <SidebarModeHarness />
+        </SidebarProvider>
+      </CompactViewportOverrideProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
+    settleMobileToggle();
+
+    const appPanel = getMobilePanel();
+    expect(appPanel.dataset.state).toBe("open");
+    expect(appPanel.textContent).toContain("App sidebar");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Navigate to settings" }),
+    );
+
+    // The route/mode changes immediately, but the currently visible panel
+    // remains mounted for its one compositor-driven close.
+    expect(getMobilePanel()).toBe(appPanel);
+    expect(appPanel.textContent).toContain("App sidebar");
+    expect(appPanel.style.translate).toBe("-100%");
+
+    settleMobileToggle();
+
+    const settingsPanel = getMobilePanel();
+    expect(settingsPanel).not.toBe(appPanel);
+    expect(settingsPanel.dataset.state).toBe("closed");
+    expect(settingsPanel.textContent).toContain("Settings sidebar");
+    expect(settingsPanel.className).toContain(
+      "data-[state=closed]:-translate-x-full",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
+    settleMobileToggle();
+    expect(getMobilePanel().dataset.state).toBe("open");
+
+    const reopenedSettingsPanel = getMobilePanel();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Navigate back to app" }),
+    );
+
+    expect(getMobilePanel()).toBe(reopenedSettingsPanel);
+    expect(reopenedSettingsPanel.textContent).toContain("Settings sidebar");
+    expect(reopenedSettingsPanel.style.translate).toBe("-100%");
+
+    settleMobileToggle();
+
+    const returnedAppPanel = getMobilePanel();
+    expect(returnedAppPanel).not.toBe(reopenedSettingsPanel);
+    expect(returnedAppPanel.dataset.state).toBe("closed");
+    expect(returnedAppPanel.textContent).toContain("App sidebar");
+    expect(returnedAppPanel.className).toContain(
+      "data-[state=closed]:-translate-x-full",
+    );
+  });
+});

--- a/apps/app/src/components/layout/AppLayoutSidebar.test.tsx
+++ b/apps/app/src/components/layout/AppLayoutSidebar.test.tsx
@@ -73,6 +73,9 @@ function SidebarModeHarness() {
       <button type="button" onClick={() => navigate("app")}>
         Navigate back to app
       </button>
+      <button type="button" onClick={() => setMode("settings")}>
+        Change route without closing
+      </button>
       <AppLayoutSidebar
         mode={mode}
         onResizeMouseDown={() => {}}
@@ -125,9 +128,6 @@ describe("AppLayoutSidebar mobile mode transitions", () => {
     expect(settingsPanel).not.toBe(appPanel);
     expect(settingsPanel.dataset.state).toBe("closed");
     expect(settingsPanel.textContent).toContain("Settings sidebar");
-    expect(settingsPanel.className).toContain(
-      "data-[state=closed]:-translate-x-full",
-    );
 
     fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
     settleMobileToggle();
@@ -148,8 +148,32 @@ describe("AppLayoutSidebar mobile mode transitions", () => {
     expect(returnedAppPanel).not.toBe(reopenedSettingsPanel);
     expect(returnedAppPanel.dataset.state).toBe("closed");
     expect(returnedAppPanel.textContent).toContain("App sidebar");
-    expect(returnedAppPanel.className).toContain(
-      "data-[state=closed]:-translate-x-full",
+  });
+
+  it("swaps modes immediately when navigation does not close the drawer", () => {
+    vi.useFakeTimers();
+    render(
+      <CompactViewportOverrideProvider isCompactViewport>
+        <SidebarProvider>
+          <SidebarModeHarness />
+        </SidebarProvider>
+      </CompactViewportOverrideProvider>,
     );
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
+    settleMobileToggle();
+
+    const appPanel = getMobilePanel();
+    expect(appPanel.dataset.state).toBe("open");
+    expect(appPanel.textContent).toContain("App sidebar");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Change route without closing" }),
+    );
+
+    const settingsPanel = getMobilePanel();
+    expect(settingsPanel).not.toBe(appPanel);
+    expect(settingsPanel.dataset.state).toBe("open");
+    expect(settingsPanel.textContent).toContain("Settings sidebar");
   });
 });

--- a/apps/app/src/components/layout/AppLayoutSidebar.tsx
+++ b/apps/app/src/components/layout/AppLayoutSidebar.tsx
@@ -1,0 +1,83 @@
+import {
+  useEffect,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+} from "react";
+import { AppSidebar } from "@/components/sidebar/AppSidebar";
+import { SettingsSidebar } from "@/components/settings/SettingsSidebar";
+import { ToolsSidebar } from "@/components/tools/ToolsSidebar";
+import { useSidebar } from "@/components/ui/sidebar.js";
+
+export type AppLayoutSidebarMode = "app" | "settings" | "tools";
+
+interface AppLayoutSidebarProps {
+  mode: AppLayoutSidebarMode;
+  onResizeMouseDown: (event: ReactMouseEvent<HTMLDivElement>) => void;
+  isResizing: boolean;
+  appRoutePath: string;
+  settingsRoutePath: string;
+  toolsBackRoutePath: string;
+  toolsRoutePath?: string;
+}
+
+/**
+ * Keeps the current mobile drawer mounted until its close animation finishes.
+ *
+ * Routes such as Settings replace the entire sidebar. Mobile closes are
+ * intentionally deferred so the compositor can finish the slide before the
+ * expensive React state commit. Swapping sidebar modes during that window
+ * would mount a fresh, still-open panel and replay the close animation.
+ */
+export function AppLayoutSidebar({
+  mode,
+  onResizeMouseDown,
+  isResizing,
+  appRoutePath,
+  settingsRoutePath,
+  toolsBackRoutePath,
+  toolsRoutePath,
+}: AppLayoutSidebarProps) {
+  const { isCompactViewport, openMobile } = useSidebar();
+  const holdCurrentMode = isCompactViewport && openMobile;
+  const [settledMode, setSettledMode] = useState(mode);
+
+  useEffect(() => {
+    if (!holdCurrentMode) {
+      setSettledMode(mode);
+    }
+  }, [holdCurrentMode, mode]);
+
+  const renderedMode = holdCurrentMode ? settledMode : mode;
+
+  if (renderedMode === "settings") {
+    return (
+      <SettingsSidebar
+        onResizeMouseDown={onResizeMouseDown}
+        isResizing={isResizing}
+        showTopReserve={true}
+        appRoutePath={appRoutePath}
+      />
+    );
+  }
+
+  if (renderedMode === "tools") {
+    return (
+      <ToolsSidebar
+        onResizeMouseDown={onResizeMouseDown}
+        isResizing={isResizing}
+        showTopReserve={true}
+        appRoutePath={toolsBackRoutePath}
+      />
+    );
+  }
+
+  return (
+    <AppSidebar
+      onResizeMouseDown={onResizeMouseDown}
+      isResizing={isResizing}
+      showTopReserve={true}
+      settingsRoutePath={settingsRoutePath}
+      toolsRoutePath={toolsRoutePath}
+    />
+  );
+}

--- a/apps/app/src/components/layout/AppLayoutSidebar.tsx
+++ b/apps/app/src/components/layout/AppLayoutSidebar.tsx
@@ -1,8 +1,4 @@
-import {
-  useEffect,
-  useState,
-  type MouseEvent as ReactMouseEvent,
-} from "react";
+import { useState, type MouseEvent as ReactMouseEvent } from "react";
 import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { SettingsSidebar } from "@/components/settings/SettingsSidebar";
 import { ToolsSidebar } from "@/components/tools/ToolsSidebar";
@@ -37,17 +33,15 @@ export function AppLayoutSidebar({
   toolsBackRoutePath,
   toolsRoutePath,
 }: AppLayoutSidebarProps) {
-  const { isCompactViewport, openMobile } = useSidebar();
-  const holdCurrentMode = isCompactViewport && openMobile;
-  const [settledMode, setSettledMode] = useState(mode);
-
-  useEffect(() => {
-    if (!holdCurrentMode) {
-      setSettledMode(mode);
-    }
-  }, [holdCurrentMode, mode]);
-
-  const renderedMode = holdCurrentMode ? settledMode : mode;
+  const { isCompactViewport, isMobileSidebarClosing } = useSidebar();
+  const holdCurrentMode = isCompactViewport && isMobileSidebarClosing;
+  const [lastVisibleMode, setLastVisibleMode] = useState(mode);
+  if (!holdCurrentMode && lastVisibleMode !== mode) {
+    // React restarts this render before committing, so the next deferred close
+    // can retain the current mode without an effect and its follow-up commit.
+    setLastVisibleMode(mode);
+  }
+  const renderedMode = holdCurrentMode ? lastVisibleMode : mode;
 
   if (renderedMode === "settings") {
     return (

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -360,6 +360,7 @@ type SidebarContext = {
   setOpenMobile: (open: boolean) => void;
   openMobileSidebar: () => void;
   closeMobileSidebar: () => void;
+  isMobileSidebarClosing: boolean;
   suppressMobileOpenAnimation: boolean;
   setSuppressMobileOpenAnimation: (suppress: boolean) => void;
   suppressMobileCloseAnimation: boolean;
@@ -447,6 +448,8 @@ const SidebarProvider = React.forwardRef<
       React.useState(false);
     const [suppressMobileCloseAnimation, setSuppressMobileCloseAnimation] =
       React.useState(false);
+    const [isMobileSidebarClosing, setIsMobileSidebarClosing] =
+      React.useState(false);
     const mobileSettleTimeoutRef = React.useRef<number | null>(null);
 
     const clearMobileSettleTimeout = React.useCallback(() => {
@@ -473,12 +476,14 @@ const SidebarProvider = React.forwardRef<
       // close commit (panel `inert`, data-state flips) then pays its style
       // recalculation after the panel has moved offscreen instead of
       // consuming the whole transition window.
+      setIsMobileSidebarClosing(true);
       applySidebarMobileDragStyles({ progress: 0, settling: true });
       mobileSettleTimeoutRef.current = window.setTimeout(() => {
         mobileSettleTimeoutRef.current = null;
         flushSync(() => {
           setSuppressMobileOpenAnimation(false);
           setSuppressMobileCloseAnimation(true);
+          setIsMobileSidebarClosing(false);
           setOpenMobile(false);
         });
         clearSidebarMobileDragAttributes();
@@ -574,6 +579,7 @@ const SidebarProvider = React.forwardRef<
         setOpenMobile,
         openMobileSidebar,
         closeMobileSidebar,
+        isMobileSidebarClosing,
         suppressMobileOpenAnimation,
         setSuppressMobileOpenAnimation,
         suppressMobileCloseAnimation,
@@ -589,6 +595,7 @@ const SidebarProvider = React.forwardRef<
         setOpenMobile,
         openMobileSidebar,
         closeMobileSidebar,
+        isMobileSidebarClosing,
         suppressMobileOpenAnimation,
         setSuppressMobileOpenAnimation,
         suppressMobileCloseAnimation,


### PR DESCRIPTION
## Summary

- keep the current mobile sidebar variant mounted through its deferred close transition
- swap app, Settings, and Extensions sidebars only after the drawer is offscreen
- add regression coverage for navigating to Settings and back to the app

## Testing

- pnpm exec turbo run test --filter=@bb/app --force -- src/components/ui/sidebar.test.tsx src/components/layout/AppLayoutSidebar.test.tsx src/components/layout/AppLayout.root-compose-project.test.tsx src/components/layout/AppLayout.plugin-panel-header.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app

> AGENT GENERATED: by Codex GPT-5