### PR TITLE
Polish active child thread banner

### DIFF
--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
@@ -732,7 +732,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="parent thread with active children (collapsed)"
-        hint="spinning icon signals active work; click to expand the child list"
+        hint="the primary child mirrors other background-work banners without an animated flash; click to expand the child list"
       >
         <Row childThreads={childThreadsFixture} mergeBase={null} />
       </StoryRow>

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
@@ -282,7 +282,7 @@ describe("ThreadPromptContextBanner", () => {
     expect(markup).toContain("PR #128 · Closed");
   });
 
-  it("labels active child threads", () => {
+  it("summarizes child work without flashing the banner", () => {
     const markup = renderToStaticMarkup(
       <MemoryRouter>
         <ThreadPromptContextBanner
@@ -307,8 +307,51 @@ describe("ThreadPromptContextBanner", () => {
       </MemoryRouter>,
     );
 
-    expect(markup).toContain('aria-label="Active child threads"');
-    expect(markup).toContain("1 active child thread");
+    expect(markup).toContain('aria-label="Child threads"');
+    expect(markup).toContain(
+      "1 child thread running: Investigate failing checks",
+    );
+    expect(markup).toContain("Running child thread:");
+    expect(markup).toContain("Investigate failing checks");
+    expect(markup).toContain('data-icon="UserRound"');
+    expect(markup).toContain("animate-shine-icon");
+    expect(markup).not.toContain("animate-shine font-medium");
+  });
+
+  it("summarizes additional running child threads", () => {
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <ThreadPromptContextBanner
+          gitSection={null}
+          gitSectionPending={false}
+          archivedSection={null}
+          environmentGoneSection={null}
+          parentThreadSection={null}
+          childThreadsSection={{
+            items: [
+              {
+                id: "thr_primary",
+                title: "Investigate failing checks",
+                href: "/threads/thr_primary",
+              },
+              {
+                id: "thr_other",
+                title: "Review the release notes",
+                href: "/threads/thr_other",
+              },
+            ],
+          }}
+          pullRequestSection={null}
+          expandedSection={null}
+          onToggleSection={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(markup).toContain(
+      "2 child threads running: Investigate failing checks",
+    );
+    expect(markup).toContain("+1 more");
   });
 
   it("labels standalone actionable pull request attention", () => {

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter } from "react-router-dom";
 import type { ThreadPullRequest } from "@bb/domain";
 import { describe, expect, it } from "vitest";
 import {
+  isThreadDisplayStatusBannerActive,
   ThreadPromptContextBanner,
   type ThreadPromptGitSection,
 } from "./ThreadPromptContextBanner";
@@ -309,16 +310,16 @@ describe("ThreadPromptContextBanner", () => {
 
     expect(markup).toContain('aria-label="Child threads"');
     expect(markup).toContain(
-      "1 child thread running: Investigate failing checks",
+      "1 active child thread: Investigate failing checks",
     );
-    expect(markup).toContain("Running child thread:");
+    expect(markup).toContain("Active child thread:");
     expect(markup).toContain("Investigate failing checks");
     expect(markup).toContain('data-icon="UserRound"');
     expect(markup).toContain("animate-shine-icon");
     expect(markup).not.toContain("animate-shine font-medium");
   });
 
-  it("summarizes additional running child threads", () => {
+  it("summarizes additional active child threads", () => {
     const markup = renderToStaticMarkup(
       <MemoryRouter>
         <ThreadPromptContextBanner
@@ -349,9 +350,43 @@ describe("ThreadPromptContextBanner", () => {
     );
 
     expect(markup).toContain(
-      "2 child threads running: Investigate failing checks",
+      "2 active child threads: Investigate failing checks",
     );
     expect(markup).toContain("+1 more");
+  });
+
+  it("uses neutral active copy for a child waiting for a host", () => {
+    expect(isThreadDisplayStatusBannerActive("waiting-for-host")).toBe(true);
+
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <ThreadPromptContextBanner
+          gitSection={null}
+          gitSectionPending={false}
+          archivedSection={null}
+          environmentGoneSection={null}
+          parentThreadSection={null}
+          childThreadsSection={{
+            items: [
+              {
+                id: "thr_waiting",
+                title: "Waiting for build host",
+                href: "/threads/thr_waiting",
+              },
+            ],
+          }}
+          pullRequestSection={null}
+          expandedSection={null}
+          onToggleSection={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(markup).toContain(
+      "1 active child thread: Waiting for build host",
+    );
+    expect(markup).toContain("Active child thread:");
+    expect(markup).not.toContain("Running child thread:");
   });
 
   it("labels standalone actionable pull request attention", () => {

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
@@ -20,7 +20,6 @@ import {
 import {
   activityIconClass,
   activityRowClass,
-  activityTextClass,
 } from "@/components/ui/activity-row-styles";
 import { WorkspaceChangesList } from "@/components/thread/WorkspaceChangesList";
 import {
@@ -250,7 +249,6 @@ function ChildThreadIcon({ className }: { className?: string }) {
 }
 
 interface SectionToggleButtonProps {
-  active?: boolean;
   id: string;
   controlsId: string;
   ariaLabel?: string;
@@ -263,7 +261,6 @@ interface SectionToggleButtonProps {
 }
 
 function SectionToggleButton({
-  active = false,
   id,
   controlsId,
   ariaLabel,
@@ -283,29 +280,22 @@ function SectionToggleButton({
       aria-label={ariaLabel}
       onClick={onToggle}
       className={cn(
-        active && activityRowClass("active"),
         "flex cursor-pointer items-center text-xs transition-colors",
         PROMPT_STACK_INLAY_SEGMENT_CLASS,
-        active
-          ? "text-foreground hover:bg-background/80"
-          : "hover:bg-state-hover",
+        "hover:bg-state-hover",
         SEGMENT_SHRINK_CLASS,
         // When a label sits between the icon and the chevron we space the row
         // for legibility (6px). With no label the chevron sits right after the
         // icon — the icons' own internal padding provides enough separation,
         // and a gap here makes the pair look untethered.
         label !== null && label !== undefined ? "gap-1.5" : "gap-0",
-        !active &&
-          (isExpanded ? "text-foreground" : "text-muted-foreground"),
+        isExpanded ? "text-foreground" : "text-muted-foreground",
       )}
     >
       {icon}
       {label !== null && label !== undefined ? (
         <span
-          className={cn(
-            "min-w-0 truncate",
-            active && activityTextClass("active"),
-          )}
+          className="min-w-0 truncate"
           data-promptbox-hide-compact={hideLabelInCompact ? "" : undefined}
         >
           {label}
@@ -314,23 +304,14 @@ function SectionToggleButton({
       {hideLabelInCompact &&
       compactLabel !== null &&
       compactLabel !== undefined ? (
-        <span
-          className={cn(
-            "min-w-0 truncate",
-            active && activityTextClass("active"),
-          )}
-          data-promptbox-compact-label=""
-        >
+        <span className="min-w-0 truncate" data-promptbox-compact-label="">
           {compactLabel}
         </span>
       ) : null}
       <Icon
         name="ChevronDown"
         className={cn(
-          active
-            ? activityIconClass("active")
-            : "text-subtle-foreground",
-          "size-3.5 shrink-0 transition-transform duration-200",
+          "size-3.5 shrink-0 text-subtle-foreground transition-transform duration-200",
           isExpanded && "rotate-180",
         )}
         aria-hidden="true"
@@ -696,7 +677,7 @@ const CHILD_THREADS_HEADER_BUTTON_CLASS = activityRowClass(
 );
 
 function childThreadsLabel(count: number): string {
-  return `${count} active child ${count === 1 ? "thread" : "threads"}`;
+  return `${count} child ${count === 1 ? "thread" : "threads"} running`;
 }
 
 function ActiveChildThreadsCard({
@@ -708,10 +689,15 @@ function ActiveChildThreadsCard({
   isExpanded: boolean;
   onToggle: () => void;
 }) {
-  const label = childThreadsLabel(childThreadsSection.items.length);
+  const primary = childThreadsSection.items[0];
+  if (!primary) {
+    return null;
+  }
+  const otherCount = childThreadsSection.items.length - 1;
+  const groupLabel = childThreadsLabel(childThreadsSection.items.length);
   return (
     <PromptStackCard
-      ariaLabel="Active child threads"
+      ariaLabel="Child threads"
       className="overflow-hidden"
       style={{ minHeight: THREAD_PROMPT_CONTEXT_BANNER_ROW_HEIGHT }}
     >
@@ -721,28 +707,32 @@ function ActiveChildThreadsCard({
           id={SECTION_IDS.childThreads.toggle}
           aria-expanded={isExpanded}
           aria-controls={SECTION_IDS.childThreads.body}
-          aria-label={label}
+          aria-label={`${groupLabel}: ${primary.title}`}
           onClick={onToggle}
           className={CHILD_THREADS_HEADER_BUTTON_CLASS}
         >
           <Icon
-            name="CircleDashed"
+            name="UserRound"
             className={activityIconClass("active", "size-3.5 shrink-0")}
             aria-hidden="true"
           />
-          <span
-            className={activityTextClass(
-              "active",
-              "min-w-0 flex-1 truncate text-left",
-            )}
-          >
-            {label}
+          <span className="min-w-0 flex-1 truncate text-left">
+            <span className="text-muted-foreground">
+              Running child thread:{" "}
+            </span>
+            <span className="font-medium text-foreground/80">
+              {primary.title}
+            </span>
           </span>
+          {otherCount > 0 ? (
+            <span className="shrink-0 text-muted-foreground">
+              +{otherCount} more
+            </span>
+          ) : null}
           <Icon
             name="ChevronDown"
             className={cn(
-              activityIconClass("active"),
-              "size-3.5 shrink-0 transition-transform duration-200",
+              "size-3.5 shrink-0 text-muted-foreground transition-transform duration-200",
               isExpanded && "rotate-180",
             )}
             aria-hidden="true"

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
@@ -677,7 +677,7 @@ const CHILD_THREADS_HEADER_BUTTON_CLASS = activityRowClass(
 );
 
 function childThreadsLabel(count: number): string {
-  return `${count} child ${count === 1 ? "thread" : "threads"} running`;
+  return `${count} active child ${count === 1 ? "thread" : "threads"}`;
 }
 
 function ActiveChildThreadsCard({
@@ -718,7 +718,7 @@ function ActiveChildThreadsCard({
           />
           <span className="min-w-0 flex-1 truncate text-left">
             <span className="text-muted-foreground">
-              Running child thread:{" "}
+              Active child thread:{" "}
             </span>
             <span className="font-medium text-foreground/80">
               {primary.title}

--- a/apps/app/src/components/ui/icon.stories.tsx
+++ b/apps/app/src/components/ui/icon.stories.tsx
@@ -38,7 +38,7 @@ const USAGE: Partial<Record<IconName, string>> = {
   ChevronsUp: "Git diff toolbar expand-all",
   Circle: "Radio item indicator in menus",
   CircleCheck: "Auth callback success state",
-  CircleDashed: "Child-thread busy section indicator",
+  CircleDashed: "Dashed status circle",
   CircleQuestion: "Thread needs user input and timeline question rows",
   CircleX: "Auth callback failure state",
   ClosePluginPane: "Close a split pane containing a plugin surface",

--- a/apps/app/src/components/ui/icon.stories.tsx
+++ b/apps/app/src/components/ui/icon.stories.tsx
@@ -100,7 +100,8 @@ const USAGE: Partial<Record<IconName, string>> = {
   Square: "Stop button while running, in-progress and pending todo glyphs",
   TextWrap: "Line-wrap toggle for diff cards and source file previews",
   Trash2: "Delete queued message, remove project source",
-  UserRound: "Parent-thread indicator in sidebar and prompt banner",
+  UserRound:
+    "Thread mentions, parent-thread indicators, and active child-thread banner",
   UserRoundPlus: "unused legacy parent-action icon",
   Workflow: "Workflow card indicator in the prompt stack",
   X: "Close dialogs/drawers, clear search input, remove attachment, close metadata panel",


### PR DESCRIPTION
## Summary

- align the active child-thread banner with background activity cards by showing the primary child title and a `+N more` count
- use the thread mention `UserRound` icon with the shared active icon shimmer while keeping the banner text static
- retain the expandable child list and update story/test coverage for single and multiple running children

## Validation

- `pnpm exec turbo run test --filter=@bb/app -- ThreadPromptContextBanner`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- visual QA in the Context banner Ladle story at desktop and compact widths

> AGENT GENERATED: by GPT-5
