### PR TITLE
Exit the github sync loop when abort arrives during a sync pass

### DIFF
--- a/plugins/github/server.auth-latch.test.ts
+++ b/plugins/github/server.auth-latch.test.ts
@@ -107,9 +107,10 @@ async function loadWithSyncServiceOnce(
   await plugin(bb);
   // Run the sync service the way the host does at activation. Before the fix
   // its first syncAll() threw NeedsConfigurationError and it stopped for
-  // good; the fixed plugin keeps looping, so abort it after its first pass.
+  // good; the fixed plugin keeps looping. Abort right away: the loop already
+  // entered its first pass, finishes it, and exits before the retry wait
+  // (no timing assumptions about how fast the fake gh spawns).
   const { controller, done } = harness.runService("sync");
-  await new Promise((resolve) => setTimeout(resolve, 150));
   controller.abort();
   await done;
   return { bb, harness };

--- a/plugins/github/server.ts
+++ b/plugins/github/server.ts
@@ -832,6 +832,9 @@ export default async function plugin(bb: BbPluginApi) {
             }`,
           );
         }
+        // The abort may have arrived while syncAll() ran; the listener below
+        // would never fire for an already-aborted signal.
+        if (signal.aborted) break;
         await new Promise<void>((resolve) => {
           const timer = setTimeout(resolve, delayMs);
           signal.addEventListener(


### PR DESCRIPTION
## What was wrong

`plugins/github/server.auth-latch.test.ts > treats a pass where every repo failed as a failure and keeps the old sync time` timed out at 5 s in CI for #1807 ([run](https://github.com/get-bb/bb/actions/runs/32187057380/job/95873006491)).

Root cause: the `sync` service loop added its `abort` listener only after `syncAll()` returned. If the abort arrived while `syncAll()` was still running (the test aborted after a fixed 150 ms; that test spawns ~10 fake `gh` processes per pass, which takes longer on a loaded CI runner), the already-aborted signal never fired the listener, so the loop slept out the full 30 s retry delay and the test timed out. The same race exists in production: an abort during a sync pass delayed the service stop by up to the sync interval.

## What changed

- `plugins/github/server.ts`: check `signal.aborted` before the retry/interval wait and exit the loop.
- `plugins/github/server.auth-latch.test.ts`: abort right after `runService()` instead of after a fixed sleep. The loop already entered its first pass, finishes it, and exits, so the test has no timing assumption.

## How I verified

- With the old `server.ts` and the immediate abort, all 6 service tests hang to the 5 s timeout (the flake, made deterministic).
- With the fix: 20 consecutive local runs of the file, 7/7 pass each time (~800 ms per run).
- `pnpm exec turbo run typecheck test --filter=bb-plugin-github --force` → 3 tasks successful, 14 tests passed.

Follow-up to #1797 / #1758.

> AGENT GENERATED: by Claude Opus 5
