### PR TITLE
Preserve native text selection in focused editors

### DIFF
--- a/apps/app/src/components/commands/AppCommandProvider.test.tsx
+++ b/apps/app/src/components/commands/AppCommandProvider.test.tsx
@@ -63,6 +63,19 @@ const testState = vi.hoisted(() => ({
       when: { all: ["mainSurface" as const], none: [] },
     },
     {
+      command: "thread.next" as const,
+      desktopOnly: false,
+      shortcut: {
+        key: "ArrowDown",
+        mod: true,
+        meta: false,
+        control: false,
+        alt: false,
+        shift: true,
+      },
+      when: { all: ["mainSurface" as const], none: [] },
+    },
+    {
       command: "thread.previous" as const,
       desktopOnly: true,
       shortcut: {
@@ -430,6 +443,60 @@ describe("AppCommandProvider", () => {
     });
     window.dispatchEvent(nativeTabShortcut);
     expect(nativeTabShortcut.defaultPrevented).toBe(false);
+  });
+
+  it.each([
+    ["thread.previous" as const, "ArrowUp"],
+    ["thread.next" as const, "ArrowDown"],
+  ])(
+    "leaves native %s selection to a focused editable control",
+    (command, key) => {
+      vi.spyOn(navigator, "platform", "get").mockReturnValue("MacIntel");
+      renderProvider(
+        <>
+          <Handler command={command} name={command} result={true} />
+          <textarea aria-label="Composer" defaultValue="alpha beta gamma" />
+        </>,
+      );
+      const composer = screen.getByLabelText("Composer");
+      composer.focus();
+      const event = new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        key,
+        metaKey: true,
+        shiftKey: true,
+      });
+
+      composer.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(testState.calls).toEqual([]);
+      expect(document.activeElement).toBe(composer);
+    },
+  );
+
+  it("still dispatches an ordinary app shortcut from a focused editable control", () => {
+    vi.spyOn(navigator, "platform", "get").mockReturnValue("MacIntel");
+    renderProvider(
+      <>
+        <Handler name="search" result={true} />
+        <textarea aria-label="Composer" />
+      </>,
+    );
+    const composer = screen.getByLabelText("Composer");
+    composer.focus();
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "k",
+      metaKey: true,
+    });
+
+    composer.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(testState.calls).toEqual(["search"]);
   });
 
   it("falls through declining handlers in priority order", () => {

--- a/apps/app/src/components/commands/AppCommandProvider.tsx
+++ b/apps/app/src/components/commands/AppCommandProvider.tsx
@@ -26,6 +26,7 @@ import {
   formatAppShortcut,
   formatAppShortcutAria,
   isEditableKeyboardTarget,
+  isNativeEditableKeyEvent,
   matchesAppCommandContext,
   type AppShortcutPresentation,
 } from "@/lib/app-keybindings";
@@ -285,6 +286,11 @@ export function AppCommandProvider({ children }: { children: ReactNode }) {
       if (event.defaultPrevented || event.isComposing || event.repeat) {
         return false;
       }
+      // Editable controls own semantic navigation and deletion keys. Their
+      // modifiers express native character/word/line/document behavior, so an
+      // app command customized onto the same chord must not preempt them. Other
+      // chords still dispatch before widget keymaps (the #1162 guarantee).
+      if (isNativeEditableKeyEvent(event)) return false;
       // A widget that dispatched first leaves the event alone when every
       // handler declines, so the same event still reaches the window listener.
       // Without this, those handlers would run a second time.

--- a/apps/app/src/components/promptbox/PromptBoxAppShortcuts.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxAppShortcuts.test.tsx
@@ -36,6 +36,32 @@ vi.mock("@/hooks/queries/system-queries", () => ({
       generalSettings: { ...defaultAppSettings },
       keybindings: [
         {
+          command: "thread.previous" as const,
+          desktopOnly: false,
+          shortcut: {
+            key: "ArrowUp",
+            mod: true,
+            meta: false,
+            control: false,
+            alt: false,
+            shift: true,
+          },
+          when: { all: ["mainSurface" as const], none: [] },
+        },
+        {
+          command: "thread.next" as const,
+          desktopOnly: false,
+          shortcut: {
+            key: "ArrowDown",
+            mod: true,
+            meta: false,
+            control: false,
+            alt: false,
+            shift: true,
+          },
+          when: { all: ["mainSurface" as const], none: [] },
+        },
+        {
           command: "sidebar.toggle" as const,
           desktopOnly: false,
           shortcut: testState.sidebarShortcut,
@@ -63,20 +89,32 @@ function SidebarToggleHandler() {
   return null;
 }
 
+function ThreadNavigationHandlers() {
+  useAppCommandHandler("thread.previous", () => {
+    testState.calls.push("thread.previous");
+    return true;
+  });
+  useAppCommandHandler("thread.next", () => {
+    testState.calls.push("thread.next");
+    return true;
+  });
+  return null;
+}
+
 function ShortcutHintState() {
   return (
     <span>{useIsAppCommandModifierHeld() ? "hint-held" : "hint-released"}</span>
   );
 }
 
-function renderComposer(extra: React.ReactNode = null) {
+function renderComposer(extra: React.ReactNode = null, value = "") {
   render(
     <MemoryRouter>
       <AppCommandProvider>
         <SidebarToggleHandler />
         {extra}
         <PromptBoxInternal
-          value=""
+          value={value}
           mentionRanges={[]}
           onChange={vi.fn()}
           onSubmit={vi.fn()}
@@ -115,8 +153,18 @@ function pressInEditor(
   return event;
 }
 
+function placeCaretAtBoundary(editor: HTMLElement, boundary: "start" | "end") {
+  const range = document.createRange();
+  range.selectNodeContents(editor);
+  range.collapse(boundary === "start");
+  const selection = document.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+}
+
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
   testState.calls.length = 0;
   testState.composerInputLocked = false;
   testState.sidebarHandlerResult = true;
@@ -131,6 +179,31 @@ afterEach(() => {
 });
 
 describe("prompt editor app shortcuts", () => {
+  it.each([
+    ["ArrowUp", "start", "end" as const],
+    ["ArrowDown", "end", "start" as const],
+  ])(
+    "leaves Meta+Shift+%s to extend selection toward the input %s",
+    (key, _targetBoundary, initialBoundary) => {
+      vi.spyOn(navigator, "platform", "get").mockReturnValue("MacIntel");
+      const editor = renderComposer(
+        <ThreadNavigationHandlers />,
+        "alpha\nbeta\ngamma",
+      );
+      placeCaretAtBoundary(editor, initialBoundary);
+
+      const event = pressInEditor(editor, {
+        key,
+        metaKey: true,
+        shiftKey: true,
+      });
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(testState.calls).toEqual([]);
+      expect(document.activeElement).toBe(editor);
+    },
+  );
+
   it("runs the sidebar shortcut while the composer has focus", () => {
     const editor = renderComposer();
 

--- a/apps/app/src/lib/app-keybindings.test.ts
+++ b/apps/app/src/lib/app-keybindings.test.ts
@@ -11,6 +11,7 @@ import {
   formatAppShortcut,
   formatAppShortcutAria,
   isEditableKeyboardTarget,
+  isNativeEditableKeyEvent,
   matchesAppCommandContext,
 } from "./app-keybindings";
 
@@ -179,6 +180,56 @@ describe("app keybindings", () => {
     expect(isEditableKeyboardTarget(document.createElement("button"))).toBe(
       false,
     );
+  });
+
+  it("recognizes native navigation and deletion keys in editable controls", () => {
+    const editor = document.createElement("div");
+    editor.setAttribute("contenteditable", "true");
+    document.body.append(editor);
+
+    for (const key of [
+      "ArrowDown",
+      "ArrowLeft",
+      "ArrowRight",
+      "ArrowUp",
+      "Backspace",
+      "Delete",
+      "End",
+      "Home",
+      "PageDown",
+      "PageUp",
+    ]) {
+      const event = new KeyboardEvent("keydown", {
+        altKey: true,
+        bubbles: true,
+        ctrlKey: true,
+        key,
+        metaKey: true,
+        shiftKey: true,
+      });
+      editor.dispatchEvent(event);
+      expect(isNativeEditableKeyEvent(event), key).toBe(true);
+    }
+
+    const formattingEvent = new KeyboardEvent("keydown", {
+      bubbles: true,
+      key: "B",
+      metaKey: true,
+      shiftKey: true,
+    });
+    editor.dispatchEvent(formattingEvent);
+    expect(isNativeEditableKeyEvent(formattingEvent)).toBe(false);
+
+    const outsideEvent = new KeyboardEvent("keydown", {
+      bubbles: true,
+      key: "ArrowUp",
+      metaKey: true,
+      shiftKey: true,
+    });
+    document.body.dispatchEvent(outsideEvent);
+    expect(isNativeEditableKeyEvent(outsideEvent)).toBe(false);
+
+    editor.remove();
   });
 
   it("formats platform-specific shortcut labels", () => {

--- a/apps/app/src/lib/app-keybindings.ts
+++ b/apps/app/src/lib/app-keybindings.ts
@@ -6,6 +6,19 @@ export interface AppShortcutPresentation {
   label: string;
 }
 
+const NATIVE_EDITING_KEYS = new Set([
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "Backspace",
+  "Delete",
+  "End",
+  "Home",
+  "PageDown",
+  "PageUp",
+]);
+
 export function isEditableKeyboardTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) {
     return false;
@@ -19,6 +32,18 @@ export function isEditableKeyboardTarget(target: EventTarget | null): boolean {
   }
   return (
     target.closest('[contenteditable]:not([contenteditable="false"])') !== null
+  );
+}
+
+/**
+ * Navigation and deletion keys keep their native editable-control behavior
+ * regardless of modifiers. This covers each platform's character, word,
+ * line, and document movement/selection chords without tying arbitration to
+ * any configurable app shortcut.
+ */
+export function isNativeEditableKeyEvent(event: KeyboardEvent): boolean {
+  return (
+    isEditableKeyboardTarget(event.target) && NATIVE_EDITING_KEYS.has(event.key)
   );
 }
 


### PR DESCRIPTION
Fixes #1397

## Root cause

This is the regression created by #1166's app-first composer dispatch. `PromptBoxInternal` offers each keydown to `AppCommandProvider` before TipTap or the browser handles it, so `Mod+Shift+ArrowUp/ArrowDown` matched `thread.previous/next`, stopped propagation, and navigated before native selection could run. The later window listener was not the winning layer.

## Implementation

- Treat semantic navigation and deletion keys from an editable target as owned by that target, regardless of modifier combination.
- Keep arbitration independent of command IDs and configured shortcut literals, so user-customized bindings follow the same rule.
- Cover arrows, Home/End, PageUp/PageDown, Backspace, and Delete. This preserves character-, word-, line-, document-, and page-wise navigation/selection and deletion conventions across macOS, Windows, and Linux.
- Preserve #1162: non-editing app chords still dispatch before the editor keymap, including `Mod+Shift+B` when rebound to an app command.

## Validation

- Reproduced both directions on clean `origin/main`: the route changed threads and the selection stayed empty.
- Live dev-app QA after the fix: `Cmd+Shift+Up/Down` selected the full multiline draft in both directions, kept editor focus, and stayed on the same thread.
- Live dev-app QA for #1162: the ordinary sidebar shortcut fired with composer focus; after rebinding it to `Mod+Shift+B`, it still toggled the sidebar instead of creating a blockquote.
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app --force` — 336 files, 2,546 tests passed
- `pnpm exec turbo run lint --filter=@bb/app` — 0 errors

> AGENT GENERATED: by GPT-5 Codex
