### PR TITLE
Fix live HTML file preview updates

### DIFF
--- a/apps/app/src/components/secondary-panel/FilePreview.test.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.test.tsx
@@ -573,4 +573,49 @@ describe("FilePreview", () => {
       expect(pierreMock.state.lastFile?.cacheKey).not.toBe(firstCacheKey);
     });
   });
+
+  it("reloads an HTML iframe only when the fetched source changes", () => {
+    const path = "reports/preview.html";
+    const htmlPreviewUrl = "/api/v1/threads/thread-1/worktree/files/preview.html";
+    const firstPreview = {
+      kind: "text" as const,
+      content: "<!doctype html><h1>First</h1>",
+      mimeType: "text/html",
+      path,
+      url: htmlPreviewUrl,
+    };
+    const view = render(
+      <SecondaryPanelFilePreview
+        activePath={path}
+        filePreview={firstPreview}
+        htmlPreviewUrl={htmlPreviewUrl}
+        isLoading={false}
+      />,
+    );
+
+    const firstIframe = screen.getByTitle(path);
+
+    view.rerender(
+      <SecondaryPanelFilePreview
+        activePath={path}
+        filePreview={{ ...firstPreview }}
+        htmlPreviewUrl={htmlPreviewUrl}
+        isLoading={false}
+      />,
+    );
+    expect(screen.getByTitle(path)).toBe(firstIframe);
+
+    view.rerender(
+      <SecondaryPanelFilePreview
+        activePath={path}
+        filePreview={{
+          ...firstPreview,
+          content: "<!doctype html><h1>Updated</h1>",
+        }}
+        htmlPreviewUrl={htmlPreviewUrl}
+        isLoading={false}
+      />,
+    );
+    expect(screen.getByTitle(path)).not.toBe(firstIframe);
+  });
 });

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -863,6 +863,11 @@ function HtmlFilePreviewBody({
         aria-hidden={isPreviewVisible ? undefined : true}
       >
         <IframeFilePreview
+          // The raw HTML route is stable across file revisions. Remount the
+          // frame when the fetched source changes so it navigates again and
+          // renders the updated document, while unrelated parent renders keep
+          // the current frame (and its in-document state) intact.
+          key={state.file.cacheKey}
           sandbox={state.iframe.sandbox}
           title={state.iframe.title}
           url={state.iframe.url}


### PR DESCRIPTION
## Summary

- reload the sandboxed HTML iframe when the fetched source revision changes
- keep the iframe stable across unrelated renders and Preview/Raw visibility toggles
- add regression coverage for both reload and stability behavior

## Root cause

Realtime invalidation refetched the HTML source, but the iframe raw URL stayed stable, leaving the existing rendered document mounted.

## Tests

- `pnpm exec turbo run test --filter=@bb/app -- src/components/secondary-panel/FilePreview.test.tsx` (15 tests)
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (0 errors; existing warnings only)

> AGENT GENERATED: by GPT-5 Codex