### PR TITLE
Hide zero task count in sidebar

### DIFF
--- a/plugins/tasks/app.test.tsx
+++ b/plugins/tasks/app.test.tsx
@@ -44,6 +44,45 @@ describe("Tasks nav panel sidebar accessory", () => {
     ).toHaveLength(3);
   });
 
+  it("hides the count when there are no open tasks", async () => {
+    let openTaskCount = 0;
+    const Accessory = app.navPanels[0]?.experimental_sidebarAccessory;
+
+    const slot = renderSlot(
+      { component: Accessory! },
+      {},
+      {
+        rpc: {
+          sidebarOpenTaskCount: () => ({ openTaskCount }),
+        },
+      },
+    );
+
+    await waitFor(() =>
+      expect(
+        slot.inspection.rpcCalls.filter(
+          ({ method }) => method === "sidebarOpenTaskCount",
+        ),
+      ).toHaveLength(1),
+    );
+    expect(slot.queryByText("0")).toBeNull();
+
+    openTaskCount = 1;
+    await slot.behavior.emitRealtime("tasks:changed", {
+      taskId: "01HZZZZZZZZZZZZZZZZZZZZZT1",
+      projectId: "01HZZZZZZZZZZZZZZZZZZZZZP1",
+    });
+    expect(await slot.findByText("1")).toBeDefined();
+
+    openTaskCount = 0;
+    await slot.behavior.emitRealtime("tasks:changed", {
+      taskId: "01HZZZZZZZZZZZZZZZZZZZZZT1",
+      projectId: "01HZZZZZZZZZZZZZZZZZZZZZP1",
+    });
+    await waitFor(() => expect(slot.queryByText("1")).toBeNull());
+    expect(slot.queryByText("0")).toBeNull();
+  });
+
   it("coalesces a burst of task changes into one trailing count refresh", async () => {
     let calls = 0;
     let resolveFirstRequest:

--- a/plugins/tasks/shell/sidebar-accessory.tsx
+++ b/plugins/tasks/shell/sidebar-accessory.tsx
@@ -57,7 +57,7 @@ export function TasksSidebarAccessory() {
   useRealtime("tasks:changed", refresh);
   useRealtime("projects:changed", refresh);
 
-  return count === null ? null : (
+  return count === null || count === 0 ? null : (
     <span className="text-muted-foreground tabular-nums">{count}</span>
   );
 }


### PR DESCRIPTION
## Summary

- hide the Tasks sidebar accessory when there are no open tasks
- cover initial zero counts and realtime transitions back to zero

## Testing

- `pnpm exec turbo run test typecheck --filter=bb-plugin-tasks --force`

> AGENT GENERATED: by GPT-5