### PR TITLE
Keep the model picker scrollable in short viewports

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -491,9 +491,12 @@ describe("ModelReasoningPicker", () => {
     );
     expect(menu.className).toContain("overflow-y-auto");
     expect(menu.className).toContain("overscroll-contain");
+    expect(
+      screen.getByRole("listbox", { name: "Models" }).className,
+    ).toContain("shrink-0");
   });
 
-  it("leaves compact drawer height and scrolling to the responsive shell", () => {
+  it("leaves compact drawer height and scrolling to the responsive shell", async () => {
     renderPicker({ compact: true, modelOptions: manyCodexModels });
 
     fireEvent.click(
@@ -503,6 +506,9 @@ describe("ModelReasoningPicker", () => {
     expect(screen.getByRole("dialog").className).not.toContain(
       "max-h-[var(--radix-popover-content-available-height)]",
     );
+    expect(
+      (await screen.findByRole("listbox", { name: "Models" })).className,
+    ).not.toContain("shrink-0");
   });
 
   it("commits a provider tab immediately and keeps its models selectable", async () => {

--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -478,6 +478,33 @@ describe("ModelReasoningPicker", () => {
     ).toBe("");
   });
 
+  it("keeps the desktop menu scrollable within the available viewport height", () => {
+    renderPicker({ modelOptions: manyCodexModels });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Provider, model and reasoning" }),
+    );
+
+    const menu = screen.getByRole("dialog");
+    expect(menu.className).toContain(
+      "max-h-[var(--radix-popover-content-available-height)]",
+    );
+    expect(menu.className).toContain("overflow-y-auto");
+    expect(menu.className).toContain("overscroll-contain");
+  });
+
+  it("leaves compact drawer height and scrolling to the responsive shell", () => {
+    renderPicker({ compact: true, modelOptions: manyCodexModels });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Provider, model and reasoning" }),
+    );
+
+    expect(screen.getByRole("dialog").className).not.toContain(
+      "max-h-[var(--radix-popover-content-available-height)]",
+    );
+  });
+
   it("commits a provider tab immediately and keeps its models selectable", async () => {
     const { onSelectedProviderChange, onModelChange } = renderPicker();
 

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -925,6 +925,8 @@ export function ModelReasoningPicker({
           "flex flex-col p-0",
           MODEL_PICKER_MENU_WIDTH_CLASS_NAME,
           "max-md:w-full max-md:min-w-0 max-md:max-w-none",
+          !isCompactViewport &&
+            "max-h-[var(--radix-popover-content-available-height)] overflow-y-auto overscroll-contain",
         )}
       >
         <ResetBrowseStateOnContentUnmount onReset={resetBrowseState} />

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -1007,7 +1007,10 @@ export function ModelReasoningPicker({
             className={cn(
               "overflow-y-auto px-1 pb-1 pt-0",
               !isCompactViewport &&
-                "max-h-[min(250px,var(--radix-popover-content-available-height,250px)-80px)]",
+                // Preserve the model scroller's intended height when the outer
+                // menu is capped; otherwise this flex item collapses before the
+                // full desktop menu can scroll to the reasoning controls.
+                "shrink-0 max-h-[min(250px,var(--radix-popover-content-available-height,250px)-80px)]",
             )}
           >
             {isShowingModelError ? null : (


### PR DESCRIPTION
## Summary

- constrain the desktop model picker to the popover available height
- allow the full menu to scroll so reasoning options remain reachable
- keep compact drawer sizing unchanged

## Tests

- `pnpm exec turbo run test --filter=@bb/app --force`
- `pnpm exec turbo run typecheck --filter=@bb/app --force`
- `pnpm exec turbo run lint --filter=@bb/app --force`
- `pnpm exec turbo run build --filter=@bb/app --force`
- verified at a 1000x400 viewport that wheel scrolling reveals the final reasoning option

> AGENT GENERATED: by GPT-5.4