### PR TITLE
Right sidebar tab splits: layout and positioning foundation

### DIFF
--- a/apps/app/src/components/secondary-panel/BrowserTabContent.chrome.test.tsx
+++ b/apps/app/src/components/secondary-panel/BrowserTabContent.chrome.test.tsx
@@ -6,6 +6,7 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
 } from "@testing-library/react";
 import type {
   BbDesktopBrowserApi,
@@ -31,21 +32,30 @@ const desktopInfo = {
 interface BrowserChromeHarness {
   api: BbDesktopBrowserApi;
   emitState: (state: BbDesktopBrowserState) => void;
+  emitNativeFocus: (tabId: string) => void;
+  focus: ReturnType<typeof vi.fn>;
   goBack: ReturnType<typeof vi.fn>;
   stop: ReturnType<typeof vi.fn>;
 }
 
 function createBrowserChromeHarness(): BrowserChromeHarness {
   const stateListeners = new Set<(state: BbDesktopBrowserState) => void>();
+  const focusListeners = new Set<(tabId: string) => void>();
+  const focus = vi.fn();
   const goBack = vi.fn();
   const stop = vi.fn();
   const api: BbDesktopBrowserApi = {
     ...createNoopDesktopBrowserApi(),
     goBack,
+    focus,
     stop,
     onState(listener) {
       stateListeners.add(listener);
       return () => stateListeners.delete(listener);
+    },
+    onFocus(listener) {
+      focusListeners.add(listener);
+      return () => focusListeners.delete(listener);
     },
   };
   return {
@@ -53,6 +63,10 @@ function createBrowserChromeHarness(): BrowserChromeHarness {
     emitState(state) {
       for (const listener of stateListeners) listener(state);
     },
+    emitNativeFocus(tabId) {
+      for (const listener of focusListeners) listener(tabId);
+    },
+    focus,
     goBack,
     stop,
   };
@@ -73,7 +87,15 @@ function browserState(
   };
 }
 
-function renderBrowserChrome(harness: BrowserChromeHarness, initialUrl = "") {
+function renderBrowserChrome(
+  harness: BrowserChromeHarness,
+  initialUrl = "",
+  options: {
+    canHandleBrowserCommands?: boolean;
+    canShowNativeBrowserView?: boolean;
+    onNativeFocus?: () => void;
+  } = {},
+) {
   window.bbDesktop = createBbDesktopApi(desktopInfo, harness.api);
   return render(
     <>
@@ -81,7 +103,9 @@ function renderBrowserChrome(harness: BrowserChromeHarness, initialUrl = "") {
         tabId="browser:test"
         initialUrl={initialUrl}
         addressFocusRequest={null}
-        canShowNativeBrowserView={false}
+        canHandleBrowserCommands={options.canHandleBrowserCommands}
+        canShowNativeBrowserView={options.canShowNativeBrowserView ?? false}
+        onNativeFocus={options.onNativeFocus}
         visibilityCoordinator={null}
         environmentId={null}
         threadId="thread-1"
@@ -137,5 +161,23 @@ describe("BrowserTabContent persistent navigation", () => {
     act(() => harness.emitState(browserState({ canGoBack: true })));
     fireEvent.click(screen.getByRole("button", { name: "Go back" }));
     expect(harness.goBack).toHaveBeenCalledWith("browser:test");
+  });
+
+  it("restores native focus to the logical pane and reports page focus", async () => {
+    const harness = createBrowserChromeHarness();
+    const onNativeFocus = vi.fn();
+    renderBrowserChrome(harness, "https://example.com/docs", {
+      canHandleBrowserCommands: true,
+      canShowNativeBrowserView: true,
+      onNativeFocus,
+    });
+
+    await waitFor(() =>
+      expect(harness.focus).toHaveBeenCalledWith("browser:test"),
+    );
+    act(() => harness.emitNativeFocus("browser:other"));
+    expect(onNativeFocus).not.toHaveBeenCalled();
+    act(() => harness.emitNativeFocus("browser:test"));
+    expect(onNativeFocus).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/app/src/components/secondary-panel/BrowserTabContent.tsx
+++ b/apps/app/src/components/secondary-panel/BrowserTabContent.tsx
@@ -65,6 +65,14 @@ export interface BrowserTabContentProps {
    */
   canShowNativeBrowserView: boolean;
   /**
+   * Whether browser commands target this tab. This is separate from native-view
+   * visibility because multiple split panes may remain visible while only the
+   * focused pane owns keyboard commands.
+   */
+  canHandleBrowserCommands?: boolean;
+  /** Called when focus enters this tab's native page surface. */
+  onNativeFocus?: () => void;
+  /**
    * Deck-owned coordinator that serializes view visibility so the previously
    * shown view is always hidden before this one is shown (no two native overlays
    * visible at once). Null on the web build, where there is no native view.
@@ -432,6 +440,8 @@ export function BrowserTabContent({
   addressFocusRequest,
   onAddressFocusRequestConsumed,
   canShowNativeBrowserView,
+  canHandleBrowserCommands = canShowNativeBrowserView,
+  onNativeFocus,
   visibilityCoordinator,
   environmentId,
   threadId,
@@ -491,6 +501,10 @@ export function BrowserTabContent({
     attachedBrowserViewIdentity.threadId === threadId;
 
   const hasPage = currentUrl.length > 0;
+  const supportsNativePaneFocus =
+    desktopBrowser?.focus !== undefined &&
+    desktopBrowser.onFocus !== undefined &&
+    desktopBrowser.setVisibleWithoutFocus !== undefined;
   const pageLoadErrorText = state?.errorText ?? null;
   const hasPageLoadError = pageLoadErrorText !== null && hasPage;
   // A blocking modal (e.g. the git-action dialog) dims the panel with a DOM
@@ -711,6 +725,7 @@ export function BrowserTabContent({
   // deactivation never reloads it.
   const isViewVisible =
     canShowNativeBrowserView &&
+    (canHandleBrowserCommands || supportsNativePaneFocus) &&
     hasPage &&
     !hasPageLoadError &&
     isBrowserViewAttached &&
@@ -725,13 +740,35 @@ export function BrowserTabContent({
       return;
     }
     if (isViewVisible) {
-      visibilityCoordinator.show(tabId, syncBounds);
+      visibilityCoordinator.show(tabId, syncBounds, {
+        focus: canHandleBrowserCommands,
+      });
       return () => {
         visibilityCoordinator.hide(tabId);
       };
     }
     visibilityCoordinator.hide(tabId);
-  }, [visibilityCoordinator, tabId, isViewVisible, syncBounds]);
+  }, [
+    canHandleBrowserCommands,
+    visibilityCoordinator,
+    tabId,
+    isViewVisible,
+    syncBounds,
+  ]);
+
+  useEffect(() => {
+    if (desktopBrowser?.onFocus === undefined || onNativeFocus === undefined) {
+      return;
+    }
+    return desktopBrowser.onFocus((focusedTabId) => {
+      if (focusedTabId === tabId) onNativeFocus();
+    });
+  }, [desktopBrowser, onNativeFocus, tabId]);
+
+  useEffect(() => {
+    if (!isViewVisible || !canHandleBrowserCommands) return;
+    desktopBrowser?.focus?.(tabId);
+  }, [canHandleBrowserCommands, desktopBrowser, isViewVisible, tabId]);
 
   useEffect(() => {
     if (addressFocusRequest === null) {
@@ -796,7 +833,7 @@ export function BrowserTabContent({
   }, [desktopBrowser, state?.isLoading, tabId]);
 
   const handleFocusLocation = useCallback((): boolean => {
-    if (!canShowNativeBrowserView || desktopBrowser === null) return false;
+    if (!canHandleBrowserCommands || desktopBrowser === null) return false;
     setAddressDraft(currentUrl);
     setIsEditing(true);
     addressInputRef.current?.focus({ preventScroll: true });
@@ -805,7 +842,7 @@ export function BrowserTabContent({
       addressInputRef.current?.select();
     });
     return true;
-  }, [canShowNativeBrowserView, currentUrl, desktopBrowser]);
+  }, [canHandleBrowserCommands, currentUrl, desktopBrowser]);
 
   useAppCommandHandler("browser.focusLocation", handleFocusLocation, 100);
 
@@ -889,7 +926,7 @@ export function BrowserTabContent({
   useAppCommandHandler(
     "browser.reload",
     () => {
-      if (!canShowNativeBrowserView || desktopBrowser === null || !hasPage) {
+      if (!canHandleBrowserCommands || desktopBrowser === null || !hasPage) {
         return false;
       }
       desktopBrowser.reload(tabId);

--- a/apps/app/src/components/secondary-panel/BrowserTabDeck.browser-view-ordering.test.tsx
+++ b/apps/app/src/components/secondary-panel/BrowserTabDeck.browser-view-ordering.test.tsx
@@ -15,21 +15,28 @@ import {
   createNoopDesktopBrowserApi,
 } from "@/test/bb-desktop-test-utils";
 import { POINTER_COARSE_QUERY } from "@bb/shared-ui/hooks/use-pointer-coarse";
-import { BrowserTabDeck } from "./BrowserTabDeck";
+import { BrowserTabDeck, BrowserTabLifecycleObserver } from "./BrowserTabDeck";
 import { resetBrowserViewPersistence } from "./browserViewVisibilityCoordinator";
 
 type BrowserCall =
   | { type: "attach"; request: BbDesktopBrowserAttachRequest }
+  | { type: "detach"; tabId: string }
   | { type: "setBounds"; request: BbDesktopBrowserSetBoundsRequest }
-  | { type: "setVisible"; request: BbDesktopBrowserSetVisibleRequest };
+  | { type: "setVisible"; request: BbDesktopBrowserSetVisibleRequest }
+  | {
+      type: "setVisibleWithoutFocus";
+      request: BbDesktopBrowserSetVisibleRequest;
+    };
 
 interface RecordingBrowserApi {
   api: BbDesktopBrowserApi;
   calls: BrowserCall[];
+  detachments: string[];
   attachments: BbDesktopBrowserAttachRequest[];
   bounds: BbDesktopBrowserSetBoundsRequest[];
   emitState: (state: BbDesktopBrowserState) => void;
   visibility: BbDesktopBrowserSetVisibleRequest[];
+  visibilityWithoutFocus: BbDesktopBrowserSetVisibleRequest[];
 }
 
 const BROWSER_PANEL_RECT = new DOMRect(12, 24, 420, 260);
@@ -58,13 +65,19 @@ function createRecordingBrowserApi(): RecordingBrowserApi {
   const calls: BrowserCall[] = [];
   const attachments: BbDesktopBrowserAttachRequest[] = [];
   const bounds: BbDesktopBrowserSetBoundsRequest[] = [];
+  const detachments: string[] = [];
   const stateListeners: Array<(state: BbDesktopBrowserState) => void> = [];
   const visibility: BbDesktopBrowserSetVisibleRequest[] = [];
+  const visibilityWithoutFocus: BbDesktopBrowserSetVisibleRequest[] = [];
   const api: BbDesktopBrowserApi = {
     ...createNoopDesktopBrowserApi(),
     attach(request) {
       attachments.push(request);
       calls.push({ type: "attach", request });
+    },
+    detach(tabId) {
+      detachments.push(tabId);
+      calls.push({ type: "detach", tabId });
     },
     setBounds(request) {
       bounds.push(request);
@@ -73,6 +86,10 @@ function createRecordingBrowserApi(): RecordingBrowserApi {
     setVisible(request) {
       visibility.push(request);
       calls.push({ type: "setVisible", request });
+    },
+    setVisibleWithoutFocus(request) {
+      visibilityWithoutFocus.push(request);
+      calls.push({ type: "setVisibleWithoutFocus", request });
     },
     onState(listener) {
       stateListeners.push(listener);
@@ -89,12 +106,14 @@ function createRecordingBrowserApi(): RecordingBrowserApi {
     calls,
     attachments,
     bounds,
+    detachments,
     emitState(state) {
       for (const listener of stateListeners) {
         listener(state);
       }
     },
     visibility,
+    visibilityWithoutFocus,
   };
 }
 
@@ -154,6 +173,34 @@ function lastCallIndex(
   }
   return -1;
 }
+
+describe("BrowserTabLifecycleObserver", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    resetBrowserViewPersistence();
+    delete window.bbDesktop;
+  });
+
+  it("destroys a closed browser view exactly once without an active deck", async () => {
+    const { api, detachments, visibility } = createRecordingBrowserApi();
+    installDesktopBrowser(api);
+    const tab = makeBrowserTab("tab-closed", "https://example.com");
+    const view = render(
+      <BrowserTabLifecycleObserver browserTabs={[tab]} threadId="thread-1" />,
+    );
+
+    await waitFor(() => expect(detachments).toHaveLength(0));
+    view.rerender(
+      <BrowserTabLifecycleObserver browserTabs={[]} threadId="thread-1" />,
+    );
+
+    await waitFor(() => expect(detachments).toEqual(["tab-closed"]));
+    expect(
+      visibility.filter((request) => request.tabId === "tab-closed"),
+    ).toEqual([{ tabId: "tab-closed", visible: false }]);
+  });
+});
 
 describe("BrowserTabDeck native browser first-show ordering", () => {
   const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
@@ -301,27 +348,52 @@ describe("BrowserTabDeck native browser first-show ordering", () => {
     expect(restoredShowIndex).toBeGreaterThan(restoredBoundsIndex);
   });
 
-  it("destroys the persisted native view when the final Browser tab is removed", async () => {
-    const { api, attachments } = createRecordingBrowserApi();
-    const detach = vi.fn();
-    api.detach = detach;
-    installDesktopBrowser(api);
-    const view = renderBrowserDeck({ canShowNativeBrowserView: true });
+  it("keeps an unfocused split view hidden on a legacy desktop focus bridge", async () => {
+    const { api, attachments, visibility } = createRecordingBrowserApi();
+    const { focus: _focus, onFocus: _onFocus, ...legacyApi } = api;
+    installDesktopBrowser(legacyApi);
 
-    await waitFor(() => expect(attachments).toHaveLength(1));
-
-    view.rerender(
+    render(
       <BrowserTabDeck
-        browserTabs={[]}
-        activeBrowserTabId={null}
+        browserTabs={[makeBrowserTab("tab-url", "https://example.com")]}
+        activeBrowserTabId="tab-url"
         environmentId="env-1"
-        canShowNativeBrowserView={false}
+        canShowNativeBrowserView
+        canHandleBrowserCommands={false}
         threadId="thread-1"
         onUpdate={() => {}}
       />,
     );
 
-    await waitFor(() => expect(detach).toHaveBeenCalledWith("tab-url"));
+    await waitFor(() => expect(attachments).toHaveLength(1));
+    expect(visibility.some((request) => request.visible)).toBe(false);
+  });
+
+  it("shows an unfocused split view without moving native focus", async () => {
+    const { api, attachments, visibility, visibilityWithoutFocus } =
+      createRecordingBrowserApi();
+    installDesktopBrowser(api);
+
+    render(
+      <BrowserTabDeck
+        browserTabs={[makeBrowserTab("tab-url", "https://example.com")]}
+        activeBrowserTabId="tab-url"
+        environmentId="env-1"
+        canShowNativeBrowserView
+        canHandleBrowserCommands={false}
+        threadId="thread-1"
+        onUpdate={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(attachments).toHaveLength(1));
+    await waitFor(() =>
+      expect(visibilityWithoutFocus).toContainEqual({
+        tabId: "tab-url",
+        visible: true,
+      }),
+    );
+    expect(visibility.some((request) => request.visible)).toBe(false);
   });
 
   it("focuses the address bar when an empty browser tab requests focus", () => {

--- a/apps/app/src/components/secondary-panel/BrowserTabDeck.tsx
+++ b/apps/app/src/components/secondary-panel/BrowserTabDeck.tsx
@@ -23,8 +23,20 @@ export interface BrowserTabDeckProps {
    * for drawer animation completion plus the post-open bounds sync.
    */
   canShowNativeBrowserView: boolean;
+  /**
+   * Whether this deck owns browser keyboard commands. Split panes can keep
+   * several native views visible at once, but commands must follow pane focus.
+   * Defaults to the visibility gate for the unchanged single-pane surface.
+   */
+  canHandleBrowserCommands?: boolean;
+  onNativeFocus?: () => void;
   threadId: string;
   onUpdate: (args: UpdateBrowserTabArgs) => void;
+}
+
+export interface BrowserTabLifecycleObserverProps {
+  browserTabs: readonly BrowserFixedPanelTab[];
+  threadId: string;
 }
 
 interface BrowserTabIdSnapshot {
@@ -40,6 +52,39 @@ export function buildBrowserTabIdSet({
   browserTabs,
 }: BuildBrowserTabIdSetArgs): ReadonlySet<string> {
   return new Set(browserTabs.map((tab) => tab.id));
+}
+
+/**
+ * Owns explicit browser-tab destruction independently of whichever browser
+ * surface is currently rendered. There must be exactly one observer per
+ * thread: pane-local decks may mount and unmount as tabs move, maximize, or
+ * close, but none of those presentation changes transfers lifecycle ownership.
+ */
+export function BrowserTabLifecycleObserver({
+  browserTabs,
+  threadId,
+}: BrowserTabLifecycleObserverProps) {
+  const desktopBrowser = useMemo(() => getDesktopBrowserApi(), []);
+  const previousTabIdsRef = useRef<BrowserTabIdSnapshot | null>(null);
+
+  useEffect(() => {
+    const tabIds = buildBrowserTabIdSet({ browserTabs });
+    const previous = previousTabIdsRef.current;
+    if (
+      desktopBrowser !== null &&
+      previous !== null &&
+      previous.threadId === threadId
+    ) {
+      for (const tabId of previous.tabIds) {
+        if (!tabIds.has(tabId)) {
+          destroyPersistedBrowserView({ desktopBrowser, tabId });
+        }
+      }
+    }
+    previousTabIdsRef.current = { tabIds, threadId };
+  }, [browserTabs, desktopBrowser, threadId]);
+
+  return null;
 }
 
 /**
@@ -80,11 +125,12 @@ export function BrowserTabDeck({
   onAddressFocusRequestConsumed,
   environmentId,
   canShowNativeBrowserView,
+  canHandleBrowserCommands = canShowNativeBrowserView,
+  onNativeFocus,
   threadId,
   onUpdate,
 }: BrowserTabDeckProps) {
   const desktopBrowser = useMemo(() => getDesktopBrowserApi(), []);
-  const previousTabIdsRef = useRef<BrowserTabIdSnapshot | null>(null);
   const visibilityCoordinator = useMemo(
     () =>
       desktopBrowser === null
@@ -92,23 +138,6 @@ export function BrowserTabDeck({
         : createBrowserViewVisibilityCoordinator(desktopBrowser),
     [desktopBrowser],
   );
-
-  useEffect(() => {
-    const tabIds = buildBrowserTabIdSet({ browserTabs });
-    const previous = previousTabIdsRef.current;
-    if (
-      desktopBrowser !== null &&
-      previous !== null &&
-      previous.threadId === threadId
-    ) {
-      for (const tabId of previous.tabIds) {
-        if (!tabIds.has(tabId)) {
-          destroyPersistedBrowserView({ desktopBrowser, tabId });
-        }
-      }
-    }
-    previousTabIdsRef.current = { tabIds, threadId };
-  }, [browserTabs, desktopBrowser, threadId]);
 
   const activeBrowserTab = selectActiveBrowserTab(
     browserTabs,
@@ -131,6 +160,8 @@ export function BrowserTabDeck({
         }
         onAddressFocusRequestConsumed={onAddressFocusRequestConsumed}
         canShowNativeBrowserView={canShowNativeBrowserView}
+        canHandleBrowserCommands={canHandleBrowserCommands}
+        onNativeFocus={onNativeFocus}
         visibilityCoordinator={visibilityCoordinator}
         environmentId={environmentId}
         threadId={threadId}

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
@@ -1,6 +1,7 @@
 import {
   type CSSProperties,
   type MouseEventHandler,
+  type PointerEvent as ReactPointerEvent,
   type RefObject,
   useCallback,
   useEffect,
@@ -86,6 +87,10 @@ const INITIAL_OVERFLOW_STATE: TabStripOverflowState = {
 
 export interface SecondaryPanelTabStripProps {
   fileTabs: SecondaryPanelFileTab[];
+  onBeginTabDrag?: (
+    tabId: string,
+    event: ReactPointerEvent<HTMLElement>,
+  ) => void;
   onReorderTab: SecondaryPanelTabReorderHandler;
   usesDesktopChrome: boolean;
   /**
@@ -103,6 +108,10 @@ interface SortableFileTabProps {
   activeTabRef: RefObject<HTMLDivElement | null>;
   dragDisabled: boolean;
   noDragClass: string | null;
+  onBeginTabDrag?: (
+    tabId: string,
+    event: ReactPointerEvent<HTMLElement>,
+  ) => void;
   tab: SecondaryPanelFileTab;
 }
 
@@ -117,6 +126,7 @@ interface SortableFileTabProps {
  */
 export function SecondaryPanelTabStrip({
   fileTabs,
+  onBeginTabDrag,
   onReorderTab,
   usesDesktopChrome,
   isPanelOpen,
@@ -430,6 +440,7 @@ export function SecondaryPanelTabStrip({
               activeTabRef={activeTabRef}
               dragDisabled={dragDisabled}
               noDragClass={noDragClass}
+              onBeginTabDrag={onBeginTabDrag}
               tab={tab}
             />
           ))}
@@ -457,6 +468,7 @@ export function SecondaryPanelTabStrip({
       fileTabs,
       dragDisabled,
       noDragClass,
+      onBeginTabDrag,
       draggingTab,
       activeTreatment,
     ],
@@ -535,6 +547,7 @@ function SortableFileTab({
   activeTabRef,
   dragDisabled,
   noDragClass,
+  onBeginTabDrag,
   tab,
 }: SortableFileTabProps) {
   const { isDragging, listeners, setNodeRef, transform, transition } =
@@ -542,6 +555,8 @@ function SortableFileTab({
       id: tab.id,
       disabled: dragDisabled,
     });
+  const { onPointerDown: sortablePointerDown, ...sortableListeners } =
+    listeners ?? {};
   const setTabRef = useCallback(
     (element: HTMLDivElement | null) => {
       setNodeRef(element);
@@ -571,7 +586,11 @@ function SortableFileTab({
         isDragging && "opacity-40",
         noDragClass,
       )}
-      {...listeners}
+      onPointerDown={(event) => {
+        onBeginTabDrag?.(tab.id, event);
+        sortablePointerDown?.(event);
+      }}
+      {...sortableListeners}
     >
       <FileTab tab={tab} activeTreatment={activeTreatment} />
     </div>

--- a/apps/app/src/components/secondary-panel/SidebarSplitContainer.test.tsx
+++ b/apps/app/src/components/secondary-panel/SidebarSplitContainer.test.tsx
@@ -1,0 +1,794 @@
+// @vitest-environment jsdom
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { TooltipProvider } from "@bb/shared-ui/tooltip";
+import { useState, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SidebarProvider } from "@/components/ui/sidebar";
+import {
+  SidebarSplitContainer,
+  type SidebarSplitHeaderRenderArgs,
+  type SidebarSplitPaneRenderArgs,
+  type SidebarSplitTabDescriptor,
+} from "./SidebarSplitContainer";
+import {
+  createSidebarSplitState,
+  focusSidebarPane,
+  moveSidebarTab,
+  serializeSidebarSplitState,
+  sidebarSplitStorageKey,
+  type SidebarSplitState,
+} from "./sidebarSplitLayout";
+import { getFixedPanelTabsStateStorageKey } from "@/lib/fixed-panel-tabs-state";
+
+const TABS: readonly SidebarSplitTabDescriptor[] = [
+  { id: "tab-a", label: "A", leadingVisual: null },
+  { id: "tab-b", label: "B", leadingVisual: null },
+];
+const PANEL_STATE_ID = "sidebar-split-container-test";
+let nextPaneInstance = 0;
+
+function createTwoPaneState(): SidebarSplitState {
+  const initial = createSidebarSplitState(
+    TABS.map((tab) => tab.id),
+    "tab-a",
+  );
+  return moveSidebarTab(
+    initial,
+    initial.layout.focusedPaneId,
+    "tab-b",
+    { paneId: initial.layout.focusedPaneId, zone: "right" },
+    { groupId: "group-b" },
+  );
+}
+
+function createStackedPaneState(): SidebarSplitState {
+  const initial = createSidebarSplitState(
+    TABS.map((tab) => tab.id),
+    "tab-a",
+  );
+  return moveSidebarTab(
+    initial,
+    initial.layout.focusedPaneId,
+    "tab-b",
+    { paneId: initial.layout.focusedPaneId, zone: "bottom" },
+    { groupId: "group-b" },
+  );
+}
+
+function persistState(state: SidebarSplitState): void {
+  window.localStorage.setItem(
+    sidebarSplitStorageKey(PANEL_STATE_ID),
+    serializeSidebarSplitState(state),
+  );
+}
+
+function renderContainer({
+  activeTabId = "tab-a",
+  onActivateTab = vi.fn(),
+  renderPane,
+  renderSplitHeader,
+  tabs = TABS,
+}: {
+  activeTabId?: string;
+  onActivateTab?: (tabId: string) => void;
+  renderPane: (args: SidebarSplitPaneRenderArgs) => ReactNode;
+  renderSplitHeader?: (args: SidebarSplitHeaderRenderArgs) => ReactNode;
+  tabs?: readonly SidebarSplitTabDescriptor[];
+}) {
+  return render(
+    <SidebarProvider>
+      <TooltipProvider>
+        <SidebarSplitContainer
+          activeTabId={activeTabId}
+          onActivateTab={onActivateTab}
+          onGlobalTabReorder={vi.fn()}
+          panelStateId={PANEL_STATE_ID}
+          renderPane={renderPane}
+          renderSplitHeader={renderSplitHeader}
+          tabs={tabs}
+        />
+      </TooltipProvider>
+    </SidebarProvider>,
+  );
+}
+
+function StatefulPane({
+  onMoveActiveTabToSide,
+  paneId,
+}: {
+  onMoveActiveTabToSide: NonNullable<
+    SidebarSplitPaneRenderArgs["onMoveActiveTabToSide"]
+  >;
+  paneId: string;
+}) {
+  const [instanceId] = useState(() => `${paneId}-${nextPaneInstance++}`);
+  return (
+    <div data-testid={`pane-content-${paneId}`}>
+      <span data-testid={`pane-instance-${paneId}`}>{instanceId}</span>
+      <button type="button" onClick={() => onMoveActiveTabToSide("left")}>
+        Move {paneId} left
+      </button>
+    </div>
+  );
+}
+
+describe("SidebarSplitContainer", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    nextPaneInstance = 0;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    document.body.style.userSelect = "";
+  });
+
+  it("activates a focused pane outside React's state updater", async () => {
+    const split = createTwoPaneState();
+    const firstPaneId =
+      split.layout.root.type === "split"
+        ? split.layout.root.children[0]?.type === "pane"
+          ? split.layout.root.children[0].paneId
+          : null
+        : null;
+    const secondPaneId =
+      split.layout.root.type === "split"
+        ? split.layout.root.children[1]?.type === "pane"
+          ? split.layout.root.children[1].paneId
+          : null
+        : null;
+    expect(firstPaneId).not.toBeNull();
+    expect(secondPaneId).not.toBeNull();
+    if (firstPaneId === null || secondPaneId === null) return;
+    persistState(focusSidebarPane(split, firstPaneId));
+
+    const activate = vi.fn();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    function Harness() {
+      const [activeTabId, setActiveTabId] = useState("tab-a");
+      return (
+        <SidebarSplitContainer
+          activeTabId={activeTabId}
+          onActivateTab={(tabId) => {
+            activate(tabId);
+            setActiveTabId(tabId);
+          }}
+          onGlobalTabReorder={vi.fn()}
+          panelStateId={PANEL_STATE_ID}
+          renderPane={({ paneId }) => (
+            <div data-testid={`pane-content-${paneId}`}>{paneId}</div>
+          )}
+          tabs={TABS}
+        />
+      );
+    }
+
+    render(
+      <SidebarProvider>
+        <TooltipProvider>
+          <Harness />
+        </TooltipProvider>
+      </SidebarProvider>,
+    );
+    fireEvent.pointerDown(screen.getByTestId(`pane-content-${secondPaneId}`));
+
+    await waitFor(() => expect(activate).toHaveBeenCalledWith("tab-b"));
+    expect(activate).toHaveBeenCalledTimes(1);
+    expect(
+      consoleError.mock.calls.some((call) =>
+        call.some(
+          (value) =>
+            typeof value === "string" &&
+            value.includes("Cannot update a component while rendering"),
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it("reports both panes as visible and assigns outer controls only once", () => {
+    const split = createTwoPaneState();
+    const focusedPaneId =
+      split.layout.root.type === "split" &&
+      split.layout.root.children[0]?.type === "pane"
+        ? split.layout.root.children[0].paneId
+        : split.layout.focusedPaneId;
+    persistState(focusSidebarPane(split, focusedPaneId));
+
+    renderContainer({
+      renderPane: ({ isFocused, isVisible, paneId, showOuterControls }) => (
+        <div data-testid={`pane-state-${paneId}`}>
+          {`${isFocused}:${isVisible}:${showOuterControls}`}
+        </div>
+      ),
+    });
+
+    const paneStates = screen.getAllByTestId(/pane-state-/);
+    expect(paneStates.map((pane) => pane.textContent)).toContain(
+      "true:true:false",
+    );
+    expect(paneStates.map((pane) => pane.textContent)).toContain(
+      "false:true:true",
+    );
+  });
+
+  it.each([
+    ["left", "flex-row", "tab-a,tab-b"],
+    ["right", "flex-row", "tab-b,tab-a"],
+    ["top", "flex-col", "tab-a,tab-b"],
+    ["bottom", "flex-col", "tab-b,tab-a"],
+  ] as const)(
+    "moves the active tab to the supported %s position without dragging",
+    (side, directionClass, expectedOrder) => {
+      renderContainer({
+        renderPane: ({ group, onMoveActiveTabToSide }) => (
+          <button type="button" onClick={() => onMoveActiveTabToSide?.(side)}>
+            Move active {side}
+            <span data-testid="active-pane-tab">{group.activeTabId}</span>
+          </button>
+        ),
+      });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: `Move active ${side}tab-a` }),
+      );
+
+      const panes = Array.from(
+        document.querySelectorAll<HTMLElement>("[data-split-pane-id]"),
+      );
+      expect(panes).toHaveLength(2);
+      expect(panes[0]?.parentElement?.parentElement?.className).toContain(
+        directionClass,
+      );
+      expect(
+        panes
+          .map(
+            (pane) =>
+              pane.querySelector<HTMLElement>("[data-testid='active-pane-tab']")
+                ?.textContent,
+          )
+          .join(","),
+      ).toBe(expectedOrder);
+    },
+  );
+
+  it("positions the focused active tab even when the control is in the outer pane", () => {
+    const split = createTwoPaneState();
+    const firstPane =
+      split.layout.root.type === "split" &&
+      split.layout.root.children[0]?.type === "pane"
+        ? split.layout.root.children[0]
+        : null;
+    expect(firstPane).not.toBeNull();
+    if (firstPane === null) return;
+    persistState(focusSidebarPane(split, firstPane.paneId));
+
+    renderContainer({
+      renderPane: ({ group, onMoveActiveTabToSide, showOuterControls }) => (
+        <div>
+          <span data-testid="active-pane-tab">{group.activeTabId}</span>
+          {showOuterControls ? (
+            <button
+              type="button"
+              onClick={() => onMoveActiveTabToSide?.("bottom")}
+            >
+              Move focused bottom
+            </button>
+          ) : null}
+        </div>
+      ),
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Move focused bottom" }),
+    );
+    expect(
+      screen
+        .getAllByTestId("active-pane-tab")
+        .map((tab) => tab.textContent)
+        .join(","),
+    ).toBe("tab-b,tab-a");
+  });
+
+  it("keeps stateful pane content attached to pane identity after a move", () => {
+    const split = createTwoPaneState();
+    persistState(split);
+
+    renderContainer({
+      renderPane: ({ onMoveActiveTabToSide, paneId }) =>
+        onMoveActiveTabToSide ? (
+          <StatefulPane
+            onMoveActiveTabToSide={onMoveActiveTabToSide}
+            paneId={paneId}
+          />
+        ) : null,
+    });
+
+    const paneIds = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-split-pane-id]"),
+      (pane) => pane.dataset.splitPaneId,
+    ).filter((paneId): paneId is string => paneId !== undefined);
+    expect(paneIds).toHaveLength(2);
+    const before = new Map(
+      paneIds.map((paneId) => [
+        paneId,
+        screen.getByTestId(`pane-instance-${paneId}`).textContent,
+      ]),
+    );
+    const paneToMove = paneIds[1];
+    expect(paneToMove).toBeDefined();
+    if (paneToMove === undefined) return;
+
+    fireEvent.click(
+      screen.getByRole("button", { name: `Move ${paneToMove} left` }),
+    );
+
+    for (const paneId of paneIds) {
+      expect(screen.getByTestId(`pane-instance-${paneId}`).textContent).toBe(
+        before.get(paneId) ?? "missing-instance",
+      );
+    }
+  });
+
+  it("keeps header slots synchronized with adjacent panes throughout resizing", () => {
+    persistState(createTwoPaneState());
+    renderContainer({
+      renderPane: ({ group, paneId }) => (
+        <div data-testid={`body-label-${paneId}`}>{group.activeTabId}</div>
+      ),
+      renderSplitHeader: ({ renderTabGroups }) => (
+        <div data-testid="shared-split-header">
+          {renderTabGroups(({ group, paneId }) => (
+            <div
+              className="min-w-0 overflow-hidden"
+              data-testid={`header-label-${paneId}`}
+            >
+              {group.activeTabId}
+            </div>
+          ))}
+        </div>
+      ),
+    });
+
+    const separators = screen.getAllByRole("separator");
+    const headerSeparator = separators.find(
+      (separator) =>
+        separator.parentElement?.dataset.sidebarSplitSurface === "header",
+    );
+    const bodySeparator = separators.find(
+      (separator) =>
+        separator.parentElement?.dataset.sidebarSplitSurface === "body",
+    );
+    expect(headerSeparator).toBeInstanceOf(HTMLElement);
+    expect(bodySeparator).toBeInstanceOf(HTMLElement);
+    if (
+      !(headerSeparator instanceof HTMLElement) ||
+      !(bodySeparator instanceof HTMLElement)
+    ) {
+      return;
+    }
+    expect(headerSeparator.className).toContain("bg-border-seam-vertical/60");
+    expect(bodySeparator.className).toContain("bg-transparent");
+
+    const headerPrevious = headerSeparator.previousElementSibling;
+    const headerNext = headerSeparator.nextElementSibling;
+    const bodyPrevious = bodySeparator.previousElementSibling;
+    const bodyNext = bodySeparator.nextElementSibling;
+    const bodyHitTarget = bodySeparator.firstElementChild;
+    if (
+      !(headerPrevious instanceof HTMLElement) ||
+      !(headerNext instanceof HTMLElement) ||
+      !(bodyPrevious instanceof HTMLElement) ||
+      !(bodyNext instanceof HTMLElement) ||
+      !(bodyHitTarget instanceof HTMLElement)
+    ) {
+      throw new Error("Expected synchronized header and body resize pairs");
+    }
+    Object.defineProperty(bodyHitTarget, "setPointerCapture", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    vi.spyOn(bodyPrevious, "getBoundingClientRect").mockReturnValue({
+      bottom: 600,
+      height: 600,
+      left: 0,
+      right: 400,
+      top: 0,
+      width: 400,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+    vi.spyOn(bodyNext, "getBoundingClientRect").mockReturnValue({
+      bottom: 600,
+      height: 600,
+      left: 401,
+      right: 801,
+      top: 0,
+      width: 400,
+      x: 401,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    fireEvent.pointerDown(bodyHitTarget, { clientX: 400, pointerId: 1 });
+    fireEvent.pointerMove(bodyHitTarget, { clientX: 600, pointerId: 1 });
+
+    expect(headerPrevious.style.flex).toBe(bodyPrevious.style.flex);
+    expect(headerNext.style.flex).toBe(bodyNext.style.flex);
+    expect(Number.parseFloat(headerPrevious.style.flex)).toBeCloseTo(0.749, 3);
+    expect(Number.parseFloat(headerNext.style.flex)).toBeCloseTo(0.251, 3);
+    for (const pane of document.querySelectorAll<HTMLElement>(
+      "[data-sidebar-split-tab-slot]",
+    )) {
+      const paneId = pane.dataset.sidebarSplitTabSlot;
+      expect(pane.className).toContain("overflow-hidden");
+      expect(
+        pane.querySelector(`[data-testid='header-label-${paneId}']`)
+          ?.textContent,
+      ).toBe(
+        document.querySelector(`[data-testid='body-label-${paneId}']`)
+          ?.textContent,
+      );
+    }
+
+    fireEvent.pointerUp(bodyHitTarget, { clientX: 600, pointerId: 1 });
+    expect(headerPrevious.style.flex).toBe(bodyPrevious.style.flex);
+    expect(headerNext.style.flex).toBe(bodyNext.style.flex);
+  });
+
+  it("resizes the adjacent panes from the shared-header separator", () => {
+    persistState(createTwoPaneState());
+    renderContainer({
+      renderPane: ({ paneId }) => <div>{paneId}</div>,
+      renderSplitHeader: ({ renderTabGroups }) => (
+        <div>
+          {renderTabGroups(({ paneId }) => (
+            <div>{paneId}</div>
+          ))}
+        </div>
+      ),
+    });
+
+    const headerSeparator = screen
+      .getAllByRole("separator")
+      .find(
+        (separator) =>
+          separator.parentElement?.dataset.sidebarSplitSurface === "header",
+      );
+    if (!(headerSeparator instanceof HTMLElement)) {
+      throw new Error("Expected shared-header resize separator");
+    }
+    const hitTarget = headerSeparator.firstElementChild;
+    const headerPrevious = headerSeparator.previousElementSibling;
+    const headerNext = headerSeparator.nextElementSibling;
+    const bodyTrack = document.querySelector<HTMLElement>(
+      '[data-sidebar-split-surface="body"][data-sidebar-split-track="root"]',
+    );
+    const bodyChildren = Array.from(bodyTrack?.children ?? []).filter(
+      (child): child is HTMLElement =>
+        child instanceof HTMLElement &&
+        child.dataset.sidebarSplitChildIndex !== undefined,
+    );
+    if (
+      !(hitTarget instanceof HTMLElement) ||
+      !(headerPrevious instanceof HTMLElement) ||
+      !(headerNext instanceof HTMLElement) ||
+      bodyChildren.length !== 2
+    ) {
+      throw new Error("Expected header and body resize elements");
+    }
+    Object.defineProperty(hitTarget, "setPointerCapture", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    vi.spyOn(headerPrevious, "getBoundingClientRect").mockReturnValue({
+      bottom: 48,
+      height: 48,
+      left: 0,
+      right: 400,
+      top: 0,
+      width: 400,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+    vi.spyOn(headerNext, "getBoundingClientRect").mockReturnValue({
+      bottom: 48,
+      height: 48,
+      left: 401,
+      right: 801,
+      top: 0,
+      width: 400,
+      x: 401,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    fireEvent.pointerDown(hitTarget, { clientX: 400, pointerId: 2 });
+    fireEvent.pointerMove(hitTarget, { clientX: 250, pointerId: 2 });
+    expect(bodyChildren[0]?.style.flex).toBe(headerPrevious.style.flex);
+    expect(bodyChildren[1]?.style.flex).toBe(headerNext.style.flex);
+    fireEvent.pointerUp(hitTarget, { clientX: 600, pointerId: 99 });
+    expect(headerSeparator.dataset.dragging).toBe("true");
+    fireEvent.pointerUp(hitTarget, { clientX: 600, pointerId: 2 });
+    expect(bodyChildren[0]?.style.flex).toBe(headerPrevious.style.flex);
+    expect(bodyChildren[1]?.style.flex).toBe(headerNext.style.flex);
+    expect(Number.parseFloat(headerPrevious.style.flex)).toBeCloseTo(0.749, 3);
+    expect(Number.parseFloat(headerNext.style.flex)).toBeCloseTo(0.251, 3);
+    expect(headerSeparator.dataset.dragging).toBeUndefined();
+  });
+
+  it("does not resize or persist when a shared-header separator is pressed and released in place", () => {
+    persistState(createTwoPaneState());
+    const storageKey = sidebarSplitStorageKey(PANEL_STATE_ID);
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
+    renderContainer({
+      renderPane: ({ paneId }) => <div>{paneId}</div>,
+      renderSplitHeader: ({ renderTabGroups }) => (
+        <div>
+          {renderTabGroups(({ paneId }) => (
+            <div>{paneId}</div>
+          ))}
+        </div>
+      ),
+    });
+    const storedState = window.localStorage.getItem(storageKey);
+    setItem.mockClear();
+
+    const headerSeparator = screen
+      .getAllByRole("separator")
+      .find(
+        (separator) =>
+          separator.parentElement?.dataset.sidebarSplitSurface === "header",
+      );
+    const bodySeparator = screen
+      .getAllByRole("separator")
+      .find(
+        (separator) =>
+          separator.parentElement?.dataset.sidebarSplitSurface === "body",
+      );
+    const hitTarget = headerSeparator?.firstElementChild;
+    const headerPrevious = headerSeparator?.previousElementSibling;
+    const headerNext = headerSeparator?.nextElementSibling;
+    const bodyPrevious = bodySeparator?.previousElementSibling;
+    const bodyNext = bodySeparator?.nextElementSibling;
+    if (
+      !(headerSeparator instanceof HTMLElement) ||
+      !(hitTarget instanceof HTMLElement) ||
+      !(headerPrevious instanceof HTMLElement) ||
+      !(headerNext instanceof HTMLElement) ||
+      !(bodyPrevious instanceof HTMLElement) ||
+      !(bodyNext instanceof HTMLElement)
+    ) {
+      throw new Error("Expected synchronized header and body resize elements");
+    }
+    Object.defineProperty(hitTarget, "setPointerCapture", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    vi.spyOn(headerPrevious, "getBoundingClientRect").mockReturnValue({
+      bottom: 48,
+      height: 48,
+      left: 0,
+      right: 400,
+      top: 0,
+      width: 400,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+    vi.spyOn(headerNext, "getBoundingClientRect").mockReturnValue({
+      bottom: 48,
+      height: 48,
+      left: 401,
+      right: 801,
+      top: 0,
+      width: 400,
+      x: 401,
+      y: 0,
+      toJSON: () => ({}),
+    });
+    const initialFlex = [
+      headerPrevious.style.flex,
+      headerNext.style.flex,
+      bodyPrevious.style.flex,
+      bodyNext.style.flex,
+    ];
+
+    fireEvent.pointerDown(hitTarget, { clientX: 400, pointerId: 22 });
+    fireEvent.pointerUp(hitTarget, { clientX: 400, pointerId: 22 });
+
+    expect([
+      headerPrevious.style.flex,
+      headerNext.style.flex,
+      bodyPrevious.style.flex,
+      bodyNext.style.flex,
+    ]).toEqual(initialFlex);
+    expect(window.localStorage.getItem(storageKey)).toBe(storedState);
+    expect(
+      setItem.mock.calls.filter(([key]) => key === storageKey),
+    ).toHaveLength(0);
+    expect(headerSeparator.dataset.dragging).toBeUndefined();
+  });
+
+  it("resizes stacked panes from their shared-header separator and restores cancellation", () => {
+    persistState(createStackedPaneState());
+    renderContainer({
+      renderPane: ({ paneId }) => <div>{paneId}</div>,
+      renderSplitHeader: ({ renderTabGroups }) => (
+        <div>{renderTabGroups(({ paneId }) => <div>{paneId}</div>)}</div>
+      ),
+    });
+
+    const headerSeparator = screen
+      .getAllByRole("separator")
+      .find(
+        (separator) =>
+          separator.parentElement?.dataset.sidebarSplitSurface === "header",
+      );
+    expect(headerSeparator).toBeInstanceOf(HTMLElement);
+    expect(headerSeparator?.className).toContain(
+      "bg-border-seam-vertical/60",
+    );
+    const bodySeparator = screen.getByRole("separator", {
+      name: "Resize stacked right panel panes",
+    });
+    const hitTarget = headerSeparator?.firstElementChild;
+    const headerPrevious = headerSeparator?.previousElementSibling;
+    const headerNext = headerSeparator?.nextElementSibling;
+    const bodyPrevious = bodySeparator.previousElementSibling;
+    const bodyNext = bodySeparator.nextElementSibling;
+    if (
+      !(headerSeparator instanceof HTMLElement) ||
+      !(hitTarget instanceof HTMLElement) ||
+      !(headerPrevious instanceof HTMLElement) ||
+      !(headerNext instanceof HTMLElement) ||
+      !(bodyPrevious instanceof HTMLElement) ||
+      !(bodyNext instanceof HTMLElement)
+    ) {
+      throw new Error("Expected stacked header and body resize elements");
+    }
+    Object.defineProperty(hitTarget, "setPointerCapture", {
+      configurable: true,
+      value: vi.fn(),
+    });
+    vi.spyOn(headerPrevious, "getBoundingClientRect").mockReturnValue({
+      bottom: 48,
+      height: 48,
+      left: 0,
+      right: 400,
+      top: 0,
+      width: 400,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+    vi.spyOn(headerNext, "getBoundingClientRect").mockReturnValue({
+      bottom: 48,
+      height: 48,
+      left: 401,
+      right: 801,
+      top: 0,
+      width: 400,
+      x: 401,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    fireEvent.pointerDown(hitTarget, { clientX: 400, pointerId: 3 });
+    fireEvent.pointerMove(hitTarget, { clientX: 520, pointerId: 3 });
+    expect(headerPrevious.style.flex).toBe(bodyPrevious.style.flex);
+    expect(headerNext.style.flex).toBe(bodyNext.style.flex);
+    expect(Number.parseFloat(headerPrevious.style.flex)).toBeCloseTo(0.649, 3);
+
+    fireEvent.pointerUp(hitTarget, { clientX: 600, pointerId: 3 });
+    expect(headerPrevious.style.flex).toBe(bodyPrevious.style.flex);
+    expect(headerNext.style.flex).toBe(bodyNext.style.flex);
+    expect(Number.parseFloat(bodyPrevious.style.flex)).toBeCloseTo(0.749, 3);
+    expect(Number.parseFloat(bodyNext.style.flex)).toBeCloseTo(0.251, 3);
+
+    const committedPreviousFlex = headerPrevious.style.flex;
+    const committedNextFlex = headerNext.style.flex;
+    fireEvent.pointerDown(hitTarget, { clientX: 600, pointerId: 4 });
+    fireEvent.pointerMove(hitTarget, { clientX: 320, pointerId: 4 });
+    expect(headerPrevious.style.flex).not.toBe(committedPreviousFlex);
+    expect(bodyPrevious.style.flex).toBe(headerPrevious.style.flex);
+    fireEvent.pointerCancel(hitTarget, { clientX: 320, pointerId: 4 });
+    expect(headerPrevious.style.flex).toBe(committedPreviousFlex);
+    expect(headerNext.style.flex).toBe(committedNextFlex);
+    expect(bodyPrevious.style.flex).toBe(committedPreviousFlex);
+    expect(bodyNext.style.flex).toBe(committedNextFlex);
+  });
+
+  it("restores both adjacent flex values after pointer cancellation", () => {
+    persistState(createTwoPaneState());
+    renderContainer({
+      renderPane: ({ paneId }) => <div>{paneId}</div>,
+    });
+
+    const separator = screen.getByRole("separator");
+    expect(separator.className).toContain("bg-transparent");
+    expect(separator.className).not.toContain("bg-border-seam");
+    const hitTarget = separator.firstElementChild;
+    const previous = separator.previousElementSibling;
+    const next = separator.nextElementSibling;
+    expect(hitTarget).toBeInstanceOf(HTMLElement);
+    expect(previous).toBeInstanceOf(HTMLElement);
+    expect(next).toBeInstanceOf(HTMLElement);
+    if (
+      !(hitTarget instanceof HTMLElement) ||
+      !(previous instanceof HTMLElement) ||
+      !(next instanceof HTMLElement)
+    ) {
+      return;
+    }
+    Object.defineProperty(hitTarget, "setPointerCapture", { value: vi.fn() });
+    Object.defineProperty(previous, "getBoundingClientRect", {
+      value: () => ({ left: 0, right: 400, top: 0, bottom: 600 }),
+    });
+    Object.defineProperty(next, "getBoundingClientRect", {
+      value: () => ({ left: 401, right: 800, top: 0, bottom: 600 }),
+    });
+    const previousFlex = previous.style.flex;
+    const nextFlex = next.style.flex;
+
+    fireEvent.pointerDown(hitTarget, { clientX: 400, pointerId: 1 });
+    fireEvent.pointerMove(hitTarget, { clientX: 560, pointerId: 1 });
+    expect(previous.style.flex).not.toBe(previousFlex);
+    expect(next.style.flex).not.toBe(nextFlex);
+
+    fireEvent.pointerCancel(hitTarget, { clientX: 560, pointerId: 1 });
+    expect(previous.style.flex).toBe(previousFlex);
+    expect(next.style.flex).toBe(nextFlex);
+    expect(document.body.style.userSelect).toBe("");
+  });
+
+  it("does not write a canonical layout or rewrite a focused-pane no-op", () => {
+    const storageKey = sidebarSplitStorageKey(PANEL_STATE_ID);
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
+
+    renderContainer({
+      renderPane: ({ paneId }) => (
+        <button data-testid="only-pane" type="button">
+          {paneId}
+        </button>
+      ),
+      tabs: [TABS[0] as SidebarSplitTabDescriptor],
+    });
+
+    fireEvent.pointerDown(screen.getByTestId("only-pane"));
+    expect(
+      setItem.mock.calls.filter(([key]) => key === storageKey),
+    ).toHaveLength(0);
+    expect(window.localStorage.getItem(storageKey)).toBeNull();
+  });
+
+  it("does not rewrite an unchanged restored split", () => {
+    persistState(createTwoPaneState());
+    window.localStorage.setItem(
+      getFixedPanelTabsStateStorageKey({ threadId: PANEL_STATE_ID }),
+      JSON.stringify({ lastUsedAt: Date.now() }),
+    );
+    const storageKey = sidebarSplitStorageKey(PANEL_STATE_ID);
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
+
+    renderContainer({
+      renderPane: ({ paneId }) => <div>{paneId}</div>,
+    });
+
+    expect(
+      setItem.mock.calls.filter(([key]) => key === storageKey),
+    ).toHaveLength(0);
+  });
+});

--- a/apps/app/src/components/secondary-panel/SidebarSplitContainer.tsx
+++ b/apps/app/src/components/secondary-panel/SidebarSplitContainer.tsx
@@ -1,0 +1,906 @@
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from "react";
+import { useAtomValue } from "jotai";
+import { cn } from "@bb/shared-ui/lib/utils";
+import { beginSplitDrag, type SplitDropTarget } from "@/lib/split-drag";
+import {
+  clampSplitPairFraction,
+  computePaneRects,
+  countPanes,
+  listPanes,
+  MAX_PANES,
+  type LayoutNode,
+  type SplitPath,
+  type SplitSide,
+} from "@/lib/split-layout";
+import { dimInactiveSplitsAtom } from "@/lib/split-layout/atoms";
+import { applyResizeCursor, clearResizeCursor } from "@/lib/resizeCursor";
+import { MACOS_APP_REGION_NO_DRAG_CLASS } from "@/lib/bb-desktop";
+import {
+  PaneContext,
+  type PaneContextValue,
+} from "@/views/thread-detail/PaneContext";
+import {
+  createSidebarSplitState,
+  focusSidebarPane,
+  getSidebarGroupForPane,
+  isCanonicalSidebarSplitState,
+  moveSidebarPaneToSide,
+  moveSidebarTab,
+  parseSidebarSplitState,
+  pruneSidebarSplitStorage,
+  reconcileSidebarSplitState,
+  reorderSidebarTab,
+  resizeSidebarSplit,
+  selectSidebarTab,
+  serializeSidebarSplitState,
+  sidebarPaneGroupId,
+  sidebarSplitStorageKey,
+  type SidebarSplitState,
+  type SidebarTabGroup,
+} from "./sidebarSplitLayout";
+import type { SecondaryPanelTabReorderRequest } from "./secondaryPanelFileTab";
+
+const PANE_DRAG_ENGAGE_DISTANCE_PX = 7;
+
+export interface SidebarSplitTabDescriptor {
+  id: string;
+  label: string;
+  leadingVisual: ReactNode;
+}
+
+export interface SidebarSplitPaneRenderArgs {
+  group: SidebarTabGroup;
+  isFocused: boolean;
+  isSplitPane: boolean;
+  isVisible: boolean;
+  onBeginTabDrag: (
+    tabId: string,
+    event: ReactPointerEvent<HTMLElement>,
+  ) => void;
+  onReorderTab: (request: SecondaryPanelTabReorderRequest) => void;
+  onFocusPane: () => void;
+  onMoveActiveTabToSide?: (side: SplitSide) => void;
+  onSelectTab: (tabId: string) => void;
+  paneId: string;
+  showOuterControls: boolean;
+}
+
+export interface SidebarSplitHeaderRenderArgs {
+  panes: readonly SidebarSplitPaneRenderArgs[];
+  renderTabGroups: (
+    renderGroup: (pane: SidebarSplitPaneRenderArgs) => ReactNode,
+  ) => ReactNode;
+}
+
+interface SidebarSplitContainerProps {
+  activeTabId: string;
+  onActivateTab: (tabId: string) => void;
+  onGlobalTabReorder: (request: SecondaryPanelTabReorderRequest) => void;
+  panelStateId: string;
+  renderPane: (args: SidebarSplitPaneRenderArgs) => ReactNode;
+  renderSplitHeader?: (args: SidebarSplitHeaderRenderArgs) => ReactNode;
+  tabs: readonly SidebarSplitTabDescriptor[];
+}
+
+export function SidebarSplitContainer({
+  activeTabId,
+  onActivateTab,
+  onGlobalTabReorder,
+  panelStateId,
+  renderPane,
+  renderSplitHeader,
+  tabs,
+}: SidebarSplitContainerProps) {
+  const availableTabIds = useMemo(() => tabs.map((tab) => tab.id), [tabs]);
+  const storageKey = sidebarSplitStorageKey(panelStateId);
+  const [initialStorageValue] = useState<string | null>(() =>
+    typeof window === "undefined"
+      ? null
+      : window.localStorage.getItem(storageKey),
+  );
+  const [state, setState] = useState<SidebarSplitState>(() =>
+    typeof window === "undefined"
+      ? createSidebarSplitState(availableTabIds, activeTabId)
+      : parseSidebarSplitState(
+          initialStorageValue,
+          availableTabIds,
+          activeTabId,
+        ),
+  );
+  const stateRef = useRef(state);
+  const lastPersistedValueRef = useRef({
+    storageKey,
+    value: initialStorageValue,
+  });
+  const previousActiveTabId = useRef(activeTabId);
+  const dimsInactiveSplits = useAtomValue(dimInactiveSplitsAtom);
+  const paneCount = countPanes(state.layout.root);
+  const hasMultiplePanes = paneCount > 1;
+
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  useEffect(() => {
+    const shouldFollowExternalSelection =
+      previousActiveTabId.current !== activeTabId;
+    previousActiveTabId.current = activeTabId;
+    const current = stateRef.current;
+    const reconciled = reconcileSidebarSplitState(
+      current,
+      availableTabIds,
+      activeTabId,
+    );
+    const activePane = shouldFollowExternalSelection
+      ? listPanes(reconciled.layout.root).find((pane) =>
+          getSidebarGroupForPane(reconciled, pane.paneId)?.tabIds.includes(
+            activeTabId,
+          ),
+        )
+      : undefined;
+    const next =
+      activePane === undefined
+        ? reconciled
+        : selectSidebarTab(reconciled, activePane.paneId, activeTabId);
+    if (next !== current) {
+      stateRef.current = next;
+      setState(next);
+    }
+  }, [activeTabId, availableTabIds]);
+
+  useEffect(() => {
+    pruneSidebarSplitStorage({
+      storage: window.localStorage,
+      now: Date.now(),
+    });
+    lastPersistedValueRef.current = {
+      storageKey,
+      value: window.localStorage.getItem(storageKey),
+    };
+  }, [storageKey]);
+
+  useEffect(() => {
+    const persistedValue = isCanonicalSidebarSplitState(
+      state,
+      availableTabIds,
+      activeTabId,
+    )
+      ? null
+      : serializeSidebarSplitState(state);
+    const previous = lastPersistedValueRef.current;
+    if (
+      previous.storageKey === storageKey &&
+      previous.value === persistedValue
+    ) {
+      return;
+    }
+    if (persistedValue === null) {
+      window.localStorage.removeItem(storageKey);
+    } else {
+      window.localStorage.setItem(storageKey, persistedValue);
+    }
+    lastPersistedValueRef.current = { storageKey, value: persistedValue };
+  }, [activeTabId, availableTabIds, state, storageKey]);
+
+  const commitState = useCallback(
+    (
+      update: (current: SidebarSplitState) => SidebarSplitState,
+      activateFocusedTab = false,
+    ) => {
+      const current = stateRef.current;
+      const next = update(current);
+      if (next === current) return current;
+      stateRef.current = next;
+      setState(next);
+      if (activateFocusedTab) {
+        const focusedGroup = getSidebarGroupForPane(
+          next,
+          next.layout.focusedPaneId,
+        );
+        if (focusedGroup !== null && focusedGroup.activeTabId !== activeTabId) {
+          onActivateTab(focusedGroup.activeTabId);
+        }
+      }
+      return next;
+    },
+    [activeTabId, onActivateTab],
+  );
+
+  const selectTab = useCallback(
+    (paneId: string, tabId: string) => {
+      commitState((current) => selectSidebarTab(current, paneId, tabId));
+      if (tabId !== activeTabId) onActivateTab(tabId);
+    },
+    [activeTabId, commitState, onActivateTab],
+  );
+
+  const focusPane = useCallback(
+    (paneId: string) => {
+      commitState((current) => focusSidebarPane(current, paneId), true);
+    },
+    [commitState],
+  );
+
+  const moveActiveTabToSide = useCallback(
+    (side: SplitSide) => {
+      commitState((current) => {
+        const paneId = current.layout.focusedPaneId;
+        const sourceGroup = getSidebarGroupForPane(current, paneId);
+        if (sourceGroup === null) return current;
+        if (sourceGroup.tabIds.length > 1) {
+          if (countPanes(current.layout.root) >= MAX_PANES) return current;
+          return moveSidebarTab(
+            current,
+            paneId,
+            sourceGroup.activeTabId,
+            { paneId, zone: side },
+            { groupId: nextSidebarSplitGroupId(current) },
+          );
+        }
+        const rects = computePaneRects(current.layout.root);
+        const target = listPanes(current.layout.root)
+          .filter((pane) => pane.paneId !== paneId)
+          .sort((first, second) => {
+            const a = rects.get(first.paneId);
+            const b = rects.get(second.paneId);
+            if (a === undefined || b === undefined) return 0;
+            const edge = (rect: typeof a) => {
+              switch (side) {
+                case "left":
+                  return rect.x;
+                case "right":
+                  return -(rect.x + rect.w);
+                case "top":
+                  return rect.y;
+                case "bottom":
+                  return -(rect.y + rect.h);
+              }
+            };
+            return edge(a) - edge(b);
+          })[0];
+        return target === undefined
+          ? current
+          : moveSidebarPaneToSide(current, paneId, target.paneId, side);
+      }, true);
+    },
+    [commitState],
+  );
+
+  const moveTab = useCallback(
+    (sourcePaneId: string, tabId: string, target: SplitDropTarget) => {
+      const groupId = nextSidebarSplitGroupId(stateRef.current);
+      commitState(
+        (current) =>
+          moveSidebarTab(current, sourcePaneId, tabId, target, {
+            groupId,
+          }),
+        true,
+      );
+    },
+    [commitState],
+  );
+
+  const beginTabDrag = useCallback(
+    (
+      sourcePaneId: string,
+      tabId: string,
+      event: ReactPointerEvent<HTMLElement>,
+    ) => {
+      if (event.button !== 0) return;
+      const sourceGroup = getSidebarGroupForPane(state, sourcePaneId);
+      const sourceElement = event.currentTarget;
+      const chrome = sourceElement.closest<HTMLElement>(
+        '[data-testid="thread-secondary-panel-top-chrome"]',
+      );
+      const chromeRect = chrome?.getBoundingClientRect() ?? null;
+      const startX = event.clientX;
+      const startY = event.clientY;
+      const label = tabs.find((tab) => tab.id === tabId)?.label ?? "Panel tab";
+      beginSplitDrag(startX, startY, {
+        ghostLabel: label,
+        sourceEl: sourceElement,
+        fallback: {
+          paneId: sourcePaneId,
+          container: sourceElement.closest<HTMLElement>("aside"),
+        },
+        cancelSidebarReorderOnEngage: true,
+        shouldEngage: (x, y) => {
+          const dx = x - startX;
+          const dy = y - startY;
+          if (Math.hypot(dx, dy) <= PANE_DRAG_ENGAGE_DISTANCE_PX) return false;
+          // Horizontal motion inside the tab row remains the existing reorder
+          // gesture. Pulling the tab into pane content hands off to split drag.
+          return (
+            Math.abs(dy) > Math.abs(dx) ||
+            chromeRect === null ||
+            y < chromeRect.top ||
+            y > chromeRect.bottom
+          );
+        },
+        decide: (targetPaneId, zone) => {
+          if (targetPaneId === sourcePaneId) {
+            if (zone === "center" || (sourceGroup?.tabIds.length ?? 0) <= 1) {
+              return null;
+            }
+          }
+          if (
+            zone !== "center" &&
+            (sourceGroup?.tabIds.length ?? 0) > 1 &&
+            countPanes(state.layout.root) >= MAX_PANES
+          ) {
+            return null;
+          }
+          return {
+            zone,
+            label: zone === "center" ? "Group tab here" : `Split ${zone}`,
+          };
+        },
+        onDrop: (target) => moveTab(sourcePaneId, tabId, target),
+      });
+    },
+    [moveTab, state, tabs],
+  );
+
+  const reorderTab = useCallback(
+    (paneId: string, request: SecondaryPanelTabReorderRequest) => {
+      commitState((current) =>
+        reorderSidebarTab(
+          current,
+          paneId,
+          request.activeTabId,
+          request.overTabId,
+        ),
+      );
+      onGlobalTabReorder(request);
+    },
+    [commitState, onGlobalTabReorder],
+  );
+
+  const resize = useCallback(
+    (path: SplitPath, childIndex: number, fraction: number) => {
+      commitState((current) =>
+        resizeSidebarSplit(current, path, childIndex, fraction),
+      );
+    },
+    [commitState],
+  );
+
+  const firstPane = listPanes(state.layout.root)[0];
+  const focusedGroup = getSidebarGroupForPane(
+    state,
+    state.layout.focusedPaneId,
+  );
+  const canMoveActiveTabToSide =
+    focusedGroup !== null &&
+    (focusedGroup.tabIds.length > 1 ? paneCount < MAX_PANES : paneCount > 1);
+  const activeTabPositionHandler = canMoveActiveTabToSide
+    ? moveActiveTabToSide
+    : undefined;
+  if (!hasMultiplePanes && firstPane !== undefined) {
+    const group = getSidebarGroupForPane(state, firstPane.paneId);
+    if (group === null) return null;
+    // renderPane is a synchronous React render callback; its handlers read refs only after pointer events.
+    // eslint-disable-next-line react-hooks/refs
+    return renderPane({
+      group,
+      isFocused: true,
+      isSplitPane: false,
+      isVisible: true,
+      onBeginTabDrag: (tabId, event) =>
+        beginTabDrag(firstPane.paneId, tabId, event),
+      onReorderTab: (request) => reorderTab(firstPane.paneId, request),
+      onFocusPane: () => focusPane(firstPane.paneId),
+      onMoveActiveTabToSide: activeTabPositionHandler,
+      onSelectTab: (tabId) => selectTab(firstPane.paneId, tabId),
+      paneId: firstPane.paneId,
+      showOuterControls: true,
+    });
+  }
+
+  const splitPanes = listPanes(state.layout.root);
+  const splitPaneRenderArgs = splitPanes.flatMap((pane, index) => {
+    const group = getSidebarGroupForPane(state, pane.paneId);
+    if (group === null) return [];
+    return [
+      {
+        group,
+        isFocused: pane.paneId === state.layout.focusedPaneId,
+        isSplitPane: true,
+        isVisible: true,
+        onBeginTabDrag: (
+          tabId: string,
+          event: ReactPointerEvent<HTMLElement>,
+        ) => beginTabDrag(pane.paneId, tabId, event),
+        onReorderTab: (request: SecondaryPanelTabReorderRequest) =>
+          reorderTab(pane.paneId, request),
+        onFocusPane: () => focusPane(pane.paneId),
+        onMoveActiveTabToSide: activeTabPositionHandler,
+        onSelectTab: (tabId: string) => selectTab(pane.paneId, tabId),
+        paneId: pane.paneId,
+        showOuterControls: index === splitPanes.length - 1,
+      },
+    ];
+  });
+  const splitPaneRenderArgsById = new Map(
+    splitPaneRenderArgs.map((pane) => [pane.paneId, pane]),
+  );
+  const splitHeader = renderSplitHeader?.({
+    panes: splitPaneRenderArgs,
+    renderTabGroups: (renderGroup) => (
+      <SidebarSplitHeaderTree
+        node={state.layout.root}
+        onResize={resize}
+        paneRenderArgsById={splitPaneRenderArgsById}
+        path={[]}
+        renderGroup={renderGroup}
+      />
+    ),
+  });
+
+  return (
+    <div
+      className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
+      data-sidebar-split-container=""
+    >
+      {splitHeader}
+      <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden">
+        <SidebarSplitTree
+          node={state.layout.root}
+          path={[]}
+          isTopRow
+          isRightEdge
+          dimsInactiveSplits={dimsInactiveSplits}
+          focusedPaneId={state.layout.focusedPaneId}
+          hasSharedHeader={splitHeader !== undefined}
+          renderPane={renderPane}
+          state={state}
+          onBeginTabDrag={beginTabDrag}
+          onFocusPane={focusPane}
+          onMoveActiveTabToSide={activeTabPositionHandler}
+          onReorderTab={reorderTab}
+          onResize={resize}
+          onSelectTab={selectTab}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface SidebarSplitTreeProps {
+  dimsInactiveSplits: boolean;
+  focusedPaneId: string;
+  hasSharedHeader: boolean;
+  isRightEdge: boolean;
+  isTopRow: boolean;
+  node: LayoutNode;
+  onBeginTabDrag: (
+    paneId: string,
+    tabId: string,
+    event: ReactPointerEvent<HTMLElement>,
+  ) => void;
+  onFocusPane: (paneId: string) => void;
+  onMoveActiveTabToSide?: (side: SplitSide) => void;
+  onReorderTab: (
+    paneId: string,
+    request: SecondaryPanelTabReorderRequest,
+  ) => void;
+  onResize: (path: SplitPath, childIndex: number, fraction: number) => void;
+  onSelectTab: (paneId: string, tabId: string) => void;
+  path: number[];
+  renderPane: (args: SidebarSplitPaneRenderArgs) => ReactNode;
+  state: SidebarSplitState;
+}
+
+interface SidebarSplitHeaderTreeProps {
+  node: LayoutNode;
+  onResize: (path: SplitPath, childIndex: number, fraction: number) => void;
+  paneRenderArgsById: ReadonlyMap<string, SidebarSplitPaneRenderArgs>;
+  path: SplitPath;
+  renderGroup: (pane: SidebarSplitPaneRenderArgs) => ReactNode;
+}
+
+function SidebarSplitHeaderTree(props: SidebarSplitHeaderTreeProps) {
+  if (props.node.type === "pane") {
+    const pane = props.paneRenderArgsById.get(props.node.paneId);
+    return pane === undefined ? null : (
+      <div
+        className="flex h-full min-w-0 flex-1 overflow-hidden"
+        data-sidebar-split-tab-slot={pane.paneId}
+      >
+        {props.renderGroup(pane)}
+      </div>
+    );
+  }
+  const node = props.node;
+  const sizes = node.sizes;
+  return (
+    <div
+      className="flex h-full min-w-0 flex-1 flex-row overflow-hidden"
+      data-sidebar-split-surface="header"
+      data-sidebar-split-track={sidebarSplitPathKey(props.path)}
+    >
+      {node.children.map((child, index) => (
+        <Fragment key={sidebarSplitSubtreeKey(child)}>
+          {index > 0 ? (
+            <SidebarSplitDivider
+              appearance="tab"
+              childIndex={index - 1}
+              dir="row"
+              hidden={false}
+              path={props.path}
+              surface="header"
+              onResize={(fraction) =>
+                props.onResize(props.path, index - 1, fraction)
+              }
+            />
+          ) : null}
+          <div
+            className="flex h-full min-w-0"
+            data-sidebar-split-child-index={index}
+            style={{ flex: `${sizes[index] ?? 1} 1 0px` }}
+          >
+            <SidebarSplitHeaderTree
+              {...props}
+              node={child}
+              path={[...props.path, index]}
+            />
+          </div>
+        </Fragment>
+      ))}
+    </div>
+  );
+}
+
+function SidebarSplitTree(props: SidebarSplitTreeProps) {
+  if (props.node.type === "pane") {
+    return <SidebarSplitLeaf {...props} pane={props.node} />;
+  }
+  const node = props.node;
+  return (
+    <div
+      className={cn(
+        "flex min-h-0 min-w-0 flex-1",
+        node.dir === "row" ? "flex-row" : "flex-col",
+      )}
+      data-sidebar-split-surface="body"
+      data-sidebar-split-track={sidebarSplitPathKey(props.path)}
+    >
+      {node.children.map((child, index) => (
+        <Fragment key={sidebarSplitSubtreeKey(child)}>
+          {index > 0 ? (
+            <SidebarSplitDivider
+              appearance="pane"
+              childIndex={index - 1}
+              dir={node.dir}
+              hidden={false}
+              path={props.path}
+              surface="body"
+              onResize={(fraction) =>
+                props.onResize(props.path, index - 1, fraction)
+              }
+            />
+          ) : null}
+          <div
+            className="flex min-h-0 min-w-0"
+            data-sidebar-split-child-index={index}
+            style={{ flex: `${node.sizes[index] ?? 1} 1 0px` }}
+          >
+            <SidebarSplitTree
+              {...props}
+              node={child}
+              path={[...props.path, index]}
+              isTopRow={props.isTopRow && (node.dir === "row" || index === 0)}
+              isRightEdge={
+                props.isRightEdge &&
+                (node.dir === "col" || index === node.children.length - 1)
+              }
+            />
+          </div>
+        </Fragment>
+      ))}
+    </div>
+  );
+}
+
+function SidebarSplitLeaf(
+  props: SidebarSplitTreeProps & {
+    pane: Extract<LayoutNode, { type: "pane" }>;
+  },
+) {
+  const { pane } = props;
+  const groupId = sidebarPaneGroupId(pane);
+  const group = groupId === null ? undefined : props.state.groups[groupId];
+  if (group === undefined) return null;
+  const isFocused = pane.paneId === props.focusedPaneId;
+  const reserveOuterControl =
+    !props.hasSharedHeader && props.isTopRow && props.isRightEdge;
+  const context: PaneContextValue = {
+    paneId: pane.paneId,
+    isFocused,
+    isSplitPane: true,
+    secondaryPanelHost: null,
+    reservesWindowPanelToggle: reserveOuterControl,
+    onRequestClose: null,
+    isMaximized: false,
+    onToggleMaximize: null,
+    isBoundedPane: true,
+    isTopRow: props.isTopRow,
+    ownsWindowTopLeft: false,
+    navigateInPane: () => {},
+  };
+  return (
+    <PaneContext.Provider value={context}>
+      <div
+        onPointerDown={() => props.onFocusPane(pane.paneId)}
+        className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden"
+        data-split-pane-id={pane.paneId}
+        data-focused={isFocused ? "true" : "false"}
+      >
+        <section className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-sidebar">
+          {props.renderPane({
+            group,
+            isFocused,
+            isSplitPane: true,
+            isVisible: true,
+            onBeginTabDrag: (tabId, event) =>
+              props.onBeginTabDrag(pane.paneId, tabId, event),
+            onReorderTab: (request) => props.onReorderTab(pane.paneId, request),
+            onFocusPane: () => props.onFocusPane(pane.paneId),
+            onMoveActiveTabToSide: props.onMoveActiveTabToSide,
+            onSelectTab: (tabId) => props.onSelectTab(pane.paneId, tabId),
+            paneId: pane.paneId,
+            showOuterControls: reserveOuterControl,
+          })}
+        </section>
+        <div
+          aria-hidden
+          data-pane-focus-scrim=""
+          className={cn(
+            "pointer-events-none absolute inset-0 z-20 transition-colors",
+            isFocused || !props.dimsInactiveSplits
+              ? "bg-transparent"
+              : "bg-background/30",
+          )}
+        />
+      </div>
+    </PaneContext.Provider>
+  );
+}
+
+function SidebarSplitDivider({
+  appearance,
+  childIndex,
+  dir,
+  hidden,
+  onResize,
+  path,
+  surface,
+}: {
+  appearance: "pane" | "tab";
+  childIndex: number;
+  dir: "row" | "col";
+  hidden: boolean;
+  onResize: (fraction: number) => void;
+  path: SplitPath;
+  surface: "body" | "header";
+}) {
+  const horizontal = dir === "row";
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const hitTarget = event.currentTarget;
+      const divider = hitTarget.parentElement;
+      const previous = divider?.previousElementSibling;
+      const next = divider?.nextElementSibling;
+      if (
+        !(divider instanceof HTMLElement) ||
+        !(previous instanceof HTMLElement) ||
+        !(next instanceof HTMLElement)
+      ) {
+        return;
+      }
+      const previousRect = previous.getBoundingClientRect();
+      const nextRect = next.getBoundingClientRect();
+      const pointerId = event.pointerId;
+      const start = horizontal ? previousRect.left : previousRect.top;
+      const end = horizontal ? nextRect.right : nextRect.bottom;
+      const pointerDownPosition = horizontal ? event.clientX : event.clientY;
+      const span = end - start;
+      if (span <= 0) return;
+      const pairs = [
+        createSidebarSplitResizePair(previous, next),
+        findSidebarSplitPeerPair({
+          childIndex,
+          divider,
+          path,
+          surface,
+        }),
+      ].filter((pair): pair is SidebarSplitResizePair => pair !== null);
+      hitTarget.setPointerCapture(pointerId);
+      divider.dataset.dragging = "true";
+      applyResizeCursor(horizontal ? "horizontal" : "vertical");
+      document.body.style.userSelect = "none";
+      let pendingFraction: number | null = null;
+      let receivedPointerMove = false;
+      let finished = false;
+      const applyPointerPosition = (pointerEvent: PointerEvent) => {
+        const pointer = horizontal ? pointerEvent.clientX : pointerEvent.clientY;
+        const fraction = clampSplitPairFraction((pointer - start) / span);
+        pendingFraction = fraction;
+        for (const pair of pairs) {
+          pair.previous.style.flex = `${pair.total * fraction} 1 0px`;
+          pair.next.style.flex = `${pair.total * (1 - fraction)} 1 0px`;
+        }
+      };
+      const move = (moveEvent: PointerEvent) => {
+        if (moveEvent.pointerId !== pointerId) return;
+        receivedPointerMove = true;
+        applyPointerPosition(moveEvent);
+      };
+      const finish = (commit: boolean) => {
+        if (finished) return;
+        finished = true;
+        delete divider.dataset.dragging;
+        hitTarget.removeEventListener("pointermove", move);
+        hitTarget.removeEventListener("pointerup", onUp);
+        hitTarget.removeEventListener("pointercancel", cancel);
+        clearResizeCursor();
+        document.body.style.userSelect = "";
+        if (commit && pendingFraction !== null) {
+          onResize(pendingFraction);
+          return;
+        }
+        for (const pair of pairs) {
+          pair.previous.style.flex = pair.previousFlex;
+          pair.next.style.flex = pair.nextFlex;
+        }
+      };
+      const onUp = (upEvent: PointerEvent) => {
+        if (upEvent.pointerId !== pointerId) return;
+        const pointerUpPosition = horizontal
+          ? upEvent.clientX
+          : upEvent.clientY;
+        if (!receivedPointerMove && pointerUpPosition === pointerDownPosition) {
+          finish(false);
+          return;
+        }
+        applyPointerPosition(upEvent);
+        finish(true);
+      };
+      const cancel = (cancelEvent: PointerEvent) => {
+        if (cancelEvent.pointerId !== pointerId) return;
+        finish(false);
+      };
+      hitTarget.addEventListener("pointermove", move);
+      hitTarget.addEventListener("pointerup", onUp);
+      hitTarget.addEventListener("pointercancel", cancel);
+    },
+    [childIndex, horizontal, onResize, path, surface],
+  );
+  return (
+    <div
+      role="separator"
+      aria-label={
+        horizontal
+          ? "Resize right panel panes"
+          : "Resize stacked right panel panes"
+      }
+      aria-orientation={horizontal ? "vertical" : "horizontal"}
+      className={cn(
+        "group relative z-[25] shrink-0 transition-colors hover:bg-ring/40 data-[dragging]:bg-ring/40",
+        appearance === "tab"
+          ? ["bg-border-seam-vertical/60", MACOS_APP_REGION_NO_DRAG_CLASS]
+          : "bg-transparent",
+        hidden && "invisible pointer-events-none",
+        horizontal ? "w-px cursor-col-resize" : "h-px cursor-row-resize",
+      )}
+    >
+      <div
+        aria-hidden
+        onPointerDown={handlePointerDown}
+        className={cn(
+          "absolute z-10 touch-none bg-transparent",
+          horizontal
+            ? "-left-1.5 top-0 h-full w-3 cursor-col-resize"
+            : "left-0 -top-1.5 h-3 w-full cursor-row-resize",
+        )}
+      />
+    </div>
+  );
+}
+
+interface SidebarSplitResizePair {
+  next: HTMLElement;
+  nextFlex: string;
+  previous: HTMLElement;
+  previousFlex: string;
+  total: number;
+}
+
+function createSidebarSplitResizePair(
+  previous: HTMLElement,
+  next: HTMLElement,
+): SidebarSplitResizePair {
+  const previousGrow = Number.parseFloat(
+    window.getComputedStyle(previous).flexGrow,
+  );
+  const nextGrow = Number.parseFloat(window.getComputedStyle(next).flexGrow);
+  return {
+    next,
+    nextFlex: next.style.flex,
+    previous,
+    previousFlex: previous.style.flex,
+    total:
+      Number.isFinite(previousGrow) &&
+      Number.isFinite(nextGrow) &&
+      previousGrow + nextGrow > 0
+        ? previousGrow + nextGrow
+        : 1,
+  };
+}
+
+function findSidebarSplitPeerPair({
+  childIndex,
+  divider,
+  path,
+  surface,
+}: {
+  childIndex: number;
+  divider: HTMLElement;
+  path: SplitPath;
+  surface: "body" | "header";
+}): SidebarSplitResizePair | null {
+  const container = divider.closest<HTMLElement>(
+    "[data-sidebar-split-container]",
+  );
+  if (container === null) return null;
+  const peerSurface = surface === "body" ? "header" : "body";
+  const pathKey = sidebarSplitPathKey(path);
+  const peerTrack = Array.from(
+    container.querySelectorAll<HTMLElement>("[data-sidebar-split-track]"),
+  ).find(
+    (track) =>
+      track.dataset.sidebarSplitSurface === peerSurface &&
+      track.dataset.sidebarSplitTrack === pathKey,
+  );
+  if (peerTrack === undefined) return null;
+  const children = Array.from(peerTrack.children).filter(
+    (child): child is HTMLElement =>
+      child instanceof HTMLElement &&
+      child.dataset.sidebarSplitChildIndex !== undefined,
+  );
+  const previous = children.find(
+    (child) => child.dataset.sidebarSplitChildIndex === String(childIndex),
+  );
+  const next = children.find(
+    (child) => child.dataset.sidebarSplitChildIndex === String(childIndex + 1),
+  );
+  return previous === undefined || next === undefined
+    ? null
+    : createSidebarSplitResizePair(previous, next);
+}
+
+function nextSidebarSplitGroupId(state: SidebarSplitState): string {
+  let sequence = 1;
+  while (state.groups[`group-split-${sequence}`] !== undefined) sequence += 1;
+  return `group-split-${sequence}`;
+}
+
+function sidebarSplitSubtreeKey(node: LayoutNode): string {
+  return listPanes(node)
+    .map((pane) => `${pane.paneId}:${sidebarPaneGroupId(pane) ?? "unknown"}`)
+    .join("|");
+}
+
+function sidebarSplitPathKey(path: SplitPath): string {
+  return path.length === 0 ? "root" : path.join(".");
+}

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
@@ -4,15 +4,25 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { PanelGroup } from "react-resizable-panels";
 import { TooltipProvider } from "@bb/shared-ui/tooltip";
+import { SidebarProvider } from "@/components/ui/sidebar";
 import {
   createGitDiffFixedPanelTab,
   createThreadInfoFixedPanelTab,
   createWorkspaceFilePreviewFixedPanelTab,
 } from "@/lib/fixed-panel-tabs-state";
+import {
+  createSidebarSplitState,
+  moveSidebarTab,
+  serializeSidebarSplitState,
+  sidebarSplitStorageKey,
+} from "./sidebarSplitLayout";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { ThreadSecondaryPanel } from "./ThreadSecondaryPanel";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+});
 
 const noop = () => {};
 
@@ -99,6 +109,96 @@ describe("ThreadSecondaryPanel compact file content", () => {
     view.rerender(renderDrawer(false));
 
     expect(screen.getByLabelText("Retained file content")).toBe(fileContent);
+  });
+
+  it("renders one active compact body and restores the saved wide split", () => {
+    const { wrapper: Wrapper } = createQueryClientTestHarness();
+    const activeTab = createWorkspaceFilePreviewFixedPanelTab({
+      environmentId: "env-test",
+      projectId: "project-test",
+      tab: {
+        lineRange: null,
+        path: "src/index.ts",
+        source: { kind: "working-tree" },
+        statusLabel: null,
+      },
+    });
+    const panelStateId = "thread-compact-split";
+    const initial = createSidebarSplitState(
+      [createThreadInfoFixedPanelTab().id, activeTab.id],
+      activeTab.id,
+    );
+    const split = moveSidebarTab(
+      initial,
+      initial.layout.focusedPaneId,
+      activeTab.id,
+      { paneId: initial.layout.focusedPaneId, zone: "right" },
+      { groupId: "group-file" },
+    );
+    const storedSplit = serializeSidebarSplitState(split);
+    const storageKey = sidebarSplitStorageKey(panelStateId);
+    window.localStorage.setItem(storageKey, storedSplit);
+    const renderSplitTabContent = vi.fn(() => (
+      <input aria-label="Unexpected split body" />
+    ));
+
+    const renderPanel = (renderAsDrawer: boolean) => (
+      <Wrapper>
+        <TooltipProvider>
+          <PanelGroup direction="horizontal">
+            <ThreadSecondaryPanel
+              activeTab={activeTab}
+              canUseGitUi={false}
+              fileTabs={[
+                {
+                  id: activeTab.id,
+                  filename: "index.ts",
+                  isActive: true,
+                  leadingVisual: null,
+                  statusLabel: null,
+                  onSelect: noop,
+                  onClose: noop,
+                },
+              ]}
+              fileTabContent={<input aria-label="Compact active body" />}
+              isConversationCollapsed={false}
+              isOpen
+              metadataContent={null}
+              onClose={noop}
+              onCollapse={noop}
+              onFileTabReorder={noop}
+              onOpenNewTab={noop}
+              onPanelChange={noop}
+              onPanelFocus={noop}
+              onToggleConversationCollapse={noop}
+              renderAsDrawer={renderAsDrawer}
+              renderSplitTabContent={renderSplitTabContent}
+              splitPanelStateId={panelStateId}
+              splitTabModels={[activeTab]}
+            />
+          </PanelGroup>
+        </TooltipProvider>
+      </Wrapper>
+    );
+    const view = render(renderPanel(true));
+
+    expect(screen.getAllByLabelText("Compact active body")).toHaveLength(1);
+    expect(screen.queryByLabelText("Unexpected split body")).toBeNull();
+    expect(renderSplitTabContent).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(storageKey)).toBe(storedSplit);
+
+    view.rerender(renderPanel(false));
+
+    const restoredPanes = document.querySelectorAll("[data-split-pane-id]");
+    expect(restoredPanes).toHaveLength(2);
+    const restoredTabGroups = document.querySelectorAll(
+      "[data-sidebar-split-tab-group]",
+    );
+    expect(restoredTabGroups).toHaveLength(2);
+    expect(restoredTabGroups[0]?.textContent).toContain("Info");
+    expect(restoredTabGroups[1]?.textContent).toContain("index.ts");
+    expect(renderSplitTabContent).toHaveBeenCalledWith(activeTab);
+    expect(window.localStorage.getItem(storageKey)).toBe(storedSplit);
   });
 });
 
@@ -219,6 +319,182 @@ describe("ThreadSecondaryPanel full-screen control", () => {
     expect(control.getAttribute("aria-pressed")).toBe("true");
 
     fireEvent.click(control);
+    expect(onToggleConversationCollapse).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers every existing split position from the right-panel control and moves the active tab", () => {
+    const { wrapper: Wrapper } = createQueryClientTestHarness();
+    const onOpenNewTab = vi.fn();
+    const fileTab = createWorkspaceFilePreviewFixedPanelTab({
+      environmentId: "env-test",
+      projectId: "project-test",
+      tab: {
+        lineRange: null,
+        path: "src/index.ts",
+        source: { kind: "working-tree" },
+        statusLabel: null,
+      },
+    });
+
+    render(
+      <Wrapper>
+        <SidebarProvider>
+          <TooltipProvider>
+            <PanelGroup direction="horizontal">
+              <ThreadSecondaryPanel
+                activeTab={fileTab}
+                canUseGitUi={false}
+                fileTabs={[
+                  {
+                    id: fileTab.id,
+                    filename: "index.ts",
+                    isActive: true,
+                    leadingVisual: null,
+                    statusLabel: null,
+                    onSelect: noop,
+                    onClose: noop,
+                  },
+                ]}
+                isConversationCollapsed={false}
+                isOpen
+                metadataContent={null}
+                onClose={noop}
+                onCollapse={noop}
+                onFileTabReorder={noop}
+                onOpenNewTab={onOpenNewTab}
+                onPanelChange={noop}
+                onPanelFocus={noop}
+                onToggleConversationCollapse={noop}
+                renderAsDrawer={false}
+                renderSplitTabContent={() => null}
+                splitPanelStateId="thread-position-menu"
+                splitTabModels={[fileTab]}
+              />
+            </PanelGroup>
+          </TooltipProvider>
+        </SidebarProvider>
+      </Wrapper>,
+    );
+
+    const control = screen.getByRole("button", { name: "Full Screen" });
+    fireEvent.focus(control);
+    expect(
+      screen.getByRole("menu", { name: "Pane arrangement" }),
+    ).not.toBeNull();
+    for (const side of ["left", "right", "top", "bottom"] as const) {
+      expect(
+        screen.getByRole("menuitem", { name: `Move ${side}` }),
+      ).not.toBeNull();
+    }
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "Move right" }));
+    const panes = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-split-pane-id]"),
+    );
+    expect(panes).toHaveLength(2);
+    const tabGroups = Array.from(
+      document.querySelectorAll<HTMLElement>("[data-sidebar-split-tab-group]"),
+    );
+    expect(tabGroups).toHaveLength(2);
+    expect(tabGroups[0]?.textContent).toContain("Info");
+    expect(tabGroups[1]?.textContent).toContain("index.ts");
+    expect(
+      document.querySelectorAll(
+        '[data-testid="thread-secondary-panel-top-chrome"]',
+      ),
+    ).toHaveLength(1);
+    expect(
+      panes.some((pane) =>
+        pane.querySelector('[data-testid="thread-secondary-panel-top-chrome"]'),
+      ),
+    ).toBe(false);
+    expect(document.querySelectorAll("header")).toHaveLength(0);
+    const newTabControls = screen.getAllByRole("button", {
+      name: "Open new tab",
+    });
+    expect(newTabControls).toHaveLength(1);
+    fireEvent.click(newTabControls[0] as HTMLElement);
+    expect(onOpenNewTab).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps one conversation restore control across split tab rows", () => {
+    const { wrapper: Wrapper } = createQueryClientTestHarness();
+    const fileTab = createWorkspaceFilePreviewFixedPanelTab({
+      environmentId: "env-test",
+      projectId: "project-test",
+      tab: {
+        lineRange: null,
+        path: "src/index.ts",
+        source: { kind: "working-tree" },
+        statusLabel: null,
+      },
+    });
+    const panelStateId = "thread-fullscreen-split";
+    const initial = createSidebarSplitState(
+      [createThreadInfoFixedPanelTab().id, fileTab.id],
+      fileTab.id,
+    );
+    const split = moveSidebarTab(
+      initial,
+      initial.layout.focusedPaneId,
+      fileTab.id,
+      { paneId: initial.layout.focusedPaneId, zone: "right" },
+      { groupId: "group-file" },
+    );
+    window.localStorage.setItem(
+      sidebarSplitStorageKey(panelStateId),
+      serializeSidebarSplitState(split),
+    );
+    const onToggleConversationCollapse = vi.fn();
+
+    render(
+      <Wrapper>
+        <SidebarProvider>
+          <TooltipProvider>
+            <PanelGroup direction="horizontal">
+              <ThreadSecondaryPanel
+                activeTab={fileTab}
+                canUseGitUi={false}
+                fileTabs={[
+                  {
+                    id: fileTab.id,
+                    filename: "index.ts",
+                    isActive: true,
+                    leadingVisual: null,
+                    statusLabel: null,
+                    onSelect: noop,
+                    onClose: noop,
+                  },
+                ]}
+                isConversationCollapsed
+                isOpen
+                metadataContent={null}
+                onClose={noop}
+                onCollapse={noop}
+                onFileTabReorder={noop}
+                onOpenNewTab={noop}
+                onPanelChange={noop}
+                onPanelFocus={noop}
+                onToggleConversationCollapse={onToggleConversationCollapse}
+                renderAsDrawer={false}
+                renderSplitTabContent={() => null}
+                splitPanelStateId={panelStateId}
+                splitTabModels={[fileTab]}
+              />
+            </PanelGroup>
+          </TooltipProvider>
+        </SidebarProvider>
+      </Wrapper>,
+    );
+
+    const restoreControls = screen.getAllByRole("button", {
+      name: "Exit Full Screen",
+    });
+    expect(restoreControls).toHaveLength(1);
+    const restoreControl = restoreControls[0];
+    if (restoreControl === undefined)
+      throw new Error("Missing restore control");
+    fireEvent.click(restoreControl);
     expect(onToggleConversationCollapse).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.stories.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.stories.tsx
@@ -12,13 +12,22 @@ import {
 } from "./ThreadSecondaryPanel";
 import type { ThreadSecondaryPanel as ThreadSecondaryPanelTab } from "@/lib/thread-secondary-panel";
 import { Icon } from "@bb/shared-ui/icon";
+import { TooltipProvider } from "@bb/shared-ui/tooltip";
+import { SidebarProvider } from "@/components/ui/sidebar";
 import {
   createGitDiffFixedPanelTab,
   createTerminalFixedPanelTab,
   createThreadInfoFixedPanelTab,
   type HostFilePreviewFixedPanelTab,
+  type SecondaryFileFixedPanelTab,
   type SecondaryFixedPanelTab,
 } from "@/lib/fixed-panel-tabs-state";
+import {
+  createSidebarSplitState,
+  moveSidebarTab,
+  serializeSidebarSplitState,
+  sidebarSplitStorageKey,
+} from "./sidebarSplitLayout";
 import type { WorkspaceFile } from "@bb/server-contract";
 import { StoryCard, StoryRow } from "../../../.ladle/story-card";
 import {
@@ -473,6 +482,135 @@ function TerminalTabsShellInner({
 
 function TerminalTabsShellRow(props: TerminalTabsShellRowProps) {
   return <TerminalTabsShellInner {...props} />;
+}
+
+const SPLIT_STORY_PANEL_STATE_ID = "ladle-production-split-panes";
+const SPLIT_STORY_FILE = createStoryFileTab("ThreadSecondaryPanel.tsx");
+const SPLIT_STORY_TERMINAL = createTerminalFixedPanelTab({
+  terminalId: "term_story_running",
+});
+const SPLIT_STORY_FILE_TABS: readonly SecondaryFileFixedPanelTab[] = [
+  SPLIT_STORY_FILE,
+  SPLIT_STORY_TERMINAL,
+];
+const SPLIT_STORY_TABS: readonly SecondaryFixedPanelTab[] = [
+  createThreadInfoFixedPanelTab(),
+  createGitDiffFixedPanelTab(),
+  ...SPLIT_STORY_FILE_TABS,
+];
+
+function createSplitStoryState() {
+  let state = createSidebarSplitState(
+    SPLIT_STORY_TABS.map((tab) => tab.id),
+    createThreadInfoFixedPanelTab().id,
+  );
+  state = moveSidebarTab(
+    state,
+    "pane-primary",
+    SPLIT_STORY_FILE.id,
+    { paneId: "pane-primary", zone: "bottom" },
+    { groupId: "group-file" },
+  );
+  return moveSidebarTab(
+    state,
+    "pane-primary",
+    SPLIT_STORY_TERMINAL.id,
+    { paneId: "pane-primary", zone: "right" },
+    { groupId: "group-terminal" },
+  );
+}
+
+function ProductionSplitPanesStory() {
+  const [activeTab, setActiveTab] = useState<SecondaryFixedPanelTab>(() => {
+    window.localStorage.setItem(
+      sidebarSplitStorageKey(SPLIT_STORY_PANEL_STATE_ID),
+      serializeSidebarSplitState(createSplitStoryState()),
+    );
+    return SPLIT_STORY_TERMINAL;
+  });
+
+  const fileTabs = useMemo<SecondaryPanelFileTab[]>(
+    () =>
+      [SPLIT_STORY_FILE, SPLIT_STORY_TERMINAL].map((tab) => ({
+        id: tab.id,
+        filename:
+          tab.kind === "terminal" ? "pnpm dev" : "ThreadSecondaryPanel.tsx",
+        isActive: tab.id === activeTab.id,
+        leadingVisual: (
+          <Icon
+            name={tab.kind === "terminal" ? "Terminal" : "Code"}
+            className="size-3.5"
+            aria-hidden
+          />
+        ),
+        statusLabel: null,
+        onSelect: () => setActiveTab(tab),
+        onClose: noop,
+      })),
+    [activeTab.id],
+  );
+
+  return (
+    <TooltipProvider>
+      <SidebarProvider>
+        <PanelStage height="info">
+          <ThreadSecondaryPanel
+            activeTab={activeTab}
+            canUseGitUi
+            requestedMergeBaseBranch="main"
+            environmentId={undefined}
+            isOpen
+            metadataContent={<RepresentativeInfoContent />}
+            fileTabs={fileTabs}
+            fileTabContent={
+              activeTab.kind === "terminal" ? (
+                <RepresentativeTerminalContent title="pnpm dev" />
+              ) : (
+                representativeFileContent
+              )
+            }
+            splitPanelStateId={SPLIT_STORY_PANEL_STATE_ID}
+            splitTabModels={SPLIT_STORY_FILE_TABS}
+            renderSplitTabContent={(tab) =>
+              tab.kind === "terminal" ? (
+                <RepresentativeTerminalContent title="pnpm dev" />
+              ) : (
+                representativeFileContent
+              )
+            }
+            splitTabContentFillsRegion={(tab) => tab.kind === "terminal"}
+            showGitDiffTab
+            onPanelFocus={noop}
+            onPanelChange={(panel) =>
+              setActiveTab(createStoryFixedPanelTab(panel))
+            }
+            onCollapse={noop}
+            onClose={noop}
+            onFileTabReorder={noop}
+            onOpenNewTab={noop}
+            isConversationCollapsed={false}
+            onToggleConversationCollapse={noop}
+            renderAsDrawer={false}
+            inlinePanelToggle="hidden"
+            showConversationCollapseControl={false}
+          />
+        </PanelStage>
+      </SidebarProvider>
+    </TooltipProvider>
+  );
+}
+
+export function SplitPanes() {
+  return (
+    <StoryCard>
+      <StoryRow
+        label="production split panes"
+        hint="real right-panel tabs, pane focus, arrangement, maximize, close, and inner divider behavior"
+      >
+        <ProductionSplitPanesStory />
+      </StoryRow>
+    </StoryCard>
+  );
 }
 
 export function Overview() {

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -1,6 +1,7 @@
 import {
   type CSSProperties,
   type FocusEvent,
+  type PointerEvent as ReactPointerEvent,
   type ReactNode,
   type TransitionEvent,
   useCallback,
@@ -83,13 +84,12 @@ import {
 import { useDesktopWindowState } from "@/hooks/useDesktopWindowState";
 import { useOptionalIsSidebarShowing } from "@/components/ui/sidebar.js";
 import { IframeDragGuardOverlay } from "@/lib/iframe-drag-guard";
-import type {
-  FixedPanelViewTab,
-  SecondaryFixedPanelTab,
-} from "@/lib/fixed-panel-tabs-state";
 import {
   createGitDiffFixedPanelTab,
   createThreadInfoFixedPanelTab,
+  type FixedPanelViewTab,
+  type SecondaryFileFixedPanelTab,
+  type SecondaryFixedPanelTab,
 } from "@/lib/fixed-panel-tabs-state";
 import { type ThreadSecondaryPanel as ThreadSecondaryPanelTab } from "@/lib/thread-secondary-panel";
 import { useAppCommandShortcut } from "@/components/commands/AppCommandProvider";
@@ -98,6 +98,18 @@ import type { AppShortcutPresentation } from "@/lib/app-keybindings";
 import { TabPill } from "@/components/ui/tab-pill";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
 import { dispatchBrowserViewBoundsSync } from "@/lib/browser-view-bounds-sync";
+import type { SplitSide } from "@/lib/split-layout";
+import { PaneArrangementButton } from "@/views/thread-detail/PaneMaximizeButton";
+import {
+  SidebarSplitContainer,
+  type SidebarSplitHeaderRenderArgs,
+  type SidebarSplitPaneRenderArgs,
+  type SidebarSplitTabDescriptor,
+} from "./SidebarSplitContainer";
+import {
+  SIDEBAR_FIXED_DIFF_TAB_ID,
+  SIDEBAR_FIXED_INFO_TAB_ID,
+} from "./sidebarSplitLayout";
 import type { GitDiffTabStatus } from "./gitDiffTabEligibility";
 export type {
   GitDiffDisplayMode,
@@ -254,11 +266,26 @@ export interface ThreadSecondaryPanelProps {
    * tests with no browser tabs.
    */
   browserDeck?: ReactNode;
+  /** Builds a retained browser surface for a pane-local browser tab. */
+  browserDeckForTab?: (
+    tabId: string,
+    pane: {
+      isFocused: boolean;
+      isVisible: boolean;
+      onFocusPane: () => void;
+    },
+  ) => ReactNode;
   /**
    * Whether the active panel tab is a browser tab. When true the deck fills the
    * content region and the normal content slot is suppressed.
    */
   isBrowserTabActive?: boolean;
+  /** Stable thread/panel id enabling persisted tab tear-out splits. */
+  splitPanelStateId?: string;
+  /** Rich tab models used to render pane-local content after a split. */
+  splitTabModels?: readonly SecondaryFileFixedPanelTab[];
+  renderSplitTabContent?: (tab: SecondaryFileFixedPanelTab) => ReactNode;
+  splitTabContentFillsRegion?: (tab: SecondaryFileFixedPanelTab) => boolean;
   isOpen: boolean;
   showConversationCollapseControl?: boolean;
   /** Legacy thread-surface inputs normalized into `fixedTabs`. */
@@ -344,7 +371,12 @@ export function ThreadSecondaryPanel({
   fileTabContentFillsRegion,
   onFileTabReorder,
   browserDeck,
+  browserDeckForTab,
   isBrowserTabActive = false,
+  splitPanelStateId,
+  splitTabModels,
+  renderSplitTabContent,
+  splitTabContentFillsRegion,
   isOpen,
   showConversationCollapseControl = true,
   showGitDiffTab = true,
@@ -512,17 +544,15 @@ export function ThreadSecondaryPanel({
   const isDiffPanelActive =
     resolvedGitDiffTabStatus === "eligible" &&
     activeFixedTab?.tab.kind === "git-diff";
-  // The diff body stays mounted while the panel is closed (see the retained
-  // content note below), but its live queries must not: every workspace write
-  // invalidates the diff TOC, evicts patches, and would otherwise refetch and
-  // re-render pierre into an off-screen panel. Gate the diff-tab data on the
-  // panel actually being open; the DOM stays, the network and diff work stop.
   const isDiffPanelLive = isDiffPanelActive && isLayoutOpen;
   const isDiffEligibilityPending =
     activeFixedTab?.tab.kind === "git-diff" &&
     (resolvedGitDiffTabStatus === "loading" ||
       resolvedGitDiffTabStatus === "error");
   const showsGitDiffToolbar = isDiffPanelActive && !hasActiveFileTab;
+  const shouldShowGitDiffTab =
+    resolvedFixedTabs.some((fixedTab) => fixedTab.tab.kind === "git-diff") &&
+    showGitDiffTab !== false;
   // Keep file content mounted across every close. The compact views defer the
   // first full panel mount, then retain it inside their persistent drawer.
   // Removing only this subtree would lose terminal and plugin state and move
@@ -625,6 +655,545 @@ export function ThreadSecondaryPanel({
     onPanelFocus();
   };
 
+  interface PanelSurfaceArgs {
+    activeSurfaceTab: SecondaryFixedPanelTab | null;
+    browserSurface: ReactNode;
+    fileSurfaceContent: ReactNode;
+    fileSurfaceContentFillsRegion: boolean;
+    fileSurfaceTabs: SecondaryPanelFileTab[] | undefined;
+    isBrowserSurfaceActive: boolean;
+    onBeginTabDrag?: (
+      tabId: string,
+      event: ReactPointerEvent<HTMLElement>,
+    ) => void;
+    onSelectSurfaceTab?: (tabId: string) => void;
+    onMoveActiveTabToSide?: (side: SplitSide) => void;
+    onSurfaceFileTabReorder: SecondaryPanelTabReorderHandler;
+    showDiffSurfaceTab: boolean;
+    showInfoSurfaceTab: boolean;
+    showOuterControls: boolean;
+    showTopChrome?: boolean;
+  }
+
+  interface PanelTabGroupArgs {
+    activeSurfaceTab: SecondaryFixedPanelTab | null;
+    fileSurfaceTabs: SecondaryPanelFileTab[] | undefined;
+    onBeginTabDrag?: (
+      tabId: string,
+      event: ReactPointerEvent<HTMLElement>,
+    ) => void;
+    onSelectSurfaceTab?: (tabId: string) => void;
+    onSurfaceFileTabReorder: SecondaryPanelTabReorderHandler;
+    showDiffSurfaceTab: boolean;
+    showInfoSurfaceTab: boolean;
+    showNewTabButton: boolean;
+  }
+
+  const renderHidePanelButton = () => (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      className={cn(
+        SECONDARY_PANEL_HIDE_ICON_BUTTON_CLASS,
+        "relative",
+        usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
+      )}
+      onClick={onClose}
+      aria-label={
+        togglePanelShortcut
+          ? `${hideControl.label} (${togglePanelShortcut.label})`
+          : hideControl.label
+      }
+      aria-keyshortcuts={togglePanelShortcut?.ariaKeyshortcuts}
+    >
+      <Icon name={hideControl.iconName} />
+      <AppCommandShortcutHint
+        shortcut={togglePanelShortcut}
+        className="absolute right-full mr-1"
+      />
+    </Button>
+  );
+
+  const renderConversationCollapseButton = (
+    onMoveActiveTabToSide?: (side: SplitSide) => void,
+  ) =>
+    conversationCollapseControl ? (
+      <PaneArrangementButton
+        className={cn(
+          "shrink-0",
+          usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
+        )}
+        isFullScreen={conversationCollapseControl.isFullScreen}
+        onMoveToSide={onMoveActiveTabToSide}
+        onToggleFullScreen={conversationCollapseControl.onClick}
+      />
+    ) : null;
+
+  const renderPanelTabGroup = ({
+    activeSurfaceTab,
+    fileSurfaceTabs,
+    onBeginTabDrag,
+    onSelectSurfaceTab,
+    onSurfaceFileTabReorder,
+    showDiffSurfaceTab,
+    showInfoSurfaceTab,
+    showNewTabButton: showGroupNewTabButton,
+  }: PanelTabGroupArgs) => {
+    const activeSurfaceFileTab = fileSurfaceTabs?.find((tab) => tab.isActive);
+    const visibleSurfaceFileTabs = fileSurfaceTabs?.filter(
+      (tab) => tab.isHidden !== true,
+    );
+    const hasActiveSurfaceFileTab = activeSurfaceFileTab !== undefined;
+    const activeSurfaceFixedPanel =
+      activeSurfaceTab?.kind === "git-diff" ? "git-diff" : "thread-info";
+    const isSurfaceDiffActive = activeSurfaceFixedPanel === "git-diff";
+
+    return (
+      <>
+        {showInfoSurfaceTab ? (
+          <PinnedIconTab
+            ariaLabel="Show thread info panel"
+            isActive={
+              activeSurfaceFixedPanel === "thread-info" &&
+              !hasActiveSurfaceFileTab
+            }
+            label="Info"
+            leadingVisual={<Icon name="Info" />}
+            onClick={() => {
+              if (onSelectSurfaceTab) {
+                onSelectSurfaceTab(SIDEBAR_FIXED_INFO_TAB_ID);
+              } else {
+                onPanelChange?.("thread-info");
+              }
+            }}
+            onPointerDown={
+              onBeginTabDrag
+                ? (event) => onBeginTabDrag(SIDEBAR_FIXED_INFO_TAB_ID, event)
+                : undefined
+            }
+            title="Thread info"
+            usesDesktopChrome={usesDesktopChrome}
+            activeTreatment="fill"
+          />
+        ) : null}
+        {showDiffSurfaceTab ? (
+          <PinnedIconTab
+            ariaLabel={
+              diffShortcut
+                ? `Show diff panel (${diffShortcut.label})`
+                : "Show diff panel"
+            }
+            ariaKeyshortcuts={diffShortcut?.ariaKeyshortcuts}
+            isActive={isSurfaceDiffActive && !hasActiveSurfaceFileTab}
+            label="Diff"
+            leadingVisual={<Icon name="FileDiff" />}
+            onClick={() => {
+              if (onSelectSurfaceTab) {
+                onSelectSurfaceTab(SIDEBAR_FIXED_DIFF_TAB_ID);
+              } else {
+                onPanelChange?.("git-diff");
+              }
+            }}
+            onPointerDown={
+              onBeginTabDrag
+                ? (event) => onBeginTabDrag(SIDEBAR_FIXED_DIFF_TAB_ID, event)
+                : undefined
+            }
+            title="Diff"
+            usesDesktopChrome={usesDesktopChrome}
+            activeTreatment="fill"
+          />
+        ) : null}
+        {visibleSurfaceFileTabs && visibleSurfaceFileTabs.length > 0 ? (
+          <SecondaryPanelTabStrip
+            fileTabs={visibleSurfaceFileTabs}
+            onBeginTabDrag={onBeginTabDrag}
+            onReorderTab={onSurfaceFileTabReorder}
+            usesDesktopChrome={usesDesktopChrome}
+            isPanelOpen={isOpen}
+            activeTreatment="fill"
+          />
+        ) : null}
+        {showGroupNewTabButton ? (
+          <NewTabButton
+            onOpenNewTab={onOpenNewTab}
+            shortcut={newTabShortcut}
+            usesDesktopChrome={usesDesktopChrome}
+          />
+        ) : null}
+      </>
+    );
+  };
+
+  const renderPanelSurface = ({
+    activeSurfaceTab,
+    browserSurface,
+    fileSurfaceContent,
+    fileSurfaceContentFillsRegion,
+    fileSurfaceTabs,
+    isBrowserSurfaceActive,
+    onBeginTabDrag,
+    onMoveActiveTabToSide,
+    onSelectSurfaceTab,
+    onSurfaceFileTabReorder,
+    showDiffSurfaceTab,
+    showInfoSurfaceTab,
+    showOuterControls,
+    showTopChrome = true,
+  }: PanelSurfaceArgs) => {
+    const activeSurfaceFileTab = fileSurfaceTabs?.find((tab) => tab.isActive);
+    const hasActiveSurfaceFileTab = activeSurfaceFileTab !== undefined;
+    const activeSurfaceFixedPanel =
+      activeSurfaceTab?.kind === "git-diff" ? "git-diff" : "thread-info";
+    const isSurfaceDiffActive = activeSurfaceFixedPanel === "git-diff";
+    const showsSurfaceDiffToolbar =
+      isSurfaceDiffActive && !hasActiveSurfaceFileTab;
+    const isSurfaceTerminalActive =
+      activeSurfaceTab?.kind === "terminal" && hasActiveSurfaceFileTab;
+
+    return (
+      <>
+        <div
+          className={getSecondaryPanelChromeStackClassName(
+            showsSurfaceDiffToolbar,
+          )}
+        >
+          {showTopChrome ? (
+            <div
+              data-testid="thread-secondary-panel-top-chrome"
+              className={cn(
+                CHROME_ROW_CLASS,
+                "min-w-0 justify-between gap-2 px-4",
+                usesDesktopChrome && MACOS_WINDOW_DRAG_CLASS,
+                usesDesktopChrome && MACOS_CHROME_CONTROL_AXIS_CLASS,
+              )}
+            >
+              <div
+                className={cn(
+                  "flex min-w-0 flex-1 items-center gap-1",
+                  `transition-[padding] ${PANEL_COLLAPSE_TRANSITION_CLASS}`,
+                  showOuterControls &&
+                    collapsedPanelTrafficLightReserveClassName,
+                )}
+                role="toolbar"
+                aria-label="Right panel views"
+              >
+                {renderPanelTabGroup({
+                  activeSurfaceTab,
+                  fileSurfaceTabs,
+                  onBeginTabDrag,
+                  onSelectSurfaceTab,
+                  onSurfaceFileTabReorder,
+                  showDiffSurfaceTab,
+                  showInfoSurfaceTab,
+                  showNewTabButton,
+                })}
+              </div>
+              {showOuterControls ? (
+                <div
+                  className="flex min-w-0 shrink-0 items-center gap-1"
+                  onPointerDown={(event) => event.stopPropagation()}
+                >
+                  {renderConversationCollapseButton(onMoveActiveTabToSide)}
+                  {renderAsDrawer || inlinePanelToggle === "button" ? (
+                    renderHidePanelButton()
+                  ) : inlinePanelToggle === "reserved" ? (
+                    <div
+                      aria-hidden
+                      className={getReservedInlinePanelToggleClassName(
+                        usesDesktopChrome,
+                      )}
+                    />
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
+          {showsSurfaceDiffToolbar ? (
+            <GitDiffToolbar
+              selectionValue={gitDiffSelectValue}
+              selectionOptions={gitDiffSelectOptions}
+              onSelectionChange={onGitDiffSelectionChange}
+              isSelectorDisabled={
+                isDiffFilesLoading || gitDiffTarget === undefined
+              }
+              stats={gitDiffStats}
+              isTruncated={isGitDiffTruncated}
+              areAllFilesCollapsed={areAllCollapsed}
+              isCollapseAllDisabled={!hasFiles || isDiffFilesLoading}
+              onToggleAllCollapsed={toggleAllCollapsed}
+              displayMode={gitDiffDisplayMode}
+              onDisplayModeChange={handleGitDiffDisplayModeChange}
+              lineOverflowMode={gitDiffLineOverflowMode}
+              onLineOverflowModeChange={setGitDiffLineOverflowMode}
+            />
+          ) : null}
+        </div>
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-sidebar">
+          {browserSurface}
+          {isBrowserSurfaceActive ? null : hasActiveSurfaceFileTab ? (
+            <div
+              className={
+                isSurfaceTerminalActive || fileSurfaceContentFillsRegion
+                  ? "min-h-0 flex-1 overflow-hidden"
+                  : cn(PANEL_SCROLL_SLOT_CLASS, "pb-3")
+              }
+              data-file-preview-scroll-container={
+                isSurfaceTerminalActive || fileSurfaceContentFillsRegion
+                  ? undefined
+                  : ""
+              }
+            >
+              {fileSurfaceContent ?? (
+                <EmptyStatePanel className="mx-4 rounded-lg">
+                  No file preview content provided.
+                </EmptyStatePanel>
+              )}
+            </div>
+          ) : isSurfaceDiffActive ? (
+            <GitDiffTabContent
+              environmentId={environmentId}
+              target={gitDiffTarget}
+              isDiffPanelActive={isSurfaceDiffActive}
+              isPanelOpen={isLayoutOpen}
+              gitDiffViewOptions={gitDiffViewOptions}
+              onClearPendingGitDiffIntent={onClearPendingGitDiffIntent}
+              onOpenFileInEditor={onOpenFileInEditor}
+              onOpenFilePreview={onOpenFilePreview}
+              onSelectionAddToChat={onSelectionAddToChat}
+              pendingGitDiffScrollPath={pendingGitDiffScrollPath}
+              workspaceRootPath={workspaceRootPath}
+            />
+          ) : (
+            <ThreadInfoTabContent metadataContent={metadataContent} />
+          )}
+        </div>
+      </>
+    );
+  };
+
+  const shouldEnableSidebarSplits =
+    !renderAsDrawer &&
+    splitPanelStateId !== undefined &&
+    splitTabModels !== undefined &&
+    renderSplitTabContent !== undefined;
+  const splitTabs = shouldEnableSidebarSplits
+    ? ([
+        ...(showInfoTab
+          ? [
+              {
+                id: SIDEBAR_FIXED_INFO_TAB_ID,
+                label: "Info",
+                leadingVisual: <Icon name="Info" />,
+              },
+            ]
+          : []),
+        ...(shouldShowGitDiffTab
+          ? [
+              {
+                id: SIDEBAR_FIXED_DIFF_TAB_ID,
+                label: "Diff",
+                leadingVisual: <Icon name="FileDiff" />,
+              },
+            ]
+          : []),
+        ...(visibleFileTabs ?? []).map((tab) => ({
+          id: tab.id,
+          label: tab.filename,
+          leadingVisual: tab.leadingVisual,
+        })),
+      ] satisfies SidebarSplitTabDescriptor[])
+    : [];
+  const globalActiveTabId =
+    activeFileTab?.id ??
+    (isDiffPanelActive ? SIDEBAR_FIXED_DIFF_TAB_ID : SIDEBAR_FIXED_INFO_TAB_ID);
+  const resolveSplitPaneModel = (pane: SidebarSplitPaneRenderArgs) => {
+    const activePaneTabId = pane.group.activeTabId;
+    return activePaneTabId === SIDEBAR_FIXED_INFO_TAB_ID
+      ? createThreadInfoFixedPanelTab()
+      : activePaneTabId === SIDEBAR_FIXED_DIFF_TAB_ID
+        ? createGitDiffFixedPanelTab()
+        : (splitTabModels?.find((tab) => tab.id === activePaneTabId) ?? null);
+  };
+  const resolveSplitPaneFileTabs = (pane: SidebarSplitPaneRenderArgs) =>
+    pane.group.tabIds
+      .map((tabId) => fileTabs?.find((tab) => tab.id === tabId))
+      .filter((tab): tab is SecondaryPanelFileTab => tab !== undefined)
+      .map((tab) => ({
+        ...tab,
+        isActive: tab.id === pane.group.activeTabId,
+        onSelect: () => pane.onSelectTab(tab.id),
+      }));
+  const panelSurface = shouldEnableSidebarSplits ? (
+    <SidebarSplitContainer
+      key={splitPanelStateId}
+      activeTabId={globalActiveTabId}
+      onActivateTab={(tabId) => {
+        if (tabId === SIDEBAR_FIXED_INFO_TAB_ID) {
+          onPanelChange?.("thread-info");
+        } else if (tabId === SIDEBAR_FIXED_DIFF_TAB_ID) {
+          onPanelChange?.("git-diff");
+        } else {
+          fileTabs?.find((tab) => tab.id === tabId)?.onSelect();
+        }
+      }}
+      onGlobalTabReorder={onFileTabReorder}
+      panelStateId={splitPanelStateId}
+      tabs={splitTabs}
+      renderSplitHeader={({
+        panes,
+        renderTabGroups,
+      }: SidebarSplitHeaderRenderArgs) => {
+        const focusedPane = panes.find((pane) => pane.isFocused) ?? panes[0];
+        return (
+          <div className={getSecondaryPanelChromeStackClassName(false)}>
+            <div
+              data-testid="thread-secondary-panel-top-chrome"
+              className={cn(
+                CHROME_ROW_CLASS,
+                "relative min-w-0",
+                usesDesktopChrome && MACOS_WINDOW_DRAG_CLASS,
+                usesDesktopChrome && MACOS_CHROME_CONTROL_AXIS_CLASS,
+              )}
+            >
+              <div
+                className="absolute inset-0 flex min-w-0 overflow-hidden"
+                role="toolbar"
+                aria-label="Right panel views"
+              >
+                {renderTabGroups((pane) => {
+                  const index = panes.findIndex(
+                    (candidate) => candidate.paneId === pane.paneId,
+                  );
+                  const paneModel = resolveSplitPaneModel(pane);
+                  return (
+                    <div
+                      key={pane.paneId}
+                      className={cn(
+                        "flex h-full min-w-0 flex-1 items-center gap-1 overflow-hidden px-2",
+                        `transition-[padding] ${PANEL_COLLAPSE_TRANSITION_CLASS}`,
+                        index === 0 && [
+                          "pl-4",
+                          collapsedPanelTrafficLightReserveClassName,
+                        ],
+                        index === panes.length - 1 &&
+                          (showNewTabButton ? "pr-28" : "pr-20"),
+                      )}
+                      data-sidebar-split-tab-group={pane.paneId}
+                      role="group"
+                      aria-label={`Pane ${index + 1} tabs`}
+                      onPointerDown={pane.onFocusPane}
+                    >
+                      {renderPanelTabGroup({
+                        activeSurfaceTab: paneModel,
+                        fileSurfaceTabs: resolveSplitPaneFileTabs(pane),
+                        onBeginTabDrag: pane.onBeginTabDrag,
+                        onSelectSurfaceTab: pane.onSelectTab,
+                        onSurfaceFileTabReorder: pane.onReorderTab,
+                        showDiffSurfaceTab: pane.group.tabIds.includes(
+                          SIDEBAR_FIXED_DIFF_TAB_ID,
+                        ),
+                        showInfoSurfaceTab: pane.group.tabIds.includes(
+                          SIDEBAR_FIXED_INFO_TAB_ID,
+                        ),
+                        showNewTabButton: false,
+                      })}
+                    </div>
+                  );
+                })}
+              </div>
+              <div
+                className="absolute right-4 z-30 flex min-w-0 shrink-0 items-center gap-1 bg-sidebar pl-1"
+                onPointerDown={(event) => event.stopPropagation()}
+              >
+                {showNewTabButton ? (
+                  <NewTabButton
+                    onOpenNewTab={onOpenNewTab}
+                    shortcut={newTabShortcut}
+                    usesDesktopChrome={usesDesktopChrome}
+                  />
+                ) : null}
+                {renderConversationCollapseButton(
+                  focusedPane?.onMoveActiveTabToSide,
+                )}
+                {renderAsDrawer || inlinePanelToggle === "button" ? (
+                  renderHidePanelButton()
+                ) : inlinePanelToggle === "reserved" ? (
+                  <div
+                    aria-hidden
+                    className={getReservedInlinePanelToggleClassName(
+                      usesDesktopChrome,
+                    )}
+                  />
+                ) : null}
+              </div>
+            </div>
+          </div>
+        );
+      }}
+      renderPane={(pane: SidebarSplitPaneRenderArgs) => {
+        const activePaneTabId = pane.group.activeTabId;
+        const paneModel = resolveSplitPaneModel(pane);
+        const paneFileTabs = resolveSplitPaneFileTabs(pane);
+        const isPaneBrowserActive = paneModel?.kind === "browser";
+        const paneFileContent =
+          paneModel !== null &&
+          paneModel.kind !== "thread-info" &&
+          paneModel.kind !== "git-diff" &&
+          paneModel.kind !== "browser"
+            ? renderSplitTabContent(paneModel)
+            : undefined;
+        return renderPanelSurface({
+          activeSurfaceTab: paneModel,
+          browserSurface:
+            isPaneBrowserActive && browserDeckForTab
+              ? browserDeckForTab(activePaneTabId, {
+                  isFocused: pane.isFocused,
+                  isVisible: pane.isVisible,
+                  onFocusPane: pane.onFocusPane,
+                })
+              : null,
+          fileSurfaceContent: paneFileContent,
+          fileSurfaceContentFillsRegion:
+            paneModel !== null &&
+            paneModel.kind !== "thread-info" &&
+            paneModel.kind !== "git-diff" &&
+            splitTabContentFillsRegion !== undefined
+              ? splitTabContentFillsRegion(paneModel)
+              : false,
+          fileSurfaceTabs: paneFileTabs,
+          isBrowserSurfaceActive: isPaneBrowserActive,
+          onBeginTabDrag: pane.onBeginTabDrag,
+          onMoveActiveTabToSide: pane.onMoveActiveTabToSide,
+          onSelectSurfaceTab: pane.onSelectTab,
+          onSurfaceFileTabReorder: pane.onReorderTab,
+          showDiffSurfaceTab: pane.group.tabIds.includes(
+            SIDEBAR_FIXED_DIFF_TAB_ID,
+          ),
+          showInfoSurfaceTab: pane.group.tabIds.includes(
+            SIDEBAR_FIXED_INFO_TAB_ID,
+          ),
+          showOuterControls: !pane.isSplitPane && pane.showOuterControls,
+          showTopChrome: !pane.isSplitPane,
+        });
+      }}
+    />
+  ) : (
+    renderPanelSurface({
+      activeSurfaceTab: activeTab,
+      browserSurface: browserDeck,
+      fileSurfaceContent: fileTabContent,
+      fileSurfaceContentFillsRegion: fileTabContentFillsRegion ?? false,
+      fileSurfaceTabs: fileTabs,
+      isBrowserSurfaceActive: isBrowserTabActive,
+      onSurfaceFileTabReorder: onFileTabReorder,
+      showDiffSurfaceTab: shouldShowGitDiffTab,
+      showInfoSurfaceTab: showInfoTab,
+      showOuterControls: true,
+    })
+  );
+
   const asideMarkup = (
     <aside
       ref={panelRef}
@@ -689,254 +1258,263 @@ export function ThreadSecondaryPanel({
       )}
     >
       <IframeDragGuardOverlay active={isSecondaryPanelResizing} />
-      <div
-        className={getSecondaryPanelChromeStackClassName(
-          showsGitDiffToolbar,
-          topChromeSurface,
-        )}
-      >
-        <div
-          data-testid="thread-secondary-panel-top-chrome"
-          className={cn(
-            CHROME_ROW_CLASS,
-            "min-w-0 justify-between gap-2 px-4",
-            usesDesktopChrome && MACOS_WINDOW_DRAG_CLASS,
-            usesDesktopChrome && MACOS_CHROME_CONTROL_AXIS_CLASS,
-          )}
-        >
+      {shouldEnableSidebarSplits ? (
+        panelSurface
+      ) : (
+        <>
           <div
-            className={cn(
-              "flex min-w-0 flex-1 items-center gap-1",
-              // When this panel owns the window's top-left (conversation
-              // collapsed, on either thread surface, with the sidebar
-              // collapsed), reserve the traffic-light
-              // safe area so the leading controls clear the lights and the
-              // pinned sidebar trigger. The padding must animate on the SAME
-              // timing/easing as the panel's collapse slide
-              // (PANEL_COLLAPSE_TRANSITION_CLASS): the panel's left edge starts
-              // well right of 120px and both ease to their endpoints together,
-              // so the combined inset (panel-left + px-4 + padding) decreases
-              // monotonically to exactly 120px and never dips below it
-              // mid-animation. A faster/looser padding transition would let the
-              // panel reach the left edge before the padding fills, briefly
-              // sliding the leading controls back under the lights/trigger.
-              `transition-[padding] ${PANEL_COLLAPSE_TRANSITION_CLASS}`,
-              collapsedPanelTrafficLightReserveClassName,
+            className={getSecondaryPanelChromeStackClassName(
+              showsGitDiffToolbar,
+              topChromeSurface,
             )}
-            // A toolbar, not a tablist: the pinned Info view, Diff control, and
-            // open-view pills are toggle buttons (`aria-pressed`) rather than
-            // `role="tab"` widgets backed by tabpanels, so `role="tablist"`
-            // would be malformed. Toolbar semantics describe this compact row
-            // without claiming the unimplemented tab contract.
-            role="toolbar"
-            aria-label="Right panel views"
           >
-            {resolvedFixedTabs.map((fixedTab) => {
-              const shortcut =
-                fixedTab.tab.kind === "git-diff" ? diffShortcut : null;
-              return (
-                <PinnedIconTab
-                  key={fixedTab.tab.id}
-                  ariaLabel={
-                    shortcut
-                      ? `${fixedTab.ariaLabel} (${shortcut.label})`
-                      : fixedTab.ariaLabel
-                  }
-                  ariaKeyshortcuts={shortcut?.ariaKeyshortcuts}
-                  isActive={
-                    activeFixedTab?.tab.id === fixedTab.tab.id &&
-                    !hasActiveFileTab
-                  }
-                  label={fixedTab.label}
-                  leadingVisual={fixedTab.leadingVisual}
-                  onClick={fixedTab.onSelect}
-                  title={fixedTab.title}
-                  usesDesktopChrome={usesDesktopChrome}
-                  activeTreatment="fill"
-                />
-              );
-            })}
-            {visibleFileTabs && visibleFileTabs.length > 0 ? (
-              <SecondaryPanelTabStrip
-                fileTabs={visibleFileTabs}
-                onReorderTab={onFileTabReorder}
-                usesDesktopChrome={usesDesktopChrome}
-                isPanelOpen={isOpen}
-                activeTreatment="fill"
-              />
-            ) : null}
-            {showNewTabButton ? (
-              <NewTabButton
-                onOpenNewTab={onOpenNewTab}
-                shortcut={newTabShortcut}
-                usesDesktopChrome={usesDesktopChrome}
-              />
-            ) : null}
-          </div>
-          <div className="flex min-w-0 shrink-0 items-center gap-1">
-            {conversationCollapseControl ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
+            <div
+              data-testid="thread-secondary-panel-top-chrome"
+              className={cn(
+                CHROME_ROW_CLASS,
+                "min-w-0 justify-between gap-2 px-4",
+                usesDesktopChrome && MACOS_WINDOW_DRAG_CLASS,
+                usesDesktopChrome && MACOS_CHROME_CONTROL_AXIS_CLASS,
+              )}
+            >
+              <div
+                className={cn(
+                  "flex min-w-0 flex-1 items-center gap-1",
+                  // When this panel owns the window's top-left (conversation
+                  // collapsed, on either thread surface, with the sidebar
+                  // collapsed), reserve the traffic-light
+                  // safe area so the leading controls clear the lights and the
+                  // pinned sidebar trigger. The padding must animate on the SAME
+                  // timing/easing as the panel's collapse slide
+                  // (PANEL_COLLAPSE_TRANSITION_CLASS): the panel's left edge starts
+                  // well right of 120px and both ease to their endpoints together,
+                  // so the combined inset (panel-left + px-4 + padding) decreases
+                  // monotonically to exactly 120px and never dips below it
+                  // mid-animation. A faster/looser padding transition would let the
+                  // panel reach the left edge before the padding fills, briefly
+                  // sliding the leading controls back under the lights/trigger.
+                  `transition-[padding] ${PANEL_COLLAPSE_TRANSITION_CLASS}`,
+                  collapsedPanelTrafficLightReserveClassName,
+                )}
+                // A toolbar, not a tablist: the pinned Info view, Diff control, and
+                // open-view pills are toggle buttons (`aria-pressed`) rather than
+                // `role="tab"` widgets backed by tabpanels, so `role="tablist"`
+                // would be malformed. Toolbar semantics describe this compact row
+                // without claiming the unimplemented tab contract.
+                role="toolbar"
+                aria-label="Right panel views"
+              >
+                {resolvedFixedTabs.map((fixedTab) => {
+                  const shortcut =
+                    fixedTab.tab.kind === "git-diff" ? diffShortcut : null;
+                  return (
+                    <PinnedIconTab
+                      key={fixedTab.tab.id}
+                      ariaLabel={
+                        shortcut
+                          ? `${fixedTab.ariaLabel} (${shortcut.label})`
+                          : fixedTab.ariaLabel
+                      }
+                      ariaKeyshortcuts={shortcut?.ariaKeyshortcuts}
+                      isActive={
+                        activeFixedTab?.tab.id === fixedTab.tab.id &&
+                        !hasActiveFileTab
+                      }
+                      label={fixedTab.label}
+                      leadingVisual={fixedTab.leadingVisual}
+                      onClick={fixedTab.onSelect}
+                      title={fixedTab.title}
+                      usesDesktopChrome={usesDesktopChrome}
+                      activeTreatment="fill"
+                    />
+                  );
+                })}
+                {visibleFileTabs && visibleFileTabs.length > 0 ? (
+                  <SecondaryPanelTabStrip
+                    fileTabs={visibleFileTabs}
+                    onReorderTab={onFileTabReorder}
+                    usesDesktopChrome={usesDesktopChrome}
+                    isPanelOpen={isOpen}
+                    activeTreatment="fill"
+                  />
+                ) : null}
+                {showNewTabButton ? (
+                  <NewTabButton
+                    onOpenNewTab={onOpenNewTab}
+                    shortcut={newTabShortcut}
+                    usesDesktopChrome={usesDesktopChrome}
+                  />
+                ) : null}
+              </div>
+              <div className="flex min-w-0 shrink-0 items-center gap-1">
+                {conversationCollapseControl ? (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className={cn(
+                          HEADER_PANE_ACTION_ICON_BUTTON_CLASS,
+                          CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS,
+                          "shrink-0",
+                          usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
+                        )}
+                        onClick={conversationCollapseControl.onClick}
+                        aria-label={conversationCollapseControl.label}
+                        aria-pressed={conversationCollapseControl.isFullScreen}
+                      >
+                        <Icon name={conversationCollapseControl.iconName} />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {conversationCollapseControl.label}
+                    </TooltipContent>
+                  </Tooltip>
+                ) : null}
+                {renderAsDrawer || inlinePanelToggle === "button" ? (
                   <Button
                     type="button"
                     variant="ghost"
                     size="icon"
                     className={cn(
-                      HEADER_PANE_ACTION_ICON_BUTTON_CLASS,
-                      CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS,
-                      "shrink-0",
+                      SECONDARY_PANEL_HIDE_ICON_BUTTON_CLASS,
+                      "relative",
                       usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
                     )}
-                    onClick={conversationCollapseControl.onClick}
-                    aria-label={conversationCollapseControl.label}
-                    aria-pressed={conversationCollapseControl.isFullScreen}
+                    onClick={onClose}
+                    aria-label={
+                      togglePanelShortcut
+                        ? `${hideControl.label} (${togglePanelShortcut.label})`
+                        : hideControl.label
+                    }
+                    aria-keyshortcuts={togglePanelShortcut?.ariaKeyshortcuts}
                   >
-                    <Icon name={conversationCollapseControl.iconName} />
+                    <Icon name={hideControl.iconName} />
+                    <AppCommandShortcutHint
+                      shortcut={togglePanelShortcut}
+                      className="absolute right-full mr-1"
+                    />
                   </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {conversationCollapseControl.label}
-                </TooltipContent>
-              </Tooltip>
-            ) : null}
-            {renderAsDrawer || inlinePanelToggle === "button" ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                className={cn(
-                  SECONDARY_PANEL_HIDE_ICON_BUTTON_CLASS,
-                  "relative",
-                  usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
-                )}
-                onClick={onClose}
-                aria-label={
-                  togglePanelShortcut
-                    ? `${hideControl.label} (${togglePanelShortcut.label})`
-                    : hideControl.label
+                ) : inlinePanelToggle === "reserved" ? (
+                  // A toggle pinned outside the panel owns show/hide on this surface
+                  // (root compose's fixed overlay); reserve this slot's footprint so
+                  // the tab strip stays clear and the pinned toggle lands over it.
+                  // Under macOS desktop chrome the slot must carve itself out of the
+                  // window-drag chrome row so the pinned toggle stays clickable; see
+                  // getReservedInlinePanelToggleClassName.
+                  <div
+                    aria-hidden
+                    className={getReservedInlinePanelToggleClassName(
+                      usesDesktopChrome,
+                    )}
+                  />
+                ) : null}
+              </div>
+            </div>
+            {showsGitDiffToolbar ? (
+              <GitDiffToolbar
+                selectionValue={gitDiffSelectValue}
+                selectionOptions={gitDiffSelectOptions}
+                onSelectionChange={onGitDiffSelectionChange}
+                isSelectorDisabled={
+                  isDiffFilesLoading || gitDiffTarget === undefined
                 }
-                aria-keyshortcuts={togglePanelShortcut?.ariaKeyshortcuts}
-              >
-                <Icon name={hideControl.iconName} />
-                <AppCommandShortcutHint
-                  shortcut={togglePanelShortcut}
-                  className="absolute right-full mr-1"
-                />
-              </Button>
-            ) : inlinePanelToggle === "reserved" ? (
-              // A toggle pinned outside the panel owns show/hide on this surface
-              // (root compose's fixed overlay); reserve this slot's footprint so
-              // the tab strip stays clear and the pinned toggle lands over it.
-              // Under macOS desktop chrome the slot must carve itself out of the
-              // window-drag chrome row so the pinned toggle stays clickable; see
-              // getReservedInlinePanelToggleClassName.
-              <div
-                aria-hidden
-                className={getReservedInlinePanelToggleClassName(
-                  usesDesktopChrome,
-                )}
+                stats={gitDiffStats}
+                isTruncated={isGitDiffTruncated}
+                areAllFilesCollapsed={areAllCollapsed}
+                isCollapseAllDisabled={!hasFiles || isDiffFilesLoading}
+                onToggleAllCollapsed={toggleAllCollapsed}
+                displayMode={gitDiffDisplayMode}
+                onDisplayModeChange={handleGitDiffDisplayModeChange}
+                lineOverflowMode={gitDiffLineOverflowMode}
+                onLineOverflowModeChange={setGitDiffLineOverflowMode}
               />
             ) : null}
           </div>
-        </div>
-        {showsGitDiffToolbar ? (
-          <GitDiffToolbar
-            selectionValue={gitDiffSelectValue}
-            selectionOptions={gitDiffSelectOptions}
-            onSelectionChange={onGitDiffSelectionChange}
-            isSelectorDisabled={
-              isDiffFilesLoading || gitDiffTarget === undefined
-            }
-            stats={gitDiffStats}
-            isTruncated={isGitDiffTruncated}
-            areAllFilesCollapsed={areAllCollapsed}
-            isCollapseAllDisabled={!hasFiles || isDiffFilesLoading}
-            onToggleAllCollapsed={toggleAllCollapsed}
-            displayMode={gitDiffDisplayMode}
-            onDisplayModeChange={handleGitDiffDisplayModeChange}
-            lineOverflowMode={gitDiffLineOverflowMode}
-            onLineOverflowModeChange={setGitDiffLineOverflowMode}
-          />
-        ) : null}
-      </div>
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-sidebar">
-        {/*
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-sidebar">
+            {/*
           The browser deck owns native-view visibility/retention and renders
           content only when a browser tab is active. The normal content slot is
           suppressed in that case because the deck fills the region.
         */}
-        {browserDeck}
-        {isBrowserTabActive ? null : hasActiveFileTab ? (
-          <div
-            className={
-              isTerminalTabActive || fileTabContentFillsRegion
-                ? "min-h-0 flex-1 overflow-hidden"
-                : cn(PANEL_SCROLL_SLOT_CLASS, "pb-3")
-            }
-            data-file-preview-scroll-container={
-              isTerminalTabActive || fileTabContentFillsRegion ? undefined : ""
-            }
-          >
-            {fileTabContent ?? (
-              <EmptyStatePanel className="mx-4 rounded-lg">
-                No file preview content provided.
+            {browserDeck}
+            {isBrowserTabActive ? null : hasActiveFileTab ? (
+              <div
+                className={
+                  isTerminalTabActive || fileTabContentFillsRegion
+                    ? "min-h-0 flex-1 overflow-hidden"
+                    : cn(PANEL_SCROLL_SLOT_CLASS, "pb-3")
+                }
+                data-file-preview-scroll-container={
+                  isTerminalTabActive || fileTabContentFillsRegion
+                    ? undefined
+                    : ""
+                }
+              >
+                {fileTabContent ?? (
+                  <EmptyStatePanel className="mx-4 rounded-lg">
+                    No file preview content provided.
+                  </EmptyStatePanel>
+                )}
+              </div>
+            ) : activeFixedTab !== undefined &&
+              fixedTabContent !== undefined ? (
+              <div
+                className={
+                  fixedTabContentFillsRegion
+                    ? "flex min-h-0 flex-1 flex-col overflow-hidden"
+                    : cn(PANEL_SCROLL_SLOT_CLASS, "p-4 pb-3")
+                }
+              >
+                {fixedTabContent}
+              </div>
+            ) : isDiffEligibilityPending ? (
+              <EmptyStatePanel className="m-4 rounded-lg" role="status">
+                {resolvedGitDiffTabStatus === "error" ? (
+                  <div className="flex flex-col items-center gap-3 text-center">
+                    <span>
+                      Could not determine whether this workspace uses Git.
+                    </span>
+                    {onRetryGitDiffEligibility ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={onRetryGitDiffEligibility}
+                      >
+                        Retry
+                      </Button>
+                    ) : null}
+                  </div>
+                ) : (
+                  "Checking Git support…"
+                )}
+              </EmptyStatePanel>
+            ) : isDiffPanelActive ? (
+              <GitDiffTabContent
+                environmentId={environmentId}
+                target={gitDiffTarget}
+                isDiffPanelActive={isDiffPanelActive}
+                isPanelOpen={isLayoutOpen}
+                gitDiffViewOptions={gitDiffViewOptions}
+                onClearPendingGitDiffIntent={onClearPendingGitDiffIntent}
+                onOpenFileInEditor={onOpenFileInEditor}
+                onOpenFilePreview={onOpenFilePreview}
+                onSelectionAddToChat={onSelectionAddToChat}
+                pendingGitDiffScrollPath={pendingGitDiffScrollPath}
+                workspaceRootPath={workspaceRootPath}
+              />
+            ) : activeFixedTab?.tab.kind === "thread-info" ? (
+              <ThreadInfoTabContent metadataContent={metadataContent} />
+            ) : (
+              <EmptyStatePanel className="m-4 rounded-lg">
+                This panel view is unavailable.
               </EmptyStatePanel>
             )}
           </div>
-        ) : activeFixedTab !== undefined && fixedTabContent !== undefined ? (
-          <div
-            className={
-              fixedTabContentFillsRegion
-                ? "flex min-h-0 flex-1 flex-col overflow-hidden"
-                : cn(PANEL_SCROLL_SLOT_CLASS, "p-4 pb-3")
-            }
-          >
-            {fixedTabContent}
-          </div>
-        ) : isDiffEligibilityPending ? (
-          <EmptyStatePanel className="m-4 rounded-lg" role="status">
-            {resolvedGitDiffTabStatus === "error" ? (
-              <div className="flex flex-col items-center gap-3 text-center">
-                <span>
-                  Could not determine whether this workspace uses Git.
-                </span>
-                {onRetryGitDiffEligibility ? (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={onRetryGitDiffEligibility}
-                  >
-                    Retry
-                  </Button>
-                ) : null}
-              </div>
-            ) : (
-              "Checking Git support…"
-            )}
-          </EmptyStatePanel>
-        ) : isDiffPanelActive ? (
-          <GitDiffTabContent
-            environmentId={environmentId}
-            target={gitDiffTarget}
-            isDiffPanelActive={isDiffPanelActive}
-            isPanelOpen={isLayoutOpen}
-            gitDiffViewOptions={gitDiffViewOptions}
-            onClearPendingGitDiffIntent={onClearPendingGitDiffIntent}
-            onOpenFileInEditor={onOpenFileInEditor}
-            onOpenFilePreview={onOpenFilePreview}
-            onSelectionAddToChat={onSelectionAddToChat}
-            pendingGitDiffScrollPath={pendingGitDiffScrollPath}
-            workspaceRootPath={workspaceRootPath}
-          />
-        ) : activeFixedTab?.tab.kind === "thread-info" ? (
-          <ThreadInfoTabContent metadataContent={metadataContent} />
-        ) : (
-          <EmptyStatePanel className="m-4 rounded-lg">
-            This panel view is unavailable.
-          </EmptyStatePanel>
-        )}
-      </div>
+        </>
+      )}
     </aside>
   );
 
@@ -1012,6 +1590,7 @@ interface PinnedIconTabProps {
   label: string;
   leadingVisual: ReactNode;
   onClick: () => void;
+  onPointerDown?: (event: ReactPointerEvent<HTMLElement>) => void;
   title: string;
   usesDesktopChrome: boolean;
 }
@@ -1024,6 +1603,7 @@ function PinnedIconTab({
   label,
   leadingVisual,
   onClick,
+  onPointerDown,
   title,
   usesDesktopChrome,
 }: PinnedIconTabProps) {
@@ -1036,6 +1616,7 @@ function PinnedIconTab({
             "shrink-0",
             usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS,
           )}
+          onPointerDown={onPointerDown}
         >
           <TabPill
             label={label}

--- a/apps/app/src/components/secondary-panel/browserViewVisibilityCoordinator.ts
+++ b/apps/app/src/components/secondary-panel/browserViewVisibilityCoordinator.ts
@@ -20,7 +20,11 @@ export interface BrowserViewVisibilityCoordinator {
    * appears at stale/zero bounds). `BrowserTabContent` calls this only after the
    * hidden attach has been issued, making this the first-show path too.
    */
-  show(tabId: string, syncBounds: () => void): void;
+  show(
+    tabId: string,
+    syncBounds: () => void,
+    options?: { focus?: boolean },
+  ): void;
   /** Hide `tabId`'s view (no-op overlay-wise if it was already hidden). */
   hide(tabId: string): void;
   /**
@@ -66,13 +70,21 @@ export function createBrowserViewVisibilityCoordinator(
   // The browser tab whose native view is currently shown, or null when none is.
   let visibleTabId: string | null = null;
   return {
-    show(tabId, syncBounds) {
+    show(tabId, syncBounds, options) {
       if (visibleTabId !== null && visibleTabId !== tabId) {
         desktopBrowser.setVisible({ tabId: visibleTabId, visible: false });
       }
       visibleTabId = tabId;
       syncBounds();
-      desktopBrowser.setVisible({ tabId, visible: true });
+      const request = { tabId, visible: true };
+      if (
+        options?.focus === false &&
+        desktopBrowser.setVisibleWithoutFocus !== undefined
+      ) {
+        desktopBrowser.setVisibleWithoutFocus(request);
+      } else {
+        desktopBrowser.setVisible(request);
+      }
     },
     hide(tabId) {
       if (visibleTabId === tabId) {

--- a/apps/app/src/components/secondary-panel/sidebarSplitLayout.test.ts
+++ b/apps/app/src/components/secondary-panel/sidebarSplitLayout.test.ts
@@ -1,0 +1,535 @@
+import { describe, expect, it } from "vitest";
+import { MAX_PANES, countPanes, listPanes } from "@/lib/split-layout";
+import {
+  FIXED_PANEL_TABS_IDLE_EXPIRY_MS,
+  createGitDiffFixedPanelTab,
+  createThreadInfoFixedPanelTab,
+  getFixedPanelTabsStateStorageKey,
+} from "@/lib/fixed-panel-tabs-state";
+import {
+  SIDEBAR_FIXED_DIFF_TAB_ID,
+  SIDEBAR_FIXED_INFO_TAB_ID,
+  closeSidebarPane,
+  createSidebarSplitState,
+  focusSidebarPane,
+  getSidebarGroupForPane,
+  isCanonicalSidebarSplitState,
+  moveSidebarPaneToSide,
+  moveSidebarTab,
+  parseSidebarSplitState,
+  pruneSidebarSplitStorage,
+  reconcileSidebarSplitState,
+  reorderSidebarTab,
+  resizeSidebarSplit,
+  selectSidebarTab,
+  serializeSidebarSplitState,
+  swapSidebarPanes,
+  toggleSidebarPaneMaximize,
+  sidebarPaneNode,
+  sidebarSplitStorageKey,
+  type SidebarSplitState,
+  type SidebarSplitStorage,
+} from "./sidebarSplitLayout";
+
+const TABS = [SIDEBAR_FIXED_INFO_TAB_ID, SIDEBAR_FIXED_DIFF_TAB_ID, "file-a"];
+
+function createMemoryStorage(
+  initialEntries: Record<string, string>,
+): SidebarSplitStorage & { has(key: string): boolean } {
+  const entries = new Map(Object.entries(initialEntries));
+  return {
+    get length() {
+      return entries.size;
+    },
+    getItem: (key) => entries.get(key) ?? null,
+    has: (key) => entries.has(key),
+    key: (index) => [...entries.keys()][index] ?? null,
+    removeItem: (key) => {
+      entries.delete(key);
+    },
+  };
+}
+
+function persistedStateWithPaneCount(count: number): SidebarSplitState {
+  const groups = Object.fromEntries(
+    Array.from({ length: count }, (_, index) => {
+      const groupId = `group-${index}`;
+      const tabId = `tab-${index}`;
+      return [groupId, { id: groupId, tabIds: [tabId], activeTabId: tabId }];
+    }),
+  );
+  return {
+    version: 1,
+    groups,
+    layout: {
+      root: {
+        type: "split",
+        dir: "row",
+        sizes: Array.from({ length: count }, () => 1 / count),
+        children: Array.from({ length: count }, (_, index) =>
+          sidebarPaneNode(`pane-${index}`, `group-${index}`),
+        ),
+      },
+      focusedPaneId: "pane-0",
+    },
+    maximizedPaneId: null,
+  };
+}
+
+function splitOff(
+  state: ReturnType<typeof createSidebarSplitState>,
+  tabId: string,
+  side: "left" | "right" | "top" | "bottom" = "right",
+) {
+  return moveSidebarTab(
+    state,
+    state.layout.focusedPaneId,
+    tabId,
+    { paneId: state.layout.focusedPaneId, zone: side },
+    { groupId: `group-${tabId}` },
+  );
+}
+
+describe("sidebar split layout", () => {
+  it("derives fixed sidebar identities from the canonical fixed-panel tabs", () => {
+    expect(SIDEBAR_FIXED_INFO_TAB_ID).toBe(createThreadInfoFixedPanelTab().id);
+    expect(SIDEBAR_FIXED_DIFF_TAB_ID).toBe(createGitDiffFixedPanelTab().id);
+  });
+
+  it("defaults old or invalid persisted state to the unchanged single pane", () => {
+    const state = parseSidebarSplitState(
+      JSON.stringify({ version: 0 }),
+      TABS,
+      SIDEBAR_FIXED_INFO_TAB_ID,
+    );
+    expect(countPanes(state.layout.root)).toBe(1);
+    expect(
+      getSidebarGroupForPane(state, state.layout.focusedPaneId)?.tabIds,
+    ).toEqual(TABS);
+  });
+
+  it("continues to parse the current raw v1 state without an envelope", () => {
+    const split = splitOff(
+      createSidebarSplitState(TABS, SIDEBAR_FIXED_INFO_TAB_ID),
+      "file-a",
+    );
+    const parsed = parseSidebarSplitState(
+      JSON.stringify(split),
+      TABS,
+      SIDEBAR_FIXED_INFO_TAB_ID,
+    );
+    expect(parsed).toEqual(split);
+  });
+
+  it("preserves state identity for no-op reconciliation, selection, and focus", () => {
+    const state = createSidebarSplitState(TABS, SIDEBAR_FIXED_INFO_TAB_ID);
+    expect(
+      reconcileSidebarSplitState(state, TABS, SIDEBAR_FIXED_INFO_TAB_ID),
+    ).toBe(state);
+    expect(
+      selectSidebarTab(
+        state,
+        state.layout.focusedPaneId,
+        SIDEBAR_FIXED_INFO_TAB_ID,
+      ),
+    ).toBe(state);
+    expect(focusSidebarPane(state, state.layout.focusedPaneId)).toBe(state);
+  });
+
+  it("recognizes only the exact reconstructible unsplit default", () => {
+    const canonical = createSidebarSplitState(TABS, SIDEBAR_FIXED_INFO_TAB_ID);
+    expect(
+      isCanonicalSidebarSplitState(canonical, TABS, SIDEBAR_FIXED_INFO_TAB_ID),
+    ).toBe(true);
+
+    const differentIdentity = createSidebarSplitState(
+      TABS,
+      SIDEBAR_FIXED_INFO_TAB_ID,
+      { groupId: "group-restored", paneId: "pane-restored" },
+    );
+    expect(
+      isCanonicalSidebarSplitState(
+        differentIdentity,
+        TABS,
+        SIDEBAR_FIXED_INFO_TAB_ID,
+      ),
+    ).toBe(false);
+
+    const reordered = createSidebarSplitState(
+      [...TABS].reverse(),
+      SIDEBAR_FIXED_INFO_TAB_ID,
+    );
+    expect(
+      isCanonicalSidebarSplitState(reordered, TABS, SIDEBAR_FIXED_INFO_TAB_ID),
+    ).toBe(false);
+  });
+
+  it("prunes split records with the fixed-tab cache's 14-day retention", () => {
+    const now = 50 * 24 * 60 * 60 * 1000;
+    const freshThreadId = "thread-fresh";
+    const boundaryThreadId = "thread-boundary";
+    const expiredThreadId = "thread-expired";
+    const missingThreadId = "thread-missing";
+    const freshSplitKey = sidebarSplitStorageKey(freshThreadId);
+    const boundarySplitKey = sidebarSplitStorageKey(boundaryThreadId);
+    const expiredSplitKey = sidebarSplitStorageKey(expiredThreadId);
+    const missingSplitKey = sidebarSplitStorageKey(missingThreadId);
+    const storage = createMemoryStorage({
+      [freshSplitKey]: "fresh-layout",
+      [boundarySplitKey]: "boundary-layout",
+      [expiredSplitKey]: "expired-layout",
+      [missingSplitKey]: "orphaned-layout",
+      [getFixedPanelTabsStateStorageKey({ threadId: freshThreadId })]:
+        JSON.stringify({ lastUsedAt: now - 1_000 }),
+      [getFixedPanelTabsStateStorageKey({ threadId: boundaryThreadId })]:
+        JSON.stringify({
+          lastUsedAt: now - FIXED_PANEL_TABS_IDLE_EXPIRY_MS,
+        }),
+      [getFixedPanelTabsStateStorageKey({ threadId: expiredThreadId })]:
+        JSON.stringify({
+          lastUsedAt: now - FIXED_PANEL_TABS_IDLE_EXPIRY_MS - 1,
+        }),
+      unrelated: "keep-me",
+    });
+
+    pruneSidebarSplitStorage({ storage, now });
+
+    expect(storage.has(freshSplitKey)).toBe(true);
+    expect(storage.has(boundarySplitKey)).toBe(true);
+    expect(storage.has(expiredSplitKey)).toBe(false);
+    expect(storage.has(missingSplitKey)).toBe(false);
+    expect(storage.has("unrelated")).toBe(true);
+  });
+
+  it("rejects persisted layouts that exceed the shared pane cap", () => {
+    const oversized = persistedStateWithPaneCount(MAX_PANES + 1);
+    const availableTabIds = Array.from(
+      { length: MAX_PANES + 1 },
+      (_, index) => `tab-${index}`,
+    );
+    const parsed = parseSidebarSplitState(
+      JSON.stringify(oversized),
+      availableTabIds,
+      "tab-0",
+    );
+    expect(isCanonicalSidebarSplitState(parsed, availableTabIds, "tab-0")).toBe(
+      true,
+    );
+  });
+
+  it.each([
+    {
+      name: "duplicate pane ids",
+      mutate: (state: SidebarSplitState) => {
+        if (state.layout.root.type === "split") {
+          const second = state.layout.root.children[1];
+          if (second?.type === "pane") second.paneId = "pane-0";
+        }
+      },
+    },
+    {
+      name: "duplicate group references",
+      mutate: (state: SidebarSplitState) => {
+        if (state.layout.root.type === "split") {
+          state.layout.root.children[1] = sidebarPaneNode("pane-1", "group-0");
+        }
+      },
+    },
+    {
+      name: "a stale focused pane",
+      mutate: (state: SidebarSplitState) => {
+        state.layout.focusedPaneId = "pane-missing";
+      },
+    },
+    {
+      name: "a mismatched group key and id",
+      mutate: (state: SidebarSplitState) => {
+        const group = state.groups["group-0"];
+        if (group !== undefined) group.id = "group-renamed";
+      },
+    },
+    {
+      name: "an orphan group",
+      mutate: (state: SidebarSplitState) => {
+        state.groups.orphan = {
+          id: "orphan",
+          tabIds: ["orphan-tab"],
+          activeTabId: "orphan-tab",
+        };
+      },
+    },
+    {
+      name: "non-normalized split sizes",
+      mutate: (state: SidebarSplitState) => {
+        if (state.layout.root.type === "split") {
+          state.layout.root.sizes = [0.75, 0.75];
+        }
+      },
+    },
+  ])("falls back safely for $name", ({ mutate }) => {
+    const malformed = persistedStateWithPaneCount(2);
+    mutate(malformed);
+    const availableTabIds = ["tab-0", "tab-1"];
+    const parsed = parseSidebarSplitState(
+      JSON.stringify(malformed),
+      availableTabIds,
+      "tab-0",
+    );
+    expect(isCanonicalSidebarSplitState(parsed, availableTabIds, "tab-0")).toBe(
+      true,
+    );
+  });
+
+  it("round-trips a split and reconciles newly opened tabs into the focused pane", () => {
+    const split = splitOff(
+      createSidebarSplitState(TABS, SIDEBAR_FIXED_INFO_TAB_ID),
+      "file-a",
+    );
+    const restored = parseSidebarSplitState(
+      serializeSidebarSplitState(split),
+      [...TABS, "terminal-a"],
+      "terminal-a",
+    );
+    expect(countPanes(restored.layout.root)).toBe(2);
+    expect(
+      getSidebarGroupForPane(restored, restored.layout.focusedPaneId)?.tabIds,
+    ).toContain("terminal-a");
+  });
+
+  it("preserves browser, terminal, and plugin tab ownership across persistence and recombination", () => {
+    const liveTabIds = [
+      SIDEBAR_FIXED_INFO_TAB_ID,
+      "browser:docs:env-a",
+      "terminal:term-a:none",
+      "plugin-panel:side-chat:thread-a",
+    ];
+    let state = splitOff(
+      createSidebarSplitState(liveTabIds, liveTabIds[1] ?? ""),
+      liveTabIds[1] ?? "",
+      "bottom",
+    );
+    const browserPaneId = state.layout.focusedPaneId;
+    const sourcePane = listPanes(state.layout.root).find(
+      (pane) => pane.paneId !== browserPaneId,
+    );
+    expect(sourcePane).toBeDefined();
+    if (sourcePane === undefined) return;
+    state = moveSidebarTab(
+      state,
+      sourcePane.paneId,
+      liveTabIds[2] ?? "",
+      { paneId: browserPaneId, zone: "right" },
+      { groupId: "group-terminal" },
+    );
+
+    const restored = parseSidebarSplitState(
+      serializeSidebarSplitState(state),
+      liveTabIds,
+      liveTabIds[2] ?? "",
+    );
+    let recombined = restored;
+    while (countPanes(recombined.layout.root) > 1) {
+      const closingPane = listPanes(recombined.layout.root).at(-1);
+      if (closingPane === undefined) break;
+      recombined = closeSidebarPane(recombined, closingPane.paneId);
+    }
+    const survivor = getSidebarGroupForPane(
+      recombined,
+      recombined.layout.focusedPaneId,
+    );
+    expect(new Set(survivor?.tabIds)).toEqual(new Set(liveTabIds));
+    expect(survivor?.tabIds).toHaveLength(liveTabIds.length);
+  });
+
+  it("keeps fixed tabs singleton while removing closed tabs", () => {
+    const split = splitOff(
+      createSidebarSplitState(TABS, SIDEBAR_FIXED_INFO_TAB_ID),
+      SIDEBAR_FIXED_DIFF_TAB_ID,
+    );
+    const duplicate = {
+      ...split,
+      groups: Object.fromEntries(
+        Object.entries(split.groups).map(([id, group]) => [
+          id,
+          { ...group, tabIds: [...group.tabIds, SIDEBAR_FIXED_INFO_TAB_ID] },
+        ]),
+      ),
+    };
+    const reconciled = reconcileSidebarSplitState(
+      duplicate,
+      [SIDEBAR_FIXED_INFO_TAB_ID, SIDEBAR_FIXED_DIFF_TAB_ID],
+      SIDEBAR_FIXED_INFO_TAB_ID,
+    );
+    const allIds = listPanes(reconciled.layout.root).flatMap(
+      (pane) => getSidebarGroupForPane(reconciled, pane.paneId)?.tabIds ?? [],
+    );
+    expect(
+      allIds.filter((id) => id === SIDEBAR_FIXED_INFO_TAB_ID),
+    ).toHaveLength(1);
+    expect(allIds).not.toContain("file-a");
+    const activeTabId = getSidebarGroupForPane(
+      reconciled,
+      reconciled.layout.focusedPaneId,
+    )?.activeTabId;
+    expect(allIds).toContain(activeTabId);
+  });
+
+  it("repairs the surviving active tab after a stale focused pane is pruned", () => {
+    const split = splitOff(
+      createSidebarSplitState(TABS, SIDEBAR_FIXED_INFO_TAB_ID),
+      "file-a",
+    );
+    const reconciled = reconcileSidebarSplitState(
+      split,
+      [SIDEBAR_FIXED_INFO_TAB_ID, SIDEBAR_FIXED_DIFF_TAB_ID],
+      SIDEBAR_FIXED_INFO_TAB_ID,
+    );
+    const survivor = getSidebarGroupForPane(
+      reconciled,
+      reconciled.layout.focusedPaneId,
+    );
+    expect(countPanes(reconciled.layout.root)).toBe(1);
+    expect(survivor?.activeTabId).toBe(SIDEBAR_FIXED_INFO_TAB_ID);
+  });
+
+  it("moves one tab, groups on center, and preserves pane-local reorder", () => {
+    let state = splitOff(
+      createSidebarSplitState([...TABS, "file-b"], SIDEBAR_FIXED_INFO_TAB_ID),
+      "file-b",
+    );
+    const destinationPaneId = state.layout.focusedPaneId;
+    const sourcePaneId = listPanes(state.layout.root).find(
+      (pane) => pane.paneId !== destinationPaneId,
+    )?.paneId;
+    expect(sourcePaneId).toBeDefined();
+    if (sourcePaneId === undefined) return;
+    state = moveSidebarTab(
+      state,
+      sourcePaneId,
+      "file-a",
+      { paneId: destinationPaneId, zone: "center" },
+      { groupId: "unused" },
+    );
+    state = reorderSidebarTab(state, destinationPaneId, "file-a", "file-b");
+    expect(getSidebarGroupForPane(state, destinationPaneId)?.tabIds).toEqual([
+      "file-a",
+      "file-b",
+    ]);
+  });
+
+  it("does not overwrite a restored group when a split id collides", () => {
+    const state = splitOff(
+      createSidebarSplitState([...TABS, "file-b"], SIDEBAR_FIXED_INFO_TAB_ID),
+      "file-a",
+    );
+    const sourcePane = listPanes(state.layout.root).find((pane) =>
+      getSidebarGroupForPane(state, pane.paneId)?.tabIds.includes("file-b"),
+    );
+    expect(sourcePane).toBeDefined();
+    if (sourcePane === undefined) return;
+    const collided = moveSidebarTab(
+      state,
+      sourcePane.paneId,
+      "file-b",
+      { paneId: sourcePane.paneId, zone: "bottom" },
+      { groupId: "group-file-a" },
+    );
+    expect(collided).toBe(state);
+  });
+
+  it("recombines a focused closed pane deterministically without losing tabs", () => {
+    let state = splitOff(
+      createSidebarSplitState(TABS, SIDEBAR_FIXED_INFO_TAB_ID),
+      "file-a",
+    );
+    const closingPaneId = state.layout.focusedPaneId;
+    state = selectSidebarTab(state, closingPaneId, "file-a");
+    const closed = closeSidebarPane(state, closingPaneId);
+    const survivor = getSidebarGroupForPane(
+      closed,
+      closed.layout.focusedPaneId,
+    );
+    expect(countPanes(closed.layout.root)).toBe(1);
+    expect(survivor?.tabIds).toEqual([
+      SIDEBAR_FIXED_INFO_TAB_ID,
+      SIDEBAR_FIXED_DIFF_TAB_ID,
+      "file-a",
+    ]);
+    expect(survivor?.activeTabId).toBe("file-a");
+  });
+
+  it("moves, swaps, and maximizes panes through the shared split operations", () => {
+    const split = splitOff(
+      createSidebarSplitState(TABS, SIDEBAR_FIXED_INFO_TAB_ID),
+      "file-a",
+    );
+    const panes = listPanes(split.layout.root);
+    const sourcePaneId = panes[0]?.paneId;
+    const targetPaneId = panes[1]?.paneId;
+    expect(sourcePaneId).toBeDefined();
+    expect(targetPaneId).toBeDefined();
+    if (sourcePaneId === undefined || targetPaneId === undefined) return;
+
+    const moved = moveSidebarPaneToSide(
+      split,
+      sourcePaneId,
+      targetPaneId,
+      "top",
+    );
+    expect(moved.layout.root.type).toBe("split");
+    if (moved.layout.root.type !== "split") return;
+    expect(moved.layout.root.dir).toBe("col");
+
+    const sourceTabsBeforeSwap = getSidebarGroupForPane(
+      moved,
+      sourcePaneId,
+    )?.tabIds;
+    const targetTabsBeforeSwap = getSidebarGroupForPane(
+      moved,
+      targetPaneId,
+    )?.tabIds;
+    const swapped = swapSidebarPanes(moved, sourcePaneId, targetPaneId);
+    expect(getSidebarGroupForPane(swapped, sourcePaneId)?.tabIds).toEqual(
+      targetTabsBeforeSwap,
+    );
+    expect(getSidebarGroupForPane(swapped, targetPaneId)?.tabIds).toEqual(
+      sourceTabsBeforeSwap,
+    );
+
+    const maximized = toggleSidebarPaneMaximize(swapped, targetPaneId);
+    expect(maximized.maximizedPaneId).toBe(targetPaneId);
+    expect(
+      toggleSidebarPaneMaximize(maximized, targetPaneId).maximizedPaneId,
+    ).toBe(null);
+  });
+
+  it("uses the existing split cap and clamps divider fractions", () => {
+    let state = createSidebarSplitState(
+      Array.from({ length: MAX_PANES + 1 }, (_, index) => `tab-${index}`),
+      "tab-0",
+    );
+    for (let index = 1; index <= MAX_PANES; index += 1) {
+      const sourcePane = listPanes(state.layout.root).find((pane) =>
+        getSidebarGroupForPane(state, pane.paneId)?.tabIds.includes(
+          `tab-${index}`,
+        ),
+      );
+      if (sourcePane === undefined) continue;
+      state = moveSidebarTab(
+        state,
+        sourcePane.paneId,
+        `tab-${index}`,
+        { paneId: state.layout.focusedPaneId, zone: "bottom" },
+        { groupId: `group-${index}` },
+      );
+    }
+    expect(countPanes(state.layout.root)).toBe(MAX_PANES);
+    const resized = resizeSidebarSplit(state, [], 0, 0.01);
+    if (resized.layout.root.type !== "split") throw new Error("expected split");
+    const pairTotal =
+      (resized.layout.root.sizes[0] ?? 0) + (resized.layout.root.sizes[1] ?? 0);
+    expect(
+      (resized.layout.root.sizes[0] ?? 0) / pairTotal,
+    ).toBeGreaterThanOrEqual(0.15);
+  });
+});

--- a/apps/app/src/components/secondary-panel/sidebarSplitLayout.ts
+++ b/apps/app/src/components/secondary-panel/sidebarSplitLayout.ts
@@ -1,0 +1,807 @@
+import { z } from "zod";
+import {
+  MAX_PANES,
+  countPanes,
+  findPane,
+  listPanes,
+  movePane,
+  removePane,
+  resizeSplit,
+  setFocus,
+  splitPane,
+  swapPanes,
+  type LayoutNode,
+  type PaneContent,
+  type PaneNode,
+  type SplitLayout,
+  type SplitPath,
+  type SplitSide,
+} from "@/lib/split-layout";
+import type { SplitDropTarget } from "@/lib/split-drag";
+import {
+  FIXED_PANEL_TABS_IDLE_EXPIRY_MS,
+  createGitDiffFixedPanelTab,
+  createThreadInfoFixedPanelTab,
+  getFixedPanelTabsStateStorageKey,
+} from "@/lib/fixed-panel-tabs-state";
+
+export const SIDEBAR_SPLIT_LAYOUT_STORAGE_VERSION = 1;
+export const SIDEBAR_SPLIT_LAYOUT_STORAGE_PREFIX =
+  "bb.thread.secondaryPanelSplitLayout";
+export const SIDEBAR_FIXED_INFO_TAB_ID = createThreadInfoFixedPanelTab().id;
+export const SIDEBAR_FIXED_DIFF_TAB_ID = createGitDiffFixedPanelTab().id;
+
+const SIDEBAR_SPLIT_PLUGIN_ID = "bb-secondary-panel-split";
+const NORMALIZED_SPLIT_SIZE_EPSILON = 1e-9;
+
+export interface SidebarSplitStorage {
+  readonly length: number;
+  getItem(key: string): string | null;
+  key(index: number): string | null;
+  removeItem(key: string): void;
+}
+
+export interface SidebarTabGroup {
+  id: string;
+  tabIds: string[];
+  activeTabId: string;
+}
+
+export interface SidebarSplitState {
+  version: typeof SIDEBAR_SPLIT_LAYOUT_STORAGE_VERSION;
+  groups: Record<string, SidebarTabGroup>;
+  layout: SplitLayout;
+  maximizedPaneId: string | null;
+}
+
+export interface SidebarSplitIds {
+  groupId: string;
+  paneId: string;
+}
+
+function groupContent(groupId: string): PaneContent {
+  return {
+    kind: "plugin-panel",
+    pluginId: SIDEBAR_SPLIT_PLUGIN_ID,
+    panelPath: groupId,
+    subPath: "",
+  };
+}
+
+export function sidebarPaneNode(paneId: string, groupId: string): PaneNode {
+  return { type: "pane", paneId, content: groupContent(groupId) };
+}
+
+export function sidebarPaneGroupId(pane: PaneNode): string | null {
+  return pane.content.kind === "plugin-panel" &&
+    pane.content.pluginId === SIDEBAR_SPLIT_PLUGIN_ID
+    ? pane.content.panelPath
+    : null;
+}
+
+export function createSidebarSplitState(
+  tabIds: readonly string[],
+  activeTabId: string,
+  ids: SidebarSplitIds = { groupId: "group-primary", paneId: "pane-primary" },
+): SidebarSplitState {
+  const normalizedTabs = [...new Set(tabIds)];
+  const resolvedActive = normalizedTabs.includes(activeTabId)
+    ? activeTabId
+    : (normalizedTabs[0] ?? SIDEBAR_FIXED_INFO_TAB_ID);
+  return {
+    version: SIDEBAR_SPLIT_LAYOUT_STORAGE_VERSION,
+    groups: {
+      [ids.groupId]: {
+        id: ids.groupId,
+        tabIds: normalizedTabs,
+        activeTabId: resolvedActive,
+      },
+    },
+    layout: {
+      root: sidebarPaneNode(ids.paneId, ids.groupId),
+      focusedPaneId: ids.paneId,
+    },
+    maximizedPaneId: null,
+  };
+}
+
+function areStringArraysEqual(
+  first: readonly string[],
+  second: readonly string[],
+): boolean {
+  return (
+    first.length === second.length &&
+    first.every((value, index) => value === second[index])
+  );
+}
+
+function areLayoutNodesEqual(first: LayoutNode, second: LayoutNode): boolean {
+  if (first.type !== second.type) return false;
+  if (first.type === "pane" || second.type === "pane") {
+    return (
+      first.type === "pane" &&
+      second.type === "pane" &&
+      first.paneId === second.paneId &&
+      sidebarPaneGroupId(first) === sidebarPaneGroupId(second)
+    );
+  }
+  return (
+    first.dir === second.dir &&
+    first.sizes.length === second.sizes.length &&
+    first.sizes.every((size, index) => size === second.sizes[index]) &&
+    first.children.length === second.children.length &&
+    first.children.every((child, index) => {
+      const otherChild = second.children[index];
+      return otherChild !== undefined && areLayoutNodesEqual(child, otherChild);
+    })
+  );
+}
+
+function areSidebarSplitStatesEqual(
+  first: SidebarSplitState,
+  second: SidebarSplitState,
+): boolean {
+  const firstGroupIds = Object.keys(first.groups);
+  const secondGroupIds = Object.keys(second.groups);
+  if (
+    first.version !== second.version ||
+    first.layout.focusedPaneId !== second.layout.focusedPaneId ||
+    first.maximizedPaneId !== second.maximizedPaneId ||
+    !areStringArraysEqual(firstGroupIds, secondGroupIds) ||
+    !areLayoutNodesEqual(first.layout.root, second.layout.root)
+  ) {
+    return false;
+  }
+  return firstGroupIds.every((groupId) => {
+    const firstGroup = first.groups[groupId];
+    const secondGroup = second.groups[groupId];
+    return (
+      firstGroup !== undefined &&
+      secondGroup !== undefined &&
+      firstGroup.id === secondGroup.id &&
+      firstGroup.activeTabId === secondGroup.activeTabId &&
+      areStringArraysEqual(firstGroup.tabIds, secondGroup.tabIds)
+    );
+  });
+}
+
+function preserveSidebarSplitStateIdentity(
+  current: SidebarSplitState,
+  next: SidebarSplitState,
+): SidebarSplitState {
+  return areSidebarSplitStatesEqual(current, next) ? current : next;
+}
+
+/**
+ * True only for the exact state reconstructed when no sidebar split has ever
+ * been made. Single-pane states produced by recombination may carry a distinct
+ * tab order or identity and therefore remain persistence-worthy.
+ */
+export function isCanonicalSidebarSplitState(
+  state: SidebarSplitState,
+  availableTabIds: readonly string[],
+  activeTabId: string,
+): boolean {
+  return areSidebarSplitStatesEqual(
+    state,
+    createSidebarSplitState(availableTabIds, activeTabId),
+  );
+}
+
+export function getSidebarGroupForPane(
+  state: SidebarSplitState,
+  paneId: string,
+): SidebarTabGroup | null {
+  const pane = findPane(state.layout.root, paneId);
+  const groupId = pane === null ? null : sidebarPaneGroupId(pane);
+  return groupId === null ? null : (state.groups[groupId] ?? null);
+}
+
+export function selectSidebarTab(
+  state: SidebarSplitState,
+  paneId: string,
+  tabId: string,
+): SidebarSplitState {
+  const pane = findPane(state.layout.root, paneId);
+  const groupId = pane === null ? null : sidebarPaneGroupId(pane);
+  const group = groupId === null ? undefined : state.groups[groupId];
+  if (
+    groupId === null ||
+    group === undefined ||
+    !group.tabIds.includes(tabId)
+  ) {
+    return state;
+  }
+  const maximizedPaneId = state.maximizedPaneId === null ? null : paneId;
+  if (
+    group.activeTabId === tabId &&
+    state.layout.focusedPaneId === paneId &&
+    state.maximizedPaneId === maximizedPaneId
+  ) {
+    return state;
+  }
+  return {
+    ...state,
+    groups: {
+      ...state.groups,
+      [groupId]: { ...group, activeTabId: tabId },
+    },
+    layout: setFocus(state.layout, paneId),
+    maximizedPaneId,
+  };
+}
+
+export function focusSidebarPane(
+  state: SidebarSplitState,
+  paneId: string,
+): SidebarSplitState {
+  if (findPane(state.layout.root, paneId) === null) return state;
+  const maximizedPaneId = state.maximizedPaneId === null ? null : paneId;
+  if (
+    state.layout.focusedPaneId === paneId &&
+    state.maximizedPaneId === maximizedPaneId
+  ) {
+    return state;
+  }
+  return {
+    ...state,
+    layout: setFocus(state.layout, paneId),
+    maximizedPaneId,
+  };
+}
+
+export function reorderSidebarTab(
+  state: SidebarSplitState,
+  paneId: string,
+  activeTabId: string,
+  overTabId: string,
+): SidebarSplitState {
+  const pane = findPane(state.layout.root, paneId);
+  const groupId = pane === null ? null : sidebarPaneGroupId(pane);
+  const group = groupId === null ? undefined : state.groups[groupId];
+  if (
+    groupId === null ||
+    group === undefined ||
+    !group.tabIds.includes(activeTabId) ||
+    !group.tabIds.includes(overTabId) ||
+    activeTabId === overTabId
+  ) {
+    return state;
+  }
+  const from = group.tabIds.indexOf(activeTabId);
+  const to = group.tabIds.indexOf(overTabId);
+  const tabIds = [...group.tabIds];
+  const [moved] = tabIds.splice(from, 1);
+  if (moved === undefined) return state;
+  tabIds.splice(to, 0, moved);
+  return {
+    ...state,
+    groups: { ...state.groups, [groupId]: { ...group, tabIds } },
+  };
+}
+
+export function moveSidebarTab(
+  state: SidebarSplitState,
+  sourcePaneId: string,
+  tabId: string,
+  target: SplitDropTarget,
+  ids: Pick<SidebarSplitIds, "groupId">,
+): SidebarSplitState {
+  const sourcePane = findPane(state.layout.root, sourcePaneId);
+  const targetPane = findPane(state.layout.root, target.paneId);
+  if (sourcePane === null || targetPane === null) return state;
+  const sourceGroupId = sidebarPaneGroupId(sourcePane);
+  const targetGroupId = sidebarPaneGroupId(targetPane);
+  const sourceGroup =
+    sourceGroupId === null ? undefined : state.groups[sourceGroupId];
+  const targetGroup =
+    targetGroupId === null ? undefined : state.groups[targetGroupId];
+  if (
+    sourceGroupId === null ||
+    targetGroupId === null ||
+    sourceGroup === undefined ||
+    targetGroup === undefined ||
+    !sourceGroup.tabIds.includes(tabId)
+  ) {
+    return state;
+  }
+
+  if (target.zone === "center") {
+    if (sourcePaneId === target.paneId) return state;
+    const groups = { ...state.groups };
+    groups[targetGroupId] = {
+      ...targetGroup,
+      tabIds: [...targetGroup.tabIds.filter((id) => id !== tabId), tabId],
+      activeTabId: tabId,
+    };
+    if (sourceGroup.tabIds.length === 1) {
+      delete groups[sourceGroupId];
+      const layout = removePane(state.layout, sourcePaneId);
+      return {
+        ...state,
+        groups,
+        layout: setFocus(layout, target.paneId),
+        maximizedPaneId: null,
+      };
+    }
+    const remainingTabs = sourceGroup.tabIds.filter((id) => id !== tabId);
+    groups[sourceGroupId] = {
+      ...sourceGroup,
+      tabIds: remainingTabs,
+      activeTabId:
+        sourceGroup.activeTabId === tabId
+          ? (remainingTabs[0] ?? targetGroup.activeTabId)
+          : sourceGroup.activeTabId,
+    };
+    return {
+      ...state,
+      groups,
+      layout: setFocus(state.layout, target.paneId),
+    };
+  }
+
+  if (sourceGroup.tabIds.length === 1) {
+    const layout = movePane(
+      state.layout,
+      sourcePaneId,
+      target.paneId,
+      target.zone,
+    );
+    return layout === state.layout
+      ? state
+      : { ...state, layout, maximizedPaneId: null };
+  }
+  if (countPanes(state.layout.root) >= MAX_PANES) return state;
+  if (state.groups[ids.groupId] !== undefined) return state;
+
+  const remainingTabs = sourceGroup.tabIds.filter((id) => id !== tabId);
+  return {
+    ...state,
+    groups: {
+      ...state.groups,
+      [sourceGroupId]: {
+        ...sourceGroup,
+        tabIds: remainingTabs,
+        activeTabId:
+          sourceGroup.activeTabId === tabId
+            ? (remainingTabs[0] ?? sourceGroup.activeTabId)
+            : sourceGroup.activeTabId,
+      },
+      [ids.groupId]: {
+        id: ids.groupId,
+        tabIds: [tabId],
+        activeTabId: tabId,
+      },
+    },
+    layout: splitPane(
+      state.layout,
+      target.paneId,
+      target.zone,
+      groupContent(ids.groupId),
+    ),
+    maximizedPaneId: null,
+  };
+}
+
+export function closeSidebarPane(
+  state: SidebarSplitState,
+  paneId: string,
+): SidebarSplitState {
+  if (countPanes(state.layout.root) <= 1) return state;
+  const pane = findPane(state.layout.root, paneId);
+  const closedGroupId = pane === null ? null : sidebarPaneGroupId(pane);
+  const closedGroup =
+    closedGroupId === null ? undefined : state.groups[closedGroupId];
+  if (closedGroupId === null || closedGroup === undefined) return state;
+
+  const wasFocused = state.layout.focusedPaneId === paneId;
+  const layout = removePane(state.layout, paneId);
+  const survivorPane = findPane(layout.root, layout.focusedPaneId);
+  const survivorGroupId =
+    survivorPane === null ? null : sidebarPaneGroupId(survivorPane);
+  const survivorGroup =
+    survivorGroupId === null ? undefined : state.groups[survivorGroupId];
+  if (survivorGroupId === null || survivorGroup === undefined) return state;
+
+  const groups = { ...state.groups };
+  delete groups[closedGroupId];
+  groups[survivorGroupId] = {
+    ...survivorGroup,
+    tabIds: [
+      ...survivorGroup.tabIds,
+      ...closedGroup.tabIds.filter((id) => !survivorGroup.tabIds.includes(id)),
+    ],
+    activeTabId: wasFocused
+      ? closedGroup.activeTabId
+      : survivorGroup.activeTabId,
+  };
+  return { ...state, groups, layout, maximizedPaneId: null };
+}
+
+export function toggleSidebarPaneMaximize(
+  state: SidebarSplitState,
+  paneId: string,
+): SidebarSplitState {
+  if (
+    countPanes(state.layout.root) < 2 ||
+    findPane(state.layout.root, paneId) === null
+  ) {
+    return state;
+  }
+  return {
+    ...state,
+    layout: setFocus(state.layout, paneId),
+    maximizedPaneId: state.maximizedPaneId === paneId ? null : paneId,
+  };
+}
+
+export function moveSidebarPaneToSide(
+  state: SidebarSplitState,
+  paneId: string,
+  targetPaneId: string,
+  side: SplitSide,
+): SidebarSplitState {
+  const layout = movePane(state.layout, paneId, targetPaneId, side);
+  return layout === state.layout
+    ? state
+    : { ...state, layout, maximizedPaneId: null };
+}
+
+export function swapSidebarPanes(
+  state: SidebarSplitState,
+  paneId: string,
+  targetPaneId: string,
+): SidebarSplitState {
+  const layout = swapPanes(state.layout, paneId, targetPaneId);
+  return layout === state.layout ? state : { ...state, layout };
+}
+
+export function resizeSidebarSplit(
+  state: SidebarSplitState,
+  path: SplitPath,
+  childIndex: number,
+  fraction: number,
+): SidebarSplitState {
+  const layout = resizeSplit(state.layout, path, childIndex, fraction);
+  return layout === state.layout ? state : { ...state, layout };
+}
+
+/**
+ * Reconciles persisted pane membership with the currently open sidebar tabs.
+ * Existing ownership/order wins; newly opened tabs join the focused pane;
+ * closed or duplicated ids disappear. A stale/invalid layout falls back to the
+ * unchanged single-pane treatment instead of stranding content.
+ */
+export function reconcileSidebarSplitState(
+  state: SidebarSplitState,
+  availableTabIds: readonly string[],
+  activeTabId: string,
+): SidebarSplitState {
+  const available = [...new Set(availableTabIds)];
+  if (available.length === 0) return state;
+  const allowed = new Set(available);
+  const seen = new Set<string>();
+  let next = state;
+  const groups = { ...state.groups };
+
+  for (const pane of listPanes(state.layout.root)) {
+    const groupId = sidebarPaneGroupId(pane);
+    const group = groupId === null ? undefined : groups[groupId];
+    if (groupId === null || group === undefined) {
+      return preserveSidebarSplitStateIdentity(
+        state,
+        createSidebarSplitState(available, activeTabId),
+      );
+    }
+    const tabIds = group.tabIds.filter((id) => {
+      if (!allowed.has(id) || seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
+    groups[groupId] = {
+      ...group,
+      tabIds,
+      activeTabId: tabIds.includes(group.activeTabId)
+        ? group.activeTabId
+        : (tabIds[0] ?? activeTabId),
+    };
+  }
+
+  next = { ...state, groups };
+  for (const pane of listPanes(next.layout.root)) {
+    const groupId = sidebarPaneGroupId(pane);
+    const group = groupId === null ? undefined : next.groups[groupId];
+    if (group !== undefined && group.tabIds.length === 0) {
+      if (countPanes(next.layout.root) === 1) break;
+      next = closeSidebarPane(next, pane.paneId);
+    }
+  }
+
+  const missing = available.filter((id) => !seen.has(id));
+  const focusedGroup = getSidebarGroupForPane(next, next.layout.focusedPaneId);
+  if (focusedGroup === null)
+    return preserveSidebarSplitStateIdentity(
+      state,
+      createSidebarSplitState(available, activeTabId),
+    );
+  if (missing.length > 0 || focusedGroup.tabIds.length === 0) {
+    next = {
+      ...next,
+      groups: {
+        ...next.groups,
+        [focusedGroup.id]: {
+          ...focusedGroup,
+          tabIds: [...focusedGroup.tabIds, ...missing],
+          activeTabId:
+            focusedGroup.tabIds.length === 0
+              ? activeTabId
+              : focusedGroup.activeTabId,
+        },
+      },
+    };
+  }
+  for (const pane of listPanes(next.layout.root)) {
+    const groupId = sidebarPaneGroupId(pane);
+    const group = groupId === null ? undefined : next.groups[groupId];
+    if (
+      groupId !== null &&
+      group !== undefined &&
+      !group.tabIds.includes(group.activeTabId)
+    ) {
+      const fallbackActiveTabId = group.tabIds[0];
+      if (fallbackActiveTabId === undefined) {
+        return preserveSidebarSplitStateIdentity(
+          state,
+          createSidebarSplitState(available, activeTabId),
+        );
+      }
+      next = {
+        ...next,
+        groups: {
+          ...next.groups,
+          [groupId]: { ...group, activeTabId: fallbackActiveTabId },
+        },
+      };
+    }
+  }
+  if (
+    next.maximizedPaneId !== null &&
+    findPane(next.layout.root, next.maximizedPaneId) === null
+  ) {
+    next = { ...next, maximizedPaneId: null };
+  }
+  return preserveSidebarSplitStateIdentity(state, next);
+}
+
+const paneContentSchema = z
+  .object({
+    kind: z.literal("plugin-panel"),
+    pluginId: z.literal(SIDEBAR_SPLIT_PLUGIN_ID),
+    panelPath: z.string().min(1),
+    subPath: z.literal(""),
+  })
+  .strict();
+const paneNodeSchema = z
+  .object({
+    type: z.literal("pane"),
+    paneId: z.string().min(1),
+    content: paneContentSchema,
+  })
+  .strict();
+const layoutNodeSchema: z.ZodType<LayoutNode> = z.lazy(() =>
+  z.union([
+    paneNodeSchema,
+    z
+      .object({
+        type: z.literal("split"),
+        dir: z.enum(["row", "col"]),
+        sizes: z.array(z.number().positive()).min(2),
+        children: z.array(layoutNodeSchema).min(2),
+      })
+      .strict()
+      .refine((node) => node.sizes.length === node.children.length),
+  ]),
+);
+
+function hasNormalizedSplitSizes(node: LayoutNode): boolean {
+  if (node.type === "pane") return true;
+  const total = node.sizes.reduce((sum, size) => sum + size, 0);
+  return (
+    Math.abs(total - 1) <= NORMALIZED_SPLIT_SIZE_EPSILON &&
+    node.children.every(hasNormalizedSplitSizes)
+  );
+}
+
+const sidebarSplitStateSchema: z.ZodType<SidebarSplitState> = z
+  .object({
+    version: z.literal(SIDEBAR_SPLIT_LAYOUT_STORAGE_VERSION),
+    groups: z.record(
+      z.string(),
+      z
+        .object({
+          id: z.string().min(1),
+          tabIds: z.array(z.string().min(1)).min(1),
+          activeTabId: z.string().min(1),
+        })
+        .strict(),
+    ),
+    layout: z
+      .object({
+        root: layoutNodeSchema,
+        focusedPaneId: z.string().min(1),
+      })
+      .strict(),
+    maximizedPaneId: z.string().min(1).nullable(),
+  })
+  .strict()
+  .superRefine((state, context) => {
+    const panes = listPanes(state.layout.root);
+    const paneIds = panes.map((pane) => pane.paneId);
+    const groupIds = panes.map(sidebarPaneGroupId);
+    const storedGroupIds = Object.keys(state.groups);
+
+    if (panes.length > MAX_PANES) {
+      context.addIssue({
+        code: "custom",
+        message: `A sidebar split supports at most ${MAX_PANES} panes`,
+        path: ["layout", "root"],
+      });
+    }
+    if (new Set(paneIds).size !== paneIds.length) {
+      context.addIssue({
+        code: "custom",
+        message: "Sidebar pane IDs must be unique",
+        path: ["layout", "root"],
+      });
+    }
+    if (!paneIds.includes(state.layout.focusedPaneId)) {
+      context.addIssue({
+        code: "custom",
+        message: "The focused sidebar pane must exist",
+        path: ["layout", "focusedPaneId"],
+      });
+    }
+    if (
+      state.maximizedPaneId !== null &&
+      !paneIds.includes(state.maximizedPaneId)
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "The maximized sidebar pane must exist",
+        path: ["maximizedPaneId"],
+      });
+    }
+    if (!hasNormalizedSplitSizes(state.layout.root)) {
+      context.addIssue({
+        code: "custom",
+        message: "Sidebar split sizes must be normalized",
+        path: ["layout", "root"],
+      });
+    }
+
+    const referencedGroupIds = groupIds.filter(
+      (groupId): groupId is string => groupId !== null,
+    );
+    if (
+      referencedGroupIds.length !== panes.length ||
+      new Set(referencedGroupIds).size !== referencedGroupIds.length
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "Each sidebar pane must reference one unique tab group",
+        path: ["layout", "root"],
+      });
+    }
+    if (
+      referencedGroupIds.length !== storedGroupIds.length ||
+      referencedGroupIds.some((groupId) => state.groups[groupId] === undefined)
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "Sidebar tab groups must map one-to-one to panes",
+        path: ["groups"],
+      });
+    }
+    for (const [groupKey, group] of Object.entries(state.groups)) {
+      if (group.id !== groupKey) {
+        context.addIssue({
+          code: "custom",
+          message: "Sidebar tab group keys must match their IDs",
+          path: ["groups", groupKey, "id"],
+        });
+      }
+      if (!group.tabIds.includes(group.activeTabId)) {
+        context.addIssue({
+          code: "custom",
+          message: "A sidebar group's active tab must belong to that group",
+          path: ["groups", groupKey, "activeTabId"],
+        });
+      }
+    }
+  });
+
+export function sidebarSplitStorageKey(panelStateId: string): string {
+  return `${SIDEBAR_SPLIT_LAYOUT_STORAGE_PREFIX}.${panelStateId}`;
+}
+
+function getFixedPanelTabsLastUsedAt(
+  storedValue: string | null,
+): number | null {
+  if (storedValue === null) return null;
+  try {
+    const parsed: unknown = JSON.parse(storedValue);
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const lastUsedAt = Reflect.get(parsed, "lastUsedAt");
+    return typeof lastUsedAt === "number" &&
+      Number.isInteger(lastUsedAt) &&
+      lastUsedAt >= 0
+      ? lastUsedAt
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Removes sidebar layouts when their owning fixed-tab record is absent,
+ * malformed, or older than the fixed-tab cache's established idle lifetime.
+ * The layout stays in its current raw v1 format; retention metadata continues
+ * to have one owner in the fixed-tab record.
+ */
+export function pruneSidebarSplitStorage({
+  storage,
+  now,
+}: {
+  storage: SidebarSplitStorage;
+  now: number;
+}): void {
+  const splitKeys: string[] = [];
+  const keyPrefix = `${SIDEBAR_SPLIT_LAYOUT_STORAGE_PREFIX}.`;
+  for (let index = 0; index < storage.length; index += 1) {
+    const key = storage.key(index);
+    if (key?.startsWith(keyPrefix)) splitKeys.push(key);
+  }
+
+  for (const splitKey of splitKeys) {
+    const panelStateId = splitKey.slice(keyPrefix.length);
+    const fixedPanelTabsKey = getFixedPanelTabsStateStorageKey({
+      threadId: panelStateId,
+    });
+    const lastUsedAt = getFixedPanelTabsLastUsedAt(
+      storage.getItem(fixedPanelTabsKey),
+    );
+    if (
+      panelStateId.length === 0 ||
+      lastUsedAt === null ||
+      now - lastUsedAt > FIXED_PANEL_TABS_IDLE_EXPIRY_MS
+    ) {
+      storage.removeItem(splitKey);
+    }
+  }
+}
+
+export function parseSidebarSplitState(
+  storedValue: string | null,
+  availableTabIds: readonly string[],
+  activeTabId: string,
+): SidebarSplitState {
+  if (storedValue !== null) {
+    try {
+      const parsed = sidebarSplitStateSchema.safeParse(JSON.parse(storedValue));
+      if (parsed.success) {
+        return reconcileSidebarSplitState(
+          parsed.data,
+          availableTabIds,
+          activeTabId,
+        );
+      }
+    } catch {
+      // Corrupt or pre-versioned state falls through to the compatible default.
+    }
+  }
+  return createSidebarSplitState(availableTabIds, activeTabId);
+}
+
+export function serializeSidebarSplitState(state: SidebarSplitState): string {
+  return JSON.stringify(state);
+}

--- a/apps/app/src/components/thread/terminal/ThreadTerminalPanel.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalPanel.tsx
@@ -18,6 +18,7 @@ interface ThreadTerminalPanelProps {
   onSelectionAddToChat?: (text: string) => void;
   panelStateId?: string;
   syncThreadId: string | null;
+  terminalId?: string;
   target: ThreadTerminalTarget;
 }
 
@@ -33,6 +34,7 @@ export function ThreadTerminalPanel({
   onSelectionAddToChat,
   panelStateId,
   syncThreadId,
+  terminalId,
   target,
 }: ThreadTerminalPanelProps) {
   const terminalController = useThreadTerminalController({
@@ -42,6 +44,7 @@ export function ThreadTerminalPanel({
     fixedPanelTarget,
     fixedTerminalId,
     panelStateId,
+    preferredTerminalId: terminalId,
     syncThreadId,
     target,
   });

--- a/apps/app/src/components/thread/terminal/useThreadTerminalController.ts
+++ b/apps/app/src/components/thread/terminal/useThreadTerminalController.ts
@@ -47,6 +47,8 @@ export interface ThreadTerminalControllerArgs {
   isPanelOpen: boolean;
   isPanelPersistedOpen: boolean;
   panelStateId?: string;
+  /** Pins this controller to one pane-owned terminal without changing global tab selection. */
+  preferredTerminalId?: string;
   /** Thread whose tabs are server-synced; null for local-only panel state. */
   syncThreadId: string | null;
   fixedPanelTarget?: TerminalCreateTarget;
@@ -205,6 +207,7 @@ export function useThreadTerminalController({
   isPanelOpen,
   isPanelPersistedOpen,
   panelStateId,
+  preferredTerminalId,
   syncThreadId,
   fixedPanelTarget,
   fixedTerminalId,
@@ -343,10 +346,15 @@ export function useThreadTerminalController({
     () =>
       pickActiveTerminalId(
         visibleSessions,
-        activeFixedTerminalId,
+        preferredTerminalId ?? activeFixedTerminalId,
         fixedTerminalId,
       ),
-    [activeFixedTerminalId, fixedTerminalId, visibleSessions],
+    [
+      activeFixedTerminalId,
+      fixedTerminalId,
+      preferredTerminalId,
+      visibleSessions,
+    ],
   );
   const activeSession =
     visibleSessions.find((session) => session.id === activeTerminalId) ?? null;
@@ -381,7 +389,10 @@ export function useThreadTerminalController({
     if (!isPanelOpen || terminalsQuery.isLoading || terminalsQuery.error) {
       return;
     }
-    if (activeFixedTerminalId === activeTerminalId) {
+    if (
+      preferredTerminalId !== undefined ||
+      activeFixedTerminalId === activeTerminalId
+    ) {
       return;
     }
     setActiveFixedTerminal(activeTerminalId);
@@ -389,6 +400,7 @@ export function useThreadTerminalController({
     activeFixedTerminalId,
     activeTerminalId,
     isPanelOpen,
+    preferredTerminalId,
     setActiveFixedTerminal,
     terminalsQuery.error,
     terminalsQuery.isLoading,

--- a/apps/app/src/test/bb-desktop-test-utils.ts
+++ b/apps/app/src/test/bb-desktop-test-utils.ts
@@ -18,12 +18,17 @@ export function createNoopDesktopBrowserApi(): BbDesktopBrowserApi {
     goForward() {},
     reload() {},
     stop() {},
+    focus() {},
     setBounds() {},
     setVisible() {},
+    setVisibleWithoutFocus() {},
     onState() {
       return () => {};
     },
     onOpenTab() {
+      return () => {};
+    },
+    onFocus() {
       return () => {};
     },
   };

--- a/apps/app/src/views/thread-detail/PaneMaximizeButton.tsx
+++ b/apps/app/src/views/thread-detail/PaneMaximizeButton.tsx
@@ -6,6 +6,7 @@ import { useAppCommandShortcut } from "@/components/commands/AppCommandProvider"
 import { HEADER_PANE_ACTION_ICON_BUTTON_CLASS } from "@/components/layout/AppPageHeader";
 import { CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS } from "@/components/ui/chromeStyleTokens";
 import { useHoverPopover } from "@/components/ui/hooks/use-hover-popover";
+import type { AppShortcutPresentation } from "@/lib/app-keybindings";
 import type { SplitSide } from "@/lib/split-layout";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { usePaneContext } from "./PaneContext";
@@ -58,6 +59,38 @@ export function PaneMaximizeButton({
 }) {
   const { isMaximized, onToggleMaximize, onMoveToSide } = usePaneContext();
   const shortcut = useAppCommandShortcut("pane.maximize.toggle");
+
+  if (onToggleMaximize === null) return null;
+
+  return (
+    <PaneArrangementButton
+      defaultMenuOpen={defaultMenuOpen}
+      defaultTooltipOpen={defaultTooltipOpen}
+      isFullScreen={isMaximized}
+      onMoveToSide={onMoveToSide ?? undefined}
+      onToggleFullScreen={onToggleMaximize}
+      shortcut={shortcut ?? undefined}
+    />
+  );
+}
+
+export function PaneArrangementButton({
+  className,
+  defaultMenuOpen = false,
+  defaultTooltipOpen = false,
+  isFullScreen,
+  onMoveToSide,
+  onToggleFullScreen,
+  shortcut,
+}: {
+  className?: string;
+  defaultMenuOpen?: boolean;
+  defaultTooltipOpen?: boolean;
+  isFullScreen: boolean;
+  onMoveToSide?: (side: SplitSide) => void;
+  onToggleFullScreen: () => void;
+  shortcut?: AppShortcutPresentation;
+}) {
   // The pointer crosses this button on the way to the close control, so the
   // menu waits before it appears.
   const {
@@ -67,11 +100,9 @@ export function PaneMaximizeButton({
     handleOpenChange,
   } = useHoverPopover({ openDelayMs: 400, closeDelayMs: 100 });
 
-  if (onToggleMaximize === null) return null;
-
-  const label = isMaximized ? "Exit Full Screen" : "Full Screen";
+  const label = isFullScreen ? "Exit Full Screen" : "Full Screen";
   const accessibleLabel = shortcut ? `${label} (${shortcut.label})` : label;
-  const menuOpen = !isMaximized && (defaultMenuOpen || hoverOpen);
+  const menuOpen = !isFullScreen && (defaultMenuOpen || hoverOpen);
   const button = (
     <Button
       type="button"
@@ -80,24 +111,25 @@ export function PaneMaximizeButton({
       className={cn(
         HEADER_PANE_ACTION_ICON_BUTTON_CLASS,
         CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS,
+        className,
       )}
       aria-label={accessibleLabel}
       aria-keyshortcuts={shortcut?.ariaKeyshortcuts}
-      aria-pressed={isMaximized}
-      aria-haspopup={!isMaximized ? "menu" : undefined}
-      aria-expanded={!isMaximized ? menuOpen : undefined}
-      onFocus={!isMaximized ? () => handleOpenChange(true) : undefined}
+      aria-pressed={isFullScreen}
+      aria-haspopup={!isFullScreen ? "menu" : undefined}
+      aria-expanded={!isFullScreen ? menuOpen : undefined}
+      onFocus={!isFullScreen ? () => handleOpenChange(true) : undefined}
       onClick={() => {
         handleOpenChange(false);
-        onToggleMaximize();
+        onToggleFullScreen();
       }}
-      {...(!isMaximized ? triggerHoverProps : {})}
+      {...(!isFullScreen ? triggerHoverProps : {})}
     >
-      <Icon name={isMaximized ? "Minimize2" : "Maximize2"} />
+      <Icon name={isFullScreen ? "Minimize2" : "Maximize2"} />
     </Button>
   );
 
-  if (isMaximized) {
+  if (isFullScreen) {
     return (
       <Tooltip defaultOpen={defaultTooltipOpen}>
         <TooltipTrigger asChild>{button}</TooltipTrigger>
@@ -127,7 +159,7 @@ export function PaneMaximizeButton({
           className={MENU_ITEM_CLASS}
           onClick={() => {
             handleOpenChange(false);
-            onToggleMaximize();
+            onToggleFullScreen();
           }}
         >
           <Icon name="Maximize2" />

--- a/apps/app/src/views/thread-detail/SplitThreadArea.stories.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.stories.tsx
@@ -17,10 +17,6 @@ import { maximizedPaneIdAtom, splitLayoutAtom } from "@/lib/split-layout/atoms";
 import type { SplitLayout } from "@/lib/split-layout";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { ThreadActionsProvider } from "@/components/thread/ThreadActionsProvider";
-import { AppPageHeader } from "@/components/layout/AppPageHeader";
-import { TooltipProvider } from "@bb/shared-ui/tooltip";
-import { PaneContext, type PaneContextValue } from "./PaneContext";
-import { PaneMaximizeButton } from "./PaneMaximizeButton";
 import { SplitThreadArea } from "./SplitThreadArea";
 
 export default {
@@ -236,63 +232,4 @@ export function ActiveAndIdle() {
 
 export function MaximizedWithoutRail() {
   return <SplitWorkspaceStory maximized />;
-}
-
-const CONTROL_CONTEXT: PaneContextValue = {
-  paneId: "pane-control",
-  isFocused: true,
-  isSplitPane: true,
-  secondaryPanelHost: null,
-  reservesWindowPanelToggle: false,
-  onRequestClose: () => {},
-  isMaximized: false,
-  onToggleMaximize: () => {},
-  onMoveToSide: () => {},
-  isBoundedPane: true,
-  isTopRow: true,
-  ownsWindowTopLeft: false,
-  navigateInPane: () => {},
-};
-
-export function FullScreenControlStates() {
-  return (
-    <TooltipProvider delayDuration={0}>
-      <main className="grid min-h-screen gap-32 bg-background p-12 md:grid-cols-2">
-        <section className="space-y-3">
-          <h2 className="text-sm font-medium text-foreground">
-            Normal · hover menu
-          </h2>
-          <div className="overflow-visible rounded-md border border-border">
-            <PaneContext.Provider value={CONTROL_CONTEXT}>
-              <AppPageHeader
-                center={
-                  <span className="text-sm font-semibold">Normal pane</span>
-                }
-                actions={<PaneMaximizeButton defaultMenuOpen />}
-              />
-            </PaneContext.Provider>
-          </div>
-        </section>
-        <section className="space-y-3">
-          <h2 className="text-sm font-medium text-foreground">
-            Full screen · exit tooltip
-          </h2>
-          <div className="overflow-visible rounded-md border border-border">
-            <PaneContext.Provider
-              value={{ ...CONTROL_CONTEXT, isMaximized: true }}
-            >
-              <AppPageHeader
-                center={
-                  <span className="text-sm font-semibold">
-                    Full-screen pane
-                  </span>
-                }
-                actions={<PaneMaximizeButton defaultTooltipOpen />}
-              />
-            </PaneContext.Provider>
-          </div>
-        </section>
-      </main>
-    </TooltipProvider>
-  );
 }

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -17,6 +17,19 @@ type ThreadDetailSecondaryContentProps = ComponentProps<
   typeof ThreadDetailSecondaryContent
 >;
 
+const secondaryPanelMockState = vi.hoisted(() => ({
+  browserDeckForTab: undefined as
+    | ((
+        activeBrowserTabId: string,
+        pane: {
+          isFocused: boolean;
+          isVisible: boolean;
+          onFocusPane: () => void;
+        },
+      ) => ReactNode)
+    | undefined,
+}));
+
 vi.mock("@/lib/bb-desktop", () => ({
   DEFAULT_DESKTOP_WINDOW_STATE: { isFullScreen: false },
   getBbDesktopInfo: () => null,
@@ -107,11 +120,13 @@ vi.mock(
       >();
 
     const ThreadSecondaryPanel = ({
+      browserDeckForTab,
       inlinePanelToggle,
       metadataContent,
       renderAsDrawer,
-    }: ComponentProps<typeof actual.ThreadSecondaryPanel>) =>
-      React.createElement(
+    }: ComponentProps<typeof actual.ThreadSecondaryPanel>) => {
+      secondaryPanelMockState.browserDeckForTab = browserDeckForTab;
+      return React.createElement(
         "section",
         {
           "data-inline-panel-toggle": inlinePanelToggle,
@@ -121,6 +136,7 @@ vi.mock(
         },
         metadataContent,
       );
+    };
 
     return { ...actual, ThreadSecondaryPanel };
   },
@@ -299,6 +315,7 @@ function renderThreadDetail(
 afterEach(() => {
   cleanup();
   publishedHostedPanel = null;
+  secondaryPanelMockState.browserDeckForTab = undefined;
   useThreadsMock.mockClear();
 });
 
@@ -309,9 +326,13 @@ describe("ThreadDetailSecondaryContent", () => {
     renderThreadDetail(false);
 
     expect(
-      (await screen.findByTestId("inline-secondary-panel")).getAttribute(
-        "data-inline-panel-toggle",
-      ),
+      (
+        await screen.findByTestId(
+          "inline-secondary-panel",
+          {},
+          { timeout: 5_000 },
+        )
+      ).getAttribute("data-inline-panel-toggle"),
     ).toBe("button");
   });
 
@@ -359,6 +380,63 @@ describe("ThreadDetailSecondaryContent", () => {
         screen.getByTestId("metadata-card"),
       ),
     ).toBe(true);
+  });
+
+  it("pins a split browser pane to its tab and gates native commands by pane focus", () => {
+    const renderBrowserDeck = vi.fn(() => null);
+    const props = createProps();
+    props.secondaryPanel.renderBrowserDeck = renderBrowserDeck;
+
+    render(
+      <MemoryRouter>
+        <DefaultPaneContextProvider>
+          <CompactViewportOverrideProvider isCompactViewport={false}>
+            <ThreadDetailSecondaryContent {...props} />
+          </CompactViewportOverrideProvider>
+        </DefaultPaneContextProvider>
+      </MemoryRouter>,
+    );
+
+    const browserDeckForTab = secondaryPanelMockState.browserDeckForTab;
+    expect(browserDeckForTab).toBeDefined();
+    if (browserDeckForTab === undefined) return;
+
+    const onFocusPane = vi.fn();
+    browserDeckForTab("browser-split", {
+      isFocused: true,
+      isVisible: true,
+      onFocusPane,
+    });
+    expect(renderBrowserDeck).toHaveBeenLastCalledWith({
+      activeBrowserTabId: "browser-split",
+      canHandleBrowserCommands: true,
+      canShowNativeBrowserView: true,
+      onNativeFocus: onFocusPane,
+    });
+
+    browserDeckForTab("browser-split", {
+      isFocused: false,
+      isVisible: true,
+      onFocusPane,
+    });
+    expect(renderBrowserDeck).toHaveBeenLastCalledWith({
+      activeBrowserTabId: "browser-split",
+      canHandleBrowserCommands: false,
+      canShowNativeBrowserView: true,
+      onNativeFocus: onFocusPane,
+    });
+
+    browserDeckForTab("browser-split", {
+      isFocused: true,
+      isVisible: false,
+      onFocusPane,
+    });
+    expect(renderBrowserDeck).toHaveBeenLastCalledWith({
+      activeBrowserTabId: "browser-split",
+      canHandleBrowserCommands: false,
+      canShowNativeBrowserView: false,
+      onNativeFocus: onFocusPane,
+    });
   });
 
   it("only requests the forks list while the secondary panel is open", () => {

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -28,10 +28,14 @@ type ThreadSecondaryPanelProps = Omit<
   | "isConversationCollapsed"
   | "onToggleConversationCollapse"
   | "browserDeck"
+  | "browserDeckForTab"
   | "drawerFallback"
 > & {
   renderBrowserDeck?: (args: {
+    activeBrowserTabId?: string | null;
+    canHandleBrowserCommands?: boolean;
     canShowNativeBrowserView: boolean;
+    onNativeFocus?: () => void;
   }) => ReactNode;
 };
 
@@ -145,7 +149,20 @@ function ThreadDetailSecondaryContentBody({
           <LazyThreadSecondaryPanel
             {...threadSecondaryPanelProps}
             drawerFallback={<ThreadMetadataLoadingSkeleton />}
-            browserDeck={renderBrowserDeck?.({ canShowNativeBrowserView })}
+            browserDeck={renderBrowserDeck?.({
+              canHandleBrowserCommands: canShowNativeBrowserView,
+              canShowNativeBrowserView,
+            })}
+            browserDeckForTab={(activeBrowserTabId, pane) =>
+              renderBrowserDeck?.({
+                activeBrowserTabId,
+                canHandleBrowserCommands:
+                  canShowNativeBrowserView && pane.isVisible && pane.isFocused,
+                canShowNativeBrowserView:
+                  canShowNativeBrowserView && pane.isVisible,
+                onNativeFocus: pane.onFocusPane,
+              })
+            }
             renderAsDrawer={presentation === "drawer"}
             isConversationCollapsed={
               presentation === "inline" && isMainCollapsed

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -156,6 +156,7 @@ import {
   useThreadStorageViewer,
 } from "@/components/secondary-panel/useThreadStorageViewer";
 import { getThreadConversationCollapsedAtom } from "@/components/secondary-panel/threadSecondaryPanelAtoms";
+import { BrowserTabLifecycleObserver } from "@/components/secondary-panel/BrowserTabDeck";
 import {
   LazyBrowserTabDeck,
   LazyHostFilePreviewTabContent,
@@ -214,7 +215,6 @@ import { useThreadReadTracking } from "@/hooks/useThreadReadTracking";
 import { useThreadUnreadDividerState } from "./useThreadUnreadDividerState";
 import {
   buildTerminalSyncedSecondaryFileTabs,
-  findActiveTerminalIdInSecondaryFileTabs,
   getRetainedTerminalTabId,
   syncTerminalTabsInFixedPanelState,
 } from "@/components/secondary-panel/terminalPanelTabs";
@@ -247,6 +247,7 @@ import {
   createGitDiffFixedPanelTab,
   createNewTabFixedPanelTab,
   createThreadInfoFixedPanelTab,
+  type SecondaryFileFixedPanelTab,
 } from "@/lib/fixed-panel-tabs-state";
 import { resolveGitDiffTabStatus } from "@/components/secondary-panel/gitDiffTabEligibility";
 import { isRootThread } from "./threadParentSelectorOptions";
@@ -693,21 +694,15 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
   });
   const {
     activeBrowserTab,
-    activeFileOpenerOwner,
     activeHostFileLineRange,
     activeHostFilePath,
-    activeStorageFileLineRange,
     activeStorageFilePath,
-    activeWorkspaceFileLineRange,
     activeWorkspaceFilePath,
-    activeWorkspaceFileSource,
-    activeWorkspaceFileStatusLabel,
     activePluginPanelTab,
     browserTabs,
     clearActiveFileTabs,
     activateTab,
     closeTab,
-    isNewTabActive,
     openTab,
     openPluginPanel,
     orderedSecondaryFileTabs,
@@ -752,20 +747,32 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
   // each one keeps a live native view that must persist across tab switches, so
   // the deck stays mounted independently of which tab is active.
   const renderBrowserDeck = useCallback(
-    ({ canShowNativeBrowserView }: { canShowNativeBrowserView: boolean }) => {
+    ({
+      canHandleBrowserCommands,
+      canShowNativeBrowserView,
+      onNativeFocus,
+      activeBrowserTabId = activeBrowserTab?.id ?? null,
+    }: {
+      canHandleBrowserCommands?: boolean;
+      canShowNativeBrowserView: boolean;
+      onNativeFocus?: () => void;
+      activeBrowserTabId?: string | null;
+    }) => {
       if (browserDeckThreadId === null) {
         return null;
       }
       return (
         <LazyBrowserTabDeck
           browserTabs={browserTabs}
-          activeBrowserTabId={activeBrowserTab?.id ?? null}
+          activeBrowserTabId={activeBrowserTabId}
           addressFocusRequest={browserAddressFocusRequest}
           onAddressFocusRequestConsumed={
             handleBrowserAddressFocusRequestConsumed
           }
           environmentId={browserDeckEnvironmentId}
           canShowNativeBrowserView={canShowNativeBrowserView}
+          canHandleBrowserCommands={canHandleBrowserCommands}
+          onNativeFocus={onNativeFocus}
           threadId={browserDeckThreadId}
           onUpdate={updateBrowserTab}
         />
@@ -2287,34 +2294,6 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
     }
     return false;
   });
-  const workspaceFileCopyPath = activeWorkspaceFilePath
-    ? resolveAbsoluteFilePath({
-        path: activeWorkspaceFilePath,
-        rootPath: workspacePreviewRootPath,
-      })
-    : null;
-  const storageFileCopyPath = activeStorageFilePath
-    ? resolveAbsoluteFilePath({
-        path: activeStorageFilePath,
-        rootPath: threadStorageRootPath,
-      })
-    : null;
-  // Relative links inside a previewed markdown file resolve against the file's
-  // own directory, mirroring how the file's links would resolve on disk.
-  const workspaceFileLinkBaseDir = workspaceFileCopyPath
-    ? getAbsoluteDirname({ path: workspaceFileCopyPath })
-    : undefined;
-  const storageFileLinkBaseDir = storageFileCopyPath
-    ? getAbsoluteDirname({ path: storageFileCopyPath })
-    : undefined;
-  const hostFileLinkBaseDir = activeHostFilePath
-    ? getAbsoluteDirname({ path: activeHostFilePath })
-    : undefined;
-  const hostFileLinkRootPath = resolveHostFilePreviewLinkRootPath({
-    baseDir: hostFileLinkBaseDir,
-    threadStorageRootPath,
-    workspaceRootPath: workspacePreviewRootPath,
-  });
   // Right-click local file links: per-open native app choices, optional
   // preview/plugin viewer choices, and utility copy actions. Left-click behavior
   // stays unchanged.
@@ -2406,51 +2385,6 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
       handleOpenTimelineLocalFileLink,
       openPathInFileTarget,
       pluginFileOpeners,
-    ],
-  );
-  const workspaceMarkdownLinkRouting = useMemo(
-    () =>
-      buildMarkdownPreviewLinkRouting({
-        baseDir: workspaceFileLinkBaseDir,
-        onOpenLink: handleOpenTimelineLink,
-        onOpenLocalFileLink: handleOpenTimelineLocalFileLink,
-        rootPath: workspacePreviewRootPath,
-      }),
-    [
-      handleOpenTimelineLink,
-      handleOpenTimelineLocalFileLink,
-      workspaceFileLinkBaseDir,
-      workspacePreviewRootPath,
-    ],
-  );
-  const hostMarkdownLinkRouting = useMemo(
-    () =>
-      buildMarkdownPreviewLinkRouting({
-        baseDir: hostFileLinkBaseDir,
-        onOpenLink: handleOpenTimelineLink,
-        onOpenLocalFileLink: handleOpenTimelineLocalFileLink,
-        rootPath: hostFileLinkRootPath,
-      }),
-    [
-      handleOpenTimelineLink,
-      handleOpenTimelineLocalFileLink,
-      hostFileLinkBaseDir,
-      hostFileLinkRootPath,
-    ],
-  );
-  const storageMarkdownLinkRouting = useMemo(
-    () =>
-      buildMarkdownPreviewLinkRouting({
-        baseDir: storageFileLinkBaseDir,
-        onOpenLink: handleOpenTimelineLink,
-        onOpenLocalFileLink: handleOpenTimelineLocalFileLink,
-        rootPath: threadStorageRootPath,
-      }),
-    [
-      handleOpenTimelineLink,
-      handleOpenTimelineLocalFileLink,
-      storageFileLinkBaseDir,
-      threadStorageRootPath,
     ],
   );
   const handleOpenFilePreview = useCallback<OpenFilePreviewHandler>(
@@ -2698,114 +2632,187 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
       thread={thread}
     />
   );
-  const activeTerminalId = findActiveTerminalIdInSecondaryFileTabs({
-    activeTabId: activeFixedSecondaryTabId,
-    tabs: syncedOrderedSecondaryFileTabs,
-  });
-  const renderFileOpenerReplacement = (original: ReactNode): ReactNode =>
-    activeFileOpenerOwner !== null && activePluginPanelTab !== null ? (
-      <ThreadTimelineNavigationProvider
-        environmentId={thread.environmentId}
-        onOpenLink={handleOpenTimelineLink}
-        onOpenLocalFileLink={handleOpenTimelineLocalFileLink}
-        resolveMentionLink={resolveMentionLink}
-        workspaceRootPath={environment?.path ?? undefined}
-      >
-        <PluginPanelTabContent
-          tab={activePluginPanelTab}
-          context={{ kind: "thread", threadId: thread.id }}
-          fileOpenerOriginal={original}
-        />
-      </ThreadTimelineNavigationProvider>
-    ) : (
-      original
-    );
-  const fileTabContent = activeTerminalId ? (
-    <LazyThreadTerminalPanel
-      autoFocus={shouldAutoFocusTerminal}
-      canCreateTerminal={canCreateTerminal}
-      isPanelOpen={isSecondaryPanelOpen}
-      isPanelPersistedOpen={isPersistedSecondaryPanelOpen}
-      onAutoFocusHandled={handleTerminalAutoFocusHandled}
-      onOpenLink={handleOpenTimelineLink}
-      onSelectionAddToChat={handleSelectionAddToChat}
-      syncThreadId={thread.id}
-      target={{ kind: "thread", threadId: thread.id }}
-    />
-  ) : isNewTabActive ? (
-    <LazyNewTabPage
-      autoFocus={shouldAutoFocusNewTab}
-      projectId={projectId ?? undefined}
-      environmentId={thread.environmentId ?? null}
-      currentThreadId={thread.id}
-      onAutoFocusHandled={handleNewTabAutoFocusHandled}
-      onSelect={handleSelectFileSearchResult}
-      onOpenBrowser={handleOpenBrowser}
-      onStartTerminal={canCreateTerminal ? handleStartTerminal : undefined}
-      pluginActions={pluginPanelActions}
-    />
-  ) : activeWorkspaceFilePath ? (
-    renderFileOpenerReplacement(
-      <LazyWorkspaceFilePreviewTabContent
-        activePath={activeWorkspaceFilePath}
-        copyPath={workspaceFileCopyPath}
-        environmentId={thread.environmentId}
-        isPanelOpen={isSecondaryPanelOpen}
-        lineRange={activeWorkspaceFileLineRange}
-        markdownLinkRouting={workspaceMarkdownLinkRouting}
-        onOpenInEditor={handleOpenFileInEditor}
-        onSelectionAddToChat={handleSelectionAddToChat}
-        source={activeWorkspaceFileSource}
-        statusLabel={activeWorkspaceFileStatusLabel}
-        threadId={thread.id}
-      />,
-    )
-  ) : activeHostFilePath ? (
-    renderFileOpenerReplacement(
-      <LazyHostFilePreviewTabContent
-        activePath={activeHostFilePath}
-        copyPath={activeHostFilePath}
-        environmentId={thread.environmentId}
-        isPanelOpen={isSecondaryPanelOpen}
-        lineRange={activeHostFileLineRange}
-        markdownLinkRouting={hostMarkdownLinkRouting}
-        onOpenInEditor={handleOpenHostFileInEditor}
-        onSelectionAddToChat={handleSelectionAddToChat}
-        threadId={thread.id}
-      />,
-    )
-  ) : activeStorageFilePath ? (
-    renderFileOpenerReplacement(
-      <LazyThreadStorageFilePreviewTabContent
-        activePath={activeStorageFilePath}
-        copyPath={storageFileCopyPath}
-        isPanelOpen={isSecondaryPanelOpen}
-        lineRange={activeStorageFileLineRange}
-        markdownLinkRouting={storageMarkdownLinkRouting}
-        onOpenInEditor={handleOpenStorageFileInEditor}
-        onSelectionAddToChat={handleSelectionAddToChat}
-        threadId={thread.id}
-      />,
-    )
-  ) : activePluginPanelTab ? (
-    <ThreadTimelineNavigationProvider
-      environmentId={thread.environmentId}
-      onOpenLink={handleOpenTimelineLink}
-      onOpenLocalFileLink={handleOpenTimelineLocalFileLink}
-      resolveMentionLink={resolveMentionLink}
-      workspaceRootPath={environment?.path ?? undefined}
-    >
-      <PluginPanelTabContent
-        tab={activePluginPanelTab}
-        context={{ kind: "thread", threadId: thread.id }}
-      />
-    </ThreadTimelineNavigationProvider>
-  ) : undefined;
+  const renderSplitTabContent = (
+    tab: SecondaryFileFixedPanelTab,
+  ): ReactNode => {
+    switch (tab.kind) {
+      case "browser":
+        return null;
+      case "terminal":
+        return (
+          <LazyThreadTerminalPanel
+            autoFocus={
+              tab.id === activeFixedSecondaryTabId && shouldAutoFocusTerminal
+            }
+            canCreateTerminal={canCreateTerminal}
+            isPanelOpen={isSecondaryPanelOpen}
+            isPanelPersistedOpen={isPersistedSecondaryPanelOpen}
+            onAutoFocusHandled={handleTerminalAutoFocusHandled}
+            onOpenLink={handleOpenTimelineLink}
+            onSelectionAddToChat={handleSelectionAddToChat}
+            syncThreadId={thread.id}
+            target={{ kind: "thread", threadId: thread.id }}
+            terminalId={tab.terminalId}
+          />
+        );
+      case "new-tab":
+        return (
+          <LazyNewTabPage
+            autoFocus={
+              tab.id === activeFixedSecondaryTabId && shouldAutoFocusNewTab
+            }
+            projectId={projectId ?? undefined}
+            environmentId={thread.environmentId ?? null}
+            currentThreadId={thread.id}
+            onAutoFocusHandled={handleNewTabAutoFocusHandled}
+            onSelect={handleSelectFileSearchResult}
+            onOpenBrowser={handleOpenBrowser}
+            onStartTerminal={
+              canCreateTerminal ? handleStartTerminal : undefined
+            }
+            pluginActions={pluginPanelActions}
+          />
+        );
+      case "workspace-file-preview": {
+        const copyPath = resolveAbsoluteFilePath({
+          path: tab.path,
+          rootPath: workspacePreviewRootPath,
+        });
+        return (
+          <LazyWorkspaceFilePreviewTabContent
+            activePath={tab.path}
+            copyPath={copyPath}
+            environmentId={tab.environmentId}
+            isPanelOpen={isSecondaryPanelOpen}
+            lineRange={tab.lineRange}
+            markdownLinkRouting={buildMarkdownPreviewLinkRouting({
+              baseDir: copyPath
+                ? getAbsoluteDirname({ path: copyPath })
+                : undefined,
+              onOpenLink: handleOpenTimelineLink,
+              onOpenLocalFileLink: handleOpenTimelineLocalFileLink,
+              rootPath: workspacePreviewRootPath,
+            })}
+            onOpenInEditor={handleOpenFileInEditor}
+            onSelectionAddToChat={handleSelectionAddToChat}
+            source={tab.source}
+            statusLabel={tab.statusLabel}
+            threadId={thread.id}
+          />
+        );
+      }
+      case "host-file-preview": {
+        const baseDir = getAbsoluteDirname({ path: tab.path });
+        return (
+          <LazyHostFilePreviewTabContent
+            activePath={tab.path}
+            copyPath={tab.path}
+            environmentId={tab.environmentId}
+            isPanelOpen={isSecondaryPanelOpen}
+            lineRange={tab.lineRange}
+            markdownLinkRouting={buildMarkdownPreviewLinkRouting({
+              baseDir,
+              onOpenLink: handleOpenTimelineLink,
+              onOpenLocalFileLink: handleOpenTimelineLocalFileLink,
+              rootPath: resolveHostFilePreviewLinkRootPath({
+                baseDir,
+                threadStorageRootPath,
+                workspaceRootPath: workspacePreviewRootPath,
+              }),
+            })}
+            onOpenInEditor={handleOpenHostFileInEditor}
+            onSelectionAddToChat={handleSelectionAddToChat}
+            threadId={thread.id}
+          />
+        );
+      }
+      case "thread-storage-file-preview": {
+        const copyPath = resolveAbsoluteFilePath({
+          path: tab.path,
+          rootPath: threadStorageRootPath,
+        });
+        return (
+          <LazyThreadStorageFilePreviewTabContent
+            activePath={tab.path}
+            copyPath={copyPath}
+            isPanelOpen={isSecondaryPanelOpen}
+            lineRange={tab.lineRange}
+            markdownLinkRouting={buildMarkdownPreviewLinkRouting({
+              baseDir: copyPath
+                ? getAbsoluteDirname({ path: copyPath })
+                : undefined,
+              onOpenLink: handleOpenTimelineLink,
+              onOpenLocalFileLink: handleOpenTimelineLocalFileLink,
+              rootPath: threadStorageRootPath,
+            })}
+            onOpenInEditor={handleOpenStorageFileInEditor}
+            onSelectionAddToChat={handleSelectionAddToChat}
+            threadId={thread.id}
+          />
+        );
+      }
+      case "plugin-panel":
+        const fileOpenerOriginal =
+          tab.fileOpenerOwner === undefined
+            ? undefined
+            : renderSplitTabContent(
+                tab.fileOpenerOwner.kind === "workspace-file-preview"
+                  ? {
+                      ...tab.fileOpenerOwner.tab,
+                      environmentId: tab.fileOpenerOwner.environmentId,
+                      id: `${tab.id}:file-opener-original`,
+                      kind: "workspace-file-preview",
+                      projectId: tab.fileOpenerOwner.projectId,
+                    }
+                  : tab.fileOpenerOwner.kind === "host-file-preview"
+                    ? {
+                        ...tab.fileOpenerOwner.tab,
+                        environmentId: tab.fileOpenerOwner.environmentId,
+                        id: `${tab.id}:file-opener-original`,
+                        kind: "host-file-preview",
+                        threadId: tab.fileOpenerOwner.threadId,
+                      }
+                    : {
+                        ...tab.fileOpenerOwner.tab,
+                        environmentId: tab.fileOpenerOwner.environmentId,
+                        id: `${tab.id}:file-opener-original`,
+                        isPinned: false,
+                        kind: "thread-storage-file-preview",
+                        threadId: tab.fileOpenerOwner.threadId,
+                      },
+              );
+        return (
+          <ThreadTimelineNavigationProvider
+            environmentId={thread.environmentId}
+            onOpenLink={handleOpenTimelineLink}
+            onOpenLocalFileLink={handleOpenTimelineLocalFileLink}
+            resolveMentionLink={resolveMentionLink}
+            workspaceRootPath={environment?.path ?? undefined}
+          >
+            <PluginPanelTabContent
+              tab={tab}
+              context={{ kind: "thread", threadId: thread.id }}
+              fileOpenerOriginal={fileOpenerOriginal}
+            />
+          </ThreadTimelineNavigationProvider>
+        );
+    }
+  };
+  const activeFileTabModel = syncedOrderedSecondaryFileTabs.find(
+    (tab) => tab.id === activeFixedSecondaryTabId,
+  );
+  const fileTabContent = activeFileTabModel
+    ? renderSplitTabContent(activeFileTabModel)
+    : undefined;
   const isBrowserTabActive = activeBrowserTab !== null;
   const threadDetailContent = (
     <MarkdownLocalFileContextMenuContext.Provider
       value={getLocalFileContextMenuItems}
     >
+      <BrowserTabLifecycleObserver
+        browserTabs={browserTabs}
+        threadId={thread.id}
+      />
       <UrlOpenRoutingProvider
         openInAppBrowser={
           canOpenUrlsInAppBrowser ? openBrowserTabAndReveal : null
@@ -2882,6 +2889,16 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
                 (candidate) =>
                   candidate.pluginId === activePluginPanelTab.pluginId &&
                   candidate.id === activePluginPanelTab.actionId,
+              )?.layout === "flush",
+            splitPanelStateId: thread.id,
+            splitTabModels: syncedOrderedSecondaryFileTabs,
+            renderSplitTabContent,
+            splitTabContentFillsRegion: (tab) =>
+              tab.kind === "plugin-panel" &&
+              pluginThreadPanelActions.find(
+                (candidate) =>
+                  candidate.pluginId === tab.pluginId &&
+                  candidate.id === tab.actionId,
               )?.layout === "flush",
             renderBrowserDeck,
             isBrowserTabActive,

--- a/apps/desktop/src/desktop-browser-ipc.ts
+++ b/apps/desktop/src/desktop-browser-ipc.ts
@@ -12,11 +12,15 @@ export const BB_DESKTOP_BROWSER_GO_FORWARD_CHANNEL =
   "bb-desktop:browser:go-forward";
 export const BB_DESKTOP_BROWSER_RELOAD_CHANNEL = "bb-desktop:browser:reload";
 export const BB_DESKTOP_BROWSER_STOP_CHANNEL = "bb-desktop:browser:stop";
+export const BB_DESKTOP_BROWSER_FOCUS_CHANNEL = "bb-desktop:browser:focus";
 export const BB_DESKTOP_BROWSER_SET_BOUNDS_CHANNEL =
   "bb-desktop:browser:set-bounds";
 export const BB_DESKTOP_BROWSER_SET_VISIBLE_CHANNEL =
   "bb-desktop:browser:set-visible";
+export const BB_DESKTOP_BROWSER_SET_VISIBLE_WITHOUT_FOCUS_CHANNEL =
+  "bb-desktop:browser:set-visible-without-focus";
 export const BB_DESKTOP_BROWSER_STATE_CHANNEL = "bb-desktop:browser:state";
+export const BB_DESKTOP_BROWSER_FOCUSED_CHANNEL = "bb-desktop:browser:focused";
 export const BB_DESKTOP_BROWSER_OPEN_TAB_CHANNEL =
   "bb-desktop:browser:open-tab";
 export const BB_DESKTOP_BROWSER_SCOPED_OPEN_TAB_CHANNEL =

--- a/apps/desktop/src/desktop-browser-main-ipc.ts
+++ b/apps/desktop/src/desktop-browser-main-ipc.ts
@@ -11,6 +11,7 @@ import {
 import {
   BB_DESKTOP_BROWSER_ATTACH_CHANNEL,
   BB_DESKTOP_BROWSER_DETACH_CHANNEL,
+  BB_DESKTOP_BROWSER_FOCUS_CHANNEL,
   BB_DESKTOP_BROWSER_FIND_IN_PAGE_CHANNEL,
   BB_DESKTOP_BROWSER_GO_BACK_CHANNEL,
   BB_DESKTOP_BROWSER_GO_FORWARD_CHANNEL,
@@ -18,6 +19,7 @@ import {
   BB_DESKTOP_BROWSER_RELOAD_CHANNEL,
   BB_DESKTOP_BROWSER_SET_BOUNDS_CHANNEL,
   BB_DESKTOP_BROWSER_SET_VISIBLE_CHANNEL,
+  BB_DESKTOP_BROWSER_SET_VISIBLE_WITHOUT_FOCUS_CHANNEL,
   BB_DESKTOP_BROWSER_STOP_CHANNEL,
   BB_DESKTOP_BROWSER_STOP_FIND_IN_PAGE_CHANNEL,
 } from "./desktop-browser-ipc.js";
@@ -117,6 +119,21 @@ export function registerDesktopBrowserIpc(
   );
 
   ipcMain.on(
+    BB_DESKTOP_BROWSER_SET_VISIBLE_WITHOUT_FOCUS_CHANNEL,
+    (event, payload: unknown) => {
+      const hostWindow = hostWindowFromBrowserIpcEvent(event);
+      if (hostWindow === null) {
+        return;
+      }
+      const parsed = bbDesktopBrowserSetVisibleRequestSchema.safeParse(payload);
+      if (!parsed.success) {
+        return;
+      }
+      manager.setVisibleWithoutFocus({ hostWindow, request: parsed.data });
+    },
+  );
+
+  ipcMain.on(
     BB_DESKTOP_BROWSER_FIND_IN_PAGE_CHANNEL,
     (event, payload: unknown) => {
       const hostWindow = hostWindowFromBrowserIpcEvent(event);
@@ -150,6 +167,10 @@ export function registerDesktopBrowserIpc(
   registerTabCommand({
     channel: BB_DESKTOP_BROWSER_DETACH_CHANNEL,
     run: (args) => manager.detach(args),
+  });
+  registerTabCommand({
+    channel: BB_DESKTOP_BROWSER_FOCUS_CHANNEL,
+    run: (args) => manager.focus(args),
   });
   registerTabCommand({
     channel: BB_DESKTOP_BROWSER_GO_BACK_CHANNEL,

--- a/apps/desktop/src/desktop-browser-view.ts
+++ b/apps/desktop/src/desktop-browser-view.ts
@@ -13,6 +13,7 @@ import {
   type BbDesktopBrowserSetVisibleRequest,
   type BbDesktopBrowserSnapshot,
   type BbDesktopBrowserState,
+  type BbDesktopBrowserTabRef,
   type BbDesktopBrowserStopFindInPageRequest,
   type BbDesktopBrowserViewportBounds,
   type BbDesktopBrowserViewBounds,
@@ -21,6 +22,7 @@ import type { AppCommandId, AppShortcutInput } from "@bb/domain";
 import {
   BB_DESKTOP_BROWSER_FIND_RESULT_CHANNEL,
   BB_DESKTOP_BROWSER_OPEN_TAB_CHANNEL,
+  BB_DESKTOP_BROWSER_FOCUSED_CHANNEL,
   BB_DESKTOP_BROWSER_SCOPED_OPEN_TAB_CHANNEL,
   BB_DESKTOP_BROWSER_SNAPSHOT_CHANNEL,
   BB_DESKTOP_BROWSER_STATE_CHANNEL,
@@ -79,6 +81,7 @@ interface BrowserViewEntry {
   rendererRecoveryAttempts: number;
   rendererRecoveryState: "healthy" | "pending" | "blocked";
   rendererRecoveryTimer: ReturnType<typeof setTimeout> | null;
+  suppressNextFocusNotification: boolean;
   visible: boolean;
   /**
    * Request id of the latest `findInPage` call, or null when no find session
@@ -94,6 +97,7 @@ export type DesktopBrowserHostWebContentsPayload =
   | BbDesktopBrowserOpenTabRequest
   | BbDesktopBrowserScopedOpenTabRequest
   | BbDesktopBrowserSnapshot
+  | BbDesktopBrowserTabRef
   | BbDesktopBrowserFindResult;
 
 export interface DesktopBrowserHostContentBounds {
@@ -160,6 +164,7 @@ interface SetEntryDesiredBoundsArgs {
 export interface DesktopBrowserViewManager {
   attach(args: HostScopedRequestArgs<BbDesktopBrowserAttachRequest>): void;
   detach(args: HostScopedTabArgs): void;
+  focus(args: HostScopedTabArgs): void;
   navigate(args: HostScopedRequestArgs<BbDesktopBrowserNavigateRequest>): void;
   goBack(args: HostScopedTabArgs): void;
   goForward(args: HostScopedTabArgs): void;
@@ -169,6 +174,9 @@ export interface DesktopBrowserViewManager {
     args: HostScopedRequestArgs<BbDesktopBrowserSetBoundsRequest>,
   ): void;
   setVisible(
+    args: HostScopedRequestArgs<BbDesktopBrowserSetVisibleRequest>,
+  ): void;
+  setVisibleWithoutFocus(
     args: HostScopedRequestArgs<BbDesktopBrowserSetVisibleRequest>,
   ): void;
   /**
@@ -468,6 +476,14 @@ export function createDesktopBrowserViewManager(
   ): void {
     const webContents = entry.view.webContents;
 
+    webContents.on("focus", () => {
+      if (entry.suppressNextFocusNotification) {
+        entry.suppressNextFocusNotification = false;
+        return;
+      }
+      send(hostWindow, BB_DESKTOP_BROWSER_FOCUSED_CHANNEL, { tabId });
+    });
+
     webContents.on("before-input-event", (event, input) => {
       if (input.type !== "keyDown" || input.isAutoRepeat || input.isComposing) {
         return;
@@ -669,6 +685,7 @@ export function createDesktopBrowserViewManager(
       rendererRecoveryAttempts: 0,
       rendererRecoveryState: "healthy",
       rendererRecoveryTimer: null,
+      suppressNextFocusNotification: false,
       visible: false,
       activeFindRequestId: null,
     };
@@ -725,6 +742,52 @@ export function createDesktopBrowserViewManager(
     fn(entry);
   }
 
+  function hasOtherVisibleEntry(
+    hostWindow: DesktopBrowserHostWindow,
+    tabId: string,
+  ): boolean {
+    const hostPrefix = `${hostWindow.webContents.id}:`;
+    const currentKey = browserViewKey(hostWindow, tabId);
+    for (const [key, entry] of entries) {
+      if (key !== currentKey && key.startsWith(hostPrefix) && entry.visible) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function focusEntryWithoutNotifying(entry: BrowserViewEntry): void {
+    entry.suppressNextFocusNotification = true;
+    entry.view.webContents.focus();
+    setTimeout(() => {
+      entry.suppressNextFocusNotification = false;
+    }, 0);
+  }
+
+  function setEntryVisibility(
+    {
+      hostWindow,
+      request,
+    }: HostScopedRequestArgs<BbDesktopBrowserSetVisibleRequest>,
+    focusOnShow: boolean,
+  ): void {
+    withEntry({ hostWindow, tabId: request.tabId }, (entry) => {
+      const wasVisible = entry.visible;
+      entry.visible = request.visible;
+      applyEntryVisibility(entry, hostWindow);
+      scheduleEntryRendererRecovery(entry, hostWindow, request.tabId);
+      if (
+        focusOnShow &&
+        request.visible &&
+        !wasVisible &&
+        !hasOtherVisibleEntry(hostWindow, request.tabId) &&
+        !entry.view.webContents.isDestroyed()
+      ) {
+        focusEntryWithoutNotifying(entry);
+      }
+    });
+  }
+
   return {
     attach({ hostWindow, request }) {
       const key = browserViewKey(hostWindow, request.tabId);
@@ -747,15 +810,19 @@ export function createDesktopBrowserViewManager(
       if (
         request.visible &&
         !wasVisible &&
+        !hasOtherVisibleEntry(hostWindow, request.tabId) &&
         !entry.view.webContents.isDestroyed()
       ) {
-        entry.view.webContents.focus();
+        focusEntryWithoutNotifying(entry);
       }
       loadIfNeeded(entry, request.url);
       pushState(hostWindow, request.tabId);
     },
     detach({ hostWindow, tabId }) {
       destroyEntry(hostWindow, browserViewKey(hostWindow, tabId));
+    },
+    focus({ hostWindow, tabId }) {
+      withEntry({ hostWindow, tabId }, focusEntryWithoutNotifying);
     },
     navigate({ hostWindow, request }) {
       withEntry({ hostWindow, tabId: request.tabId }, (entry) => {
@@ -819,23 +886,10 @@ export function createDesktopBrowserViewManager(
       });
     },
     setVisible({ hostWindow, request }) {
-      withEntry({ hostWindow, tabId: request.tabId }, (entry) => {
-        const wasVisible = entry.visible;
-        entry.visible = request.visible;
-        applyEntryVisibility(entry, hostWindow);
-        scheduleEntryRendererRecovery(entry, hostWindow, request.tabId);
-        // Focus the view only on a real not-visible → visible transition so the
-        // Edit-menu copy/cut/paste roles and Cmd+C target this view's
-        // webContents (the focused one). Skip redundant re-syncs so we never
-        // yank focus away from the React address bar mid-interaction.
-        if (
-          request.visible &&
-          !wasVisible &&
-          !entry.view.webContents.isDestroyed()
-        ) {
-          entry.view.webContents.focus();
-        }
-      });
+      setEntryVisibility({ hostWindow, request }, true);
+    },
+    setVisibleWithoutFocus({ hostWindow, request }) {
+      setEntryVisibility({ hostWindow, request }, false);
     },
     beginWindowResize(hostWindow) {
       if (isHostResizing(hostWindow)) {

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -4,6 +4,7 @@ import {
   bbDesktopBrowserFindResultSchema,
   bbDesktopBrowserOpenTabRequestSchema,
   bbDesktopBrowserScopedOpenTabRequestSchema,
+  bbDesktopBrowserTabRefSchema,
   bbDesktopBrowserSnapshotSchema,
   bbDesktopBrowserStateSchema,
   bbDesktopInfoSchema,
@@ -14,6 +15,7 @@ import {
   type BbDesktopBrowserFindResultHandler,
   type BbDesktopBrowserOpenTabHandler,
   type BbDesktopBrowserScopedOpenTabHandler,
+  type BbDesktopBrowserFocusHandler,
   type BbDesktopBrowserSnapshotHandler,
   type BbDesktopBrowserStateHandler,
   type BbDesktopBrowserUnsubscribe,
@@ -38,6 +40,8 @@ import {
 import {
   BB_DESKTOP_BROWSER_ATTACH_CHANNEL,
   BB_DESKTOP_BROWSER_DETACH_CHANNEL,
+  BB_DESKTOP_BROWSER_FOCUS_CHANNEL,
+  BB_DESKTOP_BROWSER_FOCUSED_CHANNEL,
   BB_DESKTOP_BROWSER_FIND_IN_PAGE_CHANNEL,
   BB_DESKTOP_BROWSER_FIND_RESULT_CHANNEL,
   BB_DESKTOP_BROWSER_GO_BACK_CHANNEL,
@@ -48,6 +52,7 @@ import {
   BB_DESKTOP_BROWSER_SCOPED_OPEN_TAB_CHANNEL,
   BB_DESKTOP_BROWSER_SET_BOUNDS_CHANNEL,
   BB_DESKTOP_BROWSER_SET_VISIBLE_CHANNEL,
+  BB_DESKTOP_BROWSER_SET_VISIBLE_WITHOUT_FOCUS_CHANNEL,
   BB_DESKTOP_BROWSER_SNAPSHOT_CHANNEL,
   BB_DESKTOP_BROWSER_STATE_CHANNEL,
   BB_DESKTOP_BROWSER_STOP_CHANNEL,
@@ -165,9 +170,9 @@ const browserStateListeners = new Set<BbDesktopBrowserStateHandler>();
 const browserOpenTabListeners = new Set<BbDesktopBrowserOpenTabHandler>();
 const browserScopedOpenTabListeners =
   new Set<BbDesktopBrowserScopedOpenTabHandler>();
+const browserFocusListeners = new Set<BbDesktopBrowserFocusHandler>();
 const browserSnapshotListeners = new Set<BbDesktopBrowserSnapshotHandler>();
-const browserFindResultListeners =
-  new Set<BbDesktopBrowserFindResultHandler>();
+const browserFindResultListeners = new Set<BbDesktopBrowserFindResultHandler>();
 const closeWindowRequestListeners =
   new Set<BbDesktopCloseWindowRequestHandler>();
 const openNewTabListeners = new Set<BbDesktopOpenNewTabHandler>();
@@ -242,6 +247,9 @@ const bbBrowserApi: BbDesktopBrowserApi = {
   stop(tabId): void {
     ipcRenderer.send(BB_DESKTOP_BROWSER_STOP_CHANNEL, { tabId });
   },
+  focus(tabId): void {
+    ipcRenderer.send(BB_DESKTOP_BROWSER_FOCUS_CHANNEL, { tabId });
+  },
   setBounds(request): void {
     ipcRenderer.send(BB_DESKTOP_BROWSER_SET_BOUNDS_CHANNEL, {
       ...request,
@@ -250,6 +258,12 @@ const bbBrowserApi: BbDesktopBrowserApi = {
   },
   setVisible(request): void {
     ipcRenderer.send(BB_DESKTOP_BROWSER_SET_VISIBLE_CHANNEL, request);
+  },
+  setVisibleWithoutFocus(request): void {
+    ipcRenderer.send(
+      BB_DESKTOP_BROWSER_SET_VISIBLE_WITHOUT_FOCUS_CHANNEL,
+      request,
+    );
   },
   onState(listener): BbDesktopBrowserUnsubscribe {
     browserStateListeners.add(listener);
@@ -267,6 +281,12 @@ const bbBrowserApi: BbDesktopBrowserApi = {
     browserScopedOpenTabListeners.add(listener);
     return () => {
       browserScopedOpenTabListeners.delete(listener);
+    };
+  },
+  onFocus(listener): BbDesktopBrowserUnsubscribe {
+    browserFocusListeners.add(listener);
+    return () => {
+      browserFocusListeners.delete(listener);
     };
   },
   onSnapshot(listener): BbDesktopBrowserUnsubscribe {
@@ -404,6 +424,19 @@ ipcRenderer.on(BB_DESKTOP_BROWSER_STATE_CHANNEL, (_event, payload: unknown) => {
     listener(parsed.data);
   }
 });
+
+ipcRenderer.on(
+  BB_DESKTOP_BROWSER_FOCUSED_CHANNEL,
+  (_event, payload: unknown) => {
+    const parsed = bbDesktopBrowserTabRefSchema.safeParse(payload);
+    if (!parsed.success) {
+      return;
+    }
+    for (const listener of browserFocusListeners) {
+      listener(parsed.data.tabId);
+    }
+  },
+);
 
 ipcRenderer.on(
   BB_DESKTOP_BROWSER_OPEN_TAB_CHANNEL,

--- a/apps/desktop/test/desktop-browser-main-ipc.test.ts
+++ b/apps/desktop/test/desktop-browser-main-ipc.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   BB_DESKTOP_BROWSER_ATTACH_CHANNEL,
   BB_DESKTOP_BROWSER_DETACH_CHANNEL,
+  BB_DESKTOP_BROWSER_FOCUS_CHANNEL,
   BB_DESKTOP_BROWSER_FIND_IN_PAGE_CHANNEL,
   BB_DESKTOP_BROWSER_GO_BACK_CHANNEL,
   BB_DESKTOP_BROWSER_GO_FORWARD_CHANNEL,
@@ -18,6 +19,7 @@ import {
   BB_DESKTOP_BROWSER_RELOAD_CHANNEL,
   BB_DESKTOP_BROWSER_SET_BOUNDS_CHANNEL,
   BB_DESKTOP_BROWSER_SET_VISIBLE_CHANNEL,
+  BB_DESKTOP_BROWSER_SET_VISIBLE_WITHOUT_FOCUS_CHANNEL,
   BB_DESKTOP_BROWSER_STOP_CHANNEL,
   BB_DESKTOP_BROWSER_STOP_FIND_IN_PAGE_CHANNEL,
 } from "../src/desktop-browser-ipc.js";
@@ -102,6 +104,7 @@ class RecordingDesktopBrowserViewManager implements DesktopBrowserViewManager {
   public readonly destroyAllCalls: string[] = [];
   public readonly detachCalls: DetachCall[] = [];
   public readonly endWindowResizeCalls: WindowResizeCall[] = [];
+  public readonly focusCalls: TabCommandCall[] = [];
   public readonly findInPageCalls: FindInPageCall[] = [];
   public readonly stopFindInPageCalls: StopFindInPageCall[] = [];
   public readonly goBackCalls: TabCommandCall[] = [];
@@ -111,6 +114,7 @@ class RecordingDesktopBrowserViewManager implements DesktopBrowserViewManager {
   public readonly reloadCalls: TabCommandCall[] = [];
   public readonly setBoundsCalls: SetBoundsCall[] = [];
   public readonly setVisibleCalls: SetVisibleCall[] = [];
+  public readonly setVisibleWithoutFocusCalls: SetVisibleCall[] = [];
   public readonly stopCalls: TabCommandCall[] = [];
 
   attach(args: AttachCall): void {
@@ -131,6 +135,10 @@ class RecordingDesktopBrowserViewManager implements DesktopBrowserViewManager {
 
   endWindowResize(hostWindow: WindowResizeCall): void {
     this.endWindowResizeCalls.push(hostWindow);
+  }
+
+  focus(args: TabCommandCall): void {
+    this.focusCalls.push(args);
   }
 
   findInPage(args: FindInPageCall): void {
@@ -167,6 +175,10 @@ class RecordingDesktopBrowserViewManager implements DesktopBrowserViewManager {
 
   setVisible(args: SetVisibleCall): void {
     this.setVisibleCalls.push(args);
+  }
+
+  setVisibleWithoutFocus(args: SetVisibleCall): void {
+    this.setVisibleWithoutFocusCalls.push(args);
   }
 
   stop(args: TabCommandCall): void {
@@ -246,6 +258,11 @@ describe("registerDesktopBrowserIpc", () => {
       payload: { tabId: "browser:a" },
       sender: renderer.sender,
     });
+    sendBrowserIpc({
+      channel: BB_DESKTOP_BROWSER_FOCUS_CHANNEL,
+      payload: { tabId: "browser:a" },
+      sender: renderer.sender,
+    });
 
     expect(manager.attachCalls).toHaveLength(1);
     expect(manager.attachCalls[0]?.hostWindow).toBe(renderer.hostWindow);
@@ -254,6 +271,9 @@ describe("registerDesktopBrowserIpc", () => {
     expect(manager.navigateCalls[0]?.hostWindow).toBe(renderer.hostWindow);
     expect(manager.navigateCalls[0]?.request).toEqual(navigateRequest);
     expect(manager.reloadCalls).toEqual([
+      { hostWindow: renderer.hostWindow, tabId: "browser:a" },
+    ]);
+    expect(manager.focusCalls).toEqual([
       { hostWindow: renderer.hostWindow, tabId: "browser:a" },
     ]);
   });
@@ -388,6 +408,11 @@ describe("registerDesktopBrowserIpc", () => {
       sender: renderer.sender,
     });
     sendBrowserIpc({
+      channel: BB_DESKTOP_BROWSER_SET_VISIBLE_WITHOUT_FOCUS_CHANNEL,
+      payload: visibleRequest,
+      sender: renderer.sender,
+    });
+    sendBrowserIpc({
       channel: BB_DESKTOP_BROWSER_SET_VISIBLE_CHANNEL,
       payload: visibleRequest,
       sender: renderer.sender,
@@ -395,6 +420,7 @@ describe("registerDesktopBrowserIpc", () => {
 
     for (const channel of [
       BB_DESKTOP_BROWSER_DETACH_CHANNEL,
+      BB_DESKTOP_BROWSER_FOCUS_CHANNEL,
       BB_DESKTOP_BROWSER_GO_BACK_CHANNEL,
       BB_DESKTOP_BROWSER_GO_FORWARD_CHANNEL,
       BB_DESKTOP_BROWSER_RELOAD_CHANNEL,
@@ -432,6 +458,9 @@ describe("registerDesktopBrowserIpc", () => {
       { hostWindow: renderer.hostWindow, request: boundsRequest },
     ]);
     expect(manager.setVisibleCalls).toEqual([
+      { hostWindow: renderer.hostWindow, request: visibleRequest },
+    ]);
+    expect(manager.setVisibleWithoutFocusCalls).toEqual([
       { hostWindow: renderer.hostWindow, request: visibleRequest },
     ]);
     expect(manager.detachCalls).toEqual([

--- a/apps/desktop/test/desktop-browser-view-manager.test.ts
+++ b/apps/desktop/test/desktop-browser-view-manager.test.ts
@@ -133,6 +133,7 @@ interface FakeFindInPageCall {
 }
 
 interface FakeWebContentsEventMap {
+  focus: FakeVoidWebContentsListener;
   "before-input-event": FakeBeforeInputListener;
   "will-frame-navigate": FakeWillFrameNavigateListener;
   "will-navigate": FakeWillNavigateListener;
@@ -260,6 +261,7 @@ const electronMock = vi.hoisted(() => {
       (image: FakeNativeImage) => void
     > = [];
     private readonly listeners: FakeWebContentsListeners = {
+      focus: [],
       "before-input-event": [],
       "will-frame-navigate": [],
       "will-navigate": [],
@@ -310,6 +312,7 @@ const electronMock = vi.hoisted(() => {
 
     focus(): void {
       this.focusCalls += 1;
+      this.emitFocus();
     }
 
     findInPage(
@@ -379,6 +382,10 @@ const electronMock = vi.hoisted(() => {
           args.isMainFrame,
         );
       }
+    }
+
+    emitFocus(): void {
+      for (const listener of this.listeners.focus) listener();
     }
 
     emitRenderProcessGone(details: FakeRenderProcessGoneDetails): void {
@@ -546,6 +553,7 @@ interface FakeHostWindowArgs {
 class FakeHostWebContents implements DesktopBrowserHostWebContents {
   public destroyed = false;
   public readonly sentPayloads: DesktopBrowserHostWebContentsPayload[] = [];
+  public readonly sentChannels: string[] = [];
   public readonly id: number;
 
   constructor(id: number) {
@@ -556,7 +564,8 @@ class FakeHostWebContents implements DesktopBrowserHostWebContents {
     return this.destroyed;
   }
 
-  send(_channel: string, payload: DesktopBrowserHostWebContentsPayload): void {
+  send(channel: string, payload: DesktopBrowserHostWebContentsPayload): void {
+    this.sentChannels.push(channel);
     this.sentPayloads.push(payload);
   }
 }
@@ -1280,6 +1289,43 @@ describe("DesktopBrowserViewManager", () => {
     expect(view.webContents.focusCalls).toBe(1);
   });
 
+  it("reports user focus but suppresses programmatic focus used for restoration", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 700, height: 450 },
+      webContentsId: 79,
+    });
+
+    manager.attach({
+      hostWindow,
+      request: {
+        tabId: "browser:a",
+        url: "https://example.com",
+        bounds: { x: 100, y: 50, width: 500, height: 350 },
+        visible: true,
+      },
+    });
+    const view = requireFakeView(0);
+    expect(hostWindow.webContents.sentChannels).not.toContain(
+      "bb-desktop:browser:focused",
+    );
+
+    manager.focus({ hostWindow, tabId: "browser:a" });
+    expect(hostWindow.webContents.sentChannels).not.toContain(
+      "bb-desktop:browser:focused",
+    );
+
+    view.webContents.emitFocus();
+    expect(hostWindow.webContents.sentChannels).toContain(
+      "bb-desktop:browser:focused",
+    );
+    expect(hostWindow.webContents.sentPayloads.at(-1)).toEqual({
+      tabId: "browser:a",
+    });
+  });
+
   it("defers hidden memory-eviction recovery until the panel shows the current page", () => {
     vi.useFakeTimers();
     const { hostWindow, manager, view } = createRendererRecoveryFixture(75);
@@ -1469,6 +1515,119 @@ describe("DesktopBrowserViewManager", () => {
       request: { tabId: "browser:a", visible: true },
     });
     expect(view.webContents.focusCalls).toBe(2);
+  });
+
+  it("does not let an unfocused split view steal focus on mount or restore", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 900, height: 600 },
+      webContentsId: 80,
+    });
+
+    for (const [tabId, x] of [
+      ["browser:focused", 0],
+      ["browser:sibling", 450],
+    ] as const) {
+      manager.attach({
+        hostWindow,
+        request: {
+          tabId,
+          url: `https://example.com/${tabId}`,
+          bounds: { x, y: 0, width: 450, height: 600 },
+          visible: true,
+        },
+      });
+    }
+    const focusedView = requireFakeView(0);
+    const siblingView = requireFakeView(1);
+    expect(focusedView.webContents.focusCalls).toBe(1);
+    expect(siblingView.webContents.focusCalls).toBe(0);
+
+    manager.setVisible({
+      hostWindow,
+      request: { tabId: "browser:sibling", visible: false },
+    });
+    manager.setVisible({
+      hostWindow,
+      request: { tabId: "browser:sibling", visible: true },
+    });
+
+    expect(focusedView.webContents.focusCalls).toBe(1);
+    expect(siblingView.webContents.focusCalls).toBe(0);
+  });
+
+  it("shows a browser beside a focused non-browser pane without stealing focus", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 900, height: 600 },
+      webContentsId: 82,
+    });
+
+    manager.attach({
+      hostWindow,
+      request: {
+        tabId: "browser:sibling",
+        url: "https://example.com/browser",
+        bounds: { x: 450, y: 0, width: 450, height: 600 },
+        visible: false,
+      },
+    });
+    const browserView = requireFakeView(0);
+
+    manager.setVisibleWithoutFocus({
+      hostWindow,
+      request: { tabId: "browser:sibling", visible: true },
+    });
+    expect(browserView.visible).toBe(true);
+    expect(browserView.webContents.focusCalls).toBe(0);
+
+    manager.setVisibleWithoutFocus({
+      hostWindow,
+      request: { tabId: "browser:sibling", visible: false },
+    });
+    manager.setVisibleWithoutFocus({
+      hostWindow,
+      request: { tabId: "browser:sibling", visible: true },
+    });
+    expect(browserView.visible).toBe(true);
+    expect(browserView.webContents.focusCalls).toBe(0);
+  });
+
+  it("lets logical focus override first-visible mount order", () => {
+    const manager = createDesktopBrowserViewManager({
+      partition: "persist:test",
+    });
+    const hostWindow = new FakeHostWindow({
+      contentBounds: { width: 900, height: 600 },
+      webContentsId: 81,
+    });
+
+    for (const [tabId, x] of [
+      ["browser:sibling", 0],
+      ["browser:focused", 450],
+    ] as const) {
+      manager.attach({
+        hostWindow,
+        request: {
+          tabId,
+          url: `https://example.com/${tabId}`,
+          bounds: { x, y: 0, width: 450, height: 600 },
+          visible: true,
+        },
+      });
+    }
+    const siblingView = requireFakeView(0);
+    const focusedView = requireFakeView(1);
+    expect(siblingView.webContents.focusCalls).toBe(1);
+    expect(focusedView.webContents.focusCalls).toBe(0);
+
+    manager.focus({ hostWindow, tabId: "browser:focused" });
+
+    expect(focusedView.webContents.focusCalls).toBe(1);
   });
 
   it("allows clipboard-sanitized-write but denies clipboard-read and device permissions", () => {

--- a/apps/desktop/test/preload-browser-api.test.ts
+++ b/apps/desktop/test/preload-browser-api.test.ts
@@ -19,6 +19,8 @@ import {
 import {
   BB_DESKTOP_BROWSER_ATTACH_CHANNEL,
   BB_DESKTOP_BROWSER_DETACH_CHANNEL,
+  BB_DESKTOP_BROWSER_FOCUS_CHANNEL,
+  BB_DESKTOP_BROWSER_FOCUSED_CHANNEL,
   BB_DESKTOP_BROWSER_FIND_IN_PAGE_CHANNEL,
   BB_DESKTOP_BROWSER_FIND_RESULT_CHANNEL,
   BB_DESKTOP_BROWSER_GO_BACK_CHANNEL,
@@ -29,6 +31,7 @@ import {
   BB_DESKTOP_BROWSER_SCOPED_OPEN_TAB_CHANNEL,
   BB_DESKTOP_BROWSER_SET_BOUNDS_CHANNEL,
   BB_DESKTOP_BROWSER_SET_VISIBLE_CHANNEL,
+  BB_DESKTOP_BROWSER_SET_VISIBLE_WITHOUT_FOCUS_CHANNEL,
   BB_DESKTOP_BROWSER_SNAPSHOT_CHANNEL,
   BB_DESKTOP_BROWSER_STATE_CHANNEL,
   BB_DESKTOP_BROWSER_STOP_CHANNEL,
@@ -242,10 +245,12 @@ describe("desktop preload browser API", () => {
       "attach",
       "detach",
       "findInPage",
+      "focus",
       "goBack",
       "goForward",
       "navigate",
       "onFindResult",
+      "onFocus",
       "onOpenTab",
       "onScopedOpenTab",
       "onSnapshot",
@@ -253,6 +258,7 @@ describe("desktop preload browser API", () => {
       "reload",
       "setBounds",
       "setVisible",
+      "setVisibleWithoutFocus",
       "stop",
       "stopFindInPage",
     ]);
@@ -266,8 +272,10 @@ describe("desktop preload browser API", () => {
     api.browser.goForward("browser:a");
     api.browser.reload("browser:a");
     api.browser.stop("browser:a");
+    api.browser.focus?.("browser:a");
     api.browser.setBounds(boundsRequest);
     api.browser.setVisible(visibleRequest);
+    api.browser.setVisibleWithoutFocus?.(visibleRequest);
     api.browser.findInPage?.(findRequest);
     api.browser.stopFindInPage?.(stopFindRequest);
     api.setTheme("dark");
@@ -304,11 +312,19 @@ describe("desktop preload browser API", () => {
         payload: { tabId: "browser:a" },
       },
       {
+        channel: BB_DESKTOP_BROWSER_FOCUS_CHANNEL,
+        payload: { tabId: "browser:a" },
+      },
+      {
         channel: BB_DESKTOP_BROWSER_SET_BOUNDS_CHANNEL,
         payload: boundsRequest,
       },
       {
         channel: BB_DESKTOP_BROWSER_SET_VISIBLE_CHANNEL,
+        payload: visibleRequest,
+      },
+      {
+        channel: BB_DESKTOP_BROWSER_SET_VISIBLE_WITHOUT_FOCUS_CHANNEL,
         payload: visibleRequest,
       },
       {
@@ -373,6 +389,7 @@ describe("desktop preload browser API", () => {
     const states: BbDesktopBrowserState[] = [];
     const openTabs: BbDesktopBrowserOpenTabRequest[] = [];
     const scopedOpenTabs: BbDesktopBrowserScopedOpenTabRequest[] = [];
+    const focusedTabs: string[] = [];
     const snapshots: BbDesktopBrowserSnapshot[] = [];
     const findResults: BbDesktopBrowserFindResult[] = [];
     let closeWindowRequestCount = 0;
@@ -416,6 +433,9 @@ describe("desktop preload browser API", () => {
     api.browser.onScopedOpenTab?.((request) => {
       scopedOpenTabs.push(request);
     });
+    api.browser.onFocus?.((tabId) => {
+      focusedTabs.push(tabId);
+    });
     api.browser.onSnapshot?.((nextSnapshot) => {
       snapshots.push(nextSnapshot);
     });
@@ -449,6 +469,10 @@ describe("desktop preload browser API", () => {
       payload: { tabId: "", url: "https://example.com/scoped-popup" },
     });
     emitIpcPayload({
+      channel: BB_DESKTOP_BROWSER_FOCUSED_CHANNEL,
+      payload: { tabId: "", extra: true },
+    });
+    emitIpcPayload({
       channel: BB_DESKTOP_BROWSER_SNAPSHOT_CHANNEL,
       payload: { tabId: "browser:a", dataUrl: 42 },
     });
@@ -475,6 +499,10 @@ describe("desktop preload browser API", () => {
     emitIpcPayload({
       channel: BB_DESKTOP_BROWSER_SCOPED_OPEN_TAB_CHANNEL,
       payload: scopedOpenTab,
+    });
+    emitIpcPayload({
+      channel: BB_DESKTOP_BROWSER_FOCUSED_CHANNEL,
+      payload: { tabId: "browser:a" },
     });
     emitIpcPayload({
       channel: BB_DESKTOP_BROWSER_SNAPSHOT_CHANNEL,
@@ -508,6 +536,7 @@ describe("desktop preload browser API", () => {
     expect(states).toEqual([state]);
     expect(openTabs).toEqual([openTab]);
     expect(scopedOpenTabs).toEqual([scopedOpenTab]);
+    expect(focusedTabs).toEqual(["browser:a"]);
     expect(snapshots).toEqual([snapshot]);
     expect(findResults).toEqual([findResult]);
     expect(windowStates).toEqual([{ isFullScreen: true }]);

--- a/packages/desktop-contract/src/browser.ts
+++ b/packages/desktop-contract/src/browser.ts
@@ -148,6 +148,9 @@ export const bbDesktopBrowserTabRefSchema = z
     tabId: z.string().min(1),
   })
   .strict();
+export type BbDesktopBrowserTabRef = z.infer<
+  typeof bbDesktopBrowserTabRefSchema
+>;
 
 /**
  * Current navigation state of a browser view, pushed main → renderer on every
@@ -288,6 +291,7 @@ export type BbDesktopBrowserScopedOpenTabHandler = (
 export type BbDesktopBrowserSnapshotHandler = (
   snapshot: BbDesktopBrowserSnapshot,
 ) => void;
+export type BbDesktopBrowserFocusHandler = (tabId: string) => void;
 export type BbDesktopBrowserFindResultHandler = (
   result: BbDesktopBrowserFindResult,
 ) => void;
@@ -303,8 +307,15 @@ export interface BbDesktopBrowserApi {
   goForward(tabId: string): void;
   reload(tabId: string): void;
   stop(tabId: string): void;
+  /** Focus a visible view without treating that programmatic focus as a page click. */
+  focus?(tabId: string): void;
   setBounds(request: BbDesktopBrowserSetBoundsRequest): void;
   setVisible(request: BbDesktopBrowserSetVisibleRequest): void;
+  /**
+   * Set visibility without moving native keyboard focus. Optional for version
+   * skew; split panes use it for visible browser siblings that do not own focus.
+   */
+  setVisibleWithoutFocus?(request: BbDesktopBrowserSetVisibleRequest): void;
   /** Subscribe to navigation-state pushes for every view in this window. */
   onState(listener: BbDesktopBrowserStateHandler): BbDesktopBrowserUnsubscribe;
   /** Subscribe to popup requests that should open as a new in-panel browser tab. */
@@ -318,6 +329,11 @@ export interface BbDesktopBrowserApi {
   onScopedOpenTab?(
     listener: BbDesktopBrowserScopedOpenTabHandler,
   ): BbDesktopBrowserUnsubscribe;
+  /**
+   * Subscribe to user-driven focus entering a native browser page. Optional
+   * for version skew with desktop shells that predate split browser panes.
+   */
+  onFocus?(listener: BbDesktopBrowserFocusHandler): BbDesktopBrowserUnsubscribe;
   /**
    * Subscribe to resize-burst snapshot pushes. Optional purely for version
    * skew: the SPA routinely attaches to an older desktop shell whose preload


### PR DESCRIPTION
## What was wrong

The thread right panel could show only one active tab at a time, so comparing or retaining multiple panel contexts required repeated tab switching. Its existing full-screen control had no way to position the active tab in a sidebar split. This is the foundation for #1841.

## What changed

- Added a persisted right-panel split layout that targets the active tab and reuses the existing pane arrangement model and controls.
- Kept the existing right-panel header, tab behaviors, outer width resizer, collapse control, and full-screen behavior.
- Added pane-local content and browser focus/lifecycle handling so visible split tabs retain the same panel semantics as the unsplit view.
- Added focused coverage for split creation, positioning, resizing, tab movement, persistence, browser focus, and panel lifecycle.

## How you verified

- `pnpm exec vitest run apps/app/src/components/secondary-panel/BrowserTabDeck.browser-view-ordering.test.tsx apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx apps/app/src/components/thread/terminal/useThreadTerminalController.test.ts apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx apps/app/src/views/thread-detail/SplitThreadArea.test.tsx` — 66 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Exact-head visual QA used the same deterministic `Sidebar Split QA` fixture in the launched bb desktop dev app. Captures are clipped to the rendered viewport so no off-viewport renderer content is included. Each caption records viewport and output dimensions.

### Before — `origin/main` `5f4f3dec733612fcf23defd8ac17c22462715e9d`

Viewport 1440 × 900 at DPR 2; image 2880 × 1800.

![Before: unsplit right sidebar on origin main](https://raw.githubusercontent.com/get-bb/bb/8d3314daca1b3f6fdf91dfa960aa6ba1f0c74e59/.github/pr-evidence/1841/legible-final-head-5f4/foundation-before-main-5f4f3dec7-1440x900-2x.png)

### After — foundation `3ad3d0f6c36b0b9b581360d0ca56d1c342b2b1a3`

Viewport 1440 × 900 at DPR 2; image 2880 × 1800. Browser and Side chat occupy separate sidebar panes under the existing header.

![After: Browser and Side chat split side by side](https://raw.githubusercontent.com/get-bb/bb/8d3314daca1b3f6fdf91dfa960aa6ba1f0c74e59/.github/pr-evidence/1841/legible-final-head-5f4/foundation-after-3ad3d0f6c-1440x900-2x.png)

## Exact-head screenshot matrix — `3ad3d0f6c36b0b9b581360d0ca56d1c342b2b1a3`

All captures use the same `Sidebar Split QA` project and `Primary split QA` / `Secondary split QA` threads in the exact-head desktop dev app.

### Page-split configurations

#### Wide — side-by-side thread pages

Viewport 1630 × 900 at DPR 2; image 3260 × 1800.

![Page split with primary and secondary threads side by side](https://raw.githubusercontent.com/get-bb/bb/8d3314daca1b3f6fdf91dfa960aa6ba1f0c74e59/.github/pr-evidence/1841/legible-final-head-5f4/page-wide-3ad3d0f6c-1630x900-2x.png)

#### Medium — stacked thread pages

Viewport 1224 × 768 at DPR 2; image 2448 × 1536.

![Page split with primary above secondary](https://raw.githubusercontent.com/get-bb/bb/8d3314daca1b3f6fdf91dfa960aa6ba1f0c74e59/.github/pr-evidence/1841/legible-final-head-5f4/page-medium-3ad3d0f6c-1224x768-2x.png)

#### Compact — stacked thread pages

Viewport 768 × 900 at DPR 2; image 1536 × 1800.

![Compact page split with primary above secondary](https://raw.githubusercontent.com/get-bb/bb/8d3314daca1b3f6fdf91dfa960aa6ba1f0c74e59/.github/pr-evidence/1841/legible-final-head-5f4/page-compact-3ad3d0f6c-768x900-2x.png)

### Tab-split configurations

#### Wide — Browser and Side chat side by side

Viewport 1630 × 900 at DPR 2; image 3260 × 1800.

![Wide right-sidebar tab split with Browser and Side chat](https://raw.githubusercontent.com/get-bb/bb/8d3314daca1b3f6fdf91dfa960aa6ba1f0c74e59/.github/pr-evidence/1841/legible-final-head-5f4/tabs-wide-3ad3d0f6c-1630x900-2x.png)

#### Medium — Browser and Side chat side by side

Viewport 1224 × 768 at DPR 2; image 2448 × 1536.

![Medium right-sidebar tab split with Browser and Side chat](https://raw.githubusercontent.com/get-bb/bb/8d3314daca1b3f6fdf91dfa960aa6ba1f0c74e59/.github/pr-evidence/1841/legible-final-head-5f4/tabs-medium-3ad3d0f6c-1224x768-2x.png)

#### Compact — full-screen right panel

Viewport 1024 × 900 at DPR 2; image 2048 × 1800. Uses the existing Full Screen control so both split-tab labels and bodies remain legible under compact width pressure.

![Compact full-screen right panel with Browser and Side chat split panes](https://raw.githubusercontent.com/get-bb/bb/8d3314daca1b3f6fdf91dfa960aa6ba1f0c74e59/.github/pr-evidence/1841/legible-final-head-5f4/tabs-compact-fullscreen-3ad3d0f6c-1024x900-2x.png)

#### Ultra-wide — Browser and Side chat side by side

Viewport 3440 × 1440 at DPR 1; image 3440 × 1440.

![Ultra-wide right-sidebar tab split](https://raw.githubusercontent.com/get-bb/bb/8d3314daca1b3f6fdf91dfa960aa6ba1f0c74e59/.github/pr-evidence/1841/legible-final-head-5f4/tabs-very-large-3ad3d0f6c-3440x1440-1x.png)

Fixes #1841

BB-Thread-ID: thr_4rr623umv4

> AGENT GENERATED: by GPT-5
