### PR TITLE
Route agent source pills through sender projects

### DIFF
--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
@@ -96,6 +96,8 @@ export interface ConversationMessageContentUserProps extends ConversationMessage
   onOpenLink?: ThreadTimelineLinkHandler;
   onTitleAction?: TimelineTitleActionResolver;
   senderThreadId: TimelineUserConversationRow["senderThreadId"];
+  /** Present when sender metadata identifies the source thread's project. */
+  senderThreadProjectId?: string;
   senderThreadTitle: string | null;
   /** The sender thread is one of the side-chat plugin's hidden forks, so the
    * row reads "Replying to side chat" and its name opens the plugin panel. */
@@ -200,6 +202,7 @@ interface UserConversationMessageProps {
   resolveSegmentLinkHref?: TimelineTitleLinkResolver;
   onTitleAction?: TimelineTitleActionResolver;
   senderThreadId: TimelineUserConversationRow["senderThreadId"];
+  senderThreadProjectId: string | null;
   senderThreadTitle: string | null;
   senderIsPluginSideChat: boolean;
   systemMessageKind: TimelineUserConversationRow["systemMessageKind"];
@@ -399,6 +402,7 @@ function UserConversationMessage({
   resolveSegmentLinkHref,
   onTitleAction,
   senderThreadId,
+  senderThreadProjectId,
   senderThreadTitle,
   senderIsPluginSideChat,
   systemMessageKind,
@@ -428,6 +432,7 @@ function UserConversationMessage({
         sourceName={
           senderIsPluginSideChat ? "side chat" : (senderThreadTitle ?? "Agent")
         }
+        sourceProjectId={senderThreadProjectId}
         sourceThreadId={senderThreadId}
         sourceIsPluginSideChat={senderIsPluginSideChat}
         systemMessageKind={systemMessageKind}
@@ -458,6 +463,7 @@ function UserConversationMessage({
         onTitleAction={onTitleAction}
         sourceKind="system"
         sourceName="BB"
+        sourceProjectId={null}
         sourceThreadId={null}
         sourceIsPluginSideChat={false}
         systemMessageKind={systemMessageKind}
@@ -726,6 +732,7 @@ export function ConversationMessageContent(
         resolveSegmentLinkHref={props.resolveSegmentLinkHref}
         onTitleAction={props.onTitleAction}
         senderThreadId={props.senderThreadId}
+        senderThreadProjectId={props.senderThreadProjectId ?? null}
         senderThreadTitle={props.senderThreadTitle}
         senderIsPluginSideChat={props.senderIsPluginSideChat}
         systemMessageKind={props.systemMessageKind}

--- a/apps/app/src/components/thread/timeline/GeneratedConversationMessage.test.tsx
+++ b/apps/app/src/components/thread/timeline/GeneratedConversationMessage.test.tsx
@@ -354,7 +354,11 @@ describe("GeneratedConversationMessage markdown body", () => {
 
     expect(
       (
-        await screen.findByRole("link", { name: "Archived sender" })
+        await screen.findByRole(
+          "link",
+          { name: "Archived sender" },
+          { timeout: 10_000 },
+        )
       ).getAttribute("href"),
     ).toBe("/threads/thr_agent");
     expect(getThread).toHaveBeenCalledTimes(2);

--- a/apps/app/src/components/thread/timeline/GeneratedConversationMessage.test.tsx
+++ b/apps/app/src/components/thread/timeline/GeneratedConversationMessage.test.tsx
@@ -6,17 +6,11 @@ import {
   fireEvent,
   render,
   screen,
-  waitFor,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
-import {
-  PERSONAL_PROJECT_ID,
-  type PromptTextMention,
-  type ThreadListEntry,
-} from "@bb/domain";
+import type { PromptTextMention, ThreadListEntry } from "@bb/domain";
 import type { TimelineTitleLink } from "@bb/thread-view";
-import type { ThreadResponse } from "@bb/server-contract";
 import { ConversationMessageContent } from "./ConversationMessageContent";
 import { ThreadTitleMentionResourcesProvider } from "@/components/thread/ThreadTitleMentions";
 import { RouteNavigationProvider } from "@/components/ui/app-route-anchor";
@@ -24,7 +18,6 @@ import type { TimelineTitleActionResolver } from "./TimelineTitleView";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { GENERATED_MESSAGE_COLLAPSED_PREVIEW_CHAR_CAP } from "./conversation-message-limits";
 import { generatedConversationCollapsedPreview } from "./GeneratedConversationMessage";
-import { sdk } from "@/lib/sdk";
 
 function resolveThreadLink(link: TimelineTitleLink): string | null {
   return link.kind === "thread"
@@ -149,45 +142,10 @@ function threadListEntry(
   };
 }
 
-function threadResponse(
-  overrides: Partial<ThreadResponse> = {},
-): ThreadResponse {
-  return {
-    id: "thr_agent",
-    projectId: PERSONAL_PROJECT_ID,
-    environmentId: null,
-    providerId: "codex",
-    title: "Archived sender",
-    titleFallback: "Archived sender",
-    sectionId: null,
-    status: "idle",
-    parentThreadId: null,
-    sourceThreadId: null,
-    originKind: null,
-    originPluginId: null,
-    visibility: "visible",
-    archivedAt: 1,
-    pinnedAt: null,
-    deletedAt: null,
-    lastReadAt: 0,
-    latestAttentionAt: 1,
-    createdAt: 1,
-    updatedAt: 1,
-    runtime: {
-      displayStatus: "idle",
-      hostReconnectGraceExpiresAt: null,
-    },
-    activeBackgroundAgentCount: 0,
-    canSpawnChild: true,
-    ...overrides,
-  };
-}
-
 function renderAgentMessage(
   text = AGENT_BODY,
   {
     senderIsPluginSideChat = false,
-    senderThreadProjectId = "proj_demo",
     senderThreadTitle = "Worker",
     onTitleAction,
     mentions: suppliedMentions,
@@ -195,7 +153,6 @@ function renderAgentMessage(
     mentions?: readonly PromptTextMention[];
     onTitleAction?: TimelineTitleActionResolver;
     senderIsPluginSideChat?: boolean;
-    senderThreadProjectId?: string | null;
     senderThreadTitle?: string;
   } = {},
 ) {
@@ -238,7 +195,6 @@ function renderAgentMessage(
             initiator="agent"
             originKind={null}
             senderThreadId="thr_agent"
-            senderThreadProjectId={senderThreadProjectId ?? undefined}
             senderThreadTitle={senderThreadTitle}
             senderIsPluginSideChat={senderIsPluginSideChat}
             onTitleAction={onTitleAction}
@@ -307,52 +263,6 @@ function mockContinuationSensitiveOverflow(): () => void {
 }
 
 describe("GeneratedConversationMessage markdown body", () => {
-  it("routes the source pill through the sender thread's project", () => {
-    const { container } = renderAgentMessage(AGENT_BODY, {
-      senderThreadProjectId: PERSONAL_PROJECT_ID,
-    });
-
-    expect(
-      container
-        .querySelector(
-          '[data-prompt-mention-serialized-text="@thread:thr_agent"]',
-        )
-        ?.getAttribute("href"),
-    ).toBe("/threads/thr_agent");
-  });
-
-  it("retries an uncached source lookup before making the pill interactive", async () => {
-    const getThread = vi
-      .spyOn(sdk.threads, "get")
-      .mockRejectedValueOnce(new Error("Failed to fetch"))
-      .mockResolvedValueOnce(threadResponse());
-    const { container } = renderAgentMessage(AGENT_BODY, {
-      senderThreadProjectId: null,
-      senderThreadTitle: "Agent",
-    });
-
-    await waitFor(() => expect(getThread).toHaveBeenCalledTimes(1));
-    const pendingSourcePill = container.querySelector(
-      '[data-prompt-mention-serialized-text="@thread:thr_agent"]',
-    );
-    expect(pendingSourcePill?.tagName).toBe("SPAN");
-    expect(pendingSourcePill?.getAttribute("href")).toBeNull();
-
-    expect(
-      (
-        await screen.findByRole(
-          "link",
-          { name: "Archived sender" },
-          { timeout: 10_000 },
-        )
-      ).getAttribute("href"),
-    ).toBe("/threads/thr_agent");
-    expect(getThread).toHaveBeenCalledTimes(2);
-    expect(getThread).toHaveBeenCalledWith(
-      expect.objectContaining({ threadId: "thr_agent" }),
-    );
-  });
-
   it("renders the source as a thread pill with title mentions resolved to display text", () => {
     const { container } = renderAgentMessage(AGENT_BODY, {
       senderThreadTitle:

--- a/apps/app/src/components/thread/timeline/GeneratedConversationMessage.test.tsx
+++ b/apps/app/src/components/thread/timeline/GeneratedConversationMessage.test.tsx
@@ -6,11 +6,17 @@ import {
   fireEvent,
   render,
   screen,
+  waitFor,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
-import type { PromptTextMention, ThreadListEntry } from "@bb/domain";
+import {
+  PERSONAL_PROJECT_ID,
+  type PromptTextMention,
+  type ThreadListEntry,
+} from "@bb/domain";
 import type { TimelineTitleLink } from "@bb/thread-view";
+import type { ThreadResponse } from "@bb/server-contract";
 import { ConversationMessageContent } from "./ConversationMessageContent";
 import { ThreadTitleMentionResourcesProvider } from "@/components/thread/ThreadTitleMentions";
 import { RouteNavigationProvider } from "@/components/ui/app-route-anchor";
@@ -18,6 +24,7 @@ import type { TimelineTitleActionResolver } from "./TimelineTitleView";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { GENERATED_MESSAGE_COLLAPSED_PREVIEW_CHAR_CAP } from "./conversation-message-limits";
 import { generatedConversationCollapsedPreview } from "./GeneratedConversationMessage";
+import { sdk } from "@/lib/sdk";
 
 function resolveThreadLink(link: TimelineTitleLink): string | null {
   return link.kind === "thread"
@@ -142,10 +149,45 @@ function threadListEntry(
   };
 }
 
+function threadResponse(
+  overrides: Partial<ThreadResponse> = {},
+): ThreadResponse {
+  return {
+    id: "thr_agent",
+    projectId: PERSONAL_PROJECT_ID,
+    environmentId: null,
+    providerId: "codex",
+    title: "Archived sender",
+    titleFallback: "Archived sender",
+    sectionId: null,
+    status: "idle",
+    parentThreadId: null,
+    sourceThreadId: null,
+    originKind: null,
+    originPluginId: null,
+    visibility: "visible",
+    archivedAt: 1,
+    pinnedAt: null,
+    deletedAt: null,
+    lastReadAt: 0,
+    latestAttentionAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    runtime: {
+      displayStatus: "idle",
+      hostReconnectGraceExpiresAt: null,
+    },
+    activeBackgroundAgentCount: 0,
+    canSpawnChild: true,
+    ...overrides,
+  };
+}
+
 function renderAgentMessage(
   text = AGENT_BODY,
   {
     senderIsPluginSideChat = false,
+    senderThreadProjectId = "proj_demo",
     senderThreadTitle = "Worker",
     onTitleAction,
     mentions: suppliedMentions,
@@ -153,6 +195,7 @@ function renderAgentMessage(
     mentions?: readonly PromptTextMention[];
     onTitleAction?: TimelineTitleActionResolver;
     senderIsPluginSideChat?: boolean;
+    senderThreadProjectId?: string | null;
     senderThreadTitle?: string;
   } = {},
 ) {
@@ -180,6 +223,15 @@ function renderAgentMessage(
     title: "Raw agent mention target",
     titleFallback: "Raw agent mention target",
   });
+  const senderThreadTarget =
+    senderThreadProjectId === null
+      ? null
+      : threadListEntry({
+          id: "thr_agent",
+          projectId: senderThreadProjectId,
+          title: senderThreadTitle,
+          titleFallback: senderThreadTitle,
+        });
   const { wrapper } = createQueryClientTestHarness();
 
   return render(
@@ -188,7 +240,13 @@ function renderAgentMessage(
         <ThreadTitleMentionResourcesProvider
           sectionNamesById={new Map()}
           projectNamesById={new Map()}
-          threadById={new Map([[rawMentionTarget.id, rawMentionTarget]])}
+          threadById={
+            new Map(
+              [rawMentionTarget, senderThreadTarget]
+                .filter((thread) => thread !== null)
+                .map((thread) => [thread.id, thread]),
+            )
+          }
         >
           <ConversationMessageContent
             role="user"
@@ -263,6 +321,48 @@ function mockContinuationSensitiveOverflow(): () => void {
 }
 
 describe("GeneratedConversationMessage markdown body", () => {
+  it("routes the source pill through the sender thread's project", () => {
+    const { container } = renderAgentMessage(AGENT_BODY, {
+      senderThreadProjectId: PERSONAL_PROJECT_ID,
+    });
+
+    expect(
+      container
+        .querySelector(
+          '[data-prompt-mention-serialized-text="@thread:thr_agent"]',
+        )
+        ?.getAttribute("href"),
+    ).toBe("/threads/thr_agent");
+  });
+
+  it("retries an uncached source lookup before making the pill interactive", async () => {
+    const getThread = vi
+      .spyOn(sdk.threads, "get")
+      .mockRejectedValueOnce(new Error("Failed to fetch"))
+      .mockResolvedValueOnce(threadResponse());
+    const { container } = renderAgentMessage(AGENT_BODY, {
+      senderThreadProjectId: null,
+      senderThreadTitle: "Agent",
+    });
+
+    await waitFor(() => expect(getThread).toHaveBeenCalledTimes(1));
+    const pendingSourcePill = container.querySelector(
+      '[data-prompt-mention-serialized-text="@thread:thr_agent"]',
+    );
+    expect(pendingSourcePill?.tagName).toBe("SPAN");
+    expect(pendingSourcePill?.getAttribute("href")).toBeNull();
+
+    expect(
+      (
+        await screen.findByRole("link", { name: "Archived sender" })
+      ).getAttribute("href"),
+    ).toBe("/threads/thr_agent");
+    expect(getThread).toHaveBeenCalledTimes(2);
+    expect(getThread).toHaveBeenCalledWith(
+      expect.objectContaining({ threadId: "thr_agent" }),
+    );
+  });
+
   it("renders the source as a thread pill with title mentions resolved to display text", () => {
     const { container } = renderAgentMessage(AGENT_BODY, {
       senderThreadTitle:

--- a/apps/app/src/components/thread/timeline/GeneratedConversationMessage.test.tsx
+++ b/apps/app/src/components/thread/timeline/GeneratedConversationMessage.test.tsx
@@ -223,15 +223,6 @@ function renderAgentMessage(
     title: "Raw agent mention target",
     titleFallback: "Raw agent mention target",
   });
-  const senderThreadTarget =
-    senderThreadProjectId === null
-      ? null
-      : threadListEntry({
-          id: "thr_agent",
-          projectId: senderThreadProjectId,
-          title: senderThreadTitle,
-          titleFallback: senderThreadTitle,
-        });
   const { wrapper } = createQueryClientTestHarness();
 
   return render(
@@ -240,13 +231,7 @@ function renderAgentMessage(
         <ThreadTitleMentionResourcesProvider
           sectionNamesById={new Map()}
           projectNamesById={new Map()}
-          threadById={
-            new Map(
-              [rawMentionTarget, senderThreadTarget]
-                .filter((thread) => thread !== null)
-                .map((thread) => [thread.id, thread]),
-            )
-          }
+          threadById={new Map([[rawMentionTarget.id, rawMentionTarget]])}
         >
           <ConversationMessageContent
             role="user"

--- a/apps/app/src/components/thread/timeline/GeneratedConversationMessage.test.tsx
+++ b/apps/app/src/components/thread/timeline/GeneratedConversationMessage.test.tsx
@@ -253,6 +253,7 @@ function renderAgentMessage(
             initiator="agent"
             originKind={null}
             senderThreadId="thr_agent"
+            senderThreadProjectId={senderThreadProjectId ?? undefined}
             senderThreadTitle={senderThreadTitle}
             senderIsPluginSideChat={senderIsPluginSideChat}
             onTitleAction={onTitleAction}

--- a/apps/app/src/components/thread/timeline/GeneratedConversationMessage.tsx
+++ b/apps/app/src/components/thread/timeline/GeneratedConversationMessage.tsx
@@ -67,6 +67,7 @@ interface GeneratedConversationMessageProps {
   // ignored by the source-kind switch — so the props stay non-optional.
   sourceKind: GeneratedConversationSourceKind;
   sourceName: string;
+  sourceProjectId: string | null;
   sourceThreadId: string | null;
   /** The source is a side-chat plugin hidden fork: its name carries no route
    * link because its title action opens the plugin's panel tab instead. */
@@ -379,6 +380,7 @@ interface GeneratedAgentSourceTitleProps {
   onTitleAction?: TimelineTitleActionResolver;
   sourceIsPluginSideChat: boolean;
   sourceName: string;
+  sourceProjectId: string | null;
   sourceThreadId: string | null;
   title: TimelineTitle;
 }
@@ -463,6 +465,19 @@ function GeneratedAgentSourceTitle(props: GeneratedAgentSourceTitleProps) {
       <GeneratedAgentSourceTitleContent {...props} sourceResource={null} />
     );
   }
+  if (props.sourceProjectId !== null) {
+    return (
+      <GeneratedAgentSourceTitleContent
+        {...props}
+        sourceResource={{
+          kind: "thread",
+          threadId: props.sourceThreadId,
+          projectId: props.sourceProjectId,
+          label: props.sourceName,
+        }}
+      />
+    );
+  }
   return (
     <ResolvedGeneratedAgentSourceTitle
       {...props}
@@ -514,6 +529,7 @@ export const GeneratedConversationMessage = memo(
     onTitleAction,
     sourceKind,
     sourceName,
+    sourceProjectId,
     sourceThreadId,
     sourceIsPluginSideChat,
     systemMessageKind,
@@ -563,6 +579,7 @@ export const GeneratedConversationMessage = memo(
           onTitleAction={onTitleAction}
           sourceIsPluginSideChat={sourceIsPluginSideChat}
           sourceName={sourceName}
+          sourceProjectId={sourceProjectId}
           sourceThreadId={sourceThreadId}
           title={title}
         />

--- a/apps/app/src/components/thread/timeline/GeneratedConversationMessage.tsx
+++ b/apps/app/src/components/thread/timeline/GeneratedConversationMessage.tsx
@@ -1,7 +1,6 @@
 import { memo, useCallback, useMemo, useRef } from "react";
 import type { TimelineUserConversationRow } from "@bb/server-contract";
 import type {
-  PromptMentionResource,
   PromptTextMention,
   SystemMessageKind,
   SystemMessageSubject,
@@ -37,7 +36,6 @@ import { TurnRequestLabel } from "./TurnRequestLabel.js";
 import { useOverflowMeasurement } from "./conversation-message-overflow.js";
 import { PromptMentionPill } from "./ConversationMessageMentions.js";
 import { useThreadTitleDisplayText } from "@/components/thread/ThreadTitleMentions.js";
-import { useThreadMentionResource } from "@/components/thread/ThreadTitleMentions.js";
 import { getThreadRoutePath } from "@/lib/route-paths";
 import {
   boundedMarkdownPreview,
@@ -378,6 +376,7 @@ function generatedConversationIconName(
 
 interface GeneratedAgentSourceTitleProps {
   onTitleAction?: TimelineTitleActionResolver;
+  resolveSegmentLinkHref?: TimelineTitleLinkResolver;
   sourceIsPluginSideChat: boolean;
   sourceName: string;
   sourceProjectId: string | null;
@@ -385,34 +384,31 @@ interface GeneratedAgentSourceTitleProps {
   title: TimelineTitle;
 }
 
-interface GeneratedAgentSourceTitleContentProps extends GeneratedAgentSourceTitleProps {
-  sourceResource: PromptMentionResource | null;
-}
-
-function GeneratedAgentSourceTitleContent({
+function GeneratedAgentSourceTitle({
   onTitleAction,
+  resolveSegmentLinkHref,
   sourceIsPluginSideChat,
   sourceName,
-  sourceResource,
+  sourceProjectId,
   sourceThreadId,
   title,
-}: GeneratedAgentSourceTitleContentProps) {
-  const sourceDisplayName = useThreadTitleDisplayText(
-    sourceResource?.kind === "thread" ? sourceResource.label : sourceName,
-  );
+}: GeneratedAgentSourceTitleProps) {
+  const sourceDisplayName = useThreadTitleDisplayText(sourceName);
   const sourceTitleAction =
     title.action && onTitleAction ? onTitleAction(title.action) : null;
   // A side chat opens in the plugin's panel (a title action), so its name
   // carries no route link; other sources navigate to the source thread.
   const sourceLinkHref =
-    sourceThreadId !== null &&
-    !sourceIsPluginSideChat &&
-    sourceResource?.kind === "thread" &&
-    sourceResource.projectId
-      ? getThreadRoutePath({
-          projectId: sourceResource.projectId,
-          threadId: sourceThreadId,
-        })
+    sourceThreadId !== null && !sourceIsPluginSideChat
+      ? sourceProjectId !== null
+        ? getThreadRoutePath({
+            projectId: sourceProjectId,
+            threadId: sourceThreadId,
+          })
+        : (resolveSegmentLinkHref?.({
+            kind: "thread",
+            threadId: sourceThreadId,
+          }) ?? null)
       : null;
   const leadIn = title.segments[0]?.text ?? "Message from";
 
@@ -433,9 +429,7 @@ function GeneratedAgentSourceTitleContent({
           resource={{
             kind: "thread",
             threadId: sourceThreadId,
-            ...(sourceResource?.kind === "thread" && sourceResource.projectId
-              ? { projectId: sourceResource.projectId }
-              : {}),
+            ...(sourceProjectId === null ? {} : { projectId: sourceProjectId }),
             label: sourceDisplayName,
           }}
           serializedText={`@thread:${sourceThreadId}`}
@@ -444,45 +438,6 @@ function GeneratedAgentSourceTitleContent({
         />
       )}
     </span>
-  );
-}
-
-function ResolvedGeneratedAgentSourceTitle(
-  props: GeneratedAgentSourceTitleProps & { sourceThreadId: string },
-) {
-  const sourceResource = useThreadMentionResource(props.sourceThreadId);
-  return (
-    <GeneratedAgentSourceTitleContent
-      {...props}
-      sourceResource={sourceResource}
-    />
-  );
-}
-
-function GeneratedAgentSourceTitle(props: GeneratedAgentSourceTitleProps) {
-  if (props.sourceThreadId === null || props.sourceIsPluginSideChat) {
-    return (
-      <GeneratedAgentSourceTitleContent {...props} sourceResource={null} />
-    );
-  }
-  if (props.sourceProjectId !== null) {
-    return (
-      <GeneratedAgentSourceTitleContent
-        {...props}
-        sourceResource={{
-          kind: "thread",
-          threadId: props.sourceThreadId,
-          projectId: props.sourceProjectId,
-          label: props.sourceName,
-        }}
-      />
-    );
-  }
-  return (
-    <ResolvedGeneratedAgentSourceTitle
-      {...props}
-      sourceThreadId={props.sourceThreadId}
-    />
   );
 }
 
@@ -577,6 +532,7 @@ export const GeneratedConversationMessage = memo(
       sourceKind === "agent" ? (
         <GeneratedAgentSourceTitle
           onTitleAction={onTitleAction}
+          resolveSegmentLinkHref={resolveSegmentLinkHref}
           sourceIsPluginSideChat={sourceIsPluginSideChat}
           sourceName={sourceName}
           sourceProjectId={sourceProjectId}

--- a/apps/app/src/components/thread/timeline/GeneratedConversationMessage.tsx
+++ b/apps/app/src/components/thread/timeline/GeneratedConversationMessage.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useMemo, useRef } from "react";
 import type { TimelineUserConversationRow } from "@bb/server-contract";
 import type {
+  PromptMentionResource,
   PromptTextMention,
   SystemMessageKind,
   SystemMessageSubject,
@@ -36,6 +37,8 @@ import { TurnRequestLabel } from "./TurnRequestLabel.js";
 import { useOverflowMeasurement } from "./conversation-message-overflow.js";
 import { PromptMentionPill } from "./ConversationMessageMentions.js";
 import { useThreadTitleDisplayText } from "@/components/thread/ThreadTitleMentions.js";
+import { useThreadMentionResource } from "@/components/thread/ThreadTitleMentions.js";
+import { getThreadRoutePath } from "@/lib/route-paths";
 import {
   boundedMarkdownPreview,
   closeUnterminatedMarkdownCodeSpan,
@@ -374,29 +377,40 @@ function generatedConversationIconName(
 
 interface GeneratedAgentSourceTitleProps {
   onTitleAction?: TimelineTitleActionResolver;
-  resolveSegmentLinkHref?: TimelineTitleLinkResolver;
   sourceIsPluginSideChat: boolean;
   sourceName: string;
   sourceThreadId: string | null;
   title: TimelineTitle;
 }
 
-function GeneratedAgentSourceTitle({
+interface GeneratedAgentSourceTitleContentProps extends GeneratedAgentSourceTitleProps {
+  sourceResource: PromptMentionResource | null;
+}
+
+function GeneratedAgentSourceTitleContent({
   onTitleAction,
-  resolveSegmentLinkHref,
   sourceIsPluginSideChat,
   sourceName,
+  sourceResource,
   sourceThreadId,
   title,
-}: GeneratedAgentSourceTitleProps) {
-  const sourceDisplayName = useThreadTitleDisplayText(sourceName);
+}: GeneratedAgentSourceTitleContentProps) {
+  const sourceDisplayName = useThreadTitleDisplayText(
+    sourceResource?.kind === "thread" ? sourceResource.label : sourceName,
+  );
   const sourceTitleAction =
     title.action && onTitleAction ? onTitleAction(title.action) : null;
   // A side chat opens in the plugin's panel (a title action), so its name
   // carries no route link; other sources navigate to the source thread.
   const sourceLinkHref =
-    sourceThreadId !== null && !sourceIsPluginSideChat && resolveSegmentLinkHref
-      ? resolveSegmentLinkHref({ kind: "thread", threadId: sourceThreadId })
+    sourceThreadId !== null &&
+    !sourceIsPluginSideChat &&
+    sourceResource?.kind === "thread" &&
+    sourceResource.projectId
+      ? getThreadRoutePath({
+          projectId: sourceResource.projectId,
+          threadId: sourceThreadId,
+        })
       : null;
   const leadIn = title.segments[0]?.text ?? "Message from";
 
@@ -417,6 +431,9 @@ function GeneratedAgentSourceTitle({
           resource={{
             kind: "thread",
             threadId: sourceThreadId,
+            ...(sourceResource?.kind === "thread" && sourceResource.projectId
+              ? { projectId: sourceResource.projectId }
+              : {}),
             label: sourceDisplayName,
           }}
           serializedText={`@thread:${sourceThreadId}`}
@@ -425,6 +442,32 @@ function GeneratedAgentSourceTitle({
         />
       )}
     </span>
+  );
+}
+
+function ResolvedGeneratedAgentSourceTitle(
+  props: GeneratedAgentSourceTitleProps & { sourceThreadId: string },
+) {
+  const sourceResource = useThreadMentionResource(props.sourceThreadId);
+  return (
+    <GeneratedAgentSourceTitleContent
+      {...props}
+      sourceResource={sourceResource}
+    />
+  );
+}
+
+function GeneratedAgentSourceTitle(props: GeneratedAgentSourceTitleProps) {
+  if (props.sourceThreadId === null || props.sourceIsPluginSideChat) {
+    return (
+      <GeneratedAgentSourceTitleContent {...props} sourceResource={null} />
+    );
+  }
+  return (
+    <ResolvedGeneratedAgentSourceTitle
+      {...props}
+      sourceThreadId={props.sourceThreadId}
+    />
   );
 }
 
@@ -518,7 +561,6 @@ export const GeneratedConversationMessage = memo(
       sourceKind === "agent" ? (
         <GeneratedAgentSourceTitle
           onTitleAction={onTitleAction}
-          resolveSegmentLinkHref={resolveSegmentLinkHref}
           sourceIsPluginSideChat={sourceIsPluginSideChat}
           sourceName={sourceName}
           sourceThreadId={sourceThreadId}

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.render-stability.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.render-stability.test.tsx
@@ -5,6 +5,7 @@ import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, describe, expect, it } from "vitest";
+import { PERSONAL_PROJECT_ID } from "@bb/domain";
 import { threadsQueryKey } from "@/hooks/queries/query-keys";
 import { makeThreadListEntry } from "@/test/fixtures/thread-list-entries";
 import { conversationRow } from "@/test/fixtures/thread-timeline-rows";
@@ -71,6 +72,22 @@ afterEach(() => {
 });
 
 describe("ThreadTimelineRows render stability", () => {
+  it("routes a personal-project sender pill from sender metadata", () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(threadsQueryKey(), [
+      makeThreadListEntry({
+        id: "thr_sender",
+        projectId: PERSONAL_PROJECT_ID,
+        title: "Personal sender",
+      }),
+    ]);
+    const { view } = renderProfiledTimeline(queryClient);
+
+    expect(
+      view.getByRole("link", { name: "Personal sender" }).getAttribute("href"),
+    ).toBe("/threads/thr_sender");
+  });
+
   it("does not re-render the timeline when cache events carry equal thread metadata", async () => {
     const queryClient = new QueryClient();
     queryClient.setQueryData(threadsQueryKey(), [

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.render-stability.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.render-stability.test.tsx
@@ -4,12 +4,13 @@ import { Profiler, type ProfilerOnRenderCallback } from "react";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { PERSONAL_PROJECT_ID } from "@bb/domain";
 import { threadsQueryKey } from "@/hooks/queries/query-keys";
 import { makeThreadListEntry } from "@/test/fixtures/thread-list-entries";
 import { conversationRow } from "@/test/fixtures/thread-timeline-rows";
 import { ThreadTimelineRows } from "./ThreadTimelineRows";
+import { sdk } from "@/lib/sdk";
 
 // The query cache notifies through notifyManager's scheduler (a macrotask),
 // so cache writes only reach subscribers after a timer tick.
@@ -69,10 +70,12 @@ function renderProfiledTimeline(queryClient: QueryClient) {
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
 });
 
 describe("ThreadTimelineRows render stability", () => {
-  it("routes a personal-project sender pill from sender metadata", () => {
+  it("routes a personal-project sender pill directly from sender metadata", async () => {
+    const getThread = vi.spyOn(sdk.threads, "get");
     const queryClient = new QueryClient();
     queryClient.setQueryData(threadsQueryKey(), [
       makeThreadListEntry({
@@ -86,6 +89,8 @@ describe("ThreadTimelineRows render stability", () => {
     expect(
       view.getByRole("link", { name: "Personal sender" }).getAttribute("href"),
     ).toBe("/threads/thr_sender");
+    await flushCacheNotifications();
+    expect(getThread).not.toHaveBeenCalled();
   });
 
   it("does not re-render the timeline when cache events carry equal thread metadata", async () => {

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -1048,6 +1048,7 @@ function ConversationRow({
         resolveSegmentLinkHref={resolveSegmentLinkHref}
         onTitleAction={onTitleAction}
         senderThreadId={row.senderThreadId}
+        senderThreadProjectId={senderThreadMetadata?.projectId}
         senderThreadTitle={senderThreadMetadata?.title ?? null}
         senderIsPluginSideChat={isPluginSideChatSenderThread(
           senderThreadMetadata,

--- a/apps/app/src/hooks/useSenderThreadMetadataById.test.tsx
+++ b/apps/app/src/hooks/useSenderThreadMetadataById.test.tsx
@@ -36,6 +36,7 @@ describe("useSenderThreadMetadataById", () => {
     const { result } = renderMetadataHook(queryClient);
     const initial = result.current;
     expect(initial.get("thr_sender")?.title).toBe("Sender thread");
+    expect(initial.get("thr_sender")?.projectId).toBe("proj_test");
 
     // A fresh array with equal entries fires an "updated" cache event; the
     // rebuilt map is value-equal, so the hook must keep the old reference or

--- a/apps/app/src/hooks/useSenderThreadMetadataById.ts
+++ b/apps/app/src/hooks/useSenderThreadMetadataById.ts
@@ -24,6 +24,7 @@ import {
 } from "@/hooks/cache-owners/thread-list-cache-data";
 
 export interface SenderThreadMetadata {
+  projectId: string;
   title: string | null;
   originKind: ThreadOriginKind | null;
   originPluginId: string | null;
@@ -37,6 +38,7 @@ interface SenderThreadTitleSource {
 
 interface SenderThreadMetadataSource extends SenderThreadTitleSource {
   id: string;
+  projectId: string;
   originKind: ThreadOriginKind | null;
   originPluginId: string | null;
   visibility: ThreadVisibility;
@@ -61,6 +63,7 @@ function addSenderThreadMetadata(
     return;
   }
   metadataById.set(thread.id, {
+    projectId: thread.projectId,
     title,
     originKind: thread.originKind,
     originPluginId: thread.originPluginId,
@@ -120,6 +123,7 @@ function areSenderThreadMetadataEntriesEqual(
   right: SenderThreadMetadata,
 ): boolean {
   return (
+    left.projectId === right.projectId &&
     left.title === right.title &&
     left.originKind === right.originKind &&
     left.originPluginId === right.originPluginId &&

--- a/apps/app/src/lib/side-chat-plugin.test.ts
+++ b/apps/app/src/lib/side-chat-plugin.test.ts
@@ -7,6 +7,7 @@ import {
 
 describe("isPluginSideChatSenderThread", () => {
   const pluginFork: SenderThreadMetadata = {
+    projectId: "proj_test",
     title: null,
     originKind: "fork",
     originPluginId: SIDE_CHAT_PLUGIN_ID,


### PR DESCRIPTION
## What was wrong

Agent-message source pills reused the receiving timeline's project-scoped route resolver. When the sender lived in another project, bb placed the sender thread ID under the receiver's project route, so the destination rendered `Not found`; Personal senders were affected because their canonical route is `/threads/:id`.

## What changed

- Carry `projectId` through the existing cached sender-thread metadata and build source-pill routes from the sender's project.
- Preserve the existing route-resolver fallback when sender project metadata is unavailable.
- Add a regression for a Personal-project sender routed from a standard-project timeline.

## How you verified

- Regression proof: the cross-project test failed before the fix with `/projects/proj_recipient/threads/thr_sender` instead of `/threads/thr_sender`.
- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/thread/timeline/GeneratedConversationMessage.test.tsx src/components/thread/timeline/ThreadTimelineRows.render-stability.test.tsx src/hooks/useSenderThreadMetadataById.test.tsx src/lib/side-chat-plugin.test.ts` — 27 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.
- Exact final-head dev-app QA: five Personal sender-pill navigations per viewport landed on `/threads/thr_g49hje39bp` without `Not found` at 390×844, 768×900, 1440×900, and 3440×1440.

## Before / after

| Before: dev app at merge base after clicking the Personal sender pill | After: dev app at PR head after the same click |
| --- | --- |
| ![Before: desktop dev app renders Not found after the source-pill click](https://raw.githubusercontent.com/get-bb/bb/42c49025cfbaf680461526dba639878d42705c2c/.github/pr-evidence/thr_gts7ugydiz/pr1-before.png) | ![After: desktop dev app opens the Personal project sender after the same click](https://raw.githubusercontent.com/get-bb/bb/42c49025cfbaf680461526dba639878d42705c2c/.github/pr-evidence/thr_gts7ugydiz/pr1-after.png) |

## Responsive QA

Final-head dev-app captures from `a129b17163bd102fce5f26874668c4640677b126` after navigating to the Personal sender thread.

| Mobile — 390×844 | Small/narrow — 768×900 |
| --- | --- |
| ![PR 1862 mobile final-head QA](<https://raw.githubusercontent.com/get-bb/bb/1e998291094e4dcab53254c9fb9399fb4fbaad84/.github/pr-evidence/thr_gts7ugydiz/responsive/pr1-mobile-390x844.png>) | ![PR 1862 small-window final-head QA](<https://raw.githubusercontent.com/get-bb/bb/1e998291094e4dcab53254c9fb9399fb4fbaad84/.github/pr-evidence/thr_gts7ugydiz/responsive/pr1-small-768x900.png>) |

| Normal desktop — 1440×900 | Very large desktop — 3440×1440 |
| --- | --- |
| ![PR 1862 normal-desktop final-head QA](<https://raw.githubusercontent.com/get-bb/bb/1e998291094e4dcab53254c9fb9399fb4fbaad84/.github/pr-evidence/thr_gts7ugydiz/responsive/pr1-normal-1440x900.png>) | ![PR 1862 ultrawide final-head QA](<https://raw.githubusercontent.com/get-bb/bb/1e998291094e4dcab53254c9fb9399fb4fbaad84/.github/pr-evidence/thr_gts7ugydiz/responsive/pr1-large-3440x1440.png>) |

BB-Thread-ID: thr_gts7ugydiz

> AGENT GENERATED: by GPT-5

