### PR TITLE
Keep app shortcuts alive next to a retained closed drawer

### DIFF
--- a/apps/app/src/components/commands/AppCommandProvider.test.tsx
+++ b/apps/app/src/components/commands/AppCommandProvider.test.tsx
@@ -34,7 +34,7 @@ const testState = vi.hoisted(() => ({
         alt: false,
         shift: true,
       },
-      when: { all: ["mainSurface" as const], none: [] },
+      when: { all: ["mainSurface" as const], none: ["modalOpen" as const] },
     },
     {
       command: "thread.new" as const,
@@ -47,7 +47,7 @@ const testState = vi.hoisted(() => ({
         alt: false,
         shift: false,
       },
-      when: { all: ["mainSurface" as const], none: [] },
+      when: { all: ["mainSurface" as const], none: ["modalOpen" as const] },
     },
     {
       command: "thread.previous" as const,
@@ -165,6 +165,19 @@ const testState = vi.hoisted(() => ({
         all: ["mainSurface" as const, "questionOpen" as const],
         none: [],
       },
+    },
+    {
+      command: "panel.toggle" as const,
+      desktopOnly: false,
+      shortcut: {
+        key: "j",
+        mod: true,
+        meta: false,
+        control: false,
+        alt: false,
+        shift: false,
+      },
+      when: { all: ["mainSurface" as const], none: ["modalOpen" as const] },
     },
     {
       command: "browser.reload" as const,
@@ -566,5 +579,74 @@ describe("AppCommandProvider", () => {
     expect(testState.calls).toEqual([]);
     expect(dispatchReload(inside).defaultPrevented).toBe(true);
     expect(testState.calls).toEqual(["browser"]);
+  });
+
+  // The compact sidebar drawer keeps its `aria-modal` panel mounted across
+  // open/close and only marks it `inert` while closed, so a retained panel used
+  // to keep `modalOpen` on for the rest of the session.
+  it.each([
+    ["thread.new" as const, "o", true],
+    ["panel.toggle" as const, "j", false],
+  ])(
+    "runs %s from any focused surface while a closed drawer stays mounted",
+    (command, key, shiftKey) => {
+      renderProvider(
+        <>
+          <Handler command={command} name={command} result={true} />
+          <div role="dialog" aria-modal="true" data-state="closed" inert>
+            {/* Nested and still marked open: only an inert ancestor rules it
+                out, so this covers the ancestor half of the selector. */}
+            <div role="dialog" data-state="open">
+              <button type="button">Sidebar entry</button>
+            </div>
+          </div>
+          <button type="button">Timeline row</button>
+          <div contentEditable data-testid="composer" />
+        </>,
+      );
+      const dispatchChord = (target: Element | null) => {
+        const event = new KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          ctrlKey: true,
+          key,
+          shiftKey,
+        });
+        target?.dispatchEvent(event);
+        return event;
+      };
+
+      for (const target of [
+        screen.getByText("Timeline row"),
+        screen.getByText("Sidebar entry"),
+        screen.getByTestId("composer"),
+      ]) {
+        testState.calls.length = 0;
+        expect(dispatchChord(target).defaultPrevented).toBe(true);
+        expect(testState.calls).toEqual([command]);
+      }
+    },
+  );
+
+  it("suppresses main-surface commands while a drawer is actually open", () => {
+    renderProvider(
+      <>
+        <Handler command="thread.new" name="thread.new" result={true} />
+        <div role="dialog" aria-modal="true" data-state="open">
+          <button type="button">Drawer entry</button>
+        </div>
+      </>,
+    );
+    const event = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      ctrlKey: true,
+      key: "o",
+      shiftKey: true,
+    });
+    screen.getByText("Drawer entry").dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(testState.calls).toEqual([]);
   });
 });

--- a/apps/app/src/components/commands/AppCommandProvider.tsx
+++ b/apps/app/src/components/commands/AppCommandProvider.tsx
@@ -83,12 +83,20 @@ function browserPlatform(): string {
   return typeof navigator === "undefined" ? "" : navigator.platform;
 }
 
+// A dialog that is mounted but not showing must not suppress app commands. The
+// compact sidebar drawer keeps its `aria-modal` panel in the DOM across
+// open/close and only marks it `inert` while closed (see `SidebarMobilePanel`),
+// so matching `aria-modal` alone left `modalOpen` stuck on for the whole
+// session on narrow windows — every `mainSurface` chord (thread.new,
+// panel.toggle, terminal.open, …) then silently declined. The `inert`
+// exclusions cover the node itself and any inert ancestor.
+const OPEN_MODAL_SELECTOR = [
+  '[aria-modal="true"]:not([inert]):not([inert] *):not([data-state="closed"])',
+  '[role="dialog"][data-state="open"]:not([inert]):not([inert] *)',
+].join(", ");
+
 function hasOpenModal(): boolean {
-  return (
-    document.querySelector(
-      '[aria-modal="true"], [role="dialog"][data-state="open"]',
-    ) !== null
-  );
+  return document.querySelector(OPEN_MODAL_SELECTOR) !== null;
 }
 
 export function AppCommandProvider({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Root cause

`AppCommandProvider.hasOpenModal()` treated **any** `[aria-modal="true"]` node as an open modal. bb's compact sidebar drawer (`SidebarMobilePanel`) intentionally stays mounted across open/close and only marks its panel `inert` while closed (#1261), so that panel matched the selector permanently.

Result: on any window narrower than the 767px compact breakpoint — reachable on desktop, where `MIN_WINDOW_WIDTH` is 500 — `modalOpen` was stuck `true` for the whole session, and every `mainSurface` binding that excludes `modalOpen` (`thread.new`, `panel.toggle`, `terminal.open`, `sidebar.toggle`, …) silently declined, exactly the "observed behavior is narrower than the declared context" symptom reported in #1812.

## Fix

In the shared app-command path only: a candidate counts as an open modal only when it is neither inside an `[inert]` subtree nor `data-state="closed"`. A drawer or dialog that is genuinely open still suppresses commands.

## Validation

Live in the dev app (`scripts/bb-dev-app`, 700px-wide window, thread route), before the fix:

- focus in the timeline/body: `thread.new`, `panel.toggle`, `terminal.open` all no-ops (`defaultPrevented === false`), the retained node reporting `role=dialog state=closed inert=true`
- focus in the composer: also a no-op

After the fix, all of them run with focus in the timeline, on a sidebar button, and in the composer, and with the drawer actually open `thread.new` is still suppressed.

Unit coverage added in `AppCommandProvider.test.tsx` (fails without the fix): `thread.new` and `panel.toggle` dispatch from a timeline row, a sidebar entry, and a contenteditable composer while a closed, inert drawer is mounted; a genuinely open drawer still suppresses.

`turbo run test --filter=@bb/app` (commands, promptbox shortcuts, app-keybindings, root-compose handlers: 41 passed), `turbo run typecheck lint --filter=@bb/app` (0 errors).

## Note for the reporter

I could not reproduce the composer-only asymmetry described in the issue on a wide window: with the real desktop shell (Electron, CDP-driven), on web, and with a Linux-platform-emulated renderer, `thread.new` and `panel.toggle` already dispatched from body, sidebar-button, and timeline focus. The defect above is the one path that does kill those exact commands while the effective keybindings still advertise them. If the original report was on a wide window, please reopen with the window size and whether the sidebar was a drawer.

Two adjacent gaps found while tracing, left out as separate concerns:
- the desktop native-menu path dispatches `thread.new`/`panel.newTab`/`settings.open` via IPC with no context evaluation and a `null` target, unlike every renderer-dispatched chord;
- when the desktop browser panel's `WebContentsView` has focus, `resolveDesktopBrowserAppCommand` only resolves `browserFocus`-scoped bindings, so global chords are dropped there.

Closes #1812

> AGENT GENERATED: by Claude Opus 5