### PR TITLE
Preserve machine display names across daemon reconnects

### DIFF
--- a/apps/server/test/public/public-host-management.test.ts
+++ b/apps/server/test/public/public-host-management.test.ts
@@ -9,7 +9,10 @@ import {
   createHostJoinCodeResponseSchema,
   type CreateHostJoinCodeResponse,
 } from "@bb/server-contract";
-import { HOST_DAEMON_PROTOCOL_VERSION } from "@bb/host-daemon-contract";
+import {
+  HOST_DAEMON_PROTOCOL_VERSION,
+  hostDaemonSessionOpenResponseSchema,
+} from "@bb/host-daemon-contract";
 import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { readJson } from "../helpers/json.js";
@@ -46,7 +49,7 @@ function requestJoinCode(app: {
 }
 
 describe("public host management", () => {
-  it("mints a join code that enrolls through the existing internal route", async () => {
+  it("preserves a renamed host across a daemon reconnect", async () => {
     await withTestHarness(async (harness) => {
       const issued = await createJoinCode(harness.app);
       expect(issued.joinCode).toMatch(/^bbde_/u);
@@ -82,6 +85,20 @@ describe("public host management", () => {
         type: "persistent",
       });
 
+      const renameResponse = await harness.app.request(
+        `${API}/hosts/${issued.hostId}`,
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ name: "My Build Box" }),
+        },
+      );
+      expect(renameResponse.status).toBe(200);
+      expect(await readJson(renameResponse)).toMatchObject({
+        id: issued.hostId,
+        name: "My Build Box",
+      });
+
       const sessionResponse = await harness.app.request(
         "/internal/session/open",
         {
@@ -106,9 +123,25 @@ describe("public host management", () => {
         },
       );
       expect(sessionResponse.status).toBe(201);
-      expect(getHost(harness.db, issued.hostId)?.connectMachineId).toBe(
-        "machine-cloud-2",
+      const openedSession = hostDaemonSessionOpenResponseSchema.parse(
+        await readJson(sessionResponse),
       );
+      expect(getHost(harness.db, issued.hostId)).toMatchObject({
+        connectMachineId: "machine-cloud-2",
+        name: "My Build Box",
+      });
+      expect(
+        getSessionById(harness.db, { sessionId: openedSession.sessionId }),
+      ).toMatchObject({ hostName: "Build Machine" });
+
+      const publicHostResponse = await harness.app.request(
+        `${API}/hosts/${issued.hostId}`,
+      );
+      expect(publicHostResponse.status).toBe(200);
+      expect(await readJson(publicHostResponse)).toMatchObject({
+        id: issued.hostId,
+        name: "My Build Box",
+      });
     });
   });
 

--- a/packages/db/src/data/hosts.ts
+++ b/packages/db/src/data/hosts.ts
@@ -10,6 +10,10 @@ type HostWriteConnection = DbConnection | DbTransaction;
 export interface UpsertHostInput {
   connectMachineId?: string | null;
   id?: string;
+  /**
+   * Seeds the display name for a new host. Existing display names are
+   * preserved because daemon-reported names are recorded on session rows.
+   */
   name: string;
   type: HostType;
   destroyedAt?: number | null;
@@ -67,7 +71,6 @@ export function upsertHost(
     const updated = db
       .update(hosts)
       .set({
-        name: input.name,
         type: input.type,
         connectMachineId:
           input.connectMachineId !== undefined

--- a/packages/db/test/data/hosts.test.ts
+++ b/packages/db/test/data/hosts.test.ts
@@ -35,9 +35,10 @@ describe("hosts", () => {
     expect(host.lastSeenAt).toBeNull();
   });
 
-  it("upsert with same ID preserves lastSeenAt", () => {
+  it("upsert with same ID preserves the display name and lastSeenAt", () => {
     const { db } = setup();
     const host1 = upsertHost(db, noopNotifier, {
+      connectMachineId: "machine-1",
       name: "My Machine",
       type: "persistent",
     });
@@ -45,13 +46,15 @@ describe("hosts", () => {
     markHostSeen(db, host1.id, 1_000);
 
     const host2 = upsertHost(db, noopNotifier, {
+      connectMachineId: "machine-2",
       id: host1.id,
-      name: "Updated Name",
+      name: "Updated Reported Name",
       type: "persistent",
     });
 
     expect(host2.id).toBe(host1.id);
-    expect(host2.name).toBe("Updated Name");
+    expect(host2.name).toBe("My Machine");
+    expect(host2.connectMachineId).toBe("machine-2");
     expect(host2.lastSeenAt).toBe(1_000);
   });
 
@@ -72,7 +75,7 @@ describe("hosts", () => {
     expect(updated).toMatchObject({
       destroyedAt: 123,
       id: host.id,
-      name: "Disconnected Host Renamed",
+      name: "Disconnected Host",
       type: "persistent",
     });
   });


### PR DESCRIPTION
## Summary

- preserve `hosts.name` when an existing daemon enrolls or opens a session
- continue to initialize new hosts from the daemon-reported hostname
- keep each reported hostname in `host_daemon_sessions.host_name`
- add database and server regression coverage for rename followed by reconnect

## Verification

- `pnpm exec turbo run test --filter=@bb/db --force`
- `pnpm exec turbo run test --filter=@bb/server --force`
- `pnpm exec turbo run typecheck --filter=@bb/db --filter=@bb/server`
- `pnpm exec prettier packages/db/src/data/hosts.ts packages/db/test/data/hosts.test.ts apps/server/test/public/public-host-management.test.ts --check`
- `git diff --check`
- isolated live QA: rename, daemon reconnect, server restart, and session hostname inspection

> AGENT GENERATED: by GPT-5.4