### PR TITLE
Shard the @bb/app test suite across three CI runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,12 +93,26 @@ jobs:
         include:
           - shard: server
             filter: --filter=@bb/server
-          - shard: app
+            args: ""
+          # @bb/app is by far the largest suite (365 files) and was the critical
+          # path once the macOS smoke leg was fixed. Vitest splits by file, and
+          # Turbo hashes passthrough args, so each leg is a distinct cache entry
+          # rather than three jobs racing to reuse one.
+          - shard: app-1
             filter: --filter=@bb/app
+            args: -- --shard=1/3
+          - shard: app-2
+            filter: --filter=@bb/app
+            args: -- --shard=2/3
+          - shard: app-3
+            filter: --filter=@bb/app
+            args: -- --shard=3/3
           - shard: integration
             filter: --filter=@bb/integration-tests
+            args: ""
           - shard: packages
             filter: --filter='!@bb/server' --filter='!@bb/app' --filter='!@bb/integration-tests'
+            args: ""
 
     steps:
       - name: Checkout repository
@@ -112,7 +126,7 @@ jobs:
           cache-prefix: test-${{ matrix.shard }}
 
       - name: Test
-        run: pnpm exec turbo run test ${{ matrix.filter }} --cache-dir=.turbo/cache --output-logs=new-only
+        run: pnpm exec turbo run test ${{ matrix.filter }} --cache-dir=.turbo/cache --output-logs=new-only ${{ matrix.args }}
 
   # The macOS legs run without the Turbo cache. Blacksmith's transparent cache
   # only backs their Linux runners, so on macOS the cache moves over GitHub's


### PR DESCRIPTION
## What was wrong

With the macOS smoke leg fixed in #1831, `Tests (app)` became the critical path of every CI run at ~3:13. `@bb/app` is by far the largest suite in the repo — 365 files and 2902 tests, against 182 files for the next biggest — and it ran on a single 4 vCPU runner while four other test legs sat idle.

## What changed

**`.github/workflows/ci.yml`** — the `app` matrix leg becomes `app-1`, `app-2` and `app-3`, each passing vitest's file-level `--shard=N/3` through Turbo. Every leg gains an `args` field (empty for the non-sharded legs) that is appended to the `Test` step's command.

Turbo includes passthrough args in the task hash, which this depends on:

```
--shard=1/3 -> a80e86f0055ac7b7
--shard=2/3 -> 8dbfc806f0b65e41
```

That matters more than it might look. If the args were *not* hashed, all three legs would share one cache entry, and two of them would report a false cache hit and silently skip their tests while reporting green. I verified the hashes differ rather than assuming it.

## How you verified

All three shards run clean locally and partition the suite exactly — no gaps, no overlaps:

| shard | files | tests |
|---|---|---|
| 1/3 | 122 | 918 |
| 2/3 | 122 | 968 |
| 3/3 | 121 | 1016 |
| **total** | **365** | **2902** |

365 matches the file count of the unsharded suite exactly.

Also confirmed the `--shard` argument survives the package script's `&&` chain (`node scripts/generate-pwa-icons.mjs --check && vitest run --config vitest.config.ts`) and lands on `vitest` rather than the icon check — it does, since Turbo appends to the last command.

## What this does and does not fix

It buys wall clock at the cost of CPU minutes. It does not remove the underlying waste, and I want to be explicit that the gain is sublinear rather than 3x.

The suite's own breakdown, summed across workers:

```
Duration 83.34s (transform 32.47s, setup 7.35s, import 720.09s,
                 tests 122.81s, environment 306.37s)
```

Import and environment setup are ~87% of the work; actual test execution is 122s. Each shard re-pays a share of that import cost because most files pull in overlapping React/UI modules — so a third of the files takes 46% of the time, not 33% (83.4s full vs 38.4s for shard 1 locally). **Expect `Tests (app)` ~3:13 to ~1:40, not ~1:05.** That is enough to take it off the critical path, which now sits at ~2:54 for the macOS smoke leg.

## Follow-up: the real fix, and a pre-existing bug

Removing the import overhead outright means `isolate: false` via the existing `findIsolationRequiringTests` helper, already used by `apps/server` and `packages/agent-runtime`. Measured at **83.34s -> 40.02s (-52%)** on this suite. It is not viable yet: `apps/app` has cross-file coupling through module-level state that no static heuristic can detect. Two examples found so far —

- `SidebarSectionRow.test.tsx` writes to `localStorage` and expects a module-level `jotai` atom to read it; under a shared module registry the atom already cached its value at import.
- `MachinePicker.test.tsx` uses only `vi.fn()` and `vi.clearAllMocks()`, neither of which implies module-registry mutation, so nothing static would flag it.

Separately, and independent of any of this: **`apps/app` has pre-existing order-dependent flakiness on `main` today.** Running the unmodified config with shuffled file order reproduces it:

```
--sequence.shuffle --sequence.seed=11 -> 3 failed
  PluginPendingInteractionComposer.test.tsx
  QueuedMessagesList.test.tsx
  SecondaryPanelLayout.test.tsx
--sequence.shuffle --sequence.seed=22 -> 1 failed
  QueuedMessagesList.test.tsx
--sequence.shuffle --sequence.seed=33 -> 3 failed
  PluginPanelRightPanelHost.test.tsx
  PluginPendingInteractionComposer.test.tsx
  SecondaryPanelLayout.test.tsx
```

I ran this against both the modified and unmodified configs with the same seeds and got identical failures, so these are not caused by sharding or by `isolate: false` — they are latent today, masked only because vitest's default file ordering is deterministic. A rename or a new test file could surface them in an unrelated PR. Being fixed in batches, starting with these four.

> AGENT GENERATED: by Claude Opus 5