### PR TITLE
Keep tab overflow caret beside fixed controls

### DIFF
--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
@@ -88,7 +88,7 @@ describe("secondary panel tab-strip edge fades", () => {
     expect(rightFade?.classList.contains("opacity-0")).toBe(true);
     Object.defineProperties(viewport!, {
       clientWidth: { configurable: true, value: 120 },
-      scrollWidth: { configurable: true, value: 240 },
+      scrollWidth: { configurable: true, value: 480 },
       scrollLeft: { configurable: true, value: 0, writable: true },
     });
     Object.defineProperty(strip!, "clientWidth", {
@@ -97,7 +97,7 @@ describe("secondary panel tab-strip edge fades", () => {
     });
     Object.defineProperty(content!, "scrollWidth", {
       configurable: true,
-      value: 240,
+      value: 480,
     });
     act(() => {
       resizeCallback?.([], {} as ResizeObserver);
@@ -135,12 +135,34 @@ describe("secondary panel tab-strip edge fades", () => {
 
     overflowButton?.focus();
     expect(document.activeElement).toBe(overflowButton);
-    viewport!.scrollLeft = 120;
+    viewport!.scrollLeft = 140;
     fireEvent.scroll(viewport!);
     act(() => animationFrameCallback?.(0));
     expect(overflowButton?.getAttribute("aria-hidden")).toBe("false");
+    expect(overflowButton?.getAttribute("aria-label")).toBe(
+      "Scroll tabs right",
+    );
+    fireEvent.click(overflowButton!);
+    expect(scrollBy).toHaveBeenLastCalledWith({
+      left: 140,
+      behavior: "smooth",
+    });
+
+    viewport!.scrollLeft = 360;
+    fireEvent.scroll(viewport!);
+    act(() => animationFrameCallback?.(0));
     expect(overflowButton?.getAttribute("aria-label")).toBe("Scroll tabs left");
     expect(document.activeElement).toBe(overflowButton);
+    fireEvent.click(overflowButton!);
+    expect(scrollBy).toHaveBeenLastCalledWith({
+      left: -140,
+      behavior: "smooth",
+    });
+
+    viewport!.scrollLeft = 220;
+    fireEvent.scroll(viewport!);
+    act(() => animationFrameCallback?.(0));
+    expect(overflowButton?.getAttribute("aria-label")).toBe("Scroll tabs left");
     fireEvent.click(overflowButton!);
     expect(scrollBy).toHaveBeenLastCalledWith({
       left: -140,

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
@@ -78,14 +78,11 @@ describe("secondary panel tab-strip edge fades", () => {
         .querySelector("[data-overflow-fade='left']")
         ?.classList.contains("w-6"),
     ).toBe(true);
-    const leftButton = container.querySelector<HTMLButtonElement>(
-      '[aria-label="Scroll tabs left"]',
+    const overflowButton = container.querySelector<HTMLButtonElement>(
+      "[data-secondary-panel-tab-overflow-control]",
     );
-    const rightButton = container.querySelector<HTMLButtonElement>(
-      '[aria-label="Scroll tabs right"]',
-    );
-    expect(leftButton?.classList.contains("w-0")).toBe(true);
-    expect(rightButton?.classList.contains("w-0")).toBe(true);
+    expect(overflowButton).not.toBeNull();
+    expect(overflowButton?.classList.contains("w-0")).toBe(true);
 
     const rightFade = container.querySelector("[data-overflow-fade='right']");
     expect(rightFade?.classList.contains("opacity-0")).toBe(true);
@@ -110,39 +107,45 @@ describe("secondary panel tab-strip edge fades", () => {
     const scrollRegion = container.querySelector(
       "[data-secondary-panel-tab-scroll-region]",
     );
-    expect(strip?.children[0]).toBe(leftButton);
+    expect(strip?.children[0]).toBe(overflowButton);
     expect(strip?.children[1]).toBe(scrollRegion);
-    expect(strip?.children[2]).toBe(rightButton);
-    expect(leftButton?.classList.contains("absolute")).toBe(false);
-    expect(rightButton?.classList.contains("absolute")).toBe(false);
-    expect(leftButton?.classList.contains("w-5")).toBe(true);
-    expect(rightButton?.classList.contains("w-5")).toBe(true);
-    expect(leftButton?.classList.contains("opacity-0")).toBe(true);
-    expect(leftButton?.tabIndex).toBe(-1);
-    expect(rightButton?.classList.contains("opacity-100")).toBe(true);
-    expect(rightButton?.tabIndex).toBe(0);
-    expect(rightButton?.classList.contains("bg-sidebar")).toBe(true);
+    expect(strip?.children).toHaveLength(2);
+    expect(overflowButton?.classList.contains("absolute")).toBe(false);
+    expect(overflowButton?.classList.contains("w-5")).toBe(true);
+    expect(overflowButton?.classList.contains("opacity-100")).toBe(true);
+    expect(overflowButton?.tabIndex).toBe(0);
+    expect(overflowButton?.getAttribute("aria-label")).toBe(
+      "Scroll tabs right",
+    );
+    expect(overflowButton?.classList.contains("bg-sidebar")).toBe(true);
     expect(
-      rightButton?.classList.contains("hover:bg-surface-raised-solid"),
+      overflowButton?.classList.contains("hover:bg-surface-raised-solid"),
     ).toBe(true);
-    expect(rightButton?.classList.contains("hover:bg-state-hover")).toBe(false);
+    expect(overflowButton?.classList.contains("hover:bg-state-hover")).toBe(
+      false,
+    );
 
     const scrollBy = vi.fn();
     Object.defineProperty(viewport!, "scrollBy", {
       configurable: true,
       value: scrollBy,
     });
-    fireEvent.click(rightButton!);
+    fireEvent.click(overflowButton!);
     expect(scrollBy).toHaveBeenCalledWith({ left: 140, behavior: "smooth" });
 
-    rightButton?.focus();
-    expect(document.activeElement).toBe(rightButton);
+    overflowButton?.focus();
+    expect(document.activeElement).toBe(overflowButton);
     viewport!.scrollLeft = 120;
     fireEvent.scroll(viewport!);
     act(() => animationFrameCallback?.(0));
-    expect(rightButton?.getAttribute("aria-hidden")).toBe("true");
-    expect(leftButton?.getAttribute("aria-hidden")).toBe("false");
-    expect(document.activeElement).toBe(leftButton);
+    expect(overflowButton?.getAttribute("aria-hidden")).toBe("false");
+    expect(overflowButton?.getAttribute("aria-label")).toBe("Scroll tabs left");
+    expect(document.activeElement).toBe(overflowButton);
+    fireEvent.click(overflowButton!);
+    expect(scrollBy).toHaveBeenLastCalledWith({
+      left: -140,
+      behavior: "smooth",
+    });
 
     Object.defineProperty(content!, "scrollWidth", {
       configurable: true,
@@ -151,8 +154,8 @@ describe("secondary panel tab-strip edge fades", () => {
     act(() => {
       resizeCallback?.([], {} as ResizeObserver);
     });
-    expect(leftButton?.classList.contains("w-0")).toBe(true);
-    expect(rightButton?.classList.contains("w-0")).toBe(true);
+    expect(overflowButton?.classList.contains("w-0")).toBe(true);
+    expect(overflowButton?.getAttribute("aria-hidden")).toBe("true");
     expect(document.activeElement).toBe(
       container.querySelector('button[aria-pressed="true"]'),
     );

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
@@ -92,8 +92,8 @@ interface SortableFileTabProps {
  * The middle, horizontally-scrolling region of the secondary panel tab strip.
  *
  * Only the file tabs scroll; the leading Info/Diff controls and trailing
- * new-tab/panel controls stay anchored outside this component. Edge
- * fades and scroll buttons appear only on a side that has more tabs, and the
+ * new-tab/panel controls stay anchored outside this component. A single fixed
+ * overflow button sits beside Diff and points toward the remaining tabs. The
  * active tab is auto-scrolled into view on mount and whenever it changes
  * (covering pointer, keyboard, and programmatic selection).
  */
@@ -107,8 +107,7 @@ export function SecondaryPanelTabStrip({
   const viewportRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const activeTabRef = useRef<HTMLDivElement>(null);
-  const leftScrollButtonRef = useRef<HTMLButtonElement>(null);
-  const rightScrollButtonRef = useRef<HTMLButtonElement>(null);
+  const scrollButtonRef = useRef<HTMLButtonElement>(null);
   const [overflow, setOverflow] = useState<TabStripOverflowState>(
     INITIAL_OVERFLOW_STATE,
   );
@@ -251,32 +250,16 @@ export function SecondaryPanelTabStrip({
     activeTabElement.scrollIntoView({ inline: "nearest", block: "nearest" });
   }, [activeTabId, overflow.hasOverflow]);
 
-  // A scroll button can reach its edge while it has keyboard focus. Move focus
-  // before the button becomes an invisible, aria-hidden control.
+  // If overflow disappears while the fixed button has keyboard focus, return
+  // focus to the active tab before the button collapses out of the tab order.
   useLayoutEffect(() => {
     const focusedElement = document.activeElement;
     const activeTabButton =
       activeTabRef.current?.querySelector<HTMLButtonElement>("button") ?? null;
-    if (
-      !overflow.canScrollLeft &&
-      focusedElement === leftScrollButtonRef.current
-    ) {
-      (overflow.canScrollRight
-        ? rightScrollButtonRef.current
-        : activeTabButton
-      )?.focus();
-      return;
+    if (!overflow.hasOverflow && focusedElement === scrollButtonRef.current) {
+      activeTabButton?.focus();
     }
-    if (
-      !overflow.canScrollRight &&
-      focusedElement === rightScrollButtonRef.current
-    ) {
-      (overflow.canScrollLeft
-        ? leftScrollButtonRef.current
-        : activeTabButton
-      )?.focus();
-    }
-  }, [overflow.canScrollLeft, overflow.canScrollRight]);
+  }, [overflow.hasOverflow]);
 
   // A plain mouse wheel over the strip should move it sideways. React registers
   // its onWheel listener as passive, so a synthetic handler can't call
@@ -375,6 +358,7 @@ export function SecondaryPanelTabStrip({
   const chevronNoDragClass = usesDesktopChrome
     ? MACOS_APP_REGION_NO_DRAG_CLASS
     : null;
+  const scrollDirection = overflow.canScrollRight ? "right" : "left";
   // Memoize the sortable tab tree so the directional overflow flags — which
   // flip every time you reach a scroll edge, i.e. constantly at narrow widths —
   // re-render only the edge controls, never the tabs. Without this, each edge
@@ -434,21 +418,20 @@ export function SecondaryPanelTabStrip({
 
   return (
     // Hugs its tabs (no `flex-1`) and shrinks (`min-w-0`) when they overflow.
-    // The New Tab button follows this strip as an anchored sibling, while the
-    // in-flow scroll controls reserve their own space on either side of the tab
-    // viewport instead of covering its contents.
+    // The fixed overflow button is the strip's first child, immediately beside
+    // the preceding Diff control. The scrolling tabs and fades are confined to
+    // the following viewport, so the button never covers a label or icon.
     <div
       ref={stripRef}
       data-testid="secondary-panel-tab-strip"
       className="group relative flex min-w-0 items-center"
     >
       <TabStripScrollButton
-        buttonRef={leftScrollButtonRef}
-        direction="left"
+        buttonRef={scrollButtonRef}
+        direction={scrollDirection}
         hasOverflow={overflow.hasOverflow}
-        canScroll={overflow.canScrollLeft}
         className={chevronNoDragClass}
-        onClick={() => scrollByStep(-1)}
+        onClick={() => scrollByStep(scrollDirection === "left" ? -1 : 1)}
       />
       <div data-secondary-panel-tab-scroll-region className="relative min-w-0">
         {/* The fades are scoped to the tab viewport, so neither they nor the
@@ -488,14 +471,6 @@ export function SecondaryPanelTabStrip({
           </div>
         </div>
       </div>
-      <TabStripScrollButton
-        buttonRef={rightScrollButtonRef}
-        direction="right"
-        hasOverflow={overflow.hasOverflow}
-        canScroll={overflow.canScrollRight}
-        className={chevronNoDragClass}
-        onClick={() => scrollByStep(1)}
-      />
     </div>
   );
 }
@@ -552,7 +527,6 @@ interface TabStripScrollButtonProps {
   buttonRef: RefObject<HTMLButtonElement | null>;
   direction: "left" | "right";
   hasOverflow: boolean;
-  canScroll: boolean;
   className: string | null;
   onClick: () => void;
 }
@@ -561,7 +535,6 @@ function TabStripScrollButton({
   buttonRef,
   direction,
   hasOverflow,
-  canScroll,
   className,
   onClick,
 }: TabStripScrollButtonProps) {
@@ -572,9 +545,10 @@ function TabStripScrollButton({
       type="button"
       variant="ghost"
       size="sm"
-      tabIndex={canScroll ? 0 : -1}
-      aria-hidden={!canScroll}
+      tabIndex={hasOverflow ? 0 : -1}
+      aria-hidden={!hasOverflow}
       aria-label={label}
+      data-secondary-panel-tab-overflow-control
       onClick={onClick}
       className={cn(
         "z-20 shrink-0 bg-sidebar text-muted-foreground shadow-none hover:bg-surface-raised-solid hover:text-foreground focus-visible:bg-sidebar",
@@ -582,7 +556,7 @@ function TabStripScrollButton({
           ? TAB_STRIP_SCROLL_BUTTON_CLASS
           : "h-7 w-0 overflow-hidden p-0 max-md:pointer-coarse:h-9",
         "transition-opacity",
-        canScroll
+        hasOverflow
           ? "pointer-events-auto opacity-100"
           : "pointer-events-none opacity-0",
         className,

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
@@ -111,6 +111,9 @@ export function SecondaryPanelTabStrip({
   const [overflow, setOverflow] = useState<TabStripOverflowState>(
     INITIAL_OVERFLOW_STATE,
   );
+  const [scrollDirection, setScrollDirection] = useState<"left" | "right">(
+    "right",
+  );
   // Scroll capacity (max scrollLeft). Measured only on resize / tab-list change,
   // never per scroll: reading scrollWidth/clientWidth in a scroll handler forces
   // a synchronous reflow, which thrashes at narrow widths where every edge
@@ -151,6 +154,19 @@ export function SecondaryPanelTabStrip({
     const canScrollLeft = isScrollable && scrollLeft > EDGE_EPSILON_PX;
     const canScrollRight =
       isScrollable && scrollLeft < maxScrollLeft - EDGE_EPSILON_PX;
+    // A single caret must keep advancing in the same direction through long
+    // tab lists. Reverse only after it reaches that direction's hard edge;
+    // otherwise repeated clicks at an intermediate position would bounce back
+    // and forth over the same step.
+    setScrollDirection((previousDirection) => {
+      if (!isScrollable || !canScrollLeft) {
+        return "right";
+      }
+      if (!canScrollRight) {
+        return "left";
+      }
+      return previousDirection;
+    });
     // Return the existing state object when neither flag changed so React bails
     // out of re-rendering. With the tab tree memoized, a real change only
     // repaints the always-mounted edge fades/chevrons (an opacity toggle).
@@ -358,7 +374,6 @@ export function SecondaryPanelTabStrip({
   const chevronNoDragClass = usesDesktopChrome
     ? MACOS_APP_REGION_NO_DRAG_CLASS
     : null;
-  const scrollDirection = overflow.canScrollRight ? "right" : "left";
   // Memoize the sortable tab tree so the directional overflow flags — which
   // flip every time you reach a scroll edge, i.e. constantly at narrow widths —
   // re-render only the edge controls, never the tabs. Without this, each edge

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
@@ -65,12 +65,15 @@ interface TabStripOverflowState {
   canScrollLeft: boolean;
   /** More content remains to the right. */
   canScrollRight: boolean;
+  /** Direction retained until the caret reaches the opposite edge. */
+  scrollDirection: "left" | "right";
 }
 
 const INITIAL_OVERFLOW_STATE: TabStripOverflowState = {
   hasOverflow: false,
   canScrollLeft: false,
   canScrollRight: false,
+  scrollDirection: "right",
 };
 
 export interface SecondaryPanelTabStripProps {
@@ -110,9 +113,6 @@ export function SecondaryPanelTabStrip({
   const scrollButtonRef = useRef<HTMLButtonElement>(null);
   const [overflow, setOverflow] = useState<TabStripOverflowState>(
     INITIAL_OVERFLOW_STATE,
-  );
-  const [scrollDirection, setScrollDirection] = useState<"left" | "right">(
-    "right",
   );
   // Scroll capacity (max scrollLeft). Measured only on resize / tab-list change,
   // never per scroll: reading scrollWidth/clientWidth in a scroll handler forces
@@ -158,25 +158,28 @@ export function SecondaryPanelTabStrip({
     // tab lists. Reverse only after it reaches that direction's hard edge;
     // otherwise repeated clicks at an intermediate position would bounce back
     // and forth over the same step.
-    setScrollDirection((previousDirection) => {
-      if (!isScrollable || !canScrollLeft) {
-        return "right";
-      }
-      if (!canScrollRight) {
-        return "left";
-      }
-      return previousDirection;
-    });
-    // Return the existing state object when neither flag changed so React bails
-    // out of re-rendering. With the tab tree memoized, a real change only
-    // repaints the always-mounted edge fades/chevrons (an opacity toggle).
-    setOverflow((prev) =>
-      prev.hasOverflow === hasOverflow &&
-      prev.canScrollLeft === canScrollLeft &&
-      prev.canScrollRight === canScrollRight
+    // Return the existing state object when neither an edge flag nor the stable
+    // direction changed so React bails out of re-rendering. With the tab tree
+    // memoized, a real change only repaints the fixed overflow affordances.
+    setOverflow((prev) => {
+      const scrollDirection =
+        !isScrollable || !canScrollLeft
+          ? "right"
+          : !canScrollRight
+            ? "left"
+            : prev.scrollDirection;
+      return prev.hasOverflow === hasOverflow &&
+        prev.canScrollLeft === canScrollLeft &&
+        prev.canScrollRight === canScrollRight &&
+        prev.scrollDirection === scrollDirection
         ? prev
-        : { hasOverflow, canScrollLeft, canScrollRight },
-    );
+        : {
+            hasOverflow,
+            canScrollLeft,
+            canScrollRight,
+            scrollDirection,
+          };
+    });
   }, []);
 
   // Expensive (reads scrollWidth/clientWidth): run only on resize / tab change,
@@ -374,6 +377,7 @@ export function SecondaryPanelTabStrip({
   const chevronNoDragClass = usesDesktopChrome
     ? MACOS_APP_REGION_NO_DRAG_CLASS
     : null;
+  const { scrollDirection } = overflow;
   // Memoize the sortable tab tree so the directional overflow flags — which
   // flip every time you reach a scroll edge, i.e. constantly at narrow widths —
   // re-render only the edge controls, never the tabs. Without this, each edge


### PR DESCRIPTION
## Summary

- Keep the tab overflow caret in a fixed slot immediately beside Diff, outside the horizontal tab viewport.
- Reuse one persistent directional button while tabs overflow and collapse its slot completely when they fit.
- Preserve smooth step scrolling, wheel and trackpad behavior, active-tab visibility, dragging, selection, closing, and keyboard focus.

## Validation

- `pnpm exec turbo run test --filter=@bb/app -- --run src/components/secondary-panel/SecondaryPanelTabStrip.test.ts src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx src/components/secondary-panel/ThreadSecondaryPanel.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (0 errors; existing warning baseline only)
- Prettier and `git diff --check`
- Live Ladle verification at representative overflowing and fitting widths, including directional caret scrolling

> AGENT GENERATED: by GPT-5.6