### PR TITLE
Stabilize flaky package-shard tests

### DIFF
--- a/packages/process-utils/test/process-tree.test.ts
+++ b/packages/process-utils/test/process-tree.test.ts
@@ -134,15 +134,30 @@ posixOnly("process tree helpers", () => {
   it("rescans and kills processes that appear while the first targets shut down", async () => {
     const dir = realpathSync(mkdtempSync(join(tmpdir(), "bb-cwd-respawn-")));
     cleanupDirs.push(dir);
-    // On SIGTERM the target starts a new-session child and exits.
-    const child = spawn(
-      "sh",
+    // On SIGTERM the target starts a new-session child and exits. Use Node's
+    // portable detached spawn instead of Linux-only `setsid` so the POSIX
+    // contract is exercised on both Linux and macOS.
+    const respawnerPath = join(dir, "respawner.cjs");
+    writeFileSync(
+      respawnerPath,
       [
-        "-c",
-        "trap 'setsid sleep 300 >/dev/null 2>&1 < /dev/null & exit 0' TERM; echo ready; while :; do sleep 0.05; done",
-      ],
-      { cwd: dir, detached: true, stdio: ["ignore", "pipe", "ignore"] },
+        'const { spawn } = require("node:child_process");',
+        'process.on("SIGTERM", () => {',
+        "  spawn(process.execPath,",
+        '    ["-e", "setInterval(() => {}, 30_000)"],',
+        '    { cwd: process.cwd(), detached: true, stdio: "ignore" },',
+        "  ).unref();",
+        "  process.exit(0);",
+        "});",
+        'console.log("ready");',
+        "setInterval(() => {}, 30_000);",
+      ].join("\n"),
     );
+    const child = spawn(process.execPath, [respawnerPath], {
+      cwd: dir,
+      detached: true,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
     child.unref();
     await readFirstLine(child.stdout);
     cleanupPids.push(child.pid ?? 0);

--- a/plugins/memory/server.test.ts
+++ b/plugins/memory/server.test.ts
@@ -104,6 +104,9 @@ describe("bb-plugin-memory", () => {
     expect(instructions?.length).toBeLessThanOrEqual(3_900);
   });
 
+  // This intentionally exercises 30 sequential CLI/database writes. The
+  // packages shard runs every workspace suite in parallel, so loaded CI hosts
+  // can exceed Vitest's 5s default without the behavior being stuck.
   it("keeps a large injected catalog within budget and points to the CLI remainder", async () => {
     const host = await loadPlugin();
     for (let index = 0; index < 30; index += 1) {
@@ -124,7 +127,7 @@ describe("bb-plugin-memory", () => {
     expect(instructions).toContain("Showing");
     expect(instructions).toContain("bb memory catalog --scope all --json");
     expect(instructions).not.toContain("Private details");
-  });
+  }, 20_000);
 
   it("searches progressively and returns full details only from get", async () => {
     const host = await loadPlugin();


### PR DESCRIPTION
## Summary

- give the Memory catalog budget test an explicit loaded-CI timeout for its 30 sequential CLI/database writes
- replace a Linux-only `setsid` process-tree fixture with a portable detached Node process

## Investigation

I sampled 500 PR CI runs from August 13–18. The dominant cluster was 15 concurrent plugin-host staging failures; that race has already been fixed on main by #1741. The remaining rerun-only test failure was the Memory catalog test exceeding Vitest's 5-second default under the fully parallel packages shard.

Running that shard locally also exposed the process-tree fixture's dependency on Linux `setsid` even though the suite runs on macOS. The replacement preserves the independent-process-group behavior on both POSIX platforms.

## Testing

- Memory suite passed 10 consecutive forced runs
- process-utils suite passed 20 consecutive forced runs
- `pnpm exec turbo run typecheck --filter=bb-plugin-memory`
- `pnpm exec turbo run typecheck --filter=@bb/process-utils`
- full 66-package packages shard passed: 57/57 tasks
- Prettier and `git diff --check`

> AGENT GENERATED: by GPT-5
