### PR TITLE
Handle late cross-kind command failures

### DIFF
--- a/packages/thread-view/src/tool-activity-projection.ts
+++ b/packages/thread-view/src/tool-activity-projection.ts
@@ -300,9 +300,7 @@ function createRunningExecutionBase({
     ...(incoming.parentToolCallId
       ? { parentToolCallId: incoming.parentToolCallId }
       : {}),
-    ...(incoming.presentation
-      ? { presentation: incoming.presentation }
-      : {}),
+    ...(incoming.presentation ? { presentation: incoming.presentation } : {}),
     output: getVisibleTextBufferText(outputBuffer) ?? "",
     completedAt: incoming.completedAt ?? null,
     status: incoming.status ?? "pending",
@@ -827,6 +825,16 @@ function mergeExecutionSummary(
     mergeCallStatus(target.status, incoming.status) ?? target.status;
 }
 
+function mergeFinalizedCrossKindError(
+  target: ExecutionMergeTarget,
+  incoming: RunningExecCall,
+): void {
+  mergeExecutionOutput(target, incoming, { visibleOutput: incoming.output });
+  mergeExecutionCompletion(target, incoming);
+  target.status =
+    mergeCallStatus(target.status, incoming.status) ?? target.status;
+}
+
 function syncProjectedCallOutput(
   state: ToolActivityProjectionState,
   call: RunningExecCall,
@@ -1153,14 +1161,25 @@ export function onExecEnd(
     }
   }
 
-  if (
-    state.toolActivity.finalizedExecCallIds.has(incoming.callId) &&
-    merged.status !== "error"
-  ) {
-    return;
+  const historyMatch = findExecMessageInHistoryCells(state, incoming.callId);
+  if (state.toolActivity.finalizedExecCallIds.has(incoming.callId)) {
+    if (merged.status !== "error") {
+      return;
+    }
+    if (historyMatch && historyMatch.call.kind !== merged.kind) {
+      mergeFinalizedCrossKindError(historyMatch.call, merged);
+      historyMatch.cell.sourceSeqEnd = Math.max(
+        historyMatch.cell.sourceSeqEnd,
+        merged.sourceSeqEnd,
+      );
+      historyMatch.cell.createdAt = Math.max(
+        historyMatch.cell.createdAt,
+        merged.createdAt,
+      );
+      return;
+    }
   }
 
-  const historyMatch = findExecMessageInHistoryCells(state, incoming.callId);
   if (historyMatch) {
     mergeExecutionSummary(historyMatch.call, merged, {
       visibleOutput: merged.output,

--- a/packages/thread-view/test/background-task-timeline.test.ts
+++ b/packages/thread-view/test/background-task-timeline.test.ts
@@ -4,7 +4,11 @@ import type {
   ThreadEventBackgroundTaskItem,
   WorkflowProgressSnapshot,
 } from "@bb/domain";
-import type { TimelineRow, TimelineWorkflowWorkRow } from "@bb/server-contract";
+import type {
+  TimelineCommandWorkRow,
+  TimelineRow,
+  TimelineWorkflowWorkRow,
+} from "@bb/server-contract";
 import { describe, expect, it } from "vitest";
 import {
   buildThreadTimelineFromEvents,
@@ -59,6 +63,19 @@ function findWorkflowRows(rows: TimelineRow[]): TimelineWorkflowWorkRow[] {
     }
     if (row.kind === "turn" && row.children) {
       found.push(...findWorkflowRows(row.children));
+    }
+  }
+  return found;
+}
+
+function findCommandRows(rows: TimelineRow[]): TimelineCommandWorkRow[] {
+  const found: TimelineCommandWorkRow[] = [];
+  for (const row of rows) {
+    if (row.kind === "work" && row.workKind === "command") {
+      found.push(row);
+    }
+    if (row.kind === "turn" && row.children) {
+      found.push(...findCommandRows(row.children));
     }
   }
   return found;
@@ -750,6 +767,79 @@ describe("background task timeline projection", () => {
       "task:agent-latest",
       "task:cmd-late",
       "task:cmd-early",
+    ]);
+  });
+
+  it("merges a late failed tool completion into a finalized command row", () => {
+    const timeline = buildTimeline(
+      [
+        turnStarted("turn-1", 1),
+        withMeta(
+          {
+            type: "item/started",
+            threadId: "thread-1",
+            providerThreadId: "provider-1",
+            scope: turnScope("turn-1"),
+            item: {
+              type: "commandExecution",
+              id: "toolu-bash",
+              command: "sleep 10",
+              cwd: "/tmp",
+              status: "pending",
+              approvalStatus: null,
+            },
+          },
+          2,
+        ),
+        withMeta(
+          {
+            type: "item/completed",
+            threadId: "thread-1",
+            providerThreadId: "provider-1",
+            scope: turnScope("turn-1"),
+            item: {
+              type: "commandExecution",
+              id: "toolu-bash",
+              command: "sleep 10",
+              cwd: "/tmp",
+              status: "completed",
+              aggregatedOutput: "initial completion",
+              exitCode: 0,
+              approvalStatus: null,
+            },
+          },
+          3,
+        ),
+        withMeta(
+          {
+            type: "item/completed",
+            threadId: "thread-1",
+            providerThreadId: "provider-1",
+            scope: turnScope("turn-1"),
+            item: {
+              type: "toolCall",
+              id: "toolu-bash",
+              tool: "tool",
+              status: "failed",
+              result: "final failure",
+            },
+          },
+          4,
+        ),
+        turnCompleted("turn-1", 5),
+      ],
+      { includeNestedRows: true, turnMessageDetail: "full" },
+    );
+
+    expect(findCommandRows(timeline.rows)).toMatchObject([
+      {
+        callId: "toolu-bash",
+        command: "sleep 10",
+        completedAt: 4_000,
+        cwd: "/tmp",
+        output: "final failure",
+        status: "error",
+      },
     ]);
   });
 

--- a/packages/thread-view/test/tool-activity-projection.test.ts
+++ b/packages/thread-view/test/tool-activity-projection.test.ts
@@ -4,11 +4,13 @@ import type {
   CommandExecutionUpdate,
   DelegationExecutionUpdate,
   ExecutionOutputUpdate,
+  ToolCallExecutionUpdate,
 } from "../src/exec-lifecycle.js";
 import type {
   EventProjectionCommandMessage,
   EventProjectionDelegationMessage,
   EventProjectionMessage,
+  EventProjectionToolCallMessage,
   EventProjectionToolParsedIntent,
 } from "../src/event-projection-types.js";
 import {
@@ -38,6 +40,13 @@ interface ApplyCommandOutputArgs extends CommandOutputArgs {
   appendOutput: boolean;
   replaceOutput: boolean;
   seq: number;
+}
+
+interface ToolCallUpdateArgs {
+  callId?: string;
+  completedAt?: number | null;
+  output?: string;
+  status: NonNullable<ToolCallExecutionUpdate["status"]>;
 }
 
 interface DelegationUpdateArgs {
@@ -81,6 +90,23 @@ function commandUpdate({
   };
 }
 
+function toolCallUpdate({
+  callId = "tool-1",
+  completedAt = null,
+  output,
+  status,
+}: ToolCallUpdateArgs): ToolCallExecutionUpdate {
+  return {
+    kind: "tool-call",
+    callId,
+    toolName: "Read",
+    toolArgs: null,
+    status,
+    completedAt,
+    ...(output !== undefined ? { output } : {}),
+  };
+}
+
 function delegationUpdate({
   completedAt = null,
   output,
@@ -118,6 +144,12 @@ function isDelegationMessage(
   return message.kind === "delegation";
 }
 
+function isToolCallMessage(
+  message: EventProjectionMessage,
+): message is EventProjectionToolCallMessage {
+  return message.kind === "tool-call";
+}
+
 function activeCommandMessage(
   state: ToolActivityProjectionState,
 ): EventProjectionCommandMessage | null {
@@ -142,6 +174,12 @@ function delegationMessages(
   state: ToolActivityProjectionState,
 ): EventProjectionDelegationMessage[] {
   return state.messages.filter(isDelegationMessage);
+}
+
+function toolCallMessages(
+  state: ToolActivityProjectionState,
+): EventProjectionToolCallMessage[] {
+  return state.messages.filter(isToolCallMessage);
 }
 
 function beginCommand(state: ToolActivityProjectionState): void {
@@ -207,13 +245,7 @@ function outputBeforeCommandBegin(
   state: ToolActivityProjectionState,
   output: string,
 ): void {
-  onExecOutput(
-    state,
-    eventMeta(1),
-    commandOutput({ output }),
-    true,
-    false,
-  );
+  onExecOutput(state, eventMeta(1), commandOutput({ output }), true, false);
 }
 
 function applyCommandOutput(
@@ -269,6 +301,123 @@ describe("tool activity projection", () => {
       {
         command: latestCommand,
         parsedIntents: [],
+      },
+    ]);
+  });
+
+  it("merges a late failed tool completion into a finalized command row", () => {
+    const state = createProjectionState();
+
+    onExecBegin(
+      state,
+      eventMeta(1),
+      "thread-1",
+      "turn-1",
+      commandUpdate({
+        command: "pnpm test",
+        output: "started\n",
+        status: "pending",
+      }),
+    );
+    onExecEnd(
+      state,
+      eventMeta(2),
+      "thread-1",
+      "turn-1",
+      commandUpdate({
+        completedAt: 2,
+        output: "backgrounded\n",
+        status: "completed",
+      }),
+    );
+
+    expect(() =>
+      onExecEnd(
+        state,
+        eventMeta(3),
+        "thread-1",
+        "turn-1",
+        toolCallUpdate({
+          callId: "command-1",
+          completedAt: 3,
+          output: "failed\n",
+          status: "error",
+        }),
+      ),
+    ).not.toThrow();
+
+    expect(commandMessages(state)).toMatchObject([
+      {
+        kind: "command",
+        command: "pnpm test",
+        cwd: "/repo",
+        completedAt: 3,
+        output: "failed\n",
+        status: "error",
+      },
+    ]);
+    expect(toolCallMessages(state)).toEqual([]);
+  });
+
+  it("rejects a cross-kind update for a non-finalized command row", () => {
+    const state = createProjectionState();
+
+    onExecBegin(
+      state,
+      eventMeta(1),
+      "thread-1",
+      "turn-1",
+      commandUpdate({ status: "pending" }),
+    );
+    interruptPendingToolActivity(state, {
+      completedAt: 2,
+      turnIds: new Set(["turn-1"]),
+    });
+
+    expect(() =>
+      onExecEnd(
+        state,
+        eventMeta(3),
+        "thread-1",
+        "turn-1",
+        toolCallUpdate({ callId: "command-1", status: "completed" }),
+      ),
+    ).toThrow("Cannot merge command with tool-call for call command-1");
+  });
+
+  it("ignores a late non-error cross-kind update for a finalized command row", () => {
+    const state = createProjectionState();
+
+    beginCommand(state);
+    onExecEnd(
+      state,
+      eventMeta(2),
+      "thread-1",
+      "turn-1",
+      commandUpdate({
+        completedAt: 2,
+        output: "completed\n",
+        status: "completed",
+      }),
+    );
+    onExecEnd(
+      state,
+      eventMeta(3),
+      "thread-1",
+      "turn-1",
+      toolCallUpdate({
+        callId: "command-1",
+        completedAt: 3,
+        output: "duplicate\n",
+        status: "completed",
+      }),
+    );
+
+    expect(commandMessages(state)).toMatchObject([
+      {
+        completedAt: 2,
+        output: "completed\n",
+        status: "completed",
       },
     ]);
   });


### PR DESCRIPTION
## Problem

Some providers emit `commandExecution/completed`, then report the same call ID again as a failed generic `toolCall`. The second terminal event currently throws `Cannot merge command with tool-call`, so one record can make the thread timeline return 500.

## Fix

- keep the finalized command row and its command-specific fields
- merge only the late error's output, completion time, and status
- retain strict kind checks for non-finalized calls and existing dedupe for non-error terminal events

## Verification

- `pnpm exec turbo run test --filter=@bb/thread-view --force` (372 tests)
- `pnpm exec turbo run typecheck --filter=@bb/thread-view --force`
- Prettier and `git diff --check`

> AGENT GENERATED: by GPT-5

