### PR TITLE
Skip superseded workflow snapshots and out-of-window turn rows in timeline pages

### DIFF
--- a/apps/server/src/services/threads/timeline.ts
+++ b/apps/server/src/services/threads/timeline.ts
@@ -1538,13 +1538,13 @@ function buildSequencePageTimelineRows(
     selection.responsePageKind === "latest"
       ? ""
       : `:sequence-page:${selection.byteWindowSequenceStart}`;
-  return rowsWithPlaceholder.map((row): TimelineRow => {
+  return rowsWithPlaceholder.flatMap((row): TimelineRow[] => {
     if (
       row.kind !== "turn" ||
       selection.byteWindowSequenceEnd === null ||
       selection.byteWindowSequenceStart === null
     ) {
-      return { ...row, id: `${row.id}${suffix}` };
+      return [{ ...row, id: `${row.id}${suffix}` }];
     }
     const sourceSeqStart = Math.max(
       row.sourceSeqStart,
@@ -1554,14 +1554,25 @@ function buildSequencePageTimelineRows(
       row.sourceSeqEnd,
       selection.byteWindowSequenceEnd,
     );
-    return sourceSeqStart <= sourceSeqEnd
-      ? {
-          ...row,
-          id: `${row.id}${suffix}`,
-          sourceSeqEnd,
-          sourceSeqStart,
-        }
-      : { ...row, id: `${row.id}${suffix}` };
+    if (sourceSeqStart > sourceSeqEnd) {
+      // A finished turn with no event inside this byte window is closure
+      // context, not page content: the window's rows carried a
+      // `parentToolCallId` (a workflow's progress snapshots name the Workflow
+      // call in the turn that started it), parent closure pulled that tool
+      // call in, and turn lifecycle closure completed the turn around it. The
+      // page that holds the turn's own events renders its summary; emitting
+      // it here too gives every byte page another "Worked for" row under a
+      // page-unique id.
+      return [];
+    }
+    return [
+      {
+        ...row,
+        id: `${row.id}${suffix}`,
+        sourceSeqEnd,
+        sourceSeqStart,
+      },
+    ];
   });
 }
 

--- a/apps/server/test/services/threads/timeline-workflow-progress-window.test.ts
+++ b/apps/server/test/services/threads/timeline-workflow-progress-window.test.ts
@@ -21,6 +21,7 @@ import type {
   TimelineRow,
 } from "@bb/server-contract";
 import {
+  buildThreadConversationOutline,
   buildThreadTimelineWithProfile,
   THREAD_TIMELINE_EVENT_DATA_BYTE_LIMIT,
 } from "../../../src/services/threads/timeline.js";
@@ -287,9 +288,10 @@ function buildPage(
   db: DbConnection,
   thread: Thread,
   cursor: TimelinePaginationCursor | null,
+  eventBudget = LARGE_BUDGET,
 ) {
   return buildThreadTimelineWithProfile(db, thread, {
-    eventBudget: LARGE_BUDGET,
+    eventBudget,
     includeProviderUnhandledOperations: false,
     includeNestedRows: false,
     maxInlineOutputChars: 32_000,
@@ -385,5 +387,20 @@ describe("workflow progress snapshots across timeline pages", () => {
     expect(
       latest.response.rows.filter((row) => row.kind === "turn"),
     ).toHaveLength(1);
+
+    // The event-count budget counts the same rows. The thread has ~15 live
+    // events, so a budget of 30 binds only if the 45 superseded snapshots are
+    // counted.
+    const eventBudgeted = buildPage(db, thread, null, 30);
+    expect(eventBudgeted.response.timelinePage.hasOlderRows).toBe(false);
+    expect(eventBudgeted.response.rows).toEqual(latest.response.rows);
+
+    // The conversation outline reads the task's structural rows too; it must
+    // not decode every old snapshot to list two messages.
+    const outline = buildThreadConversationOutline(db, thread, { maxSeq: 0 });
+    expect(outline.items.map((item) => item.role)).toEqual([
+      "user",
+      "assistant",
+    ]);
   });
 });

--- a/apps/server/test/services/threads/timeline-workflow-progress-window.test.ts
+++ b/apps/server/test/services/threads/timeline-workflow-progress-window.test.ts
@@ -1,0 +1,389 @@
+import { describe, expect, it } from "vitest";
+import {
+  encodeClientTurnRequestIdNumber,
+  LOCAL_WORKFLOW_TASK_TYPE,
+  threadScope,
+  turnScope,
+} from "@bb/domain";
+import type { Thread } from "@bb/domain";
+import {
+  createConnection,
+  createProject,
+  createThread,
+  insertEvents,
+  migrate,
+  noopNotifier,
+  upsertHost,
+} from "@bb/db";
+import type { DbConnection } from "@bb/db";
+import type {
+  TimelinePaginationCursor,
+  TimelineRow,
+} from "@bb/server-contract";
+import {
+  buildThreadTimelineWithProfile,
+  THREAD_TIMELINE_EVENT_DATA_BYTE_LIMIT,
+} from "../../../src/services/threads/timeline.js";
+
+/** Larger than any thread these tests build, so the event budget never binds. */
+const LARGE_BUDGET = 1_000_000;
+const providerThreadId = "provider-root";
+const WORKFLOW_CALL_ID = "call-workflow";
+const WORKFLOW_TASK_ID = "task:wf-1";
+/**
+ * A workflow snapshot with a couple hundred agents is ~250 KB. Enough of them
+ * to span several 4 MiB byte windows.
+ */
+const SNAPSHOT_BYTES = 300_000;
+const SNAPSHOT_COUNT = 45;
+
+const execution = {
+  model: "gpt-5",
+  serviceTier: "default",
+  reasoningLevel: "medium",
+  permissionMode: "full",
+  source: "client/turn/requested",
+} as const;
+
+type EventInput = Parameters<typeof insertEvents>[2][number];
+
+function setup(): { db: DbConnection; thread: Thread } {
+  const db = createConnection(":memory:");
+  migrate(db);
+  const host = upsertHost(db, noopNotifier, {
+    name: "test-host",
+    type: "persistent",
+  });
+  const { project } = createProject(db, noopNotifier, {
+    name: "test-project",
+    source: { type: "local_path", hostId: host.id, path: "/tmp/test" },
+  });
+  const thread = createThread(db, noopNotifier, {
+    projectId: project.id,
+    providerId: "claude-code",
+  });
+  return { db, thread };
+}
+
+function workflowTaskData(args: {
+  status: "pending" | "completed";
+  padding: number;
+}): string {
+  return JSON.stringify({
+    providerThreadId,
+    item: {
+      type: "backgroundTask",
+      id: WORKFLOW_TASK_ID,
+      taskType: LOCAL_WORKFLOW_TASK_TYPE,
+      description: "sweep the codebase",
+      status: args.status,
+      taskStatus: args.status === "pending" ? "running" : "completed",
+      skipTranscript: false,
+      workflowName: "sweep",
+      parentToolCallId: WORKFLOW_CALL_ID,
+      workflow: {
+        phases: [{ index: 1, title: "Find" }],
+        agents: [
+          {
+            index: 1,
+            label: "find:boot",
+            state: "running",
+            model: "gpt-5",
+            attempt: 1,
+            cached: false,
+            lastProgressAt: 1,
+            promptPreview: "x".repeat(args.padding),
+          },
+        ],
+      },
+    },
+  });
+}
+
+/**
+ * Turn 1: user asks, agent starts a Workflow tool call (a local_workflow
+ * background task), reports back, and the turn completes. The workflow keeps
+ * running and streams thread-scoped progress snapshots long after turn 1
+ * completed. Turn 2 is a provider-opened turn that is still pending.
+ */
+function seedWorkflowThread(
+  db: DbConnection,
+  thread: Thread,
+  options: {
+    /** Large completed command items in the pending turn 2. */
+    pendingTurnItems?: number;
+    snapshotCount: number;
+  },
+): void {
+  const events: EventInput[] = [];
+  let sequence = 0;
+  const push = (event: Omit<EventInput, "sequence" | "threadId">): void => {
+    sequence += 1;
+    events.push({ ...event, sequence, threadId: thread.id });
+  };
+  const clientRequestId = encodeClientTurnRequestIdNumber({ value: 1 });
+  push({
+    type: "client/turn/requested",
+    scope: threadScope(),
+    itemId: null,
+    itemKind: null,
+    data: JSON.stringify({
+      direction: "outbound",
+      source: "tell",
+      initiator: "user",
+      request: { method: "turn/start", params: {} },
+      requestId: clientRequestId,
+      senderThreadId: null,
+      input: [{ type: "text", text: "Sweep the codebase", mentions: [] }],
+      target: { kind: "thread-start" },
+      execution,
+    }),
+  });
+  push({
+    type: "turn/started",
+    scope: turnScope("turn-1"),
+    providerThreadId,
+    itemId: null,
+    itemKind: null,
+    data: JSON.stringify({}),
+  });
+  push({
+    type: "turn/input/accepted",
+    scope: turnScope("turn-1"),
+    providerThreadId,
+    itemId: null,
+    itemKind: null,
+    data: JSON.stringify({ clientRequestId }),
+  });
+  push({
+    type: "item/started",
+    scope: turnScope("turn-1"),
+    providerThreadId,
+    itemId: WORKFLOW_CALL_ID,
+    itemKind: "toolCall",
+    data: JSON.stringify({
+      providerThreadId,
+      item: {
+        type: "toolCall",
+        id: WORKFLOW_CALL_ID,
+        tool: "Workflow",
+        arguments: { script: "export const meta = {}" },
+        status: "pending",
+      },
+    }),
+  });
+  push({
+    type: "item/started",
+    scope: turnScope("turn-1"),
+    providerThreadId,
+    itemId: WORKFLOW_TASK_ID,
+    itemKind: "backgroundTask",
+    data: workflowTaskData({ status: "pending", padding: 0 }),
+  });
+  push({
+    type: "item/completed",
+    scope: turnScope("turn-1"),
+    providerThreadId,
+    itemId: WORKFLOW_CALL_ID,
+    itemKind: "toolCall",
+    data: JSON.stringify({
+      providerThreadId,
+      item: {
+        type: "toolCall",
+        id: WORKFLOW_CALL_ID,
+        tool: "Workflow",
+        arguments: { script: "export const meta = {}" },
+        result: "started",
+        status: "completed",
+      },
+    }),
+  });
+  push({
+    type: "item/completed",
+    scope: turnScope("turn-1"),
+    providerThreadId,
+    itemId: "assistant-1",
+    itemKind: "agentMessage",
+    data: JSON.stringify({
+      providerThreadId,
+      item: {
+        type: "agentMessage",
+        id: "assistant-1",
+        text: "The workflow will notify me when it completes.",
+        status: "completed",
+      },
+    }),
+  });
+  push({
+    type: "turn/completed",
+    scope: turnScope("turn-1"),
+    providerThreadId,
+    itemId: null,
+    itemKind: null,
+    data: JSON.stringify({ status: "completed", providerThreadId }),
+  });
+  push({
+    type: "turn/started",
+    scope: turnScope("turn-2"),
+    providerThreadId,
+    itemId: null,
+    itemKind: null,
+    data: JSON.stringify({}),
+  });
+  for (let index = 0; index < (options.pendingTurnItems ?? 0); index += 1) {
+    const itemId = `turn-2-item-${index}`;
+    const command = "x".repeat(25_000);
+    push({
+      type: "item/started",
+      scope: turnScope("turn-2"),
+      providerThreadId,
+      itemId,
+      itemKind: "commandExecution",
+      data: JSON.stringify({
+        item: {
+          type: "commandExecution",
+          id: itemId,
+          command,
+          cwd: "/tmp/test",
+          status: "pending",
+          approvalStatus: null,
+        },
+      }),
+    });
+    push({
+      type: "item/completed",
+      scope: turnScope("turn-2"),
+      providerThreadId,
+      itemId,
+      itemKind: "commandExecution",
+      data: JSON.stringify({
+        item: {
+          type: "commandExecution",
+          id: itemId,
+          command,
+          cwd: "/tmp/test",
+          status: "completed",
+          approvalStatus: null,
+          exitCode: 0,
+          aggregatedOutput: `output ${index}`,
+        },
+      }),
+    });
+  }
+  for (let index = 0; index < options.snapshotCount; index += 1) {
+    push({
+      type: "item/backgroundTask/progress",
+      scope: threadScope(),
+      providerThreadId,
+      itemId: WORKFLOW_TASK_ID,
+      itemKind: "backgroundTask",
+      data: workflowTaskData({ status: "pending", padding: SNAPSHOT_BYTES }),
+    });
+  }
+  insertEvents(db, noopNotifier, events);
+}
+
+function buildPage(
+  db: DbConnection,
+  thread: Thread,
+  cursor: TimelinePaginationCursor | null,
+) {
+  return buildThreadTimelineWithProfile(db, thread, {
+    eventBudget: LARGE_BUDGET,
+    includeProviderUnhandledOperations: false,
+    includeNestedRows: false,
+    maxInlineOutputChars: 32_000,
+    maxSeq: 0,
+    page: cursor
+      ? { kind: "older", beforeCursor: cursor, segmentLimit: 20 }
+      : { kind: "latest", segmentLimit: 20 },
+  });
+}
+
+interface WalkResult {
+  maxEventDataBytes: number;
+  pages: number;
+  rows: TimelineRow[];
+}
+
+function walkAllPages(db: DbConnection, thread: Thread): WalkResult {
+  const rowsByPage: TimelineRow[][] = [];
+  let cursor: TimelinePaginationCursor | null = null;
+  let maxEventDataBytes = 0;
+  let pages = 0;
+  for (;;) {
+    const { profile, response } = buildPage(db, thread, cursor);
+    pages += 1;
+    maxEventDataBytes = Math.max(maxEventDataBytes, profile.eventDataBytes);
+    rowsByPage.push(response.rows);
+    if (!response.timelinePage.hasOlderRows) {
+      break;
+    }
+    cursor = response.timelinePage.olderCursor;
+    expect(cursor).not.toBeNull();
+    expect(pages).toBeLessThan(50);
+  }
+  return { maxEventDataBytes, pages, rows: rowsByPage.reverse().flat() };
+}
+
+describe("workflow progress snapshots across timeline pages", () => {
+  it("renders the spawning turn's summary once, not once per byte page", () => {
+    const { db, thread } = setup();
+    seedWorkflowThread(db, thread, { snapshotCount: SNAPSHOT_COUNT });
+    expect(SNAPSHOT_BYTES * SNAPSHOT_COUNT).toBeGreaterThan(
+      THREAD_TIMELINE_EVENT_DATA_BYTE_LIMIT * 2,
+    );
+
+    const walk = walkAllPages(db, thread);
+    const turnRows = walk.rows.filter(
+      (row): row is Extract<TimelineRow, { kind: "turn" }> =>
+        row.kind === "turn",
+    );
+    const turnOneRows = turnRows.filter((row) => row.turnId === "turn-1");
+
+    // One finished turn, one "Worked for" row — whatever the paging did.
+    expect(turnOneRows.map((row) => row.id)).toHaveLength(1);
+    // And no page ever emits a finished-turn row that lies entirely outside
+    // the events that page actually covers.
+    expect(new Set(turnRows.map((row) => row.id)).size).toBe(turnRows.length);
+  });
+
+  it("does not emit the spawning turn's summary on byte pages of a later turn", () => {
+    const { db, thread } = setup();
+    // Turn 2 is pending and large enough to page by bytes. The workflow's
+    // single latest snapshot sits at the tail, so the latest page carries it
+    // (and its parentToolCallId, which names the Workflow call in turn 1).
+    seedWorkflowThread(db, thread, { pendingTurnItems: 250, snapshotCount: 1 });
+
+    const walk = walkAllPages(db, thread);
+    expect(walk.pages).toBeGreaterThan(2);
+    const turnOneRows = walk.rows.filter(
+      (row) => row.kind === "turn" && row.turnId === "turn-1",
+    );
+    expect(turnOneRows.map((row) => row.id)).toHaveLength(1);
+    // The one summary is on the page that holds turn 1's own events.
+    expect(turnOneRows[0]?.sourceSeqStart).toBeLessThan(10);
+    // Turn 2 is pending: no summary row for it, only its command rows.
+    expect(
+      walk.rows.filter((row) => row.kind === "turn" && row.turnId === "turn-2"),
+    ).toHaveLength(0);
+    // The workflow banner still comes from the latest snapshot.
+    const latest = buildPage(db, thread, null);
+    expect(latest.response.activeWorkflows).toHaveLength(1);
+  }, 15_000);
+
+  it("does not spend the byte budget on superseded progress snapshots", () => {
+    const { db, thread } = setup();
+    seedWorkflowThread(db, thread, { snapshotCount: SNAPSHOT_COUNT });
+
+    const latest = buildPage(db, thread, null);
+    // Only the latest snapshot per task is load-bearing (see
+    // pruneBackgroundTaskProgressEvents), so the whole thread fits one page.
+    expect(latest.response.timelinePage.hasOlderRows).toBe(false);
+    expect(latest.profile.eventDataBytes).toBeLessThan(SNAPSHOT_BYTES * 3);
+    expect(latest.response.activeWorkflows).toHaveLength(1);
+    expect(
+      latest.response.rows.filter((row) => row.kind === "turn"),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -113,6 +113,28 @@ const isNotNestedTurnUsageEvent = sql`NOT EXISTS (
     AND COALESCE(json_extract(nested_turn_started.data, '$.parentToolCallId'), '') <> ''
 )`;
 
+/**
+ * A background-task progress row that a later progress or completed row for
+ * the same item supersedes. Each snapshot carries the full task state (a
+ * workflow snapshot with hundreds of agents is hundreds of KB), consumers
+ * replace rather than merge, and `pruneBackgroundTaskProgressEvents` deletes
+ * superseded rows on its own cadence. Timeline reads skip them so a burst of
+ * snapshots between prunes cannot spend the page byte budget on rows that
+ * project to nothing.
+ */
+const isNotSupersededBackgroundTaskProgress = sql`NOT (
+  ${events.type} = 'item/backgroundTask/progress'
+  AND EXISTS (
+    SELECT 1
+    FROM events AS newer_task_state
+    WHERE newer_task_state.thread_id = ${events.threadId}
+      AND newer_task_state.item_kind = 'backgroundTask'
+      AND newer_task_state.item_id = ${events.itemId}
+      AND newer_task_state.type IN ('item/backgroundTask/progress', 'item/backgroundTask/completed')
+      AND newer_task_state.sequence > ${events.sequence}
+  )
+)`;
+
 export interface InsertEventInput {
   threadId: string;
   environmentId?: string | null;
@@ -1520,6 +1542,7 @@ function storedEventRowsByParentToolCallIdsConditions(
       inArray(eventParentToolCallId, parentToolCallIds),
       inArray(itemParentToolCallId, parentToolCallIds),
     )!,
+    isNotSupersededBackgroundTaskProgress,
   ];
   if (args.excludedTypes && args.excludedTypes.length > 0) {
     conditions.push(notInArray(events.type, [...args.excludedTypes]));
@@ -2467,18 +2490,18 @@ export function listRecentStoredEventRows(
   db: DbConnection,
   args: ListRecentStoredEventRowsArgs,
 ): StoredEventRow[] {
-  const condition =
-    args.excludedTypes && args.excludedTypes.length > 0
-      ? and(
-          eq(events.threadId, args.threadId),
-          notInArray(events.type, [...args.excludedTypes]),
-        )
-      : eq(events.threadId, args.threadId);
+  const conditions: SQL[] = [
+    eq(events.threadId, args.threadId),
+    isNotSupersededBackgroundTaskProgress,
+  ];
+  if (args.excludedTypes && args.excludedTypes.length > 0) {
+    conditions.push(notInArray(events.type, [...args.excludedTypes]));
+  }
 
   return db
     .select(storedEventRowFieldsWithInlineOutputLimit(args.maxInlineOutputChars))
     .from(events)
-    .where(condition)
+    .where(and(...conditions))
     .orderBy(events.sequence)
     .all();
 }
@@ -2635,7 +2658,10 @@ export function findTimelineWindowBudgetFloorSequence(
   db: DbConnection,
   args: FindTimelineWindowBudgetFloorSequenceArgs,
 ): number | undefined {
-  const conditions: SQL[] = [eq(events.threadId, args.threadId)];
+  const conditions: SQL[] = [
+    eq(events.threadId, args.threadId),
+    isNotSupersededBackgroundTaskProgress,
+  ];
   if (args.excludedTypes.length > 0) {
     conditions.push(notInArray(events.type, [...args.excludedTypes]));
   }
@@ -2831,6 +2857,7 @@ function storedTimelineWindowConditions(
   const conditions: SQL[] = [
     eq(events.threadId, args.threadId),
     gte(events.sequence, args.sequenceStart),
+    isNotSupersededBackgroundTaskProgress,
   ];
   if (args.beforeSequence !== undefined) {
     conditions.push(lt(events.sequence, args.beforeSequence));

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -1536,13 +1536,17 @@ function storedEventRowsByParentToolCallIdsConditions(
 
   const eventParentToolCallId = sql<string>`json_extract(${events.data}, '$.parentToolCallId')`;
   const itemParentToolCallId = sql<string>`json_extract(${events.data}, '$.item.parentToolCallId')`;
+  // The snapshot check goes before the JSON parent tests: it is a type
+  // comparison for most rows and an indexed probe for progress rows, while
+  // each `json_extract` parses the whole payload — hundreds of KB for a
+  // workflow snapshot. SQLite evaluates these terms in order.
   const conditions: SQL[] = [
     eq(events.threadId, args.threadId),
+    isNotSupersededBackgroundTaskProgress,
     or(
       inArray(eventParentToolCallId, parentToolCallIds),
       inArray(itemParentToolCallId, parentToolCallIds),
     )!,
-    isNotSupersededBackgroundTaskProgress,
   ];
   if (args.excludedTypes && args.excludedTypes.length > 0) {
     conditions.push(notInArray(events.type, [...args.excludedTypes]));
@@ -2570,6 +2574,7 @@ export function listStoredConversationOutlineEventRows(
         eq(events.threadId, args.threadId),
         inArray(events.type, structuralItemLifecycleTypes),
         inArray(events.itemKind, structuralItemKinds),
+        isNotSupersededBackgroundTaskProgress,
       ),
     );
 

--- a/packages/db/test/data/events.test.ts
+++ b/packages/db/test/data/events.test.ts
@@ -19,6 +19,7 @@ import {
   appendStoredThreadEventsInTransaction,
   findStoredEventRow,
   findStoredTimelineWindowByteBudgetFloor,
+  findTimelineWindowBudgetFloorSequence,
   getActiveStoredTurnId,
   getHighWaterMarks,
   getLastStoredProviderThreadId,
@@ -32,6 +33,7 @@ import {
   listEvents,
   listLatestGoalEventRowsByThreadIds,
   listRecentStoredEventRows,
+  listStoredConversationOutlineEventRows,
   listTimelineSegmentAnchorsDescending,
   findTimelineSegmentAnchorSequenceAfter,
   getTimelineSegmentAnchorAtSequence,
@@ -1574,6 +1576,28 @@ describe("events", () => {
         threadId: thread.id,
       }).reduce((bytes, row) => bytes + Buffer.byteLength(row.data), 0),
     );
+    // The event-count floor counts the same rows: a budget of 2 lands on the
+    // second-newest surviving row (6), not on a superseded snapshot (5).
+    expect(
+      findTimelineWindowBudgetFloorSequence(db, {
+        eventBudget: 2,
+        excludedTypes: [],
+        threadId: thread.id,
+      }),
+    ).toBe(2);
+    expect(
+      findTimelineWindowBudgetFloorSequence(db, {
+        eventBudget: 1,
+        excludedTypes: [],
+        threadId: thread.id,
+      }),
+    ).toBe(6);
+    // The conversation outline reads the structural task rows too.
+    expect(
+      listStoredConversationOutlineEventRows(db, {
+        threadId: thread.id,
+      }).map((row) => row.sequence),
+    ).toEqual([1, 2, 6, 7]);
   });
 
   it("lists accepted input rows for requested client turn sequences", () => {

--- a/packages/db/test/data/events.test.ts
+++ b/packages/db/test/data/events.test.ts
@@ -1461,6 +1461,121 @@ describe("events", () => {
     ).toEqual([2, 3]);
   });
 
+  it("skips superseded backgroundTask progress snapshots in timeline reads", () => {
+    const { db, thread } = setup();
+
+    const taskData = (id: string, status: "pending" | "completed") =>
+      JSON.stringify({
+        item: {
+          id,
+          type: "backgroundTask",
+          taskType: "local_workflow",
+          description: "fixture workflow",
+          status,
+          taskStatus: status === "pending" ? "running" : "completed",
+          skipTranscript: false,
+        },
+      });
+    const progress = (sequence: number, itemId: string) => ({
+      threadId: thread.id,
+      sequence,
+      scope: threadScope(),
+      type: "item/backgroundTask/progress" as const,
+      itemId,
+      itemKind: "backgroundTask" as const,
+      data: taskData(itemId, "pending"),
+    });
+
+    insertEvents(db, noopNotifier, [
+      {
+        threadId: thread.id,
+        sequence: 1,
+        scope: turnScope("turn-1"),
+        type: "item/started",
+        itemId: "task:wf-1",
+        itemKind: "backgroundTask",
+        data: taskData("task:wf-1", "pending"),
+      },
+      {
+        threadId: thread.id,
+        sequence: 2,
+        scope: turnScope("turn-1"),
+        type: "item/started",
+        itemId: "task:wf-2",
+        itemKind: "backgroundTask",
+        data: taskData("task:wf-2", "pending"),
+      },
+      // wf-1: 3 and 4 are superseded by 6; wf-2: 5 is superseded by the
+      // completed row at 7, which is not a progress row and stays.
+      progress(3, "task:wf-1"),
+      progress(4, "task:wf-1"),
+      progress(5, "task:wf-2"),
+      progress(6, "task:wf-1"),
+      {
+        threadId: thread.id,
+        sequence: 7,
+        scope: threadScope(),
+        type: "item/backgroundTask/completed",
+        itemId: "task:wf-2",
+        itemKind: "backgroundTask",
+        data: taskData("task:wf-2", "completed"),
+      },
+    ]);
+
+    expect(
+      listStoredTimelineWindowEventRows(db, {
+        maxInlineOutputChars: null,
+        sequenceStart: 1,
+        threadId: thread.id,
+      }).map((row) => row.sequence),
+    ).toEqual([1, 2, 6, 7]);
+    // A window that ends before the superseding row still skips the
+    // superseded ones: the timeline only ever needs the newest snapshot.
+    expect(
+      listStoredTimelineWindowEventRows(db, {
+        beforeSequence: 6,
+        maxInlineOutputChars: null,
+        sequenceStart: 1,
+        threadId: thread.id,
+      }).map((row) => row.sequence),
+    ).toEqual([1, 2]);
+    expect(
+      listRecentStoredEventRows(db, {
+        maxInlineOutputChars: null,
+        threadId: thread.id,
+      }).map((row) => row.sequence),
+    ).toEqual([1, 2, 6, 7]);
+    // The byte floor walks the same rows the window read returns.
+    expect(
+      findStoredTimelineWindowByteBudgetFloor(db, {
+        maxDataBytes: 1_000_000,
+        maxInlineOutputChars: null,
+        sequenceStart: 1,
+        threadId: thread.id,
+      }),
+    ).toEqual({
+      eventDataBytes: getStoredTimelineWindowEventDataBytes(db, {
+        maxInlineOutputChars: null,
+        sequenceStart: 1,
+        threadId: thread.id,
+      }),
+      kind: "fits",
+    });
+    expect(
+      getStoredTimelineWindowEventDataBytes(db, {
+        maxInlineOutputChars: null,
+        sequenceStart: 1,
+        threadId: thread.id,
+      }),
+    ).toBe(
+      listStoredTimelineWindowEventRows(db, {
+        maxInlineOutputChars: null,
+        sequenceStart: 1,
+        threadId: thread.id,
+      }).reduce((bytes, row) => bytes + Buffer.byteLength(row.data), 0),
+    );
+  });
+
   it("lists accepted input rows for requested client turn sequences", () => {
     const { db, thread } = setup();
 

--- a/packages/db/test/query-plans.test.ts
+++ b/packages/db/test/query-plans.test.ts
@@ -380,44 +380,60 @@ describe("slow query index plans", () => {
   });
 
   it("uses selective indexes for conversation-outline events", () => {
-    const { db, logger, thread } = setup();
+    const { db, thread } = setup();
 
-    listStoredConversationOutlineEventRows(db, { threadId: thread.id });
-
-    const debugLog = findOnlyDebugLog({
-      logger,
-      predicate: (fields) =>
-        fields.operation === "all" && fields.sql.includes('from "events"'),
+    // The slow-query log truncates this union past 1,000 chars; capture the
+    // statement itself.
+    const captured = captureStatements(db, () => {
+      listStoredConversationOutlineEventRows(db, { threadId: thread.id });
     });
-    assertEmittedQueryPlanUsesIndex({
+    const outline = captured.filter((query) =>
+      query.sql.includes('from "events"'),
+    );
+    expect(outline).toHaveLength(1);
+    const [query] = outline;
+    expect(query?.params).toEqual([
+      thread.id,
+      "client/turn/requested",
+      "turn/input/accepted",
+      "turn/started",
+      "turn/completed",
+      "system/manager/user_message",
+      "system/thread/interrupted",
+      "system/error",
+      "provider/error",
+      "item/agentMessage/delta",
+      "item/plan/delta",
+      thread.id,
+      "item/completed",
+      "agentMessage",
+      "plan",
+      thread.id,
+      "item/started",
+      "item/completed",
+      "item/backgroundTask/progress",
+      "item/backgroundTask/completed",
+      "backgroundTask",
+      "toolCall",
+    ]);
+    const details = queryPlanDetails({
       db,
-      debugLog,
-      indexName: "events_thread_type_item_kind_sequence_idx",
-      params: [
-        thread.id,
-        "client/turn/requested",
-        "turn/input/accepted",
-        "turn/started",
-        "turn/completed",
-        "system/manager/user_message",
-        "system/thread/interrupted",
-        "system/error",
-        "provider/error",
-        "item/agentMessage/delta",
-        "item/plan/delta",
-        thread.id,
-        "item/completed",
-        "agentMessage",
-        "plan",
-        thread.id,
-        "item/started",
-        "item/completed",
-        "item/backgroundTask/progress",
-        "item/backgroundTask/completed",
-        "backgroundTask",
-        "toolCall",
-      ],
+      params: query?.params ?? [],
+      sql: query?.sql ?? "",
     });
+    // Each union branch stays on a thread/type index (the lifecycle branch has
+    // no item kind); the superseded-snapshot check on the structural branch
+    // probes the background-task partial index instead of scanning.
+    expect(
+      details.match(/USING INDEX events_thread_type_sequence_idx/gu),
+    ).toHaveLength(1);
+    expect(
+      details.match(/USING INDEX events_thread_type_item_kind_sequence_idx/gu),
+    ).toHaveLength(2);
+    expect(details).toMatch(
+      /USING COVERING INDEX events_background_task_thread_type_item_sequence_idx/u,
+    );
+    expect(details).not.toMatch(/SCAN events/u);
 
     db.$client.close();
   });


### PR DESCRIPTION
## What was wrong

A thread whose finished turn started a long-running `Workflow` stacked the same `Worked for 7m 19s` row six or seven times above `Working…` and paged in through "Loading older messages…" (#1868, report: https://get-bb.github.io/reports/issues/1868.html). Two causes combine. (1) Every `item/backgroundTask/progress` row carries the full workflow snapshot (~250 KB with 206 agents). Only the newest snapshot per task is load-bearing and `pruneBackgroundTaskProgressEvents` deletes the rest, but only every 250 sequences / 30 s, so between prunes 100+ snapshots (25 MB+) sat above the 4 MiB `THREAD_TIMELINE_EVENT_DATA_BYTE_LIMIT` and the thread was cut into byte pages that held nothing but superseded snapshots. (2) The snapshots name the `Workflow` tool call in the finished spawning turn as `parentToolCallId`; on each byte page, parent closure pulled that tool call in, turn lifecycle closure added the turn's `turn/started`/`turn/completed`, byte-window mode clears `contextOnlyToolCallIds`, and `buildSequencePageTimelineRows` returned the resulting turn row verbatim (its range lies entirely below the window, so the clamp did not apply) under a page-unique `:sequence-page:<anchor>` id. The client keeps one row per id, so every page added another `Worked for`.

## What changed

- `packages/db/src/data/events.ts`: a shared predicate `isNotSupersededBackgroundTaskProgress` (same rule as the pruner: a progress row with a later progress or completed row for the same item) is applied to the timeline reads that decide and materialize a window: `storedTimelineWindowConditions` (byte floor, byte count, window rows), `findTimelineWindowBudgetFloorSequence`, `listRecentStoredEventRows` (full read), and `storedEventRowsByParentToolCallIdsConditions` (parent-child closure). The subquery uses the existing partial index `events_background_task_thread_type_item_sequence_idx` (covering).
- `apps/server/src/services/threads/timeline.ts` `buildSequencePageTimelineRows`: on byte pages, a finished-turn row whose source range does not intersect the window is dropped instead of emitted verbatim; the page that holds the turn's own events renders its summary.
- No wire changes; no CLI/doc changes.

## How you verified

- New `apps/server/test/services/threads/timeline-workflow-progress-window.test.ts` (3 tests): the spawning turn's summary appears once across pages; byte pages of a large later turn do not emit it; superseded snapshots do not spend the byte budget (`hasOlderRows: false`, one page). Each half fails on `main` without its fix (`4 turn rows` / `2 turn rows` / `hasOlderRows true`).
- New db test in `packages/db/test/data/events.test.ts`: window read, full read, byte floor and byte count agree and keep only the newest snapshot per task while keeping the completed row and other items.
- `pnpm exec turbo run test --filter=@bb/db --filter=@bb/server`: db 391/391; server 1732/1733 — the one failure is `test/internal/internal-skill-trees.test.ts`, which also fails on the pristine tree (known local file-mode failure). `pnpm exec turbo run typecheck --filter=@bb/db --filter=@bb/server` clean.
- Manual: imported `thr_7wvd28jzpj` (with 125 synthesized 262 KB snapshots, 33 MB) into a dev instance. Before: latest page = 1 phantom turn row + 7 byte pages; after: one page, 7 rows, the two real `Worked for` segments, workflow banner intact; the timeline read shrinks from 259 rows / 33 MB to 135 rows / 475 KB. `EXPLAIN QUERY PLAN` shows the covering partial index for the correlated subquery.

Fixes #1868

> AGENT GENERATED: by Claude Opus 5
