### PR TITLE
Speed up clean dev startup with runtime-only plugin SDK build

### DIFF
--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -90,6 +90,7 @@
   "types": "./bundled-types/bb-plugin-sdk.d.ts",
   "scripts": {
     "build": "node scripts/build-bundled-dts.mjs && node scripts/build-runtime.mjs",
+    "build:runtime": "node scripts/build-runtime.mjs",
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "prepack": "node scripts/build-bundled-dts.mjs && node scripts/build-runtime.mjs",
     "test": "vitest run --config vitest.config.ts",

--- a/turbo.json
+++ b/turbo.json
@@ -252,7 +252,7 @@
       // `@get-bb/plugin-sdk/provider-bridge` entry from the SDK dist, so a
       // clean worktree must build that runtime before the server starts.
       "dependsOn": [
-        "@get-bb/plugin-sdk#build"
+        "@get-bb/plugin-sdk#build:runtime"
       ],
       "cache": false,
       "persistent": true,
@@ -497,6 +497,17 @@
       ],
       "outputs": [
         "bundled-types/**",
+        "dist/**"
+      ]
+    },
+    "@get-bb/plugin-sdk#build:runtime": {
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/packages/*/package.json",
+        "$TURBO_ROOT$/packages/*/src/**",
+        "$TURBO_ROOT$/packages/plugin-sdk/scripts/build-runtime.mjs"
+      ],
+      "outputs": [
         "dist/**"
       ]
     },


### PR DESCRIPTION
## Summary

- add a cached runtime-only build task for `@get-bb/plugin-sdk`
- make `@bb/server#dev` depend on the runtime task instead of the full SDK package build
- preserve the full declaration-generating build for packaging and validation

## Why

A clean `pnpm dev` only needs the SDK runtime in `dist` before the server builds first-party provider artifacts. The previous dependency ran all 11 portable declaration bundles first, adding roughly 15 seconds to the server startup critical path.

The forced runtime-only task completes in about 400 ms inside Turbo, while the full SDK build remains unchanged.

## Testing

- `pnpm exec turbo run dev --filter=@bb/app --filter=@bb/server --filter=@bb/host-daemon --dry=json`
- `pnpm exec turbo run build:runtime --filter=@get-bb/plugin-sdk --force`
- `pnpm exec turbo run build --filter=@get-bb/plugin-sdk --force`
- `git diff --check origin/main...HEAD`

> AGENT GENERATED: by GPT-5