### PR TITLE
Fix iOS touch targets and the two-tap send in the composer

### DIFF
--- a/apps/app/src/components/promptbox/InlineMessageEditorFrame.tsx
+++ b/apps/app/src/components/promptbox/InlineMessageEditorFrame.tsx
@@ -36,11 +36,18 @@ export function InlineMessageEditorFrame({
         type="button"
         size="icon"
         variant="ghost"
-        className="ml-auto size-6 shrink-0 text-subtle-foreground"
+        /* 24px is the smallest target in the app and the only exit from edit
+           mode. Coarse pointers get a real target; precise pointers keep the
+           compact size. */
+        className="ml-auto size-6 shrink-0 text-subtle-foreground max-md:pointer-coarse:size-11"
         onClick={onCancel}
         aria-label={cancelLabel}
       >
-        <Icon name="X" className="size-3" aria-hidden />
+        <Icon
+          name="X"
+          className="size-3 max-md:pointer-coarse:size-4"
+          aria-hidden
+        />
       </Button>
     </div>
   );

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -2174,6 +2174,40 @@ describe("PromptBoxInternal compact layout", () => {
     expect(document.activeElement).toBe(editor);
   });
 
+  it("cancels the pointer submit default even when the editor reports unfocused", async () => {
+    // Regression: on iOS the editor can report unfocused at pointerdown while
+    // its keyboard is still up, because WebKit has already begun moving focus
+    // by the time the handler runs. Skipping preventDefault in that state let
+    // the keyboard dismiss and the composer reflow upward, so the click landed
+    // where the button used to be and the message only sent on a second tap.
+    const onSubmit = vi.fn();
+    render(
+      <PromptBoxInternal
+        {...createPromptBoxProps({
+          value: "Send this follow-up",
+          onSubmit,
+          compact: {
+            isCompact: true,
+            placeholder: "Ask a follow-up",
+          },
+        })}
+      />,
+    );
+
+    await waitForPromptFocus();
+    const submit = screen.getByRole("button", { name: "Submit (Enter)" });
+
+    // Stand in for WebKit having already moved focus off the editor.
+    getPromptEditorElement().blur();
+
+    expect(
+      fireEvent.pointerDown(submit, { button: 0, pointerType: "touch" }),
+    ).toBe(false);
+
+    fireEvent.click(submit, { detail: 1 });
+    expect(onSubmit).toHaveBeenCalledOnce();
+  });
+
   it("blurs the editor after a pointer submit when requested", async () => {
     const onSubmit = vi.fn();
     render(

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -122,8 +122,12 @@ import { parsePromptMentionClipboardElement } from "./mentions/prompt-mention-cl
 
 const PROMPTBOX_MIN_HEIGHT = 68;
 const PROMPTBOX_SELECTION_REVEAL_MARGIN = 12;
+// 32px is below the 44px minimum touch target, and this is the slot shared by
+// submit, stop and voice input — the most-tapped control in the app. Coarse
+// pointers get the full target; precise pointers keep the compact size, so
+// desktop density is unchanged.
 const COMPACT_PROMPT_ACTION_BUTTON_CLASS =
-  "size-8 p-0 transition-all [&_svg]:size-4";
+  "size-8 p-0 transition-all [&_svg]:size-4 max-md:pointer-coarse:size-11 max-md:pointer-coarse:[&_svg]:size-5";
 const RICH_PASTE_BLOCK_TAGS = new Set([
   "ADDRESS",
   "ARTICLE",
@@ -2646,18 +2650,23 @@ export function PromptBoxInternal({
     (event: ReactPointerEvent<HTMLButtonElement>) => {
       if (event.button !== 0) return;
       const currentEditor = editorRef.current;
-      if (
-        !currentEditor ||
-        currentEditor.isDestroyed ||
-        !currentEditor.isFocused
-      ) {
-        return;
-      }
+      if (!currentEditor || currentEditor.isDestroyed) return;
 
       // Focus transfer happens before click. On iOS, moving focus from the
       // editor to this button begins keyboard dismissal and resizes the app
       // shell before the form can submit. Keep the editor focused; the click
       // still owns the commit, while genuine outside focus dismisses normally.
+      //
+      // Deliberately not gated on `isFocused`. On iOS the editor can report
+      // false at pointerdown while its keyboard is still up, because WebKit has
+      // already begun moving focus by the time this runs. Skipping
+      // preventDefault in that state is precisely when the dismissal it guards
+      // against happens: the keyboard closes, the composer reflows upward, and
+      // the click lands where the button used to be — so the tap appears to do
+      // nothing and the message only sends on a second press.
+      //
+      // Cancelling the default is safe regardless of focus state. It suppresses
+      // the focus transfer for this press only, and the click still fires.
       event.preventDefault();
     },
     [],

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -737,6 +737,10 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
                   "pointer-events-none absolute right-2.5 top-1/2 hidden -translate-y-1/2 items-center gap-0.5 rounded-md opacity-0 transition-opacity duration-[120ms] ease-out md:flex",
                   "group-hover/row:pointer-events-auto group-hover/row:opacity-100",
                   "group-focus-within/row:pointer-events-auto group-focus-within/row:opacity-100",
+                  // Touch has no hover, so below `md` these actions were never
+                  // reachable and the row fell back to the overflow menu alone.
+                  // Show them outright on coarse pointers.
+                  "max-md:pointer-coarse:flex max-md:pointer-coarse:pointer-events-auto max-md:pointer-coarse:opacity-100",
                 )}
               >
                 <Tooltip>
@@ -817,6 +821,11 @@ const QueuedMessageRow = memo(function QueuedMessageRow({
                     "data-[state=open]:pointer-events-auto data-[state=open]:opacity-100",
                     "[@media(hover:none)]:pointer-events-auto [@media(hover:none)]:opacity-100",
                     compact ? "size-7" : "size-8",
+                    // This menu and the inline actions are anchored to the same
+                    // edge and are meant to be alternatives. Now that coarse
+                    // pointers get the inline actions, showing this too would
+                    // stack the two sets on top of each other.
+                    "max-md:pointer-coarse:hidden",
                   )}
                   disabled={actionDisabled}
                   aria-label={`Queued message ${index + 1} actions`}

--- a/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
@@ -227,15 +227,20 @@ export function ThreadBackgroundCommandsCard({
                     key={row.id}
                     // px-3 matches the full-width header row's padding so the
                     // icon lines up under the header icon.
-                    className="flex min-w-0 items-center gap-1.5 px-3 py-0.5 text-xs"
+                    className="flex min-w-0 items-center gap-1.5 px-3 py-0.5 text-xs max-md:pointer-coarse:items-start"
                   >
                     <Icon
                       name={display.icon}
-                      className="size-3.5 shrink-0 text-muted-foreground/60"
+                      className="size-3.5 shrink-0 text-muted-foreground/60 max-md:pointer-coarse:mt-0.5"
                       aria-hidden="true"
                     />
+                    {/* The title attribute is the only way to read a truncated
+                        command, and hover does not exist on touch — so the
+                        expanded list is a dead end on a phone. Wrap to a couple
+                        of lines there instead; the collapsed summary above
+                        still truncates to one line. */}
                     <span
-                      className="min-w-0 flex-1 truncate text-muted-foreground"
+                      className="min-w-0 flex-1 truncate text-muted-foreground max-md:pointer-coarse:whitespace-normal max-md:pointer-coarse:line-clamp-2 max-md:pointer-coarse:break-words"
                       title={row.description}
                     >
                       {row.description}

--- a/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
@@ -95,10 +95,16 @@ function BackgroundActivitySummary({
         className="min-w-0 truncate max-md:pointer-coarse:whitespace-normal max-md:pointer-coarse:line-clamp-2 max-md:pointer-coarse:break-words"
         title={row.description}
       >
+        {/* The prefix is ~27 characters and consumes the whole first line on a
+            phone, pushing the description onto a second line before it has had
+            any room. The icon already identifies the kind of task and the row's
+            aria-label still carries the full "<label>: <description>", so drop
+            the visible prefix on touch and give the description the width. */}
         <span
-          className={
-            active ? activityMetaClass("active") : "text-muted-foreground"
-          }
+          className={cn(
+            active ? activityMetaClass("active") : "text-muted-foreground",
+            "max-md:pointer-coarse:hidden",
+          )}
         >
           {display.runningPrefix}{" "}
         </span>

--- a/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
@@ -83,10 +83,18 @@ function BackgroundActivitySummary({
 }) {
   const display = backgroundActivityDisplay(row);
   return (
-    <span className="flex min-w-0 flex-1 items-center gap-1 text-left">
+    <span className="flex min-w-0 flex-1 items-center gap-1 text-left max-md:pointer-coarse:items-start">
       {/* Verb + description truncate as one unit so the trailing controls
-          ("+N more", chevron, duration) never get pushed off a narrow banner. */}
-      <span className="min-w-0 truncate" title={row.description}>
+          ("+N more", chevron, duration) never get pushed off a narrow banner.
+
+          On touch that single line is a dead end: the full text is reachable
+          only through the title attribute, and there is no hover. Wrap to two
+          lines there. The trailing controls are shrink-0 siblings, so the row
+          grows downward instead of pushing them off the edge. */}
+      <span
+        className="min-w-0 truncate max-md:pointer-coarse:whitespace-normal max-md:pointer-coarse:line-clamp-2 max-md:pointer-coarse:break-words"
+        title={row.description}
+      >
         <span
           className={
             active ? activityMetaClass("active") : "text-muted-foreground"


### PR DESCRIPTION
Found while using bb daily from an installed iOS PWA on a phone. Three problems in the composer, all touch-only — nothing here changes desktop behaviour.

## 1. Send needs two taps

`handleSubmitPointerDown` skipped `preventDefault()` unless the TipTap editor reported `isFocused`:

```ts
if (!currentEditor || currentEditor.isDestroyed || !currentEditor.isFocused) {
  return;
}
event.preventDefault();
```

On iOS that check reads `false` at `pointerdown` while the keyboard is still up, because WebKit has already begun moving focus by the time the handler runs. That is precisely the case the guard exists to protect against, so it opts out exactly when it is needed: focus leaves the editor, the keyboard dismisses, the composer reflows upward, and the click lands where the button used to be. The first tap appears to do nothing and the message only sends on a second press.

Cancelling the default is safe regardless of focus state — it suppresses the focus transfer for that press only, and the `click` still fires, which is what owns the commit.

Added a regression test. It fails on `main` with `expected true to be false` (the default is not cancelled) and passes with the fix.

## 2. Touch targets under 44px

- The composer's submit / stop / voice slot is **32px** (`size-8`). It is the most-tapped control in the app.
- The inline message editor's cancel is **24px** (`size-6`), and it is the only exit from edit mode.

Both grow on coarse pointers only.

## 3. Queued-message actions are unreachable on touch

Send-now / Edit / Delete are rendered, but the container is `hidden … md:flex` and only revealed on `group-hover`. On a phone neither condition is ever true, so the row falls back to the 28px overflow menu as the only affordance.

They now show outright on coarse pointers. The overflow trigger hides there in the same breath — both are absolutely positioned against the same right edge, so showing both stacks the two sets on top of each other at different offsets.

## Notes

- Uses the existing `max-md:pointer-coarse:` idiom already used in `ProjectList` and `ThreadRow`, so the scoping matches the codebase. Worth noting that a bare `pointer-coarse:` would also cover tablets at `md` and above, where 44px is equally right — happy to widen it if you would prefer that.
- `pnpm exec vitest run apps/app/src/components/promptbox` → 329 passed, 30 files.
- `pnpm exec tsc --noEmit -p apps/app/tsconfig.json` → clean.
- Verified against a real device rather than only emulation; the two-tap behaviour in particular does not reproduce in headless Chromium, since it depends on WebKit's focus timing.
