### PR TITLE
Back off Keep Awake reconciles after host worker exits

### DIFF
--- a/plugins/keep-awake/server.test.ts
+++ b/plugins/keep-awake/server.test.ts
@@ -210,40 +210,104 @@ describe("builtin Keep Awake server entry", () => {
     await host.harness.dispose();
   });
 
-  it("reconciles immediately after its host worker exits unexpectedly", async () => {
-    const subscriptions = lifecycleSubscriptions();
-    const host = createFakePluginHost({
-      pluginId: "keep-awake",
-      sdk: {
-        subscribe: subscriptions.subscribe,
-        hosts: { list: async () => [hostRecord("host-1")] },
-      },
-      experimental_callHostRpc: () => ({ enabled: true, supported: true }),
-    });
-    await host.bb.storage.kv.set("configuration", {
-      enabled: true,
-      selection: { mode: "all" },
-    });
-    await plugin(host.bb);
-    const running = host.harness.runService("desired-state-reconciler");
-    await vi.waitFor(() => {
+  it("retries after a backoff delay when its host worker exits unexpectedly", async () => {
+    vi.useFakeTimers();
+    try {
+      const subscriptions = lifecycleSubscriptions();
+      const host = createFakePluginHost({
+        pluginId: "keep-awake",
+        sdk: {
+          subscribe: subscriptions.subscribe,
+          hosts: { list: async () => [hostRecord("host-1")] },
+        },
+        experimental_callHostRpc: () => ({ enabled: true, supported: true }),
+      });
+      await host.bb.storage.kv.set("configuration", {
+        enabled: true,
+        selection: { mode: "all" },
+      });
+      await plugin(host.bb);
+      const running = host.harness.runService("desired-state-reconciler");
+      await vi.advanceTimersByTimeAsync(0);
       expect(host.harness.experimental_hostRpcCalls).toHaveLength(1);
-    });
 
-    await host.harness.experimental_emitHostWorkerExit("host-1");
+      await host.harness.experimental_emitHostWorkerExit("host-1");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(host.harness.experimental_hostRpcCalls).toHaveLength(1);
+      expect(host.harness.logEntries).toContainEqual({
+        level: "warn",
+        message:
+          "Keep Awake host worker exited unexpectedly on host host-1; retrying",
+      });
 
-    await vi.waitFor(() => {
+      await vi.advanceTimersByTimeAsync(1_000);
       expect(host.harness.experimental_hostRpcCalls).toHaveLength(2);
-    });
-    expect(host.harness.logEntries).toContainEqual({
-      level: "warn",
-      message:
-        "Keep Awake host worker exited unexpectedly on host host-1; retrying",
-    });
 
-    running.controller.abort();
-    await running.done;
-    await host.harness.dispose();
+      running.controller.abort();
+      await running.done;
+      await host.harness.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("backs off exponentially while its host worker crash-loops", async () => {
+    vi.useFakeTimers();
+    try {
+      const subscriptions = lifecycleSubscriptions();
+      let harness: ReturnType<typeof createFakePluginHost>["harness"] | null =
+        null;
+      const host = createFakePluginHost({
+        pluginId: "keep-awake",
+        sdk: {
+          subscribe: subscriptions.subscribe,
+          hosts: { list: async () => [hostRecord("host-1")] },
+        },
+        experimental_callHostRpc: async () => {
+          // The daemon reports the worker exit before the call rejects.
+          await harness?.experimental_emitHostWorkerExit("host-1");
+          throw new Error("host plugin worker exited (1)");
+        },
+      });
+      harness = host.harness;
+      await host.bb.storage.kv.set("configuration", {
+        enabled: true,
+        selection: { mode: "all" },
+      });
+      await plugin(host.bb);
+      const running = host.harness.runService("desired-state-reconciler");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(host.harness.experimental_hostRpcCalls).toHaveLength(1);
+
+      // Retry delays double: 1s, 2s, 4s, ... capped at 30s.
+      await vi.advanceTimersByTimeAsync(999);
+      expect(host.harness.experimental_hostRpcCalls).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(host.harness.experimental_hostRpcCalls).toHaveLength(2);
+      await vi.advanceTimersByTimeAsync(1_999);
+      expect(host.harness.experimental_hostRpcCalls).toHaveLength(2);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(host.harness.experimental_hostRpcCalls).toHaveLength(3);
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(host.harness.experimental_hostRpcCalls).toHaveLength(4);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(host.harness.experimental_hostRpcCalls.length).toBeLessThanOrEqual(
+        7,
+      );
+
+      // A configuration change still reconciles immediately.
+      const before = host.harness.experimental_hostRpcCalls.length;
+      const result = await host.harness.runCli(["disable"]);
+      expect(result.exitCode).toBe(0);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(host.harness.experimental_hostRpcCalls).toHaveLength(before + 1);
+
+      running.controller.abort();
+      await running.done;
+      await host.harness.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("loads its host selection from plugin KV and exposes CLI parity", async () => {

--- a/plugins/keep-awake/server.ts
+++ b/plugins/keep-awake/server.ts
@@ -75,7 +75,11 @@ export default async function keepAwakePlugin(bb: BbPluginApi): Promise<void> {
     contract: keepAwakeHostContract,
   });
 
+  // `reconcileRequested` asks for an immediate pass (configuration or host
+  // changes). `retryRequested` asks for a pass after the current backoff delay
+  // (host worker exits), so a crash-looping worker cannot spin the reconciler.
   let reconcileRequested = true;
+  let retryRequested = false;
   let wakeWaiter: (() => void) | null = null;
   const storedConfiguration = keepAwakeConfigurationSchema.safeParse(
     await bb.storage.kv.get<unknown>(CONFIGURATION_KEY),
@@ -86,6 +90,11 @@ export default async function keepAwakePlugin(bb: BbPluginApi): Promise<void> {
 
   function requestReconcile(): void {
     reconcileRequested = true;
+    wakeWaiter?.();
+  }
+
+  function requestRetry(): void {
+    retryRequested = true;
     wakeWaiter?.();
   }
 
@@ -214,7 +223,7 @@ export default async function keepAwakePlugin(bb: BbPluginApi): Promise<void> {
     bb.log.warn(
       `Keep Awake host worker exited unexpectedly on host ${hostId}; retrying`,
     );
-    requestReconcile();
+    requestRetry();
   });
 
   async function reconcile(signal: AbortSignal): Promise<ReconcileOutcome> {
@@ -274,7 +283,7 @@ export default async function keepAwakePlugin(bb: BbPluginApi): Promise<void> {
 
   function waitForReconcile(
     signal: AbortSignal,
-    retryMs: number | null,
+    options: { readonly retryDelayMs: number; readonly retryPending: boolean },
   ): Promise<void> {
     if (signal.aborted || reconcileRequested) return Promise.resolve();
     return new Promise((resolve) => {
@@ -284,14 +293,25 @@ export default async function keepAwakePlugin(bb: BbPluginApi): Promise<void> {
         if (settled) return;
         settled = true;
         if (timer !== null) clearTimeout(timer);
-        if (wakeWaiter === finish) wakeWaiter = null;
+        if (wakeWaiter === wake) wakeWaiter = null;
         signal.removeEventListener("abort", finish);
         resolve();
       };
-      wakeWaiter = finish;
+      const armRetry = (): void => {
+        if (timer !== null) return;
+        timer = setTimeout(finish, options.retryDelayMs);
+      };
+      const wake = (): void => {
+        if (signal.aborted || reconcileRequested) {
+          finish();
+          return;
+        }
+        if (retryRequested) armRetry();
+      };
+      wakeWaiter = wake;
       signal.addEventListener("abort", finish, { once: true });
-      if (retryMs !== null) timer = setTimeout(finish, retryMs);
-      if (signal.aborted || reconcileRequested) finish();
+      if (options.retryPending) armRetry();
+      wake();
     });
   }
 
@@ -315,15 +335,18 @@ export default async function keepAwakePlugin(bb: BbPluginApi): Promise<void> {
       try {
         while (!signal.aborted) {
           reconcileRequested = false;
+          retryRequested = false;
           const outcome = await reconcile(signal);
           if (signal.aborted) break;
           if (reconcileRequested) continue;
-          if (outcome === "retry") {
-            await waitForReconcile(signal, retryMs);
+          const retryPending = outcome === "retry" || retryRequested;
+          if (!retryPending) retryMs = RETRY_MIN_MS;
+          await waitForReconcile(signal, {
+            retryDelayMs: retryMs,
+            retryPending,
+          });
+          if (retryPending || retryRequested) {
             retryMs = Math.min(retryMs * 2, RETRY_MAX_MS);
-          } else {
-            retryMs = RETRY_MIN_MS;
-            await waitForReconcile(signal, null);
           }
         }
       } finally {


### PR DESCRIPTION
## Problem

Keep Awake's `experimental_onWorkerExit` handler called `requestReconcile()`, which forces an immediate pass and skips the retry backoff. When a host worker crashes on start (see #1790 for the packaging cause), the server loops every ~80ms:

```
Keep Awake host worker exited unexpectedly on host host_...; retrying
Could not reconcile Keep Awake on host host_...: host plugin worker exited (1)
```

One log file collected 60k+ of these lines.

## Change

- `plugins/keep-awake/server.ts`: worker exits now request a *retry*, which waits for the exponential backoff (1s → 2s → … → 30s cap). Configuration changes and host connects still reconcile immediately.
- `plugins/keep-awake/server.test.ts`: fake-timer tests for the delayed retry and the crash-loop backoff. The crash-loop test spins forever on the old code.

This is the plugin-side half of #1790, split out so it can land now. The packaging fix (ship `bb-plugin-host-worker.mjs`) stays in #1790.

## Verification

`turbo run test typecheck --filter=bb-plugin-keep-awake` passes.

> AGENT GENERATED: by Claude Opus 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)