### PR TITLE
Keep a foreign DOM mutation from blanking the app

### DIFF
--- a/apps/app/src/components/AppErrorBoundary.test.tsx
+++ b/apps/app/src/components/AppErrorBoundary.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { createRoot } from "react-dom/client";
+import { act } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AppErrorBoundary } from "./AppErrorBoundary";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mountRoot(): {
+  container: HTMLDivElement;
+  render: (node: React.ReactNode) => void;
+  dispose: () => void;
+} {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container, {
+    // Any error that reaches here means the boundary did not catch it and the
+    // root came down — the white page the report describes.
+    onUncaughtError: (error) => {
+      throw error;
+    },
+  });
+  return {
+    container,
+    render: (node) => act(() => root.render(node)),
+    dispose: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+describe("AppErrorBoundary", () => {
+  it("replaces a crashed tree with a recovery screen", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { container, render, dispose } = mountRoot();
+
+    function Boom(): never {
+      throw new Error("render exploded");
+    }
+    render(
+      <AppErrorBoundary>
+        <Boom />
+      </AppErrorBoundary>,
+    );
+
+    expect(container.textContent).toContain("bb hit an error and stopped");
+    expect(container.querySelector("button")?.textContent).toBe("Reload bb");
+    // The message stays reachable so a report can carry it.
+    expect(container.textContent).toContain("render exploded");
+    dispose();
+  });
+
+  it("catches the commit-phase removeChild failure instead of blanking the root", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { container, render, dispose } = mountRoot();
+
+    function Tree({ mounted }: { mounted: boolean }) {
+      return <div>{mounted ? <p data-moved="">body</p> : null}</div>;
+    }
+    render(
+      <AppErrorBoundary>
+        <Tree mounted />
+      </AppErrorBoundary>,
+    );
+    const moved = container.querySelector("[data-moved]");
+    expect(moved).not.toBeNull();
+    // The foreign mutation the crash report points at.
+    document.createElement("section").appendChild(moved!);
+
+    render(
+      <AppErrorBoundary>
+        <Tree mounted={false} />
+      </AppErrorBoundary>,
+    );
+
+    expect(container.textContent).toContain("bb hit an error and stopped");
+    dispose();
+  });
+});

--- a/apps/app/src/components/AppErrorBoundary.tsx
+++ b/apps/app/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,75 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+/**
+ * The last boundary above the router.
+ *
+ * Without one, React has nowhere to send an uncaught render or commit error, so
+ * it unmounts the whole root and the window goes white — no message, no way
+ * back except a manual reload. That is a total loss for a fault that usually
+ * belongs to one subtree.
+ *
+ * The fallback deliberately renders plain elements and theme tokens only. It
+ * pulls in no shared-ui component, no query client, and no router hook, so
+ * whatever crashed cannot also take the recovery screen down with it.
+ * `applyCachedAppThemeCss` runs before the first render, so the tokens resolve
+ * even when React never reached the app.
+ */
+
+interface AppErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface AppErrorBoundaryState {
+  error: Error | null;
+}
+
+export class AppErrorBoundary extends Component<
+  AppErrorBoundaryProps,
+  AppErrorBoundaryState
+> {
+  override state: AppErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: unknown): AppErrorBoundaryState {
+    return { error: error instanceof Error ? error : new Error(String(error)) };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    // The component stack is the part a screenshot of the console never has,
+    // and the part that names the subtree at fault.
+    console.error("[bb] the app crashed", error, info.componentStack);
+  }
+
+  override render(): ReactNode {
+    const { error } = this.state;
+    if (error === null) {
+      return this.props.children;
+    }
+    return (
+      <div className="flex h-dvh w-full items-center justify-center bg-background p-6 text-foreground">
+        <div className="w-full max-w-md rounded-lg border border-border bg-card p-6">
+          <h1 className="text-base font-medium">bb hit an error and stopped</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            A reload is safe. Your threads live on the server and an unsent
+            draft is kept locally. If this repeats, open the browser console
+            and send us the message below.
+          </p>
+          <details className="mt-4">
+            <summary className="cursor-pointer text-sm text-muted-foreground">
+              Error details
+            </summary>
+            <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border p-3 text-xs">
+              {error.stack ?? error.message}
+            </pre>
+          </details>
+          <button
+            type="button"
+            className="mt-4 w-full cursor-pointer rounded-md bg-primary px-3 py-2 text-sm text-primary-foreground"
+            onClick={() => window.location.reload()}
+          >
+            Reload bb
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/apps/app/src/lib/foreign-dom-mutation-guard.test.tsx
+++ b/apps/app/src/lib/foreign-dom-mutation-guard.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { createRoot } from "react-dom/client";
+import { act } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  foreignDomMutationCount,
+  installForeignDomMutationGuard,
+  uninstallForeignDomMutationGuardForTest,
+} from "./foreign-dom-mutation-guard";
+
+afterEach(() => {
+  uninstallForeignDomMutationGuardForTest();
+  vi.restoreAllMocks();
+});
+
+/**
+ * Reproduces the reported crash: React mounts a node, something outside React
+ * reparents it, and React's next unmount of that node calls
+ * `originalParent.removeChild(node)`. Returns the errors React escalated to the
+ * root, which is what tears the whole app down when nothing catches them.
+ */
+function unmountAfterForeignReparent(): Error[] {
+  const errors: Error[] = [];
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container, {
+    onUncaughtError: (error) => {
+      errors.push(error instanceof Error ? error : new Error(String(error)));
+    },
+  });
+
+  function Tree({ mounted }: { mounted: boolean }) {
+    return <div>{mounted ? <p data-moved="">body</p> : null}</div>;
+  }
+
+  act(() => root.render(<Tree mounted />));
+  const moved = container.querySelector("[data-moved]");
+  expect(moved).not.toBeNull();
+  // The foreign mutation: an extension content script (or the browser's page
+  // translator) adopts the node into DOM of its own.
+  document.createElement("section").appendChild(moved!);
+
+  // `act` rethrows whatever React escalates, so both delivery paths (the root
+  // callback and the rethrow) have to be collected for the comparison to mean
+  // anything.
+  const run = (work: () => void): void => {
+    try {
+      act(work);
+    } catch (error) {
+      errors.push(error instanceof Error ? error : new Error(String(error)));
+    }
+  };
+  run(() => root.render(<Tree mounted={false} />));
+  run(() => root.unmount());
+  container.remove();
+  return errors;
+}
+
+describe("foreign DOM mutation guard", () => {
+  it("keeps a foreign reparent from escalating to a root teardown", () => {
+    const unguarded = unmountAfterForeignReparent();
+    expect(unguarded).toHaveLength(1);
+    // jsdom drops Chrome's "Failed to execute 'removeChild' on 'Node'" prefix;
+    // the shared part of the DOMException message is the stable assertion.
+    expect(unguarded[0]?.message).toMatch(/not a child of this node/);
+
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    installForeignDomMutationGuard();
+    expect(unmountAfterForeignReparent()).toEqual([]);
+    expect(foreignDomMutationCount()).toBe(1);
+  });
+
+
+  it("suppresses the removeChild that a foreign reparent turns into a throw", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const reactParent = document.createElement("div");
+    const child = document.createElement("span");
+    reactParent.appendChild(child);
+    installForeignDomMutationGuard();
+
+    // What an extension (or the browser's translator) does: adopt the node
+    // into DOM of its own, leaving React still pointing at `reactParent`.
+    const foreignParent = document.createElement("font");
+    foreignParent.appendChild(child);
+
+    expect(() => reactParent.removeChild(child)).not.toThrow();
+    expect(foreignDomMutationCount()).toBe(1);
+    expect(warn).toHaveBeenCalledOnce();
+    // The node is left where the foreign mutation put it rather than detached,
+    // so a later unmount of `foreignParent` still cleans it up.
+    expect(child.parentNode).toBe(foreignParent);
+  });
+
+  it("appends instead of throwing when the insertBefore reference node moved away", () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const parent = document.createElement("div");
+    const reference = document.createElement("span");
+    parent.appendChild(reference);
+    installForeignDomMutationGuard();
+    document.createElement("font").appendChild(reference);
+
+    const inserted = document.createElement("b");
+    expect(() => parent.insertBefore(inserted, reference)).not.toThrow();
+    // Dropping the node would silently lose rendered content; appending keeps
+    // it reachable, with only its ordering disturbed.
+    expect(inserted.parentNode).toBe(parent);
+    expect(foreignDomMutationCount()).toBe(1);
+  });
+
+  it("leaves well-formed calls on the native path", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    installForeignDomMutationGuard();
+    const parent = document.createElement("div");
+    const first = document.createElement("span");
+    const second = document.createElement("span");
+    parent.appendChild(second);
+
+    expect(parent.insertBefore(first, second)).toBe(first);
+    expect([...parent.children]).toEqual([first, second]);
+    expect(parent.removeChild(first)).toBe(first);
+    expect([...parent.children]).toEqual([second]);
+    expect(foreignDomMutationCount()).toBe(0);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/lib/foreign-dom-mutation-guard.ts
+++ b/apps/app/src/lib/foreign-dom-mutation-guard.ts
@@ -1,0 +1,134 @@
+/**
+ * Keeps foreign DOM mutation from killing the app.
+ *
+ * React owns every node it renders and remembers which parent each one belongs
+ * to. On unmount it calls `parent.removeChild(node)` directly. When another
+ * agent in the page — a browser extension's content script, the browser's own
+ * page translator, a bookmarklet — moves or removes one of those nodes first,
+ * React's call throws:
+ *
+ *   NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be
+ *   removed is not a child of this node.
+ *
+ * React catches that throw in the commit phase and escalates it to the nearest
+ * error boundary. bb has no boundary above the router, so React tears the whole
+ * root down and the user gets a blank page — a total loss for a mutation that
+ * only ever affected one subtree.
+ *
+ * This guard makes both calls non-fatal. `removeChild` returns the node instead
+ * of throwing when it already has a different parent (the node is gone from
+ * where React expected it, which is exactly the outcome React wanted).
+ * `insertBefore` appends instead of throwing when the reference node has moved
+ * away, so the content still reaches the DOM rather than vanishing.
+ *
+ * This is the workaround React's own maintainers publish for translated pages
+ * (facebook/react#11538). It is deliberately narrow: both wrappers only change
+ * behavior in the case that would otherwise throw, so every well-formed call
+ * reaches the native method unchanged.
+ *
+ * Suppressed calls are counted and the first few are logged, because a burst of
+ * them from a build where no extension is involved would point at a real bug in
+ * our own rendering instead.
+ */
+
+/** Log at most this many suppressions, then only keep counting. */
+const MAX_LOGGED_SUPPRESSIONS = 3;
+
+type RemoveChild = <T extends Node>(child: T) => T;
+type InsertBefore = <T extends Node>(node: T, child: Node | null) => T;
+
+interface InstalledGuard {
+  removeChild: RemoveChild;
+  insertBefore: InsertBefore;
+}
+
+let installed: InstalledGuard | null = null;
+let suppressedCount = 0;
+let loggedCount = 0;
+
+/** How many throwing DOM calls the guard has absorbed this session. */
+export function foreignDomMutationCount(): number {
+  return suppressedCount;
+}
+
+function describe(node: Node): string {
+  if (node instanceof Element) {
+    const id = node.id ? `#${node.id}` : "";
+    const testId = node.getAttribute("data-testid");
+    return `<${node.localName}${id}${testId ? `[data-testid=${testId}]` : ""}>`;
+  }
+  if (node.nodeType === Node.TEXT_NODE) return "#text";
+  return `#node(${node.nodeType})`;
+}
+
+function recordSuppression(
+  operation: "removeChild" | "insertBefore",
+  node: Node,
+  expectedParent: Node,
+): void {
+  suppressedCount += 1;
+  if (loggedCount >= MAX_LOGGED_SUPPRESSIONS) return;
+  loggedCount += 1;
+  console.warn(
+    `[bb] ${operation}: ${describe(node)} is no longer a child of ${describe(
+      expectedParent,
+    )}. Something outside React moved or removed it (a browser extension or ` +
+      `page translation is the usual cause); the call was suppressed instead ` +
+      `of crashing the app.`,
+    { node, expectedParent, actualParent: node.parentNode },
+  );
+}
+
+/**
+ * Wrap `Node.prototype.removeChild` / `insertBefore`. Safe to call more than
+ * once; only the first call installs.
+ */
+export function installForeignDomMutationGuard(): void {
+  if (installed !== null || typeof Node !== "function") return;
+
+  const nativeRemoveChild = Node.prototype.removeChild;
+  const nativeInsertBefore = Node.prototype.insertBefore;
+
+  // Both wrappers return their own argument rather than the native return
+  // value: the DOM spec defines each of these as returning the node it was
+  // handed, so this keeps the generic result type without an `as` cast.
+  const guardedRemoveChild: RemoveChild = function removeChild<T extends Node>(
+    this: Node,
+    child: T,
+  ): T {
+    if (child.parentNode !== this) {
+      recordSuppression("removeChild", child, this);
+      return child;
+    }
+    nativeRemoveChild.call(this, child);
+    return child;
+  };
+
+  const guardedInsertBefore: InsertBefore = function insertBefore<
+    T extends Node,
+  >(this: Node, node: T, child: Node | null): T {
+    if (child !== null && child.parentNode !== this) {
+      recordSuppression("insertBefore", child, this);
+      // Append rather than drop the node: the ordering is already wrong
+      // because of the foreign mutation, but the content stays reachable.
+      nativeInsertBefore.call(this, node, null);
+      return node;
+    }
+    nativeInsertBefore.call(this, node, child);
+    return node;
+  };
+
+  Node.prototype.removeChild = guardedRemoveChild;
+  Node.prototype.insertBefore = guardedInsertBefore;
+  installed = { removeChild: nativeRemoveChild, insertBefore: nativeInsertBefore };
+}
+
+/** Restore the native methods and the counters. Test-only. */
+export function uninstallForeignDomMutationGuardForTest(): void {
+  if (installed === null) return;
+  Node.prototype.removeChild = installed.removeChild;
+  Node.prototype.insertBefore = installed.insertBefore;
+  installed = null;
+  suppressedCount = 0;
+  loggedCount = 0;
+}

--- a/apps/app/src/lib/foreign-dom-mutation-guard.ts
+++ b/apps/app/src/lib/foreign-dom-mutation-guard.ts
@@ -11,9 +11,11 @@
  *   removed is not a child of this node.
  *
  * React catches that throw in the commit phase and escalates it to the nearest
- * error boundary. bb has no boundary above the router, so React tears the whole
- * root down and the user gets a blank page — a total loss for a mutation that
- * only ever affected one subtree.
+ * error boundary. bb had none above the router, so React tore the whole root
+ * down and the user got a blank page. `AppErrorBoundary` now catches it and
+ * shows a recovery screen, but a recovery screen still costs the user their
+ * place for a mutation that only ever affected one subtree. This guard keeps
+ * the fault from reaching that boundary at all.
  *
  * This guard makes both calls non-fatal. `removeChild` returns the node instead
  * of throwing when it already has a different parent (the node is gone from

--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -3,10 +3,12 @@ import { createRoot } from "react-dom/client";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter } from "react-router-dom";
 import { App } from "./App";
+import { AppErrorBoundary } from "./components/AppErrorBoundary";
 import { AppToaster } from "./components/AppToaster";
 import { registerProviderCliInstallQueryClient } from "./components/provider-cli/provider-cli-install-store";
 import { initializePreferredTheme } from "./hooks/useTheme";
 import { initializeFavicon } from "./lib/favicon-color-preference";
+import { installForeignDomMutationGuard } from "./lib/foreign-dom-mutation-guard";
 import {
   createAppQueryClient,
   installAppQueryClientBrowserEvents,
@@ -14,6 +16,17 @@ import {
 import { takeOverPanelResizeCursor } from "./lib/resizeCursor";
 import { applyCachedAppThemeCss } from "./lib/themes";
 import "./app.css";
+
+// Before anything renders: a content script that moves a React-owned node out
+// from under React turns the next unmount into a blank page. See the module
+// doc for why this is a wrapper rather than a fix in our own components.
+installForeignDomMutationGuard();
+
+// V8 keeps 10 frames by default, which a React commit-phase throw fills
+// entirely with reconciler internals — a crash report then names no bb
+// component at all. Deep enough to reach our own frames, cheap because it only
+// costs anything when an Error is actually constructed.
+Error.stackTraceLimit = 50;
 
 const queryClient = createAppQueryClient();
 installAppQueryClientBrowserEvents(queryClient);
@@ -29,13 +42,28 @@ applyCachedAppThemeCss();
 initializeFavicon();
 takeOverPanelResizeCursor();
 
-createRoot(document.getElementById("root")!).render(
+createRoot(document.getElementById("root")!, {
+  // An uncaught render/commit error unmounts the whole root. React's default
+  // handler reports only the error, so the report never says which subtree
+  // died; the component stack is the one piece that makes it actionable.
+  onUncaughtError: (error, errorInfo) => {
+    console.error(
+      "[bb] uncaught render error — the app root was torn down",
+      error,
+      errorInfo.componentStack,
+    );
+  },
+}).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <App />
-        <AppToaster position="bottom-right" />
-      </BrowserRouter>
-    </QueryClientProvider>
+    {/* Outside the providers: a crash in the query client or the router has to
+        land here too, or it still takes the window white. */}
+    <AppErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <App />
+          <AppToaster position="bottom-right" />
+        </BrowserRouter>
+      </QueryClientProvider>
+    </AppErrorBoundary>
   </StrictMode>,
 );


### PR DESCRIPTION
A user reported a white screen. Their console held repeated `NotFoundError: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.`

## Root cause

The stack decodes exactly against a local production build — the columns match, so this is not a guess:

| Frame | Decodes to |
|---|---|
| `dist-<hash>.js` | the react-dom chunk |
| col `98077` | `hostParent.removeChild(node)` in `commitDeletionEffectsOnFiber`, the **plain-parent** branch (not the portal-container one) |
| col `97489` | the recursive call in `recursivelyTraverseDeletionEffects` |
| col `98395` | the branch for function, forwardRef, memo, and lazy components |

React deleted a subtree and the parent element no longer held the node.

Our own code never moves React-owned nodes. A scan across every package and plugin finds DOM mutation only on `document.head`, `document.body`, or elements the code created itself. cmdk (used by the Tasks plugin) reorders within one parent, and `removeChild` throws only on a parent mismatch, so it cannot produce this either. React 19 does not produce it from duplicate keys — it leaks a node instead. That leaves an agent outside React, and the report's console shows an extension content script live in the page (`ObjectMultiplex`, Node `EventEmitter` warnings).

The blank window is ours, though: bb had no error boundary above the router, so React had nowhere to send the error and unmounted the whole root.

## What changed

- **`lib/foreign-dom-mutation-guard.ts`** wraps `Node.prototype.removeChild` and `insertBefore`. Each wrapper changes behavior only in the case that would otherwise throw, so every well-formed call reaches the native method unchanged. It counts suppressed calls and logs the first three, so a burst with no extension in play points at a bug of ours. This is the workaround React's maintainers publish for translated pages ([facebook/react#11538](https://github.com/facebook/react/issues/11538)).
- **`components/AppErrorBoundary.tsx`** is the last boundary above the router. It shows a message, the stack behind a details toggle, and a reload button. It pulls in no shared-ui component, no query client, and no router hook, so whatever crashed cannot take the recovery screen down too. Colors come from `--canvas`/`--ink`-derived tokens, so custom palettes re-tint it.
- **`main.tsx`** installs both, raises `Error.stackTraceLimit` to 50, and logs the component stack from `onUncaughtError`. V8's default of 10 frames was entirely reconciler internals, which is why the original report named no bb component.

## Validation

- New tests reproduce the exact failure: mount a node, reparent it the way an extension does, then unmount. The guard test asserts React escalates nothing. **The boundary test runs the same reproduction with the guard switched off** and asserts the recovery screen renders — so the white screen is closed even if my reading of the cause is wrong.
- Rendered the boundary in a real browser, light and dark, against the built CSS.
- `@bb/app`: 338 test files, 2552 tests pass. Typecheck passes. Lint reports 0 errors. Production build passes.

## Notes and risks

- Patching `Node.prototype` is global. Both wrappers are no-ops for well-formed calls, and `removeChild`/`insertBefore` are the only two patched.
- Not included, as a product call for a reviewer: `translate="no"` / `<meta name="google" content="notranslate">`. The browser's page translator is the other common cause of this error, and the opt-out is standard for developer tools, but it removes UI translation for non-English readers. The guard stops the crash either way.

> AGENT GENERATED: by Claude Opus 5