### PR TITLE
Prevent bleed-through in sticky open-in-split thread rows

### DIFF
--- a/apps/app/src/components/sidebar/ThreadRow.test.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.test.tsx
@@ -10,6 +10,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ThreadRow, type ThreadRowOptions } from "./ThreadRow";
 import { SidebarThreadTitleMentionResourcesProvider } from "./SidebarThreadTitleMentions";
 import {
+  SIDEBAR_ROW_OPEN_IN_SPLIT_STATE_CLASS,
   SIDEBAR_SUCCESS_STATUS_COLOR_CLASS,
   SIDEBAR_WORKING_STATUS_COLOR_CLASS,
 } from "./sidebarRowClasses";
@@ -336,6 +337,28 @@ describe("ThreadRow", () => {
       expect(container.querySelector('[data-icon="Loading"]')).toBeNull();
     },
   );
+
+  it("uses the opaque split tint on a sticky parent thread row", () => {
+    const { container } = renderSplitThreadRow({
+      options: {
+        kind: "parent",
+        depth: 0,
+        isCompact: false,
+        isCollapsed: false,
+        childCount: 1,
+        childActivity: NO_COLLAPSED_CHILD_ACTIVITY,
+        stickyLevel: 0,
+        onToggleCollapsed: vi.fn(),
+      },
+    });
+
+    const stickyRow = container.querySelector(
+      '[data-sidebar-sticky-tier="parent"]',
+    );
+    expect(stickyRow?.classList).toContain(
+      SIDEBAR_ROW_OPEN_IN_SPLIT_STATE_CLASS,
+    );
+  });
 
   it.each([
     ["idle", createThread()],

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -55,6 +55,7 @@ import {
   SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
   SIDEBAR_ROW_SELECTED_STATE_CLASS,
   SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
+  SIDEBAR_ROW_OPEN_IN_SPLIT_STATE_CLASS,
   SIDEBAR_SUCCESS_STATUS_COLOR_CLASS,
   SIDEBAR_SUCCESS_STATUS_DOT_CLASS,
   SIDEBAR_WORKING_STATUS_COLOR_CLASS,
@@ -598,7 +599,9 @@ function ThreadRowComponent({
     // Subtle open-in-split tint, weaker than the active-row treatment. The
     // focused pane's thread is already the active row, so this only marks the
     // other open panes; hover still wins over it.
-    !showActive && splitIndicator.isOpenInSplit && "bg-sidebar-accent/50",
+    !showActive &&
+      splitIndicator.isOpenInSplit &&
+      SIDEBAR_ROW_OPEN_IN_SPLIT_STATE_CLASS,
     !showActive && "has-[[data-state=open]]:bg-sidebar-accent",
     rowDragBindings && !rowDragBindings.disabled && "select-none",
   );

--- a/apps/app/src/components/sidebar/sidebarRowClasses.test.ts
+++ b/apps/app/src/components/sidebar/sidebarRowClasses.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { CONTEXT_SELECTION_SURFACE_CLASS } from "@/components/ui/context-selection";
-import { SIDEBAR_ROW_SELECTED_STATE_CLASS } from "./sidebarRowClasses";
+import {
+  SIDEBAR_ROW_OPEN_IN_SPLIT_STATE_CLASS,
+  SIDEBAR_ROW_SELECTED_STATE_CLASS,
+} from "./sidebarRowClasses";
 
-describe("sidebar selected thread styling", () => {
+describe("sidebar thread state styling", () => {
   it("uses the shared active-context surface", () => {
     expect(SIDEBAR_ROW_SELECTED_STATE_CLASS).toContain(
       CONTEXT_SELECTION_SURFACE_CLASS,
@@ -13,6 +16,12 @@ describe("sidebar selected thread styling", () => {
   it("marks the row for an opaque backing surface when it becomes sticky", () => {
     expect(SIDEBAR_ROW_SELECTED_STATE_CLASS).toContain(
       "bb-sidebar-selected-row",
+    );
+  });
+
+  it("marks open-in-split rows for an opaque sidebar-resolved tint", () => {
+    expect(SIDEBAR_ROW_OPEN_IN_SPLIT_STATE_CLASS).toBe(
+      "bb-sidebar-open-in-split-row",
     );
   });
 });

--- a/apps/app/src/components/sidebar/sidebarRowClasses.ts
+++ b/apps/app/src/components/sidebar/sidebarRowClasses.ts
@@ -70,6 +70,14 @@ export const SIDEBAR_ROW_STATIC_STATE_CLASS =
 export const SIDEBAR_ROW_SELECTED_STATE_CLASS =
   `${CONTEXT_SELECTION_SURFACE_CLASS} bb-sidebar-selected-row text-sidebar-foreground`;
 
+/**
+ * A quieter marker for a thread that is open in an unfocused split pane.
+ * theme.css resolves this tint against the sidebar to keep sticky parent rows
+ * opaque while their descendants scroll underneath them.
+ */
+export const SIDEBAR_ROW_OPEN_IN_SPLIT_STATE_CLASS =
+  "bb-sidebar-open-in-split-row";
+
 export const SIDEBAR_MORE_ACTION_TRIGGER_CLASS =
   "relative m-1 h-5 w-5 after:absolute after:left-1/2 after:top-1/2 after:h-7 after:w-7 after:-translate-x-1/2 after:-translate-y-1/2 after:content-[''] max-md:pointer-coarse:m-0 max-md:pointer-coarse:h-9 max-md:pointer-coarse:w-9 max-md:pointer-coarse:after:hidden";
 

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -212,6 +212,39 @@
       linear-gradient(var(--sidebar), var(--sidebar));
   }
 
+  /* This state is sidebar-only, so resolve its quiet accent tint against the
+     sidebar up front. Keeping it opaque prevents an unfocused split's sticky
+     parent-thread row from revealing descendants that scroll underneath it. */
+  .bb-sidebar-open-in-split-row {
+    --bb-sidebar-open-in-split-background: color-mix(
+      in oklch,
+      var(--sidebar-accent) 50%,
+      var(--sidebar)
+    );
+    background-color: var(--bb-sidebar-open-in-split-background);
+  }
+
+  /* Utility-layer bg-sidebar owns the sticky tier's base background-color, so
+     paint the state above it as an image just like the selected-row treatment. */
+  [data-sidebar-sticky-stack]
+    [data-sidebar-sticky-tier].bb-sidebar-open-in-split-row {
+    background-image: linear-gradient(
+      var(--bb-sidebar-open-in-split-background),
+      var(--bb-sidebar-open-in-split-background)
+    );
+  }
+
+  [data-sidebar-sticky-stack]
+    [data-sidebar-sticky-tier].bb-sidebar-open-in-split-row:is(
+      :hover,
+      :has([data-state="open"])
+    ) {
+    background-image: linear-gradient(
+      var(--sidebar-accent),
+      var(--sidebar-accent)
+    );
+  }
+
   .bb-sidebar-hover-actions {
     pointer-events: none;
     opacity: 0;

--- a/apps/app/src/components/ui/theme.test.ts
+++ b/apps/app/src/components/ui/theme.test.ts
@@ -146,6 +146,32 @@ describe("theme.css neutral ramp", () => {
     );
   });
 
+  it("resolves the open-in-split thread tint to an opaque sidebar color", () => {
+    const rule = css.match(
+      /\.bb-sidebar-open-in-split-row\s*\{([^}]*)\}/s,
+    )?.[1];
+
+    expect(rule).toContain("color-mix(");
+    expect(rule).toContain("in oklch");
+    expect(rule).toContain("var(--sidebar-accent) 50%");
+    expect(rule).toContain("var(--sidebar)");
+    expect(rule).not.toContain("transparent");
+
+    const stickyRule = css.match(
+      /\[data-sidebar-sticky-tier\]\.bb-sidebar-open-in-split-row\s*\{([^}]*)\}/s,
+    )?.[1];
+    expect(stickyRule).toContain("background-image: linear-gradient(");
+    expect(
+      stickyRule?.match(/var\(--bb-sidebar-open-in-split-background\)/g),
+    ).toHaveLength(2);
+
+    const interactiveRule = css.match(
+      /\[data-sidebar-sticky-tier\]\.bb-sidebar-open-in-split-row:is\([^{]+\)\s*\{([^}]*)\}/s,
+    )?.[1];
+    expect(interactiveRule).toContain("background-image: linear-gradient(");
+    expect(interactiveRule?.match(/var\(--sidebar-accent\)/g)).toHaveLength(2);
+  });
+
   for (const mode of MODES) {
     describe(mode, () => {
       const block = modeBlock(mode);


### PR DESCRIPTION
## Summary

- resolve the unfocused open-in-split thread tint against the sidebar so it is opaque
- preserve the stronger hover and menu-open treatment
- add regression coverage for sticky rendering of that related thread-row state

## Scope clarification

This is a follow-up issue found while auditing the reported no-split bleed-through; it is not the root cause of that incident. The selected-parent path shown in the original report was fixed by #1183. Git ancestry confirms that fix is included in desktop 0.37.0 but not 0.36.0, so a user who has not updated can still reproduce the old bug without using splits.

The current no-split paths were rechecked with a seeded two-level hierarchy: selected parents, ordinary parents, pinned trees, project grouping, manual grouping, and machine grouping all compute to opacity 1 with an opaque backing surface while descendant rows overlap them. Project, section, and worktree headers also use opaque fills; leaf thread rows do not become sticky.

The audit did find one adjacent gap: an unfocused thread open in a split uses a separate 50% accent tint. If that thread is also a sticky parent, descendants can show through it. This PR closes that gap.

## Validation

- pnpm exec turbo run test --filter=@bb/app -- src/components/sidebar/ThreadRow.test.tsx src/components/sidebar/sidebarRowClasses.test.ts src/components/ui/theme.test.ts (94 tests)
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app (0 errors; existing warnings only)
- seeded an isolated dev database with 80 threads and a two-level parent/child hierarchy
- verified no-split sticky overlap in project, manual, and machine organization modes, including selected, ordinary, and pinned parent rows
- verified the related sticky open-in-split tint stays opaque and the stronger hover tint still wins

> AGENT GENERATED: by GPT-5