### PR TITLE
Fix timeline failures for large scoped item windows

### DIFF
--- a/apps/server/test/services/threads/timeline-in-turn-window.test.ts
+++ b/apps/server/test/services/threads/timeline-in-turn-window.test.ts
@@ -525,6 +525,41 @@ describe("in-turn timeline windows", () => {
     );
   });
 
+  it("pages a compact byte slice with hundreds of item identities", () => {
+    const { db, thread } = setup();
+    // One early large command pushes the 1,000 compact commands after it into a
+    // separate byte-budget page. Querying every scoped identity in that page
+    // as its own OR branch exceeds SQLite's expression-depth limit even though
+    // the page itself is correctly bounded.
+    seedTurns(db, thread, {
+      commandChars: THREAD_TIMELINE_EVENT_DATA_BYTE_LIMIT - 500_000,
+      completeLastTurn: false,
+      itemsPerTurn: [1],
+    });
+    appendCommandItems(db, thread, {
+      commandChars: 1,
+      count: 1_000,
+      itemStart: 1,
+    });
+    insertEvents(db, noopNotifier, [
+      {
+        threadId: thread.id,
+        sequence: getLatestThreadSequence(db, { threadId: thread.id }) + 1,
+        type: "turn/completed",
+        scope: turnScope("turn-1"),
+        providerThreadId,
+        itemId: null,
+        itemKind: null,
+        data: JSON.stringify({ status: "completed", providerThreadId }),
+      },
+    ]);
+
+    const walked = walkAllPages(db, thread, LARGE_BUDGET);
+
+    expect(walked.pages).toBeGreaterThan(1);
+    expect(walked.rows).not.toHaveLength(0);
+  });
+
   it("pages back through a running oversized turn to exactly the unbudgeted rows", () => {
     const { db, thread } = setup();
     seedTurns(db, thread, {

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -1460,20 +1460,44 @@ function dedupeScopedItemRefs(
  * Restrict a read to exactly the given item identities.
  *
  * The `item_id` list is kept as its own predicate so the query still narrows
- * through the item-id index; the scope disjunction then drops the rows that
- * belong to a different turn's reuse of the same id.
+ * through the item-id index. The scope disjunction has one branch per scope,
+ * with that scope's item ids in an `IN` predicate, so a large single-turn
+ * window does not exceed SQLite's expression-depth limit with one branch per
+ * item. The grouping still drops rows that belong to a different turn's reuse
+ * of the same id.
  */
 function scopedItemRefsPredicate(
   items: readonly ScopedItemRef[],
 ): SQL | undefined {
   const itemIds = [...new Set(items.map((item) => item.itemId))];
-  const scopePredicates = items.map((item) =>
+  const scopeGroups = new Map<
+    string,
+    {
+      itemIds: Set<string>;
+      scopeKind: ThreadEventScopeKind;
+      turnId: string | null;
+    }
+  >();
+  for (const item of items) {
+    const scopeKey = `${item.scopeKind}\u0000${item.turnId ?? ""}`;
+    const existing = scopeGroups.get(scopeKey);
+    if (existing) {
+      existing.itemIds.add(item.itemId);
+      continue;
+    }
+    scopeGroups.set(scopeKey, {
+      itemIds: new Set([item.itemId]),
+      scopeKind: item.scopeKind,
+      turnId: item.turnId,
+    });
+  }
+  const scopePredicates = [...scopeGroups.values()].map((group) =>
     and(
-      eq(events.itemId, item.itemId),
-      eq(events.scopeKind, item.scopeKind),
-      item.turnId === null
+      inArray(events.itemId, [...group.itemIds]),
+      eq(events.scopeKind, group.scopeKind),
+      group.turnId === null
         ? isNull(events.turnId)
-        : eq(events.turnId, item.turnId),
+        : eq(events.turnId, group.turnId),
     ),
   );
   return and(inArray(events.itemId, itemIds), or(...scopePredicates));


### PR DESCRIPTION
## Summary

- group timeline item IDs by scope before building SQLite predicates
- preserve cross-turn item ID isolation without one OR branch per item
- add a regression for a byte-budget page containing 1,000 compact items

## Validation

- `pnpm exec turbo run test --filter=@bb/db --filter=@bb/server --force`
  - 379 database tests passed
  - 1,437 server tests passed
- `pnpm exec turbo run typecheck --filter=@bb/db --filter=@bb/server`
- focused 20-test timeline suite passed after rebasing onto current main
- Prettier and `git diff --check` passed

## Performance

On six real thread tails, the affected query improved from 1.7x to 8.9x at median where the old query completed. The originally failing 1,049-item thread changed from a SQLite maximum-expression-depth error to a 2.7 ms median query. Results matched exactly for every comparable thread.

> AGENT GENERATED: by GPT-5