### PR TITLE
[issue sweep] Show the command for ACP task tool calls

### DIFF
--- a/packages/agent-runtime/src/acp/adapter.test.ts
+++ b/packages/agent-runtime/src/acp/adapter.test.ts
@@ -1175,6 +1175,187 @@ describe("acp adapter event translation", () => {
     ]);
   });
 
+  // Payload shapes below are recorded from `opencode acp` 1.18.18 driven by a
+  // minimal ACP client (see the pull request for the capture). opencode opens
+  // every tool call with an empty `rawInput` and sends the real input on the
+  // next update, so the task row must pick up its command mid-call.
+  it("surfaces an opencode task command once its arguments arrive", () => {
+    const adapter = createCompactingAdapter();
+    startTurn(adapter);
+
+    expect(
+      adapter.translateEvent(
+        updateNotification({
+          sessionUpdate: "tool_call",
+          toolCallId: "call-task",
+          title: "task",
+          kind: "think",
+          status: "pending",
+          locations: [],
+          rawInput: {},
+        }),
+        THREAD_CONTEXT,
+      ),
+    ).toEqual([
+      {
+        type: "item/started",
+        threadId: "",
+        providerThreadId: "",
+        scope: turnScope("turn-1"),
+        item: {
+          type: "toolCall",
+          id: "call-task",
+          tool: "task",
+          status: "pending",
+        },
+      },
+    ]);
+
+    const rawInput = {
+      command: "/review",
+      description: "Report workspace contents",
+      prompt: "Explore the workspace and report what is in it.",
+      subagent_type: "explore",
+    };
+    expect(
+      adapter.translateEvent(
+        updateNotification({
+          sessionUpdate: "tool_call_update",
+          toolCallId: "call-task",
+          status: "in_progress",
+          kind: "think",
+          title: "Report workspace contents",
+          locations: [],
+          rawInput,
+        }),
+        THREAD_CONTEXT,
+      ),
+    ).toEqual([
+      {
+        type: "item/started",
+        threadId: "",
+        providerThreadId: "",
+        scope: turnScope("turn-1"),
+        item: {
+          type: "toolCall",
+          id: "call-task",
+          tool: "Report workspace contents",
+          arguments: rawInput,
+          status: "pending",
+        },
+      },
+    ]);
+
+    // A repeat of the same input must not restate the item again.
+    expect(
+      adapter.translateEvent(
+        updateNotification({
+          sessionUpdate: "tool_call_update",
+          toolCallId: "call-task",
+          status: "in_progress",
+          kind: "think",
+          title: "Report workspace contents",
+          locations: [],
+          rawInput,
+        }),
+        THREAD_CONTEXT,
+      ),
+    ).toEqual([]);
+
+    // opencode's completion carries the output but repeats neither kind nor
+    // rawInput, so the merged item must still hold the command.
+    expect(
+      adapter.translateEvent(
+        updateNotification({
+          sessionUpdate: "tool_call_update",
+          toolCallId: "call-task",
+          status: "completed",
+          title: "Report workspace contents",
+          content: [
+            {
+              type: "content",
+              content: {
+                type: "text",
+                text: "<task_result>done</task_result>",
+              },
+            },
+          ],
+        }),
+        THREAD_CONTEXT,
+      ),
+    ).toEqual([
+      {
+        type: "item/completed",
+        threadId: "",
+        providerThreadId: "",
+        scope: turnScope("turn-1"),
+        item: {
+          type: "toolCall",
+          id: "call-task",
+          tool: "Report workspace contents",
+          arguments: rawInput,
+          status: "completed",
+          result: "<task_result>done</task_result>",
+        },
+      },
+    ]);
+  });
+
+  it("keeps the plain label for a task call that carries no arguments", () => {
+    const adapter = createCompactingAdapter();
+    startTurn(adapter);
+    adapter.translateEvent(
+      updateNotification({
+        sessionUpdate: "tool_call",
+        toolCallId: "call-bare",
+        title: "task",
+        kind: "think",
+        status: "pending",
+        rawInput: {},
+      }),
+      THREAD_CONTEXT,
+    );
+
+    expect(
+      adapter.translateEvent(
+        updateNotification({
+          sessionUpdate: "tool_call_update",
+          toolCallId: "call-bare",
+          status: "in_progress",
+          kind: "think",
+          title: "task",
+          rawInput: {},
+        }),
+        THREAD_CONTEXT,
+      ),
+    ).toEqual([]);
+
+    expect(
+      adapter.translateEvent(
+        updateNotification({
+          sessionUpdate: "tool_call_update",
+          toolCallId: "call-bare",
+          status: "completed",
+          title: "task",
+        }),
+        THREAD_CONTEXT,
+      ),
+    ).toEqual([
+      {
+        type: "item/completed",
+        threadId: "",
+        providerThreadId: "",
+        scope: turnScope("turn-1"),
+        item: {
+          type: "toolCall",
+          id: "call-bare",
+          tool: "task",
+          status: "completed",
+        },
+      },
+    ]);
+  });
+
   it("translates plan updates", () => {
     const adapter = createAdapter();
     startTurn(adapter);

--- a/packages/agent-runtime/src/acp/adapter.ts
+++ b/packages/agent-runtime/src/acp/adapter.ts
@@ -194,6 +194,26 @@ function extractAcpCommand(event: {
   return toOptionalString(event.title);
 }
 
+const acpRawInputRecordSchema = z.record(z.string(), z.unknown());
+
+/**
+ * ACP `rawInput` is the agent's own tool input object, so it holds the call's
+ * command. opencode sends its `task` tool as kind `think` titled `task`, with
+ * the real work in `rawInput` (`command`, `description`, `prompt`,
+ * `subagent_type`); without this the timeline row can only say "task". Surface
+ * it as the item's `arguments`, the same field the Codex adapter fills, so the
+ * existing tool-call detail renders the command next to the output.
+ */
+function extractAcpToolCallArguments(event: {
+  rawInput?: unknown;
+}): Record<string, unknown> | undefined {
+  const parsed = acpRawInputRecordSchema.safeParse(event.rawInput);
+  if (!parsed.success || Object.keys(parsed.data).length === 0) {
+    return undefined;
+  }
+  return parsed.data;
+}
+
 function extractAcpToolCallPath(
   event: Pick<AcpToolCallUpdateEvent, "locations" | "rawInput">,
 ): string | undefined {
@@ -312,11 +332,13 @@ function translateAcpToolCallItem(
   }
 
   const outputText = extractAcpToolCallOutputText(event);
+  const toolArguments = extractAcpToolCallArguments(event);
   return withParentToolCallId(
     {
       type: "toolCall",
       id: event.toolCallId,
       tool: toOptionalString(event.title) ?? event.kind ?? "tool",
+      ...(toolArguments === undefined ? {} : { arguments: toolArguments }),
       status,
       ...(outputText === undefined ? {} : { result: outputText }),
     },
@@ -903,8 +925,27 @@ export function createAcpProviderAdapter(
           return events;
         }
         state.toolCallEventsByCallId.set(parsed.data.toolCallId, mergedEvent);
+        const revealsArguments =
+          startedItem?.type === "toolCall" &&
+          mergedItem.type === "toolCall" &&
+          startedItem.arguments === undefined &&
+          mergedItem.arguments !== undefined;
         if (!startedItem || startedItem.type === mergedItem.type) {
           state.toolItemsByCallId.set(parsed.data.toolCallId, mergedItem);
+        }
+        // opencode opens every tool call with a bare skeleton (`rawInput: {}`)
+        // and sends the real input on the next update, so the running row would
+        // keep the placeholder label with no detail for the whole call. Restate
+        // the item once, when its arguments first arrive; the timeline merges a
+        // repeated `item/started` into the running call instead of adding a row.
+        if (revealsArguments) {
+          events.push({
+            type: "item/started",
+            threadId: UNSTAMPED_THREAD_ID,
+            providerThreadId: "",
+            scope: turnScope(state.currentTurnId),
+            item: mergedItem,
+          });
         }
         const progressText = extractAcpToolCallOutputText(parsed.data);
         if (progressText && mergedItem.type === "toolCall") {

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -36,7 +36,7 @@ import {
   providerCliStatusResponseSchema,
 } from "./local.js";
 
-export const HOST_DAEMON_PROTOCOL_VERSION = 117 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 119 as const;
 
 export {
   BRANCH_LIST_LIMIT_MAX,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1056,6 +1056,8 @@ describe("host-daemon local schemas", () => {
 });
 
 describe("host-daemon command schemas", () => {
+  // Version 119 sends ACP tool-call arguments and restates a tool call once
+  // its input arrives.
   // Version 117 adds thread/context/cleared to the provider event wire model.
   // Version 116 reports provider exits that happen while a turn start is
   // pending. Older daemons can leave the server thread active until the live
@@ -1068,8 +1070,8 @@ describe("host-daemon command schemas", () => {
   // against its Pi provider ladder, so enrolled machines must not run that
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
-  it("uses protocol version 117 for context-cleared provider events", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(117);
+  it("uses protocol version 119 for ACP tool-call arguments", () => {
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(119);
   });
 
   it("binds Plan cancellation to a required turn id and typed result", () => {

--- a/packages/thread-view/test/build-thread-timeline.test.ts
+++ b/packages/thread-view/test/build-thread-timeline.test.ts
@@ -1047,6 +1047,40 @@ describe("buildThreadTimelineFromEvents", () => {
     ]);
   });
 
+  // The ACP adapter restates a tool call's `item/started` when the agent sends
+  // its input after the call opens (opencode does this for every tool call).
+  // The restatement must enrich the running row, not add a second one.
+  it("merges a restated tool call item/started into one row with its arguments", () => {
+    const toolArgs = {
+      command: "/review",
+      description: "Report workspace contents",
+      subagent_type: "explore",
+    };
+    const rows = buildTimelineRows(
+      [
+        turnStartedEvent({ seq: 1 }),
+        toolCallItemEvent({ seq: 2, tool: "task", type: "item/started" }),
+        toolCallItemEvent({
+          seq: 3,
+          tool: "task",
+          toolArgs,
+          type: "item/started",
+        }),
+      ],
+      "active",
+    );
+
+    const toolRows = collectToolRows(rows);
+    expect(toolRows).toHaveLength(1);
+    expect(toolRows[0]).toEqual(
+      expect.objectContaining({
+        status: "pending",
+        toolArgs,
+        toolName: "task",
+      }),
+    );
+  });
+
   it("extracts the exact active Plan turn id from the accepted input scope", () => {
     const event = createTimelineEventFactory({ threadId: "thread-1" });
     const requestId = "creq_23456789ab";


### PR DESCRIPTION
## Summary

An opencode `task` tool call rendered only the generic label `task`, hiding what the task was doing.

I captured the real payload rather than guessing field names. `opencode acp` 1.18.18 sends a `task` call as:

```json
{"sessionUpdate":"tool_call","toolCallId":"call_00_D31…","title":"task","kind":"think","status":"pending","locations":[],"rawInput":{}}
{"sessionUpdate":"tool_call_update","toolCallId":"call_00_D31…","status":"in_progress","kind":"think","title":"Report workspace contents","rawInput":{"description":"Report workspace contents","prompt":"Explore the workspace at …","subagent_type":"explore"}}
{"sessionUpdate":"tool_call_update","toolCallId":"call_00_D31…","status":"completed","title":"Report workspace contents","content":[{"type":"content","content":{"type":"text","text":"<task …><task_result>…"}}],"rawOutput":{"output":"…","metadata":{…}}}
```

Two facts drove the change:

1. The command lives in `rawInput`. opencode's `task` tool takes `description`, `prompt`, `subagent_type`, an optional `task_id`, and an optional `command` ("The command that triggered this task"). The ACP adapter discarded `rawInput` for generic tool calls, so nothing reached the UI.
2. opencode opens **every** tool call with a bare skeleton (`title` = tool name, `rawInput: {}`) and sends the real input on the next update. The adapter emitted `item/started` from that skeleton and then emitted nothing for a non-terminal update unless it carried output text, so the running row kept the placeholder for the whole call.

The change is confined to the ACP adapter:

- Map `rawInput` onto the tool-call item's `arguments`, the same field the Codex adapter fills. The existing tool-call detail (`ToolCallDetailBlock`) already renders `arguments` above the output, and the row title already runs them through `formatToolCallCommand`. No new panel and no new detail design.
- Restate the item with one repeated `item/started` when its arguments first arrive, so the command shows while the task runs. The timeline merges a repeated begin into the running call (`onExecBegin` → `upsertRunningExecCall`), so this enriches the row rather than adding a second one; a test pins that.
- A call whose `rawInput` stays empty emits no extra event, keeps its plain label, and gains no detail.

Output while the task runs: opencode does not stream it. Its ACP layer snapshots tool output mid-call only for `bash` (`toolName === "bash"`), and the two in_progress updates for a `task` call carried no `content`. The completion update carries the result, which the existing `result` mapping already surfaces. BB's existing `item/toolCall/progress` path still forwards mid-call `content` whenever an agent does send it.

`HOST_DAEMON_PROTOCOL_VERSION` 117 → 119: this changes what the daemon sends to the server (an extra `item/started`, plus `arguments` on ACP tool-call items). 118 is claimed by three other open sweeps (#1496, #1523, #1525), so this takes the next free number; it will need re-deriving if the ordering changes.

## Scope: this changes tool-call projection for every ACP provider, not only opencode

Stating this plainly because the issue names opencode. `packages/agent-runtime/src/acp/adapter.ts` is the single adapter behind every ACP provider: `acp-cursor`, `acp-opencode`, `acp-omp`, `acp-grok`, `acp-hermes-agent`, and any user-registered `customAcpAgents` (which is how a pi-acp or do.computer agent is wired up). All of them now get `arguments` on generic tool calls.

**Why I kept it generic rather than gating on `tool === "task"`.** The defect is not opencode-specific: the adapter discarded `rawInput` for *all* generic tool calls, so no ACP provider could ever show a tool call's input. @SawyerHood's comment on the issue says the same ("I think this applies to all acp providers"). Special-casing one tool name inside a protocol adapter would leave the same hole open for every other ACP agent and every other tool, and would be the kind of provider-sniffing the adapter otherwise avoids.

**A provider that sends no `rawInput` keeps its current rendering, byte for byte.** `extractAcpToolCallArguments` returns `undefined` for an absent, empty (`{}`), non-object, `null`, or array `rawInput` (verified against Zod directly), so the item omits `arguments` and no extra `item/started` is emitted. Cursor's existing generic-tool-call assertions in `adapter.test.ts` — which send no `rawInput` and assert the exact item shape `{type, id, tool, status}` — pass unchanged, and a new test covers the empty-`rawInput` case explicitly.

**What a provider sending a large `rawInput` will now show.** The full object, uncapped. The row title truncates each value to 40 characters (`formatToolCallCommand`), and the detail line-clamps to three lines behind a "Show more" toggle, so the *rendering* stays bounded — but the bytes are stored in the event and shipped in the timeline payload. `arguments` is outside all three truncation layers: the SQL read boundary caps only `$.item.aggregatedOutput`, `$.item.result`, and `$.item.resultText` (`event-output-truncation.ts`), the timeline row pass caps only `row.output` (`timeline-output-truncation.ts`), and the on-disk retention sweep caps only those same output fields (`truncateCompletedEventItemOutputs`). I deliberately did not add an ACP-only cap: Codex already puts `arguments` on `toolCall` items uncapped via `toOptionalRecord`, so this is a pre-existing gap in the shared item contract rather than something new to ACP, and inventing a different policy for one adapter would make the two inconsistent. Filed as #1528 so the finding outlives this pull request: it records which fields each truncation layer does cap, that Codex shares the gap through `toOptionalRecord`, and that a correct fix caps `arguments` once in the shared contract.

**No secret reaches the timeline that did not already.** `rawInput` is the tool input the agent's own model produced, echoed back over `session/update` — the agent already renders it in its own UI (opencode's TUI prints `input.description` and `input.subagent_type`). Nothing BB owns flows into it: BB passes environment values to the agent process at launch, in `thread/start`'s `envVars`, and never into ACP tool payloads; the adapter reads `rawInput` only from notifications the agent sends. `rawInput` was also never treated as private before this change — `extractAcpCommand` already lifted `rawInput.command` into `commandExecution.command` for execute-kind calls (rendered as `$ <command>`), and `buildOpaqueAcpPermissionCommand` already showed it in permission prompts. The residual exposure is a model choosing to put a credential in a tool argument, which renders identically for Claude and Codex today.

## Testing

`opencode` 1.18.18 was installed and driven for real on this machine, through a minimal ACP client over stdio against `opencode acp` (free `opencode/big-pickle` model, no credentials needed). The recorded `session/update` stream is the payload evidence quoted above.

Replaying that recorded stream through the adapter and then through `buildThreadTimelineFromEvents`:

| | before | after |
| --- | --- | --- |
| mid-run title | `Running tool: task` | `Running tool: task { description: Report workspace contents, prompt: Explore the workspace at /tmp/ocprobe..., subagent_type: explore }` |
| mid-run `toolArgs` | `null` | the full task input |
| final title | `Ran tool task` | same, plus the task output in the detail |

Checks on the extra `item/started`, since a repeated lifecycle event is the risky part:

- `events` has no uniqueness on `(threadId, type, itemId)` — only `(threadId, sequence)` — so a second row is valid.
- The projection keeps the original `startedAt` and bumps only `createdAt`, so durations still measure from the true start.
- Thread search indexes only titles and messages (`threadSearchSourceKindValues`), so it never sees tool-call events.

Automated, on this branch rebased onto `main` at 596aab429:

- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime --filter=@bb/thread-view --filter=@bb/host-daemon-contract` — passes.
- `pnpm exec turbo run test --filter=@bb/agent-runtime --filter=@bb/thread-view --filter=@bb/host-daemon-contract --force` — 944 + 367 + 49 tests pass.
- New: two adapter tests over the recorded payload (command surfaces once its arguments arrive; no restatement for a repeat of the same input; a bare call keeps its label), and one `thread-view` test that a restated `item/started` merges into a single row.

Fixes #1309

> AGENT GENERATED: by Claude Opus 5
