### PR TITLE
Fix the render loop when a New plugin example seeds the root composer

### DIFF
--- a/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
+++ b/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
@@ -765,6 +765,7 @@ describe("PluginNewThreadComposer seeding", () => {
           argument.includes("Maximum update depth exceeded"),
       ),
     );
+    consoleError.mockRestore();
     expect(updateDepthErrors).toEqual([]);
   });
 

--- a/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
+++ b/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
@@ -709,6 +709,65 @@ describe("PluginNewThreadComposer seeding", () => {
     expect(latestPromptBoxProps().attachments.items).toEqual([]);
   });
 
+  // Installed → New plugin → an example lands on the root composer with a
+  // `replaceInitialPrompt` seed. Applying it writes the draft store, which
+  // re-renders the view synchronously before the router's transition clears
+  // the location state; the effect must not re-apply the seed on that render
+  // or the two updates starve each other until React aborts the loop.
+  it("applies a replacing initial prompt from location state exactly once", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    window.localStorage.setItem("bb.root-compose.project-id", "proj_1");
+    const rootDraft = getPromptDraftAccessor({ kind: "new-thread" });
+    rootDraft.setDraft({
+      text: "leftover draft",
+      mentions: [],
+      attachments: [],
+    });
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const router = createMemoryRouter(
+      [{ path: "/", element: <RootComposeView /> }],
+      {
+        initialEntries: [
+          {
+            pathname: "/",
+            state: {
+              focusPrompt: true,
+              initialPrompt: "Create a kanban plugin",
+              replaceInitialPrompt: true,
+            },
+          },
+        ],
+      },
+    );
+    render(
+      <Provider>
+        <QueryClientProvider client={queryClient}>
+          <RouterProvider router={router} />
+        </QueryClientProvider>
+      </Provider>,
+    );
+
+    await waitFor(() => {
+      expect(latestPromptBoxProps().value).toBe("Create a kanban plugin");
+    });
+    await waitFor(() => {
+      expect(router.state.location.state).toBeNull();
+    });
+    expect(rootDraft.getCurrent().text).toBe("Create a kanban plugin");
+    const updateDepthErrors = consoleError.mock.calls.filter((call) =>
+      call.some(
+        (argument) =>
+          typeof argument === "string" &&
+          argument.includes("Maximum update depth exceeded"),
+      ),
+    );
+    expect(updateDepthErrors).toEqual([]);
+  });
+
   it("ignores a repeated submit while the first submission is pending", async () => {
     let finishSubmit: (() => void) | null = null;
     const onSubmit = vi.fn(

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -788,6 +788,14 @@ function RootComposeSurface({
     [promptBoxRef, promptDraft, setStartedComposing],
   );
 
+  // Both location-state effects below write the draft store and then clear
+  // the state through a router transition. The store write re-renders this
+  // view synchronously with a new `promptDraft` object, before the transition
+  // commits, so an effect that depends on `promptDraft` itself would re-run
+  // against the same location state, write again, and starve the transition
+  // until React aborts the loop. Depend on the stable setters instead.
+  const setPromptDraft = promptDraft.setDraft;
+  const restorePromptDraftIfEmpty = promptDraft.restoreIfEmpty;
   useEffect(() => {
     const sectionTarget = readRootComposeSectionTargetFromLocationState(
       location.state,
@@ -834,7 +842,7 @@ function RootComposeSurface({
           encodeReuseValue(nextHandoffSeed.environmentId),
         );
       }
-      promptDraft.setDraft(buildThreadHandoffPromptDraft(nextHandoffSeed));
+      setPromptDraft(buildThreadHandoffPromptDraft(nextHandoffSeed));
     }
     navigate(getRootComposeRoutePath() + location.search, {
       replace: true,
@@ -844,10 +852,10 @@ function RootComposeSurface({
     location.search,
     location.state,
     navigate,
-    promptDraft,
     seedEnvironmentSelectionValue,
     setForkSeed,
     setPermissionMode,
+    setPromptDraft,
     setProviderModelReasoning,
     setRootComposeProjectId,
     setRootComposeSectionId,
@@ -859,15 +867,21 @@ function RootComposeSurface({
     if (initialPrompt === null) return;
     const nextDraft = { text: initialPrompt, mentions: [], attachments: [] };
     if (shouldReplaceInitialPromptFromLocationState(location.state)) {
-      promptDraft.setDraft(nextDraft);
+      setPromptDraft(nextDraft);
     } else {
-      promptDraft.restoreIfEmpty(nextDraft);
+      restorePromptDraftIfEmpty(nextDraft);
     }
     navigate(getRootComposeRoutePath() + location.search, {
       replace: true,
       state: { focusPrompt: true },
     });
-  }, [location.search, location.state, navigate, promptDraft]);
+  }, [
+    location.search,
+    location.state,
+    navigate,
+    restorePromptDraftIfEmpty,
+    setPromptDraft,
+  ]);
   const shouldFocusPrompt =
     typeof location.state === "object" &&
     location.state !== null &&


### PR DESCRIPTION
## Summary

- Fixes #1685: Installed plugins → New plugin arrow → an Examples/Capabilities entry crashed the app with `Maximum update depth exceeded`.
- Cause: `RootComposeView` applies a `replaceInitialPrompt` seed from location state in an effect that depended on the `promptDraft` object. The draft write re-renders the view synchronously with a new `promptDraft` identity before the router's `startTransition` navigation clears the state, so the effect re-applied the seed each render and starved the transition until React aborted. The plain button used `restoreIfEmpty` (a no-op after the first write), which is why only the seeded entries looped.
- Fix: depend on the stable `setDraft` / `restoreIfEmpty` setters in both location-state effects.
- Test: a `RootComposeView` router test with a replacing `initialPrompt` state; it crashes the worker with the update-depth error before the fix and passes after.

## Verification

- Reproduced in the dev app with a headless browser: Installed → New plugin options → Kanban board crashed before the fix and loads the composer without errors after it.
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app -- src/views src/components/plugin/PluginNewThreadComposer.test.tsx src/components/promptbox/NewThreadPromptBox.test.tsx` (37 files, 347 tests pass)

Note: the issue also mentions the `.nvmrc` / pnpm Node requirement mismatch; this PR does not change that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> AGENT GENERATED: by Claude Opus 5