### PR TITLE
host-daemon: give unanswered user questions a ten-minute deadline

### DIFF
--- a/apps/host-daemon/src/app.ts
+++ b/apps/host-daemon/src/app.ts
@@ -432,6 +432,13 @@ export async function createHostDaemonApp(
         threadIds: [request.threadId],
       });
     },
+    onTimeout: (request) => {
+      enqueueInteractiveInterrupt({
+        providerId: request.providerId,
+        reason: "User question timed out waiting for an answer",
+        threadIds: [request.threadId],
+      });
+    },
   });
 
   let sendServerMessage = (_message: HostDaemonDaemonWsMessage) => false;
@@ -597,7 +604,8 @@ export async function createHostDaemonApp(
       } catch (error) {
         if (
           error instanceof InteractiveRequestRegistryError &&
-          error.code === "interactive_request_rejected"
+          (error.code === "interactive_request_rejected" ||
+            error.code === "interactive_request_timeout")
         ) {
           options.logger.warn(
             {
@@ -609,7 +617,9 @@ export async function createHostDaemonApp(
               providerRequestId: request.providerRequestId,
               kind: request.payload.kind,
             },
-            "Interactive provider request rejected by server",
+            error.code === "interactive_request_timeout"
+              ? "Interactive user question timed out"
+              : "Interactive provider request rejected by server",
           );
           throw error;
         }

--- a/apps/host-daemon/src/interactive-request-registry.test.ts
+++ b/apps/host-daemon/src/interactive-request-registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   PendingInteractionCreate,
   PendingInteractionResolution,
@@ -7,6 +7,7 @@ import type { HostDaemonInteractiveRequestResponse } from "@bb/host-daemon-contr
 import {
   InteractiveRequestRegistry,
   InteractiveRequestRegistryError,
+  USER_QUESTION_DEADLINE_MS,
 } from "./interactive-request-registry.js";
 
 interface Deferred<TValue> {
@@ -19,6 +20,7 @@ interface CreateRegistryArgs {
   registerRequest: (
     request: PendingInteractionCreate,
   ) => Promise<HostDaemonInteractiveRequestResponse>;
+  onTimeout?: (request: PendingInteractionCreate) => void;
 }
 
 interface CreateCommandApprovalRequestArgs {
@@ -71,9 +73,45 @@ function createCommandApprovalResolution(): PendingInteractionResolution {
   };
 }
 
+function createUserQuestionRequest(): PendingInteractionCreate {
+  return {
+    threadId: "thr_registry_question",
+    turnId: "turn_registry_question",
+    providerId: "claude-code",
+    providerThreadId: "provider-thread-registry-question",
+    providerRequestId: "request-registry-question",
+    payload: {
+      kind: "user_question",
+      questions: [
+        {
+          id: "question-registry",
+          prompt: "Should I proceed?",
+          shortLabel: "Proceed?",
+          multiSelect: false,
+          options: [
+            { value: "yes", label: "Yes" },
+            { value: "no", label: "No" },
+          ],
+          allowFreeText: false,
+        },
+      ],
+    },
+  };
+}
+
+function createUserQuestionResolution(): PendingInteractionResolution {
+  return {
+    kind: "user_answer",
+    answers: {
+      "Should I proceed?": { selected: ["yes"] },
+    },
+  };
+}
+
 function createRegistry(args: CreateRegistryArgs): InteractiveRequestRegistry {
   return new InteractiveRequestRegistry({
     registerRequest: args.registerRequest,
+    onTimeout: args.onTimeout,
   });
 }
 
@@ -199,6 +237,115 @@ describe("InteractiveRequestRegistry", () => {
       message: "Thread is already awaiting user interaction",
       name: "InteractiveRequestRegistryError",
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("rejects a user question no client answers within the deadline", async () => {
+    vi.useFakeTimers();
+    const request = createUserQuestionRequest();
+    const timedOutRequests: PendingInteractionCreate[] = [];
+    const registry = createRegistry({
+      registerRequest: async () => ({
+        outcome: "created",
+        interactionId: "pint_registry_question",
+        status: "pending",
+      }),
+      onTimeout: (timedOutRequest) => {
+        timedOutRequests.push(timedOutRequest);
+      },
+    });
+
+    const pending = registry.registerAndWait(request);
+    vi.advanceTimersByTime(USER_QUESTION_DEADLINE_MS);
+
+    await expect(pending).rejects.toMatchObject({
+      code: "interactive_request_timeout",
+      name: "InteractiveRequestRegistryError",
+    });
+    expect(timedOutRequests).toEqual([request]);
+  });
+
+  it("does not apply the deadline to approval requests", async () => {
+    vi.useFakeTimers();
+    const request = createCommandApprovalRequest();
+    const timedOutRequests: PendingInteractionCreate[] = [];
+    const registry = createRegistry({
+      registerRequest: async () => ({
+        outcome: "created",
+        interactionId: "pint_registry",
+        status: "pending",
+      }),
+      onTimeout: (timedOutRequest) => {
+        timedOutRequests.push(timedOutRequest);
+      },
+    });
+
+    const pending = registry.registerAndWait(request);
+    vi.advanceTimersByTime(USER_QUESTION_DEADLINE_MS * 2);
+
+    // Still awaiting the user's decision.
+    await expect(
+      Promise.race([
+        pending.then(() => "resolved", () => "rejected"),
+        Promise.resolve("still-pending"),
+      ]),
+    ).resolves.toBe("still-pending");
+    expect(timedOutRequests).toEqual([]);
+  });
+
+  it("clears the deadline when a user question is answered in time", async () => {
+    vi.useFakeTimers();
+    const request = createUserQuestionRequest();
+    const resolution = createUserQuestionResolution();
+    const timedOutRequests: PendingInteractionCreate[] = [];
+    const registry = createRegistry({
+      registerRequest: async () => ({
+        outcome: "created",
+        interactionId: "pint_registry_question",
+        status: "pending",
+      }),
+      onTimeout: (timedOutRequest) => {
+        timedOutRequests.push(timedOutRequest);
+      },
+    });
+
+    const pending = registry.registerAndWait(request);
+    registry.resolve({
+      interactionId: "pint_registry_question",
+      providerId: request.providerId,
+      providerRequestId: request.providerRequestId,
+      providerThreadId: request.providerThreadId,
+      resolution,
+      threadId: request.threadId,
+    });
+    await expect(pending).resolves.toEqual(resolution);
+
+    vi.advanceTimersByTime(USER_QUESTION_DEADLINE_MS * 2);
+    expect(timedOutRequests).toEqual([]);
+  });
+
+  it("does not time out a user question whose registration failed", async () => {
+    vi.useFakeTimers();
+    const request = createUserQuestionRequest();
+    const timedOutRequests: PendingInteractionCreate[] = [];
+    const registry = createRegistry({
+      registerRequest: async () => ({
+        outcome: "rejected",
+        reason: "Thread is already awaiting user interaction",
+      }),
+      onTimeout: (timedOutRequest) => {
+        timedOutRequests.push(timedOutRequest);
+      },
+    });
+
+    await expect(registry.registerAndWait(request)).rejects.toMatchObject({
+      code: "interactive_request_rejected",
+    });
+    vi.advanceTimersByTime(USER_QUESTION_DEADLINE_MS * 2);
+    expect(timedOutRequests).toEqual([]);
   });
 
   it("rejects provider waits when the provider exits", async () => {

--- a/apps/host-daemon/src/interactive-request-registry.ts
+++ b/apps/host-daemon/src/interactive-request-registry.ts
@@ -7,6 +7,16 @@ import { normalizeCaughtError } from "./error-utils.js";
 
 const DELIVERED_INTERACTIVE_REQUEST_TOMBSTONE_TTL_MS = 5 * 60 * 1000;
 
+/**
+ * How long a user-question interaction may sit unanswered before the daemon
+ * gives up on it. The plugin interaction path defaults to the same ten
+ * minutes (`bb.ui.requestInput`), so a native provider question waits no
+ * longer than a plugin one. Without this, `registerAndWait` resolves only
+ * when a client answers or the provider exits, so an unattended thread hangs
+ * for hours and the human's replies queue behind a turn that never ends.
+ */
+export const USER_QUESTION_DEADLINE_MS = 10 * 60 * 1000;
+
 export interface InteractiveResolveCommandInput {
   interactionId: string;
   providerId: string;
@@ -28,6 +38,8 @@ export interface InteractiveRequestRegistryOptions {
   registerRequest: (
     request: PendingInteractionCreate,
   ) => Promise<HostDaemonInteractiveRequestResponse>;
+  /** Invoked when a user-question request exceeds its deadline unanswered. */
+  onTimeout?: (request: PendingInteractionCreate) => void;
 }
 
 export interface InterruptInteractiveThreadsArgs {
@@ -42,6 +54,8 @@ interface PendingInteractiveRequestEntry {
   reject: (error: Error) => void;
   resolve: (resolution: PendingInteractionResolution) => void;
   request: PendingInteractionCreate;
+  /** Armed for user questions; cleared on every terminal path. */
+  timeout?: ReturnType<typeof setTimeout>;
 }
 
 interface DeliveredInteractiveRequestTombstone {
@@ -130,11 +144,17 @@ export class InteractiveRequestRegistry {
       request,
     };
     this.pendingEntries.set(key, entry);
+    if (request.payload.kind === "user_question") {
+      entry.timeout = setTimeout(() => {
+        this.expireUserQuestionEntry(key, entry);
+      }, USER_QUESTION_DEADLINE_MS);
+      entry.timeout.unref();
+    }
 
     try {
       const response = await this.options.registerRequest(request);
       if (response.outcome === "rejected") {
-        this.pendingEntries.delete(key);
+        this.removeEntry(key);
         entry.reject(
           new InteractiveRequestRegistryError(
             "interactive_request_rejected",
@@ -146,7 +166,7 @@ export class InteractiveRequestRegistry {
 
       entry.interactionId = response.interactionId;
       if (response.status !== "pending" && response.status !== "resolving") {
-        this.pendingEntries.delete(key);
+        this.removeEntry(key);
         entry.reject(
           new Error(
             `Pending interaction ${response.interactionId} is already ${response.status}`,
@@ -154,7 +174,7 @@ export class InteractiveRequestRegistry {
         );
       }
     } catch (error) {
-      this.pendingEntries.delete(key);
+      this.removeEntry(key);
       const registrationError = normalizeCaughtError(error);
       this.options.onRegistrationFailure?.({
         error: registrationError,
@@ -164,6 +184,39 @@ export class InteractiveRequestRegistry {
     }
 
     return promise;
+  }
+
+  /**
+   * Gives up on a user question no client answered within the deadline. The
+   * rejection propagates to the provider bridge, which turns it into a denial
+   * the model can answer in prose; `onTimeout` lets the caller tell the server
+   * to drop the still-pending row so the thread is not stuck "already awaiting
+   * user interaction" afterwards.
+   */
+  private expireUserQuestionEntry(
+    key: string,
+    entry: PendingInteractiveRequestEntry,
+  ): void {
+    if (!this.pendingEntries.has(key)) {
+      return;
+    }
+    this.removeEntry(key);
+    entry.reject(
+      new InteractiveRequestRegistryError(
+        "interactive_request_timeout",
+        `No client answered this question within ${USER_QUESTION_DEADLINE_MS / 60_000} minutes — ask it in prose instead so the answer arrives as a message`,
+      ),
+    );
+    this.options.onTimeout?.(entry.request);
+  }
+
+  private removeEntry(key: string): void {
+    const entry = this.pendingEntries.get(key);
+    if (entry?.timeout !== undefined) {
+      clearTimeout(entry.timeout);
+      entry.timeout = undefined;
+    }
+    this.pendingEntries.delete(key);
   }
 
   resolve(request: InteractiveResolveCommandInput): void {
@@ -190,7 +243,7 @@ export class InteractiveRequestRegistry {
       );
     }
 
-    this.pendingEntries.delete(key);
+    this.removeEntry(key);
     this.addDeliveredTombstone(tombstoneKey);
     entry.resolve(request.resolution);
   }
@@ -205,7 +258,7 @@ export class InteractiveRequestRegistry {
         continue;
       }
 
-      this.pendingEntries.delete(key);
+      this.removeEntry(key);
       entry.reject(new Error(args.reason));
     }
   }


### PR DESCRIPTION
## Problem

A native user-question request — claude-code's `AskUserQuestion` forwarded over `interaction/request` — registers with the server and then resolves only when a client answers or the provider exits. With nobody watching the thread, the `registerAndWait` promise never settles: the turn never ends and the human's typed replies queue behind it (measured: a question pending 2h30m, the reply delivered 13 minutes later as an abort).

The plugin interaction path (`bb.ui.requestInput`) already defaults to a ten-minute timeout; the native path has none (`expiresAt: null`).

## Fix

`InteractiveRequestRegistry.registerAndWait` now arms a ten-minute deadline for `user_question` payloads (approvals keep their current behavior). On expiry the entry is dropped and rejected with `interactive_request_timeout`, which propagates to the provider bridge as a JSON-RPC error and resolves the tool call as a denial telling the model to ask in prose instead — one wasted turn instead of a multi-hour hang. A new `onTimeout` option (wired in `app.ts` to the existing interactive-interrupt push) marks the server row interrupted so the thread is not left stuck "already awaiting user interaction".

## Tests

- `interactive-request-registry.test.ts`: rejects an unanswered user question at the deadline (fails on the old code — the promise never settles), applies no deadline to approvals, clears the deadline when answered in time, and does not time out a question whose registration failed.
- Full `@bb/host-daemon` suite (586 tests) and typecheck pass.