### PR TITLE
fix(pi): allow disabling thinking for models that support off

### DIFF
--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -87,7 +87,8 @@ describe("appendCustomModels", () => {
       piModels[0].supportedReasoningEfforts.map(
         (effort) => effort.reasoningEffort,
       ),
-    ).toEqual(["low", "medium", "high", "xhigh", "max"]);
+    ).toEqual(["none", "low", "medium", "high", "xhigh", "max"]);
+    expect(piModels[0].defaultReasoningEffort).toBe("medium");
   });
 
   it("appends dynamic ACP custom models with the agent-managed effort", () => {

--- a/apps/server/test/threads/thread-runtime-config.test.ts
+++ b/apps/server/test/threads/thread-runtime-config.test.ts
@@ -663,37 +663,40 @@ describe("thread runtime config", () => {
     });
   });
 
-  it("accepts max reasoning for Pi sessions", async () => {
-    await withTestHarness(async (harness) => {
-      const { host } = seedHostSession(harness.deps, {
-        id: "host-runtime-pi-max-reasoning",
-      });
-      const { project } = seedProjectWithSource(harness.deps, {
-        hostId: host.id,
-      });
-      const environment = seedEnvironment(harness.deps, {
-        hostId: host.id,
-        projectId: project.id,
-      });
-      const thread = seedThread(harness.deps, {
-        projectId: project.id,
-        environmentId: environment.id,
-        providerId: "pi",
-      });
+  it.each(["none", "max"] as const)(
+    "accepts %s reasoning for Pi sessions",
+    async (reasoningLevel) => {
+      await withTestHarness(async (harness) => {
+        const { host } = seedHostSession(harness.deps, {
+          id: `host-runtime-pi-${reasoningLevel}-reasoning`,
+        });
+        const { project } = seedProjectWithSource(harness.deps, {
+          hostId: host.id,
+        });
+        const environment = seedEnvironment(harness.deps, {
+          hostId: host.id,
+          projectId: project.id,
+        });
+        const thread = seedThread(harness.deps, {
+          projectId: project.id,
+          environmentId: environment.id,
+          providerId: "pi",
+        });
 
-      const execution = await resolveExecutionOptions(harness.deps, {
-        threadId: thread.id,
-        requestedExecution: {
-          model: "openai-codex/gpt-5.6-luna",
-          permissionMode: "full",
-          reasoningLevel: "max",
-          source: "client/turn/requested",
-        },
-      });
+        const execution = await resolveExecutionOptions(harness.deps, {
+          threadId: thread.id,
+          requestedExecution: {
+            model: "openai-codex/gpt-5.6-luna",
+            permissionMode: "full",
+            reasoningLevel,
+            source: "client/turn/requested",
+          },
+        });
 
-      expect(execution.reasoningLevel).toBe("max");
-    });
-  });
+        expect(execution.reasoningLevel).toBe(reasoningLevel);
+      });
+    },
+  );
 
   it("rejects reasoning levels unsupported by the provider", async () => {
     await withTestHarness(async (harness) => {

--- a/packages/agent-providers/src/catalog.ts
+++ b/packages/agent-providers/src/catalog.ts
@@ -182,7 +182,12 @@ const PI_SERVER_CAPABILITIES: ProviderServerCapabilities = {
   supportsWorkflows: false,
   supportsExecutionOverride: false,
   backsHostDaemonAiServices: false,
-  reasoningLevels: ["low", "medium", "high", "xhigh", "max"],
+  // "none" is the thinking-off level: some Pi models (e.g. Ollama Cloud models
+  // whose `thinkingLevelMap` advertises `off`, and non-reasoning models) expose
+  // it per-model via `supportedReasoningEfforts`. The picker only offers it for
+  // those models, but this coarse ladder must include it so the plan-path
+  // validation accepts a `none` selection the picker legitimately offered.
+  reasoningLevels: ["none", "low", "medium", "high", "xhigh", "max"],
 };
 
 // ACP agents manage reasoning effort internally; "medium" is the single

--- a/packages/agent-providers/src/catalog.ts
+++ b/packages/agent-providers/src/catalog.ts
@@ -184,9 +184,11 @@ const PI_SERVER_CAPABILITIES: ProviderServerCapabilities = {
   backsHostDaemonAiServices: false,
   // "none" is the thinking-off level: some Pi models (e.g. Ollama Cloud models
   // whose `thinkingLevelMap` advertises `off`, and non-reasoning models) expose
-  // it per-model via `supportedReasoningEfforts`. The picker only offers it for
-  // those models, but this coarse ladder must include it so the plan-path
-  // validation accepts a `none` selection the picker legitimately offered.
+  // it per-model via `supportedReasoningEfforts`. Daemon-backed models only
+  // offer it when their precise catalog entry does; server-defined custom
+  // models inherit this coarse fallback ladder. The ladder must include it so
+  // plan-path validation accepts a `none` selection the daemon legitimately
+  // offered.
   reasoningLevels: ["none", "low", "medium", "high", "xhigh", "max"],
 };
 

--- a/packages/agent-providers/test/catalog.test.ts
+++ b/packages/agent-providers/test/catalog.test.ts
@@ -31,6 +31,12 @@ describe("agent provider catalog", () => {
     expect(supportsManualCompaction("acp-opencode")).toBe(true);
   });
 
+  it("allows Pi thinking-off selections through server-side validation", () => {
+    expect(
+      getBuiltInAgentProviderServerCapabilities("pi").reasoningLevels,
+    ).toEqual(["none", "low", "medium", "high", "xhigh", "max"]);
+  });
+
   it("synthesizes dynamic ACP provider metadata with shared ACP policy", () => {
     expect(
       buildAcpProviderInfo({

--- a/packages/agent-runtime/src/claude-code/bridge/session-options.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/session-options.ts
@@ -82,8 +82,9 @@ export function toSdkEffort(
   reasoningLevel: ReasoningLevel,
 ): ClaudeSdkReasoningEffort {
   if (reasoningLevel === "ultracode") return "xhigh";
-  // "none" (thinking-off) is a Cursor-only level; Claude Code models never
-  // expose it, so this is a defensive floor that reconciliation never reaches.
+  // "none" (thinking-off) is a level Cursor and some Pi models expose;
+  // Claude Code models never expose it, so this is a defensive floor that
+  // reconciliation never reaches.
   if (reasoningLevel === "none") return "low";
   // "ultra" is a Codex-only top tier; if it ever reaches Claude, floor to max.
   if (reasoningLevel === "ultra") return "max";

--- a/packages/agent-runtime/src/codex/adapter.ts
+++ b/packages/agent-runtime/src/codex/adapter.ts
@@ -665,9 +665,10 @@ function toCodexReasoningEffort(
 ): CodexReasoningEffort {
   const codexEffort = mapBbReasoningLevelToCodex(reasoningLevel);
   if (codexEffort == null) {
-    // "none" is Cursor-only; "ultracode" is Claude-specific. Codex models
-    // never expose either, so model-switch reconciliation maps them away
-    // before here — but fail closed if something slips through.
+    // "none" is exposed by Cursor and some Pi models; "ultracode" is
+    // Claude-specific. Codex models never expose either, so model-switch
+    // reconciliation maps them away before here — but fail closed if
+    // something slips through.
     throw new Error(
       `Codex does not support the ${reasoningLevel} reasoning level.`,
     );

--- a/packages/agent-runtime/src/pi/adapter.test.ts
+++ b/packages/agent-runtime/src/pi/adapter.test.ts
@@ -461,6 +461,54 @@ describe("pi provider adapter", () => {
     });
   });
 
+  it("maps none to Pi off for every session launch path", () => {
+    const adapter = createPiProviderAdapter();
+    const options = {
+      ...fullProviderExecutionContext,
+      reasoningLevel: "none",
+    } satisfies ProviderExecutionContext;
+
+    expect(
+      adapter.buildCommandPlan({
+        type: "thread/start",
+        cwd: "/tmp/worktree",
+        threadId: "new-thread",
+        input: [promptTextInput({ text: "hello" })],
+        instructionMode: "append",
+        options,
+      }),
+    ).toMatchObject({
+      method: "thread/start",
+      params: { reasoningLevel: "off" },
+    });
+    expect(
+      adapter.buildCommandPlan({
+        type: "thread/resume",
+        cwd: "/tmp/worktree",
+        threadId: "bb-thread",
+        providerThreadId: "pi-thread",
+        instructionMode: "append",
+        options,
+      }),
+    ).toMatchObject({
+      method: "thread/resume",
+      params: { reasoningLevel: "off" },
+    });
+    expect(
+      adapter.buildCommandPlan({
+        type: "thread/fork",
+        cwd: "/tmp/worktree",
+        threadId: "forked-thread",
+        sourceProviderThreadId: "source-thread",
+        instructionMode: "append",
+        options,
+      }),
+    ).toMatchObject({
+      method: "thread/fork",
+      params: { reasoningLevel: "off" },
+    });
+  });
+
   it("buildCommand thread/start uses baseInstructions for replace instructions", () => {
     const adapter = createPiProviderAdapter();
     const cmd = adapter.buildCommandPlan({
@@ -2161,6 +2209,52 @@ describe("pi provider adapter", () => {
     expect(models.find((model) => model.isDefault)?.id).toBe(
       "anthropic/claude-sonnet-4",
     );
+  });
+
+  it("exposes off as none without changing models that lack off", () => {
+    const { models } = buildPiAvailableModels({
+      models: [
+        {
+          id: "kimi-k2.7-code",
+          name: "Kimi K2.7 Code",
+          provider: "ollama-cloud",
+          reasoning: true,
+          input: ["text"],
+          supportedThinkingLevels: ["off", "low", "medium", "high"],
+        },
+        {
+          id: "minimax-m2.7",
+          name: "MiniMax M2.7",
+          provider: "ollama-cloud",
+          reasoning: true,
+          input: ["text"],
+          supportedThinkingLevels: ["low", "medium", "high"],
+        },
+        {
+          id: "non-reasoning-model",
+          name: "Non-reasoning model",
+          provider: "custom",
+          reasoning: false,
+          input: ["text"],
+          supportedThinkingLevels: ["off"],
+        },
+      ],
+    });
+
+    expect(
+      models[0]?.supportedReasoningEfforts.map(
+        ({ reasoningEffort }) => reasoningEffort,
+      ),
+    ).toEqual(["none", "low", "medium", "high"]);
+    expect(
+      models[1]?.supportedReasoningEfforts.map(
+        ({ reasoningEffort }) => reasoningEffort,
+      ),
+    ).toEqual(["low", "medium", "high"]);
+    expect(models[2]).toMatchObject({
+      supportedReasoningEfforts: [{ reasoningEffort: "none" }],
+      defaultReasoningEffort: "none",
+    });
   });
 
   it("routes dated Pi versions to the selected-only bucket", () => {

--- a/packages/agent-runtime/src/pi/adapter.ts
+++ b/packages/agent-runtime/src/pi/adapter.ts
@@ -458,23 +458,23 @@ function buildPiAdditionalSkillPathsParams(
 // Levels Pi does not support ("ultracode", "ultra") are dropped so the bridge
 // schema never receives a value it would reject; reconciliation picks the
 // closest supported level before this point, so this is a defensive floor.
-const PI_THINKING_LEVELS = new Set<PiReasoningLevel>([
-  "off",
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-  "max",
-]);
-
 function toPiThinkingLevel(
   reasoningLevel: ProviderExecutionContext["reasoningLevel"],
 ): PiReasoningLevel | undefined {
-  if (reasoningLevel === undefined) return undefined;
-  const piLevel = reasoningLevel === "none" ? "off" : reasoningLevel;
-  return PI_THINKING_LEVELS.has(piLevel as PiReasoningLevel)
-    ? (piLevel as PiReasoningLevel)
-    : undefined;
+  switch (reasoningLevel) {
+    case "none":
+      return "off";
+    case "low":
+    case "medium":
+    case "high":
+    case "xhigh":
+    case "max":
+      return reasoningLevel;
+    case "ultracode":
+    case "ultra":
+    case undefined:
+      return undefined;
+  }
 }
 
 function buildPiConfig(
@@ -1172,7 +1172,11 @@ export function createPiProviderAdapter(
                   ? { model: command.options.model }
                   : {}),
                 ...(command.options?.reasoningLevel
-                  ? { reasoningLevel: toPiThinkingLevel(command.options.reasoningLevel) }
+                  ? {
+                      reasoningLevel: toPiThinkingLevel(
+                        command.options.reasoningLevel,
+                      ),
+                    }
                   : {}),
                 ...(dynamicTools && dynamicTools.length > 0
                   ? { dynamicTools }
@@ -1212,7 +1216,11 @@ export function createPiProviderAdapter(
                   ? { model: command.options.model }
                   : {}),
                 ...(command.options?.reasoningLevel
-                  ? { reasoningLevel: toPiThinkingLevel(command.options.reasoningLevel) }
+                  ? {
+                      reasoningLevel: toPiThinkingLevel(
+                        command.options.reasoningLevel,
+                      ),
+                    }
                   : {}),
                 ...(dynamicTools && dynamicTools.length > 0
                   ? { dynamicTools }
@@ -1300,7 +1308,11 @@ export function createPiProviderAdapter(
                   ? { model: command.options.model }
                   : {}),
                 ...(command.options?.reasoningLevel
-                  ? { reasoningLevel: toPiThinkingLevel(command.options.reasoningLevel) }
+                  ? {
+                      reasoningLevel: toPiThinkingLevel(
+                        command.options.reasoningLevel,
+                      ),
+                    }
                   : {}),
                 ...(dynamicTools && dynamicTools.length > 0
                   ? { dynamicTools }

--- a/packages/agent-runtime/src/pi/adapter.ts
+++ b/packages/agent-runtime/src/pi/adapter.ts
@@ -76,6 +76,7 @@ import type { JsonRpcMessage } from "../runtime-json-rpc.js";
 import type { AgentRuntimeSkillRoot } from "../types.js";
 import { toCanonicalPiModelId } from "./model-list.js";
 import { piVisibilityMetadata } from "./visibility.js";
+import type { PiReasoningLevel } from "./bridge/bridge.js";
 
 // ---------------------------------------------------------------------------
 // Pi event and command types
@@ -449,6 +450,30 @@ function buildPiAdditionalSkillPathsParams(
           piSkillRootPath({ skillRoot }),
         ),
       }
+    : undefined;
+}
+
+// BB's reasoning ladder is a superset of Pi's thinking levels. The only name
+// that differs is BB's "none" (no extended thinking), which Pi calls "off".
+// Levels Pi does not support ("ultracode", "ultra") are dropped so the bridge
+// schema never receives a value it would reject; reconciliation picks the
+// closest supported level before this point, so this is a defensive floor.
+const PI_THINKING_LEVELS = new Set<PiReasoningLevel>([
+  "off",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+]);
+
+function toPiThinkingLevel(
+  reasoningLevel: ProviderExecutionContext["reasoningLevel"],
+): PiReasoningLevel | undefined {
+  if (reasoningLevel === undefined) return undefined;
+  const piLevel = reasoningLevel === "none" ? "off" : reasoningLevel;
+  return PI_THINKING_LEVELS.has(piLevel as PiReasoningLevel)
+    ? (piLevel as PiReasoningLevel)
     : undefined;
 }
 
@@ -1147,7 +1172,7 @@ export function createPiProviderAdapter(
                   ? { model: command.options.model }
                   : {}),
                 ...(command.options?.reasoningLevel
-                  ? { reasoningLevel: command.options.reasoningLevel }
+                  ? { reasoningLevel: toPiThinkingLevel(command.options.reasoningLevel) }
                   : {}),
                 ...(dynamicTools && dynamicTools.length > 0
                   ? { dynamicTools }
@@ -1187,7 +1212,7 @@ export function createPiProviderAdapter(
                   ? { model: command.options.model }
                   : {}),
                 ...(command.options?.reasoningLevel
-                  ? { reasoningLevel: command.options.reasoningLevel }
+                  ? { reasoningLevel: toPiThinkingLevel(command.options.reasoningLevel) }
                   : {}),
                 ...(dynamicTools && dynamicTools.length > 0
                   ? { dynamicTools }
@@ -1275,7 +1300,7 @@ export function createPiProviderAdapter(
                   ? { model: command.options.model }
                   : {}),
                 ...(command.options?.reasoningLevel
-                  ? { reasoningLevel: command.options.reasoningLevel }
+                  ? { reasoningLevel: toPiThinkingLevel(command.options.reasoningLevel) }
                   : {}),
                 ...(dynamicTools && dynamicTools.length > 0
                   ? { dynamicTools }

--- a/packages/agent-runtime/src/pi/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/pi/bridge/__tests__/bridge.test.ts
@@ -396,29 +396,32 @@ describe("pi bridge", () => {
     }
   });
 
-  it("passes thread/start max reasoningLevel through to Pi thinkingLevel", async () => {
-    const bridge = createBridgeJsonRpcTestHarness(handleLine);
-    mockCreateAgentSession.mockImplementation(async () => ({
-      session: createControlledPiAgentSession(),
-    }));
+  it.each(["off", "max"] as const)(
+    "passes thread/start %s reasoningLevel through to Pi thinkingLevel",
+    async (reasoningLevel) => {
+      const bridge = createBridgeJsonRpcTestHarness(handleLine);
+      mockCreateAgentSession.mockImplementation(async () => ({
+        session: createControlledPiAgentSession(),
+      }));
 
-    try {
-      bridge.sendRequest(3, "thread/start", {
-        cwd: "/tmp/worktree",
-        threadId: "thread-reasoning",
-        reasoningLevel: "max",
-      });
-      await bridge.waitForResponse(3);
+      try {
+        bridge.sendRequest(3, "thread/start", {
+          cwd: "/tmp/worktree",
+          threadId: `thread-reasoning-${reasoningLevel}`,
+          reasoningLevel,
+        });
+        await bridge.waitForResponse(3);
 
-      expect(mockCreateAgentSession).toHaveBeenCalledWith(
-        expect.objectContaining({
-          thinkingLevel: "max",
-        }),
-      );
-    } finally {
-      bridge.restore();
-    }
-  });
+        expect(mockCreateAgentSession).toHaveBeenCalledWith(
+          expect.objectContaining({
+            thinkingLevel: reasoningLevel,
+          }),
+        );
+      } finally {
+        bridge.restore();
+      }
+    },
+  );
 
   it("uses the configured bridge session directory for default Pi sessions", async () => {
     const bridge = createBridgeJsonRpcTestHarness(handleLine);

--- a/packages/agent-runtime/src/pi/bridge/__tests__/model-list.test.ts
+++ b/packages/agent-runtime/src/pi/bridge/__tests__/model-list.test.ts
@@ -55,6 +55,10 @@ describe("pi bridge model list", () => {
           routeProviderId: "anthropic",
           description: "Anthropic reasoning, multimodal model via Pi",
           supportedReasoningEfforts: [
+            {
+              reasoningEffort: "none",
+              description: "No extended thinking",
+            },
             { reasoningEffort: "low", description: "Low reasoning effort" },
             {
               reasoningEffort: "medium",
@@ -113,6 +117,9 @@ describe("pi bridge model list", () => {
     expect(result.models[0]?.description).toBe(
       "Commandcode non-reasoning model via Pi",
     );
+    expect(result.models[0]?.supportedReasoningEfforts).toEqual([
+      { reasoningEffort: "none", description: "No extended thinking" },
+    ]);
   });
 
   // `id` is equally extension-supplied. Without it the list builder called
@@ -159,6 +166,7 @@ describe("pi bridge model list", () => {
     const result = await listPiBridgeModels(modelRuntime);
 
     expect(result.models[0]?.supportedReasoningEfforts).toEqual([
+      { reasoningEffort: "none", description: "No extended thinking" },
       { reasoningEffort: "high", description: "High reasoning effort" },
       { reasoningEffort: "max", description: "Maximum reasoning effort" },
     ]);

--- a/packages/agent-runtime/src/pi/bridge/bridge.ts
+++ b/packages/agent-runtime/src/pi/bridge/bridge.ts
@@ -88,6 +88,7 @@ const piInstructionOverrideSchemaOptions = {
 };
 
 const piReasoningLevelValues = [
+  "off",
   "low",
   "medium",
   "high",
@@ -95,7 +96,7 @@ const piReasoningLevelValues = [
   "max",
 ] as const;
 const piReasoningLevelSchema = z.enum(piReasoningLevelValues);
-type PiReasoningLevel = z.infer<typeof piReasoningLevelSchema>;
+export type PiReasoningLevel = z.infer<typeof piReasoningLevelSchema>;
 const piAdditionalSkillPathsSchema = z.array(z.string()).optional();
 
 const piThreadStartParamsSchema = z

--- a/packages/agent-runtime/src/pi/model-list.ts
+++ b/packages/agent-runtime/src/pi/model-list.ts
@@ -4,6 +4,7 @@ import {
   LOW_REASONING_EFFORT,
   MAX_REASONING_EFFORT,
   MEDIUM_REASONING_EFFORT,
+  NONE_REASONING_EFFORT,
   XHIGH_REASONING_EFFORT,
   type AvailableModel,
   type ModelReasoningEffort,
@@ -111,18 +112,22 @@ export function toCanonicalPiModelId(
 }
 
 function getPiReasoningEfforts(model: PiCatalogModel): ModelReasoningEffort[] {
-  if (!model.reasoning) {
-    return [LOW_REASONING_EFFORT];
-  }
-
+  // Derive the picker ladder from the model's supported thinking levels rather
+  // than treating non-reasoning models specially: a non-reasoning model reports
+  // only "off", so it surfaces a single "No extended thinking" entry, and a
+  // reasoning model that can disable thinking (e.g. Ollama Cloud's
+  // `kimi-k2.7-code` with `off: "none"`) gets "none" at the bottom of its
+  // ladder. Pi's `getSupportedThinkingLevels` is the source of truth for which
+  // levels are usable, so honor "off" here instead of silently dropping it.
   const supportedLevels = new Set(model.supportedThinkingLevels);
   const efforts: ModelReasoningEffort[] = [];
+  if (supportedLevels.has("off")) efforts.push(NONE_REASONING_EFFORT);
   if (supportedLevels.has("low")) efforts.push(LOW_REASONING_EFFORT);
   if (supportedLevels.has("medium")) efforts.push(MEDIUM_REASONING_EFFORT);
   if (supportedLevels.has("high")) efforts.push(HIGH_REASONING_EFFORT);
   if (supportedLevels.has("xhigh")) efforts.push(XHIGH_REASONING_EFFORT);
   if (supportedLevels.has("max")) efforts.push(MAX_REASONING_EFFORT);
-  return efforts.length > 0 ? efforts : [LOW_REASONING_EFFORT];
+  return efforts.length > 0 ? efforts : [NONE_REASONING_EFFORT];
 }
 
 function describePiModel(model: PiCatalogModel): string {

--- a/packages/agent-runtime/src/pi/model-list.ts
+++ b/packages/agent-runtime/src/pi/model-list.ts
@@ -53,8 +53,11 @@ function buildPiAvailableModel(model: PiCatalogModel): AvailableModel {
     supportedReasoningEfforts.find(
       ({ reasoningEffort }) => reasoningEffort === "medium",
     )?.reasoningEffort ??
+    supportedReasoningEfforts.find(
+      ({ reasoningEffort }) => reasoningEffort !== "none",
+    )?.reasoningEffort ??
     supportedReasoningEfforts[0]?.reasoningEffort ??
-    "low";
+    "none";
   return {
     id: canonicalId,
     model: canonicalId,

--- a/packages/domain/src/shared-types.ts
+++ b/packages/domain/src/shared-types.ts
@@ -3,7 +3,8 @@ import { z } from "zod";
 /**
  * Order is load-bearing: `reasoningRank` (index) drives model-switch
  * reconciliation. "none" (no extended thinking) sits at the bottom — only
- * providers that expose a thinking-off variant list it (currently Cursor).
+ * providers that expose a thinking-off variant list it (currently Cursor and
+ * Pi models whose `thinkingLevelMap` advertises `off`).
  * "ultracode" sits between "xhigh" and "max" because its underlying effort IS
  * xhigh (plus standing workflow orchestration) — a model without ultracode
  * support should reconcile down to xhigh, not up to max.

--- a/packages/domain/test/reasoning-level.test.ts
+++ b/packages/domain/test/reasoning-level.test.ts
@@ -62,6 +62,10 @@ describe("reconcileReasoningLevel", () => {
     expect(reconcileReasoningLevel("max", ["low"])).toBe("low");
   });
 
+  it("reconciles a stored low preference to none for a non-reasoning model", () => {
+    expect(reconcileReasoningLevel("low", ["none"])).toBe("none");
+  });
+
   it("throws when supported is empty", () => {
     expect(() => reconcileReasoningLevel("medium", [])).toThrow();
   });

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -36,7 +36,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 113 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 114 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1056,12 +1056,13 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
-  // Version 113 replaces the Windsurf open target id with Devin Desktop.
-  // Version 112 makes ACP stale-steer results trigger a safe new-turn retry.
-  // Version 111 restores parentToolCallId on a resumed Codex child turn.
-  // Version 110 waits for a late full-output record before command completion.
-  it("uses protocol version 113 for the Devin Desktop open target", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(113);
+  // Version 114 lets the daemon report `none` in Pi model reasoning efforts.
+  // A version 113 server accepts that value on the wire but rejects it later
+  // against its Pi provider ladder, so enrolled machines must not run that
+  // mixed version. Version 113 carried the Devin Desktop open target rename
+  // and remains part of the protocol lineage.
+  it("uses protocol version 114 for Pi thinking-off model capabilities", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(114);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {


### PR DESCRIPTION
Pi models that advertise a thinking-off level (for example, models with `off` in their `thinkingLevelMap`, plus non-reasoning models) can now be set to "Reasoning: None" in the picker. Three gaps previously dropped the level:

- `getPiReasoningEfforts` never emitted `none`, only `low` through `max`.
- The Pi bridge schema excluded `off`, with no `none` → `off` translation.
- Server-side plan validation used a coarse Pi provider ladder that lacked `none`.

The picker now exposes `none` when Pi reports `off`, the adapter maps `none` to `off` on every session launch path (start, resume, and fork), and the server accepts the selection. Models without `off`, such as `minimax-m2.7`, remain unchanged. Non-reasoning models now surface a truthful single "Reasoning: None" entry instead of a misleading `low`.

Sparse reasoning ladders preserve their previous default: `medium` is preferred, then the first non-`none` level. For example, a model reporting `[off, high]` still defaults to `high` while offering `none` as an explicit choice.

Server-defined custom Pi models inherit the coarse ladder, including `none`, and continue to default to `medium`.

## Protocol compatibility

This changes the `supportedReasoningEfforts` reported by the host daemon, so `HOST_DAEMON_PROTOCOL_VERSION` is bumped from 113 to 114.

- New server + old daemon: benign feature omission; the old daemon does not report `none`, so the picker does not offer it.
- New daemon + old server: the old server can parse `none` in the model list, but rejects a turn using it against its old Pi provider ladder.

The version bump prevents the broken second pairing and triggers the normal enrolled-daemon update path.

## Persisted preferences

No persisted-preference migration is needed. Models that genuinely support `low` retain it. Non-reasoning models previously advertised `low`, but Pi already clamped that selection to `off`; reconciliation now displays `none` without changing execution behavior. A provider-wide `low` → `none` migration would incorrectly alter preferences for other Pi models.

## Validation

Post-rebase validation on `origin/main`:

- Typechecks: `@bb/agent-providers`, `@bb/agent-runtime`, `@bb/domain`, `@bb/server`, `@bb/host-daemon-contract`, and `@bb/host-daemon`.
- Focused regression tests:
  - Pi runtime and bridge: 101
  - server execution options and runtime validation: 58
  - provider catalog: 6
  - persisted reasoning reconciliation: 11
  - host-daemon contract: 35
- `git diff --check`

Original implementation by @fgrehm; compatibility hardening and regression coverage added during maintainer review.

> AGENT GENERATED: by glm-5.2 (ollama-cloud)
