### PR TITLE
Use bracket defaults for thread navigation

### DIFF
--- a/apps/server/src/services/system/app-keybindings.ts
+++ b/apps/server/src/services/system/app-keybindings.ts
@@ -123,6 +123,11 @@ const pickerOpenOnly = {
   none: [],
 } as const;
 
+const webMainWithoutModal = {
+  all: ["mainSurface", "webSurface"],
+  none: ["modalOpen"],
+} as const;
+
 const splitWithoutModal = {
   all: ["mainSurface", "splitActive"],
   none: ["modalOpen"],
@@ -141,12 +146,22 @@ export const DEFAULT_APP_KEYBINDINGS: AppDefaultKeybindings = [
   unassignedBinding("thread.archive", mainWithoutModal),
   binding("settings.open", ",", { mod: true }, mainWithoutModal),
   binding("sidebar.toggle", "\\", { mod: true }, mainWithoutModal),
-  binding("thread.previous", "ArrowUp", { mod: true, shift: true }, mainWithoutModal),
+  binding(
+    "thread.previous",
+    "[",
+    { control: true, shift: true },
+    webMainWithoutModal,
+  ),
   binding("thread.previous", "[", { mod: true, shift: true }, {
     ...mainWithoutModal,
     desktopOnly: true,
   }),
-  binding("thread.next", "ArrowDown", { mod: true, shift: true }, mainWithoutModal),
+  binding(
+    "thread.next",
+    "]",
+    { control: true, shift: true },
+    webMainWithoutModal,
+  ),
   binding("thread.next", "]", { mod: true, shift: true }, {
     ...mainWithoutModal,
     desktopOnly: true,

--- a/apps/server/test/system/app-keybindings.test.ts
+++ b/apps/server/test/system/app-keybindings.test.ts
@@ -60,10 +60,31 @@ describe("app keybindings", () => {
           .map((binding) => ({
             desktopOnly: binding.desktopOnly,
             key: binding.shortcut.key,
+            mod: binding.shortcut.mod,
+            control: binding.shortcut.control,
+            shift: binding.shortcut.shift,
+            when: binding.when,
           })),
       ).toEqual([
-        { desktopOnly: false, key: "ArrowUp" },
-        { desktopOnly: true, key: "[" },
+        {
+          desktopOnly: false,
+          key: "[",
+          mod: false,
+          control: true,
+          shift: true,
+          when: {
+            all: ["mainSurface", "webSurface"],
+            none: ["modalOpen"],
+          },
+        },
+        {
+          desktopOnly: true,
+          key: "[",
+          mod: true,
+          control: false,
+          shift: true,
+          when: { all: ["mainSurface"], none: ["modalOpen"] },
+        },
       ]);
       expect(
         assignedDefaultKeybindings
@@ -71,10 +92,31 @@ describe("app keybindings", () => {
           .map((binding) => ({
             desktopOnly: binding.desktopOnly,
             key: binding.shortcut.key,
+            mod: binding.shortcut.mod,
+            control: binding.shortcut.control,
+            shift: binding.shortcut.shift,
+            when: binding.when,
           })),
       ).toEqual([
-        { desktopOnly: false, key: "ArrowDown" },
-        { desktopOnly: true, key: "]" },
+        {
+          desktopOnly: false,
+          key: "]",
+          mod: false,
+          control: true,
+          shift: true,
+          when: {
+            all: ["mainSurface", "webSurface"],
+            none: ["modalOpen"],
+          },
+        },
+        {
+          desktopOnly: true,
+          key: "]",
+          mod: true,
+          control: false,
+          shift: true,
+          when: { all: ["mainSurface"], none: ["modalOpen"] },
+        },
       ]);
       expect(
         assignedDefaultKeybindings

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -184,7 +184,8 @@ before bb receives them.
 pane shortcuts follow Slack's browser-safe convention: web uses
 `Control+1…9` on macOS and `Ctrl+Shift+1…9` on Windows/Linux, while desktop
 uses `Mod+1…9`. The web aliases leave native browser `Mod+1…9` tab switching
-untouched.
+untouched. Previous and next thread use `Mod+Shift+[/]` on desktop and
+`Control+Shift+[/]` on the web.
 
 The "Show keyboard hints when holding CMD / Control" preference defaults
 to on. Set it with
@@ -197,7 +198,7 @@ delayed shortcut badges without disabling any shortcuts.
 | Threads   | Search threads                     | `Mod+K`                           | All clients              |
 | Threads   | Rename focused thread              | Unassigned                        | Thread view              |
 | Threads   | Archive focused thread             | Unassigned                        | Thread view              |
-| Threads   | Previous / next thread             | `Mod+Shift+[/]` / `Mod+Shift+↑/↓` | Desktop / web            |
+| Threads   | Previous / next thread             | Surface defaults above            | Desktop / web            |
 | Threads   | Open visible thread 1–9            | Platform defaults above           | Web / desktop            |
 | Layout    | Previous / next chat pane          | `Mod+Shift+[/]`                   | While split              |
 | Layout    | Focus chat pane 1–8                | Platform defaults above           | Split (web / desktop)    |
@@ -222,8 +223,9 @@ Cycle commands wrap in both directions. Reasoning cycles only through the
 current model's supported efforts in canonical low-to-high rank order, not the
 provider response order. The cycle shortcuts act only from the active composer
 or an open picker; unrelated editable controls retain their Option-composed
-character input. Navigation and deletion keys remain native in editable controls
-when assigned to an app command.
+character input. A configured app shortcut takes precedence in editable
+controls; when no matching command handles a chord, the control retains its
+native behavior.
 
 The desktop application menu uses the same resolved bindings for New Thread,
 New Window, New Tab, Close, and Settings. There is no separate menu shortcut


### PR DESCRIPTION
## Summary

- Change Previous Thread and Next Thread to `Mod+Shift+[` / `Mod+Shift+]` in desktop clients.
- Use explicit `Control+Shift+[` / `Control+Shift+]` on the web, including macOS, to avoid browser-owned Command shortcuts.
- Remove the shipped `Mod+Shift+ArrowUp/ArrowDown` defaults that conflict with native text selection.
- Document and test the client-specific default policy at the system-config boundary.
- Keep the shortcut documentation consistent with the configured-shortcut precedence restored by #1484.

This complements the merged #1484 behavior change. Existing user overrides remain unchanged.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/server`
- `pnpm exec turbo run test --filter=@bb/server --force` — 162 files, 1,468 tests passed
- `pnpm exec prettier --check apps/server/test/system/app-keybindings.test.ts`

> AGENT GENERATED: by GPT-5 Codex