### PR TITLE
Add a global All tasks board

### DIFF
--- a/plugins/tasks/shell/app-shell.tsx
+++ b/plugins/tasks/shell/app-shell.tsx
@@ -162,7 +162,11 @@ function RouteOutlet({
 }) {
   switch (route.kind) {
     case "all":
-      return <ListView projectId={null} />;
+      return route.view === "board" && boardUsable ? (
+        <BoardView projectId={null} />
+      ) : (
+        <ListView projectId={null} />
+      );
     case "active":
       return <ListView projectId={null} activeOnly />;
     case "manage":
@@ -244,7 +248,7 @@ function TasksAppShellContent({ subPath }: PluginNavPanelProps) {
     // Routes are plain data; keying on subPath tracks every route change.
   }, [subPath]);
   const backFromTask = () =>
-    navigation.go(lastBrowseRouteRef.current ?? { kind: "all" });
+    navigation.go(lastBrowseRouteRef.current ?? { kind: "all", view: "list" });
   const onTaskRoute = route.kind === "task";
   const backRef = useRef(backFromTask);
   backRef.current = backFromTask;

--- a/plugins/tasks/shell/routes.ts
+++ b/plugins/tasks/shell/routes.ts
@@ -7,7 +7,7 @@ export const PANEL_PATH = "tasks";
 export type TaskViewMode = "list" | "board";
 
 export type TasksRoute =
-  | { kind: "all" }
+  | { kind: "all"; view: TaskViewMode }
   | { kind: "active" }
   | { kind: "manage" }
   | { kind: "project"; projectId: string; view: TaskViewMode }
@@ -15,8 +15,8 @@ export type TasksRoute =
 
 /**
  * subPath grammar (the trailing route below /plugins/tasks/tasks):
- *   ""                      → all tasks (default)
- *   "all"                   → all tasks
+ *   ""                      → all tasks (default list view)
+ *   "all?view=board"        → all tasks board view
  *   "active"                → tasks with agents working
  *   "manage"                → manage panel (labels, presets, folders)
  *   "task/<taskKey>"        → task detail (e.g. task/TSK-4)
@@ -40,13 +40,19 @@ export function parseTasksRoute(rawSubPath: string): TasksRoute {
   const query = queryIndex === -1 ? "" : subPath.slice(queryIndex + 1);
   const segments = path.split("/").filter((segment) => segment.length > 0);
   const head = segments[0];
-  if (head === undefined || head === "all") return { kind: "all" };
+  if (head === undefined || head === "all") {
+    return {
+      kind: "all",
+      view:
+        new URLSearchParams(query).get("view") === "board" ? "board" : "list",
+    };
+  }
   if (head === "active") return { kind: "active" };
   if (head === "manage") return { kind: "manage" };
   if (head === "task") {
     const taskKey = segments[1];
     if (taskKey !== undefined) return { kind: "task", taskKey };
-    return { kind: "all" };
+    return { kind: "all", view: "list" };
   }
   const view = new URLSearchParams(query).get("view");
   return {
@@ -59,7 +65,7 @@ export function parseTasksRoute(rawSubPath: string): TasksRoute {
 export function tasksRouteToSubPath(route: TasksRoute): string {
   switch (route.kind) {
     case "all":
-      return "all";
+      return route.view === "board" ? "all?view=board" : "all";
     case "active":
       return "active";
     case "manage":

--- a/plugins/tasks/shell/shell.test.tsx
+++ b/plugins/tasks/shell/shell.test.tsx
@@ -2,6 +2,7 @@
 import { cleanup, fireEvent, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadPluginApp, renderSlot } from "@bb/plugin-sdk/testing/app";
+import type { TaskStatus } from "../shared/contract.js";
 
 // jsdom lacks matchMedia; the vendored Dialog's responsive root needs it.
 if (!window.matchMedia) {
@@ -730,8 +731,19 @@ describe("tasks app shell", () => {
         rpc: seededRpc({
           listProjects: () => ({ projects: [project, secondProject] }),
           sidebarSummary: () => ({ projects: [] }),
-          listTasks: (input: { activeOnly?: boolean }) => ({
-            tasks: input.activeOnly ? [] : tasks,
+          // Status filtering is server-side, so the fake honors `statuses`:
+          // the canceled card is absent only if the board asked for it to be.
+          listTasks: (input: {
+            activeOnly?: boolean;
+            statuses?: TaskStatus[];
+          }) => ({
+            tasks: input.activeOnly
+              ? []
+              : tasks.filter(
+                  (task) =>
+                    input.statuses === undefined ||
+                    input.statuses.includes(task.status),
+                ),
           }),
           listLabels: () => ({ labels: [] }),
           listTaskThreads: () => ({ taskThreads: [] }),

--- a/plugins/tasks/shell/shell.test.tsx
+++ b/plugins/tasks/shell/shell.test.tsx
@@ -45,6 +45,14 @@ const project = {
   createdAt: "2026-07-15T00:00:00.000Z",
 };
 
+const secondProject = {
+  ...project,
+  id: "01HZZZZZZZZZZZZZZZZZZZZZP2",
+  name: "Infrastructure",
+  prefix: "INF",
+  color: "green",
+};
+
 const folder = {
   id: FOLDER_ID,
   name: "bb",
@@ -75,7 +83,8 @@ const emptyRpc = seededRpc({
 describe("tasks route grammar", () => {
   it("round-trips every route kind and decodes host-encoded subPaths", () => {
     const routes = [
-      { kind: "all" },
+      { kind: "all", view: "list" },
+      { kind: "all", view: "board" },
       { kind: "active" },
       { kind: "manage" },
       { kind: "task", taskKey: "TSK-4" },
@@ -91,7 +100,7 @@ describe("tasks route grammar", () => {
       projectId: PROJECT_ID,
       view: "board",
     });
-    expect(parseTasksRoute("")).toEqual({ kind: "all" });
+    expect(parseTasksRoute("")).toEqual({ kind: "all", view: "list" });
   });
 });
 
@@ -696,6 +705,48 @@ describe("tasks app shell", () => {
     });
   });
 
+  it("renders one All tasks board across projects, with project identity and no canceled cards by default", async () => {
+    const tasks = [
+      {
+        ...pagerTask("TSK-1", "todo", 1),
+        title: "Ship the tasks board",
+        projectId: project.id,
+      },
+      {
+        ...pagerTask("INF-1", "in_progress", 1),
+        title: "Migrate worker host",
+        projectId: secondProject.id,
+      },
+      {
+        ...pagerTask("INF-2", "canceled", 2),
+        title: "Canceled migration",
+        projectId: secondProject.id,
+      },
+    ];
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: "all?view=board" },
+      {
+        rpc: seededRpc({
+          listProjects: () => ({ projects: [project, secondProject] }),
+          sidebarSummary: () => ({ projects: [] }),
+          listTasks: (input: { activeOnly?: boolean }) => ({
+            tasks: input.activeOnly ? [] : tasks,
+          }),
+          listLabels: () => ({ labels: [] }),
+          listTaskThreads: () => ({ taskThreads: [] }),
+          listAttachments: () => ({ attachments: [] }),
+        }),
+      },
+    );
+    await slot.findByText("Ship the tasks board");
+    expect(slot.getAllByText("Tasks Plugin").length).toBeGreaterThan(1);
+    expect(slot.getAllByText("Infrastructure").length).toBeGreaterThan(1);
+    expect(slot.queryByText("Canceled migration")).toBeNull();
+    expect(slot.getByRole("button", { name: "List" })).toBeDefined();
+    expect(slot.getByRole("button", { name: "Board" })).toBeDefined();
+  });
+
   it("routes 'manage' to the manage panel via the sidebar footer", async () => {
     const slot = renderSlot(app.navPanels[0]!, { subPath: "manage" }, {
       rpc: seededRpc({ listLabels: () => ({ labels: [] }) }),
@@ -734,22 +785,26 @@ describe("tasks app shell", () => {
       builtin: false,
       createdAt: "2026-07-15T00:00:00.000Z",
     };
-    const slot = renderSlot(app.navPanels[0]!, { subPath: "all" }, {
-      rpc: seededRpc({
-        listPresets: () => ({
-          presets: [
-            basePreset,
-            {
-              ...basePreset,
-              id: "01HZZZZZZZZZZZZZZZZZZZZZE2",
-              name: "Worktree env",
-              environmentKind: "new-worktree",
-              baseBranch: "main",
-            },
-          ],
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: "all" },
+      {
+        rpc: seededRpc({
+          listPresets: () => ({
+            presets: [
+              basePreset,
+              {
+                ...basePreset,
+                id: "01HZZZZZZZZZZZZZZZZZZZZZE2",
+                name: "Worktree env",
+                environmentKind: "new-worktree",
+                baseBranch: "main",
+              },
+            ],
+          }),
         }),
-      }),
-    });
+      },
+    );
     await slot.findByText("Worktree env");
     expect(slot.getByText("Default env")).toBeDefined();
     expect(slot.getAllByLabelText("Spawns a new worktree")).toHaveLength(1);
@@ -757,14 +812,18 @@ describe("tasks app shell", () => {
 
   it("refetches sidebar data when invalidation channels fire", async () => {
     let projectCalls = 0;
-    const slot = renderSlot(app.navPanels[0]!, { subPath: "all" }, {
-      rpc: seededRpc({
-        listProjects: () => {
-          projectCalls += 1;
-          return { projects: [project] };
-        },
-      }),
-    });
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: "all" },
+      {
+        rpc: seededRpc({
+          listProjects: () => {
+            projectCalls += 1;
+            return { projects: [project] };
+          },
+        }),
+      },
+    );
     await slot.findByText("Tasks Plugin");
     const before = projectCalls;
     await slot.emitRealtime("projects:changed", { projectId: null });

--- a/plugins/tasks/shell/sidebar.tsx
+++ b/plugins/tasks/shell/sidebar.tsx
@@ -345,7 +345,7 @@ export function TasksSidebar({
         <div className="space-y-px">
           <SidebarRow
             active={route.kind === "all"}
-            onClick={() => onNavigate({ kind: "all" })}
+            onClick={() => onNavigate({ kind: "all", view: "list" })}
           >
             <Icon name="ListView" className="size-3.5 shrink-0" />
             <span className="flex-1">All tasks</span>

--- a/plugins/tasks/shell/topbar.tsx
+++ b/plugins/tasks/shell/topbar.tsx
@@ -329,7 +329,7 @@ export function TasksTopbar({
           onNavigate={onNavigate}
         />
       ) : null}
-      {route.kind === "project" ? (
+      {route.kind === "project" || route.kind === "all" ? (
         // Hidden in phone-width containers, where the board is unusable and
         // the shell renders the list regardless (see BOARD_MIN_WIDTH).
         <span className="hidden @md:block">

--- a/plugins/tasks/views/board/drop-position.test.ts
+++ b/plugins/tasks/views/board/drop-position.test.ts
@@ -4,6 +4,7 @@ import {
   applyBoardMove,
   dropIndexForPointer,
   dropNeighborsForIndex,
+  projectDropNeighbors,
   visibleBoardStatuses,
 } from "./drop-position.js";
 
@@ -36,6 +37,22 @@ describe("visibleBoardStatuses", () => {
       "done",
       "canceled",
     ]);
+  });
+});
+
+describe("projectDropNeighbors", () => {
+  it("never uses another project's card as a server reorder neighbor", () => {
+    const local = { id: "a", projectId: "project-a" };
+    const column = [
+      { id: "b", projectId: "project-b" },
+      local,
+      { id: "c", projectId: "project-a" },
+      { id: "d", projectId: "project-b" },
+    ];
+    expect(projectDropNeighbors(column, local, 3)).toEqual({
+      beforeTaskId: "c",
+      afterTaskId: null,
+    });
   });
 });
 

--- a/plugins/tasks/views/board/drop-position.ts
+++ b/plugins/tasks/views/board/drop-position.ts
@@ -55,6 +55,29 @@ export function dropNeighborsForIndex(
 }
 
 /**
+ * Finds reorder neighbors for a global board column. Cards from other
+ * projects participate in the visual insertion position but must never be
+ * sent as neighbors: board positions are stored per project.
+ */
+export function projectDropNeighbors<
+  T extends { id: string; projectId: string },
+>(column: readonly T[], task: T, visualDropIndex: number): BoardDropNeighbors {
+  const projectDropIndex = column
+    .slice(0, visualDropIndex)
+    .filter(
+      (candidate) =>
+        candidate.id !== task.id && candidate.projectId === task.projectId,
+    ).length;
+  return dropNeighborsForIndex(
+    column
+      .filter((candidate) => candidate.projectId === task.projectId)
+      .map((candidate) => candidate.id),
+    task.id,
+    projectDropIndex,
+  );
+}
+
+/**
  * Insertion slot for a pointer at `pointerY`, given the vertical centers of
  * the column's cards (top-to-bottom, dragged card excluded): the card count
  * whose center sits above the pointer.

--- a/plugins/tasks/views/board/index.tsx
+++ b/plugins/tasks/views/board/index.tsx
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useMemo,
   useRef,
   useState,
   type PointerEvent as ReactPointerEvent,
@@ -8,23 +9,34 @@ import {
 import {
   TASK_STATUSES,
   type Label,
+  type Project,
   type Task,
   type TaskStatus,
   type TaskThread,
 } from "../../shared/contract.js";
 import {
   listAllTasks,
+  useProjects,
   useTasksQuery,
   useTasksRpc,
   type TasksRpc,
 } from "../../shell/data.js";
 import { useTasksNavigation } from "../../shell/routes.js";
 import { NewTaskDialog } from "../manage/index.js";
+import { ListFilterBar, type ListFilterState } from "../list/filter-bar.js";
+import {
+  listPreferenceScope,
+  loadListPreference,
+  storeListPreference,
+  type ListPreference,
+} from "../list/list-preference.js";
+import { labelFilterOptions, selectedLabelIds } from "../list/lib.js";
+import { useLabels } from "../list/data.js";
 import {
   applyBoardMove,
   BOARD_STATUSES,
   dropIndexForPointer,
-  dropNeighborsForIndex,
+  projectDropNeighbors,
   visibleBoardStatuses,
 } from "./drop-position.js";
 import { PriorityIcon, STATUS_LABELS, StatusIcon } from "./icons.js";
@@ -58,16 +70,35 @@ const EMPTY_META: BoardCardMeta = {
 
 async function fetchBoard(
   rpc: TasksRpc,
-  projectId: string,
+  projectId: string | null,
+  projectIds: readonly string[],
+  filters: {
+    statuses: readonly TaskStatus[];
+    priorities: readonly Task["priority"][];
+    labelIds: readonly string[] | null;
+  },
 ): Promise<BoardData> {
-  const tasks = await listAllTasks(rpc, { projectId });
+  const tasks = await listAllTasks(rpc, {
+    ...(projectId === null ? {} : { projectId }),
+    statuses: [...filters.statuses],
+    ...(filters.priorities.length > 0
+      ? { priorities: [...filters.priorities] }
+      : {}),
+    ...(filters.labelIds === null ? {} : { labelIds: [...filters.labelIds] }),
+  });
   const topLevel = tasks.filter((task) => task.parentTaskId === null);
 
   // Everything below decorates cards; a failure hides chips, never the board.
-  const labels = await rpc.call("listLabels", { projectId }).then(
-    (result) => result.labels,
-    () => [],
-  );
+  const labels = (
+    await Promise.all(
+      projectIds.map((id) =>
+        rpc.call("listLabels", { projectId: id }).then(
+          (result) => result.labels,
+          () => [],
+        ),
+      ),
+    )
+  ).flat();
   const subProgress = new Map<string, { done: number; total: number }>();
   for (const task of tasks) {
     if (task.parentTaskId === null) continue;
@@ -77,7 +108,7 @@ async function fetchBoard(
     subProgress.set(task.parentTaskId, entry);
   }
   const activeTaskIds = await listAllTasks(rpc, {
-    projectId,
+    ...(projectId === null ? {} : { projectId }),
     activeOnly: true,
   }).then(
     (result) => new Set(result.map((task) => task.id)),
@@ -179,6 +210,7 @@ interface TaskCardProps {
   task: Task;
   labelsById: Map<string, Label>;
   meta: BoardCardMeta;
+  project?: Project;
   ghost?: boolean;
   dragging?: boolean;
   cardRef?: (element: HTMLDivElement | null) => void;
@@ -190,6 +222,7 @@ function TaskCard({
   task,
   labelsById,
   meta,
+  project,
   ghost = false,
   dragging = false,
   cardRef,
@@ -217,6 +250,16 @@ function TaskCard({
         <span className="tabular-nums">{task.key}</span>
         <WorkingAgentsChip threads={meta.workingThreads} />
       </div>
+      {project ? (
+        <div className="mt-1 flex min-w-0 items-center gap-1.5 text-2xs font-medium text-muted-foreground">
+          <span
+            aria-hidden
+            className="size-2.5 shrink-0 rounded-sm"
+            style={{ backgroundColor: project.color }}
+          />
+          <span className="truncate">{project.name}</span>
+        </div>
+      ) : null}
       <div className="mt-1 line-clamp-2 text-sm leading-snug font-medium">
         {task.title}
       </div>
@@ -272,16 +315,80 @@ function BoardSkeleton() {
 }
 
 export interface BoardViewProps {
-  projectId: string;
+  /** null combines tasks from every current and future project. */
+  projectId: string | null;
 }
 
 export function BoardView({ projectId }: BoardViewProps) {
   const rpc = useTasksRpc();
   const navigation = useTasksNavigation();
+  const projects = useProjects();
+  const globalBoard = projectId === null;
+  const preferenceScope = listPreferenceScope(projectId, false);
+  const [preference, setPreference] = useState<ListPreference>(() =>
+    loadListPreference(preferenceScope),
+  );
+  useEffect(() => {
+    setPreference(loadListPreference(preferenceScope));
+  }, [preferenceScope]);
+  const projectIds = useMemo(
+    () =>
+      projectId === null
+        ? (projects.data ?? []).map((project) => project.id)
+        : [projectId],
+    [projectId, projects.data],
+  );
+  const labels = useLabels(projectIds);
+  const labelOptions = useMemo(
+    () => labelFilterOptions(labels.data ?? []),
+    [labels.data],
+  );
+  const labelIds = useMemo(() => {
+    if (!globalBoard || preference.filters.labelNames.length === 0) return null;
+    if (labels.data === undefined) return null;
+    return selectedLabelIds(labelOptions, preference.filters.labelNames);
+  }, [globalBoard, labelOptions, labels.data, preference.filters.labelNames]);
+  // An unfiltered All tasks board intentionally omits canceled work. Selecting
+  // Canceled in the shared Status filter remains an explicit inspection path.
+  const boardFilters = useMemo(
+    () => ({
+      statuses: globalBoard
+        ? preference.filters.statuses.length > 0
+          ? preference.filters.statuses
+          : TASK_STATUSES.filter((status) => status !== "canceled")
+        : TASK_STATUSES,
+      priorities: globalBoard ? preference.filters.priorities : [],
+      labelIds: globalBoard ? labelIds : null,
+    }),
+    [
+      globalBoard,
+      labelIds,
+      preference.filters.priorities,
+      preference.filters.statuses,
+    ],
+  );
+  const projectsById = useMemo(
+    () =>
+      new Map((projects.data ?? []).map((project) => [project.id, project])),
+    [projects.data],
+  );
+  const setFilters = (filters: ListFilterState) => {
+    setPreference((current) => {
+      const next: ListPreference = { filters, sort: current.sort };
+      storeListPreference(preferenceScope, next);
+      return next;
+    });
+  };
   const board = useTasksQuery(
-    (queryRpc) => fetchBoard(queryRpc, projectId),
+    (queryRpc) => fetchBoard(queryRpc, projectId, projectIds, boardFilters),
     ["tasks:changed", "projects:changed", "threads:changed"],
-    [projectId],
+    [
+      projectId,
+      projectIds.join(),
+      boardFilters.statuses.join(),
+      boardFilters.priorities.join(),
+      boardFilters.labelIds?.join() ?? "",
+    ],
   );
 
   // Local column state renders instantly on drop; realtime refetches replace
@@ -349,11 +456,15 @@ export function BoardView({ projectId }: BoardViewProps) {
   ) => {
     const current = columnsRef.current;
     if (!current) return;
-    const neighbors = dropNeighborsForIndex(
-      current[toStatus].map((task) => task.id),
-      taskId,
-      dropIndex,
-    );
+    const task = Object.values(current)
+      .flat()
+      .find((candidate) => candidate.id === taskId);
+    if (!task) return;
+    // Positions are intentionally scoped to a project. A global column can
+    // visually interleave projects, but its server reorder neighbors must
+    // never cross that boundary (nor can a board move change projectId).
+    const destination = current[toStatus];
+    const neighbors = projectDropNeighbors(destination, task, dropIndex);
     setColumns(applyBoardMove(current, taskId, toStatus, dropIndex));
     void rpc
       .call("boardMove", {
@@ -502,6 +613,7 @@ export function BoardView({ projectId }: BoardViewProps) {
           task={task}
           labelsById={labelsById}
           meta={metaByTaskId.get(task.id) ?? EMPTY_META}
+          project={globalBoard ? projectsById.get(task.projectId) : undefined}
           dragging={drag?.taskId === task.id}
           cardRef={(element) => {
             if (element) cardRefs.current.set(task.id, element);
@@ -550,7 +662,7 @@ export function BoardView({ projectId }: BoardViewProps) {
     );
   };
 
-  return (
+  const boardContent = (
     <div
       ref={boardRef}
       className={cn(
@@ -572,6 +684,9 @@ export function BoardView({ projectId }: BoardViewProps) {
             task={ghostTask}
             labelsById={labelsById}
             meta={metaByTaskId.get(ghostTask.id) ?? EMPTY_META}
+            project={
+              globalBoard ? projectsById.get(ghostTask.projectId) : undefined
+            }
             ghost
           />
         </div>
@@ -585,5 +700,21 @@ export function BoardView({ projectId }: BoardViewProps) {
         defaultStatus={quickAddStatus ?? undefined}
       />
     </div>
+  );
+  return globalBoard ? (
+    <div className="flex h-full min-h-0 flex-col">
+      <ListFilterBar
+        filters={preference.filters}
+        onChange={setFilters}
+        sort={preference.sort}
+        onSortChange={() => {}}
+        labelOptions={labelOptions}
+        taskCount={board.data?.tasks.length}
+        showSort={false}
+      />
+      <div className="min-h-0 flex-1">{boardContent}</div>
+    </div>
+  ) : (
+    boardContent
   );
 }

--- a/plugins/tasks/views/list/filter-bar.tsx
+++ b/plugins/tasks/views/list/filter-bar.tsx
@@ -144,6 +144,7 @@ export function ListFilterBar({
   onSortChange,
   labelOptions,
   taskCount,
+  showSort = true,
 }: {
   filters: ListFilterState;
   onChange: (filters: ListFilterState) => void;
@@ -151,6 +152,7 @@ export function ListFilterBar({
   onSortChange: (sort: TaskSort) => void;
   labelOptions: readonly LabelFilterOption[];
   taskCount: number | undefined;
+  showSort?: boolean;
 }) {
   const keepOpen = (event: Event) => event.preventDefault();
   // Show the Label chip whenever there are options or a remembered selection
@@ -296,7 +298,7 @@ export function ListFilterBar({
       </div>
       {/* Sort and the count sit outside the scroller so they stay visible and
           aligned however far the filter chips overflow. */}
-      <SortChip sort={sort} onChange={onSortChange} />
+      {showSort ? <SortChip sort={sort} onChange={onSortChange} /> : null}
       <span className="shrink-0 whitespace-nowrap text-xs tabular-nums text-subtle-foreground">
         {taskCount === undefined
           ? ""


### PR DESCRIPTION
## Summary

"All tasks" can now be viewed as a board spanning every project, not just as a list.

- The route grammar carries a view mode for the all-tasks route (`all?view=board`), so the choice is linkable and survives navigation.
- The topbar list/board switch now renders on the all-tasks route (still hidden below `BOARD_MIN_WIDTH`, where the shell falls back to the list).
- `BoardView` accepts a `null` projectId to load tasks across all projects, reusing the list filter bar for status/priority/label filtering. Cards show project identity.
- An unfiltered global board omits canceled work: it sends an explicit `statuses` list to `listTasks`. Selecting Canceled in the shared Status filter is still an explicit inspection path.

## Cross-project drag correctness

Board positions are stored per project. A drag in a global column can land between cards from other projects, so `projectDropNeighbors` maps the visual insertion index to same-project neighbors before computing the `beforeTaskId`/`afterTaskId` sent to the server — cards from other projects influence the visual slot but are never sent as reorder neighbors.

## Testing

Three unit tests cover the new behavior. All CI checks pass; locally the two touched test files pass (38 tests) along with `tsc --noEmit` for the plugin.

What the tests actually verify:

- **`routes.ts` round-trip** (`shell.test.tsx`) — `parseTasksRoute(tasksRouteToSubPath(route))` is identity for both all-tasks view modes, and an empty subPath still parses to the list view. This is the guard against the view mode getting dropped or defaulting to board.
- **Global board rendering** (`shell.test.tsx`) — mounting the panel at `all?view=board` with tasks seeded across two projects renders cards from both, shows each project's name on the cards, exposes the List/Board switch, and renders no canceled card. The fake rpc honors the `statuses` argument, so the canceled assertion is a check on the request the board makes, not on the fake.
- **`projectDropNeighbors`** (`drop-position.test.ts`) — one case where a card is dragged in a column interleaved with another project's cards, asserting the neighbors sent to the server are same-project only.

Limits worth naming: the drag coverage is a single unit test of the neighbor calculation, not a rendered drag interaction, and there is no test for the filter bar wiring (priority/label filters) on the global board. I did not run the plugin's `cli/` suite locally — those e2e tests were timing out in this sandbox — but they are untouched by this change and pass in CI.

The first CI run failed on the canceled-card assertion: status filtering is server-side, and the test's fake rpc originally ignored `statuses`, returning the canceled task regardless of what the board requested. Making the fake filter by `statuses` fixed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)