### PR TITLE
Keep plugin terminal tabs out of thread sync

### DIFF
--- a/apps/app/src/components/plugin/PluginPanelRightPanelHost.test.tsx
+++ b/apps/app/src/components/plugin/PluginPanelRightPanelHost.test.tsx
@@ -12,12 +12,57 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@bb/shared-ui/tooltip";
-import { getFixedPanelTabsStateStorageKey } from "@/lib/fixed-panel-tabs-state";
+import {
+  createEmptyFixedPanelTabsState,
+  createTerminalFixedPanelTab,
+  getFixedPanelTabsStateStorageKey,
+  serializeFixedPanelTabsState,
+} from "@/lib/fixed-panel-tabs-state";
 import { PluginPanelRightPanelHost } from "./PluginPanelRightPanelHost";
 import { getPluginPagePanelStateId } from "./plugin-page-panel-state";
 
 const browserState = vi.hoisted(() => ({ available: false }));
 const createTerminal = vi.hoisted(() => vi.fn());
+const threadTabsApi = vi.hoisted(() => ({
+  get: vi.fn(),
+  update: vi.fn(),
+}));
+const terminalQueryState = vi.hoisted(() => ({
+  sessions: [
+    {
+      id: "terminal-1",
+      threadId: "thread-restored-target",
+      environmentId: "environment-1",
+      hostId: "host-1",
+      title: "Terminal 1",
+      initialCwd: "/workspace",
+      cols: 100,
+      rows: 30,
+      status: "running",
+      exitCode: null,
+      closeReason: null,
+      createdAt: 1,
+      updatedAt: 1,
+      lastUserInputAt: null,
+    },
+    {
+      id: "terminal-2",
+      threadId: "thread-restored-target",
+      environmentId: "environment-1",
+      hostId: "host-1",
+      title: "Terminal 2",
+      initialCwd: "/workspace",
+      cols: 100,
+      rows: 30,
+      status: "running",
+      exitCode: null,
+      closeReason: null,
+      createdAt: 1,
+      updatedAt: 1,
+      lastUserInputAt: null,
+    },
+  ],
+}));
 const hostState = vi.hoisted(() => ({
   hosts: [
     { id: "host-1", name: "Studio", status: "connected" },
@@ -25,6 +70,20 @@ const hostState = vi.hoisted(() => ({
   ],
   primaryHostId: "host-1",
 }));
+
+vi.mock("@/lib/sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/sdk")>();
+  return {
+    ...actual,
+    sdk: {
+      ...actual.sdk,
+      threads: {
+        ...actual.sdk.threads,
+        tabs: threadTabsApi,
+      },
+    },
+  };
+});
 
 vi.mock("@bb/shared-ui/hooks/use-compact-viewport", () => ({
   useIsCompactViewport: () => false,
@@ -66,17 +125,45 @@ vi.mock("@/hooks/queries/thread-terminal-queries", () => ({
     isPending: false,
     mutateAsync: createTerminal,
   }),
-  useCloseTerminal: () => ({ mutateAsync: vi.fn() }),
+  useCreateEnvironmentTerminal: () => ({
+    isPending: false,
+    mutateAsync: vi.fn(),
+  }),
+  useCreateThreadTerminal: () => ({
+    isPending: false,
+    mutateAsync: vi.fn(),
+  }),
+  useCloseTerminal: () => ({
+    isPending: false,
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    variables: undefined,
+  }),
+  useCloseEnvironmentTerminal: () => ({
+    isPending: false,
+    mutate: vi.fn(),
+    variables: undefined,
+  }),
+  useCloseThreadTerminal: () => ({
+    isPending: false,
+    mutate: vi.fn(),
+    variables: undefined,
+  }),
+  useRenameTerminal: () => ({ mutate: vi.fn() }),
+  useRenameEnvironmentTerminal: () => ({ mutate: vi.fn() }),
+  useRenameThreadTerminal: () => ({ mutate: vi.fn() }),
+  useEnvironmentTerminals: () => ({
+    data: terminalQueryState,
+    error: null,
+    isLoading: false,
+  }),
+  useThreadTerminals: () => ({
+    data: terminalQueryState,
+    error: null,
+    isLoading: false,
+  }),
   useTerminals: () => ({
-    data: {
-      sessions: [
-        {
-          id: "terminal-1",
-          title: "Terminal",
-          status: "running",
-        },
-      ],
-    },
+    data: terminalQueryState,
     error: null,
     isLoading: false,
   }),
@@ -206,9 +293,27 @@ vi.mock("@/components/secondary-panel/BrowserTabDeck", () => ({
   BrowserTabDeck: () => <div data-testid="plugin-page-browser" />,
 }));
 
-vi.mock("@/components/thread/terminal/ThreadTerminalPanel", () => ({
-  ThreadTerminalPanel: () => <div data-testid="plugin-page-terminal" />,
-}));
+vi.mock("@/components/thread/terminal/ThreadTerminalPanel", async () => {
+  const { useThreadTerminalController } =
+    await import("@/components/thread/terminal/useThreadTerminalController");
+  return {
+    ThreadTerminalPanel: (
+      props: Parameters<typeof useThreadTerminalController>[0],
+    ) => {
+      const controller = useThreadTerminalController(props);
+      return (
+        <div data-testid="plugin-page-terminal">
+          <button
+            type="button"
+            onClick={() => controller.handleSelectTerminal("terminal-2")}
+          >
+            Select sibling terminal
+          </button>
+        </div>
+      );
+    },
+  };
+});
 
 function renderHost(panelPath = "board") {
   const panelStateId = getPluginPagePanelStateId({
@@ -241,6 +346,10 @@ describe("PluginPanelRightPanelHost", () => {
     browserState.available = false;
     createTerminal.mockReset();
     createTerminal.mockResolvedValue({ id: "terminal-1" });
+    threadTabsApi.get.mockReset();
+    threadTabsApi.get.mockResolvedValue({ revision: 4, tabs: [] });
+    threadTabsApi.update.mockReset();
+    threadTabsApi.update.mockResolvedValue({ revision: 5, tabs: [] });
     localStorage.clear();
   });
 
@@ -372,5 +481,57 @@ describe("PluginPanelRightPanelHost", () => {
       }),
     );
     expect(await screen.findByTestId("plugin-page-terminal")).toBeTruthy();
+  });
+
+  it("keeps a restored thread-targeted terminal out of thread tab sync", async () => {
+    const panelStateId = getPluginPagePanelStateId({
+      panelPath: "board",
+      pluginId: "demo",
+    });
+    const restoredTarget = {
+      kind: "thread" as const,
+      threadId: "thread-restored-target",
+    };
+    const restoredTab = createTerminalFixedPanelTab({
+      terminalId: "terminal-1",
+      target: restoredTarget,
+    });
+    localStorage.setItem(
+      getFixedPanelTabsStateStorageKey({ threadId: panelStateId }),
+      serializeFixedPanelTabsState({
+        state: createEmptyFixedPanelTabsState({
+          lastUsedAt: Date.now(),
+          secondary: {
+            activeTabId: restoredTab.id,
+            isOpen: true,
+            tabs: [restoredTab],
+          },
+        }),
+      }),
+    );
+
+    renderHost();
+    expect(await screen.findByTestId("plugin-page-terminal")).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Select sibling terminal" }),
+    );
+
+    const siblingTab = createTerminalFixedPanelTab({
+      terminalId: "terminal-2",
+      target: restoredTarget,
+    });
+    await waitFor(() => {
+      const storedValue = localStorage.getItem(
+        getFixedPanelTabsStateStorageKey({ threadId: panelStateId }),
+      );
+      if (storedValue === null) {
+        throw new Error("Expected plugin panel state to remain persisted");
+      }
+      expect(JSON.parse(storedValue)).toMatchObject({
+        secondary: { activeTabId: siblingTab.id },
+      });
+    });
+    expect(threadTabsApi.get).not.toHaveBeenCalled();
+    expect(threadTabsApi.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
+++ b/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
@@ -487,6 +487,7 @@ export function PluginPanelRightPanelHost({
             isPanelOpen={isOpen}
             isPanelPersistedOpen={panelState.secondary.isOpen}
             panelStateId={panelStateId}
+            syncThreadId={null}
             target={activeTerminalTarget!}
           />
         </Suspense>

--- a/apps/app/src/components/plugin/file-opener-tabs.test.ts
+++ b/apps/app/src/components/plugin/file-opener-tabs.test.ts
@@ -11,7 +11,7 @@ const MARKDOWN_OPENER = {
   id: "markdown",
   pluginId: "docs",
   title: "Docs editor",
-} as unknown as PluginFileOpenerSlot;
+} satisfies PluginFileOpenerSlot;
 
 const REQUESTS: readonly {
   label: string;
@@ -72,7 +72,7 @@ describe("createFileOpenerTabForRequest thread-tabs contract", () => {
     const tab = createFileOpenerTabForRequest({
       fileOpeners: [MARKDOWN_OPENER],
       preference: {},
-      projectId: "prj_docs",
+      projectId: null,
       request: {
         kind: "workspace-file-preview",
         tab: {
@@ -89,7 +89,7 @@ describe("createFileOpenerTabForRequest thread-tabs contract", () => {
     expect(tab?.fileOpenerOwner).toMatchObject({
       environmentId: null,
       kind: "workspace-file-preview",
-      projectId: "prj_docs",
+      projectId: null,
       threadId: null,
     });
     expect(() => threadTabsSchema.parse([tab])).not.toThrow();

--- a/apps/app/src/components/thread/terminal/ThreadTerminalPanel.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalPanel.tsx
@@ -17,6 +17,7 @@ interface ThreadTerminalPanelProps {
   onOpenLink?: MarkdownPreviewLinkHandler;
   onSelectionAddToChat?: (text: string) => void;
   panelStateId?: string;
+  syncThreadId: string | null;
   target: ThreadTerminalTarget;
 }
 
@@ -31,6 +32,7 @@ export function ThreadTerminalPanel({
   onOpenLink,
   onSelectionAddToChat,
   panelStateId,
+  syncThreadId,
   target,
 }: ThreadTerminalPanelProps) {
   const terminalController = useThreadTerminalController({
@@ -40,6 +42,7 @@ export function ThreadTerminalPanel({
     fixedPanelTarget,
     fixedTerminalId,
     panelStateId,
+    syncThreadId,
     target,
   });
 

--- a/apps/app/src/components/thread/terminal/useThreadTerminalController.ts
+++ b/apps/app/src/components/thread/terminal/useThreadTerminalController.ts
@@ -47,6 +47,8 @@ export interface ThreadTerminalControllerArgs {
   isPanelOpen: boolean;
   isPanelPersistedOpen: boolean;
   panelStateId?: string;
+  /** Thread whose tabs are server-synced; null for local-only panel state. */
+  syncThreadId: string | null;
   fixedPanelTarget?: TerminalCreateTarget;
   fixedTerminalId?: string;
   target: ThreadTerminalTarget;
@@ -175,6 +177,7 @@ export function useThreadTerminalController({
   isPanelOpen,
   isPanelPersistedOpen,
   panelStateId,
+  syncThreadId,
   fixedPanelTarget,
   fixedTerminalId,
   target,
@@ -191,24 +194,22 @@ export function useThreadTerminalController({
   const environmentQueryId =
     target.kind === "environment" ? target.environmentId : "";
   const fixedPanelStateId = panelStateId ?? terminalTargetId;
-  const fixedPanelSyncThreadId =
-    target.kind === "thread" ? target.threadId : null;
   const activeFixedTerminalId = useActiveFixedRightTerminalId(
     fixedPanelStateId,
-    fixedPanelSyncThreadId,
+    syncThreadId,
   );
   const closeFixedSecondaryPanel = useCloseFixedSecondaryPanel(
     fixedPanelStateId,
-    fixedPanelSyncThreadId,
+    syncThreadId,
   );
   const setActiveFixedTerminal = useSetFixedRightTerminalActiveTerminal(
     fixedPanelStateId,
-    fixedPanelSyncThreadId,
+    syncThreadId,
     fixedPanelTarget,
   );
   const removeFixedTerminalTab = useRemoveFixedRightTerminalTab(
     fixedPanelStateId,
-    fixedPanelSyncThreadId,
+    syncThreadId,
   );
   const uiCreatedTerminalIdsRef = useRef<Set<string>>(new Set());
   const dirtyTerminalIdsRef = useRef<Set<string>>(new Set());

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -2012,6 +2012,7 @@ function RootComposeSurface({
         onOpenLink={handleOpenPanelLink}
         onSelectionAddToChat={handleRootPanelSelectionAddToChat}
         panelStateId={ROOT_COMPOSE_FIXED_PANEL_STATE_ID}
+        syncThreadId={null}
         target={rootPanelTerminalTarget}
       />
     ) : isNewTabActive ? (

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -2694,6 +2694,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
       onAutoFocusHandled={handleTerminalAutoFocusHandled}
       onOpenLink={handleOpenTimelineLink}
       onSelectionAddToChat={handleSelectionAddToChat}
+      syncThreadId={thread.id}
       target={{ kind: "thread", threadId: thread.id }}
     />
   ) : isNewTabActive ? (


### PR DESCRIPTION
## Summary

- separate terminal execution targets from thread-tab sync ownership
- keep plugin-page and root-compose terminal tabs local while thread views continue syncing to their thread
- add restored thread-target coverage that verifies plugin pages make no thread-tab reads or writes
- tighten the file-opener fixture and make its projectless case truly projectless

## Why

A restored plugin-page terminal can legitimately target a thread, but that does not make the thread the owner of the plugin page tab state. Deriving both concepts from the terminal target could replace plugin tabs with thread tabs and later persist plugin tabs into the thread.

## Verification

- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/plugin/PluginPanelRightPanelHost.test.tsx src/components/plugin/file-opener-tabs.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app --force` (0 errors; 147 existing warnings)
- `git diff --check origin/main...HEAD`

Follow-up to #1793.

> AGENT GENERATED: by GPT-5