### PR TITLE
Replace Tailwind group-has variants that make Blink restyle the whole page on every DOM insert

### DIFF
--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -1264,14 +1264,14 @@ describe("QueuedMessagesList", () => {
     expect(control.className).toContain("border-transparent");
     expect(control.className).toContain("bg-transparent");
     expect(control.className).toContain(
-      "group-has-[[data-queued-message-group-boundary-row]:hover]/queue:border-border",
+      "queue-boundary-row-hover:border-border",
     );
     expect(control.className).toContain(
-      "group-has-[[data-queued-message-group-boundary-row]:focus-within]/queue:bg-background",
+      "queue-boundary-row-focus-within:bg-background",
     );
     expect(grip?.getAttribute("class")).toContain("opacity-55");
     expect(grip?.getAttribute("class")).toContain(
-      "group-has-[[data-queued-message-group-boundary-row]:hover]/queue:opacity-100",
+      "queue-boundary-row-hover:opacity-100",
     );
   });
 

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -893,7 +893,7 @@ function SortableGroupBoundaryHandle({ disabled }: { disabled: boolean }) {
                   ref={setActivatorNodeRef}
                   type="button"
                   className={cn(
-                    "pointer-events-auto flex size-6 shrink-0 touch-none select-none items-center justify-center rounded-full border border-transparent bg-transparent text-muted-foreground transition-[background-color,border-color,box-shadow,color] focus-visible:border-border focus-visible:bg-background focus-visible:shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-has-[[data-queued-message-group-boundary-row]:hover]/queue:border-border group-has-[[data-queued-message-group-boundary-row]:hover]/queue:bg-background group-has-[[data-queued-message-group-boundary-row]:hover]/queue:shadow-sm group-has-[[data-queued-message-group-boundary-row]:focus-within]/queue:border-border group-has-[[data-queued-message-group-boundary-row]:focus-within]/queue:bg-background group-has-[[data-queued-message-group-boundary-row]:focus-within]/queue:shadow-sm hover:border-border hover:bg-background hover:shadow-sm [@media(hover:none)]:border-border [@media(hover:none)]:bg-background [@media(hover:none)]:shadow-sm",
+                    "pointer-events-auto flex size-6 shrink-0 touch-none select-none items-center justify-center rounded-full border border-transparent bg-transparent text-muted-foreground transition-[background-color,border-color,box-shadow,color] focus-visible:border-border focus-visible:bg-background focus-visible:shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring queue-boundary-row-hover:border-border queue-boundary-row-hover:bg-background queue-boundary-row-hover:shadow-sm queue-boundary-row-focus-within:border-border queue-boundary-row-focus-within:bg-background queue-boundary-row-focus-within:shadow-sm hover:border-border hover:bg-background hover:shadow-sm [@media(hover:none)]:border-border [@media(hover:none)]:bg-background [@media(hover:none)]:shadow-sm",
                     anotherItemIsDragging
                       ? "pointer-events-none opacity-0"
                       : "opacity-100",
@@ -908,7 +908,7 @@ function SortableGroupBoundaryHandle({ disabled }: { disabled: boolean }) {
                 >
                   <Icon
                     name="DragDropHorizontal"
-                    className="size-3.5 opacity-55 transition-opacity group-has-[[data-queued-message-group-boundary-row]:hover]/queue:opacity-100 group-has-[[data-queued-message-group-boundary-row]:focus-within]/queue:opacity-100 [@media(hover:none)]:opacity-100"
+                    className="size-3.5 opacity-55 transition-opacity queue-boundary-row-hover:opacity-100 queue-boundary-row-focus-within:opacity-100 [@media(hover:none)]:opacity-100"
                     aria-hidden="true"
                   />
                 </button>

--- a/apps/app/src/components/ui/tab-pill.tsx
+++ b/apps/app/src/components/ui/tab-pill.tsx
@@ -91,7 +91,7 @@ export function TabPill({
               TAB_PILL_LEADING_VISUAL_CLASS,
               !iconOnly && "mr-1.5",
               closeAction
-                ? "group-hover/tab-pill:opacity-0 group-has-[[data-tab-pill-close]:focus-visible]/tab-pill:opacity-0 max-md:pointer-coarse:opacity-0"
+                ? "group-hover/tab-pill:opacity-0 tab-pill-close-focus-visible:opacity-0 max-md:pointer-coarse:opacity-0"
                 : null,
             )}
           >

--- a/apps/app/src/components/ui/tailwind-has-variants.test.ts
+++ b/apps/app/src/components/ui/tailwind-has-variants.test.ts
@@ -1,0 +1,48 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// Tailwind compiles `group-has-*` and `peer-has-*` variants to selectors
+// like `.x:is(:where(.group):has(ARG) *)`. Blink cannot anchor a `:has()`
+// that sits inside `:is()`/`:where()` with a universal subject, so while one
+// such rule exists in the page, every DOM insertion or removal restyles the
+// whole subtree. On a large thread that cost ~1 s per streaming update.
+// Use a named `@custom-variant` in theme.css that keeps `:has()` on the group
+// element itself (`:where(.group\/x):has(ARG) &`) instead.
+const FORBIDDEN_VARIANT = /\b(?:group|peer)-has-(?:\[|[a-z])/u;
+
+const here = dirname(fileURLToPath(import.meta.url));
+const roots = [
+  join(here, "..", ".."),
+  join(here, "..", "..", "..", "..", "..", "packages", "shared-ui", "src"),
+];
+
+function* sourceFiles(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === "dist") continue;
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) {
+      yield* sourceFiles(path);
+    } else if (/\.(?:tsx?|css)$/u.test(entry) && !entry.endsWith(".test.ts")) {
+      yield path;
+    }
+  }
+}
+
+describe("Tailwind has-variants", () => {
+  it("does not use group-has-* or peer-has-* variants", () => {
+    const offenders: string[] = [];
+    for (const root of roots) {
+      for (const file of sourceFiles(root)) {
+        const lines = readFileSync(file, "utf8").split("\n");
+        lines.forEach((line, index) => {
+          if (FORBIDDEN_VARIANT.test(line)) {
+            offenders.push(`${file}:${index + 1}`);
+          }
+        });
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -9,6 +9,17 @@
 
 @custom-variant dark (&:is(.dark *));
 
+/*
+ * Blink cannot anchor a `:has()` that Tailwind nests inside `:is()`/`:where()`
+ * with a universal subject (the shape it emits for `group-has-*` variants).
+ * With that shape present, every DOM insertion or removal under the page
+ * restyles the whole subtree (~1 s on a large thread). Keep `:has()` on the
+ * group element itself instead.
+ */
+@custom-variant queue-boundary-row-hover (:where(.group\/queue):has([data-queued-message-group-boundary-row]:hover) &);
+@custom-variant queue-boundary-row-focus-within (:where(.group\/queue):has([data-queued-message-group-boundary-row]:focus-within) &);
+@custom-variant tab-pill-close-focus-visible (:where(.group\/tab-pill):has([data-tab-pill-close]:focus-visible) &);
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);


### PR DESCRIPTION
## Summary

A Chrome trace of a large streaming thread showed the renderer main thread busy 36.5 s out of 69 s, with **22.4 s in Layout**: about once per second a streaming update (TanStack `setQueryData` → ~45 ms React work → 3 style-changed elements) was followed by an **820–1390 ms Layout with only ~44 dirty objects** on a ~123k-object document. Hover changes in the sidebar on the same document cost 2 ms, so DOM size alone was not the cause.

Reproduced on the real app (perf fixture, ~870 rows / 22k elements) and bisected: any **DOM insertion or removal** in the thread pane triggered a ~180–320 ms whole-subtree **style recalc** (`UpdateLayoutTree elementCount 20,959`), while text/height changes cost <1 ms. Deleting the 26 `:has()` rules dropped it to 0.7 ms; adding back any single Tailwind **`group-has-*`** rule brought it back (175–244 ms) even with zero matching `.group/*` elements in the DOM.

Tailwind compiles `group-has-[X]/queue:opacity-100` to `.x:is(:where(.group\/queue):has(X) *)`. Blink cannot anchor a `:has()` nested inside `:is()`/`:where()` with a universal `*` subject, so it invalidates the whole subtree on every insertion/removal. The same rule as `.group\/queue:has(X) .x` costs ~2 ms. Because the pane sits inside `container-type: inline-size` ancestors (`@container/page`, `@container`), Blink interleaves that recalc into Layout, which is why the trace showed a ~1 s "Layout" with `elementCount 3`.

| selector shape | one DOM insertion (22k elements) |
|---|---|
| no `:has()` rules | 0.5 ms |
| Tailwind `group-has-*` output: `.x:is(:where(.group\/q):has(ARG) *)` | **175–203 ms** |
| `.group\/q:has(ARG) .x` (this PR's shape) | 2 ms |
| subject `:has()` (`has-*` variants) | 0.6 ms |

## Change

- `theme.css`: three named `@custom-variant`s of the shape `:where(.group\/x):has(ARG) &`, which keeps `:has()` on the group element. Same match set and specificity as the Tailwind output.
- Swap the three usages in `tab-pill.tsx` and `QueuedMessagesList.tsx` (+ test assertions).
- New guard test `tailwind-has-variants.test.ts`: fails on any `group-has-*` / `peer-has-*` class in `apps/app/src` or `packages/shared-ui/src`.

Measured on the real page after a clean dev restart: row insert **178 → 3.6 ms**, list append **219 → 2.4 ms**, composer insert **188 → 1.8 ms**.

## Before / after (visual parity)

Captured from the Ladle stories with the pre-fix and post-fix CSS. Every pair is **byte-identical** (`cmp`), and the computed styles for each state match (grip bg/border/shadow and icon opacity; tab-pill leading icon opacity).

| state | before | after |
|---|---|---|
| queue at rest | ![](https://raw.githubusercontent.com/get-bb/reports/main/assets/tailwind-group-has/before-queue-rest.png) | ![](https://raw.githubusercontent.com/get-bb/reports/main/assets/tailwind-group-has/after-queue-rest.png) |
| queue boundary row hover | ![](https://raw.githubusercontent.com/get-bb/reports/main/assets/tailwind-group-has/before-queue-hover.png) | ![](https://raw.githubusercontent.com/get-bb/reports/main/assets/tailwind-group-has/after-queue-hover.png) |
| queue boundary row focus-within | ![](https://raw.githubusercontent.com/get-bb/reports/main/assets/tailwind-group-has/before-queue-focus-within.png) | ![](https://raw.githubusercontent.com/get-bb/reports/main/assets/tailwind-group-has/after-queue-focus-within.png) |
| tab pill at rest | ![](https://raw.githubusercontent.com/get-bb/reports/main/assets/tailwind-group-has/before-tabpill-rest.png) | ![](https://raw.githubusercontent.com/get-bb/reports/main/assets/tailwind-group-has/after-tabpill-rest.png) |
| tab pill close button focus-visible (leading icon hides) | ![](https://raw.githubusercontent.com/get-bb/reports/main/assets/tailwind-group-has/before-tabpill-close-focus-visible.png) | ![](https://raw.githubusercontent.com/get-bb/reports/main/assets/tailwind-group-has/after-tabpill-close-focus-visible.png) |

## Test plan

- [x] `vitest`: `tailwind-has-variants.test.ts`, `theme.test.ts`, `QueuedMessagesList.test.tsx`, `tab-pill.test.tsx` (70 passed)
- [x] Real-app measurement before/after (numbers above)
- [x] Ladle before/after screenshots byte-identical

## Follow-ups (not in this PR)

- Timeline rows have no virtualization/containment; `content-visibility: auto` on rows cut even the pathological cost to ~11 ms and would bound layout/paint on huge threads.
- Read-after-write forced layouts in effects (`conversation-message-overflow` scrollHeight in a ResizeObserver, follow-bottom scrollHeight reads, `file-tree-container` connectedCallback scrollbar probe, ProseMirror mount).
- Renderer heap 1.3–1.9 GB with ~19k node/listener churn per second on that thread.

> AGENT GENERATED: by Claude Opus 5
