### PR TITLE
Strip _VOLTA_TOOL_RECURSION from bb-spawned child process env

### DIFF
--- a/packages/process-utils/src/index.ts
+++ b/packages/process-utils/src/index.ts
@@ -178,10 +178,20 @@ export function resolveContainedPath(
 }
 
 /**
+ * Volta's re-entrancy guard. A Volta package shim sets it on the process it
+ * launches (bb-app), and Volta's own `node`/`npm`/`npx` shims treat its
+ * presence as "do not re-evaluate the platform" and pass through to a system
+ * Node instead. bb children are new contexts, exactly like `volta run`, which
+ * removes the same variable before it spawns a command.
+ */
+const VOLTA_RECURSION_GUARD_ENV = "_VOLTA_TOOL_RECURSION";
+
+/**
  * The one answer to "what does a bb-spawned child process inherit": the
- * parent's env minus bb runtime-owned variables (`BB_*`) and `NODE_ENV`,
- * optionally with the user's login-shell PATH substituted. Callers overlay
- * only the child-specific bb env they intentionally expose afterward.
+ * parent's env minus bb runtime-owned variables (`BB_*`), `NODE_ENV`, and
+ * Volta's `_VOLTA_TOOL_RECURSION` guard, optionally with the user's
+ * login-shell PATH substituted. Callers overlay only the child-specific bb
+ * env they intentionally expose afterward.
  */
 export function sanitizeInheritedChildProcessEnv(
   args: SanitizeInheritedChildProcessEnvArgs,
@@ -191,7 +201,11 @@ export function sanitizeInheritedChildProcessEnv(
     if (value === undefined) {
       continue;
     }
-    if (key === "NODE_ENV" || key.startsWith("BB_")) {
+    if (
+      key === "NODE_ENV" ||
+      key === VOLTA_RECURSION_GUARD_ENV ||
+      key.startsWith("BB_")
+    ) {
       continue;
     }
     sanitizedEnv[key] = value;

--- a/packages/process-utils/test/index.test.ts
+++ b/packages/process-utils/test/index.test.ts
@@ -300,6 +300,30 @@ describe("process utils", () => {
     expect("SKIP_ME" in sanitizedEnv).toBe(false);
   });
 
+  it("drops Volta's _VOLTA_TOOL_RECURSION guard so child shims re-resolve the platform (#1545)", () => {
+    // Exactly what a Volta package shim injects into bb-app's process env.
+    const env: NodeJS.ProcessEnv = {
+      HOME: "/Users/example",
+      PATH: "/Users/example/.volta/tools/image/node/25.0.0/bin:/Users/example/.volta/bin:/usr/bin:/bin",
+      VOLTA_HOME: "/Users/example/.volta",
+      _VOLTA_TOOL_RECURSION: "1",
+    };
+
+    const sanitizedEnv = sanitizeInheritedChildProcessEnv({
+      env,
+      // The daemon substitutes the login-shell PATH, which puts Volta's shim
+      // directory (not the image bin dir) in front.
+      shellPath: "/Users/example/.volta/bin:/usr/bin:/bin",
+    });
+
+    // VOLTA_HOME must survive: the shims need it to find the Volta layout.
+    expect(sanitizedEnv.VOLTA_HOME).toBe("/Users/example/.volta");
+    expect(sanitizedEnv.PATH).toBe("/Users/example/.volta/bin:/usr/bin:/bin");
+    // With the guard present, Volta's `node`/`npm`/`npx` shims skip platform
+    // resolution and fail with "Volta error: Node is not available."
+    expect("_VOLTA_TOOL_RECURSION" in sanitizedEnv).toBe(false);
+  });
+
   it("does not mutate the inherited env", () => {
     const env: NodeJS.ProcessEnv = {
       BB_DATA_DIR: "/tmp/bb-data",


### PR DESCRIPTION
## What was wrong

Volta sets `_VOLTA_TOOL_RECURSION=1` on every program that a Volta package shim launches. When a user installs bb with `volta install bb-app`, the bb server and host daemon inherit this guard. The host daemon spawns each provider bridge, terminal, git command, and script child through `sanitizeInheritedChildProcessEnv`, which only removed `BB_*` and `NODE_ENV`. Volta's `node`, `npm`, and `npx` shims treat the guard as "skip platform resolution" and pass through to a system Node. On a machine whose only Node is Volta's, bare `node`, `npm`, `npx`, `bb`, and `$BB_CLI` fail in the agent shell with the misleading `Volta error: Node is not available.`

Report: https://get-bb.github.io/reports/issues/1545.html

## What changed

- `packages/process-utils/src/index.ts`: `sanitizeInheritedChildProcessEnv` now also drops `_VOLTA_TOOL_RECURSION`. This is the single choke point for every bb-spawned child, and it mirrors `volta run`, which removes the same variable because a new command is a new context. No wire change and no protocol bump.
- `packages/process-utils/test/index.test.ts`: regression test that asserts the guard does not leak while `VOLTA_HOME` and the substituted PATH survive.

This matches the fix that the report proposed. I did not add the optional hardening in bb-app `createDaemonEnv`/`createServerEnv`.

## How I verified

- Added the test first: `pnpm exec turbo run test --filter=@bb/process-utils --force` → 13 tests, 1 failed (the new test).
- Applied the fix: `pnpm exec turbo run typecheck test --filter=@bb/process-utils --force` → typecheck clean, 13 passed.

Fixes #1545

> AGENT GENERATED: by Claude Opus 5
