### PR TITLE
Document relative pane shortcuts as unassigned

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -200,7 +200,7 @@ delayed shortcut badges without disabling any shortcuts.
 | Threads   | Archive focused thread             | Unassigned                        | Thread view              |
 | Threads   | Previous / next thread             | Surface defaults above            | Desktop / web            |
 | Threads   | Open visible thread 1–9            | Platform defaults above           | Web / desktop            |
-| Layout    | Previous / next chat pane          | `Mod+Shift+[/]`                   | While split              |
+| Layout    | Previous / next chat pane          | Unassigned                        | While split              |
 | Layout    | Focus chat pane 1–8                | Platform defaults above           | Split (web / desktop)    |
 | Layout    | Maximize / restore chat pane       | `Mod+Shift+E`                     | While split              |
 | Layout    | Close focused chat pane            | `Mod+Shift+X`                     | While split              |


### PR DESCRIPTION
## Summary

- update the keyboard shortcut table to show previous and next chat pane as unassigned
- follow up on the post-merge review comment from #1488

## Testing

- Not run (documentation-only change)

> AGENT GENERATED: by GPT-5 Codex