### PR TITLE
Open a sidebar HTML preview full-page in the external browser

### DIFF
--- a/apps/app/src/components/secondary-panel/FilePreview.test.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.test.tsx
@@ -379,6 +379,88 @@ describe("FilePreview", () => {
     });
   });
 
+  it("opens a rendered HTML preview in the external browser", () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+
+    render(
+      <FilePreview
+        path="docs/progress-vis.html"
+        state={{
+          kind: "html",
+          file: { name: "progress-vis.html", contents: "<p>chart</p>" },
+          iframe: {
+            sandbox: "allow-scripts",
+            title: "docs/progress-vis.html",
+            url: "/api/v1/threads/thr_1/worktree/files/docs/progress-vis.html",
+          },
+          lineRange: null,
+        }}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open in external browser" }),
+    );
+
+    expect(openSpy).toHaveBeenCalledWith(
+      `${window.location.origin}/api/v1/threads/thr_1/worktree/files/docs/progress-vis.html`,
+      "_blank",
+      "noopener,noreferrer",
+    );
+    openSpy.mockRestore();
+  });
+
+  it("hands the desktop shell an absolute preview url", () => {
+    const openExternalUrl = vi.fn();
+    // The desktop main process drops a relative path, so the button has to
+    // resolve the app-relative preview route before handing it over.
+    (window as unknown as { bbDesktop: unknown }).bbDesktop = {
+      openExternalUrl,
+    };
+
+    try {
+      render(
+        <FilePreview
+          path="docs/progress-vis.html"
+          state={{
+            kind: "iframe",
+            sandbox: "allow-scripts",
+            title: "docs/progress-vis.html",
+            url: "/api/v1/threads/thr_1/worktree/files/docs/progress-vis.html",
+          }}
+        />,
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: "Open in external browser" }),
+      );
+
+      expect(openExternalUrl).toHaveBeenCalledWith(
+        `${window.location.origin}/api/v1/threads/thr_1/worktree/files/docs/progress-vis.html`,
+      );
+    } finally {
+      delete (window as unknown as { bbDesktop?: unknown }).bbDesktop;
+    }
+  });
+
+  it("offers no external browser action for a preview with no rendered page", () => {
+    render(
+      <FilePreview
+        path="README.md"
+        state={{
+          kind: "ready",
+          file: { name: "README.md", contents: "# Preview" },
+          lineRange: null,
+          textPreviewKind: "markdown",
+        }}
+      />,
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Open in external browser" }),
+    ).toBeNull();
+  });
+
   it("toggles source line wrap from the header button", async () => {
     render(
       <FilePreview

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -36,6 +36,7 @@ import { TruncateStart } from "@/components/ui/truncate-start.js";
 import { usePreferredTheme } from "@/hooks/useTheme";
 import { useResolvedCodeThemePair } from "@/lib/code-theme";
 import { copyToClipboardWithToast } from "@/lib/clipboard";
+import { openUrlInExternalBrowser } from "@/lib/url-open-routing";
 import type {
   FilePreviewLineRange,
   WorkspaceFilePreviewStatusLabel,
@@ -118,6 +119,7 @@ interface FilePreviewHeaderProps {
   path: string;
   copyPath: string | null;
   rawContents: string | null;
+  externalUrl: string | null;
   onOpenInEditor?: (path: string) => void;
   onRefresh?: () => void;
   isRefreshing: boolean;
@@ -234,6 +236,28 @@ const HTML_FILE_PREVIEW_IFRAME_STYLE = {
 const IFRAME_LOADING_INDICATOR_DELAY_MS = 160;
 const FILE_PREVIEW_HEADER_ICON_BUTTON_CLASS =
   "h-5 w-5 rounded-sm p-0 [&_svg]:size-3 max-md:pointer-coarse:h-9 max-md:pointer-coarse:w-9 max-md:pointer-coarse:[&_svg]:size-5";
+
+// The rendered HTML previews (a plain iframe target, or the html kind whose
+// preview tab wraps one) are the only states with a page a browser can open on
+// its own. Everything else is text we render ourselves.
+function getFilePreviewExternalUrl(state: FilePreviewState): string | null {
+  if (state.kind === "iframe") {
+    return state.url;
+  }
+  if (state.kind === "html") {
+    return state.iframe.url;
+  }
+  return null;
+}
+
+// The preview URL is a same-origin app path; the external browser needs the
+// whole address.
+function toAbsolutePreviewUrl(url: string): string {
+  if (typeof window === "undefined") {
+    return url;
+  }
+  return new URL(url, window.location.href).toString();
+}
 
 function getFilePreviewToggleKind(
   state: FilePreviewState,
@@ -451,6 +475,7 @@ export function FilePreview({
   const toggleKind = getFilePreviewToggleKind(state);
   const filePreviewLineRange = getFilePreviewLineRange(state);
   const rawContents = getRawFilePreviewContents(state);
+  const externalUrl = getFilePreviewExternalUrl(state);
   const [viewMode, setViewMode] = useState<FilePreviewViewMode>(
     getInitialFilePreviewViewMode({
       lineRange: filePreviewLineRange,
@@ -517,6 +542,7 @@ export function FilePreview({
           path={path}
           copyPath={copyPath}
           rawContents={rawContents}
+          externalUrl={externalUrl}
           onOpenInEditor={onOpenInEditor}
           onRefresh={onRefresh}
           isRefreshing={isRefreshing}
@@ -624,6 +650,7 @@ function FilePreviewHeader({
   path,
   copyPath,
   rawContents,
+  externalUrl,
   onOpenInEditor,
   onRefresh,
   isRefreshing,
@@ -702,6 +729,35 @@ function FilePreviewHeader({
                 </TooltipTrigger>
                 <TooltipContent side="bottom">
                   {copyFileContentsLabel}
+                </TooltipContent>
+              </Tooltip>
+            )}
+            {externalUrl === null ? null : (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className={cn(
+                      FILE_PREVIEW_HEADER_ICON_BUTTON_CLASS,
+                      "shrink-0 text-muted-foreground hover:bg-state-hover hover:text-foreground",
+                    )}
+                    onClick={() => {
+                      openUrlInExternalBrowser(
+                        toAbsolutePreviewUrl(externalUrl),
+                      );
+                    }}
+                    aria-label="Open in external browser"
+                  >
+                    {/* Globe, not ExternalLink: the neighbouring
+                        OpenInEditorButton already spends ExternalLink on a
+                        different destination. */}
+                    <Icon name="Globe" aria-hidden />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  Open in external browser
                 </TooltipContent>
               </Tooltip>
             )}


### PR DESCRIPTION
An inline visualization in a thread (`::inline-vis{file="…"}`) has an external icon whose click opens the file in the sidebar. This adds the second step: once it is open there, the sidebar preview header gains an **Open in external browser** action that opens the visualization **full-page in the user's default browser**.

The first click is unchanged — `plugins/inline-vis/app.tsx` is untouched, so the in-thread icon still only ever opens the sidebar.

## Decisions worth reviewing

- **`Globe`, not `ExternalLink`.** `OpenInEditorButton` already renders `ExternalLink` in this same toolbar; reusing it produced two identical adjacent icons. `Globe` is the codebase's browser signifier (`BrowserTabContent`, `NewTabFileSearch`, `ThreadDetailView`). The existing "Open in editor" affordance is untouched and still works.
- **The absolute-URL resolution is load-bearing, not cosmetic.** Preview URLs are relative app paths, and `apps/desktop/src/main.ts` parses with `new URL(payload)` and no base — a relative path throws into a bare `return`, i.e. a dead button with no error. `toAbsolutePreviewUrl` is what makes the desktop path work; a test pins it.
- **`openUrlInExternalBrowser`, deliberately not `useOpenUrlByPreference`.** The latter honours the in-app-browser preference and would route the visualization to bb's in-app browser panel, which is not "the user's default external browser".
- **Scope:** the button appears only for rendered-HTML previews (`html` and `iframe` states) and is absent for text/markdown/csv. A negative test pins that.
- **Judgment call, no test pins it:** the button also shows on the **Raw** tab of an HTML preview, not just **Preview**. Reading: you're asking for the rendered page regardless of which tab you're on. Defensible either way — happy to gate it to Preview if reviewers prefer.

## Verification

Gates on this branch, rebased onto current `main` (includes #1630 and #1635): `tsc --noEmit` clean · `FilePreview.test.tsx` 19/19 · `plugins/inline-vis` 16/16 unchanged · ESLint 0 errors (4 pre-existing `set-state-in-effect` warnings on lines this diff does not touch).

Driven through the real UI in an isolated dev instance, three assertions:

| Click | Result |
| --- | --- |
| In-thread icon | sidebar opens · **0** new browser tabs |
| Sidebar Globe | **1** new tab, absolute URL, rendered full-page |
| In-thread icon again | **0** new tabs |

The served route returns `200 text/html` with no `content-disposition`, so it renders rather than downloads. It carries `content-security-policy: sandbox allow-scripts`, which also applies to the top-level document: scripts run and relative assets load, but `localStorage`/cookies/same-origin fetches are unavailable — identical to what the sidebar iframe already imposes. The CSP is the security boundary for arbitrary worktree HTML and is deliberately left alone.

## Known gap

The live click-through exercised the **browser** dispatch (`window.open`). The **desktop** dispatch (`shell.openExternal` → OS default browser) is covered by a unit test asserting `openExternalUrl` receives the absolute URL, and the main-process consumer was confirmed by reading `main.ts`, but the IPC hop itself was not exercised by clicking inside a packaged Electron build.


Fixes #1842

BB-Thread-ID: thr_zhe3sbcbgx
