### PR TITLE
Guard bb's local HTTP services against foreign browser origins

### DIFF
--- a/apps/host-daemon/src/local-api.test.ts
+++ b/apps/host-daemon/src/local-api.test.ts
@@ -113,13 +113,16 @@ describe("local API server", () => {
       getConnected: () => true,
       openInTarget,
     });
-    const port = server.port;
+    const { port } = server;
+    // Connect to the address the API actually bound: `localhost` resolves to
+    // ::1 on some hosts, so a hardcoded 127.0.0.1 is refused there.
+    const { bindHost } = server;
 
     function post(headers: Record<string, string>): Promise<number> {
       return new Promise((resolve, reject) => {
         const request = http.request(
           {
-            host: "127.0.0.1",
+            host: bindHost,
             port,
             path: "/open-in-target",
             method: "POST",
@@ -154,8 +157,8 @@ describe("local API server", () => {
     // The loopback authority a real local caller sends still works.
     expect(
       await post({
-        origin: `http://127.0.0.1:${port}`,
-        host: `127.0.0.1:${port}`,
+        origin: `http://${bindHost}:${port}`,
+        host: `${bindHost}:${port}`,
       }),
     ).toBe(200);
     expect(openInTarget).toHaveBeenCalledTimes(1);

--- a/apps/host-daemon/src/local-api.test.ts
+++ b/apps/host-daemon/src/local-api.test.ts
@@ -34,6 +34,69 @@ describe("local API server", () => {
     server = null;
   });
 
+  // The in-app browser can now reach any loopback port bb does not reserve, and
+  // a second bb daemon on this machine sits on one. CORS only hides a response:
+  // a `no-cors` POST with a simple content type skips the preflight and still
+  // runs `/open-in-target`. The origin must be rejected, not just unanswered.
+  it("rejects a foreign browser origin instead of only withholding CORS", async () => {
+    const openInTarget = vi.fn(async () => undefined);
+    server = await startLocalApiServer({
+      hostId: "host-1",
+      localApiConfig: createLocalApiConfig(),
+      serverUrl: "http://server.test",
+      serverPort: 3334,
+      devAppPort: 5173,
+      getConnected: () => true,
+      openInTarget,
+    });
+    const baseUrl = `http://localhost:${server.port}`;
+
+    async function postOpenInTarget(
+      headers: Record<string, string>,
+    ): Promise<number> {
+      const response = await fetch(`${baseUrl}/open-in-target`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          context: { kind: "local" },
+          columnNumber: null,
+          lineNumber: null,
+          path: tmpdir(),
+          targetId: "vscode",
+        }),
+      });
+      return response.status;
+    }
+
+    // A blind cross-origin POST: simple content type, so no preflight guards it.
+    expect(
+      await postOpenInTarget({
+        "content-type": "text/plain",
+        origin: "http://127.0.0.1:3009",
+      }),
+    ).toBe(403);
+    // A DNS-rebound page presents its own public origin.
+    expect(
+      await postOpenInTarget({
+        "content-type": "text/plain",
+        origin: "http://rebind.example",
+      }),
+    ).toBe(403);
+    expect(openInTarget).not.toHaveBeenCalled();
+
+    // The bb app's own origin still works, as does a caller sending none.
+    expect(
+      await postOpenInTarget({
+        "content-type": "application/json",
+        origin: "http://localhost:3334",
+      }),
+    ).toBe(200);
+    expect(await postOpenInTarget({ "content-type": "application/json" })).toBe(
+      200,
+    );
+    expect(openInTarget).toHaveBeenCalledTimes(2);
+  });
+
   it("serves host identity and status over localhost", async () => {
     server = await startLocalApiServer({
       hostId: "host-1",

--- a/apps/host-daemon/src/local-api.test.ts
+++ b/apps/host-daemon/src/local-api.test.ts
@@ -1,3 +1,4 @@
+import http from "node:http";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { createServer as createNetServer } from "node:net";
 import { tmpdir } from "node:os";
@@ -95,6 +96,69 @@ describe("local API server", () => {
       200,
     );
     expect(openInTarget).toHaveBeenCalledTimes(2);
+  });
+
+  // A rebound page sends a matching Origin and Host pair, which the self-origin
+  // branch previously accepted as the daemon's own origin. This API binds
+  // loopback, so a genuine caller always addresses it by a loopback name or a
+  // bare address.
+  it("rejects a DNS-rebound origin that matches its own Host", async () => {
+    const openInTarget = vi.fn(async () => undefined);
+    server = await startLocalApiServer({
+      hostId: "host-1",
+      localApiConfig: createLocalApiConfig(),
+      serverUrl: "http://server.test",
+      serverPort: 3334,
+      devAppPort: 5173,
+      getConnected: () => true,
+      openInTarget,
+    });
+    const port = server.port;
+
+    function post(headers: Record<string, string>): Promise<number> {
+      return new Promise((resolve, reject) => {
+        const request = http.request(
+          {
+            host: "127.0.0.1",
+            port,
+            path: "/open-in-target",
+            method: "POST",
+            headers: { ...headers, "content-type": "application/json" },
+          },
+          (response) => {
+            response.resume();
+            resolve(response.statusCode ?? 0);
+          },
+        );
+        request.once("error", reject);
+        request.end(
+          JSON.stringify({
+            context: { kind: "local" },
+            columnNumber: null,
+            lineNumber: null,
+            path: tmpdir(),
+            targetId: "vscode",
+          }),
+        );
+      });
+    }
+
+    expect(
+      await post({
+        origin: `http://rebind.example:${port}`,
+        host: `rebind.example:${port}`,
+      }),
+    ).toBe(403);
+    expect(openInTarget).not.toHaveBeenCalled();
+
+    // The loopback authority a real local caller sends still works.
+    expect(
+      await post({
+        origin: `http://127.0.0.1:${port}`,
+        host: `127.0.0.1:${port}`,
+      }),
+    ).toBe(200);
+    expect(openInTarget).toHaveBeenCalledTimes(1);
   });
 
   it("serves host identity and status over localhost", async () => {

--- a/apps/host-daemon/src/local-api.ts
+++ b/apps/host-daemon/src/local-api.ts
@@ -89,6 +89,22 @@ interface ResolveOpenPathInTargetArgs {
 const CLIENT_CONFIG_CACHE_TTL_MS = 1_000;
 const EMPTY_CLIENT_CONFIG: ClientConfig = { servers: {} };
 
+/**
+ * Whether an origin hostname is one a DNS-rebound page cannot mint: a loopback
+ * name, or a bare IP literal. Mirrors the server's check in
+ * `browser-request-guard.ts`; see #1531 for folding both into one module.
+ */
+function isSelfEvidentLocalHostname(hostname: string): boolean {
+  if (hostname === "localhost" || hostname.endsWith(".localhost")) {
+    return true;
+  }
+  // `URL.hostname` keeps the brackets on an IPv6 literal.
+  if (hostname.startsWith("[") && hostname.endsWith("]")) {
+    return true;
+  }
+  return /^\d{1,3}(?:\.\d{1,3}){3}$/u.test(hostname);
+}
+
 function isNoEntryError(error: unknown): boolean {
   return error instanceof Error && "code" in error && error.code === "ENOENT";
 }
@@ -211,10 +227,28 @@ export async function startLocalApiServer(
   const isAllowedAppOrigin = async (
     origin: string,
     requestUrl: string,
-  ): Promise<boolean> =>
-    origin === new URL(requestUrl).origin ||
-    allowedCorsOrigins.has(origin) ||
-    (await isConfiguredClientOrigin(origin, clientConfigLoader));
+  ): Promise<boolean> => {
+    if (
+      allowedCorsOrigins.has(origin) ||
+      (await isConfiguredClientOrigin(origin, clientConfigLoader))
+    ) {
+      return true;
+    }
+    // Matching the addressed authority proves nothing by itself: a page on a
+    // public name that resolves to this machine controls both `Origin` and
+    // `Host`, so it can make them agree. This API binds loopback, so a genuine
+    // caller always addresses it by a loopback name or a bare address.
+    let originUrl: URL;
+    try {
+      originUrl = new URL(origin);
+    } catch {
+      return false;
+    }
+    return (
+      isSelfEvidentLocalHostname(originUrl.hostname) &&
+      origin === new URL(requestUrl).origin
+    );
+  };
 
   app.use(
     "*",

--- a/apps/host-daemon/src/local-api.ts
+++ b/apps/host-daemon/src/local-api.ts
@@ -208,26 +208,45 @@ export async function startLocalApiServer(
     value: options.devAppPort,
   });
   const allowedCorsOrigins = new Set<string>(buildLocalAppOrigins(originArgs));
+  const isAllowedAppOrigin = async (
+    origin: string,
+    requestUrl: string,
+  ): Promise<boolean> =>
+    origin === new URL(requestUrl).origin ||
+    allowedCorsOrigins.has(origin) ||
+    (await isConfiguredClientOrigin(origin, clientConfigLoader));
+
   app.use(
     "*",
     cors({
-      origin: async (origin, context) => {
-        const requestOrigin = new URL(context.req.url).origin;
-        if (
-          origin === requestOrigin ||
-          allowedCorsOrigins.has(origin) ||
-          (await isConfiguredClientOrigin(origin, clientConfigLoader))
-        ) {
-          return origin;
-        }
-        return null;
-      },
+      origin: async (origin, context) =>
+        (await isAllowedAppOrigin(origin, context.req.url)) ? origin : null,
     }),
   );
 
   app.get(options.localApiConfig.healthPath, (c) =>
     c.text(healthResponseSchema.parse(options.localApiConfig.healthValue)),
   );
+  // CORS hides a response; it does not stop the request being acted on. A
+  // `no-cors` POST with a simple content type skips the preflight, reaches
+  // `/open-in-target`, and runs it, while the page never reads the reply. The
+  // in-app browser can now reach any loopback port it is not told to avoid, and
+  // a second bb daemon on this machine sits on a port the desktop cannot name,
+  // so reject a foreign browser origin outright instead of only withholding the
+  // response header. Non-browser callers send no `Origin` and are unaffected.
+  app.use("*", async (c, next) => {
+    const origin = c.req.header("origin");
+    if (
+      origin !== undefined &&
+      !(await isAllowedAppOrigin(origin, c.req.url))
+    ) {
+      return c.json(
+        { error: `origin "${origin}" is not a local BB app origin` },
+        403,
+      );
+    }
+    await next();
+  });
   app.use("*", async (c, next) => {
     if (options.localApiConfig.mode === "health-only") {
       return c.notFound();

--- a/apps/host-daemon/src/machine-auth-proxy.test.ts
+++ b/apps/host-daemon/src/machine-auth-proxy.test.ts
@@ -213,6 +213,135 @@ describe("startMachineAuthProxy", () => {
     expect(upstreamRequests).toBe(0);
   });
 
+  // The in-app browser can now reach any unreserved loopback port, and this
+  // proxy's port is chosen at random so no reserved list can name it. A browsed
+  // page must not be able to borrow the machine credential with a blind
+  // `no-cors` request, whose response it cannot read but whose effect lands.
+  it("rejects browser-originated requests without reaching upstream", async () => {
+    let upstreamRequests = 0;
+    const upstream = http.createServer((_request, response) => {
+      upstreamRequests += 1;
+      response.end();
+    });
+    const upstreamPort = await listen(upstream);
+    const proxy = await startMachineAuthProxy({
+      machineCredential: "bbcm_machine",
+      serverUrl: `http://127.0.0.1:${upstreamPort}`,
+    });
+    proxies.push(proxy);
+
+    const browserHeaders: Array<Record<string, string>> = [
+      // A blind cross-origin POST: no preflight, and the effect still lands.
+      { origin: "http://127.0.0.1:3009", "content-type": "text/plain" },
+      // A blind `no-cors` GET carries no Origin, but Chromium still marks it.
+      { "sec-fetch-site": "cross-site" },
+    ];
+    for (const headers of browserHeaders) {
+      const response = await fetch(`${proxy.serverUrl}/api/v1/threads`, {
+        method: "POST",
+        headers,
+        body: "{}",
+      });
+      expect(response.status).toBe(403);
+    }
+    expect(upstreamRequests).toBe(0);
+
+    // A runtime process using Node's own `fetch` still gets through. Node sends
+    // `sec-fetch-mode: cors`, so that header must not be a discriminator.
+    const allowed = await fetch(`${proxy.serverUrl}/api/v1/threads`, {
+      method: "POST",
+      body: "{}",
+    });
+    expect(allowed.status).toBe(200);
+    expect(upstreamRequests).toBe(1);
+  });
+
+  it("rejects a browser WebSocket handshake without reaching upstream", async () => {
+    let upstreamUpgrades = 0;
+    const upstream = http.createServer((_request, response) => response.end());
+    upstream.on("upgrade", (_request, socket) => {
+      upstreamUpgrades += 1;
+      socket.destroy();
+    });
+    const upstreamPort = await listen(upstream);
+    const proxy = await startMachineAuthProxy({
+      machineCredential: "bbcm_machine",
+      serverUrl: `http://127.0.0.1:${upstreamPort}`,
+    });
+    proxies.push(proxy);
+    const proxyUrl = new URL(proxy.serverUrl);
+
+    const handshake = await new Promise<string>((resolve, reject) => {
+      const socket = net.connect(
+        Number(proxyUrl.port),
+        proxyUrl.hostname,
+        () => {
+          socket.write(
+            `GET /ws HTTP/1.1\r\nHost: ${proxyUrl.host}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: ${Buffer.from("0123456789abcdef").toString("base64")}\r\nSec-WebSocket-Version: 13\r\nOrigin: http://127.0.0.1:3009\r\n\r\n`,
+          );
+        },
+      );
+      socket.setEncoding("utf8");
+      socket.once("data", (chunk) => resolve(String(chunk)));
+      socket.once("error", reject);
+    });
+
+    expect(handshake).toContain("403 Forbidden");
+    expect(upstreamUpgrades).toBe(0);
+  });
+
+  // A page on a public hostname that DNS-rebinds to 127.0.0.1 reaches this
+  // socket with that name in `Host`, and Chromium sends no `Origin` or
+  // `Sec-Fetch-*` for a `no-cors` GET to a non-trustworthy URL — so the header
+  // check alone cannot see it. Verified in Electron with
+  // `--host-resolver-rules="MAP rebind.example 127.0.0.1"`.
+  it("rejects a rebound public Host without reaching upstream", async () => {
+    let upstreamRequests = 0;
+    const upstream = http.createServer((_request, response) => {
+      upstreamRequests += 1;
+      response.end();
+    });
+    const upstreamPort = await listen(upstream);
+    const proxy = await startMachineAuthProxy({
+      machineCredential: "bbcm_machine",
+      serverUrl: `http://127.0.0.1:${upstreamPort}`,
+    });
+    proxies.push(proxy);
+    const proxyUrl = new URL(proxy.serverUrl);
+
+    async function statusForHost(host: string): Promise<number | undefined> {
+      return await new Promise<number | undefined>((resolve, reject) => {
+        const request = http.request(
+          {
+            host: proxyUrl.hostname,
+            port: proxyUrl.port,
+            path: "/api/v1/threads",
+            headers: { host },
+          },
+          (response) => resolve(response.statusCode),
+        );
+        request.once("error", reject);
+        request.end();
+      });
+    }
+
+    // No Origin, no Sec-Fetch-Site: only the Host header gives it away.
+    expect(await statusForHost(`rebind.example:${proxyUrl.port}`)).toBe(403);
+    // A mismatched port on a loopback name is not this proxy either.
+    expect(await statusForHost("127.0.0.1:1")).toBe(403);
+    expect(upstreamRequests).toBe(0);
+
+    // The authorities a real runtime client sends still pass.
+    for (const host of [
+      `127.0.0.1:${proxyUrl.port}`,
+      `localhost:${proxyUrl.port}`,
+      `[::1]:${proxyUrl.port}`,
+    ]) {
+      expect(await statusForHost(host)).toBe(200);
+    }
+    expect(upstreamRequests).toBe(3);
+  });
+
   it("rejects loudly when its loopback port cannot be bound", async () => {
     const occupied = net.createServer();
     const port = await listen(occupied);

--- a/apps/host-daemon/src/machine-auth-proxy.ts
+++ b/apps/host-daemon/src/machine-auth-proxy.ts
@@ -21,16 +21,95 @@ export interface MachineAuthProxy {
   close(): Promise<void>;
 }
 
+// Headers no non-browser client sends. `Origin` rides every browser write and
+// WebSocket handshake; `Sec-Fetch-Site` rides every browser fetch, including a
+// blind `no-cors` GET that carries no `Origin`. `Sec-Fetch-Mode` is NOT a
+// discriminator: Node's own `fetch` sends `sec-fetch-mode: cors`, so keying on
+// it would reject the runtime processes this proxy exists to serve.
+const BROWSER_REQUEST_HEADERS = ["origin", "sec-fetch-site"] as const;
+
+const REJECTED_SOCKET_MESSAGES = {
+  400: "Bad Request",
+  403: "Forbidden",
+  405: "Method Not Allowed",
+} as const;
+
+type RejectedSocketStatus = keyof typeof REJECTED_SOCKET_MESSAGES;
+
+/**
+ * Whether a web page made this request. This proxy exists for the Node runtime
+ * processes it hands `BB_SERVER_URL` to, and it stamps every forwarded request
+ * with a machine credential. A page can reach any loopback port it can guess,
+ * and a `no-cors` request still acts even though its response stays hidden, so
+ * a browsed page must never borrow that credential.
+ */
+export function isBrowserRequest(headers: IncomingHttpHeaders): boolean {
+  return BROWSER_REQUEST_HEADERS.some((name) => headers[name] !== undefined);
+}
+
+// The only authorities that reach this proxy legitimately. It binds 127.0.0.1
+// and hands out `http://127.0.0.1:<port>`, so every real caller sends one of
+// these.
+const LOOPBACK_AUTHORITY_HOSTNAMES = new Set([
+  "127.0.0.1",
+  "localhost",
+  "[::1]",
+]);
+
+function parseHostAuthority(
+  host: string,
+): { hostname: string; port: string } | null {
+  try {
+    const url = new URL(`http://${host}`);
+    return url.username.length === 0 &&
+      url.password.length === 0 &&
+      url.pathname === "/" &&
+      url.search.length === 0 &&
+      url.hash.length === 0
+      ? { hostname: url.hostname, port: url.port }
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether the request's `Host` is this proxy's own loopback authority.
+ *
+ * A page on a public hostname that DNS-rebinds to 127.0.0.1 reaches this socket
+ * carrying that public name in `Host`. {@link isBrowserRequest} cannot see it:
+ * `http://rebind.example` is not a potentially trustworthy URL, so Chromium
+ * sends no `Sec-Fetch-*`, and a `no-cors` GET sends no `Origin` either.
+ */
+export function isProxyLoopbackAuthority(
+  host: string | undefined,
+  boundPort: number,
+): boolean {
+  if (host === undefined) {
+    return false;
+  }
+  const parsed = parseHostAuthority(host);
+  if (parsed === null) {
+    return false;
+  }
+  const hostPort = parsed.port.length > 0 ? Number(parsed.port) : 80;
+  return (
+    hostPort === boundPort && LOOPBACK_AUTHORITY_HOSTNAMES.has(parsed.hostname)
+  );
+}
+
 function isOriginFormTarget(target: string | undefined): target is string {
   return (
     target !== undefined && target.startsWith("/") && !target.startsWith("//")
   );
 }
 
-function writeRejectedSocket(socket: Duplex, status: 400 | 405): void {
-  const message = status === 405 ? "Method Not Allowed" : "Bad Request";
+function writeRejectedSocket(
+  socket: Duplex,
+  status: RejectedSocketStatus,
+): void {
   socket.end(
-    `HTTP/1.1 ${status} ${message}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`,
+    `HTTP/1.1 ${status} ${REJECTED_SOCKET_MESSAGES[status]}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`,
   );
 }
 
@@ -47,11 +126,20 @@ function upstreamHeaders(
 }
 
 function proxyRequest(args: {
+  boundPort: number | null;
   machineCredential: string;
   request: IncomingMessage;
   response: ServerResponse;
   target: URL;
 }): void {
+  if (
+    args.boundPort === null ||
+    isBrowserRequest(args.request.headers) ||
+    !isProxyLoopbackAuthority(args.request.headers.host, args.boundPort)
+  ) {
+    args.response.writeHead(403).end();
+    return;
+  }
   if (!isOriginFormTarget(args.request.url)) {
     args.response.writeHead(400).end();
     return;
@@ -91,12 +179,21 @@ function proxyRequest(args: {
 }
 
 function proxyUpgrade(args: {
+  boundPort: number | null;
   clientSocket: Duplex;
   head: Buffer;
   machineCredential: string;
   request: IncomingMessage;
   target: URL;
 }): void {
+  if (
+    args.boundPort === null ||
+    isBrowserRequest(args.request.headers) ||
+    !isProxyLoopbackAuthority(args.request.headers.host, args.boundPort)
+  ) {
+    writeRejectedSocket(args.clientSocket, 403);
+    return;
+  }
   if (!isOriginFormTarget(args.request.url)) {
     writeRejectedSocket(args.clientSocket, 400);
     return;
@@ -147,8 +244,12 @@ export async function startMachineAuthProxy(
     );
   }
   const sockets = new Set<Socket>();
+  // Read at request time, so the handlers see the port the socket actually
+  // bound rather than the (possibly zero) requested one.
+  let boundPort: number | null = null;
   const server = http.createServer((request, response) =>
     proxyRequest({
+      boundPort,
       machineCredential: options.machineCredential,
       request,
       response,
@@ -158,6 +259,7 @@ export async function startMachineAuthProxy(
   server.on("connect", (_request, socket) => writeRejectedSocket(socket, 405));
   server.on("upgrade", (request, socket, head) =>
     proxyUpgrade({
+      boundPort,
       clientSocket: socket,
       head,
       machineCredential: options.machineCredential,
@@ -184,10 +286,12 @@ export async function startMachineAuthProxy(
     // Accepted trade-off: any same-user local process can use this proxy while
     // the daemon runs. It is restricted to one server origin and exposes no
     // durable credential that can be exfiltrated from an agent environment.
+    // Browsed pages are NOT included in that trade: they are rejected above.
     server.listen(options.port ?? 0, LOOPBACK_HOST);
   });
 
   const address = server.address() as AddressInfo;
+  boundPort = address.port;
   return {
     serverUrl: `http://${LOOPBACK_HOST}:${address.port}`,
     async close(): Promise<void> {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -74,6 +74,12 @@ import {
 } from "./services/plugin-catalog/plugin-catalog-service.js";
 import { callHostRetryableOnlineRpc } from "./services/hosts/online-rpc.js";
 import { browserRequestProblem } from "./browser-request-guard.js";
+
+/**
+ * `/api/v1/plugins/<id>/http/...` — the plugin-owned wire, whose auth mode is
+ * declared per route by the plugin itself.
+ */
+const PLUGIN_WIRE_HTTP_PATH = /^\/api\/v1\/plugins\/[^/]+\/http(?:\/|$)/u;
 import { rankAcceptedAssetEncodings } from "./asset-content-encoding.js";
 
 export type CloseWebSockets = () => Promise<void>;
@@ -418,6 +424,31 @@ export function createApp(
   // Bridge runtime-config assembly to plugin skills + context (§4.4).
   setPluginAgentContributions(pluginService);
   const publicApi = new Hono();
+  // CORS decides whether a browser may *read* a response; it does not stop the
+  // request being sent and acted on. A `no-cors` POST with a simple content
+  // type skips the preflight entirely, and the typed route parser reads the
+  // body with `c.req.json()` regardless of content type — so a page on any
+  // origin could drive this API blind. Reject a foreign browser origin here
+  // instead. `requireJsonForMutation` is deliberately NOT set: it answers 415
+  // to any mutation without `application/json`, which would break every
+  // existing `curl -d` caller. The origin check alone stops browser CSRF,
+  // because a browser always sends `Origin` on a cross-origin mutation.
+  // Non-browser callers (curl, the `bb` CLI, the SDK) send no `Origin` and pass
+  // through untouched.
+  publicApi.use("*", async (context, next) => {
+    // A plugin's own HTTP routes declare their auth mode (`local` | `token` |
+    // `none`). `none` is deliberately reachable from any origin, and `token`
+    // authenticates with a secret rather than an origin, so this blanket check
+    // must not pre-empt the per-route one `registerPluginRoutes` applies.
+    if (PLUGIN_WIRE_HTTP_PATH.test(context.req.path)) {
+      return next();
+    }
+    const problem = browserRequestProblem(context, deps);
+    if (problem !== null) {
+      throw new ApiError(problem.status, "forbidden_origin", problem.error);
+    }
+    return next();
+  });
   const pluginCatalogService = createPluginCatalogService({
     db: deps.db,
     appVersion: deps.config.appVersion,

--- a/apps/server/test/security/api-origin-guard.test.ts
+++ b/apps/server/test/security/api-origin-guard.test.ts
@@ -1,0 +1,154 @@
+import { createNodeBbSdk } from "@bb/sdk/node";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  startTestServer,
+  type RunningTestServer,
+} from "../helpers/test-app.js";
+
+// CORS decides whether a browser may read a response; it never stops the
+// request. A `no-cors` POST with a simple content type skips the preflight and
+// the handler runs. `/api/v1/*` now rejects a foreign browser origin outright.
+//
+// These tests pin the callers that must keep working, because the guard's whole
+// risk is locking someone out: bb Connect through the tunnel, curl, the `bb`
+// CLI, and the SDK.
+
+let server: RunningTestServer | null = null;
+
+afterEach(async () => {
+  await server?.close();
+  server = null;
+});
+
+interface RequestArgs {
+  headers?: Record<string, string>;
+  method?: string;
+  path?: string;
+}
+
+async function statusFor(
+  baseUrl: string,
+  args: RequestArgs = {},
+): Promise<number> {
+  const response = await fetch(
+    new URL(args.path ?? "/api/v1/threads", baseUrl),
+    {
+      method: args.method ?? "GET",
+      ...(args.headers === undefined ? {} : { headers: args.headers }),
+    },
+  );
+  return response.status;
+}
+
+describe("/api/v1 browser origin guard", () => {
+  it("passes callers that send no Origin: curl, the bb CLI, and the SDK", async () => {
+    server = await startTestServer();
+
+    // Node's `fetch` sends no `Origin` on a same-origin-less request, exactly
+    // as curl and the CLI/SDK HTTP clients do.
+    expect(await statusFor(server.baseUrl)).toBe(200);
+    expect(
+      await statusFor(server.baseUrl, {
+        method: "POST",
+        path: "/api/v1/threads",
+        headers: { "content-type": "application/json" },
+      }),
+    ).not.toBe(403);
+
+    // A mutation with a non-JSON body must NOT be rejected for its content
+    // type: `requireJsonForMutation` stays off so `curl -d` keeps working.
+    expect(
+      await statusFor(server.baseUrl, {
+        method: "POST",
+        path: "/api/v1/threads",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      }),
+    ).not.toBe(415);
+
+    // The SDK over its own HTTP client, end to end.
+    const sdk = createNodeBbSdk({ baseUrl: server.baseUrl });
+    await expect(sdk.threads.list()).resolves.toBeDefined();
+  });
+
+  it("rejects a foreign browser origin on both reads and mutations", async () => {
+    server = await startTestServer();
+
+    for (const method of ["GET", "POST", "PATCH", "DELETE"]) {
+      expect(
+        await statusFor(server.baseUrl, {
+          method,
+          headers: {
+            origin: "http://127.0.0.1:3009",
+            "content-type": "text/plain",
+          },
+        }),
+      ).toBe(403);
+    }
+  });
+
+  it("rejects a sandboxed iframe's opaque origin", async () => {
+    server = await startTestServer();
+
+    // A `sandbox="allow-scripts"` frame (the HTML/file previews) has an opaque
+    // origin and sends the literal `null`, which is not a bb app origin.
+    expect(
+      await statusFor(server.baseUrl, {
+        method: "POST",
+        headers: { origin: "null", "content-type": "text/plain" },
+      }),
+    ).toBe(403);
+  });
+
+  it("accepts the app's own origin and the request host", async () => {
+    server = await startTestServer();
+    const origin = new URL(server.baseUrl).origin;
+
+    expect(await statusFor(server.baseUrl, { headers: { origin } })).toBe(200);
+  });
+
+  // The bb Connect tunnel forwards a remote request to the loopback server
+  // after rewriting `Origin` from the public connect origin to the loopback
+  // origin (`headersForLoopbackRequest` in @bb/tunnel-client) and dropping the
+  // public `Host`. That rewrite is what keeps a remote user working; this test
+  // is the canary for it.
+  it("accepts the origin the connect tunnel rewrites to", async () => {
+    server = await startTestServer();
+    const loopbackOrigin = new URL(server.baseUrl).origin;
+
+    expect(
+      await statusFor(server.baseUrl, {
+        method: "POST",
+        headers: {
+          origin: loopbackOrigin,
+          host: new URL(server.baseUrl).host,
+          "content-type": "application/json",
+        },
+      }),
+    ).not.toBe(403);
+  });
+
+  // If the tunnel ever stops rewriting `Origin`, a remote user is locked out of
+  // their own server. This asserts the shape of that failure so the cause is
+  // obvious rather than mysterious.
+  it("rejects an unrewritten public connect origin, documenting the tunnel dependency", async () => {
+    server = await startTestServer();
+
+    expect(
+      await statusFor(server.baseUrl, {
+        headers: { origin: "https://bee.getbb.app" },
+      }),
+    ).toBe(403);
+  });
+
+  // A deployment that serves the app from a non-loopback domain configures
+  // `appUrl`; that origin must be trusted.
+  it("accepts a configured app origin", async () => {
+    server = await startTestServer({ appUrl: "https://app.example.com" });
+
+    expect(
+      await statusFor(server.baseUrl, {
+        headers: { origin: "https://app.example.com" },
+      }),
+    ).toBe(200);
+  });
+});

--- a/apps/server/test/security/api-origin-guard.test.ts
+++ b/apps/server/test/security/api-origin-guard.test.ts
@@ -1,3 +1,4 @@
+import http from "node:http";
 import { createNodeBbSdk } from "@bb/sdk/node";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -38,6 +39,25 @@ async function statusFor(
     },
   );
   return response.status;
+}
+
+/** `fetch` drops a `Host` override, so proxy shapes need the raw client. */
+function rawStatus(
+  baseUrl: string,
+  headers: Record<string, string>,
+): Promise<number> {
+  const url = new URL("/api/v1/threads", baseUrl);
+  return new Promise((resolve, reject) => {
+    const request = http.request(
+      { host: url.hostname, port: url.port, path: url.pathname, headers },
+      (response) => {
+        response.resume();
+        resolve(response.statusCode ?? 0);
+      },
+    );
+    request.once("error", reject);
+    request.end();
+  });
 }
 
 describe("/api/v1 browser origin guard", () => {
@@ -136,6 +156,66 @@ describe("/api/v1 browser origin guard", () => {
     expect(
       await statusFor(server.baseUrl, {
         headers: { origin: "https://bee.getbb.app" },
+      }),
+    ).toBe(403);
+  });
+
+  // bb is commonly served over a LAN address or Tailscale Serve, which the
+  // server cannot enumerate into an allowlist. `isTrustedOrigin` admits those
+  // by matching the origin against the request `Host` (or `X-Forwarded-Host`
+  // with `X-Forwarded-Proto`). `fetch` silently drops a `Host` override, so
+  // these go over `http.request` — a `fetch`-based version of this test passes
+  // for the wrong reason.
+  it("accepts bb served over a LAN address or Tailscale Serve", async () => {
+    server = await startTestServer();
+    const port = new URL(server.baseUrl).port;
+
+    // LAN: the reverse proxy passes Host through.
+    expect(
+      await rawStatus(server.baseUrl, {
+        origin: `http://192.168.1.5:${port}`,
+        host: `192.168.1.5:${port}`,
+      }),
+    ).toBe(200);
+
+    // Tailscale Serve: TLS terminated upstream, Host preserved. bb supports
+    // this shape deliberately (see the plugin-wire suite), so it must pass.
+    expect(
+      await rawStatus(server.baseUrl, {
+        origin: "https://box.ts.net",
+        host: "box.ts.net",
+        "x-forwarded-proto": "https",
+      }),
+    ).toBe(200);
+
+    // A LAN deployment behind a proxy that rewrites Host but forwards it.
+    expect(
+      await rawStatus(server.baseUrl, {
+        origin: `http://192.168.1.5:${port}`,
+        host: `127.0.0.1:${port}`,
+        "x-forwarded-host": `192.168.1.5:${port}`,
+      }),
+    ).toBe(200);
+
+    // IPv6 literals are addresses too.
+    expect(
+      await rawStatus(server.baseUrl, {
+        origin: `http://[::1]:${port}`,
+        host: `[::1]:${port}`,
+      }),
+    ).toBe(200);
+  });
+
+  // A rewriting proxy must forward the original authority. bb already imposes
+  // this on its plugin routes, which have used the same check all along.
+  it("requires a rewriting proxy to send X-Forwarded-Host", async () => {
+    server = await startTestServer();
+    const port = new URL(server.baseUrl).port;
+
+    expect(
+      await rawStatus(server.baseUrl, {
+        origin: `http://192.168.1.5:${port}`,
+        host: `127.0.0.1:${port}`,
       }),
     ).toBe(403);
   });


### PR DESCRIPTION
**Layer 1 of 2.** Prerequisite for #1537, which deletes the in-app browser's loopback firewall. This layer must land first: it gives each bb service the origin guard that the firewall was standing in for.

## Summary

CORS decides whether a browser may *read* a response. It never stops the request being sent and acted on. A `no-cors` POST with a simple content type skips the preflight entirely, and the typed route parser reads the body with `c.req.json()` regardless of content type — so a page on any origin could drive these APIs blind, seeing nothing but changing state.

Three services now reject a foreign browser origin outright:

| Service | Before | After |
|---|---|---|
| Server `/api/v1/*` | `cors()` only. `browserRequestProblem` was applied to `/ws`, `/ws/terminals/:id`, and routes in `plugins.ts` / `files.ts` — not the rest. | Origin guard on the whole subtree. |
| Host daemon local API | Computed an allow predicate for `cors({origin})` but never rejected on it. | The same predicate enforced as a request guard. |
| Machine-auth proxy | Nothing. It stamps `x-bb-connect-machine` onto everything it forwards. | `Origin` + `Sec-Fetch-Site`, plus a `Host` authority check. |

**Excluded on purpose: `/api/v1/plugins/<id>/http/*`.** A plugin declares its own auth mode per route — `local`, `token`, or `none` — and `none` is deliberately reachable from any origin while `token` authenticates with a secret. `registerPluginRoutes` applies the right check per route; a blanket guard would pre-empt it. I found this by running the suite, not by reading: three `plugin-wire` tests failed, including `auth "none" passes foreign origins through`.

**`requireJsonForMutation` is deliberately NOT set** on `/api/v1/*`. It answers 415 to any mutation without `application/json`, which would break every existing `curl -d` caller. The origin check alone stops browser CSRF, because a browser always sends `Origin` on a cross-origin mutation.

**`Sec-Fetch-Mode` is deliberately not a discriminator** on the proxy. Node's own `fetch` sends `sec-fetch-mode: cors`, so keying on it rejects the runtime processes the proxy exists to serve — three proxy tests went red when I tried.

## DNS rebinding (from review)

SlopCop found that `isTrustedOrigin` trusts an origin matching the authority the client addressed, and a page on a public name resolving to this machine controls both `Origin` and `Host`. Reproduced: `Origin: http://rebind.example:<port>` with a matching `Host` returned **200**.

**Fixed for the host-daemon local API** (6018b61). That API binds `127.0.0.1`, so a genuine caller always addresses it by a loopback name or a bare address; the self-origin branch now requires that. Configured allowlists are untouched. Regression test included, over `http.request` since `fetch` drops a `Host` override.

**Not fixed for the server**, deliberately. I implemented the same rule there and the existing suite rejected it:

```
plugin-wire.test.ts > local auth rejects foreign origins but tolerates host-bound LAN/Tailscale serving
AssertionError: expected 403 to be 200
```

bb deliberately supports being served at an arbitrary DNS name bound to the request `Host` — `https://bb.lan.test` is asserted to return 200, with a comment saying so. That is header-indistinguishable from `rebind.example`, so closing the bypass necessarily drops unconfigured DNS-name serving. That is a decision about supported deployment shapes, not a bug fix, so it is filed rather than made here.

Scope note: this is **pre-existing**, not introduced here — `browserRequestProblem` has guarded `/ws` and the plugin and file routes with this same branch all along. This PR widens its reach to the rest of `/api/v1`, which is strictly more protection than the `cors()`-only state it replaces.

## Verification

Everything below was tested, not reasoned about. `apps/server/test/security/api-origin-guard.test.ts` runs against a real server.

**1. bb Connect through the tunnel — the highest risk, and it is safe.** Not because the guard is lenient, but because the tunnel already rewrites the origin. For the bare-handle path (the bb server, which is what `https://bee.getbb.app` uses), `resolveStreamOrigin` in `plugins/connect/src/tunnel.ts` sets `publicOrigin` to the credential's server origin, and `headersForLoopbackRequest` in `@bb/tunnel-client` rewrites a matching `Origin` to the loopback origin while dropping the public `Host`. The local server therefore sees `Origin: http://127.0.0.1:38886` against a matching `Host` — same-origin, allowed.

Two tests pin this: one asserts the rewritten shape passes, and one asserts an **unrewritten** `https://bee.getbb.app` gets 403. That second test is the canary — if the rewrite ever regresses, it names the cause instead of leaving a mysterious lockout.

**2. Sandboxed iframes.** The HTML/file previews use `sandbox="allow-scripts"` without `allow-same-origin`, so their origin is opaque and they send `Origin: null`, which fails the parse and gets 403. What that does and does not affect:

- The iframe's own document load is a **navigation** and sends no `Origin` → unaffected. `plugins/inline-vis` loads `/api/v1/threads/<id>/worktree/files/...` directly as the frame `src`, and it keeps working.
- Sub-resource loads (`<script src>`, `<img>`) send no `Origin` → unaffected.
- Only `fetch`/XHR **from inside** a sandboxed preview is now rejected. I checked: nothing bb ships does that. The only in-app call to `/api/v1` outside the app bundle is `plugins/tasks`, which runs in the main document at the app origin.

That behavior change is intended — sandboxed previews render untrusted user and agent output.

**3. curl, the `bb` CLI, and the SDK.** All send no `Origin` and pass untouched. Tested directly, including a `POST` with `application/x-www-form-urlencoded` asserting it is **not** 415, so the `curl -d` path is pinned against someone turning `requireJsonForMutation` on later. The SDK is exercised end to end through `createNodeBbSdk`.

## GET side-effect audit

Because a browser does not send `Origin` on a GET, a state-changing GET would slip past this guard. I enumerated all **66** GET handlers under `/api/v1/*` and checked each for mutating calls.

**No GET changes durable state.** Two are worth naming:

- `threads/:id/events/wait` — a bounded long-poll (≤60s) that registers a waiter and cancels it. A resource hold, not a state change, and the response is unreadable cross-origin.
- `terminals/:id/output` — sends a `terminal.attach` replay RPC to the daemon. Idempotent; `sinceSeq` is caller-supplied and nothing is consumed.

The rest of the flagged matches were false positives on inspection: `createDaemonFileContentResponse` builds a `Response`, and the `delete` hits are in-memory cache and lease eviction (`conversationOutlineCache`, `previewLeases`). `requireThreadCommandEnvironment` looks up an environment and never provisions one, so `GET /rate-limit-recovery` is a pure read.

Nothing to fix, so nothing filed.

## Testing

- `apps/server/test/security/api-origin-guard.test.ts` — 7 tests covering all four verifications above.
- Salvaged with their reviewed tests from the closed #1522: the daemon local-API guard and the machine-auth proxy guards, including the rebound-`Host` test.
- `pnpm exec turbo run typecheck test --filter=@bb/server --filter=@bb/host-daemon --force`: **1479** server tests, **553** host-daemon tests, all passing.

One unrelated pre-existing failure in this environment: `internal-skill-trees.test.ts` asserts file mode `0644` while my shell's `umask 0002` produces `0664`. It passes under `umask 022`, and touches no code in this change.

Fixes #1531

> AGENT GENERATED: by Claude Opus 5
