### PR TITLE
Clean up interrupted plugin host build stages

### DIFF
--- a/packages/plugin-build/src/build-plugin-host.test.ts
+++ b/packages/plugin-build/src/build-plugin-host.test.ts
@@ -1,5 +1,12 @@
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -114,6 +121,47 @@ describe("plugin host build", () => {
     expect(builtEntry.default.handlers.echo("from-artifact")).toBe(
       "from-artifact",
     );
+  });
+
+  it("removes host staging directories left by interrupted builds", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "bb-host-stage-cleanup-test-"));
+    tempDirs.push(dir);
+    const distDir = join(dir, "dist");
+    await mkdir(join(distDir, ".host-stage-abandoned"), { recursive: true });
+    await writeFile(
+      join(distDir, ".host-stage-abandoned", "partial-host.js"),
+      "partial artifact\n",
+    );
+    await mkdir(join(distDir, ".stage-app-build"));
+    await writeFile(
+      join(dir, "package.json"),
+      JSON.stringify({
+        name: "bb-plugin-host-stage-cleanup-fixture",
+        version: "1.0.0",
+        engines: { bb: ">=0.0" },
+        bb: {
+          name: "Host stage cleanup fixture",
+          description: "Exercises stale host staging directory cleanup.",
+          branding: { icon: "Cpu" },
+          server: "./server.ts",
+          host: "./host.ts",
+        },
+      }),
+    );
+    await writeFile(
+      join(dir, "server.ts"),
+      "export default function plugin() {}\n",
+    );
+    await writeFile(join(dir, "host.ts"), "export default {};\n");
+
+    await buildPluginHost(dir, "0.9.0-test", await testToolchain());
+
+    const distEntries = await readdir(distDir);
+    expect(distEntries).not.toContain(".host-stage-abandoned");
+    expect(distEntries).toContain(".stage-app-build");
+    expect(
+      distEntries.filter((entry) => entry.startsWith(".host-stage-")),
+    ).toEqual([]);
   });
 
   it("rejects a host entry outside the plugin directory", async () => {

--- a/packages/plugin-build/src/build-plugin-host.ts
+++ b/packages/plugin-build/src/build-plugin-host.ts
@@ -3,6 +3,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  readdir,
   rename,
   rm,
   stat,
@@ -23,6 +24,7 @@ const NODE_ESM_REQUIRE_BANNER = [
 ].join("\n");
 
 const PLUGIN_SDK_HOST_RUNTIME_NAMESPACE = "bb-host-sdk-runtime";
+const HOST_STAGE_DIRECTORY_PREFIX = ".host-stage-";
 
 // Managed plugins are installed with production dependencies only. The SDK
 // is intentionally a development/type dependency for plugin authors, so the
@@ -267,6 +269,23 @@ export interface PluginHostBuildResult {
   artifactDigest: string;
 }
 
+async function removeStaleHostStageDirectories(
+  distDir: string,
+): Promise<void> {
+  const entries = await readdir(distDir, { withFileTypes: true });
+  await Promise.all(
+    entries
+      .filter(
+        (entry) =>
+          entry.isDirectory() &&
+          entry.name.startsWith(HOST_STAGE_DIRECTORY_PREFIX),
+      )
+      .map((entry) =>
+        rm(join(distDir, entry.name), { recursive: true, force: true }),
+      ),
+  );
+}
+
 /** Build the optional Node host entry into a self-contained remote artifact. */
 export async function buildPluginHost(
   rootDir: string,
@@ -280,7 +299,8 @@ export async function buildPluginHost(
   const jsPath = join(distDir, "host.js");
   const mapPath = join(distDir, "host.js.map");
   const metaPath = join(distDir, "host.meta.json");
-  const stageDir = await mkdtemp(join(distDir, ".host-stage-"));
+  await removeStaleHostStageDirectories(distDir);
+  const stageDir = await mkdtemp(join(distDir, HOST_STAGE_DIRECTORY_PREFIX));
   try {
     const stagedJsPath = join(stageDir, "host.js");
     const stagedMetaPath = join(stageDir, "host.meta.json");


### PR DESCRIPTION
## Summary

- remove abandoned dist/.host-stage-* directories before the next host build creates its staging directory
- leave unrelated dist staging directories untouched
- add regression coverage for cleanup of a non-empty interrupted stage

## Testing

- pnpm exec turbo run test --filter=@bb/plugin-build --force
- pnpm exec turbo run typecheck --filter=@bb/plugin-build

Fixes #1726

> AGENT GENERATED: by GPT-5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/get-bb/codesmith/bb/pr/1730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789595990&installation_model_id=432835&pr_number=1730&repository=get-bb%2Fbb&return_to=https%3A%2F%2Fgithub.com%2Fget-bb%2Fbb%2Fpull%2F1730&signature=2f164407a9fca0dab6cfdb96777638e406137d3dec2699fa4efeadab704d54ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->