### PR TITLE
fix(app): prevent composer history update loops

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -2,6 +2,8 @@
 
 import type { PromptTextMention } from "@bb/domain";
 import {
+  Profiler,
+  startTransition,
   createRef,
   useLayoutEffect,
   useRef,
@@ -9,6 +11,7 @@ import {
   type ComponentProps,
   type RefObject,
 } from "react";
+import { flushSync } from "react-dom";
 import {
   act,
   cleanup,
@@ -256,6 +259,35 @@ function PromptBoxHistoryAutoFocusAfterLayoutStealHarness({
         Late layout focus target
       </button>
     </>
+  );
+}
+
+function PromptBoxEmptyHistoryTransitionHarness({
+  scheduleRenderRef,
+}: {
+  scheduleRenderRef: RefObject<(() => void) | null>;
+}) {
+  const [, setRenderVersion] = useState(0);
+
+  useLayoutEffect(() => {
+    scheduleRenderRef.current = () =>
+      setRenderVersion((current) => current + 1);
+    return () => {
+      scheduleRenderRef.current = null;
+    };
+  }, [scheduleRenderRef]);
+
+  return (
+    <PromptBoxInternal
+      {...createPromptBoxProps({
+        history: {
+          currentDraft: emptyPromptDraftState(),
+          entries: [],
+          onSelectEntry: vi.fn(),
+          resetKey: "thread-1",
+        },
+      })}
+    />
   );
 }
 
@@ -1042,6 +1074,30 @@ describe("PromptBoxInternal controlled value sync", () => {
     } finally {
       restoreMatchMedia();
     }
+  });
+
+  it("does not loop when an empty history object is recreated across update priorities", () => {
+    const onRender = vi.fn();
+    const scheduleRenderRef = createRef<(() => void) | null>();
+    render(
+      <Profiler id="prompt-box" onRender={onRender}>
+        <PromptBoxEmptyHistoryTransitionHarness
+          scheduleRenderRef={scheduleRenderRef}
+        />
+      </Profiler>,
+    );
+    const scheduleRender = scheduleRenderRef.current;
+    if (!scheduleRender) throw new Error("Expected render scheduler");
+    let commitsAfterSynchronousRender = -1;
+
+    act(() => {
+      startTransition(scheduleRender);
+      flushSync(scheduleRender);
+      commitsAfterSynchronousRender = onRender.mock.calls.length;
+    });
+
+    expect(commitsAfterSynchronousRender).toBe(4);
+    expect(onRender).toHaveBeenCalledTimes(5);
   });
 
   it("refocuses when the history reset key changes on fine pointers", async () => {

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -2,8 +2,6 @@
 
 import type { PromptTextMention } from "@bb/domain";
 import {
-  Profiler,
-  startTransition,
   createRef,
   useLayoutEffect,
   useRef,
@@ -11,7 +9,6 @@ import {
   type ComponentProps,
   type RefObject,
 } from "react";
-import { flushSync } from "react-dom";
 import {
   act,
   cleanup,
@@ -259,35 +256,6 @@ function PromptBoxHistoryAutoFocusAfterLayoutStealHarness({
         Late layout focus target
       </button>
     </>
-  );
-}
-
-function PromptBoxEmptyHistoryTransitionHarness({
-  scheduleRenderRef,
-}: {
-  scheduleRenderRef: RefObject<(() => void) | null>;
-}) {
-  const [, setRenderVersion] = useState(0);
-
-  useLayoutEffect(() => {
-    scheduleRenderRef.current = () =>
-      setRenderVersion((current) => current + 1);
-    return () => {
-      scheduleRenderRef.current = null;
-    };
-  }, [scheduleRenderRef]);
-
-  return (
-    <PromptBoxInternal
-      {...createPromptBoxProps({
-        history: {
-          currentDraft: emptyPromptDraftState(),
-          entries: [],
-          onSelectEntry: vi.fn(),
-          resetKey: "thread-1",
-        },
-      })}
-    />
   );
 }
 
@@ -1074,30 +1042,6 @@ describe("PromptBoxInternal controlled value sync", () => {
     } finally {
       restoreMatchMedia();
     }
-  });
-
-  it("does not loop when an empty history object is recreated across update priorities", () => {
-    const onRender = vi.fn();
-    const scheduleRenderRef = createRef<(() => void) | null>();
-    render(
-      <Profiler id="prompt-box" onRender={onRender}>
-        <PromptBoxEmptyHistoryTransitionHarness
-          scheduleRenderRef={scheduleRenderRef}
-        />
-      </Profiler>,
-    );
-    const scheduleRender = scheduleRenderRef.current;
-    if (!scheduleRender) throw new Error("Expected render scheduler");
-    let commitsAfterSynchronousRender = -1;
-
-    act(() => {
-      startTransition(scheduleRender);
-      flushSync(scheduleRender);
-      commitsAfterSynchronousRender = onRender.mock.calls.length;
-    });
-
-    expect(commitsAfterSynchronousRender).toBe(4);
-    expect(onRender).toHaveBeenCalledTimes(5);
   });
 
   it("refocuses when the history reset key changes on fine pointers", async () => {

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -1253,6 +1253,9 @@ export function PromptBoxInternal({
     useState<PromptDraftState | null>(null);
   const [recalledHistoryDraft, setRecalledHistoryDraft] =
     useState<PromptDraftState | null>(null);
+  // Mark session transitions before dispatching state so overlapping React
+  // priorities cannot enqueue the same multi-state reset more than once.
+  const hasActiveHistorySessionRef = useRef(false);
   const resolvedZenModeStorageKey =
     zenModeStorageKey ?? ZEN_MODE_STORAGE_KEY[zenModeLayout];
   const zenModeAtom = useMemo(
@@ -1993,6 +1996,8 @@ export function PromptBoxInternal({
   }, [isZenMode, minHeight, scheduleRevealEditorSelection]);
 
   const resetHistorySession = useCallback(() => {
+    if (!hasActiveHistorySessionRef.current) return;
+    hasActiveHistorySessionRef.current = false;
     setActiveHistoryIndex(null);
     setTemporaryHistoryDraft(null);
     setRecalledHistoryDraft(null);
@@ -2917,6 +2922,7 @@ export function PromptBoxInternal({
             activeHistoryIndex === null
               ? 0
               : Math.min(activeHistoryIndex + 1, history.entries.length - 1);
+          hasActiveHistorySessionRef.current = true;
           if (activeHistoryIndex === null) {
             setTemporaryHistoryDraft(history.currentDraft);
           }


### PR DESCRIPTION
## Summary

- deduplicate composer history resets before React state dispatch
- mark history sessions active before recall updates and inactive before reset updates

## Problem

Opening a bb thread could fail with React error #185 (`Maximum update depth exceeded`). The production stack pointed to `PromptBoxInternal`'s history reset effect and `resetHistorySession`.

## Root cause

Callers may recreate an empty `history` object while React is processing overlapping transition and synchronous updates. Each effect pass unconditionally dispatched three `null` state updates. With another update lane already pending, React could not always take its eager same-value bailout, so the redundant passive-effect commit could feed another render and eventually hit the nested update limit.

## Fix

The reset now uses a ref as the accepted session-transition marker. History recall marks the session active before state dispatch. Reset marks it inactive before dispatching its three clears, so inactive sessions perform no state updates and re-entrant effects cannot enqueue the same reset twice.

## User impact

Thread composers no longer risk blanking the route with React #185 when empty history props are recreated during concurrent rendering. Normal history recall and reset behavior is preserved.

## Validation

- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/promptbox/PromptBoxInternal.test.tsx` — 97 passed
- `pnpm exec turbo run typecheck --filter=@bb/app --force` — passed

> AGENT GENERATED: by GPT-5.6
