### PR TITLE
POC: Send native images through Claude sessions

### DIFF
--- a/apps/host-daemon/package.json
+++ b/apps/host-daemon/package.json
@@ -55,6 +55,7 @@
     "pino-roll": "^4.0.0",
     "proper-lockfile": "^4.1.2",
     "semver": "^7.7.4",
+    "sharp": "^0.34.5",
     "smol-toml": "^1.7.1",
     "ws": "^8.19.0",
     "yaml": "^2.9.0",

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -37,6 +37,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@earendil-works/pi-ai": "0.84.0",
     "@earendil-works/pi-coding-agent": "0.84.0",
+    "sharp": "^0.34.5",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/bridge.test.ts
@@ -19,10 +19,14 @@ import {
   type PermissionEscalation,
 } from "@bb/domain";
 
-const { forkSessionMock, queryMock } = vi.hoisted(() => ({
-  forkSessionMock: vi.fn(),
-  queryMock: vi.fn(),
-}));
+const { forkSessionMock, openActualMock, openMock, queryMock } = vi.hoisted(
+  () => ({
+    forkSessionMock: vi.fn(),
+    openActualMock: vi.fn<typeof import("node:fs/promises").open>(),
+    openMock: vi.fn<typeof import("node:fs/promises").open>(),
+    queryMock: vi.fn(),
+  }),
+);
 
 vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
   query: queryMock,
@@ -30,6 +34,13 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
   createSdkMcpServer: vi.fn(() => ({})),
   tool: vi.fn((_name, _desc, _schema, handler) => handler),
 }));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  openActualMock.mockImplementation(actual.open);
+  openMock.mockImplementation(actual.open);
+  return { ...actual, open: openMock };
+});
 
 import { buildSessionOptions, handleLine } from "../bridge.js";
 import {
@@ -112,6 +123,30 @@ interface ControlledClaudeQuery {
   [Symbol.asyncIterator](): AsyncIterator<SDKMessage>;
 }
 
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolvePromise: (value: T) => void = () => undefined;
+  const promise = new Promise<T>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: resolvePromise };
+}
+
+function delayNextImageRead(
+  readStarted: Deferred<void>,
+  releaseRead: Deferred<void>,
+): void {
+  openMock.mockImplementationOnce(async (...args) => {
+    readStarted.resolve(undefined);
+    await releaseRead.promise;
+    return openActualMock(...args);
+  });
+}
+
 interface ClaudeQueryCallOptions {
   canUseTool?: CanUseTool;
   env?: Record<string, string | undefined>;
@@ -158,6 +193,7 @@ const tempDirs: string[] = [];
 
 interface StartBridgeThreadArgs {
   bridge: BridgeJsonRpcTestHarness;
+  requestId?: number;
   threadId: string;
 }
 
@@ -172,6 +208,7 @@ interface ResumeBridgeThreadArgs {
 interface StopBridgeThreadArgs {
   bridge: BridgeJsonRpcTestHarness;
   queries: ControlledClaudeQuery[];
+  requestId?: number;
   threadId: string;
 }
 
@@ -513,7 +550,8 @@ function createBridgeUserQuestionInput(): ClaudeUserQuestionInput {
 }
 
 async function startBridgeThread(args: StartBridgeThreadArgs): Promise<void> {
-  args.bridge.sendRequest(1, "thread/start", {
+  const requestId = args.requestId ?? 1;
+  args.bridge.sendRequest(requestId, "thread/start", {
     workflowsEnabled: false,
     claudeCodeMockCliTraffic: DEFAULT_CLAUDE_CODE_MOCK_CLI_TRAFFIC_CONFIG,
     baseInstructions: "test",
@@ -525,7 +563,7 @@ async function startBridgeThread(args: StartBridgeThreadArgs): Promise<void> {
     permissionScope: "workspace",
     threadId: args.threadId,
   });
-  await args.bridge.waitForResponse(1);
+  await args.bridge.waitForResponse(requestId);
 }
 
 function sendResumeThread(args: ResumeBridgeThreadArgs): void {
@@ -545,12 +583,13 @@ function sendResumeThread(args: ResumeBridgeThreadArgs): void {
 }
 
 async function stopBridgeThread(args: StopBridgeThreadArgs): Promise<void> {
-  args.bridge.sendRequest(2, "thread/stop", {
+  const requestId = args.requestId ?? 2;
+  args.bridge.sendRequest(requestId, "thread/stop", {
     threadId: args.threadId,
   });
   await args.bridge.flushWork();
-  args.queries[0]?.finish();
-  await args.bridge.waitForResponse(2);
+  args.queries.at(-1)?.finish();
+  await args.bridge.waitForResponse(requestId);
 }
 
 async function forwardAskUserQuestion({
@@ -3868,13 +3907,18 @@ describe("bridge", () => {
     },
   );
 
-  describe("prompt attachment text markers", () => {
+  describe("prompt attachments", () => {
+    const VALID_PNG_BYTES = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg==",
+      "base64",
+    );
+
     async function sendTurnAndReadPrompt(
       bridge: BridgeJsonRpcTestHarness,
       queries: ControlledClaudeQuery[],
       threadId: string,
       input: JsonValue[],
-    ): Promise<string> {
+    ): Promise<SDKUserMessage["message"]["content"]> {
       await startBridgeThread({ bridge, threadId });
       bridge.sendRequest(2, "turn/start", {
         permissionEscalation: "ask",
@@ -3883,9 +3927,23 @@ describe("bridge", () => {
         threadId,
       });
       await bridge.waitForResponse(2);
-      const text = await readNextPromptText(getLatestQueryCall());
+      const content = (await readNextPrompt(getLatestQueryCall())).message
+        .content;
       await stopBridgeThread({ bridge, queries, threadId });
-      return text;
+      return content;
+    }
+
+    function createLocalPng(
+      name: string,
+      rawSize = VALID_PNG_BYTES.length,
+    ): { bytes: Buffer; path: string } {
+      const directory = mkdtempSync(join(tmpdir(), "bb-claude-image-"));
+      tempDirs.push(directory);
+      const path = join(directory, name);
+      const bytes = Buffer.alloc(rawSize);
+      VALID_PNG_BYTES.copy(bytes);
+      writeFileSync(path, bytes);
+      return { bytes, path };
     }
 
     function withBridgeHarness(): {
@@ -3935,25 +3993,641 @@ describe("bridge", () => {
       }
     });
 
-    it("emits a path-bearing marker for a localImage attachment", async () => {
+    it("sends a local image as native content in the same user message", async () => {
       const { bridge, queries } = withBridgeHarness();
+      const image = createLocalPng("screenshot.png");
       try {
-        const text = await sendTurnAndReadPrompt(
+        const content = await sendTurnAndReadPrompt(
           bridge,
           queries,
-          "thread-marker-local-image",
+          "thread-native-local-image",
           [
             { type: "text", text: "Describe this" },
             {
               type: "localImage",
-              path: "/staged/runtime-attachments/req-1/000-screenshot.png",
+              path: image.path,
             },
           ],
         );
-        expect(text).toBe(
-          "Describe this\n[Attached image. It is on disk at /staged/runtime-attachments/req-1/000-screenshot.png — use the Read tool to view it.]",
-        );
+        expect(content).toEqual([
+          { type: "text", text: "Describe this" },
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: image.bytes.toString("base64"),
+            },
+          },
+        ]);
       } finally {
+        bridge.restore();
+      }
+    });
+
+    it("shares one native-image budget across grouped SDK messages", async () => {
+      const { bridge, queries } = withBridgeHarness();
+      const image = createLocalPng("grouped-budget.png", 6 * 1024 * 1024);
+      try {
+        const threadId = "thread-grouped-image-budget";
+        await startBridgeThread({ bridge, threadId });
+        const group = [{ type: "localImage", path: image.path }];
+        bridge.sendRequest(2, "turn/start", {
+          permissionEscalation: "ask",
+          input: [...group, ...group, ...group],
+          inputGroups: [group, group, group],
+          providerThreadId: null,
+          threadId,
+        });
+        await bridge.waitForResponse(2);
+
+        const prompt = getLatestQueryCall().prompt[Symbol.asyncIterator]();
+        const contents = [
+          await prompt.next(),
+          await prompt.next(),
+          await prompt.next(),
+        ];
+        expect(
+          contents.map((result) => {
+            const content = result.value?.message.content;
+            return Array.isArray(content) ? content[0]?.type : "text";
+          }),
+        ).toEqual(["image", "image", "text"]);
+        expect(contents[2]?.value?.message.content).toContain(
+          "use the Read tool to view it",
+        );
+
+        await stopBridgeThread({ bridge, queries, threadId });
+      } finally {
+        queries.forEach((query) => query.finish());
+        bridge.restore();
+      }
+    });
+
+    it("keeps the native-image budget across turns in one session", async () => {
+      const { bridge, queries } = withBridgeHarness();
+      const image = createLocalPng("retained-budget.png", 6 * 1024 * 1024);
+      try {
+        const threadId = "thread-retained-image-budget";
+        await startBridgeThread({ bridge, threadId });
+        bridge.sendRequest(2, "turn/start", {
+          permissionEscalation: "ask",
+          input: [
+            { type: "localImage", path: image.path },
+            { type: "localImage", path: image.path },
+          ],
+          providerThreadId: null,
+          threadId,
+        });
+        await bridge.waitForResponse(2);
+        const first = await readNextPrompt(getLatestQueryCall());
+        expect(
+          Array.isArray(first.message.content)
+            ? first.message.content.map((block) => block.type)
+            : [],
+        ).toEqual(["image", "image"]);
+
+        bridge.sendRequest(3, "turn/start", {
+          permissionEscalation: "ask",
+          input: [{ type: "localImage", path: image.path }],
+          providerThreadId: null,
+          threadId,
+        });
+        await bridge.waitForResponse(3);
+        await expect(
+          readNextPromptText(getLatestQueryCall()),
+        ).resolves.toContain("use the Read tool to view it");
+
+        await stopBridgeThread({
+          bridge,
+          queries,
+          requestId: 4,
+          threadId,
+        });
+      } finally {
+        queries.forEach((query) => query.finish());
+        bridge.restore();
+      }
+    });
+
+    it("carries the native-image budget into stream recovery", async () => {
+      const { bridge, queries } = withBridgeHarness();
+      const image = createLocalPng("recovery-budget.png", 6 * 1024 * 1024);
+      try {
+        const threadId = "thread-recovery-image-budget";
+        await startBridgeThread({ bridge, threadId });
+        bridge.sendRequest(2, "turn/start", {
+          permissionEscalation: "ask",
+          input: [
+            { type: "localImage", path: image.path },
+            { type: "localImage", path: image.path },
+          ],
+          providerThreadId: null,
+          threadId,
+        });
+        await bridge.waitForResponse(2);
+        await readNextPrompt(getLatestQueryCall());
+
+        queries[0]?.finish();
+        await bridge.flushWork();
+        bridge.sendRequest(3, "turn/start", {
+          permissionEscalation: "ask",
+          input: [{ type: "localImage", path: image.path }],
+          providerThreadId: null,
+          threadId,
+        });
+        await bridge.waitForResponse(3);
+
+        expect(queries).toHaveLength(2);
+        await expect(
+          readNextPromptText(getLatestQueryCall()),
+        ).resolves.toContain("use the Read tool to view it");
+
+        await stopBridgeThread({
+          bridge,
+          queries,
+          requestId: 4,
+          threadId,
+        });
+      } finally {
+        queries.forEach((query) => query.finish());
+        bridge.restore();
+      }
+    });
+
+    it("uses Read-tool markers when resumed history size is unknown", async () => {
+      const { bridge, queries } = withBridgeHarness();
+      const image = createLocalPng("resumed.png");
+      try {
+        const threadId = "thread-resumed-image-budget";
+        sendResumeThread({
+          bridge,
+          providerThreadId: "external-provider-session",
+          requestId: 1,
+          threadId,
+        });
+        await bridge.waitForResponse(1);
+        bridge.sendRequest(2, "turn/start", {
+          permissionEscalation: "ask",
+          input: [{ type: "localImage", path: image.path }],
+          providerThreadId: "external-provider-session",
+          threadId,
+        });
+        await bridge.waitForResponse(2);
+
+        await expect(
+          readNextPromptText(getLatestQueryCall()),
+        ).resolves.toContain("use the Read tool to view it");
+        await stopBridgeThread({ bridge, queries, threadId });
+      } finally {
+        queries.forEach((query) => query.finish());
+        bridge.restore();
+      }
+    });
+
+    it("uses Read-tool markers when forked history size is unknown", async () => {
+      const { bridge, queries } = withBridgeHarness();
+      const image = createLocalPng("forked.png");
+      try {
+        const threadId = "thread-forked-image-budget";
+        bridge.sendRequest(1, "thread/fork", {
+          approvedPlanPermissionMode: "default",
+          workflowsEnabled: false,
+          claudeCodeMockCliTraffic: DEFAULT_CLAUDE_CODE_MOCK_CLI_TRAFFIC_CONFIG,
+          baseInstructions: "test",
+          cwd: "/tmp/worktree",
+          instructionMode: "append",
+          permissionEscalation: "ask",
+          permissionMode: "default",
+          permissionScope: "workspace",
+          sourceProviderCheckpointId: "assistant-message-42",
+          sourceProviderThreadId: "source-session-1",
+          threadId,
+        });
+        await bridge.waitForResponse(1);
+        bridge.sendRequest(2, "turn/start", {
+          permissionEscalation: "ask",
+          input: [{ type: "localImage", path: image.path }],
+          providerThreadId: "forked-session-1",
+          threadId,
+        });
+        await bridge.waitForResponse(2);
+
+        await expect(
+          readNextPromptText(getLatestQueryCall()),
+        ).resolves.toContain("use the Read tool to view it");
+        await stopBridgeThread({ bridge, queries, threadId });
+      } finally {
+        queries.forEach((query) => query.finish());
+        bridge.restore();
+      }
+    });
+
+    it("preserves same-thread start then steer order while an image read is pending", async () => {
+      const { bridge, queries } = withBridgeHarness();
+      const image = createLocalPng("delayed.png");
+      const readStarted = createDeferred<void>();
+      const releaseRead = createDeferred<void>();
+      delayNextImageRead(readStarted, releaseRead);
+
+      try {
+        await startBridgeThread({
+          bridge,
+          threadId: "thread-native-image-order",
+        });
+        bridge.sendRequest(10, "turn/start", {
+          permissionEscalation: "ask",
+          input: [
+            { type: "text", text: "First" },
+            { type: "localImage", path: image.path },
+          ],
+          providerThreadId: null,
+          threadId: "thread-native-image-order",
+        });
+        await readStarted.promise;
+
+        bridge.sendRequest(11, "turn/steer", {
+          permissionEscalation: "ask",
+          expectedTurnId: "turn-1",
+          input: [{ type: "text", text: "Second" }],
+          providerThreadId: null,
+          threadId: "thread-native-image-order",
+        });
+        await bridge.flushWork();
+        expect(bridge.hasResponse(11)).toBe(false);
+
+        releaseRead.resolve(undefined);
+        await bridge.waitForResponse(10);
+        const prompt = getLatestQueryCall().prompt[Symbol.asyncIterator]();
+        const first = await prompt.next();
+        const second = await prompt.next();
+        await bridge.waitForResponse(11);
+        expect(first.value?.message.content).toEqual([
+          { type: "text", text: "First" },
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: image.bytes.toString("base64"),
+            },
+          },
+        ]);
+        expect(second.value?.message.content).toBe("Second");
+
+        bridge.sendRequest(12, "thread/stop", {
+          threadId: "thread-native-image-order",
+        });
+        await bridge.flushWork();
+        queries[0]?.finish();
+        await bridge.waitForResponse(12);
+      } finally {
+        releaseRead.resolve(undefined);
+        queries[0]?.finish();
+        bridge.restore();
+      }
+    });
+
+    it("preserves same-thread steer then start order while an image read is pending", async () => {
+      const { bridge, queries } = withBridgeHarness();
+      const image = createLocalPng("delayed-steer.png");
+      const readStarted = createDeferred<void>();
+      const releaseRead = createDeferred<void>();
+      delayNextImageRead(readStarted, releaseRead);
+
+      try {
+        const threadId = "thread-native-image-steer-order";
+        await startBridgeThread({ bridge, threadId });
+        bridge.sendRequest(10, "turn/steer", {
+          permissionEscalation: "ask",
+          expectedTurnId: "turn-1",
+          input: [{ type: "localImage", path: image.path }],
+          providerThreadId: null,
+          threadId,
+        });
+        await readStarted.promise;
+
+        bridge.sendRequest(11, "turn/start", {
+          permissionEscalation: "ask",
+          input: [{ type: "text", text: "Second" }],
+          providerThreadId: null,
+          threadId,
+        });
+        await bridge.flushWork();
+        expect(bridge.hasResponse(11)).toBe(false);
+
+        releaseRead.resolve(undefined);
+        const prompt = getLatestQueryCall().prompt[Symbol.asyncIterator]();
+        const first = await prompt.next();
+        await bridge.waitForResponse(10);
+        await bridge.waitForResponse(11);
+        const second = await prompt.next();
+        expect(first.value?.message.content).toEqual([
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: image.bytes.toString("base64"),
+            },
+          },
+        ]);
+        expect(second.value?.message.content).toBe("Second");
+
+        bridge.sendRequest(12, "thread/stop", { threadId });
+        await bridge.flushWork();
+        queries[0]?.finish();
+        await bridge.waitForResponse(12);
+      } finally {
+        releaseRead.resolve(undefined);
+        queries[0]?.finish();
+        bridge.restore();
+      }
+    });
+
+    it("continues the same-thread lane after an invalid turn", async () => {
+      const { bridge, queries } = withBridgeHarness();
+      try {
+        const threadId = "thread-turn-lane-recovery";
+        await startBridgeThread({ bridge, threadId });
+        bridge.sendRequest(10, "turn/start", {
+          permissionEscalation: "ask",
+          input: [{ type: "text", text: "" }],
+          providerThreadId: null,
+          threadId,
+        });
+        bridge.sendRequest(11, "turn/start", {
+          permissionEscalation: "ask",
+          input: [{ type: "text", text: "Valid follow-up" }],
+          providerThreadId: null,
+          threadId,
+        });
+
+        await expect(bridge.waitForResponse(10)).resolves.toMatchObject({
+          error: { code: -32602, message: "Missing input text" },
+        });
+        await expect(bridge.waitForResponse(11)).resolves.toMatchObject({
+          result: { threadId },
+        });
+        await expect(readNextPromptText(getLatestQueryCall())).resolves.toBe(
+          "Valid follow-up",
+        );
+
+        await stopBridgeThread({ bridge, queries, threadId });
+      } finally {
+        queries[0]?.finish();
+        bridge.restore();
+      }
+    });
+
+    it("rejects delayed and queued turns instead of sending them to a replacement session", async () => {
+      const { bridge, queries } = withBridgeHarness();
+      const image = createLocalPng("replacement.png");
+      const readStarted = createDeferred<void>();
+      const releaseRead = createDeferred<void>();
+      delayNextImageRead(readStarted, releaseRead);
+
+      try {
+        const threadId = "thread-image-session-replacement";
+        await startBridgeThread({ bridge, requestId: 1, threadId });
+        bridge.sendRequest(10, "turn/start", {
+          permissionEscalation: "ask",
+          input: [{ type: "localImage", path: image.path }],
+          providerThreadId: null,
+          threadId,
+        });
+        await readStarted.promise;
+
+        bridge.sendRequest(11, "turn/steer", {
+          permissionEscalation: "ask",
+          expectedTurnId: "turn-1",
+          input: [{ type: "text", text: "Queued on the old session" }],
+          providerThreadId: null,
+          threadId,
+        });
+        await bridge.flushWork();
+        expect(bridge.hasResponse(11)).toBe(false);
+
+        await startBridgeThread({ bridge, requestId: 2, threadId });
+        expect(queries).toHaveLength(2);
+        releaseRead.resolve(undefined);
+        await expect(bridge.waitForResponse(10)).resolves.toMatchObject({
+          error: {
+            code: -32000,
+            message: "Thread session changed while preparing input",
+          },
+        });
+        await expect(bridge.waitForResponse(11)).resolves.toMatchObject({
+          error: {
+            code: -32000,
+            message: "Thread session changed while preparing input",
+          },
+        });
+
+        bridge.sendRequest(12, "turn/start", {
+          permissionEscalation: "ask",
+          input: [{ type: "text", text: "Replacement session only" }],
+          providerThreadId: null,
+          threadId,
+        });
+        await bridge.waitForResponse(12);
+        await expect(readNextPromptText(getLatestQueryCall())).resolves.toBe(
+          "Replacement session only",
+        );
+
+        bridge.sendRequest(13, "thread/stop", { threadId });
+        await bridge.flushWork();
+        queries[1]?.finish();
+        await bridge.waitForResponse(13);
+      } finally {
+        releaseRead.resolve(undefined);
+        queries.forEach((query) => query.finish());
+        bridge.restore();
+      }
+    });
+
+    it("lets thread stop reject delayed and queued turns", async () => {
+      const { bridge, queries } = withBridgeHarness();
+      const image = createLocalPng("stopped.png");
+      const readStarted = createDeferred<void>();
+      const releaseRead = createDeferred<void>();
+      delayNextImageRead(readStarted, releaseRead);
+
+      try {
+        const threadId = "thread-image-stop";
+        await startBridgeThread({ bridge, threadId });
+        bridge.sendRequest(10, "turn/start", {
+          permissionEscalation: "ask",
+          input: [{ type: "localImage", path: image.path }],
+          providerThreadId: null,
+          threadId,
+        });
+        await readStarted.promise;
+
+        bridge.sendRequest(11, "turn/start", {
+          permissionEscalation: "ask",
+          input: [{ type: "text", text: "Queued before stop" }],
+          providerThreadId: null,
+          threadId,
+        });
+        await bridge.flushWork();
+        expect(bridge.hasResponse(11)).toBe(false);
+
+        bridge.sendRequest(12, "thread/stop", { threadId });
+        await bridge.flushWork();
+        queries[0]?.finish();
+        await bridge.waitForResponse(12);
+        expect(bridge.hasResponse(10)).toBe(false);
+        expect(bridge.hasResponse(11)).toBe(false);
+
+        releaseRead.resolve(undefined);
+        await expect(bridge.waitForResponse(10)).resolves.toMatchObject({
+          error: {
+            code: -32000,
+            message: "Thread session changed while preparing input",
+          },
+        });
+        await expect(bridge.waitForResponse(11)).resolves.toMatchObject({
+          error: {
+            code: -32000,
+            message: "Thread session changed while preparing input",
+          },
+        });
+      } finally {
+        releaseRead.resolve(undefined);
+        queries[0]?.finish();
+        bridge.restore();
+      }
+    });
+
+    it("rejects old-generation turns when the SDK stream ends during an image read", async () => {
+      const { bridge, queries } = withBridgeHarness();
+      const image = createLocalPng("stream-ended.png", 6 * 1024 * 1024);
+      const readStarted = createDeferred<void>();
+      const releaseRead = createDeferred<void>();
+      delayNextImageRead(readStarted, releaseRead);
+
+      try {
+        const threadId = "thread-image-stream-ended";
+        await startBridgeThread({ bridge, threadId });
+        bridge.sendRequest(10, "turn/start", {
+          permissionEscalation: "ask",
+          input: [
+            { type: "localImage", path: image.path },
+            { type: "localImage", path: image.path },
+          ],
+          providerThreadId: null,
+          threadId,
+        });
+        await readStarted.promise;
+
+        bridge.sendRequest(11, "turn/steer", {
+          permissionEscalation: "ask",
+          expectedTurnId: "turn-1",
+          input: [{ type: "text", text: "Queued before stream end" }],
+          providerThreadId: null,
+          threadId,
+        });
+        await bridge.flushWork();
+        queries[0]?.finish();
+        await bridge.flushWork();
+
+        bridge.sendRequest(12, "turn/start", {
+          permissionEscalation: "ask",
+          input: [{ type: "localImage", path: image.path }],
+          providerThreadId: null,
+          threadId,
+        });
+        await bridge.flushWork();
+        expect(queries).toHaveLength(1);
+        expect(bridge.hasResponse(12)).toBe(false);
+
+        releaseRead.resolve(undefined);
+        for (const requestId of [10, 11]) {
+          await expect(
+            bridge.waitForResponse(requestId),
+          ).resolves.toMatchObject({
+            error: {
+              code: -32000,
+              message: "Thread session changed while preparing input",
+            },
+          });
+        }
+        await expect(bridge.waitForResponse(12)).resolves.toMatchObject({
+          result: { threadId },
+        });
+        expect(queries).toHaveLength(2);
+        const replacementPrompt = await readNextPrompt(getLatestQueryCall());
+        expect(
+          Array.isArray(replacementPrompt.message.content)
+            ? replacementPrompt.message.content[0]?.type
+            : "text",
+        ).toBe("image");
+
+        bridge.sendRequest(13, "thread/stop", { threadId });
+        await bridge.flushWork();
+        queries[1]?.finish();
+        await bridge.waitForResponse(13);
+      } finally {
+        releaseRead.resolve(undefined);
+        queries.forEach((query) => query.finish());
+        bridge.restore();
+      }
+    });
+
+    it("does not block turns on another thread while reading an image", async () => {
+      const { bridge, queries } = withBridgeHarness();
+      const image = createLocalPng("delayed.png");
+      const readStarted = createDeferred<void>();
+      const releaseRead = createDeferred<void>();
+      delayNextImageRead(readStarted, releaseRead);
+
+      try {
+        await startBridgeThread({
+          bridge,
+          requestId: 1,
+          threadId: "thread-delayed-image",
+        });
+        await startBridgeThread({
+          bridge,
+          requestId: 2,
+          threadId: "thread-concurrent-text",
+        });
+        bridge.sendRequest(10, "turn/start", {
+          permissionEscalation: "ask",
+          input: [{ type: "localImage", path: image.path }],
+          providerThreadId: null,
+          threadId: "thread-delayed-image",
+        });
+        await readStarted.promise;
+
+        bridge.sendRequest(11, "turn/start", {
+          permissionEscalation: "ask",
+          input: [{ type: "text", text: "Not blocked" }],
+          providerThreadId: null,
+          threadId: "thread-concurrent-text",
+        });
+        await bridge.waitForResponse(11);
+        expect(bridge.hasResponse(10)).toBe(false);
+
+        releaseRead.resolve(undefined);
+        await bridge.waitForResponse(10);
+
+        bridge.sendRequest(12, "thread/stop", {
+          threadId: "thread-delayed-image",
+        });
+        bridge.sendRequest(13, "thread/stop", {
+          threadId: "thread-concurrent-text",
+        });
+        await bridge.flushWork();
+        queries.forEach((query) => query.finish());
+        await Promise.all([
+          bridge.waitForResponse(12),
+          bridge.waitForResponse(13),
+        ]);
+      } finally {
+        releaseRead.resolve(undefined);
+        queries.forEach((query) => query.finish());
         bridge.restore();
       }
     });
@@ -4006,21 +4680,25 @@ describe("bridge", () => {
       }
     });
 
-    it("emits a URL marker for a remote image attachment", async () => {
+    it("sends a remote image as native URL content", async () => {
       const { bridge, queries } = withBridgeHarness();
       try {
-        const text = await sendTurnAndReadPrompt(
+        const content = await sendTurnAndReadPrompt(
           bridge,
           queries,
-          "thread-marker-image-url",
+          "thread-native-image-url",
           [
             { type: "text", text: "Compare to:" },
             { type: "image", url: "https://example.com/cat.png" },
           ],
         );
-        expect(text).toBe(
-          "Compare to:\n[Attached image: https://example.com/cat.png]",
-        );
+        expect(content).toEqual([
+          { type: "text", text: "Compare to:" },
+          {
+            type: "image",
+            source: { type: "url", url: "https://example.com/cat.png" },
+          },
+        ]);
       } finally {
         bridge.restore();
       }
@@ -4028,21 +4706,29 @@ describe("bridge", () => {
 
     it("accepts an attachment-only turn (no text fragments)", async () => {
       const { bridge, queries } = withBridgeHarness();
+      const image = createLocalPng("only.png");
       try {
-        const text = await sendTurnAndReadPrompt(
+        const content = await sendTurnAndReadPrompt(
           bridge,
           queries,
-          "thread-marker-attachment-only",
+          "thread-native-attachment-only",
           [
             {
               type: "localImage",
-              path: "/staged/runtime-attachments/req-4/000-only.png",
+              path: image.path,
             },
           ],
         );
-        expect(text).toBe(
-          "[Attached image. It is on disk at /staged/runtime-attachments/req-4/000-only.png — use the Read tool to view it.]",
-        );
+        expect(content).toEqual([
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: image.bytes.toString("base64"),
+            },
+          },
+        ]);
       } finally {
         bridge.restore();
       }

--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/prompt-input-content.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/prompt-input-content.test.ts
@@ -1,0 +1,369 @@
+import { mkdtemp, rm, truncate, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+import sharp from "sharp";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { openActualMock, openMock } = vi.hoisted(() => ({
+  openActualMock: vi.fn<typeof import("node:fs/promises").open>(),
+  openMock: vi.fn<typeof import("node:fs/promises").open>(),
+}));
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  openActualMock.mockImplementation(actual.open);
+  openMock.mockImplementation(actual.open);
+  return { ...actual, open: openMock };
+});
+
+import {
+  buildClaudePromptContent,
+  buildClaudePromptContents,
+  CLAUDE_BASE64_IMAGE_SESSION_BUDGET_BYTES,
+} from "../prompt-input-content.js";
+
+type ClaudePromptContent = SDKUserMessage["message"]["content"];
+type ClaudePromptBlock = Exclude<ClaudePromptContent, string>[number];
+
+const VALID_IMAGES = [
+  {
+    bytes: Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACXBIWXMAAAPoAAAD6AG1e1JrAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg==",
+      "base64",
+    ),
+    extension: "png",
+    mediaType: "image/png",
+  },
+  {
+    bytes: Buffer.from(
+      "/9j/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAACAAIDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAf/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAABgj/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwCdABykX//Z",
+      "base64",
+    ),
+    extension: "jpg",
+    mediaType: "image/jpeg",
+  },
+  {
+    bytes: Buffer.from(
+      "R0lGODlhAQABAIAAAExpcf8AACH5BAUAAAAALAAAAAABAAEAAAICTAEAOw==",
+      "base64",
+    ),
+    extension: "gif",
+    mediaType: "image/gif",
+  },
+  {
+    bytes: Buffer.from(
+      "UklGRjwAAABXRUJQVlA4IDAAAADQAQCdASoBAAEAAUAmJaACdLoB+AADsAD+8ut//NgVzXPv9//S4P0uD9Lg/9KQAAA=",
+      "base64",
+    ),
+    extension: "webp",
+    mediaType: "image/webp",
+  },
+] as const;
+const PNG_BYTES = VALID_IMAGES[0].bytes;
+const tempDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "bb-claude-prompt-"));
+  tempDirs.push(directory);
+  return directory;
+}
+
+function requireBlocks(
+  content: ClaudePromptContent | undefined,
+): ClaudePromptBlock[] {
+  if (!Array.isArray(content)) {
+    throw new Error("Expected Claude content blocks");
+  }
+  return content;
+}
+
+describe("buildClaudePromptContent", () => {
+  afterEach(async () => {
+    for (const directory of tempDirs.splice(0)) {
+      await rm(directory, { force: true, recursive: true });
+    }
+  });
+
+  it("preserves text-only prompts as strings", async () => {
+    await expect(
+      buildClaudePromptContent([
+        { type: "text", text: "Line one" },
+        { type: "text", text: "Line two" },
+      ]),
+    ).resolves.toBe("Line one\nLine two");
+  });
+
+  it.each(VALID_IMAGES)(
+    "inlines a decoded local $extension image as $mediaType",
+    async (testCase) => {
+      const directory = await createTempDir();
+      const path = join(directory, `image.${testCase.extension}`);
+      await writeFile(path, testCase.bytes);
+
+      const blocks = requireBlocks(
+        await buildClaudePromptContent([{ type: "localImage", path }]),
+      );
+      expect(blocks).toEqual([
+        {
+          type: "image",
+          source: {
+            type: "base64",
+            media_type: testCase.mediaType,
+            data: testCase.bytes.toString("base64"),
+          },
+        },
+      ]);
+    },
+  );
+
+  it("keeps text and native images ordered in one user message", async () => {
+    const directory = await createTempDir();
+    const path = join(directory, "image.png");
+    await writeFile(path, PNG_BYTES);
+
+    const blocks = requireBlocks(
+      await buildClaudePromptContent([
+        { type: "text", text: "Before" },
+        { type: "localImage", path },
+        { type: "text", text: "After" },
+      ]),
+    );
+    expect(blocks).toEqual([
+      { type: "text", text: "Before" },
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: PNG_BYTES.toString("base64"),
+        },
+      },
+      { type: "text", text: "After" },
+    ]);
+  });
+
+  it.each(["http", "https"])(
+    "sends %s URL images as native image blocks",
+    async (protocol) => {
+      const url = `${protocol}://example.com/image.png`;
+      const blocks = requireBlocks(
+        await buildClaudePromptContent([{ type: "image", url }]),
+      );
+      expect(blocks).toEqual([
+        {
+          type: "image",
+          source: { type: "url", url },
+        },
+      ]);
+    },
+  );
+
+  it("keeps non-HTTP image URLs as text markers", async () => {
+    const url = "ftp://example.com/image.png";
+    await expect(
+      buildClaudePromptContent([{ type: "image", url }]),
+    ).resolves.toBe(`[Attached image: ${url}]`);
+  });
+
+  it("keeps ordinary files as path markers beside native images", async () => {
+    const blocks = requireBlocks(
+      await buildClaudePromptContent([
+        { type: "image", url: "https://example.com/image.png" },
+        {
+          type: "localFile",
+          path: "/tmp/report.pdf",
+          name: "report.pdf",
+          mimeType: "application/pdf",
+          sizeBytes: 42,
+        },
+      ]),
+    );
+    expect(blocks).toEqual([
+      {
+        type: "image",
+        source: { type: "url", url: "https://example.com/image.png" },
+      },
+      {
+        type: "text",
+        text: '[Attached file "report.pdf" (application/pdf, 42 bytes). It is on disk at /tmp/report.pdf — use the Read tool to view it.]',
+      },
+    ]);
+  });
+
+  it.each([
+    { name: "missing", bytes: null },
+    { name: "unsupported SVG", bytes: Buffer.from("<svg></svg>") },
+    { name: "unknown image data", bytes: Buffer.from("not an image") },
+    {
+      name: "truncated PNG",
+      bytes: PNG_BYTES.subarray(0, Math.floor(PNG_BYTES.length / 2)),
+    },
+    {
+      name: "warning-level JPEG corruption",
+      bytes: Buffer.concat([
+        VALID_IMAGES[1].bytes.subarray(0, 2),
+        Buffer.alloc(16),
+        VALID_IMAGES[1].bytes.subarray(2),
+      ]),
+    },
+  ])("keeps $name available as a Read-tool marker", async (testCase) => {
+    const directory = await createTempDir();
+    const path = join(directory, "image.svg");
+    if (testCase.bytes !== null) await writeFile(path, testCase.bytes);
+
+    await expect(
+      buildClaudePromptContent([{ type: "localImage", path }]),
+    ).resolves.toBe(
+      `[Attached image. It is on disk at ${path} — use the Read tool to view it.]`,
+    );
+  });
+
+  it("rejects images whose decoded dimensions exceed Claude's limit", async () => {
+    const directory = await createTempDir();
+    const path = join(directory, "too-wide.png");
+    const bytes = await sharp({
+      create: {
+        width: 8_001,
+        height: 1,
+        channels: 3,
+        background: "white",
+      },
+    })
+      .png()
+      .toBuffer();
+    await writeFile(path, bytes);
+
+    await expect(
+      buildClaudePromptContent([{ type: "localImage", path }]),
+    ).resolves.toContain("use the Read tool to view it");
+  });
+
+  it("inlines the exact base64 size limit and falls back above it", async () => {
+    const directory = await createTempDir();
+    const exactPath = join(directory, "exact.png");
+    const oversizedPath = join(directory, "oversized.png");
+    const encodedLimit = 10 * 1024 * 1024;
+    const exactRawSize = 3 * (encodedLimit / 4);
+
+    await writeFile(exactPath, PNG_BYTES);
+    await truncate(exactPath, exactRawSize);
+    const exactBlocks = requireBlocks(
+      await buildClaudePromptContent([{ type: "localImage", path: exactPath }]),
+    );
+    const exactImage = exactBlocks[0];
+    expect(exactImage?.type).toBe("image");
+    if (exactImage?.type !== "image" || exactImage.source.type !== "base64") {
+      throw new Error("Expected a base64 image block at the size limit");
+    }
+    expect(exactImage.source.data).toHaveLength(encodedLimit);
+
+    await writeFile(oversizedPath, PNG_BYTES);
+    await truncate(oversizedPath, exactRawSize + 1);
+    await expect(
+      buildClaudePromptContent([{ type: "localImage", path: oversizedPath }]),
+    ).resolves.toContain("use the Read tool to view it");
+  });
+
+  it("keeps aggregate native image data within the message budget", async () => {
+    const directory = await createTempDir();
+    const path = join(directory, "budget.png");
+    await writeFile(path, PNG_BYTES);
+    await truncate(path, 6 * 1024 * 1024);
+
+    const blocks = requireBlocks(
+      await buildClaudePromptContent([
+        { type: "localImage", path },
+        { type: "localImage", path },
+        { type: "localImage", path },
+      ]),
+    );
+
+    expect(blocks.slice(0, 2).map((block) => block.type)).toEqual([
+      "image",
+      "image",
+    ]);
+    expect(blocks[2]).toEqual({
+      type: "text",
+      text: `[Attached image. It is on disk at ${path} — use the Read tool to view it.]`,
+    });
+    const encodedBytes = blocks.reduce(
+      (total, block) =>
+        block.type === "image" && block.source.type === "base64"
+          ? total + block.source.data.length
+          : total,
+      0,
+    );
+    expect(encodedBytes).toBe(16 * 1024 * 1024);
+    expect(encodedBytes).toBeLessThanOrEqual(20 * 1024 * 1024);
+  });
+
+  it("shares the native-image budget across grouped SDK messages", async () => {
+    const directory = await createTempDir();
+    const path = join(directory, "grouped-budget.png");
+    await writeFile(path, PNG_BYTES);
+    await truncate(path, 6 * 1024 * 1024);
+
+    const result = await buildClaudePromptContents(
+      [
+        [{ type: "localImage", path }],
+        [{ type: "localImage", path }],
+        [{ type: "localImage", path }],
+      ],
+      CLAUDE_BASE64_IMAGE_SESSION_BUDGET_BYTES,
+    );
+    if (!result) throw new Error("Expected grouped Claude prompt content");
+
+    expect(result.base64ImageBytes).toBe(16 * 1024 * 1024);
+    expect(
+      result.contents.map((content) =>
+        Array.isArray(content) ? content[0]?.type : "text",
+      ),
+    ).toEqual(["image", "image", "text"]);
+    expect(result.contents[2]).toContain("use the Read tool to view it");
+  });
+
+  it("falls back when a local image grows during its bounded read", async () => {
+    const path = "/tmp/growing.png";
+    const read = vi
+      .fn()
+      .mockImplementationOnce(async (bytes: Buffer) => {
+        PNG_BYTES.copy(bytes);
+        return { buffer: bytes, bytesRead: PNG_BYTES.length };
+      })
+      .mockImplementationOnce(async (bytes: Buffer) => ({
+        buffer: bytes,
+        bytesRead: 1,
+      }));
+    const close = vi.fn().mockResolvedValue(undefined);
+    openMock.mockResolvedValueOnce({
+      close,
+      read,
+      stat: vi.fn().mockResolvedValue({
+        isFile: () => true,
+        size: PNG_BYTES.length,
+      }),
+    } as never);
+
+    await expect(
+      buildClaudePromptContent([{ type: "localImage", path }]),
+    ).resolves.toBe(
+      `[Attached image. It is on disk at ${path} — use the Read tool to view it.]`,
+    );
+    expect(read).toHaveBeenNthCalledWith(
+      1,
+      expect.any(Buffer),
+      0,
+      PNG_BYTES.length,
+      0,
+    );
+    expect(read).toHaveBeenNthCalledWith(
+      2,
+      expect.any(Buffer),
+      0,
+      1,
+      PNG_BYTES.length,
+    );
+    expect(close).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/agent-runtime/src/claude-code/bridge/__tests__/sdk-session.test.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/__tests__/sdk-session.test.ts
@@ -158,6 +158,33 @@ describe("SdkSession", () => {
     session.stop();
   });
 
+  it("preserves structured content and prompt identity", async () => {
+    keepSdkStreamOpen();
+    const session = new SdkSession(defaultOptions, vi.fn(), vi.fn());
+    const promptId = "00000000-0000-0000-0000-000000000002";
+    const content: SDKUserMessage["message"]["content"] = [
+      { type: "text", text: "Describe this" },
+      {
+        type: "image",
+        source: {
+          type: "base64",
+          media_type: "image/png",
+          data: "iVBORw0KGgo=",
+        },
+      },
+    ];
+
+    session.start();
+    const consumed = session.pushInput(content, promptId);
+    const result = await getLatestPrompt()[Symbol.asyncIterator]().next();
+
+    expect(result.done).toBe(false);
+    expect(result.value?.message.content).toEqual(content);
+    expect(result.value?.uuid).toBe(promptId);
+    await consumed;
+    session.stop();
+  });
+
   it("rejects queued input when the SDK input stream closes before consumption", async () => {
     const session = new SdkSession(defaultOptions, vi.fn(), vi.fn());
     const consumed = session.pushInput("hello");

--- a/packages/agent-runtime/src/claude-code/bridge/bridge.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/bridge.ts
@@ -31,7 +31,6 @@ import {
   type PermissionResult,
   type SDKMessage,
 } from "@anthropic-ai/claude-agent-sdk";
-import { z } from "zod";
 import { extractEnvOverrides } from "../../shared/adapter-utils.js";
 import {
   decodeBridgeJsonRpcResponse,
@@ -49,8 +48,16 @@ import {
 } from "../../shared/bridge-session-registry.js";
 import { withoutBridgeRuntimeEnv } from "../../shared/bridge-runtime-env.js";
 import { shouldAutoDenyInteractiveRequest } from "../../shared/permission-policy.js";
-import { SdkSession, type SdkSessionOptions } from "./sdk-session.js";
 import { listClaudeCodeBridgeModels } from "./model-list.js";
+import {
+  buildClaudePromptContents,
+  CLAUDE_BASE64_IMAGE_SESSION_BUDGET_BYTES,
+} from "./prompt-input-content.js";
+import {
+  SdkSession,
+  type ClaudePromptContent,
+  type SdkSessionOptions,
+} from "./sdk-session.js";
 import {
   decodeClaudeCodeJsonRpcRequest,
   type ClaudeCodeJsonRpcRequest,
@@ -99,28 +106,6 @@ import {
   toPendingInteractionPermissionProfile,
 } from "../interactive-contract.js";
 export { buildSessionOptions } from "./session-options.js";
-
-const promptInputItemSchema = z.discriminatedUnion("type", [
-  z.object({
-    type: z.literal("text"),
-    text: z.string(),
-  }),
-  z.object({
-    type: z.literal("image"),
-    url: z.string(),
-  }),
-  z.object({
-    type: z.literal("localImage"),
-    path: z.string(),
-  }),
-  z.object({
-    type: z.literal("localFile"),
-    path: z.string(),
-    name: z.string().optional(),
-    sizeBytes: z.number().optional(),
-    mimeType: z.string().optional(),
-  }),
-]);
 
 const CLAUDE_PROVIDER_SUBAGENT_TOOL_NAMES = new Set(["Agent", "Task"]);
 const CLAUDE_WORKFLOW_TOOL_NAME = "Workflow";
@@ -190,11 +175,23 @@ interface ClaudeSessionPermissionGrantCoverageArgs {
   toolName: string;
 }
 
+interface TurnSessionBinding {
+  sessionSerial: number;
+  streamEndedAtRequestStart: boolean;
+}
+
+interface ActiveTurnSession {
+  binding: TurnSessionBinding;
+  threadSession: ThreadSession;
+}
+
 interface ThreadSession {
   session: SdkSession;
   sessionConstructionConfig: SessionConstructionConfig;
   sessionOptions: SdkSessionOptions;
   sessionSerial: number;
+  /** Null means resumed history whose retained native-image size is unknown. */
+  retainedBase64ImageBytes: number | null;
   closing: boolean;
   streamEnded: boolean;
   mockCliTrafficProxy: ClaudeCodeMockCliTrafficProxy | null;
@@ -234,6 +231,7 @@ interface CreateThreadSessionArgs {
   liveSettings: ClaudeLiveSessionSettings;
   approvedPlanPermissionMode: ClaudePermissionMode;
   providerThreadId?: string;
+  retainedBase64ImageBytes: number | null;
   sessionConstructionConfig: SessionConstructionConfig;
   sessionOptions: SdkSessionOptions;
   sessionPermissionGrants?: ClaudeSessionPermissionGrant[];
@@ -333,6 +331,7 @@ interface ForwardUserQuestionRequestArgs extends BuildUserQuestionRequestParamsA
 
 let sessionSerialCounter = 0;
 let toolCallRequestIdCounter = 0;
+const threadTurnRequestTails = new Map<string, Promise<void>>();
 
 // Runtime waits on thread/stop until the SDK stream drains or this timeout
 // forces the session closed. Stop remains a best-effort success boundary.
@@ -469,9 +468,32 @@ function ignoreInputConsumption(promise: Promise<void>): void {
   void promise.catch(() => {});
 }
 
+// Bridge requests run detached. Serialize turns per thread so asynchronous
+// attachment reads cannot reorder them; lifecycle requests stay concurrent so
+// stop and replacement can interrupt a pending turn.
+function runInThreadTurnLane(
+  threadId: string,
+  work: () => Promise<void>,
+): Promise<void> {
+  const previousTail =
+    threadTurnRequestTails.get(threadId) ?? Promise.resolve();
+  const next = previousTail.catch(() => undefined).then(work);
+  const done = next.then(
+    () => undefined,
+    () => undefined,
+  );
+  threadTurnRequestTails.set(threadId, done);
+  void done.then(() => {
+    if (threadTurnRequestTails.get(threadId) === done) {
+      threadTurnRequestTails.delete(threadId);
+    }
+  });
+  return next;
+}
+
 function pushPromptInput(
   threadSession: ThreadSession,
-  input: string,
+  input: ClaudePromptContent,
   permissionEscalation: PermissionEscalation | null,
 ): Promise<void> {
   const promptId = randomUUID();
@@ -487,7 +509,7 @@ function pushPromptInput(
 
 function queuePromptInputs(
   threadSession: ThreadSession,
-  inputs: readonly string[],
+  inputs: readonly ClaudePromptContent[],
   permissionEscalation: PermissionEscalation | null,
 ): boolean {
   if (!threadSession.session.canPushInput()) {
@@ -640,6 +662,7 @@ function createThreadSession(args: CreateThreadSessionArgs): ThreadSession {
     sessionConstructionConfig: args.sessionConstructionConfig,
     sessionOptions: args.sessionOptions,
     sessionSerial,
+    retainedBase64ImageBytes: args.retainedBase64ImageBytes,
     closing: false,
     streamEnded: false,
     mockCliTrafficProxy: args.mockCliTrafficProxy,
@@ -959,6 +982,7 @@ function replaceEndedThreadSession(
     permissionMode: args.threadSession.permissionMode,
     approvedPlanPermissionMode: args.threadSession.approvedPlanPermissionMode,
     providerThreadId,
+    retainedBase64ImageBytes: args.threadSession.retainedBase64ImageBytes,
     sessionConstructionConfig: args.threadSession.sessionConstructionConfig,
     sessionOptions: args.threadSession.sessionOptions,
     sessionPermissionGrants: args.threadSession.sessionPermissionGrants,
@@ -975,15 +999,52 @@ function replaceEndedThreadSession(
   return replacementSession;
 }
 
-function getWritableThreadSession(threadId: string): ThreadSession | undefined {
+function captureTurnSessionBinding(
+  threadId: string,
+): TurnSessionBinding | undefined {
   const threadSession = sessions.get(threadId);
-  if (!threadSession || threadSession.closing) {
+  if (!threadSession || threadSession.closing) return undefined;
+  return {
+    sessionSerial: threadSession.sessionSerial,
+    streamEndedAtRequestStart: threadSession.streamEnded,
+  };
+}
+
+function getBoundTurnSession(
+  threadId: string,
+  binding: TurnSessionBinding,
+): ThreadSession | undefined {
+  const threadSession = sessions.get(threadId);
+  if (
+    !threadSession ||
+    threadSession.closing ||
+    threadSession.streamEnded !== binding.streamEndedAtRequestStart ||
+    threadSession.sessionSerial !== binding.sessionSerial
+  ) {
     return undefined;
   }
-  if (!threadSession.streamEnded) {
-    return threadSession;
+  return threadSession;
+}
+
+function activateTurnSession(
+  threadId: string,
+  binding: TurnSessionBinding,
+): ActiveTurnSession | undefined {
+  const threadSession = getBoundTurnSession(threadId, binding);
+  if (!threadSession) return undefined;
+  if (!binding.streamEndedAtRequestStart) {
+    return { binding, threadSession };
   }
-  return replaceEndedThreadSession({ threadId, threadSession });
+
+  const replacement = replaceEndedThreadSession({ threadId, threadSession });
+  if (!replacement) return undefined;
+  return {
+    binding: {
+      sessionSerial: replacement.sessionSerial,
+      streamEndedAtRequestStart: false,
+    },
+    threadSession: replacement,
+  };
 }
 
 function getCurrentThreadSession(
@@ -1611,12 +1672,20 @@ async function handleRequest(request: ClaudeCodeJsonRpcRequest): Promise<void> {
     case "thread/fork":
       await handleThreadFork(request.id, request.params);
       break;
-    case "turn/start":
-      await handleTurnStart(request.id, request.params);
+    case "turn/start": {
+      const binding = captureTurnSessionBinding(request.params.threadId);
+      await runInThreadTurnLane(request.params.threadId, () =>
+        handleTurnStart(request.id, request.params, binding),
+      );
       break;
-    case "turn/steer":
-      await handleTurnSteer(request.id, request.params);
+    }
+    case "turn/steer": {
+      const binding = captureTurnSessionBinding(request.params.threadId);
+      await runInThreadTurnLane(request.params.threadId, () =>
+        handleTurnSteer(request.id, request.params, binding),
+      );
       break;
+    }
     case "thread/stop":
       sendResult(request.id, await handleThreadStop(request.params));
       break;
@@ -1663,6 +1732,7 @@ async function handleThreadStart(
     permissionMode: params.permissionMode,
     approvedPlanPermissionMode: params.approvedPlanPermissionMode,
     providerThreadId,
+    retainedBase64ImageBytes: 0,
     sessionConstructionConfig: toSessionConstructionConfig(params),
     sessionOptions,
     sessionPermissionGrants: [],
@@ -1684,6 +1754,11 @@ async function handleThreadResume(
   const sessionConstructionConfig = toSessionConstructionConfig(params);
 
   const existing = sessions.get(threadId);
+  const retainedBase64ImageBytes = requestedProviderThreadId
+    ? existing?.providerThreadId === requestedProviderThreadId
+      ? existing.retainedBase64ImageBytes
+      : null
+    : 0;
   if (
     existing &&
     requestedProviderThreadId &&
@@ -1740,6 +1815,7 @@ async function handleThreadResume(
     ...(requestedProviderThreadId
       ? { providerThreadId: requestedProviderThreadId }
       : {}),
+    retainedBase64ImageBytes,
     sessionConstructionConfig,
     sessionOptions,
     sessionPermissionGrants: [],
@@ -1807,6 +1883,7 @@ async function handleThreadFork(
     permissionMode: params.permissionMode,
     approvedPlanPermissionMode: params.approvedPlanPermissionMode,
     providerThreadId: forkedProviderThreadId,
+    retainedBase64ImageBytes: null,
     sessionConstructionConfig: toSessionConstructionConfig(params),
     sessionOptions,
     sessionPermissionGrants: [],
@@ -1819,37 +1896,61 @@ async function handleThreadFork(
   sendThreadIdentity(threadId, forkedProviderThreadId);
 }
 
-function buildPromptTexts(
+async function buildPromptContents(
   input: unknown,
   inputGroups: unknown[][] | undefined,
-): string[] | undefined {
+  base64ImageBudgetBytes: number,
+): ReturnType<typeof buildClaudePromptContents> {
   const groups = inputGroups ?? [input];
-  const texts: string[] = [];
-  for (const group of groups) {
-    const text = buildPromptText(group);
-    if (text === undefined) {
-      return undefined;
-    }
-    texts.push(text);
-  }
-  return texts;
+  return buildClaudePromptContents(groups, base64ImageBudgetBytes);
+}
+
+function remainingBase64ImageBudget(threadSession: ThreadSession): number {
+  return threadSession.retainedBase64ImageBytes === null
+    ? 0
+    : Math.max(
+        0,
+        CLAUDE_BASE64_IMAGE_SESSION_BUDGET_BYTES -
+          threadSession.retainedBase64ImageBytes,
+      );
+}
+
+function retainBase64ImageBytes(
+  threadSession: ThreadSession,
+  bytes: number,
+): void {
+  if (threadSession.retainedBase64ImageBytes === null) return;
+  threadSession.retainedBase64ImageBytes += bytes;
 }
 
 async function handleTurnStart(
   id: string | number,
   params: TurnStartParams,
+  binding: TurnSessionBinding | undefined,
 ): Promise<void> {
-  const inputs = buildPromptTexts(params.input, params.inputGroups);
-  if (!inputs) {
+  const boundSession = binding
+    ? getBoundTurnSession(params.threadId, binding)
+    : undefined;
+  const prompt = await buildPromptContents(
+    params.input,
+    params.inputGroups,
+    boundSession ? remainingBase64ImageBudget(boundSession) : 0,
+  );
+  if (!prompt) {
     sendError(id, -32602, "Missing input text");
     return;
   }
 
-  const threadSession = getWritableThreadSession(params.threadId);
-  if (!threadSession) {
+  if (!binding) {
     sendError(id, -32000, "No active session");
     return;
   }
+  const activeSession = activateTurnSession(params.threadId, binding);
+  if (!activeSession) {
+    sendError(id, -32000, "Thread session changed while preparing input");
+    return;
+  }
+  const { binding: activeBinding, threadSession } = activeSession;
 
   if (!threadSession.session.canPushInput()) {
     sendError(id, -32000, "Claude SDK input stream is closed");
@@ -1866,10 +1967,22 @@ async function handleTurnStart(
     return;
   }
 
-  if (!queuePromptInputs(threadSession, inputs, params.permissionEscalation)) {
+  if (!getBoundTurnSession(params.threadId, activeBinding)) {
+    sendError(id, -32000, "Thread session changed while preparing input");
+    return;
+  }
+
+  if (
+    !queuePromptInputs(
+      threadSession,
+      prompt.contents,
+      params.permissionEscalation,
+    )
+  ) {
     sendError(id, -32000, "Claude SDK input stream is closed");
     return;
   }
+  retainBase64ImageBytes(threadSession, prompt.base64ImageBytes);
   threadSession.permissionEscalation = params.permissionEscalation;
   sendResult(id, { threadId: params.threadId });
 }
@@ -1877,18 +1990,31 @@ async function handleTurnStart(
 async function handleTurnSteer(
   id: string | number,
   params: TurnSteerParams,
+  binding: TurnSessionBinding | undefined,
 ): Promise<void> {
-  const inputs = buildPromptTexts(params.input, params.inputGroups);
-  if (!inputs) {
+  const boundSession = binding
+    ? getBoundTurnSession(params.threadId, binding)
+    : undefined;
+  const prompt = await buildPromptContents(
+    params.input,
+    params.inputGroups,
+    boundSession ? remainingBase64ImageBudget(boundSession) : 0,
+  );
+  if (!prompt) {
     sendError(id, -32602, "Missing input text");
     return;
   }
 
-  const threadSession = getWritableThreadSession(params.threadId);
-  if (!threadSession) {
+  if (!binding) {
     sendError(id, -32000, "No active session");
     return;
   }
+  const activeSession = activateTurnSession(params.threadId, binding);
+  if (!activeSession) {
+    sendError(id, -32000, "Thread session changed while preparing input");
+    return;
+  }
+  const { binding: activeBinding, threadSession } = activeSession;
 
   if (!threadSession.session.canPushInput()) {
     sendError(id, -32000, "Claude SDK input stream is closed");
@@ -1905,24 +2031,40 @@ async function handleTurnSteer(
     return;
   }
 
-  if (inputs.length > 1) {
+  if (!getBoundTurnSession(params.threadId, activeBinding)) {
+    sendError(id, -32000, "Thread session changed while preparing input");
+    return;
+  }
+
+  if (prompt.contents.length > 1) {
     if (
-      !queuePromptInputs(threadSession, inputs, params.permissionEscalation)
+      !queuePromptInputs(
+        threadSession,
+        prompt.contents,
+        params.permissionEscalation,
+      )
     ) {
       sendError(id, -32000, "Claude SDK input stream is closed");
       return;
     }
+    retainBase64ImageBytes(threadSession, prompt.base64ImageBytes);
     threadSession.permissionEscalation = params.permissionEscalation;
     sendResult(id, { threadId: params.threadId });
     return;
   }
 
   try {
-    await pushPromptInput(
+    if (!threadSession.session.canPushInput()) {
+      sendError(id, -32000, "Claude SDK input stream is closed");
+      return;
+    }
+    const consumed = pushPromptInput(
       threadSession,
-      inputs[0] ?? "",
+      prompt.contents[0] ?? "",
       params.permissionEscalation,
     );
+    retainBase64ImageBytes(threadSession, prompt.base64ImageBytes);
+    await consumed;
     // A failed steer must not change the running turn's escalation.
     threadSession.permissionEscalation = params.permissionEscalation;
     sendResult(id, { threadId: params.threadId });
@@ -1941,59 +2083,6 @@ async function handleThreadStop(
     threadId: params.threadId,
   });
   return { ok: true };
-}
-
-function localAttachmentMarker(args: {
-  kind: "image" | "file";
-  path: string;
-  name?: string | undefined;
-  mimeType?: string | undefined;
-  sizeBytes?: number | undefined;
-}): string {
-  const namePart = args.name && args.name.length > 0 ? ` "${args.name}"` : "";
-  const details: string[] = [];
-  if (args.mimeType) details.push(args.mimeType);
-  if (args.sizeBytes !== undefined) details.push(`${args.sizeBytes} bytes`);
-  const suffix = details.length > 0 ? ` (${details.join(", ")})` : "";
-  return `[Attached ${args.kind}${namePart}${suffix}. It is on disk at ${args.path} — use the Read tool to view it.]`;
-}
-
-function buildPromptText(input: unknown): string | undefined {
-  if (typeof input === "string") {
-    return input.length > 0 ? input : undefined;
-  }
-  if (!Array.isArray(input)) return undefined;
-
-  const chunks: string[] = [];
-  for (const item of input) {
-    const parsed = promptInputItemSchema.safeParse(item);
-    if (!parsed.success) continue;
-    const entry = parsed.data;
-    switch (entry.type) {
-      case "text":
-        if (entry.text.length > 0) chunks.push(entry.text);
-        break;
-      case "image":
-        chunks.push(`[Attached image: ${entry.url}]`);
-        break;
-      case "localImage":
-        chunks.push(localAttachmentMarker({ kind: "image", path: entry.path }));
-        break;
-      case "localFile":
-        chunks.push(
-          localAttachmentMarker({
-            kind: "file",
-            path: entry.path,
-            name: entry.name,
-            mimeType: entry.mimeType,
-            sizeBytes: entry.sizeBytes,
-          }),
-        );
-        break;
-    }
-  }
-
-  return chunks.length > 0 ? chunks.join("\n") : undefined;
 }
 
 function handleParsedMessage(parsed: unknown): void {

--- a/packages/agent-runtime/src/claude-code/bridge/prompt-input-content.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/prompt-input-content.ts
@@ -1,0 +1,279 @@
+import { constants } from "node:fs";
+import { open } from "node:fs/promises";
+import type { SDKUserMessage } from "@anthropic-ai/claude-agent-sdk";
+import { promptInputSchema } from "@bb/domain";
+import sharp from "sharp";
+
+type ClaudePromptContent = SDKUserMessage["message"]["content"];
+
+type ClaudePromptBlock = Exclude<ClaudePromptContent, string>[number];
+type ClaudeImageBlock = Extract<ClaudePromptBlock, { type: "image" }>;
+type ClaudeImageMediaType = Extract<
+  ClaudeImageBlock["source"],
+  { type: "base64" }
+>["media_type"];
+type ClaudePromptPart = string | ClaudeImageBlock;
+type ClaudePromptContents = ClaudePromptContent[];
+
+interface ClaudePromptContentsResult {
+  base64ImageBytes: number;
+  contents: ClaudePromptContents;
+}
+
+interface Base64ImageBudget {
+  remainingBytes: number;
+}
+
+// Anthropic limits direct-API images to 10 MiB after base64 encoding. Larger
+// staged images remain available through Claude Code's Read tool.
+const CLAUDE_BASE64_IMAGE_LIMIT_BYTES = 10 * 1024 * 1024;
+// Keep native image data well below the 32 MiB request limit so text and JSON
+// framing still have room. The bridge applies this across retained session
+// history because the SDK can coalesce messages and resend earlier images.
+export const CLAUDE_BASE64_IMAGE_SESSION_BUDGET_BYTES = 20 * 1024 * 1024;
+const CLAUDE_MAX_IMAGE_DIMENSION = 8_000;
+const CLAUDE_MAX_IMAGE_PIXELS =
+  CLAUDE_MAX_IMAGE_DIMENSION * CLAUDE_MAX_IMAGE_DIMENSION;
+
+function localAttachmentMarker(args: {
+  kind: "image" | "file";
+  path: string;
+  name?: string | undefined;
+  mimeType?: string | undefined;
+  sizeBytes?: number | undefined;
+}): string {
+  const namePart = args.name && args.name.length > 0 ? ` "${args.name}"` : "";
+  const details: string[] = [];
+  if (args.mimeType) details.push(args.mimeType);
+  if (args.sizeBytes !== undefined) details.push(`${args.sizeBytes} bytes`);
+  const suffix = details.length > 0 ? ` (${details.join(", ")})` : "";
+  return `[Attached ${args.kind}${namePart}${suffix}. It is on disk at ${args.path} — use the Read tool to view it.]`;
+}
+
+function remoteImageMarker(url: string): string {
+  return `[Attached image: ${url}]`;
+}
+
+function isHttpUrl(url: string): boolean {
+  const protocol = new URL(url).protocol;
+  return protocol === "http:" || protocol === "https:";
+}
+
+function base64EncodedSize(rawSize: number): number {
+  return 4 * Math.ceil(rawSize / 3);
+}
+
+function toClaudeImageMediaType(
+  format: string | undefined,
+): ClaudeImageMediaType | null {
+  switch (format) {
+    case "png":
+      return "image/png";
+    case "jpeg":
+      return "image/jpeg";
+    case "gif":
+      return "image/gif";
+    case "webp":
+      return "image/webp";
+    default:
+      return null;
+  }
+}
+
+async function validateClaudeImage(
+  bytes: Buffer,
+): Promise<ClaudeImageMediaType | null> {
+  const image = sharp(bytes, {
+    failOn: "warning",
+    limitInputPixels: CLAUDE_MAX_IMAGE_PIXELS,
+    pages: -1,
+    sequentialRead: true,
+  });
+  const metadata = await image.metadata();
+  const mediaType = toClaudeImageMediaType(metadata.format);
+  if (
+    mediaType === null ||
+    metadata.width === undefined ||
+    metadata.height === undefined ||
+    metadata.width > CLAUDE_MAX_IMAGE_DIMENSION ||
+    metadata.height > CLAUDE_MAX_IMAGE_DIMENSION
+  ) {
+    return null;
+  }
+
+  // Metadata alone does not prove that the pixel stream is complete. Force a
+  // small decode so truncated or corrupt images fall back to the Read tool.
+  await image.resize({ width: 1, height: 1, fit: "inside" }).toBuffer();
+  return mediaType;
+}
+
+async function readLocalImage(
+  path: string,
+  encodedSizeLimit: number,
+): Promise<Buffer | null> {
+  const handle = await open(path, constants.O_RDONLY | constants.O_NONBLOCK);
+  try {
+    const file = await handle.stat();
+    if (!file.isFile() || base64EncodedSize(file.size) > encodedSizeLimit) {
+      return null;
+    }
+
+    const bytes = Buffer.alloc(file.size);
+    let offset = 0;
+    while (offset < bytes.length) {
+      const result = await handle.read(
+        bytes,
+        offset,
+        bytes.length - offset,
+        offset,
+      );
+      if (result.bytesRead === 0) return null;
+      offset += result.bytesRead;
+    }
+
+    // A bounded read prevents a file that grows after stat() from causing an
+    // unbounded allocation. Fall back if it changed while being read.
+    const trailingByte = Buffer.allocUnsafe(1);
+    const trailingRead = await handle.read(trailingByte, 0, 1, offset);
+    return trailingRead.bytesRead === 0 ? bytes : null;
+  } finally {
+    await handle.close();
+  }
+}
+
+async function buildLocalImagePart(
+  path: string,
+  remainingSessionBudget: number,
+): Promise<ClaudePromptPart> {
+  const fallback = localAttachmentMarker({ kind: "image", path });
+  if (remainingSessionBudget <= 0) return fallback;
+  try {
+    const encodedSizeLimit = Math.min(
+      CLAUDE_BASE64_IMAGE_LIMIT_BYTES,
+      remainingSessionBudget,
+    );
+    const bytes = await readLocalImage(path, encodedSizeLimit);
+    if (bytes === null) return fallback;
+    const mediaType = await validateClaudeImage(bytes);
+    if (mediaType === null) return fallback;
+
+    return {
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: mediaType,
+        data: bytes.toString("base64"),
+      },
+    };
+  } catch {
+    return fallback;
+  }
+}
+
+function toContentBlocks(parts: ClaudePromptPart[]): ClaudePromptBlock[] {
+  const blocks: ClaudePromptBlock[] = [];
+  let textParts: string[] = [];
+  const flushText = (): void => {
+    if (textParts.length === 0) return;
+    blocks.push({ type: "text", text: textParts.join("\n") });
+    textParts = [];
+  };
+
+  for (const part of parts) {
+    if (typeof part === "string") {
+      textParts.push(part);
+      continue;
+    }
+    flushText();
+    blocks.push(part);
+  }
+  flushText();
+  return blocks;
+}
+
+async function buildClaudePromptContentWithBudget(
+  input: unknown,
+  budget: Base64ImageBudget,
+): Promise<ClaudePromptContent | undefined> {
+  if (typeof input === "string") {
+    return input.length > 0 ? input : undefined;
+  }
+  if (!Array.isArray(input)) return undefined;
+
+  const parts: ClaudePromptPart[] = [];
+  for (const item of input) {
+    const parsed = promptInputSchema.safeParse(item);
+    if (!parsed.success) continue;
+    const entry = parsed.data;
+    switch (entry.type) {
+      case "text":
+        if (entry.text.length > 0) parts.push(entry.text);
+        break;
+      case "image":
+        parts.push(
+          isHttpUrl(entry.url)
+            ? {
+                type: "image",
+                source: { type: "url", url: entry.url },
+              }
+            : remoteImageMarker(entry.url),
+        );
+        break;
+      case "localImage": {
+        const part = await buildLocalImagePart(
+          entry.path,
+          budget.remainingBytes,
+        );
+        parts.push(part);
+        if (typeof part !== "string" && part.source.type === "base64") {
+          budget.remainingBytes -= part.source.data.length;
+        }
+        break;
+      }
+      case "localFile":
+        parts.push(
+          localAttachmentMarker({
+            kind: "file",
+            path: entry.path,
+            name: entry.name,
+            mimeType: entry.mimeType,
+            sizeBytes: entry.sizeBytes,
+          }),
+        );
+        break;
+    }
+  }
+
+  if (parts.length === 0) return undefined;
+  return parts.some((part) => typeof part !== "string")
+    ? toContentBlocks(parts)
+    : parts.join("\n");
+}
+
+/** Convert one BB prompt input using a fresh Claude session image budget. */
+export async function buildClaudePromptContent(
+  input: unknown,
+): Promise<ClaudePromptContent | undefined> {
+  return buildClaudePromptContentWithBudget(input, {
+    remainingBytes: CLAUDE_BASE64_IMAGE_SESSION_BUDGET_BYTES,
+  });
+}
+
+/** Convert every message that may share one Claude provider request. */
+export async function buildClaudePromptContents(
+  inputs: readonly unknown[],
+  base64ImageBudgetBytes: number,
+): Promise<ClaudePromptContentsResult | undefined> {
+  const budget = { remainingBytes: Math.max(0, base64ImageBudgetBytes) };
+  const initialBudget = budget.remainingBytes;
+  const contents: ClaudePromptContents = [];
+  for (const input of inputs) {
+    const content = await buildClaudePromptContentWithBudget(input, budget);
+    if (content === undefined) return undefined;
+    contents.push(content);
+  }
+  return {
+    base64ImageBytes: initialBudget - budget.remainingBytes,
+    contents,
+  };
+}

--- a/packages/agent-runtime/src/claude-code/bridge/sdk-session.ts
+++ b/packages/agent-runtime/src/claude-code/bridge/sdk-session.ts
@@ -64,6 +64,8 @@ interface QueuedSdkInputMessage {
   resolveConsumed: () => void;
 }
 
+export type ClaudePromptContent = SDKUserMessage["message"]["content"];
+
 interface SdkPermissionOptions {
   allowDangerouslySkipPermissions?: true;
   permissionMode: ClaudePermissionMode;
@@ -285,12 +287,12 @@ export class SdkSession {
   }
 
   pushInput(
-    text: string,
+    content: ClaudePromptContent,
     promptId?: NonNullable<SDKUserMessage["uuid"]>,
   ): Promise<void> {
     const message: SDKUserMessage = {
       type: "user",
-      message: { role: "user", content: text },
+      message: { role: "user", content },
       parent_tool_use_id: null,
       session_id: this.sessionId ?? "",
       ...(promptId !== undefined ? { uuid: promptId } : {}),

--- a/packages/bb-app/package.json
+++ b/packages/bb-app/package.json
@@ -79,6 +79,7 @@
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",
     "pino-roll": "^4.0.0",
+    "sharp": "^0.34.5",
     "zod": "4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -705,6 +705,9 @@ importers:
       semver:
         specifier: ^7.7.4
         version: 7.7.4
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       smol-toml:
         specifier: ^1.7.1
         version: 1.7.1
@@ -1209,6 +1212,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.3.6)
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       zod:
         specifier: 4.3.6
         version: 4.3.6
@@ -1273,6 +1279,9 @@ importers:
       pino-roll:
         specifier: ^4.0.0
         version: 4.0.0
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       zod:
         specifier: 4.3.6
         version: 4.3.6

--- a/scripts/build-utils.mjs
+++ b/scripts/build-utils.mjs
@@ -20,6 +20,7 @@ export const NATIVE_EXTERNAL_PACKAGES = [
   "pino",
   "pino-pretty",
   "pino-roll",
+  "sharp",
   "thread-stream",
   "utf-8-validate",
   // jiti loads plugin server entries as TypeScript at runtime and lazily


### PR DESCRIPTION
## Summary

- send supported local PNG, JPEG, GIF, and WebP attachments as native Claude image content
- send HTTP(S) image attachments as native URL image content
- validate local image data and fall back to Read-tool markers for invalid, unsupported, oversized, or over-budget inputs
- retain one base64 image budget across grouped messages, turns, and SDK stream recovery
- package Sharp for the host daemon, `bb-app`, and production bridge bundles

## POC status

This is a work-in-progress proof of concept for review. Known follow-up items:

- requests with more than 20 native images need the stricter Anthropic dimension policy or a native-image count cap
- animated GIF/WebP validation currently decodes all pages, which can reject valid animations when Sharp reports stacked frame dimensions; Claude uses only the first frame
- no billed live-Claude smoke test has run

## Validation

- `pnpm exec turbo run test typecheck --filter=@bb/agent-runtime --force` — 975 tests passed
- `pnpm exec turbo run build --filter=@bb/host-daemon --filter=bb-app --force`
- `git diff --check`

> AGENT GENERATED: by GPT-5.4
