### PR TITLE
Dedupe and briefly cache workspace status and pull-request reads (B7, B8)

### DIFF
--- a/apps/server/src/routes/environments.ts
+++ b/apps/server/src/routes/environments.ts
@@ -38,7 +38,10 @@ import {
 } from "./branch-list-query.js";
 import { parseFileListLimit } from "./file-list-query.js";
 import { parsePathKindInclusion } from "./path-list-inclusion.js";
-import { requireWorkspaceCommandTarget } from "../services/environments/workspace-command-target.js";
+import {
+  requireWorkspaceCommandTarget,
+  type WorkspaceCommandTarget,
+} from "../services/environments/workspace-command-target.js";
 import { callEnvironmentWorkspaceStatus } from "../services/environments/workspace-status.js";
 import { assembleThreadPullRequest } from "../services/environments/pull-request.js";
 import {
@@ -148,6 +151,22 @@ function toWorkspaceDiffTarget(query: EnvironmentDiffQuery) {
       return _exhaustive;
     }
   }
+}
+
+/**
+ * Cache key for read-only workspace probes. The workspace context is part
+ * of the key so a re-provisioned environment (new path or provision type)
+ * never reads a probe of the previous checkout.
+ */
+function workspaceReadCacheKey(target: WorkspaceCommandTarget): string {
+  return JSON.stringify(target.workspaceContext);
+}
+
+function workspaceStatusCacheKey(
+  target: WorkspaceCommandTarget,
+  mergeBaseBranch: string | undefined,
+): string {
+  return `${workspaceReadCacheKey(target)} ${mergeBaseBranch ?? ""}`;
 }
 
 function isWorktreeEnvironment(environment: Environment): boolean {
@@ -332,12 +351,20 @@ export function registerEnvironmentRoutes(app: Hono, deps: AppDeps): void {
       });
     }
     const target = requireWorkspaceCommandTarget(environment);
-    const result = await callEnvironmentWorkspaceStatus(deps, {
-      environment,
-      target,
-      ...(query.mergeBaseBranch
-        ? { mergeBaseBranch: query.mergeBaseBranch }
-        : {}),
+    // Reads share one daemon probe per environment and reuse it briefly;
+    // daemon environment events invalidate (see WorkspaceReadCaches).
+    const result = await deps.workspaceReadCaches.status.read({
+      environmentId: environment.id,
+      hostId: target.hostId,
+      key: workspaceStatusCacheKey(target, query.mergeBaseBranch),
+      load: () =>
+        callEnvironmentWorkspaceStatus(deps, {
+          environment,
+          target,
+          ...(query.mergeBaseBranch
+            ? { mergeBaseBranch: query.mergeBaseBranch }
+            : {}),
+        }),
     });
     if (result.outcome === "unavailable") {
       return context.json({
@@ -361,14 +388,22 @@ export function registerEnvironmentRoutes(app: Hono, deps: AppDeps): void {
       return context.json({ outcome: "absent" });
     }
     const target = requireWorkspaceCommandTarget(environment);
-    const result = await callHostRetryableOnlineRpc(deps, {
+    // `gh pr view` per read is expensive; reads share one daemon probe per
+    // environment and reuse it briefly (see WorkspaceReadCaches).
+    const result = await deps.workspaceReadCaches.pullRequest.read({
+      environmentId: environment.id,
       hostId: target.hostId,
-      timeoutMs: COMMAND_TIMEOUT_MS,
-      command: {
-        type: "workspace.pull_request",
-        environmentId: target.environmentId,
-        workspaceContext: target.workspaceContext,
-      },
+      key: workspaceReadCacheKey(target),
+      load: () =>
+        callHostRetryableOnlineRpc(deps, {
+          hostId: target.hostId,
+          timeoutMs: COMMAND_TIMEOUT_MS,
+          command: {
+            type: "workspace.pull_request",
+            environmentId: target.environmentId,
+            workspaceContext: target.workspaceContext,
+          },
+        }),
     });
     if (result.outcome === "available") {
       return context.json({
@@ -613,273 +648,282 @@ export function registerEnvironmentRoutes(app: Hono, deps: AppDeps): void {
       context.req.param("id"),
     );
 
-    switch (payload.action) {
-      case "commit": {
-        const target = requireWorkspaceCommandTarget(environment);
-        const { workspaceContext } = target;
+    // Every action below writes to the workspace (or its pull request), and
+    // the client refetches status / pull request as soon as the response
+    // lands. The daemon watcher event for the write arrives asynchronously,
+    // often after that refetch, so drop the cached reads here, whether the
+    // action succeeded or failed midway; a partial write may have landed.
+    try {
+      switch (payload.action) {
+        case "commit": {
+          const target = requireWorkspaceCommandTarget(environment);
+          const { workspaceContext } = target;
 
-        const [statusResult, diffResult] = await Promise.all([
-          callEnvironmentWorkspaceStatus(deps, {
+          const [statusResult, diffResult] = await Promise.all([
+            callEnvironmentWorkspaceStatus(deps, {
+              environment,
+              target,
+            }),
+            callHostRetryableOnlineRpc(deps, {
+              hostId: target.hostId,
+              timeoutMs: COMMAND_TIMEOUT_MS,
+              command: {
+                type: "workspace.diff",
+                environmentId: target.environmentId,
+                workspaceContext,
+                target: { type: "uncommitted" },
+                maxDiffBytes: AI_MAX_DIFF_BYTES,
+                maxFileListBytes: AI_MAX_FILE_LIST_BYTES,
+                maxUntrackedFiles: WORKSPACE_DIFF_MAX_FILES,
+              },
+            }),
+          ]);
+          const workspaceStatus = requireAvailableWorkspaceStatus(statusResult);
+          const workspaceDiff = requireAvailableWorkspaceDiff(diffResult);
+          if (!workspaceStatus.workingTree.hasUncommittedChanges) {
+            throw new ApiError(
+              409,
+              "no_changes",
+              "No uncommitted changes to commit",
+            );
+          }
+
+          const aiMessage = await generateCommitMessage(deps, {
+            diffDescription: "uncommitted changes",
+            shortstat: workspaceDiff.shortstat,
+            files: workspaceDiff.files,
+            patch: workspaceDiff.diff,
+          });
+          const commitMessage = aiMessage ?? COMMIT_FALLBACK_MESSAGE;
+
+          const result = await mapNoChangesTo409(
+            "No uncommitted changes to commit",
+            () =>
+              runLiveCommandAndWait(deps, {
+                hostId: target.hostId,
+                timeoutMs: COMMAND_TIMEOUT_MS,
+                command: {
+                  type: "workspace.commit",
+                  environmentId: target.environmentId,
+                  workspaceContext,
+                  message: commitMessage,
+                },
+              }),
+          );
+          return context.json({
+            ok: true,
+            action: "commit",
+            message: `Created commit ${result.commitSha}`,
+            commitSha: result.commitSha,
+            commitSubject: result.commitSubject,
+          });
+        }
+        case "squash_merge": {
+          const target = requireWorkspaceCommandTarget(environment);
+          const { workspaceContext } = target;
+          const targetBranch = payload.options.mergeBaseBranch;
+
+          const statusResult = await callEnvironmentWorkspaceStatus(deps, {
             environment,
             target,
-          }),
-          callHostRetryableOnlineRpc(deps, {
-            hostId: target.hostId,
+          });
+          const workspaceStatus = requireAvailableWorkspaceStatus(statusResult);
+
+          const currentBranch = workspaceStatus.branch.currentBranch;
+          if (!currentBranch) {
+            throw new ApiError(
+              409,
+              "invalid_request",
+              "Cannot squash merge from a detached workspace",
+            );
+          }
+
+          const targetBranchResult = await callHostRetryableOnlineRpc(deps, {
+            hostId: environment.hostId,
             timeoutMs: COMMAND_TIMEOUT_MS,
             command: {
-              type: "workspace.diff",
-              environmentId: target.environmentId,
-              workspaceContext,
-              target: { type: "uncommitted" },
-              maxDiffBytes: AI_MAX_DIFF_BYTES,
-              maxFileListBytes: AI_MAX_FILE_LIST_BYTES,
-              maxUntrackedFiles: WORKSPACE_DIFF_MAX_FILES,
+              type: "host.list_branches",
+              path: environment.path,
+              selectedBranch: targetBranch,
+              limit: 1,
             },
-          }),
-        ]);
-        const workspaceStatus = requireAvailableWorkspaceStatus(statusResult);
-        const workspaceDiff = requireAvailableWorkspaceDiff(diffResult);
-        if (!workspaceStatus.workingTree.hasUncommittedChanges) {
-          throw new ApiError(
-            409,
-            "no_changes",
-            "No uncommitted changes to commit",
-          );
-        }
+          });
+          assertSquashMergeTargetIsLocal({
+            selectedBranch: targetBranchResult.selectedBranch,
+            targetBranch,
+          });
 
-        const aiMessage = await generateCommitMessage(deps, {
-          diffDescription: "uncommitted changes",
-          shortstat: workspaceDiff.shortstat,
-          files: workspaceDiff.files,
-          patch: workspaceDiff.diff,
-        });
-        const commitMessage = aiMessage ?? COMMIT_FALLBACK_MESSAGE;
-
-        const result = await mapNoChangesTo409(
-          "No uncommitted changes to commit",
-          () =>
-            runLiveCommandAndWait(deps, {
+          if (workspaceStatus.workingTree.hasUncommittedChanges) {
+            await runLiveCommandAndWait(deps, {
               hostId: target.hostId,
               timeoutMs: COMMAND_TIMEOUT_MS,
               command: {
                 type: "workspace.commit",
                 environmentId: target.environmentId,
                 workspaceContext,
-                message: commitMessage,
+                message: PRE_MERGE_COMMIT_MESSAGE,
               },
-            }),
-        );
-        return context.json({
-          ok: true,
-          action: "commit",
-          message: `Created commit ${result.commitSha}`,
-          commitSha: result.commitSha,
-          commitSubject: result.commitSubject,
-        });
-      }
-      case "squash_merge": {
-        const target = requireWorkspaceCommandTarget(environment);
-        const { workspaceContext } = target;
-        const targetBranch = payload.options.mergeBaseBranch;
+            });
+          }
 
-        const statusResult = await callEnvironmentWorkspaceStatus(deps, {
-          environment,
-          target,
-        });
-        const workspaceStatus = requireAvailableWorkspaceStatus(statusResult);
-
-        const currentBranch = workspaceStatus.branch.currentBranch;
-        if (!currentBranch) {
-          throw new ApiError(
-            409,
-            "invalid_request",
-            "Cannot squash merge from a detached workspace",
-          );
-        }
-
-        const targetBranchResult = await callHostRetryableOnlineRpc(deps, {
-          hostId: environment.hostId,
-          timeoutMs: COMMAND_TIMEOUT_MS,
-          command: {
-            type: "host.list_branches",
-            path: environment.path,
-            selectedBranch: targetBranch,
-            limit: 1,
-          },
-        });
-        assertSquashMergeTargetIsLocal({
-          selectedBranch: targetBranchResult.selectedBranch,
-          targetBranch,
-        });
-
-        if (workspaceStatus.workingTree.hasUncommittedChanges) {
-          await runLiveCommandAndWait(deps, {
+          const diffResult = await callHostRetryableOnlineRpc(deps, {
             hostId: target.hostId,
             timeoutMs: COMMAND_TIMEOUT_MS,
             command: {
-              type: "workspace.commit",
+              type: "workspace.diff",
               environmentId: target.environmentId,
               workspaceContext,
-              message: PRE_MERGE_COMMIT_MESSAGE,
+              target: {
+                type: "branch_committed",
+                mergeBaseBranch: targetBranch,
+              },
+              maxDiffBytes: AI_MAX_DIFF_BYTES,
+              maxFileListBytes: AI_MAX_FILE_LIST_BYTES,
+              maxUntrackedFiles: WORKSPACE_DIFF_MAX_FILES,
             },
           });
+          const workspaceDiff = requireAvailableWorkspaceDiff(diffResult);
+
+          const aiMessage = await generateCommitMessage(deps, {
+            diffDescription: `squash merge of ${currentBranch} into ${targetBranch}`,
+            shortstat: workspaceDiff.shortstat,
+            files: workspaceDiff.files,
+            patch: workspaceDiff.diff,
+          });
+          const commitMessage = aiMessage ?? SQUASH_MERGE_FALLBACK_MESSAGE;
+
+          const result = await mapNoChangesTo409(
+            `No changes to merge into ${targetBranch}`,
+            () =>
+              runLiveCommandAndWait(deps, {
+                hostId: target.hostId,
+                timeoutMs: COMMAND_TIMEOUT_MS,
+                command: {
+                  type: "workspace.squash_merge",
+                  environmentId: target.environmentId,
+                  workspaceContext,
+                  targetBranch,
+                  commitMessage,
+                },
+              }),
+          );
+          return context.json({
+            ok: true,
+            action: "squash_merge",
+            merged: result.merged,
+            message: "Squash merge completed",
+            commitSha: result.commitSha,
+            commitSubject: result.commitSubject,
+          });
         }
+        case "pull_request_ready": {
+          if (!environment.isGitRepo) {
+            throw new ApiError(
+              409,
+              "invalid_request",
+              "Pull request actions require a git environment",
+            );
+          }
+          const target = requireWorkspaceCommandTarget(environment);
+          const pullRequest = await getPullRequestForWorkspaceTarget(
+            deps,
+            target,
+          );
+          assertCanMarkPullRequestReady(pullRequest);
 
-        const diffResult = await callHostRetryableOnlineRpc(deps, {
-          hostId: target.hostId,
-          timeoutMs: COMMAND_TIMEOUT_MS,
-          command: {
-            type: "workspace.diff",
-            environmentId: target.environmentId,
-            workspaceContext,
-            target: {
-              type: "branch_committed",
-              mergeBaseBranch: targetBranch,
-            },
-            maxDiffBytes: AI_MAX_DIFF_BYTES,
-            maxFileListBytes: AI_MAX_FILE_LIST_BYTES,
-            maxUntrackedFiles: WORKSPACE_DIFF_MAX_FILES,
-          },
-        });
-        const workspaceDiff = requireAvailableWorkspaceDiff(diffResult);
-
-        const aiMessage = await generateCommitMessage(deps, {
-          diffDescription: `squash merge of ${currentBranch} into ${targetBranch}`,
-          shortstat: workspaceDiff.shortstat,
-          files: workspaceDiff.files,
-          patch: workspaceDiff.diff,
-        });
-        const commitMessage = aiMessage ?? SQUASH_MERGE_FALLBACK_MESSAGE;
-
-        const result = await mapNoChangesTo409(
-          `No changes to merge into ${targetBranch}`,
-          () =>
+          await mapPullRequestActionFailureTo409(() =>
             runLiveCommandAndWait(deps, {
               hostId: target.hostId,
               timeoutMs: COMMAND_TIMEOUT_MS,
               command: {
-                type: "workspace.squash_merge",
+                type: "workspace.pull_request_action",
+                operation: "ready",
                 environmentId: target.environmentId,
-                workspaceContext,
-                targetBranch,
-                commitMessage,
+                workspaceContext: target.workspaceContext,
               },
             }),
-        );
-        return context.json({
-          ok: true,
-          action: "squash_merge",
-          merged: result.merged,
-          message: "Squash merge completed",
-          commitSha: result.commitSha,
-          commitSubject: result.commitSubject,
-        });
-      }
-      case "pull_request_ready": {
-        if (!environment.isGitRepo) {
-          throw new ApiError(
-            409,
-            "invalid_request",
-            "Pull request actions require a git environment",
           );
+          return context.json({
+            ok: true,
+            action: "pull_request_ready",
+            message: "Pull request marked ready",
+          });
         }
-        const target = requireWorkspaceCommandTarget(environment);
-        const pullRequest = await getPullRequestForWorkspaceTarget(
-          deps,
-          target,
-        );
-        assertCanMarkPullRequestReady(pullRequest);
-
-        await mapPullRequestActionFailureTo409(() =>
-          runLiveCommandAndWait(deps, {
-            hostId: target.hostId,
-            timeoutMs: COMMAND_TIMEOUT_MS,
-            command: {
-              type: "workspace.pull_request_action",
-              operation: "ready",
-              environmentId: target.environmentId,
-              workspaceContext: target.workspaceContext,
-            },
-          }),
-        );
-        return context.json({
-          ok: true,
-          action: "pull_request_ready",
-          message: "Pull request marked ready",
-        });
-      }
-      case "pull_request_draft": {
-        if (!environment.isGitRepo) {
-          throw new ApiError(
-            409,
-            "invalid_request",
-            "Pull request actions require a git environment",
+        case "pull_request_draft": {
+          if (!environment.isGitRepo) {
+            throw new ApiError(
+              409,
+              "invalid_request",
+              "Pull request actions require a git environment",
+            );
+          }
+          const target = requireWorkspaceCommandTarget(environment);
+          const pullRequest = await getPullRequestForWorkspaceTarget(
+            deps,
+            target,
           );
-        }
-        const target = requireWorkspaceCommandTarget(environment);
-        const pullRequest = await getPullRequestForWorkspaceTarget(
-          deps,
-          target,
-        );
-        assertCanConvertPullRequestToDraft(pullRequest);
+          assertCanConvertPullRequestToDraft(pullRequest);
 
-        await mapPullRequestActionFailureTo409(() =>
-          runLiveCommandAndWait(deps, {
-            hostId: target.hostId,
-            timeoutMs: COMMAND_TIMEOUT_MS,
-            command: {
-              type: "workspace.pull_request_action",
-              operation: "draft",
-              environmentId: target.environmentId,
-              workspaceContext: target.workspaceContext,
-            },
-          }),
-        );
-        return context.json({
-          ok: true,
-          action: "pull_request_draft",
-          message: "Pull request converted to draft",
-        });
-      }
-      case "pull_request_merge": {
-        if (!environment.isGitRepo) {
-          throw new ApiError(
-            409,
-            "invalid_request",
-            "Pull request actions require a git environment",
+          await mapPullRequestActionFailureTo409(() =>
+            runLiveCommandAndWait(deps, {
+              hostId: target.hostId,
+              timeoutMs: COMMAND_TIMEOUT_MS,
+              command: {
+                type: "workspace.pull_request_action",
+                operation: "draft",
+                environmentId: target.environmentId,
+                workspaceContext: target.workspaceContext,
+              },
+            }),
           );
+          return context.json({
+            ok: true,
+            action: "pull_request_draft",
+            message: "Pull request converted to draft",
+          });
         }
-        const target = requireWorkspaceCommandTarget(environment);
-        const pullRequest = await getPullRequestForWorkspaceTarget(
-          deps,
-          target,
-        );
-        assertCanMergePullRequest(pullRequest);
+        case "pull_request_merge": {
+          if (!environment.isGitRepo) {
+            throw new ApiError(
+              409,
+              "invalid_request",
+              "Pull request actions require a git environment",
+            );
+          }
+          const target = requireWorkspaceCommandTarget(environment);
+          const pullRequest = await getPullRequestForWorkspaceTarget(
+            deps,
+            target,
+          );
+          assertCanMergePullRequest(pullRequest);
 
-        await mapPullRequestActionFailureTo409(() =>
-          runLiveCommandAndWait(deps, {
-            hostId: target.hostId,
-            timeoutMs: COMMAND_TIMEOUT_MS,
-            command: {
-              type: "workspace.pull_request_action",
-              operation: "merge",
-              method: payload.options.method,
-              environmentId: target.environmentId,
-              workspaceContext: target.workspaceContext,
-            },
-          }),
-        );
-        return context.json({
-          ok: true,
-          action: "pull_request_merge",
-          method: payload.options.method,
-          message: "Pull request merge started",
-        });
+          await mapPullRequestActionFailureTo409(() =>
+            runLiveCommandAndWait(deps, {
+              hostId: target.hostId,
+              timeoutMs: COMMAND_TIMEOUT_MS,
+              command: {
+                type: "workspace.pull_request_action",
+                operation: "merge",
+                method: payload.options.method,
+                environmentId: target.environmentId,
+                workspaceContext: target.workspaceContext,
+              },
+            }),
+          );
+          return context.json({
+            ok: true,
+            action: "pull_request_merge",
+            method: payload.options.method,
+            message: "Pull request merge started",
+          });
+        }
+        default: {
+          const _exhaustive: never = payload;
+          throw new Error(`Unhandled environment action: ${_exhaustive}`);
+        }
       }
-      default: {
-        const _exhaustive: never = payload;
-        throw new Error(`Unhandled environment action: ${_exhaustive}`);
-      }
+    } finally {
+      deps.workspaceReadCaches.invalidateEnvironment(environment.id);
     }
   });
 }

--- a/apps/server/src/routes/files.ts
+++ b/apps/server/src/routes/files.ts
@@ -199,6 +199,21 @@ export function registerFileRoutes(app: Hono, deps: AppDeps): void {
     });
   }
 
+  // A host file write may land inside an environment checkout. The daemon
+  // watcher event for it arrives asynchronously, and only when someone is
+  // subscribed, so drop the host's cached workspace reads before responding
+  // (whether the write succeeded or failed midway).
+  const runHostFileMutation = async <T>(
+    hostId: string,
+    run: () => Promise<T>,
+  ): Promise<T> => {
+    try {
+      return await run();
+    } finally {
+      deps.workspaceReadCaches.invalidateHost(hostId);
+    }
+  };
+
   post(fileRoutes.read, async (context, payload) => {
     const hostId = resolveHostId(payload.hostId);
     try {
@@ -222,24 +237,26 @@ export function registerFileRoutes(app: Hono, deps: AppDeps): void {
   post(fileRoutes.write, async (context, payload) => {
     const hostId = resolveHostId(payload.hostId);
     try {
-      const result = await callHostOnlineRpc(deps, {
-        hostId,
-        timeoutMs: COMMAND_TIMEOUT_MS,
-        command: {
-          type: "host.write_file",
-          path: payload.path,
-          content: payload.content,
-          contentEncoding: payload.contentEncoding ?? "utf8",
-          createParents: payload.createParents ?? false,
-          ...(payload.rootPath !== undefined
-            ? { rootPath: payload.rootPath }
-            : {}),
-          ...(payload.expectedSha256 !== undefined
-            ? { expectedSha256: payload.expectedSha256 }
-            : {}),
-          ...(payload.mode !== undefined ? { mode: payload.mode } : {}),
-        },
-      });
+      const result = await runHostFileMutation(hostId, () =>
+        callHostOnlineRpc(deps, {
+          hostId,
+          timeoutMs: COMMAND_TIMEOUT_MS,
+          command: {
+            type: "host.write_file",
+            path: payload.path,
+            content: payload.content,
+            contentEncoding: payload.contentEncoding ?? "utf8",
+            createParents: payload.createParents ?? false,
+            ...(payload.rootPath !== undefined
+              ? { rootPath: payload.rootPath }
+              : {}),
+            ...(payload.expectedSha256 !== undefined
+              ? { expectedSha256: payload.expectedSha256 }
+              : {}),
+            ...(payload.mode !== undefined ? { mode: payload.mode } : {}),
+          },
+        }),
+      );
       return context.json(result);
     } catch (error) {
       return remapDaemonFileRouteError(error);
@@ -289,18 +306,20 @@ export function registerFileRoutes(app: Hono, deps: AppDeps): void {
   post(fileRoutes.mkdir, async (context, payload) => {
     const hostId = resolveHostId(payload.hostId);
     try {
-      const result = await callHostOnlineRpc(deps, {
-        hostId,
-        timeoutMs: COMMAND_TIMEOUT_MS,
-        command: {
-          type: "host.mkdir",
-          path: payload.path,
-          recursive: payload.recursive ?? false,
-          ...(payload.rootPath !== undefined
-            ? { rootPath: payload.rootPath }
-            : {}),
-        },
-      });
+      const result = await runHostFileMutation(hostId, () =>
+        callHostOnlineRpc(deps, {
+          hostId,
+          timeoutMs: COMMAND_TIMEOUT_MS,
+          command: {
+            type: "host.mkdir",
+            path: payload.path,
+            recursive: payload.recursive ?? false,
+            ...(payload.rootPath !== undefined
+              ? { rootPath: payload.rootPath }
+              : {}),
+          },
+        }),
+      );
       return context.json(result);
     } catch (error) {
       return remapDaemonFileRouteError(error);
@@ -310,18 +329,20 @@ export function registerFileRoutes(app: Hono, deps: AppDeps): void {
   post(fileRoutes.move, async (context, payload) => {
     const hostId = resolveHostId(payload.hostId);
     try {
-      const result = await callHostOnlineRpc(deps, {
-        hostId,
-        timeoutMs: COMMAND_TIMEOUT_MS,
-        command: {
-          type: "host.move_path",
-          sourcePath: payload.sourcePath,
-          destinationPath: payload.destinationPath,
-          ...(payload.rootPath !== undefined
-            ? { rootPath: payload.rootPath }
-            : {}),
-        },
-      });
+      const result = await runHostFileMutation(hostId, () =>
+        callHostOnlineRpc(deps, {
+          hostId,
+          timeoutMs: COMMAND_TIMEOUT_MS,
+          command: {
+            type: "host.move_path",
+            sourcePath: payload.sourcePath,
+            destinationPath: payload.destinationPath,
+            ...(payload.rootPath !== undefined
+              ? { rootPath: payload.rootPath }
+              : {}),
+          },
+        }),
+      );
       return context.json(result);
     } catch (error) {
       return remapDaemonFileRouteError(error);
@@ -331,18 +352,20 @@ export function registerFileRoutes(app: Hono, deps: AppDeps): void {
   post(fileRoutes.remove, async (context, payload) => {
     const hostId = resolveHostId(payload.hostId);
     try {
-      const result = await callHostOnlineRpc(deps, {
-        hostId,
-        timeoutMs: COMMAND_TIMEOUT_MS,
-        command: {
-          type: "host.remove_path",
-          path: payload.path,
-          recursive: payload.recursive ?? false,
-          ...(payload.rootPath !== undefined
-            ? { rootPath: payload.rootPath }
-            : {}),
-        },
-      });
+      const result = await runHostFileMutation(hostId, () =>
+        callHostOnlineRpc(deps, {
+          hostId,
+          timeoutMs: COMMAND_TIMEOUT_MS,
+          command: {
+            type: "host.remove_path",
+            path: payload.path,
+            recursive: payload.recursive ?? false,
+            ...(payload.rootPath !== undefined
+              ? { rootPath: payload.rootPath }
+              : {}),
+          },
+        }),
+      );
       return context.json(result);
     } catch (error) {
       return remapDaemonFileRouteError(error);

--- a/apps/server/src/services/environments/workspace-read-cache.test.ts
+++ b/apps/server/src/services/environments/workspace-read-cache.test.ts
@@ -1,0 +1,292 @@
+import type { ChangedMessage } from "@bb/domain";
+import { describe, expect, it } from "vitest";
+import {
+  EnvironmentReadCache,
+  WorkspaceReadCaches,
+} from "./workspace-read-cache.js";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function createClock(start = 1_000) {
+  let now = start;
+  return {
+    now: () => now,
+    advance(ms: number) {
+      now += ms;
+    },
+  };
+}
+
+function createCounter<T>(values: T[]) {
+  const loads: Deferred<T>[] = [];
+  return {
+    loads,
+    load: () => {
+      const next = deferred<T>();
+      loads.push(next);
+      const value = values[loads.length - 1];
+      if (value !== undefined) {
+        next.resolve(value);
+      }
+      return next.promise;
+    },
+  };
+}
+
+function createFakeHub() {
+  const listeners = new Set<(message: ChangedMessage) => void>();
+  return {
+    onChangedMessage(listener: (message: ChangedMessage) => void) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    emit(message: ChangedMessage) {
+      for (const listener of listeners) {
+        listener(message);
+      }
+    },
+  };
+}
+
+const READ = { environmentId: "env-1", hostId: "host-1", key: "k" };
+
+describe("EnvironmentReadCache", () => {
+  it("shares one in-flight load between overlapping reads and reuses it inside the TTL", async () => {
+    const clock = createClock();
+    const cache = new EnvironmentReadCache<string>({
+      now: clock.now,
+      ttlMs: 3_000,
+    });
+    const counter = createCounter<string>([]);
+
+    const first = cache.read({ ...READ, load: counter.load });
+    const second = cache.read({ ...READ, load: counter.load });
+    expect(counter.loads).toHaveLength(1);
+    counter.loads[0]?.resolve("a");
+    await expect(first).resolves.toBe("a");
+    await expect(second).resolves.toBe("a");
+
+    clock.advance(2_999);
+    await expect(cache.read({ ...READ, load: counter.load })).resolves.toBe(
+      "a",
+    );
+    expect(counter.loads).toHaveLength(1);
+
+    clock.advance(1);
+    const third = cache.read({ ...READ, load: counter.load });
+    expect(counter.loads).toHaveLength(2);
+    counter.loads[1]?.resolve("b");
+    await expect(third).resolves.toBe("b");
+  });
+
+  it("keys reads by environment and by input key", async () => {
+    const cache = new EnvironmentReadCache<string>({
+      now: () => 0,
+      ttlMs: 3_000,
+    });
+    const counter = createCounter(["a", "b", "c"]);
+
+    await cache.read({ ...READ, load: counter.load });
+    await cache.read({ ...READ, key: "other", load: counter.load });
+    await cache.read({ ...READ, environmentId: "env-2", load: counter.load });
+    await cache.read({ ...READ, load: counter.load });
+    expect(counter.loads).toHaveLength(3);
+  });
+
+  it("does not cache a rejected load and lets the next read retry", async () => {
+    const cache = new EnvironmentReadCache<string>({
+      now: () => 0,
+      ttlMs: 3_000,
+    });
+    const counter = createCounter<string>([]);
+
+    const first = cache.read({ ...READ, load: counter.load });
+    counter.loads[0]?.reject(new Error("boom"));
+    await expect(first).rejects.toThrow("boom");
+
+    const second = cache.read({ ...READ, load: counter.load });
+    expect(counter.loads).toHaveLength(2);
+    counter.loads[1]?.resolve("ok");
+    await expect(second).resolves.toBe("ok");
+  });
+
+  it("detaches an in-flight probe on invalidation so its result is not reused", async () => {
+    const cache = new EnvironmentReadCache<string>({
+      now: () => 0,
+      ttlMs: 3_000,
+    });
+    const counter = createCounter<string>([]);
+
+    const stale = cache.read({ ...READ, load: counter.load });
+    cache.invalidateEnvironment("env-1");
+
+    // A reader arriving after the change must not join the pre-change probe.
+    const fresh = cache.read({ ...READ, load: counter.load });
+    expect(counter.loads).toHaveLength(2);
+
+    counter.loads[0]?.resolve("pre-change");
+    counter.loads[1]?.resolve("post-change");
+    await expect(stale).resolves.toBe("pre-change");
+    await expect(fresh).resolves.toBe("post-change");
+
+    // The detached probe's late completion must not overwrite the cache.
+    await expect(cache.read({ ...READ, load: counter.load })).resolves.toBe(
+      "post-change",
+    );
+    expect(counter.loads).toHaveLength(2);
+  });
+
+  it("invalidates only the entries that belong to the given host", async () => {
+    const cache = new EnvironmentReadCache<string>({
+      now: () => 0,
+      ttlMs: 3_000,
+    });
+    const counter = createCounter(["a", "b", "c"]);
+
+    await cache.read({ ...READ, load: counter.load });
+    await cache.read({
+      ...READ,
+      environmentId: "env-2",
+      hostId: "host-2",
+      load: counter.load,
+    });
+    cache.invalidateHost("host-1");
+
+    await cache.read({
+      ...READ,
+      environmentId: "env-2",
+      hostId: "host-2",
+      load: counter.load,
+    });
+    expect(counter.loads).toHaveLength(2);
+    await cache.read({ ...READ, load: counter.load });
+    expect(counter.loads).toHaveLength(3);
+  });
+});
+
+describe("WorkspaceReadCaches", () => {
+  const statusResult = {
+    outcome: "unavailable" as const,
+    failure: {
+      code: "unknown" as const,
+      workspacePath: "/tmp/env-1",
+      message: "no git",
+    },
+  };
+  const pullRequestResult = { outcome: "absent" as const };
+
+  async function primeBoth(caches: WorkspaceReadCaches) {
+    const status = createCounter([statusResult, statusResult, statusResult]);
+    const pullRequest = createCounter([
+      pullRequestResult,
+      pullRequestResult,
+      pullRequestResult,
+    ]);
+    await caches.status.read({ ...READ, load: status.load });
+    await caches.pullRequest.read({ ...READ, load: pullRequest.load });
+    return {
+      async readBoth() {
+        await caches.status.read({ ...READ, load: status.load });
+        await caches.pullRequest.read({ ...READ, load: pullRequest.load });
+        return {
+          status: status.loads.length,
+          pullRequest: pullRequest.loads.length,
+        };
+      },
+    };
+  }
+
+  it("drops both caches for an environment on work-status-changed and git-refs-changed", async () => {
+    for (const change of ["work-status-changed", "git-refs-changed"] as const) {
+      const hub = createFakeHub();
+      const caches = new WorkspaceReadCaches({ hub, now: () => 0 });
+      const primed = await primeBoth(caches);
+
+      hub.emit({
+        type: "changed",
+        entity: "environment",
+        id: "env-2",
+        changes: [change],
+      });
+      expect(await primed.readBoth()).toEqual({ status: 1, pullRequest: 1 });
+
+      hub.emit({
+        type: "changed",
+        entity: "environment",
+        id: "env-1",
+        changes: [change],
+      });
+      expect(await primed.readBoth()).toEqual({ status: 2, pullRequest: 2 });
+    }
+  });
+
+  it("keeps cached reads across record-only environment changes", async () => {
+    const hub = createFakeHub();
+    const caches = new WorkspaceReadCaches({ hub, now: () => 0 });
+    const primed = await primeBoth(caches);
+
+    // The status probe records the observed branch (metadata-changed) while
+    // it is still in flight; that must not detach the probe.
+    hub.emit({
+      type: "changed",
+      entity: "environment",
+      id: "env-1",
+      changes: ["metadata-changed", "thread-storage-changed"],
+    });
+    expect(await primed.readBoth()).toEqual({ status: 1, pullRequest: 1 });
+  });
+
+  it("drops cached reads for a host when that host connects or disconnects", async () => {
+    const hub = createFakeHub();
+    const caches = new WorkspaceReadCaches({ hub, now: () => 0 });
+    const primed = await primeBoth(caches);
+
+    hub.emit({
+      type: "changed",
+      entity: "host",
+      id: "host-2",
+      changes: ["host-connected"],
+    });
+    expect(await primed.readBoth()).toEqual({ status: 1, pullRequest: 1 });
+
+    hub.emit({
+      type: "changed",
+      entity: "host",
+      id: "host-1",
+      changes: ["host-connected"],
+    });
+    expect(await primed.readBoth()).toEqual({ status: 2, pullRequest: 2 });
+  });
+
+  it("drops both caches when a server-side mutation invalidates the environment or host", async () => {
+    const hub = createFakeHub();
+    const caches = new WorkspaceReadCaches({ hub, now: () => 0 });
+    const primed = await primeBoth(caches);
+
+    caches.invalidateEnvironment("env-2");
+    caches.invalidateHost("host-2");
+    expect(await primed.readBoth()).toEqual({ status: 1, pullRequest: 1 });
+
+    caches.invalidateEnvironment("env-1");
+    expect(await primed.readBoth()).toEqual({ status: 2, pullRequest: 2 });
+
+    caches.invalidateHost("host-1");
+    expect(await primed.readBoth()).toEqual({ status: 3, pullRequest: 3 });
+  });
+});

--- a/apps/server/src/services/environments/workspace-read-cache.ts
+++ b/apps/server/src/services/environments/workspace-read-cache.ts
@@ -1,0 +1,253 @@
+import type { ChangedMessage, EnvironmentChangeKind } from "@bb/domain";
+import type { HostDaemonOnlineRpcResult } from "@bb/host-daemon-contract";
+
+/**
+ * Per-environment in-flight dedupe plus a short TTL cache for read-only
+ * workspace probes (`workspace.status`, `workspace.pull_request`).
+ *
+ * Every probe spawns git/gh subprocesses on the host. Several clients (a
+ * thread view, sidebar rows, a phone that just came back to the foreground)
+ * ask for the same environment within the same second, so identical reads
+ * that overlap share one daemon RPC and repeated reads inside the TTL are
+ * served from memory.
+ *
+ * Freshness is driven by two sources. Server-side workspace mutations
+ * (the environment action route, host file writes) call
+ * `invalidateEnvironment` / `invalidateHost` before they respond, because
+ * the client refetches on mutation success and the daemon's watcher event
+ * for that write arrives asynchronously, often after the response. The
+ * environment change events the web client already refetches on
+ * (`work-status-changed`, `git-refs-changed`, ...) cover writes the server
+ * does not perform itself (agent edits, the user's shell). Either source
+ * drops the cached value AND detaches any in-flight probe for that
+ * environment, because a probe that started before the change may have
+ * observed the pre-change tree. Later readers then start a fresh probe. The
+ * TTL only bounds staleness for the case where nobody is subscribed to the
+ * environment, so no daemon events arrive.
+ */
+
+/**
+ * Environment change kinds that leave workspace reads untouched.
+ *
+ * `metadata-changed` is record-only (name, recorded branch, ...). The status
+ * probe itself records the observed branch, so treating it as a tree change
+ * would detach every probe that follows a branch switch. A workspace move
+ * changes the read key (the workspace context is part of it), so it never
+ * reads a probe of the previous checkout.
+ */
+const IGNORED_ENVIRONMENT_CHANGES: ReadonlySet<EnvironmentChangeKind> = new Set(
+  ["metadata-changed", "thread-storage-changed"],
+);
+
+interface CacheEntry<TValue> {
+  expiresAt: number;
+  hostId: string;
+  value: TValue;
+}
+
+interface InFlightEntry<TValue> {
+  hostId: string;
+  promise: Promise<TValue>;
+}
+
+export interface EnvironmentReadCacheReadArgs<TValue> {
+  environmentId: string;
+  hostId: string;
+  /** Distinguishes reads of the same environment with different inputs. */
+  key: string;
+  load: () => Promise<TValue>;
+}
+
+interface EnvironmentReadCacheOptions {
+  now: () => number;
+  ttlMs: number;
+}
+
+interface EnvironmentReadCacheInvalidation {
+  invalidateAll(): void;
+  invalidateEnvironment(environmentId: string): void;
+  invalidateHost(hostId: string): void;
+}
+
+export class EnvironmentReadCache<
+  TValue,
+> implements EnvironmentReadCacheInvalidation {
+  private readonly entries = new Map<string, CacheEntry<TValue>>();
+  private readonly inFlight = new Map<string, InFlightEntry<TValue>>();
+
+  constructor(private readonly options: EnvironmentReadCacheOptions) {}
+
+  read(args: EnvironmentReadCacheReadArgs<TValue>): Promise<TValue> {
+    const cacheKey = `${args.environmentId} ${args.key}`;
+    const cached = this.entries.get(cacheKey);
+    if (cached && cached.expiresAt > this.options.now()) {
+      return Promise.resolve(cached.value);
+    }
+    if (cached) {
+      this.entries.delete(cacheKey);
+    }
+
+    const pending = this.inFlight.get(cacheKey);
+    if (pending) {
+      return pending.promise;
+    }
+
+    const promise = args.load().then(
+      (value) => {
+        // Only publish the value when this probe is still the current one.
+        // An invalidation that arrived mid-flight detached it, and the value
+        // may describe the pre-change tree.
+        if (this.inFlight.get(cacheKey)?.promise === promise) {
+          this.inFlight.delete(cacheKey);
+          this.entries.set(cacheKey, {
+            expiresAt: this.options.now() + this.options.ttlMs,
+            hostId: args.hostId,
+            value,
+          });
+        }
+        return value;
+      },
+      (error: unknown) => {
+        if (this.inFlight.get(cacheKey)?.promise === promise) {
+          this.inFlight.delete(cacheKey);
+        }
+        throw error;
+      },
+    );
+    this.inFlight.set(cacheKey, { hostId: args.hostId, promise });
+    return promise;
+  }
+
+  invalidateEnvironment(environmentId: string): void {
+    const prefix = `${environmentId} `;
+    this.dropWhere((cacheKey) => cacheKey.startsWith(prefix));
+  }
+
+  invalidateHost(hostId: string): void {
+    this.dropWhere((_cacheKey, entryHostId) => entryHostId === hostId);
+  }
+
+  invalidateAll(): void {
+    this.entries.clear();
+    this.inFlight.clear();
+  }
+
+  private dropWhere(
+    predicate: (cacheKey: string, hostId: string) => boolean,
+  ): void {
+    for (const [cacheKey, entry] of this.entries) {
+      if (predicate(cacheKey, entry.hostId)) {
+        this.entries.delete(cacheKey);
+      }
+    }
+    for (const [cacheKey, entry] of this.inFlight) {
+      if (predicate(cacheKey, entry.hostId)) {
+        this.inFlight.delete(cacheKey);
+      }
+    }
+  }
+}
+
+/**
+ * How long a `workspace.status` result may be reused without a daemon
+ * event. Long enough to fold the burst of reads a thread open or a phone
+ * foreground produces; short enough that an unsubscribed environment (no
+ * events) never shows a stale tree for long.
+ */
+export const WORKSPACE_STATUS_CACHE_TTL_MS = 3_000;
+/**
+ * How long a `workspace.pull_request` result may be reused without a daemon
+ * event. Remote check runs change without any local event, so this bounds
+ * how stale a check status can be between polls.
+ */
+export const WORKSPACE_PULL_REQUEST_CACHE_TTL_MS = 10_000;
+
+interface WorkspaceReadCachesDeps {
+  hub: {
+    onChangedMessage(listener: (message: ChangedMessage) => void): () => void;
+  };
+  now?: () => number;
+  pullRequestTtlMs?: number;
+  statusTtlMs?: number;
+}
+
+export class WorkspaceReadCaches {
+  readonly status: EnvironmentReadCache<
+    HostDaemonOnlineRpcResult<"workspace.status">
+  >;
+  readonly pullRequest: EnvironmentReadCache<
+    HostDaemonOnlineRpcResult<"workspace.pull_request">
+  >;
+
+  constructor(deps: WorkspaceReadCachesDeps) {
+    const now = deps.now ?? Date.now;
+    this.status = new EnvironmentReadCache({
+      now,
+      ttlMs: deps.statusTtlMs ?? WORKSPACE_STATUS_CACHE_TTL_MS,
+    });
+    this.pullRequest = new EnvironmentReadCache({
+      now,
+      ttlMs: deps.pullRequestTtlMs ?? WORKSPACE_PULL_REQUEST_CACHE_TTL_MS,
+    });
+    deps.hub.onChangedMessage((message) => {
+      this.handleChangedMessage(message);
+    });
+  }
+
+  private get caches(): EnvironmentReadCacheInvalidation[] {
+    return [this.status, this.pullRequest];
+  }
+
+  /**
+   * Drop every cached and in-flight read of one environment. Call this after
+   * any server-side workspace mutation for the environment (commit, squash
+   * merge, pull request action, ...) whether it succeeded or failed midway:
+   * the tree may have changed and the daemon's watcher event, if any, only
+   * arrives later. Over-invalidating costs one extra probe.
+   */
+  invalidateEnvironment(environmentId: string): void {
+    for (const cache of this.caches) {
+      cache.invalidateEnvironment(environmentId);
+    }
+  }
+
+  /** Drop every cached and in-flight read of every environment on a host. */
+  invalidateHost(hostId: string): void {
+    for (const cache of this.caches) {
+      cache.invalidateHost(hostId);
+    }
+  }
+
+  private invalidateAll(): void {
+    for (const cache of this.caches) {
+      cache.invalidateAll();
+    }
+  }
+
+  private handleChangedMessage(message: ChangedMessage): void {
+    if (message.entity === "environment") {
+      const relevant = message.changes.some(
+        (change) => !IGNORED_ENVIRONMENT_CHANGES.has(change),
+      );
+      if (!relevant) {
+        return;
+      }
+      if (message.id === undefined) {
+        this.invalidateAll();
+      } else {
+        this.invalidateEnvironment(message.id);
+      }
+      return;
+    }
+    if (message.entity === "host") {
+      // A daemon that reconnects may be looking at a different tree than
+      // the one it reported before it dropped; the client refetches on
+      // host changes too, so serve those refetches a fresh probe.
+      if (message.id === undefined) {
+        this.invalidateAll();
+      } else {
+        this.invalidateHost(message.id);
+      }
+    }
+  }
+}

--- a/apps/server/src/start-server.ts
+++ b/apps/server/src/start-server.ts
@@ -30,6 +30,7 @@ import { MANAGED_ENVIRONMENT_RETIRE_GRACE_MS } from "./constants.js";
 import type { ServerRuntimeConfig } from "./types.js";
 import { NotificationHub } from "./ws/hub.js";
 import { WatchInterestCoordinator } from "./ws/watch-interests.js";
+import { WorkspaceReadCaches } from "./services/environments/workspace-read-cache.js";
 import { HostSharedPortCoordinator } from "./ws/host-shared-ports.js";
 
 interface StartHttpListenerArgs {
@@ -57,6 +58,7 @@ export async function runServer(serverConfig: ServerConfig): Promise<void> {
   const hub = new NotificationHub();
   const watchInterests = new WatchInterestCoordinator({ db, hub });
   const sharedPorts = new HostSharedPortCoordinator({ db, hub });
+  const workspaceReadCaches = new WorkspaceReadCaches({ hub });
   const lifecycleDedupers = createLifecycleDedupers();
   const appUrl = toOptionalString(serverConfig.BB_APP_URL);
   const threadStorageRootPath = resolveThreadStorageRootPath({
@@ -184,6 +186,7 @@ export async function runServer(serverConfig: ServerConfig): Promise<void> {
       terminalSessions,
       watchInterests,
       sharedPorts,
+      workspaceReadCaches,
     },
     { staticDir },
   );

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -15,6 +15,7 @@ import type { TerminalSessionLifecycle } from "./services/terminals/terminal-ses
 import type { LifecycleDedupers } from "./lifecycle-dedupers.js";
 import type { NotificationHub } from "./ws/hub.js";
 import type { WatchInterestCoordinator } from "./ws/watch-interests.js";
+import type { WorkspaceReadCaches } from "./services/environments/workspace-read-cache.js";
 import type { HostSharedPortCoordinator } from "./ws/host-shared-ports.js";
 import type { SkillTreeRegistry } from "./services/skills/injected-skills.js";
 import type { ProviderRegistryService } from "./services/providers/provider-registry.js";
@@ -68,6 +69,7 @@ export interface AppDeps {
   terminalSessions: TerminalSessionLifecycle;
   watchInterests: WatchInterestCoordinator;
   sharedPorts: HostSharedPortCoordinator;
+  workspaceReadCaches: WorkspaceReadCaches;
 }
 
 export interface ServerAppDeps extends AppDeps {

--- a/apps/server/test/environments/workspace-read-cache-routes.test.ts
+++ b/apps/server/test/environments/workspace-read-cache-routes.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, it } from "vitest";
+import type { GitHostPullRequest, WorkspaceWorkingTree } from "@bb/domain";
+import type { HostDaemonOnlineRpcResult } from "@bb/host-daemon-contract";
+import {
+  listQueuedCommands,
+  reportQueuedCommandSuccess,
+  waitForQueuedCommand,
+  waitForQueuedCommandAfter,
+} from "../helpers/commands.js";
+import { readJson } from "../helpers/json.js";
+import {
+  seedEnvironment,
+  seedHostSession,
+  seedProjectWithSource,
+} from "../helpers/seed.js";
+import { withTestHarness, type TestAppHarness } from "../helpers/test-app.js";
+
+function workspaceStatus(
+  currentBranch: string,
+  state: WorkspaceWorkingTree["state"] = "clean",
+): HostDaemonOnlineRpcResult<"workspace.status"> {
+  const hasUncommittedChanges =
+    state === "untracked" ||
+    state === "dirty_uncommitted" ||
+    state === "dirty_and_committed_unmerged";
+  return {
+    outcome: "available",
+    workspaceStatus: {
+      workingTree: {
+        insertions: 0,
+        deletions: 0,
+        lineStatsComplete: true,
+        files: [],
+        hasUncommittedChanges,
+        state,
+      },
+      branch: { currentBranch, defaultBranch: "main" },
+      checkout: { kind: "branch", branchName: currentBranch, headSha: null },
+      mergeBase: null,
+    },
+  };
+}
+
+function rawPullRequest(
+  overrides: Partial<GitHostPullRequest> = {},
+): GitHostPullRequest {
+  return {
+    number: 42,
+    title: "Cache the PR probe",
+    state: "OPEN",
+    url: "https://github.com/acme/bb/pull/42",
+    isDraft: false,
+    baseRefName: "main",
+    headRefName: "bb/pr-cache",
+    updatedAt: "2026-06-16T12:30:00Z",
+    checks: [],
+    reviewDecision: null,
+    reviewRequestCount: 0,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    ...overrides,
+  };
+}
+
+function seedGitEnvironment(harness: TestAppHarness, suffix: string) {
+  const { host } = seedHostSession(harness.deps, {
+    id: `host-workspace-read-cache-${suffix}`,
+  });
+  const { project } = seedProjectWithSource(harness.deps, {
+    hostId: host.id,
+  });
+  const environment = seedEnvironment(harness.deps, {
+    hostId: host.id,
+    projectId: project.id,
+    branchName: "bb/pr-cache",
+    defaultBranch: "main",
+    path: `/tmp/workspace-read-cache-${suffix}`,
+    workspaceProvisionType: "managed-worktree",
+  });
+  return { host, environment };
+}
+
+describe("workspace read caches on the environment routes", () => {
+  it("serves overlapping and repeated status reads from one daemon probe until work-status-changed", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment } = seedGitEnvironment(harness, "status");
+      const url = `/api/v1/environments/${environment.id}/status`;
+
+      const first = harness.app.request(url);
+      const second = harness.app.request(url);
+      const statusCommand = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "workspace.status" &&
+          command.environmentId === environment.id,
+      );
+      await reportQueuedCommandSuccess(
+        harness,
+        statusCommand,
+        workspaceStatus("feature/one"),
+      );
+      for (const response of await Promise.all([first, second])) {
+        expect(response.status).toBe(200);
+        await expect(readJson(response)).resolves.toMatchObject({
+          outcome: "available",
+          workspace: { branch: { currentBranch: "feature/one" } },
+        });
+      }
+
+      // A read inside the TTL with no daemon event reuses the probe: the
+      // request resolves without a second `workspace.status` reaching the
+      // daemon (an uncached read would block on the settled capture above).
+      const third = await harness.app.request(url);
+      expect(third.status).toBe(200);
+      await expect(readJson(third)).resolves.toMatchObject({
+        workspace: { branch: { currentBranch: "feature/one" } },
+      });
+      expect(listQueuedCommands(harness, "workspace.status")).toHaveLength(0);
+
+      // A different merge base is a different read.
+      const withMergeBase = harness.app.request(
+        `${url}?mergeBaseBranch=release`,
+      );
+      const mergeBaseCommand = await waitForQueuedCommandAfter(
+        harness,
+        statusCommand.row.cursor,
+        ({ command }) =>
+          command.type === "workspace.status" &&
+          command.environmentId === environment.id,
+      );
+      expect(mergeBaseCommand.command).toMatchObject({
+        mergeBaseBranch: "release",
+      });
+      await reportQueuedCommandSuccess(
+        harness,
+        mergeBaseCommand,
+        workspaceStatus("feature/one"),
+      );
+      expect((await withMergeBase).status).toBe(200);
+
+      // The daemon's work-status-changed event invalidates the cached read.
+      harness.hub.notifyEnvironment(environment.id, ["work-status-changed"]);
+      const fourth = harness.app.request(url);
+      const refreshedCommand = await waitForQueuedCommandAfter(
+        harness,
+        mergeBaseCommand.row.cursor,
+        ({ command }) =>
+          command.type === "workspace.status" &&
+          command.environmentId === environment.id &&
+          command.mergeBaseBranch === undefined,
+      );
+      await reportQueuedCommandSuccess(
+        harness,
+        refreshedCommand,
+        workspaceStatus("feature/two"),
+      );
+      const fourthResponse = await fourth;
+      expect(fourthResponse.status).toBe(200);
+      await expect(readJson(fourthResponse)).resolves.toMatchObject({
+        workspace: { branch: { currentBranch: "feature/two" } },
+      });
+    });
+  });
+
+  it("serves repeated pull request reads from one gh probe until git-refs-changed", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment } = seedGitEnvironment(harness, "pull-request");
+      const url = `/api/v1/environments/${environment.id}/pull-request`;
+
+      const first = harness.app.request(url);
+      const second = harness.app.request(url);
+      const pullRequestCommand = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "workspace.pull_request" &&
+          command.environmentId === environment.id,
+      );
+      await reportQueuedCommandSuccess(harness, pullRequestCommand, {
+        outcome: "available",
+        pullRequest: rawPullRequest({ isDraft: true }),
+      });
+      for (const response of await Promise.all([first, second])) {
+        expect(response.status).toBe(200);
+        await expect(readJson(response)).resolves.toMatchObject({
+          outcome: "available",
+          pullRequest: { number: 42, state: "draft" },
+        });
+      }
+
+      // Same reasoning as the status test: an uncached read would block on
+      // a second `workspace.pull_request` that nobody answers.
+      const third = await harness.app.request(url);
+      expect(third.status).toBe(200);
+      await expect(readJson(third)).resolves.toMatchObject({
+        pullRequest: { number: 42, state: "draft" },
+      });
+      expect(
+        listQueuedCommands(harness, "workspace.pull_request"),
+      ).toHaveLength(0);
+
+      harness.hub.notifyEnvironment(environment.id, ["git-refs-changed"]);
+      const fourth = harness.app.request(url);
+      const refreshedCommand = await waitForQueuedCommandAfter(
+        harness,
+        pullRequestCommand.row.cursor,
+        ({ command }) =>
+          command.type === "workspace.pull_request" &&
+          command.environmentId === environment.id,
+      );
+      await reportQueuedCommandSuccess(harness, refreshedCommand, {
+        outcome: "available",
+        pullRequest: rawPullRequest({ isDraft: false }),
+      });
+      const fourthResponse = await fourth;
+      expect(fourthResponse.status).toBe(200);
+      await expect(readJson(fourthResponse)).resolves.toMatchObject({
+        pullRequest: { number: 42, state: "open" },
+      });
+    });
+  });
+
+  it("drops the cached status and pull request when the commit action mutates the workspace", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment } = seedGitEnvironment(harness, "commit-action");
+      const statusUrl = `/api/v1/environments/${environment.id}/status`;
+      const pullRequestUrl = `/api/v1/environments/${environment.id}/pull-request`;
+
+      // Warm both caches with the pre-commit tree.
+      const dirtyRead = harness.app.request(statusUrl);
+      const dirtyCommand = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "workspace.status" &&
+          command.environmentId === environment.id,
+      );
+      await reportQueuedCommandSuccess(
+        harness,
+        dirtyCommand,
+        workspaceStatus("bb/pr-cache", "untracked"),
+      );
+      await expect(readJson(await dirtyRead)).resolves.toMatchObject({
+        workspace: { workingTree: { state: "untracked" } },
+      });
+      const pullRequestRead = harness.app.request(pullRequestUrl);
+      const pullRequestCommand = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "workspace.pull_request" &&
+          command.environmentId === environment.id,
+      );
+      await reportQueuedCommandSuccess(harness, pullRequestCommand, {
+        outcome: "absent",
+      });
+      expect((await pullRequestRead).status).toBe(200);
+
+      // The commit action probes the workspace directly (not through the
+      // cache), commits, and responds. No daemon event is emitted here: the
+      // real watcher event arrives asynchronously, after the response.
+      const commitResponse = harness.app.request(
+        `/api/v1/environments/${environment.id}/actions`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ action: "commit" }),
+        },
+      );
+      const preflightCommand = await waitForQueuedCommandAfter(
+        harness,
+        pullRequestCommand.row.cursor,
+        ({ command }) =>
+          command.type === "workspace.status" &&
+          command.environmentId === environment.id,
+      );
+      await reportQueuedCommandSuccess(
+        harness,
+        preflightCommand,
+        workspaceStatus("bb/pr-cache", "untracked"),
+      );
+      const diffCommand = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "workspace.diff" &&
+          command.environmentId === environment.id,
+      );
+      await reportQueuedCommandSuccess(harness, diffCommand, {
+        outcome: "available",
+        diff: {
+          diff: "",
+          files: "",
+          mergeBaseRef: null,
+          shortstat: "",
+          truncated: false,
+        },
+      });
+      const commitCommand = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "workspace.commit" &&
+          command.environmentId === environment.id,
+      );
+      await reportQueuedCommandSuccess(harness, commitCommand, {
+        commitSha: "abc123",
+        commitSubject: "bb: automated commit",
+      });
+      expect((await commitResponse).status).toBe(200);
+
+      // The client refetches on mutation success, inside the status TTL.
+      // That read must probe the daemon again rather than serve the
+      // pre-commit "untracked" tree from the cache.
+      const refreshedRead = harness.app.request(statusUrl);
+      const refreshedCommand = await waitForQueuedCommandAfter(
+        harness,
+        commitCommand.row.cursor,
+        ({ command }) =>
+          command.type === "workspace.status" &&
+          command.environmentId === environment.id,
+      );
+      await reportQueuedCommandSuccess(
+        harness,
+        refreshedCommand,
+        workspaceStatus("bb/pr-cache", "clean"),
+      );
+      const refreshedResponse = await refreshedRead;
+      expect(refreshedResponse.status).toBe(200);
+      await expect(readJson(refreshedResponse)).resolves.toMatchObject({
+        workspace: { workingTree: { state: "clean" } },
+      });
+
+      // The pull request read (10 s TTL) is dropped by the same action.
+      const refreshedPullRequestRead = harness.app.request(pullRequestUrl);
+      const refreshedPullRequestCommand = await waitForQueuedCommandAfter(
+        harness,
+        commitCommand.row.cursor,
+        ({ command }) =>
+          command.type === "workspace.pull_request" &&
+          command.environmentId === environment.id,
+      );
+      await reportQueuedCommandSuccess(harness, refreshedPullRequestCommand, {
+        outcome: "available",
+        pullRequest: rawPullRequest(),
+      });
+      await expect(
+        readJson(await refreshedPullRequestRead),
+      ).resolves.toMatchObject({ pullRequest: { number: 42 } });
+    });
+  });
+});

--- a/apps/server/test/helpers/test-app.ts
+++ b/apps/server/test/helpers/test-app.ts
@@ -29,6 +29,7 @@ import type { NotificationHub } from "../../src/ws/hub.js";
 import { NotificationHub as NotificationHubImpl } from "../../src/ws/hub.js";
 import { WatchInterestCoordinator } from "../../src/ws/watch-interests.js";
 import { HostSharedPortCoordinator } from "../../src/ws/host-shared-ports.js";
+import { WorkspaceReadCaches } from "../../src/services/environments/workspace-read-cache.js";
 
 const TEST_MACHINE_KEY_PREFIX = "test-daemon-key";
 const TEST_SERVER_HOST = "127.0.0.1";
@@ -133,6 +134,7 @@ export async function createTestAppHarness(
   const hub = new NotificationHubImpl();
   const watchInterests = new WatchInterestCoordinator({ db, hub });
   const sharedPorts = new HostSharedPortCoordinator({ db, hub });
+  const workspaceReadCaches = new WorkspaceReadCaches({ hub });
   const providerRegistry = createProviderRegistryService({
     resolveAcpAgentCapabilities: (providerId) =>
       resolveAcpAgentCapabilitiesForProviderId({ config }, providerId),
@@ -244,6 +246,7 @@ export async function createTestAppHarness(
     terminalSessions,
     watchInterests,
     sharedPorts,
+    workspaceReadCaches,
   };
   const { app, pluginCatalogService, pluginService } = createApp(deps);
 

--- a/tests/integration/helpers/harness.ts
+++ b/tests/integration/helpers/harness.ts
@@ -49,6 +49,7 @@ import type {
 import { HostSharedPortCoordinator } from "../../../apps/server/src/ws/host-shared-ports.js";
 import { NotificationHub } from "../../../apps/server/src/ws/hub.js";
 import { WatchInterestCoordinator } from "../../../apps/server/src/ws/watch-interests.js";
+import { WorkspaceReadCaches } from "../../../apps/server/src/services/environments/workspace-read-cache.js";
 import { createPublicApiClient } from "@bb/server-contract";
 import { waitForHostConnected } from "./assertions.js";
 import { createIntegrationFetch } from "./fetch.js";
@@ -227,6 +228,7 @@ async function startIntegrationServer(
   const hub = new NotificationHub();
   const sharedPorts = new HostSharedPortCoordinator({ db, hub });
   const watchInterests = new WatchInterestCoordinator({ db, hub });
+  const workspaceReadCaches = new WorkspaceReadCaches({ hub });
   const config: ServerRuntimeConfig = {
     appSurface: "web",
     appVersion: "0.0.0-dev",
@@ -332,6 +334,7 @@ async function startIntegrationServer(
     telemetry,
     terminalSessions,
     watchInterests,
+    workspaceReadCaches,
   });
 
   let addressInfo: ListeningAddress | null = null;


### PR DESCRIPTION
## What was wrong

`GET /environments/:id/status` and `GET /environments/:id/pull-request` forwarded every request to the host daemon. Each status probe spawns 4-5 git subprocesses (measured 240-344 ms); each pull-request probe spawns `gh pr view`. A thread open, sidebar rows and a phone returning to the foreground ask for the same environment inside the same second, and the client refetches status on every `work-status-changed` batch. One editing turn produced a stream of duplicate probes on the host (audit findings B7, B8).

## What changed

- New `WorkspaceReadCaches` (`apps/server/src/services/environments/workspace-read-cache.ts`) on `AppDeps`: a per-environment in-flight dedupe plus a short TTL cache, 3 s for `workspace.status`, 10 s for `workspace.pull_request`.
- The two read routes go through the cache. Overlapping reads share one daemon RPC. Repeated reads inside the TTL are served from memory. The response shape is unchanged.
- Freshness follows the daemon events the client already refetches on. Any environment change except record-only `metadata-changed` / `thread-storage-changed` drops the cached value and detaches any in-flight probe for that environment (a probe that started before the change may have read the pre-change tree). Host connect/disconnect drops that host's entries. `metadata-changed` is ignored because the status probe itself records the observed branch mid-flight.
- Cache keys include the workspace context and the merge-base branch, so a re-provisioned environment or a different merge base never reads a stale entry. Mutation routes (commit, squash-merge, PR actions) keep probing directly.
- No server/daemon wire change.

## How you verified

- `apps/server/src/services/environments/workspace-read-cache.test.ts`: in-flight sharing, TTL expiry with a fake clock, key separation, no caching of rejections, in-flight detachment on invalidation (late result does not overwrite), host-scoped invalidation, both caches dropped on `work-status-changed` / `git-refs-changed`, kept across `metadata-changed` / `thread-storage-changed`, dropped on host events.
- `apps/server/test/environments/workspace-read-cache-routes.test.ts`: two concurrent status GETs produce one `workspace.status` daemon command; a third GET is served without a daemon round trip; `?mergeBaseBranch=` is a separate probe; `work-status-changed` forces a fresh probe. Same for `/pull-request` with `git-refs-changed`. These fail before the change (the third request blocks on an unanswered second daemon command).
- `pnpm exec turbo run typecheck --filter=@bb/server` passes; related suites (`test/public`, `test/hosts`, `test/internal`, `test/environments`, `test/ai/commit-message.test.ts`, `src/services/environments`) pass except one pre-existing umask-dependent assertion in `internal-skill-trees.test.ts` (file mode 0664 vs 0644, unrelated).

Fixes: part of the mobile / iOS Safari performance program (verified sweep report in the bb thread; no single issue).


## Stack context

Layer 7 of 22 in the `bb/mobile-perf/*` stack (bottom → top: quick wins first, big rocks last).
- Prerequisite (layer below): `bb/mobile-perf/list-models-cache` (#1885).
- Next layer: `bb/mobile-perf/search-fts` (#1887).
- Audit findings addressed: see title IDs. Review: approved.
- Reviewer notes / follow-ups: B8 client half (drop PR key from the work-status-changed handler, refetchOnWindowFocus:true, ~30 s pending-checks poll) is not in this package by design; until it lands, agent edit | Remote-only PR changes (e.g. `gh pr create` from a shell with no local ref change) can be up to 10 s stale; unsubscribed environments up to 3 s stale for status. Both are within wh | apps/server/src/routes/environments.ts has a pre-existing prettier drift (assertCanMarkPullRequestReady / assertCanConvertPullRequestToDraft) that predates this branch; not touched
- Wire/contract: None. No server<->daemon message, command, result, or HOST_DAEMON_PROTOCOL_VERSION change. HTTP responses for /status and /pull-request are byte-identical in shape; only freshness/dedupe changed. New internal AppDeps member `workspaceReadCaches` (server-only).

> AGENT GENERATED: by Claude Opus 5

