### PR TITLE
Stop test-only edits from invalidating the production build

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,9 @@
     "@bb/web#build": {
       "inputs": [
         "$TURBO_DEFAULT$",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.tsx",
         "$TURBO_ROOT$/apps/web/package.json",
         "$TURBO_ROOT$/apps/web/src/**",
         "$TURBO_ROOT$/apps/web/tsconfig.json",
@@ -13,25 +16,20 @@
         "$TURBO_ROOT$/pnpm-workspace.yaml",
         "$TURBO_ROOT$/turbo.json"
       ],
-      "env": [
-        "CLOUDFLARE_ENV",
-        "VITE_POSTHOG_KEY",
-        "VITE_POSTHOG_HOST"
-      ],
-      "outputs": [
-        "dist/**"
-      ]
+      "env": ["CLOUDFLARE_ENV", "VITE_POSTHOG_KEY", "VITE_POSTHOG_HOST"],
+      "outputs": ["dist/**"]
     },
     // Mirrors "build" but also caches bundle-stats.json, which the
     // bb:bundle-stats Vite plugin writes beside dist for the boot-payload
     // budget check. Without it a cache hit would leave CI checking a stale
     // file, or none at all.
     "@bb/app#build": {
-      "dependsOn": [
-        "topo"
-      ],
+      "dependsOn": ["topo"],
       "inputs": [
         "$TURBO_DEFAULT$",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.tsx",
         "$TURBO_ROOT$/package.json",
         "$TURBO_ROOT$/packages/tsconfig/*.json",
         "$TURBO_ROOT$/pnpm-lock.yaml",
@@ -42,17 +40,15 @@
         "$TURBO_ROOT$/scripts/precompress-app-dist.mjs",
         "$TURBO_ROOT$/turbo.json"
       ],
-      "outputs": [
-        "bundle-stats.json",
-        "dist/**"
-      ]
+      "outputs": ["bundle-stats.json", "dist/**"]
     },
     "build": {
-      "dependsOn": [
-        "topo"
-      ],
+      "dependsOn": ["topo"],
       "inputs": [
         "$TURBO_DEFAULT$",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.tsx",
         "$TURBO_ROOT$/package.json",
         "$TURBO_ROOT$/packages/tsconfig/*.json",
         "$TURBO_ROOT$/pnpm-lock.yaml",
@@ -63,15 +59,10 @@
         "$TURBO_ROOT$/scripts/precompress-app-dist.mjs",
         "$TURBO_ROOT$/turbo.json"
       ],
-      "outputs": [
-        "dist/**"
-      ]
+      "outputs": ["dist/**"]
     },
     "@bb/sdk#test": {
-      "dependsOn": [
-        "//#ensure-native-modules",
-        "topo"
-      ],
+      "dependsOn": ["//#ensure-native-modules", "topo"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/apps/*/package.json",
@@ -107,6 +98,9 @@
       ],
       "inputs": [
         "$TURBO_DEFAULT$",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.tsx",
         "$TURBO_ROOT$/apps/app/dist/**",
         "$TURBO_ROOT$/apps/server/dist/**",
         "$TURBO_ROOT$/apps/host-daemon/dist/**",
@@ -126,30 +120,21 @@
         "!$TURBO_ROOT$/plugins/*/node_modules/**",
         "$TURBO_ROOT$/scripts/*.mjs"
       ],
-      "outputs": [
-        "app/**",
-        "dist/**",
-        "host-daemon/**",
-        "server/**"
-      ]
+      "outputs": ["app/**", "dist/**", "host-daemon/**", "server/**"]
     },
     "bb-plugin-tasks#build": {
       // The tasks plugin's app bundle imports the @get-bb/plugin-sdk root at
       // runtime (shared RPC contract), so the SDK dist must exist first.
-      "dependsOn": [
-        "topo",
-        "@get-bb/plugin-sdk#build"
-      ]
+      "dependsOn": ["topo", "@get-bb/plugin-sdk#build"]
     },
     "@bb/desktop#build": {
-      "dependsOn": [
-        "bb-app#build"
-      ],
-      "env": [
-        "BB_DESKTOP_RELEASE_CHANNEL"
-      ],
+      "dependsOn": ["bb-app#build"],
+      "env": ["BB_DESKTOP_RELEASE_CHANNEL"],
       "inputs": [
         "$TURBO_DEFAULT$",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.tsx",
         "$TURBO_ROOT$/apps/desktop/**",
         "$TURBO_ROOT$/packages/bb-app/app/**",
         "$TURBO_ROOT$/packages/bb-app/dist/**",
@@ -160,62 +145,36 @@
         "$TURBO_ROOT$/pnpm-workspace.yaml",
         "$TURBO_ROOT$/turbo.json"
       ],
-      "outputs": [
-        "dist/**"
-      ]
+      "outputs": ["dist/**"]
     },
     "@bb/desktop#desktop:build": {
-      "dependsOn": [
-        "bb-app#build",
-        "@bb/desktop#build"
-      ],
+      "dependsOn": ["bb-app#build", "@bb/desktop#build"],
       "cache": false,
-      "outputs": [
-        "release/**"
-      ],
-      "passThroughEnv": [
-        "*"
-      ]
+      "outputs": ["release/**"],
+      "passThroughEnv": ["*"]
     },
     "@bb/desktop#desktop:build:linux": {
-      "dependsOn": [
-        "bb-app#build",
-        "@bb/desktop#build"
-      ],
+      "dependsOn": ["bb-app#build", "@bb/desktop#build"],
       "cache": false,
-      "outputs": [
-        "release/**"
-      ],
-      "passThroughEnv": [
-        "*"
-      ]
+      "outputs": ["release/**"],
+      "passThroughEnv": ["*"]
     },
     "@bb/desktop#smoke:packaged": {
       "cache": false,
       "outputs": [],
-      "passThroughEnv": [
-        "*"
-      ]
+      "passThroughEnv": ["*"]
     },
     "@bb/desktop#dev": {
-      "dependsOn": [
-        "bb-app#build"
-      ],
+      "dependsOn": ["bb-app#build"],
       "cache": false,
       "persistent": true,
-      "passThroughEnv": [
-        "*"
-      ]
+      "passThroughEnv": ["*"]
     },
     "@bb/desktop#start": {
-      "dependsOn": [
-        "bb-app#build"
-      ],
+      "dependsOn": ["bb-app#build"],
       "cache": false,
       "persistent": true,
-      "passThroughEnv": [
-        "*"
-      ]
+      "passThroughEnv": ["*"]
     },
     "bundle": {
       "cache": false,
@@ -228,57 +187,39 @@
     "@bb/app#dev": {
       "cache": false,
       "persistent": true,
-      "passThroughEnv": [
-        "*"
-      ]
+      "passThroughEnv": ["*"]
     },
     "storybook": {
       "cache": false,
       "persistent": true,
-      "passThroughEnv": [
-        "*"
-      ]
+      "passThroughEnv": ["*"]
     },
     "@bb/host-daemon#dev": {
       "cache": false,
       "persistent": true,
-      "passThroughEnv": [
-        "*"
-      ]
+      "passThroughEnv": ["*"]
     },
     "@bb/server#dev": {
       // The server installs first-party provider plugins during startup and
       // builds their host artifacts. Those builds resolve the published
       // `@get-bb/plugin-sdk/provider-bridge` entry from the SDK dist, so a
       // clean worktree must build that runtime before the server starts.
-      "dependsOn": [
-        "@get-bb/plugin-sdk#build:runtime"
-      ],
+      "dependsOn": ["@get-bb/plugin-sdk#build:runtime"],
       "cache": false,
       "persistent": true,
-      "passThroughEnv": [
-        "*"
-      ]
+      "passThroughEnv": ["*"]
     },
     "@bb/host-daemon#start:prod": {
-      "dependsOn": [
-        "build"
-      ],
+      "dependsOn": ["build"],
       "cache": false,
       "persistent": true,
-      "passThroughEnv": [
-        "*"
-      ]
+      "passThroughEnv": ["*"]
     },
     "@bb/server#start:prod": {
-      "dependsOn": [
-        "build"
-      ],
+      "dependsOn": ["build"],
       "cache": false,
       "persistent": true,
-      "passThroughEnv": [
-        "*"
-      ]
+      "passThroughEnv": ["*"]
     },
     "clean": {
       "cache": false
@@ -308,28 +249,32 @@
     // dependency packages. Without it, a change in e.g. packages/domain
     // would cache-hit @bb/server#test/#typecheck and skip them stale.
     "topo": {
-      "dependsOn": [
-        "^topo"
+      "dependsOn": ["^topo"],
+      // Test files are excluded for the same reason the build tasks exclude
+      // them: nothing downstream of a package consumes its tests. Without this
+      // the exclusion in the build tasks does nothing, because `build` depends
+      // on `topo` and `topo` would hash every file in the package — so editing
+      // one test rebuilt the app bundle, the bb-app tarball and both smoke
+      // legs. A package's own tests still reach its own `test` task, which
+      // hashes them through `$TURBO_DEFAULT$`.
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.tsx"
       ]
     },
     "typecheck": {
-      "dependsOn": [
-        "topo"
-      ]
+      "dependsOn": ["topo"]
     },
     "@bb/templates#typecheck": {
       // Templates embed the plugin SDK's generated declarations by file path.
       // Keep the check from racing the SDK build without adding a package edge,
       // which would create a dependency cycle through @bb/sdk.
-      "dependsOn": [
-        "@get-bb/plugin-sdk#build",
-        "topo"
-      ]
+      "dependsOn": ["@get-bb/plugin-sdk#build", "topo"]
     },
     "@bb/integration-tests#typecheck": {
-      "dependsOn": [
-        "topo"
-      ],
+      "dependsOn": ["topo"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/apps/server/package.json",
@@ -342,14 +287,8 @@
       ]
     },
     "test": {
-      "dependsOn": [
-        "//#ensure-native-modules",
-        "topo"
-      ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/vitest.shared.ts"
-      ]
+      "dependsOn": ["//#ensure-native-modules", "topo"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/vitest.shared.ts"]
     },
     "@bb/templates#test": {
       "dependsOn": [
@@ -357,10 +296,7 @@
         "@get-bb/plugin-sdk#build",
         "topo"
       ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/vitest.shared.ts"
-      ]
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/vitest.shared.ts"]
     },
     // Installs first-party provider plugins, which makes the plugin runtime
     // build their host artifacts. esbuild resolves the plugin sources'
@@ -374,10 +310,7 @@
         "@get-bb/plugin-sdk#build",
         "topo"
       ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/vitest.shared.ts"
-      ]
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/vitest.shared.ts"]
     },
     // Builds real plugin host artifacts (the builtin artifacts suite, plus the
     // fixture that pins the published bridge surface as bundled-not-stubbed),
@@ -388,10 +321,7 @@
         "@get-bb/plugin-sdk#build",
         "topo"
       ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/vitest.shared.ts"
-      ]
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/vitest.shared.ts"]
     },
     // The live-CLI suite's global setup rebuilds every first-party provider
     // bridge from source, so it needs the SDK dist too.
@@ -401,15 +331,10 @@
         "@get-bb/plugin-sdk#build",
         "topo"
       ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/vitest.shared.ts"
-      ]
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/vitest.shared.ts"]
     },
     "smoke:tarball": {
-      "dependsOn": [
-        "build"
-      ],
+      "dependsOn": ["build"],
       "cache": false,
       "outputs": []
     },
@@ -434,14 +359,8 @@
       ]
     },
     "test:smoke": {
-      "dependsOn": [
-        "//#ensure-native-modules",
-        "topo"
-      ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/vitest.shared.ts"
-      ]
+      "dependsOn": ["//#ensure-native-modules", "topo"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/vitest.shared.ts"]
     },
     "@bb/integration-tests#test:smoke": {
       "dependsOn": [
@@ -461,14 +380,8 @@
       ]
     },
     "test:integration": {
-      "dependsOn": [
-        "//#ensure-native-modules",
-        "topo"
-      ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/vitest.shared.ts"
-      ]
+      "dependsOn": ["//#ensure-native-modules", "topo"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/vitest.shared.ts"]
     },
     "@bb/integration-tests#test:integration": {
       "dependsOn": [
@@ -491,30 +404,29 @@
     "@get-bb/plugin-sdk#build": {
       "inputs": [
         "$TURBO_DEFAULT$",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.tsx",
         "$TURBO_ROOT$/packages/*/package.json",
         "$TURBO_ROOT$/packages/*/src/**",
         "$TURBO_ROOT$/packages/plugin-sdk/scripts/**"
       ],
-      "outputs": [
-        "bundled-types/**",
-        "dist/**"
-      ]
+      "outputs": ["bundled-types/**", "dist/**"]
     },
     "@get-bb/plugin-sdk#build:runtime": {
       "inputs": [
         "$TURBO_DEFAULT$",
+        "!**/*.test.ts",
+        "!**/*.test.tsx",
+        "!**/*.stories.tsx",
         "$TURBO_ROOT$/packages/*/package.json",
         "$TURBO_ROOT$/packages/*/src/**",
         "$TURBO_ROOT$/packages/plugin-sdk/scripts/build-runtime.mjs"
       ],
-      "outputs": [
-        "dist/**"
-      ]
+      "outputs": ["dist/**"]
     },
     "@bb/plugin-build#typecheck": {
-      "dependsOn": [
-        "topo"
-      ],
+      "dependsOn": ["topo"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/apps/app/src/components/ui/theme.css",
@@ -522,23 +434,12 @@
       ]
     },
     "@bb/plugin-registry#typecheck": {
-      "dependsOn": [
-        "topo"
-      ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/packages/shared-ui/src/**"
-      ]
+      "dependsOn": ["topo"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/shared-ui/src/**"]
     },
     "@bb/plugin-registry#test": {
-      "dependsOn": [
-        "//#ensure-native-modules",
-        "topo"
-      ],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/packages/shared-ui/src/**"
-      ]
+      "dependsOn": ["//#ensure-native-modules", "topo"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/shared-ui/src/**"]
     }
   }
 }


### PR DESCRIPTION
## What was wrong

Editing a single test file changed `@bb/app#build`'s hash:

```
@bb/app#build hash before: 2f3b21fa725a19d5
@bb/app#build hash after:  a9960eb5d4ff1c3c   # after appending a comment to one .test.ts
```

Through that it also invalidated `bb-app#build`, `smoke:tarball` on **both** platforms, and the build step of the `checks` job. Test files are never bundled, so none of that work was needed — and since nearly every pull request touches a test, nearly every pull request paid for it.

This is the shared cost sitting underneath the whole 129-166s cluster of jobs, not a problem with any one of them.

## How it was found

I went looking for why the macOS package-smoke leg was slow. It turned out not to be the interesting question — at 166s it is only ~29s above the next job, so the critical path is a cluster (Linux smoke 137s, server tests 134s, checks 134s, packages 129s) rather than a spike, and deleting the macOS job outright would save ~29s.

What was interesting is that **both** smoke legs reported `0 cached, 8 total` on a pull request that changed only test files, and their task hashes are nearly identical across platforms:

```
macOS: c8f32b5a 846dd18c 13a26d7a 65d081b8 9c41c7f2 ...
Linux: c8f32b5a 846dd18c 13a26d7a 65d081b8 9c41c7f2 ...
```

Six of eight match, which rules out a platform-specific cause and points at a shared input.

## What changed

`turbo.json` only. `!**/*.test.ts`, `!**/*.test.tsx` and `!**/*.stories.tsx` added to the build tasks — and to `topo`.

**The `topo` half is the load-bearing one, and this is worth knowing before anyone tries the obvious version of this fix.** Excluding tests from the build tasks alone does nothing. Those tasks then genuinely hash zero test files (I verified: 799 hashed inputs, 0 matching `*.test.*`) and the hash *still* moves, because `build` depends on `topo`, `topo` declared no `inputs`, and so it fell back to every file in the package and carried the test file in through the dependency edge. Both exclusions are required together, which is why the comment lives on `topo`.

`topo` is a transit node that exists to propagate dependency *sources* to tasks resolving `@bb/*` through the `source` export condition. Nothing downstream of a package consumes that package's tests, so dropping them there removes only cross-package invalidation that should not exist in the first place. A package's own tests still reach its own `test` and `typecheck` tasks, which hash them through `$TURBO_DEFAULT$`.

## How you verified

Both directions, because the dangerous failure here is under-invalidation, not over-invalidation:

```
                   @bb/app#build     bb-app#build
clean:             9b4206b734737179  37c570b4067f4901
after TEST edit:   9b4206b734737179  37c570b4067f4901  <= unchanged (the win)
after SOURCE edit: 917cf94b66e62681  30c092750deaabef  <= changed (still correct)
```

The third row is the one that matters. An over-broad exclusion would make CI silently skip work it needs to do, which is far worse than being slow.

Also confirmed:

- No production module imports a `.test` or `.stories` file, so nothing that ships depends on the excluded inputs.
- `turbo run build typecheck` passes for `@bb/app`, `bb-app` and `@bb/server`.
- `typecheck` still hashes test files. My first patch matched `@bb/plugin-build#typecheck` on the substring "build" and wrongly excluded them there; that is reverted and asserted against.

## Expected effect

Any pull request that does not touch production source should now get build cache hits instead of rebuilding, which removes the build portion of `checks`, both `package-smoke` legs, and the build dependencies of the test shards. I have deliberately not put a number on it — this pull request's own CI run is the measurement, and it touches no test files, so the *next* test-only pull request is where the benefit will actually show.

> AGENT GENERATED: by Claude Opus 5