### PR TITLE
Fix pending interaction banner overflow

### DIFF
--- a/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.tsx
+++ b/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.tsx
@@ -111,7 +111,7 @@ function BannerShell({
   sourceThread,
 }: BannerShellProps) {
   return (
-    <div className="mb-2 rounded-lg border border-border bg-surface-recessed px-4 py-3 text-xs text-muted-foreground">
+    <div className="mb-2 min-w-0 max-w-full overflow-hidden rounded-lg border border-border bg-surface-recessed px-4 py-3 text-xs text-muted-foreground">
       {sourceThread ? (
         <NavLink
           to={sourceThread.href}
@@ -305,17 +305,17 @@ function buildApprovalSubject({
       return {
         title: payload.reason ?? "Do you want to run this command?",
         body: command ? (
-          <div className="overflow-hidden rounded-lg border border-border bg-card">
+          <div className="min-w-0 max-w-full overflow-hidden rounded-lg border border-border bg-card">
             <pre
               className={cn(
                 getDetailScrollMaxHeightClass("base"),
-                "overflow-auto whitespace-pre px-3 py-2 font-mono text-xs leading-relaxed text-foreground",
+                "max-w-full overflow-auto whitespace-pre px-3 py-2 font-mono text-xs leading-relaxed text-foreground",
               )}
             >
               $ {command}
             </pre>
             {detailLines.length > 0 ? (
-              <ul className="border-t border-border px-3 py-2 text-xs text-muted-foreground">
+              <ul className="min-w-0 border-t border-border px-3 py-2 text-xs text-muted-foreground [overflow-wrap:anywhere]">
                 {detailLines.map((line) => (
                   <li key={line}>{line}</li>
                 ))}

--- a/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.tsx
+++ b/apps/app/src/components/thread/pending-interactions/ThreadPendingInteractionBanner.tsx
@@ -281,6 +281,27 @@ function approvalResolutionDecision(
   return resolution.decision;
 }
 
+function ApprovalDetailList({
+  className,
+  lines,
+}: {
+  className: string;
+  lines: readonly string[];
+}) {
+  return (
+    <ul
+      className={cn(
+        "min-w-0 max-w-full text-xs text-muted-foreground [overflow-wrap:anywhere]",
+        className,
+      )}
+    >
+      {lines.map((line) => (
+        <li key={line}>{line}</li>
+      ))}
+    </ul>
+  );
+}
+
 function buildApprovalSubject({
   interaction,
   payload,
@@ -315,11 +336,10 @@ function buildApprovalSubject({
               $ {command}
             </pre>
             {detailLines.length > 0 ? (
-              <ul className="min-w-0 border-t border-border px-3 py-2 text-xs text-muted-foreground [overflow-wrap:anywhere]">
-                {detailLines.map((line) => (
-                  <li key={line}>{line}</li>
-                ))}
-              </ul>
+              <ApprovalDetailList
+                className="border-t border-border px-3 py-2"
+                lines={detailLines}
+              />
             ) : null}
           </div>
         ) : null,
@@ -332,11 +352,10 @@ function buildApprovalSubject({
         title: payload.reason ?? "Do you want to make these changes?",
         body:
           detailLines.length > 0 ? (
-            <ul className="rounded-lg border border-border bg-card px-3 py-2 text-xs text-muted-foreground">
-              {detailLines.map((line) => (
-                <li key={line}>{line}</li>
-              ))}
-            </ul>
+            <ApprovalDetailList
+              className="rounded-lg border border-border bg-card px-3 py-2"
+              lines={detailLines}
+            />
           ) : null,
       };
     }
@@ -347,11 +366,10 @@ function buildApprovalSubject({
         title: payload.reason ?? "Do you want to grant this permission?",
         body:
           detailLines.length > 0 ? (
-            <ul className="rounded-lg border border-border bg-card px-3 py-2 text-xs text-muted-foreground">
-              {detailLines.map((line) => (
-                <li key={line}>{line}</li>
-              ))}
-            </ul>
+            <ApprovalDetailList
+              className="rounded-lg border border-border bg-card px-3 py-2"
+              lines={detailLines}
+            />
           ) : null,
       };
     }


### PR DESCRIPTION
## Summary

- Keep pending interaction banners within the available composer width.
- Keep long commands horizontally scrollable.
- Wrap long paths and action details inside the approval card.

## Root cause

The banner and command container kept their intrinsic minimum width. Long command and detail text could therefore expand the parent grid item beyond the viewport.

## User impact

Approval cards now remain inside the thread view when commands, paths, or action details are long.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/app`
- `git diff --check`

> AGENT GENERATED: by GPT-5
