### PR TITLE
Retry Connect tunnel after rejected WebSocket upgrades

### DIFF
--- a/plugins/connect/src/tunnel-lifecycle.test.ts
+++ b/plugins/connect/src/tunnel-lifecycle.test.ts
@@ -8,7 +8,9 @@ interface FakeWebSocketOptions {
 }
 
 interface FakeTunnelSocket {
+  readyState: number;
   emit(eventName: string, ...args: unknown[]): boolean;
+  terminate(): void;
 }
 
 const fakeWebSockets = vi.hoisted(() => ({
@@ -162,6 +164,33 @@ describe("ConnectTunnel socket lifecycle", () => {
       expect(fakeWebSockets.options[0]!.handshakeTimeout).toBeGreaterThan(0);
     } finally {
       tunnel.stop();
+      await fakeHost.harness.dispose();
+    }
+  });
+
+  it("retries when the handshake never completes within the deadline", async () => {
+    vi.useFakeTimers();
+    const { fakeHost, tunnel } = createTunnelFixture();
+
+    try {
+      await tunnel.start();
+      const socket = fakeWebSockets.instances[0]!;
+      const terminate = vi.spyOn(socket, "terminate");
+
+      // No open/error/close arrives: a peer that drips header bytes keeps
+      // ws's idle handshakeTimeout from firing. The absolute deadline must.
+      await vi.advanceTimersByTimeAsync(15_000);
+
+      expect(terminate).toHaveBeenCalledOnce();
+      expect(tunnel.status().lastError).toContain("handshake timed out");
+      const nextRetryAt = tunnel.status().nextRetryAt;
+      expect(nextRetryAt).not.toBeNull();
+
+      await vi.advanceTimersByTimeAsync(nextRetryAt! - Date.now());
+      expect(fakeWebSockets.instances).toHaveLength(2);
+    } finally {
+      tunnel.stop();
+      vi.useRealTimers();
       await fakeHost.harness.dispose();
     }
   });

--- a/plugins/connect/src/tunnel-lifecycle.test.ts
+++ b/plugins/connect/src/tunnel-lifecycle.test.ts
@@ -3,12 +3,17 @@ import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
 import { ShareHostResolver } from "./hosts.js";
 import { ShareRegistry } from "./shares.js";
 
+interface FakeWebSocketOptions {
+  handshakeTimeout?: number;
+}
+
 interface FakeTunnelSocket {
   emit(eventName: string, ...args: unknown[]): boolean;
 }
 
 const fakeWebSockets = vi.hoisted(() => ({
   instances: [] as FakeTunnelSocket[],
+  options: [] as FakeWebSocketOptions[],
 }));
 
 vi.mock("ws", async (importOriginal) => {
@@ -18,9 +23,10 @@ vi.mock("ws", async (importOriginal) => {
   class FakeWebSocket extends EventEmitter {
     readyState = 0;
 
-    constructor() {
+    constructor(_url: unknown, options: FakeWebSocketOptions) {
       super();
       fakeWebSockets.instances.push(this);
+      fakeWebSockets.options.push(options);
     }
 
     terminate(): void {
@@ -87,6 +93,7 @@ function createTunnelFixture() {
 describe("ConnectTunnel socket lifecycle", () => {
   afterEach(() => {
     fakeWebSockets.instances.length = 0;
+    fakeWebSockets.options.length = 0;
   });
 
   it("ignores events from a socket after the tunnel stops", async () => {
@@ -138,6 +145,80 @@ describe("ConnectTunnel socket lifecycle", () => {
       expect(tunnel.status().state).toBe("connected");
     } finally {
       tunnel.stop();
+      await fakeHost.harness.dispose();
+    }
+  });
+
+  it("sets a bounded opening handshake timeout", async () => {
+    const { fakeHost, tunnel } = createTunnelFixture();
+
+    try {
+      await tunnel.start();
+
+      expect(fakeWebSockets.options).toHaveLength(1);
+      expect(fakeWebSockets.options[0]?.handshakeTimeout).toEqual(
+        expect.any(Number),
+      );
+      expect(fakeWebSockets.options[0]!.handshakeTimeout).toBeGreaterThan(0);
+    } finally {
+      tunnel.stop();
+      await fakeHost.harness.dispose();
+    }
+  });
+
+  it("retries an HTTP rejection without waiting for close", async () => {
+    vi.useFakeTimers();
+    const { fakeHost, tunnel } = createTunnelFixture();
+
+    try {
+      await tunnel.start();
+      const socket = fakeWebSockets.instances[0]!;
+      const response = { statusCode: 500, resume: vi.fn() };
+
+      socket.emit("unexpected-response", {}, response);
+
+      expect(response.resume).toHaveBeenCalledOnce();
+      expect(tunnel.status().lastError).toBe("tunnel rejected: HTTP 500");
+      const nextRetryAt = tunnel.status().nextRetryAt;
+      expect(nextRetryAt).not.toBeNull();
+
+      await vi.advanceTimersByTimeAsync(nextRetryAt! - Date.now());
+
+      expect(fakeWebSockets.instances).toHaveLength(2);
+      expect(tunnel.status().nextRetryAt).toBeNull();
+    } finally {
+      tunnel.stop();
+      vi.useRealTimers();
+      await fakeHost.harness.dispose();
+    }
+  });
+
+  it("schedules one retry when rejection is followed by close", async () => {
+    vi.useFakeTimers();
+    const { fakeHost, tunnel } = createTunnelFixture();
+
+    try {
+      await tunnel.start();
+      const socket = fakeWebSockets.instances[0]!;
+      socket.emit(
+        "unexpected-response",
+        {},
+        {
+          statusCode: 500,
+          resume: vi.fn(),
+        },
+      );
+      const nextRetryAt = tunnel.status().nextRetryAt;
+      expect(nextRetryAt).not.toBeNull();
+
+      socket.emit("close", 1006, Buffer.from("late close"));
+
+      expect(tunnel.status().nextRetryAt).toBe(nextRetryAt);
+      await vi.advanceTimersByTimeAsync(nextRetryAt! - Date.now());
+      expect(fakeWebSockets.instances).toHaveLength(2);
+    } finally {
+      tunnel.stop();
+      vi.useRealTimers();
       await fakeHost.harness.dispose();
     }
   });

--- a/plugins/connect/src/tunnel.ts
+++ b/plugins/connect/src/tunnel.ts
@@ -44,6 +44,7 @@ import type { ShareHost } from "./hosts.js";
 import type { ConnectStateName, ConnectStatus } from "./types.js";
 
 const DISCONNECT_TIMEOUT_MS = 5_000;
+const TUNNEL_HANDSHAKE_TIMEOUT_MS = 15_000;
 
 async function notifyCloudOfDisconnect(
   credential: ConnectCredential,
@@ -445,6 +446,7 @@ export class ConnectTunnel {
     try {
       tunnel = new NodeWebSocket(tunnelUrl, {
         headers: { authorization: `Bearer ${credential.credential}` },
+        handshakeTimeout: TUNNEL_HANDSHAKE_TIMEOUT_MS,
       });
     } catch (error) {
       // A malformed stored serverUrl throws synchronously. Retrying cannot
@@ -458,9 +460,38 @@ export class ConnectTunnel {
     }
     this.tunnel = tunnel;
     let connectedAt = 0;
+    let retryScheduled = false;
+
+    const scheduleReconnect = (detail: string): void => {
+      if (retryScheduled || this.stopped || this.tunnel !== tunnel) {
+        return;
+      }
+      retryScheduled = true;
+      this.connected = false;
+      this.session?.dispose();
+      this.session = undefined;
+      this.remoteClients = 0;
+      const stable = connectedAt ? Date.now() - connectedAt : 0;
+      const delay = this.backoff.nextDelayAfterClose(stable);
+      if (this.lastError === null) {
+        this.lastError = `can't reach ${connectApexHost(credential.serverUrl)} — connection closed`;
+      }
+      this.nextRetryAt = Date.now() + delay;
+      this.options.log.warn(`${detail}; reconnecting in ${delay}ms`);
+      this.reconnectTimer = setTimeout(() => {
+        if (this.stopped || this.tunnel !== tunnel) return;
+        this.reconnectTimer = undefined;
+        this.nextRetryAt = null;
+        this.publish();
+        this.openTunnel();
+      }, delay);
+      this.publish();
+    };
 
     tunnel.on("open", () => {
-      if (this.stopped || this.tunnel !== tunnel) return;
+      if (retryScheduled || this.stopped || this.tunnel !== tunnel) {
+        return;
+      }
       connectedAt = Date.now();
       this.connected = true;
       this.lastError = null;
@@ -483,16 +514,20 @@ export class ConnectTunnel {
     });
     tunnel.on("unexpected-response", (_req, res) => {
       if (this.stopped || this.tunnel !== tunnel) return;
+      res.resume();
       const statusCode = res.statusCode ?? 0;
       if (statusCode === 401 || statusCode === 403) {
         this.credentialRejected(statusCode);
         return;
       }
       this.lastError = `tunnel rejected: HTTP ${statusCode}`;
-      this.options.log.warn(this.lastError);
+      scheduleReconnect(this.lastError);
+      tunnel.terminate();
     });
     tunnel.on("error", (e: Error) => {
-      if (this.stopped || this.tunnel !== tunnel) return;
+      if (retryScheduled || this.stopped || this.tunnel !== tunnel) {
+        return;
+      }
       // Humanize transport failures for the reconnecting card; the raw
       // message still rides the log via the close handler below.
       this.lastError = humanizeTransportError(
@@ -501,24 +536,9 @@ export class ConnectTunnel {
       );
     });
     tunnel.on("close", (code: number, reason: Buffer) => {
-      if (this.stopped || this.tunnel !== tunnel) return;
-      this.connected = false;
-      this.session?.dispose();
-      this.session = undefined;
-      this.remoteClients = 0;
-      const stable = connectedAt ? Date.now() - connectedAt : 0;
-      const delay = this.backoff.nextDelayAfterClose(stable);
-      // A clean close with no prior socket error still leaves the card empty;
-      // give it an honest line so the reconnecting state is never blank.
-      if (this.lastError === null) {
-        this.lastError = `can't reach ${connectApexHost(credential.serverUrl)} — connection closed`;
-      }
-      this.nextRetryAt = Date.now() + delay;
-      this.options.log.warn(
-        `tunnel closed (code ${code}${reason.length > 0 ? `, ${reason.toString()}` : ""}); reconnecting in ${delay}ms`,
+      scheduleReconnect(
+        `tunnel closed (code ${code}${reason.length > 0 ? `, ${reason.toString()}` : ""})`,
       );
-      this.reconnectTimer = setTimeout(() => this.openTunnel(), delay);
-      this.publish();
     });
   }
 }

--- a/plugins/connect/src/tunnel.ts
+++ b/plugins/connect/src/tunnel.ts
@@ -461,12 +461,14 @@ export class ConnectTunnel {
     this.tunnel = tunnel;
     let connectedAt = 0;
     let retryScheduled = false;
+    let handshakeDeadline: ReturnType<typeof setTimeout> | undefined;
 
     const scheduleReconnect = (detail: string): void => {
       if (retryScheduled || this.stopped || this.tunnel !== tunnel) {
         return;
       }
       retryScheduled = true;
+      clearTimeout(handshakeDeadline);
       this.connected = false;
       this.session?.dispose();
       this.session = undefined;
@@ -488,10 +490,22 @@ export class ConnectTunnel {
       this.publish();
     };
 
+    // `ws`'s handshakeTimeout is a socket idle timeout: a peer that drips
+    // header bytes resets it and can hold this dial in CONNECTING forever.
+    // Enforce an absolute per-dial deadline as well.
+    handshakeDeadline = setTimeout(() => {
+      if (retryScheduled || this.stopped || this.tunnel !== tunnel) return;
+      this.lastError = `can't reach ${connectApexHost(credential.serverUrl)} — handshake timed out`;
+      scheduleReconnect(this.lastError);
+      tunnel.terminate();
+    }, TUNNEL_HANDSHAKE_TIMEOUT_MS);
+    handshakeDeadline.unref?.();
+
     tunnel.on("open", () => {
       if (retryScheduled || this.stopped || this.tunnel !== tunnel) {
         return;
       }
+      clearTimeout(handshakeDeadline);
       connectedAt = Date.now();
       this.connected = true;
       this.lastError = null;


### PR DESCRIPTION
## Summary

- bound Connect tunnel opening handshakes to 15 seconds
- schedule capped-backoff reconnects directly after non-auth HTTP upgrade rejections
- drain and terminate rejected responses while preserving their HTTP status for diagnostics
- make reconnect scheduling idempotent when `unexpected-response`, `error`, and `close` arrive for the same attempt
- clear an elapsed `nextRetryAt` when the next dial begins

## Why

`ConnectTunnel` handled `unexpected-response` by recording the HTTP status, but only scheduled another attempt from the WebSocket `close` handler. Once an `unexpected-response` listener handles the response, `ws` leaves cleanup to the caller and a later `close` event is not guaranteed. That can leave a paired server indefinitely stuck in `reconnecting` after a transient HTTP 500.

The handshake deadline also prevents a replacement dial from remaining pending forever when the gate accepts the connection but never completes the upgrade.

Fixes #1782.

## Verification

- `npx --yes pnpm@9.15.0 exec turbo run test --filter=bb-plugin-connect --force` — 81 tests passed
- `npx --yes pnpm@9.15.0 exec turbo run typecheck --filter=bb-plugin-connect` — passed

> AGENT GENERATED: by GPT-5.6 Sol