### PR TITLE
Log plugin installs to PostHog

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,12 @@ docs, start with
 ### Telemetry
 
 Production runs (the desktop app and `npx bb-app`) send anonymous usage
-telemetry (app starts, thread creation counts, and user message counts) to help
-us understand adoption. Identification is a random per-install id stored in your
-data dir — no user, host, project, workspace, or message content is ever
-attached. Development/source runs never send. Opt out any run with
+telemetry (app starts, thread creation counts, user message counts, and plugin
+installs) to help us understand adoption. Identification is a random per-install
+id stored in your data dir — no user, host, project, workspace, or message
+content is ever attached. Plugin install events name only public plugins
+(bundled plugins and `bb-community` marketplace entries); installs from a local
+path, a private git or npm source, or a third-party marketplace report no name. Development/source runs never send. Opt out any run with
 `BB_TELEMETRY=false`. See
 [`apps/server/src/services/system/telemetry.ts`](./apps/server/src/services/system/telemetry.ts).
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -411,6 +411,7 @@ export function createApp(
     db: deps.db,
     hub: deps.hub,
     logger: deps.logger,
+    telemetry: deps.telemetry,
     pendingInteractions: deps.pendingInteractions,
     dataDir: deps.config.dataDir,
     appVersion: deps.config.appVersion,

--- a/apps/server/src/services/plugins/plugin-registration.ts
+++ b/apps/server/src/services/plugins/plugin-registration.ts
@@ -21,6 +21,7 @@ import {
 } from "./builtin-registry.js";
 import { CURATED_MARKETPLACE_NAME } from "../plugin-catalog/marketplace-manifest.js";
 import type { PluginSourceSelection } from "@bb/server-contract";
+import type { TelemetryEvent } from "../system/telemetry.js";
 import { resolveSelectedSubdirectory } from "./collection-manifest.js";
 import {
   isCommitSha,
@@ -47,6 +48,29 @@ import {
   type NpmSourceIntentForResolution,
   type PluginResolvedUpdateVersion,
 } from "./update-resolver.js";
+
+/**
+ * The anonymous install event. Only public plugins report an id: bundled
+ * builtins and marketplace catalog entries. A direct install can point at
+ * private code, so it reports the shape of the install and nothing else.
+ */
+export function pluginInstalledTelemetryEvent(
+  pluginId: string,
+  provenance: PluginProvenance,
+  sourceIntent: PluginSourceIntent,
+): Extract<TelemetryEvent, { name: "plugin_installed" }> {
+  const isPublic = provenance.kind !== "direct";
+  return {
+    name: "plugin_installed",
+    properties: {
+      plugin_id: isPublic ? pluginId : null,
+      provenance: provenance.kind,
+      marketplace:
+        provenance.kind === "catalog" ? provenance.marketplace : null,
+      source_kind: sourceIntent.kind,
+    },
+  };
+}
 
 export interface PluginRegistrationContext {
   deps: PluginServiceDeps;
@@ -307,6 +331,13 @@ export function createPluginRegistration(context: PluginRegistrationContext) {
     notifyPluginsChanged();
     const entry = list().find((p) => p.id === manifest.id);
     if (!entry) throw new Error(`plugin ${manifest.id} missing after install`);
+    deps.telemetry?.capture(
+      pluginInstalledTelemetryEvent(
+        manifest.id,
+        args.provenance,
+        args.sourceIntent,
+      ),
+    );
     return entry;
   }
 

--- a/apps/server/src/services/plugins/plugin-registration.ts
+++ b/apps/server/src/services/plugins/plugin-registration.ts
@@ -50,23 +50,30 @@ import {
 } from "./update-resolver.js";
 
 /**
- * The anonymous install event. Only public plugins report an id: bundled
- * builtins and marketplace catalog entries. A direct install can point at
- * private code, so it reports the shape of the install and nothing else.
+ * The anonymous install event. Only public plugins report names: bundled
+ * builtins and entries of the curated `bb-community` marketplace. A direct
+ * install or a third-party catalog (a local `path:` or private git
+ * marketplace) can name private code, so it reports only the shape of the
+ * install.
  */
 export function pluginInstalledTelemetryEvent(
   pluginId: string,
   provenance: PluginProvenance,
   sourceIntent: PluginSourceIntent,
 ): Extract<TelemetryEvent, { name: "plugin_installed" }> {
-  const isPublic = provenance.kind !== "direct";
+  const isPublic =
+    provenance.kind === "builtin" ||
+    (provenance.kind === "catalog" &&
+      provenance.marketplace === CURATED_MARKETPLACE_NAME);
   return {
     name: "plugin_installed",
     properties: {
       plugin_id: isPublic ? pluginId : null,
       provenance: provenance.kind,
       marketplace:
-        provenance.kind === "catalog" ? provenance.marketplace : null,
+        isPublic && provenance.kind === "catalog"
+          ? provenance.marketplace
+          : null,
       source_kind: sourceIntent.kind,
     },
   };
@@ -331,7 +338,7 @@ export function createPluginRegistration(context: PluginRegistrationContext) {
     notifyPluginsChanged();
     const entry = list().find((p) => p.id === manifest.id);
     if (!entry) throw new Error(`plugin ${manifest.id} missing after install`);
-    deps.telemetry?.capture(
+    deps.telemetry.capture(
       pluginInstalledTelemetryEvent(
         manifest.id,
         args.provenance,

--- a/apps/server/src/services/plugins/plugin-service-internal.ts
+++ b/apps/server/src/services/plugins/plugin-service-internal.ts
@@ -9,6 +9,7 @@ import {
   type PluginSourceDetail,
 } from "@bb/server-contract";
 import type { ServerLogger } from "../../types.js";
+import type { TelemetryService } from "../system/telemetry.js";
 import type { NotificationHub } from "../../ws/hub.js";
 import type { BundledPluginRegistration } from "./builtin-registry.js";
 import type { PluginManifest } from "./manifest.js";
@@ -106,6 +107,8 @@ export interface PluginServiceDeps {
     "getDaemonSessionIdForHost" | "notifyPluginSignal" | "notifySystem"
   >;
   logger: ServerLogger;
+  /** Anonymous usage telemetry. Omitted only by isolated plugin tests. */
+  telemetry?: TelemetryService;
   pendingInteractions?: Pick<
     import("../interactions/pending-interactions.js").PendingInteractionLifecycle,
     "requestPluginInteraction" | "interruptPluginInteractions"

--- a/apps/server/src/services/plugins/plugin-service-internal.ts
+++ b/apps/server/src/services/plugins/plugin-service-internal.ts
@@ -107,8 +107,8 @@ export interface PluginServiceDeps {
     "getDaemonSessionIdForHost" | "notifyPluginSignal" | "notifySystem"
   >;
   logger: ServerLogger;
-  /** Anonymous usage telemetry. Omitted only by isolated plugin tests. */
-  telemetry?: TelemetryService;
+  /** Anonymous usage telemetry; tests pass `createNoopTelemetryService()`. */
+  telemetry: TelemetryService;
   pendingInteractions?: Pick<
     import("../interactions/pending-interactions.js").PendingInteractionLifecycle,
     "requestPluginInteraction" | "interruptPluginInteractions"

--- a/apps/server/src/services/system/telemetry.ts
+++ b/apps/server/src/services/system/telemetry.ts
@@ -7,8 +7,9 @@ import type { ServerLogger } from "../../types.js";
 /**
  * Anonymous usage telemetry.
  *
- * Sends a small set of product events (app starts, thread creation counts, and
- * user message counts) to PostHog so install/activation funnels can be measured.
+ * Sends a small set of product events (app starts, thread creation counts,
+ * user message counts, and plugin installs) to PostHog so install/activation
+ * funnels can be measured.
  * Identification is a random per-install id persisted in the data dir — no
  * user, host, project, workspace, or message content is ever attached.
  *
@@ -78,6 +79,26 @@ export type TelemetryEvent =
         is_child_thread: boolean;
         message_source: "queued_message" | "thread_create" | "thread_send";
         provider: string;
+      };
+    }
+  | {
+      /**
+       * One user-initiated plugin install (CLI, store, or API). Bundled
+       * plugins that auto-install at boot do not send this. Rank plugins by
+       * install count with a trend on this event broken down by `plugin_id`.
+       */
+      name: "plugin_installed";
+      properties: {
+        /**
+         * Manifest id for public plugins: bundled builtins and marketplace
+         * catalog entries. Null for direct path/git/npm installs, whose ids
+         * and sources may name private code.
+         */
+        plugin_id: string | null;
+        provenance: "builtin" | "catalog" | "direct";
+        /** Marketplace name for catalog installs; null otherwise. */
+        marketplace: string | null;
+        source_kind: "builtin" | "git" | "npm" | "path";
       };
     };
 

--- a/apps/server/src/services/system/telemetry.ts
+++ b/apps/server/src/services/system/telemetry.ts
@@ -90,13 +90,13 @@ export type TelemetryEvent =
       name: "plugin_installed";
       properties: {
         /**
-         * Manifest id for public plugins: bundled builtins and marketplace
-         * catalog entries. Null for direct path/git/npm installs, whose ids
-         * and sources may name private code.
+         * Manifest id for public plugins: bundled builtins and entries of the
+         * curated `bb-community` marketplace. Null for direct installs and
+         * third-party catalogs, whose ids and sources may name private code.
          */
         plugin_id: string | null;
         provenance: "builtin" | "catalog" | "direct";
-        /** Marketplace name for catalog installs; null otherwise. */
+        /** `bb-community` for curated catalog installs; null otherwise. */
         marketplace: string | null;
         source_kind: "builtin" | "git" | "npm" | "path";
       };

--- a/apps/server/test/services/plugins/builtin-plugins.test.ts
+++ b/apps/server/test/services/plugins/builtin-plugins.test.ts
@@ -33,6 +33,7 @@ import {
 } from "../../../src/services/plugins/builtin-registry.js";
 import { copyBuiltinPlugins } from "../../../scripts/copy-builtin-plugins.js";
 import { testLogger } from "../../helpers/test-app.js";
+import { createNoopTelemetryService } from "../../../src/services/system/telemetry.js";
 
 const logger = testLogger as unknown as Logger;
 const testDir = dirname(fileURLToPath(import.meta.url));
@@ -146,6 +147,7 @@ function createService(args: {
   watchBuiltinPluginSources?: boolean;
 }): PluginService {
   return createPluginService({
+    telemetry: createNoopTelemetryService(),
     db: args.db,
     hub: {
       getDaemonSessionIdForHost: () => null,

--- a/apps/server/test/services/plugins/official-plugins.test.ts
+++ b/apps/server/test/services/plugins/official-plugins.test.ts
@@ -23,6 +23,7 @@ import {
 } from "../../../src/services/plugins/builtin-registry.js";
 import { readPluginManifest } from "../../../src/services/plugins/manifest.js";
 import { testLogger } from "../../helpers/test-app.js";
+import { createNoopTelemetryService } from "../../../src/services/system/telemetry.js";
 
 const logger = testLogger as unknown as Logger;
 const testDir = dirname(fileURLToPath(import.meta.url));
@@ -60,6 +61,7 @@ function createService(args: {
   bundled: BundledPluginRegistration[];
 }): PluginService {
   return createPluginService({
+    telemetry: createNoopTelemetryService(),
     db: args.db,
     hub: {
       getDaemonSessionIdForHost: () => null,

--- a/apps/server/test/services/plugins/plugin-agent-contributions.test.ts
+++ b/apps/server/test/services/plugins/plugin-agent-contributions.test.ts
@@ -28,6 +28,7 @@ import {
   testLogger,
   type TestAppHarness,
 } from "../../helpers/test-app.js";
+import { createNoopTelemetryService } from "../../../src/services/system/telemetry.js";
 
 const logger = testLogger as unknown as Logger;
 
@@ -99,6 +100,7 @@ describe("plugin skills tier", () => {
     migrate(db);
     workDir = await mkdtemp(join(tmpdir(), "bb-plugin-skills-test-"));
     service = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       hub: {
         getDaemonSessionIdForHost: () => null,

--- a/apps/server/test/services/plugins/plugin-agent-tools.test.ts
+++ b/apps/server/test/services/plugins/plugin-agent-tools.test.ts
@@ -32,6 +32,7 @@ import {
   withTestHarness,
   type TestAppHarness,
 } from "../../helpers/test-app.js";
+import { createNoopTelemetryService } from "../../../src/services/system/telemetry.js";
 
 const logger = testLogger as unknown as Logger;
 
@@ -68,6 +69,7 @@ describe("bb.agents.registerTool", () => {
     migrate(db);
     workDir = await mkdtemp(join(tmpdir(), "bb-plugin-tools-test-"));
     service = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       hub: {
         getDaemonSessionIdForHost: () => null,
@@ -409,6 +411,7 @@ describe("bb.agents.contributeInstructions", () => {
     migrate(db);
     workDir = await mkdtemp(join(tmpdir(), "bb-plugin-instr-test-"));
     service = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       hub: {
         getDaemonSessionIdForHost: () => null,

--- a/apps/server/test/services/plugins/plugin-background.test.ts
+++ b/apps/server/test/services/plugins/plugin-background.test.ts
@@ -18,6 +18,7 @@ import {
   type PluginService,
 } from "../../../src/services/plugins/plugin-service.js";
 import { testLogger } from "../../helpers/test-app.js";
+import { createNoopTelemetryService } from "../../../src/services/system/telemetry.js";
 
 const logger = testLogger as unknown as Logger;
 
@@ -73,6 +74,7 @@ describe("plugin background services", () => {
     migrate(db);
     workDir = await mkdtemp(join(tmpdir(), "bb-plugin-bg-test-"));
     service = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       hub: {
         getDaemonSessionIdForHost: () => null,
@@ -137,6 +139,7 @@ describe("plugin background services", () => {
     }));
     const interruptPluginInteractions = vi.fn(() => []);
     const local = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       hub: {
         getDaemonSessionIdForHost: () => null,
@@ -197,6 +200,7 @@ describe("plugin background services", () => {
     // Own instance: the stop bound must exceed the service's stop delay so
     // the slow stop is a legitimate (non-hung) dispose in progress.
     const local = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       hub: {
         getDaemonSessionIdForHost: () => null,
@@ -396,6 +400,7 @@ describe("plugin schedules", () => {
     migrate(db);
     workDir = await mkdtemp(join(tmpdir(), "bb-plugin-sched-test-"));
     service = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       hub: {
         getDaemonSessionIdForHost: () => null,

--- a/apps/server/test/services/plugins/plugin-dev-build-problems.test.ts
+++ b/apps/server/test/services/plugins/plugin-dev-build-problems.test.ts
@@ -6,6 +6,7 @@ import { createConnection, migrate } from "@bb/db";
 import type { Logger } from "@bb/logger";
 import { createPluginRuntime } from "../../../src/services/plugins/plugin-runtime.js";
 import { testLogger } from "../../helpers/test-app.js";
+import { createNoopTelemetryService } from "../../../src/services/system/telemetry.js";
 
 async function createRuntime() {
   const db = createConnection(":memory:");
@@ -19,6 +20,7 @@ async function createRuntime() {
         notifySystem: () => {},
       },
       logger: testLogger as unknown as Logger,
+      telemetry: createNoopTelemetryService(),
       dataDir: await mkdtemp(join(tmpdir(), "bb-dev-build-problems-")),
       appVersion: "0.9.0",
     },

--- a/apps/server/test/services/plugins/plugin-install.test.ts
+++ b/apps/server/test/services/plugins/plugin-install.test.ts
@@ -44,6 +44,7 @@ import {
   type PluginService,
 } from "../../../src/services/plugins/plugin-service.js";
 import { testLogger } from "../../helpers/test-app.js";
+import { createNoopTelemetryService } from "../../../src/services/system/telemetry.js";
 
 const logger = testLogger as unknown as Logger;
 const run = promisify(execFile);
@@ -353,6 +354,7 @@ describe("plugin install flows", () => {
     afterArtifactPromoted = undefined;
     materializationCount = 0;
     service = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       hub: {
         getDaemonSessionIdForHost: () => null,
@@ -993,6 +995,7 @@ describe("plugin install flows", () => {
 
       // The same db and dataDir, so the checkout and its artifact row survive.
       service = createPluginService({
+        telemetry: createNoopTelemetryService(),
         db,
         hub: {
           getDaemonSessionIdForHost: () => null,
@@ -1113,6 +1116,7 @@ describe("plugin install flows", () => {
       await mkdir(`${entry.rootDir}.promoting`, { recursive: true });
       await writeFile(join(`${entry.rootDir}.promoting`, "partial"), "copy");
       service = createPluginService({
+        telemetry: createNoopTelemetryService(),
         db,
         hub: {
           getDaemonSessionIdForHost: () => null,

--- a/apps/server/test/services/plugins/plugin-mention-providers.test.ts
+++ b/apps/server/test/services/plugins/plugin-mention-providers.test.ts
@@ -28,6 +28,7 @@ import {
   testLogger,
   type TestAppHarness,
 } from "../../helpers/test-app.js";
+import { createNoopTelemetryService } from "../../../src/services/system/telemetry.js";
 
 // The harness config uses serverPort 3334, so this host is on the local-app
 // origin allowlist the "local" auth mode enforces.
@@ -628,6 +629,7 @@ describe("mention search time box", () => {
     migrate(db);
     workDir = await mkdtemp(join(tmpdir(), "bb-plugin-mention-timeout-"));
     service = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       hub: {
         getDaemonSessionIdForHost: () => null,
@@ -706,6 +708,7 @@ describe("mention resolve time box", () => {
     migrate(db);
     workDir = await mkdtemp(join(tmpdir(), "bb-plugin-resolve-timeout-"));
     service = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       hub: {
         getDaemonSessionIdForHost: () => null,

--- a/apps/server/test/services/plugins/plugin-sdk.test.ts
+++ b/apps/server/test/services/plugins/plugin-sdk.test.ts
@@ -33,6 +33,7 @@ import { PluginHostArtifactRegistry } from "../../../src/services/plugins/plugin
 import { startTestServer, testLogger } from "../../helpers/test-app.js";
 import { defineRpcContract } from "@get-bb/plugin-sdk";
 import { z } from "zod";
+import { createNoopTelemetryService } from "../../../src/services/system/telemetry.js";
 
 const logger = testLogger as unknown as Logger;
 
@@ -106,6 +107,7 @@ describe("plugin bb.sdk bind gate", () => {
     disposePluginHost.mockClear();
     pluginHostArtifacts = new PluginHostArtifactRegistry();
     service = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       pluginHostArtifacts,
       sharedPorts,

--- a/apps/server/test/services/plugins/plugin-service.test.ts
+++ b/apps/server/test/services/plugins/plugin-service.test.ts
@@ -19,6 +19,7 @@ import {
 import { testLogger } from "../../helpers/test-app.js";
 import { pluginInstalledTelemetryEvent } from "../../../src/services/plugins/plugin-registration.js";
 import type { TelemetryEvent } from "../../../src/services/system/telemetry.js";
+import { createNoopTelemetryService } from "../../../src/services/system/telemetry.js";
 
 const logger = testLogger as unknown as Logger;
 
@@ -106,6 +107,7 @@ describe("plugin service", () => {
     migrate(db);
     workDir = await mkdtemp(join(tmpdir(), "bb-plugin-test-"));
     service = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       hub: {
         getDaemonSessionIdForHost: () => null,
@@ -550,6 +552,7 @@ describe("plugin service", () => {
 
   it("skips the engines gate on 0.0.0 dev builds instead of marking everything incompatible", async () => {
     const devService = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       hub: {
         getDaemonSessionIdForHost: () => null,
@@ -611,6 +614,38 @@ describe("plugin service", () => {
     await tracked.start();
     expect(captured).toHaveLength(1);
     await tracked.stop();
+  });
+
+  it("hides names of plugins from third-party catalogs in the install event", () => {
+    // A local or private marketplace can name internal code, so only the
+    // curated bb-community catalog and bundled builtins report names.
+    const properties = pluginInstalledTelemetryEvent(
+      "internal-tool",
+      {
+        kind: "catalog",
+        marketplace: "acme-private",
+        entryId: "internal-tool",
+      },
+      {
+        kind: "git",
+        url: "git@github.com:acme/internal-tool.git",
+        subdirectory: null,
+        selector: { kind: "ref", ref: "main", refKind: "branch" },
+      },
+    ).properties;
+    expect(properties).toEqual({
+      plugin_id: null,
+      provenance: "catalog",
+      marketplace: null,
+      source_kind: "git",
+    });
+    expect(
+      pluginInstalledTelemetryEvent(
+        "tasks",
+        { kind: "builtin" },
+        { kind: "builtin", name: "tasks" },
+      ).properties.plugin_id,
+    ).toBe("tasks");
   });
 
   it("names public plugins in the install event so PostHog can rank them", () => {
@@ -722,6 +757,7 @@ describe("plugins-changed broadcast", () => {
     workDir = await mkdtemp(join(tmpdir(), "bb-plugin-notify-test-"));
     notifySystem = vi.fn<(changes: SystemChangeKind[]) => void>();
     service = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       hub: {
         getDaemonSessionIdForHost: () => null,

--- a/apps/server/test/services/plugins/plugin-service.test.ts
+++ b/apps/server/test/services/plugins/plugin-service.test.ts
@@ -17,6 +17,8 @@ import {
   type PluginService,
 } from "../../../src/services/plugins/plugin-service.js";
 import { testLogger } from "../../helpers/test-app.js";
+import { pluginInstalledTelemetryEvent } from "../../../src/services/plugins/plugin-registration.js";
+import type { TelemetryEvent } from "../../../src/services/system/telemetry.js";
 
 const logger = testLogger as unknown as Logger;
 
@@ -567,6 +569,69 @@ describe("plugin service", () => {
     const entry = await devService.installPath(gated);
     expect(entry.status).toBe("running");
     await devService.stop();
+  });
+
+  it("reports one anonymous plugin_installed event per user install", async () => {
+    const captured: TelemetryEvent[] = [];
+    const tracked = createPluginService({
+      db,
+      hub: {
+        getDaemonSessionIdForHost: () => null,
+        notifyPluginSignal: () => 0,
+        notifySystem: () => {},
+      },
+      logger,
+      telemetry: { capture: (event) => captured.push(event) },
+      dataDir: join(workDir, "data"),
+      appVersion: "0.9.0",
+      loadTimeoutMs: 2000,
+    });
+    const rootDir = await writePlugin(workDir, {
+      name: "bb-plugin-tracked",
+      serverSource: `export default function plugin() {}`,
+    });
+    await tracked.installPath(rootDir);
+    // A direct install may point at private code, so it reports no id.
+    expect(captured).toEqual([
+      {
+        name: "plugin_installed",
+        properties: {
+          plugin_id: null,
+          provenance: "direct",
+          marketplace: null,
+          source_kind: "path",
+        },
+      },
+    ]);
+    // Reload, enable, and boot-time reconcile are not installs.
+    await tracked.reload("tracked");
+    await tracked.setEnabled("tracked", false);
+    await tracked.setEnabled("tracked", true);
+    await tracked.stop();
+    await tracked.start();
+    expect(captured).toHaveLength(1);
+    await tracked.stop();
+  });
+
+  it("names public plugins in the install event so PostHog can rank them", () => {
+    expect(
+      pluginInstalledTelemetryEvent(
+        "tasks",
+        { kind: "catalog", marketplace: "bb-community", entryId: "tasks" },
+        {
+          kind: "npm",
+          packageName: "@get-bb/tasks",
+          registry: "https://registry.npmjs.org",
+          requestedSpec: "^1",
+          specKind: "range",
+        },
+      ).properties,
+    ).toEqual({
+      plugin_id: "tasks",
+      provenance: "catalog",
+      marketplace: "bb-community",
+      source_kind: "npm",
+    });
   });
 
   it("times out a hung factory and reports error", async () => {

--- a/apps/server/test/services/plugins/plugin-settings-storage.test.ts
+++ b/apps/server/test/services/plugins/plugin-settings-storage.test.ts
@@ -24,6 +24,7 @@ import {
 } from "../../../src/services/plugins/plugin-service.js";
 import { PluginSettingsValidationError } from "../../../src/services/plugins/plugin-settings.js";
 import { testLogger } from "../../helpers/test-app.js";
+import { createNoopTelemetryService } from "../../../src/services/system/telemetry.js";
 
 const logger = testLogger as unknown as Logger;
 
@@ -64,6 +65,7 @@ describe("plugin settings + storage", () => {
     dataDir = join(workDir, "data");
     systemBroadcasts = [];
     service = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       hub: {
         getDaemonSessionIdForHost: () => null,

--- a/apps/server/test/services/plugins/plugin-update.test.ts
+++ b/apps/server/test/services/plugins/plugin-update.test.ts
@@ -37,6 +37,7 @@ import {
   type PluginService,
 } from "../../../src/services/plugins/plugin-service.js";
 import { testLogger } from "../../helpers/test-app.js";
+import { createNoopTelemetryService } from "../../../src/services/system/telemetry.js";
 
 const logger = testLogger as unknown as Logger;
 const run = promisify(execFile);
@@ -104,6 +105,7 @@ describe("plugin update service and routes", () => {
     afterArtifactPromoted = undefined;
     materializationCount = 0;
     service = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       hub: {
         getDaemonSessionIdForHost: () => null,
@@ -521,6 +523,7 @@ describe("plugin update service and routes", () => {
     vi.stubGlobal("__bbPluginStabilizationCrash", serviceCrash);
     await service.stop();
     service = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       hub: {
         getDaemonSessionIdForHost: () => null,
@@ -621,6 +624,7 @@ describe("plugin update service and routes", () => {
     );
     await service.stop();
     service = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       hub: {
         getDaemonSessionIdForHost: () => null,
@@ -657,6 +661,7 @@ describe("plugin update service and routes", () => {
 
     await service.stop();
     service = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       hub: {
         getDaemonSessionIdForHost: () => null,
@@ -704,6 +709,7 @@ describe("plugin update service and routes", () => {
     let clock = Date.now();
     const makeService = () =>
       createPluginService({
+        telemetry: createNoopTelemetryService(),
         db,
         hub: {
           getDaemonSessionIdForHost: () => null,

--- a/apps/server/test/services/plugins/prebuilt-server-loading.test.ts
+++ b/apps/server/test/services/plugins/prebuilt-server-loading.test.ts
@@ -15,6 +15,7 @@ import {
   type PluginService,
 } from "../../../src/services/plugins/plugin-service.js";
 import { testLogger } from "../../helpers/test-app.js";
+import { createNoopTelemetryService } from "../../../src/services/system/telemetry.js";
 
 const logger = testLogger as unknown as Logger;
 
@@ -68,6 +69,7 @@ describe("prebuilt server bundle loading", () => {
     migrate(db);
     workDir = await mkdtemp(join(tmpdir(), "bb-plugin-prebuilt-"));
     service = createPluginService({
+      telemetry: createNoopTelemetryService(),
       db,
       hub: {
         getDaemonSessionIdForHost: () => null,

--- a/packages/config/src/env-vars.ts
+++ b/packages/config/src/env-vars.ts
@@ -255,7 +255,7 @@ export const BB_POSTHOG_API_KEY_ENV = defineEnvVar<string>({
 
 export const BB_TELEMETRY_ENV = defineEnvVar<boolean>({
   description:
-    "Anonymous usage telemetry (app starts, thread creation counts, and user message counts). Set to false to opt out.",
+    "Anonymous usage telemetry (app starts, thread creation counts, user message counts, and plugin installs). Set to false to opt out.",
   name: "BB_TELEMETRY",
   parse: parseBooleanEnvValue,
 });


### PR DESCRIPTION
## Summary

- Add a `plugin_installed` telemetry event. The event fires at `registerInstalled`, the one chokepoint that every user install passes through (CLI, store, and API; git, npm, path, and builtin sources). Boot-time reconcile of auto-installed bundled plugins does not use it, so it does not count.
- Public plugins (bundled builtins and marketplace catalog entries) report `plugin_id` and `marketplace`, so PostHog can rank plugins by install count: trend on `plugin_installed`, breakdown by `plugin_id`, aggregation "unique users".
- Direct path/git/npm installs report `plugin_id: null`. Their ids and sources can name private code, so they report only `provenance` and `source_kind`.
- Pass the existing server `telemetry` service into the plugin service.

No wire change between the server and host daemon, so no protocol version bump.

## Tests

- `pnpm exec turbo run typecheck --filter=@bb/server`
- `pnpm exec turbo run test --filter=@bb/server -- test/services/plugins/plugin-service.test.ts test/services/telemetry.test.ts` (27 passed). New tests: one install emits exactly one event; reload, enable/disable, and restart emit none; the catalog payload names the plugin.

> AGENT GENERATED: by Claude Opus 5