### PR TITLE
Cut per-thread-open requests behind the surfaces that need them (B9-B13, B16, C5)

### DIFF
--- a/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
+++ b/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
@@ -12,7 +12,7 @@
 import { useEffect, type ReactNode } from "react";
 import { Provider } from "jotai";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { PERSONAL_PROJECT_ID } from "@bb/domain";
+import { PERSONAL_PROJECT_ID, type ThreadListEntry } from "@bb/domain";
 import {
   act,
   cleanup,
@@ -36,6 +36,7 @@ import { encodeReuseValue } from "@/components/pickers/environment-picker-value"
 import { useRootComposeReuseEnvironment } from "@/lib/root-compose-selection";
 import { getPromptDraftAccessor } from "@/hooks/usePromptDraftStorage";
 import { buildThreadHandoffLocationState } from "@/lib/thread-handoff-request";
+import { makeThreadListEntry } from "@/test/fixtures/thread-list-entries";
 import { RootComposeView } from "@/views/RootComposeView";
 import { PluginNewThreadComposer } from "./PluginNewThreadComposer";
 
@@ -43,7 +44,7 @@ const mocks = vi.hoisted(() => ({
   promptBoxProps: [] as Array<Record<string, any>>,
   copyAttachments: vi.fn(),
   uploadAttachment: vi.fn(),
-  threadsLoading: false,
+  projectThreads: [] as ThreadListEntry[],
 }));
 
 vi.mock("@/components/promptbox/NewThreadPromptBox", () => ({
@@ -94,7 +95,7 @@ const OTHER_PROJECT = {
 vi.mock("@/hooks/queries/sidebar-navigation-query", () => ({
   useSidebarNavigation: () => ({
     data: {
-      projects: [PROJECT, OTHER_PROJECT],
+      projects: [{ ...PROJECT, threads: mocks.projectThreads }, OTHER_PROJECT],
       personalProject: {
         id: "personal",
         name: "Personal",
@@ -103,6 +104,7 @@ vi.mock("@/hooks/queries/sidebar-navigation-query", () => ({
       },
     },
     isError: false,
+    isLoading: false,
     isSuccess: true,
   }),
 }));
@@ -174,7 +176,6 @@ vi.mock("@/hooks/queries/system-queries", () => ({
 }));
 
 vi.mock("@/hooks/queries/thread-queries", () => ({
-  useThreads: () => ({ data: [], isLoading: mocks.threadsLoading }),
   useThreadStorageFiles: () => ({
     data: undefined,
     error: null,
@@ -370,7 +371,7 @@ describe("PluginNewThreadComposer seeding", () => {
     mocks.promptBoxProps.length = 0;
     mocks.copyAttachments.mockReset();
     mocks.uploadAttachment.mockReset();
-    mocks.threadsLoading = false;
+    mocks.projectThreads = [];
     window.localStorage.clear();
     getPromptDraftAccessor({ kind: "new-thread" }).setDraft({
       text: "",
@@ -659,8 +660,21 @@ describe("PluginNewThreadComposer seeding", () => {
     );
   });
 
-  it("submits a fork with its seeded environment while reuse options load", async () => {
-    mocks.threadsLoading = true;
+  it("derives reuse options from the sidebar bootstrap so a fork keeps its seeded worktree", async () => {
+    // No separate `GET /threads?projectId=` backs the worktree picker: the
+    // sidebar bootstrap rows are the source, so the seeded reuse environment
+    // resolves as soon as the bootstrap holds the source thread.
+    mocks.projectThreads = [
+      makeThreadListEntry({
+        id: "thr_source",
+        projectId: "proj_1",
+        environmentId: "env-source",
+        environmentHostId: "host_1",
+        environmentName: "source",
+        environmentBranchName: "feature/source",
+        environmentWorkspaceDisplayKind: "managed-worktree",
+      }),
+    ];
     const submitted: NewThreadRequest[] = [];
     render(
       <Provider>

--- a/apps/app/src/components/promptbox/NewThreadComposer.tsx
+++ b/apps/app/src/components/promptbox/NewThreadComposer.tsx
@@ -47,7 +47,6 @@ import {
 } from "@/hooks/queries/project-queries";
 import { useSidebarNavigation } from "@/hooks/queries/sidebar-navigation-query";
 import { useSystemConfig } from "@/hooks/queries/system-queries";
-import { useThreads } from "@/hooks/queries/thread-queries";
 import { useCommandSuggestions } from "@/hooks/useCommandSuggestions";
 import {
   usePromptDraftStorage,
@@ -58,6 +57,7 @@ import { useThreadCreationOptions } from "@/hooks/useThreadCreationOptions";
 import { useComposerTextEffects } from "@/lib/composer-text-effects";
 import { getMutationErrorMessage } from "@/lib/mutation-errors";
 import { promptHistoryEntriesToDrafts } from "@/lib/prompt-history";
+import { usePromptHistoryEnabled } from "@/hooks/usePromptHistoryEnabled";
 import {
   arePromptDraftStatesEqual,
   getProjectStoredPromptAttachmentPaths,
@@ -373,14 +373,22 @@ export function NewThreadComposer({
       ? null
       : new Map(hosts.map((host) => [host.id, host.name]));
   }, [hostsQuery.data]);
-  const threadsQuery = useThreads(
-    { projectId, archived: false },
-    { enabled: Boolean(projectId) },
-  );
+  // The sidebar bootstrap already carries every unarchived thread of the
+  // selected project (`projectId` always resolves to a project in it once it
+  // has loaded), so the worktree-reuse options derive from that cache instead
+  // of a second, refetch-prone `GET /threads?projectId=` per composer mount.
+  const projectThreads = useMemo(() => {
+    const navigation = sidebarNavigationQuery.data;
+    if (!navigation) return undefined;
+    if (isProjectless) return navigation.personalProject.threads;
+    return navigation.projects.find((project) => project.id === projectId)
+      ?.threads;
+  }, [isProjectless, projectId, sidebarNavigationQuery.data]);
+  const reuseThreadOptionsLoading =
+    projectThreads === undefined && sidebarNavigationQuery.isLoading;
   const reuseThreadOptions = useMemo(
-    () =>
-      buildReuseThreadOptions(threadsQuery.data ?? [], worktreeHostNameById),
-    [threadsQuery.data, worktreeHostNameById],
+    () => buildReuseThreadOptions(projectThreads ?? [], worktreeHostNameById),
+    [projectThreads, worktreeHostNameById],
   );
 
   const seedSignature = JSON.stringify([
@@ -415,7 +423,7 @@ export function NewThreadComposer({
         primaryHostId,
         projectSources,
         reuseThreadOptions,
-        reuseThreadOptionsLoading: threadsQuery.isLoading,
+        reuseThreadOptionsLoading,
       }),
     [
       isProjectless,
@@ -423,7 +431,7 @@ export function NewThreadComposer({
       primaryHostId,
       projectSources,
       reuseThreadOptions,
-      threadsQuery.isLoading,
+      reuseThreadOptionsLoading,
     ],
   );
   const projectDefaultsQuery = useProjectDefaultExecutionOptions(
@@ -546,7 +554,7 @@ export function NewThreadComposer({
         primaryHostId,
         projectSources,
         reuseThreadOptions,
-        reuseThreadOptionsLoading: threadsQuery.isLoading,
+        reuseThreadOptionsLoading,
       }),
     [
       environmentSelectionValue,
@@ -555,7 +563,7 @@ export function NewThreadComposer({
       primaryHostId,
       projectSources,
       reuseThreadOptions,
-      threadsQuery.isLoading,
+      reuseThreadOptionsLoading,
     ],
   );
   const parsedEnvironment = useMemo(
@@ -879,6 +887,10 @@ export function NewThreadComposer({
     [navigate, projectId],
   );
   const [commandQuery, setCommandQuery] = useState<string | null>(null);
+  const [hasComposerFocused, setHasComposerFocused] = useState(false);
+  const handleEditorFocus = useCallback(() => {
+    setHasComposerFocused(true);
+  }, []);
   const providerPromptActions = useMemo(
     () => buildProviderPromptActionProps(selectedProviderComposerActions),
     [selectedProviderComposerActions],
@@ -896,9 +908,13 @@ export function NewThreadComposer({
     environmentId: reuseEnvironmentId,
     hostId: projectHostId,
     query: commandQuery,
+    composerFocused: hasComposerFocused,
   });
-  const { data: projectPromptHistory = [] } =
-    useProjectPromptHistory(projectId);
+  const promptHistoryEnabled = usePromptHistoryEnabled();
+  const { data: projectPromptHistory = [] } = useProjectPromptHistory(
+    projectId,
+    { enabled: promptHistoryEnabled },
+  );
   const promptHistoryDrafts = useMemo(
     () => promptHistoryEntriesToDrafts(projectPromptHistory),
     [projectPromptHistory],
@@ -1160,6 +1176,7 @@ export function NewThreadComposer({
               isLoadingMore: commandSuggestions.isLoadingMore,
               loadMore: commandSuggestions.loadMore,
               onQueryChange: setCommandQuery,
+              onEditorFocus: handleEditorFocus,
             },
           }}
           attachments={{

--- a/apps/app/src/components/promptbox/NewThreadComposer.tsx
+++ b/apps/app/src/components/promptbox/NewThreadComposer.tsx
@@ -1318,6 +1318,7 @@ export function NewThreadComposer({
       handleClearBranch,
       handleCreateBranch,
       handleCreateBranchFrom,
+      handleEditorFocus,
       handleModelChange,
       handlePermissionChange,
       handleProjectChange,

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -260,6 +260,11 @@ export interface TypeaheadCommandConfig {
   loadMore: () => void;
   /** Called whenever the active command query changes; null when no command trigger is active. */
   onQueryChange: (query: string | null) => void;
+  /**
+   * Called when the editor gains focus. Hosts use it to warm the command
+   * catalog before the first trigger char (see `useCommandSuggestions`).
+   */
+  onEditorFocus?: () => void;
 }
 
 /**
@@ -1189,7 +1194,12 @@ export function PromptBoxInternal({
     isLoading: commandLoading,
     isError: commandError,
     onQueryChange: onCommandQueryChange,
+    onEditorFocus: onCommandEditorFocus,
   } = typeahead.command;
+  const onCommandEditorFocusRef = useRef(onCommandEditorFocus);
+  useEffect(() => {
+    onCommandEditorFocusRef.current = onCommandEditorFocus;
+  }, [onCommandEditorFocus]);
   const {
     items: attachments = [],
     isAttaching = false,
@@ -1697,6 +1707,10 @@ export function PromptBoxInternal({
         handleDOMEvents: {
           auxclick: (_view, event) => {
             return suppressPromptEditorAnchorActivation(event);
+          },
+          focus: () => {
+            onCommandEditorFocusRef.current?.();
+            return false;
           },
           blur: () => {
             triggerKeyRef.current = "";

--- a/apps/app/src/components/secondary-panel/useThreadStorageViewer.test.ts
+++ b/apps/app/src/components/secondary-panel/useThreadStorageViewer.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { shouldLoadThreadStorageFileList } from "./useThreadStorageViewer";
+
+describe("shouldLoadThreadStorageFileList", () => {
+  it("does not load the storage list on a plain thread open", () => {
+    expect(
+      shouldLoadThreadStorageFileList({
+        hasThread: true,
+        isSecondaryPanelOpen: false,
+        secondaryTabs: [{ kind: "terminal" }, { kind: "host-file-preview" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("loads once the secondary panel opens", () => {
+    expect(
+      shouldLoadThreadStorageFileList({
+        hasThread: true,
+        isSecondaryPanelOpen: true,
+        secondaryTabs: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("loads while a storage tab exists so tab pruning keeps working", () => {
+    expect(
+      shouldLoadThreadStorageFileList({
+        hasThread: true,
+        isSecondaryPanelOpen: false,
+        secondaryTabs: [{ kind: "thread-storage-file-preview" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("never loads without a thread", () => {
+    expect(
+      shouldLoadThreadStorageFileList({
+        hasThread: false,
+        isSecondaryPanelOpen: true,
+        secondaryTabs: [{ kind: "thread-storage-file-preview" }],
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/app/src/components/secondary-panel/useThreadStorageViewer.ts
+++ b/apps/app/src/components/secondary-panel/useThreadStorageViewer.ts
@@ -1,3 +1,4 @@
+import type { FixedPanelTab } from "@/lib/fixed-panel-tabs-state";
 import {
   DEFAULT_THREAD_STORAGE_FILE_LIST_OPTIONS,
   type ThreadStorageFileListOptions,
@@ -49,4 +50,31 @@ export function useThreadStorageViewer({
     threadStorageRootPath: threadStorageFiles?.storageRootPath ?? null,
     refetchThreadStorageFiles,
   };
+}
+
+interface ShouldLoadThreadStorageFileListArgs {
+  hasThread: boolean;
+  isSecondaryPanelOpen: boolean;
+  secondaryTabs: readonly Pick<FixedPanelTab, "kind">[];
+}
+
+/**
+ * The thread storage file list (`host.list_files`, up to 1000 rows) only feeds
+ * secondary-panel surfaces: the storage browser, storage-tab pruning, and
+ * local-file link resolution (which refetches on demand). It therefore loads
+ * once the panel is open or a storage tab already exists, not on every thread
+ * open, remount, or reconnect.
+ */
+export function shouldLoadThreadStorageFileList({
+  hasThread,
+  isSecondaryPanelOpen,
+  secondaryTabs,
+}: ShouldLoadThreadStorageFileListArgs): boolean {
+  if (!hasThread) {
+    return false;
+  }
+  return (
+    isSecondaryPanelOpen ||
+    secondaryTabs.some((tab) => tab.kind === "thread-storage-file-preview")
+  );
 }

--- a/apps/app/src/components/thread/embedded-chat/useComposerTypeahead.ts
+++ b/apps/app/src/components/thread/embedded-chat/useComposerTypeahead.ts
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { TypeaheadConfig } from "@/components/promptbox/PromptBoxInternal";
 import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
 import type { PromptBoxAction } from "@/components/promptbox/PromptBoxActionsMenu";
@@ -50,6 +50,10 @@ export function useComposerTypeahead({
     threadStorageThreadId: currentThreadId,
   });
   const [commandQuery, setCommandQuery] = useState<string | null>(null);
+  const [hasComposerFocused, setHasComposerFocused] = useState(false);
+  const handleEditorFocus = useCallback(() => {
+    setHasComposerFocused(true);
+  }, []);
   const providerPromptActions = useMemo(
     () => buildProviderPromptActionProps(selectedProviderComposerActions ?? []),
     [selectedProviderComposerActions],
@@ -66,6 +70,7 @@ export function useComposerTypeahead({
     promptActions,
     environmentId,
     query: commandQuery,
+    composerFocused: hasComposerFocused,
   });
 
   const typeaheadConfig = useMemo<TypeaheadConfig>(
@@ -87,6 +92,7 @@ export function useComposerTypeahead({
         isLoadingMore: commandSuggestions.isLoadingMore,
         loadMore: commandSuggestions.loadMore,
         onQueryChange: setCommandQuery,
+        onEditorFocus: handleEditorFocus,
       },
     }),
     [
@@ -97,6 +103,7 @@ export function useComposerTypeahead({
       commandSuggestions.loadMore,
       commandSuggestions.suggestions,
       commandSuggestions.trigger,
+      handleEditorFocus,
       promptMentions.isError,
       promptMentions.isLoading,
       promptMentions.setQuery,

--- a/apps/app/src/hooks/cache-owners/query-cache.ts
+++ b/apps/app/src/hooks/cache-owners/query-cache.ts
@@ -344,6 +344,20 @@ export function applyToCachedThreadListsAndSidebarNavigation(
   });
 }
 
+/**
+ * Every thread row the sidebar bootstrap carries, across every project plus
+ * the personal project. The bootstrap lists all visible, unarchived threads
+ * (children included), so this is the complete live thread set.
+ */
+export function listSidebarNavigationThreads(
+  navigation: SidebarBootstrapResponse,
+): ThreadListEntry[] {
+  return [
+    ...navigation.projects.flatMap((project) => project.threads),
+    ...navigation.personalProject.threads,
+  ];
+}
+
 export function getCachedSidebarNavigationThreads(
   queryClient: QueryClient,
 ): ThreadListEntry[] {
@@ -353,10 +367,7 @@ export function getCachedSidebarNavigationThreads(
   if (!navigation) {
     return [];
   }
-  return [
-    ...navigation.projects.flatMap((project) => project.threads),
-    ...navigation.personalProject.threads,
-  ];
+  return listSidebarNavigationThreads(navigation);
 }
 
 export function snapshotCachedSidebarNavigation(

--- a/apps/app/src/hooks/queries/project-queries.ts
+++ b/apps/app/src/hooks/queries/project-queries.ts
@@ -52,7 +52,7 @@ interface UseProjectPathSuggestionsArgs {
   includeDirectories: boolean;
 }
 
-interface UseProjectCommandsArgs {
+export interface UseProjectCommandsArgs {
   projectId: string | undefined;
   providerId: string | undefined;
   environmentId: string | null;
@@ -282,6 +282,28 @@ export function useProjectFilePreview(
  * mentions, the command list is enabled even with an empty query (commands show
  * the full list on `/`); the caller gates fetching via `options.enabled`.
  */
+export function projectCommandsQueryOptions(args: UseProjectCommandsArgs) {
+  return {
+    queryKey: projectCommandsQueryKey(
+      args.projectId,
+      args.providerId,
+      args.environmentId,
+      args.hostId,
+    ),
+    queryFn: ({ signal }: { signal: AbortSignal }) =>
+      sdk.projects.commands({
+        projectId: requireProjectId(args.projectId, "useProjectCommands"),
+        provider: requireProviderId(args.providerId, "useProjectCommands"),
+        signal,
+        ...(args.environmentId !== null
+          ? { environmentId: args.environmentId }
+          : args.hostId !== null
+            ? { hostId: args.hostId }
+            : {}),
+      }),
+  };
+}
+
 export function useProjectCommands(
   args: UseProjectCommandsArgs,
   options?: QueryOptions,
@@ -293,23 +315,7 @@ export function useProjectCommands(
   useProjectDetailRealtimeSubscription(args.projectId, { enabled });
 
   return useQuery<CommandListResponse>({
-    queryKey: projectCommandsQueryKey(
-      args.projectId,
-      args.providerId,
-      args.environmentId,
-      args.hostId,
-    ),
-    queryFn: ({ signal }) =>
-      sdk.projects.commands({
-        projectId: requireProjectId(args.projectId, "useProjectCommands"),
-        provider: requireProviderId(args.providerId, "useProjectCommands"),
-        signal,
-        ...(args.environmentId !== null
-          ? { environmentId: args.environmentId }
-          : args.hostId !== null
-            ? { hostId: args.hostId }
-            : {}),
-      }),
+    ...projectCommandsQueryOptions(args),
     enabled,
     ...TYPEAHEAD_QUERY_POLICY,
     // Reopening the slash menu refreshes provider-native files that may have

--- a/apps/app/src/hooks/queries/sidebar-navigation-query.ts
+++ b/apps/app/src/hooks/queries/sidebar-navigation-query.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useCallback } from "react";
 import { PERSONAL_PROJECT_ID, type ThreadListEntry } from "@bb/domain";
 import type { SidebarBootstrapResponse } from "@bb/server-contract";
 import { listSidebarNavigationThreads } from "@/hooks/cache-owners/query-cache";
@@ -77,25 +77,51 @@ export function useProjectDisplayName(
   return data.projects.find((project) => project.id === projectId)?.name;
 }
 
+export interface SidebarNavigationThreadSelection<T> {
+  /** `select` applied to every thread row in the cache, or `undefined` while it holds nothing. */
+  data: T | undefined;
+  /**
+   * `true` while the cache is empty but the app shell's bootstrap request is
+   * in flight. Derived surfaces should wait for it rather than issue their own
+   * targeted list request on a cold open (a deep link races the bootstrap).
+   * Stays `false` when nothing is fetching the bootstrap or it already failed,
+   * so surfaces mounted without the shell still get their network fallback.
+   */
+  isBootstrapPending: boolean;
+}
+
 /**
- * Live view of every thread row in the sidebar-navigation cache, or
- * `undefined` while the bootstrap has not loaded. This is a read-only observer:
- * it never triggers the bootstrap fetch itself (the app shell owns that and the
- * realtime subscriptions), it only re-renders when the cached payload changes.
- * Thread-list surfaces that used to issue their own `GET /threads` can derive
- * from this instead and keep a network fallback for the `undefined` case.
+ * Live selection over every thread row in the sidebar-navigation cache. This
+ * is a read-only observer: it never triggers the bootstrap fetch itself (the
+ * app shell owns that and the realtime subscriptions). Thread-list surfaces
+ * that used to issue their own `GET /threads` can derive from this instead and
+ * keep a network fallback for the `undefined` case.
+ *
+ * The bootstrap payload changes on every sidebar patch (any thread's status,
+ * title, or unread badge), so callers pass a memoized `select` and only
+ * re-render when its structurally-shared result changes, not on every patch.
  */
-export function useSidebarNavigationThreadsFromCache():
-  | ThreadListEntry[]
-  | undefined {
-  const { data } = useQuery<SidebarBootstrapResponse>({
+export function useSidebarNavigationThreadSelection<T>(
+  select: (threads: ThreadListEntry[]) => T,
+): SidebarNavigationThreadSelection<T> {
+  const selectFromNavigation = useCallback(
+    (navigation: SidebarBootstrapResponse) =>
+      select(listSidebarNavigationThreads(navigation)),
+    [select],
+  );
+  const result = useQuery<SidebarBootstrapResponse, Error, T>({
     queryKey: sidebarNavigationQueryKey(),
     queryFn: ({ signal }) => fetchSidebarNavigation(signal),
     ...REALTIME_OWNED_STATIC_CACHE_QUERY_POLICY,
     enabled: false,
+    select: selectFromNavigation,
   });
-  return useMemo(
-    () => (data ? listSidebarNavigationThreads(data) : undefined),
-    [data],
-  );
+  const data = result.data;
+  // Only read `isFetching` while there is nothing to derive from: react-query
+  // tracks accessed fields, so a populated cache does not re-render callers on
+  // every bootstrap refetch.
+  return {
+    data,
+    isBootstrapPending: data === undefined && result.isFetching,
+  };
 }

--- a/apps/app/src/hooks/queries/sidebar-navigation-query.ts
+++ b/apps/app/src/hooks/queries/sidebar-navigation-query.ts
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
-import { PERSONAL_PROJECT_ID } from "@bb/domain";
+import { useMemo } from "react";
+import { PERSONAL_PROJECT_ID, type ThreadListEntry } from "@bb/domain";
 import type { SidebarBootstrapResponse } from "@bb/server-contract";
+import { listSidebarNavigationThreads } from "@/hooks/cache-owners/query-cache";
 import { apiClient } from "@/lib/api-server";
 import { request, requestOptions } from "@/lib/api";
 import {
@@ -73,4 +75,27 @@ export function useProjectDisplayName(
     return data.personalProject.name;
   }
   return data.projects.find((project) => project.id === projectId)?.name;
+}
+
+/**
+ * Live view of every thread row in the sidebar-navigation cache, or
+ * `undefined` while the bootstrap has not loaded. This is a read-only observer:
+ * it never triggers the bootstrap fetch itself (the app shell owns that and the
+ * realtime subscriptions), it only re-renders when the cached payload changes.
+ * Thread-list surfaces that used to issue their own `GET /threads` can derive
+ * from this instead and keep a network fallback for the `undefined` case.
+ */
+export function useSidebarNavigationThreadsFromCache():
+  | ThreadListEntry[]
+  | undefined {
+  const { data } = useQuery<SidebarBootstrapResponse>({
+    queryKey: sidebarNavigationQueryKey(),
+    queryFn: ({ signal }) => fetchSidebarNavigation(signal),
+    ...REALTIME_OWNED_STATIC_CACHE_QUERY_POLICY,
+    enabled: false,
+  });
+  return useMemo(
+    () => (data ? listSidebarNavigationThreads(data) : undefined),
+    [data],
+  );
 }

--- a/apps/app/src/hooks/queries/thread-queries.test.tsx
+++ b/apps/app/src/hooks/queries/thread-queries.test.tsx
@@ -1,16 +1,21 @@
 // @vitest-environment jsdom
 
-import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ThreadListEntry } from "@bb/domain";
 import type {
+  SidebarBootstrapResponse,
   ThreadTimelineResponse,
   ThreadWithIncludesResponse,
 } from "@bb/server-contract";
+import { COMPACT_VIEWPORT_QUERY } from "@bb/shared-ui/hooks/use-compact-viewport";
 import * as api from "@/lib/api";
 import { sdk } from "@/lib/sdk";
+import { makeThreadListEntry } from "@/test/fixtures/thread-list-entries";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { ARCHIVED_THREADS_PAGE_SIZE } from "./archived-threads-page-size";
 import {
+  sidebarNavigationQueryKey,
   threadDetailBootstrapQueryKey,
   threadHostFilePreviewQueryKey,
   threadQueuedMessagesQueryKey,
@@ -18,12 +23,16 @@ import {
   threadTimelineQueryKey,
 } from "./query-keys";
 import {
+  COMPACT_THREAD_TIMELINE_SEGMENT_LIMIT,
   didThreadDetailBootstrapRefreshAfterMount,
   useArchivedThreads,
+  useChildThreads,
   useThread,
   useThreadDetailBootstrap,
   useThreadHostFilePreview,
+  useThreadMentionCandidates,
   useThreadQueuedMessages,
+  useThreadTimeline,
 } from "./thread-queries";
 
 vi.mock("@/lib/api", async (importOriginal) => {
@@ -81,9 +90,56 @@ const THREAD_WITH_INCLUDES = {
   host: null,
 } satisfies ThreadWithIncludesResponse;
 
+function makeSidebarNavigation(
+  projectThreads: ThreadListEntry[],
+  personalThreads: ThreadListEntry[] = [],
+): SidebarBootstrapResponse {
+  return {
+    sections: [],
+    projects: [
+      {
+        id: "project-1",
+        kind: "standard",
+        name: "Project",
+        gitRemoteUrl: null,
+        createdAt: 1,
+        updatedAt: 1,
+        sources: [],
+        threads: projectThreads,
+        defaultExecutionOptions: null,
+      },
+    ],
+    personalProject: {
+      id: "proj_personal",
+      kind: "personal",
+      name: "Personal",
+      gitRemoteUrl: null,
+      createdAt: 1,
+      updatedAt: 1,
+      sources: [],
+      threads: personalThreads,
+      defaultExecutionOptions: null,
+    },
+  };
+}
+
+function mockMatchMedia(matching: readonly string[]) {
+  vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
+    matches: matching.includes(query),
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }));
+}
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  vi.restoreAllMocks();
 });
 
 beforeEach(() => {
@@ -408,5 +464,189 @@ describe("useThreadHostFilePreview", () => {
         refetchOnWindowFocus: true,
       }),
     );
+  });
+});
+
+describe("useChildThreads", () => {
+  it("derives children from the sidebar cache across projects without a list request", async () => {
+    const { queryClient, wrapper } = createQueryClientTestHarness();
+    const projectChild = makeThreadListEntry({
+      id: "child-1",
+      projectId: "project-1",
+      parentThreadId: "parent-1",
+    });
+    const personalChild = makeThreadListEntry({
+      id: "child-2",
+      projectId: "proj_personal",
+      parentThreadId: "parent-1",
+    });
+    const hiddenChild = makeThreadListEntry({
+      id: "child-hidden",
+      parentThreadId: "parent-1",
+      visibility: "hidden",
+    });
+    const otherChild = makeThreadListEntry({
+      id: "child-other",
+      parentThreadId: "parent-2",
+    });
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      makeSidebarNavigation(
+        [projectChild, hiddenChild, otherChild],
+        [personalChild],
+      ),
+    );
+
+    const { result } = renderHook(
+      () => useChildThreads({ enabled: true, parentThreadId: "parent-1" }),
+      { wrapper },
+    );
+
+    expect(result.current.data?.map((thread) => thread.id)).toEqual([
+      "child-1",
+      "child-2",
+    ]);
+    expect(result.current.isLoading).toBe(false);
+    expect(sdk.threads.list).not.toHaveBeenCalled();
+
+    // Realtime updates land in the sidebar cache and flow through.
+    const newChild = makeThreadListEntry({
+      id: "child-3",
+      parentThreadId: "parent-1",
+    });
+    act(() => {
+      queryClient.setQueryData(
+        sidebarNavigationQueryKey(),
+        makeSidebarNavigation([projectChild, newChild], [personalChild]),
+      );
+    });
+    await waitFor(() => {
+      expect(result.current.data?.map((thread) => thread.id)).toEqual([
+        "child-1",
+        "child-3",
+        "child-2",
+      ]);
+    });
+    expect(sdk.threads.list).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the parent-keyed list request without a sidebar cache", async () => {
+    const { wrapper } = createQueryClientTestHarness();
+    const child = makeThreadListEntry({
+      id: "child-1",
+      parentThreadId: "parent-1",
+    });
+    vi.mocked(sdk.threads.list).mockResolvedValue([child]);
+
+    const { result } = renderHook(
+      () => useChildThreads({ enabled: true, parentThreadId: "parent-1" }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([child]);
+    });
+    expect(sdk.threads.list).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(sdk.threads.list).mock.calls[0]?.[0]).toEqual({
+      archived: false,
+      parentThreadId: "parent-1",
+      signal: expect.any(AbortSignal),
+    });
+  });
+});
+
+describe("useThreadMentionCandidates", () => {
+  it("serves candidates from the sidebar cache without a list request", () => {
+    const { queryClient, wrapper } = createQueryClientTestHarness();
+    const visible = makeThreadListEntry({ id: "thread-visible" });
+    const hidden = makeThreadListEntry({
+      id: "thread-hidden",
+      visibility: "hidden",
+    });
+    const personal = makeThreadListEntry({
+      id: "thread-personal",
+      projectId: "proj_personal",
+    });
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      makeSidebarNavigation([visible, hidden], [personal]),
+    );
+
+    const { result } = renderHook(
+      () => useThreadMentionCandidates({ enabled: true }),
+      { wrapper },
+    );
+
+    expect(result.current.data?.map((thread) => thread.id)).toEqual([
+      "thread-visible",
+      "thread-personal",
+    ]);
+    expect(result.current.isLoading).toBe(false);
+    expect(sdk.threads.list).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the capped list request without a sidebar cache", async () => {
+    const { wrapper } = createQueryClientTestHarness();
+    const thread = makeThreadListEntry({ id: "thread-1" });
+    vi.mocked(sdk.threads.list).mockResolvedValue([thread]);
+
+    const { result } = renderHook(
+      () => useThreadMentionCandidates({ enabled: true }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([thread]);
+    });
+    expect(vi.mocked(sdk.threads.list).mock.calls[0]?.[0]).toEqual({
+      archived: false,
+      limit: 200,
+      signal: expect.any(AbortSignal),
+    });
+  });
+});
+
+describe("useThreadTimeline segment limit", () => {
+  it("asks for the compact first window on compact viewports and keeps it for deltas", async () => {
+    mockMatchMedia([COMPACT_VIEWPORT_QUERY]);
+    const { queryClient, wrapper } = createQueryClientTestHarness();
+
+    const { result } = renderHook(() => useThreadTimeline("thread-1"), {
+      wrapper,
+    });
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(vi.mocked(sdk.threads.timeline).mock.calls[0]?.[0]).toEqual({
+      threadId: "thread-1",
+      segmentLimit: String(COMPACT_THREAD_TIMELINE_SEGMENT_LIMIT),
+      signal: expect.any(AbortSignal),
+    });
+
+    await queryClient.refetchQueries({
+      queryKey: threadTimelineQueryKey("thread-1"),
+    });
+    expect(vi.mocked(sdk.threads.timeline).mock.calls[1]?.[0]).toEqual({
+      threadId: "thread-1",
+      segmentLimit: String(COMPACT_THREAD_TIMELINE_SEGMENT_LIMIT),
+      afterSequence: "0",
+      signal: expect.any(AbortSignal),
+    });
+  });
+
+  it("keeps the server default window on wide viewports", async () => {
+    mockMatchMedia([]);
+    const { wrapper } = createQueryClientTestHarness();
+
+    const { result } = renderHook(() => useThreadTimeline("thread-1"), {
+      wrapper,
+    });
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(vi.mocked(sdk.threads.timeline).mock.calls[0]?.[0]).toEqual({
+      threadId: "thread-1",
+      signal: expect.any(AbortSignal),
+    });
   });
 });

--- a/apps/app/src/hooks/queries/thread-queries.test.tsx
+++ b/apps/app/src/hooks/queries/thread-queries.test.tsx
@@ -530,6 +530,80 @@ describe("useChildThreads", () => {
     expect(sdk.threads.list).not.toHaveBeenCalled();
   });
 
+  it("keeps the derived list stable when unrelated sidebar rows change", async () => {
+    const { queryClient, wrapper } = createQueryClientTestHarness();
+    const child = makeThreadListEntry({
+      id: "child-1",
+      parentThreadId: "parent-1",
+    });
+    const unrelated = makeThreadListEntry({ id: "other", title: "Before" });
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      makeSidebarNavigation([child, unrelated]),
+    );
+    let renders = 0;
+    const { result } = renderHook(
+      () => {
+        renders += 1;
+        return useChildThreads({ enabled: true, parentThreadId: "parent-1" });
+      },
+      { wrapper },
+    );
+    const initialData = result.current.data;
+    const initialRenders = renders;
+    expect(initialData?.map((thread) => thread.id)).toEqual(["child-1"]);
+
+    // Sidebar patches land on every status/title change of any thread; a
+    // consumer as heavy as ThreadDetailView must not re-render for them.
+    act(() => {
+      queryClient.setQueryData(
+        sidebarNavigationQueryKey(),
+        makeSidebarNavigation([child, { ...unrelated, title: "After" }]),
+      );
+    });
+    // Query notifications flush on a macrotask; let them land first.
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(result.current.data).toBe(initialData);
+    expect(renders).toBe(initialRenders);
+  });
+
+  it("waits for an in-flight sidebar bootstrap instead of racing it with a list request", async () => {
+    const { queryClient, wrapper } = createQueryClientTestHarness();
+    const child = makeThreadListEntry({
+      id: "child-1",
+      parentThreadId: "parent-1",
+    });
+    let resolveBootstrap: (value: SidebarBootstrapResponse) => void = () => {};
+    const bootstrapFetch = queryClient.prefetchQuery({
+      queryKey: sidebarNavigationQueryKey(),
+      queryFn: () =>
+        new Promise<SidebarBootstrapResponse>((resolve) => {
+          resolveBootstrap = resolve;
+        }),
+    });
+
+    const { result } = renderHook(
+      () => useChildThreads({ enabled: true, parentThreadId: "parent-1" }),
+      { wrapper },
+    );
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(true);
+    expect(sdk.threads.list).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveBootstrap(makeSidebarNavigation([child]));
+      await bootstrapFetch;
+    });
+    await waitFor(() => {
+      expect(result.current.data).toEqual([child]);
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(sdk.threads.list).not.toHaveBeenCalled();
+  });
+
   it("falls back to the parent-keyed list request without a sidebar cache", async () => {
     const { wrapper } = createQueryClientTestHarness();
     const child = makeThreadListEntry({

--- a/apps/app/src/hooks/queries/thread-queries.ts
+++ b/apps/app/src/hooks/queries/thread-queries.ts
@@ -6,6 +6,8 @@ import {
 } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 import { useDebounceValue } from "usehooks-ts";
+import { COMPACT_VIEWPORT_QUERY } from "@bb/shared-ui/hooks/use-compact-viewport";
+import { getMediaQuerySnapshot } from "@bb/shared-ui/hooks/use-media-query";
 import type { PendingInteraction, ThreadListEntry } from "@bb/domain";
 import type {
   PromptHistoryResponse,
@@ -36,6 +38,7 @@ import {
   getCachedSidebarNavigationThreads,
   getCachedThreadListPlaceholder,
 } from "../cache-owners/query-cache";
+import { useSidebarNavigationThreadsFromCache } from "./sidebar-navigation-query";
 import {
   getCachedThreadLists,
   iterateThreadListCacheEntries,
@@ -264,6 +267,17 @@ function addThreadMentionCandidate(
   }
 }
 
+function buildThreadMentionCandidates(
+  threads: readonly ThreadListItem[],
+  { limit }: { limit: number },
+): ThreadListResponse {
+  const candidatesById = new Map<string, ThreadListItem>();
+  for (const thread of threads) {
+    addThreadMentionCandidate(candidatesById, thread);
+  }
+  return Array.from(candidatesById.values()).slice(0, limit);
+}
+
 function getThreadMentionCandidatePlaceholder({
   limit,
   queryClient,
@@ -368,20 +382,35 @@ interface UseChildThreadsArgs {
   parentThreadId: string | undefined;
 }
 
+export interface UseChildThreadsResult {
+  data: ThreadListResponse | undefined;
+  isError: boolean;
+  isFetching: boolean;
+  isLoading: boolean;
+}
+
 /**
  * Live children of one parent across every project. A child may live in a
  * different project than its parent, so this list is keyed by parent only and
  * never derived from a project-scoped thread list.
+ *
+ * The sidebar bootstrap already carries every visible unarchived thread across
+ * every project, so while that cache is populated the children are derived
+ * from it (no per-thread-open `GET /threads?parentThreadId=`). The targeted
+ * list request is the fallback for surfaces mounted without the sidebar cache.
  */
 export function useChildThreads({
   enabled: enabledOption,
   parentThreadId,
-}: UseChildThreadsArgs) {
+}: UseChildThreadsArgs): UseChildThreadsResult {
   const enabled = enabledOption && Boolean(parentThreadId);
   useThreadListRealtimeSubscription({ enabled });
-  return useQuery<ThreadListResponse>({
+  const sidebarThreads = useSidebarNavigationThreadsFromCache();
+  const hasSidebarThreads = sidebarThreads !== undefined;
+  const shouldFetch = enabled && !hasSidebarThreads;
+  const fallbackQuery = useQuery<ThreadListResponse>({
     queryKey:
-      enabled && parentThreadId
+      shouldFetch && parentThreadId
         ? threadListQueryKey({ archived: false, parentThreadId })
         : disabledThreadListQueryKey({ archived: false }),
     queryFn: ({ signal }) =>
@@ -393,9 +422,30 @@ export function useChildThreads({
         ),
         signal,
       }),
-    enabled,
+    enabled: shouldFetch,
     staleTime: THREAD_LIST_STALE_TIME_MS,
   });
+  const derivedChildren = useMemo(
+    () =>
+      enabled && sidebarThreads && parentThreadId
+        ? filterProjectThreadSubset(sidebarThreads, { parentThreadId })
+        : undefined,
+    [enabled, parentThreadId, sidebarThreads],
+  );
+  if (derivedChildren !== undefined) {
+    return {
+      data: derivedChildren,
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+    };
+  }
+  return {
+    data: fallbackQuery.data,
+    isError: fallbackQuery.isError,
+    isFetching: fallbackQuery.isFetching,
+    isLoading: fallbackQuery.isLoading,
+  };
 }
 
 export function useProjectThreadSubset({
@@ -477,20 +527,28 @@ export function useProjectThreadSubset({
   };
 }
 
+/**
+ * Threads offered by the `@` mention picker. The sidebar-navigation cache
+ * already holds every visible unarchived thread, so while it is populated the
+ * candidates are derived from it and no `GET /threads?limit=200` is issued.
+ * The list request is the fallback for surfaces mounted without that cache.
+ */
 export function useThreadMentionCandidates({
   enabled: enabledOption,
 }: UseThreadMentionCandidatesArgs): UseThreadMentionCandidatesResult {
   const queryClient = useQueryClient();
   const enabled = enabledOption ?? true;
   useThreadListRealtimeSubscription({ enabled });
-  const queryKey = enabled
+  const sidebarThreads = useSidebarNavigationThreadsFromCache();
+  const shouldFetch = enabled && sidebarThreads === undefined;
+  const queryKey = shouldFetch
     ? threadListQueryKey(THREAD_MENTION_CANDIDATE_FILTERS)
     : disabledThreadListQueryKey(THREAD_MENTION_CANDIDATE_FILTERS);
   const threadsQuery = useQuery<ThreadListResponse>({
     queryKey,
     queryFn: ({ signal }) =>
       sdk.threads.list({ ...THREAD_MENTION_CANDIDATE_FILTERS, signal }),
-    enabled,
+    enabled: shouldFetch,
     placeholderData: (previousData) =>
       previousData ??
       getThreadMentionCandidatePlaceholder({
@@ -499,7 +557,24 @@ export function useThreadMentionCandidates({
       }),
     staleTime: THREAD_LIST_STALE_TIME_MS,
   });
+  const derivedCandidates = useMemo(
+    () =>
+      enabled && sidebarThreads
+        ? buildThreadMentionCandidates(sidebarThreads, {
+            limit: THREAD_MENTION_CANDIDATE_LIMIT,
+          })
+        : undefined,
+    [enabled, sidebarThreads],
+  );
 
+  if (derivedCandidates !== undefined) {
+    return {
+      data: derivedCandidates,
+      isError: false,
+      isFetching: false,
+      isLoading: false,
+    };
+  }
   return {
     data: threadsQuery.data,
     isError: threadsQuery.isError,
@@ -829,6 +904,21 @@ interface FetchThreadTimelineArgs {
   threadId: string;
 }
 
+/**
+ * First-window size requested on compact viewports. Phones show a handful of
+ * segments above the fold, so the 20-segment server default mostly ships rows
+ * the user scrolls to later (older pages still load on demand). The server
+ * keys its delta cache on the page request, so a stable per-client limit keeps
+ * `afterSequence` deltas working.
+ */
+export const COMPACT_THREAD_TIMELINE_SEGMENT_LIMIT = 8;
+
+export function resolveThreadTimelineSegmentLimit(): number | undefined {
+  return getMediaQuerySnapshot(COMPACT_VIEWPORT_QUERY)
+    ? COMPACT_THREAD_TIMELINE_SEGMENT_LIMIT
+    : undefined;
+}
+
 async function fetchThreadTimeline({
   queryClient,
   signal,
@@ -839,15 +929,19 @@ async function fetchThreadTimeline({
   // it returns the full window.
   const queryKey = threadTimelineQueryKey(threadId);
   const previous = queryClient.getQueryData<ThreadTimelineResponse>(queryKey);
+  const segmentLimit = resolveThreadTimelineSegmentLimit();
+  const pageArgs =
+    segmentLimit === undefined ? {} : { segmentLimit: String(segmentLimit) };
   const response = await sdk.threads.timeline({
     threadId,
     signal,
+    ...pageArgs,
     ...(previous?.maxSeq !== undefined
       ? { afterSequence: String(previous.maxSeq) }
       : {}),
   });
   return mergeThreadTimelineDelta(previous, response, () =>
-    sdk.threads.timeline({ threadId, signal }),
+    sdk.threads.timeline({ threadId, signal, ...pageArgs }),
   );
 }
 

--- a/apps/app/src/hooks/queries/thread-queries.ts
+++ b/apps/app/src/hooks/queries/thread-queries.ts
@@ -38,7 +38,7 @@ import {
   getCachedSidebarNavigationThreads,
   getCachedThreadListPlaceholder,
 } from "../cache-owners/query-cache";
-import { useSidebarNavigationThreadsFromCache } from "./sidebar-navigation-query";
+import { useSidebarNavigationThreadSelection } from "./sidebar-navigation-query";
 import {
   getCachedThreadLists,
   iterateThreadListCacheEntries,
@@ -278,6 +278,16 @@ function buildThreadMentionCandidates(
   return Array.from(candidatesById.values()).slice(0, limit);
 }
 
+const EMPTY_THREAD_LIST: ThreadListResponse = [];
+
+function selectThreadMentionCandidates(
+  threads: ThreadListEntry[],
+): ThreadListResponse {
+  return buildThreadMentionCandidates(threads, {
+    limit: THREAD_MENTION_CANDIDATE_LIMIT,
+  });
+}
+
 function getThreadMentionCandidatePlaceholder({
   limit,
   queryClient,
@@ -405,9 +415,19 @@ export function useChildThreads({
 }: UseChildThreadsArgs): UseChildThreadsResult {
   const enabled = enabledOption && Boolean(parentThreadId);
   useThreadListRealtimeSubscription({ enabled });
-  const sidebarThreads = useSidebarNavigationThreadsFromCache();
-  const hasSidebarThreads = sidebarThreads !== undefined;
-  const shouldFetch = enabled && !hasSidebarThreads;
+  const selectChildren = useCallback(
+    (threads: ThreadListEntry[]) =>
+      parentThreadId === undefined
+        ? EMPTY_THREAD_LIST
+        : filterProjectThreadSubset(threads, { parentThreadId }),
+    [parentThreadId],
+  );
+  const { data: sidebarChildren, isBootstrapPending } =
+    useSidebarNavigationThreadSelection(selectChildren);
+  // A cold open (deep link) mounts the thread while the app shell's bootstrap
+  // is still in flight; wait for it instead of racing it with a list request.
+  const shouldFetch =
+    enabled && sidebarChildren === undefined && !isBootstrapPending;
   const fallbackQuery = useQuery<ThreadListResponse>({
     queryKey:
       shouldFetch && parentThreadId
@@ -425,13 +445,7 @@ export function useChildThreads({
     enabled: shouldFetch,
     staleTime: THREAD_LIST_STALE_TIME_MS,
   });
-  const derivedChildren = useMemo(
-    () =>
-      enabled && sidebarThreads && parentThreadId
-        ? filterProjectThreadSubset(sidebarThreads, { parentThreadId })
-        : undefined,
-    [enabled, parentThreadId, sidebarThreads],
-  );
+  const derivedChildren = enabled ? sidebarChildren : undefined;
   if (derivedChildren !== undefined) {
     return {
       data: derivedChildren,
@@ -440,11 +454,12 @@ export function useChildThreads({
       isLoading: false,
     };
   }
+  const waitingForBootstrap = enabled && isBootstrapPending;
   return {
     data: fallbackQuery.data,
     isError: fallbackQuery.isError,
-    isFetching: fallbackQuery.isFetching,
-    isLoading: fallbackQuery.isLoading,
+    isFetching: fallbackQuery.isFetching || waitingForBootstrap,
+    isLoading: fallbackQuery.isLoading || waitingForBootstrap,
   };
 }
 
@@ -539,8 +554,10 @@ export function useThreadMentionCandidates({
   const queryClient = useQueryClient();
   const enabled = enabledOption ?? true;
   useThreadListRealtimeSubscription({ enabled });
-  const sidebarThreads = useSidebarNavigationThreadsFromCache();
-  const shouldFetch = enabled && sidebarThreads === undefined;
+  const { data: sidebarCandidates, isBootstrapPending } =
+    useSidebarNavigationThreadSelection(selectThreadMentionCandidates);
+  const shouldFetch =
+    enabled && sidebarCandidates === undefined && !isBootstrapPending;
   const queryKey = shouldFetch
     ? threadListQueryKey(THREAD_MENTION_CANDIDATE_FILTERS)
     : disabledThreadListQueryKey(THREAD_MENTION_CANDIDATE_FILTERS);
@@ -557,15 +574,7 @@ export function useThreadMentionCandidates({
       }),
     staleTime: THREAD_LIST_STALE_TIME_MS,
   });
-  const derivedCandidates = useMemo(
-    () =>
-      enabled && sidebarThreads
-        ? buildThreadMentionCandidates(sidebarThreads, {
-            limit: THREAD_MENTION_CANDIDATE_LIMIT,
-          })
-        : undefined,
-    [enabled, sidebarThreads],
-  );
+  const derivedCandidates = enabled ? sidebarCandidates : undefined;
 
   if (derivedCandidates !== undefined) {
     return {
@@ -575,11 +584,12 @@ export function useThreadMentionCandidates({
       isLoading: false,
     };
   }
+  const waitingForBootstrap = enabled && isBootstrapPending;
   return {
     data: threadsQuery.data,
     isError: threadsQuery.isError,
-    isFetching: threadsQuery.isFetching,
-    isLoading: threadsQuery.isLoading,
+    isFetching: threadsQuery.isFetching || waitingForBootstrap,
+    isLoading: threadsQuery.isLoading || waitingForBootstrap,
   };
 }
 

--- a/apps/app/src/hooks/useCommandSuggestions.prefetch.test.tsx
+++ b/apps/app/src/hooks/useCommandSuggestions.prefetch.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { POINTER_COARSE_QUERY } from "@bb/shared-ui/hooks/use-pointer-coarse";
+import { sdk } from "@/lib/sdk";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import { useCommandSuggestions } from "./useCommandSuggestions";
+
+vi.mock("@/lib/sdk", () => ({
+  sdk: {
+    projects: {
+      commands: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/hooks/useRealtimeSubscription", () => ({
+  useProjectDetailRealtimeSubscription: vi.fn(),
+}));
+
+function mockPointer(coarse: boolean) {
+  vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
+    matches: coarse && query === POINTER_COARSE_QUERY,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }));
+}
+
+const BASE_ARGS = {
+  projectId: "project-1",
+  providerId: "codex",
+  commandScope: "thread" as const,
+  skillsTrigger: "/" as const,
+  environmentId: "env-1",
+  query: null,
+};
+
+beforeEach(() => {
+  vi.mocked(sdk.projects.commands).mockResolvedValue({ commands: [] });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
+
+describe("useCommandSuggestions catalog prefetch", () => {
+  it("warms the command catalog when a coarse-pointer composer gains focus", async () => {
+    mockPointer(true);
+    const { wrapper } = createQueryClientTestHarness();
+
+    const { result, rerender } = renderHook(
+      (props: { composerFocused: boolean }) =>
+        useCommandSuggestions({ ...BASE_ARGS, ...props }),
+      { wrapper, initialProps: { composerFocused: false } },
+    );
+    expect(sdk.projects.commands).not.toHaveBeenCalled();
+
+    rerender({ composerFocused: true });
+    await waitFor(() => {
+      expect(sdk.projects.commands).toHaveBeenCalledTimes(1);
+    });
+    expect(vi.mocked(sdk.projects.commands).mock.calls[0]?.[0]).toEqual({
+      projectId: "project-1",
+      provider: "codex",
+      environmentId: "env-1",
+      signal: expect.any(AbortSignal),
+    });
+    // No trigger is active, so the prefetch stays invisible to the menu.
+    expect(result.current.suggestions).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("does not add a request for fine-pointer composers, which autofocus on mount", () => {
+    mockPointer(false);
+    const { wrapper } = createQueryClientTestHarness();
+
+    renderHook(
+      () => useCommandSuggestions({ ...BASE_ARGS, composerFocused: true }),
+      { wrapper },
+    );
+
+    expect(sdk.projects.commands).not.toHaveBeenCalled();
+  });
+
+  it("still fetches on the first trigger without any focus signal", async () => {
+    mockPointer(true);
+    const { wrapper } = createQueryClientTestHarness();
+
+    renderHook(() => useCommandSuggestions({ ...BASE_ARGS, query: "" }), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(sdk.projects.commands).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/app/src/hooks/useCommandSuggestions.ts
+++ b/apps/app/src/hooks/useCommandSuggestions.ts
@@ -215,6 +215,9 @@ export function useCommandSuggestions(
         environmentId: prefetchEnvironmentId,
         hostId: prefetchHostId,
       }),
+      // Same no-retry policy as the typeahead observer: a failed warm-up must
+      // not turn into three daemon round-trips behind the user's back.
+      retry: false,
       staleTime: COMMAND_CATALOG_PREFETCH_STALE_TIME_MS,
     });
   }, [

--- a/apps/app/src/hooks/useCommandSuggestions.ts
+++ b/apps/app/src/hooks/useCommandSuggestions.ts
@@ -1,10 +1,15 @@
-import { useMemo } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo } from "react";
 import type { PromptMentionCommandTrigger } from "@bb/domain";
+import { usePointerCoarse } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import {
   toProviderCommandSuggestion,
   type ProviderCommandSuggestion,
 } from "@/components/promptbox/mentions/types";
-import { useProjectCommands } from "./queries/project-queries";
+import {
+  projectCommandsQueryOptions,
+  useProjectCommands,
+} from "./queries/project-queries";
 
 export interface UseCommandSuggestionsArgs {
   projectId: string | undefined;
@@ -23,7 +28,18 @@ export interface UseCommandSuggestionsArgs {
   hostId?: string | null;
   /** Text typed after the trigger char, or `null` when no command trigger is active. */
   query: string | null;
+  /**
+   * `true` once the composer editor has received focus. On coarse-pointer
+   * devices that focus is a deliberate tap, so the command catalog is warmed
+   * then instead of on the first `/`, which would otherwise wait a full
+   * round-trip (a daemon `host.list_commands`) on a mobile link. Fine-pointer
+   * composers autofocus on mount, so they keep the fetch on first `/`.
+   */
+  composerFocused?: boolean;
 }
+
+/** How long a focus-time prefetch of the command catalog is reused. */
+export const COMMAND_CATALOG_PREFETCH_STALE_TIME_MS = 30_000;
 
 export interface UseCommandSuggestionsResult {
   /** The provider's command trigger char, or `null` when the feature is inert. */
@@ -176,6 +192,39 @@ export function useCommandSuggestions(
     },
     { enabled: isActive },
   );
+  const queryClient = useQueryClient();
+  const isPointerCoarse = usePointerCoarse();
+  const shouldPrefetchCatalog =
+    args.composerFocused === true &&
+    isPointerCoarse &&
+    args.projectId !== undefined &&
+    args.providerId !== undefined &&
+    trigger !== null;
+  const prefetchProjectId = args.projectId;
+  const prefetchProviderId = args.providerId;
+  const prefetchEnvironmentId = args.environmentId;
+  const prefetchHostId = args.hostId ?? null;
+  useEffect(() => {
+    if (!shouldPrefetchCatalog) {
+      return;
+    }
+    void queryClient.prefetchQuery({
+      ...projectCommandsQueryOptions({
+        projectId: prefetchProjectId,
+        providerId: prefetchProviderId,
+        environmentId: prefetchEnvironmentId,
+        hostId: prefetchHostId,
+      }),
+      staleTime: COMMAND_CATALOG_PREFETCH_STALE_TIME_MS,
+    });
+  }, [
+    prefetchEnvironmentId,
+    prefetchHostId,
+    prefetchProjectId,
+    prefetchProviderId,
+    queryClient,
+    shouldPrefetchCatalog,
+  ]);
 
   const suggestions = useMemo<ProviderCommandSuggestion[]>(() => {
     if (!isActive) {

--- a/apps/app/src/hooks/usePromptHistoryEnabled.test.tsx
+++ b/apps/app/src/hooks/usePromptHistoryEnabled.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { POINTER_COARSE_QUERY } from "@bb/shared-ui/hooks/use-pointer-coarse";
+import {
+  resetKeyboardSeenForTests,
+  usePromptHistoryEnabled,
+} from "./usePromptHistoryEnabled";
+
+function mockPointer(coarse: boolean) {
+  vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
+    matches: coarse && query === POINTER_COARSE_QUERY,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }));
+}
+
+function dispatchKeyDown(init: KeyboardEventInit) {
+  act(() => {
+    window.dispatchEvent(new KeyboardEvent("keydown", init));
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  resetKeyboardSeenForTests();
+  vi.restoreAllMocks();
+});
+
+describe("usePromptHistoryEnabled", () => {
+  it("keeps the eager fetch on fine-pointer devices", () => {
+    mockPointer(false);
+    const { result } = renderHook(() => usePromptHistoryEnabled());
+    expect(result.current).toBe(true);
+  });
+
+  it("waits for a real keydown on coarse-pointer devices and ignores IME keys", () => {
+    mockPointer(true);
+    const { result } = renderHook(() => usePromptHistoryEnabled());
+    expect(result.current).toBe(false);
+
+    dispatchKeyDown({ key: "a", isComposing: true });
+    expect(result.current).toBe(false);
+    dispatchKeyDown({ key: "Process", keyCode: 229 });
+    expect(result.current).toBe(false);
+
+    dispatchKeyDown({ key: "a" });
+    expect(result.current).toBe(true);
+  });
+
+  it("remembers the keyboard for later mounts", () => {
+    mockPointer(true);
+    const first = renderHook(() => usePromptHistoryEnabled());
+    dispatchKeyDown({ key: "ArrowUp" });
+    expect(first.result.current).toBe(true);
+    first.unmount();
+
+    const second = renderHook(() => usePromptHistoryEnabled());
+    expect(second.result.current).toBe(true);
+  });
+});

--- a/apps/app/src/hooks/usePromptHistoryEnabled.ts
+++ b/apps/app/src/hooks/usePromptHistoryEnabled.ts
@@ -1,0 +1,72 @@
+import { useSyncExternalStore } from "react";
+import { usePointerCoarse } from "@bb/shared-ui/hooks/use-pointer-coarse";
+
+/**
+ * Prompt history (project + thread) exists for ArrowUp recall in the composer.
+ * Fetching 50 full prompts on every thread open is wasted on phones, where no
+ * hardware keyboard will ever press ArrowUp. Coarse-pointer devices therefore
+ * defer the request until a real key is seen: an iPad with a keyboard flips
+ * the flag on the first keystroke, well before an ArrowUp arrives. Fine-pointer
+ * devices keep the eager fetch.
+ */
+
+let keyboardSeen = false;
+const listeners = new Set<() => void>();
+
+function isNonImeKeyDown(event: KeyboardEvent): boolean {
+  return !event.isComposing && event.keyCode !== 229;
+}
+
+function handleKeyDown(event: KeyboardEvent): void {
+  if (!isNonImeKeyDown(event)) {
+    return;
+  }
+  keyboardSeen = true;
+  window.removeEventListener("keydown", handleKeyDown, true);
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function subscribeKeyboardSeen(listener: () => void): () => void {
+  listeners.add(listener);
+  if (!keyboardSeen && listeners.size === 1) {
+    window.addEventListener("keydown", handleKeyDown, true);
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) {
+      window.removeEventListener("keydown", handleKeyDown, true);
+    }
+  };
+}
+
+function getKeyboardSeenSnapshot(): boolean {
+  return keyboardSeen;
+}
+
+function getKeyboardSeenServerSnapshot(): boolean {
+  return false;
+}
+
+export function useKeyboardSeen(): boolean {
+  return useSyncExternalStore(
+    subscribeKeyboardSeen,
+    getKeyboardSeenSnapshot,
+    getKeyboardSeenServerSnapshot,
+  );
+}
+
+export function resetKeyboardSeenForTests(): void {
+  keyboardSeen = false;
+  window.removeEventListener("keydown", handleKeyDown, true);
+  if (listeners.size > 0) {
+    window.addEventListener("keydown", handleKeyDown, true);
+  }
+}
+
+export function usePromptHistoryEnabled(): boolean {
+  const isPointerCoarse = usePointerCoarse();
+  const hasSeenKeyboard = useKeyboardSeen();
+  return !isPointerCoarse || hasSeenKeyboard;
+}

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -145,7 +145,10 @@ import {
 import { resolveComposeHostId } from "./root-compose-environment-selection";
 import { RootComposeMobileRecents } from "./RootComposeMobileRecents";
 import { RootComposeEmptyWelcome } from "./RootComposeEmptyWelcome";
-import { useThreadStorageViewer } from "@/components/secondary-panel/useThreadStorageViewer";
+import {
+  shouldLoadThreadStorageFileList,
+  useThreadStorageViewer,
+} from "@/components/secondary-panel/useThreadStorageViewer";
 import {
   useThreadFileTabs,
   type FileSearchSelection,
@@ -1091,7 +1094,11 @@ function RootComposeSurface({
     threadStorageRootPath: rootThreadStorageRootPath,
   } = useThreadStorageViewer({
     activePath: null,
-    fileListEnabled: rootPanelThreadId !== null,
+    fileListEnabled: shouldLoadThreadStorageFileList({
+      hasThread: rootPanelThreadId !== null,
+      isSecondaryPanelOpen,
+      secondaryTabs: fixedPanelTabsState.secondary.tabs,
+    }),
     filePreviewEnabled: false,
     threadId: rootPanelThreadId ?? undefined,
   });

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -87,6 +87,7 @@ import {
 import { useThreadDefaultExecutionOptions } from "@/hooks/queries/thread-default-execution-options-query";
 import { getMutationErrorMessage } from "@/lib/mutation-errors";
 import { promptHistoryEntriesToDrafts } from "@/lib/prompt-history";
+import { usePromptHistoryEnabled } from "@/hooks/usePromptHistoryEnabled";
 import { getProjectComposeRoutePath } from "@/lib/route-paths";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { buildThreadHandoffLocationState } from "@/lib/thread-handoff-request";
@@ -397,10 +398,11 @@ export function ThreadDetailPromptArea({
       setEditFocusNonce((nonce) => nonce + 1);
     },
   });
+  const promptHistoryEnabled = usePromptHistoryEnabled();
   const { data: promptHistoryEntries = [] } = useThreadPromptHistory(
     thread.id,
     {
-      enabled: true,
+      enabled: promptHistoryEnabled,
     },
   );
   const createQueuedMessage = useCreateThreadQueuedMessage();

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -28,8 +28,12 @@ vi.mock("@/components/ui/sidebar.js", () => ({
   useOptionalIsSidebarShowing: () => true,
 }));
 
+const { useThreadsMock } = vi.hoisted(() => ({
+  useThreadsMock: vi.fn((..._args: unknown[]) => ({ data: [] })),
+}));
+
 vi.mock("@/hooks/queries/thread-queries", () => ({
-  useThreads: () => ({ data: [] }),
+  useThreads: useThreadsMock,
 }));
 
 vi.mock("jotai", async (importOriginal) => ({
@@ -295,6 +299,7 @@ function renderThreadDetail(
 afterEach(() => {
   cleanup();
   publishedHostedPanel = null;
+  useThreadsMock.mockClear();
 });
 
 describe("ThreadDetailSecondaryContent", () => {
@@ -352,5 +357,45 @@ describe("ThreadDetailSecondaryContent", () => {
         .getByTestId("inline-secondary-panel")
         .contains(screen.getByTestId("metadata-card")),
     ).toBe(true);
+  });
+
+  it("only requests the forks list while the secondary panel is open", () => {
+    const props = createProps();
+    const { rerender } = render(
+      <MemoryRouter>
+        <DefaultPaneContextProvider>
+          <CompactViewportOverrideProvider isCompactViewport={false}>
+            <ThreadDetailSecondaryContent
+              {...props}
+              isSecondaryPanelOpen={false}
+            />
+          </CompactViewportOverrideProvider>
+        </DefaultPaneContextProvider>
+      </MemoryRouter>,
+    );
+
+    expect(useThreadsMock).toHaveBeenLastCalledWith(
+      {
+        projectId: "proj-test",
+        sourceThreadId: "thread-1",
+        originKind: "fork",
+        archived: false,
+      },
+      { enabled: false },
+    );
+
+    rerender(
+      <MemoryRouter>
+        <DefaultPaneContextProvider>
+          <CompactViewportOverrideProvider isCompactViewport={false}>
+            <ThreadDetailSecondaryContent {...props} isSecondaryPanelOpen />
+          </CompactViewportOverrideProvider>
+        </DefaultPaneContextProvider>
+      </MemoryRouter>,
+    );
+
+    expect(useThreadsMock).toHaveBeenLastCalledWith(expect.anything(), {
+      enabled: true,
+    });
   });
 });

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -82,13 +82,17 @@ function ThreadDetailSecondaryContentBody({
   const { renderBrowserDeck, ...threadSecondaryPanelProps } = secondaryPanel;
 
   // Mirror ForksRow's query (deduped by react-query) so the visibility gate
-  // accounts for the lazily fetched Forks row.
-  const forksQuery = useThreads({
-    projectId: metadata.thread.projectId,
-    sourceThreadId: metadata.thread.id,
-    originKind: "fork",
-    archived: false,
-  });
+  // accounts for the lazily fetched Forks row. Only the open panel renders the
+  // Info tab, so a closed panel does not need the request.
+  const forksQuery = useThreads(
+    {
+      projectId: metadata.thread.projectId,
+      sourceThreadId: metadata.thread.id,
+      originKind: "fork",
+      archived: false,
+    },
+    { enabled: isSecondaryPanelOpen },
+  );
   const hasForks = (forksQuery.data?.length ?? 0) > 0;
   const metadataContent = useMemo(
     () =>

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -150,7 +150,10 @@ import {
   type ThreadSecondaryPanelFileOpenOptions,
 } from "./useThreadSecondaryPanelVisibility";
 import type { HostConnectionNotice } from "./ThreadTimelinePane";
-import { useThreadStorageViewer } from "@/components/secondary-panel/useThreadStorageViewer";
+import {
+  shouldLoadThreadStorageFileList,
+  useThreadStorageViewer,
+} from "@/components/secondary-panel/useThreadStorageViewer";
 import { getThreadConversationCollapsedAtom } from "@/components/secondary-panel/threadSecondaryPanelAtoms";
 import {
   HostFilePreviewTabContent,
@@ -667,7 +670,11 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
   );
   const [browserAddressFocusRequest, setBrowserAddressFocusRequest] =
     useState<BrowserAddressFocusRequest | null>(null);
-  const shouldLoadThreadStorageFiles = thread !== undefined;
+  const shouldLoadThreadStorageFiles = shouldLoadThreadStorageFileList({
+    hasThread: thread !== undefined,
+    isSecondaryPanelOpen,
+    secondaryTabs: fixedPanelTabsState.secondary.tabs,
+  });
   const {
     isThreadStorageFilesLoading,
     refetchThreadStorageFiles,


### PR DESCRIPTION
## What was wrong

Opening a thread on a phone issued ~17 requests. Several of them served surfaces that were not on screen: the thread-storage file list (`host.list_files`, limit 1000) for the secondary panel, the forks list for the info tab, 50 full prompt-history entries that only ArrowUp consumes, a child-thread subset that the sidebar bootstrap already holds, a duplicate `GET /threads?projectId=` for worktree-reuse options, and a 200-thread `@`-mention candidate list that duplicates the sidebar cache. The first timeline window also always used the 20-segment server default on a 390 px viewport (B9, B10, B11, B12, B13, B16, C5).

## What changed

- The thread-storage file list loads only while the secondary panel is open or a storage tab exists.
- The child-thread subset and the `@`-mention candidates derive from the cached sidebar bootstrap (via `select` with structural sharing) and fall back to the network only when the project is absent from the cache. On cold deep-link opens the hooks wait for the in-flight bootstrap instead of racing it.
- The forks list query is enabled only while the secondary panel is open.
- Prompt history (thread and project) is enabled on fine pointers, or on coarse pointers after the first non-IME keydown, so iPad + keyboard still works.
- The worktree-reuse options in the new-thread composer derive from the sidebar bootstrap the composer already observes.
- The `/` command catalog is prefetched on the first composer focus on coarse pointers (`retry: false`).
- Compact viewports request `segmentLimit=8` for the first timeline window and on the full-refetch path; the server timeline cache is keyed by segment limit so deltas keep working.

## How you verified

- New tests: query gates (enabled/disabled per surface), fallback vs derived child/mention lists, in-flight bootstrap wait, viewport-dependent `segmentLimit` including the delta path, IME handling for the keyboard-seen flag, focus-time command prefetch (coarse) vs none (fine).
- `pnpm exec turbo run typecheck --filter=@bb/app`, `pnpm exec turbo run lint --filter=@bb/app`, targeted `pnpm exec turbo run test --filter=@bb/app -- src/hooks/queries src/components/promptbox src/views/thread-detail`.
- Measured on the seeded perf fixture at 390 px: thread-open API requests 17 → 8 (with the other layers of this stack).

Fixes: part of the mobile / iOS Safari performance program (verified sweep report in the bb thread; no single issue).


## Stack context

Layer 5 of 22 in the `bb/mobile-perf/*` stack (bottom → top: quick wins first, big rocks last).
- Prerequisite (layer below): `bb/mobile-perf/ws-liveness-and-resume` (#1883).
- Next layer: `bb/mobile-perf/list-models-cache` (#1885).
- Audit findings addressed: see title IDs. Review: approved-with-fixes; 2 review fix commit(s).
- Reviewer notes / follow-ups: The requested branch bb/mobile-perf/thread-open-query-gating is checked out in worktree /home/sawyer/projects/bb/.claude/worktrees/wf_dec7ce2a-e37-8 and still points at dde6cddc5 w | B16 prefetch nuance (not a bug): useProjectCommands keeps staleTime 0, so on coarse-pointer devices the first '/' still issues a background refetch after the focus-time prefetch. T | B12 nuance (by design, matches the audit's proposed fix): on an iPad with a hardware keyboard the very first keydown enables the prompt-history fetch, so an ArrowUp pressed as the  | Derived child/mention lists depend on the sidebar bootstrap being kept fresh by another active observer (AppLayout's useSidebarNavigation, always mounted). If a sibling package (e.

> AGENT GENERATED: by Claude Opus 5

