### PR TITLE
Improve model picker loading state

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -150,6 +150,7 @@ function renderPicker({
   alternateProviderModels,
   providerRouting,
   selectedProviderId = "codex",
+  modelIsLoading = false,
   compact = false,
   splitPane = false,
 }: {
@@ -165,6 +166,7 @@ function renderPicker({
   alternateProviderModels?: AvailableModel[];
   providerRouting?: SystemProvidersQuery;
   selectedProviderId?: string;
+  modelIsLoading?: boolean;
   compact?: boolean;
   splitPane?: boolean;
 } = {}) {
@@ -197,6 +199,7 @@ function renderPicker({
         modelValue={modelValue}
         modelOptions={modelOptions}
         moreModelOptions={moreModelOptions}
+        modelIsLoading={modelIsLoading}
         onModelChange={onModelChange}
         reasoningValue={reasoningValue}
         reasoningOptions={pickerReasoningOptions}
@@ -237,6 +240,33 @@ afterEach(() => {
 });
 
 describe("ModelReasoningPicker", () => {
+  it("holds the trigger and model-list layout with skeletons while loading", () => {
+    renderPicker({
+      modelOptions: [],
+      modelValue: "",
+      pickerReasoningOptions: [],
+      modelIsLoading: true,
+    });
+    const trigger = screen.getByRole("button", {
+      name: "Provider, model and reasoning",
+    });
+
+    expect(
+      trigger.querySelectorAll("[data-model-loading-placeholder]"),
+    ).toHaveLength(2);
+    expect(trigger.textContent).not.toContain("Loading models...");
+
+    fireEvent.click(trigger);
+
+    const loadingStatus = screen.getByRole("status", {
+      name: "Loading models",
+    });
+    expect(
+      loadingStatus.querySelectorAll("[data-model-loading-row]"),
+    ).toHaveLength(4);
+    expect(screen.queryByText("Loading models…")).toBeNull();
+  });
+
   it("cycles models backward from a Tab-focused composer control", () => {
     const { onModelChange } = renderPicker({
       modelOptions: [

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -31,6 +31,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@bb/shared-ui/popover";
+import { Skeleton } from "@bb/shared-ui/skeleton";
 import { Switch } from "@bb/shared-ui/switch";
 import { LIST_HOVER_TRANSITION } from "@bb/shared-ui/motion";
 import {
@@ -791,7 +792,8 @@ export function ModelReasoningPicker({
     return () => window.cancelAnimationFrame(frame);
   }, [open, isCompactViewport, isPointerCoarse]);
 
-  const TriggerIcon = hasSelectedModel ? ProviderIcon : undefined;
+  const TriggerIcon =
+    hasSelectedModel || modelIsLoading ? ProviderIcon : undefined;
   const triggerTitleModelLabel = modelIsLoading
     ? "Loading models..."
     : selectedModelLoadFailed
@@ -830,7 +832,30 @@ export function ModelReasoningPicker({
       )}
     >
       <span className={OPTION_TRIGGER_CONTENT_CLASS_NAME} title={triggerTitle}>
-        {showSelectedFastMode ? (
+        {modelIsLoading ? (
+          <>
+            {TriggerIcon ? (
+              <TriggerIcon className="size-3.5 shrink-0" />
+            ) : (
+              <Icon
+                name="Spinner"
+                className="size-3.5 shrink-0 animate-spin text-muted-foreground"
+                aria-hidden
+              />
+            )}
+            <span className="sr-only">Loading models</span>
+            <Skeleton
+              aria-hidden
+              data-model-loading-placeholder="trigger-model"
+              className="h-3 w-10 shrink-0 rounded-sm"
+            />
+            <Skeleton
+              aria-hidden
+              data-model-loading-placeholder="trigger-reasoning"
+              className="h-3 w-8 shrink-0 rounded-sm"
+            />
+          </>
+        ) : showSelectedFastMode ? (
           <Icon
             name="Zap"
             className="size-3.5 shrink-0 fill-current text-subtle-foreground"
@@ -838,28 +863,31 @@ export function ModelReasoningPicker({
         ) : TriggerIcon ? (
           <TriggerIcon className="size-3.5 shrink-0" />
         ) : null}
-        <span
-          className={cn(
-            "min-w-0 truncate",
-            modelIsLoading && "animate-shine whitespace-nowrap",
-            triggerModelValueIsDestructive && "text-destructive-text",
-          )}
-        >
-          {triggerModelBase}
-        </span>
-        {triggerModelTag ? (
-          <span className="shrink-0 text-subtle-foreground">
-            {triggerModelTag}
-          </span>
-        ) : null}
-        {triggerReasoningLabel ? (
-          <span
-            className="shrink-0 text-subtle-foreground"
-            data-promptbox-hide-compact=""
-          >
-            {triggerReasoningLabel}
-          </span>
-        ) : null}
+        {modelIsLoading ? null : (
+          <>
+            <span
+              className={cn(
+                "min-w-0 truncate",
+                triggerModelValueIsDestructive && "text-destructive-text",
+              )}
+            >
+              {triggerModelBase}
+            </span>
+            {triggerModelTag ? (
+              <span className="shrink-0 text-subtle-foreground">
+                {triggerModelTag}
+              </span>
+            ) : null}
+            {triggerReasoningLabel ? (
+              <span
+                className="shrink-0 text-subtle-foreground"
+                data-promptbox-hide-compact=""
+              >
+                {triggerReasoningLabel}
+              </span>
+            ) : null}
+          </>
+        )}
       </span>
       {disabled ? null : (
         <Icon
@@ -983,14 +1011,7 @@ export function ModelReasoningPicker({
               <MenuSectionLabel>Model</MenuSectionLabel>
             )}
             {activeModelIsLoading ? (
-              <div
-                className={cn(
-                  "px-2 text-xs text-muted-foreground",
-                  isCompactViewport ? "py-2" : "py-[0.3125rem]",
-                )}
-              >
-                Loading models…
-              </div>
+              <ModelPickerLoadingRows />
             ) : hasActiveModelOptions ? (
               <>
                 {navRows.map((row, index) => {
@@ -1157,6 +1178,33 @@ function MenuSectionLabel({ children }: { children: ReactNode }) {
       )}
     >
       {children}
+    </div>
+  );
+}
+
+const MODEL_LOADING_ROW_WIDTHS = ["w-20", "w-28", "w-24", "w-32"] as const;
+
+function ModelPickerLoadingRows() {
+  const isCompactViewport = useIsCompactViewport();
+
+  return (
+    <div role="status" aria-label="Loading models" className="pb-1">
+      <span className="sr-only">Loading models</span>
+      {MODEL_LOADING_ROW_WIDTHS.map((widthClassName) => (
+        <div
+          key={widthClassName}
+          data-model-loading-row=""
+          aria-hidden
+          className={cn(
+            "flex items-center rounded-sm px-2",
+            isCompactViewport ? "py-2" : "py-[0.3125rem]",
+          )}
+        >
+          <Skeleton
+            className={cn("h-3 max-w-[75%] rounded-sm", widthClassName)}
+          />
+        </div>
+      ))}
     </div>
   );
 }

--- a/apps/app/src/hooks/queries/system-queries.test.tsx
+++ b/apps/app/src/hooks/queries/system-queries.test.tsx
@@ -76,6 +76,26 @@ afterEach(() => {
 });
 
 describe("useSystemExecutionOptions", () => {
+  it("preloads built-in provider identities while their models are loading", () => {
+    vi.mocked(sdk.system.executionOptions).mockImplementation(
+      () => new Promise(() => undefined),
+    );
+    const { wrapper } = createQueryClientTestHarness();
+
+    const { result } = renderHook(
+      () => useSystemExecutionOptions({ providerId: "codex" }),
+      { wrapper },
+    );
+
+    expect(result.current.isPlaceholderData).toBe(true);
+    expect(result.current.data?.models).toEqual([]);
+    expect(
+      result.current.data?.providers.some(
+        (provider) => provider.id === "codex",
+      ),
+    ).toBe(true);
+  });
+
   it("separates requests and cache entries for different hosts", async () => {
     vi.mocked(sdk.system.executionOptions).mockImplementation(async (args) =>
       args?.hostId === "host-a"

--- a/apps/app/src/hooks/queries/system-queries.ts
+++ b/apps/app/src/hooks/queries/system-queries.ts
@@ -153,8 +153,14 @@ const PLACEHOLDER_PROVIDER_INFOS: ProviderInfo[] = [
     },
     composerActions: [
       { kind: "skills", trigger: "/" },
-      { kind: "plan", command: { trigger: "/", name: "plan", trailingText: " " } },
-      { kind: "goal", command: { trigger: "/", name: "goal", trailingText: " " } },
+      {
+        kind: "plan",
+        command: { trigger: "/", name: "plan", trailingText: " " },
+      },
+      {
+        kind: "goal",
+        command: { trigger: "/", name: "goal", trailingText: " " },
+      },
     ],
   },
   {
@@ -173,7 +179,10 @@ const PLACEHOLDER_PROVIDER_INFOS: ProviderInfo[] = [
     },
     composerActions: [
       { kind: "skills", trigger: "/" },
-      { kind: "plan", command: { trigger: "/", name: "plan", trailingText: " " } },
+      {
+        kind: "plan",
+        command: { trigger: "/", name: "plan", trailingText: " " },
+      },
     ],
   },
   {
@@ -209,6 +218,19 @@ const PLACEHOLDER_PROVIDER_INFOS: ProviderInfo[] = [
     composerActions: [{ kind: "skills", trigger: "/" }],
   },
 ];
+
+// Seed only the stable identities from the same built-in placeholder catalog
+// used by the server. This keeps the picker branded while model discovery runs;
+// the authoritative response still replaces it and adds configured providers.
+function builtInProviderPlaceholderExecutionOptions(): SystemExecutionOptionsResponse {
+  return {
+    providers: PLACEHOLDER_PROVIDER_INFOS,
+    models: [],
+    selectedOnlyModels: [],
+    permissionCeiling: "full",
+    modelLoadError: null,
+  };
+}
 
 // Claude's account-scoped model probe spawns a CLI process on the host, so
 // waiting for it leaves the composer with no model list for seconds. Render a
@@ -333,6 +355,9 @@ export function useSystemExecutionOptions(
   const enabled = args.enabled ?? true;
   useSystemRealtimeSubscription({ enabled });
   const isClaudeCode = providerId === CLAUDE_CODE_PROVIDER_ID;
+  const canPreloadBuiltInProviders =
+    providerId === null ||
+    PLACEHOLDER_PROVIDER_INFOS.some((provider) => provider.id === providerId);
   const catalogCacheKey = claudeModelCatalogCacheKey({
     environmentId,
     hostId,
@@ -367,10 +392,12 @@ export function useSystemExecutionOptions(
     staleTime: 60_000,
     retry: shouldRetrySystemExecutionOptions,
     retryDelay: SYSTEM_EXECUTION_OPTIONS_RETRY_DELAY_MS,
-    ...(isClaudeCode
+    ...(canPreloadBuiltInProviders
       ? {
           placeholderData: () =>
-            claudeCodePlaceholderExecutionOptions(catalogCacheKey),
+            isClaudeCode
+              ? claudeCodePlaceholderExecutionOptions(catalogCacheKey)
+              : builtInProviderPlaceholderExecutionOptions(),
         }
       : {}),
   });

--- a/apps/app/src/hooks/useThreadCreationOptions.test.tsx
+++ b/apps/app/src/hooks/useThreadCreationOptions.test.tsx
@@ -237,6 +237,25 @@ afterEach(() => {
 });
 
 describe("useThreadCreationOptions", () => {
+  it("keeps the selected built-in provider branded while models load", () => {
+    window.localStorage.setItem("bb.promptbox.provider", "codex");
+    vi.mocked(sdk.system.executionOptions).mockImplementation(
+      () => new Promise(() => undefined),
+    );
+
+    const { result } = renderHook(
+      () => useThreadCreationOptions({ scope: "new-thread" }),
+      { wrapper: createQueryClientTestHarness().wrapper },
+    );
+
+    expect(result.current.isLoadingModels).toBe(true);
+    expect(result.current.selectedProviderId).toBe("codex");
+    expect(
+      result.current.providerOptions.find((option) => option.value === "codex")
+        ?.icon,
+    ).toBeDefined();
+  });
+
   it("uses the medium product default for providers without reasoning history", async () => {
     vi.mocked(sdk.system.executionOptions).mockImplementation(async (args) =>
       providerExecutionOptionsResponse(args?.providerId),

--- a/apps/app/src/hooks/useThreadCreationOptions.ts
+++ b/apps/app/src/hooks/useThreadCreationOptions.ts
@@ -315,7 +315,10 @@ export function useThreadCreationOptions(
   const systemConfig = useSystemConfig();
   const providers = executionOptionsQuery.data?.providers ?? EMPTY_PROVIDERS;
   const isLoadingModels =
-    executionOptionsQueryEnabled && executionOptionsQuery.isLoading;
+    executionOptionsQueryEnabled &&
+    (executionOptionsQuery.isLoading ||
+      (executionOptionsQuery.isPlaceholderData &&
+        (executionOptionsQuery.data?.models.length ?? 0) === 0));
   const isResolvingInitialProvider =
     shouldResolveConnectedProvider && connectedAgentsQuery.isPending;
   const modelLoadError =


### PR DESCRIPTION
## Summary

- replace the model picker loading label with trigger and menu skeletons
- keep built-in provider branding visible while model discovery is pending
- preserve the loading state while placeholder provider data is active

## Testing

- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/pickers/ModelReasoningPicker.test.tsx src/hooks/queries/system-queries.test.tsx src/hooks/useThreadCreationOptions.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`

> AGENT GENERATED: by GPT-5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/get-bb/codesmith/bb/pr/1728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789595653&installation_model_id=432835&pr_number=1728&repository=get-bb%2Fbb&return_to=https%3A%2F%2Fgithub.com%2Fget-bb%2Fbb%2Fpull%2F1728&signature=8c8a893d285abd8b26deda7f8d21cc14edd853686bdcd19fd4b921f13a5983d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->