### PR TITLE
Add a keyboard shortcut for archiving the focused thread

### DIFF
--- a/apps/app/src/lib/app-command-metadata.ts
+++ b/apps/app/src/lib/app-command-metadata.ts
@@ -48,6 +48,11 @@ export const APP_COMMAND_GROUPS: readonly AppCommandGroup[] = [
         "Next thread",
         "Open the next visible sidebar thread.",
       ),
+      command(
+        "thread.archive",
+        "Archive thread",
+        "Archive the thread you are viewing and its child threads.",
+      ),
       ...THREAD_JUMP_APP_COMMAND_IDS.map((id, index) =>
         command(
           id,

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -65,6 +65,7 @@ import {
   ThreadActionsMenu,
   type ThreadActionsMenuResponsiveAction,
 } from "@/components/thread/ThreadActionsMenu";
+import { useThreadActions } from "@/components/thread/ThreadActionsProvider";
 import { PluginThreadHeaderActions } from "@/components/plugin/PluginThreadHeaderActions";
 import { ThreadWorkspaceOpenButton } from "@/components/thread/ThreadWorkspaceOpenButton";
 import {
@@ -458,6 +459,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
   const { isFocused, navigateInPane, onRequestClose, isBoundedPane } =
     usePaneContext();
   const navigate = useNavigate();
+  const { archiveThreadAndChildren } = useThreadActions();
   useFixedPanelTabsStorageMaintenance(threadId);
   const systemConfigQuery = useSystemConfig();
   const fixedPanelTabsState = useFixedPanelTabsState(threadId, threadId);
@@ -1295,6 +1297,15 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
     handleCloseTerminalTab,
     isSecondaryPanelOpen,
   ]);
+  useAppCommandHandler("thread.archive", () => {
+    // Archived threads stay viewable; the shortcut is archive-only, so let the
+    // event through instead of silently toggling them back to active.
+    if (!isFocused || thread === undefined || thread.archivedAt !== null) {
+      return false;
+    }
+    archiveThreadAndChildren(thread);
+    return true;
+  });
   useAppCommandHandler("panel.toggle", () => {
     if (!isFocused) return false;
     toggleSecondaryPanel();

--- a/apps/server/src/services/system/app-keybindings.ts
+++ b/apps/server/src/services/system/app-keybindings.ts
@@ -120,6 +120,16 @@ export const DEFAULT_APP_KEYBINDINGS: AppKeybindings = [
     ...mainWithoutModal,
     desktopOnly: true,
   }),
+  // Archive the focused thread. Every Mod+Shift+<letter> chord that reads as
+  // "archive" is either taken by bb or reserved by browsers (Mod+Shift+A opens
+  // tab search in Chrome), so this uses Alt like the model-cycling chords: it
+  // is free in bb, the browser, and both desktop menus, and needs no web alias.
+  // macOS composes Option+A into "å", so it matches on the physical key — see
+  // `normalizeAppShortcutInputKey` in @bb/domain.
+  binding("thread.archive", "a", { alt: true }, {
+    ...mainWithoutModal,
+    none: ["modalOpen", "terminalFocus", "browserFocus"],
+  }),
   // Browsers reserve Mod+1…9 for native tab switching. Match Slack's web
   // navigation convention: Control+N on macOS and Ctrl+Shift+N elsewhere,
   // while keeping the shorter Mod chord on desktop.
@@ -180,8 +190,9 @@ export const DEFAULT_APP_KEYBINDINGS: AppKeybindings = [
     none: [],
   }),
   // Rotate the composer's model and reasoning level without opening the picker,
-  // scoped exactly like `modelPicker.toggle` above. Alt is otherwise unused by
-  // bb, the browser, and both desktop menus, so these chords shadow nothing.
+  // scoped exactly like `modelPicker.toggle` above. Alt chords are unclaimed by
+  // the browser and both desktop menus, and bb keeps each one distinct (see
+  // `thread.archive`), so these chords shadow nothing.
   // macOS composes Option+<letter> into another character, so they match on the
   // physical key — see `normalizeAppShortcutInputKey` in @bb/domain.
   binding("modelPicker.cycleModel", "m", { alt: true }, {

--- a/apps/server/test/system/app-keybindings.test.ts
+++ b/apps/server/test/system/app-keybindings.test.ts
@@ -120,6 +120,31 @@ describe("app keybindings", () => {
         { desktopOnly: false, key: "Enter" },
         { desktopOnly: true, key: "t" },
       ]);
+      // Archive is a single Alt chord on every client: the Mod+Shift letters
+      // that read as "archive" are taken by bb or reserved by browsers, so
+      // there is no web/desktop split to keep in sync here.
+      expect(
+        config.defaultKeybindings.filter(
+          (binding) => binding.command === "thread.archive",
+        ),
+      ).toEqual([
+        {
+          command: "thread.archive",
+          desktopOnly: false,
+          shortcut: {
+            key: "a",
+            mod: false,
+            meta: false,
+            control: false,
+            alt: true,
+            shift: false,
+          },
+          when: {
+            all: ["mainSurface"],
+            none: ["modalOpen", "terminalFocus", "browserFocus"],
+          },
+        },
+      ]);
       expect(
         config.defaultKeybindings.find(
           (binding) => binding.command === "composer.focus",

--- a/packages/domain/src/app-keybindings.ts
+++ b/packages/domain/src/app-keybindings.ts
@@ -40,6 +40,7 @@ export const APP_COMMAND_IDS = [
   "thread.search",
   "thread.previous",
   "thread.next",
+  "thread.archive",
   ...THREAD_JUMP_APP_COMMAND_IDS,
   "pane.focus.previous",
   "pane.focus.next",


### PR DESCRIPTION
Superseded by #1516 — same branch, reopened there after the PR head failed to track a new push. Closed.