### PR TITLE
Fix iOS terminal touch focus

### DIFF
--- a/apps/app/src/components/thread/terminal/ThreadTerminalView.test.ts
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalView.test.ts
@@ -9,6 +9,7 @@ import {
   loadOptionalTerminalWebglAddon,
   loadTerminalWebglRenderer,
   shouldFocusTerminalAfterAsyncMount,
+  shouldFocusTerminalFromTouchRelease,
   TERMINAL_ALLOW_PROPOSED_API,
   TERMINAL_FONT_FAMILY,
   TERMINAL_UNICODE_VERSION,
@@ -80,6 +81,29 @@ describe("terminal async mount focus", () => {
         isPanelOpen: false,
       }),
     ).toBe(false);
+  });
+});
+
+describe("terminal touch focus", () => {
+  it("focuses the terminal after a tap", () => {
+    expect(
+      shouldFocusTerminalFromTouchRelease({ x: 40, y: 80 }, { x: 43, y: 84 }),
+    ).toBe(true);
+  });
+
+  it("does not focus the terminal after a scroll gesture", () => {
+    expect(
+      shouldFocusTerminalFromTouchRelease({ x: 40, y: 80 }, { x: 40, y: 120 }),
+    ).toBe(false);
+  });
+
+  it("does not focus the terminal without one complete touch", () => {
+    expect(shouldFocusTerminalFromTouchRelease(null, { x: 40, y: 80 })).toBe(
+      false,
+    );
+    expect(shouldFocusTerminalFromTouchRelease({ x: 40, y: 80 }, null)).toBe(
+      false,
+    );
   });
 });
 

--- a/apps/app/src/components/thread/terminal/ThreadTerminalView.test.ts
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalView.test.ts
@@ -5,16 +5,29 @@ import {
   buildTerminalThemeFromCssColors,
   decodeTerminalOutputBytes,
   encodeTerminalInputChunks,
+  focusTerminalFromTouchRelease,
   forwardTerminalData,
   loadOptionalTerminalWebglAddon,
   loadTerminalWebglRenderer,
   shouldFocusTerminalAfterAsyncMount,
-  shouldFocusTerminalFromTouchRelease,
+  startTerminalTouchFocusGesture,
   TERMINAL_ALLOW_PROPOSED_API,
   TERMINAL_FONT_FAMILY,
   TERMINAL_UNICODE_VERSION,
   writeTerminalOutput,
+  updateTerminalTouchFocusGesture,
 } from "./ThreadTerminalView";
+
+function startTouchFocusGesture() {
+  const gesture = startTerminalTouchFocusGesture(
+    [{ identifier: 1, x: 40, y: 80 }],
+    100,
+  );
+  if (gesture === null) {
+    throw new Error("Expected one touch to start a focus gesture");
+  }
+  return gesture;
+}
 
 describe("terminal async mount focus", () => {
   it("preserves focus that moved to the composer while xterm loaded", () => {
@@ -86,24 +99,60 @@ describe("terminal async mount focus", () => {
 
 describe("terminal touch focus", () => {
   it("focuses the terminal after a tap", () => {
+    const focus = vi.fn();
+
     expect(
-      shouldFocusTerminalFromTouchRelease({ x: 40, y: 80 }, { x: 43, y: 84 }),
+      focusTerminalFromTouchRelease({
+        changedTouches: [{ identifier: 1, x: 43, y: 84 }],
+        focus,
+        gesture: startTouchFocusGesture(),
+        releasedAt: 200,
+        remainingTouchCount: 0,
+      }),
     ).toBe(true);
+    expect(focus).toHaveBeenCalledOnce();
   });
 
-  it("does not focus the terminal after a scroll gesture", () => {
+  it("does not focus after a drag returns near its start", () => {
+    const focus = vi.fn();
+    const gesture = updateTerminalTouchFocusGesture(startTouchFocusGesture(), [
+      { identifier: 1, x: 40, y: 120 },
+    ]);
+
     expect(
-      shouldFocusTerminalFromTouchRelease({ x: 40, y: 80 }, { x: 40, y: 120 }),
+      focusTerminalFromTouchRelease({
+        changedTouches: [{ identifier: 1, x: 40, y: 81 }],
+        focus,
+        gesture,
+        releasedAt: 200,
+        remainingTouchCount: 0,
+      }),
     ).toBe(false);
+    expect(focus).not.toHaveBeenCalled();
   });
 
-  it("does not focus the terminal without one complete touch", () => {
-    expect(shouldFocusTerminalFromTouchRelease(null, { x: 40, y: 80 })).toBe(
-      false,
-    );
-    expect(shouldFocusTerminalFromTouchRelease({ x: 40, y: 80 }, null)).toBe(
-      false,
-    );
+  it("does not focus after a long press", () => {
+    const focus = vi.fn();
+
+    expect(
+      focusTerminalFromTouchRelease({
+        changedTouches: [{ identifier: 1, x: 40, y: 80 }],
+        focus,
+        gesture: startTouchFocusGesture(),
+        releasedAt: 800,
+        remainingTouchCount: 0,
+      }),
+    ).toBe(false);
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it("invalidates the gesture when another touch starts", () => {
+    expect(
+      updateTerminalTouchFocusGesture(startTouchFocusGesture(), [
+        { identifier: 1, x: 40, y: 80 },
+        { identifier: 2, x: 80, y: 80 },
+      ]),
+    ).toBeNull();
   });
 });
 

--- a/apps/app/src/components/thread/terminal/ThreadTerminalView.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalView.tsx
@@ -36,6 +36,7 @@ export const TERMINAL_FONT_FAMILY =
 export const TERMINAL_UNICODE_VERSION = "11";
 export const TERMINAL_ALLOW_PROPOSED_API = true;
 const TERMINAL_SELECTION_DRAG_DIRECTION_THRESHOLD_PX = 4;
+const TERMINAL_TOUCH_FOCUS_MAX_DURATION_MS = 700;
 const TERMINAL_TOUCH_FOCUS_MOVEMENT_THRESHOLD_PX = 10;
 
 type TerminalFitScheduler = () => void;
@@ -108,18 +109,110 @@ interface TerminalSelectionAnchorPoint {
   y: number;
 }
 
-export function shouldFocusTerminalFromTouchRelease(
-  startPoint: TerminalSelectionAnchorPoint | null,
-  releasePoint: TerminalSelectionAnchorPoint | null,
-): boolean {
-  if (startPoint === null || releasePoint === null) {
+interface TerminalTouchPoint extends TerminalSelectionAnchorPoint {
+  identifier: number;
+}
+
+interface TerminalTouchFocusGesture {
+  identifier: number;
+  maximumMovementPx: number;
+  startedAt: number;
+  startPoint: TerminalSelectionAnchorPoint;
+}
+
+interface FocusTerminalFromTouchReleaseArgs {
+  changedTouches: readonly TerminalTouchPoint[];
+  focus: () => void;
+  gesture: TerminalTouchFocusGesture | null;
+  releasedAt: number;
+  remainingTouchCount: number;
+}
+
+function terminalTouchMovement(
+  startPoint: TerminalSelectionAnchorPoint,
+  currentPoint: TerminalSelectionAnchorPoint,
+): number {
+  return Math.hypot(
+    currentPoint.x - startPoint.x,
+    currentPoint.y - startPoint.y,
+  );
+}
+
+export function startTerminalTouchFocusGesture(
+  touches: readonly TerminalTouchPoint[],
+  startedAt: number,
+): TerminalTouchFocusGesture | null {
+  const touch = touches.length === 1 ? touches[0] : undefined;
+  if (touch === undefined) {
+    return null;
+  }
+  return {
+    identifier: touch.identifier,
+    maximumMovementPx: 0,
+    startedAt,
+    startPoint: { x: touch.x, y: touch.y },
+  };
+}
+
+export function updateTerminalTouchFocusGesture(
+  gesture: TerminalTouchFocusGesture | null,
+  touches: readonly TerminalTouchPoint[],
+): TerminalTouchFocusGesture | null {
+  const touch = touches.length === 1 ? touches[0] : undefined;
+  if (
+    gesture === null ||
+    touch === undefined ||
+    touch.identifier !== gesture.identifier
+  ) {
+    return null;
+  }
+  return {
+    ...gesture,
+    maximumMovementPx: Math.max(
+      gesture.maximumMovementPx,
+      terminalTouchMovement(gesture.startPoint, touch),
+    ),
+  };
+}
+
+export function focusTerminalFromTouchRelease({
+  changedTouches,
+  focus,
+  gesture,
+  releasedAt,
+  remainingTouchCount,
+}: FocusTerminalFromTouchReleaseArgs): boolean {
+  if (remainingTouchCount !== 0) {
     return false;
   }
-  const deltaX = releasePoint.x - startPoint.x;
-  const deltaY = releasePoint.y - startPoint.y;
-  return (
-    Math.hypot(deltaX, deltaY) <= TERMINAL_TOUCH_FOCUS_MOVEMENT_THRESHOLD_PX
+  const completedGesture = updateTerminalTouchFocusGesture(
+    gesture,
+    changedTouches,
   );
+  if (completedGesture === null) {
+    return false;
+  }
+  const duration = releasedAt - completedGesture.startedAt;
+  if (
+    duration < 0 ||
+    duration >= TERMINAL_TOUCH_FOCUS_MAX_DURATION_MS ||
+    completedGesture.maximumMovementPx >
+      TERMINAL_TOUCH_FOCUS_MOVEMENT_THRESHOLD_PX
+  ) {
+    return false;
+  }
+  focus();
+  return true;
+}
+
+function terminalTouchPoints(
+  touches: ReactTouchEvent<HTMLDivElement>["touches"],
+): TerminalTouchPoint[] {
+  return Array.from(touches, (touch) => ({
+    identifier: touch.identifier,
+    x: touch.clientX,
+    y: touch.clientY,
+  }));
 }
 
 interface TerminalSelectionAnchor {
@@ -516,7 +609,7 @@ export function ThreadTerminalView({
   const pointerStartPointRef = useRef<TerminalSelectionAnchorPoint | null>(
     null,
   );
-  const touchStartPointRef = useRef<TerminalSelectionAnchorPoint | null>(null);
+  const touchFocusGestureRef = useRef<TerminalTouchFocusGesture | null>(null);
   const lastPointerReleaseAnchorRef = useRef<TerminalSelectionAnchor | null>(
     null,
   );
@@ -625,37 +718,47 @@ export function ThreadTerminalView({
 
   const handleTerminalTouchStart = useCallback(
     (event: ReactTouchEvent<HTMLDivElement>) => {
-      const touch = event.touches.length === 1 ? event.touches.item(0) : null;
-      touchStartPointRef.current =
-        touch === null ? null : { x: touch.clientX, y: touch.clientY };
+      touchFocusGestureRef.current = startTerminalTouchFocusGesture(
+        terminalTouchPoints(event.touches),
+        event.timeStamp,
+      );
+    },
+    [],
+  );
+
+  const handleTerminalTouchMove = useCallback(
+    (event: ReactTouchEvent<HTMLDivElement>) => {
+      touchFocusGestureRef.current = updateTerminalTouchFocusGesture(
+        touchFocusGestureRef.current,
+        terminalTouchPoints(event.touches),
+      );
     },
     [],
   );
 
   const handleTerminalTouchEnd = useCallback(
     (event: ReactTouchEvent<HTMLDivElement>) => {
-      const startPoint = touchStartPointRef.current;
-      touchStartPointRef.current = null;
-      const touch =
-        event.touches.length === 0 && event.changedTouches.length === 1
-          ? event.changedTouches.item(0)
-          : null;
-      const releasePoint =
-        touch === null ? null : { x: touch.clientX, y: touch.clientY };
-      if (shouldFocusTerminalFromTouchRelease(startPoint, releasePoint)) {
-        // xterm cancels the synthetic mouse event on touch devices.
-        // Focus during the touch event so iOS can open its software keyboard.
-        terminalRef.current?.focus();
-      }
+      const gesture = touchFocusGestureRef.current;
+      touchFocusGestureRef.current = null;
+      // xterm cancels the synthetic mouse event on touch devices.
+      // Focus during the touch event so iOS can open its software keyboard.
+      focusTerminalFromTouchRelease({
+        changedTouches: terminalTouchPoints(event.changedTouches),
+        focus: () => terminalRef.current?.focus(),
+        gesture,
+        releasedAt: event.timeStamp,
+        remainingTouchCount: event.touches.length,
+      });
     },
     [],
   );
 
   const handleTerminalTouchCancel = useCallback(() => {
-    touchStartPointRef.current = null;
+    touchFocusGestureRef.current = null;
   }, []);
 
   useEffect(() => {
+    touchFocusGestureRef.current = null;
     setActiveSelection(null);
   }, [session.id]);
 
@@ -952,6 +1055,7 @@ export function ThreadTerminalView({
       onPointerUp={handleTerminalPointerRelease}
       onPointerCancel={handleTerminalPointerCancel}
       onTouchStart={handleTerminalTouchStart}
+      onTouchMove={handleTerminalTouchMove}
       onTouchEnd={handleTerminalTouchEnd}
       onTouchCancel={handleTerminalTouchCancel}
     >

--- a/apps/app/src/components/thread/terminal/ThreadTerminalView.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalView.tsx
@@ -4,6 +4,7 @@ import {
   useRef,
   useState,
   type PointerEvent as ReactPointerEvent,
+  type TouchEvent as ReactTouchEvent,
 } from "react";
 import "@xterm/xterm/css/xterm.css";
 import type {
@@ -35,6 +36,7 @@ export const TERMINAL_FONT_FAMILY =
 export const TERMINAL_UNICODE_VERSION = "11";
 export const TERMINAL_ALLOW_PROPOSED_API = true;
 const TERMINAL_SELECTION_DRAG_DIRECTION_THRESHOLD_PX = 4;
+const TERMINAL_TOUCH_FOCUS_MOVEMENT_THRESHOLD_PX = 10;
 
 type TerminalFitScheduler = () => void;
 
@@ -104,6 +106,20 @@ export function loadTerminalWebglRenderer(
 interface TerminalSelectionAnchorPoint {
   x: number;
   y: number;
+}
+
+export function shouldFocusTerminalFromTouchRelease(
+  startPoint: TerminalSelectionAnchorPoint | null,
+  releasePoint: TerminalSelectionAnchorPoint | null,
+): boolean {
+  if (startPoint === null || releasePoint === null) {
+    return false;
+  }
+  const deltaX = releasePoint.x - startPoint.x;
+  const deltaY = releasePoint.y - startPoint.y;
+  return (
+    Math.hypot(deltaX, deltaY) <= TERMINAL_TOUCH_FOCUS_MOVEMENT_THRESHOLD_PX
+  );
 }
 
 interface TerminalSelectionAnchor {
@@ -500,6 +516,7 @@ export function ThreadTerminalView({
   const pointerStartPointRef = useRef<TerminalSelectionAnchorPoint | null>(
     null,
   );
+  const touchStartPointRef = useRef<TerminalSelectionAnchorPoint | null>(null);
   const lastPointerReleaseAnchorRef = useRef<TerminalSelectionAnchor | null>(
     null,
   );
@@ -605,6 +622,38 @@ export function ThreadTerminalView({
       reportTerminalSelection(lastPointerReleaseAnchorRef.current);
     });
   }, [reportTerminalSelection]);
+
+  const handleTerminalTouchStart = useCallback(
+    (event: ReactTouchEvent<HTMLDivElement>) => {
+      const touch = event.touches.length === 1 ? event.touches.item(0) : null;
+      touchStartPointRef.current =
+        touch === null ? null : { x: touch.clientX, y: touch.clientY };
+    },
+    [],
+  );
+
+  const handleTerminalTouchEnd = useCallback(
+    (event: ReactTouchEvent<HTMLDivElement>) => {
+      const startPoint = touchStartPointRef.current;
+      touchStartPointRef.current = null;
+      const touch =
+        event.touches.length === 0 && event.changedTouches.length === 1
+          ? event.changedTouches.item(0)
+          : null;
+      const releasePoint =
+        touch === null ? null : { x: touch.clientX, y: touch.clientY };
+      if (shouldFocusTerminalFromTouchRelease(startPoint, releasePoint)) {
+        // xterm cancels the synthetic mouse event on touch devices.
+        // Focus during the touch event so iOS can open its software keyboard.
+        terminalRef.current?.focus();
+      }
+    },
+    [],
+  );
+
+  const handleTerminalTouchCancel = useCallback(() => {
+    touchStartPointRef.current = null;
+  }, []);
 
   useEffect(() => {
     setActiveSelection(null);
@@ -902,6 +951,9 @@ export function ThreadTerminalView({
       onPointerDown={handleTerminalPointerDown}
       onPointerUp={handleTerminalPointerRelease}
       onPointerCancel={handleTerminalPointerCancel}
+      onTouchStart={handleTerminalTouchStart}
+      onTouchEnd={handleTerminalTouchEnd}
+      onTouchCancel={handleTerminalTouchCancel}
     >
       <div
         ref={containerRef}


### PR DESCRIPTION
## Summary

- focus the terminal during a short single-finger touch on iOS
- keep scroll, cancel, and multi-touch gestures from opening the keyboard
- cover tap and scroll focus decisions with tests

## Validation

- `pnpm exec vitest run --config vitest.config.ts src/components/thread/terminal/ThreadTerminalView.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- targeted ESLint and Prettier checks
- manual iOS test through the shared dev server

> AGENT GENERATED: by GPT-5