### PR TITLE
Keep right-panel tabs clear of overflow carets

### DIFF
--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
@@ -63,7 +63,12 @@ describe("secondary panel tab-strip edge fades", () => {
     const content = container.querySelector(
       "[data-secondary-panel-tab-content]",
     );
+    const strip = container.querySelector(
+      '[data-testid="secondary-panel-tab-strip"]',
+    );
     expect(content).not.toBeNull();
+    expect(strip).not.toBeNull();
+    expect(observed).toContain(strip);
     expect(observed).toContain(viewport);
     expect(observed).toContain(content);
     expect(resizeCallback).toBeDefined();
@@ -73,12 +78,14 @@ describe("secondary panel tab-strip edge fades", () => {
         .querySelector("[data-overflow-fade='left']")
         ?.classList.contains("w-6"),
     ).toBe(true);
-    expect(
-      container.querySelector('[aria-label="Scroll tabs left"]'),
-    ).not.toBeNull();
-    expect(
-      container.querySelector('[aria-label="Scroll tabs right"]'),
-    ).not.toBeNull();
+    const leftButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Scroll tabs left"]',
+    );
+    const rightButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Scroll tabs right"]',
+    );
+    expect(leftButton?.classList.contains("w-0")).toBe(true);
+    expect(rightButton?.classList.contains("w-0")).toBe(true);
 
     const rightFade = container.querySelector("[data-overflow-fade='right']");
     expect(rightFade?.classList.contains("opacity-0")).toBe(true);
@@ -87,17 +94,29 @@ describe("secondary panel tab-strip edge fades", () => {
       scrollWidth: { configurable: true, value: 240 },
       scrollLeft: { configurable: true, value: 0, writable: true },
     });
+    Object.defineProperty(strip!, "clientWidth", {
+      configurable: true,
+      value: 120,
+    });
+    Object.defineProperty(content!, "scrollWidth", {
+      configurable: true,
+      value: 240,
+    });
     act(() => {
       resizeCallback?.([], {} as ResizeObserver);
     });
     expect(rightFade?.classList.contains("opacity-100")).toBe(true);
 
-    const leftButton = container.querySelector<HTMLButtonElement>(
-      '[aria-label="Scroll tabs left"]',
+    const scrollRegion = container.querySelector(
+      "[data-secondary-panel-tab-scroll-region]",
     );
-    const rightButton = container.querySelector<HTMLButtonElement>(
-      '[aria-label="Scroll tabs right"]',
-    );
+    expect(strip?.children[0]).toBe(leftButton);
+    expect(strip?.children[1]).toBe(scrollRegion);
+    expect(strip?.children[2]).toBe(rightButton);
+    expect(leftButton?.classList.contains("absolute")).toBe(false);
+    expect(rightButton?.classList.contains("absolute")).toBe(false);
+    expect(leftButton?.classList.contains("w-5")).toBe(true);
+    expect(rightButton?.classList.contains("w-5")).toBe(true);
     expect(leftButton?.classList.contains("opacity-0")).toBe(true);
     expect(leftButton?.tabIndex).toBe(-1);
     expect(rightButton?.classList.contains("opacity-100")).toBe(true);
@@ -124,5 +143,18 @@ describe("secondary panel tab-strip edge fades", () => {
     expect(rightButton?.getAttribute("aria-hidden")).toBe("true");
     expect(leftButton?.getAttribute("aria-hidden")).toBe("false");
     expect(document.activeElement).toBe(leftButton);
+
+    Object.defineProperty(content!, "scrollWidth", {
+      configurable: true,
+      value: 100,
+    });
+    act(() => {
+      resizeCallback?.([], {} as ResizeObserver);
+    });
+    expect(leftButton?.classList.contains("w-0")).toBe(true);
+    expect(rightButton?.classList.contains("w-0")).toBe(true);
+    expect(document.activeElement).toBe(
+      container.querySelector('button[aria-pressed="true"]'),
+    );
   });
 });

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
@@ -28,7 +28,6 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Button } from "@bb/shared-ui/button";
-import { COARSE_POINTER_COMPACT_ICON_BUTTON_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import { Icon } from "@bb/shared-ui/icon";
 import {
   OverflowFade,
@@ -50,12 +49,18 @@ export type { SecondaryPanelFileTab } from "./secondaryPanelFileTab";
 // Roughly one wide tab, so one click reveals the next tab without overshooting.
 const CHEVRON_SCROLL_STEP_PX = 140;
 
+// Keep fine-pointer caret columns compact without shrinking touch targets.
+const TAB_STRIP_SCROLL_BUTTON_CLASS =
+  "h-7 w-5 rounded-md p-0 [&_svg]:size-3.5 max-md:pointer-coarse:h-9 max-md:pointer-coarse:w-9 max-md:pointer-coarse:[&_svg]:size-5";
+
 // Slack so sub-pixel scroll offsets don't leave an overflow cue at a hard edge.
 const EDGE_EPSILON_PX = 1;
 
 export const SECONDARY_PANEL_TAB_STRIP_FADE_TONE: OverflowFadeTone = "sidebar";
 
 interface TabStripOverflowState {
+  /** The intrinsic tab row is wider than the whole strip. */
+  hasOverflow: boolean;
   /** Scrolled away from the left edge (content hidden to the left). */
   canScrollLeft: boolean;
   /** More content remains to the right. */
@@ -63,6 +68,7 @@ interface TabStripOverflowState {
 }
 
 const INITIAL_OVERFLOW_STATE: TabStripOverflowState = {
+  hasOverflow: false,
   canScrollLeft: false,
   canScrollRight: false,
 };
@@ -97,6 +103,7 @@ export function SecondaryPanelTabStrip({
   usesDesktopChrome,
   activeTreatment = "fill",
 }: SecondaryPanelTabStripProps) {
+  const stripRef = useRef<HTMLDivElement>(null);
   const viewportRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const activeTabRef = useRef<HTMLDivElement>(null);
@@ -111,6 +118,7 @@ export function SecondaryPanelTabStrip({
   // crossing (and its fade/chevron repaint) re-dirties layout. The scroll handler
   // then reads only scrollLeft, which is cheap and doesn't flush layout.
   const maxScrollLeftRef = useRef(0);
+  const hasOverflowRef = useRef(false);
   const scrollFrameRef = useRef<number | null>(null);
   const [draggingTabId, setDraggingTabId] = useState<string | null>(null);
   const {
@@ -138,7 +146,8 @@ export function SecondaryPanelTabStrip({
       return;
     }
     const maxScrollLeft = maxScrollLeftRef.current;
-    const isScrollable = maxScrollLeft > EDGE_EPSILON_PX;
+    const hasOverflow = hasOverflowRef.current;
+    const isScrollable = hasOverflow && maxScrollLeft > EDGE_EPSILON_PX;
     const { scrollLeft } = viewport;
     const canScrollLeft = isScrollable && scrollLeft > EDGE_EPSILON_PX;
     const canScrollRight =
@@ -147,21 +156,32 @@ export function SecondaryPanelTabStrip({
     // out of re-rendering. With the tab tree memoized, a real change only
     // repaints the always-mounted edge fades/chevrons (an opacity toggle).
     setOverflow((prev) =>
+      prev.hasOverflow === hasOverflow &&
       prev.canScrollLeft === canScrollLeft &&
       prev.canScrollRight === canScrollRight
         ? prev
-        : { canScrollLeft, canScrollRight },
+        : { hasOverflow, canScrollLeft, canScrollRight },
     );
   }, []);
 
   // Expensive (reads scrollWidth/clientWidth): run only on resize / tab change,
   // then re-derive the edge flags from the fresh capacity.
   const measureCapacity = useCallback(() => {
+    const strip = stripRef.current;
     const viewport = viewportRef.current;
-    if (viewport === null) {
+    const content = contentRef.current;
+    if (strip === null || viewport === null || content === null) {
       return;
     }
-    maxScrollLeftRef.current = viewport.scrollWidth - viewport.clientWidth;
+    // Decide whether controls are needed against the whole strip width, not the
+    // narrower viewport between those controls. Otherwise the control slots can
+    // make themselves permanently necessary after the tabs would fit again.
+    const hasOverflow =
+      content.scrollWidth > strip.clientWidth + EDGE_EPSILON_PX;
+    hasOverflowRef.current = hasOverflow;
+    maxScrollLeftRef.current = hasOverflow
+      ? Math.max(0, viewport.scrollWidth - viewport.clientWidth)
+      : 0;
     applyEdgeFlags();
   }, [applyEdgeFlags]);
 
@@ -186,6 +206,9 @@ export function SecondaryPanelTabStrip({
     };
     viewport.addEventListener("scroll", handleScroll, { passive: true });
     const resizeObserver = new ResizeObserver(measureCapacity);
+    if (stripRef.current !== null) {
+      resizeObserver.observe(stripRef.current);
+    }
     resizeObserver.observe(viewport);
     if (contentRef.current !== null) {
       resizeObserver.observe(contentRef.current);
@@ -214,9 +237,11 @@ export function SecondaryPanelTabStrip({
     void document.fonts?.ready?.then(() => measureCapacity());
   }, [measureCapacity]);
 
-  // Bring the active tab into view on mount and on every active-tab change. This
-  // is the single hook that covers click, keyboard focus, and programmatic
-  // selection. jsdom doesn't implement scrollIntoView, so guard the call.
+  // Bring the active tab into view on mount, on every active-tab change, and
+  // after the overflow control slots enter or leave the row. The last case
+  // keeps a tab that was aligned to the old viewport edge from being clipped
+  // when the controls reserve space. jsdom doesn't implement scrollIntoView,
+  // so guard the call.
   const activeTabId = fileTabs.find((tab) => tab.isActive)?.id ?? null;
   useLayoutEffect(() => {
     const activeTabElement = activeTabRef.current;
@@ -224,7 +249,7 @@ export function SecondaryPanelTabStrip({
       return;
     }
     activeTabElement.scrollIntoView({ inline: "nearest", block: "nearest" });
-  }, [activeTabId]);
+  }, [activeTabId, overflow.hasOverflow]);
 
   // A scroll button can reach its edge while it has keyboard focus. Move focus
   // before the button becomes an invisible, aria-hidden control.
@@ -350,9 +375,9 @@ export function SecondaryPanelTabStrip({
   const chevronNoDragClass = usesDesktopChrome
     ? MACOS_APP_REGION_NO_DRAG_CLASS
     : null;
-  // Memoize the sortable tab tree so the overflow-flag state — which flips every
-  // time you reach a scroll edge, i.e. constantly at narrow widths — re-renders
-  // only the edge controls, never the tabs. Without this, each edge
+  // Memoize the sortable tab tree so the directional overflow flags — which
+  // flip every time you reach a scroll edge, i.e. constantly at narrow widths —
+  // re-render only the edge controls, never the tabs. Without this, each edge
   // crossing reconciles the whole list and re-runs useSortable for every tab,
   // which is what kept narrow-width scrolling stuttery.
   const dndTabs = useMemo(
@@ -408,61 +433,65 @@ export function SecondaryPanelTabStrip({
   );
 
   return (
-    // Hugs its tabs (no `flex-1`) and shrinks (`min-w-0`) to scroll them under
-    // the edge controls when they overflow. The New Tab button follows this
-    // viewport as an anchored sibling, so it stays visible at the trailing edge
-    // while overflowing tabs scroll beneath the fades.
+    // Hugs its tabs (no `flex-1`) and shrinks (`min-w-0`) when they overflow.
+    // The New Tab button follows this strip as an anchored sibling, while the
+    // in-flow scroll controls reserve their own space on either side of the tab
+    // viewport instead of covering its contents.
     <div
+      ref={stripRef}
       data-testid="secondary-panel-tab-strip"
       className="group relative flex min-w-0 items-center"
     >
-      {/* Keep both overflow cues stationary while the tab content moves below
-          them. The buttons use the panel surface as a solid background, so tab
-          text cannot show through a button during a smooth scroll. */}
-      <OverflowFade
-        placement="left"
-        tone={SECONDARY_PANEL_TAB_STRIP_FADE_TONE}
-        className={cn(
-          "z-10",
-          overflow.canScrollLeft ? "opacity-100" : "opacity-0",
-        )}
-      />
-      <OverflowFade
-        placement="right"
-        tone={SECONDARY_PANEL_TAB_STRIP_FADE_TONE}
-        className={cn(
-          "z-10",
-          overflow.canScrollRight ? "opacity-100" : "opacity-0",
-        )}
-      />
-      <div
-        ref={viewportRef}
-        onClickCapture={handleClickCapture}
-        // No `scroll-smooth` here: wheel translation assigns scrollLeft directly
-        // (see the wheel handler), and CSS smooth-scroll would turn each wheel
-        // notch into its own ~150ms animation — the strip advances, sits frozen
-        // between notches, then jumps. Letting it track 1:1 matches native
-        // horizontal trackpad scrolling.
-        className="no-scrollbar min-w-0 overflow-x-auto overflow-y-hidden"
-      >
-        <div
-          ref={contentRef}
-          data-secondary-panel-tab-content
-          className="flex w-max items-center gap-1"
-        >
-          {dndTabs}
-        </div>
-      </div>
       <TabStripScrollButton
         buttonRef={leftScrollButtonRef}
         direction="left"
+        hasOverflow={overflow.hasOverflow}
         canScroll={overflow.canScrollLeft}
         className={chevronNoDragClass}
         onClick={() => scrollByStep(-1)}
       />
+      <div data-secondary-panel-tab-scroll-region className="relative min-w-0">
+        {/* The fades are scoped to the tab viewport, so neither they nor the
+            scrolling pills extend into the in-flow caret slots. */}
+        <OverflowFade
+          placement="left"
+          tone={SECONDARY_PANEL_TAB_STRIP_FADE_TONE}
+          className={cn(
+            "z-10",
+            overflow.canScrollLeft ? "opacity-100" : "opacity-0",
+          )}
+        />
+        <OverflowFade
+          placement="right"
+          tone={SECONDARY_PANEL_TAB_STRIP_FADE_TONE}
+          className={cn(
+            "z-10",
+            overflow.canScrollRight ? "opacity-100" : "opacity-0",
+          )}
+        />
+        <div
+          ref={viewportRef}
+          onClickCapture={handleClickCapture}
+          // No `scroll-smooth` here: wheel translation assigns scrollLeft
+          // directly (see the wheel handler), and CSS smooth-scroll would turn
+          // each wheel notch into its own ~150ms animation — the strip advances,
+          // sits frozen between notches, then jumps. Letting it track 1:1 matches
+          // native horizontal trackpad scrolling.
+          className="no-scrollbar min-w-0 overflow-x-auto overflow-y-hidden"
+        >
+          <div
+            ref={contentRef}
+            data-secondary-panel-tab-content
+            className="flex w-max items-center gap-1"
+          >
+            {dndTabs}
+          </div>
+        </div>
+      </div>
       <TabStripScrollButton
         buttonRef={rightScrollButtonRef}
         direction="right"
+        hasOverflow={overflow.hasOverflow}
         canScroll={overflow.canScrollRight}
         className={chevronNoDragClass}
         onClick={() => scrollByStep(1)}
@@ -522,6 +551,7 @@ function SortableFileTab({
 interface TabStripScrollButtonProps {
   buttonRef: RefObject<HTMLButtonElement | null>;
   direction: "left" | "right";
+  hasOverflow: boolean;
   canScroll: boolean;
   className: string | null;
   onClick: () => void;
@@ -530,12 +560,12 @@ interface TabStripScrollButtonProps {
 function TabStripScrollButton({
   buttonRef,
   direction,
+  hasOverflow,
   canScroll,
   className,
   onClick,
 }: TabStripScrollButtonProps) {
-  const label =
-    direction === "left" ? "Scroll tabs left" : "Scroll tabs right";
+  const label = direction === "left" ? "Scroll tabs left" : "Scroll tabs right";
   return (
     <Button
       ref={buttonRef}
@@ -547,9 +577,10 @@ function TabStripScrollButton({
       aria-label={label}
       onClick={onClick}
       className={cn(
-        "absolute z-20 shrink-0 bg-sidebar text-muted-foreground shadow-none hover:bg-surface-raised-solid hover:text-foreground focus-visible:bg-sidebar",
-        direction === "left" ? "left-0" : "right-0",
-        COARSE_POINTER_COMPACT_ICON_BUTTON_CLASS,
+        "z-20 shrink-0 bg-sidebar text-muted-foreground shadow-none hover:bg-surface-raised-solid hover:text-foreground focus-visible:bg-sidebar",
+        hasOverflow
+          ? TAB_STRIP_SCROLL_BUTTON_CLASS
+          : "h-7 w-0 overflow-hidden p-0 max-md:pointer-coarse:h-9",
         "transition-opacity",
         canScroll
           ? "pointer-events-auto opacity-100"


### PR DESCRIPTION
## Summary

- Keep right-panel tabs and overflow fades inside a dedicated scroll viewport so they no longer pass beneath the caret controls.
- Reserve stable, compact caret columns only while the tab row overflows: 20px for fine pointers and 36px for coarse pointers.
- Preserve active-tab visibility and keyboard focus as overflow appears, disappears, or reaches either edge.

## Validation

- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/secondary-panel/SecondaryPanelTabStrip.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (0 errors; existing warning baseline only)
- Development app startup and HTTP smoke check

> AGENT GENERATED: by GPT-5.6
