### PR TITLE
Cancel the live ACP prompt when a turn is steered

### DIFF
--- a/packages/agent-runtime/src/acp/bridge/bridge.test.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.test.ts
@@ -1590,8 +1590,34 @@ describe("acp bridge", () => {
     }
   });
 
-  it("chains steer input onto the active turn", async () => {
-    const { providerThreadId } = await startThread();
+  it("cancels a hung prompt and continues the same turn with steer input", async () => {
+    const { bbThreadId, providerThreadId } = await startThread();
+    const turnId = sendRequest("turn/start", {
+      threadId: providerThreadId,
+      input: [{ type: "text", text: "hang", mentions: [] }],
+    });
+    await waitForResponse(turnId);
+
+    const steerId = sendRequest("turn/steer", {
+      threadId: providerThreadId,
+      expectedTurnId: "turn-1",
+      input: [{ type: "text", text: "steered", mentions: [] }],
+    });
+    await waitForResponse(steerId);
+
+    const completed = await waitForTurnCompleted();
+    expect(completed.params).toEqual({
+      threadId: bbThreadId,
+      stopReason: "end_turn",
+    });
+    expect(agentMessageTexts()).toContain("echo:steered");
+    expect(agentMessageTexts()).not.toContain("echo:hang");
+    expect(notifications("acp/turn/started")).toHaveLength(1);
+    expect(notifications("acp/turn/completed")).toHaveLength(1);
+  });
+
+  it("keeps partial output from the cancelled prompt then continues", async () => {
+    const { bbThreadId, providerThreadId } = await startThread();
     const turnId = sendRequest("turn/start", {
       threadId: providerThreadId,
       input: [{ type: "text", text: "slow first", mentions: [] }],
@@ -1610,9 +1636,45 @@ describe("acp bridge", () => {
     });
     await waitForResponse(steerId);
 
-    await waitForTurnCompleted();
+    const completed = await waitForTurnCompleted();
+    expect(completed.params).toEqual({
+      threadId: bbThreadId,
+      stopReason: "end_turn",
+    });
+    expect(agentMessageTexts()).toContain("echo:slow first");
     expect(agentMessageTexts()).toContain("echo:steered");
-    // One bb turn spans both prompts.
+    expect(notifications("acp/turn/started")).toHaveLength(1);
+    expect(notifications("acp/turn/completed")).toHaveLength(1);
+  });
+
+  it("cancels once and delivers stacked steers on the same turn", async () => {
+    const { bbThreadId, providerThreadId } = await startThread();
+    const turnId = sendRequest("turn/start", {
+      threadId: providerThreadId,
+      input: [{ type: "text", text: "hang", mentions: [] }],
+    });
+    await waitForResponse(turnId);
+
+    const firstSteerId = sendRequest("turn/steer", {
+      threadId: providerThreadId,
+      expectedTurnId: "turn-1",
+      input: [{ type: "text", text: "first-steer", mentions: [] }],
+    });
+    const secondSteerId = sendRequest("turn/steer", {
+      threadId: providerThreadId,
+      expectedTurnId: "turn-1",
+      input: [{ type: "text", text: "second-steer", mentions: [] }],
+    });
+    await waitForResponse(firstSteerId);
+    await waitForResponse(secondSteerId);
+
+    const completed = await waitForTurnCompleted();
+    expect(completed.params).toEqual({
+      threadId: bbThreadId,
+      stopReason: "end_turn",
+    });
+    expect(agentMessageTexts()).toContain("echo:first-steer");
+    expect(agentMessageTexts()).toContain("echo:second-steer");
     expect(notifications("acp/turn/started")).toHaveLength(1);
     expect(notifications("acp/turn/completed")).toHaveLength(1);
   });

--- a/packages/agent-runtime/src/acp/bridge/bridge.test.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.test.ts
@@ -1647,7 +1647,7 @@ describe("acp bridge", () => {
     expect(notifications("acp/turn/completed")).toHaveLength(1);
   });
 
-  it("cancels once and delivers stacked steers on the same turn", async () => {
+  it("delivers stacked steers on the same turn", async () => {
     const { bbThreadId, providerThreadId } = await startThread();
     const turnId = sendRequest("turn/start", {
       threadId: providerThreadId,
@@ -1674,6 +1674,39 @@ describe("acp bridge", () => {
       stopReason: "end_turn",
     });
     expect(agentMessageTexts()).toContain("echo:first-steer");
+    expect(agentMessageTexts()).toContain("echo:second-steer");
+    expect(notifications("acp/turn/started")).toHaveLength(1);
+    expect(notifications("acp/turn/completed")).toHaveLength(1);
+  });
+
+  it("cancels a stacked steer prompt that also hangs", async () => {
+    const { bbThreadId, providerThreadId } = await startThread();
+    const turnId = sendRequest("turn/start", {
+      threadId: providerThreadId,
+      input: [{ type: "text", text: "hang", mentions: [] }],
+    });
+    await waitForResponse(turnId);
+
+    // The first steer also hangs, so the second steer must trigger a second
+    // cancel instead of waiting for a prompt that never finishes.
+    const firstSteerId = sendRequest("turn/steer", {
+      threadId: providerThreadId,
+      expectedTurnId: "turn-1",
+      input: [{ type: "text", text: "hang again", mentions: [] }],
+    });
+    const secondSteerId = sendRequest("turn/steer", {
+      threadId: providerThreadId,
+      expectedTurnId: "turn-1",
+      input: [{ type: "text", text: "second-steer", mentions: [] }],
+    });
+    await waitForResponse(firstSteerId);
+    await waitForResponse(secondSteerId);
+
+    const completed = await waitForTurnCompleted();
+    expect(completed.params).toEqual({
+      threadId: bbThreadId,
+      stopReason: "end_turn",
+    });
     expect(agentMessageTexts()).toContain("echo:second-steer");
     expect(notifications("acp/turn/started")).toHaveLength(1);
     expect(notifications("acp/turn/completed")).toHaveLength(1);

--- a/packages/agent-runtime/src/acp/bridge/bridge.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.ts
@@ -130,6 +130,10 @@ interface AcpThreadSession {
   pendingInstructions: string | undefined;
   activePromptKind: "turn" | "compaction" | null;
   queuedInputs: PromptInput[][];
+  /** True while a session/prompt request is outstanding. */
+  promptRequestPending: boolean;
+  /** True after a steer sent session/cancel for the current prompt. */
+  cancelRequested: boolean;
   loading: boolean;
   loadingSessionId: string | undefined;
   pendingLoadUsageUpdate: AcpUsageUpdate | undefined;
@@ -1226,7 +1230,11 @@ function handlePermissionRequest(
     return;
   }
 
-  if (session.stopping || session.activePromptKind !== "turn") {
+  if (
+    session.stopping ||
+    session.cancelRequested ||
+    session.activePromptKind !== "turn"
+  ) {
     responder.result({ outcome: { outcome: "cancelled" } });
     return;
   }
@@ -1476,6 +1484,8 @@ async function startAgentSession(
     pendingInstructions: params.instructions,
     activePromptKind: null,
     queuedInputs: [],
+    promptRequestPending: false,
+    cancelRequested: false,
     loading: false,
     loadingSessionId: undefined,
     pendingLoadUsageUpdate: undefined,
@@ -1627,6 +1637,36 @@ async function stopSession(session: AcpThreadSession): Promise<void> {
 // Turn loop
 // ---------------------------------------------------------------------------
 
+function requestSteerCancel(session: AcpThreadSession): void {
+  if (
+    session.stopping ||
+    session.cancelRequested ||
+    !session.promptRequestPending ||
+    session.connection.exited
+  ) {
+    return;
+  }
+  session.cancelRequested = true;
+  cancelPendingPermissions(session);
+  session.connection.notify("session/cancel", {
+    sessionId: session.providerThreadId,
+  });
+}
+
+function finishTurn(
+  session: AcpThreadSession,
+  stopReason: z.infer<typeof acpStopReasonSchema>,
+): void {
+  session.activePromptKind = null;
+  session.queuedInputs = [];
+  session.promptRequestPending = false;
+  session.cancelRequested = false;
+  sendNotification(ACP_TURN_COMPLETED_METHOD, {
+    threadId: session.bbThreadId,
+    stopReason,
+  });
+}
+
 function runTurn(session: AcpThreadSession, firstInput: PromptInput[]): void {
   session.activePromptKind = "turn";
   sendNotification(ACP_TURN_STARTED_METHOD, { threadId: session.bbThreadId });
@@ -1634,8 +1674,15 @@ function runTurn(session: AcpThreadSession, firstInput: PromptInput[]): void {
   session.turnSettled = (async () => {
     let input = firstInput;
     for (;;) {
+      if (session.stopping) {
+        finishTurn(session, "cancelled");
+        return;
+      }
+
       let stopReason: z.infer<typeof acpStopReasonSchema>;
+      session.cancelRequested = false;
       try {
+        session.promptRequestPending = true;
         const result = await session.connection.request({
           method: "session/prompt",
           params: {
@@ -1646,8 +1693,10 @@ function runTurn(session: AcpThreadSession, firstInput: PromptInput[]): void {
         });
         stopReason = result.stopReason;
       } catch (error) {
-        session.activePromptKind = null;
+        session.promptRequestPending = false;
         session.queuedInputs = [];
+        session.cancelRequested = false;
+        session.activePromptKind = null;
         // An exited agent already produced an error notification from the
         // connection's exit handler; only report in-protocol prompt failures.
         if (!session.stopping && !session.connection.exited) {
@@ -1658,9 +1707,10 @@ function runTurn(session: AcpThreadSession, firstInput: PromptInput[]): void {
         }
         return;
       }
+      session.promptRequestPending = false;
 
-      if (stopReason !== "cancelled" && !session.stopping) {
-        // Steer inputs queued during the prompt continue the same bb turn.
+      // Hard steer cancels the current prompt, then continues this bb turn.
+      if (!session.stopping) {
         const next = session.queuedInputs.shift();
         if (next) {
           input = next;
@@ -1668,12 +1718,7 @@ function runTurn(session: AcpThreadSession, firstInput: PromptInput[]): void {
         }
       }
 
-      session.activePromptKind = null;
-      session.queuedInputs = [];
-      sendNotification(ACP_TURN_COMPLETED_METHOD, {
-        threadId: session.bbThreadId,
-        stopReason,
-      });
+      finishTurn(session, stopReason);
       return;
     }
   })();
@@ -1911,6 +1956,7 @@ async function handleRequest(
         return;
       }
       session.queuedInputs.push(request.params.input);
+      requestSteerCancel(session);
       sendResult(request.id, { threadId: request.params.threadId });
       return;
     }

--- a/packages/agent-runtime/src/acp/bridge/bridge.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.ts
@@ -1683,7 +1683,7 @@ function runTurn(session: AcpThreadSession, firstInput: PromptInput[]): void {
       session.cancelRequested = false;
       try {
         session.promptRequestPending = true;
-        const result = await session.connection.request({
+        const promptResult = session.connection.request({
           method: "session/prompt",
           params: {
             sessionId: session.providerThreadId,
@@ -1691,6 +1691,12 @@ function runTurn(session: AcpThreadSession, firstInput: PromptInput[]): void {
           },
           resultSchema: acpPromptResultSchema,
         });
+        // A steer that stacked behind the cancelled prompt still needs its own
+        // cancel; otherwise this prompt can hang and strand the later input.
+        if (session.queuedInputs.length > 0) {
+          requestSteerCancel(session);
+        }
+        const result = await promptResult;
         stopReason = result.stopReason;
       } catch (error) {
         session.promptRequestPending = false;


### PR DESCRIPTION
## Summary

- ACP `turn/steer` now sends `session/cancel` while a prompt is open
- After the cancelled prompt returns, the bridge continues the same BB turn with the steer text
- `thread/stop` still clears the queue and ends the turn as cancelled
- Partial agent output from the cancelled prompt stays in the timeline

ACP v1 has no mid-loop inject. This is cancel-then-prompt, which is the only interrupt the protocol allows.

## Tests

- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime`
- `pnpm exec turbo run test --filter=@bb/agent-runtime -- --project @bb/agent-runtime:isolated src/acp/bridge/bridge.test.ts`

## Notes

This change does not alter the server and host daemon wire contract.

> AGENT GENERATED: by Grok 4.6