### PR TITLE
Fix Fish terminal capability query before xterm attaches

### DIFF
--- a/apps/host-daemon/src/terminals/terminal-manager.test.ts
+++ b/apps/host-daemon/src/terminals/terminal-manager.test.ts
@@ -1105,7 +1105,7 @@ describe("TerminalManager", () => {
       tailBytes: 4 * 1024 * 1024,
     });
 
-    expect(pty.writeCalls).toEqual(["\u001b[?1;2c", "\u001b[?1;2c"]);
+    expect(pty.writeCalls).toEqual(["\u001b[?1;2c\u001b[?1;2c"]);
     expect(collectTerminalOutput(harness.messages)).toBe("beforebetweenafter");
     expect(harness.messages).toContainEqual({
       type: "terminal.replay",
@@ -1149,6 +1149,16 @@ describe("TerminalManager", () => {
       replayStartSeq: 0,
       nextSeq: 0,
     });
+  });
+
+  it("bounds device attribute replies for one flooded output chunk", async () => {
+    const harness = createHarness();
+    const pty = await openTerminal(harness);
+
+    pty.emitData("\u001b[c".repeat(5_000));
+
+    expect(pty.writeCalls).toEqual(["\u001b[?1;2c".repeat(8)]);
+    expect(collectTerminalOutput(harness.messages)).toBe("");
   });
 
   it("preserves near matches and incomplete device attribute queries on exit", async () => {

--- a/apps/host-daemon/src/terminals/terminal-manager.test.ts
+++ b/apps/host-daemon/src/terminals/terminal-manager.test.ts
@@ -1092,6 +1092,87 @@ describe("TerminalManager", () => {
     });
   });
 
+  it("answers primary device attribute queries without replaying them", async () => {
+    const harness = createHarness();
+    const pty = await openTerminal(harness);
+
+    pty.emitData("before\u001b[0cbetween\u001b[cafter");
+    await harness.manager.handleMessage({
+      type: "terminal.attach",
+      requestId: "attach-da1",
+      terminalId: "term-1",
+      sinceSeq: 0,
+      tailBytes: 4 * 1024 * 1024,
+    });
+
+    expect(pty.writeCalls).toEqual(["\u001b[?1;2c", "\u001b[?1;2c"]);
+    expect(collectTerminalOutput(harness.messages)).toBe("beforebetweenafter");
+    expect(harness.messages).toContainEqual({
+      type: "terminal.replay",
+      requestId: "attach-da1",
+      terminalId: "term-1",
+      chunks: [
+        {
+          seq: 0,
+          dataBase64: Buffer.from("beforebetweenafter", "utf8").toString(
+            "base64",
+          ),
+        },
+      ],
+      replayStartSeq: 0,
+      nextSeq: 1,
+    });
+  });
+
+  it("answers primary device attribute queries split across output chunks", async () => {
+    const harness = createHarness();
+    const pty = await openTerminal(harness);
+
+    for (const chunk of ["\u001b", "[", "0", "c", "\u001b[", "c"]) {
+      pty.emitData(chunk);
+    }
+    await harness.manager.handleMessage({
+      type: "terminal.attach",
+      requestId: "attach-split-da1",
+      terminalId: "term-1",
+      sinceSeq: 0,
+      tailBytes: 4 * 1024 * 1024,
+    });
+
+    expect(pty.writeCalls).toEqual(["\u001b[?1;2c", "\u001b[?1;2c"]);
+    expect(collectTerminalOutput(harness.messages)).toBe("");
+    expect(harness.messages).toContainEqual({
+      type: "terminal.replay",
+      requestId: "attach-split-da1",
+      terminalId: "term-1",
+      chunks: [],
+      replayStartSeq: 0,
+      nextSeq: 0,
+    });
+  });
+
+  it("preserves near matches and incomplete device attribute queries on exit", async () => {
+    const harness = createHarness();
+    const pty = await openTerminal(harness);
+
+    pty.emitData("before\u001b[1cafter\u001b[0");
+    pty.emitExit(0);
+
+    expect(pty.writeCalls).toEqual([]);
+    expect(collectTerminalOutput(harness.messages)).toBe(
+      "before\u001b[1cafter\u001b[0",
+    );
+    expect(
+      harness.messages
+        .filter(
+          (message) =>
+            message.type === "terminal.output" ||
+            message.type === "terminal.exited",
+        )
+        .map((message) => message.type),
+    ).toEqual(["terminal.output", "terminal.exited"]);
+  });
+
   it("bounds replay to the requested tail without splitting output chunks", async () => {
     const harness = createHarness();
     const pty = await openTerminal(harness);

--- a/apps/host-daemon/src/terminals/terminal-manager.ts
+++ b/apps/host-daemon/src/terminals/terminal-manager.ts
@@ -19,6 +19,16 @@ const DEFAULT_SCROLLBACK_MAX_CHUNKS = 10_000;
 const MAX_OUTPUT_CHUNK_BYTES = 64 * 1024;
 const DEFAULT_OUTPUT_BATCH_DELAY_MS = 4;
 const DEFAULT_TERMINAL_CLOSE_GRACE_PERIOD_MS = 2_000;
+// The PTY starts before browser xterm can attach, so a shell can send its
+// required DA1 startup query while no terminal emulator is present. Although
+// browser xterm supports DA1, bb suppresses replies generated from replayed
+// output because the same output may have been processed before a reconnect.
+// Answer DA1 at the always-present PTY boundary and remove the query from
+// output so a later browser cannot send a duplicate response. If detached
+// query support grows beyond DA1, use one authoritative headless emulator
+// instead of adding more protocol-specific handlers here.
+const PRIMARY_DEVICE_ATTRIBUTES_QUERY_PATTERN = /\u001b\[(?:0)?c/g;
+const PRIMARY_DEVICE_ATTRIBUTES_RESPONSE = "\u001b[?1;2c";
 const NODE_PTY_NATIVE_DIRS: readonly string[] = [
   path.join("build", "Release"),
   path.join("build", "Debug"),
@@ -102,11 +112,24 @@ interface TerminalSession {
   outputBuffers: Buffer[];
   outputBytes: number;
   outputFlushTimeout: ReturnType<typeof setTimeout> | null;
+  pendingPrimaryDeviceAttributesQuery: PendingPrimaryDeviceAttributesQuery;
   pty: TerminalPtyProcess;
   rows: number;
   scrollback: ScrollbackEntry[];
   scrollbackBytes: number;
   terminalId: string;
+}
+
+type PendingPrimaryDeviceAttributesQuery =
+  | ""
+  | "\u001b"
+  | "\u001b["
+  | "\u001b[0";
+
+interface PrimaryDeviceAttributesQueryResult {
+  output: string;
+  pendingQuery: PendingPrimaryDeviceAttributesQuery;
+  queryCount: number;
 }
 
 interface SendTerminalErrorArgs {
@@ -391,6 +414,38 @@ function createTerminalOperationCompletion(): TerminalOperationCompletion {
   return { promise, resolve: resolveCompletion };
 }
 
+function consumePrimaryDeviceAttributesQueries(
+  pendingQuery: PendingPrimaryDeviceAttributesQuery,
+  data: string,
+): PrimaryDeviceAttributesQueryResult {
+  const input = pendingQuery + data;
+  // Hold only a suffix that can become a complete DA1 query in the next PTY
+  // output chunk. finishTerminalSession flushes it unchanged if the PTY exits.
+  const nextPendingQuery: PendingPrimaryDeviceAttributesQuery = input.endsWith(
+    "\u001b[0",
+  )
+    ? "\u001b[0"
+    : input.endsWith("\u001b[")
+      ? "\u001b["
+      : input.endsWith("\u001b")
+        ? "\u001b"
+        : "";
+  const completeInput = input.slice(0, input.length - nextPendingQuery.length);
+  let queryCount = 0;
+  const output = completeInput.replace(
+    PRIMARY_DEVICE_ATTRIBUTES_QUERY_PATTERN,
+    () => {
+      queryCount += 1;
+      return "";
+    },
+  );
+  return {
+    output,
+    pendingQuery: nextPendingQuery,
+    queryCount,
+  };
+}
+
 export class TerminalManager {
   private readonly closeGracePeriodMs: number;
   private readonly outputBatchDelayMs: number;
@@ -553,6 +608,7 @@ export class TerminalManager {
         outputBuffers: [],
         outputBytes: 0,
         outputFlushTimeout: null,
+        pendingPrimaryDeviceAttributesQuery: "",
         pty,
         rows: message.rows,
         scrollback: [],
@@ -801,6 +857,18 @@ export class TerminalManager {
       return;
     }
 
+    const result = consumePrimaryDeviceAttributesQueries(
+      session.pendingPrimaryDeviceAttributesQuery,
+      data,
+    );
+    session.pendingPrimaryDeviceAttributesQuery = result.pendingQuery;
+    for (let index = 0; index < result.queryCount; index += 1) {
+      session.pty.write(PRIMARY_DEVICE_ATTRIBUTES_RESPONSE);
+    }
+    this.bufferTerminalOutput(session, result.output);
+  }
+
+  private bufferTerminalOutput(session: TerminalSession, data: string): void {
     const buffer = Buffer.from(data, "utf8");
     if (buffer.byteLength === 0) {
       return;
@@ -883,6 +951,13 @@ export class TerminalManager {
   private finishTerminalSession(args: FinishTerminalSessionArgs): void {
     if (this.sessions.get(args.session.terminalId) !== args.session) {
       return;
+    }
+    if (args.session.pendingPrimaryDeviceAttributesQuery.length > 0) {
+      this.bufferTerminalOutput(
+        args.session,
+        args.session.pendingPrimaryDeviceAttributesQuery,
+      );
+      args.session.pendingPrimaryDeviceAttributesQuery = "";
     }
     this.flushTerminalOutput(args.session);
     if (args.session.closeTimeout !== null) {

--- a/apps/host-daemon/src/terminals/terminal-manager.ts
+++ b/apps/host-daemon/src/terminals/terminal-manager.ts
@@ -29,6 +29,11 @@ const DEFAULT_TERMINAL_CLOSE_GRACE_PERIOD_MS = 2_000;
 // instead of adding more protocol-specific handlers here.
 const PRIMARY_DEVICE_ATTRIBUTES_QUERY_PATTERN = /\u001b\[(?:0)?c/g;
 const PRIMARY_DEVICE_ATTRIBUTES_RESPONSE = "\u001b[?1;2c";
+// One 64 KiB output chunk can hold more than 20,000 DA1 queries. node-pty
+// copies each reply into an unbounded write queue, so a terminal process could
+// exhaust host daemon memory. Send one bounded write for each output chunk.
+// A shell needs only one answer for each startup query.
+const MAX_PRIMARY_DEVICE_ATTRIBUTES_REPLIES_PER_CHUNK = 8;
 const NODE_PTY_NATIVE_DIRS: readonly string[] = [
   path.join("build", "Release"),
   path.join("build", "Debug"),
@@ -862,8 +867,12 @@ export class TerminalManager {
       data,
     );
     session.pendingPrimaryDeviceAttributesQuery = result.pendingQuery;
-    for (let index = 0; index < result.queryCount; index += 1) {
-      session.pty.write(PRIMARY_DEVICE_ATTRIBUTES_RESPONSE);
+    if (result.queryCount > 0) {
+      const replyCount = Math.min(
+        result.queryCount,
+        MAX_PRIMARY_DEVICE_ATTRIBUTES_REPLIES_PER_CHUNK,
+      );
+      session.pty.write(PRIMARY_DEVICE_ATTRIBUTES_RESPONSE.repeat(replyCount));
     }
     this.bufferTerminalOutput(session, result.output);
   }


### PR DESCRIPTION
## Summary

Handle Primary Device Attributes (DA1) queries at the host PTY boundary.

This prevents Fish from waiting 10 seconds and showing:

> fish could not read response to Primary Device Attribute query

## Problem

bb starts the host PTY before the browser terminal attaches. This lets terminal processes start immediately, retain their session, and buffer output while no terminal view is open.

During startup, Fish sends a DA1 query (`ESC[c` or `ESC[0c`) and waits for a terminal emulator to answer. xterm.js supports this query, but it cannot answer before it attaches to the PTY.

Forwarding the query through replay does not provide a safe fix. Replayed output can be processed again after reconnects, which could produce duplicate terminal responses.

## Solution

The host daemon now:

- detects both supported DA1 query forms;
- recognizes queries split across output chunks;
- writes the xterm-compatible `ESC[?1;2c` response directly to the PTY;
- removes handled queries from live and replayed output, which prevents duplicate browser responses;
- preserves near matches and incomplete queries if the PTY exits.

This is intentionally a small protocol-specific handler. Adding a headless terminal emulator package would introduce parser state and a larger dependency for one startup query. If detached terminal emulation needs to support more queries later, the code comments identify `@xterm/headless` as the correct replacement.

The host daemon protocol version increases from 119 to 120 so enrolled machines cannot use old terminal semantics with the updated server.

## Verification

- Host daemon tests: 557 passed
- Host daemon contract tests: 49 passed
- Turbo typechecks passed for both affected packages
- `git diff --check` passed
- Live Fish 4.8.1 session:
  - prompt appeared normally;
  - no warning appeared after 11 seconds;
  - no handled DA1 query remained in terminal replay output
- Electron dev build started successfully

> AGENT GENERATED: by GPT-5.4