### PR TITLE
Ship and verify the packaged host plugin worker

### DIFF
--- a/apps/host-daemon/scripts/bundle-manifest.mjs
+++ b/apps/host-daemon/scripts/bundle-manifest.mjs
@@ -57,6 +57,15 @@ export const bundleTargets = [
     outfile: resolve(packageRoot, "dist", "bb-provider-bridge-worker.mjs"),
   },
   {
+    // Forked child that runs a plugin's `bb.host` entry (plugin-host-manager.ts).
+    // Emitted next to the daemon bundle so defaultWorkerEntryPath resolves it as
+    // a sibling in the packaged app.
+    banner: NODE_ESM_REQUIRE_BANNER,
+    entryPoint: resolve(packageRoot, "src", "plugin-host-worker.ts"),
+    label: "plugin host worker",
+    outfile: resolve(packageRoot, "dist", "bb-plugin-host-worker.mjs"),
+  },
+  {
     banner: NODE_ESM_REQUIRE_BANNER,
     entryPoint: resolve(workspaceRoot, "apps", "cli", "src", "index.ts"),
     executable: true,

--- a/apps/host-daemon/src/plugin-host-manager.ts
+++ b/apps/host-daemon/src/plugin-host-manager.ts
@@ -154,12 +154,24 @@ function workerLogContext(worker: WorkerState): Record<string, unknown> {
   };
 }
 
+// Resolve the worker entry relative to this module's runtime location. In the
+// packaged app this file is bundled into daemon-bundle.mjs, so the emitted
+// worker bundle (bb-plugin-host-worker.mjs, see scripts/bundle-manifest.mjs)
+// sits beside it in dist/. Built-but-unbundled output has the `.js` sibling,
+// and dev runs from the `.ts` source (forked children inherit `--import tsx`).
 function defaultWorkerEntryPath(): string {
-  const compiled = fileURLToPath(
-    new URL("./plugin-host-worker.js", import.meta.url),
+  const candidates = [
+    "./bb-plugin-host-worker.mjs",
+    "./plugin-host-worker.js",
+    "./plugin-host-worker.ts",
+  ];
+  for (const candidate of candidates) {
+    const candidatePath = fileURLToPath(new URL(candidate, import.meta.url));
+    if (existsSync(candidatePath)) return candidatePath;
+  }
+  throw new Error(
+    `host plugin worker entry not found beside ${fileURLToPath(import.meta.url)} (looked for ${candidates.join(", ")})`,
   );
-  if (existsSync(compiled)) return compiled;
-  return fileURLToPath(new URL("./plugin-host-worker.ts", import.meta.url));
 }
 
 function errorMessage(error: unknown): string {
@@ -963,7 +975,6 @@ export class PluginHostManager {
       logger: this.options.logger,
     });
   }
-
 
   private async stopWorker(worker: WorkerState, reason: string): Promise<void> {
     if (worker.disposing) return worker.closed;

--- a/packages/bb-app/package.json
+++ b/packages/bb-app/package.json
@@ -49,6 +49,7 @@
     "host-daemon/dist/bb",
     "host-daemon/dist/bb-parcel-watcher-child.mjs",
     "host-daemon/dist/bb-pi-bridge.mjs",
+    "host-daemon/dist/bb-plugin-host-worker.mjs",
     "host-daemon/dist/bb-provider-bridge-worker.mjs",
     "host-daemon/dist/daemon-bundle.mjs",
     "server/dist",

--- a/packages/bb-app/scripts/smoke-tarball.mjs
+++ b/packages/bb-app/scripts/smoke-tarball.mjs
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { fork, spawn } from "node:child_process";
 import { mkdirSync } from "node:fs";
 import {
   mkdir,
@@ -358,12 +358,7 @@ function spawnPackedBridge({ bridgePath, packageDir, pluginId }) {
   return spawn(
     process.execPath,
     [
-      join(
-        packageDir,
-        "host-daemon",
-        "dist",
-        "bb-provider-bridge-worker.mjs",
-      ),
+      join(packageDir, "host-daemon", "dist", "bb-provider-bridge-worker.mjs"),
       bridgePath,
       pluginId,
       dataDir,
@@ -505,6 +500,87 @@ async function smokeProviderBridgeBundles(packageDir) {
   });
 }
 
+// The daemon forks bb-plugin-host-worker.mjs (a sibling of daemon-bundle.mjs)
+// for every plugin `bb.host` entry. The published package must ship it, and
+// it must load a packed builtin host artifact and report ready over IPC;
+// otherwise every host plugin call fails with "host plugin worker exited (1)".
+async function smokePluginHostWorkerBundle(packageDir) {
+  const workerPath = join(
+    packageDir,
+    "host-daemon",
+    "dist",
+    "bb-plugin-host-worker.mjs",
+  );
+  const artifactPath = join(
+    packageDir,
+    "server",
+    "dist",
+    "builtin-plugins",
+    "keep-awake",
+    "dist",
+    "host.js",
+  );
+  const dataDir = join(tempRoot, "plugin-host-worker", "data");
+  const workerTempDir = join(tempRoot, "plugin-host-worker", "tmp");
+  mkdirSync(dataDir, { recursive: true });
+  mkdirSync(workerTempDir, { recursive: true });
+  const generation = "smoke-generation";
+  const childProcess = fork(
+    workerPath,
+    [artifactPath, "keep-awake", generation, dataDir, workerTempDir],
+    { cwd: tempRoot, stdio: ["ignore", "ignore", "pipe", "ipc"] },
+  );
+  const output = collectProcessOutput(childProcess);
+  const exited = waitForProcessExit(childProcess);
+  const ready = new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error("plugin host worker did not report ready in time"));
+    }, BRIDGE_WAIT_TIMEOUT_MS);
+    childProcess.on("message", (message) => {
+      if (!isRecord(message)) return;
+      if (message.type === "ready") {
+        clearTimeout(timer);
+        resolve(message);
+      } else if (message.type === "startup-error") {
+        clearTimeout(timer);
+        reject(new Error(`plugin host worker startup error: ${message.error}`));
+      }
+    });
+    void exited.then((result) => {
+      clearTimeout(timer);
+      reject(
+        new Error(
+          `plugin host worker exited before ready (${result.code ?? result.signal})`,
+        ),
+      );
+    });
+  });
+  try {
+    const message = await ready;
+    if (
+      message.pluginId !== "keep-awake" ||
+      message.generation !== generation
+    ) {
+      throw new Error(
+        `plugin host worker reported an unexpected identity: ${JSON.stringify(message)}`,
+      );
+    }
+    childProcess.disconnect();
+    const result = await exited;
+    if (result.code !== 0) {
+      throw new Error(
+        `plugin host worker exited with ${result.code ?? result.signal} after disconnect`,
+      );
+    }
+    process.stdout.write("bb-app tarball smoke: plugin host worker ready\n");
+  } catch (error) {
+    if (childProcess.exitCode === null) childProcess.kill("SIGKILL");
+    throw new Error(
+      `${error instanceof Error ? error.message : String(error)}\n${formatProcessOutput(output)}`,
+    );
+  }
+}
+
 function collectJsonRpcMessages({ childProcess, onMessage }) {
   const messages = [];
   let buffer = "";
@@ -632,12 +708,7 @@ async function smokePiUserConfiguration(packageDir) {
   const childProcess = spawn(
     process.execPath,
     [
-      join(
-        packageDir,
-        "host-daemon",
-        "dist",
-        "bb-provider-bridge-worker.mjs",
-      ),
+      join(packageDir, "host-daemon", "dist", "bb-provider-bridge-worker.mjs"),
       bridgePath,
       "provider-pi",
       maintenanceDir,
@@ -1134,6 +1205,7 @@ try {
   const sdkDir = await smokeSdkPackage(tarballPath);
   const installedPackageDir = join(sdkDir, "node_modules", "bb-app");
   await smokeProviderBridgeBundles(installedPackageDir);
+  await smokePluginHostWorkerBundle(installedPackageDir);
   await smokePiUserConfiguration(installedPackageDir);
   await smokeFullStack(tarballPath, sdkDir);
   await smokeDaemonJoin(tarballPath);

--- a/packages/bb-app/scripts/smoke-tarball.mjs
+++ b/packages/bb-app/scripts/smoke-tarball.mjs
@@ -17,6 +17,7 @@ const HTTP_WAIT_TIMEOUT_MS = 60_000;
 const HTTP_WAIT_INTERVAL_MS = 250;
 const PLUGIN_LOAD_TIMEOUT_MS = 60_000;
 const PLUGIN_LOAD_INTERVAL_MS = 1_000;
+const HOST_PLUGIN_WORKER_TIMEOUT_MS = 60_000;
 // Auto-installed, default-enabled builtins (apps/server/src/services/plugins/
 // builtin-registry.ts). Each must reach "running" in the packed tarball —
 // bundles that pass health checks can still fail to load (0.0.31 shipped with
@@ -31,6 +32,7 @@ const EXPECTED_RUNNING_BUILTIN_PLUGINS = [
   "connect",
   "custom-instructions",
   "inline-vis",
+  "keep-awake",
   "secrets",
 ];
 // The smoke drives every bridge as a canonical Provider Bridge Protocol
@@ -208,6 +210,30 @@ async function waitForHttp({ label, processRef, url }) {
   }
   throw new Error(
     `Timed out waiting for ${label} at ${url}\n${formatProcessOutput(processRef.output)}`,
+  );
+}
+
+async function waitForHostPluginWorker({ pluginId, processRef }) {
+  const deadline = Date.now() + HOST_PLUGIN_WORKER_TIMEOUT_MS;
+  while (Date.now() <= deadline) {
+    if (
+      processRef.output.stdout.includes("Host plugin worker ready") &&
+      processRef.output.stdout.includes(pluginId)
+    ) {
+      return;
+    }
+    if (
+      processRef.childProcess.exitCode !== null ||
+      processRef.childProcess.signalCode !== null
+    ) {
+      throw new Error(
+        `${processRef.label} exited before host plugin ${pluginId} started\n${formatProcessOutput(processRef.output)}`,
+      );
+    }
+    await delay(HTTP_WAIT_INTERVAL_MS);
+  }
+  throw new Error(
+    `Timed out waiting for host plugin ${pluginId} on ${processRef.label}\n${formatProcessOutput(processRef.output)}`,
   );
 }
 
@@ -558,6 +584,7 @@ async function smokePluginHostWorkerBundle(packageDir) {
   try {
     const message = await ready;
     if (
+      !isRecord(message) ||
       message.pluginId !== "keep-awake" ||
       message.generation !== generation
     ) {
@@ -1080,7 +1107,7 @@ async function smokeFullStack(tarballPath, sdkDir) {
     ]),
     command: "npx",
     env: {
-      BB_LOG_LEVEL: "warn",
+      BB_LOG_LEVEL: "info",
     },
     label: "bb-app full stack",
   });
@@ -1108,6 +1135,13 @@ async function smokeFullStack(tarballPath, sdkDir) {
       label: "bb cli status",
     });
     await smokeBuiltinPluginsRunning({ cliEnv, tarballPath });
+    // Keep Awake reconciles even its default disabled state, so reaching this
+    // log proves the packed daemon found its companion worker, downloaded the
+    // plugin artifact, and started the worker for a host RPC call.
+    await waitForHostPluginWorker({
+      pluginId: "keep-awake",
+      processRef: stack,
+    });
     await runCommand({
       args: [
         "--input-type=module",
@@ -1132,10 +1166,22 @@ async function smokeFullStack(tarballPath, sdkDir) {
 
 async function smokeDaemonJoin(tarballPath) {
   const serverDataDir = join(tempRoot, "join-server-data");
-  const daemonDataDir = join(tempRoot, "join-daemon-data");
-  const [serverPort, daemonPort, staleEnvPort] = await getFreePorts(3);
+  const [serverPort, firstDaemonPort, secondDaemonPort, staleEnvPort] =
+    await getFreePorts(4);
   const serverUrl = `http://127.0.0.1:${serverPort}`;
   const staleEnvServerUrl = `http://127.0.0.1:${staleEnvPort}`;
+  const daemonSpecs = [
+    {
+      dataDir: join(tempRoot, "join-daemon-data-1"),
+      label: "bb-app host-daemon join 1",
+      port: firstDaemonPort,
+    },
+    {
+      dataDir: join(tempRoot, "join-daemon-data-2"),
+      label: "bb-app host-daemon join 2",
+      port: secondDaemonPort,
+    },
+  ];
   const server = spawnManagedProcess({
     args: createNpxArgs(tarballPath, "bb-server", [
       "--data-dir",
@@ -1143,7 +1189,7 @@ async function smokeDaemonJoin(tarballPath) {
       "--server-port",
       String(serverPort),
       "--host-daemon-port",
-      String(daemonPort),
+      String(firstDaemonPort),
     ]),
     command: "npx",
     env: {
@@ -1152,48 +1198,66 @@ async function smokeDaemonJoin(tarballPath) {
     label: "bb-server",
   });
 
-  let daemon;
+  const daemons = [];
   try {
     await waitForHttp({
       label: server.label,
       processRef: server,
       url: `${serverUrl}/health`,
     });
-    daemon = spawnManagedProcess({
-      args: createNpxArgs(tarballPath, "bb-app", [
-        "host-daemon",
-        "join",
-        "--data-dir",
-        daemonDataDir,
-        "--server-url",
-        serverUrl,
-        "--host-daemon-port",
-        String(daemonPort),
-      ]),
-      command: "npx",
-      env: {
-        BB_LOG_LEVEL: "warn",
-        BB_SERVER_URL: staleEnvServerUrl,
-      },
-      label: "bb-app host-daemon join",
-    });
-    await waitForHttp({
-      label: daemon.label,
-      processRef: daemon,
-      url: `http://${DEFAULT_HOST_DAEMON_LOCAL_BIND_HOST}:${daemonPort}/health`,
-    });
-    const configJson = JSON.parse(
-      await readFile(join(daemonDataDir, "config.json"), "utf8"),
-    );
-    if (configJson.serverUrl !== serverUrl) {
-      throw new Error(
-        `Expected persisted server URL ${serverUrl}, received ${configJson.serverUrl}`,
+    for (const spec of daemonSpecs) {
+      const daemon = spawnManagedProcess({
+        args: createNpxArgs(tarballPath, "bb-app", [
+          "host-daemon",
+          "join",
+          "--data-dir",
+          spec.dataDir,
+          "--server-url",
+          serverUrl,
+          "--host-daemon-port",
+          String(spec.port),
+        ]),
+        command: "npx",
+        env: {
+          BB_LOG_LEVEL: "info",
+          BB_SERVER_URL: staleEnvServerUrl,
+        },
+        label: spec.label,
+      });
+      daemons.push(daemon);
+      await waitForHttp({
+        label: daemon.label,
+        processRef: daemon,
+        url: `http://${DEFAULT_HOST_DAEMON_LOCAL_BIND_HOST}:${spec.port}/health`,
+      });
+      const configJson = JSON.parse(
+        await readFile(join(spec.dataDir, "config.json"), "utf8"),
       );
+      if (configJson.serverUrl !== serverUrl) {
+        throw new Error(
+          `Expected persisted server URL ${serverUrl}, received ${configJson.serverUrl}`,
+        );
+      }
     }
+    const cliEnv = {
+      BB_DATA_DIR: serverDataDir,
+      BB_HOST_DAEMON_PORT: String(firstDaemonPort),
+      BB_SERVER_URL: serverUrl,
+    };
+    await smokeBuiltinPluginsRunning({ cliEnv, tarballPath });
+    // Both daemons joined a server in a different process and data directory.
+    // Ready workers on both prove host-plugin artifacts and calls fan out to
+    // enrolled machines instead of assuming server-local paths.
+    await Promise.all(
+      daemons.map((daemon) =>
+        waitForHostPluginWorker({
+          pluginId: "keep-awake",
+          processRef: daemon,
+        }),
+      ),
+    );
   } finally {
-    if (daemon) {
-      await stopManagedProcess(daemon);
-    }
+    await Promise.all(daemons.map((daemon) => stopManagedProcess(daemon)));
     await stopManagedProcess(server);
   }
 }

--- a/packages/bb-app/src/launcher.ts
+++ b/packages/bb-app/src/launcher.ts
@@ -2040,6 +2040,10 @@ function requiredArtifactPaths(context: BbAppStartContext): ArtifactPath[] {
       label: "parcel watcher child",
       path: join(context.daemonBundleDir, "bb-parcel-watcher-child.mjs"),
     },
+    {
+      label: "plugin host worker",
+      path: join(context.daemonBundleDir, "bb-plugin-host-worker.mjs"),
+    },
     { label: "web app", path: join(context.appDistDir, "index.html") },
   ];
 }

--- a/packages/bb-app/test/index.test.ts
+++ b/packages/bb-app/test/index.test.ts
@@ -183,6 +183,7 @@ const packageMetadataSchema = z.object({
   engines: z.object({
     node: z.string(),
   }),
+  files: z.array(z.string()),
   os: z.array(z.string()),
 });
 
@@ -2042,6 +2043,9 @@ describe("bb-app launcher", () => {
     const metadata = readPackageMetadata();
 
     expect(metadata.engines.node).toBe("^22.19.0 || ^24.0.0 || ^26.0.0");
+    expect(metadata.files).toContain(
+      "host-daemon/dist/bb-plugin-host-worker.mjs",
+    );
     expect(metadata.os).toEqual(["darwin", "linux"]);
   });
 });


### PR DESCRIPTION
## Problem

Packaged `bb-app` daemons fail every host plugin call with `host plugin worker exited (1)`. Their stderr reports that neither the compiled worker nor its TypeScript development fallback exists in the installed package.

`defaultWorkerEntryPath()` looked for `plugin-host-worker.js` beside `daemon-bundle.mjs` and fell back to the `.ts` source. The published package contained neither: the bundle manifest had no worker target, and the `bb-app` package whitelist only shipped the `.mjs` bundles.

The Keep Awake-specific retry mitigation was split out and merged in #1792. This PR now contains only the general packaging fix and its release-level coverage.

## Changes

- Add a self-contained `bb-plugin-host-worker.mjs` bundle.
- Resolve the packaged `.mjs` worker first while retaining compiled-development and source-development fallbacks.
- Ship the worker in `bb-app` and require it during launcher artifact validation.
- Assert that the npm package whitelist includes the worker.
- Exercise the packed worker directly with the packed Keep Awake host artifact.
- Verify worker startup in the full packaged stack and on two independently enrolled packaged daemons.

No daemon wire contract changed, so no `HOST_DAEMON_PROTOCOL_VERSION` bump is needed.

## Verification

- `turbo run typecheck --filter=@bb/host-daemon --filter=bb-app`
- `turbo run test --filter=@bb/host-daemon --filter=bb-app --force` (583 host-daemon tests and 65 bb-app tests)
- `turbo run smoke:tarball --filter=bb-app --force` (direct packed worker, full stack, and two-daemon enrollment)
- Prettier, JavaScript syntax check, and `git diff --check`

> AGENT GENERATED: by GPT-5
