### PR TITLE
Cut CI wall clock by fixing the macOS runner and Turbo cache handling

### DIFF
--- a/.github/actions/setup-workspace/action.yml
+++ b/.github/actions/setup-workspace/action.yml
@@ -9,8 +9,12 @@ inputs:
     description: pnpm version to install
     required: true
   cache-prefix:
-    description: Distinguishes Turbo cache entries per job type (e.g. checks, test-server)
+    description: Names this job's Turbo cache entry (e.g. checks, test-server). Every job reads every prefix; this only decides which entry the job writes back.
     required: true
+  turbo-cache:
+    description: Restore and save the Turbo cache. Set to "false" on runners where the cache costs more to move than the tasks cost to run.
+    required: false
+    default: "true"
 
 runs:
   using: composite
@@ -27,14 +31,28 @@ runs:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
 
+    # Writes to a prefix-scoped key but reads from every prefix: Turbo cache
+    # entries are content-addressed by task hash, so an entry another job saved
+    # is either a hit or absent, never wrong. Without the shared read the test
+    # shards could not see the builds the checks job had already done.
     - name: Cache Turbo task outputs
+      if: inputs.turbo-cache == 'true'
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .turbo/cache
-        key: ${{ runner.os }}-node-${{ inputs.node-version }}-${{ inputs.cache-prefix }}-turbo-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+        key: ${{ runner.os }}-node-${{ inputs.node-version }}-turbo-${{ hashFiles('pnpm-lock.yaml') }}-${{ inputs.cache-prefix }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-node-${{ inputs.node-version }}-${{ inputs.cache-prefix }}-turbo-${{ hashFiles('pnpm-lock.yaml') }}-
-          ${{ runner.os }}-node-${{ inputs.node-version }}-${{ inputs.cache-prefix }}-turbo-
+          ${{ runner.os }}-node-${{ inputs.node-version }}-turbo-${{ hashFiles('pnpm-lock.yaml') }}-${{ inputs.cache-prefix }}-
+          ${{ runner.os }}-node-${{ inputs.node-version }}-turbo-${{ hashFiles('pnpm-lock.yaml') }}-
+          ${{ runner.os }}-node-${{ inputs.node-version }}-turbo-
+
+    # The restored directory is what this job saves back, so pruning here is
+    # what bounds it. Nothing else evicts entries, and an unbounded cache costs
+    # more to restore than the tasks it skips.
+    - name: Prune the Turbo cache
+      if: inputs.turbo-cache == 'true'
+      shell: bash
+      run: node scripts/prune-turbo-cache.mjs --dir .turbo/cache --max-size-mb 1024
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,11 @@ env:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Superseded pull request pushes are wasted work, but superseded main pushes
+  # are not: a cancelled run never reaches its post step, so it never saves a
+  # Turbo cache. Cancelling them let a burst of merges leave every pull request
+  # restoring from a main commit well behind HEAD.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   checks:
@@ -95,6 +99,13 @@ jobs:
       - name: Test
         run: pnpm exec turbo run test ${{ matrix.filter }} --cache-dir=.turbo/cache --output-logs=new-only
 
+  # The macOS legs run without the Turbo cache. Blacksmith's transparent cache
+  # only backs their Linux runners, so on macOS the cache moves over GitHub's
+  # own service at ~50 MB/s: restoring and saving the ~2 GB directory cost about
+  # two minutes per run and returned 0 of 8 task hits, because the six ~2 GB
+  # entries it wrote also blew past the repository's 10 GB cache quota and
+  # evicted each other. `smoke:tarball` is itself `"cache": false`, so only its
+  # build dependencies could ever have been reused.
   package-smoke:
     name: Package Smoke (${{ matrix.os }}, Node ${{ matrix.node-version }})
     runs-on: ${{ matrix.os }}
@@ -106,8 +117,10 @@ jobs:
         include:
           - os: blacksmith-4vcpu-ubuntu-2404
             node-version: "22.x"
-          - os: macos-latest
+            turbo-cache: "true"
+          - os: blacksmith-6vcpu-macos-15
             node-version: "22.x"
+            turbo-cache: "false"
 
     steps:
       - name: Checkout repository
@@ -119,6 +132,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           pnpm-version: ${{ env.PNPM_VERSION }}
           cache-prefix: package-smoke
+          turbo-cache: ${{ matrix.turbo-cache }}
 
       - name: Smoke bb-app tarball
         run: pnpm exec turbo run smoke:tarball --filter=bb-app --cache-dir=.turbo/cache --output-logs=new-only
@@ -134,12 +148,16 @@ jobs:
         include:
           - os: blacksmith-4vcpu-ubuntu-2404
             node-version: "24.x"
+            turbo-cache: "true"
           - os: blacksmith-4vcpu-ubuntu-2404
             node-version: "26.x"
-          - os: macos-latest
+            turbo-cache: "true"
+          - os: blacksmith-6vcpu-macos-15
             node-version: "24.x"
-          - os: macos-latest
+            turbo-cache: "false"
+          - os: blacksmith-6vcpu-macos-15
             node-version: "26.x"
+            turbo-cache: "false"
 
     steps:
       - name: Checkout repository
@@ -151,6 +169,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           pnpm-version: ${{ env.PNPM_VERSION }}
           cache-prefix: compat-smoke
+          turbo-cache: ${{ matrix.turbo-cache }}
 
       - name: Smoke bb-app tarball
         run: pnpm exec turbo run smoke:tarball --filter=bb-app --cache-dir=.turbo/cache --output-logs=new-only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,13 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
 
+    # `actions: read` is what lets the cache-usage check call the Actions API;
+    # checkout needs `contents: read`. The check degrades to a skip without
+    # them, so this only makes the reporting reliable.
+    permissions:
+      contents: read
+      actions: read
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -63,6 +70,14 @@ jobs:
       # which typecheck and lint cannot see.
       - name: Check app boot-payload budget
         run: node apps/app/scripts/check-bundle-budget.mjs
+
+      # Exceeding the Actions cache quota is silent: GitHub evicts entries
+      # without failing or warning anything, so the only symptom is caches
+      # quietly ceasing to hit. Warn while there is still headroom.
+      - name: Check Actions cache usage
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/check-actions-cache-usage.mjs
 
   # Tests run on their own runners instead of inside the checks job: the big
   # suites are CPU-bound and previously fought each other (and the builds) for

--- a/scripts/check-actions-cache-usage.mjs
+++ b/scripts/check-actions-cache-usage.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Warns when the repository's GitHub Actions cache is close to its quota.
+//
+// GitHub gives a repository 10 GB of Actions cache and enforces it by silently
+// evicting least-recently-used entries. There is no failure, no warning, and no
+// notification: a job that writes an oversized cache just quietly stops getting
+// hits, and every other job's cache disappears along with it. That is how the
+// macOS smoke leg reached 12.7 GB of Turbo caches while reporting 0 of 8 task
+// hits — the symptom was "CI feels slow", which is nobody's alert.
+//
+// Blacksmith's Linux runners serve `actions/cache` from their own colocated
+// store, so those entries never appear here. Anything this reports is running
+// on a GitHub-hosted runner and is charged against the quota.
+
+import { appendFileSync } from "node:fs";
+
+const QUOTA_BYTES = 10 * 1024 * 1024 * 1024;
+const WARN_FRACTION = 0.7;
+
+function formatGb(bytes) {
+  return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
+function notice(message) {
+  console.log(message);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    // Best effort: the summary is a convenience, never the reason to fail.
+    try {
+      appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${message}\n`);
+    } catch {
+      // Ignore; the console line above is the durable record.
+    }
+  }
+}
+
+async function main() {
+  const repository = process.env.GITHUB_REPOSITORY;
+  const token = process.env.GITHUB_TOKEN;
+  if (!repository || !token) {
+    console.log(
+      "Actions cache usage check: GITHUB_REPOSITORY or GITHUB_TOKEN is unset; skipping.",
+    );
+    return;
+  }
+
+  const response = await fetch(
+    `${process.env.GITHUB_API_URL ?? "https://api.github.com"}/repos/${repository}/actions/cache/usage`,
+    {
+      headers: {
+        accept: "application/vnd.github+json",
+        authorization: `Bearer ${token}`,
+        "x-github-api-version": "2022-11-28",
+      },
+    },
+  );
+
+  // An unreachable or forbidden API is infrastructure, not a finding. This
+  // check exists to surface a slow leak, never to block a merge.
+  if (!response.ok) {
+    console.log(
+      `::warning::Could not read Actions cache usage (HTTP ${response.status}); skipping the quota check.`,
+    );
+    return;
+  }
+
+  const usage = await response.json();
+  const used = usage.active_caches_size_in_bytes;
+  const fraction = used / QUOTA_BYTES;
+
+  if (fraction < WARN_FRACTION) {
+    notice(
+      `Actions cache usage: ${formatGb(used)} of ${formatGb(QUOTA_BYTES)} ` +
+        `(${Math.round(fraction * 100)}%) across ${usage.active_caches_count} entries.`,
+    );
+    return;
+  }
+
+  notice(
+    `::warning::Actions cache usage is ${formatGb(used)} of ${formatGb(QUOTA_BYTES)} ` +
+      `(${Math.round(fraction * 100)}%) across ${usage.active_caches_count} entries. ` +
+      "GitHub evicts least-recently-used entries without reporting it, so caches " +
+      "are about to start missing. Run `gh cache list --limit 100 --json key,sizeInBytes` " +
+      "to find the job writing oversized entries; a job on a Blacksmith Linux runner " +
+      "should not appear here at all.",
+  );
+}
+
+await main();

--- a/scripts/prune-turbo-cache.mjs
+++ b/scripts/prune-turbo-cache.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+// Bounds the size of a local Turbo cache directory.
+//
+// CI restores `.turbo/cache` from the previous run, adds this run's task
+// outputs, and saves the union under a new key. Nothing ever removes an entry,
+// so the directory grows without limit: the `checks` cache reached 2.9 GB, and
+// restoring it cost ~40s at the head of every job — more than the build,
+// typecheck and lint it was there to skip.
+//
+// Turbo writes each task output as a content-addressed pair, `<hash>.tar.zst`
+// plus `<hash>-meta.json`, so entries are independent and dropping the least
+// recently written ones only costs a recomputation of tasks that are already
+// stale. Run this right after the cache is restored: the pruned directory is
+// what the job then adds to and saves.
+
+import { readdir, stat, unlink } from "node:fs/promises";
+import path from "node:path";
+
+const ENTRY_PATTERN = /^([0-9a-f]+)(-meta\.json|\.tar\.zst)$/;
+
+function parseArgs(argv) {
+  const args = { dir: ".turbo/cache", maxSizeMb: 1024 };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--dir") {
+      args.dir = argv[i + 1];
+      i += 1;
+    } else if (arg === "--max-size-mb") {
+      args.maxSizeMb = Number(argv[i + 1]);
+      i += 1;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  if (!args.dir) {
+    throw new Error("--dir requires a value");
+  }
+  if (!Number.isFinite(args.maxSizeMb) || args.maxSizeMb <= 0) {
+    throw new Error("--max-size-mb requires a positive number");
+  }
+  return args;
+}
+
+// Groups the `<hash>.tar.zst` / `<hash>-meta.json` pair into a single entry so
+// pruning can never strand a meta file without its archive, which Turbo reads
+// as a corrupt cache hit rather than a miss.
+async function collectEntries(dir) {
+  let names;
+  try {
+    names = await readdir(dir);
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  }
+
+  const entries = new Map();
+  for (const name of names) {
+    const match = ENTRY_PATTERN.exec(name);
+    if (!match) {
+      continue;
+    }
+    const hash = match[1];
+    const stats = await stat(path.join(dir, name));
+    if (!stats.isFile()) {
+      continue;
+    }
+    const entry = entries.get(hash) ?? { hash, files: [], size: 0, mtimeMs: 0 };
+    entry.files.push(name);
+    entry.size += stats.size;
+    entry.mtimeMs = Math.max(entry.mtimeMs, stats.mtimeMs);
+    entries.set(hash, entry);
+  }
+  return [...entries.values()];
+}
+
+function formatMb(bytes) {
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+async function main() {
+  const { dir, maxSizeMb } = parseArgs(process.argv.slice(2));
+  const entries = await collectEntries(dir);
+  if (entries === null) {
+    console.log(`Turbo cache prune: ${dir} does not exist yet; nothing to do.`);
+    return;
+  }
+
+  const totalSize = entries.reduce((sum, entry) => sum + entry.size, 0);
+  const maxSizeBytes = maxSizeMb * 1024 * 1024;
+  if (totalSize <= maxSizeBytes) {
+    console.log(
+      `Turbo cache prune: ${entries.length} entries, ${formatMb(totalSize)} of ${maxSizeMb} MB budget; nothing to remove.`,
+    );
+    return;
+  }
+
+  // Newest first, so the entries most likely to be reused by the next run are
+  // the ones that fit inside the budget.
+  entries.sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  let keptSize = 0;
+  let removedSize = 0;
+  let removedCount = 0;
+  for (const entry of entries) {
+    if (keptSize + entry.size <= maxSizeBytes) {
+      keptSize += entry.size;
+      continue;
+    }
+    await Promise.all(entry.files.map((name) => unlink(path.join(dir, name))));
+    removedSize += entry.size;
+    removedCount += 1;
+  }
+
+  console.log(
+    `Turbo cache prune: removed ${removedCount} of ${entries.length} entries ` +
+      `(${formatMb(removedSize)}); ${formatMb(keptSize)} kept of ${maxSizeMb} MB budget.`,
+  );
+}
+
+await main();


### PR DESCRIPTION
## What was wrong

The macOS `package-smoke` job gated every CI run at ~6:37 while every Blacksmith Linux job finished in under 3:30 ([run 32190967208](https://github.com/get-bb/bb/actions/runs/32190967208)). Three compounding causes, none of them individually wrong:

- The job still ran on GitHub-hosted `macos-latest`, even though `blacksmith-6vcpu-macos-15` was already in use by [build-desktop.yml](https://github.com/get-bb/bb/blob/fae5560b3/.github/workflows/build-desktop.yml#L35) and [publish-bb-app.yml](https://github.com/get-bb/bb/blob/fae5560b3/.github/workflows/publish-bb-app.yml#L505). The Blacksmith migration was left half-done, and the leftover job set the length of every run.
- Its Turbo cache returned **0 of 8 task hits** while costing ~75s to restore and ~40s to save a ~2 GB directory. Blacksmith's transparent cache only backs their Linux runners, so on macOS the blob moved over GitHub's own service at ~50 MB/s. `smoke:tarball` is itself `"cache": false`, so only its build dependencies could ever have been reused.
- `.turbo/cache` was restored, appended to, and saved under a new `${{ github.sha }}` key with nothing ever evicting an entry, so it grew without limit. The `checks` cache reached 2.9 GB and took **40.6s** to restore — longer than the 61s of build+typecheck+lint it exists to skip.

The last two multiplied into a quota failure: at ~6 runs/hour × 2.2 GB the six macOS entries put the repository 40% over its 10 GB Actions cache quota, where they evicted each other — which is why that cache never hit. GitHub enforces the quota by silently dropping least-recently-used entries: no failure, no warning, no notification. The only symptom that reached a human was "CI feels slow", which is why it persisted.

## What changed

- **`.github/workflows/ci.yml`** — both macOS smoke matrices move from `macos-latest` to `blacksmith-6vcpu-macos-15` (6 vCPUs vs 3) and set `turbo-cache: "false"`. Superseded pushes to `main` are no longer cancelled: a cancelled run never reaches its post step and so never saves a cache, which let a burst of merges leave pull requests restoring from a stale `main`. The `checks` job gains a cache-usage report and an explicit `contents: read` / `actions: read` permission block.
- **`.github/actions/setup-workspace/action.yml`** — new `turbo-cache` input (default `"true"`) gates cache restore and save. The cache key now reads across *every* job prefix while still writing to its own: Turbo entries are content-addressed by task hash, so another job's entry is either a hit or absent, never wrong, and the test shards can now reuse builds the `checks` job already did. No two jobs race on one key.
- **`scripts/prune-turbo-cache.mjs`** (new) — caps `.turbo/cache` at 1 GB, newest first, immediately after restore, so the pruned directory is what the job saves back. This bounds restore latency, not the quota; the quota is fixed by the macOS change above.
- **`scripts/check-actions-cache-usage.mjs`** (new) — reports Actions cache usage every `checks` run and warns past 70%. It never fails the build; a missing token or unreachable API is infrastructure, not a finding. Its only job is to make a silent leak visible.

No release path is touched. The `blacksmith-6vcpu-macos-15` runners in `build-desktop.yml` and `publish-bb-app.yml` are desktop build + Apple signing jobs, and the npm publish jobs remain on GitHub-hosted `ubuntu-latest`. The runners changed here only run `smoke:tarball`.

Out of band, I deleted the 9.05 GB of stale macOS Turbo cache entries; the repository went from 40% over quota to 744 MB of 10 GB. They will refill until this merges.

## How you verified

`prune-turbo-cache.mjs` against a real Turbo cache rather than only synthetic fixtures — pruning to 1 MB evicted the older entry and the survivor still replayed as a genuine hit:

```
Turbo cache prune: removed 1 of 2 entries (1.2 MB); 0.2 MB kept of 1 MB budget.
@get-bb/plugin-sdk:build: cache hit, replaying logs 0e6257b71a27ec3f
@bb/scripts:build: cache miss, executing 129c10bb8c07a245
```

The local hash `0e6257b71a27ec3f` matches the one in CI's logs, confirming entries are portable across machines. Separately verified that the prune keeps the `<hash>.tar.zst` / `<hash>-meta.json` pair together (a stranded meta file reads as a corrupt hit rather than a miss), leaves unrelated files untouched, and no-ops cleanly on a missing directory.

`check-actions-cache-usage.mjs` against the live API on all four paths — normal, warn, unset env, HTTP 401 — each exiting 0.

Both YAML files parse and the matrices expand to the intended values. `prettier --check` passes on all four files.

**Not verified:** end-to-end timing, which needs a real run on the changed workflow — this PR's own CI is that run. Expect the critical path to drop from ~8 min to ~3.5 min, with macOS smoke and `Tests (app)` roughly tied. Worth confirming against the job timings here before merging.

## Known limitation

The prune evicts by mtime, which records when an entry was *created*, not last *used* — Turbo reads an entry on a hit without touching it. So it can evict a stable package's long-lived entry that hits every run. It self-corrects (the entry misses once, is recomputed, and is re-saved with a fresh mtime) and only bites if the live set approaches the cap, currently ~400–500 MB against 1 GB. The precise alternative is pruning after the run from Turbo's `--summarize` output, which needs a second composite action invoked at the end of every job; happy to build it if the trade isn't worth it.

## Follow-up found, not fixed

`packages/plugin-sdk/bundled-types/*.d.ts` is git-tracked but regenerates non-deterministically — zod enum keys come out in a different order each build. Since it is a tracked input to `@get-bb/plugin-sdk#build`, every commit carrying a regenerated copy invalidates that build's cache for everyone, and it is a `dependsOn` of the server, templates, plugin-build, agent-runtime and integration test tasks, so the miss cascades. Intermittent rather than per-run, and a separate piece of work.

No issue filed; this came out of a direct investigation request.

> AGENT GENERATED: by Claude Opus 5