### PR TITLE
Stop clipping two-digit ordered list markers

### DIFF
--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -910,7 +910,7 @@ function MarkdownOrderedList({
   return (
     <ol
       {...orderedListProps}
-      className="mb-2 list-decimal pl-5 text-foreground"
+      className="mb-2 list-decimal pl-7 text-foreground"
     >
       {children}
     </ol>


### PR DESCRIPTION
Ordered lists in rendered markdown indent 20px (`pl-5`), but a `10.` marker at `text-sm` is ~21px wide and paints outside the content box. Every message body that has not been expanded carries `overflow-hidden` (it also holds the 15-line clamp), and that box has no padding of its own, so its edge sits on the bubble content edge and cuts the marker: `10.` renders as `l0.`, `11.` as `l1.`.

Widen ordered lists to 28px (`pl-7`). Bullet lists are unchanged — disc markers are narrow and never overflowed.

## Reproduction

Measured from a report screenshot: the clip sits 18.5 CSS px from the bubble border, matching `1px border + 16px padding`. The `1` glyph loses its flag and the left half of its foot serif on the same vertical line, which is a clip rather than a font problem. Reproduced in the `UserMessageMarkdown` story in its default, non-expanded state, and confirmed fixed at `pl-7`. Both a short list starting at 7 and the pre-existing long collapsible "Migration rollout" story hit it.

The composer (`ComposerEditorSlot`) uses the same `pl-5` but does not clip: its scroll container has 16px of padding, so the overhang has room. Verified live with rich-text editing on; left unchanged.

## Verification

- `pnpm exec turbo run typecheck --filter=@bb/app` — clean
- `pnpm exec turbo run test --filter=@bb/app` — 2807 passed

> AGENT GENERATED: by Claude Opus 5