### PR TITLE
Publish the nightly channel after a stable release

### DIFF
--- a/.github/workflows/publish-bb-app.yml
+++ b/.github/workflows/publish-bb-app.yml
@@ -56,6 +56,13 @@ jobs:
       id-token: write
     outputs:
       version: ${{ steps.release.outputs.version }}
+    # Every publish that moves the `nightly` dist-tag shares one group, so the
+    # cron and a release run's publish-nightly job cannot move that tag at the
+    # same time. A stable release publishes `latest` here instead, so it takes a
+    # per-run group and never waits on the cron.
+    concurrency:
+      group: ${{ (github.event_name == 'schedule' || inputs.npm_tag == 'nightly') && 'publish-nightly-npm' || format('publish-bb-app-npm-{0}', github.run_id) }}
+      cancel-in-progress: false
 
     steps:
       - name: Require main branch
@@ -243,6 +250,10 @@ jobs:
       id-token: write
     outputs:
       version: ${{ steps.nightly_version.outputs.version }}
+    # Shares the publish job's nightly group. See that job for why.
+    concurrency:
+      group: publish-nightly-npm
+      cancel-in-progress: false
 
     steps:
       - name: Checkout repository
@@ -288,12 +299,19 @@ jobs:
           echo "version=${nightly_version}" >> "$GITHUB_OUTPUT"
           echo "Prepared bb-app and desktop version ${nightly_version}."
 
+      # bb-app has no prepack hook and its `files` list ships built output, so
+      # `npm publish` packs whatever is on disk. This job runs on a fresh
+      # runner, so it must build before it packs. smoke:tarball depends on
+      # build and also proves the packed tarball runs at the nightly version.
+      - name: Smoke bb-app tarball
+        run: pnpm exec turbo run smoke:tarball --filter=bb-app --force --output-logs=new-only
+
       - name: Preview npm package
         working-directory: packages/bb-app
         run: npm pack --dry-run
 
-      # No typecheck, test, or tarball smoke here: the publish job ran them on
-      # this same commit and only the version string differs.
+      # No typecheck or unit tests here: the publish job ran them on this same
+      # commit and only the version string differs.
       - name: Publish to npm
         working-directory: packages/bb-app
         run: npm publish --tag nightly

--- a/.github/workflows/publish-bb-app.yml
+++ b/.github/workflows/publish-bb-app.yml
@@ -224,6 +224,114 @@ jobs:
             echo "- commit: \`${GITHUB_SHA}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+  # A stable release moves `latest` past the newest nightly, because a nightly
+  # version is the next patch of whatever main held the night before. The
+  # nightly channel would then sit behind `latest` until the next 3am cron. This
+  # job republishes the nightly channel from the same release commit, at
+  # <next patch>-nightly.<run id>.<attempt>, so nightly stays ahead of the
+  # release it was cut from. It runs only for a real `latest` publish, and a
+  # failure here cannot roll back the stable release that already shipped.
+  publish-nightly:
+    name: Publish bb-app nightly after the release
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.npm_tag == 'latest' && inputs.dry_run == false }}
+    needs: publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: npm-release
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      version: ${{ steps.nightly_version.outputs.version }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          version: 9.15.0
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+
+      - name: Ensure npm supports trusted publishing
+        run: |
+          npm_version="$(npm --version)"
+          node - "$npm_version" <<'NODE' || npm install --global npm@latest
+          const version = process.argv[2];
+          const [major, minor, patch] = version.split(".").map(Number);
+          const supported =
+            major > 11 ||
+            (major === 11 && (minor > 5 || (minor === 5 && patch >= 1)));
+          process.exit(supported ? 0 : 1);
+          NODE
+          npm --version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Prepare nightly version
+        id: nightly_version
+        run: |
+          set -euo pipefail
+
+          # Runs after the release commit is checked out, so the derived
+          # version is the next patch above the version just published.
+          nightly_version="$(node scripts/prepare-nightly-version.mjs)"
+          echo "PACKAGE_VERSION=${nightly_version}" >> "$GITHUB_ENV"
+          echo "version=${nightly_version}" >> "$GITHUB_OUTPUT"
+          echo "Prepared bb-app and desktop version ${nightly_version}."
+
+      - name: Preview npm package
+        working-directory: packages/bb-app
+        run: npm pack --dry-run
+
+      # No typecheck, test, or tarball smoke here: the publish job ran them on
+      # this same commit and only the version string differs.
+      - name: Publish to npm
+        working-directory: packages/bb-app
+        run: npm publish --tag nightly
+
+      - name: Verify npm release
+        run: |
+          for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+            package_version="$(npm view "bb-app@$PACKAGE_VERSION" version --json 2>/tmp/bb-app-version.err || true)"
+            tag_version="$(npm view "bb-app@nightly" version --json 2>/tmp/bb-app-tag.err || true)"
+
+            if [ "$package_version" = "\"$PACKAGE_VERSION\"" ] && [ "$tag_version" = "\"$PACKAGE_VERSION\"" ]; then
+              echo "$package_version"
+              npm view bb-app version dist-tags --json
+              exit 0
+            fi
+
+            echo "Registry has not exposed bb-app@$PACKAGE_VERSION on tag nightly yet; retrying ($attempt/12)."
+            cat /tmp/bb-app-version.err || true
+            cat /tmp/bb-app-tag.err || true
+            sleep 10
+          done
+
+          echo "::error::Timed out waiting for bb-app@$PACKAGE_VERSION to appear on npm tag nightly."
+          exit 1
+
+      - name: Summarize the nightly release
+        env:
+          RELEASE_VERSION: ${{ needs.publish.outputs.version }}
+        run: |
+          {
+            echo "## bb-app nightly after the release"
+            echo
+            echo "- released version: \`$RELEASE_VERSION\`"
+            echo "- nightly version: \`$PACKAGE_VERSION\`"
+            echo "- npm tag: \`nightly\`"
+            echo "- commit: \`${GITHUB_SHA}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   # Rides the same release train as bb-app but stays independent of it: the SDK
   # version is settled in the repo (packages/domain/src/plugin-sdk-version.ts,
   # mirrored in packages/plugin-sdk/package.json), never computed here. Every
@@ -362,8 +470,18 @@ jobs:
 
   nightly-desktop-macos:
     name: Build bb Nightly desktop (macOS)
-    if: ${{ github.event_name == 'schedule' || (inputs.npm_tag == 'nightly' && inputs.dry_run == false) }}
-    needs: publish
+    # `!cancelled()` is required because publish-nightly is skipped on the
+    # scheduled and manual nightly paths, and a skipped need would otherwise
+    # skip this job too.
+    if: >-
+      ${{ !cancelled()
+      && needs.publish.result == 'success'
+      && (github.event_name == 'schedule'
+      || (inputs.npm_tag == 'nightly' && inputs.dry_run == false)
+      || needs.publish-nightly.result == 'success') }}
+    needs:
+      - publish
+      - publish-nightly
     runs-on: macos-15
     timeout-minutes: 45
     outputs:
@@ -397,7 +515,10 @@ jobs:
       - name: Apply the nightly version
         id: nightly_version
         env:
-          NIGHTLY_VERSION: ${{ needs.publish.outputs.version }}
+          # publish-nightly holds the version on a release run; publish holds it
+          # on the scheduled and manual nightly paths, where publish-nightly is
+          # skipped and reports an empty version.
+          NIGHTLY_VERSION: ${{ needs.publish-nightly.outputs.version || needs.publish.outputs.version }}
         run: |
           set -euo pipefail
 
@@ -484,8 +605,16 @@ jobs:
 
   nightly-desktop-linux:
     name: Build bb Nightly desktop (Linux)
-    if: ${{ github.event_name == 'schedule' || (inputs.npm_tag == 'nightly' && inputs.dry_run == false) }}
-    needs: publish
+    # See the macOS job for why this condition uses `!cancelled()`.
+    if: >-
+      ${{ !cancelled()
+      && needs.publish.result == 'success'
+      && (github.event_name == 'schedule'
+      || (inputs.npm_tag == 'nightly' && inputs.dry_run == false)
+      || needs.publish-nightly.result == 'success') }}
+    needs:
+      - publish
+      - publish-nightly
     # Pinned rather than ubuntu-latest so the glibc the AppImage links against
     # changes only when we choose it: the build machine's glibc sets the
     # minimum distro version users need.
@@ -518,7 +647,8 @@ jobs:
       - name: Apply the nightly version
         id: nightly_version
         env:
-          NIGHTLY_VERSION: ${{ needs.publish.outputs.version }}
+          # See the macOS job for why the version comes from either npm job.
+          NIGHTLY_VERSION: ${{ needs.publish-nightly.outputs.version || needs.publish.outputs.version }}
         run: |
           set -euo pipefail
 
@@ -576,6 +706,13 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: write
+    # The workflow-level group splits nightly from ref, so a release run and the
+    # cron can reach this job at the same time. Both delete every asset on the
+    # moving release and upload their own, so a race can leave one platform's
+    # binaries missing. Serialize the reset instead.
+    concurrency:
+      group: publish-nightly-desktop
+      cancel-in-progress: false
 
     steps:
       - name: Checkout repository

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -176,6 +176,11 @@ To publish or dry-run the channel manually from `main`, dispatch the same
 workflow with `npm_tag=nightly`. A non-dry run publishes both npm and desktop;
 a dry run validates only the npm package path.
 
+A stable release also refreshes the channel. A non-dry `npm_tag=latest` run
+publishes the release, then derives the next nightly version from the release
+commit and publishes npm and desktop nightly again. Without this step the
+nightly channel stays below `latest` until the next scheduled run.
+
 The nightly desktop is a separate installation:
 
 - product name: `bb Nightly`

--- a/docs/bb-release-process.md
+++ b/docs/bb-release-process.md
@@ -38,6 +38,15 @@ gh workflow run publish-bb-app.yml \
 
 Set `dry_run=false` to publish both npm and the signed desktop nightly.
 
+A stable release refreshes the nightly channel too. A nightly version is the
+next patch above the version on `main`, so a new `latest` release moves ahead of
+the newest nightly. To prevent a nightly channel that is older than `latest`, a
+non-dry `npm_tag=latest` run adds a `publish-nightly` job. That job derives
+`<next patch>-nightly.<run id>.<attempt>` from the release commit, publishes it
+under the `nightly` dist-tag, and the same desktop jobs then rebuild and move
+the `desktop-nightly` release. The nightly jobs run after the stable publish
+succeeds, so a nightly failure cannot affect the release that already shipped.
+
 ## Release Policy
 
 - Publish only from `main`.
@@ -154,6 +163,10 @@ gh workflow run publish-bb-app.yml \
   -f allow_prerelease_latest=false \
   -f dry_run=false
 ```
+
+This run publishes the release and then republishes the nightly channel from the
+same commit, so the run also builds the `bb Nightly` desktop app. Expect the run
+to take longer than the npm publish alone.
 
 Use prerelease dist-tags such as `alpha` only when the user explicitly asks for
 a separate prerelease channel. npm Trusted Publishing authenticates


### PR DESCRIPTION
## Problem

A nightly version is `<next patch>-nightly.<run id>.<attempt>`, derived from the version on `main`. When we release `0.38.0`, the newest nightly is `0.37.1-nightly.*`, which is lower than `latest`. The nightly npm dist-tag and the `bb Nightly` desktop app therefore stay behind the stable release until the 3am cron.

## Change

A non-dry `npm_tag=latest` run now refreshes the nightly channel from the same release commit.

- New `publish-nightly` job. It runs only for a non-dry `latest` dispatch, after `publish` succeeds. It derives the next nightly version from the release commit, publishes it under the `nightly` dist-tag, and verifies the registry. It runs `smoke:tarball` first, because `bb-app` has no `prepack` hook and its `files` list ships built output, so a fresh runner must build before it packs. It skips typecheck and unit tests, because `publish` ran them on this same commit and only the version string differs.
- The nightly desktop build jobs take the version from either npm job: `needs.publish-nightly.outputs.version || needs.publish.outputs.version`. Their `if` uses `!cancelled()`, because `publish-nightly` is skipped on the scheduled and manual nightly paths and a skipped need would otherwise skip them.
- Both npm publishes that move the `nightly` dist-tag share one job-level concurrency group, `publish-nightly-npm`, so the cron and a release run cannot move that tag at the same time. A stable release publishes `latest`, so it takes a per-run group and never queues behind the cron.
- `nightly-desktop-publish` gets its own concurrency group. The workflow-level group splits `nightly` from `ref`, so a release run and the cron could reach the moving `desktop-nightly` release at the same time. That job deletes every asset before upload, so the race could leave one platform's binaries missing.
- `docs/bb-release-process.md` and `apps/desktop/README.md` describe the new step.

The nightly jobs run after the stable publish succeeds, so a nightly failure cannot affect the release that already shipped.

## Tests

- Parsed the workflow YAML and confirmed the job graph, the `if` expressions, and the `needs` lists.
- No unit tests: the change is GitHub Actions job wiring. `prepare-nightly-version.mjs` and `bump-version.mjs` are unchanged.

## Risks

- A `latest` run grows from about 7 minutes to about 30 minutes, because it now also builds the signed macOS and Linux nightly desktop apps. Measured from recent runs: `Publish bb-app` 7m, macOS desktop 14m, Linux desktop 4m, desktop publish under 1m. The stable npm publish still completes about 7 minutes in, so users do not get the release later.
- The `npm-release` environment gate applies to `publish-nightly` too, so an approval-gated setup asks a second time.
- The full path only runs on a real release dispatch, so the first live exercise is the next stable release.

> AGENT GENERATED: by Claude Opus 5
