### PR TITLE
Invalidate model pickers only for provider changes

### DIFF
--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -517,9 +517,13 @@ export const REALTIME_SYSTEM_CHANGE_REGISTRY = {
       dirtyPluginContributionQueries,
       dirtyProjectCommandCatalogQueries,
       dirtyPluginManagementQueries,
-      dirtySystemProviderQueries, // Provider plugins add/remove picker entries.
-      dirtySystemExecutionOptionQueries, // Refresh a boot-time partial provider roster.
       reconcilePluginFrontendBundles,
+    ],
+  },
+  "provider-registrations-changed": {
+    dirty: [
+      dirtySystemProviderQueries, // Provider plugins add/remove picker entries.
+      dirtySystemExecutionOptionQueries, // Refresh changed or boot-time partial provider rosters.
     ],
   },
 } satisfies SystemChangeRegistry;

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -181,7 +181,7 @@ describe("createRealtimeCacheEffects", () => {
     effects.dispose();
   });
 
-  it("invalidates plugin contributions, commands, and provider pickers on plugins-changed", () => {
+  it("keeps provider pickers cached on unrelated plugins-changed events", () => {
     const { effects, queryClient } = createRealtimeEffectsTestContext();
     const contributionsKey = pluginContributionsQueryKey();
     queryClient.setQueryData(contributionsKey, {
@@ -216,6 +216,29 @@ describe("createRealtimeCacheEffects", () => {
       true,
     );
     expect(queryClient.getQueryState(commandsKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(providersKey)?.isInvalidated).toBe(false);
+    expect(queryClient.getQueryState(executionOptionsKey)?.isInvalidated).toBe(
+      false,
+    );
+  });
+
+  it("invalidates provider pickers on provider registration changes", () => {
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const providersKey = systemProvidersQueryKey({ hostId: "host-1" });
+    queryClient.setQueryData(providersKey, []);
+    const executionOptionsKey = systemExecutionOptionsQueryKey({
+      environmentId: "environment-1",
+      hostId: "host-1",
+      providerId: "codex",
+    });
+    queryClient.setQueryData(executionOptionsKey, {});
+
+    effects.handleChanged({
+      type: "changed",
+      entity: "system",
+      changes: ["provider-registrations-changed"],
+    });
+
     expect(queryClient.getQueryState(providersKey)?.isInvalidated).toBe(true);
     expect(queryClient.getQueryState(executionOptionsKey)?.isInvalidated).toBe(
       true,

--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -10,6 +10,7 @@ import {
   type DeclaredCodeTheme,
   type JsonValue,
   type PluginThemeMeta,
+  type SystemChangeKind,
   type ToolCallResponse,
 } from "@bb/domain";
 import {
@@ -960,6 +961,8 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
   const artifactRetentionMs =
     deps.artifactRetentionMs ?? DEFAULT_ARTIFACT_RETENTION_MS;
   const now = deps.now ?? Date.now;
+  let lastNotifiedProviderRegistrationRevision =
+    deps.providerRegistry?.getRegistrationRevision() ?? 0;
   const scheduleStabilizationWindow =
     deps.scheduleStabilizationWindow ??
     ((durationMs: number, onElapsed: () => void) => {
@@ -1148,11 +1151,23 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
   /**
    * Broadcast that the set of running plugins (and therefore host-rendered
    * contributions) changed, so open app pages re-fetch instead of waiting
-   * out their query stale time. Fired on install/remove/enable/disable/
+   * out their query stale time. Provider cache invalidation gets its own
+   * change kind and only rides the broadcast when the registry changed since
+   * the previous lifecycle boundary. Fired on install/remove/enable/disable/
    * reload completion.
    */
   function notifyPluginsChanged(): void {
-    deps.hub.notifySystem(["plugins-changed"]);
+    const changes: SystemChangeKind[] = ["plugins-changed"];
+    const providerRegistrationRevision =
+      deps.providerRegistry?.getRegistrationRevision();
+    if (
+      providerRegistrationRevision !== undefined &&
+      providerRegistrationRevision !== lastNotifiedProviderRegistrationRevision
+    ) {
+      lastNotifiedProviderRegistrationRevision = providerRegistrationRevision;
+      changes.push("provider-registrations-changed");
+    }
+    deps.hub.notifySystem(changes);
   }
 
   function compactPath(path: string): string {

--- a/apps/server/src/services/providers/provider-registry.ts
+++ b/apps/server/src/services/providers/provider-registry.ts
@@ -128,6 +128,12 @@ export interface ProviderRegistryService {
   list(): ProviderRegistration[];
   get(providerId: string): ProviderRegistration | null;
   /**
+   * Monotonic revision of the live registration set. Plugin lifecycle
+   * notifications use it to distinguish provider changes from unrelated
+   * plugin changes without broadcasting every intermediate reload step.
+   */
+  getRegistrationRevision(): number;
+  /**
    * Policy accessors: one answer per question, covering registered providers
    * plus the dynamic ACP tier (acp-* ids resolved from launch specs are never
    * registered — they fall back to the shared ACP capability set, exactly as
@@ -223,6 +229,7 @@ export function createProviderRegistryService(
 ): ProviderRegistryService {
   const pluginRegistrations = new Map<string, ProviderRegistration>();
   const providerRegistrationWaiters = new Map<string, Set<() => void>>();
+  let registrationRevision = 0;
   let settle: (() => void) | null = null;
   const settled: Promise<void> =
     deps.deferRegistrationsSettled === true
@@ -297,6 +304,10 @@ export function createProviderRegistryService(
 
     get(providerId) {
       return getRegistration(providerId);
+    },
+
+    getRegistrationRevision() {
+      return registrationRevision;
     },
 
     getServerCapabilities(providerId) {
@@ -378,11 +389,13 @@ export function createProviderRegistryService(
         ...(registration.icon === undefined ? {} : { icon: registration.icon }),
       };
       pluginRegistrations.set(providerId, entry);
+      registrationRevision += 1;
       releaseProviderRegistrationWaiters(providerId);
       return {
         dispose() {
           if (pluginRegistrations.get(providerId) === entry) {
             pluginRegistrations.delete(providerId);
+            registrationRevision += 1;
           }
         },
       };

--- a/apps/server/test/services/plugins/plugin-provider-registration.test.ts
+++ b/apps/server/test/services/plugins/plugin-provider-registration.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { listSystemProviderInfos } from "../../../src/services/system/execution-options.js";
 import {
   resolveCreateThreadExecutionDefaults,
@@ -90,12 +90,17 @@ describe("bb.agents.experimental_registerProvider (server)", () => {
 
   it("adds the provider to the composed listing and removes it when the plugin is disabled", async () => {
     await withTestHarness(async (harness) => {
+      const notifySystem = vi.spyOn(harness.deps.hub, "notifySystem");
       const rootDir = await writePlugin(workDir, {
         name: "bb-plugin-remote-agent",
         serverSource: REGISTER_PROVIDER_SOURCE("my-remote-agent"),
       });
       const entry = await harness.pluginService.installPath(rootDir);
       expect(entry.status).toBe("running");
+      expect(notifySystem).toHaveBeenCalledWith([
+        "plugins-changed",
+        "provider-registrations-changed",
+      ]);
 
       const registration = harness.deps.providerRegistry.get("my-remote-agent");
       expect(registration).toMatchObject({
@@ -139,12 +144,18 @@ describe("bb.agents.experimental_registerProvider (server)", () => {
       );
 
       // Disabling the plugin runs its dispose hooks and removes the provider.
+      notifySystem.mockClear();
       await harness.pluginService.setEnabled(entry.id, false);
+      expect(notifySystem).toHaveBeenCalledWith([
+        "plugins-changed",
+        "provider-registrations-changed",
+      ]);
       expect(harness.deps.providerRegistry.get("my-remote-agent")).toBeNull();
       const afterDisable = await listSystemProviderInfos(harness.deps, {});
       expect(afterDisable.map((provider) => provider.id)).not.toContain(
         "my-remote-agent",
       );
+      notifySystem.mockRestore();
     });
   });
 

--- a/apps/server/test/services/plugins/plugin-service.test.ts
+++ b/apps/server/test/services/plugins/plugin-service.test.ts
@@ -20,6 +20,7 @@ import { testLogger } from "../../helpers/test-app.js";
 import { pluginInstalledTelemetryEvent } from "../../../src/services/plugins/plugin-registration.js";
 import type { TelemetryEvent } from "../../../src/services/system/telemetry.js";
 import { createNoopTelemetryService } from "../../../src/services/system/telemetry.js";
+import { createProviderRegistryService } from "../../../src/services/providers/provider-registry.js";
 
 const logger = testLogger as unknown as Logger;
 
@@ -749,6 +750,7 @@ describe("plugins-changed broadcast", () => {
   let notifySystem: ReturnType<
     typeof vi.fn<(changes: SystemChangeKind[]) => void>
   >;
+  let providerRegistry: ReturnType<typeof createProviderRegistryService>;
   let service: PluginService;
 
   beforeEach(async () => {
@@ -756,6 +758,7 @@ describe("plugins-changed broadcast", () => {
     migrate(db);
     workDir = await mkdtemp(join(tmpdir(), "bb-plugin-notify-test-"));
     notifySystem = vi.fn<(changes: SystemChangeKind[]) => void>();
+    providerRegistry = createProviderRegistryService();
     service = createPluginService({
       telemetry: createNoopTelemetryService(),
       db,
@@ -765,6 +768,7 @@ describe("plugins-changed broadcast", () => {
         notifySystem,
       },
       logger,
+      providerRegistry,
       dataDir: join(workDir, "data"),
       appVersion: "0.9.0",
       loadTimeoutMs: 2000,

--- a/packages/domain/src/change-kinds.ts
+++ b/packages/domain/src/change-kinds.ts
@@ -55,6 +55,7 @@ export type HostChangeKind = (typeof HOST_CHANGE_KINDS)[number];
 export const SYSTEM_CHANGE_KINDS = [
   "config-changed",
   "plugins-changed",
+  "provider-registrations-changed",
 ] as const;
 export type SystemChangeKind = (typeof SYSTEM_CHANGE_KINDS)[number];
 

--- a/packages/plugin-sdk/bundled-types/bb-plugin-sdk.d.ts
+++ b/packages/plugin-sdk/bundled-types/bb-plugin-sdk.d.ts
@@ -215,6 +215,7 @@ declare const changedMessageSchema: z$1.ZodDiscriminatedUnion<[z$1.ZodObject<{
     changes: z$1.ZodReadonly<z$1.ZodArray<z$1.ZodEnum<{
         "config-changed": "config-changed";
         "plugins-changed": "plugins-changed";
+        "provider-registrations-changed": "provider-registrations-changed";
     }>>>;
 }, z$1.core.$strict>], "entity">;
 type ChangedMessage = z$1.infer<typeof changedMessageSchema>;


### PR DESCRIPTION
## Summary

- add a provider-registration-specific realtime change kind
- coalesce registry mutations at plugin lifecycle boundaries using a monotonic registration revision
- keep provider and execution-option caches intact for unrelated plugin changes
- invalidate picker caches when a provider is installed, removed, enabled, disabled, or reloaded

Addresses the performance finding from https://github.com/get-bb/bb/pull/1810#discussion_r3807221803.

## Testing

- `pnpm exec turbo run test --filter=@bb/server -- --run test/services/plugins/plugin-service.test.ts test/services/plugins/plugin-provider-registration.test.ts -t "broadcasts plugins-changed|adds the provider"`
- `pnpm exec turbo run test --filter=@bb/app -- --run src/hooks/realtime-cache-effects.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/domain --filter=@bb/server --filter=@bb/app`
- `pnpm exec turbo run typecheck --filter=@get-bb/plugin-sdk`
- `pnpm exec turbo run lint --filter=@bb/app --filter=@bb/server --filter=@bb/domain` (0 errors; existing warnings remain)

This changes only the server-to-app realtime event contract; the host-daemon protocol is unchanged.

> AGENT GENERATED: by GPT-5