### PR TITLE
[issue sweep] Let in-app browser pages reach other loopback ports

### DIFF
--- a/apps/desktop/src/desktop-browser-policy.ts
+++ b/apps/desktop/src/desktop-browser-policy.ts
@@ -409,6 +409,11 @@ export interface ResolveReservedLoopbackPortsArgs {
   /** The attached runtime's server URL, or null when none is attached. */
   localServerUrl: string | null;
   /**
+   * URL the bb app window itself loads, or null before the first load. In dev
+   * that is a loopback Vite server bb owns, which is otherwise unnamed here.
+   */
+  appWindowUrl: string | null;
+  /**
    * Host-daemon port an attached loopback server reports, or null before the
    * first system-config fetch lands and after the config sync stops.
    */
@@ -416,7 +421,9 @@ export interface ResolveReservedLoopbackPortsArgs {
 }
 
 /**
- * The loopback ports bb itself serves, which browsed pages must never reach.
+ * The loopback ports bb itself serves, which browsed pages must never reach:
+ * the bb server, the host daemon, and in dev the Vite server that hosts the bb
+ * app window.
  *
  * The packaged host-daemon port is always reserved, because
  * `localHostDaemonPort` only arrives with the first system-config fetch and a
@@ -429,8 +436,12 @@ export function resolveReservedLoopbackPorts(
   args: ResolveReservedLoopbackPortsArgs,
 ): readonly number[] {
   const ports = new Set<number>([BB_PROD_HOST_DAEMON_PORT]);
-  for (const serverUrl of [args.builtinServerUrl, args.localServerUrl]) {
-    const port = serverUrl === null ? null : loopbackServicePort(serverUrl);
+  for (const url of [
+    args.builtinServerUrl,
+    args.localServerUrl,
+    args.appWindowUrl,
+  ]) {
+    const port = url === null ? null : loopbackServicePort(url);
     if (port !== null) {
       ports.add(port);
     }

--- a/apps/desktop/src/desktop-browser-policy.ts
+++ b/apps/desktop/src/desktop-browser-policy.ts
@@ -1,6 +1,8 @@
 // Pure navigation/popup policy for the in-app browser view. Kept free of any
 // `electron` import so it can be unit tested under vitest's node environment.
 
+import { BB_PROD_HOST_DAEMON_PORT } from "@bb/config/runtime";
+
 /**
  * Only `http`/`https` top-level navigations are allowed in the browser view.
  * Everything else (`file:`, `javascript:`, custom schemes, `about:` beyond
@@ -399,6 +401,44 @@ export function loopbackServicePort(url: string): number | null {
     return null;
   }
   return effectiveRequestPort(parsed);
+}
+
+export interface ResolveReservedLoopbackPortsArgs {
+  /** The loopback bb server URL this app starts or attaches to. */
+  builtinServerUrl: string;
+  /** The attached runtime's server URL, or null when none is attached. */
+  localServerUrl: string | null;
+  /**
+   * Host-daemon port an attached loopback server reports, or null before the
+   * first system-config fetch lands and after the config sync stops.
+   */
+  localHostDaemonPort: number | null;
+}
+
+/**
+ * The loopback ports bb itself serves, which browsed pages must never reach.
+ *
+ * The packaged host-daemon port is always reserved, because
+ * `localHostDaemonPort` only arrives with the first system-config fetch and a
+ * browsed page must not reach the daemon during that window. The cost is that
+ * a user's own service on a reserved port is unreachable from the in-app
+ * browser; that is the right trade, because a browsed page reaching bb is far
+ * worse than a browsed page missing one port.
+ */
+export function resolveReservedLoopbackPorts(
+  args: ResolveReservedLoopbackPortsArgs,
+): readonly number[] {
+  const ports = new Set<number>([BB_PROD_HOST_DAEMON_PORT]);
+  for (const serverUrl of [args.builtinServerUrl, args.localServerUrl]) {
+    const port = serverUrl === null ? null : loopbackServicePort(serverUrl);
+    if (port !== null) {
+      ports.add(port);
+    }
+  }
+  if (args.localHostDaemonPort !== null) {
+    ports.add(args.localHostDaemonPort);
+  }
+  return [...ports];
 }
 
 export interface ResolveRequestingFrameLocalOriginKeyArgs {

--- a/apps/desktop/src/desktop-browser-policy.ts
+++ b/apps/desktop/src/desktop-browser-policy.ts
@@ -50,6 +50,16 @@ export function resolveWindowOpenAction(url: string): WindowOpenDecision {
 // public name that resolves to a private IP (DNS rebinding) is not caught here.
 // That is a deeper, separate mitigation and out of scope for v1.
 
+/**
+ * The loopback ports bb serves, or `pending` while a local runtime is up whose
+ * host-daemon port bb has not read yet. Cross-port loopback stays closed until
+ * bb can name every port of its own, so a slow — or permanently failing —
+ * system-config fetch never opens a window onto the daemon.
+ */
+export type ReservedLoopbackPorts =
+  | { kind: "known"; ports: readonly number[] }
+  | { kind: "pending" };
+
 export interface ShouldBlockBrowserRequestArgs {
   url: string;
   method: string;
@@ -60,11 +70,10 @@ export interface ShouldBlockBrowserRequestArgs {
   currentMainFrameLocalOriginKey: string | null;
   requestingFrameOriginKey: string | null;
   /**
-   * Loopback ports bb's own services occupy (the local bb server, the host
-   * daemon local API). A browsed page never reaches these, whichever loopback
-   * name it addresses them by.
+   * Loopback ports bb's own services occupy, or `pending` while bb cannot yet
+   * name them all.
    */
-  reservedLoopbackPorts: readonly number[];
+  reservedLoopbackPorts: ReservedLoopbackPorts;
 }
 
 interface ParsedBrowserRequestUrl {
@@ -418,6 +427,22 @@ export interface ResolveReservedLoopbackPortsArgs {
    * first system-config fetch lands and after the config sync stops.
    */
   localHostDaemonPort: number | null;
+  /**
+   * Raw `BB_HOST_DAEMON_PORT`. It is set for every dev instance and for a
+   * configured production deployment, so reading it names the daemon port
+   * before any fetch and keeps the pending window shut.
+   */
+  configuredHostDaemonPort: string | undefined;
+  /** Whether a local bb runtime is attached or spawned right now. */
+  hasLocalRuntime: boolean;
+}
+
+function parsePortValue(value: string | undefined): number | null {
+  if (value === undefined) {
+    return null;
+  }
+  const port = Number(value.trim());
+  return Number.isInteger(port) && port >= 1 && port <= 65_535 ? port : null;
 }
 
 /**
@@ -434,7 +459,19 @@ export interface ResolveReservedLoopbackPortsArgs {
  */
 export function resolveReservedLoopbackPorts(
   args: ResolveReservedLoopbackPortsArgs,
-): readonly number[] {
+): ReservedLoopbackPorts {
+  const configuredHostDaemonPort = parsePortValue(
+    args.configuredHostDaemonPort,
+  );
+  // A local runtime whose daemon port is neither configured nor fetched yet
+  // sits on a port bb cannot name. Stay closed rather than guess.
+  if (
+    args.hasLocalRuntime &&
+    args.localHostDaemonPort === null &&
+    configuredHostDaemonPort === null
+  ) {
+    return { kind: "pending" };
+  }
   const ports = new Set<number>([BB_PROD_HOST_DAEMON_PORT]);
   for (const url of [
     args.builtinServerUrl,
@@ -446,10 +483,12 @@ export function resolveReservedLoopbackPorts(
       ports.add(port);
     }
   }
-  if (args.localHostDaemonPort !== null) {
-    ports.add(args.localHostDaemonPort);
+  for (const port of [configuredHostDaemonPort, args.localHostDaemonPort]) {
+    if (port !== null) {
+      ports.add(port);
+    }
   }
-  return [...ports];
+  return { kind: "known", ports: [...ports] };
 }
 
 export interface ResolveRequestingFrameLocalOriginKeyArgs {
@@ -552,7 +591,12 @@ export function shouldBlockBrowserRequest(
   // A committed loopback page reaching a second loopback port is ordinary local
   // development, so it is allowed here as it is in Chrome and Safari. bb's own
   // loopback services stay unreachable, which is what this firewall protects.
-  return args.reservedLoopbackPorts.includes(effectiveRequestPort(parsed));
+  if (args.reservedLoopbackPorts.kind === "pending") {
+    return true;
+  }
+  return args.reservedLoopbackPorts.ports.includes(
+    effectiveRequestPort(parsed),
+  );
 }
 
 // --- Popup-tab rate limiting ---

--- a/apps/desktop/src/desktop-browser-policy.ts
+++ b/apps/desktop/src/desktop-browser-policy.ts
@@ -39,6 +39,11 @@ export function resolveWindowOpenAction(url: string): WindowOpenDecision {
 // `session.webRequest` wiring in desktop-browser-view) using these predicates,
 // which classify the request's URL host as loopback / link-local / private.
 //
+// A loopback page may still reach other loopback ports, because that is how
+// ordinary local development works (a dev server on one port, its API or
+// WebSocket backend on another) and every real browser allows it. The ports bb
+// itself serves are the ones held back, named by `reservedLoopbackPorts`.
+//
 // Residual: this classifies the URL host, not the DNS-resolved address, so a
 // public name that resolves to a private IP (DNS rebinding) is not caught here.
 // That is a deeper, separate mitigation and out of scope for v1.
@@ -52,6 +57,12 @@ export interface ShouldBlockBrowserRequestArgs {
   entryWebContentsId: number | null;
   currentMainFrameLocalOriginKey: string | null;
   requestingFrameOriginKey: string | null;
+  /**
+   * Loopback ports bb's own services occupy (the local bb server, the host
+   * daemon local API). A browsed page never reaches these, whichever loopback
+   * name it addresses them by.
+   */
+  reservedLoopbackPorts: readonly number[];
 }
 
 interface ParsedBrowserRequestUrl {
@@ -267,6 +278,18 @@ function isReadOnlyMainFrameRequestMethod(method: string): boolean {
   return normalizedMethod === "GET" || normalizedMethod === "HEAD";
 }
 
+/**
+ * The port a guarded request actually reaches. `URL` leaves `port` empty for a
+ * scheme's default port, so a bare `http://127.0.0.1/` must still compare as
+ * port 80. Every caller has already narrowed the protocol to `http(s)`/`ws(s)`.
+ */
+function effectiveRequestPort(parsed: ParsedBrowserRequestUrl): number {
+  if (parsed.port.length > 0) {
+    return Number(parsed.port);
+  }
+  return parsed.protocol === "https:" || parsed.protocol === "wss:" ? 443 : 80;
+}
+
 function localRequestProtocolClass(protocol: string): string | null {
   if (protocol === "http:" || protocol === "ws:") {
     return "local";
@@ -359,6 +382,23 @@ export function localRequestOriginKey(url: string): string | null {
     return null;
   }
   return `${protocolClass}|${parsed.originHost}|${parsed.port}`;
+}
+
+/**
+ * The loopback port a bb service URL occupies, or null when the URL is not a
+ * loopback `http(s)` URL. The caller collects these into the reserved-port list
+ * the request firewall keeps unreachable from browsed pages.
+ */
+export function loopbackServicePort(url: string): number | null {
+  const parsed = parseBrowserRequestUrl(url);
+  if (
+    parsed === null ||
+    (parsed.protocol !== "http:" && parsed.protocol !== "https:") ||
+    !isLoopbackBrowserRequestHost(parsed.host)
+  ) {
+    return null;
+  }
+  return effectiveRequestPort(parsed);
 }
 
 export interface ResolveRequestingFrameLocalOriginKeyArgs {
@@ -455,7 +495,13 @@ export function shouldBlockBrowserRequest(
   ) {
     return true;
   }
-  return targetOriginKey !== args.currentMainFrameLocalOriginKey;
+  if (targetOriginKey === args.currentMainFrameLocalOriginKey) {
+    return false;
+  }
+  // A committed loopback page reaching a second loopback port is ordinary local
+  // development, so it is allowed here as it is in Chrome and Safari. bb's own
+  // loopback services stay unreachable, which is what this firewall protects.
+  return args.reservedLoopbackPorts.includes(effectiveRequestPort(parsed));
 }
 
 // --- Popup-tab rate limiting ---

--- a/apps/desktop/src/desktop-browser-view.ts
+++ b/apps/desktop/src/desktop-browser-view.ts
@@ -28,6 +28,7 @@ import {
   resolveRequestingFrameLocalOriginKey,
   resolveWindowOpenAction,
   shouldBlockBrowserRequest,
+  type ReservedLoopbackPorts,
 } from "./desktop-browser-policy.js";
 
 // At most this many popup → in-panel tabs may be spawned per view in a sliding
@@ -119,7 +120,7 @@ export interface CreateDesktopBrowserViewManagerArgs {
    * reach. Read per request rather than captured once, because the local
    * runtime and its host-daemon port attach after the manager is created.
    */
-  getReservedLoopbackPorts: () => readonly number[];
+  getReservedLoopbackPorts: () => ReservedLoopbackPorts;
   partition?: string;
   resolveAppCommand: (input: AppShortcutInput) => AppCommandId | null;
 }
@@ -265,7 +266,7 @@ function commitEntryMainFrameUrl(entry: BrowserViewEntry, url: string): void {
 function shouldBlockEntryTopLevelRequest(
   entry: BrowserViewEntry,
   url: string,
-  reservedLoopbackPorts: readonly number[],
+  reservedLoopbackPorts: ReservedLoopbackPorts,
 ): boolean {
   if (!isAllowedBrowserUrl(url)) {
     return true;
@@ -337,10 +338,7 @@ export function createDesktopBrowserViewManager(
     return resizingHostIds.has(hostWindow.webContents.id);
   }
 
-  function blockTopLevelRequest(
-    entry: BrowserViewEntry,
-    url: string,
-  ): boolean {
+  function blockTopLevelRequest(entry: BrowserViewEntry, url: string): boolean {
     return shouldBlockEntryTopLevelRequest(
       entry,
       url,

--- a/apps/desktop/src/desktop-browser-view.ts
+++ b/apps/desktop/src/desktop-browser-view.ts
@@ -114,6 +114,12 @@ export interface DispatchDesktopBrowserAppCommandArgs {
 export interface CreateDesktopBrowserViewManagerArgs {
   dispatchAppCommand: (args: DispatchDesktopBrowserAppCommandArgs) => void;
   focusHostWebContents: (hostWebContentsId: number) => void;
+  /**
+   * Loopback ports bb's own services occupy, which browsed pages must never
+   * reach. Read per request rather than captured once, because the local
+   * runtime and its host-daemon port attach after the manager is created.
+   */
+  getReservedLoopbackPorts: () => readonly number[];
   partition?: string;
   resolveAppCommand: (input: AppShortcutInput) => AppCommandId | null;
 }
@@ -259,6 +265,7 @@ function commitEntryMainFrameUrl(entry: BrowserViewEntry, url: string): void {
 function shouldBlockEntryTopLevelRequest(
   entry: BrowserViewEntry,
   url: string,
+  reservedLoopbackPorts: readonly number[],
 ): boolean {
   if (!isAllowedBrowserUrl(url)) {
     return true;
@@ -273,6 +280,7 @@ function shouldBlockEntryTopLevelRequest(
     entryWebContentsId: webContentsId,
     currentMainFrameLocalOriginKey: entry.currentMainFrameLocalOriginKey,
     requestingFrameOriginKey: null,
+    reservedLoopbackPorts,
   });
 }
 
@@ -327,6 +335,17 @@ export function createDesktopBrowserViewManager(
 
   function isHostResizing(hostWindow: DesktopBrowserHostWindow): boolean {
     return resizingHostIds.has(hostWindow.webContents.id);
+  }
+
+  function blockTopLevelRequest(
+    entry: BrowserViewEntry,
+    url: string,
+  ): boolean {
+    return shouldBlockEntryTopLevelRequest(
+      entry,
+      url,
+      args.getReservedLoopbackPorts(),
+    );
   }
 
   function applyEntryVisibility(
@@ -427,6 +446,7 @@ export function createDesktopBrowserViewManager(
             // SPA dev server (Vite, etc.) is not blocked into a blank page.
             isTopFrame: details.frame?.parent === null,
           }),
+          reservedLoopbackPorts: args.getReservedLoopbackPorts(),
         }),
       });
     });
@@ -485,12 +505,12 @@ export function createDesktopBrowserViewManager(
       if (!event.isMainFrame) {
         return;
       }
-      if (shouldBlockEntryTopLevelRequest(entry, event.url)) {
+      if (blockTopLevelRequest(entry, event.url)) {
         event.preventDefault();
       }
     });
     webContents.on("will-navigate", (event, url) => {
-      if (shouldBlockEntryTopLevelRequest(entry, url)) {
+      if (blockTopLevelRequest(entry, url)) {
         event.preventDefault();
       }
     });
@@ -498,7 +518,7 @@ export function createDesktopBrowserViewManager(
       if (!isMainFrame) {
         return;
       }
-      if (shouldBlockEntryTopLevelRequest(entry, url)) {
+      if (blockTopLevelRequest(entry, url)) {
         event.preventDefault();
       }
     });

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -884,10 +884,12 @@ async function refreshSystemConfig(
     if (token !== systemConfigRefreshToken) {
       return;
     }
-    currentLocalHostDaemonPort =
-      loopbackServicePort(args.serverUrl) === null
-        ? null
-        : config.hostDaemonPort;
+    // Only a loopback server describes this machine's daemon. A remote target
+    // must not clear the port either: switching to one leaves the local
+    // runtime, and its daemon, running.
+    if (loopbackServicePort(args.serverUrl) !== null) {
+      currentLocalHostDaemonPort = config.hostDaemonPort;
+    }
     currentAppKeybindings = config.keybindings;
     currentApplicationMenuAccelerators = resolveApplicationMenuAccelerators(
       currentAppKeybindings,
@@ -936,6 +938,7 @@ function createRemoteSystemConfigSync(serverUrl: string): SystemConfigSync {
   };
 }
 
+/** Runs when the local runtime stops or the app quits, never on a target switch. */
 function stopSystemConfigSync(): void {
   systemConfigSync?.stop();
   systemConfigSync = null;
@@ -952,6 +955,7 @@ function reservedLoopbackPorts(): readonly number[] {
   return resolveReservedLoopbackPorts({
     builtinServerUrl,
     localServerUrl: currentRuntime?.serverUrl ?? null,
+    appWindowUrl: currentWindowUrl,
     localHostDaemonPort: currentLocalHostDaemonPort,
   });
 }

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -145,6 +145,7 @@ import {
 import {
   loopbackServicePort,
   resolveReservedLoopbackPorts,
+  type ReservedLoopbackPorts,
 } from "./desktop-browser-policy.js";
 import { resolveDesktopBrowserAppCommand } from "./desktop-browser-shortcuts.js";
 import { registerDesktopBrowserIpc } from "./desktop-browser-main-ipc.js";
@@ -951,12 +952,14 @@ function stopSystemConfigSync(): void {
  * (a user's own dev server and its separate API/WebSocket backend) stays
  * reachable, as it is in Chrome and Safari.
  */
-function reservedLoopbackPorts(): readonly number[] {
+function reservedLoopbackPorts(): ReservedLoopbackPorts {
   return resolveReservedLoopbackPorts({
     builtinServerUrl,
     localServerUrl: currentRuntime?.serverUrl ?? null,
     appWindowUrl: currentWindowUrl,
     localHostDaemonPort: currentLocalHostDaemonPort,
+    configuredHostDaemonPort: process.env.BB_HOST_DAEMON_PORT,
+    hasLocalRuntime: currentRuntime !== null,
   });
 }
 

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -142,6 +142,7 @@ import {
   createDesktopBrowserViewManager,
   type DesktopBrowserViewManager,
 } from "./desktop-browser-view.js";
+import { loopbackServicePort } from "./desktop-browser-policy.js";
 import { resolveDesktopBrowserAppCommand } from "./desktop-browser-shortcuts.js";
 import { registerDesktopBrowserIpc } from "./desktop-browser-main-ipc.js";
 import { ensurePackagedMacOsUserShellPath } from "./desktop-shell-path.js";
@@ -292,6 +293,12 @@ let currentApplicationMenuAccelerators = DEFAULT_APPLICATION_MENU_ACCELERATORS;
 let desktopUpdateService: DesktopUpdateService | null = null;
 let desktopAutoUpdateService: DesktopAutoUpdateService | null = null;
 let currentRuntime: DesktopRuntime | null = null;
+/**
+ * Host-daemon local API port, recorded only while the attached bb server runs
+ * on this machine's loopback. A remote server reports its own machine's port,
+ * which says nothing about what listens on this Mac's loopback.
+ */
+let currentLocalHostDaemonPort: number | null = null;
 let currentWindowUrl: string | null = null;
 let logViewerIpcHandlersInstalled = false;
 let logViewerLineBuffer: LogLineBuffer | null = null;
@@ -874,6 +881,10 @@ async function refreshSystemConfig(
     if (token !== systemConfigRefreshToken) {
       return;
     }
+    currentLocalHostDaemonPort =
+      loopbackServicePort(args.serverUrl) === null
+        ? null
+        : config.hostDaemonPort;
     currentAppKeybindings = config.keybindings;
     currentApplicationMenuAccelerators = resolveApplicationMenuAccelerators(
       currentAppKeybindings,
@@ -925,6 +936,28 @@ function createRemoteSystemConfigSync(serverUrl: string): SystemConfigSync {
 function stopSystemConfigSync(): void {
   systemConfigSync?.stop();
   systemConfigSync = null;
+  currentLocalHostDaemonPort = null;
+}
+
+/**
+ * Loopback ports bb itself serves on this Mac. The in-app browser firewall
+ * keeps them unreachable from browsed pages, while every other loopback port
+ * (a user's own dev server and its separate API/WebSocket backend) stays
+ * reachable, as it is in Chrome and Safari.
+ */
+function reservedLoopbackPorts(): readonly number[] {
+  const ports = new Set<number>();
+  for (const serverUrl of [builtinServerUrl, currentRuntime?.serverUrl]) {
+    const port =
+      serverUrl === undefined ? null : loopbackServicePort(serverUrl);
+    if (port !== null) {
+      ports.add(port);
+    }
+  }
+  if (currentLocalHostDaemonPort !== null) {
+    ports.add(currentLocalHostDaemonPort);
+  }
+  return [...ports];
 }
 
 function startSystemConfigSync(serverUrl: string): void {
@@ -2167,6 +2200,7 @@ async function runDesktopApp(): Promise<void> {
         browserWindow.webContents.focus();
       }
     },
+    getReservedLoopbackPorts: reservedLoopbackPorts,
     resolveAppCommand(input) {
       return resolveDesktopBrowserAppCommand({
         input,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -142,7 +142,10 @@ import {
   createDesktopBrowserViewManager,
   type DesktopBrowserViewManager,
 } from "./desktop-browser-view.js";
-import { loopbackServicePort } from "./desktop-browser-policy.js";
+import {
+  loopbackServicePort,
+  resolveReservedLoopbackPorts,
+} from "./desktop-browser-policy.js";
 import { resolveDesktopBrowserAppCommand } from "./desktop-browser-shortcuts.js";
 import { registerDesktopBrowserIpc } from "./desktop-browser-main-ipc.js";
 import { ensurePackagedMacOsUserShellPath } from "./desktop-shell-path.js";
@@ -946,18 +949,11 @@ function stopSystemConfigSync(): void {
  * reachable, as it is in Chrome and Safari.
  */
 function reservedLoopbackPorts(): readonly number[] {
-  const ports = new Set<number>();
-  for (const serverUrl of [builtinServerUrl, currentRuntime?.serverUrl]) {
-    const port =
-      serverUrl === undefined ? null : loopbackServicePort(serverUrl);
-    if (port !== null) {
-      ports.add(port);
-    }
-  }
-  if (currentLocalHostDaemonPort !== null) {
-    ports.add(currentLocalHostDaemonPort);
-  }
-  return [...ports];
+  return resolveReservedLoopbackPorts({
+    builtinServerUrl,
+    localServerUrl: currentRuntime?.serverUrl ?? null,
+    localHostDaemonPort: currentLocalHostDaemonPort,
+  });
 }
 
 function startSystemConfigSync(serverUrl: string): void {

--- a/apps/desktop/test/desktop-browser-policy.test.ts
+++ b/apps/desktop/test/desktop-browser-policy.test.ts
@@ -13,6 +13,7 @@ import {
   isLoopbackBrowserRequestHost,
   isPrivateBrowserRequestHost,
   localRequestOriginKey,
+  loopbackServicePort,
   resolveRequestingFrameLocalOriginKey,
   resolveWindowOpenAction,
   shouldBlockBrowserRequest,
@@ -325,6 +326,22 @@ describe("localRequestOriginKey", () => {
   });
 });
 
+describe("loopbackServicePort", () => {
+  it("reads the port of a loopback bb service URL, filling in scheme defaults", () => {
+    expect(loopbackServicePort("http://127.0.0.1:38886")).toBe(38886);
+    expect(loopbackServicePort("http://localhost:3011/")).toBe(3011);
+    expect(loopbackServicePort("http://[::1]/")).toBe(80);
+    expect(loopbackServicePort("https://localhost/")).toBe(443);
+  });
+
+  it("returns null for URLs that name no loopback bb service", () => {
+    expect(loopbackServicePort("https://bee.getbb.app")).toBeNull();
+    expect(loopbackServicePort("http://192.168.1.10:38886")).toBeNull();
+    expect(loopbackServicePort("ws://127.0.0.1:38886")).toBeNull();
+    expect(loopbackServicePort("not a url")).toBeNull();
+  });
+});
+
 describe("shouldBlockBrowserRequest", () => {
   const localhost3000 = requireLocalOriginKey("http://localhost:3000/");
   const localhost5173 = requireLocalOriginKey("http://localhost:5173/");
@@ -340,6 +357,7 @@ describe("shouldBlockBrowserRequest", () => {
     entryWebContentsId: 1,
     currentMainFrameLocalOriginKey: null,
     requestingFrameOriginKey: null,
+    reservedLoopbackPorts: [],
   };
 
   it("allows public requests regardless of local attribution fields", () => {
@@ -522,9 +540,12 @@ describe("shouldBlockBrowserRequest", () => {
     }
   });
 
-  it("blocks cross-origin loopback requests from a committed local page", () => {
+  // Issue #1452: a local app's frontend and its WebSocket/API backend commonly
+  // sit on different loopback ports, and every real browser connects them.
+  it("allows cross-origin loopback requests from a committed local page", () => {
     for (const url of [
       "http://localhost:5173/api",
+      "ws://localhost:5173/socket",
       "http://127.0.0.1:3000/api",
       "https://localhost:3000/api",
       "http://localhost.:3000/api",
@@ -538,10 +559,46 @@ describe("shouldBlockBrowserRequest", () => {
           currentMainFrameLocalOriginKey: localhost3000,
           requestingFrameOriginKey: localhost3000,
         }),
-      ).toBe(true);
+      ).toBe(false);
     }
 
     expect(loopbackIpv4).not.toBe(localhost3000);
+  });
+
+  it("blocks reserved bb loopback ports under any loopback name or scheme", () => {
+    for (const url of [
+      "http://localhost:38886/api/v1/threads",
+      "ws://127.0.0.1:38886/ws",
+      "https://[::1]:38886/api/v1/threads",
+      "http://127.0.0.1/", // default port 80 must compare as 80
+    ]) {
+      expect(
+        shouldBlockBrowserRequest({
+          ...baseRequest,
+          url,
+          resourceType: "xhr",
+          isMainFrame: false,
+          currentMainFrameLocalOriginKey: localhost3000,
+          requestingFrameOriginKey: localhost3000,
+          reservedLoopbackPorts: [38886, 80],
+        }),
+      ).toBe(true);
+    }
+  });
+
+  it("still allows a page served from a reserved port to load its own subresources", () => {
+    const reservedOrigin = requireLocalOriginKey("http://localhost:38886/");
+    expect(
+      shouldBlockBrowserRequest({
+        ...baseRequest,
+        url: "http://localhost:38886/assets/app.js",
+        resourceType: "script",
+        isMainFrame: false,
+        currentMainFrameLocalOriginKey: reservedOrigin,
+        requestingFrameOriginKey: reservedOrigin,
+        reservedLoopbackPorts: [38886],
+      }),
+    ).toBe(false);
   });
 
   it("blocks private requests even when attribution and frame origin are present", () => {
@@ -655,6 +712,7 @@ describe("loopback SPA subresource firewall (regression)", () => {
     targetWebContentsId: 1,
     entryWebContentsId: 1,
     currentMainFrameLocalOriginKey: originKey,
+    reservedLoopbackPorts: [],
   };
 
   it("allows a same-origin top-frame subresource resolved via the URL fallback", () => {

--- a/apps/desktop/test/desktop-browser-policy.test.ts
+++ b/apps/desktop/test/desktop-browser-policy.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { BB_PROD_HOST_DAEMON_PORT } from "@bb/config/runtime";
 import {
   BB_DESKTOP_BROWSER_MAX_URL_LENGTH,
   bbDesktopBrowserAttachRequestSchema,
@@ -15,6 +16,7 @@ import {
   localRequestOriginKey,
   loopbackServicePort,
   resolveRequestingFrameLocalOriginKey,
+  resolveReservedLoopbackPorts,
   resolveWindowOpenAction,
   shouldBlockBrowserRequest,
   type ShouldBlockBrowserRequestArgs,
@@ -339,6 +341,43 @@ describe("loopbackServicePort", () => {
     expect(loopbackServicePort("http://192.168.1.10:38886")).toBeNull();
     expect(loopbackServicePort("ws://127.0.0.1:38886")).toBeNull();
     expect(loopbackServicePort("not a url")).toBeNull();
+  });
+});
+
+describe("resolveReservedLoopbackPorts", () => {
+  // The daemon port only arrives with the first system-config fetch. A browsed
+  // page opened before that fetch lands must still reach nothing bb serves.
+  it("reserves the packaged host-daemon port before any port is fetched", () => {
+    expect(
+      resolveReservedLoopbackPorts({
+        builtinServerUrl: "http://127.0.0.1:38886",
+        localServerUrl: null,
+        localHostDaemonPort: null,
+      }),
+    ).toEqual(expect.arrayContaining([BB_PROD_HOST_DAEMON_PORT, 38886]));
+  });
+
+  it("adds the fetched daemon port and the attached runtime's port", () => {
+    const ports = resolveReservedLoopbackPorts({
+      builtinServerUrl: "http://127.0.0.1:38886",
+      localServerUrl: "http://127.0.0.1:19123",
+      localHostDaemonPort: 27123,
+    });
+    expect(ports).toEqual(
+      expect.arrayContaining([BB_PROD_HOST_DAEMON_PORT, 38886, 19123, 27123]),
+    );
+  });
+
+  it("keeps bb's own ports reserved when attached to a remote server", () => {
+    const ports = resolveReservedLoopbackPorts({
+      builtinServerUrl: "http://127.0.0.1:38886",
+      localServerUrl: "https://bee.getbb.app",
+      localHostDaemonPort: null,
+    });
+    expect(ports).toEqual(
+      expect.arrayContaining([BB_PROD_HOST_DAEMON_PORT, 38886]),
+    );
+    expect(ports).toHaveLength(2);
   });
 });
 

--- a/apps/desktop/test/desktop-browser-policy.test.ts
+++ b/apps/desktop/test/desktop-browser-policy.test.ts
@@ -352,6 +352,7 @@ describe("resolveReservedLoopbackPorts", () => {
       resolveReservedLoopbackPorts({
         builtinServerUrl: "http://127.0.0.1:38886",
         localServerUrl: null,
+        appWindowUrl: null,
         localHostDaemonPort: null,
       }),
     ).toEqual(expect.arrayContaining([BB_PROD_HOST_DAEMON_PORT, 38886]));
@@ -361,6 +362,7 @@ describe("resolveReservedLoopbackPorts", () => {
     const ports = resolveReservedLoopbackPorts({
       builtinServerUrl: "http://127.0.0.1:38886",
       localServerUrl: "http://127.0.0.1:19123",
+      appWindowUrl: null,
       localHostDaemonPort: 27123,
     });
     expect(ports).toEqual(
@@ -368,16 +370,32 @@ describe("resolveReservedLoopbackPorts", () => {
     );
   });
 
-  it("keeps bb's own ports reserved when attached to a remote server", () => {
+  // In dev the bb app window loads from a loopback Vite server bb owns, which
+  // no server URL or daemon port names.
+  it("reserves the loopback app-window port in dev", () => {
+    expect(
+      resolveReservedLoopbackPorts({
+        builtinServerUrl: "http://127.0.0.1:19123",
+        localServerUrl: "http://127.0.0.1:19123",
+        appWindowUrl: "http://127.0.0.1:11123/",
+        localHostDaemonPort: 27123,
+      }),
+    ).toEqual(expect.arrayContaining([11123, 19123, 27123]));
+  });
+
+  // Switching to a remote target leaves the local runtime and its daemon
+  // running, so their ports must survive the switch.
+  it("keeps the local daemon port reserved while pointed at a remote server", () => {
     const ports = resolveReservedLoopbackPorts({
       builtinServerUrl: "http://127.0.0.1:38886",
-      localServerUrl: "https://bee.getbb.app",
-      localHostDaemonPort: null,
+      localServerUrl: "http://127.0.0.1:19123",
+      appWindowUrl: "https://bee.getbb.app",
+      localHostDaemonPort: 27123,
     });
     expect(ports).toEqual(
-      expect.arrayContaining([BB_PROD_HOST_DAEMON_PORT, 38886]),
+      expect.arrayContaining([BB_PROD_HOST_DAEMON_PORT, 38886, 19123, 27123]),
     );
-    expect(ports).toHaveLength(2);
+    expect(ports).toHaveLength(4);
   });
 });
 

--- a/apps/desktop/test/desktop-browser-policy.test.ts
+++ b/apps/desktop/test/desktop-browser-policy.test.ts
@@ -19,6 +19,7 @@ import {
   resolveReservedLoopbackPorts,
   resolveWindowOpenAction,
   shouldBlockBrowserRequest,
+  type ReservedLoopbackPorts,
   type ShouldBlockBrowserRequestArgs,
 } from "../src/desktop-browser-policy.js";
 
@@ -345,26 +346,77 @@ describe("loopbackServicePort", () => {
 });
 
 describe("resolveReservedLoopbackPorts", () => {
-  // The daemon port only arrives with the first system-config fetch. A browsed
-  // page opened before that fetch lands must still reach nothing bb serves.
+  const baseArgs = {
+    builtinServerUrl: "http://127.0.0.1:38886",
+    localServerUrl: null,
+    appWindowUrl: null,
+    localHostDaemonPort: null,
+    configuredHostDaemonPort: undefined,
+    hasLocalRuntime: false,
+  };
+
+  function requireKnownPorts(result: ReservedLoopbackPorts): readonly number[] {
+    if (result.kind !== "known") {
+      throw new Error("Expected a known reserved-port set");
+    }
+    return result.ports;
+  }
+
   it("reserves the packaged host-daemon port before any port is fetched", () => {
+    expect(requireKnownPorts(resolveReservedLoopbackPorts(baseArgs))).toEqual(
+      expect.arrayContaining([BB_PROD_HOST_DAEMON_PORT, 38886]),
+    );
+  });
+
+  // A local runtime whose daemon sits on a non-default port is unnamed until
+  // the config fetch lands, and the fetch may never land. Stay closed.
+  it("stays pending while a local runtime's daemon port is unknown", () => {
     expect(
       resolveReservedLoopbackPorts({
-        builtinServerUrl: "http://127.0.0.1:38886",
-        localServerUrl: null,
-        appWindowUrl: null,
-        localHostDaemonPort: null,
+        ...baseArgs,
+        localServerUrl: "http://127.0.0.1:19123",
+        hasLocalRuntime: true,
       }),
-    ).toEqual(expect.arrayContaining([BB_PROD_HOST_DAEMON_PORT, 38886]));
+    ).toEqual({ kind: "pending" });
+  });
+
+  // `BB_HOST_DAEMON_PORT` is set for every dev instance and for a configured
+  // production deployment, so the window never opens there.
+  it("names a configured daemon port without waiting for the fetch", () => {
+    const ports = requireKnownPorts(
+      resolveReservedLoopbackPorts({
+        ...baseArgs,
+        localServerUrl: "http://127.0.0.1:19123",
+        hasLocalRuntime: true,
+        configuredHostDaemonPort: "27123",
+      }),
+    );
+    expect(ports).toEqual(
+      expect.arrayContaining([BB_PROD_HOST_DAEMON_PORT, 38886, 19123, 27123]),
+    );
+  });
+
+  it("treats an unusable BB_HOST_DAEMON_PORT as unknown", () => {
+    for (const configuredHostDaemonPort of ["", "0", "70000", "not-a-port"]) {
+      expect(
+        resolveReservedLoopbackPorts({
+          ...baseArgs,
+          hasLocalRuntime: true,
+          configuredHostDaemonPort,
+        }),
+      ).toEqual({ kind: "pending" });
+    }
   });
 
   it("adds the fetched daemon port and the attached runtime's port", () => {
-    const ports = resolveReservedLoopbackPorts({
-      builtinServerUrl: "http://127.0.0.1:38886",
-      localServerUrl: "http://127.0.0.1:19123",
-      appWindowUrl: null,
-      localHostDaemonPort: 27123,
-    });
+    const ports = requireKnownPorts(
+      resolveReservedLoopbackPorts({
+        ...baseArgs,
+        localServerUrl: "http://127.0.0.1:19123",
+        hasLocalRuntime: true,
+        localHostDaemonPort: 27123,
+      }),
+    );
     expect(ports).toEqual(
       expect.arrayContaining([BB_PROD_HOST_DAEMON_PORT, 38886, 19123, 27123]),
     );
@@ -374,24 +426,31 @@ describe("resolveReservedLoopbackPorts", () => {
   // no server URL or daemon port names.
   it("reserves the loopback app-window port in dev", () => {
     expect(
-      resolveReservedLoopbackPorts({
-        builtinServerUrl: "http://127.0.0.1:19123",
-        localServerUrl: "http://127.0.0.1:19123",
-        appWindowUrl: "http://127.0.0.1:11123/",
-        localHostDaemonPort: 27123,
-      }),
+      requireKnownPorts(
+        resolveReservedLoopbackPorts({
+          ...baseArgs,
+          builtinServerUrl: "http://127.0.0.1:19123",
+          localServerUrl: "http://127.0.0.1:19123",
+          appWindowUrl: "http://127.0.0.1:11123/",
+          hasLocalRuntime: true,
+          localHostDaemonPort: 27123,
+        }),
+      ),
     ).toEqual(expect.arrayContaining([11123, 19123, 27123]));
   });
 
   // Switching to a remote target leaves the local runtime and its daemon
   // running, so their ports must survive the switch.
   it("keeps the local daemon port reserved while pointed at a remote server", () => {
-    const ports = resolveReservedLoopbackPorts({
-      builtinServerUrl: "http://127.0.0.1:38886",
-      localServerUrl: "http://127.0.0.1:19123",
-      appWindowUrl: "https://bee.getbb.app",
-      localHostDaemonPort: 27123,
-    });
+    const ports = requireKnownPorts(
+      resolveReservedLoopbackPorts({
+        ...baseArgs,
+        localServerUrl: "http://127.0.0.1:19123",
+        appWindowUrl: "https://bee.getbb.app",
+        hasLocalRuntime: true,
+        localHostDaemonPort: 27123,
+      }),
+    );
     expect(ports).toEqual(
       expect.arrayContaining([BB_PROD_HOST_DAEMON_PORT, 38886, 19123, 27123]),
     );
@@ -414,7 +473,7 @@ describe("shouldBlockBrowserRequest", () => {
     entryWebContentsId: 1,
     currentMainFrameLocalOriginKey: null,
     requestingFrameOriginKey: null,
-    reservedLoopbackPorts: [],
+    reservedLoopbackPorts: { kind: "known", ports: [] },
   };
 
   it("allows public requests regardless of local attribution fields", () => {
@@ -637,7 +696,7 @@ describe("shouldBlockBrowserRequest", () => {
           isMainFrame: false,
           currentMainFrameLocalOriginKey: localhost3000,
           requestingFrameOriginKey: localhost3000,
-          reservedLoopbackPorts: [38886, 80],
+          reservedLoopbackPorts: { kind: "known", ports: [38886, 80] },
         }),
       ).toBe(true);
     }
@@ -653,7 +712,7 @@ describe("shouldBlockBrowserRequest", () => {
         isMainFrame: false,
         currentMainFrameLocalOriginKey: reservedOrigin,
         requestingFrameOriginKey: reservedOrigin,
-        reservedLoopbackPorts: [38886],
+        reservedLoopbackPorts: { kind: "known", ports: [38886] },
       }),
     ).toBe(false);
   });
@@ -769,7 +828,7 @@ describe("loopback SPA subresource firewall (regression)", () => {
     targetWebContentsId: 1,
     entryWebContentsId: 1,
     currentMainFrameLocalOriginKey: originKey,
-    reservedLoopbackPorts: [],
+    reservedLoopbackPorts: { kind: "known", ports: [] },
   };
 
   it("allows a same-origin top-frame subresource resolved via the URL fallback", () => {

--- a/apps/desktop/test/desktop-browser-view-manager.test.ts
+++ b/apps/desktop/test/desktop-browser-view-manager.test.ts
@@ -19,7 +19,7 @@ function createDesktopBrowserViewManager(
   return createProductionDesktopBrowserViewManager({
     dispatchAppCommand: () => undefined,
     focusHostWebContents: () => undefined,
-    getReservedLoopbackPorts: () => [],
+    getReservedLoopbackPorts: () => ({ kind: "known", ports: [] }),
     resolveAppCommand: () => null,
     ...args,
   });
@@ -1318,7 +1318,10 @@ describe("DesktopBrowserViewManager", () => {
   // and Safari, while bb's own loopback services stay unreachable.
   it("allows cross-port loopback requests but never bb's own loopback ports", () => {
     const manager = createDesktopBrowserViewManager({
-      getReservedLoopbackPorts: () => [38886, 3011],
+      getReservedLoopbackPorts: () => ({
+        kind: "known",
+        ports: [38886, 3011],
+      }),
       partition: "persist:test",
     });
     const hostWindow = new FakeHostWindow({
@@ -1335,7 +1338,10 @@ describe("DesktopBrowserViewManager", () => {
     const view = requireFakeView(0);
     view.webContents.emitDidNavigate("http://127.0.0.1:3009/");
 
-    for (const url of ["ws://127.0.0.1:3210/api", "http://127.0.0.1:3210/api"]) {
+    for (const url of [
+      "ws://127.0.0.1:3210/api",
+      "http://127.0.0.1:3210/api",
+    ]) {
       expect(
         browserRequestBlocked({
           url,
@@ -1371,6 +1377,46 @@ describe("DesktopBrowserViewManager", () => {
         frameOrigin: "https://example.com",
       }),
     ).toBe(true);
+  });
+
+  // Restored tabs can load before the first system-config response names the
+  // daemon port, and that fetch may fail outright. Cross-port stays shut until
+  // bb can name every port of its own; same-origin keeps working throughout.
+  it("blocks cross-port loopback while bb cannot name its own ports", () => {
+    const manager = createDesktopBrowserViewManager({
+      getReservedLoopbackPorts: () => ({ kind: "pending" }),
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 67,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "http://127.0.0.1:3009/",
+    });
+    const view = requireFakeView(0);
+    view.webContents.emitDidNavigate("http://127.0.0.1:3009/");
+
+    expect(
+      browserRequestBlocked({
+        url: "ws://127.0.0.1:3210/api",
+        resourceType: "webSocket",
+        webContentsId: view.webContents.id,
+        frameOrigin: "http://127.0.0.1:3009",
+      }),
+    ).toBe(true);
+    expect(
+      browserRequestBlocked({
+        url: "http://127.0.0.1:3009/app.js",
+        resourceType: "script",
+        webContentsId: view.webContents.id,
+        frameOrigin: "http://127.0.0.1:3009",
+      }),
+    ).toBe(false);
   });
 
   it("allows top-level localhost frame navigation but blocks public iframe subresources", () => {

--- a/apps/desktop/test/desktop-browser-view-manager.test.ts
+++ b/apps/desktop/test/desktop-browser-view-manager.test.ts
@@ -19,6 +19,7 @@ function createDesktopBrowserViewManager(
   return createProductionDesktopBrowserViewManager({
     dispatchAppCommand: () => undefined,
     focusHostWebContents: () => undefined,
+    getReservedLoopbackPorts: () => [],
     resolveAppCommand: () => null,
     ...args,
   });
@@ -1296,14 +1297,6 @@ describe("DesktopBrowserViewManager", () => {
       }),
     ).toBe(false);
     expect(
-      browserRequestBlocked({
-        url: "http://localhost:38886/api",
-        resourceType: "xhr",
-        webContentsId: view.webContents.id,
-        frameOrigin: "http://localhost:5173",
-      }),
-    ).toBe(true);
-    expect(
       view.webContents.emitWillFrameNavigate(
         "http://localhost:38886/",
         true,
@@ -1318,6 +1311,66 @@ describe("DesktopBrowserViewManager", () => {
         frameOrigin: "http://localhost:5173",
       }),
     ).toBe(false);
+  });
+
+  // Regression for issue #1452: a local app whose frontend and WebSocket
+  // backend sit on different loopback ports must connect, as it does in Chrome
+  // and Safari, while bb's own loopback services stay unreachable.
+  it("allows cross-port loopback requests but never bb's own loopback ports", () => {
+    const manager = createDesktopBrowserViewManager({
+      getReservedLoopbackPorts: () => [38886, 3011],
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 66,
+    });
+
+    attachBrowserTab({
+      manager,
+      hostWindow,
+      tabId: "browser:a",
+      url: "http://127.0.0.1:3009/",
+    });
+    const view = requireFakeView(0);
+    view.webContents.emitDidNavigate("http://127.0.0.1:3009/");
+
+    for (const url of ["ws://127.0.0.1:3210/api", "http://127.0.0.1:3210/api"]) {
+      expect(
+        browserRequestBlocked({
+          url,
+          resourceType: url.startsWith("ws:") ? "webSocket" : "xhr",
+          webContentsId: view.webContents.id,
+          frameOrigin: "http://127.0.0.1:3009",
+        }),
+      ).toBe(false);
+    }
+
+    // bb's server and host-daemon ports stay blocked, under any loopback name.
+    for (const url of [
+      "ws://127.0.0.1:38886/ws",
+      "http://localhost:38886/api/v1/threads",
+      "http://[::1]:3011/",
+    ]) {
+      expect(
+        browserRequestBlocked({
+          url,
+          resourceType: url.startsWith("ws:") ? "webSocket" : "xhr",
+          webContentsId: view.webContents.id,
+          frameOrigin: "http://127.0.0.1:3009",
+        }),
+      ).toBe(true);
+    }
+
+    // A page that never committed a loopback origin still reaches nothing.
+    expect(
+      browserRequestBlocked({
+        url: "ws://127.0.0.1:3210/api",
+        resourceType: "webSocket",
+        webContentsId: view.webContents.id,
+        frameOrigin: "https://example.com",
+      }),
+    ).toBe(true);
   });
 
   it("allows top-level localhost frame navigation but blocks public iframe subresources", () => {

--- a/apps/host-daemon/src/local-api.test.ts
+++ b/apps/host-daemon/src/local-api.test.ts
@@ -34,6 +34,69 @@ describe("local API server", () => {
     server = null;
   });
 
+  // The in-app browser can now reach any loopback port bb does not reserve, and
+  // a second bb daemon on this machine sits on one. CORS only hides a response:
+  // a `no-cors` POST with a simple content type skips the preflight and still
+  // runs `/open-in-target`. The origin must be rejected, not just unanswered.
+  it("rejects a foreign browser origin instead of only withholding CORS", async () => {
+    const openInTarget = vi.fn(async () => undefined);
+    server = await startLocalApiServer({
+      hostId: "host-1",
+      localApiConfig: createLocalApiConfig(),
+      serverUrl: "http://server.test",
+      serverPort: 3334,
+      devAppPort: 5173,
+      getConnected: () => true,
+      openInTarget,
+    });
+    const baseUrl = `http://localhost:${server.port}`;
+
+    async function postOpenInTarget(
+      headers: Record<string, string>,
+    ): Promise<number> {
+      const response = await fetch(`${baseUrl}/open-in-target`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          context: { kind: "local" },
+          columnNumber: null,
+          lineNumber: null,
+          path: tmpdir(),
+          targetId: "vscode",
+        }),
+      });
+      return response.status;
+    }
+
+    // A blind cross-origin POST: simple content type, so no preflight guards it.
+    expect(
+      await postOpenInTarget({
+        "content-type": "text/plain",
+        origin: "http://127.0.0.1:3009",
+      }),
+    ).toBe(403);
+    // A DNS-rebound page presents its own public origin.
+    expect(
+      await postOpenInTarget({
+        "content-type": "text/plain",
+        origin: "http://rebind.example",
+      }),
+    ).toBe(403);
+    expect(openInTarget).not.toHaveBeenCalled();
+
+    // The bb app's own origin still works, as does a caller sending none.
+    expect(
+      await postOpenInTarget({
+        "content-type": "application/json",
+        origin: "http://localhost:3334",
+      }),
+    ).toBe(200);
+    expect(await postOpenInTarget({ "content-type": "application/json" })).toBe(
+      200,
+    );
+    expect(openInTarget).toHaveBeenCalledTimes(2);
+  });
+
   it("serves host identity and status over localhost", async () => {
     server = await startLocalApiServer({
       hostId: "host-1",

--- a/apps/host-daemon/src/local-api.ts
+++ b/apps/host-daemon/src/local-api.ts
@@ -208,26 +208,45 @@ export async function startLocalApiServer(
     value: options.devAppPort,
   });
   const allowedCorsOrigins = new Set<string>(buildLocalAppOrigins(originArgs));
+  const isAllowedAppOrigin = async (
+    origin: string,
+    requestUrl: string,
+  ): Promise<boolean> =>
+    origin === new URL(requestUrl).origin ||
+    allowedCorsOrigins.has(origin) ||
+    (await isConfiguredClientOrigin(origin, clientConfigLoader));
+
   app.use(
     "*",
     cors({
-      origin: async (origin, context) => {
-        const requestOrigin = new URL(context.req.url).origin;
-        if (
-          origin === requestOrigin ||
-          allowedCorsOrigins.has(origin) ||
-          (await isConfiguredClientOrigin(origin, clientConfigLoader))
-        ) {
-          return origin;
-        }
-        return null;
-      },
+      origin: async (origin, context) =>
+        (await isAllowedAppOrigin(origin, context.req.url)) ? origin : null,
     }),
   );
 
   app.get(options.localApiConfig.healthPath, (c) =>
     c.text(healthResponseSchema.parse(options.localApiConfig.healthValue)),
   );
+  // CORS hides a response; it does not stop the request being acted on. A
+  // `no-cors` POST with a simple content type skips the preflight, reaches
+  // `/open-in-target`, and runs it, while the page never reads the reply. The
+  // in-app browser can now reach any loopback port it is not told to avoid, and
+  // a second bb daemon on this machine sits on a port the desktop cannot name,
+  // so reject a foreign browser origin outright instead of only withholding the
+  // response header. Non-browser callers send no `Origin` and are unaffected.
+  app.use("*", async (c, next) => {
+    const origin = c.req.header("origin");
+    if (
+      origin !== undefined &&
+      !(await isAllowedAppOrigin(origin, c.req.url))
+    ) {
+      return c.json(
+        { error: `origin "${origin}" is not a local BB app origin` },
+        403,
+      );
+    }
+    await next();
+  });
   app.use("*", async (c, next) => {
     if (options.localApiConfig.mode === "health-only") {
       return c.notFound();

--- a/apps/host-daemon/src/machine-auth-proxy.test.ts
+++ b/apps/host-daemon/src/machine-auth-proxy.test.ts
@@ -290,6 +290,58 @@ describe("startMachineAuthProxy", () => {
     expect(upstreamUpgrades).toBe(0);
   });
 
+  // A page on a public hostname that DNS-rebinds to 127.0.0.1 reaches this
+  // socket with that name in `Host`, and Chromium sends no `Origin` or
+  // `Sec-Fetch-*` for a `no-cors` GET to a non-trustworthy URL — so the header
+  // check alone cannot see it. Verified in Electron with
+  // `--host-resolver-rules="MAP rebind.example 127.0.0.1"`.
+  it("rejects a rebound public Host without reaching upstream", async () => {
+    let upstreamRequests = 0;
+    const upstream = http.createServer((_request, response) => {
+      upstreamRequests += 1;
+      response.end();
+    });
+    const upstreamPort = await listen(upstream);
+    const proxy = await startMachineAuthProxy({
+      machineCredential: "bbcm_machine",
+      serverUrl: `http://127.0.0.1:${upstreamPort}`,
+    });
+    proxies.push(proxy);
+    const proxyUrl = new URL(proxy.serverUrl);
+
+    async function statusForHost(host: string): Promise<number | undefined> {
+      return await new Promise<number | undefined>((resolve, reject) => {
+        const request = http.request(
+          {
+            host: proxyUrl.hostname,
+            port: proxyUrl.port,
+            path: "/api/v1/threads",
+            headers: { host },
+          },
+          (response) => resolve(response.statusCode),
+        );
+        request.once("error", reject);
+        request.end();
+      });
+    }
+
+    // No Origin, no Sec-Fetch-Site: only the Host header gives it away.
+    expect(await statusForHost(`rebind.example:${proxyUrl.port}`)).toBe(403);
+    // A mismatched port on a loopback name is not this proxy either.
+    expect(await statusForHost("127.0.0.1:1")).toBe(403);
+    expect(upstreamRequests).toBe(0);
+
+    // The authorities a real runtime client sends still pass.
+    for (const host of [
+      `127.0.0.1:${proxyUrl.port}`,
+      `localhost:${proxyUrl.port}`,
+      `[::1]:${proxyUrl.port}`,
+    ]) {
+      expect(await statusForHost(host)).toBe(200);
+    }
+    expect(upstreamRequests).toBe(3);
+  });
+
   it("rejects loudly when its loopback port cannot be bound", async () => {
     const occupied = net.createServer();
     const port = await listen(occupied);

--- a/apps/host-daemon/src/machine-auth-proxy.test.ts
+++ b/apps/host-daemon/src/machine-auth-proxy.test.ts
@@ -213,6 +213,83 @@ describe("startMachineAuthProxy", () => {
     expect(upstreamRequests).toBe(0);
   });
 
+  // The in-app browser can now reach any unreserved loopback port, and this
+  // proxy's port is chosen at random so no reserved list can name it. A browsed
+  // page must not be able to borrow the machine credential with a blind
+  // `no-cors` request, whose response it cannot read but whose effect lands.
+  it("rejects browser-originated requests without reaching upstream", async () => {
+    let upstreamRequests = 0;
+    const upstream = http.createServer((_request, response) => {
+      upstreamRequests += 1;
+      response.end();
+    });
+    const upstreamPort = await listen(upstream);
+    const proxy = await startMachineAuthProxy({
+      machineCredential: "bbcm_machine",
+      serverUrl: `http://127.0.0.1:${upstreamPort}`,
+    });
+    proxies.push(proxy);
+
+    const browserHeaders: Array<Record<string, string>> = [
+      // A blind cross-origin POST: no preflight, and the effect still lands.
+      { origin: "http://127.0.0.1:3009", "content-type": "text/plain" },
+      // A blind `no-cors` GET carries no Origin, but Chromium still marks it.
+      { "sec-fetch-site": "cross-site" },
+    ];
+    for (const headers of browserHeaders) {
+      const response = await fetch(`${proxy.serverUrl}/api/v1/threads`, {
+        method: "POST",
+        headers,
+        body: "{}",
+      });
+      expect(response.status).toBe(403);
+    }
+    expect(upstreamRequests).toBe(0);
+
+    // A runtime process using Node's own `fetch` still gets through. Node sends
+    // `sec-fetch-mode: cors`, so that header must not be a discriminator.
+    const allowed = await fetch(`${proxy.serverUrl}/api/v1/threads`, {
+      method: "POST",
+      body: "{}",
+    });
+    expect(allowed.status).toBe(200);
+    expect(upstreamRequests).toBe(1);
+  });
+
+  it("rejects a browser WebSocket handshake without reaching upstream", async () => {
+    let upstreamUpgrades = 0;
+    const upstream = http.createServer((_request, response) => response.end());
+    upstream.on("upgrade", (_request, socket) => {
+      upstreamUpgrades += 1;
+      socket.destroy();
+    });
+    const upstreamPort = await listen(upstream);
+    const proxy = await startMachineAuthProxy({
+      machineCredential: "bbcm_machine",
+      serverUrl: `http://127.0.0.1:${upstreamPort}`,
+    });
+    proxies.push(proxy);
+    const proxyUrl = new URL(proxy.serverUrl);
+
+    const handshake = await new Promise<string>((resolve, reject) => {
+      const socket = net.connect(
+        Number(proxyUrl.port),
+        proxyUrl.hostname,
+        () => {
+          socket.write(
+            `GET /ws HTTP/1.1\r\nHost: ${proxyUrl.host}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: ${Buffer.from("0123456789abcdef").toString("base64")}\r\nSec-WebSocket-Version: 13\r\nOrigin: http://127.0.0.1:3009\r\n\r\n`,
+          );
+        },
+      );
+      socket.setEncoding("utf8");
+      socket.once("data", (chunk) => resolve(String(chunk)));
+      socket.once("error", reject);
+    });
+
+    expect(handshake).toContain("403 Forbidden");
+    expect(upstreamUpgrades).toBe(0);
+  });
+
   it("rejects loudly when its loopback port cannot be bound", async () => {
     const occupied = net.createServer();
     const port = await listen(occupied);

--- a/apps/host-daemon/src/machine-auth-proxy.ts
+++ b/apps/host-daemon/src/machine-auth-proxy.ts
@@ -21,16 +21,44 @@ export interface MachineAuthProxy {
   close(): Promise<void>;
 }
 
+// Headers no non-browser client sends. `Origin` rides every browser write and
+// WebSocket handshake; `Sec-Fetch-Site` rides every browser fetch, including a
+// blind `no-cors` GET that carries no `Origin`. `Sec-Fetch-Mode` is NOT a
+// discriminator: Node's own `fetch` sends `sec-fetch-mode: cors`, so keying on
+// it would reject the runtime processes this proxy exists to serve.
+const BROWSER_REQUEST_HEADERS = ["origin", "sec-fetch-site"] as const;
+
+const REJECTED_SOCKET_MESSAGES = {
+  400: "Bad Request",
+  403: "Forbidden",
+  405: "Method Not Allowed",
+} as const;
+
+type RejectedSocketStatus = keyof typeof REJECTED_SOCKET_MESSAGES;
+
+/**
+ * Whether a web page made this request. This proxy exists for the Node runtime
+ * processes it hands `BB_SERVER_URL` to, and it stamps every forwarded request
+ * with a machine credential. A page can reach any loopback port it can guess,
+ * and a `no-cors` request still acts even though its response stays hidden, so
+ * a browsed page must never borrow that credential.
+ */
+export function isBrowserRequest(headers: IncomingHttpHeaders): boolean {
+  return BROWSER_REQUEST_HEADERS.some((name) => headers[name] !== undefined);
+}
+
 function isOriginFormTarget(target: string | undefined): target is string {
   return (
     target !== undefined && target.startsWith("/") && !target.startsWith("//")
   );
 }
 
-function writeRejectedSocket(socket: Duplex, status: 400 | 405): void {
-  const message = status === 405 ? "Method Not Allowed" : "Bad Request";
+function writeRejectedSocket(
+  socket: Duplex,
+  status: RejectedSocketStatus,
+): void {
   socket.end(
-    `HTTP/1.1 ${status} ${message}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`,
+    `HTTP/1.1 ${status} ${REJECTED_SOCKET_MESSAGES[status]}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`,
   );
 }
 
@@ -52,6 +80,10 @@ function proxyRequest(args: {
   response: ServerResponse;
   target: URL;
 }): void {
+  if (isBrowserRequest(args.request.headers)) {
+    args.response.writeHead(403).end();
+    return;
+  }
   if (!isOriginFormTarget(args.request.url)) {
     args.response.writeHead(400).end();
     return;
@@ -97,6 +129,10 @@ function proxyUpgrade(args: {
   request: IncomingMessage;
   target: URL;
 }): void {
+  if (isBrowserRequest(args.request.headers)) {
+    writeRejectedSocket(args.clientSocket, 403);
+    return;
+  }
   if (!isOriginFormTarget(args.request.url)) {
     writeRejectedSocket(args.clientSocket, 400);
     return;

--- a/apps/host-daemon/src/machine-auth-proxy.ts
+++ b/apps/host-daemon/src/machine-auth-proxy.ts
@@ -47,6 +47,57 @@ export function isBrowserRequest(headers: IncomingHttpHeaders): boolean {
   return BROWSER_REQUEST_HEADERS.some((name) => headers[name] !== undefined);
 }
 
+// The only authorities that reach this proxy legitimately. It binds 127.0.0.1
+// and hands out `http://127.0.0.1:<port>`, so every real caller sends one of
+// these.
+const LOOPBACK_AUTHORITY_HOSTNAMES = new Set([
+  "127.0.0.1",
+  "localhost",
+  "[::1]",
+]);
+
+function parseHostAuthority(
+  host: string,
+): { hostname: string; port: string } | null {
+  try {
+    const url = new URL(`http://${host}`);
+    return url.username.length === 0 &&
+      url.password.length === 0 &&
+      url.pathname === "/" &&
+      url.search.length === 0 &&
+      url.hash.length === 0
+      ? { hostname: url.hostname, port: url.port }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether the request's `Host` is this proxy's own loopback authority.
+ *
+ * A page on a public hostname that DNS-rebinds to 127.0.0.1 reaches this socket
+ * carrying that public name in `Host`. {@link isBrowserRequest} cannot see it:
+ * `http://rebind.example` is not a potentially trustworthy URL, so Chromium
+ * sends no `Sec-Fetch-*`, and a `no-cors` GET sends no `Origin` either.
+ */
+export function isProxyLoopbackAuthority(
+  host: string | undefined,
+  boundPort: number,
+): boolean {
+  if (host === undefined) {
+    return false;
+  }
+  const parsed = parseHostAuthority(host);
+  if (parsed === null) {
+    return false;
+  }
+  const hostPort = parsed.port.length > 0 ? Number(parsed.port) : 80;
+  return (
+    hostPort === boundPort && LOOPBACK_AUTHORITY_HOSTNAMES.has(parsed.hostname)
+  );
+}
+
 function isOriginFormTarget(target: string | undefined): target is string {
   return (
     target !== undefined && target.startsWith("/") && !target.startsWith("//")
@@ -75,12 +126,17 @@ function upstreamHeaders(
 }
 
 function proxyRequest(args: {
+  boundPort: number | null;
   machineCredential: string;
   request: IncomingMessage;
   response: ServerResponse;
   target: URL;
 }): void {
-  if (isBrowserRequest(args.request.headers)) {
+  if (
+    args.boundPort === null ||
+    isBrowserRequest(args.request.headers) ||
+    !isProxyLoopbackAuthority(args.request.headers.host, args.boundPort)
+  ) {
     args.response.writeHead(403).end();
     return;
   }
@@ -123,13 +179,18 @@ function proxyRequest(args: {
 }
 
 function proxyUpgrade(args: {
+  boundPort: number | null;
   clientSocket: Duplex;
   head: Buffer;
   machineCredential: string;
   request: IncomingMessage;
   target: URL;
 }): void {
-  if (isBrowserRequest(args.request.headers)) {
+  if (
+    args.boundPort === null ||
+    isBrowserRequest(args.request.headers) ||
+    !isProxyLoopbackAuthority(args.request.headers.host, args.boundPort)
+  ) {
     writeRejectedSocket(args.clientSocket, 403);
     return;
   }
@@ -183,8 +244,12 @@ export async function startMachineAuthProxy(
     );
   }
   const sockets = new Set<Socket>();
+  // Read at request time, so the handlers see the port the socket actually
+  // bound rather than the (possibly zero) requested one.
+  let boundPort: number | null = null;
   const server = http.createServer((request, response) =>
     proxyRequest({
+      boundPort,
       machineCredential: options.machineCredential,
       request,
       response,
@@ -194,6 +259,7 @@ export async function startMachineAuthProxy(
   server.on("connect", (_request, socket) => writeRejectedSocket(socket, 405));
   server.on("upgrade", (request, socket, head) =>
     proxyUpgrade({
+      boundPort,
       clientSocket: socket,
       head,
       machineCredential: options.machineCredential,
@@ -220,10 +286,12 @@ export async function startMachineAuthProxy(
     // Accepted trade-off: any same-user local process can use this proxy while
     // the daemon runs. It is restricted to one server origin and exposes no
     // durable credential that can be exfiltrated from an agent environment.
+    // Browsed pages are NOT included in that trade: they are rejected above.
     server.listen(options.port ?? 0, LOOPBACK_HOST);
   });
 
   const address = server.address() as AddressInfo;
+  boundPort = address.port;
   return {
     serverUrl: `http://${LOOPBACK_HOST}:${address.port}`,
     async close(): Promise<void> {


### PR DESCRIPTION
> [!CAUTION]
> **DO NOT MERGE before the `/api/v1/*` origin guard in #1531 lands.**
>
> This change makes a **second bb server's REST API reachable from a browsed page**, and nothing rejects the request. `apps/server/src/server.ts` applies `browserRequestProblem` to `/ws`, `/ws/terminals/:id`, and routes in `plugins.ts` and `files.ts`, but `/api/v1/*` has only `cors()` — which decides whether to echo `Access-Control-Allow-Origin` and never rejects. A `no-cors` POST with `content-type: text/plain` skips the preflight and the handler runs.
>
> The **attached** instance's port is reserved and is not affected. The hole is a **second** instance — a dev instance running alongside the packaged app, which is the everyday bb-developer setup — whose port no reserved list can name. Before this change the exact-origin rule blocked that cross-port request outright, so this is a regression introduced here.
>
> It is not fixed in this PR deliberately: `/api/v1/*` touches every API route and has connect-tunnel and public-share paths that cannot be verified from this PR's test surface. Guessing there would be worse than a clear blocker. See the coverage table below and #1531.

## Summary

A page served from one localhost port could not open a WebSocket to a second localhost port in bb's in-app browser. The page shell loaded, but live data stayed pending forever. The same URL worked in Chrome and Safari.

**Cause.** It is not a CSP, a certificate, a proxy, or a permission handler. The in-app browser has no CSP injection and no proxy. The single enforcement point is `session.webRequest.onBeforeRequest` in `apps/desktop/src/desktop-browser-view.ts`, which calls `shouldBlockBrowserRequest`. For any non-main-frame request to a loopback host, that function required the target's local-origin key to equal the committed main frame's key exactly. The key includes the port (`local|127.0.0.1|3009`), so `ws://127.0.0.1:3210` never matched `http://127.0.0.1:3009` and Chromium cancelled the handshake. Vite HMR was unaffected because it uses the page's own port.

**Fix.** The firewall exists to keep browsed pages away from bb's own loopback services and from the user's LAN. This change names those bb ports instead of guessing them from the page's port:

- `shouldBlockBrowserRequest` takes `reservedLoopbackPorts`. A committed loopback page may now reach other loopback ports, except the reserved ones.
- `resolveReservedLoopbackPorts` assembles that list: the packaged host-daemon port always, plus the local bb server port and the host-daemon port the attached server reports. The reported daemon port is recorded only when the attached server runs on this machine's loopback, because a remote server reports its own machine's port.
- The list is read per request, since the local runtime and its host-daemon port attach after the browser view manager is created.

**Trade-off a reader should not have to work out.** A user's own service on a reserved port is now unreachable from the in-app browser. The packaged ports (38886, 38887) are held back even when no bb server is listening on them. That is the correct trade: a browsed page reaching bb is far worse than a browsed page missing one port.

Nothing else moves. `webSecurity`, `sandbox`, `contextIsolation`, and `allowRunningInsecureContent` are untouched. The permission handlers are untouched. Remote origins still reach no loopback port: a page whose main frame is not loopback has a null local-origin key and is blocked before the port check. Private and LAN hosts stay blocked outright.

**Found by audit, not by review.** The second commit closes a gap I found auditing my own change, before Slop Cop reported: `currentLocalHostDaemonPort` was populated only by the first successful `/api/v1/system/config` fetch and cleared by `stopSystemConfigSync`, so the host daemon's local API was unreserved during that window. Reserving the packaged constant unconditionally closes it, and the assembly moved into a pure function so the window is covered by a test.

**Review findings.** Slop Cop found three ways the relaxed firewall still let a page reach bb. All three were confirmed in the code and fixed:

- A remote target set the local host-daemon port to `null` while the local runtime and its daemon kept running (`setActiveServerTarget` never stops the runtime). Only a loopback server now writes that port, and only the local runtime stopping clears it.
- The dev bb app window loads from a loopback Vite server bb owns, which no server URL or daemon port named. `resolveReservedLoopbackPorts` now reserves the app window URL's port.
- The host daemon's machine-auth proxy binds a **random** loopback port that no reserved list can name, and stamps every forwarded request with a machine credential. A browsed page could reach it and act through a blind `no-cors` request whose response CORS hides. The proxy now rejects browser-originated requests: `Origin` covers writes and WebSocket handshakes, `Sec-Fetch-Site` covers the `no-cors` GET that sends no `Origin`. `Sec-Fetch-Mode` is deliberately excluded — Node's own `fetch` sends it, so keying on it rejected the runtime processes the proxy exists to serve. No `HOST_DAEMON_PROTOCOL_VERSION` bump: the proxy is a local endpoint for spawned runtime processes, not the server↔daemon channel, and no field on that channel changed.

**Second review pass.** A forced re-review of the pushed SHA found two more, both confirmed and fixed:

- The proxy's header check treated a missing `Origin` and `Sec-Fetch-Site` as proof of a trusted caller. A page on a public hostname that DNS-rebinds to `127.0.0.1` sends neither, because `http://rebind.example` is not a potentially trustworthy URL — so Chromium omits `Sec-Fetch-*`, and a `no-cors` GET omits `Origin`. The proxy now also requires the request's `Host` to be its own loopback authority.
- The reserved set named only the packaged daemon port until the first system-config fetch landed, and that fetch can fail permanently. `ReservedLoopbackPorts` is now `known | pending`; cross-port loopback stays closed while a local runtime is up whose daemon port bb cannot name, and `BB_HOST_DAEMON_PORT` is read directly (set for every dev instance and for a configured production deployment). Same-origin subresources keep working while pending, so a restored tab still renders.

**Third review pass.** One more, confirmed and fixed: a second bb daemon on the machine (a dev instance alongside the packaged app) sits on a port the desktop cannot enumerate, and its local API only *set* CORS headers rather than rejecting. A `no-cors` POST with a simple content type skips the preflight and runs `/open-in-target` while the page never reads the reply. The allow predicate the CORS callback already computed is now enforced as a request guard. This one is a genuine regression from the relaxation, since the old exact-origin rule blocked the cross-port request outright.

**Not fixed here, filed as #1530.** The desktop firewall classifies the URL host, not the resolved address, so a public name resolving to loopback bypasses it for every loopback service. That branch already allowed public hostnames before this change, so it is not a regression from it. #1530 also carries SlopCop's stronger suggestion of an unguessable capability in the proxy URL, which changes what `BB_SERVER_URL` hands every runtime process and is a wider blast radius than this PR should carry.

## Loopback service coverage

Three review passes each found another service the old exact-origin rule protected by accident. Rather than wait for a fourth, here is every loopback listener a bb machine can run, found by searching for listeners (`.listen(`, `serve(`, `createServer(`) across `apps/`, `packages/`, and `plugins/` rather than from memory.

| Service | Where it binds | What stops a browsed page reaching it |
|---|---|---|
| bb server (attached instance) | `apps/server/src/start-server.ts` | **Reserved port** (`builtinServerUrl`, attached runtime URL). Plus an `Origin` check on `/ws` and `/ws/terminals/:id`. |
| Host daemon local API (attached instance) | `apps/host-daemon/src/local-api.ts` | **Reserved port** (packaged constant, `BB_HOST_DAEMON_PORT`, fetched value), **and** an `Origin` allowlist enforced as a request guard (this PR). |
| Machine-auth proxy | `apps/host-daemon/src/machine-auth-proxy.ts` | **Cannot be reserved** — random port. `Origin` + `Sec-Fetch-Site` check **and** a `Host` authority check (this PR). Injects a machine credential, so this is the highest-authority service on the list. |
| ACP dynamic tool bridge | `packages/agent-runtime/src/acp/bridge/bridge.ts` | **Cannot be reserved** — random port. Protected by an unguessable 256-bit token required per request (`bridge.ts:282`), on a newline-JSON protocol an HTTP request cannot satisfy. This is the capability-token control SlopCop recommended, already in place here. |
| bb app Vite dev server | dev only, `apps/app/vite.dev.config.ts` | **Reserved port** via `appWindowUrl` (this PR), when it is the window the desktop loaded. |
| **Second bb server** (dev instance alongside the packaged app) | same as above | **Nothing.** `/api/v1/*` has `cors()` but no request-rejecting origin guard. Filed as #1531. |
| **Mock CLI traffic proxy** | `packages/agent-runtime/src/claude-code/bridge/mock-cli-traffic-proxy.ts` | **Nothing**, but it injects no credential (`rewriteHeaders` forwards only what the caller sent), so it carries no ambient authority. Off by default behind the `claudeCodeMockCliTraffic` experiment. Filed as #1531. |
| Second host daemon local API | same as above | The `Origin` guard added in this PR, which is per-service and so covers every instance. |
| Second machine-auth proxy / ACP bridge | same as above | Their guards are per-service and cover every instance. |

**What could not be enumerated.** Any *second* bb instance: it is started outside the desktop process and reports its ports to nobody, so no reserved list can name it. That is precisely why the services themselves are guarded rather than their ports listed — a guard covers every instance, a port list covers one. The two rows above with no control are the gap that remains, both filed as #1531 with the reason each was too wide for this PR.

Not included: `apps/connect/scripts/spike-origin.mts`, `apps/desktop/scripts/smoke-packaged-app.mjs`, `packages/bb-app/scripts/smoke-tarball.mjs`, `scripts/bb-cloud-dev.mjs`, and `packages/scripts/src/commands/run-dev.ts` (which binds only to probe a port, then closes). None run as part of a user's bb.

## Should this have been two pull requests?

**Yes — service guards first, the firewall relaxation second.** Recording the assessment rather than splitting now, since splitting mid-review restarts the review passes that produced the guards.

The case for splitting is that the two halves have different revert semantics. The guards stand on their own: rejecting a foreign browser origin at the host-daemon local API, or a rebound `Host` at the machine-auth proxy, is correct whether or not the firewall is ever relaxed. The relaxation is the risky half. As one PR, reverting the bug fix also reverts the hardening — exactly backwards, since a revert would most likely be prompted by a security concern. It would also bisect more clearly, and each guard could be verified against its own service without the reviewer holding the firewall change in mind.

The case against is that the guards would land with no observable behavior change and no evident motivation; the reason each is needed is that the relaxation removes the accidental protection. That is a commit-message problem, not a correctness one, and the coverage table above is the artifact that would carry over either way.

One honest caveat: the split is **not** clean along the existing commits. Commits 3 and 4 each mix relaxation-side fixes (reserved-port assembly, pending state) with service-side guards (proxy `Origin`, proxy `Host`), so a split would need re-partitioning rather than a cherry-pick. If a reviewer wants it split, that is the cost.

## Testing

**Real reproduction, before the fix.** A harness drove the production `createDesktopBrowserViewManager` (bundled from source with esbuild) inside a real Electron 41 process under Xvfb, against three loopback servers: a page server on `127.0.0.1:3009` that also serves a same-port WebSocket, a WebSocket backend on `127.0.0.1:3210`, and a stand-in bb service. The page opened all three sockets and reported each verdict back to its own origin.

```
[same-port-ws] connection accepted
[report] same-port-open ok
[report] cross-port-error error        <- the bug; port 3210 never saw a connection
```

**Control, same page in a plain Chromium window** (identical `webPreferences`, no bb firewall):

```
[same-port-ws] connection accepted
[cross-port-ws] connection accepted
[report] same-port-open ok
[report] cross-port-open ok
```

That pins the cancel on bb's `onBeforeRequest` handler, not on Chromium.

**After the fix, same harness, reserved ports supplied:**

```
[same-port-ws] connection accepted
[cross-port-ws] connection accepted    <- fixed; the backend accepted the socket
[report] same-port-open ok
[report] cross-port-open ok
[report] bb-port-error error           <- reserved port still unreachable
```

The reserved-port server logged no connection. Re-running the same binary with an empty reserved list let that socket through (`[bb-port-ws] connection accepted`), which shows the reserved list is what holds it back.

**The unreservable proxy port.** The same page fired blind `no-cors` probes at an unreserved loopback port, standing in for the machine-auth proxy's random port:

```
[proxy-stand-in] GET  guard=REJECT via=sec-fetch-site
[proxy-stand-in] POST guard=REJECT via=origin,sec-fetch-site
```

Both reach the port under the relaxed firewall, and both are caught by the daemon-side guard. Real Chromium marks the `no-cors` GET with `Sec-Fetch-Site` even though it sends no `Origin`.

**DNS rebinding.** With `--host-resolver-rules="MAP rebind.example 127.0.0.1"`, the rebound request carries neither header, so the header check alone cannot see it:

```
[proxy-stand-in] GET host=rebind.example:41999 guard=ALLOW via=none
```

Re-run against the **real** proxy (bundled from `apps/host-daemon/src`, fronting an upstream that logs the credential), no probe reaches upstream, while a Node client still does:

```
[node-client] status=200
[upstream] REACHED POST /api/v1/threads credential=bbcm_repro
```

**Automated.**

- `apps/desktop/test/desktop-browser-policy.test.ts`: cross-origin loopback requests now pass; reserved ports are blocked under any loopback name, scheme, and with a default port; a page served from a reserved port still loads its own subresources; `loopbackServicePort` unit tests; and `resolveReservedLoopbackPorts` tests covering the startup window (a null, not-yet-fetched daemon port must still reserve the packaged port), the dev instance, and a remote-server attachment.
- `apps/desktop/test/desktop-browser-view-manager.test.ts`: a manager-level regression test through the real `onBeforeRequest` wiring, covering the cross-port WebSocket, the reserved ports, and a public page that still reaches no loopback port.
- `apps/host-daemon/src/machine-auth-proxy.test.ts`: browser-originated HTTP requests and WebSocket handshakes are rejected without reaching upstream, and a Node `fetch` caller still gets through.
- `apps/host-daemon/src/machine-auth-proxy.test.ts`: browser-originated HTTP requests, browser WebSocket handshakes, and a rebound public `Host` are all rejected without reaching upstream, while a Node `fetch` caller and the three real loopback authorities still get through.
- `pnpm exec turbo run typecheck --filter=@bb/desktop --filter=@bb/host-daemon` passes.
- `apps/host-daemon/src/local-api.test.ts`: a foreign and a DNS-rebound browser origin are rejected before `/open-in-target` runs, while the bb app's own origin and a caller sending no `Origin` still succeed. Verified the test fails without the guard (`expected 200 to be 403`), so it protects the bug rather than passing by construction.
- `pnpm exec turbo run test --filter=@bb/desktop --filter=@bb/host-daemon --force` passes: 245 desktop tests, 549 host-daemon tests.

Fixes #1452

> AGENT GENERATED: by Claude Opus 5
