### PR TITLE
Fix lost first tap on mobile follow-up submit

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -2174,6 +2174,29 @@ describe("PromptBoxInternal compact layout", () => {
     expect(document.activeElement).toBe(editor);
   });
 
+  it("keeps DOM focus through submit when TipTap focus state is stale", async () => {
+    render(
+      <PromptBoxInternal
+        {...createPromptBoxProps({ value: "Send this follow-up" })}
+      />,
+    );
+
+    await waitForPromptFocus();
+    const editor = getPromptEditorElement();
+    const submit = screen.getByRole("button", { name: "Submit (Enter)" });
+
+    // TipTap derives isFocused from focus and blur events. Model the iOS
+    // window where its blur event has arrived but the contenteditable still
+    // owns native focus and therefore still controls the software keyboard.
+    editor.dispatchEvent(new FocusEvent("blur"));
+    expect(document.activeElement).toBe(editor);
+
+    expect(
+      fireEvent.pointerDown(submit, { button: 0, pointerType: "touch" }),
+    ).toBe(false);
+    expect(document.activeElement).toBe(editor);
+  });
+
   it("blurs the editor after a pointer submit when requested", async () => {
     const onSubmit = vi.fn();
     render(

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -2616,18 +2616,22 @@ export function PromptBoxInternal({
     (event: ReactPointerEvent<HTMLButtonElement>) => {
       if (event.button !== 0) return;
       const currentEditor = editorRef.current;
+      const editorElement = currentEditor?.view.dom;
+      const activeElement = editorElement?.ownerDocument.activeElement;
       if (
         !currentEditor ||
         currentEditor.isDestroyed ||
-        !currentEditor.isFocused
+        !editorElement?.contains(activeElement ?? null)
       ) {
         return;
       }
 
       // Focus transfer happens before click. On iOS, moving focus from the
       // editor to this button begins keyboard dismissal and resizes the app
-      // shell before the form can submit. Keep the editor focused; the click
-      // still owns the commit, while genuine outside focus dismisses normally.
+      // shell before the form can submit. Use the DOM's focus state here rather
+      // than TipTap's event-derived isFocused flag, which can briefly lag the
+      // browser. Keep the editor focused; the click still owns the commit,
+      // while genuine outside focus dismisses normally.
       event.preventDefault();
     },
     [],


### PR DESCRIPTION
## User-facing problem

On iPhone, submitting a follow-up can feel like the button ignored the first tap:

1. The user taps Submit.
2. The keyboard closes and the composer shrinks.
3. The message remains unsent.
4. The user has to tap Submit again.

This is especially confusing because it resembles network lag, even though the first submission never actually committed.

## What this changes

The submit button now checks which DOM element the browser actually considers focused instead of relying on TipTap's event-derived focus flag.

During the brief iOS focus transition where those states can disagree, bb keeps the editor and keyboard stable long enough for the first tap to produce its click. After submission commits, the existing keyboard dismissal and compact-composer behavior continue normally.

The change is intentionally narrow: genuine focus outside the editor behaves as before, and desktop submission behavior is unchanged.

## Verification

- Added a regression test that models stale TipTap focus while the contenteditable still owns native focus.
- All 98 PromptBoxInternal tests pass.
- Turbo app typecheck passes.
- Prettier and git diff checks pass.

> AGENT GENERATED: by GPT-5