### PR TITLE
Splice timeline windows on event coverage instead of row arithmetic

### DIFF
--- a/apps/app/src/components/thread/timeline/useThreadTimelineController.merge.test.ts
+++ b/apps/app/src/components/thread/timeline/useThreadTimelineController.merge.test.ts
@@ -22,6 +22,7 @@ interface TimelineTestRowArgs {
 
 interface TimelineTurnTestRowArgs extends TimelineTestRowArgs {
   children?: TimelineRow[];
+  endSequence?: number;
 }
 
 function timelineCursor(args: TimelineTestRowArgs): TimelinePaginationCursor {
@@ -83,7 +84,7 @@ function turnSummaryRow(args: TimelineTurnTestRowArgs): TimelineTurnRow {
     threadId: "thread-1",
     turnId: "turn-1",
     sourceSeqStart: args.sequence,
-    sourceSeqEnd: args.sequence,
+    sourceSeqEnd: args.endSequence ?? args.sequence,
     startedAt: args.sequence,
     createdAt: args.sequence,
     kind: "turn",
@@ -94,9 +95,15 @@ function turnSummaryRow(args: TimelineTurnTestRowArgs): TimelineTurnRow {
   };
 }
 
+/**
+ * `headSequence` is the thread's highest event sequence when the page was read,
+ * which the server reports as `maxSeq`. Together with the cursor naming the
+ * window's first sequence it states the event range the response covers.
+ */
 function makeTimelineResponse(
   rows: TimelineRow[],
   olderCursor: TimelinePaginationCursor | null,
+  headSequence: number,
 ): ThreadTimelineResponse {
   return {
     rows,
@@ -107,7 +114,7 @@ function makeTimelineResponse(
     pendingTodos: null,
     goal: null,
     modelFallback: null,
-    maxSeq: 0,
+    maxSeq: headSequence,
     timelinePage: {
       kind: "latest",
       segmentLimit: 20,
@@ -121,8 +128,10 @@ function makeTimelineResponse(
 function makeLoadedTimelineState(
   rows: TimelineRow[],
   olderCursor: TimelinePaginationCursor | null,
+  headSequence: number,
 ): LoadedTimelineState {
   return {
+    coverageEndSequence: headSequence,
     rows,
     olderCursor,
     surfaceKey: "thread-1:default",
@@ -297,10 +306,12 @@ describe("timeline page row merging", () => {
     const current = makeLoadedTimelineState(
       [userRow({ id: "oldest", sequence: 1 })],
       oldestCursor,
+      1,
     );
     const latestTimeline = makeTimelineResponse(
       [userRow({ id: "latest", sequence: 50 })],
       latestCursor,
+      50,
     );
 
     const next = mergeLoadedTimelineWithLatest({
@@ -322,10 +333,12 @@ describe("timeline page row merging", () => {
     const current = makeLoadedTimelineState(
       [userRow({ id: "oldest", sequence: 1 })],
       oldestCursor,
+      1,
     );
     const latestTimeline = makeTimelineResponse(
       [userRow({ id: "latest", sequence: 2 })],
       timelineCursor({ id: "latest-page", sequence: 2 }),
+      2,
     );
 
     const next = mergeLoadedTimelineWithLatest({
@@ -352,6 +365,7 @@ describe("timeline page row merging", () => {
     const current = makeLoadedTimelineState(
       [commandRow({ id: "live-work", sequence: 500 }), liveTail],
       inTurnCursor,
+      520,
     );
     const finishedCursor = timelineCursor({ id: "older-turn", sequence: 1 });
     const latestTimeline = makeTimelineResponse(
@@ -361,6 +375,7 @@ describe("timeline page row merging", () => {
         liveTail,
       ],
       finishedCursor,
+      520,
     );
 
     const next = mergeLoadedTimelineWithLatest({
@@ -377,6 +392,82 @@ describe("timeline page row merging", () => {
     expect(next.olderCursor).toEqual(finishedCursor);
   });
 
+  it("keeps loaded rows when unprojected events separate them from the follow-up window", () => {
+    // The shape a follow-up submission produces on a byte-budgeted thread: the
+    // completed turn's summary spans to `turn/completed`, a provider error that
+    // began later sorts after it and ends earlier, and the events that carry
+    // the turn's end never become rows at all. The prompt opening the next turn
+    // is the first sequence of the fresh window and continues the loaded
+    // history directly, so nothing may be dropped — dropping here truncates the
+    // timeline on submit until auto-load pages it back.
+    const oldestCursor = timelineCursor({ id: "oldest", sequence: 1 });
+    const current = makeLoadedTimelineState(
+      [
+        userRow({ id: "oldest", sequence: 1 }),
+        turnSummaryRow({ endSequence: 100, id: "turn-summary", sequence: 10 }),
+        commandRow({ id: "late-error", sequence: 99 }),
+      ],
+      oldestCursor,
+      100,
+    );
+    const latestTimeline = makeTimelineResponse(
+      [userRow({ id: "follow-up", sequence: 101 })],
+      timelineCursor({ id: "follow-up", sequence: 101 }),
+      104,
+    );
+
+    const next = mergeLoadedTimelineWithLatest({
+      current,
+      latestTimeline,
+      surfaceKey: "thread-1:default",
+    });
+
+    expect(next.rows.map((row) => row.id)).toEqual([
+      "oldest",
+      "turn-summary",
+      "late-error",
+      "follow-up",
+    ]);
+    expect(next.olderCursor).toEqual(oldestCursor);
+    expect(next.coverageEndSequence).toBe(104);
+  });
+
+  it("keeps loaded rows when a window's first row is backfilled from below the cut", () => {
+    // A sequence-cut window names the cut in its cursor, but its first row can
+    // start under it: the projection backfills the running turn's `turn/started`
+    // row from wherever that turn began. The window still continues the loaded
+    // history, so the loaded pages stay.
+    const inTurnCursor = timelineCursor({
+      id: "thread-1:in-turn:60",
+      sequence: 60,
+    });
+    const current = makeLoadedTimelineState(
+      [commandRow({ id: "loaded-work", sequence: 40 })],
+      timelineCursor({ id: "thread-1:in-turn:30", sequence: 30 }),
+      59,
+    );
+    const latestTimeline = makeTimelineResponse(
+      [
+        turnSummaryRow({ endSequence: 70, id: "turn-summary", sequence: 20 }),
+        commandRow({ id: "live-work", sequence: 65 }),
+      ],
+      inTurnCursor,
+      70,
+    );
+
+    const next = mergeLoadedTimelineWithLatest({
+      current,
+      latestTimeline,
+      surfaceKey: "thread-1:default",
+    });
+
+    expect(next.rows.map((row) => row.id)).toEqual([
+      "loaded-work",
+      "turn-summary",
+      "live-work",
+    ]);
+  });
+
   it("recovers from a stale cursor with a fresh latest cursor without dropping loaded rows", () => {
     const staleCursor = timelineCursor({ id: "stale-cursor", sequence: 1 });
     const freshCursor = timelineCursor({ id: "fresh-cursor", sequence: 40 });
@@ -387,10 +478,10 @@ describe("timeline page row merging", () => {
       sourceSeqEnd: oldTail.sourceSeqEnd + 1,
       text: "updated tail",
     };
-    const latestTimeline = makeTimelineResponse([updatedTail], freshCursor);
+    const latestTimeline = makeTimelineResponse([updatedTail], freshCursor, 41);
 
     const next = recoverLoadedTimelineAfterStaleCursor({
-      current: makeLoadedTimelineState([olderUser, oldTail], staleCursor),
+      current: makeLoadedTimelineState([olderUser, oldTail], staleCursor, 20),
       latestTimeline,
       surfaceKey: "thread-1:default",
     });

--- a/apps/app/src/components/thread/timeline/useThreadTimelineController.ts
+++ b/apps/app/src/components/thread/timeline/useThreadTimelineController.ts
@@ -39,12 +39,20 @@ export interface UseThreadTimelineControllerResult {
 type NullableTimelinePaginationCursor = TimelinePaginationCursor | null;
 
 export interface LoadedTimelineState {
+  /**
+   * Highest event sequence the loaded rows account for: the thread head as of
+   * the response that produced them. With the window start named by
+   * `olderCursor`, this closes the event-sequence interval the loaded rows
+   * cover. See {@link canSpliceLatestTimelineWindow}.
+   */
+  coverageEndSequence: number;
   olderCursor: NullableTimelinePaginationCursor;
   rows: TimelineRow[];
   surfaceKey: string;
 }
 
 interface BuildLoadedTimelineStateArgs {
+  coverageEndSequence: number;
   latestRows: TimelineRow[];
   olderCursor: NullableTimelinePaginationCursor;
   surfaceKey: string;
@@ -141,11 +149,13 @@ function filterThreadTimelineResponse({
 }
 
 function buildLoadedTimelineState({
+  coverageEndSequence,
   latestRows,
   olderCursor,
   surfaceKey,
 }: BuildLoadedTimelineStateArgs): LoadedTimelineState {
   return {
+    coverageEndSequence,
     olderCursor,
     rows: latestRows,
     surfaceKey,
@@ -300,46 +310,68 @@ export function mergeLatestTimelineRows({
 }
 
 /**
+ * First event sequence a window covers.
+ *
+ * Every pagination cursor names the first sequence the page that issued it
+ * covered — that is what makes older pages chain — so the cursor is the exact
+ * lower bound of the window it came with. No cursor means the page reached the
+ * start of the thread.
+ */
+function timelineWindowStartSequence(
+  olderCursor: NullableTimelinePaginationCursor,
+): number {
+  return olderCursor === null ? 0 : olderCursor.anchorSeq;
+}
+
+/**
  * Whether a fresh latest window can be spliced onto what is already loaded.
  *
- * Splicing assumes the loaded rows are a prefix of the same history: older
- * first, the latest window continuing from somewhere inside them. Two shapes
- * break that assumption, and both became reachable once a window could be cut
- * inside a running turn rather than on a user message:
+ * Both sides are half of an event-sequence interval the server states outright:
+ * a window starts at its `olderCursor` and a latest window runs to `maxSeq`,
+ * the thread head when it was read. Splicing is sound exactly when the loaded
+ * interval reaches the latest one, so this compares the two intervals rather
+ * than inferring them from the rows.
  *
- * - The latest window reaches back *past* the oldest loaded row. A turn watched
- *   mid-flight is windowed from the budget floor; the moment it finishes it
- *   collapses into one summary row spanning the whole turn, so the next latest
- *   response starts at that turn's user message — before everything held.
- *   Splicing renders the user's prompt after the work it produced.
- * - The latest window starts after the newest loaded row with nothing in
- *   common. Everything between is history neither response contains, and
- *   `olderCursor` still points below the loaded rows, so scrolling never
- *   reaches it.
+ * Rows cannot answer this. Most events never become a row — `turn/completed`,
+ * token-usage and rate-limit updates — so the gap between the last loaded row
+ * and the next window is routinely non-zero while the history is in fact
+ * continuous. Rows are ordered by where they start, not where they end, so the
+ * last row is not the one that reaches furthest: a turn summary spans its whole
+ * turn while shorter rows that begin later sort after it. And a window's first
+ * row can start *below* the window, because the projection backfills a turn's
+ * `turn/started` row from under the cut. Each of those makes row arithmetic
+ * report a break in continuous history, and the caller responds by dropping
+ * every loaded page — the timeline visibly truncates to the newest window and
+ * then refills as auto-load pages it back.
  *
- * Neither can be repaired by merging, so the loaded rows are dropped and the
- * fresh response becomes the timeline. The cost is a scrolled-back reader
- * losing their loaded pages; the alternative is showing them a reordered or
- * silently incomplete thread.
+ * Two shapes are genuinely unspliceable and still return false:
+ *
+ * - The latest window starts below the loaded window. A turn watched mid-flight
+ *   is windowed from the budget floor; the moment it finishes it collapses into
+ *   one summary row spanning the whole turn, so the next latest response starts
+ *   at that turn's user message — before everything held. The fresh window is a
+ *   superset, so rebuilding from it loses no history.
+ * - The latest window starts past the loaded head. Everything between is
+ *   history neither response contains, and `olderCursor` still points below the
+ *   loaded rows, so scrolling could never reach it.
  */
-function isLatestTimelineWindowContiguous({
-  latestRows,
-  loadedRows,
-}: MergeLatestTimelineRowsArgs): boolean {
-  const oldestLoaded = loadedRows[0];
-  const newestLoaded = loadedRows.at(-1);
-  const oldestLatest = latestRows[0];
-  if (!oldestLoaded || !newestLoaded || !oldestLatest) {
+function canSpliceLatestTimelineWindow({
+  current,
+  latestTimeline,
+}: {
+  current: LoadedTimelineState;
+  latestTimeline: ThreadTimelineResponse;
+}): boolean {
+  if (current.rows.length === 0) {
     return true;
   }
-  if (oldestLatest.sourceSeqStart < oldestLoaded.sourceSeqStart) {
+  const latestStartSequence = timelineWindowStartSequence(
+    latestTimeline.timelinePage.olderCursor,
+  );
+  if (latestStartSequence < timelineWindowStartSequence(current.olderCursor)) {
     return false;
   }
-  const loadedRowIds = new Set(loadedRows.map((row) => row.id));
-  if (latestRows.some((row) => loadedRowIds.has(row.id))) {
-    return true;
-  }
-  return oldestLatest.sourceSeqStart <= newestLoaded.sourceSeqEnd + 1;
+  return latestStartSequence <= current.coverageEndSequence + 1;
 }
 
 export function mergeLoadedTimelineWithLatest({
@@ -350,12 +382,10 @@ export function mergeLoadedTimelineWithLatest({
   if (
     current.surfaceKey !== surfaceKey ||
     (current.rows.length === 0 && current.olderCursor === null) ||
-    !isLatestTimelineWindowContiguous({
-      latestRows: latestTimeline.rows,
-      loadedRows: current.rows,
-    })
+    !canSpliceLatestTimelineWindow({ current, latestTimeline })
   ) {
     return buildLoadedTimelineState({
+      coverageEndSequence: latestTimeline.maxSeq,
       latestRows: latestTimeline.rows,
       olderCursor: latestTimeline.timelinePage.olderCursor,
       surfaceKey,
@@ -369,6 +399,13 @@ export function mergeLoadedTimelineWithLatest({
 
   return {
     ...current,
+    // A response older than one already merged (a retry losing a race, a
+    // replayed cache entry) must not walk the head backwards and reopen a gap
+    // that was already closed.
+    coverageEndSequence: Math.max(
+      current.coverageEndSequence,
+      latestTimeline.maxSeq,
+    ),
     olderCursor: current.olderCursor,
     rows: latestMerge.rows,
   };
@@ -381,6 +418,7 @@ export function recoverLoadedTimelineAfterStaleCursor({
 }: RecoverLoadedTimelineAfterStaleCursorArgs): LoadedTimelineState {
   if (current.surfaceKey !== surfaceKey) {
     return buildLoadedTimelineState({
+      coverageEndSequence: latestTimeline.maxSeq,
       latestRows: latestTimeline.rows,
       olderCursor: latestTimeline.timelinePage.olderCursor,
       surfaceKey,
@@ -393,6 +431,10 @@ export function recoverLoadedTimelineAfterStaleCursor({
   });
 
   return {
+    coverageEndSequence: Math.max(
+      current.coverageEndSequence,
+      latestTimeline.maxSeq,
+    ),
     olderCursor: latestTimeline.timelinePage.olderCursor,
     rows: latestMerge.rows,
     surfaceKey,
@@ -427,6 +469,7 @@ export function useThreadTimelineController({
   const [loadedTimeline, setLoadedTimeline] = useState<LoadedTimelineState>(
     () =>
       buildLoadedTimelineState({
+        coverageEndSequence: 0,
         latestRows: [],
         olderCursor: null,
         surfaceKey,
@@ -450,6 +493,7 @@ export function useThreadTimelineController({
         current.surfaceKey === surfaceKey
           ? current
           : buildLoadedTimelineState({
+              coverageEndSequence: 0,
               latestRows: [],
               olderCursor: null,
               surfaceKey,
@@ -499,6 +543,9 @@ export function useThreadTimelineController({
           return current;
         }
         return {
+          // An older page extends the loaded window downwards only; the head it
+          // reaches is unchanged.
+          coverageEndSequence: current.coverageEndSequence,
           olderCursor: areTimelinePaginationCursorsEqual({
             left: current.olderCursor,
             right: nextOlderCursor,


### PR DESCRIPTION
## Problem

Submitting a follow-up on a large thread flashes a truncated timeline: the loaded pages vanish, only the newest window renders, and auto-load then pages the history back in.

A thread past the timeline byte budget (`thr_gcuc46ug4j`: 35.5k events, ~61 MB) gets a latest window of a single segment — 4 rows. Everything above it is auto-loaded. Before rendering a fresh latest window, `useThreadTimelineController` asks whether it continues the loaded rows; when it decides it does not, it drops every loaded page and rebuilds from that 4-row window.

## Why the check was wrong

It answered that question with row source-sequence arithmetic, which rows cannot support:

- **Most events never become rows** — `turn/completed`, token-usage and rate-limit updates — so a continuous history routinely shows a non-zero gap between the last loaded row and the next window.
- **Rows sort by where they start, not where they end**, so the last row is not the one that reaches furthest. A turn summary spans its whole turn while shorter rows that begin later sort after it.
- **A window's first row can start below the window**, because the projection backfills a turn's `turn/started` row from under the cut. That tripped the "latest reaches back past the loaded rows" branch on windows that were perfectly contiguous.

On `thr_gcuc46ug4j` the loaded tail was a `provider/error` row ending at 62634, the turn summary above it reached 62635, and the follow-up prompt opened the next window at 62636. One event short — because `turn/completed` at 62635 is not a row.

## Fix

The server already states the interval each page covers: a pagination cursor names the first sequence its page covered (the invariant that makes older pages chain, `apps/server/src/services/threads/timeline.ts:1330`), and a latest window runs to `maxSeq`, the thread head at read time. `LoadedTimelineState` now carries that head as `coverageEndSequence`, and the splice test compares the two intervals instead of inferring them from rows.

The genuinely unspliceable shapes still rebuild, now stated exactly:

- a latest window starting **below** the loaded one — a turn watched mid-flight that collapsed into one summary row; the fresh window is a superset, so nothing is lost;
- a latest window starting **past** the loaded head — history neither response contains, which `olderCursor` could never page back to.

Coverage is also filter-independent, so filtered surfaces (`rowFilter`) stop understating their reach and rebuilding more often than the main timeline.

Client-only: no contract or server change, since `maxSeq` and the cursor were already on the wire.

## Verification

- Two new tests in `useThreadTimelineController.merge.test.ts` — the follow-up shape from the reported thread, and the backfilled-first-row shape. Both fail against the previous logic (verified by running them against the stashed `HEAD` controller) and pass here.
- Existing merge tests re-expressed in coverage terms, including the turn-collapse rebuild, the real-gap rebuild, and stale-cursor recovery.
- `turbo run test --filter=@bb/app -- timeline`: 186 passed. `typecheck` clean, `lint` 0 errors.
- Against live data for `thr_gcuc46ug4j`: latest window is `olderCursor.anchorSeq 62636 … maxSeq 62718` and the loaded head was 62635, so `62636 <= 62636` splices instead of dropping.

> AGENT GENERATED: by Claude Opus 5