### PR TITLE
Fix connect tunnel stall on non-auth handshake rejection

### DIFF
--- a/plugins/connect/src/tunnel-handshake.test.ts
+++ b/plugins/connect/src/tunnel-handshake.test.ts
@@ -1,0 +1,91 @@
+// Socket-level test that only manifests against a real `ws` handshake: when the
+// gate rejects the upgrade with a non-auth status (e.g. a 502 Cloudflare returns
+// mid-deploy), the tunnel must schedule a reconnect rather than sit in
+// CONNECTING forever. Because a `unexpected-response` listener is registered, ws
+// skips `abortHandshake`, so unless that branch tears the socket down itself no
+// `error`/`close` fires and the backoff timer is never set. This runs against a
+// real http server so it exercises the actual handshake path (the sibling
+// tunnel-lifecycle test mocks `ws` and cannot observe this).
+import http from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
+import { ShareHostResolver } from "./hosts.js";
+import { ShareRegistry } from "./shares.js";
+import { ConnectTunnel } from "./tunnel.js";
+import { DEFAULT_CONNECT_BASE_URL } from "./redeem.js";
+
+function createTunnelFixture(serverUrl: string) {
+  const fakeHost = createFakePluginHost({
+    pluginId: "connect",
+    sdk: {
+      system: {
+        config: async () => ({ primaryHostId: "host-server" }) as never,
+      },
+    },
+  });
+  const pluginBb = fakeHost.bb;
+  const credential = { serverUrl, handle: "sawyer", credential: "bbcred_x" };
+  const shares = new ShareRegistry({
+    kv: {
+      get: async () => undefined,
+      set: async () => {},
+      delete: async () => {},
+    },
+    hosts: pluginBb.hosts,
+    hostResolver: new ShareHostResolver(() => pluginBb.sdk),
+    getLoopbackBaseUrl: () => "http://127.0.0.1:38886",
+    getCredential: () => credential,
+    log: pluginBb.log,
+  });
+  const tunnel = new ConnectTunnel({
+    store: {
+      read: async () => credential,
+      write: async () => {},
+      clear: async () => {},
+    },
+    shares,
+    defaultBaseUrl: DEFAULT_CONNECT_BASE_URL,
+    getLoopbackBaseUrl: () => "http://127.0.0.1:38886",
+    log: pluginBb.log,
+    onStatusChange: vi.fn(),
+  });
+  return { fakeHost, tunnel };
+}
+
+describe("ConnectTunnel — non-auth handshake rejection", () => {
+  let cleanup: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    await cleanup?.();
+    cleanup = undefined;
+  });
+
+  it("schedules a reconnect instead of stalling on a 502 handshake", async () => {
+    const server = http.createServer();
+    server.on("upgrade", (_req, socket) => {
+      socket.write("HTTP/1.1 502 Bad Gateway\r\n\r\n");
+      socket.destroy();
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as { port: number }).port;
+
+    const { fakeHost, tunnel } = createTunnelFixture(`http://127.0.0.1:${port}`);
+    cleanup = async () => {
+      tunnel.stop();
+      await fakeHost.harness.dispose();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    };
+
+    await tunnel.start();
+
+    // Without a socket teardown in the non-auth branch, no close fires and
+    // nextRetryAt stays null forever.
+    await vi.waitFor(
+      () => {
+        expect(tunnel.status().nextRetryAt).not.toBeNull();
+      },
+      { timeout: 3000 },
+    );
+    expect(tunnel.status().state).toBe("reconnecting");
+  });
+});

--- a/plugins/connect/src/tunnel.ts
+++ b/plugins/connect/src/tunnel.ts
@@ -490,6 +490,13 @@ export class ConnectTunnel {
       }
       this.lastError = `tunnel rejected: HTTP ${statusCode}`;
       this.options.log.warn(this.lastError);
+      // Registering this 'unexpected-response' listener makes ws skip its own
+      // abortHandshake, so without an explicit teardown neither 'error' nor
+      // 'close' fires and the socket sits in CONNECTING forever — the backoff
+      // that schedules a reconnect lives in the close handler. terminate()
+      // during CONNECTING routes to abortHandshake, emitting 'error' then
+      // 'close' so the existing reconnect path runs unchanged.
+      tunnel.terminate();
     });
     tunnel.on("error", (e: Error) => {
       if (this.stopped || this.tunnel !== tunnel) return;


### PR DESCRIPTION
## The bug

In `plugins/connect/src/tunnel.ts`, the `unexpected-response` handler for the
connect tunnel handles a gate handshake rejection. For statuses other than
401/403 it only recorded `lastError` and logged a warning:

```ts
this.lastError = `tunnel rejected: HTTP ${statusCode}`;
this.options.log.warn(this.lastError);
```

The subtle part is *why* that leaves the socket wedged. Registering an
`unexpected-response` listener makes `ws` skip its own internal
`abortHandshake` — it assumes the app now owns teardown. But this handler never
tore the socket down, so **neither `error` nor `close` ever fired**. The
reconnect backoff (`ReconnectBackoff` + the `setTimeout` that re-dials) lives
entirely in the `close` handler, so it was never scheduled and the socket sat in
`CONNECTING` indefinitely.

## User impact

A single non-auth rejection from the getbb.app gate — exactly the transient
`502`/`503` Cloudflare serves mid-deploy — took a user's `bb connect` tunnel
permanently offline. It presented silently as "connect randomly stops working
and never comes back," recoverable only by reloading the plugin or re-pairing.

## The fix

Call `tunnel.terminate()` in that branch. During `CONNECTING`, `terminate()`
routes to `abortHandshake`, which aborts the request and emits `error` then
`close`, so the existing backoff/reconnect path runs unchanged — no handler
restructuring needed.

The 401/403 branch was already fine: `credentialRejected()` calls `teardown()`,
which invokes `this.tunnel?.terminate()`, so that socket is torn down rather than
stranded in `CONNECTING`.

## Reproduction / test

Added `tunnel-handshake.test.ts`, which stands up a real `ws` server that
rejects the upgrade with an HTTP `502`, points a `ConnectTunnel` at it, and
asserts a reconnect is scheduled (`nextRetryAt` becomes non-null, state is
`reconnecting`). It runs against a real handshake because a mocked `ws` cannot
reproduce the `abortHandshake`-skip behavior.

- **Before the fix:** the test fails — `nextRetryAt` stays `null` and the wait
  times out after 3s.
- **After the fix:** it passes in ~60ms. All 79 package tests and typecheck pass.

`HOST_DAEMON_PROTOCOL_VERSION` is unaffected: this changes only the plugin's
client-side reaction to a gate handshake rejection, no server↔host-daemon wire
message, session payload, or RPC.

> AGENT GENERATED: by Claude Opus 4.8
