### PR TITLE
Memoize provider.list_models on the server and key follow-up execution options by host (B6)

### DIFF
--- a/apps/app/src/components/plugin/PluginThreadChat.tsx
+++ b/apps/app/src/components/plugin/PluginThreadChat.tsx
@@ -270,6 +270,7 @@ function PluginThreadChatBody({
         executionDefaultsThreadId: threadId,
         executionResetKey: threadId,
         executionEnvironmentId: thread.environmentId ?? undefined,
+        executionEnvironmentHostId: environment?.hostId,
         // "inherit" pins sends to the thread's own resolved defaults, never
         // widened by a plugin surface. "editable" is the opt-in that hands
         // the picker to the user for this thread alone.

--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
@@ -145,6 +145,8 @@ export interface EmbeddedThreadChatComposerProps {
   executionDefaultsThreadId: string;
   executionResetKey: string;
   executionEnvironmentId?: string;
+  /** Machine of `executionEnvironmentId`; lets host-scoped catalogs share one query across environments. */
+  executionEnvironmentHostId?: string;
   /**
    * Defer model/permission metadata loading until the surface first becomes
    * active — lets a retained hidden panel's first paint win over host-backed
@@ -381,6 +383,7 @@ function EmbeddedThreadChatWithComposer({
     enabled: shouldLoadExecutionOptions,
     scope: "component-local",
     environmentId: composer.executionEnvironmentId,
+    environmentHostId: composer.executionEnvironmentHostId,
     resetKey: composer.executionResetKey,
     initialProviderId: providerId,
     initialModel: defaultExecutionOptions?.model,

--- a/apps/app/src/hooks/thread-creation-options/selection-state.ts
+++ b/apps/app/src/hooks/thread-creation-options/selection-state.ts
@@ -31,6 +31,12 @@ export type ScopedExecutionInputSources =
 export interface UsePromptModelReasoningOptions {
   enabled?: boolean;
   environmentId?: string;
+  /**
+   * The machine the environment lives on. Component-local composers route
+   * host-scoped provider catalogs by host so threads in different
+   * environments on one machine share a single execution-options query.
+   */
+  environmentHostId?: string;
   scope?: ThreadCreationOptionsScope;
   resetKey?: string | number | null;
   initialProviderId?: string;

--- a/apps/app/src/hooks/useThreadCreationOptions.test.tsx
+++ b/apps/app/src/hooks/useThreadCreationOptions.test.tsx
@@ -756,6 +756,70 @@ describe("useThreadCreationOptions", () => {
     ).toBe("host:project-host:worktree");
   });
 
+  it("routes a host-scoped component-local catalog by the environment's host", async () => {
+    const { wrapper } = createQueryClientTestHarness();
+
+    const { result } = renderHook(
+      () =>
+        useThreadCreationOptions({
+          scope: "component-local",
+          environmentId: "env_follow_up",
+          environmentHostId: "host_follow_up",
+          resetKey: "thr_host_scoped",
+          initialProviderId: "claude-code",
+          initialModel: "claude-opus-5",
+          initialReasoningLevel: "medium",
+          initialPermissionMode: "full",
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(sdk.system.executionOptions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          environmentId: undefined,
+          hostId: "host_follow_up",
+          providerId: "claude-code",
+        }),
+      );
+      expect(result.current.executionOptionsRouting).toEqual({
+        hostId: "host_follow_up",
+      });
+    });
+  });
+
+  it("keeps a workspace-scoped component-local catalog routed by environment", async () => {
+    const { wrapper } = createQueryClientTestHarness();
+
+    const { result } = renderHook(
+      () =>
+        useThreadCreationOptions({
+          scope: "component-local",
+          environmentId: "env_follow_up",
+          environmentHostId: "host_follow_up",
+          resetKey: "thr_workspace_scoped",
+          initialProviderId: "pi",
+          initialModel: "anthropic/opus",
+          initialReasoningLevel: "medium",
+          initialPermissionMode: "full",
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(sdk.system.executionOptions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          environmentId: "env_follow_up",
+          hostId: undefined,
+          providerId: "pi",
+        }),
+      );
+      expect(result.current.executionOptionsRouting).toEqual({
+        environmentId: "env_follow_up",
+      });
+    });
+  });
+
   it("loads provider composer actions for environmentless component-local threads", async () => {
     const { wrapper } = createQueryClientTestHarness();
 

--- a/apps/app/src/hooks/useThreadCreationOptions.ts
+++ b/apps/app/src/hooks/useThreadCreationOptions.ts
@@ -21,7 +21,11 @@ import { PERMISSION_MODE_OPTIONS } from "@/lib/permission-mode-options";
 import { useRootComposeReuseEnvironment } from "@/lib/root-compose-selection";
 import { getProviderIconInfo } from "@/lib/provider-icon";
 import { REASONING_LABELS } from "@/lib/reasoning-labels";
-import { permissionModeRank, reconcileReasoningLevel } from "@bb/domain";
+import {
+  permissionModeRank,
+  providerModelCatalogDependsOnWorkspace,
+  reconcileReasoningLevel,
+} from "@bb/domain";
 import { selectPrimaryHost, useHosts } from "./queries/host-queries";
 import {
   useOnboardingAgents,
@@ -118,17 +122,35 @@ export interface UseThreadCreationOptionsResult<TExecutionInputSources> {
 
 interface ResolveThreadCreationProviderRoutingArgs {
   environmentId?: string;
+  environmentHostId?: string;
   environmentSelectionValue: string;
+  providerId: string;
   scope: "component-local" | "new-thread";
 }
 
 export function resolveThreadCreationProviderRouting({
   environmentId,
+  environmentHostId,
   environmentSelectionValue,
+  providerId,
   scope,
 }: ResolveThreadCreationProviderRoutingArgs): SystemProvidersQuery {
   if (scope === "component-local") {
-    return environmentId === undefined ? {} : { environmentId };
+    if (environmentId === undefined) {
+      return {};
+    }
+    // A host-scoped catalog is the same for every environment on the machine,
+    // so route by host: opening threads in different environments then shares
+    // one cached query instead of issuing a probe per environment. Workspace-
+    // scoped catalogs (and providers whose scope is unknown) keep the
+    // environment so the server can pass the workspace path through.
+    if (
+      environmentHostId !== undefined &&
+      !providerModelCatalogDependsOnWorkspace(providerId)
+    ) {
+      return { hostId: environmentHostId };
+    }
+    return { environmentId };
   }
   const parsed = parseEnvironmentValue(environmentSelectionValue);
   if (parsed?.type === "host") {
@@ -167,6 +189,7 @@ export function useThreadCreationOptions(
   const {
     enabled = true,
     environmentId,
+    environmentHostId,
     initialEnvironmentSelectionValue,
     initialModel,
     initialProviderId,
@@ -281,7 +304,9 @@ export function useThreadCreationOptions(
     ? resolveProviderRouting(rawEnvironmentSelectionValue)
     : resolveThreadCreationProviderRouting({
         environmentId,
+        environmentHostId,
         environmentSelectionValue: rawEnvironmentSelectionValue,
+        providerId: selectedProviderIdBeforeConnectedFallback,
         scope,
       });
   const shouldResolveConnectedProvider =

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -150,6 +150,8 @@ interface ThreadDetailPromptAreaProps {
     EnvironmentStatus,
     "destroying" | "destroyed"
   > | null;
+  /** Machine of the thread's environment; routes host-scoped model catalogs by host. */
+  environmentHostId?: string;
   environmentIcon?: IconName;
   environmentLabel?: string;
   onCreateNewThreadInWorktree?: () => void;
@@ -313,6 +315,7 @@ export function ThreadDetailPromptArea({
   environmentCheckout,
   environmentCompactLabel,
   environmentGoneStatus,
+  environmentHostId,
   environmentIcon,
   environmentLabel,
   onCreateNewThreadInWorktree,
@@ -580,6 +583,7 @@ export function ThreadDetailPromptArea({
   } = useThreadCreationOptions({
     enabled: thread.archivedAt === null,
     environmentId: thread.environmentId ?? undefined,
+    environmentHostId,
     scope: "component-local",
     resetKey: thread.id,
     initialProviderId: thread.providerId,

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -2649,6 +2649,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
           : undefined
       }
       environmentGoneStatus={threadEnvironmentGoneStatus}
+      environmentHostId={environment?.hostId}
       isEnvironmentActionPending={requestEnvironmentAction.isPending}
       onCreateNewThreadInWorktree={onCreateNewThreadInWorktree}
       onEscapeEmptyPrompt={undefined}

--- a/apps/server/src/lifecycle-dedupers.ts
+++ b/apps/server/src/lifecycle-dedupers.ts
@@ -1,10 +1,33 @@
+import type { AvailableModel } from "@bb/domain";
 import {
   createAsyncDeduper,
   type AsyncDeduper,
 } from "./services/lib/async-deduper.js";
+import {
+  createAsyncTtlMemo,
+  type AsyncTtlMemo,
+} from "./services/lib/async-ttl-memo.js";
+
+/**
+ * How long a successful `provider.list_models` answer is reused. Provider
+ * catalogs change on the order of releases, and the memo key already carries
+ * the daemon session and provider registration revision, so a daemon restart
+ * or a plugin reload re-probes immediately regardless of this window.
+ */
+export const PROVIDER_MODEL_LIST_MEMO_TTL_MS = 10 * 60_000;
+
+export interface ProviderModelListMemoValue {
+  models: AvailableModel[];
+  selectedOnlyModels: AvailableModel[];
+}
 
 export interface LifecycleDedupers {
   environmentCleanupAdvance: AsyncDeduper<string, void>;
+  /**
+   * Memo for host model probes: every execution-options read (each thread
+   * open, focus, and reconnect) used to spawn a provider CLI on the host.
+   */
+  providerModelList: AsyncTtlMemo<string, ProviderModelListMemoValue>;
   queuedMessageAutoSend: AsyncDeduper<string, void>;
   threadProvisionAdvance: AsyncDeduper<string, void>;
 }
@@ -12,6 +35,9 @@ export interface LifecycleDedupers {
 export function createLifecycleDedupers(): LifecycleDedupers {
   return {
     environmentCleanupAdvance: createAsyncDeduper<string, void>(),
+    providerModelList: createAsyncTtlMemo<string, ProviderModelListMemoValue>({
+      ttlMs: PROVIDER_MODEL_LIST_MEMO_TTL_MS,
+    }),
     queuedMessageAutoSend: createAsyncDeduper<string, void>(),
     threadProvisionAdvance: createAsyncDeduper<string, void>(),
   };

--- a/apps/server/src/services/lib/async-ttl-memo.ts
+++ b/apps/server/src/services/lib/async-ttl-memo.ts
@@ -1,0 +1,72 @@
+/**
+ * An in-process memo for expensive async lookups: concurrent calls for one key
+ * share the in-flight promise, and a settled success is served from memory
+ * until it expires. Failures are never stored, so the next call retries.
+ */
+export interface AsyncTtlMemo<TKey, TValue> {
+  clear(): void;
+  run(key: TKey, task: () => Promise<TValue>): Promise<TValue>;
+}
+
+export interface CreateAsyncTtlMemoOptions {
+  ttlMs: number;
+  now?: () => number;
+}
+
+interface MemoEntry<TValue> {
+  expiresAt: number;
+  value: TValue;
+}
+
+export function createAsyncTtlMemo<TKey, TValue>({
+  ttlMs,
+  now = Date.now,
+}: CreateAsyncTtlMemoOptions): AsyncTtlMemo<TKey, TValue> {
+  const settledByKey = new Map<TKey, MemoEntry<TValue>>();
+  const pendingByKey = new Map<TKey, Promise<TValue>>();
+
+  function pruneExpired(currentTime: number): void {
+    for (const [key, entry] of settledByKey) {
+      if (entry.expiresAt <= currentTime) {
+        settledByKey.delete(key);
+      }
+    }
+  }
+
+  return {
+    clear() {
+      settledByKey.clear();
+      pendingByKey.clear();
+    },
+    run(key, task) {
+      const currentTime = now();
+      const settled = settledByKey.get(key);
+      if (settled !== undefined) {
+        if (settled.expiresAt > currentTime) {
+          return Promise.resolve(settled.value);
+        }
+        settledByKey.delete(key);
+      }
+      const pending = pendingByKey.get(key);
+      if (pending !== undefined) {
+        return pending;
+      }
+      const started = task()
+        .then((value) => {
+          const settledAt = now();
+          // Expired neighbours are swept here rather than on a timer so the map
+          // stays bounded without keeping the process alive.
+          pruneExpired(settledAt);
+          settledByKey.set(key, { value, expiresAt: settledAt + ttlMs });
+          return value;
+        })
+        .finally(() => {
+          if (pendingByKey.get(key) === started) {
+            pendingByKey.delete(key);
+          }
+        });
+      pendingByKey.set(key, started);
+      return started;
+    },
+  };
+}

--- a/apps/server/src/services/system/execution-options.ts
+++ b/apps/server/src/services/system/execution-options.ts
@@ -13,11 +13,16 @@ import {
   type CustomProviderModel,
 } from "@bb/config/bb-app-managed-config";
 import {
+  providerModelCatalogDependsOnWorkspace,
   reasoningEffortsForLevels,
   type AvailableModel,
   type ProviderInfo,
 } from "@bb/domain";
-import { normalizeHostDaemonAcpLaunchSpec } from "@bb/host-daemon-contract";
+import {
+  normalizeHostDaemonAcpLaunchSpec,
+  type HostDaemonRetryableOnlineRpcCommand,
+} from "@bb/host-daemon-contract";
+import type { ProviderModelListMemoValue } from "../../lifecycle-dedupers.js";
 import type { LoggedWorkSessionDeps } from "../../types.js";
 import { COMMAND_TIMEOUT_MS } from "../../constants.js";
 import { ApiError } from "../../errors.js";
@@ -574,29 +579,30 @@ async function loadSystemProviderModels(
       ? findKnownAcpAgentForProviderId(provider.id)
       : undefined;
   const bridgeLaunch = requireBridgeLaunchForProviderId(deps, provider.id);
+  const command: ProviderListModelsCommand = {
+    type: "provider.list_models",
+    providerId: provider.id,
+    // Only a workspace-scoped catalog gets the path: the other bridges ignore
+    // it, and leaving it out lets every environment on the host share one
+    // memo entry.
+    ...(cwd !== undefined && providerModelCatalogDependsOnWorkspace(provider.id)
+      ? { cwd }
+      : {}),
+    ...(customAcpAgent !== undefined
+      ? {
+          acpLaunchSpec: normalizeHostDaemonAcpLaunchSpec(customAcpAgent),
+        }
+      : knownAcpAgent !== undefined
+        ? {
+            acpLaunchSpec: normalizeHostDaemonAcpLaunchSpec(knownAcpAgent),
+          }
+        : {}),
+    bridgeLaunch,
+  };
   try {
-    const { models, selectedOnlyModels } = await callHostRetryableOnlineRpc(
+    const { models, selectedOnlyModels } = await listProviderModelsMemoized(
       deps,
-      {
-        hostId,
-        timeoutMs: COMMAND_TIMEOUT_MS,
-        command: {
-          type: "provider.list_models",
-          providerId: provider.id,
-          ...(cwd !== undefined ? { cwd } : {}),
-          ...(customAcpAgent !== undefined
-            ? {
-                acpLaunchSpec: normalizeHostDaemonAcpLaunchSpec(customAcpAgent),
-              }
-            : knownAcpAgent !== undefined
-              ? {
-                  acpLaunchSpec:
-                    normalizeHostDaemonAcpLaunchSpec(knownAcpAgent),
-                }
-              : {}),
-          bridgeLaunch,
-        },
-      },
+      { command, hostId },
     );
     return {
       models,
@@ -631,6 +637,47 @@ async function loadSystemProviderModels(
       modelLoadError,
     };
   }
+}
+
+type ProviderListModelsCommand = Extract<
+  HostDaemonRetryableOnlineRpcCommand,
+  { type: "provider.list_models" }
+>;
+
+/**
+ * Runs the host model probe through the process-wide memo. The key carries
+ * everything the answer depends on: the host, the daemon session serving it
+ * (a reconnected daemon may have a new CLI or account, so its first probe is
+ * fresh), the provider registration revision (a plugin reload can change the
+ * bridge), and the full command (provider, launch spec, bridge launch, and the
+ * workspace path when the catalog is workspace-scoped). Concurrent callers for
+ * one key share the in-flight probe; failures are not memoized.
+ *
+ * The probe is skipped only when no daemon session is registered yet: the
+ * retryable RPC waits for one, and its answer would then belong to a session
+ * this call cannot name.
+ */
+async function listProviderModelsMemoized(
+  deps: LoggedWorkSessionDeps,
+  { command, hostId }: { command: ProviderListModelsCommand; hostId: string },
+): Promise<ProviderModelListMemoValue> {
+  const probe = (): Promise<ProviderModelListMemoValue> =>
+    callHostRetryableOnlineRpc(deps, {
+      hostId,
+      timeoutMs: COMMAND_TIMEOUT_MS,
+      command,
+    });
+  const daemonSessionId = deps.hub.getDaemonSessionIdForHost(hostId);
+  if (daemonSessionId === null) {
+    return probe();
+  }
+  const memoKey = JSON.stringify([
+    hostId,
+    daemonSessionId,
+    deps.providerRegistry.getRegistrationRevision(),
+    command,
+  ]);
+  return deps.lifecycleDedupers.providerModelList.run(memoKey, probe);
 }
 
 // A transient probe failure is not evidence that a model was retired, so the

--- a/apps/server/test/public/public-threads.defaults.test.ts
+++ b/apps/server/test/public/public-threads.defaults.test.ts
@@ -405,9 +405,11 @@ describe("public thread default routes", () => {
         {
           type: "provider.list_models",
           providerId: "codex",
-          cwd: "/tmp/thread-defaults-missing",
         },
       ]);
+      // The Codex catalog is host-scoped, so the probe carries no workspace
+      // path (it would only fragment the server's model-list memo).
+      expect(providerResponder.requests[0].command).not.toHaveProperty("cwd");
     });
   });
 

--- a/apps/server/test/services/async-ttl-memo.test.ts
+++ b/apps/server/test/services/async-ttl-memo.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAsyncTtlMemo } from "../../src/services/lib/async-ttl-memo.js";
+
+describe("createAsyncTtlMemo", () => {
+  it("serves a settled value until it expires, then runs the task again", async () => {
+    let currentTime = 1_000;
+    const memo = createAsyncTtlMemo<string, number>({
+      ttlMs: 100,
+      now: () => currentTime,
+    });
+    const task = vi.fn(async () => currentTime);
+
+    await expect(memo.run("k", task)).resolves.toBe(1_000);
+    currentTime = 1_099;
+    await expect(memo.run("k", task)).resolves.toBe(1_000);
+    expect(task).toHaveBeenCalledTimes(1);
+
+    currentTime = 1_100;
+    await expect(memo.run("k", task)).resolves.toBe(1_100);
+    expect(task).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares one in-flight task and never stores a rejection", async () => {
+    const memo = createAsyncTtlMemo<string, string>({ ttlMs: 60_000 });
+    let reject: (error: Error) => void = () => {};
+    const task = vi.fn(
+      () =>
+        new Promise<string>((_resolve, rejectTask) => {
+          reject = rejectTask;
+        }),
+    );
+
+    const first = memo.run("k", task);
+    const second = memo.run("k", task);
+    expect(task).toHaveBeenCalledTimes(1);
+    reject(new Error("probe failed"));
+    await expect(first).rejects.toThrow("probe failed");
+    await expect(second).rejects.toThrow("probe failed");
+
+    const recovered = vi.fn(async () => "ok");
+    await expect(memo.run("k", recovered)).resolves.toBe("ok");
+    expect(recovered).toHaveBeenCalledTimes(1);
+  });
+
+  it("keys entries independently and clears them on demand", async () => {
+    const memo = createAsyncTtlMemo<string, string>({ ttlMs: 60_000 });
+    await expect(memo.run("a", async () => "A")).resolves.toBe("A");
+    await expect(memo.run("b", async () => "B")).resolves.toBe("B");
+    await expect(memo.run("a", async () => "A2")).resolves.toBe("A");
+    memo.clear();
+    await expect(memo.run("a", async () => "A2")).resolves.toBe("A2");
+  });
+});

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  hostDaemonServerWsMessageSchema,
+  type HostDaemonOnlineRpcRequestMessage,
+} from "@bb/host-daemon-contract";
+import {
   appendCustomModels,
   listSystemProviderInfos,
   resolveSystemExecutionOptions,
@@ -10,8 +14,13 @@ import {
   registerHostRpcResponder,
   registerProviderHostRpcResponder,
 } from "../helpers/host-rpc.js";
-import { seedHostSession } from "../helpers/seed.js";
-import { withTestHarness } from "../helpers/test-app.js";
+import {
+  seedEnvironment,
+  seedHostSession,
+  seedProjectWithSource,
+  seedSession,
+} from "../helpers/seed.js";
+import { withTestHarness, type TestAppHarness } from "../helpers/test-app.js";
 import {
   createTestProviderRegistry,
   registerFirstPartyProviders,
@@ -1240,4 +1249,303 @@ describe("resolveSystemExecutionOptions", () => {
       );
     },
   );
+});
+
+/**
+ * A daemon socket that holds every `provider.list_models` request until the
+ * test releases it, so two callers can be observed sharing one probe.
+ */
+function registerHeldModelListResponder(
+  harness: TestAppHarness,
+  args: { hostId: string; sessionId: string; modelId: string },
+): {
+  requests: HostDaemonOnlineRpcRequestMessage[];
+  release(): void;
+} {
+  const requests: HostDaemonOnlineRpcRequestMessage[] = [];
+  harness.hub.registerDaemon(args.sessionId, args.hostId, {
+    close() {},
+    send(data: string) {
+      const message = hostDaemonServerWsMessageSchema.parse(JSON.parse(data));
+      if (message.type !== "host-rpc.request") {
+        throw new Error(`Unexpected daemon websocket message ${message.type}`);
+      }
+      if (message.command.type === "known_acp_agents.status") {
+        harness.hub.recordHostOnlineRpcResponse({
+          sessionId: args.sessionId,
+          message: {
+            type: "host-rpc.response",
+            requestId: message.requestId,
+            commandType: message.command.type,
+            ok: true,
+            result: {
+              agents: message.command.agents.map((agent) => ({
+                ...agent,
+                installed: false,
+                executablePath: null,
+              })),
+            },
+          },
+        });
+        return;
+      }
+      if (message.command.type !== "provider.list_models") {
+        throw new Error(`Unexpected RPC command ${message.command.type}`);
+      }
+      requests.push(message);
+    },
+  });
+  return {
+    requests,
+    release() {
+      for (const request of requests) {
+        harness.hub.recordHostOnlineRpcResponse({
+          sessionId: args.sessionId,
+          message: {
+            type: "host-rpc.response",
+            requestId: request.requestId,
+            commandType: "provider.list_models",
+            ok: true,
+            result: {
+              models: [availableModelFixture({ model: args.modelId })],
+              selectedOnlyModels: [],
+            },
+          },
+        });
+      }
+    },
+  };
+}
+
+function seedEnvironmentPath(
+  harness: TestAppHarness,
+  args: { hostId: string; path: string },
+): string {
+  const { project } = seedProjectWithSource(harness.deps, {
+    hostId: args.hostId,
+    path: args.path,
+  });
+  return seedEnvironment(harness.deps, {
+    hostId: args.hostId,
+    projectId: project.id,
+    path: args.path,
+  }).id;
+}
+
+describe("resolveSystemExecutionOptions model probe memo", () => {
+  it("serves a host-scoped catalog to every environment on the host from one probe without the workspace path", async () => {
+    await withTestHarness({}, async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-model-memo-shared",
+      });
+      const catalogModel = availableModelFixture({ model: "claude-opus-5" });
+      const responder = registerProviderHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        modelsByProviderId: {
+          "claude-code": { models: [catalogModel], selectedOnlyModels: [] },
+        },
+      });
+      const environmentA = seedEnvironmentPath(harness, {
+        hostId: host.id,
+        path: "/tmp/memo-workspace-a",
+      });
+      const environmentB = seedEnvironmentPath(harness, {
+        hostId: host.id,
+        path: "/tmp/memo-workspace-b",
+      });
+
+      const responses = [
+        await resolveSystemExecutionOptions(harness.deps, {
+          environmentId: environmentA,
+          providerId: "claude-code",
+        }),
+        await resolveSystemExecutionOptions(harness.deps, {
+          environmentId: environmentB,
+          providerId: "claude-code",
+        }),
+        await resolveSystemExecutionOptions(harness.deps, {
+          hostId: host.id,
+          providerId: "claude-code",
+        }),
+      ];
+
+      for (const response of responses) {
+        expect(response.models).toEqual([catalogModel]);
+        expect(response.modelLoadError).toBeNull();
+      }
+      const modelListCommands = responder.requests
+        .map((request) => request.command)
+        .filter((command) => command.type === "provider.list_models");
+      expect(modelListCommands).toHaveLength(1);
+      expect(modelListCommands[0]).not.toHaveProperty("cwd");
+    });
+  });
+
+  it("keeps a workspace-scoped catalog keyed by workspace path", async () => {
+    await withTestHarness({}, async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-model-memo-workspace-scoped",
+      });
+      const responder = registerProviderHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        modelsByProviderId: {
+          pi: {
+            models: [availableModelFixture({ model: "anthropic/opus" })],
+            selectedOnlyModels: [],
+          },
+        },
+      });
+      const environmentA = seedEnvironmentPath(harness, {
+        hostId: host.id,
+        path: "/tmp/memo-pi-a",
+      });
+      const environmentB = seedEnvironmentPath(harness, {
+        hostId: host.id,
+        path: "/tmp/memo-pi-b",
+      });
+
+      for (const environmentId of [environmentA, environmentA, environmentB]) {
+        await resolveSystemExecutionOptions(harness.deps, {
+          environmentId,
+          providerId: "pi",
+        });
+      }
+
+      expect(
+        responder.requests
+          .map((request) => request.command)
+          .filter((command) => command.type === "provider.list_models")
+          .map((command) => command.cwd),
+      ).toEqual(["/tmp/memo-pi-a", "/tmp/memo-pi-b"]);
+    });
+  });
+
+  it("shares one in-flight probe between concurrent readers", async () => {
+    await withTestHarness({}, async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-model-memo-inflight",
+      });
+      const responder = registerHeldModelListResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        modelId: "gpt-5",
+      });
+
+      const pending = Promise.all([
+        resolveSystemExecutionOptions(harness.deps, {
+          hostId: host.id,
+          providerId: "codex",
+        }),
+        resolveSystemExecutionOptions(harness.deps, {
+          hostId: host.id,
+          providerId: "codex",
+        }),
+      ]);
+      await vi.waitFor(() => {
+        expect(responder.requests.length).toBeGreaterThan(0);
+      });
+      responder.release();
+      const [first, second] = await pending;
+
+      expect(first.models.map((model) => model.model)).toEqual(["gpt-5"]);
+      expect(second.models).toEqual(first.models);
+      expect(
+        responder.requests.filter(
+          (request) => request.command.type === "provider.list_models",
+        ),
+      ).toHaveLength(1);
+    });
+  });
+
+  it("does not memoize a failed probe and re-probes after the daemon reconnects", async () => {
+    await withTestHarness({}, async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-model-memo-invalidation",
+      });
+      const catalogModel = availableModelFixture({ model: "gpt-5" });
+      let failProbe = true;
+      const responder = registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: (request) => {
+          if (request.command.type === "known_acp_agents.status") {
+            return {
+              ok: true,
+              result: {
+                agents: request.command.agents.map((agent) => ({
+                  ...agent,
+                  installed: false,
+                  executablePath: null,
+                })),
+              },
+            };
+          }
+          if (request.command.type !== "provider.list_models") {
+            throw new Error(`Unexpected RPC command ${request.command.type}`);
+          }
+          if (failProbe) {
+            return {
+              ok: false,
+              errorCode: "command_timeout",
+              errorMessage: "Model probe timed out",
+            };
+          }
+          return {
+            ok: true,
+            result: { models: [catalogModel], selectedOnlyModels: [] },
+          };
+        },
+      });
+      const query = { hostId: host.id, providerId: "codex" };
+
+      const failed = await resolveSystemExecutionOptions(harness.deps, query);
+      expect(failed.modelLoadError).toEqual({
+        providerId: "codex",
+        code: "timeout",
+      });
+
+      failProbe = false;
+      const recovered = await resolveSystemExecutionOptions(
+        harness.deps,
+        query,
+      );
+      expect(recovered.modelLoadError).toBeNull();
+      expect(recovered.models).toEqual([catalogModel]);
+      await resolveSystemExecutionOptions(harness.deps, query);
+      expect(
+        responder.requests.filter(
+          (request) => request.command.type === "provider.list_models",
+        ),
+      ).toHaveLength(2);
+
+      // A reconnected daemon may run a different CLI or account: its first
+      // probe must not be answered from the previous session's memo.
+      harness.hub.unregisterDaemon(session.id);
+      const nextSession = seedSession(harness.deps, host.id);
+      const nextResponder = registerProviderHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: nextSession.id,
+        modelsByProviderId: {
+          codex: {
+            models: [availableModelFixture({ model: "gpt-6" })],
+            selectedOnlyModels: [],
+          },
+        },
+      });
+      const afterReconnect = await resolveSystemExecutionOptions(
+        harness.deps,
+        query,
+      );
+      expect(afterReconnect.models.map((model) => model.model)).toEqual([
+        "gpt-6",
+      ]);
+      expect(
+        nextResponder.requests.filter(
+          (request) => request.command.type === "provider.list_models",
+        ),
+      ).toHaveLength(1);
+    });
+  });
 });

--- a/apps/server/test/system/provider-routing.test.ts
+++ b/apps/server/test/system/provider-routing.test.ts
@@ -146,17 +146,12 @@ describe("system provider host routing", () => {
         "remote-model",
       ]);
       // Only the routing facts matter here; `bridgeLaunch` rides every
-      // command and has its own tests.
+      // command and has its own tests. The Codex catalog is host-scoped, so
+      // the environment read carries no workspace path and is served from the
+      // memo filled by the explicit-host read: one probe on the remote host.
       expect(
         remoteModelCommands.map(({ bridgeLaunch: _ignored, ...rest }) => rest),
-      ).toEqual([
-        { type: "provider.list_models", providerId: "codex" },
-        {
-          type: "provider.list_models",
-          providerId: "codex",
-          cwd: "/tmp/test-environment",
-        },
-      ]);
+      ).toEqual([{ type: "provider.list_models", providerId: "codex" }]);
     });
   });
 

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -33,6 +33,7 @@ export * from "./prompt-history.js";
 export * from "./protocol-ids.js";
 export * from "./provider-event.js";
 export * from "./provider-fork.js";
+export * from "./provider-model-catalog.js";
 export * from "./provider-types.js";
 export * from "./raw-thread-id.js";
 export * from "./reasoning-efforts.js";

--- a/packages/domain/src/provider-model-catalog.ts
+++ b/packages/domain/src/provider-model-catalog.ts
@@ -1,0 +1,25 @@
+/**
+ * Whether a provider's model catalog can differ between workspaces on the same
+ * machine.
+ *
+ * `provider.list_models` may carry a workspace path, but only the Pi bridge
+ * reads it: project-level Pi configuration decides which model providers are
+ * configured. The Claude Code, Codex, and ACP bridges answer `model/list` from
+ * account or agent state and ignore the path, so their catalogs are host-scoped.
+ * The server uses this to memoize host-scoped catalogs across environments and
+ * to leave the workspace path out of the probe; the app uses it to route
+ * follow-up execution-options reads by host so threads in different
+ * environments share one query. Unknown (third-party) providers are treated as
+ * workspace-scoped because their bridge may read the path.
+ */
+export function providerModelCatalogDependsOnWorkspace(
+  providerId: string,
+): boolean {
+  if (providerId === "claude-code" || providerId === "codex") {
+    return false;
+  }
+  if (providerId.startsWith("acp-")) {
+    return false;
+  }
+  return true;
+}

--- a/plugins/provider-claude-code/src/bridge/__tests__/model-list-memo.test.ts
+++ b/plugins/provider-claude-code/src/bridge/__tests__/model-list-memo.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from "vitest";
+import { createClaudeCodeBridgeModelListMemo } from "../model-list.js";
+
+function catalog(model: string) {
+  return {
+    models: [
+      {
+        id: model,
+        model,
+        displayName: model,
+        description: "",
+        supportedReasoningEfforts: [],
+        defaultReasoningEffort: "medium" as const,
+        isDefault: true,
+      },
+    ],
+    selectedOnlyModels: [],
+  };
+}
+
+describe("createClaudeCodeBridgeModelListMemo", () => {
+  it("shares one probe between concurrent asks and reuses it until the window ends", async () => {
+    let currentTime = 0;
+    let resolveProbe: (value: ReturnType<typeof catalog>) => void = () => {};
+    const list = vi.fn(
+      () =>
+        new Promise<ReturnType<typeof catalog>>((resolve) => {
+          resolveProbe = resolve;
+        }),
+    );
+    const listModels = createClaudeCodeBridgeModelListMemo({
+      list,
+      now: () => currentTime,
+      ttlMs: 1_000,
+    });
+
+    const first = listModels();
+    const second = listModels();
+    expect(list).toHaveBeenCalledTimes(1);
+    resolveProbe(catalog("opus"));
+    await expect(first).resolves.toEqual(catalog("opus"));
+    await expect(second).resolves.toEqual(catalog("opus"));
+
+    currentTime = 999;
+    await expect(listModels()).resolves.toEqual(catalog("opus"));
+    expect(list).toHaveBeenCalledTimes(1);
+
+    currentTime = 1_000;
+    const refreshed = listModels();
+    expect(list).toHaveBeenCalledTimes(2);
+    resolveProbe(catalog("sonnet"));
+    await expect(refreshed).resolves.toEqual(catalog("sonnet"));
+  });
+
+  it("does not keep a failed probe", async () => {
+    const list = vi
+      .fn<() => Promise<ReturnType<typeof catalog>>>()
+      .mockRejectedValueOnce(new Error("temporary discovery failure"))
+      .mockResolvedValueOnce(catalog("opus"));
+    const listModels = createClaudeCodeBridgeModelListMemo({
+      list,
+      ttlMs: 60_000,
+    });
+
+    await expect(listModels()).rejects.toThrow("temporary discovery failure");
+    await expect(listModels()).resolves.toEqual(catalog("opus"));
+    expect(list).toHaveBeenCalledTimes(2);
+  });
+});

--- a/plugins/provider-claude-code/src/bridge/bridge.ts
+++ b/plugins/provider-claude-code/src/bridge/bridge.ts
@@ -74,7 +74,7 @@ import {
 } from "../session-params.js";
 import { buildInterruptedClaudeTaskEvents } from "../task-translation.js";
 import { SdkSession, type SdkSessionOptions } from "./sdk-session.js";
-import { listClaudeCodeBridgeModels } from "./model-list.js";
+import { createClaudeCodeBridgeModelListMemo } from "./model-list.js";
 import {
   claudeThreadForkParamsSchema,
   claudeThreadResumeParamsSchema,
@@ -663,6 +663,15 @@ async function applyLiveSessionSettings(
 const sessionIdEntropyPrefix = `bt${randomUUID().slice(0, 8)}-`;
 let translatorSessionSerial = 0;
 const CLAUDE_PROVIDER_ID = "claude-code";
+/**
+ * Model catalogs change on the order of releases; two minutes is enough to
+ * absorb the burst of picker, thread-open, and reconnect asks that hit one
+ * bridge, while the server-side memo owns the longer window.
+ */
+const MODEL_LIST_MEMO_TTL_MS = 2 * 60_000;
+const listModelsMemoized = createClaudeCodeBridgeModelListMemo({
+  ttlMs: MODEL_LIST_MEMO_TTL_MS,
+});
 
 function createSessionTranslator(): ClaudeEventTranslator {
   translatorSessionSerial += 1;
@@ -2010,7 +2019,7 @@ async function handleRequest(request: ClaudeCodeJsonRpcRequest): Promise<void> {
       sendResult(request.id, result);
       break;
     case "model/list":
-      sendResult(request.id, await listClaudeCodeBridgeModels());
+      sendResult(request.id, await listModelsMemoized());
       break;
     case "thread/start":
       await handleThreadStart(

--- a/plugins/provider-claude-code/src/bridge/model-list.ts
+++ b/plugins/provider-claude-code/src/bridge/model-list.ts
@@ -49,9 +49,7 @@ export async function listClaudeCodeBridgeModels(
 }
 
 export interface ClaudeCodeBridgeModelListMemoOptions {
-  list?: (
-    env?: NodeJS.ProcessEnv,
-  ) => ReturnType<typeof listClaudeCodeBridgeModels>;
+  list?: () => ReturnType<typeof listClaudeCodeBridgeModels>;
   now?: () => number;
   ttlMs: number;
 }

--- a/plugins/provider-claude-code/src/bridge/model-list.ts
+++ b/plugins/provider-claude-code/src/bridge/model-list.ts
@@ -1,6 +1,4 @@
-import {
-  type AvailableModel,
-} from "@get-bb/plugin-sdk/provider-bridge";
+import { type AvailableModel } from "@get-bb/plugin-sdk/provider-bridge";
 import { query, type Options } from "@anthropic-ai/claude-agent-sdk";
 import { buildClaudeCodeModels } from "../model-list.js";
 import { translateMissingClaudeCliError } from "./missing-cli-error.js";
@@ -48,4 +46,55 @@ export async function listClaudeCodeBridgeModels(
   } finally {
     session.close();
   }
+}
+
+export interface ClaudeCodeBridgeModelListMemoOptions {
+  list?: (
+    env?: NodeJS.ProcessEnv,
+  ) => ReturnType<typeof listClaudeCodeBridgeModels>;
+  now?: () => number;
+  ttlMs: number;
+}
+
+/**
+ * Memoizes {@link listClaudeCodeBridgeModels} for one bridge process. Each
+ * probe spawns a Claude CLI, and every picker open, thread open, and server
+ * reconnect asks for the catalog; concurrent asks share one probe and a
+ * settled catalog is reused until the window ends. Failures are never kept so
+ * a transient probe error is retried on the next ask. The window stays short
+ * because the server memoizes on top of this and this bridge outlives server
+ * restarts: it absorbs bursts without doubling the staleness a login change
+ * can see.
+ */
+export function createClaudeCodeBridgeModelListMemo({
+  list = listClaudeCodeBridgeModels,
+  now = Date.now,
+  ttlMs,
+}: ClaudeCodeBridgeModelListMemoOptions): () => ReturnType<
+  typeof listClaudeCodeBridgeModels
+> {
+  type Catalog = Awaited<ReturnType<typeof listClaudeCodeBridgeModels>>;
+  let settled: { catalog: Catalog; expiresAt: number } | null = null;
+  let pending: Promise<Catalog> | null = null;
+  return () => {
+    if (settled !== null && settled.expiresAt > now()) {
+      return Promise.resolve(settled.catalog);
+    }
+    settled = null;
+    if (pending !== null) {
+      return pending;
+    }
+    const probe = list()
+      .then((catalog) => {
+        settled = { catalog, expiresAt: now() + ttlMs };
+        return catalog;
+      })
+      .finally(() => {
+        if (pending === probe) {
+          pending = null;
+        }
+      });
+    pending = probe;
+    return probe;
+  };
 }


### PR DESCRIPTION
## What was wrong

Every execution-options read (each thread open, window focus, reconnect) sent a fresh `provider.list_models` RPC to the host, and the host spawned a provider CLI per request (measured 1-3 s). Nothing cached the answer on the server, daemon, or bridge. The request carried the environment's cwd although the Claude Code, Codex, and ACP bridges ignore it, so every environment probed separately. On the client, the follow-up composer keyed its query by `environmentId`, so each thread in a different environment on the same machine issued its own request. On mobile this put a CLI spawn on the critical path of every thread open. (Mobile perf sweep finding B6.)

## What changed

- `apps/server`: `listProviderModelsMemoized` runs the probe through a new `createAsyncTtlMemo` (`services/lib/async-ttl-memo.ts`) held on `lifecycleDedupers.providerModelList` (10 min TTL, in-flight dedupe, failures never stored). The key is `[hostId, daemonSessionId, providerRegistrationRevision, command]`, so a daemon reconnect or a plugin reload re-probes at once. The probe bypasses the memo only while no daemon session is registered.
- `packages/domain`: `providerModelCatalogDependsOnWorkspace(providerId)` states which first-party bridges read the workspace path (only Pi). The server sends `cwd` only for those; host-scoped catalogs share one memo entry across environments.
- `apps/app`: component-local composers (`ThreadDetailPromptArea`, `EmbeddedThreadChat` via `PluginThreadChat`) receive the environment's host and `resolveThreadCreationProviderRouting` routes by `hostId` when the selected provider's catalog is host-scoped. Pi and unknown providers keep environment routing.
- `plugins/provider-claude-code`: `model/list` goes through `createClaudeCodeBridgeModelListMemo` (2 min window plus in-flight dedupe; failures not kept) so bursts share one CLI spawn.

## How you verified

- New tests: `apps/server/test/services/async-ttl-memo.test.ts` (TTL expiry, in-flight sharing, rejection not stored, clear); `apps/server/test/system/execution-options.test.ts` "model probe memo" block (one probe without cwd across two environments plus explicit host; Pi keeps cwd and keys per workspace; two concurrent readers share one held RPC; a failed probe is retried and a reconnected daemon session re-probes); `apps/app/src/hooks/useThreadCreationOptions.test.tsx` (claude-code component-local routes by host, pi routes by environment); `plugins/provider-claude-code/src/bridge/__tests__/model-list-memo.test.ts` (shared probe, window expiry, failure retry). Updated `provider-routing.test.ts` and `public-threads.defaults.test.ts` for the host-scoped Codex probe (no cwd, single probe).
- `pnpm exec turbo run typecheck --force` for @bb/domain, @bb/server, @bb/app, bb-plugin-provider-claude-code: pass. `lint` for @bb/app: 0 errors, 147 warnings (same as baseline). Targeted vitest runs above: server 54/54, app 134/134, claude plugin 264/264. Full @bb/server suite: 1735 passed, 2 unrelated failures (file-mode umask assertion in internal-skill-trees, timeout in plugin-service under load).

Fixes: part of the mobile / iOS Safari performance program (verified sweep report in the bb thread; no single issue).


## Stack context

Layer 6 of 22 in the `bb/mobile-perf/*` stack (bottom → top: quick wins first, big rocks last).
- Prerequisite (layer below): `bb/mobile-perf/thread-open-query-gating-review` (#1884).
- Next layer: `bb/mobile-perf/workspace-status-and-pr-cache` (#1886).
- Audit findings addressed: see title IDs. Review: approved-with-fixes; 1 review fix commit(s).
- Reviewer notes / follow-ups: Minor (not fixed, low value): on plugin surfaces (PluginThreadChat) the environment is fetched separately from the thread, so the follow-up execution-options query can flip its key | Design note: host-scoped catalogs are reused for up to 10 min (server) + 2 min (Claude bridge) after an account/CLI change on the same daemon session; the curated Claude catalog is
- Wire/contract: No schema or protocol change. HOST_DAEMON_PROTOCOL_VERSION not bumped (still 135). The only wire-visible difference: the server now omits the already-optional `cwd` field from `provider.list_models` for claude-code, codex, and acp-* providers (verified their bridges ignore it: Claude `model/list` params are `z.object({})`, Codex `handleModelList(id)` takes no params, ACP builds its list from the l

> AGENT GENERATED: by Claude Opus 5

