### PR TITLE
Handle retried turn starts in timelines

### DIFF
--- a/apps/server/test/internal/internal-events-tool-calls.test.ts
+++ b/apps/server/test/internal/internal-events-tool-calls.test.ts
@@ -1010,13 +1010,18 @@ describe("internal event and tool-call routes", () => {
         harness.db.select().from(threads).where(eq(threads.id, thread.id)).get()
           ?.status,
       ).toBe("idle");
-      expect(
-        harness.db
-          .select()
-          .from(events)
-          .where(eq(events.threadId, thread.id))
-          .all(),
-      ).toHaveLength(4);
+      const storedEventTypes = harness.db
+        .select({ type: events.type })
+        .from(events)
+        .where(eq(events.threadId, thread.id))
+        .orderBy(events.sequence)
+        .all()
+        .map((event) => event.type);
+      expect(storedEventTypes).toEqual([
+        "turn/started",
+        "turn/completed",
+        "turn/completed",
+      ]);
     });
   });
 

--- a/apps/server/test/public/public-thread-data.test.ts
+++ b/apps/server/test/public/public-thread-data.test.ts
@@ -65,7 +65,6 @@ import { withTestHarness } from "../helpers/test-app.js";
 const queuedMessageIdResponseSchema = z.object({
   id: z.string(),
 });
-
 const threadReadResponseSchema = z.object({
   lastReadAt: z.number().nullable(),
 });
@@ -440,6 +439,63 @@ describe("public thread data routes", () => {
             }),
           ]),
         }),
+      );
+    });
+  });
+
+  it("returns a timeline when persisted daemon retry history has duplicate turn starts", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedThreadFixture(harness);
+      const eventBase = {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-retried",
+        scope: turnScope("turn-retried"),
+      };
+
+      seedEvent(harness.deps, {
+        ...eventBase,
+        sequence: 1,
+        type: "turn/started",
+        data: {},
+      });
+      seedEvent(harness.deps, {
+        ...eventBase,
+        sequence: 2,
+        type: "turn/started",
+        data: {},
+      });
+      seedEvent(harness.deps, {
+        ...eventBase,
+        sequence: 3,
+        type: "item/completed",
+        data: {
+          item: {
+            type: "toolCall",
+            id: "tool-call-retried",
+            tool: "read",
+            status: "completed",
+            result: "ok",
+          },
+        },
+      });
+      seedEvent(harness.deps, {
+        ...eventBase,
+        sequence: 4,
+        type: "turn/completed",
+        data: { status: "completed" },
+      });
+
+      const response = await harness.app.request(
+        `/api/v1/threads/${thread.id}/timeline`,
+      );
+
+      expect(response.status).toBe(200);
+      const timeline = threadTimelineResponseSchema.parse(
+        await readJson(response),
+      );
+      expect(timeline.rows.filter((row) => row.kind === "turn")).toHaveLength(
+        1,
       );
     });
   });

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -354,9 +354,6 @@ function collectDaemonTurnStartLookupKeys(
   const keys: ThreadTurnKey[] = [];
 
   for (const input of eventInputs) {
-    if (input.type === "turn/started") {
-      continue;
-    }
     const turnId = getThreadEventScopeTurnId(input.scope);
     if (turnId === undefined) {
       continue;
@@ -399,14 +396,25 @@ const ORPHAN_DROPPABLE_TURN_EVENT_TYPES: ReadonlySet<ThreadEventType> = new Set(
   "provider/unhandled",
 ]);
 
-type DaemonTurnStartDisposition = "append" | "skip-orphan-snapshot";
+type DaemonTurnStartDisposition =
+  | "append"
+  | "skip-duplicate-turn-start"
+  | "skip-orphan-snapshot";
 
 function resolveDaemonTurnStartDisposition(
   input: AppendDaemonEventInput,
   startedTurnKeys: ReadonlySet<string>,
 ): DaemonTurnStartDisposition {
   if (input.type === "turn/started") {
-    return "append";
+    const turnId = getThreadEventScopeTurnId(input.scope);
+    if (turnId === undefined) {
+      return "append";
+    }
+    const key = buildThreadTurnKey({ threadId: input.threadId, turnId });
+    // A retry after an ambiguous 5xx can repost a batch the server already
+    // committed. Turn identity is stable across that retry, so keep the first
+    // start as canonical instead of persisting a projection-breaking duplicate.
+    return startedTurnKeys.has(key) ? "skip-duplicate-turn-start" : "append";
   }
 
   const turnId = getThreadEventScopeTurnId(input.scope);
@@ -585,11 +593,15 @@ export function appendDaemonEventsInTransaction(
   );
   const now = Date.now();
   for (const [index, input] of eventInputs.entries()) {
-    if (
-      resolveDaemonTurnStartDisposition(input, startedTurnKeys) ===
-      "skip-orphan-snapshot"
-    ) {
+    const turnStartDisposition = resolveDaemonTurnStartDisposition(
+      input,
+      startedTurnKeys,
+    );
+    if (turnStartDisposition === "skip-orphan-snapshot") {
       skippedTurnUnstartedInputIndexes.push(index);
+      continue;
+    }
+    if (turnStartDisposition === "skip-duplicate-turn-start") {
       continue;
     }
 

--- a/packages/db/test/data/events.test.ts
+++ b/packages/db/test/data/events.test.ts
@@ -371,6 +371,36 @@ describe("events", () => {
     ]);
   });
 
+  it("does not append turn/started again when a daemon retries an accepted batch", () => {
+    const { db, thread } = setup();
+    const turnStarted = {
+      threadId: thread.id,
+      type: "turn/started" as const,
+      ...createTurnEventFields({ turnId: "turn_retried" }),
+      environmentId: null,
+      providerThreadId: "provider_thr_retried",
+      data: JSON.stringify({
+        providerThreadId: "provider_thr_retried",
+        turnId: "turn_retried",
+      }),
+    };
+
+    const first = db.transaction(
+      (tx) => appendDaemonEventsInTransaction(tx, [turnStarted]),
+      { behavior: "immediate" },
+    );
+    const retry = db.transaction(
+      (tx) => appendDaemonEventsInTransaction(tx, [turnStarted]),
+      { behavior: "immediate" },
+    );
+
+    expect(first.insertedInputIndexes).toEqual([0]);
+    expect(retry.insertedInputIndexes).toEqual([]);
+    expect(
+      listEvents(db, { threadId: thread.id }).map((event) => event.type),
+    ).toEqual(["turn/started"]);
+  });
+
   it("rejects daemon turn-scoped events before turn/started is stored", () => {
     const { db, thread } = setup();
 

--- a/packages/thread-view/src/group-event-projection-turns.ts
+++ b/packages/thread-view/src/group-event-projection-turns.ts
@@ -250,9 +250,11 @@ export function groupEventProjectionTurns(
       });
       const existing = turnsById.get(turnId);
       if (existing) {
-        throw new Error(
-          `Timeline projection found duplicate turn/started for ${turnId}`,
-        );
+        // Daemon delivery retries can leave legacy histories with the same
+        // provider turn start persisted twice after an ambiguous 5xx. The turn
+        // id is the identity boundary; keep its first start as canonical so one
+        // replayed lifecycle marker cannot make the whole timeline unreadable.
+        continue;
       }
       turnsById.set(turnId, createProjectionTurn(event, meta));
       entryDrafts.push({

--- a/packages/thread-view/test/build-thread-timeline.test.ts
+++ b/packages/thread-view/test/build-thread-timeline.test.ts
@@ -948,6 +948,28 @@ function fileChangeRowIdByPath(
 }
 
 describe("buildThreadTimelineFromEvents", () => {
+  it("renders one turn when daemon retry history contains duplicate turn starts", () => {
+    const rows = buildTimelineRows([
+      turnStartedEvent({ seq: 1 }),
+      turnStartedEvent({ seq: 2 }),
+      toolCallItemEvent({
+        seq: 3,
+        tool: "read",
+        type: "item/started",
+      }),
+      toolCallItemEvent({
+        result: "ok",
+        seq: 4,
+        tool: "read",
+        type: "item/completed",
+      }),
+      turnCompletedEvent({ seq: 5 }),
+    ]);
+
+    expect(rows.filter((row) => row.kind === "turn")).toHaveLength(1);
+    expect(collectToolRows(rows)).toHaveLength(1);
+  });
+
   const lowercaseStructuredToolCases: LowercaseStructuredToolCase[] = [
     {
       expectedIntent: {


### PR DESCRIPTION
## Summary

- tolerate legacy timeline histories containing duplicate `turn/started` events after daemon delivery retries
- prevent future retries from persisting the same turn start twice
- cover the ingestion, projection, and public timeline route paths with regressions

## Root cause

The host-to-server event channel is intentionally at-least-once, but daemon event ingestion was not idempotent for `turn/started`:

1. The server writes a daemon event batch inside an immediate database transaction.
2. The transaction can commit before the HTTP request finishes its post-commit effects and returns an acknowledgement.
3. If the daemon receives an ambiguous network failure or retryable 5xx after that commit, its event sink keeps the entire in-memory queue and posts it again on the next flush.
4. Daemon event envelopes have no stable delivery ID. The server assigns a new event ID and sequence to every insert, and the previous ingestion path always appended `turn/started` without checking the semantic identity `(threadId, turnId)`.
5. The retry therefore persisted another start for the same provider turn.
6. Timeline projection requires exactly one start per turn and threw on the duplicate, causing the public timeline route to return 500 even though thread metadata, events, and final output remained stored.

The observed incident matched this mechanism: repeated gateway 502/504 responses were followed by repeated lifecycle rows with the same stable turn and item IDs at later server sequences. That proves the daemon replayed an already-accepted batch; the provider did not create distinct turns.

## Fix boundary

This PR restores the invariant at both relevant boundaries:

- ingestion treats `(threadId, turnId)` as the identity of `turn/started` and skips a replay when that start is already stored
- projection keeps the first start as canonical so histories written before this fix remain readable

This is deliberately not a general exactly-once event-delivery redesign. Other replayed event types retain their existing behavior. General batch idempotency would require a stable daemon delivery identity and a broader persistence contract; it is not necessary to stop duplicate turn starts from making timelines unreadable.

## Reproduce the bug locally

This repro uses only synthetic test data. It does not require access to a production database, user account, or affected thread.

From a checkout of this PR:

```bash
repo_dir=$(git rev-parse --show-toplevel)
repro_dir=/tmp/bb-timeline-pr-repro-1560
base_sha=a83c12946
fixed_sha=f4b6cbba7

git worktree add --detach "${repro_dir}" "${base_sha}"
git diff "${base_sha}" "${fixed_sha}" \
  -- apps/server/test/public/public-thread-data.test.ts |
  git -C "${repro_dir}" apply -

cd "${repro_dir}"
pnpm install --frozen-lockfile
pnpm exec turbo run test \
  --filter=@bb/server \
  --only \
  --force \
  -- \
  --run test/public/public-thread-data.test.ts \
  -t "returns a timeline when persisted daemon retry history has duplicate turn starts"
```

The regression fixture inserts two `turn/started` rows with the same turn ID, then requests the public timeline route. The unfixed parent commit fails with:

```text
AssertionError: expected 500 to be 200
```

Clean up the disposable worktree:

```bash
cd "${repo_dir}"
git worktree remove --force "${repro_dir}"
```

## Verify the fix

On this PR's head:

```bash
pnpm exec turbo run test \
  --filter=@bb/server \
  --only \
  --force \
  -- \
  --run test/public/public-thread-data.test.ts \
  -t "returns a timeline when persisted daemon retry history has duplicate turn starts"
```

Expected result: the route returns 200, the test passes, and the timeline contains one canonical turn.

## Behavior after this PR

- Existing duplicate-start histories remain readable.
- Reposted `turn/started` events are ignored at ingestion, preventing new projection-breaking histories.
- Other replayed event types retain their existing behavior.

## Verification

- Red repro on `a83c12946`: route regression fails with `expected 500 to be 200`
- `@bb/thread-view` timeline test file: 72 passed
- `@bb/db` events test file: 79 passed
- `@bb/server` public thread data test file: 75 passed
- `@bb/server` internal event/tool-call test file: 25 passed
- Turbo typecheck: `@bb/db`, `@bb/thread-view`, and `@bb/server` passed
- CI: all required checks passed
- Independent architecture and code reviews: CORRECT
- Visual QA: not applicable; this changes event ingestion/projection and no UI code


Fixes #1839

BB-Thread-ID: thr_tq4bctwps7

> AGENT GENERATED: by GPT-5
