### PR TITLE
Present ACP file-write permissions as file-change approvals

### DIFF
--- a/plugins/provider-acp/src/bridge/bridge.test.ts
+++ b/plugins/provider-acp/src/bridge/bridge.test.ts
@@ -1560,6 +1560,54 @@ describe("acp bridge", () => {
     expect(agentMessageTexts()).toContain("permission:no");
   });
 
+  it("presents an external-directory write permission as a file-change approval", async () => {
+    const { providerThreadId } = await startThread({
+      permissionMode: "accept-edits",
+      permissionEscalation: "ask",
+    });
+    const turnId = sendTurnRequest("turn/start", providerThreadId, {
+      input: [
+        {
+          type: "text",
+          text: "request-external-directory-permission",
+          mentions: [],
+        },
+      ],
+    });
+    await waitForResponse(turnId);
+    const forwarded = await waitFor(
+      () =>
+        output.messages.find(
+          (message) =>
+            message.method === "interaction/request" &&
+            message.id !== undefined,
+        ),
+      "forwarded permission request",
+    );
+    // The permission's own tool call is the generic kind "other" with a bare
+    // directory title; the in-flight edit tool call with the same id makes it
+    // a file-change approval bounded by the named directory.
+    expect(forwarded.params).toMatchObject({
+      payload: {
+        kind: "approval",
+        subject: {
+          kind: "file_change",
+          itemId: "write-tool-1",
+          writeScope: "/tmp/qa-1719",
+        },
+      },
+    });
+    handleLine(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: forwarded.id,
+        result: { decision: "allow_once", grantedPermissions: null },
+      }),
+    );
+    await waitForTurnCompleted();
+    expect(agentMessageTexts()).toContain("permission:yes");
+  });
+
   it("answers session-grant decisions with the allow_always option", async () => {
     const { providerThreadId } = await startThread({
       permissionMode: "accept-edits",

--- a/plugins/provider-acp/src/bridge/bridge.ts
+++ b/plugins/provider-acp/src/bridge/bridge.ts
@@ -1376,6 +1376,9 @@ function handlePermissionRequest(
         ...(rawInputCommand.success
           ? { command: rawInputCommand.data.command }
           : {}),
+        ...(toolCall.locations && toolCall.locations.length > 0
+          ? { locations: toolCall.locations.map((location) => location.path) }
+          : {}),
       }
     : undefined;
 

--- a/plugins/provider-acp/src/bridge/bridge.ts
+++ b/plugins/provider-acp/src/bridge/bridge.ts
@@ -1328,10 +1328,6 @@ function cancelPendingPermissions(session: AcpThreadSession): void {
   session.pendingPermissions.clear();
 }
 
-const acpRawInputCommandSchema = z
-  .object({ command: z.string() })
-  .passthrough();
-
 function handlePermissionRequest(
   session: AcpThreadSession,
   params: unknown,
@@ -1365,20 +1361,23 @@ function handlePermissionRequest(
   session.pendingPermissions.add(pending);
 
   const toolCall = parsed.data.toolCall;
-  const rawInputCommand = acpRawInputCommandSchema.safeParse(
-    toolCall?.rawInput,
-  );
+  const translatorState = session.translator.resolveState({
+    threadId: session.bbThreadId,
+  });
   const normalizedToolCall = toolCall?.toolCallId
     ? {
         toolCallId: toolCall.toolCallId,
-        ...(toolCall.title ? { title: toolCall.title } : {}),
-        ...(toolCall.kind ? { kind: toolCall.kind } : {}),
-        ...(rawInputCommand.success
-          ? { command: rawInputCommand.data.command }
+        ...(toolCall.title !== undefined ? { title: toolCall.title } : {}),
+        ...(toolCall.kind !== undefined ? { kind: toolCall.kind } : {}),
+        ...(toolCall.rawInput !== undefined
+          ? { rawInput: toolCall.rawInput }
           : {}),
-        ...(toolCall.locations && toolCall.locations.length > 0
-          ? { locations: toolCall.locations.map((location) => location.path) }
+        ...(toolCall.locations !== undefined
+          ? { locations: toolCall.locations }
           : {}),
+        startedToolCall: translatorState.toolCallEventsByCallId.get(
+          toolCall.toolCallId,
+        ),
       }
     : undefined;
 
@@ -1389,13 +1388,10 @@ function handlePermissionRequest(
       toolCall: normalizedToolCall,
       options: parsed.data.options,
     });
-    const state = session.translator.resolveState({
-      threadId: session.bbThreadId,
-    });
     void sendRuntimeRequest(BRIDGE_INBOUND_REQUEST_METHODS.interactionRequest, {
       providerThreadId: session.providerThreadId,
       threadId: session.bbThreadId,
-      turnId: state.currentTurnId ?? null,
+      turnId: translatorState.currentTurnId ?? null,
       payload,
     })
       .then((result) => {

--- a/plugins/provider-acp/src/bridge/fake-acp-agent.mjs
+++ b/plugins/provider-acp/src/bridge/fake-acp-agent.mjs
@@ -269,6 +269,48 @@ async function handlePrompt(message) {
 
   if (text === "/compact") {
     // OpenCode treats this exact prompt as a provider-local control.
+  } else if (text.includes("request-external-directory-permission")) {
+    // opencode's external_directory permission: the running edit tool asks
+    // with the generic kind "other", a bare directory title, and
+    // locations = [file, parentDir]. Mirrors get-bb/bb#1719.
+    notifyUpdate({
+      sessionUpdate: "tool_call",
+      toolCallId: "write-tool-1",
+      title: "Editing notes.md",
+      kind: "edit",
+      status: "pending",
+      locations: [{ path: "/tmp/qa-1719/notes.md" }],
+    });
+    let outcome = "cancelled";
+    try {
+      const result = await requestClient("session/request_permission", {
+        sessionId: activeSessionId,
+        toolCall: {
+          toolCallId: "write-tool-1",
+          title: "/tmp/qa-1719",
+          kind: "other",
+          locations: [
+            { path: "/tmp/qa-1719/notes.md" },
+            { path: "/tmp/qa-1719" },
+          ],
+          rawInput: {
+            filepath: "/tmp/qa-1719/notes.md",
+            parentDir: "/tmp/qa-1719",
+          },
+        },
+        options: [
+          { optionId: "yes", name: "Allow", kind: "allow_once" },
+          { optionId: "no", name: "Deny", kind: "reject_once" },
+        ],
+      });
+      outcome =
+        result?.outcome?.outcome === "selected"
+          ? result.outcome.optionId
+          : "cancelled";
+    } catch {
+      outcome = "error";
+    }
+    notifyUpdate(messageChunk(`permission:${outcome}`));
   } else if (text.includes("request-permission")) {
     notifyUpdate({
       sessionUpdate: "tool_call",

--- a/plugins/provider-acp/src/event-translation.ts
+++ b/plugins/provider-acp/src/event-translation.ts
@@ -30,7 +30,6 @@ import {
   type AcceptedUserMessageState,
   type ProviderRuntimeEvent,
 } from "@get-bb/plugin-sdk/provider-bridge";
-import { z } from "zod";
 /**
  * The per-event translation scope the runtime's generic adapter passes in. Its
  * `ProviderTranslationContext` satisfies this structurally; stated here so the
@@ -55,6 +54,10 @@ import {
   acpUpdateNotificationParamsSchema,
   acpWarningNotificationParamsSchema,
 } from "./bridge-protocol.js";
+import {
+  type AcpToolCallOperation,
+  classifyAcpToolCall,
+} from "./tool-call-operation.js";
 import { acpVisibilityMetadata } from "./visibility.js";
 import {
   acpAgentMessageChunkUpdateSchema,
@@ -112,46 +115,6 @@ function mapAcpToolCallStatus(
   }
 }
 
-const acpRawInputCommandSchema = z
-  .object({ command: z.string() })
-  .passthrough();
-const acpRawInputPathSchema = z
-  .object({
-    path: z.string().optional(),
-    filePath: z.string().optional(),
-    file_path: z.string().optional(),
-  })
-  .passthrough();
-
-function extractAcpCommand(event: {
-  rawInput?: unknown;
-  title?: string;
-}): string | undefined {
-  const parsed = acpRawInputCommandSchema.safeParse(event.rawInput);
-  if (parsed.success && parsed.data.command.trim().length > 0) {
-    return parsed.data.command;
-  }
-  return toOptionalString(event.title);
-}
-
-function extractAcpToolCallPath(
-  event: Pick<AcpToolCallUpdateEvent, "locations" | "rawInput">,
-): string | undefined {
-  for (const location of event.locations ?? []) {
-    if (location.path.trim().length > 0) {
-      return location.path;
-    }
-  }
-  const parsed = acpRawInputPathSchema.safeParse(event.rawInput);
-  if (!parsed.success) {
-    return undefined;
-  }
-  return [parsed.data.path, parsed.data.filePath, parsed.data.file_path].find(
-    (value): value is string =>
-      typeof value === "string" && value.trim().length > 0,
-  );
-}
-
 function extractAcpToolCallOutputText(
   event: AcpToolCallUpdateEvent,
 ): string | undefined {
@@ -177,6 +140,7 @@ function extractAcpToolCallOutputText(
 
 function buildAcpFileChangesFromToolCall(
   event: AcpToolCallUpdateEvent,
+  operation: Extract<AcpToolCallOperation, { kind: "file_change" }>,
 ): Extract<ThreadEventItem, { type: "fileChange" }>["changes"] {
   const changes: Extract<ThreadEventItem, { type: "fileChange" }>["changes"] =
     [];
@@ -195,18 +159,8 @@ function buildAcpFileChangesFromToolCall(
   if (changes.length > 0) {
     return changes;
   }
-
-  const path = extractAcpToolCallPath(event);
-  if (!path) {
-    return [];
-  }
-  if (event.kind === "edit") {
-    return [{ path, kind: "update" }];
-  }
-  if (event.kind === "delete") {
-    return [{ path, kind: "delete" }];
-  }
-  return [];
+  const [path] = operation.paths;
+  return path === undefined ? [] : [{ path, kind: operation.changeKind }];
 }
 
 function translateAcpToolCallItem(
@@ -214,41 +168,41 @@ function translateAcpToolCallItem(
   parentToolCallId: string | undefined,
 ): ThreadEventItem {
   const status = mapAcpToolCallStatus(event.status);
+  const operation = classifyAcpToolCall(event);
 
-  if (event.kind === "execute") {
-    const command = extractAcpCommand(event);
-    if (command) {
-      const outputText = extractAcpToolCallOutputText(event);
+  if (operation.kind === "command") {
+    const outputText = extractAcpToolCallOutputText(event);
+    return withParentToolCallId(
+      {
+        type: "commandExecution",
+        id: event.toolCallId,
+        command: operation.command,
+        cwd: "",
+        status,
+        approvalStatus: null,
+        ...(outputText === undefined ? {} : { aggregatedOutput: outputText }),
+        ...(status === "completed" || status === "failed"
+          ? { exitCode: status === "failed" ? 1 : 0 }
+          : {}),
+      },
+      parentToolCallId,
+    );
+  }
+
+  if (operation.kind === "file_change") {
+    const fileChanges = buildAcpFileChangesFromToolCall(event, operation);
+    if (fileChanges.length > 0) {
       return withParentToolCallId(
         {
-          type: "commandExecution",
+          type: "fileChange",
           id: event.toolCallId,
-          command,
-          cwd: "",
+          changes: fileChanges,
           status,
           approvalStatus: null,
-          ...(outputText === undefined ? {} : { aggregatedOutput: outputText }),
-          ...(status === "completed" || status === "failed"
-            ? { exitCode: status === "failed" ? 1 : 0 }
-            : {}),
         },
         parentToolCallId,
       );
     }
-  }
-
-  const fileChanges = buildAcpFileChangesFromToolCall(event);
-  if (fileChanges.length > 0) {
-    return withParentToolCallId(
-      {
-        type: "fileChange",
-        id: event.toolCallId,
-        changes: fileChanges,
-        status,
-        approvalStatus: null,
-      },
-      parentToolCallId,
-    );
   }
 
   const outputText = extractAcpToolCallOutputText(event);

--- a/plugins/provider-acp/src/interactions.test.ts
+++ b/plugins/provider-acp/src/interactions.test.ts
@@ -20,7 +20,7 @@ describe("buildAcpPermissionInteractionPayload", () => {
         toolCallId: "call-1",
         title: "Run command",
         kind: "execute",
-        command: "git status",
+        rawInput: { command: "git status" },
       },
       options: allowDenyOptions,
     });
@@ -121,15 +121,16 @@ describe("buildAcpApprovalDecisions", () => {
 //      locations = [file], no `command`.
 //   2. `external_directory` permission (write outside the project): kind
 //      "other", title = parentDir (a bare directory), locations = [file,
-//      parentDir], no `command`.
+//      parentDir], no `command`. The running `edit` tool call with the same
+//      id is the write signal.
 describe("buildAcpPermissionInteractionPayload file-change subjects", () => {
-  it("classifies an edit-kind permission without a command as a file_change subject", () => {
+  it("classifies an edit-kind permission that names a path as a file_change subject", () => {
     const payload = buildAcpPermissionInteractionPayload({
       toolCall: {
         toolCallId: "write-tool-1",
         title: "/tmp/qa-1719/notes.md",
         kind: "edit",
-        locations: ["/tmp/qa-1719/notes.md"],
+        locations: [{ path: "/tmp/qa-1719/notes.md" }],
       },
       options: allowDenyOptions,
     });
@@ -145,13 +146,25 @@ describe("buildAcpPermissionInteractionPayload file-change subjects", () => {
     });
   });
 
-  it("classifies an unclassified permission that names locations as a file_change subject with the containing directory as write scope", () => {
+  it("classifies an opencode external_directory permission as a file_change subject when the in-flight tool call is an edit", () => {
     const payload = buildAcpPermissionInteractionPayload({
       toolCall: {
         toolCallId: "write-tool-1",
         title: "/tmp/qa-1719",
         kind: "other",
-        locations: ["/tmp/qa-1719/notes.md", "/tmp/qa-1719"],
+        locations: [
+          { path: "/tmp/qa-1719/notes.md" },
+          { path: "/tmp/qa-1719" },
+        ],
+        rawInput: {
+          filepath: "/tmp/qa-1719/notes.md",
+          parentDir: "/tmp/qa-1719",
+        },
+        startedToolCall: {
+          title: "Editing notes.md",
+          kind: "edit",
+          locations: [{ path: "/tmp/qa-1719/notes.md" }],
+        },
       },
       options: allowDenyOptions,
     });
@@ -165,31 +178,75 @@ describe("buildAcpPermissionInteractionPayload file-change subjects", () => {
     });
   });
 
-  it("keeps an edit-kind permission without locations as a file_change subject with a null write scope", () => {
-    const payload = buildAcpPermissionInteractionPayload({
-      toolCall: { toolCallId: "write-tool-2", title: "notes.md", kind: "edit" },
-      options: allowDenyOptions,
-    });
-
-    expect(payload).toMatchObject({
-      subject: { kind: "file_change", itemId: "write-tool-2", writeScope: null },
-    });
-  });
-
-  it("keeps a permission that carries a shell command as a command subject", () => {
+  it("keeps a generic other-kind permission with locations as a command subject when nothing signals a write", () => {
     const payload = buildAcpPermissionInteractionPayload({
       toolCall: {
-        toolCallId: "call-5",
-        title: "/tmp/qa-1719",
+        toolCallId: "read-tool-1",
+        title: "Read secrets.txt",
         kind: "other",
-        command: "rm -rf /tmp/qa-1719",
-        locations: ["/tmp/qa-1719"],
+        locations: [{ path: "/tmp/qa-1719/secrets.txt" }],
+        startedToolCall: {
+          title: "Reading secrets.txt",
+          kind: "read",
+          locations: [{ path: "/tmp/qa-1719/secrets.txt" }],
+        },
       },
       options: allowDenyOptions,
     });
 
     expect(payload).toMatchObject({
-      subject: { kind: "command", command: "rm -rf /tmp/qa-1719" },
+      subject: { kind: "command", command: "Read secrets.txt" },
+    });
+  });
+
+  it("keeps an edit-kind permission without any path as a command subject, like the timeline", () => {
+    const payload = buildAcpPermissionInteractionPayload({
+      toolCall: {
+        toolCallId: "write-tool-2",
+        title: "Edit file",
+        kind: "edit",
+      },
+      options: allowDenyOptions,
+    });
+
+    expect(payload).toMatchObject({
+      subject: {
+        kind: "command",
+        itemId: "write-tool-2",
+        command: "Edit file",
+      },
+    });
+  });
+
+  it("keeps a move-kind permission as a command subject, like the timeline", () => {
+    const payload = buildAcpPermissionInteractionPayload({
+      toolCall: {
+        toolCallId: "move-tool-1",
+        title: "Move notes.md",
+        kind: "move",
+        locations: [{ path: "/tmp/a/notes.md" }, { path: "/tmp/b/notes.md" }],
+      },
+      options: allowDenyOptions,
+    });
+
+    expect(payload).toMatchObject({
+      subject: { kind: "command", command: "Move notes.md" },
+    });
+  });
+
+  it("uses a null write scope when a blank location path is the only one", () => {
+    const payload = buildAcpPermissionInteractionPayload({
+      toolCall: {
+        toolCallId: "write-tool-3",
+        kind: "edit",
+        locations: [{ path: "" }],
+        rawInput: { path: "/tmp/qa-1719/notes.md" },
+      },
+      options: allowDenyOptions,
+    });
+
+    expect(payload).toMatchObject({
+      subject: { kind: "file_change", writeScope: "/tmp/qa-1719/notes.md" },
     });
   });
 });

--- a/plugins/provider-acp/src/interactions.test.ts
+++ b/plugins/provider-acp/src/interactions.test.ts
@@ -113,3 +113,83 @@ describe("buildAcpApprovalDecisions", () => {
     expect(buildAcpApprovalDecisions([])).toEqual(["deny"]);
   });
 });
+
+// Fix for get-bb/bb#1719: an ACP `session/request_permission` for a file
+// write must surface as a file-change approval subject, not as a command
+// approval whose "command" is a bare path. Two shapes opencode sends:
+//   1. `write`/`edit` permission: kind "edit", title = file path,
+//      locations = [file], no `command`.
+//   2. `external_directory` permission (write outside the project): kind
+//      "other", title = parentDir (a bare directory), locations = [file,
+//      parentDir], no `command`.
+describe("buildAcpPermissionInteractionPayload file-change subjects", () => {
+  it("classifies an edit-kind permission without a command as a file_change subject", () => {
+    const payload = buildAcpPermissionInteractionPayload({
+      toolCall: {
+        toolCallId: "write-tool-1",
+        title: "/tmp/qa-1719/notes.md",
+        kind: "edit",
+        locations: ["/tmp/qa-1719/notes.md"],
+      },
+      options: allowDenyOptions,
+    });
+
+    expect(payload).toMatchObject({
+      kind: "approval",
+      subject: {
+        kind: "file_change",
+        itemId: "write-tool-1",
+        writeScope: "/tmp/qa-1719/notes.md",
+        sessionGrant: null,
+      },
+    });
+  });
+
+  it("classifies an unclassified permission that names locations as a file_change subject with the containing directory as write scope", () => {
+    const payload = buildAcpPermissionInteractionPayload({
+      toolCall: {
+        toolCallId: "write-tool-1",
+        title: "/tmp/qa-1719",
+        kind: "other",
+        locations: ["/tmp/qa-1719/notes.md", "/tmp/qa-1719"],
+      },
+      options: allowDenyOptions,
+    });
+
+    expect(payload).toMatchObject({
+      subject: {
+        kind: "file_change",
+        itemId: "write-tool-1",
+        writeScope: "/tmp/qa-1719",
+      },
+    });
+  });
+
+  it("keeps an edit-kind permission without locations as a file_change subject with a null write scope", () => {
+    const payload = buildAcpPermissionInteractionPayload({
+      toolCall: { toolCallId: "write-tool-2", title: "notes.md", kind: "edit" },
+      options: allowDenyOptions,
+    });
+
+    expect(payload).toMatchObject({
+      subject: { kind: "file_change", itemId: "write-tool-2", writeScope: null },
+    });
+  });
+
+  it("keeps a permission that carries a shell command as a command subject", () => {
+    const payload = buildAcpPermissionInteractionPayload({
+      toolCall: {
+        toolCallId: "call-5",
+        title: "/tmp/qa-1719",
+        kind: "other",
+        command: "rm -rf /tmp/qa-1719",
+        locations: ["/tmp/qa-1719"],
+      },
+      options: allowDenyOptions,
+    });
+
+    expect(payload).toMatchObject({
+      subject: { kind: "command", command: "rm -rf /tmp/qa-1719" },
+    });
+  });
+});

--- a/plugins/provider-acp/src/interactions.ts
+++ b/plugins/provider-acp/src/interactions.ts
@@ -14,8 +14,15 @@ import {
   type PendingInteractionResolution,
   isApprovalPendingInteractionPayload,
   isApprovalPendingInteractionResolution,
-  toOptionalString,
 } from "@get-bb/plugin-sdk/provider-bridge";
+import {
+  type AcpToolCallOperation,
+  type AcpToolCallOperationInput,
+  classifyAcpToolCall,
+  extractAcpCommand,
+  extractAcpToolCallPaths,
+  resolveAcpFileChangeWriteScope,
+} from "./tool-call-operation.js";
 import type { AcpPermissionOptionKind } from "./wire.js";
 
 /**
@@ -26,65 +33,29 @@ export interface AcpPermissionResponse {
   decision: "allow_once" | "allow_for_session" | "deny";
 }
 
-export interface AcpPermissionToolCall {
+export interface AcpPermissionToolCall extends AcpToolCallOperationInput {
   toolCallId: string;
-  title?: string | undefined;
-  kind?: string | undefined;
-  command?: string | undefined;
-  /** Absolute paths from the ACP tool call's `locations`. */
-  locations?: readonly string[] | undefined;
-}
-
-/** ACP tool kinds whose permission is a request to change files on disk. */
-const ACP_FILE_CHANGE_TOOL_KINDS: ReadonlySet<string> = new Set([
-  "edit",
-  "delete",
-  "move",
-]);
-
-/**
- * True when the permission is about changing files rather than running a
- * shell command: an edit/delete/move tool, or an unclassified tool (ACP kind
- * `other`, or no kind) that names filesystem locations. The latter is what
- * opencode sends for its `external_directory` permission (a write outside the
- * project): kind `other`, title = parent directory, locations = [file, dir].
- * Anything with a shell `command` stays a command approval.
- */
-function isAcpFileChangePermission(toolCall: AcpPermissionToolCall): boolean {
-  if (toolCall.command !== undefined) {
-    return false;
-  }
-  if (
-    toolCall.kind !== undefined &&
-    ACP_FILE_CHANGE_TOOL_KINDS.has(toolCall.kind)
-  ) {
-    return true;
-  }
-  return (
-    (toolCall.kind === undefined || toolCall.kind === "other") &&
-    (toolCall.locations?.length ?? 0) > 0
-  );
+  /**
+   * The in-flight `tool_call` with the same id, when the agent started one
+   * before it asked. opencode's `external_directory` permission (a write
+   * outside the project) arrives as the generic kind `other` with a bare
+   * directory title; the running `edit` tool call is the write signal.
+   */
+  startedToolCall?: AcpToolCallOperationInput | undefined;
 }
 
 /**
- * The directory boundary of a file-change permission: the location that
- * contains every other location (opencode's `external_directory` sends
- * `[file, parentDir]`), else the first location.
+ * The operation an ACP permission asks about: the permission's own tool call
+ * when it classifies, else the in-flight tool call it belongs to.
  */
-function acpFileChangeWriteScope(
-  locations: readonly string[] | undefined,
-): string | null {
-  if (!locations || locations.length === 0) {
-    return null;
+function classifyAcpPermission(
+  toolCall: AcpPermissionToolCall,
+): AcpToolCallOperation {
+  const own = classifyAcpToolCall(toolCall);
+  if (own.kind !== "generic" || !toolCall.startedToolCall) {
+    return own;
   }
-  const root = locations.find((candidate) =>
-    locations.every(
-      (other) =>
-        other === candidate ||
-        other.startsWith(candidate.endsWith("/") ? candidate : `${candidate}/`),
-    ),
-  );
-  return toOptionalString(root ?? locations[0]) ?? null;
+  return classifyAcpToolCall(toolCall.startedToolCall);
 }
 
 export function buildAcpApprovalDecisions(
@@ -106,16 +77,11 @@ export function buildAcpApprovalDecisions(
   return decisions.length > 0 ? decisions : ["deny"];
 }
 
-function buildOpaqueAcpPermissionCommand(toolCall: {
-  command?: string | undefined;
-  title?: string | undefined;
-  kind?: string | undefined;
-}): string {
+function buildOpaqueAcpPermissionCommand(
+  toolCall: AcpPermissionToolCall,
+): string {
   return (
-    toOptionalString(toolCall.command) ??
-    toOptionalString(toolCall.title) ??
-    toolCall.kind ??
-    "ACP permission request"
+    extractAcpCommand(toolCall) ?? toolCall.kind ?? "ACP permission request"
   );
 }
 
@@ -126,22 +92,35 @@ export function buildAcpPermissionInteractionPayload(args: {
 }): PendingInteractionPayload {
   const toolCall = args.toolCall;
   const availableDecisions = buildAcpApprovalDecisions(args.options);
-  if (toolCall && isAcpFileChangePermission(toolCall)) {
+  const operation = toolCall ? classifyAcpPermission(toolCall) : undefined;
+  if (toolCall && operation?.kind === "file_change") {
+    const ownPaths = extractAcpToolCallPaths(toolCall);
     return {
       kind: "approval",
       subject: {
         kind: "file_change",
         itemId: toolCall.toolCallId,
-        writeScope: acpFileChangeWriteScope(toolCall.locations),
+        // The permission's own locations bound the write (opencode's
+        // external_directory names [file, parentDir]); the in-flight tool
+        // call's paths are the fallback.
+        writeScope: resolveAcpFileChangeWriteScope(
+          ownPaths.length > 0 ? ownPaths : operation.paths,
+        ),
         sessionGrant: null,
       },
       reason: null,
       availableDecisions,
     };
   }
-  const command = toolCall
-    ? buildOpaqueAcpPermissionCommand(toolCall)
-    : "ACP permission request";
+  // Commands and generic tools both take the command subject: it is the one
+  // canonical subject that carries free text, and the fallback chain
+  // command → title → kind → fixed text always yields a grantable subject.
+  const command =
+    operation?.kind === "command"
+      ? operation.command
+      : toolCall
+        ? buildOpaqueAcpPermissionCommand(toolCall)
+        : "ACP permission request";
   return {
     kind: "approval",
     subject: {

--- a/plugins/provider-acp/src/interactions.ts
+++ b/plugins/provider-acp/src/interactions.ts
@@ -31,6 +31,60 @@ export interface AcpPermissionToolCall {
   title?: string | undefined;
   kind?: string | undefined;
   command?: string | undefined;
+  /** Absolute paths from the ACP tool call's `locations`. */
+  locations?: readonly string[] | undefined;
+}
+
+/** ACP tool kinds whose permission is a request to change files on disk. */
+const ACP_FILE_CHANGE_TOOL_KINDS: ReadonlySet<string> = new Set([
+  "edit",
+  "delete",
+  "move",
+]);
+
+/**
+ * True when the permission is about changing files rather than running a
+ * shell command: an edit/delete/move tool, or an unclassified tool (ACP kind
+ * `other`, or no kind) that names filesystem locations. The latter is what
+ * opencode sends for its `external_directory` permission (a write outside the
+ * project): kind `other`, title = parent directory, locations = [file, dir].
+ * Anything with a shell `command` stays a command approval.
+ */
+function isAcpFileChangePermission(toolCall: AcpPermissionToolCall): boolean {
+  if (toolCall.command !== undefined) {
+    return false;
+  }
+  if (
+    toolCall.kind !== undefined &&
+    ACP_FILE_CHANGE_TOOL_KINDS.has(toolCall.kind)
+  ) {
+    return true;
+  }
+  return (
+    (toolCall.kind === undefined || toolCall.kind === "other") &&
+    (toolCall.locations?.length ?? 0) > 0
+  );
+}
+
+/**
+ * The directory boundary of a file-change permission: the location that
+ * contains every other location (opencode's `external_directory` sends
+ * `[file, parentDir]`), else the first location.
+ */
+function acpFileChangeWriteScope(
+  locations: readonly string[] | undefined,
+): string | null {
+  if (!locations || locations.length === 0) {
+    return null;
+  }
+  const root = locations.find((candidate) =>
+    locations.every(
+      (other) =>
+        other === candidate ||
+        other.startsWith(candidate.endsWith("/") ? candidate : `${candidate}/`),
+    ),
+  );
+  return toOptionalString(root ?? locations[0]) ?? null;
 }
 
 export function buildAcpApprovalDecisions(
@@ -71,6 +125,20 @@ export function buildAcpPermissionInteractionPayload(args: {
   options: readonly { kind: AcpPermissionOptionKind }[];
 }): PendingInteractionPayload {
   const toolCall = args.toolCall;
+  const availableDecisions = buildAcpApprovalDecisions(args.options);
+  if (toolCall && isAcpFileChangePermission(toolCall)) {
+    return {
+      kind: "approval",
+      subject: {
+        kind: "file_change",
+        itemId: toolCall.toolCallId,
+        writeScope: acpFileChangeWriteScope(toolCall.locations),
+        sessionGrant: null,
+      },
+      reason: null,
+      availableDecisions,
+    };
+  }
   const command = toolCall
     ? buildOpaqueAcpPermissionCommand(toolCall)
     : "ACP permission request";
@@ -85,7 +153,7 @@ export function buildAcpPermissionInteractionPayload(args: {
       sessionGrant: null,
     },
     reason: null,
-    availableDecisions: buildAcpApprovalDecisions(args.options),
+    availableDecisions,
   };
 }
 

--- a/plugins/provider-acp/src/tool-call-operation.test.ts
+++ b/plugins/provider-acp/src/tool-call-operation.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyAcpToolCall,
+  resolveAcpFileChangeWriteScope,
+} from "./tool-call-operation.js";
+
+describe("classifyAcpToolCall", () => {
+  it("treats an other-kind tool with locations as generic, not as a file change", () => {
+    expect(
+      classifyAcpToolCall({
+        kind: "other",
+        title: "/tmp/qa-1719",
+        locations: [{ path: "/tmp/qa-1719/notes.md" }],
+      }),
+    ).toEqual({ kind: "generic" });
+  });
+
+  it("treats a move-kind tool and a location-free edit as generic", () => {
+    expect(
+      classifyAcpToolCall({
+        kind: "move",
+        locations: [{ path: "/tmp/a" }, { path: "/tmp/b" }],
+      }),
+    ).toEqual({ kind: "generic" });
+    expect(classifyAcpToolCall({ kind: "edit", title: "Edit" })).toEqual({
+      kind: "generic",
+    });
+  });
+
+  it("drops blank location paths and falls back to rawInput paths", () => {
+    expect(
+      classifyAcpToolCall({
+        kind: "delete",
+        locations: [{ path: "  " }],
+        rawInput: { file_path: "/tmp/qa-1719/old.md" },
+      }),
+    ).toEqual({
+      kind: "file_change",
+      changeKind: "delete",
+      paths: ["/tmp/qa-1719/old.md"],
+    });
+    expect(
+      classifyAcpToolCall({ kind: "edit", locations: [{ path: "" }] }),
+    ).toEqual({ kind: "generic" });
+  });
+
+  it("classifies diff content as a file change whatever the kind", () => {
+    expect(
+      classifyAcpToolCall({
+        kind: "other",
+        content: [{ type: "diff", path: "/tmp/x.md", newText: "hi" }],
+      }),
+    ).toEqual({
+      kind: "file_change",
+      changeKind: "update",
+      paths: ["/tmp/x.md"],
+    });
+  });
+});
+
+describe("resolveAcpFileChangeWriteScope", () => {
+  it("returns the location that contains every other location", () => {
+    expect(
+      resolveAcpFileChangeWriteScope([
+        "/tmp/qa-1719/notes.md",
+        "/tmp/qa-1719/",
+      ]),
+    ).toBe("/tmp/qa-1719");
+  });
+
+  it("normalizes .. segments so a path outside the candidate does not pass a raw prefix test", () => {
+    expect(
+      resolveAcpFileChangeWriteScope(["/repo/../secret/key", "/repo"]),
+    ).toBeNull();
+    expect(
+      resolveAcpFileChangeWriteScope(["/repo/src/../notes.md", "/repo"]),
+    ).toBe("/repo");
+  });
+
+  it("returns null for paths in different directories and for a lookalike prefix", () => {
+    expect(
+      resolveAcpFileChangeWriteScope(["/tmp/a/notes.md", "/tmp/b/notes.md"]),
+    ).toBeNull();
+    expect(
+      resolveAcpFileChangeWriteScope(["/tmp/qa-17190/x", "/tmp/qa-1719"]),
+    ).toBeNull();
+  });
+
+  it("ignores blank paths and never yields an empty scope", () => {
+    expect(resolveAcpFileChangeWriteScope(["", "  "])).toBeNull();
+    expect(resolveAcpFileChangeWriteScope(["", "/tmp/qa-1719/notes.md"])).toBe(
+      "/tmp/qa-1719/notes.md",
+    );
+  });
+});

--- a/plugins/provider-acp/src/tool-call-operation.ts
+++ b/plugins/provider-acp/src/tool-call-operation.ts
@@ -1,0 +1,158 @@
+/**
+ * One classifier for ACP tool calls.
+ *
+ * The timeline (`event-translation.ts`) and the permission mapping
+ * (`interactions.ts`) both decide whether an ACP tool call is a shell command,
+ * a file change, or a generic tool. They must agree: the server materializes a
+ * permission subject as a timeline item with the ACP tool-call id, so a
+ * mismatch flips one row between item types (get-bb/bb#1719).
+ */
+
+import path from "node:path";
+import { toOptionalString } from "@get-bb/plugin-sdk/provider-bridge";
+import { z } from "zod";
+import type { AcpToolCallContent } from "./wire.js";
+
+/** The fields of an ACP tool call that drive classification. */
+export interface AcpToolCallOperationInput {
+  title?: string | undefined;
+  kind?: string | undefined;
+  content?: readonly AcpToolCallContent[] | undefined;
+  locations?: readonly { path: string }[] | undefined;
+  rawInput?: unknown;
+}
+
+export type AcpToolCallOperation =
+  | { kind: "command"; command: string }
+  | {
+      kind: "file_change";
+      changeKind: "update" | "delete";
+      /** Non-blank paths the tool call names, in wire order. */
+      paths: readonly string[];
+    }
+  | { kind: "generic" };
+
+const acpRawInputCommandSchema = z
+  .object({ command: z.string() })
+  .passthrough();
+const acpRawInputPathSchema = z
+  .object({
+    path: z.string().optional(),
+    filePath: z.string().optional(),
+    file_path: z.string().optional(),
+  })
+  .passthrough();
+
+/** The shell command of an execute tool call: `rawInput.command`, else title. */
+export function extractAcpCommand(
+  event: Pick<AcpToolCallOperationInput, "rawInput" | "title">,
+): string | undefined {
+  const parsed = acpRawInputCommandSchema.safeParse(event.rawInput);
+  if (parsed.success && parsed.data.command.trim().length > 0) {
+    return parsed.data.command;
+  }
+  return toOptionalString(event.title);
+}
+
+function isNonBlank(value: string | undefined): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Every non-blank path the tool call names: diff content paths, then
+ * `locations`, then the conventional `rawInput` path fields.
+ */
+export function extractAcpToolCallPaths(
+  event: Pick<AcpToolCallOperationInput, "content" | "locations" | "rawInput">,
+): string[] {
+  const paths: string[] = [];
+  for (const entry of event.content ?? []) {
+    if (entry.type === "diff" && isNonBlank(entry.path)) {
+      paths.push(entry.path);
+    }
+  }
+  for (const location of event.locations ?? []) {
+    if (isNonBlank(location.path)) {
+      paths.push(location.path);
+    }
+  }
+  if (paths.length > 0) {
+    return paths;
+  }
+  const parsed = acpRawInputPathSchema.safeParse(event.rawInput);
+  if (!parsed.success) {
+    return [];
+  }
+  const rawInputPath = [
+    parsed.data.path,
+    parsed.data.filePath,
+    parsed.data.file_path,
+  ].find(isNonBlank);
+  return rawInputPath === undefined ? [] : [rawInputPath];
+}
+
+/**
+ * Classify an ACP tool call. An `execute` tool with a command is a command. A
+ * tool with diff content, or an `edit`/`delete` tool that names a path, is a
+ * file change. Everything else, including ACP's generic `other` kind, is a
+ * generic tool: locations alone are not a write signal, because read-only
+ * tools name locations too.
+ */
+export function classifyAcpToolCall(
+  event: AcpToolCallOperationInput,
+): AcpToolCallOperation {
+  if (event.kind === "execute") {
+    const command = extractAcpCommand(event);
+    if (command) {
+      return { kind: "command", command };
+    }
+  }
+  const paths = extractAcpToolCallPaths(event);
+  if (paths.length === 0) {
+    return { kind: "generic" };
+  }
+  const hasDiff = (event.content ?? []).some((entry) => entry.type === "diff");
+  if (hasDiff || event.kind === "edit") {
+    return { kind: "file_change", changeKind: "update", paths };
+  }
+  if (event.kind === "delete") {
+    return { kind: "file_change", changeKind: "delete", paths };
+  }
+  return { kind: "generic" };
+}
+
+/**
+ * The write boundary of a file change: the one named path that contains every
+ * other named path (opencode's `external_directory` permission names
+ * `[file, parentDir]`), else null. Paths are normalized first so `..`
+ * segments cannot fake containment. Linear in the number of paths.
+ */
+export function resolveAcpFileChangeWriteScope(
+  paths: readonly string[],
+): string | null {
+  const normalized = paths.filter(isNonBlank).map((entry) => {
+    const value = path.normalize(entry);
+    return value.length > 1 && value.endsWith(path.sep)
+      ? value.slice(0, -1)
+      : value;
+  });
+  const [first, ...rest] = normalized;
+  if (first === undefined) {
+    return null;
+  }
+  let candidate = first;
+  for (const entry of rest) {
+    if (entry.length < candidate.length) {
+      candidate = entry;
+    }
+  }
+  const prefix = candidate.endsWith(path.sep)
+    ? candidate
+    : candidate + path.sep;
+  for (const entry of normalized) {
+    if (entry !== candidate && !entry.startsWith(prefix)) {
+      return null;
+    }
+  }
+  return candidate;
+}


### PR DESCRIPTION
## What was wrong

When an ACP agent (observed with OpenCode) asked permission to write a file, bb rendered the request as a **command** approval whose "command" was a bare directory path, and the timeline showed the item as `commandExecution`. The ACP bridge only forwarded the tool call's title/kind into the interaction payload and dropped `toolCall.locations[].path`, so `buildAcpPermissionInteractionPayload` had no file information and fell back to the command shape for every non-shell request. Report: https://get-bb.github.io/reports/issues/1719.html

## What changed

All changes are in `plugins/provider-acp`; no server/daemon wire shape changed (no `HOST_DAEMON_PROTOCOL_VERSION` bump).

- `src/tool-call-operation.ts` (new): one classifier, `classifyAcpToolCall`, that yields `command` / `file_change` (with the named paths) / `generic`. Both the timeline translator and the permission mapping use it, so an approval row and its timeline item can never disagree. `move` and location-free `edit` stay `generic` in both. `resolveAcpFileChangeWriteScope` normalizes paths, drops blank ones, and returns the one named path that contains all the others (linear scan) or `null` — so `..` segments, cross-directory sets, and lookalike prefixes never produce a false write root.
- `src/bridge/bridge.ts`: `handlePermissionRequest` forwards `toolCall.locations[].path` into the normalized permission tool call, and passes the in-flight `edit` tool call with the same id (from `translator.resolveState().toolCallEventsByCallId`) as the positive write signal for OpenCode's `external_directory` request, whose own kind is the generic `other`.
- `src/interactions.ts`: `AcpPermissionToolCall` gains `locations`; `buildAcpPermissionInteractionPayload` returns a `file_change` subject (`itemId` = tool-call id, `writeScope` from the resolver, `sessionGrant: null`) when the shared classifier says file change; a request with a shell command, or an `other`-kind tool without a write signal, keeps the command fallback.
- `src/event-translation.ts`: `translateAcpToolCallItem` uses the shared classifier (same behavior as before for existing shapes).
- `src/bridge/fake-acp-agent.mjs`: fixture support for the `external_directory` permission shape.

Deviation from the report: the report proposed classifying `edit`/`delete`/`move`, or `other`+locations, as file changes. SlopCop's review showed that rule diverges from the timeline classifier and treats read-only `other` tools as writes, so it was replaced by the shared classifier above (findings addressed on the inline threads).

## Tests

- `src/tool-call-operation.test.ts` (new): classifier and write-scope cases — `move`, location-free `edit`, generic `other`+locations, `..` / cross-directory / lookalike-prefix paths, blank paths.
- `src/interactions.test.ts`: OpenCode `edit`-kind write → `file_change`; OpenCode `external_directory` (`other` kind, bare directory title) with the in-flight edit → `file_change` with `writeScope: "/tmp/qa-1719"`; `edit` without locations → `writeScope: null`; a shell-command request stays `command`. The three file-change cases failed before the change (`subject.kind === "command"`).
- `src/bridge/bridge.test.ts`: end-to-end bridge test for the OpenCode `external_directory` shape — asserts the `file_change` subject and that Allow settles the ACP request.

## How I verified

`pnpm exec turbo run lint typecheck test --filter=bb-plugin-provider-acp --force` → 9 files / 161 tests pass, lint/typecheck/prettier clean. CI green.

Fixes #1719

> AGENT GENERATED: by Claude Opus 5
