### PR TITLE
Keep plugin sidebar overflow menus visible on mobile

### DIFF
--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -143,6 +143,19 @@ describe("PluginNavSidebarItems", () => {
     ).toBeNull();
   });
 
+  it("keeps the panel options trigger visible on mobile", () => {
+    registerPanel("docs", "Docs");
+
+    renderSidebarItems();
+
+    expect(
+      screen
+        .getByRole("button", { name: "Docs panel options" })
+        .closest("[data-sidebar-hover-actions-mobile]")
+        ?.getAttribute("data-sidebar-hover-actions-mobile"),
+    ).toBe("always");
+  });
+
   it("bounds and truncates a long sidebar accessory", () => {
     registerPanel("tasks", "Tasks", () => (
       <span>123456789012345678901234567890</span>

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -46,6 +46,7 @@ import { SIDEBAR_MORE_ACTION_TRIGGER_CLASS } from "@/components/sidebar/sidebarR
 import {
   SIDEBAR_HOVER_ACTIONS_CLASS,
   SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
+  SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE,
   SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
 } from "@/components/ui/sidebar-hover-actions";
 import { useSidebarSortable } from "@/components/sidebar/sortableMotion";
@@ -597,6 +598,9 @@ function SidebarNavRowChrome({
           ) : null}
           <div
             data-sidebar-hover-actions-open={isActionsOpen ? "true" : undefined}
+            data-sidebar-hover-actions-mobile={
+              SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE
+            }
             className={cn(
               SIDEBAR_HOVER_ACTIONS_CLASS,
               // right-0 (not right-1): the trigger's own m-1 supplies the inset,


### PR DESCRIPTION
## Summary

- keep the `…` menu visible on the plugin nav rows at the top of the sidebar on a phone
- reuse the existing `data-sidebar-hover-actions-mobile="always"` flag that project and section rows already use
- leave thread-row menus hover-only; a long press would conflict with drag-to-reorder on these chrome rows

A phone has no hover, so hide/show for Extensions, Docs, Tasks, and the other plugin rows was unreachable.

## Validation

- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/plugin/PluginNavSidebarItems.test.tsx`
- local dev app started for phone QA

## Risks

Small. The `…` glyph now stays on those few chrome rows on coarse pointers, matching project and section chrome.

> AGENT GENERATED: by Grok 4.6