### PR TITLE
Accept cross-realm Response objects from plugin HTTP routes

### DIFF
--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -26,6 +26,7 @@ import {
   PLUGIN_AGENT_SELECTION_MAX_IDS,
   PLUGIN_AGENT_TOOL_PARAMETERS_MAX_BYTES,
   RESERVED_AGENT_TOOL_NAMES,
+  adoptHttpRouteResponse,
 } from "@get-bb/plugin-sdk/internal/host-policy";
 // The build engine's natives (esbuild, Tailwind oxide) are dynamically
 // imported inside buildPluginApp — importing this loads nothing heavy.
@@ -916,42 +917,6 @@ function normalizePluginAgentConfiguration(args: {
     }),
     instructions,
   };
-}
-
-/**
- * Plugin handlers can run in a different realm (jiti-loaded modules, bundled
- * fetch polyfills), so a valid `Response` from a handler may fail
- * `instanceof Response` here (#1661). Accept a structurally valid Response
- * from any realm and re-wrap it into a this-realm `Response`, so Hono always
- * consumes a native object and a malformed return still fails at this
- * boundary with a pointed error.
- */
-async function adoptHandlerResponse(value: unknown): Promise<Response> {
-  if (value instanceof Response) return value;
-  if (!isResponseLike(value)) {
-    throw new Error("http route handler must return a Response");
-  }
-  const body = await value.arrayBuffer();
-  const status = value.status;
-  const isNullBodyStatus =
-    status === 101 || status === 204 || status === 205 || status === 304;
-  return new Response(isNullBodyStatus ? null : body, {
-    status,
-    statusText: typeof value.statusText === "string" ? value.statusText : "",
-    headers: new Headers(value.headers),
-  });
-}
-
-function isResponseLike(value: unknown): value is Response {
-  if (value === null || typeof value !== "object") return false;
-  const candidate = value as Partial<Response>;
-  return (
-    typeof candidate.status === "number" &&
-    typeof candidate.headers === "object" &&
-    candidate.headers !== null &&
-    typeof candidate.arrayBuffer === "function" &&
-    typeof candidate.clone === "function"
-  );
 }
 
 export function createPluginService(deps: PluginServiceDeps): PluginService {
@@ -1862,7 +1827,7 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
         `http ${route.method} ${route.path}`,
         async () => {
           const response = await route.handler(context);
-          return await adoptHandlerResponse(response);
+          return adoptHttpRouteResponse(response);
         },
       );
       if (outcome.ok) return outcome.value;

--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -918,6 +918,42 @@ function normalizePluginAgentConfiguration(args: {
   };
 }
 
+/**
+ * Plugin handlers can run in a different realm (jiti-loaded modules, bundled
+ * fetch polyfills), so a valid `Response` from a handler may fail
+ * `instanceof Response` here (#1661). Accept a structurally valid Response
+ * from any realm and re-wrap it into a this-realm `Response`, so Hono always
+ * consumes a native object and a malformed return still fails at this
+ * boundary with a pointed error.
+ */
+async function adoptHandlerResponse(value: unknown): Promise<Response> {
+  if (value instanceof Response) return value;
+  if (!isResponseLike(value)) {
+    throw new Error("http route handler must return a Response");
+  }
+  const body = await value.arrayBuffer();
+  const status = value.status;
+  const isNullBodyStatus =
+    status === 101 || status === 204 || status === 205 || status === 304;
+  return new Response(isNullBodyStatus ? null : body, {
+    status,
+    statusText: typeof value.statusText === "string" ? value.statusText : "",
+    headers: new Headers(value.headers),
+  });
+}
+
+function isResponseLike(value: unknown): value is Response {
+  if (value === null || typeof value !== "object") return false;
+  const candidate = value as Partial<Response>;
+  return (
+    typeof candidate.status === "number" &&
+    typeof candidate.headers === "object" &&
+    candidate.headers !== null &&
+    typeof candidate.arrayBuffer === "function" &&
+    typeof candidate.clone === "function"
+  );
+}
+
 export function createPluginService(deps: PluginServiceDeps): PluginService {
   const logger = deps.logger;
   const bundledPlugins =
@@ -1826,10 +1862,7 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
         `http ${route.method} ${route.path}`,
         async () => {
           const response = await route.handler(context);
-          if (!(response instanceof Response)) {
-            throw new Error("http route handler must return a Response");
-          }
-          return response;
+          return await adoptHandlerResponse(response);
         },
       );
       if (outcome.ok) return outcome.value;

--- a/apps/server/test/services/plugins/plugin-wire.test.ts
+++ b/apps/server/test/services/plugins/plugin-wire.test.ts
@@ -57,6 +57,29 @@ const WIRE_SOURCE = `
         status: real.status,
         statusText: real.statusText,
         headers: real.headers,
+        body: real.body,
+        arrayBuffer: () => real.arrayBuffer(),
+        clone: () => real.clone(),
+      };
+    });
+    // Streams two chunks; the second is only produced after the test releases
+    // it, so buffering the whole body would hang the first read.
+    bb.http.route("GET", "/foreign-stream", () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        async start(controller) {
+          controller.enqueue(encoder.encode("first;"));
+          await globalThis.__releaseSecondChunk;
+          controller.enqueue(encoder.encode("second"));
+          controller.close();
+        },
+      });
+      const real = new Response(stream, { status: 200 });
+      return {
+        status: real.status,
+        statusText: real.statusText,
+        headers: real.headers,
+        body: real.body,
         arrayBuffer: () => real.arrayBuffer(),
         clone: () => real.clone(),
       };
@@ -418,6 +441,34 @@ describe("plugin wire surfaces (http/rpc dispatcher + realtime)", () => {
     expect(await response.json()).toEqual({ foreign: true });
     const entry = harness.pluginService.list().find((p) => p.id === "wire");
     expect(entry?.handlerStats.errorCount).toBe(0);
+  });
+
+  it("streams a foreign response body instead of buffering it", async () => {
+    let release!: () => void;
+    (globalThis as any).__releaseSecondChunk = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    try {
+      const response = await harness.app.request(
+        `${BASE}/api/v1/plugins/wire/http/foreign-stream`,
+      );
+      expect(response.status).toBe(200);
+      const reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      const first = await reader.read();
+      expect(decoder.decode(first.value)).toBe("first;");
+      release();
+      let rest = "";
+      for (;;) {
+        const chunk = await reader.read();
+        if (chunk.done) break;
+        rest += decoder.decode(chunk.value, { stream: true });
+      }
+      expect(rest).toBe("second");
+    } finally {
+      release();
+      delete (globalThis as any).__releaseSecondChunk;
+    }
   });
 
   it("rejects a non-Response return with a pointed 500 at the invoke boundary", async () => {

--- a/apps/server/test/services/plugins/plugin-wire.test.ts
+++ b/apps/server/test/services/plugins/plugin-wire.test.ts
@@ -45,6 +45,23 @@ const WIRE_SOURCE = `
     bb.http.route("GET", "/boom", () => {
       throw new Error("route boom");
     });
+    // A structurally valid Response whose prototype is not this realm's
+    // Response, as a handler running in another realm would return (#1661).
+    bb.http.route("GET", "/foreign", () => {
+      const real = new Response(JSON.stringify({ foreign: true }), {
+        status: 201,
+        statusText: "Created",
+        headers: { "content-type": "application/json", "x-foreign": "yes" },
+      });
+      return {
+        status: real.status,
+        statusText: real.statusText,
+        headers: real.headers,
+        arrayBuffer: () => real.arrayBuffer(),
+        clone: () => real.clone(),
+      };
+    });
+    bb.http.route("GET", "/not-a-response", () => ({ status: 200 }));
     bb.rpc.register(rpcContract, {
       echo: async (input: any) => ({ echoed: input }),
       boom: async () => {
@@ -389,6 +406,29 @@ describe("plugin wire surfaces (http/rpc dispatcher + realtime)", () => {
     const entry = harness.pluginService.list().find((p) => p.id === "wire");
     expect(entry?.handlerStats.errorCount).toBe(1);
     expect(entry?.statusDetail).toContain("http GET /boom failed");
+  });
+
+  it("adopts a structurally valid Response from another realm (#1661)", async () => {
+    const response = await harness.app.request(
+      `${BASE}/api/v1/plugins/wire/http/foreign`,
+    );
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(201);
+    expect(response.headers.get("x-foreign")).toBe("yes");
+    expect(await response.json()).toEqual({ foreign: true });
+    const entry = harness.pluginService.list().find((p) => p.id === "wire");
+    expect(entry?.handlerStats.errorCount).toBe(0);
+  });
+
+  it("rejects a non-Response return with a pointed 500 at the invoke boundary", async () => {
+    const response = await harness.app.request(
+      `${BASE}/api/v1/plugins/wire/http/not-a-response`,
+    );
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("http route handler must return a Response"),
+    });
   });
 
   it("successful reload atomically replaces the complete route and rpc tables", async () => {

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -16,7 +16,7 @@
 // PLUGIN_SDK_MAJOR is 0, so the major-only artifact gate cannot distinguish
 // 0.x releases and is intentionally vacuous for them until a future 1.0.
 // Rebuildable artifacts still rebuild on the exact sdkVersion-differs trigger.
-export const PLUGIN_SDK_VERSION = "0.4.6";
+export const PLUGIN_SDK_VERSION = "0.4.7";
 
 /** Major of {@link PLUGIN_SDK_VERSION} — the plugin API compatibility number. */
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-sdk/bundled-types/bb-plugin-sdk-internal-host-policy.d.ts
+++ b/packages/plugin-sdk/bundled-types/bb-plugin-sdk-internal-host-policy.d.ts
@@ -137,5 +137,19 @@ declare function isZodSchemaLike(value: unknown): boolean;
 /** Compact issue summary from a (possibly foreign-instance) zod error. */
 declare function summarizeParseIssues(error: unknown): string;
 declare function enforcePluginCliOutputLimit(result: Omit<PluginCliExecutionResult, "error">, jsonOutput: boolean): PluginCliExecutionResult;
+/**
+ * Adopt the value a plugin HTTP route handler returned.
+ *
+ * Plugin handlers can run in a different realm (jiti-loaded modules, bundled
+ * fetch polyfills), so a valid `Response` from a handler can fail
+ * `instanceof Response` in the host (#1661). Both the real host and the fake
+ * host accept a structurally valid Response from any realm and re-wrap it
+ * into a this-realm `Response`, so Hono always consumes a native object and a
+ * malformed return still fails at the invoke boundary with a pointed error.
+ *
+ * The body streams through: a foreign `body` stream is piped chunk by chunk
+ * with cancellation forwarded to the source, so no full-size buffer is made.
+ */
+declare function adoptHttpRouteResponse(value: unknown): Response;
 
-export { AGENT_TOOL_NAME_PATTERN, BACKGROUND_NAME_PATTERN, CLI_COMMAND_NAME_PATTERN, KV_VALUE_MAX_BYTES, MENTION_PROVIDER_ID_PATTERN, PLUGIN_AGENT_DYNAMIC_INSTRUCTIONS_MAX_CHARS, PLUGIN_AGENT_SELECTION_MAX_IDS, PLUGIN_AGENT_STATIC_INSTRUCTIONS_MAX_CHARS, PLUGIN_AGENT_STATUS_LABEL_MAX_CHARS, PLUGIN_AGENT_TOOL_PARAMETERS_MAX_BYTES, PLUGIN_HTTP_METHODS, PLUGIN_MENTION_TRIGGER_VALUES, RESERVED_AGENT_TOOL_NAMES, RESERVED_BB_CLI_COMMANDS, RPC_METHOD_PATTERN, SETTING_KEY_PATTERN, enforcePluginCliOutputLimit, isPluginMentionTrigger, isStandardSchema, isZodSchemaLike, normalizeMentionProviderTriggers, readRpcMethodContract, registerSettingDescriptors, summarizeParseIssues, validateSettingsUpdate };
+export { AGENT_TOOL_NAME_PATTERN, BACKGROUND_NAME_PATTERN, CLI_COMMAND_NAME_PATTERN, KV_VALUE_MAX_BYTES, MENTION_PROVIDER_ID_PATTERN, PLUGIN_AGENT_DYNAMIC_INSTRUCTIONS_MAX_CHARS, PLUGIN_AGENT_SELECTION_MAX_IDS, PLUGIN_AGENT_STATIC_INSTRUCTIONS_MAX_CHARS, PLUGIN_AGENT_STATUS_LABEL_MAX_CHARS, PLUGIN_AGENT_TOOL_PARAMETERS_MAX_BYTES, PLUGIN_HTTP_METHODS, PLUGIN_MENTION_TRIGGER_VALUES, RESERVED_AGENT_TOOL_NAMES, RESERVED_BB_CLI_COMMANDS, RPC_METHOD_PATTERN, SETTING_KEY_PATTERN, adoptHttpRouteResponse, enforcePluginCliOutputLimit, isPluginMentionTrigger, isStandardSchema, isZodSchemaLike, normalizeMentionProviderTriggers, readRpcMethodContract, registerSettingDescriptors, summarizeParseIssues, validateSettingsUpdate };

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/plugin-sdk/src/internal/host-policy.ts
+++ b/packages/plugin-sdk/src/internal/host-policy.ts
@@ -335,3 +335,85 @@ export function enforcePluginCliOutputLimit(
       }
     : { exitCode: 1, stdout: "", stderr: error.message, error };
 }
+
+/**
+ * Adopt the value a plugin HTTP route handler returned.
+ *
+ * Plugin handlers can run in a different realm (jiti-loaded modules, bundled
+ * fetch polyfills), so a valid `Response` from a handler can fail
+ * `instanceof Response` in the host (#1661). Both the real host and the fake
+ * host accept a structurally valid Response from any realm and re-wrap it
+ * into a this-realm `Response`, so Hono always consumes a native object and a
+ * malformed return still fails at the invoke boundary with a pointed error.
+ *
+ * The body streams through: a foreign `body` stream is piped chunk by chunk
+ * with cancellation forwarded to the source, so no full-size buffer is made.
+ */
+export function adoptHttpRouteResponse(value: unknown): Response {
+  if (value instanceof Response) return value;
+  if (!isResponseLike(value)) {
+    throw new Error("http route handler must return a Response");
+  }
+  const status = value.status;
+  const isNullBodyStatus =
+    status === 101 || status === 204 || status === 205 || status === 304;
+  const init: ResponseInit = {
+    status,
+    statusText: typeof value.statusText === "string" ? value.statusText : "",
+    headers: new Headers(value.headers),
+  };
+  if (isNullBodyStatus || value.body === null) {
+    return new Response(null, init);
+  }
+  return new Response(adoptBodyStream(value), init);
+}
+
+function adoptBodyStream(value: Response): ReadableStream<Uint8Array> {
+  const source = value.body;
+  if (!isReadableStreamLike(source)) {
+    // No usable stream (for example a body already consumed by a proxy):
+    // fall back to the buffered body so the route still returns its content.
+    return new ReadableStream<Uint8Array>({
+      async start(controller) {
+        controller.enqueue(new Uint8Array(await value.arrayBuffer()));
+        controller.close();
+      },
+    });
+  }
+  const reader = source.getReader();
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      const { done, value: chunk } = await reader.read();
+      if (done) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(chunk);
+    },
+    async cancel(reason) {
+      await reader.cancel(reason);
+    },
+  });
+}
+
+function isReadableStreamLike(
+  value: unknown,
+): value is ReadableStream<Uint8Array> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as ReadableStream).getReader === "function"
+  );
+}
+
+function isResponseLike(value: unknown): value is Response {
+  if (value === null || typeof value !== "object") return false;
+  const candidate = value as Partial<Response>;
+  return (
+    typeof candidate.status === "number" &&
+    typeof candidate.headers === "object" &&
+    candidate.headers !== null &&
+    typeof candidate.arrayBuffer === "function" &&
+    typeof candidate.clone === "function"
+  );
+}

--- a/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
+++ b/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
@@ -345,6 +345,38 @@ describe("http", () => {
       error: "plugin route failed: nope",
     });
   });
+
+  it("adopts a structurally valid Response from another realm like the host (#1661)", async () => {
+    const { bb, harness } = createFakePluginHost();
+    bb.http.route("GET", "/foreign", () => {
+      const real = new Response(JSON.stringify({ foreign: true }), {
+        status: 201,
+        headers: { "content-type": "application/json", "x-foreign": "yes" },
+      });
+      // Not `instanceof Response` in this realm; same structural shape.
+      return {
+        status: real.status,
+        statusText: real.statusText,
+        headers: real.headers,
+        body: real.body,
+        arrayBuffer: () => real.arrayBuffer(),
+        clone: () => real.clone(),
+      } as unknown as Response;
+    });
+    bb.http.route("GET", "/not-a-response", () => ({ status: 200 }) as Response);
+
+    const foreign = await harness.fetchHttp("GET", "/foreign");
+    expect(foreign.status).toBe(201);
+    expect(foreign.headers.get("x-foreign")).toBe("yes");
+    expect(await foreign.json()).toEqual({ foreign: true });
+
+    const malformed = await harness.fetchHttp("GET", "/not-a-response");
+    expect(malformed.status).toBe(500);
+    expect(await malformed.json()).toEqual({
+      ok: false,
+      error: "plugin route failed: http route handler must return a Response",
+    });
+  });
 });
 
 describe("cli", () => {

--- a/packages/plugin-sdk/src/testing/fake-plugin-host.ts
+++ b/packages/plugin-sdk/src/testing/fake-plugin-host.ts
@@ -28,6 +28,7 @@ import {
   RPC_METHOD_PATTERN,
   summarizeParseIssues,
   validateSettingsUpdate,
+  adoptHttpRouteResponse,
 } from "../internal/host-policy.js";
 import type {
   BbPluginApi,
@@ -1779,11 +1780,7 @@ function createFakePluginHostInternal(
       const app = new Hono();
       app.on(route.method, route.path, async (context) => {
         try {
-          const response = await route.handler(context);
-          if (!(response instanceof Response)) {
-            throw new Error("http route handler must return a Response");
-          }
-          return response;
+          return adoptHttpRouteResponse(await route.handler(context));
         } catch (error) {
           const message = errorMessage(error);
           emitLog(


### PR DESCRIPTION
## Summary

Plugin HTTP route handlers can run in a different realm, so a valid \`Response\` from a handler failed the \`instanceof Response\` check in \`invokeHttpRoute\`. Every plugin HTTP route then returned a 500 with \`http route handler must return a Response\`.

This change:

- Accepts a structurally valid Response (\`status\`, \`headers\`, \`arrayBuffer\`, \`clone\`) from any realm.
- Re-wraps a foreign Response into a this-realm \`Response\` at the invoke boundary, so Hono always consumes a native object.
- Keeps the pointed \`http route handler must return a Response\` error for a malformed return.

## Tests

- New tests in \`plugin-wire.test.ts\`: a foreign structural Response is adopted with status, headers, and body intact; a malformed return still yields the pointed 500.
- The new test fails without the fix and passes with it.
- \`pnpm exec turbo run typecheck --filter=@bb/server\` passes.

Fixes #1661

> AGENT GENERATED: by Claude Opus 5