### PR TITLE
Add an issue-filing guide, GitHub issue forms, and a PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,71 @@
+name: Bug report
+description: Something does not work the way it should. A stranger should be able to reproduce it from this issue alone.
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please read [docs/filing-issues.md](https://github.com/get-bb/bb/blob/main/docs/filing-issues.md) first. Short and precise beats long and vague.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What you did, what happened, what you expected. Two or three sentences for someone who does not know the codebase.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Versions and environment
+      description: bb version and install method (desktop app, npx, install.sh, source commit); OS; Node if from source; provider + provider CLI version if an agent is involved; anything unusual (remote machine, Connect, worktree env, custom ports/data dir).
+      placeholder: |
+        - bb 0.38.0 (desktop app), macOS 26
+        - claude-code, claude 2.1.x
+        - worktree environment, bb Connect paired
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered, copy-pasteable, minimal. Exact commands, clicks, or prompt text. Note anything you tried that did NOT reproduce it.
+      placeholder: |
+        1. bb thread spawn --project … --provider codex --prompt "Reply only with ok."
+        2. …
+        Did not reproduce with: claude-code; a fresh data dir.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-actual
+    attributes:
+      label: Expected vs actual
+      description: Paste actual output verbatim (terminal, logs, HTTP responses, `bb thread log` excerpts). Attach a screenshot for visual bugs and say what to look at. Then state what you expected.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Trimmed logs from ~/.bb/logs; thread/project/environment ids (thr_…, proj_…, env_…); code permalinks with a commit sha (`blob/<sha>/path#L…`); how you measured any numbers.
+  - type: textarea
+    id: ruled-out
+    attributes:
+      label: What you ruled out
+      description: One line each. "Not #N because …", "still happens on main at <sha>", "does not happen with provider X", "clean data dir does not help".
+  - type: input
+    id: priority
+    attributes:
+      label: Suggested priority and effort (optional)
+      description: How many users, workaround yes/no, data or work lost. Triage sets the built-in fields; this is input.
+      placeholder: "High — blocks every codex user mid-turn, no workaround; effort probably Low"
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I reproduced this on the latest release or on `main`, or I say above that I could not.
+          required: true
+        - label: I searched open and closed issues for the same problem.
+          required: true
+        - label: If an agent wrote this, the body ends with `> AGENT GENERATED: by <model>` and links the thread or report.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and support
+    url: https://discord.gg/kvBU6tJhcJ
+    about: Ask on Discord. Issues are for reproducible bugs, feature requests, and tasks.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: A workflow you could not complete, or behavior bb should have. Open the issue before a PR for features and UI changes.
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        See [docs/filing-issues.md](https://github.com/get-bb/bb/blob/main/docs/filing-issues.md) and [CONTRIBUTING.md](https://github.com/get-bb/bb/blob/main/CONTRIBUTING.md). Prototype links from a fork are welcome; please get sign-off here before opening a PR.
+  - type: textarea
+    id: workflow
+    attributes:
+      label: The workflow
+      description: What were you trying to do, step by step, and where did bb stop you or make it awkward?
+    validations:
+      required: true
+  - type: textarea
+    id: today
+    attributes:
+      label: What happens today
+      description: Current behavior, with output or screenshots if it helps.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you would expect
+      description: The behavior you want. If you have a concrete UI or CLI shape in mind, describe it; a prototype link is even better.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context and alternatives
+      description: Workarounds you use now, related issues, how many people this affects, anything you ruled out.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched open and closed issues for the same request.
+          required: true
+        - label: If an agent wrote this, the body ends with `> AGENT GENERATED: by <model>`.

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,25 @@
+name: Task
+description: Concrete work with no new product behavior — refactor, docs, chore, cleanup.
+labels: []
+body:
+  - type: textarea
+    id: work
+    attributes:
+      label: The work
+      description: What exactly changes, and where (paths, packages).
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why now
+      description: What this unblocks or what debt it retires. Link the issue or PR that surfaced it.
+    validations:
+      required: true
+  - type: textarea
+    id: done
+    attributes:
+      label: Acceptance criteria
+      description: How a reviewer knows it is done (tests, guards, docs updated, no behavior change).
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+<!-- Keep the four sections. Delete this comment. See docs/filing-issues.md for the issue side. -->
+
+## What was wrong
+
+<!-- One paragraph. The root cause, not the symptom. Link the issue and any investigation report. -->
+
+## What changed
+
+<!-- Files/modules and the behavior change. Call out wire changes (HOST_DAEMON_PROTOCOL_VERSION), CLI/guide/doc updates, and any deviation from the issue's proposed fix. -->
+
+## How you verified
+
+<!-- Tests added (they fail before, pass after), commands run (turbo typecheck/test filters), manual checks. -->
+
+Fixes #
+
+<!-- Agents: end with the line below. -->
+<!-- > AGENT GENERATED: by <model> -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,8 @@
 
 ## GitHub Issues And Pull Requests
 
+- Follow [docs/filing-issues.md](docs/filing-issues.md) when you file an issue. Reproduce first; give versions, minimal copy-pasteable steps, expected vs actual output pasted verbatim, evidence with commit permalinks, and what you ruled out. Use the issue form's sections. Do not file from a single symptom or log line, and do not open a duplicate — add evidence to the existing issue instead.
+- Follow `.github/PULL_REQUEST_TEMPLATE.md` when you open a pull request: what was wrong (root cause), what changed, how you verified (tests that fail before and pass after), `Fixes #N`.
 - When an agent creates a GitHub issue or pull request, add this line at the end of the body:
 
   ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for helping improve bb.
 
 ## Bugs
 
-If you run into a bug, please open an issue with the workflow you were trying to accomplish, what happened, and what you expected instead.
+If you run into a bug, please open an issue with the bug report form. Follow [docs/filing-issues.md](docs/filing-issues.md): versions, minimal copy-pasteable steps, expected vs actual output, evidence, and what you ruled out. A stranger should be able to reproduce it from the issue alone.
 
 If you fix the bug, feel free to open a pull request for it.
 

--- a/docs/filing-issues.md
+++ b/docs/filing-issues.md
@@ -1,0 +1,73 @@
+# Filing Issues
+
+A good issue lets a stranger reproduce the problem in ten minutes without asking you anything. That is the bar for humans and agents alike. The GitHub issue forms in `.github/ISSUE_TEMPLATE/` follow this guide; use them.
+
+## Before you file
+
+1. Reproduce it yourself on the latest release (or `main`). If you cannot, say so in the issue and give what you have; do not present a guess as a repro.
+2. Search open and closed issues. If one exists, comment there instead.
+3. Separate what you **observed** from what you **think the cause is**. Both are welcome; label them.
+
+## What a bug report contains
+
+Use these sections in this order.
+
+### 1. Summary
+
+Two or three sentences: what you did, what happened, what you expected. Write it for someone who does not know the codebase.
+
+### 2. Versions and environment
+
+- bb version (`bb --version` or Settings → About) and how it was installed (desktop app, `npx bb-app`, `install.sh`, from source at commit).
+- OS and version. Node version if you run from source or npm.
+- Provider and provider CLI version when the bug involves an agent (`claude --version`, `codex --version`, `pi --version`, ACP agent build).
+- Anything unusual about the setup: remote machine, bb Connect, worktree environment, custom ports or data dir, cgroup/memory limits.
+
+### 3. Steps to reproduce
+
+Numbered, copy-pasteable, minimal. Exact commands, exact UI clicks, exact prompt text. Include a tiny scratch repo or fixture if the bug needs one. Prefer `bb …` CLI steps over UI descriptions when both work; they are unambiguous.
+
+State the smallest thing that still reproduces it, and note anything you tried that did **not** reproduce it. That negative space is often the fastest route to the cause.
+
+### 4. Expected vs actual
+
+Paste the actual output verbatim (terminal output, log lines, HTTP responses, `bb thread log` excerpts). For visual bugs attach a screenshot or short recording and say what to look at. Then state what you expected instead.
+
+### 5. Evidence
+
+- Logs from `~/.bb/logs/` (or the dev data dir printed by `pnpm dev`), trimmed to the relevant window.
+- Thread ids (`thr_…`), project ids, environment ids when relevant. They are primary keys and let us query the database directly.
+- If you cite code, use a permalink to a commit: `https://github.com/get-bb/bb/blob/<sha>/<path>#L<n>-L<m>`. Branch links rot.
+- If you measured something (memory, timings, counts), say how.
+
+### 6. What you ruled out
+
+One line each: "not a duplicate of #N because …", "still happens on `main` at `<sha>`", "does not happen with provider X", "clean data dir does not help". This keeps a triager from redoing your work.
+
+### 7. Suggested priority and effort
+
+Optional but useful. One line: how many users it hits, whether there is a workaround, and whether data or work is lost. Priority and effort are set from the built-in issue fields during triage; your suggestion is input, not the decision.
+
+## Feature requests and tasks
+
+Feature requests describe the workflow you could not complete, why the current behavior falls short, and what you would expect. Prototype links from a fork are welcome. Per [CONTRIBUTING.md](../CONTRIBUTING.md), open the issue before a PR for features and UI changes.
+
+Tasks (refactors, docs, chores) state the concrete work and its acceptance criteria.
+
+## Rules for agents
+
+Agents file many issues in this repo. The same bar applies, plus:
+
+- Reproduce before you file. A log line or a symptom in one thread is not a bug report. If a live repro is impossible, write the closest faithful repro (for example a unit test at the exact code path) and mark the issue as unverified.
+- Question the report you were handed. If a user's stated cause is wrong, say what you actually observed and what you refuted.
+- Include the base commit you tested against and permalinks to the code you cite.
+- Link the bb thread or the investigation report that produced the finding.
+- Do not open duplicates: search first, and if you find the same root cause under a different symptom, comment on the existing issue with the new evidence.
+- End the body with `> AGENT GENERATED: by <model>` (see [AGENTS.md](../AGENTS.md)).
+
+## Triage labels you may see
+
+- `confirmed-repro` — someone other than the reporter reproduced it; the linked report has the steps.
+- `partial-repro` — the cause is real but part of the report did not reproduce as written.
+- `no-repro` — could not reproduce, or already fixed on `main`; the comment says what was tried.
+- Area labels (`providers`, `threads`, `ui`, `plugins`, `host`, `workspaces`, `desktop`, `mobile`, `remote`, `security`, `cli`, `perf`) and per-plugin labels (`provider-claude-code`, `tasks`, `github`, …) say which part of the product owns it. Type, Priority, and Effort live in the built-in GitHub issue fields, not in labels.


### PR DESCRIPTION
## What was wrong

The repo had no issue templates, a three-line "Bugs" note in CONTRIBUTING.md, and AGENTS.md only asked agents for the `AGENT GENERATED` footer. Issue quality varied from excellent to a single sentence, and today's triage pass (67 reproduction reports, https://get-bb.github.io/reports/) showed the same gaps over and over: no versions, no copy-pasteable steps, symptoms presented as causes, no permalinks, no note of what was ruled out.

## What changed

- `docs/filing-issues.md` (new): the guide. Before you file (reproduce, search, separate observation from theory); the seven bug-report sections in the order our reports use them (summary, versions/environment, steps, expected vs actual, evidence, what you ruled out, suggested priority/effort); feature and task expectations; extra rules for agents (reproduce first, question the report, base commit + permalinks, link the thread/report, no duplicates, footer); what the triage labels mean.
- `.github/ISSUE_TEMPLATE/bug.yml`, `feature.yml`, `task.yml`: GitHub issue forms that require the sections above (versions, steps, expected vs actual, evidence; "I reproduced on latest/main or say I could not" and "I searched" checkboxes). Kept short so people fill them in.
- `.github/ISSUE_TEMPLATE/config.yml`: blank issues off; questions routed to Discord.
- `.github/PULL_REQUEST_TEMPLATE.md`: what was wrong (root cause) / what changed / how you verified / `Fixes #N` — the shape today's fix PRs used.
- `CONTRIBUTING.md`: the Bugs section points at the guide.
- `AGENTS.md`: two bullets under "GitHub Issues And Pull Requests" so agents follow the guide when filing issues and the PR template when opening PRs.

No code changes.

## How you verified

- Rendered the forms' YAML structure by eye against GitHub's issue-forms schema (required `body`, `type`, `attributes.label`, `validations.required`); links are absolute so they resolve from the new-issue page.
- Read the guide as a first-time reporter and as an agent.

Fixes nothing directly; supports every future issue.

> AGENT GENERATED: by Claude Opus 5