### PR TITLE
Keep mid-turn user exchanges visible after a turn completes

### DIFF
--- a/apps/server/test/services/threads/conversation-outline-parity.test.ts
+++ b/apps/server/test/services/threads/conversation-outline-parity.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import { threadScope, turnScope } from "@bb/domain";
+import {
+  createConnection,
+  createProject,
+  createThread,
+  insertEvents,
+  migrate,
+  noopNotifier,
+  upsertHost,
+} from "@bb/db";
+import {
+  buildThreadConversationOutline,
+  buildThreadTimeline,
+} from "../../../src/services/threads/timeline.js";
+
+type EventInput = Parameters<typeof insertEvents>[2][number];
+
+function setup() {
+  const db = createConnection(":memory:");
+  migrate(db);
+  const host = upsertHost(db, noopNotifier, {
+    name: "test-host",
+    type: "persistent",
+  });
+  const { project } = createProject(db, noopNotifier, {
+    name: "test-project",
+    source: { type: "local_path", hostId: host.id, path: "/tmp/test" },
+  });
+  const thread = createThread(db, noopNotifier, {
+    projectId: project.id,
+    providerId: "claude-code",
+  });
+  return { db, thread };
+}
+
+function agentMessage(
+  threadId: string,
+  sequence: number,
+  text: string,
+): EventInput {
+  return {
+    threadId,
+    sequence,
+    type: "item/completed",
+    scope: turnScope("turn-1"),
+    providerThreadId: "provider-thread-1",
+    itemId: `message-${sequence}`,
+    itemKind: "agentMessage",
+    data: JSON.stringify({
+      item: { id: `message-${sequence}`, type: "agentMessage", text },
+    }),
+  };
+}
+
+function userQuestionLifecycle(
+  threadId: string,
+  sequence: number,
+  status: "pending" | "resolved",
+): EventInput {
+  return {
+    threadId,
+    sequence,
+    type: "system/userQuestion/lifecycle",
+    scope: turnScope("turn-1"),
+    itemId: null,
+    itemKind: null,
+    data: JSON.stringify({
+      interactionId: "pi-user-question",
+      providerId: "claude-code",
+      providerRequestId: "request-user-question",
+      status,
+      resolution:
+        status === "resolved"
+          ? {
+              kind: "user_answer",
+              answers: { "question-1": { selected: ["staging"] } },
+            }
+          : null,
+      statusReason: null,
+      payload: {
+        kind: "user_question",
+        questions: [
+          {
+            id: "question-1",
+            prompt: "Which deployment target should I use?",
+            shortLabel: "Target",
+            multiSelect: false,
+            options: [
+              { value: "staging", label: "Staging" },
+              { value: "production", label: "Production" },
+            ],
+            allowFreeText: false,
+          },
+        ],
+      },
+    }),
+  };
+}
+
+describe("thread conversation outline parity", () => {
+  it("exposes the same conversation rows as the timeline after an answered question", () => {
+    const { db, thread } = setup();
+    const requestId = "creq_23456789ab";
+    insertEvents(db, noopNotifier, [
+      {
+        threadId: thread.id,
+        sequence: 1,
+        type: "client/turn/requested",
+        scope: threadScope(),
+        itemId: null,
+        itemKind: null,
+        data: JSON.stringify({
+          direction: "outbound",
+          requestId,
+          source: "tell",
+          initiator: "user",
+          input: [{ type: "text", text: "Audit the router", mentions: [] }],
+          target: { kind: "new-turn" },
+          request: { method: "turn/start", params: {} },
+          execution: {
+            model: "claude-opus-4",
+            reasoningLevel: "medium",
+            permissionMode: "workspace-write",
+            source: "client/turn/requested",
+            serviceTier: "default",
+          },
+        }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 2,
+        type: "turn/started",
+        scope: turnScope("turn-1"),
+        providerThreadId: "provider-thread-1",
+        itemId: null,
+        itemKind: null,
+        data: JSON.stringify({}),
+      },
+      {
+        threadId: thread.id,
+        sequence: 3,
+        type: "turn/input/accepted",
+        scope: turnScope("turn-1"),
+        providerThreadId: "provider-thread-1",
+        itemId: null,
+        itemKind: null,
+        data: JSON.stringify({ clientRequestId: requestId }),
+      },
+      userQuestionLifecycle(thread.id, 4, "pending"),
+      userQuestionLifecycle(thread.id, 5, "resolved"),
+      agentMessage(thread.id, 6, "Staging it is."),
+      agentMessage(thread.id, 7, "Login works."),
+      agentMessage(thread.id, 8, "Audit complete."),
+      agentMessage(thread.id, 9, "Final runbook."),
+      {
+        threadId: thread.id,
+        sequence: 10,
+        type: "turn/completed",
+        scope: turnScope("turn-1"),
+        providerThreadId: "provider-thread-1",
+        itemId: null,
+        itemKind: null,
+        data: JSON.stringify({ status: "completed" }),
+      },
+    ]);
+
+    const timeline = buildThreadTimeline(db, thread, {
+      eventBudget: 1_000_000,
+      includeProviderUnhandledOperations: false,
+      includeNestedRows: false,
+      maxInlineOutputChars: null,
+      maxSeq: 10,
+      page: { kind: "latest", segmentLimit: 20 },
+    });
+    const timelineConversation = timeline.rows.flatMap((row) =>
+      row.kind === "conversation" ? [{ id: row.id, text: row.text }] : [],
+    );
+    // The answered question splits the turn: the direct reply and the
+    // segment-final message are visible, the interim one stays folded.
+    expect(timelineConversation.map((row) => row.text)).toEqual([
+      "Audit the router",
+      "Staging it is.",
+      "Audit complete.",
+      "Final runbook.",
+    ]);
+
+    const outline = buildThreadConversationOutline(db, thread, { maxSeq: 10 });
+    expect(
+      outline.items.map((item) => ({ id: item.id, text: item.preview })),
+    ).toEqual(timelineConversation);
+    db.$client.close();
+  });
+});

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -2529,6 +2529,10 @@ export function listStoredConversationOutlineEventRows(
     "system/thread/interrupted",
     "system/error",
     "provider/error",
+    // An answered question splits a completed turn's folded summary exactly
+    // like accepted user input does; the outline must see it to keep the
+    // assistant rows it exposes in step with the main timeline.
+    "system/userQuestion/lifecycle",
     "item/agentMessage/delta",
     "item/plan/delta",
   ] satisfies ThreadEventType[];

--- a/packages/db/test/query-plans.test.ts
+++ b/packages/db/test/query-plans.test.ts
@@ -402,6 +402,7 @@ describe("slow query index plans", () => {
       "system/thread/interrupted",
       "system/error",
       "provider/error",
+      "system/userQuestion/lifecycle",
       "item/agentMessage/delta",
       "item/plan/delta",
       thread.id,

--- a/packages/thread-view/src/completed-turn-grouping.ts
+++ b/packages/thread-view/src/completed-turn-grouping.ts
@@ -170,6 +170,7 @@ function groupCompletedTurnSummaryMessages(
   let segmentIndex = 0;
   let externalBoundaryIndex = 0;
   let preserveNextTerminalMessage = false;
+  let sawMidTurnUserInput = false;
 
   function appendSummaryGroup(sourceMessages: EventProjectionMessage[]): void {
     if (sourceMessages.length === 0) {
@@ -193,11 +194,13 @@ function groupCompletedTurnSummaryMessages(
       return;
     }
 
-    // Human follow-ups split one provider turn into multiple visible exchange
-    // segments. Keep each segment's last assistant/error message beside the
-    // user row instead of burying it inside that segment's collapsed summary.
-    // The first assistant/error message after user input is kept too — it is
-    // the direct reply the user already read while the turn was streaming.
+    // Mid-turn human follow-ups split one provider turn into multiple visible
+    // exchange segments. Keep each segment's last assistant/error message
+    // beside the user row instead of burying it inside that segment's
+    // collapsed summary. The first assistant/error message after mid-turn user
+    // input is kept too — it is the direct reply the user already read while
+    // the turn was streaming. The turn-starting user row must not trigger any
+    // of this, or every ordinary turn would surface its interim messages.
     const sourceMessages = groupedMessages;
     groupedMessages = [];
     const terminalMessage = preserveLastTerminalMessage
@@ -228,6 +231,7 @@ function groupCompletedTurnSummaryMessages(
       flushGroupedMessages(true);
       externalBoundaryIndex += 1;
       preserveNextTerminalMessage = true;
+      sawMidTurnUserInput = true;
     }
   }
 
@@ -235,13 +239,17 @@ function groupCompletedTurnSummaryMessages(
     flushExternalBoundariesBefore(message);
     if (isTimelineUngroupableMessage(message)) {
       const isUserInputBoundary = isTimelineUserInputBoundaryMessage(message);
+      const isMidTurnUserInput =
+        isUserInputBoundary &&
+        (items.length > 0 || groupedMessages.length > 0);
       flushGroupedMessages(isUserInputBoundary);
       items.push({
         kind: "ungrouped-message",
         message,
       });
-      if (isUserInputBoundary) {
+      if (isMidTurnUserInput) {
         preserveNextTerminalMessage = true;
+        sawMidTurnUserInput = true;
       }
       continue;
     }
@@ -261,7 +269,7 @@ function groupCompletedTurnSummaryMessages(
     flushGroupedMessages(true);
     externalBoundaryIndex += 1;
   }
-  flushGroupedMessages(true);
+  flushGroupedMessages(sawMidTurnUserInput);
   return applySingleSummaryTurnBounds(turn, items);
 }
 

--- a/packages/thread-view/src/completed-turn-grouping.ts
+++ b/packages/thread-view/src/completed-turn-grouping.ts
@@ -7,7 +7,9 @@ import { getMessageStartedAt } from "./format-helpers.js";
 import {
   findLastTerminalTimelineMessage,
   isSingletonContextManagementOperation,
+  isTimelineTerminalMessage,
   isTimelineUngroupableMessage,
+  isTimelineUserInputBoundaryMessage,
 } from "./timeline-message-helpers.js";
 
 export interface CompletedTurnSummaryGroup {
@@ -167,6 +169,7 @@ function groupCompletedTurnSummaryMessages(
   let groupedMessages: EventProjectionMessage[] = [];
   let segmentIndex = 0;
   let externalBoundaryIndex = 0;
+  let preserveNextTerminalMessage = false;
 
   function appendSummaryGroup(sourceMessages: EventProjectionMessage[]): void {
     if (sourceMessages.length === 0) {
@@ -193,6 +196,8 @@ function groupCompletedTurnSummaryMessages(
     // Human follow-ups split one provider turn into multiple visible exchange
     // segments. Keep each segment's last assistant/error message beside the
     // user row instead of burying it inside that segment's collapsed summary.
+    // The first assistant/error message after user input is kept too — it is
+    // the direct reply the user already read while the turn was streaming.
     const sourceMessages = groupedMessages;
     groupedMessages = [];
     const terminalMessage = preserveLastTerminalMessage
@@ -222,19 +227,31 @@ function groupCompletedTurnSummaryMessages(
     ) {
       flushGroupedMessages(true);
       externalBoundaryIndex += 1;
+      preserveNextTerminalMessage = true;
     }
   }
 
   for (const message of summaryMessages) {
     flushExternalBoundariesBefore(message);
     if (isTimelineUngroupableMessage(message)) {
-      flushGroupedMessages(
-        message.kind === "user" && message.initiator === "user",
-      );
+      const isUserInputBoundary = isTimelineUserInputBoundaryMessage(message);
+      flushGroupedMessages(isUserInputBoundary);
       items.push({
         kind: "ungrouped-message",
         message,
       });
+      if (isUserInputBoundary) {
+        preserveNextTerminalMessage = true;
+      }
+      continue;
+    }
+    if (preserveNextTerminalMessage && isTimelineTerminalMessage(message)) {
+      flushGroupedMessages();
+      items.push({
+        kind: "ungrouped-message",
+        message,
+      });
+      preserveNextTerminalMessage = false;
       continue;
     }
     groupedMessages.push(message);
@@ -244,7 +261,7 @@ function groupCompletedTurnSummaryMessages(
     flushGroupedMessages(true);
     externalBoundaryIndex += 1;
   }
-  flushGroupedMessages();
+  flushGroupedMessages(true);
   return applySingleSummaryTurnBounds(turn, items);
 }
 

--- a/packages/thread-view/src/completed-turn-grouping.ts
+++ b/packages/thread-view/src/completed-turn-grouping.ts
@@ -8,8 +8,8 @@ import {
   findLastTerminalTimelineMessage,
   isSingletonContextManagementOperation,
   isTimelineTerminalMessage,
+  isMidTurnUserInputBoundaryMessage,
   isTimelineUngroupableMessage,
-  isTimelineUserInputBoundaryMessage,
 } from "./timeline-message-helpers.js";
 
 export interface CompletedTurnSummaryGroup {
@@ -171,10 +171,7 @@ function groupCompletedTurnSummaryMessages(
   let externalBoundaryIndex = 0;
   let preserveNextTerminalMessage = false;
   let sawMidTurnUserInput = false;
-  // True once the turn has produced assistant/tool output. User input that
-  // precedes any output (the turn-starting row, or several initial rows from a
-  // grouped `inputGroups` request) is initial input, not a mid-turn follow-up.
-  let sawTurnOutput = false;
+  const phase = { sawTurnOutput: false };
 
   function appendSummaryGroup(sourceMessages: EventProjectionMessage[]): void {
     if (sourceMessages.length === 0) {
@@ -243,8 +240,10 @@ function groupCompletedTurnSummaryMessages(
   for (const message of summaryMessages) {
     flushExternalBoundariesBefore(message);
     if (isTimelineUngroupableMessage(message)) {
-      const isUserInputBoundary = isTimelineUserInputBoundaryMessage(message);
-      const isMidTurnUserInput = isUserInputBoundary && sawTurnOutput;
+      const isMidTurnUserInput = isMidTurnUserInputBoundaryMessage(
+        message,
+        phase,
+      );
       flushGroupedMessages(isMidTurnUserInput);
       items.push({
         kind: "ungrouped-message",
@@ -253,10 +252,13 @@ function groupCompletedTurnSummaryMessages(
       if (isMidTurnUserInput) {
         preserveNextTerminalMessage = true;
         sawMidTurnUserInput = true;
+        // An answered question is provider output too; a user request that
+        // follows it is a mid-turn follow-up even with no assistant text yet.
+        phase.sawTurnOutput = true;
       }
       continue;
     }
-    sawTurnOutput = true;
+    phase.sawTurnOutput = true;
     if (preserveNextTerminalMessage && isTimelineTerminalMessage(message)) {
       flushGroupedMessages();
       items.push({

--- a/packages/thread-view/src/completed-turn-grouping.ts
+++ b/packages/thread-view/src/completed-turn-grouping.ts
@@ -171,6 +171,10 @@ function groupCompletedTurnSummaryMessages(
   let externalBoundaryIndex = 0;
   let preserveNextTerminalMessage = false;
   let sawMidTurnUserInput = false;
+  // True once the turn has produced assistant/tool output. User input that
+  // precedes any output (the turn-starting row, or several initial rows from a
+  // grouped `inputGroups` request) is initial input, not a mid-turn follow-up.
+  let sawTurnOutput = false;
 
   function appendSummaryGroup(sourceMessages: EventProjectionMessage[]): void {
     if (sourceMessages.length === 0) {
@@ -199,8 +203,9 @@ function groupCompletedTurnSummaryMessages(
     // beside the user row instead of burying it inside that segment's
     // collapsed summary. The first assistant/error message after mid-turn user
     // input is kept too — it is the direct reply the user already read while
-    // the turn was streaming. The turn-starting user row must not trigger any
-    // of this, or every ordinary turn would surface its interim messages.
+    // the turn was streaming. Initial user rows (before any output) must not
+    // trigger any of this, or every ordinary turn would surface its interim
+    // messages.
     const sourceMessages = groupedMessages;
     groupedMessages = [];
     const terminalMessage = preserveLastTerminalMessage
@@ -239,10 +244,8 @@ function groupCompletedTurnSummaryMessages(
     flushExternalBoundariesBefore(message);
     if (isTimelineUngroupableMessage(message)) {
       const isUserInputBoundary = isTimelineUserInputBoundaryMessage(message);
-      const isMidTurnUserInput =
-        isUserInputBoundary &&
-        (items.length > 0 || groupedMessages.length > 0);
-      flushGroupedMessages(isUserInputBoundary);
+      const isMidTurnUserInput = isUserInputBoundary && sawTurnOutput;
+      flushGroupedMessages(isMidTurnUserInput);
       items.push({
         kind: "ungrouped-message",
         message,
@@ -253,6 +256,7 @@ function groupCompletedTurnSummaryMessages(
       }
       continue;
     }
+    sawTurnOutput = true;
     if (preserveNextTerminalMessage && isTimelineTerminalMessage(message)) {
       flushGroupedMessages();
       items.push({

--- a/packages/thread-view/src/timeline-message-helpers.ts
+++ b/packages/thread-view/src/timeline-message-helpers.ts
@@ -25,7 +25,22 @@ export function isTimelineUngroupableMessage(
   if (message.kind === "assistant-text") {
     return message.isLegacyUserMessage === true;
   }
+  if (message.kind === "user-question-lifecycle") {
+    return message.lifecycle === "answered";
+  }
   return message.kind === "debug/raw-event";
+}
+
+export function isTimelineUserInputBoundaryMessage(
+  message: EventProjectionMessage,
+): boolean {
+  if (message.kind === "user") {
+    return message.initiator === "user";
+  }
+  return (
+    message.kind === "user-question-lifecycle" &&
+    message.lifecycle === "answered"
+  );
 }
 
 export function isTimelineSummaryCountedMessage(

--- a/packages/thread-view/src/timeline-message-helpers.ts
+++ b/packages/thread-view/src/timeline-message-helpers.ts
@@ -31,16 +31,67 @@ export function isTimelineUngroupableMessage(
   return message.kind === "debug/raw-event";
 }
 
-export function isTimelineUserInputBoundaryMessage(
+/**
+ * Human input that the provider actually received during a turn. Only this
+ * input can split a completed turn into visible exchange segments.
+ *
+ * - `accepted-user-request`: a human-sent row the provider accepted. Pending
+ *   or rejected rows never reached the provider, so the assistant output that
+ *   follows them answers nothing the user said.
+ * - `answered-question`: a provider-initiated question the human answered.
+ * - `none`: everything else, including agent/system steers.
+ */
+export type TimelineUserInputSource =
+  | "accepted-user-request"
+  | "answered-question"
+  | "none";
+
+export function getTimelineUserInputSource(
   message: EventProjectionMessage,
-): boolean {
+): TimelineUserInputSource {
   if (message.kind === "user") {
-    return message.initiator === "user";
+    return message.initiator === "user" &&
+      message.turnRequest.status === "accepted"
+      ? "accepted-user-request"
+      : "none";
   }
-  return (
+  if (
     message.kind === "user-question-lifecycle" &&
     message.lifecycle === "answered"
-  );
+  ) {
+    return "answered-question";
+  }
+  return "none";
+}
+
+export interface TimelineTurnPhase {
+  /**
+   * True once the turn has produced assistant/tool output. User input that
+   * precedes any output (the turn-starting row, or several initial rows from
+   * a grouped `inputGroups` request) is initial input, not a mid-turn
+   * follow-up.
+   */
+  sawTurnOutput: boolean;
+}
+
+/**
+ * Whether `message` is mid-turn human input that starts a new exchange
+ * segment inside a completed turn. An accepted user request is a boundary
+ * only after the turn has produced output. An answered question is always a
+ * boundary: the provider asked it, so it is itself turn output.
+ */
+export function isMidTurnUserInputBoundaryMessage(
+  message: EventProjectionMessage,
+  phase: TimelineTurnPhase,
+): boolean {
+  switch (getTimelineUserInputSource(message)) {
+    case "accepted-user-request":
+      return phase.sawTurnOutput;
+    case "answered-question":
+      return true;
+    case "none":
+      return false;
+  }
 }
 
 export function isTimelineSummaryCountedMessage(

--- a/packages/thread-view/test/build-thread-timeline.test.ts
+++ b/packages/thread-view/test/build-thread-timeline.test.ts
@@ -623,47 +623,20 @@ function permissionGrantLifecycleEvent({
 }
 
 function userQuestionLifecycleEvent({
-  interactionId = "pi-user-question",
-  questionPrompt,
-  resolution = null,
   seq,
-  status = "pending",
-  statusReason = null,
+  ...args
 }: UserQuestionLifecycleEventArgs): ThreadEventWithMeta {
-  return {
-    event: {
-      type: "system/userQuestion/lifecycle",
-      threadId: "thread-1",
-      scope: turnScope("turn-1"),
-      interactionId,
-      providerId: "claude-code",
-      providerRequestId: "request-user-question",
-      status,
-      resolution,
-      statusReason,
-      payload: {
-        kind: "user_question",
-        questions: [
-          {
-            id: "question-1",
-            prompt: questionPrompt ?? "Which deployment target should I use?",
-            shortLabel: "Target",
-            multiSelect: false,
-            options: [
-              { value: "staging", label: "Staging" },
-              { value: "production", label: "Production" },
-            ],
-            allowFreeText: true,
-          },
-        ],
-      },
-    },
-    meta: {
+  const [event] = fromRows([
+    createTimelineEventFactory({ threadId: "thread-1" }).userQuestionLifecycle({
+      ...args,
       id: `event-${seq}`,
       seq,
-      createdAt: seq,
-    },
-  };
+    }),
+  ]);
+  if (!event) {
+    throw new Error("Expected a decoded user-question lifecycle event");
+  }
+  return event;
 }
 
 function buildContextWindowUsage(

--- a/packages/thread-view/test/completed-turn-grouping.test.ts
+++ b/packages/thread-view/test/completed-turn-grouping.test.ts
@@ -266,7 +266,7 @@ describe("groupCompletedTurnMessages", () => {
       {
         kind: "summary",
         startedAt: 1,
-        completedAt: 3,
+        completedAt: null,
         segmentIndex: 0,
         summaryCount: 1,
       },
@@ -277,13 +277,17 @@ describe("groupCompletedTurnMessages", () => {
         },
       },
       {
-        kind: "ungrouped-message",
-        message: {
-          id: "assistant-after",
-        },
+        kind: "summary",
+        startedAt: 3,
+        completedAt: null,
+        segmentIndex: 1,
+        summaryCount: 1,
       },
     ]);
-    expect(summarySourceMessageIds(groups)).toEqual([["assistant-before"]]);
+    expect(summarySourceMessageIds(groups)).toEqual([
+      ["assistant-before"],
+      ["assistant-after"],
+    ]);
   });
 
   it("slices terminal and trailing messages out of the summary groups", () => {

--- a/packages/thread-view/test/completed-turn-grouping.test.ts
+++ b/packages/thread-view/test/completed-turn-grouping.test.ts
@@ -266,7 +266,7 @@ describe("groupCompletedTurnMessages", () => {
       {
         kind: "summary",
         startedAt: 1,
-        completedAt: null,
+        completedAt: 3,
         segmentIndex: 0,
         summaryCount: 1,
       },
@@ -277,17 +277,13 @@ describe("groupCompletedTurnMessages", () => {
         },
       },
       {
-        kind: "summary",
-        startedAt: 3,
-        completedAt: null,
-        segmentIndex: 1,
-        summaryCount: 1,
+        kind: "ungrouped-message",
+        message: {
+          id: "assistant-after",
+        },
       },
     ]);
-    expect(summarySourceMessageIds(groups)).toEqual([
-      ["assistant-before"],
-      ["assistant-after"],
-    ]);
+    expect(summarySourceMessageIds(groups)).toEqual([["assistant-before"]]);
   });
 
   it("slices terminal and trailing messages out of the summary groups", () => {

--- a/packages/thread-view/test/completed-turn-user-input-visibility.test.ts
+++ b/packages/thread-view/test/completed-turn-user-input-visibility.test.ts
@@ -1,0 +1,158 @@
+import type { ThreadEventRow } from "@bb/domain";
+import { turnScope } from "@bb/domain";
+import { describe, expect, it } from "vitest";
+import {
+  createTimelineEventFactory,
+  renderTimelineFixture,
+} from "./timeline-test-harness.js";
+import type { TimelineEventFactory } from "./timeline-test-harness.js";
+
+function topLevelAssistantTexts(
+  rows: ReturnType<typeof renderTimelineFixture>["rows"],
+): string[] {
+  return rows.flatMap((row) =>
+    row.kind === "conversation" && row.role === "assistant" ? [row.text] : [],
+  );
+}
+
+function renderTimeline(
+  events: ThreadEventRow[],
+  threadStatus: "active" | "idle",
+) {
+  return renderTimelineFixture({
+    events,
+    projectionOptions: {
+      threadStatus,
+      turnMessageDetail: "summary",
+    },
+  });
+}
+
+function answeredUserQuestionEvent(seq: number): ThreadEventRow {
+  return {
+    id: `evt-user-question-${seq}`,
+    threadId: "thread-1",
+    seq,
+    createdAt: seq,
+    scope: turnScope("turn-1"),
+    type: "system/userQuestion/lifecycle",
+    data: {
+      interactionId: "pint_question_1",
+      providerId: "claude-code",
+      providerRequestId: "request-question-1",
+      status: "resolved",
+      resolution: {
+        kind: "user_answer",
+        answers: {
+          "question-1": { selected: ["all"] },
+        },
+      },
+      statusReason: null,
+      payload: {
+        kind: "user_question",
+        questions: [
+          {
+            id: "question-1",
+            prompt: "Which changes should I include?",
+            shortLabel: "Scope",
+            multiSelect: false,
+            options: [
+              { value: "all", label: "All of them" },
+              { value: "none", label: "None" },
+            ],
+            allowFreeText: false,
+          },
+        ],
+      },
+    },
+  } as ThreadEventRow;
+}
+
+describe("completed turn user input visibility", () => {
+  function buildSteerEvents(event: TimelineEventFactory, completed: boolean) {
+    const request = event.clientTurnRequested({
+      target: { kind: "new-turn" },
+      text: "Check my router setup",
+    });
+    const steer = event.clientTurnRequested({
+      target: { kind: "steer", expectedTurnId: "turn-1" },
+      source: "tell",
+      text: "explore but do not apply changes",
+      requestId: "creq_steersteer" as never,
+    });
+    const events: ThreadEventRow[] = [
+      request,
+      event.turnStarted(),
+      event.inputAccepted({ clientRequestId: request.data.requestId }),
+      event.assistantCompleted({ itemId: "a1", text: "Starting the audit." }),
+      steer,
+      event.inputAccepted({ clientRequestId: steer.data.requestId }),
+      event.assistantCompleted({
+        itemId: "a2",
+        text: "Understood - read-only only.",
+      }),
+      event.commandCompleted({ itemId: "tool-1", command: "ssh router" }),
+      event.assistantCompleted({ itemId: "a3", text: "Login works." }),
+      event.assistantCompleted({
+        itemId: "a4",
+        text: "Audit complete. Nothing was changed.",
+      }),
+      event.assistantCompleted({ itemId: "a5", text: "Final runbook." }),
+    ];
+    if (completed) {
+      events.push(event.turnCompleted());
+    }
+    return events;
+  }
+
+  it("keeps the direct reply and the segment-final message visible after a steered turn completes", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const runningTexts = topLevelAssistantTexts(
+      renderTimeline(buildSteerEvents(event, false), "active").rows,
+    );
+    expect(runningTexts).toContain("Understood - read-only only.");
+    expect(runningTexts).toContain("Audit complete. Nothing was changed.");
+
+    const completedEvent = createTimelineEventFactory({ threadId: "thread-1" });
+    const completedTexts = topLevelAssistantTexts(
+      renderTimeline(buildSteerEvents(completedEvent, true), "idle").rows,
+    );
+    expect(completedTexts).toContain("Understood - read-only only.");
+    expect(completedTexts).toContain("Audit complete. Nothing was changed.");
+    expect(completedTexts).toContain("Final runbook.");
+    expect(completedTexts).not.toContain("Login works.");
+  });
+
+  it("keeps an answered question and the report preceding it visible after the turn completes", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const request = event.clientTurnRequested({
+      target: { kind: "new-turn" },
+      text: "Audit the router",
+    });
+    const timeline = renderTimeline(
+      [
+        request,
+        event.turnStarted(),
+        event.inputAccepted({ clientRequestId: request.data.requestId }),
+        event.commandCompleted({ itemId: "tool-1", command: "ssh router" }),
+        event.assistantCompleted({
+          itemId: "a1",
+          text: "Audit complete. Which changes should I include?",
+        }),
+        answeredUserQuestionEvent(6),
+        event.assistantCompleted({ itemId: "a2", text: "Final runbook." }),
+        event.turnCompleted(),
+      ],
+      "idle",
+    );
+
+    const texts = topLevelAssistantTexts(timeline.rows);
+    expect(texts).toContain("Audit complete. Which changes should I include?");
+    expect(texts).toContain("Final runbook.");
+    expect(
+      timeline.rows.some(
+        (row) => row.kind === "work" && row.workKind === "question",
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/thread-view/test/completed-turn-user-input-visibility.test.ts
+++ b/packages/thread-view/test/completed-turn-user-input-visibility.test.ts
@@ -1,5 +1,4 @@
 import type { ThreadEventRow } from "@bb/domain";
-import { turnScope } from "@bb/domain";
 import { describe, expect, it } from "vitest";
 import {
   createTimelineEventFactory,
@@ -26,46 +25,6 @@ function renderTimeline(
       turnMessageDetail: "summary",
     },
   });
-}
-
-function answeredUserQuestionEvent(seq: number): ThreadEventRow {
-  return {
-    id: `evt-user-question-${seq}`,
-    threadId: "thread-1",
-    seq,
-    createdAt: seq,
-    scope: turnScope("turn-1"),
-    type: "system/userQuestion/lifecycle",
-    data: {
-      interactionId: "pint_question_1",
-      providerId: "claude-code",
-      providerRequestId: "request-question-1",
-      status: "resolved",
-      resolution: {
-        kind: "user_answer",
-        answers: {
-          "question-1": { selected: ["all"] },
-        },
-      },
-      statusReason: null,
-      payload: {
-        kind: "user_question",
-        questions: [
-          {
-            id: "question-1",
-            prompt: "Which changes should I include?",
-            shortLabel: "Scope",
-            multiSelect: false,
-            options: [
-              { value: "all", label: "All of them" },
-              { value: "none", label: "None" },
-            ],
-            allowFreeText: false,
-          },
-        ],
-      },
-    },
-  } as ThreadEventRow;
 }
 
 describe("completed turn user input visibility", () => {
@@ -148,6 +107,46 @@ describe("completed turn user input visibility", () => {
     ]);
   });
 
+  it("keeps interim messages folded when the turn starts from several grouped input rows", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const request = event.clientTurnRequested({
+      target: { kind: "new-turn" },
+      text: "Fix the bug\n\nThen add a regression test",
+      input: [
+        {
+          type: "text",
+          text: "Fix the bug\n\nThen add a regression test",
+          mentions: [],
+        },
+      ],
+      inputGroups: [
+        [{ type: "text", text: "Fix the bug", mentions: [] }],
+        [{ type: "text", text: "Then add a regression test", mentions: [] }],
+      ],
+    });
+    const timeline = renderTimeline(
+      [
+        request,
+        event.turnStarted(),
+        event.inputAccepted({ clientRequestId: request.data.requestId }),
+        event.assistantCompleted({ itemId: "a1", text: "Looking into it." }),
+        event.commandCompleted({ itemId: "tool-1", command: "grep bug" }),
+        event.assistantCompleted({ itemId: "a2", text: "Found the cause." }),
+        event.assistantCompleted({ itemId: "a3", text: "Fixed and verified." }),
+        event.turnCompleted(),
+      ],
+      "idle",
+    );
+
+    const userTexts = timeline.rows.flatMap((row) =>
+      row.kind === "conversation" && row.role === "user" ? [row.text] : [],
+    );
+    expect(userTexts).toEqual(["Fix the bug", "Then add a regression test"]);
+    expect(topLevelAssistantTexts(timeline.rows)).toEqual([
+      "Fixed and verified.",
+    ]);
+  });
+
   it("keeps an answered question and the report preceding it visible after the turn completes", () => {
     const event = createTimelineEventFactory({ threadId: "thread-1" });
     const request = event.clientTurnRequested({
@@ -164,7 +163,15 @@ describe("completed turn user input visibility", () => {
           itemId: "a1",
           text: "Audit complete. Which changes should I include?",
         }),
-        answeredUserQuestionEvent(6),
+        event.userQuestionLifecycle({ interactionId: "pint_question_1" }),
+        event.userQuestionLifecycle({
+          interactionId: "pint_question_1",
+          status: "resolved",
+          resolution: {
+            kind: "user_answer",
+            answers: { "question-1": { selected: ["all"] } },
+          },
+        }),
         event.assistantCompleted({ itemId: "a2", text: "Final runbook." }),
         event.turnCompleted(),
       ],

--- a/packages/thread-view/test/completed-turn-user-input-visibility.test.ts
+++ b/packages/thread-view/test/completed-turn-user-input-visibility.test.ts
@@ -123,6 +123,31 @@ describe("completed turn user input visibility", () => {
     expect(completedTexts).not.toContain("Login works.");
   });
 
+  it("keeps interim messages of an unsteered turn folded after completion", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const request = event.clientTurnRequested({
+      target: { kind: "new-turn" },
+      text: "Fix the bug",
+    });
+    const timeline = renderTimeline(
+      [
+        request,
+        event.turnStarted(),
+        event.inputAccepted({ clientRequestId: request.data.requestId }),
+        event.assistantCompleted({ itemId: "a1", text: "Looking into it." }),
+        event.commandCompleted({ itemId: "tool-1", command: "grep bug" }),
+        event.assistantCompleted({ itemId: "a2", text: "Found the cause." }),
+        event.assistantCompleted({ itemId: "a3", text: "Fixed and verified." }),
+        event.turnCompleted(),
+      ],
+      "idle",
+    );
+
+    expect(topLevelAssistantTexts(timeline.rows)).toEqual([
+      "Fixed and verified.",
+    ]);
+  });
+
   it("keeps an answered question and the report preceding it visible after the turn completes", () => {
     const event = createTimelineEventFactory({ threadId: "thread-1" });
     const request = event.clientTurnRequested({

--- a/packages/thread-view/test/completed-turn-user-input-visibility.test.ts
+++ b/packages/thread-view/test/completed-turn-user-input-visibility.test.ts
@@ -37,7 +37,6 @@ describe("completed turn user input visibility", () => {
       target: { kind: "steer", expectedTurnId: "turn-1" },
       source: "tell",
       text: "explore but do not apply changes",
-      requestId: "creq_steersteer" as never,
     });
     const events: ThreadEventRow[] = [
       request,
@@ -147,6 +146,82 @@ describe("completed turn user input visibility", () => {
     ]);
   });
 
+  it("keeps the direct reply after an answered question that is the turn's first output", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const request = event.clientTurnRequested({
+      target: { kind: "new-turn" },
+      text: "Audit the router",
+    });
+    const timeline = renderTimeline(
+      [
+        request,
+        event.turnStarted(),
+        event.inputAccepted({ clientRequestId: request.data.requestId }),
+        event.userQuestionLifecycle(),
+        event.userQuestionLifecycle({
+          status: "resolved",
+          resolution: {
+            kind: "user_answer",
+            answers: { "question-1": { selected: ["staging"] } },
+          },
+        }),
+        event.assistantCompleted({ itemId: "a1", text: "Staging it is." }),
+        event.commandCompleted({ itemId: "tool-1", command: "ssh router" }),
+        event.assistantCompleted({ itemId: "a2", text: "Login works." }),
+        event.assistantCompleted({ itemId: "a3", text: "Audit complete." }),
+        event.assistantCompleted({ itemId: "a4", text: "Final runbook." }),
+        event.turnCompleted(),
+      ],
+      "idle",
+    );
+
+    const texts = topLevelAssistantTexts(timeline.rows);
+    expect(texts).toContain("Staging it is.");
+    expect(texts).toContain("Audit complete.");
+    expect(texts).toContain("Final runbook.");
+    expect(texts).not.toContain("Login works.");
+  });
+
+  it("keeps interim messages folded around a rejected steer", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const request = event.clientTurnRequested({
+      target: { kind: "new-turn" },
+      text: "Check my router setup",
+    });
+    const steer = event.clientTurnRequested({
+      target: { kind: "steer", expectedTurnId: "turn-1" },
+      source: "tell",
+      text: "explore but do not apply changes",
+    });
+    const timeline = renderTimeline(
+      [
+        request,
+        event.turnStarted(),
+        event.inputAccepted({ clientRequestId: request.data.requestId }),
+        event.assistantCompleted({ itemId: "a1", text: "Starting the audit." }),
+        steer,
+        event.clientTurnRejected({ requestId: steer.data.requestId }),
+        event.assistantCompleted({ itemId: "a2", text: "Checking config." }),
+        event.commandCompleted({ itemId: "tool-1", command: "ssh router" }),
+        event.assistantCompleted({ itemId: "a3", text: "Login works." }),
+        event.assistantCompleted({ itemId: "a4", text: "Audit complete." }),
+        event.turnCompleted(),
+      ],
+      "idle",
+    );
+
+    const steerRow = timeline.rows.find(
+      (row) =>
+        row.kind === "conversation" &&
+        row.role === "user" &&
+        row.text === "explore but do not apply changes",
+    );
+    expect(steerRow).toMatchObject({
+      turnRequest: { kind: "steer", status: "rejected" },
+    });
+    expect(topLevelAssistantTexts(timeline.rows)).toEqual(["Audit complete."]);
+  });
+
   it("keeps an answered question and the report preceding it visible after the turn completes", () => {
     const event = createTimelineEventFactory({ threadId: "thread-1" });
     const request = event.clientTurnRequested({
@@ -163,9 +238,8 @@ describe("completed turn user input visibility", () => {
           itemId: "a1",
           text: "Audit complete. Which changes should I include?",
         }),
-        event.userQuestionLifecycle({ interactionId: "pint_question_1" }),
+        event.userQuestionLifecycle(),
         event.userQuestionLifecycle({
-          interactionId: "pint_question_1",
           status: "resolved",
           resolution: {
             kind: "user_answer",

--- a/packages/thread-view/test/timeline-test-harness.ts
+++ b/packages/thread-view/test/timeline-test-harness.ts
@@ -19,6 +19,7 @@ import type {
   ThreadEventWarningCategory,
   ThreadTurnInitiator,
   TurnRequestTarget,
+  UserQuestionPendingInteractionResolution,
 } from "@bb/domain";
 import type { TimelineRow } from "@bb/server-contract";
 import type {
@@ -257,6 +258,16 @@ interface PermissionGrantLifecycleArgs extends DefaultTurnEventOptions {
   toolName?: string;
 }
 
+interface UserQuestionLifecycleArgs extends DefaultTurnEventOptions {
+  interactionId?: string;
+  providerId?: string;
+  providerRequestId?: string;
+  questionPrompt?: string;
+  resolution?: UserQuestionPendingInteractionResolution | null;
+  status?: "pending" | "resolving" | "resolved" | "interrupted";
+  statusReason?: string | null;
+}
+
 interface LegacyUserMessageArgs extends EventFactoryRowOptions {
   text: string;
   turnId?: string;
@@ -326,6 +337,9 @@ export interface TimelineEventFactory {
   providerError(
     args: ProviderErrorArgs,
   ): ThreadEventRowOfType<"provider/error">;
+  userQuestionLifecycle(
+    args?: UserQuestionLifecycleArgs,
+  ): ThreadEventRowOfType<"system/userQuestion/lifecycle">;
   providerUnhandled(
     args?: ProviderUnhandledArgs,
   ): ThreadEventRowOfType<"provider/unhandled">;
@@ -805,6 +819,41 @@ export function createTimelineEventFactory(
                 write: [],
               },
             },
+          },
+        },
+      };
+    },
+    userQuestionLifecycle(args = {}) {
+      const base = nextDefaultTurnScopedRowBase(
+        "user-question-lifecycle",
+        args,
+      );
+      return {
+        ...base,
+        type: "system/userQuestion/lifecycle",
+        data: {
+          interactionId: args.interactionId ?? "pint_question_1",
+          providerId: args.providerId ?? "claude-code",
+          providerRequestId: args.providerRequestId ?? "request-question-1",
+          status: args.status ?? "pending",
+          resolution: args.resolution ?? null,
+          statusReason: args.statusReason ?? null,
+          payload: {
+            kind: "user_question",
+            questions: [
+              {
+                id: "question-1",
+                prompt:
+                  args.questionPrompt ?? "Which changes should I include?",
+                shortLabel: "Scope",
+                multiSelect: false,
+                options: [
+                  { value: "all", label: "All of them" },
+                  { value: "none", label: "None" },
+                ],
+                allowFreeText: false,
+              },
+            ],
           },
         },
       };

--- a/packages/thread-view/test/timeline-test-harness.ts
+++ b/packages/thread-view/test/timeline-test-harness.ts
@@ -832,9 +832,9 @@ export function createTimelineEventFactory(
         ...base,
         type: "system/userQuestion/lifecycle",
         data: {
-          interactionId: args.interactionId ?? "pint_question_1",
+          interactionId: args.interactionId ?? "pi-user-question",
           providerId: args.providerId ?? "claude-code",
-          providerRequestId: args.providerRequestId ?? "request-question-1",
+          providerRequestId: args.providerRequestId ?? "request-user-question",
           status: args.status ?? "pending",
           resolution: args.resolution ?? null,
           statusReason: args.statusReason ?? null,
@@ -844,14 +844,15 @@ export function createTimelineEventFactory(
               {
                 id: "question-1",
                 prompt:
-                  args.questionPrompt ?? "Which changes should I include?",
-                shortLabel: "Scope",
+                  args.questionPrompt ??
+                  "Which deployment target should I use?",
+                shortLabel: "Target",
                 multiSelect: false,
                 options: [
-                  { value: "all", label: "All of them" },
-                  { value: "none", label: "None" },
+                  { value: "staging", label: "Staging" },
+                  { value: "production", label: "Production" },
                 ],
-                allowFreeText: false,
+                allowFreeText: true,
               },
             ],
           },


### PR DESCRIPTION
## Summary

Fixes #1656.

Completed-turn grouping buried messages the user had already read once `turn/completed` re-grouped the turn:

- the direct reply to a mid-turn user message (only each segment's last assistant message survived),
- the final segment's last terminal message (the final flush never preserved one),
- answered user questions and the report preceding them (answered questions were groupable and not boundaries).

Changes in `packages/thread-view`:

- Preserve the first assistant/error message after user input (steer, external boundary, or answered question) — the direct reply.
- Final flush preserves its last terminal message, matching boundary flushes.
- Answered `user-question-lifecycle` messages are ungroupable and act as user-input boundaries.

Turns without mid-turn user input keep the existing single-summary collapse. Regression tests in `completed-turn-user-input-visibility.test.ts`; one existing expectation updated (the trailing segment after a legacy user message now keeps its last terminal visible).

> AGENT GENERATED: by Claude Fable 5