### PR TITLE
Avoid timeline rerenders while typing in prompt boxes

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import type { PromptTextMention } from "@bb/domain";
+import { EditorView } from "@tiptap/pm/view";
 import {
   createRef,
   useLayoutEffect,
@@ -2924,6 +2925,53 @@ describe("PromptBoxInternal mention triggers", () => {
 });
 
 describe("PromptBoxInternal prompt actions", () => {
+  it("keeps the custom caret reveal for composer-handled text pastes", async () => {
+    const { changes, promptBoxRef } = renderPromptBox("");
+
+    await focusPromptEnd(promptBoxRef);
+    await act(
+      () =>
+        new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
+    );
+
+    const scrollContainer = document.querySelector(
+      "[data-promptbox-editor-scroll]",
+    );
+    if (!(scrollContainer instanceof HTMLElement)) {
+      throw new Error("Prompt editor scroll container was not rendered");
+    }
+    const scrollRectSpy = vi
+      .spyOn(scrollContainer, "getBoundingClientRect")
+      .mockReturnValue(new DOMRect(0, 0, 320, 100));
+    const coordsAtPosSpy = vi
+      .spyOn(EditorView.prototype, "coordsAtPos")
+      .mockReturnValue({
+        left: 0,
+        right: 0,
+        top: 120,
+        bottom: 136,
+      });
+
+    try {
+      pastePlainText("first line\nsecond line");
+
+      await waitFor(() =>
+        expect(latestValue(changes)).toBe("first line\nsecond line"),
+      );
+      await act(
+        () =>
+          new Promise<void>((resolve) =>
+            requestAnimationFrame(() => resolve()),
+          ),
+      );
+
+      expect(coordsAtPosSpy).toHaveBeenCalled();
+    } finally {
+      coordsAtPosSpy.mockRestore();
+      scrollRectSpy.mockRestore();
+    }
+  });
+
   it("preserves blockquote structure when pasting copied blockquote html", async () => {
     const { changes, promptBoxRef } = renderPromptBox("");
 

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -1761,7 +1761,12 @@ export function PromptBoxInternal({
               promptEditorContentFromValue(pastedValue, {
                 richTextMarkdown: richTextEditing,
               }).content ?? [];
-            currentEditor?.chain().focus().insertContent(pastedContent).run();
+            currentEditor
+              ?.chain()
+              .focus()
+              .insertContent(pastedContent)
+              .setMeta("uiEvent", "paste")
+              .run();
             if (currentEditor && !currentEditor.isDestroyed) {
               const nextValue = trimTrailingPromptNewlines(
                 promptEditorValueFromDoc(currentEditor.state.doc),
@@ -1785,6 +1790,7 @@ export function PromptBoxInternal({
             ?.chain()
             .focus()
             .insertContent(promptEditorInlineContentFromValue(pastedValue))
+            .setMeta("uiEvent", "paste")
             .run();
           return true;
         },

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -1796,17 +1796,28 @@ export function PromptBoxInternal({
           mentions: mentionRanges,
         });
       },
-      onSelectionUpdate({ editor: updatedEditor }) {
+      onSelectionUpdate({ editor: updatedEditor, transaction }) {
+        // A typing transaction changes both the document and the selection, so
+        // TipTap emits selectionUpdate immediately before update. Let onUpdate
+        // handle that transaction once. The browser already reveals the caret
+        // for native contenteditable edits; measuring it here with coordsAtPos
+        // forces layout on every keystroke.
+        if (transaction.docChanged) return;
         syncTriggerStateRef.current(updatedEditor);
         scheduleRevealEditorSelection();
       },
-      onUpdate({ editor: updatedEditor }) {
+      onUpdate({ editor: updatedEditor, transaction }) {
         if (skipEditorChangeRef.current) return;
         const nextValue = promptEditorValueFromDoc(updatedEditor.state.doc);
         editorValueKeyRef.current = promptEditorValueKey(nextValue);
         onChangeRef.current(nextValue.text, nextValue.mentions);
         syncTriggerStateRef.current(updatedEditor);
-        scheduleRevealEditorSelection();
+        // Native typing already asks ProseMirror to scroll the selection into
+        // view. Clipboard and drop transactions still need the prompt's custom
+        // scroll-container reveal that originally fixed multiline paste.
+        if (transaction.getMeta("uiEvent") !== undefined) {
+          scheduleRevealEditorSelection();
+        }
       },
       // Rebuild the editor when the rich-text preference toggles so the schema
       // and input rules switch. The editor is otherwise created once; its

--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
@@ -371,6 +371,25 @@ describe("EmbeddedThreadChat", () => {
     );
   });
 
+  it("keeps add-to-chat callbacks stable while the composer draft changes", () => {
+    renderEmbeddedChat();
+    const initialTimelineProps = mocks.timelinePanelProps.at(-1);
+
+    fireEvent.change(screen.getByTestId("embedded-chat-composer"), {
+      target: { value: "Typing must not invalidate timeline rows" },
+    });
+
+    // ThreadTimelineRows memoizes its static renderer context around these
+    // callbacks. Replacing either one on every draft write re-renders every
+    // visible timeline row for each keystroke.
+    expect(mocks.timelinePanelProps.at(-1)).toEqual(
+      expect.objectContaining({
+        onMessageAddToChat: initialTimelineProps?.onMessageAddToChat,
+        onSelectionAddToChat: initialTimelineProps?.onSelectionAddToChat,
+      }),
+    );
+  });
+
   it("restores the draft and a stream that advanced while unmounted on remount", () => {
     mocks.threadRuntimeDisplayStatus = "active";
     mocks.timelineRows = [{ text: "First reply" }];

--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
@@ -754,12 +754,13 @@ function EmbeddedThreadChatWithComposer({
     void handleSaveInlineQueuedMessage();
   }, [handleSaveInlineQueuedMessage]);
 
+  const addQuoteToPromptDraft = promptDraft.addQuote;
   const handleAddToChat = useCallback<ThreadTimelineAddToChatHandler>(
     (text, attachments) => {
-      promptDraft.addQuote(text, attachments);
+      addQuoteToPromptDraft(text, attachments);
       setComposerFocusNonce((nonce) => nonce + 1);
     },
-    [promptDraft],
+    [addQuoteToPromptDraft],
   );
 
   // ---- Plugin composer host --------------------------------------------------

--- a/apps/app/src/hooks/useLocalOpenTargets.test.tsx
+++ b/apps/app/src/hooks/useLocalOpenTargets.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from "@testing-library/react";
+import type { OpenInTargetContext } from "@bb/host-daemon-contract";
+import { afterEach, describe, expect, it } from "vitest";
+import { useLocalOpenTargets } from "./useLocalOpenTargets";
+
+afterEach(() => {
+  cleanup();
+});
+
+const contextCases: Array<{
+  createContext: () => OpenInTargetContext;
+  kind: OpenInTargetContext["kind"];
+}> = [
+  {
+    kind: "local",
+    createContext: () => ({ kind: "local" }),
+  },
+  {
+    kind: "remote-ssh",
+    createContext: () => ({
+      kind: "remote-ssh",
+      hostId: "host-1",
+      serverOrigin: "https://bb.example.test",
+    }),
+  },
+];
+
+describe("useLocalOpenTargets", () => {
+  it.each(contextCases)(
+    "keeps file-open callbacks stable for equal $kind contexts",
+    ({ createContext }) => {
+      const { result, rerender } = renderHook(() =>
+        useLocalOpenTargets({
+          enabled: false,
+          openContext: createContext(),
+        }),
+      );
+      const initialOpenPathInFileTarget = result.current.openPathInFileTarget;
+
+      rerender();
+
+      expect(result.current.openPathInFileTarget).toBe(
+        initialOpenPathInFileTarget,
+      );
+    },
+  );
+});

--- a/apps/app/src/hooks/useLocalOpenTargets.ts
+++ b/apps/app/src/hooks/useLocalOpenTargets.ts
@@ -211,9 +211,25 @@ function useOpenTargetResolution(
 export function useLocalOpenTargets(
   args: UseLocalOpenTargetsArgs,
 ): UseLocalOpenTargetsResult {
+  const openContextKind = args.openContext?.kind ?? "local";
+  const openContextHostId =
+    args.openContext?.kind === "remote-ssh" ? args.openContext.hostId : null;
+  const openContextServerOrigin =
+    args.openContext?.kind === "remote-ssh"
+      ? args.openContext.serverOrigin
+      : null;
   const openContext = useMemo<OpenInTargetContext>(
-    () => args.openContext ?? { kind: "local" },
-    [args.openContext],
+    () =>
+      openContextKind === "remote-ssh" &&
+      openContextHostId !== null &&
+      openContextServerOrigin !== null
+        ? {
+            kind: "remote-ssh",
+            hostId: openContextHostId,
+            serverOrigin: openContextServerOrigin,
+          }
+        : { kind: "local" },
+    [openContextHostId, openContextKind, openContextServerOrigin],
   );
   const contextKind = openContext.kind;
   const { hasDaemon } = useHostDaemon();

--- a/apps/app/src/hooks/usePromptDraftStorage.test.tsx
+++ b/apps/app/src/hooks/usePromptDraftStorage.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, renderHook } from "@testing-library/react";
+import { act, cleanup, render, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  getPromptDraftAccessor,
   usePromptDraftInputThreadIds,
   usePromptDraftStorage,
 } from "./usePromptDraftStorage";
@@ -128,6 +129,36 @@ describe("usePromptDraftStorage", () => {
 });
 
 describe("usePromptDraftStorage addQuote", () => {
+  it("keeps an imperative draft-action consumer unsubscribed from composer writes", () => {
+    const scope = uniqueScope();
+    let consumerRenders = 0;
+    let draftActions: ReturnType<typeof getPromptDraftAccessor> | undefined;
+
+    function DraftActionConsumer() {
+      consumerRenders += 1;
+      draftActions = getPromptDraftAccessor(scope);
+      return null;
+    }
+
+    render(<DraftActionConsumer />);
+    const rendersBeforeTyping = consumerRenders;
+    const composer = renderHook(() => usePromptDraftStorage(scope));
+
+    act(() => {
+      composer.result.current.setTextAndMentions("typed reply", []);
+    });
+
+    expect(consumerRenders).toBe(rendersBeforeTyping);
+    expect(draftActions?.storageKey).toBe(composer.result.current.storageKey);
+
+    act(() => {
+      draftActions?.addQuote("selected text");
+    });
+
+    expect(composer.result.current.text).toBe("typed reply\n> selected text\n");
+    expect(consumerRenders).toBe(rendersBeforeTyping);
+  });
+
   it("appends a trimmed quote as a '> ' block to the draft text and persists", () => {
     const scope = uniqueScope();
     const { result } = renderHook(() => usePromptDraftStorage(scope));

--- a/apps/app/src/hooks/usePromptDraftStorage.ts
+++ b/apps/app/src/hooks/usePromptDraftStorage.ts
@@ -224,6 +224,26 @@ function restorePromptDraftIfEmpty(
   return true;
 }
 
+function addQuoteToPromptDraft(
+  storageKey: string,
+  text: string,
+  attachments: readonly PromptDraftAttachment[] = [],
+): void {
+  const currentDraft = readPromptDraft(storageKey);
+  const nextDraft = appendQuoteAndAttachmentsToDraft(
+    currentDraft,
+    text,
+    attachments,
+  );
+  // Whitespace-only text with no new attachments is a no-op; skip the write
+  // so an empty selection can't mark an otherwise-empty draft dirty.
+  if (nextDraft === currentDraft) {
+    return;
+  }
+
+  writePromptDraft(storageKey, nextDraft);
+}
+
 function getPromptDraftStorageKey(scope: PromptDraftScope): string {
   if (scope.kind === "automation-edit") {
     const normalizedAutomationId = normalizeStorageSegment(scope.automationId);
@@ -251,13 +271,21 @@ function getPromptDraftStorageKey(scope: PromptDraftScope): string {
  * renders the draft.
  */
 export function getPromptDraftAccessor(scope: PromptDraftScope): {
+  storageKey: string;
   getCurrent: () => PromptDraftState;
   setDraft: (draft: PromptDraftState) => void;
+  addQuote: (
+    text: string,
+    attachments?: readonly PromptDraftAttachment[],
+  ) => void;
 } {
   const storageKey = getPromptDraftStorageKey(scope);
   return {
+    storageKey,
     getCurrent: () => readPromptDraft(storageKey),
     setDraft: (draft) => writePromptDraft(storageKey, draft),
+    addQuote: (text, attachments) =>
+      addQuoteToPromptDraft(storageKey, text, attachments),
   };
 }
 
@@ -333,21 +361,8 @@ export function usePromptDraftStorage(scope: PromptDraftScope) {
   );
 
   const addQuote = useCallback(
-    (text: string, attachments: readonly PromptDraftAttachment[] = []) => {
-      const currentDraft = readPromptDraft(storageKey);
-      const nextDraft = appendQuoteAndAttachmentsToDraft(
-        currentDraft,
-        text,
-        attachments,
-      );
-      // Whitespace-only text with no new attachments is a no-op; skip the write
-      // so an empty selection can't mark an otherwise-empty draft dirty.
-      if (nextDraft === currentDraft) {
-        return;
-      }
-
-      writePromptDraft(storageKey, nextDraft);
-    },
+    (text: string, attachments?: readonly PromptDraftAttachment[]) =>
+      addQuoteToPromptDraft(storageKey, text, attachments),
     [storageKey],
   );
 

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -74,7 +74,7 @@ import {
   type ProjectThreadSubsetFilters,
 } from "../../hooks/queries/thread-queries";
 import { isTransientReadError } from "@/hooks/queries/query-helpers";
-import { usePromptDraftStorage } from "@/hooks/usePromptDraftStorage";
+import { getPromptDraftAccessor } from "@/hooks/usePromptDraftStorage";
 import { subscribeComposerFocusRequests } from "@/lib/composer-focus-requests";
 import { ThreadGitActionDialog } from "@/components/dialogs/ThreadGitActionDialog";
 import { PageShell } from "@/components/ui/page-shell.js";
@@ -988,11 +988,19 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
   // localStorage-backed draft — the quoted text is appended to the draft as a
   // `> ` blockquote block and renders inline in the composer immediately, with
   // no duplicated draft state.
-  const selectionPromptDraft = usePromptDraftStorage({
-    kind: "thread",
-    projectId: thread?.projectId ?? projectId ?? "",
-    threadId: thread?.id ?? "",
-  });
+  // This view only needs draft actions at event time. Subscribing to the draft
+  // here made every composer write re-render the surrounding thread tree.
+  const selectionPromptDraftProjectId = thread?.projectId ?? projectId ?? "";
+  const selectionPromptDraftThreadId = thread?.id ?? "";
+  const selectionPromptDraft = useMemo(
+    () =>
+      getPromptDraftAccessor({
+        kind: "thread",
+        projectId: selectionPromptDraftProjectId,
+        threadId: selectionPromptDraftThreadId,
+      }),
+    [selectionPromptDraftProjectId, selectionPromptDraftThreadId],
+  );
   const addQuoteToComposer = selectionPromptDraft.addQuote;
   // Desktop quote actions keep their existing focus handoff. Mobile web does
   // not focus inputs programmatically; see PromptBoxInternal.


### PR DESCRIPTION
## Summary

- keep the embedded timeline's add-to-chat callbacks stable across composer draft writes so typing does not invalidate visible timeline rows
- stop `ThreadDetailViewInternal` from subscribing to per-keystroke draft writes when it only needs imperative `addQuote` and `storageKey` actions
- memoize local/remote workspace-open context structurally so equal context objects do not churn the timeline-wide local-file context menu provider
- skip the prompt's custom `coordsAtPos` caret measurement for ordinary native typing while retaining it for selection-only, clipboard, and drop updates
- preserve custom text-paste caret reveal by tagging composer-handled paste transactions with the same `uiEvent` metadata as ProseMirror's default paste path

Fixes #1304.

## Root cause

The original PR addressed two genuine local costs, but issue #1304's broader scaling path remained: `ThreadDetailViewInternal` subscribed to `usePromptDraftStorage` only for stable draft actions. Every keystroke therefore re-rendered the whole thread view. Each render also rebuilt an equal `OpenInTargetContext`; identity-keyed memoization recreated `openPathInFileTarget`, then the `MarkdownLocalFileContextMenuContext.Provider` value around the mounted timeline, forcing React to scan that subtree for consumers.

The thread view now uses the non-subscribing draft accessor, whose quote action shares the hook's existing implementation. `useLocalOpenTargets` keys its context memo on `kind`, `hostId`, and `serverOrigin`, preserving callback identity for semantically equal contexts without keeping stale remote context fields.

## Verification

- focused prompt/editor, embedded-chat, draft-accessor, and open-context tests: 4 files / 122 tests passed
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` (0 errors; repository baseline of 147 warnings)
- `pnpm exec turbo run test --filter=@bb/app --force`: 363 files / 2,870 tests passed
- Prettier and `git diff --check`

> AGENT GENERATED: by GPT-5
