### PR TITLE
fix(host-daemon): detect known ACP agents on the user shell PATH

### DIFF
--- a/apps/host-daemon/src/command-dispatch.test.ts
+++ b/apps/host-daemon/src/command-dispatch.test.ts
@@ -1571,4 +1571,54 @@ describe("dispatchCommand", () => {
       fixture.originalCatalogHash,
     );
   });
+
+  it("detects known ACP agents on the resolved user shell PATH, not the daemon's process PATH", async () => {
+    // Regression: known_acp_agents.status must query `which` with the user's
+    // resolved login-shell PATH (like provider_cli.status), otherwise ACP CLIs
+    // installed only on the login PATH — e.g. Hermes' `hermes` under
+    // ~/.local/bin — are invisible to a daemon launched by launchd/systemd with
+    // a stripped PATH.
+    const binDir = await makeTempDir("bb-acp-shell-path-");
+    const executableName = `bb-acp-probe-${process.pid}`;
+    const executablePath = path.join(binDir, executableName);
+    await fs.writeFile(executablePath, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
+
+    const runtime = createRuntime();
+    const manager = new RuntimeManager({
+      createRuntime: () => runtime,
+      provisionWorkspace: async () => createWorkspace(),
+    });
+    // The probe executable exists ONLY on the shell PATH the manager reports,
+    // never on process.env.PATH, so a detection that ignores the shell env
+    // fails to find it. System bin dirs stay on PATH so `which` itself resolves;
+    // only binDir (the stand-in for ~/.local/bin) is exclusive to the shell env.
+    manager.replaceManagedShellEnv({ PATH: `${binDir}:/usr/bin:/bin` });
+
+    const result = await dispatchOnlineRpcCommand(
+      {
+        type: "known_acp_agents.status",
+        agents: [{ id: "acp-probe", executableName }],
+      },
+      {
+        dataDir: "/tmp/bb-data",
+        eventSink: { emit: vi.fn(), flush: vi.fn(async () => undefined) },
+        fetchProjectAttachment: async () => {
+          throw new Error("Unexpected project attachment fetch");
+        },
+        runtimeManager: manager,
+        threadStorageRootPath: "/tmp/bb-thread-storage",
+      },
+    );
+
+    expect(result).toEqual({
+      agents: [
+        {
+          id: "acp-probe",
+          executableName,
+          installed: true,
+          executablePath,
+        },
+      ],
+    });
+  });
 });

--- a/apps/host-daemon/src/command-dispatch.ts
+++ b/apps/host-daemon/src/command-dispatch.ts
@@ -619,8 +619,11 @@ const onlineRpcHandlers: OnlineRpcHandlerMap = {
         ? { acpLaunchSpec: command.acpLaunchSpec }
         : {}),
     }),
-  "known_acp_agents.status": async (command) =>
-    getKnownAcpAgentsStatus({ agents: command.agents }),
+  "known_acp_agents.status": async (command, options) =>
+    getKnownAcpAgentsStatus({
+      agents: command.agents,
+      env: providerCliEnvFromShellEnv(options.runtimeManager.getShellEnv()),
+    }),
   "provider.usage": async () => getProviderUsage(),
   "provider_cli.status": async (_command, options) =>
     getProviderCliStatus({


### PR DESCRIPTION
Fixes #1388

## Summary

`known_acp_agents.status` resolved ACP-agent CLIs against the daemon's process `PATH`, while the sibling `provider_cli.status` handler resolves the user's login-shell `PATH` via `providerCliEnvFromShellEnv(runtimeManager.getShellEnv())`. A daemon started by launchd/systemd inherits a stripped `PATH`, so ACP CLIs installed only on the login PATH (e.g. Hermes' `hermes` under `~/.local/bin`) were reported as not installed and never appeared as providers — even though codex/claude detection on the same host worked.

## Change

`apps/host-daemon/src/command-dispatch.ts`:

```diff
-  "known_acp_agents.status": async (command) =>
-    getKnownAcpAgentsStatus({ agents: command.agents }),
+  "known_acp_agents.status": async (command, options) =>
+    getKnownAcpAgentsStatus({
+      agents: command.agents,
+      env: providerCliEnvFromShellEnv(options.runtimeManager.getShellEnv()),
+    }),
```

`getKnownAcpAgentsStatus` already accepts an optional `env`; this wires it to the resolved shell env, identical to `provider_cli.status` two lines below. No signature or wire-protocol change.

## Tests

Added a regression test in `command-dispatch.test.ts` that places an executable **only** on the manager's shell PATH (a stand-in for `~/.local/bin`), keeps system bin dirs on PATH so `which` itself resolves, and asserts the ACP agent is detected with the correct `executablePath`.

Differential verification (the pre-filing gate):

- With the fix: test passes (`installed: true`).
- Reverting **only** the one-line fix (test unchanged): test fails (`installed: false`).

Suite results (`@bb/host-daemon`, via Turbo):

- `pnpm exec turbo run typecheck --filter=@bb/host-daemon` → pass
- `command-dispatch.test.ts` → **24 passed** (23 pre-existing + 1 new)
- Full `@bb/host-daemon` test run → 543 total, all green with the fix (the single failure seen mid-development was a test-setup issue in the new test, since fixed).

## Risk

Low, and strictly a widening. Previously the handler could only see the daemon's process PATH; now it additionally sees the resolved user shell PATH — exactly what the provider-CLI checks already do. No behavior change for agents already on the process PATH.
