### PR TITLE
Survive a broken pipe to the watcher child

### DIFF
--- a/packages/host-watcher/src/parcel-subprocess/fork-channel.ts
+++ b/packages/host-watcher/src/parcel-subprocess/fork-channel.ts
@@ -1,4 +1,4 @@
-import { fork } from "node:child_process";
+import { type ChildProcess, fork } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -29,14 +29,66 @@ function resolveChildEntry(): string {
   );
 }
 
-export function createForkChannel(): ChildChannel {
-  const child = fork(resolveChildEntry(), [], {
-    stdio: ["ignore", "inherit", "inherit", "ipc"],
-  });
+/**
+ * Adapt an already-forked child to the {@link ChildChannel} contract. Split out
+ * from {@link createForkChannel} so the IPC failure paths can be exercised
+ * without spawning a real process.
+ *
+ * Nothing here may throw. The proxy pings the child from a bare `setInterval`,
+ * so an escaping IPC error becomes an `uncaughtException` that takes down the
+ * whole host daemon — and with it every thread running on the host. A broken
+ * pipe is not even rare: `child.connected` stays true while the channel is
+ * tearing down, so a ping racing a dying child fails with EPIPE. That window
+ * yawns open exactly when the daemon is already struggling, because a stalled
+ * event loop delays the timer past the child's unprocessed `exit` event.
+ *
+ * A failed send therefore means "this child is gone", which is a condition the
+ * proxy already recovers from: report it through the exit path and it kills,
+ * respawns, and replays every subscription.
+ */
+export function createChildChannel(child: ChildProcess): ChildChannel {
+  const exitListeners = new Set<() => void>();
+  let gone = false;
+
+  function markGone(): void {
+    if (gone) {
+      return;
+    }
+    gone = true;
+    for (const listener of exitListeners) {
+      listener();
+    }
+  }
+
+  // The pipe broke but the process may still be alive, holding the inotify fds
+  // and threads its watches allocated. SIGKILL it so the OS reclaims them,
+  // rather than leaking an orphan watcher per failure.
+  function abandon(): void {
+    if (gone) {
+      return;
+    }
+    child.kill("SIGKILL");
+    markGone();
+  }
+
+  // Without an `error` listener a spawn or kill failure is an unhandled 'error'
+  // event, which is the same fatal outcome by another route.
+  child.on("error", markGone);
+  child.on("exit", markGone);
+
   return {
     send(message: ParentToChildMessage) {
-      if (child.connected) {
-        child.send(message);
+      if (gone || !child.connected) {
+        return;
+      }
+      try {
+        child.send(message, (error) => {
+          if (error) {
+            abandon();
+          }
+        });
+      } catch {
+        abandon();
       }
     },
     onMessage(listener) {
@@ -45,10 +97,18 @@ export function createForkChannel(): ChildChannel {
       });
     },
     onExit(listener) {
-      child.on("exit", () => listener());
+      exitListeners.add(listener);
     },
     kill() {
       child.kill("SIGKILL");
     },
   };
+}
+
+export function createForkChannel(): ChildChannel {
+  return createChildChannel(
+    fork(resolveChildEntry(), [], {
+      stdio: ["ignore", "inherit", "inherit", "ipc"],
+    }),
+  );
 }

--- a/packages/host-watcher/src/parcel-subprocess/parcel-watcher-proxy.ts
+++ b/packages/host-watcher/src/parcel-subprocess/parcel-watcher-proxy.ts
@@ -155,11 +155,17 @@ export function createParcelWatcherProxy(
   }
 
   function replaySubscriptions(rescan: boolean): void {
-    if (channel === null) {
+    // Bind the channel once. A send that fails reports the child gone from
+    // inside this call, which nulls `channel` and may respawn onto a new one —
+    // so re-reading it per iteration would either dereference null or replay
+    // the rest of the subscriptions onto a child that is not ready yet. Sends
+    // to an already-gone channel are no-ops, so the dead target is harmless.
+    const target = channel;
+    if (target === null) {
       return;
     }
     for (const record of subscriptions.values()) {
-      channel.send({
+      target.send({
         kind: "subscribe",
         id: record.id,
         dir: record.dir,

--- a/packages/host-watcher/test/fork-channel.test.ts
+++ b/packages/host-watcher/test/fork-channel.test.ts
@@ -1,0 +1,120 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcess } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import { createChildChannel } from "../src/parcel-subprocess/fork-channel.js";
+
+type SendCallback = (error: Error | null) => void;
+
+/**
+ * Minimal stand-in for a forked child, so the IPC failure paths can be driven
+ * deterministically (a real EPIPE only shows up under a race).
+ */
+class FakeChild extends EventEmitter {
+  connected = true;
+  killedWith: string | null = null;
+  sendCount = 0;
+  send: (message: unknown, callback?: SendCallback) => boolean = () => true;
+
+  kill(signal?: string): boolean {
+    this.killedWith = signal ?? "SIGTERM";
+    return true;
+  }
+
+  /** Fail every send synchronously, the way a torn-down channel does. */
+  failSyncWith(error: NodeJS.ErrnoException): void {
+    this.send = () => {
+      this.sendCount += 1;
+      throw error;
+    };
+  }
+
+  /** Fail every send via the callback, the way an async write error does. */
+  failAsyncWith(error: NodeJS.ErrnoException): void {
+    this.send = (_message, callback) => {
+      this.sendCount += 1;
+      callback?.(error);
+      return false;
+    };
+  }
+}
+
+function epipe(): NodeJS.ErrnoException {
+  const error: NodeJS.ErrnoException = new Error("write EPIPE");
+  error.code = "EPIPE";
+  return error;
+}
+
+function setup(): {
+  child: FakeChild;
+  channel: ReturnType<typeof createChildChannel>;
+  exits: number;
+} {
+  const child = new FakeChild();
+  const channel = createChildChannel(child as unknown as ChildProcess);
+  const state = { child, channel, exits: 0 };
+  channel.onExit(() => {
+    state.exits += 1;
+  });
+  return state;
+}
+
+describe("createChildChannel", () => {
+  it("swallows a synchronous EPIPE and reports the child as exited", () => {
+    // The regression: `connected` is still true while the pipe is tearing down,
+    // so the proxy's ping throws. Escaping here kills the whole host daemon.
+    const state = setup();
+    state.child.failSyncWith(epipe());
+
+    expect(() => state.channel.send({ kind: "ping", nonce: 1 })).not.toThrow();
+    expect(state.exits).toBe(1);
+    // The process may have survived its pipe: SIGKILL reclaims its inotify fds.
+    expect(state.child.killedWith).toBe("SIGKILL");
+  });
+
+  it("treats an asynchronous send failure the same way", () => {
+    const state = setup();
+    state.child.failAsyncWith(epipe());
+
+    expect(() => state.channel.send({ kind: "ping", nonce: 1 })).not.toThrow();
+    expect(state.exits).toBe(1);
+    expect(state.child.killedWith).toBe("SIGKILL");
+  });
+
+  it("handles a child 'error' event rather than leaving it unhandled", () => {
+    const state = setup();
+
+    // An unhandled 'error' on an EventEmitter is thrown — the same fatal
+    // outcome the send guard exists to prevent.
+    expect(() =>
+      state.child.emit("error", new Error("spawn ENOENT")),
+    ).not.toThrow();
+    expect(state.exits).toBe(1);
+  });
+
+  it("reports exit exactly once and stops sending after a failure", () => {
+    const state = setup();
+    state.child.failSyncWith(epipe());
+
+    state.channel.send({ kind: "ping", nonce: 1 });
+    state.channel.send({ kind: "ping", nonce: 2 });
+    // The real exit lands after the pipe broke; the proxy must not respawn twice.
+    state.child.emit("exit", null, "SIGKILL");
+
+    expect(state.exits).toBe(1);
+    expect(state.child.sendCount).toBe(1);
+  });
+
+  it("delivers messages and exit normally while the child is healthy", () => {
+    const state = setup();
+    const received: unknown[] = [];
+    state.channel.onMessage((message) => received.push(message));
+
+    state.channel.send({ kind: "ping", nonce: 1 });
+    state.child.emit("message", { kind: "pong", nonce: 1 });
+    expect(received).toEqual([{ kind: "pong", nonce: 1 }]);
+    expect(state.exits).toBe(0);
+
+    state.child.emit("exit", 0, null);
+    expect(state.exits).toBe(1);
+  });
+});

--- a/packages/host-watcher/test/parcel-watcher-proxy.test.ts
+++ b/packages/host-watcher/test/parcel-watcher-proxy.test.ts
@@ -89,6 +89,12 @@ class FakeChild {
   readonly channel: ChildChannel;
   exited = false;
   responsive = true;
+  /**
+   * Report the child gone from inside `send`, the way the real fork channel
+   * does when the IPC pipe breaks: it catches the EPIPE and runs its exit
+   * listeners synchronously, before `send` returns.
+   */
+  dieOnSend = false;
 
   private readonly handler;
   private parentListener: ((message: ChildToParentMessage) => void) | null =
@@ -104,6 +110,10 @@ class FakeChild {
     this.channel = {
       send: (message: ParentToChildMessage) => {
         if (this.exited || !this.responsive) {
+          return;
+        }
+        if (this.dieOnSend) {
+          this.exit();
           return;
         }
         this.handler.handleMessage(message);
@@ -396,6 +406,42 @@ describe("createParcelWatcherProxy", () => {
 
       // The proxy keeps recovering — it never surfaces a permanent give-up error.
       expect(terminalError).toBeNull();
+      proxy.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("recovers when a replacement child's pipe breaks mid-replay", async () => {
+    vi.useFakeTimers();
+    try {
+      const { proxy, children, current } = createHarness({
+        baseRestartDelayMs: 1_000,
+        pingIntervalMs: 100_000, // keep pings out of this test
+      });
+      await proxy.subscribe("/root", () => {});
+      await proxy.subscribe("/other", () => {});
+      await flush();
+      expect(children).toHaveLength(1);
+
+      // Crash once. This heals immediately, which arms the backoff counter — so
+      // the NEXT failure schedules its respawn instead of spawning inline.
+      current().exit();
+      expect(children).toHaveLength(2);
+
+      // Break the replacement's pipe before it announces readiness, so the
+      // first replayed subscribe reports the child gone from inside `send`.
+      // That detaches the channel mid-loop; the replay must not follow it.
+      current().dieOnSend = true;
+      await flush();
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await flush();
+
+      // A third child came up with BOTH watches re-armed — the replay survived
+      // the death instead of taking the daemon down with a null dereference.
+      expect(children).toHaveLength(3);
+      expect(current().parcel.activeDirs().sort()).toEqual(["/other", "/root"]);
       proxy.dispose();
     } finally {
       vi.useRealTimers();


### PR DESCRIPTION
Fixes #1505.

## Problem

`ChildChannel.send` guarded the IPC write with `child.connected` alone:

```ts
send(message: ParentToChildMessage) {
  if (child.connected) {
    child.send(message);
  }
},
```

That flag stays `true` while the channel is tearing down, so the send can still fail with `EPIPE`. The proxy pings the child from a bare `setInterval`, so there is nothing above it to catch — the throw escapes as an `uncaughtException` and kills the host daemon, taking every thread on the host with it (`Thread interrupted because the host daemon disconnected`).

The race opens widest when the daemon is already unhealthy: a stalled event loop delays the ping timer past the child's unprocessed `exit` event, so the timer fires at a child that is already gone. On my host that meant heartbeat gaps of up to 403s, then `write EPIPE`, then 5 dead threads. Full evidence in #1505.

## Fix

A failed send means "this child is gone" — which is precisely the condition `createParcelWatcherProxy` already recovers from by killing, respawning, and replaying every subscription. So route it there instead of throwing:

- `try/catch` around `child.send` **and** a send callback, covering the synchronous throw and the async write error.
- `child.on("error", ...)` — an unhandled `'error'` event on a ChildProcess is the same fatal outcome by another route, and there was no listener at all.
- SIGKILL before reporting the child gone, so a process that outlived its pipe doesn't leak the inotify fds and threads its watches allocated.
- `onExit` listeners moved behind a `gone` latch, so a pipe failure followed by the real `exit` doesn't drive two respawns.

`createChildChannel(child)` is split out from `createForkChannel()` purely as a test seam — a real EPIPE only reproduces under a race.

## Tests

`packages/host-watcher/test/fork-channel.test.ts`, 5 cases: synchronous EPIPE, async send failure, `'error'` event, exit-reported-once-and-no-further-sends, and the healthy path.

These are real regression tests, not just coverage — reverting the guard makes 4 of the 5 fail with exactly the EPIPE escape:

```
FAIL test/fork-channel.test.ts > swallows a synchronous EPIPE and reports the child as exited
FAIL test/fork-channel.test.ts > treats an asynchronous send failure the same way
FAIL test/fork-channel.test.ts > handles a child 'error' event rather than leaving it unhandled
FAIL test/fork-channel.test.ts > reports exit exactly once and stops sending after a failure
```

With the fix, all 44 `@bb/host-watcher` tests pass; `turbo run typecheck --filter=@bb/host-watcher` and prettier are clean.

## Scope

This is the crash only. The event-loop stalls that widen the race are a separate problem — after this change the watcher recycles cleanly instead of taking the daemon down with it. No server↔daemon wire change, so no `HOST_DAEMON_PROTOCOL_VERSION` bump.

> AGENT GENERATED: by Claude Opus 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
