### PR TITLE
Cap the prompt banner changed-files list and lazy-mount collapsed bodies

### DIFF
--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
@@ -1,7 +1,10 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
 import type { ThreadPullRequest } from "@bb/domain";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   isThreadDisplayStatusBannerActive,
   ThreadPromptContextBanner,
@@ -387,9 +390,7 @@ describe("ThreadPromptContextBanner", () => {
       </MemoryRouter>,
     );
 
-    expect(markup).toContain(
-      "1 active child thread: Waiting for build host",
-    );
+    expect(markup).toContain("1 active child thread: Waiting for build host");
     expect(markup).toContain("Active child thread:");
     expect(markup).not.toContain("Running child thread:");
   });
@@ -528,5 +529,44 @@ describe("ThreadPromptContextBanner", () => {
     expect(markup).toContain("PR #128");
     expect(markup).toContain("Committed");
     expect(markup).toContain("1 file");
+  });
+});
+
+describe("ThreadPromptContextBanner git section body", () => {
+  afterEach(cleanup);
+
+  function renderBanner(expandedSection: "git" | null) {
+    return (
+      <MemoryRouter>
+        <ThreadPromptContextBanner
+          gitSection={makeGitSection("uncommitted")}
+          gitSectionPending={false}
+          archivedSection={null}
+          environmentGoneSection={null}
+          parentThreadSection={null}
+          childThreadsSection={null}
+          pullRequestSection={null}
+          expandedSection={expandedSection}
+          onToggleSection={noop}
+        />
+      </MemoryRouter>
+    );
+  }
+
+  it("does not mount the changed-files list until the section first expands", () => {
+    // The list can hold thousands of rows. A collapsed body still costs
+    // layout for every node inside it, so it must stay out of the DOM.
+    const { rerender } = render(renderBanner(null));
+    expect(screen.queryByRole("list", { hidden: true })).toBeNull();
+
+    rerender(renderBanner("git"));
+    expect(screen.getByRole("list")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: `Open ${changedFile.path}` }),
+    ).toBeTruthy();
+
+    // Retain the realized body after collapse so re-opening is instant.
+    rerender(renderBanner(null));
+    expect(screen.getByRole("list", { hidden: true })).toBeTruthy();
   });
 });

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
@@ -1,4 +1,9 @@
-import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from "react";
+import {
+  forwardRef,
+  useState,
+  type ButtonHTMLAttributes,
+  type ReactNode,
+} from "react";
 import { NavLink } from "react-router-dom";
 import type {
   EnvironmentStatus,
@@ -668,6 +673,15 @@ function AnimatedBody({
   isExpanded: boolean;
   children: ReactNode;
 }) {
+  // Realize the body only after the first expand, then retain it. A collapsed
+  // body still costs layout for every node inside it, and the changed-files
+  // list can be large, so the DOM must not carry it before anyone opens it.
+  const [hasRealizedBody, setHasRealizedBody] = useState(isExpanded);
+  if (isExpanded && !hasRealizedBody) {
+    setHasRealizedBody(true);
+  }
+  const isBodyRealized = hasRealizedBody || isExpanded;
+
   return (
     <section
       id={id}
@@ -681,7 +695,9 @@ function AnimatedBody({
           : "pointer-events-none grid-rows-[0fr] border-t border-transparent opacity-0",
       )}
     >
-      <div className="overflow-hidden bg-popover">{children}</div>
+      <div className="overflow-hidden bg-popover">
+        {isBodyRealized ? children : null}
+      </div>
     </section>
   );
 }
@@ -759,9 +775,7 @@ function ActiveChildThreadsCard({
           />
           <span className="min-w-0 flex-1 truncate text-left">
             <span className="text-muted-foreground">
-              {needsApproval
-                ? "Needs your input: "
-                : "Active child thread: "}
+              {needsApproval ? "Needs your input: " : "Active child thread: "}
             </span>
             <span className="font-medium text-foreground/80">
               {primary.title}
@@ -858,10 +872,7 @@ function ReadOnlyContextBanner({
             className="size-3.5 shrink-0"
             aria-hidden="true"
           />
-          <span
-            className="min-w-0 truncate"
-            aria-hidden="true"
-          >
+          <span className="min-w-0 truncate" aria-hidden="true">
             {statusLabel}
           </span>
         </div>
@@ -916,9 +927,7 @@ export function ThreadPromptContextBanner({
         statusAriaLabel={
           environmentGoneCopy?.ariaLabel ?? ARCHIVED_THREAD_STATUS_LABEL
         }
-        statusLabel={
-          environmentGoneCopy?.label ?? ARCHIVED_THREAD_STATUS_LABEL
-        }
+        statusLabel={environmentGoneCopy?.label ?? ARCHIVED_THREAD_STATUS_LABEL}
         statusAction={
           archivedSection?.onUnarchive && !environmentGone ? (
             <ThreadUnarchiveTextAction
@@ -1017,8 +1026,7 @@ export function ThreadPromptContextBanner({
   // inline as "Parent <name>" with the name as a link. There's no other
   // context to compete for the row, so the icon-only toggle would be a strict
   // downgrade in legibility.
-  const isParentThreadOnly =
-    showParentThread && !showGit && !showPullRequest;
+  const isParentThreadOnly = showParentThread && !showGit && !showPullRequest;
 
   const pullRequest = pullRequestSection?.pullRequest ?? null;
   const showPullRequestLabel =

--- a/apps/app/src/components/thread/WorkspaceChangesList.test.tsx
+++ b/apps/app/src/components/thread/WorkspaceChangesList.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  WORKSPACE_CHANGES_LIST_MAX_ROWS,
+  WorkspaceChangesList,
+  type WorkspaceChangedFile,
+} from "./WorkspaceChangesList";
+
+function makeFiles(count: number): WorkspaceChangedFile[] {
+  return Array.from({ length: count }, (_, index) => ({
+    path: `dist/output-${index}.js`,
+    status: "??" as const,
+    insertions: null,
+    deletions: null,
+  }));
+}
+
+afterEach(cleanup);
+
+describe("WorkspaceChangesList", () => {
+  it("renders every file when the list fits under the row cap", () => {
+    render(<WorkspaceChangesList files={makeFiles(3)} />);
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+    expect(screen.queryByText(/more files not shown/)).toBeNull();
+  });
+
+  it("caps the scrollable list and reports the hidden remainder", () => {
+    // A stray untracked build directory can put tens of thousands of files
+    // in workspace status. Rendering all of them made every page layout cost
+    // hundreds of milliseconds, so the list must stop at the cap.
+    const files = makeFiles(WORKSPACE_CHANGES_LIST_MAX_ROWS + 1234);
+    render(<WorkspaceChangesList files={files} />);
+
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+    expect(screen.getAllByRole("listitem")).toHaveLength(
+      WORKSPACE_CHANGES_LIST_MAX_ROWS + 1,
+    );
+    expect(
+      screen.getByText(`${(1234).toLocaleString()} more files not shown`),
+    ).toBeTruthy();
+    expect(screen.queryByTitle(files[files.length - 1]!.path)).toBeNull();
+  });
+});

--- a/apps/app/src/components/thread/WorkspaceChangesList.tsx
+++ b/apps/app/src/components/thread/WorkspaceChangesList.tsx
@@ -34,6 +34,19 @@ interface WorkspaceChangesListItemProps {
 const WORKSPACE_CHANGE_ROW_CLASS =
   "grid grid-cols-[1.5rem_minmax(0,1fr)_auto] items-start gap-x-3";
 
+/**
+ * Upper bound on rows the scrollable (non-`limit`) mode renders. Workspace
+ * status carries every changed path, and a stray untracked build directory
+ * can produce tens of thousands of files. Rendering all of them makes every
+ * layout on the page cost hundreds of milliseconds, so the list shows the
+ * leading slice and reports how many rows it left out.
+ */
+export const WORKSPACE_CHANGES_LIST_MAX_ROWS = 200;
+
+function formatHiddenFileCount(count: number): string {
+  return `${count.toLocaleString()} more ${count === 1 ? "file" : "files"} not shown`;
+}
+
 function fileKey(file: WorkspaceChangedFile): string {
   return `${file.status}:${file.path}`;
 }
@@ -108,13 +121,24 @@ export function WorkspaceChangesList({
     );
   }
 
+  const visibleFiles =
+    files.length > WORKSPACE_CHANGES_LIST_MAX_ROWS
+      ? files.slice(0, WORKSPACE_CHANGES_LIST_MAX_ROWS)
+      : files;
+  const hiddenFileCount = files.length - visibleFiles.length;
+
   return (
     <ul className={cn("space-y-1 overflow-auto", className)}>
-      {files.map((file) => (
+      {visibleFiles.map((file) => (
         <li key={fileKey(file)}>
           <WorkspaceChangesListItem file={file} onFileClick={onFileClick} />
         </li>
       ))}
+      {hiddenFileCount > 0 ? (
+        <li className="px-1 text-xs leading-5 text-muted-foreground">
+          {formatHiddenFileCount(hiddenFileCount)}
+        </li>
+      ) : null}
     </ul>
   );
 }


### PR DESCRIPTION
## Summary

- `WorkspaceChangesList` scroll mode (the prompt banner) now renders at most 200 rows and adds a `N more files not shown` row for the remainder.
- `AnimatedBody` in `ThreadPromptContextBanner` mounts its children on the first expand and retains them afterwards, so a collapsed section no longer carries its DOM.
- Adds `WorkspaceChangesList.test.tsx` and a banner test for the lazy mount.

## Why

Fixes #1777.

The DevTools trace attached to #1777 (bb 0.38.0) showed one `UL class='space-y-1 overflow-auto max-h-32 ...'` with 15,701 children: the prompt banner's changed-files list for a workspace with a huge untracked tree. That single list produced ~65k elements and ~97k layout objects, so every full layout cost 320–580 ms and a click on a file row blocked the main thread for 1.44 s (React re-created all rows, then two layout effects forced synchronous layout). The list was in the DOM even while the git section was collapsed.

#1496 and #1607 bounded the daemon side (process count, diff content, 500-file diff ceiling) but kept every path in workspace status. This change bounds the client render. The metadata panel already caps its copy at `limit={5}`.

Follow-up (not in this PR): bound `workingTree.files` at the server with a truncation signal so no surface can render an unbounded list.

## Verification

- `WorkspaceChangesList.test.tsx` and `ThreadPromptContextBanner.test.tsx`: 20 passed
- `pnpm exec turbo run typecheck --filter=@bb/app` passed; ESLint and Prettier clean
- End-to-end in the dev app with a repo of 3,000 untracked files: collapsed page has no list mounted (578 elements); expanded shows 200 rows plus `2,801 more files not shown` (1,392 elements); body is retained and `aria-hidden` after collapse.

> AGENT GENERATED: by Claude Opus 5

