### PR TITLE
Treat pi's manual compaction refusal as a skipped compaction, not a failed turn

### DIFF
--- a/packages/agent-runtime/src/pi/event-translation.test.ts
+++ b/packages/agent-runtime/src/pi/event-translation.test.ts
@@ -520,7 +520,7 @@ describe("pi event translation", () => {
         expect.objectContaining({
           type: "provider/warning",
           scope: turnScope("turn-1"),
-          category: "general",
+          category: "compaction-skipped",
           summary: "Context compaction skipped",
           details: errorMessage,
         }),

--- a/packages/agent-runtime/src/pi/event-translation.test.ts
+++ b/packages/agent-runtime/src/pi/event-translation.test.ts
@@ -506,17 +506,49 @@ describe("pi event translation", () => {
   });
 
   it.each([
+    "Compaction failed: Nothing to compact (session too small)",
+    "Compaction failed: Already compacted",
+  ])(
+    "translateEvent manual compaction refusal %j completes the turn as a no-op",
+    (errorMessage) => {
+      const { completed } = translateManualCompaction({
+        aborted: false,
+        errorMessage,
+      });
+
+      expect(completed).toEqual([
+        expect.objectContaining({
+          type: "provider/warning",
+          scope: turnScope("turn-1"),
+          category: "general",
+          summary: "Context compaction skipped",
+          details: errorMessage,
+        }),
+        {
+          type: "turn/completed",
+          threadId: "",
+          providerThreadId: "",
+          scope: turnScope("turn-1"),
+          status: "completed",
+        },
+      ]);
+      expect(completed.some((event) => event.type === "thread/compacted")).toBe(
+        false,
+      );
+    },
+  );
+
+  it.each([
     {
       label: "failed",
       args: {
         aborted: false,
-        errorMessage:
-          "Compaction failed: Nothing to compact (session too small)",
+        errorMessage: "Compaction failed: Summarization failed: 500",
       },
       expected: {
         status: "failed",
         error: {
-          message: "Compaction failed: Nothing to compact (session too small)",
+          message: "Compaction failed: Summarization failed: 500",
         },
       },
     },

--- a/packages/agent-runtime/src/pi/event-translation.ts
+++ b/packages/agent-runtime/src/pi/event-translation.ts
@@ -212,6 +212,21 @@ const piCompactionEndEventSchema = z
   })
   .passthrough();
 
+/**
+ * Pi refuses a manual compaction before it calls the model when the session
+ * has nothing to summarize. Pi reports the refusal through the same
+ * `compaction_end.errorMessage` field as a real failure, so bb must tell them
+ * apart: a refusal is a no-op, not a failed turn.
+ */
+const piCompactionNoopMessages = new Set([
+  "Compaction failed: Nothing to compact (session too small)",
+  "Compaction failed: Already compacted",
+]);
+
+function isPiCompactionNoop(errorMessage: string): boolean {
+  return piCompactionNoopMessages.has(errorMessage.trim());
+}
+
 const piMessageUpdateEventSchema = z
   .object({
     type: z.literal("message_update"),
@@ -747,12 +762,29 @@ export function createPiEventTranslator(
         if (turnId.length === 0) {
           return buildUnexpectedEvent(event);
         }
+        const compactionNoopDetail =
+          parsed.data.reason === "manual" &&
+          !parsed.data.aborted &&
+          parsed.data.errorMessage !== undefined &&
+          isPiCompactionNoop(parsed.data.errorMessage)
+            ? parsed.data.errorMessage
+            : undefined;
         if (!parsed.data.aborted && !parsed.data.errorMessage) {
           events.push({
             type: "thread/compacted",
             threadId,
             providerThreadId: "",
             scope: turnScope(turnId),
+          });
+        } else if (compactionNoopDetail !== undefined) {
+          events.push({
+            type: "provider/warning",
+            threadId,
+            providerThreadId: "",
+            scope: turnScope(turnId),
+            category: "general",
+            summary: "Context compaction skipped",
+            details: compactionNoopDetail,
           });
         } else if (parsed.data.reason !== "manual") {
           events.push({
@@ -776,10 +808,10 @@ export function createPiEventTranslator(
             scope: turnScope(turnId),
             status: parsed.data.aborted
               ? "interrupted"
-              : parsed.data.errorMessage
+              : parsed.data.errorMessage && compactionNoopDetail === undefined
                 ? "failed"
                 : "completed",
-            ...(parsed.data.errorMessage
+            ...(parsed.data.errorMessage && compactionNoopDetail === undefined
               ? { error: { message: parsed.data.errorMessage } }
               : {}),
           });

--- a/packages/agent-runtime/src/pi/event-translation.ts
+++ b/packages/agent-runtime/src/pi/event-translation.ts
@@ -782,7 +782,7 @@ export function createPiEventTranslator(
             threadId,
             providerThreadId: "",
             scope: turnScope(turnId),
-            category: "general",
+            category: "compaction-skipped",
             summary: "Context compaction skipped",
             details: compactionNoopDetail,
           });

--- a/packages/domain/src/provider-event.ts
+++ b/packages/domain/src/provider-event.ts
@@ -233,6 +233,11 @@ export const threadEventWarningCategorySchema = z.enum([
   "deprecation",
   "config",
   "general",
+  /**
+   * The provider declined a compaction that bb asked for because there was
+   * nothing to compact. The warning settles the pending compaction row.
+   */
+  "compaction-skipped",
 ]);
 export type ThreadEventWarningCategory = z.infer<
   typeof threadEventWarningCategorySchema

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,8 @@
+// Version 135 adds the `compaction-skipped` provider warning category. The Pi
+// bridge now reports a refused manual compaction ("Nothing to compact") as
+// that warning plus a completed turn instead of a failed turn. An older daemon
+// still sends the failed turn, so the server would move the thread to error.
+//
 // Version 134 keeps replayed Codex usage snapshots off unknown turn ids: the
 // Codex bridge drops the turn-only token usage that codex replays on
 // thread/resume and thread/fork and emits the replayed context-window usage
@@ -39,7 +44,7 @@
 //
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 134 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 135 as const;
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1142,7 +1142,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(134);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(135);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/packages/plugin-sdk/bundled-types/bb-plugin-sdk-provider-bridge.d.ts
+++ b/packages/plugin-sdk/bundled-types/bb-plugin-sdk-provider-bridge.d.ts
@@ -728,8 +728,8 @@ declare const instructionModeSchema: z.ZodEnum<{
 type InstructionMode = z.infer<typeof instructionModeSchema>;
 declare const permissionModeSchema: z.ZodEnum<{
     full: "full";
-    "accept-edits": "accept-edits";
     auto: "auto";
+    "accept-edits": "accept-edits";
 }>;
 type PermissionMode = z.infer<typeof permissionModeSchema>;
 declare const permissionEscalationValues: readonly ["ask", "deny"];
@@ -2235,6 +2235,7 @@ declare const providerEventSchema: z.ZodIntersection<z.ZodDiscriminatedUnion<[z.
         deprecation: "deprecation";
         config: "config";
         general: "general";
+        "compaction-skipped": "compaction-skipped";
     }>;
     summary: z.ZodOptional<z.ZodString>;
     details: z.ZodOptional<z.ZodString>;
@@ -3134,6 +3135,7 @@ declare const threadEventSchema: z.ZodPipe<z.ZodUnknown, z.ZodUnion<readonly [z.
         deprecation: "deprecation";
         config: "config";
         general: "general";
+        "compaction-skipped": "compaction-skipped";
     }>;
     summary: z.ZodOptional<z.ZodString>;
     details: z.ZodOptional<z.ZodString>;
@@ -3427,8 +3429,8 @@ declare const threadEventSchema: z.ZodPipe<z.ZodUnknown, z.ZodUnion<readonly [z.
         permissionMode: z.ZodEnum<{
             readonly: "readonly";
             full: "full";
-            "accept-edits": "accept-edits";
             auto: "auto";
+            "accept-edits": "accept-edits";
             "workspace-write": "workspace-write";
         }>;
     }, z.core.$strip>;
@@ -4310,8 +4312,8 @@ declare const initializeResultSchema: z.ZodObject<{
             checkpoint: "checkpoint";
         }>>;
         approvalEnforcedBy: z.ZodDefault<z.ZodEnum<{
-            runtime: "runtime";
             provider: "provider";
+            runtime: "runtime";
         }>>;
     }, z.core.$loose>>;
 }, z.core.$loose>;
@@ -4355,16 +4357,16 @@ declare const bridgeExecutionOptionsSchema: z.ZodIntersection<z.ZodObject<{
     permissionScope: z.ZodLiteral<"workspace">;
     approvalReviewer: z.ZodLiteral<"user">;
     permissionEscalation: z.ZodEnum<{
-        ask: "ask";
         deny: "deny";
+        ask: "ask";
     }>;
 }, z.core.$strip>, z.ZodObject<{
     permissionMode: z.ZodLiteral<"auto">;
     permissionScope: z.ZodLiteral<"workspace">;
     approvalReviewer: z.ZodLiteral<"automatic">;
     permissionEscalation: z.ZodEnum<{
-        ask: "ask";
         deny: "deny";
+        ask: "ask";
     }>;
 }, z.core.$strip>, z.ZodObject<{
     permissionMode: z.ZodLiteral<"full">;
@@ -4508,16 +4510,16 @@ declare const threadStartParamsSchema: z.ZodObject<{
         permissionScope: z.ZodLiteral<"workspace">;
         approvalReviewer: z.ZodLiteral<"user">;
         permissionEscalation: z.ZodEnum<{
-            ask: "ask";
             deny: "deny";
+            ask: "ask";
         }>;
     }, z.core.$strip>, z.ZodObject<{
         permissionMode: z.ZodLiteral<"auto">;
         permissionScope: z.ZodLiteral<"workspace">;
         approvalReviewer: z.ZodLiteral<"automatic">;
         permissionEscalation: z.ZodEnum<{
-            ask: "ask";
             deny: "deny";
+            ask: "ask";
         }>;
     }, z.core.$strip>, z.ZodObject<{
         permissionMode: z.ZodLiteral<"full">;
@@ -4564,16 +4566,16 @@ declare const threadResumeParamsSchema: z.ZodObject<{
         permissionScope: z.ZodLiteral<"workspace">;
         approvalReviewer: z.ZodLiteral<"user">;
         permissionEscalation: z.ZodEnum<{
-            ask: "ask";
             deny: "deny";
+            ask: "ask";
         }>;
     }, z.core.$strip>, z.ZodObject<{
         permissionMode: z.ZodLiteral<"auto">;
         permissionScope: z.ZodLiteral<"workspace">;
         approvalReviewer: z.ZodLiteral<"automatic">;
         permissionEscalation: z.ZodEnum<{
-            ask: "ask";
             deny: "deny";
+            ask: "ask";
         }>;
     }, z.core.$strip>, z.ZodObject<{
         permissionMode: z.ZodLiteral<"full">;
@@ -4621,16 +4623,16 @@ declare const threadForkParamsSchema: z.ZodObject<{
         permissionScope: z.ZodLiteral<"workspace">;
         approvalReviewer: z.ZodLiteral<"user">;
         permissionEscalation: z.ZodEnum<{
-            ask: "ask";
             deny: "deny";
+            ask: "ask";
         }>;
     }, z.core.$strip>, z.ZodObject<{
         permissionMode: z.ZodLiteral<"auto">;
         permissionScope: z.ZodLiteral<"workspace">;
         approvalReviewer: z.ZodLiteral<"automatic">;
         permissionEscalation: z.ZodEnum<{
-            ask: "ask";
             deny: "deny";
+            ask: "ask";
         }>;
     }, z.core.$strip>, z.ZodObject<{
         permissionMode: z.ZodLiteral<"full">;
@@ -4788,16 +4790,16 @@ declare const turnStartParamsSchema: z.ZodObject<{
         permissionScope: z.ZodLiteral<"workspace">;
         approvalReviewer: z.ZodLiteral<"user">;
         permissionEscalation: z.ZodEnum<{
-            ask: "ask";
             deny: "deny";
+            ask: "ask";
         }>;
     }, z.core.$strip>, z.ZodObject<{
         permissionMode: z.ZodLiteral<"auto">;
         permissionScope: z.ZodLiteral<"workspace">;
         approvalReviewer: z.ZodLiteral<"automatic">;
         permissionEscalation: z.ZodEnum<{
-            ask: "ask";
             deny: "deny";
+            ask: "ask";
         }>;
     }, z.core.$strip>, z.ZodObject<{
         permissionMode: z.ZodLiteral<"full">;
@@ -4916,16 +4918,16 @@ declare const turnSteerParamsSchema: z.ZodObject<{
         permissionScope: z.ZodLiteral<"workspace">;
         approvalReviewer: z.ZodLiteral<"user">;
         permissionEscalation: z.ZodEnum<{
-            ask: "ask";
             deny: "deny";
+            ask: "ask";
         }>;
     }, z.core.$strip>, z.ZodObject<{
         permissionMode: z.ZodLiteral<"auto">;
         permissionScope: z.ZodLiteral<"workspace">;
         approvalReviewer: z.ZodLiteral<"automatic">;
         permissionEscalation: z.ZodEnum<{
-            ask: "ask";
             deny: "deny";
+            ask: "ask";
         }>;
     }, z.core.$strip>, z.ZodObject<{
         permissionMode: z.ZodLiteral<"full">;
@@ -5828,6 +5830,7 @@ declare const threadEventNotificationSchema: z.ZodObject<{
             deprecation: "deprecation";
             config: "config";
             general: "general";
+            "compaction-skipped": "compaction-skipped";
         }>;
         summary: z.ZodOptional<z.ZodString>;
         details: z.ZodOptional<z.ZodString>;
@@ -5838,8 +5841,8 @@ declare const threadEventNotificationSchema: z.ZodObject<{
         originalModel: z.ZodString;
         fallbackModel: z.ZodString;
         reason: z.ZodEnum<{
-            provider: "provider";
             refusal: "refusal";
+            provider: "provider";
         }>;
         message: z.ZodString;
     }, z.core.$strip>, z.ZodObject<{
@@ -6120,8 +6123,8 @@ declare const threadEventNotificationSchema: z.ZodObject<{
             }>;
             permissionMode: z.ZodEnum<{
                 readonly: "readonly";
-                "accept-edits": "accept-edits";
                 auto: "auto";
+                "accept-edits": "accept-edits";
                 full: "full";
                 "workspace-write": "workspace-write";
             }>;

--- a/packages/plugin-sdk/bundled-types/bb-plugin-sdk.d.ts
+++ b/packages/plugin-sdk/bundled-types/bb-plugin-sdk.d.ts
@@ -319,8 +319,8 @@ declare const providerPendingInteractionSchema: z$1.ZodObject<{
     id: z$1.ZodString;
     threadId: z$1.ZodString;
     status: z$1.ZodEnum<{
-        interrupted: "interrupted";
         pending: "pending";
+        interrupted: "interrupted";
         resolving: "resolving";
         resolved: "resolved";
     }>;
@@ -462,8 +462,8 @@ declare const pluginPendingInteractionSchema: z$1.ZodObject<{
     id: z$1.ZodString;
     threadId: z$1.ZodString;
     status: z$1.ZodEnum<{
-        interrupted: "interrupted";
         pending: "pending";
+        interrupted: "interrupted";
         resolving: "resolving";
         resolved: "resolved";
     }>;
@@ -715,8 +715,8 @@ declare const threadEventSchema: z$1.ZodPipe<z$1.ZodUnknown, z$1.ZodUnion<readon
     providerThreadId: z$1.ZodString;
     objective: z$1.ZodString;
     status: z$1.ZodEnum<{
-        active: "active";
         paused: "paused";
+        active: "active";
         budgetLimited: "budgetLimited";
         complete: "complete";
     }>;
@@ -760,10 +760,10 @@ declare const threadEventSchema: z$1.ZodPipe<z$1.ZodUnknown, z$1.ZodUnion<readon
         command: z$1.ZodString;
         cwd: z$1.ZodString;
         status: z$1.ZodEnum<{
+            pending: "pending";
             completed: "completed";
             failed: "failed";
             interrupted: "interrupted";
-            pending: "pending";
         }>;
         approvalStatus: z$1.ZodNullable<z$1.ZodEnum<{
             waiting_for_approval: "waiting_for_approval";
@@ -807,10 +807,10 @@ declare const threadEventSchema: z$1.ZodPipe<z$1.ZodUnknown, z$1.ZodUnion<readon
             diff: z$1.ZodOptional<z$1.ZodString>;
         }, z$1.core.$strip>>;
         status: z$1.ZodEnum<{
+            pending: "pending";
             completed: "completed";
             failed: "failed";
             interrupted: "interrupted";
-            pending: "pending";
         }>;
         approvalStatus: z$1.ZodNullable<z$1.ZodEnum<{
             waiting_for_approval: "waiting_for_approval";
@@ -847,10 +847,10 @@ declare const threadEventSchema: z$1.ZodPipe<z$1.ZodUnknown, z$1.ZodUnion<readon
             completed: z$1.ZodString;
         }, z$1.core.$strip>>;
         status: z$1.ZodEnum<{
+            pending: "pending";
             completed: "completed";
             failed: "failed";
             interrupted: "interrupted";
-            pending: "pending";
         }>;
         result: z$1.ZodOptional<z$1.ZodUnknown>;
         error: z$1.ZodOptional<z$1.ZodString>;
@@ -897,17 +897,17 @@ declare const threadEventSchema: z$1.ZodPipe<z$1.ZodUnknown, z$1.ZodUnion<readon
         taskType: z$1.ZodString;
         description: z$1.ZodString;
         status: z$1.ZodEnum<{
+            pending: "pending";
             completed: "completed";
             failed: "failed";
             interrupted: "interrupted";
-            pending: "pending";
         }>;
         taskStatus: z$1.ZodEnum<{
-            completed: "completed";
-            failed: "failed";
-            paused: "paused";
             pending: "pending";
             running: "running";
+            paused: "paused";
+            completed: "completed";
+            failed: "failed";
             killed: "killed";
             stopped: "stopped";
         }>;
@@ -923,8 +923,8 @@ declare const threadEventSchema: z$1.ZodPipe<z$1.ZodUnknown, z$1.ZodUnion<readon
                 index: z$1.ZodNumber;
                 label: z$1.ZodString;
                 state: z$1.ZodEnum<{
-                    failed: "failed";
                     running: "running";
+                    failed: "failed";
                     queued: "queued";
                     done: "done";
                     skipped: "skipped";
@@ -992,10 +992,10 @@ declare const threadEventSchema: z$1.ZodPipe<z$1.ZodUnknown, z$1.ZodUnion<readon
         command: z$1.ZodString;
         cwd: z$1.ZodString;
         status: z$1.ZodEnum<{
+            pending: "pending";
             completed: "completed";
             failed: "failed";
             interrupted: "interrupted";
-            pending: "pending";
         }>;
         approvalStatus: z$1.ZodNullable<z$1.ZodEnum<{
             waiting_for_approval: "waiting_for_approval";
@@ -1039,10 +1039,10 @@ declare const threadEventSchema: z$1.ZodPipe<z$1.ZodUnknown, z$1.ZodUnion<readon
             diff: z$1.ZodOptional<z$1.ZodString>;
         }, z$1.core.$strip>>;
         status: z$1.ZodEnum<{
+            pending: "pending";
             completed: "completed";
             failed: "failed";
             interrupted: "interrupted";
-            pending: "pending";
         }>;
         approvalStatus: z$1.ZodNullable<z$1.ZodEnum<{
             waiting_for_approval: "waiting_for_approval";
@@ -1079,10 +1079,10 @@ declare const threadEventSchema: z$1.ZodPipe<z$1.ZodUnknown, z$1.ZodUnion<readon
             completed: z$1.ZodString;
         }, z$1.core.$strip>>;
         status: z$1.ZodEnum<{
+            pending: "pending";
             completed: "completed";
             failed: "failed";
             interrupted: "interrupted";
-            pending: "pending";
         }>;
         result: z$1.ZodOptional<z$1.ZodUnknown>;
         error: z$1.ZodOptional<z$1.ZodString>;
@@ -1129,17 +1129,17 @@ declare const threadEventSchema: z$1.ZodPipe<z$1.ZodUnknown, z$1.ZodUnion<readon
         taskType: z$1.ZodString;
         description: z$1.ZodString;
         status: z$1.ZodEnum<{
+            pending: "pending";
             completed: "completed";
             failed: "failed";
             interrupted: "interrupted";
-            pending: "pending";
         }>;
         taskStatus: z$1.ZodEnum<{
-            completed: "completed";
-            failed: "failed";
-            paused: "paused";
             pending: "pending";
             running: "running";
+            paused: "paused";
+            completed: "completed";
+            failed: "failed";
             killed: "killed";
             stopped: "stopped";
         }>;
@@ -1155,8 +1155,8 @@ declare const threadEventSchema: z$1.ZodPipe<z$1.ZodUnknown, z$1.ZodUnion<readon
                 index: z$1.ZodNumber;
                 label: z$1.ZodString;
                 state: z$1.ZodEnum<{
-                    failed: "failed";
                     running: "running";
+                    failed: "failed";
                     queued: "queued";
                     done: "done";
                     skipped: "skipped";
@@ -1258,17 +1258,17 @@ declare const threadEventSchema: z$1.ZodPipe<z$1.ZodUnknown, z$1.ZodUnion<readon
         taskType: z$1.ZodString;
         description: z$1.ZodString;
         status: z$1.ZodEnum<{
+            pending: "pending";
             completed: "completed";
             failed: "failed";
             interrupted: "interrupted";
-            pending: "pending";
         }>;
         taskStatus: z$1.ZodEnum<{
-            completed: "completed";
-            failed: "failed";
-            paused: "paused";
             pending: "pending";
             running: "running";
+            paused: "paused";
+            completed: "completed";
+            failed: "failed";
             killed: "killed";
             stopped: "stopped";
         }>;
@@ -1284,8 +1284,8 @@ declare const threadEventSchema: z$1.ZodPipe<z$1.ZodUnknown, z$1.ZodUnion<readon
                 index: z$1.ZodNumber;
                 label: z$1.ZodString;
                 state: z$1.ZodEnum<{
-                    failed: "failed";
                     running: "running";
+                    failed: "failed";
                     queued: "queued";
                     done: "done";
                     skipped: "skipped";
@@ -1330,17 +1330,17 @@ declare const threadEventSchema: z$1.ZodPipe<z$1.ZodUnknown, z$1.ZodUnion<readon
         taskType: z$1.ZodString;
         description: z$1.ZodString;
         status: z$1.ZodEnum<{
+            pending: "pending";
             completed: "completed";
             failed: "failed";
             interrupted: "interrupted";
-            pending: "pending";
         }>;
         taskStatus: z$1.ZodEnum<{
-            completed: "completed";
-            failed: "failed";
-            paused: "paused";
             pending: "pending";
             running: "running";
+            paused: "paused";
+            completed: "completed";
+            failed: "failed";
             killed: "killed";
             stopped: "stopped";
         }>;
@@ -1356,8 +1356,8 @@ declare const threadEventSchema: z$1.ZodPipe<z$1.ZodUnknown, z$1.ZodUnion<readon
                 index: z$1.ZodNumber;
                 label: z$1.ZodString;
                 state: z$1.ZodEnum<{
-                    failed: "failed";
                     running: "running";
+                    failed: "failed";
                     queued: "queued";
                     done: "done";
                     skipped: "skipped";
@@ -1429,10 +1429,10 @@ declare const threadEventSchema: z$1.ZodPipe<z$1.ZodUnknown, z$1.ZodUnion<readon
     plan: z$1.ZodArray<z$1.ZodObject<{
         step: z$1.ZodString;
         status: z$1.ZodOptional<z$1.ZodEnum<{
+            pending: "pending";
             completed: "completed";
             failed: "failed";
             active: "active";
-            pending: "pending";
         }>>;
     }, z$1.core.$strip>>;
     explanation: z$1.ZodOptional<z$1.ZodString>;
@@ -1519,6 +1519,7 @@ declare const threadEventSchema: z$1.ZodPipe<z$1.ZodUnknown, z$1.ZodUnion<readon
         deprecation: "deprecation";
         config: "config";
         general: "general";
+        "compaction-skipped": "compaction-skipped";
     }>;
     summary: z$1.ZodOptional<z$1.ZodString>;
     details: z$1.ZodOptional<z$1.ZodString>;
@@ -1880,8 +1881,8 @@ declare const threadEventSchema: z$1.ZodPipe<z$1.ZodUnknown, z$1.ZodUnion<readon
     providerId: z$1.ZodString;
     providerRequestId: z$1.ZodString;
     status: z$1.ZodEnum<{
-        interrupted: "interrupted";
         pending: "pending";
+        interrupted: "interrupted";
         resolving: "resolving";
         resolved: "resolved";
     }>;
@@ -1932,8 +1933,8 @@ declare const threadEventSchema: z$1.ZodPipe<z$1.ZodUnknown, z$1.ZodUnion<readon
     providerId: z$1.ZodString;
     providerRequestId: z$1.ZodString;
     status: z$1.ZodEnum<{
-        interrupted: "interrupted";
         pending: "pending";
+        interrupted: "interrupted";
         resolving: "resolving";
         resolved: "resolved";
     }>;
@@ -2122,8 +2123,8 @@ declare const threadTimelinePendingTodosSchema: z$1.ZodObject<{
         id: z$1.ZodString;
         text: z$1.ZodString;
         status: z$1.ZodEnum<{
-            completed: "completed";
             pending: "pending";
+            completed: "completed";
             in_progress: "in_progress";
         }>;
     }, z$1.core.$strip>>;
@@ -2955,8 +2956,8 @@ declare const environmentArchiveThreadsResponseSchema: z$1.ZodObject<{
 type EnvironmentArchiveThreadsResponse = z$1.infer<typeof environmentArchiveThreadsResponseSchema>;
 declare const pullRequestMergeMethodSchema: z$1.ZodEnum<{
     merge: "merge";
-    squash: "squash";
     rebase: "rebase";
+    squash: "squash";
 }>;
 type PullRequestMergeMethod = z$1.infer<typeof pullRequestMergeMethodSchema>;
 declare const commitActionResponseSchema: z$1.ZodObject<{
@@ -2987,8 +2988,8 @@ declare const pullRequestMergeActionResponseSchema: z$1.ZodObject<{
     action: z$1.ZodLiteral<"pull_request_merge">;
     method: z$1.ZodEnum<{
         merge: "merge";
-        squash: "squash";
         rebase: "rebase";
+        squash: "squash";
     }>;
     message: z$1.ZodString;
 }, z$1.core.$strip>;
@@ -3568,9 +3569,9 @@ declare const hostDaemonCommandRegistry: {
             capabilities: z$1.ZodObject<{
                 supportsServiceTier: z$1.ZodBoolean;
                 permissionModes: z$1.ZodArray<z$1.ZodEnum<{
-                    auto: "auto";
-                    "accept-edits": "accept-edits";
                     full: "full";
+                    "accept-edits": "accept-edits";
+                    auto: "auto";
                 }>>;
                 supportsThreadArchive: z$1.ZodBoolean;
                 supportsThreadRename: z$1.ZodBoolean;
@@ -3610,16 +3611,16 @@ declare const hostDaemonCommandRegistry: {
             permissionScope: z$1.ZodLiteral<"workspace">;
             approvalReviewer: z$1.ZodLiteral<"user">;
             permissionEscalation: z$1.ZodEnum<{
-                deny: "deny";
                 ask: "ask";
+                deny: "deny";
             }>;
         }, z$1.core.$strip>, z$1.ZodObject<{
             permissionMode: z$1.ZodLiteral<"auto">;
             permissionScope: z$1.ZodLiteral<"workspace">;
             approvalReviewer: z$1.ZodLiteral<"automatic">;
             permissionEscalation: z$1.ZodEnum<{
-                deny: "deny";
                 ask: "ask";
+                deny: "deny";
             }>;
         }, z$1.core.$strip>, z$1.ZodObject<{
             permissionMode: z$1.ZodLiteral<"full">;
@@ -3795,9 +3796,9 @@ declare const hostDaemonCommandRegistry: {
             capabilities: z$1.ZodObject<{
                 supportsServiceTier: z$1.ZodBoolean;
                 permissionModes: z$1.ZodArray<z$1.ZodEnum<{
-                    auto: "auto";
-                    "accept-edits": "accept-edits";
                     full: "full";
+                    "accept-edits": "accept-edits";
+                    auto: "auto";
                 }>>;
                 supportsThreadArchive: z$1.ZodBoolean;
                 supportsThreadRename: z$1.ZodBoolean;
@@ -3837,16 +3838,16 @@ declare const hostDaemonCommandRegistry: {
             permissionScope: z$1.ZodLiteral<"workspace">;
             approvalReviewer: z$1.ZodLiteral<"user">;
             permissionEscalation: z$1.ZodEnum<{
-                deny: "deny";
                 ask: "ask";
+                deny: "deny";
             }>;
         }, z$1.core.$strip>, z$1.ZodObject<{
             permissionMode: z$1.ZodLiteral<"auto">;
             permissionScope: z$1.ZodLiteral<"workspace">;
             approvalReviewer: z$1.ZodLiteral<"automatic">;
             permissionEscalation: z$1.ZodEnum<{
-                deny: "deny";
                 ask: "ask";
+                deny: "deny";
             }>;
         }, z$1.core.$strip>, z$1.ZodObject<{
             permissionMode: z$1.ZodLiteral<"full">;
@@ -3940,9 +3941,9 @@ declare const hostDaemonCommandRegistry: {
                         skill: "skill";
                     }>;
                     origin: z$1.ZodEnum<{
-                        user: "user";
-                        project: "project";
                         builtin: "builtin";
+                        project: "project";
+                        user: "user";
                     }>;
                     label: z$1.ZodString;
                     argumentHint: z$1.ZodNullable<z$1.ZodString>;
@@ -4021,9 +4022,9 @@ declare const hostDaemonCommandRegistry: {
                         skill: "skill";
                     }>;
                     origin: z$1.ZodEnum<{
-                        user: "user";
-                        project: "project";
                         builtin: "builtin";
+                        project: "project";
+                        user: "user";
                     }>;
                     label: z$1.ZodString;
                     argumentHint: z$1.ZodNullable<z$1.ZodString>;
@@ -4114,9 +4115,9 @@ declare const hostDaemonCommandRegistry: {
                         skill: "skill";
                     }>;
                     origin: z$1.ZodEnum<{
-                        user: "user";
-                        project: "project";
                         builtin: "builtin";
+                        project: "project";
+                        user: "user";
                     }>;
                     label: z$1.ZodString;
                     argumentHint: z$1.ZodNullable<z$1.ZodString>;
@@ -4195,9 +4196,9 @@ declare const hostDaemonCommandRegistry: {
                         skill: "skill";
                     }>;
                     origin: z$1.ZodEnum<{
-                        user: "user";
-                        project: "project";
                         builtin: "builtin";
+                        project: "project";
+                        user: "user";
                     }>;
                     label: z$1.ZodString;
                     argumentHint: z$1.ZodNullable<z$1.ZodString>;
@@ -4260,16 +4261,16 @@ declare const hostDaemonCommandRegistry: {
             permissionScope: z$1.ZodLiteral<"workspace">;
             approvalReviewer: z$1.ZodLiteral<"user">;
             permissionEscalation: z$1.ZodEnum<{
-                deny: "deny";
                 ask: "ask";
+                deny: "deny";
             }>;
         }, z$1.core.$strip>, z$1.ZodObject<{
             permissionMode: z$1.ZodLiteral<"auto">;
             permissionScope: z$1.ZodLiteral<"workspace">;
             approvalReviewer: z$1.ZodLiteral<"automatic">;
             permissionEscalation: z$1.ZodEnum<{
-                deny: "deny";
                 ask: "ask";
+                deny: "deny";
             }>;
         }, z$1.core.$strip>, z$1.ZodObject<{
             permissionMode: z$1.ZodLiteral<"full">;
@@ -4386,9 +4387,9 @@ declare const hostDaemonCommandRegistry: {
             capabilities: z$1.ZodObject<{
                 supportsServiceTier: z$1.ZodBoolean;
                 permissionModes: z$1.ZodArray<z$1.ZodEnum<{
-                    auto: "auto";
-                    "accept-edits": "accept-edits";
                     full: "full";
+                    "accept-edits": "accept-edits";
+                    auto: "auto";
                 }>>;
                 supportsThreadArchive: z$1.ZodBoolean;
                 supportsThreadRename: z$1.ZodBoolean;
@@ -4408,9 +4409,6 @@ declare const hostDaemonCommandRegistry: {
                     personal: "personal";
                 }>;
             }, z$1.core.$strip>;
-            projectId: z$1.ZodString;
-            providerThreadId: z$1.ZodString;
-            providerId: z$1.ZodString;
             bridgeLaunch: z$1.ZodObject<{
                 pluginId: z$1.ZodString;
                 source: z$1.ZodDiscriminatedUnion<[z$1.ZodObject<{
@@ -4424,9 +4422,9 @@ declare const hostDaemonCommandRegistry: {
                 capabilities: z$1.ZodObject<{
                     supportsServiceTier: z$1.ZodBoolean;
                     permissionModes: z$1.ZodArray<z$1.ZodEnum<{
-                        auto: "auto";
-                        "accept-edits": "accept-edits";
                         full: "full";
+                        "accept-edits": "accept-edits";
+                        auto: "auto";
                     }>>;
                     supportsThreadArchive: z$1.ZodBoolean;
                     supportsThreadRename: z$1.ZodBoolean;
@@ -4441,6 +4439,8 @@ declare const hostDaemonCommandRegistry: {
                 append: "append";
                 replace: "replace";
             }>;
+            projectId: z$1.ZodString;
+            providerId: z$1.ZodString;
             acpLaunchSpec: z$1.ZodOptional<z$1.ZodObject<{
                 displayName: z$1.ZodString;
                 command: z$1.ZodString;
@@ -4572,6 +4572,7 @@ declare const hostDaemonCommandRegistry: {
                 skillFilePath: z$1.ZodString;
             }, z$1.core.$strict>], "kind">>;
             disallowedTools: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+            providerThreadId: z$1.ZodString;
         }, z$1.core.$strict>;
         target: z$1.ZodDiscriminatedUnion<[z$1.ZodObject<{
             mode: z$1.ZodLiteral<"start">;
@@ -4584,8 +4585,8 @@ declare const hostDaemonCommandRegistry: {
         }, z$1.core.$strip>], "mode">;
     }, z$1.core.$strict>, z$1.ZodObject<{
         appliedAs: z$1.ZodEnum<{
-            "new-turn": "new-turn";
             steer: "steer";
+            "new-turn": "new-turn";
         }>;
     }, z$1.core.$strip>, "settled", false>;
     "thread.stop": HostDaemonCommandDescriptor<"thread.stop", z$1.ZodObject<{
@@ -4632,16 +4633,16 @@ declare const hostDaemonCommandRegistry: {
             permissionScope: z$1.ZodLiteral<"workspace">;
             approvalReviewer: z$1.ZodLiteral<"user">;
             permissionEscalation: z$1.ZodEnum<{
-                deny: "deny";
                 ask: "ask";
+                deny: "deny";
             }>;
         }, z$1.core.$strip>, z$1.ZodObject<{
             permissionMode: z$1.ZodLiteral<"auto">;
             permissionScope: z$1.ZodLiteral<"workspace">;
             approvalReviewer: z$1.ZodLiteral<"automatic">;
             permissionEscalation: z$1.ZodEnum<{
-                deny: "deny";
                 ask: "ask";
+                deny: "deny";
             }>;
         }, z$1.core.$strip>, z$1.ZodObject<{
             permissionMode: z$1.ZodLiteral<"full">;
@@ -4758,9 +4759,9 @@ declare const hostDaemonCommandRegistry: {
             capabilities: z$1.ZodObject<{
                 supportsServiceTier: z$1.ZodBoolean;
                 permissionModes: z$1.ZodArray<z$1.ZodEnum<{
-                    auto: "auto";
-                    "accept-edits": "accept-edits";
                     full: "full";
+                    "accept-edits": "accept-edits";
+                    auto: "auto";
                 }>>;
                 supportsThreadArchive: z$1.ZodBoolean;
                 supportsThreadRename: z$1.ZodBoolean;
@@ -4780,9 +4781,6 @@ declare const hostDaemonCommandRegistry: {
                     personal: "personal";
                 }>;
             }, z$1.core.$strip>;
-            projectId: z$1.ZodString;
-            providerThreadId: z$1.ZodString;
-            providerId: z$1.ZodString;
             bridgeLaunch: z$1.ZodObject<{
                 pluginId: z$1.ZodString;
                 source: z$1.ZodDiscriminatedUnion<[z$1.ZodObject<{
@@ -4796,9 +4794,9 @@ declare const hostDaemonCommandRegistry: {
                 capabilities: z$1.ZodObject<{
                     supportsServiceTier: z$1.ZodBoolean;
                     permissionModes: z$1.ZodArray<z$1.ZodEnum<{
-                        auto: "auto";
-                        "accept-edits": "accept-edits";
                         full: "full";
+                        "accept-edits": "accept-edits";
+                        auto: "auto";
                     }>>;
                     supportsThreadArchive: z$1.ZodBoolean;
                     supportsThreadRename: z$1.ZodBoolean;
@@ -4813,6 +4811,8 @@ declare const hostDaemonCommandRegistry: {
                 append: "append";
                 replace: "replace";
             }>;
+            projectId: z$1.ZodString;
+            providerId: z$1.ZodString;
             acpLaunchSpec: z$1.ZodOptional<z$1.ZodObject<{
                 displayName: z$1.ZodString;
                 command: z$1.ZodString;
@@ -4944,6 +4944,7 @@ declare const hostDaemonCommandRegistry: {
                 skillFilePath: z$1.ZodString;
             }, z$1.core.$strict>], "kind">>;
             disallowedTools: z$1.ZodOptional<z$1.ZodArray<z$1.ZodString>>;
+            providerThreadId: z$1.ZodString;
         }, z$1.core.$strict>;
     }, z$1.core.$strict>, z$1.ZodObject<{
         cleared: z$1.ZodBoolean;
@@ -4989,9 +4990,9 @@ declare const hostDaemonCommandRegistry: {
             capabilities: z$1.ZodObject<{
                 supportsServiceTier: z$1.ZodBoolean;
                 permissionModes: z$1.ZodArray<z$1.ZodEnum<{
-                    auto: "auto";
-                    "accept-edits": "accept-edits";
                     full: "full";
+                    "accept-edits": "accept-edits";
+                    auto: "auto";
                 }>>;
                 supportsThreadArchive: z$1.ZodBoolean;
                 supportsThreadRename: z$1.ZodBoolean;
@@ -5022,9 +5023,9 @@ declare const hostDaemonCommandRegistry: {
             capabilities: z$1.ZodObject<{
                 supportsServiceTier: z$1.ZodBoolean;
                 permissionModes: z$1.ZodArray<z$1.ZodEnum<{
-                    auto: "auto";
-                    "accept-edits": "accept-edits";
                     full: "full";
+                    "accept-edits": "accept-edits";
+                    auto: "auto";
                 }>>;
                 supportsThreadArchive: z$1.ZodBoolean;
                 supportsThreadRename: z$1.ZodBoolean;
@@ -5155,9 +5156,9 @@ declare const hostDaemonCommandRegistry: {
             text: z$1.ZodString;
             startedAt: z$1.ZodOptional<z$1.ZodNumber>;
             status: z$1.ZodOptional<z$1.ZodEnum<{
+                started: "started";
                 completed: "completed";
                 failed: "failed";
-                started: "started";
             }>>;
             metadata: z$1.ZodOptional<z$1.ZodRecord<z$1.ZodString, z$1.ZodUnknown>>;
         }, z$1.core.$strip>>;
@@ -5412,8 +5413,8 @@ declare const hostDaemonCommandRegistry: {
                 skill: "skill";
             }>;
             origin: z$1.ZodEnum<{
-                user: "user";
                 project: "project";
+                user: "user";
             }>;
             description: z$1.ZodNullable<z$1.ZodString>;
             argumentHint: z$1.ZodNullable<z$1.ZodString>;
@@ -5434,9 +5435,9 @@ declare const hostDaemonCommandRegistry: {
             description: z$1.ZodNullable<z$1.ZodString>;
             filePath: z$1.ZodString;
             rootKind: z$1.ZodEnum<{
-                plugin: "plugin";
                 "shared-user": "shared-user";
                 "shared-project": "shared-project";
+                plugin: "plugin";
                 "bb-project": "bb-project";
                 "bb-data-dir": "bb-data-dir";
                 "bb-builtin": "bb-builtin";
@@ -5742,9 +5743,9 @@ declare const hostDaemonCommandRegistry: {
             capabilities: z$1.ZodObject<{
                 supportsServiceTier: z$1.ZodBoolean;
                 permissionModes: z$1.ZodArray<z$1.ZodEnum<{
-                    auto: "auto";
-                    "accept-edits": "accept-edits";
                     full: "full";
+                    "accept-edits": "accept-edits";
+                    auto: "auto";
                 }>>;
                 supportsThreadArchive: z$1.ZodBoolean;
                 supportsThreadRename: z$1.ZodBoolean;
@@ -5952,8 +5953,8 @@ declare const hostDaemonCommandRegistry: {
         npmGlobalPackageVersion: z$1.ZodNullable<z$1.ZodString>;
         installAction: z$1.ZodNullable<z$1.ZodObject<{
             kind: z$1.ZodEnum<{
-                update: "update";
                 install: "install";
+                update: "update";
             }>;
             label: z$1.ZodEnum<{
                 Install: "Install";
@@ -5975,8 +5976,8 @@ declare const hostDaemonCommandRegistry: {
             cursor: "cursor";
         }>;
         actionKind: z$1.ZodEnum<{
-            update: "update";
             install: "install";
+            update: "update";
         }>;
         type: z$1.ZodLiteral<"provider_cli.install">;
     }, z$1.core.$strict>, z$1.ZodObject<{
@@ -6332,9 +6333,9 @@ declare const hostDaemonCommandRegistry: {
                 conclusion: z$1.ZodNullable<z$1.ZodEnum<{
                     unknown: "unknown";
                     success: "success";
-                    skipped: "skipped";
                     cancelled: "cancelled";
                     failure: "failure";
+                    skipped: "skipped";
                     neutral: "neutral";
                     timed_out: "timed_out";
                     action_required: "action_required";
@@ -7770,9 +7771,9 @@ declare const terminalSessionSchema: z$1.ZodObject<{
     cols: z$1.ZodNumber;
     rows: z$1.ZodNumber;
     status: z$1.ZodEnum<{
-        running: "running";
         starting: "starting";
         disconnected: "disconnected";
+        running: "running";
         exited: "exited";
     }>;
     exitCode: z$1.ZodNullable<z$1.ZodNumber>;
@@ -7801,9 +7802,9 @@ declare const terminalListResponseSchema: z$1.ZodObject<{
         cols: z$1.ZodNumber;
         rows: z$1.ZodNumber;
         status: z$1.ZodEnum<{
-            running: "running";
             starting: "starting";
             disconnected: "disconnected";
+            running: "running";
             exited: "exited";
         }>;
         exitCode: z$1.ZodNullable<z$1.ZodNumber>;
@@ -10524,8 +10525,8 @@ declare const threadTimelineResponseSchema: z$1.ZodObject<{
         updatedAt: z$1.ZodNumber;
         objective: z$1.ZodString;
         status: z$1.ZodEnum<{
-            paused: "paused";
             active: "active";
+            paused: "paused";
             budgetLimited: "budgetLimited";
             complete: "complete";
         }>;

--- a/packages/thread-view/src/build-event-projection.ts
+++ b/packages/thread-view/src/build-event-projection.ts
@@ -597,6 +597,15 @@ function getCompactionTurnFinalization(
       detail: decoded.detail ?? decoded.message,
     };
   }
+  // A provider warning inside a compaction turn means the provider declined
+  // to compact (for example pi's "Nothing to compact"): the row settles as a
+  // skipped compaction instead of staying pending forever.
+  if (decoded.type === "provider/warning") {
+    return {
+      status: "completed",
+      detail: decoded.details ?? decoded.summary,
+    };
+  }
   if (decoded.type === "turn/completed" && decoded.status === "failed") {
     return {
       status: "error",
@@ -703,7 +712,7 @@ function buildFlatProjectionData(
 
     const compactionTurnFinalization = getCompactionTurnFinalization(decoded);
     if (compactionTurnFinalization) {
-      finalizeOpenCompactionsForTurn({
+      const settledPendingCompaction = finalizeOpenCompactionsForTurn({
         state,
         meta,
         threadId: decoded.threadId,
@@ -711,6 +720,11 @@ function buildFlatProjectionData(
         status: compactionTurnFinalization.status,
         detail: compactionTurnFinalization.detail,
       });
+      // The skipped-compaction row already carries the warning text; do not
+      // render the same notice a second time as a standalone warning row.
+      if (settledPendingCompaction && decoded.type === "provider/warning") {
+        continue;
+      }
     }
 
     if (isTerminalBufferedTextFlushEvent(eventType)) {

--- a/packages/thread-view/src/build-event-projection.ts
+++ b/packages/thread-view/src/build-event-projection.ts
@@ -597,10 +597,13 @@ function getCompactionTurnFinalization(
       detail: decoded.detail ?? decoded.message,
     };
   }
-  // A provider warning inside a compaction turn means the provider declined
-  // to compact (for example pi's "Nothing to compact"): the row settles as a
-  // skipped compaction instead of staying pending forever.
-  if (decoded.type === "provider/warning") {
+  // The provider declined a requested compaction (for example pi's "Nothing
+  // to compact"): the row settles as a skipped compaction instead of staying
+  // pending forever. Other warnings inside the turn leave the row alone.
+  if (
+    decoded.type === "provider/warning" &&
+    decoded.category === "compaction-skipped"
+  ) {
     return {
       status: "completed",
       detail: decoded.details ?? decoded.summary,

--- a/packages/thread-view/src/operation-projection.ts
+++ b/packages/thread-view/src/operation-projection.ts
@@ -71,7 +71,7 @@ export function createOperationProjectionState(
 
 export type CompactionTurnFinalizationStatus = Extract<
   EventProjectionOperationMessage["status"],
-  "error" | "interrupted"
+  "completed" | "error" | "interrupted"
 >;
 
 interface FinalizeOpenCompactionsForTurnArgs {
@@ -921,15 +921,22 @@ function finalizeOpenCompaction(
   message.title =
     status === "error"
       ? "Context compaction failed"
-      : "Context compaction interrupted";
+      : status === "completed"
+        ? "Context compaction skipped"
+        : "Context compaction interrupted";
   message.detail = detail ?? message.detail;
 }
 
+/**
+ * Returns true when at least one still-pending compaction row was settled, so
+ * the caller knows the finalizing event now belongs to that row.
+ */
 export function finalizeOpenCompactionsForTurn(
   args: FinalizeOpenCompactionsForTurnArgs,
-): void {
-  if (!args.turnId) return;
+): boolean {
+  if (!args.turnId) return false;
 
+  let settledPending = false;
   for (const message of args.state.openCompactionsByKey.values()) {
     if (
       message.threadId !== args.threadId ||
@@ -939,8 +946,12 @@ export function finalizeOpenCompactionsForTurn(
       continue;
     }
 
+    if (message.status === "pending") {
+      settledPending = true;
+    }
     finalizeOpenCompaction(message, args.meta, args.status, args.detail);
   }
+  return settledPending;
 }
 
 /** Settle only compactions that are pending when this interruption is seen. */

--- a/packages/thread-view/test/timeline-interruption.test.ts
+++ b/packages/thread-view/test/timeline-interruption.test.ts
@@ -104,6 +104,7 @@ describe("timeline interruption projection", () => {
       event.turnStarted({ createdAt: 0 }),
       event.contextCompactionStarted({ createdAt: 1_000 }),
       event.providerWarning({
+        category: "compaction-skipped",
         summary: "Context compaction skipped",
         details: "Compaction failed: Nothing to compact (session too small)",
         createdAt: 2_000,
@@ -127,6 +128,43 @@ describe("timeline interruption projection", () => {
           message.kind === "operation" && message.opType === "warning",
       ),
     ).toBe(false);
+  });
+
+  it("keeps a pending compaction and renders an unrelated warning in the same turn", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const timeline = renderTimelineFixture({
+      events: [
+        event.turnStarted({ createdAt: 0 }),
+        event.contextCompactionStarted({ createdAt: 1_000 }),
+        event.providerWarning({
+          summary: "Model fallback",
+          details: "Requested model unavailable; using a fallback.",
+          createdAt: 2_000,
+        }),
+      ],
+      projectionOptions: {
+        threadStatus: "active",
+        turnMessageDetail: "full",
+      },
+    });
+
+    expect(timeline.messages).toContainEqual(
+      expect.objectContaining({
+        kind: "operation",
+        opType: "compaction",
+        status: "pending",
+        title: "Compacting context",
+        completedAt: null,
+      }),
+    );
+    expect(timeline.messages).toContainEqual(
+      expect.objectContaining({
+        kind: "operation",
+        opType: "warning",
+        title: "Model fallback",
+        detail: "Requested model unavailable; using a fallback.",
+      }),
+    );
   });
 
   it("interrupts post-turn compaction when the thread is explicitly interrupted", () => {

--- a/packages/thread-view/test/timeline-interruption.test.ts
+++ b/packages/thread-view/test/timeline-interruption.test.ts
@@ -98,6 +98,37 @@ describe("timeline interruption projection", () => {
     );
   });
 
+  it("settles a skipped manual compaction from the provider warning", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const timeline = renderIdleTimeline([
+      event.turnStarted({ createdAt: 0 }),
+      event.contextCompactionStarted({ createdAt: 1_000 }),
+      event.providerWarning({
+        summary: "Context compaction skipped",
+        details: "Compaction failed: Nothing to compact (session too small)",
+        createdAt: 2_000,
+      }),
+      event.turnCompleted({ createdAt: 3_000 }),
+    ]);
+
+    expect(timeline.messages).toContainEqual(
+      expect.objectContaining({
+        kind: "operation",
+        opType: "compaction",
+        status: "completed",
+        title: "Context compaction skipped",
+        detail: "Compaction failed: Nothing to compact (session too small)",
+        completedAt: 2_000,
+      }),
+    );
+    expect(
+      timeline.messages.some(
+        (message) =>
+          message.kind === "operation" && message.opType === "warning",
+      ),
+    ).toBe(false);
+  });
+
   it("interrupts post-turn compaction when the thread is explicitly interrupted", () => {
     const event = createTimelineEventFactory({ threadId: "thread-1" });
     const timeline = renderIdleTimeline([

--- a/packages/thread-view/test/timeline-test-harness.ts
+++ b/packages/thread-view/test/timeline-test-harness.ts
@@ -228,6 +228,7 @@ interface ProviderErrorArgs extends ProviderTurnEventOptions {
 }
 
 interface ProviderWarningArgs extends ProviderTurnEventOptions {
+  category?: ThreadEventWarningCategory;
   details?: string;
   summary?: string;
 }
@@ -828,7 +829,7 @@ export function createTimelineEventFactory(
         type: "provider/warning",
         data: {
           ...providerFields(args),
-          category: "general",
+          category: args.category ?? "general",
           summary: args.summary,
           details: args.details,
         },

--- a/packages/thread-view/test/timeline-test-harness.ts
+++ b/packages/thread-view/test/timeline-test-harness.ts
@@ -227,6 +227,11 @@ interface ProviderErrorArgs extends ProviderTurnEventOptions {
   willRetry?: boolean;
 }
 
+interface ProviderWarningArgs extends ProviderTurnEventOptions {
+  details?: string;
+  summary?: string;
+}
+
 interface SystemOperationArgs extends EventFactoryRowOptions {
   message: string;
   metadata?: Record<string, JsonValue>;
@@ -323,6 +328,9 @@ export interface TimelineEventFactory {
   providerUnhandled(
     args?: ProviderUnhandledArgs,
   ): ThreadEventRowOfType<"provider/unhandled">;
+  providerWarning(
+    args?: ProviderWarningArgs,
+  ): ThreadEventRowOfType<"provider/warning">;
   providerUserMessage(
     args: ProviderUserMessageArgs,
   ): ThreadEventRowOfType<"item/completed">;
@@ -810,6 +818,19 @@ export function createTimelineEventFactory(
           message: args.message,
           detail: args.detail,
           willRetry: args.willRetry,
+        },
+      };
+    },
+    providerWarning(args = {}) {
+      const base = nextProviderTurnScopedRowBase("provider-warning", args);
+      return {
+        ...base,
+        type: "provider/warning",
+        data: {
+          ...providerFields(args),
+          category: "general",
+          summary: args.summary,
+          details: args.details,
         },
       };
     },


### PR DESCRIPTION
## What was wrong

Pi has a `keepRecentTokens` floor (20k tokens by default). When a session has nothing before that floor, `/compact` refuses before it calls the model with `Compaction failed: Nothing to compact (session too small)`. Pi reports that refusal through the same `compaction_end.errorMessage` field as a real failure. The pi event translator (`packages/agent-runtime/src/pi/event-translation.ts`) turned every manual `compaction_end` error into `turn/completed status=failed`. The server maps a failed root turn to `run.failed`, so the thread moved to `error`, the composer showed "Retry by sending a follow-up message", and `bb thread tell` (steer mode) answered `HTTP 409: Thread is not active`. Nothing was wrong with the session.

Report: https://get-bb.github.io/reports/issues/1721.html

## What changed

- `packages/agent-runtime/src/pi/event-translation.ts`: a manual `compaction_end` with pi's pre-flight refusal messages (`Nothing to compact (session too small)`, `Already compacted`) is a no-op. The translator emits `provider/warning { summary: "Context compaction skipped", details: <pi message> }` and a normal `turn/completed status=completed`. Real failures (for example `Summarization failed: ...`) still emit `status=failed`. Manual compaction still owns its maintenance turn.
- `packages/thread-view/src/build-event-projection.ts`, `operation-projection.ts`: a `provider/warning` inside a compaction turn settles the pending compaction row as `Context compaction skipped` with the warning detail. The row was otherwise pending forever, because no `thread/compacted` or `item/completed` follows a refusal. The warning is not rendered a second time as a standalone row.
- Tests: `event-translation.test.ts` gets the no-op case for both refusal messages and the pinned failure case now uses a real failure message. `timeline-interruption.test.ts` gets the projection case (with a `providerWarning` factory in the harness).

## Deviation from the report

The report suggested `provider/error{message:"Context compaction skipped"}` as the cheapest way to close the compaction row. That renders a red "Provider error" row and an error-status compaction row, which is not informational. This PR uses `provider/warning` instead and settles the row with a `completed` status. No wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## Update after SlopCop review

- Added the `compaction-skipped` provider warning category (`packages/domain`). The pi translator emits it for a refused manual compaction, and the thread view settles the pending compaction row **only** for that category. An unrelated warning inside a compaction turn keeps its own row and leaves the compaction pending (new test `keeps a pending compaction and renders an unrelated warning in the same turn`, fails before / passes after).
- Bumped `HOST_DAEMON_PROTOCOL_VERSION` to 135 (134 was taken by #1804) (plus the contract test), because the daemon event stream and the warning category enum changed.
- Regenerated `packages/plugin-sdk/bundled-types` for the new enum member.
- Verified: `turbo typecheck` for domain, agent-runtime, thread-view, host-daemon-contract, plugin-sdk, server, app — 7 successful; `turbo test` for domain (145), host-daemon-contract (52), thread-view (378), agent-runtime (320) — all pass.

## How I verified

- Before the change: the two new translator tests failed (`status: "failed"` with the pi error), and the new thread-view test failed (row stayed `pending`).
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime --filter=@bb/thread-view` — 2 successful.
- `pnpm exec turbo run test --filter=@bb/agent-runtime --filter=@bb/thread-view` — agent-runtime 320 passed, thread-view 377 passed.

Fixes #1721

> AGENT GENERATED: by Claude Opus 5

