### PR TITLE
Tune realtime invalidations: PR key, work-status debounce, branch list, send path, search, archived (B8, K5, B14, B15, B17, B18, B24)

### DIFF
--- a/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
+++ b/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
@@ -185,6 +185,7 @@ const CACHE_OWNER_QUERY_KEY_IMPORTS: CacheOwnerQueryKeyImportRegistry = {
     "threadStorageFilePreviewQueryKeyPrefix",
     "threadStorageFilesForThreadQueryKeyPrefix",
     "threadStoragePathsForThreadQueryKeyPrefix",
+    "threadTimelineQueryKeyPrefix",
     "terminalsQueryKey",
     "threadsQueryKey",
   ],

--- a/apps/app/src/hooks/cache-owners/mutation-cache-effects.ts
+++ b/apps/app/src/hooks/cache-owners/mutation-cache-effects.ts
@@ -181,24 +181,32 @@ export function invalidateThreadQueuedMessageSendQueries({
   });
 }
 
-export function invalidateThreadAcceptedMessageQueries({
+/**
+ * After a send is accepted the sender already holds the new prompt-history
+ * entry (prepended locally) and the composer keeps the execution options it
+ * just sent, so neither needs a network round-trip. Default execution options
+ * are marked stale for the next mount only: consumers read them as initial
+ * values, and a live refetch would only race the realtime turn events.
+ */
+export function markThreadAcceptedMessageQueriesStale({
   queryClient,
   threadId,
 }: ThreadArg): void {
   queryClient.invalidateQueries({
     queryKey: threadDefaultExecutionOptionsQueryKey(threadId),
-  });
-  invalidateQueryKeys({
-    queryClient,
-    queryKeys: getThreadPromptHistoryInvalidationQueryKeys({ threadId }),
+    refetchType: "none",
   });
 }
 
+/**
+ * Same as {@link markThreadAcceptedMessageQueriesStale}, plus the refetches
+ * that realtime `events-appended`/`status-changed` would otherwise deliver.
+ */
 export function invalidateThreadAcceptedMessageQueriesWithoutRealtime({
   queryClient,
   threadId,
 }: ThreadArg): void {
-  invalidateThreadAcceptedMessageQueries({ queryClient, threadId });
+  markThreadAcceptedMessageQueriesStale({ queryClient, threadId });
   invalidateQueryKeys({
     queryClient,
     queryKeys: [
@@ -209,6 +217,20 @@ export function invalidateThreadAcceptedMessageQueriesWithoutRealtime({
         queryClient,
       }),
     ],
+  });
+}
+
+/**
+ * A queued send only changed the queue; while realtime is connected the
+ * server's `queue-changed` notification refreshes prompt history and the
+ * thread record, so only the queue list itself is refetched here.
+ */
+export function invalidateThreadQueuedMessageListQuery({
+  queryClient,
+  threadId,
+}: ThreadArg): void {
+  queryClient.invalidateQueries({
+    queryKey: threadQueuedMessagesQueryKey(threadId),
   });
 }
 
@@ -223,9 +245,13 @@ export function invalidateThreadHistoryRewriteQueries({
   queryClient.invalidateQueries({ queryKey: threadSearchQueryKeyPrefix() });
   invalidateQueryKeys({
     queryClient,
-    queryKeys: getProjectPromptHistoryInvalidationQueryKeys({
-      projectId: undefined,
-    }),
+    queryKeys: [
+      // A rewrite can drop or reorder prompts, which no local prepend covers.
+      ...getThreadPromptHistoryInvalidationQueryKeys({ threadId }),
+      ...getProjectPromptHistoryInvalidationQueryKeys({
+        projectId: undefined,
+      }),
+    ],
   });
 }
 

--- a/apps/app/src/hooks/cache-owners/mutation-cache-effects.ts
+++ b/apps/app/src/hooks/cache-owners/mutation-cache-effects.ts
@@ -221,9 +221,10 @@ export function invalidateThreadAcceptedMessageQueriesWithoutRealtime({
 }
 
 /**
- * A queued send only changed the queue; while realtime is connected the
- * server's `queue-changed` notification refreshes prompt history and the
- * thread record, so only the queue list itself is refetched here.
+ * A queued send only inserts a queue row; the thread record itself is not
+ * written, and while realtime is connected the server's `queue-changed`
+ * notification refreshes prompt history, so only the queue list itself is
+ * refetched here.
  */
 export function invalidateThreadQueuedMessageListQuery({
   queryClient,

--- a/apps/app/src/hooks/cache-owners/query-cache.ts
+++ b/apps/app/src/hooks/cache-owners/query-cache.ts
@@ -197,6 +197,32 @@ function getArchivedThreadListFiltersFromQueryKey(
   return filters;
 }
 
+export function isArchivedThreadListQueryKey(queryKey: QueryKey): boolean {
+  return getArchivedThreadListFiltersFromQueryKey(queryKey) !== undefined;
+}
+
+/**
+ * Every cached thread-list key (active and archived, all projects). Used by
+ * handlers that must treat archived lists differently from active ones and so
+ * cannot rely on a bare `threadsQueryKey()` prefix invalidation.
+ */
+export function getCachedThreadListQueryKeys(
+  queryClient: QueryClient,
+): QueryKey[] {
+  const queryKeys: QueryKey[] = [];
+  for (const [queryKey] of queryClient.getQueriesData({
+    queryKey: threadsQueryKey(),
+  })) {
+    if (
+      getThreadListFiltersFromQueryKey(queryKey) !== undefined ||
+      getArchivedThreadListFiltersFromQueryKey(queryKey) !== undefined
+    ) {
+      queryKeys.push(queryKey);
+    }
+  }
+  return queryKeys;
+}
+
 function getThreadListProjectIdFromQueryKey(
   queryKey: QueryKey,
 ): string | undefined {

--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -50,9 +50,11 @@ import {
   getCachedRootOrderThreadListInvalidationQueryKeys,
   getCachedSidebarNavigationThreads,
   getCachedThreadListPlaceholder,
+  getCachedThreadListQueryKeys,
   getEnvironmentBranchListInvalidationQueryKeys,
   getEnvironmentRecordInvalidationQueryKeys,
   getEnvironmentWorkspaceStateInvalidationQueryKeys,
+  isArchivedThreadListQueryKey,
   removeEnvironmentDiffPatchQueries,
   updateCachedThreadListPendingInteractionState,
 } from "./query-cache";
@@ -92,6 +94,7 @@ import {
   threadStorageFilePreviewQueryKeyPrefix,
   threadStorageFilesForThreadQueryKeyPrefix,
   threadStoragePathsForThreadQueryKeyPrefix,
+  threadTimelineQueryKeyPrefix,
 } from "../queries/query-keys";
 import { schedulePluginFrontendReconcile } from "../../lib/plugin-frontend-lazy";
 import {
@@ -132,6 +135,32 @@ const trailingActiveRefetchUnsubscribers = new WeakMap<
   Map<string, () => void>
 >();
 
+interface ThrottledActiveRefetchEntry {
+  lastRunAt: number;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+const throttledActiveRefetchEntries = new WeakMap<
+  QueryClient,
+  Map<string, ThrottledActiveRefetchEntry>
+>();
+
+interface ThrottledActiveRefetchArgs {
+  minIntervalMs: number;
+  queryClient: QueryClient;
+  queryKey: QueryKey;
+}
+
+/**
+ * `work-status-changed` arrives on every file-change burst while an agent
+ * edits. Each active work-status refetch is a `git status` probe on the host,
+ * and the default invalidation aborts the probe already in flight. Compact
+ * clients render the tally/branch from this query, so it must stay live —
+ * but one probe per second is enough. Changes inside the interval coalesce
+ * into a single trailing refetch, and an in-flight probe is never cancelled.
+ */
+const WORK_STATUS_REFETCH_MIN_INTERVAL_MS = 1_000;
+
 /**
  * The trailing refetch is self-clocking: it fires as soon as the in-flight
  * fetch settles and any event arrived meanwhile. During a streaming turn events
@@ -168,6 +197,69 @@ function hasActiveFetchingQueries(
     .getQueryCache()
     .findAll({ queryKey, type: "active" })
     .some((query) => query.state.fetchStatus !== "idle");
+}
+
+function hasActiveQueries(
+  queryClient: QueryClient,
+  queryKey: QueryKey,
+): boolean {
+  return (
+    queryClient.getQueryCache().findAll({ queryKey, type: "active" }).length >
+    0
+  );
+}
+
+function refetchActiveQueriesWithoutCanceling({
+  queryClient,
+  queryKey,
+}: ScheduleTrailingActiveRefetchArgs): void {
+  const hadActiveFetch = hasActiveFetchingQueries(queryClient, queryKey);
+  void queryClient
+    .refetchQueries({ queryKey, type: "active" }, { cancelRefetch: false })
+    .catch(() => {
+      // Individual query state already captures the refetch error.
+    });
+  if (hadActiveFetch) {
+    // A change that raced the in-flight read must not be lost.
+    scheduleTrailingActiveRefetch({ queryClient, queryKey });
+  }
+}
+
+/**
+ * Marks matching queries stale immediately (so a remount refetches) and
+ * refetches the active ones at most once per `minIntervalMs`: the first change
+ * after a quiet period refetches right away, later changes inside the interval
+ * coalesce into one trailing refetch. Never cancels an in-flight fetch.
+ */
+function invalidateQueryKeyWithThrottledActiveRefetch({
+  minIntervalMs,
+  queryClient,
+  queryKey,
+}: ThrottledActiveRefetchArgs): void {
+  queryClient.invalidateQueries({ queryKey, refetchType: "none" });
+
+  const scheduleKey = timelineInvalidationKey(queryKey);
+  let entries = throttledActiveRefetchEntries.get(queryClient);
+  if (!entries) {
+    entries = new Map();
+    throttledActiveRefetchEntries.set(queryClient, entries);
+  }
+  const entry = entries.get(scheduleKey);
+  if (entry?.timer) {
+    // A trailing refetch is already pending; this change rides along.
+    return;
+  }
+  const run = () => {
+    entries.set(scheduleKey, { lastRunAt: Date.now(), timer: null });
+    refetchActiveQueriesWithoutCanceling({ queryClient, queryKey });
+  };
+  const lastRunAt = entry?.lastRunAt ?? Number.NEGATIVE_INFINITY;
+  const delayMs = Math.max(0, lastRunAt + minIntervalMs - Date.now());
+  if (delayMs === 0) {
+    run();
+    return;
+  }
+  entries.set(scheduleKey, { lastRunAt, timer: setTimeout(run, delayMs) });
 }
 
 function scheduleTrailingActiveRefetch({
@@ -263,6 +355,15 @@ function invalidateTerminalTimelineQueryKeys({
 }
 
 export function disposeTrailingActiveRefetches(queryClient: QueryClient): void {
+  const throttled = throttledActiveRefetchEntries.get(queryClient);
+  if (throttled) {
+    for (const entry of throttled.values()) {
+      if (entry.timer) {
+        clearTimeout(entry.timer);
+      }
+    }
+    throttledActiveRefetchEntries.delete(queryClient);
+  }
   const unsubscribers = trailingActiveRefetchUnsubscribers.get(queryClient);
   if (!unsubscribers) {
     return;
@@ -297,7 +398,7 @@ export const REALTIME_THREAD_CHANGE_REGISTRY = {
     dirty: [
       dirtyThreadListQueriesForBackgroundActivity, // Sidebar rows render active workflow/background task state.
       dirtyThreadDetailQueriesForBackgroundActivity, // Detail indicator reads activeBackgroundAgentCount.
-      dirtyThreadSearchQueries, // Indexed conversation content may now match a search query.
+      dirtyThreadSearchQueriesForCompletedTurn, // Indexed conversation content may match a search query once the turn settles.
       dirtyThreadTimelineQueries, // Timeline rows are built from appended events.
       dirtyThreadPullRequestQueryForCompletedTurn, // A turn may create a remote PR without changing the workspace.
       dirtyThreadPromptHistoryQueriesForTurnRequests, // Follow-up recall is built from client turn requests.
@@ -326,14 +427,14 @@ export const REALTIME_THREAD_CHANGE_REGISTRY = {
   "status-changed": {
     flush: "immediate",
     dirty: [
-      dirtyThreadListQueries, // List rows render status/runtime badges.
+      dirtyActiveThreadListQueries, // List rows render status/runtime badges; archived pages only go stale.
       dirtyThreadDetailQueries, // Detail controls and banners depend on status.
     ],
   },
   "title-changed": {
     flush: "debounced",
     dirty: [
-      dirtyThreadListQueries, // List rows render display title.
+      dirtyActiveThreadListQueries, // List rows render display title; archived pages only go stale.
       dirtyThreadDetailQueries, // Detail headers and breadcrumbs render display title.
     ],
   },
@@ -368,7 +469,7 @@ export const REALTIME_THREAD_CHANGE_REGISTRY = {
   "environment-changed": {
     flush: "immediate",
     dirty: [
-      dirtyThreadListQueries, // Thread rows render environment/worktree metadata.
+      dirtyActiveThreadListQueries, // Thread rows render environment/worktree metadata; archived pages only go stale.
       dirtyThreadDetailQueries, // Detail views use the attached environment for workspace UI.
       dirtyThreadDefaultExecutionOptionsQueries, // Environment changes can change inherited thread defaults.
       dirtyThreadStorageQueriesForThread, // Thread storage is resolved through the attached environment.
@@ -432,7 +533,7 @@ export const REALTIME_ENVIRONMENT_CHANGE_REGISTRY = {
   },
   "work-status-changed": {
     dirty: [
-      dirtyEnvironmentLiveWorkspaceStateQueries, // Refresh live workspace-derived views after file edits.
+      dirtyEnvironmentLiveWorkspaceStateQueries, // Refresh live workspace-derived views after file edits (PR state is remote and unaffected).
     ],
   },
   "git-refs-changed": {
@@ -537,9 +638,26 @@ export interface RealtimeDirtyContext {
 export interface ThreadRealtimeDirtyContext extends RealtimeDirtyContext {
   backgroundActivityChanged: boolean | undefined;
   eventTypes: readonly ThreadEventType[] | undefined;
+  /**
+   * `true` the first time a key is seen within the current flush of batched
+   * thread changes, `false` afterwards. Handlers whose effect is global (not
+   * thread-scoped) use it to run once per flush instead of once per thread.
+   */
+  flushOnce: (key: string) => boolean;
   hasPendingInteraction: boolean | undefined;
   projectId: string | undefined;
   threadId: string | undefined;
+}
+
+export function createFlushOncePredicate(): (key: string) => boolean {
+  const seen = new Set<string>();
+  return (key) => {
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  };
 }
 
 export interface EnvironmentRealtimeDirtyContext extends RealtimeDirtyContext {
@@ -663,13 +781,44 @@ function dirtyThreadListQueries({
   return getThreadListInvalidationQueryKeys({ projectId, queryClient });
 }
 
+/**
+ * Same scope as {@link dirtyThreadListQueries}, but archived list pages are
+ * only marked stale (`refetchType: "none"`): a status/title/environment change
+ * on one thread does not justify refetching every un-windowed archived page
+ * that the settings screen holds open. They refresh on the next mount.
+ */
+function dirtyActiveThreadListQueries({
+  projectId,
+  queryClient,
+}: ThreadRealtimeDirtyContext): QueryKey[] {
+  const listQueryKeys = projectId
+    ? [
+        ...getCachedProjectThreadListInvalidationQueryKeys({
+          projectId,
+          queryClient,
+        }),
+        ...getCachedGlobalThreadListInvalidationQueryKeys({ queryClient }),
+      ]
+    : getCachedThreadListQueryKeys(queryClient);
+  for (const queryKey of listQueryKeys) {
+    queryClient.invalidateQueries({
+      exact: true,
+      queryKey,
+      ...(isArchivedThreadListQueryKey(queryKey)
+        ? { refetchType: "none" }
+        : {}),
+    });
+  }
+  return [sidebarNavigationQueryKey(), threadSearchQueryKeyPrefix()];
+}
+
 function dirtyThreadListQueriesForBackgroundActivity(
   context: ThreadRealtimeDirtyContext,
 ): QueryKey[] {
   if (context.backgroundActivityChanged !== true) {
     return [];
   }
-  return dirtyThreadListQueries(context);
+  return dirtyActiveThreadListQueries(context);
 }
 
 function dirtyThreadDetailQueriesForBackgroundActivity(
@@ -722,6 +871,30 @@ function dirtyThreadSearchQueries(): QueryKey[] {
   return [threadSearchQueryKeyPrefix()];
 }
 
+/**
+ * Every client's list subscription receives every streaming thread's
+ * `events-appended` batches. Re-issuing (and, by default, aborting) the open
+ * search request on each 50-100 ms flush can starve it forever on a slow link,
+ * so search only goes stale when a turn completes, once per flush, and without
+ * cancelling a request in flight. Thread list changes cover the rest.
+ */
+function dirtyThreadSearchQueriesForCompletedTurn({
+  eventTypes,
+  flushOnce,
+  queryClient,
+}: ThreadRealtimeDirtyContext): void {
+  if (!eventTypes?.includes("turn/completed")) {
+    return;
+  }
+  if (!flushOnce("thread-search:turn-completed")) {
+    return;
+  }
+  queryClient.invalidateQueries(
+    { queryKey: threadSearchQueryKeyPrefix() },
+    { cancelRefetch: false },
+  );
+}
+
 function dirtyThreadTimelineQueries({
   eventTypes,
   queryClient,
@@ -730,6 +903,18 @@ function dirtyThreadTimelineQueries({
   // Window only: completed turn-summary-details are immutable, so realtime
   // event batches must not refetch open detail panels (see helper docs).
   const queryKeys = getThreadTimelineWindowInvalidationQueryKeys({ threadId });
+  if (
+    threadId !== undefined &&
+    !hasActiveQueries(queryClient, threadTimelineQueryKeyPrefix(threadId))
+  ) {
+    // Nobody is viewing this thread: mark the cached window stale so a remount
+    // refetches, but skip the fetch pacing/cancel machinery. List
+    // subscriptions deliver every streaming thread's batches to every client.
+    for (const queryKey of queryKeys) {
+      queryClient.invalidateQueries({ queryKey, refetchType: "none" });
+    }
+    return;
+  }
   if (eventTypes?.includes("turn/completed")) {
     invalidateTerminalTimelineQueryKeys({ queryClient, queryKeys });
     return;
@@ -899,12 +1084,14 @@ function dirtyEnvironmentLiveWorkspaceStateQueries({
   environmentId,
   queryClient,
 }: EnvironmentRealtimeDirtyContext): void {
-  queryClient.invalidateQueries({
+  invalidateQueryKeyWithThrottledActiveRefetch({
+    minIntervalMs: WORK_STATUS_REFETCH_MIN_INTERVAL_MS,
+    queryClient,
     queryKey: environmentWorkStatusQueryKeyPrefix(environmentId),
   });
-  queryClient.invalidateQueries({
-    queryKey: environmentPullRequestQueryKey(environmentId),
-  });
+  // The pull request is remote state: a local file edit cannot change it, so
+  // it is deliberately not refetched here (`turn/completed` and the pending
+  // check poll cover it).
   queryClient.invalidateQueries({
     queryKey: environmentFilePreviewQueryKeyPrefix(environmentId),
   });

--- a/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.test.ts
+++ b/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.test.ts
@@ -4,7 +4,8 @@ import type {
   ThreadSearchResponse,
   ThreadTimelineResponse,
 } from "@bb/server-contract";
-import { describe, expect, it } from "vitest";
+import { QueryObserver } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
 import { createAppQueryClient } from "@/lib/query-client";
 import {
   sidebarNavigationQueryKey,
@@ -19,6 +20,7 @@ import { threadDefaultExecutionOptionsQueryKey } from "../queries/thread-default
 import {
   applyQueuedMessageCreateResult,
   applyQueuedMessageUpdateResult,
+  applySendThreadMessageSuccess,
   applyThreadGoalClearResult,
   applyThreadPlanCancellationResult,
   beginCreateQueuedMessageTransaction,
@@ -925,5 +927,141 @@ describe("thread runtime cache owner", () => {
         threadTimelineQueryKey("thread-1"),
       )?.rows,
     ).toEqual([]);
+  });
+  it("keeps an accepted send local while realtime is connected: prompt history is prepended, not refetched, and default execution options only go stale", async () => {
+    const queryClient = createAppQueryClient({
+      defaultOptions: { queries: { gcTime: Infinity, retry: false } },
+      showMutationErrorToasts: false,
+    });
+    queryClient.setQueryData(threadQueryKey("thread-1"), {
+      id: "thread-1",
+      status: "idle",
+      runtime: { displayStatus: "idle", hostReconnectGraceExpiresAt: null },
+    });
+    const promptHistoryQueryFn = vi.fn(async () => []);
+    const defaultExecutionOptionsQueryFn = vi.fn(async () => null);
+    const promptHistoryObserver = new QueryObserver(queryClient, {
+      queryKey: threadPromptHistoryQueryKey("thread-1"),
+      queryFn: promptHistoryQueryFn,
+      staleTime: Infinity,
+    });
+    const defaultExecutionOptionsObserver = new QueryObserver(queryClient, {
+      queryKey: threadDefaultExecutionOptionsQueryKey("thread-1"),
+      queryFn: defaultExecutionOptionsQueryFn,
+      staleTime: Infinity,
+    });
+    const unsubscribers = [
+      promptHistoryObserver.subscribe(() => {}),
+      defaultExecutionOptionsObserver.subscribe(() => {}),
+    ];
+    await vi.waitFor(() => {
+      expect(promptHistoryQueryFn).toHaveBeenCalledTimes(1);
+      expect(defaultExecutionOptionsQueryFn).toHaveBeenCalledTimes(1);
+    });
+    const request = {
+      id: "thread-1",
+      mode: "auto" as const,
+      input: [{ type: "text" as const, text: "Accepted prompt", mentions: [] }],
+    };
+    const transaction = await beginSendThreadMessageTransaction({
+      queryClient,
+      request,
+    });
+    expect(transaction.kind).toBe("accepted-turn");
+
+    applySendThreadMessageSuccess({
+      queryClient,
+      realtimeConnected: true,
+      request,
+      transaction,
+    });
+    await Promise.resolve();
+
+    expect(
+      queryClient.getQueryData(threadPromptHistoryQueryKey("thread-1")),
+    ).toMatchObject([{ input: request.input }]);
+    expect(promptHistoryQueryFn).toHaveBeenCalledTimes(1);
+    expect(
+      queryClient.getQueryState(threadPromptHistoryQueryKey("thread-1"))
+        ?.isInvalidated,
+    ).toBe(false);
+    expect(
+      queryClient.getQueryState(
+        threadDefaultExecutionOptionsQueryKey("thread-1"),
+      )?.isInvalidated,
+    ).toBe(true);
+    expect(defaultExecutionOptionsQueryFn).toHaveBeenCalledTimes(1);
+
+    for (const unsubscribe of unsubscribers) {
+      unsubscribe();
+    }
+  });
+
+  it("refetches only the queue list for a queued send while realtime is connected", async () => {
+    const queryClient = createAppQueryClient({
+      defaultOptions: { queries: { gcTime: Infinity, retry: false } },
+      showMutationErrorToasts: false,
+    });
+    queryClient.setQueryData(threadQueryKey("thread-1"), { status: "active" });
+    const queuedMessagesQueryFn = vi.fn(async () => []);
+    const promptHistoryQueryFn = vi.fn(async () => []);
+    const threadQueryFn = vi.fn(async () => ({ status: "active" }));
+    const observers = [
+      new QueryObserver(queryClient, {
+        queryKey: threadQueuedMessagesQueryKey("thread-1"),
+        queryFn: queuedMessagesQueryFn,
+        staleTime: Infinity,
+      }),
+      new QueryObserver(queryClient, {
+        queryKey: threadPromptHistoryQueryKey("thread-1"),
+        queryFn: promptHistoryQueryFn,
+        staleTime: Infinity,
+      }),
+      new QueryObserver(queryClient, {
+        queryKey: threadQueryKey("thread-1"),
+        queryFn: threadQueryFn,
+        staleTime: Infinity,
+      }),
+    ];
+    const unsubscribers = observers.map((observer) =>
+      observer.subscribe(() => {}),
+    );
+    await vi.waitFor(() => {
+      expect(queuedMessagesQueryFn).toHaveBeenCalledTimes(1);
+      expect(promptHistoryQueryFn).toHaveBeenCalledTimes(1);
+    });
+    const request = {
+      id: "thread-1",
+      mode: "queue-if-active" as const,
+      input: [{ type: "text" as const, text: "Queued prompt", mentions: [] }],
+    };
+    const transaction = await beginSendThreadMessageTransaction({
+      queryClient,
+      request,
+    });
+    expect(transaction.kind).toBe("queued-message");
+
+    applySendThreadMessageSuccess({
+      queryClient,
+      realtimeConnected: true,
+      request,
+      transaction,
+    });
+    await vi.waitFor(() => {
+      expect(queuedMessagesQueryFn).toHaveBeenCalledTimes(2);
+    });
+
+    expect(
+      queryClient.getQueryData(threadPromptHistoryQueryKey("thread-1")),
+    ).toMatchObject([{ input: request.input }]);
+    expect(promptHistoryQueryFn).toHaveBeenCalledTimes(1);
+    expect(threadQueryFn).not.toHaveBeenCalled();
+    expect(
+      queryClient.getQueryState(threadQueryKey("thread-1"))?.isInvalidated,
+    ).toBe(false);
+
+    for (const unsubscribe of unsubscribers) {
+      unsubscribe();
+    }
   });
 });

--- a/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.ts
@@ -54,9 +54,10 @@ import {
 import { threadDefaultExecutionOptionsQueryKey } from "../queries/thread-default-execution-options-query";
 import {
   invalidateProjectPromptHistoryQueries,
-  invalidateThreadAcceptedMessageQueries,
   invalidateThreadAcceptedMessageQueriesWithoutRealtime,
+  invalidateThreadQueuedMessageListQuery,
   invalidateThreadQueueQueries,
+  markThreadAcceptedMessageQueriesStale,
   invalidateThreadQueuedMessageSendQueries,
   invalidateThreadStopQueries,
   refetchThreadListsAfterComposerThreadCreate,
@@ -884,7 +885,25 @@ export function applySendThreadMessageSuccess({
   transaction,
 }: ApplySendThreadMessageSuccessArgs): void {
   if (transaction?.kind === "queued-message") {
-    invalidateThreadQueueQueries({ queryClient, threadId: request.id });
+    // Queued prompts enter recall too; prepend locally instead of refetching.
+    prependThreadPromptHistory(
+      queryClient,
+      request.id,
+      buildAcceptedPromptHistoryEntry({
+        createdAt: Date.now(),
+        input: request.input,
+      }),
+    );
+    if (realtimeConnected) {
+      // `queue-changed` covers the thread record; only the queue list needs a
+      // read to swap the optimistic row for the server row.
+      invalidateThreadQueuedMessageListQuery({
+        queryClient,
+        threadId: request.id,
+      });
+    } else {
+      invalidateThreadQueueQueries({ queryClient, threadId: request.id });
+    }
     return;
   }
   prependThreadPromptHistory(
@@ -895,11 +914,11 @@ export function applySendThreadMessageSuccess({
       input: request.input,
     }),
   );
-  const invalidateAcceptedMessageQueries = realtimeConnected
-    ? invalidateThreadAcceptedMessageQueries
+  const applyAcceptedMessageQueries = realtimeConnected
+    ? markThreadAcceptedMessageQueriesStale
     : invalidateThreadAcceptedMessageQueriesWithoutRealtime;
 
-  invalidateAcceptedMessageQueries({
+  applyAcceptedMessageQueries({
     queryClient,
     threadId: request.id,
   });

--- a/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.ts
@@ -895,8 +895,9 @@ export function applySendThreadMessageSuccess({
       }),
     );
     if (realtimeConnected) {
-      // `queue-changed` covers the thread record; only the queue list needs a
-      // read to swap the optimistic row for the server row.
+      // Enqueuing does not write the thread record, and `queue-changed`
+      // refreshes prompt history; only the queue list needs a read to swap
+      // the optimistic row for the server row.
       invalidateThreadQueuedMessageListQuery({
         queryClient,
         threadId: request.id,

--- a/apps/app/src/hooks/queries/archived-threads-page-size.ts
+++ b/apps/app/src/hooks/queries/archived-threads-page-size.ts
@@ -1,1 +1,3 @@
-export const ARCHIVED_THREADS_PAGE_SIZE = 100;
+// Archived pages are un-windowed rows; smaller pages keep the first paint and
+// each realtime-driven refetch light on phones.
+export const ARCHIVED_THREADS_PAGE_SIZE = 50;

--- a/apps/app/src/hooks/queries/environment-queries.test.tsx
+++ b/apps/app/src/hooks/queries/environment-queries.test.tsx
@@ -24,7 +24,7 @@ vi.mock("@/hooks/useRealtimeSubscription", () => ({
 const ENVIRONMENT_ID = "env-1";
 const ACTIVE_PULL_REQUEST_STALE_MS = 30_000;
 const SETTLED_PULL_REQUEST_STALE_MS = 60 * 60_000;
-const ACTIVE_PULL_REQUEST_REFETCH_MS = 5_000;
+const ACTIVE_PULL_REQUEST_REFETCH_MS = 30_000;
 
 const pullRequestFixture: ThreadPullRequest = {
   number: 128,
@@ -163,7 +163,7 @@ describe("useEnvironmentPullRequest", () => {
     ).toBe(false);
   });
 
-  it("refetches stale pull request data on mount and always refetches on window focus", async () => {
+  it("refetches stale pull request data on mount and on window focus", async () => {
     const { wrapper, queryClient } = createQueryClientTestHarness();
     vi.mocked(sdk.environments.pullRequest).mockResolvedValue(
       pullRequestResponse(pullRequestFixture),
@@ -182,7 +182,7 @@ describe("useEnvironmentPullRequest", () => {
     expect(query?.options).toEqual(
       expect.objectContaining({
         refetchOnMount: true,
-        refetchOnWindowFocus: "always",
+        refetchOnWindowFocus: true,
         refetchInterval: expect.any(Function),
         staleTime: expect.any(Function),
       }),

--- a/apps/app/src/hooks/queries/environment-queries.ts
+++ b/apps/app/src/hooks/queries/environment-queries.ts
@@ -64,7 +64,7 @@ interface UseEnvironmentDiffFilesOptions extends QueryOptions {
 
 const ENVIRONMENT_PULL_REQUEST_STALE_MS = 30_000;
 const ENVIRONMENT_SETTLED_PULL_REQUEST_STALE_MS = 60 * 60_000;
-const ENVIRONMENT_ACTIVE_PULL_REQUEST_REFETCH_MS = 5_000;
+const ENVIRONMENT_ACTIVE_PULL_REQUEST_REFETCH_MS = 30_000;
 const MERGE_BASE_BRANCHES_STALE_MS = 30_000;
 const MERGE_BASE_BRANCHES_LIMIT = 50;
 /** Staleness window for the environment diff TOC query. */
@@ -192,7 +192,10 @@ export function useEnvironmentPullRequest(
       }),
     enabled,
     refetchOnMount: true,
-    refetchOnWindowFocus: "always",
+    // Each lookup spawns `gh pr view` on the host, so refetch on focus only
+    // when the cached PR is stale; a still-fresh PR does not need a re-probe on
+    // every foreground.
+    refetchOnWindowFocus: true,
     refetchInterval: (query) =>
       getEnvironmentPullRequestRefetchInterval(
         getEnvironmentPullRequestFromResponse(query.state.data),

--- a/apps/app/src/hooks/queries/project-queries.test.tsx
+++ b/apps/app/src/hooks/queries/project-queries.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { sdk } from "@/lib/sdk";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useProjectSourceBranches } from "./project-queries";
+import { projectSourceBranchesQueryKeyPrefix } from "./query-keys";
+
+vi.mock("@/lib/sdk", () => ({
+  sdk: { projects: { branches: vi.fn() } },
+}));
+
+vi.mock("@/hooks/useRealtimeSubscription", () => ({
+  useProjectDetailRealtimeSubscription: vi.fn(),
+}));
+
+describe("useProjectSourceBranches", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("does not re-run the daemon branch RPC on window focus while the list is fresh", async () => {
+    const { wrapper, queryClient } = createQueryClientTestHarness();
+    vi.mocked(sdk.projects.branches).mockResolvedValue({
+      branches: ["main"],
+      branchesTruncated: false,
+      checkout: { kind: "branch", branchName: "main", headSha: null },
+      defaultBranch: "main",
+      defaultBranchRelation: "equal",
+      defaultWorktreeBaseBranch: null,
+      hasUncommittedChanges: false,
+      operation: { kind: "none" },
+      originDefaultBranch: "main",
+      remoteBranches: [],
+      remoteBranchesTruncated: false,
+      selectedBranch: null,
+    });
+
+    renderHook(() => useProjectSourceBranches("project-1", "host-1"), {
+      wrapper,
+    });
+    await waitFor(() => {
+      expect(sdk.projects.branches).toHaveBeenCalledTimes(1);
+    });
+
+    const [query] = queryClient.getQueryCache().findAll({
+      queryKey: projectSourceBranchesQueryKeyPrefix("project-1"),
+    });
+    expect(query?.options).toEqual(
+      expect.objectContaining({
+        refetchOnWindowFocus: false,
+        staleTime: 30_000,
+      }),
+    );
+  });
+});

--- a/apps/app/src/hooks/queries/project-queries.ts
+++ b/apps/app/src/hooks/queries/project-queries.ts
@@ -28,7 +28,7 @@ import {
 } from "./query-helpers";
 import {
   EXPENSIVE_MANUAL_QUERY_POLICY,
-  FAST_FOCUS_OWNED_LIVE_QUERY_POLICY,
+  REALTIME_OWNED_NO_FOCUS_QUERY_POLICY,
   TYPEAHEAD_QUERY_POLICY,
 } from "./query-policies";
 
@@ -60,6 +60,13 @@ interface UseProjectCommandsArgs {
 }
 
 const PROJECT_SOURCE_BRANCHES_LIMIT = 50;
+/**
+ * The branch list is a daemon git RPC (throttled fetch + several git
+ * commands). Realtime `project-sources-changed` refreshes it and the branch
+ * picker refetches on open, so a foreground/focus refetch only re-runs that
+ * RPC without new information.
+ */
+const PROJECT_SOURCE_BRANCHES_STALE_MS = 30_000;
 
 function decodeBase64Bytes(content: string): Uint8Array {
   const binaryContent = atob(content);
@@ -130,7 +137,8 @@ export function useProjectSourceBranches(
         signal,
       }),
     enabled,
-    ...FAST_FOCUS_OWNED_LIVE_QUERY_POLICY,
+    ...REALTIME_OWNED_NO_FOCUS_QUERY_POLICY,
+    staleTime: PROJECT_SOURCE_BRANCHES_STALE_MS,
     placeholderData: (previousData, previousQuery) =>
       projectId && hostId
         ? resolveProjectSourceBranchesPlaceholder({

--- a/apps/app/src/hooks/queries/query-policies.ts
+++ b/apps/app/src/hooks/queries/query-policies.ts
@@ -6,7 +6,6 @@
 
 const SERVER_SESSION_STALE_TIME_MS = 60 * 60_000;
 const FOCUS_OWNED_LIVE_STALE_TIME_MS = 30_000;
-const FAST_FOCUS_OWNED_LIVE_STALE_TIME_MS = 5_000;
 const TYPEAHEAD_STALE_TIME_MS = 15_000;
 
 export const SESSION_STATIC_QUERY_POLICY = {
@@ -26,12 +25,6 @@ export const FOCUS_OWNED_LIVE_QUERY_POLICY = {
   refetchOnReconnect: true,
   refetchOnWindowFocus: true,
   staleTime: FOCUS_OWNED_LIVE_STALE_TIME_MS,
-} as const;
-
-export const FAST_FOCUS_OWNED_LIVE_QUERY_POLICY = {
-  refetchOnReconnect: true,
-  refetchOnWindowFocus: true,
-  staleTime: FAST_FOCUS_OWNED_LIVE_STALE_TIME_MS,
 } as const;
 
 export const RESUME_REFETCH_QUERY_POLICY = {

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -35,6 +35,7 @@ import {
   terminalsQueryKey,
   threadStorageFilePreviewQueryKey,
   threadTimelineQueryKey,
+  threadTimelineQueryKeyPrefix,
   threadTimelineTurnSummaryDetailsQueryKey,
 } from "./queries/query-keys";
 import { pluginContributionsQueryKey } from "./queries/query-keys";
@@ -422,7 +423,7 @@ describe("createRealtimeCacheEffects", () => {
     effects.dispose();
   });
 
-  it("invalidates cached thread search results when indexed thread content changes", () => {
+  it("invalidates cached thread search results only once a turn completes, not on every appended batch", () => {
     vi.useFakeTimers();
     const { effects, queryClient } = createRealtimeEffectsTestContext();
     const threadSearchKey = threadSearchQueryKey({
@@ -444,9 +445,215 @@ describe("createRealtimeCacheEffects", () => {
     vi.advanceTimersByTime(50);
 
     expect(queryClient.getQueryState(threadSearchKey)?.isInvalidated).toBe(
+      false,
+    );
+
+    effects.handleChanged({
+      type: "changed",
+      entity: "thread",
+      id: "thr_1",
+      metadata: {
+        eventTypes: ["item/completed", "turn/completed"],
+        projectId: "project-1",
+      },
+      changes: ["events-appended"],
+    });
+    vi.advanceTimersByTime(50);
+
+    expect(queryClient.getQueryState(threadSearchKey)?.isInvalidated).toBe(
       true,
     );
 
+    effects.dispose();
+  });
+
+  it("refreshes an open search once per flush without aborting the request in flight", async () => {
+    vi.useFakeTimers();
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const threadSearchKey = threadSearchQueryKey({
+      limitPerGroup: 20,
+      query: "needle",
+    });
+    const signals: AbortSignal[] = [];
+    const resolveFetches: Array<(value: unknown) => void> = [];
+    const searchQueryFn = vi.fn(({ signal }: { signal: AbortSignal }) => {
+      signals.push(signal);
+      return new Promise((resolve) => {
+        resolveFetches.push(resolve);
+      });
+    });
+    const searchObserver = new QueryObserver(queryClient, {
+      queryKey: threadSearchKey,
+      queryFn: searchQueryFn,
+      staleTime: Infinity,
+    });
+    const unsubscribeSearch = searchObserver.subscribe(() => {});
+    await vi.advanceTimersByTimeAsync(0);
+    expect(searchQueryFn).toHaveBeenCalledTimes(1);
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    // Two threads complete a turn inside one debounce window.
+    for (const threadId of ["thr_1", "thr_2"]) {
+      effects.handleChanged({
+        type: "changed",
+        entity: "thread",
+        id: threadId,
+        metadata: { eventTypes: ["turn/completed"], projectId: "project-1" },
+        changes: ["events-appended"],
+      });
+    }
+    await vi.advanceTimersByTimeAsync(50);
+
+    const searchInvalidations = invalidateSpy.mock.calls.filter(
+      ([filters]) =>
+        JSON.stringify(filters?.queryKey) ===
+        JSON.stringify([threadSearchKey[0]]),
+    );
+    expect(searchInvalidations).toHaveLength(1);
+    expect(searchInvalidations[0]?.[1]).toEqual({ cancelRefetch: false });
+    // The in-flight search keeps running; it is not aborted and re-issued.
+    expect(signals[0]?.aborted).toBe(false);
+    expect(searchQueryFn).toHaveBeenCalledTimes(1);
+
+    resolveFetches[0]?.({
+      active: { results: [], total: 0 },
+      archived: { results: [], total: 0 },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    invalidateSpy.mockRestore();
+    unsubscribeSearch();
+    effects.dispose();
+  });
+
+  it("marks the timeline of an unviewed thread stale without scheduling a refetch", async () => {
+    vi.useFakeTimers();
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const viewedTimelineKey = threadTimelineQueryKey("thr_viewed");
+    const unviewedTimelineKey = threadTimelineQueryKey("thr_unviewed");
+    queryClient.setQueryData(unviewedTimelineKey, { rows: [] });
+    const viewedTimelineQueryFn = vi.fn(async () => ({ rows: [] }));
+    const viewedObserver = new QueryObserver(queryClient, {
+      queryKey: viewedTimelineKey,
+      queryFn: viewedTimelineQueryFn,
+      staleTime: Infinity,
+    });
+    const unsubscribeViewed = viewedObserver.subscribe(() => {});
+    await vi.advanceTimersByTimeAsync(0);
+    viewedTimelineQueryFn.mockClear();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    for (const threadId of ["thr_viewed", "thr_unviewed"]) {
+      effects.handleChanged({
+        type: "changed",
+        entity: "thread",
+        id: threadId,
+        metadata: { eventTypes: ["item/completed"], projectId: "project-1" },
+        changes: ["events-appended"],
+      });
+    }
+    await vi.advanceTimersByTimeAsync(50);
+
+    // The unviewed thread's cached window is stale for its next mount...
+    expect(
+      queryClient.getQueryState(unviewedTimelineKey)?.isInvalidated,
+    ).toBe(true);
+    const unviewedInvalidations = invalidateSpy.mock.calls.filter(
+      ([filters]) =>
+        JSON.stringify(filters?.queryKey) ===
+        JSON.stringify(threadTimelineQueryKeyPrefix("thr_unviewed")),
+    );
+    expect(unviewedInvalidations).toHaveLength(1);
+    expect(unviewedInvalidations[0]?.[0]?.refetchType).toBe("none");
+    // ...while the viewed thread refetches through the paced path.
+    const viewedInvalidations = invalidateSpy.mock.calls.filter(
+      ([filters]) =>
+        JSON.stringify(filters?.queryKey) ===
+        JSON.stringify(threadTimelineQueryKeyPrefix("thr_viewed")),
+    );
+    expect(viewedInvalidations).toHaveLength(1);
+    expect(viewedInvalidations[0]?.[0]?.refetchType).toBeUndefined();
+    expect(viewedTimelineQueryFn).toHaveBeenCalledTimes(1);
+
+    invalidateSpy.mockRestore();
+    unsubscribeViewed();
+    effects.dispose();
+  });
+
+  it("marks archived thread lists stale without refetching them for status changes", async () => {
+    vi.useFakeTimers();
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const activeListKey = threadListQueryKey({
+      archived: false,
+      projectId: "project-1",
+    });
+    const archivedListKey = archivedThreadsListQueryKey({
+      projectId: "project-1",
+    });
+    const globalArchivedListKey = archivedThreadsListQueryKey({});
+    const activeListQueryFn = vi.fn(async () => []);
+    const archivedListQueryFn = vi.fn(async () => []);
+    const globalArchivedListQueryFn = vi.fn(async () => []);
+    const observers = [
+      new QueryObserver(queryClient, {
+        queryKey: activeListKey,
+        queryFn: activeListQueryFn,
+        staleTime: Infinity,
+      }),
+      new QueryObserver(queryClient, {
+        queryKey: archivedListKey,
+        queryFn: archivedListQueryFn,
+        staleTime: Infinity,
+      }),
+      new QueryObserver(queryClient, {
+        queryKey: globalArchivedListKey,
+        queryFn: globalArchivedListQueryFn,
+        staleTime: Infinity,
+      }),
+    ];
+    const unsubscribers = observers.map((observer) =>
+      observer.subscribe(() => {}),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    activeListQueryFn.mockClear();
+    archivedListQueryFn.mockClear();
+    globalArchivedListQueryFn.mockClear();
+
+    for (const change of ["status-changed", "title-changed"] as const) {
+      effects.handleChanged({
+        type: "changed",
+        entity: "thread",
+        id: "thr_1",
+        metadata: { projectId: "project-1" },
+        changes: [change],
+      });
+      await vi.advanceTimersByTimeAsync(50);
+    }
+
+    expect(activeListQueryFn).toHaveBeenCalledTimes(2);
+    expect(archivedListQueryFn).not.toHaveBeenCalled();
+    expect(globalArchivedListQueryFn).not.toHaveBeenCalled();
+    expect(queryClient.getQueryState(archivedListKey)?.isInvalidated).toBe(
+      true,
+    );
+    expect(
+      queryClient.getQueryState(globalArchivedListKey)?.isInvalidated,
+    ).toBe(true);
+
+    // Archive membership changes still refetch archived pages.
+    effects.handleChanged({
+      type: "changed",
+      entity: "thread",
+      id: "thr_1",
+      metadata: { projectId: "project-1" },
+      changes: ["archived-changed"],
+    });
+    await vi.advanceTimersByTimeAsync(50);
+    expect(archivedListQueryFn).toHaveBeenCalledTimes(1);
+    expect(globalArchivedListQueryFn).toHaveBeenCalledTimes(1);
+
+    for (const unsubscribe of unsubscribers) {
+      unsubscribe();
+    }
     effects.dispose();
   });
 
@@ -836,6 +1043,99 @@ describe("createRealtimeCacheEffects", () => {
     expect(queryClient.getQueryData(diffPatchKey)).toBeUndefined();
 
     unsubscribeDiffFiles();
+    unsubscribeWorkStatus();
+    effects.dispose();
+  });
+
+  it("does not refetch the environment pull request for work-status changes", async () => {
+    vi.useFakeTimers();
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const pullRequestKey = environmentPullRequestQueryKey("env-1");
+    const pullRequestQueryFn = vi.fn(async () => ({ outcome: "absent" }));
+    const pullRequestObserver = new QueryObserver(queryClient, {
+      queryFn: pullRequestQueryFn,
+      queryKey: pullRequestKey,
+      staleTime: Infinity,
+    });
+    const unsubscribePullRequest = pullRequestObserver.subscribe(() => {});
+    await vi.advanceTimersByTimeAsync(0);
+    pullRequestQueryFn.mockClear();
+
+    effects.handleChanged({
+      type: "changed",
+      entity: "environment",
+      id: "env-1",
+      changes: ["work-status-changed"],
+    });
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(pullRequestQueryFn).not.toHaveBeenCalled();
+    expect(queryClient.getQueryState(pullRequestKey)?.isInvalidated).toBe(
+      false,
+    );
+
+    unsubscribePullRequest();
+    effects.dispose();
+  });
+
+  it("paces work-status refetches to one per second and never aborts the probe in flight", async () => {
+    vi.useFakeTimers();
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const workStatusKey = environmentWorkStatusQueryKey("env-1", "main");
+    const signals: AbortSignal[] = [];
+    const resolveFetches: Array<(value: unknown) => void> = [];
+    const workStatusQueryFn = vi.fn(({ signal }: { signal: AbortSignal }) => {
+      signals.push(signal);
+      return new Promise((resolve) => {
+        resolveFetches.push(resolve);
+      });
+    });
+    const workStatusObserver = new QueryObserver(queryClient, {
+      queryKey: workStatusKey,
+      queryFn: workStatusQueryFn,
+      staleTime: Infinity,
+    });
+    const unsubscribeWorkStatus = workStatusObserver.subscribe(() => {});
+    await vi.advanceTimersByTimeAsync(0);
+    expect(workStatusQueryFn).toHaveBeenCalledTimes(1);
+    resolveFetches[0]?.(null);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const emitWorkStatusChanged = () => {
+      effects.handleChanged({
+        type: "changed",
+        entity: "environment",
+        id: "env-1",
+        changes: ["work-status-changed"],
+      });
+    };
+
+    // t=0: first change after a quiet period refetches on the next flush.
+    emitWorkStatusChanged();
+    await vi.advanceTimersByTimeAsync(250);
+    expect(workStatusQueryFn).toHaveBeenCalledTimes(2);
+
+    // t=300 and t=600: two more file-change bursts while the probe is still
+    // running. Neither aborts it, and neither starts a probe of its own.
+    await vi.advanceTimersByTimeAsync(50);
+    emitWorkStatusChanged();
+    await vi.advanceTimersByTimeAsync(300);
+    emitWorkStatusChanged();
+    await vi.advanceTimersByTimeAsync(300);
+    expect(signals[1]?.aborted).toBe(false);
+    expect(workStatusQueryFn).toHaveBeenCalledTimes(2);
+
+    // The probe lands; the coalesced changes fire one trailing refetch, no
+    // sooner than one second after the previous run.
+    resolveFetches[1]?.(null);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(workStatusQueryFn).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(400);
+    expect(workStatusQueryFn).toHaveBeenCalledTimes(3);
+    resolveFetches[2]?.(null);
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(workStatusQueryFn).toHaveBeenCalledTimes(3);
+
     unsubscribeWorkStatus();
     effects.dispose();
   });

--- a/apps/app/src/hooks/realtime-cache-effects.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.ts
@@ -16,6 +16,7 @@ import {
 import { createBufferedEnvironmentInvalidator } from "./buffered-environment-invalidator";
 import {
   collectCachedThreadIdsForEnvironment,
+  createFlushOncePredicate,
   disposeTrailingActiveRefetches,
   executeRealtimeDirtyHandlers,
   REALTIME_ENVIRONMENT_CHANGE_REGISTRY,
@@ -138,11 +139,13 @@ function flushThreadInvalidations(
   queryClient: QueryClient,
   state: ThreadChangeState,
 ): void {
+  const flushOnce = createFlushOncePredicate();
   for (const changeKind of state.globalChangeKinds) {
     executeRealtimeDirtyHandlers({
       context: {
         backgroundActivityChanged: undefined,
         eventTypes: undefined,
+        flushOnce,
         hasPendingInteraction: undefined,
         projectId: undefined,
         queryClient,
@@ -158,8 +161,9 @@ function flushThreadInvalidations(
       executeRealtimeDirtyHandlers({
         context: {
           backgroundActivityChanged: metadata?.backgroundActivityChanged,
-          hasPendingInteraction: metadata?.hasPendingInteraction,
           eventTypes: metadata?.eventTypes,
+          flushOnce,
+          hasPendingInteraction: metadata?.hasPendingInteraction,
           projectId: metadata?.projectId,
           queryClient,
           threadId,


### PR DESCRIPTION
## What was wrong

Realtime and query policies on the client did more network and git work than the UI needed, which is expensive on phones and through bb connect:

- `work-status-changed` fired on every file-change burst. It refetched (and aborted) the in-flight `git status` probe every flush and also refetched the pull request, which a local edit cannot change. The PR query itself refetched on every focus (`"always"`) and polled every 5 s while checks were pending; each lookup spawns `gh pr view`.
- The root-compose branch list (a daemon git RPC) went stale after 5 s and refetched on every foreground.
- After a send succeeded, the client prepended the prompt-history entry locally and then invalidated the same query; it also refetched default execution options that consumers read only as initial values, and a queued send refetched thread detail although `queue-changed` arrives over realtime.
- Every `events-appended` flush from any thread invalidated (cancelling) the open thread search and ran the timeline pacing machinery for threads nobody was viewing.
- Every status/title/environment change refetched every open archived settings page (100-row un-windowed pages).

## What changed

- PR query: `refetchOnWindowFocus: true`, 30 s pending-check poll, PR key dropped from the work-status handler. `turn/completed` and the poll keep it current.
- Branch list: `REALTIME_OWNED_NO_FOCUS_QUERY_POLICY` + 30 s stale; picker open still refetches. Removed the now-unused `FAST_FOCUS_OWNED_LIVE_QUERY_POLICY`.
- Work status: marked stale immediately, active observers refetched at most once per second per environment with `cancelRefetch: false`; changes inside the interval coalesce into one trailing refetch; timers cleared on dispose.
- Send success: prompt history is prepended locally on both paths, default-exec marked stale with `refetchType: "none"`, queued sends refetch only the queue list while realtime is connected. History rewrites still refetch prompt history explicitly.
- Search: goes stale only when a batch contains `turn/completed`, once per flush (`flushOnce` on `ThreadRealtimeDirtyContext`), with `cancelRefetch: false`.
- Timelines without an active observer are only marked stale (`refetchType: "none"`).
- Archived list keys are marked stale, not refetched, by status/title/environment handlers (`dirtyActiveThreadListQueries`); `archived-changed` still refetches. Archived page size 100 -> 50.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/app` and `pnpm exec turbo run lint --filter=@bb/app` pass (lint: 0 errors, pre-existing warnings only).
- New tests fail on `origin/main` and pass on this branch (verified by stashing the source changes):
  - `apps/app/src/hooks/realtime-cache-effects.test.ts`: search invalidated only on turn/completed; once per flush without aborting the in-flight search; unviewed timeline marked stale with `refetchType: "none"` while the viewed one refetches; archived lists not refetched on status/title but refetched on archived-changed; PR not refetched on work-status-changed; work-status refetch paced to one per second without aborting the probe.
  - `apps/app/src/hooks/cache-owners/thread-runtime-cache-owner.test.ts`: accepted send keeps prompt history local and only marks default-exec stale; queued send refetches only the queue list.
  - `apps/app/src/hooks/queries/project-queries.test.tsx`: branch list has no focus refetch and 30 s stale.
  - `apps/app/src/hooks/queries/environment-queries.test.tsx`: updated for `refetchOnWindowFocus: true` and 30 s poll.
- `pnpm exec turbo run test --filter=@bb/app -- src/hooks src/components/settings src/views/thread-detail src/components/thread/timeline src/components/promptbox src/lib/query-client`: 134 files, 1018 tests pass.

Fixes: part of the mobile / iOS Safari performance program (verified sweep report in the bb thread; no single issue).


## Stack context

Layer 3 of 22 in the `bb/mobile-perf/*` stack (bottom → top: quick wins first, big rocks last).
- Prerequisite (layer below): `bb/mobile-perf/secondary-panel-gating` (#1881).
- Next layer: `bb/mobile-perf/ws-liveness-and-resume` (#1883).
- Audit findings addressed: see title IDs. Review: approved-with-fixes; 1 review fix commit(s).
- Reviewer notes / follow-ups: Client-side only: the PR query is no longer refreshed by any realtime signal other than turn/completed (git-refs-changed does not touch it, and it never did). A PR created/pushed f | Archived settings pages go stale (not refetched) on status/title/environment changes until the settings route remounts or a focus refetch; archived-changed still refetches. Accepte | K5 is a leading-edge throttle with a coalesced trailing refetch (first change after a quiet period refetches immediately) rather than a pure 1 s debounce; the trailing refetch sche
- Wire/contract: None. All changes are client-side (apps/app) query policy and cache-invalidation behavior; no server routes, host daemon RPCs, WebSocket messages, or session payloads changed, so HOST_DAEMON_PROTOCOL_VERSION is unchanged.

> AGENT GENERATED: by Claude Opus 5

