### PR TITLE
Fix provider process exit lifecycle races

### DIFF
--- a/packages/agent-runtime/src/runtime-provider-process.ts
+++ b/packages/agent-runtime/src/runtime-provider-process.ts
@@ -28,6 +28,7 @@ export interface RuntimeProviderProcess {
   adapter: ProviderAdapter;
   child: ChildProcess;
   expectedShutdownExpectations: number;
+  exitFinalized: Promise<void>;
   identity: RuntimeProviderIdentityState;
   interactiveRequestScope: string;
   pending: Map<string | number, PendingJsonRpcRequest>;
@@ -122,6 +123,7 @@ interface ProviderProcessExitedErrorArgs {
 }
 
 const PROVIDER_STDERR_TAIL_MAX_BYTES = 4_000;
+const PROVIDER_PROCESS_CLOSE_GRACE_MS = 1_000;
 
 function createAdapterTurnIdPrefix(): string {
   const adapterId = randomUUID().replaceAll("-", "").slice(0, 16);
@@ -156,7 +158,20 @@ export class RuntimeProviderProcessManager {
       return;
     }
 
-    if (this.processes.has(args.processKey)) return;
+    const existingProcess = this.processes.get(args.processKey);
+    if (existingProcess !== undefined) {
+      if (!hasChildProcessExited(existingProcess.child)) return;
+      await existingProcess.exitFinalized;
+
+      // Another caller may have started the replacement while this caller
+      // waited for the exited process to finish draining its stdio.
+      const concurrentStart = this.providerStarting.get(args.processKey);
+      if (concurrentStart !== undefined) {
+        await concurrentStart;
+        return;
+      }
+      if (this.processes.has(args.processKey)) return;
+    }
 
     const startPromise = (async () => {
       const adapter = this.getAdapter(args.providerId, args.acpLaunchSpec);
@@ -254,7 +269,6 @@ export class RuntimeProviderProcessManager {
       throw new Error(`Provider "${args.providerId}" is not running`);
     }
     if (hasChildProcessExited(providerProcess.child)) {
-      this.processes.delete(args.processKey);
       throw new Error(
         `Provider "${args.providerId}" has exited (${formatChildProcessExitStatus(providerProcess.child)})`,
       );
@@ -264,13 +278,22 @@ export class RuntimeProviderProcessManager {
 
   listRunningProviders(): string[] {
     return [
-      ...new Set([...this.processes.values()].map((proc) => proc.providerId)),
+      ...new Set(
+        [...this.processes.values()]
+          .filter((proc) => !hasChildProcessExited(proc.child))
+          .map((proc) => proc.providerId),
+      ),
     ];
   }
 
   async shutdownProvider(args: ShutdownRuntimeProviderArgs): Promise<void> {
     const providerProcess = this.processes.get(args.processKey);
-    if (!providerProcess || hasChildProcessExited(providerProcess.child)) {
+    if (!providerProcess) {
+      return;
+    }
+
+    if (hasChildProcessExited(providerProcess.child)) {
+      await providerProcess.exitFinalized;
       return;
     }
 
@@ -279,6 +302,9 @@ export class RuntimeProviderProcessManager {
       providerProcess,
       timeoutMs: args.timeoutMs,
     });
+    if (hasChildProcessExited(providerProcess.child)) {
+      await providerProcess.exitFinalized;
+    }
   }
 
   async shutdown(): Promise<void> {
@@ -286,21 +312,23 @@ export class RuntimeProviderProcessManager {
     const shutdownPromises: Promise<void>[] = [];
 
     for (const [processKey, providerProcess] of this.processes) {
-      shutdownPromises.push(
-        new Promise<void>((resolve) => {
-          const timer = setTimeout(() => {
-            providerProcess.child.kill("SIGKILL");
-            resolve();
-          }, 5000);
+      if (!hasChildProcessExited(providerProcess.child)) {
+        shutdownPromises.push(
+          new Promise<void>((resolve) => {
+            const timer = setTimeout(() => {
+              providerProcess.child.kill("SIGKILL");
+              resolve();
+            }, 5000);
 
-          providerProcess.child.on("exit", () => {
-            clearTimeout(timer);
-            resolve();
-          });
+            providerProcess.child.on("exit", () => {
+              clearTimeout(timer);
+              resolve();
+            });
 
-          providerProcess.child.kill("SIGTERM");
-        }),
-      );
+            providerProcess.child.kill("SIGTERM");
+          }),
+        );
+      }
       for (const [, pending] of providerProcess.pending) {
         pending.reject(new Error("Runtime shutting down"));
       }
@@ -353,11 +381,16 @@ export class RuntimeProviderProcessManager {
       cwd: this.args.workspacePath,
       env,
     });
+    let finalizeExit: () => void = () => undefined;
+    const exitFinalized = new Promise<void>((resolve) => {
+      finalizeExit = resolve;
+    });
 
     const providerProcess: RuntimeProviderProcess = {
       child,
       adapter: args.adapter,
       expectedShutdownExpectations: 0,
+      exitFinalized,
       interactiveRequestScope: randomUUID(),
       identity: this.args.createProviderIdentityState(args.providerId),
       pending: new Map(),
@@ -369,7 +402,10 @@ export class RuntimeProviderProcessManager {
 
     const stdout = createInterface({ input: child.stdout });
     stdout.on("line", (line) => {
-      if (this.shuttingDown) {
+      if (
+        this.shuttingDown ||
+        !this.isCurrentProviderProcess({ providerProcess })
+      ) {
         return;
       }
       this.args.handleStdoutLine({
@@ -379,7 +415,10 @@ export class RuntimeProviderProcessManager {
     });
 
     child.stderr.on("data", (chunk: Buffer) => {
-      if (this.shuttingDown) {
+      if (
+        this.shuttingDown ||
+        !this.isCurrentProviderProcess({ providerProcess })
+      ) {
         return;
       }
       consumeProviderStderrChunk({
@@ -389,7 +428,11 @@ export class RuntimeProviderProcessManager {
       });
     });
     child.stderr.on("end", () => {
-      if (this.shuttingDown || providerProcess.stderrLineTail.length === 0) {
+      if (
+        this.shuttingDown ||
+        !this.isCurrentProviderProcess({ providerProcess }) ||
+        providerProcess.stderrLineTail.length === 0
+      ) {
         return;
       }
       this.args.onStderr?.(decodeStderrLine(providerProcess.stderrLineTail));
@@ -403,13 +446,55 @@ export class RuntimeProviderProcessManager {
         providerProcess,
       });
     });
+    let exitStatus: ProviderProcessExitStatus | null = null;
+    let closeGraceTimer: NodeJS.Timeout | null = null;
+    let exitHandled = false;
+    const handleExit = (status: ProviderProcessExitStatus): void => {
+      if (exitHandled) return;
+      exitHandled = true;
+      if (closeGraceTimer !== null) {
+        clearTimeout(closeGraceTimer);
+      }
+      try {
+        this.handleProviderProcessExit({
+          code: status.code,
+          providerId: args.providerId,
+          providerProcess,
+          signal: status.signal,
+        });
+      } finally {
+        finalizeExit();
+      }
+    };
+
     child.on("exit", (code, signal) => {
-      this.handleProviderProcessExit({
+      const status = {
         code: code ?? null,
-        providerId: args.providerId,
-        providerProcess,
         signal: signal ?? null,
-      });
+      };
+      exitStatus = status;
+      // `exit` can precede the final stdout/stderr data events. Prefer
+      // `close`, which fires after stdio closes, so final provider output is
+      // consumed before pending requests and diagnostics are settled. Bound
+      // the wait because a descendant can inherit and hold a pipe open.
+      closeGraceTimer = setTimeout(() => {
+        // Stop an inherited pipe from outliving its provider entry. Otherwise
+        // a descendant can emit stale protocol messages after the replacement
+        // process has become current, and the unread streams remain retained.
+        stdout.close();
+        child.stdout.destroy();
+        child.stderr.destroy();
+        handleExit(status);
+      }, PROVIDER_PROCESS_CLOSE_GRACE_MS);
+      closeGraceTimer.unref();
+    });
+    child.on("close", (code, signal) => {
+      handleExit(
+        exitStatus ?? {
+          code: code ?? null,
+          signal: signal ?? null,
+        },
+      );
     });
 
     this.processes.set(args.processKey, providerProcess);

--- a/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
@@ -1,3 +1,4 @@
+import { once } from "node:events";
 import {
   existsSync,
   readFileSync,
@@ -27,6 +28,7 @@ import type { ProviderRuntimeEvent } from "./runtime-json-rpc.js";
 interface CreateProviderProcessManagerArgs {
   adapterProcessEnv?: Record<string, string>;
   env?: Record<string, string>;
+  handleStdoutLine?: (line: string, childPid: number | undefined) => void;
   onStderr?: NonNullable<AgentRuntimeOptions["onStderr"]>;
   onProcessExit: NonNullable<AgentRuntimeOptions["onProcessExit"]>;
   scriptPath: string;
@@ -78,7 +80,8 @@ describe("createAgentRuntime process lifecycle", () => {
         identityRegistry.createProviderState({ providerId }),
       env: args.env,
       getNextRequestId: () => nextRequestId++,
-      handleStdoutLine: () => undefined,
+      handleStdoutLine: ({ line, providerProcess }) =>
+        args.handleStdoutLine?.(line, providerProcess.child.pid),
       onProcessExit: args.onProcessExit,
       onProviderIdentityWaitersInterrupted: (providerProcess) =>
         identityRegistry.resolvePendingIdentityWaiters(
@@ -440,8 +443,8 @@ rl.on("line", (line) => {
     const crashScript = join(tmpDir, "large-stderr-provider.cjs");
     writeFileSync(
       crashScript,
-      `process.stderr.write("a".repeat(100_000) + "stderr-tail");
-      process.exit(42);`,
+      `process.exitCode = 42;
+      process.stderr.write("a".repeat(100_000) + "stderr-tail");`,
     );
     const manager = createProviderProcessManager({
       onProcessExit: exitInfo,
@@ -463,6 +466,244 @@ rl.on("line", (line) => {
     expect(Buffer.byteLength(stderrLines[0] ?? "", "utf8")).toBeLessThanOrEqual(
       4_000,
     );
+    await manager.shutdown();
+  });
+
+  it("drains provider stderr before reporting process exit", async () => {
+    const exitInfo = vi.fn<NonNullable<AgentRuntimeOptions["onProcessExit"]>>();
+    const crashScript = join(tmpDir, "delayed-stderr-provider.cjs");
+    const delayedWriter =
+      'setTimeout(() => process.stderr.write("stderr-after-exit"), 50);';
+    writeFileSync(
+      crashScript,
+      `const { spawn } = require("node:child_process");
+      const writer = spawn(process.execPath, ["-e", ${JSON.stringify(delayedWriter)}], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+      writer.unref();
+      process.exit(42);`,
+    );
+    const manager = createProviderProcessManager({
+      onProcessExit: exitInfo,
+      scriptPath: crashScript,
+      workspacePath: tmpDir,
+    });
+
+    await manager.ensureProvider({ processKey: "fake", providerId: "fake" });
+    await waitForRuntimeState({
+      label: "drained provider stderr exit callback",
+      predicate: () => exitInfo.mock.calls.length === 1,
+    });
+
+    expect(exitInfo.mock.calls[0]?.[0].stderr).toBe("stderr-after-exit");
+    await manager.shutdown();
+  });
+
+  it("does not wait for an already-exited provider during shutdown", async () => {
+    const crashScript = join(tmpDir, "open-stderr-provider.cjs");
+    const delayedWriter = "setTimeout(() => {}, 400);";
+    writeFileSync(
+      crashScript,
+      `const { spawn } = require("node:child_process");
+      const writer = spawn(process.execPath, ["-e", ${JSON.stringify(delayedWriter)}], {
+        stdio: ["ignore", "ignore", "inherit"],
+      });
+      writer.unref();
+      setTimeout(() => process.exit(42), 100);`,
+    );
+    const manager = createProviderProcessManager({
+      onProcessExit: vi.fn(),
+      scriptPath: crashScript,
+      workspacePath: tmpDir,
+    });
+
+    await manager.ensureProvider({ processKey: "fake", providerId: "fake" });
+    const providerProcess = manager.requireProviderProcess({
+      processKey: "fake",
+      providerId: "fake",
+    });
+    await once(providerProcess.child, "exit");
+
+    // A descendant still holds the stderr pipe open, so shutdown must not fall
+    // back to the multi-second SIGTERM/SIGKILL escalation for a process that
+    // has already exited.
+    const startedAt = Date.now();
+    await manager.shutdown();
+
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+  });
+
+  it("waits for an exited provider to finalize before replacing it", async () => {
+    const crashScript = join(tmpDir, "replace-after-stderr-provider.cjs");
+    const startMarker = join(tmpDir, "replace-after-stderr.started");
+    const delayedWriter = "setTimeout(() => {}, 400);";
+    writeFileSync(
+      crashScript,
+      `const { existsSync, writeFileSync } = require("node:fs");
+      const { spawn } = require("node:child_process");
+      const startMarker = ${JSON.stringify(startMarker)};
+      if (!existsSync(startMarker)) {
+        writeFileSync(startMarker, "started");
+        const writer = spawn(process.execPath, ["-e", ${JSON.stringify(delayedWriter)}], {
+          stdio: ["ignore", "ignore", "inherit"],
+        });
+        writer.unref();
+        setTimeout(() => process.exit(42), 100);
+      } else {
+        setInterval(() => {}, 1_000);
+      }`,
+    );
+    const manager = createProviderProcessManager({
+      onProcessExit: vi.fn(),
+      scriptPath: crashScript,
+      workspacePath: tmpDir,
+    });
+
+    await manager.ensureProvider({ processKey: "fake", providerId: "fake" });
+    const exitedProvider = manager.requireProviderProcess({
+      processKey: "fake",
+      providerId: "fake",
+    });
+    await once(exitedProvider.child, "exit");
+
+    await manager.ensureProvider({ processKey: "fake", providerId: "fake" });
+    const replacementProvider = manager.requireProviderProcess({
+      processKey: "fake",
+      providerId: "fake",
+    });
+    expect(replacementProvider.child.pid).not.toBe(exitedProvider.child.pid);
+    await manager.shutdown();
+  });
+
+  it("starts a single replacement for concurrent callers after an exit", async () => {
+    const crashScript = join(tmpDir, "concurrent-replace-provider.cjs");
+    const startsLog = join(tmpDir, "concurrent-replace.starts");
+    const delayedWriter = "setTimeout(() => {}, 400);";
+    writeFileSync(
+      crashScript,
+      `const { appendFileSync, readFileSync } = require("node:fs");
+      const { spawn } = require("node:child_process");
+      const startsLog = ${JSON.stringify(startsLog)};
+      appendFileSync(startsLog, process.pid + "\\n");
+      const isFirstStart =
+        readFileSync(startsLog, "utf8").trim().split("\\n").length === 1;
+      if (isFirstStart) {
+        const writer = spawn(process.execPath, ["-e", ${JSON.stringify(delayedWriter)}], {
+          stdio: ["ignore", "ignore", "inherit"],
+        });
+        writer.unref();
+        setTimeout(() => process.exit(42), 100);
+      } else {
+        setInterval(() => {}, 1_000);
+      }`,
+    );
+    const manager = createProviderProcessManager({
+      onProcessExit: vi.fn(),
+      scriptPath: crashScript,
+      workspacePath: tmpDir,
+    });
+
+    await manager.ensureProvider({ processKey: "fake", providerId: "fake" });
+    const exitedProvider = manager.requireProviderProcess({
+      processKey: "fake",
+      providerId: "fake",
+    });
+    await once(exitedProvider.child, "exit");
+
+    // Every caller waits on the same exit finalization, so each one resumes
+    // needing to re-check whether a peer already spawned the replacement.
+    await Promise.all([
+      manager.ensureProvider({ processKey: "fake", providerId: "fake" }),
+      manager.ensureProvider({ processKey: "fake", providerId: "fake" }),
+      manager.ensureProvider({ processKey: "fake", providerId: "fake" }),
+    ]);
+
+    const replacementProvider = manager.requireProviderProcess({
+      processKey: "fake",
+      providerId: "fake",
+    });
+    // The replacement records its own start asynchronously, so wait for it and
+    // then settle to give any extra spawn a chance to show up in the log.
+    await waitForRuntimeState({
+      label: "replacement provider recorded its start",
+      predicate: () => readLogLines(startsLog).length >= 2,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    expect(replacementProvider.child.pid).not.toBe(exitedProvider.child.pid);
+    expect(readLogLines(startsLog)).toHaveLength(2);
+    expect(manager.listRunningProviders()).toEqual(["fake"]);
+    await manager.shutdown();
+  });
+
+  it("cuts off inherited provider output before starting a replacement", async () => {
+    const crashScript = join(tmpDir, "stale-descendant-output-provider.cjs");
+    const startMarker = join(tmpDir, "stale-descendant-output.started");
+    const writeMarker = join(tmpDir, "stale-descendant-output.wrote");
+    // The descendant keeps holding both inherited pipes past the assertions
+    // below, so the pipes can only be closed by the grace-deadline cleanup
+    // rather than by the descendant itself exiting and letting them EOF.
+    const delayedWriter = `const fs = require("node:fs");
+      const writeMarker = ${JSON.stringify(writeMarker)};
+      setTimeout(() => {
+        fs.writeFileSync(writeMarker, "wrote");
+        process.stdout.write("stale-from-old-provider\\n");
+      }, 1_200);
+      setTimeout(() => process.exit(0), 5_000);`;
+    writeFileSync(
+      crashScript,
+      `const { existsSync, writeFileSync } = require("node:fs");
+      const { spawn } = require("node:child_process");
+      const startMarker = ${JSON.stringify(startMarker)};
+      if (!existsSync(startMarker)) {
+        writeFileSync(startMarker, "started");
+        const writer = spawn(process.execPath, ["-e", ${JSON.stringify(delayedWriter)}], {
+          stdio: ["ignore", "inherit", "inherit"],
+        });
+        writer.unref();
+        setTimeout(() => process.exit(42), 50);
+      } else {
+        setInterval(() => {}, 1_000);
+      }`,
+    );
+    const lines: Array<{ childPid: number | undefined; line: string }> = [];
+    const manager = createProviderProcessManager({
+      handleStdoutLine: (line, childPid) => lines.push({ childPid, line }),
+      onProcessExit: vi.fn(),
+      scriptPath: crashScript,
+      workspacePath: tmpDir,
+    });
+
+    await manager.ensureProvider({ processKey: "fake", providerId: "fake" });
+    const exitedProvider = manager.requireProviderProcess({
+      processKey: "fake",
+      providerId: "fake",
+    });
+    await once(exitedProvider.child, "exit");
+
+    await manager.ensureProvider({ processKey: "fake", providerId: "fake" });
+    const replacementProvider = manager.requireProviderProcess({
+      processKey: "fake",
+      providerId: "fake",
+    });
+    await waitForRuntimeState({
+      label: "old provider descendant attempted delayed output",
+      predicate: () => existsSync(writeMarker),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const exitedStdout = exitedProvider.child.stdout;
+    const exitedStderr = exitedProvider.child.stderr;
+    if (!exitedStdout || !exitedStderr) {
+      throw new Error("Expected provider process pipes");
+    }
+    expect(replacementProvider.child.pid).not.toBe(exitedProvider.child.pid);
+    expect(exitedStdout.destroyed).toBe(true);
+    expect(exitedStderr.destroyed).toBe(true);
+    expect(lines).not.toContainEqual({
+      childPid: exitedProvider.child.pid,
+      line: "stale-from-old-provider",
+    });
     await manager.shutdown();
   });
 
@@ -528,6 +769,7 @@ rl.on("line", (line) => {
       providerId: "fake",
     });
     replacementProcess.child.emit("exit", 64, null);
+    replacementProcess.child.emit("close", 64, null);
 
     await waitForRuntimeState({
       label: "unexpected replacement process exit",


### PR DESCRIPTION
Extracted from #1385 as a focused split: only the provider process shutdown/replacement race fixes, plus their regression tests. No Codex adapter, provisioning, schema, or docs changes ride along.

## The races

An exited provider process could corrupt the state of the session that replaced it. Three distinct races made that possible.

**1. Exit vs. close drain.** The manager finalized a provider on the child `exit` event. Node can emit `exit` before the final stdout/stderr bytes have been read from the pipes, so pending requests were rejected and exit diagnostics reported *without* the provider's last output — losing exactly the error text that explains why it died. Finalization now waits for `close` (stdio fully drained), bounded by a one-second grace deadline so a descendant that inherited a pipe cannot block finalization forever.

**2. Replacement synchronization.** A caller could observe an exited provider and start a replacement while the old process was still draining, briefly yielding two "current" providers for one process key. Provider entries now carry an explicit `exitFinalized` promise. The replacement, shutdown, and concurrent-start paths await it and then **re-check** whether another caller already created the replacement, so only one current provider exists.

**3. Stale stream output.** A descendant holding an inherited pipe could emit protocol messages after the replacement became current, injecting stale output into a fresh session. When the grace deadline expires the old readline interface is closed and both provider pipes destroyed; the stdout/stderr callbacks additionally verify their process is still current before forwarding anything.

## Two distinct issues behind the stderr test

These were initially conflated and are worth separating:

- **Fixture bug (test-only).** `bounds provider stderr while data arrives without a newline` fails deterministically on current `main`. The fake provider did `process.stderr.write(100KB)` then `process.exit(42)`. `process.exit()` discards Node's async-buffered pipe output, so the child attempted ~100,011 bytes but the parent only ever saw 65,536 — at *both* `exit` and `close`. No parent-side drain can recover bytes the child never wrote. Fixed by setting `process.exitCode = 42` and letting the process exit naturally.
- **Production bug (issue 1 above).** Genuinely separate. Verified by experiment: clean-`main` runtime + fixed fixture passes 3/3, so that test does *not* exercise the drain race. The production race is covered instead by `drains provider stderr before reporting process exit`, where a descendant writes to the inherited pipe 50 ms *after* the provider exits — an ordering that guarantees `exit` precedes the final data and that only the close/grace fix handles.

## Tests

Six regression tests in `runtime.process-lifecycle.test.ts`: final output after exit, concurrent replacement/start synchronization, descendant-held pipes, stale descendant output after replacement, stream destruction, and bounded cleanup.

Each was mutation-verified — every fix was individually reverted to confirm the corresponding test actually fails, rather than passing incidentally:

| Reverted fix | Failing test(s) |
| --- | --- |
| stream destruction | `cuts off inherited provider output…` |
| close/grace drain | `drains provider stderr…`, `cuts off inherited…` |
| `ensureProvider` synchronization | `waits for an exited provider…`, `starts a single replacement…`, `cuts off inherited…` |
| shutdown skip for exited process | `does not wait for an already-exited provider…` |

This caught two initially-weak assertions, which were then strengthened: the stream-destruction check passed incidentally because the descendant had already exited and let the pipes EOF naturally, and the shutdown test had no assertion at all and relied on vitest's ambient timeout.

## Scope

Product reliability change. **No database schema, migration, or Drizzle snapshot change. No host-daemon contract or protocol-version change** — verified by inspection: `RuntimeProviderProcess` never leaves `@bb/agent-runtime`, the new `exitFinalized` field is a `Promise` (inherently non-serializable), and the only production consumers of the adjusted `listRunningProviders()` are two host-local `length === 0` bookkeeping checks in `runtime-manager.ts` that are never serialized. `HOST_DAEMON_PROTOCOL_VERSION` is therefore deliberately unchanged.

## Validation

- `turbo run typecheck lint test --filter=@bb/agent-runtime --filter=@bb/host-daemon` — green (916 + 543 tests)
- `turbo run build` for both packages — green
- `runtime.process-lifecycle.test.ts` run 20× consecutively — 20/20, no flake
- Rebased onto latest `main` (`c288a199a`) and re-validated

> AGENT GENERATED: by Claude Opus 5
