### PR TITLE
Reduce thread-open request fanout

### DIFF
--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -35,6 +35,7 @@ import {
   useThreadDetailBootstrap,
   useThreadPendingInteractions,
 } from "@/hooks/queries/thread-queries";
+import { THREAD_OPEN_MOUNT_COALESCE_STALE_TIME_MS } from "@/hooks/queries/query-policies";
 import { useRouteState } from "@/hooks/useRouteState";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { applyResizeCursor, clearResizeCursor } from "@/lib/resizeCursor";
@@ -727,7 +728,10 @@ export function AppLayout({ children }: AppLayoutProps) {
   // mirroring how the in-view unread signal covers every thread kind.
   const currentThreadPendingInteractionsQuery = useThreadPendingInteractions(
     threadId ?? "",
-    { enabled: isThreadView && Boolean(threadId) },
+    {
+      enabled: isThreadView && Boolean(threadId),
+      staleTime: THREAD_OPEN_MOUNT_COALESCE_STALE_TIME_MS,
+    },
   );
   const currentThreadHasPendingInteraction =
     getLatestPendingInteraction(currentThreadPendingInteractionsQuery.data) !==

--- a/apps/app/src/components/secondary-panel/useThreadStorageViewer.test.tsx
+++ b/apps/app/src/components/secondary-panel/useThreadStorageViewer.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { sdk } from "@/lib/sdk";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import { useThreadStorageViewer } from "./useThreadStorageViewer";
+
+vi.mock("@/lib/sdk", () => ({
+  sdk: {
+    threads: {
+      storageFiles: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/hooks/useRealtimeSubscription", () => ({
+  useThreadDetailRealtimeSubscription: vi.fn(),
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useThreadStorageViewer", () => {
+  it("defers the storage listing until its panel is enabled", async () => {
+    vi.mocked(sdk.threads.storageFiles).mockResolvedValue({
+      files: [],
+      storageRootPath: "/tmp/thread-storage/thread-1",
+      truncated: false,
+    });
+    const { wrapper } = createQueryClientTestHarness();
+    const result = renderHook(
+      ({ fileListEnabled }: { fileListEnabled: boolean }) =>
+        useThreadStorageViewer({
+          activePath: null,
+          fileListEnabled,
+          filePreviewEnabled: false,
+          threadId: "thread-1",
+        }),
+      { initialProps: { fileListEnabled: false }, wrapper },
+    );
+
+    expect(sdk.threads.storageFiles).not.toHaveBeenCalled();
+
+    result.rerender({ fileListEnabled: true });
+    await waitFor(() => {
+      expect(sdk.threads.storageFiles).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/app/src/components/secondary-panel/useThreadStorageViewer.ts
+++ b/apps/app/src/components/secondary-panel/useThreadStorageViewer.ts
@@ -9,7 +9,7 @@ import {
 
 interface UseThreadStorageViewerParams {
   activePath: string | null;
-  fileListEnabled?: boolean;
+  fileListEnabled: boolean;
   fileListOptions?: ThreadStorageFileListOptions;
   filePreviewEnabled?: boolean;
   threadId?: string;
@@ -17,7 +17,7 @@ interface UseThreadStorageViewerParams {
 
 export function useThreadStorageViewer({
   activePath,
-  fileListEnabled = true,
+  fileListEnabled,
   fileListOptions = DEFAULT_THREAD_STORAGE_FILE_LIST_OPTIONS,
   filePreviewEnabled = true,
   threadId,

--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -861,9 +861,6 @@ function dirtyEnvironmentLiveWorkspaceStateQueries({
     queryKey: environmentWorkStatusQueryKeyPrefix(environmentId),
   });
   queryClient.invalidateQueries({
-    queryKey: environmentPullRequestQueryKey(environmentId),
-  });
-  queryClient.invalidateQueries({
     queryKey: environmentFilePreviewQueryKeyPrefix(environmentId),
   });
   queryClient.invalidateQueries({
@@ -886,6 +883,12 @@ function dirtyEnvironmentRefDerivedWorkspaceStateQueries({
   )) {
     queryClient.invalidateQueries({ queryKey });
   }
+  // Pull requests follow the checked-out ref, not content-only worktree edits.
+  // Refresh them when refs move without paying for a PR lookup on every file
+  // watcher event.
+  queryClient.invalidateQueries({
+    queryKey: environmentPullRequestQueryKey(environmentId),
+  });
   // A moved merge base affects every ref-derived diff target; evict the
   // observer-less patch cache so the panel re-requests fresh patches.
   removeEnvironmentDiffPatchQueries({ environmentId, queryClient });

--- a/apps/app/src/hooks/queries/query-policies.ts
+++ b/apps/app/src/hooks/queries/query-policies.ts
@@ -9,6 +9,11 @@ const FOCUS_OWNED_LIVE_STALE_TIME_MS = 30_000;
 const FAST_FOCUS_OWNED_LIVE_STALE_TIME_MS = 5_000;
 const TYPEAHEAD_STALE_TIME_MS = 15_000;
 
+// Route transitions can mount two observers for the same live query a few
+// milliseconds apart. Keep the first answer fresh only long enough to coalesce
+// that handoff; realtime invalidation still refreshes actual changes.
+export const THREAD_OPEN_MOUNT_COALESCE_STALE_TIME_MS = 1_000;
+
 export const SESSION_STATIC_QUERY_POLICY = {
   refetchOnMount: false,
   refetchOnReconnect: false,

--- a/apps/app/src/hooks/queries/thread-tabs-query.ts
+++ b/apps/app/src/hooks/queries/thread-tabs-query.ts
@@ -8,6 +8,10 @@ interface ThreadTabsQueryOptions {
   enabled?: boolean;
 }
 
+export function fetchThreadTabs(threadId: string, signal?: AbortSignal) {
+  return sdk.threads.tabs.get({ threadId, signal });
+}
+
 export function useThreadTabs(
   threadId: string,
   options?: ThreadTabsQueryOptions,
@@ -16,7 +20,7 @@ export function useThreadTabs(
 
   return useQuery<ThreadTabsResponse>({
     queryKey: threadTabsQueryKey(threadId),
-    queryFn: ({ signal }) => sdk.threads.tabs.get({ threadId, signal }),
+    queryFn: ({ signal }) => fetchThreadTabs(threadId, signal),
     enabled,
     ...RESUME_REFETCH_QUERY_POLICY,
   });

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -733,7 +733,7 @@ describe("createRealtimeCacheEffects", () => {
     effects.dispose();
   });
 
-  it("refetches the active diff TOC and work-status queries but evicts the observer-less patch cache for work-status changes", async () => {
+  it("refreshes content-derived queries without rechecking pull requests for work-status changes", async () => {
     vi.useFakeTimers();
     const { effects, queryClient } = createRealtimeEffectsTestContext();
     const diffFilesKey = environmentDiffFilesQueryKey("env-1", "all", "main");
@@ -744,6 +744,7 @@ describe("createRealtimeCacheEffects", () => {
       "file.ts",
     );
     const workStatusKey = environmentWorkStatusQueryKey("env-1", "main");
+    const pullRequestKey = environmentPullRequestQueryKey("env-1");
     queryClient.setQueryData(diffFilesKey, {
       outcome: "available",
       files: [],
@@ -761,6 +762,7 @@ describe("createRealtimeCacheEffects", () => {
       truncated: false,
     });
     queryClient.setQueryData(workStatusKey, null);
+    queryClient.setQueryData(pullRequestKey, null);
     const diffFilesQueryFn = vi.fn(async () => ({
       outcome: "available" as const,
       files: [],
@@ -768,6 +770,7 @@ describe("createRealtimeCacheEffects", () => {
       mergeBaseRef: "base-ref",
     }));
     const workStatusQueryFn = vi.fn(async () => null);
+    const pullRequestQueryFn = vi.fn(async () => null);
     const diffFilesObserver = new QueryObserver(queryClient, {
       queryKey: diffFilesKey,
       queryFn: diffFilesQueryFn,
@@ -778,10 +781,17 @@ describe("createRealtimeCacheEffects", () => {
       queryFn: workStatusQueryFn,
       staleTime: Infinity,
     });
+    const pullRequestObserver = new QueryObserver(queryClient, {
+      queryKey: pullRequestKey,
+      queryFn: pullRequestQueryFn,
+      staleTime: Infinity,
+    });
     const unsubscribeDiffFiles = diffFilesObserver.subscribe(() => {});
     const unsubscribeWorkStatus = workStatusObserver.subscribe(() => {});
+    const unsubscribePullRequest = pullRequestObserver.subscribe(() => {});
     diffFilesQueryFn.mockClear();
     workStatusQueryFn.mockClear();
+    pullRequestQueryFn.mockClear();
 
     effects.handleChanged({
       type: "changed",
@@ -794,12 +804,42 @@ describe("createRealtimeCacheEffects", () => {
     // The observer-backed TOC and work-status queries refetch.
     expect(diffFilesQueryFn).toHaveBeenCalledTimes(1);
     expect(workStatusQueryFn).toHaveBeenCalledTimes(1);
+    expect(pullRequestQueryFn).not.toHaveBeenCalled();
     // The observer-less patch entry is evicted, not left stale — so the panel's
     // readDiffPatchEntry returns undefined and re-fetches a fresh patch.
     expect(queryClient.getQueryData(diffPatchKey)).toBeUndefined();
 
     unsubscribeDiffFiles();
     unsubscribeWorkStatus();
+    unsubscribePullRequest();
+    effects.dispose();
+  });
+
+  it("rechecks the active pull request when git refs change", async () => {
+    vi.useFakeTimers();
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const pullRequestKey = environmentPullRequestQueryKey("env-1");
+    queryClient.setQueryData(pullRequestKey, null);
+    const pullRequestQueryFn = vi.fn(async () => null);
+    const pullRequestObserver = new QueryObserver(queryClient, {
+      queryKey: pullRequestKey,
+      queryFn: pullRequestQueryFn,
+      staleTime: Infinity,
+    });
+    const unsubscribePullRequest = pullRequestObserver.subscribe(() => {});
+    pullRequestQueryFn.mockClear();
+
+    effects.handleChanged({
+      type: "changed",
+      entity: "environment",
+      id: "env-1",
+      changes: ["git-refs-changed"],
+    });
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(pullRequestQueryFn).toHaveBeenCalledTimes(1);
+
+    unsubscribePullRequest();
     effects.dispose();
   });
 

--- a/apps/app/src/lib/fixed-panel-tabs-sync.test.ts
+++ b/apps/app/src/lib/fixed-panel-tabs-sync.test.ts
@@ -222,7 +222,7 @@ describe("fixed panel tab server sync", () => {
     });
   });
 
-  it("persists tab-list changes but not presentation-only changes", async () => {
+  it("defers the server read until the panel opens, then persists tab-list changes", async () => {
     const threadId = "sync-local-updates";
     apiMocks.getThreadTabs.mockResolvedValue({ revision: 2, tabs: [] });
     const savedTab = createThreadInfoFixedPanelTab();
@@ -238,7 +238,17 @@ describe("fixed panel tab server sync", () => {
       }),
       { wrapper: createQueryWrapper(queryClient) },
     );
-    await waitFor(() => expect(apiMocks.getThreadTabs).toHaveBeenCalled());
+    expect(apiMocks.getThreadTabs).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.update((current) => ({
+        ...current,
+        secondary: { ...current.secondary, isOpen: true },
+      }));
+    });
+    await waitFor(() => {
+      expect(apiMocks.getThreadTabs).toHaveBeenCalledTimes(1);
+    });
 
     act(() => {
       result.current.update((current) => ({
@@ -301,6 +311,14 @@ describe("fixed panel tab server sync", () => {
       }),
       { wrapper: createQueryWrapper(queryClient) },
     );
+    expect(apiMocks.getThreadTabs).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.update((current) => ({
+        ...current,
+        secondary: { ...current.secondary, isOpen: true },
+      }));
+    });
     await waitFor(() => {
       expect(result.current.state.secondary.tabs).toEqual([originalTab]);
     });

--- a/apps/app/src/lib/fixed-panel-tabs.ts
+++ b/apps/app/src/lib/fixed-panel-tabs.ts
@@ -211,7 +211,9 @@ export function useFixedPanelTabsState(
   const queryClient = useQueryClient();
   const resolvedThreadId = hasThreadId(syncThreadId) ? syncThreadId : null;
   const tabsQuery = useThreadTabs(resolvedThreadId ?? "", {
-    enabled: resolvedThreadId !== null,
+    // Tabs have no visible consumer while the secondary panel is closed. The
+    // local presentation state still restores whether the panel itself opens.
+    enabled: resolvedThreadId !== null && state.secondary.isOpen,
   });
 
   useEffect(() => {

--- a/apps/app/src/lib/thread-tabs-sync.ts
+++ b/apps/app/src/lib/thread-tabs-sync.ts
@@ -10,6 +10,8 @@ import {
   invalidateCachedThreadTabs,
   setCachedThreadTabs,
 } from "@/hooks/cache-owners/thread-tabs-cache-owner";
+import { threadTabsQueryKey } from "@/hooks/queries/query-keys";
+import { fetchThreadTabs } from "@/hooks/queries/thread-tabs-query";
 import { BbHttpError, sdk } from "./sdk";
 import {
   areFixedPanelTabsEquivalent,
@@ -128,9 +130,12 @@ async function readCurrentThreadTabs({
   if (cached !== undefined) {
     return cached;
   }
-  const response = await sdk.threads.tabs.get({ threadId });
-  setCachedThreadTabs(queryClient, threadId, response);
-  return response;
+  // Share the same query promise as the panel-open observer so opening a tab
+  // and persisting it in one action cannot race two initial reads.
+  return queryClient.fetchQuery({
+    queryKey: threadTabsQueryKey(threadId),
+    queryFn: ({ signal }) => fetchThreadTabs(threadId, signal),
+  });
 }
 
 function isThreadTabsConflict(error: unknown): boolean {

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
@@ -66,10 +66,7 @@ const mocks = vi.hoisted(() => ({
   unarchiveThreadMutate: vi.fn(),
   uploadPromptAttachmentMutateAsync: vi.fn(),
   updateQueuedMessageMutateAsync: vi.fn(),
-  useThreadDefaultExecutionOptions: vi.fn(),
   useThreadCreationOptions: vi.fn(),
-  useThreadPromptHistory: vi.fn(),
-  useThreadQueuedMessages: vi.fn(),
 }));
 
 vi.mock("react-router-dom", async (importOriginal) => {
@@ -503,27 +500,9 @@ vi.mock("@/hooks/queries/sidebar-navigation-query", () => ({
   useProjectDisplayName: () => null,
 }));
 
-vi.mock("@/hooks/queries/thread-default-execution-options-query", () => ({
-  useThreadDefaultExecutionOptions: (threadId: string, options: unknown) => {
-    mocks.useThreadDefaultExecutionOptions(threadId, options);
-    return {
-      data: mocks.defaultExecutionOptions,
-      isError: false,
-    };
-  },
-}));
-
 vi.mock("@/hooks/queries/thread-queries", () => ({
   getLatestPendingInteraction: (interactions: readonly PendingInteraction[]) =>
     interactions.at(-1) ?? null,
-  useThreadPromptHistory: (threadId: string, options: unknown) => {
-    mocks.useThreadPromptHistory(threadId, options);
-    return { data: [] };
-  },
-  useThreadQueuedMessages: (threadId: string, options: unknown) => {
-    mocks.useThreadQueuedMessages(threadId, options);
-    return { data: mocks.queuedMessages };
-  },
 }));
 
 function makeQueuedMessage(
@@ -664,6 +643,8 @@ function buildPromptAreaElement({
       childThreadsSection={null}
       composerFocusRequestNonce={0}
       contextBannerMergeBase={null}
+      defaultExecutionOptions={mocks.defaultExecutionOptions}
+      defaultExecutionOptionsError={false}
       environmentGoneStatus={null}
       goal={goal}
       modelFallback={modelFallback}
@@ -674,9 +655,11 @@ function buildPromptAreaElement({
       pendingInteractions={pendingInteractions}
       pendingInteractionsInitialLoading={pendingInteractionsInitialLoading}
       pendingTodos={null}
+      promptHistoryEntries={[]}
       projectId="proj_1"
       pullRequest={null}
       pullRequestMergeMethod="squash"
+      queuedMessages={mocks.queuedMessages}
       resolveMentionLink={() => null}
       sendMessage={{
         isPending: false,
@@ -717,9 +700,6 @@ beforeEach(() => {
   mocks.queuedMessages = [];
   mocks.updateQueuedMessageMutateAsync.mockResolvedValue(undefined);
   mocks.useThreadCreationOptions.mockClear();
-  mocks.useThreadDefaultExecutionOptions.mockClear();
-  mocks.useThreadPromptHistory.mockClear();
-  mocks.useThreadQueuedMessages.mockClear();
 });
 
 afterEach(() => {
@@ -880,23 +860,11 @@ describe("ThreadDetailPromptArea", () => {
     expect(stack.nextElementSibling).toBe(composer);
   });
 
-  it("uses the real thread cache keys immediately", () => {
+  it("uses provided composer query data immediately", () => {
     mocks.queuedMessages = [makeQueuedMessage()];
 
     renderPromptArea();
 
-    expect(mocks.useThreadDefaultExecutionOptions).toHaveBeenCalledWith(
-      "thr_1",
-      expect.objectContaining({ enabled: true }),
-    );
-    expect(mocks.useThreadPromptHistory).toHaveBeenCalledWith(
-      "thr_1",
-      expect.objectContaining({ enabled: true }),
-    );
-    expect(mocks.useThreadQueuedMessages).toHaveBeenCalledWith(
-      "thr_1",
-      expect.objectContaining({ enabled: true }),
-    );
     expect(mocks.useThreadCreationOptions).toHaveBeenCalledWith(
       expect.objectContaining({
         enabled: true,

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -12,6 +12,7 @@ import type {
   EnvironmentStatus,
   PendingInteraction,
   PromptInput,
+  ResolvedThreadExecutionOptions,
   ThreadQueuedMessage,
   ThreadPullRequest,
   ThreadTimelineActivePromptMode,
@@ -21,6 +22,7 @@ import type {
   ThreadWithRuntime,
 } from "@bb/domain";
 import type {
+  PromptHistoryResponse,
   PullRequestMergeMethod,
   ThreadTimelineResponse,
   TimelineWorkflowWorkRow,
@@ -79,12 +81,7 @@ import {
   useStopThread,
 } from "@/hooks/mutations/thread-runtime-mutations";
 import { useUnarchiveThread } from "@/hooks/mutations/thread-state-mutations";
-import {
-  getLatestPendingInteraction,
-  useThreadQueuedMessages,
-  useThreadPromptHistory,
-} from "@/hooks/queries/thread-queries";
-import { useThreadDefaultExecutionOptions } from "@/hooks/queries/thread-default-execution-options-query";
+import { getLatestPendingInteraction } from "@/hooks/queries/thread-queries";
 import { getMutationErrorMessage } from "@/lib/mutation-errors";
 import { promptHistoryEntriesToDrafts } from "@/lib/prompt-history";
 import { getProjectComposeRoutePath } from "@/lib/route-paths";
@@ -137,6 +134,8 @@ export const THREAD_DETAIL_COMPOSER_TEXTAREA_ID =
 interface ThreadDetailPromptAreaProps {
   activeBackgroundAgentCount: number;
   canUseGitUi: boolean;
+  defaultExecutionOptions: ResolvedThreadExecutionOptions | null | undefined;
+  defaultExecutionOptionsError: boolean;
   contextWindowUsage?: ThreadTimelineResponse["contextWindowUsage"];
   environmentCheckout?: WorkspaceCheckoutDisplay;
   environmentCompactLabel?: string;
@@ -160,6 +159,8 @@ interface ThreadDetailPromptAreaProps {
   isEnvironmentActionPending: boolean;
   pendingInteractions: readonly PendingInteraction[];
   pendingInteractionsInitialLoading: boolean;
+  promptHistoryEntries: PromptHistoryResponse;
+  queuedMessages: readonly ThreadQueuedMessage[];
   onChangedFileClick: (selection: WorkspaceChangedFileSelection) => void;
   openThreadDiffPanel: () => void;
   projectId: string;
@@ -308,6 +309,8 @@ function buildInlineDraftComposer(options: InlineDraftComposerOptions) {
 export function ThreadDetailPromptArea({
   activeBackgroundAgentCount,
   canUseGitUi,
+  defaultExecutionOptions,
+  defaultExecutionOptionsError,
   contextWindowUsage,
   environmentCheckout,
   environmentCompactLabel,
@@ -323,6 +326,8 @@ export function ThreadDetailPromptArea({
   isEnvironmentActionPending,
   pendingInteractions,
   pendingInteractionsInitialLoading,
+  promptHistoryEntries,
+  queuedMessages,
   onChangedFileClick,
   openThreadDiffPanel,
   projectId,
@@ -347,13 +352,6 @@ export function ThreadDetailPromptArea({
   thread,
 }: ThreadDetailPromptAreaProps) {
   const navigate = useNavigate();
-  const defaultExecutionOptionsQuery = useThreadDefaultExecutionOptions(
-    thread.id,
-    {
-      enabled: true,
-    },
-  );
-  const defaultExecutionOptions = defaultExecutionOptionsQuery.data;
   const hasResolvedDefaultExecutionOptions =
     defaultExecutionOptions !== undefined;
   const hasConcreteDefaultExecutionOptions =
@@ -361,13 +359,10 @@ export function ThreadDetailPromptArea({
   const defaultExecutionOptionsState = resolveDefaultExecutionOptionsState({
     hasConcreteDefaultExecutionOptions,
     hasResolvedDefaultExecutionOptions,
-    isError: defaultExecutionOptionsQuery.isError,
+    isError: defaultExecutionOptionsError,
   });
   const isDefaultExecutionOptionsLoading =
     defaultExecutionOptionsState === "loading";
-  const { data: queuedMessages = [] } = useThreadQueuedMessages(thread.id, {
-    enabled: true,
-  });
   const queuedMessagesRef = useRef<readonly ThreadQueuedMessage[]>([]);
   queuedMessagesRef.current = queuedMessages;
   const [bottomPluginFocusNonce, setBottomPluginFocusNonce] = useState(0);
@@ -397,12 +392,6 @@ export function ThreadDetailPromptArea({
       setEditFocusNonce((nonce) => nonce + 1);
     },
   });
-  const { data: promptHistoryEntries = [] } = useThreadPromptHistory(
-    thread.id,
-    {
-      enabled: true,
-    },
-  );
   const createQueuedMessage = useCreateThreadQueuedMessage();
   const stopThread = useStopThread();
   const cancelThreadPlan = useCancelThreadPlan();
@@ -1421,9 +1410,7 @@ export function ThreadDetailPromptArea({
             >
               From child thread: {item.childTitle}
             </NavLink>
-            <PluginPendingInteractionComposer
-              interaction={item.interaction}
-            />
+            <PluginPendingInteractionComposer interaction={item.interaction} />
           </div>
         ) : (
           <ThreadPendingInteractionBanner

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -25,6 +25,9 @@ type DrawerShellCallback = (open: boolean) => void;
 const drawerShellState = vi.hoisted(() => ({
   onContentAnimationEnd: undefined as DrawerShellCallback | undefined,
 }));
+const queryMocks = vi.hoisted(() => ({
+  useThreads: vi.fn(() => ({ data: [] })),
+}));
 
 vi.mock("@/lib/browser-view-bounds-sync", () => ({
   dispatchBrowserViewBoundsSync: vi.fn(),
@@ -42,7 +45,7 @@ vi.mock("@/components/ui/sidebar.js", () => ({
 }));
 
 vi.mock("@/hooks/queries/thread-queries", () => ({
-  useThreads: () => ({ data: [] }),
+  useThreads: queryMocks.useThreads,
 }));
 
 vi.mock("jotai", async (importOriginal) => ({
@@ -478,6 +481,29 @@ afterEach(() => {
 beforeEach(() => {
   publishedHostedPanel = null;
   vi.mocked(dispatchBrowserViewBoundsSync).mockReset();
+  queryMocks.useThreads.mockClear();
+});
+
+describe("ThreadDetailSecondaryContent query deferral", () => {
+  it("waits to list forks until the secondary panel opens", () => {
+    const view = renderThreadDetail({
+      isCompactViewport: false,
+      isSecondaryPanelOpen: false,
+      renderBrowserDeck: createBrowserDeckRenderer(),
+      threadId: "thread-1",
+    });
+
+    expect(queryMocks.useThreads).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sourceThreadId: "thread-1" }),
+      { enabled: false },
+    );
+
+    view.rerenderWith({ isSecondaryPanelOpen: true });
+    expect(queryMocks.useThreads).toHaveBeenLastCalledWith(
+      expect.objectContaining({ sourceThreadId: "thread-1" }),
+      { enabled: true },
+    );
+  });
 });
 
 describe("ThreadDetailSecondaryContent compact drawer settling", () => {

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -262,29 +262,38 @@ function ThreadDetailSecondaryContentBody({
 
   // Mirror ForksRow's query (deduped by react-query) so the visibility gate
   // accounts for the lazily-fetched Forks row.
-  const forksQuery = useThreads({
-    projectId: stableMetadata.thread.projectId,
-    sourceThreadId: stableMetadata.thread.id,
-    originKind: "fork",
-    archived: false,
-  });
+  const forksQuery = useThreads(
+    {
+      projectId: stableMetadata.thread.projectId,
+      sourceThreadId: stableMetadata.thread.id,
+      originKind: "fork",
+      archived: false,
+    },
+    {
+      enabled: isSecondaryPanelOpen,
+    },
+  );
   const hasForks = (forksQuery.data?.length ?? 0) > 0;
 
-  const metadataContent = useMemo(
-    () =>
-      hasAnyThreadMetadata(stableMetadata, hasForks) ? (
+  const metadataContent = useMemo(() => {
+    if (!isSecondaryPanelOpen) {
+      return null;
+    }
+    if (hasAnyThreadMetadata(stableMetadata, hasForks)) {
+      return (
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           <ThreadMetadataContent {...stableMetadata} />
         </div>
-      ) : isMetadataLoading ? (
-        <ThreadMetadataLoadingSkeleton />
-      ) : (
-        <div className="px-4 pt-1 text-sm text-muted-foreground">
-          No thread details available.
-        </div>
-      ),
-    [hasForks, isMetadataLoading, stableMetadata],
-  );
+      );
+    }
+    return isMetadataLoading ? (
+      <ThreadMetadataLoadingSkeleton />
+    ) : (
+      <div className="px-4 pt-1 text-sm text-muted-foreground">
+        No thread details available.
+      </div>
+    );
+  }, [hasForks, isMetadataLoading, isSecondaryPanelOpen, stableMetadata]);
   const inlineSecondaryPanelContent = useMemo(
     () =>
       !renderAsDrawer ? (

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -62,10 +62,13 @@ import {
   useThread,
   useThreadDetailBootstrap,
   useThreadPendingInteractions,
+  useThreadPromptHistory,
   useThreadQueuedMessages,
   type ProjectThreadSubsetFilters,
 } from "../../hooks/queries/thread-queries";
+import { useThreadDefaultExecutionOptions } from "@/hooks/queries/thread-default-execution-options-query";
 import { isTransientReadError } from "@/hooks/queries/query-helpers";
+import { THREAD_OPEN_MOUNT_COALESCE_STALE_TIME_MS } from "@/hooks/queries/query-policies";
 import { usePromptDraftStorage } from "@/hooks/usePromptDraftStorage";
 import { subscribeComposerFocusRequests } from "@/lib/composer-focus-requests";
 import { ThreadGitActionDialog } from "@/components/dialogs/ThreadGitActionDialog";
@@ -602,6 +605,11 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
     thread?.id ?? "",
     {
       enabled: threadQueryState.status === "ready" && Boolean(thread?.id),
+      // AppLayout already owns the page thread's current interaction query for
+      // favicon attention. Pane threads have no such parent owner and still
+      // establish their own fresh baseline.
+      refetchOnMount: props.surface === "pane",
+      staleTime: THREAD_OPEN_MOUNT_COALESCE_STALE_TIME_MS,
     },
   );
   const pendingInteractions = pendingInteractionsQuery.data ?? [];
@@ -610,10 +618,20 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
     (pendingInteractionsQuery.isLoading || pendingInteractionsQuery.isFetching);
   const hasPendingInteraction =
     getLatestPendingInteraction(pendingInteractions) !== null;
-  const { data: queuedMessagesForEditEligibility = [] } =
-    useThreadQueuedMessages(thread?.id ?? "", {
-      enabled: threadQueryState.status === "ready" && Boolean(thread?.id),
-    });
+  const composerQueriesEnabled =
+    threadQueryState.status === "ready" && Boolean(thread?.id);
+  const defaultExecutionOptionsQuery = useThreadDefaultExecutionOptions(
+    thread?.id ?? "",
+    { enabled: composerQueriesEnabled },
+  );
+  const { data: promptHistoryEntries = [] } = useThreadPromptHistory(
+    thread?.id ?? "",
+    { enabled: composerQueriesEnabled },
+  );
+  const { data: queuedMessages = [] } = useThreadQueuedMessages(
+    thread?.id ?? "",
+    { enabled: composerQueriesEnabled },
+  );
   const unreadDividerState = useThreadUnreadDividerState({
     routeThreadId: threadId,
     thread,
@@ -627,7 +645,10 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
   );
   const [browserAddressFocusRequest, setBrowserAddressFocusRequest] =
     useState<BrowserAddressFocusRequest | null>(null);
-  const shouldLoadThreadStorageFiles = thread !== undefined;
+  // Thread storage backs only the secondary file panel. Keep its directory
+  // walk off the thread-open path until that panel is actually visible.
+  const shouldLoadThreadStorageFiles =
+    thread !== undefined && isSecondaryPanelOpen;
   const {
     isThreadStorageFilesLoading,
     refetchThreadStorageFiles,
@@ -978,7 +999,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
     !createQueuedMessage.isPending &&
     !editMessage.isPending &&
     !(timelineLoading && timelineRows.length === 0) &&
-    queuedMessagesForEditEligibility.length === 0 &&
+    queuedMessages.length === 0 &&
     activeWorkflows.length === 0 &&
     thread.activeBackgroundAgentCount === 0 &&
     activeBackgroundCommands.length === 0;
@@ -2580,6 +2601,8 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
       activeBackgroundAgentCount={thread.activeBackgroundAgentCount}
       canUseGitUi={canUseGitUi}
       contextWindowUsage={contextWindowUsage}
+      defaultExecutionOptions={defaultExecutionOptionsQuery.data}
+      defaultExecutionOptionsError={defaultExecutionOptionsQuery.isError}
       environmentCheckout={threadCheckoutDisplay}
       environmentCompactLabel={
         threadEnvironmentDisplay
@@ -2634,6 +2657,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
       pendingInteractions={pendingInteractions}
       pendingInteractionsInitialLoading={pendingInteractionsInitialLoading}
       pendingTodos={pendingTodos}
+      promptHistoryEntries={promptHistoryEntries}
       activePromptMode={activePromptMode}
       goal={goal}
       modelFallback={modelFallback}
@@ -2643,6 +2667,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
       childPendingInteractions={childPendingInteractions}
       childThreadsSection={childThreadsSection}
       pullRequest={pullRequest}
+      queuedMessages={queuedMessages}
       thread={thread}
     />
   );


### PR DESCRIPTION
## Summary

- keep thread-open data in its existing granular query/cache owners; there is no aggregate bootstrap response or aggregate invalidation lifecycle
- coalesce duplicate mount-time reads for interactions, prompt history, and default execution options, while reusing the existing queued-message read
- defer thread tabs, fork metadata, and thread-storage listing until the secondary panel opens
- stop content-only worktree events from triggering pull-request lookups; PR state still refreshes when git refs move
- keep environment status and pull-request state eager because both feed the composer context banner on first paint

## Why this is not another bootstrap

The current thread-detail bootstrap is already narrow: the thread read includes its environment and host, and it starts in parallel with the timeline. The old `composer-bootstrap` bundled default execution options, queued messages, prompt history, and pending interactions; #335 removed the app's dependency on it after the aggregate became a readiness gate for resources with independent cache owners and invalidation rules.

This change does not revive that pattern. It avoids both #1302 failure modes: there is no added payload to grow, and each resource keeps its own query key and granular realtime invalidation instead of refetching a bundle wholesale.

## What the open graph contains

On the measured `main` commit (`a0b029298`), the controlled cross-environment switch completed 20 requests over 14 distinct resources: thread + environment/host, timeline, interactions, queued messages, prompt history, default execution options, tabs, fork metadata, child threads, thread storage, environment status, environment pull request, system execution options, and conversation outline. Six resource types completed twice locally because nearby route observers or realtime invalidation remounted/refetched them.

After this change, 11 distinct resources remain on open. Tabs, fork metadata, and storage wait for the closed secondary panel to open; the composer reads remain eager but are owned above its remount boundary; interaction observers share a short mount-handoff freshness window. Opening the panel was also checked manually and starts the deferred reads.

## Measurements

Measured against the existing `pnpm seed:perf` database (1,200 threads, 402,298 events, 10,344 prompt-history rows, 22,939 search segments, 496 MB). Each result is the median of three SPA switches between seeded threads on different environments. The source thread was allowed to settle for four seconds before Resource Timing was cleared. `raw` includes canceled requests; `completed` requires a transferred response; settle runs from the first request start to the last completed response.

| Profile | Current `main` | This PR | Request delta |
| --- | --- | --- | --- |
| local RTT | 21 raw / 20 completed / 14 distinct; 939.7 ms settle | 13 raw / 12 completed / 11 distinct; 951.2 ms settle | 40% fewer completed; 21% fewer distinct |
| 529 ms RTT | 19 raw / 15 completed / 14 distinct; 1,895.3 ms settle | 12 raw / 11 completed / 11 distinct; 1,937.9 ms settle | 27% fewer completed; 21% fewer distinct |

The request-count reduction is repeatable, but settle time is effectively unchanged (about +1.2% local and +2.2% at 529 ms). In every throttled run, the system execution-options request was the tail and took 1.1–1.34 seconds. That contradicts the issue's stronger framing: the per-open git probes add work, but they were not the dominant tail in this controlled data. This is why the replacement does not add a daemon status cache.

Responsiveness was sampled with lateness of a recurring 250 ms timer, not the Long Tasks API unavailable in WebKit. Median maximum lateness across the three runs was 41.5 → 22.8 ms locally and 28.4 → 6.7 ms at 529 ms RTT; those small samples are directional, not a claimed INP result.

## Scope and compatibility

The context banner visibly consumes changed-file/status and pull-request state on open, so those reads remain eager. Timeline unmounting (#1301), sidebar bootstrap size/invalidation (#1302), composer keystroke cost (#1304), and the provider execution-options tail are left to their own scopes.

The patch is app-only: 15 files, +250/-102, split between +105/-61 production code and +145/-41 regression tests. It adds no server route, public contract, SDK declaration, generated file, or daemon wire change, so `HOST_DAEMON_PROTOCOL_VERSION` does not change.

## Validation

Slow output was captured before inspection:

`pnpm exec turbo run typecheck lint test build --filter=@bb/app --force > /tmp/bb-1303-final-validation.txt 2>&1`

- Turbo: 5/5 tasks passed
- app tests: 341 files, 2,645 tests passed
- app lint: 0 errors (149 existing warnings)
- app typecheck and production build passed
- regression tests pin closed-panel deferral for storage, forks, and tabs, plus PR refresh on git-ref changes but not content-only worktree events

Partial progress on #1303; this PR intentionally does not close the issue.

> AGENT GENERATED: by GPT-5
