### PR TITLE
[issue sweep] Show active workspace in composer footer

### DIFF
--- a/apps/app/src/components/promptbox/ThreadEnvironmentSummary.test.tsx
+++ b/apps/app/src/components/promptbox/ThreadEnvironmentSummary.test.tsx
@@ -22,34 +22,40 @@ describe("ThreadEnvironmentSummary", () => {
     ).toBe("Worktree");
   });
 
-  it("updates the active workspace directory and full-path tooltip", () => {
+  it("updates the active workspace directory and full-path tooltip", async () => {
     const { container, rerender } = render(
-      <ThreadEnvironmentSummary
-        projectName="project-a"
-        projectRootPath="/path/to/project-a"
-        environmentPath="/path/to/project-b/."
-        environmentLabel="Working locally"
-      />,
+      <TooltipProvider delayDuration={0}>
+        <ThreadEnvironmentSummary
+          projectName="project-a"
+          projectRootPath="/path/to/project-a"
+          environmentPath="/path/to/project-b/."
+          environmentLabel="Working locally"
+        />
+      </TooltipProvider>,
     );
 
-    const projectLabel = container.querySelector(
-      '[data-option-display][title="/path/to/project-b/."]',
-    );
+    const projectLabel = container.querySelector("[data-option-display]");
     expect(
       projectLabel?.querySelector("[data-promptbox-full-label]")?.textContent,
     ).toBe("project-a / project-b");
+    fireEvent.pointerMove(projectLabel?.parentElement ?? projectLabel!);
+    expect((await screen.findByRole("tooltip")).textContent).toBe(
+      "/path/to/project-b/.",
+    );
 
     rerender(
-      <ThreadEnvironmentSummary
-        projectName="project-a"
-        projectRootPath="/path/to/project-a"
-        environmentPath="/other/project-c"
-        environmentLabel="Working locally"
-      />,
+      <TooltipProvider delayDuration={0}>
+        <ThreadEnvironmentSummary
+          projectName="project-a"
+          projectRootPath="/path/to/project-a"
+          environmentPath="/other/project-c"
+          environmentLabel="Working locally"
+        />
+      </TooltipProvider>,
     );
 
     const updatedProjectLabel = container.querySelector(
-      '[data-option-display][title="/other/project-c"]',
+      "[data-option-display]",
     );
     expect(
       updatedProjectLabel?.querySelector("[data-promptbox-full-label]")
@@ -59,12 +65,14 @@ describe("ThreadEnvironmentSummary", () => {
 
   it("keeps only the project name at the project root", () => {
     const { container } = render(
-      <ThreadEnvironmentSummary
-        projectName="project-a"
-        projectRootPath="/path/to/project-a/"
-        environmentPath="/path/to/project-a/child/.."
-        environmentLabel="Working locally"
-      />,
+      <TooltipProvider>
+        <ThreadEnvironmentSummary
+          projectName="project-a"
+          projectRootPath="/path/to/project-a/"
+          environmentPath="/path/to/project-a/child/.."
+          environmentLabel="Working locally"
+        />
+      </TooltipProvider>,
     );
 
     expect(

--- a/apps/app/src/components/promptbox/ThreadEnvironmentSummary.test.tsx
+++ b/apps/app/src/components/promptbox/ThreadEnvironmentSummary.test.tsx
@@ -22,6 +22,56 @@ describe("ThreadEnvironmentSummary", () => {
     ).toBe("Worktree");
   });
 
+  it("updates the active workspace directory and full-path tooltip", () => {
+    const { container, rerender } = render(
+      <ThreadEnvironmentSummary
+        projectName="project-a"
+        projectRootPath="/path/to/project-a"
+        environmentPath="/path/to/project-b"
+        environmentLabel="Working locally"
+      />,
+    );
+
+    const projectLabel = container.querySelector(
+      '[data-option-display][title="/path/to/project-b"]',
+    );
+    expect(
+      projectLabel?.querySelector("[data-promptbox-full-label]")?.textContent,
+    ).toBe("project-a / project-b");
+
+    rerender(
+      <ThreadEnvironmentSummary
+        projectName="project-a"
+        projectRootPath="/path/to/project-a"
+        environmentPath="/other/project-c"
+        environmentLabel="Working locally"
+      />,
+    );
+
+    const updatedProjectLabel = container.querySelector(
+      '[data-option-display][title="/other/project-c"]',
+    );
+    expect(
+      updatedProjectLabel?.querySelector("[data-promptbox-full-label]")
+        ?.textContent,
+    ).toBe("project-a / project-c");
+  });
+
+  it("keeps only the project name at the project root", () => {
+    const { container } = render(
+      <ThreadEnvironmentSummary
+        projectName="project-a"
+        projectRootPath="/path/to/project-a/"
+        environmentPath="/path/to/project-a"
+        environmentLabel="Working locally"
+      />,
+    );
+
+    expect(
+      container.querySelector("[data-promptbox-full-label]")?.textContent,
+    ).toBe("project-a");
+  });
+
   it("explains the create-thread action in a tooltip", async () => {
     render(
       <TooltipProvider delayDuration={0}>

--- a/apps/app/src/components/promptbox/ThreadEnvironmentSummary.test.tsx
+++ b/apps/app/src/components/promptbox/ThreadEnvironmentSummary.test.tsx
@@ -27,13 +27,13 @@ describe("ThreadEnvironmentSummary", () => {
       <ThreadEnvironmentSummary
         projectName="project-a"
         projectRootPath="/path/to/project-a"
-        environmentPath="/path/to/project-b"
+        environmentPath="/path/to/project-b/."
         environmentLabel="Working locally"
       />,
     );
 
     const projectLabel = container.querySelector(
-      '[data-option-display][title="/path/to/project-b"]',
+      '[data-option-display][title="/path/to/project-b/."]',
     );
     expect(
       projectLabel?.querySelector("[data-promptbox-full-label]")?.textContent,
@@ -62,7 +62,7 @@ describe("ThreadEnvironmentSummary", () => {
       <ThreadEnvironmentSummary
         projectName="project-a"
         projectRootPath="/path/to/project-a/"
-        environmentPath="/path/to/project-a"
+        environmentPath="/path/to/project-a/child/.."
         environmentLabel="Working locally"
       />,
     );

--- a/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
+++ b/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
@@ -84,15 +84,24 @@ export const ThreadEnvironmentSummary = memo(function ThreadEnvironmentSummary({
   return (
     <div className="flex min-w-0 max-w-full items-center gap-2 pr-1.5">
       {visibleProjectName ? (
-        <OptionDisplay
-          label="Project"
-          value={visibleProjectName}
-          compactValue={visibleProjectName}
-          leading={<Icon name="Folder" className="size-4 shrink-0" />}
-          className="h-6 max-w-[10rem] shrink-0"
-          title={environmentPath ?? `Project: ${projectName}`}
-          muted
-        />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex min-w-0 shrink-0">
+              <OptionDisplay
+                label="Project"
+                value={visibleProjectName}
+                compactValue={visibleProjectName}
+                leading={<Icon name="Folder" className="size-4 shrink-0" />}
+                className="h-6 max-w-[10rem]"
+                title=""
+                muted
+              />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            {environmentPath ?? `Project: ${projectName}`}
+          </TooltipContent>
+        </Tooltip>
       ) : null}
       <OptionDisplay
         label="Environment"

--- a/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
+++ b/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
@@ -13,9 +13,18 @@ const CHECKOUT_CHIP_BASE_CLASS_NAME =
   "flex min-w-0 flex-1 items-center gap-1 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground";
 const CHECKOUT_CHIP_BUTTON_CLASS_NAME = `${CHECKOUT_CHIP_BASE_CLASS_NAME} cursor-pointer transition-colors hover:bg-state-hover hover:text-foreground`;
 
+function trimTrailingPathSeparators(path: string): string {
+  const trimmedPath = path.replace(/[\\/]+$/u, "");
+  return trimmedPath || path;
+}
+
 interface ThreadEnvironmentSummaryProps {
   /** Display name of the thread's project, shown alongside the environment. */
   projectName?: string;
+  /** Project source path on the environment's host. */
+  projectRootPath?: string;
+  /** Full path of the thread's active environment. */
+  environmentPath?: string;
   /** Full mode label used on larger prompt boxes and in the title. */
   environmentLabel?: string;
   /** Short label used when the promptbox switches to its compact layout. */
@@ -45,6 +54,8 @@ interface ThreadEnvironmentSummaryProps {
  */
 export const ThreadEnvironmentSummary = memo(function ThreadEnvironmentSummary({
   projectName,
+  projectRootPath,
+  environmentPath,
   environmentLabel,
   environmentCompactLabel,
   environmentIcon,
@@ -56,16 +67,34 @@ export const ThreadEnvironmentSummary = memo(function ThreadEnvironmentSummary({
   }
 
   const checkoutCopyValue = environmentCheckout?.copyValue ?? null;
+  const normalizedProjectRootPath = projectRootPath
+    ? trimTrailingPathSeparators(projectRootPath)
+    : undefined;
+  const normalizedEnvironmentPath = environmentPath
+    ? trimTrailingPathSeparators(environmentPath)
+    : undefined;
+  const environmentDirectoryName = normalizedEnvironmentPath
+    ?.split(/[\\/]/u)
+    .at(-1);
+  const visibleProjectName =
+    projectName &&
+    normalizedProjectRootPath &&
+    normalizedEnvironmentPath &&
+    normalizedProjectRootPath !== normalizedEnvironmentPath &&
+    environmentDirectoryName
+      ? `${projectName} / ${environmentDirectoryName}`
+      : projectName;
+
   return (
     <div className="flex min-w-0 max-w-full items-center gap-2 pr-1.5">
-      {projectName ? (
+      {visibleProjectName ? (
         <OptionDisplay
           label="Project"
-          value={projectName}
-          compactValue={projectName}
+          value={visibleProjectName}
+          compactValue={visibleProjectName}
           leading={<Icon name="Folder" className="size-4 shrink-0" />}
           className="h-6 max-w-[10rem] shrink-0"
-          title={`Project: ${projectName}`}
+          title={environmentPath ?? `Project: ${projectName}`}
           muted
         />
       ) : null}

--- a/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
+++ b/apps/app/src/components/promptbox/ThreadEnvironmentSummary.tsx
@@ -7,16 +7,12 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@bb/shared-ui/tooltip";
+import { normalizeAbsoluteFilePath } from "@/lib/absolute-file-path";
 import type { WorkspaceCheckoutDisplay } from "@/lib/workspace-checkout-display";
 
 const CHECKOUT_CHIP_BASE_CLASS_NAME =
   "flex min-w-0 flex-1 items-center gap-1 rounded-md px-1.5 py-0.5 text-xs text-muted-foreground";
 const CHECKOUT_CHIP_BUTTON_CLASS_NAME = `${CHECKOUT_CHIP_BASE_CLASS_NAME} cursor-pointer transition-colors hover:bg-state-hover hover:text-foreground`;
-
-function trimTrailingPathSeparators(path: string): string {
-  const trimmedPath = path.replace(/[\\/]+$/u, "");
-  return trimmedPath || path;
-}
 
 interface ThreadEnvironmentSummaryProps {
   /** Display name of the thread's project, shown alongside the environment. */
@@ -68,13 +64,13 @@ export const ThreadEnvironmentSummary = memo(function ThreadEnvironmentSummary({
 
   const checkoutCopyValue = environmentCheckout?.copyValue ?? null;
   const normalizedProjectRootPath = projectRootPath
-    ? trimTrailingPathSeparators(projectRootPath)
-    : undefined;
+    ? normalizeAbsoluteFilePath({ path: projectRootPath })
+    : null;
   const normalizedEnvironmentPath = environmentPath
-    ? trimTrailingPathSeparators(environmentPath)
-    : undefined;
+    ? normalizeAbsoluteFilePath({ path: environmentPath })
+    : null;
   const environmentDirectoryName = normalizedEnvironmentPath
-    ?.split(/[\\/]/u)
+    ?.split("/")
     .at(-1);
   const visibleProjectName =
     projectName &&

--- a/apps/app/src/hooks/queries/sidebar-navigation-query.ts
+++ b/apps/app/src/hooks/queries/sidebar-navigation-query.ts
@@ -1,6 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { useCallback } from "react";
-import { PERSONAL_PROJECT_ID, type ThreadListEntry } from "@bb/domain";
+import {
+  findLocalPathProjectSourceForHost,
+  PERSONAL_PROJECT_ID,
+  type ThreadListEntry,
+} from "@bb/domain";
 import type { SidebarBootstrapResponse } from "@bb/server-contract";
 import { listSidebarNavigationThreads } from "@/hooks/cache-owners/query-cache";
 import { apiClient } from "@/lib/api-server";
@@ -56,15 +60,16 @@ export function useSidebarNavigation(options?: QueryOptions) {
 }
 
 /**
- * Read the active project's display name from the shared sidebar-navigation
- * cache. The sidebar owns the realtime subscriptions and initial load; this only
- * reads the cached projects (no extra subscriptions) so surfaces like the
- * follow-up composer footer can label the current project. Returns undefined
- * until the cache is populated or when the project is unknown.
+ * Read the active project's name and host-specific root from the shared
+ * sidebar-navigation cache. The sidebar owns the realtime subscriptions and
+ * initial load. This hook only reads the cache so the follow-up composer can
+ * identify the active workspace. Returns undefined until the cache is populated
+ * or when the project is unknown.
  */
-export function useProjectDisplayName(
+export function useProjectWorkspaceDisplay(
   projectId: string | undefined,
-): string | undefined {
+  hostId: string | undefined,
+): { name: string; rootPath: string | undefined } | undefined {
   const { data } = useQuery<SidebarBootstrapResponse>({
     queryKey: sidebarNavigationQueryKey(),
     queryFn: ({ signal }) => fetchSidebarNavigation(signal),
@@ -76,10 +81,19 @@ export function useProjectDisplayName(
   if (!data || !projectId) {
     return undefined;
   }
-  if (projectId === PERSONAL_PROJECT_ID) {
-    return data.personalProject.name;
+  const project =
+    projectId === PERSONAL_PROJECT_ID
+      ? data.personalProject
+      : data.projects.find((candidate) => candidate.id === projectId);
+  if (!project) {
+    return undefined;
   }
-  return data.projects.find((project) => project.id === projectId)?.name;
+  return {
+    name: project.name,
+    rootPath: hostId
+      ? findLocalPathProjectSourceForHost(project.sources, hostId)?.path
+      : undefined,
+  };
 }
 
 interface SidebarNavigationThreadSelection<T> {

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.keystrokes.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.keystrokes.test.tsx
@@ -258,7 +258,7 @@ vi.mock("@/hooks/mutations/thread-state-mutations", () => ({
 }));
 
 vi.mock("@/hooks/queries/sidebar-navigation-query", () => ({
-  useProjectDisplayName: () => null,
+  useProjectWorkspaceDisplay: () => null,
 }));
 
 vi.mock("@/hooks/queries/thread-default-execution-options-query", () => ({

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
@@ -534,7 +534,7 @@ vi.mock("@/hooks/mutations/thread-state-mutations", () => ({
 }));
 
 vi.mock("@/hooks/queries/sidebar-navigation-query", () => ({
-  useProjectDisplayName: () => null,
+  useProjectWorkspaceDisplay: () => null,
 }));
 
 vi.mock("@/hooks/queries/thread-default-execution-options-query", () => ({

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -67,7 +67,7 @@ import type { WorkspaceCheckoutDisplay } from "@/lib/workspace-checkout-display"
 import { useComposerTextEffects } from "@/lib/composer-text-effects";
 import { useLatestRef } from "@/hooks/useLatestRef";
 import { useThreadCreationOptions } from "@/hooks/useThreadCreationOptions";
-import { useProjectDisplayName } from "@/hooks/queries/sidebar-navigation-query";
+import { useProjectWorkspaceDisplay } from "@/hooks/queries/sidebar-navigation-query";
 import {
   useActiveComposerDraft,
   useComposerAttachmentUploads,
@@ -159,6 +159,7 @@ interface ThreadDetailPromptAreaProps {
   environmentHostId?: string;
   environmentIcon?: IconName;
   environmentLabel?: string;
+  environmentPath?: string;
   onCreateNewThreadInWorktree?: () => void;
   onPullRequestDraft?: () => void;
   onPullRequestMerge?: (method: PullRequestMergeMethod) => void;
@@ -413,6 +414,7 @@ export function ThreadDetailPromptArea({
   environmentHostId,
   environmentIcon,
   environmentLabel,
+  environmentPath,
   onCreateNewThreadInWorktree,
   onPullRequestDraft,
   onPullRequestMerge,
@@ -514,8 +516,9 @@ export function ThreadDetailPromptArea({
   const clearThreadGoal = useClearThreadGoal();
   const unarchiveThread = useUnarchiveThread();
   // The personal project isn't a meaningful label in the footer, so skip it.
-  const projectName = useProjectDisplayName(
+  const projectWorkspaceDisplay = useProjectWorkspaceDisplay(
     thread.projectId === PERSONAL_PROJECT_ID ? undefined : thread.projectId,
+    environmentHostId,
   );
   const {
     promptDraft,
@@ -1260,7 +1263,9 @@ export function ThreadDetailPromptArea({
     () =>
       environmentLabel ? (
         <ThreadEnvironmentSummary
-          projectName={projectName}
+          projectName={projectWorkspaceDisplay?.name}
+          projectRootPath={projectWorkspaceDisplay?.rootPath}
+          environmentPath={environmentPath}
           environmentLabel={environmentLabel}
           environmentCompactLabel={environmentCompactLabel}
           environmentIcon={environmentIcon}
@@ -1273,8 +1278,9 @@ export function ThreadDetailPromptArea({
       environmentCompactLabel,
       environmentIcon,
       environmentLabel,
+      environmentPath,
       onCreateNewThreadInWorktree,
-      projectName,
+      projectWorkspaceDisplay,
     ],
   );
   const activePromptModeCard = useMemo(

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -2563,7 +2563,6 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
           : undefined
       }
       environmentIcon={threadEnvironmentIcon ?? undefined}
-      environmentHostId={environment?.hostId}
       environmentLabel={
         threadEnvironmentDisplay
           ? `${environmentMachinePrefix}${threadEnvironmentDisplay.modeLabel}`

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -2563,11 +2563,13 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
           : undefined
       }
       environmentIcon={threadEnvironmentIcon ?? undefined}
+      environmentHostId={environment?.hostId}
       environmentLabel={
         threadEnvironmentDisplay
           ? `${environmentMachinePrefix}${threadEnvironmentDisplay.modeLabel}`
           : undefined
       }
+      environmentPath={environment?.path ?? undefined}
       environmentGoneStatus={threadEnvironmentGoneStatus}
       environmentHostId={environment?.hostId}
       isEnvironmentActionPending={requestEnvironmentAction.isPending}


### PR DESCRIPTION
## Summary

- Show the active workspace directory beside the project name when the environment path differs from the host-specific project root.
- Use the full active environment path in the shared project label tooltip.
- Keep the label current through the existing live environment detail query.

## What it looks like

These images come from the real dev app and a real Codex thread. The thread started in `project-a` and changed its environment to `project-b`. I did not mock UI data.

| Before the switch | After the switch |
| --- | --- |
| <img width="744" src="https://raw.githubusercontent.com/get-bb/bb/screenshots/issue-1237/issue-1237-before.png" /> | <img width="800" src="https://raw.githubusercontent.com/get-bb/bb/screenshots/issue-1237/issue-1237-after.png" /> |

The tooltip shows the full active environment path.

<img width="500" src="https://raw.githubusercontent.com/get-bb/bb/screenshots/issue-1237/issue-1237-tooltip.png" />

The label truncates a long directory name without moving the other footer controls.

<img width="500" src="https://raw.githubusercontent.com/get-bb/bb/screenshots/issue-1237/issue-1237-long-path.png" />

The screenshots live on the throwaway branch `screenshots/issue-1237`. They do not add binary files to this pull request.

## Testing

- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app --force`
- `pnpm exec turbo run lint --filter=@bb/app`
- Used a real Codex thread in `scripts/bb-dev-app current` to change the environment directory without a page reload.

Fixes #1237

> AGENT GENERATED: by GPT-5
