### PR TITLE
[issue sweep] Reject home-relative markdown links

### DIFF
--- a/apps/app/src/components/ui/markdown-local-file-link.test.ts
+++ b/apps/app/src/components/ui/markdown-local-file-link.test.ts
@@ -288,6 +288,16 @@ describe("resolveRelativeLocalFileHref", () => {
     ).toBeNull();
   });
 
+  it("rejects home-relative paths", () => {
+    expect(
+      resolveRelativeLocalFileHref({
+        baseDir: "/workspace",
+        href: "~/.config/example.md",
+        rootPath: "/workspace",
+      }),
+    ).toBeNull();
+  });
+
   it("rejects relative paths that escape the containing root", () => {
     expect(
       resolveRelativeLocalFileHref({

--- a/apps/app/src/components/ui/markdown-local-file-link.ts
+++ b/apps/app/src/components/ui/markdown-local-file-link.ts
@@ -297,6 +297,7 @@ export function resolveRelativeLocalFileHref({
     parsedHref === null ||
     parsedHref.path.length === 0 ||
     parsedHref.path.startsWith("/") ||
+    parsedHref.path.startsWith("~/") ||
     parsedHref.path.startsWith("#") ||
     parsedHref.path.startsWith("?") ||
     URI_SCHEME_PATTERN.test(parsedHref.path)


### PR DESCRIPTION
## Summary

- Reject Markdown links whose decoded path starts with `~/`.
- Keep these links as plain text.
- Do not expand home paths.

## Testing

- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app --force`

Fixes #1182

> AGENT GENERATED: by GPT-5