### PR TITLE
Fix Pi custom message turns

### DIFF
--- a/packages/agent-runtime/src/pi/event-translation.test.ts
+++ b/packages/agent-runtime/src/pi/event-translation.test.ts
@@ -3,6 +3,7 @@ import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { threadScope, turnScope } from "@bb/domain";
+import { queueAcceptedUserMessage } from "@bb/provider-bridge-protocol/bridge-kit";
 import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 import { createPiEventTranslator } from "./event-translation.js";
 
@@ -75,6 +76,76 @@ interface PiBashStartEventArgs {
   command: string;
   cwd?: string;
   toolCallId: string;
+}
+
+interface PiProcessNotificationEventArgs {
+  attention: "context" | "ignore" | "turn";
+  content: string;
+  customType?: string;
+  display?: boolean;
+  eventType?: "message_end" | "message_start";
+  kind: "log_match" | "success";
+  processId: string;
+  threadId?: string;
+}
+
+function createPiProcessNotificationEvent(
+  args: PiProcessNotificationEventArgs,
+) {
+  return {
+    jsonrpc: "2.0" as const,
+    method: "sdk/message",
+    params: {
+      threadId: args.threadId ?? "pi-thread-1",
+      message: {
+        type: args.eventType ?? "message_start",
+        message: {
+          role: "custom",
+          customType: args.customType ?? "ad-process:notification",
+          content: args.content,
+          display: args.display ?? true,
+          details: {
+            attention: args.attention,
+            kind: args.kind,
+            processId: args.processId,
+          },
+          timestamp: 1_786_919_243_630,
+        },
+      },
+    },
+  };
+}
+
+function createPiEmptyAgentEndEvent(): AgentSessionEvent {
+  return {
+    type: "agent_end",
+    willRetry: false,
+    messages: [
+      {
+        role: "assistant",
+        content: [],
+        stopReason: "stop",
+        api: "openai-responses",
+        provider: "openai-codex",
+        model: "gpt-5.6-sol",
+        usage: {
+          input: 10,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 10,
+          cost: {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            total: 0,
+          },
+        },
+        timestamp: 1_786_919_246_950,
+      },
+    ],
+  };
 }
 
 function createPiBashStartEvent(args: PiBashStartEventArgs): AgentSessionEvent {
@@ -295,6 +366,361 @@ describe("pi event translation", () => {
     expect(events.some((event) => event.type === "provider/unhandled")).toBe(
       false,
     );
+  });
+
+  it("projects one turn for a visible custom message and accepts it in agent_end", () => {
+    const translator = createTranslator();
+    const context = { threadId: "pi-thread-1" };
+    const content = '<process_event type="lifecycle" kind="success" />';
+
+    const providerStartEvents = translator.translatePiEvent(
+      loadFixture("agent-start.json"),
+      context,
+    );
+    const notificationEvents = translator.translatePiEvent(
+      createPiProcessNotificationEvent({
+        attention: "turn",
+        content,
+        customType: "third-party:notification",
+        kind: "success",
+        processId: "proc_sleep",
+      }),
+      context,
+    );
+    const duplicateEndEvents = translator.translatePiEvent(
+      createPiProcessNotificationEvent({
+        attention: "turn",
+        content,
+        customType: "third-party:notification",
+        eventType: "message_end",
+        kind: "success",
+        processId: "proc_sleep",
+      }),
+      context,
+    );
+    const terminalEvents = translator.translatePiEvent(
+      {
+        type: "agent_end",
+        messages: [
+          {
+            role: "custom",
+            customType: "third-party:notification",
+            content,
+            details: { attention: "turn" },
+          },
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "The process finished." }],
+            stopReason: "stop",
+          },
+        ],
+        providerCheckpointId: "pi-entry-process",
+        willRetry: false,
+      },
+      context,
+    );
+    const events = [
+      ...notificationEvents,
+      ...duplicateEndEvents,
+      ...providerStartEvents,
+      ...terminalEvents,
+    ];
+
+    expect(providerStartEvents).toEqual([
+      expect.objectContaining({
+        type: "turn/started",
+        scope: turnScope("turn-1"),
+      }),
+    ]);
+    expect(notificationEvents).toEqual([
+      expect.objectContaining({
+        type: "item/completed",
+        scope: turnScope("turn-1"),
+        item: expect.objectContaining({
+          type: "userMessage",
+          content: [{ type: "text", text: content }],
+        }),
+      }),
+    ]);
+    expect(duplicateEndEvents).toEqual([]);
+    expect(
+      events.filter((event) => event.type === "turn/started"),
+    ).toHaveLength(1);
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "item/completed",
+        item: expect.objectContaining({
+          type: "agentMessage",
+          text: "The process finished.",
+        }),
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "turn/completed",
+        providerCheckpointId: "pi-entry-process",
+      }),
+    );
+    expect(events.some((event) => event.type === "provider/unhandled")).toBe(
+      false,
+    );
+  });
+
+  it.each(["context", "ignore"] as const)(
+    "does not open an idle turn for a process notification with %s attention",
+    (attention) => {
+      const translator = createTranslator();
+      const context = { threadId: "pi-thread-1" };
+
+      const events = translator.translatePiEvent(
+        createPiProcessNotificationEvent({
+          attention,
+          content: `<process_event attention="${attention}" />`,
+          kind: "success",
+          processId: `proc_${attention}`,
+        }),
+        context,
+      );
+
+      expect(events).toEqual([]);
+      expect(
+        translator.translatePiEvent(loadFixture("agent-start.json"), context),
+      ).toContainEqual(
+        expect.objectContaining({
+          type: "turn/started",
+          scope: turnScope("turn-1"),
+        }),
+      );
+    },
+  );
+
+  it("uses the translator item prefix for process notification IDs", () => {
+    const firstTranslator = createPiEventTranslator({
+      providerId: "pi",
+      itemIdPrefix: "resume-a-",
+    });
+    const secondTranslator = createPiEventTranslator({
+      providerId: "pi",
+      itemIdPrefix: "resume-b-",
+    });
+    const notification = createPiProcessNotificationEvent({
+      attention: "turn",
+      content: '<process_event type="lifecycle" kind="success" />',
+      kind: "success",
+      processId: "proc_sleep",
+    });
+
+    const firstEvents = firstTranslator.translatePiEvent(notification, {
+      threadId: "pi-thread-1",
+    });
+    const secondEvents = secondTranslator.translatePiEvent(notification, {
+      threadId: "pi-thread-1",
+    });
+
+    expect(firstEvents).toContainEqual(
+      expect.objectContaining({
+        type: "item/completed",
+        item: expect.objectContaining({
+          type: "userMessage",
+          id: "resume-a-provider-input-1",
+        }),
+      }),
+    );
+    expect(secondEvents).toContainEqual(
+      expect.objectContaining({
+        type: "item/completed",
+        item: expect.objectContaining({
+          type: "userMessage",
+          id: "resume-b-provider-input-1",
+        }),
+      }),
+    );
+  });
+
+  it("coalesces clustered process notifications into one active turn", () => {
+    const translator = createTranslator();
+    const context = { threadId: "pi-thread-1" };
+
+    const lifecycleEvents = translator.translatePiEvent(
+      createPiProcessNotificationEvent({
+        attention: "turn",
+        content: '<process_event type="lifecycle" kind="success" />',
+        kind: "success",
+        processId: "proc_sleep",
+      }),
+      context,
+    );
+    const logMatchEvents = translator.translatePiEvent(
+      createPiProcessNotificationEvent({
+        attention: "turn",
+        content:
+          '<process_event type="log_match" kind="log_match"><matched_line>done</matched_line></process_event>',
+        kind: "log_match",
+        processId: "proc_sleep",
+      }),
+      context,
+    );
+    const events = [...lifecycleEvents, ...logMatchEvents];
+
+    expect(
+      events.filter((event) => event.type === "turn/started"),
+    ).toHaveLength(1);
+    expect(
+      events.filter(
+        (event) =>
+          event.type === "item/completed" && event.item.type === "userMessage",
+      ),
+    ).toHaveLength(2);
+  });
+
+  it("warns when a process-triggered turn ends without assistant text", () => {
+    const translator = createTranslator();
+    const context = { threadId: "pi-thread-1" };
+    translator.translatePiEvent(loadFixture("agent-start.json"), context);
+    translator.translatePiEvent(
+      createPiProcessNotificationEvent({
+        attention: "turn",
+        content: '<process_event type="lifecycle" kind="success" />',
+        kind: "success",
+        processId: "proc_sleep",
+      }),
+      context,
+    );
+
+    const events = translator.translatePiEvent(
+      createPiEmptyAgentEndEvent(),
+      context,
+    );
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "provider/warning",
+        scope: turnScope("turn-1"),
+        summary:
+          "Pi completed the provider-triggered turn without a text response",
+      }),
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: "turn/completed",
+        scope: turnScope("turn-1"),
+      }),
+    );
+  });
+
+  it("projects context notifications into an active user turn without reclassifying it", () => {
+    const translator = createTranslator();
+    const context = { threadId: "pi-thread-1" };
+    queueAcceptedUserMessage({
+      clientRequestId: "creq_context1",
+      state: translator.resolveState(context),
+    });
+    translator.translatePiEvent(loadFixture("agent-start.json"), context);
+
+    const notificationEvents = translator.translatePiEvent(
+      createPiProcessNotificationEvent({
+        attention: "context",
+        content: '<process_event type="lifecycle" kind="success" />',
+        kind: "success",
+        processId: "proc_sleep",
+      }),
+      context,
+    );
+    const terminalEvents = translator.translatePiEvent(
+      createPiEmptyAgentEndEvent(),
+      context,
+    );
+
+    expect(notificationEvents).toEqual([
+      expect.objectContaining({
+        type: "item/completed",
+        item: expect.objectContaining({ type: "userMessage" }),
+      }),
+    ]);
+    expect(
+      terminalEvents.some((event) => event.type === "provider/warning"),
+    ).toBe(false);
+  });
+
+  it("ignores ignore-attention notifications during an active turn", () => {
+    const translator = createTranslator();
+    const context = { threadId: "pi-thread-1" };
+    translator.translatePiEvent(loadFixture("agent-start.json"), context);
+
+    const events = translator.translatePiEvent(
+      createPiProcessNotificationEvent({
+        attention: "ignore",
+        content: '<process_event attention="ignore" />',
+        kind: "success",
+        processId: "proc_sleep",
+      }),
+      context,
+    );
+
+    expect(events).toEqual([]);
+  });
+
+  it("drops non-visible custom message boundaries without an unhandled event", () => {
+    const translator = createTranslator();
+    const context = { threadId: "pi-thread-1" };
+
+    expect(
+      translator.translatePiEvent(
+        createPiProcessNotificationEvent({
+          attention: "turn",
+          content: "hidden extension state",
+          customType: "another-extension:state",
+          display: false,
+          kind: "success",
+          processId: "proc_hidden",
+        }),
+        context,
+      ),
+    ).toEqual([]);
+  });
+
+  it("keeps an accepted user prompt from becoming a process-triggered turn", () => {
+    const translator = createTranslator();
+    const context = { threadId: "pi-thread-1" };
+    queueAcceptedUserMessage({
+      clientRequestId: "creq_abcdefghjk",
+      state: translator.resolveState(context),
+    });
+
+    const providerStartEvents = translator.translatePiEvent(
+      loadFixture("agent-start.json"),
+      context,
+    );
+    const notificationEvents = translator.translatePiEvent(
+      createPiProcessNotificationEvent({
+        attention: "turn",
+        content: '<process_event type="lifecycle" kind="success" />',
+        kind: "success",
+        processId: "proc_sleep",
+      }),
+      context,
+    );
+    const terminalEvents = translator.translatePiEvent(
+      createPiEmptyAgentEndEvent(),
+      context,
+    );
+
+    expect(providerStartEvents).toContainEqual(
+      expect.objectContaining({
+        type: "turn/input/accepted",
+        clientRequestId: "creq_abcdefghjk",
+        scope: turnScope("turn-1"),
+      }),
+    );
+    expect(notificationEvents).toContainEqual(
+      expect.objectContaining({
+        type: "item/completed",
+        item: expect.objectContaining({ type: "userMessage" }),
+      }),
+    );
+    expect(
+      terminalEvents.some((event) => event.type === "provider/warning"),
+    ).toBe(false);
   });
 
   it("translateEvent agent_end surfaces Pi assistant stop errors as failed turns", () => {

--- a/packages/agent-runtime/src/pi/event-translation.ts
+++ b/packages/agent-runtime/src/pi/event-translation.ts
@@ -106,6 +106,8 @@ const piEventTypeSchema = z
       "agent_start",
       "compaction_end",
       "compaction_start",
+      "message_end",
+      "message_start",
       "message_update",
       "tool_execution_end",
       "tool_execution_start",
@@ -138,6 +140,25 @@ const piIgnoredEventSchema = z
   .object({ type: z.string() })
   .passthrough()
   .refine((event) => PI_IGNORED_EVENT_TYPES.has(event.type));
+
+const piCustomMessageBoundaryEventSchema = z
+  .object({
+    type: z.enum(["message_end", "message_start"]),
+    message: z
+      .object({
+        role: z.literal("custom"),
+        content: z.string(),
+        display: z.boolean().default(false),
+        details: z
+          .object({
+            attention: z.enum(["context", "ignore", "turn"]).optional(),
+          })
+          .passthrough()
+          .optional(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
 
 const piMessageContentBlockSchema = z
   .object({
@@ -447,8 +468,11 @@ export interface PiTurnState {
   openAssistantMessageIdsByScope: Map<string, string>;
   openScopedItemIdsByScope: Map<string, string>;
   pendingAcceptedUserMessages: AcceptedUserMessageState["pendingAcceptedUserMessages"];
+  providerInputCounter: number;
+  providerInputTurnId: string | undefined;
   scopedItemCounter: number;
   toolItemsByCallId: Map<string, ThreadEventItem>;
+  turnStartedWithAcceptedUserMessage: boolean;
 }
 
 const piCompactionItemIds = createScopedItemIdFactory({
@@ -494,6 +518,10 @@ export function createPiEventTranslator(
     options.itemIdPrefix === undefined
       ? "pi-assistant"
       : `${options.itemIdPrefix}assistant`;
+  const providerInputIdPrefix =
+    options.itemIdPrefix === undefined
+      ? "pi-provider-input"
+      : `${options.itemIdPrefix}provider-input`;
   const piReasoningItemIds = createScopedItemIdFactory({
     prefix:
       options.itemIdPrefix === undefined
@@ -519,11 +547,20 @@ export function createPiEventTranslator(
       openAssistantMessageIdsByScope: new Map(),
       openScopedItemIdsByScope: new Map(),
       pendingAcceptedUserMessages: [],
+      providerInputCounter: 0,
+      providerInputTurnId: undefined,
       scopedItemCounter: 0,
       toolItemsByCallId: new Map(),
+      turnStartedWithAcceptedUserMessage: false,
     }),
+    onTurnFinish: ({ state }) => {
+      state.providerInputTurnId = undefined;
+      state.turnStartedWithAcceptedUserMessage = false;
+    },
     onTurnStart: ({ state }) => {
       resetPiCommandOutputSnapshots(state);
+      state.turnStartedWithAcceptedUserMessage =
+        state.pendingAcceptedUserMessages.length > 0;
     },
     turnIdPrefix: options.turnIdPrefix,
   });
@@ -715,6 +752,53 @@ export function createPiEventTranslator(
       });
 
     switch (eventType.data.type) {
+      case "message_end":
+      case "message_start": {
+        const piEvent = piCustomMessageBoundaryEventSchema.safeParse(event);
+        if (!piEvent.success) {
+          return buildUnexpectedEvent(event);
+        }
+        if (
+          piEvent.data.type === "message_end" ||
+          !piEvent.data.message.display ||
+          piEvent.data.message.details?.attention === "ignore"
+        ) {
+          return [];
+        }
+        if (
+          state.currentTurnId === undefined &&
+          piEvent.data.message.details?.attention === "context"
+        ) {
+          return [];
+        }
+        const turnId = turnState.ensureTurnStarted({
+          events,
+          state,
+          threadId,
+        });
+        state.providerInputCounter += 1;
+        if (!state.turnStartedWithAcceptedUserMessage) {
+          state.providerInputTurnId = turnId;
+        }
+        events.push({
+          type: "item/completed",
+          threadId,
+          providerThreadId: "",
+          scope: turnScope(turnId),
+          item: {
+            type: "userMessage",
+            id: `${providerInputIdPrefix}-${state.providerInputCounter}`,
+            content: [
+              {
+                type: "text",
+                text: piEvent.data.message.content,
+              },
+            ],
+          },
+        });
+        break;
+      }
+
       case "agent_start": {
         const piEvent = piAgentStartEventSchema.safeParse(event);
         if (!piEvent.success) {
@@ -859,22 +943,32 @@ export function createPiEventTranslator(
             }),
           ];
         }
-        if (lastAssistant) {
-          const text = extractAssistantText(lastAssistant);
-          if (text) {
-            const itemId = turnState.resolveCompletedAssistantMessageId({
-              assistantIdPrefix,
-              parentToolCallId: context?.parentToolCallId,
-              state,
-            });
-            events.push({
-              type: "item/completed",
-              threadId,
-              providerThreadId: "",
-              scope: turnScope(currentTurnId),
-              item: { type: "agentMessage", id: itemId, text },
-            });
-          }
+        const assistantText = lastAssistant
+          ? extractAssistantText(lastAssistant)
+          : undefined;
+        if (assistantText) {
+          const itemId = turnState.resolveCompletedAssistantMessageId({
+            assistantIdPrefix,
+            parentToolCallId: context?.parentToolCallId,
+            state,
+          });
+          events.push({
+            type: "item/completed",
+            threadId,
+            providerThreadId: "",
+            scope: turnScope(currentTurnId),
+            item: { type: "agentMessage", id: itemId, text: assistantText },
+          });
+        } else if (state.providerInputTurnId === currentTurnId) {
+          events.push({
+            type: "provider/warning",
+            threadId,
+            providerThreadId: "",
+            scope: turnScope(currentTurnId),
+            category: "general",
+            summary:
+              "Pi completed the provider-triggered turn without a text response",
+          });
         }
         const tokenUsage = extractPiTokenUsage(
           lastAssistant,

--- a/packages/agent-runtime/src/pi/visibility.ts
+++ b/packages/agent-runtime/src/pi/visibility.ts
@@ -22,7 +22,12 @@ type PiAssistantEventType =
   | "toolcall_start"
   | "unknown";
 
-type PiMessageBoundaryRole = "assistant" | "toolResult" | "user" | "unknown";
+type PiMessageBoundaryRole =
+  | "assistant"
+  | "custom"
+  | "toolResult"
+  | "user"
+  | "unknown";
 
 type PiSdkEventType =
   | "agent_end"
@@ -75,6 +80,7 @@ interface PiSimpleSdkRawEvent {
 }
 
 interface PiMessageBoundaryRawEvent {
+  display: boolean;
   kind: "sdk/message-boundary";
   role: PiMessageBoundaryRole;
   sdkType: "message_end" | "message_start";
@@ -134,6 +140,7 @@ function toPiMessageBoundaryRole(
 ): PiMessageBoundaryRole {
   switch (role) {
     case "assistant":
+    case "custom":
     case "toolResult":
     case "user":
       return role;
@@ -214,6 +221,7 @@ function parsePiRawEvent(event: JsonRpcMessage): PiRawEvent {
     case "message_end": {
       const payload = getRecordProperty(message, "message");
       return {
+        display: payload?.["display"] === true,
         kind: "sdk/message-boundary",
         sdkType,
         role: toPiMessageBoundaryRole(
@@ -319,6 +327,14 @@ function describeParsedPiRawEvent(
       switch (event.role) {
         case "assistant":
           return { kind, coverage: "noise" };
+        case "custom":
+          return {
+            kind,
+            coverage:
+              event.sdkType === "message_start" && event.display
+                ? "normalized"
+                : "noise",
+          };
         case "toolResult":
         case "user":
           return { kind, coverage: "noise" };

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,8 @@
+// Version 136 translates visible Pi custom-message boundaries into provider
+// input items, preserves their attention semantics, and warns when a
+// provider-triggered turn returns no assistant text. Older daemons still send
+// those boundaries as unhandled events and omit the warning.
+//
 // Version 135 adds the `compaction-skipped` provider warning category. The Pi
 // bridge now reports a refused manual compaction ("Nothing to compact") as
 // that warning plus a completed turn instead of a failed turn. An older daemon
@@ -44,7 +49,7 @@
 //
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 135 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 136 as const;
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1133,6 +1133,8 @@ describe("host-daemon command schemas", () => {
   // Version 116 reports provider exits that happen while a turn start is
   // pending. Older daemons can leave the server thread active until the live
   // command timeout, so enrolled machines must update before handling turns.
+  // Version 136 projects visible Pi custom messages as provider input and
+  // reports empty provider-triggered turns instead of silently completing them.
   // Version 115 settles zero-work provider prompts with a complete synthetic
   // turn lifecycle. Older daemons can leave locally handled prompts active
   // indefinitely, so enrolled machines must update for reliable completion.
@@ -1142,7 +1144,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(135);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(136);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/packages/provider-bridge-protocol/src/bridge-kit/provider-unhandled-event.test.ts
+++ b/packages/provider-bridge-protocol/src/bridge-kit/provider-unhandled-event.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { createUnhandledProviderEvent } from "./provider-unhandled-event.js";
 
 describe("provider unhandled events", () => {
-  it("does not throw when raw event params are not JSON-serializable", () => {
+  it("preserves JSON-compatible fields when provider params contain undefined", () => {
     const event = createUnhandledProviderEvent({
       providerId: "test-provider",
       rawType: "sdk/custom",
@@ -27,8 +27,8 @@ describe("provider unhandled events", () => {
         jsonrpc: "2.0",
         method: "sdk/message",
         params: {
-          serializationError:
-            "Provider raw event params were not JSON-serializable.",
+          threadId: "thread-1",
+          nested: {},
         },
       },
     });

--- a/packages/provider-bridge-protocol/src/bridge-kit/provider-unhandled-event.ts
+++ b/packages/provider-bridge-protocol/src/bridge-kit/provider-unhandled-event.ts
@@ -39,9 +39,14 @@ export interface BuildUnhandledProviderEventsArgs {
 }
 
 function toProviderRawEvent(rawEvent: JsonRpcMessage): ProviderRawEvent {
-  const parsed = providerRawEventSchema.safeParse(rawEvent);
-  if (parsed.success) {
-    return parsed.data;
+  try {
+    const normalized = JSON.parse(JSON.stringify(rawEvent));
+    const parsed = providerRawEventSchema.safeParse(normalized);
+    if (parsed.success) {
+      return parsed.data;
+    }
+  } catch {
+    // Fall through to the diagnostic envelope below.
   }
 
   return {

--- a/packages/thread-view/src/build-event-projection.ts
+++ b/packages/thread-view/src/build-event-projection.ts
@@ -53,6 +53,7 @@ import {
   parseRejectedUsersFromClientRequest,
   parseUsersFromClientRequest,
   parseLegacyUserMessage,
+  parseProviderUserMessage,
 } from "./user-message-parsing.js";
 import { isTerminalBufferedTextFlushEvent } from "./assistant-buffering.js";
 import {
@@ -821,6 +822,12 @@ function buildFlatProjectionData(
       for (const userFromClientRequest of usersFromClientRequest) {
         appendProjectedUserMessage(state, userFromClientRequest);
       }
+      continue;
+    }
+
+    const providerUserMessage = parseProviderUserMessage(decoded, meta);
+    if (providerUserMessage) {
+      appendProjectedUserMessage(state, providerUserMessage);
       continue;
     }
 

--- a/packages/thread-view/src/format-timeline-text.ts
+++ b/packages/thread-view/src/format-timeline-text.ts
@@ -443,6 +443,22 @@ function formatConversationRequestLabel(
   return "steer";
 }
 
+function conversationRoleLabel(row: TimelineConversationViewRow): string {
+  if (row.role === "assistant") {
+    return "Assistant";
+  }
+  switch (row.initiator) {
+    case "agent":
+      return "Agent";
+    case "system":
+      return "System";
+    case "user":
+      return "User";
+    default:
+      return assertNever(row.initiator);
+  }
+}
+
 function formatRow(
   row: ThreadTimelineViewRow,
   context: TimelineTextFormatContext,
@@ -450,7 +466,7 @@ function formatRow(
   switch (row.kind) {
     case "conversation":
       return [
-        rowHeader(row.role === "user" ? "User" : "Assistant", context),
+        rowHeader(conversationRoleLabel(row), context),
         maybeTruncateBodyLinesForAudit(row.text.split("\n"), context).join(
           "\n",
         ),

--- a/packages/thread-view/src/user-message-parsing.ts
+++ b/packages/thread-view/src/user-message-parsing.ts
@@ -175,6 +175,73 @@ export interface ParseRejectedUsersFromClientRequestArgs {
   options?: BuildEventProjectionMessagesOptions;
 }
 
+export function parseProviderUserMessage(
+  decoded: ThreadEvent,
+  meta: EventMeta,
+): EventProjectionUserMessage | null {
+  if (
+    decoded.type !== "item/completed" ||
+    decoded.item.type !== "userMessage"
+  ) {
+    return null;
+  }
+
+  const textParts: string[] = [];
+  const imageUrls: string[] = [];
+  const localImagePaths: string[] = [];
+  const localFilePaths: string[] = [];
+  for (const part of decoded.item.content) {
+    switch (part.type) {
+      case "text":
+        textParts.push(part.text);
+        break;
+      case "image":
+        imageUrls.push(part.url);
+        break;
+      case "localImage":
+        localImagePaths.push(part.path);
+        break;
+      case "localFile":
+        localFilePaths.push(part.path);
+        break;
+    }
+  }
+  const text = textParts.join("");
+  if (
+    text.length === 0 &&
+    imageUrls.length === 0 &&
+    localImagePaths.length === 0 &&
+    localFilePaths.length === 0
+  ) {
+    return null;
+  }
+
+  return {
+    kind: "user",
+    id: messageId(decoded.threadId, "provider-user", decoded.item.id),
+    threadId: decoded.threadId,
+    sourceSeqStart: meta.seq,
+    sourceSeqEnd: meta.seq,
+    createdAt: meta.createdAt,
+    scope: decoded.scope,
+    initiator: "system",
+    senderThreadId: null,
+    systemMessageKind: "unlabeled",
+    systemMessageSubject: null,
+    turnRequest: { isGrouped: false, kind: "message", status: "accepted" },
+    text,
+    mentions: [],
+    attachments: {
+      webImages: imageUrls.length,
+      localImages: localImagePaths.length,
+      localFiles: localFilePaths.length,
+      ...(imageUrls.length > 0 ? { imageUrls } : {}),
+      ...(localImagePaths.length > 0 ? { localImagePaths } : {}),
+      ...(localFilePaths.length > 0 ? { localFilePaths } : {}),
+    },
+  };
+}
+
 type ClientTurnRequestedEvent = Extract<
   ThreadEvent,
   { type: "client/turn/requested" }

--- a/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
+++ b/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
@@ -800,6 +800,47 @@ describe("timeline CLI rendering snapshots", () => {
     `);
   });
 
+  it("renders provider-originated input in the timeline and CLI", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const events: TimelineFixtureEvent[] = [
+      event.turnStarted({ turnId: "turn-1" }),
+      event.providerUserMessage({
+        text: '<process_event kind="success">done</process_event>',
+        turnId: "turn-1",
+      }),
+      event.assistantCompleted({
+        itemId: "assistant-1",
+        text: "The process finished.",
+        turnId: "turn-1",
+      }),
+      event.turnCompleted({ turnId: "turn-1" }),
+    ];
+    const timeline = renderIdleTimeline(events);
+
+    expect(timeline.messages).toContainEqual(
+      expect.objectContaining({
+        kind: "user",
+        initiator: "system",
+        text: '<process_event kind="success">done</process_event>',
+      }),
+    );
+    expect(timeline.rows).toContainEqual(
+      expect.objectContaining({
+        kind: "conversation",
+        role: "user",
+        initiator: "system",
+        text: '<process_event kind="success">done</process_event>',
+      }),
+    );
+    expect(timeline.text).toMatchInlineSnapshot(`
+      "── System ──────────────────────────────────────────────────
+      <process_event kind=\"success\">done</process_event>
+
+      ── Assistant ───────────────────────────────────────────────
+      The process finished."
+    `);
+  });
+
   it("keeps completed thread provisioning after the initial user request", () => {
     const event = createTimelineEventFactory({ threadId: "thread-1" });
     const initialRequest = event.clientTurnRequested({


### PR DESCRIPTION
Fixes #1681

## What was wrong

Pi extensions can inject visible custom messages and trigger a provider turn. bb did not recognize their `message_start` and `message_end` boundaries, so it stored them as `provider/unhandled` and omitted the provider-originated input from the projected timeline. A process-triggered run could then complete with no assistant text and no explanation.

## What changed

- translate visible Pi `role: "custom"` message boundaries generically, independent of `customType`
- project provider-originated input through the existing system-initiated conversation row in the app and CLI
- follow Pi's real `agent_start` then `message_start` order and warn when a provider-triggered turn returns no assistant text
- keep `message_end`, hidden custom messages, idle `context`, and all `ignore` notifications from creating duplicate turns or input
- preserve accepted user prompts as user-triggered turns
- JSON-normalize unhandled provider payloads so `undefined` fields do not replace otherwise valid raw data with a serialization-error stub
- increase `HOST_DAEMON_PROTOCOL_VERSION` from 135 to 136 for the changed daemon event semantics

The string-content `agent_end` schema fix previously stacked in this branch is not included; it already merged in #1663.

## Validation

- `pnpm exec turbo run test --filter=@bb/agent-runtime --filter=@bb/thread-view --filter=@bb/provider-bridge-protocol --filter=@bb/host-daemon-contract --force`
  - agent-runtime: 30 files, 330 tests passed
  - thread-view: 21 files, 379 tests passed
  - provider-bridge-protocol: 11 files, 77 tests passed
  - host-daemon-contract: 3 files, 52 tests passed
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime --filter=@bb/thread-view --filter=@bb/provider-bridge-protocol --filter=@bb/host-daemon-contract`
- Prettier and `git diff --check`

A live Pi extension session still needs final verification for a normal process response and an empty assistant response.

> AGENT GENERATED: by GPT-5.6 Sol
