### PR TITLE
Fix line-linked HTML preview default

### DIFF
--- a/apps/app/src/components/secondary-panel/FilePreview.test.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.test.tsx
@@ -412,6 +412,36 @@ describe("FilePreview", () => {
     ).toBe("false");
   });
 
+  it("opens line-linked HTML files in rendered preview mode", () => {
+    const { container } = render(
+      <FilePreview
+        path="docs/report.html"
+        state={{
+          kind: "html",
+          file: {
+            name: "report.html",
+            contents: "<!doctype html><h1>Report</h1>",
+          },
+          iframe: {
+            sandbox: "allow-scripts",
+            title: "docs/report.html",
+            url: "/preview/docs/report.html",
+          },
+          lineRange: { startLineNumber: 1023, endLineNumber: 1023 },
+        }}
+      />,
+    );
+
+    expect(
+      screen
+        .getByRole("button", { name: "Preview" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+    const iframe = container.querySelector("iframe");
+    expect(iframe?.getAttribute("src")).toBe("/preview/docs/report.html");
+    expect(iframe?.closest('[aria-hidden="true"]')).toBeNull();
+  });
+
   it("renders CSV previews as a table by default", () => {
     render(
       <FilePreview

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -295,7 +295,11 @@ function getInitialFilePreviewViewMode({
   lineRange,
   toggleKind,
 }: GetInitialFilePreviewViewModeArgs): FilePreviewViewMode {
-  if (toggleKind === "csv" || toggleKind === "markdown") {
+  if (
+    toggleKind === "csv" ||
+    toggleKind === "html" ||
+    toggleKind === "markdown"
+  ) {
     return "preview";
   }
   return lineRange === null ? "preview" : "source";


### PR DESCRIPTION
## Summary

- default line-linked HTML files to rendered Preview
- preserve Raw access and source targeting for ordinary code files
- add regression coverage for HTML previews carrying a line range

## Testing

- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/secondary-panel/FilePreview.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `git diff --check`

> AGENT GENERATED: by GPT-5.6 Codex