### PR TITLE
Fix file preview line scrolling

### DIFF
--- a/apps/app/src/components/secondary-panel/FilePreview.test.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.test.tsx
@@ -64,7 +64,6 @@ const pierreMock = vi.hoisted(() => {
     lastFile: null as MockPierreFileProps["file"] | null,
     mountCount: 0,
     renderCount: 0,
-    scrollIntoView: vi.fn(),
     statsCallback: null as StatsCallback | null,
     unsubscribe: vi.fn(),
   };
@@ -104,14 +103,33 @@ vi.mock("@pierre/diffs/react", async () => {
         const host = hostRef.current;
         if (host === null) return;
         const shadowRoot = host.shadowRoot ?? host.attachShadow({ mode: "open" });
-        shadowRoot.replaceChildren(
+        const code = document.createElement("code");
+        code.dataset.code = "";
+        code.scrollLeft = 240;
+        code.replaceChildren(
           ...file.contents.split("\n").map((lineContents, index) => {
             const lineNumber = index + 1;
             const line = document.createElement("div");
             line.dataset.line = String(lineNumber);
             line.dataset.lineIndex = String(index);
             line.textContent = lineContents;
-            line.scrollIntoView = pierreMock.state.scrollIntoView;
+            line.getBoundingClientRect = () => ({
+              bottom: 718 + index * 18,
+              height: 18,
+              left: 0,
+              right: 800,
+              top: 700 + index * 18,
+              width: 800,
+              x: 0,
+              y: 700 + index * 18,
+              toJSON: () => ({}),
+            });
+            // Model the native behavior that caused the regression: asking a
+            // long line to scroll into view can also move Pierre's horizontal
+            // code scroller.
+            line.scrollIntoView = () => {
+              code.scrollLeft = 0;
+            };
             if (
               selectedLines !== null &&
               lineNumber >= selectedLines.start &&
@@ -122,6 +140,7 @@ vi.mock("@pierre/diffs/react", async () => {
             return line;
           }),
         );
+        shadowRoot.replaceChildren(code);
       }, [file.contents, selectedLines]);
 
       return React.createElement(
@@ -145,7 +164,6 @@ describe("FilePreview", () => {
     pierreMock.state.lastFile = null;
     pierreMock.state.mountCount = 0;
     pierreMock.state.renderCount = 0;
-    pierreMock.state.scrollIntoView.mockClear();
     pierreMock.state.statsCallback = null;
     pierreMock.state.unsubscribe.mockClear();
     pierreMock.workerPool.subscribeToStatChanges.mockClear();
@@ -273,7 +291,23 @@ describe("FilePreview", () => {
     await screen.findByTestId("pierre-file");
   });
 
-  it("scrolls to a target line inside Pierre's shadow root after the worker is ready", async () => {
+  it("scrolls vertically to a target line without changing the horizontal offset", async () => {
+    const scrollViewport = document.createElement("div");
+    scrollViewport.style.overflowY = "auto";
+    scrollViewport.scrollTop = 100;
+    scrollViewport.getBoundingClientRect = () => ({
+      bottom: 450,
+      height: 400,
+      left: 0,
+      right: 500,
+      top: 50,
+      width: 500,
+      x: 0,
+      y: 50,
+      toJSON: () => ({}),
+    });
+    document.body.append(scrollViewport);
+
     render(
       <FilePreview
         headerMode="none"
@@ -288,14 +322,17 @@ describe("FilePreview", () => {
           textPreviewKind: null,
         }}
       />,
+      { container: scrollViewport },
     );
 
     const pierreFile = await screen.findByTestId("pierre-file");
     await waitFor(() => {
-      expect(pierreMock.state.scrollIntoView).toHaveBeenCalledWith({
-        block: "center",
-      });
+      expect(scrollViewport.scrollTop).toBe(577);
     });
+    expect(
+      pierreFile.shadowRoot?.querySelector<HTMLElement>("[data-code]")
+        ?.scrollLeft,
+    ).toBe(240);
     expect(
       pierreFile.shadowRoot
         ?.querySelector('[data-line="2"]')

--- a/apps/app/src/components/secondary-panel/FilePreview.test.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.test.tsx
@@ -22,6 +22,10 @@ interface MockPierreFileProps {
     contents: string;
     name: string;
   };
+  selectedLines?: {
+    end: number;
+    start: number;
+  } | null;
 }
 
 const pierreMock = vi.hoisted(() => {
@@ -60,6 +64,7 @@ const pierreMock = vi.hoisted(() => {
     lastFile: null as MockPierreFileProps["file"] | null,
     mountCount: 0,
     renderCount: 0,
+    scrollIntoView: vi.fn(),
     statsCallback: null as StatsCallback | null,
     unsubscribe: vi.fn(),
   };
@@ -86,21 +91,47 @@ vi.mock("@pierre/diffs/react", async () => {
   const React = await import("react");
 
   return {
-    File: ({ file }: MockPierreFileProps) => {
+    File: ({ file, selectedLines = null }: MockPierreFileProps) => {
       const [instanceId] = React.useState(() => {
         pierreMock.state.mountCount += 1;
         return pierreMock.state.mountCount;
       });
+      const hostRef = React.useRef<HTMLElement>(null);
       pierreMock.state.lastFile = file;
       pierreMock.state.renderCount += 1;
+
+      React.useLayoutEffect(() => {
+        const host = hostRef.current;
+        if (host === null) return;
+        const shadowRoot = host.shadowRoot ?? host.attachShadow({ mode: "open" });
+        shadowRoot.replaceChildren(
+          ...file.contents.split("\n").map((lineContents, index) => {
+            const lineNumber = index + 1;
+            const line = document.createElement("div");
+            line.dataset.line = String(lineNumber);
+            line.dataset.lineIndex = String(index);
+            line.textContent = lineContents;
+            line.scrollIntoView = pierreMock.state.scrollIntoView;
+            if (
+              selectedLines !== null &&
+              lineNumber >= selectedLines.start &&
+              lineNumber <= selectedLines.end
+            ) {
+              line.dataset.selectedLine = "single";
+            }
+            return line;
+          }),
+        );
+      }, [file.contents, selectedLines]);
+
       return React.createElement(
-        "pre",
+        "diffs-container",
         {
+          ref: hostRef,
           "data-instance-id": String(instanceId),
           "data-render-count": String(pierreMock.state.renderCount),
           "data-testid": "pierre-file",
         },
-        file.contents,
       );
     },
     useWorkerPool: () => pierreMock.workerPool,
@@ -114,6 +145,7 @@ describe("FilePreview", () => {
     pierreMock.state.lastFile = null;
     pierreMock.state.mountCount = 0;
     pierreMock.state.renderCount = 0;
+    pierreMock.state.scrollIntoView.mockClear();
     pierreMock.state.statsCallback = null;
     pierreMock.state.unsubscribe.mockClear();
     pierreMock.workerPool.subscribeToStatChanges.mockClear();
@@ -239,6 +271,36 @@ describe("FilePreview", () => {
     });
 
     await screen.findByTestId("pierre-file");
+  });
+
+  it("scrolls to a target line inside Pierre's shadow root after the worker is ready", async () => {
+    render(
+      <FilePreview
+        headerMode="none"
+        path="apps/app/src/lib/thread-read-state.ts"
+        state={{
+          kind: "ready",
+          file: {
+            name: "thread-read-state.ts",
+            contents: ["first", "second", "third"].join("\n"),
+          },
+          lineRange: { startLineNumber: 2, endLineNumber: 2 },
+          textPreviewKind: null,
+        }}
+      />,
+    );
+
+    const pierreFile = await screen.findByTestId("pierre-file");
+    await waitFor(() => {
+      expect(pierreMock.state.scrollIntoView).toHaveBeenCalledWith({
+        block: "center",
+      });
+    });
+    expect(
+      pierreFile.shadowRoot
+        ?.querySelector('[data-line="2"]')
+        ?.hasAttribute("data-file-preview-target-line"),
+    ).toBe(true);
   });
 
   it("remounts the code view when the highlighted file cache resolves", async () => {

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -1139,6 +1139,41 @@ function findPreviewTargetLine(
   return null;
 }
 
+function findPreviewScrollViewport(container: HTMLElement): HTMLElement | null {
+  const view = container.ownerDocument.defaultView;
+  if (view === null) return null;
+
+  let candidate = container.parentElement;
+  while (candidate !== null) {
+    const overflowY = view.getComputedStyle(candidate).overflowY;
+    if (
+      overflowY === "auto" ||
+      overflowY === "scroll" ||
+      overflowY === "overlay"
+    ) {
+      return candidate;
+    }
+    candidate = candidate.parentElement;
+  }
+  return null;
+}
+
+function scrollPreviewTargetLine(
+  container: HTMLElement,
+  line: HTMLElement,
+) {
+  const viewport = findPreviewScrollViewport(container);
+  if (viewport === null) return;
+
+  const lineRect = line.getBoundingClientRect();
+  const viewportRect = viewport.getBoundingClientRect();
+  const lineCenter = lineRect.top + lineRect.height / 2;
+  const viewportCenter = viewportRect.top + viewportRect.height / 2;
+  // Adjust only the vertical scroll offset. `scrollIntoView()` can also move
+  // the horizontal axis when a long source line extends beyond the viewport.
+  viewport.scrollTop += lineCenter - viewportCenter;
+}
+
 function formatLineRange(startLineNumber: number, endLineNumber: number) {
   return startLineNumber === endLineNumber
     ? String(startLineNumber)
@@ -1328,7 +1363,7 @@ function FilePreviewCode({
       if (line) {
         line.setAttribute("data-file-preview-target-line", "");
         line.setAttribute("data-selected-line", "single");
-        line.scrollIntoView?.({ block: "center" });
+        scrollPreviewTargetLine(container, line);
         return;
       }
 

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -8,7 +8,11 @@ import {
 } from "react";
 import { File as PierreFile, useWorkerPool } from "@pierre/diffs/react";
 import type { FileOptions } from "@pierre/diffs/react";
-import type { SelectedLineRange, SupportedLanguages } from "@pierre/diffs";
+import {
+  DIFFS_TAG_NAME,
+  type SelectedLineRange,
+  type SupportedLanguages,
+} from "@pierre/diffs";
 import type { UrlTransform } from "react-markdown";
 import { Button } from "@bb/shared-ui/button";
 import { usePierreLineSelectionActions } from "@/components/git-diff/PierreLineSelectionActions.js";
@@ -1085,13 +1089,29 @@ function IframeFilePreview({ sandbox, title, url }: IframeFilePreviewTarget) {
   );
 }
 
+function getPreviewTargetRoots(container: HTMLElement): ParentNode[] {
+  const roots: ParentNode[] = [container];
+  // Pierre owns its rendered line elements inside an open shadow root, which
+  // normal descendant queries on the React wrapper cannot cross.
+  for (const pierreContainer of container.querySelectorAll<HTMLElement>(
+    DIFFS_TAG_NAME,
+  )) {
+    if (pierreContainer.shadowRoot !== null) {
+      roots.push(pierreContainer.shadowRoot);
+    }
+  }
+  return roots;
+}
+
 function clearPreviewTargetLine(container: HTMLElement) {
-  const targetLines = container.querySelectorAll(
-    "[data-file-preview-target-line]",
-  );
-  for (const targetLine of targetLines) {
-    targetLine.removeAttribute("data-file-preview-target-line");
-    targetLine.removeAttribute("data-selected-line");
+  for (const root of getPreviewTargetRoots(container)) {
+    const targetLines = root.querySelectorAll(
+      "[data-file-preview-target-line]",
+    );
+    for (const targetLine of targetLines) {
+      targetLine.removeAttribute("data-file-preview-target-line");
+      targetLine.removeAttribute("data-selected-line");
+    }
   }
 }
 
@@ -1099,15 +1119,21 @@ function findPreviewTargetLine(
   container: HTMLElement,
   lineNumber: number,
 ): HTMLElement | null {
-  const lines = container.querySelectorAll(`[data-line="${lineNumber}"]`);
-  for (const line of lines) {
-    if (line instanceof HTMLElement && line.dataset.lineIndex !== undefined) {
-      return line;
+  const roots = getPreviewTargetRoots(container);
+  for (const root of roots) {
+    const lines = root.querySelectorAll(`[data-line="${lineNumber}"]`);
+    for (const line of lines) {
+      if (line instanceof HTMLElement && line.dataset.lineIndex !== undefined) {
+        return line;
+      }
     }
   }
-  for (const line of lines) {
-    if (line instanceof HTMLElement) {
-      return line;
+  for (const root of roots) {
+    const lines = root.querySelectorAll(`[data-line="${lineNumber}"]`);
+    for (const line of lines) {
+      if (line instanceof HTMLElement) {
+        return line;
+      }
     }
   }
   return null;
@@ -1296,12 +1322,9 @@ function FilePreviewCode({
       const container = containerRef.current;
       if (!container) return;
       clearPreviewTargetLine(container);
-      clearPreviewTargetLine(container.ownerDocument.body);
       if (targetLineNumber === null) return;
 
-      const line =
-        findPreviewTargetLine(container, targetLineNumber) ??
-        findPreviewTargetLine(container.ownerDocument.body, targetLineNumber);
+      const line = findPreviewTargetLine(container, targetLineNumber);
       if (line) {
         line.setAttribute("data-file-preview-target-line", "");
         line.setAttribute("data-selected-line", "single");
@@ -1319,13 +1342,18 @@ function FilePreviewCode({
     return () => {
       if (cleanupContainer) {
         clearPreviewTargetLine(cleanupContainer);
-        clearPreviewTargetLine(cleanupContainer.ownerDocument.body);
       }
       if (animationFrame !== null) {
         window.cancelAnimationFrame(animationFrame);
       }
     };
-  }, [file.contents, file.name, targetLineNumber]);
+  }, [
+    file.contents,
+    file.name,
+    shouldWaitForWorkerPool,
+    targetLineNumber,
+    workerHighlightCacheState,
+  ]);
 
   if (shouldWaitForWorkerPool) {
     return <FilePreviewLoading />;


### PR DESCRIPTION
## Summary

- find Pierre source lines inside the renderer's open shadow root
- rerun target-line scrolling when the worker-backed code view mounts or swaps to highlighted output
- center the target through the panel's vertical scroll offset without touching Pierre's horizontal code scroller
- scope target lookup and cleanup to the active file preview
- add regression coverage for delayed worker readiness, shadow-root line markup, and horizontal-scroll preservation

## Testing

- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/secondary-panel/FilePreview.test.tsx` (14/14)
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (passes with existing warnings)
- SawyerHood/dev-browser against the real dev app: clicked an assistant `file://.../FilePreview.tsx#L1100` link with Pierre's inner code scroller preset to `scrollLeft=240`; confirmed line 1100 was selected and fully visible after vertical scrolling to `scrollTop=19417`, while horizontal scroll remained exactly `240`

> AGENT GENERATED: by GPT-5.6 Codex