### PR TITLE
Remove deprecated composer bootstrap endpoint

### DIFF
--- a/apps/server/src/routes/threads/data.ts
+++ b/apps/server/src/routes/threads/data.ts
@@ -15,7 +15,6 @@ import {
   publicApiRoutes,
   typedRoutes,
   type PublicApiSchema,
-  type ThreadComposerBootstrapResponse,
   type ThreadConversationOutlineResponse,
   type ThreadTimelineQuery,
 } from "@bb/server-contract";
@@ -69,7 +68,6 @@ import {
   getLastThreadOutput,
   listThreadEventRows,
 } from "../../services/threads/thread-data.js";
-import { resolveSystemExecutionOptions } from "../../services/system/execution-options.js";
 import { findKnownAcpAgentForProviderId } from "../../services/system/known-acp-agents.js";
 import { listThreadPromptHistory } from "../../services/prompt-history.js";
 import { tryResolveExistingThreadExecutionPlan } from "../../services/threads/thread-execution-plan.js";
@@ -99,57 +97,6 @@ function resolveThreadProviderDisplayName(
   return isAgentProviderId(providerId)
     ? getBuiltInAgentProviderInfo(providerId).displayName
     : undefined;
-}
-
-interface ThreadComposerExecutionOptionsSource {
-  archivedAt: number | null;
-  environmentId: string | null;
-}
-
-function shouldResolveThreadComposerExecutionOptions(
-  thread: ThreadComposerExecutionOptionsSource,
-): boolean {
-  return thread.archivedAt === null && thread.environmentId !== null;
-}
-
-async function buildThreadComposerBootstrapResponse(
-  deps: AppDeps,
-  threadId: string,
-): Promise<ThreadComposerBootstrapResponse> {
-  const thread = requirePublicThread(deps.db, threadId);
-  const defaultExecutionOptions =
-    (
-      await tryResolveExistingThreadExecutionPlan(deps, {
-        executionSource: "client/turn/requested",
-        input: {},
-        threadId,
-      })
-    )?.defaultView ?? null;
-  const composerEnvironmentId = shouldResolveThreadComposerExecutionOptions(
-    thread,
-  )
-    ? thread.environmentId
-    : null;
-  const executionOptions = composerEnvironmentId
-    ? await resolveSystemExecutionOptions(deps, {
-        environmentId: composerEnvironmentId,
-        providerId: thread.providerId,
-      })
-    : null;
-
-  return {
-    defaultExecutionOptions,
-    queuedMessages: listQueuedThreadMessages(deps.db, threadId).map(
-      toThreadQueuedMessage,
-    ),
-    executionOptions,
-    pendingInteractions:
-      deps.pendingInteractions.listPendingThreadInteractions(threadId),
-    promptHistory: listThreadPromptHistory(deps, {
-      threadId,
-      limit: PROMPT_HISTORY_ENTRY_LIMIT,
-    }),
-  };
 }
 
 function validateFilePath(filePath: string): void {
@@ -503,12 +450,6 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
       output: getLastThreadOutput(deps.db, context.req.param("id")),
     });
   });
-
-  get(routes.composerBootstrap, async (context) =>
-    context.json(
-      await buildThreadComposerBootstrapResponse(deps, context.req.param("id")),
-    ),
-  );
 
   get(routes.queuedMessages, (context) => {
     const threadId = context.req.param("id");

--- a/apps/server/test/public/public-thread-data.test.ts
+++ b/apps/server/test/public/public-thread-data.test.ts
@@ -1,8 +1,6 @@
 import { and, eq } from "drizzle-orm";
 import {
-  archiveThread,
   claimQueuedThreadMessage,
-  createPromptHistoryEntry,
   createQueuedThreadMessageId,
   createThreadSection,
   deleteQueuedThreadMessage,
@@ -17,7 +15,6 @@ import {
   reorderQueuedThreadMessage,
   setQueuedThreadMessageGroupBoundary,
   setThreadExecutionOverride,
-  upsertProjectExecutionDefaults,
 } from "@bb/db";
 import {
   encodeClientTurnRequestIdNumber,
@@ -31,7 +28,6 @@ import {
   sidebarBootstrapResponseSchema,
   threadSectionMutationResponseSchema,
   threadSectionSchema,
-  threadComposerBootstrapResponseSchema,
   threadConversationOutlineResponseSchema,
   threadQueuedMessageListResponseSchema,
   threadTimelineResponseSchema,
@@ -50,19 +46,14 @@ import {
   waitForQueuedCommand,
   waitForQueuedCommandAfter,
 } from "../helpers/commands.js";
-import {
-  registerHostRpcResponder,
-  registerProviderHostRpcResponder,
-} from "../helpers/host-rpc.js";
+import { registerHostRpcResponder } from "../helpers/host-rpc.js";
 import { readJson } from "../helpers/json.js";
 import { textInput } from "../helpers/prompt-input.js";
 import {
-  seedHost,
   seedQueuedMessage,
   seedEnvironment,
   seedEvent,
   seedHostSession,
-  seedPrimaryHost,
   seedProjectWithSource,
   seedStoredEvent,
   seedThread,
@@ -3220,308 +3211,6 @@ describe("public thread data routes", () => {
           }),
         ]),
       );
-    });
-  });
-
-  it("loads legacy thread composer bootstrap state", async () => {
-    await withTestHarness(async (harness) => {
-      seedHostSession(harness.deps, {
-        id: "host-composer-default",
-      });
-      const { host, session } = seedHostSession(harness.deps, {
-        id: "host-composer-thread",
-      });
-      seedPrimaryHost(harness.deps, host.id);
-      const providerResponder = registerProviderHostRpcResponder(harness, {
-        hostId: host.id,
-        sessionId: session.id,
-        modelsByProviderId: {
-          codex: {
-            models: [
-              {
-                id: "gpt-5.5",
-                model: "gpt-5.5",
-                displayName: "GPT-5.5",
-                description: "Frontier model",
-                supportedReasoningEfforts: [
-                  {
-                    reasoningEffort: "xhigh",
-                    description: "Extra high",
-                  },
-                ],
-                defaultReasoningEffort: "xhigh",
-                isDefault: true,
-              },
-            ],
-            selectedOnlyModels: [],
-          },
-        },
-      });
-      const { project } = seedProjectWithSource(harness.deps, {
-        hostId: host.id,
-      });
-      const environment = seedEnvironment(harness.deps, {
-        hostId: host.id,
-        projectId: project.id,
-      });
-      const thread = seedThread(harness.deps, {
-        projectId: project.id,
-        environmentId: environment.id,
-      });
-      seedEvent(harness.deps, {
-        threadId: thread.id,
-        environmentId: environment.id,
-        sequence: 1,
-        type: "client/turn/requested",
-        scope: threadScope(),
-        data: {
-          direction: "outbound",
-          requestId: encodeClientTurnRequestIdNumber({ value: 601 }),
-          input: [{ type: "text", text: "Accepted prompt" }],
-          target: { kind: "new-turn" },
-          execution: {
-            model: "gpt-5.5",
-            serviceTier: "default",
-            reasoningLevel: "xhigh",
-            permissionMode: "workspace-write",
-            source: "client/turn/requested",
-          },
-          initiator: "user",
-          senderThreadId: null,
-          request: {
-            method: "turn/start",
-            params: {},
-          },
-          source: "tell",
-        },
-      });
-      createPromptHistoryEntry(harness.deps.db, {
-        projectId: project.id,
-        threadId: thread.id,
-        scope: "thread",
-        requestSequence: 1,
-        input: textInput("Accepted prompt"),
-      });
-      seedQueuedMessage(harness.deps, {
-        threadId: thread.id,
-        content: textInput("Queued message"),
-        model: "gpt-5.5",
-        reasoningLevel: "xhigh",
-        permissionMode: "accept-edits",
-        serviceTier: "default",
-      });
-
-      const response = await harness.app.request(
-        `/api/v1/threads/${thread.id}/composer-bootstrap`,
-      );
-
-      expect(response.status).toBe(200);
-      const bootstrap = threadComposerBootstrapResponseSchema.parse(
-        await readJson(response),
-      );
-      expect(bootstrap.defaultExecutionOptions).toMatchObject({
-        model: "gpt-5.5",
-        reasoningLevel: "xhigh",
-        permissionMode: "accept-edits",
-      });
-      expect(bootstrap.queuedMessages).toHaveLength(1);
-      expect(bootstrap.queuedMessages[0]?.content).toEqual(
-        textInput("Queued message"),
-      );
-      expect(bootstrap.pendingInteractions).toEqual([]);
-      expect(bootstrap.promptHistory.map((entry) => entry.input)).toEqual(
-        expect.arrayContaining([
-          textInput("Accepted prompt"),
-          textInput("Queued message"),
-        ]),
-      );
-      const { executionOptions } = bootstrap;
-      if (executionOptions === null) {
-        throw new Error(
-          "expected resolved executionOptions for an environment-backed thread",
-        );
-      }
-      const codexProvider = executionOptions.providers.find(
-        (provider) => provider.id === "codex",
-      );
-      expect(codexProvider).toMatchObject({
-        id: "codex",
-      });
-      expect(executionOptions.models[0]?.model).toBe("gpt-5.5");
-      expect(
-        providerResponder.requests.map((request) => request.command),
-      ).toEqual([
-        {
-          type: "known_acp_agents.status",
-          agents: [
-            { id: "acp-opencode", executableName: "opencode" },
-            { id: "acp-omp", executableName: "omp" },
-            { id: "acp-grok", executableName: "grok" },
-            { id: "acp-hermes-agent", executableName: "hermes" },
-          ],
-        },
-        {
-          type: "provider.list_models",
-          providerId: "codex",
-          cwd: "/tmp/test-environment",
-        },
-      ]);
-    });
-  });
-
-  it("keeps ACP thread composer defaults when provider discovery is degraded", async () => {
-    await withTestHarness(async (harness) => {
-      const { host, session } = seedHostSession(harness.deps, {
-        id: "host-composer-acp-degraded",
-      });
-      seedPrimaryHost(harness.deps, host.id);
-      const providerResponder = registerHostRpcResponder(harness, {
-        hostId: host.id,
-        sessionId: session.id,
-        handle: (request) => {
-          if (
-            request.command.type === "known_acp_agents.status" ||
-            request.command.type === "provider.list_models"
-          ) {
-            return {
-              ok: false,
-              errorCode: "command_failed",
-              errorMessage: "Runtime shutting down",
-            };
-          }
-          throw new Error(`Unexpected RPC command ${request.command.type}`);
-        },
-      });
-      const { project } = seedProjectWithSource(harness.deps, {
-        hostId: host.id,
-      });
-      upsertProjectExecutionDefaults(harness.deps.db, {
-        projectId: project.id,
-        providerId: "acp-cursor",
-        model: "composer-2.5",
-        reasoningLevel: "medium",
-        permissionMode: "accept-edits",
-        serviceTier: "default",
-      });
-      const environment = seedEnvironment(harness.deps, {
-        hostId: host.id,
-        projectId: project.id,
-      });
-      const thread = seedThread(harness.deps, {
-        projectId: project.id,
-        environmentId: environment.id,
-        providerId: "acp-opencode",
-      });
-      seedThreadRuntimeState(harness.deps, {
-        environmentId: environment.id,
-        inputText: "New review comments on the PR",
-        model: "zai-coding-plan/glm-5.2",
-        permissionMode: "accept-edits",
-        providerThreadId: "ses_opencode",
-        reasoningLevel: "medium",
-        threadId: thread.id,
-      });
-
-      const response = await harness.app.request(
-        `/api/v1/threads/${thread.id}/composer-bootstrap`,
-      );
-
-      expect(response.status).toBe(200);
-      const bootstrap = threadComposerBootstrapResponseSchema.parse(
-        await readJson(response),
-      );
-      expect(bootstrap.defaultExecutionOptions).toMatchObject({
-        model: "zai-coding-plan/glm-5.2",
-        permissionMode: "accept-edits",
-        reasoningLevel: "medium",
-      });
-      const { executionOptions } = bootstrap;
-      if (executionOptions === null) {
-        throw new Error(
-          "expected degraded executionOptions for an environment-backed ACP thread",
-        );
-      }
-      expect(
-        executionOptions.providers.some(
-          (provider) => provider.id === "acp-opencode",
-        ),
-      ).toBe(true);
-      expect(executionOptions.modelLoadError).toMatchObject({
-        providerId: "acp-opencode",
-      });
-      expect(
-        providerResponder.requests.map((request) => request.command.type),
-      ).toEqual(["known_acp_agents.status", "provider.list_models"]);
-      expect(providerResponder.requests[1]?.command).toMatchObject({
-        type: "provider.list_models",
-        providerId: "acp-opencode",
-      });
-    });
-  });
-
-  it("returns null composer defaults for stale project execution defaults", async () => {
-    await withTestHarness(async (harness) => {
-      const { host } = seedHostSession(harness.deps, {
-        id: "host-composer-stale-project-defaults",
-      });
-      const { project } = seedProjectWithSource(harness.deps, {
-        hostId: host.id,
-      });
-      upsertProjectExecutionDefaults(harness.deps.db, {
-        projectId: project.id,
-        providerId: "codex",
-        model: "gpt-5.5",
-        // ultracode is Claude-only; stale for Codex project defaults.
-        reasoningLevel: "ultracode",
-        permissionMode: "full",
-        serviceTier: "default",
-      });
-      const thread = seedThread(harness.deps, {
-        projectId: project.id,
-        environmentId: null,
-        providerId: "codex",
-      });
-
-      const response = await harness.app.request(
-        `/api/v1/threads/${thread.id}/composer-bootstrap`,
-      );
-
-      expect(response.status).toBe(200);
-      const bootstrap = threadComposerBootstrapResponseSchema.parse(
-        await readJson(response),
-      );
-      expect(bootstrap.defaultExecutionOptions).toBeNull();
-      expect(bootstrap.executionOptions).toBeNull();
-    });
-  });
-
-  it("returns null composer execution options for archived threads on offline hosts", async () => {
-    await withTestHarness(async (harness) => {
-      const host = seedHost(harness.deps, {
-        id: "host-composer-archived-offline",
-      });
-      const { project } = seedProjectWithSource(harness.deps, {
-        hostId: host.id,
-      });
-      const environment = seedEnvironment(harness.deps, {
-        hostId: host.id,
-        projectId: project.id,
-      });
-      const thread = seedThread(harness.deps, {
-        projectId: project.id,
-        environmentId: environment.id,
-      });
-      archiveThread(harness.db, harness.hub, thread.id);
-
-      const response = await harness.app.request(
-        `/api/v1/threads/${thread.id}/composer-bootstrap`,
-      );
-
-      expect(response.status).toBe(200);
-      const bootstrap = threadComposerBootstrapResponseSchema.parse(
-        await readJson(response),
-      );
-      expect(bootstrap.executionOptions).toBeNull();
     });
   });
 

--- a/packages/server-contract/src/api/threads.ts
+++ b/packages/server-contract/src/api/threads.ts
@@ -12,7 +12,6 @@ import {
   promptInputSchema,
   providerRateLimitStateSchema,
   reasoningLevelSchema,
-  resolvedThreadExecutionOptionsSchema,
   serviceTierSchema,
   threadChildOriginSchema,
   threadOriginKindSchema,
@@ -41,8 +40,6 @@ import {
   workspaceFileListResponseSchema,
   workspacePathListResponseSchema,
 } from "./shared.js";
-import { promptHistoryResponseSchema } from "./projects.js";
-import { systemExecutionOptionsResponseSchema } from "./system.js";
 
 export const sendMessageModeSchema = z.enum([
   "queue-if-active",
@@ -629,18 +626,6 @@ export const threadPaneActionResponseSchema = z.object({
 });
 export type ThreadPaneActionResponse = z.infer<
   typeof threadPaneActionResponseSchema
->;
-
-/** @deprecated Compatibility shape for clients that still call composer bootstrap. */
-export const threadComposerBootstrapResponseSchema = z.object({
-  defaultExecutionOptions: resolvedThreadExecutionOptionsSchema.nullable(),
-  queuedMessages: threadQueuedMessageListResponseSchema,
-  executionOptions: systemExecutionOptionsResponseSchema.nullable(),
-  pendingInteractions: threadPendingInteractionsResponseSchema,
-  promptHistory: promptHistoryResponseSchema,
-});
-export type ThreadComposerBootstrapResponse = z.infer<
-  typeof threadComposerBootstrapResponseSchema
 >;
 
 export const threadArchiveAllResponseSchema = z.object({

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -172,7 +172,6 @@ import type {
   TerminalResizeRequest,
   ThreadArchiveAllResponse,
   ThreadChildSummaryResponse,
-  ThreadComposerBootstrapResponse,
   ThreadEventWaitQuery,
   ThreadEventsQuery,
   ThreadSectionMutationResponse,
@@ -1006,13 +1005,6 @@ export const publicApiRoutes = {
         editMessageRequestSchema,
       ),
       response: jsonResponse<EditMessageResponse>(),
-    }),
-    /** @deprecated App code uses dedicated composer queries. */
-    composerBootstrap: defineRoute({
-      path: "/threads/:id/composer-bootstrap",
-      method: "get",
-      request: noRequest<PathId>(),
-      response: jsonResponse<ThreadComposerBootstrapResponse>(),
     }),
     queuedMessages: defineRoute({
       path: "/threads/:id/queued-messages",

--- a/packages/server-contract/test/contract.test.ts
+++ b/packages/server-contract/test/contract.test.ts
@@ -1471,11 +1471,6 @@ describe("server-contract clients", () => {
         .pathname,
     ).toBe("/api/v1/threads/thr_123/send");
     expect(
-      publicClient.threads[":id"]["composer-bootstrap"].$url({
-        param: { id: "thr_123" },
-      }).pathname,
-    ).toBe("/api/v1/threads/thr_123/composer-bootstrap");
-    expect(
       publicClient.threads[":id"]["queued-messages"].$url({
         param: { id: "thr_123" },
       }).pathname,

--- a/qa/missed-invariants.md
+++ b/qa/missed-invariants.md
@@ -1,12 +1,5 @@
 # Missed QA Invariants
 
-## Cache-owner query-key aliasing
-
-- Bug/hotfix commit: `d652c826b` (`fix: stop thread composer bootstrap from clobbering new-thread provider list`)
-- Invariant missed: a cache owner may perform raw query-client writes, but each owner must only import and write the query-key families declared for that owner. The thread composer bootstrap path touched the shared `systemExecutionOptions` family and could alias the new-thread composer key when `executionOptions` was `null`.
-- Automated guard added: `apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts` declares allowed query-key imports per cache-owner module and fails on undeclared shared-family imports. This is the remaining guard.
-- Later change: `composer-cache-owner.test.ts`, which covered the environmentless archived-thread null-bootstrap case, went away with the composer cache owner in `32197c2e7` ("Decouple composer data queries with bootstrap compatibility", #335). The composer no longer writes the shared `systemExecutionOptions` family, so the aliasing path it guarded no longer exists.
-
 ## Host RPC Response Type Correlation
 
 - Bug/hotfix commit: `e0b3e0c2b` (`fix: validate host RPC response messages by command type`)


### PR DESCRIPTION
## Summary

- delete the deprecated composer-bootstrap public API route and response schema
- remove the server builder and handler plus endpoint-specific tests and fixtures
- remove the obsolete QA note; independent composer queries remain the intended path

## Caller audit

A project-wide source search found no production callers. The remaining references were limited to the contract declaration, server implementation, endpoint-specific tests, and a historical QA note. All direct workspace consumers of `@bb/server-contract` typecheck after the deletion.

## Validation

- `pnpm exec turbo run test --filter=@bb/server-contract -- test/contract.test.ts` (33 tests passed)
- `pnpm exec turbo run test --filter=@bb/server -- test/public/public-thread-data.test.ts` (74 tests passed)
- `pnpm exec turbo run typecheck --filter=@bb/server-contract --filter=@bb/server`
- Turbo typechecks for all six direct `@bb/server-contract` consumers
- `git diff --check`

> AGENT GENERATED: by GPT-5