### PR TITLE
Align new-thread panel opener chrome

### DIFF
--- a/apps/app/src/views/RootComposeRightPanelToggle.test.tsx
+++ b/apps/app/src/views/RootComposeRightPanelToggle.test.tsx
@@ -25,7 +25,7 @@ describe("RootComposeRightPanelToggle", () => {
     ).toEqual({ inlinePanelToggle: "button", showPinnedToggle: false });
   });
 
-  it("uses a disclosure state without painting the whole click target as selected", () => {
+  it("matches shared panel chrome without painting the click target as selected", () => {
     const onToggle = vi.fn();
 
     render(<RootComposeRightPanelToggle isOpen onToggle={onToggle} />);
@@ -35,6 +35,9 @@ describe("RootComposeRightPanelToggle", () => {
     expect(button.getAttribute("aria-pressed")).toBeNull();
     expect(button.className).toContain("h-[28px]");
     expect(button.className).toContain("w-[28px]");
+    expect(button.className).toContain("text-subtle-foreground/75");
+    expect(button.className).toContain("hover:text-muted-foreground");
+    expect(button.getAttribute("data-state")).toBeNull();
 
     fireEvent.click(button);
     expect(onToggle).toHaveBeenCalledOnce();

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/components/dialogs/ProjectMachineSetupDialog";
 import type { ReuseThreadOption } from "@/components/pickers/WorktreePicker";
 import { HEADER_ICON_BUTTON_CLASS } from "@/components/layout/AppPageHeader";
+import { CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS } from "@/components/ui/chromeStyleTokens";
 import { AppCommandShortcutHint } from "@/components/commands/AppCommandShortcutHint";
 import type { SecondaryPanelFileTab } from "@/components/secondary-panel/ThreadSecondaryPanel";
 import { FilePreview } from "@/components/secondary-panel/FilePreview";
@@ -344,7 +345,7 @@ export function RootComposeRightPanelToggle({
       type="button"
       variant="ghost"
       size="icon"
-      className={`${HEADER_ICON_BUTTON_CLASS} relative`}
+      className={`${HEADER_ICON_BUTTON_CLASS} ${CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS} relative`}
       aria-label={
         shortcut ? `${rightPanelLabel} (${shortcut.label})` : rightPanelLabel
       }


### PR DESCRIPTION
## Summary

- Give the closed new-thread right-panel opener the same subtle foreground token used by thread panel controls and the open panel's Hide control.
- Preserve the existing 28px target, disclosure semantics, pinned placement, shortcut, compact drawer behavior, and handoff to panel-owned chrome.
- Add a focused regression assertion for the shared resting and hover foreground classes.

## Rationale and boundary

Thread and new-thread pages already share `SecondaryPanelLayout` and `ThreadSecondaryPanel` for width persistence, responsive drawer behavior, tabs, Browser/Terminal bodies, focus lifecycle, and resize seams. This patch stays at the new-thread wrapper boundary and changes no shared panel internals.

The new-thread page intentionally keeps its own pinned opener while the panel is closed because it has no shared page header. When open, the shared panel owns Hide and New Tab. It also intentionally omits thread-only Info, Diff, and Full Screen actions. Navigation-panel plugins remain page-header-owned and are outside this patch.

This PR is standalone on `main`. It does not depend on the plugin right-panel stack (#1546 → #1553) or the thread split-pane PR (#1601), and it has no file overlap with either.

## Verification

- Focused Vitest: `RootComposeRightPanelToggle.test.tsx` and `RootComposeSecondaryContent.test.tsx` — 10 tests passed.
- `turbo run typecheck --filter=@bb/app` — passed.
- Targeted ESLint and Prettier checks — passed.
- `git diff --check` — passed.
- Exact-branch BB desktop app plus browser-driven real interface at 390×844, 768×900, 1440×900, and 3440×1440 — passed.
- 767/768/769 responsive transition and five open/close cycles per representative viewport — passed.

BB-Thread-ID: thr_bwikffmsvp

> AGENT GENERATED: by GPT-5.6 Sol
