### PR TITLE
Fix clipped mobile sidebar in Android in-app browsers

### DIFF
--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -6,14 +6,11 @@
    * Keep the real app shell from becoming a second scroll container. These
    * selectors are class-scoped because Ladle imports app.css but does not use
    * the Vite index.html shell classes.
-   */
-  html.bb-app-shell-root,
-  body.bb-app-shell,
-  body.bb-app-shell #root {
-    height: 100%;
-  }
-
-  /*
+   *
+   * Use the dynamic viewport height in browser tabs so native/in-app browser
+   * chrome cannot leave the percentage-height containing block taller than
+   * the visible window.
+   *
    * iOS standalone subtracts the top safe-area inset from the small and
    * dynamic viewports but not from the large one. On a 852pt screen with a
    * 59pt inset, innerHeight/100svh/100dvh/height:100% all report 793 while
@@ -33,13 +30,18 @@
     --bb-shell-height: 100dvh;
   }
 
+  html.bb-app-shell-root {
+    height: var(--bb-shell-height);
+  }
+
+  body.bb-app-shell,
+  body.bb-app-shell #root {
+    height: 100%;
+  }
+
   @media (display-mode: standalone) {
     :root {
       --bb-shell-height: 100lvh;
-    }
-
-    html.bb-app-shell-root {
-      height: var(--bb-shell-height);
     }
   }
 

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -407,12 +407,14 @@ export function AppLayout({ children }: AppLayoutProps) {
   const splitWorkspaceActive = useSplitWorkspaceActive();
   const store = useStore();
   const contentShellRef = useRef<HTMLDivElement>(null);
+  const providerRef = useRef<HTMLDivElement>(null);
   const restoreIOSViewportOnKeyboardDismissal = useMemo(
     () => shouldRestoreIOSViewportOnKeyboardDismissal(navigator),
     [],
   );
   useMobileVisualViewportHeight(
     contentShellRef,
+    providerRef,
     isCompactViewport,
     restoreIOSViewportOnKeyboardDismissal,
   );
@@ -572,7 +574,6 @@ export function AppLayout({ children }: AppLayoutProps) {
     threadDetailBootstrapQuery.isSuccess || threadDetailBootstrapQuery.isError;
   const [sidebarWidth, setSidebarWidth] = useAtom(sidebarWidthAtom);
   const [isSidebarResizing, setIsSidebarResizing] = useState(false);
-  const providerRef = useRef<HTMLDivElement>(null);
   const startXRef = useRef(0);
   const startWidthRef = useRef(0);
   const liveWidthRef = useRef(sidebarWidth);

--- a/apps/app/src/components/layout/useMobileVisualViewportHeight.test.tsx
+++ b/apps/app/src/components/layout/useMobileVisualViewportHeight.test.tsx
@@ -28,15 +28,19 @@ function VisualViewportShell({
   restoreImmediatelyOnKeyboardDismissal?: boolean;
 }) {
   const shellRef = useRef<HTMLDivElement>(null);
+  const shellHeightRootRef = useRef<HTMLDivElement>(null);
   useMobileVisualViewportHeight(
     shellRef,
+    shellHeightRootRef,
     enabled,
     restoreImmediatelyOnKeyboardDismissal,
   );
   return (
-    <div ref={shellRef} data-testid="shell">
-      <textarea data-testid="editor" />
-      <textarea data-testid="other-editor" />
+    <div ref={shellHeightRootRef} data-testid="shell-height-root">
+      <div ref={shellRef} data-testid="shell">
+        <textarea data-testid="editor" />
+        <textarea data-testid="other-editor" />
+      </div>
     </div>
   );
 }
@@ -119,18 +123,28 @@ describe("useMobileVisualViewportHeight", () => {
     await withFakeVisualViewport(visualViewport, async () => {
       const { rerender } = render(<VisualViewportShell enabled />);
       const shell = screen.getByTestId("shell");
+      const shellHeightRoot = screen.getByTestId("shell-height-root");
       expect(shell.style.top).toBe("20px");
       expect(shell.style.height).toBe("500px");
+      expect(shellHeightRoot.style.getPropertyValue("--bb-shell-height")).toBe(
+        "500px",
+      );
 
       act(() => {
         visualViewport.height = 300;
         visualViewport.dispatchEvent(new Event("resize"));
       });
       await waitFor(() => expect(shell.style.height).toBe("300px"));
+      expect(shellHeightRoot.style.getPropertyValue("--bb-shell-height")).toBe(
+        "300px",
+      );
 
       rerender(<VisualViewportShell enabled={false} />);
       expect(shell.style.top).toBe("");
       expect(shell.style.height).toBe("");
+      expect(
+        shellHeightRoot.style.getPropertyValue("--bb-shell-height"),
+      ).toBe("");
     });
   });
 
@@ -154,9 +168,14 @@ describe("useMobileVisualViewportHeight", () => {
                 />,
               );
               const shell = screen.getByTestId("shell");
+              const shellHeightRoot =
+                screen.getByTestId("shell-height-root");
               const editor = screen.getByTestId("editor");
               expect(shell.style.top).toBe("");
               expect(shell.style.height).toBe("");
+              expect(
+                shellHeightRoot.style.getPropertyValue("--bb-shell-height"),
+              ).toBe("");
 
               act(() => {
                 // Android's root clientHeight can equal the visible viewport
@@ -166,12 +185,18 @@ describe("useMobileVisualViewportHeight", () => {
               });
               await waitFor(() => expect(shell.style.height).toBe("500px"));
               expect(shell.style.top).toBe("0px");
+              expect(
+                shellHeightRoot.style.getPropertyValue("--bb-shell-height"),
+              ).toBe("500px");
 
               act(() => {
                 shellContainingBlockHeight = 500;
                 window.dispatchEvent(new Event("resize"));
               });
               await waitFor(() => expect(shell.style.height).toBe(""));
+              expect(
+                shellHeightRoot.style.getPropertyValue("--bb-shell-height"),
+              ).toBe("");
 
               act(() => {
                 visualViewport.height = 300;
@@ -179,6 +204,9 @@ describe("useMobileVisualViewportHeight", () => {
               });
               await waitFor(() => expect(shell.style.height).toBe("300px"));
               expect(shell.style.top).toBe("0px");
+              expect(
+                shellHeightRoot.style.getPropertyValue("--bb-shell-height"),
+              ).toBe("300px");
 
               act(() => editor.focus());
               act(() => editor.blur());
@@ -190,6 +218,9 @@ describe("useMobileVisualViewportHeight", () => {
               });
               await waitFor(() => expect(shell.style.height).toBe(""));
               expect(shell.style.top).toBe("");
+              expect(
+                shellHeightRoot.style.getPropertyValue("--bb-shell-height"),
+              ).toBe("");
             }),
         ),
     );

--- a/apps/app/src/components/layout/useMobileVisualViewportHeight.test.tsx
+++ b/apps/app/src/components/layout/useMobileVisualViewportHeight.test.tsx
@@ -142,9 +142,9 @@ describe("useMobileVisualViewportHeight", () => {
       rerender(<VisualViewportShell enabled={false} />);
       expect(shell.style.top).toBe("");
       expect(shell.style.height).toBe("");
-      expect(
-        shellHeightRoot.style.getPropertyValue("--bb-shell-height"),
-      ).toBe("");
+      expect(shellHeightRoot.style.getPropertyValue("--bb-shell-height")).toBe(
+        "",
+      );
     });
   });
 
@@ -168,8 +168,7 @@ describe("useMobileVisualViewportHeight", () => {
                 />,
               );
               const shell = screen.getByTestId("shell");
-              const shellHeightRoot =
-                screen.getByTestId("shell-height-root");
+              const shellHeightRoot = screen.getByTestId("shell-height-root");
               const editor = screen.getByTestId("editor");
               expect(shell.style.top).toBe("");
               expect(shell.style.height).toBe("");

--- a/apps/app/src/components/layout/useMobileVisualViewportHeight.ts
+++ b/apps/app/src/components/layout/useMobileVisualViewportHeight.ts
@@ -44,20 +44,26 @@ function isKeyboardFocusTarget(target: EventTarget | null): boolean {
  */
 export function useMobileVisualViewportHeight(
   shellRef: RefObject<AppShellElement | null>,
+  shellHeightRootRef: RefObject<AppShellElement | null>,
   enabled: boolean,
   restoreImmediatelyOnKeyboardDismissal: boolean,
 ) {
   useEffect(() => {
     const shell = shellRef.current;
+    const shellHeightRoot = shellHeightRootRef.current;
     const visualViewport = window.visualViewport;
-    if (!shell || !enabled || !visualViewport) return;
+    if (!shell || !shellHeightRoot || !enabled || !visualViewport) return;
 
     let animationFrame: number | null = null;
+    const clearViewportOverride = () => {
+      shell.style.removeProperty("top");
+      shell.style.removeProperty("height");
+      shellHeightRoot.style.removeProperty("--bb-shell-height");
+    };
     const updateHeight = () => {
       animationFrame = null;
       if (visualViewport.scale !== 1) {
-        shell.style.removeProperty("top");
-        shell.style.removeProperty("height");
+        clearViewportOverride();
         return;
       }
 
@@ -76,8 +82,7 @@ export function useMobileVisualViewportHeight(
       ) {
         // Avoid an unnecessary JS override when native layout resizing
         // already matches the visible viewport.
-        shell.style.removeProperty("top");
-        shell.style.removeProperty("height");
+        clearViewportOverride();
         return;
       }
 
@@ -88,6 +93,14 @@ export function useMobileVisualViewportHeight(
       }
       shell.style.top = `${getVisualViewportPageTop(visualViewport)}px`;
       shell.style.height = `${visualViewportHeight}px`;
+      // Fixed-position descendants cannot inherit the shell element's pixel
+      // height. Publish the same correction through the existing shell-height
+      // switch so the mobile sidebar footer stays inside embedded browsers'
+      // visual viewport too.
+      shellHeightRoot.style.setProperty(
+        "--bb-shell-height",
+        `${visualViewportHeight}px`,
+      );
     };
     const scheduleUpdate = () => {
       if (animationFrame !== null) {
@@ -107,8 +120,7 @@ export function useMobileVisualViewportHeight(
         window.cancelAnimationFrame(animationFrame);
         animationFrame = null;
       }
-      shell.style.removeProperty("top");
-      shell.style.removeProperty("height");
+      clearViewportOverride();
     };
     const handleFocusIn = (event: FocusEvent) => {
       if (!isKeyboardFocusTarget(event.target)) return;
@@ -135,8 +147,12 @@ export function useMobileVisualViewportHeight(
       if (animationFrame !== null) {
         window.cancelAnimationFrame(animationFrame);
       }
-      shell.style.removeProperty("top");
-      shell.style.removeProperty("height");
+      clearViewportOverride();
     };
-  }, [enabled, restoreImmediatelyOnKeyboardDismissal, shellRef]);
+  }, [
+    enabled,
+    restoreImmediatelyOnKeyboardDismissal,
+    shellHeightRootRef,
+    shellRef,
+  ]);
 }

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -614,10 +614,9 @@ const SidebarProvider = React.forwardRef<
               } as React.CSSProperties
             }
             className={cn(
-              // Fill the shell root (html/body/#root are height:100%) instead of
-              // re-measuring the viewport. On iOS standalone, viewport units and
-              // the safe-area insets disagree, and app.css clips the difference
-              // into an unreachable band at the bottom of the screen.
+              // Fill the app root instead of re-measuring the viewport here.
+              // app.css owns the browser-mode-specific root height, while fixed
+              // sidebar panels read the shared --bb-shell-height override.
               "group/sidebar-wrapper flex h-full min-h-0 w-full has-[[data-variant=inset]]:bg-sidebar",
               className,
             )}


### PR DESCRIPTION
## Summary

- size the browser-tab app shell from the dynamic viewport while preserving the iOS standalone large-viewport exception
- publish the existing visual viewport fallback through `--bb-shell-height` so fixed mobile chrome, including the sidebar footer, matches the composer height
- clear the shared pixel override once native viewport sizing catches up or the fallback is disabled
- cover the embedded Android mismatch and cleanup behavior with regression tests

## Root cause

The follow-up composer already corrected its content shell from `visualViewport.height`, but the fixed mobile sidebar remained sized by raw `100dvh`. Android in-app browsers can report those heights differently, placing the settings footer below the visible bottom.

## Validation

- `pnpm exec turbo run test --filter=@bb/app -- src/components/layout/useMobileVisualViewportHeight.test.tsx src/components/ui/sidebar.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (passes with existing warnings)
- `pnpm exec turbo run build --filter=@bb/app`

> AGENT GENERATED: by GPT-5.6 Codex