### PR TITLE
Fix mobile file preview switch overflow

### DIFF
--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -234,6 +234,10 @@ const HTML_FILE_PREVIEW_IFRAME_STYLE = {
 const IFRAME_LOADING_INDICATOR_DELAY_MS = 160;
 const FILE_PREVIEW_HEADER_ICON_BUTTON_CLASS =
   "h-5 w-5 rounded-sm p-0 [&_svg]:size-3 max-md:pointer-coarse:h-9 max-md:pointer-coarse:w-9 max-md:pointer-coarse:[&_svg]:size-5";
+// The toggle adds 2px padding and a 1px border around these buttons. Keep its
+// coarse-pointer tabs at 30px so the complete control fits the 36px header.
+const FILE_PREVIEW_VIEW_MODE_BUTTON_CLASS =
+  "h-5 rounded-sm px-2 text-muted-foreground max-md:pointer-coarse:h-[30px]";
 
 function getFilePreviewToggleKind(
   state: FilePreviewState,
@@ -748,7 +752,7 @@ function FilePreviewHeader({
                   variant="ghost"
                   size="sm"
                   className={cn(
-                    "h-5 rounded-sm px-2 text-muted-foreground max-md:pointer-coarse:h-9",
+                    FILE_PREVIEW_VIEW_MODE_BUTTON_CLASS,
                     COARSE_POINTER_TEXT_SM_CLASS,
                   )}
                   onClick={() => onViewModeChange("preview")}
@@ -761,7 +765,7 @@ function FilePreviewHeader({
                   variant="ghost"
                   size="sm"
                   className={cn(
-                    "h-5 rounded-sm px-2 text-muted-foreground max-md:pointer-coarse:h-9",
+                    FILE_PREVIEW_VIEW_MODE_BUTTON_CLASS,
                     COARSE_POINTER_TEXT_SM_CLASS,
                   )}
                   onClick={() => onViewModeChange("source")}


### PR DESCRIPTION
## Summary

- size coarse-pointer Preview/Raw tabs so the complete bordered switch fits the 36px file header
- share the corrected sizing across markdown, CSV, and HTML preview toggles
- document the relationship between the inner tab height and the switch border/padding

## Verification

- Dev Browser at a 390x844 viewport with coarse-pointer emulation: switch reduced from 42px to 36px, with measured overflow reduced from 6px to 0
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app --force` (347 files, 2,765 tests)

> AGENT GENERATED: by GPT-5.6
