### PR TITLE
feat(acp): expose resolved service tier per prompt

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -368,6 +368,26 @@ model ids discovered through `modelCli`, not in an ACP `thought_level` option.
 Grok Build is also separate: it uses `reasoningCli` to launch
 `grok --reasoning-effort <level> agent stdio`.
 
+Every ACP `session/prompt` request includes bb's resolved service tier in ACP
+metadata:
+
+```json
+{
+  "_meta": {
+    "getbb.app/serviceTier": "default"
+  }
+}
+```
+
+The value is `default` or `fast`. bb resolves it separately for each prompt
+after applying the turn's execution-setting precedence. A tier change applies
+to the next prompt. Agents should apply the value only to that prompt and should
+not retain it as the next prompt's default. An explicit `default` clears Fast
+mode inherited from an earlier prompt. bb includes it for agents without
+`modelCli`, so agents can distinguish it from an older bb version that does not
+send this metadata. The value is a routing hint, not proof of provider support,
+entitlement, or authorization.
+
 When an agent declares `thought_level` with no options, bb hides the reasoning
 control. bb also hides it when none of the declared values map to a supported bb
 reasoning level. Omitting `thought_level` keeps the agent-managed reasoning

--- a/packages/agent-runtime/src/acp/adapter.test.ts
+++ b/packages/agent-runtime/src/acp/adapter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   createStandaloneBuiltinCompactCommandInput,
   DEFAULT_CLAUDE_CODE_MOCK_CLI_TRAFFIC_CONFIG,
+  type RuntimeThreadExecutionOptions,
   threadScope,
   turnScope,
 } from "@bb/domain";
@@ -16,8 +17,15 @@ const fullProviderExecutionContext = {
   permissionScope: "full",
   approvalReviewer: null,
   permissionEscalation: null,
+  serviceTier: "default",
   workflowsEnabled: false,
 } satisfies ProviderExecutionContext;
+
+const fullRuntimeExecutionOptions = {
+  ...fullProviderExecutionContext,
+  model: "composer-2.5",
+  reasoningLevel: "high",
+} satisfies RuntimeThreadExecutionOptions;
 
 type AcpProviderAdapter = ReturnType<typeof createAcpProviderAdapter>;
 
@@ -92,6 +100,25 @@ describe("acp adapter command plans", () => {
     ]);
   });
 
+  it("keeps tier-only changes live without CLI model selection", () => {
+    const adapter = createCompactingAdapter();
+    expect(
+      adapter.classifyExecutionSettingsChange({
+        current: fullRuntimeExecutionOptions,
+        next: { ...fullRuntimeExecutionOptions, serviceTier: "fast" },
+      }),
+    ).toBe("live");
+  });
+
+  it("restarts CLI model selection for tier-only changes", () => {
+    expect(
+      createAdapter().classifyExecutionSettingsChange({
+        current: fullRuntimeExecutionOptions,
+        next: { ...fullRuntimeExecutionOptions, serviceTier: "fast" },
+      }),
+    ).toBe("session");
+  });
+
   it("routes OpenCode's selected compact command through maintenance", () => {
     const adapter = createCompactingAdapter();
     expect(
@@ -106,7 +133,7 @@ describe("acp adapter command plans", () => {
     ).toEqual({
       kind: "request",
       method: "thread/compact",
-      params: { threadId: "sess-1" },
+      params: { threadId: "sess-1", serviceTier: "default" },
     });
   });
 
@@ -299,7 +326,7 @@ describe("acp adapter command plans", () => {
     ).toMatchObject({
       kind: "request",
       method: "turn/start",
-      params: { threadId: "sess-1" },
+      params: { threadId: "sess-1", serviceTier: "default" },
     });
     expect(
       adapter.buildCommandPlan({
@@ -314,7 +341,11 @@ describe("acp adapter command plans", () => {
     ).toMatchObject({
       kind: "request",
       method: "turn/steer",
-      params: { threadId: "sess-1", expectedTurnId: "turn-1" },
+      params: {
+        threadId: "sess-1",
+        expectedTurnId: "turn-1",
+        serviceTier: "default",
+      },
     });
     expect(
       adapter.buildCommandPlan({
@@ -583,6 +614,44 @@ describe("acp adapter model cli", () => {
         modelSelection: { modelId: "custom/strong", reasoningLevel: "high" },
       },
     });
+  });
+
+  it("forwards Fast mode on prompts for custom agents without modelCli", () => {
+    const adapter = createAcpProviderAdapter({
+      profile: {
+        providerId: "acp-custom",
+        displayName: "Custom ACP",
+        agentCommand: { command: "custom-acp", args: ["serve"] },
+      },
+      additionalWorkspaceWriteRoots: [],
+    });
+
+    expect(
+      adapter.buildCommandPlan({
+        type: "turn/start",
+        threadId: "thread-1",
+        providerThreadId: "session-1",
+        input: [promptTextInput({ text: "hi" })],
+        clientRequestId: "creq_23456789af",
+        options: { ...fullProviderExecutionContext, serviceTier: "fast" },
+      }),
+    ).toMatchObject({
+      method: "turn/start",
+      params: { serviceTier: "fast" },
+    });
+  });
+
+  it("rejects prompts without a resolved service tier", () => {
+    expect(() =>
+      createAdapter().buildCommandPlan({
+        type: "turn/start",
+        threadId: "thread-1",
+        providerThreadId: "session-1",
+        input: [promptTextInput({ text: "hi" })],
+        clientRequestId: "creq_23456789ag",
+        options: { ...fullProviderExecutionContext, serviceTier: undefined },
+      }),
+    ).toThrow("ACP prompts require a resolved service tier");
   });
 
   it("uses ACP-native selection for CLI-discovered models without a select flag", () => {

--- a/packages/agent-runtime/src/acp/adapter.ts
+++ b/packages/agent-runtime/src/acp/adapter.ts
@@ -16,6 +16,7 @@ import {
 } from "@bb/agent-providers";
 import type {
   PendingInteractionApprovalDecision,
+  ServiceTier,
   ThreadEvent,
   ThreadEventItem,
   ThreadEventItemStatus,
@@ -31,9 +32,11 @@ import {
 import { z } from "zod";
 import type {
   AdapterCommand,
+  ClassifyProviderExecutionSettingsChangeArgs,
   DecodedInteractiveRequest,
   ProviderAdapter,
   ProviderExecutionContext,
+  ProviderExecutionSettingsChange,
   ProviderTranslationContext,
 } from "../provider-adapter.js";
 import { flattenPromptInputGroups } from "../provider-adapter.js";
@@ -437,6 +440,15 @@ function requireAcpSkillRoot(
   return skillRoot;
 }
 
+function requireResolvedAcpServiceTier(
+  options: ProviderExecutionContext,
+): ServiceTier {
+  if (options.serviceTier === undefined) {
+    throw new Error("ACP prompts require a resolved service tier.");
+  }
+  return options.serviceTier;
+}
+
 function sanitizeAcpSkillDescription(description: string): string {
   const sanitized = description
     .replace(/[\r\n]+/gu, " ")
@@ -540,6 +552,31 @@ export function createAcpProviderAdapter(
       ...(profile.cwd !== undefined ? { cwd: profile.cwd } : {}),
       ...(profile.env !== undefined ? { envVars: profile.env } : {}),
     };
+  }
+
+  function usesCliModelSelection(options: { model?: string }): boolean {
+    return (
+      options.model !== undefined &&
+      options.model !== ACP_DEFAULT_MODEL_ID &&
+      buildModelListCommand() !== undefined &&
+      profile.modelCli?.selectFlag !== undefined
+    );
+  }
+
+  function classifyAcpExecutionSettingsChange(
+    args: ClassifyProviderExecutionSettingsChangeArgs,
+  ): ProviderExecutionSettingsChange {
+    const changeWithoutServiceTier = classifySessionExecutionSettingsChange({
+      current: args.current,
+      next: { ...args.next, serviceTier: args.current.serviceTier },
+    });
+    if (changeWithoutServiceTier !== "unchanged") {
+      return changeWithoutServiceTier;
+    }
+    if (args.current.serviceTier === args.next.serviceTier) {
+      return "unchanged";
+    }
+    return usesCliModelSelection(args.next) ? "session" : "live";
   }
 
   function buildReasoningCliParam(): Record<string, unknown> {
@@ -1330,10 +1367,11 @@ export function createAcpProviderAdapter(
   ): Record<string, unknown> {
     const model = options.model;
     const listCommand = buildModelListCommand();
+    const selectFlag = profile.modelCli?.selectFlag;
     if (!model || model === ACP_DEFAULT_MODEL_ID) {
       return {};
     }
-    if (!listCommand || !profile.modelCli?.selectFlag) {
+    if (!usesCliModelSelection(options) || !listCommand || !selectFlag) {
       return {
         modelSelection: {
           modelId: model,
@@ -1349,7 +1387,7 @@ export function createAcpProviderAdapter(
     return {
       modelSelection: {
         listCommand,
-        selectFlag: profile.modelCli.selectFlag,
+        selectFlag,
         model,
         ...(options.reasoningLevel !== undefined
           ? { reasoningLevel: options.reasoningLevel }
@@ -1368,7 +1406,7 @@ export function createAcpProviderAdapter(
       displayName: providerInfo.displayName,
       capabilities: providerInfo.capabilities,
       approvalRequestPolicy: "runtime",
-      classifyExecutionSettingsChange: classifySessionExecutionSettingsChange,
+      classifyExecutionSettingsChange: classifyAcpExecutionSettingsChange,
       process: {
         command: opts.bridgeNodeExecutablePath ?? "node",
         args: resolveBridgeProcessArgs({
@@ -1443,7 +1481,10 @@ export function createAcpProviderAdapter(
               return {
                 kind: "request",
                 method: "thread/compact",
-                params: { threadId: command.providerThreadId },
+                params: {
+                  threadId: command.providerThreadId,
+                  serviceTier: requireResolvedAcpServiceTier(command.options),
+                },
               };
             }
             return {
@@ -1452,6 +1493,7 @@ export function createAcpProviderAdapter(
               params: {
                 threadId: command.providerThreadId,
                 input,
+                serviceTier: requireResolvedAcpServiceTier(command.options),
               },
             };
           }
@@ -1466,6 +1508,7 @@ export function createAcpProviderAdapter(
                   command.input,
                   command.inputGroups,
                 ),
+                serviceTier: requireResolvedAcpServiceTier(command.options),
               },
             };
           case "thread/stop":

--- a/packages/agent-runtime/src/acp/bridge-protocol.ts
+++ b/packages/agent-runtime/src/acp/bridge-protocol.ts
@@ -151,17 +151,25 @@ export type AcpBridgeThreadResumeParams = z.infer<
 const acpBridgeTurnStartParamsSchema = z.object({
   threadId: z.string().min(1),
   input: z.array(promptInputSchema),
+  serviceTier: serviceTierSchema,
 });
 
 const acpBridgeTurnSteerParamsSchema = z.object({
   threadId: z.string().min(1),
   expectedTurnId: z.string().min(1),
   input: z.array(promptInputSchema),
+  serviceTier: serviceTierSchema,
 });
 
 const acpBridgeThreadIdParamsSchema = z.object({
   threadId: z.string().min(1),
 });
+
+const acpBridgeThreadCompactParamsSchema = acpBridgeThreadIdParamsSchema.extend(
+  {
+    serviceTier: serviceTierSchema,
+  },
+);
 
 export const acpBridgeCommandSchema = z.discriminatedUnion("method", [
   z.object({
@@ -196,7 +204,7 @@ export const acpBridgeCommandSchema = z.discriminatedUnion("method", [
   }),
   z.object({
     method: z.literal("thread/compact"),
-    params: acpBridgeThreadIdParamsSchema,
+    params: acpBridgeThreadCompactParamsSchema,
   }),
 ]);
 export type AcpBridgeCommand = z.infer<typeof acpBridgeCommandSchema>;

--- a/packages/agent-runtime/src/acp/bridge/bridge.test.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.test.ts
@@ -39,7 +39,14 @@ function requestId(): number {
 
 function sendRequest(method: string, params: object): number {
   const id = requestId();
-  handleLine(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+  const requestParams = ["turn/start", "turn/steer", "thread/compact"].includes(
+    method,
+  )
+    ? { serviceTier: "default", ...params }
+    : params;
+  handleLine(
+    JSON.stringify({ jsonrpc: "2.0", id, method, params: requestParams }),
+  );
   return id;
 }
 
@@ -1182,6 +1189,53 @@ describe("acp bridge", () => {
     expect(agentMessageTexts()).toContain("echo:hello there");
   });
 
+  it("sends each prompt's resolved service tier in ACP metadata", async () => {
+    const promptLog = join(workspaceDir, "prompt-meta-log.jsonl");
+    const { providerThreadId } = await startThread({
+      envVars: { FAKE_ACP_PROMPT_LOG: promptLog },
+    });
+
+    const defaultTurnId = sendRequest("turn/start", {
+      threadId: providerThreadId,
+      input: [{ type: "text", text: "default prompt", mentions: [] }],
+      serviceTier: "default",
+    });
+    await waitForResponse(defaultTurnId);
+    await waitFor(
+      () =>
+        notifications("acp/turn/completed").length === 1 ? true : undefined,
+      "default turn completion",
+    );
+
+    const fastTurnId = sendRequest("turn/start", {
+      threadId: providerThreadId,
+      input: [{ type: "text", text: "fast prompt", mentions: [] }],
+      serviceTier: "fast",
+    });
+    await waitForResponse(fastTurnId);
+    await waitFor(
+      () =>
+        notifications("acp/turn/completed").length === 2 ? true : undefined,
+      "fast turn completion",
+    );
+
+    expect(
+      readFileSync(promptLog, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line)),
+    ).toEqual([
+      {
+        text: "default prompt",
+        _meta: { "getbb.app/serviceTier": "default" },
+      },
+      {
+        text: "fast prompt",
+        _meta: { "getbb.app/serviceTier": "fast" },
+      },
+    ]);
+  });
+
   it("runs manual compaction as a provider-local maintenance prompt", async () => {
     const promptLog = join(workspaceDir, "prompt-log.jsonl");
     const { providerThreadId } = await startThread({
@@ -1191,6 +1245,7 @@ describe("acp bridge", () => {
 
     const compactId = sendRequest("thread/compact", {
       threadId: providerThreadId,
+      serviceTier: "fast",
     });
     const compactResponse = await waitForResponse(compactId);
     expect(compactResponse.error).toBeUndefined();
@@ -1215,7 +1270,12 @@ describe("acp bridge", () => {
         .trim()
         .split("\n")
         .map((line) => JSON.parse(line)),
-    ).toEqual(["/compact"]);
+    ).toEqual([
+      {
+        text: "/compact",
+        _meta: { "getbb.app/serviceTier": "fast" },
+      },
+    ]);
 
     const turnId = sendRequest("turn/start", {
       threadId: providerThreadId,
@@ -1648,7 +1708,10 @@ describe("acp bridge", () => {
   });
 
   it("delivers stacked steers on the same turn", async () => {
-    const { bbThreadId, providerThreadId } = await startThread();
+    const promptLog = join(workspaceDir, "stacked-steer-prompt-log.jsonl");
+    const { bbThreadId, providerThreadId } = await startThread({
+      envVars: { FAKE_ACP_PROMPT_LOG: promptLog },
+    });
     const turnId = sendRequest("turn/start", {
       threadId: providerThreadId,
       input: [{ type: "text", text: "hang", mentions: [] }],
@@ -1659,11 +1722,13 @@ describe("acp bridge", () => {
       threadId: providerThreadId,
       expectedTurnId: "turn-1",
       input: [{ type: "text", text: "first-steer", mentions: [] }],
+      serviceTier: "fast",
     });
     const secondSteerId = sendRequest("turn/steer", {
       threadId: providerThreadId,
       expectedTurnId: "turn-1",
       input: [{ type: "text", text: "second-steer", mentions: [] }],
+      serviceTier: "default",
     });
     await waitForResponse(firstSteerId);
     await waitForResponse(secondSteerId);
@@ -1677,6 +1742,25 @@ describe("acp bridge", () => {
     expect(agentMessageTexts()).toContain("echo:second-steer");
     expect(notifications("acp/turn/started")).toHaveLength(1);
     expect(notifications("acp/turn/completed")).toHaveLength(1);
+    expect(
+      readFileSync(promptLog, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line)),
+    ).toEqual([
+      {
+        text: "hang",
+        _meta: { "getbb.app/serviceTier": "default" },
+      },
+      {
+        text: "first-steer",
+        _meta: { "getbb.app/serviceTier": "fast" },
+      },
+      {
+        text: "second-steer",
+        _meta: { "getbb.app/serviceTier": "default" },
+      },
+    ]);
   });
 
   it("cancels a stacked steer prompt that also hangs", async () => {

--- a/packages/agent-runtime/src/acp/bridge/bridge.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.ts
@@ -23,6 +23,7 @@ import {
   type AvailableModel,
   type PromptInput,
   type ReasoningLevel,
+  type ServiceTier,
 } from "@bb/domain";
 import { buildEditDiff } from "../../shared/adapter-utils.js";
 import {
@@ -79,6 +80,7 @@ import {
   acpWriteTextFileParamsSchema,
   type AcpContentBlock,
   type AcpPermissionOption,
+  type AcpSessionPromptParams,
 } from "../wire.js";
 import {
   createAcpAgentConnection,
@@ -119,6 +121,11 @@ interface PendingAcpPermission {
   options: AcpPermissionOption[];
 }
 
+interface AcpQueuedPrompt {
+  input: PromptInput[];
+  serviceTier: ServiceTier;
+}
+
 interface AcpThreadSession {
   bbThreadId: string;
   providerThreadId: string;
@@ -129,7 +136,7 @@ interface AcpThreadSession {
   cwd: string;
   pendingInstructions: string | undefined;
   activePromptKind: "turn" | "compaction" | null;
-  queuedInputs: PromptInput[][];
+  queuedPrompts: AcpQueuedPrompt[];
   /** True while a session/prompt request is outstanding. */
   promptRequestPending: boolean;
   /** True after a steer sent session/cancel for the current prompt. */
@@ -1483,7 +1490,7 @@ async function startAgentSession(
     cwd: params.cwd,
     pendingInstructions: params.instructions,
     activePromptKind: null,
-    queuedInputs: [],
+    queuedPrompts: [],
     promptRequestPending: false,
     cancelRequested: false,
     loading: false,
@@ -1612,7 +1619,7 @@ async function stopSession(session: AcpThreadSession): Promise<void> {
     return;
   }
   session.stopping = true;
-  session.queuedInputs = [];
+  session.queuedPrompts = [];
   cancelPendingPermissions(session);
 
   if (session.activePromptKind !== null && !session.connection.exited) {
@@ -1658,7 +1665,7 @@ function finishTurn(
   stopReason: z.infer<typeof acpStopReasonSchema>,
 ): void {
   session.activePromptKind = null;
-  session.queuedInputs = [];
+  session.queuedPrompts = [];
   session.promptRequestPending = false;
   session.cancelRequested = false;
   sendNotification(ACP_TURN_COMPLETED_METHOD, {
@@ -1667,12 +1674,32 @@ function finishTurn(
   });
 }
 
-function runTurn(session: AcpThreadSession, firstInput: PromptInput[]): void {
+function requestAgentPrompt(
+  session: AcpThreadSession,
+  prompt: AcpContentBlock[],
+  serviceTier: ServiceTier,
+) {
+  const params: AcpSessionPromptParams = {
+    sessionId: session.providerThreadId,
+    prompt,
+    _meta: { "getbb.app/serviceTier": serviceTier },
+  };
+  return session.connection.request({
+    method: "session/prompt",
+    params,
+    resultSchema: acpPromptResultSchema,
+  });
+}
+
+function runTurn(
+  session: AcpThreadSession,
+  firstPrompt: AcpQueuedPrompt,
+): void {
   session.activePromptKind = "turn";
   sendNotification(ACP_TURN_STARTED_METHOD, { threadId: session.bbThreadId });
 
   session.turnSettled = (async () => {
-    let input = firstInput;
+    let currentPrompt = firstPrompt;
     for (;;) {
       if (session.stopping) {
         finishTurn(session, "cancelled");
@@ -1683,24 +1710,21 @@ function runTurn(session: AcpThreadSession, firstInput: PromptInput[]): void {
       session.cancelRequested = false;
       try {
         session.promptRequestPending = true;
-        const promptResult = session.connection.request({
-          method: "session/prompt",
-          params: {
-            sessionId: session.providerThreadId,
-            prompt: buildPromptContentBlocks(session, input),
-          },
-          resultSchema: acpPromptResultSchema,
-        });
+        const promptResult = requestAgentPrompt(
+          session,
+          buildPromptContentBlocks(session, currentPrompt.input),
+          currentPrompt.serviceTier,
+        );
         // A steer that stacked behind the cancelled prompt still needs its own
         // cancel; otherwise this prompt can hang and strand the later input.
-        if (session.queuedInputs.length > 0) {
+        if (session.queuedPrompts.length > 0) {
           requestSteerCancel(session);
         }
         const result = await promptResult;
         stopReason = result.stopReason;
       } catch (error) {
         session.promptRequestPending = false;
-        session.queuedInputs = [];
+        session.queuedPrompts = [];
         session.cancelRequested = false;
         session.activePromptKind = null;
         // An exited agent already produced an error notification from the
@@ -1717,9 +1741,9 @@ function runTurn(session: AcpThreadSession, firstInput: PromptInput[]): void {
 
       // Hard steer cancels the current prompt, then continues this bb turn.
       if (!session.stopping) {
-        const next = session.queuedInputs.shift();
+        const next = session.queuedPrompts.shift();
         if (next) {
-          input = next;
+          currentPrompt = next;
           continue;
         }
       }
@@ -1730,7 +1754,10 @@ function runTurn(session: AcpThreadSession, firstInput: PromptInput[]): void {
   })();
 }
 
-function startCompaction(session: AcpThreadSession): void {
+function startCompaction(
+  session: AcpThreadSession,
+  serviceTier: ServiceTier,
+): void {
   if (session.activePromptKind !== null) {
     throw new Error("Cannot compact context while an ACP turn is active");
   }
@@ -1740,14 +1767,11 @@ function startCompaction(session: AcpThreadSession): void {
     threadId: session.bbThreadId,
   });
 
-  const request = session.connection.request({
-    method: "session/prompt",
-    params: {
-      sessionId: session.providerThreadId,
-      prompt: [{ type: "text", text: "/compact" }],
-    },
-    resultSchema: acpPromptResultSchema,
-  });
+  const request = requestAgentPrompt(
+    session,
+    [{ type: "text", text: "/compact" }],
+    serviceTier,
+  );
   session.turnSettled = request
     .then((result) => {
       const outcome =
@@ -1942,7 +1966,10 @@ async function handleRequest(
         sendError(request.id, -32000, "A turn is already active");
         return;
       }
-      runTurn(session, request.params.input);
+      runTurn(session, {
+        input: request.params.input,
+        serviceTier: request.params.serviceTier,
+      });
       sendResult(request.id, { threadId: request.params.threadId });
       return;
     }
@@ -1961,7 +1988,10 @@ async function handleRequest(
         );
         return;
       }
-      session.queuedInputs.push(request.params.input);
+      session.queuedPrompts.push({
+        input: request.params.input,
+        serviceTier: request.params.serviceTier,
+      });
       requestSteerCancel(session);
       sendResult(request.id, { threadId: request.params.threadId });
       return;
@@ -1983,7 +2013,7 @@ async function handleRequest(
         return;
       }
       try {
-        startCompaction(session);
+        startCompaction(session, request.params.serviceTier);
         sendResult(request.id, { threadId: request.params.threadId });
       } catch (error) {
         sendError(

--- a/packages/agent-runtime/src/acp/bridge/fake-acp-agent.mjs
+++ b/packages/agent-runtime/src/acp/bridge/fake-acp-agent.mjs
@@ -31,7 +31,7 @@
  * - FAKE_ACP_WRITE_PATH      → target path for the "write-file" prompt
  * - FAKE_ACP_LAUNCH_LOG      → append one line per process launch (used to
  *                              count model-discovery spawns in cache/TTL tests)
- * - FAKE_ACP_PROMPT_LOG      → append one JSON-encoded prompt text per request
+ * - FAKE_ACP_PROMPT_LOG      → append prompt text and metadata as JSON lines
  * - FAKE_ACP_PROMPT_ERROR=1  → reject every session/prompt request
  * - FAKE_ACP_COMPACT_STOP_REASON
  *                            → stop reason returned for /compact
@@ -232,7 +232,7 @@ async function handlePrompt(message) {
   if (process.env.FAKE_ACP_PROMPT_LOG) {
     appendFileSync(
       process.env.FAKE_ACP_PROMPT_LOG,
-      `${JSON.stringify(text)}\n`,
+      `${JSON.stringify({ text, _meta: message.params?._meta })}\n`,
     );
   }
 

--- a/packages/agent-runtime/src/acp/wire.ts
+++ b/packages/agent-runtime/src/acp/wire.ts
@@ -5,6 +5,7 @@
  * `update` payloads it translates into thread events.
  */
 
+import type { ServiceTier } from "@bb/domain";
 import { z } from "zod";
 
 // ---------------------------------------------------------------------------
@@ -30,6 +31,18 @@ const acpContentBlockSchema = z.union([
   acpOtherContentBlockSchema,
 ]);
 export type AcpContentBlock = z.infer<typeof acpContentBlockSchema>;
+
+export type BbServiceTier = ServiceTier;
+
+export interface BbPromptMeta {
+  "getbb.app/serviceTier": BbServiceTier;
+}
+
+export interface AcpSessionPromptParams {
+  sessionId: string;
+  prompt: AcpContentBlock[];
+  _meta: BbPromptMeta;
+}
 
 export function extractAcpContentText(
   content: AcpContentBlock | undefined,

--- a/packages/agent-runtime/src/runtime.lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.lifecycle.test.ts
@@ -1466,6 +1466,114 @@ rl.on("line", (line) => {
       });
       await runtime.shutdown();
     });
+
+    it("defers ACP session changes until after active steers", async () => {
+      const builtCommands: AdapterCommand[] = [];
+      const events: ThreadEvent[] = [];
+      const runtime = createAgentRuntimeWithAdapters({
+        workspacePath: tmpDir,
+        onEvent: (event) => events.push(event),
+        onToolCall: async () => ({
+          contentItems: [{ type: "inputText", text: "ok" }],
+          success: true,
+        }),
+        adapterFactory: () => {
+          const adapter = createRecordingAdapter({
+            recordedCommands: builtCommands,
+            scriptPath,
+          });
+          return {
+            ...adapter,
+            capabilities: {
+              ...adapter.capabilities,
+              supportsServiceTier: true,
+            },
+          };
+        },
+      });
+
+      await runtime.startThread({
+        environmentId: "env-1",
+        threadId: "t1",
+        projectId: "p1",
+        providerId: "acp-custom",
+        options: fullRuntimeOptions,
+      });
+      await runtime.runTurn({
+        clientRequestId: "creq_222222224i",
+        threadId: "t1",
+        input: [promptTextInput({ text: "delay:1000" })],
+        options: fullRuntimeOptions,
+      });
+      await waitForThreadTurnStarted({
+        events,
+        providerId: "acp-custom",
+        runtime,
+        threadId: "t1",
+        turnId: "turn-1",
+      });
+      builtCommands.length = 0;
+
+      await runtime.steerTurn({
+        clientRequestId: "creq_222222224j",
+        threadId: "t1",
+        expectedTurnId: "turn-1",
+        input: [promptTextInput({ text: "use fast" })],
+        options: { ...fullRuntimeOptions, serviceTier: "fast" },
+      });
+
+      expect(builtCommands).toHaveLength(1);
+      expect(builtCommands[0]).toMatchObject({
+        type: "turn/steer",
+        options: { serviceTier: "fast" },
+      });
+
+      await runtime.steerTurn({
+        clientRequestId: "creq_222222224k",
+        threadId: "t1",
+        expectedTurnId: "turn-1",
+        input: [promptTextInput({ text: "also change the model" })],
+        options: {
+          ...fullRuntimeOptions,
+          model: "test-model-2",
+          serviceTier: "fast",
+        },
+      });
+
+      expect(builtCommands).toHaveLength(2);
+      expect(builtCommands[1]).toMatchObject({
+        type: "turn/steer",
+        options: { model: "test-model-2", serviceTier: "fast" },
+      });
+
+      await waitForThreadTurnCompleted({
+        events,
+        threadId: "t1",
+        turnId: "turn-1",
+      });
+      builtCommands.length = 0;
+
+      await runtime.runTurn({
+        clientRequestId: "creq_222222224m",
+        threadId: "t1",
+        input: [promptTextInput({ text: "next turn" })],
+        options: {
+          ...fullRuntimeOptions,
+          model: "test-model-2",
+          serviceTier: "fast",
+        },
+      });
+
+      expect(builtCommands.map((command) => command.type)).toEqual([
+        "thread/resume",
+        "turn/start",
+      ]);
+      expect(builtCommands[0]).toMatchObject({
+        type: "thread/resume",
+        options: { model: "test-model-2", serviceTier: "fast" },
+      });
+      await runtime.shutdown();
+    });
   });
 
   describe("models", () => {

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -71,6 +71,7 @@ import {
 import { fingerprintAcpLaunchSpec } from "./acp-launch-spec-fingerprint.js";
 
 interface ReconfigureThreadIfNeededArgs {
+  deferSessionChange?: boolean;
   options: AgentRuntimeExecutionOptions;
   threadId: string;
 }
@@ -923,6 +924,13 @@ function createAgentRuntimeInternal(
       current: currentConfig.options,
       next: nextOptions,
     });
+    if (args.deferSessionChange && settingsChange === "session") {
+      // An ACP steer must target the current active session. Replacing that
+      // session would make the steer stale, so retain the old session options
+      // and apply settings that need a fresh session before the next normal
+      // turn. Per-turn settings still ride on this steer command.
+      return;
+    }
     if (settingsChange !== "session") {
       // Live settings ride on the next turn command; record them without
       // replacing the session (which would kill its background tasks).
@@ -1921,6 +1929,7 @@ function createAgentRuntimeInternal(
           // resolve the process again before constructing the steer command.
           const proc = requireProviderProcessForThread(threadId);
           await reconfigureThreadIfNeeded({
+            deferSessionChange: isAcpProviderId(pid),
             threadId,
             options: effectiveExecOpts,
           });


### PR DESCRIPTION
## Summary

Include bb's resolved service tier in every custom-agent ACP `session/prompt` request:

```json
{
  "_meta": {
    "getbb.app/serviceTier": "default"
  }
}
```

The value is always `default` or `fast`.

## Motivation

Custom ACP agents currently need to read bb's thread event API to find the resolved service tier. This change puts the final value directly on the prompt where it applies.

## Behavior

- Sends the tier with normal prompts, steers, queued steers, and compaction prompts.
- Resolves the tier independently for each prompt after bb applies its precedence rules.
- Sends an explicit `default` instead of omitting the key.
- Works with agents that do not define `modelCli`.
- Uses ACP's extensible `_meta` field with an owner-qualified key.
- Allows existing agents to ignore the unknown metadata.

The value applies only to its prompt. Agents should not retain it as the default for later prompts. An explicit `default` clears Fast mode from an earlier prompt.

The value is a routing hint. It does not prove provider support, entitlement, or authorization.

## Why prompt metadata?

ACP session configuration is agent-advertised and session-scoped. ACP does not define a standard service-tier option or option ID.

bb owns the Fast mode control and resolves its final value per prompt. Prompt metadata keeps that value atomic with the affected prompt and avoids a second session-state mechanism.

## Session lifecycle

A setting change must not replace an active ACP session before a steer. This change defers session-level reconfiguration during active steers and applies it before the next normal turn.

This preserves the active turn and prevents stale steers while retaining CLI-backed model selection behavior.

## Verification

- Agent runtime typecheck passed.
- Focused ACP and lifecycle tests: 143 passed.
- Full `@bb/agent-runtime` suite: 942 passed.
- Formatting and diff checks passed.

> AGENT GENERATED: by Claude Mythos 5
