### PR TITLE
Gate closed secondary-panel diff queries and keep the compact terminal mounted (G1, G4)

### DIFF
--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -513,6 +513,12 @@ export function ThreadSecondaryPanel({
   const isDiffPanelActive =
     resolvedGitDiffTabStatus === "eligible" &&
     activeFixedTab?.tab.kind === "git-diff";
+  // The diff body stays mounted while the panel is closed (see the retained
+  // content note below), but its live queries must not: every workspace write
+  // invalidates the diff TOC, evicts patches, and would otherwise refetch and
+  // re-render pierre into an off-screen panel. Gate the diff-tab data on the
+  // panel actually being open; the DOM stays, the network and diff work stop.
+  const isDiffPanelLive = isDiffPanelActive && isLayoutOpen;
   const isDiffEligibilityPending =
     activeFixedTab?.tab.kind === "git-diff" &&
     (resolvedGitDiffTabStatus === "loading" ||
@@ -529,7 +535,7 @@ export function ThreadSecondaryPanel({
     onGitDiffSelectionChange,
   } = useGitDiffPanelState({
     environmentId,
-    isDiffPanelActive,
+    isDiffPanelActive: isDiffPanelLive,
     requestedMergeBaseBranch,
     onClearPendingGitDiffIntent,
     pendingGitDiffCommitSha,
@@ -543,7 +549,7 @@ export function ThreadSecondaryPanel({
   const { data: diffFilesResponse, isLoading: isDiffFilesLoading } =
     useEnvironmentDiffFiles(environmentId ?? "", {
       enabled:
-        isDiffPanelActive &&
+        isDiffPanelLive &&
         Boolean(environmentId) &&
         gitDiffTarget !== undefined,
       target: gitDiffTarget,
@@ -914,6 +920,7 @@ export function ThreadSecondaryPanel({
             environmentId={environmentId}
             target={gitDiffTarget}
             isDiffPanelActive={isDiffPanelActive}
+            isPanelOpen={isLayoutOpen}
             gitDiffViewOptions={gitDiffViewOptions}
             onClearPendingGitDiffIntent={onClearPendingGitDiffIntent}
             onOpenFileInEditor={onOpenFileInEditor}

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.panelGate.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.panelGate.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import type { WorkspaceDiffTarget } from "@bb/domain";
+import type {
+  EnvironmentDiffFileResponse,
+  EnvironmentDiffFilesResponse,
+} from "@bb/server-contract";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  environmentDiffFilesQueryKeyPrefix,
+  environmentFilePreviewQueryKeyPrefix,
+} from "@/hooks/queries/query-keys";
+import { sdk } from "@/lib/sdk";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import {
+  GitDiffTabContent,
+  WorkspaceFilePreviewTabContent,
+} from "./ThreadSecondaryPanelTabContent";
+
+vi.mock("@/lib/sdk", () => ({
+  sdk: { environments: { diffFiles: vi.fn(), diffFile: vi.fn() } },
+}));
+
+// The preview body is not under test; keep pierre out of jsdom.
+vi.mock("@pierre/diffs/react", () => ({
+  File: () => null,
+  useWorkerPool: () => null,
+}));
+
+const ENVIRONMENT_ID = "env-1";
+const TARGET: WorkspaceDiffTarget = { type: "all", mergeBaseBranch: "main" };
+
+const emptyDiff: EnvironmentDiffFilesResponse = {
+  outcome: "available",
+  files: [],
+  truncated: false,
+  shortstat: "",
+  mergeBaseRef: null,
+  initialPatches: [],
+};
+
+const previewFile: EnvironmentDiffFileResponse = {
+  path: "src/index.ts",
+  content: "export const answer = 42;\n",
+  contentEncoding: "utf8",
+  mimeType: "text/plain",
+  sizeBytes: 26,
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("GitDiffTabContent panel gating", () => {
+  it("fetches the diff TOC only while the panel is open, and refetches once on reopen", async () => {
+    vi.mocked(sdk.environments.diffFiles).mockResolvedValue(emptyDiff);
+    const { queryClient, wrapper: Wrapper } = createQueryClientTestHarness();
+    const renderTab = (isPanelOpen: boolean) => (
+      <Wrapper>
+        <GitDiffTabContent
+          environmentId={ENVIRONMENT_ID}
+          target={TARGET}
+          isDiffPanelActive
+          isPanelOpen={isPanelOpen}
+          gitDiffViewOptions={{}}
+        />
+      </Wrapper>
+    );
+
+    // Retained-but-closed panel: the body mounts, the TOC does not load.
+    const view = render(renderTab(false));
+    expect(sdk.environments.diffFiles).not.toHaveBeenCalled();
+
+    view.rerender(renderTab(true));
+    await waitFor(() => {
+      expect(sdk.environments.diffFiles).toHaveBeenCalledTimes(1);
+    });
+
+    // Closed again: realtime workspace writes invalidate the TOC, but a hidden
+    // panel must not refetch it.
+    view.rerender(renderTab(false));
+    await act(async () => {
+      await queryClient.invalidateQueries({
+        queryKey: environmentDiffFilesQueryKeyPrefix(ENVIRONMENT_ID),
+      });
+    });
+    expect(sdk.environments.diffFiles).toHaveBeenCalledTimes(1);
+
+    // Reopen: the stale TOC refreshes exactly once.
+    view.rerender(renderTab(true));
+    await waitFor(() => {
+      expect(sdk.environments.diffFiles).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe("WorkspaceFilePreviewTabContent panel gating", () => {
+  it("does not refetch an invalidated preview while the panel is closed", async () => {
+    vi.mocked(sdk.environments.diffFile).mockResolvedValue(previewFile);
+    const { queryClient, wrapper: Wrapper } = createQueryClientTestHarness();
+    const renderTab = (isPanelOpen: boolean) => (
+      <Wrapper>
+        <WorkspaceFilePreviewTabContent
+          activePath={previewFile.path}
+          environmentId={ENVIRONMENT_ID}
+          isPanelOpen={isPanelOpen}
+          lineRange={null}
+          source={{ kind: "working-tree" }}
+          statusLabel={null}
+          threadId="thr-1"
+        />
+      </Wrapper>
+    );
+
+    const view = render(renderTab(true));
+    await waitFor(() => {
+      expect(sdk.environments.diffFile).toHaveBeenCalledTimes(1);
+    });
+
+    view.rerender(renderTab(false));
+    await act(async () => {
+      await queryClient.invalidateQueries({
+        queryKey: environmentFilePreviewQueryKeyPrefix(ENVIRONMENT_ID),
+      });
+    });
+    expect(sdk.environments.diffFile).toHaveBeenCalledTimes(1);
+
+    view.rerender(renderTab(true));
+    await waitFor(() => {
+      expect(sdk.environments.diffFile).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.tsx
@@ -43,6 +43,13 @@ export interface GitDiffTabContentProps {
   environmentId?: string;
   target: WorkspaceDiffTarget | undefined;
   isDiffPanelActive: boolean;
+  /**
+   * Whether the secondary panel is currently open. The body stays mounted
+   * while the panel is closed so reopening is instant, but its TOC / patch
+   * fetches pause: realtime workspace events keep invalidating the diff cache,
+   * and refetching into an off-screen panel is wasted network and diff work.
+   */
+  isPanelOpen: boolean;
   gitDiffViewOptions: Record<string, string | boolean | number>;
   onClearPendingGitDiffIntent?: () => void;
   onOpenFileInEditor?: (path: string) => void;
@@ -58,6 +65,15 @@ export interface ThreadInfoTabContentProps {
 
 export interface WorkspaceFilePreviewTabContentProps {
   activePath: string;
+  /**
+   * Whether the secondary panel is open. The preview stays mounted while the
+   * panel is closed (retained drawer content / desktop subtree), but its
+   * content query pauses: every workspace write invalidates the preview cache,
+   * and a live observer would refetch and remount the highlighted file into an
+   * off-screen panel. A closed panel keeps its cached preview and refetches
+   * once on reopen.
+   */
+  isPanelOpen: boolean;
   copyPath?: string | null;
   environmentId?: string | null;
   lineRange: FilePreviewLineRange | null;
@@ -71,6 +87,15 @@ export interface WorkspaceFilePreviewTabContentProps {
 
 export interface ProjectFilePreviewTabContentProps {
   activePath: string;
+  /**
+   * Whether the secondary panel is open. The preview stays mounted while the
+   * panel is closed (retained drawer content / desktop subtree), but its
+   * content query pauses: every workspace write invalidates the preview cache,
+   * and a live observer would refetch and remount the highlighted file into an
+   * off-screen panel. A closed panel keeps its cached preview and refetches
+   * once on reopen.
+   */
+  isPanelOpen: boolean;
   copyPath?: string | null;
   environmentId: string | null;
   hostId: string | null;
@@ -82,6 +107,15 @@ export interface ProjectFilePreviewTabContentProps {
 
 export interface HostFilePreviewTabContentProps {
   activePath: string;
+  /**
+   * Whether the secondary panel is open. The preview stays mounted while the
+   * panel is closed (retained drawer content / desktop subtree), but its
+   * content query pauses: every workspace write invalidates the preview cache,
+   * and a live observer would refetch and remount the highlighted file into an
+   * off-screen panel. A closed panel keeps its cached preview and refetches
+   * once on reopen.
+   */
+  isPanelOpen: boolean;
   copyPath: string;
   environmentId?: string | null;
   lineRange: FilePreviewLineRange | null;
@@ -93,6 +127,15 @@ export interface HostFilePreviewTabContentProps {
 
 export interface ThreadStorageFilePreviewTabContentProps {
   activePath: string;
+  /**
+   * Whether the secondary panel is open. The preview stays mounted while the
+   * panel is closed (retained drawer content / desktop subtree), but its
+   * content query pauses: every workspace write invalidates the preview cache,
+   * and a live observer would refetch and remount the highlighted file into an
+   * off-screen panel. A closed panel keeps its cached preview and refetches
+   * once on reopen.
+   */
+  isPanelOpen: boolean;
   copyPath?: string | null;
   lineRange: FilePreviewLineRange | null;
   markdownLinkRouting?: MarkdownLinkRouting;
@@ -144,6 +187,7 @@ export function GitDiffTabContent({
   environmentId,
   target,
   isDiffPanelActive,
+  isPanelOpen,
   gitDiffViewOptions,
   onClearPendingGitDiffIntent,
   onOpenFileInEditor,
@@ -153,7 +197,10 @@ export function GitDiffTabContent({
   workspaceRootPath,
 }: GitDiffTabContentProps) {
   const isQueryEnabled =
-    isDiffPanelActive && Boolean(environmentId) && target !== undefined;
+    isDiffPanelActive &&
+    isPanelOpen &&
+    Boolean(environmentId) &&
+    target !== undefined;
   const {
     data: diffFilesResponse,
     dataUpdatedAt: diffFilesUpdatedAt,
@@ -288,6 +335,7 @@ export function GitDiffTabContent({
         filesUpdatedAt={diffFilesUpdatedAt}
         diffViewOptions={gitDiffViewOptions}
         filePathRoot={workspaceRootPath}
+        isPanelOpen={isPanelOpen}
         isPlaceholderData={isDiffFilesPlaceholder}
         scrollToPath={pendingGitDiffScrollPath}
         onScrolledToPath={onClearPendingGitDiffIntent}
@@ -310,6 +358,7 @@ export function WorkspaceFilePreviewTabContent({
   activePath,
   copyPath = null,
   environmentId,
+  isPanelOpen,
   lineRange,
   markdownLinkRouting,
   onSelectionAddToChat,
@@ -324,7 +373,9 @@ export function WorkspaceFilePreviewTabContent({
     isFetching: isWorkspaceFilePreviewFetching,
     isLoading: isWorkspaceFilePreviewLoading,
     refetch: refetchWorkspaceFilePreview,
-  } = useEnvironmentFilePreview(environmentId, activePath, source);
+  } = useEnvironmentFilePreview(environmentId, activePath, source, {
+    enabled: isPanelOpen,
+  });
 
   return (
     <SecondaryPanelFilePreview
@@ -354,6 +405,7 @@ export function ProjectFilePreviewTabContent({
   copyPath = null,
   environmentId,
   hostId,
+  isPanelOpen,
   lineRange,
   onSelectionAddToChat,
   onOpenInEditor,
@@ -365,7 +417,12 @@ export function ProjectFilePreviewTabContent({
     isFetching: isProjectFilePreviewFetching,
     isLoading: isProjectFilePreviewLoading,
     refetch: refetchProjectFilePreview,
-  } = useProjectFilePreview(projectId, activePath, { environmentId, hostId });
+  } = useProjectFilePreview(
+    projectId,
+    activePath,
+    { environmentId, hostId },
+    { enabled: isPanelOpen },
+  );
 
   return (
     <SecondaryPanelFilePreview
@@ -388,6 +445,7 @@ export function HostFilePreviewTabContent({
   activePath,
   copyPath,
   environmentId,
+  isPanelOpen,
   lineRange,
   markdownLinkRouting,
   onSelectionAddToChat,
@@ -400,7 +458,9 @@ export function HostFilePreviewTabContent({
     isFetching: isHostFilePreviewFetching,
     isLoading: isHostFilePreviewLoading,
     refetch: refetchHostFilePreview,
-  } = useThreadHostFilePreview(threadId, environmentId, activePath);
+  } = useThreadHostFilePreview(threadId, environmentId, activePath, {
+    enabled: isPanelOpen,
+  });
 
   return (
     <SecondaryPanelFilePreview
@@ -424,6 +484,7 @@ export function HostFilePreviewTabContent({
 export function ThreadStorageFilePreviewTabContent({
   activePath,
   copyPath = null,
+  isPanelOpen,
   lineRange,
   markdownLinkRouting,
   onSelectionAddToChat,
@@ -436,7 +497,9 @@ export function ThreadStorageFilePreviewTabContent({
     isFetching: isThreadStorageFilePreviewFetching,
     isLoading: isThreadStorageFilePreviewLoading,
     refetch: refetchThreadStorageFilePreview,
-  } = useThreadStorageFilePreview(threadId, activePath);
+  } = useThreadStorageFilePreview(threadId, activePath, {
+    enabled: isPanelOpen,
+  });
 
   return (
     <ThreadStorageFilePreview

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFilesPanel.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFilesPanel.tsx
@@ -46,6 +46,12 @@ export interface DiffFilesPanelProps {
   diffViewOptions: Record<string, string | boolean | number>;
   filePathRoot?: string | null;
   /**
+   * Whether the secondary panel is open. While closed the list stays mounted
+   * (and virtualized rows still resolve), but visible-row patch requests pause;
+   * they resume for the current visible set when the panel reopens.
+   */
+  isPanelOpen: boolean;
+  /**
    * True while the TOC query is serving cross-target placeholder data (the
    * previous diff target's slice). The scroll-to-file effect waits for the real
    * slice so it never lands on a stale index.
@@ -80,6 +86,7 @@ export function DiffFilesPanel({
   filesUpdatedAt,
   diffViewOptions,
   filePathRoot,
+  isPanelOpen,
   isPlaceholderData,
   scrollToPath,
   onScrolledToPath,
@@ -159,6 +166,13 @@ export function DiffFilesPanel({
   const visibleKey = visiblePaths.join("\n");
   const overscanKey = overscanPaths.join("\n");
   useEffect(() => {
+    // A closed panel requests nothing: realtime workspace events evict the
+    // patch cache while it is hidden, and refetching those patches off-screen is
+    // wasted work. Reopening re-runs this effect (`isPanelOpen` flips) and
+    // re-requests the current visible set, which dedupes against the cache.
+    if (!isPanelOpen) {
+      return;
+    }
     requestPaths({ visible: visiblePaths, overscan: overscanPaths });
     // visiblePaths/overscanPaths are derived from the keys; depend on the keys
     // so we skip re-requesting identical membership. Also re-fire when the TOC
@@ -166,7 +180,7 @@ export function DiffFilesPanel({
     // paths but evicts the patch cache, so the same visible set must be
     // re-requested to fetch the fresh patch.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [requestPaths, visibleKey, overscanKey, filesUpdatedAt]);
+  }, [isPanelOpen, requestPaths, visibleKey, overscanKey, filesUpdatedAt]);
 
   // Scroll a file requested from the info tab / prompt banner to the top of the
   // panel. The request persists until the path is in the *real* slice: opening a

--- a/apps/app/src/components/thread/terminal/ThreadTerminalContent.test.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalContent.test.tsx
@@ -7,7 +7,12 @@ import { ThreadTerminalContent } from "./ThreadTerminalContent";
 import type { ThreadTerminalController } from "./useThreadTerminalController";
 
 const threadTerminalView = vi.hoisted(() =>
-  vi.fn((_props: { autoFocus: boolean; isPanelOpen: boolean }) => null),
+  vi.fn((props: { autoFocus: boolean; isPanelOpen: boolean }) => (
+    <div
+      data-testid="terminal-view"
+      data-panel-open={String(props.isPanelOpen)}
+    />
+  )),
 );
 
 vi.mock("./ThreadTerminalView", () => ({
@@ -31,7 +36,10 @@ const session: TerminalSession = {
   lastUserInputAt: null,
 };
 
-function controller(isPanelOpen: boolean): ThreadTerminalController {
+function controller(
+  isPanelOpen: boolean,
+  shouldMountTerminalView: boolean = isPanelOpen,
+): ThreadTerminalController {
   return {
     activeSession: session,
     activeTerminalId: session.id,
@@ -49,6 +57,7 @@ function controller(isPanelOpen: boolean): ThreadTerminalController {
     isCreateTerminalPending: false,
     isPanelOpen,
     isTerminalQueryLoading: false,
+    shouldMountTerminalView,
     showTerminalPlaceholders: false,
     shouldRetainActiveTerminalView: false,
     terminalBodyMessage: "No terminals",
@@ -82,5 +91,47 @@ describe("ThreadTerminalContent", () => {
       autoFocus: true,
       isPanelOpen: true,
     });
+  });
+
+  it("keeps the mounted terminal view alive while a persisted panel is hidden", () => {
+    const rendered = render(
+      <ThreadTerminalContent autoFocus={false} controller={controller(true)} />,
+    );
+    const mountedView = rendered.getByTestId("terminal-view");
+
+    // Compact drawer swiped closed: the panel is hidden but still persisted
+    // open, so the controller asks to keep the view mounted.
+    rendered.rerender(
+      <ThreadTerminalContent
+        autoFocus={false}
+        controller={controller(false, true)}
+      />,
+    );
+
+    const hiddenView = rendered.getByTestId("terminal-view");
+    expect(hiddenView).toBe(mountedView);
+    expect(hiddenView.dataset.panelOpen).toBe("false");
+
+    // Reopening reuses the same xterm instance instead of remounting.
+    rendered.rerender(
+      <ThreadTerminalContent autoFocus={false} controller={controller(true)} />,
+    );
+    expect(rendered.getByTestId("terminal-view")).toBe(mountedView);
+  });
+
+  it("unmounts the terminal view once the panel is neither open nor persisted", () => {
+    const rendered = render(
+      <ThreadTerminalContent autoFocus={false} controller={controller(true)} />,
+    );
+    expect(rendered.queryByTestId("terminal-view")).not.toBeNull();
+
+    rendered.rerender(
+      <ThreadTerminalContent
+        autoFocus={false}
+        controller={controller(false, false)}
+      />,
+    );
+
+    expect(rendered.queryByTestId("terminal-view")).toBeNull();
   });
 });

--- a/apps/app/src/components/thread/terminal/ThreadTerminalContent.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalContent.tsx
@@ -63,9 +63,11 @@ export function ThreadTerminalContent({
   onOpenLink,
   onSelectionAddToChat,
 }: ThreadTerminalContentProps) {
-  // Keep the terminal UI entirely unmounted while its panel is hidden. In
-  // particular, mounting ThreadTerminalView initializes xterm and its socket.
-  if (!controller.isPanelOpen) {
+  // Keep the terminal UI entirely unmounted until its panel is shown: mounting
+  // ThreadTerminalView initializes xterm and its socket. Once mounted, a
+  // hidden-but-persisted panel (compact drawer closed) keeps it alive so the
+  // next open does not re-create xterm and replay the scrollback.
+  if (!controller.shouldMountTerminalView) {
     return null;
   }
 

--- a/apps/app/src/components/thread/terminal/ThreadTerminalPanel.stories.tsx
+++ b/apps/app/src/components/thread/terminal/ThreadTerminalPanel.stories.tsx
@@ -111,6 +111,7 @@ function makeController({
     isCreateTerminalPending,
     isPanelOpen,
     isTerminalQueryLoading,
+    shouldMountTerminalView: isPanelOpen,
     showTerminalPlaceholders,
     shouldRetainActiveTerminalView,
     terminalBodyMessage,

--- a/apps/app/src/components/thread/terminal/useThreadTerminalController.mount.test.tsx
+++ b/apps/app/src/components/thread/terminal/useThreadTerminalController.mount.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { TerminalSession } from "@bb/server-contract";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { sdk } from "@/lib/sdk";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import {
+  shouldMountTerminalViewForPanel,
+  useThreadTerminalController,
+  type ThreadTerminalControllerArgs,
+} from "./useThreadTerminalController";
+
+vi.mock("@/lib/sdk", () => ({
+  sdk: { terminals: { list: vi.fn() } },
+}));
+
+const session: TerminalSession = {
+  id: "term_1",
+  threadId: "thr_1",
+  environmentId: "env_1",
+  hostId: "host_1",
+  title: "Terminal",
+  initialCwd: "/workspace",
+  cols: 100,
+  rows: 30,
+  status: "running",
+  exitCode: null,
+  closeReason: null,
+  createdAt: 1,
+  updatedAt: 1,
+  lastUserInputAt: null,
+};
+
+interface PanelVisibility {
+  isPanelOpen: boolean;
+  isPanelPersistedOpen: boolean;
+}
+
+function controllerArgs(
+  visibility: PanelVisibility,
+): ThreadTerminalControllerArgs {
+  return {
+    canCreateTerminal: true,
+    isPanelOpen: visibility.isPanelOpen,
+    isPanelPersistedOpen: visibility.isPanelPersistedOpen,
+    syncThreadId: null,
+    target: { kind: "thread", threadId: "thr_1" },
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("shouldMountTerminalViewForPanel", () => {
+  it("mounts only for an open panel or a hidden panel this client already opened", () => {
+    expect(
+      shouldMountTerminalViewForPanel({
+        hasPanelOpened: false,
+        isPanelOpen: true,
+        isPanelPersistedOpen: true,
+      }),
+    ).toBe(true);
+    // Persisted-open from another device, never shown here: keep xterm cold.
+    expect(
+      shouldMountTerminalViewForPanel({
+        hasPanelOpened: false,
+        isPanelOpen: false,
+        isPanelPersistedOpen: true,
+      }),
+    ).toBe(false);
+    // Compact drawer swiped closed after it was open: keep the view alive.
+    expect(
+      shouldMountTerminalViewForPanel({
+        hasPanelOpened: true,
+        isPanelOpen: false,
+        isPanelPersistedOpen: true,
+      }),
+    ).toBe(true);
+    // Persisted panel closed: nothing to retain.
+    expect(
+      shouldMountTerminalViewForPanel({
+        hasPanelOpened: true,
+        isPanelOpen: false,
+        isPanelPersistedOpen: false,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("useThreadTerminalController terminal view mounting", () => {
+  it("does not mount a persisted-open terminal the panel never showed", () => {
+    vi.mocked(sdk.terminals.list).mockResolvedValue({ sessions: [session] });
+    const { wrapper } = createQueryClientTestHarness();
+    const { result } = renderHook(
+      () =>
+        useThreadTerminalController(
+          controllerArgs({ isPanelOpen: false, isPanelPersistedOpen: true }),
+        ),
+      { wrapper },
+    );
+
+    expect(result.current.shouldMountTerminalView).toBe(false);
+    expect(sdk.terminals.list).not.toHaveBeenCalled();
+  });
+
+  it("keeps the view mounted across a compact close and unmounts once persisted state closes", async () => {
+    vi.mocked(sdk.terminals.list).mockResolvedValue({ sessions: [session] });
+    const { wrapper } = createQueryClientTestHarness();
+    const { result, rerender } = renderHook(
+      (visibility: PanelVisibility) =>
+        useThreadTerminalController(controllerArgs(visibility)),
+      {
+        wrapper,
+        initialProps: { isPanelOpen: true, isPanelPersistedOpen: true },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.activeSession?.id).toBe(session.id);
+    });
+    expect(result.current.shouldMountTerminalView).toBe(true);
+
+    // Drawer hidden, panel still persisted open: retain the mounted view and
+    // keep the running session retained for a transient disconnect.
+    rerender({ isPanelOpen: false, isPanelPersistedOpen: true });
+    expect(result.current.shouldMountTerminalView).toBe(true);
+    expect(result.current.activeSession?.id).toBe(session.id);
+
+    // Persisted panel closed too: release the view.
+    rerender({ isPanelOpen: false, isPanelPersistedOpen: false });
+    expect(result.current.shouldMountTerminalView).toBe(false);
+
+    // Persisted-open again without this client showing it: stay cold until
+    // the panel is actually opened here.
+    rerender({ isPanelOpen: false, isPanelPersistedOpen: true });
+    expect(result.current.shouldMountTerminalView).toBe(false);
+    rerender({ isPanelOpen: true, isPanelPersistedOpen: true });
+    expect(result.current.shouldMountTerminalView).toBe(true);
+  });
+});

--- a/apps/app/src/components/thread/terminal/useThreadTerminalController.ts
+++ b/apps/app/src/components/thread/terminal/useThreadTerminalController.ts
@@ -71,6 +71,14 @@ export interface ThreadTerminalController {
   isCreateTerminalPending: boolean;
   isPanelOpen: boolean;
   isTerminalQueryLoading: boolean;
+  /**
+   * Whether the terminal UI (xterm + its socket) should be mounted right now.
+   * True while the panel is open, and — once the panel has been opened on this
+   * client — while it stays persisted-open but hidden (a compact drawer that
+   * was swiped closed). Keeping the view alive across a compact close/reopen
+   * avoids re-creating xterm/WebGL and replaying the scrollback on every open.
+   */
+  shouldMountTerminalView: boolean;
   showTerminalPlaceholders: boolean;
   shouldRetainActiveTerminalView: boolean;
   terminalBodyMessage: string;
@@ -128,6 +136,26 @@ export function shouldAutoCloseCleanTerminalSession({
     uiCreatedTerminalIds.has(session.id) &&
     !dirtyTerminalIds.has(session.id)
   );
+}
+
+/**
+ * A hidden-but-persisted panel (compact drawer closed, persisted state still
+ * open) keeps an already-mounted terminal view alive; a panel that has never
+ * been opened on this client mounts nothing, so a persisted-open terminal tab
+ * synced from another device does not start xterm on a phone that never showed
+ * it. On desktop `isPanelOpen === isPanelPersistedOpen`, so this reduces to
+ * `isPanelOpen`.
+ */
+export function shouldMountTerminalViewForPanel({
+  hasPanelOpened,
+  isPanelOpen,
+  isPanelPersistedOpen,
+}: {
+  hasPanelOpened: boolean;
+  isPanelOpen: boolean;
+  isPanelPersistedOpen: boolean;
+}): boolean {
+  return isPanelOpen || (isPanelPersistedOpen && hasPanelOpened);
 }
 
 export function shouldAutoCloseCleanTerminalSessionsForPanel({
@@ -222,6 +250,20 @@ export function useThreadTerminalController({
   const [retainedTerminalViewId, setRetainedTerminalViewId] = useState<
     string | null
   >(null);
+  // Whether this client has shown the panel since it was last persisted-open.
+  // Derived during render (not in an effect) so the mount decision below never
+  // lags a commit behind `isPanelOpen`.
+  const [hasPanelOpened, setHasPanelOpened] = useState(isPanelOpen);
+  if (isPanelOpen && !hasPanelOpened) {
+    setHasPanelOpened(true);
+  } else if (!isPanelOpen && !isPanelPersistedOpen && hasPanelOpened) {
+    setHasPanelOpened(false);
+  }
+  const shouldMountTerminalView = shouldMountTerminalViewForPanel({
+    hasPanelOpened,
+    isPanelOpen,
+    isPanelPersistedOpen,
+  });
   const threadTerminalsQuery = useThreadTerminals(threadQueryId, {
     enabled: isPanelOpen && terminalTargetKind === "thread",
   });
@@ -313,7 +355,7 @@ export function useThreadTerminalController({
     activeSession.id === retainedTerminalViewId;
 
   useEffect(() => {
-    if (!isPanelOpen) {
+    if (!shouldMountTerminalView) {
       setRetainedTerminalViewId(null);
       return;
     }
@@ -331,8 +373,8 @@ export function useThreadTerminalController({
     activeSession?.id,
     activeSession?.status,
     activeTerminalId,
-    isPanelOpen,
     retainedTerminalViewId,
+    shouldMountTerminalView,
   ]);
 
   useEffect(() => {
@@ -747,6 +789,7 @@ export function useThreadTerminalController({
     isCreateTerminalPending,
     isPanelOpen,
     isTerminalQueryLoading: terminalsQuery.isLoading,
+    shouldMountTerminalView,
     showTerminalPlaceholders,
     shouldRetainActiveTerminalView,
     terminalBodyMessage,

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -2030,6 +2030,7 @@ function RootComposeSurface({
           activePath={activeWorkspaceFilePath}
           copyPath={workspaceFileCopyPath}
           environmentId={activeWorkspaceFileEnvironmentId}
+          isPanelOpen={isSecondaryPanelOpen}
           lineRange={activeWorkspaceFileLineRange}
           onOpenInEditor={handleOpenWorkspaceFileInEditor}
           onSelectionAddToChat={handleRootPanelSelectionAddToChat}
@@ -2046,6 +2047,7 @@ function RootComposeSurface({
           copyPath={projectFileCopyPath}
           environmentId={rootPanelEnvironmentId}
           hostId={rootProjectHostId}
+          isPanelOpen={isSecondaryPanelOpen}
           lineRange={activeWorkspaceFileLineRange}
           onOpenInEditor={handleOpenProjectFileInEditor}
           onSelectionAddToChat={handleRootPanelSelectionAddToChat}
@@ -2059,6 +2061,7 @@ function RootComposeSurface({
             activePath={activeHostFilePath}
             copyPath={activeHostFilePath}
             environmentId={activeRootHostFileEnvironmentId}
+            isPanelOpen={isSecondaryPanelOpen}
             lineRange={activeHostFileLineRange}
             onOpenInEditor={handleOpenHostFileInEditor}
             onSelectionAddToChat={handleRootPanelSelectionAddToChat}
@@ -2079,6 +2082,7 @@ function RootComposeSurface({
           <ThreadStorageFilePreviewTabContent
             activePath={activeStorageFilePath}
             copyPath={storageFileCopyPath}
+            isPanelOpen={isSecondaryPanelOpen}
             lineRange={activeStorageFileLineRange}
             onOpenInEditor={handleOpenStorageFileInEditor}
             onSelectionAddToChat={handleRootPanelSelectionAddToChat}

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -2747,6 +2747,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
         activePath={activeWorkspaceFilePath}
         copyPath={workspaceFileCopyPath}
         environmentId={thread.environmentId}
+        isPanelOpen={isSecondaryPanelOpen}
         lineRange={activeWorkspaceFileLineRange}
         markdownLinkRouting={workspaceMarkdownLinkRouting}
         onOpenInEditor={handleOpenFileInEditor}
@@ -2762,6 +2763,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
         activePath={activeHostFilePath}
         copyPath={activeHostFilePath}
         environmentId={thread.environmentId}
+        isPanelOpen={isSecondaryPanelOpen}
         lineRange={activeHostFileLineRange}
         markdownLinkRouting={hostMarkdownLinkRouting}
         onOpenInEditor={handleOpenHostFileInEditor}
@@ -2774,6 +2776,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
       <ThreadStorageFilePreviewTabContent
         activePath={activeStorageFilePath}
         copyPath={storageFileCopyPath}
+        isPanelOpen={isSecondaryPanelOpen}
         lineRange={activeStorageFileLineRange}
         markdownLinkRouting={storageMarkdownLinkRouting}
         onOpenInEditor={handleOpenStorageFileInEditor}


### PR DESCRIPTION
## What was wrong

The secondary panel keeps its content mounted while closed so the next open is instant (compact drawers retain the panel off-screen; desktop keeps the subtree). But its data stayed live: the diff tab TOC query, the toolbar's shared TOC observer, visible-row patch requests, and every file-preview query kept running behind a closed panel. Each workspace write emits `work-status-changed`, which invalidates the diff TOC and previews and evicts the patch cache, so a hidden panel refetched the TOC, re-requested patches, and remounted the highlighted preview on every fs event (audit G1). Terminals were gated on `isPanelOpen`, but on compact that meant every drawer close disposed xterm and its socket, and every reopen re-created xterm/WebGL and replayed up to the full scrollback (audit G4).

## What changed

- `ThreadSecondaryPanel` derives `isDiffPanelLive = isDiffPanelActive && isLayoutOpen` and uses it for the toolbar TOC observer and the diff-target work-status query.
- `GitDiffTabContent` and `DiffFilesPanel` take `isPanelOpen`. The TOC query is enabled only while the panel is open. `requestPaths` is skipped while closed and re-fires for the current visible set on reopen (dedupes against the cache).
- Workspace / project / host / thread-storage preview tab bodies take `isPanelOpen` and pass `enabled` to their preview queries. `ThreadDetailView` and `RootComposeView` pass `isSecondaryPanelOpen`. The DOM stays mounted; an invalidated query refetches once on reopen.
- Terminal controller exposes `shouldMountTerminalView = isPanelOpen || (isPanelPersistedOpen && hasPanelOpened)`. `ThreadTerminalContent` mounts on it. A compact drawer close keeps an already-mounted terminal alive; a persisted-open tab synced from another device does not start xterm on a phone that never opened the drawer; closing the persisted panel releases the view. Desktop is unchanged (`isPanelOpen === isPanelPersistedOpen`).

## How you verified

- New `ThreadSecondaryPanelTabContent.panelGate.test.tsx`: with the real query hooks and a mocked sdk, the diff TOC and workspace preview do not fetch while `isPanelOpen` is false, do not refetch after `invalidateQueries` while closed, and refetch exactly once on reopen. Fails before, passes after.
- New `useThreadTerminalController.mount.test.tsx` and extended `ThreadTerminalContent.test.tsx`: view is retained (same DOM node) across a hidden-but-persisted panel, unmounts when persisted state closes, and never mounts for a persisted-open panel this client has not shown. Fail before, pass after.
- `pnpm exec turbo run typecheck --filter=@bb/app`, `pnpm exec turbo run lint --filter=@bb/app` (147 warnings, same as baseline, 0 errors), targeted vitest for `src/components/secondary-panel`, `src/components/thread/terminal`, `src/views/thread-detail`, `src/views/RootComposeView` (50 files, 408 tests pass).

Fixes: part of the mobile / iOS Safari performance program (verified sweep report in the bb thread; no single issue).


## Stack context

Layer 2 of 22 in the `bb/mobile-perf/*` stack (bottom → top: quick wins first, big rocks last).
- Prerequisite (layer below): `bb/mobile-perf/css-paint-ios` (#1880).
- Next layer: `bb/mobile-perf/invalidation-tuning` (#1882).
- Audit findings addressed: see title IDs. Review: approved.
- Deliberately not done here: G4 optional 'smaller replay tail for compact clients': not done. It requires a client hint on the terminal WebSocket URL plus server/daemon handling (wire chang
- Reviewer notes / follow-ups: Minor test gap (not blocking): DiffFilesPanel's `requestPaths` early-return while `isPanelOpen === false` and its re-fire on reopen is untested; no existing jsdom harness renders D | Trade-off to be aware of (by design, per G4): on compact a hidden-but-persisted terminal keeps its WebSocket and xterm/WebGL context alive off-screen while the drawer is closed; xt
- Wire/contract: None. No server, daemon, protocol, CLI, config, or plugin API changes. HOST_DAEMON_PROTOCOL_VERSION untouched.

> AGENT GENERATED: by Claude Opus 5

