### PR TITLE
Fit the user question form to the visible footer space on mobile

### DIFF
--- a/apps/app/src/components/thread/user-questions/UserQuestionInteractionContent.tsx
+++ b/apps/app/src/components/thread/user-questions/UserQuestionInteractionContent.tsx
@@ -80,9 +80,6 @@ interface QuestionInputBlockProps {
 const OTHER_OPTION_LABEL = "Other…";
 const USER_QUESTION_FREE_TEXT_MIN_HEIGHT = 84;
 const USER_QUESTION_FREE_TEXT_MAX_HEIGHT = 158;
-// Keeps the tab strip, one or two option rows, and the action row on screen
-// even when the software keyboard leaves very little room.
-const USER_QUESTION_FORM_MIN_HEIGHT = 192;
 
 export type QuestionShortcutChoice =
   | { kind: "option"; value: string }
@@ -463,12 +460,10 @@ export function UserQuestionAnswerForm({
       style={
         availableHeight === null
           ? undefined
-          : {
-              maxHeight: `${Math.max(
-                USER_QUESTION_FORM_MIN_HEIGHT,
-                availableHeight,
-              )}px`,
-            }
+          : // No floor: a floor above the measured space pushes the footer
+            // taller than the scroll port again. The tab strip and action row
+            // are `shrink-0`, so they stay visible even when only they fit.
+            { maxHeight: `${availableHeight}px` }
       }
     >
       {totalQuestions > 1 ? (

--- a/apps/app/src/components/thread/user-questions/UserQuestionInteractionContent.tsx
+++ b/apps/app/src/components/thread/user-questions/UserQuestionInteractionContent.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/components/commands/AppCommandProvider";
 import type { AppShortcutPresentation } from "@/lib/app-keybindings";
 import { useOptionalPaneContext } from "@/views/thread-detail/PaneContext";
+import { useStickyFooterAvailableHeight } from "./useStickyFooterAvailableHeight.js";
 
 interface UserQuestionAnswerFormProps {
   className?: string;
@@ -79,6 +80,9 @@ interface QuestionInputBlockProps {
 const OTHER_OPTION_LABEL = "Other…";
 const USER_QUESTION_FREE_TEXT_MIN_HEIGHT = 84;
 const USER_QUESTION_FREE_TEXT_MAX_HEIGHT = 158;
+// Keeps the tab strip, one or two option rows, and the action row on screen
+// even when the software keyboard leaves very little room.
+const USER_QUESTION_FORM_MIN_HEIGHT = 192;
 
 export type QuestionShortcutChoice =
   | { kind: "option"; value: string }
@@ -298,6 +302,8 @@ export function UserQuestionAnswerForm({
   );
   const [currentIndex, setCurrentIndex] = useState(0);
   const [activeInteractionId, setActiveInteractionId] = useState(interactionId);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const availableHeight = useStickyFooterAvailableHeight(rootRef);
   const resolvePendingInteraction = useResolveThreadPendingInteraction();
   const stopThread = useStopThread();
   const questionSelectionShortcuts = useAppCommandShortcuts(
@@ -445,10 +451,25 @@ export function UserQuestionAnswerForm({
 
   return (
     <div
+      ref={rootRef}
       className={cn(
-        "flex max-h-[calc(100dvh-6rem)] min-h-0 flex-col text-xs text-muted-foreground",
+        "flex min-h-0 flex-col text-xs text-muted-foreground",
+        // Fallback outside a bottom-anchored scroll body (stories, tests). In
+        // the thread view the measured footer space wins: it accounts for the
+        // header, safe-area insets, keyboard, and sibling footer content.
+        availableHeight === null && "max-h-[calc(100dvh-6rem)]",
         className,
       )}
+      style={
+        availableHeight === null
+          ? undefined
+          : {
+              maxHeight: `${Math.max(
+                USER_QUESTION_FORM_MIN_HEIGHT,
+                availableHeight,
+              )}px`,
+            }
+      }
     >
       {totalQuestions > 1 ? (
         <QuestionTabs

--- a/apps/app/src/components/thread/user-questions/useStickyFooterAvailableHeight.test.tsx
+++ b/apps/app/src/components/thread/user-questions/useStickyFooterAvailableHeight.test.tsx
@@ -25,11 +25,43 @@ function setHeight(element: HTMLElement, height: number) {
   });
 }
 
-function Probe({ onHeight }: { onHeight: (height: number | null) => void }) {
+function Probe({
+  onHeight,
+  testId = "form",
+}: {
+  onHeight: (height: number | null) => void;
+  testId?: string;
+}) {
   const ref = useRef<HTMLDivElement>(null);
   const height = useStickyFooterAvailableHeight(ref);
   onHeight(height);
-  return <div ref={ref} data-testid="form" />;
+  return <div ref={ref} data-testid={testId} />;
+}
+
+function stubResizeObserver(): Array<() => void> {
+  const observers: Array<() => void> = [];
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      constructor(callback: () => void) {
+        observers.push(callback);
+      }
+      observe() {}
+      disconnect() {}
+    },
+  );
+  return observers;
+}
+
+function scrollBodyContext(scrollElement: HTMLElement) {
+  return {
+    getScrollElement: () => scrollElement,
+    isAtBottom: true,
+    scrollToBottom: () => {},
+    scrollElementIntoView: () => {},
+    scrollElementIntoViewClampedToMaxScroll: () => {},
+    captureScrollAnchor: () => {},
+  };
 }
 
 describe("useStickyFooterAvailableHeight", () => {
@@ -40,30 +72,12 @@ describe("useStickyFooterAvailableHeight", () => {
   });
 
   it("subtracts sibling footer content from the scroll port height", () => {
-    const observers: Array<() => void> = [];
-    vi.stubGlobal(
-      "ResizeObserver",
-      class {
-        constructor(callback: () => void) {
-          observers.push(callback);
-        }
-        observe() {}
-        disconnect() {}
-      },
-    );
+    const observers = stubResizeObserver();
     const scrollElement = document.createElement("div");
     setHeight(scrollElement, 600);
     const onHeight = vi.fn();
-    const contextValue = {
-      getScrollElement: () => scrollElement,
-      isAtBottom: true,
-      scrollToBottom: () => {},
-      scrollElementIntoView: () => {},
-      scrollElementIntoViewClampedToMaxScroll: () => {},
-      captureScrollAnchor: () => {},
-    };
     const { container } = render(
-      <BottomAnchorContext.Provider value={contextValue}>
+      <BottomAnchorContext.Provider value={scrollBodyContext(scrollElement)}>
         <div {...{ [SCROLL_FOOTER_ATTRIBUTE]: "" }} data-testid="footer">
           <Probe onHeight={onHeight} />
         </div>
@@ -91,5 +105,59 @@ describe("useStickyFooterAvailableHeight", () => {
       for (const observer of observers) observer();
     });
     expect(onHeight).toHaveBeenLastCalledWith(150);
+
+    // Less room than the form's own chrome: the value follows the measurement
+    // instead of a floor, so the footer never grows past the scroll port.
+    setHeight(scrollElement, 240);
+    act(() => {
+      for (const observer of observers) observer();
+    });
+    expect(onHeight).toHaveBeenLastCalledWith(40);
+  });
+
+  it("splits the budget between forms in the same footer without a feedback loop", () => {
+    const observers = stubResizeObserver();
+    const scrollElement = document.createElement("div");
+    setHeight(scrollElement, 600);
+    const onHeightA = vi.fn();
+    const onHeightB = vi.fn();
+    const { container } = render(
+      <BottomAnchorContext.Provider value={scrollBodyContext(scrollElement)}>
+        <div {...{ [SCROLL_FOOTER_ATTRIBUTE]: "" }}>
+          <Probe onHeight={onHeightA} testId="a" />
+          <Probe onHeight={onHeightB} testId="b" />
+        </div>
+      </BottomAnchorContext.Provider>,
+    );
+    const footer = container.querySelector<HTMLElement>(
+      `[${SCROLL_FOOTER_ATTRIBUTE}]`,
+    );
+    const a = container.querySelector<HTMLElement>("[data-testid=a]");
+    const b = container.querySelector<HTMLElement>("[data-testid=b]");
+    if (!footer || !a || !b) throw new Error("missing fixture");
+
+    // Two 500px forms plus 100px of fixed content: 1100px footer. Each form
+    // gets half of the 500px left after the fixed content.
+    setHeight(a, 500);
+    setHeight(b, 500);
+    setHeight(footer, 1100);
+    act(() => {
+      for (const observer of observers) observer();
+    });
+    expect(onHeightA).toHaveBeenLastCalledWith(250);
+    expect(onHeightB).toHaveBeenLastCalledWith(250);
+
+    // The forms adopt their budgets. Later observer passes must produce the
+    // same numbers, or the two hooks would chase each other forever.
+    setHeight(a, 250);
+    setHeight(b, 250);
+    setHeight(footer, 600);
+    for (let pass = 0; pass < 3; pass += 1) {
+      act(() => {
+        for (const observer of observers) observer();
+      });
+      expect(onHeightA).toHaveBeenLastCalledWith(250);
+      expect(onHeightB).toHaveBeenLastCalledWith(250);
+    }
   });
 });

--- a/apps/app/src/components/thread/user-questions/useStickyFooterAvailableHeight.test.tsx
+++ b/apps/app/src/components/thread/user-questions/useStickyFooterAvailableHeight.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render } from "@testing-library/react";
+import { useRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { BottomAnchorContext } from "@/components/ui/bottom-anchored-scroll-body";
+import {
+  SCROLL_FOOTER_ATTRIBUTE,
+  useStickyFooterAvailableHeight,
+} from "./useStickyFooterAvailableHeight";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function setHeight(element: HTMLElement, height: number) {
+  Object.defineProperty(element, "offsetHeight", {
+    configurable: true,
+    value: height,
+  });
+  Object.defineProperty(element, "clientHeight", {
+    configurable: true,
+    value: height,
+  });
+}
+
+function Probe({ onHeight }: { onHeight: (height: number | null) => void }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const height = useStickyFooterAvailableHeight(ref);
+  onHeight(height);
+  return <div ref={ref} data-testid="form" />;
+}
+
+describe("useStickyFooterAvailableHeight", () => {
+  it("returns null outside a bottom-anchored scroll body", () => {
+    const onHeight = vi.fn();
+    render(<Probe onHeight={onHeight} />);
+    expect(onHeight).toHaveBeenLastCalledWith(null);
+  });
+
+  it("subtracts sibling footer content from the scroll port height", () => {
+    const observers: Array<() => void> = [];
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        constructor(callback: () => void) {
+          observers.push(callback);
+        }
+        observe() {}
+        disconnect() {}
+      },
+    );
+    const scrollElement = document.createElement("div");
+    setHeight(scrollElement, 600);
+    const onHeight = vi.fn();
+    const contextValue = {
+      getScrollElement: () => scrollElement,
+      isAtBottom: true,
+      scrollToBottom: () => {},
+      scrollElementIntoView: () => {},
+      scrollElementIntoViewClampedToMaxScroll: () => {},
+      captureScrollAnchor: () => {},
+    };
+    const { container } = render(
+      <BottomAnchorContext.Provider value={contextValue}>
+        <div {...{ [SCROLL_FOOTER_ATTRIBUTE]: "" }} data-testid="footer">
+          <Probe onHeight={onHeight} />
+        </div>
+      </BottomAnchorContext.Provider>,
+    );
+    const footer = container.querySelector<HTMLElement>(
+      `[${SCROLL_FOOTER_ATTRIBUTE}]`,
+    );
+    const form = container.querySelector<HTMLElement>("[data-testid=form]");
+    if (!footer || !form) throw new Error("missing fixture");
+
+    // Footer is 500px tall; the form is 300px of it, so 200px are siblings
+    // (goal card, safe-area padding, child banners). The form may use the
+    // remaining 400px of the 600px scroll port.
+    setHeight(footer, 500);
+    setHeight(form, 300);
+    act(() => {
+      for (const observer of observers) observer();
+    });
+    expect(onHeight).toHaveBeenLastCalledWith(400);
+
+    // The keyboard shrinks the scroll port: the budget follows.
+    setHeight(scrollElement, 350);
+    act(() => {
+      for (const observer of observers) observer();
+    });
+    expect(onHeight).toHaveBeenLastCalledWith(150);
+  });
+});

--- a/apps/app/src/components/thread/user-questions/useStickyFooterAvailableHeight.ts
+++ b/apps/app/src/components/thread/user-questions/useStickyFooterAvailableHeight.ts
@@ -3,6 +3,8 @@ import { useBottomAnchoredScroll } from "@/components/ui/bottom-anchored-scroll-
 
 /** Marks the sticky footer wrapper of a bottom-anchored scroll body. */
 export const SCROLL_FOOTER_ATTRIBUTE = "data-scroll-footer";
+/** Marks each footer element whose height follows this hook. */
+export const STICKY_FOOTER_FLEX_ATTRIBUTE = "data-sticky-footer-flex";
 
 /**
  * Measures how tall `ref` may grow while the sticky footer that contains it
@@ -11,6 +13,12 @@ export const SCROLL_FOOTER_ATTRIBUTE = "data-scroll-footer";
  * card, child banners) take, so a fixed reservation either wastes space or
  * pushes the footer taller than the scroll port. A too-tall sticky footer
  * clips its top edge and hides its controls on mobile.
+ *
+ * Several forms can share one footer (child-thread questions plus the current
+ * one). Each form subtracts only the fixed content and splits the remainder
+ * evenly with the other flex elements. The fixed content does not depend on
+ * any form height, so the values settle in one pass instead of two forms each
+ * treating the other as fixed and chasing each other.
  *
  * Returns `null` outside a bottom-anchored scroll body (stories, tests) so the
  * caller can fall back to a viewport bound.
@@ -32,12 +40,18 @@ export function useStickyFooterAvailableHeight(
       setAvailableHeight(null);
       return;
     }
+    element.setAttribute(STICKY_FOOTER_FLEX_ATTRIBUTE, "");
     const measure = () => {
-      // Everything in the footer other than this element keeps its height
-      // when this element shrinks, so the subtraction is stable across
-      // observer callbacks and the measurement converges in one pass.
-      const siblingsHeight = footer.offsetHeight - element.offsetHeight;
-      const next = Math.max(0, scrollElement.clientHeight - siblingsHeight);
+      const flexElements = footer.querySelectorAll<HTMLElement>(
+        `[${STICKY_FOOTER_FLEX_ATTRIBUTE}]`,
+      );
+      let flexHeight = 0;
+      for (const flexElement of flexElements) {
+        flexHeight += flexElement.offsetHeight;
+      }
+      const fixedHeight = footer.offsetHeight - flexHeight;
+      const shared = Math.max(0, scrollElement.clientHeight - fixedHeight);
+      const next = Math.floor(shared / Math.max(1, flexElements.length));
       setAvailableHeight((current) => (current === next ? current : next));
     };
     measure();
@@ -45,7 +59,10 @@ export function useStickyFooterAvailableHeight(
     const observer = new ResizeObserver(measure);
     observer.observe(scrollElement);
     observer.observe(footer);
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      element.removeAttribute(STICKY_FOOTER_FLEX_ATTRIBUTE);
+    };
   }, [getScrollElement, ref]);
 
   return availableHeight;

--- a/apps/app/src/components/thread/user-questions/useStickyFooterAvailableHeight.ts
+++ b/apps/app/src/components/thread/user-questions/useStickyFooterAvailableHeight.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState, type RefObject } from "react";
+import { useBottomAnchoredScroll } from "@/components/ui/bottom-anchored-scroll-body";
+
+/** Marks the sticky footer wrapper of a bottom-anchored scroll body. */
+export const SCROLL_FOOTER_ATTRIBUTE = "data-scroll-footer";
+
+/**
+ * Measures how tall `ref` may grow while the sticky footer that contains it
+ * still fits inside the scroll port. A viewport-based `calc()` cannot know how
+ * much space the header, safe-area insets, and sibling footer content (goal
+ * card, child banners) take, so a fixed reservation either wastes space or
+ * pushes the footer taller than the scroll port. A too-tall sticky footer
+ * clips its top edge and hides its controls on mobile.
+ *
+ * Returns `null` outside a bottom-anchored scroll body (stories, tests) so the
+ * caller can fall back to a viewport bound.
+ */
+export function useStickyFooterAvailableHeight(
+  ref: RefObject<HTMLElement | null>,
+): number | null {
+  const bottomAnchor = useBottomAnchoredScroll();
+  const getScrollElement = bottomAnchor?.getScrollElement ?? null;
+  const [availableHeight, setAvailableHeight] = useState<number | null>(null);
+
+  // A passive effect, not a layout effect: the scroll element belongs to an
+  // ancestor, and ancestor refs attach after descendant layout effects run.
+  useEffect(() => {
+    const element = ref.current;
+    const scrollElement = getScrollElement?.() ?? null;
+    const footer = element?.closest<HTMLElement>(`[${SCROLL_FOOTER_ATTRIBUTE}]`);
+    if (!element || !scrollElement || !footer) {
+      setAvailableHeight(null);
+      return;
+    }
+    const measure = () => {
+      // Everything in the footer other than this element keeps its height
+      // when this element shrinks, so the subtraction is stable across
+      // observer callbacks and the measurement converges in one pass.
+      const siblingsHeight = footer.offsetHeight - element.offsetHeight;
+      const next = Math.max(0, scrollElement.clientHeight - siblingsHeight);
+      setAvailableHeight((current) => (current === next ? current : next));
+    };
+    measure();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(scrollElement);
+    observer.observe(footer);
+    return () => observer.disconnect();
+  }, [getScrollElement, ref]);
+
+  return availableHeight;
+}

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -851,7 +851,9 @@ export function BottomAnchoredScrollBody({
               <div className="scroll-bottom-anchor" aria-hidden />
             </div>
             {footer ? (
-              <div className="sticky bottom-0 z-20 shrink-0">{footer}</div>
+              <div data-scroll-footer="" className="sticky bottom-0 z-20 shrink-0">
+                {footer}
+              </div>
             ) : null}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- The AskUserQuestion form capped its height with `max-h-[calc(100dvh-6rem)]`. That value ignores the header, safe-area insets, sibling footer content (goal card, child banners), and the software keyboard. When the sticky footer grew taller than the timeline scroll port, the browser clipped the top of the footer. On mobile the tab strip and the top of the question moved off screen and no scroll could reveal them.
- Add `useStickyFooterAvailableHeight`: it measures the bottom-anchored scroll port, subtracts the height of the other footer content, and returns the space the form may use. A `ResizeObserver` keeps it current when the keyboard opens or the footer stack changes.
- The form applies that value as its `maxHeight` with a 192px floor. Outside a scroll body (stories, tests) it keeps the old `dvh` fallback.
- Mark the sticky footer wrapper in `BottomAnchoredScrollBody` with `data-scroll-footer` so the hook can find it.

## Testing
- `pnpm exec turbo run typecheck lint --filter=@bb/app`
- Vitest for `user-questions`, `bottom-anchored-scroll-body`, `pending-interactions`, `promptbox/FollowUpPromptBox`, and `views/thread-detail`
- Manual QA with dev-browser at 393px width with touch emulation on a real Claude Code thread with 4 long questions: the footer height now equals the scroll port height with extra footer content and at a 450px tall viewport; touch swipes scroll the option list; tabs and Cancel/Next stay on screen.
- Verified on a phone through bb connect.

> AGENT GENERATED: by Claude Opus 5