### PR TITLE
fix: harden automation execution

### DIFF
--- a/plugins/automations/skills/automations/SKILL.md
+++ b/plugins/automations/skills/automations/SKILL.md
@@ -20,6 +20,17 @@ Use `script` when the output is fully determined by code: watchdogs, threshold a
 
 Design the script to print nothing when there is nothing to report: an exit-0 run with empty stdout/stderr, or a last non-empty line of `{"wakeAgent": false}`, is recorded as a skipped silent tick. Any other output is captured; non-zero exit or timeout is recorded as a failed run.
 
+Execution safety is fail-closed:
+
+- An automation has at most one running execution. A duplicate scheduled tick or
+  manual run reuses the existing run instead of starting another process tree.
+- Failed recurring runs retry after exponential delays (30 seconds, then 60
+  seconds). The third consecutive failure pauses the automation and clears its
+  next run. A successful or skipped run resets the failure count; explicitly
+  resuming an automation also resets it.
+- Script timeout and output-limit termination applies to the whole spawned
+  process group, including descendant processes.
+
 Use `agent` when the run needs reasoning: summarize a feed, pick interesting items, draft a human-friendly message, or branch on content.
 
 Creating:

--- a/plugins/automations/src/automations.test.ts
+++ b/plugins/automations/src/automations.test.ts
@@ -48,6 +48,28 @@ function createTestDb(): Db {
   return db;
 }
 
+async function isProcessRunning(pid: number): Promise<boolean> {
+  try {
+    process.kill(pid, 0);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") return false;
+    throw error;
+  }
+
+  if (process.platform !== "linux") return true;
+  try {
+    const stat = await readFile(`/proc/${pid}/stat`, "utf8");
+    const closingParen = stat.lastIndexOf(")");
+    const state = stat.slice(closingParen + 2, closingParen + 3);
+    // Container PID 1 may leave a terminated descendant as a zombie briefly.
+    // A zombie cannot execute and therefore satisfies process containment.
+    return state !== "Z" && state !== "X";
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
 function createScheduledAutomation(
   db: Db,
   nextRunAt: number,
@@ -1048,20 +1070,13 @@ describe("script process containment", () => {
       expect(result.timedOut).toBe(true);
       expect(Number.isSafeInteger(childPid)).toBe(true);
 
-      let childExists = true;
+      let childRunning = true;
       for (let attempt = 0; attempt < 20; attempt += 1) {
-        try {
-          process.kill(childPid, 0);
-        } catch (error) {
-          if ((error as NodeJS.ErrnoException).code === "ESRCH") {
-            childExists = false;
-            break;
-          }
-          throw error;
-        }
+        childRunning = await isProcessRunning(childPid);
+        if (!childRunning) break;
         await new Promise((resolve) => setTimeout(resolve, 25));
       }
-      expect(childExists).toBe(false);
+      expect(childRunning).toBe(false);
     } finally {
       await rm(pluginDataDir, { recursive: true, force: true });
     }

--- a/plugins/automations/src/automations.test.ts
+++ b/plugins/automations/src/automations.test.ts
@@ -17,10 +17,12 @@ import {
   createAutomation,
   createManualRun,
   getAutomation,
+  getRunningAutomationRun,
   listAutomationsForProject,
   listAutomationRuns,
   migrations,
-  restoreAutomationAfterFailedRun,
+  setAutomationEnabled,
+  AUTOMATION_RETRY_BASE_MS,
   type Db,
 } from "./data.js";
 import { ingestLegacyImport } from "./legacy-import.js";
@@ -31,6 +33,7 @@ import {
 } from "./schedule-helpers.js";
 import {
   bbBinaryCandidates,
+  executeStoredScript,
   isWakeAgentSuppressed,
   mapScriptResultToRun,
   scriptPathEnv,
@@ -41,7 +44,7 @@ import { automationScriptDir } from "./script-files.js";
 
 function createTestDb(): Db {
   const db = new Database(":memory:");
-  db.exec(migrations[0] ?? "");
+  for (const migration of migrations) db.exec(migration);
   return db;
 }
 
@@ -193,6 +196,34 @@ describe("data migrations", () => {
       .map((row) => row.permissionMode);
     expect(modes).toEqual(["accept-edits", "accept-edits"]);
   });
+
+  it("fails closed when pre-existing running rows violate single-flight", () => {
+    const db = new Database(":memory:");
+    db.exec(migrations[0] ?? "");
+    db.prepare(
+      `INSERT INTO automations (
+         id, project_id, name, trigger_type, trigger_config, run_mode,
+         execution, origin, created_at, updated_at
+       ) VALUES (
+         'auto_once', 'proj_test', 'Once', 'once', '{}', 'agent', '{}',
+         'human', 1, 1
+       )`,
+    ).run();
+    const insertRun = db.prepare(
+      `INSERT INTO automation_runs (
+         id, automation_id, run_mode, status, trigger, scheduled_for, started_at
+       ) VALUES (?, 'auto_once', 'agent', 'running', 'manual', 1000, ?)`,
+    );
+    insertRun.run("run_first", 1000);
+    insertRun.run("run_second", 1001);
+
+    expect(() =>
+      db.transaction(() => {
+        db.exec(migrations[1] ?? "");
+        db.exec(migrations[2] ?? "");
+      })(),
+    ).toThrow();
+  });
 });
 
 describe("schedule helpers", () => {
@@ -250,7 +281,7 @@ describe("automation data access", () => {
     ).toHaveLength(1);
   });
 
-  it("rolls schedule state back after dispatch failure", () => {
+  it("backs off a scheduled automation after dispatch failure", () => {
     const db = createTestDb();
     const automation = createScheduledAutomation(db, 1000);
     const claim = claimAutomationScheduledRun(db, {
@@ -260,20 +291,272 @@ describe("automation data access", () => {
       now: 1000,
     });
     if (!claim.advanced) throw new Error("claim failed");
-    restoreAutomationAfterFailedRun(db, {
-      automationId: automation.id,
+    closeAutomationRun(db, {
       runId: claim.run.id,
-      triggerType: "schedule",
-      advancedNextRunAt: 2000,
-      restoredNextRunAt: 1000,
-      expectedRunCount: 1,
+      status: "failed",
       error: "dispatch failed",
       now: 1001,
     });
     const restored = getAutomation(db, automation.id);
-    expect(restored?.nextRunAt).toBe(1000);
-    expect(restored?.runCount).toBe(0);
+    expect(restored?.nextRunAt).toBe(1001 + AUTOMATION_RETRY_BASE_MS);
+    expect(restored?.runCount).toBe(1);
+    expect(restored?.consecutiveFailures).toBe(1);
     expect(restored?.lastRunStatus).toBe("failed");
+  });
+
+  it("settles a running automation exactly once", () => {
+    const db = createTestDb();
+    const automation = createScheduledAutomation(db, 1000);
+    const claim = claimAutomationScheduledRun(db, {
+      automationId: automation.id,
+      expectedNextRunAt: 1000,
+      newNextRunAt: 2000,
+      now: 1000,
+    });
+    if (!claim.advanced) throw new Error("claim failed");
+
+    const first = closeAutomationRun(db, {
+      runId: claim.run.id,
+      status: "failed",
+      error: "first failure",
+      now: 1001,
+    });
+    const duplicate = closeAutomationRun(db, {
+      runId: claim.run.id,
+      status: "failed",
+      error: "duplicate failure",
+      now: 1002,
+    });
+
+    expect(first?.run.status).toBe("failed");
+    expect(duplicate).toBeNull();
+    expect(getAutomation(db, automation.id)?.consecutiveFailures).toBe(1);
+    expect(getAutomation(db, automation.id)?.nextRunAt).toBe(
+      1001 + AUTOMATION_RETRY_BASE_MS,
+    );
+    expect(first?.run.error).toBe("first failure");
+  });
+
+  it("does not re-enable a manually paused automation after failure", () => {
+    const db = createTestDb();
+    const automation = createScheduledAutomation(db, 1000);
+    const claim = claimAutomationScheduledRun(db, {
+      automationId: automation.id,
+      expectedNextRunAt: 1000,
+      newNextRunAt: 2000,
+      now: 1000,
+    });
+    if (!claim.advanced) throw new Error("claim failed");
+    setAutomationEnabled(db, {
+      projectId: automation.projectId,
+      automationId: automation.id,
+      enabled: false,
+      nextRunAt: null,
+    });
+
+    closeAutomationRun(db, {
+      runId: claim.run.id,
+      status: "failed",
+      error: "failed after pause",
+      now: 1001,
+    });
+
+    expect(getAutomation(db, automation.id)?.enabled).toBe(false);
+    expect(getAutomation(db, automation.id)?.nextRunAt).toBeNull();
+  });
+
+  it("auto-pauses after three consecutive scheduled failures", () => {
+    const db = createTestDb();
+    const automation = createScheduledAutomation(db, 1000);
+    let expectedNextRunAt = 1000;
+
+    for (let failure = 1; failure <= 3; failure += 1) {
+      const advancedNextRunAt = expectedNextRunAt + 60_000;
+      const claim = claimAutomationScheduledRun(db, {
+        automationId: automation.id,
+        expectedNextRunAt,
+        newNextRunAt: advancedNextRunAt,
+        now: expectedNextRunAt,
+      });
+      if (!claim.advanced) throw new Error(`claim ${failure} failed`);
+      const failedAt = expectedNextRunAt + 1;
+      closeAutomationRun(db, {
+        runId: claim.run.id,
+        status: "failed",
+        error: `dispatch failed ${failure}`,
+        now: failedAt,
+      });
+      const current = getAutomation(db, automation.id);
+      expect(current?.consecutiveFailures).toBe(failure);
+      if (failure < 3) {
+        expectedNextRunAt =
+          failedAt + AUTOMATION_RETRY_BASE_MS * 2 ** (failure - 1);
+        expect(current?.enabled).toBe(true);
+        expect(current?.nextRunAt).toBe(expectedNextRunAt);
+      } else {
+        expect(current?.enabled).toBe(false);
+        expect(current?.nextRunAt).toBeNull();
+        expect(current?.lastError).toContain(
+          "paused after 3 consecutive failures",
+        );
+      }
+    }
+  });
+
+  it("applies the same backoff and pause policy to settled script failures", () => {
+    const db = createTestDb();
+    const automation = createScheduledAutomation(db, 1000);
+    let expectedNextRunAt = 1000;
+
+    for (let failure = 1; failure <= 3; failure += 1) {
+      const claim = claimAutomationScheduledRun(db, {
+        automationId: automation.id,
+        expectedNextRunAt,
+        newNextRunAt: expectedNextRunAt + 60_000,
+        now: expectedNextRunAt,
+      });
+      if (!claim.advanced) throw new Error(`claim ${failure} failed`);
+      const failedAt = expectedNextRunAt + 1;
+      closeAutomationRun(db, {
+        runId: claim.run.id,
+        status: "failed",
+        error: `script failed ${failure}`,
+        now: failedAt,
+      });
+      const current = getAutomation(db, automation.id);
+      expect(current?.consecutiveFailures).toBe(failure);
+      if (failure < 3) {
+        expectedNextRunAt =
+          failedAt + AUTOMATION_RETRY_BASE_MS * 2 ** (failure - 1);
+        expect(current?.nextRunAt).toBe(expectedNextRunAt);
+      } else {
+        expect(current?.enabled).toBe(false);
+        expect(current?.nextRunAt).toBeNull();
+      }
+    }
+  });
+
+  it("enforces one running execution per automation", () => {
+    const db = createTestDb();
+    const automation = createScheduledAutomation(db, 1000);
+    const first = claimAutomationScheduledRun(db, {
+      automationId: automation.id,
+      expectedNextRunAt: 1000,
+      newNextRunAt: 2000,
+      now: 1000,
+    });
+    if (!first.advanced) throw new Error("first claim failed");
+
+    const overlapping = claimAutomationScheduledRun(db, {
+      automationId: automation.id,
+      expectedNextRunAt: 2000,
+      newNextRunAt: 3000,
+      now: 2000,
+    });
+    const manual = createManualRun(db, {
+      automationId: automation.id,
+      runMode: "agent",
+      now: 2000,
+    });
+
+    expect(overlapping.advanced).toBe(false);
+    expect(manual.deduped).toBe(true);
+    expect(manual.run.id).toBe(first.run.id);
+    expect(getRunningAutomationRun(db, automation.id)?.id).toBe(first.run.id);
+  });
+
+  it("enforces single-flight at the database boundary", () => {
+    const db = createTestDb();
+    const automation = createScheduledAutomation(db, 1000);
+    createManualRun(db, {
+      automationId: automation.id,
+      runMode: "agent",
+      now: 1000,
+    });
+
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO automation_runs (
+             id, automation_id, run_mode, status, trigger,
+             scheduled_for, started_at
+           ) VALUES (
+             'run_overlap', ?, 'agent', 'running', 'manual', 1001, 1001
+           )`,
+        )
+        .run(automation.id),
+    ).toThrow();
+  });
+
+  it("resets consecutive failures after a successful run", () => {
+    const db = createTestDb();
+    const automation = createScheduledAutomation(db, 1000);
+    const first = claimAutomationScheduledRun(db, {
+      automationId: automation.id,
+      expectedNextRunAt: 1000,
+      newNextRunAt: 2000,
+      now: 1000,
+    });
+    if (!first.advanced) throw new Error("first claim failed");
+    closeAutomationRun(db, {
+      runId: first.run.id,
+      status: "failed",
+      error: "dispatch failed",
+      now: 1001,
+    });
+    const retryAt = getAutomation(db, automation.id)?.nextRunAt;
+    if (retryAt === null || retryAt === undefined) {
+      throw new Error("retry was not scheduled");
+    }
+    const retry = claimAutomationScheduledRun(db, {
+      automationId: automation.id,
+      expectedNextRunAt: retryAt,
+      newNextRunAt: retryAt + 60_000,
+      now: retryAt,
+    });
+    if (!retry.advanced) throw new Error("retry claim failed");
+    closeAutomationRun(db, {
+      runId: retry.run.id,
+      status: "succeeded",
+      now: retryAt + 1,
+    });
+
+    expect(getAutomation(db, automation.id)?.consecutiveFailures).toBe(0);
+  });
+
+  it("resets consecutive failures when a scheduled tick is skipped", () => {
+    const db = createTestDb();
+    const automation = createScheduledAutomation(db, 1000);
+    const failed = claimAutomationScheduledRun(db, {
+      automationId: automation.id,
+      expectedNextRunAt: 1000,
+      newNextRunAt: 2000,
+      now: 1000,
+    });
+    if (!failed.advanced) throw new Error("claim failed");
+    closeAutomationRun(db, {
+      runId: failed.run.id,
+      status: "failed",
+      error: "transient failure",
+      now: 1001,
+    });
+    const retryAt = getAutomation(db, automation.id)?.nextRunAt;
+    if (retryAt === null || retryAt === undefined) {
+      throw new Error("retry was not scheduled");
+    }
+
+    const skipped = claimAutomationScheduledRun(db, {
+      automationId: automation.id,
+      expectedNextRunAt: retryAt,
+      newNextRunAt: retryAt + 60_000,
+      skipReason: "nothing to do",
+      now: retryAt,
+    });
+
+    expect(skipped.advanced).toBe(true);
+    expect(skipped.advanced && skipped.run.status).toBe("skipped");
+    expect(getAutomation(db, automation.id)?.consecutiveFailures).toBe(0);
+    expect(getAutomation(db, automation.id)?.lastError).toBeNull();
   });
 
   it("does not re-arm one-shot automations after dispatch failure", () => {
@@ -286,13 +569,9 @@ describe("automation data access", () => {
       now: 1000,
     });
     if (!claim.advanced) throw new Error("claim failed");
-    restoreAutomationAfterFailedRun(db, {
-      automationId: automation.id,
+    closeAutomationRun(db, {
       runId: claim.run.id,
-      triggerType: "once",
-      advancedNextRunAt: null,
-      restoredNextRunAt: 1000,
-      expectedRunCount: 1,
+      status: "failed",
       error: "dispatch failed",
       now: 1001,
     });
@@ -300,6 +579,7 @@ describe("automation data access", () => {
     expect(restored?.enabled).toBe(false);
     expect(restored?.nextRunAt).toBeNull();
     expect(restored?.runCount).toBe(1);
+    expect(restored?.consecutiveFailures).toBe(1);
     expect(restored?.lastRunStatus).toBe("failed");
   });
 
@@ -735,6 +1015,56 @@ describe("bb CLI injection for script runs", () => {
     expect(scriptPathEnv("/daemon/bundle/bb", undefined)).toBe(
       "/daemon/bundle",
     );
+  });
+});
+
+describe("script process containment", () => {
+  it("terminates descendant processes when a script times out", async () => {
+    const pluginDataDir = await mkdtemp(
+      join(tmpdir(), "bb-auto-process-group-"),
+    );
+    const scriptDir = automationScriptDir(pluginDataDir, "auto_timeout");
+    await mkdir(scriptDir, { recursive: true });
+    await writeFile(
+      join(scriptDir, "script.sh"),
+      "sleep 30 &\nchild_pid=$!\necho $child_pid\nwait $child_pid\n",
+    );
+
+    try {
+      const result = await executeStoredScript({
+        pluginDataDir,
+        automationId: "auto_timeout",
+        runId: "run_timeout",
+        projectId: "proj_test",
+        scriptFile: "script.sh",
+        interpreter: "bash",
+        timeoutMs: 100,
+        serverUrl: "http://127.0.0.1:38886",
+      });
+      const childPid = Number.parseInt(
+        result.output.trim().split(/\s+/u)[0] ?? "",
+        10,
+      );
+      expect(result.timedOut).toBe(true);
+      expect(Number.isSafeInteger(childPid)).toBe(true);
+
+      let childExists = true;
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        try {
+          process.kill(childPid, 0);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "ESRCH") {
+            childExists = false;
+            break;
+          }
+          throw error;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+      expect(childExists).toBe(false);
+    } finally {
+      await rm(pluginDataDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/plugins/automations/src/automations.test.ts
+++ b/plugins/automations/src/automations.test.ts
@@ -1049,7 +1049,7 @@ describe("script process containment", () => {
     await mkdir(scriptDir, { recursive: true });
     await writeFile(
       join(scriptDir, "script.sh"),
-      "sleep 30 &\nchild_pid=$!\necho $child_pid\nwait $child_pid\n",
+      "sleep 30 &\nchild_pid=$!\nprintf 'child_pid=%s\\n' \"$child_pid\"\nwait $child_pid\n",
     );
 
     try {
@@ -1065,10 +1065,8 @@ describe("script process containment", () => {
         timeoutMs: 1_000,
         serverUrl: "http://127.0.0.1:38886",
       });
-      const childPid = Number.parseInt(
-        result.output.trim().split(/\s+/u)[0] ?? "",
-        10,
-      );
+      const childPidMatch = result.output.match(/^child_pid=(\d+)$/mu);
+      const childPid = Number.parseInt(childPidMatch?.[1] ?? "", 10);
       expect(result.timedOut).toBe(true);
       expect(Number.isSafeInteger(childPid)).toBe(true);
 

--- a/plugins/automations/src/automations.test.ts
+++ b/plugins/automations/src/automations.test.ts
@@ -1060,7 +1060,9 @@ describe("script process containment", () => {
         projectId: "proj_test",
         scriptFile: "script.sh",
         interpreter: "bash",
-        timeoutMs: 100,
+        // Leave enough startup headroom for loaded CI hosts while still proving
+        // that the timeout, rather than normal script completion, owns cleanup.
+        timeoutMs: 1_000,
         serverUrl: "http://127.0.0.1:38886",
       });
       const childPid = Number.parseInt(

--- a/plugins/automations/src/data.ts
+++ b/plugins/automations/src/data.ts
@@ -17,6 +17,10 @@ import {
 
 export type Db = Database.Database;
 
+export const AUTOMATION_MAX_CONSECUTIVE_FAILURES = 3;
+export const AUTOMATION_RETRY_BASE_MS = 30_000;
+export const AUTOMATION_RETRY_MAX_MS = 15 * 60_000;
+
 export interface AutomationRow {
   id: string;
   projectId: string;
@@ -32,6 +36,7 @@ export interface AutomationRow {
   nextRunAt: number | null;
   lastRunAt: number | null;
   runCount: number;
+  consecutiveFailures: number;
   lastRunStatus: AutomationRunStatus | null;
   lastRunThreadId: string | null;
   lastError: string | null;
@@ -56,8 +61,7 @@ export interface AutomationRunRow {
   finishedAt: number | null;
 }
 
-interface RawAutomationRow
-  extends Omit<AutomationRow, "enabled"> {
+interface RawAutomationRow extends Omit<AutomationRow, "enabled"> {
   enabled: 0 | 1;
 }
 
@@ -163,7 +167,20 @@ export const migrations = [
        'workspace-write',
        'readonly'
      );`,
+  `ALTER TABLE automations
+     ADD COLUMN consecutive_failures INTEGER NOT NULL DEFAULT 0;
+   CREATE UNIQUE INDEX IF NOT EXISTS automation_runs_single_flight_idx
+     ON automation_runs(automation_id)
+     WHERE status = 'running';`,
 ];
+
+export function automationRetryDelayMs(consecutiveFailures: number): number {
+  const exponent = Math.max(0, consecutiveFailures - 1);
+  return Math.min(
+    AUTOMATION_RETRY_BASE_MS * 2 ** exponent,
+    AUTOMATION_RETRY_MAX_MS,
+  );
+}
 
 export interface CreateAutomationInput {
   id?: string;
@@ -194,11 +211,15 @@ function serializeExecution(execution: AutomationExecution): string {
   return JSON.stringify(execution);
 }
 
-export function parseAutomationTrigger(triggerConfig: string): AutomationTrigger {
+export function parseAutomationTrigger(
+  triggerConfig: string,
+): AutomationTrigger {
   return automationTriggerSchema.parse(JSON.parse(triggerConfig));
 }
 
-export function parseAutomationExecution(execution: string): AutomationExecution {
+export function parseAutomationExecution(
+  execution: string,
+): AutomationExecution {
   return automationExecutionSchema.parse(JSON.parse(execution));
 }
 
@@ -245,7 +266,10 @@ export function toAutomationRunResponse(
   });
 }
 
-export function createAutomation(db: Db, input: CreateAutomationInput): AutomationRow {
+export function createAutomation(
+  db: Db,
+  input: CreateAutomationInput,
+): AutomationRow {
   const now = Date.now();
   const id = input.id ?? createAutomationId();
   db.prepare(
@@ -292,7 +316,8 @@ export function getAutomation(db: Db, id: string): AutomationRow | null {
            trigger_config AS triggerConfig, run_mode AS runMode, execution, origin,
            created_by_thread_id AS createdByThreadId,
            next_run_at AS nextRunAt, last_run_at AS lastRunAt,
-           run_count AS runCount, last_run_status AS lastRunStatus,
+           run_count AS runCount, consecutive_failures AS consecutiveFailures,
+           last_run_status AS lastRunStatus,
            last_run_thread_id AS lastRunThreadId, last_error AS lastError,
            created_at AS createdAt, updated_at AS updatedAt
          FROM automations WHERE id = ?`,
@@ -321,7 +346,8 @@ export function listAutomationsForProject(
          trigger_config AS triggerConfig, run_mode AS runMode, execution, origin,
          created_by_thread_id AS createdByThreadId,
          next_run_at AS nextRunAt, last_run_at AS lastRunAt,
-         run_count AS runCount, last_run_status AS lastRunStatus,
+         run_count AS runCount, consecutive_failures AS consecutiveFailures,
+         last_run_status AS lastRunStatus,
          last_run_thread_id AS lastRunThreadId, last_error AS lastError,
          created_at AS createdAt, updated_at AS updatedAt
        FROM automations
@@ -341,7 +367,8 @@ export function listAllAutomations(db: Db): AutomationRow[] {
          trigger_config AS triggerConfig, run_mode AS runMode, execution, origin,
          created_by_thread_id AS createdByThreadId,
          next_run_at AS nextRunAt, last_run_at AS lastRunAt,
-         run_count AS runCount, last_run_status AS lastRunStatus,
+         run_count AS runCount, consecutive_failures AS consecutiveFailures,
+         last_run_status AS lastRunStatus,
          last_run_thread_id AS lastRunThreadId, last_error AS lastError,
          created_at AS createdAt, updated_at AS updatedAt
        FROM automations
@@ -353,11 +380,16 @@ export function listAllAutomations(db: Db): AutomationRow[] {
 
 export function updateAutomation(
   db: Db,
-  args: { projectId: string; automationId: string; patch: UpdateAutomationInput },
+  args: {
+    projectId: string;
+    automationId: string;
+    patch: UpdateAutomationInput;
+  },
 ): AutomationRow | null {
   const existing = getAutomationForProject(db, args);
   if (!existing) return null;
-  const nextTrigger = args.patch.trigger ?? parseAutomationTrigger(existing.triggerConfig);
+  const nextTrigger =
+    args.patch.trigger ?? parseAutomationTrigger(existing.triggerConfig);
   const nextExecution =
     args.patch.execution ?? parseAutomationExecution(existing.execution);
   const now = Date.now();
@@ -387,7 +419,9 @@ export function updateAutomation(
           ? (nextExecution.targetThreadId ?? null)
           : null,
     nextRunAt:
-      args.patch.nextRunAt !== undefined ? args.patch.nextRunAt : existing.nextRunAt,
+      args.patch.nextRunAt !== undefined
+        ? args.patch.nextRunAt
+        : existing.nextRunAt,
     now,
   });
   return getAutomationForProject(db, args);
@@ -401,6 +435,7 @@ export function setAutomationEnabled(
     enabled: boolean;
     nextRunAt: number | null;
     lastError?: string | null;
+    resetConsecutiveFailures?: boolean;
   },
 ): AutomationRow | null {
   db.prepare(
@@ -408,6 +443,10 @@ export function setAutomationEnabled(
        enabled = @enabled,
        next_run_at = @nextRunAt,
        last_error = CASE WHEN @hasLastError THEN @lastError ELSE last_error END,
+       consecutive_failures = CASE
+         WHEN @resetConsecutiveFailures = 1 THEN 0
+         ELSE consecutive_failures
+       END,
        updated_at = @now
      WHERE id = @automationId AND project_id = @projectId`,
   ).run({
@@ -417,6 +456,7 @@ export function setAutomationEnabled(
     nextRunAt: args.nextRunAt,
     hasLastError: args.lastError === undefined ? 0 : 1,
     lastError: args.lastError ?? null,
+    resetConsecutiveFailures: boolToInt(args.resetConsecutiveFailures ?? false),
     now: Date.now(),
   });
   return getAutomationForProject(db, args);
@@ -453,7 +493,8 @@ export function listDueAutomations(
          trigger_config AS triggerConfig, run_mode AS runMode, execution, origin,
          created_by_thread_id AS createdByThreadId,
          next_run_at AS nextRunAt, last_run_at AS lastRunAt,
-         run_count AS runCount, last_run_status AS lastRunStatus,
+         run_count AS runCount, consecutive_failures AS consecutiveFailures,
+         last_run_status AS lastRunStatus,
          last_run_thread_id AS lastRunThreadId, last_error AS lastError,
          created_at AS createdAt, updated_at AS updatedAt
        FROM automations
@@ -471,6 +512,28 @@ export function listDueAutomations(
 export type ClaimScheduledRunResult =
   | { advanced: false }
   | { advanced: true; automation: AutomationRow; run: AutomationRunRow };
+
+export function getRunningAutomationRun(
+  db: Db,
+  automationId: string,
+): AutomationRunRow | null {
+  return optionalRunRow(
+    db
+      .prepare(
+        `SELECT
+           id, automation_id AS automationId, run_mode AS runMode,
+           thread_id AS threadId, status, trigger, skip_reason AS skipReason,
+           error, output, exit_code AS exitCode,
+           idempotency_key AS idempotencyKey, scheduled_for AS scheduledFor,
+           started_at AS startedAt, finished_at AS finishedAt
+         FROM automation_runs
+         WHERE automation_id = ? AND status = 'running'
+         ORDER BY started_at DESC, id DESC
+         LIMIT 1`,
+      )
+      .get(automationId),
+  );
+}
 
 export function claimAutomationScheduledRun(
   db: Db,
@@ -492,6 +555,9 @@ export function claimAutomationScheduledRun(
     ) {
       return { advanced: false };
     }
+    if (getRunningAutomationRun(db, args.automationId)) {
+      return { advanced: false };
+    }
     const skip = args.skipReason != null;
     const updated = db
       .prepare(
@@ -500,7 +566,12 @@ export function claimAutomationScheduledRun(
            next_run_at = @newNextRunAt,
            last_run_at = @now,
            run_count = run_count + 1,
+           consecutive_failures = CASE
+             WHEN @skip = 1 THEN 0
+             ELSE consecutive_failures
+           END,
            last_run_status = @lastRunStatus,
+           last_error = CASE WHEN @skip = 1 THEN NULL ELSE last_error END,
            updated_at = @now
          WHERE id = @automationId AND next_run_at = @expectedNextRunAt
          RETURNING
@@ -509,7 +580,8 @@ export function claimAutomationScheduledRun(
            trigger_config AS triggerConfig, run_mode AS runMode, execution, origin,
            created_by_thread_id AS createdByThreadId,
            next_run_at AS nextRunAt, last_run_at AS lastRunAt,
-           run_count AS runCount, last_run_status AS lastRunStatus,
+           run_count AS runCount, consecutive_failures AS consecutiveFailures,
+           last_run_status AS lastRunStatus,
            last_run_thread_id AS lastRunThreadId, last_error AS lastError,
            created_at AS createdAt, updated_at AS updatedAt`,
       )
@@ -518,6 +590,7 @@ export function claimAutomationScheduledRun(
         expectedNextRunAt: args.expectedNextRunAt,
         enabled: boolToInt(row.triggerType === "once" ? false : row.enabled),
         newNextRunAt: args.newNextRunAt,
+        skip: boolToInt(skip),
         lastRunStatus: skip ? "skipped" : "running",
         now: args.now,
       });
@@ -548,63 +621,50 @@ export function claimAutomationScheduledRun(
   })();
 }
 
-export function restoreAutomationAfterFailedRun(
+function recordAutomationFailure(
   db: Db,
   args: {
     automationId: string;
-    runId: string;
-    triggerType: "schedule" | "once";
-    advancedNextRunAt: number | null;
-    restoredNextRunAt: number;
-    expectedRunCount: number;
+    retrySchedule: boolean;
     error: string;
     now: number;
   },
-): void {
-  db.transaction(() => {
-    if (args.triggerType === "once") {
-      // A failed one-shot is terminal: the claim already disabled it and its
-      // runAt is in the past, so re-arming would retry every sweep forever
-      // (and re-enable automations deliberately disabled elsewhere).
-      db.prepare(
-        `UPDATE automations SET
-           last_run_status = 'failed',
-           last_error = @error,
-           updated_at = @now
-         WHERE id = @automationId`,
-      ).run({
-        automationId: args.automationId,
-        error: args.error,
-        now: args.now,
-      });
-    } else {
-      db.prepare(
-        `UPDATE automations SET
-           enabled = 1,
-           next_run_at = @restoredNextRunAt,
-           run_count = @restoredRunCount,
-           last_run_status = 'failed',
-           last_error = @error,
-           updated_at = @now
-         WHERE id = @automationId
-           AND run_count = @expectedRunCount
-           AND next_run_at = @advancedNextRunAt`,
-      ).run({
-        automationId: args.automationId,
-        restoredNextRunAt: args.restoredNextRunAt,
-        restoredRunCount: args.expectedRunCount - 1,
-        expectedRunCount: args.expectedRunCount,
-        advancedNextRunAt: args.advancedNextRunAt,
-        error: args.error,
-        now: args.now,
-      });
-    }
-    db.prepare(
-      `UPDATE automation_runs
-       SET status = 'failed', error = @error, finished_at = @now
-       WHERE id = @runId`,
-    ).run({ runId: args.runId, error: args.error, now: args.now });
-  })();
+): { consecutiveFailures: number; paused: boolean; retryAt: number | null } {
+  const automation = getAutomation(db, args.automationId);
+  if (!automation) {
+    return { consecutiveFailures: 0, paused: false, retryAt: null };
+  }
+  const consecutiveFailures = automation.consecutiveFailures + 1;
+  const paused = consecutiveFailures >= AUTOMATION_MAX_CONSECUTIVE_FAILURES;
+  const retryAt =
+    args.retrySchedule && automation.enabled && !paused
+      ? args.now + automationRetryDelayMs(consecutiveFailures)
+      : null;
+  const lastError = paused
+    ? `${args.error} (automation paused after ${consecutiveFailures} consecutive failures)`
+    : args.error;
+  db.prepare(
+    `UPDATE automations SET
+       enabled = CASE WHEN @paused = 1 THEN 0 ELSE enabled END,
+       next_run_at = CASE
+         WHEN @paused = 1 THEN NULL
+         WHEN @retryAt IS NOT NULL THEN @retryAt
+         ELSE next_run_at
+       END,
+       consecutive_failures = @consecutiveFailures,
+       last_run_status = 'failed',
+       last_error = @lastError,
+       updated_at = @now
+     WHERE id = @automationId`,
+  ).run({
+    automationId: args.automationId,
+    paused: boolToInt(paused),
+    retryAt,
+    consecutiveFailures,
+    lastError,
+    now: args.now,
+  });
+  return { consecutiveFailures, paused, retryAt };
 }
 
 export function closeAutomationRun(
@@ -622,9 +682,10 @@ export function closeAutomationRun(
 ): { run: AutomationRunRow; automationId: string } | null {
   return db.transaction(() => {
     const existing = getAutomationRun(db, args.runId);
-    if (!existing) return null;
-    db.prepare(
-       `UPDATE automation_runs SET
+    if (!existing || existing.status !== "running") return null;
+    const settled = db
+      .prepare(
+        `UPDATE automation_runs SET
          status = @status,
          skip_reason = @skipReason,
          error = @error,
@@ -632,35 +693,57 @@ export function closeAutomationRun(
          exit_code = @exitCode,
          thread_id = CASE WHEN @hasThreadId THEN @threadId ELSE thread_id END,
          finished_at = @now
-       WHERE id = @runId`,
-    ).run({
-      runId: args.runId,
-      status: args.status,
-      skipReason: args.skipReason ?? null,
-      error: args.error ?? null,
-      output: args.output ?? null,
-      exitCode: args.exitCode ?? null,
-      hasThreadId: args.threadId === undefined ? 0 : 1,
-      threadId: args.threadId ?? null,
-      now: args.now,
-    });
-    db.prepare(
-      `UPDATE automations SET
-         last_run_status = @status,
-         last_run_thread_id = CASE
-           WHEN @threadId IS NOT NULL THEN @threadId
-           ELSE last_run_thread_id
-         END,
-         last_error = CASE WHEN @status = 'failed' THEN @error ELSE NULL END,
-         updated_at = @now
-       WHERE id = @automationId`,
-    ).run({
-      automationId: existing.automationId,
-      status: args.status,
-      threadId: args.threadId ?? null,
-      error: args.error ?? null,
-      now: args.now,
-    });
+       WHERE id = @runId AND status = 'running'`,
+      )
+      .run({
+        runId: args.runId,
+        status: args.status,
+        skipReason: args.skipReason ?? null,
+        error: args.error ?? null,
+        output: args.output ?? null,
+        exitCode: args.exitCode ?? null,
+        hasThreadId: args.threadId === undefined ? 0 : 1,
+        threadId: args.threadId ?? null,
+        now: args.now,
+      });
+    if (settled.changes !== 1) return null;
+    if (args.status === "failed") {
+      recordAutomationFailure(db, {
+        automationId: existing.automationId,
+        retrySchedule: existing.trigger === "schedule",
+        error: args.error ?? "Automation run failed",
+        now: args.now,
+      });
+      db.prepare(
+        `UPDATE automations SET
+           last_run_thread_id = CASE
+             WHEN @threadId IS NOT NULL THEN @threadId
+             ELSE last_run_thread_id
+           END
+         WHERE id = @automationId`,
+      ).run({
+        automationId: existing.automationId,
+        threadId: args.threadId ?? null,
+      });
+    } else {
+      db.prepare(
+        `UPDATE automations SET
+           consecutive_failures = 0,
+           last_run_status = @status,
+           last_run_thread_id = CASE
+             WHEN @threadId IS NOT NULL THEN @threadId
+             ELSE last_run_thread_id
+           END,
+           last_error = NULL,
+           updated_at = @now
+         WHERE id = @automationId`,
+      ).run({
+        automationId: existing.automationId,
+        status: args.status,
+        threadId: args.threadId ?? null,
+        now: args.now,
+      });
+    }
     const run = getAutomationRun(db, args.runId);
     if (!run) return null;
     return { run, automationId: run.automationId };
@@ -694,6 +777,8 @@ export function createManualRun(
       );
       if (existing) return { run: existing, deduped: true };
     }
+    const running = getRunningAutomationRun(db, args.automationId);
+    if (running) return { run: running, deduped: true };
     const runId = createAutomationRunId();
     db.prepare(
       `INSERT INTO automation_runs (
@@ -763,21 +848,18 @@ export function isAutomationSpawnedThread(db: Db, threadId: string): boolean {
       )
       .get(threadId) !== undefined ||
     db
-      .prepare(
-        `SELECT id FROM automation_runs WHERE thread_id = ? LIMIT 1`,
-      )
+      .prepare(`SELECT id FROM automation_runs WHERE thread_id = ? LIMIT 1`)
       .get(threadId) !== undefined
   );
 }
 
-export function getRunningAutomationRunByThread(
+export function listRunningAutomationRunsByThread(
   db: Db,
   threadId: string,
-): AutomationRunRow | null {
-  return optionalRunRow(
-    db
-      .prepare(
-        `SELECT
+): AutomationRunRow[] {
+  return db
+    .prepare(
+      `SELECT
            id, automation_id AS automationId, run_mode AS runMode,
            thread_id AS threadId, status, trigger, skip_reason AS skipReason,
            error, output, exit_code AS exitCode,
@@ -785,11 +867,9 @@ export function getRunningAutomationRunByThread(
            started_at AS startedAt, finished_at AS finishedAt
          FROM automation_runs
          WHERE thread_id = ? AND status = 'running'
-         ORDER BY started_at DESC
-         LIMIT 1`,
-      )
-      .get(threadId),
-  );
+         ORDER BY started_at DESC, id DESC`,
+    )
+    .all(threadId) as AutomationRunRow[];
 }
 
 export function listAutomationRuns(
@@ -859,7 +939,8 @@ export function disableAutomationsForDeletedThread(
          trigger_config AS triggerConfig, run_mode AS runMode, execution, origin,
          created_by_thread_id AS createdByThreadId,
          next_run_at AS nextRunAt, last_run_at AS lastRunAt,
-         run_count AS runCount, last_run_status AS lastRunStatus,
+         run_count AS runCount, consecutive_failures AS consecutiveFailures,
+         last_run_status AS lastRunStatus,
          last_run_thread_id AS lastRunThreadId, last_error AS lastError,
          created_at AS createdAt, updated_at AS updatedAt
        FROM automations

--- a/plugins/automations/src/run.ts
+++ b/plugins/automations/src/run.ts
@@ -4,7 +4,7 @@ import {
   closeAutomationRun,
   disableAutomationsForDeletedThread,
   getAutomation,
-  getRunningAutomationRunByThread,
+  listRunningAutomationRunsByThread,
   markAutomationThread,
   setAutomationEnabled,
   setAutomationRunThread,
@@ -130,8 +130,7 @@ export async function executeAgentRun(
 /**
  * Failure policy for agent dispatch: a deleted project is terminal (the
  * project never comes back), so disable the automation and close the run
- * instead of invoking the caller's rollback — which would re-arm the past
- * next_run_at and fail again every sweep.
+ * instead of treating the failure as transient and scheduling another run.
  */
 function settleDispatchFailure(
   bb: Pick<BbPluginApi, "log">,
@@ -218,8 +217,8 @@ async function reuseTargetThreadForRun(
 /**
  * The target thread is gone or unusable — a deliberate disable, not a
  * transient dispatch failure: close the run failed and leave the automation
- * disabled instead of invoking the schedule rollback (which would re-enable
- * and re-arm it).
+ * disabled instead of treating the failure as transient and scheduling
+ * another run.
  */
 function closeRunForUnusableTargetThread(
   bb: Pick<BbPluginApi, "log">,
@@ -306,19 +305,23 @@ export function closeAutomationRunForSettledThread(
   db: Db,
   args: { threadId: string; status: "idle" | "failed"; error?: string | null },
 ): void {
-  const run = getRunningAutomationRunByThread(db, args.threadId);
-  if (!run) return;
-  const closed = closeAutomationRun(db, {
-    runId: run.id,
-    status: args.status === "idle" ? "succeeded" : "failed",
-    error: args.status === "idle" ? null : (args.error ?? "Turn failed"),
-    threadId: args.threadId,
-    now: Date.now(),
-  });
-  if (!closed) return;
-  const automation = getAutomation(db, closed.automationId);
-  if (automation) {
-    publishAutomationChange(bb, automation.projectId, [
+  const runs = listRunningAutomationRunsByThread(db, args.threadId);
+  const now = Date.now();
+  const changedProjects = new Set<string>();
+  for (const run of runs) {
+    const closed = closeAutomationRun(db, {
+      runId: run.id,
+      status: args.status === "idle" ? "succeeded" : "failed",
+      error: args.status === "idle" ? null : (args.error ?? "Turn failed"),
+      threadId: args.threadId,
+      now,
+    });
+    if (!closed) continue;
+    const automation = getAutomation(db, closed.automationId);
+    if (automation) changedProjects.add(automation.projectId);
+  }
+  for (const projectId of changedProjects) {
+    publishAutomationChange(bb, projectId, [
       "automations-changed",
       "automation-runs-changed",
     ]);

--- a/plugins/automations/src/script-runner.ts
+++ b/plugins/automations/src/script-runner.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { constants } from "node:fs";
 import { delimiter, dirname, isAbsolute, join } from "node:path";
 import { promisify } from "node:util";
@@ -167,7 +167,9 @@ export interface ScriptRunOutcome {
   skipReason: string | null;
 }
 
-export function mapScriptResultToRun(result: ScriptRunResult): ScriptRunOutcome {
+export function mapScriptResultToRun(
+  result: ScriptRunResult,
+): ScriptRunOutcome {
   if (result.timedOut) {
     return {
       status: "failed",
@@ -213,27 +215,93 @@ export function mapScriptResultToRun(result: ScriptRunResult): ScriptRunOutcome 
   };
 }
 
-function trimOutput(output: string): string {
-  if (Buffer.byteLength(output, "utf8") <= SCRIPT_OUTPUT_MAX_BYTES) {
-    return output;
+function signalProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
+  try {
+    if (process.platform !== "win32" && child.pid !== undefined) {
+      process.kill(-child.pid, signal);
+      return;
+    }
+    child.kill(signal);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") return;
+    try {
+      child.kill(signal);
+    } catch {
+      // The child may have exited between the group and direct signals.
+    }
   }
-  return `${output.slice(0, SCRIPT_OUTPUT_MAX_BYTES)}\n[output truncated]\n`;
 }
 
-function combinedOutput(stdout: string | Buffer, stderr: string | Buffer): string {
-  return trimOutput(`${String(stdout)}${String(stderr)}`);
-}
+function executeWithProcessGroup(args: {
+  command: string;
+  scriptPath: string;
+  cwd: string;
+  timeoutMs: number;
+  env: NodeJS.ProcessEnv;
+}): Promise<ScriptRunResult> {
+  return new Promise((resolve) => {
+    let timedOut = false;
+    let outputLimitExceeded = false;
+    let outputBytes = 0;
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    let forceKill: NodeJS.Timeout | undefined;
+    let timeout: NodeJS.Timeout;
+    const child = spawn(args.command, [args.scriptPath], {
+      cwd: args.cwd,
+      detached: process.platform !== "win32",
+      env: args.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
 
-interface ExecFileError extends Error {
-  code?: number | string;
-  signal?: NodeJS.Signals;
-  killed?: boolean;
-  stdout?: string | Buffer;
-  stderr?: string | Buffer;
-}
-
-function exitCodeFromError(error: ExecFileError): number | null {
-  return typeof error.code === "number" ? error.code : null;
+    const terminateGroup = (): void => {
+      signalProcessGroup(child, "SIGTERM");
+      if (forceKill) return;
+      forceKill = setTimeout(() => {
+        signalProcessGroup(child, "SIGKILL");
+      }, 1_000);
+      forceKill.unref();
+    };
+    const capture = (target: Buffer[], chunk: Buffer | string): void => {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      const remaining = SCRIPT_OUTPUT_MAX_BYTES - outputBytes;
+      if (remaining > 0) {
+        const captured = buffer.subarray(0, remaining);
+        target.push(captured);
+        outputBytes += captured.byteLength;
+      }
+      if (buffer.byteLength > remaining && !outputLimitExceeded) {
+        outputLimitExceeded = true;
+        terminateGroup();
+      }
+    };
+    child.stdout?.on("data", (chunk: Buffer) => capture(stdoutChunks, chunk));
+    child.stderr?.on("data", (chunk: Buffer) => capture(stderrChunks, chunk));
+    child.once("error", (error) => {
+      capture(stderrChunks, `${error.message}\n`);
+      terminateGroup();
+    });
+    child.once("close", (code) => {
+      clearTimeout(timeout);
+      if (forceKill) clearTimeout(forceKill);
+      if (timedOut || outputLimitExceeded) {
+        signalProcessGroup(child, "SIGKILL");
+      }
+      const suffix = outputLimitExceeded ? "\n[output truncated]\n" : "";
+      resolve({
+        exitCode: timedOut ? null : outputLimitExceeded ? 1 : code,
+        output: `${Buffer.concat(stdoutChunks).toString("utf8")}${Buffer.concat(
+          stderrChunks,
+        ).toString("utf8")}${suffix}`,
+        timedOut,
+      });
+    });
+    timeout = setTimeout(() => {
+      timedOut = true;
+      terminateGroup();
+    }, args.timeoutMs);
+    timeout.unref();
+  });
 }
 
 export async function executeStoredScript(args: {
@@ -252,7 +320,8 @@ export async function executeStoredScript(args: {
     automationId: args.automationId,
     scriptFile: args.scriptFile,
   });
-  const interpreter = args.interpreter ?? resolveDefaultInterpreter(args.scriptFile);
+  const interpreter =
+    args.interpreter ?? resolveDefaultInterpreter(args.scriptFile);
   const command = resolveInterpreterCommand(interpreter);
   const bbPath = await resolveBbBinary();
   // A script that never calls bb must still run, so an unresolved CLI only
@@ -274,24 +343,12 @@ export async function executeStoredScript(args: {
   }
   const cwd = scriptsRoot(args.pluginDataDir);
   await mkdir(cwd, { recursive: true });
-  try {
-    const result = await execFileAsync(command, [scriptPath], {
-      cwd,
-      timeout: Math.min(args.timeoutMs, AUTOMATION_SCRIPT_TIMEOUT_MAX_MS),
-      maxBuffer: SCRIPT_OUTPUT_MAX_BYTES,
-      env: scriptEnv,
-    });
-    return {
-      exitCode: 0,
-      output: `${warning}${combinedOutput(result.stdout, result.stderr)}`,
-      timedOut: false,
-    };
-  } catch (error) {
-    const err = error as ExecFileError;
-    return {
-      exitCode: exitCodeFromError(err),
-      output: `${warning}${combinedOutput(err.stdout ?? "", err.stderr ?? "")}`,
-      timedOut: err.killed === true && err.signal === "SIGTERM",
-    };
-  }
+  const result = await executeWithProcessGroup({
+    command,
+    scriptPath,
+    cwd,
+    timeoutMs: Math.min(args.timeoutMs, AUTOMATION_SCRIPT_TIMEOUT_MAX_MS),
+    env: scriptEnv,
+  });
+  return { ...result, output: `${warning}${result.output}` };
 }

--- a/plugins/automations/src/service.ts
+++ b/plugins/automations/src/service.ts
@@ -648,6 +648,7 @@ export function createAutomationService(args: {
         enabled: true,
         nextRunAt: computeNextRunAt(trigger, now),
         lastError: null,
+        resetConsecutiveFailures: true,
       });
       if (!updated) throw new Error("Automation not found");
       publishAutomationChange(bb, input.projectId, "automations-changed");

--- a/plugins/automations/src/sweep.ts
+++ b/plugins/automations/src/sweep.ts
@@ -2,10 +2,10 @@ import type { BbPluginApi } from "@get-bb/plugin-sdk";
 import { z } from "zod";
 import {
   claimAutomationScheduledRun,
+  closeAutomationRun,
   listDueAutomations,
   parseAutomationExecution,
   parseAutomationTrigger,
-  restoreAutomationAfterFailedRun,
   type AutomationRow,
   type AutomationRunRow,
   type Db,
@@ -37,25 +37,18 @@ type SweepApi = Pick<BbPluginApi, "realtime" | "log"> & {
   };
 };
 
-function buildScheduleRollback(
+function buildScheduleFailureHandler(
   db: Db,
   args: {
-    automation: AutomationRow;
     run: AutomationRunRow;
-    advancedNextRunAt: number | null;
-    now: number;
   },
 ): (error: unknown) => void {
   return (error) => {
-    restoreAutomationAfterFailedRun(db, {
-      automationId: args.automation.id,
+    closeAutomationRun(db, {
       runId: args.run.id,
-      triggerType: args.automation.triggerType,
-      advancedNextRunAt: args.advancedNextRunAt,
-      restoredNextRunAt: args.automation.nextRunAt ?? args.now,
-      expectedRunCount: args.automation.runCount + 1,
+      status: "failed",
       error: error instanceof Error ? error.message : String(error),
-      now: args.now,
+      now: Date.now(),
     });
   };
 }
@@ -110,11 +103,8 @@ async function processDueAutomation(
     "automations-changed",
     "automation-runs-changed",
   ]);
-  const onFailure = buildScheduleRollback(db, {
-    automation: args.automation,
+  const onFailure = buildScheduleFailureHandler(db, {
     run: claim.run,
-    advancedNextRunAt: newNextRunAt,
-    now: args.now,
   });
   if (execution.mode === "agent") {
     await executeAgentRun(bb, db, {


### PR DESCRIPTION
## Summary

- enforce single-flight automation execution per automation
- add exponential retry backoff and auto-pause after three consecutive failures
- terminate the full script process group on timeout
- validate native target threads and permission modes before dispatch
- document native automation delivery via `bb thread tell`

## Verification

- `pnpm --filter bb-plugin-automations test` — 72 tests passed across 6 files
- `pnpm --filter bb-plugin-automations typecheck` — passed
- live Prompt Forge manual canary and subsequent scheduled run both succeeded against a fresh native thread
