### PR TITLE
Add a keyboard shortcut for archiving the focused thread

### DIFF
--- a/apps/app/src/lib/app-command-metadata.ts
+++ b/apps/app/src/lib/app-command-metadata.ts
@@ -48,6 +48,11 @@ export const APP_COMMAND_GROUPS: readonly AppCommandGroup[] = [
         "Next thread",
         "Open the next visible sidebar thread.",
       ),
+      command(
+        "thread.archive",
+        "Archive thread",
+        "Archive the thread you are viewing and its child threads.",
+      ),
       ...THREAD_JUMP_APP_COMMAND_IDS.map((id, index) =>
         command(
           id,

--- a/apps/app/src/views/thread-detail/SplitThreadArea.stories.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.stories.tsx
@@ -16,6 +16,7 @@ import {
 import { maximizedPaneIdAtom, splitLayoutAtom } from "@/lib/split-layout/atoms";
 import type { SplitLayout } from "@/lib/split-layout";
 import { SidebarProvider } from "@/components/ui/sidebar";
+import { ThreadActionsProvider } from "@/components/thread/ThreadActionsProvider";
 import { AppPageHeader } from "@/components/layout/AppPageHeader";
 import { TooltipProvider } from "@bb/shared-ui/tooltip";
 import { PaneContext, type PaneContextValue } from "./PaneContext";
@@ -202,15 +203,19 @@ function SplitWorkspaceStory({ maximized = false }: { maximized?: boolean }) {
     <QueryClientProvider client={queryClient}>
       <JotaiProvider store={store}>
         <SidebarProvider>
-          <div className="flex h-screen min-h-[640px] w-full flex-col bg-background p-4 md:p-5">
-            <SplitThreadArea
-              routeContent={{
-                kind: "thread",
-                projectId: PROJECT_ID,
-                threadId: ACTIVE_THREAD_ID,
-              }}
-            />
-          </div>
+          {/* The panes render the real ThreadDetailView, which reads the thread
+              actions (archive, rename, …) its header and shortcuts invoke. */}
+          <ThreadActionsProvider>
+            <div className="flex h-screen min-h-[640px] w-full flex-col bg-background p-4 md:p-5">
+              <SplitThreadArea
+                routeContent={{
+                  kind: "thread",
+                  projectId: PROJECT_ID,
+                  threadId: ACTIVE_THREAD_ID,
+                }}
+              />
+            </div>
+          </ThreadActionsProvider>
         </SidebarProvider>
       </JotaiProvider>
     </QueryClientProvider>

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -65,6 +65,7 @@ import {
   ThreadActionsMenu,
   type ThreadActionsMenuResponsiveAction,
 } from "@/components/thread/ThreadActionsMenu";
+import { useThreadActions } from "@/components/thread/ThreadActionsProvider";
 import { PluginThreadHeaderActions } from "@/components/plugin/PluginThreadHeaderActions";
 import { ThreadWorkspaceOpenButton } from "@/components/thread/ThreadWorkspaceOpenButton";
 import {
@@ -458,6 +459,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
   const { isFocused, navigateInPane, onRequestClose, isBoundedPane } =
     usePaneContext();
   const navigate = useNavigate();
+  const { archiveThreadAndChildren } = useThreadActions();
   useFixedPanelTabsStorageMaintenance(threadId);
   const systemConfigQuery = useSystemConfig();
   const fixedPanelTabsState = useFixedPanelTabsState(threadId, threadId);
@@ -1295,6 +1297,15 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
     handleCloseTerminalTab,
     isSecondaryPanelOpen,
   ]);
+  useAppCommandHandler("thread.archive", () => {
+    // Archived threads stay viewable; the shortcut is archive-only, so let the
+    // event through instead of silently toggling them back to active.
+    if (!isFocused || thread === undefined || thread.archivedAt !== null) {
+      return false;
+    }
+    archiveThreadAndChildren(thread);
+    return true;
+  });
   useAppCommandHandler("panel.toggle", () => {
     if (!isFocused) return false;
     toggleSecondaryPanel();

--- a/apps/server/src/services/system/app-keybindings.ts
+++ b/apps/server/src/services/system/app-keybindings.ts
@@ -120,6 +120,16 @@ export const DEFAULT_APP_KEYBINDINGS: AppKeybindings = [
     ...mainWithoutModal,
     desktopOnly: true,
   }),
+  // Archive the focused thread. Every Mod+Shift+<letter> chord that reads as
+  // "archive" is either taken by bb or reserved by browsers (Mod+Shift+A opens
+  // tab search in Chrome), so this uses Alt like the model-cycling chords: it
+  // is free in bb, the browser, and both desktop menus, and needs no web alias.
+  // macOS composes Option+A into "å", so it matches on the physical key — see
+  // `normalizeAppShortcutInputKey` in @bb/domain.
+  binding("thread.archive", "a", { alt: true }, {
+    ...mainWithoutModal,
+    none: ["modalOpen", "terminalFocus", "browserFocus"],
+  }),
   // Browsers reserve Mod+1…9 for native tab switching. Match Slack's web
   // navigation convention: Control+N on macOS and Ctrl+Shift+N elsewhere,
   // while keeping the shorter Mod chord on desktop.
@@ -180,8 +190,9 @@ export const DEFAULT_APP_KEYBINDINGS: AppKeybindings = [
     none: [],
   }),
   // Rotate the composer's model and reasoning level without opening the picker,
-  // scoped exactly like `modelPicker.toggle` above. Alt is otherwise unused by
-  // bb, the browser, and both desktop menus, so these chords shadow nothing.
+  // scoped exactly like `modelPicker.toggle` above. Alt chords are unclaimed by
+  // the browser and both desktop menus, and bb keeps each one distinct (see
+  // `thread.archive`), so these chords shadow nothing.
   // macOS composes Option+<letter> into another character, so they match on the
   // physical key — see `normalizeAppShortcutInputKey` in @bb/domain.
   binding("modelPicker.cycleModel", "m", { alt: true }, {

--- a/apps/server/test/system/app-keybindings.test.ts
+++ b/apps/server/test/system/app-keybindings.test.ts
@@ -120,6 +120,31 @@ describe("app keybindings", () => {
         { desktopOnly: false, key: "Enter" },
         { desktopOnly: true, key: "t" },
       ]);
+      // Archive is a single Alt chord on every client: the Mod+Shift letters
+      // that read as "archive" are taken by bb or reserved by browsers, so
+      // there is no web/desktop split to keep in sync here.
+      expect(
+        config.defaultKeybindings.filter(
+          (binding) => binding.command === "thread.archive",
+        ),
+      ).toEqual([
+        {
+          command: "thread.archive",
+          desktopOnly: false,
+          shortcut: {
+            key: "a",
+            mod: false,
+            meta: false,
+            control: false,
+            alt: true,
+            shift: false,
+          },
+          when: {
+            all: ["mainSurface"],
+            none: ["modalOpen", "terminalFocus", "browserFocus"],
+          },
+        },
+      ]);
       expect(
         config.defaultKeybindings.find(
           (binding) => binding.command === "composer.focus",

--- a/apps/server/test/system/app-keybindings.test.ts
+++ b/apps/server/test/system/app-keybindings.test.ts
@@ -226,17 +226,19 @@ describe("app keybindings", () => {
           when: { all: ["mainSurface", "modelPickerOpen"], none: [] },
         },
       ]);
-      // No other default binding may use Alt, so the cycle chords cannot be
-      // shadowed by an earlier binding for the same chord.
+      // Alt bindings are enumerated with their keys: bb gives each Alt chord a
+      // distinct key so no Alt command can be shadowed by an earlier binding
+      // for the same chord.
       expect(
         config.defaultKeybindings
           .filter((binding) => binding.shortcut.alt)
-          .map((binding) => binding.command),
+          .map((binding) => `${binding.command}:${binding.shortcut.key}`),
       ).toEqual([
-        "modelPicker.cycleModel",
-        "modelPicker.cycleReasoning",
-        "modelPicker.cycleModel",
-        "modelPicker.cycleReasoning",
+        "thread.archive:a",
+        "modelPicker.cycleModel:m",
+        "modelPicker.cycleReasoning:t",
+        "modelPicker.cycleModel:m",
+        "modelPicker.cycleReasoning:t",
       ]);
       expect(
         config.defaultKeybindings

--- a/packages/domain/src/app-keybindings.ts
+++ b/packages/domain/src/app-keybindings.ts
@@ -40,6 +40,7 @@ export const APP_COMMAND_IDS = [
   "thread.search",
   "thread.previous",
   "thread.next",
+  "thread.archive",
   ...THREAD_JUMP_APP_COMMAND_IDS,
   "pane.focus.previous",
   "pane.focus.next",

--- a/packages/plugin-sdk/bundled-types/bb-plugin-sdk.d.ts
+++ b/packages/plugin-sdk/bundled-types/bb-plugin-sdk.d.ts
@@ -62,6 +62,7 @@ declare const appKeybindingOverridesSchema: z$1.ZodArray<z$1.ZodObject<{
         "thread.search": "thread.search";
         "thread.previous": "thread.previous";
         "thread.next": "thread.next";
+        "thread.archive": "thread.archive";
         "pane.focus.previous": "pane.focus.previous";
         "pane.focus.next": "pane.focus.next";
         "pane.maximize.toggle": "pane.maximize.toggle";
@@ -2068,8 +2069,8 @@ type ThreadEventRow = {
 declare const threadStatusSchema: z$1.ZodEnum<{
     error: "error";
     active: "active";
-    idle: "idle";
     starting: "starting";
+    idle: "idle";
     stopping: "stopping";
 }>;
 type ThreadStatus = z$1.infer<typeof threadStatusSchema>;
@@ -2397,9 +2398,9 @@ declare const projectBranchesResponseSchema: z$1.ZodObject<{
     selectedBranch: z$1.ZodNullable<z$1.ZodObject<{
         name: z$1.ZodString;
         kind: z$1.ZodEnum<{
-            missing: "missing";
             local: "local";
             remote: "remote";
+            missing: "missing";
         }>;
     }, z$1.core.$strip>>;
     defaultWorktreeBaseBranch: z$1.ZodNullable<z$1.ZodString>;
@@ -2536,8 +2537,8 @@ declare const skillListResponseSchema: z$1.ZodObject<{
         name: z$1.ZodString;
         description: z$1.ZodNullable<z$1.ZodString>;
         provider: z$1.ZodNullable<z$1.ZodEnum<{
-            codex: "codex";
             "claude-code": "claude-code";
+            codex: "codex";
         }>>;
         scope: z$1.ZodEnum<{
             plugin: "plugin";
@@ -2809,9 +2810,9 @@ declare const environmentDiffBranchesResponseSchema: z$1.ZodObject<{
     selectedBranch: z$1.ZodNullable<z$1.ZodObject<{
         name: z$1.ZodString;
         kind: z$1.ZodEnum<{
-            missing: "missing";
             local: "local";
             remote: "remote";
+            missing: "missing";
         }>;
     }, z$1.core.$strip>>;
 }, z$1.core.$strip>;
@@ -2882,8 +2883,8 @@ declare const environmentDiffFileResponseSchema: z$1.ZodObject<{
     path: z$1.ZodString;
     content: z$1.ZodString;
     contentEncoding: z$1.ZodEnum<{
-        utf8: "utf8";
         base64: "base64";
+        utf8: "utf8";
     }>;
     mimeType: z$1.ZodOptional<z$1.ZodString>;
     sizeBytes: z$1.ZodNumber;
@@ -2896,8 +2897,8 @@ declare const environmentArchiveThreadsResponseSchema: z$1.ZodObject<{
 type EnvironmentArchiveThreadsResponse = z$1.infer<typeof environmentArchiveThreadsResponseSchema>;
 declare const pullRequestMergeMethodSchema: z$1.ZodEnum<{
     merge: "merge";
-    rebase: "rebase";
     squash: "squash";
+    rebase: "rebase";
 }>;
 type PullRequestMergeMethod = z$1.infer<typeof pullRequestMergeMethodSchema>;
 declare const commitActionResponseSchema: z$1.ZodObject<{
@@ -2928,8 +2929,8 @@ declare const pullRequestMergeActionResponseSchema: z$1.ZodObject<{
     action: z$1.ZodLiteral<"pull_request_merge">;
     method: z$1.ZodEnum<{
         merge: "merge";
-        rebase: "rebase";
         squash: "squash";
+        rebase: "rebase";
     }>;
     message: z$1.ZodString;
 }, z$1.core.$strip>;
@@ -3556,8 +3557,8 @@ declare const hostDaemonCommandRegistry: {
         }, z$1.core.$strict>], "kind">>;
         disallowedTools: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
         instructionMode: z$1.ZodEnum<{
-            replace: "replace";
             append: "append";
+            replace: "replace";
         }>;
         type: z$1.ZodLiteral<"thread.start">;
         requestId: z$1.ZodString;
@@ -4045,8 +4046,8 @@ declare const hostDaemonCommandRegistry: {
                 }>;
             }, z$1.core.$strip>;
             instructionMode: z$1.ZodEnum<{
-                replace: "replace";
                 append: "append";
+                replace: "replace";
             }>;
             projectId: z$1.ZodString;
             providerId: z$1.ZodString;
@@ -4341,8 +4342,8 @@ declare const hostDaemonCommandRegistry: {
                 }>;
             }, z$1.core.$strip>;
             instructionMode: z$1.ZodEnum<{
-                replace: "replace";
                 append: "append";
+                replace: "replace";
             }>;
             projectId: z$1.ZodString;
             providerId: z$1.ZodString;
@@ -5346,9 +5347,9 @@ declare const hostDaemonCommandRegistry: {
         executablePath: z$1.ZodNullable<z$1.ZodString>;
         installed: z$1.ZodBoolean;
         installSource: z$1.ZodEnum<{
+            external: "external";
             notInstalled: "notInstalled";
             npmGlobal: "npmGlobal";
-            external: "external";
         }>;
         currentVersion: z$1.ZodNullable<z$1.ZodString>;
         latestVersion: z$1.ZodNullable<z$1.ZodString>;
@@ -5521,13 +5522,13 @@ declare const hostDaemonCommandRegistry: {
         outcome: z$1.ZodLiteral<"unavailable">;
         failure: z$1.ZodObject<{
             code: z$1.ZodEnum<{
-                unknown: "unknown";
                 path_not_found: "path_not_found";
                 not_git_repo: "not_git_repo";
                 not_worktree: "not_worktree";
                 workspace_type_mismatch: "workspace_type_mismatch";
                 permission_denied: "permission_denied";
                 unknown_environment: "unknown_environment";
+                unknown: "unknown";
             }>;
             workspacePath: z$1.ZodString;
             message: z$1.ZodString;
@@ -5571,13 +5572,13 @@ declare const hostDaemonCommandRegistry: {
         outcome: z$1.ZodLiteral<"unavailable">;
         failure: z$1.ZodObject<{
             code: z$1.ZodEnum<{
-                unknown: "unknown";
                 path_not_found: "path_not_found";
                 not_git_repo: "not_git_repo";
                 not_worktree: "not_worktree";
                 workspace_type_mismatch: "workspace_type_mismatch";
                 permission_denied: "permission_denied";
                 unknown_environment: "unknown_environment";
+                unknown: "unknown";
             }>;
             workspacePath: z$1.ZodString;
             message: z$1.ZodString;
@@ -5633,13 +5634,13 @@ declare const hostDaemonCommandRegistry: {
         outcome: z$1.ZodLiteral<"unavailable">;
         failure: z$1.ZodObject<{
             code: z$1.ZodEnum<{
-                unknown: "unknown";
                 path_not_found: "path_not_found";
                 not_git_repo: "not_git_repo";
                 not_worktree: "not_worktree";
                 workspace_type_mismatch: "workspace_type_mismatch";
                 permission_denied: "permission_denied";
                 unknown_environment: "unknown_environment";
+                unknown: "unknown";
             }>;
             workspacePath: z$1.ZodString;
             message: z$1.ZodString;
@@ -5681,13 +5682,13 @@ declare const hostDaemonCommandRegistry: {
         outcome: z$1.ZodLiteral<"unavailable">;
         failure: z$1.ZodObject<{
             code: z$1.ZodEnum<{
-                unknown: "unknown";
                 path_not_found: "path_not_found";
                 not_git_repo: "not_git_repo";
                 not_worktree: "not_worktree";
                 workspace_type_mismatch: "workspace_type_mismatch";
                 permission_denied: "permission_denied";
                 unknown_environment: "unknown_environment";
+                unknown: "unknown";
             }>;
             workspacePath: z$1.ZodString;
             message: z$1.ZodString;
@@ -5805,9 +5806,9 @@ declare const providerCliStatusResponseSchema: z$1.ZodRecord<z$1.ZodEnum<{
     executablePath: z$1.ZodNullable<z$1.ZodString>;
     installed: z$1.ZodBoolean;
     installSource: z$1.ZodEnum<{
+        external: "external";
         notInstalled: "notInstalled";
         npmGlobal: "npmGlobal";
-        external: "external";
     }>;
     currentVersion: z$1.ZodNullable<z$1.ZodString>;
     latestVersion: z$1.ZodNullable<z$1.ZodString>;
@@ -5958,11 +5959,11 @@ type HostProviderCliInstallEvent = ProviderCliInstallEvent;
 declare const pluginUpdateCheckEntrySchema: z$1.ZodObject<{
     id: z$1.ZodString;
     outcome: z$1.ZodEnum<{
+        unavailable: "unavailable";
         incompatible: "incompatible";
         current: "current";
         "update-available": "update-available";
         pinned: "pinned";
-        unavailable: "unavailable";
     }>;
     devMode: z$1.ZodOptional<z$1.ZodLiteral<true>>;
     installed: z$1.ZodObject<{
@@ -6029,11 +6030,11 @@ declare const installedPluginSchema: z$1.ZodObject<{
     sourceDisplay: z$1.ZodString;
     updateState: z$1.ZodObject<{
         outcome: z$1.ZodOptional<z$1.ZodEnum<{
+            unavailable: "unavailable";
             incompatible: "incompatible";
             current: "current";
             "update-available": "update-available";
             pinned: "pinned";
-            unavailable: "unavailable";
         }>>;
         availableVersion: z$1.ZodOptional<z$1.ZodString>;
         blockedVersion: z$1.ZodOptional<z$1.ZodString>;
@@ -6053,8 +6054,8 @@ declare const installedPluginSchema: z$1.ZodObject<{
     status: z$1.ZodEnum<{
         error: "error";
         running: "running";
-        incompatible: "incompatible";
         missing: "missing";
+        incompatible: "incompatible";
         disabled: "disabled";
         degraded: "degraded";
         "needs-configuration": "needs-configuration";
@@ -6133,11 +6134,11 @@ declare const pluginListResponseSchema: z$1.ZodObject<{
         sourceDisplay: z$1.ZodString;
         updateState: z$1.ZodObject<{
             outcome: z$1.ZodOptional<z$1.ZodEnum<{
+                unavailable: "unavailable";
                 incompatible: "incompatible";
                 current: "current";
                 "update-available": "update-available";
                 pinned: "pinned";
-                unavailable: "unavailable";
             }>>;
             availableVersion: z$1.ZodOptional<z$1.ZodString>;
             blockedVersion: z$1.ZodOptional<z$1.ZodString>;
@@ -6157,8 +6158,8 @@ declare const pluginListResponseSchema: z$1.ZodObject<{
         status: z$1.ZodEnum<{
             error: "error";
             running: "running";
-            incompatible: "incompatible";
             missing: "missing";
+            incompatible: "incompatible";
             disabled: "disabled";
             degraded: "degraded";
             "needs-configuration": "needs-configuration";
@@ -6239,11 +6240,11 @@ declare const pluginReloadResponseSchema: z$1.ZodObject<{
         sourceDisplay: z$1.ZodString;
         updateState: z$1.ZodObject<{
             outcome: z$1.ZodOptional<z$1.ZodEnum<{
+                unavailable: "unavailable";
                 incompatible: "incompatible";
                 current: "current";
                 "update-available": "update-available";
                 pinned: "pinned";
-                unavailable: "unavailable";
             }>>;
             availableVersion: z$1.ZodOptional<z$1.ZodString>;
             blockedVersion: z$1.ZodOptional<z$1.ZodString>;
@@ -6263,8 +6264,8 @@ declare const pluginReloadResponseSchema: z$1.ZodObject<{
         status: z$1.ZodEnum<{
             error: "error";
             running: "running";
-            incompatible: "incompatible";
             missing: "missing";
+            incompatible: "incompatible";
             disabled: "disabled";
             degraded: "degraded";
             "needs-configuration": "needs-configuration";
@@ -6611,6 +6612,7 @@ declare const systemConfigResponseSchema: z$1.ZodObject<{
             "thread.search": "thread.search";
             "thread.previous": "thread.previous";
             "thread.next": "thread.next";
+            "thread.archive": "thread.archive";
             "thread.jump.1": "thread.jump.1";
             "thread.jump.2": "thread.jump.2";
             "thread.jump.3": "thread.jump.3";
@@ -6703,6 +6705,7 @@ declare const systemConfigResponseSchema: z$1.ZodObject<{
             "thread.search": "thread.search";
             "thread.previous": "thread.previous";
             "thread.next": "thread.next";
+            "thread.archive": "thread.archive";
             "thread.jump.1": "thread.jump.1";
             "thread.jump.2": "thread.jump.2";
             "thread.jump.3": "thread.jump.3";
@@ -6795,6 +6798,7 @@ declare const systemConfigResponseSchema: z$1.ZodObject<{
             "thread.search": "thread.search";
             "thread.previous": "thread.previous";
             "thread.next": "thread.next";
+            "thread.archive": "thread.archive";
             "thread.jump.1": "thread.jump.1";
             "thread.jump.2": "thread.jump.2";
             "thread.jump.3": "thread.jump.3";
@@ -6948,8 +6952,8 @@ declare const systemCliSkillsStatusResponseSchema: z$1.ZodObject<{
         hostName: z$1.ZodString;
         status: z$1.ZodEnum<{
             unknown: "unknown";
-            installed: "installed";
             missing: "missing";
+            installed: "installed";
             outdated: "outdated";
         }>;
     }, z$1.core.$strip>>;
@@ -6994,9 +6998,9 @@ declare const terminalSessionSchema: z$1.ZodObject<{
     cols: z$1.ZodNumber;
     rows: z$1.ZodNumber;
     status: z$1.ZodEnum<{
-        running: "running";
         starting: "starting";
         disconnected: "disconnected";
+        running: "running";
         exited: "exited";
     }>;
     exitCode: z$1.ZodNullable<z$1.ZodNumber>;
@@ -7025,9 +7029,9 @@ declare const terminalListResponseSchema: z$1.ZodObject<{
         cols: z$1.ZodNumber;
         rows: z$1.ZodNumber;
         status: z$1.ZodEnum<{
-            running: "running";
             starting: "starting";
             disconnected: "disconnected";
+            running: "running";
             exited: "exited";
         }>;
         exitCode: z$1.ZodNullable<z$1.ZodNumber>;
@@ -9534,8 +9538,8 @@ declare const threadTimelineResponseSchema: z$1.ZodObject<{
     activePromptMode: z$1.ZodNullable<z$1.ZodObject<{
         mode: z$1.ZodLiteral<"plan">;
         providerId: z$1.ZodEnum<{
-            codex: "codex";
             "claude-code": "claude-code";
+            codex: "codex";
         }>;
         prompt: z$1.ZodString;
     }, z$1.core.$strict>>;
@@ -9711,8 +9715,8 @@ declare const threadTimelineResponseSchema: z$1.ZodObject<{
         updatedAt: z$1.ZodNumber;
         objective: z$1.ZodString;
         status: z$1.ZodEnum<{
-            paused: "paused";
             active: "active";
+            paused: "paused";
             budgetLimited: "budgetLimited";
             complete: "complete";
         }>;


### PR DESCRIPTION
## What

Adds a `thread.archive` app command bound to **Alt+A** by default. It archives the thread you are currently viewing (and its children) via the existing `useThreadActions().archiveThreadAndChildren`, so it reuses the pane-close, URL reconciliation, and undo-toast behavior of the menu item.

- `packages/domain` — new `thread.archive` command id.
- `apps/server/.../app-keybindings.ts` — default binding, scoped to `mainSurface` and suppressed while a modal, terminal, or embedded browser has focus. It intentionally still fires while the composer is focused, matching the existing Alt chords.
- `apps/app/.../ThreadDetailView.tsx` — handler gated on `isFocused`, so in a split it archives the focused pane's thread. Returns `false` for an already-archived thread (archive-only; it will not silently un-archive) and when unfocused, letting the key event fall through.
- `apps/app/src/lib/app-command-metadata.ts` — "Archive thread" entry so it is listed and rebindable in Settings → Keyboard.
- `packages/plugin-sdk/bundled-types/bb-plugin-sdk.d.ts` — regenerated, since it embeds the `AppCommandId` union. The diff also contains incidental zod enum key reordering produced by the current generator.

## Why Alt+A

Every `Mod+Shift+<letter>` chord that reads as "archive" is either already claimed by bb or reserved by the browser — Chrome binds `Mod+Shift+A` to tab search. Alt is the family this codebase already uses for its own actions (`modelPicker.cycleModel`/`cycleReasoning`), it is unclaimed by the browser and both desktop menus, and it needs no separate web/desktop alias. macOS composes Option+A into "å", which `normalizeAppShortcutInputKey` already handles by falling back to the physical key.

## Tests

- `apps/server/test/system/app-keybindings.test.ts` asserts the default chord and its scope. The existing "no other binding uses Alt" assertion now enumerates each Alt binding with its key, which is the invariant that actually matters: distinct keys mean no Alt command can be shadowed by an earlier binding for the same chord.
- `SplitThreadArea.stories.tsx` renders the real `ThreadDetailView`, which now reads the thread actions, so the story is wrapped in `ThreadActionsProvider`.

Typecheck passes for `@bb/domain`, `@bb/plugin-sdk` (including `build-bundled-dts.mjs --check`), `@bb/server`, and `@bb/app`. `@bb/app` tests: 321 files / 2414 tests pass. `@bb/server` tests pass except three plugin install/update files that fail in this sandbox on `npm error code EALLOWSCRIPTS`, unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
