### PR TITLE
Show child permission prompts on the parent thread

### DIFF
--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -734,6 +734,7 @@ export function AppLayout({ children }: AppLayoutProps) {
     null;
   const faviconBadge = shouldShowFaviconAttentionDot({
     currentThreadHasPendingInteraction,
+    currentThreadId: threadId,
     isThreadView,
     sidebarThreads,
     thread,

--- a/apps/app/src/components/layout/faviconAttentionDot.test.ts
+++ b/apps/app/src/components/layout/faviconAttentionDot.test.ts
@@ -9,7 +9,9 @@ function makeSidebarThread(
   overrides: Partial<FaviconSidebarThread> = {},
 ): FaviconSidebarThread {
   return {
+    id: "thr_sidebar",
     originKind: null,
+    parentThreadId: null,
     hasPendingInteraction: false,
     lastReadAt: 10,
     latestAttentionAt: 20,
@@ -132,6 +134,47 @@ describe("shouldShowFaviconAttentionDot", () => {
         sidebarThreads: [
           makeSidebarThread({
             visibility: "hidden",
+            lastReadAt: 30,
+            latestAttentionAt: 20,
+            hasPendingInteraction: true,
+          }),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("shows the dot when a viewed parent has a delegated child waiting on the user", () => {
+    expect(
+      shouldShowFaviconAttentionDot({
+        ...BASE_ARGS,
+        isThreadView: true,
+        currentThreadId: "thr_parent",
+        thread: { lastReadAt: 30, latestAttentionAt: 20 },
+        sidebarThreads: [
+          makeSidebarThread({
+            id: "thr_child",
+            parentThreadId: "thr_parent",
+            lastReadAt: 30,
+            latestAttentionAt: 20,
+            hasPendingInteraction: true,
+          }),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores a pending fork of the viewed thread", () => {
+    expect(
+      shouldShowFaviconAttentionDot({
+        ...BASE_ARGS,
+        isThreadView: true,
+        currentThreadId: "thr_parent",
+        thread: { lastReadAt: 30, latestAttentionAt: 20 },
+        sidebarThreads: [
+          makeSidebarThread({
+            id: "thr_fork",
+            originKind: "fork",
+            parentThreadId: "thr_parent",
             lastReadAt: 30,
             latestAttentionAt: 20,
             hasPendingInteraction: true,

--- a/apps/app/src/components/layout/faviconAttentionDot.ts
+++ b/apps/app/src/components/layout/faviconAttentionDot.ts
@@ -3,13 +3,21 @@ import { isSidebarProjectThread } from "@/components/sidebar/projectThreadGroups
 import { isThreadRead, type ThreadReadState } from "@/lib/thread-read-state";
 
 type FaviconSidebarThread = ThreadReadState &
-  Pick<ThreadListEntry, "originKind" | "hasPendingInteraction" | "visibility">;
+  Pick<
+    ThreadListEntry,
+    | "hasPendingInteraction"
+    | "id"
+    | "originKind"
+    | "parentThreadId"
+    | "visibility"
+  >;
 
 interface ShouldShowFaviconAttentionDotArgs {
   // Whether the thread currently in view is blocked on a pending interaction.
   // Sourced from the thread's own pending-interactions query, since the sidebar
   // list can't see archived threads or side chats.
   currentThreadHasPendingInteraction: boolean;
+  currentThreadId?: string | null;
   isThreadView: boolean;
   sidebarThreads: readonly FaviconSidebarThread[];
   thread: ThreadReadState | null | undefined;
@@ -28,15 +36,33 @@ function isPendingSidebarThread(thread: FaviconSidebarThread): boolean {
   return isSidebarProjectThread(thread) && thread.hasPendingInteraction;
 }
 
+function isPendingDelegatedChildOfCurrentThread(
+  thread: FaviconSidebarThread,
+  currentThreadId: string,
+): boolean {
+  return (
+    thread.parentThreadId === currentThreadId &&
+    thread.originKind === null &&
+    thread.hasPendingInteraction
+  );
+}
+
 export function shouldShowFaviconAttentionDot({
   currentThreadHasPendingInteraction,
+  currentThreadId,
   isThreadView,
   sidebarThreads,
   thread,
 }: ShouldShowFaviconAttentionDotArgs): boolean {
   if (isThreadView) {
+    const childNeedsAttention =
+      currentThreadId != null &&
+      sidebarThreads.some((candidate) =>
+        isPendingDelegatedChildOfCurrentThread(candidate, currentThreadId),
+      );
     return (
       currentThreadHasPendingInteraction ||
+      childNeedsAttention ||
       Boolean(thread && !isThreadRead(thread))
     );
   }

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
@@ -343,23 +343,44 @@ const childThreadsFixture: ThreadPromptChildThreadsSection = {
       id: "thr_a",
       title: "Investigate Safari auth flake on staging",
       href: "/projects/proj-1/threads/thr_a",
+      hasPendingInteraction: false,
     },
     {
       id: "thr_b",
       title: "Review PR #4521 reviewer comments",
       href: "/projects/proj-1/threads/thr_b",
+      hasPendingInteraction: false,
     },
     {
       id: "thr_c",
       title: "Refactor email pipeline retry logic",
       href: "/projects/proj-1/threads/thr_c",
+      hasPendingInteraction: false,
     },
     {
       id: "thr_d",
       title: "Backfill workspace-status invalidation cache",
       href: "/projects/proj-1/threads/thr_d",
+      hasPendingInteraction: false,
     },
   ],
+};
+
+const childThreadsPendingFixture: ThreadPromptChildThreadsSection = {
+  items: [
+    {
+      id: "thr_blocked",
+      title: "Install workspace tools",
+      href: "/projects/proj-1/threads/thr_blocked",
+      hasPendingInteraction: true,
+    },
+  ],
+};
+
+const childThreadsMixedFixture: ThreadPromptChildThreadsSection = {
+  items: childThreadsFixture.items.map((item, index) =>
+    index === 1 ? { ...item, hasPendingInteraction: true } : item,
+  ),
 };
 
 const childThreadsLargeFixture: ThreadPromptChildThreadsSection = {
@@ -367,6 +388,7 @@ const childThreadsLargeFixture: ThreadPromptChildThreadsSection = {
     id: `thr_large_${i}`,
     title: `Child work item ${i + 1} that is busy doing thing-${i}`,
     href: `/projects/proj-1/threads/thr_large_${i}`,
+    hasPendingInteraction: i === 1,
   })),
 };
 
@@ -731,6 +753,12 @@ export function Overview() {
         <Row parentThread={sideChatFromFixture} mergeBase={null} />
       </StoryRow>
       <StoryRow
+        label="parent thread with a child waiting for approval"
+        hint="the parent banner names the blocked child and drops the active shimmer"
+      >
+        <Row childThreads={childThreadsPendingFixture} mergeBase={null} />
+      </StoryRow>
+      <StoryRow
         label="parent thread with active children (collapsed)"
         hint="the primary child mirrors other background-work banners without an animated flash; click to expand the child list"
       >
@@ -741,7 +769,7 @@ export function Overview() {
         hint="list of children with status + pending-approval marker on item 2"
       >
         <Row
-          childThreads={childThreadsFixture}
+          childThreads={childThreadsMixedFixture}
           mergeBase={null}
           initiallyExpandedSection="childThreads"
         />

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
@@ -420,9 +420,9 @@ describe("ThreadPromptContextBanner", () => {
     );
 
     expect(markup).toContain(
-      "1 child thread needs approval: Install workspace tools",
+      "1 child thread needs input: Install workspace tools",
     );
-    expect(markup).toContain("Needs your approval:");
+    expect(markup).toContain("Needs your input:");
     expect(markup).toContain("Install workspace tools");
     expect(markup).toContain('data-icon="CircleQuestion"');
     expect(markup).not.toContain("Active child thread:");

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
@@ -298,6 +298,7 @@ describe("ThreadPromptContextBanner", () => {
                 id: "thr_child",
                 title: "Investigate failing checks",
                 href: "/threads/thr_child",
+                hasPendingInteraction: false,
               },
             ],
           }}
@@ -334,11 +335,13 @@ describe("ThreadPromptContextBanner", () => {
                 id: "thr_primary",
                 title: "Investigate failing checks",
                 href: "/threads/thr_primary",
+                hasPendingInteraction: false,
               },
               {
                 id: "thr_other",
                 title: "Review the release notes",
                 href: "/threads/thr_other",
+                hasPendingInteraction: false,
               },
             ],
           }}
@@ -372,6 +375,7 @@ describe("ThreadPromptContextBanner", () => {
                 id: "thr_waiting",
                 title: "Waiting for build host",
                 href: "/threads/thr_waiting",
+                hasPendingInteraction: false,
               },
             ],
           }}
@@ -387,6 +391,42 @@ describe("ThreadPromptContextBanner", () => {
     );
     expect(markup).toContain("Active child thread:");
     expect(markup).not.toContain("Running child thread:");
+  });
+
+  it("labels a child blocked on approval instead of active work", () => {
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <ThreadPromptContextBanner
+          gitSection={null}
+          gitSectionPending={false}
+          archivedSection={null}
+          environmentGoneSection={null}
+          parentThreadSection={null}
+          childThreadsSection={{
+            items: [
+              {
+                id: "thr_blocked",
+                title: "Install workspace tools",
+                href: "/threads/thr_blocked",
+                hasPendingInteraction: true,
+              },
+            ],
+          }}
+          pullRequestSection={null}
+          expandedSection={null}
+          onToggleSection={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(markup).toContain(
+      "1 child thread needs approval: Install workspace tools",
+    );
+    expect(markup).toContain("Needs your approval:");
+    expect(markup).toContain("Install workspace tools");
+    expect(markup).toContain('data-icon="CircleQuestion"');
+    expect(markup).not.toContain("Active child thread:");
+    expect(markup).not.toContain("animate-shine-icon");
   });
 
   it("labels standalone actionable pull request attention", () => {

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
@@ -82,6 +82,8 @@ export interface ThreadPromptChildThreadItem {
   id: string;
   title: string;
   href: string;
+  /** True when this child is blocked on a permission or user question. */
+  hasPendingInteraction: boolean;
 }
 
 export interface ThreadPromptChildThreadsSection {
@@ -407,8 +409,21 @@ function ChildThreadsBody({
             title={item.title}
             className="flex min-w-0 items-center gap-2 py-0.5 text-foreground/90 underline-offset-2 hover:underline"
           >
-            <ChildThreadIcon className="text-subtle-foreground no-underline" />
+            {item.hasPendingInteraction ? (
+              <Icon
+                name="CircleQuestion"
+                className="size-3.5 shrink-0 text-muted-foreground/75 no-underline"
+                aria-hidden="true"
+              />
+            ) : (
+              <ChildThreadIcon className="text-subtle-foreground no-underline" />
+            )}
             <span className="min-w-0 flex-1 truncate">{item.title}</span>
+            {item.hasPendingInteraction ? (
+              <span className="shrink-0 text-muted-foreground">
+                Needs approval
+              </span>
+            ) : null}
           </NavLink>
         </li>
       ))}
@@ -671,13 +686,17 @@ function AnimatedBody({
   );
 }
 
-const CHILD_THREADS_HEADER_BUTTON_CLASS = activityRowClass(
-  "active",
-  "flex min-h-8 w-full min-w-0 cursor-pointer items-center gap-1.5 rounded-none px-3 py-1.5 text-xs text-foreground transition-colors hover:bg-background/80",
-);
+const CHILD_THREADS_HEADER_BUTTON_CLASS =
+  "flex min-h-8 w-full min-w-0 cursor-pointer items-center gap-1.5 rounded-none px-3 py-1.5 text-xs text-foreground transition-colors hover:bg-background/80";
 
-function childThreadsLabel(count: number): string {
-  return `${count} active child ${count === 1 ? "thread" : "threads"}`;
+function childThreadsLabel(args: {
+  count: number;
+  pendingCount: number;
+}): string {
+  if (args.pendingCount > 0) {
+    return `${args.pendingCount} child ${args.pendingCount === 1 ? "thread needs" : "threads need"} approval`;
+  }
+  return `${args.count} active child ${args.count === 1 ? "thread" : "threads"}`;
 }
 
 function ActiveChildThreadsCard({
@@ -689,12 +708,26 @@ function ActiveChildThreadsCard({
   isExpanded: boolean;
   onToggle: () => void;
 }) {
-  const primary = childThreadsSection.items[0];
+  const items = [...childThreadsSection.items].sort((left, right) =>
+    left.hasPendingInteraction === right.hasPendingInteraction
+      ? 0
+      : left.hasPendingInteraction
+        ? -1
+        : 1,
+  );
+  const primary = items[0];
   if (!primary) {
     return null;
   }
-  const otherCount = childThreadsSection.items.length - 1;
-  const groupLabel = childThreadsLabel(childThreadsSection.items.length);
+  const pendingCount = items.filter(
+    (item) => item.hasPendingInteraction,
+  ).length;
+  const otherCount = items.length - 1;
+  const groupLabel = childThreadsLabel({
+    count: items.length,
+    pendingCount,
+  });
+  const needsApproval = pendingCount > 0;
   return (
     <PromptStackCard
       ariaLabel="Child threads"
@@ -709,16 +742,26 @@ function ActiveChildThreadsCard({
           aria-controls={SECTION_IDS.childThreads.body}
           aria-label={`${groupLabel}: ${primary.title}`}
           onClick={onToggle}
-          className={CHILD_THREADS_HEADER_BUTTON_CLASS}
+          className={
+            needsApproval
+              ? CHILD_THREADS_HEADER_BUTTON_CLASS
+              : activityRowClass("active", CHILD_THREADS_HEADER_BUTTON_CLASS)
+          }
         >
           <Icon
-            name="UserRound"
-            className={activityIconClass("active", "size-3.5 shrink-0")}
+            name={needsApproval ? "CircleQuestion" : "UserRound"}
+            className={
+              needsApproval
+                ? "size-3.5 shrink-0 text-muted-foreground/75"
+                : activityIconClass("active", "size-3.5 shrink-0")
+            }
             aria-hidden="true"
           />
           <span className="min-w-0 flex-1 truncate text-left">
             <span className="text-muted-foreground">
-              Active child thread:{" "}
+              {needsApproval
+                ? "Needs your approval: "
+                : "Active child thread: "}
             </span>
             <span className="font-medium text-foreground/80">
               {primary.title}
@@ -744,7 +787,7 @@ function ActiveChildThreadsCard({
         labelledBy={SECTION_IDS.childThreads.toggle}
         isExpanded={isExpanded}
       >
-        <ChildThreadsBody items={childThreadsSection.items} />
+        <ChildThreadsBody items={items} />
       </AnimatedBody>
     </PromptStackCard>
   );

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
@@ -421,7 +421,7 @@ function ChildThreadsBody({
             <span className="min-w-0 flex-1 truncate">{item.title}</span>
             {item.hasPendingInteraction ? (
               <span className="shrink-0 text-muted-foreground">
-                Needs approval
+                Needs input
               </span>
             ) : null}
           </NavLink>
@@ -694,7 +694,7 @@ function childThreadsLabel(args: {
   pendingCount: number;
 }): string {
   if (args.pendingCount > 0) {
-    return `${args.pendingCount} child ${args.pendingCount === 1 ? "thread needs" : "threads need"} approval`;
+    return `${args.pendingCount} child ${args.pendingCount === 1 ? "thread needs" : "threads need"} input`;
   }
   return `${args.count} active child ${args.count === 1 ? "thread" : "threads"}`;
 }
@@ -760,7 +760,7 @@ function ActiveChildThreadsCard({
           <span className="min-w-0 flex-1 truncate text-left">
             <span className="text-muted-foreground">
               {needsApproval
-                ? "Needs your approval: "
+                ? "Needs your input: "
                 : "Active child thread: "}
             </span>
             <span className="font-medium text-foreground/80">

--- a/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.stories.tsx
+++ b/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.stories.tsx
@@ -3,6 +3,7 @@ import type {
   ProviderPendingInteraction,
 } from "@bb/domain";
 import { ThreadPendingInteractionBanner } from "@/components/thread/pending-interactions/ThreadPendingInteractionBanner";
+import { ThreadPromptContextBanner } from "@/components/promptbox/banner/ThreadPromptContextBanner";
 import { StoryCard, StoryRow } from "../../../../.ladle/story-card";
 
 export default {
@@ -123,6 +124,56 @@ const permissionGrant: PendingInteraction = {
 export function Overview() {
   return (
     <StoryCard>
+      <StoryRow
+        label="parent thread when a child needs approval"
+        hint="the parent composer shows the child's prompt plus the needs-approval banner"
+      >
+        <PromptStage>
+          <ThreadPendingInteractionBanner
+            interaction={commandApproval}
+            sourceThread={{
+              href: "/projects/proj-1/threads/thr_blocked",
+              title: "Install workspace tools",
+            }}
+            threadId={commandApproval.threadId}
+          />
+          <ThreadPromptContextBanner
+            gitSection={null}
+            gitSectionPending={false}
+            archivedSection={null}
+            environmentGoneSection={null}
+            parentThreadSection={null}
+            childThreadsSection={{
+              items: [
+                {
+                  id: "thr_blocked",
+                  title: "Install workspace tools",
+                  href: "/projects/proj-1/threads/thr_blocked",
+                  hasPendingInteraction: true,
+                },
+              ],
+            }}
+            pullRequestSection={null}
+            expandedSection={null}
+            onToggleSection={() => {}}
+          />
+        </PromptStage>
+      </StoryRow>
+      <StoryRow
+        label="command approval from a child thread"
+        hint="parent composer surfaces the child's permission prompt with a link back to that child"
+      >
+        <PromptStage>
+          <ThreadPendingInteractionBanner
+            interaction={commandApproval}
+            sourceThread={{
+              href: "/projects/proj-1/threads/thr_blocked",
+              title: "Install workspace tools",
+            }}
+            threadId={commandApproval.threadId}
+          />
+        </PromptStage>
+      </StoryRow>
       <StoryRow
         label="command approval"
         hint="agent wants to run a shell command; default selection is the first decision"

--- a/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.tsx
+++ b/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.tsx
@@ -1,4 +1,5 @@
 import { useMemo, type ReactNode } from "react";
+import { NavLink } from "react-router-dom";
 import {
   assertNever,
   buildPendingInteractionApprovalResolution,
@@ -25,20 +26,28 @@ import { useResolveThreadPendingInteraction } from "@/hooks/mutations/thread-int
 import { getMutationErrorMessage } from "@/lib/mutation-errors";
 import { cn } from "@bb/shared-ui/lib/utils";
 
+interface ThreadPendingInteractionSourceThread {
+  href: string;
+  title: string;
+}
+
 interface ThreadPendingInteractionBannerProps {
   interaction: PendingInteraction;
+  sourceThread?: ThreadPendingInteractionSourceThread;
   threadId: string;
 }
 
 interface ApprovalPendingInteractionBannerProps {
   interaction: PendingInteraction;
   payload: ApprovalPendingInteractionPayload;
+  sourceThread?: ThreadPendingInteractionSourceThread;
   threadId: string;
 }
 
 interface UserQuestionPendingInteractionBannerProps {
   interaction: PendingInteraction;
   payload: UserQuestionPendingInteractionPayload;
+  sourceThread?: ThreadPendingInteractionSourceThread;
   threadId: string;
 }
 
@@ -48,6 +57,7 @@ interface BannerShellProps {
   errorMessage?: string | null;
   footer?: ReactNode;
   children?: ReactNode;
+  sourceThread?: ThreadPendingInteractionSourceThread;
 }
 
 interface ApprovalSubject {
@@ -62,6 +72,7 @@ interface BuildApprovalSubjectInput {
 
 export function ThreadPendingInteractionBanner({
   interaction,
+  sourceThread,
   threadId,
 }: ThreadPendingInteractionBannerProps) {
   if (interaction.payload.kind === "plugin") {
@@ -72,6 +83,7 @@ export function ThreadPendingInteractionBanner({
       <ThreadUserQuestionPendingInteractionBanner
         interaction={interaction}
         payload={interaction.payload}
+        sourceThread={sourceThread}
         threadId={threadId}
       />
     );
@@ -85,6 +97,7 @@ export function ThreadPendingInteractionBanner({
     <ApprovalPendingInteractionBanner
       interaction={interaction}
       payload={interaction.payload}
+      sourceThread={sourceThread}
       threadId={threadId}
     />
   );
@@ -95,9 +108,18 @@ function BannerShell({
   errorMessage,
   footer,
   children,
+  sourceThread,
 }: BannerShellProps) {
   return (
     <div className="mb-2 rounded-lg border border-border bg-surface-recessed px-4 py-3 text-xs text-muted-foreground">
+      {sourceThread ? (
+        <NavLink
+          to={sourceThread.href}
+          className="mb-1 block text-xs text-muted-foreground no-underline hover:underline"
+        >
+          From child thread: {sourceThread.title}
+        </NavLink>
+      ) : null}
       {title ? (
         <h3 className="min-w-0 text-sm font-semibold text-foreground">
           <ExpandableLine fullText={title} collapsedClassName="line-clamp-2">
@@ -125,6 +147,7 @@ function BannerShell({
 function ApprovalPendingInteractionBanner({
   interaction,
   payload,
+  sourceThread,
   threadId,
 }: ApprovalPendingInteractionBannerProps) {
   const resolvePendingInteraction = useResolveThreadPendingInteraction();
@@ -163,6 +186,7 @@ function ApprovalPendingInteractionBanner({
     <BannerShell
       title={subject.title}
       errorMessage={mutationErrorMessage}
+      sourceThread={sourceThread}
       footer={payload.availableDecisions.map((decision) => (
         <ApprovalDecisionButton
           key={decision}
@@ -182,6 +206,7 @@ function ApprovalPendingInteractionBanner({
 function ThreadUserQuestionPendingInteractionBanner({
   interaction,
   payload,
+  sourceThread,
   threadId,
 }: UserQuestionPendingInteractionBannerProps) {
   const isResolving = interaction.status === "resolving";
@@ -189,7 +214,7 @@ function ThreadUserQuestionPendingInteractionBanner({
   // No shell title: the form supplies its own heading (the current question
   // prompt) plus the question tab strip.
   return (
-    <BannerShell>
+    <BannerShell sourceThread={sourceThread}>
       <UserQuestionAnswerForm
         interactionId={interaction.id}
         isResolving={isResolving}

--- a/apps/app/src/hooks/queries/child-thread-pending-interactions.test.ts
+++ b/apps/app/src/hooks/queries/child-thread-pending-interactions.test.ts
@@ -1,0 +1,80 @@
+import type { PendingInteraction } from "@bb/domain";
+import { describe, expect, it } from "vitest";
+import { collectChildThreadPendingAttention } from "./child-thread-pending-interactions";
+
+function makeApproval(id: string, createdAt: number): PendingInteraction {
+  return {
+    id,
+    threadId: "thr_child",
+    turnId: "turn_1",
+    providerId: "codex",
+    providerThreadId: "provider-thread",
+    providerRequestId: `request-${id}`,
+    origin: {
+      kind: "provider",
+      providerId: "codex",
+      providerThreadId: "provider-thread",
+      providerRequestId: `request-${id}`,
+    },
+    status: "pending",
+    resolution: null,
+    statusReason: null,
+    createdAt,
+    resolvedAt: null,
+    payload: {
+      kind: "approval",
+      subject: {
+        kind: "command",
+        itemId: "item_cmd",
+        command: "ls",
+        cwd: "/tmp",
+        actions: [],
+        sessionGrant: null,
+      },
+      reason: "Run a command",
+      availableDecisions: ["allow_once", "deny"],
+    },
+  };
+}
+
+describe("collectChildThreadPendingAttention", () => {
+  it("keeps only delegated children that still have a pending interaction", () => {
+    const latest = makeApproval("pi_new", 20);
+    const items = collectChildThreadPendingAttention(
+      [
+        {
+          id: "thr_blocked",
+          title: "Install tools",
+          href: "/threads/thr_blocked",
+          hasPendingInteraction: true,
+        },
+        {
+          id: "thr_working",
+          title: "Run tests",
+          href: "/threads/thr_working",
+          hasPendingInteraction: false,
+        },
+        {
+          id: "thr_stale",
+          title: "Old blocker",
+          href: "/threads/thr_stale",
+          hasPendingInteraction: true,
+        },
+      ],
+      new Map([
+        ["thr_blocked", [makeApproval("pi_old", 10), latest]],
+        ["thr_working", [makeApproval("pi_ignored", 30)]],
+        ["thr_stale", []],
+      ]),
+    );
+
+    expect(items).toEqual([
+      {
+        childThreadId: "thr_blocked",
+        childTitle: "Install tools",
+        href: "/threads/thr_blocked",
+        interaction: latest,
+      },
+    ]);
+  });
+});

--- a/apps/app/src/hooks/queries/child-thread-pending-interactions.ts
+++ b/apps/app/src/hooks/queries/child-thread-pending-interactions.ts
@@ -1,0 +1,90 @@
+import { useQueries } from "@tanstack/react-query";
+import { useMemo } from "react";
+import type { PendingInteraction } from "@bb/domain";
+import { sdk } from "@/lib/sdk";
+import { useThreadDetailRealtimeSubscriptions } from "@/hooks/useRealtimeSubscription";
+import { REALTIME_OWNED_NO_FOCUS_QUERY_POLICY } from "./query-policies";
+import { threadPendingInteractionsQueryKey } from "./query-keys";
+import { getLatestPendingInteraction } from "./thread-queries";
+
+export interface ChildThreadPendingAttentionSource {
+  hasPendingInteraction: boolean;
+  href: string;
+  id: string;
+  title: string;
+}
+
+export interface ChildThreadPendingAttention {
+  childThreadId: string;
+  childTitle: string;
+  href: string;
+  interaction: PendingInteraction;
+}
+
+export function collectChildThreadPendingAttention(
+  children: readonly ChildThreadPendingAttentionSource[],
+  interactionsByThreadId: ReadonlyMap<
+    string,
+    readonly PendingInteraction[] | undefined
+  >,
+): ChildThreadPendingAttention[] {
+  const items: ChildThreadPendingAttention[] = [];
+  for (const child of children) {
+    if (!child.hasPendingInteraction) {
+      continue;
+    }
+    const interaction = getLatestPendingInteraction(
+      interactionsByThreadId.get(child.id),
+    );
+    if (!interaction) {
+      continue;
+    }
+    items.push({
+      childThreadId: child.id,
+      childTitle: child.title,
+      href: child.href,
+      interaction,
+    });
+  }
+  return items;
+}
+
+export function useChildThreadPendingAttention(
+  children: readonly ChildThreadPendingAttentionSource[],
+): ChildThreadPendingAttention[] {
+  const pendingChildIds = useMemo(
+    () =>
+      children
+        .filter((child) => child.hasPendingInteraction)
+        .map((child) => child.id),
+    [children],
+  );
+  useThreadDetailRealtimeSubscriptions(pendingChildIds);
+
+  const queries = useQueries({
+    queries: pendingChildIds.map((threadId) => ({
+      queryKey: threadPendingInteractionsQueryKey(threadId),
+      queryFn: ({ signal }: { signal: AbortSignal }) =>
+        sdk.threads.interactions.list({
+          threadId,
+          signal,
+        }),
+      enabled: true,
+      refetchOnMount: true,
+      ...REALTIME_OWNED_NO_FOCUS_QUERY_POLICY,
+    })),
+  });
+
+  const interactionsByThreadId = useMemo(() => {
+    const next = new Map<string, readonly PendingInteraction[] | undefined>();
+    pendingChildIds.forEach((threadId, index) => {
+      next.set(threadId, queries[index]?.data);
+    });
+    return next;
+  }, [pendingChildIds, queries]);
+
+  return useMemo(
+    () => collectChildThreadPendingAttention(children, interactionsByThreadId),
+    [children, interactionsByThreadId],
+  );
+}

--- a/apps/app/src/hooks/queries/child-thread-pending-interactions.ts
+++ b/apps/app/src/hooks/queries/child-thread-pending-interactions.ts
@@ -2,7 +2,6 @@ import { useQueries } from "@tanstack/react-query";
 import { useMemo } from "react";
 import type { PendingInteraction } from "@bb/domain";
 import { sdk } from "@/lib/sdk";
-import { useThreadDetailRealtimeSubscriptions } from "@/hooks/useRealtimeSubscription";
 import { REALTIME_OWNED_NO_FOCUS_QUERY_POLICY } from "./query-policies";
 import { threadPendingInteractionsQueryKey } from "./query-keys";
 import { getLatestPendingInteraction } from "./thread-queries";
@@ -52,6 +51,9 @@ export function collectChildThreadPendingAttention(
 export function useChildThreadPendingAttention(
   children: readonly ChildThreadPendingAttentionSource[],
 ): ChildThreadPendingAttention[] {
+  // Thread-list realtime already flips `hasPendingInteraction`. Resolving
+  // from the parent invalidates the interaction query. Do not subscribe to
+  // each child detail stream.
   const pendingChildIds = useMemo(
     () =>
       children
@@ -59,7 +61,6 @@ export function useChildThreadPendingAttention(
         .map((child) => child.id),
     [children],
   );
-  useThreadDetailRealtimeSubscriptions(pendingChildIds);
 
   const queries = useQueries({
     queries: pendingChildIds.map((threadId) => ({

--- a/apps/app/src/hooks/useRealtimeSubscription.ts
+++ b/apps/app/src/hooks/useRealtimeSubscription.ts
@@ -43,6 +43,29 @@ export function useThreadDetailRealtimeSubscription(
   useRealtimeSubscription(target, options);
 }
 
+export function useThreadDetailRealtimeSubscriptions(
+  threadIds: readonly string[],
+  options?: RealtimeSubscriptionOptions,
+): void {
+  const enabled = options?.enabled ?? true;
+  const serializedIds = threadIds.join("\0");
+
+  useEffect(() => {
+    if (!enabled || serializedIds.length === 0) {
+      return;
+    }
+    const ids = serializedIds.split("\0");
+    for (const threadId of ids) {
+      wsManager.subscribe({ kind: "thread-detail", threadId });
+    }
+    return () => {
+      for (const threadId of ids) {
+        wsManager.unsubscribe({ kind: "thread-detail", threadId });
+      }
+    };
+  }, [enabled, serializedIds]);
+}
+
 export function useEnvironmentDetailRealtimeSubscription(
   environmentId: string | null | undefined,
   options?: RealtimeSubscriptionOptions,

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
@@ -30,6 +30,7 @@ import {
   resetPluginSlotStoreForTest,
   setPluginSlotRegistrations,
 } from "@/lib/plugin-slots";
+import type { ChildThreadPendingAttention } from "@/hooks/queries/child-thread-pending-interactions";
 import {
   ThreadDetailPromptArea,
   type ThreadDetailSentMessageEdit,
@@ -635,6 +636,7 @@ interface RenderPromptAreaOptions {
   goal?: ThreadTimelineGoal | null;
   modelFallback?: ThreadTimelineModelFallback | null;
   pendingInteractions?: readonly PendingInteraction[];
+  childPendingInteractions?: readonly ChildThreadPendingAttention[];
   pendingInteractionsInitialLoading?: boolean;
   sentMessageEdit?: ThreadDetailSentMessageEdit;
   thread?: ThreadWithRuntime;
@@ -646,6 +648,7 @@ function buildPromptAreaElement({
   goal = null,
   modelFallback = null,
   pendingInteractions = [],
+  childPendingInteractions = [],
   pendingInteractionsInitialLoading = false,
   sentMessageEdit,
   thread = makeThread(),
@@ -657,6 +660,7 @@ function buildPromptAreaElement({
       activePromptMode={activePromptMode}
       activeWorkflows={activeWorkflows}
       canUseGitUi={false}
+      childPendingInteractions={childPendingInteractions}
       childThreadsSection={null}
       composerFocusRequestNonce={0}
       contextBannerMergeBase={null}
@@ -1462,6 +1466,21 @@ describe("ThreadDetailPromptArea", () => {
         .getAllByTestId("workflow-card")
         .map((card) => card.getAttribute("data-expanded")),
     ).toEqual(["false", "true"]);
+  });
+
+  it("shows a child permission prompt on the parent composer", () => {
+    renderPromptArea({
+      childPendingInteractions: [
+        {
+          childThreadId: "thr_child",
+          childTitle: "Install workspace tools",
+          href: "/threads/thr_child",
+          interaction: makePendingInteraction(),
+        },
+      ],
+    });
+
+    expect(screen.getByText("Pending interaction")).toBeTruthy();
   });
 
   it("keeps Goal above a pending interaction", () => {

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { useNavigate } from "react-router-dom";
+import { NavLink, useNavigate } from "react-router-dom";
 import type { IconName } from "@bb/shared-ui/icon";
 import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
 import {
@@ -1414,10 +1414,17 @@ export function ThreadDetailPromptArea({
     () =>
       childPendingInteractions.map((item) =>
         isPluginPendingInteraction(item.interaction) ? (
-          <PluginPendingInteractionComposer
-            key={item.interaction.id}
-            interaction={item.interaction}
-          />
+          <div key={item.interaction.id}>
+            <NavLink
+              to={item.href}
+              className="mb-1 block text-xs text-muted-foreground no-underline hover:underline"
+            >
+              From child thread: {item.childTitle}
+            </NavLink>
+            <PluginPendingInteractionComposer
+              interaction={item.interaction}
+            />
+          </div>
         ) : (
           <ThreadPendingInteractionBanner
             key={item.interaction.id}

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -25,6 +25,7 @@ import type {
   ThreadTimelineResponse,
   TimelineWorkflowWorkRow,
 } from "@bb/server-contract";
+import type { ChildThreadPendingAttention } from "@/hooks/queries/child-thread-pending-interactions";
 import { ThreadPendingInteractionBanner } from "@/components/thread/pending-interactions/ThreadPendingInteractionBanner";
 import { PluginPendingInteractionComposer } from "@/components/plugin/PluginPendingInteractionComposer";
 import { PluginComposerBanners } from "@/components/plugin/PluginComposerBanners";
@@ -200,6 +201,8 @@ interface ThreadDetailPromptAreaProps {
   activeBackgroundCommands: TimelineWorkflowWorkRow[];
   /** Parent reference for child threads. Null for root threads. */
   parentThreadSection: ThreadPromptParentThreadSection | null;
+  /** Pending permission or question prompts from delegated child threads. */
+  childPendingInteractions: readonly ChildThreadPendingAttention[];
   /** Active child threads for parent threads. Null otherwise. */
   childThreadsSection: ThreadPromptChildThreadsSection | null;
   /** Pull request summary for the active thread branch. Null when there is no PR. */
@@ -334,6 +337,7 @@ export function ThreadDetailPromptArea({
   activeWorkflows,
   activeBackgroundCommands,
   parentThreadSection,
+  childPendingInteractions,
   childThreadsSection,
   pullRequest,
   sendMessage,
@@ -1406,9 +1410,29 @@ export function ThreadDetailPromptArea({
     thread.id,
     typeaheadConfig,
   ]);
+  const childPendingInteractionBanners = useMemo(
+    () =>
+      childPendingInteractions.map((item) =>
+        isPluginPendingInteraction(item.interaction) ? (
+          <PluginPendingInteractionComposer
+            key={item.interaction.id}
+            interaction={item.interaction}
+          />
+        ) : (
+          <ThreadPendingInteractionBanner
+            key={item.interaction.id}
+            interaction={item.interaction}
+            sourceThread={{ href: item.href, title: item.childTitle }}
+            threadId={item.childThreadId}
+          />
+        ),
+      ),
+    [childPendingInteractions],
+  );
   const promptStack = useMemo(
     () => (
       <>
+        {childPendingInteractionBanners}
         {activeWorkflows.map((workflow) => (
           <ThreadWorkflowCard
             key={workflow.id}
@@ -1500,6 +1524,7 @@ export function ThreadDetailPromptArea({
     ),
     [
       canUseGitUi,
+      childPendingInteractionBanners,
       contextBannerMergeBase,
       expandedBannerSection,
       handleDeleteQueuedMessage,
@@ -1544,6 +1569,7 @@ export function ThreadDetailPromptArea({
   const bottomContent =
     activePendingInteraction && !shouldHideComposer ? (
       <div className="grid gap-2">
+        {childPendingInteractionBanners}
         {activePromptMode ? activePromptModeCard : null}
         {goal ? activeGoalCard : null}
         <PluginComposerHostProvider value={normalPluginComposerHost}>

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -52,6 +52,10 @@ import {
   useEnvironmentWorkStatus,
 } from "../../hooks/queries/environment-queries";
 import {
+  useChildThreadPendingAttention,
+  type ChildThreadPendingAttentionSource,
+} from "../../hooks/queries/child-thread-pending-interactions";
+import {
   didThreadDetailBootstrapRefreshAfterMount,
   getLatestPendingInteraction,
   useProjectThreadSubset,
@@ -247,6 +251,8 @@ import { ThreadArchiveCommandHandler } from "./ThreadArchiveCommandHandler";
 import { ThreadRenameCommandHandler } from "./ThreadRenameCommandHandler";
 
 const EMPTY_PARENT_THREADS: readonly ThreadListEntry[] = [];
+const EMPTY_CHILD_THREAD_ITEMS: readonly ChildThreadPendingAttentionSource[] =
+  [];
 const EMPTY_PROJECT_THREAD_SUBSET_FILTERS =
   {} satisfies ProjectThreadSubsetFilters;
 const EMPTY_TERMINAL_SESSIONS: readonly TerminalSession[] = [];
@@ -1925,9 +1931,12 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
           (entry) =>
             // Forks / side chats are user-driven branches opened directly, not
             // delegated work the parent is waiting on — keep them out of the
-            // active-child banner count and drawer.
+            // active-child banner count and drawer. A child blocked on the user
+            // stays visible even if its runtime status later leaves the active
+            // set.
             entry.originKind === null &&
-            isThreadDisplayStatusBannerActive(entry.runtime.displayStatus),
+            (isThreadDisplayStatusBannerActive(entry.runtime.displayStatus) ||
+              entry.hasPendingInteraction),
         )
         .map((entry) => ({
           id: entry.id,
@@ -1936,10 +1945,21 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
             projectId: entry.projectId,
             threadId: entry.id,
           }),
-        }));
+          hasPendingInteraction: entry.hasPendingInteraction,
+        }))
+        .sort((left, right) =>
+          left.hasPendingInteraction === right.hasPendingInteraction
+            ? 0
+            : left.hasPendingInteraction
+              ? -1
+              : 1,
+        );
       if (activeItems.length === 0) return null;
       return { items: activeItems };
     }, [childThreadSubsetQuery.data]);
+  const childPendingInteractions = useChildThreadPendingAttention(
+    childThreadsSection?.items ?? EMPTY_CHILD_THREAD_ITEMS,
+  );
   const isThreadTimelinePending = timelineLoading && timelineRows.length === 0;
   useThreadReadTracking({
     markThreadRead,
@@ -2619,6 +2639,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
       activeWorkflows={activeWorkflows}
       activeBackgroundCommands={activeBackgroundCommands}
       parentThreadSection={parentThreadSection}
+      childPendingInteractions={childPendingInteractions}
       childThreadsSection={childThreadsSection}
       pullRequest={pullRequest}
       thread={thread}

--- a/apps/server/src/services/threads/thread-runtime-config.ts
+++ b/apps/server/src/services/threads/thread-runtime-config.ts
@@ -136,7 +136,10 @@ function resolveDynamicTools(
 export function resolvePermissionEscalation(
   args: ResolvePermissionEscalationArgs,
 ): PermissionEscalation {
-  if (args.initiator !== "user" || args.thread.parentThreadId !== null) {
+  // System turns (parent notifications, recovery) must not prompt. A
+  // user-started turn asks even on a delegated child so a sandbox-blocked
+  // action can surface on the parent instead of failing in silence.
+  if (args.initiator !== "user") {
     return "deny";
   }
 

--- a/apps/server/test/threads/thread-runtime-config.test.ts
+++ b/apps/server/test/threads/thread-runtime-config.test.ts
@@ -1085,7 +1085,7 @@ describe("thread runtime config", () => {
     });
   });
 
-  it("derives ask escalation only for direct user root-thread work", async () => {
+  it("derives ask escalation for user-initiated work on root and child threads", async () => {
     await withTestHarness(async (harness) => {
       const { host } = seedHostSession(harness.deps, {
         id: "host-runtime-permission-escalation",
@@ -1135,6 +1135,12 @@ describe("thread runtime config", () => {
         resolvePermissionEscalation({
           thread: childThread,
           initiator: "user",
+        }),
+      ).toBe("ask");
+      expect(
+        resolvePermissionEscalation({
+          thread: childThread,
+          initiator: "system",
         }),
       ).toBe("deny");
       expect(


### PR DESCRIPTION
## Summary

- let user-started child turns ask for sandbox escalations instead of auto-denying them
- show the child's Allow / Deny prompt on the parent composer, with a link back to that child
- mark the parent child-thread banner as needing approval and light favicon attention while a delegated child is waiting

Fixes #1417

## Why

A delegated child in `accept-edits` used to get `permissionEscalation: deny` because it had a `parentThreadId`. A sandbox-blocked action (`sudo`, network, write outside the workspace) failed in silence, and the parent still looked busy. In-sandbox Bash stays auto-allowed.

## Validation

- `pnpm exec turbo run test --filter=@bb/app -- ThreadPromptContextBanner faviconAttentionDot child-thread-pending-interactions ThreadDetailPromptArea`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/server -- thread-runtime-config`
- live QA on the local dev app: spawned a parent + `accept-edits` child, ran `sudo -n id`, approved **Allow once** from the parent, and the child completed with `uid=0(root)`

## Risks

- user-started children can now present Allow / Deny. System turns still deny.
- no host-daemon protocol bump: daemons already understand `ask`.

> AGENT GENERATED: by Grok 4.6