### PR TITLE
Add host-owned Composer renderer boundary

### DIFF
--- a/apps/app/src/components/plugin/ComposerExtensionHost.test.tsx
+++ b/apps/app/src/components/plugin/ComposerExtensionHost.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+
+import { useMemo } from "react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AppCommandProvider } from "@/components/commands/AppCommandProvider";
+import {
+  usePluginComposerHost,
+  useOptionalPluginComposerView,
+  type PluginComposerHost,
+} from "./plugin-composer-host";
+import {
+  ComposerExtensionHost,
+  useComposerExtensionController,
+} from "./ComposerExtensionHost";
+
+const mocks = vi.hoisted(() => ({
+  focusDefault: vi.fn(() => true),
+  focusHost: vi.fn(),
+}));
+
+vi.mock("@/hooks/queries/system-queries", () => ({
+  useSystemConfig: () => ({
+    data: {
+      keybindings: [
+        {
+          command: "composer.focus",
+          desktopOnly: false,
+          shortcut: {
+            key: "c",
+            mod: false,
+            meta: false,
+            control: true,
+            alt: false,
+            shift: false,
+          },
+          when: {
+            all: ["mainSurface", "promptAvailable"],
+            none: [],
+          },
+        },
+      ],
+    },
+  }),
+}));
+
+vi.mock("@/lib/bb-desktop", () => ({
+  getBbDesktopInfo: () => null,
+}));
+
+const draft = { text: "hello", mentions: [], attachments: [] };
+
+function RendererProbe() {
+  const host = usePluginComposerHost();
+  const view = useOptionalPluginComposerView();
+  return (
+    <div
+      data-testid="renderer"
+      data-host-text={host?.draft.text}
+      data-scope={view?.scope.kind}
+    />
+  );
+}
+
+function Harness({
+  hasHost = true,
+  isFocused = true,
+  isPrimary = true,
+}: {
+  hasHost?: boolean;
+  isFocused?: boolean;
+  isPrimary?: boolean;
+}) {
+  const host = useMemo<PluginComposerHost>(
+    () => ({
+      scope: { kind: "thread", threadId: "thr_test" },
+      draft,
+      textEffectKey: "thread/thr_test",
+      getCurrent: () => draft,
+      setDraft: () => undefined,
+      focus: mocks.focusHost,
+    }),
+    [],
+  );
+  const view = useMemo(
+    () => ({
+      scope: host.scope,
+      layout: "expanded" as const,
+      draft: { text: draft.text, isEmpty: false, attachmentCount: 0 },
+      run: { isRunning: false, isSubmitting: false },
+    }),
+    [host.scope],
+  );
+  const controller = useComposerExtensionController({
+    host: hasHost ? host : null,
+    view,
+    isFocused,
+    isPrimary,
+    focusDefault: mocks.focusDefault,
+  });
+  return (
+    <ComposerExtensionHost
+      controller={controller}
+      defaultRenderer={<RendererProbe />}
+    />
+  );
+}
+
+function renderHarness(props?: Parameters<typeof Harness>[0]) {
+  return render(
+    <AppCommandProvider>
+      <Harness {...props} />
+    </AppCommandProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ComposerExtensionHost", () => {
+  it("binds the default renderer and focus command to one controller", () => {
+    renderHarness();
+
+    expect(screen.getByTestId("renderer").dataset).toMatchObject({
+      hostText: "hello",
+      scope: "thread",
+    });
+    fireEvent.keyDown(window, { key: "c", ctrlKey: true });
+
+    expect(mocks.focusHost).toHaveBeenCalledOnce();
+    expect(mocks.focusDefault).not.toHaveBeenCalled();
+  });
+
+  it("keeps focus pane-scoped and preserves the hostless fallback", () => {
+    const view = renderHarness({ isFocused: false });
+    fireEvent.keyDown(window, { key: "c", ctrlKey: true });
+    expect(mocks.focusHost).not.toHaveBeenCalled();
+
+    view.rerender(
+      <AppCommandProvider>
+        <Harness hasHost={false} />
+      </AppCommandProvider>,
+    );
+    fireEvent.keyDown(window, { key: "c", ctrlKey: true });
+
+    expect(mocks.focusDefault).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/app/src/components/plugin/ComposerExtensionHost.tsx
+++ b/apps/app/src/components/plugin/ComposerExtensionHost.tsx
@@ -1,0 +1,73 @@
+import { useCallback, useMemo, type ReactNode } from "react";
+import type { ComposerView } from "@get-bb/plugin-sdk";
+import {
+  useAppCommandContext,
+  useAppCommandHandler,
+} from "@/components/commands/AppCommandProvider";
+import {
+  PluginComposerHostProvider,
+  PluginComposerViewProvider,
+  type PluginComposerHost,
+} from "./plugin-composer-host";
+
+/**
+ * The renderer-independent state for one mounted Composer. Page-specific
+ * owners keep submission and durable draft state above this boundary; the
+ * extension host keeps the active renderer bound to the same plugin API,
+ * reactive view, and keyboard-command behavior.
+ */
+export interface ComposerExtensionController {
+  host: PluginComposerHost | null;
+  view: ComposerView;
+  focus(): boolean;
+}
+
+interface UseComposerExtensionControllerOptions {
+  host: PluginComposerHost | null;
+  view: ComposerView;
+  isFocused: boolean;
+  isPrimary: boolean;
+  focusDefault(): boolean;
+}
+
+export function useComposerExtensionController({
+  host,
+  view,
+  isFocused,
+  isPrimary,
+  focusDefault,
+}: UseComposerExtensionControllerOptions): ComposerExtensionController {
+  const focus = useCallback(() => {
+    if (!isFocused || !isPrimary) return false;
+    if (host !== null) {
+      host.focus();
+      return true;
+    }
+    return focusDefault();
+  }, [focusDefault, host, isFocused, isPrimary]);
+  useAppCommandContext("promptAvailable", true);
+  useAppCommandHandler("composer.focus", focus);
+
+  return useMemo(() => ({ host, view, focus }), [focus, host, view]);
+}
+
+/**
+ * The single renderer-selection boundary for a Composer instance. It
+ * currently mounts BB's renderer; replacement resolution can be added here
+ * without moving or remounting the caller-owned controller.
+ */
+export function ComposerExtensionHost({
+  controller,
+  defaultRenderer,
+}: {
+  controller: ComposerExtensionController;
+  defaultRenderer: ReactNode;
+}) {
+  return (
+    <PluginComposerViewProvider value={controller.view}>
+      <PluginComposerHostProvider value={controller.host}>
+        {defaultRenderer}
+      </PluginComposerHostProvider>
+    </PluginComposerViewProvider>
+  );
+}

--- a/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
+++ b/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
@@ -405,6 +405,30 @@ describe("PluginNewThreadComposer seeding", () => {
     });
   });
 
+  it("binds plugin draft actions to the hosted composer instance", async () => {
+    renderComposer(STORED_REQUEST, () => undefined, "host-binding");
+
+    await waitFor(() => {
+      expect(latestPromptBoxProps().disabled).toBe(false);
+    });
+    const host = latestPromptBoxProps().pluginComposerHost;
+    expect(host.scope).toEqual({ kind: "new-thread", projectId: "proj_1" });
+    expect(host.getCurrent().text).toBe("review every PR for slop");
+
+    act(() => {
+      host.setDraft({
+        ...host.getCurrent(),
+        text: "updated through the Composer API",
+      });
+    });
+
+    await waitFor(() => {
+      expect(latestPromptBoxProps().value).toBe(
+        "updated through the Composer API",
+      );
+    });
+  });
+
   it("allows submitting a projectless thread", async () => {
     const submitted: NewThreadRequest[] = [];
     renderComposer(

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
@@ -437,6 +437,45 @@ describe("FollowUpPromptBox", () => {
     expect(queuedMessages.previousElementSibling).toBe(pluginHeaderRoot);
   });
 
+  it("does not mount plugin banners for a retained inactive composer without a real scope", () => {
+    setPluginSlotRegistrations("inactive-banner", {
+      homepageSections: [],
+      settingsSections: [],
+      navPanels: [],
+      threadPanelActions: [],
+      composerCustomizations: [
+        {
+          id: "inactive",
+          banners: [
+            {
+              id: "banner",
+              component: () => (
+                <div data-testid="inactive-plugin-banner">Plugin banner</div>
+              ),
+            },
+          ],
+        },
+      ],
+      pendingInteractions: [],
+      sidebarFooterActions: [],
+      fileOpeners: [],
+      messageDirectives: [],
+    });
+
+    render(
+      <FollowUpPromptBox
+        {...createFollowUpPromptBoxProps({ kind: "ready" })}
+        stack={<div data-testid="retained-native-stack">Queued messages</div>}
+        pluginComposerHost={null}
+        pluginComposerScope={null}
+        suppressPluginComposerCustomizations
+      />,
+    );
+
+    expect(screen.getByTestId("retained-native-stack")).toBeTruthy();
+    expect(screen.queryByTestId("inactive-plugin-banner")).toBeNull();
+  });
+
   it("keeps the bottom composer mounted when its stack changes", () => {
     const props = createFollowUpPromptBoxProps({ kind: "ready" });
 

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -795,6 +795,7 @@ function FollowUpPromptBoxWithComposer({
         <DefaultFollowUpComposer
           active={composer.threadRuntimeDisplayStatus === "active"}
           composerElement={composerElement}
+          hasPluginComposerScope={composerScope !== null}
           isPrimaryComposer={isPrimaryComposer}
           showScrollToBottomButton={showScrollToBottomButton}
           stack={stack}
@@ -808,6 +809,7 @@ function FollowUpPromptBoxWithComposer({
 interface DefaultFollowUpComposerProps {
   active: boolean;
   composerElement: ReactNode;
+  hasPluginComposerScope: boolean;
   isPrimaryComposer: boolean;
   showScrollToBottomButton: boolean;
   stack: ReactNode | null;
@@ -818,6 +820,7 @@ interface DefaultFollowUpComposerProps {
 export function DefaultFollowUpComposer({
   active,
   composerElement,
+  hasPluginComposerScope,
   isPrimaryComposer,
   showScrollToBottomButton,
   stack,
@@ -835,7 +838,11 @@ export function DefaultFollowUpComposer({
         className="space-y-2"
       >
         <div ref={stackRef} className="grid gap-2">
-          <ComposerBannersSlot>{stack}</ComposerBannersSlot>
+          {hasPluginComposerScope ? (
+            <ComposerBannersSlot>{stack}</ComposerBannersSlot>
+          ) : (
+            stack
+          )}
         </div>
         <div data-follow-up-composer-anchor="">{composerElement}</div>
       </div>

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -9,6 +9,7 @@ import {
   type ComponentProps,
   type FocusEvent as ReactFocusEvent,
   type ReactNode,
+  type RefObject,
 } from "react";
 import type {
   PromptTextMention,
@@ -25,9 +26,9 @@ import {
   usePluginComposerViewModel,
 } from "@/components/plugin/plugin-composer-host";
 import {
-  useAppCommandContext,
-  useAppCommandHandler,
-} from "@/components/commands/AppCommandProvider";
+  ComposerExtensionHost,
+  useComposerExtensionController,
+} from "@/components/plugin/ComposerExtensionHost";
 import {
   PromptBoxInternal,
   type AttachmentsConfig,
@@ -364,11 +365,16 @@ function FollowUpPromptBoxWithComposer({
   // surfaces have no pane context and default to focused.
   const paneContext = useOptionalPaneContext();
   const isFocusedPane = paneContext?.isFocused ?? true;
-  useAppCommandContext("promptAvailable", true);
-  useAppCommandHandler("composer.focus", () => {
-    if (!isFocusedPane || !isPrimaryComposer) return false;
+  const focusDefault = useCallback(() => {
     promptBoxRef.current?.focusEnd();
     return promptBoxRef.current !== null;
+  }, []);
+  const extensionController = useComposerExtensionController({
+    host: pluginComposerHost ?? null,
+    view: composerView,
+    isFocused: isFocusedPane,
+    isPrimary: isPrimaryComposer,
+    focusDefault,
   });
   const voice = usePromptVoice(promptBoxRef);
   const isCompactViewport = useIsCompactViewport();
@@ -783,32 +789,57 @@ function FollowUpPromptBoxWithComposer({
   );
 
   return (
-    <PluginComposerViewProvider value={composerView}>
-      <PluginComposerHostProvider value={pluginComposerHost ?? null}>
-        <>
-          {showScrollToBottomButton ? (
-            <ThreadTimelineScrollToBottomButton
-              active={composer.threadRuntimeDisplayStatus === "active"}
-            />
-          ) : null}
-          <div
-            data-app-composer=""
-            data-app-composer-role={isPrimaryComposer ? "primary" : "secondary"}
-            data-promptbox-shell=""
-            className="space-y-2"
-          >
-            <div ref={stackRef} className="grid gap-2">
-              {composerScope ? (
-                <ComposerBannersSlot>{stack}</ComposerBannersSlot>
-              ) : (
-                stack
-              )}
-            </div>
-            <div data-follow-up-composer-anchor="">{composerElement}</div>
-          </div>
-        </>
-      </PluginComposerHostProvider>
-    </PluginComposerViewProvider>
+    <ComposerExtensionHost
+      controller={extensionController}
+      defaultRenderer={
+        <DefaultFollowUpComposer
+          active={composer.threadRuntimeDisplayStatus === "active"}
+          composerElement={composerElement}
+          isPrimaryComposer={isPrimaryComposer}
+          showScrollToBottomButton={showScrollToBottomButton}
+          stack={stack}
+          stackRef={stackRef}
+        />
+      }
+    />
+  );
+}
+
+interface DefaultFollowUpComposerProps {
+  active: boolean;
+  composerElement: ReactNode;
+  isPrimaryComposer: boolean;
+  showScrollToBottomButton: boolean;
+  stack: ReactNode | null;
+  stackRef: RefObject<HTMLDivElement | null>;
+}
+
+/** BB's presentation for a host-owned follow-up Composer controller. */
+export function DefaultFollowUpComposer({
+  active,
+  composerElement,
+  isPrimaryComposer,
+  showScrollToBottomButton,
+  stack,
+  stackRef,
+}: DefaultFollowUpComposerProps) {
+  return (
+    <>
+      {showScrollToBottomButton ? (
+        <ThreadTimelineScrollToBottomButton active={active} />
+      ) : null}
+      <div
+        data-app-composer=""
+        data-app-composer-role={isPrimaryComposer ? "primary" : "secondary"}
+        data-promptbox-shell=""
+        className="space-y-2"
+      >
+        <div ref={stackRef} className="grid gap-2">
+          <ComposerBannersSlot>{stack}</ComposerBannersSlot>
+        </div>
+        <div data-follow-up-composer-anchor="">{composerElement}</div>
+      </div>
+    </>
   );
 }
 

--- a/apps/app/src/components/promptbox/NewThreadComposer.tsx
+++ b/apps/app/src/components/promptbox/NewThreadComposer.tsx
@@ -117,7 +117,8 @@ export interface NewThreadComposerPromptOptions {
   header?: ReactNode;
   externallyBlocked?: boolean;
   resolveMentionLink?: PromptMentionLinkResolver;
-  pluginComposerHost?: PluginComposerHost | null;
+  /** Override the host bound to this prompt box; omission uses this Composer's host. */
+  pluginComposerHost?: PluginComposerHost;
   textEffects?: NewThreadPromptBoxProps["textEffects"];
   allowNoProject?: boolean;
   createProject?: ProjectSelectorCreateProjectConfig;

--- a/apps/app/src/components/promptbox/NewThreadComposer.tsx
+++ b/apps/app/src/components/promptbox/NewThreadComposer.tsx
@@ -1131,8 +1131,8 @@ export function NewThreadComposer({
           disabled={baseSubmitDisabled || externallyBlocked}
           placeholder={options.placeholder}
           autoFocus={options.autoFocus}
-          pluginComposerHost={options.pluginComposerHost}
-          textEffects={options.textEffects}
+          pluginComposerHost={options.pluginComposerHost ?? pluginComposerHost}
+          textEffects={options.textEffects ?? textEffects}
           zenModeStorageKey={options.zenModeStorageKey}
           history={{
             currentDraft,
@@ -1324,6 +1324,7 @@ export function NewThreadComposer({
       promptDraft,
       promptHistoryDrafts,
       promptMentions,
+      pluginComposerHost,
       providerOptions,
       reasoningLevel,
       reasoningOptions,
@@ -1337,6 +1338,7 @@ export function NewThreadComposer({
       serviceTierSupportByProvider,
       supportsPermissionModeSelection,
       supportsServiceTier,
+      textEffects,
       worktreeDisabledReason,
       worktreeUnavailable,
     ],

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -7,21 +7,20 @@ import {
   useState,
   type ReactNode,
   type Ref,
+  type RefObject,
 } from "react";
 import type { Host, ProjectSource, PromptTextMention } from "@bb/domain";
 import type { ComposerView } from "@get-bb/plugin-sdk";
 import type { ComposerTextEffectSource } from "@/lib/composer-text-effects";
 import { ComposerBannersSlot } from "@/components/plugin/PluginComposerBanners";
 import {
-  PluginComposerHostProvider,
-  PluginComposerViewProvider,
   type PluginComposerHost,
   usePluginComposerViewModel,
 } from "@/components/plugin/plugin-composer-host";
 import {
-  useAppCommandContext,
-  useAppCommandHandler,
-} from "@/components/commands/AppCommandProvider";
+  ComposerExtensionHost,
+  useComposerExtensionController,
+} from "@/components/plugin/ComposerExtensionHost";
 import {
   ExecutionControls,
   type ExecutionControlsProps,
@@ -241,15 +240,11 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
   execution,
 }: NewThreadPromptBoxUIProps) {
   const promptBoxRef = useRef<PromptBoxHandle>(null);
-  // Scope Cmd+Shift+C to the focused split pane (see FollowUpPromptBox). The
-  // new-thread composer is always a pane's primary composer.
   const isFocusedPane = useOptionalPaneContext()?.isFocused ?? true;
-  useAppCommandContext("promptAvailable", true);
-  useAppCommandHandler("composer.focus", () => {
-    if (!isFocusedPane) return false;
+  const focusDefault = useCallback(() => {
     promptBoxRef.current?.focusEnd();
     return promptBoxRef.current !== null;
-  });
+  }, []);
   useImperativeHandle(
     externalPromptBoxRef,
     () => ({
@@ -270,6 +265,90 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
     [],
   );
   const voice = usePromptVoice(promptBoxRef);
+  const attachmentCount = attachments.items?.length ?? 0;
+  const [composerLayout, setComposerLayout] =
+    useState<ComposerView["layout"]>("expanded");
+  const composerView = usePluginComposerViewModel({
+    scope: pluginComposerHost?.scope ?? DEFAULT_NEW_THREAD_COMPOSER_SCOPE,
+    layout: composerLayout,
+    text: value,
+    attachmentCount,
+    isRunning: false,
+    isSubmitting,
+  });
+  const controller = useComposerExtensionController({
+    host: pluginComposerHost ?? null,
+    view: composerView,
+    isFocused: isFocusedPane,
+    isPrimary: true,
+    focusDefault,
+  });
+
+  return (
+    <ComposerExtensionHost
+      controller={controller}
+      defaultRenderer={
+        <DefaultNewThreadComposer
+          id={id}
+          value={value}
+          mentionRanges={mentionRanges}
+          onChange={onChange}
+          onSubmit={onSubmit}
+          promptBoxRef={promptBoxRef}
+          isSubmitting={isSubmitting}
+          disabled={disabled}
+          autoFocus={autoFocus}
+          textEffects={textEffects}
+          zenModeStorageKey={zenModeStorageKey}
+          placeholder={placeholderOverride}
+          history={history}
+          typeahead={typeahead}
+          attachments={attachments}
+          promptActions={promptActions}
+          modeConfig={modeConfig}
+          project={project}
+          execution={execution}
+          voice={voice}
+          onComposerLayoutChange={setComposerLayout}
+        />
+      }
+    />
+  );
+});
+
+interface DefaultNewThreadComposerProps extends Omit<
+  NewThreadPromptBoxUIProps,
+  "promptBoxRef" | "pluginComposerHost"
+> {
+  promptBoxRef: RefObject<PromptBoxHandle | null>;
+  voice: ReturnType<typeof usePromptVoice>;
+  onComposerLayoutChange: (layout: ComposerView["layout"]) => void;
+}
+
+/** BB's presentation for a host-owned new-thread Composer controller. */
+export const DefaultNewThreadComposer = memo(function DefaultNewThreadComposer({
+  id,
+  value,
+  mentionRanges,
+  onChange,
+  onSubmit,
+  promptBoxRef,
+  isSubmitting,
+  disabled,
+  autoFocus,
+  textEffects,
+  zenModeStorageKey,
+  placeholder: placeholderOverride,
+  history,
+  typeahead,
+  attachments,
+  promptActions,
+  modeConfig,
+  project,
+  execution,
+  voice,
+  onComposerLayoutChange,
+}: DefaultNewThreadComposerProps) {
   const isProjectlessPrompt = project?.value === null;
   const placeholder =
     placeholderOverride ?? getNewThreadPromptPlaceholder(isProjectlessPrompt);
@@ -292,17 +371,7 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
     : execution.model.isLoading
       ? "Loading models..."
       : "Submit (Enter)";
-  const attachmentCount = attachments.items?.length ?? 0;
-  const [composerLayout, setComposerLayout] =
-    useState<ComposerView["layout"]>("expanded");
-  const composerView = usePluginComposerViewModel({
-    scope: pluginComposerHost?.scope ?? DEFAULT_NEW_THREAD_COMPOSER_SCOPE,
-    layout: composerLayout,
-    text: value,
-    attachmentCount,
-    isRunning: false,
-    isSubmitting,
-  });
+
   return (
     <div
       data-app-composer=""
@@ -310,51 +379,41 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
       data-promptbox-shell=""
       className="w-full"
     >
-      <PluginComposerViewProvider value={composerView}>
-        <PluginComposerHostProvider value={pluginComposerHost ?? null}>
-          {modeConfig.banner || pluginComposerHost ? (
-            <div className="mb-2 grid gap-2">
-              {pluginComposerHost ? (
-                <ComposerBannersSlot ownerPlacement="before">
-                  {modeConfig.banner}
-                </ComposerBannersSlot>
-              ) : (
-                modeConfig.banner
-              )}
-            </div>
-          ) : null}
-          <PromptBoxInternal
-            id={id}
-            promptBoxRef={promptBoxRef}
-            value={value}
-            mentionRanges={mentionRanges}
-            onChange={onChange}
-            onSubmit={onSubmit}
-            textEffects={textEffects}
-            onComposerLayoutChange={setComposerLayout}
-            history={history}
-            typeahead={typeahead}
-            mentionMenuPlacement="bottom"
-            attachments={attachments}
-            promptActions={promptActions}
-            voice={voice}
-            submission={{
-              isSubmitting,
-              disabled,
-              title: submitTitle,
-            }}
-            autoFocus={autoFocus}
-            zenMode={{
-              layout: "root-compose",
-              storageKey: zenModeStorageKey,
-            }}
-            minHeight={NEW_THREAD_PROMPT_BOX_MIN_HEIGHT}
-            placeholder={placeholder}
-            header={modeConfig.header}
-            footerStart={<ExecutionControls {...execution} />}
-          />
-        </PluginComposerHostProvider>
-      </PluginComposerViewProvider>
+      <div className="mb-2 grid gap-2 empty:hidden">
+        <ComposerBannersSlot ownerPlacement="before">
+          {modeConfig.banner}
+        </ComposerBannersSlot>
+      </div>
+      <PromptBoxInternal
+        id={id}
+        promptBoxRef={promptBoxRef}
+        value={value}
+        mentionRanges={mentionRanges}
+        onChange={onChange}
+        onSubmit={onSubmit}
+        textEffects={textEffects}
+        onComposerLayoutChange={onComposerLayoutChange}
+        history={history}
+        typeahead={typeahead}
+        mentionMenuPlacement="bottom"
+        attachments={attachments}
+        promptActions={promptActions}
+        voice={voice}
+        submission={{
+          isSubmitting,
+          disabled,
+          title: submitTitle,
+        }}
+        autoFocus={autoFocus}
+        zenMode={{
+          layout: "root-compose",
+          storageKey: zenModeStorageKey,
+        }}
+        minHeight={NEW_THREAD_PROMPT_BOX_MIN_HEIGHT}
+        placeholder={placeholder}
+        header={modeConfig.header}
+        footerStart={<ExecutionControls {...execution} />}
+      />
       {/* Strip below the prompt-box card: optional project + env + branch (or
           worktree) on the left, permission picker pinned to the right. `mt-1`
           reproduces the 4px gap main got from a


### PR DESCRIPTION
## Summary

- add one renderer-selection boundary for host-owned Composer instances
- route New Thread, thread follow-up, and plugin `NewThreadComposer` through the shared controller and host
- extract BB's default New Thread and follow-up renderers without changing their presentation
- bind plugin-hosted New Thread draft actions and text effects to the actual Composer instance

## Why

This keeps drafts, attachments, submission policy, focus, and keyboard behavior outside the selected renderer. A later Composer replacement can switch presentation at one boundary without remounting or losing host-owned state.

## Validation

- `pnpm exec turbo run typecheck --filter=@bb/app`
- full `@bb/app` suite: 364 files, 2,884 tests
- focused post-rebase suite: 96 tests
- lint: 0 errors (147 existing warnings)
- Prettier and `git diff --check`

> AGENT GENERATED: by GPT-5.6
