### PR TITLE
Do not resolve home-relative chat links against the project root

### DIFF
--- a/apps/app/src/components/ui/markdown-local-file-link.test.ts
+++ b/apps/app/src/components/ui/markdown-local-file-link.test.ts
@@ -298,6 +298,38 @@ describe("resolveRelativeLocalFileHref", () => {
     ).toBeNull();
   });
 
+  it.each([
+    ["~"],
+    ["~/.config/example.md"],
+    ["%7E/.config/example.md"],
+    ["~/.config/example.md:12"],
+    ["~/notes.md#L3-L5"],
+    ["~alice/notes.md"],
+  ])("does not resolve home-relative href %s against the root", (href) => {
+    expect(
+      resolveRelativeLocalFileHref({
+        baseDir: "/workspace",
+        href,
+        rootPath: "/workspace",
+      }),
+    ).toBeNull();
+  });
+
+  it.each([
+    ["~notes.md", "/workspace/~notes.md"],
+    ["~$report.docx", "/workspace/~$report.docx"],
+    ["~notes.md:3", "/workspace/~notes.md:3"],
+    ["docs/~draft.md", "/workspace/docs/~draft.md"],
+  ])("still resolves %s as a relative file", (href, expected) => {
+    expect(
+      resolveRelativeLocalFileHref({
+        baseDir: "/workspace",
+        href,
+        rootPath: "/workspace",
+      }),
+    ).toBe(expected);
+  });
+
   it("rejects encoded dot-segment escapes before local-file parsing", () => {
     expect(
       resolveRelativeLocalFileHref({

--- a/apps/app/src/components/ui/markdown-local-file-link.ts
+++ b/apps/app/src/components/ui/markdown-local-file-link.ts
@@ -273,6 +273,15 @@ function parseAbsoluteLocalFileHref(
 // `Cargo.lock:14:33` and `foo.md:5` remain relative file links.
 const URI_SCHEME_PATTERN = /^[a-zA-Z][a-zA-Z0-9+.-]*:/u;
 
+// Shell-style home paths (`~`, `~/…`, `~user/…`) are neither absolute nor
+// workspace-relative; the renderer has no home directory to expand them
+// against. Names that merely start with `~` (`~notes.md`) stay relative.
+const HOME_RELATIVE_PATH_PATTERN = /^~(?:[^/]*\/|$)/u;
+
+function isHomeRelativePath(path: string): boolean {
+  return HOME_RELATIVE_PATH_PATTERN.test(path);
+}
+
 /**
  * Resolves a relative markdown link against the previewed file's directory so
  * links authored relative to a file on disk become absolute paths the local
@@ -297,6 +306,7 @@ export function resolveRelativeLocalFileHref({
     parsedHref === null ||
     parsedHref.path.length === 0 ||
     parsedHref.path.startsWith("/") ||
+    isHomeRelativePath(parsedHref.path) ||
     parsedHref.path.startsWith("#") ||
     parsedHref.path.startsWith("?") ||
     URI_SCHEME_PATTERN.test(parsedHref.path)


### PR DESCRIPTION
## What was wrong

When an assistant message contains a shell-style home path such as `~/.config/example.md` (inline code that ends in `.md`, or an explicit `[text](~/…)` link), the app renders it as a local-file link. `resolveRelativeLocalFileHref` in `apps/app/src/components/ui/markdown-local-file-link.ts` rejects absolute paths, fragments, queries, and URI schemes, and then treats every other href as workspace-relative. The path became `<workspace>/~/.config/example.md`, which passed the containment checks. A click opened a workspace file tab that said `Failed to load file`, and `Open in editor` failed with `Open target path does not exist: <workspace>/~/.config/example.md`.

## What changed

- `apps/app/src/components/ui/markdown-local-file-link.ts`: add `isHomeRelativePath` with the pattern `/^~(?:[^/]*\/|$)/u` and include it in the early-return guard of `resolveRelativeLocalFileHref`, next to the `startsWith("/")` check. The check runs on the decoded href, so `%7E/…` is covered. It matches `~`, `~/…`, and `~user/…`. Names that only start with `~` (`~notes.md`, `~$report.docx`, `docs/~draft.md`) stay relative files.
- `apps/app/src/components/ui/markdown-local-file-link.test.ts`: add 6 home-relative cases that must resolve to `null` and 4 positive cases that must still resolve as relative files.

The fix follows the report's proposal with no deviation. Home-directory expansion (option 2 in the report) needs a host payload field and a protocol version bump. That is a separate change.

## How I verified

- `pnpm exec vitest run src/components/ui/markdown-local-file-link.test.ts` on the base commit with only the test change: 6 failed / 15 passed. With the fix: 21 passed.
- `pnpm exec turbo run typecheck --filter=@bb/app`: clean.
- `pnpm exec turbo run test --filter=@bb/app`: 360 files, 2852 tests passed.

Fixes #1182

Report: https://get-bb.github.io/reports/issues/1182.html

> AGENT GENERATED: by Claude Opus 5