### PR TITLE
docs: record that the timeline event budget is hardware dependent

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -637,7 +637,13 @@ is synchronous, so it blocked the server's event loop — which also delayed
 dynamic tool call and before registering every interactive request. One slow
 thread therefore slowed agent work on _every_ thread on the host.
 
-A window is capped at `BB_FF_TIMELINE_WINDOW_EVENT_BUDGET` events (default 1500) and returns however many whole turns fit. Older turns load automatically
+A window is capped at `BB_FF_TIMELINE_WINDOW_EVENT_BUDGET` events (default 1500) and returns however many whole turns fit. The default assumes roughly
+0.06ms per event; that cost varies widely with hardware, and on a small VPS it
+can be closer to 0.5ms, making a full window ~720ms of blocked event loop
+instead of ~100ms. If `Thread timeline build blocked the event loop` appears
+often, divide a logged build's `totalDurationMs` by its `eventRowCount` to get
+your real per-event cost and lower this budget until a full window fits your
+latency target. Older turns load automatically
 as you scroll toward the top of the loaded window; a manual "Load older
 messages" button remains on surfaces that render no scroll body, and after a
 failed page so a broken fetch is retried on request rather than in a loop.

--- a/packages/domain/src/feature-flags.ts
+++ b/packages/domain/src/feature-flags.ts
@@ -33,6 +33,13 @@ export const defaultFeatureFlags: FeatureFlags = {
    * Measured on real threads a build costs ~0.06ms/event across the SQLite
    * read, JSON decode, and projection. 1500 keeps a cold build near 100ms; the
    * 10k-event thread that motivated the bound was ~670ms unbounded.
+   *
+   * That per-event cost is hardware dependent and the spread is wide: on a
+   * 4-core / 4.9 GiB VPS it measures 0.479ms/event at p50 (p90 0.964,
+   * max 5.55) across 541 samples, roughly 8x the figure above, which puts a
+   * full 1500-event build near 720ms of blocked event loop rather than 100ms.
+   * Operators on modest hardware should lower this via
+   * BB_FF_TIMELINE_WINDOW_EVENT_BUDGET; see docs/configuration.md.
    */
   timelineWindowEventBudget: 1_500,
 };


### PR DESCRIPTION
Refs #1749.

`timelineWindowEventBudget` is set to 1500 on the basis of a measured ~0.06ms/event, aiming to keep a cold build near 100ms.

Measured on a 4-core / 4.9 GiB VPS across 541 samples taken from bb's own `Thread timeline build blocked the event loop` logging:

| metric | value |
|---|---|
| p50 | 0.479 ms/event |
| p90 | 0.964 ms/event |
| max | 5.55 ms/event |

So a full 1500-event window costs roughly 720ms of blocked event loop there, not 100ms. Session totals on that host: 1656 slow builds, 155 seconds of blocked loop, with event-loop stall samples showing p95 maxDelay of 5058ms.

This change is deliberately documentation only. It records the spread next to the constant and explains in `docs/configuration.md` how to derive your own per-event cost from the existing logging and lower the budget accordingly.

I did not change the default, since that is a judgement call for maintainers rather than something to infer from one host.

The underlying issue is that a fixed event count is a weak proxy for cost when per-event cost varies ~8x across hardware. Happy to follow up with either startup calibration from a measured sample, or budgeting on decoded bytes instead of event count (`event-json-decode` is the dominant stage — 181ms of a 332ms build in one sample). Let me know which you would prefer and I will open it.