### PR TITLE
Re-probe gh auth in the github plugin instead of latching needs-configuration

### DIFF
--- a/plugins/github/app.tsx
+++ b/plugins/github/app.tsx
@@ -2255,6 +2255,7 @@ function NewIssueForm({
 
 interface Status {
   ghOk: boolean;
+  ghState: "ready" | "needs_configuration" | "unavailable";
   ghError: string | null;
   repos: RepoInfo[];
   lastSyncedAt: string | null;
@@ -2300,7 +2301,9 @@ function PanelHeader() {
               ? `${status.repos.length} repo${status.repos.length === 1 ? "" : "s"} · synced ${
                   status.lastSyncedAt !== null ? relativeTime(status.lastSyncedAt) : "never"
                 }`
-              : "GitHub CLI not authenticated"}
+              : status.ghState === "unavailable"
+                ? "GitHub CLI unavailable — retrying"
+                : "GitHub CLI not authenticated"}
       </span>
       <Button
         size="sm"
@@ -2401,6 +2404,13 @@ function GithubPanelBody({
   query: string;
   setQuery: (query: string) => void;
 }) {
+  if (status !== null && status.ghState === "unavailable") {
+    return (
+      <EmptyState
+        message={`GitHub CLI could not reach GitHub. Check your network or keychain; the plugin retries by itself. (${status.ghError ?? ""})`}
+      />
+    );
+  }
   if (status !== null && !status.ghOk) {
     return (
       <EmptyState

--- a/plugins/github/server.auth-latch.test.ts
+++ b/plugins/github/server.auth-latch.test.ts
@@ -1,0 +1,139 @@
+// Repro for get-bb/bb#1758: the github plugin probes `gh auth status` once at
+// load, latches needs-configuration on any failure, and never re-probes.
+//
+// A fake `gh` on PATH fails (like a network blip / locked keychain / dead
+// proxy) while the plugin loads, then starts succeeding. The plugin should
+// notice that gh works again; on main it never does.
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
+import plugin from "./server";
+
+let binDir: string;
+let offlineFlag: string; // exists → `gh auth status` fails like a network outage
+let noTokenFlag: string; // exists → gh has no credentials at all
+let callLog: string;
+const originalPath = process.env.PATH;
+
+function ghCalls(): string[] {
+  if (!existsSync(callLog)) return [];
+  return readFileSync(callLog, "utf8")
+    .trim()
+    .split("\n")
+    .filter((line: string) => line.length > 0);
+}
+
+beforeEach(() => {
+  binDir = mkdtempSync(join(tmpdir(), "bb-1758-gh-"));
+  offlineFlag = join(binDir, "gh-offline");
+  noTokenFlag = join(binDir, "gh-no-token");
+  callLog = join(binDir, "gh-calls.log");
+  // Mimics real `gh` (2.96) closely enough:
+  //  --version     always works, so the plugin's resolveGh() finds it
+  //  auth token    local-only, no network: succeeds unless no credentials
+  //  auth status   network probe: fails with gh's verbatim "token is invalid"
+  //                wording while offline (that IS what gh prints when it
+  //                cannot reach api.github.com), or "You are not logged into
+  //                any GitHub hosts" when there are no credentials.
+  writeFileSync(
+    join(binDir, "gh"),
+    `#!/usr/bin/env bash
+echo "$*" >> "${callLog}"
+case "$1 $2" in
+  "--version ") echo "gh version 2.96.0 (fake)"; exit 0;;
+  "auth token")
+    if [ -e "${noTokenFlag}" ]; then echo "no oauth token found for github.com" >&2; exit 1; fi
+    echo "gho_fake_token_is_configured_locally"; exit 0;;
+  "auth status")
+    if [ -e "${noTokenFlag}" ]; then
+      echo "You are not logged into any GitHub hosts. To log in, run: gh auth login" >&2; exit 1
+    fi
+    if [ -e "${offlineFlag}" ]; then
+      echo "github.com" >&2
+      echo "  X Failed to log in to github.com account someone (keyring)" >&2
+      echo "  - The token in keyring is invalid." >&2
+      exit 1
+    fi
+    echo "github.com"; echo "  ✓ Logged in to github.com account someone (keyring)"; exit 0;;
+  *) echo "[]"; exit 0;;
+esac
+`,
+  );
+  chmodSync(join(binDir, "gh"), 0o755);
+  process.env.PATH = `${binDir}:${originalPath ?? ""}`;
+});
+
+afterEach(() => {
+  process.env.PATH = originalPath;
+  rmSync(binDir, { recursive: true, force: true });
+});
+
+async function loadWithSyncServiceOnce() {
+  const { bb, harness } = createFakePluginHost({ pluginId: "github" });
+  await plugin(bb);
+  // Run the sync service the way the host does at activation. On main its
+  // first syncAll() throws NeedsConfigurationError and it stops for good; a
+  // fixed plugin keeps looping, so abort it after its first pass.
+  const { controller, done } = harness.runService("sync");
+  await new Promise((resolve) => setTimeout(resolve, 150));
+  controller.abort();
+  await done;
+  return { bb, harness };
+}
+
+describe("github plugin gh auth probe (#1758)", () => {
+  it("re-probes gh after a transient auth-status failure instead of latching", async () => {
+    // 1. gh is "offline" while bb starts (credentials exist, API unreachable).
+    writeFileSync(offlineFlag, "");
+    const { harness } = await loadWithSyncServiceOnce();
+    const before = (await harness.callRpc("status")) as { ghOk: boolean };
+    expect(before.ghOk).toBe(false); // probe failed at load, as expected
+    const callsWhileOffline = ghCalls().length;
+
+    // 2. gh recovers (network back / keychain unlocked). Nothing else changes.
+    rmSync(offlineFlag);
+
+    // 3. The plugin is asked for its status (panel banner / `bb github`).
+    //    A plugin that re-probes on demand or on its interval reports ghOk.
+    //    On main NOTHING re-runs `gh auth status`: ghOk stays false with the
+    //    stale error, and not a single further gh call is made.
+    const after = (await harness.callRpc("status")) as {
+      ghOk: boolean;
+      ghError: string | null;
+    };
+    expect(ghCalls().length).toBeGreaterThan(callsWhileOffline); // FAILS on main: no re-probe
+    expect(after.ghOk).toBe(true); // FAILS on main: latched
+  });
+
+  it('does not report needs-configuration ("run gh auth login") for a transient probe failure', async () => {
+    writeFileSync(offlineFlag, "");
+    const { harness } = await loadWithSyncServiceOnce();
+    // FAILS on main: both the load-time probe and the sync service latch
+    // needs-configuration with the `gh auth login` remedy, although gh holds
+    // valid credentials and only the network probe failed.
+    expect(harness.needsConfigurationMessages).toEqual([]);
+  });
+
+  it("still reports needs-configuration when gh has no credentials at all", async () => {
+    writeFileSync(noTokenFlag, "");
+    const { harness } = await loadWithSyncServiceOnce();
+    expect(harness.needsConfigurationMessages.length).toBeGreaterThan(0);
+    expect(harness.needsConfigurationMessages[0]).toContain("gh auth login");
+  });
+
+  it("control: with gh working from the start the plugin never reports needs-configuration", async () => {
+    const { harness } = await loadWithSyncServiceOnce();
+    expect(harness.needsConfigurationMessages).toEqual([]);
+    const status = (await harness.callRpc("status")) as { ghOk: boolean };
+    expect(status.ghOk).toBe(true);
+  });
+});

--- a/plugins/github/server.auth-latch.test.ts
+++ b/plugins/github/server.auth-latch.test.ts
@@ -3,7 +3,7 @@
 //
 // A fake `gh` on PATH fails (like a network blip / locked keychain / dead
 // proxy) while the plugin loads, then starts succeeding. The plugin should
-// notice that gh works again; on main it never does.
+// notice that gh works again.
 import {
   chmodSync,
   existsSync,
@@ -21,6 +21,9 @@ import plugin from "./server";
 let binDir: string;
 let offlineFlag: string; // exists → `gh auth status` fails like a network outage
 let noTokenFlag: string; // exists → gh has no credentials at all
+let badSecondaryFlag: string; // exists → an unscoped `gh auth status` fails
+let apiDownFlag: string; // exists → issue/pr list calls fail
+let slowStatusFlag: string; // exists → `gh auth status` takes 300 ms
 let callLog: string;
 const originalPath = process.env.PATH;
 
@@ -36,6 +39,9 @@ beforeEach(() => {
   binDir = mkdtempSync(join(tmpdir(), "bb-1758-gh-"));
   offlineFlag = join(binDir, "gh-offline");
   noTokenFlag = join(binDir, "gh-no-token");
+  badSecondaryFlag = join(binDir, "gh-bad-secondary");
+  apiDownFlag = join(binDir, "gh-api-down");
+  slowStatusFlag = join(binDir, "gh-slow-status");
   callLog = join(binDir, "gh-calls.log");
   // Mimics real `gh` (2.96) closely enough:
   //  --version     always works, so the plugin's resolveGh() finds it
@@ -43,7 +49,9 @@ beforeEach(() => {
   //  auth status   network probe: fails with gh's verbatim "token is invalid"
   //                wording while offline (that IS what gh prints when it
   //                cannot reach api.github.com), or "You are not logged into
-  //                any GitHub hosts" when there are no credentials.
+  //                any GitHub hosts" when there are no credentials. Without
+  //                --active it also fails when a secondary account is broken.
+  //  issue/pr list fail while the api-down flag exists
   writeFileSync(
     join(binDir, "gh"),
     `#!/usr/bin/env bash
@@ -54,6 +62,7 @@ case "$1 $2" in
     if [ -e "${noTokenFlag}" ]; then echo "no oauth token found for github.com" >&2; exit 1; fi
     echo "gho_fake_token_is_configured_locally"; exit 0;;
   "auth status")
+    [ -e "${slowStatusFlag}" ] && sleep 0.3
     if [ -e "${noTokenFlag}" ]; then
       echo "You are not logged into any GitHub hosts. To log in, run: gh auth login" >&2; exit 1
     fi
@@ -63,7 +72,18 @@ case "$1 $2" in
       echo "  - The token in keyring is invalid." >&2
       exit 1
     fi
+    if [ -e "${badSecondaryFlag}" ]; then
+      case " $* " in *" --active "*) ;; *)
+        echo "github.com" >&2
+        echo "  X Failed to log in to github.com account other (keyring)" >&2
+        echo "  - The token in keyring is invalid." >&2
+        exit 1;;
+      esac
+    fi
     echo "github.com"; echo "  ✓ Logged in to github.com account someone (keyring)"; exit 0;;
+  "issue list"|"pr list")
+    if [ -e "${apiDownFlag}" ]; then echo "error connecting to api.github.com" >&2; exit 1; fi
+    echo "[]"; exit 0;;
   *) echo "[]"; exit 0;;
 esac
 `,
@@ -77,12 +97,17 @@ afterEach(() => {
   rmSync(binDir, { recursive: true, force: true });
 });
 
-async function loadWithSyncServiceOnce() {
-  const { bb, harness } = createFakePluginHost({ pluginId: "github" });
+async function loadWithSyncServiceOnce(
+  options: { settings?: Record<string, string> } = {},
+) {
+  const { bb, harness } = createFakePluginHost({
+    pluginId: "github",
+    settings: options.settings,
+  });
   await plugin(bb);
-  // Run the sync service the way the host does at activation. On main its
-  // first syncAll() throws NeedsConfigurationError and it stops for good; a
-  // fixed plugin keeps looping, so abort it after its first pass.
+  // Run the sync service the way the host does at activation. Before the fix
+  // its first syncAll() threw NeedsConfigurationError and it stopped for
+  // good; the fixed plugin keeps looping, so abort it after its first pass.
   const { controller, done } = harness.runService("sync");
   await new Promise((resolve) => setTimeout(resolve, 150));
   controller.abort();
@@ -95,29 +120,35 @@ describe("github plugin gh auth probe (#1758)", () => {
     // 1. gh is "offline" while bb starts (credentials exist, API unreachable).
     writeFileSync(offlineFlag, "");
     const { harness } = await loadWithSyncServiceOnce();
-    const before = (await harness.callRpc("status")) as { ghOk: boolean };
+    const before = (await harness.callRpc("status")) as {
+      ghOk: boolean;
+      ghState: string;
+    };
     expect(before.ghOk).toBe(false); // probe failed at load, as expected
+    expect(before.ghState).toBe("unavailable");
     const callsWhileOffline = ghCalls().length;
 
     // 2. gh recovers (network back / keychain unlocked). Nothing else changes.
     rmSync(offlineFlag);
 
     // 3. The plugin is asked for its status (panel banner / `bb github`).
-    //    A plugin that re-probes on demand or on its interval reports ghOk.
-    //    On main NOTHING re-runs `gh auth status`: ghOk stays false with the
-    //    stale error, and not a single further gh call is made.
+    //    A plugin that re-probes on demand reports ghOk. Before the fix
+    //    nothing re-ran `gh auth status`: ghOk stayed false with the stale
+    //    error, and not a single further gh call was made.
     const after = (await harness.callRpc("status")) as {
       ghOk: boolean;
+      ghState: string;
       ghError: string | null;
     };
-    expect(ghCalls().length).toBeGreaterThan(callsWhileOffline); // FAILS on main: no re-probe
-    expect(after.ghOk).toBe(true); // FAILS on main: latched
+    expect(ghCalls().length).toBeGreaterThan(callsWhileOffline);
+    expect(after.ghOk).toBe(true);
+    expect(after.ghState).toBe("ready");
   });
 
   it('does not report needs-configuration ("run gh auth login") for a transient probe failure', async () => {
     writeFileSync(offlineFlag, "");
     const { harness } = await loadWithSyncServiceOnce();
-    // FAILS on main: both the load-time probe and the sync service latch
+    // Before the fix both the load-time probe and the sync service latched
     // needs-configuration with the `gh auth login` remedy, although gh holds
     // valid credentials and only the network probe failed.
     expect(harness.needsConfigurationMessages).toEqual([]);
@@ -128,6 +159,8 @@ describe("github plugin gh auth probe (#1758)", () => {
     const { harness } = await loadWithSyncServiceOnce();
     expect(harness.needsConfigurationMessages.length).toBeGreaterThan(0);
     expect(harness.needsConfigurationMessages[0]).toContain("gh auth login");
+    const status = (await harness.callRpc("status")) as { ghState: string };
+    expect(status.ghState).toBe("needs_configuration");
   });
 
   it("control: with gh working from the start the plugin never reports needs-configuration", async () => {
@@ -135,5 +168,61 @@ describe("github plugin gh auth probe (#1758)", () => {
     expect(harness.needsConfigurationMessages).toEqual([]);
     const status = (await harness.callRpc("status")) as { ghOk: boolean };
     expect(status.ghOk).toBe(true);
+  });
+
+  it("probes only the active github.com account, so a broken secondary account does not block sync", async () => {
+    writeFileSync(badSecondaryFlag, "");
+    const { harness } = await loadWithSyncServiceOnce();
+    expect(harness.needsConfigurationMessages).toEqual([]);
+    const status = (await harness.callRpc("status")) as { ghState: string };
+    expect(status.ghState).toBe("ready");
+    const statusCalls = ghCalls().filter((call) => call.startsWith("auth status"));
+    expect(statusCalls.length).toBeGreaterThan(0);
+    for (const call of statusCalls) {
+      expect(call).toContain("--hostname github.com");
+      expect(call).toContain("--active");
+    }
+    const tokenCalls = ghCalls().filter((call) => call.startsWith("auth token"));
+    for (const call of tokenCalls) {
+      expect(call).toContain("--hostname github.com");
+    }
+  });
+
+  it("shares one in-flight probe between concurrent status calls", async () => {
+    writeFileSync(offlineFlag, "");
+    const { harness } = await loadWithSyncServiceOnce();
+    rmSync(offlineFlag);
+    writeFileSync(slowStatusFlag, "");
+    const callsBefore = ghCalls().length;
+    // Panel header and body both ask for status when the panel opens.
+    const [a, b] = (await Promise.all([
+      harness.callRpc("status"),
+      harness.callRpc("status"),
+    ])) as Array<{ ghState: string }>;
+    expect(a.ghState).toBe("ready");
+    expect(b.ghState).toBe("ready");
+    const probes = ghCalls()
+      .slice(callsBefore)
+      .filter((call) => call.startsWith("auth status"));
+    expect(probes).toHaveLength(1);
+  });
+
+  it("treats a pass where every repo failed as a failure and keeps the old sync time", async () => {
+    writeFileSync(apiDownFlag, "");
+    const { bb, harness } = await loadWithSyncServiceOnce({
+      settings: { extraRepos: "acme/one acme/two" },
+    });
+    // The sync service must not crash out (the host would stop it during
+    // activation) and must not record a successful pass.
+    expect(harness.needsConfigurationMessages).toEqual([]);
+    expect(await bb.storage.kv.get("sync-cursor")).toBeUndefined();
+    await expect(harness.callRpc("refresh")).rejects.toThrow(/all 2 repo/);
+    expect(await bb.storage.kv.get("sync-cursor")).toBeUndefined();
+
+    // Once GitHub answers again the next pass records a sync time.
+    rmSync(apiDownFlag);
+    const result = (await harness.callRpc("refresh")) as { repos: number };
+    expect(result.repos).toBe(2);
+    expect(await bb.storage.kv.get("sync-cursor")).toBeDefined();
   });
 });

--- a/plugins/github/server.ts
+++ b/plugins/github/server.ts
@@ -12,6 +12,10 @@ import { defineRpcContract, type BbPluginApi } from "@get-bb/plugin-sdk";
 import { z } from "zod";
 
 const SYNC_INTERVAL_MS = 5 * 60_000;
+// Retry cadence while the sync fails for a reason that is not a configuration
+// problem (network blip, locked keychain, slow host): start at 30 s and back
+// off to the regular sync interval.
+const SYNC_RETRY_BASE_MS = 30_000;
 const ISSUE_PAGE = 100;
 const CLOSED_ISSUE_PAGE = 50;
 const PR_PAGE = 50;
@@ -310,6 +314,13 @@ function needsConfiguration(message: string): Error {
   });
 }
 
+function isNeedsConfigurationError(error: unknown): error is Error {
+  return error instanceof Error && error.name === "NeedsConfigurationError";
+}
+
+/** gh's own wording when it holds no credentials for the host. */
+const GH_NO_CREDENTIALS = /no oauth token|not logged in/i;
+
 /** owner/name from any GitHub remote URL (https, ssh, git@), else null. */
 export function parseGithubRemote(url: string): string | null {
   const match = url
@@ -497,14 +508,36 @@ export default async function plugin(bb: BbPluginApi) {
     return stdout;
   }
 
+  // `gh auth status` calls the GitHub API, so a failure does not by itself
+  // mean gh is unconfigured. Only two outcomes are configuration problems
+  // worth latching needs-configuration on: gh missing, and gh present but
+  // holding no credentials at all (`gh auth token` answers that without the
+  // network). Anything else (network down, keychain locked, slow host,
+  // timeout) is a plain Error so callers retry instead of latching (#1758).
   async function checkAuth(): Promise<void> {
     try {
       await gh(["auth", "status"], 10_000);
       ghAuthError = null;
+      return;
     } catch (error) {
       ghAuthError = error instanceof Error ? error.message : String(error);
+      if (isNeedsConfigurationError(error)) throw error; // gh not found
+    }
+    let hasCredentials = true;
+    try {
+      await gh(["auth", "token"], 5_000);
+    } catch (error) {
+      // Only gh's own "no credentials" answer is a configuration problem; a
+      // timeout or crash of this local check counts as transient too.
+      const message = error instanceof Error ? error.message : String(error);
+      hasCredentials = !GH_NO_CREDENTIALS.test(message);
+    }
+    if (!hasCredentials) {
       throw needsConfiguration(`GitHub CLI is not authenticated. ${GH_HINT}`);
     }
+    throw new Error(
+      `gh auth status failed; gh has credentials, so this is probably transient and will be retried: ${ghAuthError}`,
+    );
   }
 
   // ------------------------------------------------------------------
@@ -727,13 +760,31 @@ export default async function plugin(bb: BbPluginApi) {
 
   // Initial sync + 5-minute refresh loop. NeedsConfigurationError from a
   // missing/unauthenticated gh flips the plugin to needs-configuration
-  // instead of crash-looping.
+  // instead of crash-looping. Any other failure (transient gh/network
+  // trouble) is retried with backoff so the service does not stop for good.
   bb.background.service("sync", {
     async start(signal) {
+      let failures = 0;
       while (!signal.aborted) {
-        await syncAll();
+        let delayMs = SYNC_INTERVAL_MS;
+        try {
+          await syncAll();
+          failures = 0;
+        } catch (error) {
+          if (isNeedsConfigurationError(error)) throw error;
+          failures += 1;
+          delayMs = Math.min(
+            SYNC_RETRY_BASE_MS * 2 ** (failures - 1),
+            SYNC_INTERVAL_MS,
+          );
+          bb.log.warn(
+            `sync failed (retry in ${Math.round(delayMs / 1000)}s): ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
         await new Promise<void>((resolve) => {
-          const timer = setTimeout(resolve, SYNC_INTERVAL_MS);
+          const timer = setTimeout(resolve, delayMs);
           signal.addEventListener(
             "abort",
             () => {
@@ -748,13 +799,16 @@ export default async function plugin(bb: BbPluginApi) {
   });
 
   // Surface an unconfigured gh immediately instead of waiting for the
-  // service's first crash.
+  // service's first crash. A transient probe failure is only logged: the
+  // sync service retries it and the status RPC re-probes on demand.
   try {
     await checkAuth();
   } catch (error) {
-    bb.status.needsConfiguration(
-      error instanceof Error ? error.message : String(error),
-    );
+    if (isNeedsConfigurationError(error)) {
+      bb.status.needsConfiguration(error.message);
+    } else {
+      bb.log.warn(error instanceof Error ? error.message : String(error));
+    }
   }
 
   // ------------------------------------------------------------------
@@ -907,6 +961,15 @@ export default async function plugin(bb: BbPluginApi) {
   bb.rpc.register(githubRpcContract, {
     /** () → auth/sync status for the panel banner. */
     async status() {
+      // Re-probe on demand after a failed probe so a recovered gh is noticed
+      // the next time the panel or CLI asks, not only on the next sync tick.
+      if (ghAuthError !== null) {
+        try {
+          await checkAuth();
+        } catch {
+          // ghAuthError already carries the failure
+        }
+      }
       const cursor = await bb.storage.kv.get<{
         lastSyncedAt: string;
         repos: number;

--- a/plugins/github/server.ts
+++ b/plugins/github/server.ts
@@ -141,6 +141,10 @@ export const githubRpcContract = defineRpcContract({
     output: z
       .object({
         ghOk: z.boolean(),
+        /** ready: gh works. needs_configuration: gh missing or not logged in.
+            unavailable: gh has credentials but the last probe failed (network,
+            keychain, slow host); the plugin retries by itself. */
+        ghState: z.enum(["ready", "needs_configuration", "unavailable"]),
         ghError: z.string().nullable(),
         repos: z.array(repoInfoSchema),
         lastSyncedAt: z.string().nullable(),
@@ -318,8 +322,20 @@ function isNeedsConfigurationError(error: unknown): error is Error {
   return error instanceof Error && error.name === "NeedsConfigurationError";
 }
 
+/** gh is installed and has credentials, but a network-dependent step failed
+    (offline, locked keychain, slow host, GitHub outage). The sync service
+    retries these itself; every other error surfaces to the plugin host. */
+function ghUnavailable(message: string): Error {
+  return Object.assign(new Error(message), { name: "GhUnavailableError" });
+}
+
+function isGhUnavailableError(error: unknown): error is Error {
+  return error instanceof Error && error.name === "GhUnavailableError";
+}
+
 /** gh's own wording when it holds no credentials for the host. */
 const GH_NO_CREDENTIALS = /no oauth token|not logged in/i;
+const GH_HOST = "github.com";
 
 /** owner/name from any GitHub remote URL (https, ssh, git@), else null. */
 export function parseGithubRemote(url: string): string | null {
@@ -485,6 +501,8 @@ export default async function plugin(bb: BbPluginApi) {
   // common install locations once and remember the winner.
   // ------------------------------------------------------------------
   let ghPath: string | null = null;
+  type GhState = "ready" | "needs_configuration" | "unavailable";
+  let ghState: GhState = "unavailable";
   let ghAuthError: string | null = "checking gh…";
 
   async function resolveGh(): Promise<string> {
@@ -513,19 +531,25 @@ export default async function plugin(bb: BbPluginApi) {
   // worth latching needs-configuration on: gh missing, and gh present but
   // holding no credentials at all (`gh auth token` answers that without the
   // network). Anything else (network down, keychain locked, slow host,
-  // timeout) is a plain Error so callers retry instead of latching (#1758).
-  async function checkAuth(): Promise<void> {
+  // timeout) is a GhUnavailableError so callers retry instead of latching
+  // (#1758). Both commands are scoped to the active github.com account so a
+  // broken secondary account or host cannot block a valid one.
+  async function probeAuth(): Promise<void> {
     try {
-      await gh(["auth", "status"], 10_000);
+      await gh(["auth", "status", "--hostname", GH_HOST, "--active"], 10_000);
+      ghState = "ready";
       ghAuthError = null;
       return;
     } catch (error) {
       ghAuthError = error instanceof Error ? error.message : String(error);
-      if (isNeedsConfigurationError(error)) throw error; // gh not found
+      if (isNeedsConfigurationError(error)) {
+        ghState = "needs_configuration"; // gh not found
+        throw error;
+      }
     }
     let hasCredentials = true;
     try {
-      await gh(["auth", "token"], 5_000);
+      await gh(["auth", "token", "--hostname", GH_HOST], 5_000);
     } catch (error) {
       // Only gh's own "no credentials" answer is a configuration problem; a
       // timeout or crash of this local check counts as transient too.
@@ -533,11 +557,25 @@ export default async function plugin(bb: BbPluginApi) {
       hasCredentials = !GH_NO_CREDENTIALS.test(message);
     }
     if (!hasCredentials) {
+      ghState = "needs_configuration";
       throw needsConfiguration(`GitHub CLI is not authenticated. ${GH_HINT}`);
     }
-    throw new Error(
+    ghState = "unavailable";
+    throw ghUnavailable(
       `gh auth status failed; gh has credentials, so this is probably transient and will be retried: ${ghAuthError}`,
     );
+  }
+
+  // Concurrent callers (sync loop, panel header + body status RPCs) share one
+  // in-flight probe instead of spawning duplicate gh processes.
+  let authProbe: Promise<void> | null = null;
+  function checkAuth(): Promise<void> {
+    if (authProbe === null) {
+      authProbe = probeAuth().finally(() => {
+        authProbe = null;
+      });
+    }
+    return authProbe;
   }
 
   // ------------------------------------------------------------------
@@ -732,16 +770,25 @@ export default async function plugin(bb: BbPluginApi) {
       db.prepare("SELECT repo, kind, number, updated_at FROM items ORDER BY repo, kind, number").all(),
     );
     let total = 0;
+    let failed = 0;
+    let lastFailure = "";
     for (const { repo } of repos) {
       try {
         const items = await fetchRepoItems(gh, repo);
         replaceRepoRows(repo, items);
         total += items.length;
       } catch (error) {
-        bb.log.warn(
-          `sync failed for ${repo}: ${error instanceof Error ? error.message : String(error)}`,
-        );
+        failed += 1;
+        lastFailure = error instanceof Error ? error.message : String(error);
+        bb.log.warn(`sync failed for ${repo}: ${lastFailure}`);
       }
+    }
+    // Partial success still counts as a pass; a pass where every repo failed
+    // is a failure: keep the old sync time and let the caller retry soon.
+    if (repos.length > 0 && failed === repos.length) {
+      throw ghUnavailable(
+        `sync failed for all ${repos.length} repo(s); last error: ${lastFailure}`,
+      );
     }
     const after = JSON.stringify(
       db.prepare("SELECT repo, kind, number, updated_at FROM items ORDER BY repo, kind, number").all(),
@@ -760,8 +807,10 @@ export default async function plugin(bb: BbPluginApi) {
 
   // Initial sync + 5-minute refresh loop. NeedsConfigurationError from a
   // missing/unauthenticated gh flips the plugin to needs-configuration
-  // instead of crash-looping. Any other failure (transient gh/network
-  // trouble) is retried with backoff so the service does not stop for good.
+  // instead of crash-looping. GhUnavailableError (transient gh/network
+  // trouble) is retried here with backoff: the host would otherwise stop the
+  // service for good when it crashes during activation. Every other error
+  // is a real fault and surfaces to the host unchanged.
   bb.background.service("sync", {
     async start(signal) {
       let failures = 0;
@@ -771,7 +820,7 @@ export default async function plugin(bb: BbPluginApi) {
           await syncAll();
           failures = 0;
         } catch (error) {
-          if (isNeedsConfigurationError(error)) throw error;
+          if (!isGhUnavailableError(error)) throw error;
           failures += 1;
           delayMs = Math.min(
             SYNC_RETRY_BASE_MS * 2 ** (failures - 1),
@@ -806,8 +855,10 @@ export default async function plugin(bb: BbPluginApi) {
   } catch (error) {
     if (isNeedsConfigurationError(error)) {
       bb.status.needsConfiguration(error.message);
+    } else if (isGhUnavailableError(error)) {
+      bb.log.warn(error.message);
     } else {
-      bb.log.warn(error instanceof Error ? error.message : String(error));
+      throw error;
     }
   }
 
@@ -963,11 +1014,11 @@ export default async function plugin(bb: BbPluginApi) {
     async status() {
       // Re-probe on demand after a failed probe so a recovered gh is noticed
       // the next time the panel or CLI asks, not only on the next sync tick.
-      if (ghAuthError !== null) {
+      if (ghState !== "ready") {
         try {
           await checkAuth();
         } catch {
-          // ghAuthError already carries the failure
+          // ghState/ghAuthError already carry the failure
         }
       }
       const cursor = await bb.storage.kv.get<{
@@ -977,7 +1028,8 @@ export default async function plugin(bb: BbPluginApi) {
       }>("sync-cursor");
       const repos = await discoverRepos();
       return {
-        ghOk: ghAuthError === null,
+        ghOk: ghState === "ready",
+        ghState,
         ghError: ghAuthError,
         repos,
         lastSyncedAt: cursor?.lastSyncedAt ?? null,


### PR DESCRIPTION
## What was wrong

The github plugin ran `gh auth status` once at load and treated every failure as `NeedsConfigurationError`. `gh auth status` calls the GitHub API, so it also fails when the network is down, the keychain is locked, or a slow host exceeds the 10 s timeout. The load-time probe called `bb.status.needsConfiguration`, and the first pass of the `sync` background service threw the same error, which the plugin runtime treats as "stop this service until reload". After that nothing ran `gh auth status` again. `bb plugin list` showed `needs-configuration (GitHub CLI is not authenticated … run gh auth login …)` for hours while `gh auth status` succeeded in every terminal, and only `bb plugin reload github` recovered. Report: https://get-bb.github.io/reports/issues/1758.html

## What changed

`plugins/github/server.ts`:

- `checkAuth()` throws `NeedsConfigurationError` only when gh is missing or holds no credentials at all. It uses the network-free `gh auth token` to tell "not logged in" from "logged in but the API probe failed". Every other failure is a typed `GhUnavailableError` that carries gh's stderr. Both commands are scoped to the active `github.com` account (`--hostname github.com --active`), so a broken secondary account cannot block a valid one.
- Concurrent callers share one in-flight probe promise, so the panel header and body do not spawn duplicate `gh` processes.
- The `sync` service catches only `GhUnavailableError` inside its loop and retries with backoff (30 s, doubling up to the 5-min interval). Any other error surfaces to the plugin host as before. The plugin-level retry is needed because the host stops a service that crashes during activation instead of restarting it.
- A sync pass where every repo failed throws `GhUnavailableError`: the sync time does not advance and the short retry applies. Partial success is still a pass.
- The `status` RPC re-runs `checkAuth()` when the last probe was not `ready` and returns a typed `ghState` (`ready` | `needs_configuration` | `unavailable`).
- Load time calls `bb.status.needsConfiguration` only for the two genuine configuration cases and logs a transient failure.

`plugins/github/app.tsx`: the panel shows "GitHub CLI unavailable — retrying" / "GitHub CLI could not reach GitHub …" for `unavailable` instead of the `gh auth login` remedy.

Deviation from the report: `--hostname github.com --active` scoping, the typed `ghState`, the in-flight probe dedupe, and the all-repos-failed rule come from the SlopCop review. Follow-ups still out of scope: make `resolveGh()` distinguish ENOENT from a timeout, and a degraded/clear status API in the plugin runtime.

## Tests

`plugins/github/server.auth-latch.test.ts` drives the real plugin entry through `createFakePluginHost` with a fake `gh` on PATH:

- re-probes gh after a transient auth-status failure instead of latching — fails on main
- does not report needs-configuration for a transient probe failure — fails on main
- still reports needs-configuration when gh has no credentials at all
- control: gh working from the start never reports needs-configuration
- probes only the active github.com account, so a broken secondary account does not block sync — fails before the review fixes
- shares one in-flight probe between concurrent status calls — fails before the review fixes
- treats a pass where every repo failed as a failure and keeps the old sync time — fails before the review fixes

## How I verified

- `pnpm exec turbo run typecheck test --filter=bb-plugin-github --force` → 3 tasks successful, 14 tests passed

Fixes #1758

> AGENT GENERATED: by Claude Opus 5
