### PR TITLE
Require vendored plugin icons in submit-a-plugin skill

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/submit-a-plugin/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/submit-a-plugin/SKILL.md
@@ -268,9 +268,13 @@ Use this shape as a guide. Confirm every field against the current schema.
 
 ## Add the icon
 
+Always vendor the plugin's icon. Copy the icon file into the marketplace `icons/` directory. Reference only that vendored copy from the entry.
+
+Do not reference a remote URL, a CDN, a `raw.githubusercontent.com` link, or a path in the plugin repository. The marketplace must serve the icon from its own repository, so the icon stays available when the plugin repository changes or moves.
+
 Use the plugin's existing brand icon when it meets the marketplace rules.
 
-The entry can use a supported BB host icon name. It can also use an icon file.
+The entry can use a supported BB host icon name. It can also use a vendored icon file.
 
 Use `.svg`, `.png`, or `.webp` for an icon file. Keep the file at or below 256 KB.
 
@@ -377,6 +381,7 @@ Confirm these facts:
 - The author GitHub name matches the pull request account.
 - The description states the real user value.
 - The icon is clear and follows the size and format rules.
+- The icon file is vendored in `icons/`, and the entry does not reference a remote icon URL.
 - `npm run build` and `npm run check` succeed.
 
 ## Open the pull request


### PR DESCRIPTION
## Summary

- The \`submit-a-plugin\` skill now tells the agent to always vendor the plugin icon into the marketplace \`icons/\` directory.
- The skill forbids remote icon URLs, CDN links, \`raw.githubusercontent.com\` links, and paths into the plugin repository.
- The pre-PR review checklist has a new item for the vendored icon.

## Tests

Documentation-only change to a builtin skill. No tests reference the skill text.

> AGENT GENERATED: by Claude Opus 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)