### PR TITLE
Tasks first paint: last-known projects, folders, and sidebar summary

### DIFF
--- a/plugins/tasks/shell/data.ts
+++ b/plugins/tasks/shell/data.ts
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRealtime, useRpc } from "@get-bb/plugin-sdk/app";
-import type { TasksRpcContract } from "../shared/contract.js";
+import type { z } from "zod";
+import { tasksRpcContract, type TasksRpcContract } from "../shared/contract.js";
 import type { Task, TaskPriority, TaskStatus } from "../shared/contract.js";
 import { TASKS_PAGE_MAX_LIMIT, type TaskSort } from "../shared/pagination.js";
 import type { MentionItem } from "../editor/extensions.js";
+import { readQuerySnapshot, writeQuerySnapshot } from "./query-snapshot.js";
 import { useTasksRefresh } from "./refresh.js";
 
 /** Typed RPC client bound to the tasks contract. */
@@ -88,21 +90,46 @@ export interface TasksQuery<T> {
  * refresh provider so the header control can single-flight without a timer.
  * Invalidation- and deps-driven refetches do not mark the shared in-flight bit.
  */
+export interface TasksQuerySnapshot<T> {
+  /** Storage name; the value is validated against `schema` on every read. */
+  name: string;
+  schema: z.ZodType<T>;
+}
+
 export function useTasksQuery<T>(
   fetcher: (rpc: TasksRpc) => Promise<T>,
   channels: readonly InvalidationChannel[],
   deps: readonly unknown[] = [],
+  options: {
+    /**
+     * Seed the first render with the last result this browser saw for the
+     * query and keep that record fresh after every successful fetch. Use for
+     * small, shape-stable results whose absence forces a wrong-shaped loading
+     * UI (the sidebar's project list, its counts). `isLoading` still reports
+     * the in-flight fetch; only `data` starts populated.
+     */
+    snapshot?: TasksQuerySnapshot<T>;
+  } = {},
 ): TasksQuery<T> {
   const rpc = useTasksRpc();
   const { generation, beginGenerationWork, endGenerationWork } =
     useTasksRefresh();
   const fetcherRef = useRef(fetcher);
   fetcherRef.current = fetcher;
+  const snapshotRef = useRef(options.snapshot);
+  snapshotRef.current = options.snapshot;
   const [state, setState] = useState<{
     data: T | undefined;
     error: string | null;
     isLoading: boolean;
-  }>({ data: undefined, error: null, isLoading: true });
+  }>(() => ({
+    data:
+      options.snapshot === undefined
+        ? undefined
+        : readQuerySnapshot(options.snapshot.name, options.snapshot.schema),
+    error: null,
+    isLoading: true,
+  }));
   const seqRef = useRef(0);
   const previousGenerationRef = useRef(generation);
   const depsKey = JSON.stringify(deps);
@@ -111,6 +138,8 @@ export function useTasksQuery<T>(
     return fetcherRef.current(rpc).then(
       (data) => {
         if (seq !== seqRef.current) return;
+        const snapshot = snapshotRef.current;
+        if (snapshot !== undefined) writeQuerySnapshot(snapshot.name, data);
         setState({ data, error: null, isLoading: false });
       },
       (error: unknown) => {
@@ -143,17 +172,31 @@ export function useTasksQuery<T>(
   return { ...state, refresh };
 }
 
+const foldersSnapshot = {
+  name: "folders",
+  schema: tasksRpcContract.listFolders.output.shape.folders,
+};
+
 export function useFolders() {
   return useTasksQuery(
     async (rpc) => (await rpc.call("listFolders")).folders,
     ["projects:changed"],
+    [],
+    { snapshot: foldersSnapshot },
   );
 }
+
+const projectsSnapshot = {
+  name: "projects",
+  schema: tasksRpcContract.listProjects.output.shape.projects,
+};
 
 export function useProjects() {
   return useTasksQuery(
     async (rpc) => (await rpc.call("listProjects", {})).projects,
     ["projects:changed"],
+    [],
+    { snapshot: projectsSnapshot },
   );
 }
 
@@ -164,10 +207,17 @@ export function usePresets() {
   );
 }
 
+const sidebarSummarySnapshot = {
+  name: "sidebar-summary",
+  schema: tasksRpcContract.sidebarSummary.output.shape.projects,
+};
+
 export function useSidebarSummary() {
   return useTasksQuery(
     async (rpc) => (await rpc.call("sidebarSummary")).projects,
     ["tasks:changed", "projects:changed", "threads:changed"],
+    [],
+    { snapshot: sidebarSummarySnapshot },
   );
 }
 

--- a/plugins/tasks/shell/data.ts
+++ b/plugins/tasks/shell/data.ts
@@ -5,7 +5,11 @@ import { tasksRpcContract, type TasksRpcContract } from "../shared/contract.js";
 import type { Task, TaskPriority, TaskStatus } from "../shared/contract.js";
 import { TASKS_PAGE_MAX_LIMIT, type TaskSort } from "../shared/pagination.js";
 import type { MentionItem } from "../editor/extensions.js";
-import { readQuerySnapshot, writeQuerySnapshot } from "./query-snapshot.js";
+import {
+  claimQuerySnapshotRevision,
+  readQuerySnapshot,
+  writeQuerySnapshot,
+} from "./query-snapshot.js";
 import { useTasksRefresh } from "./refresh.js";
 
 /** Typed RPC client bound to the tasks contract. */
@@ -133,19 +137,32 @@ export function useTasksQuery<T>(
   const seqRef = useRef(0);
   const previousGenerationRef = useRef(generation);
   const depsKey = JSON.stringify(deps);
+  // The deps key whose result `data` currently holds. A refetch of the same
+  // key that fails keeps the rows it had (they are still this key's truth);
+  // a failed fetch for a changed key drops them, because those rows belong to
+  // a different scope and the error must not be presented over them.
+  const dataDepsKeyRef = useRef(depsKey);
   const refresh = useCallback(() => {
     const seq = ++seqRef.current;
+    const snapshot = snapshotRef.current;
+    const snapshotRevision =
+      snapshot === undefined ? 0 : claimQuerySnapshotRevision(snapshot.name);
     return fetcherRef.current(rpc).then(
       (data) => {
+        if (snapshot !== undefined) {
+          // Persist even when this instance has moved on: the revision order
+          // is what keeps an older response from replacing a newer record.
+          writeQuerySnapshot(snapshot.name, data, snapshotRevision);
+        }
         if (seq !== seqRef.current) return;
-        const snapshot = snapshotRef.current;
-        if (snapshot !== undefined) writeQuerySnapshot(snapshot.name, data);
+        dataDepsKeyRef.current = depsKey;
         setState({ data, error: null, isLoading: false });
       },
       (error: unknown) => {
         if (seq !== seqRef.current) return;
+        const keepsData = dataDepsKeyRef.current === depsKey;
         setState((current) => ({
-          data: current.data,
+          data: keepsData ? current.data : undefined,
           error: error instanceof Error ? error.message : String(error),
           isLoading: false,
         }));

--- a/plugins/tasks/shell/navigation-panel.tsx
+++ b/plugins/tasks/shell/navigation-panel.tsx
@@ -12,6 +12,13 @@ import { TasksSidebar } from "./sidebar.js";
 import { NewProjectDialog } from "../views/manage/index.js";
 import { useState } from "react";
 
+function isAwaitingFirstResult(query: {
+  data: unknown;
+  error: string | null;
+}): boolean {
+  return query.data === undefined && query.error === null;
+}
+
 function TasksNavigationPanelContent({ subPath }: PluginNavPanelProps) {
   const route = parseTasksRoute(subPath);
   const navigation = useTasksNavigation();
@@ -31,13 +38,15 @@ function TasksNavigationPanelContent({ subPath }: PluginNavPanelProps) {
         summaries={summaries.data}
         presets={presets.data}
         activeTasks={activeTasks.data}
-        // Skeleton only while there is nothing to draw: a refetch (manual
-        // refresh, invalidation) keeps the last-known rows on screen, and a
-        // snapshot-hydrated mount never shows the placeholder at all.
+        // Skeleton only while there is nothing to draw and a first answer is
+        // still pending: a refetch (manual refresh, invalidation) keeps the
+        // last-known rows on screen, a snapshot-hydrated mount never shows
+        // the placeholder at all, and a failed companion request (folders,
+        // counts) settles the gate so loaded projects stay reachable.
         isLoading={
-          folders.data === undefined ||
-          projects.data === undefined ||
-          summaries.data === undefined
+          isAwaitingFirstResult(folders) ||
+          isAwaitingFirstResult(projects) ||
+          isAwaitingFirstResult(summaries)
         }
         onNavigate={navigation.go}
         onNewProject={() => setNewProjectOpen(true)}

--- a/plugins/tasks/shell/navigation-panel.tsx
+++ b/plugins/tasks/shell/navigation-panel.tsx
@@ -31,7 +31,14 @@ function TasksNavigationPanelContent({ subPath }: PluginNavPanelProps) {
         summaries={summaries.data}
         presets={presets.data}
         activeTasks={activeTasks.data}
-        isLoading={projects.isLoading || summaries.isLoading}
+        // Skeleton only while there is nothing to draw: a refetch (manual
+        // refresh, invalidation) keeps the last-known rows on screen, and a
+        // snapshot-hydrated mount never shows the placeholder at all.
+        isLoading={
+          folders.data === undefined ||
+          projects.data === undefined ||
+          summaries.data === undefined
+        }
         onNavigate={navigation.go}
         onNewProject={() => setNewProjectOpen(true)}
       />

--- a/plugins/tasks/shell/query-snapshot.ts
+++ b/plugins/tasks/shell/query-snapshot.ts
@@ -1,9 +1,44 @@
 import type { z } from "zod";
 
-const QUERY_SNAPSHOT_STORAGE_PREFIX = "bb-tasks:query-snapshot:v1:";
+const QUERY_SNAPSHOT_STORAGE_ROOT = "bb-tasks:query-snapshot:";
+const QUERY_SNAPSHOT_STORAGE_VERSION = "v1";
+const QUERY_SNAPSHOT_STORAGE_PREFIX = `${QUERY_SNAPSHOT_STORAGE_ROOT}${QUERY_SNAPSHOT_STORAGE_VERSION}:`;
 
 export function querySnapshotStorageKey(name: string): string {
   return `${QUERY_SNAPSHOT_STORAGE_PREFIX}${name}`;
+}
+
+let prunedOtherVersions = false;
+
+/** Test-only: forget that this page load already pruned. */
+export function resetQuerySnapshotStateForTest(): void {
+  prunedOtherVersions = false;
+}
+
+/**
+ * A version bump changes the key prefix, so older entries are simply never
+ * read again — but they would sit in the profile forever. Drop them once per
+ * page load, on the first snapshot access.
+ */
+function pruneOtherSnapshotVersions(): void {
+  if (prunedOtherVersions) return;
+  prunedOtherVersions = true;
+  try {
+    const stale: string[] = [];
+    for (let index = 0; index < window.localStorage.length; index += 1) {
+      const key = window.localStorage.key(index);
+      if (
+        key !== null &&
+        key.startsWith(QUERY_SNAPSHOT_STORAGE_ROOT) &&
+        !key.startsWith(QUERY_SNAPSHOT_STORAGE_PREFIX)
+      ) {
+        stale.push(key);
+      }
+    }
+    for (const key of stale) window.localStorage.removeItem(key);
+  } catch {
+    // No storage, or none we may enumerate: nothing to prune.
+  }
 }
 
 /**
@@ -17,6 +52,7 @@ export function readQuerySnapshot<T>(
   name: string,
   schema: z.ZodType<T>,
 ): T | undefined {
+  pruneOtherSnapshotVersions();
   try {
     const raw = window.localStorage.getItem(querySnapshotStorageKey(name));
     if (raw === null) return undefined;
@@ -28,6 +64,7 @@ export function readQuerySnapshot<T>(
 }
 
 export function writeQuerySnapshot(name: string, value: unknown): void {
+  pruneOtherSnapshotVersions();
   try {
     window.localStorage.setItem(
       querySnapshotStorageKey(name),

--- a/plugins/tasks/shell/query-snapshot.ts
+++ b/plugins/tasks/shell/query-snapshot.ts
@@ -10,9 +10,31 @@ export function querySnapshotStorageKey(name: string): string {
 
 let prunedOtherVersions = false;
 
-/** Test-only: forget that this page load already pruned. */
+/**
+ * Per-name write ordering shared by every hook instance in this page load.
+ * Several mounted hooks (shell, list, task dialog) read the same query and
+ * each writes the same storage key, so a slow request that began earlier must
+ * not replace what a request that began later already recorded.
+ */
+const claimedRevisions = new Map<string, number>();
+const writtenRevisions = new Map<string, number>();
+
+/** Test-only: forget that this page load already pruned or wrote anything. */
 export function resetQuerySnapshotStateForTest(): void {
   prunedOtherVersions = false;
+  claimedRevisions.clear();
+  writtenRevisions.clear();
+}
+
+/**
+ * Reserve the next write slot for `name` at request start. Pass the returned
+ * revision to `writeQuerySnapshot` when the request resolves; a request that
+ * claimed its revision before a later one already wrote is dropped.
+ */
+export function claimQuerySnapshotRevision(name: string): number {
+  const revision = (claimedRevisions.get(name) ?? 0) + 1;
+  claimedRevisions.set(name, revision);
+  return revision;
 }
 
 /**
@@ -63,8 +85,14 @@ export function readQuerySnapshot<T>(
   }
 }
 
-export function writeQuerySnapshot(name: string, value: unknown): void {
+export function writeQuerySnapshot(
+  name: string,
+  value: unknown,
+  revision: number,
+): void {
   pruneOtherSnapshotVersions();
+  if (revision < (writtenRevisions.get(name) ?? 0)) return;
+  writtenRevisions.set(name, revision);
   try {
     window.localStorage.setItem(
       querySnapshotStorageKey(name),

--- a/plugins/tasks/shell/query-snapshot.ts
+++ b/plugins/tasks/shell/query-snapshot.ts
@@ -1,0 +1,39 @@
+import type { z } from "zod";
+
+const QUERY_SNAPSHOT_STORAGE_PREFIX = "bb-tasks:query-snapshot:v1:";
+
+export function querySnapshotStorageKey(name: string): string {
+  return `${QUERY_SNAPSHOT_STORAGE_PREFIX}${name}`;
+}
+
+/**
+ * Last-known query results, kept in the browser profile so a remount paints
+ * the same truth it showed last time instead of a loading placeholder that
+ * the real rows then replace. localStorage is a system boundary: anything
+ * that fails to parse against the query's own schema is treated as absent.
+ * Storage failures (disabled, full, private mode) degrade to "no snapshot".
+ */
+export function readQuerySnapshot<T>(
+  name: string,
+  schema: z.ZodType<T>,
+): T | undefined {
+  try {
+    const raw = window.localStorage.getItem(querySnapshotStorageKey(name));
+    if (raw === null) return undefined;
+    const parsed = schema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function writeQuerySnapshot(name: string, value: unknown): void {
+  try {
+    window.localStorage.setItem(
+      querySnapshotStorageKey(name),
+      JSON.stringify(value),
+    );
+  } catch {
+    // Best-effort: the next mount simply loads without a snapshot.
+  }
+}

--- a/plugins/tasks/shell/shell.test.tsx
+++ b/plugins/tasks/shell/shell.test.tsx
@@ -23,7 +23,8 @@ const app = await loadPluginApp(() => import("../app"));
 const { parseTasksRoute, tasksRouteToSubPath } = await import("./routes.js");
 const { pagerPosition } = await import("./topbar.js");
 const { loadViewMode } = await import("./view-preference.js");
-const { querySnapshotStorageKey } = await import("./query-snapshot.js");
+const { querySnapshotStorageKey, resetQuerySnapshotStateForTest } =
+  await import("./query-snapshot.js");
 
 const tasksRegistration = app.navPanels[0]!;
 const navigationView = tasksRegistration.experimental_fixedTabs?.[0]!;
@@ -788,6 +789,25 @@ describe("tasks app shell", () => {
       );
       expect(slot.queryByText("No projects yet")).toBeNull();
       await slot.findByText("No projects yet");
+    });
+
+    it("prunes snapshots written under an older storage version", async () => {
+      // Pruning runs once per page load; this test owns a fresh load.
+      resetQuerySnapshotStateForTest();
+      window.localStorage.setItem(
+        "bb-tasks:query-snapshot:v0:projects",
+        JSON.stringify([]),
+      );
+      const slot = renderSlot(
+        navigationRegistration,
+        { subPath: "" },
+        { rpc: seededRpc() },
+      );
+      await slot.findByText(project.name);
+      expect(
+        window.localStorage.getItem("bb-tasks:query-snapshot:v0:projects"),
+      ).toBeNull();
+      expect(window.localStorage.getItem(projectsKey)).not.toBeNull();
     });
 
     it("records the fetched projects and counts for the next mount", async () => {

--- a/plugins/tasks/shell/shell.test.tsx
+++ b/plugins/tasks/shell/shell.test.tsx
@@ -829,6 +829,95 @@ describe("tasks app shell", () => {
         ).toEqual([summary]);
       });
     });
+
+    it("keeps the newer projects snapshot when an older request resolves later", async () => {
+      // Two hook instances (shell sidebar and list view; here two panels)
+      // fetch the same query and write the same storage key. The request that
+      // started first but finished last must not replace what the later
+      // request already recorded.
+      const olderProject = { ...project, name: "Older truth" };
+      const newerProject = { ...project, name: "Newer truth" };
+      const older = deferred<{ projects: (typeof project)[] }>();
+      let calls = 0;
+      const rpc = seededRpc({
+        listProjects: () => {
+          calls += 1;
+          return calls === 1 ? older.promise : { projects: [newerProject] };
+        },
+      });
+      renderSlot(navigationRegistration, { subPath: "" }, { rpc });
+      const second = renderSlot(
+        navigationRegistration,
+        { subPath: "" },
+        { rpc },
+      );
+      await second.findByText("Newer truth");
+      await waitFor(() =>
+        expect(
+          JSON.parse(window.localStorage.getItem(projectsKey) ?? "null"),
+        ).toEqual([newerProject]),
+      );
+      older.resolve({ projects: [olderProject] });
+      // Let the older response's continuation run before asserting.
+      await act(async () => {
+        await older.promise;
+      });
+      expect(
+        JSON.parse(window.localStorage.getItem(projectsKey) ?? "null"),
+      ).toEqual([newerProject]);
+    });
+
+    it.each(["listFolders", "sidebarSummary"])(
+      "keeps loaded projects navigable when %s fails",
+      async (method) => {
+        const slot = renderSlot(
+          navigationRegistration,
+          { subPath: "all" },
+          {
+            rpc: seededRpc({
+              [method]: () => Promise.reject(new Error("boom")),
+            }),
+          },
+        );
+        // The project loaded; a failed companion request must settle the
+        // skeleton rather than hide the rows behind it forever.
+        fireEvent.click(await slot.findByText(project.name));
+        expect(slot.navigateCalls).toContainEqual({
+          method: "toPluginPanel",
+          path: "tasks",
+          options: { subPath: PROJECT_ID },
+        });
+      },
+    );
+  });
+
+  it("shows the error, not the previous route's rows, when a route change fails", async () => {
+    // Switching All -> Active reuses the ListView instance. If Active's fetch
+    // rejects, the body must not settle onto All's rows: a user would then
+    // edit tasks under the wrong context.
+    const tasks = [
+      {
+        ...pagerTask("TSK-4", "todo", 1),
+        title: "Scope truth",
+        description: "",
+        labelIds: [],
+      },
+    ];
+    const rpc = seededRpc({
+      listLabels: () => ({ labels: [] }),
+      listTasks: (input: { activeOnly?: boolean }) =>
+        input.activeOnly === true
+          ? Promise.reject(new Error("active fetch failed"))
+          : { tasks },
+    });
+    const Panel = app.navPanels[0]!.component;
+    const slot = renderSlot(app.navPanels[0]!, { subPath: "all" }, { rpc });
+    await slot.findByText("Scope truth");
+
+    slot.lifecycle.rerender(<Panel subPath="active" />);
+    await slot.findByText("Couldn't load tasks");
+    expect(slot.queryByText("Scope truth")).toBeNull();
+    expect(slot.queryByText("No agents working right now")).toBeNull();
   });
 
   it("shows the empty state and opens the New project dialog", async () => {

--- a/plugins/tasks/shell/shell.test.tsx
+++ b/plugins/tasks/shell/shell.test.tsx
@@ -23,6 +23,7 @@ const app = await loadPluginApp(() => import("../app"));
 const { parseTasksRoute, tasksRouteToSubPath } = await import("./routes.js");
 const { pagerPosition } = await import("./topbar.js");
 const { loadViewMode } = await import("./view-preference.js");
+const { querySnapshotStorageKey } = await import("./query-snapshot.js");
 
 const tasksRegistration = app.navPanels[0]!;
 const navigationView = tasksRegistration.experimental_fixedTabs?.[0]!;
@@ -696,6 +697,118 @@ describe("tasks app shell", () => {
         slot.getByRole("textbox", { name: "Task title" }).textContent,
       ).toBe("Recovered detail title"),
     );
+  });
+
+  describe("last-known snapshot", () => {
+    const projectsKey = querySnapshotStorageKey("projects");
+    const foldersKey = querySnapshotStorageKey("folders");
+    const summaryKey = querySnapshotStorageKey("sidebar-summary");
+    const summary = {
+      projectId: PROJECT_ID,
+      taskCount: 3,
+      activeAgentCount: 1,
+    };
+    // An RPC the test settles by hand, so the pre-resolution render is observable.
+    function deferred<T>() {
+      let resolve!: (value: T) => void;
+      const promise = new Promise<T>((r) => {
+        resolve = r;
+      });
+      return { promise, resolve };
+    }
+
+    it("never paints the empty state while projects are unknown", async () => {
+      const projects = deferred<{ projects: never[] }>();
+      const slot = renderSlot(
+        app.navPanels[0]!,
+        { subPath: "" },
+        {
+          rpc: seededRpc({
+            listProjects: () => projects.promise,
+            sidebarSummary: () => ({ projects: [] }),
+          }),
+        },
+      );
+      // Cold profile: emptiness is not known yet, so the empty state must wait.
+      expect(slot.queryByText("No projects yet")).toBeNull();
+      projects.resolve({ projects: [] });
+      await slot.findByText("No projects yet");
+    });
+
+    it("paints the last-known empty state before listProjects resolves", () => {
+      window.localStorage.setItem(projectsKey, JSON.stringify([]));
+      window.localStorage.setItem(foldersKey, JSON.stringify([]));
+      window.localStorage.setItem(summaryKey, JSON.stringify([]));
+      const projects = deferred<{ projects: never[] }>();
+      const slot = renderSlot(
+        app.navPanels[0]!,
+        { subPath: "" },
+        {
+          rpc: seededRpc({
+            listProjects: () => projects.promise,
+            sidebarSummary: () => ({ projects: [] }),
+          }),
+        },
+      );
+      // First paint already matches the last truth this browser saw: no list chrome first.
+      expect(slot.getByText("No projects yet")).toBeTruthy();
+    });
+
+    it("paints last-known projects before listProjects resolves and never flashes empty", async () => {
+      window.localStorage.setItem(projectsKey, JSON.stringify([project]));
+      window.localStorage.setItem(foldersKey, JSON.stringify([folder]));
+      window.localStorage.setItem(summaryKey, JSON.stringify([summary]));
+      const projects = deferred<{ projects: (typeof project)[] }>();
+      const rpc = seededRpc({ listProjects: () => projects.promise });
+      // The sidebar lives in the right-panel navigation view; the page owns
+      // the empty state. Both must paint the last-known truth first.
+      const panel = renderSlot(
+        navigationRegistration,
+        { subPath: "" },
+        { rpc },
+      );
+      const page = renderSlot(app.navPanels[0]!, { subPath: "" }, { rpc });
+      expect(panel.getByText(project.name)).toBeTruthy();
+      expect(page.queryByText("No projects yet")).toBeNull();
+      projects.resolve({ projects: [project] });
+      await waitFor(() => expect(panel.getByText(project.name)).toBeTruthy());
+      expect(page.queryByText("No projects yet")).toBeNull();
+    });
+
+    it("ignores a malformed snapshot and loads normally", async () => {
+      window.localStorage.setItem(projectsKey, "{not json");
+      window.localStorage.setItem(
+        summaryKey,
+        JSON.stringify([{ projectId: 1 }]),
+      );
+      const slot = renderSlot(
+        app.navPanels[0]!,
+        { subPath: "" },
+        { rpc: emptyRpc },
+      );
+      expect(slot.queryByText("No projects yet")).toBeNull();
+      await slot.findByText("No projects yet");
+    });
+
+    it("records the fetched projects and counts for the next mount", async () => {
+      const slot = renderSlot(
+        navigationRegistration,
+        { subPath: "" },
+        { rpc: seededRpc() },
+      );
+      await slot.findByText(project.name);
+      await waitFor(() => {
+        expect(
+          JSON.parse(window.localStorage.getItem(projectsKey) ?? "null"),
+        ).toEqual([project]);
+        expect(
+          JSON.parse(window.localStorage.getItem(foldersKey) ?? "null"),
+        ).toEqual([folder]);
+        expect(
+          JSON.parse(window.localStorage.getItem(summaryKey) ?? "null"),
+        ).toEqual([summary]);
+      });
+    });
   });
 
   it("shows the empty state and opens the New project dialog", async () => {

--- a/plugins/tasks/shell/shell.test.tsx
+++ b/plugins/tasks/shell/shell.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadPluginApp, renderSlot } from "@get-bb/plugin-sdk/testing/app";
 
@@ -842,6 +842,50 @@ describe("tasks app shell", () => {
     await slot.findByText("No projects yet");
     fireEvent.click(slot.getByRole("button", { name: /New project/ }));
     await slot.findByText("Projects group tasks under a shared key prefix.");
+  });
+
+  it("does not paint another scope's empty state while its own rows load", async () => {
+    // All tasks has rows; Active has none. Switching Active back to All keeps
+    // the same ListView instance, whose query still holds Active's empty
+    // result while All refetches; the body must read as loading, never as
+    // "No tasks yet", until All's own rows settle.
+    const tasks = [
+      {
+        ...pagerTask("TSK-4", "todo", 1),
+        title: "Scope truth",
+        description: "",
+        labelIds: [],
+      },
+    ];
+    let deferAll = false;
+    let releaseAll: (() => void) | null = null;
+    const rpc = seededRpc({
+      listLabels: () => ({ labels: [] }),
+      // The shell's own Active count also calls listTasks (activeOnly), so
+      // route by arguments rather than call order.
+      listTasks: (input: { activeOnly?: boolean }) => {
+        if (input.activeOnly === true) return { tasks: [] };
+        if (!deferAll) return { tasks };
+        return new Promise((resolve) => {
+          releaseAll = () => resolve({ tasks });
+        });
+      },
+    });
+    const Panel = app.navPanels[0]!.component;
+    const slot = renderSlot(app.navPanels[0]!, { subPath: "all" }, { rpc });
+    await slot.findByText("Scope truth");
+
+    slot.lifecycle.rerender(<Panel subPath="active" />);
+    await slot.findByText("No agents working right now");
+
+    deferAll = true;
+    slot.lifecycle.rerender(<Panel subPath="all" />);
+    await waitFor(() => expect(releaseAll).not.toBeNull());
+    // In flight: Active's emptiness must not masquerade as All's.
+    expect(slot.queryByText("No tasks yet")).toBeNull();
+    expect(slot.queryByText("Scope truth")).toBeNull();
+    act(() => releaseAll!());
+    await slot.findByText("Scope truth");
   });
 
   it("renders board and task subPaths without plugin-owned sidebar chrome", async () => {

--- a/plugins/tasks/shell/sidebar.tsx
+++ b/plugins/tasks/shell/sidebar.tsx
@@ -210,9 +210,15 @@ export function TasksSidebar({
       return next;
     });
 
-  const ungrouped = (projects ?? []).filter((p) => p.folderId === null);
   const rootFolders = (folders ?? []).filter((f) => f.parentFolderId === null);
   const childFolders = (folders ?? []).filter((f) => f.parentFolderId !== null);
+  // A project whose folder is not in hand (the folder list failed to load, or
+  // the lists briefly disagree) is listed ungrouped rather than dropped; it is
+  // still the user's project and must stay navigable.
+  const knownFolderIds = new Set((folders ?? []).map((f) => f.id));
+  const ungrouped = (projects ?? []).filter(
+    (p) => p.folderId === null || !knownFolderIds.has(p.folderId),
+  );
 
   const renderFolder = (folder: Folder, indent: boolean) => {
     const collapsed = collapsedFolders.has(folder.id);

--- a/plugins/tasks/views/list/index.tsx
+++ b/plugins/tasks/views/list/index.tsx
@@ -208,15 +208,26 @@ export function ListView({ projectId, activeOnly = false }: ListViewProps) {
   // user left off. Restore only once the real rows have loaded.
   const scrollRef = useRef<HTMLDivElement>(null);
   const scopeKey = listScrollScopeKey({ projectId, activeOnly, filters, sort });
-  // `useListTasks` keeps the previous scope's rows on screen while it refetches
-  // and only flips `isLoading` in a later effect, so on the first render after a
-  // filter/sort change the rows are stale but `isLoading` is still false. Treat
-  // the scope as loading until fresh data for it has settled, giving scroll
-  // restoration a synchronously-correct signal that more rows are still coming.
-  const settledScope = useRef(scopeKey);
-  const scopeChanged = settledScope.current !== scopeKey;
+  // `useListTasks` keeps the previous scope's rows while it refetches and
+  // only flips `isLoading` in a later effect, so on the first render after a
+  // scope change (All to Active, a project, a filter or sort) the data still
+  // belongs to the previous scope while `isLoading` reads false. Treat the
+  // scope as loading until its own fetch has settled: scroll restoration gets
+  // a synchronously-correct "more rows are coming" signal, and the body below
+  // must not present another scope's rows, or worse its emptiness, as this
+  // scope's truth. State, not a ref: settling has to rerender the body.
+  const [settledScopeKey, setSettledScopeKey] = useState(scopeKey);
+  const scopeChanged = settledScopeKey !== scopeKey;
+  const previousScopeKey = useRef(scopeKey);
   useEffect(() => {
-    if (!tasksQuery.isLoading) settledScope.current = scopeKey;
+    // The query's own effect flips `isLoading` in this same commit, but this
+    // effect still reads the previous render's value, so the commit that
+    // changes the scope must never settle it; the next resolved commit does.
+    const scopeJustChanged = previousScopeKey.current !== scopeKey;
+    previousScopeKey.current = scopeKey;
+    if (!scopeJustChanged && !tasksQuery.isLoading) {
+      setSettledScopeKey(scopeKey);
+    }
   }, [scopeKey, tasksQuery.isLoading, tasksQuery.data]);
   useListScrollRestoration(scrollRef, scopeKey, {
     contentReady: tasksQuery.data !== undefined && tasksQuery.data.length > 0,
@@ -225,9 +236,16 @@ export function ListView({ projectId, activeOnly = false }: ListViewProps) {
   });
 
   let body: React.ReactNode;
-  if (tasksQuery.data === undefined || displayTasks === undefined) {
+  if (
+    scopeChanged ||
+    tasksQuery.data === undefined ||
+    displayTasks === undefined
+  ) {
+    // While a changed scope is in flight, any held data or error is the
+    // previous scope's; only a settled result may claim this scope is empty
+    // or broken.
     body =
-      tasksQuery.error !== null ? (
+      !scopeChanged && tasksQuery.error !== null ? (
         <EmptyState
           icon="AlertCircle"
           title="Couldn't load tasks"

--- a/plugins/tasks/views/list/index.tsx
+++ b/plugins/tasks/views/list/index.tsx
@@ -208,27 +208,38 @@ export function ListView({ projectId, activeOnly = false }: ListViewProps) {
   // user left off. Restore only once the real rows have loaded.
   const scrollRef = useRef<HTMLDivElement>(null);
   const scopeKey = listScrollScopeKey({ projectId, activeOnly, filters, sort });
-  // `useListTasks` keeps the previous scope's rows while it refetches and
-  // only flips `isLoading` in a later effect, so on the first render after a
-  // scope change (All to Active, a project, a filter or sort) the data still
-  // belongs to the previous scope while `isLoading` reads false. Treat the
-  // scope as loading until its own fetch has settled: scroll restoration gets
-  // a synchronously-correct "more rows are coming" signal, and the body below
-  // must not present another scope's rows, or worse its emptiness, as this
-  // scope's truth. State, not a ref: settling has to rerender the body.
-  const [settledScopeKey, setSettledScopeKey] = useState(scopeKey);
-  const scopeChanged = settledScopeKey !== scopeKey;
-  const previousScopeKey = useRef(scopeKey);
+  // `useListTasks` keeps the previous scope's rows on screen while it refetches
+  // and only flips `isLoading` in a later effect, so on the first render after a
+  // filter/sort change the rows are stale but `isLoading` is still false. Treat
+  // the scope as loading until fresh data for it has settled, giving scroll
+  // restoration a synchronously-correct signal that more rows are still coming.
+  const settledScope = useRef(scopeKey);
+  const scopeChanged = settledScope.current !== scopeKey;
+  useEffect(() => {
+    if (!tasksQuery.isLoading) settledScope.current = scopeKey;
+  }, [scopeKey, tasksQuery.isLoading, tasksQuery.data]);
+  // The route scope is the fetch identity across views: All, Active, or one
+  // project. Switching it reuses this ListView instance, whose query still
+  // holds the previous route's result, so the body below must read as loading
+  // until this route's own fetch settles: returning from an empty Active to
+  // All must not present Active's emptiness as "No tasks yet". Narrower than
+  // `scopeKey` on purpose, so filter and sort changes keep painting the rows
+  // they already have. State, not a ref: settling has to rerender the body.
+  const routeScope = `${projectId ?? "-"}/${activeOnly}`;
+  const [settledRouteScope, setSettledRouteScope] = useState(routeScope);
+  const routeScopeChanged = settledRouteScope !== routeScope;
+  const previousRouteScope = useRef(routeScope);
   useEffect(() => {
     // The query's own effect flips `isLoading` in this same commit, but this
     // effect still reads the previous render's value, so the commit that
-    // changes the scope must never settle it; the next resolved commit does.
-    const scopeJustChanged = previousScopeKey.current !== scopeKey;
-    previousScopeKey.current = scopeKey;
-    if (!scopeJustChanged && !tasksQuery.isLoading) {
-      setSettledScopeKey(scopeKey);
+    // changes the route scope must never settle it; a later resolved commit
+    // does.
+    const routeScopeJustChanged = previousRouteScope.current !== routeScope;
+    previousRouteScope.current = routeScope;
+    if (!routeScopeJustChanged && !tasksQuery.isLoading) {
+      setSettledRouteScope(routeScope);
     }
-  }, [scopeKey, tasksQuery.isLoading, tasksQuery.data]);
+  }, [routeScope, tasksQuery.isLoading, tasksQuery.data]);
   useListScrollRestoration(scrollRef, scopeKey, {
     contentReady: tasksQuery.data !== undefined && tasksQuery.data.length > 0,
     loading: tasksQuery.isLoading || scopeChanged,
@@ -237,15 +248,15 @@ export function ListView({ projectId, activeOnly = false }: ListViewProps) {
 
   let body: React.ReactNode;
   if (
-    scopeChanged ||
+    routeScopeChanged ||
     tasksQuery.data === undefined ||
     displayTasks === undefined
   ) {
-    // While a changed scope is in flight, any held data or error is the
-    // previous scope's; only a settled result may claim this scope is empty
+    // While a changed route scope is in flight, any held data or error is the
+    // previous route's; only a settled result may claim this scope is empty
     // or broken.
     body =
-      !scopeChanged && tasksQuery.error !== null ? (
+      !routeScopeChanged && tasksQuery.error !== null ? (
         <EmptyState
           icon="AlertCircle"
           title="Couldn't load tasks"

--- a/plugins/tasks/views/manage/manage.test.tsx
+++ b/plugins/tasks/views/manage/manage.test.tsx
@@ -40,6 +40,9 @@ const { defaultPermissionMode, describePresetEnvironment, savePresetDraft } =
   await import("./preset-dialog.js");
 
 afterEach(cleanup);
+// The shell persists last-known sidebar data per browser profile; tests must
+// not inherit it from each other.
+beforeEach(() => window.localStorage.clear());
 
 const PROJECT_ID = "01HZZZZZZZZZZZZZZZZZZZZZP1";
 const TASK_ID = "01HZZZZZZZZZZZZZZZZZZZZZT1";

--- a/plugins/tasks/views/manage/manage.test.tsx
+++ b/plugins/tasks/views/manage/manage.test.tsx
@@ -40,9 +40,6 @@ const { defaultPermissionMode, describePresetEnvironment, savePresetDraft } =
   await import("./preset-dialog.js");
 
 afterEach(cleanup);
-// The shell persists last-known sidebar data per browser profile; tests must
-// not inherit it from each other.
-beforeEach(() => window.localStorage.clear());
 
 const PROJECT_ID = "01HZZZZZZZZZZZZZZZZZZZZZP1";
 const TASK_ID = "01HZZZZZZZZZZZZZZZZZZZZZT1";

--- a/plugins/tasks/vitest.setup.ts
+++ b/plugins/tasks/vitest.setup.ts
@@ -1,4 +1,5 @@
 import { configure } from "@testing-library/react";
+import { beforeEach } from "vitest";
 
 // Match slow CI runners: the default 1s async-utility timeout flakes there
 // while the suite-level vitest testTimeout still bounds real hangs.
@@ -32,3 +33,10 @@ if (typeof window !== "undefined" && !window.matchMedia) {
       }) as unknown as MediaQueryList,
   });
 }
+
+// The shell persists last-known sidebar data (projects, folders, counts) in the
+// browser profile. Every test starts from a cold profile so one file's render
+// cannot seed another's first-paint assertions.
+beforeEach(() => {
+  if (typeof window !== "undefined") window.localStorage.clear();
+});


### PR DESCRIPTION
Part of #1676 (item 1).

Tasks keeps an opt-in last-known snapshot for folders, projects, and the sidebar summary in `useTasksQuery` (localStorage, versioned key, validated against the query's own RPC output schema on read, written only after a successful fetch) and seeds the query state from it on mount, so a repeat visit paints the last resolved state immediately; the sidebar skeleton shows only while that data is absent. The empty state still waits for a resolved empty list. Snapshots from older storage versions are pruned once per load; the shared vitest setup clears storage per test.

Plugin code only (`plugins/tasks`); no SDK or host changes. `isLoading` semantics are untouched (the list view's scroll restoration depends on its flip-on-refetch behavior).

> AGENT GENERATED: by Claude Fable 5
