### PR TITLE
Fix Codex command output loss and rename race

### DIFF
--- a/packages/agent-runtime/src/codex/adapter.test.ts
+++ b/packages/agent-runtime/src/codex/adapter.test.ts
@@ -2897,6 +2897,129 @@ describe("codex provider adapter", () => {
     );
   });
 
+  it("defers completed command output until a later raw shell result arrives", () => {
+    const adapter = createCodexProviderAdapter();
+
+    adapter.translateEvent(
+      codexEvent("rawResponseItem/completed", {
+        threadId: "t1",
+        turnId: "turn-1",
+        item: {
+          type: "function_call",
+          name: "exec_command",
+          arguments: '{"cmd":"echo hi"}',
+          call_id: "cmd-1",
+        },
+      }),
+    );
+
+    const earlyEvents = adapter.translateEvent(
+      codexEvent("item/completed", {
+        threadId: "t1",
+        turnId: "turn-1",
+        completedAtMs: 0,
+        item: {
+          type: "commandExecution",
+          id: "cmd-1",
+          command: "echo hi",
+          cwd: "/tmp",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: "OUT-2\nOUT-3\n",
+          exitCode: 0,
+          durationMs: 150,
+        },
+      }),
+    );
+
+    expect(earlyEvents).toEqual([]);
+
+    const lateEvents = adapter.translateEvent(
+      codexEvent("rawResponseItem/completed", {
+        threadId: "t1",
+        turnId: "turn-1",
+        item: {
+          type: "function_call_output",
+          call_id: "cmd-1",
+          output: "Output:\nOUT-1\nOUT-2\nOUT-3\n",
+        },
+      }),
+    );
+
+    expect(lateEvents).toContainEqual(
+      expect.objectContaining({
+        type: "item/completed",
+        threadId: "t1",
+        providerThreadId: "t1",
+        scope: turnScope("turn-1"),
+        item: expect.objectContaining({
+          type: "commandExecution",
+          id: "cmd-1",
+          aggregatedOutput: "OUT-1\nOUT-2\nOUT-3\n",
+        }),
+      }),
+    );
+  });
+
+  it("releases deferred command output before turn completion when no raw result arrives", () => {
+    const adapter = createCodexProviderAdapter();
+
+    adapter.translateEvent(
+      codexEvent("rawResponseItem/completed", {
+        threadId: "t1",
+        turnId: "turn-1",
+        item: {
+          type: "function_call",
+          name: "exec_command",
+          arguments: '{"cmd":"echo hi"}',
+          call_id: "cmd-1",
+        },
+      }),
+    );
+    expect(
+      adapter.translateEvent(
+        codexEvent("item/completed", {
+          threadId: "t1",
+          turnId: "turn-1",
+          completedAtMs: 0,
+          item: {
+            type: "commandExecution",
+            id: "cmd-1",
+            command: "echo hi",
+            cwd: "/tmp",
+            processId: null,
+            source: "agent",
+            status: "completed",
+            commandActions: [],
+            aggregatedOutput: "provider output\n",
+            exitCode: 0,
+            durationMs: 150,
+          },
+        }),
+      ),
+    ).toEqual([]);
+
+    const completedEvents = adapter.translateEvent(
+      codexEvent("turn/completed", {
+        threadId: "t1",
+        turn: codexTurn({ id: "turn-1", status: "completed", error: null }),
+      }),
+    );
+
+    expect(completedEvents.map((event) => event.type)).toEqual([
+      "item/completed",
+      "turn/completed",
+    ]);
+    expect(completedEvents[0]).toMatchObject({
+      item: {
+        id: "cmd-1",
+        aggregatedOutput: "provider output\n",
+      },
+    });
+  });
+
   it("translateEvent preserves literal Output lines in recovered command output", () => {
     const adapter = createCodexProviderAdapter();
 

--- a/packages/agent-runtime/src/codex/adapter.ts
+++ b/packages/agent-runtime/src/codex/adapter.ts
@@ -788,6 +788,7 @@ type CodexParsedCommandOutput =
 
 interface CodexRawCommandOutputState {
   capturedCommandOutputByCallId: Map<string, CodexCapturedCommandOutput>;
+  pendingCompletedEventByCallId: Map<string, ThreadEvent>;
   shellToolCallIds: Set<string>;
 }
 
@@ -1150,6 +1151,7 @@ export function createCodexProviderAdapter(
         string,
         CodexCapturedCommandOutput
       >(),
+      pendingCompletedEventByCallId: new Map<string, ThreadEvent>(),
       shellToolCallIds: new Set<string>(),
     };
     rawCommandOutputStateByProviderThreadId.set(providerThreadId, nextState);
@@ -1163,6 +1165,7 @@ export function createCodexProviderAdapter(
     }
     if (
       state.capturedCommandOutputByCallId.size === 0 &&
+      state.pendingCompletedEventByCallId.size === 0 &&
       state.shellToolCallIds.size === 0
     ) {
       rawCommandOutputStateByProviderThreadId.delete(providerThreadId);
@@ -1631,40 +1634,42 @@ export function createCodexProviderAdapter(
     return completedEvents;
   }
 
-  function consumeCodexRawResponseItem(event: ProviderRuntimeEvent): boolean {
+  function consumeCodexRawResponseItem(
+    event: ProviderRuntimeEvent,
+  ): ThreadEvent[] | null {
     const rawEvent = toCodexRawNotification(event, "rawResponseItem/completed");
     if (!rawEvent) {
-      return false;
+      return null;
     }
 
     const paramsResult = codexRawResponseItemCompletedParamsSchema.safeParse(
       rawEvent.params,
     );
     if (!paramsResult.success) {
-      return true;
+      return [];
     }
 
     const { threadId: providerThreadId, item } = paramsResult.data;
 
     if (item.type === "function_call") {
       if (!CODEX_SHELL_TOOL_NAMES.has(item.name)) {
-        return true;
+        return [];
       }
       getRawCommandOutputState(providerThreadId).shellToolCallIds.add(
         item.call_id,
       );
-      return true;
+      return [];
     }
 
     if (item.type === "function_call_output") {
       const rawCommandOutputState =
         rawCommandOutputStateByProviderThreadId.get(providerThreadId);
       if (!rawCommandOutputState) {
-        return true;
+        return [];
       }
       if (!rawCommandOutputState.shellToolCallIds.has(item.call_id)) {
         pruneRawCommandOutputState(providerThreadId);
-        return true;
+        return [];
       }
 
       const recoveredOutput = extractRecoveredCommandOutput(item.output);
@@ -1673,9 +1678,25 @@ export function createCodexProviderAdapter(
           item.call_id,
           recoveredOutput,
         );
+      } else {
+        rawCommandOutputState.shellToolCallIds.delete(item.call_id);
+      }
+      const pendingCompletedEvent =
+        rawCommandOutputState.pendingCompletedEventByCallId.get(item.call_id);
+      if (pendingCompletedEvent) {
+        rawCommandOutputState.pendingCompletedEventByCallId.delete(
+          item.call_id,
+        );
+        const capturedOutput = consumeCapturedCommandOutput({
+          commandExecutionId: item.call_id,
+          providerThreadId,
+        });
+        return [
+          repairCompletedCommandOutput(pendingCompletedEvent, capturedOutput),
+        ];
       }
       pruneRawCommandOutputState(providerThreadId);
-      return true;
+      return [];
     }
 
     if (item.type === "local_shell_call") {
@@ -1683,7 +1704,7 @@ export function createCodexProviderAdapter(
       // execution as function_call(exec_command) + function_call_output. If
       // app-server starts emitting local_shell_call with recoverable output,
       // extend this repair path with a real captured fixture first.
-      return true;
+      return [];
     }
 
     if (
@@ -1692,22 +1713,35 @@ export function createCodexProviderAdapter(
     ) {
       // TODO(codex): Keep this explicit so shell recovery does not silently
       // assume custom_tool_call traffic is equivalent to exec_command.
-      return true;
+      return [];
     }
 
-    return true;
+    return [];
   }
 
-  function reconcileRawCommandOutputLifecycle(events: ThreadEvent[]): void {
+  function reconcileRawCommandOutputLifecycle(
+    events: ThreadEvent[],
+  ): ThreadEvent[] {
+    const reconciledEvents: ThreadEvent[] = [];
     for (const event of events) {
       if (event.type === "turn/completed") {
         if (event.providerThreadId !== null) {
+          const state = rawCommandOutputStateByProviderThreadId.get(
+            event.providerThreadId,
+          );
+          if (state) {
+            reconciledEvents.push(
+              ...state.pendingCompletedEventByCallId.values(),
+            );
+          }
           rawCommandOutputStateByProviderThreadId.delete(
             event.providerThreadId,
           );
         }
       }
+      reconciledEvents.push(event);
     }
+    return reconciledEvents;
   }
 
   function consumeCapturedCommandOutput(args: {
@@ -1733,6 +1767,46 @@ export function createCodexProviderAdapter(
     return capturedOutput;
   }
 
+  function repairCompletedCommandOutput(
+    event: ThreadEvent,
+    capturedOutput: CodexCapturedCommandOutput | undefined,
+  ): ThreadEvent {
+    if (
+      capturedOutput === undefined ||
+      event.type !== "item/completed" ||
+      event.item.type !== "commandExecution"
+    ) {
+      return event;
+    }
+
+    if (
+      capturedOutput.kind === "recovered" &&
+      event.item.aggregatedOutput === capturedOutput.output
+    ) {
+      return event;
+    }
+
+    if (capturedOutput.kind === "empty") {
+      if (event.item.aggregatedOutput === undefined) {
+        return event;
+      }
+      const { aggregatedOutput: _aggregatedOutput, ...itemWithoutOutput } =
+        event.item;
+      return {
+        ...event,
+        item: itemWithoutOutput,
+      };
+    }
+
+    return {
+      ...event,
+      item: {
+        ...event.item,
+        aggregatedOutput: capturedOutput.output,
+      },
+    };
+  }
+
   function applyRecoveredCommandOutput(events: ThreadEvent[]): ThreadEvent[] {
     const repairedEvents: ThreadEvent[] = [];
     for (const event of events) {
@@ -1744,44 +1818,27 @@ export function createCodexProviderAdapter(
         continue;
       }
 
+      const rawCommandOutputState = rawCommandOutputStateByProviderThreadId.get(
+        event.providerThreadId,
+      );
+      if (
+        !rawCommandOutputState?.capturedCommandOutputByCallId.has(event.item.id)
+      ) {
+        if (rawCommandOutputState?.shellToolCallIds.has(event.item.id)) {
+          rawCommandOutputState.pendingCompletedEventByCallId.set(
+            event.item.id,
+            event,
+          );
+          continue;
+        }
+        repairedEvents.push(event);
+        continue;
+      }
       const capturedOutput = consumeCapturedCommandOutput({
         commandExecutionId: event.item.id,
         providerThreadId: event.providerThreadId,
       });
-      if (capturedOutput === undefined) {
-        repairedEvents.push(event);
-        continue;
-      }
-
-      if (
-        capturedOutput.kind === "recovered" &&
-        event.item.aggregatedOutput === capturedOutput.output
-      ) {
-        repairedEvents.push(event);
-        continue;
-      }
-
-      if (capturedOutput.kind === "empty") {
-        if (event.item.aggregatedOutput === undefined) {
-          repairedEvents.push(event);
-          continue;
-        }
-        const { aggregatedOutput: _aggregatedOutput, ...itemWithoutOutput } =
-          event.item;
-        repairedEvents.push({
-          ...event,
-          item: itemWithoutOutput,
-        });
-        continue;
-      }
-
-      repairedEvents.push({
-        ...event,
-        item: {
-          ...event.item,
-          aggregatedOutput: capturedOutput.output,
-        },
-      });
+      repairedEvents.push(repairCompletedCommandOutput(event, capturedOutput));
     }
     return repairedEvents;
   }
@@ -2043,14 +2100,16 @@ export function createCodexProviderAdapter(
 
     translateEvent(event: ProviderRuntimeEvent) {
       clearClosedThreadState(event);
-      if (consumeCodexRawResponseItem(event)) {
-        return [];
+      const rawResponseEvents = consumeCodexRawResponseItem(event);
+      if (rawResponseEvents !== null) {
+        return rawResponseEvents;
       }
 
       const subAgentActivityEvents = translateCodexSubAgentActivity(event);
       if (subAgentActivityEvents !== null) {
-        reconcileRawCommandOutputLifecycle(subAgentActivityEvents);
-        return applyRecoveredCommandOutput(subAgentActivityEvents);
+        return reconcileRawCommandOutputLifecycle(
+          applyRecoveredCommandOutput(subAgentActivityEvents),
+        );
       }
 
       const translatedEvents = translateCodexEvent(
@@ -2061,8 +2120,9 @@ export function createCodexProviderAdapter(
         attachCodexDelegationParentLinks(translatedEvents);
       const completedSubAgentEvents =
         completeFinishedCodexSubAgentTurns(parentLinkedEvents);
-      reconcileRawCommandOutputLifecycle(completedSubAgentEvents);
-      return applyRecoveredCommandOutput(completedSubAgentEvents);
+      return reconcileRawCommandOutputLifecycle(
+        applyRecoveredCommandOutput(completedSubAgentEvents),
+      );
     },
 
     onSessionReplace({ command, providerThreadId }) {

--- a/packages/agent-runtime/src/runtime.command-contract.test.ts
+++ b/packages/agent-runtime/src/runtime.command-contract.test.ts
@@ -36,6 +36,7 @@ interface CreateRuntimeLinkedWorktreeFixtureArgs {
 type RuntimeEventHandler = (event: ThreadEvent) => void;
 
 interface CreateContractRuntimeArgs {
+  adapterId?: string;
   onEvent?: RuntimeEventHandler;
   scriptPath: string;
   workspacePath: string;
@@ -66,7 +67,12 @@ function createContractRuntime(args: CreateContractRuntimeArgs): AgentRuntime {
       contentItems: [{ type: "inputText", text: "ok" }],
       success: true,
     }),
-    adapterFactory: () => createFakeAdapter(args.scriptPath),
+    adapterFactory: () => {
+      const adapter = createFakeAdapter(args.scriptPath);
+      return args.adapterId === undefined
+        ? adapter
+        : { ...adapter, id: args.adapterId };
+    },
   });
 }
 
@@ -442,6 +448,155 @@ rl.on("line", (line) => {
           type: "thread/name/updated",
         }),
       );
+    } finally {
+      await runtime.shutdown();
+    }
+  });
+
+  it("retries a Codex rename while its new rollout file is still empty", async () => {
+    const renameAttemptsPath = join(tmpDir, "rename-attempts.txt");
+    const renameTitlePath = join(tmpDir, "retried-rename-title.txt");
+    const providerScriptPath = join(tmpDir, "codex-rename-retry-provider.cjs");
+    writeFileSync(
+      providerScriptPath,
+      `
+const fs = require("node:fs");
+const readline = require("node:readline");
+const renameAttemptsPath = ${JSON.stringify(renameAttemptsPath)};
+const renameTitlePath = ${JSON.stringify(renameTitlePath)};
+let renameAttempts = 0;
+
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+}
+
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  const params = message.params ?? {};
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+    return;
+  }
+  if (message.method === "thread/start") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: { providerThreadId: "provider-thread-1" },
+    });
+    return;
+  }
+  if (message.method === "thread/name/set") {
+    renameAttempts += 1;
+    fs.writeFileSync(renameAttemptsPath, String(renameAttempts), "utf8");
+    if (renameAttempts === 1) {
+      send({
+        jsonrpc: "2.0",
+        id: message.id,
+        error: {
+          code: -32603,
+          message:
+            "failed to set thread name: rollout at /tmp/new-rollout.jsonl is empty",
+        },
+      });
+      return;
+    }
+    fs.writeFileSync(renameTitlePath, params.title, "utf8");
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+  }
+});
+`,
+      "utf8",
+    );
+    const runtime = createContractRuntime({
+      adapterId: "codex",
+      scriptPath: providerScriptPath,
+      workspacePath: tmpDir,
+    });
+
+    try {
+      await runtime.startThread({
+        environmentId: "env-1",
+        threadId: "t1",
+        projectId: "p1",
+        providerId: "codex",
+        options: fullRuntimeOptions,
+      });
+      await runtime.renameThread({ threadId: "t1", title: "New Title" });
+
+      expect(readFileSync(renameAttemptsPath, "utf8")).toBe("2");
+      expect(readFileSync(renameTitlePath, "utf8")).toBe("[bb] New Title");
+    } finally {
+      await runtime.shutdown();
+    }
+  });
+
+  it("stops retrying a Codex rename once its rollout stays empty", async () => {
+    const renameAttemptsPath = join(tmpDir, "exhausted-rename-attempts.txt");
+    const providerScriptPath = join(tmpDir, "codex-rename-empty-provider.cjs");
+    writeFileSync(
+      providerScriptPath,
+      `
+const fs = require("node:fs");
+const readline = require("node:readline");
+const renameAttemptsPath = ${JSON.stringify(renameAttemptsPath)};
+let renameAttempts = 0;
+
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+}
+
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    send({ jsonrpc: "2.0", id: message.id, result: {} });
+    return;
+  }
+  if (message.method === "thread/start") {
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      result: { providerThreadId: "provider-thread-1" },
+    });
+    return;
+  }
+  if (message.method === "thread/name/set") {
+    renameAttempts += 1;
+    fs.writeFileSync(renameAttemptsPath, String(renameAttempts), "utf8");
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      error: {
+        code: -32603,
+        message:
+          "failed to set thread name: rollout at /tmp/new-rollout.jsonl is empty",
+      },
+    });
+  }
+});
+`,
+      "utf8",
+    );
+    const runtime = createContractRuntime({
+      adapterId: "codex",
+      scriptPath: providerScriptPath,
+      workspacePath: tmpDir,
+    });
+
+    try {
+      await runtime.startThread({
+        environmentId: "env-1",
+        threadId: "t1",
+        projectId: "p1",
+        providerId: "codex",
+        options: fullRuntimeOptions,
+      });
+
+      await expect(
+        runtime.renameThread({ threadId: "t1", title: "New Title" }),
+      ).rejects.toThrow(/rollout at .+ is empty/i);
+      expect(readFileSync(renameAttemptsPath, "utf8")).toBe("3");
     } finally {
       await runtime.shutdown();
     }

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -243,6 +243,51 @@ const CODEX_ACCOUNT_RESTART_PROVIDER_ERROR_TEXT_PATTERN =
   /\b(?:40[19]|429|auth(?:entication|orization)?|credits?|quota|rate[-\s]?limit(?:ed)?|unauthori[sz]ed|usage limit)\b/i;
 const CODEX_ARCHIVED_SESSION_ERROR_PATTERN =
   /\b(?:session|thread)\s+\S+\s+is archived\b/i;
+const CODEX_EMPTY_ROLLOUT_RENAME_ERROR_PATTERN = /\brollout at .+ is empty\b/i;
+const CODEX_RENAME_RETRY_DELAYS_MS = [50, 200] as const;
+
+async function delay(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+interface SendRenameWithRolloutRetriesArgs {
+  onStderr: AgentRuntimeOptions["onStderr"];
+  providerId: string;
+  send: () => Promise<void>;
+  threadId: string;
+}
+
+/**
+ * A brand-new Codex rollout file can exist before its first record is written,
+ * and a rename landing in that window fails until Codex flushes. Retry only
+ * that error, backing off after each attempt, then make one final attempt
+ * whose failure propagates. Every other error fails immediately.
+ */
+async function sendRenameWithRolloutRetries(
+  args: SendRenameWithRolloutRetriesArgs,
+): Promise<void> {
+  for (const retryDelayMs of CODEX_RENAME_RETRY_DELAYS_MS) {
+    try {
+      await args.send();
+      return;
+    } catch (error) {
+      if (
+        args.providerId !== CODEX_PROVIDER_ID ||
+        !(error instanceof Error) ||
+        !CODEX_EMPTY_ROLLOUT_RENAME_ERROR_PATTERN.test(error.message)
+      ) {
+        throw error;
+      }
+      args.onStderr?.(
+        `Codex session rollout is not ready; retrying rename for thread "${args.threadId}" in ${retryDelayMs}ms.`,
+      );
+      await delay(retryDelayMs);
+    }
+  }
+  await args.send();
+}
 
 function resolveThreadStoragePath(
   args: ResolveThreadStoragePathArgs,
@@ -2023,10 +2068,17 @@ function createAgentRuntimeInternal(
             plan: proc.adapter.buildCommandPlan(adapterCommand),
             providerId: pid,
           });
-          await sendCommand({
-            proc,
-            message: cmd,
-            resultSchema: ignoredJsonRpcResultSchema,
+          await sendRenameWithRolloutRetries({
+            onStderr: options.onStderr,
+            providerId: pid,
+            send: async () => {
+              await sendCommand({
+                proc,
+                message: cmd,
+                resultSchema: ignoredJsonRpcResultSchema,
+              });
+            },
+            threadId,
           });
           emitAcceptedCommandEvents({
             command: adapterCommand,

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -36,7 +36,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 109 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 110 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1056,13 +1056,14 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
-  // Version 108 adds the distinct `unborn_head` provisioning failure sent by
-  // the daemon when a project source has no commits. Older daemons report the
-  // internal missing-default-branch failure, so enrolled machines must update
-  // for the actionable worktree error. Version 107 carried stopped-turn
-  // provider checkpoints and remains part of the protocol lineage.
-  it("uses protocol version 108 for commitless worktree source errors", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(109);
+  // Version 110 makes Codex command completion wait for a late full-output
+  // record before publishing the completed item. Older daemons can publish a
+  // truncated completed item when app-server reorders those events, so
+  // enrolled machines must update for the complete command output. Version 109
+  // carried the Claude Code rate-limit adapter behavior and remains part of the
+  // protocol lineage.
+  it("uses protocol version 110 for complete Codex command output", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(110);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {


### PR DESCRIPTION
Two Codex runtime reliability fixes, split out of #1385 so they can be reviewed on their own.

## Bug 1: command output lost when Codex reorders events

Codex app-server normally reports a shell command as `function_call` → `function_call_output` (the full stdout) → `item/completed`. Sometimes the `item/completed` event arrives **before** the raw record carrying the output.

The adapter only repaired a completed item using output it had already captured. In the reordered case there was nothing captured yet, so it published the provider's truncated `aggregatedOutput` and the real output — which arrived a moment later — was dropped. Users saw a finished command with missing or partial output.

**Fix:** when a completed command item arrives while its shell call is still awaiting raw output, hold it instead of publishing it. Repair and emit it as soon as the raw record lands. If the raw record never arrives, flush the held item at turn completion, so output is at worst delayed rather than lost. Unparseable raw output clears the pending shell call so the completed item is released unchanged.

## Bug 2: generated-title rename fails on a brand-new session

A new Codex rollout file can exist briefly before its first record is written. A generated-title rename landing in that window fails with `rollout at <path> is empty`, and the thread keeps its placeholder title even though the same call would succeed moments later.

**Fix:** retry only that exact transient error, and only for Codex, backing off 50 ms then 200 ms before a final attempt. Every other rename failure, and every other provider, still fails immediately.

The backoff is only ever paid when the rename has *already* failed — the happy path returns on the first attempt — and the full 250 ms only when it fails for good, where the alternative was failing instantly and leaving the thread on a placeholder title.

## Protocol version

Bug 1 changes what the host daemon sends the server, so `HOST_DAEMON_PROTOCOL_VERSION` goes 109 → **110** with its contract test and comment updated. Older daemons can publish a truncated completed item, so enrolled machines must update.

Note for reviewers: #1408 bumped the constant to 109 and updated the assertion, but left the test name and comment describing 108. Rebasing onto it meant rewriting those exact lines, so this PR lands a correct 110 lineage and clears that stale wording as a side effect.

These are product reliability changes only — **no database schema, migration, or Drizzle snapshot changes**, and no other behavior from #1385.

## Validation

- `turbo run typecheck --filter=@bb/agent-runtime --filter=@bb/host-daemon-contract` — pass
- `turbo run typecheck --filter=@bb/host-daemon --filter=@bb/server` (downstream protocol consumers) — pass
- `turbo run test --filter=@bb/host-daemon-contract` — 49/49 pass
- Rebased onto `3bd8e79a0` and fully re-validated
- `turbo run test --filter=@bb/agent-runtime` — **921 pass, 0 failures**
- Prettier clean on all changed files

Three regression tests were each verified to **fail against current `main` and pass with the fix**:
- adapter: repairs a completed item when the raw output arrives late
- adapter: flushes the held item at turn end when raw output never arrives
- runtime: retries the rename through one empty-rollout error and applies the title

A fourth test pins the exhaustion path: a rollout that stays empty makes exactly 3 attempts and then propagates the error, so the retry can neither loop nor swallow a genuine failure.

## Previously-noted test failure is resolved upstream

Earlier revisions of this description flagged `runtime.process-lifecycle.test.ts > bounds provider stderr while data arrives without a newline` as failing locally on macOS. #1402 landed that fix on `main` (the fixture used `process.exit()`, which discards Node's async-buffered pipe output on macOS). After rebasing onto it, **the full suite is green: 921/921 with zero failures.**

> AGENT GENERATED: by Claude Opus 5
