### PR TITLE
Keep post-turn compaction pending while idle

### DIFF
--- a/packages/thread-view/src/build-event-projection.ts
+++ b/packages/thread-view/src/build-event-projection.ts
@@ -673,8 +673,9 @@ function buildFlatProjectionData(
         );
       } else {
         onThreadInterrupted({
-          completedAt: meta.createdAt,
+          meta,
           state,
+          threadId: decoded.threadId,
         });
         flushProjectionBufferedOutputs(state);
       }

--- a/packages/thread-view/src/event-projection-state.ts
+++ b/packages/thread-view/src/event-projection-state.ts
@@ -22,9 +22,11 @@ import { createToolActivityState } from "./tool-activity-projection.js";
 import {
   createOperationProjectionState,
   flushPendingFileEditOutput,
+  interruptOpenCompactions,
   type CompactionTurnFinalizationStatus,
   type OperationProjectionState,
 } from "./operation-projection.js";
+import type { EventMeta } from "./event-decode.js";
 import {
   createReasoningProjectionState,
   finalizeOpenReasoningLifecycles,
@@ -69,8 +71,9 @@ interface FinalizeProjectionMessagesArgs {
 }
 
 interface ThreadInterruptedArgs {
-  completedAt: number;
+  meta: EventMeta;
   state: ProjectionState;
+  threadId: string;
 }
 
 export interface ProjectionState
@@ -144,10 +147,15 @@ export function onTurnCompleted(args: CompleteTurnArgs): void {
 }
 
 export function onThreadInterrupted(args: ThreadInterruptedArgs): void {
-  args.state.threadInterruptedAt = args.completedAt;
+  args.state.threadInterruptedAt = args.meta.createdAt;
+  interruptOpenCompactions({
+    state: args.state,
+    meta: args.meta,
+    threadId: args.threadId,
+  });
   for (const turnId of args.state.openTurnIds) {
     args.state.pendingFinalizationByTurnId.set(turnId, {
-      completedAt: args.completedAt,
+      completedAt: args.meta.createdAt,
       status: "interrupted",
     });
   }
@@ -211,7 +219,6 @@ function finalizePendingMessages(args: FinalizeProjectionMessagesArgs): void {
     // interruption settles it.
     if (
       args.options?.threadStatus === "idle" &&
-      args.state.threadInterruptedAt === null &&
       message.opType === "compaction" &&
       message.scope.kind === "turn" &&
       args.state.closedTurnIds.has(message.scope.turnId)

--- a/packages/thread-view/src/event-projection-state.ts
+++ b/packages/thread-view/src/event-projection-state.ts
@@ -204,6 +204,20 @@ function finalizePendingMessages(args: FinalizeProjectionMessagesArgs): void {
 
   for (const message of args.state.messages) {
     if (message.kind !== "operation") continue;
+    // Pi can start automatic compaction after it has completed the owning
+    // turn. The thread is idle while that background lifecycle is still in
+    // flight, so idle alone is not evidence that the compaction stopped. Keep
+    // it pending until an explicit completion, provider error, or thread
+    // interruption settles it.
+    if (
+      args.options?.threadStatus === "idle" &&
+      args.state.threadInterruptedAt === null &&
+      message.opType === "compaction" &&
+      message.scope.kind === "turn" &&
+      args.state.closedTurnIds.has(message.scope.turnId)
+    ) {
+      continue;
+    }
     finalizeOperationMessage(message, args.options);
   }
 

--- a/packages/thread-view/src/operation-projection.ts
+++ b/packages/thread-view/src/operation-projection.ts
@@ -83,6 +83,12 @@ interface FinalizeOpenCompactionsForTurnArgs {
   detail: string | undefined;
 }
 
+interface InterruptOpenCompactionsArgs {
+  state: OperationProjectionState;
+  meta: EventMeta;
+  threadId: string;
+}
+
 type LifecycleStatus = Extract<
   EventProjectionOperationMessage["status"],
   "pending" | "completed" | "error" | "interrupted"
@@ -902,6 +908,23 @@ export function onCompactionEnd(
  * Turn-end finalization is provisional: keep the compaction open so a later
  * explicit compaction completion can override the inferred error/interruption.
  */
+function finalizeOpenCompaction(
+  message: EventProjectionOperationMessage,
+  meta: EventMeta,
+  status: CompactionTurnFinalizationStatus,
+  detail: string | undefined,
+): void {
+  message.sourceSeqEnd = Math.max(message.sourceSeqEnd, meta.seq);
+  message.createdAt = Math.max(message.createdAt, meta.createdAt);
+  message.completedAt = meta.createdAt;
+  message.status = status;
+  message.title =
+    status === "error"
+      ? "Context compaction failed"
+      : "Context compaction interrupted";
+  message.detail = detail ?? message.detail;
+}
+
 export function finalizeOpenCompactionsForTurn(
   args: FinalizeOpenCompactionsForTurnArgs,
 ): void {
@@ -916,14 +939,23 @@ export function finalizeOpenCompactionsForTurn(
       continue;
     }
 
-    message.sourceSeqEnd = Math.max(message.sourceSeqEnd, args.meta.seq);
-    message.createdAt = Math.max(message.createdAt, args.meta.createdAt);
-    message.completedAt = args.meta.createdAt;
-    message.status = args.status;
-    message.title =
-      args.status === "error"
-        ? "Context compaction failed"
-        : "Context compaction interrupted";
-    message.detail = args.detail ?? message.detail;
+    finalizeOpenCompaction(message, args.meta, args.status, args.detail);
+  }
+}
+
+/** Settle only compactions that are pending when this interruption is seen. */
+export function interruptOpenCompactions(
+  args: InterruptOpenCompactionsArgs,
+): void {
+  for (const message of args.state.openCompactionsByKey.values()) {
+    if (
+      message.threadId !== args.threadId ||
+      message.status !== "pending" ||
+      message.sourceSeqStart > args.meta.seq
+    ) {
+      continue;
+    }
+
+    finalizeOpenCompaction(message, args.meta, "interrupted", undefined);
   }
 }

--- a/packages/thread-view/test/timeline-interruption.test.ts
+++ b/packages/thread-view/test/timeline-interruption.test.ts
@@ -64,6 +64,59 @@ function renderIdleTimeline(events: ThreadEventRow[]) {
 }
 
 describe("timeline interruption projection", () => {
+  it("keeps post-turn automatic compaction pending while the thread is idle", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const events = [
+      event.turnStarted({ createdAt: 0 }),
+      event.turnCompleted({ createdAt: 1_000 }),
+      event.contextCompactionStarted({ createdAt: 2_000 }),
+    ];
+    const timeline = renderIdleTimeline(events);
+
+    expect(timeline.messages).toContainEqual(
+      expect.objectContaining({
+        kind: "operation",
+        opType: "compaction",
+        status: "pending",
+        title: "Compacting context",
+        completedAt: null,
+      }),
+    );
+
+    const completedTimeline = renderIdleTimeline([
+      ...events,
+      event.threadCompacted({ createdAt: 3_000 }),
+    ]);
+    expect(completedTimeline.messages).toContainEqual(
+      expect.objectContaining({
+        kind: "operation",
+        opType: "compaction",
+        status: "completed",
+        title: "Context compacted",
+        completedAt: 3_000,
+      }),
+    );
+  });
+
+  it("interrupts post-turn compaction when the thread is explicitly interrupted", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const timeline = renderIdleTimeline([
+      event.turnStarted({ createdAt: 0 }),
+      event.turnCompleted({ createdAt: 1_000 }),
+      event.contextCompactionStarted({ createdAt: 2_000 }),
+      event.systemThreadInterrupted({ createdAt: 3_000 }),
+    ]);
+
+    expect(timeline.messages).toContainEqual(
+      expect.objectContaining({
+        kind: "operation",
+        opType: "compaction",
+        status: "interrupted",
+        title: "Context compaction interrupted",
+      }),
+    );
+  });
+
   it("uses interrupted turn completion time for pending command and tool rows", () => {
     const event = createTimelineEventFactory({ threadId: "thread-1" });
     const timeline = renderIdleTimeline([

--- a/packages/thread-view/test/timeline-interruption.test.ts
+++ b/packages/thread-view/test/timeline-interruption.test.ts
@@ -113,6 +113,36 @@ describe("timeline interruption projection", () => {
         opType: "compaction",
         status: "interrupted",
         title: "Context compaction interrupted",
+        completedAt: 3_000,
+      }),
+    );
+  });
+
+  it("does not apply an old thread interruption to a later compaction", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const timeline = renderIdleTimeline([
+      event.turnStarted({ turnId: "turn-a", createdAt: 0 }),
+      event.turnCompleted({
+        turnId: "turn-a",
+        status: "interrupted",
+        createdAt: 1_000,
+      }),
+      event.systemThreadInterrupted({ createdAt: 1_100 }),
+      event.turnStarted({ turnId: "turn-b", createdAt: 2_000 }),
+      event.turnCompleted({ turnId: "turn-b", createdAt: 3_000 }),
+      event.contextCompactionStarted({
+        turnId: "turn-b",
+        createdAt: 4_000,
+      }),
+    ]);
+
+    expect(timeline.messages).toContainEqual(
+      expect.objectContaining({
+        kind: "operation",
+        opType: "compaction",
+        status: "pending",
+        title: "Compacting context",
+        completedAt: null,
       }),
     );
   });


### PR DESCRIPTION
## Summary

- keep Pi-style automatic compaction pending after its owning turn completes while the thread is idle
- allow the later explicit compaction event to settle the row as completed
- preserve interruption behavior when the thread receives a real interruption event

## Testing

- `pnpm exec turbo run test --filter=@bb/thread-view --force`
- `pnpm exec turbo run typecheck --filter=@bb/thread-view`
- `pnpm exec prettier --check packages/thread-view/src/event-projection-state.ts packages/thread-view/test/timeline-interruption.test.ts`
- `git diff --check`

> AGENT GENERATED: by GPT-5