### PR TITLE
Allow native add-on install scripts under npm 12's allowScripts policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ To run the newest automated build instead:
 npx bb-app@nightly
 ```
 
+npm 12 and later block dependency install scripts by default. bb needs those
+scripts to build its native add-ons. If your npm version is 12 or later, allow
+the scripts for the install:
+
+```bash
+npx --allow-scripts=better-sqlite3,node-pty,@parcel/watcher bb-app@latest
+```
+
+Or set the policy once for all global installs:
+
+```bash
+npm config set allow-scripts=better-sqlite3,node-pty,@parcel/watcher --location=user
+```
+
 bb uses the provider CLI you already have authenticated.
 
 For install requirements, provider setup, configuration, and package-focused
@@ -199,7 +213,30 @@ Error: Could not locate the bindings file. Tried:
  → .../node_modules/better-sqlite3/build/better_sqlite3.node
 ```
 
-The usual cause is `ignore-scripts=true` in your `~/.npmrc`. Set the
+There are two usual causes.
+
+The first cause is npm 12 or later. Since npm 12, npm blocks dependency install
+scripts by default and prints
+`npm warn install-scripts N packages had install scripts blocked`. Name bb's
+native add-ons in `--allow-scripts` to let this one command run their install
+scripts:
+
+```bash
+npx --allow-scripts=better-sqlite3,node-pty,@parcel/watcher bb-app@latest
+```
+
+For a permanent install with the same setting, use:
+
+```bash
+npm install -g --allow-scripts=better-sqlite3,node-pty,@parcel/watcher bb-app
+bb-app
+```
+
+To allow them for all global installs on this machine, run
+`npm config set allow-scripts=better-sqlite3,node-pty,@parcel/watcher --location=user`.
+npm 10 and 11 accept or ignore the flag, so it is safe on every supported Node.
+
+The second cause is `ignore-scripts=true` in your `~/.npmrc`. Set the
 `npm_config_ignore_scripts` environment variable to let this one command run its
 install scripts:
 

--- a/apps/host-daemon/src/protocol-self-update.test.ts
+++ b/apps/host-daemon/src/protocol-self-update.test.ts
@@ -92,7 +92,12 @@ describe("protocol self-update", () => {
     expect(test.runProcess).toHaveBeenCalledOnce();
     expect(test.runProcess).toHaveBeenCalledWith(
       "npm",
-      ["install", "-g", expect.stringContaining("bb-app-update-")],
+      [
+        "install",
+        "-g",
+        "--allow-scripts=better-sqlite3,node-pty,@parcel/watcher",
+        expect.stringContaining("bb-app-update-"),
+      ],
       {
         env: expect.objectContaining({
           PATH: `${dirname(process.execPath)}${delimiter}/usr/bin:/bin`,
@@ -114,6 +119,7 @@ describe("protocol self-update", () => {
       [
         "install",
         "-g",
+        "--allow-scripts=better-sqlite3,node-pty,@parcel/watcher",
         "--prefix",
         "/machine-data/npm",
         expect.stringContaining("bb-app-update-"),
@@ -132,7 +138,12 @@ describe("protocol self-update", () => {
 
     expect(test.runProcess).toHaveBeenCalledWith(
       "npm",
-      ["install", "-g", expect.stringContaining("bb-app-update-")],
+      [
+        "install",
+        "-g",
+        "--allow-scripts=better-sqlite3,node-pty,@parcel/watcher",
+        expect.stringContaining("bb-app-update-"),
+      ],
       expect.any(Object),
     );
   });

--- a/apps/host-daemon/src/protocol-self-update.ts
+++ b/apps/host-daemon/src/protocol-self-update.ts
@@ -127,6 +127,14 @@ const defaultRunProcess: SelfUpdateProcessRunner = async (
   await execFileAsync(command, args, options);
 };
 
+// bb-app depends on native add-ons whose binaries are fetched or built by npm
+// lifecycle scripts. npm >= 12 blocks dependency install scripts for global
+// installs unless they are named in --allow-scripts; the installed package's
+// own package.json#allowScripts is not consulted for `npm install -g`.
+// npm 10 ignores the unknown flag; npm 11 accepts it.
+const BB_APP_ALLOW_SCRIPTS_ARG =
+  "--allow-scripts=better-sqlite3,node-pty,@parcel/watcher";
+
 async function defaultInstallTarball(
   tarballPath: string,
   runProcess: SelfUpdateProcessRunner,
@@ -146,9 +154,13 @@ async function defaultInstallTarball(
   }
   const prefixArgs =
     configuredPrefix === undefined ? [] : ["--prefix", configuredPrefix];
-  await runProcess("npm", ["install", "-g", ...prefixArgs, tarballPath], {
-    env: { ...process.env, PATH: path },
-  });
+  await runProcess(
+    "npm",
+    ["install", "-g", BB_APP_ALLOW_SCRIPTS_ARG, ...prefixArgs, tarballPath],
+    {
+      env: { ...process.env, PATH: path },
+    },
+  );
 }
 
 export function createProtocolSelfUpdater(

--- a/apps/server/src/assets/install-machine.sh
+++ b/apps/server/src/assets/install-machine.sh
@@ -181,6 +181,13 @@ canonical_data_dir=$(node -e '
 # Keep the package private to this enrollment. Besides avoiding system-prefix
 # permissions, this lets one machine follow servers running different builds.
 machine_npm_prefix="$canonical_data_dir/npm"
+# bb-app depends on native add-ons whose binaries are fetched or built by npm
+# lifecycle scripts. npm >= 12 blocks dependency install scripts by default
+# for global installs unless they are named in --allow-scripts (the installed
+# package's own package.json#allowScripts is not consulted for -g / npx).
+# npm 10 ignores the unknown flag; npm 11 accepts it.
+bb_app_native_modules="better-sqlite3,node-pty,@parcel/watcher"
+bb_app_allow_scripts="--allow-scripts=$bb_app_native_modules"
 port_registry_dir="$HOME/.bb-machines/host-daemon-ports"
 mkdir -p "$port_registry_dir"
 
@@ -388,7 +395,7 @@ if [ "$package_status" -ge 200 ] && [ "$package_status" -lt 300 ]; then
   require_npm
   complete_step "Downloaded the server's bb-app package"
   active_step "Installing the server's bb-app build"
-  if ! npm install -g --prefix "$machine_npm_prefix" "$package_file"; then
+  if ! npm install -g "$bb_app_allow_scripts" --prefix "$machine_npm_prefix" "$package_file"; then
     rm -rf "$package_dir"
     fail_step "Could not install bb-app for this machine. Check the npm error above, then rerun this command."
     exit 1
@@ -406,7 +413,7 @@ elif [ "$package_status" = 404 ]; then
   require_npm
   warning_step "The server does not provide its bb-app package"
   active_step "Installing bb-app from the npm registry"
-  if ! npm install -g --prefix "$machine_npm_prefix" bb-app; then
+  if ! npm install -g "$bb_app_allow_scripts" --prefix "$machine_npm_prefix" bb-app; then
     rm -rf "$package_dir"
     fail_step "Could not install bb-app for this machine. Check the npm error above, then rerun this command."
     exit 1
@@ -424,6 +431,19 @@ if [ -n "$bb_app_npm_prefix" ]; then
   bb_app="$bb_app_npm_prefix/bin/bb-app"
   if [ ! -x "$bb_app" ]; then
     fail_step "npm installed bb-app, but did not create the expected executable at $bb_app."
+    exit 1
+  fi
+  # Fail loudly if npm skipped the native add-on install scripts (npm >= 12
+  # allowScripts policy, or ignore-scripts=true in an npmrc). Without this
+  # check the join only fails later, in the daemon, with a raw stack trace.
+  bb_app_root="$bb_app_npm_prefix/lib/node_modules/bb-app"
+  if ! node -e '
+    const root = process.argv[1];
+    require(root + "/node_modules/better-sqlite3");
+    require(root + "/node_modules/node-pty");
+  ' "$bb_app_root" >/dev/null 2>&1; then
+    fail_step "npm installed bb-app, but its native add-ons (better-sqlite3, node-pty) did not load."
+    detail "npm did not run their install scripts. Check the npm warnings above. If they mention allowScripts or ignore-scripts, rerun this command with: npm_config_allow_scripts=$bb_app_native_modules npm_config_ignore_scripts=false" >&2
     exit 1
   fi
 fi

--- a/apps/server/test/app/install-machine-script.test.ts
+++ b/apps/server/test/app/install-machine-script.test.ts
@@ -1,6 +1,7 @@
 import { spawn, spawnSync } from "node:child_process";
 import {
   chmodSync,
+  existsSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
@@ -160,7 +161,11 @@ process.on("SIGTERM", () => server.close(() => process.exit(0)));
 
 // Mocks curl to serve the redeem endpoint and answer the bb-app tarball
 // download with the given status; npm records invocations and fabricates a
-// bb-app that enrolls into whatever BB_DATA_DIR the script hands it.
+// bb-app that enrolls into whatever BB_DATA_DIR the script hands it. Like a
+// real install, the fake npm lays out bb-app's native add-ons as loadable
+// modules under lib/node_modules/bb-app/node_modules; when
+// FAKE_NPM_SKIP_NATIVE_MODULES is set it leaves them empty, which mimics npm
+// >= 12 blocking their install scripts (or ignore-scripts=true).
 function writeServerInstallTools(
   fixture: ReturnType<typeof createFixture>,
   artifactStatus: 200 | 404,
@@ -201,6 +206,12 @@ done
 mkdir -p "$prefix/bin"
 cp "${bbAppTemplatePath}" "$prefix/bin/bb-app"
 chmod +x "$prefix/bin/bb-app"
+for module in better-sqlite3 node-pty; do
+  mkdir -p "$prefix/lib/node_modules/bb-app/node_modules/$module"
+  if [ -z "$FAKE_NPM_SKIP_NATIVE_MODULES" ]; then
+    printf '%s\n' 'module.exports = {};' >"$prefix/lib/node_modules/bb-app/node_modules/$module/index.js"
+  fi
+done
 `,
   );
 }
@@ -369,7 +380,7 @@ describe("machine install script", () => {
       "utf8",
     );
     expect(npmInvocation).toMatch(
-      /^install -g --prefix \/.*\/data\/npm \/.*bb-app\..*\.tgz$/mu,
+      /^install -g --allow-scripts=better-sqlite3,node-pty,@parcel\/watcher --prefix \/.*\/data\/npm \/.*bb-app\..*\.tgz$/mu,
     );
     const daemonPid = Number(
       readFileSync(join(fixture.dataDir, "install-daemon.pid"), "utf8"),
@@ -390,7 +401,7 @@ describe("machine install script", () => {
       "utf8",
     );
     expect(npmInvocation).toMatch(
-      /^install -g --prefix \/.*\/data\/npm \/.*bb-app\..*\.tgz$/mu,
+      /^install -g --allow-scripts=better-sqlite3,node-pty,@parcel\/watcher --prefix \/.*\/data\/npm \/.*bb-app\..*\.tgz$/mu,
     );
     expect(npmInvocation).not.toContain("bb-app\n");
     expect(readFileSync(join(fixture.dataDir, "curl.log"), "utf8")).toContain(
@@ -432,12 +443,31 @@ describe("machine install script", () => {
 
     expect(result.status, result.stderr).toBe(0);
     expect(readFileSync(join(fixture.dataDir, "npm.log"), "utf8")).toMatch(
-      /^install -g --prefix \/.*\/data\/npm bb-app\n$/u,
+      /^install -g --allow-scripts=better-sqlite3,node-pty,@parcel\/watcher --prefix \/.*\/data\/npm bb-app\n$/u,
     );
     const daemonPid = Number(
       readFileSync(join(fixture.dataDir, "install-daemon.pid"), "utf8"),
     );
     process.kill(daemonPid, "SIGTERM");
+  });
+
+  it("fails loudly when npm skipped the native add-on install scripts", () => {
+    const fixture = createFixture();
+    writeServerInstallTools(fixture, 200);
+    const result = runScript(JOIN_ARGS, fixture, {
+      BB_INSTALL_SKIP_SERVICE: "1",
+      FAKE_NPM_SKIP_NATIVE_MODULES: "1",
+    });
+
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toContain(
+      "npm installed bb-app, but its native add-ons (better-sqlite3, node-pty) did not load.",
+    );
+    expect(result.stderr).toContain(
+      "npm_config_allow_scripts=better-sqlite3,node-pty,@parcel/watcher",
+    );
+    // The installer must stop before it starts the temporary host daemon.
+    expect(existsSync(join(fixture.dataDir, "install-daemon.pid"))).toBe(false);
   });
 
   it("defaults the data dir to a per-server directory under ~/.bb-machines", () => {

--- a/packages/bb-app/README.md
+++ b/packages/bb-app/README.md
@@ -69,6 +69,22 @@ npx bb-app@nightly
 Nightly versions are built from `main` and may be unstable. The `nightly`
 dist-tag moves independently of the stable `latest` tag.
 
+npm 12 and later block dependency install scripts by default. bb needs those
+scripts to build its native add-ons (`better-sqlite3`, `node-pty`,
+`@parcel/watcher`). Without them bb stops at startup with
+`Could not locate the bindings file`. If your npm version is 12 or later, allow
+the scripts for the install:
+
+```bash
+npx --allow-scripts=better-sqlite3,node-pty,@parcel/watcher bb-app@latest
+```
+
+Or set the policy once for all global installs:
+
+```bash
+npm config set allow-scripts=better-sqlite3,node-pty,@parcel/watcher --location=user
+```
+
 `npx bb-app@latest` downloads the published `bb-app` package, starts the server and
 local host daemon, and serves the web app. It stores bb-managed state under
 `~/.bb/` by default. If either managed child process exits unexpectedly, the


### PR DESCRIPTION
## What was wrong

bb ships as the `bb-app` npm package. Three of its dependencies are native add-ons: `better-sqlite3`, `node-pty`, and `@parcel/watcher`. npm install scripts download or build their binaries. npm 12 (12.0.2 is `npm@latest`) enforces the new `allowScripts` policy: for `npm install -g` and `npx`, npm blocks dependency install scripts unless `--allow-scripts`, `npm_config_allow_scripts`, or a user/global `.npmrc` names them. npm does not read the installed package's own `package.json#allowScripts` for global installs, so `bb-app` cannot fix this from inside the package. npm still exits 0, prints only a warning, and bb then dies at startup with `Could not locate the bindings file` (server) or `Failed to load native module: pty.node` (host daemon). The report reproduced this on all three install paths (`npm install -g bb-app`, `npx bb-app@latest`, and the "Add machine" installer). On npm 11 the policy is only advisory: npm warns and runs the scripts. The installer, the daemon self-updater, and the docs passed no allow-list, and the installer printed `✓ Installed` before it failed 30 s later at the join step with a raw stack trace.

Independent investigation report: https://get-bb.github.io/reports/issues/1120.html

## What changed

- `apps/server/src/assets/install-machine.sh`: both `npm install -g` lines pass `--allow-scripts=better-sqlite3,node-pty,@parcel/watcher`. After the install, the script requires `better-sqlite3` and `node-pty` from the installed `bb-app`. If they do not load, it fails with `npm installed bb-app, but its native add-ons (better-sqlite3, node-pty) did not load.` and points to `npm_config_allow_scripts=... npm_config_ignore_scripts=false`.
- `apps/host-daemon/src/protocol-self-update.ts`: the self-updater passes the same `--allow-scripts` argument to `npm install -g`.
- `apps/server/test/app/install-machine-script.test.ts`: the fake npm now lays out `lib/node_modules/bb-app/node_modules/{better-sqlite3,node-pty}` like a real install; the argv assertions include the flag; a new test `fails loudly when npm skipped the native add-on install scripts` sets `FAKE_NPM_SKIP_NATIVE_MODULES=1` and asserts exit 1, the message, and that no daemon starts.
- `apps/host-daemon/src/protocol-self-update.test.ts`: argv assertions include the flag.
- `README.md` and `packages/bb-app/README.md`: document `npx --allow-scripts=better-sqlite3,node-pty,@parcel/watcher bb-app@latest` and `npm config set allow-scripts=... --location=user` in the quick start and troubleshooting sections.

npm 10 ignores the unknown flag and npm 11 accepts it (verified: `npm 11.16.0 install -g --allow-scripts=... --dry-run` runs with no warning). No wire changes; no `HOST_DAEMON_PROTOCOL_VERSION` bump.

Deviation from the report: none in substance. The loud-failure check is the report's diff with the message wording adjusted and the module list stored in one shell variable.

## How I verified

- Before the change (installer script stashed), the three installer tests failed: `installs the server tarball even when a same-version bb-app is on PATH`, `falls back to npm only when the server artifact returns 404`, `fails loudly when npm skipped the native add-on install scripts`.
- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/host-daemon` → pass.
- `pnpm exec turbo run test --filter=@bb/host-daemon` → 583 passed.
- `pnpm exec turbo run test --filter=@bb/server` → 1729 passed, 2 failed. Both failures are unrelated to this change: `internal-skill-trees.test.ts` expects file mode 420 and gets 436 (local umask), and `plugin-service.test.ts` hit the 5 s timeout under full-suite load; both pass on rerun / are environmental. `install-machine-script.test.ts` (17 tests) passes.

Fixes #1120

> AGENT GENERATED: by Claude Opus 5