### PR TITLE
Avoid unsolicited local network prompt in bb connect

### DIFF
--- a/apps/app/src/components/secondary-panel/BrowserTabContent.tsx
+++ b/apps/app/src/components/secondary-panel/BrowserTabContent.tsx
@@ -45,6 +45,7 @@ import {
 } from "@/components/commands/AppCommandProvider";
 import type { AppShortcutPresentation } from "@/lib/app-keybindings";
 import { CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS } from "@/components/ui/chromeStyleTokens";
+import { isLoopbackHostname } from "@/lib/loopback-hostname";
 
 export interface BrowserTabContentProps {
   tabId: string;
@@ -181,13 +182,7 @@ function browserViewBoundsEqual(args: BrowserViewBoundsEqualArgs): boolean {
 
 function isLocalBrowserUrl(url: string): boolean {
   try {
-    const hostname = new URL(url).hostname.toLowerCase();
-    return (
-      hostname === "localhost" ||
-      hostname.endsWith(".localhost") ||
-      hostname === "::1" ||
-      hostname.startsWith("127.")
-    );
+    return isLoopbackHostname(new URL(url).hostname);
   } catch {
     return false;
   }

--- a/apps/app/src/components/settings/settings-nav.test.tsx
+++ b/apps/app/src/components/settings/settings-nav.test.tsx
@@ -8,8 +8,13 @@ import { resetPluginSlotStoreForTest } from "@/lib/plugin-slots";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { useSettingsNavState } from "./settings-nav";
 
+const mocks = vi.hoisted(() => ({
+  accessState: "unavailable",
+}));
+
 vi.mock("@/hooks/useHostDaemon", () => ({
   useHostDaemon: () => ({ hasDaemon: false }),
+  useLocalHostDaemonAccess: () => ({ accessState: mocks.accessState }),
 }));
 
 function wrapperFor(path: string) {
@@ -26,6 +31,7 @@ function wrapperFor(path: string) {
 afterEach(() => {
   cleanup();
   resetPluginSlotStoreForTest();
+  mocks.accessState = "unavailable";
 });
 
 describe("useSettingsNavState", () => {
@@ -48,6 +54,17 @@ describe("useSettingsNavState", () => {
 
     expect(result.current.sections.map((section) => section.id)).toContain(
       "machines",
+    );
+  });
+
+  it("shows Files when local helper access can be enabled", () => {
+    mocks.accessState = "permission-required";
+    const { result } = renderHook(() => useSettingsNavState(), {
+      wrapper: wrapperFor("/settings/files"),
+    });
+
+    expect(result.current.sections.map((section) => section.id)).toContain(
+      "files",
     );
   });
 

--- a/apps/app/src/components/settings/settings-nav.tsx
+++ b/apps/app/src/components/settings/settings-nav.tsx
@@ -1,6 +1,6 @@
 import { matchPath, useLocation } from "react-router-dom";
 import type { IconName } from "@bb/shared-ui/icon";
-import { useHostDaemon } from "@/hooks/useHostDaemon";
+import { useHostDaemon, useLocalHostDaemonAccess } from "@/hooks/useHostDaemon";
 import { usePluginSlots } from "@/lib/plugin-slots";
 import { usePluginList } from "@/hooks/queries/plugin-settings-queries";
 import {
@@ -77,6 +77,7 @@ export interface SettingsNavState {
 export function useSettingsNavState(): SettingsNavState {
   const location = useLocation();
   const { hasDaemon } = useHostDaemon();
+  const { accessState } = useLocalHostDaemonAccess();
   const { fileOpeners, settingsSections } = usePluginSlots();
   const pluginListQuery = usePluginList({ enabled: true });
 
@@ -117,7 +118,9 @@ export function useSettingsNavState(): SettingsNavState {
 
   const sections = SETTINGS_NAV_SECTIONS.filter((section) => {
     if (section.id === "files") {
-      return hasDaemon || fileOpeners.length > 0;
+      return (
+        hasDaemon || accessState !== "unavailable" || fileOpeners.length > 0
+      );
     }
     return true;
   });

--- a/apps/app/src/components/ui/settings-section.tsx
+++ b/apps/app/src/components/ui/settings-section.tsx
@@ -69,7 +69,7 @@ export function SettingsRow({ children, className }: SettingsRowProps) {
 export interface SettingsWithControlProps {
   label: string;
   labelBadge?: string;
-  description?: string;
+  description?: ReactNode;
   children: ReactNode;
 }
 

--- a/apps/app/src/hooks/useHostDaemon.ts
+++ b/apps/app/src/hooks/useHostDaemon.ts
@@ -1,9 +1,12 @@
 import { useCallback } from "react";
+import { useSetAtom } from "jotai";
 import {
+  localHostDaemonAccessStateAtom,
   localHostDaemonHostIdAtom,
   localHostDaemonReachableAtom,
   localHostIdAtom,
   localHostStatusAtom,
+  requestLocalHostDaemonAccessAtom,
 } from "@/lib/system-config-atoms";
 import { useAsyncAtomValue } from "@/lib/use-async-atom-value";
 
@@ -48,4 +51,14 @@ export function useHostDaemon() {
     platform,
     isLocalDaemonHost,
   };
+}
+
+export function useLocalHostDaemonAccess() {
+  const accessState = useAsyncAtomValue(
+    localHostDaemonAccessStateAtom,
+    "unavailable",
+  );
+  const requestAccess = useSetAtom(requestLocalHostDaemonAccessAtom);
+
+  return { accessState, requestAccess };
 }

--- a/apps/app/src/lib/browser-url.ts
+++ b/apps/app/src/lib/browser-url.ts
@@ -1,5 +1,7 @@
-// Address-bar / new-tab search input parsing for the browser surface. Pure and
-// dependency-free so the URL-vs-search heuristic can be unit tested directly.
+// Address-bar / new-tab search input parsing for the browser surface. Kept pure
+// so the URL-vs-search heuristic can be unit tested directly.
+
+import { isLoopbackHostname } from "./loopback-hostname";
 
 const SEARCH_ENGINE_URL = "https://www.google.com/search";
 const HTTP_SCHEME_PATTERN = /^https?:\/\//i;
@@ -73,18 +75,8 @@ function parseIpv4Octets(host: string): number[] | null {
   return octets;
 }
 
-function isIpv4LoopbackHost(host: string): boolean {
-  const octets = parseIpv4Octets(host);
-  return octets !== null && octets[0] === 127;
-}
-
 function isBareLoopbackHost(host: string): boolean {
-  return (
-    host === "localhost" ||
-    host.endsWith(".localhost") ||
-    host === "::1" ||
-    isIpv4LoopbackHost(host)
-  );
+  return isLoopbackHostname(host);
 }
 
 function isBlockedIpv4Host(host: string): boolean {
@@ -114,7 +106,7 @@ function isBlockedBareHost(host: string): boolean {
 function isPublicBareHost(host: string): boolean {
   const ipv4 = parseIpv4Octets(host);
   if (ipv4 !== null) {
-    return !isIpv4LoopbackHost(host) && !isBlockedIpv4Host(host);
+    return !isLoopbackHostname(host) && !isBlockedIpv4Host(host);
   }
 
   return (

--- a/apps/app/src/lib/local-host-daemon-access.test.ts
+++ b/apps/app/src/lib/local-host-daemon-access.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  isLoopbackHostname,
+  resolveLocalHostDaemonAccess,
+  resolveLocalHostDaemonProbePort,
+  type LocalNetworkPermissionQuery,
+} from "./local-host-daemon-access";
+
+function createPermissionQuery(
+  query: LocalNetworkPermissionQuery["query"],
+): LocalNetworkPermissionQuery {
+  return { query };
+}
+
+describe("local host daemon access", () => {
+  it.each(["localhost", "LOCALHOST.", "127.0.0.1", "::1", "[::1]"])(
+    "recognizes %s as loopback",
+    (hostname) => {
+      expect(isLoopbackHostname(hostname)).toBe(true);
+    },
+  );
+
+  it("does not query browser permission without a configured helper", async () => {
+    const query = vi.fn<LocalNetworkPermissionQuery["query"]>();
+
+    await expect(
+      resolveLocalHostDaemonAccess({
+        configuredPort: null,
+        hostname: "bb.example.com",
+        isDesktop: false,
+        permissions: createPermissionQuery(query),
+      }),
+    ).resolves.toBe("unavailable");
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { hostname: "localhost", isDesktop: false },
+    { hostname: "bb.example.com", isDesktop: true },
+  ])("allows trusted client context %# without a query", async (context) => {
+    const query = vi.fn<LocalNetworkPermissionQuery["query"]>();
+
+    await expect(
+      resolveLocalHostDaemonAccess({
+        configuredPort: 38_887,
+        ...context,
+        permissions: createPermissionQuery(query),
+      }),
+    ).resolves.toBe("available");
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { permissionState: "granted" as const, accessState: "available" },
+    {
+      permissionState: "prompt" as const,
+      accessState: "permission-required",
+    },
+    { permissionState: "denied" as const, accessState: "denied" },
+  ])(
+    "maps $permissionState permission to $accessState",
+    async ({ permissionState, accessState }) => {
+      const query = vi.fn<LocalNetworkPermissionQuery["query"]>(async () => ({
+        state: permissionState,
+      }));
+
+      await expect(
+        resolveLocalHostDaemonAccess({
+          configuredPort: 38_887,
+          hostname: "bb.example.com",
+          isDesktop: false,
+          permissions: createPermissionQuery(query),
+        }),
+      ).resolves.toBe(accessState);
+      expect(query).toHaveBeenCalledExactlyOnceWith({
+        name: "loopback-network",
+      });
+    },
+  );
+
+  it("falls back to Chrome's original permission name", async () => {
+    const query = vi.fn<LocalNetworkPermissionQuery["query"]>(
+      async ({ name }) => {
+        if (name === "loopback-network") {
+          throw new TypeError("unsupported permission");
+        }
+        return { state: "granted" };
+      },
+    );
+
+    await expect(
+      resolveLocalHostDaemonAccess({
+        configuredPort: 38_887,
+        hostname: "bb.example.com",
+        isDesktop: false,
+        permissions: createPermissionQuery(query),
+      }),
+    ).resolves.toBe("available");
+    expect(query.mock.calls).toEqual([
+      [{ name: "loopback-network" }],
+      [{ name: "local-network-access" }],
+    ]);
+  });
+
+  it("fails closed when the browser cannot report permission", async () => {
+    const query = vi.fn<LocalNetworkPermissionQuery["query"]>(async () => {
+      throw new TypeError("unsupported permission");
+    });
+
+    await expect(
+      resolveLocalHostDaemonAccess({
+        configuredPort: 38_887,
+        hostname: "bb.example.com",
+        isDesktop: false,
+        permissions: createPermissionQuery(query),
+      }),
+    ).resolves.toBe("unsupported");
+  });
+
+  it("only exposes the helper port when probing is available", () => {
+    expect(resolveLocalHostDaemonProbePort(38_887, "available")).toBe(38_887);
+    expect(
+      resolveLocalHostDaemonProbePort(38_887, "permission-required"),
+    ).toBeNull();
+    expect(resolveLocalHostDaemonProbePort(38_887, "denied")).toBeNull();
+    expect(resolveLocalHostDaemonProbePort(38_887, "unsupported")).toBeNull();
+  });
+});

--- a/apps/app/src/lib/local-host-daemon-access.test.ts
+++ b/apps/app/src/lib/local-host-daemon-access.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  isLoopbackHostname,
   resolveLocalHostDaemonAccess,
   resolveLocalHostDaemonProbePort,
   type LocalNetworkPermissionQuery,
@@ -13,13 +12,6 @@ function createPermissionQuery(
 }
 
 describe("local host daemon access", () => {
-  it.each(["localhost", "LOCALHOST.", "127.0.0.1", "::1", "[::1]"])(
-    "recognizes %s as loopback",
-    (hostname) => {
-      expect(isLoopbackHostname(hostname)).toBe(true);
-    },
-  );
-
   it("does not query browser permission without a configured helper", async () => {
     const query = vi.fn<LocalNetworkPermissionQuery["query"]>();
 
@@ -29,6 +21,7 @@ describe("local host daemon access", () => {
         hostname: "bb.example.com",
         isDesktop: false,
         permissions: createPermissionQuery(query),
+        sessionAccessGranted: false,
       }),
     ).resolves.toBe("unavailable");
     expect(query).not.toHaveBeenCalled();
@@ -45,6 +38,7 @@ describe("local host daemon access", () => {
         configuredPort: 38_887,
         ...context,
         permissions: createPermissionQuery(query),
+        sessionAccessGranted: false,
       }),
     ).resolves.toBe("available");
     expect(query).not.toHaveBeenCalled();
@@ -70,6 +64,7 @@ describe("local host daemon access", () => {
           hostname: "bb.example.com",
           isDesktop: false,
           permissions: createPermissionQuery(query),
+          sessionAccessGranted: false,
         }),
       ).resolves.toBe(accessState);
       expect(query).toHaveBeenCalledExactlyOnceWith({
@@ -94,6 +89,7 @@ describe("local host daemon access", () => {
         hostname: "bb.example.com",
         isDesktop: false,
         permissions: createPermissionQuery(query),
+        sessionAccessGranted: false,
       }),
     ).resolves.toBe("available");
     expect(query.mock.calls).toEqual([
@@ -113,8 +109,24 @@ describe("local host daemon access", () => {
         hostname: "bb.example.com",
         isDesktop: false,
         permissions: createPermissionQuery(query),
+        sessionAccessGranted: false,
       }),
     ).resolves.toBe("unsupported");
+  });
+
+  it("trusts access already proven by an explicit session request", async () => {
+    const query = vi.fn<LocalNetworkPermissionQuery["query"]>();
+
+    await expect(
+      resolveLocalHostDaemonAccess({
+        configuredPort: 38_887,
+        hostname: "bb.example.com",
+        isDesktop: false,
+        permissions: createPermissionQuery(query),
+        sessionAccessGranted: true,
+      }),
+    ).resolves.toBe("available");
+    expect(query).not.toHaveBeenCalled();
   });
 
   it("only exposes the helper port when probing is available", () => {

--- a/apps/app/src/lib/local-host-daemon-access.ts
+++ b/apps/app/src/lib/local-host-daemon-access.ts
@@ -1,0 +1,110 @@
+export type LocalHostDaemonAccessState =
+  | "available"
+  | "denied"
+  | "permission-required"
+  | "unavailable"
+  | "unsupported";
+
+type LocalNetworkPermissionName = "loopback-network" | "local-network-access";
+
+export interface LocalNetworkPermissionQuery {
+  query(descriptor: {
+    name: LocalNetworkPermissionName;
+  }): Promise<{ state: PermissionState }>;
+}
+
+interface ResolveLocalHostDaemonAccessArgs {
+  configuredPort: number | null;
+  hostname: string | null;
+  isDesktop: boolean;
+  permissions: LocalNetworkPermissionQuery | null;
+}
+
+const LOCAL_NETWORK_PERMISSION_NAMES: readonly LocalNetworkPermissionName[] = [
+  "loopback-network",
+  "local-network-access",
+];
+
+function normalizeHostname(hostname: string): string {
+  return hostname.toLowerCase().replace(/\.$/u, "");
+}
+
+export function isLoopbackHostname(hostname: string): boolean {
+  const normalizedHostname = normalizeHostname(hostname);
+  return (
+    normalizedHostname === "localhost" ||
+    normalizedHostname === "127.0.0.1" ||
+    normalizedHostname === "::1" ||
+    normalizedHostname === "[::1]"
+  );
+}
+
+export function getBrowserLocalNetworkPermissionQuery(): LocalNetworkPermissionQuery | null {
+  if (
+    typeof navigator === "undefined" ||
+    !("permissions" in navigator) ||
+    navigator.permissions === undefined
+  ) {
+    return null;
+  }
+
+  // Local Network Access permission names are newer than the DOM typings used
+  // by some supported browsers. Narrow this browser boundary once, then keep
+  // the rest of the app on the explicit local contract above.
+  return navigator.permissions as unknown as LocalNetworkPermissionQuery;
+}
+
+async function queryLoopbackPermissionState(
+  permissions: LocalNetworkPermissionQuery | null,
+): Promise<PermissionState | "unsupported"> {
+  if (!permissions) {
+    return "unsupported";
+  }
+
+  for (const name of LOCAL_NETWORK_PERMISSION_NAMES) {
+    try {
+      const result = await permissions.query({ name });
+      return result.state;
+    } catch {
+      // Chrome 142–144 only knows the original permission name. Chrome 145+
+      // supports the loopback-specific name and retains the old name as an
+      // alias, so only fall back when the newer query is unsupported.
+    }
+  }
+
+  return "unsupported";
+}
+
+export async function resolveLocalHostDaemonAccess({
+  configuredPort,
+  hostname,
+  isDesktop,
+  permissions,
+}: ResolveLocalHostDaemonAccessArgs): Promise<LocalHostDaemonAccessState> {
+  if (configuredPort === null) {
+    return "unavailable";
+  }
+
+  if (isDesktop || (hostname !== null && isLoopbackHostname(hostname))) {
+    return "available";
+  }
+
+  const permissionState = await queryLoopbackPermissionState(permissions);
+  switch (permissionState) {
+    case "granted":
+      return "available";
+    case "denied":
+      return "denied";
+    case "prompt":
+      return "permission-required";
+    case "unsupported":
+      return "unsupported";
+  }
+}
+
+export function resolveLocalHostDaemonProbePort(
+  configuredPort: number | null,
+  accessState: LocalHostDaemonAccessState,
+): number | null {
+  return accessState === "available" ? configuredPort : null;
+}

--- a/apps/app/src/lib/local-host-daemon-access.ts
+++ b/apps/app/src/lib/local-host-daemon-access.ts
@@ -1,3 +1,5 @@
+import { isLoopbackHostname } from "./loopback-hostname";
+
 export type LocalHostDaemonAccessState =
   | "available"
   | "denied"
@@ -18,26 +20,13 @@ interface ResolveLocalHostDaemonAccessArgs {
   hostname: string | null;
   isDesktop: boolean;
   permissions: LocalNetworkPermissionQuery | null;
+  sessionAccessGranted: boolean;
 }
 
 const LOCAL_NETWORK_PERMISSION_NAMES: readonly LocalNetworkPermissionName[] = [
   "loopback-network",
   "local-network-access",
 ];
-
-function normalizeHostname(hostname: string): string {
-  return hostname.toLowerCase().replace(/\.$/u, "");
-}
-
-export function isLoopbackHostname(hostname: string): boolean {
-  const normalizedHostname = normalizeHostname(hostname);
-  return (
-    normalizedHostname === "localhost" ||
-    normalizedHostname === "127.0.0.1" ||
-    normalizedHostname === "::1" ||
-    normalizedHostname === "[::1]"
-  );
-}
 
 export function getBrowserLocalNetworkPermissionQuery(): LocalNetworkPermissionQuery | null {
   if (
@@ -80,12 +69,17 @@ export async function resolveLocalHostDaemonAccess({
   hostname,
   isDesktop,
   permissions,
+  sessionAccessGranted,
 }: ResolveLocalHostDaemonAccessArgs): Promise<LocalHostDaemonAccessState> {
   if (configuredPort === null) {
     return "unavailable";
   }
 
-  if (isDesktop || (hostname !== null && isLoopbackHostname(hostname))) {
+  if (
+    sessionAccessGranted ||
+    isDesktop ||
+    (hostname !== null && isLoopbackHostname(hostname))
+  ) {
     return "available";
   }
 

--- a/apps/app/src/lib/loopback-hostname.test.ts
+++ b/apps/app/src/lib/loopback-hostname.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { isLoopbackHostname } from "./loopback-hostname";
+
+describe("isLoopbackHostname", () => {
+  it.each([
+    "localhost",
+    "LOCALHOST.",
+    "bb.localhost",
+    "pr1608.bb.localhost",
+    "127.0.0.1",
+    "127.255.255.254",
+    "::1",
+    "[::1]",
+  ])("recognizes %s as loopback", (hostname) => {
+    expect(isLoopbackHostname(hostname)).toBe(true);
+  });
+
+  it.each([
+    "localhost.example.com",
+    "notlocalhost",
+    "127.example.com",
+    "127.0.0.256",
+    "0127.0.0.1",
+    "128.0.0.1",
+  ])("does not classify %s as loopback", (hostname) => {
+    expect(isLoopbackHostname(hostname)).toBe(false);
+  });
+});

--- a/apps/app/src/lib/loopback-hostname.ts
+++ b/apps/app/src/lib/loopback-hostname.ts
@@ -1,0 +1,34 @@
+const DECIMAL_OCTET_PATTERN = /^\d+$/u;
+
+function normalizeHostname(hostname: string): string {
+  const normalized = hostname.toLowerCase().replace(/\.$/u, "");
+  return normalized.startsWith("[") && normalized.endsWith("]")
+    ? normalized.slice(1, -1)
+    : normalized;
+}
+
+function isIpv4LoopbackHostname(hostname: string): boolean {
+  const parts = hostname.split(".");
+  if (parts.length !== 4 || parts[0] !== "127") {
+    return false;
+  }
+
+  return parts.every((part) => {
+    if (!DECIMAL_OCTET_PATTERN.test(part)) {
+      return false;
+    }
+    const octet = Number(part);
+    return octet >= 0 && octet <= 255 && String(octet) === part;
+  });
+}
+
+/** Whether a browser-normalized hostname is reserved for local loopback. */
+export function isLoopbackHostname(hostname: string): boolean {
+  const normalizedHostname = normalizeHostname(hostname);
+  return (
+    normalizedHostname === "localhost" ||
+    normalizedHostname.endsWith(".localhost") ||
+    normalizedHostname === "::1" ||
+    isIpv4LoopbackHostname(normalizedHostname)
+  );
+}

--- a/apps/app/src/lib/system-config-atoms.local-access.test.ts
+++ b/apps/app/src/lib/system-config-atoms.local-access.test.ts
@@ -1,0 +1,81 @@
+import { createStore } from "jotai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchHostStatus: vi.fn(),
+  fetchSystemConfig: vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ hostDaemonPort: 38_887 }),
+  })),
+}));
+
+vi.mock("./api-server", () => ({
+  apiClient: {
+    system: {
+      config: {
+        $get: mocks.fetchSystemConfig,
+      },
+    },
+  },
+}));
+
+vi.mock("./api-host-daemon", () => ({
+  fetchHostStatus: mocks.fetchHostStatus,
+  fetchWorkspaceOpenTargets: vi.fn(async () => []),
+}));
+
+vi.mock("./bb-desktop", () => ({
+  getBbDesktopInfo: () => null,
+}));
+
+vi.mock("./ws", () => ({
+  wsManager: {
+    onChanged: () => () => {},
+    onConnected: () => () => {},
+  },
+}));
+
+import {
+  localHostDaemonAccessStateAtom,
+  localHostStatusAtom,
+  requestLocalHostDaemonAccessAtom,
+} from "./system-config-atoms";
+
+beforeEach(() => {
+  mocks.fetchHostStatus.mockReset();
+  vi.stubGlobal("window", {
+    location: { hostname: "remote.getbb.app" },
+  });
+  vi.stubGlobal("navigator", {
+    permissions: {
+      query: vi.fn(async () => ({ state: "prompt" })),
+    },
+    userAgent: "test",
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("local host daemon access atoms", () => {
+  it("does not probe loopback while a remote page is in prompt state", async () => {
+    const store = createStore();
+
+    await expect(store.get(localHostDaemonAccessStateAtom)).resolves.toBe(
+      "permission-required",
+    );
+    await expect(store.get(localHostStatusAtom)).resolves.toBeNull();
+    expect(mocks.fetchHostStatus).not.toHaveBeenCalled();
+  });
+
+  it("makes one probe when access is explicitly requested", async () => {
+    mocks.fetchHostStatus.mockResolvedValue(null);
+    const store = createStore();
+
+    await expect(store.set(requestLocalHostDaemonAccessAtom)).resolves.toBe(
+      false,
+    );
+    expect(mocks.fetchHostStatus).toHaveBeenCalledExactlyOnceWith(38_887);
+  });
+});

--- a/apps/app/src/lib/system-config-atoms.local-access.test.ts
+++ b/apps/app/src/lib/system-config-atoms.local-access.test.ts
@@ -78,4 +78,30 @@ describe("local host daemon access atoms", () => {
     );
     expect(mocks.fetchHostStatus).toHaveBeenCalledExactlyOnceWith(38_887);
   });
+
+  it("keeps successful explicit access when permission queries are unsupported", async () => {
+    vi.stubGlobal("navigator", {
+      permissions: {
+        query: vi.fn(async () => {
+          throw new TypeError("unsupported permission");
+        }),
+      },
+      userAgent: "test",
+    });
+    mocks.fetchHostStatus.mockResolvedValue({
+      connected: true,
+      hostId: "host-local",
+    });
+    const store = createStore();
+
+    await expect(store.get(localHostDaemonAccessStateAtom)).resolves.toBe(
+      "unsupported",
+    );
+    await expect(store.set(requestLocalHostDaemonAccessAtom)).resolves.toBe(
+      true,
+    );
+    await expect(store.get(localHostDaemonAccessStateAtom)).resolves.toBe(
+      "available",
+    );
+  });
 });

--- a/apps/app/src/lib/system-config-atoms.ts
+++ b/apps/app/src/lib/system-config-atoms.ts
@@ -165,17 +165,20 @@ localHostStatusRefreshTickAtom.onMount = (setRefreshTick) => {
 };
 
 const localHostDaemonAccessRefreshTickAtom = atom(0);
+const localHostDaemonSessionAccessGrantedAtom = atom(false);
 
 export const localHostDaemonAccessStateAtom = atom<
   Promise<LocalHostDaemonAccessState>
 >(async (get) => {
   get(localHostDaemonAccessRefreshTickAtom);
+  const sessionAccessGranted = get(localHostDaemonSessionAccessGrantedAtom);
   const config = await get(systemConfigAtom);
   return resolveLocalHostDaemonAccess({
     configuredPort: config.hostDaemonPort,
     hostname: typeof window === "undefined" ? null : window.location.hostname,
     isDesktop: getBbDesktopInfo() !== null,
     permissions: getBrowserLocalNetworkPermissionQuery(),
+    sessionAccessGranted,
   });
 });
 
@@ -193,6 +196,9 @@ export const requestLocalHostDaemonAccessAtom = atom(
     }
 
     const status = await fetchHostStatus(config.hostDaemonPort);
+    if (status !== null) {
+      set(localHostDaemonSessionAccessGrantedAtom, true);
+    }
     set(localHostDaemonAccessRefreshTickAtom, (count) => count + 1);
     set(localHostStatusRefreshTickAtom, (count) => count + 1);
     return status !== null;

--- a/apps/app/src/lib/system-config-atoms.ts
+++ b/apps/app/src/lib/system-config-atoms.ts
@@ -5,6 +5,13 @@ import type { HostDaemonStatusSnapshot } from "./api-host-daemon";
 import type { SystemConfigResponse } from "@bb/server-contract";
 import { apiClient } from "./api-server";
 import { fetchHostStatus, fetchWorkspaceOpenTargets } from "./api-host-daemon";
+import { getBbDesktopInfo } from "./bb-desktop";
+import {
+  getBrowserLocalNetworkPermissionQuery,
+  resolveLocalHostDaemonAccess,
+  resolveLocalHostDaemonProbePort,
+  type LocalHostDaemonAccessState,
+} from "./local-host-daemon-access";
 import { wsManager } from "./ws";
 
 // Offline/unavailable app behavior should fail closed independently of server defaults.
@@ -157,6 +164,41 @@ localHostStatusRefreshTickAtom.onMount = (setRefreshTick) => {
   };
 };
 
+const localHostDaemonAccessRefreshTickAtom = atom(0);
+
+export const localHostDaemonAccessStateAtom = atom<
+  Promise<LocalHostDaemonAccessState>
+>(async (get) => {
+  get(localHostDaemonAccessRefreshTickAtom);
+  const config = await get(systemConfigAtom);
+  return resolveLocalHostDaemonAccess({
+    configuredPort: config.hostDaemonPort,
+    hostname: typeof window === "undefined" ? null : window.location.hostname,
+    isDesktop: getBbDesktopInfo() !== null,
+    permissions: getBrowserLocalNetworkPermissionQuery(),
+  });
+});
+
+/**
+ * Deliberately request browser-local helper access from a user interaction.
+ * The status request is what causes browsers to offer the loopback permission;
+ * no permission API exists that can request it directly.
+ */
+export const requestLocalHostDaemonAccessAtom = atom(
+  null,
+  async (get, set): Promise<boolean> => {
+    const config = await get(systemConfigAtom);
+    if (config.hostDaemonPort === null) {
+      return false;
+    }
+
+    const status = await fetchHostStatus(config.hostDaemonPort);
+    set(localHostDaemonAccessRefreshTickAtom, (count) => count + 1);
+    set(localHostStatusRefreshTickAtom, (count) => count + 1);
+    return status !== null;
+  },
+);
+
 /** The local daemon status, or null if no daemon is reachable. */
 export const localHostStatusAtom = atom<
   Promise<HostDaemonStatusSnapshot | null>
@@ -217,11 +259,12 @@ export const localWorkspaceOpenTargetsAtom = atom<
 // ---------------------------------------------------------------------------
 
 /**
- * The local helper port to probe from this browser, or null when the server
- * does not expose one. The helper is reached through browser-local loopback,
- * so a remote app origin still probes this client's `127.0.0.1`.
+ * The local helper port this browser may probe, or null when unavailable. A
+ * remote web origin only receives the port after loopback access was already
+ * granted or explicitly requested by the user.
  */
 export const hostDaemonPortAtom = atom<Promise<number | null>>(async (get) => {
   const config = await get(systemConfigAtom);
-  return config.hostDaemonPort;
+  const accessState = await get(localHostDaemonAccessStateAtom);
+  return resolveLocalHostDaemonProbePort(config.hostDaemonPort, accessState);
 });

--- a/apps/app/src/views/SettingsView.local-helper.test.tsx
+++ b/apps/app/src/views/SettingsView.local-helper.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocalOpenTargetSettingsSection } from "./SettingsView";
+
+afterEach(cleanup);
+
+function renderSection({
+  accessState,
+  hasDaemon = false,
+  onRequestAccess = vi.fn(async () => true),
+}: {
+  accessState:
+    | "available"
+    | "denied"
+    | "permission-required"
+    | "unavailable"
+    | "unsupported";
+  hasDaemon?: boolean;
+  onRequestAccess?: () => Promise<boolean>;
+}) {
+  render(
+    <LocalOpenTargetSettingsSection
+      accessState={accessState}
+      directoryTargetId={null}
+      fileTargetId={null}
+      hasDaemon={hasDaemon}
+      onDirectoryTargetChange={vi.fn()}
+      onFileTargetChange={vi.fn()}
+      onRequestAccess={onRequestAccess}
+      targets={[]}
+    />,
+  );
+  return { onRequestAccess };
+}
+
+describe("LocalOpenTargetSettingsSection", () => {
+  it("requests local helper access only after the user clicks Enable", async () => {
+    const { onRequestAccess } = renderSection({
+      accessState: "permission-required",
+    });
+
+    expect(onRequestAccess).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Enable" }));
+    await waitFor(() => expect(onRequestAccess).toHaveBeenCalledTimes(1));
+  });
+
+  it("explains denied access without retrying it", () => {
+    const { onRequestAccess } = renderSection({ accessState: "denied" });
+
+    expect(
+      screen.getByRole<HTMLButtonElement>("button", { name: "Blocked" })
+        .disabled,
+    ).toBe(true);
+    expect(screen.queryByText(/allow it for this site/i)).not.toBeNull();
+    expect(onRequestAccess).not.toHaveBeenCalled();
+  });
+
+  it("shows editor preferences when the helper is reachable", () => {
+    renderSection({ accessState: "available", hasDaemon: true });
+
+    expect(screen.queryByText("Directory default")).not.toBeNull();
+    expect(screen.queryByText("File default")).not.toBeNull();
+    expect(screen.queryByText("Local editor integration")).toBeNull();
+  });
+});

--- a/apps/app/src/views/SettingsView.local-helper.test.tsx
+++ b/apps/app/src/views/SettingsView.local-helper.test.tsx
@@ -62,6 +62,14 @@ describe("LocalOpenTargetSettingsSection", () => {
     expect(onRequestAccess).not.toHaveBeenCalled();
   });
 
+  it("retries after the helper was unavailable", async () => {
+    const { onRequestAccess } = renderSection({ accessState: "available" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => expect(onRequestAccess).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText(/start bb locally, then retry/i)).not.toBeNull();
+  });
+
   it("shows editor preferences when the helper is reachable", () => {
     renderSection({ accessState: "available", hasDaemon: true });
 

--- a/apps/app/src/views/SettingsView.local-helper.test.tsx
+++ b/apps/app/src/views/SettingsView.local-helper.test.tsx
@@ -9,7 +9,10 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { LocalOpenTargetSettingsSection } from "./SettingsView";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
 function renderSection({
   accessState,
@@ -58,7 +61,7 @@ describe("LocalOpenTargetSettingsSection", () => {
       screen.getByRole<HTMLButtonElement>("button", { name: "Blocked" })
         .disabled,
     ).toBe(true);
-    expect(screen.queryByText(/allow it for this site/i)).not.toBeNull();
+    expect(screen.queryByText(/allow local network access/i)).not.toBeNull();
     expect(onRequestAccess).not.toHaveBeenCalled();
   });
 
@@ -67,7 +70,22 @@ describe("LocalOpenTargetSettingsSection", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Retry" }));
     await waitFor(() => expect(onRequestAccess).toHaveBeenCalledTimes(1));
-    expect(screen.queryByText(/start bb locally, then retry/i)).not.toBeNull();
+    expect(
+      screen.queryByText(/couldn’t connect to its local editor helper/i),
+    ).not.toBeNull();
+  });
+
+  it("opens the remote-browser setup guide", () => {
+    const openWindow = vi.spyOn(window, "open").mockImplementation(() => null);
+    renderSection({ accessState: "available" });
+
+    fireEvent.click(screen.getByRole("link", { name: "Setup guide" }));
+
+    expect(openWindow).toHaveBeenCalledExactlyOnceWith(
+      "https://github.com/get-bb/bb/blob/main/docs/multiple-devices.md#open-bb-from-another-browser",
+      "_blank",
+      "noopener,noreferrer",
+    );
   });
 
   it("shows editor preferences when the helper is reachable", () => {

--- a/apps/app/src/views/SettingsView.stories.tsx
+++ b/apps/app/src/views/SettingsView.stories.tsx
@@ -322,11 +322,13 @@ function FilePreferencesStory() {
 
   return (
     <LocalOpenTargetSettingsSection
+      accessState="available"
       directoryTargetId={state.directoryTargetId}
       fileTargetId={state.fileTargetId}
       hasDaemon={true}
       onDirectoryTargetChange={handleDirectoryTargetChange}
       onFileTargetChange={handleFileTargetChange}
+      onRequestAccess={async () => true}
       targets={connectedTargets}
     />
   );

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -507,13 +507,18 @@ export function LocalOpenTargetSettingsSection({
                 href={LOCAL_EDITOR_INTEGRATION_DOCS_URL}
                 target="_blank"
                 rel="noreferrer"
-                className="rounded-sm underline underline-offset-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                className="inline-flex items-center gap-0.5 rounded-sm underline underline-offset-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 onClick={(event) => {
                   event.preventDefault();
                   openUrlInExternalBrowser(LOCAL_EDITOR_INTEGRATION_DOCS_URL);
                 }}
               >
                 Setup guide
+                <Icon
+                  name="ExternalLink"
+                  className="size-3 shrink-0"
+                  aria-hidden
+                />
               </a>
             </>
           }

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -35,7 +35,7 @@ import {
   useThemePreference,
   type ThemePreference,
 } from "@/hooks/useTheme";
-import { useHostDaemon } from "@/hooks/useHostDaemon";
+import { useHostDaemon, useLocalHostDaemonAccess } from "@/hooks/useHostDaemon";
 import { UsageLimitsSettingsSection } from "@/components/settings/UsageLimitsSettingsSection";
 import { SidebarThreadListSetting } from "@/components/settings/SidebarThreadListSetting";
 import { SplitDimmingSetting } from "@/components/settings/SplitDimmingSetting";
@@ -79,6 +79,7 @@ import {
   type WorkspaceOpenTargetCapability,
 } from "@/lib/workspace-open-target-preference";
 import { getWorkspaceOpenTargetFallbackLabel } from "@/components/workspace-open-target/workspace-open-target-display";
+import type { LocalHostDaemonAccessState } from "@/lib/local-host-daemon-access";
 
 interface ThemePreferenceOption {
   label: string;
@@ -104,11 +105,13 @@ interface LocalOpenTargetPreferenceControlProps {
 }
 
 export interface LocalOpenTargetSettingsSectionProps {
+  accessState: LocalHostDaemonAccessState;
   directoryTargetId: StoredWorkspaceOpenTargetPreference;
   fileTargetId: StoredWorkspaceOpenTargetPreference;
   hasDaemon: boolean;
   onDirectoryTargetChange: (targetId: WorkspaceOpenTargetId) => void;
   onFileTargetChange: (targetId: WorkspaceOpenTargetId) => void;
+  onRequestAccess: () => Promise<boolean>;
   targets: WorkspaceOpenTarget[];
 }
 
@@ -447,15 +450,63 @@ function LocalOpenTargetPreferenceControl({
 }
 
 export function LocalOpenTargetSettingsSection({
+  accessState,
   directoryTargetId,
   fileTargetId,
   hasDaemon,
   onDirectoryTargetChange,
   onFileTargetChange,
+  onRequestAccess,
   targets,
 }: LocalOpenTargetSettingsSectionProps) {
-  if (!hasDaemon) {
+  const [accessRequestPending, setAccessRequestPending] = useState(false);
+
+  if (accessState === "unavailable") {
     return null;
+  }
+
+  const handleRequestAccess = async () => {
+    setAccessRequestPending(true);
+    try {
+      await onRequestAccess();
+    } finally {
+      setAccessRequestPending(false);
+    }
+  };
+
+  if (!hasDaemon) {
+    const accessDenied = accessState === "denied";
+    const accessAvailable = accessState === "available";
+    const description = accessDenied
+      ? "Loopback access is blocked. Allow it for this site in your browser settings, then reload bb."
+      : accessAvailable
+        ? "No local bb helper is reachable on this device. Start bb locally to discover installed editors."
+        : "Allow bb to discover editors on this device. Your browser may ask for access to apps and services on this computer.";
+    const buttonLabel = accessRequestPending
+      ? "Enabling…"
+      : accessDenied
+        ? "Blocked"
+        : accessAvailable
+          ? "Unavailable"
+          : "Enable";
+
+    return (
+      <SettingsSection title="File Preferences">
+        <SettingsWithControl
+          label="Local editor integration"
+          description={description}
+        >
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={accessRequestPending || accessDenied || accessAvailable}
+            onClick={handleRequestAccess}
+          >
+            {buttonLabel}
+          </Button>
+        </SettingsWithControl>
+      </SettingsSection>
+    );
   }
 
   return (
@@ -1015,6 +1066,7 @@ export function SettingsView() {
   const themePreference = useThemePreference();
   const systemConfigQuery = useSystemConfig();
   const { hasDaemon } = useHostDaemon();
+  const { accessState, requestAccess } = useLocalHostDaemonAccess();
   const { workspaceOpenTargets } = useWorkspaceOpenTargets({
     enabled: hasDaemon,
   });
@@ -1135,11 +1187,13 @@ export function SettingsView() {
     content = (
       <>
         <LocalOpenTargetSettingsSection
+          accessState={accessState}
           directoryTargetId={directoryTargetId}
           fileTargetId={fileTargetId}
           hasDaemon={hasDaemon}
           onDirectoryTargetChange={setDirectoryTargetId}
           onFileTargetChange={setFileTargetId}
+          onRequestAccess={requestAccess}
           targets={workspaceOpenTargets}
         />
         <FileOpenersSettingsSection />

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -80,6 +80,10 @@ import {
 } from "@/lib/workspace-open-target-preference";
 import { getWorkspaceOpenTargetFallbackLabel } from "@/components/workspace-open-target/workspace-open-target-display";
 import type { LocalHostDaemonAccessState } from "@/lib/local-host-daemon-access";
+import { openUrlInExternalBrowser } from "@/lib/url-open-routing";
+
+const LOCAL_EDITOR_INTEGRATION_DOCS_URL =
+  "https://github.com/get-bb/bb/blob/main/docs/multiple-devices.md#open-bb-from-another-browser";
 
 interface ThemePreferenceOption {
   label: string;
@@ -477,11 +481,11 @@ export function LocalOpenTargetSettingsSection({
   if (!hasDaemon) {
     const accessDenied = accessState === "denied";
     const accessAvailable = accessState === "available";
-    const description = accessDenied
-      ? "Loopback access is blocked. Allow it for this site in your browser settings, then reload bb."
+    const descriptionText = accessDenied
+      ? "Your browser blocked access to bb on this device. Allow local network access for this site in browser settings, then reload bb."
       : accessAvailable
-        ? "No local bb helper is reachable on this device. Start bb locally, then retry to discover installed editors."
-        : "Allow bb to discover editors on this device. Your browser may ask for access to apps and services on this computer.";
+        ? "bb couldn’t connect to its local editor helper. Make sure the bb desktop app or CLI is running on this device, then retry. If it is already running, a remote browser origin may need to be configured."
+        : "Connect this browser to bb on this device so it can discover installed editors. bb only contacts the local helper after you choose Enable; your browser may ask for local network access.";
     const buttonLabel = accessRequestPending
       ? accessAvailable
         ? "Retrying…"
@@ -496,9 +500,26 @@ export function LocalOpenTargetSettingsSection({
       <SettingsSection title="File Preferences">
         <SettingsWithControl
           label="Local editor integration"
-          description={description}
+          description={
+            <>
+              {descriptionText}{" "}
+              <a
+                href={LOCAL_EDITOR_INTEGRATION_DOCS_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="rounded-sm underline underline-offset-2 hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                onClick={(event) => {
+                  event.preventDefault();
+                  openUrlInExternalBrowser(LOCAL_EDITOR_INTEGRATION_DOCS_URL);
+                }}
+              >
+                Setup guide
+              </a>
+            </>
+          }
         >
           <Button
+            type="button"
             variant="outline"
             size="sm"
             disabled={accessRequestPending || accessDenied}

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -480,14 +480,16 @@ export function LocalOpenTargetSettingsSection({
     const description = accessDenied
       ? "Loopback access is blocked. Allow it for this site in your browser settings, then reload bb."
       : accessAvailable
-        ? "No local bb helper is reachable on this device. Start bb locally to discover installed editors."
+        ? "No local bb helper is reachable on this device. Start bb locally, then retry to discover installed editors."
         : "Allow bb to discover editors on this device. Your browser may ask for access to apps and services on this computer.";
     const buttonLabel = accessRequestPending
-      ? "Enabling…"
+      ? accessAvailable
+        ? "Retrying…"
+        : "Enabling…"
       : accessDenied
         ? "Blocked"
         : accessAvailable
-          ? "Unavailable"
+          ? "Retry"
           : "Enable";
 
     return (
@@ -499,7 +501,7 @@ export function LocalOpenTargetSettingsSection({
           <Button
             variant="outline"
             size="sm"
-            disabled={accessRequestPending || accessDenied || accessAvailable}
+            disabled={accessRequestPending || accessDenied}
             onClick={handleRequestAccess}
           >
             {buttonLabel}

--- a/docs/debugging-and-qa.md
+++ b/docs/debugging-and-qa.md
@@ -20,6 +20,19 @@ Use `scripts/bb-dev-app` when validating changes in the desktop dev app or helpi
 
 By default the launcher starts only the dev server (web frontend, server, host daemon) and prints the URL without opening a browser. Pass `--open` to open the browser after startup. Pass `--desktop` (e.g. `scripts/bb-dev-app current --desktop`) to also launch the Electron desktop shell — only do this when the user is testing a desktop-only change.
 
+A bb connect shared-port URL is a different browser origin from localhost. If
+QA through that URL needs the browser-local host daemon, restart the dev app
+with the share origin configured after exposing its app port:
+
+```bash
+BB_APP_URL=https://<handle>--<app-port>.getbb.app scripts/bb-dev-app current
+```
+
+The port remains stable for the checkout, so the existing share continues to
+work after the restart. The host daemon intentionally rejects remote origins
+that are not configured; otherwise any webpage could drive its local editor
+API.
+
 Branch switches intentionally keep dirty work in this checkout; git will stop if a local file would be overwritten. Set `BB_DEV_APP_STASH_DIRTY=1` for a one-off launch that stashes first.
 
 For CLI QA against the dev instance, run `eval "$(scripts/bb-dev-app env)"` first. This sets `BB_SERVER_URL`, `BB_HOST_DAEMON_PORT`, and `BB_PROJECT_ID=proj_personal` so `pnpm bb:dev ...` does not accidentally target the packaged app.

--- a/docs/multiple-devices.md
+++ b/docs/multiple-devices.md
@@ -45,9 +45,16 @@ container runtime must still publish that port to the host (for example,
 `docker run -p 3000:3000 ...`). Host firewall and upstream network rules also
 remain separate from bb's bind setting.
 
-If a browser on another computer should open work-host files in its local
-editor, run bb's local helper there, verify `ssh <work-host>` succeeds, and map
-the server/work-host to that SSH target:
+### Use editors installed on the browser device
+
+Local editor integration is optional. It connects the remote bb page to the
+loopback-only helper started by the bb desktop app or `npx bb-app` on the
+computer running the browser. The helper discovers installed editors and opens
+paths without exposing its API to the network.
+
+If that browser should open work-host files in its local editor, first make
+sure bb is running on the browser device. Verify `ssh <work-host>` succeeds
+there, then map the server/work-host to that SSH target:
 
 ```bash
 npx bb-app client ssh-target set <bb-server-origin> <ssh-target>
@@ -57,6 +64,14 @@ Then open Settings → Files in that browser and enable **Local editor
 integration**. The browser may ask once for permission to connect to software
 on the computer. bb does not request that permission during normal remote page
 loads; it is only needed for discovering and launching local editors.
+
+If Settings reports that it cannot connect to the helper:
+
+1. Confirm the bb desktop app or `npx bb-app` is running on the browser device.
+2. Confirm the browser allows local network access for the bb page.
+3. For a custom HTTPS or Tailscale origin, configure that exact origin with
+   `npx bb-app config set BB_APP_URL <origin>` and restart bb.
+4. Return to Settings → Files and choose **Retry**.
 
 Phones and tablets need no helper; editor-launch actions are simply unavailable.
 

--- a/docs/multiple-devices.md
+++ b/docs/multiple-devices.md
@@ -53,6 +53,11 @@ the server/work-host to that SSH target:
 npx bb-app client ssh-target set <bb-server-origin> <ssh-target>
 ```
 
+Then open Settings → Files in that browser and enable **Local editor
+integration**. The browser may ask once for permission to connect to software
+on the computer. bb does not request that permission during normal remote page
+loads; it is only needed for discovering and launching local editors.
+
 Phones and tablets need no helper; editor-launch actions are simply unavailable.
 
 ## Point the desktop app at another bb


### PR DESCRIPTION
## Summary

- stop remote bb pages from probing the browser-local host daemon before loopback access is granted
- add an explicit Settings → Files opt-in for local editor integration
- support both the current loopback-network permission and the legacy local-network-access name
- preserve automatic local helper discovery for localhost and the desktop app
- document the updated multi-device workflow

## Context

Chrome now gates requests from public origins to loopback addresses behind Local Network Access permission. The existing automatic host-daemon status probe therefore showed a browser permission prompt during ordinary bb connect page loads.

This change queries the existing permission state without triggering it and fails closed for remote web origins. The fetch that can prompt is kept directly in the Enable button click handler, so permission is requested only after an explicit user action.

## Testing

- pnpm exec turbo run test --filter=@bb/app --force — 344 files, 2,725 tests passed
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run build --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app — zero errors
- live Chrome QA through a bb connect URL with permission state prompt: zero loopback requests and no LocalNetworkAccessPermissionDenied failures during page load

> AGENT GENERATED: by GPT-5 Codex