### PR TITLE
Show voice input when the running composer expands

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -3403,7 +3403,7 @@ export function PromptBoxInternal({
                     ) : null}
                     {voice &&
                     !showVoiceActionGroup &&
-                    !showVoiceAsPrimaryAction ? (
+                    (!showVoiceAsPrimaryAction || showStop) ? (
                       <Button
                         data-promptbox-expanded-only=""
                         type="button"


### PR DESCRIPTION
## Summary

- preserve the single Stop action while the running composer is collapsed
- show the existing neutral voice action alongside Stop once the composer expands

## Validation

- `pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/PromptBoxInternal.test.tsx` (97 existing tests passed)
- `pnpm exec turbo run typecheck --filter=@bb/app`
- Prettier and diff checks passed
- visually verified collapsed and expanded states with dev-browser under coarse-pointer emulation

> AGENT GENERATED: by GPT-5