### PR TITLE
Widen Blacksmith acknowledgement image to 400px

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,4 +222,4 @@ package again, or run `npm rebuild better-sqlite3`.
 
 ## Acknowledgements
 
-<a href="https://blacksmith.sh"><img src="assets/blacksmith-ci.png" alt="CI powered by Blacksmith" width="240"></a>
+<a href="https://blacksmith.sh"><img src="assets/blacksmith-ci.png" alt="CI powered by Blacksmith" width="400"></a>


### PR DESCRIPTION
Bumps the "CI powered by Blacksmith" image in the README Acknowledgements section from 240px to 400px wide. Follow-up to #1737.

> AGENT GENERATED: by Claude Opus 5