### PR TITLE
Bump the plugin SDK to 0.4.4 and add a one-command bump script

### DIFF
--- a/docs/bb-release-process.md
+++ b/docs/bb-release-process.md
@@ -252,8 +252,15 @@ nothing: a failure there cannot hold back the npm or desktop release.
 
 The SDK version is **settled in the repo before any build**, never computed at
 publish time. It lives in `packages/domain/src/plugin-sdk-version.ts`
-(`PLUGIN_SDK_VERSION`) and is mirrored in `packages/plugin-sdk/package.json`;
-both must be bumped together. The job is publish-if-missing: it reads the local
+(`PLUGIN_SDK_VERSION`) and is mirrored in `packages/plugin-sdk/package.json`.
+Both must be bumped together, so move them with the script rather than by hand:
+
+```bash
+node scripts/bump-plugin-sdk.mjs --patch   # or --minor, --major, or an explicit version
+```
+
+The script writes both files atomically and refuses to run when they already
+disagree. The job is publish-if-missing: it reads the local
 version, asks npm whether that exact version exists, and either logs
 "already published, skipping" or publishes. Every run is therefore idempotent —
 most runs publish nothing.
@@ -266,7 +273,7 @@ enforces that on every PR from the `checks` job in `ci.yml`:
 | ------------------------------------------- | -------------------------------------------------------------------- |
 | Package or version absent (404)             | Pass — the publish job will ship this version.                       |
 | Version published, packed package identical | Pass.                                                                |
-| Version published, packed package differs   | Fail — bump `PLUGIN_SDK_VERSION` and the `plugin-sdk` manifest.      |
+| Version published, packed package differs   | Fail — run `node scripts/bump-plugin-sdk.mjs --patch`.               |
 | Registry unreachable, or local pack failed  | Exit 2; CI logs a warning and continues (infrastructure, not a bug). |
 
 The comparison covers the whole package, not just the declarations: a

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -16,7 +16,7 @@
 // PLUGIN_SDK_MAJOR is 0, so the major-only artifact gate cannot distinguish
 // 0.x releases and is intentionally vacuous for them until a future 1.0.
 // Rebuildable artifacts still rebuild on the exact sdkVersion-differs trigger.
-export const PLUGIN_SDK_VERSION = "0.4.3";
+export const PLUGIN_SDK_VERSION = "0.4.4";
 
 /** Major of {@link PLUGIN_SDK_VERSION} — the plugin API compatibility number. */
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/plugin-sdk/scripts/check-npm-version-guard.mjs
+++ b/packages/plugin-sdk/scripts/check-npm-version-guard.mjs
@@ -184,8 +184,12 @@ export function decideNpmVersionGuard({ version, local, registry }) {
       ...changed.map((name) => `  - ${name}`),
       "",
       "A published version is never republished, so this change would never reach",
-      "npm consumers. Bump the version in packages/domain/src/plugin-sdk-version.ts",
-      "and packages/plugin-sdk/package.json (they must stay in sync), then re-run.",
+      "npm consumers. Bump the version, then re-run:",
+      "",
+      "  node scripts/bump-plugin-sdk.mjs --patch",
+      "",
+      "That moves packages/domain/src/plugin-sdk-version.ts and",
+      "packages/plugin-sdk/package.json together; they must stay in sync.",
     ].join("\n"),
   };
 }

--- a/packages/scripts/test/bump-plugin-sdk.test.mjs
+++ b/packages/scripts/test/bump-plugin-sdk.test.mjs
@@ -1,0 +1,196 @@
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { bumpPluginSdk } from "../../../scripts/bump-plugin-sdk.mjs";
+
+const scriptPath = fileURLToPath(
+  new URL("../../../scripts/bump-plugin-sdk.mjs", import.meta.url),
+);
+const MANIFEST_PATH = "packages/plugin-sdk/package.json";
+const VERSION_MODULE_PATH = "packages/domain/src/plugin-sdk-version.ts";
+const testRoots = [];
+
+/**
+ * The real plugin-sdk-version.ts carries a long comment that cites version
+ * numbers ("any earlier 0.x", "0.4.3 releases"). The fixture reproduces that so
+ * a bump that rewrites prose instead of the export is a test failure, not a
+ * surprise in a release commit.
+ */
+function createVersionModule(version) {
+  return `// The major is the plugin API compatibility number. Pre-1.0, a plugin
+// built against any earlier 0.x keeps loading, so ${version} stays compatible.
+export const PLUGIN_SDK_VERSION = "${version}";
+
+/** Major of {@link PLUGIN_SDK_VERSION}. */
+export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);
+`;
+}
+
+function createTestRepo({ manifestVersion, moduleVersion }) {
+  const repoRoot = mkdtempSync(join(tmpdir(), "bb-bump-plugin-sdk-"));
+  testRoots.push(repoRoot);
+
+  mkdirSync(join(repoRoot, "packages", "plugin-sdk"), { recursive: true });
+  mkdirSync(join(repoRoot, "packages", "domain", "src"), { recursive: true });
+  writeFileSync(
+    join(repoRoot, MANIFEST_PATH),
+    `${JSON.stringify(
+      {
+        name: "@get-bb/plugin-sdk",
+        version: manifestVersion,
+        files: ["bundled-types", "dist", "README.md"],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeFileSync(
+    join(repoRoot, VERSION_MODULE_PATH),
+    createVersionModule(moduleVersion),
+  );
+
+  return repoRoot;
+}
+
+function readContent(repoRoot, path) {
+  return readFileSync(join(repoRoot, path), "utf8");
+}
+
+function readManifestVersion(repoRoot) {
+  return JSON.parse(readContent(repoRoot, MANIFEST_PATH)).version;
+}
+
+function readModuleVersion(repoRoot) {
+  const match = /export const PLUGIN_SDK_VERSION = "([^"]+)";/u.exec(
+    readContent(repoRoot, VERSION_MODULE_PATH),
+  );
+
+  return match === null ? null : match[1];
+}
+
+function runScript(repoRoot, args) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, BB_BUMP_PLUGIN_SDK_REPO_ROOT: repoRoot },
+  });
+}
+
+afterEach(() => {
+  for (const testRoot of testRoots.splice(0)) {
+    rmSync(testRoot, { force: true, recursive: true });
+  }
+});
+
+describe("bump-plugin-sdk", () => {
+  it("moves the manifest and the version module together", () => {
+    const repoRoot = createTestRepo({
+      manifestVersion: "0.4.3",
+      moduleVersion: "0.4.3",
+    });
+    const result = runScript(repoRoot, ["--patch"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("@get-bb/plugin-sdk 0.4.3 → 0.4.4");
+    expect(readManifestVersion(repoRoot)).toBe("0.4.4");
+    expect(readModuleVersion(repoRoot)).toBe("0.4.4");
+  });
+
+  it("rewrites only the export, leaving version numbers in comments alone", () => {
+    const repoRoot = createTestRepo({
+      manifestVersion: "0.4.3",
+      moduleVersion: "0.4.3",
+    });
+
+    expect(runScript(repoRoot, ["--patch"]).status).toBe(0);
+
+    const moduleContent = readContent(repoRoot, VERSION_MODULE_PATH);
+
+    expect(moduleContent).toContain("so 0.4.3 stays compatible");
+    expect(moduleContent).toContain(
+      'export const PLUGIN_SDK_VERSION = "0.4.4";',
+    );
+  });
+
+  it("refuses to bump when the two sources already disagree", () => {
+    const repoRoot = createTestRepo({
+      manifestVersion: "0.4.3",
+      moduleVersion: "0.4.2",
+    });
+    const originalManifest = readContent(repoRoot, MANIFEST_PATH);
+    const originalModule = readContent(repoRoot, VERSION_MODULE_PATH);
+    const result = runScript(repoRoot, ["--patch"]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Version mismatch before bump");
+    expect(readContent(repoRoot, MANIFEST_PATH)).toBe(originalManifest);
+    expect(readContent(repoRoot, VERSION_MODULE_PATH)).toBe(originalModule);
+  });
+
+  it("rejects a version that does not move forward", () => {
+    const repoRoot = createTestRepo({
+      manifestVersion: "0.4.3",
+      moduleVersion: "0.4.3",
+    });
+    const result = runScript(repoRoot, ["0.4.3"]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      "New version 0.4.3 must be greater than current 0.4.3.",
+    );
+    expect(readManifestVersion(repoRoot)).toBe("0.4.3");
+  });
+
+  it("restores the manifest when the version module rename fails", async () => {
+    const repoRoot = createTestRepo({
+      manifestVersion: "0.4.3",
+      moduleVersion: "0.4.3",
+    });
+    const originalManifest = readContent(repoRoot, MANIFEST_PATH);
+    const originalModule = readContent(repoRoot, VERSION_MODULE_PATH);
+    let renameCalls = 0;
+
+    await expect(
+      bumpPluginSdk({
+        args: ["--patch"],
+        fileSystem: {
+          readFile,
+          rename: async (from, to) => {
+            renameCalls += 1;
+
+            if (renameCalls === 2) {
+              throw new Error("simulated rename failure");
+            }
+
+            await rename(from, to);
+          },
+          unlink,
+          writeFile,
+        },
+        log: () => {},
+        repoRoot,
+      }),
+    ).rejects.toThrow("simulated rename failure");
+
+    // A half-applied bump is the exact drift this script prevents, so the
+    // already-renamed manifest must be rolled back.
+    expect(readContent(repoRoot, MANIFEST_PATH)).toBe(originalManifest);
+    expect(readContent(repoRoot, VERSION_MODULE_PATH)).toBe(originalModule);
+    expect(
+      readdirSync(join(repoRoot, "packages", "plugin-sdk")),
+    ).not.toContainEqual(expect.stringMatching(/^\.tmp-/u));
+    expect(
+      readdirSync(join(repoRoot, "packages", "domain", "src")),
+    ).not.toContainEqual(expect.stringMatching(/^\.tmp-/u));
+  });
+});

--- a/scripts/bump-plugin-sdk.mjs
+++ b/scripts/bump-plugin-sdk.mjs
@@ -1,0 +1,213 @@
+// Bumps @get-bb/plugin-sdk in the two files that must always agree:
+//
+//   packages/domain/src/plugin-sdk-version.ts  (PLUGIN_SDK_VERSION)
+//   packages/plugin-sdk/package.json           (version)
+//
+// The publish job is publish-if-missing (.github/workflows/publish-bb-app.yml,
+// job publish-plugin-sdk): it never republishes a version that already exists on
+// npm. So any change to the package's published content — dist/, bundled-types/,
+// README.md, or a consumer-facing manifest field — needs a new version, or npm
+// keeps serving the old content forever. check-npm-version-guard.mjs fails CI
+// when that happens and points here.
+//
+// Both files are written atomically: a temp file per target, then renames, with
+// the originals restored if any rename fails. A half-applied bump would leave
+// the repo in the exact inconsistent state this script exists to prevent.
+import { randomUUID } from "node:crypto";
+import { readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { compareSemver, resolveVersionArgument } from "./lib/semver.mjs";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const defaultRepoRoot = resolve(dirname(scriptPath), "..");
+const USAGE =
+  "Usage: node scripts/bump-plugin-sdk.mjs <new-version>|--patch|--minor|--major";
+const MANIFEST_PATH = "packages/plugin-sdk/package.json";
+const VERSION_MODULE_PATH = "packages/domain/src/plugin-sdk-version.ts";
+
+/**
+ * Matches the `PLUGIN_SDK_VERSION` export in plugin-sdk-version.ts. Anchored to
+ * the export statement rather than the bare string so the long explanatory
+ * comment above it — which cites version numbers — is never rewritten.
+ */
+const VERSION_EXPORT_PATTERN =
+  /(export const PLUGIN_SDK_VERSION = ")([^"]+)(";)/u;
+
+const defaultFileSystem = { readFile, rename, unlink, writeFile };
+
+function detectPackageJsonIndent(content) {
+  const match = /\n([ \t]+)"/u.exec(content);
+
+  return match === null ? 2 : match[1];
+}
+
+function readManifestVersion({ content, path }) {
+  const packageJson = JSON.parse(content);
+
+  if (
+    typeof packageJson !== "object" ||
+    packageJson === null ||
+    Array.isArray(packageJson)
+  ) {
+    throw new Error(`Invalid package JSON object in ${path}`);
+  }
+
+  if (typeof packageJson.version !== "string") {
+    throw new Error(`Missing string version field in ${path}`);
+  }
+
+  return { packageJson, version: packageJson.version };
+}
+
+function writeManifestVersion({ content, packageJson, newVersion }) {
+  const trailingNewline = content.endsWith("\n") ? "\n" : "";
+
+  return `${JSON.stringify(
+    { ...packageJson, version: newVersion },
+    null,
+    detectPackageJsonIndent(content),
+  )}${trailingNewline}`;
+}
+
+function readModuleVersion({ content, path }) {
+  const match = VERSION_EXPORT_PATTERN.exec(content);
+
+  if (match === null) {
+    throw new Error(`Could not find the PLUGIN_SDK_VERSION export in ${path}`);
+  }
+
+  return match[2];
+}
+
+function writeModuleVersion({ content, newVersion }) {
+  return content.replace(
+    VERSION_EXPORT_PATTERN,
+    (_match, prefix, _current, suffix) => `${prefix}${newVersion}${suffix}`,
+  );
+}
+
+async function writeTargetsAtomically({ fileSystem, updates }) {
+  const preparedUpdates = [];
+  const renamedUpdates = [];
+
+  try {
+    for (const update of updates) {
+      const temporaryPath = resolve(
+        dirname(update.absolutePath),
+        `.tmp-${process.pid}-${randomUUID()}-plugin-sdk-bump`,
+      );
+
+      await fileSystem.writeFile(temporaryPath, update.nextContent);
+      preparedUpdates.push({ ...update, temporaryPath });
+    }
+
+    for (const update of preparedUpdates) {
+      await fileSystem.rename(update.temporaryPath, update.absolutePath);
+      renamedUpdates.push(update);
+    }
+  } catch (error) {
+    for (const update of [...renamedUpdates].reverse()) {
+      await fileSystem.writeFile(update.absolutePath, update.content);
+    }
+
+    for (const update of preparedUpdates) {
+      await fileSystem.unlink(update.temporaryPath).catch(() => {});
+    }
+
+    throw error;
+  }
+}
+
+export async function bumpPluginSdk(options) {
+  const repoRoot = options.repoRoot;
+  const args = options.args;
+  const log = options.log;
+  const fileSystem = options.fileSystem ?? defaultFileSystem;
+
+  if (args.length !== 1) {
+    throw new Error(USAGE);
+  }
+
+  const manifestAbsolutePath = resolve(repoRoot, MANIFEST_PATH);
+  const moduleAbsolutePath = resolve(repoRoot, VERSION_MODULE_PATH);
+  const [manifestContent, moduleContent] = await Promise.all([
+    fileSystem.readFile(manifestAbsolutePath, "utf8"),
+    fileSystem.readFile(moduleAbsolutePath, "utf8"),
+  ]);
+
+  const { packageJson, version: manifestVersion } = readManifestVersion({
+    content: manifestContent,
+    path: MANIFEST_PATH,
+  });
+  const moduleVersion = readModuleVersion({
+    content: moduleContent,
+    path: VERSION_MODULE_PATH,
+  });
+
+  // Drifted sources have no single "current" version to bump from, and picking
+  // one would silently pin the other. Make the operator resolve it.
+  if (manifestVersion !== moduleVersion) {
+    throw new Error(
+      `Version mismatch before bump: ${MANIFEST_PATH}=${manifestVersion} ${VERSION_MODULE_PATH}=${moduleVersion}. Set both to the same version, then bump.`,
+    );
+  }
+
+  const newVersion = resolveVersionArgument({
+    argument: args[0],
+    currentVersion: manifestVersion,
+    usage: USAGE,
+  });
+
+  if (compareSemver(newVersion, manifestVersion) <= 0) {
+    throw new Error(
+      `New version ${newVersion} must be greater than current ${manifestVersion}.`,
+    );
+  }
+
+  await writeTargetsAtomically({
+    fileSystem,
+    updates: [
+      {
+        absolutePath: manifestAbsolutePath,
+        content: manifestContent,
+        nextContent: writeManifestVersion({
+          content: manifestContent,
+          packageJson,
+          newVersion,
+        }),
+      },
+      {
+        absolutePath: moduleAbsolutePath,
+        content: moduleContent,
+        nextContent: writeModuleVersion({
+          content: moduleContent,
+          newVersion,
+        }),
+      },
+    ],
+  });
+
+  log(
+    `Bumped: @get-bb/plugin-sdk ${manifestVersion} → ${newVersion} (${MANIFEST_PATH} + ${VERSION_MODULE_PATH})`,
+  );
+}
+
+async function main() {
+  const repoRoot = process.env.BB_BUMP_PLUGIN_SDK_REPO_ROOT ?? defaultRepoRoot;
+
+  await bumpPluginSdk({
+    args: process.argv.slice(2),
+    log: console.log,
+    repoRoot,
+  });
+}
+
+if (resolve(process.argv[1] ?? "") === scriptPath) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+
+    console.error(message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -2,8 +2,11 @@ import { randomUUID } from "node:crypto";
 import { readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { compareSemver, resolveVersionArgument } from "./lib/semver.mjs";
 
 const scriptPath = fileURLToPath(import.meta.url);
+const USAGE =
+  "Usage: node scripts/bump-version.mjs <new-version>|--patch|--minor|--major";
 const defaultRepoRoot = resolve(dirname(scriptPath), "..");
 const packageTargets = [
   {
@@ -15,182 +18,12 @@ const packageTargets = [
     path: "apps/desktop/package.json",
   },
 ];
-const semverPattern =
-  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/u;
-const numericIdentifierPattern = /^\d+$/u;
 const defaultFileSystem = {
   readFile,
   rename,
   unlink,
   writeFile,
 };
-
-function parseSemver(version) {
-  const match = semverPattern.exec(version);
-
-  if (match === null) {
-    return null;
-  }
-
-  const [, major, minor, patch, prerelease] = match;
-
-  return {
-    major: BigInt(major),
-    minor: BigInt(minor),
-    patch: BigInt(patch),
-    prerelease: prerelease === undefined ? [] : prerelease.split("."),
-    version,
-  };
-}
-
-function compareCoreVersions(left, right) {
-  for (const key of ["major", "minor", "patch"]) {
-    if (left[key] > right[key]) {
-      return 1;
-    }
-
-    if (left[key] < right[key]) {
-      return -1;
-    }
-  }
-
-  return 0;
-}
-
-function comparePrereleaseIdentifier(left, right) {
-  if (left === right) {
-    return 0;
-  }
-
-  const leftIsNumeric = numericIdentifierPattern.test(left);
-  const rightIsNumeric = numericIdentifierPattern.test(right);
-
-  if (leftIsNumeric && rightIsNumeric) {
-    return BigInt(left) > BigInt(right) ? 1 : -1;
-  }
-
-  if (leftIsNumeric) {
-    return -1;
-  }
-
-  if (rightIsNumeric) {
-    return 1;
-  }
-
-  return left > right ? 1 : -1;
-}
-
-function comparePrereleaseVersions(left, right) {
-  if (left.prerelease.length === 0 && right.prerelease.length === 0) {
-    return 0;
-  }
-
-  if (left.prerelease.length === 0) {
-    return 1;
-  }
-
-  if (right.prerelease.length === 0) {
-    return -1;
-  }
-
-  const identifierCount = Math.max(
-    left.prerelease.length,
-    right.prerelease.length,
-  );
-
-  for (let index = 0; index < identifierCount; index += 1) {
-    const leftIdentifier = left.prerelease[index];
-    const rightIdentifier = right.prerelease[index];
-
-    if (leftIdentifier === undefined) {
-      return -1;
-    }
-
-    if (rightIdentifier === undefined) {
-      return 1;
-    }
-
-    const comparison = comparePrereleaseIdentifier(
-      leftIdentifier,
-      rightIdentifier,
-    );
-
-    if (comparison !== 0) {
-      return comparison;
-    }
-  }
-
-  return 0;
-}
-
-export function compareSemver(leftVersion, rightVersion) {
-  const left = parseSemver(leftVersion);
-  const right = parseSemver(rightVersion);
-
-  if (left === null) {
-    throw new Error(`Invalid semver string: ${leftVersion}`);
-  }
-
-  if (right === null) {
-    throw new Error(`Invalid semver string: ${rightVersion}`);
-  }
-
-  const coreComparison = compareCoreVersions(left, right);
-
-  if (coreComparison !== 0) {
-    return coreComparison;
-  }
-
-  return comparePrereleaseVersions(left, right);
-}
-
-function deriveVersion(currentVersion, bumpType) {
-  const current = parseSemver(currentVersion);
-
-  if (current === null) {
-    throw new Error(`Invalid current version: ${currentVersion}`);
-  }
-
-  if (bumpType === "--major") {
-    return `${current.major + 1n}.0.0`;
-  }
-
-  if (bumpType === "--minor") {
-    return `${current.major}.${current.minor + 1n}.0`;
-  }
-
-  if (bumpType === "--patch") {
-    if (current.prerelease.length > 0) {
-      return `${current.major}.${current.minor}.${current.patch}`;
-    }
-
-    return `${current.major}.${current.minor}.${current.patch + 1n}`;
-  }
-
-  throw new Error(`Unsupported bump flag: ${bumpType}`);
-}
-
-function resolveVersionArgument(argument, currentVersion) {
-  if (
-    argument === "--major" ||
-    argument === "--minor" ||
-    argument === "--patch"
-  ) {
-    return deriveVersion(currentVersion, argument);
-  }
-
-  if (argument.startsWith("--")) {
-    throw new Error(
-      "Usage: node scripts/bump-version.mjs <new-version>|--patch|--minor|--major",
-    );
-  }
-
-  if (parseSemver(argument) === null) {
-    throw new Error(`Invalid version: ${argument}`);
-  }
-
-  return argument;
-}
 
 function parsePackageJson({ content, packagePath }) {
   const packageJson = JSON.parse(content);
@@ -303,9 +136,7 @@ export async function bumpVersion(options) {
   const fileSystem = options.fileSystem ?? defaultFileSystem;
 
   if (args.length !== 1) {
-    throw new Error(
-      "Usage: node scripts/bump-version.mjs <new-version>|--patch|--minor|--major",
-    );
+    throw new Error(USAGE);
   }
 
   const packageReads = await Promise.all(
@@ -314,7 +145,11 @@ export async function bumpVersion(options) {
     ),
   );
   const maxCurrentVersion = findMaxCurrentVersion(packageReads);
-  const newVersion = resolveVersionArgument(args[0], maxCurrentVersion);
+  const newVersion = resolveVersionArgument({
+    argument: args[0],
+    currentVersion: maxCurrentVersion,
+    usage: USAGE,
+  });
 
   if (compareSemver(newVersion, maxCurrentVersion) <= 0) {
     throw new Error(

--- a/scripts/lib/semver.mjs
+++ b/scripts/lib/semver.mjs
@@ -1,0 +1,176 @@
+// Semver parsing, comparison, and bump derivation shared by the repo's version
+// bump scripts (scripts/bump-version.mjs for bb-app/@bb/desktop,
+// scripts/bump-plugin-sdk.mjs for @get-bb/plugin-sdk). Kept dependency-free so
+// the release workflow can run it without an install step.
+const semverPattern =
+  /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/u;
+const numericIdentifierPattern = /^\d+$/u;
+
+export function parseSemver(version) {
+  const match = semverPattern.exec(version);
+
+  if (match === null) {
+    return null;
+  }
+
+  const [, major, minor, patch, prerelease] = match;
+
+  return {
+    major: BigInt(major),
+    minor: BigInt(minor),
+    patch: BigInt(patch),
+    prerelease: prerelease === undefined ? [] : prerelease.split("."),
+    version,
+  };
+}
+
+function compareCoreVersions(left, right) {
+  for (const key of ["major", "minor", "patch"]) {
+    if (left[key] > right[key]) {
+      return 1;
+    }
+
+    if (left[key] < right[key]) {
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+function comparePrereleaseIdentifier(left, right) {
+  if (left === right) {
+    return 0;
+  }
+
+  const leftIsNumeric = numericIdentifierPattern.test(left);
+  const rightIsNumeric = numericIdentifierPattern.test(right);
+
+  if (leftIsNumeric && rightIsNumeric) {
+    return BigInt(left) > BigInt(right) ? 1 : -1;
+  }
+
+  if (leftIsNumeric) {
+    return -1;
+  }
+
+  if (rightIsNumeric) {
+    return 1;
+  }
+
+  return left > right ? 1 : -1;
+}
+
+function comparePrereleaseVersions(left, right) {
+  if (left.prerelease.length === 0 && right.prerelease.length === 0) {
+    return 0;
+  }
+
+  if (left.prerelease.length === 0) {
+    return 1;
+  }
+
+  if (right.prerelease.length === 0) {
+    return -1;
+  }
+
+  const identifierCount = Math.max(
+    left.prerelease.length,
+    right.prerelease.length,
+  );
+
+  for (let index = 0; index < identifierCount; index += 1) {
+    const leftIdentifier = left.prerelease[index];
+    const rightIdentifier = right.prerelease[index];
+
+    if (leftIdentifier === undefined) {
+      return -1;
+    }
+
+    if (rightIdentifier === undefined) {
+      return 1;
+    }
+
+    const comparison = comparePrereleaseIdentifier(
+      leftIdentifier,
+      rightIdentifier,
+    );
+
+    if (comparison !== 0) {
+      return comparison;
+    }
+  }
+
+  return 0;
+}
+
+export function compareSemver(leftVersion, rightVersion) {
+  const left = parseSemver(leftVersion);
+  const right = parseSemver(rightVersion);
+
+  if (left === null) {
+    throw new Error(`Invalid semver string: ${leftVersion}`);
+  }
+
+  if (right === null) {
+    throw new Error(`Invalid semver string: ${rightVersion}`);
+  }
+
+  const coreComparison = compareCoreVersions(left, right);
+
+  if (coreComparison !== 0) {
+    return coreComparison;
+  }
+
+  return comparePrereleaseVersions(left, right);
+}
+
+export function deriveVersion(currentVersion, bumpType) {
+  const current = parseSemver(currentVersion);
+
+  if (current === null) {
+    throw new Error(`Invalid current version: ${currentVersion}`);
+  }
+
+  if (bumpType === "--major") {
+    return `${current.major + 1n}.0.0`;
+  }
+
+  if (bumpType === "--minor") {
+    return `${current.major}.${current.minor + 1n}.0`;
+  }
+
+  if (bumpType === "--patch") {
+    if (current.prerelease.length > 0) {
+      return `${current.major}.${current.minor}.${current.patch}`;
+    }
+
+    return `${current.major}.${current.minor}.${current.patch + 1n}`;
+  }
+
+  throw new Error(`Unsupported bump flag: ${bumpType}`);
+}
+
+/**
+ * Resolve a CLI version argument that is either an explicit semver string or one
+ * of the `--patch`/`--minor`/`--major` bump flags.
+ */
+export function resolveVersionArgument({ argument, currentVersion, usage }) {
+  if (
+    argument === "--major" ||
+    argument === "--minor" ||
+    argument === "--patch"
+  ) {
+    return deriveVersion(currentVersion, argument);
+  }
+
+  if (argument.startsWith("--")) {
+    throw new Error(usage);
+  }
+
+  if (parseSemver(argument) === null) {
+    throw new Error(`Invalid version: ${argument}`);
+  }
+
+  return argument;
+}

--- a/scripts/prepare-nightly-version.mjs
+++ b/scripts/prepare-nightly-version.mjs
@@ -1,7 +1,8 @@
 import { readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { bumpVersion, compareSemver } from "./bump-version.mjs";
+import { bumpVersion } from "./bump-version.mjs";
+import { compareSemver } from "./lib/semver.mjs";
 
 const scriptPath = fileURLToPath(import.meta.url);
 const defaultRepoRoot = resolve(dirname(scriptPath), "..");


### PR DESCRIPTION
Fixes the red CI on `main`.

## The failure

The `checks` job failed at **Check plugin SDK npm version guard**:

```
@get-bb/plugin-sdk@0.4.3 is already published, but the package this
checkout would publish differs from it:
  - README.md
```

#1576 edited `packages/plugin-sdk/README.md`, which ships inside the npm tarball (`files` lists it). #1575 had already published 0.4.3. The publish job is publish-if-missing, so the corrected README could never reach npm consumers. The guard was right to fail.

## The fix

Bump `PLUGIN_SDK_VERSION` and the `plugin-sdk` manifest to 0.4.4. That is the whole fix. Since #1569 made `engines.bbPluginSdk` a floor rather than a ceiling, the `>=0.4.3` pins across `examples/plugins/*`, the first-party `plugins/*`, and the scaffold keep resolving and do not move.

## Why a script

The fix is two files that must stay in sync, hand-edited. `scripts/bump-plugin-sdk.mjs` makes it one command:

```bash
node scripts/bump-plugin-sdk.mjs --patch
```

It writes both files atomically, refuses to run when they already disagree, and anchors its rewrite to the `PLUGIN_SDK_VERSION` export so the version numbers in the surrounding comment are not rewritten. The guard failure message now names the command, matching how `check-version-lockstep.mjs` points at `scripts/bump-version.mjs`.

Semver parsing, comparison, and bump derivation move to `scripts/lib/semver.mjs`, shared with the existing `bump-version.mjs` rather than copied.

## Verification

- 5 new tests: both files move together, comment prose survives, pre-existing drift is refused, a non-advancing version is refused, and the manifest rolls back when the second rename fails.
- The 7 existing `bump-version` tests pass unchanged, covering the semver extraction.
- `node packages/plugin-sdk/scripts/check-npm-version-guard.mjs` → `PASS — 0.4.4 is not on npm yet`.
- `build typecheck lint` green for `@bb/domain`, `@get-bb/plugin-sdk`, `@bb/scripts`; tests green for those plus `@bb/templates`.

## Note

The version numbers left in `docs/configuration.md` and the plugins guide are illustrative examples of the floor rule (`^0.4.1` still works after the SDK moves to `0.4.3` or later), not claims about the current version, so they stay put. Chasing them on every patch bump would be churn the script cannot maintain.

> AGENT GENERATED: by Claude Opus 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)