### PR TITLE
Allow Tasks dispatch without requiring Git

### DIFF
--- a/apps/app/src/components/plugin/PluginNewThreadComposer.tsx
+++ b/apps/app/src/components/plugin/PluginNewThreadComposer.tsx
@@ -50,8 +50,7 @@ import { useScopedBranchSelection } from "@/views/root-compose-branch-selection"
 import { resolveRootComposeThreadEnvironment } from "@/views/root-compose-thread-environment";
 import {
   buildReuseThreadOptions,
-  isProjectSourceWorktreeUnavailable,
-  PROJECT_SOURCE_WORKTREE_DISABLED_REASON,
+  resolveProjectSourceWorktreeDisabledReason,
   resolveRootComposeEffectiveEnvironmentValue,
   resolveRootComposeProjectRouting,
   resolveRootComposeProviderRouting,
@@ -410,9 +409,10 @@ export function PluginNewThreadComposer({
       selectedBranch: selectedBranch?.name ?? "",
     },
   );
-  const projectSourceWorktreeUnavailable = isProjectSourceWorktreeUnavailable(
-    branchesQuery.data,
-  );
+  const projectSourceWorktreeDisabledReason =
+    resolveProjectSourceWorktreeDisabledReason(branchesQuery.data);
+  const projectSourceWorktreeUnavailable =
+    projectSourceWorktreeDisabledReason !== null;
   const requestsManagedWorktree =
     isHostMode && parsedEnvironment.mode === "worktree";
   const managedWorktreeAvailabilityPending =
@@ -813,9 +813,7 @@ export function PluginNewThreadComposer({
             onChange: setEnvironmentSelectionValue,
             sources: projectSources,
             reuseDisabled: reuseThreadOptions.length === 0,
-            worktreeDisabledReason: projectSourceWorktreeUnavailable
-              ? PROJECT_SOURCE_WORKTREE_DISABLED_REASON
-              : null,
+            worktreeDisabledReason: projectSourceWorktreeDisabledReason,
           },
           branch: {
             value:

--- a/apps/app/src/views/RootComposeView.test.ts
+++ b/apps/app/src/views/RootComposeView.test.ts
@@ -35,7 +35,7 @@ import {
   shouldNavigateAfterThreadCreate,
 } from "./RootComposeView";
 import {
-  isProjectSourceWorktreeUnavailable,
+  resolveProjectSourceWorktreeDisabledReason,
   resolveComposeHostId,
   resolveRootComposeEffectiveEnvironmentValue,
   resolveRootComposeProjectRouting,
@@ -702,14 +702,16 @@ describe("shouldNavigateAfterThreadCreate", () => {
   });
 });
 
-describe("isProjectSourceWorktreeUnavailable", () => {
-  it("treats unknown checkout metadata as unavailable for worktree creation", () => {
-    expect(isProjectSourceWorktreeUnavailable(undefined)).toBe(false);
+describe("resolveProjectSourceWorktreeDisabledReason", () => {
+  it("explains why non-git and commitless sources cannot create worktrees", () => {
+    expect(resolveProjectSourceWorktreeDisabledReason(undefined)).toBeNull();
     expect(
-      isProjectSourceWorktreeUnavailable(makeProjectBranchesResponse({})),
-    ).toBe(false);
+      resolveProjectSourceWorktreeDisabledReason(
+        makeProjectBranchesResponse({}),
+      ),
+    ).toBeNull();
     expect(
-      isProjectSourceWorktreeUnavailable(
+      resolveProjectSourceWorktreeDisabledReason(
         makeProjectBranchesResponse({
           checkout: {
             kind: "unknown",
@@ -721,7 +723,20 @@ describe("isProjectSourceWorktreeUnavailable", () => {
           originDefaultBranch: null,
         }),
       ),
-    ).toBe(true);
+    ).toBe("New worktrees require a Git repository with at least one commit");
+    expect(
+      resolveProjectSourceWorktreeDisabledReason(
+        makeProjectBranchesResponse({
+          checkout: { kind: "unborn", branchName: "main" },
+          defaultBranch: null,
+          defaultBranchRelation: null,
+          defaultWorktreeBaseBranch: null,
+          originDefaultBranch: null,
+        }),
+      ),
+    ).toBe(
+      "Project source has no commits. Create an initial commit before creating a worktree",
+    );
   });
 });
 

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -192,8 +192,7 @@ import {
 import { useScopedBranchSelection } from "./root-compose-branch-selection";
 import {
   buildReuseThreadOptions,
-  isProjectSourceWorktreeUnavailable,
-  PROJECT_SOURCE_WORKTREE_DISABLED_REASON,
+  resolveProjectSourceWorktreeDisabledReason,
   resolveComposeHostId,
   resolveRootComposeEffectiveEnvironmentValue,
   resolveRootComposeProjectRouting,
@@ -1323,9 +1322,10 @@ export function RootComposeView() {
     },
   );
   const activeBranchesQuery = hostBranchesQuery;
-  const projectSourceWorktreeUnavailable = isProjectSourceWorktreeUnavailable(
-    activeBranchesQuery.data,
-  );
+  const projectSourceWorktreeDisabledReason =
+    resolveProjectSourceWorktreeDisabledReason(activeBranchesQuery.data);
+  const projectSourceWorktreeUnavailable =
+    projectSourceWorktreeDisabledReason !== null;
   const selectedEnvironmentRequestsManagedWorktree =
     parsedEnvironment?.type === "host" && parsedEnvironment.mode === "worktree";
   const managedWorktreeAvailabilityPending =
@@ -3207,9 +3207,7 @@ export function RootComposeView() {
       onChange: handleEnvironmentSelectionValueChange,
       sources: projectSources,
       reuseDisabled: reuseThreadOptions.length === 0,
-      worktreeDisabledReason: projectSourceWorktreeUnavailable
-        ? PROJECT_SOURCE_WORKTREE_DISABLED_REASON
-        : null,
+      worktreeDisabledReason: projectSourceWorktreeDisabledReason,
       disabled: isForkDraft,
       ...(isProjectless
         ? {}
@@ -3221,7 +3219,7 @@ export function RootComposeView() {
       isProjectless,
       handleEnvironmentSelectionValueChange,
       handleRequestMachineSetup,
-      projectSourceWorktreeUnavailable,
+      projectSourceWorktreeDisabledReason,
       projectSources,
       reuseThreadOptions.length,
     ],

--- a/apps/app/src/views/root-compose-environment-selection.ts
+++ b/apps/app/src/views/root-compose-environment-selection.ts
@@ -34,8 +34,10 @@ export interface ResolveRootComposeEffectiveEnvironmentValueArgs {
   reuseThreadOptionsLoading: boolean;
 }
 
-export const PROJECT_SOURCE_WORKTREE_DISABLED_REASON =
-  "Project source is not a git repository";
+const PROJECT_SOURCE_NOT_GIT_WORKTREE_DISABLED_REASON =
+  "New worktrees require a Git repository with at least one commit";
+const PROJECT_SOURCE_NO_COMMITS_WORKTREE_DISABLED_REASON =
+  "Project source has no commits. Create an initial commit before creating a worktree";
 
 function isWorktreeWithEnv(thread: ThreadListEntry): boolean {
   if (thread.environmentId === null) return false;
@@ -107,10 +109,19 @@ export function buildReuseThreadOptions(
   return options;
 }
 
-export function isProjectSourceWorktreeUnavailable(
+export function resolveProjectSourceWorktreeDisabledReason(
   data: ProjectBranchesResponse | undefined,
-): boolean {
-  return data?.checkout.kind === "unknown";
+): string | null {
+  switch (data?.checkout.kind) {
+    case "unknown":
+      return PROJECT_SOURCE_NOT_GIT_WORKTREE_DISABLED_REASON;
+    case "unborn":
+      return PROJECT_SOURCE_NO_COMMITS_WORKTREE_DISABLED_REASON;
+    case "branch":
+    case "detached":
+    case undefined:
+      return null;
+  }
 }
 
 export function resolveRootComposeEffectiveEnvironmentValue({

--- a/apps/server/src/services/threads/thread-create.ts
+++ b/apps/server/src/services/threads/thread-create.ts
@@ -617,7 +617,7 @@ export async function createThreadFromRequest(
     ...rawRequestInput,
     environment:
       rawRequestInput.environment.type === "project-default"
-        ? resolveProjectDefaultThreadEnvironment(deps, {
+        ? await resolveProjectDefaultThreadEnvironment(deps, {
             projectId: rawRequestInput.projectId,
           })
         : rawRequestInput.environment,

--- a/apps/server/src/services/threads/thread-default-policy.ts
+++ b/apps/server/src/services/threads/thread-default-policy.ts
@@ -13,8 +13,12 @@ import type {
 } from "@bb/domain";
 import { PERSONAL_PROJECT_ID } from "@bb/domain";
 import type { EnvironmentArgs } from "@bb/server-contract";
-import type { AppDeps } from "../../types.js";
+import { COMMAND_TIMEOUT_MS } from "../../constants.js";
+import type { WorkSessionDeps } from "../../types.js";
+import { callHostRetryableOnlineRpc } from "../hosts/online-rpc.js";
 import { requireConnectedPrimaryHostId } from "../hosts/primary-host.js";
+import { resolveProjectWorkspaceTarget } from "../projects/project-workspace.js";
+import { resolveDefaultWorktreeBaseBranch } from "../projects/worktree-base-branch.js";
 import { isLiveParentThread, type ParentThread } from "./thread-parent.js";
 
 export const DEFAULT_SERVICE_TIER: ServiceTier = "default";
@@ -207,25 +211,55 @@ export function buildProviderThreadExecutionDefaults(args: {
 /**
  * Resolve the `{ type: "project-default" }` thread-creation environment into
  * a concrete request. Server-owned defaulting policy for callers (plugins,
- * scripts) that must not re-derive the compose flow's choices: the personal
- * project gets a personal workspace on the primary host, and every other
- * project gets a fresh managed worktree from the project source's default
- * branch on the primary host. Throws a clear ApiError (502 host_unavailable)
- * when no enrolled, connected host exists.
+ * scripts) that must not re-derive the compose flow's choices. The personal
+ * project gets a personal workspace on the primary host. Every other project
+ * gets a fresh managed worktree when its primary source exposes a usable base
+ * branch, or works in that source checkout when it does not (for example, a
+ * non-Git directory or a repository with no commits). Host inspection failures
+ * remain failures; only a successful inspection can select the source checkout.
  */
-export function resolveProjectDefaultThreadEnvironment(
-  deps: Pick<AppDeps, "config" | "db" | "hub">,
+export async function resolveProjectDefaultThreadEnvironment(
+  deps: WorkSessionDeps,
   args: { projectId: string },
-): EnvironmentArgs {
+): Promise<EnvironmentArgs> {
   if (args.projectId === PERSONAL_PROJECT_ID) {
     // hostId is resolved to the primary host downstream, exactly like an
     // app-composed personal thread that omits it.
     return { type: "host", workspace: { type: "personal" } };
   }
+
+  const hostId = requireConnectedPrimaryHostId(deps);
+  const source = resolveProjectWorkspaceTarget(deps, {
+    hostId,
+    projectId: args.projectId,
+  });
+  const checkout = await callHostRetryableOnlineRpc(deps, {
+    hostId,
+    timeoutMs: COMMAND_TIMEOUT_MS,
+    command: {
+      type: "host.list_branches",
+      path: source.path,
+      limit: 1,
+    },
+  });
+  const baseBranch = resolveDefaultWorktreeBaseBranch(checkout);
+  if (baseBranch === null) {
+    return {
+      type: "host",
+      hostId,
+      workspace: { type: "unmanaged", path: null },
+    };
+  }
+
   return {
     type: "host",
-    hostId: requireConnectedPrimaryHostId(deps),
-    workspace: { type: "managed-worktree", baseBranch: { kind: "default" } },
+    hostId,
+    workspace: {
+      type: "managed-worktree",
+      // Pin the inspected ref so downstream provisioning does not need to
+      // inspect again or race a changing default branch.
+      baseBranch: { kind: "named", name: baseBranch },
+    },
   };
 }
 

--- a/apps/server/test/public/public-threads.project-default.test.ts
+++ b/apps/server/test/public/public-threads.project-default.test.ts
@@ -1,11 +1,17 @@
 import { getThread } from "@bb/db";
-import { PERSONAL_PROJECT_ID, threadSchema } from "@bb/domain";
+import {
+  PERSONAL_PROJECT_ID,
+  threadSchema,
+  type ProjectSourceCheckout,
+} from "@bb/domain";
 import { describe, expect, it } from "vitest";
 import { resolveProjectDefaultThreadEnvironment } from "../../src/services/threads/thread-default-policy.js";
+import { getActiveThreadProvisionContext } from "../../src/services/threads/thread-provisioning-active-context.js";
 import {
   requireManagedWorktreeEnvironmentProvisionLiveCommand,
   waitForQueuedCommand,
 } from "../helpers/commands.js";
+import { registerHostRpcResponder } from "../helpers/host-rpc.js";
 import { readJson } from "../helpers/json.js";
 import {
   seedEnvironment,
@@ -106,13 +112,10 @@ describe("project-default thread environment", () => {
         hostId: host.id,
         path: sourcePath,
       });
-      const { provision, threadId } = await createAndCaptureProvision(
-        harness,
-        {
-          projectId: project.id,
-          environment: { type: "project-default" },
-        },
-      );
+      const { provision, threadId } = await createAndCaptureProvision(harness, {
+        projectId: project.id,
+        environment: { type: "project-default" },
+      });
       expect(provision).toEqual(explicit);
       // Non-plugin origins surface a null plugin attribution.
       expect(getThread(harness.db, threadId)?.originPluginId).toBeNull();
@@ -121,13 +124,98 @@ describe("project-default thread environment", () => {
 
   it("resolves the personal project to a personal workspace on the primary host", async () => {
     await withTestHarness(async (harness) => {
-      expect(
+      await expect(
         resolveProjectDefaultThreadEnvironment(harness.deps, {
           projectId: PERSONAL_PROJECT_ID,
         }),
-      ).toEqual({ type: "host", workspace: { type: "personal" } });
+      ).resolves.toEqual({
+        type: "host",
+        workspace: { type: "personal" },
+      });
     });
   });
+
+  it.each([
+    {
+      name: "a repository with no commits",
+      checkout: {
+        branches: [],
+        branchesTruncated: false,
+        checkout: { kind: "unborn" as const, branchName: "main" },
+        defaultBranch: null,
+        defaultBranchRelation: null,
+        hasUncommittedChanges: false,
+        operation: { kind: "none" as const },
+        originDefaultBranch: null,
+        remoteBranches: [],
+        remoteBranchesTruncated: false,
+        selectedBranch: null,
+      } satisfies ProjectSourceCheckout,
+    },
+    {
+      name: "a non-Git directory",
+      checkout: {
+        branches: [],
+        branchesTruncated: false,
+        checkout: {
+          kind: "unknown" as const,
+          reason: "Path is not a git repository",
+        },
+        defaultBranch: null,
+        defaultBranchRelation: null,
+        hasUncommittedChanges: false,
+        operation: { kind: "none" as const },
+        originDefaultBranch: null,
+        remoteBranches: [],
+        remoteBranchesTruncated: false,
+        selectedBranch: null,
+      } satisfies ProjectSourceCheckout,
+    },
+  ])(
+    "dispatches a plugin thread in the project source for $name",
+    async ({ checkout }) => {
+      await withTestHarness(async (harness) => {
+        const { host, session } = seedHostSession(harness.deps);
+        seedPrimaryHost(harness.deps, host.id);
+        const sourcePath = "/tmp/project-default-unmanaged-source";
+        const { project } = seedProjectWithSource(harness.deps, {
+          hostId: host.id,
+          path: sourcePath,
+        });
+        const responder = registerHostRpcResponder(harness, {
+          hostId: host.id,
+          sessionId: session.id,
+          restoreCommandCaptureAfterResponse: true,
+          handle(request) {
+            expect(request.command).toEqual({
+              type: "host.list_branches",
+              path: sourcePath,
+              limit: 1,
+            });
+            return { ok: true, result: checkout };
+          },
+        });
+
+        const response = await postCreateThread(harness, project.id, {
+          origin: "plugin",
+          originPluginId: "tasks",
+          environment: { type: "project-default" },
+        });
+
+        expect(response.status).toBe(201);
+        const thread = threadSchema.parse(await readJson(response));
+        expect(responder.requests).toHaveLength(1);
+        expect(getThread(harness.db, thread.id)?.originPluginId).toBe("tasks");
+        expect(
+          getActiveThreadProvisionContext(thread.id)?.request.environmentIntent,
+        ).toEqual({
+          type: "direct-unmanaged",
+          hostId: host.id,
+          path: sourcePath,
+        });
+      });
+    },
+  );
 
   it("fails with a clear ApiError when the primary host is not connected", async () => {
     await withTestHarness(async (harness) => {

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -36,7 +36,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 107 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 108 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1056,10 +1056,13 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
-  // Version 107 carries a provider checkpoint through thread.stop so the
-  // server can retain an interrupted turn when a later message is edited.
-  it("uses protocol version 107 for stopped-turn checkpoints", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(107);
+  // Version 108 adds the distinct `unborn_head` provisioning failure sent by
+  // the daemon when a project source has no commits. Older daemons report the
+  // internal missing-default-branch failure, so enrolled machines must update
+  // for the actionable worktree error. Version 107 carried stopped-turn
+  // provider checkpoints and remains part of the protocol lineage.
+  it("uses protocol version 108 for commitless worktree source errors", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(108);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {

--- a/packages/host-workspace/src/git.ts
+++ b/packages/host-workspace/src/git.ts
@@ -444,6 +444,22 @@ export async function ensureGitRepo(
   );
 }
 
+export type GitRepositoryState = "not_git" | "no_commits" | "has_commits";
+
+export async function readGitRepositoryState(
+  cwd: string,
+  options: GitTimeoutOptions = {},
+): Promise<GitRepositoryState> {
+  if (!(await detectGitRepo(cwd, options))) {
+    return "not_git";
+  }
+  const result = await runGit(["rev-list", "--all", "--max-count=1"], {
+    cwd,
+    timeoutMs: options.timeoutMs,
+  });
+  return trimOutput(result.stdout).length > 0 ? "has_commits" : "no_commits";
+}
+
 async function readHeadSha(
   cwd: string,
   options: GitTimeoutOptions = {},

--- a/packages/host-workspace/src/provisioning.ts
+++ b/packages/host-workspace/src/provisioning.ts
@@ -17,6 +17,7 @@ import { tryWithCheckoutMutationLock } from "./checkout-mutation-lock.js";
 import {
   pathExists,
   readDefaultBranch,
+  readGitRepositoryState,
   runGit,
   WorkspaceError,
   type GitCommandResult,
@@ -339,6 +340,22 @@ export async function createWorktree(
   throwIfProvisionAborted(args.signal);
   if (await ensureExistingWorkspaceMatches(args.targetPath, args.branchName)) {
     return { path: args.targetPath };
+  }
+
+  throwIfProvisionAborted(args.signal);
+  switch (await readGitRepositoryState(args.sourcePath)) {
+    case "not_git":
+      throw new WorkspaceError(
+        "not_git_repo",
+        `Cannot create a worktree because the source is not a Git repository: ${args.sourcePath}. Initialize it and create at least one commit, then try again.`,
+      );
+    case "no_commits":
+      throw new WorkspaceError(
+        "unborn_head",
+        `Cannot create a worktree because the repository has no commits: ${args.sourcePath}. Create an initial commit, then try again.`,
+      );
+    case "has_commits":
+      break;
   }
 
   throwIfProvisionAborted(args.signal);

--- a/packages/host-workspace/test/provisioning.test.ts
+++ b/packages/host-workspace/test/provisioning.test.ts
@@ -100,6 +100,53 @@ afterEach(async () => {
 });
 
 describe("workspace provisioning", () => {
+  it("explains all requirements when a worktree source is not a repository", async () => {
+    const sourceDir = await makeTempDir("bb-provisioning-non-git-source-");
+    const parentDir = await makeTempDir("bb-worktree-non-git-parent-");
+    const targetPath = path.join(parentDir, "feature");
+
+    await expect(
+      createWorktree({
+        sourcePath: sourceDir,
+        targetPath,
+        branchName: "feature",
+        baseBranch: null,
+        timeoutMs: 900000,
+      }),
+    ).rejects.toMatchObject({
+      name: "WorkspaceError",
+      code: "not_git_repo",
+      message:
+        `Cannot create a worktree because the source is not a Git repository: ${sourceDir}. ` +
+        "Initialize it and create at least one commit, then try again.",
+    });
+    await expect(fs.stat(targetPath)).rejects.toThrow();
+  });
+
+  it("rejects a commitless repository with an actionable error", async () => {
+    const sourceRepo = await makeTempDir("bb-provisioning-empty-repo-");
+    await runGit(["init", "-b", "main"], { cwd: sourceRepo });
+    const parentDir = await makeTempDir("bb-worktree-empty-parent-");
+    const targetPath = path.join(parentDir, "feature");
+
+    await expect(
+      createWorktree({
+        sourcePath: sourceRepo,
+        targetPath,
+        branchName: "feature",
+        baseBranch: null,
+        timeoutMs: 900000,
+      }),
+    ).rejects.toMatchObject({
+      name: "WorkspaceError",
+      code: "unborn_head",
+      message:
+        `Cannot create a worktree because the repository has no commits: ${sourceRepo}. ` +
+        "Create an initial commit, then try again.",
+    });
+    await expect(fs.stat(targetPath)).rejects.toThrow();
+  });
+
   it("creates worktrees and is idempotent for valid targets", async () => {
     const sourceRepo = await initRepoWithOptionalSetup();
     const parentDir = await makeTempDir("bb-worktree-parent-");

--- a/packages/server-contract/src/api/shared.ts
+++ b/packages/server-contract/src/api/shared.ts
@@ -130,7 +130,8 @@ export type EnvironmentArgs = z.infer<typeof environmentArgsSchema>;
 /**
  * Server-resolved environment default for thread creation: the server picks
  * the host and workspace using its own defaulting policy (personal workspace
- * for the personal project, a managed worktree on the primary host otherwise).
+ * for the personal project; otherwise a managed worktree when the primary
+ * source has a usable base branch, or that source checkout when it does not).
  * For callers — plugins, scripts — that should not re-derive compose-flow
  * policy. Accepted only by thread creation; other surfaces keep the explicit
  * {@link environmentArgsSchema}.


### PR DESCRIPTION
## Summary

- make the server-owned project-default policy prefer an isolated worktree when the primary project source has a usable base branch, and otherwise run in the existing source checkout
- allow Tasks dispatch for non-Git directories and repositories with no commits without initializing or mutating the user's repository
- keep explicit New worktree requests strict, with distinct actionable errors for non-Git and zero-commit sources and disabled composer options when the limitation is already known
- bump the host-daemon protocol to 108 for the new unborn_head provisioning error

## QA

- reproduced the original failure through a linked Tasks project and project-default preset
- dispatched a real Tasks agent from a fresh git init -b main repository with zero commits; verified the Tasks-attributed thread ran successfully in the original path with an unmanaged, non-worktree environment and left the repository commitless
- verified project-default still provisions a managed worktree for a normal Git repository
- added server regressions for Tasks-attributed project-default dispatch from both an unborn repository and a non-Git directory
- pnpm exec turbo run test --filter=@bb/host-workspace --filter=@bb/host-daemon-contract --filter=@bb/server-contract --filter=@bb/server --filter=@bb/app --filter=bb-plugin-tasks --force
- pnpm exec turbo run typecheck --filter=@bb/host-workspace --filter=@bb/host-daemon-contract --filter=@bb/host-daemon --filter=@bb/server-contract --filter=@bb/server --filter=@bb/app --filter=bb-plugin-tasks
- pnpm exec turbo run lint --filter=@bb/app --force

Fixes #1387

> AGENT GENERATED: by GPT-5.6 Sol
