### PR TITLE
Add host-owned SourceCode and Diff rendering for the app and plugins

### DIFF
--- a/apps/app/src/components/code/BbDiff.test.tsx
+++ b/apps/app/src/components/code/BbDiff.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defaultResolvedCodeTheme } from "@bb/domain";
+import { applyResolvedCodeTheme } from "@/lib/code-theme";
+import { parseGitDiffFiles } from "@/components/git-diff/git-diff-parsing";
+import { BbDiff } from "./BbDiff";
+
+interface RenderedOptions {
+  theme: { dark: string; light: string };
+  diffStyle: string;
+  overflow: string;
+  disableLineNumbers: boolean;
+  disableFileHeader: boolean;
+}
+
+const pierre = vi.hoisted(() => ({
+  lastOptions: null as RenderedOptions | null,
+}));
+
+vi.mock("@pierre/diffs/react", async () => {
+  const React = await import("react");
+  return {
+    FileDiff: ({ options }: { options: RenderedOptions }) => {
+      pierre.lastOptions = options;
+      return React.createElement("div", { "data-testid": "pierre-file-diff" });
+    },
+  };
+});
+
+const PATCH = [
+  "diff --git a/src/app.ts b/src/app.ts",
+  "--- a/src/app.ts",
+  "+++ b/src/app.ts",
+  "@@ -1,2 +1,2 @@",
+  "-const b = 2;",
+  "+const b = 3;",
+  "",
+].join("\n");
+
+function fixture() {
+  const file = parseGitDiffFiles(PATCH)[0];
+  if (file === undefined) throw new Error("fixture patch did not parse");
+  return file;
+}
+
+beforeEach(() => {
+  pierre.lastOptions = null;
+  applyResolvedCodeTheme(defaultResolvedCodeTheme);
+});
+
+afterEach(() => {
+  cleanup();
+  applyResolvedCodeTheme(defaultResolvedCodeTheme);
+  vi.restoreAllMocks();
+});
+
+describe("BbDiff", () => {
+  it("follows the resolved code theme without any consumer watching the DOM", async () => {
+    render(
+      <BbDiff
+        file={fixture()}
+        view="unified"
+        overflow="scroll"
+        showLineNumbers
+      />,
+    );
+    await screen.findByTestId("pierre-file-diff");
+    expect(pierre.lastOptions?.theme.dark).toBe(defaultResolvedCodeTheme.dark);
+
+    act(() => {
+      applyResolvedCodeTheme({
+        dark: "custom-dark",
+        light: "custom-light",
+        files: {},
+      });
+    });
+
+    expect(pierre.lastOptions?.theme).toEqual({
+      dark: "custom-dark",
+      light: "custom-light",
+    });
+  });
+
+  it("maps semantic presentation onto the renderer's options", async () => {
+    render(
+      <BbDiff
+        file={fixture()}
+        view="split"
+        overflow="wrap"
+        showLineNumbers={false}
+      />,
+    );
+    await screen.findByTestId("pierre-file-diff");
+
+    expect(pierre.lastOptions?.diffStyle).toBe("split");
+    expect(pierre.lastOptions?.overflow).toBe("wrap");
+    expect(pierre.lastOptions?.disableLineNumbers).toBe(true);
+    // The card header owns the file name; the renderer must never draw a second.
+    expect(pierre.lastOptions?.disableFileHeader).toBe(true);
+  });
+});

--- a/apps/app/src/components/code/BbDiff.test.tsx
+++ b/apps/app/src/components/code/BbDiff.test.tsx
@@ -13,6 +13,7 @@ interface RenderedOptions {
   overflow: string;
   disableLineNumbers: boolean;
   disableFileHeader: boolean;
+  expansionLineCount?: number;
 }
 
 const pierre = vi.hoisted(() => ({
@@ -81,6 +82,40 @@ describe("BbDiff", () => {
       dark: "custom-dark",
       light: "custom-light",
     });
+  });
+
+  it("omits the expansion budget unless the caller can supply file contents", async () => {
+    // pierre renders an EMPTY diff when it is handed an expansion budget for a
+    // hunk-only patch — which is exactly what timeline file-change rows carry,
+    // since they have no way to fetch the full file. Sending the option
+    // unconditionally blanked every timeline diff.
+    render(
+      <BbDiff
+        file={fixture()}
+        view="unified"
+        overflow="scroll"
+        showLineNumbers
+      />,
+    );
+    await screen.findByTestId("pierre-file-diff");
+
+    expect(pierre.lastOptions).not.toBeNull();
+    expect("expansionLineCount" in (pierre.lastOptions ?? {})).toBe(false);
+  });
+
+  it("passes the expansion budget through when the caller supplies one", async () => {
+    render(
+      <BbDiff
+        file={fixture()}
+        view="unified"
+        overflow="scroll"
+        showLineNumbers
+        expansionLineCount={30}
+      />,
+    );
+    await screen.findByTestId("pierre-file-diff");
+
+    expect(pierre.lastOptions?.expansionLineCount).toBe(30);
   });
 
   it("maps semantic presentation onto the renderer's options", async () => {

--- a/apps/app/src/components/code/BbDiff.tsx
+++ b/apps/app/src/components/code/BbDiff.tsx
@@ -1,0 +1,150 @@
+import { useCallback, useMemo, useRef, type CSSProperties } from "react";
+import type { FileDiffOptions, SelectedLineRange } from "@pierre/diffs";
+import { FileDiff as DiffView } from "@pierre/diffs/react";
+import { usePierreLineSelectionActions } from "@/components/git-diff/PierreLineSelectionActions.js";
+import { PierreWorkerPoolBoundary } from "@/lib/pierre-worker-pool-boundary";
+import { useRequirePierreWorkerPool } from "@/lib/pierre-worker-pool-gate";
+import {
+  buildDiffDomSelectionText,
+  buildDiffLineSelectionText,
+} from "@/components/git-diff/git-diff-patch-text";
+import { useResolvedCodeThemePair } from "@/lib/code-theme";
+import { usePreferredTheme } from "@/hooks/useTheme";
+import { Skeleton } from "@bb/shared-ui/skeleton";
+import { cn } from "@bb/shared-ui/lib/utils";
+import type { BbDiffProps } from "./code-rendering";
+
+const DIFF_VIEW_STYLE = {
+  "--diffs-font-size": "12px",
+  "--diffs-line-height": "18px",
+} as CSSProperties;
+
+/**
+ * Reveal 30 unchanged lines per expand-up / expand-down click. The library
+ * default is 100 — too aggressive for our compact diff cards. The controls
+ * only appear once a caller has attached full file contents to the parsed
+ * file, so surfaces without a content fetcher never show them.
+ */
+const EXPANSION_LINE_COUNT = 30;
+
+function BbDiffSkeleton() {
+  return (
+    <div className="space-y-1.5 px-3 py-3">
+      <Skeleton className="h-3 w-full rounded-sm" />
+      <Skeleton className="h-3 w-[96%] rounded-sm" />
+      <Skeleton className="h-3 w-[93%] rounded-sm" />
+      <Skeleton className="h-3 w-[90%] rounded-sm" />
+      <Skeleton className="h-3 w-[87%] rounded-sm" />
+      <Skeleton className="h-3 w-[84%] rounded-sm" />
+    </div>
+  );
+}
+
+/**
+ * BB's default diff renderer: the `@pierre/diffs` `FileDiff` plus BB's line
+ * selection menu, resolved code theme, and presentation defaults. Reached only
+ * through {@link import("./DiffHost").DiffHost}, and only lazily — a plugin
+ * that replaces the renderer and never delegates never loads this module.
+ */
+export function BbDiff({
+  file,
+  view,
+  overflow,
+  showLineNumbers,
+  className,
+  onSelectionAddToChat,
+}: BbDiffProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const codeTheme = useResolvedCodeThemePair();
+  const themeType = usePreferredTheme();
+  const buildSelectionText = useCallback(
+    (range: SelectedLineRange) =>
+      buildDiffLineSelectionText({
+        displayStyle: view,
+        fileDiff: file,
+        range,
+      }),
+    [file, view],
+  );
+  const buildFallbackSelectionText = useCallback(
+    ({
+      containerElement,
+    }: {
+      containerElement: HTMLElement | null;
+      range: SelectedLineRange;
+    }) => buildDiffDomSelectionText({ containerElement, fileDiff: file }),
+    [file],
+  );
+  const lineSelectionActions = usePierreLineSelectionActions({
+    buildFallbackSelectionText,
+    buildSelectionText,
+    containerRef,
+    enabled: onSelectionAddToChat !== undefined,
+    onSelectionAddToChat,
+  });
+  const options = useMemo<FileDiffOptions<undefined>>(
+    () => ({
+      diffStyle: view,
+      overflow,
+      disableLineNumbers: !showLineNumbers,
+      // The card's own header owns the file name, path actions, and stats.
+      disableFileHeader: true,
+      expansionLineCount: EXPANSION_LINE_COUNT,
+      themeType,
+      theme: codeTheme,
+      enableGutterUtility: onSelectionAddToChat !== undefined,
+      enableLineSelection: onSelectionAddToChat !== undefined,
+      lineHoverHighlight:
+        onSelectionAddToChat === undefined ? "disabled" : "number",
+      onGutterUtilityClick:
+        onSelectionAddToChat === undefined
+          ? undefined
+          : lineSelectionActions.onGutterUtilityClick,
+      onLineSelectionChange: lineSelectionActions.onLineSelectionChange,
+      onLineSelectionEnd: lineSelectionActions.onLineSelectionEnd,
+      onLineSelectionStart: lineSelectionActions.onLineSelectionStart,
+    }),
+    [
+      codeTheme,
+      lineSelectionActions.onGutterUtilityClick,
+      lineSelectionActions.onLineSelectionChange,
+      lineSelectionActions.onLineSelectionEnd,
+      lineSelectionActions.onLineSelectionStart,
+      onSelectionAddToChat,
+      overflow,
+      showLineNumbers,
+      themeType,
+      view,
+    ],
+  );
+  // `DiffView` captures the worker pool when it creates its instance, so wait
+  // for the workspace to build the pool before the first render. Asking here
+  // rather than in the host keeps the pool unbuilt when a plugin replacement
+  // owns the render and never delegates.
+  const isWorkerPoolReady = useRequirePierreWorkerPool();
+  if (!isWorkerPoolReady) {
+    return <BbDiffSkeleton />;
+  }
+  return (
+    <div
+      ref={containerRef}
+      className={cn("overflow-x-auto", className)}
+      onPointerDownCapture={lineSelectionActions.onPointerDownCapture}
+      onPointerMoveCapture={lineSelectionActions.onPointerMoveCapture}
+      onPointerUpCapture={lineSelectionActions.onPointerUpCapture}
+    >
+      <div className="w-full max-w-full" style={DIFF_VIEW_STYLE}>
+        <PierreWorkerPoolBoundary>
+          <DiffView
+            fileDiff={file}
+            options={options}
+            selectedLines={lineSelectionActions.selectedRange}
+          />
+        </PierreWorkerPoolBoundary>
+      </div>
+      {lineSelectionActions.menu}
+    </div>
+  );
+}
+
+export default BbDiff;

--- a/apps/app/src/components/code/BbDiff.tsx
+++ b/apps/app/src/components/code/BbDiff.tsx
@@ -4,6 +4,7 @@ import { FileDiff as DiffView } from "@pierre/diffs/react";
 import { usePierreLineSelectionActions } from "@/components/git-diff/PierreLineSelectionActions.js";
 import { PierreWorkerPoolBoundary } from "@/lib/pierre-worker-pool-boundary";
 import { useRequirePierreWorkerPool } from "@/lib/pierre-worker-pool-gate";
+import { usePierreStrictModeRecoveryOptions } from "@/lib/pierre-strict-mode-recovery";
 import {
   buildDiffDomSelectionText,
   buildDiffLineSelectionText,
@@ -75,7 +76,7 @@ export function BbDiff({
     enabled: onSelectionAddToChat !== undefined,
     onSelectionAddToChat,
   });
-  const options = useMemo<FileDiffOptions<undefined>>(
+  const baseOptions = useMemo<FileDiffOptions<undefined>>(
     () => ({
       diffStyle: view,
       overflow,
@@ -114,6 +115,7 @@ export function BbDiff({
       view,
     ],
   );
+  const options = usePierreStrictModeRecoveryOptions(baseOptions);
   // `DiffView` captures the worker pool when it creates its instance, so wait
   // for the workspace to build the pool before the first render. Asking here
   // rather than in the host keeps the pool unbuilt when a plugin replacement

--- a/apps/app/src/components/code/BbDiff.tsx
+++ b/apps/app/src/components/code/BbDiff.tsx
@@ -19,14 +19,6 @@ const DIFF_VIEW_STYLE = {
   "--diffs-line-height": "18px",
 } as CSSProperties;
 
-/**
- * Reveal 30 unchanged lines per expand-up / expand-down click. The library
- * default is 100 — too aggressive for our compact diff cards. The controls
- * only appear once a caller has attached full file contents to the parsed
- * file, so surfaces without a content fetcher never show them.
- */
-const EXPANSION_LINE_COUNT = 30;
-
 function BbDiffSkeleton() {
   return (
     <div className="space-y-1.5 px-3 py-3">
@@ -52,6 +44,7 @@ export function BbDiff({
   overflow,
   showLineNumbers,
   className,
+  expansionLineCount,
   onSelectionAddToChat,
 }: BbDiffProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -89,7 +82,10 @@ export function BbDiff({
       disableLineNumbers: !showLineNumbers,
       // The card's own header owns the file name, path actions, and stats.
       disableFileHeader: true,
-      expansionLineCount: EXPANSION_LINE_COUNT,
+      // Only set when the caller can actually supply full file contents:
+      // pierre renders an empty diff when it is handed an expansion budget
+      // for a hunk-only patch, which is what the timeline supplies.
+      ...(expansionLineCount === undefined ? {} : { expansionLineCount }),
       themeType,
       theme: codeTheme,
       enableGutterUtility: onSelectionAddToChat !== undefined,
@@ -106,6 +102,7 @@ export function BbDiff({
     }),
     [
       codeTheme,
+      expansionLineCount,
       lineSelectionActions.onGutterUtilityClick,
       lineSelectionActions.onLineSelectionChange,
       lineSelectionActions.onLineSelectionEnd,

--- a/apps/app/src/components/code/BbSourceCode.tsx
+++ b/apps/app/src/components/code/BbSourceCode.tsx
@@ -1,0 +1,648 @@
+import {
+  type CSSProperties,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { File as PierreFile, VirtualizerContext } from "@pierre/diffs/react";
+import type { FileOptions } from "@pierre/diffs/react";
+import {
+  DIFFS_TAG_NAME,
+  Virtualizer as PierreVirtualizer,
+  type FileContents as PierreFileContents,
+  type SelectedLineRange,
+  type VirtualFileMetrics,
+} from "@pierre/diffs";
+import { Button } from "@bb/shared-ui/button";
+import { Skeleton } from "@bb/shared-ui/skeleton";
+import { usePierreLineSelectionActions } from "@/components/git-diff/PierreLineSelectionActions.js";
+import { usePreferredTheme } from "@/hooks/useTheme";
+import { useResolvedCodeThemePair } from "@/lib/code-theme";
+import { PierreWorkerPoolBoundary } from "@/lib/pierre-worker-pool-boundary";
+import {
+  usePierreWorkerPool,
+  useRequirePierreWorkerPool,
+} from "@/lib/pierre-worker-pool-gate";
+import { cn } from "@bb/shared-ui/lib/utils";
+import {
+  hashSourceContents,
+  truncateSourceCode,
+  type SourceCodeTruncation,
+} from "./source-code-budget";
+import type { BbSourceCodeProps } from "./code-rendering";
+
+/**
+ * BB's default source renderer: the `@pierre/diffs` `File` view plus BB's line
+ * selection menu, resolved code theme, worker-pool gating, virtualized
+ * scrolling, the large-file rendering budget, and highlighted-line scrolling.
+ *
+ * Reached only through {@link import("./SourceCodeHost").SourceCodeHost}, and
+ * only lazily — a plugin that replaces the renderer and never delegates never
+ * downloads this module or builds the worker pool.
+ */
+
+function BbSourceCodeSkeleton() {
+  return (
+    <div className="space-y-2 px-4 pt-4" aria-busy>
+      <Skeleton className="h-3 w-3/4 rounded-sm" />
+      <Skeleton className="h-3 w-full rounded-sm" />
+      <Skeleton className="h-3 w-5/6 rounded-sm" />
+      <Skeleton className="h-3 w-2/3 rounded-sm" />
+      <Skeleton className="h-3 w-full rounded-sm" />
+      <Skeleton className="h-3 w-3/5 rounded-sm" />
+    </div>
+  );
+}
+
+interface SourceCodeWorkerPoolStats {
+  managerState: "waiting" | "initializing" | "initialized";
+  workersFailed: boolean;
+  totalWorkers: number;
+  busyWorkers: number;
+  queuedTasks: number;
+  activeTasks: number;
+  themeSubscribers: number;
+  fileCacheSize: number;
+  diffCacheSize: number;
+}
+
+const SOURCE_LINE_HEIGHT_PX = 18;
+const SOURCE_GAP_BLOCK_PX = 16;
+
+const SOURCE_VIEW_STYLE = {
+  "--diffs-font-size": "12px",
+  "--diffs-line-height": `${SOURCE_LINE_HEIGHT_PX}px`,
+  // Pierre paints its theme bg inside this gap, so the top breathing room of
+  // the code body lives on Pierre's bg — not on the panel's bg-background.
+  // Without this, the gap above Pierre would show a visible bg-color seam.
+  "--diffs-gap-block": `${SOURCE_GAP_BLOCK_PX}px`,
+} as CSSProperties;
+
+// Pierre's virtualizer estimates row positions from these before it measures
+// them; they mirror the CSS variables above so the first layout guess is exact
+// in `scroll` overflow mode (fixed-height rows) and close in `wrap` mode.
+const SOURCE_VIRTUAL_FILE_METRICS: VirtualFileMetrics = {
+  hunkLineCount: 50,
+  lineHeight: SOURCE_LINE_HEIGHT_PX,
+  diffHeaderHeight: 0,
+  spacing: SOURCE_GAP_BLOCK_PX,
+};
+
+function getTargetRoots(container: HTMLElement): ParentNode[] {
+  const roots: ParentNode[] = [container];
+  // Pierre owns its rendered line elements inside an open shadow root, which
+  // normal descendant queries on the React wrapper cannot cross.
+  for (const pierreContainer of container.querySelectorAll<HTMLElement>(
+    DIFFS_TAG_NAME,
+  )) {
+    if (pierreContainer.shadowRoot !== null) {
+      roots.push(pierreContainer.shadowRoot);
+    }
+  }
+  return roots;
+}
+
+function clearTargetLine(container: HTMLElement) {
+  for (const root of getTargetRoots(container)) {
+    const targetLines = root.querySelectorAll(
+      "[data-bb-source-code-target-line]",
+    );
+    for (const targetLine of targetLines) {
+      targetLine.removeAttribute("data-bb-source-code-target-line");
+      targetLine.removeAttribute("data-selected-line");
+    }
+  }
+}
+
+function findTargetLine(
+  container: HTMLElement,
+  lineNumber: number,
+): HTMLElement | null {
+  const roots = getTargetRoots(container);
+  for (const root of roots) {
+    const lines = root.querySelectorAll(`[data-line="${lineNumber}"]`);
+    for (const line of lines) {
+      if (line instanceof HTMLElement && line.dataset.lineIndex !== undefined) {
+        return line;
+      }
+    }
+  }
+  for (const root of roots) {
+    const lines = root.querySelectorAll(`[data-line="${lineNumber}"]`);
+    for (const line of lines) {
+      if (line instanceof HTMLElement) {
+        return line;
+      }
+    }
+  }
+  return null;
+}
+
+function findVirtualizedViewport(
+  container: HTMLElement,
+): HTMLElement | null {
+  return container.querySelector<HTMLElement>(
+    "[data-bb-source-code-viewport]",
+  );
+}
+
+/**
+ * Nudge the virtualized code viewport toward `lineNumber` when that row is not
+ * realized yet. With rendered rows in hand the distance is measured from the
+ * nearest one (rows are at least one line tall, so the step never overshoots
+ * in `wrap` mode); with none rendered the offset is estimated from the fixed
+ * line metrics. Each call moves at most to the estimate; the caller retries on
+ * the next frame once pierre has rendered the new window.
+ */
+function approachVirtualizedTargetLine(
+  container: HTMLElement,
+  lineNumber: number,
+) {
+  const viewport = findVirtualizedViewport(container);
+  if (viewport === null) return;
+  const viewportRect = viewport.getBoundingClientRect();
+  const centerOffset = viewportRect.height / 2;
+  const renderedBounds = getRenderedLineBounds(container);
+  if (renderedBounds === null) {
+    const estimatedTop =
+      SOURCE_GAP_BLOCK_PX +
+      (lineNumber - 1) * SOURCE_LINE_HEIGHT_PX;
+    viewport.scrollTop = Math.max(0, estimatedTop - centerOffset);
+    return;
+  }
+  const { firstLineNumber, firstTop, lastLineNumber, lastBottom } =
+    renderedBounds;
+  if (lineNumber > lastLineNumber) {
+    const distance =
+      lastBottom -
+      viewportRect.top +
+      (lineNumber - lastLineNumber - 1) * SOURCE_LINE_HEIGHT_PX;
+    viewport.scrollTop += Math.max(0, distance - centerOffset);
+  } else if (lineNumber < firstLineNumber) {
+    const distance =
+      viewportRect.top -
+      firstTop +
+      (firstLineNumber - lineNumber) * SOURCE_LINE_HEIGHT_PX;
+    viewport.scrollTop = Math.max(
+      0,
+      viewport.scrollTop - distance - centerOffset,
+    );
+  }
+}
+
+interface RenderedPreviewLineBounds {
+  firstLineNumber: number;
+  firstTop: number;
+  lastLineNumber: number;
+  lastBottom: number;
+}
+
+function getRenderedLineBounds(
+  container: HTMLElement,
+): RenderedPreviewLineBounds | null {
+  let bounds: RenderedPreviewLineBounds | null = null;
+  for (const root of getTargetRoots(container)) {
+    for (const line of root.querySelectorAll<HTMLElement>(
+      "[data-line][data-line-index]",
+    )) {
+      const lineNumber = Number(line.dataset.line);
+      if (!Number.isFinite(lineNumber)) continue;
+      const rect = line.getBoundingClientRect();
+      if (bounds === null) {
+        bounds = {
+          firstLineNumber: lineNumber,
+          firstTop: rect.top,
+          lastLineNumber: lineNumber,
+          lastBottom: rect.bottom,
+        };
+        continue;
+      }
+      if (lineNumber < bounds.firstLineNumber) {
+        bounds.firstLineNumber = lineNumber;
+        bounds.firstTop = rect.top;
+      }
+      if (lineNumber > bounds.lastLineNumber) {
+        bounds.lastLineNumber = lineNumber;
+        bounds.lastBottom = rect.bottom;
+      }
+    }
+  }
+  return bounds;
+}
+
+function findScrollViewport(container: HTMLElement): HTMLElement | null {
+  const virtualizedViewport = findVirtualizedViewport(container);
+  if (virtualizedViewport !== null) {
+    return virtualizedViewport;
+  }
+  const view = container.ownerDocument.defaultView;
+  if (view === null) return null;
+
+  let candidate = container.parentElement;
+  while (candidate !== null) {
+    const overflowY = view.getComputedStyle(candidate).overflowY;
+    if (
+      overflowY === "auto" ||
+      overflowY === "scroll" ||
+      overflowY === "overlay"
+    ) {
+      return candidate;
+    }
+    candidate = candidate.parentElement;
+  }
+  return null;
+}
+
+function scrollTargetLine(container: HTMLElement, line: HTMLElement) {
+  const viewport = findScrollViewport(container);
+  if (viewport === null) return;
+
+  const lineRect = line.getBoundingClientRect();
+  const viewportRect = viewport.getBoundingClientRect();
+  const lineCenter = lineRect.top + lineRect.height / 2;
+  const viewportCenter = viewportRect.top + viewportRect.height / 2;
+  // Adjust only the vertical scroll offset. `scrollIntoView()` can also move
+  // the horizontal axis when a long source line extends beyond the viewport.
+  viewport.scrollTop += lineCenter - viewportCenter;
+}
+
+function formatLineRange(startLineNumber: number, endLineNumber: number) {
+  return startLineNumber === endLineNumber
+    ? String(startLineNumber)
+    : `${startLineNumber}-${endLineNumber}`;
+}
+
+function buildLineSelectionText({
+  contents,
+  path,
+  range,
+}: {
+  contents: string;
+  path: string;
+  range: SelectedLineRange;
+}): string | null {
+  const startLineNumber = Math.max(1, Math.min(range.start, range.end));
+  const endLineNumber = Math.max(
+    startLineNumber,
+    Math.max(range.start, range.end),
+  );
+  const lines = contents.split(/\r\n|\n|\r/);
+  const selectedLines = lines.slice(startLineNumber - 1, endLineNumber);
+  if (selectedLines.length === 0) {
+    return null;
+  }
+  const selectedText = selectedLines.join("\n").trimEnd();
+  if (selectedText.trim().length === 0) {
+    return null;
+  }
+  return `${path}:${formatLineRange(startLineNumber, endLineNumber)}\n${selectedText}`;
+}
+
+export function BbSourceCode({
+  content,
+  path,
+  cacheKey,
+  overflow,
+  highlightedLines,
+  className,
+  scrollToHighlightedLines = false,
+  onSelectionAddToChat,
+}: BbSourceCodeProps) {
+  const file = useMemo<PierreFileContents>(
+    () => ({ name: path, contents: content, cacheKey: cacheKey ?? path }),
+    [cacheKey, content, path],
+  );
+  const preferredTheme = usePreferredTheme();
+  const codeTheme = useResolvedCodeThemePair();
+  const containerRef = useRef<HTMLDivElement>(null);
+  // `PierreFile` captures the worker pool when it creates its instance, so
+  // wait for the workspace to build the pool before the first render.
+  const isWorkerPoolReady = useRequirePierreWorkerPool();
+  const workerPool = usePierreWorkerPool();
+  const lastWorkerPoolStatsKeyRef = useRef<string | null>(null);
+  const [workerPoolStats, setWorkerPoolStats] =
+    useState<SourceCodeWorkerPoolStats | null>(null);
+  const [, rerenderAfterWorkerPoolChange] = useState(0);
+  const fileIdentity = file.cacheKey ?? file.name;
+  const truncation = useMemo(
+    () => truncateSourceCode(content),
+    [content],
+  );
+  // Which file the user asked to see in full. Keyed by identity rather than a
+  // boolean so opening a different large file goes back to the capped view
+  // without an effect resetting state.
+  const [fullFileRequestedFor, setFullFileRequestedFor] = useState<
+    string | null
+  >(null);
+  const buildSelectionText = useCallback(
+    (range: SelectedLineRange) =>
+      buildLineSelectionText({ contents: content, path, range }),
+    [content, path],
+  );
+  const lineSelectionActions = usePierreLineSelectionActions({
+    buildSelectionText,
+    containerRef,
+    enabled: onSelectionAddToChat !== undefined,
+    onSelectionAddToChat,
+  });
+  const options = useMemo<FileOptions<undefined>>(
+    () => ({
+      themeType: preferredTheme,
+      theme: codeTheme,
+      overflow,
+      disableFileHeader: true,
+      enableGutterUtility: onSelectionAddToChat !== undefined,
+      enableLineSelection:
+        highlightedLines !== null || onSelectionAddToChat !== undefined,
+      lineHoverHighlight:
+        onSelectionAddToChat === undefined ? "disabled" : "number",
+      onGutterUtilityClick:
+        onSelectionAddToChat === undefined
+          ? undefined
+          : lineSelectionActions.onGutterUtilityClick,
+      onLineSelectionChange: lineSelectionActions.onLineSelectionChange,
+      onLineSelectionEnd: lineSelectionActions.onLineSelectionEnd,
+      onLineSelectionStart: lineSelectionActions.onLineSelectionStart,
+    }),
+    [
+      codeTheme,
+      highlightedLines,
+      overflow,
+      lineSelectionActions.onGutterUtilityClick,
+      lineSelectionActions.onLineSelectionChange,
+      lineSelectionActions.onLineSelectionEnd,
+      lineSelectionActions.onLineSelectionStart,
+      onSelectionAddToChat,
+      preferredTheme,
+    ],
+  );
+  const selectedLines = useMemo<SelectedLineRange | null>(() => {
+    if (lineSelectionActions.selectedRange !== null) {
+      return lineSelectionActions.selectedRange;
+    }
+    return highlightedLines === null
+      ? null
+      : { start: highlightedLines.start, end: highlightedLines.end };
+  }, [highlightedLines, lineSelectionActions.selectedRange]);
+  const targetLineNumber = scrollToHighlightedLines
+    ? (selectedLines?.start ?? null)
+    : null;
+  // A deep link past the capped prefix is an implicit request for the whole
+  // file: the target line has to exist in the DOM to be scrolled to.
+  const showsFullFile =
+    truncation === null ||
+    fullFileRequestedFor === fileIdentity ||
+    (targetLineNumber !== null &&
+      targetLineNumber > truncation.renderedLineCount);
+  const renderedFile = useMemo<PierreFileContents>(() => {
+    if (showsFullFile || truncation === null) {
+      return file;
+    }
+    return {
+      ...file,
+      // The worker highlight cache is keyed by `cacheKey`; the capped prefix
+      // must not collide with the full file's entry.
+      cacheKey:
+        file.cacheKey === undefined ? undefined : `${file.cacheKey}:head`,
+      contents: truncation.contents,
+    };
+  }, [file, showsFullFile, truncation]);
+  // Pierre's virtualized file instance keeps the contents it was hydrated
+  // with (`VirtualizedFile.render` ignores a later `file`), so a content swap
+  // — the capped prefix giving way to the full file, or a refetch — needs a
+  // fresh mount. Callers that supply a `cacheKey` already fold the content
+  // hash into it; otherwise hash here.
+  const renderedFileMountKey = useMemo(
+    () =>
+      renderedFile.cacheKey ??
+      `${renderedFile.name}:${hashSourceContents(renderedFile.contents)}`,
+    [renderedFile],
+  );
+  // "Load full file" remounts pierre with the whole file; carry the reader's
+  // scroll offset across so the prefix they were looking at stays put.
+  const pendingViewportScrollTopRef = useRef<number | null>(null);
+  const handleLoadFullFile = () => {
+    const viewport =
+      containerRef.current === null
+        ? null
+        : findVirtualizedViewport(containerRef.current);
+    pendingViewportScrollTopRef.current = viewport?.scrollTop ?? null;
+    setFullFileRequestedFor(fileIdentity);
+  };
+  useLayoutEffect(() => {
+    const scrollTop = pendingViewportScrollTopRef.current;
+    if (scrollTop === null) return;
+    pendingViewportScrollTopRef.current = null;
+    const viewport =
+      containerRef.current === null
+        ? null
+        : findVirtualizedViewport(containerRef.current);
+    if (viewport === null) return;
+    viewport.scrollTop = scrollTop;
+    // The virtualizer sizes the fresh instance on its next frame; reapply once
+    // that height exists so the offset is not clamped away.
+    const frame = window.requestAnimationFrame(() => {
+      viewport.scrollTop = scrollTop;
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [renderedFileMountKey]);
+
+  useEffect(() => {
+    if (!workerPool) {
+      setWorkerPoolStats(null);
+      return;
+    }
+
+    lastWorkerPoolStatsKeyRef.current = null;
+    return workerPool.subscribeToStatChanges((stats) => {
+      setWorkerPoolStats(stats);
+      const statsKey = [
+        stats.managerState,
+        stats.workersFailed,
+        stats.busyWorkers,
+        stats.queuedTasks,
+        stats.activeTasks,
+        stats.fileCacheSize,
+      ].join(":");
+      if (lastWorkerPoolStatsKeyRef.current === statsKey) {
+        return;
+      }
+      lastWorkerPoolStatsKeyRef.current = statsKey;
+      rerenderAfterWorkerPoolChange((version) => version + 1);
+    });
+  }, [file.contents, file.name, workerPool]);
+
+  const shouldWaitForWorkerPool =
+    workerPool !== undefined &&
+    workerPoolStats?.managerState !== "initialized" &&
+    workerPoolStats?.workersFailed !== true;
+  // Pierre can mount an empty zero-height <pre> while its worker highlighter is
+  // still initializing, so the code view waits for pool readiness. After that
+  // a single mount is enough: pierre paints the plain-text AST first and
+  // repaints in place when the worker delivers the highlighted one. That
+  // repaint swaps the line elements, so the target-line effect below re-runs
+  // when the highlight cache entry for this file appears.
+  const workerHighlightCacheState =
+    workerPool?.getFileResultCache(renderedFile) !== undefined
+      ? "highlighted"
+      : "plain";
+
+  useEffect(() => {
+    const cleanupContainer = containerRef.current;
+    let animationFrame: number | null = null;
+    let attempts = 0;
+
+    // Retry on the next frame (the target line may not be in the DOM yet). One
+    // rAF channel only: `scrollToLine` overwrites `animationFrame` on each
+    // reschedule, so at most one callback is ever pending and cleanup cancels
+    // it — no doubling or leaked stale callbacks marking the wrong line.
+    function scheduleRetry() {
+      animationFrame = window.requestAnimationFrame(scrollToLine);
+    }
+
+    function scrollToLine() {
+      const container = containerRef.current;
+      if (!container) return;
+      clearTargetLine(container);
+      if (targetLineNumber === null) return;
+
+      const line = findTargetLine(container, targetLineNumber);
+      if (line) {
+        line.setAttribute("data-bb-source-code-target-line", "");
+        line.setAttribute("data-selected-line", "single");
+        scrollTargetLine(container, line);
+        return;
+      }
+
+      // The virtualizer only realizes rows near the scroll window, so a
+      // target outside it is not in the DOM yet. Move the viewport toward the
+      // line's estimated offset and let pierre render that window before the
+      // next attempt.
+      approachVirtualizedTargetLine(container, targetLineNumber);
+      attempts += 1;
+      if (attempts < TARGET_LINE_MAX_ATTEMPTS) {
+        scheduleRetry();
+      }
+    }
+
+    scrollToLine();
+    return () => {
+      if (cleanupContainer) {
+        clearTargetLine(cleanupContainer);
+      }
+      if (animationFrame !== null) {
+        window.cancelAnimationFrame(animationFrame);
+      }
+    };
+  }, [
+    renderedFile.contents,
+    renderedFile.name,
+    shouldWaitForWorkerPool,
+    targetLineNumber,
+    workerHighlightCacheState,
+  ]);
+
+  if (shouldWaitForWorkerPool || !isWorkerPoolReady) {
+    return <BbSourceCodeSkeleton />;
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn("flex min-h-0 flex-1 flex-col", className)}
+      style={SOURCE_VIEW_STYLE}
+      data-bb-source-code-line-number={targetLineNumber ?? undefined}
+      onPointerDownCapture={lineSelectionActions.onPointerDownCapture}
+      onPointerMoveCapture={lineSelectionActions.onPointerMoveCapture}
+      onPointerUpCapture={lineSelectionActions.onPointerUpCapture}
+    >
+      <PierreWorkerPoolBoundary>
+        <SourceCodeViewport>
+          <PierreFile
+            key={renderedFileMountKey}
+            disableWorkerPool={workerPoolStats?.workersFailed === true}
+            file={renderedFile}
+            metrics={SOURCE_VIRTUAL_FILE_METRICS}
+            options={options}
+            selectedLines={selectedLines}
+          />
+          {truncation !== null && !showsFullFile ? (
+            <SourceCodeTruncationNotice
+              truncation={truncation}
+              onLoadFullFile={handleLoadFullFile}
+            />
+          ) : null}
+        </SourceCodeViewport>
+      </PierreWorkerPoolBoundary>
+      {lineSelectionActions.menu}
+    </div>
+  );
+}
+
+const TARGET_LINE_MAX_ATTEMPTS = 40;
+
+/**
+ * The code view's own scroll container, registered as pierre's virtualizer
+ * root so `PierreFile` mounts a `VirtualizedFile` that renders only the rows
+ * near the viewport. This mirrors `@pierre/diffs/react`'s `<Virtualizer>`,
+ * inlined so the scroller carries a ref and a data marker the target-line
+ * scrolling can find without walking the tree by class name.
+ */
+function SourceCodeViewport({ children }: { children: ReactNode }) {
+  const [virtualizer] = useState(() =>
+    typeof window === "undefined" ? undefined : new PierreVirtualizer(),
+  );
+  const viewportRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (node !== null) {
+        virtualizer?.setup(node);
+      } else {
+        virtualizer?.cleanUp();
+      }
+    },
+    [virtualizer],
+  );
+  return (
+    <VirtualizerContext.Provider value={virtualizer}>
+      <div
+        ref={viewportRef}
+        className="min-h-0 flex-1 overflow-y-auto"
+        data-bb-source-code-viewport
+      >
+        <div>{children}</div>
+      </div>
+    </VirtualizerContext.Provider>
+  );
+}
+
+function SourceCodeTruncationNotice({
+  truncation,
+  onLoadFullFile,
+}: {
+  truncation: SourceCodeTruncation;
+  onLoadFullFile: () => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-4 py-3 text-xs text-muted-foreground">
+      <span>
+        Showing the first {truncation.renderedLineCount.toLocaleString()} of{" "}
+        {truncation.totalLineCount.toLocaleString()} lines.
+      </span>
+      <Button
+        type="button"
+        variant="link"
+        size="sm"
+        className="h-auto p-0 text-xs underline underline-offset-4 hover:underline"
+        onClick={onLoadFullFile}
+      >
+        Load full file
+      </Button>
+    </div>
+  );
+}
+
+export default BbSourceCode;

--- a/apps/app/src/components/code/BbSourceCode.tsx
+++ b/apps/app/src/components/code/BbSourceCode.tsx
@@ -27,6 +27,7 @@ import {
   usePierreWorkerPool,
   useRequirePierreWorkerPool,
 } from "@/lib/pierre-worker-pool-gate";
+import { usePierreStrictModeRecoveryOptions } from "@/lib/pierre-strict-mode-recovery";
 import { cn } from "@bb/shared-ui/lib/utils";
 import {
   hashSourceContents,
@@ -349,7 +350,7 @@ export function BbSourceCode({
     enabled: onSelectionAddToChat !== undefined,
     onSelectionAddToChat,
   });
-  const options = useMemo<FileOptions<undefined>>(
+  const baseOptions = useMemo<FileOptions<undefined>>(
     () => ({
       themeType: preferredTheme,
       theme: codeTheme,
@@ -380,6 +381,7 @@ export function BbSourceCode({
       preferredTheme,
     ],
   );
+  const options = usePierreStrictModeRecoveryOptions(baseOptions);
   const selectedLines = useMemo<SelectedLineRange | null>(() => {
     if (lineSelectionActions.selectedRange !== null) {
       return lineSelectionActions.selectedRange;

--- a/apps/app/src/components/code/DiffHost.test.tsx
+++ b/apps/app/src/components/code/DiffHost.test.tsx
@@ -1,0 +1,243 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginDiffRendererProps } from "@get-bb/plugin-sdk";
+import { defaultResolvedCodeTheme } from "@bb/domain";
+import { applyResolvedCodeTheme } from "@/lib/code-theme";
+import {
+  resetPluginSlotStoreForTest,
+  setPluginSlotRegistrations,
+} from "@/lib/plugin-slots";
+import { resetAllCrashedPluginSlotsForTest } from "@/components/plugin/PluginSlotMount";
+import { parseGitDiffFiles } from "@/components/git-diff/git-diff-parsing";
+import { PluginDiff } from "@/components/plugin/PluginDiff";
+import { DiffHost } from "./DiffHost";
+
+/**
+ * Records whether BB's default renderer chunk was ever pulled. `vi.mock`
+ * factories run on first import of the specifier, and `DiffHost` only reaches
+ * `./BbDiff` through `lazy(() => import(...))`, so a flag set here is exactly
+ * "the default renderer chunk loaded".
+ */
+const bbDiff = vi.hoisted(() => ({
+  loaded: false,
+  lastProps: null as Record<string, unknown> | null,
+}));
+
+vi.mock("./BbDiff", async () => {
+  const React = await import("react");
+  bbDiff.loaded = true;
+  return {
+    default: (props: Record<string, unknown>) => {
+      bbDiff.lastProps = props;
+      return React.createElement(
+        "div",
+        { "data-testid": "bb-diff" },
+        `bb diff ${String(props.view)}/${String(props.overflow)}`,
+      );
+    },
+  };
+});
+
+const PATCH = [
+  "diff --git a/src/app.ts b/src/app.ts",
+  "--- a/src/app.ts",
+  "+++ b/src/app.ts",
+  "@@ -1,3 +1,3 @@",
+  " const a = 1;",
+  "-const b = 2;",
+  "+const b = 3;",
+  " const c = 4;",
+  "",
+].join("\n");
+
+function parseFixture() {
+  const file = parseGitDiffFiles(PATCH)[0];
+  if (file === undefined) throw new Error("fixture patch did not parse");
+  return file;
+}
+
+const receivedProps: PluginDiffRendererProps[] = [];
+
+function registerDiffRenderer(
+  component: (props: PluginDiffRendererProps) => React.ReactNode,
+) {
+  setPluginSlotRegistrations("demo", {
+    homepageSections: [],
+    settingsSections: [],
+    navPanels: [],
+    threadPanelActions: [],
+    sidebarFooterActions: [],
+    fileOpeners: [],
+    messageDirectives: [],
+    diffRenderers: [
+      { id: "diffs", title: "Demo diffs", component },
+    ],
+  });
+}
+
+beforeEach(() => {
+  bbDiff.loaded = false;
+  bbDiff.lastProps = null;
+  receivedProps.length = 0;
+  resetPluginSlotStoreForTest();
+  applyResolvedCodeTheme(defaultResolvedCodeTheme);
+});
+
+afterEach(() => {
+  cleanup();
+  resetAllCrashedPluginSlotsForTest();
+  resetPluginSlotStoreForTest();
+  vi.restoreAllMocks();
+});
+
+describe("DiffHost", () => {
+  it("keeps BB's renderer chunk unloaded when a replacement never delegates", async () => {
+    registerDiffRenderer((props) => {
+      receivedProps.push(props);
+      return <div data-testid="plugin-diff">plugin diff</div>;
+    });
+
+    render(
+      <DiffHost file={parseFixture()} patchText={PATCH} view="split" />,
+    );
+
+    expect(await screen.findByTestId("plugin-diff")).toBeDefined();
+    // A microtask/frame is enough for a lazy() import to settle if one were
+    // requested; assert after letting the queue drain.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(bbDiff.loaded).toBe(false);
+  });
+
+  it("hands the replacement resolved semantic props, not BB's host-only inputs", async () => {
+    registerDiffRenderer((props) => {
+      receivedProps.push(props);
+      return <div data-testid="plugin-diff">plugin diff</div>;
+    });
+
+    render(
+      <DiffHost
+        file={parseFixture()}
+        patchText={PATCH}
+        view="split"
+        overflow="wrap"
+        showLineNumbers={false}
+        onSelectionAddToChat={() => {}}
+      />,
+    );
+
+    await screen.findByTestId("plugin-diff");
+    const props = receivedProps.at(-1);
+    expect(props?.patch).toBe(PATCH);
+    expect(props?.path).toBe("src/app.ts");
+    expect(props?.view).toBe("split");
+    expect(props?.overflow).toBe("wrap");
+    expect(props?.showLineNumbers).toBe(false);
+    expect(Object.keys(props ?? {})).not.toContain("onSelectionAddToChat");
+    expect(Object.keys(props ?? {})).not.toContain("file");
+  });
+
+  it("reconstructs a complete single-file patch when the caller has no patch text", async () => {
+    registerDiffRenderer((props) => {
+      receivedProps.push(props);
+      return <div data-testid="plugin-diff">plugin diff</div>;
+    });
+
+    render(<DiffHost file={parseFixture()} />);
+
+    await screen.findByTestId("plugin-diff");
+    const patch = receivedProps.at(-1)?.patch ?? "";
+    expect(patch).toContain("diff --git a/src/app.ts b/src/app.ts");
+    expect(patch).toContain("--- a/src/app.ts");
+    expect(patch).toContain("+++ b/src/app.ts");
+    expect(patch).toContain("-const b = 2;");
+    expect(patch).toContain("+const b = 3;");
+    // The reconstruction must re-parse to the same rendered file, or a
+    // replacement would draw something the caller never asked for.
+    const reparsed = parseGitDiffFiles(patch)[0];
+    expect(reparsed?.name).toBe("src/app.ts");
+    expect(reparsed?.hunks).toHaveLength(1);
+  });
+
+  it("loads BB's renderer only when the replacement delegates", async () => {
+    registerDiffRenderer(({ path, experimental_Original: Original }) =>
+      path.endsWith(".ts") ? <Original /> : <div>plugin diff</div>,
+    );
+
+    render(<DiffHost file={parseFixture()} patchText={PATCH} />);
+
+    expect(await screen.findByTestId("bb-diff")).toBeDefined();
+    expect(bbDiff.loaded).toBe(true);
+    // Delegation must reach BB's renderer with the host-only inputs intact.
+    expect(bbDiff.lastProps?.file).toBeDefined();
+  });
+
+  it("falls back to BB's renderer when the replacement crashes", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    registerDiffRenderer(() => {
+      throw new Error("replacement exploded");
+    });
+
+    render(<DiffHost file={parseFixture()} patchText={PATCH} />);
+
+    expect(await screen.findByTestId("bb-diff")).toBeDefined();
+  });
+
+  it("uses BB's renderer with resolved presentation defaults when nothing is registered", async () => {
+    render(<DiffHost file={parseFixture()} />);
+
+    await screen.findByTestId("bb-diff");
+    expect(bbDiff.lastProps?.view).toBe("unified");
+    expect(bbDiff.lastProps?.overflow).toBe("scroll");
+    expect(bbDiff.lastProps?.showLineNumbers).toBe(true);
+  });
+});
+
+describe("experimental_Diff", () => {
+  it("shares the replacement with BB's own surfaces", async () => {
+    registerDiffRenderer((props) => {
+      receivedProps.push(props);
+      return <div data-testid="plugin-diff">plugin diff</div>;
+    });
+
+    render(<PluginDiff patch={PATCH} path="src/app.ts" />);
+
+    await screen.findByTestId("plugin-diff");
+    expect(receivedProps.at(-1)?.path).toBe("src/app.ts");
+    expect(bbDiff.loaded).toBe(false);
+  });
+
+  it("completes a header-less patch before handing it to a replacement", async () => {
+    registerDiffRenderer((props) => {
+      receivedProps.push(props);
+      return <div data-testid="plugin-diff">plugin diff</div>;
+    });
+
+    // The shape GitHub's REST API returns: hunks with no `diff --git` header.
+    render(
+      <PluginDiff
+        patch={"@@ -1,2 +1,2 @@\r\n-const b = 2;\r\n+const b = 3;"}
+        path="src/app.ts"
+      />,
+    );
+
+    await screen.findByTestId("plugin-diff");
+    const patch = receivedProps.at(-1)?.patch ?? "";
+    expect(patch.startsWith("diff --git a/src/app.ts b/src/app.ts\n")).toBe(
+      true,
+    );
+    expect(patch).not.toContain("\r");
+  });
+
+  it("degrades to plain text instead of an empty diff when the patch will not parse", () => {
+    render(<PluginDiff patch="not a patch at all" path="notes.txt" />);
+
+    expect(screen.getByText("not a patch at all")).toBeDefined();
+    expect(screen.queryByTestId("bb-diff")).toBeNull();
+    expect(bbDiff.loaded).toBe(false);
+  });
+});

--- a/apps/app/src/components/code/DiffHost.test.tsx
+++ b/apps/app/src/components/code/DiffHost.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
+import { createStore, Provider as JotaiProvider } from "jotai";
 import { act } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginDiffRendererProps } from "@get-bb/plugin-sdk";
@@ -12,6 +13,11 @@ import {
 import { resetAllCrashedPluginSlotsForTest } from "@/components/plugin/PluginSlotMount";
 import { parseGitDiffFiles } from "@/components/git-diff/git-diff-parsing";
 import { PluginDiff } from "@/components/plugin/PluginDiff";
+import {
+  BUILT_IN_REPLACEMENT_PROVIDER,
+  replacementProviderKey,
+} from "@/lib/plugin-replacement-preference";
+import { diffRendererProviderAtom } from "./codeRendererProvider";
 import { DiffHost } from "./DiffHost";
 
 /**
@@ -173,6 +179,63 @@ describe("DiffHost", () => {
     expect(bbDiff.loaded).toBe(true);
     // Delegation must reach BB's renderer with the host-only inputs intact.
     expect(bbDiff.lastProps?.file).toBeDefined();
+  });
+
+  it("honours a pin to BB's renderer without disabling the plugin", async () => {
+    registerDiffRenderer((props) => {
+      receivedProps.push(props);
+      return <div data-testid="plugin-diff">plugin diff</div>;
+    });
+    const store = createStore();
+    store.set(diffRendererProviderAtom, BUILT_IN_REPLACEMENT_PROVIDER);
+
+    render(
+      <JotaiProvider store={store}>
+        <DiffHost file={parseFixture()} patchText={PATCH} />
+      </JotaiProvider>,
+    );
+
+    expect(await screen.findByTestId("bb-diff")).toBeDefined();
+    expect(receivedProps).toHaveLength(0);
+  });
+
+  it("keeps a pinned provider selected once another plugin sorts ahead of it", async () => {
+    registerDiffRenderer((props) => {
+      receivedProps.push(props);
+      return <div data-testid="plugin-diff">first plugin</div>;
+    });
+    setPluginSlotRegistrations("aardvark", {
+      homepageSections: [],
+      settingsSections: [],
+      navPanels: [],
+      threadPanelActions: [],
+      sidebarFooterActions: [],
+      fileOpeners: [],
+      messageDirectives: [],
+      diffRenderers: [
+        {
+          id: "diffs",
+          title: "Aardvark diffs",
+          component: () => <div data-testid="aardvark-diff">aardvark</div>,
+        },
+      ],
+    });
+    const store = createStore();
+    // "aardvark" sorts before "demo", so automatic would switch the user's
+    // renderer out from under them; an explicit pin must not.
+    store.set(
+      diffRendererProviderAtom,
+      replacementProviderKey({ pluginId: "demo", id: "diffs" }),
+    );
+
+    render(
+      <JotaiProvider store={store}>
+        <DiffHost file={parseFixture()} patchText={PATCH} />
+      </JotaiProvider>,
+    );
+
+    expect(await screen.findByTestId("plugin-diff")).toBeDefined();
+    expect(screen.queryByTestId("aardvark-diff")).toBeNull();
   });
 
   it("falls back to BB's renderer when the replacement crashes", async () => {

--- a/apps/app/src/components/code/DiffHost.tsx
+++ b/apps/app/src/components/code/DiffHost.tsx
@@ -1,0 +1,102 @@
+import { Suspense, lazy, useMemo, type ReactNode } from "react";
+import { PluginReplacementSlot } from "@/components/plugin/PluginReplacementSlot";
+import type { ParsedGitDiffFile } from "@/components/git-diff/git-diff-parsing";
+import { buildFileDiffPatchText } from "@/components/git-diff/git-diff-patch-text";
+import { resolveReplacement } from "@/lib/plugin-slot-resolvers";
+import { usePluginSlots } from "@/lib/plugin-slots";
+import {
+  DEFAULT_CODE_OVERFLOW,
+  DEFAULT_DIFF_VIEW,
+  type DiffPresentation,
+} from "./code-rendering";
+
+/** Shared by the mount and the host's crash check. */
+export const DIFF_RENDERER_SLOT_KIND = "diffRenderer";
+
+const BbDiff = lazy(() => import("./BbDiff"));
+
+export interface DiffHostProps extends Partial<DiffPresentation> {
+  /**
+   * The parsed diff to render. Callers parse it anyway for their own header,
+   * and the diff panel additionally enriches it with full file contents so the
+   * renderer can expand context between hunks.
+   */
+  file: ParsedGitDiffFile;
+  /**
+   * The patch text `file` was parsed from, when the caller still has it. A
+   * plugin replacement is handed this verbatim; without it the host
+   * reconstructs an equivalent single-file patch from `file`.
+   */
+  patchText?: string;
+  className?: string;
+  /** Rendered while BB's renderer chunk loads. */
+  fallback?: ReactNode;
+  onSelectionAddToChat?: (text: string) => void;
+}
+
+/**
+ * The host boundary for diff rendering (plugin design: exclusive replacement
+ * surfaces). Every BB surface that draws a text diff — timeline file changes,
+ * the environment diff panel's file bodies — and every plugin that calls
+ * `experimental_Diff` renders through here, so one
+ * `experimental_diffRenderer` registration replaces them all at once.
+ *
+ * BB's own renderer sits behind `lazy()`. A plugin replacement that never
+ * delegates therefore never downloads it, and `experimental_Original` costs
+ * nothing until it is actually rendered.
+ */
+export function DiffHost({
+  file,
+  patchText,
+  view = DEFAULT_DIFF_VIEW,
+  overflow = DEFAULT_CODE_OVERFLOW,
+  showLineNumbers = true,
+  className,
+  fallback = null,
+  onSelectionAddToChat,
+}: DiffHostProps) {
+  const { diffRenderers } = usePluginSlots();
+  const replacement = resolveReplacement(diffRenderers);
+  const isReplaced = replacement.kind === "plugin";
+  // Only reconstructed when a replacement will actually read it: the walk is
+  // proportional to the rendered hunks, and BB's own renderer never needs it.
+  const semanticPatch = useMemo(
+    () =>
+      isReplaced ? (patchText ?? buildFileDiffPatchText(file)) : "",
+    [file, isReplaced, patchText],
+  );
+
+  const original = (
+    <Suspense fallback={fallback}>
+      <BbDiff
+        file={file}
+        view={view}
+        overflow={overflow}
+        showLineNumbers={showLineNumbers}
+        className={className}
+        onSelectionAddToChat={onSelectionAddToChat}
+      />
+    </Suspense>
+  );
+
+  return (
+    <PluginReplacementSlot
+      replacement={replacement}
+      original={original}
+      slotKind={DIFF_RENDERER_SLOT_KIND}
+    >
+      {(slot, BoundOriginal) => (
+        <div className={className}>
+          <slot.component
+            patch={semanticPatch}
+            path={file.name}
+            view={view}
+            overflow={overflow}
+            showLineNumbers={showLineNumbers}
+            experimental_Original={BoundOriginal}
+          />
+        </div>
+      )}
+    </PluginReplacementSlot>
+  );
+}

--- a/apps/app/src/components/code/DiffHost.tsx
+++ b/apps/app/src/components/code/DiffHost.tsx
@@ -2,8 +2,7 @@ import { Suspense, lazy, useMemo, type ReactNode } from "react";
 import { PluginReplacementSlot } from "@/components/plugin/PluginReplacementSlot";
 import type { ParsedGitDiffFile } from "@/components/git-diff/git-diff-parsing";
 import { buildFileDiffPatchText } from "@/components/git-diff/git-diff-patch-text";
-import { resolveReplacement } from "@/lib/plugin-slot-resolvers";
-import { usePluginSlots } from "@/lib/plugin-slots";
+import { useDiffRendererReplacement } from "./codeRendererProvider";
 import {
   DEFAULT_CODE_OVERFLOW,
   DEFAULT_DIFF_VIEW,
@@ -55,8 +54,7 @@ export function DiffHost({
   fallback = null,
   onSelectionAddToChat,
 }: DiffHostProps) {
-  const { diffRenderers } = usePluginSlots();
-  const replacement = resolveReplacement(diffRenderers);
+  const replacement = useDiffRendererReplacement();
   const isReplaced = replacement.kind === "plugin";
   // Only reconstructed when a replacement will actually read it: the walk is
   // proportional to the rendered hunks, and BB's own renderer never needs it.

--- a/apps/app/src/components/code/DiffHost.tsx
+++ b/apps/app/src/components/code/DiffHost.tsx
@@ -28,6 +28,12 @@ export interface DiffHostProps extends Partial<DiffPresentation> {
    */
   patchText?: string;
   className?: string;
+  /**
+   * Forwarded to BB's renderer; see {@link BbDiffProps.expansionLineCount}.
+   * Never reaches a plugin replacement — context expansion is a BB renderer
+   * capability, not part of the semantic contract.
+   */
+  expansionLineCount?: number;
   /** Rendered while BB's renderer chunk loads. */
   fallback?: ReactNode;
   onSelectionAddToChat?: (text: string) => void;
@@ -51,6 +57,7 @@ export function DiffHost({
   overflow = DEFAULT_CODE_OVERFLOW,
   showLineNumbers = true,
   className,
+  expansionLineCount,
   fallback = null,
   onSelectionAddToChat,
 }: DiffHostProps) {
@@ -72,6 +79,7 @@ export function DiffHost({
         overflow={overflow}
         showLineNumbers={showLineNumbers}
         className={className}
+        expansionLineCount={expansionLineCount}
         onSelectionAddToChat={onSelectionAddToChat}
       />
     </Suspense>

--- a/apps/app/src/components/code/SourceCodeHost.test.tsx
+++ b/apps/app/src/components/code/SourceCodeHost.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginSourceCodeRendererProps } from "@get-bb/plugin-sdk";
+import {
+  resetPluginSlotStoreForTest,
+  setPluginSlotRegistrations,
+} from "@/lib/plugin-slots";
+import { resetAllCrashedPluginSlotsForTest } from "@/components/plugin/PluginSlotMount";
+import { PluginSourceCode } from "@/components/plugin/PluginSourceCode";
+import { SourceCodeHost } from "./SourceCodeHost";
+
+const bbSourceCode = vi.hoisted(() => ({
+  loaded: false,
+  lastProps: null as Record<string, unknown> | null,
+}));
+
+vi.mock("./BbSourceCode", async () => {
+  const React = await import("react");
+  bbSourceCode.loaded = true;
+  return {
+    default: (props: Record<string, unknown>) => {
+      bbSourceCode.lastProps = props;
+      return React.createElement(
+        "div",
+        { "data-testid": "bb-source-code" },
+        "bb source",
+      );
+    },
+  };
+});
+
+const CONTENT = "const a = 1;\nconst b = 2;\n";
+const received: PluginSourceCodeRendererProps[] = [];
+
+function registerSourceCodeRenderer(
+  component: (props: PluginSourceCodeRendererProps) => React.ReactNode,
+) {
+  setPluginSlotRegistrations("demo", {
+    homepageSections: [],
+    settingsSections: [],
+    navPanels: [],
+    threadPanelActions: [],
+    sidebarFooterActions: [],
+    fileOpeners: [],
+    messageDirectives: [],
+    sourceCodeRenderers: [{ id: "source", title: "Demo source", component }],
+  });
+}
+
+beforeEach(() => {
+  bbSourceCode.loaded = false;
+  bbSourceCode.lastProps = null;
+  received.length = 0;
+  resetPluginSlotStoreForTest();
+});
+
+afterEach(() => {
+  cleanup();
+  resetAllCrashedPluginSlotsForTest();
+  resetPluginSlotStoreForTest();
+  vi.restoreAllMocks();
+});
+
+describe("SourceCodeHost", () => {
+  it("keeps BB's renderer chunk unloaded when a replacement never delegates", async () => {
+    registerSourceCodeRenderer((props) => {
+      received.push(props);
+      return <div data-testid="plugin-source">plugin source</div>;
+    });
+
+    render(<SourceCodeHost content={CONTENT} path="src/app.ts" />);
+
+    await screen.findByTestId("plugin-source");
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(bbSourceCode.loaded).toBe(false);
+  });
+
+  it("hands the replacement resolved semantic props, not BB's host-only inputs", async () => {
+    registerSourceCodeRenderer((props) => {
+      received.push(props);
+      return <div data-testid="plugin-source">plugin source</div>;
+    });
+
+    render(
+      <SourceCodeHost
+        content={CONTENT}
+        path="src/app.ts"
+        cacheKey="rev-2:src/app.ts"
+        overflow="wrap"
+        highlightedLines={{ start: 2, end: 2 }}
+        scrollToHighlightedLines
+        onSelectionAddToChat={() => {}}
+      />,
+    );
+
+    await screen.findByTestId("plugin-source");
+    const props = received.at(-1);
+    expect(props?.content).toBe(CONTENT);
+    expect(props?.path).toBe("src/app.ts");
+    expect(props?.overflow).toBe("wrap");
+    expect(props?.highlightedLines).toEqual({ start: 2, end: 2 });
+    expect(Object.keys(props ?? {})).not.toContain("cacheKey");
+    expect(Object.keys(props ?? {})).not.toContain("onSelectionAddToChat");
+    expect(Object.keys(props ?? {})).not.toContain("scrollToHighlightedLines");
+  });
+
+  it("loads BB's renderer only when the replacement delegates", async () => {
+    registerSourceCodeRenderer(({ path, experimental_Original: Original }) =>
+      path.endsWith(".md") ? <div>plugin source</div> : <Original />,
+    );
+
+    render(
+      <SourceCodeHost
+        content={CONTENT}
+        path="src/app.ts"
+        cacheKey="rev-2:src/app.ts"
+        scrollToHighlightedLines
+      />,
+    );
+
+    expect(await screen.findByTestId("bb-source-code")).toBeDefined();
+    expect(bbSourceCode.loaded).toBe(true);
+    // Delegation keeps the host-only inputs BB's own file preview depends on.
+    expect(bbSourceCode.lastProps?.cacheKey).toBe("rev-2:src/app.ts");
+    expect(bbSourceCode.lastProps?.scrollToHighlightedLines).toBe(true);
+  });
+
+  it("falls back to BB's renderer when the replacement crashes", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    registerSourceCodeRenderer(() => {
+      throw new Error("replacement exploded");
+    });
+
+    render(<SourceCodeHost content={CONTENT} path="src/app.ts" />);
+
+    expect(await screen.findByTestId("bb-source-code")).toBeDefined();
+  });
+
+  it("resolves presentation defaults for BB's renderer", async () => {
+    render(<SourceCodeHost content={CONTENT} path="src/app.ts" />);
+
+    await screen.findByTestId("bb-source-code");
+    expect(bbSourceCode.lastProps?.overflow).toBe("scroll");
+    expect(bbSourceCode.lastProps?.highlightedLines).toBeNull();
+  });
+});
+
+describe("experimental_SourceCode", () => {
+  it("shares the replacement with BB's own surfaces", async () => {
+    registerSourceCodeRenderer((props) => {
+      received.push(props);
+      return <div data-testid="plugin-source">plugin source</div>;
+    });
+
+    render(<PluginSourceCode content={CONTENT} path="src/app.ts" />);
+
+    await screen.findByTestId("plugin-source");
+    expect(received.at(-1)?.content).toBe(CONTENT);
+    expect(received.at(-1)?.highlightedLines).toBeNull();
+    expect(bbSourceCode.loaded).toBe(false);
+  });
+});

--- a/apps/app/src/components/code/SourceCodeHost.tsx
+++ b/apps/app/src/components/code/SourceCodeHost.tsx
@@ -1,0 +1,80 @@
+import { Suspense, lazy, type ReactNode } from "react";
+import { PluginReplacementSlot } from "@/components/plugin/PluginReplacementSlot";
+import { resolveReplacement } from "@/lib/plugin-slot-resolvers";
+import { usePluginSlots } from "@/lib/plugin-slots";
+import {
+  DEFAULT_CODE_OVERFLOW,
+  type BbSourceCodeProps,
+} from "./code-rendering";
+
+/** Shared by the mount and the host's crash check. */
+export const SOURCE_CODE_RENDERER_SLOT_KIND = "sourceCodeRenderer";
+
+const BbSourceCode = lazy(() => import("./BbSourceCode"));
+
+export interface SourceCodeHostProps
+  extends Omit<BbSourceCodeProps, "overflow" | "highlightedLines"> {
+  overflow?: BbSourceCodeProps["overflow"];
+  highlightedLines?: BbSourceCodeProps["highlightedLines"];
+  /** Rendered while BB's renderer chunk loads. */
+  fallback?: ReactNode;
+}
+
+/**
+ * The host boundary for source rendering (plugin design: exclusive replacement
+ * surfaces). BB's native file preview and every plugin that calls
+ * `experimental_SourceCode` render through here, so one
+ * `experimental_sourceCodeRenderer` registration replaces them all at once.
+ *
+ * BB's own renderer sits behind `lazy()`; a replacement that never delegates
+ * never downloads it.
+ */
+export function SourceCodeHost({
+  content,
+  path,
+  cacheKey,
+  overflow = DEFAULT_CODE_OVERFLOW,
+  highlightedLines = null,
+  className,
+  fallback = null,
+  scrollToHighlightedLines,
+  onSelectionAddToChat,
+}: SourceCodeHostProps) {
+  const { sourceCodeRenderers } = usePluginSlots();
+  const replacement = resolveReplacement(sourceCodeRenderers);
+
+  const original = (
+    <Suspense fallback={fallback}>
+      <BbSourceCode
+        content={content}
+        path={path}
+        cacheKey={cacheKey}
+        overflow={overflow}
+        highlightedLines={highlightedLines}
+        className={className}
+        scrollToHighlightedLines={scrollToHighlightedLines}
+        onSelectionAddToChat={onSelectionAddToChat}
+      />
+    </Suspense>
+  );
+
+  return (
+    <PluginReplacementSlot
+      replacement={replacement}
+      original={original}
+      slotKind={SOURCE_CODE_RENDERER_SLOT_KIND}
+    >
+      {(slot, BoundOriginal) => (
+        <div className={className}>
+          <slot.component
+            content={content}
+            path={path}
+            overflow={overflow}
+            highlightedLines={highlightedLines}
+            experimental_Original={BoundOriginal}
+          />
+        </div>
+      )}
+    </PluginReplacementSlot>
+  );
+}

--- a/apps/app/src/components/code/SourceCodeHost.tsx
+++ b/apps/app/src/components/code/SourceCodeHost.tsx
@@ -1,7 +1,6 @@
 import { Suspense, lazy, type ReactNode } from "react";
 import { PluginReplacementSlot } from "@/components/plugin/PluginReplacementSlot";
-import { resolveReplacement } from "@/lib/plugin-slot-resolvers";
-import { usePluginSlots } from "@/lib/plugin-slots";
+import { useSourceCodeRendererReplacement } from "./codeRendererProvider";
 import {
   DEFAULT_CODE_OVERFLOW,
   type BbSourceCodeProps,
@@ -40,8 +39,7 @@ export function SourceCodeHost({
   scrollToHighlightedLines,
   onSelectionAddToChat,
 }: SourceCodeHostProps) {
-  const { sourceCodeRenderers } = usePluginSlots();
-  const replacement = resolveReplacement(sourceCodeRenderers);
+  const replacement = useSourceCodeRendererReplacement();
 
   const original = (
     <Suspense fallback={fallback}>

--- a/apps/app/src/components/code/code-rendering.ts
+++ b/apps/app/src/components/code/code-rendering.ts
@@ -1,0 +1,67 @@
+import type {
+  CodeOverflowMode,
+  DiffViewMode,
+  SourceCodeLineRange,
+} from "@get-bb/plugin-sdk";
+import type { ParsedGitDiffFile } from "@/components/git-diff/git-diff-parsing";
+
+/**
+ * Internal contracts for the two host-owned code renderers.
+ *
+ * The host boundary splits every render into two halves. The *semantic* half
+ * (`SourceCodePresentation` / `DiffPresentation` plus the content) is what a
+ * plugin replacement receives — fully resolved, with no BB implementation
+ * types in it. The *host-only* half (pre-parsed diff files, selection-to-chat,
+ * layout classes) never leaves BB, so replacing a renderer can never make a
+ * plugin responsible for BB product behavior it cannot implement.
+ *
+ * This module is types plus two literals: importing it must never pull the
+ * renderer graph (`@pierre/diffs` and Shiki behind it) onto a caller's chunk.
+ */
+
+export const DEFAULT_CODE_OVERFLOW: CodeOverflowMode = "scroll";
+export const DEFAULT_DIFF_VIEW: DiffViewMode = "unified";
+
+/** Presentation the host resolved for one source render. */
+export interface SourceCodePresentation {
+  overflow: CodeOverflowMode;
+  highlightedLines: SourceCodeLineRange | null;
+}
+
+/** Presentation the host resolved for one diff render. */
+export interface DiffPresentation {
+  view: DiffViewMode;
+  overflow: CodeOverflowMode;
+  showLineNumbers: boolean;
+}
+
+/** Props BB's default source renderer receives from {@link SourceCodeHost}. */
+export interface BbSourceCodeProps extends SourceCodePresentation {
+  content: string;
+  path: string;
+  /**
+   * Stable identity for the highlighter's result cache. Defaults to `path`;
+   * callers that re-render the same path with different bytes (a file reloaded
+   * at a new revision) pass their own.
+   */
+  cacheKey?: string;
+  className?: string;
+  /**
+   * Scroll the first highlighted line into view once it renders. The file
+   * preview wants it for `?L12` deep links; an inline snippet does not.
+   */
+  scrollToHighlightedLines?: boolean;
+  onSelectionAddToChat?: (text: string) => void;
+}
+
+/** Props BB's default diff renderer receives from {@link DiffHost}. */
+export interface BbDiffProps extends DiffPresentation {
+  /**
+   * The diff to draw. Already parsed — and possibly enriched with full file
+   * contents for context expansion — by the caller, which also needs it for
+   * its own header.
+   */
+  file: ParsedGitDiffFile;
+  className?: string;
+  onSelectionAddToChat?: (text: string) => void;
+}

--- a/apps/app/src/components/code/code-rendering.ts
+++ b/apps/app/src/components/code/code-rendering.ts
@@ -63,5 +63,12 @@ export interface BbDiffProps extends DiffPresentation {
    */
   file: ParsedGitDiffFile;
   className?: string;
+  /**
+   * How many unchanged lines each expand-context click reveals. Set ONLY by a
+   * caller that can attach full file contents to `file`: pierre renders an
+   * empty diff when it is given an expansion budget for a hunk-only patch,
+   * which is what the timeline supplies.
+   */
+  expansionLineCount?: number;
   onSelectionAddToChat?: (text: string) => void;
 }

--- a/apps/app/src/components/code/codeRendererProvider.ts
+++ b/apps/app/src/components/code/codeRendererProvider.ts
@@ -1,0 +1,42 @@
+import { useAtomValue } from "jotai";
+import {
+  createReplacementPreferenceAtom,
+  resolvePreferredReplacement,
+} from "@/lib/plugin-replacement-preference";
+import type { ResolvedReplacement } from "@/lib/plugin-slot-resolvers";
+import {
+  usePluginSlots,
+  type PluginDiffRendererSlot,
+  type PluginSourceCodeRendererSlot,
+} from "@/lib/plugin-slots";
+
+const SOURCE_CODE_RENDERER_STORAGE_KEY = "bb.appearance.sourceCodeRenderer";
+const DIFF_RENDERER_STORAGE_KEY = "bb.appearance.diffRenderer";
+
+/**
+ * Automatic by default, with an explicit per-client override in Appearance —
+ * the same pin the sidebar thread list offers. A renderer replaces a surface
+ * the user cannot otherwise get back without disabling the whole plugin, so
+ * the pin is what keeps "installing activates it" reversible.
+ */
+export const sourceCodeRendererProviderAtom = createReplacementPreferenceAtom(
+  SOURCE_CODE_RENDERER_STORAGE_KEY,
+);
+
+export const diffRendererProviderAtom = createReplacementPreferenceAtom(
+  DIFF_RENDERER_STORAGE_KEY,
+);
+
+/** The active source renderer, or the owner when none applies. */
+export function useSourceCodeRendererReplacement(): ResolvedReplacement<PluginSourceCodeRendererSlot> {
+  const { sourceCodeRenderers } = usePluginSlots();
+  const preference = useAtomValue(sourceCodeRendererProviderAtom);
+  return resolvePreferredReplacement(sourceCodeRenderers, preference);
+}
+
+/** The active diff renderer, or the owner when none applies. */
+export function useDiffRendererReplacement(): ResolvedReplacement<PluginDiffRendererSlot> {
+  const { diffRenderers } = usePluginSlots();
+  const preference = useAtomValue(diffRendererProviderAtom);
+  return resolvePreferredReplacement(diffRenderers, preference);
+}

--- a/apps/app/src/components/code/source-code-budget.ts
+++ b/apps/app/src/components/code/source-code-budget.ts
@@ -1,0 +1,78 @@
+/**
+ * Rendering budget for BB's source renderer.
+ *
+ * Tokenizing and laying out a 20k-line file is what stalls iOS Safari, so the
+ * renderer paints a leading prefix until the reader asks for the whole file.
+ * The rule lives here, apart from the renderer itself, because it is pure and
+ * the file preview's tests assert it directly — importing it must never pull
+ * the `@pierre/diffs` chunk.
+ */
+
+export const SOURCE_CODE_MAX_LINES = 5_000;
+export const SOURCE_CODE_MAX_CHARS = 512 * 1024;
+
+export interface SourceCodeTruncation {
+  /** The rendered prefix, cut at a line boundary. */
+  contents: string;
+  renderedLineCount: number;
+  totalLineCount: number;
+}
+
+// FNV-1a over the contents; only used to derive a mount key for renders
+// whose caller did not supply a `cacheKey`.
+export function hashSourceContents(contents: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < contents.length; index += 1) {
+    hash ^= contents.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `${contents.length}:${(hash >>> 0).toString(36)}`;
+}
+
+function countLines(contents: string): number {
+  if (contents.length === 0) return 0;
+  let count = 1;
+  for (let index = contents.indexOf("\n"); index !== -1; ) {
+    count += 1;
+    index = contents.indexOf("\n", index + 1);
+  }
+  return contents.endsWith("\n") ? count - 1 : count;
+}
+
+/**
+ * Decide whether a source render exceeds {@link SOURCE_CODE_MAX_LINES} or
+ * {@link SOURCE_CODE_MAX_CHARS} and, if so, return the leading prefix
+ * that fits both budgets. Returns `null` when the whole file fits.
+ */
+export function truncateSourceCode(
+  contents: string,
+): SourceCodeTruncation | null {
+  const totalLineCount = countLines(contents);
+  if (
+    contents.length <= SOURCE_CODE_MAX_CHARS &&
+    totalLineCount <= SOURCE_CODE_MAX_LINES
+  ) {
+    return null;
+  }
+  let renderedLineCount = 0;
+  let cutIndex = 0;
+  for (
+    let lineStart = 0;
+    lineStart < contents.length &&
+    renderedLineCount < SOURCE_CODE_MAX_LINES;
+  ) {
+    const newlineIndex = contents.indexOf("\n", lineStart);
+    const lineEnd = newlineIndex === -1 ? contents.length : newlineIndex;
+    if (lineEnd > SOURCE_CODE_MAX_CHARS && renderedLineCount > 0) {
+      break;
+    }
+    renderedLineCount += 1;
+    cutIndex = lineEnd;
+    lineStart = lineEnd + 1;
+  }
+  return {
+    contents: contents.slice(0, cutIndex),
+    renderedLineCount,
+    totalLineCount,
+  };
+}

--- a/apps/app/src/components/git-diff/GitDiffCard.stories.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCard.stories.tsx
@@ -3,10 +3,8 @@ import { builtInThemes, defaultAppTheme, type BuiltInThemeId } from "@bb/domain"
 import { cn } from "@bb/shared-ui/lib/utils";
 import { Button } from "@bb/shared-ui/button";
 import { resolveAppThemeCss } from "@/lib/themes";
-import {
-  GitDiffCard,
-  GIT_DIFF_VIEW_BASE_OPTIONS,
-} from "@/components/git-diff/GitDiffCard";
+import { GitDiffCard } from "@/components/git-diff/GitDiffCard";
+import type { DiffPresentation } from "@/components/code/code-rendering";
 import { parseGitDiffFiles } from "@/components/git-diff/git-diff-parsing";
 
 /**
@@ -85,19 +83,25 @@ function usePaletteCss(themeId: BuiltInThemeId) {
   );
 }
 
-function DiffStack({ themeType }: { themeType: "light" | "dark" }) {
+const DIFF_PRESENTATION: DiffPresentation = {
+  view: "unified",
+  overflow: "scroll",
+  showLineNumbers: true,
+};
+
+// Syntax-highlight token colors follow the app's own light/dark preference
+// (Layer 2), so both panes below tokenize the same way. What each pane proves
+// is Layer 1: the surface, gutter, and +/- tints re-resolving through the
+// forced `.light` / `.dark` class.
+function DiffStack() {
   const files = useMemo(() => parseGitDiffFiles(SAMPLE_DIFF), []);
-  const diffViewOptions = useMemo<Record<string, string | boolean | number>>(
-    () => ({ ...GIT_DIFF_VIEW_BASE_OPTIONS, themeType }),
-    [themeType],
-  );
   return (
     <div className="flex flex-col gap-3">
       {files.map((file, index) => (
         <GitDiffCard
           key={`${file.name}-${index}`}
           fileDiff={file}
-          diffViewOptions={diffViewOptions}
+          presentation={DIFF_PRESENTATION}
         />
       ))}
     </div>
@@ -117,7 +121,7 @@ function ModePane({ mode }: { mode: "light" | "dark" }) {
       <span className="text-[11px] font-medium text-muted-foreground">
         {mode}
       </span>
-      <DiffStack themeType={mode} />
+      <DiffStack />
     </div>
   );
 }

--- a/apps/app/src/components/git-diff/GitDiffCard.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCard.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect, useMemo, useState } from "react";
 import { useIntersectionObserver } from "usehooks-ts";
 import { cn } from "@bb/shared-ui/lib/utils";
+import type { DiffPresentation } from "@/components/code/code-rendering";
 import {
   GitDiffCardBody,
   useGitDiffCardBody,
@@ -28,17 +29,11 @@ export type {
   RequestDiffFileContents,
 } from "./GitDiffCardBody";
 
-export const GIT_DIFF_VIEW_BASE_OPTIONS = {
-  overflow: "scroll",
-  disableFileHeader: false,
-  // Reveal 30 unchanged lines per expand-up / expand-down click. Library
-  // default is 100 — too aggressive for our compact diff cards.
-  expansionLineCount: 30,
-} as const;
-
 export interface GitDiffCardProps {
   fileDiff: ParsedGitDiffFile;
-  diffViewOptions: Record<string, string | boolean | number>;
+  presentation: DiffPresentation;
+  /** Raw per-file patch text, when the caller still has it. */
+  patchText?: string;
   filePathRoot?: string | null;
   onOpenFileInEditor?: (path: string) => void;
   onOpenFilePreview?: (path: string) => void;
@@ -99,7 +94,8 @@ function buildGitDiffCardHeaderModel(
 
 export const GitDiffCard = memo(function GitDiffCard({
   fileDiff,
-  diffViewOptions,
+  presentation,
+  patchText,
   filePathRoot,
   onOpenFileInEditor,
   onOpenFilePreview,
@@ -124,6 +120,7 @@ export const GitDiffCard = memo(function GitDiffCard({
     changeKind: headerModel.changeKind,
     isRendering,
     onRequestFileContents,
+    patchText,
   });
   const [svgDisplayMode, setSvgDisplayMode] =
     useState<GitDiffCardSvgDisplayMode>("preview");
@@ -202,7 +199,7 @@ export const GitDiffCard = memo(function GitDiffCard({
       {!isBodyHidden ? (
         <GitDiffCardBody
           state={bodyState}
-          diffViewOptions={diffViewOptions}
+          presentation={presentation}
           svgDisplayMode={svgDisplayMode}
           reservesCollapseGutter={supportsCollapse}
         />

--- a/apps/app/src/components/git-diff/GitDiffCardBody.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCardBody.tsx
@@ -57,6 +57,14 @@ export interface DiffImageSizeStat {
 
 export type GitDiffCardSvgDisplayMode = "preview" | "raw";
 
+/**
+ * Unchanged lines revealed per expand-up / expand-down click; the library
+ * default of 100 is too aggressive for our compact cards. Only sent for a
+ * card that can actually fetch full file contents — see
+ * {@link BbDiffProps.expansionLineCount}.
+ */
+const DIFF_EXPANSION_LINE_COUNT = 30;
+
 const GIT_DIFF_CARD_BODY_STYLE: CSSProperties = {
   contain: "layout paint style",
   contentVisibility: "auto",
@@ -768,6 +776,7 @@ interface GitDiffCardSvgBodyProps {
   fileDiffLabel: string;
   patchText: string | undefined;
   presentation: DiffPresentation;
+  expansionLineCount: number | undefined;
   onSelectionAddToChat?: (text: string) => void;
 }
 
@@ -778,6 +787,7 @@ function GitDiffCardSvgBody({
   fileDiffLabel,
   patchText,
   presentation,
+  expansionLineCount,
   onSelectionAddToChat,
 }: GitDiffCardSvgBodyProps) {
   return displayMode === "preview" ? (
@@ -791,6 +801,7 @@ function GitDiffCardSvgBody({
       file={fileDiff}
       patchText={patchText}
       {...presentation}
+      expansionLineCount={expansionLineCount}
       onSelectionAddToChat={onSelectionAddToChat}
     />
   );
@@ -839,6 +850,13 @@ export function GitDiffCardBody({
     contextExpansion,
     patchText,
   } = state;
+  // pierre renders an empty diff when it gets an expansion budget for a
+  // hunk-only patch, so only a card that can fetch full contents sends one.
+  // The timeline never can; the diff panel can, through its fetcher.
+  const expansionLineCount =
+    contextExpansion.status === "unavailable"
+      ? undefined
+      : DIFF_EXPANSION_LINE_COUNT;
 
   return (
     <div
@@ -879,6 +897,7 @@ export function GitDiffCardBody({
           fileDiffLabel={fileDiffLabel}
           patchText={patchText}
           presentation={presentation}
+          expansionLineCount={expansionLineCount}
           onSelectionAddToChat={onSelectionAddToChat}
         />
       ) : (
@@ -887,6 +906,7 @@ export function GitDiffCardBody({
             file={enrichedFileDiff}
             patchText={patchText}
             {...presentation}
+            expansionLineCount={expansionLineCount}
             fallback={<GitDiffCardBodySkeleton />}
             onSelectionAddToChat={onSelectionAddToChat}
           />

--- a/apps/app/src/components/git-diff/GitDiffCardBody.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCardBody.tsx
@@ -7,21 +7,12 @@ import {
   useRef,
   useState,
 } from "react";
-import type {
-  FileContents,
-  FileDiffOptions,
-  SelectedLineRange,
-  SelectionSide,
-} from "@pierre/diffs";
-import { useResolvedCodeThemePair } from "@/lib/code-theme";
-import { PierreWorkerPoolBoundary } from "@/lib/pierre-worker-pool-boundary";
-import { useRequirePierreWorkerPool } from "@/lib/pierre-worker-pool-gate";
-import { usePierreStrictModeRecoveryOptions } from "@/lib/pierre-strict-mode-recovery";
-import { FileDiff as DiffView } from "@pierre/diffs/react";
+import type { FileContents } from "@pierre/diffs";
 import { useIntersectionObserver } from "usehooks-ts";
 import { Button } from "@bb/shared-ui/button";
 import { usePointerCoarse } from "@bb/shared-ui/hooks/use-pointer-coarse";
-import { usePierreLineSelectionActions } from "./PierreLineSelectionActions.js";
+import { DiffHost } from "@/components/code/DiffHost";
+import type { DiffPresentation } from "@/components/code/code-rendering";
 import {
   getWrappedImageIndex,
   ImageLightbox,
@@ -65,11 +56,6 @@ export interface DiffImageSizeStat {
 }
 
 export type GitDiffCardSvgDisplayMode = "preview" | "raw";
-
-const GIT_DIFF_CARD_VIEW_STYLE = {
-  "--diffs-font-size": "12px",
-  "--diffs-line-height": "18px",
-} as CSSProperties;
 
 const GIT_DIFF_CARD_BODY_STYLE: CSSProperties = {
   contain: "layout paint style",
@@ -293,6 +279,12 @@ export interface GitDiffCardBodyState {
   imageSizeStat: DiffImageSizeStat | null;
   /** On-demand full-file context for text cards; see {@link DiffContextExpansionState}. */
   contextExpansion: DiffContextExpansionState;
+  /**
+   * The raw per-file patch the caller supplied, forwarded to the host diff
+   * boundary so a plugin replacement gets the caller's own bytes instead of a
+   * reconstruction.
+   */
+  patchText: string | undefined;
 }
 
 /**
@@ -530,6 +522,7 @@ export function useGitDiffCardBody({
     loadDeletedDiff,
     imageSizeStat,
     contextExpansion,
+    patchText,
   };
 }
 
@@ -768,601 +761,13 @@ function GitDiffCardImageBody({
   );
 }
 
-type DiffViewOptions = FileDiffOptions<undefined>;
-
-interface GitDiffCardRawDiffBodyProps {
-  fileDiff: ParsedGitDiffFile;
-  fileDiffOptions: DiffViewOptions;
-  onSelectionAddToChat?: (text: string) => void;
-}
-
-type DiffPatchDisplayStyle = "unified" | "split";
-type DiffPatchLinePrefix = " " | "+" | "-";
-
-interface DiffPatchLine {
-  hunkIndex: number;
-  newLineNumber: number | null;
-  oldLineNumber: number | null;
-  prefix: DiffPatchLinePrefix;
-  selectionSide: SelectionSide | null;
-  splitLineIndex: number;
-  text: string;
-  unifiedLineIndex: number;
-}
-
-function getDiffPatchDisplayStyle(
-  fileDiffOptions: DiffViewOptions,
-): DiffPatchDisplayStyle {
-  return fileDiffOptions.diffStyle === "split" ? "split" : "unified";
-}
-
-function trimDiffLineEnding(line: string) {
-  return line.replace(/(?:\r\n|\n|\r)$/u, "");
-}
-
-function getDiffLineNumberFromIndex({
-  hunkLineIndex,
-  hunkStart,
-  lineIndex,
-}: {
-  hunkLineIndex: number;
-  hunkStart: number;
-  lineIndex: number;
-}) {
-  return hunkStart + (lineIndex - hunkLineIndex);
-}
-
-function formatPrefixedDiffPath(path: string, prefix: "a" | "b") {
-  if (path === "/dev/null") {
-    return path;
-  }
-  return path.startsWith(`${prefix}/`) ? path : `${prefix}/${path}`;
-}
-
-function getDiffPatchPaths(fileDiff: ParsedGitDiffFile) {
-  const currentPath = normalizeGitDiffPath(fileDiff.name) ?? fileDiff.name;
-  const previousPath = normalizeGitDiffPath(fileDiff.prevName) ?? currentPath;
-  const gitOldPath = previousPath === "/dev/null" ? currentPath : previousPath;
-  const gitNewPath = currentPath === "/dev/null" ? previousPath : currentPath;
-  return {
-    diffGitOldPath: formatPrefixedDiffPath(gitOldPath, "a"),
-    diffGitNewPath: formatPrefixedDiffPath(gitNewPath, "b"),
-    oldHeaderPath:
-      fileDiff.type === "new"
-        ? "/dev/null"
-        : formatPrefixedDiffPath(previousPath, "a"),
-    newHeaderPath:
-      fileDiff.type === "deleted"
-        ? "/dev/null"
-        : formatPrefixedDiffPath(currentPath, "b"),
-  };
-}
-
-function collectDiffPatchLines(fileDiff: ParsedGitDiffFile): DiffPatchLine[] {
-  const patchLines: DiffPatchLine[] = [];
-
-  fileDiff.hunks.forEach((hunk, hunkIndex) => {
-    let unifiedLineIndex = hunk.unifiedLineStart;
-    let splitLineIndex = hunk.splitLineStart;
-    let deletionLineIndex = hunk.deletionLineIndex;
-    let additionLineIndex = hunk.additionLineIndex;
-
-    for (const content of hunk.hunkContent) {
-      if (content.type === "context") {
-        for (let offset = 0; offset < content.lines; offset += 1) {
-          const oldLineIndex = deletionLineIndex + offset;
-          const newLineIndex = additionLineIndex + offset;
-          const lineText =
-            fileDiff.additionLines[newLineIndex] ??
-            fileDiff.deletionLines[oldLineIndex];
-          if (lineText === undefined) {
-            continue;
-          }
-          patchLines.push({
-            hunkIndex,
-            newLineNumber: getDiffLineNumberFromIndex({
-              hunkLineIndex: hunk.additionLineIndex,
-              hunkStart: hunk.additionStart,
-              lineIndex: newLineIndex,
-            }),
-            oldLineNumber: getDiffLineNumberFromIndex({
-              hunkLineIndex: hunk.deletionLineIndex,
-              hunkStart: hunk.deletionStart,
-              lineIndex: oldLineIndex,
-            }),
-            prefix: " ",
-            selectionSide: null,
-            splitLineIndex: splitLineIndex + offset,
-            text: trimDiffLineEnding(lineText),
-            unifiedLineIndex: unifiedLineIndex + offset,
-          });
-        }
-        unifiedLineIndex += content.lines;
-        splitLineIndex += content.lines;
-        deletionLineIndex += content.lines;
-        additionLineIndex += content.lines;
-        continue;
-      }
-
-      const splitCount = Math.max(content.deletions, content.additions);
-      const unifiedCount = content.deletions + content.additions;
-      for (let offset = 0; offset < content.deletions; offset += 1) {
-        const oldLineIndex = deletionLineIndex + offset;
-        const lineText = fileDiff.deletionLines[oldLineIndex];
-        if (lineText === undefined) {
-          continue;
-        }
-        patchLines.push({
-          hunkIndex,
-          newLineNumber: null,
-          oldLineNumber: getDiffLineNumberFromIndex({
-            hunkLineIndex: hunk.deletionLineIndex,
-            hunkStart: hunk.deletionStart,
-            lineIndex: oldLineIndex,
-          }),
-          prefix: "-",
-          selectionSide: "deletions",
-          splitLineIndex: splitLineIndex + offset,
-          text: trimDiffLineEnding(lineText),
-          unifiedLineIndex: unifiedLineIndex + offset,
-        });
-      }
-      for (let offset = 0; offset < content.additions; offset += 1) {
-        const newLineIndex = additionLineIndex + offset;
-        const lineText = fileDiff.additionLines[newLineIndex];
-        if (lineText === undefined) {
-          continue;
-        }
-        patchLines.push({
-          hunkIndex,
-          newLineNumber: getDiffLineNumberFromIndex({
-            hunkLineIndex: hunk.additionLineIndex,
-            hunkStart: hunk.additionStart,
-            lineIndex: newLineIndex,
-          }),
-          oldLineNumber: null,
-          prefix: "+",
-          selectionSide: "additions",
-          splitLineIndex: splitLineIndex + offset,
-          text: trimDiffLineEnding(lineText),
-          unifiedLineIndex: unifiedLineIndex + content.deletions + offset,
-        });
-      }
-      unifiedLineIndex += unifiedCount;
-      splitLineIndex += splitCount;
-      deletionLineIndex += content.deletions;
-      additionLineIndex += content.additions;
-    }
-  });
-
-  return patchLines;
-}
-
-function getDiffPatchLineSelectionIndex(
-  line: DiffPatchLine,
-  displayStyle: DiffPatchDisplayStyle,
-) {
-  return displayStyle === "split" ? line.splitLineIndex : line.unifiedLineIndex;
-}
-
-function getDiffPatchSelectionPointIndex({
-  displayStyle,
-  lineNumber,
-  patchLines,
-  side,
-}: {
-  displayStyle: DiffPatchDisplayStyle;
-  lineNumber: number;
-  patchLines: DiffPatchLine[];
-  side: SelectionSide | undefined;
-}) {
-  const sides: SelectionSide[] =
-    side === undefined ? ["additions", "deletions"] : [side];
-  for (const candidateSide of sides) {
-    const line = patchLines.find((patchLine) =>
-      candidateSide === "additions"
-        ? patchLine.newLineNumber === lineNumber
-        : patchLine.oldLineNumber === lineNumber,
-    );
-    if (line !== undefined) {
-      return getDiffPatchLineSelectionIndex(line, displayStyle);
-    }
-  }
-  return null;
-}
-
-function isDiffPatchLineSelectedInSplitView({
-  line,
-  range,
-}: {
-  line: DiffPatchLine;
-  range: SelectedLineRange;
-}) {
-  const startSide = range.side ?? range.endSide ?? "additions";
-  const endSide = range.endSide ?? startSide;
-  if (startSide !== endSide || line.selectionSide === null) {
-    return true;
-  }
-  return line.selectionSide === startSide;
-}
-
-function getSelectedDiffPatchLines({
-  displayStyle,
-  patchLines,
-  range,
-}: {
-  displayStyle: DiffPatchDisplayStyle;
-  patchLines: DiffPatchLine[];
-  range: SelectedLineRange;
-}) {
-  const startIndex = getDiffPatchSelectionPointIndex({
-    displayStyle,
-    lineNumber: range.start,
-    patchLines,
-    side: range.side,
-  });
-  const endIndex = getDiffPatchSelectionPointIndex({
-    displayStyle,
-    lineNumber: range.end,
-    patchLines,
-    side: range.endSide ?? range.side,
-  });
-  if (startIndex === null || endIndex === null) {
-    return [];
-  }
-
-  const firstIndex = Math.min(startIndex, endIndex);
-  const lastIndex = Math.max(startIndex, endIndex);
-  return patchLines.filter((line) => {
-    const lineIndex = getDiffPatchLineSelectionIndex(line, displayStyle);
-    if (lineIndex < firstIndex || lineIndex > lastIndex) {
-      return false;
-    }
-    if (displayStyle === "unified") {
-      return true;
-    }
-    return isDiffPatchLineSelectedInSplitView({ line, range });
-  });
-}
-
-function formatUnifiedDiffRange(start: number, count: number) {
-  return count === 1 ? String(start) : `${start},${count}`;
-}
-
-function getMinimumLineNumber(lineNumbers: number[]) {
-  return lineNumbers.length > 0 ? Math.min(...lineNumbers) : null;
-}
-
-function buildDiffPatchHunkHeader(lines: DiffPatchLine[]) {
-  const oldLineNumbers = lines
-    .map((line) => line.oldLineNumber)
-    .filter((lineNumber) => lineNumber !== null);
-  const newLineNumbers = lines
-    .map((line) => line.newLineNumber)
-    .filter((lineNumber) => lineNumber !== null);
-  const oldStart =
-    getMinimumLineNumber(oldLineNumbers) ??
-    Math.max(0, (getMinimumLineNumber(newLineNumbers) ?? 1) - 1);
-  const newStart =
-    getMinimumLineNumber(newLineNumbers) ??
-    Math.max(0, (getMinimumLineNumber(oldLineNumbers) ?? 1) - 1);
-  return `@@ -${formatUnifiedDiffRange(
-    oldStart,
-    oldLineNumbers.length,
-  )} +${formatUnifiedDiffRange(newStart, newLineNumbers.length)} @@`;
-}
-
-function groupDiffPatchLinesByHunk(lines: DiffPatchLine[]) {
-  const groups: DiffPatchLine[][] = [];
-  for (const line of lines) {
-    const previousGroup = groups.at(-1);
-    if (previousGroup?.at(-1)?.hunkIndex === line.hunkIndex) {
-      previousGroup.push(line);
-    } else {
-      groups.push([line]);
-    }
-  }
-  return groups;
-}
-
-function buildUnifiedDiffPatchText({
-  fileDiff,
-  lines,
-}: {
-  fileDiff: ParsedGitDiffFile;
-  lines: DiffPatchLine[];
-}) {
-  const paths = getDiffPatchPaths(fileDiff);
-  const patchTextLines = [
-    `diff --git ${paths.diffGitOldPath} ${paths.diffGitNewPath}`,
-    `--- ${paths.oldHeaderPath}`,
-    `+++ ${paths.newHeaderPath}`,
-  ];
-  for (const group of groupDiffPatchLinesByHunk(lines)) {
-    patchTextLines.push(
-      buildDiffPatchHunkHeader(group),
-      ...group.map((line) => `${line.prefix}${line.text}`),
-    );
-  }
-  return patchTextLines.join("\n");
-}
-
-function buildDiffLineSelectionText({
-  displayStyle,
-  fileDiff,
-  range,
-}: {
-  displayStyle: DiffPatchDisplayStyle;
-  fileDiff: ParsedGitDiffFile;
-  range: SelectedLineRange;
-}): string | null {
-  const patchLines = collectDiffPatchLines(fileDiff);
-  const selectedLines = getSelectedDiffPatchLines({
-    displayStyle,
-    patchLines,
-    range,
-  });
-  if (selectedLines.length === 0) {
-    return null;
-  }
-  return buildUnifiedDiffPatchText({ fileDiff, lines: selectedLines });
-}
-
-function getDiffShadowRoots(containerElement: HTMLElement | null) {
-  if (containerElement === null) {
-    return [];
-  }
-  return Array.from(containerElement.querySelectorAll("diffs-container"))
-    .map((container) => container.shadowRoot)
-    .filter((root) => root !== null);
-}
-
-function getDiffDomLineSide(lineElement: HTMLElement): SelectionSide {
-  const codeElement = lineElement.closest("[data-deletions],[data-additions]");
-  if (codeElement?.hasAttribute("data-deletions")) {
-    return "deletions";
-  }
-  if (codeElement?.hasAttribute("data-additions")) {
-    return "additions";
-  }
-  return lineElement.dataset.lineType === "change-deletion"
-    ? "deletions"
-    : "additions";
-}
-
-function getDiffDomLineNumber(lineElement: HTMLElement): number | null {
-  const lineNumber = Number.parseInt(lineElement.dataset.line ?? "", 10);
-  return Number.isFinite(lineNumber) ? lineNumber : null;
-}
-
-function getDiffDomLineText(lineElement: HTMLElement): string {
-  return (lineElement.textContent ?? "").trimEnd();
-}
-
-function getDiffDomLineIndex(lineElement: HTMLElement) {
-  const [unifiedLineIndex, splitLineIndex] = (
-    lineElement.dataset.lineIndex ?? ""
-  )
-    .split(",")
-    .map((value) => Number.parseInt(value, 10));
-  if (
-    unifiedLineIndex === undefined ||
-    splitLineIndex === undefined ||
-    !Number.isFinite(unifiedLineIndex) ||
-    !Number.isFinite(splitLineIndex)
-  ) {
-    return null;
-  }
-  return { splitLineIndex, unifiedLineIndex };
-}
-
-function getDiffDomPatchPrefix(lineElement: HTMLElement): DiffPatchLinePrefix {
-  switch (lineElement.dataset.lineType) {
-    case "change-deletion":
-      return "-";
-    case "change-addition":
-      return "+";
-    default:
-      return " ";
-  }
-}
-
-function getDiffDomPatchLine({
-  hunkIndex,
-  lineElement,
-}: {
-  hunkIndex: number;
-  lineElement: HTMLElement;
-}): DiffPatchLine | null {
-  const lineIndex = getDiffDomLineIndex(lineElement);
-  if (lineIndex === null) {
-    return null;
-  }
-  const lineNumber = getDiffDomLineNumber(lineElement);
-  const prefix = getDiffDomPatchPrefix(lineElement);
-  const side = getDiffDomLineSide(lineElement);
-  return {
-    hunkIndex,
-    newLineNumber:
-      lineNumber !== null &&
-      (prefix === "+" || (prefix === " " && side === "additions"))
-        ? lineNumber
-        : null,
-    oldLineNumber:
-      lineNumber !== null &&
-      (prefix === "-" || (prefix === " " && side === "deletions"))
-        ? lineNumber
-        : null,
-    prefix,
-    selectionSide: prefix === " " ? null : side,
-    splitLineIndex: lineIndex.splitLineIndex,
-    text: getDiffDomLineText(lineElement),
-    unifiedLineIndex: lineIndex.unifiedLineIndex,
-  };
-}
-
-function mergeDiffDomContextLine(
-  existingLine: DiffPatchLine,
-  nextLine: DiffPatchLine,
-) {
-  return {
-    ...existingLine,
-    newLineNumber: existingLine.newLineNumber ?? nextLine.newLineNumber,
-    oldLineNumber: existingLine.oldLineNumber ?? nextLine.oldLineNumber,
-  };
-}
-
-function buildDiffDomSelectionText({
-  containerElement,
-  fileDiff,
-}: {
-  containerElement: HTMLElement | null;
-  fileDiff: ParsedGitDiffFile;
-}): string | null {
-  if (containerElement === null) {
-    return null;
-  }
-
-  const selectedRows: HTMLElement[] = [];
-  const seenRows = new Set<string>();
-  for (const root of getDiffShadowRoots(containerElement)) {
-    for (const row of root.querySelectorAll<HTMLElement>(
-      "[data-selected-line][data-line]",
-    )) {
-      const text = getDiffDomLineText(row);
-      const lineIndex = row.dataset.lineIndex ?? "";
-      const side = getDiffDomLineSide(row);
-      const key = `${lineIndex}:${side}:${text}`;
-      if (seenRows.has(key)) {
-        continue;
-      }
-      seenRows.add(key);
-      selectedRows.push(row);
-    }
-  }
-
-  if (selectedRows.length === 0) {
-    return null;
-  }
-
-  const patchLineMap = new Map<string, DiffPatchLine>();
-  for (const row of selectedRows) {
-    const patchLine = getDiffDomPatchLine({ hunkIndex: 0, lineElement: row });
-    if (patchLine === null) {
-      continue;
-    }
-    const key = [
-      patchLine.unifiedLineIndex,
-      patchLine.splitLineIndex,
-      patchLine.prefix,
-      patchLine.text,
-    ].join(":");
-    const existingLine = patchLineMap.get(key);
-    patchLineMap.set(
-      key,
-      existingLine !== undefined && patchLine.prefix === " "
-        ? mergeDiffDomContextLine(existingLine, patchLine)
-        : (existingLine ?? patchLine),
-    );
-  }
-  const patchLines = Array.from(patchLineMap.values()).sort((lineA, lineB) => {
-    if (lineA.unifiedLineIndex !== lineB.unifiedLineIndex) {
-      return lineA.unifiedLineIndex - lineB.unifiedLineIndex;
-    }
-    return lineA.prefix.localeCompare(lineB.prefix);
-  });
-  return patchLines.length > 0
-    ? buildUnifiedDiffPatchText({ fileDiff, lines: patchLines })
-    : null;
-}
-
-function GitDiffCardRawDiffBody({
-  fileDiff,
-  fileDiffOptions,
-  onSelectionAddToChat,
-}: GitDiffCardRawDiffBodyProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const displayStyle = getDiffPatchDisplayStyle(fileDiffOptions);
-  const buildSelectionText = useCallback(
-    (range: SelectedLineRange) =>
-      buildDiffLineSelectionText({ displayStyle, fileDiff, range }),
-    [displayStyle, fileDiff],
-  );
-  const buildFallbackSelectionText = useCallback(
-    ({
-      containerElement,
-    }: {
-      containerElement: HTMLElement | null;
-      range: SelectedLineRange;
-    }) => buildDiffDomSelectionText({ containerElement, fileDiff }),
-    [fileDiff],
-  );
-  const lineSelectionActions = usePierreLineSelectionActions({
-    buildFallbackSelectionText,
-    buildSelectionText,
-    containerRef,
-    enabled: onSelectionAddToChat !== undefined,
-    onSelectionAddToChat,
-  });
-  const baseOptions = useMemo<FileDiffOptions<undefined>>(
-    () => ({
-      ...fileDiffOptions,
-      enableGutterUtility: onSelectionAddToChat !== undefined,
-      enableLineSelection: onSelectionAddToChat !== undefined,
-      lineHoverHighlight:
-        onSelectionAddToChat === undefined ? "disabled" : "number",
-      onGutterUtilityClick:
-        onSelectionAddToChat === undefined
-          ? undefined
-          : lineSelectionActions.onGutterUtilityClick,
-      onLineSelectionChange: lineSelectionActions.onLineSelectionChange,
-      onLineSelectionEnd: lineSelectionActions.onLineSelectionEnd,
-      onLineSelectionStart: lineSelectionActions.onLineSelectionStart,
-    }),
-    [
-      fileDiffOptions,
-      lineSelectionActions.onGutterUtilityClick,
-      lineSelectionActions.onLineSelectionChange,
-      lineSelectionActions.onLineSelectionEnd,
-      lineSelectionActions.onLineSelectionStart,
-      onSelectionAddToChat,
-    ],
-  );
-  const options = usePierreStrictModeRecoveryOptions(baseOptions);
-  // `DiffView` captures the worker pool when it creates its instance, so wait
-  // for the workspace to build the pool before the first render.
-  const isWorkerPoolReady = useRequirePierreWorkerPool();
-  if (!isWorkerPoolReady) {
-    return <GitDiffCardBodySkeleton />;
-  }
-  return (
-    <div
-      ref={containerRef}
-      className="overflow-x-auto"
-      onPointerDownCapture={lineSelectionActions.onPointerDownCapture}
-      onPointerMoveCapture={lineSelectionActions.onPointerMoveCapture}
-      onPointerUpCapture={lineSelectionActions.onPointerUpCapture}
-    >
-      <div className="w-full max-w-full" style={GIT_DIFF_CARD_VIEW_STYLE}>
-        <PierreWorkerPoolBoundary>
-          <DiffView
-            fileDiff={fileDiff}
-            options={options}
-            selectedLines={lineSelectionActions.selectedRange}
-          />
-        </PierreWorkerPoolBoundary>
-      </div>
-      {lineSelectionActions.menu}
-    </div>
-  );
-}
-
 interface GitDiffCardSvgBodyProps {
   displayMode: GitDiffCardSvgDisplayMode;
   enrichment: DiffFileEnrichmentState;
   fileDiff: ParsedGitDiffFile;
   fileDiffLabel: string;
-  fileDiffOptions: DiffViewOptions;
+  patchText: string | undefined;
+  presentation: DiffPresentation;
   onSelectionAddToChat?: (text: string) => void;
 }
 
@@ -1371,7 +776,8 @@ function GitDiffCardSvgBody({
   enrichment,
   fileDiff,
   fileDiffLabel,
-  fileDiffOptions,
+  patchText,
+  presentation,
   onSelectionAddToChat,
 }: GitDiffCardSvgBodyProps) {
   return displayMode === "preview" ? (
@@ -1381,9 +787,10 @@ function GitDiffCardSvgBody({
       fitToFrame
     />
   ) : (
-    <GitDiffCardRawDiffBody
-      fileDiff={fileDiff}
-      fileDiffOptions={fileDiffOptions}
+    <DiffHost
+      file={fileDiff}
+      patchText={patchText}
+      {...presentation}
       onSelectionAddToChat={onSelectionAddToChat}
     />
   );
@@ -1391,7 +798,7 @@ function GitDiffCardSvgBody({
 
 export interface GitDiffCardBodyProps {
   state: GitDiffCardBodyState;
-  diffViewOptions: Record<string, string | boolean | number>;
+  presentation: DiffPresentation;
   svgDisplayMode: GitDiffCardSvgDisplayMode;
   /**
    * Whether the surrounding card reserves a collapse-chevron gutter. The deleted
@@ -1403,16 +810,18 @@ export interface GitDiffCardBodyProps {
 
 /**
  * The single shared diff-card body for both the timeline ({@link GitDiffCard})
- * and the diff tab (`DiffFileCard`). It renders the lazily-enriched
- * `@pierre/diffs` `FileDiff` (with context expansion), the deleted-file load
+ * and the diff tab (`DiffFileCard`). It owns everything around the text diff —
+ * the lazy enrichment that unlocks context expansion, the deleted-file load
  * gate, the in-viewport render skeleton, and inline `<img>` previews for binary
- * image changes or SVGs. The data layer lives in {@link useGitDiffCardBody};
- * both callers feed its result in as `state` so the card can also read the image
- * header stat synchronously.
+ * image changes or SVGs — and hands the text diff itself to
+ * {@link DiffHost}, so an `experimental_diffRenderer` replacement covers this
+ * surface too. The data layer lives in {@link useGitDiffCardBody}; both callers
+ * feed its result in as `state` so the card can also read the image header stat
+ * synchronously.
  */
 export function GitDiffCardBody({
   state,
-  diffViewOptions,
+  presentation,
   svgDisplayMode,
   reservesCollapseGutter,
   onSelectionAddToChat,
@@ -1428,16 +837,8 @@ export function GitDiffCardBody({
     shouldRenderDiffView,
     loadDeletedDiff,
     contextExpansion,
+    patchText,
   } = state;
-  const codeTheme = useResolvedCodeThemePair();
-  const fileDiffOptions = useMemo<DiffViewOptions>(
-    () => ({
-      ...diffViewOptions,
-      disableFileHeader: true,
-      theme: codeTheme,
-    }),
-    [codeTheme, diffViewOptions],
-  );
 
   return (
     <div
@@ -1476,14 +877,17 @@ export function GitDiffCardBody({
           enrichment={enrichment}
           fileDiff={enrichedFileDiff}
           fileDiffLabel={fileDiffLabel}
-          fileDiffOptions={fileDiffOptions}
+          patchText={patchText}
+          presentation={presentation}
           onSelectionAddToChat={onSelectionAddToChat}
         />
       ) : (
         <>
-          <GitDiffCardRawDiffBody
-            fileDiff={enrichedFileDiff}
-            fileDiffOptions={fileDiffOptions}
+          <DiffHost
+            file={enrichedFileDiff}
+            patchText={patchText}
+            {...presentation}
+            fallback={<GitDiffCardBodySkeleton />}
             onSelectionAddToChat={onSelectionAddToChat}
           />
           <GitDiffCardContextExpansionFooter

--- a/apps/app/src/components/git-diff/git-diff-parsing.ts
+++ b/apps/app/src/components/git-diff/git-diff-parsing.ts
@@ -24,6 +24,43 @@ export function parseGitDiffFiles(
   }
 }
 
+/** A normalized single-file patch plus the file it parsed to. */
+export interface NormalizedFilePatch {
+  /** Complete patch text, including a `diff --git` header. */
+  patch: string;
+  file: ParsedGitDiffFile;
+}
+
+/**
+ * Normalize and parse patch text for exactly ONE file.
+ *
+ * Patch sources disagree about headers: `git diff` emits a `diff --git` line,
+ * GitHub's REST API and inline review hunks emit bare `@@` hunks. Only the
+ * `diff --git` line puts the parser in git-aware mode — without it the `a/`
+ * and `b/` prefixes survive into the file names and every file reads as a
+ * rename. Completing the header from `path` is what makes one host renderer
+ * able to accept both shapes.
+ *
+ * Returns null when nothing renderable parses out, so callers can fall back to
+ * plain text instead of rendering an empty diff.
+ */
+export function normalizeFilePatch({
+  patch,
+  path,
+}: {
+  patch: string;
+  path: string;
+}): NormalizedFilePatch | null {
+  const normalizedPatch = patch.replace(/\r\n/g, "\n").trimEnd();
+  if (normalizedPatch.length === 0) return null;
+  const normalizedPath = normalizeGitDiffPath(path) ?? path;
+  const patchText = normalizedPatch.startsWith("diff --git")
+    ? `${normalizedPatch}\n`
+    : `diff --git a/${normalizedPath} b/${normalizedPath}\n--- a/${normalizedPath}\n+++ b/${normalizedPath}\n${normalizedPatch}\n`;
+  const file = parseGitDiffFiles(patchText)[0];
+  return file === undefined ? null : { patch: patchText, file };
+}
+
 export interface GitDiffContextEnrichmentInput {
   fileDiff: ParsedGitDiffFile;
   oldFile: FileContents;

--- a/apps/app/src/components/git-diff/git-diff-parsing.ts
+++ b/apps/app/src/components/git-diff/git-diff-parsing.ts
@@ -41,8 +41,10 @@ export interface NormalizedFilePatch {
  * rename. Completing the header from `path` is what makes one host renderer
  * able to accept both shapes.
  *
- * Returns null when nothing renderable parses out, so callers can fall back to
- * plain text instead of rendering an empty diff.
+ * Returns null when nothing renderable parses out — including the case that
+ * matters most in practice, text that is not a patch at all: completing a
+ * header in front of it still parses, just to a file with no hunks, which
+ * would render as an empty diff instead of showing the caller their content.
  */
 export function normalizeFilePatch({
   patch,
@@ -58,7 +60,8 @@ export function normalizeFilePatch({
     ? `${normalizedPatch}\n`
     : `diff --git a/${normalizedPath} b/${normalizedPath}\n--- a/${normalizedPath}\n+++ b/${normalizedPath}\n${normalizedPatch}\n`;
   const file = parseGitDiffFiles(patchText)[0];
-  return file === undefined ? null : { patch: patchText, file };
+  if (file === undefined || file.hunks.length === 0) return null;
+  return { patch: patchText, file };
 }
 
 export interface GitDiffContextEnrichmentInput {

--- a/apps/app/src/components/git-diff/git-diff-patch-text.ts
+++ b/apps/app/src/components/git-diff/git-diff-patch-text.ts
@@ -1,0 +1,522 @@
+import type { SelectedLineRange, SelectionSide } from "@pierre/diffs";
+import {
+  normalizeGitDiffPath,
+  type ParsedGitDiffFile,
+} from "./git-diff-parsing";
+
+/**
+ * Unified-patch text reconstruction for one parsed diff file.
+ *
+ * Two callers need it and neither can read the original patch bytes: the
+ * line-selection "add to chat" action, which must emit exactly the lines the
+ * user highlighted (including the DOM fallback for selections Pierre reports
+ * only as shadow-DOM state), and the host diff boundary, which hands a plugin
+ * replacement a complete single-file patch even when the caller only had a
+ * parsed file in hand.
+ */
+
+export type DiffPatchDisplayStyle = "unified" | "split";
+type DiffPatchLinePrefix = " " | "+" | "-";
+
+interface DiffPatchLine {
+  hunkIndex: number;
+  newLineNumber: number | null;
+  oldLineNumber: number | null;
+  prefix: DiffPatchLinePrefix;
+  selectionSide: SelectionSide | null;
+  splitLineIndex: number;
+  text: string;
+  unifiedLineIndex: number;
+}
+
+function trimDiffLineEnding(line: string) {
+  return line.replace(/(?:\r\n|\n|\r)$/u, "");
+}
+
+function getDiffLineNumberFromIndex({
+  hunkLineIndex,
+  hunkStart,
+  lineIndex,
+}: {
+  hunkLineIndex: number;
+  hunkStart: number;
+  lineIndex: number;
+}) {
+  return hunkStart + (lineIndex - hunkLineIndex);
+}
+
+function formatPrefixedDiffPath(path: string, prefix: "a" | "b") {
+  if (path === "/dev/null") {
+    return path;
+  }
+  return path.startsWith(`${prefix}/`) ? path : `${prefix}/${path}`;
+}
+
+function getDiffPatchPaths(fileDiff: ParsedGitDiffFile) {
+  const currentPath = normalizeGitDiffPath(fileDiff.name) ?? fileDiff.name;
+  const previousPath = normalizeGitDiffPath(fileDiff.prevName) ?? currentPath;
+  const gitOldPath = previousPath === "/dev/null" ? currentPath : previousPath;
+  const gitNewPath = currentPath === "/dev/null" ? previousPath : currentPath;
+  return {
+    diffGitOldPath: formatPrefixedDiffPath(gitOldPath, "a"),
+    diffGitNewPath: formatPrefixedDiffPath(gitNewPath, "b"),
+    oldHeaderPath:
+      fileDiff.type === "new"
+        ? "/dev/null"
+        : formatPrefixedDiffPath(previousPath, "a"),
+    newHeaderPath:
+      fileDiff.type === "deleted"
+        ? "/dev/null"
+        : formatPrefixedDiffPath(currentPath, "b"),
+  };
+}
+
+export function collectDiffPatchLines(fileDiff: ParsedGitDiffFile): DiffPatchLine[] {
+  const patchLines: DiffPatchLine[] = [];
+
+  fileDiff.hunks.forEach((hunk, hunkIndex) => {
+    let unifiedLineIndex = hunk.unifiedLineStart;
+    let splitLineIndex = hunk.splitLineStart;
+    let deletionLineIndex = hunk.deletionLineIndex;
+    let additionLineIndex = hunk.additionLineIndex;
+
+    for (const content of hunk.hunkContent) {
+      if (content.type === "context") {
+        for (let offset = 0; offset < content.lines; offset += 1) {
+          const oldLineIndex = deletionLineIndex + offset;
+          const newLineIndex = additionLineIndex + offset;
+          const lineText =
+            fileDiff.additionLines[newLineIndex] ??
+            fileDiff.deletionLines[oldLineIndex];
+          if (lineText === undefined) {
+            continue;
+          }
+          patchLines.push({
+            hunkIndex,
+            newLineNumber: getDiffLineNumberFromIndex({
+              hunkLineIndex: hunk.additionLineIndex,
+              hunkStart: hunk.additionStart,
+              lineIndex: newLineIndex,
+            }),
+            oldLineNumber: getDiffLineNumberFromIndex({
+              hunkLineIndex: hunk.deletionLineIndex,
+              hunkStart: hunk.deletionStart,
+              lineIndex: oldLineIndex,
+            }),
+            prefix: " ",
+            selectionSide: null,
+            splitLineIndex: splitLineIndex + offset,
+            text: trimDiffLineEnding(lineText),
+            unifiedLineIndex: unifiedLineIndex + offset,
+          });
+        }
+        unifiedLineIndex += content.lines;
+        splitLineIndex += content.lines;
+        deletionLineIndex += content.lines;
+        additionLineIndex += content.lines;
+        continue;
+      }
+
+      const splitCount = Math.max(content.deletions, content.additions);
+      const unifiedCount = content.deletions + content.additions;
+      for (let offset = 0; offset < content.deletions; offset += 1) {
+        const oldLineIndex = deletionLineIndex + offset;
+        const lineText = fileDiff.deletionLines[oldLineIndex];
+        if (lineText === undefined) {
+          continue;
+        }
+        patchLines.push({
+          hunkIndex,
+          newLineNumber: null,
+          oldLineNumber: getDiffLineNumberFromIndex({
+            hunkLineIndex: hunk.deletionLineIndex,
+            hunkStart: hunk.deletionStart,
+            lineIndex: oldLineIndex,
+          }),
+          prefix: "-",
+          selectionSide: "deletions",
+          splitLineIndex: splitLineIndex + offset,
+          text: trimDiffLineEnding(lineText),
+          unifiedLineIndex: unifiedLineIndex + offset,
+        });
+      }
+      for (let offset = 0; offset < content.additions; offset += 1) {
+        const newLineIndex = additionLineIndex + offset;
+        const lineText = fileDiff.additionLines[newLineIndex];
+        if (lineText === undefined) {
+          continue;
+        }
+        patchLines.push({
+          hunkIndex,
+          newLineNumber: getDiffLineNumberFromIndex({
+            hunkLineIndex: hunk.additionLineIndex,
+            hunkStart: hunk.additionStart,
+            lineIndex: newLineIndex,
+          }),
+          oldLineNumber: null,
+          prefix: "+",
+          selectionSide: "additions",
+          splitLineIndex: splitLineIndex + offset,
+          text: trimDiffLineEnding(lineText),
+          unifiedLineIndex: unifiedLineIndex + content.deletions + offset,
+        });
+      }
+      unifiedLineIndex += unifiedCount;
+      splitLineIndex += splitCount;
+      deletionLineIndex += content.deletions;
+      additionLineIndex += content.additions;
+    }
+  });
+
+  return patchLines;
+}
+
+function getDiffPatchLineSelectionIndex(
+  line: DiffPatchLine,
+  displayStyle: DiffPatchDisplayStyle,
+) {
+  return displayStyle === "split" ? line.splitLineIndex : line.unifiedLineIndex;
+}
+
+function getDiffPatchSelectionPointIndex({
+  displayStyle,
+  lineNumber,
+  patchLines,
+  side,
+}: {
+  displayStyle: DiffPatchDisplayStyle;
+  lineNumber: number;
+  patchLines: DiffPatchLine[];
+  side: SelectionSide | undefined;
+}) {
+  const sides: SelectionSide[] =
+    side === undefined ? ["additions", "deletions"] : [side];
+  for (const candidateSide of sides) {
+    const line = patchLines.find((patchLine) =>
+      candidateSide === "additions"
+        ? patchLine.newLineNumber === lineNumber
+        : patchLine.oldLineNumber === lineNumber,
+    );
+    if (line !== undefined) {
+      return getDiffPatchLineSelectionIndex(line, displayStyle);
+    }
+  }
+  return null;
+}
+
+function isDiffPatchLineSelectedInSplitView({
+  line,
+  range,
+}: {
+  line: DiffPatchLine;
+  range: SelectedLineRange;
+}) {
+  const startSide = range.side ?? range.endSide ?? "additions";
+  const endSide = range.endSide ?? startSide;
+  if (startSide !== endSide || line.selectionSide === null) {
+    return true;
+  }
+  return line.selectionSide === startSide;
+}
+
+function getSelectedDiffPatchLines({
+  displayStyle,
+  patchLines,
+  range,
+}: {
+  displayStyle: DiffPatchDisplayStyle;
+  patchLines: DiffPatchLine[];
+  range: SelectedLineRange;
+}) {
+  const startIndex = getDiffPatchSelectionPointIndex({
+    displayStyle,
+    lineNumber: range.start,
+    patchLines,
+    side: range.side,
+  });
+  const endIndex = getDiffPatchSelectionPointIndex({
+    displayStyle,
+    lineNumber: range.end,
+    patchLines,
+    side: range.endSide ?? range.side,
+  });
+  if (startIndex === null || endIndex === null) {
+    return [];
+  }
+
+  const firstIndex = Math.min(startIndex, endIndex);
+  const lastIndex = Math.max(startIndex, endIndex);
+  return patchLines.filter((line) => {
+    const lineIndex = getDiffPatchLineSelectionIndex(line, displayStyle);
+    if (lineIndex < firstIndex || lineIndex > lastIndex) {
+      return false;
+    }
+    if (displayStyle === "unified") {
+      return true;
+    }
+    return isDiffPatchLineSelectedInSplitView({ line, range });
+  });
+}
+
+function formatUnifiedDiffRange(start: number, count: number) {
+  return count === 1 ? String(start) : `${start},${count}`;
+}
+
+function getMinimumLineNumber(lineNumbers: number[]) {
+  return lineNumbers.length > 0 ? Math.min(...lineNumbers) : null;
+}
+
+function buildDiffPatchHunkHeader(lines: DiffPatchLine[]) {
+  const oldLineNumbers = lines
+    .map((line) => line.oldLineNumber)
+    .filter((lineNumber) => lineNumber !== null);
+  const newLineNumbers = lines
+    .map((line) => line.newLineNumber)
+    .filter((lineNumber) => lineNumber !== null);
+  const oldStart =
+    getMinimumLineNumber(oldLineNumbers) ??
+    Math.max(0, (getMinimumLineNumber(newLineNumbers) ?? 1) - 1);
+  const newStart =
+    getMinimumLineNumber(newLineNumbers) ??
+    Math.max(0, (getMinimumLineNumber(oldLineNumbers) ?? 1) - 1);
+  return `@@ -${formatUnifiedDiffRange(
+    oldStart,
+    oldLineNumbers.length,
+  )} +${formatUnifiedDiffRange(newStart, newLineNumbers.length)} @@`;
+}
+
+function groupDiffPatchLinesByHunk(lines: DiffPatchLine[]) {
+  const groups: DiffPatchLine[][] = [];
+  for (const line of lines) {
+    const previousGroup = groups.at(-1);
+    if (previousGroup?.at(-1)?.hunkIndex === line.hunkIndex) {
+      previousGroup.push(line);
+    } else {
+      groups.push([line]);
+    }
+  }
+  return groups;
+}
+
+export function buildUnifiedDiffPatchText({
+  fileDiff,
+  lines,
+}: {
+  fileDiff: ParsedGitDiffFile;
+  lines: DiffPatchLine[];
+}) {
+  const paths = getDiffPatchPaths(fileDiff);
+  const patchTextLines = [
+    `diff --git ${paths.diffGitOldPath} ${paths.diffGitNewPath}`,
+    `--- ${paths.oldHeaderPath}`,
+    `+++ ${paths.newHeaderPath}`,
+  ];
+  for (const group of groupDiffPatchLinesByHunk(lines)) {
+    patchTextLines.push(
+      buildDiffPatchHunkHeader(group),
+      ...group.map((line) => `${line.prefix}${line.text}`),
+    );
+  }
+  return patchTextLines.join("\n");
+}
+
+/**
+ * Reconstruct a complete single-file unified patch from a parsed diff. The
+ * host diff boundary uses it to hand a plugin replacement real patch text when
+ * the caller no longer has the bytes the file was parsed from.
+ */
+export function buildFileDiffPatchText(fileDiff: ParsedGitDiffFile): string {
+  return buildUnifiedDiffPatchText({
+    fileDiff,
+    lines: collectDiffPatchLines(fileDiff),
+  });
+}
+
+export function buildDiffLineSelectionText({
+  displayStyle,
+  fileDiff,
+  range,
+}: {
+  displayStyle: DiffPatchDisplayStyle;
+  fileDiff: ParsedGitDiffFile;
+  range: SelectedLineRange;
+}): string | null {
+  const patchLines = collectDiffPatchLines(fileDiff);
+  const selectedLines = getSelectedDiffPatchLines({
+    displayStyle,
+    patchLines,
+    range,
+  });
+  if (selectedLines.length === 0) {
+    return null;
+  }
+  return buildUnifiedDiffPatchText({ fileDiff, lines: selectedLines });
+}
+
+function getDiffShadowRoots(containerElement: HTMLElement | null) {
+  if (containerElement === null) {
+    return [];
+  }
+  return Array.from(containerElement.querySelectorAll("diffs-container"))
+    .map((container) => container.shadowRoot)
+    .filter((root) => root !== null);
+}
+
+function getDiffDomLineSide(lineElement: HTMLElement): SelectionSide {
+  const codeElement = lineElement.closest("[data-deletions],[data-additions]");
+  if (codeElement?.hasAttribute("data-deletions")) {
+    return "deletions";
+  }
+  if (codeElement?.hasAttribute("data-additions")) {
+    return "additions";
+  }
+  return lineElement.dataset.lineType === "change-deletion"
+    ? "deletions"
+    : "additions";
+}
+
+function getDiffDomLineNumber(lineElement: HTMLElement): number | null {
+  const lineNumber = Number.parseInt(lineElement.dataset.line ?? "", 10);
+  return Number.isFinite(lineNumber) ? lineNumber : null;
+}
+
+function getDiffDomLineText(lineElement: HTMLElement): string {
+  return (lineElement.textContent ?? "").trimEnd();
+}
+
+function getDiffDomLineIndex(lineElement: HTMLElement) {
+  const [unifiedLineIndex, splitLineIndex] = (
+    lineElement.dataset.lineIndex ?? ""
+  )
+    .split(",")
+    .map((value) => Number.parseInt(value, 10));
+  if (
+    unifiedLineIndex === undefined ||
+    splitLineIndex === undefined ||
+    !Number.isFinite(unifiedLineIndex) ||
+    !Number.isFinite(splitLineIndex)
+  ) {
+    return null;
+  }
+  return { splitLineIndex, unifiedLineIndex };
+}
+
+function getDiffDomPatchPrefix(lineElement: HTMLElement): DiffPatchLinePrefix {
+  switch (lineElement.dataset.lineType) {
+    case "change-deletion":
+      return "-";
+    case "change-addition":
+      return "+";
+    default:
+      return " ";
+  }
+}
+
+function getDiffDomPatchLine({
+  hunkIndex,
+  lineElement,
+}: {
+  hunkIndex: number;
+  lineElement: HTMLElement;
+}): DiffPatchLine | null {
+  const lineIndex = getDiffDomLineIndex(lineElement);
+  if (lineIndex === null) {
+    return null;
+  }
+  const lineNumber = getDiffDomLineNumber(lineElement);
+  const prefix = getDiffDomPatchPrefix(lineElement);
+  const side = getDiffDomLineSide(lineElement);
+  return {
+    hunkIndex,
+    newLineNumber:
+      lineNumber !== null &&
+      (prefix === "+" || (prefix === " " && side === "additions"))
+        ? lineNumber
+        : null,
+    oldLineNumber:
+      lineNumber !== null &&
+      (prefix === "-" || (prefix === " " && side === "deletions"))
+        ? lineNumber
+        : null,
+    prefix,
+    selectionSide: prefix === " " ? null : side,
+    splitLineIndex: lineIndex.splitLineIndex,
+    text: getDiffDomLineText(lineElement),
+    unifiedLineIndex: lineIndex.unifiedLineIndex,
+  };
+}
+
+function mergeDiffDomContextLine(
+  existingLine: DiffPatchLine,
+  nextLine: DiffPatchLine,
+) {
+  return {
+    ...existingLine,
+    newLineNumber: existingLine.newLineNumber ?? nextLine.newLineNumber,
+    oldLineNumber: existingLine.oldLineNumber ?? nextLine.oldLineNumber,
+  };
+}
+
+export function buildDiffDomSelectionText({
+  containerElement,
+  fileDiff,
+}: {
+  containerElement: HTMLElement | null;
+  fileDiff: ParsedGitDiffFile;
+}): string | null {
+  if (containerElement === null) {
+    return null;
+  }
+
+  const selectedRows: HTMLElement[] = [];
+  const seenRows = new Set<string>();
+  for (const root of getDiffShadowRoots(containerElement)) {
+    for (const row of root.querySelectorAll<HTMLElement>(
+      "[data-selected-line][data-line]",
+    )) {
+      const text = getDiffDomLineText(row);
+      const lineIndex = row.dataset.lineIndex ?? "";
+      const side = getDiffDomLineSide(row);
+      const key = `${lineIndex}:${side}:${text}`;
+      if (seenRows.has(key)) {
+        continue;
+      }
+      seenRows.add(key);
+      selectedRows.push(row);
+    }
+  }
+
+  if (selectedRows.length === 0) {
+    return null;
+  }
+
+  const patchLineMap = new Map<string, DiffPatchLine>();
+  for (const row of selectedRows) {
+    const patchLine = getDiffDomPatchLine({ hunkIndex: 0, lineElement: row });
+    if (patchLine === null) {
+      continue;
+    }
+    const key = [
+      patchLine.unifiedLineIndex,
+      patchLine.splitLineIndex,
+      patchLine.prefix,
+      patchLine.text,
+    ].join(":");
+    const existingLine = patchLineMap.get(key);
+    patchLineMap.set(
+      key,
+      existingLine !== undefined && patchLine.prefix === " "
+        ? mergeDiffDomContextLine(existingLine, patchLine)
+        : (existingLine ?? patchLine),
+    );
+  }
+  const patchLines = Array.from(patchLineMap.values()).sort((lineA, lineB) => {
+    if (lineA.unifiedLineIndex !== lineB.unifiedLineIndex) {
+      return lineA.unifiedLineIndex - lineB.unifiedLineIndex;
+    }
+    return lineA.prefix.localeCompare(lineB.prefix);
+  });
+  return patchLines.length > 0
+    ? buildUnifiedDiffPatchText({ fileDiff, lines: patchLines })
+    : null;
+}

--- a/apps/app/src/components/plugin/PluginDiff.tsx
+++ b/apps/app/src/components/plugin/PluginDiff.tsx
@@ -1,0 +1,48 @@
+import { useMemo } from "react";
+import type { DiffProps } from "@get-bb/plugin-sdk";
+import { DiffHost } from "@/components/code/DiffHost";
+import { normalizeFilePatch } from "@/components/git-diff/git-diff-parsing";
+import { cn } from "@bb/shared-ui/lib/utils";
+
+/**
+ * The public `experimental_Diff` component. It normalizes whatever patch shape
+ * the caller has (a `git diff` patch, a GitHub REST patch, a single `@@` hunk)
+ * into one the renderer understands, then hands it to the host boundary.
+ * Content that does not parse as a patch degrades to plain monospace text
+ * rather than to an empty diff.
+ */
+export function PluginDiff({
+  patch,
+  path,
+  view,
+  overflow,
+  showLineNumbers,
+  className,
+}: DiffProps) {
+  const normalized = useMemo(
+    () => normalizeFilePatch({ patch, path }),
+    [patch, path],
+  );
+  if (normalized === null) {
+    return (
+      <pre
+        className={cn(
+          "overflow-x-auto px-3 py-2 font-mono text-xs leading-5 text-foreground/80",
+          className,
+        )}
+      >
+        {patch}
+      </pre>
+    );
+  }
+  return (
+    <DiffHost
+      file={normalized.file}
+      patchText={normalized.patch}
+      view={view}
+      overflow={overflow}
+      showLineNumbers={showLineNumbers}
+      className={className}
+    />
+  );
+}

--- a/apps/app/src/components/plugin/PluginSourceCode.tsx
+++ b/apps/app/src/components/plugin/PluginSourceCode.tsx
@@ -1,0 +1,26 @@
+import type { SourceCodeProps } from "@get-bb/plugin-sdk";
+import { SourceCodeHost } from "@/components/code/SourceCodeHost";
+
+/**
+ * The public `experimental_SourceCode` component. It is the host boundary with
+ * the host-only inputs withheld: a plugin supplies text and presentation, and
+ * BB owns highlighting, gutters, the live code theme, and any active
+ * `experimental_sourceCodeRenderer` replacement.
+ */
+export function PluginSourceCode({
+  content,
+  path,
+  overflow,
+  highlightedLines,
+  className,
+}: SourceCodeProps) {
+  return (
+    <SourceCodeHost
+      content={content}
+      path={path}
+      overflow={overflow}
+      highlightedLines={highlightedLines ?? null}
+      className={className}
+    />
+  );
+}

--- a/apps/app/src/components/secondary-panel/FilePreview.stories.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.stories.tsx
@@ -234,7 +234,6 @@ export function Overview() {
               file: {
                 name: "Button.tsx",
                 contents: SAMPLE_BUTTON_TSX,
-                lang: "tsx",
               },
             }}
           />
@@ -257,7 +256,6 @@ export function Overview() {
                 cacheKey: "story:large.ts",
                 name: "large.ts",
                 contents: SAMPLE_LARGE_TS,
-                lang: "ts",
               },
             }}
           />
@@ -283,7 +281,6 @@ export function Overview() {
                 cacheKey: "story:large.ts",
                 name: "large.ts",
                 contents: SAMPLE_LARGE_TS,
-                lang: "ts",
               },
             }}
           />
@@ -306,7 +303,6 @@ export function Overview() {
                   cacheKey: "story:skill-script",
                   name: "lint.ts",
                   contents: SAMPLE_LARGE_TS.split("\n").slice(0, 400).join("\n"),
-                  lang: "ts",
                 },
               }}
             />
@@ -330,7 +326,6 @@ export function Overview() {
               file: {
                 name: "legacy-button.tsx",
                 contents: SAMPLE_BUTTON_TSX,
-                lang: "tsx",
               },
             }}
           />

--- a/apps/app/src/components/secondary-panel/FilePreview.test.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.test.tsx
@@ -10,11 +10,11 @@ import {
 import { act, type ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  FILE_PREVIEW_CODE_MAX_LINES,
   FilePreview,
   buildCsvPreviewData,
   getCsvTruncationNote,
 } from "./FilePreview";
+import { SOURCE_CODE_MAX_LINES } from "@/components/code/source-code-budget";
 import { SecondaryPanelFilePreview } from "./ThreadStorageFilePreview";
 import {
   PierreWorkerPoolGateContext,
@@ -354,7 +354,7 @@ describe("FilePreview", () => {
     // The code view scrolls its own virtualized viewport (which sits at the
     // origin in jsdom), not the surrounding panel scroller.
     const codeViewport = scrollViewport.querySelector<HTMLElement>(
-      "[data-file-preview-code-viewport]",
+      "[data-bb-source-code-viewport]",
     );
     expect(codeViewport).not.toBeNull();
     await waitFor(() => {
@@ -368,7 +368,7 @@ describe("FilePreview", () => {
     expect(
       pierreFile.shadowRoot
         ?.querySelector('[data-line="2"]')
-        ?.hasAttribute("data-file-preview-target-line"),
+        ?.hasAttribute("data-bb-source-code-target-line"),
     ).toBe(true);
   });
 
@@ -417,7 +417,7 @@ describe("FilePreview", () => {
   });
 
   it("caps oversized code previews to a leading prefix until the full file is requested", async () => {
-    const totalLineCount = FILE_PREVIEW_CODE_MAX_LINES + 1_500;
+    const totalLineCount = SOURCE_CODE_MAX_LINES + 1_500;
     const contents = Array.from(
       { length: totalLineCount },
       (_, index) => `line ${index + 1}`,
@@ -442,7 +442,7 @@ describe("FilePreview", () => {
 
     await screen.findByTestId("pierre-file");
     expect(pierreMock.state.lastFile?.contents.split("\n")).toHaveLength(
-      FILE_PREVIEW_CODE_MAX_LINES,
+      SOURCE_CODE_MAX_LINES,
     );
     // The capped prefix must not share the full file's highlight cache slot.
     expect(pierreMock.state.lastFile?.cacheKey).toBe(
@@ -450,7 +450,7 @@ describe("FilePreview", () => {
     );
     expect(
       screen.getByText(
-        `Showing the first ${FILE_PREVIEW_CODE_MAX_LINES.toLocaleString()} of ${totalLineCount.toLocaleString()} lines.`,
+        `Showing the first ${SOURCE_CODE_MAX_LINES.toLocaleString()} of ${totalLineCount.toLocaleString()} lines.`,
       ),
     ).toBeTruthy();
 
@@ -488,7 +488,7 @@ describe("FilePreview", () => {
   });
 
   it("shows the whole file when a line link points past the capped prefix", async () => {
-    const totalLineCount = FILE_PREVIEW_CODE_MAX_LINES + 20;
+    const totalLineCount = SOURCE_CODE_MAX_LINES + 20;
     const contents = Array.from(
       { length: totalLineCount },
       (_, index) => `line ${index + 1}`,
@@ -502,8 +502,8 @@ describe("FilePreview", () => {
           kind: "ready",
           file: { name: "generated.ts", contents },
           lineRange: {
-            startLineNumber: FILE_PREVIEW_CODE_MAX_LINES + 10,
-            endLineNumber: FILE_PREVIEW_CODE_MAX_LINES + 10,
+            startLineNumber: SOURCE_CODE_MAX_LINES + 10,
+            endLineNumber: SOURCE_CODE_MAX_LINES + 10,
           },
           textPreviewKind: null,
         }}

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -1,25 +1,7 @@
-import {
-  type CSSProperties,
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import { File as PierreFile, VirtualizerContext } from "@pierre/diffs/react";
-import type { FileOptions } from "@pierre/diffs/react";
-import {
-  DIFFS_TAG_NAME,
-  Virtualizer as PierreVirtualizer,
-  type SelectedLineRange,
-  type SupportedLanguages,
-  type VirtualFileMetrics,
-} from "@pierre/diffs";
+import { type CSSProperties, useEffect, useMemo, useState } from "react";
 import type { UrlTransform } from "react-markdown";
 import { Button } from "@bb/shared-ui/button";
-import { usePierreLineSelectionActions } from "@/components/git-diff/PierreLineSelectionActions.js";
+import { SourceCodeHost } from "@/components/code/SourceCodeHost";
 import { COARSE_POINTER_TEXT_SM_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import { EmptyStatePanel } from "@bb/shared-ui/empty-state";
 import { CopyButton } from "@/components/ui/copy-button.js";
@@ -37,14 +19,7 @@ import {
   TooltipTrigger,
 } from "@bb/shared-ui/tooltip";
 import { TruncateStart } from "@/components/ui/truncate-start.js";
-import { usePreferredTheme } from "@/hooks/useTheme";
-import { useResolvedCodeThemePair } from "@/lib/code-theme";
 import { copyToClipboardWithToast } from "@/lib/clipboard";
-import { PierreWorkerPoolBoundary } from "@/lib/pierre-worker-pool-boundary";
-import {
-  usePierreWorkerPool,
-  useRequirePierreWorkerPool,
-} from "@/lib/pierre-worker-pool-gate";
 import type {
   FilePreviewLineRange,
   WorkspaceFilePreviewStatusLabel,
@@ -61,7 +36,6 @@ export interface FilePreviewFile {
   cacheKey?: string;
   name: string;
   contents: string;
-  lang?: SupportedLanguages;
 }
 
 export type IframePreviewSandbox = "allow-scripts";
@@ -185,18 +159,6 @@ interface FilePreviewCodeProps {
   path: string;
 }
 
-interface FilePreviewWorkerPoolStats {
-  managerState: "waiting" | "initializing" | "initialized";
-  workersFailed: boolean;
-  totalWorkers: number;
-  busyWorkers: number;
-  queuedTasks: number;
-  activeTasks: number;
-  themeSubscribers: number;
-  fileCacheSize: number;
-  diffCacheSize: number;
-}
-
 interface GetInitialFilePreviewViewModeArgs {
   lineRange: FilePreviewLineRange | null;
   toggleKind: FilePreviewToggleKind | null;
@@ -224,101 +186,6 @@ const CSV_PREVIEW_MAX_ROWS = 500;
  * file is what stalls iOS Safari; the prefix keeps the first paint bounded and
  * the full file stays one tap away.
  */
-export const FILE_PREVIEW_CODE_MAX_LINES = 5_000;
-export const FILE_PREVIEW_CODE_MAX_CHARS = 512 * 1024;
-
-const FILE_PREVIEW_CODE_LINE_HEIGHT_PX = 18;
-const FILE_PREVIEW_CODE_GAP_BLOCK_PX = 16;
-
-const FILE_PREVIEW_VIEW_STYLE = {
-  "--diffs-font-size": "12px",
-  "--diffs-line-height": `${FILE_PREVIEW_CODE_LINE_HEIGHT_PX}px`,
-  // Pierre paints its theme bg inside this gap, so the top breathing room of
-  // the code body lives on Pierre's bg — not on the panel's bg-background.
-  // Without this, the gap above Pierre would show a visible bg-color seam.
-  "--diffs-gap-block": `${FILE_PREVIEW_CODE_GAP_BLOCK_PX}px`,
-} as CSSProperties;
-
-// Pierre's virtualizer estimates row positions from these before it measures
-// them; they mirror the CSS variables above so the first layout guess is exact
-// in `scroll` overflow mode (fixed-height rows) and close in `wrap` mode.
-const FILE_PREVIEW_VIRTUAL_FILE_METRICS: VirtualFileMetrics = {
-  hunkLineCount: 50,
-  lineHeight: FILE_PREVIEW_CODE_LINE_HEIGHT_PX,
-  diffHeaderHeight: 0,
-  spacing: FILE_PREVIEW_CODE_GAP_BLOCK_PX,
-};
-
-export interface FilePreviewCodeTruncation {
-  /** The rendered prefix, cut at a line boundary. */
-  contents: string;
-  renderedLineCount: number;
-  totalLineCount: number;
-}
-
-// FNV-1a over the contents; only used to derive a mount key for previews
-// whose caller did not supply a `cacheKey`.
-function hashFilePreviewContents(contents: string): string {
-  let hash = 0x811c9dc5;
-  for (let index = 0; index < contents.length; index += 1) {
-    hash ^= contents.charCodeAt(index);
-    hash = Math.imul(hash, 0x01000193);
-  }
-  return `${contents.length}:${(hash >>> 0).toString(36)}`;
-}
-
-function countLines(contents: string): number {
-  if (contents.length === 0) return 0;
-  let count = 1;
-  for (let index = contents.indexOf("\n"); index !== -1; ) {
-    count += 1;
-    index = contents.indexOf("\n", index + 1);
-  }
-  return contents.endsWith("\n") ? count - 1 : count;
-}
-
-/**
- * Decide whether a code preview exceeds {@link FILE_PREVIEW_CODE_MAX_LINES} or
- * {@link FILE_PREVIEW_CODE_MAX_CHARS} and, if so, return the leading prefix
- * that fits both budgets. Returns `null` when the whole file fits.
- */
-export function truncateFilePreviewCode(
-  contents: string,
-): FilePreviewCodeTruncation | null {
-  const totalLineCount = countLines(contents);
-  if (
-    contents.length <= FILE_PREVIEW_CODE_MAX_CHARS &&
-    totalLineCount <= FILE_PREVIEW_CODE_MAX_LINES
-  ) {
-    return null;
-  }
-  let renderedLineCount = 0;
-  let cutIndex = 0;
-  for (
-    let lineStart = 0;
-    lineStart < contents.length &&
-    renderedLineCount < FILE_PREVIEW_CODE_MAX_LINES;
-  ) {
-    const newlineIndex = contents.indexOf("\n", lineStart);
-    const lineEnd = newlineIndex === -1 ? contents.length : newlineIndex;
-    if (lineEnd > FILE_PREVIEW_CODE_MAX_CHARS && renderedLineCount > 0) {
-      break;
-    }
-    renderedLineCount += 1;
-    cutIndex = lineEnd;
-    lineStart = lineEnd + 1;
-  }
-  return {
-    contents: contents.slice(0, cutIndex),
-    renderedLineCount,
-    totalLineCount,
-  };
-}
-
-// `--md-content-w` tells MarkdownPreview the surrounding text-column width so
-// narrow tables sit flush with the prose on the left instead of centering in
-// the panel. `100cqi` resolves against the `@container/page` scope on the
-// wrapper below — i.e. the panel width.
 const FILE_PREVIEW_WRAPPER_STYLE = {
   "--md-content-w": "100cqi",
 } as CSSProperties;
@@ -1203,216 +1070,6 @@ function IframeFilePreview({ sandbox, title, url }: IframeFilePreviewTarget) {
   );
 }
 
-function getPreviewTargetRoots(container: HTMLElement): ParentNode[] {
-  const roots: ParentNode[] = [container];
-  // Pierre owns its rendered line elements inside an open shadow root, which
-  // normal descendant queries on the React wrapper cannot cross.
-  for (const pierreContainer of container.querySelectorAll<HTMLElement>(
-    DIFFS_TAG_NAME,
-  )) {
-    if (pierreContainer.shadowRoot !== null) {
-      roots.push(pierreContainer.shadowRoot);
-    }
-  }
-  return roots;
-}
-
-function clearPreviewTargetLine(container: HTMLElement) {
-  for (const root of getPreviewTargetRoots(container)) {
-    const targetLines = root.querySelectorAll(
-      "[data-file-preview-target-line]",
-    );
-    for (const targetLine of targetLines) {
-      targetLine.removeAttribute("data-file-preview-target-line");
-      targetLine.removeAttribute("data-selected-line");
-    }
-  }
-}
-
-function findPreviewTargetLine(
-  container: HTMLElement,
-  lineNumber: number,
-): HTMLElement | null {
-  const roots = getPreviewTargetRoots(container);
-  for (const root of roots) {
-    const lines = root.querySelectorAll(`[data-line="${lineNumber}"]`);
-    for (const line of lines) {
-      if (line instanceof HTMLElement && line.dataset.lineIndex !== undefined) {
-        return line;
-      }
-    }
-  }
-  for (const root of roots) {
-    const lines = root.querySelectorAll(`[data-line="${lineNumber}"]`);
-    for (const line of lines) {
-      if (line instanceof HTMLElement) {
-        return line;
-      }
-    }
-  }
-  return null;
-}
-
-function findVirtualizedCodeViewport(
-  container: HTMLElement,
-): HTMLElement | null {
-  return container.querySelector<HTMLElement>(
-    "[data-file-preview-code-viewport]",
-  );
-}
-
-/**
- * Nudge the virtualized code viewport toward `lineNumber` when that row is not
- * realized yet. With rendered rows in hand the distance is measured from the
- * nearest one (rows are at least one line tall, so the step never overshoots
- * in `wrap` mode); with none rendered the offset is estimated from the fixed
- * line metrics. Each call moves at most to the estimate; the caller retries on
- * the next frame once pierre has rendered the new window.
- */
-function approachVirtualizedTargetLine(
-  container: HTMLElement,
-  lineNumber: number,
-) {
-  const viewport = findVirtualizedCodeViewport(container);
-  if (viewport === null) return;
-  const viewportRect = viewport.getBoundingClientRect();
-  const centerOffset = viewportRect.height / 2;
-  const renderedBounds = getRenderedPreviewLineBounds(container);
-  if (renderedBounds === null) {
-    const estimatedTop =
-      FILE_PREVIEW_CODE_GAP_BLOCK_PX +
-      (lineNumber - 1) * FILE_PREVIEW_CODE_LINE_HEIGHT_PX;
-    viewport.scrollTop = Math.max(0, estimatedTop - centerOffset);
-    return;
-  }
-  const { firstLineNumber, firstTop, lastLineNumber, lastBottom } =
-    renderedBounds;
-  if (lineNumber > lastLineNumber) {
-    const distance =
-      lastBottom -
-      viewportRect.top +
-      (lineNumber - lastLineNumber - 1) * FILE_PREVIEW_CODE_LINE_HEIGHT_PX;
-    viewport.scrollTop += Math.max(0, distance - centerOffset);
-  } else if (lineNumber < firstLineNumber) {
-    const distance =
-      viewportRect.top -
-      firstTop +
-      (firstLineNumber - lineNumber) * FILE_PREVIEW_CODE_LINE_HEIGHT_PX;
-    viewport.scrollTop = Math.max(
-      0,
-      viewport.scrollTop - distance - centerOffset,
-    );
-  }
-}
-
-interface RenderedPreviewLineBounds {
-  firstLineNumber: number;
-  firstTop: number;
-  lastLineNumber: number;
-  lastBottom: number;
-}
-
-function getRenderedPreviewLineBounds(
-  container: HTMLElement,
-): RenderedPreviewLineBounds | null {
-  let bounds: RenderedPreviewLineBounds | null = null;
-  for (const root of getPreviewTargetRoots(container)) {
-    for (const line of root.querySelectorAll<HTMLElement>(
-      "[data-line][data-line-index]",
-    )) {
-      const lineNumber = Number(line.dataset.line);
-      if (!Number.isFinite(lineNumber)) continue;
-      const rect = line.getBoundingClientRect();
-      if (bounds === null) {
-        bounds = {
-          firstLineNumber: lineNumber,
-          firstTop: rect.top,
-          lastLineNumber: lineNumber,
-          lastBottom: rect.bottom,
-        };
-        continue;
-      }
-      if (lineNumber < bounds.firstLineNumber) {
-        bounds.firstLineNumber = lineNumber;
-        bounds.firstTop = rect.top;
-      }
-      if (lineNumber > bounds.lastLineNumber) {
-        bounds.lastLineNumber = lineNumber;
-        bounds.lastBottom = rect.bottom;
-      }
-    }
-  }
-  return bounds;
-}
-
-function findPreviewScrollViewport(container: HTMLElement): HTMLElement | null {
-  const virtualizedViewport = findVirtualizedCodeViewport(container);
-  if (virtualizedViewport !== null) {
-    return virtualizedViewport;
-  }
-  const view = container.ownerDocument.defaultView;
-  if (view === null) return null;
-
-  let candidate = container.parentElement;
-  while (candidate !== null) {
-    const overflowY = view.getComputedStyle(candidate).overflowY;
-    if (
-      overflowY === "auto" ||
-      overflowY === "scroll" ||
-      overflowY === "overlay"
-    ) {
-      return candidate;
-    }
-    candidate = candidate.parentElement;
-  }
-  return null;
-}
-
-function scrollPreviewTargetLine(container: HTMLElement, line: HTMLElement) {
-  const viewport = findPreviewScrollViewport(container);
-  if (viewport === null) return;
-
-  const lineRect = line.getBoundingClientRect();
-  const viewportRect = viewport.getBoundingClientRect();
-  const lineCenter = lineRect.top + lineRect.height / 2;
-  const viewportCenter = viewportRect.top + viewportRect.height / 2;
-  // Adjust only the vertical scroll offset. `scrollIntoView()` can also move
-  // the horizontal axis when a long source line extends beyond the viewport.
-  viewport.scrollTop += lineCenter - viewportCenter;
-}
-
-function formatLineRange(startLineNumber: number, endLineNumber: number) {
-  return startLineNumber === endLineNumber
-    ? String(startLineNumber)
-    : `${startLineNumber}-${endLineNumber}`;
-}
-
-function buildFilePreviewLineSelectionText({
-  contents,
-  path,
-  range,
-}: {
-  contents: string;
-  path: string;
-  range: SelectedLineRange;
-}): string | null {
-  const startLineNumber = Math.max(1, Math.min(range.start, range.end));
-  const endLineNumber = Math.max(
-    startLineNumber,
-    Math.max(range.start, range.end),
-  );
-  const lines = contents.split(/\r\n|\n|\r/);
-  const selectedLines = lines.slice(startLineNumber - 1, endLineNumber);
-  if (selectedLines.length === 0) {
-    return null;
-  }
-  const selectedText = selectedLines.join("\n").trimEnd();
-  if (selectedText.trim().length === 0) {
-    return null;
-  }
-  return `${path}:${formatLineRange(startLineNumber, endLineNumber)}\n${selectedText}`;
-}
-
 function FilePreviewLoading() {
   return (
     <div className="space-y-2 px-4 pt-4" aria-busy>
@@ -1434,6 +1091,12 @@ function FilePreviewMessage({ message, role }: FilePreviewMessageProps) {
   );
 }
 
+/**
+ * The preview's source body. Everything here is chrome and policy — which
+ * lines to highlight, whether to scroll to them, the selection-to-chat hook —
+ * while the render itself goes through the shared host boundary, so an
+ * `experimental_sourceCodeRenderer` replacement covers the file preview too.
+ */
 function FilePreviewCode({
   file,
   lineOverflowMode,
@@ -1441,336 +1104,27 @@ function FilePreviewCode({
   onSelectionAddToChat,
   path,
 }: FilePreviewCodeProps) {
-  const preferredTheme = usePreferredTheme();
-  const codeTheme = useResolvedCodeThemePair();
-  const containerRef = useRef<HTMLDivElement>(null);
-  // `PierreFile` captures the worker pool when it creates its instance, so
-  // wait for the workspace to build the pool before the first render.
-  const isWorkerPoolReady = useRequirePierreWorkerPool();
-  const workerPool = usePierreWorkerPool();
-  const lastWorkerPoolStatsKeyRef = useRef<string | null>(null);
-  const [workerPoolStats, setWorkerPoolStats] =
-    useState<FilePreviewWorkerPoolStats | null>(null);
-  const [, rerenderAfterWorkerPoolChange] = useState(0);
-  const fileIdentity = file.cacheKey ?? file.name;
-  const truncation = useMemo(
-    () => truncateFilePreviewCode(file.contents),
-    [file.contents],
-  );
-  // Which file the user asked to see in full. Keyed by identity rather than a
-  // boolean so opening a different large file goes back to the capped view
-  // without an effect resetting state.
-  const [fullFileRequestedFor, setFullFileRequestedFor] = useState<
-    string | null
-  >(null);
-  const buildSelectionText = useCallback(
-    (range: SelectedLineRange) =>
-      buildFilePreviewLineSelectionText({
-        contents: file.contents,
-        path,
-        range,
-      }),
-    [file.contents, path],
-  );
-  const lineSelectionActions = usePierreLineSelectionActions({
-    buildSelectionText,
-    containerRef,
-    enabled: onSelectionAddToChat !== undefined,
-    onSelectionAddToChat,
-  });
-  const options = useMemo<FileOptions<undefined>>(
-    () => ({
-      themeType: preferredTheme,
-      theme: codeTheme,
-      overflow: lineOverflowMode,
-      disableFileHeader: true,
-      enableGutterUtility: onSelectionAddToChat !== undefined,
-      enableLineSelection:
-        lineRange !== null || onSelectionAddToChat !== undefined,
-      lineHoverHighlight:
-        onSelectionAddToChat === undefined ? "disabled" : "number",
-      onGutterUtilityClick:
-        onSelectionAddToChat === undefined
-          ? undefined
-          : lineSelectionActions.onGutterUtilityClick,
-      onLineSelectionChange: lineSelectionActions.onLineSelectionChange,
-      onLineSelectionEnd: lineSelectionActions.onLineSelectionEnd,
-      onLineSelectionStart: lineSelectionActions.onLineSelectionStart,
-    }),
-    [
-      codeTheme,
-      lineOverflowMode,
-      lineRange,
-      lineSelectionActions.onGutterUtilityClick,
-      lineSelectionActions.onLineSelectionChange,
-      lineSelectionActions.onLineSelectionEnd,
-      lineSelectionActions.onLineSelectionStart,
-      onSelectionAddToChat,
-      preferredTheme,
-    ],
-  );
-  const selectedLines = useMemo<SelectedLineRange | null>(() => {
-    if (lineSelectionActions.selectedRange !== null) {
-      return lineSelectionActions.selectedRange;
-    }
-    return lineRange === null
-      ? null
-      : {
-          start: lineRange.startLineNumber,
-          end: lineRange.endLineNumber,
-        };
-  }, [lineRange, lineSelectionActions.selectedRange]);
-  const targetLineNumber = selectedLines?.start ?? null;
-  // A deep link past the capped prefix is an implicit request for the whole
-  // file: the target line has to exist in the DOM to be scrolled to.
-  const showsFullFile =
-    truncation === null ||
-    fullFileRequestedFor === fileIdentity ||
-    (targetLineNumber !== null &&
-      targetLineNumber > truncation.renderedLineCount);
-  const renderedFile = useMemo<FilePreviewFile>(() => {
-    if (showsFullFile || truncation === null) {
-      return file;
-    }
-    return {
-      ...file,
-      // The worker highlight cache is keyed by `cacheKey`; the capped prefix
-      // must not collide with the full file's entry.
-      cacheKey:
-        file.cacheKey === undefined ? undefined : `${file.cacheKey}:head`,
-      contents: truncation.contents,
-    };
-  }, [file, showsFullFile, truncation]);
-  // Pierre's virtualized file instance keeps the contents it was hydrated
-  // with (`VirtualizedFile.render` ignores a later `file`), so a content swap
-  // — the capped prefix giving way to the full file, or a refetch — needs a
-  // fresh mount. Callers that supply a `cacheKey` already fold the content
-  // hash into it; otherwise hash here.
-  const renderedFileMountKey = useMemo(
+  const highlightedLines = useMemo(
     () =>
-      renderedFile.cacheKey ??
-      `${renderedFile.name}:${hashFilePreviewContents(renderedFile.contents)}`,
-    [renderedFile],
-  );
-  // "Load full file" remounts pierre with the whole file; carry the reader's
-  // scroll offset across so the prefix they were looking at stays put.
-  const pendingViewportScrollTopRef = useRef<number | null>(null);
-  const handleLoadFullFile = () => {
-    const viewport =
-      containerRef.current === null
+      lineRange === null
         ? null
-        : findVirtualizedCodeViewport(containerRef.current);
-    pendingViewportScrollTopRef.current = viewport?.scrollTop ?? null;
-    setFullFileRequestedFor(fileIdentity);
-  };
-  useLayoutEffect(() => {
-    const scrollTop = pendingViewportScrollTopRef.current;
-    if (scrollTop === null) return;
-    pendingViewportScrollTopRef.current = null;
-    const viewport =
-      containerRef.current === null
-        ? null
-        : findVirtualizedCodeViewport(containerRef.current);
-    if (viewport === null) return;
-    viewport.scrollTop = scrollTop;
-    // The virtualizer sizes the fresh instance on its next frame; reapply once
-    // that height exists so the offset is not clamped away.
-    const frame = window.requestAnimationFrame(() => {
-      viewport.scrollTop = scrollTop;
-    });
-    return () => window.cancelAnimationFrame(frame);
-  }, [renderedFileMountKey]);
-
-  useEffect(() => {
-    if (!workerPool) {
-      setWorkerPoolStats(null);
-      return;
-    }
-
-    lastWorkerPoolStatsKeyRef.current = null;
-    return workerPool.subscribeToStatChanges((stats) => {
-      setWorkerPoolStats(stats);
-      const statsKey = [
-        stats.managerState,
-        stats.workersFailed,
-        stats.busyWorkers,
-        stats.queuedTasks,
-        stats.activeTasks,
-        stats.fileCacheSize,
-      ].join(":");
-      if (lastWorkerPoolStatsKeyRef.current === statsKey) {
-        return;
-      }
-      lastWorkerPoolStatsKeyRef.current = statsKey;
-      rerenderAfterWorkerPoolChange((version) => version + 1);
-    });
-  }, [file.contents, file.name, workerPool]);
-
-  const shouldWaitForWorkerPool =
-    workerPool !== undefined &&
-    workerPoolStats?.managerState !== "initialized" &&
-    workerPoolStats?.workersFailed !== true;
-  // Pierre can mount an empty zero-height <pre> while its worker highlighter is
-  // still initializing, so the code view waits for pool readiness. After that
-  // a single mount is enough: pierre paints the plain-text AST first and
-  // repaints in place when the worker delivers the highlighted one. That
-  // repaint swaps the line elements, so the target-line effect below re-runs
-  // when the highlight cache entry for this file appears.
-  const workerHighlightCacheState =
-    workerPool?.getFileResultCache(renderedFile) !== undefined
-      ? "highlighted"
-      : "plain";
-
-  useEffect(() => {
-    const cleanupContainer = containerRef.current;
-    let animationFrame: number | null = null;
-    let attempts = 0;
-
-    // Retry on the next frame (the target line may not be in the DOM yet). One
-    // rAF channel only: `scrollToLine` overwrites `animationFrame` on each
-    // reschedule, so at most one callback is ever pending and cleanup cancels
-    // it — no doubling or leaked stale callbacks marking the wrong line.
-    function scheduleRetry() {
-      animationFrame = window.requestAnimationFrame(scrollToLine);
-    }
-
-    function scrollToLine() {
-      const container = containerRef.current;
-      if (!container) return;
-      clearPreviewTargetLine(container);
-      if (targetLineNumber === null) return;
-
-      const line = findPreviewTargetLine(container, targetLineNumber);
-      if (line) {
-        line.setAttribute("data-file-preview-target-line", "");
-        line.setAttribute("data-selected-line", "single");
-        scrollPreviewTargetLine(container, line);
-        return;
-      }
-
-      // The virtualizer only realizes rows near the scroll window, so a
-      // target outside it is not in the DOM yet. Move the viewport toward the
-      // line's estimated offset and let pierre render that window before the
-      // next attempt.
-      approachVirtualizedTargetLine(container, targetLineNumber);
-      attempts += 1;
-      if (attempts < FILE_PREVIEW_TARGET_LINE_MAX_ATTEMPTS) {
-        scheduleRetry();
-      }
-    }
-
-    scrollToLine();
-    return () => {
-      if (cleanupContainer) {
-        clearPreviewTargetLine(cleanupContainer);
-      }
-      if (animationFrame !== null) {
-        window.cancelAnimationFrame(animationFrame);
-      }
-    };
-  }, [
-    renderedFile.contents,
-    renderedFile.name,
-    shouldWaitForWorkerPool,
-    targetLineNumber,
-    workerHighlightCacheState,
-  ]);
-
-  if (shouldWaitForWorkerPool || !isWorkerPoolReady) {
-    return <FilePreviewLoading />;
-  }
-
-  return (
-    <div
-      ref={containerRef}
-      className="flex min-h-0 flex-1 flex-col"
-      style={FILE_PREVIEW_VIEW_STYLE}
-      data-file-preview-line-number={targetLineNumber ?? undefined}
-      onPointerDownCapture={lineSelectionActions.onPointerDownCapture}
-      onPointerMoveCapture={lineSelectionActions.onPointerMoveCapture}
-      onPointerUpCapture={lineSelectionActions.onPointerUpCapture}
-    >
-      <PierreWorkerPoolBoundary>
-        <FilePreviewCodeViewport>
-          <PierreFile
-            key={renderedFileMountKey}
-            disableWorkerPool={workerPoolStats?.workersFailed === true}
-            file={renderedFile}
-            metrics={FILE_PREVIEW_VIRTUAL_FILE_METRICS}
-            options={options}
-            selectedLines={selectedLines}
-          />
-          {truncation !== null && !showsFullFile ? (
-            <FilePreviewCodeTruncationNotice
-              truncation={truncation}
-              onLoadFullFile={handleLoadFullFile}
-            />
-          ) : null}
-        </FilePreviewCodeViewport>
-      </PierreWorkerPoolBoundary>
-      {lineSelectionActions.menu}
-    </div>
-  );
-}
-
-const FILE_PREVIEW_TARGET_LINE_MAX_ATTEMPTS = 40;
-
-/**
- * The code view's own scroll container, registered as pierre's virtualizer
- * root so `PierreFile` mounts a `VirtualizedFile` that renders only the rows
- * near the viewport. This mirrors `@pierre/diffs/react`'s `<Virtualizer>`,
- * inlined so the scroller carries a ref and a data marker the target-line
- * scrolling can find without walking the tree by class name.
- */
-function FilePreviewCodeViewport({ children }: { children: ReactNode }) {
-  const [virtualizer] = useState(() =>
-    typeof window === "undefined" ? undefined : new PierreVirtualizer(),
-  );
-  const viewportRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (node !== null) {
-        virtualizer?.setup(node);
-      } else {
-        virtualizer?.cleanUp();
-      }
-    },
-    [virtualizer],
+        : { start: lineRange.startLineNumber, end: lineRange.endLineNumber },
+    [lineRange],
   );
   return (
-    <VirtualizerContext.Provider value={virtualizer}>
-      <div
-        ref={viewportRef}
-        className="min-h-0 flex-1 overflow-y-auto"
-        data-file-preview-code-viewport
-      >
-        <div>{children}</div>
-      </div>
-    </VirtualizerContext.Provider>
-  );
-}
-
-function FilePreviewCodeTruncationNotice({
-  truncation,
-  onLoadFullFile,
-}: {
-  truncation: FilePreviewCodeTruncation;
-  onLoadFullFile: () => void;
-}) {
-  return (
-    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-4 py-3 text-xs text-muted-foreground">
-      <span>
-        Showing the first {truncation.renderedLineCount.toLocaleString()} of{" "}
-        {truncation.totalLineCount.toLocaleString()} lines.
-      </span>
-      <Button
-        type="button"
-        variant="link"
-        size="sm"
-        className="h-auto p-0 text-xs underline underline-offset-4 hover:underline"
-        onClick={onLoadFullFile}
-      >
-        Load full file
-      </Button>
-    </div>
+    <SourceCodeHost
+      content={file.contents}
+      path={path}
+      // `path` is what the panel shows and what a copied selection is
+      // labelled with; `file.name` can be a shorter server-supplied display
+      // name for the same file, and it is the identity the highlighter's
+      // result cache was keyed on before this went through the host.
+      cacheKey={file.cacheKey ?? file.name}
+      overflow={lineOverflowMode}
+      highlightedLines={highlightedLines}
+      scrollToHighlightedLines
+      fallback={<FilePreviewLoading />}
+      onSelectionAddToChat={onSelectionAddToChat}
+    />
   );
 }

--- a/apps/app/src/components/secondary-panel/GitDiffCard.stories.tsx
+++ b/apps/app/src/components/secondary-panel/GitDiffCard.stories.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState, type ReactNode } from "react";
 import type { FileContents } from "@pierre/diffs";
+import type { DiffPresentation } from "@/components/code/code-rendering";
 import {
-  GIT_DIFF_VIEW_BASE_OPTIONS,
   GitDiffCard,
   type DiffFileContentsResult,
   type RequestDiffFileContents,
@@ -20,7 +20,6 @@ import {
   summarizeGitDiff,
   type ParsedGitDiffFile,
 } from "../git-diff/git-diff-parsing";
-import { usePreferredTheme } from "@/hooks/useTheme";
 import { StoryCard, StoryRow } from "../../../.ladle/story-card";
 import { appToast } from "@/components/ui/app-toast";
 
@@ -745,7 +744,6 @@ function InteractiveDiffPanel({
       ),
     [parsed],
   );
-  const preferredTheme = usePreferredTheme();
   const [selection, setSelection] = useState("working");
   const [displayMode, setDisplayMode] = useState<GitDiffDisplayMode>("unified");
   const [lineOverflowMode, setLineOverflowMode] = useState<CodeOverflowMode>(
@@ -776,14 +774,13 @@ function InteractiveDiffPanel({
       return next;
     });
   }, []);
-  const viewOptions = useMemo(
+  const presentation = useMemo<DiffPresentation>(
     () => ({
-      ...GIT_DIFF_VIEW_BASE_OPTIONS,
-      diffStyle: displayMode,
+      view: displayMode,
       overflow: lineOverflowMode,
-      themeType: preferredTheme,
+      showLineNumbers: true,
     }),
-    [displayMode, lineOverflowMode, preferredTheme],
+    [displayMode, lineOverflowMode],
   );
   const onOpenFileInEditor = useCallback((path: string) => {
     appToast.message("Opening in editor", { description: path });
@@ -837,7 +834,7 @@ function InteractiveDiffPanel({
             <GitDiffCard
               key={fileKey}
               fileDiff={fileDiff}
-              diffViewOptions={viewOptions}
+              presentation={presentation}
               onOpenFileInEditor={onOpenFileInEditor}
               isCollapsed={collapsedFileKeys.has(fileKey)}
               onToggleCollapsed={() => toggleFileCollapsed(fileKey)}

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -46,13 +46,12 @@ import type {
   SecondaryPanelFileTab,
   SecondaryPanelTabReorderHandler,
 } from "./secondaryPanelFileTab";
-import { GIT_DIFF_VIEW_BASE_OPTIONS } from "../git-diff/GitDiffCard";
-import { usePreferredTheme } from "@/hooks/useTheme";
 import { useEnvironmentDiffFiles } from "@/hooks/queries/environment-queries";
 import {
   DEFAULT_CODE_OVERFLOW_MODE,
   type CodeOverflowMode,
 } from "@/lib/code-overflow-mode";
+import type { DiffPresentation } from "@/components/code/code-rendering";
 import { useGitDiffPanelState } from "./git-diff/useGitDiffPanelState";
 import { useResponsiveGitDiffPanelDisplay } from "./git-diff/useResponsiveGitDiffPanelDisplay";
 import {
@@ -634,15 +633,13 @@ export function ThreadSecondaryPanel({
         windowState: desktopWindowState,
       }),
     });
-  const preferredTheme = usePreferredTheme();
-  const gitDiffViewOptions = useMemo(
+  const gitDiffPresentation = useMemo<DiffPresentation>(
     () => ({
-      ...GIT_DIFF_VIEW_BASE_OPTIONS,
-      diffStyle: gitDiffDisplayMode,
+      view: gitDiffDisplayMode,
       overflow: gitDiffLineOverflowMode,
-      themeType: preferredTheme,
+      showLineNumbers: true,
     }),
-    [gitDiffDisplayMode, gitDiffLineOverflowMode, preferredTheme],
+    [gitDiffDisplayMode, gitDiffLineOverflowMode],
   );
   const handlePanelFocusCapture = (event: FocusEvent<HTMLElement>) => {
     const previousTarget = event.relatedTarget;
@@ -957,7 +954,7 @@ export function ThreadSecondaryPanel({
               target={gitDiffTarget}
               isDiffPanelActive={isSurfaceDiffActive}
               isPanelOpen={isLayoutOpen}
-              gitDiffViewOptions={gitDiffViewOptions}
+              gitDiffPresentation={gitDiffPresentation}
               onClearPendingGitDiffIntent={onClearPendingGitDiffIntent}
               onOpenFileInEditor={onOpenFileInEditor}
               onOpenFilePreview={onOpenFilePreview}
@@ -1496,7 +1493,7 @@ export function ThreadSecondaryPanel({
                 target={gitDiffTarget}
                 isDiffPanelActive={isDiffPanelActive}
                 isPanelOpen={isLayoutOpen}
-                gitDiffViewOptions={gitDiffViewOptions}
+                gitDiffPresentation={gitDiffPresentation}
                 onClearPendingGitDiffIntent={onClearPendingGitDiffIntent}
                 onOpenFileInEditor={onOpenFileInEditor}
                 onOpenFilePreview={onOpenFilePreview}

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.panelGate.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.panelGate.test.tsx
@@ -68,7 +68,11 @@ describe("GitDiffTabContent panel gating", () => {
           target={TARGET}
           isDiffPanelActive
           isPanelOpen={isPanelOpen}
-          gitDiffViewOptions={{}}
+          gitDiffPresentation={{
+          view: "unified",
+          overflow: "scroll",
+          showLineNumbers: true,
+        }}
         />
       </Wrapper>
     );

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
@@ -1,4 +1,5 @@
 import { useEffect, type ReactNode } from "react";
+import type { DiffPresentation } from "@/components/code/code-rendering";
 import type { WorkspaceDiffTarget } from "@bb/domain";
 import type { MarkdownLinkRouting } from "@/components/ui/markdown-link-routing.js";
 import { Skeleton } from "@bb/shared-ui/skeleton";
@@ -50,7 +51,7 @@ export interface GitDiffTabContentProps {
    * and refetching into an off-screen panel is wasted network and diff work.
    */
   isPanelOpen: boolean;
-  gitDiffViewOptions: Record<string, string | boolean | number>;
+  gitDiffPresentation: DiffPresentation;
   onClearPendingGitDiffIntent?: () => void;
   onOpenFileInEditor?: (path: string) => void;
   onOpenFilePreview?: (path: string) => void;
@@ -188,7 +189,7 @@ export function GitDiffTabContent({
   target,
   isDiffPanelActive,
   isPanelOpen,
-  gitDiffViewOptions,
+  gitDiffPresentation,
   onClearPendingGitDiffIntent,
   onOpenFileInEditor,
   onOpenFilePreview,
@@ -333,7 +334,7 @@ export function GitDiffTabContent({
         files={diffFilesResponse.files}
         initialPatches={diffFilesResponse.initialPatches}
         filesUpdatedAt={diffFilesUpdatedAt}
-        diffViewOptions={gitDiffViewOptions}
+        presentation={gitDiffPresentation}
         filePathRoot={workspaceRootPath}
         isPanelOpen={isPanelOpen}
         isPlaceholderData={isDiffFilesPlaceholder}

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.contextExpansion.test.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.contextExpansion.test.tsx
@@ -23,6 +23,22 @@ vi.mock("@pierre/diffs/react", () => ({
   },
 }));
 
+/**
+ * BB's diff renderer is a lazy chunk behind the host boundary (the same
+ * pattern `LazyTimelineFileDiffBlock` uses), so the card paints its skeleton
+ * until that import resolves. Testing Library's 1s default is not enough for
+ * a module compile while the whole suite runs in parallel.
+ */
+const DIFF_RENDERER_CHUNK_TIMEOUT_MS = 10_000;
+
+function findDiffView() {
+  return screen.findByTestId(
+    "diff-view",
+    {},
+    { timeout: DIFF_RENDERER_CHUNK_TIMEOUT_MS },
+  );
+}
+
 const MODIFIED_PATCH = [
   "diff --git a/src/file.ts b/src/file.ts",
   "index 1111111..2222222 100644",
@@ -114,7 +130,11 @@ function renderModifiedCard(onRequestFileContents: RequestDiffFileContents) {
   render(
     <DiffFileCard
       entry={buildEntry()}
-      diffViewOptions={{}}
+      presentation={{
+        view: "unified",
+        overflow: "scroll",
+        showLineNumbers: true,
+      }}
       isCollapsed={false}
       onToggleCollapsed={() => {}}
       patchState={{ status: "loaded", patch: MODIFIED_PATCH, truncated: false }}
@@ -164,7 +184,7 @@ describe("DiffFileCard context expansion", () => {
     renderModifiedCard(onRequestFileContents);
     revealCardBodies();
 
-    await screen.findByTestId("diff-view");
+    await findDiffView();
     const expandButton = await screen.findByRole("button", {
       name: "Expand context",
     });
@@ -263,7 +283,11 @@ describe("DiffFileCard context expansion", () => {
           additions: 2,
           deletions: 0,
         })}
-        diffViewOptions={{}}
+        presentation={{
+        view: "unified",
+        overflow: "scroll",
+        showLineNumbers: true,
+      }}
         isCollapsed={false}
         onToggleCollapsed={() => {}}
         patchState={{ status: "loaded", patch: ADDED_PATCH, truncated: false }}
@@ -274,7 +298,7 @@ describe("DiffFileCard context expansion", () => {
     );
     revealCardBodies();
 
-    await screen.findByTestId("diff-view");
+    await findDiffView();
     await new Promise((resolve) => setTimeout(resolve, 300));
     expect(onRequestFileContents).not.toHaveBeenCalled();
     expect(

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.stories.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.stories.tsx
@@ -1,9 +1,8 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import type { DiffFileEntry } from "@bb/server-contract";
-import { GIT_DIFF_VIEW_BASE_OPTIONS } from "@/components/git-diff/GitDiffCard";
+import type { DiffPresentation } from "@/components/code/code-rendering";
 import type { RequestDiffFileContents } from "@/components/git-diff/GitDiffCardBody";
 import { DEFAULT_CODE_OVERFLOW_MODE } from "@/lib/code-overflow-mode";
-import { usePreferredTheme } from "@/hooks/useTheme";
 import type { DiffPatchState } from "@/hooks/queries/use-environment-diff-patches";
 import { appToast } from "@/components/ui/app-toast";
 import { StoryCard, StoryRow } from "../../../../.ladle/story-card";
@@ -116,22 +115,18 @@ interface CardStageProps {
 
 // Mounts a single DiffFileCard at a panel-realistic width with live theme-aware
 // view options, mirroring how DiffFilesPanel renders each row.
+const CARD_PRESENTATION: DiffPresentation = {
+  view: "unified",
+  overflow: DEFAULT_CODE_OVERFLOW_MODE,
+  showLineNumbers: true,
+};
+
 function CardStage({
   entry,
   patchState = { status: "idle" },
   collapsed = false,
   onRequestFileContents,
 }: CardStageProps) {
-  const preferredTheme = usePreferredTheme();
-  const diffViewOptions = useMemo(
-    () => ({
-      ...GIT_DIFF_VIEW_BASE_OPTIONS,
-      diffStyle: "unified",
-      overflow: DEFAULT_CODE_OVERFLOW_MODE,
-      themeType: preferredTheme,
-    }),
-    [preferredTheme],
-  );
   const [isCollapsed, setIsCollapsed] = useState(collapsed);
   const toast = useCallback(
     (label: string) => (path: string) =>
@@ -142,7 +137,7 @@ function CardStage({
     <div className="w-full max-w-[640px] min-w-0">
       <DiffFileCard
         entry={buildEntry(entry)}
-        diffViewOptions={diffViewOptions}
+        presentation={CARD_PRESENTATION}
         isCollapsed={isCollapsed}
         onToggleCollapsed={() => setIsCollapsed((value) => !value)}
         patchState={patchState}

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.test.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.test.tsx
@@ -40,7 +40,11 @@ function renderCard({
   render(
     <DiffFileCard
       entry={entry}
-      diffViewOptions={{}}
+      presentation={{
+        view: "unified",
+        overflow: "scroll",
+        showLineNumbers: true,
+      }}
       isCollapsed={false}
       onToggleCollapsed={() => {}}
       patchState={patchState}

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.test.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.test.tsx
@@ -7,7 +7,22 @@ import type {
   RequestDiffFileContents,
 } from "@/components/git-diff/GitDiffCardBody";
 import type { DiffPatchState } from "@/hooks/queries/use-environment-diff-patches";
+import {
+  resetPluginSlotStoreForTest,
+  setPluginSlotRegistrations,
+} from "@/lib/plugin-slots";
 import { DiffFileCard } from "./DiffFileCard";
+
+// The diff body defers its renderer until the card scrolls into view. jsdom
+// has no layout, so report every observed sentinel as visible.
+vi.mock("usehooks-ts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("usehooks-ts")>()),
+  useIntersectionObserver: () => ({
+    ref: () => {},
+    isIntersecting: true,
+    entry: undefined,
+  }),
+}));
 
 const IMAGE_DATA_URL =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/Qo3AAAAAElFTkSuQmCC";
@@ -55,8 +70,19 @@ function renderCard({
   );
 }
 
+const TEXT_PATCH = [
+  "diff --git a/src/file.ts b/src/file.ts",
+  "--- a/src/file.ts",
+  "+++ b/src/file.ts",
+  "@@ -1,2 +1,2 @@",
+  "-const b = 2;",
+  "+const b = 3;",
+  "",
+].join("\n");
+
 afterEach(() => {
   cleanup();
+  resetPluginSlotStoreForTest();
 });
 
 describe("DiffFileCard", () => {
@@ -123,6 +149,43 @@ describe("DiffFileCard", () => {
     });
     expect(screen.getByText("Load diff")).toBeTruthy();
     expect(onRequestFileContents).not.toHaveBeenCalled();
+  });
+
+  it("renders its text body through the shared host diff boundary", async () => {
+    // The point of the boundary: one `experimental_diffRenderer` registration
+    // has to reach BB's own diff panel, not just plugin-rendered diffs.
+    const seen: { patch: string; path: string; view: string }[] = [];
+    setPluginSlotRegistrations("demo", {
+      homepageSections: [],
+      settingsSections: [],
+      navPanels: [],
+      threadPanelActions: [],
+      sidebarFooterActions: [],
+      fileOpeners: [],
+      messageDirectives: [],
+      diffRenderers: [
+        {
+          id: "diffs",
+          title: "Demo diffs",
+          component: ({ patch, path, view }) => {
+            seen.push({ patch, path, view });
+            return <div data-testid="plugin-diff-body">plugin diff</div>;
+          },
+        },
+      ],
+    });
+
+    renderCard({
+      entry: buildEntry(),
+      patchState: { status: "loaded", patch: TEXT_PATCH },
+    });
+
+    expect(await screen.findByTestId("plugin-diff-body")).toBeTruthy();
+    // The caller had the real bytes, so the replacement gets those — not a
+    // reconstruction.
+    expect(seen.at(-1)?.patch).toBe(TEXT_PATCH);
+    expect(seen.at(-1)?.path).toBe("src/file.ts");
+    expect(seen.at(-1)?.view).toBe("unified");
   });
 
   it("falls back to the load gate when an image-looking path is not previewable", async () => {

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { useIntersectionObserver } from "usehooks-ts";
 import type { DiffFileEntry } from "@bb/server-contract";
+import type { DiffPresentation } from "@/components/code/code-rendering";
 import {
   getGitDiffCardImageSizeStat,
   GitDiffCardBody,
@@ -121,7 +122,7 @@ function buildBinaryImagePreviewPlan(
 
 export interface DiffFileCardProps {
   entry: DiffFileEntry;
-  diffViewOptions: Record<string, string | boolean | number>;
+  presentation: DiffPresentation;
   filePathRoot?: string | null;
   isCollapsed: boolean;
   onToggleCollapsed: () => void;
@@ -174,7 +175,7 @@ function areDiffFileCardPropsEqual(
 ): boolean {
   return (
     previous.entry === next.entry &&
-    previous.diffViewOptions === next.diffViewOptions &&
+    previous.presentation === next.presentation &&
     previous.filePathRoot === next.filePathRoot &&
     previous.isCollapsed === next.isCollapsed &&
     previous.onToggleCollapsed === next.onToggleCollapsed &&
@@ -275,7 +276,7 @@ function useBinaryImagePreview({
 
 export const DiffFileCard = memo(function DiffFileCard({
   entry,
-  diffViewOptions,
+  presentation,
   filePathRoot,
   isCollapsed,
   onToggleCollapsed,
@@ -400,7 +401,7 @@ export const DiffFileCard = memo(function DiffFileCard({
         <DiffFileCardBody
           entry={entry}
           changedLines={changedLines}
-          diffViewOptions={diffViewOptions}
+          presentation={presentation}
           parsedFile={parsedFile}
           patchState={patchState}
           svgDisplayMode={svgDisplayMode}
@@ -423,7 +424,7 @@ export const DiffFileCard = memo(function DiffFileCard({
 interface DiffFileCardBodyProps {
   entry: DiffFileEntry;
   changedLines: number;
-  diffViewOptions: Record<string, string | boolean | number>;
+  presentation: DiffPresentation;
   parsedFile: ParsedGitDiffFile | null;
   patchState: DiffPatchState;
   svgDisplayMode: GitDiffCardSvgDisplayMode;
@@ -483,7 +484,7 @@ function DiffFileCardLoadDiffNotice({
 function DiffFileCardBody({
   entry,
   changedLines,
-  diffViewOptions,
+  presentation,
   parsedFile,
   patchState,
   svgDisplayMode,
@@ -597,7 +598,7 @@ function DiffFileCardBody({
       entry={entry}
       parsedFile={parsedFile}
       patchText={patchState.truncated ? undefined : patchState.patch}
-      diffViewOptions={diffViewOptions}
+      presentation={presentation}
       svgDisplayMode={svgDisplayMode}
       truncated={patchState.truncated ?? false}
       onOpenFilePreview={onOpenFilePreview}
@@ -611,7 +612,7 @@ interface DiffFileCardRenderedBodyProps {
   entry: DiffFileEntry;
   parsedFile: ParsedGitDiffFile;
   patchText?: string;
-  diffViewOptions: Record<string, string | boolean | number>;
+  presentation: DiffPresentation;
   svgDisplayMode: GitDiffCardSvgDisplayMode;
   truncated: boolean;
   onOpenFilePreview?: (path: string) => void;
@@ -630,7 +631,7 @@ function DiffFileCardRenderedBody({
   entry,
   parsedFile,
   patchText,
-  diffViewOptions,
+  presentation,
   svgDisplayMode,
   truncated,
   onOpenFilePreview,
@@ -648,7 +649,7 @@ function DiffFileCardRenderedBody({
     <>
       <GitDiffCardBody
         state={bodyState}
-        diffViewOptions={diffViewOptions}
+        presentation={presentation}
         svgDisplayMode={svgDisplayMode}
         reservesCollapseGutter
         onSelectionAddToChat={onSelectionAddToChat}

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFilesPanel.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFilesPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useAtom } from "jotai";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import type { DiffFileEntry, DiffPatchEntry } from "@bb/server-contract";
+import type { DiffPresentation } from "@/components/code/code-rendering";
 import type { WorkspaceDiffTarget } from "@bb/domain";
 import type { RequestDiffFileContents } from "@/components/git-diff/GitDiffCardBody";
 import {
@@ -43,7 +44,7 @@ export interface DiffFilesPanelProps {
    * are re-fetched even when the path set is identical.
    */
   filesUpdatedAt: number;
-  diffViewOptions: Record<string, string | boolean | number>;
+  presentation: DiffPresentation;
   filePathRoot?: string | null;
   /**
    * Whether the secondary panel is open. While closed the list stays mounted
@@ -84,7 +85,7 @@ export function DiffFilesPanel({
   files,
   initialPatches,
   filesUpdatedAt,
-  diffViewOptions,
+  presentation,
   filePathRoot,
   isPanelOpen,
   isPlaceholderData,
@@ -232,7 +233,7 @@ export function DiffFilesPanel({
                 entry={entry}
                 diffIdentity={diffIdentity}
                 fileCount={files.length}
-                diffViewOptions={diffViewOptions}
+                presentation={presentation}
                 filePathRoot={filePathRoot}
                 patchState={getPatchState(entry.path)}
                 loadPath={loadPath}
@@ -257,7 +258,7 @@ interface DiffFileRowProps {
   entry: DiffFileEntry;
   diffIdentity: string;
   fileCount: number;
-  diffViewOptions: Record<string, string | boolean | number>;
+  presentation: DiffPresentation;
   filePathRoot?: string | null;
   patchState: DiffPatchState;
   loadPath: LoadDiffPatchPath;
@@ -272,7 +273,7 @@ function DiffFileRow({
   entry,
   diffIdentity,
   fileCount,
-  diffViewOptions,
+  presentation,
   filePathRoot,
   patchState,
   loadPath,
@@ -308,7 +309,7 @@ function DiffFileRow({
   return (
     <DiffFileCard
       entry={entry}
-      diffViewOptions={diffViewOptions}
+      presentation={presentation}
       filePathRoot={filePathRoot}
       isCollapsed={collapsed}
       onToggleCollapsed={handleToggleCollapsed}

--- a/apps/app/src/components/settings/CodeRendererSettings.test.tsx
+++ b/apps/app/src/components/settings/CodeRendererSettings.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { createStore, Provider as JotaiProvider } from "jotai";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  resetPluginSlotStoreForTest,
+  setPluginSlotRegistrations,
+} from "@/lib/plugin-slots";
+import {
+  diffRendererProviderAtom,
+  sourceCodeRendererProviderAtom,
+} from "@/components/code/codeRendererProvider";
+import {
+  AUTOMATIC_REPLACEMENT_PROVIDER,
+  BUILT_IN_REPLACEMENT_PROVIDER,
+} from "@/lib/plugin-replacement-preference";
+import { CodeRendererSettings } from "./CodeRendererSettings";
+
+const EMPTY_REGISTRATIONS = {
+  homepageSections: [],
+  settingsSections: [],
+  navPanels: [],
+  threadPanelActions: [],
+  sidebarFooterActions: [],
+  fileOpeners: [],
+  messageDirectives: [],
+};
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+  resetPluginSlotStoreForTest();
+});
+
+describe("CodeRendererSettings", () => {
+  it("shows no control until a plugin supplies a renderer", () => {
+    render(
+      <JotaiProvider store={createStore()}>
+        <CodeRendererSettings />
+      </JotaiProvider>,
+    );
+
+    expect(screen.queryByRole("button", { name: "Source code" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Diffs" })).toBeNull();
+  });
+
+  it("pins BB's diff renderer without touching the source-code choice", async () => {
+    setPluginSlotRegistrations("inkwell", {
+      ...EMPTY_REGISTRATIONS,
+      sourceCodeRenderers: [
+        { id: "source", title: "Inkwell source", component: () => null },
+      ],
+      diffRenderers: [
+        { id: "diffs", title: "Inkwell diffs", component: () => null },
+      ],
+    });
+    const store = createStore();
+    render(
+      <JotaiProvider store={store}>
+        <CodeRendererSettings />
+      </JotaiProvider>,
+    );
+
+    const diffTrigger = screen.getByRole("button", { name: "Diffs" });
+    expect(diffTrigger.textContent).toContain("Automatic");
+
+    fireEvent.pointerDown(diffTrigger, { button: 0 });
+    fireEvent.click(await screen.findByRole("menuitem", { name: /built-in/u }));
+
+    expect(store.get(diffRendererProviderAtom)).toBe(
+      BUILT_IN_REPLACEMENT_PROVIDER,
+    );
+    // The two renderers are pinned independently — turning off plugin diffs
+    // must not silently turn off its source viewer too.
+    expect(store.get(sourceCodeRendererProviderAtom)).toBe(
+      AUTOMATIC_REPLACEMENT_PROVIDER,
+    );
+  });
+
+  it("offers each registered provider by name", () => {
+    setPluginSlotRegistrations("inkwell", {
+      ...EMPTY_REGISTRATIONS,
+      diffRenderers: [
+        { id: "diffs", title: "Inkwell diffs", component: () => null },
+      ],
+    });
+    setPluginSlotRegistrations("zed", {
+      ...EMPTY_REGISTRATIONS,
+      diffRenderers: [
+        {
+          id: "zed-diffs",
+          title: "Zed diffs",
+          description: "Side-by-side with word highlights.",
+          component: () => null,
+        },
+      ],
+    });
+    const store = createStore();
+    render(
+      <JotaiProvider store={store}>
+        <CodeRendererSettings />
+      </JotaiProvider>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Diffs" });
+    // Plugin ids sort, so "inkwell" is the automatic winner and the label has
+    // to name it rather than whichever plugin loaded first.
+    expect(trigger.textContent).toContain("Automatic");
+    fireEvent.pointerDown(trigger, { button: 0 });
+    expect(
+      screen.getByRole("menuitem", { name: /Currently using Inkwell diffs/u }),
+    ).toBeTruthy();
+    // Both providers stay individually pinnable, and each carries its own
+    // description rather than the generic "From the <plugin> plugin" fallback.
+    const items = screen
+      .getAllByRole("menuitem")
+      .map((item) => item.textContent ?? "");
+    expect(items).toHaveLength(4);
+    expect(items.some((text) => text.includes("From the inkwell plugin"))).toBe(
+      true,
+    );
+    expect(
+      items.some((text) =>
+        text.includes("Side-by-side with word highlights."),
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/app/src/components/settings/CodeRendererSettings.tsx
+++ b/apps/app/src/components/settings/CodeRendererSettings.tsx
@@ -1,0 +1,145 @@
+import { useAtom, type PrimitiveAtom } from "jotai";
+import { Icon } from "@bb/shared-ui/icon";
+import { cn } from "@bb/shared-ui/lib/utils";
+import { COARSE_POINTER_ICON_SIZE_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
+import { Button } from "@bb/shared-ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@bb/shared-ui/dropdown-menu";
+import { SettingsWithControl } from "@/components/ui/settings-section";
+import {
+  diffRendererProviderAtom,
+  sourceCodeRendererProviderAtom,
+} from "@/components/code/codeRendererProvider";
+import {
+  AUTOMATIC_REPLACEMENT_PROVIDER,
+  BUILT_IN_REPLACEMENT_PROVIDER,
+  replacementProviderKey,
+} from "@/lib/plugin-replacement-preference";
+import { usePluginSlots } from "@/lib/plugin-slots";
+
+interface CodeRendererProviderSlot {
+  pluginId: string;
+  id: string;
+  title: string;
+  description?: string;
+}
+
+interface CodeRendererSettingProps {
+  label: string;
+  description: string;
+  builtInDescription: string;
+  preferenceAtom: PrimitiveAtom<string>;
+  slots: readonly CodeRendererProviderSlot[];
+}
+
+/**
+ * The per-client pin for one code renderer, mirroring the sidebar thread list
+ * control. A renderer takes over surfaces the user has no other way back
+ * from — the file preview, every diff — so pinning has to be reachable
+ * without uninstalling the plugin that supplied it.
+ */
+function CodeRendererSetting({
+  label,
+  description,
+  builtInDescription,
+  preferenceAtom,
+  slots,
+}: CodeRendererSettingProps) {
+  const [preference, setPreference] = useAtom(preferenceAtom);
+
+  const automaticProvider = slots[0];
+  if (automaticProvider === undefined) return null;
+  const builtInOption = {
+    key: BUILT_IN_REPLACEMENT_PROVIDER,
+    title: "bb (built-in)",
+    description: builtInDescription,
+  };
+  const options = [
+    {
+      key: AUTOMATIC_REPLACEMENT_PROVIDER,
+      title: "Automatic",
+      description: `Currently using ${automaticProvider.title} from ${automaticProvider.pluginId}.`,
+    },
+    builtInOption,
+    ...slots.map((slot) => ({
+      key: replacementProviderKey(slot),
+      title: slot.title,
+      description: slot.description ?? `From the ${slot.pluginId} plugin.`,
+    })),
+  ];
+  // An unavailable explicit provider renders BB's renderer until it returns.
+  const selected =
+    options.find((option) => option.key === preference) ?? builtInOption;
+
+  return (
+    <SettingsWithControl label={label} description={description}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            className="min-w-40 justify-between"
+            aria-label={label}
+          >
+            <span className="min-w-0 truncate">{selected.title}</span>
+            <Icon
+              name="ChevronDown"
+              className="size-3.5 text-muted-foreground"
+            />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-72">
+          {options.map((option) => (
+            <DropdownMenuItem
+              key={option.key}
+              onSelect={() => setPreference(option.key)}
+              className="flex items-start gap-2"
+            >
+              <span className="flex min-w-0 flex-col">
+                <span className="truncate">{option.title}</span>
+                <span className="truncate text-xs text-muted-foreground">
+                  {option.description}
+                </span>
+              </span>
+              <Icon
+                name="Check"
+                className={cn(
+                  "ml-auto mt-0.5",
+                  selected.key !== option.key && "opacity-0",
+                  COARSE_POINTER_ICON_SIZE_CLASS,
+                )}
+              />
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </SettingsWithControl>
+  );
+}
+
+/** Both code-renderer pins; each row hides itself when no plugin supplies one. */
+export function CodeRendererSettings() {
+  const { sourceCodeRenderers, diffRenderers } = usePluginSlots();
+  return (
+    <>
+      <CodeRendererSetting
+        label="Source code"
+        description="Choose automatic activation, BB's viewer, or a specific plugin on this device."
+        builtInDescription="Syntax highlighting and gutters from the bb code theme."
+        preferenceAtom={sourceCodeRendererProviderAtom}
+        slots={sourceCodeRenderers}
+      />
+      <CodeRendererSetting
+        label="Diffs"
+        description="Applies to file diffs in threads, the diff panel, and plugin views."
+        builtInDescription="Unified and split diffs from the bb code theme."
+        preferenceAtom={diffRendererProviderAtom}
+        slots={diffRenderers}
+      />
+    </>
+  );
+}

--- a/apps/app/src/components/sidebar/threadListProvider.ts
+++ b/apps/app/src/components/sidebar/threadListProvider.ts
@@ -1,33 +1,34 @@
-import { atomWithStorage } from "jotai/utils";
 import { useAtomValue } from "jotai";
-import { createJsonLocalStorage } from "@/lib/browser-storage";
-import { resolveThreadListReplacement } from "@/lib/plugin-slot-resolvers";
+import {
+  AUTOMATIC_REPLACEMENT_PROVIDER,
+  BUILT_IN_REPLACEMENT_PROVIDER,
+  createReplacementPreferenceAtom,
+  replacementProviderKey,
+  resolvePreferredReplacement,
+} from "@/lib/plugin-replacement-preference";
 import type { ResolvedReplacement } from "@/lib/plugin-slot-resolvers";
 import { usePluginSlots, type PluginThreadListSlot } from "@/lib/plugin-slots";
 
 const THREAD_LIST_PROVIDER_STORAGE_KEY = "bb.sidebar.threadListProvider";
 
 /** Follow deterministic slot order and activate the first provider. */
-export const AUTOMATIC_THREAD_LIST_PROVIDER = "__automatic__";
+export const AUTOMATIC_THREAD_LIST_PROVIDER = AUTOMATIC_REPLACEMENT_PROVIDER;
 
 /** Always use BB's own thread list. */
-export const BUILT_IN_THREAD_LIST_PROVIDER = "__builtin__";
+export const BUILT_IN_THREAD_LIST_PROVIDER = BUILT_IN_REPLACEMENT_PROVIDER;
 
 /**
  * Automatic by default, with an explicit per-client override available in
  * Appearance. Existing stored built-in and plugin selections remain valid.
  */
-export const threadListProviderAtom = atomWithStorage<string>(
+export const threadListProviderAtom = createReplacementPreferenceAtom(
   THREAD_LIST_PROVIDER_STORAGE_KEY,
-  AUTOMATIC_THREAD_LIST_PROVIDER,
-  createJsonLocalStorage<string>(),
-  { getOnInit: true },
 );
 
 export function threadListProviderKey(
   slot: Pick<PluginThreadListSlot, "pluginId" | "id">,
 ): string {
-  return `${slot.pluginId}/${slot.id}`;
+  return replacementProviderKey(slot);
 }
 
 /**
@@ -39,26 +40,13 @@ export function resolveThreadListProvider(
   slots: readonly PluginThreadListSlot[],
   preference: string = AUTOMATIC_THREAD_LIST_PROVIDER,
 ): PluginThreadListSlot | null {
-  const resolved = resolveThreadListProviderReplacement(slots, preference);
+  const resolved = resolvePreferredReplacement(slots, preference);
   return resolved.kind === "plugin" ? resolved.registration : null;
-}
-
-function resolveThreadListProviderReplacement(
-  slots: readonly PluginThreadListSlot[],
-  preference: string,
-): ResolvedReplacement<PluginThreadListSlot> {
-  if (preference === BUILT_IN_THREAD_LIST_PROVIDER) return { kind: "owner" };
-  return resolveThreadListReplacement(
-    slots,
-    preference === AUTOMATIC_THREAD_LIST_PROVIDER
-      ? undefined
-      : (candidate) => threadListProviderKey(candidate) === preference,
-  );
 }
 
 /** The active replacement, or the owner when none is registered. */
 export function useThreadListReplacement(): ResolvedReplacement<PluginThreadListSlot> {
   const { threadLists } = usePluginSlots();
   const preference = useAtomValue(threadListProviderAtom);
-  return resolveThreadListProviderReplacement(threadLists, preference);
+  return resolvePreferredReplacement(threadLists, preference);
 }

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -62,7 +62,6 @@ import type {
   ThreadTimelineImageViewSrcResolver,
   ThreadTimelineConsumerMessageAction,
   ThreadTimelinePluginMessageAction,
-  ThreadTimelineTheme,
   ThreadTimelineUnreadDividerPlacement,
   UserAttachmentImageSrcResolver,
 } from "./types.js";
@@ -186,7 +185,6 @@ export interface ThreadTimelineRowsProps {
   hasOlderTimelineRows?: boolean;
   isLoadingOlderTimelineRows?: boolean;
   onLoadOlderRows?: () => Promise<void> | void;
-  themeType?: ThreadTimelineTheme;
   timelineRows: TimelineRow[];
   threadId?: string;
   threadRuntimeDisplayStatus: ThreadRuntimeDisplayStatus;
@@ -250,7 +248,6 @@ interface TimelineRendererStaticContextValue {
   resolveMentionLink: PromptMentionLinkResolver | undefined;
   resolveSegmentLinkHref: TimelineTitleLinkResolver | undefined;
   resolveUserAttachmentImageSrc: UserAttachmentImageSrcResolver | undefined;
-  themeType: ThreadTimelineTheme;
   threadId: string | undefined;
   workspaceRootPath: string | undefined;
 }
@@ -1306,7 +1303,6 @@ function TimelineExpandableBody({
     onOpenLocalFileLink,
     projectId,
     resolveUserAttachmentImageSrc,
-    themeType,
     workspaceRootPath,
     resolveImageViewSrc,
   } = useTimelineRendererStaticContext();
@@ -1416,7 +1412,6 @@ function TimelineExpandableBody({
         <WorkRowBody
           row={row}
           resolveImageViewSrc={resolveImageViewSrc}
-          themeType={themeType}
           workspaceRootPath={workspaceRootPath}
         />
       );
@@ -2120,7 +2115,6 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
     () => (scopeActive ? findStreamingAssistantMessageId(rows) : null),
     [rows, scopeActive],
   );
-  const themeType = props.themeType ?? "light";
   const computedAutoExpansionRowIds = useMemo(
     () => collectTimelineAutoExpansionRowIds({ rows, scopeActive }),
     [rows, scopeActive],
@@ -2281,7 +2275,6 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
       resolveMentionLink: props.resolveMentionLink,
       resolveSegmentLinkHref,
       resolveUserAttachmentImageSrc: props.resolveUserAttachmentImageSrc,
-      themeType,
       threadId: props.threadId,
       workspaceRootPath: props.workspaceRootPath,
     }),
@@ -2311,7 +2304,6 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
       props.resolveUserAttachmentImageSrc,
       props.threadId,
       props.workspaceRootPath,
-      themeType,
     ],
   );
   const turnStateContextValue = useMemo<TimelineTurnStateContextValue>(

--- a/apps/app/src/components/thread/timeline/ThreadTimelineSurface.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineSurface.tsx
@@ -11,7 +11,6 @@ import { ConversationTimeline } from "@/components/ui/conversation.js";
 import { HeightTransition } from "@/components/ui/height-transition.js";
 import { Icon } from "@bb/shared-ui/icon";
 import { Skeleton } from "@bb/shared-ui/skeleton";
-import { usePreferredTheme } from "@/hooks/useTheme";
 import { toUserAttachmentImageSrc } from "@/lib/user-attachment-images";
 import { ThreadTimelineRows } from "./ThreadTimelineRows.js";
 import { useAutoLoadOlderRows } from "./useAutoLoadOlderRows.js";
@@ -178,7 +177,6 @@ export function ThreadTimelineSurface({
   unreadDividerPlacement,
   workspaceRootPath,
 }: ThreadTimelineSurfaceProps) {
-  const preferredTheme = usePreferredTheme();
   const showActiveThinking =
     activeThinking !== null && ongoingIndicatorLabel === undefined;
   const activeThinkingText = activeThinking?.text.trim() ?? "";
@@ -241,7 +239,6 @@ export function ThreadTimelineSurface({
           hasOlderTimelineRows={hasOlderTimelineRows}
           isLoadingOlderTimelineRows={isLoadingOlderTimelineRows}
           onLoadOlderRows={onLoadOlderRows}
-          themeType={preferredTheme}
           timelineRows={timelineRowsWithPendingStop}
           threadId={threadId}
           threadRuntimeDisplayStatus={threadRuntimeDisplayStatus}

--- a/apps/app/src/components/thread/timeline/TimelineFileDiffBlock.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineFileDiffBlock.tsx
@@ -8,12 +8,11 @@ import {
 } from "@bb/client-core";
 import { GitDiffCard } from "../../git-diff/GitDiffCard.js";
 import { EventCodeBlock } from "../../ui/event-code-block.js";
+import type { DiffPresentation } from "@/components/code/code-rendering";
 import { TimelineDetailScroll } from "./TimelineDetailScroll.js";
-import type { ThreadTimelineTheme } from "./types.js";
 
 export interface TimelineFileDiffBlockProps {
   change: TimelineFileChange;
-  themeType: ThreadTimelineTheme;
   /**
    * Workspace root path the agent ran in (`environment.path`). When defined,
    * the prefix is stripped from `change.path`/`change.movePath` before the
@@ -27,17 +26,13 @@ export interface TimelineFileDiffBlockProps {
 interface RenderablePatch {
   disableLineNumbers: boolean;
   fileDiff: FileDiffMetadata;
+  patch: string;
 }
 
 interface RenderedFileChange {
   plainDiff: string | null;
   renderablePatch: RenderablePatch | null;
 }
-
-const DIFF_VIEW_BASE_OPTIONS = {
-  overflow: "scroll",
-  diffStyle: "unified",
-} as const;
 
 const renderedFileChangeCache = new WeakMap<
   TimelineFileChange,
@@ -63,6 +58,7 @@ function parseRenderablePatch(
     return {
       disableLineNumbers: patchText.disableLineNumbers,
       fileDiff,
+      patch: patchText.patch,
     };
   } catch {
     return null;
@@ -92,7 +88,6 @@ function buildRenderedFileChange(
 
 export const TimelineFileDiffBlock = memo(function TimelineFileDiffBlock({
   change,
-  themeType,
   workspaceRootPath,
 }: TimelineFileDiffBlockProps) {
   const renderedChange = useMemo(
@@ -100,16 +95,16 @@ export const TimelineFileDiffBlock = memo(function TimelineFileDiffBlock({
     [change],
   );
   const renderablePatch = renderedChange.renderablePatch;
-  const cardDiffViewOptions = useMemo(
+  const cardPresentation = useMemo<DiffPresentation | null>(
     () =>
       renderablePatch
         ? {
-            ...DIFF_VIEW_BASE_OPTIONS,
-            themeType,
-            disableLineNumbers: renderablePatch.disableLineNumbers,
+            view: "unified",
+            overflow: "scroll",
+            showLineNumbers: !renderablePatch.disableLineNumbers,
           }
         : null,
-    [renderablePatch, themeType],
+    [renderablePatch],
   );
 
   if (renderablePatch === null && renderedChange.plainDiff === null) {
@@ -122,7 +117,7 @@ export const TimelineFileDiffBlock = memo(function TimelineFileDiffBlock({
 
   const diffContentKey = `${renderablePatch ? "p" : "n"}:${renderedChange.plainDiff?.length ?? 0}`;
 
-  if (renderablePatch && cardDiffViewOptions) {
+  if (renderablePatch && cardPresentation) {
     return (
       <TimelineDetailScroll
         size="base"
@@ -134,7 +129,8 @@ export const TimelineFileDiffBlock = memo(function TimelineFileDiffBlock({
         <div data-timeline-file-diff="">
           <GitDiffCard
             fileDiff={renderablePatch.fileDiff}
-            diffViewOptions={cardDiffViewOptions}
+            patchText={renderablePatch.patch}
+            presentation={cardPresentation}
             filePathRoot={workspaceRootPath}
             cardClassName="rounded-none border-0 bg-transparent"
             showStuckHeaderEdge={false}

--- a/apps/app/src/components/thread/timeline/TimelineRowDetails.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineRowDetails.tsx
@@ -23,13 +23,11 @@ import {
   type TimelineWorkRowFullOutputState,
 } from "./useTimelineWorkRowFullOutput.js";
 import { buildThreadHostFileContentUrl } from "@/lib/file-content-urls";
-import type { ThreadTimelineTheme } from "./types.js";
 import type { ThreadTimelineImageViewSrcResolver } from "./types.js";
 
 export interface WorkRowBodyProps {
   resolveImageViewSrc?: ThreadTimelineImageViewSrcResolver;
   row: TimelineViewWorkRow;
-  themeType: ThreadTimelineTheme;
   workspaceRootPath: string | undefined;
 }
 
@@ -230,7 +228,6 @@ function ToolWorkRowBody({ row }: ToolWorkRowBodyProps) {
 export function WorkRowBody({
   resolveImageViewSrc,
   row,
-  themeType,
   workspaceRootPath,
 }: WorkRowBodyProps) {
   switch (row.workKind) {
@@ -243,7 +240,6 @@ export function WorkRowBody({
         <div className="space-y-2">
           <LazyTimelineFileDiffBlock
             change={row.change}
-            themeType={themeType}
             workspaceRootPath={workspaceRootPath}
           />
           {row.stderr ? (

--- a/apps/app/src/components/thread/timeline/index.ts
+++ b/apps/app/src/components/thread/timeline/index.ts
@@ -45,6 +45,5 @@ export type {
   ThreadTimelineLocalFileLinkHandler,
   ThreadTimelineOpenPluginPanelHandler,
   ThreadTimelineUnreadDividerPlacement,
-  ThreadTimelineTheme,
   UserAttachmentImageSrcResolver,
 } from "./types.js";

--- a/apps/app/src/components/thread/timeline/rows/FileChange.stories.tsx
+++ b/apps/app/src/components/thread/timeline/rows/FileChange.stories.tsx
@@ -1,9 +1,5 @@
 import type { TimelineRow } from "@bb/server-contract";
-import {
-  ThreadTimelineRows,
-  type ThreadTimelineRowsProps,
-} from "@/components/thread/timeline";
-import { usePreferredTheme } from "@/hooks/useTheme";
+import { ThreadTimelineRows } from "@/components/thread/timeline";
 import { fileChangeRow } from "@/test/fixtures/thread-timeline-rows";
 import { StoryCard, StoryRow } from "../../../../../.ladle/story-card";
 
@@ -19,18 +15,6 @@ const baseProps = {
   threadRuntimeDisplayStatus: "idle" as const,
   workspaceRootPath: "/Users/michael/.bb-dev/worktrees/env_story/bb",
 };
-
-// Story-only wrapper — pulls the active theme from ladle so the diff body's
-// syntax highlighting flips with the toolbar toggle. Without this each
-// ThreadTimelineRows render would default to themeType="light" regardless
-// of the page theme.
-type ThemedTimelineRowsProps = Omit<ThreadTimelineRowsProps, "themeType"> &
-  Partial<Pick<ThreadTimelineRowsProps, "themeType">>;
-
-function ThemedTimelineRows(props: ThemedTimelineRowsProps) {
-  const themeType = usePreferredTheme();
-  return <ThreadTimelineRows themeType={themeType} {...props} />;
-}
 
 // ---------------------------------------------------------------------------
 // Real file-change rows pulled from live threads in ~/.bb-dev/bb.db.
@@ -199,7 +183,7 @@ export function Overview() {
         hint="production-default — header only, click to expand. Real unified diff."
       >
         <TimelineStage>
-          <ThemedTimelineRows {...baseProps} timelineRows={[updateApiTypes]} />
+          <ThreadTimelineRows {...baseProps} timelineRows={[updateApiTypes]} />
         </TimelineStage>
       </StoryRow>
       <StoryRow
@@ -207,7 +191,7 @@ export function Overview() {
         hint="kind=add. Diff is the full new-file content; stats count plain lines."
       >
         <TimelineStage>
-          <ThemedTimelineRows
+          <ThreadTimelineRows
             {...baseProps}
             timelineRows={[addFormatHelpersTest]}
           />
@@ -218,7 +202,7 @@ export function Overview() {
         hint="kind=delete. Diff is the prior file content; stats count as removed."
       >
         <TimelineStage>
-          <ThemedTimelineRows
+          <ThreadTimelineRows
             {...baseProps}
             timelineRows={[deleteActiveThinking]}
           />
@@ -229,7 +213,7 @@ export function Overview() {
         hint="status=pending, no completedAt — edit is mid-flight"
       >
         <TimelineStage>
-          <ThemedTimelineRows
+          <ThreadTimelineRows
             {...baseProps}
             timelineRows={[runningFileChange]}
           />
@@ -237,7 +221,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow label="collapsed — error" hint="status=error, stderr populated">
         <TimelineStage>
-          <ThemedTimelineRows {...baseProps} timelineRows={[errorFileChange]} />
+          <ThreadTimelineRows {...baseProps} timelineRows={[errorFileChange]} />
         </TimelineStage>
       </StoryRow>
       <StoryRow
@@ -245,7 +229,7 @@ export function Overview() {
         hint="status=interrupted — turn was cancelled mid-edit"
       >
         <TimelineStage>
-          <ThemedTimelineRows
+          <ThreadTimelineRows
             {...baseProps}
             timelineRows={[interruptedFileChange]}
           />
@@ -256,7 +240,7 @@ export function Overview() {
         hint="approvalStatus=waiting_for_approval, parked before applying the edit"
       >
         <TimelineStage>
-          <ThemedTimelineRows
+          <ThreadTimelineRows
             {...baseProps}
             timelineRows={[waitingApprovalFileChange]}
           />
@@ -267,7 +251,7 @@ export function Overview() {
         hint="approvalStatus=denied, user rejected the edit"
       >
         <TimelineStage>
-          <ThemedTimelineRows
+          <ThreadTimelineRows
             {...baseProps}
             timelineRows={[deniedFileChange]}
           />
@@ -278,7 +262,7 @@ export function Overview() {
         hint="extract-to-memo refactor of ThreadFollowUpComposer.tsx — full diff body inline"
       >
         <TimelineStage>
-          <ThemedTimelineRows
+          <ThreadTimelineRows
             {...baseProps}
             initialExpanded={new Set([largeRefactorComposer.id])}
             timelineRows={[largeRefactorComposer]}

--- a/apps/app/src/components/thread/timeline/types.ts
+++ b/apps/app/src/components/thread/timeline/types.ts
@@ -8,8 +8,6 @@ import type { MarkdownPreviewLinkHandler } from "../../ui/markdown-link.js";
 import type { PromptDraftAttachment } from "@/lib/prompt-draft";
 import type { MarkdownMessageDirectiveOpenThreadPanel } from "@/components/ui/markdown-message-directives";
 
-export type ThreadTimelineTheme = "light" | "dark";
-
 export type ThreadTimelineLocalFileLink = MarkdownPreviewLocalFileLink;
 
 export type ThreadTimelineLocalFileLinkHandler =

--- a/apps/app/src/components/tools/PluginCapabilities.tsx
+++ b/apps/app/src/components/tools/PluginCapabilities.tsx
@@ -252,6 +252,18 @@ function pluginAppSurfaceItems(
     ),
     ...namedSlotItems(
       pluginId,
+      slots.sourceCodeRenderers,
+      "source-code-renderer",
+      "Replaces how source code is displayed everywhere in the app.",
+    ),
+    ...namedSlotItems(
+      pluginId,
+      slots.diffRenderers,
+      "diff-renderer",
+      "Replaces how diffs are displayed everywhere in the app.",
+    ),
+    ...namedSlotItems(
+      pluginId,
       slots.threadPanelActions,
       "thread-panel",
       "Adds an action that opens a panel beside a thread.",

--- a/apps/app/src/lib/plugin-replacement-preference.ts
+++ b/apps/app/src/lib/plugin-replacement-preference.ts
@@ -1,0 +1,57 @@
+import { atomWithStorage } from "jotai/utils";
+import { createJsonLocalStorage } from "@/lib/browser-storage";
+import {
+  resolveReplacement,
+  type ResolvedReplacement,
+} from "@/lib/plugin-slot-resolvers";
+
+/**
+ * The per-client pin shared by every exclusive replacement surface that offers
+ * one (the sidebar thread list, the source and diff renderers).
+ *
+ * All three answer the same question — automatic, BB's own, or one named
+ * provider — so they answer it the same way, and a stored selection for an
+ * unavailable provider degrades to BB without being erased: a temporarily
+ * disabled plugin gets its surface back when it returns.
+ */
+
+/** Follow deterministic slot order and activate the first provider. */
+export const AUTOMATIC_REPLACEMENT_PROVIDER = "__automatic__";
+
+/** Always use BB's own implementation. */
+export const BUILT_IN_REPLACEMENT_PROVIDER = "__builtin__";
+
+interface ReplacementProviderIdentity {
+  pluginId: string;
+  id: string;
+}
+
+export function replacementProviderKey(
+  slot: ReplacementProviderIdentity,
+): string {
+  return `${slot.pluginId}/${slot.id}`;
+}
+
+export function createReplacementPreferenceAtom(storageKey: string) {
+  return atomWithStorage<string>(
+    storageKey,
+    AUTOMATIC_REPLACEMENT_PROVIDER,
+    createJsonLocalStorage<string>(),
+    { getOnInit: true },
+  );
+}
+
+export function resolvePreferredReplacement<
+  Slot extends ReplacementProviderIdentity,
+>(
+  slots: readonly Slot[],
+  preference: string = AUTOMATIC_REPLACEMENT_PROVIDER,
+): ResolvedReplacement<Slot> {
+  if (preference === BUILT_IN_REPLACEMENT_PROVIDER) return { kind: "owner" };
+  return resolveReplacement(
+    slots,
+    preference === AUTOMATIC_REPLACEMENT_PROVIDER
+      ? undefined
+      : (candidate) => replacementProviderKey(candidate) === preference,
+  );
+}

--- a/apps/app/src/lib/plugin-sdk-app-impl.tsx
+++ b/apps/app/src/lib/plugin-sdk-app-impl.tsx
@@ -1,6 +1,8 @@
 import { useMemo } from "react";
 import type { MarkdownProps, PluginSdkApp } from "@get-bb/plugin-sdk";
+import { PluginDiff } from "@/components/plugin/PluginDiff";
 import { PluginNewThreadComposer } from "@/components/plugin/PluginNewThreadComposer";
+import { PluginSourceCode } from "@/components/plugin/PluginSourceCode";
 import { PluginThreadChat } from "@/components/plugin/PluginThreadChat";
 import { MarkdownPreview } from "@/components/ui/markdown-preview";
 import type {
@@ -58,6 +60,11 @@ export const pluginSdkAppImplementation = {
   // Experimental (see docs/api_to_audit.md): the create-side counterpart to
   // ThreadChat.
   experimental_NewThreadComposer: PluginNewThreadComposer,
+  // Experimental (see docs/api_to_audit.md): the host-owned code renderers.
+  // Both resolve any active plugin replacement, so first-party surfaces and
+  // plugins share one boundary.
+  experimental_SourceCode: PluginSourceCode,
+  experimental_Diff: PluginDiff,
   // Experimental (see docs/api_to_audit.md): the sidebar thread-list data
   // plane, for plugins that replace the list itself.
   experimental_useSidebarThreads: useSidebarThreads,

--- a/apps/app/src/lib/plugin-slot-resolvers.test.ts
+++ b/apps/app/src/lib/plugin-slot-resolvers.test.ts
@@ -4,7 +4,6 @@ import type {
   PluginFileOpenerSlot,
   PluginMessageDirectiveSlot,
   PluginPendingInteractionSlot,
-  PluginThreadListSlot,
 } from "./plugin-slots";
 import {
   BUILT_IN_FILE_OPENER_PREFERENCE,
@@ -19,7 +18,6 @@ import {
   resolveMessageDirectiveRegistry,
   resolvePendingInteraction,
   resolveReplacement,
-  resolveThreadListReplacement,
 } from "./plugin-slot-resolvers";
 
 function Component() {
@@ -162,22 +160,6 @@ describe("replacement resolvers", () => {
       ),
     ).toEqual({ kind: "plugin", registration: gamma });
     expect(resolveReplacement([], () => true)).toEqual({ kind: "owner" });
-  });
-
-  it("automatically activates the first thread-list replacement", () => {
-    const threadList: PluginThreadListSlot = {
-      pluginId: "inbox",
-      generation: 1,
-      id: "threads",
-      title: "Inbox",
-      component: Component,
-    };
-
-    expect(resolveThreadListReplacement([threadList])).toEqual({
-      kind: "plugin",
-      registration: threadList,
-    });
-    expect(resolveThreadListReplacement([])).toEqual({ kind: "owner" });
   });
 
   it("activates the first matching file opener and preserves per-open overrides", () => {

--- a/apps/app/src/lib/plugin-slot-resolvers.ts
+++ b/apps/app/src/lib/plugin-slot-resolvers.ts
@@ -8,7 +8,6 @@ import type {
   PluginFileOpenerSlot,
   PluginMessageDirectiveSlot,
   PluginPendingInteractionSlot,
-  PluginThreadListSlot,
 } from "./plugin-slots";
 
 type ComposerAction = NonNullable<ComposerCustomization["actions"]>[number];
@@ -263,13 +262,6 @@ export function resolveReplacement<Registration>(
   return registration === undefined
     ? OWNER_REPLACEMENT
     : { kind: "plugin", registration };
-}
-
-export function resolveThreadListReplacement(
-  registrations: readonly PluginThreadListSlot[],
-  applies?: (registration: PluginThreadListSlot) => boolean,
-): ResolvedReplacement<PluginThreadListSlot> {
-  return resolveReplacement(registrations, applies);
 }
 
 export type FileOpenerOverride =

--- a/apps/app/src/lib/plugin-slots.ts
+++ b/apps/app/src/lib/plugin-slots.ts
@@ -1,6 +1,7 @@
 import { useSyncExternalStore } from "react";
 import type {
   ComposerCustomization,
+  PluginDiffRendererRegistration,
   PluginPendingInteractionRegistration,
   PluginFileOpenerRegistration,
   PluginHomepageSectionRegistration,
@@ -11,6 +12,7 @@ import type {
   PluginProviderIconRegistration,
   PluginSettingsSectionRegistration,
   PluginSidebarFooterActionRegistration,
+  PluginSourceCodeRendererRegistration,
   PluginThreadHeaderActionRegistration,
   PluginThreadListRegistration,
   PluginThreadPanelActionRegistration,
@@ -42,6 +44,13 @@ export interface PluginRegistrationSet {
   /** Optional for the same reason as `threadLists`: bundles built earlier. */
   threadHeaderActions?: readonly PluginThreadHeaderActionRegistration[];
   fileOpeners: readonly PluginFileOpenerRegistration[];
+  /**
+   * Optional for the same reason as `threadLists`: bundles built before the
+   * exclusive code-rendering slots existed never call them.
+   */
+  sourceCodeRenderers?: readonly PluginSourceCodeRendererRegistration[];
+  /** Optional for the same reason as `sourceCodeRenderers`. */
+  diffRenderers?: readonly PluginDiffRendererRegistration[];
   messageDirectives: readonly PluginMessageDirectiveRegistration[];
   messageActions?: readonly PluginMessageActionRegistration[];
   /** Optional for the same reason as `threadLists`: bundles built earlier. */
@@ -81,6 +90,10 @@ export interface PluginThreadHeaderActionSlot
   extends PluginThreadHeaderActionRegistration, PluginSlotBase {}
 export interface PluginFileOpenerSlot
   extends PluginFileOpenerRegistration, PluginSlotBase {}
+export interface PluginSourceCodeRendererSlot
+  extends PluginSourceCodeRendererRegistration, PluginSlotBase {}
+export interface PluginDiffRendererSlot
+  extends PluginDiffRendererRegistration, PluginSlotBase {}
 export interface PluginMessageDirectiveSlot
   extends PluginMessageDirectiveRegistration, PluginSlotBase {}
 export interface PluginMessageActionSlot
@@ -101,6 +114,8 @@ export interface PluginSlotSnapshot {
   threadLists: readonly PluginThreadListSlot[];
   threadHeaderActions: readonly PluginThreadHeaderActionSlot[];
   fileOpeners: readonly PluginFileOpenerSlot[];
+  sourceCodeRenderers: readonly PluginSourceCodeRendererSlot[];
+  diffRenderers: readonly PluginDiffRendererSlot[];
   messageDirectives: readonly PluginMessageDirectiveSlot[];
   messageActions: readonly PluginMessageActionSlot[];
   providerIcons: readonly PluginProviderIconSlot[];
@@ -118,6 +133,8 @@ export const EMPTY_PLUGIN_SLOT_SNAPSHOT: PluginSlotSnapshot = {
   threadLists: [],
   threadHeaderActions: [],
   fileOpeners: [],
+  sourceCodeRenderers: [],
+  diffRenderers: [],
   messageDirectives: [],
   messageActions: [],
   providerIcons: [],
@@ -142,6 +159,8 @@ const SLOT_KINDS: readonly SlotKind[] = [
   "threadLists",
   "threadHeaderActions",
   "fileOpeners",
+  "sourceCodeRenderers",
+  "diffRenderers",
   "messageDirectives",
   "messageActions",
   "providerIcons",
@@ -187,6 +206,8 @@ function flattenRegistrations(
     threadLists: stamp(set.threadLists),
     threadHeaderActions: stamp(set.threadHeaderActions),
     fileOpeners: stamp(set.fileOpeners),
+    sourceCodeRenderers: stamp(set.sourceCodeRenderers),
+    diffRenderers: stamp(set.diffRenderers),
     messageDirectives: stamp(set.messageDirectives),
     messageActions: stamp(set.messageActions),
     providerIcons: stamp(set.providerIcons),

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/hooks/useTheme";
 import { useHostDaemon, useLocalHostDaemonAccess } from "@/hooks/useHostDaemon";
 import { UsageLimitsSettingsSection } from "@/components/settings/UsageLimitsSettingsSection";
+import { CodeRendererSettings } from "@/components/settings/CodeRendererSettings";
 import { SidebarThreadListSetting } from "@/components/settings/SidebarThreadListSetting";
 import { SplitDimmingSetting } from "@/components/settings/SplitDimmingSetting";
 import { useSettingsNavState } from "@/components/settings/settings-nav";
@@ -684,6 +685,7 @@ export function AppearanceSettingsSection({
     <SettingsSection title="Appearance">
       <div className="space-y-5">
         <SidebarThreadListSetting />
+        <CodeRendererSettings />
         <SettingsWithControl label="Theme">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
@@ -1682,6 +1682,33 @@ projectId }` (nullable fields) and `path` follows the source (workspace:
   always use the built-in preview, and a removed/disabled opener degrades
   back to it. Pair with `bb.sdk.files` (rpc from your server) to load and
   CAS-save the content.
+- `experimental_sourceCodeRenderer` / `experimental_diffRenderer` →
+  replace bb's source or diff renderer everywhere it draws supplied content:
+  the native file preview, timeline file diffs, the environment diff panel's
+  file bodies, and every plugin calling the host components. Registration:
+  `{ id, title, description?, component }`. Like `experimental_threadList`
+  each slot is **exclusive** — one renderer at a time, first in slot order
+  wins, and a missing, disabled, or crashing replacement falls back to bb's
+  renderer. Installing and enabling the plugin activates it; there are no
+  scope or extension filters on the registration, so conditional behavior
+  belongs in the component. Source props:
+  `{ content, path, overflow, highlightedLines, experimental_Original }`;
+  diff props:
+  `{ patch, path, view, overflow, showLineNumbers, experimental_Original }`.
+  Every value is already resolved. Render `experimental_Original` (bb's
+  renderer, bound to this call) to delegate without re-entering resolution —
+  behind a plugin setting, by language, over a size threshold:
+
+  ```tsx
+  app.slots.experimental_diffRenderer({
+    id: "compact",
+    title: "Compact diffs",
+    component: ({ patch, path, experimental_Original: Original }) =>
+      patch.length > 20_000 ? <Original /> : <MyDiff patch={patch} path={path} />,
+  });
+  ```
+
+  Experimental: see `docs/api_to_audit.md`.
 - `messageDirective` → `{ attributes, source, message,
 openWorkspaceFile }` — register a leaf
   assistant-message directive. Registration:
@@ -1772,6 +1799,32 @@ className?, leadingContent?, messageActions? }` —
   host owns timeline loading, streaming, drafts, send/queue/steer/stop,
   attachments, execution controls, pending interactions, and read tracking —
   do not proxy thread data through your own RPC or rebuild the composer.
+- `experimental_SourceCode` — bb's source viewer. Props:
+  `{ content, path, overflow?, highlightedLines?, className? }` — `path`
+  drives language detection, `overflow` is `"scroll"` (default) or `"wrap"`,
+  and `highlightedLines` is a 1-based inclusive `{ start, end }` (default
+  null). bb owns syntax highlighting, gutters, and the live code theme.
+- `experimental_Diff` — bb's diff viewer. Props:
+  `{ patch, path, view?, overflow?, showLineNumbers?, className? }` —
+  `patch` is a unified patch for exactly ONE file and `view` is `"unified"`
+  (default) or `"split"`. bb normalizes the patch, so a GitHub REST patch or
+  a bare `@@` hunk works without synthesizing a `diff --git` header
+  yourself; unparseable content degrades to plain monospace text. Reference:
+  `plugins/github/app.tsx`.
+
+  Alias both on import — JSX reads a lowercase-initial name as an intrinsic
+  element:
+
+  ```tsx
+  import { experimental_Diff as Diff } from "@get-bb/plugin-sdk/app";
+
+  <Diff patch={file.patch} path={file.path} />;
+  ```
+
+  Highlighting uses the host's shared worker pool from React context. Thread
+  panels and plugin nav panels have one; homepage and settings sections do
+  not, so code there renders unhighlighted rather than broken.
+  Experimental: see `docs/api_to_audit.md`.
 - `Markdown` — bb's chat-message markdown renderer (same typography,
   spacing, and code styling as timeline messages). Props:
   `{ content, className? }`. Use it wherever plugin UI quotes or previews
@@ -1973,16 +2026,12 @@ only `definePluginApp` + the hooks):
   its namespace would bloat the host's boot payload) — it bundles from your
   `node_modules` in both `app.tsx` and `server.ts`, so keep it in
   `dependencies`.
-- Syntax-highlighted diffs: `parsePatchFiles` from `@pierre/diffs` +
-  `FileDiff` from `@pierre/diffs/react` render patches exactly like the
-  app's own diff panel (the host provides the highlighting worker pool via
-  React context on every plugin surface; add `@pierre/diffs` to
-  devDependencies for types). Pass
-  `theme: { dark: document.documentElement.dataset.bbCodeThemeDark,
-light: document.documentElement.dataset.bbCodeThemeLight }` so a custom
-  UI theme's Pierre JSON applies. Synthesize a `diff --git a/<p> b/<p>`
-  header when your patch source (e.g. the GitHub REST API) omits it — see
-  `plugins/github/app.tsx`.
+- Source and diffs: use the host components
+  `experimental_SourceCode` / `experimental_Diff` (see "Host components"),
+  NOT a direct
+  `@pierre/diffs` import. The shim stays for compatibility, but hand-rolled
+  Pierre usage means owning patch normalization and the code theme yourself,
+  and it opts you out of any installed renderer replacement.
 - Everything else bundles from YOUR `node_modules` (hugeicons, lucide,
   non-portal radix, zod, form/calendar/chart libs): run `npm install`
   after adding components (`bb plugin new` runs the first one; `shadcn add`

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
@@ -1689,7 +1689,9 @@ projectId }` (nullable fields) and `path` follows the source (workspace:
   `{ id, title, description?, component }`. Like `experimental_threadList`
   each slot is **exclusive** — one renderer at a time, first in slot order
   wins, and a missing, disabled, or crashing replacement falls back to bb's
-  renderer. Installing and enabling the plugin activates it; there are no
+  renderer. Installing and enabling the plugin activates it, and the user can
+  pin bb's renderer or a specific provider under
+  **Settings → Appearance** ("Source code" / "Diffs"), per client. There are no
   scope or extension filters on the registration, so conditional behavior
   belongs in the component. Source props:
   `{ content, path, overflow, highlightedLines, experimental_Original }`;

--- a/apps/server/test/services/plugins/plugin-authoring-docs.test.ts
+++ b/apps/server/test/services/plugins/plugin-authoring-docs.test.ts
@@ -8,6 +8,7 @@ import {
   type PluginAppSlots,
   type PluginContentScriptContext,
   type PluginContentScriptRegistration,
+  type PluginDiffRendererProps,
   type PluginFileOpenerProps,
   type PluginHomepageSectionProps,
   type PluginHttpAuthMode,
@@ -22,6 +23,7 @@ import {
   type PluginSettingDescriptor,
   type PluginSettingsSectionProps,
   type PluginSidebarFooterActionProps,
+  type PluginSourceCodeRendererProps,
   type PluginThreadHeaderActionProps,
   type PluginThreadListProps,
   type PluginSidebarFooterActionRegistration,
@@ -162,6 +164,8 @@ type SlotPropsByName = {
   experimental_threadList: PluginThreadListProps;
   experimental_threadHeaderAction: PluginThreadHeaderActionProps;
   fileOpener: PluginFileOpenerProps;
+  experimental_sourceCodeRenderer: PluginSourceCodeRendererProps;
+  experimental_diffRenderer: PluginDiffRendererProps;
   messageDirective: PluginMessageDirectiveProps;
   messageAction: PluginMessageActionContext;
   // Registration-object slot: the component receives only className, so the
@@ -240,6 +244,21 @@ const FRONTEND_SLOT_PROP_FIELDS = {
     "isCompactViewport",
   ],
   fileOpener: ["path", "source", "experimental_Original"],
+  experimental_sourceCodeRenderer: [
+    "content",
+    "path",
+    "overflow",
+    "highlightedLines",
+    "experimental_Original",
+  ],
+  experimental_diffRenderer: [
+    "patch",
+    "path",
+    "view",
+    "overflow",
+    "showLineNumbers",
+    "experimental_Original",
+  ],
   messageDirective: ["attributes", "source", "message", "openWorkspaceFile"],
   messageAction: ["threadId", "message", "selectedText", "openPanel"],
   experimental_providerIcon: ["providerId", "icon"],

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -557,6 +557,105 @@ the same plugin again.
 4. Verify the owner renderer remains independent of provider precedence and
    cannot recurse through file-opener resolution.
 
+## `experimental_SourceCode` / `experimental_Diff` (`@get-bb/plugin-sdk/app`)
+
+**What it does.** Two host-owned renderers for supplied code content.
+`experimental_SourceCode` takes source text plus a path and owns syntax
+highlighting, gutters, wrapping, highlighted-line presentation, and the live BB
+code theme. `experimental_Diff` takes a single-file patch plus a path and owns
+patch normalization (a patch without a `diff --git` header is completed from
+`path`, which is what makes GitHub's REST patches and bare `@@` hunks render),
+syntax highlighting, unified/split presentation, gutters, and the same live
+theme. Patch content that will not parse degrades to plain monospace text.
+
+These are the same components BB's own file preview, timeline file diffs, and
+environment diff panel render through, so an active
+`experimental_sourceCodeRenderer` / `experimental_diffRenderer` replacement
+covers first-party surfaces and plugin surfaces at once. Fetching files or git
+data, multi-file lists, tabs, card headers, git actions, and add-to-prompt
+behavior deliberately stay with the caller.
+
+**Audit before stabilizing.**
+
+1. **Prop surface.** Confirm content + path + presentation is the right minimal
+   contract, and decide whether `className` belongs in it at all — a
+   replacement never receives it today, so a `className` that only styles BB's
+   renderer is a quiet inconsistency.
+2. **Diff input shape.** Confirm single-file patch text is the right currency.
+   Multi-file patches, `processFile`-style pre-parsed input, and per-hunk
+   rendering are all things callers have wanted; none are expressible now.
+3. **Language selection.** Highlighting is inferred from `path` only. Confirm
+   an explicit language override is not needed before the names freeze, and
+   that no implementation-library language union leaks in when it is added.
+4. **Worker pool.** Highlighting needs BB's Pierre worker pool from React
+   context. Thread panes and plugin nav panels provide one; homepage and
+   settings sections do not, so a diff rendered there is unhighlighted rather
+   than broken. Decide whether the host should provide the pool at the
+   component instead of the surface.
+5. **Selection to chat.** BB's own surfaces pass a selection-to-composer
+   handler that the public component withholds. Confirm plugins should reach
+   that through `useComposer()` rather than a renderer prop.
+6. **Size and virtualization.** Neither component caps input size or
+   virtualizes. Audit against a plugin that renders a very large file or patch.
+
+## `app.slots.experimental_sourceCodeRenderer` / `app.slots.experimental_diffRenderer` (`@get-bb/plugin-sdk/app`)
+
+**What it does.** Replaces BB's source or diff renderer everywhere it draws
+supplied content — the native file preview, timeline file diffs, the
+environment diff panel's file bodies, and every plugin calling the public
+components. Like `experimental_threadList` these slots are **exclusive**: one
+renderer each. Registering activates it while the plugin is enabled; if several
+are registered the first in slot snapshot order wins (plugin ids sorted, then
+each plugin's registration order). There are deliberately no scope, extension,
+or enabled-by-setting filters on the registration — conditional behavior
+belongs in the component, which decides per call from its semantic props and
+renders `experimental_Original` when it does not want the render.
+
+Fallbacks: no registration renders BB's renderer; a disabled or uninstalled
+plugin reveals the next registration or BB's renderer; a component that throws
+renders BB's renderer through the slot's crash fallback.
+
+**Audit before stabilizing.**
+
+1. **Arbitration.** Unlike the thread list there is no user-facing pin under
+   Settings. Confirm automatic-only selection is right for a renderer, or add
+   the same pinning model before stabilizing.
+2. **Crash signal.** The thread list toasts when a crash swaps the sidebar
+   back. These slots fall back silently, because a diff card is not a whole
+   sidebar. Confirm silence is right, especially when many cards crash at once.
+3. **Scope.** One registration replaces BB's own surfaces and other plugins'
+   surfaces alike. Confirm a plugin should be able to change how *another*
+   plugin's `experimental_Diff` renders, and whether a first-party-only or
+   own-surfaces-only scope is ever needed.
+4. **Capability parity.** A replacement cannot implement context expansion,
+   selection-to-chat, or the deleted-file gate, because those inputs are
+   host-only. Confirm that asymmetry is acceptable, or promote the ones that
+   should be part of the contract.
+5. **Two slots or one.** Confirm source and diff should stay separately
+   replaceable rather than one "code renderer" registration.
+
+## `PluginSourceCodeRendererProps.experimental_Original` / `PluginDiffRendererProps.experimental_Original` (`@get-bb/plugin-sdk/app`)
+
+**What it does.** Supplies a renderer replacement with BB's renderer bound to
+the current render. Rendering it delegates without re-entering replacement
+resolution; the host renders the same component as the crash fallback. BB's
+renderers are behind `lazy()`, so a replacement that never delegates never
+downloads them.
+
+**Audit before stabilizing.**
+
+1. Confirm a no-props bound component stays the right delegation contract as
+   the host-only inputs (pre-parsed files, selection-to-chat) grow.
+2. Verify delegation preserves everything the owner path does on BB's own
+   surfaces — context expansion, line selection, highlighted-line scrolling —
+   when the replacement delegates from inside a first-party card.
+3. Confirm the lazy boundary stays lazy: a replacement that never delegates
+   must not pull BB's renderer chunk, and the Suspense fallback must not
+   flash on the owner path.
+4. Decide whether this field should stabilize together with the shared
+   replacement primitive that `PluginThreadListProps` and
+   `PluginFileOpenerProps` also use, rather than per surface.
+
 ## `experimental_useSidebarThreads` / `experimental_useSidebarThreadActions` (`@get-bb/plugin-sdk/app`)
 
 **What it does.** Gives a plugin component the sidebar's live thread view and

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -623,17 +623,26 @@ is temporarily unavailable renders BB's renderer without erasing the pin.
 **Audit before stabilizing.**
 
 1. **Arbitration.** Confirm automatic/pinned/built-in is the right long-term
-   selection model here as it is for the thread list, and that a per-client
-   choice is the right scope for something as visible as every diff in the app.
-   The two renderers pin independently; confirm users do not instead expect one
-   "code rendering" choice.
-2. **Crash signal.** The thread list toasts when a crash swaps the sidebar
-   back. These slots fall back silently, because a diff card is not a whole
-   sidebar. Confirm silence is right, especially when many cards crash at once.
-3. **Scope.** One registration replaces BB's own surfaces and other plugins'
-   surfaces alike. Confirm a plugin should be able to change how *another*
-   plugin's `experimental_Diff` renders, and whether a first-party-only or
-   own-surfaces-only scope is ever needed.
+   selection model here as it is for the thread list. **Resolved (Aug 2026):
+   the pin stays per client.** A device-local override matches the sidebar
+   thread list, even though the key/value app settings added in #1875 would
+   now make an account-level pin cheap to add. Still open: the two renderers
+   pin independently; confirm users do not instead expect one "code rendering"
+   choice.
+2. **Resolved (Aug 2026): a crash swaps back to BB's renderer silently.**
+   A diff card is not a whole sidebar — the reader still sees a correct diff,
+   where a blank thread list strands them — so neither host passes `onCrash`.
+   Authors are not left without a signal: `PluginSlotBoundary` still
+   `console.warn`s the plugin id, slot key, and component stack. The hosts pass
+   no `instanceId`, so the first crash disables the slot for the session rather
+   than letting cards crash one at a time.
+3. **Resolved (Aug 2026): the replacement is global, other plugins'
+   surfaces included.** "Install this and every diff looks like X" is the
+   point; covering BB's surfaces but not the GitHub plugin's would be a
+   half-measure, and a plugin calling `experimental_Diff` would silently opt
+   its users out. No first-party-only or own-surfaces-only scope. Audit this as
+   precedent rather than as a fact about these two slots: no other slot lets a
+   plugin reach into another plugin's rendered output.
 4. **Capability parity.** A replacement cannot implement context expansion,
    selection-to-chat, or the deleted-file gate, because those inputs are
    host-only. Confirm that asymmetry is acceptable, or promote the ones that

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -606,20 +606,27 @@ environment diff panel's file bodies, and every plugin calling the public
 components. Like `experimental_threadList` these slots are **exclusive**: one
 renderer each. Registering activates it while the plugin is enabled; if several
 are registered the first in slot snapshot order wins (plugin ids sorted, then
-each plugin's registration order). There are deliberately no scope, extension,
-or enabled-by-setting filters on the registration — conditional behavior
-belongs in the component, which decides per call from its semantic props and
-renders `experimental_Original` when it does not want the render.
+each plugin's registration order). The user can override that under
+Settings → Appearance ("Source code" and "Diffs") by pinning BB's renderer or
+a specific provider; the choice is per client, and it is the same
+automatic/built-in/named-provider model the sidebar thread list uses. There are
+deliberately no scope, extension, or enabled-by-setting filters on the
+registration — conditional behavior belongs in the component, which decides per
+call from its semantic props and renders `experimental_Original` when it does
+not want the render.
 
 Fallbacks: no registration renders BB's renderer; a disabled or uninstalled
 plugin reveals the next registration or BB's renderer; a component that throws
-renders BB's renderer through the slot's crash fallback.
+renders BB's renderer through the slot's crash fallback. A pinned provider that
+is temporarily unavailable renders BB's renderer without erasing the pin.
 
 **Audit before stabilizing.**
 
-1. **Arbitration.** Unlike the thread list there is no user-facing pin under
-   Settings. Confirm automatic-only selection is right for a renderer, or add
-   the same pinning model before stabilizing.
+1. **Arbitration.** Confirm automatic/pinned/built-in is the right long-term
+   selection model here as it is for the thread list, and that a per-client
+   choice is the right scope for something as visible as every diff in the app.
+   The two renderers pin independently; confirm users do not instead expect one
+   "code rendering" choice.
 2. **Crash signal.** The thread list toasts when a crash swaps the sidebar
    back. These slots fall back silently, because a diff card is not a whole
    sidebar. Confirm silence is right, especially when many cards crash at once.

--- a/packages/plugin-sdk/src/app-contract.ts
+++ b/packages/plugin-sdk/src/app-contract.ts
@@ -183,6 +183,108 @@ export interface PluginFileOpenerProps {
   experimental_Original: ComponentType;
 }
 
+// ---------------------------------------------------------------------------
+// Host-owned code rendering (SourceCode / Diff) — the public components and
+// the props their replacements receive.
+// ---------------------------------------------------------------------------
+
+/** How a code line longer than the viewport is presented. */
+export type CodeOverflowMode = "scroll" | "wrap";
+
+/** How a diff presents its two sides. */
+export type DiffViewMode = "unified" | "split";
+
+/** A 1-based, inclusive line range. */
+export interface SourceCodeLineRange {
+  start: number;
+  end: number;
+}
+
+/**
+ * Props of the host-owned `experimental_SourceCode` component — BB's source
+ * viewer. The host owns syntax highlighting, gutters, wrapping, line-selection
+ * presentation, and the live BB code theme; the caller owns loading the text
+ * and any surrounding chrome.
+ */
+export interface SourceCodeProps {
+  /** The complete source text to render. */
+  content: string;
+  /** File path or name. Drives language detection and the a11y label. */
+  path: string;
+  /** Long-line presentation. Defaults to `"scroll"`. */
+  overflow?: CodeOverflowMode;
+  /**
+   * Lines to highlight and scroll into view (1-based, inclusive). Defaults to
+   * `null` — nothing highlighted.
+   */
+  highlightedLines?: SourceCodeLineRange | null;
+  /** Applied to the renderer's root element. */
+  className?: string;
+}
+
+/**
+ * Props of the host-owned `experimental_Diff` component — BB's diff viewer.
+ * The host owns patch normalization (a patch without a `diff --git` header is
+ * completed from `path`), syntax highlighting, unified/split presentation,
+ * gutters, line-selection presentation, and the live BB code theme. Content
+ * that cannot be parsed as a patch degrades to plain monospace text.
+ */
+export interface DiffProps {
+  /** Unified patch text for exactly ONE file. */
+  patch: string;
+  /**
+   * The file the patch applies to. Used to complete a patch that arrives
+   * without a `diff --git` header (GitHub's REST patches, single `@@` hunks)
+   * and for language detection.
+   */
+  path: string;
+  /** Side-by-side or inline. Defaults to `"unified"`. */
+  view?: DiffViewMode;
+  /** Long-line presentation. Defaults to `"scroll"`. */
+  overflow?: CodeOverflowMode;
+  /** Whether the gutter shows line numbers. Defaults to `true`. */
+  showLineNumbers?: boolean;
+  /** Applied to the renderer's root element. */
+  className?: string;
+}
+
+/**
+ * Props passed to an `experimental_sourceCodeRenderer` component. Every value
+ * is already resolved — the replacement never re-applies a host default.
+ */
+export interface PluginSourceCodeRendererProps {
+  content: string;
+  path: string;
+  overflow: CodeOverflowMode;
+  highlightedLines: SourceCodeLineRange | null;
+  /**
+   * BB's source renderer, bound to this request. Render it to delegate
+   * conditionally without re-entering plugin replacement resolution.
+   *
+   * @experimental Audit before relying on this as a stable contract.
+   */
+  experimental_Original: ComponentType;
+}
+
+/**
+ * Props passed to an `experimental_diffRenderer` component. `patch` is always
+ * a complete single-file unified patch, whatever shape the caller supplied.
+ */
+export interface PluginDiffRendererProps {
+  patch: string;
+  path: string;
+  view: DiffViewMode;
+  overflow: CodeOverflowMode;
+  showLineNumbers: boolean;
+  /**
+   * BB's diff renderer, bound to this request. Render it to delegate
+   * conditionally without re-entering plugin replacement resolution.
+   *
+   * @experimental Audit before relying on this as a stable contract.
+   */
+  experimental_Original: ComponentType;
+}
+
 /**
  * Message context passed to a `messageDirective` component — the assistant
  * (or nested agent) message that contained the directive.
@@ -731,6 +833,43 @@ export interface PluginFileOpenerRegistration {
 }
 
 /**
+ * Replace BB's source-code renderer everywhere it renders supplied source
+ * text — the native file preview and every plugin that calls
+ * `experimental_SourceCode`. Like `experimental_threadList` this slot is
+ * **exclusive**: one renderer at a time. Registering activates it while the
+ * plugin is enabled; if several are registered the first in deterministic slot
+ * order wins. A missing, disabled, or crashing replacement falls back to BB's
+ * renderer, and a replacement can render `experimental_Original` to delegate
+ * per call (behind its own setting, by language, by size — whatever it needs).
+ */
+export interface PluginSourceCodeRendererRegistration {
+  /** Unique within the plugin; letters, digits, `-`, `_`. */
+  id: string;
+  /** Label shown in capability details. */
+  title: string;
+  /** Optional one-line description shown with the provider choice. */
+  description?: string;
+  component: ComponentType<PluginSourceCodeRendererProps>;
+}
+
+/**
+ * Replace BB's diff renderer everywhere it renders supplied diff content — the
+ * timeline file diffs, the environment diff panel's text bodies, and every
+ * plugin that calls `experimental_Diff`. Exclusive, with the same activation,
+ * fallback, and `experimental_Original` delegation rules as
+ * {@link PluginSourceCodeRendererRegistration}.
+ */
+export interface PluginDiffRendererRegistration {
+  /** Unique within the plugin; letters, digits, `-`, `_`. */
+  id: string;
+  /** Label shown in capability details. */
+  title: string;
+  /** Optional one-line description shown with the provider choice. */
+  description?: string;
+  component: ComponentType<PluginDiffRendererProps>;
+}
+
+/**
  * Register a leaf message directive rendered inside assistant (and nested
  * agent) message Markdown. `id` is the directive name: `inline-vis` matches
  * `::inline-vis{file="demo.html"}`.
@@ -877,6 +1016,22 @@ export interface PluginAppSlots {
     registration: PluginThreadHeaderActionRegistration,
   ): void;
   fileOpener(registration: PluginFileOpenerRegistration): void;
+  /**
+   * Replace BB's source-code renderer (see
+   * {@link PluginSourceCodeRendererRegistration}). Experimental: see
+   * docs/api_to_audit.md.
+   */
+  experimental_sourceCodeRenderer(
+    registration: PluginSourceCodeRendererRegistration,
+  ): void;
+  /**
+   * Replace BB's diff renderer (see
+   * {@link PluginDiffRendererRegistration}). Experimental: see
+   * docs/api_to_audit.md.
+   */
+  experimental_diffRenderer(
+    registration: PluginDiffRendererRegistration,
+  ): void;
   messageDirective(registration: PluginMessageDirectiveRegistration): void;
   messageAction(registration: PluginMessageActionRegistration): void;
   /**
@@ -1526,5 +1681,20 @@ export interface PluginSdkApp {
    * docs/api_to_audit.md for what to audit before the prefix drops.
    */
   experimental_NewThreadComposer: ComponentType<NewThreadComposerProps>;
+  /**
+   * The host-owned source viewer (see {@link SourceCodeProps}). Renders
+   * supplied source text with BB's syntax highlighting, gutters, and live code
+   * theme, and honours an active `experimental_sourceCodeRenderer`
+   * replacement. Experimental: see docs/api_to_audit.md.
+   */
+  experimental_SourceCode: ComponentType<SourceCodeProps>;
+  /**
+   * The host-owned diff viewer (see {@link DiffProps}). Renders supplied patch
+   * content with BB's normalization, syntax highlighting, unified/split
+   * presentation, and live code theme, and honours an active
+   * `experimental_diffRenderer` replacement. Experimental: see
+   * docs/api_to_audit.md.
+   */
+  experimental_Diff: ComponentType<DiffProps>;
   useComposerView(): ComposerView;
 }

--- a/packages/plugin-sdk/src/app.ts
+++ b/packages/plugin-sdk/src/app.ts
@@ -50,6 +50,9 @@ export const ThreadChat = runtime.ThreadChat;
 export const Markdown = runtime.Markdown;
 export const experimental_NewThreadComposer =
   runtime.experimental_NewThreadComposer;
+// Host-owned code rendering (experimental — see docs/api_to_audit.md).
+export const experimental_SourceCode = runtime.experimental_SourceCode;
+export const experimental_Diff = runtime.experimental_Diff;
 export const useRpc = runtime.useRpc;
 export const useRealtime = runtime.useRealtime;
 export const useRealtimeConnectionState = runtime.useRealtimeConnectionState;

--- a/packages/plugin-sdk/src/internal/plugin-app-collector.ts
+++ b/packages/plugin-sdk/src/internal/plugin-app-collector.ts
@@ -2,6 +2,7 @@ import type {
   ComposerCustomization,
   PluginAppDefinition,
   PluginContentScriptRegistration,
+  PluginDiffRendererRegistration,
   PluginFileOpenerRegistration,
   PluginHomepageSectionRegistration,
   PluginMessageActionRegistration,
@@ -12,6 +13,7 @@ import type {
   PluginProviderIconRegistration,
   PluginSettingsSectionRegistration,
   PluginSidebarFooterActionRegistration,
+  PluginSourceCodeRendererRegistration,
   PluginThreadHeaderActionRegistration,
   PluginThreadListRegistration,
   PluginThreadPanelActionRegistration,
@@ -45,6 +47,8 @@ export interface CollectedPluginAppRegistrations {
   threadLists: PluginThreadListRegistration[];
   threadHeaderActions: PluginThreadHeaderActionRegistration[];
   fileOpeners: PluginFileOpenerRegistration[];
+  sourceCodeRenderers: PluginSourceCodeRendererRegistration[];
+  diffRenderers: PluginDiffRendererRegistration[];
   messageDirectives: PluginMessageDirectiveRegistration[];
   messageActions: PluginMessageActionRegistration[];
   providerIcons: PluginProviderIconRegistration[];
@@ -74,6 +78,8 @@ export function collectPluginAppRegistrations(
     threadLists: [],
     threadHeaderActions: [],
     fileOpeners: [],
+    sourceCodeRenderers: [],
+    diffRenderers: [],
     messageDirectives: [],
     messageActions: [],
     providerIcons: [],
@@ -91,6 +97,8 @@ export function collectPluginAppRegistrations(
     threadList: new Set<string>(),
     threadHeaderAction: new Set<string>(),
     fileOpener: new Set<string>(),
+    sourceCodeRenderer: new Set<string>(),
+    diffRenderer: new Set<string>(),
     messageDirective: new Set<string>(),
     messageAction: new Set<string>(),
     providerIcon: new Set<string>(),
@@ -350,6 +358,38 @@ export function collectPluginAppRegistrations(
           id,
           title: requireNonEmptyString(kind, "title", registration.title),
           extensions,
+          component: requireComponent(kind, registration.component),
+        });
+      },
+      experimental_sourceCodeRenderer(registration) {
+        const kind = "slots.experimental_sourceCodeRenderer";
+        const id = requireSlotId(kind, registration?.id);
+        requireUniqueId(kind, seenIds.sourceCodeRenderer, id);
+        const description = requireOptionalString(
+          kind,
+          "description",
+          registration.description,
+        );
+        collected.sourceCodeRenderers.push({
+          id,
+          title: requireNonEmptyString(kind, "title", registration.title),
+          ...(description !== undefined ? { description } : {}),
+          component: requireComponent(kind, registration.component),
+        });
+      },
+      experimental_diffRenderer(registration) {
+        const kind = "slots.experimental_diffRenderer";
+        const id = requireSlotId(kind, registration?.id);
+        requireUniqueId(kind, seenIds.diffRenderer, id);
+        const description = requireOptionalString(
+          kind,
+          "description",
+          registration.description,
+        );
+        collected.diffRenderers.push({
+          id,
+          title: requireNonEmptyString(kind, "title", registration.title),
+          ...(description !== undefined ? { description } : {}),
           component: requireComponent(kind, registration.component),
         });
       },

--- a/packages/plugin-sdk/src/testing/app.tsx
+++ b/packages/plugin-sdk/src/testing/app.tsx
@@ -29,6 +29,7 @@ import {
   type PluginHomepageSectionRegistration,
   type PluginMessageActionRegistration,
   type PluginMessageDirectiveRegistration,
+  type PluginDiffRendererRegistration,
   type PluginNavPanelRegistration,
   type PluginNewThreadPanelActionRegistration,
   type PluginPendingInteractionRegistration,
@@ -44,6 +45,7 @@ import {
   type PluginSidebarThreadPullRequestState,
   type PluginSidebarThreadSplit,
   type PluginSidebarThreadsState,
+  type PluginSourceCodeRendererRegistration,
   type PluginThreadHeaderActionRegistration,
   type PluginThreadListRegistration,
   type PluginThreadPanelActionRegistration,
@@ -53,6 +55,8 @@ import {
   type MarkdownProps,
   type NewThreadComposerProps,
   type ThreadChatProps,
+  type DiffProps,
+  type SourceCodeProps,
   type JsonValue,
 } from "@get-bb/plugin-sdk";
 import { isComposerDraftEmpty } from "../internal/composer-view.js";
@@ -360,6 +364,61 @@ function TestNewThreadComposer({
   );
 }
 
+/**
+ * Stand-in for the host-owned source viewer: emits the raw source in a
+ * recognizable wrapper carrying the resolved presentation, so plugin tests can
+ * assert what they asked the host to render without the real highlighter.
+ */
+function TestSourceCode({
+  content,
+  path,
+  overflow = "scroll",
+  highlightedLines = null,
+  className,
+}: SourceCodeProps) {
+  return (
+    <pre
+      data-testid="bb-source-code"
+      data-path={path}
+      data-overflow={overflow}
+      data-highlighted-lines={
+        highlightedLines === null
+          ? ""
+          : `${highlightedLines.start}-${highlightedLines.end}`
+      }
+      className={className}
+    >
+      {content}
+    </pre>
+  );
+}
+
+/**
+ * Stand-in for the host-owned diff viewer: emits the raw patch in a
+ * recognizable wrapper carrying the resolved presentation.
+ */
+function TestDiff({
+  patch,
+  path,
+  view = "unified",
+  overflow = "scroll",
+  showLineNumbers = true,
+  className,
+}: DiffProps) {
+  return (
+    <pre
+      data-testid="bb-diff"
+      data-path={path}
+      data-view={view}
+      data-overflow={overflow}
+      data-show-line-numbers={showLineNumbers ? "true" : "false"}
+      className={className}
+    >
+      {patch}
+    </pre>
+  );
+}
+
 const testPluginSdkApp = {
   definePluginApp,
   useRpc<
@@ -425,6 +484,8 @@ const testPluginSdkApp = {
   ThreadChat: TestThreadChat,
   Markdown: TestMarkdown,
   experimental_NewThreadComposer: TestNewThreadComposer,
+  experimental_SourceCode: TestSourceCode,
+  experimental_Diff: TestDiff,
   experimental_useSidebarThreads(): PluginSidebarThreadsState {
     return useSlotEnv("experimental_useSidebarThreads").sidebarThreads;
   },
@@ -515,6 +576,8 @@ export interface CapturedPluginApp {
   threadLists: PluginThreadListRegistration[];
   threadHeaderActions: PluginThreadHeaderActionRegistration[];
   fileOpeners: PluginFileOpenerRegistration[];
+  sourceCodeRenderers: PluginSourceCodeRendererRegistration[];
+  diffRenderers: PluginDiffRendererRegistration[];
   messageDirectives: PluginMessageDirectiveRegistration[];
   messageActions: PluginMessageActionRegistration[];
   providerIcons: PluginProviderIconRegistration[];

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -535,10 +535,13 @@ components/ui/ and `npx shadcn add @bb/<name>` pulls more from the BB
 component registry (the full stock shadcn set, version-matched to the
 running BB via the pinned ref in components.json). `import { toast } from
 "sonner"` reaches the host toaster; react, the portaling radix families,
-sonner, vaul, @pierre/diffs (the app's syntax-highlighted diff
-renderer), and the host-resident clsx, tailwind-merge, and
-class-variance-authority libraries are runtime-shimmed (never bundled),
-everything else (zod included) bundles from the plugin's node_modules (`npm install` for authors; BB installs
+sonner, vaul, @pierre/diffs, and the host-resident clsx, tailwind-merge, and
+class-variance-authority libraries are runtime-shimmed (never bundled) —
+though source and diffs should go through the host's own
+experimental_SourceCode / experimental_Diff components rather than
+@pierre/diffs directly, so bb owns patch normalization, syntax
+highlighting, and the live code theme.
+Everything else (zod included) bundles from the plugin's node_modules (`npm install` for authors; BB installs
 release packages with their declared production dependencies). A crashing slot collapses to a
 "plugin <id> crashed" chip without
 touching the rest of the app. Installed plugins and their declared settings

--- a/plugins/github/app.tsx
+++ b/plugins/github/app.tsx
@@ -15,10 +15,10 @@ import {
   useMemo,
   useRef,
   useState,
-  useSyncExternalStore,
 } from "react";
 import {
   definePluginApp,
+  experimental_Diff as Diff,
   useBbNavigate,
   useRealtime,
   useRpc,
@@ -37,11 +37,6 @@ import {
   type SuggestionIcon,
 } from "./app-logic.js";
 import type { githubRpcContract } from "./server.js";
-// Shimmed to the host's copy at build time (shared worker-pool context +
-// shiki stays out of the plugin bundle) — diffs render with the same syntax
-// highlighting as the app's own diff panel.
-import { parsePatchFiles, type FileDiffMetadata } from "@pierre/diffs";
-import { FileDiff as PierreFileDiff } from "@pierre/diffs/react";
 import { toast } from "sonner";
 import { Badge } from "@bb/shared-ui/badge";
 import { Button } from "@bb/shared-ui/button";
@@ -1391,114 +1386,14 @@ function ChecksSection({ checks }: { checks: PullCheck[] }) {
   );
 }
 
-function readHostCodeTheme(): { dark: string; light: string } {
-  const root = document.documentElement.dataset;
-  return {
-    dark: root.bbCodeThemeDark ?? "pierre-dark",
-    light: root.bbCodeThemeLight ?? "pierre-light",
-  };
-}
-
-/** Read lazily: this module also loads outside a DOM, such as in the plugin
-    bundle tests, where a module-eval `document` access throws. */
-let hostCodeTheme: { dark: string; light: string } | null = null;
-const hostCodeThemeListeners = new Set<() => void>();
-let hostCodeThemeObserver: MutationObserver | null = null;
-
-function getHostCodeTheme(): { dark: string; light: string } {
-  hostCodeTheme ??= readHostCodeTheme();
-  return hostCodeTheme;
-}
-
-function subscribeHostCodeTheme(onStoreChange: () => void): () => void {
-  hostCodeThemeListeners.add(onStoreChange);
-  if (hostCodeThemeObserver === null) {
-    hostCodeThemeObserver = new MutationObserver(() => {
-      const next = readHostCodeTheme();
-      const current = getHostCodeTheme();
-      if (next.dark === current.dark && next.light === current.light) {
-        return;
-      }
-      hostCodeTheme = next;
-      for (const listener of hostCodeThemeListeners) listener();
-    });
-    hostCodeThemeObserver.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["data-bb-code-theme-dark", "data-bb-code-theme-light"],
-    });
-  }
-  return () => {
-    hostCodeThemeListeners.delete(onStoreChange);
-  };
-}
-
-function useHostCodeTheme(): { dark: string; light: string } {
-  return useSyncExternalStore(
-    subscribeHostCodeTheme,
-    getHostCodeTheme,
-    getHostCodeTheme,
-  );
-}
-
-/** The host toggles dark mode via a `dark` class on <html>; pierre's diff
-    themes are picked per render, so track it live. */
-function useIsDarkTheme(): boolean {
-  const [dark, setDark] = useState(() =>
-    document.documentElement.classList.contains("dark"),
-  );
-  useEffect(() => {
-    const observer = new MutationObserver(() =>
-      setDark(document.documentElement.classList.contains("dark")),
-    );
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["class"],
-    });
-    return () => observer.disconnect();
-  }, []);
-  return dark;
-}
-
 /**
- * A patch (or single `@@` hunk) rendered through the host's @pierre/diffs —
- * syntax highlighting included (the host provides the worker pool via
- * context). GitHub's REST patches lack the `diff --git` header, so one is
- * synthesized; unparseable input falls back to plain mono text.
+ * A patch (or single `@@` hunk) rendered through the host's own diff
+ * component. It owns patch normalization (GitHub's REST patches arrive
+ * without a `diff --git` header), syntax highlighting, the live BB code
+ * theme, and the plain-text fallback for content that will not parse.
  */
 function DiffPatch({ path, patch }: { path: string; patch: string }) {
-  const dark = useIsDarkTheme();
-  const codeTheme = useHostCodeTheme();
-  const fileDiff = useMemo<FileDiffMetadata | null>(() => {
-    const normalized = patch.replace(/\r\n/g, "\n").trimEnd();
-    if (normalized.length === 0) return null;
-    const text = normalized.startsWith("diff --git")
-      ? `${normalized}\n`
-      : `diff --git a/${path} b/${path}\n--- a/${path}\n+++ b/${path}\n${normalized}\n`;
-    try {
-      return parsePatchFiles(text)[0]?.files[0] ?? null;
-    } catch {
-      return null;
-    }
-  }, [path, patch]);
-  const options = useMemo(
-    () =>
-      ({
-        diffStyle: "unified",
-        overflow: "scroll",
-        disableFileHeader: true,
-        themeType: dark ? "dark" : "light",
-        theme: codeTheme,
-      }) as const,
-    [codeTheme, dark],
-  );
-  if (fileDiff === null) {
-    return (
-      <pre className="overflow-x-auto px-3 py-2 font-mono text-xs leading-5 text-foreground/80">
-        {patch}
-      </pre>
-    );
-  }
-  return <PierreFileDiff fileDiff={fileDiff} options={options} />;
+  return <Diff patch={patch} path={path} />;
 }
 
 function FileDiffCard({ file, url }: { file: PullFile; url: string }) {

--- a/plugins/github/app.tsx
+++ b/plugins/github/app.tsx
@@ -1386,16 +1386,6 @@ function ChecksSection({ checks }: { checks: PullCheck[] }) {
   );
 }
 
-/**
- * A patch (or single `@@` hunk) rendered through the host's own diff
- * component. It owns patch normalization (GitHub's REST patches arrive
- * without a `diff --git` header), syntax highlighting, the live BB code
- * theme, and the plain-text fallback for content that will not parse.
- */
-function DiffPatch({ path, patch }: { path: string; patch: string }) {
-  return <Diff patch={patch} path={path} />;
-}
-
 function FileDiffCard({ file, url }: { file: PullFile; url: string }) {
   const [open, setOpen] = useState(false);
   return (
@@ -1423,7 +1413,7 @@ function FileDiffCard({ file, url }: { file: PullFile; url: string }) {
       {open ? (
         file.patch !== null ? (
           <div className="border-t border-border">
-            <DiffPatch path={file.path} patch={file.patch} />
+            <Diff patch={file.patch} path={file.path} />
           </div>
         ) : (
           <p className="border-t border-border px-3 py-2 text-xs text-muted-foreground">
@@ -1449,7 +1439,7 @@ function ReviewThreadCard({ thread }: { thread: ReviewThread }) {
       </p>
       {thread.diffHunk.length > 0 ? (
         <div className="border-b border-border">
-          <DiffPatch path={thread.path} patch={thread.diffHunk} />
+          <Diff patch={thread.diffHunk} path={thread.path} />
         </div>
       ) : null}
       <div className="flex flex-col gap-3 p-3">

--- a/plugins/github/package.json
+++ b/plugins/github/package.json
@@ -44,7 +44,6 @@
   },
   "devDependencies": {
     "@get-bb/plugin-sdk": "workspace:*",
-    "@pierre/diffs": "^1.2.9",
     "@radix-ui/react-dialog": "^1.1.19",
     "@radix-ui/react-dropdown-menu": "^2.1.20",
     "@types/node": "^22.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3111,9 +3111,6 @@ importers:
       '@get-bb/plugin-sdk':
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
-      '@pierre/diffs':
-        specifier: ^1.2.9
-        version: 1.2.9(@shikijs/themes@3.23.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-dialog':
         specifier: ^1.1.19
         version: 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## What was wrong

BB rendered code in two independent places and had no way for a plugin to change either. The file preview drove `@pierre/diffs`' `File` view and the diff card drove its `FileDiff` view, each assembling its own options record, its own line-selection wiring, and its own code-theme lookup. A plugin that wanted to render source or a diff had a third path: import `@pierre/diffs` directly through the runtime shim and rebuild the host's behavior by hand. `plugins/github` did exactly that — synthesizing a `diff --git` header for GitHub's REST patches, calling `parsePatchFiles`, and running two MutationObservers (one on the root `class`, one on `data-bb-code-theme-*`) to keep Pierre's theme in step with BB's.

That is three copies of one capability, and it made "change how bb renders code" impossible to express: there was nothing to replace.

## What changed

**One host boundary per capability.** `SourceCodeHost` and `DiffHost` (`apps/app/src/components/code/`) resolve an exclusive plugin replacement through the same `resolveReplacement` + `PluginReplacementSlot` path the sidebar thread list and file openers already use, and otherwise render BB's own renderer. Both BB renderers (`BbSourceCode`, `BbDiff`) sit behind `lazy()`, so a replacement that never delegates never downloads them and `experimental_Original` costs nothing until it is rendered.

**Public API** (all `experimental_`, with entries in `docs/api_to_audit.md`):

```ts
experimental_SourceCode: { content, path, overflow?, highlightedLines?, className? }
experimental_Diff:       { patch, path, view?, overflow?, showLineNumbers?, className? }

app.slots.experimental_sourceCodeRenderer({ id, title, description?, component })
app.slots.experimental_diffRenderer({ id, title, description?, component })
```

A replacement receives fully resolved semantic props plus a bound `experimental_Original`, so it can delegate per call without re-entering resolution. Host-only inputs — the pre-parsed `ParsedGitDiffFile`, the raw patch text, the highlighter cache key, selection-to-composer — never cross the boundary, and no `@pierre/diffs`, Shiki, `FileOptions`, or `ParsedGitDiffFile` type appears in the public contract. `experimental_Diff` owns patch normalization, so a patch with no `diff --git` header (GitHub REST, a bare `@@` hunk) renders without the caller synthesizing one; content that parses to no hunks degrades to plain monospace text instead of an empty diff.

**Migrations.** The native file preview, timeline file diffs, and the environment diff panel's file bodies all render through the boundary, so one registration covers BB's surfaces and plugin surfaces alike. `plugins/github` renders `experimental_Diff` and drops its `@pierre/diffs` devDependency along with both MutationObservers; its bundle no longer references the Pierre runtime shim (417.0 KB → 409.0 KB). The shim itself stays for compatibility with existing plugins.

**User control.** Settings → Appearance gains **Source code** and **Diffs** rows beside **Sidebar** — Automatic / bb (built-in) / each registered provider, per client, each row hidden when no plugin supplies that renderer. A renderer takes over surfaces there is otherwise no route back from, so this is what keeps "installing activates it" reversible. `lib/plugin-replacement-preference.ts` now owns that automatic/built-in/named-provider rule and the thread list consumes it too, retiring its private copy and the `resolveThreadListReplacement` wrapper only its own test still called. Registered renderers also appear in the plugin detail's capability list.

**Two cleanups fell out.** The opaque `diffViewOptions: Record<string, string | boolean | number>` threaded through five components became the semantic `DiffPresentation` (`view` / `overflow` / `showLineNumbers`). The renderers own light/dark selection themselves, which made the `themeType` prop chain from `ThreadTimelineSurface` down to `TimelineFileDiffBlock` dead; it and `ThreadTimelineTheme` are removed.

**Docs and generated artifacts.** `docs/api_to_audit.md` gains three entries (components, slots, `experimental_Original`); the `bb-plugin-authoring` skill and the `bb guide` plugins chapter now point at the host components rather than a direct `@pierre/diffs` import, and the skill's own coverage test is extended so the new slots and their props stay documented. Bundled SDK declarations, the runtime export manifest, and the templates bundle were regenerated with the repository scripts. No wire changes, so no `HOST_DAEMON_PROTOCOL_VERSION` bump.

## How you verified

Regression coverage for what the boundary actually promises — each of these fails without the corresponding behavior:

- a replacement that never delegates leaves BB's renderer chunk unloaded; delegating through `experimental_Original` loads it;
- the replacement receives resolved semantic props only — no parsed file, no cache key, no selection-to-chat;
- with no patch text in hand the host reconstructs a single-file patch that re-parses to the same file;
- crash and no-registration paths land on BB's renderer;
- BB's diff renderer follows `applyResolvedCodeTheme` live — the behavior `plugins/github` previously got from a DOM MutationObserver;
- `DiffFileCard`, a first-party surface, renders its text body through the same boundary;
- a built-in pin renders BB's renderer with the plugin still installed and enabled, and an explicit pin survives a later plugin whose id sorts ahead of it (where automatic selection would silently swap the user's renderer).

Commands run:

- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@get-bb/plugin-sdk --filter=@bb/plugin-build --filter=@bb/templates --filter=@bb/server --filter=bb-plugin-github --filter=@bb/cli` — passed.
- `pnpm exec turbo run test --filter=@bb/app` — 367 files / 2909 tests passed.
- `pnpm exec turbo run test --filter=@bb/server` — 182 files / 1730 tests passed.
- `pnpm exec turbo run test --filter=@get-bb/plugin-sdk --filter=@bb/plugin-build --filter=@bb/templates --filter=bb-plugin-github --filter=@bb/cli` — 631 tests passed.
- `pnpm exec turbo run lint --filter=@bb/app` — 0 errors (the repository's existing 147 react-compiler warnings; several are carried over verbatim with the extracted renderer code).
- `pnpm exec turbo run build --filter=bb-plugin-github` — builds; the bundle contains `experimental_Diff` and no Pierre shim reference.

**Bundle impact.** Boot payload 1655.6 → 1659.1 KB raw and 448.8 → 453.7 KB brotli against the 1671.0 / 456.4 budget; 40 → 43 chunks. I confirmed this is not new code on the boot path — stubbing out the patch reconstruction moved it by 0.3 KB — it is the extra chunks compressing slightly worse than fewer larger ones. All `forbiddenBootPackages` still pass. New lazy chunks: `BbDiff` 2.6 KB raw / 1.1 KB brotli, `BbSourceCode` 6.1 KB raw / 2.4 KB brotli. Brotli headroom drops from ~7.6 KB to ~2.7 KB, which is worth knowing before the next feature lands on that budget.

**Deliberately not migrated.** Markdown fenced code blocks are genuine source but run `sugar-high` — a synchronous ~2 KB highlighter with no worker pool, no shadow DOM, and no async settle, which is what a streaming chat timeline needs. Routing them through the host would either regress that or require a second per-surface default renderer, contradicting one host per capability. Raw-log surfaces (`EventCodeBlock`, terminal output) are monospace styling, not code rendering, and are untouched.

**Open questions for review**, all recorded in `docs/api_to_audit.md`: whether a per-client pin is the right scope for something as visible as every diff (and whether users expect one combined choice rather than two); whether a plugin should be able to change how *another* plugin's `experimental_Diff` renders; and whether the silent crash fallback is right where the thread list toasts.

> AGENT GENERATED: by Claude Opus 5
