### PR TITLE
Fix Pi extension-triggered turn completion

### DIFF
--- a/packages/agent-runtime/src/pi/event-translation.test.ts
+++ b/packages/agent-runtime/src/pi/event-translation.test.ts
@@ -221,6 +221,82 @@ describe("pi event translation", () => {
     expect(events.some((event) => event.type === "provider/error")).toBe(false);
   });
 
+  it("completes extension-triggered turns when agent_end includes string custom content", () => {
+    const translator = createTranslator();
+    const context = { threadId: "pi-thread-1" };
+    const agentEndEvent = {
+      type: "agent_end",
+      messages: [
+        {
+          role: "custom",
+          customType: "pi-processes",
+          content: "Process completed successfully",
+          display: true,
+          timestamp: 1777995780000,
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "The process finished." }],
+          api: "anthropic-messages",
+          provider: "anthropic",
+          model: "claude-haiku-4-5",
+          usage: {
+            input: 10,
+            output: 5,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 15,
+            cost: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              total: 0,
+            },
+          },
+          stopReason: "stop",
+          timestamp: 1777995781000,
+        },
+      ],
+      willRetry: false,
+    } satisfies AgentSessionEvent;
+
+    translator.translatePiEvent(
+      {
+        jsonrpc: "2.0",
+        method: "sdk/message",
+        params: {
+          threadId: context.threadId,
+          message: { type: "agent_start" },
+        },
+      },
+      context,
+    );
+
+    const events = translator.translatePiEvent(
+      {
+        jsonrpc: "2.0",
+        method: "sdk/message",
+        params: {
+          threadId: context.threadId,
+          message: agentEndEvent,
+        },
+      },
+      context,
+    );
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "turn/completed",
+        scope: turnScope("turn-1"),
+        status: "completed",
+      }),
+    );
+    expect(events.some((event) => event.type === "provider/unhandled")).toBe(
+      false,
+    );
+  });
+
   it("translateEvent agent_end surfaces Pi assistant stop errors as failed turns", () => {
     const translator = createTranslator();
     const context = { threadId: "bb-thread-1" };

--- a/packages/agent-runtime/src/pi/event-translation.ts
+++ b/packages/agent-runtime/src/pi/event-translation.ts
@@ -170,7 +170,9 @@ const piAssistantMessageSchema = z
 const piConversationMessageSchema = z
   .object({
     role: z.string(),
-    content: z.array(piMessageContentBlockSchema).optional(),
+    content: z
+      .union([z.string(), z.array(piMessageContentBlockSchema)])
+      .optional(),
     stopReason: z.string().optional(),
     errorMessage: z.string().optional(),
     provider: z.string().optional(),


### PR DESCRIPTION
Fixes #1633.

## Summary

- accept string content in Pi conversation messages, as allowed by `AgentMessage`
- complete extension-triggered turns when `agent_end` contains a custom message with string content
- cover the pi-processes notification shape with a regression test

## Root cause

The Pi event translator accepted only content-block arrays in `agent_end.messages`. Pi extensions can also send user or custom messages with string content. Schema validation rejected the complete event, emitted `provider/unhandled`, and prevented `turn/completed` for extension-triggered turns.

## Validation

- `pnpm exec turbo run test --filter=@bb/agent-runtime --force`
  - 29 test files passed
  - 314 tests passed
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime`
- `git diff --check`
- independent review found no blockers

> AGENT GENERATED: by GPT-5.6 Sol
