### PR TITLE
[issue sweep] Tighten the thread timeline's vertical rhythm

### DIFF
--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
@@ -49,11 +49,7 @@ import {
 import { USER_MESSAGE_CHAR_CAP } from "./conversation-message-limits.js";
 import { turnRequestLabel } from "./conversation-turn-request-label.js";
 import { TurnRequestLabel } from "./TurnRequestLabel.js";
-import {
-  MESSAGE_ACTION_BAR_SLOT_CLASS_NAME,
-  MESSAGE_ACTION_BAR_SLOT_CONTENT_CLASS_NAME,
-  MessageActionBar,
-} from "./MessageActionBar.js";
+import { MessageActionBar } from "./MessageActionBar.js";
 import {
   ConversationMessageOverflowToggle,
   useIsOverflowing,
@@ -495,29 +491,21 @@ function UserConversationMessage({
             projectId={projectId}
           />
         </div>
-        {messageText ||
-        addToChatAttachments.length > 0 ||
-        onEdit !== undefined ||
-        pluginActions.length > 0 ? (
-          <div className={MESSAGE_ACTION_BAR_SLOT_CLASS_NAME}>
-            <div
-              className={cn(
-                MESSAGE_ACTION_BAR_SLOT_CONTENT_CLASS_NAME,
-                "right-0",
-              )}
-            >
-              <MessageActionBar
-                messageText={messageText}
-                alignment="end"
-                mobileActionDisplay={mobileActionDisplay}
-                addToChatAttachments={addToChatAttachments}
-                onAddToChat={onAddToChat}
-                onEdit={onEdit}
-                pluginActions={pluginActions}
-              />
-            </div>
-          </div>
-        ) : null}
+        {/*
+          The bar sits in normal flow: it is hidden by opacity, so it occupies
+          its own height whether or not it is revealed, and it renders nothing
+          at all when the message has no action. `MessageActionBar` is the one
+          place that decides which of those two cases holds.
+        */}
+        <MessageActionBar
+          messageText={messageText}
+          alignment="end"
+          mobileActionDisplay={mobileActionDisplay}
+          addToChatAttachments={addToChatAttachments}
+          onAddToChat={onAddToChat}
+          onEdit={onEdit}
+          pluginActions={pluginActions}
+        />
       </div>
     </div>
   );
@@ -665,23 +653,17 @@ function AssistantConversationMessage({
           `disabled` greys both fork and side chat together when the thread is at
           the spawn-depth cap (both spawn a child thread, one guard).
         */
-        <div className={MESSAGE_ACTION_BAR_SLOT_CLASS_NAME}>
-          <div
-            className={cn(MESSAGE_ACTION_BAR_SLOT_CONTENT_CLASS_NAME, "left-0")}
-          >
-            <MessageActionBar
-              messageText={text}
-              alignment="start"
-              mobileActionDisplay={mobileActionDisplay}
-              addToChatAttachments={addToChatAttachments}
-              onAddToChat={onAddToChat}
-              onFork={onFork}
-              onSendToMain={onSendToMain}
-              disabled={forkDisabled}
-              pluginActions={pluginActions}
-            />
-          </div>
-        </div>
+        <MessageActionBar
+          messageText={text}
+          alignment="start"
+          mobileActionDisplay={mobileActionDisplay}
+          addToChatAttachments={addToChatAttachments}
+          onAddToChat={onAddToChat}
+          onFork={onFork}
+          onSendToMain={onSendToMain}
+          disabled={forkDisabled}
+          pluginActions={pluginActions}
+        />
       ) : null}
     </div>
   );

--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
@@ -49,7 +49,11 @@ import {
 import { USER_MESSAGE_CHAR_CAP } from "./conversation-message-limits.js";
 import { turnRequestLabel } from "./conversation-turn-request-label.js";
 import { TurnRequestLabel } from "./TurnRequestLabel.js";
-import { MessageActionBar } from "./MessageActionBar.js";
+import {
+  MESSAGE_ACTION_BAR_SLOT_CLASS_NAME,
+  MESSAGE_ACTION_BAR_SLOT_CONTENT_CLASS_NAME,
+  MessageActionBar,
+} from "./MessageActionBar.js";
 import {
   ConversationMessageOverflowToggle,
   useIsOverflowing,
@@ -495,16 +499,23 @@ function UserConversationMessage({
         addToChatAttachments.length > 0 ||
         onEdit !== undefined ||
         pluginActions.length > 0 ? (
-          <div className="mt-1 flex justify-end">
-            <MessageActionBar
-              messageText={messageText}
-              alignment="end"
-              mobileActionDisplay={mobileActionDisplay}
-              addToChatAttachments={addToChatAttachments}
-              onAddToChat={onAddToChat}
-              onEdit={onEdit}
-              pluginActions={pluginActions}
-            />
+          <div className={MESSAGE_ACTION_BAR_SLOT_CLASS_NAME}>
+            <div
+              className={cn(
+                MESSAGE_ACTION_BAR_SLOT_CONTENT_CLASS_NAME,
+                "right-0",
+              )}
+            >
+              <MessageActionBar
+                messageText={messageText}
+                alignment="end"
+                mobileActionDisplay={mobileActionDisplay}
+                addToChatAttachments={addToChatAttachments}
+                onAddToChat={onAddToChat}
+                onEdit={onEdit}
+                pluginActions={pluginActions}
+              />
+            </div>
           </div>
         ) : null}
       </div>
@@ -654,12 +665,9 @@ function AssistantConversationMessage({
           `disabled` greys both fork and side chat together when the thread is at
           the spawn-depth cap (both spawn a child thread, one guard).
         */
-        <div className="relative h-5 max-md:pointer-coarse:h-7">
+        <div className={MESSAGE_ACTION_BAR_SLOT_CLASS_NAME}>
           <div
-            className={cn(
-              "absolute left-0 top-1",
-              "max-md:pointer-coarse:top-0",
-            )}
+            className={cn(MESSAGE_ACTION_BAR_SLOT_CONTENT_CLASS_NAME, "left-0")}
           >
             <MessageActionBar
               messageText={text}

--- a/apps/app/src/components/thread/timeline/MessageActionBar.tsx
+++ b/apps/app/src/components/thread/timeline/MessageActionBar.tsx
@@ -193,19 +193,6 @@ const MOBILE_OVERFLOW_CONTENT_CLASS =
 const MOBILE_OVERFLOW_ITEM_CLASS =
   "flex min-h-8 w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-left text-xs text-foreground transition-colors hover:bg-surface-recessed focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring active:bg-state-active disabled:pointer-events-none disabled:opacity-40 select-none";
 
-/**
- * Vertical slot a message renders its action bar into. The bar is 20px tall but
- * reserves only 16px of layout, and the 2px offset keeps it clear of the message
- * body. Its last pixels fall in the timeline row gap, which is empty, so a
- * one-line message keeps its density while the bar still neither overlaps the
- * next row's text nor pushes the layout when hover reveals it. Coarse pointers
- * get a taller, always visible bar, so they reserve its full height.
- */
-export const MESSAGE_ACTION_BAR_SLOT_CLASS_NAME =
-  "relative h-4 max-md:pointer-coarse:h-7";
-export const MESSAGE_ACTION_BAR_SLOT_CONTENT_CLASS_NAME =
-  "absolute top-0.5 max-md:pointer-coarse:top-0";
-
 export function findMessageActionTooltipCollisionBoundary(
   node: HTMLElement | null,
 ): HTMLElement | undefined {

--- a/apps/app/src/components/thread/timeline/MessageActionBar.tsx
+++ b/apps/app/src/components/thread/timeline/MessageActionBar.tsx
@@ -193,6 +193,19 @@ const MOBILE_OVERFLOW_CONTENT_CLASS =
 const MOBILE_OVERFLOW_ITEM_CLASS =
   "flex min-h-8 w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-left text-xs text-foreground transition-colors hover:bg-surface-recessed focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring active:bg-state-active disabled:pointer-events-none disabled:opacity-40 select-none";
 
+/**
+ * Vertical slot a message renders its action bar into. The bar is 20px tall but
+ * reserves only 16px of layout, and the 2px offset keeps it clear of the message
+ * body. Its last pixels fall in the timeline row gap, which is empty, so a
+ * one-line message keeps its density while the bar still neither overlaps the
+ * next row's text nor pushes the layout when hover reveals it. Coarse pointers
+ * get a taller, always visible bar, so they reserve its full height.
+ */
+export const MESSAGE_ACTION_BAR_SLOT_CLASS_NAME =
+  "relative h-4 max-md:pointer-coarse:h-7";
+export const MESSAGE_ACTION_BAR_SLOT_CONTENT_CLASS_NAME =
+  "absolute top-0.5 max-md:pointer-coarse:top-0";
+
 export function findMessageActionTooltipCollisionBoundary(
   node: HTMLElement | null,
 ): HTMLElement | undefined {

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -719,14 +719,19 @@ function TimelineStaticRow({
   );
 }
 
+/**
+ * Vertical rhythm between timeline rows. Most rows are a single 20px line (a
+ * command, a file edit, a bundle summary), so the gap is the dominant cost of
+ * the thread view: the list stays readable at 8px and reads as dense work
+ * rather than as isolated cards. Bundle children run flush inside their group.
+ */
 function timelineRowsListGapClassName(
   spacing: TimelineRowsListSpacing,
 ): string {
   switch (spacing) {
     case "top-level":
-      return "gap-4";
     case "nested":
-      return "gap-3";
+      return "gap-2";
     case "bundle":
       return "gap-0";
   }


### PR DESCRIPTION
## Summary

The thread view spent more vertical space on gaps than on content. I measured
the running app before changing anything (dev app, a seeded thread plus a real
agent run) and found two causes, not one:

| Cause | Cost |
| --- | --- |
| `gap-4` between every top-level row, even between two 20px single-line rows | 16px per row boundary |
| Each message added a wrapper around its action bar: a 20px spacer for the agent message, `mt-1` plus the bar for the user message | 4px per message, plus a clipped bar (see below) |

The reporter blamed the hover buttons. That is half correct. The buttons do cost
space, but the uniform 16px row gap costs more, because most timeline rows are
one 20px line: a command, a file edit, or a bundle summary.

The change:

- Row gap 16px → 8px (top-level and nested; bundle children stay flush).
- Both messages now render the bar directly, with no wrapper. The bar is hidden
  by opacity, so in normal flow it already occupies its own height whether or
  not hover reveals it, and it contributes nothing when it has no action to
  show. It therefore cannot push the layout, cannot overlap the next row, and
  cannot be clipped.

No colors, no fonts, no typography tokens, and no component structure changed —
only spacing. The diff removes more markup than it adds.

## Before / after

Same thread, same viewport, same scroll position. The timeline block is 16%
shorter (809px → 681px) with no content removed.

| Before | After |
| --- | --- |
| <img width="390" src="https://raw.githubusercontent.com/get-bb/bb/screenshots/issue-1130/before-mixed.png" /> | <img width="390" src="https://raw.githubusercontent.com/get-bb/bb/screenshots/issue-1130/after-mixed.png" /> |

A real agent thread with an expanded turn body, which matches the layout in the
issue's screenshot (379px → 347px):

| Before | After |
| --- | --- |
| <img width="390" src="https://raw.githubusercontent.com/get-bb/bb/screenshots/issue-1130/before-agent.png" /> | <img width="390" src="https://raw.githubusercontent.com/get-bb/bb/screenshots/issue-1130/after-agent.png" /> |

The bar stays usable and keeps 8px of clearance from the next row. These shots
reveal it through keyboard focus, which uses the same reveal rule as hover:

| Agent message | User message |
| --- | --- |
| <img width="390" src="https://raw.githubusercontent.com/get-bb/bb/screenshots/issue-1130/focus-assistant.png" /> | <img width="390" src="https://raw.githubusercontent.com/get-bb/bb/screenshots/issue-1130/focus-user.png" /> |

The last message in a thread, where `AutoHeightContainer` clips at its measured
height. The complete bar stays inside the box (`main` clips 4px off it today):

<img width="390" src="https://raw.githubusercontent.com/get-bb/bb/screenshots/issue-1130/focus-last-row.png" />

Compact viewport with a coarse pointer, where the bar is larger and always
visible. The bar sizes its own row, so it needs no separate rule:

<img width="260" src="https://raw.githubusercontent.com/get-bb/bb/screenshots/issue-1130/coarse-mobile.png" />

The screenshots live on the throwaway branch `screenshots/issue-1130` so they
stay out of this diff. Delete that branch after the merge.

## Testing

- `pnpm exec turbo run typecheck --filter=@bb/app` — pass.
- `pnpm exec turbo run test --filter=@bb/app --force` — 339 files, 2572 tests, all pass.
- Manual measurement in the dev app (`scripts/bb-dev-app current`), through the
  DOM, on a seeded thread and on a real Claude Code thread:
  - Row gap: 16px → 8px.
  - User message block: 67px → 63.1px for one line of text.
  - Bar to next row: 8px of clearance on a fine pointer, and 8px on an emulated
    coarse pointer at a 420px viewport, where the bar is 28px instead of 20px.
  - Last row: the bar now ends 0px past the clip boundary, against 6px for the
    reserved-slot attempt and 4px on `main`.
  - The user bar's right edge still aligns with the bubble's right edge.

I added no test. The change is a class string and two removed wrappers, and the
invariant that matters (the bar neither overlaps nor is clipped) is a layout
fact that jsdom cannot measure; a test over class names would only restate the
source. AGENTS.md asks for tests only where a real bug can return.

Fixes #1130

> AGENT GENERATED: by Claude Opus 5
