### PR TITLE
Remove plugin SDK requirements from marketplace listings

### DIFF
--- a/apps/server/src/services/plugin-catalog/marketplace-manifest.ts
+++ b/apps/server/src/services/plugin-catalog/marketplace-manifest.ts
@@ -111,13 +111,6 @@ const authorSchema = z
   })
   .strict();
 
-const enginesSchema = z
-  .object({
-    bb: semverRange.optional(),
-    bbPluginSdk: semverRange.optional(),
-  })
-  .strict();
-
 const npmSourceSchema = z
   .object({
     npm: z
@@ -241,6 +234,14 @@ const gitSourceSchema = z.union([
     .strict(),
 ]);
 
+/**
+ * A listing describes a plugin and where to get it; it does not declare
+ * compatibility. A listing's copy of an `engines` range is a second source of
+ * truth that goes stale the moment the plugin publishes a new version, and it
+ * hid a compatible plugin behind an out-of-date manifest. BB reads
+ * `engines.bb` and `engines.bbPluginSdk` from the fetched plugin's own
+ * package.json and refuses the install there instead.
+ */
 const entrySchema = z
   .object({
     id: z.string().regex(NAME_PATTERN),
@@ -249,7 +250,6 @@ const entrySchema = z
     icon: iconSchema,
     tags: z.array(z.string().max(32).regex(TAG_PATTERN)).max(10).optional(),
     author: authorSchema,
-    engines: enginesSchema.optional(),
     source: z.union([npmSourceSchema, gitSourceSchema]),
   })
   .strict();
@@ -285,7 +285,6 @@ const marketplaceManifestSchema = z
 
 export type MarketplaceManifest = z.infer<typeof marketplaceManifestSchema>;
 export type MarketplaceEntry = MarketplaceManifest["plugins"][number];
-export type MarketplaceEngines = z.infer<typeof enginesSchema>;
 
 function formatIssues(error: z.ZodError): string {
   return error.issues
@@ -391,32 +390,6 @@ export function resolveEntryIcon(
     path: join(base.root, ...relativePath.split("/")),
     relativePath,
   };
-}
-
-/**
- * A marketplace may narrow the plugin manifest's engine ranges, never widen
- * them: a listing must not promise compatibility the plugin itself denies.
- */
-export function marketplacePolicyWideningProblem(
-  engines: MarketplaceEngines | undefined,
-  manifest: {
-    bbEngineRange: string | undefined;
-    bbPluginSdkRange: string | undefined;
-  },
-): string | null {
-  for (const [name, entryRange, manifestRange] of [
-    ["bb", engines?.bb, manifest.bbEngineRange],
-    ["bbPluginSdk", engines?.bbPluginSdk, manifest.bbPluginSdkRange],
-  ] as const) {
-    if (
-      entryRange !== undefined &&
-      manifestRange !== undefined &&
-      !semver.subset(entryRange, manifestRange)
-    ) {
-      return `marketplace engines.${name} range ${JSON.stringify(entryRange)} widens plugin manifest range ${JSON.stringify(manifestRange)}`;
-    }
-  }
-  return null;
 }
 
 /** Human-readable source of an entry, shown before anything is installed. */

--- a/apps/server/src/services/plugin-catalog/official-marketplace.ts
+++ b/apps/server/src/services/plugin-catalog/official-marketplace.ts
@@ -24,7 +24,6 @@ export const BUNDLED_OFFICIAL_MARKETPLACE: MarketplaceManifest = {
       icon: "ZoomIn",
       tags: ["interface", "threads", "sidebar"],
       author: { name: "BB Team", github: "get-bb", url: "https://getbb.app" },
-      engines: { bb: ">=0.0.34", bbPluginSdk: "^0.5.0" },
       source: {
         git: {
           url: "https://github.com/brsbl/bb-plugins.git",
@@ -41,7 +40,6 @@ export const BUNDLED_OFFICIAL_MARKETPLACE: MarketplaceManifest = {
       icon: "AiContentGenerator01",
       tags: ["agent-interaction", "prompts"],
       author: { name: "BB Team", github: "get-bb", url: "https://getbb.app" },
-      engines: { bb: ">=0.0.34", bbPluginSdk: "^0.5.0" },
       source: {
         git: {
           url: "https://github.com/brsbl/bb-plugins.git",

--- a/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
+++ b/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
@@ -318,6 +318,12 @@ export function createPluginCatalogService(deps: {
     };
   }
 
+  /**
+   * Compatibility of a plugin whose own manifest bb already has. Only bundled
+   * plugins qualify before an install: a marketplace listing declares no
+   * ranges, so its entry is offered as compatible and the install pipeline
+   * refuses it once the fetched package.json says otherwise.
+   */
   function compatibilityProblem(ranges: {
     bbRange: string | undefined;
     sdkRange: string | undefined;
@@ -411,10 +417,6 @@ export function createPluginCatalogService(deps: {
   }): PluginCatalogSearchResult {
     const { entry, row, catalog } = args;
     const official = row.name === OFFICIAL_MARKETPLACE_NAME;
-    const problem = compatibilityProblem({
-      bbRange: entry.engines?.bb,
-      sdkRange: entry.engines?.bbPluginSdk,
-    });
     return {
       entryId: entry.id,
       // An entry id is the plugin id it installs; the install aborts when the
@@ -433,8 +435,10 @@ export function createPluginCatalogService(deps: {
       installed:
         args.installedEntryIds.has(catalogEntryKey(row.name, entry.id)) ||
         getInstalledPlugin(deps.db, entry.id) !== undefined,
-      compatible: problem === null,
-      incompatibleReason: problem,
+      // The listing declares no ranges, so bb cannot judge a marketplace
+      // entry until it has fetched the plugin's own manifest.
+      compatible: true,
+      incompatibleReason: null,
     };
   }
 
@@ -812,13 +816,6 @@ export function createPluginCatalogService(deps: {
     return resolveGitEntrySource(git);
   }
 
-  function entryCompatibilityProblem(entry: MarketplaceEntry): string | null {
-    return compatibilityProblem({
-      bbRange: entry.engines?.bb,
-      sdkRange: entry.engines?.bbPluginSdk,
-    });
-  }
-
   /**
    * The exact artifact a confirmed third-party install is bound to. The
    * install pipeline refuses anything else, so a mutable range, dist-tag, or
@@ -833,10 +830,9 @@ export function createPluginCatalogService(deps: {
     entry: MarketplaceEntry,
     binding?: ConfirmedEntryBinding,
   ): Promise<InstalledPlugin> {
-    // The UI disables incompatible entries, but the server owns the policy:
-    // refuse direct installs the store would not offer.
-    const problem = entryCompatibilityProblem(entry);
-    if (problem !== null) throw new Error(`install refused: ${problem}`);
+    // Compatibility is the install pipeline's call: it reads the ranges from
+    // the plugin's own package.json once the source is fetched, and refuses
+    // the install there.
     const resolved = resolvedEntrySource(entry);
     return deps.plugins.installCatalogPlugin({
       marketplace: row.name,
@@ -844,7 +840,6 @@ export function createPluginCatalogService(deps: {
       pluginId: entry.id,
       source: resolved.source,
       selection: resolved.selection,
-      ...(entry.engines === undefined ? {} : { engines: entry.engines }),
       ...(resolved.npmRegistry === undefined
         ? {}
         : { npmRegistry: resolved.npmRegistry }),
@@ -1127,7 +1122,6 @@ export function createPluginCatalogService(deps: {
       }
       const { row, entry } = resolved;
       const official = row.name === OFFICIAL_MARKETPLACE_NAME;
-      const problem = entryCompatibilityProblem(entry);
       return {
         kind: "marketplace",
         entryId: entry.id,
@@ -1139,8 +1133,8 @@ export function createPluginCatalogService(deps: {
         author: entryAuthor(entry),
         source: resolvedEntrySource(entry).source,
         resolvedSource: await resolvedEntrySourceView(entry, official),
-        compatible: problem === null,
-        incompatibleReason: problem,
+        compatible: true,
+        incompatibleReason: null,
       };
     },
 

--- a/apps/server/src/services/plugins/managed-plugin-artifacts.ts
+++ b/apps/server/src/services/plugins/managed-plugin-artifacts.ts
@@ -49,7 +49,6 @@ import type {
   PluginListEntry,
   PluginServiceDeps,
 } from "./plugin-service-internal.js";
-import type { MarketplaceEngines } from "../plugin-catalog/marketplace-manifest.js";
 import {
   createNpmResolverRun,
   evaluateCompatibility,
@@ -72,8 +71,6 @@ export interface InstallRegistrationIdentity {
 export interface RegisterInstalledArgs extends InstallRegistrationIdentity {
   rootDir: string;
   source: string;
-  /** Engine ranges the marketplace listing declared, when it declared any. */
-  marketplaceEngines?: MarketplaceEngines;
   exactResolution: PluginExactResolution;
   refuseEngineMismatch: boolean;
   validated: boolean;
@@ -92,11 +89,6 @@ export interface InstallContext {
   expectedPluginId?: string;
   /** Git commit shown in the third-party install confirmation. */
   expectedGitCommit?: string;
-  /**
-   * Engine ranges a marketplace listing declared. They may narrow the plugin
-   * manifest's own ranges; {@link RegisterInstalledArgs} refuses widening.
-   */
-  marketplaceEngines?: MarketplaceEngines;
   /** npm registry a listing pins, replacing the host's npm configuration. */
   npmRegistry?: string;
   /**
@@ -228,15 +220,6 @@ export function createManagedPluginArtifacts(
   const directInstallContext: InstallContext = {
     provenance: { kind: "direct" },
   };
-
-  /** Listing policy carried into `registerInstalled` from an install context. */
-  function marketplacePolicy(context: InstallContext): {
-    marketplaceEngines?: MarketplaceEngines;
-  } {
-    return context.marketplaceEngines === undefined
-      ? {}
-      : { marketplaceEngines: context.marketplaceEngines };
-  }
 
   /** Use the guarded network and byte policy only for a listing's registry. */
   function npmResolverRun(listedRegistry: string | undefined) {
@@ -802,7 +785,6 @@ export function createManagedPluginArtifacts(
             rootDir: targetRoot,
             source,
             ...cachedRegistrationIdentity,
-            ...marketplacePolicy(context),
             exactResolution: { kind: "git", commit: resolvedCommit },
             refuseEngineMismatch: true,
             validated: true,
@@ -901,7 +883,6 @@ export function createManagedPluginArtifacts(
           rootDir: stagedTargetRoot,
           source,
           ...stagedRegistrationIdentity,
-          ...marketplacePolicy(context),
           exactResolution: { kind: "git", commit: resolvedCommit },
           refuseEngineMismatch: true,
           validated: true,
@@ -1099,7 +1080,6 @@ export function createManagedPluginArtifacts(
             rootDir,
             source,
             ...registrationIdentity,
-            ...marketplacePolicy(context),
             exactResolution: {
               kind: "npm",
               version: candidate.version,
@@ -1186,7 +1166,6 @@ export function createManagedPluginArtifacts(
           rootDir,
           source,
           ...registrationIdentity,
-          ...marketplacePolicy(context),
           exactResolution: {
             kind: "npm",
             version: candidate.version,

--- a/apps/server/src/services/plugins/plugin-registration.ts
+++ b/apps/server/src/services/plugins/plugin-registration.ts
@@ -54,6 +54,8 @@ export interface PluginRegistrationContext {
   disposeOne: (id: string) => Promise<void>;
   loadOne: (row: InstalledPluginRow) => Promise<void>;
   validateInstallDir: (args: RegisterInstalledArgs) => Promise<PluginManifest>;
+  checkEngineRange: (manifest: PluginManifest) => string | undefined;
+  checkPluginSdkRange: (manifest: PluginManifest) => string | undefined;
   syncCliSkill: () => Promise<void>;
   notifyPluginsChanged: () => void;
   list: () => PluginListEntry[];
@@ -67,6 +69,8 @@ export function createPluginRegistration(context: PluginRegistrationContext) {
     disposeOne,
     loadOne,
     validateInstallDir,
+    checkEngineRange,
+    checkPluginSdkRange,
     syncCliSkill,
     notifyPluginsChanged,
     list,
@@ -248,6 +252,22 @@ export function createPluginRegistration(context: PluginRegistrationContext) {
       args.sourceIntent.kind !== "builtin"
     ) {
       refuseBuiltinShadow(initialManifest.id);
+    }
+    // Compatibility is decided here, at the one chokepoint every managed
+    // registration passes through. `validateInstallDir` runs the same checks,
+    // but a cache hit registers with `validated: true` and skips it — and a
+    // cached artifact this bb accepted before can fail its own range after a
+    // bb or SDK version change. The plugin's package.json is the only source
+    // of truth for compatibility, so read it on every path.
+    if (args.refuseEngineMismatch) {
+      const engineProblem =
+        checkEngineRange(initialManifest) ??
+        checkPluginSdkRange(initialManifest);
+      if (engineProblem !== undefined) {
+        throw new Error(
+          `install refused: plugin "${initialManifest.id}" ${engineProblem}`,
+        );
+      }
     }
     const manifest = args.validated
       ? initialManifest

--- a/apps/server/src/services/plugins/plugin-registration.ts
+++ b/apps/server/src/services/plugins/plugin-registration.ts
@@ -18,10 +18,7 @@ import {
   builtinPluginSource,
   type BundledPluginRegistration,
 } from "./builtin-registry.js";
-import {
-  marketplacePolicyWideningProblem,
-  OFFICIAL_MARKETPLACE_NAME,
-} from "../plugin-catalog/marketplace-manifest.js";
+import { OFFICIAL_MARKETPLACE_NAME } from "../plugin-catalog/marketplace-manifest.js";
 import type { PluginSourceSelection } from "@bb/server-contract";
 import { resolveSelectedSubdirectory } from "./collection-manifest.js";
 import {
@@ -43,7 +40,6 @@ import type {
   PluginServiceDeps,
 } from "./plugin-service-internal.js";
 import {
-  evaluateCompatibility,
   gitResolvedVersion,
   resolveGitRef,
   type GitRefKind,
@@ -247,30 +243,6 @@ export function createPluginRegistration(context: PluginRegistrationContext) {
       args,
       initialManifest.id,
     );
-    // A marketplace listing may narrow the plugin's own engine ranges; it may
-    // never widen them, and it may not promise this bb build a plugin the
-    // listing itself declares incompatible.
-    const wideningProblem = marketplacePolicyWideningProblem(
-      args.marketplaceEngines,
-      initialManifest,
-    );
-    if (wideningProblem !== null) {
-      throw new Error(`install refused: ${wideningProblem}`);
-    }
-    if (args.marketplaceEngines !== undefined) {
-      const listed = evaluateCompatibility({
-        bbRange: args.marketplaceEngines.bb,
-        sdkRange: args.marketplaceEngines.bbPluginSdk,
-        appVersion: deps.appVersion,
-      });
-      if (listed.effective.length > 0) {
-        throw new Error(
-          `install refused by marketplace compatibility policy: ${listed.effective
-            .map((problem) => problem.message)
-            .join("; ")}`,
-        );
-      }
-    }
     if (
       args.provenance.kind !== "builtin" &&
       args.sourceIntent.kind !== "builtin"

--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -99,7 +99,6 @@ import {
   type InstallContext,
   type RegisterInstalledArgs,
 } from "./managed-plugin-artifacts.js";
-import type { MarketplaceEngines } from "../plugin-catalog/marketplace-manifest.js";
 import { createPluginRegistration } from "./plugin-registration.js";
 import { createPluginRuntime, forgetMutableRoot } from "./plugin-runtime.js";
 import { createPluginUpdates } from "./plugin-updates.js";
@@ -205,8 +204,6 @@ export interface PluginService {
     source: string;
     /** Which plugin of a multi-plugin repository the entry lists. */
     selection: PluginSourceSelection;
-    /** Listed engine ranges; they may narrow the manifest's, never widen it. */
-    engines?: MarketplaceEngines;
     /** npm registry the listing pins. */
     npmRegistry?: string;
     /** Git commit the user confirmed before a third-party install. */
@@ -1554,9 +1551,6 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
             entryId: entry.entryId,
           },
           expectedPluginId: entry.pluginId,
-          ...(entry.engines === undefined
-            ? {}
-            : { marketplaceEngines: entry.engines }),
           ...(entry.npmRegistry === undefined
             ? {}
             : { npmRegistry: entry.npmRegistry }),

--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -998,6 +998,8 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
     disposeOne,
     loadOne,
     validateInstallDir: (args) => managedValidateInstallDir(args),
+    checkEngineRange,
+    checkPluginSdkRange,
     syncCliSkill,
     notifyPluginsChanged,
     list,

--- a/apps/server/test/services/plugin-catalog/marketplace-manifest.test.ts
+++ b/apps/server/test/services/plugin-catalog/marketplace-manifest.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import {
   entrySourceDisplay,
-  marketplacePolicyWideningProblem,
   parseMarketplaceManifest,
   resolveEntryIcon,
   resolvedEntrySource,
@@ -86,7 +85,6 @@ describe("marketplace manifest schema", () => {
           github: "acme-co",
           url: "https://acme.example",
         },
-        engines: { bb: ">=0.0.34", bbPluginSdk: "^0.5.0" },
       }),
     ]);
     expect(parsed.plugins).toHaveLength(1);
@@ -378,37 +376,18 @@ describe("marketplace manifest schema", () => {
   });
 
   describe("engines policy", () => {
-    it("allows a listing to narrow the manifest ranges", () => {
-      expect(
-        marketplacePolicyWideningProblem(
-          { bb: ">=1.2.0", bbPluginSdk: "^0.5.0" },
-          { bbEngineRange: ">=1.0.0", bbPluginSdkRange: "^0.5.0" },
-        ),
-      ).toBe(null);
-    });
-
-    it("refuses a listing that widens a manifest range", () => {
-      expect(
-        marketplacePolicyWideningProblem(
-          { bb: ">=0.1.0" },
-          { bbEngineRange: ">=1.0.0", bbPluginSdkRange: undefined },
-        ),
-      ).toMatch(/widens plugin manifest range/);
-      expect(
-        marketplacePolicyWideningProblem(
-          { bbPluginSdk: ">=0.4.0" },
-          { bbEngineRange: undefined, bbPluginSdkRange: "^0.5.0" },
-        ),
-      ).toMatch(/engines\.bbPluginSdk/);
-    });
-
-    it("ignores ranges the plugin manifest does not declare", () => {
-      expect(
-        marketplacePolicyWideningProblem(
-          { bb: ">=0.1.0" },
-          { bbEngineRange: undefined, bbPluginSdkRange: undefined },
-        ),
-      ).toBe(null);
+    // A listing no longer declares compatibility: the ranges live in the
+    // plugin's own package.json and the install pipeline enforces them there.
+    // The entry schema is strict, so a stale listing fails loudly rather than
+    // carrying a range bb would silently ignore.
+    it("refuses an entry that declares engine ranges", () => {
+      for (const engines of [
+        { bb: ">=1.0.0" },
+        { bbPluginSdk: "^0.5.0" },
+        { bb: ">=1.0.0", bbPluginSdk: "^0.5.0" },
+      ]) {
+        expect(() => parse([entry({ engines })])).toThrow(/engines/u);
+      }
     });
   });
 

--- a/apps/server/test/services/plugin-catalog/marketplace-schema-parity.test.ts
+++ b/apps/server/test/services/plugin-catalog/marketplace-schema-parity.test.ts
@@ -67,8 +67,13 @@ function rangeFixture(label: string, range: string, valid: boolean): Fixture {
   };
 }
 
-function enginesFixture(label: string, bb: string, valid: boolean): Fixture {
-  return { label, valid, manifest: manifestWith({ engines: { bb } }) };
+/**
+ * A listing declares no compatibility ranges. Both documents must reject the
+ * old `engines` key alike, so a stale manifest fails in the registry's CI
+ * rather than only inside bb.
+ */
+function enginesFixture(label: string, engines: unknown): Fixture {
+  return { label, valid: false, manifest: manifestWith({ engines }) };
 }
 
 const fixtures: readonly Fixture[] = [
@@ -154,8 +159,9 @@ const fixtures: readonly Fixture[] = [
   rangeFixture("four segments", "1.2.3.4", false),
   rangeFixture("garbage alternative", "1.0.0 || garbage", false),
 
-  enginesFixture("engines range", ">=0.30.0", true),
-  enginesFixture("engines prose", "newest", false),
+  enginesFixture("engines.bb range", { bb: ">=0.30.0" }),
+  enginesFixture("engines.bbPluginSdk range", { bbPluginSdk: "^0.5.0" }),
+  enginesFixture("empty engines object", {}),
 
   {
     label: "marketplace name at the route limit",

--- a/apps/server/test/services/plugin-catalog/plugin-catalog-service.test.ts
+++ b/apps/server/test/services/plugin-catalog/plugin-catalog-service.test.ts
@@ -9,7 +9,6 @@ import {
   upsertInstalledPlugin,
   type DbConnection,
 } from "@bb/db";
-import { PLUGIN_SDK_VERSION } from "@bb/domain";
 import { ROOT_PLUGIN_SOURCE_SELECTION } from "@bb/server-contract";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createPluginCatalogService } from "../../../src/services/plugin-catalog/plugin-catalog-service.js";
@@ -39,7 +38,6 @@ function remoteEntry(overrides: Record<string, unknown> = {}) {
     icon: { url: "./icons/widgets.svg" },
     tags: ["interface", "widgets"],
     author: { name: "Acme", github: "acme" },
-    engines: { bb: ">=0.0.1" },
     source: {
       git: {
         url: "https://github.com/acme/plugins.git",
@@ -199,8 +197,8 @@ describe("plugin catalog service", () => {
       source:
         "git:https://github.com/brsbl/bb-plugins.git@30f91fd977ba1ce60532af27a68534464fb62516",
       installed: false,
-      compatible: false,
-      incompatibleReason: `requires bb plugin SDK ^0.5.0, running SDK is ${PLUGIN_SDK_VERSION}`,
+      compatible: true,
+      incompatibleReason: null,
     });
   });
 
@@ -555,7 +553,6 @@ describe("plugin catalog service", () => {
           pluginId: "widgets",
           source: "git:https://github.com/acme/plugins.git@v1.0.0",
           selection: { kind: "subdirectory", path: "plugins/widgets" },
-          engines: { bb: ">=0.0.1" },
         },
       ]);
       expect(installedNames).toEqual([]);
@@ -584,25 +581,26 @@ describe("plugin catalog service", () => {
           pluginId: "widgets",
           source: "npm:bb-plugin-widgets@beta",
           selection: ROOT_PLUGIN_SOURCE_SELECTION,
-          engines: { bb: ">=0.0.1" },
           npmRegistry: "https://npm.acme.test",
         },
       ]);
     });
 
-    it("refuses an entry this bb build cannot run", async () => {
-      const catalog = await refreshedCatalog(
-        remoteEntry({ icon: "Zap", engines: { bb: ">=99.0.0" } }),
-      );
+    // A listing carries no ranges, so the store cannot pre-judge an entry.
+    // It offers every entry and lets the install pipeline read the plugin's
+    // own package.json and refuse there.
+    it("offers a marketplace entry without judging compatibility", async () => {
+      const catalog = await refreshedCatalog(remoteEntry({ icon: "Zap" }));
       const [entry] = await catalog.search("widgets");
       expect(entry).toMatchObject({
-        compatible: false,
-        incompatibleReason: expect.stringContaining(">=99.0.0"),
+        compatible: true,
+        incompatibleReason: null,
       });
+      const plan = await catalog.installPlan({ entryId: "widgets" });
+      expect(plan).toMatchObject({ compatible: true, incompatibleReason: null });
       await expect(catalog.install({ entryId: "widgets" })).rejects.toThrow(
-        /install refused/,
+        "catalog installation stopped by test",
       );
-      expect(installedCatalogEntries).toEqual([]);
     });
 
     it("reads the installed flag from catalog provenance", async () => {

--- a/apps/server/test/services/plugins/plugin-install.test.ts
+++ b/apps/server/test/services/plugins/plugin-install.test.ts
@@ -964,6 +964,52 @@ describe("plugin install flows", () => {
       await stat(join(pathDir, "package.json"));
     });
 
+    // A cache hit registers with `validated: true`, which skips
+    // `validateInstallDir` and the engine checks inside it. The cached bytes
+    // were compatible when bb first accepted them, so nothing re-reads the
+    // range — and after a bb version change the same artifact can register
+    // while this build cannot run it.
+    it("refuses a cached artifact whose engine range no longer matches", async () => {
+      const repoDir = join(workDir, "repo-cached-engine");
+      await writePluginFixture(repoDir, {
+        name: "bb-plugin-cached-engine",
+        engines: ">=0.9.0",
+      });
+      await initGitRepo(repoDir);
+      await commitAll(repoDir, "init");
+      const source = `git:${repoDir}@main`;
+
+      await service.install(source, { kind: "root" });
+      expect(await service.remove("cached-engine")).toBe(true);
+      const clonesBefore = materializationCount;
+      await service.stop();
+
+      // The same db and dataDir, so the checkout and its artifact row survive.
+      service = createPluginService({
+        db,
+        hub: {
+          getDaemonSessionIdForHost: () => null,
+          notifyPluginSignal: () => 0,
+          notifySystem: () => {},
+        },
+        logger,
+        dataDir,
+        appVersion: "0.5.0",
+        loadTimeoutMs: 2000,
+        onArtifactMaterialize: () => {
+          materializationCount += 1;
+        },
+      });
+
+      await expect(
+        service.install(source, { kind: "root" }),
+      ).rejects.toThrowError(/install refused.*requires bb >=0\.9\.0/u);
+      // No re-clone: the refusal came from the cache-hit path, not a fresh
+      // materialization that would have run the checks anyway.
+      expect(materializationCount).toBe(clonesBefore);
+      expect(getInstalledPluginRegistration(db, "cached-engine")).toBeUndefined();
+    });
+
     it("refuses a git url without the git binary being asked to run arbitrary flags", async () => {
       await expect(
         service.install("git:@main", { kind: "root" }),

--- a/apps/server/test/services/plugins/plugin-install.test.ts
+++ b/apps/server/test/services/plugins/plugin-install.test.ts
@@ -450,27 +450,34 @@ describe("plugin install flows", () => {
       expect(getInstalledPlugin(db, "confirmed")).toBeUndefined();
     });
 
-    it("refuses a catalog entry that widens the plugin's engine range", async () => {
-      const repoDir = join(workDir, "repo-catalog-widening");
+    // A listing declares no ranges, so nothing rejects this entry before the
+    // clone. The plugin's own package.json is the only source of truth, and
+    // the install pipeline must read it and refuse.
+    it("refuses a catalog entry whose plugin requires another plugin SDK", async () => {
+      const repoDir = join(workDir, "repo-catalog-sdk-too-new");
       await writePluginFixture(repoDir, {
-        name: "bb-plugin-narrow",
-        engines: ">=0.5.0",
+        name: "bb-plugin-sdk-listed",
+        pluginSdkRange: ">=99.0.0",
       });
       await initGitRepo(repoDir);
       await commitAll(repoDir, "init");
-      await git(repoDir, ["branch", "plugin/narrow"]);
+      await git(repoDir, ["branch", "plugin/listed"]);
 
       await expect(
         service.installCatalogPlugin({
           marketplace: "bb-official",
-          entryId: "narrow",
-          pluginId: "narrow",
-          source: `git:${repoDir}@plugin/narrow`,
+          entryId: "sdk-listed",
+          pluginId: "sdk-listed",
+          source: `git:${repoDir}@plugin/listed`,
           selection: ROOT_PLUGIN_SOURCE_SELECTION,
-          engines: { bb: ">=0.1.0" },
         }),
-      ).rejects.toThrow(/widens plugin manifest range/);
-      expect(getInstalledPluginRegistration(db, "narrow")).toBeUndefined();
+      ).rejects.toThrow(
+        new RegExp(
+          `install refused.*requires bb plugin SDK >=99\\.0\\.0, running SDK is ${PLUGIN_SDK_VERSION.replaceAll(".", "\\.")}`,
+          "u",
+        ),
+      );
+      expect(getInstalledPluginRegistration(db, "sdk-listed")).toBeUndefined();
     });
 
     it("refuses a listed npm registry that is not a public https host", async () => {

--- a/apps/web/public/schemas/marketplace.schema.json
+++ b/apps/web/public/schemas/marketplace.schema.json
@@ -40,6 +40,7 @@
     "entry": {
       "type": "object",
       "additionalProperties": false,
+      "$comment": "An entry does not declare compatibility. BB reads engines.bb and engines.bbPluginSdk from the plugin's own package.json and refuses the install there.",
       "required": [
         "id",
         "displayName",
@@ -110,19 +111,6 @@
             "url": {
               "type": "string",
               "pattern": "^https://"
-            }
-          }
-        },
-        "engines": {
-          "type": "object",
-          "additionalProperties": false,
-          "$comment": "May narrow the plugin manifest's ranges; BB refuses an install that widens them.",
-          "properties": {
-            "bb": {
-              "$ref": "#/$defs/semverRange"
-            },
-            "bbPluginSdk": {
-              "$ref": "#/$defs/semverRange"
             }
           }
         },

--- a/docs/plugin-marketplace-plan.md
+++ b/docs/plugin-marketplace-plan.md
@@ -48,7 +48,6 @@ collection manifest by pinning a ref and pointing each entry at its subdir.
         "github": "get-bb",
         "url": "https://getbb.app"
       },
-      "engines": { "bb": ">=0.0.34", "bbPluginSdk": "^0.5.0" },
       "source": {
         "git": {
           "url": "https://github.com/brsbl/bb-plugins.git",
@@ -88,8 +87,12 @@ Rules:
   the Browse tab derives its groupings from tags. The official marketplace
   keeps a curated tag vocabulary (the current `PLUGIN_CATALOG_CATEGORIES`
   set, lowercased) so its sections stay stable.
-- `engines` may narrow the package manifest's ranges. It may never widen them.
-  Restore the `marketplacePolicyWideningProblem` check from PR #636.
+- A listing declares no compatibility. There is no `engines` field, and the
+  strict schema rejects one. A listing's copy of a range is a second source of
+  truth that goes stale as soon as the plugin publishes a new version, and it
+  hid compatible plugins behind an out-of-date manifest. bb reads `engines.bb`
+  and `engines.bbPluginSdk` from the fetched plugin's own `package.json` and
+  refuses the install there instead.
 - Sources are objects, not strings. Strings stay in the CLI; the manifest is a
   machine contract with per-field validation and no parser to reimplement.
 - Display fields exist so the store renders without a clone or an npm fetch.


### PR DESCRIPTION
## Summary

A marketplace listing declared `engines.bb` and `engines.bbPluginSdk`, and bb judged an entry's compatibility from those ranges before it fetched anything. A listing's copy of a range is a second source of truth: it goes stale the moment the plugin publishes a new version, and a stale range hides a plugin that this bb can in fact run.

This removes `engines` from the marketplace contract. The store now offers every listed entry, and the install pipeline decides compatibility from the plugin's own `package.json`.

## What changed

- **`marketplace-manifest.ts`** — deleted `enginesSchema`, the `engines` entry field, the `MarketplaceEngines` type, and `marketplacePolicyWideningProblem`. The entry schema is `.strict()`, so a listing that still declares `engines` fails to parse.
- **`marketplace.schema.json`** — the same removal, so the registry's CI rejects a stale listing before bb sees it.
- **`official-marketplace.ts`** — dropped `engines` from both seed entries.
- **`plugin-catalog-service.ts`** — a marketplace entry is always offered as `compatible: true`. Bundled plugins keep their pre-install check, because bb already holds their manifests. The pre-install refusal and the `engines` hand-off to `installCatalogPlugin` are gone.
- **`plugin-service.ts`, `managed-plugin-artifacts.ts`, `plugin-registration.ts`** — removed `marketplaceEngines` from the install contract and the two listing-policy checks it fed.
- **Docs** — updated the marketplace plan rules. `docs/configuration.md` already described install-time enforcement and needed no change.

## Where enforcement lives now

`managed-plugin-artifacts.validateManifestOnly` runs `checkEngineRange` then `checkPluginSdkRange` against the fetched plugin's `package.json`, under `refuseEngineMismatch: true` on every managed git and npm path. Catalog installs use those same paths, so a store install fails with:

```
install refused: plugin "x" requires bb plugin SDK >=99.0.0, running SDK is 0.4.5
```

The app surfaces that through the existing install-error toast.

## Side effect worth knowing

The seed entries declared `bbPluginSdk: "^0.5.0"` while `PLUGIN_SDK_VERSION` is `0.4.5`. Both seed entries evaluated as incompatible, and `BrowsePluginsTab` filters incompatible entries out — so the first-run and offline official catalog rendered empty. Removing the field fixes that. A catalog test asserted the broken state; this updates it.

## Compatibility

A published manifest that still declares `engines` is now rejected whole. This is deliberate: a strict schema fails loudly in the registry's CI rather than carrying a range bb silently ignores. `github.com/brsbl/bb-plugins` must republish without the field.

`HOST_DAEMON_PROTOCOL_VERSION` is not bumped. `marketplaceEngines` lived only in server-internal service types and never crossed the server/daemon wire.

## Testing

- New: the manifest schema refuses an entry with `engines`; schema-parity fixtures assert both documents refuse it alike.
- Replaced the "listing widens the manifest range" install test with one proving a catalog install is refused by the plugin's own `engines.bbPluginSdk`.
- `@bb/server` 1657 passed, `@bb/cli` 448 passed, `@bb/sdk` 90 passed. Typecheck and lint clean.

One unrelated test fails on this branch and identically on base: `internal-skill-trees.test.ts > returns a registered tree manifest to an authenticated daemon`.

> AGENT GENERATED: by Claude Opus 5

---

## Follow-up from review (8772e57)

SlopCop caught a real gap in exactly what this PR promises. `registerInstalled` computes `args.validated ? initialManifest : await validateInstallDir(args)`, and every cache-hit path registers with `validated: true` — so `refuseEngineMismatch: true` was accepted and then silently ignored, because the engine and SDK checks live inside `validateInstallDir`. A cached artifact bb accepted before a version change could register again on a build that cannot run it.

The check now runs in `registerInstalled` itself, the one chokepoint every managed registration passes through, gated on `refuseEngineMismatch` so path and builtin installs are unchanged.

Regression test: installs under bb `0.9.0`, removes the plugin, restarts the service as bb `0.5.0`, and reinstalls from the same commit. It asserts the refusal and that `materializationCount` did not increase, proving the refusal came from the cache-hit path rather than a fresh clone. Verified failing without the fix.

## Release sequencing

`parseMarketplaceManifest` rejects a document whole, so the official manifest at `https://getbb.app/marketplace/v1/marketplace.json` must be republished without `engines` **before this ships**. Until then a refresh fails and the store serves the last-known-good catalog, or the bundled seed on a fresh install.
