### PR TITLE
Preserve parent assistant state across nested turns

### DIFF
--- a/packages/thread-view/src/assistant-stream-projection.ts
+++ b/packages/thread-view/src/assistant-stream-projection.ts
@@ -33,6 +33,7 @@ interface FlushBufferedTextMessagesArgs {
   buffers: Map<string, VisibleTextBuffer>;
   finalizedKeys: Set<string>;
   openMessages: Map<string, EventProjectionAssistantTextMessage>;
+  shouldFlush: (message: EventProjectionAssistantTextMessage) => boolean;
   state: AssistantStreamProjectionState;
   visibleKeys: Set<string>;
 }
@@ -67,12 +68,14 @@ export function syncBufferedTextMessage(
 }
 
 function flushBufferedTextMessages(args: FlushBufferedTextMessagesArgs): void {
-  const pendingMessages = Array.from(args.openMessages.entries()).sort(
-    (left, right) =>
-      left[1].sourceSeqStart - right[1].sourceSeqStart ||
-      left[1].sourceSeqEnd - right[1].sourceSeqEnd ||
-      left[1].createdAt - right[1].createdAt,
-  );
+  const pendingMessages = Array.from(args.openMessages.entries())
+    .filter(([, message]) => args.shouldFlush(message))
+    .sort(
+      (left, right) =>
+        left[1].sourceSeqStart - right[1].sourceSeqStart ||
+        left[1].sourceSeqEnd - right[1].sourceSeqEnd ||
+        left[1].createdAt - right[1].createdAt,
+    );
 
   for (const [messageKey, message] of pendingMessages) {
     const buffer = args.buffers.get(messageKey);
@@ -90,11 +93,10 @@ function flushBufferedTextMessages(args: FlushBufferedTextMessagesArgs): void {
       message.status = "completed";
     }
     args.finalizedKeys.add(messageKey);
+    args.openMessages.delete(messageKey);
+    args.buffers.delete(messageKey);
+    args.visibleKeys.delete(messageKey);
   }
-
-  args.openMessages.clear();
-  args.buffers.clear();
-  args.visibleKeys.clear();
 }
 
 export function flushBufferedAssistantMessages(
@@ -104,6 +106,22 @@ export function flushBufferedAssistantMessages(
     buffers: state.assistantTextBuffersByKey,
     finalizedKeys: state.finalizedAssistantMessageKeys,
     openMessages: state.openAssistantMessagesByKey,
+    shouldFlush: () => true,
+    state,
+    visibleKeys: state.visibleAssistantMessageKeys,
+  });
+}
+
+export function flushBufferedAssistantMessagesForTurn(
+  state: AssistantStreamProjectionState,
+  turnId: string,
+): void {
+  flushBufferedTextMessages({
+    buffers: state.assistantTextBuffersByKey,
+    finalizedKeys: state.finalizedAssistantMessageKeys,
+    openMessages: state.openAssistantMessagesByKey,
+    shouldFlush: (message) =>
+      message.scope.kind === "turn" && message.scope.turnId === turnId,
     state,
     visibleKeys: state.visibleAssistantMessageKeys,
   });

--- a/packages/thread-view/src/build-event-projection.ts
+++ b/packages/thread-view/src/build-event-projection.ts
@@ -84,6 +84,7 @@ import {
   createProjectionState,
   finalizeProjectionState,
   flushProjectionBufferedOutputs,
+  flushProjectionBufferedOutputsForTurn,
   onThreadInterrupted,
   onTurnCompleted,
   onTurnStarted,
@@ -614,22 +615,24 @@ function buildFlatProjectionData(
 
     if (isTerminalBufferedTextFlushEvent(eventType)) {
       if (decoded.type === "turn/completed") {
+        const completedTurnId = requireThreadEventScopeTurnId({
+          type: decoded.type,
+          scope: decoded.scope,
+        });
         onTurnCompleted({
           completedAt: meta.createdAt,
           state,
-          turnId: requireThreadEventScopeTurnId({
-            type: decoded.type,
-            scope: decoded.scope,
-          }),
+          turnId: completedTurnId,
           status: decoded.status,
         });
+        flushProjectionBufferedOutputsForTurn(state, completedTurnId);
       } else {
         onThreadInterrupted({
           completedAt: meta.createdAt,
           state,
         });
+        flushProjectionBufferedOutputs(state);
       }
-      flushProjectionBufferedOutputs(state);
     }
 
     if (decoded.type === "turn/input/accepted") {

--- a/packages/thread-view/src/build-event-projection.ts
+++ b/packages/thread-view/src/build-event-projection.ts
@@ -84,7 +84,7 @@ import {
   createProjectionState,
   finalizeProjectionState,
   flushProjectionBufferedOutputs,
-  flushProjectionBufferedOutputsForTurn,
+  flushProjectionBufferedOutputsAfterTurnCompleted,
   onThreadInterrupted,
   onTurnCompleted,
   onTurnStarted,
@@ -625,7 +625,10 @@ function buildFlatProjectionData(
           turnId: completedTurnId,
           status: decoded.status,
         });
-        flushProjectionBufferedOutputsForTurn(state, completedTurnId);
+        flushProjectionBufferedOutputsAfterTurnCompleted(
+          state,
+          completedTurnId,
+        );
       } else {
         onThreadInterrupted({
           completedAt: meta.createdAt,

--- a/packages/thread-view/src/event-projection-state.ts
+++ b/packages/thread-view/src/event-projection-state.ts
@@ -6,6 +6,7 @@ import type {
 } from "./event-projection-types.js";
 import {
   flushBufferedAssistantMessages,
+  flushBufferedAssistantMessagesForTurn,
   type AssistantStreamProjectionState,
 } from "./assistant-stream-projection.js";
 import {
@@ -15,18 +16,21 @@ import {
 import {
   flushActiveToolCell,
   flushPendingToolActivityOutput,
+  flushPendingToolActivityOutputForTurn,
   interruptPendingToolActivity,
 } from "./tool-activity-projection.js";
 import { createToolActivityState } from "./tool-activity-projection.js";
 import {
   createOperationProjectionState,
   flushPendingFileEditOutput,
+  flushPendingFileEditOutputForTurn,
   type CompactionTurnFinalizationStatus,
   type OperationProjectionState,
 } from "./operation-projection.js";
 import {
   createReasoningProjectionState,
   finalizeOpenReasoningLifecycles,
+  finalizeOpenReasoningLifecyclesForTurn,
   type ReasoningProjectionState,
 } from "./reasoning-lifecycle-projection.js";
 import { shouldPreservePendingMessages } from "./user-message-parsing.js";
@@ -72,7 +76,8 @@ interface ThreadInterruptedArgs {
 }
 
 export interface ProjectionState
-  extends AssistantStreamProjectionState,
+  extends
+    AssistantStreamProjectionState,
     OperationProjectionState,
     ReasoningProjectionState,
     BackgroundTaskProjectionState {
@@ -137,7 +142,7 @@ export function onTurnCompleted(args: CompleteTurnArgs): void {
       status: "interrupted",
     });
   }
-  finalizeOpenReasoningLifecycles(args.state);
+  finalizeOpenReasoningLifecyclesForTurn(args.state, args.turnId);
 }
 
 export function onThreadInterrupted(args: ThreadInterruptedArgs): void {
@@ -156,6 +161,15 @@ export function flushProjectionBufferedOutputs(state: ProjectionState): void {
   flushBufferedAssistantMessages(state);
   flushPendingToolActivityOutput(state);
   flushPendingFileEditOutput(state);
+}
+
+export function flushProjectionBufferedOutputsForTurn(
+  state: ProjectionState,
+  turnId: string,
+): void {
+  flushBufferedAssistantMessagesForTurn(state, turnId);
+  flushPendingToolActivityOutputForTurn(state, turnId);
+  flushPendingFileEditOutputForTurn(state, turnId);
 }
 
 function finalizePendingMessages(args: FinalizeProjectionMessagesArgs): void {

--- a/packages/thread-view/src/event-projection-state.ts
+++ b/packages/thread-view/src/event-projection-state.ts
@@ -16,14 +16,12 @@ import {
 import {
   flushActiveToolCell,
   flushPendingToolActivityOutput,
-  flushPendingToolActivityOutputForTurn,
   interruptPendingToolActivity,
 } from "./tool-activity-projection.js";
 import { createToolActivityState } from "./tool-activity-projection.js";
 import {
   createOperationProjectionState,
   flushPendingFileEditOutput,
-  flushPendingFileEditOutputForTurn,
   type CompactionTurnFinalizationStatus,
   type OperationProjectionState,
 } from "./operation-projection.js";
@@ -163,13 +161,16 @@ export function flushProjectionBufferedOutputs(state: ProjectionState): void {
   flushPendingFileEditOutput(state);
 }
 
-export function flushProjectionBufferedOutputsForTurn(
+export function flushProjectionBufferedOutputsAfterTurnCompleted(
   state: ProjectionState,
   turnId: string,
 ): void {
   flushBufferedAssistantMessagesForTurn(state, turnId);
-  flushPendingToolActivityOutputForTurn(state, turnId);
-  flushPendingFileEditOutputForTurn(state, turnId);
+  // Tool and file-edit buffers predate turn-scoped assistant buffering. Their
+  // call identity is not uniformly scope-qualified, so retain the established
+  // global flush behavior until that state is redesigned end to end.
+  flushPendingToolActivityOutput(state);
+  flushPendingFileEditOutput(state);
 }
 
 function finalizePendingMessages(args: FinalizeProjectionMessagesArgs): void {

--- a/packages/thread-view/src/operation-projection.ts
+++ b/packages/thread-view/src/operation-projection.ts
@@ -365,24 +365,6 @@ function isTerminalFileEditStatus(
 export function flushPendingFileEditOutput(
   state: OperationProjectionState,
 ): void {
-  flushPendingFileEditOutputWhere(state, () => true);
-}
-
-export function flushPendingFileEditOutputForTurn(
-  state: OperationProjectionState,
-  turnId: string,
-): void {
-  flushPendingFileEditOutputWhere(
-    state,
-    (fileEdit) =>
-      fileEdit.scope.kind === "turn" && fileEdit.scope.turnId === turnId,
-  );
-}
-
-function flushPendingFileEditOutputWhere(
-  state: OperationProjectionState,
-  shouldFlush: (fileEdit: EventProjectionFileEditMessage) => boolean,
-): void {
   // Rows for one call id can sit in different scopes, and each scope owns its
   // own output buffer, so resolve the buffer from the row's own scope. Each
   // buffer flushes once, and every row of that scope then takes its text.
@@ -392,9 +374,6 @@ function flushPendingFileEditOutputWhere(
   >();
   for (const [callId, fileEdits] of state.fileEditsByCallId.entries()) {
     for (const fileEdit of fileEdits) {
-      if (!shouldFlush(fileEdit)) {
-        continue;
-      }
       const scopedCallKey = scopedFileEditCallKey(callId, fileEdit);
       let flushedBuffer = flushedBufferByScopedCallKey.get(scopedCallKey);
       if (flushedBuffer === undefined) {

--- a/packages/thread-view/src/operation-projection.ts
+++ b/packages/thread-view/src/operation-projection.ts
@@ -365,6 +365,24 @@ function isTerminalFileEditStatus(
 export function flushPendingFileEditOutput(
   state: OperationProjectionState,
 ): void {
+  flushPendingFileEditOutputWhere(state, () => true);
+}
+
+export function flushPendingFileEditOutputForTurn(
+  state: OperationProjectionState,
+  turnId: string,
+): void {
+  flushPendingFileEditOutputWhere(
+    state,
+    (fileEdit) =>
+      fileEdit.scope.kind === "turn" && fileEdit.scope.turnId === turnId,
+  );
+}
+
+function flushPendingFileEditOutputWhere(
+  state: OperationProjectionState,
+  shouldFlush: (fileEdit: EventProjectionFileEditMessage) => boolean,
+): void {
   // Rows for one call id can sit in different scopes, and each scope owns its
   // own output buffer, so resolve the buffer from the row's own scope. Each
   // buffer flushes once, and every row of that scope then takes its text.
@@ -374,6 +392,9 @@ export function flushPendingFileEditOutput(
   >();
   for (const [callId, fileEdits] of state.fileEditsByCallId.entries()) {
     for (const fileEdit of fileEdits) {
+      if (!shouldFlush(fileEdit)) {
+        continue;
+      }
       const scopedCallKey = scopedFileEditCallKey(callId, fileEdit);
       let flushedBuffer = flushedBufferByScopedCallKey.get(scopedCallKey);
       if (flushedBuffer === undefined) {

--- a/packages/thread-view/src/reasoning-lifecycle-projection.ts
+++ b/packages/thread-view/src/reasoning-lifecycle-projection.ts
@@ -33,8 +33,7 @@ export interface ReasoningProjectionState {
 }
 
 interface ReasoningLifecycleHostState
-  extends ReasoningProjectionState,
-    ReasoningTurnLifecycleState {}
+  extends ReasoningProjectionState, ReasoningTurnLifecycleState {}
 
 interface UpsertReasoningLifecycleArgs {
   identity: BufferedTextInstanceIdentity | null;
@@ -171,6 +170,19 @@ export function finalizeOpenReasoningLifecycles(
     state.finalizedReasoningKeys.add(messageKey);
   }
   state.openReasoningLifecyclesByKey.clear();
+}
+
+export function finalizeOpenReasoningLifecyclesForTurn(
+  state: ReasoningProjectionState,
+  turnId: string,
+): void {
+  for (const [messageKey, lifecycle] of state.openReasoningLifecyclesByKey) {
+    if (lifecycle.turnId !== turnId) {
+      continue;
+    }
+    state.finalizedReasoningKeys.add(messageKey);
+    state.openReasoningLifecyclesByKey.delete(messageKey);
+  }
 }
 
 export function getReasoningTextBuffer(

--- a/packages/thread-view/src/tool-activity-projection.ts
+++ b/packages/thread-view/src/tool-activity-projection.ts
@@ -812,27 +812,7 @@ export function flushToolActivityBeforeNonToolMessage(
 export function flushPendingToolActivityOutput(
   state: ToolActivityProjectionState,
 ): void {
-  flushPendingToolActivityOutputWhere(state, () => true);
-}
-
-export function flushPendingToolActivityOutputForTurn(
-  state: ToolActivityProjectionState,
-  turnId: string,
-): void {
-  flushPendingToolActivityOutputWhere(
-    state,
-    (call) => call.scope.kind === "turn" && call.scope.turnId === turnId,
-  );
-}
-
-function flushPendingToolActivityOutputWhere(
-  state: ToolActivityProjectionState,
-  shouldFlush: (call: RunningExecCall) => boolean,
-): void {
   for (const call of state.toolActivity.runningCallsById.values()) {
-    if (!shouldFlush(call)) {
-      continue;
-    }
     if (!flushVisibleTextBuffer(call.outputBuffer)) {
       continue;
     }

--- a/packages/thread-view/src/tool-activity-projection.ts
+++ b/packages/thread-view/src/tool-activity-projection.ts
@@ -335,7 +335,9 @@ function createRunningExecCall(
         kind: "tool-call",
         toolName: incoming.toolName ?? null,
         toolArgs: incoming.toolArgs ?? null,
-        ...(incoming.statusLabels ? { statusLabels: incoming.statusLabels } : {}),
+        ...(incoming.statusLabels
+          ? { statusLabels: incoming.statusLabels }
+          : {}),
         parsedIntents: incoming.parsedIntents ?? [],
         approvalStatus: incoming.approvalStatus ?? null,
       };
@@ -810,7 +812,27 @@ export function flushToolActivityBeforeNonToolMessage(
 export function flushPendingToolActivityOutput(
   state: ToolActivityProjectionState,
 ): void {
+  flushPendingToolActivityOutputWhere(state, () => true);
+}
+
+export function flushPendingToolActivityOutputForTurn(
+  state: ToolActivityProjectionState,
+  turnId: string,
+): void {
+  flushPendingToolActivityOutputWhere(
+    state,
+    (call) => call.scope.kind === "turn" && call.scope.turnId === turnId,
+  );
+}
+
+function flushPendingToolActivityOutputWhere(
+  state: ToolActivityProjectionState,
+  shouldFlush: (call: RunningExecCall) => boolean,
+): void {
   for (const call of state.toolActivity.runningCallsById.values()) {
+    if (!shouldFlush(call)) {
+      continue;
+    }
     if (!flushVisibleTextBuffer(call.outputBuffer)) {
       continue;
     }

--- a/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
+++ b/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
@@ -1331,6 +1331,64 @@ describe("timeline CLI rendering snapshots", () => {
     ).toBe(false);
   });
 
+  it("preserves a root assistant stream when a nested turn completes first", () => {
+    const event = createTimelineEventFactory({
+      providerThreadId: "root-provider",
+      threadId: "thread-1",
+      turnId: "root-turn",
+    });
+    const timeline = renderIdleTimeline([
+      event.turnStarted(),
+      event.toolCallStarted({
+        itemId: "delegation-1",
+        tool: "spawnAgent",
+        arguments: {
+          prompt: "Research the issue",
+          receiverThreadIds: ["child-provider"],
+        },
+      }),
+      event.turnStarted({
+        parentToolCallId: "delegation-1",
+        turnId: "child-turn",
+      }),
+      event.assistantDelta({
+        delta: "I",
+        itemId: "root-assistant",
+      }),
+      event.assistantCompleted({
+        itemId: "child-assistant",
+        text: "Child research complete.",
+        turnId: "child-turn",
+      }),
+      event.turnCompleted({ turnId: "child-turn" }),
+      event.toolCallCompleted({
+        itemId: "delegation-1",
+        tool: "spawnAgent",
+        arguments: {
+          prompt: "Research the issue",
+          receiverThreadIds: ["child-provider"],
+        },
+      }),
+      event.assistantCompleted({
+        itemId: "root-assistant",
+        text: "I recommend applying the focused fix.",
+      }),
+      event.turnCompleted(),
+    ]);
+
+    const rootAssistantRows = timeline.rows.filter(
+      (row) =>
+        row.kind === "conversation" &&
+        row.role === "assistant" &&
+        row.turnId === "root-turn",
+    );
+    expect(rootAssistantRows).toEqual([
+      expect.objectContaining({
+        text: "I recommend applying the focused fix.",
+      }),
+    ]);
+  });
+
   it("does not attach later root turns to Claude receiver-thread delegations", () => {
     const event = createTimelineEventFactory({
       providerThreadId: "root-provider",

--- a/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
+++ b/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
@@ -1389,6 +1389,39 @@ describe("timeline CLI rendering snapshots", () => {
     ]);
   });
 
+  it("keeps root reasoning active when a nested turn completes first", () => {
+    const event = createTimelineEventFactory({
+      providerThreadId: "root-provider",
+      threadId: "thread-1",
+      turnId: "root-turn",
+    });
+    const timeline = renderActiveTimeline([
+      event.turnStarted(),
+      event.toolCallStarted({
+        itemId: "delegation-1",
+        tool: "spawnAgent",
+        arguments: {
+          prompt: "Research the issue",
+          receiverThreadIds: ["child-provider"],
+        },
+      }),
+      event.turnStarted({
+        parentToolCallId: "delegation-1",
+        turnId: "child-turn",
+      }),
+      event.reasoningDelta({
+        delta: "Root is still thinking.\n",
+        itemId: "root-reasoning",
+      }),
+      event.turnCompleted({ turnId: "child-turn" }),
+    ]);
+
+    expect(timeline.projection.state.activeThinking).toMatchObject({
+      id: "root-reasoning",
+      text: "Root is still thinking.\n",
+    });
+  });
+
   it("does not attach later root turns to Claude receiver-thread delegations", () => {
     const event = createTimelineEventFactory({
       providerThreadId: "root-provider",


### PR DESCRIPTION
## Summary

- keep a nested turn completion from prematurely finalizing a root assistant stream
- finalize assistant and reasoning state only for the turn that completed
- retain the established global flush behavior for tool and file-edit output buffers
- add regressions for root assistant and reasoning activity surviving nested turn completion

## Reproduction

Before this change, a root assistant message that had streamed `I` was marked finalized when a nested turn completed. The later completed root item was ignored, leaving the timeline permanently projected as `I` even though the full final output was stored. Nested completion could likewise clear the root turn's active reasoning state.

Tool and file-edit buffers remain global because tool activity does not yet use scope-qualified identity end to end. Redesigning that state also needs to preserve late terminal events for background work that outlives its spawning turn, so it is intentionally outside this focused fix.

## Validation

- `pnpm exec turbo run test --filter=@bb/thread-view --force` (368 tests)
- `pnpm exec turbo run typecheck --filter=@bb/thread-view`
- `pnpm exec turbo run typecheck --filter=@bb/server`
- Prettier check and `git diff --check`

> AGENT GENERATED: by GPT-5