### PR TITLE
Keep Settings accessible in the iPhone drawer

### DIFF
--- a/apps/app/src/app-shell-height.test.ts
+++ b/apps/app/src/app-shell-height.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const appCss = readFileSync(
+  fileURLToPath(new URL("./app.css", import.meta.url)),
+  "utf8",
+);
+
+describe("app shell height", () => {
+  it("adds only the exposed top safe area to standalone dynamic height", () => {
+    expect(appCss).toMatch(
+      /@media \(display-mode: standalone\)[\s\S]*?--bb-shell-height:\s*calc\(100dvh \+ env\(safe-area-inset-top\)\)/u,
+    );
+    expect(appCss).not.toMatch(/--bb-shell-height:\s*100lvh/u);
+  });
+});

--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -11,15 +11,15 @@
    * chrome cannot leave the percentage-height containing block taller than
    * the visible window.
    *
-   * iOS standalone subtracts the top safe-area inset from the small and
-   * dynamic viewports but not from the large one. On a 852pt screen with a
-   * 59pt inset, innerHeight/100svh/100dvh/height:100% all report 793 while
-   * 100lvh reports the true 852. The shell starts at y=0 under the
-   * translucent status bar, so a 793pt shell leaves a 59pt dead band at the
-   * bottom. 100lvh is the only value that spans the screen.
+   * iOS standalone subtracts the top safe-area inset from the dynamic
+   * viewport when the app paints beneath a translucent status bar. Add that
+   * inset back so the shell still spans the physical screen. Some installed
+   * apps instead start below an opaque status bar; there the safe-area inset
+   * is zero, so the same expression stays at the visible 100dvh height rather
+   * than extending a 100lvh shell below the home indicator.
    *
-   * Scoped to standalone: in a Safari tab, lvh is the toolbars-retracted
-   * height, which is taller than what the user can see.
+   * Scoped to standalone because browser tabs already report the correct
+   * visible 100dvh and must not add the status-area inset a second time.
    *
    * `position: fixed` elements cannot inherit the shell height: a percentage
    * height on them resolves against the initial containing block, which is the
@@ -41,7 +41,7 @@
 
   @media (display-mode: standalone) {
     :root {
-      --bb-shell-height: 100lvh;
+      --bb-shell-height: calc(100dvh + env(safe-area-inset-top));
     }
   }
 

--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -3,6 +3,7 @@ import { cn } from "@bb/shared-ui/lib/utils";
 import { THREAD_JUMP_APP_COMMAND_IDS } from "@bb/domain";
 import { Link, useNavigate } from "react-router-dom";
 import { Icon } from "@bb/shared-ui/icon";
+import { Button } from "@bb/shared-ui/button";
 import { COARSE_POINTER_CHILD_ICON_BUTTON_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import { usePointerCoarse } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import { OverflowFade } from "@/components/ui/overflow-fade.js";
@@ -16,7 +17,11 @@ import {
   useCloseMobileSidebar,
   useSidebar,
 } from "@/components/ui/sidebar.js";
-import { ProjectList, ProjectListActionButtons } from "./ProjectList";
+import {
+  PROJECT_LIST_ACTION_BUTTON_CLASS,
+  ProjectList,
+  ProjectListActionButtons,
+} from "./ProjectList";
 import { PluginThreadList } from "./PluginThreadList";
 import { useThreadListReplacement } from "./threadListProvider";
 import { PluginNavSidebarItems } from "@/components/plugin/PluginNavSidebarItems";
@@ -325,6 +330,21 @@ export function AppSidebar({
               query: threadSearch.query,
             }}
           />
+          {isCompactViewport ? (
+            <Button
+              asChild
+              size="sm"
+              variant="ghost"
+              className={cn(PROJECT_LIST_ACTION_BUTTON_CLASS, "mt-0.5 w-full")}
+            >
+              <Link to={settingsRoutePath} onClick={closeOnMobile}>
+                <Icon name="Settings" />
+                <span className="min-w-0 flex-1 truncate text-left">
+                  Settings
+                </span>
+              </Link>
+            </Button>
+          ) : null}
         </div>
         <PluginNavSidebarItems
           onNavigate={closeOnMobile}
@@ -351,30 +371,32 @@ export function AppSidebar({
            * they sit flush left because the spacer stays behind on the action
            * line. */}
           <SidebarMenu className="flex-row flex-wrap-reverse items-center gap-1">
-            <SidebarMenuItem className="min-w-0">
-              <SidebarMenuButton
-                asChild
-                aria-label={
-                  settingsShortcut
-                    ? `Settings (${settingsShortcut.label})`
-                    : "Settings"
-                }
-                aria-keyshortcuts={settingsShortcut?.ariaKeyshortcuts}
-                tooltip={{
-                  children: settingsShortcut
-                    ? `Settings (${settingsShortcut.label})`
-                    : "Settings",
-                  hidden: false,
-                  side: "top",
-                }}
-                className={SIDEBAR_FOOTER_ACTION_CLASS}
-              >
-                <Link to={settingsRoutePath} onClick={closeOnMobile}>
-                  <Icon name="Settings" />
-                  <span className="sr-only">Settings</span>
-                </Link>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
+            {!isCompactViewport ? (
+              <SidebarMenuItem className="min-w-0">
+                <SidebarMenuButton
+                  asChild
+                  aria-label={
+                    settingsShortcut
+                      ? `Settings (${settingsShortcut.label})`
+                      : "Settings"
+                  }
+                  aria-keyshortcuts={settingsShortcut?.ariaKeyshortcuts}
+                  tooltip={{
+                    children: settingsShortcut
+                      ? `Settings (${settingsShortcut.label})`
+                      : "Settings",
+                    hidden: false,
+                    side: "top",
+                  }}
+                  className={SIDEBAR_FOOTER_ACTION_CLASS}
+                >
+                  <Link to={settingsRoutePath} onClick={closeOnMobile}>
+                    <Icon name="Settings" />
+                    <span className="sr-only">Settings</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            ) : null}
             <PluginSidebarFooterActions onNavigate={closeOnMobile} />
             <SidebarMenuItem className="min-w-0">
               <SidebarMenuButton


### PR DESCRIPTION
## User-facing problem

On an installed iPhone PWA, Settings can become effectively inaccessible:

- The only entry is an unlabeled gear in the drawer footer.
- The standalone viewport can place that footer below the visible screen or home indicator.
- A user opening the drawer may therefore see neither an obvious Settings action nor the clipped footer control.

This is both a discoverability problem and a viewport-sizing problem.

## What this changes

On compact viewports, the drawer now shows a labeled Settings row beside the primary actions near the top. Desktop keeps the existing icon-only footer action, so its established layout does not change.

The standalone iOS shell also uses the dynamic viewport height plus the exposed top safe-area inset. This covers the physical screen when bb paints under a translucent status bar without extending the drawer below the home indicator when iOS already positions the app beneath an opaque status bar.

Together, these changes give iPhone users a reliable, visible route to Settings while keeping the rest of the footer accessible.

## Verification

- Added regression coverage for the standalone shell-height rule.
- All 14 focused shell and sidebar tests pass.
- Turbo app typecheck passes.
- Prettier and git diff checks pass.

> AGENT GENERATED: by GPT-5