### PR TITLE
[issue sweep] Report provider CLI update failures

### DIFF
--- a/apps/app/src/components/onboarding/OnboardingHost.test.tsx
+++ b/apps/app/src/components/onboarding/OnboardingHost.test.tsx
@@ -48,6 +48,7 @@ beforeEach(() => {
   mocks.useHostProviderCliStatus.mockReturnValue({ data: undefined });
   mocks.usePrimaryHost.mockReturnValue({ id: "host-1" });
   mocks.useProviderCliInstallRunner.mockReturnValue({
+    failuresByJobKey: new Map(),
     queuedJobKeys: new Set(),
     runningJobKey: null,
     startInstall: vi.fn(),

--- a/apps/app/src/components/provider-cli/provider-cli-install-store.ts
+++ b/apps/app/src/components/provider-cli/provider-cli-install-store.ts
@@ -24,6 +24,11 @@ export interface ProviderCliInstallJob {
   issue: ProviderCliActionableIssue;
 }
 
+export interface ProviderCliInstallFailure {
+  issueFingerprint: string;
+  logDialogState: ProviderCliInstallLogDialogState;
+}
+
 export interface ProviderCliInstallSnapshot {
   /** The job currently executing on a host, or null when nothing is running. */
   runningJobKey: string | null;
@@ -31,6 +36,8 @@ export interface ProviderCliInstallSnapshot {
   queuedJobKeys: ReadonlySet<string>;
   /** The failure log a user opened from a toast, or null when closed. */
   logDialogState: ProviderCliInstallLogDialogState | null;
+  /** The latest failed attempt for each provider row. */
+  failuresByJobKey: ReadonlyMap<string, ProviderCliInstallFailure>;
 }
 
 const PROVIDER_CLI_TITLE_TEMPLATES = {
@@ -48,11 +55,16 @@ const PROVIDER_CLI_TITLE_TEMPLATES = {
 >;
 
 const EMPTY_QUEUED_JOB_KEYS: ReadonlySet<string> = new Set();
+const EMPTY_FAILURES_BY_JOB_KEY: ReadonlyMap<
+  string,
+  ProviderCliInstallFailure
+> = new Map();
 
 const INITIAL_SNAPSHOT: ProviderCliInstallSnapshot = {
   runningJobKey: null,
   queuedJobKeys: EMPTY_QUEUED_JOB_KEYS,
   logDialogState: null,
+  failuresByJobKey: EMPTY_FAILURES_BY_JOB_KEY,
 };
 
 // Module-level, not component state: a provider CLI install keeps running (and
@@ -141,6 +153,7 @@ function getProviderCliTitle(args: {
 }
 
 function showProviderCliInstallFailureToast(args: {
+  jobKey: string;
   issue: ProviderCliActionableIssue;
   log: string;
   message: string;
@@ -152,6 +165,12 @@ function showProviderCliInstallFailureToast(args: {
     message: args.message,
     title: getProviderCliTitle({ issue: args.issue, phase: "log" }),
   };
+  const failuresByJobKey = new Map(snapshot.failuresByJobKey);
+  failuresByJobKey.set(args.jobKey, {
+    issueFingerprint: args.issue.fingerprint,
+    logDialogState,
+  });
+  setSnapshot({ failuresByJobKey });
 
   appToast.error(getProviderCliTitle({ issue: args.issue, phase: "failure" }), {
     id: args.toastId,
@@ -168,7 +187,9 @@ function runInstall(job: ProviderCliInstallJob): void {
   const { action, provider } = issue;
   const jobKey = providerCliJobKey(hostId, provider);
 
-  setSnapshot({ runningJobKey: jobKey });
+  const failuresByJobKey = new Map(snapshot.failuresByJobKey);
+  failuresByJobKey.delete(jobKey);
+  setSnapshot({ failuresByJobKey, runningJobKey: jobKey });
   const failureToastId = `provider-cli-install-failure:${jobKey}`;
   let installLogChunks = [`$ ${action.command}\n`];
   let completedEvent: ProviderCliInstallCompletedEvent | null = null;
@@ -214,6 +235,7 @@ function runInstall(job: ProviderCliInstallJob): void {
           ? exitDescription(completedEvent)
           : "Command finished without reporting success.");
       showProviderCliInstallFailureToast({
+        jobKey,
         issue,
         log: installLogChunks.join(""),
         message: failureMessage,
@@ -224,6 +246,7 @@ function runInstall(job: ProviderCliInstallJob): void {
       const message = error instanceof Error ? error.message : String(error);
       installLogChunks.push(`\n${message}\n`);
       showProviderCliInstallFailureToast({
+        jobKey,
         issue,
         log: installLogChunks.join(""),
         message,

--- a/apps/app/src/components/provider-cli/provider-cli-install-store.ts
+++ b/apps/app/src/components/provider-cli/provider-cli-install-store.ts
@@ -19,6 +19,11 @@ type ProviderCliInstallCompletedEvent = Extract<
 type ProviderCliTitlePhase = "failure" | "log";
 type ProviderCliTitleTemplate = (displayName: string) => string;
 
+export const PROVIDER_CLI_FAILURE_LOG_MAX_BYTES = 128 * 1024;
+export const PROVIDER_CLI_FAILURE_MAX_ENTRIES = 32;
+const PROVIDER_CLI_FAILURE_LOG_TRUNCATION_MARKER =
+  "\n\n… provider update output truncated …\n\n";
+
 export interface ProviderCliInstallJob {
   hostId: string;
   issue: ProviderCliActionableIssue;
@@ -152,6 +157,47 @@ function getProviderCliTitle(args: {
   );
 }
 
+function truncateProviderCliFailureLog(log: string): string {
+  const encoder = new TextEncoder();
+  const encodedLog = encoder.encode(log);
+  if (encodedLog.byteLength <= PROVIDER_CLI_FAILURE_LOG_MAX_BYTES) {
+    return log;
+  }
+
+  const encodedMarker = encoder.encode(
+    PROVIDER_CLI_FAILURE_LOG_TRUNCATION_MARKER,
+  );
+  const outputBudget =
+    PROVIDER_CLI_FAILURE_LOG_MAX_BYTES - encodedMarker.byteLength;
+  const headBudget = Math.floor(outputBudget / 2);
+  const tailBudget = outputBudget - headBudget;
+  const head = new TextDecoder()
+    .decode(encodedLog.slice(0, headBudget))
+    .replace(/\uFFFD$/u, "");
+  const tail = new TextDecoder()
+    .decode(encodedLog.slice(-tailBudget))
+    .replace(/^\uFFFD/u, "");
+  return `${head}${PROVIDER_CLI_FAILURE_LOG_TRUNCATION_MARKER}${tail}`;
+}
+
+function setProviderCliInstallFailure(args: {
+  failure: ProviderCliInstallFailure;
+  jobKey: string;
+}): void {
+  const failuresByJobKey = new Map(snapshot.failuresByJobKey);
+  // Refresh an existing key's insertion order so eviction stays least-recent.
+  failuresByJobKey.delete(args.jobKey);
+  failuresByJobKey.set(args.jobKey, args.failure);
+  while (failuresByJobKey.size > PROVIDER_CLI_FAILURE_MAX_ENTRIES) {
+    const oldest = failuresByJobKey.keys().next();
+    if (oldest.done) {
+      break;
+    }
+    failuresByJobKey.delete(oldest.value);
+  }
+  setSnapshot({ failuresByJobKey });
+}
+
 function showProviderCliInstallFailureToast(args: {
   jobKey: string;
   issue: ProviderCliActionableIssue;
@@ -161,16 +207,17 @@ function showProviderCliInstallFailureToast(args: {
 }): void {
   const logDialogState: ProviderCliInstallLogDialogState = {
     displayName: args.issue.status.displayName,
-    log: args.log,
+    log: truncateProviderCliFailureLog(args.log),
     message: args.message,
     title: getProviderCliTitle({ issue: args.issue, phase: "log" }),
   };
-  const failuresByJobKey = new Map(snapshot.failuresByJobKey);
-  failuresByJobKey.set(args.jobKey, {
-    issueFingerprint: args.issue.fingerprint,
-    logDialogState,
+  setProviderCliInstallFailure({
+    jobKey: args.jobKey,
+    failure: {
+      issueFingerprint: args.issue.fingerprint,
+      logDialogState,
+    },
   });
-  setSnapshot({ failuresByJobKey });
 
   appToast.error(getProviderCliTitle({ issue: args.issue, phase: "failure" }), {
     id: args.toastId,

--- a/apps/app/src/components/provider-cli/provider-cli-install.test.tsx
+++ b/apps/app/src/components/provider-cli/provider-cli-install.test.tsx
@@ -297,24 +297,38 @@ describe("useProviderCliInstallRunner", () => {
     expect(remounted.result.current.runningJobKey).toBe("host_1:claudeCode");
   });
 
-  it("reports a failed install with a log the user can still open", async () => {
+  it("keeps a failed install and its stderr available for a retry", async () => {
     const { result } = renderRunner();
+    const issue = issueForProvider("codex");
 
     act(() => {
       result.current.startInstall({
         hostId: "host_1",
-        issue: issueForProvider("codex"),
+        issue,
       });
     });
 
     await act(async () => {
-      completeInstall(installAt(0), {
-        type: "completed",
-        provider: "codex",
-        success: false,
-        exitCode: 1,
-        signal: null,
-      });
+      installAt(0).resolve([
+        {
+          type: "started",
+          provider: "codex",
+          command: "codex update",
+        },
+        {
+          type: "output",
+          provider: "codex",
+          stream: "stderr",
+          text: "permission denied\n",
+        },
+        {
+          type: "completed",
+          provider: "codex",
+          success: false,
+          exitCode: 1,
+          signal: null,
+        },
+      ]);
     });
 
     expect(appToastMock.error).toHaveBeenCalledWith(
@@ -324,5 +338,17 @@ describe("useProviderCliInstallRunner", () => {
         action: expect.objectContaining({ label: "View log" }),
       }),
     );
+    expect(result.current.failuresByJobKey.get("host_1:codex")).toMatchObject({
+      issueFingerprint: issue.fingerprint,
+      logDialogState: {
+        message: "Command exited with code 1",
+        log: "$ codex update\npermission denied\n",
+      },
+    });
+
+    act(() => {
+      result.current.startInstall({ hostId: "host_1", issue });
+    });
+    expect(result.current.failuresByJobKey.has("host_1:codex")).toBe(false);
   });
 });

--- a/apps/app/src/components/provider-cli/provider-cli-install.test.tsx
+++ b/apps/app/src/components/provider-cli/provider-cli-install.test.tsx
@@ -20,6 +20,8 @@ import {
   useProviderCliInstallRunner,
 } from "./provider-cli-install";
 import {
+  PROVIDER_CLI_FAILURE_LOG_MAX_BYTES,
+  PROVIDER_CLI_FAILURE_MAX_ENTRIES,
   registerProviderCliInstallQueryClient,
   resetProviderCliInstallStoreForTests,
 } from "./provider-cli-install-store";
@@ -350,5 +352,62 @@ describe("useProviderCliInstallRunner", () => {
       result.current.startInstall({ hostId: "host_1", issue });
     });
     expect(result.current.failuresByJobKey.has("host_1:codex")).toBe(false);
+  });
+
+  it("bounds retained failures by entry count and log bytes", async () => {
+    const { result } = renderRunner();
+    const issue = issueForProvider("codex");
+
+    for (let index = 0; index <= PROVIDER_CLI_FAILURE_MAX_ENTRIES; index += 1) {
+      const hostId = `host_${index}`;
+      act(() => {
+        result.current.startInstall({ hostId, issue });
+      });
+      const output =
+        index === PROVIDER_CLI_FAILURE_MAX_ENTRIES
+          ? `first line\n${"x".repeat(PROVIDER_CLI_FAILURE_LOG_MAX_BYTES * 2)}\nlast line\n`
+          : "failed\n";
+      await act(async () => {
+        installAt(index).resolve([
+          {
+            type: "started",
+            provider: "codex",
+            command: "codex update",
+          },
+          {
+            type: "output",
+            provider: "codex",
+            stream: "stderr",
+            text: output,
+          },
+          {
+            type: "completed",
+            provider: "codex",
+            success: false,
+            exitCode: 1,
+            signal: null,
+          },
+        ]);
+      });
+    }
+
+    expect(result.current.failuresByJobKey.size).toBe(
+      PROVIDER_CLI_FAILURE_MAX_ENTRIES,
+    );
+    expect(result.current.failuresByJobKey.has("host_0:codex")).toBe(false);
+    const newestFailure = result.current.failuresByJobKey.get(
+      `host_${PROVIDER_CLI_FAILURE_MAX_ENTRIES}:codex`,
+    );
+    if (newestFailure === undefined) {
+      throw new Error("Expected the newest provider failure to be retained");
+    }
+    expect(newestFailure.logDialogState.log).toContain(
+      "provider update output truncated",
+    );
+    expect(newestFailure.logDialogState.log).toContain("$ codex update");
+    expect(newestFailure.logDialogState.log).toContain("last line");
+    expect(
+      new TextEncoder().encode(newestFailure.logDialogState.log).byteLength,
+    ).toBeLessThanOrEqual(PROVIDER_CLI_FAILURE_LOG_MAX_BYTES);
   });
 });

--- a/apps/app/src/components/provider-cli/provider-cli-install.tsx
+++ b/apps/app/src/components/provider-cli/provider-cli-install.tsx
@@ -135,6 +135,7 @@ export function useProviderCliInstallRunner() {
   );
 
   return {
+    failuresByJobKey: snapshot.failuresByJobKey,
     queuedJobKeys: snapshot.queuedJobKeys,
     runningJobKey: snapshot.runningJobKey,
     startInstall: startProviderCliInstall,

--- a/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
@@ -19,6 +19,10 @@ import type {
 } from "@/components/provider-cli/provider-cli-install";
 import { useProviderCliInstallRunner } from "@/components/provider-cli/provider-cli-install";
 import { resetAppUpdateCheckStoreForTests } from "@/components/settings/app-update-check-store";
+import {
+  getProviderCliInstallSnapshot,
+  resetProviderCliInstallStoreForTests,
+} from "@/components/provider-cli/provider-cli-install-store";
 import { sdk } from "@/lib/sdk";
 import { useDesktopUpdateInfo } from "@/hooks/useDesktopUpdateInfo";
 import {
@@ -71,6 +75,7 @@ vi.mock("@/components/provider-cli/provider-cli-install", async (original) => {
   return {
     ...actual,
     useProviderCliInstallRunner: vi.fn(() => ({
+      failuresByJobKey: new Map(),
       queuedJobKeys: new Set<string>(),
       runningJobKey: null,
       startInstall: startInstallMock,
@@ -230,6 +235,7 @@ const useProviderCliInstallRunnerMock = vi.mocked(useProviderCliInstallRunner);
 
 beforeEach(() => {
   useProviderCliInstallRunnerMock.mockReturnValue({
+    failuresByJobKey: new Map(),
     queuedJobKeys: new Set<string>(),
     runningJobKey: null,
     startInstall: startInstallMock,
@@ -239,6 +245,7 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   resetAppUpdateCheckStoreForTests();
+  resetProviderCliInstallStoreForTests();
   vi.clearAllMocks();
 });
 
@@ -363,6 +370,7 @@ describe("UpdatesSettingsSection", () => {
       }),
     );
     useProviderCliInstallRunnerMock.mockReturnValue({
+      failuresByJobKey: new Map(),
       queuedJobKeys: new Set(["host_1:claudeCode"]),
       runningJobKey: "host_1:codex",
       startInstall: startInstallMock,
@@ -374,6 +382,50 @@ describe("UpdatesSettingsSection", () => {
     expect(screen.getByText("2 updates in progress")).toBeDefined();
     expect(screen.getByText("Running…")).toBeDefined();
     expect(screen.getByText("Queued")).toBeDefined();
+  });
+
+  it("keeps a provider update failure and its command log on the row", () => {
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    const host = makeHost({ id: "host_1", name: "workstation" });
+    const issue = makeUpdateIssue({ provider: "claudeCode" });
+    const logDialogState = {
+      displayName: "Claude Code",
+      log: "$ claude update\npermission denied\n",
+      message: "Command exited with code 1",
+      title: "Claude Code update log",
+    };
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        machines: [makeMachine({ host, issues: [issue] })],
+      }),
+    );
+    useProviderCliInstallRunnerMock.mockReturnValue({
+      failuresByJobKey: new Map([
+        [
+          "host_1:claudeCode",
+          { issueFingerprint: issue.fingerprint, logDialogState },
+        ],
+      ]),
+      queuedJobKeys: new Set(),
+      runningJobKey: null,
+      startInstall: startInstallMock,
+    });
+
+    renderSection();
+
+    expect(screen.getByText("Failed")).toBeDefined();
+    expect(screen.getByRole("alert").textContent).toBe(
+      "Command exited with code 1",
+    );
+    expect(screen.getByRole("button", { name: "Retry" })).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "View log" }));
+    expect(getProviderCliInstallSnapshot().logDialogState).toEqual(
+      logDialogState,
+    );
   });
 
   it("forces the web update check and shows the upgrade command inline", async () => {

--- a/apps/app/src/components/settings/UpdatesSettingsSection.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.tsx
@@ -17,7 +17,11 @@ import {
   type ProviderCliActionableIssue,
   type ProviderCliIssue,
 } from "@/components/provider-cli/provider-cli-install";
-import { providerCliJobKey } from "@/components/provider-cli/provider-cli-install-store";
+import {
+  openProviderCliInstallLog,
+  providerCliJobKey,
+  type ProviderCliInstallFailure,
+} from "@/components/provider-cli/provider-cli-install-store";
 import {
   getAppUpdateCheckSnapshot,
   startAppUpdateCheck,
@@ -40,6 +44,10 @@ import { openUrlInExternalBrowser } from "@/lib/url-open-routing";
 import { sdk } from "@/lib/sdk";
 
 const CHANGELOG_URL = "https://github.com/get-bb/bb/blob/main/CHANGELOG.md";
+const EMPTY_PROVIDER_CLI_FAILURES: ReadonlyMap<
+  string,
+  ProviderCliInstallFailure
+> = new Map();
 
 /**
  * The rows and the machine bands above them share one text edge: names start
@@ -381,6 +389,7 @@ export interface MachineUpdatesRowsProps {
   machine: UpdateInventoryMachine;
   runningJobKey: string | null;
   queuedJobKeys: ReadonlySet<string>;
+  failuresByJobKey?: ReadonlyMap<string, ProviderCliInstallFailure>;
   retryUpdatePending: boolean;
   onStartInstall: (hostId: string, issue: ProviderCliActionableIssue) => void;
   onRetryDaemonUpdate: (hostId: string) => void;
@@ -489,6 +498,7 @@ export function MachineUpdatesRows({
   machine,
   runningJobKey,
   queuedJobKeys,
+  failuresByJobKey = EMPTY_PROVIDER_CLI_FAILURES,
   retryUpdatePending,
   onStartInstall,
   onRetryDaemonUpdate,
@@ -586,6 +596,12 @@ export function MachineUpdatesRows({
           const jobKey = providerCliJobKey(host.id, provider);
           const running = runningJobKey === jobKey;
           const queued = queuedJobKeys.has(jobKey);
+          const storedFailure = failuresByJobKey.get(jobKey) ?? null;
+          const failure =
+            issue !== null &&
+            storedFailure?.issueFingerprint === issue.fingerprint
+              ? storedFailure
+              : null;
           const actionable =
             issue !== null &&
             hasProviderCliAction(issue) &&
@@ -596,7 +612,11 @@ export function MachineUpdatesRows({
               key={provider}
               indent
               tone={
-                running || queued ? "default" : (state?.rowTone ?? "default")
+                running || queued
+                  ? "default"
+                  : failure !== null
+                    ? "destructive"
+                    : (state?.rowTone ?? "default")
               }
             >
               <RowName
@@ -605,7 +625,9 @@ export function MachineUpdatesRows({
                 latest={issue !== null ? status.latestVersion : null}
               />
               <RowActions>
-                {running ? (
+                {failure !== null ? (
+                  <RowStatus tone="destructive">Failed</RowStatus>
+                ) : running ? (
                   <RowStatus live tone="attention">
                     <span className="inline-flex items-center gap-1.5">
                       <Icon name="Spinner" className="size-3 animate-spin" />
@@ -617,12 +639,29 @@ export function MachineUpdatesRows({
                 ) : state === null ? null : (
                   <RowStatus tone={state.statusTone}>{state.label}</RowStatus>
                 )}
+                {failure !== null ? (
+                  <RowButton
+                    onClick={() =>
+                      openProviderCliInstallLog(failure.logDialogState)
+                    }
+                  >
+                    View log
+                  </RowButton>
+                ) : null}
                 {actionable ? (
                   <RowButton onClick={() => onStartInstall(host.id, issue)}>
-                    {issue.action.label}
+                    {failure === null ? issue.action.label : "Retry"}
                   </RowButton>
                 ) : null}
               </RowActions>
+              {failure !== null ? (
+                <p
+                  role="alert"
+                  className="basis-full text-xs text-destructive-text"
+                >
+                  {failure.logDialogState.message}
+                </p>
+              ) : null}
             </UpdatesRow>
           );
         })
@@ -655,7 +694,7 @@ export function UpdatesSettingsSection() {
     getAppUpdateCheckSnapshot,
   );
   const now = useNow(30_000);
-  const { queuedJobKeys, runningJobKey, startInstall } =
+  const { failuresByJobKey, queuedJobKeys, runningJobKey, startInstall } =
     useProviderCliInstallRunner();
 
   const allActionableIssues: {
@@ -861,6 +900,7 @@ export function UpdatesSettingsSection() {
                 machine={machine}
                 runningJobKey={runningJobKey}
                 queuedJobKeys={queuedJobKeys}
+                failuresByJobKey={failuresByJobKey}
                 retryUpdatePending={
                   retryHostUpdate.isPending &&
                   retryHostUpdate.variables === machine.host.id

--- a/apps/host-daemon/src/command-dispatch.test.ts
+++ b/apps/host-daemon/src/command-dispatch.test.ts
@@ -1405,6 +1405,79 @@ describe("dispatchCommand", () => {
     ]);
   });
 
+  it("reports a successful Claude update as unverified when the pre-update version check fails", async () => {
+    const dataDir = await makeTempDir("bb-command-dispatch-provider-cli-");
+    const manager = new RuntimeManager({
+      createRuntime,
+      dataDir,
+      provisionWorkspace: async () => createWorkspace(),
+    });
+    const getProviderCliStatusForProvider = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(
+        claudeCodeStatus({
+          currentVersion: "2.1.220",
+          latestVersion: "2.1.227",
+        }),
+      );
+
+    const result = await dispatchOnlineRpcCommand(
+      {
+        type: "provider_cli.install",
+        provider: "claudeCode",
+        actionKind: "update",
+      },
+      {
+        dataDir,
+        eventSink: {
+          emit: vi.fn(),
+          flush: vi.fn(async () => undefined),
+        },
+        fetchProjectAttachment: async () => {
+          throw new Error("Unexpected project attachment fetch");
+        },
+        getProviderCliStatusForProvider,
+        runtimeManager: manager,
+        streamProviderCliInstall: () =>
+          createProviderCliInstallEventStream([
+            {
+              type: "started",
+              provider: "claudeCode",
+              command: "claude update",
+            },
+            {
+              type: "completed",
+              provider: "claudeCode",
+              exitCode: 0,
+              signal: null,
+              success: true,
+            },
+          ]),
+        threadStorageRootPath: "/tmp/bb-thread-storage",
+      },
+    );
+
+    expect(getProviderCliStatusForProvider).toHaveBeenCalledTimes(2);
+    expect(result.events).toEqual([
+      expect.objectContaining({ type: "started" }),
+      expect.objectContaining({
+        type: "error",
+        provider: "claudeCode",
+        message: expect.stringContaining(
+          "bb could not read /Users/me/.local/bin/claude's version before the update",
+        ),
+      }),
+      {
+        type: "completed",
+        provider: "claudeCode",
+        exitCode: 0,
+        signal: null,
+        success: false,
+      },
+    ]);
+  });
+
   it("accepts a Claude update that advances when the release channel is unknown", async () => {
     const verification = await runSuccessfulClaudeCodeUpdateVerification({
       before: claudeCodeStatus({

--- a/apps/host-daemon/src/command-dispatch.ts
+++ b/apps/host-daemon/src/command-dispatch.ts
@@ -190,19 +190,32 @@ async function tryGetProviderCliStatusForProvider(
 }
 
 function verifyClaudeCodeUpdateEvents(args: {
-  before: ProviderCliStatus;
+  before: ProviderCliStatus | null;
   after: ProviderCliStatus | null;
   events: ProviderCliInstallEvent[];
 }): ProviderCliInstallEvent[] {
   const completedIndex = args.events.findIndex(
     (event) => event.type === "completed" && event.success,
   );
-  const expectedVersion = args.before.latestVersion;
-  const previousVersion = args.before.currentVersion;
-  const actualVersion = args.after?.currentVersion ?? null;
   if (completedIndex === -1) {
     return args.events;
   }
+  const executable =
+    args.after?.executablePath ??
+    args.before?.executablePath ??
+    args.before?.executableName ??
+    "claude";
+  if (args.before === null) {
+    return failClaudeCodeUpdateVerification({
+      ...args,
+      completedIndex,
+      message: `Claude Code's update command exited successfully, but bb could not read ${executable}'s version before the update. bb cannot confirm that the active executable changed. Run \`claude --version\` and \`claude doctor\` on this machine, then use the command output to update the installation they report.`,
+    });
+  }
+
+  const expectedVersion = args.before.latestVersion;
+  const previousVersion = args.before.currentVersion;
+  const actualVersion = args.after?.currentVersion ?? null;
 
   const validExpectedVersion =
     expectedVersion === null ? null : semver.valid(expectedVersion);
@@ -214,7 +227,11 @@ function verifyClaudeCodeUpdateEvents(args: {
   const canVerifyAdvancement =
     expectedVersion === null && validPreviousVersion !== null;
   if (!hasKnownTarget && !canVerifyAdvancement) {
-    return args.events;
+    return failClaudeCodeUpdateVerification({
+      ...args,
+      completedIndex,
+      message: `Claude Code's update command exited successfully, but bb could not compare ${executable}'s version before and after the update. Run \`claude --version\` and \`claude doctor\` on this machine, then use the command output to update the installation they report.`,
+    });
   }
   const updateVerified =
     validActualVersion !== null &&
@@ -226,24 +243,32 @@ function verifyClaudeCodeUpdateEvents(args: {
     return args.events;
   }
 
-  const executable =
-    args.after?.executablePath ??
-    args.before.executablePath ??
-    args.before.executableName;
   const expectation = hasKnownTarget
     ? `expected ${validExpectedVersion}`
     : `expected a version newer than ${validPreviousVersion}`;
   const message = `Claude Code's update command exited successfully, but ${executable} still reports ${actualVersion ?? "an unknown version"} (${expectation}). The executable may be pinned by PATH or managed by another installer. Run \`claude doctor\` on this machine and update the installation it reports.`;
+  return failClaudeCodeUpdateVerification({
+    ...args,
+    completedIndex,
+    message,
+  });
+}
+
+function failClaudeCodeUpdateVerification(args: {
+  completedIndex: number;
+  events: ProviderCliInstallEvent[];
+  message: string;
+}): ProviderCliInstallEvent[] {
   const verifiedEvents = [...args.events];
-  const completedEvent = verifiedEvents[completedIndex];
+  const completedEvent = verifiedEvents[args.completedIndex];
   if (completedEvent?.type !== "completed") {
     return args.events;
   }
-  verifiedEvents[completedIndex] = { ...completedEvent, success: false };
-  verifiedEvents.splice(completedIndex, 0, {
+  verifiedEvents[args.completedIndex] = { ...completedEvent, success: false };
+  verifiedEvents.splice(args.completedIndex, 0, {
     type: "error",
     provider: "claudeCode",
-    message,
+    message: args.message,
   });
   return verifiedEvents;
 }
@@ -274,7 +299,8 @@ async function installProviderCliOnHost(
       }),
     );
     if (
-      claudeCodeStatusBefore !== null &&
+      command.provider === "claudeCode" &&
+      command.actionKind === "update" &&
       events.some((event) => event.type === "completed" && event.success)
     ) {
       const claudeCodeStatusAfter = await tryGetProviderCliStatusForProvider(

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -36,7 +36,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 117 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 118 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1056,6 +1056,9 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
+  // Version 118 rejects successful provider update results when the daemon
+  // cannot verify a version change. Older daemons can report a no-op Claude
+  // update as successful, so enrolled machines must update for honest results.
   // Version 117 adds thread/context/cleared to the provider event wire model.
   // Version 116 reports provider exits that happen while a turn start is
   // pending. Older daemons can leave the server thread active until the live
@@ -1068,7 +1071,7 @@ describe("host-daemon command schemas", () => {
   // against its Pi provider ladder, so enrolled machines must not run that
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
-  it("uses protocol version 117 for context-cleared provider events", () => {
+  it("uses protocol version 118 for verified provider update results", () => {
     expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(118);
   });
 

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1069,7 +1069,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses protocol version 117 for context-cleared provider events", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(117);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(118);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {


### PR DESCRIPTION
## Summary

- treat a successful Claude update command as failed when bb cannot verify the active version changed
- keep provider update failures on the Updates row with the reason, a retry action, and the complete command log
- bump the host daemon protocol so enrolled machines receive the corrected result semantics

## What a failure looks like

These screenshots come from the real dev app and its full update path. I put an isolated fake `claude` executable first on the dev daemon PATH. I did not mock UI data.

For the zero-exit test, `claude update` exited zero and left version `2.1.220` unchanged. bb read the version again and expected `2.1.231`.

| Failure row | Expanded command log |
| --- | --- |
| <img width="728" src="https://raw.githubusercontent.com/get-bb/bb/screenshots/issue-1490/issue-1490-zero-exit-failure.png" /> | <img width="512" src="https://raw.githubusercontent.com/get-bb/bb/screenshots/issue-1490/issue-1490-zero-exit-log.png" /> |

For the non-zero test, `claude update` wrote `permission denied: cannot replace /opt/claude/bin/claude` to stderr. It then exited with code 1.

| Failure row | Expanded stderr log |
| --- | --- |
| <img width="728" src="https://raw.githubusercontent.com/get-bb/bb/screenshots/issue-1490/issue-1490-nonzero-failure.png" /> | <img width="512" src="https://raw.githubusercontent.com/get-bb/bb/screenshots/issue-1490/issue-1490-nonzero-stderr-log.png" /> |

For comparison, the success test changed the reported version from `2.1.220` to `2.1.231`. The row returned to its normal state.

<img width="728" src="https://raw.githubusercontent.com/get-bb/bb/screenshots/issue-1490/issue-1490-normal-success.png" />

The screenshots live on the throwaway branch `screenshots/issue-1490`. They do not add binary files to this pull request.

## Testing

- reproduced a non-zero update with stderr by injecting `permission denied` and exit code 1; verified the row keeps the failure and log
- reproduced a zero-exit no-op by making the pre-update version check fail and leaving Claude at 2.1.220; verified bb reports an unverified update instead of success
- ran both failures and a successful update through `scripts/bb-dev-app current`; captured the real Updates row and log dialog
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/host-daemon --filter=@bb/host-daemon-contract`
- `pnpm exec turbo run test --filter=@bb/app --force > /tmp/test-1490-app.txt 2>&1`
- `pnpm exec turbo run test --filter=@bb/host-daemon --force > /tmp/test-1490-host-daemon.txt 2>&1`
- `pnpm exec turbo run test --filter=@bb/host-daemon-contract --force > /tmp/test-1490-host-daemon-contract.txt 2>&1`

Fixes #1490

> AGENT GENERATED: by GPT-5
