### PR TITLE
Honor configured shortcuts in focused editors

### DIFF
--- a/apps/app/src/components/commands/AppCommandProvider.test.tsx
+++ b/apps/app/src/components/commands/AppCommandProvider.test.tsx
@@ -449,13 +449,13 @@ describe("AppCommandProvider", () => {
     ["thread.previous" as const, "ArrowUp"],
     ["thread.next" as const, "ArrowDown"],
   ])(
-    "leaves native %s selection to a focused editable control",
+    "dispatches configured %s shortcuts from a focused editable control",
     (command, key) => {
       vi.spyOn(navigator, "platform", "get").mockReturnValue("MacIntel");
       renderProvider(
         <>
           <Handler command={command} name={command} result={true} />
-          <textarea aria-label="Composer" defaultValue="alpha beta gamma" />
+          <textarea aria-label="Composer" />
         </>,
       );
       const composer = screen.getByLabelText("Composer");
@@ -470,34 +470,11 @@ describe("AppCommandProvider", () => {
 
       composer.dispatchEvent(event);
 
-      expect(event.defaultPrevented).toBe(false);
-      expect(testState.calls).toEqual([]);
+      expect(event.defaultPrevented).toBe(true);
+      expect(testState.calls).toEqual([command]);
       expect(document.activeElement).toBe(composer);
     },
   );
-
-  it("still dispatches an ordinary app shortcut from a focused editable control", () => {
-    vi.spyOn(navigator, "platform", "get").mockReturnValue("MacIntel");
-    renderProvider(
-      <>
-        <Handler name="search" result={true} />
-        <textarea aria-label="Composer" />
-      </>,
-    );
-    const composer = screen.getByLabelText("Composer");
-    composer.focus();
-    const event = new KeyboardEvent("keydown", {
-      bubbles: true,
-      cancelable: true,
-      key: "k",
-      metaKey: true,
-    });
-
-    composer.dispatchEvent(event);
-
-    expect(event.defaultPrevented).toBe(true);
-    expect(testState.calls).toEqual(["search"]);
-  });
 
   it("falls through declining handlers in priority order", () => {
     renderProvider(

--- a/apps/app/src/components/commands/AppCommandProvider.tsx
+++ b/apps/app/src/components/commands/AppCommandProvider.tsx
@@ -26,7 +26,6 @@ import {
   formatAppShortcut,
   formatAppShortcutAria,
   isEditableKeyboardTarget,
-  isNativeEditableKeyEvent,
   matchesAppCommandContext,
   type AppShortcutPresentation,
 } from "@/lib/app-keybindings";
@@ -286,11 +285,6 @@ export function AppCommandProvider({ children }: { children: ReactNode }) {
       if (event.defaultPrevented || event.isComposing || event.repeat) {
         return false;
       }
-      // Editable controls own semantic navigation and deletion keys. Their
-      // modifiers express native character/word/line/document behavior, so an
-      // app command customized onto the same chord must not preempt them. Other
-      // chords still dispatch before widget keymaps (the #1162 guarantee).
-      if (isNativeEditableKeyEvent(event)) return false;
       // A widget that dispatched first leaves the event alone when every
       // handler declines, so the same event still reaches the window listener.
       // Without this, those handlers would run a second time.

--- a/apps/app/src/components/promptbox/PromptBoxAppShortcuts.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxAppShortcuts.test.tsx
@@ -107,14 +107,14 @@ function ShortcutHintState() {
   );
 }
 
-function renderComposer(extra: React.ReactNode = null, value = "") {
+function renderComposer(extra: React.ReactNode = null) {
   render(
     <MemoryRouter>
       <AppCommandProvider>
         <SidebarToggleHandler />
         {extra}
         <PromptBoxInternal
-          value={value}
+          value=""
           mentionRanges={[]}
           onChange={vi.fn()}
           onSubmit={vi.fn()}
@@ -153,15 +153,6 @@ function pressInEditor(
   return event;
 }
 
-function placeCaretAtBoundary(editor: HTMLElement, boundary: "start" | "end") {
-  const range = document.createRange();
-  range.selectNodeContents(editor);
-  range.collapse(boundary === "start");
-  const selection = document.getSelection();
-  selection?.removeAllRanges();
-  selection?.addRange(range);
-}
-
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
@@ -180,29 +171,22 @@ afterEach(() => {
 
 describe("prompt editor app shortcuts", () => {
   it.each([
-    ["ArrowUp", "start", "end" as const],
-    ["ArrowDown", "end", "start" as const],
-  ])(
-    "leaves Meta+Shift+%s to extend selection toward the input %s",
-    (key, _targetBoundary, initialBoundary) => {
-      vi.spyOn(navigator, "platform", "get").mockReturnValue("MacIntel");
-      const editor = renderComposer(
-        <ThreadNavigationHandlers />,
-        "alpha\nbeta\ngamma",
-      );
-      placeCaretAtBoundary(editor, initialBoundary);
+    ["ArrowUp", "thread.previous"],
+    ["ArrowDown", "thread.next"],
+  ])("runs the configured Meta+Shift+%s app shortcut", (key, command) => {
+    vi.spyOn(navigator, "platform", "get").mockReturnValue("MacIntel");
+    const editor = renderComposer(<ThreadNavigationHandlers />);
 
-      const event = pressInEditor(editor, {
-        key,
-        metaKey: true,
-        shiftKey: true,
-      });
+    const event = pressInEditor(editor, {
+      key,
+      metaKey: true,
+      shiftKey: true,
+    });
 
-      expect(event.defaultPrevented).toBe(false);
-      expect(testState.calls).toEqual([]);
-      expect(document.activeElement).toBe(editor);
-    },
-  );
+    expect(event.defaultPrevented).toBe(true);
+    expect(testState.calls).toEqual([command]);
+    expect(document.activeElement).toBe(editor);
+  });
 
   it("runs the sidebar shortcut while the composer has focus", () => {
     const editor = renderComposer();

--- a/apps/app/src/lib/app-keybindings.test.ts
+++ b/apps/app/src/lib/app-keybindings.test.ts
@@ -11,7 +11,6 @@ import {
   formatAppShortcut,
   formatAppShortcutAria,
   isEditableKeyboardTarget,
-  isNativeEditableKeyEvent,
   matchesAppCommandContext,
 } from "./app-keybindings";
 
@@ -180,56 +179,6 @@ describe("app keybindings", () => {
     expect(isEditableKeyboardTarget(document.createElement("button"))).toBe(
       false,
     );
-  });
-
-  it("recognizes native navigation and deletion keys in editable controls", () => {
-    const editor = document.createElement("div");
-    editor.setAttribute("contenteditable", "true");
-    document.body.append(editor);
-
-    for (const key of [
-      "ArrowDown",
-      "ArrowLeft",
-      "ArrowRight",
-      "ArrowUp",
-      "Backspace",
-      "Delete",
-      "End",
-      "Home",
-      "PageDown",
-      "PageUp",
-    ]) {
-      const event = new KeyboardEvent("keydown", {
-        altKey: true,
-        bubbles: true,
-        ctrlKey: true,
-        key,
-        metaKey: true,
-        shiftKey: true,
-      });
-      editor.dispatchEvent(event);
-      expect(isNativeEditableKeyEvent(event), key).toBe(true);
-    }
-
-    const formattingEvent = new KeyboardEvent("keydown", {
-      bubbles: true,
-      key: "B",
-      metaKey: true,
-      shiftKey: true,
-    });
-    editor.dispatchEvent(formattingEvent);
-    expect(isNativeEditableKeyEvent(formattingEvent)).toBe(false);
-
-    const outsideEvent = new KeyboardEvent("keydown", {
-      bubbles: true,
-      key: "ArrowUp",
-      metaKey: true,
-      shiftKey: true,
-    });
-    document.body.dispatchEvent(outsideEvent);
-    expect(isNativeEditableKeyEvent(outsideEvent)).toBe(false);
-
-    editor.remove();
   });
 
   it("formats platform-specific shortcut labels", () => {

--- a/apps/app/src/lib/app-keybindings.ts
+++ b/apps/app/src/lib/app-keybindings.ts
@@ -6,19 +6,6 @@ export interface AppShortcutPresentation {
   label: string;
 }
 
-const NATIVE_EDITING_KEYS = new Set([
-  "ArrowDown",
-  "ArrowLeft",
-  "ArrowRight",
-  "ArrowUp",
-  "Backspace",
-  "Delete",
-  "End",
-  "Home",
-  "PageDown",
-  "PageUp",
-]);
-
 export function isEditableKeyboardTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) {
     return false;
@@ -32,18 +19,6 @@ export function isEditableKeyboardTarget(target: EventTarget | null): boolean {
   }
   return (
     target.closest('[contenteditable]:not([contenteditable="false"])') !== null
-  );
-}
-
-/**
- * Navigation and deletion keys keep their native editable-control behavior
- * regardless of modifiers. This covers each platform's character, word,
- * line, and document movement/selection chords without tying arbitration to
- * any configurable app shortcut.
- */
-export function isNativeEditableKeyEvent(event: KeyboardEvent): boolean {
-  return (
-    isEditableKeyboardTarget(event.target) && NATIVE_EDITING_KEYS.has(event.key)
   );
 }
 


### PR DESCRIPTION
Fixes #1476

## Summary

- Revert #1403's global exemption for navigation and deletion keys from editable controls.
- Restore the normal keybinding contract: a configured, context-matching command runs from the focused composer; unmatched or unhandled events remain native.
- Add regression coverage for previous/next thread bindings in a focused textarea and the real prompt editor.

The conflicting shipped arrow-key defaults are intentionally handled in a separate follow-up PR so this behavioral fix stays independent.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app --force` — 340 files, 2,640 tests passed
- `pnpm exec turbo run lint --filter=@bb/app` — 0 errors (149 existing warnings)

> AGENT GENERATED: by GPT-5 Codex