### PR TITLE
Fix thread mentions in reused worktrees

### DIFF
--- a/apps/app/src/components/promptbox/NewThreadComposer.tsx
+++ b/apps/app/src/components/promptbox/NewThreadComposer.tsx
@@ -853,9 +853,9 @@ export function NewThreadComposer({
   const promptMentions = usePromptMentions(
     isProjectless ? undefined : projectId,
     {
-      currentThreadId: panelThreadId ?? undefined,
       environmentId: reuseEnvironmentId,
       hostId: projectHostId,
+      threadStorageThreadId: panelThreadId ?? undefined,
     },
   );
   const defaultMentionLinkResolver = useCallback<PromptMentionLinkResolver>(

--- a/apps/app/src/components/thread/embedded-chat/useComposerTypeahead.ts
+++ b/apps/app/src/components/thread/embedded-chat/useComposerTypeahead.ts
@@ -47,6 +47,7 @@ export function useComposerTypeahead({
   const promptMentions = usePromptMentions(mentionsProjectId ?? projectId, {
     currentThreadId,
     environmentId,
+    threadStorageThreadId: currentThreadId,
   });
   const [commandQuery, setCommandQuery] = useState<string | null>(null);
   const providerPromptActions = useMemo(

--- a/apps/app/src/hooks/usePromptMentions.thread-context.test.tsx
+++ b/apps/app/src/hooks/usePromptMentions.thread-context.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from "@testing-library/react";
+import type { Thread } from "@bb/domain";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { usePromptMentions } from "./usePromptMentions";
+
+const mocks = vi.hoisted(() => ({
+  usePathSuggestions: vi.fn(),
+  usePluginContributions: vi.fn(),
+  usePluginMentionSearch: vi.fn(),
+  useSidebarNavigation: vi.fn(),
+  useThreadMentionCandidates: vi.fn(),
+}));
+
+vi.mock("./usePathSuggestions", () => ({
+  PATH_SUGGESTION_DEBOUNCE_MS: 0,
+  usePathSuggestions: mocks.usePathSuggestions,
+}));
+
+vi.mock("./queries/plugin-contribution-queries", () => ({
+  usePluginContributions: mocks.usePluginContributions,
+  usePluginMentionSearch: mocks.usePluginMentionSearch,
+}));
+
+vi.mock("./queries/sidebar-navigation-query", () => ({
+  useSidebarNavigation: mocks.useSidebarNavigation,
+}));
+
+vi.mock("./queries/thread-queries", () => ({
+  useThreadMentionCandidates: mocks.useThreadMentionCandidates,
+}));
+
+function makeThread(): Thread {
+  return {
+    id: "thr_existing",
+    projectId: "proj_1",
+    environmentId: "env_worktree",
+    providerId: "codex",
+    title: "Only worktree thread",
+    titleFallback: null,
+    sectionId: null,
+    status: "idle",
+    parentThreadId: null,
+    sourceThreadId: null,
+    originKind: null,
+    originPluginId: null,
+    visibility: "visible",
+    archivedAt: null,
+    pinnedAt: null,
+    deletedAt: null,
+    lastReadAt: null,
+    latestAttentionAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+beforeEach(() => {
+  mocks.usePathSuggestions.mockReturnValue({
+    suggestions: [],
+    isLoading: false,
+    isError: false,
+    isDebouncing: false,
+  });
+  mocks.usePluginContributions.mockReturnValue({
+    data: { mentionProviders: [] },
+  });
+  mocks.usePluginMentionSearch.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+  });
+  mocks.useSidebarNavigation.mockReturnValue({ data: undefined });
+  mocks.useThreadMentionCandidates.mockReturnValue({
+    data: [makeThread()],
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+  });
+});
+
+describe("usePromptMentions thread contexts", () => {
+  it("can mention the only thread in a reused worktree while searching its storage", () => {
+    const { result } = renderHook(() =>
+      usePromptMentions("proj_1", {
+        environmentId: "env_worktree",
+        threadStorageThreadId: "thr_existing",
+      }),
+    );
+
+    act(() => {
+      result.current.setQuery("Only worktree", "@");
+    });
+
+    expect(result.current.suggestions).toEqual([
+      expect.objectContaining({
+        kind: "thread",
+        threadId: "thr_existing",
+      }),
+    ]);
+    expect(mocks.usePathSuggestions).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        currentThreadId: "thr_existing",
+        environmentId: "env_worktree",
+      }),
+    );
+  });
+});

--- a/apps/app/src/hooks/usePromptMentions.ts
+++ b/apps/app/src/hooks/usePromptMentions.ts
@@ -32,7 +32,10 @@ import {
 const PROMPT_MENTION_SOURCE_LIMIT = 8;
 
 export interface UsePromptMentionsOptions {
+  /** Existing thread that owns the composer and must not mention itself. */
   currentThreadId?: string;
+  /** Thread whose storage files are available to the composer. */
+  threadStorageThreadId?: string;
   environmentId: string | null;
   hostId?: string | null;
 }
@@ -170,7 +173,7 @@ export function usePromptMentions(
     limit: PROMPT_MENTION_SOURCE_LIMIT,
     environmentId: options.environmentId,
     hostId: options.hostId,
-    currentThreadId: options.currentThreadId,
+    currentThreadId: options.threadStorageThreadId,
     includeDirectories: true,
   });
   const projectNamesQuery = useSidebarNavigation({


### PR DESCRIPTION
## Summary
- keep the representative reused-worktree thread available as an @-mention target
- separate composer self-exclusion from the thread used for storage-file suggestions
- add regression coverage for a reused worktree with exactly one thread

## Root cause
The new-thread composer passed the reused worktree representative thread as currentThreadId. The mention builder correctly excludes currentThreadId, so a worktree with one thread had no thread mention candidates.

## Validation
- full @bb/app test suite: 353 files, 2,802 tests passed
- @bb/app typecheck passed
- @bb/app lint passed with the existing warning baseline and no errors
- Prettier check passed

> AGENT GENERATED: by GPT-5