### PR TITLE
Revert "Stop clipping two-digit ordered list markers (#1759)"

### DIFF
--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -910,7 +910,7 @@ function MarkdownOrderedList({
   return (
     <ol
       {...orderedListProps}
-      className="mb-2 list-decimal pl-7 text-foreground"
+      className="mb-2 list-decimal pl-5 text-foreground"
     >
       {children}
     </ol>


### PR DESCRIPTION
This reverts commit 9e102e093be4d71fec6d8be2d1b9fc4b13e4cc3f (#1759).

## Tests

- Clean `git revert` of a one-line change. No new tests.

> AGENT GENERATED: by Claude Opus 5