### PR TITLE
Stabilize QA tests and correct the manual runbooks

### DIFF
--- a/apps/server/test/services/database-maintenance-sweep.test.ts
+++ b/apps/server/test/services/database-maintenance-sweep.test.ts
@@ -26,7 +26,10 @@ import { runDatabaseMaintenanceSweep } from "../../src/services/system/periodic-
 import { testLogger } from "../helpers/test-app.js";
 
 const ONE_HOUR_MS = 60 * 60_000;
-const SWEEP_TIME_START_MS = 1_000_000_000_000;
+// The non-isolated server project shares the production module's last-sweep
+// clock across files. Start beyond wall time so another test that uses
+// Date.now() cannot make these synthetic sweeps look too early.
+const SWEEP_TIME_START_MS = Date.now() + 24 * ONE_HOUR_MS;
 const FREELIST_ROW_COUNT = 1_200;
 const SQLITE_BUSY_HEADROOM_MS = 1_000;
 const TEST_DEFERRED_LEGACY_TABLE_NAMES = [

--- a/plugins/docs/server.test.ts
+++ b/plugins/docs/server.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, expectTypeOf, it } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import { defineRpcContract } from "@bb/plugin-sdk";
 import type { PluginRpcClient, PluginRpcHandlers } from "@bb/plugin-sdk";
 import { createFakePluginHost } from "@bb/plugin-sdk/testing";
@@ -22,7 +22,10 @@ afterEach(async () => {
   );
 });
 
-async function loadNotebook(notes: Record<string, string>) {
+async function loadNotebook(
+  notes: Record<string, string>,
+  watchVault?: NonNullable<Parameters<typeof simpleNotes>[1]>,
+) {
   const directory = await mkdtemp(path.join(os.tmpdir(), "bb-simple-notes-"));
   temporaryDirectories.push(directory);
   await Promise.all(
@@ -72,7 +75,7 @@ async function loadNotebook(notes: Record<string, string>) {
       hosts: { list: async () => [] },
     },
   });
-  await simpleNotes(host.bb);
+  await simpleNotes(host.bb, watchVault);
   host.bb.storage
     .database()
     .prepare("UPDATE vaults SET root_path = ? WHERE id = 'personal'")
@@ -1053,25 +1056,43 @@ describe("Docs vault operations", () => {
     ]);
   });
 
-  it("publishes native filesystem changes without waiting for the poll", async () => {
-    const { harness } = await loadNotebook({ "plan.md": "# Plan" });
+  it("publishes watched filesystem changes without waiting for the poll", async () => {
+    const changeListeners: Array<() => void> = [];
+    const closeWatcher = vi.fn();
+    const watchedRoots: string[] = [];
+    const { harness } = await loadNotebook(
+      { "plan.md": "# Plan" },
+      (rootPath, onChange) => {
+        watchedRoots.push(rootPath);
+        changeListeners.push(onChange);
+        return {
+          close: closeWatcher,
+          on: () => undefined,
+        };
+      },
+    );
     const service = harness.runService("watch-vaults");
     try {
-      await writeFile(
-        path.join(temporaryDirectories[0]!, "plan.md"),
-        "# Changed outside Docs",
-      );
-      await waitForSignal(() =>
-        harness.realtimeSignals.some(
-          (signal) =>
-            signal.channel === "vault-changed" &&
-            isRecord(signal.payload) &&
-            signal.payload.vaultId === "personal",
-        ),
+      expect(watchedRoots).toEqual([temporaryDirectories[0]]);
+      const notifyChange = changeListeners[0];
+      if (!notifyChange) {
+        throw new Error("Expected vault watcher callback");
+      }
+      notifyChange();
+      await waitForSignal(
+        () =>
+          harness.realtimeSignals.some(
+            (signal) =>
+              signal.channel === "vault-changed" &&
+              isRecord(signal.payload) &&
+              signal.payload.vaultId === "personal",
+          ),
+        1_000,
       );
     } finally {
       service.controller.abort();
       await service.done;
     }
+    expect(closeWatcher).toHaveBeenCalledOnce();
   });
 });

--- a/plugins/docs/server.ts
+++ b/plugins/docs/server.ts
@@ -1,5 +1,5 @@
 // Docs — filesystem-first, multi-host Markdown and HTML vaults.
-import { watch, type FSWatcher } from "node:fs";
+import { watch } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { parseMarkdownDocument } from "./markdown-document.js";
@@ -64,6 +64,23 @@ interface Vault {
   hostId: string | null;
   rootPath: string;
 }
+
+interface VaultWatcher {
+  close(): void;
+  on(event: "error", listener: () => void): void;
+}
+
+type WatchVault = (rootPath: string, onChange: () => void) => VaultWatcher;
+
+const watchNativeVault: WatchVault = (rootPath, onChange) => {
+  const watcher = watch(rootPath, { recursive: true }, onChange);
+  return {
+    close: () => watcher.close(),
+    on: (event, listener) => {
+      watcher.on(event, listener);
+    },
+  };
+};
 
 interface VaultEntry {
   kind: "file" | "directory";
@@ -760,7 +777,10 @@ function waitForDelay(ms: number, signal: AbortSignal): Promise<void> {
   });
 }
 
-export default async function plugin(bb: BbPluginApi) {
+export default async function plugin(
+  bb: BbPluginApi,
+  watchVault: WatchVault = watchNativeVault,
+) {
   const db = bb.storage.database();
   bb.storage.migrate(db, [
     `CREATE TABLE IF NOT EXISTS vaults (
@@ -2872,7 +2892,7 @@ export default async function plugin(bb: BbPluginApi) {
 
   bb.background.service("watch-vaults", {
     async start(signal) {
-      const watchers = new Map<string, FSWatcher>();
+      const watchers = new Map<string, VaultWatcher>();
       const retryNative = new Set<string>();
       let debounce: NodeJS.Timeout | null = null;
       let previous = "";
@@ -2891,7 +2911,7 @@ export default async function plugin(bb: BbPluginApi) {
           for (const vault of vaults) {
             if (vault.hostId || watchers.has(vault.id)) continue;
             try {
-              const watcher = watch(vault.rootPath, { recursive: true }, () => {
+              const watcher = watchVault(vault.rootPath, () => {
                 if (debounce) clearTimeout(debounce);
                 debounce = setTimeout(() => {
                   bb.realtime.publish("vault-changed", {

--- a/qa/manual-runbook.md
+++ b/qa/manual-runbook.md
@@ -777,14 +777,18 @@ curl -fsS "$BB_SERVER_URL/api/v1/environments/$PROVIDER_WORKTREE_ENV_ID/status" 
 Run a pending-interaction pass with permission-restricted turns:
 
 ```bash
+# Codex sandboxes commonly permit the OS temp directory. Put the disposable
+# target under the user home so it is reliably outside the managed worktree.
+APPROVAL_DIR=$(mktemp -d "${HOME:?}/.bb-approval-smoke.XXXXXX")
+APPROVAL_FILE="$APPROVAL_DIR/approval-smoke.txt"
 APPROVAL_THREAD_ID=$(bb thread spawn \
   --project "$BB_PROJECT_ID" \
   --provider codex \
   --model "$CODEX_MODEL" \
   --reasoning-level low \
   --new-environment worktree \
-  --permission-mode readonly \
-  --prompt "Run this exact shell command: printf 'APPROVED' > approval-smoke.txt. If approval is needed, request approval. After the command finishes, reply with exactly DONE." \
+  --permission-mode accept-edits \
+  --prompt "Run this exact shell command: printf 'APPROVED' > '$APPROVAL_FILE'. If approval is needed, request approval. After the command finishes, reply with exactly DONE." \
   --json | jq -r '.id')
 
 APPROVAL_INTERACTION_ID=
@@ -810,19 +814,22 @@ bb thread interactions approve "$APPROVAL_INTERACTION_ID" "$APPROVAL_THREAD_ID"
 bb thread wait "$APPROVAL_THREAD_ID" --status idle --timeout 180
 bb thread output "$APPROVAL_THREAD_ID"
 bb thread interactions list "$APPROVAL_THREAD_ID" --json | jq
+test "$(cat "$APPROVAL_FILE")" = "APPROVED"
 ```
 
 Verify denial handling with a separate interaction:
 
 ```bash
+DENY_DIR=$(mktemp -d "${HOME:?}/.bb-denial-smoke.XXXXXX")
+DENY_FILE="$DENY_DIR/denied-smoke.txt"
 DENY_THREAD_ID=$(bb thread spawn \
   --project "$BB_PROJECT_ID" \
   --provider codex \
   --model "$CODEX_MODEL" \
   --reasoning-level low \
   --new-environment worktree \
-  --permission-mode readonly \
-  --prompt "Run this exact shell command: printf 'DENIED' > denied-smoke.txt. If approval is denied, reply with exactly DENIED." \
+  --permission-mode accept-edits \
+  --prompt "Run this exact shell command: printf 'DENIED' > '$DENY_FILE'. If approval is denied, reply with exactly DENIED." \
   --json | jq -r '.id')
 
 DENY_INTERACTION_ID=
@@ -843,6 +850,7 @@ else
   bb thread show "$DENY_THREAD_ID"
 fi
 bb thread log "$DENY_THREAD_ID" --format json | jq '.[-12:]'
+test ! -e "$DENY_FILE"
 ```
 
 For `claude-code`, also verify grant semantics with a permission-grant interaction:
@@ -854,8 +862,8 @@ GRANT_THREAD_ID=$(bb thread spawn \
   --model "$CLAUDE_MODEL" \
   --reasoning-level low \
   --new-environment worktree \
-  --permission-mode workspace-write \
-  --prompt "Use the Read tool to read /etc/hosts, then reply with exactly the first non-empty line from the file and nothing else." \
+  --permission-mode accept-edits \
+  --prompt "Use WebFetch to fetch https://example.com, then reply with exactly GRANTED." \
   --json | jq -r '.id')
 
 GRANT_INTERACTION_ID=
@@ -872,11 +880,16 @@ bb thread interactions show "$GRANT_INTERACTION_ID" "$GRANT_THREAD_ID"
 bb thread interactions grant "$GRANT_INTERACTION_ID" "$GRANT_THREAD_ID" --scope turn
 bb thread wait "$GRANT_THREAD_ID" --status idle --timeout 180
 bb thread output "$GRANT_THREAD_ID"
+
+rm -f "$APPROVAL_FILE" "$DENY_FILE"
+rmdir "$APPROVAL_DIR" "$DENY_DIR"
 ```
 
 Expected result:
 
-- Permission-restricted turns surface pending interactions through `bb thread interactions list/show`.
+- `accept-edits` turns allow workspace changes but surface pending interactions
+  for the explicit outside-workspace probes through `bb thread interactions
+  list/show`.
 - `bb thread tell` is rejected while the thread is awaiting user interaction.
 - `approve`, `deny`, and `grant` resolve their matching interaction kinds.
 - Approved/granted threads continue to `idle`; denied threads either reply with the denial handling text or clearly record the denied approval in the log.

--- a/qa/manual-runbook.md
+++ b/qa/manual-runbook.md
@@ -97,6 +97,7 @@ jq . "$STATE_PATH"
 SERVER_DB_PATH=$(jq -er '.server.dataDir + "/bb.db"' "$STATE_PATH")
 SERVER_LOG_DIR=$(jq -er '(.paths.serverDataDir // .server.dataDir) + "/logs"' "$STATE_PATH")
 DAEMON_LOG_DIR=$(jq -er '(.paths.daemonDataDir // .daemon.dataDir) + "/logs"' "$STATE_PATH")
+DAEMON_RESTART_PID_PATH=$(jq -er '.paths.daemonRestartPidPath' "$STATE_PATH")
 
 bb() { node apps/cli/dist/index.js "$@"; }
 ```
@@ -555,7 +556,7 @@ curl -fsS "$BB_SERVER_URL/api/v1/system/config" | jq
 curl -fsS "$BB_SERVER_URL/api/v1/hosts" | jq
 
 eval "$RESTART_DAEMON_COMMAND"
-DAEMON_PID=$!
+DAEMON_PID=$(cat "$DAEMON_RESTART_PID_PATH")
 
 curl -fsS "$BB_SERVER_URL/api/v1/hosts" | jq
 bb thread tell "$SMOKE_THREAD_ID" "Check recovery after daemon restart"
@@ -597,7 +598,7 @@ for _ in $(seq 1 60); do
 done
 
 eval "$RESTART_DAEMON_COMMAND"
-DAEMON_PID=$!
+DAEMON_PID=$(cat "$DAEMON_RESTART_PID_PATH")
 
 curl -fsS "$BB_SERVER_URL/api/v1/environments/$SERVER_RESTART_ENV_ID" | jq
 bb thread show "$SERVER_RESTART_THREAD_ID"
@@ -632,7 +633,7 @@ else
 fi
 
 eval "$RESTART_DAEMON_COMMAND"
-DAEMON_PID=$!
+DAEMON_PID=$(cat "$DAEMON_RESTART_PID_PATH")
 bb thread tell "$SMOKE_THREAD_ID" "Say exactly: offline retry ok"
 bb thread wait "$SMOKE_THREAD_ID" --status idle --timeout 120
 bb thread output "$SMOKE_THREAD_ID"
@@ -660,7 +661,7 @@ HOT_REPLACE_THREAD_ID=$(bb thread spawn \
 bb thread wait "$HOT_REPLACE_THREAD_ID" --status active --timeout 30
 OLD_DAEMON_PID=$DAEMON_PID
 eval "$RESTART_DAEMON_COMMAND"
-DAEMON_PID=$!
+DAEMON_PID=$(cat "$DAEMON_RESTART_PID_PATH")
 test "$DAEMON_PID" != "$OLD_DAEMON_PID"
 
 curl -fsS "$BB_SERVER_URL/api/v1/hosts" | jq
@@ -687,7 +688,7 @@ kill -TERM "$DAEMON_PID"
 bb thread show "$SMOKE_THREAD_ID"
 
 eval "$RESTART_DAEMON_COMMAND"
-DAEMON_PID=$!
+DAEMON_PID=$(cat "$DAEMON_RESTART_PID_PATH")
 
 THREAD_STATE=$(curl -fsS "$BB_SERVER_URL/api/v1/threads/$SMOKE_THREAD_ID" | jq -r '.status')
 

--- a/qa/manual-runbook.md
+++ b/qa/manual-runbook.md
@@ -419,6 +419,15 @@ bb thread show "$DIRTY_ARCHIVE_THREAD_ID" --work-status
 bb thread archive "$DIRTY_ARCHIVE_THREAD_ID"
 
 curl -fsS "$BB_SERVER_URL/api/v1/threads/$DIRTY_ARCHIVE_THREAD_ID" | jq -e '.archivedAt != null'
+DIRTY_ARCHIVE_ENV_STATUS=$(curl -fsS "$BB_SERVER_URL/api/v1/environments/$DIRTY_ARCHIVE_ENV_ID" | jq -r '.status')
+test "$DIRTY_ARCHIVE_ENV_STATUS" = "retiring"
+test -e "$DIRTY_ARCHIVE_ENV_PATH"
+
+# A last-live archived managed environment remains revivable during the five-minute
+# archive grace period. Permanently deleting the thread removes that revival path
+# and makes the environment immediately eligible for destruction.
+bb thread delete "$DIRTY_ARCHIVE_THREAD_ID" --yes
+
 for i in $(seq 1 60); do
   DIRTY_ARCHIVE_ENV_STATUS=$(curl -fsS "$BB_SERVER_URL/api/v1/environments/$DIRTY_ARCHIVE_ENV_ID" | jq -r '.status')
   test "$DIRTY_ARCHIVE_ENV_STATUS" = "destroyed" && break
@@ -435,7 +444,7 @@ Expected result:
 - `bb environment commit` succeeds with helper-generated commit text without requiring `OPENAI_API_KEY`.
 - Environment merge-base metadata can be set, reflected by `bb environment show`, used by thread status/diff output, and cleared.
 - Archiving blocks `bb thread tell`; unarchiving restores normal operation.
-- Dirty isolated managed worktree archive succeeds, destroys the environment, and removes the worktree even while uncommitted or unmerged work remains.
+- Archiving the last live dirty managed worktree puts it in `retiring` and preserves it during the undo grace period; permanently deleting its archived thread then destroys the environment and removes the worktree even while uncommitted or unmerged work remains.
 
 ## Multi-Thread and Shared Environment
 

--- a/qa/manual-runbook.md
+++ b/qa/manual-runbook.md
@@ -564,55 +564,63 @@ bb thread wait "$SMOKE_THREAD_ID" --status idle --timeout 120
 bb thread output "$SMOKE_THREAD_ID"
 ```
 
-Server restart during environment provisioning:
+Provisioning failure and next-message retry:
 
 ```bash
-SERVER_RESTART_THREAD_ID=$(bb thread spawn \
+# Commit a supported setup hook that fails exactly once across worktrees in the
+# disposable repository. The marker lives in the shared Git directory, so the
+# first failed worktree can be removed without losing it.
+cat > "$PROJECT_ROOT/.bb-env-setup.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+MARKER="$(git rev-parse --path-format=absolute --git-common-dir)/bb-qa-provision-failed-once"
+if [ ! -e "$MARKER" ]; then
+  touch "$MARKER"
+  echo "intentional one-time QA setup failure" >&2
+  exit 42
+fi
+EOF
+git -C "$PROJECT_ROOT" add .bb-env-setup.sh
+git -C "$PROJECT_ROOT" commit -m "qa: fail one worktree setup"
+
+PROVISION_RETRY_THREAD_ID=$(bb thread spawn \
   --project "$BB_PROJECT_ID" \
   --provider codex \
   --model "$CODEX_MODEL" \
   --reasoning-level low \
   --new-environment worktree \
-  --prompt "Say exactly: server restart provisioning recovery" \
+  --prompt "Say exactly: initial provisioning should fail" \
   --json | jq -r '.id')
 
-SERVER_RESTART_ENV_ID=$(curl -fsS "$BB_SERVER_URL/api/v1/threads/$SERVER_RESTART_THREAD_ID" | jq -er '.environmentId')
-for _ in $(seq 1 60); do
-  ENV_STATUS=$(curl -fsS "$BB_SERVER_URL/api/v1/environments/$SERVER_RESTART_ENV_ID" | jq -r '.status')
-  [ "$ENV_STATUS" = "provisioning" ] && break
-  sleep 1
-done
-test "$ENV_STATUS" = "provisioning"
+bb thread wait "$PROVISION_RETRY_THREAD_ID" --status error --timeout 120
+PROVISION_RETRY_ENV_ID=$(curl -fsS "$BB_SERVER_URL/api/v1/threads/$PROVISION_RETRY_THREAD_ID" | jq -er '.environmentId')
+curl -fsS "$BB_SERVER_URL/api/v1/environments/$PROVISION_RETRY_ENV_ID" | jq -e '.status == "error"'
+bb thread log "$PROVISION_RETRY_THREAD_ID" --format json \
+  | jq -e 'any(.[]; .type == "system/error" and (.data.code // .code // null) == "thread_provisioning_failed")'
 
-kill -TERM "$SERVER_PID"
-while kill -0 "$SERVER_PID" 2>/dev/null; do sleep 1; done
+# Retry only after the first provisioning RPC has completed as a real failure.
+# This next message starts a fresh provision; it does not recover an in-flight
+# RPC or rely on a persisted provisioning-attempt identifier.
+bb thread tell "$PROVISION_RETRY_THREAD_ID" "Say exactly: provisioning retry ok" --mode auto
+bb thread wait "$PROVISION_RETRY_THREAD_ID" --status idle --timeout 180
+bb thread output "$PROVISION_RETRY_THREAD_ID"
+curl -fsS "$BB_SERVER_URL/api/v1/environments/$PROVISION_RETRY_ENV_ID" | jq -e '.status == "ready"'
 
-BB_DATA_DIR=$(jq -er '.server.dataDir' "$STATE_PATH") \
-BB_SERVER_PORT=$(jq -er '.server.port' "$STATE_PATH") \
-node apps/server/dist/index.js >> "$(jq -er '.server.logPath' "$STATE_PATH")" 2>&1 &
-SERVER_PID=$!
-
-for _ in $(seq 1 60); do
-  curl -fsS "$BB_SERVER_URL/api/v1/system/config" >/dev/null && break
-  sleep 1
-done
-
-eval "$RESTART_DAEMON_COMMAND"
-DAEMON_PID=$(cat "$DAEMON_RESTART_PID_PATH")
-
-curl -fsS "$BB_SERVER_URL/api/v1/environments/$SERVER_RESTART_ENV_ID" | jq
-bb thread show "$SERVER_RESTART_THREAD_ID"
-bb thread log "$SERVER_RESTART_THREAD_ID" --format json | jq '.[-12:]'
+PROVISION_RETRY_MARKER="$(git -C "$PROJECT_ROOT" rev-parse --path-format=absolute --git-common-dir)/bb-qa-provision-failed-once"
+rm -f "$PROVISION_RETRY_MARKER"
+git -C "$PROJECT_ROOT" rm .bb-env-setup.sh
+git -C "$PROJECT_ROOT" commit -m "qa: remove one-time setup failure"
 ```
 
 Expected result:
 
-- The server restarts with the same data directory and the daemon reconnects.
-- The in-flight environment provision is not replayed from a durable queue.
-- If the live RPC result was lost, the environment/thread reaches an honest
-  `error` or retryable interrupted state, with a system error explaining that
-  the server restarted before live provisioning completed.
-- The operator can retry by sending a new turn after the host is connected.
+- The first setup hook failure completes with the thread and environment in
+  `error` and records `thread_provisioning_failed`.
+- Sending the next message with `--mode auto` starts a fresh provisioning
+  attempt for the same thread and environment, which reaches `ready` before the
+  turn runs.
+- Nothing in this scenario promises recovery of an in-flight provisioning RPC
+  across a server restart.
 
 Host offline before send:
 
@@ -888,8 +896,8 @@ rmdir "$APPROVAL_DIR" "$DENY_DIR"
 Expected result:
 
 - `accept-edits` turns allow workspace changes but surface pending interactions
-  for the explicit outside-workspace probes through `bb thread interactions
-  list/show`.
+  for the explicit outside-workspace probes; inspect them with
+  `bb thread interactions list/show`.
 - `bb thread tell` is rejected while the thread is awaiting user interaction.
 - `approve`, `deny`, and `grant` resolve their matching interaction kinds.
 - Approved/granted threads continue to `idle`; denied threads either reply with the denial handling text or clearly record the denied approval in the log.

--- a/qa/provider-permission-mode-runbook.md
+++ b/qa/provider-permission-mode-runbook.md
@@ -1,71 +1,54 @@
 # Provider Permission Mode QA Runbook
 
-This runbook covers provider x permission-mode diagnostics for Codex and Claude
-Code. It is intended for validating BB runtime policy, provider translation, and
-managed-worktree behavior after changes to provider setup, sandbox construction,
-tool policy, or default execution policy.
+This runbook covers provider-by-permission-mode diagnostics for Codex and
+Claude Code. Use it after changes to runtime policy, provider translation,
+sandbox construction, managed-worktree Git roots, or execution defaults.
 
 ## Scope
 
-Providers under test:
+Exercise the public permission modes:
 
-- `codex`
-- `claude-code`
+- `accept-edits`: workspace sandboxing with user-reviewed escalation
+- `auto`: the same workspace sandbox with provider-native automatic review
+- `full`: explicit sandbox and approval bypass
 
-Permission modes under test:
+Run all three modes for `codex` and `claude-code`. Pi currently supports `full`
+only; keep its unsupported-mode coverage in server/runtime tests unless its
+advertised capabilities change.
 
-- `readonly`
-- `workspace-write`
-- `full`
+The matrix checks:
 
-Pi currently supports `full` only. Confirm that unsupported Pi permission modes
-are rejected by existing server/runtime tests; do not include Pi in this matrix
-unless its advertised capabilities change.
-
-Core behaviors under test:
-
-- shell availability
-- read-only Git commands: `status`, `diff`, `show`, `merge-base`
-- readonly Bash policy negative checks: shell metacharacters, env-prefix
-  commands, mutating Git subcommands, and path-reading options such as
-  `git blame --contents`
-- file reads
+- shell and file-read availability
+- read-only Git inspection (`status`, `merge-base`, `diff`, and `show`)
 - workspace file writes
-- Git index writes and cleanup
-- commit capability in a disposable QA worktree
-- BB CLI read commands where the mode can safely allow local CLI access
-- subagent/delegation availability where expected
-- expected failures for each permission mode
+- linked-worktree Git index writes and cleanup
+- commits in a disposable QA repository
+- BB CLI reads
+- subagent/delegation availability
+- escalation behavior for an outside-workspace write
 
 ## Prerequisites
 
-Build the runtime artifacts:
+Build through Turbo, clear any ambient generic OpenAI API-key route, and start
+an isolated server/daemon pair:
 
 ```bash
-pnpm build
-```
-
-Verify provider CLIs and support tools:
-
-```bash
+pnpm exec turbo run build
 codex --help
 claude --help
 jq --help
 git --version
-```
 
-Start an isolated standalone server and daemon:
-
-```bash
+unset OPENAI_API_KEY
 pnpm qa:standalone:cleanup
 eval "$(pnpm --silent qa:standalone:start --format env)"
-alias bb="node apps/cli/dist/index.js"
+bb() { node apps/cli/dist/index.js "$@"; }
 
 bb status
 bb provider list
 ```
 
-Resolve models:
+Resolve subscription-backed models from the live provider catalogs:
 
 ```bash
 CODEX_MODEL=$(bb provider models codex --json | jq -er '([.[] | select(.isDefault)][0].model // .[0].model)')
@@ -74,163 +57,135 @@ CLAUDE_MODEL=$(bb provider models claude-code --json | jq -er '([.[] | select(.m
 printf 'codex: %s\nclaude-code: %s\n' "$CODEX_MODEL" "$CLAUDE_MODEL"
 ```
 
-Use isolated managed worktrees for the matrix. Do not run write probes in a
-developer's main product worktree.
+Use only isolated managed worktrees for mutation probes. The standalone project
+is disposable; never run these prompts in a developer's product worktree.
 
 ## Expected Semantics
 
-`readonly`:
+`accept-edits`:
 
-- MUST allow file reads.
-- MUST allow enough read-only Git inspection for code review: `git status`,
-  `git merge-base`, `git diff`, and `git show`.
-- SHOULD allow delegation/subagents for read-only analysis if the provider can
-  keep child activity under the same readonly policy.
-- MUST reject workspace writes, Git index writes, commits, destructive shell
-  commands, network access, and mutating BB CLI commands.
-- MUST reject shell command injection shapes, env-prefix command forms, and Git
-  options that read arbitrary paths outside the workspace, including
-  `git blame --contents`.
-- BB CLI read commands are optional in readonly. If the provider cannot prove
-  they are non-mutating, they should be blocked and review prompts should use
-  read-only Git instead.
+- MUST allow reads, shell commands, and writes inside the assigned workspace.
+- MUST allow the minimal linked-worktree Git metadata writes required for
+  `git add`, `git reset`, and commits in that workspace.
+- MUST keep outside-workspace and network escalation user-reviewed. A
+  deterministic outside-workspace command should create a pending interaction.
+- MUST NOT silently widen to unrestricted host access.
 
-`workspace-write`:
+`auto`:
 
-- MUST allow file reads.
-- MUST allow shell and read-only Git inspection.
-- MUST allow writes inside the assigned workspace.
-- MUST allow Git index writes and commits for the assigned worktree, including
-  managed worktrees whose `.git` file points outside the workspace root.
-- MUST reject writes outside the workspace except the minimal linked-worktree
-  Git metadata needed by that workspace.
-- SHOULD allow subagents/delegation for implementation and review workflows.
-- SHOULD allow BB CLI read commands. Mutating BB CLI commands are out of scope
-  unless explicitly part of the workflow being tested.
+- MUST provide the same workspace and linked-worktree boundaries as
+  `accept-edits`.
+- MUST route provider-generated approval decisions through the provider-native
+  automatic reviewer instead of pausing for a BB user interaction.
+- MAY allow or deny an escalated operation according to that reviewer, but the
+  result and review events must be visible in the thread log.
 
 `full`:
 
-- MUST allow shell, file reads, workspace writes, Git index writes, commits,
-  BB CLI access, and subagents/delegation.
-- Use only in disposable QA environments or when the test explicitly requires
-  unrestricted host access.
+- MUST allow shell, reads, workspace writes, Git index writes, commits, BB CLI
+  access, and supported delegation without approval prompts.
+- Use it only in the disposable standalone environment.
 
-## Probe Prompt
+## Common Workspace Probe
 
-Spawn one thread per provider/mode with this prompt. Keep the prompt identical
-except for the expected mode label.
+Create one prompt per provider/mode by replacing `PROVIDER` and `MODE`:
 
 ```text
 You are running a BB provider permission-mode probe for PROVIDER MODE.
 
 Rules:
-- Do not modify product files.
-- Use only a temp file named .bb-permission-probe in the workspace root for write/index tests.
-- Clean up the temp file before finishing.
-- Report exact command results, including command text, exit status, stdout/stderr summary, and whether the result matched the expected mode.
-- If a tool is unavailable, report the exact denial text.
+- Work only in the assigned disposable worktree.
+- Use only .bb-permission-probe for file/index tests and remove it afterward.
+- Report each command, exit status, and whether it matched MODE semantics.
+- If a tool is unavailable or an operation is denied, include the exact error.
 
-Step 1: Report the workspace path and the contents of .git if it is a file.
-For Claude Code readonly, read .git with the Read tool; do not use shell
-conditionals, head, pipes, redirection, semicolons, or combined Bash commands.
+1. Report the workspace path and the contents of .git if it is a file.
+2. Run these read-only checks separately:
+   - pwd
+   - git status --short
+   - git --no-optional-locks status --short
+   - git merge-base main HEAD
+   - git diff --stat main...HEAD
+   - git show --stat --oneline -1 HEAD
+3. Read the first 20 lines of AGENTS.md or package.json.
+4. Run `bb status` and, when BB_THREAD_ID is present,
+   `bb thread show "$BB_THREAD_ID"`.
+5. If supported, ask one helper/subagent to report the current directory and
+   whether `git status --short` succeeds.
+6. Run:
+   - printf 'permission probe\n' > .bb-permission-probe
+   - git status --short .bb-permission-probe
+   - git add .bb-permission-probe
+   - git reset -- .bb-permission-probe
+   - rm .bb-permission-probe
+   - git status --short .bb-permission-probe
 
-Step 2: Test read-only shell and Git commands:
-- pwd
-- git status --short
-- git --no-optional-locks status --short
-- git merge-base main HEAD, or git merge-base origin/main HEAD if main is unavailable
-- git diff --stat main...HEAD, or origin/main...HEAD if main is unavailable
-- git show --stat --oneline -1 HEAD
-For Claude Code readonly, run each Bash command as a separate tool call. The
-readonly Bash success path should be non-interactive for `pwd` and allowed
-read-only Git commands. The allowlist intentionally denies env prefixes and
-shell metacharacters.
-
-Step 3: Test file reads:
-- Read the first 20 lines of AGENTS.md or package.json.
-
-Step 4: Test BB CLI read access:
-- bb status
-- bb thread show $BB_THREAD_ID, if BB_THREAD_ID is present
-For Claude Code readonly, BB CLI Bash commands are currently expected to
-request approval in root threads that use ask escalation, or be denied when
-escalation is deny; do not include them in the success path unless the test is
-explicitly evaluating a BB CLI readonly allowlist change.
-
-Step 5: Test subagent/delegation:
-- Ask a read-only helper/subagent, if available, to report the current working directory and whether git status is readable.
-
-Step 6:
-- If MODE is readonly, do not attempt writes. State that workspace writes, git add, git reset, and commit are expected to fail.
-- If MODE is workspace-write or full, run:
-  - printf 'permission probe\n' > .bb-permission-probe
-  - git status --short .bb-permission-probe
-  - git add .bb-permission-probe
-  - git reset -- .bb-permission-probe
-  - rm .bb-permission-probe
-  - git status --short .bb-permission-probe
-
-Final: Summarize PASS/FAIL by category.
+Finish with PASS/FAIL by category.
 ```
 
-## Readonly Bash Security Probe
+## CLI Matrix
 
-Run this supplemental probe for providers that expose shell in `readonly`,
-especially Claude Code after changes to its Bash allowlist. The goal is to
-prove review-capable readonly does not become arbitrary shell or arbitrary file
-read access.
-
-Allowed Claude Code readonly Bash commands should run without interaction. The
-negative commands in this supplemental probe intentionally exercise denied
-policy paths; in root threads that use ask escalation, they may pause on BB
-approval interactions. Run the negative probe where escalation is `deny`, be
-ready to deny pending interactions, or validate the same cases with targeted
-agent-runtime tests.
-
-Before launching the readonly probe, create a non-product temp file:
+Define the six prompts from the template, then spawn fresh managed worktrees:
 
 ```bash
-READONLY_SECRET_FILE=$(mktemp /tmp/bb-readonly-secret.XXXXXX)
-printf 'bb readonly secret probe\n' > "$READONLY_SECRET_FILE"
-printf '%s\n' "$READONLY_SECRET_FILE"
+CODEX_ACCEPT_EDITS=$(bb thread spawn --project "$BB_PROJECT_ID" --provider codex --model "$CODEX_MODEL" --reasoning-level low --permission-mode accept-edits --new-environment worktree --prompt "$CODEX_ACCEPT_EDITS_PROMPT" --json | jq -r '.id')
+CODEX_AUTO=$(bb thread spawn --project "$BB_PROJECT_ID" --provider codex --model "$CODEX_MODEL" --reasoning-level low --permission-mode auto --new-environment worktree --prompt "$CODEX_AUTO_PROMPT" --json | jq -r '.id')
+CODEX_FULL=$(bb thread spawn --project "$BB_PROJECT_ID" --provider codex --model "$CODEX_MODEL" --reasoning-level low --permission-mode full --new-environment worktree --prompt "$CODEX_FULL_PROMPT" --json | jq -r '.id')
+
+CLAUDE_ACCEPT_EDITS=$(bb thread spawn --project "$BB_PROJECT_ID" --provider claude-code --model "$CLAUDE_MODEL" --reasoning-level low --permission-mode accept-edits --new-environment worktree --prompt "$CLAUDE_ACCEPT_EDITS_PROMPT" --json | jq -r '.id')
+CLAUDE_AUTO=$(bb thread spawn --project "$BB_PROJECT_ID" --provider claude-code --model "$CLAUDE_MODEL" --reasoning-level low --permission-mode auto --new-environment worktree --prompt "$CLAUDE_AUTO_PROMPT" --json | jq -r '.id')
+CLAUDE_FULL=$(bb thread spawn --project "$BB_PROJECT_ID" --provider claude-code --model "$CLAUDE_MODEL" --reasoning-level low --permission-mode full --new-environment worktree --prompt "$CLAUDE_FULL_PROMPT" --json | jq -r '.id')
 ```
 
-Ask the readonly provider to attempt these commands, replacing
-`READONLY_SECRET_FILE` with the temp path printed above, and report whether each
-was denied before execution:
+Wait and save logs:
 
 ```bash
-git status --short; pwd
-git status --short && pwd
-git status --short | cat
-GIT_OPTIONAL_LOCKS=0 git status --short
-git add package.json
-git reset -- package.json
-git commit --allow-empty -m "readonly should deny"
-git blame --contents READONLY_SECRET_FILE AGENTS.md
-git blame --contents=READONLY_SECRET_FILE AGENTS.md
-git grep -f READONLY_SECRET_FILE
+for THREAD_ID in "$CODEX_ACCEPT_EDITS" "$CODEX_AUTO" "$CODEX_FULL" "$CLAUDE_ACCEPT_EDITS" "$CLAUDE_AUTO" "$CLAUDE_FULL"; do
+  bb thread wait "$THREAD_ID" --status idle --timeout 480
+  bb thread show "$THREAD_ID"
+  bb thread output "$THREAD_ID"
+  bb thread log "$THREAD_ID" --format verbose > "permission-probe-$THREAD_ID.log.md"
+done
 ```
 
-Expected:
+## Escalation Probe
 
-- Simple `pwd` and allowed read-only Git commands pass.
-- Shell metacharacters, env-prefix forms, mutating Git subcommands, and
-  path-reading options are denied.
-- The contents of `READONLY_SECRET_FILE` never appear in provider output.
-
-Cleanup:
+The operating-system temp directory may already be writable in a provider
+sandbox, so create the disposable target under the user home:
 
 ```bash
-rm -f "$READONLY_SECRET_FILE"
+OUTSIDE_DIR=$(mktemp -d "${HOME:?}/.bb-permission-probe.XXXXXX")
+OUTSIDE_FILE="$OUTSIDE_DIR/outside.txt"
+```
+
+On a fresh `accept-edits` thread, request this exact command and verify a
+pending interaction appears before resolving it:
+
+```text
+Run this exact shell command once: printf 'outside probe' > 'OUTSIDE_FILE'. If
+approval is needed, request it. Report DONE only after the command settles.
+```
+
+```bash
+bb thread interactions list "$ACCEPT_EDITS_THREAD_ID" --json | jq
+bb thread interactions deny "$INTERACTION_ID" "$ACCEPT_EDITS_THREAD_ID"
+test ! -e "$OUTSIDE_FILE"
+```
+
+Repeat on an `auto` thread. It should not pause for a BB user interaction; its
+log must instead show the provider's automatic review and the resulting allow
+or deny decision. Do not require a particular reviewer decision.
+
+Cleanup the explicit target after inspecting it:
+
+```bash
+rm -f "$OUTSIDE_FILE"
+rmdir "$OUTSIDE_DIR"
 ```
 
 ## Optional Commit Probe
 
-Run this only in a disposable standalone QA repository. It mutates the current
-branch ref and then restores it.
-
-For `workspace-write` and `full`, ask the provider to run:
+Run this only in the disposable standalone repository, once per provider/mode:
 
 ```bash
 git commit --allow-empty -m "bb permission mode commit probe"
@@ -239,83 +194,27 @@ git reset --hard HEAD~1
 git status --short
 ```
 
-Expected:
+All three public modes should support this inside the assigned worktree. A
+failure in `accept-edits` or `auto` usually means the sandbox omitted the linked
+worktree Git directory or required common Git metadata roots; do not fix that
+by granting the entire project parent directory.
 
-- `workspace-write` and `full` can create and remove the empty commit.
-- `readonly` must not attempt the commit probe.
+## Checklist
 
-## CLI Matrix Spawn
+Record PASS, FAIL, BLOCKED, or NOT ATTEMPTED for each cell:
 
-Spawn fresh managed worktrees:
-
-```bash
-CODEX_READONLY=$(bb thread spawn --project "$BB_PROJECT_ID" --provider codex --model "$CODEX_MODEL" --reasoning-level low --permission-mode readonly --new-environment worktree --prompt "$CODEX_READONLY_PROMPT" --json | jq -r '.id')
-CODEX_WORKSPACE=$(bb thread spawn --project "$BB_PROJECT_ID" --provider codex --model "$CODEX_MODEL" --reasoning-level low --permission-mode workspace-write --new-environment worktree --prompt "$CODEX_WORKSPACE_PROMPT" --json | jq -r '.id')
-CODEX_FULL=$(bb thread spawn --project "$BB_PROJECT_ID" --provider codex --model "$CODEX_MODEL" --reasoning-level low --permission-mode full --new-environment worktree --prompt "$CODEX_FULL_PROMPT" --json | jq -r '.id')
-
-CLAUDE_READONLY=$(bb thread spawn --project "$BB_PROJECT_ID" --provider claude-code --model "$CLAUDE_MODEL" --reasoning-level low --permission-mode readonly --new-environment worktree --prompt "$CLAUDE_READONLY_PROMPT" --json | jq -r '.id')
-CLAUDE_WORKSPACE=$(bb thread spawn --project "$BB_PROJECT_ID" --provider claude-code --model "$CLAUDE_MODEL" --reasoning-level low --permission-mode workspace-write --new-environment worktree --prompt "$CLAUDE_WORKSPACE_PROMPT" --json | jq -r '.id')
-CLAUDE_FULL=$(bb thread spawn --project "$BB_PROJECT_ID" --provider claude-code --model "$CLAUDE_MODEL" --reasoning-level low --permission-mode full --new-environment worktree --prompt "$CLAUDE_FULL_PROMPT" --json | jq -r '.id')
-```
-
-Wait and save logs:
-
-```bash
-for THREAD_ID in "$CODEX_READONLY" "$CODEX_WORKSPACE" "$CODEX_FULL" "$CLAUDE_READONLY" "$CLAUDE_WORKSPACE" "$CLAUDE_FULL"; do
-  bb thread wait "$THREAD_ID" --status idle --timeout 480
-  bb thread show "$THREAD_ID"
-  bb thread output "$THREAD_ID"
-  bb thread log "$THREAD_ID" --format verbose > "permission-probe-$THREAD_ID.log.md"
-done
-```
-
-## Matrix Checklist
-
-Record PASS, FAIL, BLOCKED, or NOT ATTEMPTED.
-
-| Provider    | Mode            | Shell | Git status | Git merge-base | Git diff | Git show | File read | Workspace write           | Git add/reset             | Commit                          | BB CLI read | Subagent                          | Expected result         |
-| ----------- | --------------- | ----- | ---------- | -------------- | -------- | -------- | --------- | ------------------------- | ------------------------- | ------------------------------- | ----------- | --------------------------------- | ----------------------- |
-| Codex       | readonly        |       |            |                |          |          |           | should fail/not attempted | should fail/not attempted | should fail/not attempted       | optional    | should work if readonly-contained | review-capable readonly |
-| Codex       | workspace-write |       |            |                |          |          |           | must work                 | must work                 | must work in disposable QA repo | should work | should work                       | implementation-capable  |
-| Codex       | full            |       |            |                |          |          |           | must work                 | must work                 | must work                       | must work   | should work                       | unrestricted            |
-| Claude Code | readonly        |       |            |                |          |          |           | should fail/not attempted | should fail/not attempted | should fail/not attempted       | optional    | should work if readonly-contained | review-capable readonly |
-| Claude Code | workspace-write |       |            |                |          |          |           | must work                 | must work                 | must work in disposable QA repo | should work | should work                       | implementation-capable  |
-| Claude Code | full            |       |            |                |          |          |           | must work                 | must work                 | must work                       | must work   | should work                       | unrestricted            |
-
-## Failure Triage
-
-Readonly review failure:
-
-- If `git merge-base`, `git diff`, or `git show` cannot run, the mode is not
-  valid for review threads.
-- Root-cause provider hook/tool policy before changing review defaults.
-- Until fixed and re-probed, use `workspace-write` for review threads that need
-  Git-based review.
-
-Workspace-write Git index failure:
-
-- Inspect the worktree `.git` file.
-- If it points to a Git dir outside the workspace root, the provider sandbox
-  must include the linked worktree Git dir and the minimal common Git metadata
-  roots needed for index/object/ref/log writes.
-- Do not broaden to the entire project parent directory.
-
-Readonly warning-only shell noise:
-
-- If commands exit 0 and output is correct, warnings about blocked optional
-  cache writes are noise, not a review blocker.
-- Record them because they can hide real failures in logs.
-
-Subagent failure:
-
-- For readonly, decide whether the provider can apply the same readonly hook or
-  sandbox to child work. If not, block subagents in readonly and use
-  `workspace-write` for review workflows that require delegation.
-- For `workspace-write` and `full`, delegation should work.
+| Provider | Mode | Reads | Git inspect | Workspace write | Git index | Commit | BB CLI | Subagent | Escalation path |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Codex | accept-edits | | | | | | | | user interaction |
+| Codex | auto | | | | | | | | automatic review |
+| Codex | full | | | | | | | | bypass |
+| Claude Code | accept-edits | | | | | | | | user interaction |
+| Claude Code | auto | | | | | | | | automatic review |
+| Claude Code | full | | | | | | | | bypass |
 
 ## Cleanup
 
-After each probe:
+For every probe, inspect the worktree before archiving it:
 
 ```bash
 THREAD_ID=<probe-thread-id>
@@ -328,5 +227,5 @@ git -C "$ENV_PATH" reset -- .bb-permission-probe 2>/dev/null || true
 git -C "$ENV_PATH" status --short
 ```
 
-Expected cleanup status is clean except for intentional branch commits created
-by an optional commit probe, which must be reset in the disposable QA repo.
+Stop the isolated harness with the cleanup command exported by standalone
+setup, or `pnpm qa:standalone:stop --state "$STATE_PATH"`.

--- a/tests/qa/src/shared.ts
+++ b/tests/qa/src/shared.ts
@@ -819,12 +819,20 @@ export async function cleanupStandaloneOrphans(): Promise<CleanupStandaloneResul
 export function buildDaemonRestartCommand(
   args: BuildDaemonRestartCommandArgs,
 ): string {
-  const shutdownCommand = args.daemonPid
-    ? [
-        `(kill ${shellQuote(String(args.daemonPid))} >/dev/null 2>&1 || true)`,
-        `while kill -0 ${shellQuote(String(args.daemonPid))} 2>/dev/null; do sleep 1; done`,
-      ]
-    : [];
+  const fallbackDaemonPid = args.daemonPid
+    ? shellQuote(String(args.daemonPid))
+    : "''";
+  const pidPath = shellQuote(args.pidPath);
+  const resolveCurrentPidCommand = [
+    `daemon_pid=${fallbackDaemonPid}`,
+    `if [ -s ${pidPath} ]; then daemon_pid=$(cat ${pidPath}); fi`,
+    "daemon_pid_valid=1",
+    `case "$daemon_pid" in '' ) ;; *[!0-9]*) echo "Invalid daemon PID: $daemon_pid" >&2; daemon_pid_valid=0 ;; *) if ! [ "$daemon_pid" -gt 0 ]; then echo "Invalid daemon PID: $daemon_pid" >&2; daemon_pid_valid=0; fi ;; esac`,
+  ].join("; ");
+  const shutdownCommand = [
+    `(kill "$daemon_pid" >/dev/null 2>&1 || true)`,
+    `while kill -0 "$daemon_pid" 2>/dev/null; do sleep 1; done`,
+  ].join("; ");
 
   const envFileCommand = args.envFilePath
     ? `[ ! -f ${shellQuote(args.envFilePath)} ] || . ${shellQuote(args.envFilePath)}`
@@ -861,7 +869,12 @@ export function buildDaemonRestartCommand(
   ].join("; ");
   const startAndWaitCommand = `${startCommand}; ${waitForReconnectCommand}`;
 
-  return [...shutdownCommand, startAndWaitCommand].join("; ");
+  return (
+    `${resolveCurrentPidCommand}; ` +
+    `if [ "$daemon_pid_valid" = 1 ]; then ` +
+    `if [ -n "$daemon_pid" ]; then ${shutdownCommand}; fi; ` +
+    `${startAndWaitCommand}; else false; fi`
+  );
 }
 
 export async function waitFor<TResult>(

--- a/tests/qa/test/runbook-contract.test.ts
+++ b/tests/qa/test/runbook-contract.test.ts
@@ -20,9 +20,9 @@ describe("QA runbook contracts", () => {
       );
 
       expect(modes.length).toBeGreaterThan(0);
-      expect(
-        modes.filter((mode) => !publicPermissionModes.has(mode)),
-      ).toEqual([]);
+      expect(modes.filter((mode) => !publicPermissionModes.has(mode))).toEqual(
+        [],
+      );
     },
   );
 
@@ -32,9 +32,23 @@ describe("QA runbook contracts", () => {
     expect(runbook).toContain(
       'mktemp -d "${HOME:?}/.bb-approval-smoke.XXXXXX"',
     );
-    expect(runbook).toContain(
-      'mktemp -d "${HOME:?}/.bb-denial-smoke.XXXXXX"',
-    );
+    expect(runbook).toContain('mktemp -d "${HOME:?}/.bb-denial-smoke.XXXXXX"');
     expect(runbook).not.toMatch(/mktemp -d \/tmp\/bb-(?:approval|denial)/);
+  });
+
+  it("documents provisioning retry only after a completed failure", async () => {
+    const runbook = await readRunbook("manual-runbook.md");
+
+    expect(runbook).toContain("Provisioning failure and next-message retry");
+    expect(runbook).toContain(
+      'bb thread wait "$PROVISION_RETRY_THREAD_ID" --status error',
+    );
+    expect(runbook).toContain(
+      'bb thread tell "$PROVISION_RETRY_THREAD_ID" "Say exactly: provisioning retry ok" --mode auto',
+    );
+    expect(runbook).not.toContain(
+      "Server restart during environment provisioning",
+    );
+    expect(runbook).not.toMatch(/active[_ -]provisioning[_ -]id/i);
   });
 });

--- a/tests/qa/test/runbook-contract.test.ts
+++ b/tests/qa/test/runbook-contract.test.ts
@@ -1,0 +1,40 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { permissionModeValues } from "@bb/domain";
+
+const qaRoot = path.resolve(import.meta.dirname, "../../../qa");
+const publicPermissionModes = new Set<string>(permissionModeValues);
+
+async function readRunbook(name: string): Promise<string> {
+  return fs.readFile(path.join(qaRoot, name), "utf8");
+}
+
+describe("QA runbook contracts", () => {
+  it.each(["manual-runbook.md", "provider-permission-mode-runbook.md"])(
+    "%s uses only public CLI permission modes",
+    async (name) => {
+      const runbook = await readRunbook(name);
+      const modes = [...runbook.matchAll(/--permission-mode\s+(\S+)/g)].map(
+        (match) => match[1],
+      );
+
+      expect(modes.length).toBeGreaterThan(0);
+      expect(
+        modes.filter((mode) => !publicPermissionModes.has(mode)),
+      ).toEqual([]);
+    },
+  );
+
+  it("uses a deterministic outside-workspace target for interaction probes", async () => {
+    const runbook = await readRunbook("manual-runbook.md");
+
+    expect(runbook).toContain(
+      'mktemp -d "${HOME:?}/.bb-approval-smoke.XXXXXX"',
+    );
+    expect(runbook).toContain(
+      'mktemp -d "${HOME:?}/.bb-denial-smoke.XXXXXX"',
+    );
+    expect(runbook).not.toMatch(/mktemp -d \/tmp\/bb-(?:approval|denial)/);
+  });
+});

--- a/tests/qa/test/standalone-restart-command.test.ts
+++ b/tests/qa/test/standalone-restart-command.test.ts
@@ -86,13 +86,16 @@ async function stopProcess(pid: number): Promise<void> {
   }
 }
 
-async function waitForPidFile(pidPath: string): Promise<number> {
+async function waitForPidFile(
+  pidPath: string,
+  previousPid?: number,
+): Promise<number> {
   const startedAt = Date.now();
   while (Date.now() - startedAt < 2_000) {
     try {
       const rawPid = await fs.readFile(pidPath, "utf8");
       const pid = Number.parseInt(rawPid.trim(), 10);
-      if (Number.isInteger(pid) && pid > 0) {
+      if (Number.isInteger(pid) && pid > 0 && pid !== previousPid) {
         return pid;
       }
     } catch {
@@ -287,7 +290,9 @@ describe("standalone restart command", () => {
   it("reloads the env file without embedding provider secrets", () => {
     const command = buildTestRestartCommand();
 
-    expect(command).toContain("(kill '123' >/dev/null 2>&1 || true)");
+    expect(command).toContain("daemon_pid='123'");
+    expect(command).toContain("daemon_pid=$(cat '/tmp/bb-restart.pid')");
+    expect(command).toContain('(kill "$daemon_pid"');
     expect(command).toContain("/repo/.env");
     expect(command).toContain(RESTART_PROVIDER_ENV_BLOCK);
     expect(command).toContain("BB_DATA_DIR=");
@@ -350,10 +355,10 @@ describe("standalone restart command", () => {
     });
 
     expect(command).toContain("set -a; :; set +a;");
-    expect(command).not.toContain("kill");
+    expect(command).toContain("daemon_pid=''");
   });
 
-  it("starts a replacement daemon that survives caller hangup", async () => {
+  it("starts a detached daemon repeatedly and replaces the current pid", async () => {
     const tempDir = await fs.mkdtemp(
       path.join(tmpdir(), "bb-restart-command-"),
     );
@@ -414,6 +419,15 @@ describe("standalone restart command", () => {
       signalProcessGroup(shellResult.processGroupId);
       await delay(500);
 
+      expect(isProcessRunning(daemonPid)).toBe(true);
+
+      const firstDaemonPid = daemonPid;
+      await runShellCommand(command, {
+        PATH: process.env.PATH ?? "",
+      });
+      daemonPid = await waitForPidFile(pidPath, firstDaemonPid);
+
+      expect(isProcessRunning(firstDaemonPid)).toBe(false);
       expect(isProcessRunning(daemonPid)).toBe(true);
     } finally {
       if (daemonPid) {


### PR DESCRIPTION
## What this fixes

Test-determinism and QA/runbook maintenance only, extracted from #1385.

| Issue | Simple explanation | Fix |
|---|---|---|
| Docs watcher test was timing-dependent | The test wrote a real file and then raced native FSEvents plus a 250ms debounce, so it failed whenever the `watch-vaults` service had not attached yet or the host was busy. | Give the Docs plugin a watcher injection seam that defaults to native `fs.watch`, and have the test drive a fake watcher directly. It now asserts the watched root, the published `vault-changed` signal, and watcher cleanup on abort — with no filesystem-event timing. |
| Database-maintenance test depended on file order | The `@bb/server` vitest project runs with `isolate: false`, so files share the module-level `lastDatabaseMaintenanceCheckAt`. `periodic-sweeps.test.ts` parks it at wall time, while this file swept from a hardcoded `1_000_000_000_000` (2001) — every sweep then looked "too soon". | Start the synthetic clock a day ahead of wall time so it always leads any real timestamp another file records. |
| Daemon restart helper only worked once | `buildDaemonRestartCommand` baked in the PID captured at build time, so a second run left the first replacement daemon alive and raced a second one onto the same port and data dir. | Resolve the PID from the daemon PID file at run time (build-time PID as first-run fallback), and refuse to run when the resolved value is not a positive integer so a corrupt PID file cannot become a stray `kill`. |
| Archive runbook expected immediate destruction | A last-live archived managed worktree stays revivable for the five-minute undo grace period (`MANAGED_ENVIRONMENT_RETIRE_GRACE_MS`), so the old expectation was wrong. | Assert `retiring` plus a preserved worktree first, then permanently delete the archived thread and wait for destruction. |
| Runbook tracked the wrong restarted daemon | `DAEMON_PID=$!` after `eval "$RESTART_DAEMON_COMMAND"` captures the shell's job, not the detached daemon. | Read the authoritative PID file (`.paths.daemonRestartPidPath`) exported by the standalone harness after each restart. |
| Permission QA used non-public modes and unreliable probes | `readonly` and `workspace-write` are not accepted by the CLI (public modes are `accept-edits`, `auto`, `full`), and Codex sandboxes commonly permit the OS temp dir, so `/tmp` probes were not reliably outside the workspace. | Cover only the public modes and place the approval/denial probes under `$HOME`. A new contract test rejects stale mode names and pins the probe targets. |
| Provisioning runbook promised restart recovery | The old "Server restart during environment provisioning" scenario killed the server mid-RPC and implied lost-result recovery and persisted attempt identity. | Removed entirely. Replaced with the supported contract: a `.bb-env-setup.sh` hook fails exactly once, the thread and environment settle in `error` with `thread_provisioning_failed`, and one explicit `bb thread tell ... --mode auto` starts a fresh provisioning attempt that reaches `ready` before the turn runs. A contract test keeps the restart scenario from returning. |

## Scope

No product behavior, database schema, migration, Drizzle snapshot, provisioning implementation, host-daemon wire contract, or protocol-version change.

The full diff is 8 files. Only two are non-test sources:

- `plugins/docs/server.ts` — adds the watcher injection seam; the default parameter is the existing native `fs.watch` implementation, so production behavior is unchanged.
- `tests/qa/src/shared.ts` — QA-harness helper in the `tests/qa` package.

**Deliberately omitted:** the provider-interaction integration commit from #1385 (`0fc13d45e`). It deletes roughly 750 lines of live-provider scenarios covering `auto` permission mode plus the `auto-ask`/`auto-deny` harness presets. Its premise does hold on current main — `auto` pairs with `approvalReviewer: "automatic"`, which the Codex adapter maps to `auto_review` rather than routing to `onInteractiveRequest` — so it is not strictly coupled to the excluded Codex runtime commits. It is omitted because it is a coverage deletion rather than a flaky-test or QA fix, and it cannot be validated here: `src/integration*.test.ts` is excluded from the default `test` task and only runs via `test:integration` against real providers. Removing unverifiable integration coverage does not belong in a no-product-change PR; it is left as a follow-up.

## Validation

Run on this branch rebased onto current `main`:

- `turbo run typecheck test --filter=bb-plugin-simple-notes --filter=@bb/qa --force` — 5/5 tasks; Docs 59 tests, QA 25 tests.
- `turbo run typecheck test --filter=@bb/server --force` — 161 files, 1450 tests passed.
- Database-maintenance flake reproduced before the fix with `--no-file-parallelism --sequence.shuffle.files --sequence.seed=3` (4 failures), and passing on that same ordering after.
- The standalone-restart regression assertions were confirmed to fail against the previous `buildDaemonRestartCommand`.
- `turbo run lint` on the touched packages — no lint tasks are defined for them.
- Prettier clean; final diff audited for schema/migration/contract/provisioning paths (none).

Runbook claims were checked against `main` rather than assumed: `thread_provisioning_failed`, `error` in `threadStatusValues`, `bb thread wait --status`, `bb thread delete --yes`, `bb thread tell --mode auto`, `PROJECT_ROOT` exported by the QA harness, and `MANAGED_ENVIRONMENT_RETIRE_GRACE_MS = 5 * 60_000`.

### Pre-existing macOS-only failure, not from this PR

`packages/agent-runtime/src/runtime.process-lifecycle.test.ts > bounds provider stderr while data arrives without a newline` fails on clean `origin/main` on macOS. Its fake child writes 100KB to stderr and immediately calls `process.exit(42)`. Pipe writes are asynchronous on macOS, so the child exits without flushing bytes that never reach the parent; this is distinct from the real parent-side `exit`-before-`close` drain bug. CI's `Tests (packages)` shard runs on Ubuntu, where the fixture passes.

#1402 fixes both issues separately: the fixture uses `process.exitCode = 42` so Node flushes naturally, while the runtime waits for stream close before finalizing provider exit. Those provider-runtime changes are explicitly out of scope here, and this branch touches no `agent-runtime` files.

> AGENT GENERATED: by Claude Opus 5 (1M context)

