### PR TITLE
Add a Linux desktop build target (AppImage, x64)

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -1,7 +1,8 @@
 # @bb/desktop
 
-macOS Electron shell for bb. The desktop app loads the existing bb web UI and
-uses the packaged `bb-app` launcher for server and host-daemon lifecycle.
+macOS and Linux Electron shell for bb. The desktop app loads the existing bb
+web UI and uses the packaged `bb-app` launcher for server and host-daemon
+lifecycle.
 
 ## Development
 
@@ -82,6 +83,26 @@ the app's process tree, which can stall process launches system-wide. On
 machines with no keychain identity (or with `CSC_IDENTITY_AUTO_DISCOVERY=false`,
 as CI sets for workflow-artifact-only builds), artifacts remain unsigned and
 macOS shows the normal Gatekeeper warning on first launch.
+
+### Linux (AppImage, x64)
+
+Linux packaging targets x64 glibc-based distributions. Install `python3`,
+`make`, and `g++` so node-gyp can build node-pty during dependency installation.
+
+From the repo root, build an unpacked app, an AppImage distribution, or smoke
+test the current packaged output with:
+
+```bash
+pnpm --filter @bb/desktop run package:linux
+pnpm --filter @bb/desktop run dist:linux
+pnpm --filter @bb/desktop run smoke:packaged
+```
+
+Running an AppImage normally requires FUSE and, on some distributions, the
+`libfuse2` compatibility package. If FUSE is unavailable, launch it with
+`--appimage-extract-and-run` instead.
+
+Auto-update is disabled on Linux because there is no Linux update feed yet.
 
 ## Releasing
 

--- a/apps/desktop/electron-builder.config.json
+++ b/apps/desktop/electron-builder.config.json
@@ -48,6 +48,12 @@
       }
     ]
   },
+  "linux": {
+    "category": "Development",
+    "executableName": "bb",
+    "icon": "assets/icon.png",
+    "target": [{ "target": "AppImage", "arch": ["x64"] }]
+  },
   "dmg": {
     "sign": false
   },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,22 +2,27 @@
   "name": "@bb/desktop",
   "version": "0.37.0",
   "private": true,
-  "description": "macOS Electron shell for bb",
+  "description": "macOS and Linux Electron shell for bb",
   "main": "dist/main.js",
   "os": [
-    "darwin"
+    "darwin",
+    "linux"
   ],
   "scripts": {
     "build": "node scripts/build.mjs",
     "clean": "rimraf dist release",
     "desktop:build": "pnpm run build && node scripts/run-electron-builder.mjs --mac --publish always",
+    "desktop:build:linux": "pnpm run build && node scripts/run-electron-builder.mjs --linux --x64 --publish never",
     "desktop:version-feed": "tsx scripts/generate-version-feed.mts",
     "dev": "pnpm run prepare-runtime && pnpm run build && node --conditions=source --import tsx scripts/run-electron-dev.mjs",
     "dist": "pnpm run prepare-runtime && pnpm run desktop:build",
+    "dist:linux": "pnpm run prepare-runtime && pnpm run desktop:build:linux",
     "package": "pnpm run prepare-runtime && pnpm run build && node scripts/run-electron-builder.mjs --mac --dir",
+    "package:linux": "pnpm run prepare-runtime && pnpm run build && node scripts/run-electron-builder.mjs --linux --dir --x64",
     "prepare-runtime": "pnpm exec turbo run build --filter=bb-app --output-logs=new-only",
     "smoke:packaged": "node scripts/smoke-packaged-app.mjs",
     "start": "pnpm run package && node scripts/run-packaged-app.mjs",
+    "start:linux": "pnpm run package:linux && node scripts/run-packaged-app.mjs",
     "test": "vitest run --config vitest.config.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/desktop/scripts/packaged-app-paths.mjs
+++ b/apps/desktop/scripts/packaged-app-paths.mjs
@@ -1,0 +1,41 @@
+import { access, readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+export async function resolvePackagedAppBinary({
+  executableName,
+  platform,
+  productName,
+  releaseDir,
+}) {
+  if (platform === "linux") {
+    return join(releaseDir, "linux-unpacked", executableName);
+  }
+  if (platform !== "darwin") {
+    throw new Error(`Unsupported packaged desktop platform: ${platform}`);
+  }
+
+  const appBundleName = `${productName}.app`;
+  const appBinaryRelativePath = join(
+    appBundleName,
+    "Contents",
+    "MacOS",
+    productName,
+  );
+  const entries = await readdir(releaseDir, { withFileTypes: true });
+  const macOutputDirectories = entries
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith("mac"))
+    .map((entry) => entry.name)
+    .sort();
+
+  for (const directory of macOutputDirectories) {
+    const appBinary = join(releaseDir, directory, appBinaryRelativePath);
+    try {
+      await access(appBinary);
+      return appBinary;
+    } catch {
+      continue;
+    }
+  }
+
+  throw new Error(`No packaged ${appBundleName} found under ${releaseDir}`);
+}

--- a/apps/desktop/scripts/prepare-native-modules.cjs
+++ b/apps/desktop/scripts/prepare-native-modules.cjs
@@ -22,8 +22,6 @@ const PACKAGED_NATIVE_PACKAGE_NAMES = [
 // `npmRebuild` is disabled and we fetch the Electron prebuild into the packaged
 // copy here, leaving the shared store untouched. Desktop dev runs bb-app with
 // the host Node executable so it can use the workspace's normal Node-ABI binary.
-const NATIVE_MODULE_PLATFORM = "darwin";
-
 const NODE_PTY_PREBUILD_PLATFORMS = ["darwin-arm64", "darwin-x64"];
 const NODE_PTY_SPAWN_HELPER_RELATIVE_PATHS = [
   path.join("build", "Release", "spawn-helper"),
@@ -151,12 +149,16 @@ async function prepareNodePtyPackageDirectory(packageDirectory) {
   );
 }
 
-function resolveBetterSqlite3PrebuildArguments({ electronVersion, arch }) {
+function resolveBetterSqlite3PrebuildArguments({
+  electronVersion,
+  arch,
+  platform,
+}) {
   return [
     "--runtime=electron",
     `--target=${electronVersion}`,
     `--arch=${arch}`,
-    `--platform=${NATIVE_MODULE_PLATFORM}`,
+    `--platform=${platform}`,
   ];
 }
 
@@ -234,6 +236,7 @@ async function preparePackagedNativeModules(appOutDir, options = {}) {
       prepareBetterSqlite3PackageDirectory(packageDirectory, {
         arch: options.arch,
         electronVersion: options.electronVersion,
+        platform: options.platform,
       }),
     ),
   );
@@ -266,6 +269,7 @@ async function afterPack(context) {
   await preparePackagedNativeModules(context.appOutDir, {
     arch: resolveArchName(context),
     electronVersion: resolveElectronVersion(),
+    platform: context.electronPlatformName ?? process.platform,
   });
 }
 
@@ -284,11 +288,19 @@ function parseStandaloneArguments(argv) {
       options.arch = archMatch[1];
       continue;
     }
+    const platformMatch = argument.match(/^--platform=(.+)$/);
+    if (platformMatch) {
+      options.platform = platformMatch[1];
+      continue;
+    }
     appOutDir = argument;
   }
 
   if (options.arch === undefined) {
     options.arch = process.arch;
+  }
+  if (options.platform === undefined) {
+    options.platform = process.platform;
   }
 
   return { appOutDir, options };
@@ -301,7 +313,7 @@ async function main() {
   if (appOutDir === undefined || appOutDir.length === 0) {
     throw new Error(
       "Usage: node apps/desktop/scripts/prepare-native-modules.cjs <appOutDir> " +
-        "[--electron-version=<version>] [--arch=<arch>]",
+        "[--electron-version=<version>] [--arch=<arch>] [--platform=<platform>]",
     );
   }
 
@@ -314,6 +326,7 @@ module.exports.prepareNodePtyPackageDirectory = prepareNodePtyPackageDirectory;
 module.exports.prepareBetterSqlite3PackageDirectory =
   prepareBetterSqlite3PackageDirectory;
 module.exports.preparePackagedNativeModules = preparePackagedNativeModules;
+module.exports.parseStandaloneArguments = parseStandaloneArguments;
 module.exports.resolveBetterSqlite3PrebuildArguments =
   resolveBetterSqlite3PrebuildArguments;
 

--- a/apps/desktop/scripts/run-electron-builder.mjs
+++ b/apps/desktop/scripts/run-electron-builder.mjs
@@ -179,6 +179,10 @@ export function resolveElectronBuilderConfig(baseConfig, env) {
   }
 
   config.mac = mac;
+  config.linux = {
+    ...config.linux,
+    icon: "assets/" + releaseConfig.iconFileName,
+  };
   config.appId = releaseConfig.appId;
   config.artifactName = releaseConfig.artifactName;
   config.productName = releaseConfig.applicationName;
@@ -264,7 +268,14 @@ async function main() {
     return;
   }
 
-  logSigningPlan(signingPlan);
+  if (
+    electronBuilderArgs.includes("--linux") &&
+    !electronBuilderArgs.includes("--mac")
+  ) {
+    console.log("macOS signing is not applicable for Linux-only builds.");
+  } else {
+    logSigningPlan(signingPlan);
+  }
   await mkdir(dirname(generatedConfigPath), { recursive: true });
   await writeGeneratedConfig(config);
   try {

--- a/apps/desktop/scripts/run-packaged-app.mjs
+++ b/apps/desktop/scripts/run-packaged-app.mjs
@@ -1,4 +1,3 @@
-import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
@@ -6,18 +5,12 @@ import {
   createDesktopReleaseConfig,
   resolveDesktopReleaseChannel,
 } from "./desktop-release-channel.mjs";
+import { resolvePackagedAppBinary } from "./packaged-app-paths.mjs";
 
 const packageRoot = process.cwd();
 const releaseDir = join(packageRoot, "release");
 const releaseConfig = createDesktopReleaseConfig(
   resolveDesktopReleaseChannel(process.env),
-);
-const appBundleName = `${releaseConfig.applicationName}.app`;
-const appBinaryRelativePath = join(
-  appBundleName,
-  "Contents",
-  "MacOS",
-  releaseConfig.applicationName,
 );
 
 function createElectronAppEnv(env) {
@@ -29,21 +22,19 @@ function createElectronAppEnv(env) {
   return childEnv;
 }
 
-async function resolvePackagedAppBinary() {
-  const entries = await readdir(releaseDir, { withFileTypes: true });
-  for (const entry of entries) {
-    if (!entry.isDirectory() || !entry.name.startsWith("mac")) {
-      continue;
-    }
-    return join(releaseDir, entry.name, appBinaryRelativePath);
-  }
-  throw new Error(`No packaged ${appBundleName} found under ${releaseDir}`);
-}
-
-const child = spawn(await resolvePackagedAppBinary(), [], {
-  env: createElectronAppEnv(process.env),
-  stdio: "inherit",
-});
+const child = spawn(
+  await resolvePackagedAppBinary({
+    executableName: "bb",
+    platform: process.platform,
+    productName: releaseConfig.applicationName,
+    releaseDir,
+  }),
+  [],
+  {
+    env: createElectronAppEnv(process.env),
+    stdio: "inherit",
+  },
+);
 
 process.once("SIGINT", () => {
   child.kill("SIGINT");

--- a/apps/desktop/scripts/smoke-packaged-app.mjs
+++ b/apps/desktop/scripts/smoke-packaged-app.mjs
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { createServer } from "node:http";
-import { access, readFile, readdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,19 +8,13 @@ import {
   createDesktopReleaseConfig,
   resolveDesktopReleaseChannel,
 } from "./desktop-release-channel.mjs";
+import { resolvePackagedAppBinary } from "./packaged-app-paths.mjs";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const desktopPackageRoot = resolve(scriptDirectory, "..");
 const releaseDir = join(desktopPackageRoot, "release");
 const releaseConfig = createDesktopReleaseConfig(
   resolveDesktopReleaseChannel(process.env),
-);
-const appBundleName = `${releaseConfig.applicationName}.app`;
-const appBinaryRelativePath = join(
-  appBundleName,
-  "Contents",
-  "MacOS",
-  releaseConfig.applicationName,
 );
 const startupTimeoutMs = 20_000;
 const exitTimeoutMs = 5_000;
@@ -71,7 +65,7 @@ function createDesktopVersionFeed(version) {
   };
 }
 
-function renderSmokePage(expectedDesktopVersion) {
+function renderSmokePage(expectedDesktopPlatform, expectedDesktopVersion) {
   return `<!doctype html>
 <meta charset="utf-8">
 <title>bb packaged desktop smoke</title>
@@ -87,9 +81,10 @@ function renderSmokePage(expectedDesktopVersion) {
       reason = "missing window.bbDesktop.getInfo";
     } else {
       const info = await window.bbDesktop.getInfo();
+      const expectedPlatform = ${JSON.stringify(expectedDesktopPlatform)};
       const expectedVersion = ${JSON.stringify(expectedDesktopVersion)};
       ok =
-        window.bbDesktop.platform === "macos" &&
+        window.bbDesktop.platform === expectedPlatform &&
         window.bbDesktop.version === expectedVersion &&
         info.version === expectedVersion;
       reason = ok ? "" : "unexpected desktop bridge info";
@@ -123,27 +118,11 @@ async function readDesktopPackageVersion() {
   return packageJson.version;
 }
 
-async function resolvePackagedAppBinary() {
-  const entries = await readdir(releaseDir, { withFileTypes: true });
-  const macOutputDirectories = entries
-    .filter((entry) => entry.isDirectory() && entry.name.startsWith("mac"))
-    .map((entry) => entry.name)
-    .sort();
-
-  for (const directory of macOutputDirectories) {
-    const appBinary = join(releaseDir, directory, appBinaryRelativePath);
-    try {
-      await access(appBinary);
-      return appBinary;
-    } catch {
-      continue;
-    }
-  }
-
-  throw new Error(`No packaged ${appBundleName} found under ${releaseDir}`);
-}
-
-async function startSmokeServer({ dataDir, expectedDesktopVersion }) {
+async function startSmokeServer({
+  dataDir,
+  expectedDesktopPlatform,
+  expectedDesktopVersion,
+}) {
   let resolvePreloadReady = () => {};
   const preloadReady = new Promise((resolvePromise) => {
     resolvePreloadReady = resolvePromise;
@@ -187,7 +166,10 @@ async function startSmokeServer({ dataDir, expectedDesktopVersion }) {
     }
 
     if (request.url === "/" || request.url === "/index.html") {
-      writeHtml(response, renderSmokePage(expectedDesktopVersion));
+      writeHtml(
+        response,
+        renderSmokePage(expectedDesktopPlatform, expectedDesktopVersion),
+      );
       return;
     }
 
@@ -354,17 +336,24 @@ async function stopPackagedApp(child) {
 }
 
 async function smokePackagedApp() {
-  if (process.platform !== "darwin") {
-    throw new Error("Packaged desktop smoke only runs on macOS.");
+  if (process.platform !== "darwin" && process.platform !== "linux") {
+    throw new Error("Packaged desktop smoke only runs on macOS or Linux.");
   }
 
   const desktopVersion = await readDesktopPackageVersion();
-  const appBinary = await resolvePackagedAppBinary();
+  const desktopPlatform = process.platform === "darwin" ? "macos" : "linux";
+  const appBinary = await resolvePackagedAppBinary({
+    executableName: "bb",
+    platform: process.platform,
+    productName: releaseConfig.applicationName,
+    releaseDir,
+  });
   const smokeRoot = await mkdtemp(join(tmpdir(), "bb-desktop-packaged-smoke-"));
   const dataDir = join(smokeRoot, "data");
   const userDataDir = join(smokeRoot, "user-data");
   const smokeServer = await startSmokeServer({
     dataDir,
+    expectedDesktopPlatform: desktopPlatform,
     expectedDesktopVersion: desktopVersion,
   });
   const serverUrl = `http://127.0.0.1:${smokeServer.port}`;

--- a/apps/desktop/src/desktop-auto-update.ts
+++ b/apps/desktop/src/desktop-auto-update.ts
@@ -61,6 +61,7 @@ export interface CreateDesktopAutoUpdateServiceArgs {
   forceDevUpdateConfig: boolean;
   logger?: DesktopAutoUpdateLogger;
   now?: () => number;
+  platform: BbDesktopInfo["platform"];
   updater: DesktopAutoUpdaterAdapter;
 }
 
@@ -90,13 +91,16 @@ export interface DesktopAutoUpdateService extends DesktopUpdateService {
   installUpdate(): void;
 }
 
-function createBaseInfo(currentVersion: string): BbDesktopInfo {
+function createBaseInfo(
+  currentVersion: string,
+  platform: BbDesktopInfo["platform"],
+): BbDesktopInfo {
   return {
     downloadState: "idle",
     lastCheckedAt: null,
     latestVersion: null,
     pendingVersion: null,
-    platform: "macos",
+    platform,
     updateAvailable: false,
     updateDownloaded: false,
     version: currentVersion,
@@ -200,7 +204,7 @@ export function createDesktopAutoUpdateService(
   const logger = args.logger ?? createDefaultLogger();
   const now = args.now ?? (() => Date.now());
 
-  let currentInfo = createBaseInfo(args.currentVersion);
+  let currentInfo = createBaseInfo(args.currentVersion, args.platform);
   let inflight: Promise<BbDesktopInfo> | null = null;
   let intervalHandle: DesktopUpdateIntervalHandle | null = null;
   let lastAttemptedAt: number | null = null;

--- a/apps/desktop/src/desktop-platform.ts
+++ b/apps/desktop/src/desktop-platform.ts
@@ -1,0 +1,7 @@
+import type { BbDesktopInfo } from "@bb/desktop-contract";
+
+export function resolveBbDesktopPlatform(
+  platform: NodeJS.Platform,
+): BbDesktopInfo["platform"] {
+  return platform === "darwin" ? "macos" : "linux";
+}

--- a/apps/desktop/src/desktop-shell-path.ts
+++ b/apps/desktop/src/desktop-shell-path.ts
@@ -26,12 +26,12 @@ export type SpawnLoginShellPath = (
   args: SpawnLoginShellPathArgs,
 ) => ShellPathSpawnResult;
 
-export type EnsurePackagedMacOsUserShellPathResult =
+export type EnsurePackagedUserShellPathResult =
   | ShellPathSkippedResult
   | ShellPathUpdatedResult
   | ShellPathUnchangedResult;
 
-export interface EnsurePackagedMacOsUserShellPathArgs {
+export interface EnsurePackagedUserShellPathArgs {
   env: NodeJS.ProcessEnv;
   isPackaged: boolean;
   logger: DesktopShellPathLogger;
@@ -41,7 +41,7 @@ export interface EnsurePackagedMacOsUserShellPathArgs {
 
 export interface ShellPathSkippedResult {
   kind: "skipped";
-  reason: "non-darwin" | "not-packaged";
+  reason: "not-packaged" | "unsupported-platform";
 }
 
 export interface ShellPathUnchangedResult {
@@ -72,7 +72,7 @@ function defaultSpawnLoginShellPath(
 }
 
 function warnShellPathFallback(
-  args: EnsurePackagedMacOsUserShellPathArgs,
+  args: EnsurePackagedUserShellPathArgs,
   message: string,
 ): void {
   args.logger.warn(
@@ -80,11 +80,11 @@ function warnShellPathFallback(
   );
 }
 
-export function ensurePackagedMacOsUserShellPath(
-  args: EnsurePackagedMacOsUserShellPathArgs,
-): EnsurePackagedMacOsUserShellPathResult {
-  if (args.platform !== "darwin") {
-    return { kind: "skipped", reason: "non-darwin" };
+export function ensurePackagedUserShellPath(
+  args: EnsurePackagedUserShellPathArgs,
+): EnsurePackagedUserShellPathResult {
+  if (args.platform !== "darwin" && args.platform !== "linux") {
+    return { kind: "skipped", reason: "unsupported-platform" };
   }
   if (!args.isPackaged) {
     return { kind: "skipped", reason: "not-packaged" };
@@ -94,7 +94,10 @@ export function ensurePackagedMacOsUserShellPath(
     args.spawnLoginShellPath ?? defaultSpawnLoginShellPath;
   const result = spawnLoginShellPath({
     args: ["-ilc", SHELL_PATH_COMMAND],
-    command: MACOS_LOGIN_SHELL,
+    command:
+      args.platform === "darwin"
+        ? MACOS_LOGIN_SHELL
+        : (args.env.SHELL ?? "/bin/bash"),
     timeoutMs: SHELL_PATH_TIMEOUT_MS,
   });
 

--- a/apps/desktop/src/desktop-update-check.ts
+++ b/apps/desktop/src/desktop-update-check.ts
@@ -22,6 +22,7 @@ export interface ParseDesktopVersionFeedArgs {
   checkedAt: string;
   currentVersion: string;
   payloadText: string;
+  platform: BbDesktopInfo["platform"];
 }
 
 interface ValidDesktopVersionFeedParseResult {
@@ -46,6 +47,7 @@ export interface CreateDesktopUpdateServiceArgs {
   fetchImpl?: typeof fetch;
   logger?: DesktopUpdateLogger;
   now?: () => number;
+  platform: BbDesktopInfo["platform"];
 }
 
 export interface DesktopUpdateService {
@@ -67,12 +69,15 @@ interface ApplyFailureArgs {
   message: string;
 }
 
-function createBaseInfo(currentVersion: string): BbDesktopInfo {
+function createBaseInfo(
+  currentVersion: string,
+  platform: BbDesktopInfo["platform"],
+): BbDesktopInfo {
   return {
     lastCheckedAt: null,
     latestVersion: null,
     pendingVersion: null,
-    platform: "macos",
+    platform,
     updateAvailable: false,
     updateDownloaded: false,
     version: currentVersion,
@@ -140,7 +145,7 @@ export function parseDesktopVersionFeed(
       lastCheckedAt: args.checkedAt,
       latestVersion: parsedFeed.data.version,
       pendingVersion: null,
-      platform: "macos",
+      platform: args.platform,
       updateAvailable: semver.gt(parsedFeedVersion, parsedCurrentVersion),
       updateDownloaded: false,
       version: args.currentVersion,
@@ -179,7 +184,7 @@ export function createDesktopUpdateService(
   const logger = args.logger ?? console;
   const now = args.now ?? (() => Date.now());
 
-  let currentInfo = createBaseInfo(args.currentVersion);
+  let currentInfo = createBaseInfo(args.currentVersion, args.platform);
   let inflight: Promise<BbDesktopInfo> | null = null;
   let intervalHandle: DesktopUpdateIntervalHandle | null = null;
   let lastAttemptedAt: number | null = null;
@@ -235,6 +240,7 @@ export function createDesktopUpdateService(
         checkedAt,
         currentVersion: args.currentVersion,
         payloadText,
+        platform: args.platform,
       });
       if (parsed.kind === "malformed") {
         return applyFailure({

--- a/apps/desktop/src/desktop-window-factory.ts
+++ b/apps/desktop/src/desktop-window-factory.ts
@@ -87,6 +87,7 @@ export interface CreateDesktopWindowFactoryArgs {
   createWindowStateKey(): WindowStateKey;
   displayWorkAreas: DisplayWorkArea[] | null;
   icon: DesktopWindowIcon;
+  isMac: boolean;
   isQuitting(): boolean;
   openExternalUrl(args: OpenExternalUrlArgs): void;
   preloadPath: string;
@@ -136,6 +137,7 @@ interface LoadUrlIntoWindowArgs {
 interface CreateWindowOptionsArgs {
   bounds: WindowBounds;
   icon: DesktopWindowIcon;
+  isMac: boolean;
   preloadPath: string;
 }
 
@@ -166,15 +168,19 @@ function createWindowOptions(
   args: CreateWindowOptionsArgs,
 ): BrowserWindowConstructorOptions {
   return {
-    frame: false,
+    ...(args.isMac
+      ? {
+          frame: false,
+          titleBarStyle: "hiddenInset" as const,
+          trafficLightPosition: MACOS_TRAFFIC_LIGHT_POSITION,
+        }
+      : {}),
     height: args.bounds.height,
     icon: args.icon,
     minHeight: MIN_WINDOW_HEIGHT,
     minWidth: MIN_WINDOW_WIDTH,
     show: false,
     title: "bb",
-    titleBarStyle: "hiddenInset",
-    trafficLightPosition: MACOS_TRAFFIC_LIGHT_POSITION,
     webPreferences: {
       contextIsolation: true,
       nodeIntegration: false,
@@ -231,6 +237,7 @@ export function createDesktopWindowFactory(
         createWindowOptions({
           bounds: restoredState.bounds,
           icon: args.icon,
+          isMac: args.isMac,
           preloadPath: args.preloadPath,
         }),
       );

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -145,7 +145,7 @@ import {
 } from "./desktop-browser-view.js";
 import { resolveDesktopBrowserAppCommand } from "./desktop-browser-shortcuts.js";
 import { registerDesktopBrowserIpc } from "./desktop-browser-main-ipc.js";
-import { ensurePackagedMacOsUserShellPath } from "./desktop-shell-path.js";
+import { ensurePackagedUserShellPath } from "./desktop-shell-path.js";
 import { clearPackagedSessionHttpCache } from "./desktop-session-cache.js";
 import { resolveDesktopReloadShortcut } from "./desktop-reload-shortcut.js";
 import {
@@ -1932,7 +1932,7 @@ async function initializeRuntime(args: InitializeRuntimeArgs): Promise<void> {
 }
 
 async function runDesktopApp(): Promise<void> {
-  ensurePackagedMacOsUserShellPath({
+  ensurePackagedUserShellPath({
     env: process.env,
     isPackaged: app.isPackaged,
     logger: createDesktopLogger(),

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -107,6 +107,7 @@ import {
   type DesktopWindowFactory,
 } from "./desktop-window-factory.js";
 import { registerDesktopContextMenu } from "./desktop-context-menu.js";
+import { resolveBbDesktopPlatform } from "./desktop-platform.js";
 import {
   createDesktopUpdateService,
   DESKTOP_UPDATE_FEED_URL,
@@ -648,6 +649,7 @@ function buildMenuServerItems(): Array<{
 function installCurrentApplicationMenu(): void {
   installApplicationMenu({
     accelerators: currentApplicationMenuAccelerators,
+    isMac: process.platform === "darwin",
     createNewWindow() {
       void createApplicationWindow({
         initialUrl: currentWindowUrl,
@@ -2121,21 +2123,29 @@ async function runDesktopApp(): Promise<void> {
     },
   });
 
+  const desktopPlatform = resolveBbDesktopPlatform(process.platform);
+  const desktopUpdatesSupported = process.platform === "darwin";
   desktopUpdateService = createDesktopUpdateService({
     currentVersion: desktopVersion,
-    enabled: app.isPackaged || process.env.BB_DESKTOP_VERSION_CHECK === "1",
+    enabled:
+      desktopUpdatesSupported &&
+      (app.isPackaged || process.env.BB_DESKTOP_VERSION_CHECK === "1"),
     feedUrl: desktopUpdateFeedUrl,
     logger: createDesktopLogger(),
+    platform: desktopPlatform,
   });
   desktopAutoUpdateService = createDesktopAutoUpdateService({
     currentVersion: desktopVersion,
-    enabled: shouldEnableDesktopAutoUpdate({
-      env: process.env,
-      isPackaged: app.isPackaged,
-    }),
+    enabled:
+      desktopUpdatesSupported &&
+      shouldEnableDesktopAutoUpdate({
+        env: process.env,
+        isPackaged: app.isPackaged,
+      }),
     forceDevUpdateConfig:
       !app.isPackaged && process.env.BB_DESKTOP_AUTO_UPDATE === "1",
     logger: createDesktopLogger(),
+    platform: desktopPlatform,
     updater: createElectronAutoUpdaterAdapter(autoUpdater),
   });
   desktopUpdateService.subscribe(() => {
@@ -2176,8 +2186,14 @@ async function runDesktopApp(): Promise<void> {
     },
   });
   registerDesktopBrowserIpc(desktopBrowserViewManager);
-  desktopUpdateService.start();
-  desktopAutoUpdateService.start();
+  if (desktopUpdatesSupported) {
+    desktopUpdateService.start();
+    desktopAutoUpdateService.start();
+  } else {
+    logger.info(
+      "Desktop update checks disabled on linux: no Linux update feed yet.",
+    );
+  }
 
   const browserWindowCreator: DesktopBrowserWindowCreator = {
     create(options) {
@@ -2194,6 +2210,7 @@ async function runDesktopApp(): Promise<void> {
     },
     displayWorkAreas: null,
     icon: nativeImage.createFromPath(iconPath),
+    isMac: process.platform === "darwin",
     isQuitting() {
       return quitting;
     },

--- a/apps/desktop/src/menu.ts
+++ b/apps/desktop/src/menu.ts
@@ -28,6 +28,7 @@ export interface ApplicationMenuServerItem {
 
 export interface InstallApplicationMenuArgs {
   accelerators: ApplicationMenuAccelerators;
+  isMac: boolean;
   openNewTab(): void;
   openNewThread(): void;
   openSettings(): void;
@@ -103,12 +104,16 @@ export function buildApplicationMenuTemplate(
           label: OPEN_SETTINGS_MENU_LABEL,
         },
         { type: "separator" },
-        { role: "services" },
-        { type: "separator" },
-        { role: "hide" },
-        { role: "hideOthers" },
-        { role: "unhide" },
-        { type: "separator" },
+        ...(args.isMac
+          ? [
+              { role: "services" as const },
+              { type: "separator" as const },
+              { role: "hide" as const },
+              { role: "hideOthers" as const },
+              { role: "unhide" as const },
+              { type: "separator" as const },
+            ]
+          : []),
         { role: "quit" },
       ],
     },
@@ -145,7 +150,9 @@ export function buildApplicationMenuTemplate(
             // These panels have no Electron BaseWindow, so use the native
             // close action.
             if (browserWindow === null) {
-              Menu.sendActionToFirstResponder("performClose:");
+              if (args.isMac) {
+                Menu.sendActionToFirstResponder("performClose:");
+              }
               return;
             }
             args.closeWindowOrSideTab(browserWindow);
@@ -186,7 +193,9 @@ export function buildApplicationMenuTemplate(
           },
         },
         {
-          accelerator: TOGGLE_DEVELOPER_TOOLS_ACCELERATOR,
+          accelerator: args.isMac
+            ? TOGGLE_DEVELOPER_TOOLS_ACCELERATOR
+            : "Control+Shift+I",
           label: TOGGLE_DEVELOPER_TOOLS_MENU_LABEL,
           role: "toggleDevTools",
         },
@@ -201,15 +210,19 @@ export function buildApplicationMenuTemplate(
       label: "Window",
       submenu: [
         { role: "minimize" },
-        { role: "zoom" },
+        ...(args.isMac ? [{ role: "zoom" as const }] : []),
         { type: "separator" },
         {
           id: SERVER_MENU_ITEM_ID,
           label: SERVER_MENU_LABEL,
           submenu: createServerMenuItems(args),
         },
-        { type: "separator" },
-        { role: "front" },
+        ...(args.isMac
+          ? [
+              { type: "separator" as const },
+              { role: "front" as const },
+            ]
+          : []),
       ],
     },
   ];

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -60,6 +60,7 @@ import {
   BB_DESKTOP_SPELLCHECK_GLOBAL_NAME,
   type BbDesktopSpellcheckApi,
 } from "./desktop-spellcheck-contract.js";
+import { resolveBbDesktopPlatform } from "./desktop-platform.js";
 
 function getDesktopVersion(version: string | undefined): string {
   if (version === undefined || version.length === 0) {
@@ -74,7 +75,7 @@ function createInitialDesktopInfo(): BbDesktopInfo {
     lastCheckedAt: null,
     latestVersion: null,
     pendingVersion: null,
-    platform: "macos",
+    platform: resolveBbDesktopPlatform(process.platform),
     updateAvailable: false,
     updateDownloaded: false,
     version: getDesktopVersion(process.env.BB_DESKTOP_VERSION),
@@ -280,7 +281,7 @@ const bbDesktopApi: BbDesktopApi = {
   get pendingVersion() {
     return currentInfo.pendingVersion;
   },
-  platform: "macos",
+  platform: resolveBbDesktopPlatform(process.platform),
   get updateAvailable() {
     return currentInfo.updateAvailable;
   },

--- a/apps/desktop/test/desktop-auto-update.test.ts
+++ b/apps/desktop/test/desktop-auto-update.test.ts
@@ -218,6 +218,7 @@ describe("desktop auto-update service", () => {
       forceDevUpdateConfig: false,
       logger: createLogger(messages),
       now: () => Date.parse(checkedAt),
+      platform: "macos",
       updater,
     });
 
@@ -237,6 +238,7 @@ describe("desktop auto-update service", () => {
       forceDevUpdateConfig: false,
       logger: createLogger(messages),
       now: () => Date.parse(checkedAt),
+      platform: "macos",
       updater,
     });
 
@@ -284,6 +286,7 @@ describe("desktop auto-update service", () => {
       forceDevUpdateConfig: false,
       logger: createLogger(createLoggerMessages()),
       now: () => Date.parse(checkedAt),
+      platform: "macos",
       updater,
     });
 
@@ -311,6 +314,7 @@ describe("desktop auto-update service", () => {
       forceDevUpdateConfig: false,
       logger: createLogger(messages),
       now: () => Date.parse(checkedAt),
+      platform: "macos",
       updater,
     });
 
@@ -344,6 +348,7 @@ describe("desktop auto-update service", () => {
       forceDevUpdateConfig: false,
       logger: createLogger(createLoggerMessages()),
       now: () => Date.parse(checkedAt),
+      platform: "macos",
       updater,
     });
 
@@ -374,6 +379,7 @@ describe("desktop auto-update service", () => {
       forceDevUpdateConfig: false,
       logger: createLogger(createLoggerMessages()),
       now: () => Date.parse(checkedAt),
+      platform: "macos",
       updater,
     });
 

--- a/apps/desktop/test/desktop-shell-path.test.ts
+++ b/apps/desktop/test/desktop-shell-path.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  ensurePackagedMacOsUserShellPath,
+  ensurePackagedUserShellPath,
   type DesktopShellPathLogger,
   type ShellPathSpawnResult,
   type SpawnLoginShellPath,
@@ -77,7 +77,7 @@ describe("desktop shell PATH loading", () => {
     });
     const warningLogger = createWarningLogger();
 
-    const result = ensurePackagedMacOsUserShellPath({
+    const result = ensurePackagedUserShellPath({
       env,
       isPackaged: true,
       logger: warningLogger.logger,
@@ -101,7 +101,7 @@ describe("desktop shell PATH loading", () => {
     const env: NodeJS.ProcessEnv = { PATH: "/opt/homebrew/bin:/usr/bin:/bin" };
     const warningLogger = createWarningLogger();
 
-    const result = ensurePackagedMacOsUserShellPath({
+    const result = ensurePackagedUserShellPath({
       env,
       isPackaged: false,
       logger: warningLogger.logger,
@@ -121,7 +121,7 @@ describe("desktop shell PATH loading", () => {
     });
     const warningLogger = createWarningLogger();
 
-    const result = ensurePackagedMacOsUserShellPath({
+    const result = ensurePackagedUserShellPath({
       env,
       isPackaged: true,
       logger: warningLogger.logger,
@@ -146,7 +146,7 @@ describe("desktop shell PATH loading", () => {
     });
     const warningLogger = createWarningLogger();
 
-    const result = ensurePackagedMacOsUserShellPath({
+    const result = ensurePackagedUserShellPath({
       env,
       isPackaged: true,
       logger: warningLogger.logger,
@@ -157,5 +157,69 @@ describe("desktop shell PATH loading", () => {
     expect(result).toEqual({ kind: "unchanged", reason: "shell-error" });
     expect(env.PATH).toBe("/usr/bin:/bin");
     expect(warningLogger.warnings[0]).toContain("ETIMEDOUT");
+  });
+
+  it("uses the configured Linux login shell", () => {
+    const env: NodeJS.ProcessEnv = {
+      PATH: "/usr/bin:/bin",
+      SHELL: "/usr/bin/fish",
+    };
+    const shellPath = "/home/sawyer/.local/bin:/usr/bin:/bin";
+    const fakeSpawn = createFakeSpawn({
+      result: createSpawnResult({ stdout: shellPath }),
+    });
+
+    const result = ensurePackagedUserShellPath({
+      env,
+      isPackaged: true,
+      logger: createWarningLogger().logger,
+      platform: "linux",
+      spawnLoginShellPath: fakeSpawn.spawn,
+    });
+
+    expect(result).toEqual({ kind: "updated", path: shellPath });
+    expect(env.PATH).toBe(shellPath);
+    expect(fakeSpawn.calls).toEqual([
+      {
+        args: ["-ilc", 'printf "%s" "$PATH"'],
+        command: "/usr/bin/fish",
+        timeoutMs: 2_000,
+      },
+    ]);
+  });
+
+  it("falls back to bash when Linux SHELL is unset", () => {
+    const env: NodeJS.ProcessEnv = { PATH: "/usr/bin:/bin" };
+    const fakeSpawn = createFakeSpawn({
+      result: createSpawnResult({ stdout: "/home/sawyer/bin:/usr/bin:/bin" }),
+    });
+
+    ensurePackagedUserShellPath({
+      env,
+      isPackaged: true,
+      logger: createWarningLogger().logger,
+      platform: "linux",
+      spawnLoginShellPath: fakeSpawn.spawn,
+    });
+
+    expect(fakeSpawn.calls[0]?.command).toBe("/bin/bash");
+  });
+
+  it("skips unsupported platforms", () => {
+    const env: NodeJS.ProcessEnv = { PATH: "C:\\Windows\\System32" };
+
+    const result = ensurePackagedUserShellPath({
+      env,
+      isPackaged: true,
+      logger: createWarningLogger().logger,
+      platform: "win32",
+      spawnLoginShellPath: failIfSpawned(),
+    });
+
+    expect(result).toEqual({
+      kind: "skipped",
+      reason: "unsupported-platform",
+    });
+    expect(env.PATH).toBe("C:\\Windows\\System32");
   });
 });

--- a/apps/desktop/test/desktop-update-check.test.ts
+++ b/apps/desktop/test/desktop-update-check.test.ts
@@ -44,6 +44,7 @@ describe("desktop update feed parsing", () => {
       checkedAt,
       currentVersion: "0.0.1",
       payloadText: JSON.stringify(createFeed("0.0.2")),
+      platform: "macos",
     });
 
     expect(result.kind).toBe("valid");
@@ -86,6 +87,7 @@ describe("desktop update feed parsing", () => {
       checkedAt,
       currentVersion: "0.0.1",
       payloadText: JSON.stringify(payload),
+      platform: "macos",
     });
 
     expect(result.kind).toBe("malformed");
@@ -96,6 +98,7 @@ describe("desktop update feed parsing", () => {
       checkedAt,
       currentVersion: "0.0.1",
       payloadText: "{",
+      platform: "macos",
     });
 
     expect(result.kind).toBe("malformed");
@@ -106,6 +109,7 @@ describe("desktop update feed parsing", () => {
       checkedAt,
       currentVersion: "0.0.2",
       payloadText: JSON.stringify(createFeed("0.0.1")),
+      platform: "macos",
     });
 
     expect(result.kind).toBe("valid");
@@ -143,6 +147,7 @@ describe("desktop update service", () => {
       fetchImpl,
       logger: { warn() {} },
       now: () => nowMs,
+      platform: "macos",
     });
 
     const successfulInfo = await service.checkForUpdates();
@@ -201,6 +206,7 @@ describe("desktop update service", () => {
         fetchImpl,
         logger: { warn() {} },
         now: () => nowMs,
+        platform: "macos",
       });
 
       await service.checkForUpdates();
@@ -238,6 +244,7 @@ describe("desktop update service", () => {
       fetchImpl,
       logger: { warn() {} },
       now: () => nowMs,
+      platform: "macos",
     });
 
     const firstInfo = await service.checkAfterActive();
@@ -254,5 +261,16 @@ describe("desktop update service", () => {
     await service.checkAfterActive();
 
     expect(fetchCount).toBe(2);
+  });
+
+  it("reports the injected linux platform in its base info", () => {
+    const service = createDesktopUpdateService({
+      currentVersion: "0.0.1",
+      enabled: false,
+      feedUrl: "https://example.test/desktop-version.json",
+      platform: "linux",
+    });
+
+    expect(service.getInfo().platform).toBe("linux");
   });
 });

--- a/apps/desktop/test/desktop-window-factory.test.ts
+++ b/apps/desktop/test/desktop-window-factory.test.ts
@@ -250,6 +250,7 @@ describe("desktop window factory", () => {
         },
       ],
       icon: undefined,
+      isMac: true,
       isQuitting() {
         return false;
       },
@@ -344,6 +345,7 @@ describe("desktop window factory", () => {
         },
       ],
       icon: undefined,
+      isMac: true,
       isQuitting() {
         return false;
       },
@@ -401,6 +403,7 @@ describe("desktop window factory", () => {
         },
       ],
       icon: undefined,
+      isMac: true,
       isQuitting() {
         return false;
       },
@@ -455,6 +458,7 @@ describe("desktop window factory", () => {
         },
       ],
       icon: undefined,
+      isMac: true,
       isQuitting() {
         return false;
       },
@@ -511,6 +515,7 @@ describe("desktop window factory", () => {
         },
       ],
       icon: undefined,
+      isMac: true,
       isQuitting() {
         return false;
       },
@@ -570,6 +575,7 @@ describe("desktop window factory", () => {
         },
       ],
       icon: undefined,
+      isMac: true,
       isQuitting() {
         return false;
       },
@@ -601,5 +607,47 @@ describe("desktop window factory", () => {
     expect(secondWindow.webContents.sentMessages).toEqual([
       { channel: "bb:test", payload: { action: "new-tab" } },
     ]);
+  });
+
+  it("uses the native window frame on Linux", async () => {
+    const tempDir = await createTempDir();
+    const createdWindows: FakeDesktopWindow[] = [];
+    const browserWindowCreator: DesktopBrowserWindowCreator = {
+      create(options) {
+        const browserWindow = new FakeDesktopWindow({ options });
+        createdWindows.push(browserWindow);
+        return browserWindow;
+      },
+    };
+    const factory = createDesktopWindowFactory({
+      browserWindowCreator,
+      createWindowStateKey() {
+        return "linux-window";
+      },
+      displayWorkAreas: [
+        {
+          height: 900,
+          width: 1440,
+          x: 0,
+          y: 0,
+        },
+      ],
+      icon: undefined,
+      isMac: false,
+      isQuitting() {
+        return false;
+      },
+      openExternalUrl() {},
+      preloadPath: "/tmp/preload.cjs",
+      userDataPath: tempDir.path,
+    });
+
+    await factory.createWindow({ initialUrl: null, stateKey: null });
+
+    expect(createdWindows[0]?.options).not.toHaveProperty("frame");
+    expect(createdWindows[0]?.options).not.toHaveProperty("titleBarStyle");
+    expect(createdWindows[0]?.options).not.toHaveProperty(
+      "trafficLightPosition",
+    );
   });
 });

--- a/apps/desktop/test/electron-builder-config.test.ts
+++ b/apps/desktop/test/electron-builder-config.test.ts
@@ -9,6 +9,7 @@ import {
   stat,
   writeFile,
 } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { z } from "zod";
@@ -19,6 +20,22 @@ import {
 } from "../src/desktop-update-provider.js";
 
 const desktopPackageRoot = process.cwd();
+const require = createRequire(resolve(desktopPackageRoot, "package.json"));
+const nativeModulesScript: {
+  parseStandaloneArguments(argv: string[]): {
+    appOutDir: string | undefined;
+    options: {
+      arch: string;
+      electronVersion?: string;
+      platform: string;
+    };
+  };
+  resolveBetterSqlite3PrebuildArguments(options: {
+    arch: string;
+    electronVersion: string;
+    platform: string;
+  }): string[];
+} = require("./scripts/prepare-native-modules.cjs");
 
 const macConfigSchema = z
   .object({
@@ -29,6 +46,22 @@ const macConfigSchema = z
     icon: z.string().min(1),
     identity: z.string().nullable().optional(),
     notarize: z.boolean(),
+  })
+  .passthrough();
+
+const linuxConfigSchema = z
+  .object({
+    category: z.literal("Development"),
+    executableName: z.literal("bb"),
+    icon: z.string().min(1),
+    target: z.tuple([
+      z
+        .object({
+          arch: z.tuple([z.literal("x64")]),
+          target: z.literal("AppImage"),
+        })
+        .passthrough(),
+    ]),
   })
   .passthrough();
 
@@ -55,6 +88,7 @@ const electronBuilderConfigSchema = z
       })
       .passthrough(),
     files: z.array(electronBuilderFilePatternSchema),
+    linux: linuxConfigSchema,
     mac: macConfigSchema,
     npmRebuild: z.literal(false),
     appId: z.string().min(1),
@@ -270,6 +304,47 @@ describe("electron-builder signing config", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("passes the standalone platform through to better-sqlite3 prebuild-install", () => {
+    const { options } = nativeModulesScript.parseStandaloneArguments([
+      "/tmp/linux-unpacked",
+      "--electron-version=41.7.0",
+      "--arch=x64",
+      "--platform=linux",
+    ]);
+    const electronVersion = options.electronVersion;
+    if (electronVersion === undefined) {
+      throw new Error("Expected the standalone Electron version argument");
+    }
+
+    expect(
+      nativeModulesScript.resolveBetterSqlite3PrebuildArguments({
+        arch: options.arch,
+        electronVersion,
+        platform: options.platform,
+      }),
+    ).toEqual([
+      "--runtime=electron",
+      "--target=41.7.0",
+      "--arch=x64",
+      "--platform=linux",
+    ]);
+  });
+
+  it("preserves the macOS better-sqlite3 prebuild-install arguments", () => {
+    expect(
+      nativeModulesScript.resolveBetterSqlite3PrebuildArguments({
+        arch: "arm64",
+        electronVersion: "41.7.0",
+        platform: "darwin",
+      }),
+    ).toEqual([
+      "--runtime=electron",
+      "--target=41.7.0",
+      "--arch=arm64",
+      "--platform=darwin",
+    ]);
+  });
+
   it("installs native plugin build packages for arm64 and x64", async () => {
     const packageJsonText = await readFile(
       resolve(desktopPackageRoot, "..", "..", "package.json"),
@@ -403,6 +478,23 @@ describe("electron-builder signing config", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("packages a Linux AppImage for x64", async () => {
+    const configText = await readFile(
+      resolve(desktopPackageRoot, "electron-builder.config.json"),
+      "utf8",
+    );
+    const config = electronBuilderConfigSchema.parse(JSON.parse(configText));
+
+    expect(config.linux).toMatchObject({
+      category: "Development",
+      executableName: "bb",
+      target: [{ arch: ["x64"], target: "AppImage" }],
+    });
+    await expect(
+      access(resolve(desktopPackageRoot, config.linux.icon)),
+    ).resolves.toBeUndefined();
+  });
+
   it("grants audio input to the signed app and helper processes", async () => {
     const configText = await readFile(
       resolve(desktopPackageRoot, "electron-builder.config.json"),
@@ -446,6 +538,7 @@ describe("electron-builder signing config", () => {
     expect(config.appId).toBe("dev.bb.desktop.nightly");
     expect(config.productName).toBe("bb Nightly");
     expect(config.artifactName).toBe("bb-nightly-${version}-${arch}.${ext}");
+    expect(config.linux.icon).toBe("assets/icon-nightly.png");
     expect(config.mac.icon).toBe("assets/icon-nightly.icns");
     await expect(
       access(resolve(desktopPackageRoot, config.mac.icon)),

--- a/apps/desktop/test/menu.test.ts
+++ b/apps/desktop/test/menu.test.ts
@@ -28,6 +28,7 @@ function menuArgs(
     },
     closeWindowOrSideTab: () => {},
     createNewWindow: () => {},
+    isMac: true,
     openNewTab: () => {},
     openNewThread: () => {},
     openServerDaemonLogs: () => {},
@@ -130,5 +131,39 @@ describe("application menu", () => {
     expect(selectServer).toHaveBeenCalledWith("custom");
     serverSubmenu[3]?.click?.({} as never, undefined, {} as never);
     expect(setServerUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it("builds a native Linux menu with the Linux DevTools accelerator", () => {
+    vi.mocked(Menu.sendActionToFirstResponder).mockClear();
+    const template = buildApplicationMenuTemplate(
+      menuArgs(() => {}, { isMac: false }),
+    );
+    const appMenu = template[0]?.submenu as MenuItemConstructorOptions[];
+    const windowMenu = template.find((item) => item.label === "Window");
+    const windowSubmenu =
+      windowMenu?.submenu as MenuItemConstructorOptions[];
+    const viewMenu = template.find((item) => item.label === "View");
+    const viewSubmenu = viewMenu?.submenu as MenuItemConstructorOptions[];
+    const fileMenu = template.find((item) => item.label === "File");
+    const fileSubmenu = fileMenu?.submenu as MenuItemConstructorOptions[];
+    const closeWindow = fileSubmenu.find(
+      (item) => item.label === "Close Window",
+    );
+
+    expect(appMenu.map((item) => item.role).filter(Boolean)).toEqual([
+      "about",
+      "quit",
+    ]);
+    expect(windowSubmenu.map((item) => item.role).filter(Boolean)).toEqual([
+      "minimize",
+    ]);
+    expect(windowSubmenu.some((item) => item.label === "Server")).toBe(true);
+    expect(
+      viewSubmenu.find((item) => item.label === "Toggle Developer Tools")
+        ?.accelerator,
+    ).toBe("Control+Shift+I");
+
+    closeWindow?.click?.({} as never, null as never, {} as never);
+    expect(Menu.sendActionToFirstResponder).not.toHaveBeenCalled();
   });
 });

--- a/docs/repository-overview.md
+++ b/docs/repository-overview.md
@@ -5,7 +5,7 @@ This monorepo contains the packaged app plus the runtime services it bundles:
 | Package or app                                                      | Role                                                                                                |
 | ------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | [`packages/bb-app`](../packages/bb-app)                             | Published npm package, `npx bb-app@latest` launcher, bundled `bb` CLI entry, and public SDK export. |
-| [`apps/desktop`](../apps/desktop)                                   | macOS Electron shell that supervises the packaged runtime and loads the bb web UI.                  |
+| [`apps/desktop`](../apps/desktop)                                   | macOS/Linux Electron shell that supervises the packaged runtime and loads the bb web UI.            |
 | [`apps/app`](../apps/app)                                           | Web UI for inspecting projects, threads, environments, and running work.                            |
 | [`apps/server`](../apps/server)                                     | HTTP API, WebSocket notifications, state management, and server-owned product policy.               |
 | [`apps/host-daemon`](../apps/host-daemon)                           | Host-local runtime that provisions workspaces and runs provider processes.                          |

--- a/packages/desktop-contract/src/info.ts
+++ b/packages/desktop-contract/src/info.ts
@@ -24,7 +24,7 @@ export const bbDesktopInfoSchema = z.object({
   lastCheckedAt: isoUtcDateTimeSchema.nullable(),
   latestVersion: z.string().min(1).nullable(),
   pendingVersion: z.string().min(1).nullable(),
-  platform: z.literal("macos"),
+  platform: z.enum(["macos", "linux"]),
   updateAvailable: z.boolean(),
   updateDownloaded: z.boolean(),
   version: z.string().min(1),

--- a/packages/desktop-contract/test/info.test.ts
+++ b/packages/desktop-contract/test/info.test.ts
@@ -30,4 +30,22 @@ describe("bbDesktopInfoSchema", () => {
       }).success,
     ).toBe(false);
   });
+
+  it("accepts linux", () => {
+    expect(
+      bbDesktopInfoSchema.safeParse({
+        ...baseInfo,
+        platform: "linux",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects win32", () => {
+    expect(
+      bbDesktopInfoSchema.safeParse({
+        ...baseInfo,
+        platform: "win32",
+      }).success,
+    ).toBe(false);
+  });
 });

--- a/turbo.json
+++ b/turbo.json
@@ -177,6 +177,19 @@
         "*"
       ]
     },
+    "@bb/desktop#desktop:build:linux": {
+      "dependsOn": [
+        "bb-app#build",
+        "@bb/desktop#build"
+      ],
+      "cache": false,
+      "outputs": [
+        "release/**"
+      ],
+      "passThroughEnv": [
+        "*"
+      ]
+    },
     "@bb/desktop#smoke:packaged": {
       "cache": false,
       "outputs": [],


### PR DESCRIPTION
## Summary

Adds a **Linux x64 AppImage** build target to `apps/desktop`. Linux is already a first-class bb host — `bb-app` ships `"os": ["darwin", "linux"]`, `docs/platform-support.md` lists the Linux persistent host as supported, and Ubuntu is the required CI gate — but the desktop shell was macOS-arm64-only. This closes that gap with a deliberately minimal, additive change: packaging only, no CI or release-infrastructure changes.

Per CONTRIBUTING I know features normally start as an issue — happy to convert this into one and treat the branch as the linked prototype if you prefer; opening it as a PR so the concrete diff is easy to evaluate.

## Work done

- **electron-builder**: top-level `linux` block only (AppImage, x64, `executableName: "bb"` — the Linux default derives the binary name from the sanitized package name, yielding `@bbdesktop`). Existing `mac`/`dmg`/`publish`/`npmRebuild`/`files` config untouched; the config gatekeeper test keeps all existing assertions and gains Linux ones.
- **Scripts**: `desktop:build:linux` (`--publish never`), `dist:linux`, `package:linux`, `start:linux`, mirroring the mac script names; a `@bb/desktop#desktop:build:linux` turbo task mirroring `desktop:build`.
- **Contract**: `@bb/desktop-contract` `platform` widens `z.literal("macos")` → `z.enum(["macos", "linux"])` (`info.ts` only; the version-feed schema is untouched since no Linux feed exists).
- **Shell**: `platform`/`isMac` are injected into pure modules as required args (matching how `@bb/desktop` unit tests already run on ubuntu-latest); only `main.ts`/`preload.ts` read `process.platform`. Linux windows use the native frame (the renderer already falls back to non-macOS chrome); the menu drops darwin-only roles; DevTools is `Control+Shift+I`.
- **Updates**: both the electron-updater path and the JSON version-feed check are gated to darwin and log one line on Linux ("no Linux update feed yet"). Nothing Linux-related is published.
- **Native modules**: the `afterPack` hook is platform-parameterized; better-sqlite3 fetches the `electron-v145-linux-x64` prebuild (Electron stays pinned at 41.7.0); node-pty compiles at install time via node-gyp (N-API, so ABI-safe under Electron).
- **Login-shell PATH** (separate commit, droppable if unwanted): `ensurePackagedMacOsUserShellPath` → `ensurePackagedUserShellPath`; Linux uses `$SHELL` (fallback `/bin/bash`) `-ilc`, so AppImages launched from a desktop entry get the user's real PATH.
- **Smoke**: `smoke:packaged` is now cross-platform (darwin|linux) via a shared packaged-binary path resolver.
- **Docs**: Linux section in `apps/desktop/README.md`; `docs/repository-overview.md` one-liner.

### Testing

- `turbo run typecheck test` green for `@bb/desktop` (241 tests) and `@bb/desktop-contract` (17 tests); the first commit is also independently green so the PATH commit can be dropped cleanly.
- Built and ran on Arch-family Linux (x64, Wayland): `package:linux` → packaged smoke test passes (bridge reports `platform: "linux"`); `dist:linux` → `bb-0.37.0-x86_64.AppImage` launches with the full stack healthy (server, host-daemon, parcel-watcher child under Electron-as-Node, better-sqlite3 Electron prebuild, node-pty).
- Repo-wide test sweep: the only failing packages fail identically on pristine `main` on that machine (zlib golden-byte off-by-ones and timing-sensitive UI tests) — environmental, not introduced here.

## Work still missing (intentionally deferred — your calls)

1. **Linux auto-update feed** — publishing `latest-linux.yml` + AppImage to `desktop-latest` (the release job force-resets all assets, so a Linux artifact needs coordination there).
2. **CI** — a Linux job in `build-desktop.yml` (ubuntu-latest, no signing). A *published* AppImage should also build against an older glibc baseline than a dev machine.
3. **Web download surface** — a Linux entry alongside the macOS download route/CTA.
4. **arm64** and the **Linux nightly channel** (nightly's `bb Nightly` productName needs an executableName decision).
5. AppImage desktop integration polish (e.g. AppStream metadata) if you want launcher-first UX.

> AGENT GENERATED: by Claude Fable 5 (orchestrating a GPT-5.6 worker), reviewed and tested by @salemsayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyDzQ6R3oZGzpii6UA5vAW
