### PR TITLE
Reduce oversized file read log noise

### DIFF
--- a/apps/host-daemon/src/command-dispatch-support.test.ts
+++ b/apps/host-daemon/src/command-dispatch-support.test.ts
@@ -16,8 +16,10 @@ vi.mock("@bb/agent-runtime", async (importOriginal) => {
 });
 
 import {
+  CommandDispatchError,
   defaultListModels,
   getErrorCode,
+  isExpectedOnlineRpcFailureError,
   shutdownDefaultListModelsRuntimes,
 } from "./command-dispatch-support.js";
 
@@ -117,6 +119,14 @@ describe("command dispatch support", () => {
         ),
       ),
     ).toBe("auth_required");
+  });
+
+  it("classifies oversized file reads as expected RPC failures", () => {
+    expect(
+      isExpectedOnlineRpcFailureError(
+        new CommandDispatchError("file_too_large", "File exceeds the limit"),
+      ),
+    ).toBe(true);
   });
 
   it("reuses the default model list runtime until shutdown", async () => {

--- a/apps/host-daemon/src/command-dispatch-support.ts
+++ b/apps/host-daemon/src/command-dispatch-support.ts
@@ -93,7 +93,10 @@ export function isExpectedCommandDispatchError(
   return error instanceof ExpectedCommandDispatchError;
 }
 
-const EXPECTED_ONLINE_RPC_FAILURE_CODES = new Set(["provision_cancelled"]);
+const EXPECTED_ONLINE_RPC_FAILURE_CODES = new Set([
+  "file_too_large",
+  "provision_cancelled",
+]);
 
 export function isExpectedOnlineRpcFailureError(error: unknown): boolean {
   return (


### PR DESCRIPTION
## Summary

- classify file_too_large as an expected online host RPC failure
- preserve the compact debug lifecycle event and unchanged RPC error response while avoiding repetitive warning stack traces
- add regression coverage for the expected-failure classification

## Testing

- pnpm exec turbo run typecheck --filter=@bb/host-daemon
- pnpm exec turbo run test --filter=@bb/host-daemon --force (543 tests)

> AGENT GENERATED: by GPT-5