### PR TITLE
Recover Codex model listing after child failures

### DIFF
--- a/plugins/provider-codex/src/bridge/bridge.model-list.test.ts
+++ b/plugins/provider-codex/src/bridge/bridge.model-list.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { createBridgeJsonRpcTestHarness } from "@bb/provider-bridge-protocol/testing";
@@ -8,6 +11,7 @@ const fakeAppServerPath = fileURLToPath(
 );
 
 let harness: ReturnType<typeof createBridgeJsonRpcTestHarness>;
+const temporaryDirectories: string[] = [];
 
 beforeEach(() => {
   vi.stubEnv("BB_CODEX_BRIDGE_APP_SERVER_COMMAND", process.execPath);
@@ -18,10 +22,15 @@ beforeEach(() => {
   harness = createBridgeJsonRpcTestHarness(handleLine);
 });
 
-afterEach(() => {
+afterEach(async () => {
   experimental_killAllChildrenForTests();
   harness.restore();
   vi.unstubAllEnvs();
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true })),
+  );
 });
 
 it("reuses one initialized app-server across model catalog requests", async () => {
@@ -35,4 +44,38 @@ it("reuses one initialized app-server across model catalog requests", async () =
   // The fixture puts a random per-process identity in its model id. Equal
   // catalogs therefore prove both requests reached the same child process.
   expect(second.result).toEqual(first.result);
+});
+
+it("replaces the cached app-server after a model catalog failure", async () => {
+  const workDir = await mkdtemp(join(tmpdir(), "bb-codex-model-list-"));
+  temporaryDirectories.push(workDir);
+  const scriptPath = join(workDir, "script.json");
+  await writeFile(
+    scriptPath,
+    JSON.stringify({
+      modelListFailOnceMarkerPath: join(workDir, "failed-once"),
+      turns: [],
+    }),
+  );
+  vi.stubEnv(
+    "BB_CODEX_BRIDGE_APP_SERVER_ARGS",
+    JSON.stringify([fakeAppServerPath, scriptPath]),
+  );
+
+  harness.sendRequest(1, "model/list", {});
+  const failed = await harness.waitForResponse(1);
+  harness.sendRequest(2, "model/list", {});
+  const recovered = await harness.waitForResponse(2);
+
+  expect(failed.error?.message).toContain(
+    "Codex model/list returned no supported models.",
+  );
+  expect(recovered.error).toBeUndefined();
+  expect(recovered.result).toMatchObject({
+    models: [
+      {
+        displayName: "Fake model",
+      },
+    ],
+  });
 });

--- a/plugins/provider-codex/src/bridge/bridge.ts
+++ b/plugins/provider-codex/src/bridge/bridge.ts
@@ -1345,6 +1345,19 @@ async function getModelListConnection(): Promise<CodexAppServerConnection> {
   }
 }
 
+/**
+ * Retire a cached model-list child after a request-level failure. A timeout or
+ * malformed response does not make the connection report `exited`, but it is
+ * no longer safe to reuse: a later picker refresh must get a fresh process.
+ */
+function retireModelListConnection(connection: CodexAppServerConnection): void {
+  maintenanceConnections.delete(connection);
+  if (modelListConnection === connection) {
+    modelListConnection = null;
+  }
+  connection.kill();
+}
+
 async function withChildForThread<T>(
   bbThreadId: string,
   fn: (connection: CodexAppServerConnection) => Promise<T>,
@@ -1397,8 +1410,9 @@ function handleInitialize(id: string | number): void {
 }
 
 async function handleModelList(id: string | number): Promise<void> {
+  let connection: CodexAppServerConnection | null = null;
   try {
-    const connection = await getModelListConnection();
+    connection = await getModelListConnection();
     const result = await connection.request({
       method: "model/list",
       params: {},
@@ -1413,6 +1427,9 @@ async function handleModelList(id: string | number): Promise<void> {
       selectedOnlyModels: [],
     });
   } catch (error) {
+    if (connection !== null) {
+      retireModelListConnection(connection);
+    }
     sendError(
       id,
       BRIDGE_JSON_RPC_ERRORS.BRIDGE_ERROR,

--- a/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
+++ b/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
@@ -23,7 +23,7 @@
  * behavior below is unchanged.
  */
 
-import { readFileSync } from "node:fs";
+import { closeSync, openSync, readFileSync } from "node:fs";
 import { createInterface } from "node:readline";
 
 let threadCounter = 0;
@@ -102,10 +102,25 @@ function runScriptedTurn(threadId) {
 // argv, not an env var: the bridge builds its child's environment from an
 // allowlist, so an env var set by a test never reaches this process.
 const scriptPath = process.argv[2];
-const scriptedTurns = scriptPath
-  ? JSON.parse(readFileSync(scriptPath, "utf8")).turns
-  : null;
+const script = scriptPath ? JSON.parse(readFileSync(scriptPath, "utf8")) : null;
+const scriptedTurns = script?.turns ?? null;
+const modelListFailOnceMarkerPath = script?.modelListFailOnceMarkerPath ?? null;
 let scriptedTurnIndex = 0;
+
+function shouldFailThisModelList() {
+  if (modelListFailOnceMarkerPath === null) {
+    return false;
+  }
+  try {
+    closeSync(openSync(modelListFailOnceMarkerPath, "wx"));
+    return true;
+  } catch (error) {
+    if (error && typeof error === "object" && error.code === "EEXIST") {
+      return false;
+    }
+    throw error;
+  }
+}
 
 /** Rewrite every `threadId` to the id this process minted for the session. */
 function withThreadId(value, threadId) {
@@ -173,6 +188,10 @@ async function handleRequest(message) {
       respond(id, { rateLimits: {} });
       return;
     case "model/list":
+      if (shouldFailThisModelList()) {
+        respond(id, { data: [] });
+        return;
+      }
       respond(id, {
         data: [
           {


### PR DESCRIPTION
## Summary

- retire the reusable Codex model-list child after request or catalog validation failures
- force the next picker refresh to initialize a fresh app-server process
- cover failure recovery while preserving successful child reuse

Addresses the reliability finding from https://github.com/get-bb/bb/pull/1810#discussion_r3807221848.

## Testing

- `pnpm exec turbo run test --filter=bb-plugin-provider-codex --force`
- `pnpm exec turbo run typecheck --filter=bb-plugin-provider-codex`
- `pnpm exec prettier --check plugins/provider-codex/src/bridge/bridge.ts plugins/provider-codex/src/bridge/bridge.model-list.test.ts plugins/provider-codex/src/bridge/fake-codex-app-server.mjs`

> AGENT GENERATED: by GPT-5