### PR TITLE
Promote Cursor Grok 4.6 in the model picker

### DIFF
--- a/packages/agent-runtime/src/acp/profiles.ts
+++ b/packages/agent-runtime/src/acp/profiles.ts
@@ -60,7 +60,7 @@ export const ACP_AGENT_PROFILES: readonly BuiltInAcpAgentProfile[] = [
       // catalog folds effort and the `-fast` tail into one entry per family.
       primaryModels: [
         "auto",
-        "cursor-grok-4.5-medium",
+        "cursor-grok-4.6-medium",
         "gpt-5.6-sol-medium",
         "claude-opus-5-thinking-medium",
         "claude-fable-5-thinking-medium",


### PR DESCRIPTION
Fixes #1688.

Cursor already discovers Grok 4.6, but the built-in `primaryModels` policy still names the exact Grok 4.5 family ID. That leaves 4.6 under More models and omits it from the default `bb provider models acp-cursor` output.

This replaces the curated Grok entry with `cursor-grok-4.6-medium`.

We intentionally left the existing generic adapter test unchanged to follow the historical Grok 4.5 fix in commit `9daeffb7`, which updated only the profile entry. A model-specific assertion would duplicate the current policy value and would not detect a future Cursor model release.

`HOST_DAEMON_PROTOCOL_VERSION` also remains unchanged. This updates catalog values within the existing model-list contract rather than changing the wire shape. Commit `9daeffb7` followed the same precedent.

Verified with:

- `pnpm exec turbo run test typecheck --filter=@bb/agent-runtime --force`
- A source-built dev server and daemon where `pnpm bb:dev provider models acp-cursor --json` returns Cursor Grok 4.6 as the second primary model

This does not address the separate recursive tool-schema failure tracked in #1612.

> HUMAN REVIEWED: by Yuri Laguardia
> AGENT GENERATED: by GPT-5.6 Sol