### PR TITLE
Reduce the thread-open request waterfall

### DIFF
--- a/apps/app/src/components/secondary-panel/useThreadStorageViewer.test.tsx
+++ b/apps/app/src/components/secondary-panel/useThreadStorageViewer.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { sdk } from "@/lib/sdk";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import { useThreadStorageViewer } from "./useThreadStorageViewer";
+
+vi.mock("@/lib/sdk", () => ({
+  sdk: {
+    threads: {
+      storageFiles: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/hooks/useRealtimeSubscription", () => ({
+  useThreadDetailRealtimeSubscription: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useThreadStorageViewer", () => {
+  it("defers the storage listing until its panel is enabled", async () => {
+    vi.mocked(sdk.threads.storageFiles).mockResolvedValue({
+      files: [],
+      storageRootPath: "/tmp/thread-storage/thread-1",
+      truncated: false,
+    });
+    const { wrapper } = createQueryClientTestHarness();
+    const result = renderHook(
+      ({ fileListEnabled }: { fileListEnabled?: boolean }) =>
+        useThreadStorageViewer({
+          activePath: null,
+          ...(fileListEnabled !== undefined ? { fileListEnabled } : {}),
+          filePreviewEnabled: false,
+          threadId: "thread-1",
+        }),
+      { initialProps: {}, wrapper },
+    );
+
+    expect(sdk.threads.storageFiles).not.toHaveBeenCalled();
+
+    result.rerender({ fileListEnabled: true });
+    await waitFor(() => {
+      expect(sdk.threads.storageFiles).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/app/src/components/secondary-panel/useThreadStorageViewer.ts
+++ b/apps/app/src/components/secondary-panel/useThreadStorageViewer.ts
@@ -17,7 +17,7 @@ interface UseThreadStorageViewerParams {
 
 export function useThreadStorageViewer({
   activePath,
-  fileListEnabled = true,
+  fileListEnabled = false,
   fileListOptions = DEFAULT_THREAD_STORAGE_FILE_LIST_OPTIONS,
   filePreviewEnabled = true,
   threadId,

--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -861,9 +861,6 @@ function dirtyEnvironmentLiveWorkspaceStateQueries({
     queryKey: environmentWorkStatusQueryKeyPrefix(environmentId),
   });
   queryClient.invalidateQueries({
-    queryKey: environmentPullRequestQueryKey(environmentId),
-  });
-  queryClient.invalidateQueries({
     queryKey: environmentFilePreviewQueryKeyPrefix(environmentId),
   });
   queryClient.invalidateQueries({
@@ -886,6 +883,12 @@ function dirtyEnvironmentRefDerivedWorkspaceStateQueries({
   )) {
     queryClient.invalidateQueries({ queryKey });
   }
+  // A pull request follows the checked-out ref, not content-only worktree
+  // edits. Refresh it when refs move without paying for a PR lookup on every
+  // file-watcher event.
+  queryClient.invalidateQueries({
+    queryKey: environmentPullRequestQueryKey(environmentId),
+  });
   // A moved merge base affects every ref-derived diff target; evict the
   // observer-less patch cache so the panel re-requests fresh patches.
   removeEnvironmentDiffPatchQueries({ environmentId, queryClient });

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -733,7 +733,7 @@ describe("createRealtimeCacheEffects", () => {
     effects.dispose();
   });
 
-  it("refetches the active diff TOC and work-status queries but evicts the observer-less patch cache for work-status changes", async () => {
+  it("refreshes content-derived queries without rechecking pull requests for work-status changes", async () => {
     vi.useFakeTimers();
     const { effects, queryClient } = createRealtimeEffectsTestContext();
     const diffFilesKey = environmentDiffFilesQueryKey("env-1", "all", "main");
@@ -744,6 +744,7 @@ describe("createRealtimeCacheEffects", () => {
       "file.ts",
     );
     const workStatusKey = environmentWorkStatusQueryKey("env-1", "main");
+    const pullRequestKey = environmentPullRequestQueryKey("env-1");
     queryClient.setQueryData(diffFilesKey, {
       outcome: "available",
       files: [],
@@ -761,6 +762,7 @@ describe("createRealtimeCacheEffects", () => {
       truncated: false,
     });
     queryClient.setQueryData(workStatusKey, null);
+    queryClient.setQueryData(pullRequestKey, null);
     const diffFilesQueryFn = vi.fn(async () => ({
       outcome: "available" as const,
       files: [],
@@ -768,6 +770,7 @@ describe("createRealtimeCacheEffects", () => {
       mergeBaseRef: "base-ref",
     }));
     const workStatusQueryFn = vi.fn(async () => null);
+    const pullRequestQueryFn = vi.fn(async () => null);
     const diffFilesObserver = new QueryObserver(queryClient, {
       queryKey: diffFilesKey,
       queryFn: diffFilesQueryFn,
@@ -778,10 +781,17 @@ describe("createRealtimeCacheEffects", () => {
       queryFn: workStatusQueryFn,
       staleTime: Infinity,
     });
+    const pullRequestObserver = new QueryObserver(queryClient, {
+      queryKey: pullRequestKey,
+      queryFn: pullRequestQueryFn,
+      staleTime: Infinity,
+    });
     const unsubscribeDiffFiles = diffFilesObserver.subscribe(() => {});
     const unsubscribeWorkStatus = workStatusObserver.subscribe(() => {});
+    const unsubscribePullRequest = pullRequestObserver.subscribe(() => {});
     diffFilesQueryFn.mockClear();
     workStatusQueryFn.mockClear();
+    pullRequestQueryFn.mockClear();
 
     effects.handleChanged({
       type: "changed",
@@ -794,12 +804,42 @@ describe("createRealtimeCacheEffects", () => {
     // The observer-backed TOC and work-status queries refetch.
     expect(diffFilesQueryFn).toHaveBeenCalledTimes(1);
     expect(workStatusQueryFn).toHaveBeenCalledTimes(1);
+    expect(pullRequestQueryFn).not.toHaveBeenCalled();
     // The observer-less patch entry is evicted, not left stale — so the panel's
     // readDiffPatchEntry returns undefined and re-fetches a fresh patch.
     expect(queryClient.getQueryData(diffPatchKey)).toBeUndefined();
 
     unsubscribeDiffFiles();
     unsubscribeWorkStatus();
+    unsubscribePullRequest();
+    effects.dispose();
+  });
+
+  it("rechecks the active pull request when git refs change", async () => {
+    vi.useFakeTimers();
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const pullRequestKey = environmentPullRequestQueryKey("env-1");
+    queryClient.setQueryData(pullRequestKey, null);
+    const pullRequestQueryFn = vi.fn(async () => null);
+    const pullRequestObserver = new QueryObserver(queryClient, {
+      queryKey: pullRequestKey,
+      queryFn: pullRequestQueryFn,
+      staleTime: Infinity,
+    });
+    const unsubscribePullRequest = pullRequestObserver.subscribe(() => {});
+    pullRequestQueryFn.mockClear();
+
+    effects.handleChanged({
+      type: "changed",
+      entity: "environment",
+      id: "env-1",
+      changes: ["git-refs-changed"],
+    });
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(pullRequestQueryFn).toHaveBeenCalledTimes(1);
+
+    unsubscribePullRequest();
     effects.dispose();
   });
 

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -627,7 +627,10 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
   );
   const [browserAddressFocusRequest, setBrowserAddressFocusRequest] =
     useState<BrowserAddressFocusRequest | null>(null);
-  const shouldLoadThreadStorageFiles = thread !== undefined;
+  // Thread storage backs only the secondary file panel. Keep its directory
+  // walk off the thread-open path until that panel is actually visible.
+  const shouldLoadThreadStorageFiles =
+    thread !== undefined && isSecondaryPanelOpen;
   const {
     isThreadStorageFilesLoading,
     refetchThreadStorageFiles,

--- a/apps/host-daemon/src/app.ts
+++ b/apps/host-daemon/src/app.ts
@@ -23,6 +23,7 @@ import {
   type RuntimeManagerOptions,
 } from "./runtime-manager.js";
 import { WatchManager } from "./watch-manager.js";
+import { WorkspaceStatusCache } from "./workspace-status-cache.js";
 import { ConnectTunnelClient } from "./connect-tunnel/index.js";
 import {
   TerminalManager,
@@ -428,6 +429,7 @@ export async function createHostDaemonApp(
     },
   });
 
+  const workspaceStatusCache = new WorkspaceStatusCache();
   let sendServerMessage = (_message: HostDaemonDaemonWsMessage) => false;
   watchManager = new WatchManager({
     dataDir: options.dataDir,
@@ -435,6 +437,7 @@ export async function createHostDaemonApp(
     refreshWorkspace: (args) =>
       runtimeManager.refreshEnvironmentWorkspace(args),
     threadStorageRootPath,
+    workspaceStatusCache,
     onThreadStorageChanged: ({ environmentId }) => {
       sendServerMessage({
         type: "environment-change",
@@ -553,6 +556,7 @@ export async function createHostDaemonApp(
       );
     },
     onWorkspaceStatusChanged: ({ environmentId, changeKinds }) => {
+      workspaceStatusCache.invalidateEnvironment(environmentId);
       for (const change of changeKinds) {
         sendServerMessage({
           type: "environment-change",
@@ -757,6 +761,7 @@ export async function createHostDaemonApp(
     ensureConnectTunnelIdentity: () => connectTunnel.ensureTunnelIdentity(),
     caffeinateManager,
     threadStorageRootPath,
+    workspaceStatusCache,
     logger: options.logger,
     eventSink: {
       emit: (event) => eventSink.emit(event),

--- a/apps/host-daemon/src/command-dispatch-support.ts
+++ b/apps/host-daemon/src/command-dispatch-support.ts
@@ -23,6 +23,7 @@ import type { TerminalManager } from "./terminals/terminal-manager.js";
 import type { FetchProjectAttachment } from "./project-attachments.js";
 import type { FetchSkillTree } from "./skill-trees.js";
 import type { CaffeinateManager } from "./command-handlers/caffeinate.js";
+import type { WorkspaceStatusCacheAccess } from "./workspace-status-cache.js";
 
 type DispatchCommand = HostDaemonCommand | HostDaemonOnlineRpcCommand;
 
@@ -68,6 +69,7 @@ export interface CommandDispatchOptions {
   caffeinateManager?: CaffeinateManager;
   ensureConnectTunnelIdentity?: () => Promise<HostDaemonConnectTunnelIdentity>;
   threadStorageRootPath: string;
+  workspaceStatusCache?: WorkspaceStatusCacheAccess;
 }
 
 export class CommandDispatchError extends Error {

--- a/apps/host-daemon/src/command-dispatch.test.ts
+++ b/apps/host-daemon/src/command-dispatch.test.ts
@@ -8,6 +8,7 @@ import type {
   ProviderCliStatus,
 } from "@bb/host-daemon-contract";
 import type { HostWorkspace } from "@bb/host-workspace";
+import { makeWorkspaceStatus } from "@bb/test-helpers";
 import { afterEach, describe, expect, it, vi, type Mock } from "vitest";
 import {
   dispatchCommand,
@@ -15,6 +16,7 @@ import {
 } from "./command-dispatch.js";
 import type { CommandOf } from "./command-dispatch-support.js";
 import { RuntimeManager } from "./runtime-manager.js";
+import { WorkspaceStatusCache } from "./workspace-status-cache.js";
 
 const WORKSPACE_PATH = "/tmp/bb-command-dispatch-test";
 
@@ -319,6 +321,78 @@ async function runSuccessfulClaudeCodeUpdateVerification(args: {
 }
 
 describe("dispatchCommand", () => {
+  it("invalidates cached status before acknowledging a workspace commit", async () => {
+    const runtime = createRuntime();
+    const getStatus = vi.fn(async () => makeWorkspaceStatus());
+    const commit = vi.fn(async () => ({
+      commitSha: "commit-2",
+      commitSubject: "commit",
+    }));
+    const workspace: HostWorkspace = {
+      ...createWorkspace(),
+      managed: true,
+      isGitRepo: true,
+      isWorktree: true,
+      getStatus,
+      commit,
+    };
+    const manager = new RuntimeManager({
+      createRuntime: () => runtime,
+      provisionWorkspace: async () => workspace,
+    });
+    await manager.ensureEnvironment({
+      environmentId: "env-1",
+      workspacePath: WORKSPACE_PATH,
+    });
+    const workspaceStatusCache = new WorkspaceStatusCache();
+    const dispatchOptions = {
+      dataDir: "/tmp/bb-data",
+      eventSink: {
+        emit: vi.fn(),
+        flush: vi.fn(async () => undefined),
+      },
+      fetchProjectAttachment: async () => {
+        throw new Error("Unexpected project attachment fetch");
+      },
+      runtimeManager: manager,
+      threadStorageRootPath: "/tmp/bb-thread-storage",
+      workspaceStatusCache,
+    };
+    const workspaceContext = {
+      workspacePath: WORKSPACE_PATH,
+      workspaceProvisionType: "managed-worktree" as const,
+    };
+
+    await dispatchOnlineRpcCommand(
+      {
+        type: "workspace.status",
+        environmentId: "env-1",
+        workspaceContext,
+      },
+      dispatchOptions,
+    );
+    await dispatchCommand(
+      {
+        type: "workspace.commit",
+        environmentId: "env-1",
+        message: "commit",
+        workspaceContext,
+      },
+      dispatchOptions,
+    );
+    await dispatchOnlineRpcCommand(
+      {
+        type: "workspace.status",
+        environmentId: "env-1",
+        workspaceContext,
+      },
+      dispatchOptions,
+    );
+
+    expect(commit).toHaveBeenCalledOnce();
+    expect(getStatus).toHaveBeenCalledTimes(2);
+  });
+
   it("flushes buffered events before reporting thread.stop success", async () => {
     const runtime = createRuntime();
     const manager = new RuntimeManager({

--- a/apps/host-daemon/src/command-dispatch.ts
+++ b/apps/host-daemon/src/command-dispatch.ts
@@ -525,6 +525,9 @@ const commandHandlers: CommandHandlerMap = {
     if (!resolution.ok) {
       // Treat already-missing workspaces as successful destroy (idempotent retry).
       if (resolution.failure.code === "path_not_found") {
+        options.workspaceStatusCache?.invalidateEnvironment(
+          command.environmentId,
+        );
         return {};
       }
       throw new ExpectedCommandDispatchError(
@@ -537,6 +540,7 @@ const commandHandlers: CommandHandlerMap = {
       reason: "environment-destroyed",
     });
     await options.runtimeManager.destroyEnvironment(command.environmentId);
+    options.workspaceStatusCache?.invalidateEnvironment(command.environmentId);
     return {};
   },
   "workspace.commit": async (command, options) => {
@@ -548,12 +552,20 @@ const commandHandlers: CommandHandlerMap = {
       runtimeManager: options.runtimeManager,
       workspaceContext: command.workspaceContext,
     });
-    return entry.workspace.commit({
+    const result = await entry.workspace.commit({
       message: command.message,
       noVerify: true,
     });
+    // Watcher delivery is asynchronous. Invalidate before acknowledging this
+    // mutation so an immediate status read cannot observe the pre-commit cache.
+    options.workspaceStatusCache?.invalidateEnvironment(command.environmentId);
+    return result;
   },
-  "workspace.squash_merge": squashMerge,
+  "workspace.squash_merge": async (command, options) => {
+    const result = await squashMerge(command, options);
+    options.workspaceStatusCache?.invalidateEnvironment(command.environmentId);
+    return result;
+  },
   "workspace.pull_request_action": async (command, options) => {
     const entry = await requireResolvedWorkspaceForCommand({
       dataDir: options.dataDir,
@@ -594,9 +606,22 @@ const onlineRpcHandlers: OnlineRpcHandlerMap = {
   },
   "host.list_files": listHostFiles,
   "host.list_paths": listHostPaths,
-  "host.mkdir": mkdirHostPath,
-  "host.move_path": moveHostPath,
-  "host.remove_path": removeHostPath,
+  "host.mkdir": async (command, options) => {
+    const result = await mkdirHostPath(command);
+    options.workspaceStatusCache?.invalidatePath(command.path);
+    return result;
+  },
+  "host.move_path": async (command, options) => {
+    const result = await moveHostPath(command);
+    options.workspaceStatusCache?.invalidatePath(command.sourcePath);
+    options.workspaceStatusCache?.invalidatePath(command.destinationPath);
+    return result;
+  },
+  "host.remove_path": async (command, options) => {
+    const result = await removeHostPath(command);
+    options.workspaceStatusCache?.invalidatePath(command.path);
+    return result;
+  },
   "host.browse_directory": browseHostDirectory,
   "host.paths_exist": checkHostPathsExist,
   "project.inspect": async (command) => inspectProjectPath(command.path),
@@ -617,7 +642,13 @@ const onlineRpcHandlers: OnlineRpcHandlerMap = {
   "host.file_metadata": readHostFileMetadata,
   "host.read_file": readHostFile,
   "host.read_file_relative": readHostRelativeFile,
-  "host.write_file": writeHostFile,
+  "host.write_file": async (command, options) => {
+    const result = await writeHostFile(command);
+    if (result.outcome === "written") {
+      options.workspaceStatusCache?.invalidatePath(command.path);
+    }
+    return result;
+  },
   "provider.list_models": async (command, options) =>
     (options.listModels ?? defaultListModels)({
       providerId: command.providerId,
@@ -642,33 +673,48 @@ const onlineRpcHandlers: OnlineRpcHandlerMap = {
       env: options.runtimeManager.getShellEnv(),
     }),
   "workspace.status": async (command, options) => {
-    const resolution = await resolveWorkspaceForCommand({
-      dataDir: options.dataDir,
+    const load = async (): Promise<
+      HostDaemonOnlineRpcResult<"workspace.status">
+    > => {
+      const resolution = await resolveWorkspaceForCommand({
+        dataDir: options.dataDir,
+        environmentId: command.environmentId,
+        requireGit: true,
+        requireManagedWorktree: true,
+        runtimeManager: options.runtimeManager,
+        workspaceContext: command.workspaceContext,
+      });
+      if (!resolution.ok) {
+        return { outcome: "unavailable", failure: resolution.failure };
+      }
+      try {
+        return {
+          outcome: "available",
+          workspaceStatus: await resolution.entry.workspace.getStatus({
+            mergeBaseBranch: command.mergeBaseBranch,
+          }),
+        };
+      } catch (error) {
+        return {
+          outcome: "unavailable",
+          failure: workspaceResolutionFailureFromError({
+            error,
+            workspacePath: command.workspaceContext.workspacePath,
+          }),
+        };
+      }
+    };
+    if (!options.workspaceStatusCache) {
+      return load();
+    }
+    return options.workspaceStatusCache.getOrLoad({
       environmentId: command.environmentId,
-      requireGit: true,
-      requireManagedWorktree: true,
-      runtimeManager: options.runtimeManager,
+      load,
+      ...(command.mergeBaseBranch !== undefined
+        ? { mergeBaseBranch: command.mergeBaseBranch }
+        : {}),
       workspaceContext: command.workspaceContext,
     });
-    if (!resolution.ok) {
-      return { outcome: "unavailable", failure: resolution.failure };
-    }
-    try {
-      return {
-        outcome: "available",
-        workspaceStatus: await resolution.entry.workspace.getStatus({
-          mergeBaseBranch: command.mergeBaseBranch,
-        }),
-      };
-    } catch (error) {
-      return {
-        outcome: "unavailable",
-        failure: workspaceResolutionFailureFromError({
-          error,
-          workspacePath: command.workspaceContext.workspacePath,
-        }),
-      };
-    }
   },
   "workspace.diff": async (command, options) => {
     const resolution = await resolveWorkspaceForCommand({

--- a/apps/host-daemon/src/command-router.ts
+++ b/apps/host-daemon/src/command-router.ts
@@ -113,6 +113,7 @@ export interface CommandRouterOptions {
   caffeinateManager?: CommandDispatchOptions["caffeinateManager"];
   ensureConnectTunnelIdentity?: CommandDispatchOptions["ensureConnectTunnelIdentity"];
   threadStorageRootPath: string;
+  workspaceStatusCache?: CommandDispatchOptions["workspaceStatusCache"];
   logger: CommandRouterLogger;
 }
 
@@ -326,6 +327,9 @@ export class CommandRouter {
       caffeinateManager: this.options.caffeinateManager,
       ensureConnectTunnelIdentity: this.options.ensureConnectTunnelIdentity,
       threadStorageRootPath: this.options.threadStorageRootPath,
+      ...(this.options.workspaceStatusCache
+        ? { workspaceStatusCache: this.options.workspaceStatusCache }
+        : {}),
     };
   }
 

--- a/apps/host-daemon/src/watch-manager.test.ts
+++ b/apps/host-daemon/src/watch-manager.test.ts
@@ -8,6 +8,7 @@ import type { HostWorkspace } from "@bb/host-workspace";
 import { makeWorkspaceMergeBase, makeWorkspaceStatus } from "@bb/test-helpers";
 import { describe, expect, it, vi } from "vitest";
 import { WatchManager, type WatchManagerOptions } from "./watch-manager.js";
+import { WorkspaceStatusCache } from "./workspace-status-cache.js";
 
 type GetLocalStateFingerprintResult = Awaited<
   ReturnType<HostWorkspace["getLocalStateFingerprint"]>
@@ -147,6 +148,62 @@ function createFakeHostWatcher(
 }
 
 describe("WatchManager", () => {
+  it("invalidates cached workspace status when the worktree changes", async () => {
+    let watchWorkspaceArgs: WatchWorkspaceArgs | undefined;
+    const workspace = createFakeWorkspace("/tmp/env-watch");
+    const { hostWatcher } = createFakeHostWatcher({
+      watchWorkspaceImplementation: (args) => {
+        watchWorkspaceArgs = args;
+        return () => undefined;
+      },
+    });
+    const cache = new WorkspaceStatusCache();
+    const load = vi.fn(async () => ({
+      outcome: "available" as const,
+      workspaceStatus: makeWorkspaceStatus(),
+    }));
+    const cacheArgs = {
+      environmentId: "env-watch",
+      load,
+      workspaceContext: {
+        workspacePath: "/tmp/env-watch",
+        workspaceProvisionType: "unmanaged" as const,
+      },
+    };
+    const onWorkspaceStatusChanged = vi.fn();
+    const manager = new WatchManager({
+      hostWatcher,
+      provisionWorkspace: vi.fn(async () => workspace),
+      onWorkspaceStatusChanged,
+      workspaceStatusCache: cache,
+    });
+
+    await cache.getOrLoad(cacheArgs);
+    await manager.replaceWatchSet({
+      generation: 1,
+      workspaceTargets: [
+        {
+          environmentId: "env-watch",
+          workspaceContext: cacheArgs.workspaceContext,
+        },
+      ],
+      threadStorageTargets: [],
+    });
+    watchWorkspaceArgs?.onChange({
+      changedPaths: ["/tmp/env-watch/README.md"],
+      changeKinds: ["workspace-content-changed"],
+      kind: "workspace-status-changed",
+      environmentId: "env-watch",
+    });
+    expect(onWorkspaceStatusChanged).toHaveBeenCalledWith({
+      changeKinds: ["work-status-changed"],
+      environmentId: "env-watch",
+    });
+    await cache.getOrLoad(cacheArgs);
+
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
   it("starts watching before initial workspace fingerprints finish", async () => {
     const workspace = createFakeWorkspace("/tmp/env-watch");
     const localFingerprint = createDeferred<GetLocalStateFingerprintResult>();

--- a/apps/host-daemon/src/watch-manager.ts
+++ b/apps/host-daemon/src/watch-manager.ts
@@ -18,6 +18,7 @@ import type {
   WorkspaceWatchError,
 } from "@bb/host-watcher";
 import { reconnectProvisionArgsFromWorkspaceContext } from "./workspace-provision-target.js";
+import type { WorkspaceStatusCacheAccess } from "./workspace-status-cache.js";
 
 type StopWatching = () => void | Promise<void>;
 
@@ -73,6 +74,10 @@ export interface WatchManagerOptions {
     workspace: DiscoveredWorkspaceProperties;
   }) => void;
   onWorkspaceStatusWatchError?: (args: { error: WorkspaceWatchError }) => void;
+  workspaceStatusCache?: Pick<
+    WorkspaceStatusCacheAccess,
+    "invalidateEnvironment"
+  >;
 }
 
 function toErrorMessage(error: Error): string {
@@ -333,7 +338,7 @@ export class WatchManager {
       // The filesystem event itself is sufficient evidence that live content
       // is stale. Notify before any Git fingerprint work: large diffs can make
       // status/numstat slow or fail, but previews must still refresh.
-      this.options.onWorkspaceStatusChanged?.({
+      this.notifyWorkspaceStatusChanged({
         changeKinds: ["work-status-changed"],
         environmentId: args.entry.target.environmentId,
       });
@@ -408,13 +413,23 @@ export class WatchManager {
       if (changeKinds.length === 0) {
         return;
       }
-      this.options.onWorkspaceStatusChanged?.({
+      this.notifyWorkspaceStatusChanged({
         changeKinds,
         environmentId: args.entry.target.environmentId,
       });
     } catch (error) {
       this.reportWorkspaceWatchError(args.entry, error);
     }
+  }
+
+  private notifyWorkspaceStatusChanged(args: {
+    changeKinds: HostDaemonEnvironmentChange[];
+    environmentId: string;
+  }): void {
+    this.options.workspaceStatusCache?.invalidateEnvironment(
+      args.environmentId,
+    );
+    this.options.onWorkspaceStatusChanged?.(args);
   }
 
   private reportWorkspaceWatchError(

--- a/apps/host-daemon/src/workspace-status-cache.test.ts
+++ b/apps/host-daemon/src/workspace-status-cache.test.ts
@@ -1,0 +1,104 @@
+import type { HostDaemonOnlineRpcResult } from "@bb/host-daemon-contract";
+import { makeWorkspaceStatus } from "@bb/test-helpers";
+import { describe, expect, it, vi } from "vitest";
+import { WorkspaceStatusCache } from "./workspace-status-cache.js";
+
+const WORKSPACE_CONTEXT = {
+  workspacePath: "/tmp/env-1",
+  workspaceProvisionType: "managed-worktree",
+} as const;
+
+function availableStatus(): HostDaemonOnlineRpcResult<"workspace.status"> {
+  return {
+    outcome: "available",
+    workspaceStatus: makeWorkspaceStatus(),
+  };
+}
+
+describe("WorkspaceStatusCache", () => {
+  it("coalesces concurrent reads and reuses the result within the TTL", async () => {
+    let now = 1_000;
+    const cache = new WorkspaceStatusCache({ nowMs: () => now, ttlMs: 5_000 });
+    const load = vi.fn(async () => availableStatus());
+    const args = {
+      environmentId: "env-1",
+      load,
+      mergeBaseBranch: "main",
+      workspaceContext: WORKSPACE_CONTEXT,
+    };
+
+    const [first, second] = await Promise.all([
+      cache.getOrLoad(args),
+      cache.getOrLoad(args),
+    ]);
+    now += 4_999;
+    const third = await cache.getOrLoad(args);
+
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(first).toEqual(second);
+    expect(third).toEqual(first);
+
+    now += 2;
+    await cache.getOrLoad(args);
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops an environment result immediately when invalidated", async () => {
+    const cache = new WorkspaceStatusCache();
+    const load = vi.fn(async () => availableStatus());
+    const args = {
+      environmentId: "env-1",
+      load,
+      workspaceContext: WORKSPACE_CONTEXT,
+    };
+
+    await cache.getOrLoad(args);
+    cache.invalidateEnvironment("env-1");
+    await cache.getOrLoad(args);
+
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops matching workspace results when a nested path changes", async () => {
+    const cache = new WorkspaceStatusCache();
+    const load = vi.fn(async () => availableStatus());
+    const args = {
+      environmentId: "env-1",
+      load,
+      workspaceContext: WORKSPACE_CONTEXT,
+    };
+
+    await cache.getOrLoad(args);
+    cache.invalidatePath("/tmp/env-1/src/file.ts");
+    await cache.getOrLoad(args);
+
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not restore an in-flight result after invalidation", async () => {
+    let resolveLoad!: (value: ReturnType<typeof availableStatus>) => void;
+    const firstLoad = new Promise<ReturnType<typeof availableStatus>>(
+      (resolve) => {
+        resolveLoad = resolve;
+      },
+    );
+    const cache = new WorkspaceStatusCache();
+    const load = vi
+      .fn<() => Promise<ReturnType<typeof availableStatus>>>()
+      .mockReturnValueOnce(firstLoad)
+      .mockResolvedValue(availableStatus());
+    const args = {
+      environmentId: "env-1",
+      load,
+      workspaceContext: WORKSPACE_CONTEXT,
+    };
+
+    const staleRead = cache.getOrLoad(args);
+    cache.invalidateEnvironment("env-1");
+    resolveLoad(availableStatus());
+    await staleRead;
+    await cache.getOrLoad(args);
+
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/host-daemon/src/workspace-status-cache.ts
+++ b/apps/host-daemon/src/workspace-status-cache.ts
@@ -1,0 +1,163 @@
+import path from "node:path";
+import type {
+  HostDaemonOnlineRpcResult,
+  WorkspaceContext,
+} from "@bb/host-daemon-contract";
+
+const DEFAULT_WORKSPACE_STATUS_CACHE_TTL_MS = 5_000;
+const DEFAULT_WORKSPACE_STATUS_CACHE_MAX_ENTRIES = 128;
+
+type WorkspaceStatusResult = HostDaemonOnlineRpcResult<"workspace.status">;
+
+interface WorkspaceStatusCacheEntry {
+  environmentId: string;
+  expiresAtMs: number | null;
+  promise: Promise<WorkspaceStatusResult>;
+  workspacePath: string;
+}
+
+export interface WorkspaceStatusCacheLoadArgs {
+  environmentId: string;
+  load: () => Promise<WorkspaceStatusResult>;
+  mergeBaseBranch?: string;
+  workspaceContext: WorkspaceContext;
+}
+
+export interface WorkspaceStatusCacheAccess {
+  getOrLoad(args: WorkspaceStatusCacheLoadArgs): Promise<WorkspaceStatusResult>;
+  invalidateEnvironment(environmentId: string): void;
+  invalidatePath(changedPath: string): void;
+}
+
+interface WorkspaceStatusCacheOptions {
+  maxEntries?: number;
+  nowMs?: () => number;
+  ttlMs?: number;
+}
+
+function buildWorkspaceStatusCacheKey({
+  environmentId,
+  mergeBaseBranch,
+  workspaceContext,
+}: Omit<WorkspaceStatusCacheLoadArgs, "load">): string {
+  return JSON.stringify([
+    environmentId,
+    workspaceContext.workspacePath,
+    workspaceContext.workspaceProvisionType,
+    mergeBaseBranch ?? null,
+  ]);
+}
+
+function pathsOverlap(firstPath: string, secondPath: string): boolean {
+  const firstRelativeToSecond = path.relative(secondPath, firstPath);
+  const secondRelativeToFirst = path.relative(firstPath, secondPath);
+  return (
+    firstRelativeToSecond === "" ||
+    (!firstRelativeToSecond.startsWith("..") &&
+      !path.isAbsolute(firstRelativeToSecond)) ||
+    (!secondRelativeToFirst.startsWith("..") &&
+      !path.isAbsolute(secondRelativeToFirst))
+  );
+}
+
+export class WorkspaceStatusCache implements WorkspaceStatusCacheAccess {
+  private readonly entries = new Map<string, WorkspaceStatusCacheEntry>();
+  private readonly maxEntries: number;
+  private readonly nowMs: () => number;
+  private readonly ttlMs: number;
+
+  constructor(options: WorkspaceStatusCacheOptions = {}) {
+    this.maxEntries =
+      options.maxEntries ?? DEFAULT_WORKSPACE_STATUS_CACHE_MAX_ENTRIES;
+    this.nowMs = options.nowMs ?? Date.now;
+    this.ttlMs = options.ttlMs ?? DEFAULT_WORKSPACE_STATUS_CACHE_TTL_MS;
+  }
+
+  getOrLoad({
+    environmentId,
+    load,
+    mergeBaseBranch,
+    workspaceContext,
+  }: WorkspaceStatusCacheLoadArgs): Promise<WorkspaceStatusResult> {
+    const key = buildWorkspaceStatusCacheKey({
+      environmentId,
+      ...(mergeBaseBranch !== undefined ? { mergeBaseBranch } : {}),
+      workspaceContext,
+    });
+    const now = this.nowMs();
+    const existing = this.entries.get(key);
+    if (
+      existing &&
+      (existing.expiresAtMs === null || existing.expiresAtMs > now)
+    ) {
+      return existing.promise;
+    }
+    if (existing) {
+      this.entries.delete(key);
+    }
+
+    this.pruneExpiredEntries(now);
+    const loadPromise = load();
+    const promise = loadPromise.then(
+      (result) => {
+        // Identity-check the entry so invalidation during an in-flight git
+        // probe cannot let that stale result repopulate the cache.
+        if (this.entries.get(key) === entry && result.outcome === "available") {
+          entry.expiresAtMs = this.nowMs() + this.ttlMs;
+        } else if (this.entries.get(key) === entry) {
+          this.entries.delete(key);
+        }
+        return result;
+      },
+      (error: unknown) => {
+        if (this.entries.get(key) === entry) {
+          this.entries.delete(key);
+        }
+        throw error;
+      },
+    );
+    const entry: WorkspaceStatusCacheEntry = {
+      environmentId,
+      expiresAtMs: null,
+      promise,
+      workspacePath: workspaceContext.workspacePath,
+    };
+    this.entries.set(key, entry);
+    this.pruneOverflowEntries();
+    return promise;
+  }
+
+  invalidateEnvironment(environmentId: string): void {
+    for (const [key, entry] of this.entries) {
+      if (entry.environmentId === environmentId) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  invalidatePath(changedPath: string): void {
+    for (const [key, entry] of this.entries) {
+      if (pathsOverlap(changedPath, entry.workspacePath)) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  private pruneExpiredEntries(now: number): void {
+    for (const [key, entry] of this.entries) {
+      if (entry.expiresAtMs !== null && entry.expiresAtMs <= now) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  private pruneOverflowEntries(): void {
+    while (this.entries.size > this.maxEntries) {
+      const oldestKey = this.entries.keys().next().value;
+      if (oldestKey === undefined) {
+        return;
+      }
+      this.entries.delete(oldestKey);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- keep thread-open data in its existing granular query/cache owners; this revision does **not** add an aggregate bootstrap endpoint or a shared readiness gate
- defer the thread-storage directory listing until the secondary panel is visible
- cache successful `workspace.status` results in the host daemon for 5 seconds and coalesce concurrent reads
- invalidate that cache synchronously after daemon-owned workspace mutations, from real watcher/runtime events, and by affected path; invalidation also prevents an in-flight stale result from repopulating the cache
- stop content-only worktree events from triggering pull-request lookups; PR state still refreshes when git refs move

## Why there is no new bootstrap

The history has two different "bootstrap" paths:

1. The current thread-detail bootstrap ([`d136d0a60`](https://github.com/get-bb/bb/commit/d136d0a60f660361d5ccbec157292e4a711ba3eb)) is still present. It is the narrow `GET thread?include=environment,host` read, and #909/#915 already made it start in parallel with the timeline.
2. The old `composer-bootstrap` aggregated default execution options, queued messages, prompt history, and pending interactions. [#335](https://github.com/get-bb/bb/pull/335) deliberately removed the app's dependency on it because the aggregate had become a readiness gate for resources with independent cache ownership and invalidation rules.

The first version of this PR recreated the second pattern and hydrated the granular caches from one response. Even though its payload was small, it could overwrite a newer realtime-owned value when the aggregate response arrived late. It also made the patch much larger through a new route, public contracts, SDK declarations, and a readiness context.

This revision removes all of that. It avoids both #1302 failure modes by having no new aggregate payload and no aggregate invalidation/refetch lifecycle at all.

## Measurements

Measured against the existing `pnpm seed:perf` database: 1,200 threads, 402,298 events, 22,939 search segments, 10,344 prompt-history rows, and a 500 MB `bb.db`. The A/B used the same database and same thread pairs, fresh 390x844 Chromium profiles, and a daemon restart on current `main` and this commit. Counts include `/api/v1/` resource timings; "completed" excludes canceled entries (`transferSize === 0`). Settle runs from the first request start to the last completed response.

| Profile | `main` | This PR | Delta |
| --- | --- | --- | --- |
| warm local SPA switch | 20 raw / 18 completed / 13 distinct, 1,903.3 ms settle | 17 raw / 15 completed / 12 distinct, 864.8 ms settle | 17% fewer completed requests; 8% fewer distinct |
| switch with 529 ms network latency | 18 raw / 14 completed / 13 distinct, 1,735.8 ms settle | 16 raw / 12 completed / 12 distinct, 1,617.6 ms settle | 14% fewer completed requests; 6.8% shorter settle |

The warm settle improvement is not all attributable to this patch: provider execution-option discovery varied from 1,824.9 ms on `main` to 782.4 ms here. That endpoint is still the tail, which confirms the issue's git probes are important but not always dominant. The request-count comparison is the reviewable result: the storage request is always absent until its panel opens, while watcher timing determines whether the status/PR repeat is also present. In the warm A/B, `main` issued status twice (107.9/55.8 ms) and PR twice (128.1/87.5 ms); this PR issued each once.

For the daemon cache itself, a status read after TTL expiry took 70.7 ms and the immediate repeated read took 2.6 ms (96% faster). Only `available` results are cached.

The responsiveness sampler uses lateness of a recurring 250 ms timer, not the Long Tasks API that WebKit does not expose. Across 20 samples in the 529 ms profile, maximum observed lateness was 1.8 ms on `main` and 57.2 ms on this run; neither result is reported as a `longtask`-derived zero.

## First-paint decisions

- Environment status and pull-request state stay eager because the composer context banner renders checkout, changed-file, and PR state on open.
- Thread tabs stay eager because persisted tabs can determine the visible secondary surface.
- Thread storage listing is deferred because no first-paint surface consumes its file list while the secondary panel is closed.

## Cache correctness and protocol compatibility

Watcher invalidation alone is eventual. The previous head's red integration job exposed that race: `workspace.commit` could return, then an immediate `workspace.status` could read the pre-commit cache before the watcher fired. This revision invalidates synchronously before successful mutation commands return, while retaining watcher invalidation for provider/external edits. `fake/smoke/environment-actions.test.ts`, which failed on the previous head, now passes all 6 tests.

No server/host-daemon command, result, session, or WebSocket payload changed. This is daemon-internal memoization of the existing result, so `HOST_DAEMON_PROTOCOL_VERSION` remains unchanged.

## Patch size

The original PR was 38 files and +1,523/-129, including 577 generated lines. The reworked PR is 14 files and +606/-38: +278/-37 production and +328/-1 regression tests. There is no server route, public contract, SDK, template, or generated declaration churn.

## Validation

All slow commands ran through Turbo with output captured to files before inspection.

- `@bb/app`: 341 files, 2,644 tests passed
- `@bb/host-daemon`: 47 files, 551 tests passed
- targeted integration regression: 6/6 passed
- Turbo typechecks passed for `@bb/app` and `@bb/host-daemon`
- `@bb/app` lint passed with 0 errors (149 existing warnings)
- focused cache/storage/realtime suites: 90/90 passed

Tests pin lazy storage loading, PR invalidation only for ref changes, cache TTL/coalescing, environment/path/watcher invalidation, stale in-flight invalidation, and immediate post-commit freshness.

Fixes #1303

> AGENT GENERATED: by GPT-5.6 Sol
