### PR TITLE
Fix compact composer banner responsiveness

### DIFF
--- a/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.stories.tsx
@@ -66,7 +66,7 @@ const runningCommand = (
 const single: TimelineWorkflowWorkRow[] = [
   runningCommand({
     id: "thr_fixture:bg:tail-dev-log",
-    description: "Tail the dev server log",
+    description: "Poll all CI runs for batching head until completion",
     startedAt: Date.now() - 8_000,
   }),
 ];
@@ -114,7 +114,7 @@ export function Overview() {
     <StoryCard>
       <StoryRow
         label="single"
-        hint="one running command: non-expandable single line with live time"
+        hint="compact: summarized and expandable; wide: detailed single line"
       >
         <ResponsiveStage>
           <ExpandableCard commands={single} />

--- a/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.test.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.test.tsx
@@ -3,13 +3,52 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { useState } from "react";
 import { afterEach, describe, expect, it } from "vitest";
-import { workflowRow } from "@/test/fixtures/thread-timeline-rows";
+import {
+  backgroundCommandRow,
+  workflowRow,
+} from "@/test/fixtures/thread-timeline-rows";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { ThreadBackgroundCommandsCard } from "./ThreadBackgroundCommandsCard";
 
 afterEach(cleanup);
 
 describe("ThreadBackgroundCommandsCard", () => {
+  it("summarizes and expands a single background command in compact mode", () => {
+    const description = "Poll all CI runs for batching head until completion";
+
+    function CompactCard() {
+      const [isExpanded, setIsExpanded] = useState(false);
+      return (
+        <CompactViewportOverrideProvider isCompactViewport>
+          <ThreadBackgroundCommandsCard
+            commands={[
+              backgroundCommandRow({
+                description,
+                startedAt: 1,
+                status: "pending",
+                taskStatus: "running",
+              }),
+            ]}
+            isExpanded={isExpanded}
+            onToggle={() => setIsExpanded((value) => !value)}
+          />
+        </CompactViewportOverrideProvider>
+      );
+    }
+
+    render(<CompactCard />);
+
+    const toggle = screen.getByRole("button", {
+      name: "Running 1 background command",
+    });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(toggle);
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByText(description).textContent).toBe(description);
+  });
+
   it("summarizes and expands a single background agent in compact mode", () => {
     const description = "Inspect mobile background banner";
 
@@ -22,7 +61,7 @@ describe("ThreadBackgroundCommandsCard", () => {
               workflowRow({
                 description,
                 model: "haiku",
-                startedAt: Date.now() - 2_000,
+                startedAt: 1,
                 status: "pending",
                 taskStatus: "running",
                 taskType: "local_agent",

--- a/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.test.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.test.tsx
@@ -1,8 +1,14 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { useState } from "react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   backgroundCommandRow,
   workflowRow,
@@ -10,11 +16,49 @@ import {
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { ThreadBackgroundCommandsCard } from "./ThreadBackgroundCommandsCard";
 
-afterEach(cleanup);
+let resizeObserverCallback: ResizeObserverCallback | null = null;
+let resizeObserver: TestResizeObserver | null = null;
+
+class TestResizeObserver implements ResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    resizeObserverCallback = callback;
+    resizeObserver = this;
+  }
+
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function reportCardWidth(target: Element, width: number): void {
+  if (!resizeObserverCallback || !resizeObserver) {
+    throw new Error("Expected the background card to observe its width.");
+  }
+  const callback = resizeObserverCallback;
+  const observer = resizeObserver;
+  const size: ResizeObserverSize = { inlineSize: width, blockSize: 32 };
+  const entry: ResizeObserverEntry = {
+    target,
+    contentRect: new DOMRect(0, 0, width, 32),
+    borderBoxSize: [size],
+    contentBoxSize: [size],
+    devicePixelContentBoxSize: [size],
+  };
+  act(() => callback([entry], observer));
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  resizeObserverCallback = null;
+  resizeObserver = null;
+});
 
 describe("ThreadBackgroundCommandsCard", () => {
   it("summarizes and expands a single background command in compact mode", () => {
     const description = "Poll all CI runs for batching head until completion";
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
 
     function CompactCard() {
       const [isExpanded, setIsExpanded] = useState(false);
@@ -42,11 +86,43 @@ describe("ThreadBackgroundCommandsCard", () => {
       name: "Running 1 background command",
     });
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(setIntervalSpy).not.toHaveBeenCalled();
 
     fireEvent.click(toggle);
 
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
     expect(screen.getByText(description).textContent).toBe(description);
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the card width when a narrow composer sits in a wide viewport", () => {
+    const description = "Poll all CI runs for batching head until completion";
+    vi.stubGlobal("ResizeObserver", TestResizeObserver);
+    render(
+      <CompactViewportOverrideProvider isCompactViewport={false}>
+        <ThreadBackgroundCommandsCard
+          commands={[
+            backgroundCommandRow({
+              description,
+              startedAt: 1,
+              status: "pending",
+              taskStatus: "running",
+            }),
+          ]}
+          isExpanded={false}
+          onToggle={() => {}}
+        />
+      </CompactViewportOverrideProvider>,
+    );
+
+    const card = screen.getByRole("region", { name: "Background commands" });
+    expect(screen.queryByRole("button")).toBeNull();
+
+    reportCardWidth(card, 320);
+
+    expect(
+      screen.getByRole("button", { name: "Running 1 background command" }),
+    ).not.toBeNull();
   });
 
   it("summarizes and expands a single background agent in compact mode", () => {

--- a/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
@@ -174,8 +174,9 @@ export interface ThreadBackgroundCommandsCardProps {
 /**
  * Prompt-stack card for running non-workflow background tasks, independent of
  * the workflow card. Wide layouts show the most recent task and append "+N
- * more" when needed. Compact layouts summarize background agents by count and
- * expand even a single agent so its full description and model stay readable.
+ * more" when needed. Compact layouts summarize background activity by count
+ * and expand even a single item so its full description and model stay
+ * readable.
  * Each task also keeps its own timeline row carrying the terminal outcome;
  * this card only tracks the live ones and drops out once none remain.
  */
@@ -191,10 +192,7 @@ export function ThreadBackgroundCommandsCard({
   }
   const others = commands.slice(1);
   const hasMore = others.length > 0;
-  const hasAgent = commands.some((row) =>
-    isBackgroundAgentTaskType(row.taskType),
-  );
-  const useCompactSummary = isCompactViewport && hasAgent;
+  const useCompactSummary = isCompactViewport;
   const canExpand = hasMore || useCompactSummary;
   const expandedRows = useCompactSummary ? commands : others;
   const compactLabel = compactBackgroundActivityLabel(commands);

--- a/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
@@ -1,6 +1,8 @@
+import { useRef, useState } from "react";
 import { isBackgroundAgentTaskType } from "@bb/domain";
 import type { TimelineWorkflowWorkRow } from "@bb/server-contract";
 import { durationToCompactString } from "@bb/thread-view";
+import { useResizeObserver } from "usehooks-ts";
 import { AnimatedBody } from "@/components/promptbox/banner/AnimatedBody";
 import { PromptStackCard } from "@/components/promptbox/banner/PromptStackCard";
 import { useSecondTick } from "@/hooks/useSecondTick";
@@ -17,6 +19,24 @@ import { cn } from "@bb/shared-ui/lib/utils";
 const CARD_ROW_HEIGHT = 32;
 const BODY_ID = "thread-background-commands-card-body";
 const TOGGLE_ID = "thread-background-commands-card-toggle";
+// Keep this threshold aligned with the promptbox-shell container query in
+// app.css. The card observes its own border box because a narrow split can sit
+// inside a wide browser viewport.
+const COMPACT_PROMPT_SHELL_MAX_WIDTH_REM = 34;
+const DEFAULT_ROOT_FONT_SIZE_PX = 16;
+
+function isCompactPromptShellWidth(width: number): boolean {
+  const parsedRootFontSize =
+    typeof window === "undefined"
+      ? Number.NaN
+      : Number.parseFloat(
+          window.getComputedStyle(document.documentElement).fontSize,
+        );
+  const rootFontSize = Number.isFinite(parsedRootFontSize)
+    ? parsedRootFontSize
+    : DEFAULT_ROOT_FONT_SIZE_PX;
+  return width <= COMPACT_PROMPT_SHELL_MAX_WIDTH_REM * rootFontSize;
+}
 
 interface BackgroundActivityDisplay {
   icon: "Terminal" | "UserRoundPlus";
@@ -186,13 +206,26 @@ export function ThreadBackgroundCommandsCard({
   onToggle,
 }: ThreadBackgroundCommandsCardProps) {
   const isCompactViewport = useIsCompactViewport();
+  const cardRef = useRef<HTMLElement>(null!);
+  const [isCompactCard, setIsCompactCard] = useState<boolean | null>(null);
+  useResizeObserver({
+    ref: cardRef,
+    box: "border-box",
+    onResize: ({ width }) => {
+      if (width === undefined) return;
+      const nextIsCompact = isCompactPromptShellWidth(width);
+      setIsCompactCard((previous) =>
+        previous === nextIsCompact ? previous : nextIsCompact,
+      );
+    },
+  });
   const primary = commands[0];
   if (!primary) {
     return null;
   }
   const others = commands.slice(1);
   const hasMore = others.length > 0;
-  const useCompactSummary = isCompactViewport;
+  const useCompactSummary = isCompactCard ?? isCompactViewport;
   const canExpand = hasMore || useCompactSummary;
   const expandedRows = useCompactSummary ? commands : others;
   const compactLabel = compactBackgroundActivityLabel(commands);
@@ -201,6 +234,7 @@ export function ThreadBackgroundCommandsCard({
 
   return (
     <PromptStackCard
+      rootRef={cardRef}
       ariaLabel={groupLabel}
       className="overflow-hidden"
       style={{ minHeight: CARD_ROW_HEIGHT }}
@@ -317,7 +351,9 @@ export function ThreadBackgroundCommandsCard({
                     </span>
                   ) : null}
                   <span className="shrink-0 whitespace-nowrap text-subtle-foreground">
-                    <BackgroundActivityDuration startedAt={row.startedAt} />
+                    {isExpanded ? (
+                      <BackgroundActivityDuration startedAt={row.startedAt} />
+                    ) : null}
                   </span>
                 </div>
               );

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
@@ -4,6 +4,7 @@ import type {
   WorkspaceFileStatus,
   WorkspaceStatus,
 } from "@bb/domain";
+import type { PullRequestMergeMethod } from "@bb/server-contract";
 import {
   ThreadPromptContextBanner,
   type ContextBannerMergeBaseConfig,
@@ -317,6 +318,25 @@ const uncommittedSection = sectionFor(dirtyUncommittedStatus);
 const uncommittedManySection = sectionFor(dirtyUncommittedManyStatus);
 const untrackedSection = sectionFor(untrackedOnlyStatus);
 const committedSection = sectionFor(committedUnmergedStatus);
+const committedManyFiles: WorkspaceFileStatus[] = Array.from(
+  { length: 72 },
+  (_, index) => ({
+    path: `apps/app/src/committed-fixture-${index + 1}.tsx`,
+    status: "M",
+    insertions: 10,
+    deletions: 2,
+  }),
+);
+const committedManySection: WorkspaceChangedFilesSection = {
+  ...committedSection,
+  files: committedManyFiles,
+  stats: {
+    ...committedSection.stats,
+    files: committedManyFiles,
+    insertions: 720,
+    deletions: 144,
+  },
+};
 
 const featureBranchMergeBase: ContextBannerMergeBaseConfig = {
   branch: "main",
@@ -443,6 +463,16 @@ function buildPullRequestFixture(
 }
 
 const pullRequestFixture = buildPullRequestFixture();
+const pendingPullRequestFixture = buildPullRequestFixture({
+  checks: {
+    state: "pending",
+    totalCount: 3,
+    passedCount: 1,
+    failedCount: 0,
+    pendingCount: 2,
+  },
+  attention: "checks_pending",
+});
 
 const pullRequestStateRows: readonly {
   label: string;
@@ -597,6 +627,7 @@ interface RowConfig {
   childThreads?: ThreadPromptChildThreadsSection | null;
   pullRequest?: ThreadPullRequest | null;
   pullRequestActions?: boolean;
+  pullRequestMergeMethod?: PullRequestMergeMethod;
   initiallyExpandedSection?: ThreadPromptContextBannerExpandedSection | null;
 }
 
@@ -609,6 +640,7 @@ function ContextBannerPreview({
   childThreads = null,
   pullRequest = null,
   pullRequestActions = false,
+  pullRequestMergeMethod = "merge",
   initiallyExpandedSection = null,
   size,
 }: RowConfig & { size: PromptStageSize }) {
@@ -642,6 +674,7 @@ function ContextBannerPreview({
                       actions: {
                         onMarkReady: noop,
                         onMerge: noop,
+                        selectedMergeMethod: pullRequestMergeMethod,
                       },
                     }
                   : {}),
@@ -832,6 +865,17 @@ export function Overview() {
         hint="committed branch changes use the same label with or without PR context"
       >
         <Row pullRequest={pullRequestFixture} section={committedSection} />
+      </StoryRow>
+      <StoryRow
+        label="pull request + many committed + actions"
+        hint="the GitHub status pill stays intact beside a long committed summary and merge action"
+      >
+        <Row
+          pullRequest={pendingPullRequestFixture}
+          pullRequestActions
+          pullRequestMergeMethod="squash"
+          section={committedManySection}
+        />
       </StoryRow>
       <StoryRow
         label="uncommitted (collapsed)"

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
@@ -770,6 +770,17 @@ export function Overview() {
         <Row childThreads={childThreadsFixture} mergeBase={null} />
       </StoryRow>
       <StoryRow
+        label="active child + pull request + uncommitted"
+        hint="long child titles stay within the shared stack; compact rows hide pull request actions"
+      >
+        <Row
+          childThreads={childThreadsFixture}
+          pullRequest={pullRequestFixture}
+          pullRequestActions
+          section={uncommittedSection}
+        />
+      </StoryRow>
+      <StoryRow
         label="parent thread with active children (expanded)"
         hint="list of children with status + pending-approval marker on item 2"
       >

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
@@ -771,7 +771,7 @@ export function Overview() {
       </StoryRow>
       <StoryRow
         label="active child + pull request + uncommitted"
-        hint="long child titles stay within the shared stack; compact rows hide pull request actions"
+        hint="long child titles stay within the shared stack; pull request actions remain available"
       >
         <Row
           childThreads={childThreadsFixture}

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
@@ -69,6 +69,8 @@ function makeGitSection(
   };
 }
 
+afterEach(cleanup);
+
 describe("ThreadPromptContextBanner", () => {
   it("renders the archived read-only status without an action", () => {
     const markup = renderToStaticMarkup(
@@ -362,6 +364,41 @@ describe("ThreadPromptContextBanner", () => {
     expect(markup).toContain("+1 more");
   });
 
+  it("lets combined child and context cards shrink inside the composer stack", () => {
+    render(
+      <MemoryRouter>
+        <ThreadPromptContextBanner
+          gitSection={makeGitSection("uncommitted")}
+          gitSectionPending={false}
+          archivedSection={null}
+          environmentGoneSection={null}
+          parentThreadSection={null}
+          childThreadsSection={{
+            items: [
+              {
+                id: "thr_child",
+                title: "Host-owned SourceCode and Diff renderers",
+                href: "/threads/thr_child",
+                hasPendingInteraction: false,
+              },
+            ],
+          }}
+          pullRequestSection={null}
+          expandedSection={null}
+          onToggleSection={noop}
+        />
+      </MemoryRouter>,
+    );
+
+    const childCard = screen.getByRole("region", { name: "Child threads" });
+    const contextCard = screen.getByRole("region", {
+      name: "Thread context before sending",
+    });
+
+    expect(childCard.parentElement).toBe(contextCard.parentElement);
+    expect(childCard.parentElement?.classList.contains("min-w-0")).toBe(true);
+  });
+
   it("uses neutral active copy for a child waiting for a host", () => {
     expect(isThreadDisplayStatusBannerActive("waiting-for-host")).toBe(true);
 
@@ -485,8 +522,8 @@ describe("ThreadPromptContextBanner", () => {
     expect(markup).toContain("1 file");
   });
 
-  it("keeps the pull request action visible beside other context segments", () => {
-    const markup = renderToStaticMarkup(
+  it("hides the pull request action in compact composer shells", () => {
+    render(
       <ThreadPromptContextBanner
         gitSection={makeGitSection("uncommitted")}
         gitSectionPending={false}
@@ -506,9 +543,20 @@ describe("ThreadPromptContextBanner", () => {
       />,
     );
 
-    expect(markup).toContain("PR #128");
-    expect(markup).toContain("Uncommitted");
-    expect(markup).toContain("Rebase and merge");
+    expect(
+      screen.getByRole("link", { name: "Pull request 128: Ready to merge" }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", {
+        name: "Changed files: Uncommitted, 1 file, +2 -0",
+      }),
+    ).not.toBeNull();
+    expect(screen.getByText("Rebase and merge")).not.toBeNull();
+    expect(
+      screen
+        .getByRole("button", { name: "Choose pull request merge method" })
+        .closest("[data-promptbox-hide-compact]"),
+    ).not.toBeNull();
   });
 
   it("uses the shared committed git label beside pull request context", () => {
@@ -533,8 +581,6 @@ describe("ThreadPromptContextBanner", () => {
 });
 
 describe("ThreadPromptContextBanner git section body", () => {
-  afterEach(cleanup);
-
   function renderBanner(expandedSection: "git" | null) {
     return (
       <MemoryRouter>

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
@@ -522,8 +522,8 @@ describe("ThreadPromptContextBanner", () => {
     expect(markup).toContain("1 file");
   });
 
-  it("hides the pull request action in compact composer shells", () => {
-    render(
+  it("keeps the pull request action visible beside other context segments", () => {
+    const markup = renderToStaticMarkup(
       <ThreadPromptContextBanner
         gitSection={makeGitSection("uncommitted")}
         gitSectionPending={false}
@@ -543,20 +543,9 @@ describe("ThreadPromptContextBanner", () => {
       />,
     );
 
-    expect(
-      screen.getByRole("link", { name: "Pull request 128: Ready to merge" }),
-    ).not.toBeNull();
-    expect(
-      screen.getByRole("button", {
-        name: "Changed files: Uncommitted, 1 file, +2 -0",
-      }),
-    ).not.toBeNull();
-    expect(screen.getByText("Rebase and merge")).not.toBeNull();
-    expect(
-      screen
-        .getByRole("button", { name: "Choose pull request merge method" })
-        .closest("[data-promptbox-hide-compact]"),
-    ).not.toBeNull();
+    expect(markup).toContain("PR #128");
+    expect(markup).toContain("Uncommitted");
+    expect(markup).toContain("Rebase and merge");
   });
 
   it("uses the shared committed git label beside pull request context", () => {

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
@@ -993,7 +993,7 @@ export function ThreadPromptContextBanner({
   const pullRequestAction =
     pullRequest && pullRequestActions ? (
       pullRequest.state === "draft" && pullRequestActions.onMarkReady ? (
-        <BannerActionSlot>
+        <BannerActionSlot hideInCompact>
           <PullRequestReadyTextAction
             disabled={pullRequestActions.isPending}
             onMarkReady={pullRequestActions.onMarkReady}
@@ -1002,7 +1002,7 @@ export function ThreadPromptContextBanner({
       ) : pullRequest.state === "open" &&
         pullRequest.mergeability.state === "mergeable" &&
         pullRequestActions.onMerge ? (
-        <BannerActionSlot>
+        <BannerActionSlot hideInCompact>
           <PullRequestMergeSplitButton
             disabled={pullRequestActions.isPending}
             onConvertToDraft={pullRequestActions.onConvertToDraft}
@@ -1136,7 +1136,7 @@ export function ThreadPromptContextBanner({
 
   if (activeChildThreadsCard && compactContextBanner) {
     return (
-      <div className="space-y-2">
+      <div className="min-w-0 space-y-2">
         {activeChildThreadsCard}
         {compactContextBanner}
       </div>

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
@@ -993,7 +993,7 @@ export function ThreadPromptContextBanner({
   const pullRequestAction =
     pullRequest && pullRequestActions ? (
       pullRequest.state === "draft" && pullRequestActions.onMarkReady ? (
-        <BannerActionSlot hideInCompact>
+        <BannerActionSlot>
           <PullRequestReadyTextAction
             disabled={pullRequestActions.isPending}
             onMarkReady={pullRequestActions.onMarkReady}
@@ -1002,7 +1002,7 @@ export function ThreadPromptContextBanner({
       ) : pullRequest.state === "open" &&
         pullRequest.mergeability.state === "mergeable" &&
         pullRequestActions.onMerge ? (
-        <BannerActionSlot hideInCompact>
+        <BannerActionSlot>
           <PullRequestMergeSplitButton
             disabled={pullRequestActions.isPending}
             onConvertToDraft={pullRequestActions.onConvertToDraft}

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
@@ -634,7 +634,9 @@ function PullRequestBannerLink({
       className={cn(
         "flex items-center gap-1.5 text-xs text-muted-foreground no-underline transition-colors hover:bg-state-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
         PROMPT_STACK_INLAY_SEGMENT_CLASS,
-        SEGMENT_SHRINK_CLASS,
+        // Preserve the checked status pill (min-w-9) plus the inlay's px-2.
+        // Labels may still truncate, but the two status glyphs must not clip.
+        "min-w-13 overflow-hidden",
       )}
     >
       <PullRequestStatusPill pullRequest={pullRequest} className="h-4" />


### PR DESCRIPTION
## What was wrong

Compact composer banners had four independent gaps. The wrapper used when child-thread and context cards render together retained its intrinsic flex minimum width. Background-command compaction followed the browser viewport instead of the composer card, so a narrow split inside a wide window remained lossy and non-expandable. Compact disclosure bodies also kept hidden elapsed-time components ticking every second while collapsed. Finally, the pull-request segment could shrink below the GitHub status pill's own minimum width when a long committed summary and merge action competed for space.

## What changed

- let combined child-thread and context cards shrink inside the composer stack
- derive compact background-command presentation from the card's observed width, updating React state only when the compact breakpoint changes
- apply the existing compact background-activity summary and expansion behavior to commands as well as agents
- mount elapsed-time components in disclosure rows only while the body is expanded
- keep pull-request merge and ready actions available in compact composer shells
- preserve the full pull-request status pill before allowing adjacent labels to truncate
- add focused regression tests and long-content Ladle fixtures for the affected combinations, including 72 committed files with a squash-merge action
- no host-daemon wire, CLI, guide, or configuration changes

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx src/components/promptbox/banner/ThreadBackgroundCommandsCard.test.tsx` — 23 tests passed
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app` — 0 errors; 146 existing warnings
- `git diff --check`
- dev-browser QA with a 1600px viewport containing simultaneous 658px and 320px cards: the wide card retained its detailed non-expandable row while the narrow card used the expandable compact summary
- matched dev-browser before/after captures for the 320px background-command card, plus the combined child/PR/git fixture with merge controls visibly present
- dev-browser reproduction at a 360px composer width: before the PR link shrank to 42.7px and clipped its 36px pill; after it retained 52px, showed the full pill and squash action, and produced no horizontal overflow
- reproduced against the reported thread states in [thread thr_m9gz6riv9t](https://ymichael.getbb.app/projects/proj_qrv2s45kmq/threads/thr_m9gz6riv9t) and [thread thr_gcuc46ug4j](https://ymichael.getbb.app/projects/proj_qrv2s45kmq/threads/thr_gcuc46ug4j)

Fixes the mobile composer banner regressions reported in the linked bb threads.

> AGENT GENERATED: by GPT-5.6
