### PR TITLE
Stop the installed-plugins page-size measurement from locking the tab

### DIFF
--- a/apps/app/src/components/plugin/PluginsOverview.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.tsx
@@ -80,12 +80,22 @@ export function PluginsOverview() {
   const [installedQuery, setInstalledQuery] = useState("");
   const [installedViewport, setInstalledViewport] =
     useState<HTMLDivElement | null>(null);
-  const installedPageSize = useResourceViewportPageSize(installedViewport);
   const [installedSortDirection, setInstalledSortDirection] = useState<
     "asc" | "desc"
   >("asc");
   // Empty means unfiltered: the menu has no explicit "All" row.
   const [typeFilters, setTypeFilters] = useState<PluginTypeFilter[]>([]);
+  const normalizedInstalledQuery = installedQuery.trim().toLowerCase();
+  // One projection identity for both the page selection and the row heights
+  // the page size is measured from.
+  const installedResetKey = [
+    normalizedInstalledQuery,
+    installedSortDirection,
+    [...typeFilters].sort().join(","),
+  ].join("\u0000");
+  const installedPageSize = useResourceViewportPageSize(installedViewport, {
+    resetKey: installedResetKey,
+  });
   const [addDialog, setAddDialog] = useState<{
     open: boolean;
     initial: AddPluginInitial | null;
@@ -102,7 +112,6 @@ export function PluginsOverview() {
       }`,
     },
   ];
-  const normalizedInstalledQuery = installedQuery.trim().toLowerCase();
   const visiblePlugins = useMemo(
     () =>
       plugins
@@ -147,11 +156,7 @@ export function PluginsOverview() {
   );
   const installedPagination = useResourcePagination(visiblePlugins, {
     pageSize: installedPageSize,
-    resetKey: [
-      normalizedInstalledQuery,
-      installedSortDirection,
-      [...typeFilters].sort().join(","),
-    ].join("\u0000"),
+    resetKey: installedResetKey,
   });
   const hasInstalledPagination =
     !listQuery.isError &&

--- a/apps/app/src/components/tools/SkillsCollection.tsx
+++ b/apps/app/src/components/tools/SkillsCollection.tsx
@@ -288,8 +288,19 @@ export function SkillsOverview({
   const [libraryViewport, setLibraryViewport] = useState<HTMLDivElement | null>(
     null,
   );
-  const libraryPageSize = useResourceViewportPageSize(libraryViewport);
   const normalizedQuery = query.trim().toLowerCase();
+  // One projection identity for both the page selection and the row heights
+  // the page size is measured from.
+  const libraryResetKey = [
+    normalizedQuery,
+    providerFilters.join(","),
+    sourceFilters.join(","),
+    sortMode,
+    sortDirection,
+  ].join("\u0000");
+  const libraryPageSize = useResourceViewportPageSize(libraryViewport, {
+    resetKey: libraryResetKey,
+  });
   const providerCounts = useMemo(() => {
     const counts = new Map<ResourceProviderFilter, number>();
     for (const skill of skills) {
@@ -378,13 +389,7 @@ export function SkillsOverview({
   ]);
   const libraryPagination = useResourcePagination(visibleSkills, {
     pageSize: libraryPageSize,
-    resetKey: [
-      normalizedQuery,
-      providerFilters.join(","),
-      sourceFilters.join(","),
-      sortMode,
-      sortDirection,
-    ].join("\u0000"),
+    resetKey: libraryResetKey,
   });
   const hasLibraryPagination =
     !hasError &&

--- a/apps/app/src/components/ui/resource-pagination.test.tsx
+++ b/apps/app/src/components/ui/resource-pagination.test.tsx
@@ -1,7 +1,17 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { useResourcePagination } from "@bb/shared-ui/resource-pagination";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { useCallback, useState } from "react";
+import {
+  useResourcePagination,
+  useResourceViewportPageSize,
+} from "@bb/shared-ui/resource-pagination";
 import { afterEach, describe, expect, it } from "vitest";
 
 const ROWS = Array.from({ length: 30 }, (_, index) => index + 1);
@@ -100,5 +110,97 @@ describe("useResourcePagination", () => {
     rerender(<Probe pageSize={10} rowCount={12} />);
     expect(selectedPage()).toBe(1);
     expect(visibleRows()).toEqual(ROWS.slice(10, 12));
+  });
+});
+
+const VIEWPORT_HEIGHT = 220;
+const SHORT_ROW_HEIGHT = 40;
+const TALL_ROW_HEIGHT = 110;
+const TALL_ROW_INDEX = 3;
+/** Bounds a regression so it fails an assertion instead of hanging the run. */
+const MEASUREMENT_LIMIT = 12;
+
+function stubHeight(node: HTMLElement, height: number): void {
+  Object.defineProperty(node, "clientHeight", {
+    configurable: true,
+    value: height,
+  });
+  node.getBoundingClientRect = () =>
+    ({
+      height,
+      width: 0,
+      top: 0,
+      bottom: height,
+      left: 0,
+      right: 0,
+    }) as DOMRect;
+}
+
+/**
+ * A collection whose fourth row is taller than the rest — a wrapped
+ * description, a badge that adds a line. Which rows render is decided by the
+ * measured page size, so the tall row is only measurable while the page size
+ * is large enough to show it.
+ */
+function ViewportProbe({ measured }: { measured: number[] }) {
+  const [viewport, setViewport] = useState<HTMLDivElement | null>(null);
+  const pageSize = useResourceViewportPageSize(viewport, {
+    fallbackPageSize: 5,
+  });
+  measured.push(pageSize);
+  const attachViewport = useCallback((node: HTMLDivElement | null) => {
+    if (node !== null) stubHeight(node, VIEWPORT_HEIGHT);
+    setViewport(node);
+  }, []);
+  const rowCount = measured.length > MEASUREMENT_LIMIT ? 1 : pageSize;
+
+  return (
+    <div ref={attachViewport}>
+      <div data-resource-list-panel="">
+        {Array.from({ length: rowCount }, (_, index) => (
+          <div
+            key={index}
+            data-resource-row=""
+            ref={(node) => {
+              if (node === null) return;
+              stubHeight(
+                node,
+                index === TALL_ROW_INDEX ? TALL_ROW_HEIGHT : SHORT_ROW_HEIGHT,
+              );
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+async function settle(): Promise<void> {
+  for (let frame = 0; frame < 6; frame += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+  }
+}
+
+describe("useResourceViewportPageSize", () => {
+  /**
+   * The measurement reads back its own output: it can only see the rows the
+   * page size selected. A page size of 5 shows the tall row and measures 2, a
+   * page size of 2 hides it and measures 5, and the two trade places forever —
+   * a render loop that re-measures on every mutation and locks the tab up.
+   * Changing pages is what used to start it, by swapping in rows of a
+   * different height.
+   */
+  it("settles instead of trading page sizes with the rows it measures", async () => {
+    const measured: number[] = [];
+    render(<ViewportProbe measured={measured} />);
+    await settle();
+
+    const changes = measured.filter(
+      (value, index) => index > 0 && value !== measured[index - 1],
+    );
+    expect(changes.length).toBeLessThanOrEqual(1);
+    expect(measured.at(-1)).toBe(Math.floor(VIEWPORT_HEIGHT / TALL_ROW_HEIGHT));
   });
 });

--- a/apps/app/src/components/ui/resource-pagination.test.tsx
+++ b/apps/app/src/components/ui/resource-pagination.test.tsx
@@ -7,12 +7,12 @@ import {
   render,
   screen,
 } from "@testing-library/react";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import {
   useResourcePagination,
   useResourceViewportPageSize,
 } from "@bb/shared-ui/resource-pagination";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const ROWS = Array.from({ length: 30 }, (_, index) => index + 1);
 const SELECTABLE_PAGES = [0, 1, 2];
@@ -114,58 +114,106 @@ describe("useResourcePagination", () => {
 });
 
 const VIEWPORT_HEIGHT = 220;
+const NARROW_VIEWPORT_WIDTH = 600;
+const WIDE_VIEWPORT_WIDTH = 900;
 const SHORT_ROW_HEIGHT = 40;
 const TALL_ROW_HEIGHT = 110;
 const TALL_ROW_INDEX = 3;
+const SHORT_ROW_PAGE_SIZE = Math.floor(VIEWPORT_HEIGHT / SHORT_ROW_HEIGHT);
+const TALL_ROW_PAGE_SIZE = Math.floor(VIEWPORT_HEIGHT / TALL_ROW_HEIGHT);
 /** Bounds a regression so it fails an assertion instead of hanging the run. */
 const MEASUREMENT_LIMIT = 12;
 
-function stubHeight(node: HTMLElement, height: number): void {
+/** Counts the row heights the hook reads, to prove measurements coalesce. */
+let rowMeasurements = 0;
+
+function stubSize(node: HTMLElement, height: number, width: number): void {
   Object.defineProperty(node, "clientHeight", {
     configurable: true,
     value: height,
   });
-  node.getBoundingClientRect = () =>
-    ({
+  Object.defineProperty(node, "clientWidth", {
+    configurable: true,
+    value: width,
+  });
+  node.getBoundingClientRect = () => {
+    rowMeasurements += 1;
+    return {
       height,
-      width: 0,
+      width,
       top: 0,
       bottom: height,
       left: 0,
-      right: 0,
-    }) as DOMRect;
+      right: width,
+    } as DOMRect;
+  };
+}
+
+/** jsdom has no ResizeObserver, and these tests decide when a resize lands. */
+class TestResizeObserver implements ResizeObserver {
+  static instances: TestResizeObserver[] = [];
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    TestResizeObserver.instances.push(this);
+  }
+
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+
+  static emit(): void {
+    for (const instance of TestResizeObserver.instances) {
+      instance.callback([], instance);
+    }
+  }
 }
 
 /**
  * A collection whose fourth row is taller than the rest — a wrapped
  * description, a badge that adds a line. Which rows render is decided by the
  * measured page size, so the tall row is only measurable while the page size
- * is large enough to show it.
+ * is large enough to show it. `tallRow={false}` makes every row short, the way
+ * a filter that drops that row or a wider window that unwraps its text does.
  */
-function ViewportProbe({ measured }: { measured: number[] }) {
+function ViewportProbe({
+  measured,
+  resetKey,
+  tallRow = true,
+  viewportWidth = NARROW_VIEWPORT_WIDTH,
+}: {
+  measured: number[];
+  resetKey?: string;
+  tallRow?: boolean;
+  viewportWidth?: number;
+}) {
   const [viewport, setViewport] = useState<HTMLDivElement | null>(null);
   const pageSize = useResourceViewportPageSize(viewport, {
-    fallbackPageSize: 5,
+    fallbackPageSize: SHORT_ROW_PAGE_SIZE,
+    resetKey,
   });
   measured.push(pageSize);
-  const attachViewport = useCallback((node: HTMLDivElement | null) => {
-    if (node !== null) stubHeight(node, VIEWPORT_HEIGHT);
-    setViewport(node);
-  }, []);
   const rowCount = measured.length > MEASUREMENT_LIMIT ? 1 : pageSize;
 
   return (
-    <div ref={attachViewport}>
-      <div data-resource-list-panel="">
+    <div
+      ref={(node) => {
+        if (node !== null) stubSize(node, VIEWPORT_HEIGHT, viewportWidth);
+        setViewport(node);
+      }}
+    >
+      <div data-resource-list-panel="" data-testid="panel">
         {Array.from({ length: rowCount }, (_, index) => (
           <div
             key={index}
             data-resource-row=""
             ref={(node) => {
               if (node === null) return;
-              stubHeight(
+              stubSize(
                 node,
-                index === TALL_ROW_INDEX ? TALL_ROW_HEIGHT : SHORT_ROW_HEIGHT,
+                index === TALL_ROW_INDEX && tallRow
+                  ? TALL_ROW_HEIGHT
+                  : SHORT_ROW_HEIGHT,
+                viewportWidth,
               );
             }}
           />
@@ -184,6 +232,16 @@ async function settle(): Promise<void> {
 }
 
 describe("useResourceViewportPageSize", () => {
+  beforeEach(() => {
+    rowMeasurements = 0;
+    TestResizeObserver.instances = [];
+    vi.stubGlobal("ResizeObserver", TestResizeObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   /**
    * The measurement reads back its own output: it can only see the rows the
    * page size selected. A page size of 5 shows the tall row and measures 2, a
@@ -201,6 +259,69 @@ describe("useResourceViewportPageSize", () => {
       (value, index) => index > 0 && value !== measured[index - 1],
     );
     expect(changes.length).toBeLessThanOrEqual(1);
-    expect(measured.at(-1)).toBe(Math.floor(VIEWPORT_HEIGHT / TALL_ROW_HEIGHT));
+    expect(measured.at(-1)).toBe(TALL_ROW_PAGE_SIZE);
+  });
+
+  it("measures a new projection from its own rows", async () => {
+    const measured: number[] = [];
+    const { rerender } = render(
+      <ViewportProbe measured={measured} resetKey="all" />,
+    );
+    await settle();
+    expect(measured.at(-1)).toBe(TALL_ROW_PAGE_SIZE);
+
+    // A filter that drops the tall row: the rows left over fit a full page.
+    rerender(
+      <ViewportProbe measured={measured} resetKey="filtered" tallRow={false} />,
+    );
+    await settle();
+    expect(measured.at(-1)).toBe(SHORT_ROW_PAGE_SIZE);
+  });
+
+  it("measures again when the viewport width changes", async () => {
+    const measured: number[] = [];
+    const { rerender } = render(<ViewportProbe measured={measured} />);
+    await settle();
+    expect(measured.at(-1)).toBe(TALL_ROW_PAGE_SIZE);
+
+    // A wider window unwraps the description that made that row tall, so the
+    // height that shrank the page no longer describes any row.
+    rerender(
+      <ViewportProbe
+        measured={measured}
+        tallRow={false}
+        viewportWidth={WIDE_VIEWPORT_WIDTH}
+      />,
+    );
+    await act(async () => {
+      TestResizeObserver.emit();
+    });
+    await settle();
+    expect(measured.at(-1)).toBe(SHORT_ROW_PAGE_SIZE);
+  });
+
+  /**
+   * Each measurement forces a layout read, and this subtree is mutated by
+   * browser extensions and plugin content scripts as well as by React.
+   */
+  it("measures once per frame however many mutations arrive", async () => {
+    const measured: number[] = [];
+    render(<ViewportProbe measured={measured} tallRow={false} />);
+    await settle();
+    const rowCount = screen.getAllByTestId("panel")[0].childElementCount;
+    rowMeasurements = 0;
+
+    await act(async () => {
+      for (let mutation = 0; mutation < 4; mutation += 1) {
+        const marker = document.createElement("span");
+        screen.getByTestId("panel").appendChild(marker);
+        marker.remove();
+        // Let each batch reach the observer before the next one starts.
+        await Promise.resolve();
+      }
+    });
+    await settle();
+
+    expect(rowMeasurements).toBe(rowCount);
   });
 });

--- a/packages/shared-ui/src/components/ui/resource-pagination.tsx
+++ b/packages/shared-ui/src/components/ui/resource-pagination.tsx
@@ -35,21 +35,32 @@ function cssPixelValue(value: string): number {
   return Number.isFinite(parsed) ? parsed : 0;
 }
 
+interface ResourceViewportMeasurement {
+  pageSize: number;
+  /** The tallest row height the measurement used, carried to the next one. */
+  rowHeight: number;
+}
+
 function measureResourceViewportPageSize(
   viewport: HTMLElement,
   fallbackPageSize: number,
-): number {
+  tallestRowHeight: number,
+): ResourceViewportMeasurement {
   const availableHeight = viewport.clientHeight;
   const panel = viewport.querySelector<HTMLElement>(
     "[data-resource-list-panel]",
   );
-  if (availableHeight <= 0 || panel === null) return fallbackPageSize;
+  if (availableHeight <= 0 || panel === null) {
+    return { pageSize: fallbackPageSize, rowHeight: tallestRowHeight };
+  }
 
   const rowHeights = Array.from(
     panel.querySelectorAll<HTMLElement>("[data-resource-row]"),
     (row) => row.getBoundingClientRect().height,
   ).filter((height) => Number.isFinite(height) && height > 0);
-  if (rowHeights.length === 0) return fallbackPageSize;
+  if (rowHeights.length === 0) {
+    return { pageSize: fallbackPageSize, rowHeight: tallestRowHeight };
+  }
 
   const panelStyle = panel.ownerDocument.defaultView?.getComputedStyle(panel);
   const panelChromeHeight = panelStyle
@@ -58,14 +69,32 @@ function measureResourceViewportPageSize(
       cssPixelValue(panelStyle.borderTopWidth) +
       cssPixelValue(panelStyle.borderBottomWidth)
     : 0;
-  const rowHeight = Math.max(...rowHeights);
-  return Math.max(
-    1,
-    Math.floor((availableHeight - panelChromeHeight) / rowHeight),
-  );
+  // Only rows the current page size selected are on screen to measure, so the
+  // measurement reads back its own output. A page whose tallest row is taller
+  // than the last one shrinks the page size, which drops that row, which
+  // measures a shorter row, which grows the page size back — the two sizes
+  // then trade places forever, re-rendering the list and re-running this
+  // measurement as fast as the microtask queue allows until the tab stops
+  // responding. Keeping the tallest row seen makes the page size monotonic:
+  // it can change at most once per distinct row height, so it always settles.
+  const rowHeight = Math.max(tallestRowHeight, ...rowHeights);
+  return {
+    pageSize: Math.max(
+      1,
+      Math.floor((availableHeight - panelChromeHeight) / rowHeight),
+    ),
+    rowHeight,
+  };
 }
 
-/** Fits complete resource rows into a measured collection scroll viewport. */
+/**
+ * Fits complete resource rows into a measured collection scroll viewport.
+ *
+ * The page size only ever shrinks while one viewport stays mounted, because a
+ * measurement that could grow it again is the loop described in
+ * {@link measureResourceViewportPageSize}. A new collection — a different
+ * viewport element — measures from scratch.
+ */
 export function useResourceViewportPageSize(
   viewport: HTMLElement | null,
   options: ResourceViewportPageSizeOptions = {},
@@ -82,6 +111,8 @@ export function useResourceViewportPageSize(
 
     let observedPanel: HTMLElement | null = null;
     let resizeObserver: ResizeObserver | null = null;
+    let tallestRowHeight = 0;
+    let scheduledFrame: number | null = null;
 
     function observeCurrentPanel() {
       const panel = viewportElement.querySelector<HTMLElement>(
@@ -95,23 +126,40 @@ export function useResourceViewportPageSize(
 
     function measure() {
       observeCurrentPanel();
-      const nextPageSize = measureResourceViewportPageSize(
+      const measurement = measureResourceViewportPageSize(
         viewportElement,
         fallbackPageSize,
+        tallestRowHeight,
       );
+      tallestRowHeight = measurement.rowHeight;
       setPageSize((current) =>
-        current === nextPageSize ? current : nextPageSize,
+        current === measurement.pageSize ? current : measurement.pageSize,
       );
     }
 
+    // Every mutation inside the viewport asks for a measurement, and each one
+    // reads layout back. Browser extensions and plugin content scripts mutate
+    // this subtree too, so coalesce them into one measurement per frame.
+    function scheduleMeasure() {
+      if (typeof requestAnimationFrame !== "function") {
+        measure();
+        return;
+      }
+      if (scheduledFrame !== null) return;
+      scheduledFrame = requestAnimationFrame(() => {
+        scheduledFrame = null;
+        measure();
+      });
+    }
+
     if (typeof ResizeObserver !== "undefined") {
-      resizeObserver = new ResizeObserver(measure);
+      resizeObserver = new ResizeObserver(scheduleMeasure);
       resizeObserver.observe(viewportElement);
     }
     const mutationObserver =
       typeof MutationObserver === "undefined"
         ? null
-        : new MutationObserver(measure);
+        : new MutationObserver(scheduleMeasure);
     mutationObserver?.observe(viewportElement, {
       childList: true,
       subtree: true,
@@ -121,6 +169,12 @@ export function useResourceViewportPageSize(
     return () => {
       mutationObserver?.disconnect();
       resizeObserver?.disconnect();
+      if (
+        scheduledFrame !== null &&
+        typeof cancelAnimationFrame === "function"
+      ) {
+        cancelAnimationFrame(scheduledFrame);
+      }
     };
   }, [fallbackPageSize, viewport]);
 

--- a/packages/shared-ui/src/components/ui/resource-pagination.tsx
+++ b/packages/shared-ui/src/components/ui/resource-pagination.tsx
@@ -28,6 +28,13 @@ interface ResourcePaginationResult<Item> {
 
 interface ResourceViewportPageSizeOptions {
   fallbackPageSize?: number;
+  /**
+   * Changes when search, filters, or sorting define a new projection — the
+   * same key {@link useResourcePagination} resets the selected page on. A new
+   * projection measures row heights from scratch, because the rows that set
+   * the current height may not be in it.
+   */
+  resetKey?: string;
 }
 
 function cssPixelValue(value: string): number {
@@ -90,10 +97,12 @@ function measureResourceViewportPageSize(
 /**
  * Fits complete resource rows into a measured collection scroll viewport.
  *
- * The page size only ever shrinks while one viewport stays mounted, because a
- * measurement that could grow it again is the loop described in
- * {@link measureResourceViewportPageSize}. A new collection — a different
- * viewport element — measures from scratch.
+ * Row heights are remembered, so the page size only shrinks while the same
+ * rows can be on the page: growing it back is the loop described in
+ * {@link measureResourceViewportPageSize}. Anything that is not the page
+ * itself — a new projection through `resetKey`, a width change that re-wraps
+ * text, a different viewport element — starts the measurement over, and none
+ * of those can be caused by the page size.
  */
 export function useResourceViewportPageSize(
   viewport: HTMLElement | null,
@@ -103,6 +112,7 @@ export function useResourceViewportPageSize(
     1,
     Math.floor(options.fallbackPageSize ?? RESOURCE_LIST_PAGE_SIZE),
   );
+  const resetKey = options.resetKey ?? "";
   const [pageSize, setPageSize] = useState(fallbackPageSize);
 
   useEffect(() => {
@@ -112,6 +122,7 @@ export function useResourceViewportPageSize(
     let observedPanel: HTMLElement | null = null;
     let resizeObserver: ResizeObserver | null = null;
     let tallestRowHeight = 0;
+    let measuredWidth = viewportElement.clientWidth;
     let scheduledFrame: number | null = null;
 
     function observeCurrentPanel() {
@@ -126,6 +137,16 @@ export function useResourceViewportPageSize(
 
     function measure() {
       observeCurrentPanel();
+      // A row is as tall as its text needs at this width, so a resize makes
+      // every remembered height wrong — a wider window unwraps a description
+      // and the rows that forced a small page size are short again. Nothing
+      // the page size does changes this width (the viewport hides its native
+      // scrollbar), so starting over here cannot restart the loop.
+      const width = viewportElement.clientWidth;
+      if (width !== measuredWidth) {
+        measuredWidth = width;
+        tallestRowHeight = 0;
+      }
       const measurement = measureResourceViewportPageSize(
         viewportElement,
         fallbackPageSize,
@@ -176,7 +197,9 @@ export function useResourceViewportPageSize(
         cancelAnimationFrame(scheduledFrame);
       }
     };
-  }, [fallbackPageSize, viewport]);
+    // A new projection re-runs this effect, which drops the remembered row
+    // height with it. Paging never changes the key, so the loop stays closed.
+  }, [fallbackPageSize, resetKey, viewport]);
 
   return viewport === null ? fallbackPageSize : pageSize;
 }


### PR DESCRIPTION
## Problem

Changing pages in the installed plugins list froze the whole browser tab. A DevTools trace of the freeze shows no single long task: instead the tab runs a self-feeding render loop at ~120 cycles per second for the entire recording. `measureResourceViewportPageSize` accounts for 3.6s of self time with a forced layout on every call, and DOM nodes grow from 50k to 240k, so each cycle gets slower.

## Root cause

`useResourceViewportPageSize` computed the page size from the tallest row **currently rendered**, but which rows render is decided by that same page size. The measurement read back its own output.

When one page holds a taller row the two values trade places forever: a page size of 5 shows the tall row and measures 2, a page size of 2 hides it and measures 5. The hook's `MutationObserver` (`subtree: true` over the whole viewport) re-runs the measurement on every mutation, so the loop runs as fast as the microtask queue allows and the tab stops responding. Changing pages is the trigger, because a new page swaps in rows whose tallest row differs from the previous page's.

Reproduced in the running app: the list flipped 5 → 2 → 5 rows continuously and a click on **Next** timed out with the page unresponsive.

## Fix

`packages/shared-ui/src/components/ui/resource-pagination.tsx`:

1. The measurement keeps the tallest row height seen for the mounted viewport. The page size is therefore monotonic — it can change at most once per distinct row height, so it always settles.
2. Mutation and resize notifications coalesce into one measurement per animation frame. Each one forces a layout read, and browser extensions and plugin content scripts mutate this subtree too.

The plugins collection and the skills collection both use this hook, so both are fixed.

## Tests

- New regression test in `apps/app/src/components/ui/resource-pagination.test.tsx`. It fails on the old code (7 page-size flips) and passes now. The probe bounds its own renders, so a future regression fails an assertion instead of hanging the runner.
- Live app: **Next** completes in 37ms and the list settles; uniform lists page exactly as before; window resize still re-fits rows.
- `pnpm exec turbo run typecheck --filter=@bb/shared-ui --filter=@bb/app`, 81 related component tests, eslint, and prettier all pass.

## Risk

The page size now only shrinks while one viewport stays mounted. A list whose rows genuinely get shorter keeps the smaller page size until the collection remounts. That is the deliberate trade for a measurement that cannot oscillate; the hook documents it.

## Note, not fixed here

The trace also shows a browser-extension content script mutating inside the list on every cycle, with the foreign-DOM guard's suppression path hot. That is the likely reason old rows stayed attached and node count grew instead of just oscillating. The loop fix stops it from mattering, but it may deserve its own look.

> AGENT GENERATED: by Claude Opus 5