### PR TITLE
Escape Unicode separators in JSON-RPC lines

### DIFF
--- a/packages/agent-runtime/src/runtime-json-rpc.test.ts
+++ b/packages/agent-runtime/src/runtime-json-rpc.test.ts
@@ -1,7 +1,14 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { createInterface } from "node:readline";
+import { Readable } from "node:stream";
 import { setTimeout as delay } from "node:timers/promises";
-import { describe, it } from "vitest";
-import { sendJsonRpcResult } from "./runtime-json-rpc.js";
+import { describe, expect, it } from "vitest";
+import {
+  type JsonRpcMessage,
+  sendJsonRpc,
+  sendJsonRpcResult,
+} from "./runtime-json-rpc.js";
+import { createBridgeIo } from "./shared/bridge-harness.js";
 
 const EPIPE_PAYLOAD_SIZE = 1024 * 1024;
 
@@ -28,7 +35,75 @@ function waitForChildExit(child: ChildProcess): Promise<void> {
   });
 }
 
+function readLines(input: string): Promise<string[]> {
+  const readline = createInterface({ input: Readable.from([input]) });
+  const lines: string[] = [];
+  readline.on("line", (line) => lines.push(line));
+  return new Promise((resolve) => {
+    readline.once("close", () => resolve(lines));
+  });
+}
+
 describe("runtime JSON-RPC transport", () => {
+  it("preserves Unicode line separators inside messages", async () => {
+    const child = spawn(
+      process.execPath,
+      [
+        "-e",
+        `const readline = require("node:readline");
+const input = readline.createInterface({ input: process.stdin });
+input.once("line", (line) => {
+  try {
+    const message = JSON.parse(line);
+    process.stdout.write(JSON.stringify({ ok: true, text: message.params.text }) + "\\n");
+  } catch {
+    process.stdout.write(JSON.stringify({ ok: false }) + "\\n");
+  }
+});`,
+      ],
+      { stdio: ["pipe", "pipe", "ignore"] },
+    );
+    const text = "before\u2028middle\u2029after";
+
+    try {
+      sendJsonRpc(child, {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "test",
+        params: { text },
+      });
+
+      await expect(readChildStdout(child)).resolves.toBe(
+        `${JSON.stringify({ ok: true, text })}\n`,
+      );
+    } finally {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGKILL");
+      }
+      await waitForChildExit(child);
+    }
+  });
+
+  it("preserves Unicode line separators inside bridge messages", async () => {
+    const text = "before\u2028middle\u2029after";
+    const message: JsonRpcMessage = {
+      jsonrpc: "2.0",
+      method: "test",
+      params: { text },
+    };
+    let output = "";
+    const { send } = createBridgeIo<JsonRpcMessage>({
+      write: (line) => {
+        output += line;
+      },
+    });
+
+    send(message);
+
+    const lines = await readLines(output);
+    expect(lines.map((line) => JSON.parse(line))).toEqual([message]);
+  });
+
   it("does not surface closed provider stdin errors as unhandled process errors", async () => {
     const child = spawn(
       process.execPath,

--- a/packages/agent-runtime/src/runtime-json-rpc.ts
+++ b/packages/agent-runtime/src/runtime-json-rpc.ts
@@ -2,6 +2,7 @@ import type { ChildProcess } from "node:child_process";
 import type { Writable } from "node:stream";
 import { z } from "zod";
 import type { ProviderRequestCommandPlan } from "./provider-adapter.js";
+import { stringifyJsonRpcLine } from "./shared/json-rpc-line.js";
 
 export type JsonRpcObject = Record<string, unknown>;
 
@@ -279,7 +280,7 @@ export function sendJsonRpc(
   child: ChildProcess,
   message: JsonRpcMessage | ProviderRequestCommandPlan,
 ): void {
-  const line = JSON.stringify(toJsonRpcMessage(message));
+  const line = stringifyJsonRpcLine(toJsonRpcMessage(message));
   writeJsonRpcLine(child, line);
 }
 
@@ -329,7 +330,7 @@ export function sendJsonRpcRequest<TResult>(
 export function sendJsonRpcResult(args: SendJsonRpcResultArgs): void {
   writeJsonRpcLine(
     args.child,
-    JSON.stringify({
+    stringifyJsonRpcLine({
       jsonrpc: "2.0",
       id: args.id,
       result: args.result,
@@ -340,7 +341,7 @@ export function sendJsonRpcResult(args: SendJsonRpcResultArgs): void {
 export function sendJsonRpcError(args: SendJsonRpcErrorArgs): void {
   writeJsonRpcLine(
     args.child,
-    JSON.stringify({
+    stringifyJsonRpcLine({
       jsonrpc: "2.0",
       id: args.id,
       error: {

--- a/packages/agent-runtime/src/shared/bridge-harness.ts
+++ b/packages/agent-runtime/src/shared/bridge-harness.ts
@@ -2,6 +2,7 @@ import { realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
+import { stringifyJsonRpcLine } from "./json-rpc-line.js";
 
 export type BridgeJsonRpcId = string | number;
 
@@ -29,7 +30,7 @@ export function createBridgeIo<TMessage>({
   sendResult: (id: BridgeJsonRpcId, result: unknown) => void;
 } {
   const send = (message: TMessage | BridgeJsonRpcResponse): void => {
-    write(`${JSON.stringify(message)}\n`);
+    write(`${stringifyJsonRpcLine(message)}\n`);
   };
   return {
     send,

--- a/packages/agent-runtime/src/shared/json-rpc-line.ts
+++ b/packages/agent-runtime/src/shared/json-rpc-line.ts
@@ -1,0 +1,12 @@
+const JSON_LINE_SEPARATOR = "\u2028";
+const JSON_PARAGRAPH_SEPARATOR = "\u2029";
+
+export function stringifyJsonRpcLine(message: unknown): string {
+  const json = JSON.stringify(message);
+  if (json === undefined) {
+    throw new TypeError("JSON-RPC message is not serializable");
+  }
+  return json
+    .replaceAll(JSON_LINE_SEPARATOR, "\\u2028")
+    .replaceAll(JSON_PARAGRAPH_SEPARATOR, "\\u2029");
+}

--- a/packages/agent-runtime/src/shared/json-rpc-line.ts
+++ b/packages/agent-runtime/src/shared/json-rpc-line.ts
@@ -1,3 +1,4 @@
+// Node readline treats these valid JSON string characters as line endings.
 const JSON_LINE_SEPARATOR = "\u2028";
 const JSON_PARAGRAPH_SEPARATOR = "\u2029";
 


### PR DESCRIPTION
## Current failure

BB uses one JSON object per line between the host daemon and each provider bridge.

Injected instructions can contain U+2028 or U+2029. These are valid Unicode line separator characters.

1. `JSON.stringify` leaves each character literal inside the JSON string.
2. Node `readline` treats each character as the end of a line.
3. A `thread/start` request becomes two incomplete lines before the bridge parses it.
4. The bridge catches each `JSON.parse` failure and returns without a response.
5. The host waits until `thread/start` times out. Claude never starts.
6. The user can remain on **Preparing workspace** without a useful error.

This failure occurs before BB starts Claude. It is a BB message framing bug, not a Claude Code failure.

## Why BB must fix this

The input text is valid and must remain valid. It can come from these sources:

- `AGENTS.md`
- skills
- system instructions
- prompts
- tool schemas
- provider messages

Sanitizing each source would be fragile and could change user text. The JSON-RPC framing layer owns this requirement.

Escaping these characters keeps each message on one physical line. `JSON.parse` restores the original Unicode text at the receiver.

## Fix

- Escape U+2028 and U+2029 before BB writes line-delimited JSON-RPC.
- Apply the fix to runtime-to-bridge messages.
- Apply the fix to bridge-to-runtime messages.
- Add regression tests that pass both characters through Node `readline`.

## Validation

- `pnpm exec vitest run src/runtime-json-rpc.test.ts --config vitest.config.ts`
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime`

> AGENT GENERATED: by GPT-5.6 Sol