### PR TITLE
Match the new-thread tabbed panel to thread panels

### DIFF
--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -362,7 +362,10 @@ export function ThreadSecondaryPanel({
   const togglePanelShortcut = useAppCommandShortcut("panel.toggle");
   const diffShortcut = useAppCommandShortcut("diff.toggle");
   const activeFileTab = fileTabs?.find((tab) => tab.isActive);
-  const visibleFileTabs = fileTabs?.filter((tab) => tab.isHidden !== true);
+  const visibleFileTabs = useMemo(
+    () => fileTabs?.filter((tab) => tab.isHidden !== true),
+    [fileTabs],
+  );
   const hasActiveFileTab = activeFileTab !== undefined;
   const isTerminalTabActive =
     activeTab?.kind === "terminal" && hasActiveFileTab;

--- a/apps/app/src/views/RootComposeView.test.ts
+++ b/apps/app/src/views/RootComposeView.test.ts
@@ -23,6 +23,7 @@ import { subscribeComposerFocusRequests } from "@/lib/composer-focus-requests";
 import { getProjectStoredPromptAttachmentPaths } from "@/lib/prompt-draft";
 import { THREAD_HANDOFF_CREATE_SEED_LOCATION_STATE_KEY } from "@/lib/thread-handoff-request";
 import {
+  buildRootComposeNewTabFileTab,
   buildRootComposeTerminalSessions,
   buildMobileRecentThreads,
   canCreateRootComposeTerminal,
@@ -32,6 +33,7 @@ import {
   readInitialPromptFromLocationState,
   requestRootComposePluginFocus,
   resolveRootComposePanelThreadId,
+  shouldHideRootComposePanelOnTabClose,
   shouldReplaceInitialPromptFromLocationState,
   shouldStartComposingFromLocationState,
   shouldNavigateAfterThreadCreate,
@@ -58,6 +60,46 @@ describe("requestRootComposePluginFocus", () => {
 
     expect(focusRequests).toBe(1);
     unsubscribe();
+  });
+});
+
+describe("new-thread right-panel tabs", () => {
+  it("renders the launcher as the same visible, closable tab used by threads", () => {
+    const onClose = () => undefined;
+    const onSelect = () => undefined;
+    const tab = buildRootComposeNewTabFileTab({
+      activeTabId: "new-tab",
+      onClose,
+      onSelect,
+      tabId: "new-tab",
+    });
+
+    expect(tab.filename).toBe("New tab");
+    expect(tab.isActive).toBe(true);
+    expect(tab.isHidden).toBeUndefined();
+    expect(tab.onClose).toBe(onClose);
+    expect(tab.onSelect).toBe(onSelect);
+  });
+
+  it("hides the panel only when its launcher is the sole remaining tab", () => {
+    expect(
+      shouldHideRootComposePanelOnTabClose({
+        tabCount: 1,
+        tabKind: "new-tab",
+      }),
+    ).toBe(true);
+    expect(
+      shouldHideRootComposePanelOnTabClose({
+        tabCount: 2,
+        tabKind: "new-tab",
+      }),
+    ).toBe(false);
+    expect(
+      shouldHideRootComposePanelOnTabClose({
+        tabCount: 1,
+        tabKind: "browser",
+      }),
+    ).toBe(false);
   });
 });
 

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -121,7 +121,10 @@ import {
   useTouchFixedPanelTabsState,
   useUpdateFixedPanelTabsState,
 } from "@/lib/fixed-panel-tabs";
-import { createNewTabFixedPanelTab } from "@/lib/fixed-panel-tabs-state";
+import {
+  createNewTabFixedPanelTab,
+  type SecondaryFileFixedPanelTab,
+} from "@/lib/fixed-panel-tabs-state";
 import type { ThreadSecondaryPanel as ThreadSecondaryPanelTab } from "@/lib/thread-secondary-panel";
 import {
   getFilePreviewLineRangeStart,
@@ -301,6 +304,23 @@ interface RootComposeRightPanelToggleProps {
   onToggle: () => void;
 }
 
+interface ShouldHideRootComposePanelOnTabCloseArgs {
+  tabCount: number;
+  tabKind: SecondaryFileFixedPanelTab["kind"];
+}
+
+/**
+ * Root compose has no fixed Info view to reveal after its last launcher tab
+ * closes. Keep the launcher mounted and hide the panel instead, matching the
+ * existing Cmd+W behavior while making the visible close control honest.
+ */
+export function shouldHideRootComposePanelOnTabClose({
+  tabCount,
+  tabKind,
+}: ShouldHideRootComposePanelOnTabCloseArgs): boolean {
+  return tabKind === "new-tab" && tabCount === 1;
+}
+
 export function resolveRootComposePanelTogglePlacement(args: {
   isHosted: boolean;
   isOpen: boolean;
@@ -319,6 +339,37 @@ export function resolveRootComposePanelTogglePlacement(args: {
 
 interface RightPanelFileTabIconProps {
   path: string;
+}
+
+interface BuildRootComposeNewTabFileTabArgs {
+  activeTabId: string | null;
+  onClose: () => void;
+  onSelect: () => void;
+  tabId: string;
+}
+
+/** The root launcher uses the same visible tab-pill model as thread panels. */
+export function buildRootComposeNewTabFileTab({
+  activeTabId,
+  onClose,
+  onSelect,
+  tabId,
+}: BuildRootComposeNewTabFileTabArgs): SecondaryPanelFileTab {
+  return {
+    id: tabId,
+    filename: "New tab",
+    isActive: tabId === activeTabId,
+    leadingVisual: (
+      <Icon
+        name="NewTab"
+        className={COARSE_POINTER_COMPACT_ICON_SIZE_CLASS}
+        aria-hidden
+      />
+    ),
+    statusLabel: null,
+    onSelect,
+    onClose,
+  };
 }
 
 function RightPanelFileTabIcon({ path }: RightPanelFileTabIconProps) {
@@ -1577,6 +1628,8 @@ function RootComposeSurface({
       rootPanelTerminalTarget,
     ],
   );
+  const secondaryFileTabCount =
+    fixedPanelTabsState.secondary.tabs.filter(isSecondaryFileTab).length;
   const handleCloseWindowRequest = useCallback(() => {
     // Gate on the visible panel state, not the persisted flag: on compact
     // viewports the drawer can be dismissed while tabs stay persisted, and
@@ -1592,8 +1645,10 @@ function RootComposeSurface({
       // whenever the panel would otherwise be empty), so hide the panel
       // instead of churning the placeholder.
       if (
-        activeFixedSecondaryTab.kind === "new-tab" &&
-        fixedPanelTabsState.secondary.tabs.length === 1
+        shouldHideRootComposePanelOnTabClose({
+          tabCount: secondaryFileTabCount,
+          tabKind: activeFixedSecondaryTab.kind,
+        })
       ) {
         closeSecondaryPanel();
         return true;
@@ -1613,10 +1668,25 @@ function RootComposeSurface({
     activeFixedSecondaryTab,
     closeSecondaryPanel,
     closeTab,
-    fixedPanelTabsState.secondary.tabs,
     handleCloseTerminalTab,
     isSecondaryPanelOpen,
+    secondaryFileTabCount,
   ]);
+  const handleCloseNewTab = useCallback(
+    (tabId: string) => {
+      if (
+        shouldHideRootComposePanelOnTabClose({
+          tabCount: secondaryFileTabCount,
+          tabKind: "new-tab",
+        })
+      ) {
+        closeSecondaryPanel();
+        return;
+      }
+      closeTab(tabId);
+    },
+    [closeSecondaryPanel, closeTab, secondaryFileTabCount],
+  );
   const fileTabs = (() => {
     const filenameOf = (path: string) => path.split("/").at(-1) ?? path;
     const tabs = syncedOrderedSecondaryFileTabs.map(
@@ -1695,22 +1765,12 @@ function RootComposeSurface({
               onClose: () => closeTab(tab.id),
             };
           case "new-tab":
-            return {
-              id: tab.id,
-              filename: "New tab",
-              isHidden: true,
-              isActive: tab.id === activeFixedSecondaryTabId,
-              leadingVisual: (
-                <Icon
-                  name="NewTab"
-                  className={COARSE_POINTER_COMPACT_ICON_SIZE_CLASS}
-                  aria-hidden
-                />
-              ),
-              statusLabel: null,
+            return buildRootComposeNewTabFileTab({
+              activeTabId: activeFixedSecondaryTabId,
+              onClose: () => handleCloseNewTab(tab.id),
               onSelect: () => handleActivateFileTab(tab.id),
-              onClose: () => closeTab(tab.id),
-            };
+              tabId: tab.id,
+            });
           case "plugin-panel": {
             const actionIcon =
               rootPanelNewThreadPanelActions.find(
@@ -2366,6 +2426,9 @@ function RootComposeSurface({
             renderBrowserDeck,
             isBrowserTabActive,
             isOpen: isSecondaryPanelOpen,
+            // The shell, tab strip, launcher, resize, and drawer behavior are
+            // shared with threads. Info, Diff, and conversation full-screen
+            // stay thread-only because no thread exists on this surface yet.
             showConversationCollapseControl: false,
             showGitDiffTab: false,
             showInfoTab: false,

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -1687,7 +1687,7 @@ function RootComposeSurface({
     },
     [closeSecondaryPanel, closeTab, secondaryFileTabCount],
   );
-  const fileTabs = (() => {
+  const fileTabs = useMemo(() => {
     const filenameOf = (path: string) => path.split("/").at(-1) ?? path;
     const tabs = syncedOrderedSecondaryFileTabs.map(
       (tab): SecondaryPanelFileTab => {
@@ -1798,7 +1798,17 @@ function RootComposeSurface({
       },
     );
     return tabs.length > 0 ? tabs : undefined;
-  })();
+  }, [
+    activeFixedSecondaryTabId,
+    closeTab,
+    handleActivateFileTab,
+    handleActivateTerminalTab,
+    handleCloseNewTab,
+    handleCloseTerminalTab,
+    rootPanelNewThreadPanelActions,
+    syncedOrderedSecondaryFileTabs,
+    terminalsById,
+  ]);
   const { isLocalDaemonHost } = useHostDaemon();
   const activeWorkspaceEnvironmentQuery = useEnvironment(
     activeWorkspaceFileEnvironmentId,


### PR DESCRIPTION
## Summary

- render the new-thread launcher as a normal active `New tab` pill in the shared right-panel tab strip
- keep the shared add-tab, tab-close, resize, hide, and responsive drawer interactions aligned with thread panels
- hide the panel when its lone launcher tab is closed, avoiding an immediate close-and-respawn loop

## Why

Root compose was explicitly marking its launcher tab as hidden. The panel therefore opened to an unlabeled launcher body with only a bare `+`, even though it already used the same panel shell as thread pages.

This replaces closed PR #1700, which changed only the external opener color and did not address the requested tabbed panel.

## Intentional differences

The new-thread surface still omits Info, Diff, and conversation full-screen controls because there is no materialized thread, thread metadata, or conversation pane yet. The panel shell, tab strip, launcher, resizing, hide control, persistence, and compact drawer remain shared.

## Verification

- focused `@bb/app` panel tests — 73 tests passed
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed
- `pnpm exec turbo run lint --filter=@bb/app` — passed with repository baseline warnings and no errors
- changed-file ESLint for `RootComposeView.tsx` and its test — passed with no findings
- real BB UI at 390×844, 768×900, 1440×900, and 3440×1440 — visible active `New tab`, adjacent add-tab control, lone-tab close behavior, and five open/close cycles passed
- `git diff --check` — passed

BB-Thread-ID: thr_bwikffmsvp

> AGENT GENERATED: by GPT-5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/get-bb/codesmith/bb/pr/1715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789594897&installation_model_id=432835&pr_number=1715&repository=get-bb%2Fbb&return_to=https%3A%2F%2Fgithub.com%2Fget-bb%2Fbb%2Fpull%2F1715&signature=ab96e0f8229a393a4bf8523dd3578325ddd32583e5ae1b636c0f1f3cdc379272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->