### PR TITLE
Stop the background-command banner from swallowing the command name

### DIFF
--- a/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
@@ -118,23 +118,33 @@ function BackgroundActivitySummary({
   const model = backgroundActivityModel(row);
   return (
     <span className="flex min-w-0 flex-1 items-center gap-1 text-left">
-      <span className="min-w-0 truncate" title={row.description}>
-        <span
-          className={
-            active ? activityMetaClass("active") : "text-muted-foreground"
-          }
-        >
-          {display.runningPrefix}{" "}
-        </span>
-        <span
-          className={
-            active
-              ? activityTextClass("active")
-              : "font-medium text-foreground opacity-70"
-          }
-        >
-          {row.description}
-        </span>
+      {/*
+       * The prefix and the description truncate as separate flex items rather
+       * than as one truncating span. `activityTextClass("active")` carries
+       * `animate-shine`, which is `display: inline-block` so its
+       * background-clip gradient has a box to size against — an atomic inline
+       * inside a truncating parent is dropped whole when it overflows, so the
+       * description collapsed to a bare ellipsis with the rest of the row left
+       * empty. Truncating on the shimmering element itself clips its own text.
+       */}
+      <span
+        className={cn(
+          "shrink-0 whitespace-nowrap",
+          active ? activityMetaClass("active") : "text-muted-foreground",
+        )}
+      >
+        {display.runningPrefix}
+      </span>
+      <span
+        className={cn(
+          "min-w-0 truncate",
+          active
+            ? activityTextClass("active")
+            : "font-medium text-foreground opacity-70",
+        )}
+        title={row.description}
+      >
+        {row.description}
       </span>
       {model ? (
         <span


### PR DESCRIPTION
## What was wrong

The prompt-box background-command banner rendered `Running background command: …` with the command name gone and the rest of the row blank, however wide the card was. The data was fine — the stored `backgroundTask` item descriptions are intact. `BackgroundActivitySummary` put the prefix and the description inside a single `truncate` span (`overflow:hidden; text-overflow:ellipsis; white-space:nowrap`), and the description span uses `activityTextClass("active")`, which includes `animate-shine`. `.animate-shine` sets `display: inline-block` (`theme.css`) so its `background-clip: text` gradient has a box to size against. An `inline-block` is an atomic inline: it cannot be clipped mid-word, so when it overflows an ellipsis container the browser drops it whole and renders only the ellipsis. `ThreadWorkflowCard` never hit this because it puts `truncate` *on* the shimmering element; `TimelineTitleView` likewise applies shimmer and truncate to the same segment element, so timeline rows are unaffected.

## What changed

`apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx` only. The prefix and the description are now separate flex items: the prefix is `shrink-0 whitespace-nowrap`, and `min-w-0 truncate` moves onto the shimmering description element itself, where the ellipsis clips that element's own text. `title` still carries the full command. No wire, CLI, or doc surface is touched.

## How you verified

- Reproduced the failure in real Chrome with the two markup variants side by side (identical except `display:inline-block` on the description): the inline-block row renders `Running background command: …` across an otherwise empty 600px row; the plain-inline row truncates normally.
- Re-rendered the fixed markup: the full width is used, and at 300px it degrades to `Running background command: cd /…` instead of vanishing.
- `pnpm exec turbo run typecheck lint --filter=@bb/app` — clean (the 147 lint warnings are pre-existing).
- `pnpm exec turbo run test --filter=@bb/app -- ThreadBackgroundCommandsCard` — 2 passed.

No test added: this is a layout-only failure and jsdom performs no layout, so any assertion would just restate the class list.

> AGENT GENERATED: by Claude Opus 5
