### PR TITLE
Upgrade pinned GitHub Actions as one batch

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -16,19 +16,19 @@ runs:
   using: composite
   steps:
     - name: Set up pnpm
-      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       with:
         version: ${{ inputs.pnpm-version }}
         run_install: false
 
     - name: Set up Node.js
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
 
     - name: Cache Turbo task outputs
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .turbo/cache
         key: ${{ runner.os }}-node-${{ inputs.node-version }}-${{ inputs.cache-prefix }}-turbo-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,12 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: /
+    directories:
+      - /
+      - /.github/actions/setup-workspace
     schedule:
       interval: weekly
-
-  - package-ecosystem: github-actions
-    directory: /.github/actions/setup-workspace
-    schedule:
-      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -37,16 +37,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
@@ -164,7 +164,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Upload desktop workflow artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bb-desktop-macos-arm64-x64
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
@@ -92,7 +92,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace
@@ -124,7 +124,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup workspace
         uses: ./.github/actions/setup-workspace

--- a/.github/workflows/deploy-connect.yml
+++ b/.github/workflows/deploy-connect.yml
@@ -34,16 +34,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -33,22 +33,22 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: ${{ env.PNPM_VERSION }}
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
       - name: Cache Turbo task outputs
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .turbo/cache
           key: ${{ runner.os }}-node-${{ env.NODE_VERSION }}-web-turbo-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}

--- a/.github/workflows/publish-bb-app.yml
+++ b/.github/workflows/publish-bb-app.yml
@@ -59,16 +59,16 @@ jobs:
           exit 1
 
       - name: Checkout repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 9.15.0
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
@@ -232,16 +232,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 9.15.0
           run_install: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.x
           cache: pnpm
@@ -315,7 +315,7 @@ jobs:
         run: pnpm --dir apps/desktop run desktop:version-feed
 
       - name: Upload nightly desktop workflow artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bb-nightly-desktop-macos-arm64-x64-${{ steps.nightly_version.outputs.version }}
           retention-days: 14

--- a/.github/workflows/version-lockstep.yml
+++ b/.github/workflows/version-lockstep.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22.x
 


### PR DESCRIPTION
## Summary

- upgrade all pinned GitHub Actions consistently across workflows and the local composite action
- combine the two GitHub Actions update locations into one `directories:` entry
- add a wildcard Dependabot group so future action upgrades arrive in one PR

This replaces #1460, #1461, #1462, #1463, #1464, #1465, #1466, and #1467.

## SHA verification

All target tags were independently resolved against their upstream repositories:

| Action | Tag | Verified commit |
| --- | --- | --- |
| `actions/checkout` | `v7.0.1` | `3d3c42e5aac5ba805825da76410c181273ba90b1` |
| `pnpm/action-setup` | `v6.0.10` | `0977fd99725f1db4007ccb2928dbb4e90d06cc86` |
| `actions/upload-artifact` | `v7.0.1` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` |
| `actions/setup-node` | `v7.0.0` | `820762786026740c76f36085b0efc47a31fe5020` |
| `actions/cache` | `v6.1.0` | `55cc8345863c7cc4c66a329aec7e433d2d1c52a9` |

## Breaking-change review

- **`actions/setup-node` 4 → 7: safe.** v5 moved the action runtime to Node 24 and enabled automatic package-manager caching; v6 limited automatic caching to npm and removed `always-auth`; v7 removed the dummy `NODE_AUTH_TOKEN`. The cache consumers explicitly request `cache: pnpm`. The npm publish job intentionally has no `NODE_AUTH_TOKEN`, grants `id-token: write`, runs on a GitHub-hosted runner with Node 24, and upgrades npm to at least 11.5.1, so removing the dummy value preserves the trusted-publishing OIDC path. `publish-bb-app.yml` was not dispatched because its scheduled path performs a real publication.
- **`actions/checkout` 4 → 7: safe.** v5's Node 24 runtime requirement is satisfied by the GitHub-hosted runners. v6 moved persisted credentials out of the repository into runner temp, but `persist-credentials` remains enabled and the workflows do not inspect the old storage location. The defaults used here—no submodules and shallow fetch—remain compatible. v7's fork-PR guard does not affect these workflow triggers.
- **`actions/cache` 4 → 6: safe.** The starting v4.3.0 already used the cache service v2 migration. v5 moved to Node 24; v6 moved action internals to ESM; v6.1 improves read-only cache handling. Both call sites use explicit keys and ordered restore prefixes, with no dependency on changed internals.
- **`pnpm/action-setup` 4 → 6: safe.** v5 moved the action runtime to Node 24 and v6 added pnpm 11 support. Every call site explicitly requests pnpm 9.15.0, matching the root `packageManager`, and keeps `run_install: false`, so version inference and install behavior do not change.
- **`actions/upload-artifact` 4 → 7: safe.** Both consumers already start on v4.6.2, after v4's immutable artifact and hidden-file changes. Each job performs one upload with its own artifact name, so it does not rely on implicit same-name merging. v5/v6's Node 24 requirement is satisfied; v7's direct-upload behavior is opt-in through `archive: false`, which is not used.

The intended merge order is therefore one atomic merge of this PR; there are no held upgrades or version twins left split across PRs.

## Validation

- `pnpm exec prettier --check .github/dependabot.yml .github/actions/setup-workspace/action.yml .github/workflows/*.yml`
- Dependabot YAML parse and structural assertions for one update entry, both directories, and the `*` group
- `pnpm exec turbo run build typecheck lint --cache-dir=.turbo/cache --output-logs=new-only`
- `node apps/app/scripts/check-bundle-budget.mjs`
- all server tests: 1,468 passed
- all non-server Turbo test tasks: 54 passed
- `pnpm exec turbo run smoke:tarball --filter=bb-app --cache-dir=.turbo/cache --output-logs=new-only`

The first all-at-once local test run had one unrelated server test exceed its 15-second timeout under contention; the complete server shard passed when rerun alone. PR CI will exercise `ci.yml` and `version-lockstep.yml`. A safe `build-desktop.yml` branch dispatch will separately exercise the macOS setup and artifact-upload path. The publish, deploy, cache-restore, and credential-cleanup paths can only be fully proven by their native GitHub-hosted runs.

> AGENT GENERATED: by GPT-5
