### PR TITLE
Stop the sidebar section drag from looping into React #185

### DIFF
--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -103,6 +103,17 @@
   body[data-sidebar-dragging="true"] * {
     cursor: grabbing !important;
   }
+
+  /* A sidebar drag projects the dragged row into the hovered list, which can
+   * grow or shrink content above the scrolled viewport. Scroll anchoring would
+   * then move scrollTop to keep the visible rows still, but dnd-kit offsets
+   * its measured droppable rects by that scroll delta even though nothing
+   * moved on screen, so `over` resolves against the wrong rows and the
+   * projection flips back and forth (#1830). Keep scrollTop stable while a
+   * sidebar drag is active so the measured geometry matches the pointer. */
+  body[data-sidebar-dragging="true"] [data-sidebar="content"] {
+    overflow-anchor: none;
+  }
 }
 
 @layer components {

--- a/apps/app/src/components/sidebar/useSectionThreadDnd.projection.test.tsx
+++ b/apps/app/src/components/sidebar/useSectionThreadDnd.projection.test.tsx
@@ -1,0 +1,202 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type {
+  DragCancelEvent,
+  DragOverEvent,
+  DragStartEvent,
+} from "@dnd-kit/core";
+import type { ThreadListEntry } from "@bb/domain";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildSectionThreadList,
+  CHRONOLOGICAL_CONTAINER_ID,
+} from "./projectThreadGroups";
+import {
+  collectSectionThreadDndLookup,
+  SectionThreadProjectionGate,
+  useSectionThreadDnd,
+} from "./useSectionThreadDnd";
+
+function createThread(overrides: Partial<ThreadListEntry>): ThreadListEntry {
+  return {
+    id: "thread",
+    projectId: "project",
+    environmentId: null,
+    providerId: "codex",
+    title: "Thread",
+    titleFallback: "Thread",
+    sectionId: null,
+    status: "idle",
+    parentThreadId: null,
+    sourceThreadId: null,
+    originKind: null,
+    originPluginId: null,
+    visibility: "visible",
+    archivedAt: null,
+    pinnedAt: null,
+    pinSortKey: null,
+    deletedAt: null,
+    lastReadAt: 0,
+    latestAttentionAt: 2,
+    createdAt: 1,
+    updatedAt: 2,
+    activity: {
+      activeWorkflowCount: 0,
+      activeBackgroundAgentCount: 0,
+      activeBackgroundCommandCount: 0,
+      activePlanModeCount: 0,
+      activeGoalCount: 0,
+    },
+    hasPendingInteraction: false,
+    environmentHostId: null,
+    environmentName: null,
+    environmentBranchName: null,
+    environmentWorkspaceDisplayKind: "other",
+    runtime: {
+      displayStatus: "idle",
+      hostReconnectGraceExpiresAt: null,
+    },
+    ...overrides,
+  };
+}
+
+const SECTIONS = [
+  { id: "a", name: "Section A" },
+  { id: "b", name: "Section B" },
+];
+const ROOT_ITEMS = buildSectionThreadList(
+  [
+    createThread({ id: "dragged", sectionId: "a" }),
+    createThread({ id: "peer-a", sectionId: "a", createdAt: 2 }),
+    createThread({ id: "in-b", sectionId: "b", createdAt: 3 }),
+    createThread({ id: "loose", createdAt: 4 }),
+  ],
+  undefined,
+  SECTIONS,
+);
+const LOOKUP = collectSectionThreadDndLookup(
+  ROOT_ITEMS,
+  CHRONOLOGICAL_CONTAINER_ID,
+);
+const SECTION_B_PARENT_KEY =
+  LOOKUP.sectionParentKeyBySectionId.get("section:b");
+
+function dragStart(id: string): DragStartEvent {
+  return { active: { id } } as DragStartEvent;
+}
+
+function dragOver(activeId: string, overId: string): DragOverEvent {
+  return { active: { id: activeId }, over: { id: overId } } as DragOverEvent;
+}
+
+function renderSectionThreadDnd() {
+  const queryClient = new QueryClient();
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return renderHook(
+    () =>
+      useSectionThreadDnd({
+        containerId: CHRONOLOGICAL_CONTAINER_ID,
+        enabled: true,
+        rootItems: ROOT_ITEMS,
+        topLevelSectionOrder: ["pinned", "section:a", "section:b", "threads"],
+        onTopLevelSectionOrderChange: vi.fn(),
+        pinnedReorderPending: false,
+        pinnedThreads: [],
+        onReorderPinnedThread: vi.fn(),
+      }),
+    { wrapper },
+  );
+}
+
+function notePointerMove() {
+  document.dispatchEvent(
+    new MouseEvent("pointermove", { bubbles: true, clientX: 10, clientY: 10 }),
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useSectionThreadDnd projection feedback loop (#1830)", () => {
+  it("does not un-project when `over` flips back without new user input", () => {
+    const { result } = renderSectionThreadDnd();
+    const props = () => result.current!.dndContextProps;
+
+    act(() => props().onDragStart?.(dragStart("dragged")));
+    act(() => props().onDragOver?.(dragOver("dragged", "section:b")));
+    expect(result.current?.dragOverParentKey).toBe(SECTION_B_PARENT_KEY);
+    expect(result.current?.projectedSectionId).toBe("b");
+
+    // The projection re-rendered the row into section B and dnd-kit resolved
+    // `over` against the source section again with the pointer unmoved. That
+    // is our own render feeding back, so the projection must hold; reverting
+    // here is what looped until React error #185.
+    act(() => props().onDragOver?.(dragOver("dragged", "peer-a")));
+    expect(result.current?.dragOverParentKey).toBe(SECTION_B_PARENT_KEY);
+    expect(result.current?.projectedSectionId).toBe("b");
+
+    // A target the pointer has not visited yet is still allowed.
+    act(() => props().onDragOver?.(dragOver("dragged", "loose")));
+    expect(result.current?.dragOverParentKey).toBe(CHRONOLOGICAL_CONTAINER_ID);
+    expect(result.current?.projectedSectionId).toBeNull();
+
+    // Real input re-opens every target, including the source section.
+    act(() => notePointerMove());
+    act(() => props().onDragOver?.(dragOver("dragged", "peer-a")));
+    expect(result.current?.dragOverParentKey).toBeNull();
+    expect(result.current?.projectedSectionId).toBeUndefined();
+
+    act(() => notePointerMove());
+    act(() => props().onDragOver?.(dragOver("dragged", "section:b")));
+    expect(result.current?.dragOverParentKey).toBe(SECTION_B_PARENT_KEY);
+  });
+
+  it("stops tracking input once the drag ends", () => {
+    const addSpy = vi.spyOn(document, "addEventListener");
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+    const { result, unmount } = renderSectionThreadDnd();
+    const props = () => result.current!.dndContextProps;
+
+    act(() => props().onDragStart?.(dragStart("dragged")));
+    const added = addSpy.mock.calls.filter(([type]) => type === "pointermove");
+    expect(added).toHaveLength(1);
+
+    act(() =>
+      props().onDragCancel?.({ active: { id: "dragged" } } as DragCancelEvent),
+    );
+    expect(
+      removeSpy.mock.calls.filter(([type]) => type === "pointermove"),
+    ).toHaveLength(1);
+
+    act(() => props().onDragStart?.(dragStart("dragged")));
+    unmount();
+    expect(
+      removeSpy.mock.calls.filter(([type]) => type === "pointermove"),
+    ).toHaveLength(2);
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+});
+
+describe("SectionThreadProjectionGate", () => {
+  it("allows each target once per input and blocks reverts", () => {
+    const gate = new SectionThreadProjectionGate();
+    expect(gate.allow(null, "b")).toBe(true);
+    expect(gate.allow("b", null)).toBe(false);
+    expect(gate.allow("b", "c")).toBe(true);
+    expect(gate.allow("c", "b")).toBe(false);
+
+    gate.noteInput();
+    expect(gate.allow("c", "b")).toBe(true);
+    expect(gate.allow("b", "c")).toBe(false);
+
+    gate.reset();
+    expect(gate.allow("b", "c")).toBe(true);
+  });
+});

--- a/apps/app/src/components/sidebar/useSectionThreadDnd.ts
+++ b/apps/app/src/components/sidebar/useSectionThreadDnd.ts
@@ -266,6 +266,61 @@ export function resolveProjectedSectionThreadDropTarget(
   return { activeId, fromParentKey, toParentKey: projectedParentKey };
 }
 
+/**
+ * Decides whether a projection change may apply (#1830).
+ *
+ * dnd-kit recomputes `over` synchronously whenever a projection re-renders the
+ * dragged row into another list: the row's droppable re-registers, every
+ * container is re-measured, and the sidebar's scroll geometry can shift under
+ * a pointer that never moved. That recomputation can resolve to the target we
+ * just left, which un-projects the row, which flips `over` again, until React
+ * aborts the nested update loop with error #185 and the route falls into its
+ * error boundary.
+ *
+ * The gate therefore lets each target apply at most once per user input
+ * (pointer move, touch move, wheel, key press). A revert that arrives without
+ * new input is our own render feeding back, not the user, and is dropped.
+ */
+export class SectionThreadProjectionGate {
+  private inputGeneration = 0;
+  private appliedInputGeneration = -1;
+  private readonly visitedTargets = new Set<string | null>();
+
+  /** Records user input; the next projection change starts a fresh cycle. */
+  noteInput(): void {
+    this.inputGeneration += 1;
+  }
+
+  reset(): void {
+    this.inputGeneration = 0;
+    this.appliedInputGeneration = -1;
+    this.visitedTargets.clear();
+  }
+
+  /**
+   * Returns true when `target` may replace `current`. Call only when they
+   * differ; a successful call marks `target` as visited for the current input.
+   */
+  allow(current: string | null, target: string | null): boolean {
+    if (this.appliedInputGeneration !== this.inputGeneration) {
+      this.appliedInputGeneration = this.inputGeneration;
+      this.visitedTargets.clear();
+      this.visitedTargets.add(current);
+    } else if (this.visitedTargets.has(target)) {
+      return false;
+    }
+    this.visitedTargets.add(target);
+    return true;
+  }
+}
+
+const PROJECTION_INPUT_EVENTS = [
+  "pointermove",
+  "touchmove",
+  "wheel",
+  "keydown",
+] as const;
+
 function getEventIds(event: DragOverEvent | DragEndEvent) {
   return {
     activeId: typeof event.active.id === "string" ? event.active.id : null,
@@ -337,6 +392,30 @@ export function useSectionThreadDnd({
   const dwellTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const dropSettleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const dwellParentKeyRef = useRef<string | null>(null);
+  const projectionGateRef = useRef(new SectionThreadProjectionGate());
+  const stopProjectionInputTrackingRef = useRef<(() => void) | null>(null);
+
+  const stopProjectionInputTracking = useCallback(() => {
+    stopProjectionInputTrackingRef.current?.();
+    stopProjectionInputTrackingRef.current = null;
+  }, []);
+  const startProjectionInputTracking = useCallback(() => {
+    stopProjectionInputTracking();
+    const gate = projectionGateRef.current;
+    gate.reset();
+    const noteInput = () => gate.noteInput();
+    for (const type of PROJECTION_INPUT_EVENTS) {
+      document.addEventListener(type, noteInput, {
+        capture: true,
+        passive: true,
+      });
+    }
+    stopProjectionInputTrackingRef.current = () => {
+      for (const type of PROJECTION_INPUT_EVENTS) {
+        document.removeEventListener(type, noteInput, { capture: true });
+      }
+    };
+  }, [stopProjectionInputTracking]);
 
   const clearDropDwell = useCallback(() => {
     if (dwellTimerRef.current !== null) clearTimeout(dwellTimerRef.current);
@@ -359,8 +438,9 @@ export function useSectionThreadDnd({
     () => () => {
       clearDropDwell();
       clearDropSettle();
+      stopProjectionInputTracking();
     },
-    [clearDropDwell, clearDropSettle],
+    [clearDropDwell, clearDropSettle, stopProjectionInputTracking],
   );
 
   const handleDragStart = useCallback(
@@ -373,10 +453,11 @@ export function useSectionThreadDnd({
       draggingThreadRef.current = thread !== null;
       clearDropSettle();
       clearDropDwell();
+      startProjectionInputTracking();
       setActiveThread(thread);
       setDragOverParentKey(null);
     },
-    [clearDropDwell, clearDropSettle, lookup],
+    [clearDropDwell, clearDropSettle, lookup, startProjectionInputTracking],
   );
 
   const handleDragOver = useCallback(
@@ -410,6 +491,14 @@ export function useSectionThreadDnd({
           : (drop?.toParentKey ??
             (decision?.kind === "pin" ? PINNED_THREAD_PARENT_KEY : null));
       if (targetParentKey === dwellParentKeyRef.current) return;
+      if (
+        !projectionGateRef.current.allow(
+          dwellParentKeyRef.current,
+          targetParentKey,
+        )
+      ) {
+        return;
+      }
 
       clearDropDwell();
       dwellParentKeyRef.current = targetParentKey;
@@ -451,6 +540,7 @@ export function useSectionThreadDnd({
     (event: DragEndEvent) => {
       draggingThreadRef.current = false;
       clearDropDwell();
+      stopProjectionInputTracking();
       if (!enabled) {
         clearProjectedDrag();
         return;
@@ -525,6 +615,7 @@ export function useSectionThreadDnd({
       lookup,
       onTopLevelSectionOrderChange,
       pinThread,
+      stopProjectionInputTracking,
       topLevelSectionIds,
       topLevelSectionOrder,
       updateThread,
@@ -536,8 +627,9 @@ export function useSectionThreadDnd({
   const handleDragCancel = useCallback(() => {
     draggingThreadRef.current = false;
     clearDropDwell();
+    stopProjectionInputTracking();
     clearProjectedDrag();
-  }, [clearDropDwell, clearProjectedDrag]);
+  }, [clearDropDwell, clearProjectedDrag, stopProjectionInputTracking]);
 
   const { consumeClickSuppression, dndContextProps, onClickCapture } =
     useSidebarReorderDnd({


### PR DESCRIPTION
## What was wrong

The crash in #1830 is a feedback loop in the sidebar section-thread drag (`useSectionThreadDnd`, the multi-container sorter in `ProjectRow`), not a defect in dnd-kit's `useRect`. `handleDragOver` re-projects the dragged row into whatever list dnd-kit reports as `over`. That projection re-renders the row into another list, so its droppable re-registers and dnd-kit re-measures every container in the same commit chain. When the sidebar is scrolled and the row is projected into a section above the viewport, the browser's scroll anchoring moves `scrollTop` to keep the visible rows still, but dnd-kit offsets its measured rects by that scroll delta even though nothing moved on screen. `over` then resolves to the source list under a pointer that never moved, the row is un-projected, `over` flips again, and each hop is a layout-effect or synchronously flushed passive-effect update. React counts them as nested updates and aborts with error #185; the thrower is whichever `setState` runs 51st, which is why the packaged stack lands on dnd-kit's `setRect`.

Reproduced on this branch with a headless Chromium script: manual sidebar mode, a 520px-tall viewport so the sidebar scrolls, scroll to the bottom, drag a section thread to the bottom edge and then to the top edge, hold. Every attempt logged `Maximum update depth exceeded` and `[bb] the app crashed`; the per-`over` log shows the projection flipping Alpha → Beta → Alpha with `scrollTop` alternating 172 ↔ 203 and the raw pointer fixed at y=160. The same script no longer crashes with this fix (3/3 runs), and reverting the fix crashes again.

## What changed

- `apps/app/src/components/sidebar/useSectionThreadDnd.ts`: `SectionThreadProjectionGate` allows each projection target at most once per user input (pointer move, touch move, wheel, key press). A revert that arrives without new input is our own render feeding back and is dropped. The hook tracks input with capture listeners on `document` from drag start until end, cancel, or unmount.
- `apps/app/src/app.css`: `overflow-anchor: none` on the sidebar scroller while `body[data-sidebar-dragging="true"]`, so a projection cannot move `scrollTop` and desynchronize dnd-kit's rects from the pointer. Either change alone stops the reproduced crash; the gate is the general guard against the feedback loop, the CSS removes the geometry trigger.
- No wire or CLI changes.

## How you verified

- New `useSectionThreadDnd.projection.test.tsx`: renders the hook, drags a thread over section B, then reports `over` on the source section with no input. Fails before (`expected null to be 'chronological::b'`), passes after. Also covers that unvisited targets stay allowed, that input reopens targets, that listeners are removed on cancel/unmount, and the gate itself.
- `pnpm exec turbo run typecheck --filter=@bb/app` and `pnpm exec turbo run test --filter=@bb/app` (360 files, 2862 tests) pass.
- Manual: headless Chromium repro above crashes on `main` and does not crash with the fix; a normal drag from Alpha into Beta still projects and drops (thread `sectionId` updated).

Fixes #1830

> AGENT GENERATED: by Claude Opus 5
