### PR TITLE
Keep queued mention menus inside the editor workspace

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -45,7 +45,7 @@ import {
   type PluginComposerHost,
 } from "@/components/plugin/plugin-composer-host";
 import { resetAllCrashedPluginSlotsForTest } from "@/components/plugin/PluginSlotMount";
-import { QueuedEditorTypeaheadLayoutProvider } from "@/components/promptbox/queued-editor-typeahead-layout";
+import { QueuedEditorTypeaheadLayoutContext } from "@/components/promptbox/queued-editor-typeahead-layout";
 import {
   resetPluginLogoStoreForTest,
   setPluginLogoUrls,
@@ -2785,70 +2785,44 @@ describe("PromptBoxInternal mention triggers", () => {
 
   it("reports the queued editor typeahead's open state and measured height", async () => {
     const layouts: Array<{ height: number; isOpen: boolean }> = [];
-    const resizeCallbacks: Array<() => void> = [];
-    class ResizeObserverMock {
-      constructor(callback: ResizeObserverCallback) {
-        resizeCallbacks.push(() =>
-          callback([], this as unknown as ResizeObserver),
-        );
-      }
-
-      observe() {}
-      disconnect() {}
-    }
-    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
-    let menuHeight = 64;
     const nativeGetBoundingClientRect =
       HTMLElement.prototype.getBoundingClientRect;
     const rectSpy = vi
       .spyOn(HTMLElement.prototype, "getBoundingClientRect")
       .mockImplementation(function (this: HTMLElement) {
         if (this.hasAttribute("data-promptbox-typeahead-menu")) {
-          return new DOMRect(0, 0, 600, menuHeight);
+          return new DOMRect(0, 0, 600, 144);
         }
         return nativeGetBoundingClientRect.call(this);
       });
     const promptBoxRef = createRef<PromptBoxHandle>();
 
-    try {
-      render(
-        <QueuedEditorTypeaheadLayoutProvider
-          onLayoutChange={(layout) => layouts.push(layout)}
-        >
-          <PromptBoxInternal
-            {...createPromptBoxProps({
-              value: "@fix",
-              typeahead: buildTypeaheadConfig({
-                mentionSuggestions: [githubIssueSuggestion],
-              }),
-            })}
-            promptBoxRef={promptBoxRef}
-          />
-        </QueuedEditorTypeaheadLayoutProvider>,
-      );
+    render(
+      <QueuedEditorTypeaheadLayoutContext.Provider
+        value={(layout) => layouts.push(layout)}
+      >
+        <PromptBoxInternal
+          {...createPromptBoxProps({
+            value: "@fix",
+            typeahead: buildTypeaheadConfig({
+              mentionSuggestions: [githubIssueSuggestion],
+            }),
+          })}
+          promptBoxRef={promptBoxRef}
+        />
+      </QueuedEditorTypeaheadLayoutContext.Provider>,
+    );
 
-      await focusPromptEnd(promptBoxRef);
-      await waitFor(() =>
-        expect(layouts).toContainEqual({ height: 64, isOpen: true }),
-      );
+    await focusPromptEnd(promptBoxRef);
+    await waitFor(() =>
+      expect(layouts).toContainEqual({ height: 144, isOpen: true }),
+    );
 
-      menuHeight = 144;
-      act(() => {
-        for (const notifyResize of resizeCallbacks) notifyResize();
-      });
-      await waitFor(() =>
-        expect(layouts.at(-1)).toEqual({ height: 144, isOpen: true }),
-      );
-
-      fireEvent.keyDown(getPromptEditorElement(), { key: "Escape" });
-      await waitFor(() =>
-        expect(layouts.at(-1)).toEqual({ height: 0, isOpen: false }),
-      );
-    } finally {
-      cleanup();
-      rectSpy.mockRestore();
-      vi.unstubAllGlobals();
-    }
+    fireEvent.keyDown(getPromptEditorElement(), { key: "Escape" });
+    await waitFor(() =>
+      expect(layouts.at(-1)).toEqual({ height: 0, isOpen: false }),
+    );
+    rectSpy.mockRestore();
   });
 
   it("renders a plugin mention's named icon hint", async () => {

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -45,6 +45,7 @@ import {
   type PluginComposerHost,
 } from "@/components/plugin/plugin-composer-host";
 import { resetAllCrashedPluginSlotsForTest } from "@/components/plugin/PluginSlotMount";
+import { QueuedEditorTypeaheadLayoutProvider } from "@/components/promptbox/queued-editor-typeahead-layout";
 import {
   resetPluginLogoStoreForTest,
   setPluginLogoUrls,
@@ -2781,6 +2782,47 @@ describe("PromptBoxInternal mention triggers", () => {
     icon: null,
     replacement: "#42 Fix login bug",
   };
+
+  it("reports the queued editor typeahead's open state and measured height", async () => {
+    const layouts: Array<{ height: number; isOpen: boolean }> = [];
+    const nativeGetBoundingClientRect =
+      HTMLElement.prototype.getBoundingClientRect;
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        if (this.hasAttribute("data-promptbox-typeahead-menu")) {
+          return new DOMRect(0, 0, 600, 144);
+        }
+        return nativeGetBoundingClientRect.call(this);
+      },
+    );
+    const promptBoxRef = createRef<PromptBoxHandle>();
+
+    render(
+      <QueuedEditorTypeaheadLayoutProvider
+        onLayoutChange={(layout) => layouts.push(layout)}
+      >
+        <PromptBoxInternal
+          {...createPromptBoxProps({
+            value: "@fix",
+            typeahead: buildTypeaheadConfig({
+              mentionSuggestions: [githubIssueSuggestion],
+            }),
+          })}
+          promptBoxRef={promptBoxRef}
+        />
+      </QueuedEditorTypeaheadLayoutProvider>,
+    );
+
+    await focusPromptEnd(promptBoxRef);
+    await waitFor(() =>
+      expect(layouts).toContainEqual({ height: 144, isOpen: true }),
+    );
+
+    fireEvent.keyDown(getPromptEditorElement(), { key: "Escape" });
+    await waitFor(() =>
+      expect(layouts.at(-1)).toEqual({ height: 0, isOpen: false }),
+    );
+  });
 
   it("renders a plugin mention's named icon hint", async () => {
     const suggestion = { ...githubIssueSuggestion, icon: "FileText" };

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -2785,43 +2785,70 @@ describe("PromptBoxInternal mention triggers", () => {
 
   it("reports the queued editor typeahead's open state and measured height", async () => {
     const layouts: Array<{ height: number; isOpen: boolean }> = [];
+    const resizeCallbacks: Array<() => void> = [];
+    class ResizeObserverMock {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallbacks.push(() =>
+          callback([], this as unknown as ResizeObserver),
+        );
+      }
+
+      observe() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    let menuHeight = 64;
     const nativeGetBoundingClientRect =
       HTMLElement.prototype.getBoundingClientRect;
-    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
-      function (this: HTMLElement) {
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: HTMLElement) {
         if (this.hasAttribute("data-promptbox-typeahead-menu")) {
-          return new DOMRect(0, 0, 600, 144);
+          return new DOMRect(0, 0, 600, menuHeight);
         }
         return nativeGetBoundingClientRect.call(this);
-      },
-    );
+      });
     const promptBoxRef = createRef<PromptBoxHandle>();
 
-    render(
-      <QueuedEditorTypeaheadLayoutProvider
-        onLayoutChange={(layout) => layouts.push(layout)}
-      >
-        <PromptBoxInternal
-          {...createPromptBoxProps({
-            value: "@fix",
-            typeahead: buildTypeaheadConfig({
-              mentionSuggestions: [githubIssueSuggestion],
-            }),
-          })}
-          promptBoxRef={promptBoxRef}
-        />
-      </QueuedEditorTypeaheadLayoutProvider>,
-    );
+    try {
+      render(
+        <QueuedEditorTypeaheadLayoutProvider
+          onLayoutChange={(layout) => layouts.push(layout)}
+        >
+          <PromptBoxInternal
+            {...createPromptBoxProps({
+              value: "@fix",
+              typeahead: buildTypeaheadConfig({
+                mentionSuggestions: [githubIssueSuggestion],
+              }),
+            })}
+            promptBoxRef={promptBoxRef}
+          />
+        </QueuedEditorTypeaheadLayoutProvider>,
+      );
 
-    await focusPromptEnd(promptBoxRef);
-    await waitFor(() =>
-      expect(layouts).toContainEqual({ height: 144, isOpen: true }),
-    );
+      await focusPromptEnd(promptBoxRef);
+      await waitFor(() =>
+        expect(layouts).toContainEqual({ height: 64, isOpen: true }),
+      );
 
-    fireEvent.keyDown(getPromptEditorElement(), { key: "Escape" });
-    await waitFor(() =>
-      expect(layouts.at(-1)).toEqual({ height: 0, isOpen: false }),
-    );
+      menuHeight = 144;
+      act(() => {
+        for (const notifyResize of resizeCallbacks) notifyResize();
+      });
+      await waitFor(() =>
+        expect(layouts.at(-1)).toEqual({ height: 144, isOpen: true }),
+      );
+
+      fireEvent.keyDown(getPromptEditorElement(), { key: "Escape" });
+      await waitFor(() =>
+        expect(layouts.at(-1)).toEqual({ height: 0, isOpen: false }),
+      );
+    } finally {
+      cleanup();
+      rectSpy.mockRestore();
+      vi.unstubAllGlobals();
+    }
   });
 
   it("renders a plugin mention's named icon hint", async () => {

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -113,6 +113,7 @@ import { applyPromptParagraphNewline } from "./editor/prompt-editor-paragraph";
 import { MentionMenu, type TypeaheadSuggestion } from "./mentions/MentionMenu";
 import { parsePromptMentionClipboardElement } from "./mentions/prompt-mention-clipboard";
 import { ComposerEditorSlot } from "./ComposerEditorSlot";
+import { useQueuedEditorTypeaheadLayoutReporter } from "./queued-editor-typeahead-layout";
 
 const PROMPTBOX_MIN_HEIGHT = 68;
 const PROMPTBOX_SELECTION_REVEAL_MARGIN = 12;
@@ -1213,6 +1214,9 @@ export function PromptBoxInternal({
   // Passive text autofocus opens the soft keyboard on coarse-pointer devices.
   const shouldAvoidSoftKeyboardAutofocus = isPointerCoarse;
   const formRef = useRef<HTMLFormElement>(null);
+  const typeaheadMenuRef = useRef<HTMLDivElement>(null);
+  const reportQueuedEditorTypeaheadLayout =
+    useQueuedEditorTypeaheadLayoutReporter();
   const blurAfterPointerSubmitRef = useRef(false);
   const heightAnimationFromRef = useRef<number | null>(null);
   const capturePromptBoxHeight = useCallback(() => {
@@ -2199,6 +2203,32 @@ export function PromptBoxInternal({
     activeTriggerKind === "command"
       ? { trigger: "command", state: commandMenuState }
       : { trigger: "mention", state: mentionMenuState };
+
+  useLayoutEffect(() => {
+    if (reportQueuedEditorTypeaheadLayout === null) return;
+    const menu = typeaheadMenuRef.current;
+    if (!showTypeaheadMenu || menu === null) {
+      reportQueuedEditorTypeaheadLayout({ height: 0, isOpen: false });
+      return;
+    }
+
+    const reportOpenLayout = () => {
+      reportQueuedEditorTypeaheadLayout({
+        height: menu.getBoundingClientRect().height,
+        isOpen: true,
+      });
+    };
+    reportOpenLayout();
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(reportOpenLayout);
+    resizeObserver?.observe(menu);
+    return () => {
+      resizeObserver?.disconnect();
+      reportQueuedEditorTypeaheadLayout({ height: 0, isOpen: false });
+    };
+  }, [reportQueuedEditorTypeaheadLayout, showTypeaheadMenu]);
 
   useEffect(() => {
     if (activeSuggestions.length === 0) {
@@ -3247,6 +3277,8 @@ export function PromptBoxInternal({
 
           {showTypeaheadMenu ? (
             <div
+              ref={typeaheadMenuRef}
+              data-promptbox-typeahead-menu=""
               className={cn(
                 // Zen mode: menu floats inside the form, anchored just above
                 // the action footer so it stays visible. The form's pb-3 +

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -575,11 +575,7 @@ describe("QueuedMessagesList", () => {
                 ? {
                     queuedMessageId: "q_one",
                     queuedMessageIndex: 0,
-                    content: (
-                      <TypeaheadLayoutFixture
-                        layout={{ height: 120, isOpen: true }}
-                      />
-                    ),
+                    content: <div>Inline editor</div>,
                     onDismiss: noop,
                   }
                 : undefined
@@ -596,11 +592,6 @@ describe("QueuedMessagesList", () => {
     const composer = container.querySelector("[data-test-bottom-composer]");
 
     await waitFor(() => expect(surface?.style.height).toBe("140px"));
-    expect(
-      container.querySelector<HTMLElement>(
-        "[data-queued-editor-typeahead-reservation]",
-      )?.style.paddingTop,
-    ).toBe("128px");
     expect(surface?.compareDocumentPosition(composer as Node) ?? 0).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
@@ -803,7 +794,7 @@ describe("QueuedMessagesList", () => {
       neighborTop: 32,
     },
   ])(
-    "sizes a $label-item edit from only the neighbor that exists",
+    "reserves and scroll-aligns a $label queued editor in a constrained drawer",
     async ({ editorTop, expectedScrollTop, messages, neighborTop }) => {
       const viewport = document.createElement("div");
       Object.defineProperty(viewport, "clientHeight", { value: 500 });
@@ -886,14 +877,9 @@ describe("QueuedMessagesList", () => {
       const editorFrame = reservation.closest(
         '[data-inline-message-editor-frame="embedded"]',
       );
-      expect(editorFrame).not.toBeNull();
-      const editorHeader = Array.from(editorFrame?.children ?? []).find(
-        (element) => element.textContent?.includes("Editing queued message"),
+      expect(editorFrame?.firstElementChild?.textContent).toContain(
+        "Editing queued message",
       );
-      expect(
-        (editorHeader?.compareDocumentPosition(reservation) ?? 0) &
-          Node.DOCUMENT_POSITION_FOLLOWING,
-      ).not.toBe(0);
       expect(scroll?.scrollTop).toBe(expectedScrollTop);
     },
   );

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -784,6 +784,7 @@ describe("QueuedMessagesList", () => {
   it.each([
     {
       label: "first",
+      expectedScrollTop: 0,
       messages: [
         makeQueuedMessage("q_editing", "Edited queued message"),
         makeQueuedMessage("q_neighbor", "Following queued message"),
@@ -793,6 +794,7 @@ describe("QueuedMessagesList", () => {
     },
     {
       label: "last",
+      expectedScrollTop: 80,
       messages: [
         makeQueuedMessage("q_neighbor", "Previous queued message"),
         makeQueuedMessage("q_editing", "Edited queued message"),
@@ -802,7 +804,7 @@ describe("QueuedMessagesList", () => {
     },
   ])(
     "sizes a $label-item edit from only the neighbor that exists",
-    async ({ editorTop, messages, neighborTop }) => {
+    async ({ editorTop, expectedScrollTop, messages, neighborTop }) => {
       const viewport = document.createElement("div");
       Object.defineProperty(viewport, "clientHeight", { value: 500 });
       bottomAnchorMocks.scrollElement = viewport;
@@ -823,10 +825,16 @@ describe("QueuedMessagesList", () => {
           return new DOMRect(0, 32, 600, 180);
         }
         if (this.hasAttribute("data-queued-message-inline-editor")) {
-          return new DOMRect(0, editorTop, 600, 278);
+          const scrollTop =
+            this.closest<HTMLElement>("[data-queued-messages-scroll]")
+              ?.scrollTop ?? 0;
+          return new DOMRect(0, editorTop - scrollTop, 600, 278);
         }
         if (this.getAttribute("data-queued-message-id") === "q_neighbor") {
-          return new DOMRect(0, neighborTop, 600, 80);
+          const scrollTop =
+            this.closest<HTMLElement>("[data-queued-messages-scroll]")
+              ?.scrollTop ?? 0;
+          return new DOMRect(0, neighborTop - scrollTop, 600, 80);
         }
         return nativeGetBoundingClientRect.call(this);
       });
@@ -865,13 +873,28 @@ describe("QueuedMessagesList", () => {
       const surface = container.querySelector<HTMLElement>(
         'section[aria-label="Queued messages"]',
       );
+      const scroll = container.querySelector<HTMLElement>(
+        "[data-queued-messages-scroll]",
+      );
 
       await waitFor(() => expect(surface?.style.height).toBe("400px"));
+      const reservation = container.querySelector<HTMLElement>(
+        "[data-queued-editor-typeahead-reservation]",
+      );
+      if (!reservation) throw new Error("Expected typeahead reservation");
+      expect(reservation?.style.paddingTop).toBe("128px");
+      const editorFrame = reservation.closest(
+        '[data-inline-message-editor-frame="embedded"]',
+      );
+      expect(editorFrame).not.toBeNull();
+      const editorHeader = Array.from(editorFrame?.children ?? []).find(
+        (element) => element.textContent?.includes("Editing queued message"),
+      );
       expect(
-        container.querySelector<HTMLElement>(
-          "[data-queued-editor-typeahead-reservation]",
-        )?.style.paddingTop,
-      ).toBe("128px");
+        (editorHeader?.compareDocumentPosition(reservation) ?? 0) &
+          Node.DOCUMENT_POSITION_FOLLOWING,
+      ).not.toBe(0);
+      expect(scroll?.scrollTop).toBe(expectedScrollTop);
     },
   );
 

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.test.tsx
@@ -7,6 +7,7 @@ import {
   render,
   waitFor,
 } from "@testing-library/react";
+import { useLayoutEffect } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ThreadQueuedMessage } from "@bb/domain";
 import type { Active, DroppableContainer } from "@dnd-kit/core";
@@ -19,6 +20,10 @@ import {
   resolveQueuedMessageDrag,
   snapGroupBoundaryDragTransform,
 } from "./QueuedMessagesList";
+import {
+  useQueuedEditorTypeaheadLayoutReporter,
+  type QueuedEditorTypeaheadLayout,
+} from "@/components/promptbox/queued-editor-typeahead-layout";
 
 const bottomAnchorMocks = vi.hoisted(() => ({
   scrollElement: null as HTMLElement | null,
@@ -34,6 +39,18 @@ vi.mock("@/components/ui/bottom-anchored-scroll-body", () => ({
 }));
 
 const noop = () => {};
+
+function TypeaheadLayoutFixture({
+  layout,
+}: {
+  layout: QueuedEditorTypeaheadLayout;
+}) {
+  const reportLayout = useQueuedEditorTypeaheadLayoutReporter();
+  useLayoutEffect(() => {
+    reportLayout?.(layout);
+  }, [layout, reportLayout]);
+  return <div>Inline editor</div>;
+}
 
 function makeQueuedMessage(id: string, text: string): ThreadQueuedMessage {
   return {
@@ -558,7 +575,11 @@ describe("QueuedMessagesList", () => {
                 ? {
                     queuedMessageId: "q_one",
                     queuedMessageIndex: 0,
-                    content: <div>Inline editor</div>,
+                    content: (
+                      <TypeaheadLayoutFixture
+                        layout={{ height: 120, isOpen: true }}
+                      />
+                    ),
                     onDismiss: noop,
                   }
                 : undefined
@@ -575,6 +596,11 @@ describe("QueuedMessagesList", () => {
     const composer = container.querySelector("[data-test-bottom-composer]");
 
     await waitFor(() => expect(surface?.style.height).toBe("140px"));
+    expect(
+      container.querySelector<HTMLElement>(
+        "[data-queued-editor-typeahead-reservation]",
+      )?.style.paddingTop,
+    ).toBe("128px");
     expect(surface?.compareDocumentPosition(composer as Node) ?? 0).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
@@ -763,7 +789,7 @@ describe("QueuedMessagesList", () => {
         makeQueuedMessage("q_neighbor", "Following queued message"),
       ],
       editorTop: 32,
-      neighborTop: 182,
+      neighborTop: 310,
     },
     {
       label: "last",
@@ -797,7 +823,7 @@ describe("QueuedMessagesList", () => {
           return new DOMRect(0, 32, 600, 180);
         }
         if (this.hasAttribute("data-queued-message-inline-editor")) {
-          return new DOMRect(0, editorTop, 600, 150);
+          return new DOMRect(0, editorTop, 600, 278);
         }
         if (this.getAttribute("data-queued-message-id") === "q_neighbor") {
           return new DOMRect(0, neighborTop, 600, 80);
@@ -815,7 +841,11 @@ describe("QueuedMessagesList", () => {
                 queuedMessageIndex: messages.findIndex(
                   (message) => message.id === "q_editing",
                 ),
-                content: <div>Inline editor</div>,
+                content: (
+                  <TypeaheadLayoutFixture
+                    layout={{ height: 120, isOpen: true }}
+                  />
+                ),
                 onDismiss: noop,
               }}
               sendDisabled={false}
@@ -836,7 +866,12 @@ describe("QueuedMessagesList", () => {
         'section[aria-label="Queued messages"]',
       );
 
-      await waitFor(() => expect(surface?.style.height).toBe("290px"));
+      await waitFor(() => expect(surface?.style.height).toBe("400px"));
+      expect(
+        container.querySelector<HTMLElement>(
+          "[data-queued-editor-typeahead-reservation]",
+        )?.style.paddingTop,
+      ).toBe("128px");
     },
   );
 

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -76,6 +76,10 @@ import {
   substitutePromptMentions,
 } from "@/components/ui/markdown-prompt-mentions";
 import { normalizePromptBlockquoteBoundaries } from "@/components/ui/markdown-prompt-blockquote-boundaries";
+import {
+  QueuedEditorTypeaheadLayoutProvider,
+  type QueuedEditorTypeaheadLayout,
+} from "@/components/promptbox/queued-editor-typeahead-layout";
 
 /** Which in-flight action the processing message is running, for its label. */
 export type QueuedMessageProcessingAction = "send" | "edit" | "delete";
@@ -141,6 +145,7 @@ const WORKSPACE_MIN_HEIGHT = 240;
 const WORKSPACE_MAX_HEIGHT = 360;
 const WORKSPACE_CHROME_HEIGHT = 56;
 const WORKSPACE_ROW_HEIGHT = 40;
+const TYPEAHEAD_MENU_GAP = 8;
 const SURFACE_DRAG_THRESHOLD = 72;
 const QUEUED_MESSAGE_ACTION_TAKEOVER_CLASS =
   "relative bg-surface-raised-solid before:pointer-events-none before:absolute before:inset-y-0 before:right-full before:w-4 before:bg-gradient-to-r before:from-transparent before:to-surface-raised-solid before:content-['']";
@@ -928,22 +933,38 @@ function clamp(value: number, minimum: number, maximum: number): number {
 
 function QueuedMessageInlineEditorSlot({
   editor,
+  onTypeaheadLayoutChange,
+  typeaheadLayout,
 }: {
   editor: QueuedMessageInlineEditor;
+  onTypeaheadLayoutChange: (layout: QueuedEditorTypeaheadLayout) => void;
+  typeaheadLayout: QueuedEditorTypeaheadLayout;
 }) {
+  const typeaheadReservation = typeaheadLayout.isOpen
+    ? Math.ceil(typeaheadLayout.height) + TYPEAHEAD_MENU_GAP
+    : 0;
   return (
     <li
       data-queued-message-inline-editor=""
       className="relative z-10 border-b border-border/35 px-2.5 py-1 last:border-b-0"
     >
       <OverflowFade placement="above" tone="surface-raised" className="z-10" />
-      <InlineMessageEditorFrame
-        cancelLabel="Stop editing queued message"
-        label={`Editing queued message ${editor.queuedMessageIndex + 1}`}
-        onCancel={editor.onDismiss}
+      <QueuedEditorTypeaheadLayoutProvider
+        onLayoutChange={onTypeaheadLayoutChange}
       >
-        {editor.content}
-      </InlineMessageEditorFrame>
+        <div
+          data-queued-editor-typeahead-reservation=""
+          style={{ paddingTop: typeaheadReservation }}
+        >
+          <InlineMessageEditorFrame
+            cancelLabel="Stop editing queued message"
+            label={`Editing queued message ${editor.queuedMessageIndex + 1}`}
+            onCancel={editor.onDismiss}
+          >
+            {editor.content}
+          </InlineMessageEditorFrame>
+        </div>
+      </QueuedEditorTypeaheadLayoutProvider>
       <OverflowFade placement="below" tone="surface-raised" className="z-10" />
     </li>
   );
@@ -988,7 +1009,30 @@ export function QueuedMessagesList({
   const [inlineEditorDesiredHeight, setInlineEditorDesiredHeight] = useState<
     number | null
   >(null);
+  const [reportedTypeaheadLayout, setReportedTypeaheadLayout] = useState<
+    QueuedEditorTypeaheadLayout & { editorId: string | null }
+  >({ editorId: null, height: 0, isOpen: false });
   const inlineEditorActive = inlineEditor !== undefined;
+  const inlineEditorId = inlineEditor?.queuedMessageId ?? null;
+  const inlineEditorTypeaheadLayout: QueuedEditorTypeaheadLayout =
+    reportedTypeaheadLayout.editorId === inlineEditorId
+      ? reportedTypeaheadLayout
+      : { height: 0, isOpen: false };
+  const handleTypeaheadLayoutChange = useCallback(
+    (layout: QueuedEditorTypeaheadLayout) => {
+      setReportedTypeaheadLayout((current) => {
+        if (
+          current.editorId === inlineEditorId &&
+          current.height === layout.height &&
+          current.isOpen === layout.isOpen
+        ) {
+          return current;
+        }
+        return { ...layout, editorId: inlineEditorId };
+      });
+    },
+    [inlineEditorId],
+  );
   const getScrollElement = useBottomAnchoredScroll()?.getScrollElement;
   const surfaceRef = useRef<HTMLElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
@@ -1152,7 +1196,13 @@ export function QueuedMessagesList({
       resizeObserver?.disconnect();
       window.removeEventListener("resize", measureInlineEditorMaxHeight);
     };
-  }, [getScrollElement, inlineEditorActive, measureInlineEditorMaxHeight]);
+  }, [
+    getScrollElement,
+    inlineEditorActive,
+    inlineEditorTypeaheadLayout.height,
+    inlineEditorTypeaheadLayout.isOpen,
+    measureInlineEditorMaxHeight,
+  ]);
 
   // Render from a local order so a drag can reorder synchronously in the drop
   // event (no snap-back). The prop is re-adopted only when the queue's
@@ -1454,6 +1504,8 @@ export function QueuedMessagesList({
         <QueuedMessageInlineEditorSlot
           key={`inline-editor:${inlineEditor.queuedMessageId}`}
           editor={inlineEditor}
+          onTypeaheadLayoutChange={handleTypeaheadLayoutChange}
+          typeaheadLayout={inlineEditorTypeaheadLayout}
         />,
       );
       inlineEditorInserted = true;
@@ -1485,6 +1537,8 @@ export function QueuedMessagesList({
       <QueuedMessageInlineEditorSlot
         key={`inline-editor:${inlineEditor.queuedMessageId}`}
         editor={inlineEditor}
+        onTypeaheadLayoutChange={handleTypeaheadLayoutChange}
+        typeaheadLayout={inlineEditorTypeaheadLayout}
       />,
     );
   }

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -77,7 +77,7 @@ import {
 } from "@/components/ui/markdown-prompt-mentions";
 import { normalizePromptBlockquoteBoundaries } from "@/components/ui/markdown-prompt-blockquote-boundaries";
 import {
-  QueuedEditorTypeaheadLayoutProvider,
+  QueuedEditorTypeaheadLayoutContext,
   type QueuedEditorTypeaheadLayout,
 } from "@/components/promptbox/queued-editor-typeahead-layout";
 
@@ -933,13 +933,11 @@ function clamp(value: number, minimum: number, maximum: number): number {
 
 function QueuedMessageInlineEditorSlot({
   editor,
-  onTypeaheadLayoutChange,
-  typeaheadLayout,
 }: {
   editor: QueuedMessageInlineEditor;
-  onTypeaheadLayoutChange: (layout: QueuedEditorTypeaheadLayout) => void;
-  typeaheadLayout: QueuedEditorTypeaheadLayout;
 }) {
+  const [typeaheadLayout, setTypeaheadLayout] =
+    useState<QueuedEditorTypeaheadLayout>({ height: 0, isOpen: false });
   const typeaheadReservation = typeaheadLayout.isOpen
     ? Math.ceil(typeaheadLayout.height) + TYPEAHEAD_MENU_GAP
     : 0;
@@ -954,16 +952,14 @@ function QueuedMessageInlineEditorSlot({
         label={`Editing queued message ${editor.queuedMessageIndex + 1}`}
         onCancel={editor.onDismiss}
       >
-        <QueuedEditorTypeaheadLayoutProvider
-          onLayoutChange={onTypeaheadLayoutChange}
-        >
+        <QueuedEditorTypeaheadLayoutContext.Provider value={setTypeaheadLayout}>
           <div
             data-queued-editor-typeahead-reservation=""
             style={{ paddingTop: typeaheadReservation }}
           >
             {editor.content}
           </div>
-        </QueuedEditorTypeaheadLayoutProvider>
+        </QueuedEditorTypeaheadLayoutContext.Provider>
       </InlineMessageEditorFrame>
       <OverflowFade placement="below" tone="surface-raised" className="z-10" />
     </li>
@@ -1009,30 +1005,7 @@ export function QueuedMessagesList({
   const [inlineEditorDesiredHeight, setInlineEditorDesiredHeight] = useState<
     number | null
   >(null);
-  const [reportedTypeaheadLayout, setReportedTypeaheadLayout] = useState<
-    QueuedEditorTypeaheadLayout & { editorId: string | null }
-  >({ editorId: null, height: 0, isOpen: false });
   const inlineEditorActive = inlineEditor !== undefined;
-  const inlineEditorId = inlineEditor?.queuedMessageId ?? null;
-  const inlineEditorTypeaheadLayout: QueuedEditorTypeaheadLayout =
-    reportedTypeaheadLayout.editorId === inlineEditorId
-      ? reportedTypeaheadLayout
-      : { height: 0, isOpen: false };
-  const handleTypeaheadLayoutChange = useCallback(
-    (layout: QueuedEditorTypeaheadLayout) => {
-      setReportedTypeaheadLayout((current) => {
-        if (
-          current.editorId === inlineEditorId &&
-          current.height === layout.height &&
-          current.isOpen === layout.isOpen
-        ) {
-          return current;
-        }
-        return { ...layout, editorId: inlineEditorId };
-      });
-    },
-    [inlineEditorId],
-  );
   const getScrollElement = useBottomAnchoredScroll()?.getScrollElement;
   const surfaceRef = useRef<HTMLElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
@@ -1196,13 +1169,7 @@ export function QueuedMessagesList({
       resizeObserver?.disconnect();
       window.removeEventListener("resize", measureInlineEditorMaxHeight);
     };
-  }, [
-    getScrollElement,
-    inlineEditorActive,
-    inlineEditorTypeaheadLayout.height,
-    inlineEditorTypeaheadLayout.isOpen,
-    measureInlineEditorMaxHeight,
-  ]);
+  }, [getScrollElement, inlineEditorActive, measureInlineEditorMaxHeight]);
 
   // Render from a local order so a drag can reorder synchronously in the drop
   // event (no snap-back). The prop is re-adopted only when the queue's
@@ -1504,8 +1471,6 @@ export function QueuedMessagesList({
         <QueuedMessageInlineEditorSlot
           key={`inline-editor:${inlineEditor.queuedMessageId}`}
           editor={inlineEditor}
-          onTypeaheadLayoutChange={handleTypeaheadLayoutChange}
-          typeaheadLayout={inlineEditorTypeaheadLayout}
         />,
       );
       inlineEditorInserted = true;
@@ -1537,8 +1502,6 @@ export function QueuedMessagesList({
       <QueuedMessageInlineEditorSlot
         key={`inline-editor:${inlineEditor.queuedMessageId}`}
         editor={inlineEditor}
-        onTypeaheadLayoutChange={handleTypeaheadLayoutChange}
-        typeaheadLayout={inlineEditorTypeaheadLayout}
       />,
     );
   }

--- a/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
+++ b/apps/app/src/components/promptbox/banner/QueuedMessagesList.tsx
@@ -949,22 +949,22 @@ function QueuedMessageInlineEditorSlot({
       className="relative z-10 border-b border-border/35 px-2.5 py-1 last:border-b-0"
     >
       <OverflowFade placement="above" tone="surface-raised" className="z-10" />
-      <QueuedEditorTypeaheadLayoutProvider
-        onLayoutChange={onTypeaheadLayoutChange}
+      <InlineMessageEditorFrame
+        cancelLabel="Stop editing queued message"
+        label={`Editing queued message ${editor.queuedMessageIndex + 1}`}
+        onCancel={editor.onDismiss}
       >
-        <div
-          data-queued-editor-typeahead-reservation=""
-          style={{ paddingTop: typeaheadReservation }}
+        <QueuedEditorTypeaheadLayoutProvider
+          onLayoutChange={onTypeaheadLayoutChange}
         >
-          <InlineMessageEditorFrame
-            cancelLabel="Stop editing queued message"
-            label={`Editing queued message ${editor.queuedMessageIndex + 1}`}
-            onCancel={editor.onDismiss}
+          <div
+            data-queued-editor-typeahead-reservation=""
+            style={{ paddingTop: typeaheadReservation }}
           >
             {editor.content}
-          </InlineMessageEditorFrame>
-        </div>
-      </QueuedEditorTypeaheadLayoutProvider>
+          </div>
+        </QueuedEditorTypeaheadLayoutProvider>
+      </InlineMessageEditorFrame>
       <OverflowFade placement="below" tone="surface-raised" className="z-10" />
     </li>
   );

--- a/apps/app/src/components/promptbox/queued-editor-typeahead-layout.tsx
+++ b/apps/app/src/components/promptbox/queued-editor-typeahead-layout.tsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+export interface QueuedEditorTypeaheadLayout {
+  height: number;
+  isOpen: boolean;
+}
+
+type QueuedEditorTypeaheadLayoutReporter = (
+  layout: QueuedEditorTypeaheadLayout,
+) => void;
+
+const QueuedEditorTypeaheadLayoutContext =
+  createContext<QueuedEditorTypeaheadLayoutReporter | null>(null);
+
+export function QueuedEditorTypeaheadLayoutProvider({
+  children,
+  onLayoutChange,
+}: {
+  children: ReactNode;
+  onLayoutChange: QueuedEditorTypeaheadLayoutReporter;
+}) {
+  return (
+    <QueuedEditorTypeaheadLayoutContext.Provider value={onLayoutChange}>
+      {children}
+    </QueuedEditorTypeaheadLayoutContext.Provider>
+  );
+}
+
+export function useQueuedEditorTypeaheadLayoutReporter(): QueuedEditorTypeaheadLayoutReporter | null {
+  return useContext(QueuedEditorTypeaheadLayoutContext);
+}

--- a/apps/app/src/components/promptbox/queued-editor-typeahead-layout.tsx
+++ b/apps/app/src/components/promptbox/queued-editor-typeahead-layout.tsx
@@ -1,30 +1,16 @@
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, useContext } from "react";
 
 export interface QueuedEditorTypeaheadLayout {
   height: number;
   isOpen: boolean;
 }
 
-type QueuedEditorTypeaheadLayoutReporter = (
+export type QueuedEditorTypeaheadLayoutReporter = (
   layout: QueuedEditorTypeaheadLayout,
 ) => void;
 
-const QueuedEditorTypeaheadLayoutContext =
+export const QueuedEditorTypeaheadLayoutContext =
   createContext<QueuedEditorTypeaheadLayoutReporter | null>(null);
-
-export function QueuedEditorTypeaheadLayoutProvider({
-  children,
-  onLayoutChange,
-}: {
-  children: ReactNode;
-  onLayoutChange: QueuedEditorTypeaheadLayoutReporter;
-}) {
-  return (
-    <QueuedEditorTypeaheadLayoutContext.Provider value={onLayoutChange}>
-      {children}
-    </QueuedEditorTypeaheadLayoutContext.Provider>
-  );
-}
 
 export function useQueuedEditorTypeaheadLayoutReporter(): QueuedEditorTypeaheadLayoutReporter | null {
   return useContext(QueuedEditorTypeaheadLayoutContext);


### PR DESCRIPTION
## What was wrong

The queued editor rendered its mention typeahead above the prompt inside an overflow-clipped queue surface. Because the drawer reserved no space for that menu, first and last queued rows could hide it; a higher z-index could not escape the clipping boundary.

## What changed

- Report the queued prompt's open typeahead height to its editor slot and reserve that space below the edit header.
- Reuse the queue's existing resize measurement to grow and scroll-align the editor neighborhood when the reservation changes.
- Cover first-row, last-row, and constrained-drawer placement.

## How you verified

- Regression proof: the new queue tests failed before the fix because no typeahead space was reserved.
- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/promptbox/banner/QueuedMessagesList.test.tsx src/components/promptbox/PromptBoxInternal.test.tsx` — 135 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.
- `pnpm exec turbo run lint --filter=@bb/app` — passed with the repository's existing 147 warnings and no errors.
- Exact final-head dev-app QA: first- and last-row menus remained fully visible inside the constrained drawer at 390×844, 768×900, 1440×900, and 3440×1440; five open/close cycles passed per viewport.

## Before / after

| Before: parent-branch dev app with the menu top clipped | After: PR-head dev app with the full menu visible |
| --- | --- |
| ![Before: desktop dev app clips Threads and Update target above the last queued-row editor](https://raw.githubusercontent.com/get-bb/bb/0575f8039b3084f62b5cf9349ae6b592f1d546a5/.github/pr-evidence/thr_gts7ugydiz/pr2-before.png) | ![After: desktop dev app shows Threads and Update target above the same queued-row editor](https://raw.githubusercontent.com/get-bb/bb/0575f8039b3084f62b5cf9349ae6b592f1d546a5/.github/pr-evidence/thr_gts7ugydiz/pr2-after.png) |

## Responsive QA

Final-head dev-app captures from `744fa9289951d6b45cdc7e89306fbdd02c8d28ec` with the last queued-row mention menu open; the same run also passed the first queued row.

| Mobile — 390×844 | Small/narrow — 768×900 |
| --- | --- |
| ![PR 1866 mobile final-head QA](<https://raw.githubusercontent.com/get-bb/bb/1e998291094e4dcab53254c9fb9399fb4fbaad84/.github/pr-evidence/thr_gts7ugydiz/responsive/pr2-mobile-390x844.png>) | ![PR 1866 small-window final-head QA](<https://raw.githubusercontent.com/get-bb/bb/1e998291094e4dcab53254c9fb9399fb4fbaad84/.github/pr-evidence/thr_gts7ugydiz/responsive/pr2-small-768x900.png>) |

| Normal desktop — 1440×900 | Very large desktop — 3440×1440 |
| --- | --- |
| ![PR 1866 normal-desktop final-head QA](<https://raw.githubusercontent.com/get-bb/bb/1e998291094e4dcab53254c9fb9399fb4fbaad84/.github/pr-evidence/thr_gts7ugydiz/responsive/pr2-normal-1440x900.png>) | ![PR 1866 ultrawide final-head QA](<https://raw.githubusercontent.com/get-bb/bb/1e998291094e4dcab53254c9fb9399fb4fbaad84/.github/pr-evidence/thr_gts7ugydiz/responsive/pr2-large-3440x1440.png>) |

BB-Thread-ID: thr_gts7ugydiz

> AGENT GENERATED: by GPT-5

