### PR TITLE
Fix lowercase Pi tool call rendering

### DIFF
--- a/packages/thread-view/src/tool-call-parsing.ts
+++ b/packages/thread-view/src/tool-call-parsing.ts
@@ -7,9 +7,13 @@ const DELEGATION_TOOL_NAMES = new Set([
   "spawnAgent",
   "resumeAgent",
 ]);
-const STRUCTURED_READ_TOOL_NAMES = new Set(["Read"]);
-const STRUCTURED_SEARCH_TOOL_NAMES = new Set(["Grep"]);
-const STRUCTURED_LIST_TOOL_NAMES = new Set(["Glob"]);
+// Claude names these built-ins with title case while Pi uses lowercase names.
+// Keep this as an explicit alias list instead of normalizing every tool name:
+// plugin-contributed tool names are case-sensitive and may not share the
+// built-ins' semantics.
+const STRUCTURED_READ_TOOL_NAMES = new Set(["Read", "read"]);
+const STRUCTURED_SEARCH_TOOL_NAMES = new Set(["Grep", "grep"]);
+const STRUCTURED_LIST_TOOL_NAMES = new Set(["Glob", "glob"]);
 
 const SHELL_SEGMENT_BREAK_TOKENS = new Set(["&&", "||", "|", ";", "\n"]);
 

--- a/packages/thread-view/test/build-thread-timeline.test.ts
+++ b/packages/thread-view/test/build-thread-timeline.test.ts
@@ -23,6 +23,7 @@ import type {
 } from "@bb/server-contract";
 import { describe, expect, it } from "vitest";
 import {
+  buildTimelineRowTitle,
   buildThreadTimelineFromEvents,
   extractThreadTimelineActivePlanTurn,
   type ThreadEventWithMeta,
@@ -58,6 +59,13 @@ interface ToolCallItemEventArgs {
   tool: string;
   toolArgs?: JsonObject;
   type: "item/completed" | "item/started";
+}
+
+interface LowercaseStructuredToolCase {
+  expectedIntent: JsonObject;
+  expectedTitle: string;
+  tool: string;
+  toolArgs: JsonObject;
 }
 
 interface ImageViewItemEventArgs {
@@ -912,6 +920,75 @@ function fileChangeRowIdByPath(
 }
 
 describe("buildThreadTimelineFromEvents", () => {
+  const lowercaseStructuredToolCases: LowercaseStructuredToolCase[] = [
+    {
+      expectedIntent: {
+        type: "read",
+        name: "read",
+        path: "src/app.ts",
+      },
+      expectedTitle: "Read src/app.ts",
+      tool: "read",
+      toolArgs: { path: "src/app.ts", offset: 1, limit: 20 },
+    },
+    {
+      expectedIntent: {
+        type: "search",
+        query: "TODO",
+        path: "src",
+      },
+      expectedTitle: "Searched for TODO in src",
+      tool: "grep",
+      toolArgs: { pattern: "TODO", path: "src" },
+    },
+    {
+      expectedIntent: {
+        type: "list_files",
+        path: "src/**/*.ts",
+      },
+      expectedTitle: "Listed files in src/**/*.ts",
+      tool: "glob",
+      toolArgs: { pattern: "src/**/*.ts" },
+    },
+  ];
+
+  it.each(lowercaseStructuredToolCases)(
+    "humanizes Pi's lowercase $tool tool calls",
+    ({ expectedIntent, expectedTitle, tool, toolArgs }) => {
+      const rows = buildTimelineRows([
+        turnStartedEvent({ seq: 1 }),
+        toolCallItemEvent({
+          seq: 2,
+          tool,
+          toolArgs,
+          type: "item/started",
+        }),
+        toolCallItemEvent({
+          result: "ok",
+          seq: 3,
+          tool,
+          toolArgs,
+          type: "item/completed",
+        }),
+      ]);
+      const [row] = collectToolRows(rows);
+
+      expect(row).toBeDefined();
+      if (!row) {
+        throw new Error(`Expected a projected ${tool} tool row`);
+      }
+      expect(row.activityIntents).toEqual([
+        expect.objectContaining(expectedIntent),
+      ]);
+      expect(
+        buildTimelineRowTitle(row, {
+          summaryStyle: "bundle",
+          workStyle: "default",
+        }).plain,
+      ).toBe(expectedTitle);
+    },
+  );
+
   it("preserves server-enriched plugin status labels on a tool row", () => {
     const statusLabels = {
       pending: "Reading project overview",


### PR DESCRIPTION
## Summary

- Recognize Pi lowercase `read`, `grep`, and `glob` calls in structured timeline projection.
- Preserve the title-case aliases emitted by Claude.
- Add end-to-end timeline coverage for semantic activity intents and humanized labels.

## Verification

- `pnpm exec turbo run test --filter=@bb/thread-view --force` — 358 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/thread-view` — passed.
- Live Pi smoke thread emitted lowercase `read` and rendered as `Read package.json` in the dev UI.

> AGENT GENERATED: by GPT-5