### PR TITLE
[issue sweep] Add a Send all action to the queued messages header

### DIFF
--- a/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.stories.tsx
@@ -760,6 +760,7 @@ function Row({
             current.filter((message) => message.id !== id),
           )
         }
+        onSendAll={() => setStoryQueuedMessages([])}
         onReorder={noop}
         onSetGroupBoundary={noop}
         onEdit={handleEditQueuedMessage}

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.stories.tsx
@@ -208,6 +208,7 @@ function StaticQueuedMessagesList({
       processingMessageId={null}
       processingAction={null}
       onSendImmediately={noop}
+      onSendAll={noop}
       onReorder={noop}
       onSetGroupBoundary={noop}
       onEdit={noop}
@@ -312,6 +313,7 @@ function ReorderableQueuedMessagesList() {
       processingMessageId={null}
       processingAction={null}
       onSendImmediately={noop}
+      onSendAll={noop}
       onReorder={handleReorder}
       onSetGroupBoundary={handleSetGroupBoundary}
       onEdit={noop}
@@ -405,6 +407,7 @@ export function Overview() {
             processingMessageId={null}
             processingAction={null}
             onSendImmediately={noop}
+            onSendAll={noop}
             onReorder={noop}
             onSetGroupBoundary={noop}
             onEdit={noop}
@@ -432,6 +435,7 @@ export function Overview() {
             processingMessageId={null}
             processingAction={null}
             onSendImmediately={noop}
+            onSendAll={noop}
             onReorder={noop}
             onSetGroupBoundary={noop}
             onEdit={noop}
@@ -451,6 +455,7 @@ export function Overview() {
             processingMessageId={null}
             processingAction={null}
             onSendImmediately={noop}
+            onSendAll={noop}
             onReorder={noop}
             onSetGroupBoundary={noop}
             onEdit={noop}
@@ -470,6 +475,7 @@ export function Overview() {
             processingMessageId={null}
             processingAction={null}
             onSendImmediately={noop}
+            onSendAll={noop}
             onReorder={noop}
             onSetGroupBoundary={noop}
             onEdit={noop}
@@ -489,6 +495,7 @@ export function Overview() {
             processingMessageId="q_b"
             processingAction="send"
             onSendImmediately={noop}
+            onSendAll={noop}
             onReorder={noop}
             onSetGroupBoundary={noop}
             onEdit={noop}
@@ -508,6 +515,7 @@ export function Overview() {
             processingMessageId={null}
             processingAction={null}
             onSendImmediately={noop}
+            onSendAll={noop}
             onReorder={noop}
             onSetGroupBoundary={noop}
             onEdit={noop}

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -338,12 +338,12 @@ describe("QueuedMessagesList", () => {
     const onSendAll = vi.fn();
     const renderSendAll = (
       queuedMessages: readonly ThreadQueuedMessage[],
-      sendDisabled = false,
+      overrides: Partial<Parameters<typeof QueuedMessagesList>[0]> = {},
     ) =>
       render(
         <QueuedMessagesList
           queuedMessages={queuedMessages}
-          sendDisabled={sendDisabled}
+          sendDisabled={false}
           actionDisabled={false}
           processingMessageId={null}
           processingAction={null}
@@ -353,6 +353,7 @@ describe("QueuedMessagesList", () => {
           onSetGroupBoundary={noop}
           onEdit={noop}
           onDelete={noop}
+          {...overrides}
         />,
       );
 
@@ -366,37 +367,104 @@ describe("QueuedMessagesList", () => {
       makeQueuedMessage("q_two", "Second"),
     ]);
     const sendAllButton = compatible.getByRole("button", { name: "Send all" });
-    expect(sendAllButton).toHaveProperty("disabled", false);
+    expect(sendAllButton.getAttribute("aria-disabled")).toBe("false");
     fireEvent.click(sendAllButton);
     expect(onSendAll).toHaveBeenCalledTimes(1);
     cleanup();
 
-    // The head cannot group with the next message, so there is nothing to
-    // release as one turn.
-    const mixed = renderSendAll([
-      makeQueuedMessage("q_one", "First"),
+    // Every blocked case keeps the control focusable and names the real
+    // reason, so keyboard and touch users are not left guessing.
+    const blockedCases: {
+      expectedReason: RegExp;
+      messages: readonly ThreadQueuedMessage[];
+      overrides?: Partial<Parameters<typeof QueuedMessagesList>[0]>;
+    }[] = [
       {
-        ...makeQueuedMessage("q_two", "Second"),
-        model: "claude-opus-5",
+        // The head cannot group with the next message, so there is nothing to
+        // release as one turn.
+        expectedReason: /different execution options/u,
+        messages: [
+          makeQueuedMessage("q_one", "First"),
+          { ...makeQueuedMessage("q_two", "Second"), model: "claude-opus-5" },
+        ],
       },
-    ]);
-    expect(
-      mixed.getByRole("button", { name: "Send all" }),
-    ).toHaveProperty("disabled", true);
-    cleanup();
+      {
+        expectedReason: /cannot accept a send right now/u,
+        messages: [
+          makeQueuedMessage("q_one", "First"),
+          makeQueuedMessage("q_two", "Second"),
+        ],
+        overrides: { sendDisabled: true },
+      },
+      {
+        // Sending would delete the row the editor is attached to.
+        expectedReason: /Finish editing/u,
+        messages: [
+          makeQueuedMessage("q_one", "First"),
+          makeQueuedMessage("q_two", "Second"),
+        ],
+        overrides: {
+          inlineEditor: {
+            queuedMessageId: "q_one",
+            queuedMessageIndex: 0,
+            content: <div>editor</div>,
+            onDismiss: noop,
+          },
+        },
+      },
+    ];
 
-    const busy = renderSendAll(
-      [
-        makeQueuedMessage("q_one", "First"),
-        makeQueuedMessage("q_two", "Second"),
-      ],
-      true,
+    for (const blockedCase of blockedCases) {
+      const blocked = renderSendAll(blockedCase.messages, blockedCase.overrides);
+      const button = blocked.getByRole("button", { name: "Send all" });
+      expect(button.getAttribute("aria-disabled")).toBe("true");
+      // Focusable while blocked: no `disabled` attribute removing it from the
+      // tab order.
+      expect(button).toHaveProperty("disabled", false);
+      const describedById = button.getAttribute("aria-describedby");
+      expect(describedById).not.toBeNull();
+      expect(
+        document.getElementById(describedById!)?.textContent ?? "",
+      ).toMatch(blockedCase.expectedReason);
+      fireEvent.click(button);
+      // Still the single click from the enabled case above.
+      expect(onSendAll).toHaveBeenCalledTimes(1);
+      cleanup();
+    }
+  });
+
+  it("describes a partial send without claiming the rest all differ", () => {
+    // A A B A: the run breaks at B, and the trailing A cannot rejoin even
+    // though its execution options match the head.
+    const { getByRole } = render(
+      <QueuedMessagesList
+        queuedMessages={[
+          makeQueuedMessage("q_one", "First"),
+          makeQueuedMessage("q_two", "Second"),
+          { ...makeQueuedMessage("q_three", "Third"), model: "claude-opus-5" },
+          makeQueuedMessage("q_four", "Fourth"),
+        ]}
+        sendDisabled={false}
+        actionDisabled={false}
+        processingMessageId={null}
+        processingAction={null}
+        onSendImmediately={noop}
+        onSendAll={noop}
+        onReorder={noop}
+        onSetGroupBoundary={noop}
+        onEdit={noop}
+        onDelete={noop}
+      />,
     );
-    expect(busy.getByRole("button", { name: "Send all" })).toHaveProperty(
-      "disabled",
-      true,
+
+    const describedById = getByRole("button", { name: "Send all" }).getAttribute(
+      "aria-describedby",
     );
-    expect(onSendAll).toHaveBeenCalledTimes(1);
+    const hint =
+      document.getElementById(describedById!)?.textContent ?? "";
+    expect(hint).toContain("Send the first 2 of 4 queued messages");
+    expect(hint).toContain("cannot group past a change in execution options");
+    expect(hint).not.toContain("The rest use different execution options");
   });
 
   it("replaces the edited row with the real inline composer", () => {

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -86,6 +86,7 @@ function renderQueuedMessages(queuedMessages: readonly ThreadQueuedMessage[]) {
       processingMessageId={null}
       processingAction={null}
       onSendImmediately={noop}
+      onSendAll={noop}
       onReorder={noop}
       onSetGroupBoundary={noop}
       onEdit={noop}
@@ -107,6 +108,7 @@ function renderQueuedMessagesWithOptions(
       processingMessageId={null}
       processingAction={null}
       onSendImmediately={noop}
+      onSendAll={noop}
       onReorder={noop}
       onSetGroupBoundary={noop}
       onEdit={noop}
@@ -185,6 +187,7 @@ describe("QueuedMessagesList", () => {
       processingMessageId: null,
       processingAction: null,
       onSendImmediately: noop,
+      onSendAll: noop,
       onReorder: noop,
       onSetGroupBoundary: noop,
       onEdit: noop,
@@ -331,6 +334,71 @@ describe("QueuedMessagesList", () => {
     }
   });
 
+  it("offers Send all only when the leading run can group into one turn", () => {
+    const onSendAll = vi.fn();
+    const renderSendAll = (
+      queuedMessages: readonly ThreadQueuedMessage[],
+      sendDisabled = false,
+    ) =>
+      render(
+        <QueuedMessagesList
+          queuedMessages={queuedMessages}
+          sendDisabled={sendDisabled}
+          actionDisabled={false}
+          processingMessageId={null}
+          processingAction={null}
+          onSendImmediately={noop}
+          onSendAll={onSendAll}
+          onReorder={noop}
+          onSetGroupBoundary={noop}
+          onEdit={noop}
+          onDelete={noop}
+        />,
+      );
+
+    // A single queued message already has its own row send action.
+    const single = renderSendAll([makeQueuedMessage("q_one", "First")]);
+    expect(single.queryByRole("button", { name: "Send all" })).toBeNull();
+    cleanup();
+
+    const compatible = renderSendAll([
+      makeQueuedMessage("q_one", "First"),
+      makeQueuedMessage("q_two", "Second"),
+    ]);
+    const sendAllButton = compatible.getByRole("button", { name: "Send all" });
+    expect(sendAllButton).toHaveProperty("disabled", false);
+    fireEvent.click(sendAllButton);
+    expect(onSendAll).toHaveBeenCalledTimes(1);
+    cleanup();
+
+    // The head cannot group with the next message, so there is nothing to
+    // release as one turn.
+    const mixed = renderSendAll([
+      makeQueuedMessage("q_one", "First"),
+      {
+        ...makeQueuedMessage("q_two", "Second"),
+        model: "claude-opus-5",
+      },
+    ]);
+    expect(
+      mixed.getByRole("button", { name: "Send all" }),
+    ).toHaveProperty("disabled", true);
+    cleanup();
+
+    const busy = renderSendAll(
+      [
+        makeQueuedMessage("q_one", "First"),
+        makeQueuedMessage("q_two", "Second"),
+      ],
+      true,
+    );
+    expect(busy.getByRole("button", { name: "Send all" })).toHaveProperty(
+      "disabled",
+      true,
+    );
+    expect(onSendAll).toHaveBeenCalledTimes(1);
+  });
+
   it("replaces the edited row with the real inline composer", () => {
     const onDismiss = vi.fn();
     const queuedMessages = [
@@ -354,6 +422,7 @@ describe("QueuedMessagesList", () => {
         processingMessageId={null}
         processingAction={null}
         onSendImmediately={noop}
+        onSendAll={noop}
         onReorder={noop}
         onSetGroupBoundary={noop}
         onEdit={noop}
@@ -424,6 +493,7 @@ describe("QueuedMessagesList", () => {
         processingMessageId={null}
         processingAction={null}
         onSendImmediately={noop}
+        onSendAll={noop}
         onReorder={noop}
         onSetGroupBoundary={noop}
         onEdit={noop}
@@ -457,6 +527,7 @@ describe("QueuedMessagesList", () => {
       processingMessageId: null,
       processingAction: null,
       onSendImmediately: noop,
+      onSendAll: noop,
       onReorder: noop,
       onSetGroupBoundary: noop,
       onEdit: noop,
@@ -504,6 +575,7 @@ describe("QueuedMessagesList", () => {
       processingMessageId: null,
       processingAction: null,
       onSendImmediately: noop,
+      onSendAll: noop,
       onReorder: noop,
       onSetGroupBoundary: noop,
       onEdit: noop,
@@ -565,6 +637,7 @@ describe("QueuedMessagesList", () => {
       processingMessageId: null,
       processingAction: null,
       onSendImmediately: noop,
+      onSendAll: noop,
       onReorder: noop,
       onSetGroupBoundary: noop,
       onEdit: noop,
@@ -667,6 +740,7 @@ describe("QueuedMessagesList", () => {
             processingMessageId={null}
             processingAction={null}
             onSendImmediately={noop}
+            onSendAll={noop}
             onReorder={noop}
             onSetGroupBoundary={noop}
             onEdit={noop}
@@ -753,6 +827,7 @@ describe("QueuedMessagesList", () => {
             processingMessageId={null}
             processingAction={null}
             onSendImmediately={noop}
+            onSendAll={noop}
             onReorder={noop}
             onSetGroupBoundary={noop}
             onEdit={noop}
@@ -845,6 +920,7 @@ describe("QueuedMessagesList", () => {
               processingMessageId={null}
               processingAction={null}
               onSendImmediately={noop}
+              onSendAll={noop}
               onReorder={noop}
               onSetGroupBoundary={noop}
               onEdit={noop}
@@ -1023,6 +1099,7 @@ describe("QueuedMessagesList", () => {
         processingMessageId={queuedMessage.id}
         processingAction="send"
         onSendImmediately={noop}
+        onSendAll={noop}
         onReorder={noop}
         onSetGroupBoundary={noop}
         onEdit={noop}
@@ -1361,6 +1438,7 @@ describe("QueuedMessagesList", () => {
         processingMessageId={null}
         processingAction={null}
         onSendImmediately={noop}
+        onSendAll={noop}
         onReorder={noop}
         onSetGroupBoundary={onSetGroupBoundary}
         onEdit={noop}
@@ -1570,6 +1648,7 @@ describe("QueuedMessagesList", () => {
         processingMessageId={null}
         processingAction={null}
         onSendImmediately={noop}
+        onSendAll={noop}
         onReorder={noop}
         onSetGroupBoundary={noop}
         onEdit={noop}
@@ -1594,6 +1673,7 @@ describe("QueuedMessagesList", () => {
         processingMessageId={null}
         processingAction={null}
         onSendImmediately={noop}
+        onSendAll={noop}
         onReorder={noop}
         onSetGroupBoundary={noop}
         onEdit={noop}

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -64,6 +64,7 @@ import {
 } from "@bb/shared-ui/tooltip";
 import { cn } from "@bb/shared-ui/lib/utils";
 import {
+  collectSendAllQueuedMessageGroupIds,
   countQueuedMessageAttachments,
   formatQueuedMessagePreview,
 } from "@/views/thread-detail/threadQueuedMessages";
@@ -106,6 +107,8 @@ export interface QueuedMessagesListProps {
   processingAction: QueuedMessageProcessingAction | null;
   inlineEditor?: QueuedMessageInlineEditor;
   onSendImmediately: (id: string) => void;
+  /** Groups the leading compatible run into one turn, then sends the head. */
+  onSendAll: () => void;
   onReorder: (request: QueuedMessageReorderRequest) => void;
   onSetGroupBoundary: (request: QueuedMessageGroupBoundaryRequest) => void;
   onEdit: (request: QueuedMessageEditRequest) => void;
@@ -958,6 +961,7 @@ export function QueuedMessagesList({
   processingAction,
   inlineEditor,
   onSendImmediately,
+  onSendAll,
   onReorder,
   onSetGroupBoundary,
   onEdit,
@@ -1174,6 +1178,10 @@ export function QueuedMessagesList({
     setOrderedMessages(queuedMessages);
   }
 
+  const sendAllGroupIds = useMemo(
+    () => collectSendAllQueuedMessageGroupIds(queuedMessages),
+    [queuedMessages],
+  );
   const groupBoundaryIndex = useMemo(() => {
     const firstUngroupedIndex = orderedMessages.findIndex(
       (queuedMessage) => !queuedMessage.groupWithNext,
@@ -1491,6 +1499,16 @@ export function QueuedMessagesList({
 
   if (queuedMessages.length === 0 && !inlineEditor) return null;
 
+  // "Send all" groups the leading compatible run and steers its head, so it
+  // only makes sense once at least two messages can travel together.
+  const sendAllGroupSize = sendAllGroupIds.length;
+  const sendAllPossible = sendAllGroupSize > 1;
+  const sendAllTooltip = !sendAllPossible
+    ? "The next queued message uses different execution options, so the queue cannot send as one turn"
+    : sendAllGroupSize === queuedMessages.length
+      ? `Send all ${queuedMessages.length} queued messages as one turn`
+      : `Send the first ${sendAllGroupSize} of ${queuedMessages.length} queued messages as one turn. The rest use different execution options.`;
+
   const queueFitsDrawer = queuedMessages.length <= DRAWER_MAX_VISIBLE_MESSAGES;
   const caretWillCollapse =
     mode === "workspace" || (mode === "drawer" && queueFitsDrawer);
@@ -1530,11 +1548,34 @@ export function QueuedMessagesList({
         )}
         data-queued-messages-mode={mode}
       >
-        <div className="flex min-w-16 items-baseline gap-1.5 pl-1">
+        <div className="flex min-w-16 items-center gap-1.5 pl-1">
           <span className="text-xs font-medium text-foreground">Queued</span>
           <span className="text-2xs text-subtle-foreground">
             {queuedMessages.length}
           </span>
+          {queuedMessages.length > 1 ? (
+            <TooltipProvider delayDuration={300}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  {/* The span keeps the tooltip reachable while the button is
+                      disabled, which is exactly when it explains the most. */}
+                  <span className="inline-flex">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="ghost"
+                      className="h-6 px-1.5 text-2xs text-muted-foreground hover:bg-surface-recessed"
+                      disabled={sendDisabled || !sendAllPossible}
+                      onClick={onSendAll}
+                    >
+                      Send all
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>{sendAllTooltip}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : null}
         </div>
         <button
           type="button"

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -2,6 +2,7 @@ import {
   memo,
   useCallback,
   useEffect,
+  useId,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -64,6 +65,7 @@ import {
 } from "@bb/shared-ui/tooltip";
 import { cn } from "@bb/shared-ui/lib/utils";
 import {
+  collectLeadQueuedMessageGroupIds,
   collectSendAllQueuedMessageGroupIds,
   countQueuedMessageAttachments,
   formatQueuedMessagePreview,
@@ -278,17 +280,6 @@ function CompactQueuedMarkdownPreview({
       </ReactMarkdown>
     </span>
   );
-}
-
-function collectLeadQueuedMessageGroupIds(
-  queuedMessages: readonly ThreadQueuedMessage[],
-): string[] {
-  const ids: string[] = [];
-  for (const queuedMessage of queuedMessages) {
-    ids.push(queuedMessage.id);
-    if (!queuedMessage.groupWithNext) break;
-  }
-  return ids;
 }
 
 function preserveLeadQueuedMessageGroupAfterReorder({
@@ -1178,6 +1169,7 @@ export function QueuedMessagesList({
     setOrderedMessages(queuedMessages);
   }
 
+  const sendAllHintId = useId();
   const sendAllGroupIds = useMemo(
     () => collectSendAllQueuedMessageGroupIds(queuedMessages),
     [queuedMessages],
@@ -1502,12 +1494,21 @@ export function QueuedMessagesList({
   // "Send all" groups the leading compatible run and steers its head, so it
   // only makes sense once at least two messages can travel together.
   const sendAllGroupSize = sendAllGroupIds.length;
-  const sendAllPossible = sendAllGroupSize > 1;
-  const sendAllTooltip = !sendAllPossible
-    ? "The next queued message uses different execution options, so the queue cannot send as one turn"
-    : sendAllGroupSize === queuedMessages.length
-      ? `Send all ${queuedMessages.length} queued messages as one turn`
-      : `Send the first ${sendAllGroupSize} of ${queuedMessages.length} queued messages as one turn. The rest use different execution options.`;
+  // Each reason states why the action cannot run right now. The button stays
+  // focusable while blocked so keyboard and touch users reach the reason too.
+  const sendAllBlockedReason =
+    sendAllGroupSize < 2
+      ? "The next queued message uses different execution options, so the queue cannot send as one turn."
+      : inlineEditor
+        ? "Finish editing the queued message before you send the queue."
+        : sendDisabled
+          ? "The thread cannot accept a send right now."
+          : null;
+  const sendAllHint =
+    sendAllBlockedReason ??
+    (sendAllGroupSize === queuedMessages.length
+      ? `Send all ${queuedMessages.length} queued messages as one turn.`
+      : `Send the first ${sendAllGroupSize} of ${queuedMessages.length} queued messages as one turn. The queue cannot group past a change in execution options, so the rest stay queued.`);
 
   const queueFitsDrawer = queuedMessages.length <= DRAWER_MAX_VISIBLE_MESSAGES;
   const caretWillCollapse =
@@ -1543,7 +1544,7 @@ export function QueuedMessagesList({
     >
       <header
         className={cn(
-          "group/queue-header flex h-8 shrink-0 items-center gap-2 px-2",
+          "group/queue-header relative flex h-8 shrink-0 items-center gap-2 px-2",
           mode !== "collapsed" && "border-b border-border/35",
         )}
         data-queued-messages-mode={mode}
@@ -1557,30 +1558,41 @@ export function QueuedMessagesList({
             <TooltipProvider delayDuration={300}>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  {/* The span keeps the tooltip reachable while the button is
-                      disabled, which is exactly when it explains the most. */}
-                  <span className="inline-flex">
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="ghost"
-                      className="h-6 px-1.5 text-2xs text-muted-foreground hover:bg-surface-recessed"
-                      disabled={sendDisabled || !sendAllPossible}
-                      onClick={onSendAll}
-                    >
-                      Send all
-                    </Button>
-                  </span>
+                  {/* `aria-disabled` instead of `disabled` keeps the control
+                      focusable while blocked, so keyboard and touch users can
+                      still reach the reason it carries. */}
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    className={cn(
+                      "h-6 px-1.5 text-2xs text-muted-foreground hover:bg-surface-recessed",
+                      sendAllBlockedReason !== null &&
+                        "opacity-50 hover:bg-transparent",
+                    )}
+                    aria-disabled={sendAllBlockedReason !== null}
+                    aria-describedby={sendAllHintId}
+                    onClick={() => {
+                      if (sendAllBlockedReason === null) onSendAll();
+                    }}
+                  >
+                    Send all
+                  </Button>
                 </TooltipTrigger>
-                <TooltipContent>{sendAllTooltip}</TooltipContent>
+                <TooltipContent>{sendAllHint}</TooltipContent>
               </Tooltip>
             </TooltipProvider>
+          ) : null}
+          {queuedMessages.length > 1 ? (
+            <span id={sendAllHintId} className="sr-only">
+              {sendAllHint}
+            </span>
           ) : null}
         </div>
         <button
           type="button"
           className={cn(
-            "group/handle flex h-full min-w-16 flex-1 touch-none select-none items-center justify-center focus-visible:rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+            "group/handle flex h-full min-w-16 flex-1 touch-none select-none items-center focus-visible:rounded focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
             surfaceDragging ? "cursor-grabbing" : "cursor-grab",
           )}
           aria-label={
@@ -1593,9 +1605,13 @@ export function QueuedMessagesList({
           onPointerUp={finishSurfaceDrag}
           onPointerCancel={finishSurfaceDrag}
           onKeyDown={handleSurfaceKeyDown}
-        >
-          <span className="h-px w-7 rounded-full bg-muted-foreground opacity-30 transition-opacity group-hover/handle:opacity-50 group-focus-visible/handle:opacity-50" />
-        </button>
+        />
+        {/* The grip centers on the header, not on the drag area, so a wider
+            left cluster cannot pull it off center. */}
+        <span
+          aria-hidden
+          className="pointer-events-none absolute left-1/2 top-1/2 h-px w-7 -translate-x-1/2 -translate-y-1/2 rounded-full bg-muted-foreground opacity-30 transition-opacity group-hover/queue-header:opacity-50"
+        />
         <div className="flex min-w-16 items-center justify-end">
           <TooltipProvider delayDuration={300}>
             <Tooltip>

--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
@@ -561,6 +561,7 @@ function EmbeddedThreadChatWithComposer({
     queuedMessageActionPending,
     isUpdateQueuedMessagePending,
     handleSendQueuedImmediately,
+    handleSendAllQueuedMessages,
     handleSaveInlineQueuedMessage,
     handleDeleteQueuedMessage,
     handleReorderQueuedMessage,
@@ -1260,6 +1261,7 @@ function EmbeddedThreadChatWithComposer({
           processingMessageId={processingQueuedMessage?.id ?? null}
           processingAction={processingQueuedMessage?.action ?? null}
           onSendImmediately={handleSendQueuedImmediately}
+          onSendAll={handleSendAllQueuedMessages}
           onReorder={handleReorderQueuedMessage}
           onSetGroupBoundary={handleSetQueuedMessageGroupBoundary}
           onEdit={beginEditQueuedMessage}
@@ -1270,6 +1272,7 @@ function EmbeddedThreadChatWithComposer({
       beginEditQueuedMessage,
       handleDeleteQueuedMessage,
       handleReorderQueuedMessage,
+      handleSendAllQueuedMessages,
       handleSendQueuedImmediately,
       handleSetQueuedMessageGroupBoundary,
       inlineEditor,

--- a/apps/app/src/components/thread/embedded-chat/useQueuedMessageActions.test.tsx
+++ b/apps/app/src/components/thread/embedded-chat/useQueuedMessageActions.test.tsx
@@ -3,6 +3,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ThreadQueuedMessage } from "@bb/domain";
+import type { InlineQueuedMessageEditState } from "./useInlineQueuedMessageEditing";
 import { useQueuedMessageActions } from "./useQueuedMessageActions";
 
 const mocks = vi.hoisted(() => ({
@@ -13,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   updateQueuedMessage: vi.fn(),
   toastError: vi.fn(),
   toastMessage: vi.fn(),
+  toastWarning: vi.fn(),
 }));
 
 vi.mock("@/hooks/mutations/thread-runtime-mutations", () => ({
@@ -39,7 +41,11 @@ vi.mock("@/hooks/mutations/thread-runtime-mutations", () => ({
 }));
 
 vi.mock("@/components/ui/app-toast", () => ({
-  appToast: { error: mocks.toastError, message: mocks.toastMessage },
+  appToast: {
+    error: mocks.toastError,
+    message: mocks.toastMessage,
+    warning: mocks.toastWarning,
+  },
 }));
 
 function makeQueuedMessage(
@@ -60,13 +66,16 @@ function makeQueuedMessage(
   };
 }
 
-function renderActions(queuedMessages: readonly ThreadQueuedMessage[]) {
+function renderActions(
+  queuedMessages: readonly ThreadQueuedMessage[],
+  inlineEditingQueuedMessage: InlineQueuedMessageEditState | null = null,
+) {
   return renderHook(() =>
     useQueuedMessageActions({
       threadId: "thr_1",
       queuedMessages,
       sendProcessingPersistence: "clear-on-settle",
-      inlineEditingQueuedMessage: null,
+      inlineEditingQueuedMessage,
       dismissInlineQueuedMessageEditor: () => {},
       activeComposerDraftInput: [],
     }),
@@ -127,7 +136,7 @@ describe("useQueuedMessageActions send all", () => {
     expect(mocks.toastMessage).toHaveBeenCalledWith(
       "Sent 2 of 4 queued messages",
       expect.objectContaining({
-        description: expect.stringContaining("2 messages use"),
+        description: expect.stringContaining("2 messages stayed queued"),
       }),
     );
   });
@@ -148,20 +157,77 @@ describe("useQueuedMessageActions send all", () => {
     expect(result.current.processingQueuedMessage).toBeNull();
   });
 
-  it("skips the remainder toast when the send itself fails", async () => {
+  it("skips the remainder toast and undoes the group when the send fails", async () => {
     mocks.sendQueuedMessage.mockRejectedValue(new Error("boom"));
     const { result } = renderActions([
-      makeQueuedMessage("q_one"),
+      // The first two already travel together, so that is the boundary to
+      // restore after the failed send.
+      makeQueuedMessage("q_one", { groupWithNext: true }),
       makeQueuedMessage("q_two"),
-      makeQueuedMessage("q_three", { model: "claude-opus-5" }),
+      makeQueuedMessage("q_three"),
     ]);
 
     await act(async () => {
       result.current.handleSendAllQueuedMessages();
     });
 
-    expect(mocks.setGroupBoundary).toHaveBeenCalledTimes(1);
     expect(mocks.toastError).toHaveBeenCalledTimes(1);
     expect(mocks.toastMessage).not.toHaveBeenCalled();
+    expect(mocks.setGroupBoundary).toHaveBeenCalledTimes(2);
+    expect(mocks.setGroupBoundary).toHaveBeenLastCalledWith({
+      id: "thr_1",
+      expectedGroupedPrefixQueuedMessageIds: ["q_one", "q_two"],
+      groupBoundaryQueuedMessageId: "q_two",
+    });
+    expect(mocks.toastWarning).not.toHaveBeenCalled();
+  });
+
+  it("reports the leftover group when the undo also fails", async () => {
+    mocks.sendQueuedMessage.mockRejectedValue(new Error("boom"));
+    mocks.setGroupBoundary
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error("undo failed"));
+    const { result } = renderActions([
+      makeQueuedMessage("q_one"),
+      makeQueuedMessage("q_two"),
+    ]);
+
+    await act(async () => {
+      result.current.handleSendAllQueuedMessages();
+    });
+
+    expect(mocks.toastWarning).toHaveBeenCalledWith(
+      "The queued messages stayed grouped",
+      expect.objectContaining({
+        description: expect.stringContaining("go together on the next turn"),
+      }),
+    );
+  });
+
+  it("refuses to send while a queued message has an open edit", async () => {
+    const inlineEdit: InlineQueuedMessageEditState = {
+      draft: { attachments: [], mentions: [], text: "unsaved text" },
+      editSessionId: 1,
+      expectedUpdatedAt: 1,
+      model: "gpt-5.5",
+      ownerThreadId: "thr_1",
+      permissionMode: "auto",
+      queuedMessageId: "q_one",
+      queuedMessageIndex: 0,
+      reasoningLevel: "medium",
+      serviceTier: "default",
+    };
+    const { result } = renderActions(
+      [makeQueuedMessage("q_one"), makeQueuedMessage("q_two")],
+      inlineEdit,
+    );
+
+    await act(async () => {
+      result.current.handleSendAllQueuedMessages();
+    });
+
+    // Nothing may run: the send would delete the row the editor is bound to.
+    expect(mocks.setGroupBoundary).not.toHaveBeenCalled();
+    expect(mocks.sendQueuedMessage).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/components/thread/embedded-chat/useQueuedMessageActions.test.tsx
+++ b/apps/app/src/components/thread/embedded-chat/useQueuedMessageActions.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ThreadQueuedMessage } from "@bb/domain";
+import { useQueuedMessageActions } from "./useQueuedMessageActions";
+
+const mocks = vi.hoisted(() => ({
+  deleteQueuedMessage: vi.fn(),
+  reorderQueuedMessage: vi.fn(),
+  sendQueuedMessage: vi.fn(),
+  setGroupBoundary: vi.fn(),
+  updateQueuedMessage: vi.fn(),
+  toastError: vi.fn(),
+  toastMessage: vi.fn(),
+}));
+
+vi.mock("@/hooks/mutations/thread-runtime-mutations", () => ({
+  useDeleteThreadQueuedMessage: () => ({
+    isPending: false,
+    mutateAsync: mocks.deleteQueuedMessage,
+  }),
+  useReorderThreadQueuedMessage: () => ({
+    isPending: false,
+    mutateAsync: mocks.reorderQueuedMessage,
+  }),
+  useSendThreadQueuedMessage: () => ({
+    isPending: false,
+    mutateAsync: mocks.sendQueuedMessage,
+  }),
+  useSetThreadQueuedMessageGroupBoundary: () => ({
+    isPending: false,
+    mutateAsync: mocks.setGroupBoundary,
+  }),
+  useUpdateThreadQueuedMessage: () => ({
+    isPending: false,
+    mutateAsync: mocks.updateQueuedMessage,
+  }),
+}));
+
+vi.mock("@/components/ui/app-toast", () => ({
+  appToast: { error: mocks.toastError, message: mocks.toastMessage },
+}));
+
+function makeQueuedMessage(
+  id: string,
+  overrides: Partial<ThreadQueuedMessage> = {},
+): ThreadQueuedMessage {
+  return {
+    id,
+    content: [{ type: "text", text: id, mentions: [] }],
+    model: "gpt-5.5",
+    reasoningLevel: "medium",
+    permissionMode: "auto",
+    serviceTier: "default",
+    groupWithNext: false,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+function renderActions(queuedMessages: readonly ThreadQueuedMessage[]) {
+  return renderHook(() =>
+    useQueuedMessageActions({
+      threadId: "thr_1",
+      queuedMessages,
+      sendProcessingPersistence: "clear-on-settle",
+      inlineEditingQueuedMessage: null,
+      dismissInlineQueuedMessageEditor: () => {},
+      activeComposerDraftInput: [],
+    }),
+  );
+}
+
+describe("useQueuedMessageActions send all", () => {
+  beforeEach(() => {
+    for (const mock of Object.values(mocks)) mock.mockReset();
+    mocks.setGroupBoundary.mockResolvedValue([]);
+    mocks.sendQueuedMessage.mockResolvedValue({ ok: true });
+  });
+
+  it("widens the group to the last message, then sends the head once", async () => {
+    const { result } = renderActions([
+      makeQueuedMessage("q_one"),
+      makeQueuedMessage("q_two"),
+      makeQueuedMessage("q_three"),
+    ]);
+
+    await act(async () => {
+      result.current.handleSendAllQueuedMessages();
+    });
+
+    expect(mocks.setGroupBoundary).toHaveBeenCalledWith({
+      id: "thr_1",
+      expectedGroupedPrefixQueuedMessageIds: ["q_one", "q_two", "q_three"],
+      groupBoundaryQueuedMessageId: "q_three",
+    });
+    // A thread runs one turn at a time: the single head send claims the group.
+    expect(mocks.sendQueuedMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.sendQueuedMessage).toHaveBeenCalledWith({
+      id: "thr_1",
+      mode: "auto",
+      queuedMessageId: "q_one",
+    });
+    expect(mocks.toastMessage).not.toHaveBeenCalled();
+  });
+
+  it("sends the compatible run and reports the messages left behind", async () => {
+    const { result } = renderActions([
+      makeQueuedMessage("q_one"),
+      makeQueuedMessage("q_two"),
+      makeQueuedMessage("q_three", { reasoningLevel: "high" }),
+      makeQueuedMessage("q_four", { reasoningLevel: "high" }),
+    ]);
+
+    await act(async () => {
+      result.current.handleSendAllQueuedMessages();
+    });
+
+    expect(mocks.setGroupBoundary).toHaveBeenCalledWith({
+      id: "thr_1",
+      expectedGroupedPrefixQueuedMessageIds: ["q_one", "q_two"],
+      groupBoundaryQueuedMessageId: "q_two",
+    });
+    expect(mocks.sendQueuedMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.toastMessage).toHaveBeenCalledWith(
+      "Sent 2 of 4 queued messages",
+      expect.objectContaining({
+        description: expect.stringContaining("2 messages use"),
+      }),
+    );
+  });
+
+  it("does not send when the group boundary is rejected", async () => {
+    mocks.setGroupBoundary.mockRejectedValue(new Error("boom"));
+    const { result } = renderActions([
+      makeQueuedMessage("q_one"),
+      makeQueuedMessage("q_two"),
+    ]);
+
+    await act(async () => {
+      result.current.handleSendAllQueuedMessages();
+    });
+
+    expect(mocks.sendQueuedMessage).not.toHaveBeenCalled();
+    expect(mocks.toastError).toHaveBeenCalledTimes(1);
+    expect(result.current.processingQueuedMessage).toBeNull();
+  });
+
+  it("skips the remainder toast when the send itself fails", async () => {
+    mocks.sendQueuedMessage.mockRejectedValue(new Error("boom"));
+    const { result } = renderActions([
+      makeQueuedMessage("q_one"),
+      makeQueuedMessage("q_two"),
+      makeQueuedMessage("q_three", { model: "claude-opus-5" }),
+    ]);
+
+    await act(async () => {
+      result.current.handleSendAllQueuedMessages();
+    });
+
+    expect(mocks.setGroupBoundary).toHaveBeenCalledTimes(1);
+    expect(mocks.toastError).toHaveBeenCalledTimes(1);
+    expect(mocks.toastMessage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/components/thread/embedded-chat/useQueuedMessageActions.ts
+++ b/apps/app/src/components/thread/embedded-chat/useQueuedMessageActions.ts
@@ -15,7 +15,10 @@ import { getMutationErrorMessage } from "@/lib/mutation-errors";
 import type { QueuedMessageReorderRequest } from "@/lib/queued-message-reorder";
 import { appToast } from "@/components/ui/app-toast";
 import { BbHttpError } from "@/lib/sdk";
-import { collectSendAllQueuedMessageGroupIds } from "@/views/thread-detail/threadQueuedMessages";
+import {
+  collectLeadQueuedMessageGroupIds,
+  collectSendAllQueuedMessageGroupIds,
+} from "@/views/thread-detail/threadQueuedMessages";
 import type { InlineQueuedMessageEditState } from "./useInlineQueuedMessageEditing";
 
 export type QueuedMessageSendGuard = "current-head" | "exists" | "none";
@@ -183,6 +186,10 @@ export function useQueuedMessageActions({
       if (threadId === null || (canSendNow !== undefined && !canSendNow())) {
         return;
       }
+      // Sending removes the queued rows and closes the inline editor with them,
+      // so an open edit must be resolved before the queue can go.
+      if (inlineEditingQueuedMessage) return;
+
       const queuedMessages = queuedMessagesRef.current;
       const headQueuedMessage = queuedMessages[0];
       const groupIds = collectSendAllQueuedMessageGroupIds(queuedMessages);
@@ -194,6 +201,8 @@ export function useQueuedMessageActions({
       ) {
         return;
       }
+      const originalGroupIds = collectLeadQueuedMessageGroupIds(queuedMessages);
+      const originalBoundaryQueuedMessageId = originalGroupIds.at(-1);
 
       setProcessingQueuedMessage({ id: headQueuedMessage.id, action: "send" });
       try {
@@ -220,20 +229,40 @@ export function useQueuedMessageActions({
         guard: "current-head",
         messageId: headQueuedMessage.id,
       });
+      if (!sent) {
+        // The widened group only existed to carry this send. Put the previous
+        // boundary back so a failed send cannot silently change what the next
+        // turn picks up, and say so plainly when the undo cannot land.
+        if (originalBoundaryQueuedMessageId === undefined) return;
+        try {
+          await setQueuedMessageGroupBoundary.mutateAsync({
+            id: threadId,
+            expectedGroupedPrefixQueuedMessageIds: originalGroupIds,
+            groupBoundaryQueuedMessageId: originalBoundaryQueuedMessageId,
+          });
+        } catch {
+          appToast.warning("The queued messages stayed grouped", {
+            description: `The send failed after the group changed. The first ${groupIds.length} queued messages will now go together on the next turn.`,
+          });
+        }
+        return;
+      }
+
       const remainingCount = queuedMessages.length - groupIds.length;
-      if (sent && remainingCount > 0) {
+      if (remainingCount > 0) {
         appToast.message(
           `Sent ${groupIds.length} of ${queuedMessages.length} queued messages`,
           {
-            description: `${remainingCount} ${
-              remainingCount === 1 ? "message uses" : "messages use"
-            } different execution options and stayed queued.`,
+            description: `The queue cannot group past a change in execution options, so ${remainingCount} ${
+              remainingCount === 1 ? "message stayed" : "messages stayed"
+            } queued.`,
           },
         );
       }
     })();
   }, [
     canSendNow,
+    inlineEditingQueuedMessage,
     sendQueuedMessageById,
     setQueuedMessageGroupBoundary,
     threadId,

--- a/apps/app/src/components/thread/embedded-chat/useQueuedMessageActions.ts
+++ b/apps/app/src/components/thread/embedded-chat/useQueuedMessageActions.ts
@@ -15,6 +15,7 @@ import { getMutationErrorMessage } from "@/lib/mutation-errors";
 import type { QueuedMessageReorderRequest } from "@/lib/queued-message-reorder";
 import { appToast } from "@/components/ui/app-toast";
 import { BbHttpError } from "@/lib/sdk";
+import { collectSendAllQueuedMessageGroupIds } from "@/views/thread-detail/threadQueuedMessages";
 import type { InlineQueuedMessageEditState } from "./useInlineQueuedMessageEditing";
 
 export type QueuedMessageSendGuard = "current-head" | "exists" | "none";
@@ -53,8 +54,10 @@ export interface UseQueuedMessageActionsResult {
   } | null;
   queuedMessageActionPending: boolean;
   isUpdateQueuedMessagePending: boolean;
-  sendQueuedMessageById: (args: SendQueuedMessageByIdArgs) => Promise<void>;
+  /** Resolves to whether the send request succeeded. */
+  sendQueuedMessageById: (args: SendQueuedMessageByIdArgs) => Promise<boolean>;
   handleSendQueuedImmediately: (queuedMessageId: string) => void;
+  handleSendAllQueuedMessages: () => void;
   handleSaveInlineQueuedMessage: () => Promise<void>;
   handleDeleteQueuedMessage: (queuedMessageId: string) => void;
   handleReorderQueuedMessage: (request: QueuedMessageReorderRequest) => void;
@@ -108,19 +111,19 @@ export function useQueuedMessageActions({
   const sendQueuedMessageById = useCallback(
     async ({ guard, messageId }: SendQueuedMessageByIdArgs) => {
       if (threadId === null || (canSendNow !== undefined && !canSendNow())) {
-        return;
+        return false;
       }
       if (
         guard !== "none" &&
         !queuedMessagesRef.current.some((message) => message.id === messageId)
       ) {
-        return;
+        return false;
       }
       if (
         guard === "current-head" &&
         queuedMessagesRef.current[0]?.id !== messageId
       ) {
-        return;
+        return false;
       }
 
       setProcessingQueuedMessage({ id: messageId, action: "send" });
@@ -138,6 +141,7 @@ export function useQueuedMessageActions({
         }
         // With `until-left-queue`, the displayed processing state clears via
         // derivation once the message leaves the queue.
+        return true;
       } catch (error) {
         appToast.error(
           getMutationErrorMessage({
@@ -149,6 +153,7 @@ export function useQueuedMessageActions({
         setProcessingQueuedMessage((current) =>
           current?.id === messageId ? null : current,
         );
+        return false;
       }
     },
     [
@@ -166,6 +171,73 @@ export function useQueuedMessageActions({
     },
     [sendQueuedMessageById],
   );
+
+  /**
+   * Sends the whole queue as one turn. A thread runs one turn at a time and
+   * every send re-claims the queue, so this never loops the per-message send:
+   * it widens the lead group to the last compatible message and then steers the
+   * head, which claims the entire group in one call.
+   */
+  const handleSendAllQueuedMessages = useCallback(() => {
+    void (async () => {
+      if (threadId === null || (canSendNow !== undefined && !canSendNow())) {
+        return;
+      }
+      const queuedMessages = queuedMessagesRef.current;
+      const headQueuedMessage = queuedMessages[0];
+      const groupIds = collectSendAllQueuedMessageGroupIds(queuedMessages);
+      const lastGroupedQueuedMessageId = groupIds.at(-1);
+      if (
+        !headQueuedMessage ||
+        lastGroupedQueuedMessageId === undefined ||
+        groupIds.length < 2
+      ) {
+        return;
+      }
+
+      setProcessingQueuedMessage({ id: headQueuedMessage.id, action: "send" });
+      try {
+        await setQueuedMessageGroupBoundary.mutateAsync({
+          id: threadId,
+          expectedGroupedPrefixQueuedMessageIds: groupIds,
+          groupBoundaryQueuedMessageId: lastGroupedQueuedMessageId,
+        });
+      } catch (error) {
+        setProcessingQueuedMessage((current) =>
+          current?.id === headQueuedMessage.id ? null : current,
+        );
+        appToast.error(
+          getMutationErrorMessage({
+            error,
+            fallbackMessage: "Failed to group queued messages",
+            lifecycleOperation: "set_queued_message_group_boundary",
+          }),
+        );
+        return;
+      }
+
+      const sent = await sendQueuedMessageById({
+        guard: "current-head",
+        messageId: headQueuedMessage.id,
+      });
+      const remainingCount = queuedMessages.length - groupIds.length;
+      if (sent && remainingCount > 0) {
+        appToast.message(
+          `Sent ${groupIds.length} of ${queuedMessages.length} queued messages`,
+          {
+            description: `${remainingCount} ${
+              remainingCount === 1 ? "message uses" : "messages use"
+            } different execution options and stayed queued.`,
+          },
+        );
+      }
+    })();
+  }, [
+    canSendNow,
+    sendQueuedMessageById,
+    setQueuedMessageGroupBoundary,
+    threadId,
+  ]);
 
   const handleSaveInlineQueuedMessage = useCallback(async () => {
     if (
@@ -310,6 +382,7 @@ export function useQueuedMessageActions({
     isUpdateQueuedMessagePending: updateQueuedMessage.isPending,
     sendQueuedMessageById,
     handleSendQueuedImmediately,
+    handleSendAllQueuedMessages,
     handleSaveInlineQueuedMessage,
     handleDeleteQueuedMessage,
     handleReorderQueuedMessage,

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -632,6 +632,7 @@ export function ThreadDetailPromptArea({
     queuedMessageActionPending,
     isUpdateQueuedMessagePending,
     sendQueuedMessageById,
+    handleSendAllQueuedMessages,
     handleSaveInlineQueuedMessage,
     handleDeleteQueuedMessage,
     handleReorderQueuedMessage,
@@ -1521,6 +1522,7 @@ export function ThreadDetailPromptArea({
             processingMessageId={displayedProcessingQueuedMessage?.id ?? null}
             processingAction={displayedProcessingQueuedMessage?.action ?? null}
             onSendImmediately={handleSendQueuedImmediately}
+            onSendAll={handleSendAllQueuedMessages}
             onReorder={handleReorderQueuedMessage}
             onSetGroupBoundary={handleSetQueuedMessageGroupBoundary}
             onEdit={beginEditQueuedMessage}
@@ -1538,6 +1540,7 @@ export function ThreadDetailPromptArea({
       beginEditQueuedMessage,
       handlePromptBannerFileClick,
       handleReorderQueuedMessage,
+      handleSendAllQueuedMessages,
       handleSendQueuedImmediately,
       handleSetQueuedMessageGroupBoundary,
       handleToggleBannerSection,

--- a/apps/app/src/views/thread-detail/threadQueuedMessages.test.ts
+++ b/apps/app/src/views/thread-detail/threadQueuedMessages.test.ts
@@ -1,9 +1,28 @@
 import { describe, expect, it } from "vitest";
-import type { PromptInput } from "@bb/domain";
+import type { PromptInput, ThreadQueuedMessage } from "@bb/domain";
 import {
+  collectSendAllQueuedMessageGroupIds,
   formatQueuedMessagePreview,
   queuedInputToDraft,
 } from "./threadQueuedMessages";
+
+function makeQueuedMessage(
+  id: string,
+  overrides: Partial<ThreadQueuedMessage> = {},
+): ThreadQueuedMessage {
+  return {
+    id,
+    content: [{ type: "text", text: id, mentions: [] }],
+    model: "gpt-5.5",
+    reasoningLevel: "medium",
+    permissionMode: "auto",
+    serviceTier: "default",
+    groupWithNext: false,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
 
 describe("threadQueuedMessages", () => {
   it("formats queued-message previews from text or attachment-only inputs", () => {
@@ -112,5 +131,43 @@ describe("threadQueuedMessages", () => {
         },
       ],
     });
+  });
+
+  it("stops the send-all group at the first mismatched execution option", () => {
+    expect(collectSendAllQueuedMessageGroupIds([])).toEqual([]);
+    expect(
+      collectSendAllQueuedMessageGroupIds([
+        makeQueuedMessage("q_one"),
+        makeQueuedMessage("q_two"),
+        makeQueuedMessage("q_three"),
+      ]),
+    ).toEqual(["q_one", "q_two", "q_three"]);
+    expect(
+      collectSendAllQueuedMessageGroupIds([
+        makeQueuedMessage("q_one"),
+        makeQueuedMessage("q_two"),
+        makeQueuedMessage("q_three", { model: "claude-opus-5" }),
+        // A later match must not rejoin the group once the run is broken.
+        makeQueuedMessage("q_four"),
+      ]),
+    ).toEqual(["q_one", "q_two"]);
+    expect(
+      collectSendAllQueuedMessageGroupIds([
+        makeQueuedMessage("q_one"),
+        makeQueuedMessage("q_two", { reasoningLevel: "high" }),
+      ]),
+    ).toEqual(["q_one"]);
+    expect(
+      collectSendAllQueuedMessageGroupIds([
+        makeQueuedMessage("q_one"),
+        makeQueuedMessage("q_two", { permissionMode: "full" }),
+      ]),
+    ).toEqual(["q_one"]);
+    expect(
+      collectSendAllQueuedMessageGroupIds([
+        makeQueuedMessage("q_one"),
+        makeQueuedMessage("q_two", { serviceTier: "fast" }),
+      ]),
+    ).toEqual(["q_one"]);
   });
 });

--- a/apps/app/src/views/thread-detail/threadQueuedMessages.ts
+++ b/apps/app/src/views/thread-detail/threadQueuedMessages.ts
@@ -1,4 +1,4 @@
-import { type PromptInput } from "@bb/domain";
+import { type PromptInput, type ThreadQueuedMessage } from "@bb/domain";
 import { fileNameFromPath } from "@bb/thread-view";
 import { promptInputToDraft, type PromptDraftState } from "@/lib/prompt-draft";
 
@@ -82,6 +82,35 @@ export function formatQueuedMessagePreview(
   }
 
   return "(empty message)";
+}
+
+/**
+ * The leading run of queued messages that the server can group into one turn.
+ * A group carries a single execution envelope, so the run stops at the first
+ * message whose model, reasoning level, permission mode, or service tier
+ * differs from the head. The server applies one more rule the client cannot
+ * see — it also refuses to group messages from different sender threads — so a
+ * boundary request built from this run can still fail; surface that error.
+ */
+export function collectSendAllQueuedMessageGroupIds(
+  queuedMessages: readonly ThreadQueuedMessage[],
+): string[] {
+  const headQueuedMessage = queuedMessages[0];
+  if (!headQueuedMessage) return [];
+
+  const ids: string[] = [];
+  for (const queuedMessage of queuedMessages) {
+    if (
+      queuedMessage.model !== headQueuedMessage.model ||
+      queuedMessage.reasoningLevel !== headQueuedMessage.reasoningLevel ||
+      queuedMessage.permissionMode !== headQueuedMessage.permissionMode ||
+      queuedMessage.serviceTier !== headQueuedMessage.serviceTier
+    ) {
+      break;
+    }
+    ids.push(queuedMessage.id);
+  }
+  return ids;
 }
 
 export function queuedInputToDraft(

--- a/apps/app/src/views/thread-detail/threadQueuedMessages.ts
+++ b/apps/app/src/views/thread-detail/threadQueuedMessages.ts
@@ -113,6 +113,18 @@ export function collectSendAllQueuedMessageGroupIds(
   return ids;
 }
 
+/** The queued messages that currently travel together as the lead group. */
+export function collectLeadQueuedMessageGroupIds(
+  queuedMessages: readonly ThreadQueuedMessage[],
+): string[] {
+  const ids: string[] = [];
+  for (const queuedMessage of queuedMessages) {
+    ids.push(queuedMessage.id);
+    if (!queuedMessage.groupWithNext) break;
+  }
+  return ids;
+}
+
 export function queuedInputToDraft(
   input: readonly PromptInput[],
 ): PromptDraftState {


### PR DESCRIPTION
## Summary

With several messages queued, the user had to send each one separately. The mechanism was already there but not discoverable: `claimQueuedThreadMessageGroup` claims the whole lead group when the head message sends, and only the drag divider set that boundary.

The queued messages header now shows a **Send all** button next to the `Queued N` count. It sets the group boundary to the last compatible message, then sends the head. That single call claims the whole group. It does not loop the per-message send: a thread runs one turn at a time and each send re-claims the queue.

### Mixed queues

`queuedMessageGroupingEnvelopeMatches` refuses a group across a different `model`, `reasoningLevel`, `permissionMode`, `serviceTier`, or `senderThreadId`. The new `collectSendAllQueuedMessageGroupIds` helper collects only the leading run that shares the head's envelope, so the action behaves like this:

- The whole queue is compatible: send it all as one turn.
- Only a prefix is compatible: send that run, then report the remainder in a toast and in the button's hint.
- The head cannot group with the next message: block the action and state the reason.

Note that a later message can match the head and still stay queued, because the run breaks at the first mismatch. The wording says so.

### Blocked states

The action refuses to run, and names the reason, when:

- the leading run is shorter than two messages,
- a queued message has an open inline edit (sending would delete the row and lose the unsaved text),
- `sendDisabled` is set for any other reason.

The button uses `aria-disabled` with a guarded click rather than `disabled`, so it keeps keyboard focus and its `aria-describedby` hint reaches keyboard and touch users, not just mouse hover.

### Failure handling

The boundary write and the send are two requests. If the send fails, the previous boundary is restored, so a failed send cannot silently change what the next turn picks up. If that undo also fails, a warning states that the messages stayed grouped and how many will go together next turn.

### Files

- `apps/app/src/views/thread-detail/threadQueuedMessages.ts` — `collectSendAllQueuedMessageGroupIds`, plus `collectLeadQueuedMessageGroupIds` moved here from `QueuedMessagesList.tsx` so the view and the actions hook share one copy.
- `apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx` — the header button, its blocked reasons, and the accessible hint. It reuses the existing `sendDisabled` prop. The header grip now centers on the header rather than on the drag area, so the wider left cluster cannot pull it off center.
- `apps/app/src/components/thread/embedded-chat/useQueuedMessageActions.ts` — `handleSendAllQueuedMessages` sequences the boundary update, the head send, and the undo-on-failure. `sendQueuedMessageById` now resolves to whether the send succeeded, so the remainder toast never follows a failed send.
- `ThreadDetailPromptArea.tsx` and `EmbeddedThreadChat.tsx` — wire the new action.

No server, database, or wire-protocol change. Both routes already exist.

## Review follow-up

Slop Cop raised four findings. Two are fixed here; two are architectural and are tracked in **#1515**.

| Finding | Outcome |
| --- | --- |
| High — `Send all` can drop a queued item with an unsaved open edit | Fixed. The action refuses to run while an inline editor is open. |
| High — the boundary write and the send are two requests | Partly mitigated here (undo on failure, clear report when the undo fails); the atomic server operation is #1515. |
| Medium — the client copies server grouping rules but cannot see `senderThreadId` | Deferred to #1515. A mixed-sender queue fails loudly with the server's own message rather than silently. |
| Medium — the disabled explanation has no keyboard or touch access, and can give the wrong reason | Fixed. `aria-disabled` plus `aria-describedby`, and the reason now names the real cause. |

Both low-risk notes are also fixed: the partial-send wording and the off-center header grip.

## Testing

- `pnpm exec turbo run typecheck --filter=@bb/app` — passes.
- `pnpm exec turbo run lint --filter=@bb/app` — 0 errors (147 pre-existing warnings, count unchanged).
- `pnpm exec turbo run test --filter=@bb/app --force` — 340 files, 2581 tests pass.

New tests:

- `threadQueuedMessages.test.ts` — the group run stops at the first mismatch of each envelope field, and a later match does not rejoin a broken run.
- `QueuedMessagesList.test.tsx` — the action is absent for one message and clickable for a compatible pair; all three blocked states keep the button focusable, expose the correct reason through `aria-describedby`, and swallow the click; the partial-send hint does not claim that every remaining message differs.
- `useQueuedMessageActions.test.tsx` (new file) — the boundary moves to the last compatible message and the head sends exactly once; a mixed queue reports the remainder; a rejected boundary sends nothing; a failed send skips the remainder toast and restores the previous boundary; a failed undo warns; an open inline edit blocks everything.

Fixes #1185
Follow-up: #1515

> AGENT GENERATED: by Claude Opus 5