### PR TITLE
Reactivate threads when a provider resumes work on a completed turn

### DIFF
--- a/apps/server/src/internal/events.ts
+++ b/apps/server/src/internal/events.ts
@@ -23,6 +23,7 @@ import {
   type HostDaemonRejectedEvent,
 } from "@bb/host-daemon-contract";
 import {
+  getThreadEventScopeTurnId,
   requireThreadEventScopeTurnId,
   type ThreadEventType,
   type ThreadEventTurnStatus,
@@ -154,6 +155,11 @@ interface HasThreadCommandFailureSystemErrorForTurnDeps {
 interface HasThreadCommandFailureSystemErrorForTurnArgs {
   threadId: string;
   turnId: string;
+}
+
+interface ResolveReopenedTurnIdArgs {
+  event: Extract<HostDaemonEventEnvelope["event"], { type: "item/started" }>;
+  threadId: string;
 }
 
 interface HasThreadStopBeforeTurnStartedArgs {
@@ -404,6 +410,24 @@ async function applyEventEffects(
         continue;
       }
 
+      if (event.type === "item/started") {
+        // A provider can keep working on a turn after it reported that turn as
+        // completed (Codex hook/compaction continuations, issue #1646). The
+        // work is real, so the thread must show as active again until the
+        // provider closes the turn a second time.
+        const turnId = resolveReopenedTurnId(deps, {
+          event,
+          threadId: entry.threadId,
+        });
+        if (turnId !== null) {
+          applyLoggedThreadLifecycleEvent(deps, {
+            event: { type: "run.started" },
+            threadId: entry.threadId,
+          });
+        }
+        continue;
+      }
+
       if (event.type === "turn/completed") {
         const turnId = requireThreadEventScopeTurnId({
           type: event.type,
@@ -642,6 +666,64 @@ function hasThreadStopBeforeTurnStarted(
       .limit(1)
       .get() !== undefined
   );
+}
+
+/**
+ * Returns the turn id when `event` is root provider work on a turn the thread
+ * already completed, the thread sits idle, and no stop arrived after that
+ * completion. Such work must reactivate the thread.
+ */
+function resolveReopenedTurnId(
+  deps: Pick<AppDeps, "db">,
+  args: ResolveReopenedTurnIdArgs,
+): string | null {
+  const { event } = args;
+  if (event.item.type === "userMessage" || event.item.parentToolCallId) {
+    return null;
+  }
+  const turnId = getThreadEventScopeTurnId(event.scope);
+  if (turnId === undefined) {
+    return null;
+  }
+  const thread = getThread(deps.db, args.threadId);
+  if (
+    !thread ||
+    thread.status !== "idle" ||
+    thread.archivedAt !== null ||
+    thread.deletedAt !== null
+  ) {
+    return null;
+  }
+  const turnCompleted = deps.db
+    .select({ sequence: storedEvents.sequence })
+    .from(storedEvents)
+    .where(
+      and(
+        eq(storedEvents.threadId, args.threadId),
+        eq(storedEvents.turnId, turnId),
+        eq(storedEvents.type, "turn/completed"),
+      ),
+    )
+    .orderBy(desc(storedEvents.sequence))
+    .limit(1)
+    .get();
+  if (!turnCompleted) {
+    return null;
+  }
+  const stoppedAfterCompletion =
+    deps.db
+      .select({ id: storedEvents.id })
+      .from(storedEvents)
+      .where(
+        and(
+          eq(storedEvents.threadId, args.threadId),
+          eq(storedEvents.type, "system/thread/interrupted"),
+          gt(storedEvents.sequence, turnCompleted.sequence),
+        ),
+      )
+      .limit(1)
+      .get() !== undefined;
+  return stoppedAfterCompletion ? null : turnId;
 }
 
 function hasThreadAlreadyStartedRun(

--- a/apps/server/src/internal/events.ts
+++ b/apps/server/src/internal/events.ts
@@ -24,6 +24,7 @@ import {
 } from "@bb/host-daemon-contract";
 import {
   getThreadEventScopeTurnId,
+  isTurnReopeningWorkItem,
   requireThreadEventScopeTurnId,
   type ThreadEventType,
   type ThreadEventTurnStatus,
@@ -678,7 +679,7 @@ function resolveReopenedTurnId(
   args: ResolveReopenedTurnIdArgs,
 ): string | null {
   const { event } = args;
-  if (event.item.type === "userMessage" || event.item.parentToolCallId) {
+  if (!isTurnReopeningWorkItem(event.item)) {
     return null;
   }
   const turnId = getThreadEventScopeTurnId(event.scope);
@@ -695,7 +696,7 @@ function resolveReopenedTurnId(
     return null;
   }
   const turnCompleted = deps.db
-    .select({ sequence: storedEvents.sequence })
+    .select({ id: storedEvents.id })
     .from(storedEvents)
     .where(
       and(
@@ -704,13 +705,58 @@ function resolveReopenedTurnId(
         eq(storedEvents.type, "turn/completed"),
       ),
     )
-    .orderBy(desc(storedEvents.sequence))
     .limit(1)
     .get();
   if (!turnCompleted) {
     return null;
   }
-  const stoppedAfterCompletion =
+  return hasThreadStopSinceTurnRequested(deps, {
+    threadId: args.threadId,
+    turnId,
+  })
+    ? null
+    : turnId;
+}
+
+/**
+ * True when a stop was recorded at any point after the turn request that
+ * produced `turnId`. Only a newer turn request clears the user's stop intent,
+ * so late provider work must not reactivate a stopped thread.
+ */
+function hasThreadStopSinceTurnRequested(
+  deps: Pick<AppDeps, "db">,
+  args: HasThreadStopBeforeTurnStartedArgs,
+): boolean {
+  const turnStarted = deps.db
+    .select({ sequence: storedEvents.sequence })
+    .from(storedEvents)
+    .where(
+      and(
+        eq(storedEvents.threadId, args.threadId),
+        eq(storedEvents.turnId, args.turnId),
+        eq(storedEvents.type, "turn/started"),
+      ),
+    )
+    .limit(1)
+    .get();
+  if (!turnStarted) {
+    return true;
+  }
+  const latestTurnRequest = deps.db
+    .select({ sequence: storedEvents.sequence })
+    .from(storedEvents)
+    .where(
+      and(
+        eq(storedEvents.threadId, args.threadId),
+        eq(storedEvents.type, "client/turn/requested"),
+        lt(storedEvents.sequence, turnStarted.sequence),
+      ),
+    )
+    .orderBy(desc(storedEvents.sequence))
+    .limit(1)
+    .get();
+  const lowerSequence = latestTurnRequest?.sequence ?? 0;
+  return (
     deps.db
       .select({ id: storedEvents.id })
       .from(storedEvents)
@@ -718,12 +764,12 @@ function resolveReopenedTurnId(
         and(
           eq(storedEvents.threadId, args.threadId),
           eq(storedEvents.type, "system/thread/interrupted"),
-          gt(storedEvents.sequence, turnCompleted.sequence),
+          gt(storedEvents.sequence, lowerSequence),
         ),
       )
       .limit(1)
-      .get() !== undefined;
-  return stoppedAfterCompletion ? null : turnId;
+      .get() !== undefined
+  );
 }
 
 function hasThreadAlreadyStartedRun(

--- a/apps/server/test/internal/internal-event-append-ownership.test.ts
+++ b/apps/server/test/internal/internal-event-append-ownership.test.ts
@@ -846,6 +846,43 @@ describe("provider work after turn/completed", () => {
     }
   });
 
+  it("keeps a thread idle when a stop precedes a later completion of the same turn", async () => {
+    const { harness, session, thread } = await setupEventRoute();
+    const turn = buildTurnEvents(thread.id, "turn-stop-then-complete");
+    try {
+      const first = await postEventBatch({
+        harness,
+        sessionId: session.id,
+        events: [
+          turn.started,
+          turn.completed,
+          {
+            threadId: thread.id,
+            event: {
+              type: "system/thread/interrupted",
+              threadId: thread.id,
+              scope: threadScope(),
+              reason: "manual-stop",
+            },
+          },
+          turn.completed,
+        ],
+      });
+      expect(first.status).toBe(200);
+      expect(getThread(harness.db, thread.id)?.status).toBe("idle");
+
+      const second = await postEventBatch({
+        harness,
+        sessionId: session.id,
+        events: [turn.command],
+      });
+      expect(second.status).toBe(200);
+      expect(getThread(harness.db, thread.id)?.status).toBe("idle");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
   it("keeps a stopped thread idle when late provider work arrives", async () => {
     const { harness, session, thread } = await setupEventRoute();
     const turn = buildTurnEvents(thread.id, "turn-stopped");

--- a/apps/server/test/internal/internal-event-append-ownership.test.ts
+++ b/apps/server/test/internal/internal-event-append-ownership.test.ts
@@ -771,3 +771,114 @@ describe("internal event append ownership", () => {
     }
   });
 });
+
+describe("provider work after turn/completed", () => {
+  function buildTurnEvents(threadId: string, turnId: string) {
+    return {
+      started: {
+        threadId,
+        event: {
+          type: "turn/started" as const,
+          threadId,
+          providerThreadId: "provider-reopen",
+          scope: turnScope(turnId),
+        },
+      },
+      completed: {
+        threadId,
+        event: {
+          type: "turn/completed" as const,
+          threadId,
+          providerThreadId: "provider-reopen",
+          scope: turnScope(turnId),
+          status: "completed" as const,
+        },
+      },
+      command: {
+        threadId,
+        event: {
+          type: "item/started" as const,
+          threadId,
+          providerThreadId: "provider-reopen",
+          scope: turnScope(turnId),
+          item: {
+            type: "commandExecution" as const,
+            id: `${turnId}-cmd`,
+            command: "npm test",
+            cwd: "/repo",
+            status: "pending" as const,
+            approvalStatus: null,
+          },
+        },
+      },
+    };
+  }
+
+  it("reactivates an idle thread when the provider streams work on a completed turn", async () => {
+    const { harness, session, thread } = await setupEventRoute();
+    const turn = buildTurnEvents(thread.id, "turn-reopen");
+    try {
+      const first = await postEventBatch({
+        harness,
+        sessionId: session.id,
+        events: [turn.started, turn.completed],
+      });
+      expect(first.status).toBe(200);
+      expect(getThread(harness.db, thread.id)?.status).toBe("idle");
+
+      const second = await postEventBatch({
+        harness,
+        sessionId: session.id,
+        events: [turn.command],
+      });
+      expect(second.status).toBe(200);
+      expect(getThread(harness.db, thread.id)?.status).toBe("active");
+
+      const third = await postEventBatch({
+        harness,
+        sessionId: session.id,
+        events: [turn.completed],
+      });
+      expect(third.status).toBe(200);
+      expect(getThread(harness.db, thread.id)?.status).toBe("idle");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("keeps a stopped thread idle when late provider work arrives", async () => {
+    const { harness, session, thread } = await setupEventRoute();
+    const turn = buildTurnEvents(thread.id, "turn-stopped");
+    try {
+      const first = await postEventBatch({
+        harness,
+        sessionId: session.id,
+        events: [
+          turn.started,
+          turn.completed,
+          {
+            threadId: thread.id,
+            event: {
+              type: "system/thread/interrupted",
+              threadId: thread.id,
+              scope: threadScope(),
+              reason: "manual-stop",
+            },
+          },
+        ],
+      });
+      expect(first.status).toBe(200);
+      expect(getThread(harness.db, thread.id)?.status).toBe("idle");
+
+      const second = await postEventBatch({
+        harness,
+        sessionId: session.id,
+        events: [turn.command],
+      });
+      expect(second.status).toBe(200);
+      expect(getThread(harness.db, thread.id)?.status).toBe("idle");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+});

--- a/packages/agent-runtime/src/runtime-turn-state.test.ts
+++ b/packages/agent-runtime/src/runtime-turn-state.test.ts
@@ -206,6 +206,29 @@ describe("RuntimeTurnState reopened turns", () => {
     expect(state.getActiveTurnId("t1")).toBeNull();
   });
 
+  it("does not reopen from an unparented background task", () => {
+    const state = new RuntimeTurnState();
+    state.observe(turnStarted("turn-1"));
+    state.observe(turnCompleted("turn-1"));
+
+    state.observe({
+      type: "item/started",
+      threadId: "t1",
+      providerThreadId: "p1",
+      scope: turnScope("turn-1"),
+      item: {
+        type: "backgroundTask",
+        id: "task-1",
+        taskType: "local_bash",
+        description: "long build",
+        status: "pending",
+        taskStatus: "running",
+        skipTranscript: false,
+      },
+    });
+    expect(state.getActiveTurnId("t1")).toBeNull();
+  });
+
   it("does not reopen from delegated child work or while a turn is active", () => {
     const state = new RuntimeTurnState();
     state.observe(commandStarted("child-turn", { parentToolCallId: "tool-1" }));

--- a/packages/agent-runtime/src/runtime-turn-state.test.ts
+++ b/packages/agent-runtime/src/runtime-turn-state.test.ts
@@ -169,6 +169,54 @@ describe("RuntimeTurnState", () => {
   });
 });
 
+describe("RuntimeTurnState reopened turns", () => {
+  function commandStarted(
+    turnId: string,
+    options: { parentToolCallId?: string } = {},
+  ): ThreadEvent {
+    return {
+      type: "item/started",
+      threadId: "t1",
+      providerThreadId: "p1",
+      scope: turnScope(turnId),
+      item: {
+        type: "commandExecution",
+        id: `${turnId}-cmd`,
+        command: "npm test",
+        cwd: "/repo",
+        status: "pending",
+        approvalStatus: null,
+        ...(options.parentToolCallId
+          ? { parentToolCallId: options.parentToolCallId }
+          : {}),
+      },
+    };
+  }
+
+  it("reopens the active turn when root work resumes on a completed turn", () => {
+    const state = new RuntimeTurnState();
+    state.observe(turnStarted("turn-1"));
+    state.observe(turnCompleted("turn-1"));
+    expect(state.getActiveTurnId("t1")).toBeNull();
+
+    state.observe(commandStarted("turn-1"));
+    expect(state.getActiveTurnId("t1")).toBe("turn-1");
+
+    state.observe(turnCompleted("turn-1"));
+    expect(state.getActiveTurnId("t1")).toBeNull();
+  });
+
+  it("does not reopen from delegated child work or while a turn is active", () => {
+    const state = new RuntimeTurnState();
+    state.observe(commandStarted("child-turn", { parentToolCallId: "tool-1" }));
+    expect(state.getActiveTurnId("t1")).toBeNull();
+
+    state.observe(turnStarted("turn-2"));
+    state.observe(commandStarted("turn-1"));
+    expect(state.getActiveTurnId("t1")).toBe("turn-2");
+  });
+});
+
 describe("RuntimeTurnReplayFilter", () => {
   it("marks replayed turn starts as drops", () => {
     const filter = new RuntimeTurnReplayFilter();

--- a/packages/agent-runtime/src/runtime-turn-state.ts
+++ b/packages/agent-runtime/src/runtime-turn-state.ts
@@ -1,5 +1,8 @@
 import type { ThreadEvent } from "@bb/domain";
-import { requireThreadEventScopeTurnId } from "@bb/domain";
+import {
+  getThreadEventScopeTurnId,
+  requireThreadEventScopeTurnId,
+} from "@bb/domain";
 
 interface PendingActiveTurnWaiter {
   resolve: (turnId: string | null) => void;
@@ -92,6 +95,24 @@ export class RuntimeTurnState {
       if (this.activeTurnIdByThreadId.get(event.threadId) === turnId) {
         this.activeTurnIdByThreadId.delete(event.threadId);
       }
+      return;
+    }
+
+    // A provider can resume root work on a turn it already reported as
+    // completed (Codex hook/compaction continuations). Reopen the turn from
+    // that work so stop/steer can still target it.
+    if (
+      event.type === "item/started" &&
+      event.item.type !== "userMessage" &&
+      !event.item.parentToolCallId &&
+      !this.activeTurnIdByThreadId.has(event.threadId)
+    ) {
+      const turnId = getThreadEventScopeTurnId(event.scope);
+      if (turnId === undefined) {
+        return;
+      }
+      this.activeTurnIdByThreadId.set(event.threadId, turnId);
+      this.resolveWaiters(event.threadId, turnId);
     }
   }
 

--- a/packages/agent-runtime/src/runtime-turn-state.ts
+++ b/packages/agent-runtime/src/runtime-turn-state.ts
@@ -1,6 +1,7 @@
 import type { ThreadEvent } from "@bb/domain";
 import {
   getThreadEventScopeTurnId,
+  isTurnReopeningWorkItem,
   requireThreadEventScopeTurnId,
 } from "@bb/domain";
 
@@ -103,8 +104,7 @@ export class RuntimeTurnState {
     // that work so stop/steer can still target it.
     if (
       event.type === "item/started" &&
-      event.item.type !== "userMessage" &&
-      !event.item.parentToolCallId &&
+      isTurnReopeningWorkItem(event.item) &&
       !this.activeTurnIdByThreadId.has(event.threadId)
     ) {
       const turnId = getThreadEventScopeTurnId(event.scope);

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -707,6 +707,16 @@ function createAgentRuntimeInternal(
     if (event.type === "provider/error" && event.willRetry !== true) {
       pendingTurnStartThreadIds.delete(event.threadId);
       markHostedProviderSessionIdle(event.threadId);
+      return;
+    }
+
+    // Root work that reopens a completed turn (see RuntimeTurnState) means the
+    // provider session is busy again; it must not be reaped as idle.
+    if (
+      event.type === "item/started" &&
+      turnState.getActiveTurnId(event.threadId) !== null
+    ) {
+      markProviderSessionNotIdle(event.threadId);
     }
   }
 

--- a/packages/domain/src/provider-event.ts
+++ b/packages/domain/src/provider-event.ts
@@ -380,6 +380,21 @@ export const threadEventItemSchema = z.discriminatedUnion("type", [
   threadEventBackgroundTaskItemSchema,
 ]);
 export type ThreadEventItem = z.infer<typeof threadEventItemSchema>;
+
+/**
+ * True when a started item is root foreground work: something the agent does
+ * inside a turn, as opposed to user input, delegated child work, or a
+ * background task that may outlive the turn. Both the server and the daemon
+ * runtime use this to decide that provider work on a completed turn reopens
+ * that turn.
+ */
+export function isTurnReopeningWorkItem(item: ThreadEventItem): boolean {
+  return (
+    item.type !== "userMessage" &&
+    item.type !== "backgroundTask" &&
+    !item.parentToolCallId
+  );
+}
 export type ThreadEventItemType = ThreadEventItem["type"];
 
 /**


### PR DESCRIPTION
Fixes #1646

## Problem

Codex can keep streaming root work (`commandExecution`, `fileChange`, `agentMessage`, `reasoning`) on a turn it already reported with `turn/completed`, then complete that turn a second time. The store proves this: BB rejects turn-scoped content for a turn with no stored `turn/started` (409), and the idle-gap items in the report were persisted, so they used an already-started turn id. BB only derived thread status from `turn/started` and `turn/completed`, so:

- the thread showed `idle` (no spinner, `bb thread wait --status idle` returned early) while commands ran;
- the daemon held no active turn, so `thread/stop` was a no-op and idle-session reaping could target the busy provider session.

## Change

- **Server** (`apps/server/src/internal/events.ts`): a root `item/started` on an idle thread for a turn that already has a stored `turn/completed`, with no `system/thread/interrupted` after that completion, applies `run.started` again. The next `turn/completed` settles the thread to `idle` as before.
- **Daemon** (`packages/agent-runtime/src/runtime-turn-state.ts`, `runtime.ts`): `RuntimeTurnState` reopens the active turn from that work so stop/steer target it, and the provider session is marked busy again.

No wire format change; no `HOST_DAEMON_PROTOCOL_VERSION` bump.

## Tests

- `apps/server/test/internal/internal-event-append-ownership.test.ts`: reactivation on late provider work; stopped thread stays idle.
- `packages/agent-runtime/src/runtime-turn-state.test.ts`: reopen from root work; ignore delegated child work and active turns.
- `pnpm exec turbo run typecheck/test --filter=@bb/agent-runtime --filter=@bb/server` pass (one pre-existing unrelated failure in `internal-skill-trees.test.ts` from a local umask file mode).

> AGENT GENERATED: by Claude Opus 5
