### PR TITLE
fix(plugins): warn when installing a path plugin from a managed workspace

### DIFF
--- a/apps/server/src/services/plugins/plugin-registration.ts
+++ b/apps/server/src/services/plugins/plugin-registration.ts
@@ -1,4 +1,5 @@
 import { resolve } from "node:path";
+import { isBbManagedWorkspacePath } from "../threads/worktree-paths.js";
 import {
   getInstalledPlugin,
   getInstalledPluginRegistration,
@@ -334,6 +335,13 @@ export function createPluginRegistration(context: PluginRegistrationContext) {
             pluginRootDir(checkoutDir, subdirectory),
             "plugin subdirectory",
           );
+    if (isBbManagedWorkspacePath({ dataDir: deps.dataDir, path: rootDir })) {
+      logger.warn(
+        `plugin "${rootDir}" is installed from inside a bb-managed workspace; ` +
+          "its source will be deleted when that environment is destroyed (e.g. when the owning thread is archived). " +
+          "Reinstall from a stable path outside the managed workspace to avoid losing it.",
+      );
+    }
     return registerInstalled({
       rootDir,
       source: `path:${rootDir}`,

--- a/apps/server/test/services/plugins/plugin-service.test.ts
+++ b/apps/server/test/services/plugins/plugin-service.test.ts
@@ -1,6 +1,6 @@
-import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rename, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createConnection, migrate, type DbConnection } from "@bb/db";
 import type { SystemChangeKind } from "@bb/domain";
@@ -608,6 +608,31 @@ describe("plugin service", () => {
       status: "running",
     });
     expect(service.getApi("reinstalled")).toBeDefined();
+  });
+
+  it("warns when a path plugin is installed from inside a managed workspace", async () => {
+    const warnSpy = vi.spyOn(logger, "warn");
+    // dataDir is <workDir>/data; install from <dataDir>/personal-workspaces/env_X/...
+    const managedRoot = join(
+      workDir,
+      "data",
+      "personal-workspaces",
+      "env_test",
+      "bb-plugin-managed",
+    );
+    const written = await writePlugin(workDir, {
+      name: "bb-plugin-managed",
+      serverSource: `export default function plugin() {}`,
+    });
+    // Move the written plugin into the managed workspace path so the install
+    // source resolves under <dataDir>/personal-workspaces/.
+    await mkdir(dirname(managedRoot), { recursive: true });
+    await rename(written, managedRoot);
+
+    await service.installPath(managedRoot);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("bb-managed workspace"),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

Cheapest of the three fixes proposed in #1565. When a user runs `bb plugin install <path>` (or `installPath`) and the resolved `source_path` lives inside a bb-managed workspace (`<dataDir>/personal-workspaces/env_*/` or `<dataDir>/worktrees/`), emit a `logger.warn` so they know the source is ephemeral — it will be deleted when that environment is destroyed (e.g. when the owning thread is archived).

This does **not** change install behavior; it only surfaces the hazard. It reuses the existing `isBbManagedWorkspacePath` predicate (already used for thread path-claims in `worktree-paths.ts`), so there's no new concept to maintain.

## Why

I lost six plugins this way on a single machine (`browser-preview`, `automaker`, `file-explorer`, `prime-agent-ui`, `terminal-dock`, `thread-ops`), one of them twice. The natural workflow — scaffold a plugin inside the thread's env via `bb plugin new`, then `bb plugin install .` — collides with the normal archive→env-destroy lifecycle. The plugin source is silently `rm -rf`'d by `provisionPersonalWorkspace`'s `destroyFn` ([`packages/host-workspace/src/provision.ts:762`](https://github.com/get-bb/bb/blob/main/packages/host-workspace/src/provision.ts#L762)), leaving a dangling `missing (reinstall)` registration.

A warning at install time is high-leverage and zero-risk: it teaches the user the model the first time, before any data is lost. The destroy-time guard (option 2 in the issue) is the stronger fix and is worth doing separately, but this PR stands on its own.

## Changes

- `apps/server/src/services/plugins/plugin-registration.ts`: in `installPathSource`, after resolving `rootDir`, check `isBbManagedWorkspacePath({ dataDir: deps.dataDir, path: rootDir })` and `logger.warn(...)` if true.
- `apps/server/test/services/plugins/plugin-service.test.ts`: new test asserts the warning fires for an install under `<dataDir>/personal-workspaces/env_test/...`.

## Test plan

- [x] `pnpm vitest run` in `apps/server` — 19/19 plugin-service tests pass (including the new one)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on both changed files

Closes #1565 (install-time-warning portion).

<!-- Suggested follow-up: option 2 from the issue — a destroy-time guard in `destroyEnvironment` that scans `installed_plugins` for `source LIKE 'path:%/<env.path>/%'` and blocks/migrates/warns before the `rm`. -->
