### PR TITLE
Use tabular numerals for duration counters

### DIFF
--- a/apps/app/src/components/dialogs/AddMachineDialog.tsx
+++ b/apps/app/src/components/dialogs/AddMachineDialog.tsx
@@ -243,7 +243,7 @@ function AddMachineDialogContent({
                   </Button>
                 </>
               ) : remainingMs !== null ? (
-                <span className="text-xs text-subtle-foreground">
+                <span className="text-xs tabular-nums text-subtle-foreground">
                   Code expires in {formatCountdown(remainingMs)}
                 </span>
               ) : null}

--- a/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
@@ -69,7 +69,9 @@ function BackgroundActivityDuration({ startedAt }: { startedAt: number }) {
   if (elapsed <= 1_000) {
     return null;
   }
-  return <>{durationToCompactString(elapsed)}</>;
+  return (
+    <span className="tabular-nums">{durationToCompactString(elapsed)}</span>
+  );
 }
 
 function BackgroundActivitySummary({

--- a/apps/app/src/components/promptbox/banner/ThreadGoalCard.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadGoalCard.tsx
@@ -155,7 +155,7 @@ export function ThreadGoalCard({
                 />
                 {formatTokenUsage(goal)}
               </span>
-              <span className="inline-flex items-center gap-1.5">
+              <span className="inline-flex items-center gap-1.5 tabular-nums">
                 <Icon
                   name="Clock"
                   className="size-3.5 shrink-0"

--- a/apps/app/src/components/thread/timeline/TimelineTitleView.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineTitleView.tsx
@@ -242,8 +242,8 @@ function renderDecoration(
   switch (decoration.kind) {
     case "duration": {
       const durationClass = decoration.em
-        ? cn("shrink-0 whitespace-pre", emToneClass(tone))
-        : baseClass;
+        ? cn("shrink-0 whitespace-pre tabular-nums", emToneClass(tone))
+        : cn(baseClass, "tabular-nums");
       return (
         <span key={index} className={durationClass}>
           {decoration.completedAt !== null ? (
@@ -275,7 +275,9 @@ function renderDecoration(
               "inline-flex items-baseline gap-1",
             )}
           >
-            {durationText ? <span>{durationText}</span> : null}
+            {durationText ? (
+              <span className="tabular-nums">{durationText}</span>
+            ) : null}
             {renderStatusDecorationText(
               decoration.status,
               // Only an emphasized error — one that is the row's primary signal,


### PR DESCRIPTION
## Summary

- apply tabular numerals to live and completed timeline durations
- stabilize background activity, goal elapsed-time, and machine-code countdown digits
- preserve the existing duration formatting and update cadence

## Testing

- pnpm exec turbo run test --filter=@bb/app -- --run src/components/promptbox/banner/ThreadGoalCard.test.tsx src/components/dialogs/AddMachineDialog.test.tsx
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app (zero errors; existing warnings remain)

> AGENT GENERATED: by GPT-5