### PR TITLE
Publish @get-bb/plugin-sdk with the release train

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,25 @@ jobs:
       - name: Build, typecheck, and lint
         run: pnpm exec turbo run build typecheck lint --cache-dir=.turbo/cache --output-logs=new-only
 
+      # Runs after build and typecheck, so the guard's own turbo build is a
+      # cache hit and the package it packs is the one this commit really ships.
+      # A published version whose packed files or consumer-facing manifest
+      # fields changed is a hard failure; an unreachable registry or a failed
+      # local pack (exit 2) is infrastructure, not a finding.
+      - name: Check plugin SDK npm version guard
+        run: |
+          # +e so the exit code can be inspected: GitHub's default shell runs
+          # with -e, which would abort the step before the exit-2 check.
+          set +e
+          node packages/plugin-sdk/scripts/check-npm-version-guard.mjs
+          guard_exit=$?
+          set -e
+          if [[ "$guard_exit" -eq 2 ]]; then
+            echo "::warning::Skipping the plugin SDK npm version guard: the npm registry was unreachable."
+            exit 0
+          fi
+          exit "$guard_exit"
+
       # Guards the JavaScript that blocks first paint in the web app. Heavy
       # editor, diff and math code reaches that path through barrel re-exports,
       # which typecheck and lint cannot see.

--- a/.github/workflows/publish-bb-app.yml
+++ b/.github/workflows/publish-bb-app.yml
@@ -59,9 +59,9 @@ jobs:
 
     steps:
       - name: Require main branch
-        if: ${{ github.ref_name != 'main' }}
+        if: ${{ github.ref != 'refs/heads/main' }}
         run: |
-          echo "::error::Publish bb-app must run from main, got ${GITHUB_REF_NAME}."
+          echo "::error::Publish bb-app must run from the main branch, got ${GITHUB_REF}."
           exit 1
 
       - name: Checkout repository
@@ -220,6 +220,142 @@ jobs:
             echo
             echo "- version: \`$PACKAGE_VERSION\`"
             echo "- npm tag: \`$RELEASE_NPM_TAG\`"
+            echo "- dry run: \`$RELEASE_DRY_RUN\`"
+            echo "- commit: \`${GITHUB_SHA}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Rides the same release train as bb-app but stays independent of it: the SDK
+  # version is settled in the repo (packages/domain/src/plugin-sdk-version.ts,
+  # mirrored in packages/plugin-sdk/package.json), never computed here. Every
+  # run publishes only when that exact version is missing from npm, so a run
+  # where it already exists skips and succeeds. Nothing needs this job and it
+  # needs nothing, so a failure here cannot hold back the app or desktop
+  # release.
+  #
+  # BOOTSTRAP: until @get-bb/plugin-sdk has been published once by hand and its
+  # npm trusted publisher is configured (this repo, this workflow file, the
+  # npm-release environment), the publish step below will fail with a 404/auth
+  # error. That is expected and does not affect the bb-app jobs. See
+  # docs/bb-release-process.md#publishing-the-plugin-sdk.
+  publish-plugin-sdk:
+    name: Publish @get-bb/plugin-sdk
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: npm-release
+    permissions:
+      contents: read
+      id-token: write
+    # Its own group, separate from the workflow-level one: that group splits
+    # nightly from ref, so the cron and a manual dispatch on main land in
+    # different groups and can run at the same time. Both would then reach
+    # `npm publish` for the same immutable version, and the loser fails red.
+    # Serializing this job lets the second run observe the first one's publish
+    # and skip. Job-level concurrency does not affect the bb-app jobs.
+    concurrency:
+      group: publish-plugin-sdk
+      cancel-in-progress: false
+
+    steps:
+      - name: Require main branch
+        if: ${{ github.ref != 'refs/heads/main' }}
+        run: |
+          echo "::error::Publish @get-bb/plugin-sdk must run from the main branch, got ${GITHUB_REF}."
+          exit 1
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 9.15.0
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Ensure npm supports trusted publishing
+        run: |
+          npm_version="$(npm --version)"
+          node - "$npm_version" <<'NODE' || npm install --global npm@latest
+          const version = process.argv[2];
+          const [major, minor, patch] = version.split(".").map(Number);
+          const supported =
+            major > 11 ||
+            (major === 11 && (minor > 5 || (minor === 5 && patch >= 1)));
+          process.exit(supported ? 0 : 1);
+          NODE
+          npm --version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build the SDK
+        run: pnpm exec turbo run build --filter=@get-bb/plugin-sdk --output-logs=new-only
+
+      - name: Resolve the settled SDK version
+        id: sdk_version
+        run: |
+          set -euo pipefail
+
+          # The version is whatever the repo already says it is. Never bump or
+          # derive one at publish time.
+          sdk_version="$(node -p "require('./packages/plugin-sdk/package.json').version")"
+          echo "SDK_VERSION=${sdk_version}" >> "$GITHUB_ENV"
+          echo "version=${sdk_version}" >> "$GITHUB_OUTPUT"
+          echo "Local @get-bb/plugin-sdk version is ${sdk_version}."
+
+      - name: Check whether this version is already on npm
+        id: published
+        run: |
+          set -euo pipefail
+
+          # `npm view` exits non-zero both for "no such version" and for real
+          # registry errors, so distinguish them from the captured output
+          # rather than from the exit code alone.
+          if view_output="$(npm view "@get-bb/plugin-sdk@${SDK_VERSION}" version 2>&1)"; then
+            if [[ -n "$view_output" ]]; then
+              echo "@get-bb/plugin-sdk@${SDK_VERSION} already published, skipping."
+              echo "already_published=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          elif ! grep -qiE "E404|no match(ing)? version|is not in this registry" <<<"$view_output"; then
+            echo "::error::Could not query npm for @get-bb/plugin-sdk@${SDK_VERSION}: ${view_output}"
+            exit 1
+          fi
+
+          echo "@get-bb/plugin-sdk@${SDK_VERSION} is not on npm; it will be published."
+          echo "already_published=false" >> "$GITHUB_OUTPUT"
+
+      - name: Preview npm package
+        if: ${{ steps.published.outputs.already_published == 'false' }}
+        working-directory: packages/plugin-sdk
+        run: npm pack --dry-run
+
+      - name: npm publish dry run
+        if: ${{ steps.published.outputs.already_published == 'false' && env.RELEASE_DRY_RUN == 'true' }}
+        working-directory: packages/plugin-sdk
+        run: npm publish --dry-run
+
+      - name: Publish to npm
+        if: ${{ steps.published.outputs.already_published == 'false' && env.RELEASE_DRY_RUN != 'true' }}
+        working-directory: packages/plugin-sdk
+        # prepack rebuilds bundled-types and dist; publishConfig.access is
+        # already public in the manifest, so no --access flag is needed.
+        run: npm publish
+
+      - name: Summarize the SDK release
+        env:
+          ALREADY_PUBLISHED: ${{ steps.published.outputs.already_published }}
+        run: |
+          {
+            echo "## @get-bb/plugin-sdk"
+            echo
+            echo "- version: \`$SDK_VERSION\`"
+            echo "- already published: \`$ALREADY_PUBLISHED\`"
             echo "- dry run: \`$RELEASE_DRY_RUN\`"
             echo "- commit: \`${GITHUB_SHA}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/bb-release-process.md
+++ b/docs/bb-release-process.md
@@ -243,6 +243,76 @@ Add to the report from "Verify The Release":
 - desktop version published and whether signed binaries were uploaded
 - desktop workflow run URL
 
+## Publishing The Plugin SDK
+
+`@get-bb/plugin-sdk` rides the same release train as `bb-app`. The
+`publish-plugin-sdk` job in `publish-bb-app.yml` runs on the same nightly cron
+and `workflow_dispatch` triggers, but depends on nothing and is depended on by
+nothing: a failure there cannot hold back the npm or desktop release.
+
+The SDK version is **settled in the repo before any build**, never computed at
+publish time. It lives in `packages/domain/src/plugin-sdk-version.ts`
+(`PLUGIN_SDK_VERSION`) and is mirrored in `packages/plugin-sdk/package.json`;
+both must be bumped together. The job is publish-if-missing: it reads the local
+version, asks npm whether that exact version exists, and either logs
+"already published, skipping" or publishes. Every run is therefore idempotent —
+most runs publish nothing.
+
+Because a published version is never republished, an already-released version's
+published content must never change underneath it. `check-npm-version-guard.mjs`
+enforces that on every PR from the `checks` job in `ci.yml`:
+
+| Registry state                              | Result                                                               |
+| ------------------------------------------- | -------------------------------------------------------------------- |
+| Package or version absent (404)             | Pass — the publish job will ship this version.                       |
+| Version published, packed package identical | Pass.                                                                |
+| Version published, packed package differs   | Fail — bump `PLUGIN_SDK_VERSION` and the `plugin-sdk` manifest.      |
+| Registry unreachable, or local pack failed  | Exit 2; CI logs a warning and continues (infrastructure, not a bug). |
+
+The comparison covers the whole package, not just the declarations: a
+runtime-only change (different `dist/` output, an edited exports entry, a
+widened peer range) leaves `bundled-types/` identical, and publish-if-missing
+would then never ship it. The guard builds the SDK through turbo, runs
+`npm pack` to get exactly what publish would upload, and diffs that against the
+published tarball for the current version:
+
+- every packed file — `bundled-types/*`, `dist/*`, `README.md` — normalizing
+  line endings and end-of-file whitespace
+- the manifest fields consumers resolve against: `exports`, `files`, `main`,
+  `peerDependencies`, `peerDependenciesMeta`, `publishConfig`, `repository`,
+  `types` (compared by value, so key order is not drift)
+
+Comparing `dist/` content is safe because the esbuild bundles are reproducible:
+they embed no timestamps, paths, or hashes, so repeated builds of the same
+commit are byte-identical. Run the guard locally the same way CI does:
+
+```bash
+node packages/plugin-sdk/scripts/check-npm-version-guard.mjs
+```
+
+### One-Time Bootstrap
+
+npm trusted publishing cannot create a package that does not exist yet, so the
+first release is manual:
+
+1. Publish `@get-bb/plugin-sdk` once by hand from `packages/plugin-sdk` with
+   normal npm authentication (`npm publish`; `publishConfig.access` is already
+   `public`).
+2. On GitHub, restrict the `npm-release` environment to `main` (Settings →
+   Environments → `npm-release` → deployment branches → selected branches,
+   `main` only). `workflow_dispatch` accepts any branch, and the environment is
+   what npm's trusted publisher trusts: without a branch policy, a run from any
+   branch could request the same OIDC identity. The in-file "Require main
+   branch" step is a convenience check that a workflow edit could remove; the
+   environment policy is the control that holds.
+3. On npmjs.com, add a trusted publisher for the package pointing at this
+   repository, the workflow file `.github/workflows/publish-bb-app.yml`, and the
+   `npm-release` environment — the same values `bb-app` uses.
+
+Until all three steps are done, the `publish-plugin-sdk` job fails at
+`npm publish`. That failure is expected and isolated; the bb-app and desktop
+jobs are unaffected.
+
 ## Failure Handling
 
 - If the version already exists on npm, stop. Bump to the next version in a new

--- a/packages/plugin-sdk/scripts/check-npm-version-guard.mjs
+++ b/packages/plugin-sdk/scripts/check-npm-version-guard.mjs
@@ -1,0 +1,393 @@
+// Keeps npm from lagging the plugin SDK.
+//
+// The publish job (.github/workflows/publish-bb-app.yml, job publish-plugin-sdk)
+// only publishes @get-bb/plugin-sdk when PLUGIN_SDK_VERSION is absent from npm.
+// That is safe exactly as long as a released version's *published content* never
+// changes underneath it. Declarations alone are not enough: a runtime-only change
+// (dist/ output, an exports map entry, a peer range) leaves bundled-types
+// identical, so a types-only guard would pass and publish-if-missing would then
+// never ship it — npm would keep serving stale executable code under a version
+// that no longer matches this repo.
+//
+// So this guard compares the whole would-be-published package against the
+// published tarball for the current version:
+//   - every packed file (bundled-types/*, dist/*, README.md)
+//   - the manifest fields consumers actually resolve against (see
+//     COMPARED_MANIFEST_FIELDS)
+// The local side is produced by `npm pack`, i.e. the same file selection npm
+// will use at publish time, rather than a hand-maintained list.
+//
+// Content equality is trustworthy here because dist/ is reproducible: the
+// esbuild bundles embed no timestamps, paths, or hashes, and two forced rebuilds
+// of this package produce byte-identical dist/ output.
+//
+// Exit codes: 0 pass, 1 published content drift without a version bump, 2
+// infrastructure (registry unreachable, or the local package could not be built
+// or packed).
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pkgRoot = path.resolve(here, "..");
+const repoRoot = path.resolve(pkgRoot, "..", "..");
+const PACKAGE_NAME = "@get-bb/plugin-sdk";
+const REGISTRY_URL = "https://registry.npmjs.org/@get-bb%2Fplugin-sdk";
+
+/**
+ * Manifest fields whose value is part of what consumers resolve against. A
+ * change to any of them changes the package for everyone who already installed
+ * this version, so it needs a version bump just like a file change. Fields that
+ * only describe the release (version, description, homepage, devDependencies)
+ * are deliberately excluded.
+ */
+export const COMPARED_MANIFEST_FIELDS = [
+  "exports",
+  "files",
+  "main",
+  "peerDependencies",
+  "peerDependenciesMeta",
+  "publishConfig",
+  "repository",
+  "types",
+];
+
+/**
+ * Normalize a packed text file for content comparison: line endings differ
+ * across the checkout and the packed tarball, and trailing whitespace at EOF is
+ * not part of what ships. Nothing else is touched — we want real drift to be
+ * visible.
+ */
+export function normalizePackedFile(text) {
+  return text.replace(/\r\n/gu, "\n").replace(/\s+$/u, "") + "\n";
+}
+
+/** Stable stringify so key order in package.json is not reported as drift. */
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalize(value[key])]),
+    );
+  }
+  return value;
+}
+
+function manifestFieldsDiffer(a, b) {
+  return JSON.stringify(canonicalize(a)) !== JSON.stringify(canonicalize(b));
+}
+
+/**
+ * Pure decision logic, separated from IO so the matrix is testable.
+ *
+ * @param {object} input
+ * @param {string} input.version local package version
+ * @param {object} input.local one of:
+ *   {kind:"packed", files: Record<string,string>, manifest: Record<string,unknown>}
+ *   {kind:"pack-failed", message}
+ *   Only consulted when the registry says this version is published.
+ * @param {object} input.registry one of:
+ *   {kind:"network-error", message}
+ *   {kind:"package-not-found"}
+ *   {kind:"version-not-found"}
+ *   {kind:"published", files: Record<string,string>, manifest: Record<string,unknown>}
+ * @returns {{status:"pass"|"fail"|"error", exitCode:0|1|2, reason:string,
+ *   message:string, changedFiles:string[]}}
+ */
+export function decideNpmVersionGuard({ version, local, registry }) {
+  if (registry.kind === "network-error") {
+    return {
+      status: "error",
+      exitCode: 2,
+      reason: "registry-unreachable",
+      changedFiles: [],
+      message: `could not reach registry for ${PACKAGE_NAME}: ${registry.message}`,
+    };
+  }
+
+  if (registry.kind === "package-not-found") {
+    return {
+      status: "pass",
+      exitCode: 0,
+      reason: "package-not-published",
+      changedFiles: [],
+      message: `${PACKAGE_NAME} is not on npm yet, so ${version} cannot have drifted. The publish job will ship it.`,
+    };
+  }
+
+  if (registry.kind === "version-not-found") {
+    return {
+      status: "pass",
+      exitCode: 0,
+      reason: "version-not-published",
+      changedFiles: [],
+      message: `${PACKAGE_NAME}@${version} is not on npm yet. The publish job will ship this version.`,
+    };
+  }
+
+  if (local.kind === "pack-failed") {
+    return {
+      status: "error",
+      exitCode: 2,
+      reason: "local-package-unavailable",
+      changedFiles: [],
+      message: `could not build or pack ${PACKAGE_NAME} locally: ${local.message}`,
+    };
+  }
+
+  const allPaths = [
+    ...new Set([...Object.keys(local.files), ...Object.keys(registry.files)]),
+  ].sort();
+  const changedFiles = allPaths.filter(
+    (name) =>
+      normalizePackedFile(local.files[name] ?? "") !==
+      normalizePackedFile(registry.files[name] ?? ""),
+  );
+
+  const changedManifestFields = COMPARED_MANIFEST_FIELDS.filter((field) =>
+    manifestFieldsDiffer(local.manifest[field], registry.manifest[field]),
+  );
+
+  if (changedFiles.length === 0 && changedManifestFields.length === 0) {
+    return {
+      status: "pass",
+      exitCode: 0,
+      reason: "package-matches-published",
+      changedFiles: [],
+      message: `${PACKAGE_NAME}@${version} is published and its packed files and manifest match this checkout.`,
+    };
+  }
+
+  const changed = [
+    ...changedFiles,
+    ...changedManifestFields.map((field) => `package.json (${field})`),
+  ];
+  return {
+    status: "fail",
+    exitCode: 1,
+    reason: "package-changed-without-version-bump",
+    changedFiles: changed,
+    message: [
+      `${PACKAGE_NAME}@${version} is already published, but the package this checkout would publish differs from it:`,
+      ...changed.map((name) => `  - ${name}`),
+      "",
+      "A published version is never republished, so this change would never reach",
+      "npm consumers. Bump the version in packages/domain/src/plugin-sdk-version.ts",
+      "and packages/plugin-sdk/package.json (they must stay in sync), then re-run.",
+    ].join("\n"),
+  };
+}
+
+/** Read every file under `dir` as text, keyed by its path relative to `dir`. */
+function readPackedTree(dir) {
+  const files = {};
+  const walk = (current, prefix) => {
+    for (const name of readdirSync(current).sort()) {
+      const absolute = path.join(current, name);
+      const relative = prefix ? `${prefix}/${name}` : name;
+      if (statSync(absolute).isDirectory()) {
+        walk(absolute, relative);
+      } else {
+        files[relative] = readFileSync(absolute, "utf8");
+      }
+    }
+  };
+  walk(dir, "");
+  return files;
+}
+
+/**
+ * Split an extracted `package/` directory into its manifest and its other
+ * files. package.json is compared field by field, not as text, so npm's own
+ * normalization of the packed manifest is not reported as drift.
+ */
+function splitPackage(packageDir) {
+  const files = readPackedTree(packageDir);
+  const manifestText = files["package.json"] ?? "{}";
+  delete files["package.json"];
+  return { files, manifest: JSON.parse(manifestText) };
+}
+
+function extractTarball(tarballPath, workDir) {
+  execFileSync("tar", ["-xzf", tarballPath, "-C", workDir], { stdio: "pipe" });
+  return splitPackage(path.join(workDir, "package"));
+}
+
+/**
+ * Build the package and pack it exactly as npm publish would, so the comparison
+ * covers dist/ and the manifest, not just the declarations.
+ *
+ * The build runs through turbo so upstream `^build` dependencies are honored. In
+ * CI it is a cache hit: ci.yml already runs `turbo run build typecheck lint`
+ * before this guard, and publish-bb-app.yml builds the SDK before publishing.
+ * `npm pack --ignore-scripts` then packs that freshly built tree without
+ * re-running prepack.
+ */
+function loadLocalPackage() {
+  try {
+    execFileSync(
+      "pnpm",
+      [
+        "exec",
+        "turbo",
+        "run",
+        "build",
+        `--filter=${PACKAGE_NAME}`,
+        "--output-logs=errors-only",
+      ],
+      { cwd: repoRoot, stdio: "pipe" },
+    );
+  } catch (error) {
+    return {
+      kind: "pack-failed",
+      message: `turbo build failed: ${error}`,
+    };
+  }
+
+  if (!existsSync(path.join(pkgRoot, "dist"))) {
+    return {
+      kind: "pack-failed",
+      message: "the build produced no dist/ directory",
+    };
+  }
+
+  const workDir = mkdtempSync(path.join(tmpdir(), "plugin-sdk-guard-local-"));
+  try {
+    const output = execFileSync(
+      "npm",
+      ["pack", "--ignore-scripts", "--json", "--pack-destination", workDir],
+      { cwd: pkgRoot, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    );
+    const [packed] = JSON.parse(output);
+    const tarballPath = path.join(workDir, packed.filename);
+    return { kind: "packed", ...extractTarball(tarballPath, workDir) };
+  } catch (error) {
+    return { kind: "pack-failed", message: `npm pack failed: ${error}` };
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+/** Fetch registry metadata and, when the version exists, its packed content. */
+async function loadRegistryState(version) {
+  let response;
+  try {
+    response = await fetch(REGISTRY_URL, {
+      headers: { accept: "application/json" },
+    });
+  } catch (error) {
+    return { kind: "network-error", message: String(error) };
+  }
+
+  if (response.status === 404) return { kind: "package-not-found" };
+  if (!response.ok) {
+    return {
+      kind: "network-error",
+      message: `registry responded ${response.status}`,
+    };
+  }
+
+  let metadata;
+  try {
+    metadata = await response.json();
+  } catch (error) {
+    return {
+      kind: "network-error",
+      message: `unreadable registry body: ${error}`,
+    };
+  }
+
+  const published = metadata?.versions?.[version];
+  if (!published) return { kind: "version-not-found" };
+
+  const tarballUrl = published?.dist?.tarball;
+  if (typeof tarballUrl !== "string") {
+    return {
+      kind: "network-error",
+      message: `no tarball URL for ${PACKAGE_NAME}@${version}`,
+    };
+  }
+
+  let tarball;
+  try {
+    const tarballResponse = await fetch(tarballUrl);
+    if (!tarballResponse.ok) {
+      return {
+        kind: "network-error",
+        message: `tarball download responded ${tarballResponse.status}`,
+      };
+    }
+    tarball = Buffer.from(await tarballResponse.arrayBuffer());
+  } catch (error) {
+    return {
+      kind: "network-error",
+      message: `tarball download failed: ${error}`,
+    };
+  }
+
+  // tar is present on GitHub runners and dev machines; extracting with it keeps
+  // this script dependency-free.
+  const workDir = mkdtempSync(path.join(tmpdir(), "plugin-sdk-guard-"));
+  try {
+    const tarballPath = path.join(workDir, "package.tgz");
+    writeFileSync(tarballPath, tarball);
+    try {
+      return { kind: "published", ...extractTarball(tarballPath, workDir) };
+    } catch (error) {
+      // A corrupt or truncated download is infrastructure, not real drift.
+      return {
+        kind: "network-error",
+        message: `tarball extraction failed: ${error}`,
+      };
+    }
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  const asJson = process.argv.includes("--json");
+  const { version } = JSON.parse(
+    readFileSync(path.join(pkgRoot, "package.json"), "utf8"),
+  );
+  const registry = await loadRegistryState(version);
+  // Building and packing costs ~20s, so only pay it when there is a published
+  // tarball to compare against.
+  const local =
+    registry.kind === "published"
+      ? loadLocalPackage()
+      : { kind: "not-needed", files: {}, manifest: {} };
+  const decision = decideNpmVersionGuard({ version, local, registry });
+
+  if (asJson) {
+    console.log(
+      JSON.stringify({ package: PACKAGE_NAME, version, ...decision }, null, 2),
+    );
+  } else if (decision.status === "pass") {
+    console.log(`npm version guard: PASS — ${decision.message}`);
+  } else {
+    console.error(
+      `::error::npm version guard: ${decision.status.toUpperCase()}\n${decision.message}`,
+    );
+  }
+  process.exit(decision.exitCode);
+}
+
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+) {
+  await main();
+}

--- a/packages/plugin-sdk/scripts/check-npm-version-guard.test.mjs
+++ b/packages/plugin-sdk/scripts/check-npm-version-guard.test.mjs
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+
+import { decideNpmVersionGuard } from "./check-npm-version-guard.mjs";
+
+const version = "0.5.0";
+
+const files = {
+  "README.md": "# sdk\n",
+  "bundled-types/bb-plugin-sdk.d.ts": "export declare const a: string;\n",
+  "bundled-types/bb-plugin-sdk-app.d.ts": "export declare const b: number;\n",
+  "dist/index.js": "export const a = 'a';\n",
+  "dist/app.js": "export const b = 1;\n",
+};
+
+const manifest = {
+  exports: { ".": { import: "./dist/index.js" } },
+  files: ["bundled-types", "dist", "README.md"],
+  peerDependencies: { react: "^19.0.0" },
+  peerDependenciesMeta: { react: { optional: true } },
+  publishConfig: { access: "public" },
+  repository: { type: "git", url: "git+https://example.invalid/bb.git" },
+  types: "./bundled-types/bb-plugin-sdk.d.ts",
+};
+
+const local = { kind: "packed", files, manifest };
+
+function publishedRegistry(overrides = {}) {
+  return {
+    kind: "published",
+    files: { ...files, ...(overrides.files ?? {}) },
+    manifest: { ...manifest, ...(overrides.manifest ?? {}) },
+  };
+}
+
+describe("decideNpmVersionGuard", () => {
+  it("passes when the package has never been published", () => {
+    const decision = decideNpmVersionGuard({
+      version,
+      local: { kind: "not-needed", files: {}, manifest: {} },
+      registry: { kind: "package-not-found" },
+    });
+    expect(decision).toMatchObject({ status: "pass", exitCode: 0 });
+  });
+
+  it("passes when this version is not on npm yet", () => {
+    const decision = decideNpmVersionGuard({
+      version,
+      local: { kind: "not-needed", files: {}, manifest: {} },
+      registry: { kind: "version-not-found" },
+    });
+    expect(decision).toMatchObject({
+      status: "pass",
+      exitCode: 0,
+      reason: "version-not-published",
+    });
+  });
+
+  it("passes when packed files and manifest match, ignoring line endings, EOF whitespace, and key order", () => {
+    const decision = decideNpmVersionGuard({
+      version,
+      local,
+      registry: publishedRegistry({
+        files: {
+          "bundled-types/bb-plugin-sdk.d.ts":
+            "export declare const a: string;\r\n\r\n",
+          "dist/index.js": "export const a = 'a';",
+        },
+        manifest: {
+          repository: {
+            url: "git+https://example.invalid/bb.git",
+            type: "git",
+          },
+        },
+      }),
+    });
+    expect(decision).toMatchObject({
+      status: "pass",
+      exitCode: 0,
+      reason: "package-matches-published",
+    });
+  });
+
+  it("fails on a runtime-only change with unchanged declarations", () => {
+    const decision = decideNpmVersionGuard({
+      version,
+      local,
+      registry: publishedRegistry({
+        files: { "dist/index.js": "export const a = 'stale';\n" },
+      }),
+    });
+    expect(decision).toMatchObject({
+      status: "fail",
+      exitCode: 1,
+      reason: "package-changed-without-version-bump",
+      changedFiles: ["dist/index.js"],
+    });
+  });
+
+  it("fails when a published declaration changed without a version bump", () => {
+    const decision = decideNpmVersionGuard({
+      version,
+      local,
+      registry: publishedRegistry({
+        files: {
+          "bundled-types/bb-plugin-sdk-app.d.ts":
+            "export declare const b: boolean;\n",
+        },
+      }),
+    });
+    expect(decision).toMatchObject({
+      status: "fail",
+      exitCode: 1,
+      changedFiles: ["bundled-types/bb-plugin-sdk-app.d.ts"],
+    });
+    expect(decision.message).toContain("plugin-sdk-version.ts");
+  });
+
+  it("fails when a packed file is added or removed", () => {
+    const withoutReadme = publishedRegistry();
+    delete withoutReadme.files["README.md"];
+    const decision = decideNpmVersionGuard({
+      version,
+      local,
+      registry: withoutReadme,
+    });
+    expect(decision).toMatchObject({
+      status: "fail",
+      exitCode: 1,
+      changedFiles: ["README.md"],
+    });
+  });
+
+  it("fails when a consumer-facing manifest field changed", () => {
+    const decision = decideNpmVersionGuard({
+      version,
+      local,
+      registry: publishedRegistry({
+        manifest: {
+          exports: { ".": { import: "./dist/old.js" } },
+          peerDependencies: { react: "^18.0.0" },
+        },
+      }),
+    });
+    expect(decision).toMatchObject({ status: "fail", exitCode: 1 });
+    expect(decision.changedFiles).toEqual([
+      "package.json (exports)",
+      "package.json (peerDependencies)",
+    ]);
+  });
+
+  it("ignores manifest fields that do not affect consumers", () => {
+    const decision = decideNpmVersionGuard({
+      version,
+      local,
+      registry: publishedRegistry({
+        manifest: {
+          description: "different",
+          devDependencies: { vitest: "^1.0.0" },
+          version: "0.4.0",
+        },
+      }),
+    });
+    expect(decision).toMatchObject({ status: "pass", exitCode: 0 });
+  });
+
+  it("reports registry failures as infrastructure with exit code 2", () => {
+    const decision = decideNpmVersionGuard({
+      version,
+      local,
+      registry: { kind: "network-error", message: "ENOTFOUND" },
+    });
+    expect(decision).toMatchObject({ status: "error", exitCode: 2 });
+    expect(decision.message).toContain("could not reach registry");
+  });
+
+  it("reports a failed local build or pack as infrastructure with exit code 2", () => {
+    const decision = decideNpmVersionGuard({
+      version,
+      local: { kind: "pack-failed", message: "turbo build failed: boom" },
+      registry: publishedRegistry(),
+    });
+    expect(decision).toMatchObject({
+      status: "error",
+      exitCode: 2,
+      reason: "local-package-unavailable",
+    });
+  });
+});

--- a/packages/plugin-sdk/vitest.config.ts
+++ b/packages/plugin-sdk/vitest.config.ts
@@ -4,7 +4,12 @@ export default defineWorkspaceTestConfig({
   test: {
     silent: "passed-only",
     name: "@get-bb/plugin-sdk",
-    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+    include: [
+      "src/**/*.test.ts",
+      "src/**/*.test.tsx",
+      // Build/release scripts are plain .mjs and live outside src.
+      "scripts/**/*.test.mjs",
+    ],
     exclude: ["dist/**", "node_modules/**"],
   },
 });


### PR DESCRIPTION
Layer 2 of 4 in the plugin-SDK npm publishing stack (#1578). Requires #1574 (the rename) below it.

Closes #1134.

Adds a `publish-plugin-sdk` job to `publish-bb-app.yml`: build the SDK, then publish only when the current version is absent from npm (idempotent skip otherwise), via OIDC trusted publishing in the `npm-release` environment. The job has no dependents, so a failure cannot block the bb-app or desktop publishes. It honors `RELEASE_DRY_RUN`, and always publishes to `latest` — the SDK has no channel concept.

Adds the pin-to-host CI guard: `check-npm-version-guard.mjs` fails a PR when the committed `bundled-types/` differ from the published content of the current `PLUGIN_SDK_VERSION`, so npm can never silently lag the API. Package/version-not-found passes (pre-bootstrap state); registry outages exit 2 and surface as CI warnings, not failures. Decision logic is a pure function with a unit-tested decision matrix.

Drive-by hardening from review: the main-only guards (both the new SDK job and the pre-existing bb-app job) now compare `github.ref == 'refs/heads/main'` — the old `ref_name` check accepted a tag named `main`.

One-time bootstrap after this lands (documented in `docs/bb-release-process.md`): manual first `npm publish`, then add the trusted publisher entry on npmjs.com pointing at this workflow file and the `npm-release` environment.

> AGENT GENERATED: by Claude Fable 5 (implementation: Claude Opus 5; review: GPT-5.6-Sol)