### PR TITLE
Preserve active plugin host build stages

### DIFF
--- a/packages/plugin-build/src/build-plugin-host.test.ts
+++ b/packages/plugin-build/src/build-plugin-host.test.ts
@@ -123,15 +123,17 @@ describe("plugin host build", () => {
     );
   });
 
-  it("removes host staging directories left by interrupted builds", async () => {
+  it("removes abandoned host stages without touching a live process", async () => {
     const dir = await mkdtemp(join(tmpdir(), "bb-host-stage-cleanup-test-"));
     tempDirs.push(dir);
     const distDir = join(dir, "dist");
+    const activeStageName = `.host-stage-${process.ppid}-active`;
     await mkdir(join(distDir, ".host-stage-abandoned"), { recursive: true });
     await writeFile(
       join(distDir, ".host-stage-abandoned", "partial-host.js"),
       "partial artifact\n",
     );
+    await mkdir(join(distDir, activeStageName));
     await mkdir(join(distDir, ".stage-app-build"));
     await writeFile(
       join(dir, "package.json"),
@@ -158,10 +160,11 @@ describe("plugin host build", () => {
 
     const distEntries = await readdir(distDir);
     expect(distEntries).not.toContain(".host-stage-abandoned");
+    expect(distEntries).toContain(activeStageName);
     expect(distEntries).toContain(".stage-app-build");
     expect(
       distEntries.filter((entry) => entry.startsWith(".host-stage-")),
-    ).toEqual([]);
+    ).toEqual([activeStageName]);
   });
 
   it("rejects a host entry outside the plugin directory", async () => {

--- a/packages/plugin-build/src/build-plugin-host.ts
+++ b/packages/plugin-build/src/build-plugin-host.ts
@@ -269,6 +269,28 @@ export interface PluginHostBuildResult {
   artifactDigest: string;
 }
 
+function hostStageOwnerIsAlive(entryName: string): boolean {
+  const ownerMatch = /^(\d+)-/u.exec(
+    entryName.slice(HOST_STAGE_DIRECTORY_PREFIX.length),
+  );
+  if (ownerMatch === null) return false;
+  const ownerPid = Number(ownerMatch[1]);
+  if (!Number.isSafeInteger(ownerPid) || ownerPid <= 0) return false;
+  if (ownerPid === process.pid) return true;
+  try {
+    process.kill(ownerPid, 0);
+    return true;
+  } catch (error) {
+    // EPERM also means the process exists. Unknown errors are treated
+    // conservatively so cleanup never removes a possibly active build.
+    return !(
+      error instanceof Error &&
+      "code" in error &&
+      error.code === "ESRCH"
+    );
+  }
+}
+
 async function removeStaleHostStageDirectories(
   distDir: string,
 ): Promise<void> {
@@ -278,7 +300,8 @@ async function removeStaleHostStageDirectories(
       .filter(
         (entry) =>
           entry.isDirectory() &&
-          entry.name.startsWith(HOST_STAGE_DIRECTORY_PREFIX),
+          entry.name.startsWith(HOST_STAGE_DIRECTORY_PREFIX) &&
+          !hostStageOwnerIsAlive(entry.name),
       )
       .map((entry) =>
         rm(join(distDir, entry.name), { recursive: true, force: true }),
@@ -300,7 +323,9 @@ export async function buildPluginHost(
   const mapPath = join(distDir, "host.js.map");
   const metaPath = join(distDir, "host.meta.json");
   await removeStaleHostStageDirectories(distDir);
-  const stageDir = await mkdtemp(join(distDir, HOST_STAGE_DIRECTORY_PREFIX));
+  const stageDir = await mkdtemp(
+    join(distDir, `${HOST_STAGE_DIRECTORY_PREFIX}${process.pid}-`),
+  );
   try {
     const stagedJsPath = join(stageDir, "host.js");
     const stagedMetaPath = join(stageDir, "host.meta.json");


### PR DESCRIPTION
## Summary

- include the builder process id in each `.host-stage-*` directory name
- remove abandoned legacy or dead-process stages while preserving stages owned by a live process
- cover cleanup of an abandoned stage alongside a live stage

## Why

The cleanup added by #1730 removes every matching staging directory before a build. Concurrent integration workers build the same first-party provider artifacts, so one worker can delete another worker stage and cause `ENOENT` while reading or promoting the artifact.

This change was extracted from #1715 so the New Thread panel PR remains scoped to its UI work.

## Verification

- `pnpm exec turbo run test --filter=@bb/plugin-build --force` — 20 passed, 1 skipped
- `pnpm exec turbo run typecheck --filter=@bb/plugin-build --force` — passed
- `pnpm exec turbo run test --filter=@bb/integration-tests --force` — 55 passed
- `git diff --check` — passed

> AGENT GENERATED: by GPT-5