### PR TITLE
Restore three non-presentational tests dropped in #1832

### DIFF
--- a/apps/app/src/components/ui/tab-pill.test.tsx
+++ b/apps/app/src/components/ui/tab-pill.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TabPill } from "./tab-pill";
+
+afterEach(cleanup);
+
+describe("TabPill", () => {
+  // An icon-only tab has no visible text, so its whole accessible presence
+  // comes from `ariaLabel` plus the visually-hidden label. Losing either one
+  // leaves a button a screen reader announces as unlabelled.
+  it("keeps an icon-only tab reachable by its accessible name", () => {
+    render(
+      <TabPill
+        label="Info"
+        ariaLabel="Show thread info panel"
+        iconOnly
+        leadingVisual={<span aria-hidden>i</span>}
+        title="Thread info"
+        isActive
+        onSelect={vi.fn()}
+        closeAction={null}
+      />,
+    );
+
+    const tab = screen.getByRole("button", { name: "Show thread info panel" });
+    expect(tab.getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByText("Info").classList).toContain("sr-only");
+  });
+
+  it("reports the pressed state of an inactive tab", () => {
+    render(
+      <TabPill
+        label="Browser"
+        title="Browser"
+        isActive={false}
+        onSelect={vi.fn()}
+        closeAction={null}
+      />,
+    );
+
+    expect(
+      screen
+        .getByRole("button", { name: "Browser" })
+        .getAttribute("aria-pressed"),
+    ).toBe("false");
+  });
+});

--- a/apps/app/src/views/RootComposeSecondaryContent.test.tsx
+++ b/apps/app/src/views/RootComposeSecondaryContent.test.tsx
@@ -298,6 +298,26 @@ describe("RootComposeSecondaryContent desktop layout", () => {
   // be opened. jsdom can't run the native region resolution, so these lock the
   // class/DOM contract that drives it: the cutout is a child of the strip
   // (resolved after it) at the pinned toggle's shared position.
+  it("carves the pinned toggle footprint out of the drag strip while the panel is closed", () => {
+    setMacosDesktopChrome();
+
+    renderRootCompose({
+      isCompactViewport: false,
+      isSecondaryPanelOpen: false,
+    });
+
+    const strip = screen.getByTestId("root-compose-main-window-drag-strip");
+    const cutout = screen.getByTestId("root-compose-drag-strip-toggle-cutout");
+    expect(cutout.parentElement).toBe(strip);
+    expect(cutout.className).toContain("[app-region:no-drag]");
+    expect(cutout.className).toContain("[-webkit-app-region:no-drag]");
+    for (const positionClass of ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS.split(
+      " ",
+    )) {
+      expect(cutout.className).toContain(positionClass);
+    }
+  });
+
   it("keeps the drag strip whole while the panel is open (the panel chrome carves instead)", () => {
     setMacosDesktopChrome();
 

--- a/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
@@ -1669,6 +1669,52 @@ describe("SplitThreadArea", () => {
     expect(document.querySelectorAll("[data-split-pane-id]")).toHaveLength(7);
   });
 
+  // The pane header is itself a macOS drag region, so the plugin pane's own
+  // drag handle has to opt back out or the OS swallows its pointer events as
+  // window drags and panes can no longer be reordered. jsdom can't resolve
+  // native regions, so this locks the class contract that drives them.
+  it("carves a plugin pane drag handle out of the macOS window-drag region", async () => {
+    const desktopInfo: BbDesktopInfo = {
+      lastCheckedAt: null,
+      latestVersion: null,
+      pendingVersion: null,
+      platform: "macos",
+      updateAvailable: false,
+      updateDownloaded: false,
+      version: "0.0.0-test",
+    };
+    window.bbDesktop = createBbDesktopApi(desktopInfo);
+    setPluginSlotRegistrations("docs", {
+      homepageSections: [],
+      settingsSections: [],
+      navPanels: [
+        {
+          id: "docs",
+          title: "Docs",
+          icon: "FileText",
+          path: "docs",
+          component: () => <div>Docs panel</div>,
+        },
+      ],
+      threadPanelActions: [],
+      pendingInteractions: [],
+      sidebarFooterActions: [],
+      fileOpeners: [],
+      messageDirectives: [],
+    });
+
+    renderSplitArea({
+      path: "/plugins/docs/docs",
+      layout: pluginSplitLayout(),
+      routeContent: docsContent,
+    });
+
+    const title = await screen.findByText("Docs");
+    const dragHandle = title.parentElement?.parentElement;
+    expect(dragHandle?.className).toContain("[app-region:no-drag]");
+    expect(dragHandle?.className).toContain("[-webkit-app-region:no-drag]");
+  });
+
   it("makes only top-row split headers desktop window-drag regions", async () => {
     const desktopInfo: BbDesktopInfo = {
       lastCheckedAt: null,


### PR DESCRIPTION
## What was wrong

[#1832](https://github.com/get-bb/bb/pull/1832) deleted tests whose assertions only restated Tailwind utility classes. Three of its removals were misclassified: they read classes the app itself keys on, which is the exception #1832 stated but did not apply here.

Two are macOS window-drag contracts. Electron resolves `app-region` from DOM order and jsdom cannot run that resolution, so the class/DOM shape is the only thing a test can hold. Without the root-compose cutout, the closed right panel sits inside the drag strip's rect and can never be reopened; without the plugin pane handle's exemption, the OS swallows the pane-reorder gesture as a window drag. The 6-line comment explaining the first contract [survived the deletion](https://github.com/get-bb/bb/blob/f4e158aa30d72f959c1e6e0830f38b25e6d0e631/apps/app/src/views/RootComposeSecondaryContent.test.tsx#L294-L300) while the test it described did not, and the surviving `SplitThreadArea` coverage asserts only the positive `drag` region, never the `no-drag` exemption.

The third is `TabPill`, which was left with no test anywhere in the repo. An icon-only tab's entire accessible presence is `ariaLabel` plus the visually hidden label, so losing either leaves a button screen readers announce as unlabelled — something neither tsc nor the JSX-echo argument covers.

These were raised as slop-cop review comments on #1832 after it merged.

## What changed

Test-only, +115 lines across 3 files. No production code, no wire format, no CLI or docs surface — `HOST_DAEMON_PROTOCOL_VERSION` is untouched.

- `apps/app/src/views/RootComposeSecondaryContent.test.tsx` — restored "carves the pinned toggle footprint out of the drag strip while the panel is closed", verbatim, directly under the comment that already explains it.
- `apps/app/src/views/thread-detail/SplitThreadArea.test.tsx` — restored "carves a plugin pane drag handle out of the macOS window-drag region", minus its `cursor-grab` assertion, with a comment naming the failure mode.
- `apps/app/src/components/ui/tab-pill.test.tsx` — recreated with two tests covering only the accessibility contract: accessible name, `aria-pressed` in both states, and the `sr-only` label fallback.

Restored assertions carry no presentational tokens. The `bg-state-active`, `after:h-0.5`, and `cursor-grab` reads from the originals stay deleted, as do the other 51 tests and 246 assertions #1832 removed.

The fourth comment, on the `apps/cli` `cliFetch` deletion, is deliberately not acted on. That function is `return fetch(input, init)` and the test stubbed `fetch` to assert it received the arguments just passed to it, so it restates the function body and would not catch credential injection — which would happen in the SDK transport or in callers, not there.

## How you verified

Restoring a test is only worth it if the test can fail, so each one was checked against a targeted mutation of the production class it guards:

| Mutation | Result |
| --- | --- |
| Drop `MACOS_APP_REGION_NO_DRAG_CLASS` from the RootCompose toggle cutout | 1 failed, 6 passed |
| Drop `usesDesktopChrome && MACOS_WINDOW_NO_DRAG_CLASS` from `SplitThreadArea.tsx:1205` | 1 failed, 40 passed |
| Drop `iconOnly ? "sr-only"` from `tab-pill.tsx:103` | 1 failed, 1 passed |

Each mutation took down exactly its own test and no others; all three were reverted.

- `pnpm exec turbo run test --filter=@bb/app --force` — green, 360 files / 2,863 tests.
- `pnpm exec turbo run typecheck --filter=@bb/app` — clean.
- `pnpm exec turbo run lint --filter=@bb/app` — 0 errors (147 pre-existing warnings, unchanged from #1832).
- `pnpm exec prettier --write` on every touched file.

Follow-up to #1832.

> AGENT GENERATED: by Claude Opus 5