### PR TITLE
Fix long streamed messages across timeline completion

### DIFF
--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -631,6 +631,20 @@ function timelineRowsOwnerKey({
   return ownerThreadId;
 }
 
+function timelineHeightSnapRevision(rows: readonly TimelineRow[]): string {
+  // Active turns render their work rows directly. Completion replaces those
+  // rows with one or more turn summaries plus the terminal message. Key the
+  // height container by the newest completed summary so that authoritative
+  // topology replacement snaps instead of looking like a second stream.
+  for (let index = rows.length - 1; index >= 0; index -= 1) {
+    const row = rows[index];
+    if (row?.kind === "turn") {
+      return `${row.id}:${row.sourceSeqStart}:${row.sourceSeqEnd}`;
+    }
+  }
+  return "active";
+}
+
 function useTimelineViewRowsCache(): GetTimelineViewRows {
   // Each `rawRows` reference is consumed under exactly one scope: the
   // top-level prop ("open" — pending work may still arrive) or a lazily
@@ -1931,6 +1945,7 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
     () => getViewRows(props.timelineRows),
     [getViewRows, props.timelineRows],
   );
+  const heightSnapRevision = timelineHeightSnapRevision(props.timelineRows);
   const latestActionableAssistantMessageId = useMemo(
     () => findLastActionableAssistantMessageId(rows),
     [rows],
@@ -2165,7 +2180,7 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
               value={latestActionableUserMessageId}
             >
               <TimelineTurnStateContext.Provider value={turnStateContextValue}>
-                <AutoHeightContainer>
+                <AutoHeightContainer snapRevision={heightSnapRevision}>
                   <TimelineRowsList
                     hasOlderTimelineRows={props.hasOlderTimelineRows}
                     isLoadingOlderTimelineRows={

--- a/apps/app/src/components/ui/height-transition.test.tsx
+++ b/apps/app/src/components/ui/height-transition.test.tsx
@@ -2,7 +2,7 @@
 
 import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { HeightTransition } from "./height-transition";
+import { AutoHeightContainer, HeightTransition } from "./height-transition";
 
 class ResizeObserverStub implements ResizeObserver {
   observe: ResizeObserver["observe"] = vi.fn();
@@ -52,8 +52,8 @@ describe("HeightTransition", () => {
         <span data-testid="restored-child">Restored content</span>
       </HeightTransition>,
     );
-    const wrapper = view.getByTestId("restored-child").parentElement
-      ?.parentElement;
+    const wrapper =
+      view.getByTestId("restored-child").parentElement?.parentElement;
 
     expect(wrapper?.style.height).toBe("40px");
     offsetHeight.mockReturnValue(80);
@@ -64,5 +64,38 @@ describe("HeightTransition", () => {
 
     expect(wrapper?.style.height).toBe("80px");
     expect(wrapper?.style.transitionDuration).toBe("0s");
+  });
+});
+
+describe("AutoHeightContainer", () => {
+  it("snap-syncs an authoritative layout revision", () => {
+    class ResizeObserverMock {
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    }
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+
+    const view = render(
+      <AutoHeightContainer snapRevision="active">
+        <span>Streaming response</span>
+      </AutoHeightContainer>,
+    );
+    const inner = view.getByText("Streaming response").parentElement;
+    const wrapper = inner?.parentElement;
+    expect(inner).not.toBeNull();
+    expect(wrapper?.style.height).toBe("0px");
+
+    Object.defineProperty(inner, "offsetHeight", {
+      configurable: true,
+      value: 480,
+    });
+    view.rerender(
+      <AutoHeightContainer snapRevision="completed-turn:1:2000">
+        <span>Completed response</span>
+      </AutoHeightContainer>,
+    );
+
+    expect(wrapper?.style.height).toBe("480px");
   });
 });

--- a/apps/app/src/components/ui/height-transition.test.tsx
+++ b/apps/app/src/components/ui/height-transition.test.tsx
@@ -5,12 +5,19 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { AutoHeightContainer, HeightTransition } from "./height-transition";
 
 class ResizeObserverStub implements ResizeObserver {
+  static instances: ResizeObserverStub[] = [];
+
+  constructor(readonly callback: ResizeObserverCallback) {
+    ResizeObserverStub.instances.push(this);
+  }
+
   observe: ResizeObserver["observe"] = vi.fn();
   unobserve: ResizeObserver["unobserve"] = vi.fn();
   disconnect: ResizeObserver["disconnect"] = vi.fn();
 }
 
 afterEach(() => {
+  ResizeObserverStub.instances.length = 0;
   cleanup();
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
@@ -52,8 +59,8 @@ describe("HeightTransition", () => {
         <span data-testid="restored-child">Restored content</span>
       </HeightTransition>,
     );
-    const wrapper =
-      view.getByTestId("restored-child").parentElement?.parentElement;
+    const wrapper = view.getByTestId("restored-child").parentElement
+      ?.parentElement;
 
     expect(wrapper?.style.height).toBe("40px");
     offsetHeight.mockReturnValue(80);
@@ -69,12 +76,7 @@ describe("HeightTransition", () => {
 
 describe("AutoHeightContainer", () => {
   it("snap-syncs an authoritative layout revision", () => {
-    class ResizeObserverMock {
-      observe() {}
-      disconnect() {}
-      unobserve() {}
-    }
-    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    vi.stubGlobal("ResizeObserver", ResizeObserverStub);
 
     const view = render(
       <AutoHeightContainer snapRevision="active">
@@ -83,8 +85,10 @@ describe("AutoHeightContainer", () => {
     );
     const inner = view.getByText("Streaming response").parentElement;
     const wrapper = inner?.parentElement;
+    const observer = ResizeObserverStub.instances[0];
     expect(inner).not.toBeNull();
     expect(wrapper?.style.height).toBe("0px");
+    expect(observer).toBeDefined();
 
     Object.defineProperty(inner, "offsetHeight", {
       configurable: true,
@@ -97,5 +101,8 @@ describe("AutoHeightContainer", () => {
     );
 
     expect(wrapper?.style.height).toBe("480px");
+    expect(wrapper?.style.transitionDuration).toBe("0s");
+    expect(ResizeObserverStub.instances).toEqual([observer]);
+    expect(observer?.disconnect).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/components/ui/height-transition.tsx
+++ b/apps/app/src/components/ui/height-transition.tsx
@@ -183,7 +183,8 @@ export function HeightTransition({
       // scrollHeight, which the bottom-anchor sentinel then chases.
       const layoutAnimationActive =
         store.get(layoutAnimationInFlightCountAtom) > 0;
-      const snap = widthChanged || pendingVisibilitySnap || layoutAnimationActive;
+      const snap =
+        widthChanged || pendingVisibilitySnap || layoutAnimationActive;
       pendingVisibilitySnap = false;
       lastWidth = width;
       const nextHeight = visible ? `${height}px` : "0px";
@@ -250,6 +251,11 @@ export interface AutoHeightContainerProps {
   children: ReactNode;
   className?: string;
   durationMs?: number;
+  /**
+   * A revision for authoritative layout replacements that should not animate
+   * through their intermediate height. Normal child growth still animates.
+   */
+  snapRevision?: string;
 }
 
 /**
@@ -280,10 +286,14 @@ export function AutoHeightContainer({
   children,
   className,
   durationMs = HEIGHT_TRANSITION_DURATION_MS,
+  snapRevision,
 }: AutoHeightContainerProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
   const store = useStore();
+  // A revision change reinstalls the observer and writes the replacement's
+  // intrinsic height before paint. This is intentionally rare (turn completion)
+  // and leaves ordinary streaming ResizeObserver updates animated.
   useLayoutEffect(() => {
     const wrapper = wrapperRef.current;
     const inner = innerRef.current;
@@ -363,7 +373,7 @@ export function AutoHeightContainer({
       cancelIntrinsicHeightRestore(resizeState);
       cleanupSnapState(wrapper, snapState);
     };
-  }, [store]);
+  }, [snapRevision, store]);
   return (
     <div
       ref={wrapperRef}

--- a/apps/app/src/components/ui/height-transition.tsx
+++ b/apps/app/src/components/ui/height-transition.tsx
@@ -183,8 +183,7 @@ export function HeightTransition({
       // scrollHeight, which the bottom-anchor sentinel then chases.
       const layoutAnimationActive =
         store.get(layoutAnimationInFlightCountAtom) > 0;
-      const snap =
-        widthChanged || pendingVisibilitySnap || layoutAnimationActive;
+      const snap = widthChanged || pendingVisibilitySnap || layoutAnimationActive;
       pendingVisibilitySnap = false;
       lastWidth = width;
       const nextHeight = visible ? `${height}px` : "0px";
@@ -290,10 +289,9 @@ export function AutoHeightContainer({
 }: AutoHeightContainerProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
+  const snapToCurrentHeightRef = useRef<(() => void) | null>(null);
+  const previousSnapRevisionRef = useRef(snapRevision);
   const store = useStore();
-  // A revision change reinstalls the observer and writes the replacement's
-  // intrinsic height before paint. This is intentionally rare (turn completion)
-  // and leaves ordinary streaming ResizeObserver updates animated.
   useLayoutEffect(() => {
     const wrapper = wrapperRef.current;
     const inner = innerRef.current;
@@ -310,6 +308,12 @@ export function AutoHeightContainer({
       restoreTimerId: null,
       usingIntrinsicHeight: false,
     };
+    const snapToCurrentHeight = () => {
+      cancelIntrinsicHeightRestore(resizeState);
+      resizeState.usingIntrinsicHeight = false;
+      applyHeight(wrapper, `${inner.offsetHeight}px`, true, snapState);
+    };
+    snapToCurrentHeightRef.current = snapToCurrentHeight;
     const deferInitialSettleComplete = () => {
       if (initialSettleComplete) {
         return;
@@ -360,20 +364,28 @@ export function AutoHeightContainer({
     const onVisibility = () => {
       if (!isDocumentVisible()) return;
       pendingVisibilitySnap = true;
-      cancelIntrinsicHeightRestore(resizeState);
-      resizeState.usingIntrinsicHeight = false;
-      applyHeight(wrapper, `${inner.offsetHeight}px`, true, snapState);
+      snapToCurrentHeight();
     };
     const unsubscribeFromDocumentVisibility =
       subscribeToDocumentVisibility(onVisibility);
     return () => {
+      snapToCurrentHeightRef.current = null;
       observer.disconnect();
       unsubscribeFromDocumentVisibility();
       window.clearTimeout(initialSettleTimerId);
       cancelIntrinsicHeightRestore(resizeState);
       cleanupSnapState(wrapper, snapState);
     };
-  }, [snapRevision, store]);
+  }, [store]);
+  // Authoritative replacements (turn completion) must update before paint,
+  // but they must not reinstall the observer and reset its settle/resize state.
+  useLayoutEffect(() => {
+    if (previousSnapRevisionRef.current === snapRevision) {
+      return;
+    }
+    previousSnapRevisionRef.current = snapRevision;
+    snapToCurrentHeightRef.current?.();
+  }, [snapRevision]);
   return (
     <div
       ref={wrapperRef}

--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -258,7 +258,7 @@ function invalidateTerminalTimelineQueryKeys({
     // cancel the stale read and fetch the terminal shape immediately.
     cancelTrailingActiveRefetch({ queryClient, queryKey });
     void queryClient.cancelQueries({ queryKey });
-    queryClient.invalidateQueries({ queryKey }, { cancelRefetch: false });
+    queryClient.invalidateQueries({ queryKey });
   }
 }
 

--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -112,12 +112,17 @@ interface CollectCachedThreadIdsForEnvironmentArgs {
   queryClient: QueryClient;
 }
 
-interface InvalidateQueryKeysWithoutCancelingActiveFetchesArgs {
+interface TimelineInvalidationQueryKeysArgs {
   queryClient: QueryClient;
   queryKeys: readonly QueryKey[];
 }
 
 interface ScheduleTrailingActiveRefetchArgs {
+  queryClient: QueryClient;
+  queryKey: QueryKey;
+}
+
+interface CancelTrailingActiveRefetchArgs {
   queryClient: QueryClient;
   queryKey: QueryKey;
 }
@@ -210,10 +215,26 @@ function scheduleTrailingActiveRefetch({
   unsubscribers.set(scheduleKey, unsubscribe);
 }
 
+function cancelTrailingActiveRefetch({
+  queryClient,
+  queryKey,
+}: CancelTrailingActiveRefetchArgs): void {
+  const unsubscribers = trailingActiveRefetchUnsubscribers.get(queryClient);
+  if (!unsubscribers) {
+    return;
+  }
+  const scheduleKey = timelineInvalidationKey(queryKey);
+  unsubscribers.get(scheduleKey)?.();
+  unsubscribers.delete(scheduleKey);
+  if (unsubscribers.size === 0) {
+    trailingActiveRefetchUnsubscribers.delete(queryClient);
+  }
+}
+
 function invalidateQueryKeysWithoutCancelingActiveFetches({
   queryClient,
   queryKeys,
-}: InvalidateQueryKeysWithoutCancelingActiveFetchesArgs): void {
+}: TimelineInvalidationQueryKeysArgs): void {
   for (const queryKey of queryKeys) {
     const hadActiveFetch = hasActiveFetchingQueries(queryClient, queryKey);
     // Avoid aborting the active timeline request on every event batch, but keep
@@ -222,6 +243,22 @@ function invalidateQueryKeysWithoutCancelingActiveFetches({
     if (hadActiveFetch) {
       scheduleTrailingActiveRefetch({ queryClient, queryKey });
     }
+  }
+}
+
+function invalidateTerminalTimelineQueryKeys({
+  queryClient,
+  queryKeys,
+}: TimelineInvalidationQueryKeysArgs): void {
+  for (const queryKey of queryKeys) {
+    // A terminal event changes the latest window from an in-turn projection to
+    // the canonical completed-turn projection. Letting an older read land after
+    // that boundary briefly restores the streaming shape before the paced
+    // trailing refetch corrects it. Completion is rare and authoritative, so
+    // cancel the stale read and fetch the terminal shape immediately.
+    cancelTrailingActiveRefetch({ queryClient, queryKey });
+    void queryClient.cancelQueries({ queryKey });
+    queryClient.invalidateQueries({ queryKey }, { cancelRefetch: false });
   }
 }
 
@@ -680,15 +717,18 @@ function dirtyThreadSearchQueries(): QueryKey[] {
 }
 
 function dirtyThreadTimelineQueries({
+  eventTypes,
   queryClient,
   threadId,
 }: ThreadRealtimeDirtyContext): void {
   // Window only: completed turn-summary-details are immutable, so realtime
   // event batches must not refetch open detail panels (see helper docs).
-  invalidateQueryKeysWithoutCancelingActiveFetches({
-    queryClient,
-    queryKeys: getThreadTimelineWindowInvalidationQueryKeys({ threadId }),
-  });
+  const queryKeys = getThreadTimelineWindowInvalidationQueryKeys({ threadId });
+  if (eventTypes?.includes("turn/completed")) {
+    invalidateTerminalTimelineQueryKeys({ queryClient, queryKeys });
+    return;
+  }
+  invalidateQueryKeysWithoutCancelingActiveFetches({ queryClient, queryKeys });
 }
 
 function dirtyThreadTimelineRewriteQueries({

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -1151,6 +1151,78 @@ describe("createRealtimeCacheEffects", () => {
     effects.dispose();
   });
 
+  it("supersedes an in-flight timeline read when a turn completes", async () => {
+    vi.useFakeTimers();
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const timelineKey = threadTimelineQueryKey("thr_1");
+    const signals: AbortSignal[] = [];
+    const resolveFetches: Array<(value: unknown) => void> = [];
+    const timelineQueryFn = vi.fn(({ signal }: { signal: AbortSignal }) => {
+      signals.push(signal);
+      return new Promise((resolve) => {
+        resolveFetches.push(resolve);
+      });
+    });
+    const timelineObserver = new QueryObserver(queryClient, {
+      queryKey: timelineKey,
+      queryFn: timelineQueryFn,
+      staleTime: Infinity,
+    });
+    const unsubscribeTimeline = timelineObserver.subscribe(() => {});
+    await vi.advanceTimersByTimeAsync(0);
+    expect(timelineQueryFn).toHaveBeenCalledTimes(1);
+
+    // A normal streaming event arms the paced trailing refetch without
+    // canceling the read already in flight.
+    effects.handleChanged({
+      type: "changed",
+      entity: "thread",
+      id: "thr_1",
+      metadata: { eventTypes: ["item/agentMessage/delta"] },
+      changes: ["events-appended"],
+    });
+    await vi.advanceTimersByTimeAsync(50);
+    expect(signals[0]?.aborted).toBe(false);
+
+    // The server sends events-appended before its immediate status-changed
+    // notification. The latter flushes both buffered changes together.
+    effects.handleChanged({
+      type: "changed",
+      entity: "thread",
+      id: "thr_1",
+      metadata: { eventTypes: ["turn/completed"] },
+      changes: ["events-appended"],
+    });
+    effects.handleChanged({
+      type: "changed",
+      entity: "thread",
+      id: "thr_1",
+      changes: ["status-changed"],
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(signals[0]?.aborted).toBe(true);
+    expect(timelineQueryFn).toHaveBeenCalledTimes(2);
+
+    resolveFetches[1]?.({
+      rows: [],
+      timelinePage: {
+        kind: "latest",
+        topLevelLimit: 100,
+        returnedOlderTopLevelRowCount: 0,
+        hasOlderRows: false,
+        olderCursor: null,
+      },
+    });
+    await vi.advanceTimersByTimeAsync(1_500);
+
+    // Completion also clears the trailing refetch armed by the earlier delta.
+    expect(timelineQueryFn).toHaveBeenCalledTimes(2);
+
+    unsubscribeTimeline();
+    effects.dispose();
+  });
+
   it("invalidates thread prompt history when a batched appended event includes a turn request", () => {
     vi.useFakeTimers();
     const { effects, queryClient } = createRealtimeEffectsTestContext();

--- a/apps/server/src/services/threads/timeline.ts
+++ b/apps/server/src/services/threads/timeline.ts
@@ -921,7 +921,7 @@ function ensureSequenceWindowWholeItemRows(
     const ref = storedEventRowItemRef(row);
     const key = scopedItemRefKey(ref);
     if (!completedItemKeys.has(key) && itemsStartingBeforeWindow.has(key)) {
-      bufferedTextItems.set(key, itemsStartingBeforeWindow.get(key) ?? ref);
+      bufferedTextItems.set(key, ref);
     }
   }
   const bufferedTextRows = listStoredBufferedTextDeltaRowsByItems(db, {

--- a/apps/server/src/services/threads/timeline.ts
+++ b/apps/server/src/services/threads/timeline.ts
@@ -793,6 +793,22 @@ interface SequenceWindowItemRowsArgs extends TimelineWindowRowsArgs {
   sequenceStart: number;
 }
 
+function rowIdentifiesBufferedTextItem(row: StoredEventRow): boolean {
+  if (row.type === "item/started") {
+    return (
+      row.itemKind === "agentMessage" ||
+      row.itemKind === "plan" ||
+      row.itemKind === "reasoning"
+    );
+  }
+  return (
+    row.type === "item/agentMessage/delta" ||
+    row.type === "item/plan/delta" ||
+    row.type === "item/reasoning/summaryTextDelta" ||
+    row.type === "item/reasoning/textDelta"
+  );
+}
+
 /**
  * Makes a sequence-cut window own whole items rather than halves of them.
  *
@@ -893,23 +909,19 @@ function ensureSequenceWindowWholeItemRows(
       completedItemKeys.add(scopedItemRefKey(storedEventRowItemRef(row)));
     }
   }
-  // Delta rows are stored with a null itemKind, and an item that started below
-  // the cut has only delta rows inside the window — so the kind must be read
-  // from the backfilled item/started row, never from the in-window rows.
+  // Delta rows are stored with a null itemKind, and providers may begin an
+  // assistant, plan, or reasoning item with its first delta rather than an
+  // item/started event. Classify from either the backfilled lifecycle row or
+  // the in-window delta type so those delta-only items keep their prefix too.
   const bufferedTextItems = new Map<string, ScopedItemRef>();
-  for (const row of backfillRows) {
-    if (row.type !== "item/started" || row.itemId === null) {
+  for (const row of [...backfillRows, ...rows]) {
+    if (row.itemId === null || !rowIdentifiesBufferedTextItem(row)) {
       continue;
     }
     const ref = storedEventRowItemRef(row);
     const key = scopedItemRefKey(ref);
-    if (
-      !completedItemKeys.has(key) &&
-      (row.itemKind === "agentMessage" ||
-        row.itemKind === "plan" ||
-        row.itemKind === "reasoning")
-    ) {
-      bufferedTextItems.set(key, ref);
+    if (!completedItemKeys.has(key) && itemsStartingBeforeWindow.has(key)) {
+      bufferedTextItems.set(key, itemsStartingBeforeWindow.get(key) ?? ref);
     }
   }
   const bufferedTextRows = listStoredBufferedTextDeltaRowsByItems(db, {

--- a/apps/server/test/services/threads/timeline-in-turn-window.test.ts
+++ b/apps/server/test/services/threads/timeline-in-turn-window.test.ts
@@ -1175,74 +1175,100 @@ describe("in-turn windows and items that only stream", () => {
     expect(matches[0]).toContain('"status":"completed"');
   });
 
-  it("keeps a delta-only unfinished assistant message whole across the cut", () => {
-    const { db, thread } = setup();
-    const itemId = "assistant-1";
-    const turnId = "turn-1";
-    seedTurns(db, thread, {
-      completeLastTurn: false,
-      itemsPerTurn: [100],
-    });
-    // Pi, Claude, and ACP can begin an assistant item with its first delta;
-    // there is no item/started row for whole-item closure to classify.
-    const events: EventInput[] = [];
-    const chunks = Array.from({ length: 200 }, (_, index) => `[${index}]\n`);
-    chunks.forEach((delta, index) => {
-      events.push({
-        threadId: thread.id,
-        sequence: index + 204,
-        type: "item/agentMessage/delta",
-        scope: turnScope(turnId),
-        providerThreadId,
-        itemId,
-        itemKind: null,
-        data: JSON.stringify({
-          delta,
-          itemId,
-          providerThreadId,
-        }),
+  it.each([
+    { includeStartedEvent: false, providerShape: "without item/started" },
+    { includeStartedEvent: true, providerShape: "with item/started" },
+  ])(
+    "keeps an unfinished assistant message whole across the cut $providerShape",
+    ({ includeStartedEvent }) => {
+      const { db, thread } = setup();
+      const itemId = "assistant-1";
+      const turnId = "turn-1";
+      seedTurns(db, thread, {
+        completeLastTurn: false,
+        itemsPerTurn: [100],
       });
-    });
-    insertEvents(db, noopNotifier, events);
-
-    const budgeted = buildPage(db, thread, 100, null);
-    const assistant = budgeted.response.rows.find(
-      (row) => row.kind === "conversation" && row.role === "assistant",
-    );
-
-    expect(budgeted.response.timelinePage.hasOlderRows).toBe(true);
-    expect(assistant?.text).toBe(chunks.join(""));
-    const laterChunks = Array.from(
-      { length: 25 },
-      (_, index) => `[later-${index}]\n`,
-    );
-    insertEvents(
-      db,
-      noopNotifier,
-      laterChunks.map((delta, index) => ({
-        threadId: thread.id,
-        sequence: index + 404,
-        type: "item/agentMessage/delta",
-        scope: turnScope(turnId),
-        providerThreadId,
-        itemId,
-        itemKind: null,
-        data: JSON.stringify({
-          delta,
-          itemId,
+      // Pi, Claude, and ACP may begin an assistant item with its first delta,
+      // while other provider paths emit item/started first. Both shapes must
+      // preserve the buffered prefix when the event budget cuts through it.
+      const events: EventInput[] = includeStartedEvent
+        ? [
+            {
+              threadId: thread.id,
+              sequence: 204,
+              type: "item/started",
+              scope: turnScope(turnId),
+              providerThreadId,
+              itemId,
+              itemKind: "agentMessage",
+              data: JSON.stringify({
+                item: { type: "agentMessage", id: itemId, text: "" },
+                providerThreadId,
+              }),
+            },
+          ]
+        : [];
+      const firstDeltaSequence = includeStartedEvent ? 205 : 204;
+      const chunks = Array.from({ length: 200 }, (_, index) => `[${index}]\n`);
+      chunks.forEach((delta, index) => {
+        events.push({
+          threadId: thread.id,
+          sequence: index + firstDeltaSequence,
+          type: "item/agentMessage/delta",
+          scope: turnScope(turnId),
           providerThreadId,
-        }),
-      })),
-    );
+          itemId,
+          itemKind: null,
+          data: JSON.stringify({
+            delta,
+            itemId,
+            providerThreadId,
+          }),
+        });
+      });
+      insertEvents(db, noopNotifier, events);
 
-    const refreshed = buildPage(db, thread, 100, null);
-    const refreshedAssistant = refreshed.response.rows.find(
-      (row) => row.kind === "conversation" && row.role === "assistant",
-    );
-    expect(refreshedAssistant?.text).toBe([...chunks, ...laterChunks].join(""));
-    const unbudgeted = buildPage(db, thread, LARGE_BUDGET, null);
-    expect(walkAllPages(db, thread, 100).rows).toEqual(
-      unbudgeted.response.rows.map((row) => JSON.stringify(row)),
-    );
-  });
+      const budgeted = buildPage(db, thread, 100, null);
+      const assistant = budgeted.response.rows.find(
+        (row) => row.kind === "conversation" && row.role === "assistant",
+      );
+
+      expect(budgeted.response.timelinePage.hasOlderRows).toBe(true);
+      expect(assistant?.text).toBe(chunks.join(""));
+      const laterChunks = Array.from(
+        { length: 25 },
+        (_, index) => `[later-${index}]\n`,
+      );
+      insertEvents(
+        db,
+        noopNotifier,
+        laterChunks.map((delta, index) => ({
+          threadId: thread.id,
+          sequence: index + firstDeltaSequence + chunks.length,
+          type: "item/agentMessage/delta",
+          scope: turnScope(turnId),
+          providerThreadId,
+          itemId,
+          itemKind: null,
+          data: JSON.stringify({
+            delta,
+            itemId,
+            providerThreadId,
+          }),
+        })),
+      );
+
+      const refreshed = buildPage(db, thread, 100, null);
+      const refreshedAssistant = refreshed.response.rows.find(
+        (row) => row.kind === "conversation" && row.role === "assistant",
+      );
+      expect(refreshedAssistant?.text).toBe(
+        [...chunks, ...laterChunks].join(""),
+      );
+      const unbudgeted = buildPage(db, thread, LARGE_BUDGET, null);
+      expect(walkAllPages(db, thread, 100).rows).toEqual(
+        unbudgeted.response.rows.map((row) => JSON.stringify(row)),
+      );
+    },
+  );
 });

--- a/apps/server/test/services/threads/timeline-in-turn-window.test.ts
+++ b/apps/server/test/services/threads/timeline-in-turn-window.test.ts
@@ -1175,7 +1175,7 @@ describe("in-turn windows and items that only stream", () => {
     expect(matches[0]).toContain('"status":"completed"');
   });
 
-  it("keeps an unfinished assistant message whole as its deltas cross the cut", () => {
+  it("keeps a delta-only unfinished assistant message whole across the cut", () => {
     const { db, thread } = setup();
     const itemId = "assistant-1";
     const turnId = "turn-1";
@@ -1183,26 +1183,14 @@ describe("in-turn windows and items that only stream", () => {
       completeLastTurn: false,
       itemsPerTurn: [100],
     });
-    const events: EventInput[] = [
-      {
-        threadId: thread.id,
-        sequence: 204,
-        type: "item/started",
-        scope: turnScope(turnId),
-        providerThreadId,
-        itemId,
-        itemKind: "agentMessage",
-        data: JSON.stringify({
-          item: { type: "agentMessage", id: itemId, text: "" },
-          providerThreadId,
-        }),
-      },
-    ];
+    // Pi, Claude, and ACP can begin an assistant item with its first delta;
+    // there is no item/started row for whole-item closure to classify.
+    const events: EventInput[] = [];
     const chunks = Array.from({ length: 200 }, (_, index) => `[${index}]\n`);
     chunks.forEach((delta, index) => {
       events.push({
         threadId: thread.id,
-        sequence: index + 205,
+        sequence: index + 204,
         type: "item/agentMessage/delta",
         scope: turnScope(turnId),
         providerThreadId,
@@ -1233,7 +1221,7 @@ describe("in-turn windows and items that only stream", () => {
       noopNotifier,
       laterChunks.map((delta, index) => ({
         threadId: thread.id,
-        sequence: index + 405,
+        sequence: index + 404,
         type: "item/agentMessage/delta",
         scope: turnScope(turnId),
         providerThreadId,


### PR DESCRIPTION
## Summary

- preserve the complete text of delta-only assistant, plan, and reasoning items when an active turn crosses the timeline event budget
- supersede in-flight timeline reads and cancel paced trailing refetches when `turn/completed` arrives, preventing an active-turn projection from landing after the canonical completed projection
- snap the authoritative active-to-completed timeline height replacement while preserving normal streaming height transitions and observer state
- add provider-shaped regression coverage for the sequence-window closure and client completion handoff

## Problem

Pi, Claude, and ACP can begin assistant text with `item/agentMessage/delta` and never emit `item/started`. When an unfinished turn crossed the event budget, whole-item closure only recognized buffered text through a backfilled `item/started` row. A window cut inside a delta-only message therefore projected only the suffix inside the budget instead of carrying its earlier deltas forward.

Completion then replaced that suffix with the canonical full `item/completed` text. The normal streaming invalidation path deliberately avoids cancelling active reads and schedules a paced trailing refetch, so an older suffix projection could also land around the terminal boundary before the trailing fetch restored the completed shape. Animating the whole timeline height made these replacements look like the response was streaming in reverse.

## Fix

Whole-item closure now identifies unfinished buffered text from either its lifecycle row or its in-window delta event type, then uses the existing prefix query to reconstruct the complete item. This is provider-independent and also handles already-stored delta-only threads.

The client keeps its non-cancelling behavior for ordinary stream events. Only the authoritative `turn/completed` boundary cancels obsolete work and immediately requests the terminal shape. The completed-turn topology replacement snaps through the existing zero-duration height path without reinstalling the `ResizeObserver`, so settle and resize state remain intact.

## Testing

- full `@bb/app` suite — 341 files and 2,707 tests passed
- full `@bb/server` suite — 166 files and 1,506 tests passed
- focused regressions after the final rebase — 46 app tests and 22 server pagination tests passed
- `pnpm exec turbo run typecheck --filter=@bb/server`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `git diff --check`

> AGENT GENERATED: by GPT-5.6
