### PR TITLE
Probe native add-ons for real after install and self-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,18 +236,19 @@ To allow them for all global installs on this machine, run
 `npm config set allow-scripts=better-sqlite3,node-pty,@parcel/watcher --location=user`.
 npm 10 and 11 accept or ignore the flag, so it is safe on every supported Node.
 
-The second cause is `ignore-scripts=true` in your `~/.npmrc`. Set the
-`npm_config_ignore_scripts` environment variable to let this one command run its
-install scripts:
+The second cause is `ignore-scripts=true` in your `~/.npmrc`. That setting
+overrides `--allow-scripts`. Set the `npm_config_ignore_scripts` environment
+variable and pass `--allow-scripts` to let this one command run its install
+scripts on every npm version:
 
 ```bash
-npm_config_ignore_scripts=false npx bb-app@latest
+npm_config_ignore_scripts=false npx --allow-scripts=better-sqlite3,node-pty,@parcel/watcher bb-app@latest
 ```
 
 For a permanent install with the same setting, use:
 
 ```bash
-npm_config_ignore_scripts=false npm install -g bb-app
+npm_config_ignore_scripts=false npm install -g --allow-scripts=better-sqlite3,node-pty,@parcel/watcher bb-app
 bb-app
 ```
 

--- a/apps/host-daemon/src/protocol-self-update.test.ts
+++ b/apps/host-daemon/src/protocol-self-update.test.ts
@@ -26,6 +26,7 @@ async function createFixture(
     enabled?: boolean;
     protocolVersion?: number;
     installFailure?: Error;
+    nativeProbeFailure?: Error;
     now?: () => number;
     serverUrl?: string;
     useDefaultInstaller?: boolean;
@@ -36,7 +37,18 @@ async function createFixture(
   const installTarball = vi.fn(async () => {
     if (args.installFailure) throw args.installFailure;
   });
-  const runProcess = vi.fn(async () => undefined);
+  const runProcess = vi.fn(async (command: string, cliArgs: string[]) => {
+    if (command === "npm" && cliArgs[0] === "root") {
+      const prefixIndex = cliArgs.indexOf("--prefix");
+      const prefix =
+        prefixIndex === -1 ? "/usr/local" : cliArgs[prefixIndex + 1];
+      return { stdout: `${prefix}/lib/node_modules\n` };
+    }
+    if (command === process.execPath && args.nativeProbeFailure) {
+      throw args.nativeProbeFailure;
+    }
+    return { stdout: "" };
+  });
   const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input);
     if (url.endsWith("/install/version")) {
@@ -89,8 +101,9 @@ describe("protocol self-update", () => {
       "updated",
     );
 
-    expect(test.runProcess).toHaveBeenCalledOnce();
-    expect(test.runProcess).toHaveBeenCalledWith(
+    expect(test.runProcess).toHaveBeenCalledTimes(3);
+    expect(test.runProcess).toHaveBeenNthCalledWith(
+      1,
       "npm",
       [
         "install",
@@ -125,6 +138,53 @@ describe("protocol self-update", () => {
         expect.stringContaining("bb-app-update-"),
       ],
       expect.any(Object),
+    );
+  });
+
+  it("verifies the installed native add-ons before it reports an update", async () => {
+    vi.stubEnv("BB_APP_NPM_PREFIX", "/machine-data/npm");
+    const test = await createFixture({ useDefaultInstaller: true });
+
+    await expect(test.updater.handleProtocolMismatch()).resolves.toBe(
+      "updated",
+    );
+
+    expect(test.runProcess).toHaveBeenNthCalledWith(
+      2,
+      "npm",
+      ["root", "-g", "--prefix", "/machine-data/npm"],
+      expect.any(Object),
+    );
+    expect(test.runProcess).toHaveBeenNthCalledWith(
+      3,
+      process.execPath,
+      [
+        "-e",
+        expect.stringMatching(/better-sqlite3[\s\S]*:memory:[\s\S]*node-pty/u),
+        "/machine-data/npm/lib/node_modules/bb-app",
+      ],
+      expect.any(Object),
+    );
+  });
+
+  it("keeps the current daemon when the installed native add-ons do not load", async () => {
+    vi.stubEnv("BB_APP_NPM_PREFIX", "/machine-data/npm");
+    const test = await createFixture({
+      useDefaultInstaller: true,
+      nativeProbeFailure: new Error("Could not locate the bindings file"),
+    });
+
+    await expect(test.updater.handleProtocolMismatch()).resolves.toBe("failed");
+
+    expect(test.logger.error).toHaveBeenCalledWith(
+      {
+        err: expect.objectContaining({
+          message: expect.stringContaining(
+            "native add-ons (better-sqlite3, node-pty) did not load",
+          ),
+        }),
+      },
+      expect.stringContaining("keeping the current daemon running"),
     );
   });
 

--- a/apps/host-daemon/src/protocol-self-update.ts
+++ b/apps/host-daemon/src/protocol-self-update.ts
@@ -40,7 +40,7 @@ interface SelfUpdateProcessRunner {
     command: string,
     args: string[],
     options: { env: NodeJS.ProcessEnv },
-  ): Promise<void>;
+  ): Promise<{ stdout: string }>;
 }
 
 interface CreateProtocolSelfUpdaterOptions {
@@ -124,7 +124,8 @@ const defaultRunProcess: SelfUpdateProcessRunner = async (
   args,
   options,
 ) => {
-  await execFileAsync(command, args, options);
+  const { stdout } = await execFileAsync(command, args, options);
+  return { stdout };
 };
 
 // bb-app depends on native add-ons whose binaries are fetched or built by npm
@@ -132,8 +133,47 @@ const defaultRunProcess: SelfUpdateProcessRunner = async (
 // installs unless they are named in --allow-scripts; the installed package's
 // own package.json#allowScripts is not consulted for `npm install -g`.
 // npm 10 ignores the unknown flag; npm 11 accepts it.
-const BB_APP_ALLOW_SCRIPTS_ARG =
-  "--allow-scripts=better-sqlite3,node-pty,@parcel/watcher";
+const BB_APP_NATIVE_MODULES = "better-sqlite3,node-pty,@parcel/watcher";
+const BB_APP_ALLOW_SCRIPTS_ARG = `--allow-scripts=${BB_APP_NATIVE_MODULES}`;
+
+// npm exits 0 even when it skips the native add-on install scripts (npm >= 12
+// allowScripts policy, or ignore-scripts=true in an npmrc, which overrides the
+// allow-list). This probe loads the installed add-ons the way bb does at
+// startup: better-sqlite3 loads its binding when a database opens; node-pty
+// loads pty.node when the module loads. It runs in a child process so a
+// broken package cannot take the running daemon down.
+// Keep in sync with the check in apps/server/src/assets/install-machine.sh.
+const NATIVE_MODULE_PROBE = `
+const root = process.argv[1];
+const Database = require(root + "/node_modules/better-sqlite3");
+new Database(":memory:").close();
+require(root + "/node_modules/node-pty");
+`;
+
+async function verifyInstalledNativeModules(
+  prefixArgs: string[],
+  runProcess: SelfUpdateProcessRunner,
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  const { stdout } = await runProcess("npm", ["root", "-g", ...prefixArgs], {
+    env,
+  });
+  const globalRoot = stdout.trim();
+  if (globalRoot === "") {
+    throw new Error("npm root -g returned no path for the installed bb-app");
+  }
+  const bbAppRoot = join(globalRoot, "bb-app");
+  try {
+    await runProcess(process.execPath, ["-e", NATIVE_MODULE_PROBE, bbAppRoot], {
+      env,
+    });
+  } catch (error) {
+    throw new Error(
+      `npm installed bb-app at ${bbAppRoot}, but its native add-ons (better-sqlite3, node-pty) did not load. npm did not run their install scripts; check for an npm allowScripts or ignore-scripts policy and rerun with npm_config_allow_scripts=${BB_APP_NATIVE_MODULES} npm_config_ignore_scripts=false.`,
+      { cause: error },
+    );
+  }
+}
 
 async function defaultInstallTarball(
   tarballPath: string,
@@ -154,13 +194,13 @@ async function defaultInstallTarball(
   }
   const prefixArgs =
     configuredPrefix === undefined ? [] : ["--prefix", configuredPrefix];
+  const env = { ...process.env, PATH: path };
   await runProcess(
     "npm",
     ["install", "-g", BB_APP_ALLOW_SCRIPTS_ARG, ...prefixArgs, tarballPath],
-    {
-      env: { ...process.env, PATH: path },
-    },
+    { env },
   );
+  await verifyInstalledNativeModules(prefixArgs, runProcess, env);
 }
 
 export function createProtocolSelfUpdater(

--- a/apps/server/src/assets/install-machine.sh
+++ b/apps/server/src/assets/install-machine.sh
@@ -436,10 +436,13 @@ if [ -n "$bb_app_npm_prefix" ]; then
   # Fail loudly if npm skipped the native add-on install scripts (npm >= 12
   # allowScripts policy, or ignore-scripts=true in an npmrc). Without this
   # check the join only fails later, in the daemon, with a raw stack trace.
+  # better-sqlite3 loads its binding only when a database opens; node-pty
+  # loads pty.node when the module loads.
   bb_app_root="$bb_app_npm_prefix/lib/node_modules/bb-app"
   if ! node -e '
     const root = process.argv[1];
-    require(root + "/node_modules/better-sqlite3");
+    const Database = require(root + "/node_modules/better-sqlite3");
+    new Database(":memory:").close();
     require(root + "/node_modules/node-pty");
   ' "$bb_app_root" >/dev/null 2>&1; then
     fail_step "npm installed bb-app, but its native add-ons (better-sqlite3, node-pty) did not load."

--- a/apps/server/test/app/install-machine-script.test.ts
+++ b/apps/server/test/app/install-machine-script.test.ts
@@ -162,10 +162,14 @@ process.on("SIGTERM", () => server.close(() => process.exit(0)));
 // Mocks curl to serve the redeem endpoint and answer the bb-app tarball
 // download with the given status; npm records invocations and fabricates a
 // bb-app that enrolls into whatever BB_DATA_DIR the script hands it. Like a
-// real install, the fake npm lays out bb-app's native add-ons as loadable
-// modules under lib/node_modules/bb-app/node_modules; when
-// FAKE_NPM_SKIP_NATIVE_MODULES is set it leaves them empty, which mimics npm
-// >= 12 blocking their install scripts (or ignore-scripts=true).
+// real install, the fake npm lays out bb-app's native add-ons under
+// lib/node_modules/bb-app/node_modules: the package JavaScript is always
+// present, and the fake modules load their build/Release/*.node output the
+// way the real ones do (better-sqlite3 when a database opens, node-pty at
+// module load). FAKE_NPM_SKIP_NATIVE_MODULES names the modules (comma
+// separated) whose native output the fake npm leaves out while it keeps their
+// JavaScript, which mimics npm >= 12 blocking those install scripts (or
+// ignore-scripts=true).
 function writeServerInstallTools(
   fixture: ReturnType<typeof createFixture>,
   artifactStatus: 200 | 404,
@@ -206,12 +210,35 @@ done
 mkdir -p "$prefix/bin"
 cp "${bbAppTemplatePath}" "$prefix/bin/bb-app"
 chmod +x "$prefix/bin/bb-app"
-for module in better-sqlite3 node-pty; do
-  mkdir -p "$prefix/lib/node_modules/bb-app/node_modules/$module"
-  if [ -z "$FAKE_NPM_SKIP_NATIVE_MODULES" ]; then
-    printf '%s\n' 'module.exports = {};' >"$prefix/lib/node_modules/bb-app/node_modules/$module/index.js"
-  fi
-done
+sqlite_dir="$prefix/lib/node_modules/bb-app/node_modules/better-sqlite3"
+pty_dir="$prefix/lib/node_modules/bb-app/node_modules/node-pty"
+mkdir -p "$sqlite_dir/build/Release" "$pty_dir/build/Release"
+cat >"$sqlite_dir/index.js" <<'JS'
+const fs = require("node:fs");
+const path = require("node:path");
+module.exports = class Database {
+  constructor() {
+    const binding = path.join(__dirname, "build/Release/better_sqlite3.node");
+    if (!fs.existsSync(binding)) throw new Error("Could not locate the bindings file. Tried: " + binding);
+  }
+  close() {}
+};
+JS
+cat >"$pty_dir/index.js" <<'JS'
+const fs = require("node:fs");
+const path = require("node:path");
+const binding = path.join(__dirname, "build/Release/pty.node");
+if (!fs.existsSync(binding)) throw new Error("Failed to load native module: pty.node, checked: " + binding);
+module.exports = {};
+JS
+case ",$FAKE_NPM_SKIP_NATIVE_MODULES," in
+  *,better-sqlite3,*) ;;
+  *) : >"$sqlite_dir/build/Release/better_sqlite3.node" ;;
+esac
+case ",$FAKE_NPM_SKIP_NATIVE_MODULES," in
+  *,node-pty,*) ;;
+  *) : >"$pty_dir/build/Release/pty.node" ;;
+esac
 `,
   );
 }
@@ -451,24 +478,36 @@ describe("machine install script", () => {
     process.kill(daemonPid, "SIGTERM");
   });
 
-  it("fails loudly when npm skipped the native add-on install scripts", () => {
-    const fixture = createFixture();
-    writeServerInstallTools(fixture, 200);
-    const result = runScript(JOIN_ARGS, fixture, {
-      BB_INSTALL_SKIP_SERVICE: "1",
-      FAKE_NPM_SKIP_NATIVE_MODULES: "1",
-    });
+  // npm exits 0 when it blocks install scripts. better-sqlite3 loads its
+  // binding only when a database opens, so a plain require passes; node-pty
+  // loads pty.node at module load.
+  it.each([
+    ["better-sqlite3,node-pty", "both native add-ons"],
+    ["better-sqlite3", "only better-sqlite3's native output"],
+    ["node-pty", "only node-pty's native output"],
+  ])(
+    "fails loudly when npm skipped the install scripts for %s (%s)",
+    (skipped) => {
+      const fixture = createFixture();
+      writeServerInstallTools(fixture, 200);
+      const result = runScript(JOIN_ARGS, fixture, {
+        BB_INSTALL_SKIP_SERVICE: "1",
+        FAKE_NPM_SKIP_NATIVE_MODULES: skipped,
+      });
 
-    expect(result.status, result.stderr).toBe(1);
-    expect(result.stderr).toContain(
-      "npm installed bb-app, but its native add-ons (better-sqlite3, node-pty) did not load.",
-    );
-    expect(result.stderr).toContain(
-      "npm_config_allow_scripts=better-sqlite3,node-pty,@parcel/watcher",
-    );
-    // The installer must stop before it starts the temporary host daemon.
-    expect(existsSync(join(fixture.dataDir, "install-daemon.pid"))).toBe(false);
-  });
+      expect(result.status, result.stderr).toBe(1);
+      expect(result.stderr).toContain(
+        "npm installed bb-app, but its native add-ons (better-sqlite3, node-pty) did not load.",
+      );
+      expect(result.stderr).toContain(
+        "npm_config_allow_scripts=better-sqlite3,node-pty,@parcel/watcher npm_config_ignore_scripts=false",
+      );
+      // The installer must stop before it starts the temporary host daemon.
+      expect(existsSync(join(fixture.dataDir, "install-daemon.pid"))).toBe(
+        false,
+      );
+    },
+  );
 
   it("defaults the data dir to a per-server directory under ~/.bb-machines", () => {
     const fixture = createFixture();


### PR DESCRIPTION
Follow-up to #1805 (issue #1120). It addresses the three correctness findings from the SlopCop review on that PR, which merged before the fixes landed.

## What was wrong

1. The installer health check only did `require("better-sqlite3")`. That loads JavaScript only; the native binding loads in the `Database` constructor. With npm 12 and only the `better-sqlite3` script blocked, npm and the probe both returned 0, and bb still failed at startup with `Could not locate the bindings file`.
2. The daemon self-updater had no native health check. `ignore-scripts=true` in an npmrc overrides `--allow-scripts`, npm returns 0, and the daemon reported `updated` and restarted into a package with missing bindings.
3. The `ignore-scripts` recovery commands in the README omitted `--allow-scripts`, so on npm 12 they still produced a broken install.

## What changed

- `apps/server/src/assets/install-machine.sh`: the probe opens and closes an in-memory `better-sqlite3` database, then requires `node-pty` (which loads `pty.node` at module load).
- `apps/host-daemon/src/protocol-self-update.ts`: after `npm install -g`, the updater runs `npm root -g [--prefix ...]`, then runs the same probe in a `node` child process against `<root>/bb-app`. If it fails, `installTarball` throws with a message that names the add-ons and the `npm_config_allow_scripts=... npm_config_ignore_scripts=false` fix, so `handleProtocolMismatch` returns `failed` and keeps the current daemon running. `SelfUpdateProcessRunner` now returns `{ stdout }`.
- `apps/server/test/app/install-machine-script.test.ts`: the fake npm keeps the add-on JavaScript and models the native output as `build/Release/*.node` files that the fake modules load like the real ones. `FAKE_NPM_SKIP_NATIVE_MODULES` names the modules whose native output is missing. Three cases: both, only `better-sqlite3`, only `node-pty`.
- `apps/host-daemon/src/protocol-self-update.test.ts`: asserts the `npm root -g` and probe calls, and that a probe failure yields `failed` with the loud error.
- `README.md`: the `ignore-scripts` recovery commands set both controls (`npm_config_ignore_scripts=false npx --allow-scripts=... bb-app@latest`, and the `npm install -g` form).

Not done: the "single policy manifest" note. The list lives in shell (installer) and TypeScript (daemon) with no shared build step between them; a manifest would need a generation step, which is more than this follow-up. Both sites carry a keep-in-sync comment.

## How I verified

- Before the probe change, with only `better-sqlite3`'s native output missing, the installer test `fails loudly when npm skipped the install scripts for better-sqlite3` failed (installer exit 0). After: all 19 installer tests pass.
- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/host-daemon` → pass.
- `pnpm exec turbo run test --filter=@bb/host-daemon` → 585 passed (includes the two new self-updater tests).
- `pnpm exec turbo run test --filter=@bb/server` → 1726 passed, 1 failed: `internal-skill-trees.test.ts` expects file mode 420 and gets 436 (local umask); unrelated and green in CI.

Refs #1120

> AGENT GENERATED: by Claude Opus 5