### PR TITLE
Fix follow-up scroll jumps in long threads

### DIFF
--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx
@@ -25,7 +25,10 @@ import {
   setPluginSlotRegistrations,
   type PluginRegistrationSet,
 } from "@/lib/plugin-slots";
-import { ThreadTimelineRows } from "./ThreadTimelineRows";
+import {
+  ThreadTimelineRows,
+  timelineHeightSnapRevision,
+} from "./ThreadTimelineRows";
 
 function messageActionRegistrationSet(
   messageActions: readonly PluginMessageActionRegistration[],
@@ -264,6 +267,53 @@ afterEach(() => {
   cleanup();
   resetPluginSlotStoreForTest();
   vi.restoreAllMocks();
+});
+
+describe("timelineHeightSnapRevision", () => {
+  it("snaps a newly submitted user row without snapping assistant streaming", () => {
+    const firstUserRow = conversationRow({
+      id: "user-1",
+      role: "user",
+      sourceSeqStart: 1,
+      sourceSeqEnd: 1,
+      text: "First request",
+    });
+    const streamingAssistantRow = conversationRow({
+      id: "assistant-1",
+      role: "assistant",
+      sourceSeqStart: 2,
+      sourceSeqEnd: 2,
+      text: "Working",
+    });
+    const updatedAssistantRow = conversationRow({
+      id: "assistant-1",
+      role: "assistant",
+      sourceSeqStart: 2,
+      sourceSeqEnd: 3,
+      text: "Working on it",
+    });
+    const firstRevision = timelineHeightSnapRevision([
+      firstUserRow,
+      streamingAssistantRow,
+    ]);
+
+    expect(
+      timelineHeightSnapRevision([firstUserRow, updatedAssistantRow]),
+    ).toBe(firstRevision);
+    expect(
+      timelineHeightSnapRevision([
+        firstUserRow,
+        updatedAssistantRow,
+        conversationRow({
+          id: "user-2",
+          role: "user",
+          sourceSeqStart: 4,
+          sourceSeqEnd: 4,
+          text: "Follow-up",
+        }),
+      ]),
+    ).not.toBe(firstRevision);
+  });
 });
 
 describe("ThreadTimelineRows actions", () => {

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -631,14 +631,21 @@ function timelineRowsOwnerKey({
   return ownerThreadId;
 }
 
-function timelineHeightSnapRevision(rows: readonly TimelineRow[]): string {
-  // Active turns render their work rows directly. Completion replaces those
-  // rows with one or more turn summaries plus the terminal message. Key the
-  // height container by the newest completed summary so that authoritative
-  // topology replacement snaps instead of looking like a second stream.
+export function timelineHeightSnapRevision(
+  rows: readonly TimelineRow[],
+): string {
+  // User messages are discrete submissions rather than streamed content. Snap
+  // their height into the timeline so a bottom-pinned reader does not watch the
+  // entire row-list boundary chase the new prompt for 180ms. Active turns still
+  // animate subsequent work and assistant content. Completion replaces those
+  // rows with one or more turn summaries plus the terminal message, which also
+  // snaps instead of looking like a second stream.
   for (let index = rows.length - 1; index >= 0; index -= 1) {
     const row = rows[index];
     if (row?.kind === "turn") {
+      return `${row.id}:${row.sourceSeqStart}:${row.sourceSeqEnd}`;
+    }
+    if (row && isUserAuthoredConversationRow(row)) {
       return `${row.id}:${row.sourceSeqStart}:${row.sourceSeqEnd}`;
     }
   }

--- a/apps/app/src/components/thread/timeline/ThreadTimelineSurface.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineSurface.tsx
@@ -260,7 +260,7 @@ export function ThreadTimelineSurface({
           }
         />
       ) : null}
-      <HeightTransition visible={showOngoingIndicator}>
+      <HeightTransition visible={showOngoingIndicator} snapOnEnter>
         <TimelineWorkingIndicator
           key={ongoingIndicatorKey}
           details={activeThinkingDetails}

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
@@ -117,13 +117,13 @@ function ScrollToBottomControl() {
   );
 }
 
-function renderTimeline({
+function timelineElement({
   threadId,
   rowIds,
   showCapturePrependAnchorControl = false,
   showScrollToBottomControl = false,
 }: RenderArgs) {
-  const view = render(
+  return (
     <BottomAnchoredScrollBody
       footer={<div>Footer</div>}
       maxWidthClassName="max-w-none"
@@ -137,8 +137,13 @@ function renderTimeline({
           {rowId}
         </div>
       ))}
-    </BottomAnchoredScrollBody>,
+    </BottomAnchoredScrollBody>
   );
+}
+
+function renderTimeline(args: RenderArgs) {
+  const { rowIds } = args;
+  const view = render(timelineElement(args));
 
   const scrollArea = requireHTMLElement(
     view.container.querySelector(`.${SCROLL_AREA_CLASS}`),
@@ -155,6 +160,8 @@ function renderTimeline({
 
   return {
     getByRole: view.getByRole,
+    rerender: (nextArgs: RenderArgs) =>
+      view.rerender(timelineElement(nextArgs)),
     scrollArea,
     rowElements,
     unmount: view.unmount,
@@ -457,6 +464,78 @@ describe("BottomAnchoredScrollBody scroll preservation", () => {
     getLatestResizeObserver().trigger();
 
     expect(scrollArea.scrollTop).toBe(300);
+  });
+
+  it("does not let a pending prepend restore undo an explicit bottom scroll", () => {
+    const renderArgs: RenderArgs = {
+      threadId: "thread-a",
+      rowIds: ["row-a", "row-b", "row-c"],
+      showCapturePrependAnchorControl: true,
+      showScrollToBottomControl: true,
+    };
+    const { getByRole, rerender, scrollArea } = renderTimeline(renderArgs);
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 400,
+      clientHeight: 100,
+      scrollTop: 0,
+    });
+
+    fireEvent.click(getByRole("button", { name: "Capture prepend anchor" }));
+    fireEvent.click(getByRole("button", { name: "Bottom" }));
+    expect(scrollArea.scrollTop).toBe(300);
+
+    // The older page's animated wrapper finishes growing only after the
+    // explicit bottom request. A stale prepend anchor would misclassify this
+    // 100px as older-page growth and jump back to scrollTop 100 on this render.
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 500,
+      clientHeight: 100,
+      scrollTop: scrollArea.scrollTop,
+    });
+    rerender({
+      ...renderArgs,
+      rowIds: [...renderArgs.rowIds, "row-d"],
+    });
+
+    expect(scrollArea.scrollTop).toBe(300);
+    getLatestResizeObserver().trigger();
+    expect(scrollArea.scrollTop).toBe(400);
+  });
+
+  it("discards a pending prepend anchor after settling at the bottom", () => {
+    const renderArgs: RenderArgs = {
+      threadId: "thread-a",
+      rowIds: ["row-a", "row-b", "row-c"],
+      showCapturePrependAnchorControl: true,
+    };
+    const { getByRole, rerender, scrollArea } = renderTimeline(renderArgs);
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 400,
+      clientHeight: 100,
+      scrollTop: 0,
+    });
+    fireEvent.click(getByRole("button", { name: "Capture prepend anchor" }));
+
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 400,
+      clientHeight: 100,
+      scrollTop: 300,
+    });
+    fireEvent.scroll(scrollArea);
+
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 500,
+      clientHeight: 100,
+      scrollTop: scrollArea.scrollTop,
+    });
+    rerender({
+      ...renderArgs,
+      rowIds: [...renderArgs.rowIds, "row-d"],
+    });
+
+    expect(scrollArea.scrollTop).toBe(300);
+    getLatestResizeObserver().trigger();
+    expect(scrollArea.scrollTop).toBe(400);
   });
 
   it("keeps sticking after manual scroll reaches bottom before more growth", () => {

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -307,6 +307,10 @@ export function BottomAnchoredScrollBody({
     pendingScrollRestoreRef.current = null;
   }, []);
 
+  const cancelPendingPrependAnchor = useCallback(() => {
+    pendingPrependAnchorRef.current = null;
+  }, []);
+
   const cancelQueuedRestore = useCallback(() => {
     if (restoreFrameRef.current === null) return;
     window.cancelAnimationFrame(restoreFrameRef.current);
@@ -367,6 +371,11 @@ export function BottomAnchoredScrollBody({
   const scrollToBottom = useCallback(() => {
     const scrollArea = scrollAreaRef.current;
     cancelPendingScrollRestore();
+    // An explicit bottom request supersedes a position captured for an older
+    // page that was still settling. Leaving that prepend anchor armed lets the
+    // next unrelated height change (commonly an optimistic follow-up row)
+    // restore the stale reading position before sticky-bottom corrects it.
+    cancelPendingPrependAnchor();
     userScrollIntentUntilRef.current = 0;
     pointerScrollIntentRef.current = false;
     userDetachedFromBottomRef.current = false;
@@ -376,7 +385,11 @@ export function BottomAnchoredScrollBody({
       scrollElementToBottom(scrollArea);
     }
     queueBottomRestore();
-  }, [cancelPendingScrollRestore, queueBottomRestore]);
+  }, [
+    cancelPendingPrependAnchor,
+    cancelPendingScrollRestore,
+    queueBottomRestore,
+  ]);
 
   const scrollElementIntoView = useCallback(
     ({ element, options }: ScrollElementIntoViewArgs) => {
@@ -613,6 +626,10 @@ export function BottomAnchoredScrollBody({
     }
 
     if (isScrolledNearBottom(scrollArea)) {
+      // Reaching the bottom after the native-anchor guard above is an
+      // authoritative bottom position. A pending prepend restore must not
+      // survive and reinterpret a later follow-up as older-page growth.
+      cancelPendingPrependAnchor();
       userDetachedFromBottomRef.current = false;
       shouldStickToBottomRef.current = true;
       userScrollIntentUntilRef.current = 0;
@@ -631,7 +648,11 @@ export function BottomAnchoredScrollBody({
     cancelQueuedRestore();
     // The user is scrolling on their own; don't yank them back to the anchor.
     pendingScrollRestoreRef.current = null;
-  }, [cancelQueuedRestore, hasRecentUserScrollIntent]);
+  }, [
+    cancelPendingPrependAnchor,
+    cancelQueuedRestore,
+    hasRecentUserScrollIntent,
+  ]);
 
   const handleScroll = useCallback(() => {
     syncBottomStateFromScroll();

--- a/apps/app/src/components/ui/height-transition.test.tsx
+++ b/apps/app/src/components/ui/height-transition.test.tsx
@@ -59,8 +59,8 @@ describe("HeightTransition", () => {
         <span data-testid="restored-child">Restored content</span>
       </HeightTransition>,
     );
-    const wrapper = view.getByTestId("restored-child").parentElement
-      ?.parentElement;
+    const wrapper =
+      view.getByTestId("restored-child").parentElement?.parentElement;
 
     expect(wrapper?.style.height).toBe("40px");
     offsetHeight.mockReturnValue(80);
@@ -71,6 +71,30 @@ describe("HeightTransition", () => {
 
     expect(wrapper?.style.height).toBe("80px");
     expect(wrapper?.style.transitionDuration).toBe("0s");
+  });
+
+  it("can snap an entrance that should land with adjacent content", () => {
+    vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+    const offsetHeight = vi
+      .spyOn(HTMLElement.prototype, "offsetHeight", "get")
+      .mockReturnValue(40);
+    const view = render(
+      <HeightTransition visible={false} snapOnEnter>
+        <span data-testid="entering-child">Working...</span>
+      </HeightTransition>,
+    );
+    const wrapper =
+      view.getByTestId("entering-child").parentElement?.parentElement;
+
+    view.rerender(
+      <HeightTransition visible snapOnEnter>
+        <span data-testid="entering-child">Working...</span>
+      </HeightTransition>,
+    );
+
+    expect(wrapper?.style.height).toBe("40px");
+    expect(wrapper?.style.transitionDuration).toBe("0s");
+    offsetHeight.mockRestore();
   });
 });
 

--- a/apps/app/src/components/ui/height-transition.tsx
+++ b/apps/app/src/components/ui/height-transition.tsx
@@ -143,6 +143,7 @@ export interface HeightTransitionProps {
   children: ReactNode;
   durationMs?: number;
   className?: string;
+  snapOnEnter?: boolean;
 }
 
 /**
@@ -159,19 +160,30 @@ export function HeightTransition({
   children,
   durationMs = HEIGHT_TRANSITION_DURATION_MS,
   className,
+  snapOnEnter = false,
 }: HeightTransitionProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
+  const previousVisibleRef = useRef(visible);
   const store = useStore();
   useLayoutEffect(() => {
     const wrapper = wrapperRef.current;
     const inner = innerRef.current;
     if (!wrapper || !inner) return;
-    wrapper.style.height = visible ? `${inner.offsetHeight}px` : "0px";
-    if (typeof ResizeObserver === "undefined") return;
+    const isEntering = visible && !previousVisibleRef.current;
+    previousVisibleRef.current = visible;
     let lastWidth: number | null = null;
     let pendingVisibilitySnap = false;
     const snapState: SnapState = { savedDuration: null, restoreFrame: null };
+    applyHeight(
+      wrapper,
+      visible ? `${inner.offsetHeight}px` : "0px",
+      snapOnEnter && isEntering,
+      snapState,
+    );
+    if (typeof ResizeObserver === "undefined") {
+      return () => cleanupSnapState(wrapper, snapState);
+    }
     const observer = new ResizeObserver((entries) => {
       const entry = entries[0];
       if (!entry) return;
@@ -183,7 +195,8 @@ export function HeightTransition({
       // scrollHeight, which the bottom-anchor sentinel then chases.
       const layoutAnimationActive =
         store.get(layoutAnimationInFlightCountAtom) > 0;
-      const snap = widthChanged || pendingVisibilitySnap || layoutAnimationActive;
+      const snap =
+        widthChanged || pendingVisibilitySnap || layoutAnimationActive;
       pendingVisibilitySnap = false;
       lastWidth = width;
       const nextHeight = visible ? `${height}px` : "0px";
@@ -210,7 +223,7 @@ export function HeightTransition({
       unsubscribeFromDocumentVisibility();
       cleanupSnapState(wrapper, snapState);
     };
-  }, [visible, store]);
+  }, [snapOnEnter, visible, store]);
   return (
     <div
       ref={wrapperRef}


### PR DESCRIPTION
## Summary

- clear stale older-page scroll anchors when the reader explicitly returns to the bottom
- snap newly submitted user rows and the working indicator into the timeline so bottom restoration happens before paint
- preserve animated assistant streaming while adding regressions for both stale-anchor paths

## Testing

- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx src/components/ui/height-transition.test.tsx src/components/thread/timeline/ThreadTimelineRows.actions.test.tsx`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- reproduced with 856 mounted rows using dev-browser; the former bottom-to-802-to-bottom scroll excursion no longer occurs

> AGENT GENERATED: by GPT-5