### PR TITLE
Speed up model and reasoning picker loading

### DIFF
--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -517,6 +517,8 @@ export const REALTIME_SYSTEM_CHANGE_REGISTRY = {
       dirtyPluginContributionQueries,
       dirtyProjectCommandCatalogQueries,
       dirtyPluginManagementQueries,
+      dirtySystemProviderQueries, // Provider plugins add/remove picker entries.
+      dirtySystemExecutionOptionQueries, // Refresh a boot-time partial provider roster.
       reconcilePluginFrontendBundles,
     ],
   },

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -23,6 +23,8 @@ import {
   projectsQueryKey,
   sidebarNavigationQueryKey,
   systemConfigQueryKey,
+  systemExecutionOptionsQueryKey,
+  systemProvidersQueryKey,
   threadDefaultExecutionOptionsQueryKey,
   threadQueuedMessagesQueryKey,
   threadListQueryKey,
@@ -179,7 +181,7 @@ describe("createRealtimeCacheEffects", () => {
     effects.dispose();
   });
 
-  it("invalidates plugin contributions and command catalogs on plugins-changed", () => {
+  it("invalidates plugin contributions, commands, and provider pickers on plugins-changed", () => {
     const { effects, queryClient } = createRealtimeEffectsTestContext();
     const contributionsKey = pluginContributionsQueryKey();
     queryClient.setQueryData(contributionsKey, {
@@ -193,6 +195,14 @@ describe("createRealtimeCacheEffects", () => {
       null,
     );
     queryClient.setQueryData(commandsKey, { commands: [] });
+    const providersKey = systemProvidersQueryKey({ hostId: "host-1" });
+    queryClient.setQueryData(providersKey, []);
+    const executionOptionsKey = systemExecutionOptionsQueryKey({
+      environmentId: "environment-1",
+      hostId: "host-1",
+      providerId: "codex",
+    });
+    queryClient.setQueryData(executionOptionsKey, {});
 
     effects.handleChanged({
       type: "changed",
@@ -206,6 +216,10 @@ describe("createRealtimeCacheEffects", () => {
       true,
     );
     expect(queryClient.getQueryState(commandsKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(providersKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(executionOptionsKey)?.isInvalidated).toBe(
+      true,
+    );
   });
 
   it("invalidates timelines when config changes provider event visibility", () => {

--- a/apps/server/src/services/providers/provider-registry.ts
+++ b/apps/server/src/services/providers/provider-registry.ts
@@ -166,12 +166,25 @@ export interface ProviderRegistryService {
     registration: Omit<ProviderRegistration, "source"> & { pluginId: string },
   ): { dispose(): void };
   /**
+   * Resolves as soon as the requested provider's plugin has registered, or
+   * when plugin startup settles without it. Dynamic `acp-*` ids share the ACP
+   * tier registration, since those per-agent ids are resolved from config and
+   * are never registered individually.
+   *
+   * Use this for a request already scoped to one provider. Full provider
+   * listings still use {@link whenRegistrationsSettled} so their roster is
+   * complete rather than reflecting a partially loaded plugin set.
+   */
+  whenProviderRegistered(providerId: string): Promise<void>;
+  /**
    * Resolves once provider registrations have settled — that is, once plugin
    * startup finished (or failed). Providers exist only while their plugin is
    * loaded, and the HTTP listener deliberately starts serving before plugins
    * load, so anything that routes work by provider must wait for this: on that
-   * boot window the registry is still empty and the request would fail with
-   * "no provider available" or dispatch a command with no bridge launch.
+   * boot window the registry is still empty and an unscoped request would
+   * fail with "no provider available". Picker/model requests already scoped
+   * to a provider use {@link whenProviderRegistered} so unrelated plugins do
+   * not hold them behind this full-startup gate.
    *
    * Bounded by {@link REGISTRATIONS_SETTLED_TIMEOUT_MS} so a stuck plugin
    * cannot wedge requests, and so a plugin's own loopback SDK call during
@@ -209,6 +222,7 @@ export function createProviderRegistryService(
   deps: ProviderRegistryDeps = {},
 ): ProviderRegistryService {
   const pluginRegistrations = new Map<string, ProviderRegistration>();
+  const providerRegistrationWaiters = new Map<string, Set<() => void>>();
   let settle: (() => void) | null = null;
   const settled: Promise<void> =
     deps.deferRegistrationsSettled === true
@@ -219,6 +233,55 @@ export function createProviderRegistryService(
 
   function getRegistration(providerId: string): ProviderRegistration | null {
     return pluginRegistrations.get(providerId) ?? null;
+  }
+
+  function registrationWaiterKey(providerId: string): string {
+    return isAcpProviderId(providerId) ? ACP_TIER_OWNER_PLUGIN_ID : providerId;
+  }
+
+  function hasProviderRegistration(providerId: string): boolean {
+    if (!isAcpProviderId(providerId)) {
+      return pluginRegistrations.has(providerId);
+    }
+    for (const registeredProviderId of pluginRegistrations.keys()) {
+      if (isAcpProviderId(registeredProviderId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function releaseProviderRegistrationWaiters(providerId: string): void {
+    const key = registrationWaiterKey(providerId);
+    const waiters = providerRegistrationWaiters.get(key);
+    if (waiters === undefined) return;
+    providerRegistrationWaiters.delete(key);
+    for (const resolve of waiters) resolve();
+  }
+
+  function releaseAllProviderRegistrationWaiters(): void {
+    for (const waiters of providerRegistrationWaiters.values()) {
+      for (const resolve of waiters) resolve();
+    }
+    providerRegistrationWaiters.clear();
+  }
+
+  async function waitUntilSettledOrTimeout(
+    readiness: Promise<void>,
+  ): Promise<void> {
+    if (settle === null) {
+      return;
+    }
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    await Promise.race([
+      readiness,
+      settled,
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, REGISTRATIONS_SETTLED_TIMEOUT_MS);
+        timer.unref?.();
+      }),
+    ]);
+    clearTimeout(timer);
   }
 
   return {
@@ -315,6 +378,7 @@ export function createProviderRegistryService(
         ...(registration.icon === undefined ? {} : { icon: registration.icon }),
       };
       pluginRegistrations.set(providerId, entry);
+      releaseProviderRegistrationWaiters(providerId);
       return {
         dispose() {
           if (pluginRegistrations.get(providerId) === entry) {
@@ -324,24 +388,37 @@ export function createProviderRegistryService(
       };
     },
 
-    async whenRegistrationsSettled() {
-      if (settle === null) {
-        return settled;
+    async whenProviderRegistered(providerId) {
+      if (hasProviderRegistration(providerId) || settle === null) {
+        return;
       }
-      let timer: ReturnType<typeof setTimeout> | undefined;
-      await Promise.race([
-        settled,
-        new Promise<void>((resolve) => {
-          timer = setTimeout(resolve, REGISTRATIONS_SETTLED_TIMEOUT_MS);
-          timer.unref?.();
-        }),
-      ]);
-      clearTimeout(timer);
+      const key = registrationWaiterKey(providerId);
+      let release!: () => void;
+      const registered = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const waiters = providerRegistrationWaiters.get(key) ?? new Set();
+      waiters.add(release);
+      providerRegistrationWaiters.set(key, waiters);
+      try {
+        await waitUntilSettledOrTimeout(registered);
+      } finally {
+        const currentWaiters = providerRegistrationWaiters.get(key);
+        currentWaiters?.delete(release);
+        if (currentWaiters?.size === 0) {
+          providerRegistrationWaiters.delete(key);
+        }
+      }
+    },
+
+    async whenRegistrationsSettled() {
+      await waitUntilSettledOrTimeout(settled);
     },
 
     markRegistrationsSettled() {
       settle?.();
       settle = null;
+      releaseAllProviderRegistrationWaiters();
     },
   };
 }

--- a/apps/server/src/services/system/execution-options.ts
+++ b/apps/server/src/services/system/execution-options.ts
@@ -312,7 +312,7 @@ export async function resolveSystemProviderModels(
   deps: LoggedWorkSessionDeps,
   args: ResolveSystemProviderModelsArgs,
 ): Promise<ModelListResult> {
-  await deps.providerRegistry.whenRegistrationsSettled();
+  await deps.providerRegistry.whenProviderRegistered(args.providerId);
   const configuredProvider = listConfiguredSystemProviderInfos(deps, []).find(
     (provider) => provider.id === args.providerId,
   );
@@ -433,7 +433,11 @@ export async function resolveSystemExecutionOptions(
   deps: LoggedWorkSessionDeps,
   query: SystemExecutionOptionsRequest,
 ): Promise<SystemExecutionOptionsResponse> {
-  await deps.providerRegistry.whenRegistrationsSettled();
+  if (query.providerId === undefined) {
+    await deps.providerRegistry.whenRegistrationsSettled();
+  } else {
+    await deps.providerRegistry.whenProviderRegistered(query.providerId);
+  }
   const cwd =
     query.environmentId === undefined
       ? undefined

--- a/apps/server/test/providers/provider-registry.test.ts
+++ b/apps/server/test/providers/provider-registry.test.ts
@@ -241,4 +241,42 @@ describe("provider registry", () => {
     });
     second.dispose();
   });
+
+  it("releases a provider-scoped boot wait as soon as that provider registers", async () => {
+    const registry = createProviderRegistryService({
+      deferRegistrationsSettled: true,
+    });
+    let requestedProviderReady = false;
+    let unrelatedProviderReady = false;
+    const requestedWait = registry.whenProviderRegistered("codex").then(() => {
+      requestedProviderReady = true;
+    });
+    const unrelatedWait = registry
+      .whenProviderRegistered("claude-code")
+      .then(() => {
+        unrelatedProviderReady = true;
+      });
+
+    registerProvider(registry, "codex", "provider-codex");
+    await requestedWait;
+
+    expect(requestedProviderReady).toBe(true);
+    expect(unrelatedProviderReady).toBe(false);
+
+    registry.markRegistrationsSettled();
+    await unrelatedWait;
+    expect(unrelatedProviderReady).toBe(true);
+  });
+
+  it("uses the shared ACP tier registration to release dynamic ACP waits", async () => {
+    const registry = createProviderRegistryService({
+      deferRegistrationsSettled: true,
+    });
+    const ready = registry.whenProviderRegistered("acp-opencode");
+
+    registerProvider(registry, "acp-cursor", "provider-acp");
+
+    await ready;
+    expect(registry.get("acp-opencode")).toBeNull();
+  });
 });

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -1058,6 +1058,47 @@ describe("resolveSystemExecutionOptions", () => {
     );
   });
 
+  it("answers a provider-scoped picker request before unrelated plugins finish loading", async () => {
+    await withTestHarness(
+      { seedFirstPartyProviders: false },
+      async (harness) => {
+        const registry = createProviderRegistryService({
+          deferRegistrationsSettled: true,
+        });
+        harness.deps.providerRegistry = registry;
+        const { host, session } = seedHostSession(harness.deps, {
+          id: "host-execution-options-provider-ready",
+        });
+        registerProviderHostRpcResponder(harness, {
+          hostId: host.id,
+          sessionId: session.id,
+        });
+
+        const optionsPromise = resolveSystemExecutionOptions(harness.deps, {
+          hostId: host.id,
+          providerId: "pi",
+        });
+        await registerFirstPartyProviders(registry, {
+          excludePluginIds: [
+            "provider-acp",
+            "provider-claude-code",
+            "provider-codex",
+          ],
+        });
+
+        const response = await optionsPromise;
+        expect(response.providers.map((provider) => provider.id)).toEqual([
+          "pi",
+        ]);
+        expect(response.modelLoadError).toBeNull();
+
+        // Full plugin startup is intentionally still outstanding. It may
+        // complete later and invalidate this partial boot-time roster.
+        registry.markRegistrationsSettled();
+      },
+    );
+  });
+
   // Dynamic ACP ids run on the ACP plugin's bridge and are never registered
   // themselves, so with that plugin disabled they have no bridge anywhere:
   // listing them would offer agents whose first turn fails on the daemon.

--- a/plugins/provider-codex/src/bridge/app-server-connection.ts
+++ b/plugins/provider-codex/src/bridge/app-server-connection.ts
@@ -1,9 +1,9 @@
 /**
  * JSON-RPC 2.0 endpoint over a spawned `codex app-server` child's stdio.
  *
- * The codex bridge supervises one app-server child per bb thread (plus
- * short-lived maintenance children). This module owns the child-process
- * exit races the runtime learned in #1402:
+ * The codex bridge supervises one app-server child per bb thread, a reusable
+ * model-list child, and short-lived thread-maintenance children. This module
+ * owns the child-process exit races the runtime learned in #1402:
  *
  * - Exit is finalized on `close`, not `exit`, with a bounded grace so a
  *   descendant holding an inherited pipe cannot delay teardown forever —

--- a/plugins/provider-codex/src/bridge/bridge.model-list.test.ts
+++ b/plugins/provider-codex/src/bridge/bridge.model-list.test.ts
@@ -1,0 +1,38 @@
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createBridgeJsonRpcTestHarness } from "@bb/provider-bridge-protocol/testing";
+import { experimental_killAllChildrenForTests, handleLine } from "./bridge.js";
+
+const fakeAppServerPath = fileURLToPath(
+  new URL("./fake-codex-app-server.mjs", import.meta.url),
+);
+
+let harness: ReturnType<typeof createBridgeJsonRpcTestHarness>;
+
+beforeEach(() => {
+  vi.stubEnv("BB_CODEX_BRIDGE_APP_SERVER_COMMAND", process.execPath);
+  vi.stubEnv(
+    "BB_CODEX_BRIDGE_APP_SERVER_ARGS",
+    JSON.stringify([fakeAppServerPath]),
+  );
+  harness = createBridgeJsonRpcTestHarness(handleLine);
+});
+
+afterEach(() => {
+  experimental_killAllChildrenForTests();
+  harness.restore();
+  vi.unstubAllEnvs();
+});
+
+it("reuses one initialized app-server across model catalog requests", async () => {
+  harness.sendRequest(1, "model/list", {});
+  const first = await harness.waitForResponse(1);
+  harness.sendRequest(2, "model/list", {});
+  const second = await harness.waitForResponse(2);
+
+  expect(first.error).toBeUndefined();
+  expect(second.error).toBeUndefined();
+  // The fixture puts a random per-process identity in its model id. Equal
+  // catalogs therefore prove both requests reached the same child process.
+  expect(second.result).toEqual(first.result);
+});

--- a/plugins/provider-codex/src/bridge/bridge.ts
+++ b/plugins/provider-codex/src/bridge/bridge.ts
@@ -369,6 +369,8 @@ interface CodexBridgeSession {
 
 const sessionsByBbThreadId = new Map<string, CodexBridgeSession>();
 const maintenanceConnections = new Set<CodexAppServerConnection>();
+let modelListConnection: CodexAppServerConnection | null = null;
+let modelListConnectionPromise: Promise<CodexAppServerConnection> | null = null;
 let sessionSerialCounter = 0;
 let configuredSkillExtraRoots: string[] | null = null;
 
@@ -1258,16 +1260,14 @@ async function rebuildThreadSession(
 }
 
 // ---------------------------------------------------------------------------
-// Maintenance children (model/list; thread ops without a live child)
+// Maintenance children (thread ops without a live child; reusable model list)
 // ---------------------------------------------------------------------------
 
 /**
- * Run one request against an app-server. Thread-scoped maintenance uses the
- * thread's live child when one exists (the rollout is open there); otherwise
- * — and always for model/list — a one-shot child is spawned and killed after
- * the call. One-shot keeps the bridge free of a persistent maintenance
- * process to supervise; archive/rename after release are rare enough that
- * the extra spawn is the simpler correct trade.
+ * Run one request against a one-shot app-server. Thread-scoped maintenance
+ * uses the thread's live child when one exists (the rollout is open there);
+ * archive/rename after release are rare enough that spawning here remains the
+ * simpler trade.
  */
 async function withMaintenanceChild<T>(
   fn: (connection: CodexAppServerConnection) => Promise<T>,
@@ -1289,6 +1289,59 @@ async function withMaintenanceChild<T>(
   } finally {
     maintenanceConnections.delete(connection);
     connection.kill();
+  }
+}
+
+/**
+ * Lazily initialize and retain the app-server used for model catalogs. The
+ * host daemon already retains one bridge runtime for model listing, so keeping
+ * its child alive restores the pre-plugin behavior: later picker refreshes ask
+ * an initialized process instead of paying process startup on every request.
+ * A concurrent cold lookup shares the same initialization promise, and an
+ * exited child is replaced by the next lookup.
+ */
+async function getModelListConnection(): Promise<CodexAppServerConnection> {
+  if (modelListConnection !== null && !modelListConnection.exited) {
+    return modelListConnection;
+  }
+  if (modelListConnectionPromise !== null) {
+    return modelListConnectionPromise;
+  }
+
+  const connectionPromise = (async () => {
+    const connection = spawnChildConnection({
+      onNotification: () => {},
+      onRequest: (_method, _params, responder) => {
+        responder.error(
+          BRIDGE_JSON_RPC_ERRORS.METHOD_NOT_FOUND,
+          "model-list codex app-server does not serve requests",
+        );
+      },
+      onExit: () => {
+        maintenanceConnections.delete(connection);
+        if (modelListConnection === connection) {
+          modelListConnection = null;
+        }
+      },
+    });
+    maintenanceConnections.add(connection);
+    try {
+      await initializeChild(connection);
+      modelListConnection = connection;
+      return connection;
+    } catch (error) {
+      maintenanceConnections.delete(connection);
+      connection.kill();
+      throw error;
+    }
+  })();
+  modelListConnectionPromise = connectionPromise;
+  try {
+    return await connectionPromise;
+  } finally {
+    if (modelListConnectionPromise === connectionPromise) {
+      modelListConnectionPromise = null;
+    }
   }
 }
 
@@ -1345,14 +1398,13 @@ function handleInitialize(id: string | number): void {
 
 async function handleModelList(id: string | number): Promise<void> {
   try {
-    const result = await withMaintenanceChild((connection) =>
-      connection.request({
-        method: "model/list",
-        params: {},
-        resultSchema: ignoredChildResultSchema,
-        timeoutMs: CHILD_REQUEST_TIMEOUT_MS,
-      }),
-    );
+    const connection = await getModelListConnection();
+    const result = await connection.request({
+      method: "model/list",
+      params: {},
+      resultSchema: ignoredChildResultSchema,
+      timeoutMs: CHILD_REQUEST_TIMEOUT_MS,
+    });
     // Codex's upstream API only exposes an active model list; legacy/retired
     // models aren't surfaced separately, so selectedOnlyModels is always
     // empty.
@@ -1939,11 +1991,16 @@ function killAllChildren(): void {
     session.connection = null;
   }
   sessionsByBbThreadId.clear();
+  modelListConnection = null;
+  modelListConnectionPromise = null;
   for (const connection of maintenanceConnections) {
     connection.kill();
   }
   maintenanceConnections.clear();
 }
+
+/** @internal Test cleanup for bridge tests that create a persistent child. */
+export const experimental_killAllChildrenForTests = killAllChildren;
 
 export const experimental_providerBridge = experimental_defineProviderBridge({
   handleLine,

--- a/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
+++ b/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
@@ -29,6 +29,7 @@ import { createInterface } from "node:readline";
 let threadCounter = 0;
 let turnCounter = 0;
 const openTurnIdsByThreadId = new Map();
+const processInstanceId = `${process.pid}-${Date.now()}-${Math.random()}`;
 
 function send(message) {
   process.stdout.write(`${JSON.stringify(message)}\n`);
@@ -170,6 +171,23 @@ async function handleRequest(message) {
       return;
     case "account/rateLimits/read":
       respond(id, { rateLimits: {} });
+      return;
+    case "model/list":
+      respond(id, {
+        data: [
+          {
+            id: `fake-model-${processInstanceId}`,
+            model: `fake-model-${processInstanceId}`,
+            displayName: "Fake model",
+            description: "Hermetic bridge fixture model",
+            supportedReasoningEfforts: [
+              { reasoningEffort: "medium", description: "Medium" },
+            ],
+            defaultReasoningEffort: "medium",
+            isDefault: true,
+          },
+        ],
+      });
       return;
     case "skills/extraRoots/set":
       respond(id, {});


### PR DESCRIPTION
## Summary

- unblock provider-scoped picker requests as soon as the requested provider plugin registers
- reuse one initialized Codex app-server for model catalog refreshes
- invalidate provider and execution-option caches when plugin state changes
- keep full provider listings gated until plugin startup settles

## Testing

- `pnpm exec turbo run test --filter=@bb/server -- --run test/providers/provider-registry.test.ts test/system/execution-options.test.ts`
- `pnpm exec turbo run test --filter=bb-plugin-provider-codex --force`
- `pnpm exec turbo run test --filter=@bb/app -- --run src/hooks/realtime-cache-effects.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/app --filter=bb-plugin-provider-codex`
- `pnpm exec turbo run lint --filter=@bb/app` (0 errors; existing warnings remain)

> AGENT GENERATED: by GPT-5