### PR TITLE
Build and publish the Linux desktop app in the release and nightly channels

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -99,7 +99,7 @@ jobs:
 
           HAS_SIGNING_SECRETS="false"
           if [[ "${#PRESENT_SECRET_NAMES[@]}" -eq 0 ]]; then
-            echo "::warning::macOS signing/notarization secrets are not configured; building unsigned workflow artifacts and publishing desktop-version.json only."
+            echo "::warning::macOS signing/notarization secrets are not configured; building unsigned macOS workflow artifacts that a publish run will withhold. Both version feeds and the Linux AppImage still publish."
           elif [[ "${#MISSING_SECRET_NAMES[@]}" -eq 0 ]]; then
             echo "macOS signing/notarization secrets are complete; signed and notarized artifacts will be produced."
             HAS_SIGNING_SECRETS="true"
@@ -175,7 +175,9 @@ jobs:
         run: pnpm exec turbo run test --filter=@bb/desktop --filter=bb-app --force --output-logs=new-only
 
       - name: Package x64 AppImage
-        run: pnpm exec turbo run desktop:build:linux --filter=@bb/desktop --force --output-logs=new-only
+        # No --force: the packaging task is already cache: false, and forcing also
+        # rebuilds its cached bb-app/@bb/desktop dependencies a second time.
+        run: pnpm exec turbo run desktop:build:linux --filter=@bb/desktop --output-logs=new-only
 
       - name: Smoke test packaged desktop app
         # The packaged app opens a real BrowserWindow, so the headless runner
@@ -210,18 +212,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Download macOS desktop artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: bb-desktop-macos-arm64-x64
-          path: release/macos
-
-      - name: Download Linux desktop artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: bb-desktop-linux-x64
-          path: release/linux
-
+      # The plan runs before the downloads: a qa or publish=false run has no use
+      # for several hundred MB of binaries it will never upload.
       - name: Plan release publication
         id: release_plan
         env:
@@ -257,6 +249,20 @@ jobs:
             echo "should_publish=$SHOULD_PUBLISH"
             echo "publish_macos_binaries=$PUBLISH_MACOS_BINARIES"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Download macOS desktop artifacts
+        if: steps.release_plan.outputs.should_publish == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bb-desktop-macos-arm64-x64
+          path: release/macos
+
+      - name: Download Linux desktop artifacts
+        if: steps.release_plan.outputs.should_publish == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bb-desktop-linux-x64
+          path: release/linux
 
       - name: Publish stable desktop release feed
         if: steps.release_plan.outputs.should_publish == 'true'

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -23,7 +23,7 @@ env:
   PNPM_VERSION: "9.15.0"
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: build-desktop-${{ github.ref }}
@@ -34,6 +34,8 @@ jobs:
     name: macOS arm64 + x64 desktop artifacts
     runs-on: macos-15-intel
     timeout-minutes: 45
+    outputs:
+      has_signing_secrets: ${{ steps.signing.outputs.has_signing_secrets }}
 
     steps:
       - name: Checkout repository
@@ -67,6 +69,7 @@ jobs:
         run: pnpm exec turbo run test --filter=@bb/desktop --filter=bb-app --force --output-logs=new-only
 
       - name: Validate macOS signing secrets
+        id: signing
         env:
           MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
           MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
@@ -94,14 +97,18 @@ jobs:
             fi
           done
 
+          HAS_SIGNING_SECRETS="false"
           if [[ "${#PRESENT_SECRET_NAMES[@]}" -eq 0 ]]; then
             echo "::warning::macOS signing/notarization secrets are not configured; building unsigned workflow artifacts and publishing desktop-version.json only."
           elif [[ "${#MISSING_SECRET_NAMES[@]}" -eq 0 ]]; then
             echo "macOS signing/notarization secrets are complete; signed and notarized artifacts will be produced."
+            HAS_SIGNING_SECRETS="true"
           else
             echo "::error::Incomplete macOS signing/notarization secret set. Present: ${PRESENT_SECRET_NAMES[*]}. Missing: ${MISSING_SECRET_NAMES[*]}."
             exit 1
           fi
+
+          echo "has_signing_secrets=$HAS_SIGNING_SECRETS" >> "$GITHUB_OUTPUT"
 
       - name: Package arm64 and x64 desktop artifacts
         env:
@@ -119,16 +126,108 @@ jobs:
       - name: Generate desktop version feed
         run: pnpm --dir apps/desktop run desktop:version-feed
 
+      - name: Upload desktop workflow artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bb-desktop-macos-arm64-x64
+          path: |
+            apps/desktop/release/*.dmg
+            apps/desktop/release/*.zip
+            apps/desktop/release/*.blockmap
+            apps/desktop/release/latest-mac.yml
+            apps/desktop/release/desktop-version.json
+          if-no-files-found: error
+
+  linux:
+    name: Linux x64 desktop artifacts
+    # Pinned rather than ubuntu-latest so the glibc the AppImage links against
+    # changes only when we choose it: the build machine's glibc sets the
+    # minimum distro version users need.
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Typecheck desktop and launcher
+        run: pnpm exec turbo run typecheck --filter=@bb/desktop --filter=bb-app --output-logs=new-only
+
+      - name: Build desktop
+        run: pnpm exec turbo run build --filter=@bb/desktop --output-logs=new-only
+
+      - name: Test desktop and launcher
+        run: pnpm exec turbo run test --filter=@bb/desktop --filter=bb-app --force --output-logs=new-only
+
+      - name: Package x64 AppImage
+        run: pnpm exec turbo run desktop:build:linux --filter=@bb/desktop --force --output-logs=new-only
+
+      - name: Smoke test packaged desktop app
+        # The packaged app opens a real BrowserWindow, so the headless runner
+        # needs a virtual display.
+        run: xvfb-run -a pnpm exec turbo run smoke:packaged --filter=@bb/desktop --force --output-logs=new-only
+
+      - name: Generate desktop version feed
+        run: pnpm --dir apps/desktop run desktop:version-feed
+
+      - name: Upload desktop workflow artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bb-desktop-linux-x64
+          path: |
+            apps/desktop/release/*.AppImage
+            apps/desktop/release/*.blockmap
+            apps/desktop/release/latest-linux.yml
+            apps/desktop/release/desktop-version-linux.json
+          if-no-files-found: error
+
+  publish:
+    name: Publish stable desktop release
+    needs:
+      - macos
+      - linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download macOS desktop artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bb-desktop-macos-arm64-x64
+          path: release/macos
+
+      - name: Download Linux desktop artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bb-desktop-linux-x64
+          path: release/linux
+
       - name: Plan release publication
         id: release_plan
         env:
+          HAS_SIGNING_SECRETS: ${{ needs.macos.outputs.has_signing_secrets }}
           INPUT_PUBLISH: ${{ inputs.publish }}
           RELEASE_CHANNEL: ${{ inputs.release_channel }}
-          CSC_LINK: ${{ secrets.MACOS_CERTIFICATE_P12 }}
-          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           set -euo pipefail
 
@@ -143,60 +242,73 @@ jobs:
             SHOULD_PUBLISH="true"
           fi
 
-          HAS_SIGNING_SECRETS="false"
-          if [[ -n "${CSC_LINK:-}" && -n "${CSC_KEY_PASSWORD:-}" && -n "${APPLE_ID:-}" && -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" && -n "${APPLE_TEAM_ID:-}" ]]; then
-            HAS_SIGNING_SECRETS="true"
-          fi
-
-          PUBLISH_BINARIES="false"
+          # Linux AppImages have no notarization equivalent, so they publish on
+          # their own. Only the macOS binaries wait on the Apple secrets.
+          PUBLISH_MACOS_BINARIES="false"
           if [[ "$HAS_SIGNING_SECRETS" == "true" ]]; then
-            PUBLISH_BINARIES="true"
+            PUBLISH_MACOS_BINARIES="true"
           elif [[ "$SHOULD_PUBLISH" == "true" ]]; then
-            echo "::warning::macOS signing/notarization secrets are missing; publishing desktop-version.json only and withholding unsigned .dmg/.zip artifacts."
+            echo "::warning::macOS signing/notarization secrets are missing; publishing the version feeds and Linux AppImage only, and withholding unsigned .dmg/.zip artifacts."
           fi
 
           {
             echo "version=$VERSION"
             echo "is_prerelease=$IS_PRERELEASE"
             echo "should_publish=$SHOULD_PUBLISH"
-            echo "publish_binaries=$PUBLISH_BINARIES"
-            echo "has_signing_secrets=$HAS_SIGNING_SECRETS"
+            echo "publish_macos_binaries=$PUBLISH_MACOS_BINARIES"
           } >> "$GITHUB_OUTPUT"
-
-      - name: Upload desktop workflow artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: bb-desktop-macos-arm64-x64
-          path: |
-            apps/desktop/release/*.dmg
-            apps/desktop/release/*.zip
-            apps/desktop/release/*.blockmap
-            apps/desktop/release/latest-mac.yml
-            apps/desktop/release/desktop-version.json
-          if-no-files-found: error
 
       - name: Publish stable desktop release feed
         if: steps.release_plan.outputs.should_publish == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.release_plan.outputs.version }}
-          PUBLISH_BINARIES: ${{ steps.release_plan.outputs.publish_binaries }}
+          PUBLISH_MACOS_BINARIES: ${{ steps.release_plan.outputs.publish_macos_binaries }}
         run: |
           set -euo pipefail
 
           VERSION_TAG="desktop-v${VERSION}"
           LATEST_TAG="desktop-latest"
-          RELEASE_DIR="apps/desktop/release"
-          METADATA_ASSETS=("$RELEASE_DIR/desktop-version.json")
-          RELEASE_ASSETS=("${METADATA_ASSETS[@]}")
+          MACOS_DIR="release/macos"
+          LINUX_DIR="release/linux"
 
-          if [[ "$PUBLISH_BINARIES" == "true" ]]; then
-            RELEASE_ASSETS+=("$RELEASE_DIR/latest-mac.yml")
-            RELEASE_ASSETS+=("$RELEASE_DIR"/*.dmg)
-            RELEASE_ASSETS+=("$RELEASE_DIR"/*.zip)
-            RELEASE_ASSETS+=("$RELEASE_DIR"/*.blockmap)
+          RELEASE_ASSETS=()
+
+          # An unmatched glob would otherwise reach gh as a literal pattern and
+          # fail the upload, so each expansion states whether it is required.
+          add_required_glob() {
+            local matches=("$@")
+            if [[ ! -e "${matches[0]}" ]]; then
+              echo "::error::No release artifact matched ${matches[0]}."
+              exit 1
+            fi
+            RELEASE_ASSETS+=("${matches[@]}")
+          }
+
+          add_optional_glob() {
+            local matches=("$@")
+            if [[ -e "${matches[0]}" ]]; then
+              RELEASE_ASSETS+=("${matches[@]}")
+            fi
+          }
+
+          # Both platforms reset the same moving release, so a single job
+          # assembles every asset. Splitting the reset across platform jobs
+          # would let whichever finished last delete the other's binaries.
+          add_required_glob "$MACOS_DIR/desktop-version.json"
+          add_required_glob "$LINUX_DIR/desktop-version-linux.json"
+          add_required_glob "$LINUX_DIR/latest-linux.yml"
+          add_required_glob "$LINUX_DIR"/*.AppImage
+          # AppImage embeds its block map, so a sidecar file is not guaranteed.
+          add_optional_glob "$LINUX_DIR"/*.blockmap
+
+          if [[ "$PUBLISH_MACOS_BINARIES" == "true" ]]; then
+            add_required_glob "$MACOS_DIR/latest-mac.yml"
+            add_required_glob "$MACOS_DIR"/*.dmg
+            add_required_glob "$MACOS_DIR"/*.zip
+            add_required_glob "$MACOS_DIR"/*.blockmap
           else
-            echo "Signing/notarization gate is closed; publishing desktop-version.json only."
+            echo "Signing/notarization gate is closed; publishing the macOS version feed without macOS binaries."
           fi
 
           if gh release view "$VERSION_TAG" >/dev/null 2>&1; then
@@ -243,7 +355,7 @@ jobs:
       - name: Summarize
         env:
           IS_PRERELEASE: ${{ steps.release_plan.outputs.is_prerelease }}
-          PUBLISH_BINARIES: ${{ steps.release_plan.outputs.publish_binaries }}
+          PUBLISH_MACOS_BINARIES: ${{ steps.release_plan.outputs.publish_macos_binaries }}
           SHOULD_PUBLISH: ${{ steps.release_plan.outputs.should_publish }}
           VERSION: ${{ steps.release_plan.outputs.version }}
         run: |
@@ -251,9 +363,11 @@ jobs:
             echo "## bb desktop artifacts"
             echo
             echo "- arm64 and x64 macOS .dmg/.zip artifacts, latest-mac.yml, and desktop-version.json uploaded as workflow artifacts"
+            echo "- x64 Linux .AppImage, latest-linux.yml, and desktop-version-linux.json uploaded as workflow artifacts"
             echo "- version: ${VERSION}"
             echo "- prerelease version: ${IS_PRERELEASE}"
             echo "- stable release publication requested and allowed: ${SHOULD_PUBLISH}"
-            echo "- release binary upload enabled: ${PUBLISH_BINARIES}"
-            echo "- desktop feed URL: https://github.com/get-bb/bb/releases/download/desktop-latest/desktop-version.json"
+            echo "- macOS release binary upload enabled: ${PUBLISH_MACOS_BINARIES}"
+            echo "- macOS feed URL: https://github.com/get-bb/bb/releases/download/desktop-latest/desktop-version.json"
+            echo "- Linux feed URL: https://github.com/get-bb/bb/releases/download/desktop-latest/desktop-version-linux.json"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-bb-app.yml
+++ b/.github/workflows/publish-bb-app.yml
@@ -218,14 +218,14 @@ jobs:
             echo "- commit: \`${GITHUB_SHA}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
-  nightly-desktop:
-    name: Publish bb Nightly desktop
+  nightly-desktop-macos:
+    name: Build bb Nightly desktop (macOS)
     if: ${{ github.event_name == 'schedule' || (inputs.npm_tag == 'nightly' && inputs.dry_run == false) }}
     needs: publish
     runs-on: macos-15-intel
     timeout-minutes: 45
-    permissions:
-      contents: write
+    outputs:
+      version: ${{ steps.nightly_version.outputs.version }}
     env:
       BB_DESKTOP_RELEASE_CHANNEL: nightly
       CSC_IDENTITY_AUTO_DISCOVERY: "false"
@@ -327,22 +327,150 @@ jobs:
             apps/desktop/release/desktop-version.json
           if-no-files-found: error
 
+  nightly-desktop-linux:
+    name: Build bb Nightly desktop (Linux)
+    if: ${{ github.event_name == 'schedule' || (inputs.npm_tag == 'nightly' && inputs.dry_run == false) }}
+    needs: publish
+    # Pinned rather than ubuntu-latest so the glibc the AppImage links against
+    # changes only when we choose it: the build machine's glibc sets the
+    # minimum distro version users need.
+    runs-on: ubuntu-22.04
+    timeout-minutes: 45
+    outputs:
+      version: ${{ steps.nightly_version.outputs.version }}
+    env:
+      BB_DESKTOP_RELEASE_CHANNEL: nightly
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 9.15.0
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.x
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Prepare nightly version
+        id: nightly_version
+        # The version derives from the run ID and the checked-in package
+        # versions, so this job and the macOS job agree without sharing state.
+        run: |
+          nightly_version="$(node scripts/prepare-nightly-version.mjs)"
+          echo "version=${nightly_version}" >> "$GITHUB_OUTPUT"
+          echo "Prepared bb-app and desktop version ${nightly_version}."
+
+      - name: Typecheck desktop and launcher
+        run: pnpm exec turbo run typecheck --filter=@bb/desktop --filter=bb-app --output-logs=new-only
+
+      - name: Build desktop
+        run: pnpm exec turbo run build --filter=@bb/desktop --output-logs=new-only
+
+      - name: Test desktop and launcher
+        run: pnpm exec turbo run test --filter=@bb/desktop --filter=bb-app --force --output-logs=new-only
+
+      - name: Package x64 nightly AppImage
+        run: pnpm exec turbo run desktop:build:linux --filter=@bb/desktop --force --output-logs=new-only
+
+      - name: Smoke test packaged nightly desktop app
+        # The packaged app opens a real BrowserWindow, so the headless runner
+        # needs a virtual display.
+        run: xvfb-run -a pnpm exec turbo run smoke:packaged --filter=@bb/desktop --force --output-logs=new-only
+
+      - name: Generate nightly desktop version feed
+        run: pnpm --dir apps/desktop run desktop:version-feed
+
+      - name: Upload nightly desktop workflow artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: bb-nightly-desktop-linux-x64-${{ steps.nightly_version.outputs.version }}
+          retention-days: 14
+          path: |
+            apps/desktop/release/*.AppImage
+            apps/desktop/release/*.blockmap
+            apps/desktop/release/nightly-linux.yml
+            apps/desktop/release/desktop-version-linux.json
+          if-no-files-found: error
+
+  nightly-desktop-publish:
+    name: Publish bb Nightly desktop
+    needs:
+      - nightly-desktop-macos
+      - nightly-desktop-linux
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Download macOS nightly desktop artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bb-nightly-desktop-macos-arm64-x64-${{ needs.nightly-desktop-macos.outputs.version }}
+          path: release/macos
+
+      - name: Download Linux nightly desktop artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bb-nightly-desktop-linux-x64-${{ needs.nightly-desktop-linux.outputs.version }}
+          path: release/linux
+
       - name: Publish moving nightly desktop release
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ steps.nightly_version.outputs.version }}
+          VERSION: ${{ needs.nightly-desktop-macos.outputs.version }}
         run: |
           set -euo pipefail
 
           nightly_tag="desktop-nightly"
-          release_dir="apps/desktop/release"
-          release_assets=(
-            "$release_dir/desktop-version.json"
-            "$release_dir/nightly-mac.yml"
-            "$release_dir"/*.dmg
-            "$release_dir"/*.zip
-            "$release_dir"/*.blockmap
-          )
+          macos_dir="release/macos"
+          linux_dir="release/linux"
+
+          release_assets=()
+
+          # An unmatched glob would otherwise reach gh as a literal pattern and
+          # fail the upload, so each expansion states whether it is required.
+          add_required_glob() {
+            local matches=("$@")
+            if [[ ! -e "${matches[0]}" ]]; then
+              echo "::error::No release artifact matched ${matches[0]}."
+              exit 1
+            fi
+            release_assets+=("${matches[@]}")
+          }
+
+          add_optional_glob() {
+            local matches=("$@")
+            if [[ -e "${matches[0]}" ]]; then
+              release_assets+=("${matches[@]}")
+            fi
+          }
+
+          # Both platforms reset the same moving release, so a single job
+          # assembles every asset. Splitting the reset across platform jobs
+          # would let whichever finished last delete the other's binaries.
+          add_required_glob "$macos_dir/desktop-version.json"
+          add_required_glob "$macos_dir/nightly-mac.yml"
+          add_required_glob "$macos_dir"/*.dmg
+          add_required_glob "$macos_dir"/*.zip
+          add_required_glob "$macos_dir"/*.blockmap
+          add_required_glob "$linux_dir/desktop-version-linux.json"
+          add_required_glob "$linux_dir/nightly-linux.yml"
+          add_required_glob "$linux_dir"/*.AppImage
+          # AppImage embeds its block map, so a sidecar file is not guaranteed.
+          add_optional_glob "$linux_dir"/*.blockmap
 
           git tag -f "$nightly_tag" "$GITHUB_SHA"
           git push --force origin "refs/tags/${nightly_tag}"
@@ -373,14 +501,16 @@ jobs:
 
       - name: Summarize nightly desktop release
         env:
-          VERSION: ${{ steps.nightly_version.outputs.version }}
+          VERSION: ${{ needs.nightly-desktop-macos.outputs.version }}
         run: |
           {
             echo "## bb Nightly desktop"
             echo
             echo "- version: \`$VERSION\`"
             echo "- app identity: \`dev.bb.desktop.nightly\`"
+            echo "- platforms: macOS arm64 + x64 (signed), Linux x64 AppImage"
             echo "- release: https://github.com/get-bb/bb/releases/tag/desktop-nightly"
-            echo "- update feed: https://github.com/get-bb/bb/releases/download/desktop-nightly/desktop-version.json"
+            echo "- macOS update feed: https://github.com/get-bb/bb/releases/download/desktop-nightly/desktop-version.json"
+            echo "- Linux update feed: https://github.com/get-bb/bb/releases/download/desktop-nightly/desktop-version-linux.json"
             echo "- retention for workflow artifacts: 14 days"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-bb-app.yml
+++ b/.github/workflows/publish-bb-app.yml
@@ -31,9 +31,10 @@ on:
 
 run-name: ${{ github.event_name == 'schedule' && 'Publish bb-app + desktop nightly' || format('Publish bb-app ({0}{1})', inputs.npm_tag, inputs.dry_run && ', dry run' || '') }}
 
+# Only the npm publish job gets id-token: write, for npm trusted publishing.
+# The desktop build jobs must not inherit an OIDC token they never use.
 permissions:
   contents: read
-  id-token: write
 
 concurrency:
   group: publish-bb-app-${{ (github.event_name == 'schedule' || inputs.npm_tag == 'nightly') && 'nightly' || github.ref }}
@@ -50,6 +51,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: npm-release
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      version: ${{ steps.release.outputs.version }}
 
     steps:
       - name: Require main branch
@@ -252,12 +258,25 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
 
-      - name: Prepare nightly version
+      - name: Apply the nightly version
         id: nightly_version
+        env:
+          NIGHTLY_VERSION: ${{ needs.publish.outputs.version }}
         run: |
-          nightly_version="$(node scripts/prepare-nightly-version.mjs)"
-          echo "version=${nightly_version}" >> "$GITHUB_OUTPUT"
-          echo "Prepared bb-app and desktop version ${nightly_version}."
+          set -euo pipefail
+
+          # Reuse the npm job's version rather than deriving one per platform.
+          # prepare-nightly-version.mjs embeds GITHUB_RUN_ATTEMPT, so re-running
+          # only the failed jobs would otherwise build macOS and Linux at
+          # different versions and publish them into one release.
+          if [[ -z "$NIGHTLY_VERSION" ]]; then
+            echo "::error::The npm publish job reported no version."
+            exit 1
+          fi
+
+          node scripts/bump-version.mjs "$NIGHTLY_VERSION"
+          echo "version=${NIGHTLY_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Applied bb-app and desktop version ${NIGHTLY_VERSION}."
 
       - name: Typecheck desktop and launcher
         run: pnpm exec turbo run typecheck --filter=@bb/desktop --filter=bb-app --output-logs=new-only
@@ -360,14 +379,23 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
 
-      - name: Prepare nightly version
+      - name: Apply the nightly version
         id: nightly_version
-        # The version derives from the run ID and the checked-in package
-        # versions, so this job and the macOS job agree without sharing state.
+        env:
+          NIGHTLY_VERSION: ${{ needs.publish.outputs.version }}
         run: |
-          nightly_version="$(node scripts/prepare-nightly-version.mjs)"
-          echo "version=${nightly_version}" >> "$GITHUB_OUTPUT"
-          echo "Prepared bb-app and desktop version ${nightly_version}."
+          set -euo pipefail
+
+          # One version for every platform: see the macOS job for why deriving
+          # it per job is unsafe across a partial re-run.
+          if [[ -z "$NIGHTLY_VERSION" ]]; then
+            echo "::error::The npm publish job reported no version."
+            exit 1
+          fi
+
+          node scripts/bump-version.mjs "$NIGHTLY_VERSION"
+          echo "version=${NIGHTLY_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Applied bb-app and desktop version ${NIGHTLY_VERSION}."
 
       - name: Typecheck desktop and launcher
         run: pnpm exec turbo run typecheck --filter=@bb/desktop --filter=bb-app --output-logs=new-only
@@ -379,7 +407,9 @@ jobs:
         run: pnpm exec turbo run test --filter=@bb/desktop --filter=bb-app --force --output-logs=new-only
 
       - name: Package x64 nightly AppImage
-        run: pnpm exec turbo run desktop:build:linux --filter=@bb/desktop --force --output-logs=new-only
+        # No --force: the packaging task is already cache: false, and forcing also
+        # rebuilds its cached bb-app/@bb/desktop dependencies a second time.
+        run: pnpm exec turbo run desktop:build:linux --filter=@bb/desktop --output-logs=new-only
 
       - name: Smoke test packaged nightly desktop app
         # The packaged app opens a real BrowserWindow, so the headless runner
@@ -414,6 +444,23 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Require one version across platforms
+        env:
+          LINUX_VERSION: ${{ needs.nightly-desktop-linux.outputs.version }}
+          MACOS_VERSION: ${{ needs.nightly-desktop-macos.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          # Both jobs take the version from the npm publish job, so a mismatch
+          # means that assumption broke. Refuse rather than publish a release
+          # whose two platforms disagree about what version they are.
+          if [[ -z "$MACOS_VERSION" || "$MACOS_VERSION" != "$LINUX_VERSION" ]]; then
+            echo "::error::Platform versions disagree. macOS: '${MACOS_VERSION}'. Linux: '${LINUX_VERSION}'."
+            exit 1
+          fi
+
+          echo "Publishing bb Nightly ${MACOS_VERSION} for macOS and Linux."
 
       - name: Download macOS nightly desktop artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -102,7 +102,18 @@ Running an AppImage normally requires FUSE and, on some distributions, the
 `libfuse2` compatibility package. If FUSE is unavailable, launch it with
 `--appimage-extract-and-run` instead.
 
-Auto-update is disabled on Linux because there is no Linux update feed yet.
+CI builds Linux artifacts on the pinned `ubuntu-22.04` runner. The AppImage
+links against the build machine's glibc, so that pin sets the oldest
+distribution that can run a published build. Raise it deliberately.
+
+Linux gets both update paths, but they are not equivalent:
+
+- The JSON version feed (`desktop-version-linux.json`) is polled on every Linux
+  install and reports that a newer release exists.
+- Self-installing auto-update runs only inside an AppImage, which electron-updater
+  detects through the `APPIMAGE` environment variable. An extracted directory or
+  a distribution package has no single file to replace, so it reports new
+  versions without installing them.
 
 ## Releasing
 
@@ -127,6 +138,21 @@ release; use `scripts/bump-version.mjs` so both files move together.
 The desktop release tag uses the locked version: `desktop-v<version>` for
 immutable releases and `desktop-latest` for the moving pointer.
 
+`build-desktop.yml` builds macOS and Linux in parallel jobs, then publishes
+both from one job. The moving release resets all of its assets on each publish,
+so a single publisher is what keeps one platform from deleting the other's
+binaries. Each platform has its own update feed file inside the same release
+tag:
+
+| Platform | Artifacts               | electron-updater metadata | Version feed                 |
+| -------- | ----------------------- | ------------------------- | ---------------------------- |
+| macOS    | `.dmg`, `.zip` (2 arch) | `latest-mac.yml`          | `desktop-version.json`       |
+| Linux    | `.AppImage` (x64)       | `latest-linux.yml`        | `desktop-version-linux.json` |
+
+macOS keeps the unsuffixed feed name because released macOS builds already
+request it. Linux artifacts are unsigned; only the macOS binaries wait on the
+Apple signing secrets.
+
 ## Nightly channel
 
 The scheduled `publish-bb-app.yml` workflow runs from `main` every day at
@@ -143,8 +169,11 @@ The nightly desktop is a separate installation:
 
 - product name: `bb Nightly`
 - bundle identifier: `dev.bb.desktop.nightly`
+- Linux binary name: `bb-nightly`, so it never shadows stable `bb` on PATH
 - app/update release: `desktop-nightly`
-- update metadata: `nightly-mac.yml`
+- update metadata: `nightly-mac.yml` and `nightly-linux.yml`
+- version feeds: `desktop-version.json` (macOS) and
+  `desktop-version-linux.json` (Linux)
 - icon: `assets/icon-nightly.icns` and `assets/icon-nightly.png`
 
 Download it from

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -110,10 +110,22 @@ Linux gets both update paths, but they are not equivalent:
 
 - The JSON version feed (`desktop-version-linux.json`) is polled on every Linux
   install and reports that a newer release exists.
-- Self-installing auto-update runs only inside an AppImage, which electron-updater
-  detects through the `APPIMAGE` environment variable. An extracted directory or
-  a distribution package has no single file to replace, so it reports new
-  versions without installing them.
+- Self-installing auto-update runs only inside an AppImage whose directory the
+  app can write to. electron-updater detects the AppImage through the `APPIMAGE`
+  environment variable, and its install step unlinks the running file *before*
+  moving the replacement in — so a read-only directory would delete the app and
+  leave nothing behind. Both the startup check and the install handler verify
+  write and search access on the parent directory first.
+- Everything else — an extracted directory, a distribution package, or an
+  AppImage in a read-only location — reports new versions without installing
+  them.
+
+The Linux AppImage is unsigned, and electron-updater performs no signature
+check on Linux: it verifies only the SHA-512 recorded in the update metadata
+that ships beside it. macOS installs through Squirrel, which additionally
+requires the replacement to satisfy the running app's code-signing
+requirement. Write access to the release assets is therefore sufficient to
+push code to Linux clients. Treat the release token accordingly.
 
 ## Releasing
 

--- a/apps/desktop/scripts/desktop-release-channel.d.mts
+++ b/apps/desktop/scripts/desktop-release-channel.d.mts
@@ -1,13 +1,20 @@
 export type DesktopReleaseChannel = "latest" | "nightly";
+export type DesktopBuildPlatform = "macos" | "linux";
+
+export interface DesktopUpdateMetadataFileNames {
+  linux: "latest-linux.yml" | "nightly-linux.yml";
+  macos: "latest-mac.yml" | "nightly-mac.yml";
+}
 
 export interface DesktopReleaseConfig {
   appId: "dev.bb.desktop" | "dev.bb.desktop.nightly";
   applicationName: "bb" | "bb Nightly";
   artifactName: string;
   iconFileName: "icon.png" | "icon-nightly.png";
+  linuxExecutableName: "bb" | "bb-nightly";
   macIconPath: "assets/icon.icns" | "assets/icon-nightly.icns";
   releaseTag: "desktop-latest" | "desktop-nightly";
-  updateMetadataFileName: "latest-mac.yml" | "nightly-mac.yml";
+  updateMetadataFileNames: DesktopUpdateMetadataFileNames;
 }
 
 export const DESKTOP_RELEASE_CHANNEL_ENV_NAME: "BB_DESKTOP_RELEASE_CHANNEL";
@@ -15,6 +22,10 @@ export const DESKTOP_RELEASE_CHANNEL_ENV_NAME: "BB_DESKTOP_RELEASE_CHANNEL";
 export function resolveDesktopReleaseChannel(
   env: NodeJS.ProcessEnv,
 ): DesktopReleaseChannel;
+
+export function resolveDesktopBuildPlatform(
+  nodePlatform: string,
+): DesktopBuildPlatform;
 
 export function createDesktopReleaseConfig(
   channel: DesktopReleaseChannel,

--- a/apps/desktop/scripts/desktop-release-channel.mjs
+++ b/apps/desktop/scripts/desktop-release-channel.mjs
@@ -14,6 +14,19 @@ export function resolveDesktopReleaseChannel(env) {
   );
 }
 
+export function resolveDesktopBuildPlatform(nodePlatform) {
+  if (nodePlatform === "darwin") {
+    return "macos";
+  }
+  if (nodePlatform === "linux") {
+    return "linux";
+  }
+
+  throw new Error(
+    `Desktop builds support darwin and linux only, got ${nodePlatform}.`,
+  );
+}
+
 export function createDesktopReleaseConfig(channel) {
   if (channel === "nightly") {
     return {
@@ -21,9 +34,15 @@ export function createDesktopReleaseConfig(channel) {
       applicationName: "bb Nightly",
       artifactName: "bb-nightly-${version}-${arch}.${ext}",
       iconFileName: "icon-nightly.png",
+      // The Linux binary name must differ from stable so both channels can be
+      // installed at once without one shadowing the other on PATH.
+      linuxExecutableName: "bb-nightly",
       macIconPath: "assets/icon-nightly.icns",
       releaseTag: "desktop-nightly",
-      updateMetadataFileName: "nightly-mac.yml",
+      updateMetadataFileNames: {
+        linux: "nightly-linux.yml",
+        macos: "nightly-mac.yml",
+      },
     };
   }
 
@@ -32,9 +51,13 @@ export function createDesktopReleaseConfig(channel) {
     applicationName: "bb",
     artifactName: "${productName}-${version}-${arch}.${ext}",
     iconFileName: "icon.png",
+    linuxExecutableName: "bb",
     macIconPath: "assets/icon.icns",
     releaseTag: "desktop-latest",
-    updateMetadataFileName: "latest-mac.yml",
+    updateMetadataFileNames: {
+      linux: "latest-linux.yml",
+      macos: "latest-mac.yml",
+    },
   };
 }
 

--- a/apps/desktop/scripts/generate-version-feed.mts
+++ b/apps/desktop/scripts/generate-version-feed.mts
@@ -4,10 +4,12 @@ import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 import {
   bbDesktopVersionFeedSchema,
+  createBbDesktopVersionFeedFileName,
   type BbDesktopVersionFeed,
 } from "@bb/desktop-contract";
 import {
   createDesktopReleaseConfig,
+  resolveDesktopBuildPlatform,
   resolveDesktopReleaseChannel,
 } from "./desktop-release-channel.mjs";
 
@@ -15,30 +17,35 @@ const packageRoot = process.cwd();
 const packageJsonPath = resolve(packageRoot, "package.json");
 const releaseChannel = resolveDesktopReleaseChannel(process.env);
 const releaseConfig = createDesktopReleaseConfig(releaseChannel);
+// The feed describes the artifacts electron-builder just produced, so it always
+// describes the platform this build ran on.
+const buildPlatform = resolveDesktopBuildPlatform(process.platform);
+const updateMetadataFileName =
+  releaseConfig.updateMetadataFileNames[buildPlatform];
 const updateMetadataPath = resolve(
   packageRoot,
   "release",
-  releaseConfig.updateMetadataFileName,
+  updateMetadataFileName,
 );
 const desktopVersionFeedPath = resolve(
   packageRoot,
   "release",
-  "desktop-version.json",
+  createBbDesktopVersionFeedFileName(buildPlatform),
 );
 
 const packageJsonSchema = z.object({
   version: z.string().min(1),
 });
 
-const latestMacFileSchema = z.object({
+const updateMetadataFileSchema = z.object({
   url: z.string().min(1),
   sha512: z.string().min(1),
   size: z.number().int().nonnegative(),
 });
 
-const latestMacSchema = z.object({
+const updateMetadataSchema = z.object({
   version: z.string().min(1),
-  files: z.array(latestMacFileSchema).min(1),
+  files: z.array(updateMetadataFileSchema).min(1),
   path: z.string().min(1),
   sha512: z.string().min(1),
   releaseDate: z.iso.datetime(),
@@ -51,13 +58,13 @@ function parseJson(text: string): unknown {
 const packageJson = packageJsonSchema.parse(
   parseJson(await readFile(packageJsonPath, "utf8")),
 );
-const updateMetadata = latestMacSchema.parse(
+const updateMetadata = updateMetadataSchema.parse(
   parseYaml(await readFile(updateMetadataPath, "utf8")),
 );
 
 if (updateMetadata.version !== packageJson.version) {
   throw new Error(
-    `${releaseConfig.updateMetadataFileName} version ${updateMetadata.version} did not match apps/desktop/package.json version ${packageJson.version}`,
+    `${updateMetadataFileName} version ${updateMetadata.version} did not match apps/desktop/package.json version ${packageJson.version}`,
   );
 }
 
@@ -66,7 +73,7 @@ const desktopVersionFeed: BbDesktopVersionFeed = {
   files: updateMetadata.files,
   minimumSystemVersion: null,
   path: updateMetadata.path,
-  platform: "macos",
+  platform: buildPlatform,
   releaseDate: updateMetadata.releaseDate,
   releaseName: `${releaseConfig.applicationName} desktop ${packageJson.version}`,
   releaseNotes: null,

--- a/apps/desktop/scripts/run-electron-builder.mjs
+++ b/apps/desktop/scripts/run-electron-builder.mjs
@@ -181,6 +181,7 @@ export function resolveElectronBuilderConfig(baseConfig, env) {
   config.mac = mac;
   config.linux = {
     ...config.linux,
+    executableName: releaseConfig.linuxExecutableName,
     icon: "assets/" + releaseConfig.iconFileName,
   };
   config.appId = releaseConfig.appId;

--- a/apps/desktop/scripts/run-packaged-app.mjs
+++ b/apps/desktop/scripts/run-packaged-app.mjs
@@ -24,7 +24,7 @@ function createElectronAppEnv(env) {
 
 const child = spawn(
   await resolvePackagedAppBinary({
-    executableName: "bb",
+    executableName: releaseConfig.linuxExecutableName,
     platform: process.platform,
     productName: releaseConfig.applicationName,
     releaseDir,

--- a/apps/desktop/scripts/smoke-packaged-app.mjs
+++ b/apps/desktop/scripts/smoke-packaged-app.mjs
@@ -42,11 +42,11 @@ function writeNotFound(response) {
   response.end(JSON.stringify({ message: "not found" }));
 }
 
-function createDesktopVersionFeed(version) {
+function createDesktopVersionFeed(platform, version) {
   return {
     schemaVersion: 1,
     channel: "latest",
-    platform: "macos",
+    platform,
     version,
     releaseDate: new Date(0).toISOString(),
     releaseName: `bb desktop ${version}`,
@@ -161,7 +161,13 @@ async function startSmokeServer({
     }
 
     if (request.url === "/desktop-version.json") {
-      writeJson(response, createDesktopVersionFeed(expectedDesktopVersion));
+      writeJson(
+        response,
+        createDesktopVersionFeed(
+          expectedDesktopPlatform,
+          expectedDesktopVersion,
+        ),
+      );
       return;
     }
 
@@ -343,7 +349,7 @@ async function smokePackagedApp() {
   const desktopVersion = await readDesktopPackageVersion();
   const desktopPlatform = process.platform === "darwin" ? "macos" : "linux";
   const appBinary = await resolvePackagedAppBinary({
-    executableName: "bb",
+    executableName: releaseConfig.linuxExecutableName,
     platform: process.platform,
     productName: releaseConfig.applicationName,
     releaseDir,

--- a/apps/desktop/scripts/smoke-packaged-app.mjs
+++ b/apps/desktop/scripts/smoke-packaged-app.mjs
@@ -13,9 +13,8 @@ import { resolvePackagedAppBinary } from "./packaged-app-paths.mjs";
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const desktopPackageRoot = resolve(scriptDirectory, "..");
 const releaseDir = join(desktopPackageRoot, "release");
-const releaseConfig = createDesktopReleaseConfig(
-  resolveDesktopReleaseChannel(process.env),
-);
+const releaseChannel = resolveDesktopReleaseChannel(process.env);
+const releaseConfig = createDesktopReleaseConfig(releaseChannel);
 const startupTimeoutMs = 20_000;
 const exitTimeoutMs = 5_000;
 const postReadySettleMs = 300;
@@ -45,7 +44,9 @@ function writeNotFound(response) {
 function createDesktopVersionFeed(platform, version) {
   return {
     schemaVersion: 1,
-    channel: "latest",
+    // The app rejects a feed whose channel is not its own, so a nightly
+    // packaged build must be smoked against a nightly feed.
+    channel: releaseChannel,
     platform,
     version,
     releaseDate: new Date(0).toISOString(),

--- a/apps/desktop/src/desktop-update-check.ts
+++ b/apps/desktop/src/desktop-update-check.ts
@@ -19,6 +19,7 @@ export interface DesktopUpdateLogger {
 }
 
 export interface ParseDesktopVersionFeedArgs {
+  channel: BbDesktopVersionFeed["channel"];
   checkedAt: string;
   currentVersion: string;
   payloadText: string;
@@ -41,6 +42,7 @@ export type DesktopVersionFeedParseResult =
   | ValidDesktopVersionFeedParseResult;
 
 export interface CreateDesktopUpdateServiceArgs {
+  channel: BbDesktopVersionFeed["channel"];
   currentVersion: string;
   enabled: boolean;
   feedUrl: string;
@@ -127,6 +129,22 @@ export function parseDesktopVersionFeed(
     return {
       kind: "malformed",
       reason: `The desktop version feed did not match schema: ${parsedFeed.error.message}`,
+    };
+  }
+
+  // Both platforms publish a feed into the same release tag, so a swapped or
+  // mis-uploaded asset is now possible where it was not before. A feed that
+  // does not describe this build must never raise an update prompt.
+  if (parsedFeed.data.platform !== args.platform) {
+    return {
+      kind: "malformed",
+      reason: `The desktop version feed is for another platform: expected ${args.platform}, got ${parsedFeed.data.platform}`,
+    };
+  }
+  if (parsedFeed.data.channel !== args.channel) {
+    return {
+      kind: "malformed",
+      reason: `The desktop version feed is for another channel: expected ${args.channel}, got ${parsedFeed.data.channel}`,
     };
   }
 
@@ -237,6 +255,7 @@ export function createDesktopUpdateService(
       }
 
       const parsed = parseDesktopVersionFeed({
+        channel: args.channel,
         checkedAt,
         currentVersion: args.currentVersion,
         payloadText,

--- a/apps/desktop/src/desktop-update-check.ts
+++ b/apps/desktop/src/desktop-update-check.ts
@@ -7,7 +7,7 @@ import {
   type BbDesktopVersionFeed,
 } from "@bb/desktop-contract";
 
-export { DESKTOP_UPDATE_FEED_URL } from "./desktop-update-provider.js";
+export { createDesktopUpdateFeedUrl } from "./desktop-update-provider.js";
 export const DESKTOP_UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
 export const DESKTOP_UPDATE_CHECK_TIMEOUT_MS = 5_000;
 export const DESKTOP_UPDATE_ACTIVE_MIN_INTERVAL_MS = 15 * 60 * 1000;
@@ -116,7 +116,7 @@ export function parseDesktopVersionFeed(
   } catch (error) {
     return {
       kind: "malformed",
-      reason: `desktop-version.json was not valid JSON: ${formatErrorMessage(
+      reason: `The desktop version feed was not valid JSON: ${formatErrorMessage(
         error,
       )}`,
     };
@@ -126,7 +126,7 @@ export function parseDesktopVersionFeed(
   if (!parsedFeed.success) {
     return {
       kind: "malformed",
-      reason: `desktop-version.json did not match schema: ${parsedFeed.error.message}`,
+      reason: `The desktop version feed did not match schema: ${parsedFeed.error.message}`,
     };
   }
 
@@ -135,7 +135,7 @@ export function parseDesktopVersionFeed(
   if (parsedCurrentVersion === null || parsedFeedVersion === null) {
     return {
       kind: "malformed",
-      reason: `desktop-version.json contained an invalid version: current=${args.currentVersion} feed=${parsedFeed.data.version}`,
+      reason: `The desktop version feed contained an invalid version: current=${args.currentVersion} feed=${parsedFeed.data.version}`,
     };
   }
 

--- a/apps/desktop/src/desktop-update-provider.ts
+++ b/apps/desktop/src/desktop-update-provider.ts
@@ -83,6 +83,11 @@ export interface DesktopUpdateSupport {
 }
 
 export interface ResolveDesktopUpdateSupportArgs {
+  /**
+   * Whether the AppImage at this path can actually be replaced in place.
+   * Injected so the decision stays testable without touching a real file.
+   */
+  canReplaceAppImage: (appImagePath: string) => boolean;
   env: NodeJS.ProcessEnv;
   platform: BbDesktopVersionFeedPlatform;
 }
@@ -97,5 +102,15 @@ export function resolveDesktopUpdateSupport(
   // A distro package or an extracted directory cannot rewrite itself, so those
   // Linux installs still learn that a release exists but never self-install.
   const appImagePath = args.env.APPIMAGE?.trim() ?? "";
-  return { autoUpdate: appImagePath.length > 0, versionCheck: true };
+  if (appImagePath.length === 0) {
+    return { autoUpdate: false, versionCheck: true };
+  }
+
+  // electron-updater's AppImage install unlinks the running file before it
+  // moves the replacement in, so a read-only directory destroys the user's
+  // install instead of failing harmlessly. Never offer the install path there.
+  return {
+    autoUpdate: args.canReplaceAppImage(appImagePath),
+    versionCheck: true,
+  };
 }

--- a/apps/desktop/src/desktop-update-provider.ts
+++ b/apps/desktop/src/desktop-update-provider.ts
@@ -1,3 +1,8 @@
+import {
+  createBbDesktopVersionFeedFileName,
+  type BbDesktopVersionFeedPlatform,
+} from "@bb/desktop-contract";
+
 export type DesktopReleaseChannel = "latest" | "nightly";
 
 export interface DesktopReleaseInfo {
@@ -47,7 +52,12 @@ export const DESKTOP_RELEASE_INFO = createDesktopReleaseInfo(
 export const DESKTOP_UPDATE_RELEASE_BASE_URL =
   DESKTOP_RELEASE_INFO.updateReleaseBaseUrl;
 export const DESKTOP_UPDATE_CHANNEL = DESKTOP_RELEASE_CHANNEL;
-export const DESKTOP_UPDATE_FEED_URL = `${DESKTOP_UPDATE_RELEASE_BASE_URL}desktop-version.json`;
+
+export function createDesktopUpdateFeedUrl(
+  platform: BbDesktopVersionFeedPlatform,
+): string {
+  return `${DESKTOP_UPDATE_RELEASE_BASE_URL}${createBbDesktopVersionFeedFileName(platform)}`;
+}
 
 export interface DesktopAutoUpdateFeedConfig {
   channel: DesktopReleaseChannel;
@@ -60,3 +70,32 @@ export const DESKTOP_AUTO_UPDATE_FEED_CONFIG: DesktopAutoUpdateFeedConfig = {
   provider: "generic",
   url: DESKTOP_UPDATE_RELEASE_BASE_URL,
 };
+
+export interface DesktopUpdateSupport {
+  /**
+   * electron-updater can download a replacement build and install it. Linux
+   * only qualifies inside an AppImage, which is the one Linux target that can
+   * replace its own file in place.
+   */
+  autoUpdate: boolean;
+  /** The JSON version feed can be polled to tell the user a release exists. */
+  versionCheck: boolean;
+}
+
+export interface ResolveDesktopUpdateSupportArgs {
+  env: NodeJS.ProcessEnv;
+  platform: BbDesktopVersionFeedPlatform;
+}
+
+export function resolveDesktopUpdateSupport(
+  args: ResolveDesktopUpdateSupportArgs,
+): DesktopUpdateSupport {
+  if (args.platform === "macos") {
+    return { autoUpdate: true, versionCheck: true };
+  }
+
+  // A distro package or an extracted directory cannot rewrite itself, so those
+  // Linux installs still learn that a release exists but never self-install.
+  const appImagePath = args.env.APPIMAGE?.trim() ?? "";
+  return { autoUpdate: appImagePath.length > 0, versionCheck: true };
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
+import { accessSync, constants as fsConstants } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import {
   app,
   BrowserWindow,
@@ -115,6 +116,7 @@ import {
 } from "./desktop-update-check.js";
 import {
   DESKTOP_RELEASE_INFO,
+  DESKTOP_UPDATE_CHANNEL,
   resolveDesktopUpdateSupport,
 } from "./desktop-update-provider.js";
 import {
@@ -361,6 +363,25 @@ function resolveDesktopWindowUrl(args: ResolveDesktopWindowUrlArgs): string {
     throw new Error("BB_DESKTOP_APP_URL must be an http(s) URL");
   }
   return rawAppUrl;
+}
+
+/**
+ * electron-updater unlinks the running AppImage before it moves the downloaded
+ * one into place, so both operations need write and search access on the parent
+ * directory. Without that access the install deletes the user's app and leaves
+ * nothing behind, so this gates the install path rather than the download.
+ */
+function canReplaceAppImage(appImagePath: string): boolean {
+  try {
+    accessSync(
+      dirname(appImagePath),
+      // eslint-disable-next-line no-bitwise
+      fsConstants.W_OK | fsConstants.X_OK,
+    );
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function resolveDesktopUpdateFeedUrl(
@@ -1550,6 +1571,20 @@ function registerDesktopUpdateIpc(): void {
       desktopAutoUpdateService.installUpdate();
       return;
     }
+    // finishQuit stops the local runtime, and it cannot be undone. Re-check
+    // that the swap can still succeed first: permissions may have changed
+    // since startup, and on Linux a failed swap would otherwise leave a shell
+    // with no runtime and no application file.
+    const appImagePath = process.env.APPIMAGE?.trim() ?? "";
+    if (
+      process.platform === "linux" &&
+      (appImagePath.length === 0 || !canReplaceAppImage(appImagePath))
+    ) {
+      createDesktopLogger().error(
+        `Desktop update install skipped: ${appImagePath || "this build"} cannot be replaced in place. The runtime stays up; download the new AppImage instead.`,
+      );
+      return;
+    }
     quitting = true;
     stoppingForQuit = true;
     await finishQuit();
@@ -2130,10 +2165,12 @@ async function runDesktopApp(): Promise<void> {
   });
 
   const desktopUpdateSupport = resolveDesktopUpdateSupport({
+    canReplaceAppImage,
     env: process.env,
     platform: desktopPlatform,
   });
   desktopUpdateService = createDesktopUpdateService({
+    channel: DESKTOP_UPDATE_CHANNEL,
     currentVersion: desktopVersion,
     enabled:
       desktopUpdateSupport.versionCheck &&

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -110,10 +110,13 @@ import { registerDesktopContextMenu } from "./desktop-context-menu.js";
 import { resolveBbDesktopPlatform } from "./desktop-platform.js";
 import {
   createDesktopUpdateService,
-  DESKTOP_UPDATE_FEED_URL,
+  createDesktopUpdateFeedUrl,
   type DesktopUpdateService,
 } from "./desktop-update-check.js";
-import { DESKTOP_RELEASE_INFO } from "./desktop-update-provider.js";
+import {
+  DESKTOP_RELEASE_INFO,
+  resolveDesktopUpdateSupport,
+} from "./desktop-update-provider.js";
 import {
   createDesktopAutoUpdateService,
   createElectronAutoUpdaterAdapter,
@@ -260,6 +263,7 @@ interface ResolveDesktopWindowUrlArgs {
 
 interface ResolveDesktopUpdateFeedUrlArgs {
   env: NodeJS.ProcessEnv;
+  platform: BbDesktopInfo["platform"];
 }
 
 interface FetchSystemConfigArgs {
@@ -364,7 +368,7 @@ function resolveDesktopUpdateFeedUrl(
 ): string {
   const rawFeedUrl = args.env.BB_DESKTOP_VERSION_FEED_URL?.trim();
   if (rawFeedUrl === undefined || rawFeedUrl.length === 0) {
-    return DESKTOP_UPDATE_FEED_URL;
+    return createDesktopUpdateFeedUrl(args.platform);
   }
   return rawFeedUrl;
 }
@@ -2032,8 +2036,10 @@ async function runDesktopApp(): Promise<void> {
   builtinServerUrl = serverUrl;
   desktopBridgePath = bridgePath;
   const desktopVersion = getDesktopVersion(process.env.BB_DESKTOP_VERSION);
+  const desktopPlatform = resolveBbDesktopPlatform(process.platform);
   const desktopUpdateFeedUrl = resolveDesktopUpdateFeedUrl({
     env: process.env,
+    platform: desktopPlatform,
   });
   const userDataPath = app.getPath("userData");
   desktopUserDataPath = userDataPath;
@@ -2123,12 +2129,14 @@ async function runDesktopApp(): Promise<void> {
     },
   });
 
-  const desktopPlatform = resolveBbDesktopPlatform(process.platform);
-  const desktopUpdatesSupported = process.platform === "darwin";
+  const desktopUpdateSupport = resolveDesktopUpdateSupport({
+    env: process.env,
+    platform: desktopPlatform,
+  });
   desktopUpdateService = createDesktopUpdateService({
     currentVersion: desktopVersion,
     enabled:
-      desktopUpdatesSupported &&
+      desktopUpdateSupport.versionCheck &&
       (app.isPackaged || process.env.BB_DESKTOP_VERSION_CHECK === "1"),
     feedUrl: desktopUpdateFeedUrl,
     logger: createDesktopLogger(),
@@ -2137,7 +2145,7 @@ async function runDesktopApp(): Promise<void> {
   desktopAutoUpdateService = createDesktopAutoUpdateService({
     currentVersion: desktopVersion,
     enabled:
-      desktopUpdatesSupported &&
+      desktopUpdateSupport.autoUpdate &&
       shouldEnableDesktopAutoUpdate({
         env: process.env,
         isPackaged: app.isPackaged,
@@ -2186,12 +2194,14 @@ async function runDesktopApp(): Promise<void> {
     },
   });
   registerDesktopBrowserIpc(desktopBrowserViewManager);
-  if (desktopUpdatesSupported) {
+  if (desktopUpdateSupport.versionCheck) {
     desktopUpdateService.start();
+  }
+  if (desktopUpdateSupport.autoUpdate) {
     desktopAutoUpdateService.start();
   } else {
     logger.info(
-      "Desktop update checks disabled on linux: no Linux update feed yet.",
+      "Desktop auto-install is disabled: only the Linux AppImage build can replace itself. Version checks still report new releases.",
     );
   }
 

--- a/apps/desktop/test/desktop-update-check.test.ts
+++ b/apps/desktop/test/desktop-update-check.test.ts
@@ -41,6 +41,7 @@ function createFeedResponse(version: string): Response {
 describe("desktop update feed parsing", () => {
   it("accepts a valid desktop-version.json payload", () => {
     const result = parseDesktopVersionFeed({
+      channel: "latest",
       checkedAt,
       currentVersion: "0.0.1",
       payloadText: JSON.stringify(createFeed("0.0.2")),
@@ -84,6 +85,7 @@ describe("desktop update feed parsing", () => {
     };
 
     const result = parseDesktopVersionFeed({
+      channel: "latest",
       checkedAt,
       currentVersion: "0.0.1",
       payloadText: JSON.stringify(payload),
@@ -95,6 +97,7 @@ describe("desktop update feed parsing", () => {
 
   it("rejects malformed JSON", () => {
     const result = parseDesktopVersionFeed({
+      channel: "latest",
       checkedAt,
       currentVersion: "0.0.1",
       payloadText: "{",
@@ -104,8 +107,65 @@ describe("desktop update feed parsing", () => {
     expect(result.kind).toBe("malformed");
   });
 
+  it("rejects a feed that describes another platform", () => {
+    // macOS and Linux feeds share a release tag, so a swapped upload would
+    // otherwise advertise a Linux build to macOS users as an update.
+    const result = parseDesktopVersionFeed({
+      channel: "latest",
+      checkedAt,
+      currentVersion: "0.0.1",
+      payloadText: JSON.stringify({
+        ...createFeed("0.0.2"),
+        platform: "linux",
+      }),
+      platform: "macos",
+    });
+
+    expect(result.kind).toBe("malformed");
+    if (result.kind !== "malformed") {
+      throw new Error("Expected a cross-platform feed to be rejected");
+    }
+    expect(result.reason).toContain("another platform");
+  });
+
+  it("rejects a feed that describes another channel", () => {
+    // A stable build must never take an update from the nightly feed.
+    const result = parseDesktopVersionFeed({
+      channel: "latest",
+      checkedAt,
+      currentVersion: "0.0.1",
+      payloadText: JSON.stringify({
+        ...createFeed("0.0.2"),
+        channel: "nightly",
+      }),
+      platform: "macos",
+    });
+
+    expect(result.kind).toBe("malformed");
+    if (result.kind !== "malformed") {
+      throw new Error("Expected a cross-channel feed to be rejected");
+    }
+    expect(result.reason).toContain("another channel");
+  });
+
+  it("accepts a Linux feed on a Linux build", () => {
+    const result = parseDesktopVersionFeed({
+      channel: "latest",
+      checkedAt,
+      currentVersion: "0.0.1",
+      payloadText: JSON.stringify({
+        ...createFeed("0.0.2"),
+        platform: "linux",
+      }),
+      platform: "linux",
+    });
+
+    expect(result.kind).toBe("valid");
+  });
+
   it("does not mark a lower feed version as an available update", () => {
     const result = parseDesktopVersionFeed({
+      channel: "latest",
       checkedAt,
       currentVersion: "0.0.2",
       payloadText: JSON.stringify(createFeed("0.0.1")),
@@ -141,6 +201,7 @@ describe("desktop update service", () => {
       throw new Error("network offline");
     };
     const service = createDesktopUpdateService({
+      channel: "latest",
       currentVersion: "0.0.1",
       enabled: true,
       feedUrl: "https://example.test/desktop-version.json",
@@ -200,6 +261,7 @@ describe("desktop update service", () => {
         });
       };
       const service = createDesktopUpdateService({
+        channel: "latest",
         currentVersion: "0.0.1",
         enabled: true,
         feedUrl: "https://example.test/desktop-version.json",
@@ -238,6 +300,7 @@ describe("desktop update service", () => {
       return createFeedResponse("0.0.2");
     };
     const service = createDesktopUpdateService({
+      channel: "latest",
       currentVersion: "0.0.1",
       enabled: true,
       feedUrl: "https://example.test/desktop-version.json",
@@ -265,6 +328,7 @@ describe("desktop update service", () => {
 
   it("reports the injected linux platform in its base info", () => {
     const service = createDesktopUpdateService({
+      channel: "latest",
       currentVersion: "0.0.1",
       enabled: false,
       feedUrl: "https://example.test/desktop-version.json",

--- a/apps/desktop/test/desktop-update-provider.test.ts
+++ b/apps/desktop/test/desktop-update-provider.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  createDesktopUpdateFeedUrl,
+  resolveDesktopUpdateSupport,
+} from "../src/desktop-update-provider.js";
+
+describe("desktop update feed url", () => {
+  it("gives each platform its own feed file inside one release tag", () => {
+    // macOS and Linux assets share the desktop-latest release, so a single
+    // feed name would make the last publish overwrite the other platform.
+    expect(createDesktopUpdateFeedUrl("macos")).toBe(
+      "https://github.com/get-bb/bb/releases/download/desktop-latest/desktop-version.json",
+    );
+    expect(createDesktopUpdateFeedUrl("linux")).toBe(
+      "https://github.com/get-bb/bb/releases/download/desktop-latest/desktop-version-linux.json",
+    );
+  });
+});
+
+describe("desktop update support", () => {
+  it("enables both update paths on macOS", () => {
+    expect(resolveDesktopUpdateSupport({ env: {}, platform: "macos" })).toEqual(
+      {
+        autoUpdate: true,
+        versionCheck: true,
+      },
+    );
+  });
+
+  it("installs updates on Linux only inside an AppImage", () => {
+    // electron-updater replaces the running AppImage file in place. A distro
+    // package or an extracted directory has nothing to replace, so it would
+    // fail every download instead of quietly doing nothing.
+    expect(
+      resolveDesktopUpdateSupport({
+        env: { APPIMAGE: "/home/user/Apps/bb-0.37.0-x86_64.AppImage" },
+        platform: "linux",
+      }),
+    ).toEqual({ autoUpdate: true, versionCheck: true });
+    expect(resolveDesktopUpdateSupport({ env: {}, platform: "linux" })).toEqual(
+      {
+        autoUpdate: false,
+        versionCheck: true,
+      },
+    );
+    expect(
+      resolveDesktopUpdateSupport({
+        env: { APPIMAGE: "  " },
+        platform: "linux",
+      }),
+    ).toEqual({ autoUpdate: false, versionCheck: true });
+  });
+});

--- a/apps/desktop/test/desktop-update-provider.test.ts
+++ b/apps/desktop/test/desktop-update-provider.test.ts
@@ -17,14 +17,19 @@ describe("desktop update feed url", () => {
   });
 });
 
+const APP_IMAGE_PATH = "/home/user/Apps/bb-0.37.0-x86_64.AppImage";
+const alwaysReplaceable = () => true;
+const neverReplaceable = () => false;
+
 describe("desktop update support", () => {
   it("enables both update paths on macOS", () => {
-    expect(resolveDesktopUpdateSupport({ env: {}, platform: "macos" })).toEqual(
-      {
-        autoUpdate: true,
-        versionCheck: true,
-      },
-    );
+    expect(
+      resolveDesktopUpdateSupport({
+        canReplaceAppImage: neverReplaceable,
+        env: {},
+        platform: "macos",
+      }),
+    ).toEqual({ autoUpdate: true, versionCheck: true });
   });
 
   it("installs updates on Linux only inside an AppImage", () => {
@@ -33,21 +38,59 @@ describe("desktop update support", () => {
     // fail every download instead of quietly doing nothing.
     expect(
       resolveDesktopUpdateSupport({
-        env: { APPIMAGE: "/home/user/Apps/bb-0.37.0-x86_64.AppImage" },
+        canReplaceAppImage: alwaysReplaceable,
+        env: { APPIMAGE: APP_IMAGE_PATH },
         platform: "linux",
       }),
     ).toEqual({ autoUpdate: true, versionCheck: true });
-    expect(resolveDesktopUpdateSupport({ env: {}, platform: "linux" })).toEqual(
-      {
-        autoUpdate: false,
-        versionCheck: true,
-      },
-    );
     expect(
       resolveDesktopUpdateSupport({
+        canReplaceAppImage: alwaysReplaceable,
+        env: {},
+        platform: "linux",
+      }),
+    ).toEqual({ autoUpdate: false, versionCheck: true });
+    expect(
+      resolveDesktopUpdateSupport({
+        canReplaceAppImage: alwaysReplaceable,
         env: { APPIMAGE: "  " },
         platform: "linux",
       }),
     ).toEqual({ autoUpdate: false, versionCheck: true });
+  });
+
+  it("refuses to install into an AppImage it cannot replace", () => {
+    // electron-updater unlinks the running AppImage before moving the new one
+    // in, so attempting this in a read-only directory deletes the user's app
+    // and leaves nothing behind. Version checks must survive that.
+    const checked: Array<string> = [];
+
+    expect(
+      resolveDesktopUpdateSupport({
+        canReplaceAppImage: (path) => {
+          checked.push(path);
+          return false;
+        },
+        env: { APPIMAGE: APP_IMAGE_PATH },
+        platform: "linux",
+      }),
+    ).toEqual({ autoUpdate: false, versionCheck: true });
+    expect(checked).toEqual([APP_IMAGE_PATH]);
+  });
+
+  it("does not consult the filesystem on macOS", () => {
+    // macOS installs through Squirrel, which owns its own replacement path.
+    let consulted = false;
+
+    resolveDesktopUpdateSupport({
+      canReplaceAppImage: () => {
+        consulted = true;
+        return true;
+      },
+      env: { APPIMAGE: APP_IMAGE_PATH },
+      platform: "macos",
+    });
+
+    expect(consulted).toBe(false);
   });
 });

--- a/apps/desktop/test/electron-builder-config.test.ts
+++ b/apps/desktop/test/electron-builder-config.test.ts
@@ -52,7 +52,7 @@ const macConfigSchema = z
 const linuxConfigSchema = z
   .object({
     category: z.literal("Development"),
-    executableName: z.literal("bb"),
+    executableName: z.enum(["bb", "bb-nightly"]),
     icon: z.string().min(1),
     target: z.tuple([
       z
@@ -272,10 +272,7 @@ describe("electron-builder signing config", () => {
     );
 
     expect(Object.keys(packageJson.optionalDependencies ?? {})).not.toEqual(
-      expect.arrayContaining([
-        "@esbuild/darwin-arm64",
-        "@esbuild/darwin-x64",
-      ]),
+      expect.arrayContaining(["@esbuild/darwin-arm64", "@esbuild/darwin-x64"]),
     );
   });
 
@@ -539,6 +536,9 @@ describe("electron-builder signing config", () => {
     expect(config.productName).toBe("bb Nightly");
     expect(config.artifactName).toBe("bb-nightly-${version}-${arch}.${ext}");
     expect(config.linux.icon).toBe("assets/icon-nightly.png");
+    // A shared Linux binary name would let one channel shadow the other on
+    // PATH, and the two channels are meant to be installed side by side.
+    expect(config.linux.executableName).toBe("bb-nightly");
     expect(config.mac.icon).toBe("assets/icon-nightly.icns");
     await expect(
       access(resolve(desktopPackageRoot, config.mac.icon)),

--- a/docs/bb-release-process.md
+++ b/docs/bb-release-process.md
@@ -17,9 +17,11 @@ desktop app is published at the same version (see "Publish The Desktop App").
 
 The automated nightly channel is the exception to the manual stable flow. The
 scheduled path in `publish-bb-app.yml` derives a unique next-patch prerelease,
-publishes it under npm's `nightly` dist-tag, then builds and publishes the
-separately installable `bb Nightly` app at `desktop-nightly`. It does not commit
-the generated version or move either stable `latest` pointer. If the
+publishes it under npm's `nightly` dist-tag, then builds the separately
+installable `bb Nightly` app for macOS and Linux and publishes both at
+`desktop-nightly`. It does not commit the generated version or move either
+stable `latest` pointer. Each platform job derives the nightly version from the
+run ID, so the two jobs agree without sharing state. If the
 `npm-release` GitHub environment requires approval, scheduled runs will wait
 for that approval; remove the reviewer gate only if fully unattended nightly
 publishing is intended.
@@ -186,10 +188,15 @@ Report:
 ## Publish The Desktop App
 
 The npm publish does not build or publish the desktop app. The desktop release
-is a separate workflow that builds, signs, and notarizes the macOS app, creates
-the immutable `desktop-v<version>` GitHub release, and moves the `desktop-latest`
-release and its `desktop-version.json` auto-update feed. Run it from the same
-pushed `main` commit, at the same version, for every stable release.
+is a separate workflow. It builds the signed and notarized macOS app and the
+Linux x64 AppImage in parallel jobs, then one publish job creates the immutable
+`desktop-v<version>` GitHub release and moves the `desktop-latest` release with
+both auto-update feeds: `desktop-version.json` for macOS and
+`desktop-version-linux.json` for Linux. Run it from the same pushed `main`
+commit, at the same version, for every stable release.
+
+A failure in either platform job stops the publish job, so no release can ship
+one platform's binaries against the other platform's stale feed.
 
 ```bash
 gh workflow run build-desktop.yml \

--- a/docs/bb-release-process.md
+++ b/docs/bb-release-process.md
@@ -210,7 +210,9 @@ gh workflow run build-desktop.yml \
 - Only a non-prerelease version is published. The workflow refuses to publish a
   prerelease (`X.Y.Z-...`) to `desktop-latest`.
 - macOS signing/notarization secrets must be configured, or the workflow
-  publishes `desktop-version.json` only and withholds the unsigned `.dmg`/`.zip`.
+  withholds the unsigned `.dmg`/`.zip` and publishes both version feeds plus the
+  Linux AppImage. Linux has no notarization equivalent, so it never waits on the
+  Apple secrets.
 - The `desktop-v<version>` release is immutable: if it already exists the
   workflow fails. Bump to a new version rather than re-running the same one.
 - The immutable `desktop-v<version>` release owns GitHub's repository-wide
@@ -259,6 +261,7 @@ Add to the report from "Verify The Release":
 - If the desktop workflow fails because `desktop-v<version>` already exists, do
   not delete the immutable release. Bump to the next version, re-run the npm
   publish, then re-run the desktop workflow.
-- If the desktop workflow publishes `desktop-version.json` only (binaries
-  withheld), the macOS signing secrets are missing or incomplete. Fix the
-  secrets and re-run; do not hand-upload unsigned binaries to `desktop-latest`.
+- If the desktop workflow withholds the macOS binaries (feeds and the Linux
+  AppImage still publish), the macOS signing secrets are missing or incomplete.
+  Fix the secrets and re-run; do not hand-upload unsigned macOS binaries to
+  `desktop-latest`.

--- a/packages/desktop-contract/src/version-feed.ts
+++ b/packages/desktop-contract/src/version-feed.ts
@@ -8,10 +8,15 @@ export const bbDesktopVersionFeedFileSchema = z.object({
   size: z.number().int().nonnegative(),
 });
 
+export const bbDesktopVersionFeedPlatformSchema = z.enum(["macos", "linux"]);
+export type BbDesktopVersionFeedPlatform = z.infer<
+  typeof bbDesktopVersionFeedPlatformSchema
+>;
+
 export const bbDesktopVersionFeedSchema = z.object({
   schemaVersion: z.literal(1),
   channel: z.enum(["latest", "nightly"]),
-  platform: z.literal("macos"),
+  platform: bbDesktopVersionFeedPlatformSchema,
   version: z.string().min(1),
   releaseDate: isoUtcDateTimeSchema,
   releaseName: z.string().min(1),
@@ -23,3 +28,20 @@ export const bbDesktopVersionFeedSchema = z.object({
   stagingPercentage: z.number().min(0).max(100).nullable(),
 });
 export type BbDesktopVersionFeed = z.infer<typeof bbDesktopVersionFeedSchema>;
+
+/**
+ * One feed file per platform lives under each release tag, so the release job
+ * can publish macOS and Linux assets into the same moving release. macOS keeps
+ * the original unsuffixed name: shipped macOS builds already request it, and
+ * renaming it would strand every installed app on its current version.
+ */
+export const BB_DESKTOP_VERSION_FEED_FILE_NAMES = {
+  linux: "desktop-version-linux.json",
+  macos: "desktop-version.json",
+} as const satisfies Record<BbDesktopVersionFeedPlatform, string>;
+
+export function createBbDesktopVersionFeedFileName(
+  platform: BbDesktopVersionFeedPlatform,
+): string {
+  return BB_DESKTOP_VERSION_FEED_FILE_NAMES[platform];
+}

--- a/packages/desktop-contract/test/version-feed.test.ts
+++ b/packages/desktop-contract/test/version-feed.test.ts
@@ -4,6 +4,7 @@ import {
   bbDesktopThemeSchema,
   bbDesktopVersionFeedSchema,
   bbDesktopWindowStateSchema,
+  createBbDesktopVersionFeedFileName,
 } from "../src/index.js";
 
 const checkedAt = "2026-05-21T00:00:00.000Z";
@@ -98,6 +99,42 @@ describe("desktop version feed schema", () => {
         version: "0.0.2-nightly.1.1",
       }).success,
     ).toBe(true);
+  });
+
+  it("accepts a Linux AppImage version feed payload", () => {
+    expect(
+      bbDesktopVersionFeedSchema.safeParse({
+        channel: "latest",
+        files: [
+          {
+            sha512: "BASE64_SHA512_FROM_ELECTRON_BUILDER",
+            size: 123456789,
+            url: "bb-0.0.2-x86_64.AppImage",
+          },
+        ],
+        minimumSystemVersion: null,
+        path: "bb-0.0.2-x86_64.AppImage",
+        platform: "linux",
+        releaseDate: checkedAt,
+        releaseName: "bb desktop 0.0.2",
+        releaseNotes: null,
+        schemaVersion: 1,
+        sha512: "BASE64_SHA512_FROM_ELECTRON_BUILDER",
+        stagingPercentage: null,
+        version: "0.0.2",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("keeps the macOS feed file name unsuffixed so shipped builds keep updating", () => {
+    // Both platforms publish into one release tag, so the names must differ,
+    // and macOS must keep the name its released builds already request.
+    expect(createBbDesktopVersionFeedFileName("macos")).toBe(
+      "desktop-version.json",
+    );
+    expect(createBbDesktopVersionFeedFileName("linux")).toBe(
+      "desktop-version-linux.json",
+    );
   });
 
   it("rejects malformed version feed payloads", () => {


### PR DESCRIPTION
## Summary

The Linux AppImage target landed in #1392 as packaging only — it deferred CI, the update feed, and the nightly channel. This closes those three gaps, so Linux ships on every stable release, gets a nightly channel, and has a working update stream.

## Work done

**Release (`build-desktop.yml`)** — split into `macos`, `linux` (x64 AppImage), and one `publish` job that needs both.

**Nightly (`publish-bb-app.yml`)** — the `nightly-desktop` job became `nightly-desktop-macos` + `nightly-desktop-linux` + `nightly-desktop-publish`, same shape. Both platform jobs derive the nightly version from the run ID, so they agree without sharing state.

The single publisher is load-bearing. `desktop-latest` and `desktop-nightly` are moving releases whose assets are fully reset on each publish, so two platform jobs publishing independently would delete each other's binaries. Building in parallel and publishing once removes that race. A failure in either platform job stops the publish, so a release can never ship one platform's binaries against the other's stale feed.

**Update stream** — each platform gets its own feed file inside the same release tag:

| Platform | Artifacts | electron-updater metadata | Version feed |
| --- | --- | --- | --- |
| macOS | `.dmg`, `.zip` (2 arch) | `latest-mac.yml` | `desktop-version.json` |
| Linux | `.AppImage` (x64) | `latest-linux.yml` | `desktop-version-linux.json` |

macOS keeps the unsuffixed name deliberately: shipped macOS builds already request it, and renaming would strand every installed app on its current version. The feed contract's `platform` widened from `z.literal("macos")` to an enum, and the file-name mapping lives in `@bb/desktop-contract` so the build script and the app read one source of truth.

**Linux updates ungated** in `main.ts`, split into two capabilities rather than one flag:

- Version checks run on every Linux install and report new releases.
- Self-installing auto-update runs only inside an AppImage (detected via `APPIMAGE`). An extracted directory or a distro package has no single file to replace, so it would fail every download rather than quietly doing nothing.

**Channel separation** — nightly Linux builds use `bb-nightly` as the executable name, so stable and nightly can be installed side by side without one shadowing the other on PATH.

Linux artifacts are unsigned; only the macOS binaries wait on the Apple signing secrets, since AppImages have no notarization equivalent.

## Testing

Verified locally:

- `turbo run typecheck test` green for `@bb/desktop` (223 tests), `@bb/desktop-contract` (19), and `@bb/app` typecheck.
- Both workflows parse as YAML; job graph and `needs` wiring confirmed.
- The new asset-assembly shell helper exercised directly: required globs exit 1 when unmatched, optional ones skip. This matters because an unmatched glob would otherwise reach `gh` as a literal pattern and fail the upload.
- The AppImage packaging assumption checked against the installed electron-builder source — `AppImageTarget` dispatches with `isWriteUpdateInfo: true`, and update-info files are written whenever a publish config exists, independent of `--publish`. So `latest-linux.yml` is produced under the existing `--publish never`.

Four `@bb/desktop` suites cannot run in the dev worktree because the Electron binary is not installed; they fail identically on pristine `main`.

## Verification

`Build Desktop` was dispatched against this branch before merge with `publish=false, release_channel=qa` — safe by construction, since publishing requires `publish=true` **and** `release_channel=stable` **and** a non-prerelease version. [Run 31683115574](https://github.com/get-bb/bb/actions/runs/31683115574) passed all three jobs:

- **Linux** — real AppImage build on `ubuntu-22.04`, `latest-linux.yml`, the version-feed generator, and the headless `xvfb` smoke test. The feed step reads `latest-linux.yml` and would have thrown if it were missing, so both it and `desktop-version-linux.json` are confirmed produced.
- **macOS** — unchanged path, still green.
- **Publish** — planned first, then correctly skipped both downloads and the release step, avoiding ~953 MB of artifact transfer it would never use.

Locally: 228 tests plus 19 in `@bb/desktop-contract`, typechecks clean for `@bb/desktop`, `@bb/desktop-contract`, and `@bb/app`. Four `@bb/desktop` suites cannot run in the dev worktree because the Electron binary is not installed; they fail identically on pristine `main`.

Still unexercised by any dry run:

- **The release mutation.** Force-pushing the moving tag and resetting assets only happens on a real stable publish. The failure mode is recoverable: the immutable `desktop-v<version>` release is created first and refuses to overwrite.
- **The nightly desktop path.** Its jobs are gated on `dry_run == false` (pre-existing), so they cannot run from a branch. They are structurally identical to the jobs above; what is nightly-specific — `bb-nightly` as executable name, `nightly-linux.yml`, the nightly icon — is locally testable with `BB_DESKTOP_RELEASE_CHANNEL=nightly pnpm --filter @bb/desktop run dist:linux`.

## Deliberately out of scope

The web download surface has no Linux entry — `apps/web/src/landing/site.ts` still exposes only `DOWNLOAD_MACOS_VERSION_FEED_URL`. Nothing is broken, since macOS kept its feed name, but there is no Linux download CTA yet. Also still deferred from #1392: Linux arm64 and AppStream metadata.

The `ubuntu-22.04` runner pin is intentional. The AppImage links against the build machine's glibc, so that pin sets the oldest distro that can run a published build. It is the oldest hosted image GitHub offers, and worth revisiting when it is retired.

> AGENT GENERATED: by Claude Opus 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
