### PR TITLE
[issue sweep] Recover in-panel browser after renderer exit

### DIFF
--- a/apps/desktop/src/desktop-browser-view.ts
+++ b/apps/desktop/src/desktop-browser-view.ts
@@ -43,6 +43,8 @@ const POPUP_RATE_MAX_IN_WINDOW = 3;
 const RESIZE_SNAPSHOT_HIDE_CAP_MS = 80;
 /** Placeholder quality: transient, stretched during the drag — favor size. */
 const RESIZE_SNAPSHOT_JPEG_QUALITY = 70;
+const RENDERER_RECOVERY_DELAY_MS = 250;
+const RENDERER_RECOVERY_MAX_ATTEMPTS = 2;
 
 function truncate(value: string, max: number): string {
   return value.length > max ? value.slice(0, max) : value;
@@ -74,6 +76,9 @@ interface BrowserViewEntry {
    */
   desiredBounds: BbDesktopBrowserViewBounds;
   popupTimestamps: number[];
+  rendererRecoveryAttempts: number;
+  rendererRecoveryState: "healthy" | "pending" | "blocked";
+  rendererRecoveryTimer: ReturnType<typeof setTimeout> | null;
   visible: boolean;
 }
 
@@ -336,7 +341,60 @@ export function createDesktopBrowserViewManager(
     if (entry.view.webContents.isDestroyed()) {
       return;
     }
-    entry.view.setVisible(entry.visible && !isHostResizing(hostWindow));
+    entry.view.setVisible(
+      entry.visible &&
+        entry.rendererRecoveryState === "healthy" &&
+        !isHostResizing(hostWindow),
+    );
+  }
+
+  function clearEntryRendererRecoveryTimer(entry: BrowserViewEntry): void {
+    if (entry.rendererRecoveryTimer !== null) {
+      clearTimeout(entry.rendererRecoveryTimer);
+      entry.rendererRecoveryTimer = null;
+    }
+  }
+
+  function resetEntryRendererRecovery(entry: BrowserViewEntry): void {
+    clearEntryRendererRecoveryTimer(entry);
+    entry.rendererRecoveryAttempts = 0;
+    entry.rendererRecoveryState = "healthy";
+  }
+
+  function scheduleEntryRendererRecovery(
+    entry: BrowserViewEntry,
+    hostWindow: DesktopBrowserHostWindow,
+    tabId: string,
+  ): void {
+    if (
+      entry.rendererRecoveryState !== "pending" ||
+      !entry.visible ||
+      entry.rendererRecoveryTimer !== null
+    ) {
+      return;
+    }
+    if (entry.rendererRecoveryAttempts >= RENDERER_RECOVERY_MAX_ATTEMPTS) {
+      entry.rendererRecoveryState = "blocked";
+      entry.lastErrorText = "The page renderer stopped repeatedly";
+      pushState(hostWindow, tabId);
+      return;
+    }
+    entry.rendererRecoveryTimer = setTimeout(() => {
+      entry.rendererRecoveryTimer = null;
+      const webContents = entry.view.webContents;
+      if (
+        webContents.isDestroyed() ||
+        entry.rendererRecoveryState !== "pending" ||
+        !entry.visible
+      ) {
+        return;
+      }
+      entry.rendererRecoveryAttempts += 1;
+      entry.rendererRecoveryState = "healthy";
+      entry.lastErrorText = null;
+      webContents.reload();
+      applyEntryVisibility(entry, hostWindow);
+    }, RENDERER_RECOVERY_DELAY_MS);
   }
 
   /**
@@ -558,18 +616,36 @@ export function createDesktopBrowserViewManager(
       menu.popup();
     });
 
-    webContents.on("render-process-gone", () => {
+    webContents.on("render-process-gone", (_event, details) => {
       if (webContents.isDestroyed() || webContents.getURL().length === 0) {
         return;
       }
+      clearEntryRendererRecoveryTimer(entry);
+      entry.rendererRecoveryState = "blocked";
+      if (
+        details.reason === "launch-failed" ||
+        details.reason === "integrity-failure"
+      ) {
+        entry.lastErrorText = "The page renderer could not start";
+        applyEntryVisibility(entry, hostWindow);
+        pushState(hostWindow, tabId);
+        return;
+      }
+      entry.rendererRecoveryState = "pending";
       entry.lastErrorText = null;
-      // The native view and its current navigation entry survive renderer
-      // eviction or failure. Reload that entry in a new renderer so a hidden
-      // or idle page recovers without recreating the tab from its original URL.
-      webContents.reload();
+      applyEntryVisibility(entry, hostWindow);
+      // Hidden views wait until the panel opens. This keeps memory eviction
+      // effective. Visible views retry after a short delay and stop after the
+      // bounded attempt count, so a crash loop cannot restart indefinitely.
+      scheduleEntryRendererRecovery(entry, hostWindow, tabId);
     });
 
     const refresh = () => pushState(hostWindow, tabId);
+    webContents.on("did-finish-load", () => {
+      resetEntryRendererRecovery(entry);
+      applyEntryVisibility(entry, hostWindow);
+      refresh();
+    });
     webContents.on("did-start-loading", refresh);
     webContents.on("did-stop-loading", refresh);
     webContents.on("did-navigate", (_event, url) => {
@@ -626,6 +702,9 @@ export function createDesktopBrowserViewManager(
       currentMainFrameLocalOriginKey: null,
       desiredBounds: args.desiredBounds,
       popupTimestamps: [],
+      rendererRecoveryAttempts: 0,
+      rendererRecoveryState: "healthy",
+      rendererRecoveryTimer: null,
       visible: false,
     };
     wireWebContents(args.hostWindow, args.tabId, entry);
@@ -661,6 +740,7 @@ export function createDesktopBrowserViewManager(
     }
     entries.delete(key);
     entriesByWebContentsId.delete(entry.view.webContents.id);
+    clearEntryRendererRecoveryTimer(entry);
     clearEntryLocalOriginState(entry);
     if (!hostWindow.isDestroyed()) {
       hostWindow.contentView.removeChildView(entry.view);
@@ -715,12 +795,16 @@ export function createDesktopBrowserViewManager(
     },
     navigate({ hostWindow, request }) {
       withEntry({ hostWindow, tabId: request.tabId }, (entry) => {
+        resetEntryRendererRecovery(entry);
+        applyEntryVisibility(entry, hostWindow);
         loadIfNeeded(entry, request.url);
       });
     },
     goBack({ hostWindow, tabId }) {
       withEntry({ hostWindow, tabId }, (entry) => {
         if (entry.view.webContents.navigationHistory.canGoBack()) {
+          resetEntryRendererRecovery(entry);
+          applyEntryVisibility(entry, hostWindow);
           entry.view.webContents.navigationHistory.goBack();
         }
       });
@@ -728,13 +812,17 @@ export function createDesktopBrowserViewManager(
     goForward({ hostWindow, tabId }) {
       withEntry({ hostWindow, tabId }, (entry) => {
         if (entry.view.webContents.navigationHistory.canGoForward()) {
+          resetEntryRendererRecovery(entry);
+          applyEntryVisibility(entry, hostWindow);
           entry.view.webContents.navigationHistory.goForward();
         }
       });
     },
     reload({ hostWindow, tabId }) {
       withEntry({ hostWindow, tabId }, (entry) => {
+        resetEntryRendererRecovery(entry);
         entry.view.webContents.reload();
+        applyEntryVisibility(entry, hostWindow);
       });
     },
     stop({ hostWindow, tabId }) {
@@ -752,6 +840,7 @@ export function createDesktopBrowserViewManager(
         const wasVisible = entry.visible;
         entry.visible = request.visible;
         applyEntryVisibility(entry, hostWindow);
+        scheduleEntryRendererRecovery(entry, hostWindow, request.tabId);
         // Focus the view only on a real not-visible → visible transition so the
         // Edit-menu copy/cut/paste roles and Cmd+C target this view's
         // webContents (the focused one). Skip redundant re-syncs so we never
@@ -809,6 +898,7 @@ export function createDesktopBrowserViewManager(
         }
         entries.delete(key);
         entriesByWebContentsId.delete(entry.view.webContents.id);
+        clearEntryRendererRecoveryTimer(entry);
         clearEntryLocalOriginState(entry);
         if (!entry.view.webContents.isDestroyed()) {
           entry.view.webContents.close();
@@ -820,6 +910,7 @@ export function createDesktopBrowserViewManager(
       for (const [key, entry] of [...entries.entries()]) {
         entries.delete(key);
         entriesByWebContentsId.delete(entry.view.webContents.id);
+        clearEntryRendererRecoveryTimer(entry);
         clearEntryLocalOriginState(entry);
         if (!entry.view.webContents.isDestroyed()) {
           entry.view.webContents.close();

--- a/apps/desktop/src/desktop-browser-view.ts
+++ b/apps/desktop/src/desktop-browser-view.ts
@@ -558,6 +558,17 @@ export function createDesktopBrowserViewManager(
       menu.popup();
     });
 
+    webContents.on("render-process-gone", () => {
+      if (webContents.isDestroyed() || webContents.getURL().length === 0) {
+        return;
+      }
+      entry.lastErrorText = null;
+      // The native view and its current navigation entry survive renderer
+      // eviction or failure. Reload that entry in a new renderer so a hidden
+      // or idle page recovers without recreating the tab from its original URL.
+      webContents.reload();
+    });
+
     const refresh = () => pushState(hostWindow, tabId);
     webContents.on("did-start-loading", refresh);
     webContents.on("did-stop-loading", refresh);

--- a/apps/desktop/test/desktop-browser-view-manager.test.ts
+++ b/apps/desktop/test/desktop-browser-view-manager.test.ts
@@ -1,4 +1,4 @@
-import type { WebContentsView } from "electron";
+import type { RenderProcessGoneDetails, WebContentsView } from "electron";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { BbDesktopBrowserViewBounds } from "@bb/desktop-contract";
 import {
@@ -104,10 +104,10 @@ type FakeBeforeInputListener = (
   input: FakeInput,
 ) => void;
 
-interface FakeRenderProcessGoneDetails {
-  exitCode: number;
-  reason: "memory-eviction";
-}
+type FakeRenderProcessGoneDetails = Pick<
+  RenderProcessGoneDetails,
+  "exitCode" | "reason"
+>;
 
 type FakeRenderProcessGoneListener = (
   event: FakeWebContentsEvent,
@@ -121,6 +121,7 @@ interface FakeWebContentsEventMap {
   "will-redirect": FakeWillRedirectListener;
   "did-start-loading": FakeVoidWebContentsListener;
   "did-stop-loading": FakeVoidWebContentsListener;
+  "did-finish-load": FakeVoidWebContentsListener;
   "did-navigate": FakeDidNavigateListener;
   "did-navigate-in-page": FakeDidNavigateInPageListener;
   "did-start-navigation": FakeVoidWebContentsListener;
@@ -280,6 +281,7 @@ const electronMock = vi.hoisted(() => {
       "will-redirect": [],
       "did-start-loading": [],
       "did-stop-loading": [],
+      "did-finish-load": [],
       "did-navigate": [],
       "did-navigate-in-page": [],
       "did-start-navigation": [],
@@ -378,6 +380,12 @@ const electronMock = vi.hoisted(() => {
     emitRenderProcessGone(details: FakeRenderProcessGoneDetails): void {
       for (const listener of this.listeners["render-process-gone"]) {
         listener(fakeWebContentsEvent, details);
+      }
+    }
+
+    emitDidFinishLoad(): void {
+      for (const listener of this.listeners["did-finish-load"]) {
+        listener();
       }
     }
 
@@ -590,6 +598,7 @@ class FakeHostWindow implements DesktopBrowserHostWindow {
 }
 
 beforeEach(() => {
+  vi.useRealTimers();
   electronMock.fakeSessions.length = 0;
   electronMock.fakeViews.length = 0;
 });
@@ -655,6 +664,23 @@ function requireFakeView(
     throw new Error("Expected the browser view to be created.");
   }
   return view;
+}
+
+function createRendererRecoveryFixture(webContentsId: number) {
+  const manager = createDesktopBrowserViewManager({
+    partition: "persist:test",
+  });
+  const hostWindow = new FakeHostWindow({
+    contentBounds: { width: 700, height: 450 },
+    webContentsId,
+  });
+  attachBrowserTab({
+    manager,
+    hostWindow,
+    tabId: "browser:a",
+    url: "https://example.com/original",
+  });
+  return { manager, hostWindow, view: requireFakeView(0) };
 }
 
 function requireOnBeforeRequestListener(): FakeOnBeforeRequestListener {
@@ -1813,22 +1839,9 @@ describe("DesktopBrowserViewManager", () => {
     expect(view.webContents.focusCalls).toBe(1);
   });
 
-  it("recovers a hidden page after its renderer process exits", () => {
-    const manager = createDesktopBrowserViewManager({
-      partition: "persist:test",
-    });
-    const hostWindow = new FakeHostWindow({
-      contentBounds: { width: 700, height: 450 },
-      webContentsId: 75,
-    });
-
-    attachBrowserTab({
-      manager,
-      hostWindow,
-      tabId: "browser:a",
-      url: "https://example.com/original",
-    });
-    const view = requireFakeView(0);
+  it("defers hidden memory-eviction recovery until the panel shows the current page", () => {
+    vi.useFakeTimers();
+    const { hostWindow, manager, view } = createRendererRecoveryFixture(75);
     view.webContents.emitDidNavigate("https://example.com/current");
     manager.setVisible({
       hostWindow,
@@ -1840,10 +1853,87 @@ describe("DesktopBrowserViewManager", () => {
       reason: "memory-eviction",
     });
 
+    expect(view.webContents.reloadCalls).toBe(0);
+    expect(view.visible).toBe(false);
+
+    manager.setVisible({
+      hostWindow,
+      request: { tabId: "browser:a", visible: true },
+    });
+    expect(view.visible).toBe(false);
+    vi.runOnlyPendingTimers();
+
     expect(view.webContents.reloadCalls).toBe(1);
     expect(view.webContents.getURL()).toBe("https://example.com/current");
     expect(electronMock.fakeViews).toHaveLength(1);
+    expect(view.visible).toBe(true);
+  });
+
+  it("stops automatic recovery after two repeated renderer crashes", () => {
+    vi.useFakeTimers();
+    const { hostWindow, view } = createRendererRecoveryFixture(76);
+
+    for (let attempt = 1; attempt <= 2; attempt += 1) {
+      view.webContents.emitRenderProcessGone({
+        exitCode: 1,
+        reason: "crashed",
+      });
+      expect(view.visible).toBe(false);
+      vi.runOnlyPendingTimers();
+      expect(view.webContents.reloadCalls).toBe(attempt);
+      expect(view.visible).toBe(true);
+    }
+
+    view.webContents.emitRenderProcessGone({
+      exitCode: 1,
+      reason: "crashed",
+    });
+    vi.runOnlyPendingTimers();
+
+    expect(view.webContents.reloadCalls).toBe(2);
     expect(view.visible).toBe(false);
+    expect(hostWindow.webContents.sentPayloads.at(-1)).toMatchObject({
+      tabId: "browser:a",
+      errorText: "The page renderer stopped repeatedly",
+    });
+  });
+
+  it.each(["launch-failed", "integrity-failure"] as const)(
+    "does not automatically retry a %s renderer failure",
+    (reason) => {
+      vi.useFakeTimers();
+      const { hostWindow, view } = createRendererRecoveryFixture(77);
+
+      view.webContents.emitRenderProcessGone({ exitCode: 1, reason });
+      vi.runOnlyPendingTimers();
+
+      expect(view.webContents.reloadCalls).toBe(0);
+      expect(view.visible).toBe(false);
+      expect(hostWindow.webContents.sentPayloads.at(-1)).toMatchObject({
+        tabId: "browser:a",
+        errorText: "The page renderer could not start",
+      });
+    },
+  );
+
+  it("resets the renderer recovery limit after a page finishes loading", () => {
+    vi.useFakeTimers();
+    const { view } = createRendererRecoveryFixture(78);
+
+    view.webContents.emitRenderProcessGone({
+      exitCode: 1,
+      reason: "crashed",
+    });
+    vi.runOnlyPendingTimers();
+    view.webContents.emitDidFinishLoad();
+    view.webContents.emitRenderProcessGone({
+      exitCode: 1,
+      reason: "crashed",
+    });
+    vi.runOnlyPendingTimers();
+
+    expect(view.webContents.reloadCalls).toBe(2);
+    expect(view.visible).toBe(true);
   });
 
   it("does not focus a freshly-attached inactive tab", () => {

--- a/apps/desktop/test/desktop-browser-view-manager.test.ts
+++ b/apps/desktop/test/desktop-browser-view-manager.test.ts
@@ -104,6 +104,16 @@ type FakeBeforeInputListener = (
   input: FakeInput,
 ) => void;
 
+interface FakeRenderProcessGoneDetails {
+  exitCode: number;
+  reason: "memory-eviction";
+}
+
+type FakeRenderProcessGoneListener = (
+  event: FakeWebContentsEvent,
+  details: FakeRenderProcessGoneDetails,
+) => void;
+
 interface FakeWebContentsEventMap {
   "before-input-event": FakeBeforeInputListener;
   "will-frame-navigate": FakeWillFrameNavigateListener;
@@ -117,6 +127,7 @@ interface FakeWebContentsEventMap {
   "page-title-updated": FakeVoidWebContentsListener;
   "did-fail-load": FakeDidFailLoadListener;
   "context-menu": FakeContextMenuListener;
+  "render-process-gone": FakeRenderProcessGoneListener;
 }
 
 type FakeResourceType =
@@ -258,6 +269,7 @@ const electronMock = vi.hoisted(() => {
     public historyEntries: Array<{ title: string; url: string }> = [];
     public readonly id: number;
     public readonly loadURLCalls: string[] = [];
+    public reloadCalls = 0;
     public readonly pendingCaptureResolvers: Array<
       (image: FakeNativeImage) => void
     > = [];
@@ -274,6 +286,7 @@ const electronMock = vi.hoisted(() => {
       "page-title-updated": [],
       "did-fail-load": [],
       "context-menu": [],
+      "render-process-gone": [],
     };
     private title = "";
     private url = "";
@@ -340,7 +353,9 @@ const electronMock = vi.hoisted(() => {
       this.listeners[eventName].push(listener);
     }
 
-    reload(): void {}
+    reload(): void {
+      this.reloadCalls += 1;
+    }
 
     setWindowOpenHandler(handler: FakeWindowOpenHandler): void {
       this.windowOpenHandler = handler;
@@ -357,6 +372,12 @@ const electronMock = vi.hoisted(() => {
           args.validatedURL,
           args.isMainFrame,
         );
+      }
+    }
+
+    emitRenderProcessGone(details: FakeRenderProcessGoneDetails): void {
+      for (const listener of this.listeners["render-process-gone"]) {
+        listener(fakeWebContentsEvent, details);
       }
     }
 
@@ -1790,6 +1811,39 @@ describe("DesktopBrowserViewManager", () => {
 
     const view = requireFakeView(0);
     expect(view.webContents.focusCalls).toBe(1);
+  });
+
+  it("recovers a hidden page after its renderer process exits", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 75,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "https://example.com/original",
+    });
+    const view = requireFakeView(0);
+    view.webContents.emitDidNavigate("https://example.com/current");
+    manager.setVisible({
+      hostWindow,
+      request: { tabId: "browser:a", visible: false },
+    });
+
+    view.webContents.emitRenderProcessGone({
+      exitCode: 0,
+      reason: "memory-eviction",
+    });
+
+    expect(view.webContents.reloadCalls).toBe(1);
+    expect(view.webContents.getURL()).toBe("https://example.com/current");
+    expect(electronMock.fakeViews).toHaveLength(1);
+    expect(view.visible).toBe(false);
   });
 
   it("does not focus a freshly-attached inactive tab", () => {


### PR DESCRIPTION
## Summary

- Listen for Electron's `render-process-gone` event on each in-panel browser view.
- Reload the retained current navigation entry after a temporary renderer failure.
- Defer hidden recovery until the panel opens, and stop after two failed retries.
- Show an error without retrying renderer launch or integrity failures.
- Keep the existing native view hidden or visible as requested, instead of recreating the tab from its original URL.

The panel close path already retained the native view and its current URL. The fault occurred when Electron removed or lost that view's renderer process. The browser manager did not listen for that event, so the retained view stayed unusable until the user opened the link again.

## Reproduction and proof

I reproduced the failing state in the browser view manager test. The test loads an original URL, navigates to a different current URL, hides the view like a closed panel, and emits Electron's `memory-eviction` renderer exit. Before the fix, the test reported zero reloads. After the fix, the same retained view keeps its current URL and reloads when the panel shows it again.

The tests also prove that repeated crashes stop after two retries. They prove that launch and integrity failures do not retry automatically.

## Testing

- `pnpm exec turbo run typecheck --filter=@bb/desktop`
- `pnpm exec turbo run test --filter=@bb/desktop --force > /tmp/test-1386.txt 2>&1`
- 33 desktop test files passed with 254 tests.

Fixes #1386

> AGENT GENERATED: by GPT-5 Codex
