### PR TITLE
Window large mobile timelines

### DIFF
--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
@@ -691,6 +691,111 @@ describe("ThreadTimelineRows actions", () => {
     expect(setScrollTop).not.toHaveBeenCalled();
   });
 
+  it("re-budgets estimate placeholders to the measured average at idle", async () => {
+    let intersectionCallback: IntersectionObserverCallback | null = null;
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class IntersectionObserverMock {
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback;
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    const rows = Array.from({ length: 80 }, (_, index) =>
+      conversationRow({
+        id: `message_${index}`,
+        role: index % 2 === 0 ? "user" : "assistant",
+        text: `Timeline message ${index}`,
+        sourceSeqStart: index + 1,
+        sourceSeqEnd: index + 1,
+        threadId: "thr_large",
+      }),
+    );
+    const scrollElement = document.createElement("div");
+    const setScrollTop = vi.fn();
+    Object.defineProperty(scrollElement, "scrollTop", {
+      configurable: true,
+      get: () => 500,
+      set: setScrollTop,
+    });
+    Object.defineProperty(scrollElement, "scrollHeight", {
+      configurable: true,
+      value: 16_000,
+    });
+    Object.defineProperty(scrollElement, "clientHeight", {
+      configurable: true,
+      value: 0,
+    });
+    scrollElement.getBoundingClientRect = () =>
+      ({ top: 0, bottom: 800 }) as DOMRect;
+    const bottomAnchor: BottomAnchorContextValue = {
+      captureScrollAnchor: vi.fn(),
+      getScrollElement: () => scrollElement,
+      isAtBottom: false,
+      scrollElementIntoView: vi.fn(),
+      scrollElementIntoViewClampedToMaxScroll: vi.fn(),
+      scrollToBottom: vi.fn(),
+    };
+
+    const { container } = renderWithRouter(
+      <BottomAnchorContext.Provider value={bottomAnchor}>
+        <CompactViewportOverrideProvider isCompactViewport>
+          <ThreadTimelineRows
+            threadId="thr_large"
+            timelineRows={rows}
+            threadRuntimeDisplayStatus="idle"
+            workspaceRootPath={undefined}
+          />
+        </CompactViewportOverrideProvider>
+      </BottomAnchorContext.Provider>,
+    );
+
+    const wrapperOf = (id: string) =>
+      container.querySelector<HTMLElement>(`[data-timeline-row-id="${id}"]`);
+
+    // Realize eight 500px rows above the viewport in one scroll-time batch:
+    // 8 × (500 − 120) = 3,040px of donor demand against the 3,600px pool in
+    // message_0..29. The final 40px shortfall sits under the residual
+    // tolerance, so no scrollTop write happens.
+    scrollElement.dataset.scrollbarScrolling = "true";
+    const targets = Array.from({ length: 8 }, (_, offset) => {
+      const wrapper = wrapperOf(`message_${30 + offset}`);
+      wrapper!.getBoundingClientRect = () => ({ height: 500 }) as DOMRect;
+      return wrapper!;
+    });
+    act(() => {
+      intersectionCallback?.(
+        targets.map(
+          (target) =>
+            ({
+              target,
+              isIntersecting: true,
+              boundingClientRect: { top: -600, height: 120 },
+            }) as unknown as IntersectionObserverEntry,
+        ),
+        {} as IntersectionObserver,
+      );
+    });
+    expect(wrapperOf("message_30")?.dataset.timelineRowRealized).toBe("true");
+    expect(wrapperOf("message_0")?.style.height).toBe("0px");
+    expect(wrapperOf("message_26")?.style.height).toBe("120px");
+    expect(setScrollTop).not.toHaveBeenCalled();
+
+    // Once the scroll idles, never-realized placeholders re-seed to the
+    // measured 500px average, refilling the drained donor pool.
+    scrollElement.removeAttribute("data-scrollbar-scrolling");
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 450));
+    });
+    expect(wrapperOf("message_0")?.style.height).toBe("500px");
+    expect(wrapperOf("message_26")?.style.height).toBe("500px");
+    expect(wrapperOf("message_50")?.style.height).toBe("500px");
+    expect(setScrollTop).not.toHaveBeenCalled();
+  });
+
   it("releases the oldest interaction pin once the cap is exceeded", async () => {
     let intersectionCallback: IntersectionObserverCallback | null = null;
     vi.stubGlobal(

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
@@ -12,6 +12,12 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useState, type ComponentProps, type ReactElement } from "react";
 import { MemoryRouter, useNavigate } from "react-router-dom";
+import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
+import { getDefaultStore } from "jotai";
+import {
+  BottomAnchorContext,
+  type BottomAnchorContextValue,
+} from "@/components/ui/bottom-anchored-scroll-body";
 import { COMPACT_VIEWPORT_QUERY } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { POINTER_COARSE_QUERY } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import type { PluginMessageActionRegistration } from "@bb/plugin-sdk";
@@ -25,6 +31,7 @@ import {
   setPluginSlotRegistrations,
   type PluginRegistrationSet,
 } from "@/lib/plugin-slots";
+import { threadTimelineScrollAnchorAtomFamily } from "@/lib/thread-timeline-scroll-anchor";
 import { ThreadTimelineRows } from "./ThreadTimelineRows";
 
 function messageActionRegistrationSet(
@@ -268,11 +275,420 @@ function mockSelectionMenuMedia({
 
 afterEach(() => {
   cleanup();
+  getDefaultStore().set(
+    threadTimelineScrollAnchorAtomFamily("thr_large"),
+    null,
+  );
   resetPluginSlotStoreForTest();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("ThreadTimelineRows actions", () => {
+  it("keeps measured placeholders and preserves the visible row", async () => {
+    let intersectionCallback: IntersectionObserverCallback | null = null;
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class IntersectionObserverMock {
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback;
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    const rows = Array.from({ length: 80 }, (_, index) =>
+      conversationRow({
+        id: `message_${index}`,
+        role: index % 2 === 0 ? "user" : "assistant",
+        text: `Timeline message ${index}`,
+        sourceSeqStart: index + 1,
+        sourceSeqEnd: index + 1,
+        threadId: "thr_large",
+      }),
+    );
+    const scrollElement = document.createElement("div");
+    let scrollTop = 17;
+    const setScrollTop = vi.fn((value: number) => {
+      scrollTop = value;
+    });
+    Object.defineProperty(scrollElement, "clientHeight", {
+      configurable: true,
+      value: 0,
+    });
+    Object.defineProperty(scrollElement, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: setScrollTop,
+    });
+    Object.defineProperty(scrollElement, "scrollHeight", {
+      configurable: true,
+      value: 16_000,
+    });
+    scrollElement.getBoundingClientRect = () =>
+      ({ top: 0, bottom: 800 }) as DOMRect;
+
+    const bottomAnchor: BottomAnchorContextValue = {
+      captureScrollAnchor: vi.fn(),
+      getScrollElement: () => scrollElement,
+      isAtBottom: true,
+      scrollElementIntoView: vi.fn(),
+      scrollElementIntoViewClampedToMaxScroll: vi.fn(),
+      scrollToBottom: vi.fn(),
+    };
+
+    const { container } = renderWithRouter(
+      <BottomAnchorContext.Provider value={bottomAnchor}>
+        <CompactViewportOverrideProvider isCompactViewport>
+          <ThreadTimelineRows
+            threadId="thr_large"
+            timelineRows={rows}
+            threadRuntimeDisplayStatus="idle"
+            workspaceRootPath={undefined}
+          />
+        </CompactViewportOverrideProvider>
+      </BottomAnchorContext.Provider>,
+    );
+
+    const windowedList = container.querySelector<HTMLElement>(
+      '[data-timeline-windowed="true"]',
+    );
+    expect(windowedList).not.toBeNull();
+    expect(windowedList?.closest('[style*="overflow-y: clip"]')).toBeNull();
+    expect(container.querySelectorAll("[data-timeline-row-id]").length).toBe(
+      rows.length,
+    );
+    expect(
+      container.querySelectorAll('[data-timeline-row-realized="true"]').length,
+    ).toBeLessThan(rows.length);
+
+    const firstWrapper = container.querySelector<HTMLElement>(
+      '[data-timeline-row-id="message_0"]',
+    );
+    const lastWrapper = container.querySelector<HTMLElement>(
+      '[data-timeline-row-id="message_79"]',
+    );
+    lastWrapper!.getBoundingClientRect = () => {
+      const top =
+        firstWrapper?.dataset.timelineRowRealized === "true" ? 320 : 200;
+      return { top, bottom: top + 100 } as DOMRect;
+    };
+    expect(firstWrapper?.dataset.timelineRowRealized).toBe("false");
+    expect(lastWrapper?.dataset.timelineRowRealized).toBe("true");
+
+    act(() => {
+      intersectionCallback?.(
+        [
+          {
+            target: lastWrapper!,
+            isIntersecting: false,
+            boundingClientRect: { height: 144 },
+          } as unknown as IntersectionObserverEntry,
+        ],
+        {} as IntersectionObserver,
+      );
+    });
+    await waitFor(() =>
+      expect(lastWrapper?.dataset.timelineRowRealized).toBe("false"),
+    );
+
+    await act(async () => {
+      intersectionCallback?.(
+        [
+          {
+            target: firstWrapper!,
+            isIntersecting: true,
+            boundingClientRect: { height: 120 },
+          } as unknown as IntersectionObserverEntry,
+        ],
+        {} as IntersectionObserver,
+      );
+    });
+    await waitFor(() =>
+      expect(firstWrapper?.dataset.timelineRowRealized).toBe("true"),
+    );
+    expect(scrollTop).toBe(137);
+
+    act(() => {
+      intersectionCallback?.(
+        [
+          {
+            target: firstWrapper!,
+            isIntersecting: false,
+            boundingClientRect: { height: 212 },
+          } as unknown as IntersectionObserverEntry,
+        ],
+        {} as IntersectionObserver,
+      );
+    });
+    await waitFor(() =>
+      expect(firstWrapper?.dataset.timelineRowRealized).toBe("false"),
+    );
+    expect(firstWrapper?.style.height).toBe("212px");
+    expect(scrollTop).toBe(17);
+    expect(setScrollTop).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps an interacted row mounted after it leaves the window", async () => {
+    let intersectionCallback: IntersectionObserverCallback | null = null;
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class IntersectionObserverMock {
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback;
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    const rows = [
+      turnRow({
+        id: "expandable_turn",
+        children: [
+          conversationRow({
+            id: "expanded_child",
+            role: "assistant",
+            text: "Expanded row state stays mounted.",
+            threadId: "thr_large",
+          }),
+        ],
+        threadId: "thr_large",
+      }),
+      ...Array.from({ length: 79 }, (_, index) =>
+        conversationRow({
+          id: `message_${index + 1}`,
+          role: index % 2 === 0 ? "user" : "assistant",
+          text: `Timeline message ${index + 1}`,
+          sourceSeqStart: index + 20,
+          sourceSeqEnd: index + 20,
+          threadId: "thr_large",
+        }),
+      ),
+    ];
+    const scrollElement = document.createElement("div");
+    const bottomAnchor: BottomAnchorContextValue = {
+      captureScrollAnchor: vi.fn(),
+      getScrollElement: () => scrollElement,
+      isAtBottom: true,
+      scrollElementIntoView: vi.fn(),
+      scrollElementIntoViewClampedToMaxScroll: vi.fn(),
+      scrollToBottom: vi.fn(),
+    };
+
+    const { container } = renderWithRouter(
+      <BottomAnchorContext.Provider value={bottomAnchor}>
+        <CompactViewportOverrideProvider isCompactViewport>
+          <ThreadTimelineRows
+            threadId="thr_large"
+            timelineRows={rows}
+            threadRuntimeDisplayStatus="idle"
+            workspaceRootPath={undefined}
+          />
+        </CompactViewportOverrideProvider>
+      </BottomAnchorContext.Provider>,
+    );
+
+    const wrapper = container.querySelector<HTMLElement>(
+      '[data-timeline-row-id="expandable_turn"]',
+    );
+    expect(wrapper?.dataset.timelineRowRealized).toBe("false");
+
+    await act(async () => {
+      intersectionCallback?.(
+        [
+          {
+            target: wrapper!,
+            isIntersecting: true,
+            boundingClientRect: { height: 120 },
+          } as unknown as IntersectionObserverEntry,
+        ],
+        {} as IntersectionObserver,
+      );
+    });
+    const toggle = await waitFor(() => {
+      const element = wrapper?.querySelector<HTMLButtonElement>(
+        'button[aria-expanded="false"]',
+      );
+      if (element === null || element === undefined) {
+        throw new Error("The realized row toggle was not rendered");
+      }
+      return element;
+    });
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("Expanded row state stays mounted.")).toBeTruthy();
+
+    act(() => {
+      intersectionCallback?.(
+        [
+          {
+            target: wrapper!,
+            isIntersecting: false,
+            boundingClientRect: { height: 212 },
+          } as unknown as IntersectionObserverEntry,
+        ],
+        {} as IntersectionObserver,
+      );
+    });
+    await waitFor(() =>
+      expect(wrapper?.dataset.timelineRowRealized).toBe("true"),
+    );
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText("Expanded row state stays mounted.")).toBeTruthy();
+  });
+
+  it("uses a saved anchor when search state belongs to another thread", () => {
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class IntersectionObserverMock {
+        constructor(_callback: IntersectionObserverCallback) {}
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    getDefaultStore().set(threadTimelineScrollAnchorAtomFamily("thr_large"), {
+      rowId: "message_60",
+      offsetWithinRow: 0,
+      atBottom: false,
+    });
+    const rows = Array.from({ length: 80 }, (_, index) =>
+      conversationRow({
+        id: `message_${index}`,
+        role: index % 2 === 0 ? "user" : "assistant",
+        text: `Timeline message ${index}`,
+        sourceSeqStart: index + 1,
+        sourceSeqEnd: index + 1,
+        threadId: "thr_large",
+      }),
+    );
+    const scrollElement = document.createElement("div");
+    const bottomAnchor: BottomAnchorContextValue = {
+      captureScrollAnchor: vi.fn(),
+      getScrollElement: () => scrollElement,
+      isAtBottom: false,
+      scrollElementIntoView: vi.fn(),
+      scrollElementIntoViewClampedToMaxScroll: vi.fn(),
+      scrollToBottom: vi.fn(),
+    };
+
+    const { container } = renderWithRouter(
+      <BottomAnchorContext.Provider value={bottomAnchor}>
+        <CompactViewportOverrideProvider isCompactViewport>
+          <ThreadTimelineRows
+            threadId="thr_large"
+            timelineRows={rows}
+            threadRuntimeDisplayStatus="idle"
+            workspaceRootPath={undefined}
+          />
+        </CompactViewportOverrideProvider>
+      </BottomAnchorContext.Provider>,
+      [
+        {
+          pathname: "/thread",
+          state: { searchMessageSeq: 11, searchThreadId: "thr_other" },
+        },
+      ],
+    );
+
+    expect(
+      container.querySelector<HTMLElement>(
+        '[data-timeline-row-id="message_60"]',
+      )?.dataset.timelineRowRealized,
+    ).toBe("true");
+    expect(
+      container.querySelector<HTMLElement>(
+        '[data-timeline-row-id="message_10"]',
+      )?.dataset.timelineRowRealized,
+    ).toBe("false");
+  });
+
+  it("realizes a search target before it reveals a windowed timeline row", async () => {
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class IntersectionObserverMock {
+        constructor(_callback: IntersectionObserverCallback) {}
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    vi.stubGlobal(
+      "ResizeObserver",
+      class ResizeObserverMock {
+        constructor(_callback: ResizeObserverCallback) {}
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      callback(performance.now());
+      return 1;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+
+    const rows = Array.from({ length: 80 }, (_, index) =>
+      conversationRow({
+        id: `search_message_${index}`,
+        role: index % 2 === 0 ? "user" : "assistant",
+        text: `Search timeline message ${index}`,
+        sourceSeqStart: index + 1,
+        sourceSeqEnd: index + 1,
+        threadId: "thr_large_search",
+      }),
+    );
+    const scrollElement = document.createElement("div");
+    Object.defineProperty(scrollElement, "clientHeight", {
+      configurable: true,
+      value: 800,
+    });
+    const scrollElementIntoView = vi.fn();
+    const bottomAnchor: BottomAnchorContextValue = {
+      captureScrollAnchor: vi.fn(),
+      getScrollElement: () => scrollElement,
+      isAtBottom: false,
+      scrollElementIntoView,
+      scrollElementIntoViewClampedToMaxScroll: vi.fn(),
+      scrollToBottom: vi.fn(),
+    };
+
+    const { container } = renderWithRouter(
+      <BottomAnchorContext.Provider value={bottomAnchor}>
+        <CompactViewportOverrideProvider isCompactViewport>
+          <ThreadTimelineRows
+            threadId="thr_large_search"
+            timelineRows={rows}
+            threadRuntimeDisplayStatus="idle"
+            workspaceRootPath={undefined}
+          />
+        </CompactViewportOverrideProvider>
+      </BottomAnchorContext.Provider>,
+      [
+        {
+          pathname: "/thread",
+          state: {
+            searchMessageSeq: 11,
+            searchThreadId: "thr_large_search",
+          },
+        },
+      ],
+    );
+
+    const target = container.querySelector<HTMLElement>(
+      '[data-timeline-row-id="search_message_10"]',
+    );
+    expect(target?.dataset.timelineRowRealized).toBe("true");
+    await waitFor(() =>
+      expect(scrollElementIntoView).toHaveBeenCalledWith({
+        element: target,
+        options: { block: "center" },
+      }),
+    );
+  });
+
   it("uses inline mobile actions only for the last assistant message", () => {
     const { container } = renderWithRouter(
       <ThreadTimelineRows

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
@@ -429,24 +429,59 @@ describe("ThreadTimelineRows actions", () => {
     expect(scrollTop).toBe(17);
     expect(setScrollTop).toHaveBeenCalledTimes(2);
 
+    // While a scroll is active, a placeholder fully below the viewport
+    // realizes immediately: its height change cannot shift visible content,
+    // so no compensating scrollTop write happens.
     scrollElement.dataset.scrollbarScrolling = "true";
+    const belowViewportWrapper = container.querySelector<HTMLElement>(
+      '[data-timeline-row-id="message_40"]',
+    );
+    expect(belowViewportWrapper?.dataset.timelineRowRealized).toBe("false");
     await act(async () => {
       intersectionCallback?.(
         [
           {
-            target: firstWrapper!,
+            target: belowViewportWrapper!,
             isIntersecting: true,
-            boundingClientRect: { height: 212 },
+            boundingClientRect: { top: 900, height: 120 },
           } as unknown as IntersectionObserverEntry,
         ],
         {} as IntersectionObserver,
       );
     });
     await waitFor(() =>
-      expect(firstWrapper?.dataset.timelineRowRealized).toBe("true"),
+      expect(belowViewportWrapper?.dataset.timelineRowRealized).toBe("true"),
     );
     expect(scrollTop).toBe(17);
     expect(setScrollTop).toHaveBeenCalledTimes(2);
+
+    // A placeholder above the viewport defers while the scroll is active —
+    // realizing it mid-scroll would shift visible content with no WebKit
+    // scroll anchoring to absorb it.
+    await act(async () => {
+      intersectionCallback?.(
+        [
+          {
+            target: firstWrapper!,
+            isIntersecting: true,
+            boundingClientRect: { top: -400, height: 212 },
+          } as unknown as IntersectionObserverEntry,
+        ],
+        {} as IntersectionObserver,
+      );
+    });
+    expect(firstWrapper?.dataset.timelineRowRealized).toBe("false");
+    expect(scrollTop).toBe(17);
+
+    // Once the scroll idles, the deferred realization flushes with anchor
+    // compensation: the visible row keeps its on-screen position.
+    scrollElement.removeAttribute("data-scrollbar-scrolling");
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 350));
+    });
+    expect(firstWrapper?.dataset.timelineRowRealized).toBe("true");
+    expect(scrollTop).toBe(137);
+    expect(setScrollTop).toHaveBeenCalledTimes(3);
   });
 
   it("keeps an interacted row mounted after it leaves the window", async () => {

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
@@ -428,6 +428,25 @@ describe("ThreadTimelineRows actions", () => {
     expect(firstWrapper?.style.height).toBe("212px");
     expect(scrollTop).toBe(17);
     expect(setScrollTop).toHaveBeenCalledTimes(2);
+
+    scrollElement.dataset.scrollbarScrolling = "true";
+    await act(async () => {
+      intersectionCallback?.(
+        [
+          {
+            target: firstWrapper!,
+            isIntersecting: true,
+            boundingClientRect: { height: 212 },
+          } as unknown as IntersectionObserverEntry,
+        ],
+        {} as IntersectionObserver,
+      );
+    });
+    await waitFor(() =>
+      expect(firstWrapper?.dataset.timelineRowRealized).toBe("true"),
+    );
+    expect(scrollTop).toBe(17);
+    expect(setScrollTop).toHaveBeenCalledTimes(2);
   });
 
   it("keeps an interacted row mounted after it leaves the window", async () => {

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
@@ -455,11 +455,10 @@ describe("ThreadTimelineRows actions", () => {
     expect(scrollTop).toBe(17);
     expect(setScrollTop).toHaveBeenCalledTimes(2);
 
-    // The first row has no donor placeholders above it, so a scroll-time
-    // realization cannot balance its height delta. It reverts to its
-    // unchanged placeholder and waits for the idle flush — realizing it
-    // uncompensated would shift visible content with no WebKit scroll
-    // anchoring to absorb it.
+    // The first row has no donor placeholders above it, so its scroll-time
+    // realization compensates through a clamped scrollTop write instead of
+    // leaving a blank row. The content measures 0px (the jsdom default)
+    // against the 212px placeholder, so the -212 residual clamps 17 to 0.
     await act(async () => {
       intersectionCallback?.(
         [
@@ -472,17 +471,8 @@ describe("ThreadTimelineRows actions", () => {
         {} as IntersectionObserver,
       );
     });
-    expect(firstWrapper?.dataset.timelineRowRealized).toBe("false");
-    expect(scrollTop).toBe(17);
-
-    // Once the scroll idles, the deferred realization flushes with anchor
-    // compensation: the visible row keeps its on-screen position.
-    scrollElement.removeAttribute("data-scrollbar-scrolling");
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 350));
-    });
     expect(firstWrapper?.dataset.timelineRowRealized).toBe("true");
-    expect(scrollTop).toBe(137);
+    expect(scrollTop).toBe(0);
     expect(setScrollTop).toHaveBeenCalledTimes(3);
   });
 
@@ -581,13 +571,25 @@ describe("ThreadTimelineRows actions", () => {
     expect(setScrollTop).not.toHaveBeenCalled();
   });
 
-  it("grows a donor placeholder when scroll-time content is shorter than its placeholder", () => {
+  it("grows a donor placeholder for short content and re-balances late growth", () => {
     let intersectionCallback: IntersectionObserverCallback | null = null;
     vi.stubGlobal(
       "IntersectionObserver",
       class IntersectionObserverMock {
         constructor(callback: IntersectionObserverCallback) {
           intersectionCallback = callback;
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    let resizeCallback: ResizeObserverCallback | null = null;
+    vi.stubGlobal(
+      "ResizeObserver",
+      class ResizeObserverMock {
+        constructor(callback: ResizeObserverCallback) {
+          resizeCallback = callback;
         }
         observe() {}
         unobserve() {}
@@ -668,6 +670,105 @@ describe("ThreadTimelineRows actions", () => {
     expect(wrapperOf("message_0")?.style.height).toBe("240px");
     expect(wrapperOf("message_1")?.style.height).toBe("120px");
     expect(setScrollTop).not.toHaveBeenCalled();
+
+    // Late content growth (a lazy image decoding) in the realized row — the
+    // wrapper sits above the viewport (rect bottom 0, viewport top 0), so the
+    // 90px delta against the 0px baseline comes back out of the donor.
+    act(() => {
+      resizeCallback?.(
+        [
+          {
+            target: target!,
+            borderBoxSize: [{ blockSize: 90, inlineSize: 390 }],
+            contentRect: { height: 90 },
+          } as unknown as ResizeObserverEntry,
+        ],
+        {} as ResizeObserver,
+      );
+    });
+    expect(target?.dataset.timelineRowRealized).toBe("true");
+    expect(wrapperOf("message_0")?.style.height).toBe("150px");
+    expect(setScrollTop).not.toHaveBeenCalled();
+  });
+
+  it("releases the oldest interaction pin once the cap is exceeded", async () => {
+    let intersectionCallback: IntersectionObserverCallback | null = null;
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class IntersectionObserverMock {
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback;
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    const rows = Array.from({ length: 80 }, (_, index) =>
+      conversationRow({
+        id: `message_${index}`,
+        role: index % 2 === 0 ? "user" : "assistant",
+        text: `Timeline message ${index}`,
+        sourceSeqStart: index + 1,
+        sourceSeqEnd: index + 1,
+        threadId: "thr_large",
+      }),
+    );
+    const scrollElement = document.createElement("div");
+    const bottomAnchor: BottomAnchorContextValue = {
+      captureScrollAnchor: vi.fn(),
+      getScrollElement: () => scrollElement,
+      isAtBottom: true,
+      scrollElementIntoView: vi.fn(),
+      scrollElementIntoViewClampedToMaxScroll: vi.fn(),
+      scrollToBottom: vi.fn(),
+    };
+
+    const { container } = renderWithRouter(
+      <BottomAnchorContext.Provider value={bottomAnchor}>
+        <CompactViewportOverrideProvider isCompactViewport>
+          <ThreadTimelineRows
+            threadId="thr_large"
+            timelineRows={rows}
+            threadRuntimeDisplayStatus="idle"
+            workspaceRootPath={undefined}
+          />
+        </CompactViewportOverrideProvider>
+      </BottomAnchorContext.Provider>,
+    );
+
+    const wrapperOf = (id: string) =>
+      container.querySelector<HTMLElement>(`[data-timeline-row-id="${id}"]`);
+    expect(wrapperOf("message_66")?.dataset.timelineRowRealized).toBe("true");
+    expect(wrapperOf("message_65")?.dataset.timelineRowRealized).toBe("true");
+
+    // Pin message_66 first, then message_65, then 23 more rows. The 25th pin
+    // exceeds the cap of 24, so the oldest pin (message_66) releases.
+    fireEvent.click(wrapperOf("message_66")!);
+    fireEvent.click(wrapperOf("message_65")!);
+    for (let index = 0; index < 23; index += 1) {
+      fireEvent.click(wrapperOf(`message_${index}`)!);
+    }
+
+    const exitEntry = (id: string) =>
+      ({
+        target: wrapperOf(id)!,
+        isIntersecting: false,
+        boundingClientRect: { height: 100 },
+      }) as unknown as IntersectionObserverEntry;
+    act(() => {
+      intersectionCallback?.(
+        [exitEntry("message_66"), exitEntry("message_65")],
+        {} as IntersectionObserver,
+      );
+    });
+    await waitFor(() =>
+      expect(wrapperOf("message_66")?.dataset.timelineRowRealized).toBe(
+        "false",
+      ),
+    );
+    // The still-pinned row survives the same exit.
+    expect(wrapperOf("message_65")?.dataset.timelineRowRealized).toBe("true");
   });
 
   it("keeps an interacted row mounted after it leaves the window", async () => {

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
@@ -456,9 +456,8 @@ describe("ThreadTimelineRows actions", () => {
     expect(setScrollTop).toHaveBeenCalledTimes(2);
 
     // The first row has no donor placeholders above it, so its scroll-time
-    // realization compensates through a clamped scrollTop write instead of
-    // leaving a blank row. The content measures 0px (the jsdom default)
-    // against the 212px placeholder, so the -212 residual clamps 17 to 0.
+    // realization reverts to the unchanged placeholder: nothing on screen
+    // moves, and no scrollTop write can kill momentum mid-gesture.
     await act(async () => {
       intersectionCallback?.(
         [
@@ -471,8 +470,18 @@ describe("ThreadTimelineRows actions", () => {
         {} as IntersectionObserver,
       );
     });
+    expect(firstWrapper?.dataset.timelineRowRealized).toBe("false");
+    expect(scrollTop).toBe(17);
+    expect(setScrollTop).toHaveBeenCalledTimes(2);
+
+    // The idle pass mounts it with anchor compensation once the scroll
+    // stops: the visible row keeps its on-screen position.
+    scrollElement.removeAttribute("data-scrollbar-scrolling");
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 450));
+    });
     expect(firstWrapper?.dataset.timelineRowRealized).toBe("true");
-    expect(scrollTop).toBe(0);
+    expect(scrollTop).toBe(137);
     expect(setScrollTop).toHaveBeenCalledTimes(3);
   });
 
@@ -671,9 +680,8 @@ describe("ThreadTimelineRows actions", () => {
     expect(wrapperOf("message_1")?.style.height).toBe("120px");
     expect(setScrollTop).not.toHaveBeenCalled();
 
-    // Late content growth (a lazy image decoding) in the realized row — the
-    // wrapper sits above the viewport (rect bottom 0, viewport top 0), so the
-    // 90px delta against the 0px baseline comes back out of the donor.
+    // Late growth while the scroll is active only updates the baseline —
+    // mutating geometry mid-gesture is what reads as snapping.
     act(() => {
       resizeCallback?.(
         [
@@ -686,9 +694,27 @@ describe("ThreadTimelineRows actions", () => {
         {} as ResizeObserver,
       );
     });
-    expect(target?.dataset.timelineRowRealized).toBe("true");
-    expect(wrapperOf("message_0")?.style.height).toBe("150px");
+    expect(wrapperOf("message_0")?.style.height).toBe("240px");
     expect(setScrollTop).not.toHaveBeenCalled();
+
+    // At idle, further growth above the viewport compensates with a direct
+    // scrollTop nudge: 150 − 90 = 60 on top of the current 500.
+    scrollElement.removeAttribute("data-scrollbar-scrolling");
+    act(() => {
+      resizeCallback?.(
+        [
+          {
+            target: target!,
+            borderBoxSize: [{ blockSize: 150, inlineSize: 390 }],
+            contentRect: { height: 150 },
+          } as unknown as ResizeObserverEntry,
+        ],
+        {} as ResizeObserver,
+      );
+    });
+    expect(target?.dataset.timelineRowRealized).toBe("true");
+    expect(wrapperOf("message_0")?.style.height).toBe("240px");
+    expect(setScrollTop).toHaveBeenCalledWith(560);
   });
 
   it("re-budgets estimate placeholders to the measured average at idle", async () => {
@@ -758,8 +784,8 @@ describe("ThreadTimelineRows actions", () => {
 
     // Realize eight 500px rows above the viewport in one scroll-time batch:
     // 8 × (500 − 120) = 3,040px of donor demand against the 3,600px pool in
-    // message_0..29. The final 40px shortfall sits under the residual
-    // tolerance, so no scrollTop write happens.
+    // message_0..29 — solvent, so every row realizes with no scrollTop
+    // write.
     scrollElement.dataset.scrollbarScrolling = "true";
     const targets = Array.from({ length: 8 }, (_, offset) => {
       const wrapper = wrapperOf(`message_${30 + offset}`);

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
@@ -455,9 +455,11 @@ describe("ThreadTimelineRows actions", () => {
     expect(scrollTop).toBe(17);
     expect(setScrollTop).toHaveBeenCalledTimes(2);
 
-    // A placeholder above the viewport defers while the scroll is active —
-    // realizing it mid-scroll would shift visible content with no WebKit
-    // scroll anchoring to absorb it.
+    // The first row has no donor placeholders above it, so a scroll-time
+    // realization cannot balance its height delta. It reverts to its
+    // unchanged placeholder and waits for the idle flush — realizing it
+    // uncompensated would shift visible content with no WebKit scroll
+    // anchoring to absorb it.
     await act(async () => {
       intersectionCallback?.(
         [
@@ -482,6 +484,190 @@ describe("ThreadTimelineRows actions", () => {
     expect(firstWrapper?.dataset.timelineRowRealized).toBe("true");
     expect(scrollTop).toBe(137);
     expect(setScrollTop).toHaveBeenCalledTimes(3);
+  });
+
+  it("realizes above-viewport rows during a scroll by shrinking donor placeholders", () => {
+    let intersectionCallback: IntersectionObserverCallback | null = null;
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class IntersectionObserverMock {
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback;
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    const rows = Array.from({ length: 80 }, (_, index) =>
+      conversationRow({
+        id: `message_${index}`,
+        role: index % 2 === 0 ? "user" : "assistant",
+        text: `Timeline message ${index}`,
+        sourceSeqStart: index + 1,
+        sourceSeqEnd: index + 1,
+        threadId: "thr_large",
+      }),
+    );
+    const scrollElement = document.createElement("div");
+    const setScrollTop = vi.fn();
+    Object.defineProperty(scrollElement, "scrollTop", {
+      configurable: true,
+      get: () => 500,
+      set: setScrollTop,
+    });
+    Object.defineProperty(scrollElement, "scrollHeight", {
+      configurable: true,
+      value: 16_000,
+    });
+    Object.defineProperty(scrollElement, "clientHeight", {
+      configurable: true,
+      value: 0,
+    });
+    scrollElement.getBoundingClientRect = () =>
+      ({ top: 0, bottom: 800 }) as DOMRect;
+    const bottomAnchor: BottomAnchorContextValue = {
+      captureScrollAnchor: vi.fn(),
+      getScrollElement: () => scrollElement,
+      isAtBottom: false,
+      scrollElementIntoView: vi.fn(),
+      scrollElementIntoViewClampedToMaxScroll: vi.fn(),
+      scrollToBottom: vi.fn(),
+    };
+
+    const { container } = renderWithRouter(
+      <BottomAnchorContext.Provider value={bottomAnchor}>
+        <CompactViewportOverrideProvider isCompactViewport>
+          <ThreadTimelineRows
+            threadId="thr_large"
+            timelineRows={rows}
+            threadRuntimeDisplayStatus="idle"
+            workspaceRootPath={undefined}
+          />
+        </CompactViewportOverrideProvider>
+      </BottomAnchorContext.Provider>,
+    );
+
+    const wrapperOf = (id: string) =>
+      container.querySelector<HTMLElement>(`[data-timeline-row-id="${id}"]`);
+    const target = wrapperOf("message_30");
+    expect(target?.dataset.timelineRowRealized).toBe("false");
+    // The realized content measures 500px against a 120px placeholder, so a
+    // 380px delta must come out of donor placeholders above it.
+    target!.getBoundingClientRect = () => ({ height: 500 }) as DOMRect;
+
+    scrollElement.dataset.scrollbarScrolling = "true";
+    act(() => {
+      intersectionCallback?.(
+        [
+          {
+            target: target!,
+            isIntersecting: true,
+            boundingClientRect: { top: -600, height: 120 },
+          } as unknown as IntersectionObserverEntry,
+        ],
+        {} as IntersectionObserver,
+      );
+    });
+
+    expect(target?.dataset.timelineRowRealized).toBe("true");
+    // Donors shrink topmost-first: 120 + 120 + 120 + 20 covers the delta.
+    expect(wrapperOf("message_0")?.style.height).toBe("0px");
+    expect(wrapperOf("message_1")?.style.height).toBe("0px");
+    expect(wrapperOf("message_2")?.style.height).toBe("0px");
+    expect(wrapperOf("message_3")?.style.height).toBe("100px");
+    expect(wrapperOf("message_4")?.style.height).toBe("120px");
+    // No scrollTop write happened, so momentum scrolling survives.
+    expect(setScrollTop).not.toHaveBeenCalled();
+  });
+
+  it("grows a donor placeholder when scroll-time content is shorter than its placeholder", () => {
+    let intersectionCallback: IntersectionObserverCallback | null = null;
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class IntersectionObserverMock {
+        constructor(callback: IntersectionObserverCallback) {
+          intersectionCallback = callback;
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    const rows = Array.from({ length: 80 }, (_, index) =>
+      conversationRow({
+        id: `message_${index}`,
+        role: index % 2 === 0 ? "user" : "assistant",
+        text: `Timeline message ${index}`,
+        sourceSeqStart: index + 1,
+        sourceSeqEnd: index + 1,
+        threadId: "thr_large",
+      }),
+    );
+    const scrollElement = document.createElement("div");
+    const setScrollTop = vi.fn();
+    Object.defineProperty(scrollElement, "scrollTop", {
+      configurable: true,
+      get: () => 500,
+      set: setScrollTop,
+    });
+    Object.defineProperty(scrollElement, "scrollHeight", {
+      configurable: true,
+      value: 16_000,
+    });
+    Object.defineProperty(scrollElement, "clientHeight", {
+      configurable: true,
+      value: 0,
+    });
+    scrollElement.getBoundingClientRect = () =>
+      ({ top: 0, bottom: 800 }) as DOMRect;
+    const bottomAnchor: BottomAnchorContextValue = {
+      captureScrollAnchor: vi.fn(),
+      getScrollElement: () => scrollElement,
+      isAtBottom: false,
+      scrollElementIntoView: vi.fn(),
+      scrollElementIntoViewClampedToMaxScroll: vi.fn(),
+      scrollToBottom: vi.fn(),
+    };
+
+    const { container } = renderWithRouter(
+      <BottomAnchorContext.Provider value={bottomAnchor}>
+        <CompactViewportOverrideProvider isCompactViewport>
+          <ThreadTimelineRows
+            threadId="thr_large"
+            timelineRows={rows}
+            threadRuntimeDisplayStatus="idle"
+            workspaceRootPath={undefined}
+          />
+        </CompactViewportOverrideProvider>
+      </BottomAnchorContext.Provider>,
+    );
+
+    const wrapperOf = (id: string) =>
+      container.querySelector<HTMLElement>(`[data-timeline-row-id="${id}"]`);
+    const target = wrapperOf("message_30");
+    expect(target?.dataset.timelineRowRealized).toBe("false");
+    // The realized content measures 0px (the jsdom default) against a 120px
+    // placeholder, so the topmost donor absorbs the 120px of slack.
+
+    scrollElement.dataset.scrollbarScrolling = "true";
+    act(() => {
+      intersectionCallback?.(
+        [
+          {
+            target: target!,
+            isIntersecting: true,
+            boundingClientRect: { top: -600, height: 120 },
+          } as unknown as IntersectionObserverEntry,
+        ],
+        {} as IntersectionObserver,
+      );
+    });
+
+    expect(target?.dataset.timelineRowRealized).toBe("true");
+    expect(wrapperOf("message_0")?.style.height).toBe("240px");
+    expect(wrapperOf("message_1")?.style.height).toBe("120px");
+    expect(setScrollTop).not.toHaveBeenCalled();
   });
 
   it("keeps an interacted row mounted after it leaves the window", async () => {

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -287,6 +287,12 @@ interface TimelineWindowItemController {
   peekPlaceholderHeight: () => number | null;
   /** Grow or shrink the placeholder (clamped at zero) to absorb a height delta. */
   adjustPlaceholderHeight: (delta: number) => void;
+  /**
+   * Whether the item has ever mounted its real content. A false value means
+   * its placeholder height is still a pure estimate, eligible for
+   * re-budgeting; a true value means the placeholder carries a measurement.
+   */
+  hasEverRealized: () => boolean;
   /** Release an interaction pin so the row can derealize on its next exit. */
   unpin: () => void;
 }
@@ -445,6 +451,17 @@ const TIMELINE_WINDOW_FALLBACK_VIEWPORT_HEIGHT_PX = 800;
 // cannot keep every heavy row realized forever: the oldest pin releases
 // first, and its row derealizes on its next window exit.
 const TIMELINE_WINDOW_MAX_INTERACTION_PINS = 24;
+// A residual below this threshold shifts visible content instead of writing
+// scrollTop. The write stops WebKit momentum outright; a sub-threshold drift
+// reads as a minor stutter at worst.
+const TIMELINE_WINDOW_RESIDUAL_JUMP_TOLERANCE_PX = 48;
+// Re-budgeting replaces never-measured placeholder estimates with the running
+// average of measured rows once the scroll idles, so the donor pool tracks
+// the timeline's real heights instead of draining monotonically.
+const TIMELINE_WINDOW_REBUDGET_MIN_SAMPLES = 8;
+const TIMELINE_WINDOW_REBUDGET_DRIFT_PX = 24;
+const TIMELINE_WINDOW_REBUDGET_IDLE_DELAY_MS = 300;
+const TIMELINE_WINDOW_REBUDGET_MAX_ESTIMATE_PX = 1_000;
 
 function timelineListItemKey(item: TimelineRowsListItem): string {
   return item.kind === "row" ? item.row.id : item.id;
@@ -1970,6 +1987,7 @@ function TimelineWindowedListItem({
   const placeholderHeightRef = useRef(estimatedHeight);
   const locallyRealizedRef = useRef(locallyRealized);
   const alwaysRealizedRef = useRef(alwaysRealized);
+  const everRealizedRef = useRef(initiallyRealized || alwaysRealized);
   const interactionPinnedRef = useRef(false);
   const lastIntersectionRef = useRef<boolean | null>(null);
   useLayoutEffect(() => {
@@ -1978,6 +1996,9 @@ function TimelineWindowedListItem({
   }, [alwaysRealized, locallyRealized]);
 
   const updateLocallyRealized = useCallback((next: boolean) => {
+    if (next) {
+      everRealizedRef.current = true;
+    }
     if (locallyRealizedRef.current === next) {
       return;
     }
@@ -2020,6 +2041,7 @@ function TimelineWindowedListItem({
           Math.max(0, placeholderHeightRef.current + delta),
         );
       },
+      hasEverRealized: () => everRealizedRef.current,
       unpin: () => {
         interactionPinnedRef.current = false;
       },
@@ -2402,17 +2424,95 @@ function TimelineRowsList({
       return remaining > 0.5 ? remaining : 0;
     };
 
-    // Residuals occur only when placeholders above have no height left to
-    // donate — the final viewport-heights of the timeline. A scrollTop write
-    // there can stop momentum, but the alternatives are a visible jump or a
-    // blank row, and the scroll is about to hit the hard top anyway.
+    // Residuals occur when placeholders above have no height left to donate.
+    // Small residuals shift content instead of writing scrollTop — the write
+    // stops WebKit momentum outright, which reads worse than a sub-threshold
+    // stutter. Large residuals take the write: a big uncompensated jump is
+    // the original bug this windowing exists to prevent.
     const applyResidual = (residual: number) => {
-      if (Math.abs(residual) > 0.5) {
-        scrollElement.scrollTop = Math.max(
-          0,
-          scrollElement.scrollTop + residual,
-        );
+      if (Math.abs(residual) <= TIMELINE_WINDOW_RESIDUAL_JUMP_TOLERANCE_PX) {
+        return;
       }
+      scrollElement.scrollTop = Math.max(
+        0,
+        scrollElement.scrollTop + residual,
+      );
+    };
+
+    // Running average of first-measured item heights. Never-realized
+    // placeholders start from a static estimate that real content usually
+    // exceeds, so donor capacity would otherwise drain monotonically during
+    // upward scrolling until every realization needed a momentum-killing
+    // residual write. Re-budgeting those estimates to the measured average
+    // while the scroll is idle (when a compensating scrollTop write is free)
+    // keeps the donor pool solvent.
+    const measuredSampleKeys = new Set<string>();
+    let measuredSampleSum = 0;
+    let lastRebudgetAverage: number | null = null;
+    const measuredAverage = () =>
+      Math.min(
+        TIMELINE_WINDOW_REBUDGET_MAX_ESTIMATE_PX,
+        measuredSampleSum / measuredSampleKeys.size,
+      );
+    const rebudgetEstimatedPlaceholders = () => {
+      if (measuredSampleKeys.size < TIMELINE_WINDOW_REBUDGET_MIN_SAMPLES) {
+        return;
+      }
+      const average = measuredAverage();
+      if (
+        lastRebudgetAverage !== null &&
+        Math.abs(average - lastRebudgetAverage) <
+          TIMELINE_WINDOW_REBUDGET_DRIFT_PX
+      ) {
+        return;
+      }
+      const adjustments: Array<[TimelineWindowItemController, number]> = [];
+      for (const key of itemKeysRef.current) {
+        const controller = controllerByKeyRef.current.get(key);
+        if (controller === undefined || controller.hasEverRealized()) {
+          continue;
+        }
+        const current = controller.peekPlaceholderHeight();
+        if (current === null) {
+          continue;
+        }
+        const delta = average - current;
+        if (Math.abs(delta) < 1) {
+          continue;
+        }
+        adjustments.push([controller, delta]);
+      }
+      lastRebudgetAverage = average;
+      if (adjustments.length === 0) {
+        return;
+      }
+      applyWithScrollCompensation(() => {
+        for (const [controller, delta] of adjustments) {
+          controller.adjustPlaceholderHeight(delta);
+        }
+      });
+    };
+    let rebudgetTimeout: number | null = null;
+    const scheduleRebudget = () => {
+      if (rebudgetTimeout !== null) {
+        window.clearTimeout(rebudgetTimeout);
+      }
+      rebudgetTimeout = window.setTimeout(() => {
+        rebudgetTimeout = null;
+        if (scrollElement.dataset.scrollbarScrolling === "true") {
+          scheduleRebudget();
+          return;
+        }
+        rebudgetEstimatedPlaceholders();
+      }, TIMELINE_WINDOW_REBUDGET_IDLE_DELAY_MS);
+    };
+    const recordMeasuredSample = (key: string, height: number) => {
+      if (height <= 0 || measuredSampleKeys.has(key)) {
+        return;
+      }
+      measuredSampleKeys.add(key);
+      measuredSampleSum += height;
+      scheduleRebudget();
     };
 
     // Realize items whose top sits above the viewport while a scroll is
@@ -2455,6 +2555,7 @@ function TimelineRowsList({
         for (const candidate of candidates) {
           const measured = candidate.wrapper.getBoundingClientRect().height;
           realizedHeightByKey.set(candidate.key, measured);
+          recordMeasuredSample(candidate.key, measured);
           const delta = measured - candidate.placeholderHeight;
           if (delta === 0) {
             continue;
@@ -2571,6 +2672,7 @@ function TimelineRowsList({
             entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
           const previous = realizedHeightByKey.get(key);
           realizedHeightByKey.set(key, height);
+          recordMeasuredSample(key, height);
           if (previous === undefined) {
             // First observation after a realization whose delta was already
             // balanced (or that mounted through the anchor-compensated path).
@@ -2610,12 +2712,20 @@ function TimelineRowsList({
       observer.observe(wrapper);
       contentGrowthObserver?.observe(wrapper);
     }
+    // Scroll events push a pending re-budget out to the next idle moment.
+    scrollElement.addEventListener("scroll", scheduleRebudget, {
+      passive: true,
+    });
 
     return () => {
       intersectionObserverRef.current = null;
       resizeObserverRef.current = null;
       observer.disconnect();
       contentGrowthObserver?.disconnect();
+      scrollElement.removeEventListener("scroll", scheduleRebudget);
+      if (rebudgetTimeout !== null) {
+        window.clearTimeout(rebudgetTimeout);
+      }
       realizedHeightByKey.clear();
     };
   }, [getScrollElement, shouldWindow]);

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -282,6 +282,7 @@ interface TimelineRowsListProps {
 
 interface TimelineWindowItemController {
   handleIntersection: (entry: IntersectionObserverEntry) => void;
+  realize: () => void;
 }
 
 interface TimelineVisibleAnchor {
@@ -432,6 +433,11 @@ type TimelineRowsListItem =
 const TIMELINE_WINDOWING_MIN_ITEM_COUNT = 40;
 const TIMELINE_WINDOW_MARGIN_PX = 1_000;
 const TIMELINE_WINDOW_FALLBACK_VIEWPORT_HEIGHT_PX = 800;
+// How long after the last scroll event deferred realizations flush. Momentum
+// scrolling emits scroll events every frame, so this much silence means the
+// scroll (including its inertial tail) has stopped and a compensating
+// scrollTop write can no longer kill momentum.
+const TIMELINE_WINDOW_SCROLL_IDLE_FLUSH_DELAY_MS = 250;
 
 function timelineListItemKey(item: TimelineRowsListItem): string {
   return item.kind === "row" ? item.row.id : item.id;
@@ -1982,6 +1988,13 @@ function TimelineWindowedListItem({
           updateLocallyRealized(false);
         }
       },
+      // Applies a realization whose intersection entry was deferred while a
+      // scroll was active. The entry reported the item intersecting, so the
+      // last-intersection state matches what handleIntersection would have set.
+      realize: () => {
+        lastIntersectionRef.current = true;
+        updateLocallyRealized(true);
+      },
     }),
     [updateLocallyRealized],
   );
@@ -2188,6 +2201,9 @@ function TimelineRowsList({
     new Map<string, TimelineWindowItemController>(),
   );
   const intersectionObserverRef = useRef<IntersectionObserver | null>(null);
+  // Realizations deferred while a scroll was active, keyed by item key. They
+  // flush with scroll compensation once the scroll idles.
+  const pendingRealizeKeysRef = useRef(new Set<string>());
   const alwaysRealizedKeys = useMemo(() => {
     if (!shouldWindow) {
       return EMPTY_ROW_ID_SET;
@@ -2261,41 +2277,125 @@ function TimelineRowsList({
       return;
     }
 
+    const pendingRealizeKeys = pendingRealizeKeysRef.current;
+
+    const realizePendingKeys = () => {
+      for (const key of pendingRealizeKeys) {
+        controllerByKeyRef.current.get(key)?.realize();
+      }
+      pendingRealizeKeys.clear();
+    };
+
+    const applyWithScrollCompensation = (apply: () => void) => {
+      const maxScrollTop = Math.max(
+        0,
+        scrollElement.scrollHeight - scrollElement.clientHeight,
+      );
+      const wasAtBottom = maxScrollTop - scrollElement.scrollTop <= 2;
+      const anchor = wasAtBottom
+        ? null
+        : captureTimelineVisibleAnchor({
+            scrollElement,
+            orderedKeys: itemKeys,
+            wrapperByKey: wrapperByKeyRef.current,
+          });
+      flushSync(apply);
+      restoreTimelineVisibleAnchor({ anchor, scrollElement, wasAtBottom });
+    };
+
+    let idleFlushTimeout: number | null = null;
+    const cancelIdleFlush = () => {
+      if (idleFlushTimeout !== null) {
+        window.clearTimeout(idleFlushTimeout);
+        idleFlushTimeout = null;
+      }
+    };
+    const scheduleIdleFlush = () => {
+      cancelIdleFlush();
+      idleFlushTimeout = window.setTimeout(() => {
+        idleFlushTimeout = null;
+        if (pendingRealizeKeys.size === 0) {
+          return;
+        }
+        applyWithScrollCompensation(realizePendingKeys);
+      }, TIMELINE_WINDOW_SCROLL_IDLE_FLUSH_DELAY_MS);
+    };
+    // Every scroll event pushes the flush out, so it fires only once the
+    // scroll — including WebKit's inertial tail — has actually stopped.
+    const handleScrollWhilePending = () => {
+      if (pendingRealizeKeys.size > 0) {
+        scheduleIdleFlush();
+      }
+    };
+
     const observer = new IntersectionObserver(
       (entries) => {
-        const updateWindowItems = () => {
+        // A programmatic scrollTop write stops WebKit's native momentum
+        // scrolling, and WebKit — the only engine this compact-viewport list
+        // runs on for mobile — has no scroll anchoring to absorb layout
+        // shifts. While a scroll is active (the scroll owner keeps this
+        // marker present through the inertial tail), apply only the updates
+        // that cannot shift visible content: derealizations swap in their
+        // just-measured height, and realizations fully below the viewport
+        // only push layout further down. Realizations at or above the
+        // viewport would shift what the user sees by the placeholder-vs-real
+        // height delta, so they wait for the idle flush, which restores the
+        // visible anchor after realizing.
+        if (scrollElement.dataset.scrollbarScrolling === "true") {
+          let viewportBottom: number | null = null;
           for (const entry of entries) {
             const key = keyByWrapperRef.current.get(entry.target);
             if (key === undefined) {
               continue;
             }
-            controllerByKeyRef.current.get(key)?.handleIntersection(entry);
+            const controller = controllerByKeyRef.current.get(key);
+            if (controller === undefined) {
+              continue;
+            }
+            if (!entry.isIntersecting) {
+              pendingRealizeKeys.delete(key);
+              controller.handleIntersection(entry);
+              continue;
+            }
+            const alreadyRealized =
+              wrapperByKeyRef.current.get(key)?.dataset
+                .timelineRowRealized === "true";
+            if (alreadyRealized) {
+              controller.handleIntersection(entry);
+              continue;
+            }
+            // rootBounds already includes the rootMargin expansion; strip it
+            // to recover the true viewport edge without forcing a layout.
+            const rootBottom = entry.rootBounds?.bottom;
+            viewportBottom ??=
+              rootBottom !== undefined
+                ? rootBottom - TIMELINE_WINDOW_MARGIN_PX
+                : scrollElement.getBoundingClientRect().bottom;
+            if (entry.boundingClientRect.top >= viewportBottom) {
+              controller.handleIntersection(entry);
+              continue;
+            }
+            pendingRealizeKeys.add(key);
           }
-        };
-
-        // A programmatic scrollTop write stops WebKit's native momentum
-        // scrolling. The scroll owner keeps this marker present for the full
-        // scroll, including its inertial tail. Let the browser's normal scroll
-        // anchoring cover window updates until scrolling stops.
-        if (scrollElement.dataset.scrollbarScrolling === "true") {
-          updateWindowItems();
+          if (pendingRealizeKeys.size > 0) {
+            scheduleIdleFlush();
+          }
           return;
         }
 
-        const maxScrollTop = Math.max(
-          0,
-          scrollElement.scrollHeight - scrollElement.clientHeight,
-        );
-        const wasAtBottom = maxScrollTop - scrollElement.scrollTop <= 2;
-        const anchor = wasAtBottom
-          ? null
-          : captureTimelineVisibleAnchor({
-              scrollElement,
-              orderedKeys: itemKeys,
-              wrapperByKey: wrapperByKeyRef.current,
-            });
-        flushSync(updateWindowItems);
-        restoreTimelineVisibleAnchor({ anchor, scrollElement, wasAtBottom });
+        applyWithScrollCompensation(() => {
+          for (const entry of entries) {
+            const key = keyByWrapperRef.current.get(entry.target);
+            if (key === undefined) {
+              continue;
+            }
+            if (entry.isIntersecting) {
+              pendingRealizeKeys.delete(key);
+            }
+            controllerByKeyRef.current.get(key)?.handleIntersection(entry);
+          }
+          realizePendingKeys();
+        });
       },
       {
         root: scrollElement,
@@ -2306,10 +2406,18 @@ function TimelineRowsList({
     for (const wrapper of wrapperByKeyRef.current.values()) {
       observer.observe(wrapper);
     }
+    scrollElement.addEventListener("scroll", handleScrollWhilePending, {
+      passive: true,
+    });
 
     return () => {
       intersectionObserverRef.current = null;
       observer.disconnect();
+      scrollElement.removeEventListener("scroll", handleScrollWhilePending);
+      cancelIdleFlush();
+      // A replacement observer reports fresh intersections for every wrapper
+      // on creation, so dropping the queue cannot strand an item.
+      pendingRealizeKeys.clear();
     };
   }, [getScrollElement, itemKeys, shouldWindow]);
 

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -283,12 +283,12 @@ interface TimelineRowsListProps {
 interface TimelineWindowItemController {
   handleIntersection: (entry: IntersectionObserverEntry) => void;
   realize: () => void;
-  /** Revert a just-realized item to its unchanged placeholder. */
-  derealize: () => void;
   /** The current placeholder height, or null while the item is realized. */
   peekPlaceholderHeight: () => number | null;
   /** Grow or shrink the placeholder (clamped at zero) to absorb a height delta. */
   adjustPlaceholderHeight: (delta: number) => void;
+  /** Release an interaction pin so the row can derealize on its next exit. */
+  unpin: () => void;
 }
 
 interface TimelineVisibleAnchor {
@@ -307,6 +307,7 @@ interface TimelineWindowedListItemProps {
     key: string,
     controller: TimelineWindowItemController | null,
   ) => void;
+  registerInteractionPin: (key: string) => void;
   rowId: string | undefined;
 }
 
@@ -439,12 +440,11 @@ type TimelineRowsListItem =
 const TIMELINE_WINDOWING_MIN_ITEM_COUNT = 40;
 const TIMELINE_WINDOW_MARGIN_PX = 1_000;
 const TIMELINE_WINDOW_FALLBACK_VIEWPORT_HEIGHT_PX = 800;
-// How long after the last scroll event deferred realizations flush. Momentum
-// scrolling emits scroll events every frame, so this much silence means the
-// scroll (including its inertial tail) has stopped and a compensating
-// scrollTop write can no longer kill momentum. Only realizations that found
-// no donor placeholder capacity wait for this flush.
-const TIMELINE_WINDOW_SCROLL_IDLE_FLUSH_DELAY_MS = 250;
+// Interaction pins keep rows mounted so their local state (expansion,
+// long-message reveal) survives eviction. Cap them so a long session of taps
+// cannot keep every heavy row realized forever: the oldest pin releases
+// first, and its row derealizes on its next window exit.
+const TIMELINE_WINDOW_MAX_INTERACTION_PINS = 24;
 
 function timelineListItemKey(item: TimelineRowsListItem): string {
   return item.kind === "row" ? item.row.id : item.id;
@@ -1960,6 +1960,7 @@ function TimelineWindowedListItem({
   itemKey,
   registerWrapper,
   registerController,
+  registerInteractionPin,
   rowId,
 }: TimelineWindowedListItemProps) {
   const [locallyRealized, setLocallyRealized] = useState(initiallyRealized);
@@ -2010,9 +2011,6 @@ function TimelineWindowedListItem({
         lastIntersectionRef.current = true;
         updateLocallyRealized(true);
       },
-      derealize: () => {
-        updateLocallyRealized(false);
-      },
       peekPlaceholderHeight: () =>
         alwaysRealizedRef.current || locallyRealizedRef.current
           ? null
@@ -2021,6 +2019,9 @@ function TimelineWindowedListItem({
         applyPlaceholderHeight(
           Math.max(0, placeholderHeightRef.current + delta),
         );
+      },
+      unpin: () => {
+        interactionPinnedRef.current = false;
       },
     }),
     [applyPlaceholderHeight, updateLocallyRealized],
@@ -2042,7 +2043,10 @@ function TimelineWindowedListItem({
 
   const pinInteractedItem = useCallback(() => {
     interactionPinnedRef.current = true;
-  }, []);
+    // Reporting every interaction (not just the first) keeps the list-level
+    // pin order in recency order, so the least-recently-touched pin evicts.
+    registerInteractionPin(itemKey);
+  }, [itemKey, registerInteractionPin]);
   const handleWrapperRef = useCallback(
     (node: HTMLDivElement | null) => registerWrapper(itemKey, node),
     [itemKey, registerWrapper],
@@ -2228,9 +2232,20 @@ function TimelineRowsList({
     new Map<string, TimelineWindowItemController>(),
   );
   const intersectionObserverRef = useRef<IntersectionObserver | null>(null);
-  // Realizations deferred while a scroll was active, keyed by item key. They
-  // flush with scroll compensation once the scroll idles.
-  const pendingRealizeKeysRef = useRef(new Set<string>());
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  // Last committed content height of each realized wrapper. Late growth
+  // (lazy images, async rendering) diffs against this baseline so it can be
+  // compensated the same way as the mount-time delta.
+  const realizedHeightByKeyRef = useRef(new Map<string, number>());
+  // Interaction-pinned keys in recency order, capped so pins cannot
+  // accumulate without bound over a long session.
+  const pinnedKeysRef = useRef<string[]>([]);
+  // The observers outlive row streaming, so their callbacks read the current
+  // key order through this ref instead of re-creating per rows change.
+  const itemKeysRef = useRef(itemKeys);
+  useLayoutEffect(() => {
+    itemKeysRef.current = itemKeys;
+  }, [itemKeys]);
   const alwaysRealizedKeys = useMemo(() => {
     if (!shouldWindow) {
       return EMPTY_ROW_ID_SET;
@@ -2272,14 +2287,17 @@ function TimelineRowsList({
       if (previous !== undefined && previous !== node) {
         keyByWrapperRef.current.delete(previous);
         intersectionObserverRef.current?.unobserve(previous);
+        resizeObserverRef.current?.unobserve(previous);
       }
       if (node === null) {
         wrapperByKeyRef.current.delete(key);
+        realizedHeightByKeyRef.current.delete(key);
         return;
       }
       wrapperByKeyRef.current.set(key, node);
       keyByWrapperRef.current.set(node, key);
       intersectionObserverRef.current?.observe(node);
+      resizeObserverRef.current?.observe(node);
     },
     [],
   );
@@ -2293,6 +2311,20 @@ function TimelineRowsList({
     },
     [],
   );
+  const registerInteractionPin = useCallback((key: string) => {
+    const pinned = pinnedKeysRef.current;
+    const existing = pinned.indexOf(key);
+    if (existing >= 0) {
+      pinned.splice(existing, 1);
+    }
+    pinned.push(key);
+    while (pinned.length > TIMELINE_WINDOW_MAX_INTERACTION_PINS) {
+      const evicted = pinned.shift();
+      if (evicted !== undefined) {
+        controllerByKeyRef.current.get(evicted)?.unpin();
+      }
+    }
+  }, []);
 
   const getScrollElement = bottomAnchor?.getScrollElement;
   useEffect(() => {
@@ -2304,15 +2336,6 @@ function TimelineRowsList({
       return;
     }
 
-    const pendingRealizeKeys = pendingRealizeKeysRef.current;
-
-    const realizePendingKeys = () => {
-      for (const key of pendingRealizeKeys) {
-        controllerByKeyRef.current.get(key)?.realize();
-      }
-      pendingRealizeKeys.clear();
-    };
-
     const applyWithScrollCompensation = (apply: () => void) => {
       const maxScrollTop = Math.max(
         0,
@@ -2323,53 +2346,88 @@ function TimelineRowsList({
         ? null
         : captureTimelineVisibleAnchor({
             scrollElement,
-            orderedKeys: itemKeys,
+            orderedKeys: itemKeysRef.current,
             wrapperByKey: wrapperByKeyRef.current,
           });
       flushSync(apply);
       restoreTimelineVisibleAnchor({ anchor, scrollElement, wasAtBottom });
     };
 
-    let idleFlushTimeout: number | null = null;
-    const cancelIdleFlush = () => {
-      if (idleFlushTimeout !== null) {
-        window.clearTimeout(idleFlushTimeout);
-        idleFlushTimeout = null;
-      }
-    };
-    const scheduleIdleFlush = () => {
-      cancelIdleFlush();
-      idleFlushTimeout = window.setTimeout(() => {
-        idleFlushTimeout = null;
-        if (pendingRealizeKeys.size === 0) {
-          return;
+    // Distributes one above-viewport height delta into placeholder donors
+    // that sit earlier in the list (and therefore also fully above the
+    // viewport). Positive deltas shrink donors topmost-first so placeholders
+    // nearest the viewport keep accurate heights; negative deltas hand the
+    // slack to the topmost donor. Returns the residual no donor could
+    // absorb. Must run inside flushSync so donor commits paint atomically
+    // with the change they balance.
+    const compensateAboveViewportDelta = (
+      candidateIndex: number,
+      delta: number,
+    ): number => {
+      const keys = itemKeysRef.current;
+      if (delta < 0) {
+        for (let index = 0; index < candidateIndex; index += 1) {
+          const key = keys[index];
+          if (key === undefined) {
+            continue;
+          }
+          const controller = controllerByKeyRef.current.get(key);
+          if ((controller?.peekPlaceholderHeight() ?? null) !== null) {
+            controller?.adjustPlaceholderHeight(-delta);
+            return 0;
+          }
         }
-        applyWithScrollCompensation(realizePendingKeys);
-      }, TIMELINE_WINDOW_SCROLL_IDLE_FLUSH_DELAY_MS);
+        return delta;
+      }
+      let remaining = delta;
+      for (
+        let index = 0;
+        index < candidateIndex && remaining > 0.5;
+        index += 1
+      ) {
+        const key = keys[index];
+        if (key === undefined) {
+          continue;
+        }
+        const controller = controllerByKeyRef.current.get(key);
+        const available = controller?.peekPlaceholderHeight() ?? null;
+        if (available === null || available <= 0) {
+          continue;
+        }
+        const take = Math.min(available, remaining);
+        controller?.adjustPlaceholderHeight(-take);
+        remaining -= take;
+      }
+      return remaining > 0.5 ? remaining : 0;
     };
-    // Every scroll event pushes the flush out, so it fires only once the
-    // scroll — including WebKit's inertial tail — has actually stopped.
-    const handleScrollWhilePending = () => {
-      if (pendingRealizeKeys.size > 0) {
-        scheduleIdleFlush();
+
+    // Residuals occur only when placeholders above have no height left to
+    // donate — the final viewport-heights of the timeline. A scrollTop write
+    // there can stop momentum, but the alternatives are a visible jump or a
+    // blank row, and the scroll is about to hit the hard top anyway.
+    const applyResidual = (residual: number) => {
+      if (Math.abs(residual) > 0.5) {
+        scrollElement.scrollTop = Math.max(
+          0,
+          scrollElement.scrollTop + residual,
+        );
       }
     };
 
     // Realize items whose top sits above the viewport while a scroll is
     // active. Mount their content in one synchronous commit, measure each
     // realized height, then balance every height delta against placeholder
-    // "donors" that also sit fully above the viewport, in a second commit in
-    // the same task (so nothing paints in between). The net height change
-    // above the viewport is zero, which keeps visible content still without
-    // a momentum-killing scrollTop write. Donor placeholders self-correct:
-    // they re-measure whenever they realize or derealize later. An item that
-    // finds no donor capacity (near the top of the timeline) reverts to its
-    // unchanged placeholder and waits for the idle flush instead.
+    // donors in a second commit in the same task (so nothing paints in
+    // between). The net height change above the viewport stays zero, which
+    // keeps visible content still without a momentum-killing scrollTop
+    // write. Donor placeholders self-correct: they re-measure whenever they
+    // realize or derealize later.
     const realizeAboveViewportDuringScroll = (keys: readonly string[]) => {
+      const itemKeysNow = itemKeysRef.current;
       const candidates = keys.flatMap((key) => {
         const controller = controllerByKeyRef.current.get(key);
         const wrapper = wrapperByKeyRef.current.get(key);
-        const index = itemKeys.indexOf(key);
+        const index = itemKeysNow.indexOf(key);
         const placeholderHeight = controller?.peekPlaceholderHeight() ?? null;
         if (
           controller === undefined ||
@@ -2391,94 +2449,19 @@ function TimelineRowsList({
         }
       });
 
-      // Plan the donor adjustments against post-realize measurements. Donors
-      // are taken topmost-first so the placeholders nearest the viewport —
-      // the ones most likely to realize next — keep accurate heights.
-      const plannedAdjustments = new Map<string, number>();
-      const effectivePlaceholderHeight = (key: string): number | null => {
-        const peeked =
-          controllerByKeyRef.current.get(key)?.peekPlaceholderHeight() ?? null;
-        if (peeked === null) {
-          return null;
-        }
-        return Math.max(0, peeked + (plannedAdjustments.get(key) ?? 0));
-      };
-      const reverts: typeof candidates = [];
-      for (const candidate of candidates) {
-        const delta =
-          candidate.wrapper.getBoundingClientRect().height -
-          candidate.placeholderHeight;
-        if (delta === 0) {
-          continue;
-        }
-        if (delta < 0) {
-          // Shorter than its placeholder: hand the slack to the topmost donor.
-          let donorKey: string | null = null;
-          for (let index = 0; index < candidate.index; index += 1) {
-            const key = itemKeys[index];
-            if (key !== undefined && effectivePlaceholderHeight(key) !== null) {
-              donorKey = key;
-              break;
-            }
-          }
-          if (donorKey === null) {
-            reverts.push(candidate);
+      let residual = 0;
+      flushSync(() => {
+        for (const candidate of candidates) {
+          const measured = candidate.wrapper.getBoundingClientRect().height;
+          realizedHeightByKeyRef.current.set(candidate.key, measured);
+          const delta = measured - candidate.placeholderHeight;
+          if (delta === 0) {
             continue;
           }
-          plannedAdjustments.set(
-            donorKey,
-            (plannedAdjustments.get(donorKey) ?? 0) - delta,
-          );
-          continue;
+          residual += compensateAboveViewportDelta(candidate.index, delta);
         }
-        // Taller than its placeholder: shrink donors above it until covered.
-        let remaining = delta;
-        const takes: Array<[string, number]> = [];
-        for (
-          let index = 0;
-          index < candidate.index && remaining > 0.5;
-          index += 1
-        ) {
-          const key = itemKeys[index];
-          if (key === undefined) {
-            continue;
-          }
-          const available = effectivePlaceholderHeight(key);
-          if (available === null || available <= 0) {
-            continue;
-          }
-          const take = Math.min(available, remaining);
-          takes.push([key, take]);
-          remaining -= take;
-        }
-        if (remaining > 0.5) {
-          reverts.push(candidate);
-          continue;
-        }
-        for (const [key, take] of takes) {
-          plannedAdjustments.set(
-            key,
-            (plannedAdjustments.get(key) ?? 0) - take,
-          );
-        }
-      }
-      if (plannedAdjustments.size > 0 || reverts.length > 0) {
-        flushSync(() => {
-          for (const [key, adjustment] of plannedAdjustments) {
-            if (adjustment !== 0) {
-              controllerByKeyRef.current
-                .get(key)
-                ?.adjustPlaceholderHeight(adjustment);
-            }
-          }
-          for (const candidate of reverts) {
-            candidate.controller.derealize();
-          }
-        });
-      }
-      for (const candidate of reverts) {
-        pendingRealizeKeys.add(candidate.key);
-      }
+      });
+      applyResidual(residual);
     };
 
     const observer = new IntersectionObserver(
@@ -2506,7 +2489,7 @@ function TimelineRowsList({
               continue;
             }
             if (!entry.isIntersecting) {
-              pendingRealizeKeys.delete(key);
+              realizedHeightByKeyRef.current.delete(key);
               controller.handleIntersection(entry);
               continue;
             }
@@ -2525,7 +2508,6 @@ function TimelineRowsList({
                 ? rootTop + TIMELINE_WINDOW_MARGIN_PX
                 : scrollElement.getBoundingClientRect().top;
             if (entry.boundingClientRect.top >= viewportTop) {
-              pendingRealizeKeys.delete(key);
               controller.handleIntersection(entry);
               continue;
             }
@@ -2533,9 +2515,6 @@ function TimelineRowsList({
           }
           if (growUpKeys.length > 0) {
             realizeAboveViewportDuringScroll(growUpKeys);
-          }
-          if (pendingRealizeKeys.size > 0) {
-            scheduleIdleFlush();
           }
           return;
         }
@@ -2546,12 +2525,11 @@ function TimelineRowsList({
             if (key === undefined) {
               continue;
             }
-            if (entry.isIntersecting) {
-              pendingRealizeKeys.delete(key);
+            if (!entry.isIntersecting) {
+              realizedHeightByKeyRef.current.delete(key);
             }
             controllerByKeyRef.current.get(key)?.handleIntersection(entry);
           }
-          realizePendingKeys();
         });
       },
       {
@@ -2560,23 +2538,86 @@ function TimelineRowsList({
       },
     );
     intersectionObserverRef.current = observer;
+
+    // Late content growth in a realized row above the viewport (a lazy image
+    // decoding, async rendering settling) shifts visible content exactly like
+    // an uncompensated realization would. ResizeObserver fires between layout
+    // and paint, so balancing the delta into donors here commits before the
+    // shift ever paints. Growth in or below the viewport stays uncompensated:
+    // a visible image expanding in place is expected content behavior.
+    let contentGrowthObserver: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== "undefined") {
+      contentGrowthObserver = new ResizeObserver((entries) => {
+        let viewportTop: number | null = null;
+        const compensations: Array<{ index: number; delta: number }> = [];
+        for (const entry of entries) {
+          const key = keyByWrapperRef.current.get(entry.target);
+          if (key === undefined) {
+            continue;
+          }
+          const wrapper = wrapperByKeyRef.current.get(key);
+          if (wrapper === undefined) {
+            continue;
+          }
+          if (wrapper.dataset.timelineRowRealized !== "true") {
+            // Placeholder height changes are this component's own writes
+            // (donor adjustments, derealization measurements) — already
+            // balanced, never compensated again.
+            realizedHeightByKeyRef.current.delete(key);
+            continue;
+          }
+          const height =
+            entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
+          const previous = realizedHeightByKeyRef.current.get(key);
+          realizedHeightByKeyRef.current.set(key, height);
+          if (previous === undefined) {
+            // First observation after a realization whose delta was already
+            // balanced (or that mounted through the anchor-compensated path).
+            continue;
+          }
+          const delta = height - previous;
+          if (Math.abs(delta) < 0.5) {
+            continue;
+          }
+          viewportTop ??= scrollElement.getBoundingClientRect().top;
+          if (wrapper.getBoundingClientRect().bottom > viewportTop) {
+            continue;
+          }
+          const index = itemKeysRef.current.indexOf(key);
+          if (index >= 0) {
+            compensations.push({ index, delta });
+          }
+        }
+        if (compensations.length === 0) {
+          return;
+        }
+        let residual = 0;
+        flushSync(() => {
+          for (const compensation of compensations) {
+            residual += compensateAboveViewportDelta(
+              compensation.index,
+              compensation.delta,
+            );
+          }
+        });
+        applyResidual(residual);
+      });
+    }
+    resizeObserverRef.current = contentGrowthObserver;
+
     for (const wrapper of wrapperByKeyRef.current.values()) {
       observer.observe(wrapper);
+      contentGrowthObserver?.observe(wrapper);
     }
-    scrollElement.addEventListener("scroll", handleScrollWhilePending, {
-      passive: true,
-    });
 
     return () => {
       intersectionObserverRef.current = null;
+      resizeObserverRef.current = null;
       observer.disconnect();
-      scrollElement.removeEventListener("scroll", handleScrollWhilePending);
-      cancelIdleFlush();
-      // A replacement observer reports fresh intersections for every wrapper
-      // on creation, so dropping the queue cannot strand an item.
-      pendingRealizeKeys.clear();
+      contentGrowthObserver?.disconnect();
+      realizedHeightByKeyRef.current.clear();
     };
-  }, [getScrollElement, itemKeys, shouldWindow]);
+  }, [getScrollElement, shouldWindow]);
 
   const renderedRowsKey = shouldWindow
     ? [...alwaysRealizedKeys].sort().join("\u0000")
@@ -2629,6 +2670,7 @@ function TimelineRowsList({
                 initiallyRealized={initiallyRealizedKeys.has(itemKey)}
                 itemKey={itemKey}
                 registerController={registerController}
+                registerInteractionPin={registerInteractionPin}
                 registerWrapper={registerWrapper}
                 rowId={item.kind === "row" ? item.row.id : undefined}
               >
@@ -2719,8 +2761,22 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
   const liveAutoExpandedRowIds = useStableReadonlySet(
     computedAutoExpansionRowIds.liveFrontierRowIds,
   );
+  // Terminal auto-expansion is a one-shot latch per row, and the latch lives
+  // in row-local state that windowed eviction unmounts. Accumulate every id
+  // that has ever latched so an evicted frontier-error row re-expands when it
+  // remounts. A row the user manually collapses stays collapsed: collapsing
+  // is an interaction, which pins the row against eviction, so its manual
+  // override survives.
+  const accumulatedTerminalRowIdsRef = useRef(new Set<string>());
+  const accumulatedTerminalRowIds = useMemo(() => {
+    const accumulated = accumulatedTerminalRowIdsRef.current;
+    for (const id of computedAutoExpansionRowIds.terminalFrontierRowIds) {
+      accumulated.add(id);
+    }
+    return new Set(accumulated);
+  }, [computedAutoExpansionRowIds.terminalFrontierRowIds]);
   const terminalAutoExpandedRowIds = useStableReadonlySet(
-    computedAutoExpansionRowIds.terminalFrontierRowIds,
+    accumulatedTerminalRowIds,
   );
   const initialAutoExpandedRowIds = useStableReadonlySet(
     props.initialExpanded ?? EMPTY_ROW_ID_SET,

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -283,6 +283,12 @@ interface TimelineRowsListProps {
 interface TimelineWindowItemController {
   handleIntersection: (entry: IntersectionObserverEntry) => void;
   realize: () => void;
+  /** Revert a just-realized item to its unchanged placeholder. */
+  derealize: () => void;
+  /** The current placeholder height, or null while the item is realized. */
+  peekPlaceholderHeight: () => number | null;
+  /** Grow or shrink the placeholder (clamped at zero) to absorb a height delta. */
+  adjustPlaceholderHeight: (delta: number) => void;
 }
 
 interface TimelineVisibleAnchor {
@@ -436,7 +442,8 @@ const TIMELINE_WINDOW_FALLBACK_VIEWPORT_HEIGHT_PX = 800;
 // How long after the last scroll event deferred realizations flush. Momentum
 // scrolling emits scroll events every frame, so this much silence means the
 // scroll (including its inertial tail) has stopped and a compensating
-// scrollTop write can no longer kill momentum.
+// scrollTop write can no longer kill momentum. Only realizations that found
+// no donor placeholder capacity wait for this flush.
 const TIMELINE_WINDOW_SCROLL_IDLE_FLUSH_DELAY_MS = 250;
 
 function timelineListItemKey(item: TimelineRowsListItem): string {
@@ -1957,6 +1964,9 @@ function TimelineWindowedListItem({
 }: TimelineWindowedListItemProps) {
   const [locallyRealized, setLocallyRealized] = useState(initiallyRealized);
   const [placeholderHeight, setPlaceholderHeight] = useState(estimatedHeight);
+  // Mirrors the placeholder-height state so the window controller can read
+  // and adjust it synchronously between two flushSync commits in one task.
+  const placeholderHeightRef = useRef(estimatedHeight);
   const locallyRealizedRef = useRef(locallyRealized);
   const alwaysRealizedRef = useRef(alwaysRealized);
   const interactionPinnedRef = useRef(false);
@@ -1973,6 +1983,10 @@ function TimelineWindowedListItem({
     locallyRealizedRef.current = next;
     setLocallyRealized(next);
   }, []);
+  const applyPlaceholderHeight = useCallback((next: number) => {
+    placeholderHeightRef.current = next;
+    setPlaceholderHeight(next);
+  }, []);
   const controller = useMemo<TimelineWindowItemController>(
     () => ({
       handleIntersection: (entry) => {
@@ -1982,21 +1996,34 @@ function TimelineWindowedListItem({
           return;
         }
         if (entry.boundingClientRect.height > 0) {
-          setPlaceholderHeight(entry.boundingClientRect.height);
+          applyPlaceholderHeight(entry.boundingClientRect.height);
         }
         if (!alwaysRealizedRef.current && !interactionPinnedRef.current) {
           updateLocallyRealized(false);
         }
       },
-      // Applies a realization whose intersection entry was deferred while a
-      // scroll was active. The entry reported the item intersecting, so the
-      // last-intersection state matches what handleIntersection would have set.
+      // Applies a realization outside an intersection entry (scroll-time
+      // realization or the idle flush). The item is intersecting when this
+      // runs, so the last-intersection state matches what handleIntersection
+      // would have set.
       realize: () => {
         lastIntersectionRef.current = true;
         updateLocallyRealized(true);
       },
+      derealize: () => {
+        updateLocallyRealized(false);
+      },
+      peekPlaceholderHeight: () =>
+        alwaysRealizedRef.current || locallyRealizedRef.current
+          ? null
+          : placeholderHeightRef.current,
+      adjustPlaceholderHeight: (delta) => {
+        applyPlaceholderHeight(
+          Math.max(0, placeholderHeightRef.current + delta),
+        );
+      },
     }),
-    [updateLocallyRealized],
+    [applyPlaceholderHeight, updateLocallyRealized],
   );
   useLayoutEffect(() => {
     registerController(itemKey, controller);
@@ -2328,21 +2355,147 @@ function TimelineRowsList({
       }
     };
 
+    // Realize items whose top sits above the viewport while a scroll is
+    // active. Mount their content in one synchronous commit, measure each
+    // realized height, then balance every height delta against placeholder
+    // "donors" that also sit fully above the viewport, in a second commit in
+    // the same task (so nothing paints in between). The net height change
+    // above the viewport is zero, which keeps visible content still without
+    // a momentum-killing scrollTop write. Donor placeholders self-correct:
+    // they re-measure whenever they realize or derealize later. An item that
+    // finds no donor capacity (near the top of the timeline) reverts to its
+    // unchanged placeholder and waits for the idle flush instead.
+    const realizeAboveViewportDuringScroll = (keys: readonly string[]) => {
+      const candidates = keys.flatMap((key) => {
+        const controller = controllerByKeyRef.current.get(key);
+        const wrapper = wrapperByKeyRef.current.get(key);
+        const index = itemKeys.indexOf(key);
+        const placeholderHeight = controller?.peekPlaceholderHeight() ?? null;
+        if (
+          controller === undefined ||
+          wrapper === undefined ||
+          index < 0 ||
+          placeholderHeight === null
+        ) {
+          return [];
+        }
+        return [{ controller, index, key, placeholderHeight, wrapper }];
+      });
+      if (candidates.length === 0) {
+        return;
+      }
+
+      flushSync(() => {
+        for (const candidate of candidates) {
+          candidate.controller.realize();
+        }
+      });
+
+      // Plan the donor adjustments against post-realize measurements. Donors
+      // are taken topmost-first so the placeholders nearest the viewport —
+      // the ones most likely to realize next — keep accurate heights.
+      const plannedAdjustments = new Map<string, number>();
+      const effectivePlaceholderHeight = (key: string): number | null => {
+        const peeked =
+          controllerByKeyRef.current.get(key)?.peekPlaceholderHeight() ?? null;
+        if (peeked === null) {
+          return null;
+        }
+        return Math.max(0, peeked + (plannedAdjustments.get(key) ?? 0));
+      };
+      const reverts: typeof candidates = [];
+      for (const candidate of candidates) {
+        const delta =
+          candidate.wrapper.getBoundingClientRect().height -
+          candidate.placeholderHeight;
+        if (delta === 0) {
+          continue;
+        }
+        if (delta < 0) {
+          // Shorter than its placeholder: hand the slack to the topmost donor.
+          let donorKey: string | null = null;
+          for (let index = 0; index < candidate.index; index += 1) {
+            const key = itemKeys[index];
+            if (key !== undefined && effectivePlaceholderHeight(key) !== null) {
+              donorKey = key;
+              break;
+            }
+          }
+          if (donorKey === null) {
+            reverts.push(candidate);
+            continue;
+          }
+          plannedAdjustments.set(
+            donorKey,
+            (plannedAdjustments.get(donorKey) ?? 0) - delta,
+          );
+          continue;
+        }
+        // Taller than its placeholder: shrink donors above it until covered.
+        let remaining = delta;
+        const takes: Array<[string, number]> = [];
+        for (
+          let index = 0;
+          index < candidate.index && remaining > 0.5;
+          index += 1
+        ) {
+          const key = itemKeys[index];
+          if (key === undefined) {
+            continue;
+          }
+          const available = effectivePlaceholderHeight(key);
+          if (available === null || available <= 0) {
+            continue;
+          }
+          const take = Math.min(available, remaining);
+          takes.push([key, take]);
+          remaining -= take;
+        }
+        if (remaining > 0.5) {
+          reverts.push(candidate);
+          continue;
+        }
+        for (const [key, take] of takes) {
+          plannedAdjustments.set(
+            key,
+            (plannedAdjustments.get(key) ?? 0) - take,
+          );
+        }
+      }
+      if (plannedAdjustments.size > 0 || reverts.length > 0) {
+        flushSync(() => {
+          for (const [key, adjustment] of plannedAdjustments) {
+            if (adjustment !== 0) {
+              controllerByKeyRef.current
+                .get(key)
+                ?.adjustPlaceholderHeight(adjustment);
+            }
+          }
+          for (const candidate of reverts) {
+            candidate.controller.derealize();
+          }
+        });
+      }
+      for (const candidate of reverts) {
+        pendingRealizeKeys.add(candidate.key);
+      }
+    };
+
     const observer = new IntersectionObserver(
       (entries) => {
         // A programmatic scrollTop write stops WebKit's native momentum
         // scrolling, and WebKit — the only engine this compact-viewport list
         // runs on for mobile — has no scroll anchoring to absorb layout
         // shifts. While a scroll is active (the scroll owner keeps this
-        // marker present through the inertial tail), apply only the updates
-        // that cannot shift visible content: derealizations swap in their
-        // just-measured height, and realizations fully below the viewport
-        // only push layout further down. Realizations at or above the
-        // viewport would shift what the user sees by the placeholder-vs-real
-        // height delta, so they wait for the idle flush, which restores the
-        // visible anchor after realizing.
+        // marker present through the inertial tail), apply derealizations
+        // and at-or-below-viewport realizations directly: derealizations
+        // swap in their just-measured height, and an item whose top edge is
+        // at or below the viewport top only pushes layout below that edge
+        // when it grows. Items whose top is above the viewport realize with
+        // donor compensation instead.
         if (scrollElement.dataset.scrollbarScrolling === "true") {
-          let viewportBottom: number | null = null;
+          let viewportTop: number | null = null;
+          const growUpKeys: string[] = [];
           for (const entry of entries) {
             const key = keyByWrapperRef.current.get(entry.target);
             if (key === undefined) {
@@ -2366,16 +2519,20 @@ function TimelineRowsList({
             }
             // rootBounds already includes the rootMargin expansion; strip it
             // to recover the true viewport edge without forcing a layout.
-            const rootBottom = entry.rootBounds?.bottom;
-            viewportBottom ??=
-              rootBottom !== undefined
-                ? rootBottom - TIMELINE_WINDOW_MARGIN_PX
-                : scrollElement.getBoundingClientRect().bottom;
-            if (entry.boundingClientRect.top >= viewportBottom) {
+            const rootTop = entry.rootBounds?.top;
+            viewportTop ??=
+              rootTop !== undefined
+                ? rootTop + TIMELINE_WINDOW_MARGIN_PX
+                : scrollElement.getBoundingClientRect().top;
+            if (entry.boundingClientRect.top >= viewportTop) {
+              pendingRealizeKeys.delete(key);
               controller.handleIntersection(entry);
               continue;
             }
-            pendingRealizeKeys.add(key);
+            growUpKeys.push(key);
+          }
+          if (growUpKeys.length > 0) {
+            realizeAboveViewportDuringScroll(growUpKeys);
           }
           if (pendingRealizeKeys.size > 0) {
             scheduleIdleFlush();

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -283,6 +283,8 @@ interface TimelineRowsListProps {
 interface TimelineWindowItemController {
   handleIntersection: (entry: IntersectionObserverEntry) => void;
   realize: () => void;
+  /** Revert a just-realized item to its unchanged placeholder. */
+  derealize: () => void;
   /** The current placeholder height, or null while the item is realized. */
   peekPlaceholderHeight: () => number | null;
   /** Grow or shrink the placeholder (clamped at zero) to absorb a height delta. */
@@ -451,10 +453,6 @@ const TIMELINE_WINDOW_FALLBACK_VIEWPORT_HEIGHT_PX = 800;
 // cannot keep every heavy row realized forever: the oldest pin releases
 // first, and its row derealizes on its next window exit.
 const TIMELINE_WINDOW_MAX_INTERACTION_PINS = 24;
-// A residual below this threshold shifts visible content instead of writing
-// scrollTop. The write stops WebKit momentum outright; a sub-threshold drift
-// reads as a minor stutter at worst.
-const TIMELINE_WINDOW_RESIDUAL_JUMP_TOLERANCE_PX = 48;
 // Re-budgeting replaces never-measured placeholder estimates with the running
 // average of measured rows once the scroll idles, so the donor pool tracks
 // the timeline's real heights instead of draining monotonically.
@@ -2032,6 +2030,9 @@ function TimelineWindowedListItem({
         lastIntersectionRef.current = true;
         updateLocallyRealized(true);
       },
+      derealize: () => {
+        updateLocallyRealized(false);
+      },
       peekPlaceholderHeight: () =>
         alwaysRealizedRef.current || locallyRealizedRef.current
           ? null
@@ -2380,13 +2381,14 @@ function TimelineRowsList({
     // that sit earlier in the list (and therefore also fully above the
     // viewport). Positive deltas shrink donors topmost-first so placeholders
     // nearest the viewport keep accurate heights; negative deltas hand the
-    // slack to the topmost donor. Returns the residual no donor could
-    // absorb. Must run inside flushSync so donor commits paint atomically
-    // with the change they balance.
-    const compensateAboveViewportDelta = (
+    // slack to the topmost donor. All-or-nothing: donors change only when
+    // the whole delta is covered, so the swap is exactly net zero. Must run
+    // inside flushSync so donor commits paint atomically with the change
+    // they balance.
+    const tryCompensateAboveViewportDelta = (
       candidateIndex: number,
       delta: number,
-    ): number => {
+    ): boolean => {
       const keys = itemKeysRef.current;
       if (delta < 0) {
         for (let index = 0; index < candidateIndex; index += 1) {
@@ -2397,12 +2399,13 @@ function TimelineRowsList({
           const controller = controllerByKeyRef.current.get(key);
           if ((controller?.peekPlaceholderHeight() ?? null) !== null) {
             controller?.adjustPlaceholderHeight(-delta);
-            return 0;
+            return true;
           }
         }
-        return delta;
+        return false;
       }
       let remaining = delta;
+      const takes: Array<[TimelineWindowItemController, number]> = [];
       for (
         let index = 0;
         index < candidateIndex && remaining > 0.5;
@@ -2413,59 +2416,61 @@ function TimelineRowsList({
           continue;
         }
         const controller = controllerByKeyRef.current.get(key);
-        const available = controller?.peekPlaceholderHeight() ?? null;
+        if (controller === undefined) {
+          continue;
+        }
+        const available = controller.peekPlaceholderHeight();
         if (available === null || available <= 0) {
           continue;
         }
         const take = Math.min(available, remaining);
-        controller?.adjustPlaceholderHeight(-take);
+        takes.push([controller, take]);
         remaining -= take;
       }
-      return remaining > 0.5 ? remaining : 0;
+      if (remaining > 0.5) {
+        return false;
+      }
+      for (const [controller, take] of takes) {
+        controller.adjustPlaceholderHeight(-take);
+      }
+      return true;
     };
 
-    // Residuals occur when placeholders above have no height left to donate.
-    // Small residuals shift content instead of writing scrollTop — the write
-    // stops WebKit momentum outright, which reads worse than a sub-threshold
-    // stutter. Large residuals take the write: a big uncompensated jump is
-    // the original bug this windowing exists to prevent.
-    const applyResidual = (residual: number) => {
-      if (Math.abs(residual) <= TIMELINE_WINDOW_RESIDUAL_JUMP_TOLERANCE_PX) {
-        return;
-      }
-      scrollElement.scrollTop = Math.max(
-        0,
-        scrollElement.scrollTop + residual,
-      );
-    };
+    // Realizations that found no donor capacity while scrolling. They keep
+    // their unchanged placeholders (nothing on screen moves) and mount at
+    // the next idle pass, where a compensating scrollTop write is free.
+    // During an active scroll the ONLY geometry this component changes is
+    // the exact net-zero donor swap — no scrollTop writes, no tolerated
+    // drift. Anything that cannot satisfy that invariant waits for idle.
+    const pendingRealizeKeys = new Set<string>();
 
     // Running average of first-measured item heights. Never-realized
     // placeholders start from a static estimate that real content usually
     // exceeds, so donor capacity would otherwise drain monotonically during
-    // upward scrolling until every realization needed a momentum-killing
-    // residual write. Re-budgeting those estimates to the measured average
-    // while the scroll is idle (when a compensating scrollTop write is free)
-    // keeps the donor pool solvent.
+    // upward scrolling. Re-budgeting those estimates to the measured average
+    // at idle keeps the donor pool solvent, which keeps insolvency reverts
+    // (and their brief near-top blanks) rare.
     const measuredSampleKeys = new Set<string>();
     let measuredSampleSum = 0;
     let lastRebudgetAverage: number | null = null;
-    const measuredAverage = () =>
-      Math.min(
+    const computeRebudgetAdjustments = (): Array<
+      [TimelineWindowItemController, number]
+    > => {
+      if (measuredSampleKeys.size < TIMELINE_WINDOW_REBUDGET_MIN_SAMPLES) {
+        return [];
+      }
+      const average = Math.min(
         TIMELINE_WINDOW_REBUDGET_MAX_ESTIMATE_PX,
         measuredSampleSum / measuredSampleKeys.size,
       );
-    const rebudgetEstimatedPlaceholders = () => {
-      if (measuredSampleKeys.size < TIMELINE_WINDOW_REBUDGET_MIN_SAMPLES) {
-        return;
-      }
-      const average = measuredAverage();
       if (
         lastRebudgetAverage !== null &&
         Math.abs(average - lastRebudgetAverage) <
           TIMELINE_WINDOW_REBUDGET_DRIFT_PX
       ) {
-        return;
+        return [];
       }
+      lastRebudgetAverage = average;
       const adjustments: Array<[TimelineWindowItemController, number]> = [];
       for (const key of itemKeysRef.current) {
         const controller = controllerByKeyRef.current.get(key);
@@ -2482,28 +2487,40 @@ function TimelineRowsList({
         }
         adjustments.push([controller, delta]);
       }
-      lastRebudgetAverage = average;
-      if (adjustments.length === 0) {
+      return adjustments;
+    };
+
+    // One idle pass covers both deferred works: mount the insolvent
+    // realizations and re-seed estimate placeholders, in a single
+    // anchor-compensated commit.
+    const runIdlePass = () => {
+      const pending = [...pendingRealizeKeys];
+      pendingRealizeKeys.clear();
+      const adjustments = computeRebudgetAdjustments();
+      if (pending.length === 0 && adjustments.length === 0) {
         return;
       }
       applyWithScrollCompensation(() => {
+        for (const key of pending) {
+          controllerByKeyRef.current.get(key)?.realize();
+        }
         for (const [controller, delta] of adjustments) {
           controller.adjustPlaceholderHeight(delta);
         }
       });
     };
-    let rebudgetTimeout: number | null = null;
-    const scheduleRebudget = () => {
-      if (rebudgetTimeout !== null) {
-        window.clearTimeout(rebudgetTimeout);
+    let idlePassTimeout: number | null = null;
+    const scheduleIdlePass = () => {
+      if (idlePassTimeout !== null) {
+        window.clearTimeout(idlePassTimeout);
       }
-      rebudgetTimeout = window.setTimeout(() => {
-        rebudgetTimeout = null;
+      idlePassTimeout = window.setTimeout(() => {
+        idlePassTimeout = null;
         if (scrollElement.dataset.scrollbarScrolling === "true") {
-          scheduleRebudget();
+          scheduleIdlePass();
           return;
         }
-        rebudgetEstimatedPlaceholders();
+        runIdlePass();
       }, TIMELINE_WINDOW_REBUDGET_IDLE_DELAY_MS);
     };
     const recordMeasuredSample = (key: string, height: number) => {
@@ -2512,7 +2529,7 @@ function TimelineRowsList({
       }
       measuredSampleKeys.add(key);
       measuredSampleSum += height;
-      scheduleRebudget();
+      scheduleIdlePass();
     };
 
     // Realize items whose top sits above the viewport while a scroll is
@@ -2550,20 +2567,26 @@ function TimelineRowsList({
         }
       });
 
-      let residual = 0;
       flushSync(() => {
         for (const candidate of candidates) {
           const measured = candidate.wrapper.getBoundingClientRect().height;
-          realizedHeightByKey.set(candidate.key, measured);
           recordMeasuredSample(candidate.key, measured);
           const delta = measured - candidate.placeholderHeight;
-          if (delta === 0) {
+          if (
+            delta !== 0 &&
+            !tryCompensateAboveViewportDelta(candidate.index, delta)
+          ) {
+            // No donor capacity (near the top of the timeline): revert to
+            // the unchanged placeholder — net zero, nothing painted in
+            // between — and mount at the idle pass instead.
+            candidate.controller.derealize();
+            pendingRealizeKeys.add(candidate.key);
+            scheduleIdlePass();
             continue;
           }
-          residual += compensateAboveViewportDelta(candidate.index, delta);
+          realizedHeightByKey.set(candidate.key, measured);
         }
       });
-      applyResidual(residual);
     };
 
     const observer = new IntersectionObserver(
@@ -2592,6 +2615,7 @@ function TimelineRowsList({
             }
             if (!entry.isIntersecting) {
               realizedHeightByKey.delete(key);
+              pendingRealizeKeys.delete(key);
               controller.handleIntersection(entry);
               continue;
             }
@@ -2627,8 +2651,11 @@ function TimelineRowsList({
             if (key === undefined) {
               continue;
             }
-            if (!entry.isIntersecting) {
+            if (entry.isIntersecting) {
+              pendingRealizeKeys.delete(key);
+            } else {
               realizedHeightByKey.delete(key);
+              pendingRealizeKeys.delete(key);
             }
             controllerByKeyRef.current.get(key)?.handleIntersection(entry);
           }
@@ -2642,16 +2669,20 @@ function TimelineRowsList({
     intersectionObserverRef.current = observer;
 
     // Late content growth in a realized row above the viewport (a lazy image
-    // decoding, async rendering settling) shifts visible content exactly like
-    // an uncompensated realization would. ResizeObserver fires between layout
-    // and paint, so balancing the delta into donors here commits before the
-    // shift ever paints. Growth in or below the viewport stays uncompensated:
-    // a visible image expanding in place is expected content behavior.
+    // decoding, async rendering settling) shifts visible content, because
+    // WebKit has no scroll anchoring. Compensate with a direct scrollTop
+    // nudge — but only while the scroll is idle, where the write is free.
+    // During an active scroll only the baseline updates: mutating geometry
+    // mid-gesture is exactly what reads as snapping. Growth in or below the
+    // viewport stays uncompensated: a visible image expanding in place is
+    // expected content behavior.
     let contentGrowthObserver: ResizeObserver | null = null;
     if (typeof ResizeObserver !== "undefined") {
       contentGrowthObserver = new ResizeObserver((entries) => {
         let viewportTop: number | null = null;
-        const compensations: Array<{ index: number; delta: number }> = [];
+        let idleAdjustment = 0;
+        const scrolling =
+          scrollElement.dataset.scrollbarScrolling === "true";
         for (const entry of entries) {
           const key = keyByWrapperRef.current.get(entry.target);
           if (key === undefined) {
@@ -2673,9 +2704,9 @@ function TimelineRowsList({
           const previous = realizedHeightByKey.get(key);
           realizedHeightByKey.set(key, height);
           recordMeasuredSample(key, height);
-          if (previous === undefined) {
-            // First observation after a realization whose delta was already
-            // balanced (or that mounted through the anchor-compensated path).
+          if (previous === undefined || scrolling) {
+            // First observation after an already-balanced realization, or a
+            // mid-scroll change that must not mutate geometry.
             continue;
           }
           const delta = height - previous;
@@ -2686,24 +2717,14 @@ function TimelineRowsList({
           if (wrapper.getBoundingClientRect().bottom > viewportTop) {
             continue;
           }
-          const index = itemKeysRef.current.indexOf(key);
-          if (index >= 0) {
-            compensations.push({ index, delta });
-          }
+          idleAdjustment += delta;
         }
-        if (compensations.length === 0) {
-          return;
+        if (idleAdjustment !== 0) {
+          scrollElement.scrollTop = Math.max(
+            0,
+            scrollElement.scrollTop + idleAdjustment,
+          );
         }
-        let residual = 0;
-        flushSync(() => {
-          for (const compensation of compensations) {
-            residual += compensateAboveViewportDelta(
-              compensation.index,
-              compensation.delta,
-            );
-          }
-        });
-        applyResidual(residual);
       });
     }
     resizeObserverRef.current = contentGrowthObserver;
@@ -2712,8 +2733,8 @@ function TimelineRowsList({
       observer.observe(wrapper);
       contentGrowthObserver?.observe(wrapper);
     }
-    // Scroll events push a pending re-budget out to the next idle moment.
-    scrollElement.addEventListener("scroll", scheduleRebudget, {
+    // Scroll events push the pending idle pass out to the next quiet moment.
+    scrollElement.addEventListener("scroll", scheduleIdlePass, {
       passive: true,
     });
 
@@ -2722,10 +2743,11 @@ function TimelineRowsList({
       resizeObserverRef.current = null;
       observer.disconnect();
       contentGrowthObserver?.disconnect();
-      scrollElement.removeEventListener("scroll", scheduleRebudget);
-      if (rebudgetTimeout !== null) {
-        window.clearTimeout(rebudgetTimeout);
+      scrollElement.removeEventListener("scroll", scheduleIdlePass);
+      if (idlePassTimeout !== null) {
+        window.clearTimeout(idlePassTimeout);
       }
+      pendingRealizeKeys.clear();
       realizedHeightByKey.clear();
     };
   }, [getScrollElement, shouldWindow]);

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -4,13 +4,16 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
   useSyncExternalStore,
 } from "react";
 import type { ReactNode } from "react";
+import { flushSync } from "react-dom";
 import { useLocation } from "react-router-dom";
+import { useStore } from "jotai";
 import {
   isBackgroundAgentTaskType,
   isBackgroundCommandTaskType,
@@ -86,6 +89,8 @@ import { AutoHeightContainer } from "../../ui/height-transition.js";
 import { Icon, type IconName } from "@bb/shared-ui/icon";
 import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
 import { useBottomAnchoredScroll } from "@/components/ui/bottom-anchored-scroll-body.js";
+import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
+import { threadTimelineScrollAnchorAtomFamily } from "@/lib/thread-timeline-scroll-anchor.js";
 import {
   collectSearchedMessageAncestorRowIds,
   readSearchMessageTarget,
@@ -275,6 +280,29 @@ interface TimelineRowsListProps {
   unreadDividerPlacement: ThreadTimelineUnreadDividerPlacement | null;
 }
 
+interface TimelineWindowItemController {
+  handleIntersection: (entry: IntersectionObserverEntry) => void;
+}
+
+interface TimelineVisibleAnchor {
+  element: HTMLDivElement;
+  top: number;
+}
+
+interface TimelineWindowedListItemProps {
+  alwaysRealized: boolean;
+  children: ReactNode;
+  estimatedHeight: number;
+  initiallyRealized: boolean;
+  itemKey: string;
+  registerWrapper: (key: string, node: HTMLDivElement | null) => void;
+  registerController: (
+    key: string,
+    controller: TimelineWindowItemController | null,
+  ) => void;
+  rowId: string | undefined;
+}
+
 interface TimelineUnreadDividerProps {
   autoScroll: boolean;
 }
@@ -400,6 +428,74 @@ type TimelineRowsListItem =
       kind: "unread-divider";
       id: "thread-unread-divider";
     };
+
+const TIMELINE_WINDOWING_MIN_ITEM_COUNT = 40;
+const TIMELINE_WINDOW_MARGIN_PX = 1_000;
+const TIMELINE_WINDOW_FALLBACK_VIEWPORT_HEIGHT_PX = 800;
+
+function timelineListItemKey(item: TimelineRowsListItem): string {
+  return item.kind === "row" ? item.row.id : item.id;
+}
+
+function estimateTimelineListItemHeight(item: TimelineRowsListItem): number {
+  if (item.kind === "unread-divider") {
+    return 24;
+  }
+  if (item.row.kind === "conversation") {
+    return 120;
+  }
+  return 40;
+}
+
+function collectTimelineWindowKeys({
+  centerIndex,
+  items,
+}: {
+  centerIndex: number;
+  items: readonly TimelineRowsListItem[];
+}): ReadonlySet<string> {
+  if (items.length === 0) {
+    return EMPTY_ROW_ID_SET;
+  }
+
+  const keys = new Set<string>();
+  const boundedCenterIndex = Math.max(
+    0,
+    Math.min(centerIndex, items.length - 1),
+  );
+  const coverage =
+    TIMELINE_WINDOW_MARGIN_PX + TIMELINE_WINDOW_FALLBACK_VIEWPORT_HEIGHT_PX;
+
+  let beforeHeight = 0;
+  for (
+    let index = boundedCenterIndex;
+    index >= 0 && beforeHeight <= coverage;
+    index -= 1
+  ) {
+    const item = items[index];
+    if (item === undefined) {
+      break;
+    }
+    keys.add(timelineListItemKey(item));
+    beforeHeight += estimateTimelineListItemHeight(item);
+  }
+
+  let afterHeight = 0;
+  for (
+    let index = boundedCenterIndex + 1;
+    index < items.length && afterHeight <= coverage;
+    index += 1
+  ) {
+    const item = items[index];
+    if (item === undefined) {
+      break;
+    }
+    keys.add(timelineListItemKey(item));
+    afterHeight += estimateTimelineListItemHeight(item);
+  }
+
+  return keys;
+}
 
 interface ConversationRowProps {
   row: TimelineConversationViewRow;
@@ -1843,6 +1939,152 @@ function buildTimelineRowsListItems({
   return items;
 }
 
+function TimelineWindowedListItem({
+  alwaysRealized,
+  children,
+  estimatedHeight,
+  initiallyRealized,
+  itemKey,
+  registerWrapper,
+  registerController,
+  rowId,
+}: TimelineWindowedListItemProps) {
+  const [locallyRealized, setLocallyRealized] = useState(initiallyRealized);
+  const [placeholderHeight, setPlaceholderHeight] = useState(estimatedHeight);
+  const locallyRealizedRef = useRef(locallyRealized);
+  const alwaysRealizedRef = useRef(alwaysRealized);
+  const interactionPinnedRef = useRef(false);
+  const lastIntersectionRef = useRef<boolean | null>(null);
+  useLayoutEffect(() => {
+    locallyRealizedRef.current = locallyRealized;
+    alwaysRealizedRef.current = alwaysRealized;
+  }, [alwaysRealized, locallyRealized]);
+
+  const updateLocallyRealized = useCallback((next: boolean) => {
+    if (locallyRealizedRef.current === next) {
+      return;
+    }
+    locallyRealizedRef.current = next;
+    setLocallyRealized(next);
+  }, []);
+  const controller = useMemo<TimelineWindowItemController>(
+    () => ({
+      handleIntersection: (entry) => {
+        lastIntersectionRef.current = entry.isIntersecting;
+        if (entry.isIntersecting) {
+          updateLocallyRealized(true);
+          return;
+        }
+        if (entry.boundingClientRect.height > 0) {
+          setPlaceholderHeight(entry.boundingClientRect.height);
+        }
+        if (!alwaysRealizedRef.current && !interactionPinnedRef.current) {
+          updateLocallyRealized(false);
+        }
+      },
+    }),
+    [updateLocallyRealized],
+  );
+  useLayoutEffect(() => {
+    registerController(itemKey, controller);
+    return () => registerController(itemKey, null);
+  }, [controller, itemKey, registerController]);
+  useLayoutEffect(() => {
+    if (
+      !alwaysRealized &&
+      lastIntersectionRef.current === false &&
+      !interactionPinnedRef.current
+    ) {
+      const frame = requestAnimationFrame(() => updateLocallyRealized(false));
+      return () => cancelAnimationFrame(frame);
+    }
+  }, [alwaysRealized, updateLocallyRealized]);
+
+  const pinInteractedItem = useCallback(() => {
+    interactionPinnedRef.current = true;
+  }, []);
+  const handleWrapperRef = useCallback(
+    (node: HTMLDivElement | null) => registerWrapper(itemKey, node),
+    [itemKey, registerWrapper],
+  );
+  const isRealized = alwaysRealized || locallyRealized;
+
+  return (
+    <div
+      ref={handleWrapperRef}
+      data-timeline-row-id={rowId}
+      data-timeline-row-realized={isRealized ? "true" : "false"}
+      aria-hidden={isRealized ? undefined : true}
+      style={isRealized ? undefined : { height: placeholderHeight }}
+      onClickCapture={pinInteractedItem}
+      onFocusCapture={pinInteractedItem}
+    >
+      {isRealized ? children : null}
+    </div>
+  );
+}
+
+function captureTimelineVisibleAnchor({
+  orderedKeys,
+  scrollElement,
+  wrapperByKey,
+}: {
+  orderedKeys: readonly string[];
+  scrollElement: HTMLElement;
+  wrapperByKey: ReadonlyMap<string, HTMLDivElement>;
+}): TimelineVisibleAnchor | null {
+  const scrollRect = scrollElement.getBoundingClientRect();
+  let low = 0;
+  let high = orderedKeys.length - 1;
+  let firstVisibleIndex = orderedKeys.length;
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    const key = orderedKeys[middle];
+    const element = key === undefined ? undefined : wrapperByKey.get(key);
+    if (element === undefined) {
+      return null;
+    }
+    if (element.getBoundingClientRect().bottom > scrollRect.top) {
+      firstVisibleIndex = middle;
+      high = middle - 1;
+    } else {
+      low = middle + 1;
+    }
+  }
+  const key = orderedKeys[firstVisibleIndex];
+  const element = key === undefined ? undefined : wrapperByKey.get(key);
+  if (element === undefined) {
+    return null;
+  }
+  const rect = element.getBoundingClientRect();
+  return rect.top < scrollRect.bottom ? { element, top: rect.top } : null;
+}
+
+function restoreTimelineVisibleAnchor({
+  anchor,
+  scrollElement,
+  wasAtBottom,
+}: {
+  anchor: TimelineVisibleAnchor | null;
+  scrollElement: HTMLElement;
+  wasAtBottom: boolean;
+}): void {
+  if (wasAtBottom) {
+    scrollElement.scrollTop = Math.max(
+      0,
+      scrollElement.scrollHeight - scrollElement.clientHeight,
+    );
+    return;
+  }
+  if (anchor === null || !anchor.element.isConnected) {
+    return;
+  }
+  const topDelta = anchor.element.getBoundingClientRect().top - anchor.top;
+  if (Math.abs(topDelta) > 0.5) {
+    scrollElement.scrollTop += topDelta;
+  }
+}
+
 function TimelineRowsList({
   compactActivityIntents,
   hasOlderTimelineRows,
@@ -1857,13 +2099,12 @@ function TimelineRowsList({
   unreadDividerPlacement,
 }: TimelineRowsListProps) {
   const { threadId } = useTimelineRendererStaticContext();
+  const isCompactViewport = useIsCompactViewport();
+  const bottomAnchor = useBottomAnchoredScroll();
+  const store = useStore();
+  const location = useLocation();
   const searchExpandedRowIds = useTimelineSearchExpansionRowIds(rows);
   const stableSearchExpandedRowIds = useStableReadonlySet(searchExpandedRowIds);
-  useScrollToSearchedMessage(rows, threadId, {
-    hasOlderRows: hasOlderTimelineRows,
-    isLoadingOlderRows: isLoadingOlderTimelineRows,
-    onLoadOlderRows,
-  });
   const activeLatestBundleId = useMemo(
     () => findActiveLatestBundleId(rows),
     [rows],
@@ -1872,7 +2113,259 @@ function TimelineRowsList({
     () => buildTimelineRowsListItems({ rows, unreadDividerPlacement }),
     [rows, unreadDividerPlacement],
   );
-  return (
+  const itemKeys = useMemo(() => items.map(timelineListItemKey), [items]);
+  const shouldWindow =
+    spacing === "top-level" &&
+    isCompactViewport &&
+    bottomAnchor !== null &&
+    typeof IntersectionObserver !== "undefined" &&
+    items.length >= TIMELINE_WINDOWING_MIN_ITEM_COUNT;
+  const searchTarget = useMemo(
+    () => readSearchMessageTarget(location.state),
+    [location.state],
+  );
+  const searchTargetsTimeline =
+    searchTarget !== null &&
+    (threadId === undefined ||
+      searchTarget.threadId === null ||
+      searchTarget.threadId === threadId);
+  const initialWindowCenterIndex = useMemo(() => {
+    if (searchTarget !== null && searchTargetsTimeline) {
+      const searchIndex = items.findIndex(
+        (item) =>
+          item.kind === "row" &&
+          item.row.sourceSeqStart <= searchTarget.seq &&
+          searchTarget.seq <= item.row.sourceSeqEnd,
+      );
+      if (searchIndex >= 0) {
+        return searchIndex;
+      }
+    }
+
+    if (unreadDividerAutoScroll) {
+      const dividerIndex = items.findIndex(
+        (item) => item.kind === "unread-divider",
+      );
+      if (dividerIndex >= 0) {
+        return dividerIndex;
+      }
+    }
+
+    if (threadId !== undefined) {
+      const anchor = store.get(threadTimelineScrollAnchorAtomFamily(threadId));
+      if (anchor !== null && !anchor.atBottom && anchor.rowId.length > 0) {
+        const anchorIndex = items.findIndex(
+          (item) => item.kind === "row" && item.row.id === anchor.rowId,
+        );
+        if (anchorIndex >= 0) {
+          return anchorIndex;
+        }
+      }
+    }
+
+    return Math.max(0, items.length - 1);
+  }, [
+    items,
+    searchTarget,
+    searchTargetsTimeline,
+    store,
+    threadId,
+    unreadDividerAutoScroll,
+  ]);
+  const initiallyRealizedKeys = useMemo(
+    () =>
+      shouldWindow
+        ? collectTimelineWindowKeys({
+            centerIndex: initialWindowCenterIndex,
+            items,
+          })
+        : EMPTY_ROW_ID_SET,
+    [initialWindowCenterIndex, items, shouldWindow],
+  );
+  const wrapperByKeyRef = useRef(new Map<string, HTMLDivElement>());
+  const keyByWrapperRef = useRef(new Map<Element, string>());
+  const controllerByKeyRef = useRef(
+    new Map<string, TimelineWindowItemController>(),
+  );
+  const intersectionObserverRef = useRef<IntersectionObserver | null>(null);
+  const alwaysRealizedKeys = useMemo(() => {
+    if (!shouldWindow) {
+      return EMPTY_ROW_ID_SET;
+    }
+    const keys = new Set<string>();
+    if (searchTarget !== null && searchTargetsTimeline) {
+      const searchIndex = items.findIndex(
+        (item) =>
+          item.kind === "row" &&
+          item.row.sourceSeqStart <= searchTarget.seq &&
+          searchTarget.seq <= item.row.sourceSeqEnd,
+      );
+      const searchItem = items[searchIndex];
+      if (searchItem !== undefined) {
+        keys.add(timelineListItemKey(searchItem));
+      }
+    }
+    if (unreadDividerAutoScroll) {
+      const dividerIndex = items.findIndex(
+        (item) => item.kind === "unread-divider",
+      );
+      const divider = items[dividerIndex];
+      if (divider !== undefined) {
+        keys.add(timelineListItemKey(divider));
+      }
+    }
+    return keys;
+  }, [
+    items,
+    searchTarget,
+    searchTargetsTimeline,
+    shouldWindow,
+    unreadDividerAutoScroll,
+  ]);
+
+  const registerWrapper = useCallback(
+    (key: string, node: HTMLDivElement | null) => {
+      const previous = wrapperByKeyRef.current.get(key);
+      if (previous !== undefined && previous !== node) {
+        keyByWrapperRef.current.delete(previous);
+        intersectionObserverRef.current?.unobserve(previous);
+      }
+      if (node === null) {
+        wrapperByKeyRef.current.delete(key);
+        return;
+      }
+      wrapperByKeyRef.current.set(key, node);
+      keyByWrapperRef.current.set(node, key);
+      intersectionObserverRef.current?.observe(node);
+    },
+    [],
+  );
+  const registerController = useCallback(
+    (key: string, controller: TimelineWindowItemController | null) => {
+      if (controller === null) {
+        controllerByKeyRef.current.delete(key);
+        return;
+      }
+      controllerByKeyRef.current.set(key, controller);
+    },
+    [],
+  );
+
+  const getScrollElement = bottomAnchor?.getScrollElement;
+  useEffect(() => {
+    if (!shouldWindow || typeof IntersectionObserver === "undefined") {
+      return;
+    }
+    const scrollElement = getScrollElement?.() ?? null;
+    if (scrollElement === null) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const maxScrollTop = Math.max(
+          0,
+          scrollElement.scrollHeight - scrollElement.clientHeight,
+        );
+        const wasAtBottom = maxScrollTop - scrollElement.scrollTop <= 2;
+        const anchor = wasAtBottom
+          ? null
+          : captureTimelineVisibleAnchor({
+              scrollElement,
+              orderedKeys: itemKeys,
+              wrapperByKey: wrapperByKeyRef.current,
+            });
+        flushSync(() => {
+          for (const entry of entries) {
+            const key = keyByWrapperRef.current.get(entry.target);
+            if (key === undefined) {
+              continue;
+            }
+            controllerByKeyRef.current.get(key)?.handleIntersection(entry);
+          }
+        });
+        restoreTimelineVisibleAnchor({ anchor, scrollElement, wasAtBottom });
+      },
+      {
+        root: scrollElement,
+        rootMargin: `${TIMELINE_WINDOW_MARGIN_PX}px 0px`,
+      },
+    );
+    intersectionObserverRef.current = observer;
+    for (const wrapper of wrapperByKeyRef.current.values()) {
+      observer.observe(wrapper);
+    }
+
+    return () => {
+      intersectionObserverRef.current = null;
+      observer.disconnect();
+    };
+  }, [getScrollElement, itemKeys, shouldWindow]);
+
+  const renderedRowsKey = shouldWindow
+    ? [...alwaysRealizedKeys].sort().join("\u0000")
+    : "all";
+
+  useScrollToSearchedMessage(rows, threadId, {
+    hasOlderRows: hasOlderTimelineRows,
+    isLoadingOlderRows: isLoadingOlderTimelineRows,
+    onLoadOlderRows,
+    renderedRowsKey,
+  });
+
+  const renderItem = (item: TimelineRowsListItem) => {
+    if (item.kind === "unread-divider") {
+      return <TimelineUnreadDivider autoScroll={unreadDividerAutoScroll} />;
+    }
+    return (
+      <MemoizedTimelineRowView
+        activeLatestBundleId={activeLatestBundleId}
+        row={item.row}
+        scopeActive={scopeActive}
+        showAssistantMessageActions={showAssistantMessageActions}
+        spacing={spacing}
+        compactActivityIntents={compactActivityIntents}
+      />
+    );
+  };
+
+  if (shouldWindow) {
+    return (
+      <TimelineSearchExpansionContext.Provider
+        value={stableSearchExpandedRowIds}
+      >
+        <div
+          className={cn(
+            "flex min-w-0 flex-col [&_button:not(:disabled)]:cursor-pointer",
+            timelineRowsListGapClassName(spacing),
+            className,
+          )}
+          data-timeline-row-list={spacing}
+          data-timeline-windowed="true"
+        >
+          {items.map((item) => {
+            const itemKey = timelineListItemKey(item);
+            return (
+              <TimelineWindowedListItem
+                key={itemKey}
+                alwaysRealized={alwaysRealizedKeys.has(itemKey)}
+                estimatedHeight={estimateTimelineListItemHeight(item)}
+                initiallyRealized={initiallyRealizedKeys.has(itemKey)}
+                itemKey={itemKey}
+                registerController={registerController}
+                registerWrapper={registerWrapper}
+                rowId={item.kind === "row" ? item.row.id : undefined}
+              >
+                {renderItem(item)}
+              </TimelineWindowedListItem>
+            );
+          })}
+        </div>
+      </TimelineSearchExpansionContext.Provider>
+    );
+  }
+
+  const list = (
     <TimelineSearchExpansionContext.Provider value={stableSearchExpandedRowIds}>
       <div
         className={cn(
@@ -1893,20 +2386,22 @@ function TimelineRowsList({
           }
 
           return (
-            <div key={item.row.id} data-timeline-row-id={item.row.id}>
-              <MemoizedTimelineRowView
-                activeLatestBundleId={activeLatestBundleId}
-                row={item.row}
-                scopeActive={scopeActive}
-                showAssistantMessageActions={showAssistantMessageActions}
-                spacing={spacing}
-                compactActivityIntents={compactActivityIntents}
-              />
+            <div
+              key={item.row.id}
+              data-timeline-row-id={item.row.id}
+              data-timeline-row-realized="true"
+            >
+              {renderItem(item)}
             </div>
           );
         })}
       </div>
     </TimelineSearchExpansionContext.Provider>
+  );
+  return spacing === "top-level" ? (
+    <AutoHeightContainer>{list}</AutoHeightContainer>
+  ) : (
+    list
   );
 }
 
@@ -2158,26 +2653,20 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
               value={latestActionableUserMessageId}
             >
               <TimelineTurnStateContext.Provider value={turnStateContextValue}>
-                <AutoHeightContainer>
-                  <TimelineRowsList
-                    hasOlderTimelineRows={props.hasOlderTimelineRows}
-                    isLoadingOlderTimelineRows={
-                      props.isLoadingOlderTimelineRows
-                    }
-                    onLoadOlderRows={props.onLoadOlderRows}
-                    rows={rows}
-                    scopeActive={scopeActive}
-                    showAssistantMessageActions={true}
-                    compactActivityIntents={false}
-                    spacing="top-level"
-                    unreadDividerAutoScroll={
-                      props.unreadDividerAutoScroll ?? true
-                    }
-                    unreadDividerPlacement={
-                      props.unreadDividerPlacement ?? null
-                    }
-                  />
-                </AutoHeightContainer>
+                <TimelineRowsList
+                  hasOlderTimelineRows={props.hasOlderTimelineRows}
+                  isLoadingOlderTimelineRows={props.isLoadingOlderTimelineRows}
+                  onLoadOlderRows={props.onLoadOlderRows}
+                  rows={rows}
+                  scopeActive={scopeActive}
+                  showAssistantMessageActions={true}
+                  compactActivityIntents={false}
+                  spacing="top-level"
+                  unreadDividerAutoScroll={
+                    props.unreadDividerAutoScroll ?? true
+                  }
+                  unreadDividerPlacement={props.unreadDividerPlacement ?? null}
+                />
                 {hasSelectionActions ? (
                   <TimelineSelectionMenu
                     selection={activeSelection?.selection ?? null}

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -2263,6 +2263,25 @@ function TimelineRowsList({
 
     const observer = new IntersectionObserver(
       (entries) => {
+        const updateWindowItems = () => {
+          for (const entry of entries) {
+            const key = keyByWrapperRef.current.get(entry.target);
+            if (key === undefined) {
+              continue;
+            }
+            controllerByKeyRef.current.get(key)?.handleIntersection(entry);
+          }
+        };
+
+        // A programmatic scrollTop write stops WebKit's native momentum
+        // scrolling. The scroll owner keeps this marker present for the full
+        // scroll, including its inertial tail. Let the browser's normal scroll
+        // anchoring cover window updates until scrolling stops.
+        if (scrollElement.dataset.scrollbarScrolling === "true") {
+          updateWindowItems();
+          return;
+        }
+
         const maxScrollTop = Math.max(
           0,
           scrollElement.scrollHeight - scrollElement.clientHeight,
@@ -2275,15 +2294,7 @@ function TimelineRowsList({
               orderedKeys: itemKeys,
               wrapperByKey: wrapperByKeyRef.current,
             });
-        flushSync(() => {
-          for (const entry of entries) {
-            const key = keyByWrapperRef.current.get(entry.target);
-            if (key === undefined) {
-              continue;
-            }
-            controllerByKeyRef.current.get(key)?.handleIntersection(entry);
-          }
-        });
+        flushSync(updateWindowItems);
         restoreTimelineVisibleAnchor({ anchor, scrollElement, wasAtBottom });
       },
       {

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -2335,6 +2335,7 @@ function TimelineRowsList({
     if (scrollElement === null) {
       return;
     }
+    const realizedHeightByKey = realizedHeightByKeyRef.current;
 
     const applyWithScrollCompensation = (apply: () => void) => {
       const maxScrollTop = Math.max(
@@ -2453,7 +2454,7 @@ function TimelineRowsList({
       flushSync(() => {
         for (const candidate of candidates) {
           const measured = candidate.wrapper.getBoundingClientRect().height;
-          realizedHeightByKeyRef.current.set(candidate.key, measured);
+          realizedHeightByKey.set(candidate.key, measured);
           const delta = measured - candidate.placeholderHeight;
           if (delta === 0) {
             continue;
@@ -2489,7 +2490,7 @@ function TimelineRowsList({
               continue;
             }
             if (!entry.isIntersecting) {
-              realizedHeightByKeyRef.current.delete(key);
+              realizedHeightByKey.delete(key);
               controller.handleIntersection(entry);
               continue;
             }
@@ -2526,7 +2527,7 @@ function TimelineRowsList({
               continue;
             }
             if (!entry.isIntersecting) {
-              realizedHeightByKeyRef.current.delete(key);
+              realizedHeightByKey.delete(key);
             }
             controllerByKeyRef.current.get(key)?.handleIntersection(entry);
           }
@@ -2563,13 +2564,13 @@ function TimelineRowsList({
             // Placeholder height changes are this component's own writes
             // (donor adjustments, derealization measurements) — already
             // balanced, never compensated again.
-            realizedHeightByKeyRef.current.delete(key);
+            realizedHeightByKey.delete(key);
             continue;
           }
           const height =
             entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
-          const previous = realizedHeightByKeyRef.current.get(key);
-          realizedHeightByKeyRef.current.set(key, height);
+          const previous = realizedHeightByKey.get(key);
+          realizedHeightByKey.set(key, height);
           if (previous === undefined) {
             // First observation after a realization whose delta was already
             // balanced (or that mounted through the anchor-compensated path).
@@ -2615,7 +2616,7 @@ function TimelineRowsList({
       resizeObserverRef.current = null;
       observer.disconnect();
       contentGrowthObserver?.disconnect();
-      realizedHeightByKeyRef.current.clear();
+      realizedHeightByKey.clear();
     };
   }, [getScrollElement, shouldWindow]);
 

--- a/apps/app/src/components/thread/timeline/useScrollToSearchedMessage.ts
+++ b/apps/app/src/components/thread/timeline/useScrollToSearchedMessage.ts
@@ -21,6 +21,8 @@ interface SearchMessagePaginationOptions {
   hasOlderRows?: boolean;
   isLoadingOlderRows?: boolean;
   onLoadOlderRows?: () => Promise<void> | void;
+  /** Changes when a virtual list mounts a different row range. */
+  renderedRowsKey?: string;
 }
 
 interface SeqRange {
@@ -195,6 +197,7 @@ export function useScrollToSearchedMessage(
     hasOlderRows = false,
     isLoadingOlderRows = false,
     onLoadOlderRows,
+    renderedRowsKey,
   }: SearchMessagePaginationOptions = {},
 ): void {
   const location = useLocation();
@@ -247,7 +250,11 @@ export function useScrollToSearchedMessage(
       return;
     }
     const selector = `[data-timeline-row-id="${escapeTimelineRowId(targetLeafRow.id)}"]`;
-    if (document.querySelector(selector) === null) {
+    const renderedTarget = document.querySelector<HTMLElement>(selector);
+    if (
+      renderedTarget === null ||
+      renderedTarget.dataset.timelineRowRealized === "false"
+    ) {
       return;
     }
     handledKeyRef.current = location.key;
@@ -291,6 +298,7 @@ export function useScrollToSearchedMessage(
     isLoadingOlderRows,
     location.key,
     onLoadOlderRows,
+    renderedRowsKey,
     rows,
     targetSeq,
     targetThreadId,


### PR DESCRIPTION
## Summary

- Replace the absolute-position timeline virtualizer with in-flow row windows.
- Keep measured placeholders in normal document flow.
- Update each window row independently instead of rerendering the complete list.
- Preserve the visible row when placeholder heights change.
- Preserve search targets, unread targets, stored scroll anchors, row interaction state, and bottom follow behavior.

## iOS Safari results

Tested an 85-row mobile timeline from a seeded thread with 1,368 event rows.

- 620 scroll samples across both directions after the final correction
- 17 to 41 complete rows mounted during the run
- 0.125-pixel maximum visible-row drift across ten delayed height-settle checks
- 0 potential WebKit hangs in the Time Profiler trace

## Verification

- `pnpm exec turbo run lint typecheck --filter=@bb/app`
- 51 focused app tests
- `pnpm exec turbo run build --filter=@bb/app`
- iPhone 16 Pro Simulator with iOS 18.4 Safari

> AGENT GENERATED: by GPT-5.6



---

## Update: scroll-time realization (2026-08-12)

Two follow-up commits fix scroll defects that field testing found after the results above.

**Skips and jitters during momentum scrolls.** The scroll owner sets `data-scrollbar-scrolling` on every scroll event, so window updates during a scroll skipped the anchor compensation and trusted native scroll anchoring — which WebKit does not implement. A placeholder that realized above the viewport shifted visible content by the placeholder-vs-real height delta.

**Fix: donor-compensated realization.** While a scroll is active:

- Derealizations apply immediately (they swap in their just-measured height, so they are height-neutral).
- Rows whose top is at or below the viewport realize immediately (growth only pushes layout downward).
- Rows above the viewport mount and measure in one synchronous commit, then other placeholders that also sit fully above the viewport shrink by the same delta in a second commit in the same task. The net height above the viewport stays zero: nothing visible moves, no `scrollTop` write happens, and momentum survives. Donors shrink topmost-first and self-correct when they later realize or derealize.
- A row with no donor capacity (near the top of the timeline) reverts to its unchanged placeholder within the same task and realizes through an idle flush (250ms after the last scroll event) with the standard capture/flushSync/restore anchor compensation.

An intermediate approach that deferred all above-viewport realizations to scroll idle was rejected: iOS emits scroll events through the whole momentum tail, so rows stayed blank until the scroll fully stopped.

New unit tests cover scroll-time below-viewport realization, donor shrink across multiple placeholders, donor growth for shorter-than-placeholder content, and the no-donor revert + idle-flush path. Typecheck passes and the timeline and scroll-body suites pass (170 tests).

> AGENT GENERATED: update by Claude Fable 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
