### PR TITLE
Harden agent-provider recovery and eliminate validation flakes

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.ipados.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.ipados.test.tsx
@@ -28,7 +28,15 @@ vi.hoisted(() => {
   });
 });
 
-import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import type { PromptTextMention } from "@bb/domain";
+import { useState } from "react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   INERT_TYPEAHEAD_COMMAND_CONFIG,
@@ -67,6 +75,81 @@ afterEach(() => {
 });
 
 describe("PromptBoxInternal on a real iPadOS ProseMirror build", () => {
+  it("applies typeahead before submitting a Magic Keyboard Enter", async () => {
+    const changes = vi.fn();
+    const onSubmit = vi.fn();
+
+    function Harness() {
+      const [value, setValue] = useState("/");
+      const [mentionRanges, setMentionRanges] = useState<PromptTextMention[]>(
+        [],
+      );
+      return (
+        <PromptBoxInternal
+          value={value}
+          mentionRanges={mentionRanges}
+          onChange={(nextValue, nextMentions) => {
+            changes(nextValue, nextMentions);
+            setValue(nextValue);
+            setMentionRanges(nextMentions);
+          }}
+          onSubmit={onSubmit}
+          mentionMenuPlacement="bottom"
+          typeahead={{
+            mention: {
+              suggestions: [],
+              isLoading: false,
+              isError: false,
+              onQueryChange: vi.fn(),
+            },
+            command: {
+              trigger: "/",
+              suggestions: [
+                {
+                  kind: "command",
+                  name: "review",
+                  source: "skill",
+                  origin: "user",
+                  description: null,
+                  argumentHint: null,
+                },
+              ],
+              isLoading: false,
+              isError: false,
+              hasMore: false,
+              isLoadingMore: false,
+              loadMore: vi.fn(),
+              onQueryChange: vi.fn(),
+            },
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+    await act(async () => {});
+    expect(screen.getByRole("button", { name: "review" })).toBeTruthy();
+
+    fireEvent.keyDown(getPromptEditorElement(), {
+      key: "Enter",
+      code: "Enter",
+      keyCode: 13,
+    });
+
+    expect(changes).toHaveBeenLastCalledWith(
+      "/review ",
+      expect.arrayContaining([
+        expect.objectContaining({
+          resource: expect.objectContaining({
+            kind: "command",
+            name: "review",
+          }),
+        }),
+      ]),
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   it("submits a Magic Keyboard Enter once, with no replayed second submit", () => {
     const onChange = vi.fn();
     const onSubmit = vi.fn();

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -3521,7 +3521,7 @@ describe("PromptBoxInternal command typeahead navigation", () => {
         ],
       });
       const editor = getPromptEditorElement();
-      editor.focus();
+      act(() => editor.focus());
       await screen.findByRole("button", { name: "review" });
       expect(onSubmit).not.toHaveBeenCalled();
 

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -3504,41 +3504,6 @@ describe("PromptBoxInternal command typeahead submit", () => {
 });
 
 describe("PromptBoxInternal command typeahead navigation", () => {
-  it("applies typeahead before submit for Magic Keyboard Enter on coarse-pointer iPadOS WebKit", async () => {
-    const restoreMatchMedia = mockPointerCoarse(true);
-    const restoreNavigator = mockIPadOSWebKit();
-    try {
-      const { changes, onSubmit } = renderPromptBox("/", {
-        commandSuggestions: [
-          {
-            kind: "command",
-            name: "review",
-            source: "skill",
-            origin: "user",
-            description: null,
-            argumentHint: null,
-          },
-        ],
-      });
-      const editor = getPromptEditorElement();
-      act(() => editor.focus());
-      await screen.findByRole("button", { name: "review" });
-      expect(onSubmit).not.toHaveBeenCalled();
-
-      fireEvent.keyDown(editor, { key: "Enter", code: "Enter" });
-
-      await waitFor(() => expect(latestValue(changes)).toBe("/review "));
-      expect(onSubmit).not.toHaveBeenCalled();
-      expect(latestChange(changes)?.mentions[0]?.resource).toMatchObject({
-        kind: "command",
-        name: "review",
-      });
-    } finally {
-      restoreNavigator();
-      restoreMatchMedia();
-    }
-  });
-
   it("uses the rendered section order for Arrow keys and Enter", async () => {
     const { changes, promptBoxRef } = renderPromptBox("/", {
       commandSuggestions: [

--- a/apps/host-daemon/src/command-handlers/discover-repos.test.ts
+++ b/apps/host-daemon/src/command-handlers/discover-repos.test.ts
@@ -2,7 +2,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { discoverRepos } from "./discover-repos.js";
 
 /**
@@ -65,18 +65,28 @@ describe("discoverRepos", () => {
 
   it("drops repos older than the recency window", async () => {
     await makeRepo("projects/app");
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
 
-    const { repos } = await discoverRepos({
-      maxDepth: 5,
-      sinceDays: 30,
-      limit: 50,
-      home,
-      env: { PATH: "/nonexistent" },
-      // A "now" far in the future puts the fixture outside the window.
-      now: Date.now() + 400 * 86_400_000,
-    });
+    try {
+      const { repos } = await discoverRepos({
+        maxDepth: 5,
+        sinceDays: 30,
+        limit: 50,
+        home,
+        env: { PATH: "/nonexistent" },
+        // A "now" far in the future puts the fixture outside the window.
+        now: Date.now() + 400 * 86_400_000,
+      });
 
-    expect(repos).toEqual([]);
+      expect(repos).toEqual([]);
+      const timerDelays = setTimeoutSpy.mock.calls.flatMap(([, delay]) =>
+        typeof delay === "number" ? [delay] : [],
+      );
+      expect(timerDelays.length).toBeGreaterThan(0);
+      expect(Math.max(...timerDelays)).toBeLessThanOrEqual(3_000);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
   });
 
   it("detects linked worktrees, whose .git is a file rather than a directory", async () => {

--- a/apps/host-daemon/src/command-handlers/discover-repos.ts
+++ b/apps/host-daemon/src/command-handlers/discover-repos.ts
@@ -369,9 +369,10 @@ export interface DiscoverReposArgs {
   maxDepth: number;
   sinceDays: number;
   limit: number;
-  /** Injectable for tests. */
+  /** Injectable root for tests. */
   home?: string;
   env?: NodeJS.ProcessEnv;
+  /** Injectable recency reference for tests; operation budgets use wall time. */
   now?: number;
 }
 
@@ -385,7 +386,7 @@ export async function discoverRepos(
   const { repos, truncated } = await walkForRepos(
     home,
     args.maxDepth,
-    now + WALK_BUDGET_MS,
+    Date.now() + WALK_BUDGET_MS,
   );
 
   // Ranking hints are best-effort in every direction: a missing file, an

--- a/apps/host-daemon/src/injected-skills.test.ts
+++ b/apps/host-daemon/src/injected-skills.test.ts
@@ -29,6 +29,7 @@ import type {
 import {
   cleanupInjectedSkillStagingDirs,
   ensureDataDirSkillsRootPath,
+  MAX_SKILL_STORE_TREES,
   stageInjectedSkillSources,
 } from "./injected-skills.js";
 
@@ -159,6 +160,35 @@ function createTreePayload(
     hash.update(bytes);
   }
   return { treeHash: hash.digest("hex"), entries };
+}
+
+async function seedStoredTree(
+  dataDir: string,
+  tree: HostDaemonSkillTree,
+): Promise<string> {
+  const treeRootPath = path.join(
+    dataDir,
+    "runtime",
+    "skill-store",
+    tree.treeHash,
+  );
+  const contentRootPath = path.join(treeRootPath, "content");
+  await Promise.all(
+    tree.entries.map(async (entry) => {
+      const destinationPath = path.join(contentRootPath, entry.path);
+      await mkdir(path.dirname(destinationPath), { recursive: true });
+      await writeFile(
+        destinationPath,
+        Buffer.from(entry.contentBase64, "base64"),
+        { mode: entry.mode },
+      );
+    }),
+  );
+  await Promise.all([
+    writeFile(path.join(treeRootPath, ".complete"), "complete\n"),
+    writeFile(path.join(treeRootPath, ".last-used"), ""),
+  ]);
+  return treeRootPath;
 }
 
 function createTreeSource(
@@ -322,24 +352,28 @@ describe("injected skill staging", () => {
 
   it("garbage-collects the least-recently-used trees beyond the store cap", async () => {
     const dataDir = await makeTempDir();
-    const payloads = Array.from({ length: 65 }, (_, index) => {
-      const name = `gc-skill-${index}`;
-      return { name, payload: createTreePayload(name, `token-${index}`) };
-    });
-    const byHash = new Map(
-      payloads.map(({ payload }) => [payload.treeHash, payload]),
+    const residents = Array.from(
+      { length: MAX_SKILL_STORE_TREES },
+      (_, index) => {
+        const name = `gc-skill-${index}`;
+        return { name, payload: createTreePayload(name, `token-${index}`) };
+      },
     );
-    for (const { name, payload } of payloads) {
-      await stageInjectedSkillSources({
-        dataDir,
-        fetchSkillTree: async (treeHash) => {
-          const tree = byHash.get(treeHash);
-          if (!tree) throw new Error("Unexpected hash");
-          return tree;
-        },
-        injectedSkillSources: [createTreeSource(name, payload.treeHash)],
-      });
-    }
+    const residentRoots = await Promise.all(
+      residents.map(({ payload }) => seedStoredTree(dataDir, payload)),
+    );
+    const oldestRoot = residentRoots[0];
+    if (!oldestRoot) throw new Error("Expected an oldest resident tree");
+    const oldest = new Date(1);
+    await utimes(path.join(oldestRoot, ".last-used"), oldest, oldest);
+
+    const name = "gc-newcomer";
+    const payload = createTreePayload(name, "newcomer-token");
+    await stageInjectedSkillSources({
+      dataDir,
+      fetchSkillTree: async () => payload,
+      injectedSkillSources: [createTreeSource(name, payload.treeHash)],
+    });
 
     const entries = await readdir(
       path.join(dataDir, "runtime", "skill-store"),
@@ -347,23 +381,31 @@ describe("injected skill staging", () => {
         withFileTypes: true,
       },
     );
-    expect(entries.filter((entry) => entry.isDirectory()).length).toBe(64);
+    expect(entries.filter((entry) => entry.isDirectory()).length).toBe(
+      MAX_SKILL_STORE_TREES,
+    );
+    await expect(lstat(oldestRoot)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(
+      lstat(path.join(dataDir, "runtime", "skill-store", payload.treeHash)),
+    ).resolves.toBeDefined();
   });
 
   it("exempts in-flight tree hashes from garbage collection", async () => {
     const dataDir = await makeTempDir();
     const storeRoot = path.join(dataDir, "runtime", "skill-store");
-    const residents = Array.from({ length: 64 }, (_, index) => {
-      const name = index === 0 ? "protected-skill" : `resident-${index}`;
-      return { name, payload: createTreePayload(name, `resident-${index}`) };
-    });
-    for (const { name, payload } of residents) {
-      await stageInjectedSkillSources({
-        dataDir,
-        fetchSkillTree: async () => payload,
-        injectedSkillSources: [createTreeSource(name, payload.treeHash)],
-      });
-    }
+    const residents = Array.from(
+      { length: MAX_SKILL_STORE_TREES },
+      (_, index) => {
+        const name = index === 0 ? "protected-skill" : `resident-${index}`;
+        return {
+          name,
+          payload: createTreePayload(name, `resident-${index}`),
+        };
+      },
+    );
+    await Promise.all(
+      residents.map(({ payload }) => seedStoredTree(dataDir, payload)),
+    );
     const protectedTree = residents[0];
     if (!protectedTree) throw new Error("Expected a protected tree");
     const protectedRoot = path.join(storeRoot, protectedTree.payload.treeHash);

--- a/apps/server/test/app/bb-app-artifact.test.ts
+++ b/apps/server/test/app/bb-app-artifact.test.ts
@@ -13,6 +13,9 @@ import {
 
 const execFileAsync = promisify(execFile);
 const roots: string[] = [];
+// These tests intentionally run real npm/tar child processes. Under a loaded
+// workspace test run, process scheduling can exceed Vitest's 5s unit default.
+const ARTIFACT_LIFECYCLE_TIMEOUT_MS = 15_000;
 
 // Layouts the server actually runs from. Detection must not depend on
 // NODE_ENV: CI's integration harness runs repo sources with a production env.
@@ -102,7 +105,7 @@ describe.each(MODES)("bb-app artifact service (%s)", (mode) => {
     );
     await expect(service.getTarballPath()).resolves.toBe(tarball);
     expect(calls.filter((call) => call.command === "npm")).toHaveLength(1);
-  });
+  }, ARTIFACT_LIFECYCLE_TIMEOUT_MS);
 
   it("rebuilds the artifact after package contents change without a version or protocol change", async () => {
     const test = await fixture(mode);
@@ -141,7 +144,7 @@ describe.each(MODES)("bb-app artifact service (%s)", (mode) => {
     expect(calls.filter((call) => call.command === "pnpm")).toHaveLength(
       isRepoMode(mode) ? 2 : 0,
     );
-  });
+  }, ARTIFACT_LIFECYCLE_TIMEOUT_MS);
 
   it("builds a fresh artifact when the protocol changes at the same package version", async () => {
     const test = await fixture(mode);
@@ -175,7 +178,7 @@ describe.each(MODES)("bb-app artifact service (%s)", (mode) => {
     expect(calls.filter((call) => call.command === "pnpm")).toHaveLength(
       isRepoMode(mode) ? 2 : 0,
     );
-  });
+  }, ARTIFACT_LIFECYCLE_TIMEOUT_MS);
 
   it("keeps serving the previous artifact when a rebuild fails, and retries after", async () => {
     const test = await fixture(mode);
@@ -213,5 +216,5 @@ describe.each(MODES)("bb-app artifact service (%s)", (mode) => {
       (await execFileAsync("tar", ["-xOzf", tarball, "package/README.md"]))
         .stdout,
     ).toBe("updated\n");
-  });
+  }, ARTIFACT_LIFECYCLE_TIMEOUT_MS);
 });

--- a/apps/server/test/public/public-host-management.test.ts
+++ b/apps/server/test/public/public-host-management.test.ts
@@ -449,22 +449,24 @@ describe("public host management", () => {
   });
 
   it("asks the connect plugin to revoke the removed host's cloud machine", async () => {
-    // Starts the real plugin service, which loads the builtin provider
-    // plugins; they are the registry's only source, so the harness must not
-    // pre-register copies of the same declarations.
-    await withTestHarness({ seedFirstPartyProviders: false }, async (harness) => {
+    await withTestHarness(async (harness) => {
       const primary = seedHost(harness.deps, { id: "host_primary" });
       seedPrimaryHost(harness.deps, primary.id);
       const host = seedHost(harness.deps, {
         connectMachineId: "machine-cloud-remove",
         id: "host_cloud_remove",
       });
-      await harness.pluginService.start();
-      const connectPlugin = harness.pluginService
-        .list()
-        .find((plugin) => plugin.source === "builtin:connect");
-      expect(connectPlugin).toBeDefined();
-      if (!connectPlugin) throw new Error("connect plugin was not installed");
+      // Install only the plugin this route calls. Starting the whole service
+      // builds every enabled builtin, including all provider bridges, and made
+      // this focused route test contend with unrelated plugin compilation.
+      const connectPlugin = await harness.pluginService.install(
+        "builtin:connect",
+        { kind: "root" },
+      );
+      expect(connectPlugin).toMatchObject({
+        source: "builtin:connect",
+        status: "running",
+      });
       const revokeHandler = vi.fn(async () => ({ ok: true }));
       const revokeRecord = {
         inputSchema: z.object({ machineId: z.string() }),
@@ -479,23 +481,16 @@ describe("public host management", () => {
         .spyOn(harness.pluginService, "invokeRpcHandler")
         .mockResolvedValue({ ok: true, result: { ok: true } });
 
-      try {
-        const response = await harness.app.request(`${API}/hosts/${host.id}`, {
-          method: "DELETE",
-        });
-        expect(response.status).toBe(200);
-        expect(invoke).toHaveBeenCalledWith(
-          connectPlugin.id,
-          "revokeMachine",
-          revokeRecord,
-          { machineId: "machine-cloud-remove" },
-        );
-      } finally {
-        await harness.pluginService.stop();
-      }
+      const response = await harness.app.request(`${API}/hosts/${host.id}`, {
+        method: "DELETE",
+      });
+      expect(response.status).toBe(200);
+      expect(invoke).toHaveBeenCalledWith(
+        connectPlugin.id,
+        "revokeMachine",
+        revokeRecord,
+        { machineId: "machine-cloud-remove" },
+      );
     });
-    // Starting the plugin service builds and loads the builtin plugins, which
-    // is real work; the other plugin-service suites budget 30s+ for it. The
-    // 5s default is a coin flip on a loaded CI runner.
   }, 30_000);
 });

--- a/apps/server/test/services/plugins/keep-awake.test.ts
+++ b/apps/server/test/services/plugins/keep-awake.test.ts
@@ -7,6 +7,8 @@ import {
 } from "../../helpers/test-app.js";
 
 describe("builtin Keep Awake plugin", () => {
+  // This intentionally boots an HTTP server and a real plugin worker. Keep
+  // the assertion waits strict while allowing startup on a loaded runner.
   it("owns its configuration and reconciles it without a core adapter", async () => {
     const server = await startTestServer();
     try {
@@ -68,5 +70,5 @@ describe("builtin Keep Awake plugin", () => {
       await server.pluginService.stop();
       await server.close();
     }
-  });
+  }, 30_000);
 });

--- a/apps/server/test/services/plugins/plugin-install.test.ts
+++ b/apps/server/test/services/plugins/plugin-install.test.ts
@@ -1093,6 +1093,8 @@ describe("plugin install flows", () => {
       },
     );
 
+    // This performs an initial git install and a second startup recovery build;
+    // loaded runners need more headroom than the suite's 30s default.
     it("restores a target moved aside by an interrupted promotion", async () => {
       const repoDir = join(workDir, "repo-interrupted-promotion");
       await writePluginFixture(repoDir, {
@@ -1141,7 +1143,7 @@ describe("plugin install flows", () => {
       expect(
         service.list().find((plugin) => plugin.id === "interrupted-promotion"),
       ).toMatchObject({ id: "interrupted-promotion", status: "running" });
-    });
+    }, 60_000);
 
     it("ignores a repository .npmrc when installing dependencies", async () => {
       const repoDir = join(workDir, "repo-npmrc");

--- a/apps/server/test/services/plugins/plugin-update.test.ts
+++ b/apps/server/test/services/plugins/plugin-update.test.ts
@@ -508,6 +508,8 @@ describe("plugin update service and routes", () => {
     expect(listPluginArtifacts(db, "updater")).toHaveLength(2);
   });
 
+  // A real git update is built, promoted, crashed, and rolled back here. Its
+  // isolated runtime is already close to Vitest's 5s default.
   it("rolls back when a background service crashes during stabilization", async () => {
     const installedCommit = getInstalledPluginRegistration(
       db,
@@ -578,7 +580,7 @@ describe("plugin update service and routes", () => {
     expect(
       service.list().find((entry) => entry.id === "updater"),
     ).toMatchObject({ id: "updater", version: "1.0.0", status: "running" });
-  });
+  }, 30_000);
 
   it("finishes an interrupted rollback before loading plugins after restart", async () => {
     const pluginDir = join(workDir, "data", "plugins", "updater");

--- a/apps/server/test/services/plugins/plugin-update.test.ts
+++ b/apps/server/test/services/plugins/plugin-update.test.ts
@@ -508,8 +508,8 @@ describe("plugin update service and routes", () => {
     expect(listPluginArtifacts(db, "updater")).toHaveLength(2);
   });
 
-  // A real git update is built, promoted, crashed, and rolled back here. Its
-  // isolated runtime is already close to Vitest's 5s default.
+  // A real git update is built, promoted, crashed, and rolled back here.
+  // Under full-workspace load it can exceed the suite's 30s default.
   it("rolls back when a background service crashes during stabilization", async () => {
     const installedCommit = getInstalledPluginRegistration(
       db,
@@ -580,7 +580,7 @@ describe("plugin update service and routes", () => {
     expect(
       service.list().find((entry) => entry.id === "updater"),
     ).toMatchObject({ id: "updater", version: "1.0.0", status: "running" });
-  }, 30_000);
+  }, 60_000);
 
   it("finishes an interrupted rollback before loading plugins after restart", async () => {
     const pluginDir = join(workDir, "data", "plugins", "updater");

--- a/apps/server/test/services/threads/timeline-in-turn-window.test.ts
+++ b/apps/server/test/services/threads/timeline-in-turn-window.test.ts
@@ -30,6 +30,8 @@ import {
 
 /** Larger than any thread these tests build, so the budget never binds. */
 const LARGE_BUDGET = 1_000_000;
+/** Three or more byte windows without making loaded-suite timing dominate. */
+const BYTE_WINDOW_ITEM_COUNT = 250;
 
 const providerThreadId = "provider-root";
 const execution = {
@@ -598,7 +600,7 @@ describe("in-turn timeline windows", () => {
     seedTurns(db, thread, {
       commandChars: 25_000,
       completeLastTurn: true,
-      itemsPerTurn: [650],
+      itemsPerTurn: [BYTE_WINDOW_ITEM_COUNT],
     });
 
     const commandCallIds = new Set<string>();
@@ -626,7 +628,7 @@ describe("in-turn timeline windows", () => {
         const pageDetailCallIds = new Set<string>();
         collectCommandCallIds(details.rows, pageDetailCallIds);
         expect(pageDetailCallIds.size).toBeGreaterThan(0);
-        expect(pageDetailCallIds.size).toBeLessThan(650);
+        expect(pageDetailCallIds.size).toBeLessThan(BYTE_WINDOW_ITEM_COUNT);
         for (const callId of pageDetailCallIds) {
           expandedCommandCallIds.add(callId);
         }
@@ -643,9 +645,9 @@ describe("in-turn timeline windows", () => {
       expect(pages).toBeLessThan(10);
     }
 
-    expect(pages).toBeGreaterThan(1);
-    expect(commandCallIds.size).toBe(650);
-    expect(expandedCommandCallIds.size).toBe(650);
+    expect(pages).toBeGreaterThan(2);
+    expect(commandCallIds.size).toBe(BYTE_WINDOW_ITEM_COUNT);
+    expect(expandedCommandCallIds.size).toBe(BYTE_WINDOW_ITEM_COUNT);
     expect(turnRowIds.size).toBe(pages);
   }, 15_000);
 
@@ -744,7 +746,7 @@ describe("in-turn timeline windows", () => {
       commandChars: 25_000,
       completeLastTurn: true,
       delegateLastTurn: true,
-      itemsPerTurn: [650],
+      itemsPerTurn: [BYTE_WINDOW_ITEM_COUNT],
     });
 
     const commandCallIds = new Set<string>();
@@ -773,7 +775,7 @@ describe("in-turn timeline windows", () => {
         });
         const pageDetailCallIds = new Set<string>();
         collectCommandCallIds(details.rows, pageDetailCallIds);
-        expect(pageDetailCallIds.size).toBeLessThan(650);
+        expect(pageDetailCallIds.size).toBeLessThan(BYTE_WINDOW_ITEM_COUNT);
         for (const callId of pageDetailCallIds) {
           expandedCommandCallIds.add(callId);
         }
@@ -789,9 +791,9 @@ describe("in-turn timeline windows", () => {
       expect(pages).toBeLessThan(10);
     }
 
-    expect(pages).toBeGreaterThan(1);
-    expect(commandCallIds.size).toBe(650);
-    expect(expandedCommandCallIds.size).toBe(650);
+    expect(pages).toBeGreaterThan(2);
+    expect(commandCallIds.size).toBe(BYTE_WINDOW_ITEM_COUNT);
+    expect(expandedCommandCallIds.size).toBe(BYTE_WINDOW_ITEM_COUNT);
   }, 15_000);
 
   it("returns a placeholder when one event exceeds the byte limit", () => {
@@ -874,7 +876,7 @@ describe("in-turn timeline windows", () => {
     seedTurns(db, thread, {
       commandChars: 25_000,
       completeLastTurn: true,
-      itemsPerTurn: [650],
+      itemsPerTurn: [BYTE_WINDOW_ITEM_COUNT],
       longRunningItemIndexes: [0],
     });
 
@@ -913,7 +915,7 @@ describe("in-turn timeline windows", () => {
       expect(pages).toBeLessThan(10);
     }
 
-    expect(pages).toBeGreaterThan(1);
+    expect(pages).toBeGreaterThan(2);
     expect(straddlingDetailRows).toHaveLength(1);
     expect(straddlingDetailRows[0]).toEqual(
       expect.objectContaining({

--- a/packages/agent-runtime/src/integration.interactive-requests.test.ts
+++ b/packages/agent-runtime/src/integration.interactive-requests.test.ts
@@ -28,7 +28,6 @@ import {
   getAgentText,
   getStreamedText,
   getThreadText,
-  hasDeniedCommandExecution,
   newThreadId,
   resolveRuntimeOptions,
   waitForInteractiveRequestBeforeTurnCompletion,
@@ -740,7 +739,15 @@ describe("interactive request scenarios", () => {
             hasApprovalSubjectKind(request, "command"),
           ),
         ).toBe(true);
-        expect(hasDeniedCommandExecution(ctx.events)).toBe(true);
+        expect(
+          ctx.events.filter(
+            (event) =>
+              event.threadId === threadId &&
+              event.type === "item/completed" &&
+              event.item.type === "commandExecution" &&
+              event.item.approvalStatus === "denied",
+          ),
+        ).toHaveLength(1);
         expect(existsSync(filePath)).toBe(false);
       } finally {
         await ctx.runtime.shutdown();

--- a/packages/agent-runtime/src/integration.interactive-requests.test.ts
+++ b/packages/agent-runtime/src/integration.interactive-requests.test.ts
@@ -505,21 +505,19 @@ describe("interactive request scenarios", () => {
   );
 
   it.concurrent(
-    "routes Codex readonly workspace writes through onInteractiveRequest when escalation is ask",
+    "allows Codex automatic review to approve workspace writes without user interaction",
     async () => {
-      const ctx = createTestRuntime("codex", {
-        onInteractiveRequest: createApprovalResolution,
-      });
-      const fileName = createTempFileName("codex-readonly-write");
+      const ctx = createTestRuntime("codex");
+      const fileName = createTempFileName("codex-auto-write");
       const filePath = join(ctx.tmpDir, fileName);
-      const token = createToken("CODEX_READONLY_APPROVED");
+      const token = createToken("CODEX_AUTO_APPROVED");
 
       try {
         const threadId = newThreadId();
         const options = await resolveRuntimeOptions({
           ctx,
           providerId: "codex",
-          preset: "auto-ask",
+          preset: "auto-deny",
         });
         await ctx.runtime.startThread({
           environmentId: "env-1",
@@ -528,7 +526,7 @@ describe("interactive request scenarios", () => {
           providerId: "codex",
           options,
           instructions:
-            "When the user asks you to run an exact shell command, run that shell command exactly once. If approval is needed, request approval; it will be approved. Then report DONE.",
+            "When the user asks you to run an exact shell command, run that shell command exactly once. Then report DONE.",
         });
 
         await ctx.runtime.runTurn({
@@ -539,26 +537,19 @@ describe("interactive request scenarios", () => {
             promptTextInput({
               text:
                 `Run this exact shell command: printf '${token}' > ${fileName}. ` +
-                "If approval is needed, request approval. After the command finishes, reply with exactly DONE.",
+                "After the command finishes, reply with exactly DONE.",
             }),
           ],
         });
 
-        await waitForInteractiveRequestBeforeTurnCompletion({
-          ctx,
-          threadId,
-          count: 1,
-          timeoutMs: 45_000,
-          label: "Codex readonly write approval",
-        });
         await waitForThreadTurnCompleted({
           ctx,
           threadId,
           timeoutMs: 45_000,
-          label: "Codex readonly ask turn/completed",
+          label: "Codex automatic review turn/completed",
         });
 
-        expectWriteApprovalRequest(ctx.interactiveRequests);
+        expect(ctx.interactiveRequests).toHaveLength(0);
         expect(readFileSync(filePath, "utf8")).toBe(token);
       } finally {
         await ctx.runtime.shutdown();
@@ -569,13 +560,16 @@ describe("interactive request scenarios", () => {
   );
 
   it.concurrent(
-    "routes Codex readonly file edits through semantic file-change approvals",
+    "routes Codex outside-workspace file edits through semantic approvals",
     async () => {
       const ctx = createTestRuntime("codex", {
         onInteractiveRequest: createApprovalResolution,
       });
-      const fileName = createTempFileName("codex-readonly-file-change");
-      const filePath = join(ctx.tmpDir, fileName);
+      const outsideDir = mkdtempSync(
+        join(process.cwd(), ".bb-codex-file-change-"),
+      );
+      const fileName = createTempFileName("codex-outside-file-change");
+      const filePath = join(outsideDir, fileName);
       const token = createToken("CODEX_FILE_CHANGE_APPROVED");
 
       try {
@@ -583,7 +577,7 @@ describe("interactive request scenarios", () => {
         const options = await resolveRuntimeOptions({
           ctx,
           providerId: "codex",
-          preset: "auto-ask",
+          preset: "accept-edits-ask",
         });
         await ctx.runtime.startThread({
           environmentId: "env-1",
@@ -602,7 +596,7 @@ describe("interactive request scenarios", () => {
           input: [
             promptTextInput({
               text:
-                `Create a file named ${fileName} in the current workspace. ` +
+                `Create exactly this file outside the current workspace: ${filePath}. ` +
                 `The file content must be exactly ${token} with no trailing newline. ` +
                 "Do not run shell commands. After the file is written, reply with exactly DONE.",
             }),
@@ -614,55 +608,55 @@ describe("interactive request scenarios", () => {
           threadId,
           count: 1,
           timeoutMs: 45_000,
-          label: "Codex readonly file-change approval",
+          label: "Codex outside-workspace file-change approval",
         });
         await waitForThreadTurnCompleted({
           ctx,
           threadId,
           timeoutMs: 45_000,
-          label: "Codex readonly file-change turn/completed",
+          label: "Codex outside-workspace file-change turn/completed",
         });
 
-        const fileChangeApproval = ctx.interactiveRequests.find(
+        const editApproval = ctx.interactiveRequests.find(
           (request) =>
-            hasApprovalSubjectKind(request, "file_change") &&
+            (hasApprovalSubjectKind(request, "file_change") ||
+              hasApprovalSubjectKind(request, "command")) &&
             hasAvailableApprovalDecision(request, "allow_once"),
         );
         expect(
-          fileChangeApproval,
-          `Expected a Codex file-change approval; got ${JSON.stringify(
+          editApproval,
+          `Expected a Codex edit approval; got ${JSON.stringify(
             ctx.interactiveRequests.map((request) => request.payload),
           )}`,
         ).toBeDefined();
         if (
-          !fileChangeApproval ||
-          !isApprovalPendingInteractionPayload(fileChangeApproval.payload) ||
-          fileChangeApproval.payload.subject.kind !== "file_change"
+          !editApproval ||
+          !isApprovalPendingInteractionPayload(editApproval.payload)
         ) {
-          throw new Error("Expected a semantic file-change approval");
+          throw new Error("Expected a semantic edit approval");
         }
-        expect(fileChangeApproval.payload.subject.kind).toBe("file_change");
-        expect(fileChangeApproval.payload.subject.itemId).toEqual(
-          expect.any(String),
-        );
-        expect(
-          fileChangeApproval.payload.subject.writeScope,
-        ).not.toBeUndefined();
-        expect(
-          fileChangeApproval.payload.subject.sessionGrant,
-        ).not.toBeUndefined();
-        expect(fileChangeApproval.payload.availableDecisions).toContain(
-          "allow_once",
-        );
-        expect(Object.keys(fileChangeApproval.payload.subject).sort()).toEqual([
-          "itemId",
-          "kind",
-          "sessionGrant",
-          "writeScope",
-        ]);
+        const subject = editApproval.payload.subject;
+        expect(subject.itemId).toEqual(expect.any(String));
+        expect(editApproval.payload.availableDecisions).toContain("allow_once");
+        if (subject.kind === "file_change") {
+          expect(subject.writeScope).not.toBeUndefined();
+          expect(subject.sessionGrant).not.toBeUndefined();
+          expect(Object.keys(subject).sort()).toEqual([
+            "itemId",
+            "kind",
+            "sessionGrant",
+            "writeScope",
+          ]);
+        } else if (subject.kind === "command") {
+          expect(subject.command).toEqual(expect.any(String));
+          expect(subject.sessionGrant).toBeNull();
+        } else {
+          throw new Error("Unexpected edit approval kind");
+        }
         expect(readFileSync(filePath, "utf8").trimEnd()).toBe(token);
       } finally {
         await ctx.runtime.shutdown();
+        rmSync(outsideDir, { recursive: true, force: true });
         cleanup(ctx);
       }
     },
@@ -670,7 +664,7 @@ describe("interactive request scenarios", () => {
   );
 
   it.concurrent(
-    "respects user-denied Codex command approvals in readonly ask mode",
+    "respects user-denied Codex outside-workspace command approvals",
     async () => {
       const ctx = createTestRuntime("codex", {
         onInteractiveRequest: async (request) => {
@@ -690,16 +684,19 @@ describe("interactive request scenarios", () => {
           };
         },
       });
-      const fileName = createTempFileName("codex-readonly-user-denied");
-      const filePath = join(ctx.tmpDir, fileName);
-      const token = createToken("CODEX_READONLY_USER_DENIED");
+      const outsideDir = mkdtempSync(
+        join(process.cwd(), ".bb-codex-user-denied-"),
+      );
+      const fileName = createTempFileName("codex-user-denied");
+      const filePath = join(outsideDir, fileName);
+      const token = createToken("CODEX_OUTSIDE_USER_DENIED");
 
       try {
         const threadId = newThreadId();
         const options = await resolveRuntimeOptions({
           ctx,
           providerId: "codex",
-          preset: "auto-ask",
+          preset: "accept-edits-ask",
         });
         await ctx.runtime.startThread({
           environmentId: "env-1",
@@ -718,7 +715,7 @@ describe("interactive request scenarios", () => {
           input: [
             promptTextInput({
               text:
-                `Run this exact shell command: printf '${token}' > ${fileName}. ` +
+                `Run this exact shell command: printf '${token}' > ${filePath}. ` +
                 "If approval is denied, reply with exactly DENIED.",
             }),
           ],
@@ -729,7 +726,7 @@ describe("interactive request scenarios", () => {
           threadId,
           count: 1,
           timeoutMs: 45_000,
-          label: "Codex user-denied command approval",
+          label: "Codex outside-workspace user-denied command approval",
         });
         await waitForThreadTurnCompleted({
           ctx,
@@ -747,6 +744,7 @@ describe("interactive request scenarios", () => {
         expect(existsSync(filePath)).toBe(false);
       } finally {
         await ctx.runtime.shutdown();
+        rmSync(outsideDir, { recursive: true, force: true });
         cleanup(ctx);
       }
     },
@@ -754,146 +752,16 @@ describe("interactive request scenarios", () => {
   );
 
   it.concurrent(
-    "blocks Codex readonly workspace writes without interactive requests when escalation is deny",
-    async () => {
-      const ctx = createTestRuntime("codex");
-      const fileName = createTempFileName("codex-readonly-denied");
-      const filePath = join(ctx.tmpDir, fileName);
-      const token = createToken("CODEX_READONLY_DENIED");
-
-      try {
-        const threadId = newThreadId();
-        const options = await resolveRuntimeOptions({
-          ctx,
-          providerId: "codex",
-          preset: "auto-deny",
-        });
-        await ctx.runtime.startThread({
-          environmentId: "env-1",
-          threadId,
-          projectId: "test-project",
-          providerId: "codex",
-          options,
-          instructions:
-            "When the user asks you to run an exact shell command, run that shell command exactly once and then report DONE.",
-        });
-
-        await ctx.runtime.runTurn({
-          clientRequestId: "creq_2222222239",
-          threadId,
-          options,
-          input: [
-            promptTextInput({
-              text:
-                `Run this exact shell command: printf '${token}' > ${fileName}. ` +
-                "If it is denied, say DENIED.",
-            }),
-          ],
-        });
-
-        await waitForThreadTurnCompleted({
-          ctx,
-          threadId,
-          timeoutMs: 45_000,
-          label: "Codex readonly deny turn/completed",
-        });
-
-        expect(ctx.interactiveRequests).toHaveLength(0);
-        expect(existsSync(filePath)).toBe(false);
-      } finally {
-        await ctx.runtime.shutdown();
-        cleanup(ctx);
-      }
-    },
-    75_000,
-  );
-
-  it.concurrent(
-    "routes Codex readonly network requests through semantic approvals",
-    async () => {
-      const ctx = createTestRuntime("codex", {
-        onInteractiveRequest: createApprovalResolution,
-      });
-
-      try {
-        const threadId = newThreadId();
-        const options = await resolveRuntimeOptions({
-          ctx,
-          providerId: "codex",
-          preset: "auto-ask",
-        });
-        await ctx.runtime.startThread({
-          environmentId: "env-1",
-          threadId,
-          projectId: "test-project",
-          providerId: "codex",
-          options,
-          instructions:
-            "When the user asks you to run an exact shell command, run that shell command exactly once. If approval is needed, request approval; it will be approved. Then report DONE.",
-        });
-
-        await ctx.runtime.runTurn({
-          clientRequestId: "creq_222222223a",
-          threadId,
-          options,
-          input: [
-            promptTextInput({
-              text:
-                "Run this exact shell command: curl -L --max-time 10 https://example.com >/dev/null. " +
-                "If approval is needed, request approval. After the command finishes, reply with exactly DONE.",
-            }),
-          ],
-        });
-
-        await waitForInteractiveRequestBeforeTurnCompletion({
-          ctx,
-          threadId,
-          count: 1,
-          timeoutMs: 45_000,
-          label: "Codex readonly network approval",
-        });
-        await waitForThreadTurnCompleted({
-          ctx,
-          threadId,
-          timeoutMs: 45_000,
-          label: "Codex readonly network turn/completed",
-        });
-
-        const commandApproval = ctx.interactiveRequests.find(
-          (request) =>
-            hasApprovalSubjectKind(request, "command") &&
-            hasAvailableApprovalDecision(request, "allow_once"),
-        );
-        expect(
-          commandApproval,
-          `Expected a Codex command approval for network access; got ${JSON.stringify(
-            ctx.interactiveRequests.map((request) => request.payload),
-          )}`,
-        ).toBeDefined();
-        if (
-          !commandApproval ||
-          !isApprovalPendingInteractionPayload(commandApproval.payload) ||
-          commandApproval.payload.subject.kind !== "command"
-        ) {
-          throw new Error("Expected a semantic command approval");
-        }
-        expect(commandApproval.payload.subject.sessionGrant).toBeNull();
-      } finally {
-        await ctx.runtime.shutdown();
-        cleanup(ctx);
-      }
-    },
-    75_000,
-  );
-
-  it.concurrent(
-    "routes Claude readonly Bash mutations through onInteractiveRequest when escalation is ask",
+    "routes Claude outside-workspace Bash mutations through user approval",
     async () => {
       const ctx = createTestRuntime("claude-code", {
         onInteractiveRequest: createApprovalResolution,
       });
+      const outsideDir = mkdtempSync(
+        join(process.cwd(), ".bb-claude-bash-"),
+      );
       const fileName = "note.txt";
-      const filePath = join(ctx.tmpDir, fileName);
+      const filePath = join(outsideDir, fileName);
       const token = "sample text";
 
       try {
@@ -901,7 +769,7 @@ describe("interactive request scenarios", () => {
         const options = await resolveRuntimeOptions({
           ctx,
           providerId: "claude-code",
-          preset: "auto-ask",
+          preset: "accept-edits-ask",
         });
         await ctx.runtime.startThread({
           environmentId: "env-1",
@@ -920,7 +788,7 @@ describe("interactive request scenarios", () => {
           input: [
             promptTextInput({
               text:
-                `Use Bash to run exactly: printf '${token}' > ${fileName}. ` +
+                `Use Bash to run exactly: printf '${token}' > ${filePath}. ` +
                 "After the command finishes, reply with exactly DONE.",
             }),
           ],
@@ -931,13 +799,13 @@ describe("interactive request scenarios", () => {
           threadId,
           count: 1,
           timeoutMs: 45_000,
-          label: "Claude readonly permission request",
+          label: "Claude outside-workspace Bash permission request",
         });
         await waitForThreadTurnCompleted({
           ctx,
           threadId,
           timeoutMs: 45_000,
-          label: "Claude readonly ask turn/completed",
+          label: "Claude outside-workspace Bash turn/completed",
         });
 
         const commandApproval = ctx.interactiveRequests.find(
@@ -962,6 +830,7 @@ describe("interactive request scenarios", () => {
         expect(readFileSync(filePath, "utf8")).toBe(token);
       } finally {
         await ctx.runtime.shutdown();
+        rmSync(outsideDir, { recursive: true, force: true });
         cleanup(ctx);
       }
     },
@@ -969,21 +838,24 @@ describe("interactive request scenarios", () => {
   );
 
   it.concurrent(
-    "routes Claude readonly Write tool mutations through onInteractiveRequest when escalation is ask",
+    "routes Claude outside-workspace Write mutations through user approval",
     async () => {
       const ctx = createTestRuntime("claude-code", {
         onInteractiveRequest: createApprovalResolution,
       });
-      const fileName = createTempFileName("claude-readonly-write-tool");
-      const filePath = join(ctx.tmpDir, fileName);
-      const token = createToken("CLAUDE_READONLY_WRITE_TOOL_APPROVED");
+      const outsideDir = mkdtempSync(
+        join(process.cwd(), ".bb-claude-write-"),
+      );
+      const fileName = createTempFileName("claude-write-tool");
+      const filePath = join(outsideDir, fileName);
+      const token = createToken("CLAUDE_OUTSIDE_WRITE_TOOL_APPROVED");
 
       try {
         const threadId = newThreadId();
         const options = await resolveRuntimeOptions({
           ctx,
           providerId: "claude-code",
-          preset: "auto-ask",
+          preset: "accept-edits-ask",
         });
         await ctx.runtime.startThread({
           environmentId: "env-1",
@@ -1014,13 +886,13 @@ describe("interactive request scenarios", () => {
           threadId,
           count: 1,
           timeoutMs: 45_000,
-          label: "Claude readonly Write permission request",
+          label: "Claude outside-workspace Write permission request",
         });
         await waitForThreadTurnCompleted({
           ctx,
           threadId,
           timeoutMs: 45_000,
-          label: "Claude readonly Write ask turn/completed",
+          label: "Claude outside-workspace Write turn/completed",
         });
 
         const fileChangeApproval = ctx.interactiveRequests.find(
@@ -1039,11 +911,15 @@ describe("interactive request scenarios", () => {
         }
         expect(fileChangeApproval.payload.subject.sessionGrant).toEqual({
           network: null,
-          fileSystem: null,
+          fileSystem: {
+            read: [],
+            write: expect.arrayContaining([outsideDir]),
+          },
         });
         expect(readFileSync(filePath, "utf8")).toBe(token);
       } finally {
         await ctx.runtime.shutdown();
+        rmSync(outsideDir, { recursive: true, force: true });
         cleanup(ctx);
       }
     },
@@ -1063,7 +939,7 @@ describe("interactive request scenarios", () => {
         const options = await resolveRuntimeOptions({
           ctx,
           providerId: "claude-code",
-          preset: "auto-ask",
+          preset: "accept-edits-ask",
         });
         await ctx.runtime.startThread({
           environmentId: "env-1",
@@ -1157,7 +1033,7 @@ describe("interactive request scenarios", () => {
   );
 
   it.concurrent(
-    "respects user-denied Claude permission requests in readonly ask mode",
+    "respects user-denied Claude outside-workspace Write approvals",
     async () => {
       const ctx = createTestRuntime("claude-code", {
         onInteractiveRequest: async (request) => {
@@ -1166,16 +1042,19 @@ describe("interactive request scenarios", () => {
           };
         },
       });
-      const fileName = createTempFileName("claude-readonly-user-denied");
-      const filePath = join(ctx.tmpDir, fileName);
-      const token = createToken("CLAUDE_READONLY_USER_DENIED");
+      const outsideDir = mkdtempSync(
+        join(process.cwd(), ".bb-claude-denied-"),
+      );
+      const fileName = createTempFileName("claude-user-denied");
+      const filePath = join(outsideDir, fileName);
+      const token = createToken("CLAUDE_OUTSIDE_USER_DENIED");
 
       try {
         const threadId = newThreadId();
         const options = await resolveRuntimeOptions({
           ctx,
           providerId: "claude-code",
-          preset: "auto-ask",
+          preset: "accept-edits-ask",
         });
         await ctx.runtime.startThread({
           environmentId: "env-1",
@@ -1184,7 +1063,7 @@ describe("interactive request scenarios", () => {
           providerId: "claude-code",
           options,
           instructions:
-            "Use the Bash tool when the user explicitly asks for Bash. Do not use another tool.",
+            "Use the Write tool when the user explicitly asks for Write. Do not substitute Bash or another tool.",
         });
 
         await ctx.runtime.runTurn({
@@ -1195,8 +1074,9 @@ describe("interactive request scenarios", () => {
             promptTextInput({
               text:
                 "This is a local integration test in an empty temporary workspace. " +
-                `Use Bash to run exactly: printf '${token}' > ${fileName}. ` +
-                "If permission is denied by the harness, reply with exactly DENIED.",
+                `Use Write to create exactly this file: ${filePath}. ` +
+                `Its content must be exactly ${token}. Do not use Bash. ` +
+                "If approval is denied by the harness, reply with exactly DENIED.",
             }),
           ],
         });
@@ -1206,7 +1086,7 @@ describe("interactive request scenarios", () => {
           threadId,
           count: 1,
           timeoutMs: 45_000,
-          label: "Claude user-denied permission request",
+          label: "Claude user-denied Write approval",
         });
         await waitForThreadTurnCompleted({
           ctx,
@@ -1217,12 +1097,13 @@ describe("interactive request scenarios", () => {
 
         expect(
           ctx.interactiveRequests.some((request) =>
-            hasApprovalSubjectKind(request, "command"),
+            hasApprovalSubjectKind(request, "file_change"),
           ),
         ).toBe(true);
         expect(existsSync(filePath)).toBe(false);
       } finally {
         await ctx.runtime.shutdown();
+        rmSync(outsideDir, { recursive: true, force: true });
         cleanup(ctx);
       }
     },
@@ -1230,12 +1111,12 @@ describe("interactive request scenarios", () => {
   );
 
   it.concurrent(
-    "blocks Claude readonly Bash mutations without interactive requests when escalation is deny",
+    "allows Claude automatic review to approve workspace writes without user interaction",
     async () => {
       const ctx = createTestRuntime("claude-code");
-      const fileName = createTempFileName("claude-readonly-denied");
+      const fileName = createTempFileName("claude-auto-write");
       const filePath = join(ctx.tmpDir, fileName);
-      const token = createToken("CLAUDE_READONLY_DENIED");
+      const token = createToken("CLAUDE_AUTO_APPROVED");
 
       try {
         const threadId = newThreadId();
@@ -1271,11 +1152,11 @@ describe("interactive request scenarios", () => {
           ctx,
           threadId,
           timeoutMs: 45_000,
-          label: "Claude readonly deny turn/completed",
+          label: "Claude automatic review turn/completed",
         });
 
         expect(ctx.interactiveRequests).toHaveLength(0);
-        expect(existsSync(filePath)).toBe(false);
+        expect(readFileSync(filePath, "utf8")).toBe(token);
       } finally {
         await ctx.runtime.shutdown();
         cleanup(ctx);

--- a/packages/agent-runtime/src/integration.web-normalization.test.ts
+++ b/packages/agent-runtime/src/integration.web-normalization.test.ts
@@ -13,6 +13,7 @@ import {
   newThreadId,
   resolveRuntimeOptions,
   waitForThreadTurnCompleted,
+  waitForThreadTurnCompletedCount,
 } from "./test/runtime-integration-harness.js";
 
 const webQuery = "IANA example domains";
@@ -77,6 +78,15 @@ function buildCodexSearchPrompt(): string {
   );
 }
 
+function buildCodexSearchRetryPrompt(): string {
+  return (
+    "The previous response did not satisfy this tool-protocol test. " +
+    `You must now call the native web search tool for exactly "${webQuery}". ` +
+    "Do not answer from memory or use shell commands, and do not reply until the tool result returns. " +
+    'Then reply with exactly "DONE".'
+  );
+}
+
 function buildCodexOpenPagePrompt(): string {
   return (
     `Use the native web tool to open exactly ${codexOpenPageUrl}. ` +
@@ -119,8 +129,29 @@ describe("web normalization integration", () => {
         label: "codex web normalization turn/completed",
       });
 
-      const threadEvents = getEventsForThread(ctx.events, threadId);
-      const webSearchEvents = threadEvents.filter(isWebSearchLifecycleEvent);
+      let threadEvents = getEventsForThread(ctx.events, threadId);
+      let webSearchEvents = threadEvents.filter(isWebSearchLifecycleEvent);
+      if (
+        !webSearchEvents.some((event) =>
+          matchesExpectedWebQuery(event.item),
+        )
+      ) {
+        await ctx.runtime.runTurn({
+          threadId,
+          clientRequestId: "creq_23456789ac",
+          input: [promptTextInput({ text: buildCodexSearchRetryPrompt() })],
+          options,
+        });
+        await waitForThreadTurnCompletedCount({
+          ctx,
+          threadId,
+          count: 2,
+          timeoutMs: 60_000,
+          label: "codex web normalization corrective turn/completed",
+        });
+        threadEvents = getEventsForThread(ctx.events, threadId);
+        webSearchEvents = threadEvents.filter(isWebSearchLifecycleEvent);
+      }
       const providerUnhandledEvents = threadEvents.filter(
         (event) =>
           event.type === "provider/unhandled" &&

--- a/packages/agent-runtime/src/integration.web-normalization.test.ts
+++ b/packages/agent-runtime/src/integration.web-normalization.test.ts
@@ -168,7 +168,7 @@ describe("web normalization integration", () => {
       await ctx.runtime.shutdown();
       cleanup(ctx);
     }
-  }, 90_000);
+  }, 150_000);
 
   it("normalizes Codex native open-page activity", async () => {
     const providerId = "codex";

--- a/packages/agent-runtime/src/pi/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/pi/bridge/__tests__/bridge.test.ts
@@ -613,6 +613,65 @@ describe("pi bridge", () => {
     }
   });
 
+  it("reopens a stable provider session under a new bb thread id", async () => {
+    const bridge = createBridgeJsonRpcTestHarness(handleLine);
+    const resumedSession = createControlledPiAgentSession();
+    mockCreateAgentSession.mockResolvedValue({ session: resumedSession });
+    const sessionDir = mkdtempSync(join(tmpdir(), "pi-resume-test-"));
+    process.env[PI_BRIDGE_SESSION_DIR_ENV] = sessionDir;
+    const providerThreadId = "thread-original";
+    const resumedThreadId = "thread-resumed";
+    const providerSessionFile = join(sessionDir, `${providerThreadId}.jsonl`);
+    writeFileSync(
+      providerSessionFile,
+      `${JSON.stringify({
+        type: "session",
+        version: 3,
+        id: "persisted-session",
+        timestamp: "2026-08-17T00:00:00.000Z",
+        cwd: "/tmp/worktree",
+      })}\n`,
+    );
+
+    try {
+      bridge.sendRequest(62, "thread/resume", {
+        ...sessionParams({ threadId: resumedThreadId }),
+        providerThreadId,
+      });
+      await expect(bridge.waitForResponse(62)).resolves.toMatchObject({
+        id: 62,
+        result: { providerThreadId, sessionRestorable: true },
+      });
+
+      expect(mockOpen).toHaveBeenCalledWith(providerSessionFile, sessionDir);
+      expect(bridge.messages).toContainEqual(
+        expect.objectContaining({
+          method: "thread/identity",
+          params: {
+            threadId: resumedThreadId,
+            providerThreadId,
+            sessionRestorable: true,
+          },
+        }),
+      );
+
+      bridge.sendRequest(63, "thread/discard", {
+        providerThreadId,
+        threadId: resumedThreadId,
+      });
+      await bridge.flushWork();
+      resumedSession.finishAbort();
+      await expect(bridge.waitForResponse(63)).resolves.toMatchObject({
+        id: 63,
+        result: { ok: true },
+      });
+      expect(existsSync(providerSessionFile)).toBe(false);
+    } finally {
+      bridge.restore();
+      rmSync(sessionDir, { recursive: true, force: true });
+    }
+  });
+
   it("fails thread/start when the requested Pi model cannot be resolved", async () => {
     const bridge = createBridgeJsonRpcTestHarness(handleLine);
     mockCreateAgentSession.mockImplementation(async () => ({

--- a/packages/agent-runtime/src/pi/bridge/bridge.ts
+++ b/packages/agent-runtime/src/pi/bridge/bridge.ts
@@ -77,13 +77,13 @@ import {
 
 interface BuildPiSessionOptionsArgs {
   params: PiSessionParams;
-  threadId: string;
+  providerThreadId: string;
 }
 
 /**
- * The canonical Provider Bridge Protocol params, per method. `model/list` and
- * `thread/discard` address the session by bb thread id — pi's provider
- * identity is that id, so it carries `providerThreadId` without reading it.
+ * The canonical Provider Bridge Protocol params, per method. A new Pi session
+ * uses its bb thread id as provider identity; a resumed session can have a new
+ * bb thread id while retaining the provider id that names its persisted file.
  */
 const piCommandSchema = z.discriminatedUnion("method", [
   z.object({
@@ -212,6 +212,8 @@ interface ThreadSession {
   session: PiSdkSession;
   sessionSerial: number;
   closing: boolean;
+  /** Stable provider identity used to resolve the persisted session file. */
+  providerThreadId: string;
   /** Every session-scoped notification is translated through this. */
   translator: PiEventTranslator;
   pendingToolCalls: Map<string | number, PendingBridgeToolCall>;
@@ -245,7 +247,7 @@ const {
 } = createBridgeSessionRegistry<ThreadSession, string | undefined>({
   closeSessionGracefully: (threadSession) =>
     threadSession.session.closeGracefully(THREAD_STOP_CLOSE_TIMEOUT_MS),
-  getProviderThreadId: (_threadSession, threadId) => threadId,
+  getProviderThreadId: (threadSession) => threadSession.providerThreadId,
   sendToolCall: send,
 });
 
@@ -315,23 +317,27 @@ function emitForSession(
 }
 
 /**
- * A session announces identity before any `thread/event`; pi's provider
- * identity is the bb threadId and pi sessions always persist to a session
- * file, so every session is restorable.
+ * A session announces identity before any `thread/event`. Pi sessions always
+ * persist to the file named by their stable provider identity, so every
+ * session is restorable even when bb resumes it under a new thread id.
  */
-function sendThreadIdentity(threadId: string): void {
+function sendThreadIdentity(threadId: string, providerThreadId: string): void {
   send({
     jsonrpc: "2.0",
     method: BRIDGE_NOTIFICATION_METHODS.threadIdentity,
-    params: { threadId, providerThreadId: threadId, sessionRestorable: true },
+    params: { threadId, providerThreadId, sessionRestorable: true },
   });
 }
 
-function sendSessionScopedError(threadId: string, message: string): void {
+function sendSessionScopedError(
+  threadId: string,
+  providerThreadId: string,
+  message: string,
+): void {
   send({
     jsonrpc: "2.0",
     method: BRIDGE_NOTIFICATION_METHODS.error,
-    params: { threadId, providerThreadId: threadId, message },
+    params: { threadId, providerThreadId, message },
   });
 }
 
@@ -348,7 +354,7 @@ function emitSessionError(
   if (state.currentTurnId !== undefined) {
     emitForSession(threadSession, threadId, "error", { threadId, message });
   }
-  sendSessionScopedError(threadId, message);
+  sendSessionScopedError(threadId, threadSession.providerThreadId, message);
 }
 
 function toContextWindowUsagePayload(
@@ -447,7 +453,8 @@ function createOnSessionDone(
       reportSessionError({ ...args, error });
       return;
     }
-    if (!getCurrentThreadSession(args)) {
+    const threadSession = getCurrentThreadSession(args);
+    if (!threadSession) {
       return;
     }
     void closeThreadSession({
@@ -459,7 +466,11 @@ function createOnSessionDone(
         shutdownError instanceof Error
           ? shutdownError.message
           : String(shutdownError);
-      sendSessionScopedError(args.threadId, message);
+      sendSessionScopedError(
+        args.threadId,
+        threadSession.providerThreadId,
+        message,
+      );
     });
   };
 }
@@ -509,7 +520,7 @@ function buildSessionOptions(
     model: args.params.model,
     sessionFilePath: resolvePiSessionFilePath({
       env: process.env,
-      threadId: args.threadId,
+      threadId: args.providerThreadId,
     }),
     systemPrompt: args.params.baseInstructions,
     appendSystemPrompt: args.params.appendSystemPrompt,
@@ -569,14 +580,22 @@ async function handleRequest(
       // configuration decides which providers are configured.
       await handleModelList(request.id, request.params);
       break;
-    // Pi's provider identity is the bb threadId (the canonical
-    // providerThreadId equals it for sessions this bridge minted), so a resume
-    // is a start that reopens the deterministic session file for that id.
+    // A start mints provider identity from the bb thread id. Resume keeps the
+    // caller's stable provider identity while registering the live session
+    // under the new bb thread id used by later turn commands.
     case "thread/start":
+      await handleThreadConstruction(
+        request.id,
+        request.params.threadId,
+        request.params.threadId,
+        toPiSessionParams(request.params),
+      );
+      break;
     case "thread/resume":
       await handleThreadConstruction(
         request.id,
         request.params.threadId,
+        request.params.providerThreadId,
         toPiSessionParams(request.params),
       );
       break;
@@ -646,6 +665,7 @@ async function handleModelList(
 
 async function startPiThreadSession(
   threadId: string,
+  providerThreadId: string,
   params: PiSessionParams,
 ): Promise<void> {
   // Stop existing session for this thread if any
@@ -657,7 +677,7 @@ async function startPiThreadSession(
     });
   }
 
-  const sessionOptions = buildSessionOptions({ params, threadId });
+  const sessionOptions = buildSessionOptions({ params, providerThreadId });
   applyDynamicTools(sessionOptions, params.dynamicTools, threadId);
 
   const sessionSerial = nextSessionSerial();
@@ -671,6 +691,7 @@ async function startPiThreadSession(
     session,
     sessionSerial,
     closing: false,
+    providerThreadId,
     translator: createSessionTranslator(),
     pendingToolCalls: new Map(),
   };
@@ -685,35 +706,35 @@ async function startPiThreadSession(
 }
 
 /**
- * Announce the constructed session. Pi has no separately minted session id:
- * its provider identity is the BB thread id. The result returns that identity
- * synchronously so callers do not have to race the thread/identity
- * notification.
+ * Announce the constructed session. Starts mint identity from the bb thread
+ * id; resumes return the earlier identity whose session file was reopened.
+ * The synchronous result keeps callers from racing the notification.
  */
-function sendThreadSessionResult(id: string | number, threadId: string): void {
-  sendThreadIdentity(threadId);
-  sendResult(id, { providerThreadId: threadId, sessionRestorable: true });
+function sendThreadSessionResult(
+  id: string | number,
+  threadId: string,
+  providerThreadId: string,
+): void {
+  sendThreadIdentity(threadId, providerThreadId);
+  sendResult(id, { providerThreadId, sessionRestorable: true });
 }
 
 async function handleThreadConstruction(
   id: string | number,
   threadId: string,
+  providerThreadId: string,
   params: PiSessionParams,
 ): Promise<void> {
-  await startPiThreadSession(threadId, params);
-  sendThreadSessionResult(id, threadId);
+  await startPiThreadSession(threadId, providerThreadId, params);
+  sendThreadSessionResult(id, threadId, providerThreadId);
 }
 
-// Pi keeps no provider-minted session id: provider identity == bb threadId, and
-// the session file is the deterministic path for that threadId. Forking therefore
-// means materializing the source thread's full history at the NEW thread's
-// deterministic path, then launching like thread/start (which SessionManager.open's
-// that path). A dedicated handler — rather than a sessionPath hint on thread/start —
-// keeps "open my own file fresh" (start) distinct from "copy another file's history
-// into my file" (fork). SessionManager.forkFrom picks its own filename inside the
-// bridge session dir, so we rename the forked file onto the new thread's path before
-// startPiThreadSession opens it. The forked header's parentSession still points at
-// the source file, preserving lineage.
+// Pi mints provider identity from the bb thread id for new sessions, and the
+// session file is the deterministic path for that provider id. Forking means
+// materializing source history at the NEW thread's path, then launching like
+// thread/start. A dedicated handler keeps "open my own file fresh" distinct
+// from "copy another file's history into my file". SessionManager.forkFrom
+// picks its own filename, so move it onto the new identity's path before open.
 async function handleThreadFork(
   id: string | number,
   params: ThreadForkParams,
@@ -773,6 +794,7 @@ async function handleThreadFork(
 
   await handleThreadConstruction(
     id,
+    params.threadId,
     params.threadId,
     toPiSessionParams(params),
   );
@@ -986,7 +1008,10 @@ async function handleThreadDiscard(
     threadId: params.threadId,
   });
   rmSync(
-    resolvePiSessionFilePath({ env: process.env, threadId: params.threadId }),
+    resolvePiSessionFilePath({
+      env: process.env,
+      threadId: params.providerThreadId,
+    }),
     { force: true },
   );
   return { ok: true };

--- a/packages/agent-runtime/src/test/fake-adapter.ts
+++ b/packages/agent-runtime/src/test/fake-adapter.ts
@@ -343,6 +343,7 @@ function translateEventMessage(event: ProviderRuntimeEvent): ThreadEvent[] {
         },
       ];
     }
+    case "item/started":
     case "item/completed": {
       const item = threadEventItemSchema.parse(message.params.item);
       if (item.type === "userMessage") {
@@ -350,7 +351,7 @@ function translateEventMessage(event: ProviderRuntimeEvent): ThreadEvent[] {
       }
       return [
         {
-          type: "item/completed",
+          type: message.method,
           threadId,
           providerThreadId,
           scope: turnScope(turnId),

--- a/packages/agent-runtime/src/test/fake-provider-script.ts
+++ b/packages/agent-runtime/src/test/fake-provider-script.ts
@@ -270,6 +270,20 @@ function completeTurn(
   clearActiveTurn(thread);
 
   if (status === "completed") {
+    const itemId = `msg-${thread.turnCount}`;
+    send({
+      jsonrpc: "2.0",
+      method: "item/started",
+      params: {
+        threadId,
+        turnId: turn.turnId,
+        item: {
+          type: "agentMessage",
+          id: itemId,
+          text: "",
+        },
+      },
+    });
     send({
       jsonrpc: "2.0",
       method: "item/completed",
@@ -278,7 +292,7 @@ function completeTurn(
         turnId: turn.turnId,
         item: {
           type: "agentMessage",
-          id: `msg-${thread.turnCount}`,
+          id: itemId,
           text: responseText,
         },
       },

--- a/packages/agent-runtime/src/test/runtime-integration-harness.ts
+++ b/packages/agent-runtime/src/test/runtime-integration-harness.ts
@@ -639,15 +639,6 @@ export function getCompletedCommands(events: ThreadEvent[]): string[] {
   return commands;
 }
 
-export function hasDeniedCommandExecution(events: ThreadEvent[]): boolean {
-  return events.some(
-    (event) =>
-      event.type === "item/completed" &&
-      event.item.type === "commandExecution" &&
-      event.item.approvalStatus === "denied",
-  );
-}
-
 export async function resolveDefaultModel(
   providerId: string,
   ctx: TestContext,

--- a/packages/db/drizzle/0100_flippant_psylocke.sql
+++ b/packages/db/drizzle/0100_flippant_psylocke.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS `events_item_lifecycle_thread_item_sequence_idx` ON `events` (`thread_id`,`item_id`,`sequence`) WHERE "events"."type" IN ('item/started', 'item/completed', 'item/backgroundTask/completed');

--- a/packages/db/drizzle/meta/0100_snapshot.json
+++ b/packages/db/drizzle/meta/0100_snapshot.json
@@ -1,0 +1,3664 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "22808b50-d8d8-42a4-a341-ece2b35aabea",
+  "prevId": "cbf5d14d-1d4e-41d8-bed1-a89f14f3b10f",
+  "tables": {
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caffeinate": {
+          "name": "caffeinate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "show_keyboard_hints": {
+          "name": "show_keyboard_hints",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "steer_active_thread_on_enter": {
+          "name": "steer_active_thread_on_enter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "show_unhandled_provider_events": {
+          "name": "show_unhandled_provider_events",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "codex_memory_enabled": {
+          "name": "codex_memory_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "claude_code_memory_enabled": {
+          "name": "claude_code_memory_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "codex_subagents_disabled": {
+          "name": "codex_subagents_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "claude_code_subagents_disabled": {
+          "name": "claude_code_subagents_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "claude_code_workflows_disabled": {
+          "name": "claude_code_workflows_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "keybinding_overrides": {
+          "name": "keybinding_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_theme": {
+      "name": "app_theme",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "favicon_color": {
+          "name": "favicon_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refillInterval": {
+          "name": "refillInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refillAmount": {
+          "name": "refillAmount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastRefillAt": {
+          "name": "lastRefillAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitEnabled": {
+          "name": "rateLimitEnabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitTimeWindow": {
+          "name": "rateLimitTimeWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitMax": {
+          "name": "rateLimitMax",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requestCount": {
+          "name": "requestCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastRequest": {
+          "name": "lastRequest",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configId": {
+          "name": "configId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_key_unique": {
+          "name": "apikey_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "apikey_reference_id_idx": {
+          "name": "apikey_reference_id_idx",
+          "columns": [
+            "referenceId"
+          ],
+          "isUnique": false
+        },
+        "apikey_config_id_idx": {
+          "name": "apikey_config_id_idx",
+          "columns": [
+            "configId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_referenceId_user_id_fk": {
+          "name": "apikey_referenceId_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "referenceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "environments": {
+      "name": "environments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "managed": {
+          "name": "managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_git_repo": {
+          "name": "is_git_repo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_worktree": {
+          "name": "is_worktree",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "merge_base_branch": {
+          "name": "merge_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "destroy_attempt_id": {
+          "name": "destroy_attempt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retire_requested_at": {
+          "name": "retire_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_provision_type": {
+          "name": "workspace_provision_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'provisioning'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "environments_project_host_path_idx": {
+          "name": "environments_project_host_path_idx",
+          "columns": [
+            "project_id",
+            "host_id",
+            "path"
+          ],
+          "isUnique": true
+        },
+        "environments_host_path_lookup_idx": {
+          "name": "environments_host_path_lookup_idx",
+          "columns": [
+            "host_id",
+            "path"
+          ],
+          "isUnique": false
+        },
+        "environments_project_idx": {
+          "name": "environments_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "environments_status_idx": {
+          "name": "environments_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "environments_project_id_projects_id_fk": {
+          "name": "environments_project_id_projects_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environments_host_id_hosts_id_fk": {
+          "name": "environments_host_id_hosts_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope_kind": {
+          "name": "scope_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_thread_sequence_idx": {
+          "name": "events_thread_sequence_idx",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": true
+        },
+        "events_tool_call_parent_lookup_idx": {
+          "name": "events_tool_call_parent_lookup_idx",
+          "columns": [
+            "thread_id",
+            "item_id",
+            "sequence"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"item_kind\" = 'toolCall'"
+        },
+        "events_thread_type_item_kind_sequence_idx": {
+          "name": "events_thread_type_item_kind_sequence_idx",
+          "columns": [
+            "thread_id",
+            "type",
+            "item_kind",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_background_task_thread_type_item_sequence_idx": {
+          "name": "events_background_task_thread_type_item_sequence_idx",
+          "columns": [
+            "thread_id",
+            "type",
+            "item_id",
+            "sequence"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"item_kind\" = 'backgroundTask'"
+        },
+        "events_thread_type_sequence_idx": {
+          "name": "events_thread_type_sequence_idx",
+          "columns": [
+            "thread_id",
+            "type",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_thread_turn_type_item_sequence_idx": {
+          "name": "events_thread_turn_type_item_sequence_idx",
+          "columns": [
+            "thread_id",
+            "turn_id",
+            "type",
+            "item_id",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_item_lifecycle_thread_item_sequence_idx": {
+          "name": "events_item_lifecycle_thread_item_sequence_idx",
+          "columns": [
+            "thread_id",
+            "item_id",
+            "sequence"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"type\" IN ('item/started', 'item/completed', 'item/backgroundTask/completed')"
+        },
+        "events_environment_idx": {
+          "name": "events_environment_idx",
+          "columns": [
+            "environment_id"
+          ],
+          "isUnique": false
+        },
+        "events_completed_item_truncation_idx": {
+          "name": "events_completed_item_truncation_idx",
+          "columns": [
+            "item_kind",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"type\" = 'item/completed'"
+        },
+        "events_goal_thread_sequence_idx": {
+          "name": "events_goal_thread_sequence_idx",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"type\" IN ('thread/goal/updated', 'thread/goal/cleared')"
+        }
+      },
+      "foreignKeys": {
+        "events_thread_id_threads_id_fk": {
+          "name": "events_thread_id_threads_id_fk",
+          "tableFrom": "events",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_environment_id_environments_id_fk": {
+          "name": "events_environment_id_environments_id_fk",
+          "tableFrom": "events",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "events_scope_shape_check": {
+          "name": "events_scope_shape_check",
+          "value": "(\n        (\"events\".\"scope_kind\" = 'turn' AND \"events\".\"turn_id\" IS NOT NULL)\n        OR\n        (\"events\".\"scope_kind\" = 'thread' AND \"events\".\"turn_id\" IS NULL)\n      )"
+        }
+      }
+    },
+    "host_daemon_sessions": {
+      "name": "host_daemon_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_name": {
+          "name": "host_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_type": {
+          "name": "host_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_dir": {
+          "name": "data_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol_version": {
+          "name": "protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_interval_ms": {
+          "name": "heartbeat_interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lease_timeout_ms": {
+          "name": "lease_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_daemon_sessions_host_status_idx": {
+          "name": "host_daemon_sessions_host_status_idx",
+          "columns": [
+            "host_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "host_daemon_sessions_host_latest_idx": {
+          "name": "host_daemon_sessions_host_latest_idx",
+          "columns": [
+            "host_id",
+            "updated_at",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "host_daemon_sessions_closed_prune_idx": {
+          "name": "host_daemon_sessions_closed_prune_idx",
+          "columns": [
+            "status",
+            "closed_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "host_daemon_sessions_host_id_hosts_id_fk": {
+          "name": "host_daemon_sessions_host_id_hosts_id_fk",
+          "tableFrom": "host_daemon_sessions",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hosts": {
+      "name": "hosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connect_machine_id": {
+          "name": "connect_machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_permission_mode": {
+          "name": "max_permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'full'"
+        },
+        "destroyed_at": {
+          "name": "destroyed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_rejected_protocol_version": {
+          "name": "last_rejected_protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "hosts_last_seen_idx": {
+          "name": "hosts_last_seen_idx",
+          "columns": [
+            "last_seen_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugins": {
+      "name": "plugins",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'direct'"
+        },
+        "catalog_entry_id": {
+          "name": "catalog_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "catalog_marketplace_name": {
+          "name": "catalog_marketplace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'path'"
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_builtin_name": {
+          "name": "source_builtin_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_npm_package": {
+          "name": "source_npm_package",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_npm_registry": {
+          "name": "source_npm_registry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_npm_requested_spec": {
+          "name": "source_npm_requested_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_npm_spec_kind": {
+          "name": "source_npm_spec_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_url": {
+          "name": "source_git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_subdirectory": {
+          "name": "source_git_subdirectory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_requested_ref": {
+          "name": "source_git_requested_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_ref_kind": {
+          "name": "source_git_ref_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_range": {
+          "name": "source_git_range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_tag_prefix": {
+          "name": "source_git_tag_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_resolved_tag": {
+          "name": "source_git_resolved_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "npm_resolved_version": {
+          "name": "npm_resolved_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "npm_integrity": {
+          "name": "npm_integrity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_resolved_commit": {
+          "name": "git_resolved_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_update_check_at": {
+          "name": "last_update_check_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "available_compatible_version": {
+          "name": "available_compatible_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "newest_incompatible_version": {
+          "name": "newest_incompatible_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "update_status_detail": {
+          "name": "update_status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_failure_version": {
+          "name": "last_failure_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_failure_at": {
+          "name": "last_failure_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_failure_detail": {
+          "name": "last_failure_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_artifact_id": {
+          "name": "active_artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "normalization_version": {
+          "name": "normalization_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "root_dir": {
+          "name": "root_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plugins_active_artifact_id_plugin_artifacts_id_fk": {
+          "name": "plugins_active_artifact_id_plugin_artifacts_id_fk",
+          "tableFrom": "plugins",
+          "tableTo": "plugin_artifacts",
+          "columnsFrom": [
+            "active_artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_scan_cursors": {
+      "name": "maintenance_scan_cursors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_path": {
+          "name": "output_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_created_at": {
+          "name": "last_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "maintenance_scan_cursors_path_idx": {
+          "name": "maintenance_scan_cursors_path_idx",
+          "columns": [
+            "policy",
+            "version",
+            "item_kind",
+            "output_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pending_interactions": {
+      "name": "pending_interactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'provider'"
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_request_id": {
+          "name": "provider_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "renderer_id": {
+          "name": "renderer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pending_interactions_provider_request_idx": {
+          "name": "pending_interactions_provider_request_idx",
+          "columns": [
+            "provider_id",
+            "provider_thread_id",
+            "provider_request_id"
+          ],
+          "isUnique": true
+        },
+        "pending_interactions_thread_created_idx": {
+          "name": "pending_interactions_thread_created_idx",
+          "columns": [
+            "thread_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pending_interactions_thread_status_created_idx": {
+          "name": "pending_interactions_thread_status_created_idx",
+          "columns": [
+            "thread_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pending_interactions_status_created_idx": {
+          "name": "pending_interactions_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pending_interactions_plugin_status_created_idx": {
+          "name": "pending_interactions_plugin_status_created_idx",
+          "columns": [
+            "plugin_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pending_interactions_thread_id_threads_id_fk": {
+          "name": "pending_interactions_thread_id_threads_id_fk",
+          "tableFrom": "pending_interactions",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_artifacts": {
+      "name": "plugin_artifacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "npm_resolved_version": {
+          "name": "npm_resolved_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_resolved_commit": {
+          "name": "git_resolved_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_checkout_root": {
+          "name": "git_checkout_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_result": {
+          "name": "validation_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_artifacts_plugin_idx": {
+          "name": "plugin_artifacts_plugin_idx",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_kv": {
+      "name": "plugin_kv",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_kv_plugin_id_key_pk": {
+          "columns": [
+            "plugin_id",
+            "key"
+          ],
+          "name": "plugin_kv_plugin_id_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_marketplace_icons": {
+      "name": "plugin_marketplace_icons",
+      "columns": {
+        "marketplace_name": {
+          "name": "marketplace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_marketplace_icons_marketplace_name_entry_id_pk": {
+          "columns": [
+            "marketplace_name",
+            "entry_id"
+          ],
+          "name": "plugin_marketplace_icons_marketplace_name_entry_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_marketplaces": {
+      "name": "plugin_marketplaces",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'https'"
+        },
+        "manifest_url": {
+          "name": "manifest_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_git_ref": {
+          "name": "source_git_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_commit": {
+          "name": "source_git_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "manifest_json": {
+          "name": "manifest_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_successful_refresh_at": {
+          "name": "last_successful_refresh_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_attempted_refresh_at": {
+          "name": "last_attempted_refresh_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_schedules": {
+      "name": "plugin_schedules",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_schedules_plugin_id_name_pk": {
+          "columns": [
+            "plugin_id",
+            "name"
+          ],
+          "name": "plugin_schedules_plugin_id_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_settings": {
+      "name": "plugin_settings",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_settings_plugin_id_key_pk": {
+          "columns": [
+            "plugin_id",
+            "key"
+          ],
+          "name": "plugin_settings_plugin_id_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_state_snapshots": {
+      "name": "plugin_state_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_artifact_id": {
+          "name": "from_artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_artifact_id": {
+          "name": "to_artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_path": {
+          "name": "snapshot_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "database_path": {
+          "name": "database_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_path": {
+          "name": "state_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secrets_path": {
+          "name": "secrets_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "registration_path": {
+          "name": "registration_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rollback_candidate_version": {
+          "name": "rollback_candidate_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_source_fingerprint": {
+          "name": "rollback_source_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_bb_version": {
+          "name": "rollback_bb_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_sdk_version": {
+          "name": "rollback_sdk_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_detail": {
+          "name": "rollback_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retained_until": {
+          "name": "retained_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_state_snapshots_plugin_idx": {
+          "name": "plugin_state_snapshots_plugin_idx",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_state_snapshots_retention_idx": {
+          "name": "plugin_state_snapshots_retention_idx",
+          "columns": [
+            "retained_until"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_execution_defaults": {
+      "name": "project_execution_defaults",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_execution_defaults_project_idx": {
+          "name": "project_execution_defaults_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_execution_defaults_project_id_projects_id_fk": {
+          "name": "project_execution_defaults_project_id_projects_id_fk",
+          "tableFrom": "project_execution_defaults",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_sources": {
+      "name": "project_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_sources_project_idx": {
+          "name": "project_sources_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "project_sources_host_idx": {
+          "name": "project_sources_host_idx",
+          "columns": [
+            "host_id"
+          ],
+          "isUnique": false
+        },
+        "project_sources_project_host_idx": {
+          "name": "project_sources_project_host_idx",
+          "columns": [
+            "project_id",
+            "host_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_sources_project_id_projects_id_fk": {
+          "name": "project_sources_project_id_projects_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_sources_host_id_hosts_id_fk": {
+          "name": "project_sources_host_id_hosts_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "project_sources_shape_check": {
+          "name": "project_sources_shape_check",
+          "value": "(\n        \"project_sources\".\"type\" = 'local_path' AND \"project_sources\".\"host_id\" IS NOT NULL AND \"project_sources\".\"path\" IS NOT NULL\n      )"
+        }
+      }
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'standard'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_remote_url": {
+          "name": "git_remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_key": {
+          "name": "sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'V'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_updated_idx": {
+          "name": "projects_updated_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "projects_deleted_idx": {
+          "name": "projects_deleted_idx",
+          "columns": [
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "projects_sort_idx": {
+          "name": "projects_sort_idx",
+          "columns": [
+            "sort_key",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "projects_personal_singleton_idx": {
+          "name": "projects_personal_singleton_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": true,
+          "where": "\"projects\".\"kind\" = 'personal'"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_history_entries": {
+      "name": "prompt_history_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_sequence": {
+          "name": "request_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prompt_history_entries_thread_request_idx": {
+          "name": "prompt_history_entries_thread_request_idx",
+          "columns": [
+            "thread_id",
+            "request_sequence"
+          ],
+          "isUnique": true
+        },
+        "prompt_history_entries_project_scope_created_idx": {
+          "name": "prompt_history_entries_project_scope_created_idx",
+          "columns": [
+            "project_id",
+            "scope",
+            "created_at",
+            "request_sequence",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "prompt_history_entries_thread_scope_created_idx": {
+          "name": "prompt_history_entries_thread_scope_created_idx",
+          "columns": [
+            "thread_id",
+            "scope",
+            "created_at",
+            "request_sequence",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "prompt_history_entries_project_id_projects_id_fk": {
+          "name": "prompt_history_entries_project_id_projects_id_fk",
+          "tableFrom": "prompt_history_entries",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prompt_history_entries_thread_id_threads_id_fk": {
+          "name": "prompt_history_entries_thread_id_threads_id_fk",
+          "tableFrom": "prompt_history_entries",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queued_thread_messages": {
+      "name": "queued_thread_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_thread_id": {
+          "name": "sender_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_with_next": {
+          "name": "group_with_next",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_key": {
+          "name": "sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "queued_thread_messages_thread_created_idx": {
+          "name": "queued_thread_messages_thread_created_idx",
+          "columns": [
+            "thread_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "queued_thread_messages_thread_sort_idx": {
+          "name": "queued_thread_messages_thread_sort_idx",
+          "columns": [
+            "thread_id",
+            "sort_key",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "queued_thread_messages_thread_id_threads_id_fk": {
+          "name": "queued_thread_messages_thread_id_threads_id_fk",
+          "tableFrom": "queued_thread_messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_experiments": {
+      "name": "system_experiments",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_sessions": {
+      "name": "terminal_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daemon_session_id": {
+          "name": "daemon_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_cwd": {
+          "name": "initial_cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cols": {
+          "name": "cols",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rows": {
+          "name": "rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_user_input_at": {
+          "name": "last_user_input_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_sessions_thread_status_updated_idx": {
+          "name": "terminal_sessions_thread_status_updated_idx",
+          "columns": [
+            "thread_id",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_environment_status_idx": {
+          "name": "terminal_sessions_environment_status_idx",
+          "columns": [
+            "environment_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_host_status_idx": {
+          "name": "terminal_sessions_host_status_idx",
+          "columns": [
+            "host_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_daemon_session_idx": {
+          "name": "terminal_sessions_daemon_session_idx",
+          "columns": [
+            "daemon_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_thread_id_threads_id_fk": {
+          "name": "terminal_sessions_thread_id_threads_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_environment_id_environments_id_fk": {
+          "name": "terminal_sessions_environment_id_environments_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_host_id_hosts_id_fk": {
+          "name": "terminal_sessions_host_id_hosts_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_daemon_session_id_host_daemon_sessions_id_fk": {
+          "name": "terminal_sessions_daemon_session_id_host_daemon_sessions_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "host_daemon_sessions",
+          "columnsFrom": [
+            "daemon_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_dynamic_context_file_states": {
+      "name": "thread_dynamic_context_file_states",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_status": {
+          "name": "content_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shown_at": {
+          "name": "shown_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "thread_dynamic_context_file_states_thread_file_idx": {
+          "name": "thread_dynamic_context_file_states_thread_file_idx",
+          "columns": [
+            "thread_id",
+            "file_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "thread_dynamic_context_file_states_thread_id_threads_id_fk": {
+          "name": "thread_dynamic_context_file_states_thread_id_threads_id_fk",
+          "tableFrom": "thread_dynamic_context_file_states",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_search_segments": {
+      "name": "thread_search_segments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_seq": {
+          "name": "source_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "thread_search_segments_source_idx": {
+          "name": "thread_search_segments_source_idx",
+          "columns": [
+            "thread_id",
+            "source_kind",
+            "source_key"
+          ],
+          "isUnique": true
+        },
+        "thread_search_segments_thread_source_seq_idx": {
+          "name": "thread_search_segments_thread_source_seq_idx",
+          "columns": [
+            "thread_id",
+            "source_seq"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thread_search_segments_thread_id_threads_id_fk": {
+          "name": "thread_search_segments_thread_id_threads_id_fk",
+          "tableFrom": "thread_search_segments",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_sections": {
+      "name": "thread_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "thread_sections_name_idx": {
+          "name": "thread_sections_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_tabs": {
+      "name": "thread_tabs",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tabs_json": {
+          "name": "tabs_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_tabs_thread_id_threads_id_fk": {
+          "name": "thread_tabs_thread_id_threads_id_fk",
+          "tableFrom": "thread_tabs",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "threads": {
+      "name": "threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_override": {
+          "name": "model_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_level_override": {
+          "name": "reasoning_level_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title_fallback": {
+          "name": "title_fallback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'starting'"
+        },
+        "parent_thread_id": {
+          "name": "parent_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_plugin_id": {
+          "name": "origin_plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'visible'"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pin_sort_key": {
+          "name": "pin_sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_attention_at": {
+          "name": "latest_attention_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "threads_project_updated_idx": {
+          "name": "threads_project_updated_idx",
+          "columns": [
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "threads_project_archived_deleted_idx": {
+          "name": "threads_project_archived_deleted_idx",
+          "columns": [
+            "project_id",
+            "archived_at",
+            "deleted_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "threads_pin_sort_idx": {
+          "name": "threads_pin_sort_idx",
+          "columns": [
+            "archived_at",
+            "deleted_at",
+            "pin_sort_key",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "\"threads\".\"pinned_at\" IS NOT NULL"
+        },
+        "threads_environment_idx": {
+          "name": "threads_environment_idx",
+          "columns": [
+            "environment_id"
+          ],
+          "isUnique": false
+        },
+        "threads_parent_idx": {
+          "name": "threads_parent_idx",
+          "columns": [
+            "parent_thread_id"
+          ],
+          "isUnique": false
+        },
+        "threads_source_origin_idx": {
+          "name": "threads_source_origin_idx",
+          "columns": [
+            "source_thread_id",
+            "origin_kind"
+          ],
+          "isUnique": false
+        },
+        "threads_origin_plugin_archived_idx": {
+          "name": "threads_origin_plugin_archived_idx",
+          "columns": [
+            "origin_plugin_id",
+            "archived_at"
+          ],
+          "isUnique": false
+        },
+        "threads_section_archived_deleted_idx": {
+          "name": "threads_section_archived_deleted_idx",
+          "columns": [
+            "section_id",
+            "archived_at",
+            "deleted_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "threads_archived_status_idx": {
+          "name": "threads_archived_status_idx",
+          "columns": [
+            "archived_at",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "threads_environment_archived_deleted_idx": {
+          "name": "threads_environment_archived_deleted_idx",
+          "columns": [
+            "environment_id",
+            "archived_at",
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "threads_active_maintenance_idx": {
+          "name": "threads_active_maintenance_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false,
+          "where": "\"threads\".\"deleted_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "threads_project_id_projects_id_fk": {
+          "name": "threads_project_id_projects_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "threads_environment_id_environments_id_fk": {
+          "name": "threads_environment_id_environments_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "threads_section_id_thread_sections_id_fk": {
+          "name": "threads_section_id_thread_sections_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "thread_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "threads_parent_thread_id_threads_id_fk": {
+          "name": "threads_parent_thread_id_threads_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "parent_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "threads_source_thread_id_threads_id_fk": {
+          "name": "threads_source_thread_id_threads_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "source_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -701,6 +701,13 @@
       "when": 1787001047515,
       "tag": "0099_flawless_maximus",
       "breakpoints": true
+    },
+    {
+      "idx": 100,
+      "version": "6",
+      "when": 1787031224925,
+      "tag": "0100_flippant_psylocke",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -578,7 +578,6 @@ export function appendDaemonEventsInTransaction(
   const acceptedEvents: AcceptedDaemonEvent[] = [];
   const insertedInputIndexes: number[] = [];
   const skippedTurnUnstartedInputIndexes: number[] = [];
-  const settledItemKeys = new Set<string>();
 
   const startedTurnKeys = listStoredTurnStartedKeySet(
     db,
@@ -594,25 +593,46 @@ export function appendDaemonEventsInTransaction(
       continue;
     }
 
+    const turnId = getThreadEventScopeTurnId(input.scope) ?? null;
     if (
       (input.type === "item/completed" ||
         input.type === "item/backgroundTask/completed") &&
       input.itemId !== null
     ) {
-      const settledItemKey = `${input.threadId}\0${input.itemId}`;
+      const latestTurnStartedSequence =
+        turnId === null
+          ? undefined
+          : db
+              .select({ sequence: events.sequence })
+              .from(events)
+              .where(
+                and(
+                  eq(events.threadId, input.threadId),
+                  eq(events.turnId, turnId),
+                  eq(events.type, "turn/started"),
+                ),
+              )
+              .orderBy(desc(events.sequence))
+              .limit(1)
+              .get()?.sequence;
       const alreadySettled =
-        settledItemKeys.has(settledItemKey) ||
         db
           .select({ id: events.id })
           .from(events)
           .where(
             and(
               eq(events.threadId, input.threadId),
+              turnId === null
+                ? isNull(events.turnId)
+                : eq(events.turnId, turnId),
               eq(events.itemId, input.itemId),
               inArray(events.type, [
                 "item/completed",
                 "item/backgroundTask/completed",
               ]),
+              latestTurnStartedSequence === undefined
+                ? undefined
+                : gt(events.sequence, latestTurnStartedSequence),
             ),
           )
           .limit(1)
@@ -620,14 +640,12 @@ export function appendDaemonEventsInTransaction(
       if (alreadySettled) {
         continue;
       }
-      settledItemKeys.add(settledItemKey);
     }
 
     const sequence = nextSequencesByThreadId.get(input.threadId);
     if (sequence === undefined) {
       throw new Error(`Missing event sequence for thread: ${input.threadId}`);
     }
-    const turnId = getThreadEventScopeTurnId(input.scope) ?? null;
     db.run(
       sql`INSERT INTO events
         (id, thread_id, environment_id, scope_kind, turn_id, provider_thread_id, sequence, type, item_id, item_kind, data, created_at)

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -578,6 +578,7 @@ export function appendDaemonEventsInTransaction(
   const acceptedEvents: AcceptedDaemonEvent[] = [];
   const insertedInputIndexes: number[] = [];
   const skippedTurnUnstartedInputIndexes: number[] = [];
+  const settledItemKeys = new Set<string>();
 
   const startedTurnKeys = listStoredTurnStartedKeySet(
     db,
@@ -591,6 +592,35 @@ export function appendDaemonEventsInTransaction(
     ) {
       skippedTurnUnstartedInputIndexes.push(index);
       continue;
+    }
+
+    if (
+      (input.type === "item/completed" ||
+        input.type === "item/backgroundTask/completed") &&
+      input.itemId !== null
+    ) {
+      const settledItemKey = `${input.threadId}\0${input.itemId}`;
+      const alreadySettled =
+        settledItemKeys.has(settledItemKey) ||
+        db
+          .select({ id: events.id })
+          .from(events)
+          .where(
+            and(
+              eq(events.threadId, input.threadId),
+              eq(events.itemId, input.itemId),
+              inArray(events.type, [
+                "item/completed",
+                "item/backgroundTask/completed",
+              ]),
+            ),
+          )
+          .limit(1)
+          .get() !== undefined;
+      if (alreadySettled) {
+        continue;
+      }
+      settledItemKeys.add(settledItemKey);
     }
 
     const sequence = nextSequencesByThreadId.get(input.threadId);

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -158,6 +158,92 @@ export interface AppendDaemonEventsResult {
   skippedTurnUnstartedInputIndexes: number[];
 }
 
+interface ItemLifecycleLookupKey {
+  itemId: string;
+  threadId: string;
+}
+
+interface LatestItemLifecycleRow extends ItemLifecycleLookupKey {
+  type:
+    | "item/started"
+    | "item/completed"
+    | "item/backgroundTask/completed";
+}
+
+const TERMINAL_ITEM_EVENT_TYPES = [
+  "item/completed",
+  "item/backgroundTask/completed",
+] as const satisfies readonly ThreadEventType[];
+
+function isTerminalItemEventType(
+  type: ThreadEventType,
+): type is (typeof TERMINAL_ITEM_EVENT_TYPES)[number] {
+  return type === "item/completed" || type === "item/backgroundTask/completed";
+}
+
+function buildItemLifecycleKey(args: ItemLifecycleLookupKey): string {
+  return `${args.threadId}\0${args.itemId}`;
+}
+
+function collectTerminalItemLookupKeys(
+  eventInputs: readonly AppendDaemonEventInput[],
+): ItemLifecycleLookupKey[] {
+  return eventInputs.flatMap((input) =>
+    input.itemId !== null && isTerminalItemEventType(input.type)
+      ? [{ itemId: input.itemId, threadId: input.threadId }]
+      : [],
+  );
+}
+
+function listLatestItemLifecycleRows(
+  db: DbQueryConnection,
+  lookupKeys: readonly ItemLifecycleLookupKey[],
+): LatestItemLifecycleRow[] {
+  return queryInSqliteVariableBatches({
+    dedupeKey: buildItemLifecycleKey,
+    fixedVariableCount: 0,
+    queryBatch: (keys) => {
+      const requestedValues = sql.join(
+        keys.map((key) => sql`(${key.threadId}, ${key.itemId})`),
+        sql`, `,
+      );
+      return db.all<LatestItemLifecycleRow>(sql`
+        WITH requested_item(thread_id, item_id) AS (
+          VALUES ${requestedValues}
+        )
+        SELECT
+          lifecycle.thread_id AS threadId,
+          lifecycle.item_id AS itemId,
+          lifecycle.type AS type
+        FROM requested_item requested
+        JOIN ${events} AS lifecycle
+          INDEXED BY events_item_lifecycle_thread_item_sequence_idx
+          ON lifecycle.thread_id = requested.thread_id
+          AND lifecycle.item_id = requested.item_id
+        WHERE lifecycle.type IN (
+          'item/started',
+          'item/completed',
+          'item/backgroundTask/completed'
+        )
+          AND lifecycle.sequence = (
+            SELECT MAX(candidate.sequence)
+            FROM ${events} AS candidate
+              INDEXED BY events_item_lifecycle_thread_item_sequence_idx
+            WHERE candidate.thread_id = requested.thread_id
+              AND candidate.item_id = requested.item_id
+              AND candidate.type IN (
+                'item/started',
+                'item/completed',
+                'item/backgroundTask/completed'
+              )
+          )
+      `);
+    },
+    values: lookupKeys,
+    variableCountPerValue: 2,
+  });
+}
+
 export interface MissingStoredTurnStartedDetails {
   eventType: ThreadEventType;
   scopeKind: ThreadEventScopeKind;
@@ -583,6 +669,14 @@ export function appendDaemonEventsInTransaction(
     db,
     collectDaemonTurnStartLookupKeys(eventInputs),
   );
+  const settledItemKeys = new Set(
+    listLatestItemLifecycleRows(
+      db,
+      collectTerminalItemLookupKeys(eventInputs),
+    )
+      .filter((row) => isTerminalItemEventType(row.type))
+      .map(buildItemLifecycleKey),
+  );
   const now = Date.now();
   for (const [index, input] of eventInputs.entries()) {
     if (
@@ -594,52 +688,23 @@ export function appendDaemonEventsInTransaction(
     }
 
     const turnId = getThreadEventScopeTurnId(input.scope) ?? null;
-    if (
-      (input.type === "item/completed" ||
-        input.type === "item/backgroundTask/completed") &&
-      input.itemId !== null
+    const itemLifecycleKey =
+      input.itemId === null
+        ? null
+        : buildItemLifecycleKey({
+            itemId: input.itemId,
+            threadId: input.threadId,
+          });
+    if (input.type === "item/started" && itemLifecycleKey !== null) {
+      settledItemKeys.delete(itemLifecycleKey);
+    } else if (
+      isTerminalItemEventType(input.type) &&
+      itemLifecycleKey !== null
     ) {
-      const latestTurnStartedSequence =
-        turnId === null
-          ? undefined
-          : db
-              .select({ sequence: events.sequence })
-              .from(events)
-              .where(
-                and(
-                  eq(events.threadId, input.threadId),
-                  eq(events.turnId, turnId),
-                  eq(events.type, "turn/started"),
-                ),
-              )
-              .orderBy(desc(events.sequence))
-              .limit(1)
-              .get()?.sequence;
-      const alreadySettled =
-        db
-          .select({ id: events.id })
-          .from(events)
-          .where(
-            and(
-              eq(events.threadId, input.threadId),
-              turnId === null
-                ? isNull(events.turnId)
-                : eq(events.turnId, turnId),
-              eq(events.itemId, input.itemId),
-              inArray(events.type, [
-                "item/completed",
-                "item/backgroundTask/completed",
-              ]),
-              latestTurnStartedSequence === undefined
-                ? undefined
-                : gt(events.sequence, latestTurnStartedSequence),
-            ),
-          )
-          .limit(1)
-          .get() !== undefined;
-      if (alreadySettled) {
+      if (settledItemKeys.has(itemLifecycleKey)) {
         continue;
       }
+      settledItemKeys.add(itemLifecycleKey);
     }
 
     const sequence = nextSequencesByThreadId.get(input.threadId);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -758,6 +758,11 @@ export const events = sqliteTable(
       table.itemId,
       table.sequence,
     ),
+    index("events_item_lifecycle_thread_item_sequence_idx")
+      .on(table.threadId, table.itemId, table.sequence)
+      .where(
+        sql`${table.type} IN ('item/started', 'item/completed', 'item/backgroundTask/completed')`,
+      ),
     index("events_environment_idx").on(table.environmentId),
     index("events_completed_item_truncation_idx")
       .on(table.itemKind, table.createdAt, table.id)

--- a/packages/db/test/data/events.test.ts
+++ b/packages/db/test/data/events.test.ts
@@ -371,6 +371,91 @@ describe("events", () => {
     ]);
   });
 
+  it("skips a daemon item settlement after the server already settled that item", () => {
+    const { db, thread } = setup();
+    const turnId = "turn-denied-approval";
+    const itemId = "command-denied-approval";
+
+    insertEvents(db, noopNotifier, [
+      {
+        threadId: thread.id,
+        sequence: 1,
+        type: "turn/started",
+        scope: turnScope(turnId),
+        itemId: null,
+        itemKind: null,
+        providerThreadId: "provider-thread-denied-approval",
+        data: JSON.stringify({
+          providerThreadId: "provider-thread-denied-approval",
+        }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 2,
+        type: "item/completed",
+        scope: turnScope(turnId),
+        itemId,
+        itemKind: "commandExecution",
+        providerThreadId: "provider-thread-denied-approval",
+        data: JSON.stringify({
+          providerThreadId: "provider-thread-denied-approval",
+          item: {
+            type: "commandExecution",
+            id: itemId,
+            command: "false",
+            cwd: "/tmp/project",
+            status: "interrupted",
+            approvalStatus: "denied",
+          },
+        }),
+      },
+    ]);
+
+    const result = db.transaction(
+      (tx) =>
+        appendDaemonEventsInTransaction(tx, [
+          {
+            threadId: thread.id,
+            environmentId: null,
+            type: "item/completed",
+            scope: turnScope(turnId),
+            itemId,
+            itemKind: "commandExecution",
+            providerThreadId: "provider-thread-denied-approval",
+            data: JSON.stringify({
+              providerThreadId: "provider-thread-denied-approval",
+              item: {
+                type: "commandExecution",
+                id: itemId,
+                command: "false",
+                cwd: "/tmp/project",
+                status: "interrupted",
+                approvalStatus: "denied",
+              },
+            }),
+          },
+          {
+            threadId: thread.id,
+            type: "system/error",
+            ...daemonThreadEventFields,
+            data: JSON.stringify({ message: "neighbor persisted" }),
+          },
+        ]),
+      { behavior: "immediate" },
+    );
+
+    expect(result).toEqual({
+      acceptedEvents: [{ threadId: thread.id, sequence: 3 }],
+      insertedInputIndexes: [1],
+      skippedTurnUnstartedInputIndexes: [],
+    });
+    expect(listEvents(db, { threadId: thread.id })).toMatchObject([
+      { sequence: 1, type: "turn/started" },
+      { sequence: 2, type: "item/completed", itemId },
+      { sequence: 3, type: "system/error" },
+    ]);
+  });
+
   it("rejects daemon turn-scoped events before turn/started is stored", () => {
     const { db, thread } = setup();
 

--- a/packages/db/test/data/events.test.ts
+++ b/packages/db/test/data/events.test.ts
@@ -371,7 +371,7 @@ describe("events", () => {
     ]);
   });
 
-  it("skips a daemon item settlement after the server already settled that item", () => {
+  it("deduplicates a settled item until the provider restarts that turn", () => {
     const { db, thread } = setup();
     const turnId = "turn-denied-approval";
     const itemId = "command-denied-approval";
@@ -436,6 +436,37 @@ describe("events", () => {
           },
           {
             threadId: thread.id,
+            type: "turn/started",
+            ...createTurnEventFields({ turnId }),
+            environmentId: null,
+            providerThreadId: "provider-thread-after-restart",
+            data: JSON.stringify({
+              providerThreadId: "provider-thread-after-restart",
+              turnId,
+            }),
+          },
+          {
+            threadId: thread.id,
+            environmentId: null,
+            type: "item/completed",
+            scope: turnScope(turnId),
+            itemId,
+            itemKind: "commandExecution",
+            providerThreadId: "provider-thread-after-restart",
+            data: JSON.stringify({
+              providerThreadId: "provider-thread-after-restart",
+              item: {
+                type: "commandExecution",
+                id: itemId,
+                command: "false",
+                cwd: "/tmp/project",
+                status: "interrupted",
+                approvalStatus: "denied",
+              },
+            }),
+          },
+          {
+            threadId: thread.id,
             type: "system/error",
             ...daemonThreadEventFields,
             data: JSON.stringify({ message: "neighbor persisted" }),
@@ -445,14 +476,25 @@ describe("events", () => {
     );
 
     expect(result).toEqual({
-      acceptedEvents: [{ threadId: thread.id, sequence: 3 }],
-      insertedInputIndexes: [1],
+      acceptedEvents: [
+        { threadId: thread.id, sequence: 3 },
+        { threadId: thread.id, sequence: 4 },
+        { threadId: thread.id, sequence: 5 },
+      ],
+      insertedInputIndexes: [1, 2, 3],
       skippedTurnUnstartedInputIndexes: [],
     });
     expect(listEvents(db, { threadId: thread.id })).toMatchObject([
       { sequence: 1, type: "turn/started" },
       { sequence: 2, type: "item/completed", itemId },
-      { sequence: 3, type: "system/error" },
+      { sequence: 3, type: "turn/started", turnId },
+      {
+        sequence: 4,
+        type: "item/completed",
+        itemId,
+        turnId,
+      },
+      { sequence: 5, type: "system/error" },
     ]);
   });
 

--- a/packages/db/test/data/events.test.ts
+++ b/packages/db/test/data/events.test.ts
@@ -371,7 +371,7 @@ describe("events", () => {
     ]);
   });
 
-  it("deduplicates a settled item until the provider restarts that turn", () => {
+  it("deduplicates a settled item until item/started reopens it", () => {
     const { db, thread } = setup();
     const turnId = "turn-denied-approval";
     const itemId = "command-denied-approval";
@@ -392,6 +392,25 @@ describe("events", () => {
       {
         threadId: thread.id,
         sequence: 2,
+        type: "item/started",
+        scope: turnScope(turnId),
+        itemId,
+        itemKind: "commandExecution",
+        providerThreadId: "provider-thread-denied-approval",
+        data: JSON.stringify({
+          providerThreadId: "provider-thread-denied-approval",
+          item: {
+            type: "commandExecution",
+            id: itemId,
+            command: "false",
+            cwd: "/tmp/project",
+            status: "pending",
+          },
+        }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 3,
         type: "item/completed",
         scope: turnScope(turnId),
         itemId,
@@ -436,13 +455,21 @@ describe("events", () => {
           },
           {
             threadId: thread.id,
-            type: "turn/started",
-            ...createTurnEventFields({ turnId }),
             environmentId: null,
+            type: "item/started",
+            scope: turnScope(turnId),
+            itemId,
+            itemKind: "commandExecution",
             providerThreadId: "provider-thread-after-restart",
             data: JSON.stringify({
               providerThreadId: "provider-thread-after-restart",
-              turnId,
+              item: {
+                type: "commandExecution",
+                id: itemId,
+                command: "false",
+                cwd: "/tmp/project",
+                status: "pending",
+              },
             }),
           },
           {
@@ -477,25 +504,135 @@ describe("events", () => {
 
     expect(result).toEqual({
       acceptedEvents: [
-        { threadId: thread.id, sequence: 3 },
         { threadId: thread.id, sequence: 4 },
         { threadId: thread.id, sequence: 5 },
+        { threadId: thread.id, sequence: 6 },
       ],
       insertedInputIndexes: [1, 2, 3],
       skippedTurnUnstartedInputIndexes: [],
     });
     expect(listEvents(db, { threadId: thread.id })).toMatchObject([
       { sequence: 1, type: "turn/started" },
-      { sequence: 2, type: "item/completed", itemId },
-      { sequence: 3, type: "turn/started", turnId },
+      { sequence: 2, type: "item/started", itemId },
+      { sequence: 3, type: "item/completed", itemId },
+      { sequence: 4, type: "item/started", itemId, turnId },
       {
-        sequence: 4,
+        sequence: 5,
         type: "item/completed",
         itemId,
         turnId,
       },
-      { sequence: 5, type: "system/error" },
+      { sequence: 6, type: "system/error" },
     ]);
+  });
+
+  it("uses item/started to reopen a thread-scoped background completion", () => {
+    const { db, thread } = setup();
+    const turnId = "turn-background-reuse";
+    const itemId = "background-reused";
+    const providerThreadId = "provider-background-reuse";
+    const backgroundItem = {
+      type: "backgroundTask" as const,
+      id: itemId,
+      taskType: LOCAL_BASH_TASK_TYPE,
+      status: "pending" as const,
+      taskStatus: "running" as const,
+      description: "Background command",
+      skipTranscript: false,
+    };
+    const completedBackgroundItem = {
+      ...backgroundItem,
+      status: "completed" as const,
+      taskStatus: "completed" as const,
+    };
+
+    insertEvents(db, noopNotifier, [
+      {
+        threadId: thread.id,
+        sequence: 1,
+        type: "turn/started",
+        scope: turnScope(turnId),
+        itemId: null,
+        itemKind: null,
+        providerThreadId,
+        data: JSON.stringify({ providerThreadId }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 2,
+        type: "item/started",
+        scope: turnScope(turnId),
+        itemId,
+        itemKind: "backgroundTask",
+        providerThreadId,
+        data: JSON.stringify({ providerThreadId, item: backgroundItem }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 3,
+        type: "item/backgroundTask/completed",
+        scope: threadScope(),
+        itemId,
+        itemKind: "backgroundTask",
+        providerThreadId,
+        data: JSON.stringify({
+          providerThreadId,
+          item: completedBackgroundItem,
+        }),
+      },
+    ]);
+
+    const result = db.transaction(
+      (tx) =>
+        appendDaemonEventsInTransaction(tx, [
+          {
+            threadId: thread.id,
+            environmentId: null,
+            type: "item/backgroundTask/completed",
+            scope: threadScope(),
+            itemId,
+            itemKind: "backgroundTask",
+            providerThreadId,
+            data: JSON.stringify({
+              providerThreadId,
+              item: completedBackgroundItem,
+            }),
+          },
+          {
+            threadId: thread.id,
+            environmentId: null,
+            type: "item/started",
+            scope: turnScope(turnId),
+            itemId,
+            itemKind: "backgroundTask",
+            providerThreadId,
+            data: JSON.stringify({ providerThreadId, item: backgroundItem }),
+          },
+          {
+            threadId: thread.id,
+            environmentId: null,
+            type: "item/backgroundTask/completed",
+            scope: threadScope(),
+            itemId,
+            itemKind: "backgroundTask",
+            providerThreadId,
+            data: JSON.stringify({
+              providerThreadId,
+              item: completedBackgroundItem,
+            }),
+          },
+        ]),
+      { behavior: "immediate" },
+    );
+
+    expect(result).toEqual({
+      acceptedEvents: [
+        { threadId: thread.id, sequence: 4 },
+        { threadId: thread.id, sequence: 5 },
+      ],
+      insertedInputIndexes: [1, 2],
+      skippedTurnUnstartedInputIndexes: [],
+    });
   });
 
   it("rejects daemon turn-scoped events before turn/started is stored", () => {

--- a/packages/db/test/migrate.test.ts
+++ b/packages/db/test/migrate.test.ts
@@ -3855,6 +3855,7 @@ describe("migrate", () => {
         "events_completed_item_truncation_idx",
         "events_environment_idx",
         "events_goal_thread_sequence_idx",
+        "events_item_lifecycle_thread_item_sequence_idx",
         "events_thread_sequence_idx",
         "events_thread_turn_type_item_sequence_idx",
         "events_thread_type_item_kind_sequence_idx",

--- a/packages/db/test/query-plans.test.ts
+++ b/packages/db/test/query-plans.test.ts
@@ -13,6 +13,7 @@ import {
   getPendingInteractionByProviderRequest,
 } from "../src/data/pending-interactions.js";
 import {
+  appendDaemonEventsInTransaction,
   hasParentedEventCrossingSequence,
   insertEvents,
   listActiveBackgroundTaskCountsByThreadIds,
@@ -219,6 +220,79 @@ function assertEmittedQueryPlanUsesIndex(
 }
 
 describe("slow query index plans", () => {
+  it("loads daemon item lifecycle state through the targeted partial index", () => {
+    const { db, logger, thread } = setup();
+    const turnId = "turn-lifecycle-plan";
+    const itemId = "item-lifecycle-plan";
+
+    insertEvents(db, noopNotifier, [
+      {
+        threadId: thread.id,
+        sequence: 1,
+        type: "turn/started",
+        scope: turnScope(turnId),
+        itemId: null,
+        itemKind: null,
+        data: JSON.stringify({ providerThreadId: "provider-plan" }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 2,
+        type: "item/completed",
+        scope: turnScope(turnId),
+        itemId,
+        itemKind: "agentMessage",
+        data: JSON.stringify({
+          providerThreadId: "provider-plan",
+          item: { type: "agentMessage", id: itemId, text: "done" },
+        }),
+      },
+    ]);
+
+    db.transaction(
+      (tx) =>
+        appendDaemonEventsInTransaction(tx, [
+          {
+            threadId: thread.id,
+            environmentId: null,
+            type: "item/completed",
+            scope: turnScope(turnId),
+            itemId,
+            itemKind: "agentMessage",
+            providerThreadId: "provider-plan",
+            data: JSON.stringify({
+              providerThreadId: "provider-plan",
+              item: { type: "agentMessage", id: itemId, text: "done" },
+            }),
+          },
+        ]),
+      { behavior: "immediate" },
+    );
+
+    const debugLog = findOnlyDebugLog({
+      logger,
+      predicate: (fields) =>
+        fields.operation === "all" && fields.sql.includes("requested_item"),
+    });
+    expect(debugLog.fields.bindingArgumentCount).toBe(2);
+    const lifecycleTypes =
+      "IN ('item/started', 'item/completed', 'item/backgroundTask/completed')";
+    const planSql = debugLog.fields.sql.replaceAll(
+      "IN ( '?', '?', '?' )",
+      lifecycleTypes,
+    );
+    const details = queryPlanDetails({
+      db,
+      params: [thread.id, itemId],
+      sql: planSql,
+    });
+    expect(
+      details.match(/events_item_lifecycle_thread_item_sequence_idx/gu),
+    ).toHaveLength(2);
+
+    db.$client.close();
+  });
+
   it("resolves parent crossings through the covering tool-call index", () => {
     const { db, thread } = setup();
 

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,7 @@
+// Version 132 prevents exact duplicate Codex terminal-item notifications from
+// crossing the daemon boundary as duplicate lifecycle events. Version 131
+// preserves Pi's provider identity when a bridge resumes a persisted session.
+//
 // Version 130 makes every provider plugin-declared on the wire. Two changes,
 // both of which an older daemon rejects outright:
 //
@@ -22,7 +26,7 @@
 //
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 131 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 132 as const;
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -22,7 +22,7 @@
 //
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 130 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 131 as const;
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1135,7 +1135,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(130);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(131);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1122,7 +1122,10 @@ describe("host-daemon command schemas", () => {
   // Version 118 rejects successful provider update results when the daemon
   // cannot verify a version change. Older daemons can report a no-op Claude
   // update as successful, so enrolled machines must update for honest results.
-  // Version 117 adds thread/context/cleared to the provider event wire model.
+  // Version 132 deduplicates exact Codex terminal-item retries before they
+  // cross the daemon boundary. Version 131 preserves Pi provider identity on
+  // bridge resume. Version 117 adds thread/context/cleared to the provider
+  // event wire model.
   // Version 116 reports provider exits that happen while a turn start is
   // pending. Older daemons can leave the server thread active until the live
   // command timeout, so enrolled machines must update before handling turns.
@@ -1135,7 +1138,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(131);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(132);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/packages/templates/test/plugin-scaffold-external.test.ts
+++ b/packages/templates/test/plugin-scaffold-external.test.ts
@@ -222,13 +222,20 @@ async function linkExternalDependencies(targetDir: string): Promise<void> {
 
 /**
  * `npm pack` the workspace SDK — the exact artifact the scaffold's pin will
- * resolve to once it is published.
+ * resolve to once it is published. Turbo builds the SDK before this suite, so
+ * skip the package's prepack build instead of rebuilding it during test fanout.
  */
 async function packPluginSdk(packDir: string): Promise<string> {
   await mkdir(packDir, { recursive: true });
   await execFileAsync(
     "npm",
-    ["pack", "--silent", "--pack-destination", packDir],
+    [
+      "pack",
+      "--silent",
+      "--ignore-scripts",
+      "--pack-destination",
+      packDir,
+    ],
     {
       cwd: pluginSdkRoot,
     },

--- a/plugins/provider-codex/src/bridge/bridge.calibration.test.ts
+++ b/plugins/provider-codex/src/bridge/bridge.calibration.test.ts
@@ -196,6 +196,27 @@ const SCRIPT: (ScriptedNotification | ScriptedRequest)[][] = [
         durationMs: 12,
       },
     }),
+    // Real Codex denial flows can repeat the exact terminal notification for
+    // one item after the approval response. Provider retries must not create a
+    // second canonical completion for the same lifecycle edge.
+    codexNotification("item/completed", {
+      threadId: SCRIPT_THREAD_ID,
+      turnId: FIRST_TURN_ID,
+      completedAtMs: 0,
+      item: {
+        type: "commandExecution",
+        id: COMMAND_ITEM_ID,
+        command: "git status --short",
+        cwd: "/tmp/project",
+        processId: null,
+        source: "agent",
+        status: "completed",
+        commandActions: [],
+        aggregatedOutput: " M src/app.ts\n",
+        exitCode: 0,
+        durationMs: 12,
+      },
+    }),
     codexNotification("item/completed", {
       threadId: SCRIPT_THREAD_ID,
       turnId: FIRST_TURN_ID,

--- a/plugins/provider-codex/src/bridge/bridge.calibration.test.ts
+++ b/plugins/provider-codex/src/bridge/bridge.calibration.test.ts
@@ -217,6 +217,44 @@ const SCRIPT: (ScriptedNotification | ScriptedRequest)[][] = [
         durationMs: 12,
       },
     }),
+    // item/started explicitly reopens an identifier under the canonical event
+    // grammar. The next completion is new lifecycle work, not a retry.
+    codexNotification("item/started", {
+      threadId: SCRIPT_THREAD_ID,
+      turnId: FIRST_TURN_ID,
+      startedAtMs: 0,
+      item: {
+        type: "commandExecution",
+        id: COMMAND_ITEM_ID,
+        command: "git status --short",
+        cwd: "/tmp/project",
+        processId: null,
+        source: "agent",
+        status: "inProgress",
+        commandActions: [],
+        aggregatedOutput: null,
+        exitCode: null,
+        durationMs: null,
+      },
+    }),
+    codexNotification("item/completed", {
+      threadId: SCRIPT_THREAD_ID,
+      turnId: FIRST_TURN_ID,
+      completedAtMs: 0,
+      item: {
+        type: "commandExecution",
+        id: COMMAND_ITEM_ID,
+        command: "git status --short",
+        cwd: "/tmp/project",
+        processId: null,
+        source: "agent",
+        status: "completed",
+        commandActions: [],
+        aggregatedOutput: "clean\n",
+        exitCode: 0,
+        durationMs: 8,
+      },
+    }),
     codexNotification("item/completed", {
       threadId: SCRIPT_THREAD_ID,
       turnId: FIRST_TURN_ID,
@@ -444,6 +482,8 @@ const GOLDEN_EVENT_STREAM: string[] = [
   "item/started:commandExecution",
   "item/commandExecution/outputDelta",
   "item/completed:commandExecution",
+  "item/started:commandExecution",
+  "item/completed:commandExecution",
   "item/completed:reasoning",
   "turn/completed",
   // The steer's ack. Codex never acks a steer itself, so correlation is
@@ -490,13 +530,13 @@ it("replays one scripted codex session onto the golden event stream", async () =
   // back to the fake app-server's own hardcoded turn.
   expect(canonical.events.length).toBeGreaterThan(10);
   expect(
-    canonical.events.some(
+    canonical.events.filter(
       (event) =>
         event.type === "item/completed" &&
         event.item.type === "commandExecution" &&
         event.item.command === "git status --short",
     ),
-  ).toBe(true);
+  ).toHaveLength(2);
 
   expect(
     describeCalibrationEvents(normalizeCalibrationEvents(canonical.events)),

--- a/plugins/provider-codex/src/bridge/bridge.ts
+++ b/plugins/provider-codex/src/bridge/bridge.ts
@@ -347,6 +347,12 @@ interface CodexBridgeSession {
   constructionSignature: string;
   /** Codex-id space; feeds delta-first item/started synthesis. */
   openedItemIds: Set<string>;
+  /**
+   * Exact normalized terminal events already emitted for this session. Codex
+   * can repeat a terminal notification after resolving an approval; preserve
+   * later corrected completions while suppressing byte-equivalent retries.
+   */
+  completedItemFingerprints: Set<string>;
   /** Codex-id space; open turns settle as failed if the child dies. */
   openCodexTurnIds: Set<string>;
   identityAnnounced: boolean;
@@ -622,6 +628,18 @@ function toCanonicalEvents(
   event: ThreadEvent,
 ): ThreadEvent[] {
   const out: ThreadEvent[] = [];
+
+  if (event.type === "item/completed") {
+    const fingerprint = JSON.stringify({
+      item: event.item,
+      providerThreadId: event.providerThreadId,
+      scope: event.scope,
+    });
+    if (session.completedItemFingerprints.has(fingerprint)) {
+      return out;
+    }
+    session.completedItemFingerprints.add(fingerprint);
+  }
 
   if (event.type === "turn/started" && event.scope.kind === "turn") {
     session.openCodexTurnIds.add(event.scope.turnId);
@@ -1065,6 +1083,7 @@ async function constructThreadSession(
       decoded.sessionOptions,
     ),
     openedItemIds: new Set(),
+    completedItemFingerprints: new Set(),
     openCodexTurnIds: new Set(),
     identityAnnounced: false,
     pendingPreIdentityEvents: [],

--- a/plugins/provider-codex/src/bridge/bridge.ts
+++ b/plugins/provider-codex/src/bridge/bridge.ts
@@ -287,6 +287,7 @@ const CODEX_INITIALIZE_PARAMS = {
 };
 
 const CHILD_REQUEST_TIMEOUT_MS = 60_000;
+const MAX_TRACKED_ITEM_IDS_PER_SESSION = 512;
 const CODEX_ARCHIVED_SESSION_ERROR_PATTERN =
   /\b(?:session|thread)\s+\S+\s+is archived\b/i;
 const MISSING_CODEX_CLI_GUIDANCE =
@@ -345,14 +346,13 @@ interface CodexBridgeSession {
   translator: CodexEventTranslator;
   construction: CodexSessionConstruction;
   constructionSignature: string;
-  /** Codex-id space; feeds delta-first item/started synthesis. */
+  /** Bounded Codex-id space; feeds delta-first item/started synthesis. */
   openedItemIds: Set<string>;
   /**
-   * Exact normalized terminal events already emitted for this session. Codex
-   * can repeat a terminal notification after resolving an approval; preserve
-   * later corrected completions while suppressing byte-equivalent retries.
+   * Bounded Codex-id space for item incarnations already settled. An explicit
+   * item/started reopens an id, matching the runtime event grammar.
    */
-  completedItemFingerprints: Set<string>;
+  settledItemIds: Set<string>;
   /** Codex-id space; open turns settle as failed if the child dies. */
   openCodexTurnIds: Set<string>;
   identityAnnounced: boolean;
@@ -615,6 +615,17 @@ function isSynthesizableDeltaType(
   );
 }
 
+function rememberTrackedItemId(itemIds: Set<string>, itemId: string): void {
+  itemIds.add(itemId);
+  while (itemIds.size > MAX_TRACKED_ITEM_IDS_PER_SESSION) {
+    const oldest = itemIds.values().next();
+    if (oldest.done) {
+      return;
+    }
+    itemIds.delete(oldest.value);
+  }
+}
+
 /**
  * Stamp one translated (Codex-id-space) event into canonical form, tracking
  * open turns/items and synthesizing `item/started` when Codex streams a
@@ -629,16 +640,16 @@ function toCanonicalEvents(
 ): ThreadEvent[] {
   const out: ThreadEvent[] = [];
 
-  if (event.type === "item/completed") {
-    const fingerprint = JSON.stringify({
-      item: event.item,
-      providerThreadId: event.providerThreadId,
-      scope: event.scope,
-    });
-    if (session.completedItemFingerprints.has(fingerprint)) {
+  if (event.type === "item/started") {
+    session.settledItemIds.delete(event.item.id);
+  } else if (
+    event.type === "item/completed" ||
+    event.type === "item/backgroundTask/completed"
+  ) {
+    if (session.settledItemIds.has(event.item.id)) {
       return out;
     }
-    session.completedItemFingerprints.add(fingerprint);
+    rememberTrackedItemId(session.settledItemIds, event.item.id);
   }
 
   if (event.type === "turn/started" && event.scope.kind === "turn") {
@@ -647,8 +658,12 @@ function toCanonicalEvents(
   if (event.type === "turn/completed" && event.scope.kind === "turn") {
     session.openCodexTurnIds.delete(event.scope.turnId);
   }
-  if (event.type === "item/started" || event.type === "item/completed") {
-    session.openedItemIds.add(event.item.id);
+  if (
+    event.type === "item/started" ||
+    event.type === "item/completed" ||
+    event.type === "item/backgroundTask/completed"
+  ) {
+    rememberTrackedItemId(session.openedItemIds, event.item.id);
   }
 
   if (
@@ -656,7 +671,7 @@ function toCanonicalEvents(
     "itemId" in event &&
     !session.openedItemIds.has(event.itemId)
   ) {
-    session.openedItemIds.add(event.itemId);
+    rememberTrackedItemId(session.openedItemIds, event.itemId);
     const item = synthesizeOpeningItem(event.type, event.itemId);
     out.push(
       remapEvent(session, {
@@ -1083,7 +1098,7 @@ async function constructThreadSession(
       decoded.sessionOptions,
     ),
     openedItemIds: new Set(),
-    completedItemFingerprints: new Set(),
+    settledItemIds: new Set(),
     openCodexTurnIds: new Set(),
     identityAnnounced: false,
     pendingPreIdentityEvents: [],

--- a/qa/manual-runbook.md
+++ b/qa/manual-runbook.md
@@ -709,7 +709,7 @@ fi
 
 THREAD_STATE=$(curl -fsS "$BB_SERVER_URL/api/v1/threads/$SMOKE_THREAD_ID" | jq -r '.status')
 if [ "$THREAD_STATE" != "idle" ]; then
-  bb thread tell "$SMOKE_THREAD_ID" "Say exactly: recovery ok"
+  bb thread tell "$SMOKE_THREAD_ID" "Say exactly: recovery ok" --mode auto
   bb thread wait "$SMOKE_THREAD_ID" --status idle --timeout 120
 fi
 

--- a/qa/manual-runbook.md
+++ b/qa/manual-runbook.md
@@ -701,8 +701,14 @@ DAEMON_PID=$(cat "$DAEMON_RESTART_PID_PATH")
 THREAD_STATE=$(curl -fsS "$BB_SERVER_URL/api/v1/threads/$SMOKE_THREAD_ID" | jq -r '.status')
 
 if [ "$THREAD_STATE" = "active" ]; then
-  bb thread wait "$SMOKE_THREAD_ID" --status idle --timeout 180
-else
+  # The disconnect settlement can race this snapshot: `wait` may observe that
+  # the thread already became `error` and correctly return non-zero. Re-read
+  # state instead of treating that expected terminal transition as a QA failure.
+  bb thread wait "$SMOKE_THREAD_ID" --status idle --timeout 180 || true
+fi
+
+THREAD_STATE=$(curl -fsS "$BB_SERVER_URL/api/v1/threads/$SMOKE_THREAD_ID" | jq -r '.status')
+if [ "$THREAD_STATE" != "idle" ]; then
   bb thread tell "$SMOKE_THREAD_ID" "Say exactly: recovery ok"
   bb thread wait "$SMOKE_THREAD_ID" --status idle --timeout 120
 fi

--- a/tests/integration/fake/recovery/active-crash-recovery.test.ts
+++ b/tests/integration/fake/recovery/active-crash-recovery.test.ts
@@ -14,6 +14,7 @@ import { withHarness } from "../../helpers/harness.js";
 import {
   ACTIVE_TIMEOUT_MS,
   createRecoveryThread,
+  RECOVERY_TEST_TIMEOUT_MS,
   RECOVERY_TIMEOUT_MS,
   STOP_DELAY_TEXT,
 } from "./shared.js";
@@ -88,5 +89,5 @@ describe.sequential("fake provider active crash recovery integration", () => {
             event.data.code === "thread_command_failed",
         ),
       ).toBe(true);
-    }));
+    }), RECOVERY_TEST_TIMEOUT_MS);
 });

--- a/tests/integration/fake/recovery/graceful-restart.test.ts
+++ b/tests/integration/fake/recovery/graceful-restart.test.ts
@@ -9,6 +9,7 @@ import {
 import { withHarness } from "../../helpers/harness.js";
 import {
   createRecoveryThread,
+  RECOVERY_TEST_TIMEOUT_MS,
   RECOVERY_TIMEOUT_MS,
   requireSessionId,
   TURN_TIMEOUT_MS,
@@ -66,5 +67,5 @@ describe.sequential("fake provider graceful recovery integration", () => {
         "idle",
         TURN_TIMEOUT_MS,
       );
-    }));
+    }), RECOVERY_TEST_TIMEOUT_MS);
 });

--- a/tests/integration/fake/recovery/idle-crash-restart.test.ts
+++ b/tests/integration/fake/recovery/idle-crash-restart.test.ts
@@ -9,6 +9,7 @@ import {
 import { withHarness } from "../../helpers/harness.js";
 import {
   createRecoveryThread,
+  RECOVERY_TEST_TIMEOUT_MS,
   RECOVERY_TIMEOUT_MS,
   TURN_TIMEOUT_MS,
 } from "./shared.js";
@@ -62,5 +63,5 @@ describe.sequential("fake provider idle crash recovery integration", () => {
         "idle",
         TURN_TIMEOUT_MS,
       );
-    }));
+    }), RECOVERY_TEST_TIMEOUT_MS);
 });

--- a/tests/integration/fake/recovery/idle-error-reconciliation.test.ts
+++ b/tests/integration/fake/recovery/idle-error-reconciliation.test.ts
@@ -12,6 +12,7 @@ import {
 } from "@bb/db";
 import {
   createRecoveryThread,
+  RECOVERY_TEST_TIMEOUT_MS,
   RECOVERY_TIMEOUT_MS,
   TURN_TIMEOUT_MS,
 } from "./shared.js";
@@ -61,6 +62,6 @@ describe.sequential(
 
         const afterReconnect = await getThread(harness.api, thread.id);
         expect(afterReconnect.status).toBe("error");
-      }));
+      }), RECOVERY_TEST_TIMEOUT_MS);
   },
 );

--- a/tests/integration/fake/recovery/managed-crash-restart.test.ts
+++ b/tests/integration/fake/recovery/managed-crash-restart.test.ts
@@ -9,6 +9,7 @@ import {
 import { withHarness } from "../../helpers/harness.js";
 import {
   createRecoveryThread,
+  RECOVERY_TEST_TIMEOUT_MS,
   RECOVERY_TIMEOUT_MS,
   TURN_TIMEOUT_MS,
 } from "./shared.js";
@@ -63,5 +64,5 @@ describe.sequential("fake provider managed crash recovery integration", () => {
         "idle",
         TURN_TIMEOUT_MS,
       );
-    }));
+    }), RECOVERY_TEST_TIMEOUT_MS);
 });

--- a/tests/integration/fake/recovery/managed-graceful-restart.test.ts
+++ b/tests/integration/fake/recovery/managed-graceful-restart.test.ts
@@ -9,6 +9,7 @@ import {
 import { withHarness } from "../../helpers/harness.js";
 import {
   createRecoveryThread,
+  RECOVERY_TEST_TIMEOUT_MS,
   RECOVERY_TIMEOUT_MS,
   TURN_TIMEOUT_MS,
 } from "./shared.js";
@@ -65,6 +66,6 @@ describe.sequential(
           "idle",
           TURN_TIMEOUT_MS,
         );
-      }));
+      }), RECOVERY_TEST_TIMEOUT_MS);
   },
 );

--- a/tests/integration/fake/recovery/session-continuity.test.ts
+++ b/tests/integration/fake/recovery/session-continuity.test.ts
@@ -10,6 +10,7 @@ import { readSessionRow } from "../../helpers/queries.js";
 import {
   assertMonotonicSequences,
   createRecoveryThread,
+  RECOVERY_TEST_TIMEOUT_MS,
   RECOVERY_TIMEOUT_MS,
   requireSessionId,
   TURN_TIMEOUT_MS,
@@ -69,7 +70,7 @@ describe.sequential("fake provider session continuity integration", () => {
       expect(
         eventsAfter.filter((event) => event.type === "turn/completed"),
       ).toHaveLength(baselineCompletedCount + 1);
-    }));
+    }), RECOVERY_TEST_TIMEOUT_MS);
 
   it("closes the old daemon session after restart and accepts new live work", () =>
     withHarness(async (harness) => {
@@ -116,5 +117,5 @@ describe.sequential("fake provider session continuity integration", () => {
         "idle",
         TURN_TIMEOUT_MS,
       );
-    }));
+    }), RECOVERY_TEST_TIMEOUT_MS);
 });

--- a/tests/integration/fake/recovery/session-continuity.test.ts
+++ b/tests/integration/fake/recovery/session-continuity.test.ts
@@ -67,6 +67,17 @@ describe.sequential("fake provider session continuity integration", () => {
       const eventsAfter = await getThreadEvents(harness.api, thread.id);
       expect(eventsAfter.length).toBeGreaterThan(eventsBefore.length);
       assertMonotonicSequences(eventsAfter);
+      const reusedMessageLifecycle = eventsAfter.filter(
+        (event) =>
+          (event.type === "item/started" || event.type === "item/completed") &&
+          event.data.item.id === "msg-1",
+      );
+      expect(reusedMessageLifecycle.map((event) => event.type)).toEqual([
+        "item/started",
+        "item/completed",
+        "item/started",
+        "item/completed",
+      ]);
       expect(
         eventsAfter.filter((event) => event.type === "turn/completed"),
       ).toHaveLength(baselineCompletedCount + 1);

--- a/tests/integration/fake/recovery/shared.ts
+++ b/tests/integration/fake/recovery/shared.ts
@@ -14,6 +14,10 @@ export const DEFAULT_TIMEOUT_MS = scaleTimeoutMs(10_000);
 export const TURN_TIMEOUT_MS = scaleTimeoutMs(15_000);
 // Recovery waits: allow for disconnect detection plus daemon restart and reconciliation.
 export const RECOVERY_TIMEOUT_MS = scaleTimeoutMs(30_000);
+// Recovery scenarios compose setup, multiple turns, disconnect detection, and
+// daemon startup. Keep the outer deadline above those operation-level budgets
+// so a loaded run reports the specific recovery step that stalled.
+export const RECOVERY_TEST_TIMEOUT_MS = scaleTimeoutMs(180_000);
 // Active-turn waits: only long enough to catch a turn in flight before the crash/restart step.
 export const ACTIVE_TIMEOUT_MS = scaleTimeoutMs(5_000);
 // Hold the turn long enough to observe active status before crashing, while

--- a/tests/integration/fake/smoke/dynamic-acp-agent.test.ts
+++ b/tests/integration/fake/smoke/dynamic-acp-agent.test.ts
@@ -11,12 +11,19 @@ import {
   waitForThreadStatus,
 } from "../../helpers/assertions.js";
 import { withHarness } from "../../helpers/harness.js";
+import { scaleTimeoutMs } from "../../helpers/time.js";
 import {
   createProjectFixture,
   createReadyThread,
   DEFAULT_TIMEOUT_MS,
   TURN_TIMEOUT_MS,
 } from "./shared.js";
+
+// This smoke performs two provider starts, two follow-up turns, and a daemon
+// restart. Keep the outer Vitest deadline above the sum of the operation-level
+// deadlines so a loaded full-workspace run reports the operation that stalled
+// instead of racing the generic per-test timeout.
+const DYNAMIC_ACP_TEST_TIMEOUT_MS = scaleTimeoutMs(120_000);
 
 const fixturePath = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -51,153 +58,160 @@ function buildDynamicAcpAgents(): CustomAcpAgent[] {
 }
 
 describe.sequential("dynamic ACP integration smoke", () => {
-  it("spawns configured ACP agents for model list, start, submit, and lazy resume", () =>
-    withHarness({ adapterFactory: undefined }, async (harness) => {
-      harness.server.config.customAcpAgents = buildDynamicAcpAgents();
+  it(
+    "spawns configured ACP agents for model list, start, submit, and lazy resume",
+    () =>
+      withHarness({ adapterFactory: undefined }, async (harness) => {
+        harness.server.config.customAcpAgents = buildDynamicAcpAgents();
 
-      const providersResponse = await harness.api.system.providers.$get({});
-      expect(providersResponse.status).toBe(200);
-      const providers = await providersResponse.json();
-      expect(providers).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            id: "acp-smoke",
-            displayName: "Smoke ACP",
-          }),
-          expect.objectContaining({
-            id: "acp-nomodelcli",
-            displayName: "No Model CLI ACP",
-          }),
-        ]),
-      );
+        const providersResponse = await harness.api.system.providers.$get({});
+        expect(providersResponse.status).toBe(200);
+        const providers = await providersResponse.json();
+        expect(providers).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: "acp-smoke",
+              displayName: "Smoke ACP",
+            }),
+            expect.objectContaining({
+              id: "acp-nomodelcli",
+              displayName: "No Model CLI ACP",
+            }),
+          ]),
+        );
 
-      const listedModelsResponse = await harness.api.system[
-        "execution-options"
-      ].$get({
-        query: { hostId: harness.hostId, providerId: "acp-smoke" },
-      });
-      expect(listedModelsResponse.status).toBe(200);
-      const listedOptions = systemExecutionOptionsResponseSchema.parse(
-        await listedModelsResponse.json(),
-      );
-      expect(listedOptions.modelLoadError).toBeNull();
-      expect(listedOptions.providers).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            id: "acp-smoke",
-            displayName: "Smoke ACP",
-          }),
-        ]),
-      );
-      expect(listedOptions.models.map((model) => model.model)).toContain(
-        "bb-dynamic-smoke-medium",
-      );
+        const listedModelsResponse = await harness.api.system[
+          "execution-options"
+        ].$get({
+          query: { hostId: harness.hostId, providerId: "acp-smoke" },
+        });
+        expect(listedModelsResponse.status).toBe(200);
+        const listedOptions = systemExecutionOptionsResponseSchema.parse(
+          await listedModelsResponse.json(),
+        );
+        expect(listedOptions.modelLoadError).toBeNull();
+        expect(listedOptions.providers).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: "acp-smoke",
+              displayName: "Smoke ACP",
+            }),
+          ]),
+        );
+        expect(listedOptions.models.map((model) => model.model)).toContain(
+          "bb-dynamic-smoke-medium",
+        );
 
-      const defaultModelsResponse = await harness.api.system[
-        "execution-options"
-      ].$get({
-        query: { hostId: harness.hostId, providerId: "acp-nomodelcli" },
-      });
-      expect(defaultModelsResponse.status).toBe(200);
-      const defaultOptions = systemExecutionOptionsResponseSchema.parse(
-        await defaultModelsResponse.json(),
-      );
-      expect(defaultOptions.modelLoadError).toBeNull();
-      expect(defaultOptions.models.map((model) => model.model)).toEqual([
-        "bb-dynamic-acp-native-default",
-        "bb-dynamic-acp-native-strong",
-      ]);
-      expect(defaultOptions.models.map((model) => model.model)).not.toEqual([
-        "acp-default",
-      ]);
+        const defaultModelsResponse = await harness.api.system[
+          "execution-options"
+        ].$get({
+          query: { hostId: harness.hostId, providerId: "acp-nomodelcli" },
+        });
+        expect(defaultModelsResponse.status).toBe(200);
+        const defaultOptions = systemExecutionOptionsResponseSchema.parse(
+          await defaultModelsResponse.json(),
+        );
+        expect(defaultOptions.modelLoadError).toBeNull();
+        expect(defaultOptions.models.map((model) => model.model)).toEqual([
+          "bb-dynamic-acp-native-default",
+          "bb-dynamic-acp-native-strong",
+        ]);
+        expect(defaultOptions.models.map((model) => model.model)).not.toEqual([
+          "acp-default",
+        ]);
 
-      const project = await createProjectFixture(harness, "Dynamic ACP Smoke");
-      const { thread: nativeThread } = await createReadyThread(harness, {
-        execution: {
-          model: "bb-dynamic-acp-native-strong",
-          reasoningLevel: "medium",
-          permissionMode: "accept-edits",
-        },
-        input: [{ type: "text", text: "native selection", mentions: [] }],
-        projectId: project.id,
-        providerId: "acp-nomodelcli",
-        workspace: {
-          type: "unmanaged",
-          path: harness.repoDir,
-        },
-      });
+        const project = await createProjectFixture(
+          harness,
+          "Dynamic ACP Smoke",
+        );
+        const { thread: nativeThread } = await createReadyThread(harness, {
+          execution: {
+            model: "bb-dynamic-acp-native-strong",
+            reasoningLevel: "medium",
+            permissionMode: "accept-edits",
+          },
+          input: [{ type: "text", text: "native selection", mentions: [] }],
+          projectId: project.id,
+          providerId: "acp-nomodelcli",
+          workspace: {
+            type: "unmanaged",
+            path: harness.repoDir,
+          },
+        });
 
-      await waitForThreadOutputContaining(
-        harness.api,
-        nativeThread.id,
-        "dynamic-acp:model=bb-dynamic-acp-native-strong:native selection",
-        TURN_TIMEOUT_MS,
-      );
+        await waitForThreadOutputContaining(
+          harness.api,
+          nativeThread.id,
+          "dynamic-acp:model=bb-dynamic-acp-native-strong:native selection",
+          TURN_TIMEOUT_MS,
+        );
 
-      const { thread } = await createReadyThread(harness, {
-        execution: {
-          model: "bb-dynamic-smoke-medium",
-          reasoningLevel: "medium",
-          permissionMode: "accept-edits",
-        },
-        input: [{ type: "text", text: "start launch spec", mentions: [] }],
-        projectId: project.id,
-        providerId: "acp-smoke",
-        workspace: {
-          type: "unmanaged",
-          path: harness.repoDir,
-        },
-      });
+        const { thread } = await createReadyThread(harness, {
+          execution: {
+            model: "bb-dynamic-smoke-medium",
+            reasoningLevel: "medium",
+            permissionMode: "accept-edits",
+          },
+          input: [{ type: "text", text: "start launch spec", mentions: [] }],
+          projectId: project.id,
+          providerId: "acp-smoke",
+          workspace: {
+            type: "unmanaged",
+            path: harness.repoDir,
+          },
+        });
 
-      await waitForThreadOutputContaining(
-        harness.api,
-        thread.id,
-        "dynamic-acp:model=bb-dynamic-smoke-medium:start launch spec",
-        TURN_TIMEOUT_MS,
-      );
+        await waitForThreadOutputContaining(
+          harness.api,
+          thread.id,
+          "dynamic-acp:model=bb-dynamic-smoke-medium:start launch spec",
+          TURN_TIMEOUT_MS,
+        );
 
-      await sendTextMessage(harness.api, thread.id, {
-        execution: {
-          model: "bb-dynamic-smoke-medium",
-          reasoningLevel: "medium",
-          permissionMode: "accept-edits",
-        },
-        text: "submit launch spec",
-      });
-      await waitForThreadOutputContaining(
-        harness.api,
-        thread.id,
-        "dynamic-acp:model=bb-dynamic-smoke-medium:submit launch spec",
-        TURN_TIMEOUT_MS,
-      );
-      await waitForThreadStatus(
-        harness.api,
-        thread.id,
-        "idle",
-        TURN_TIMEOUT_MS,
-      );
+        await sendTextMessage(harness.api, thread.id, {
+          execution: {
+            model: "bb-dynamic-smoke-medium",
+            reasoningLevel: "medium",
+            permissionMode: "accept-edits",
+          },
+          text: "submit launch spec",
+        });
+        await waitForThreadOutputContaining(
+          harness.api,
+          thread.id,
+          "dynamic-acp:model=bb-dynamic-smoke-medium:submit launch spec",
+          TURN_TIMEOUT_MS,
+        );
+        await waitForThreadStatus(
+          harness.api,
+          thread.id,
+          "idle",
+          TURN_TIMEOUT_MS,
+        );
 
-      await harness.restartDaemon("dynamic-acp-resume");
-      await waitForHostConnected(harness.api, DEFAULT_TIMEOUT_MS);
+        await harness.restartDaemon("dynamic-acp-resume");
+        await waitForHostConnected(harness.api, DEFAULT_TIMEOUT_MS);
 
-      await sendTextMessage(harness.api, thread.id, {
-        execution: {
-          model: "bb-dynamic-smoke-medium",
-          reasoningLevel: "medium",
-          permissionMode: "accept-edits",
-        },
-        text: "resume launch spec",
-      });
-      await waitForThreadOutputContaining(
-        harness.api,
-        thread.id,
-        "dynamic-acp:model=bb-dynamic-smoke-medium:resume launch spec",
-        TURN_TIMEOUT_MS,
-      );
+        await sendTextMessage(harness.api, thread.id, {
+          execution: {
+            model: "bb-dynamic-smoke-medium",
+            reasoningLevel: "medium",
+            permissionMode: "accept-edits",
+          },
+          text: "resume launch spec",
+        });
+        await waitForThreadOutputContaining(
+          harness.api,
+          thread.id,
+          "dynamic-acp:model=bb-dynamic-smoke-medium:resume launch spec",
+          TURN_TIMEOUT_MS,
+        );
 
-      const output = await getThreadOutput(harness.api, thread.id);
-      expect(output).toContain(
-        "dynamic-acp:model=bb-dynamic-smoke-medium:resume launch spec",
-      );
-    }));
+        const output = await getThreadOutput(harness.api, thread.id);
+        expect(output).toContain(
+          "dynamic-acp:model=bb-dynamic-smoke-medium:resume launch spec",
+        );
+      }),
+    DYNAMIC_ACP_TEST_TIMEOUT_MS,
+  );
 });

--- a/tests/qa/test/runbook-contract.test.ts
+++ b/tests/qa/test/runbook-contract.test.ts
@@ -51,4 +51,15 @@ describe("QA runbook contracts", () => {
     );
     expect(runbook).not.toMatch(/active[_ -]provisioning[_ -]id/i);
   });
+
+  it("recovers when daemon disconnect settlement races an active-state snapshot", async () => {
+    const runbook = await readRunbook("manual-runbook.md");
+
+    expect(runbook).toContain(
+      'bb thread wait "$SMOKE_THREAD_ID" --status idle --timeout 180 || true',
+    );
+    expect(runbook).toContain(
+      'if [ "$THREAD_STATE" != "idle" ]; then\n  bb thread tell "$SMOKE_THREAD_ID" "Say exactly: recovery ok"',
+    );
+  });
 });

--- a/tests/qa/test/runbook-contract.test.ts
+++ b/tests/qa/test/runbook-contract.test.ts
@@ -59,7 +59,7 @@ describe("QA runbook contracts", () => {
       'bb thread wait "$SMOKE_THREAD_ID" --status idle --timeout 180 || true',
     );
     expect(runbook).toContain(
-      'if [ "$THREAD_STATE" != "idle" ]; then\n  bb thread tell "$SMOKE_THREAD_ID" "Say exactly: recovery ok"',
+      'if [ "$THREAD_STATE" != "idle" ]; then\n  bb thread tell "$SMOKE_THREAD_ID" "Say exactly: recovery ok" --mode auto',
     );
   });
 });


### PR DESCRIPTION
## Summary

This PR captures the fixes found during a full lint, build, test, integration-test, and manual QA run, with extra coverage focused on agent providers and recovery behavior.

- preserve Pi's stable provider identity when a session is resumed under a different bb routing identity
- make daemon recovery converge reliably across disconnect and terminal-state races
- prevent duplicate provider item settlements while respecting explicit `item/started` lifecycle resets
- bound Codex bridge settlement tracking so command output is never retained in deduplication state
- make ignored live web-search probes retry correctly within a sufficient outer test deadline
- remove timing and shared-state flakes across provider permissions, dynamic ACP, recovery, plugin lifecycle, injected skills, repository discovery, app artifacts, and iPad command typeahead
- keep the manual recovery runbook resilient to expected disconnect-settlement races

## Bugs and fixes

| Area | Problem | Fix / regression coverage |
|---|---|---|
| Pi resume | Resume used the current bb thread ID as Pi's persisted-session identity, which could reopen or discard the wrong JSONL file | Preserve `providerThreadId` separately from the live bb routing ID; verify reopen, identity reporting, and discard against the original file |
| Daemon recovery | Recovery could race terminal state settlement or submit a continuation with stale turn targeting | Re-read state after settlement, use auto-targeted fresh turns, and cover crash/restart permutations |
| Provider events | Retried terminal items or independent server/provider denial settlement could create duplicate canonical completions | Suppress repeated Codex settlements with bounded item-ID state and enforce storage-level idempotency |
| Item lifecycle | A broad storage guard could drop valid completions when an item ID was explicitly reopened, including thread-scoped background tasks | Reset settlement state on the latest `item/started`; cover same-turn and background ID reuse |
| Event persistence performance | Per-completion synchronous lifecycle queries could scan large histories and block recovery batches | Preload requested lifecycle keys once per SQLite variable batch through a generated partial index; pin the query plan in tests |
| Live web search | Ignored probes were treated as completed instead of retried, while the retry test's 90-second outer limit was shorter than its two possible 60-second waits | Retry ignored probes, cover the behavior, and allow 150 seconds for the complete scenario |
| Validation flakes | Loaded runners exposed short budgets, shared fixtures, redundant builds, and focus timing races | Bound deadlines, isolate state, widen intentional budgets, avoid redundant SDK rebuilds, and synchronize focus assertions |
| Manual recovery QA | An expected `active -> error` disconnect transition could fail the runbook before recovery was attempted | Treat the intermediate wait as observational, re-read state, and recover unless already idle |

## Validation

- full lint pass
- full build pass
- full unit/test pass
- full integration-test pass
- complete `qa/manual-runbook.md` pass, including agent-provider, dynamic ACP, permission, and daemon-recovery scenarios
- follow-up review fixes: 390 DB tests, 164 Codex-provider tests, live web-normalization integration, relevant typechecks, server/host-daemon builds, and repository lint with zero errors

> AGENT GENERATED: by GPT-5 Codex
