### PR TITLE
API brotli, cache validators, bfcache-friendly index and hub gating (B22, D8, I5, J5, B17)

### DIFF
--- a/apps/app/src/components/promptbox/AttachmentPreview.test.tsx
+++ b/apps/app/src/components/promptbox/AttachmentPreview.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearLocalAttachmentPreviews,
+  registerLocalAttachmentPreview,
+} from "@/lib/attachment-local-previews";
+import { AttachmentPreview } from "./AttachmentPreview";
+
+describe("AttachmentPreview", () => {
+  const revoked: string[] = [];
+  let created = 0;
+
+  beforeEach(() => {
+    created = 0;
+    revoked.length = 0;
+    // jsdom's URL has no object-URL methods; install recording stand-ins.
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: () => `blob:local-${++created}`,
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: (url: string) => {
+        revoked.push(url);
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    clearLocalAttachmentPreviews();
+    Reflect.deleteProperty(URL, "createObjectURL");
+    Reflect.deleteProperty(URL, "revokeObjectURL");
+  });
+
+  it("renders a just-picked image from its local object URL and revokes it on remove", () => {
+    registerLocalAttachmentPreview(
+      "photo-1-abc.png",
+      new Blob([new Uint8Array([1, 2, 3])], { type: "image/png" }),
+    );
+    // A non-image never gets an object URL.
+    registerLocalAttachmentPreview(
+      "notes-1-abc.txt",
+      new Blob(["hi"], { type: "text/plain" }),
+    );
+    const onRemoveAttachment = vi.fn();
+    const { getAllByRole, getByLabelText } = render(
+      <AttachmentPreview
+        attachmentProjectId="proj_1"
+        attachments={[
+          {
+            type: "localImage",
+            path: "photo-1-abc.png",
+            name: "photo.png",
+            mimeType: "image/png",
+            sizeBytes: 3,
+          },
+          {
+            type: "localImage",
+            path: "restored-2-def.png",
+            name: "restored.png",
+            mimeType: "image/png",
+            sizeBytes: 3,
+          },
+        ]}
+        expandedImageIndex={null}
+        onExpandedImageIndexChange={() => {}}
+        onRemoveAttachment={onRemoveAttachment}
+      />,
+    );
+    const images = getAllByRole("img");
+    expect(images.map((image) => image.getAttribute("src"))).toEqual([
+      "blob:local-1",
+      "/api/v1/projects/proj_1/attachments/content?path=restored-2-def.png",
+    ]);
+    expect(
+      images.every((image) => image.getAttribute("decoding") === "async"),
+    ).toBe(true);
+
+    fireEvent.click(getByLabelText("Remove photo.png"));
+    expect(onRemoveAttachment).toHaveBeenCalledWith("photo-1-abc.png");
+    expect(revoked).toEqual(["blob:local-1"]);
+  });
+});

--- a/apps/app/src/components/promptbox/AttachmentPreview.tsx
+++ b/apps/app/src/components/promptbox/AttachmentPreview.tsx
@@ -3,6 +3,25 @@ import { getWrappedImageIndex, ImageLightbox } from "@/components/ui/image-light
 import { Icon } from "@bb/shared-ui/icon";
 import type { PromptDraftAttachment } from "@/lib/prompt-draft";
 import { toUserAttachmentImageSrc } from "@/lib/user-attachment-images";
+import {
+  getLocalAttachmentPreviewSrc,
+  releaseLocalAttachmentPreview,
+} from "@/lib/attachment-local-previews";
+
+/**
+ * A just-picked image renders from its local object URL; anything restored
+ * from a persisted draft (or picked in another window) falls back to the
+ * stored attachment URL.
+ */
+function resolveAttachmentPreviewSrc(
+  path: string,
+  attachmentProjectId: string | undefined,
+): string {
+  return (
+    getLocalAttachmentPreviewSrc(path) ??
+    toUserAttachmentImageSrc(path, attachmentProjectId)
+  );
+}
 
 function isImageAttachment(attachment: PromptDraftAttachment): boolean {
   return (
@@ -32,7 +51,7 @@ export function AttachmentPreview({
   );
   const attachmentImageItems = imageAttachments.map((attachment) => ({
     alt: attachment.name,
-    src: toUserAttachmentImageSrc(attachment.path, attachmentProjectId),
+    src: resolveAttachmentPreviewSrc(attachment.path, attachmentProjectId),
   }));
   const hasMultipleAttachmentImages = imageAttachments.length > 1;
   const currentAttachmentImage =
@@ -64,19 +83,20 @@ export function AttachmentPreview({
                   title={attachment.name}
                 >
                   <img
-                    src={toUserAttachmentImageSrc(
-                      attachment.path,
-                      attachmentProjectId,
-                    )}
+                    src={attachmentImageItems[index]?.src}
                     alt={attachment.name}
                     className="h-16 w-24 object-cover"
                     loading="lazy"
+                    decoding="async"
                   />
                 </button>
                 {onRemoveAttachment ? (
                   <button
                     type="button"
-                    onClick={() => onRemoveAttachment(attachment.path)}
+                    onClick={() => {
+                      releaseLocalAttachmentPreview(attachment.path);
+                      onRemoveAttachment(attachment.path);
+                    }}
                     className="absolute right-1 top-1 z-10 rounded-full bg-black/55 p-0.5 text-white transition-colors hover:bg-black/70"
                     aria-label={`Remove ${attachment.name}`}
                   >

--- a/apps/app/src/components/thread/timeline/ConversationAttachments.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationAttachments.tsx
@@ -154,6 +154,7 @@ export function ConversationAttachments({
                   align === "end" ? "h-20 max-w-36" : "h-16 w-24",
                 )}
                 loading="lazy"
+                decoding="async"
               />
             </button>
           ))}

--- a/apps/app/src/hooks/mutations/project-mutations.ts
+++ b/apps/app/src/hooks/mutations/project-mutations.ts
@@ -6,6 +6,7 @@ import type {
   UploadedPromptAttachment,
 } from "@bb/server-contract";
 import { sdk } from "@/lib/sdk";
+import { registerLocalAttachmentPreview } from "@/lib/attachment-local-previews";
 import {
   applyProjectCreateResult,
   applyProjectDeleteResult,
@@ -194,11 +195,17 @@ export function useUploadPromptAttachment() {
       errorMessage: "Failed to upload attachment.",
       showErrorToast: false,
     },
-    mutationFn: ({
+    mutationFn: async ({
       projectId,
       file,
-    }: UploadPromptAttachmentRequest): Promise<UploadedPromptAttachment> =>
-      sdk.projects.attachments.upload({ projectId, clientFile: file }),
+    }: UploadPromptAttachmentRequest): Promise<UploadedPromptAttachment> => {
+      const uploaded = await sdk.projects.attachments.upload({
+        projectId,
+        clientFile: file,
+      });
+      registerLocalAttachmentPreview(uploaded.path, file);
+      return uploaded;
+    },
     retry: false,
   });
 }

--- a/apps/app/src/lib/attachment-local-previews.ts
+++ b/apps/app/src/lib/attachment-local-previews.ts
@@ -1,0 +1,60 @@
+/**
+ * Object URLs for images the user just picked, keyed by the stored attachment
+ * path the upload returned. The composer preview reads from here first so a
+ * fresh photo renders from the local file instead of re-downloading the
+ * multi-megabyte original the browser just uploaded.
+ *
+ * Bounded and revoked in FIFO order; the entries only need to survive the
+ * composer session that produced them.
+ */
+const MAX_LOCAL_PREVIEWS = 24;
+
+const localPreviewUrlsByPath = new Map<string, string>();
+
+function canCreateObjectUrls(): boolean {
+  return (
+    typeof URL !== "undefined" && typeof URL.createObjectURL === "function"
+  );
+}
+
+export function registerLocalAttachmentPreview(
+  path: string,
+  file: Blob,
+): void {
+  if (!canCreateObjectUrls() || !file.type.startsWith("image/")) {
+    return;
+  }
+  const previous = localPreviewUrlsByPath.get(path);
+  if (previous !== undefined) {
+    URL.revokeObjectURL(previous);
+    localPreviewUrlsByPath.delete(path);
+  }
+  localPreviewUrlsByPath.set(path, URL.createObjectURL(file));
+  while (localPreviewUrlsByPath.size > MAX_LOCAL_PREVIEWS) {
+    const oldest = localPreviewUrlsByPath.keys().next();
+    if (oldest.done) {
+      break;
+    }
+    releaseLocalAttachmentPreview(oldest.value);
+  }
+}
+
+export function getLocalAttachmentPreviewSrc(path: string): string | null {
+  return localPreviewUrlsByPath.get(path) ?? null;
+}
+
+export function releaseLocalAttachmentPreview(path: string): void {
+  const url = localPreviewUrlsByPath.get(path);
+  if (url === undefined) {
+    return;
+  }
+  localPreviewUrlsByPath.delete(path);
+  URL.revokeObjectURL(url);
+}
+
+/** Test hook: revoke and forget every registered preview. */
+export function clearLocalAttachmentPreviews(): void {
+  for (const path of [...localPreviewUrlsByPath.keys()]) {
+    releaseLocalAttachmentPreview(path);
+  }
+}

--- a/apps/app/src/lib/favicon-color-preference.test.ts
+++ b/apps/app/src/lib/favicon-color-preference.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { defaultAppTheme } from "@bb/domain";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import {
@@ -86,5 +86,91 @@ describe("favicon color server sync", () => {
       expect(window.localStorage.getItem(FAVICON_COLOR_STORAGE_KEY)).toBeNull(),
     );
     expect(mocks.updateAppearance).not.toHaveBeenCalled();
+  });
+});
+
+describe("favicon rendering", () => {
+  const originalGetContext = HTMLCanvasElement.prototype.getContext;
+
+  beforeEach(() => {
+    // jsdom has no 2D context; a null context ends the draw after the image
+    // load, which is all these tests observe.
+    Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+      configurable: true,
+      value: () => null,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+      configurable: true,
+      value: originalGetContext,
+    });
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  function stubDisplayMode(standalone: boolean): void {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn((query: string) => ({
+        matches: query === "(display-mode: standalone)" ? standalone : false,
+        media: query,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      })),
+    );
+  }
+
+  class FakeImage {
+    static created = 0;
+    naturalWidth = 32;
+    naturalHeight = 32;
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    set src(_value: string) {
+      FakeImage.created += 1;
+      queueMicrotask(() => this.onload?.());
+    }
+  }
+
+  async function loadFreshModule() {
+    return import("./favicon-color-preference");
+  }
+
+  it("decodes each base glyph once across badge flips", async () => {
+    stubDisplayMode(false);
+    FakeImage.created = 0;
+    vi.stubGlobal("Image", FakeImage);
+    const module = await loadFreshModule();
+    module.initializeFavicon();
+
+    const initialProps: { badge: "none" | "unread" } = { badge: "unread" };
+    const { rerender, unmount } = renderHook(
+      ({ badge }: { badge: "none" | "unread" }) => module.useFaviconBadge(badge),
+      { initialProps },
+    );
+    await waitFor(() => expect(FakeImage.created).toBe(2));
+
+    rerender({ badge: "none" });
+    rerender({ badge: "unread" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // 16px and 32px glyphs were decoded once; the second badge does not refetch.
+    expect(FakeImage.created).toBe(2);
+    unmount();
+  });
+
+  it("skips favicon image work in standalone display mode", async () => {
+    stubDisplayMode(true);
+    FakeImage.created = 0;
+    vi.stubGlobal("Image", FakeImage);
+    const module = await loadFreshModule();
+    module.initializeFavicon();
+
+    const { unmount } = renderHook(() => module.useFaviconBadge("unread"));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(FakeImage.created).toBe(0);
+    unmount();
   });
 });

--- a/apps/app/src/lib/favicon-color-preference.ts
+++ b/apps/app/src/lib/favicon-color-preference.ts
@@ -239,6 +239,32 @@ function loadImage(src: string): Promise<HTMLImageElement> {
   });
 }
 
+// The base glyphs never change within a page load; each badge or tint flip
+// redraws from the decoded image instead of fetching the PNGs again.
+const baseImageCache = new Map<string, Promise<HTMLImageElement>>();
+
+function loadBaseImage(src: string): Promise<HTMLImageElement> {
+  const cached = baseImageCache.get(src);
+  if (cached) return cached;
+  const pending = loadImage(src);
+  baseImageCache.set(src, pending);
+  pending.catch(() => {
+    // Let a transient failure retry on the next apply.
+    baseImageCache.delete(src);
+  });
+  return pending;
+}
+
+const STANDALONE_DISPLAY_MODE_QUERY = "(display-mode: standalone)";
+
+/**
+ * An installed PWA has no tab strip, so a tinted or badged favicon is never
+ * visible there; skip the image decode and canvas work entirely.
+ */
+function isStandaloneDisplayMode(): boolean {
+  return getMediaQuerySnapshot(STANDALONE_DISPLAY_MODE_QUERY);
+}
+
 /**
  * The favicon is a monochrome glyph on a transparent background, so tinting
  * is a straight color replacement: draw the glyph, then fill with the target
@@ -253,7 +279,7 @@ async function createFaviconHref({
     return baseHref;
   }
 
-  const image = await loadImage(baseHref);
+  const image = await loadBaseImage(baseHref);
   const canvas = document.createElement("canvas");
   canvas.width = image.naturalWidth;
   canvas.height = image.naturalHeight;
@@ -303,6 +329,7 @@ let applyToken = 0;
 
 async function applyFaviconState(state: FaviconRenderState): Promise<void> {
   const token = ++applyToken;
+  if (isStandaloneDisplayMode()) return;
   const suffix = getFaviconVariantSuffix();
   const links = await Promise.all(
     FAVICON_SIZES.map(async (size): Promise<RenderedFaviconLink> => {

--- a/apps/app/src/lib/plugin-frontend.test.ts
+++ b/apps/app/src/lib/plugin-frontend.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import * as react from "react";
 import * as jsxRuntime from "react/jsx-runtime";
 import {
+  createPluginFrontendPageLifecycle,
   installPluginRuntime,
   loadPluginFrontends,
   type PluginFrontendCandidate,
@@ -186,5 +187,46 @@ describe("installPluginRuntime", () => {
     // A second call never replaces an installed runtime.
     installPluginRuntime();
     expect((globalThis as RuntimeHost).__bbPluginRuntime).toBe(runtime);
+  });
+});
+
+describe("createPluginFrontendPageLifecycle", () => {
+  function createDeps(tornDown: boolean) {
+    return {
+      isTornDown: vi.fn(() => tornDown),
+      reboot: vi.fn(),
+      reconcile: vi.fn(),
+      teardown: vi.fn(),
+    };
+  }
+
+  it("keeps frontends mounted when the page enters the back/forward cache", () => {
+    const deps = createDeps(false);
+    const lifecycle = createPluginFrontendPageLifecycle(deps);
+    lifecycle.onPageHide({ persisted: true });
+    expect(deps.teardown).not.toHaveBeenCalled();
+
+    // Restored from bfcache with plugins still mounted: only reconcile.
+    lifecycle.onPageShow({ persisted: true });
+    expect(deps.reconcile).toHaveBeenCalledTimes(1);
+    expect(deps.reboot).not.toHaveBeenCalled();
+  });
+
+  it("tears down on a real unload and reboots if a persisted restore follows a teardown", () => {
+    const deps = createDeps(true);
+    const lifecycle = createPluginFrontendPageLifecycle(deps);
+    lifecycle.onPageHide({ persisted: false });
+    expect(deps.teardown).toHaveBeenCalledTimes(1);
+
+    lifecycle.onPageShow({ persisted: true });
+    expect(deps.reboot).toHaveBeenCalledTimes(1);
+    expect(deps.reconcile).not.toHaveBeenCalled();
+  });
+
+  it("ignores the initial (non-persisted) pageshow", () => {
+    const deps = createDeps(false);
+    createPluginFrontendPageLifecycle(deps).onPageShow({ persisted: false });
+    expect(deps.reboot).not.toHaveBeenCalled();
+    expect(deps.reconcile).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/lib/plugin-frontend.ts
+++ b/apps/app/src/lib/plugin-frontend.ts
@@ -946,18 +946,64 @@ export function teardownPluginFrontends(): Promise<void> {
   return disposePluginFrontends(state, browserReconcileDeps);
 }
 
-let pageHideListenerInstalled = false;
+export interface PluginFrontendPageLifecycleDeps {
+  isTornDown: () => boolean;
+  /** Fresh boot after a teardown: resets boot state and reconciles. */
+  reboot: () => void;
+  /** Frontends survived the freeze; pick up plugin changes made meanwhile. */
+  reconcile: () => void;
+  teardown: () => void;
+}
 
-function installPluginFrontendTeardown(): void {
-  if (pageHideListenerInstalled) return;
-  pageHideListenerInstalled = true;
-  window.addEventListener(
-    "pagehide",
-    () => {
+/**
+ * Page lifecycle policy for plugin frontends. A `pagehide` with `persisted`
+ * means the page is entering the back/forward cache: WebKit may restore it
+ * without a reload, so the frontends stay mounted (tearing down would leave
+ * a restored page with no plugin UI). Only a real unload tears down. On a
+ * persisted `pageshow` the frontends either reconcile (still mounted) or,
+ * if a teardown did happen, boot again.
+ */
+export function createPluginFrontendPageLifecycle(
+  deps: PluginFrontendPageLifecycleDeps,
+): {
+  onPageHide: (event: { persisted: boolean }) => void;
+  onPageShow: (event: { persisted: boolean }) => void;
+} {
+  return {
+    onPageHide(event) {
+      if (event.persisted) return;
+      deps.teardown();
+    },
+    onPageShow(event) {
+      if (!event.persisted) return;
+      if (deps.isTornDown()) {
+        deps.reboot();
+        return;
+      }
+      deps.reconcile();
+    },
+  };
+}
+
+let pageLifecycleListenersInstalled = false;
+
+function installPluginFrontendPageLifecycle(): void {
+  if (pageLifecycleListenersInstalled) return;
+  pageLifecycleListenersInstalled = true;
+  const lifecycle = createPluginFrontendPageLifecycle({
+    isTornDown: () => state.tornDown,
+    reboot: () => {
+      state.tornDown = false;
+      bootPromise = null;
+      void bootPluginFrontends();
+    },
+    reconcile: () => schedulePluginFrontendReconcile(),
+    teardown: () => {
       void teardownPluginFrontends();
     },
-    { once: true },
-  );
+  });
+  window.addEventListener("pagehide", (event) => lifecycle.onPageHide(event));
+  window.addEventListener("pageshow", (event) => lifecycle.onPageShow(event));
 }
 
 /**
@@ -967,7 +1013,7 @@ function installPluginFrontendTeardown(): void {
 export function bootPluginFrontends(): Promise<void> {
   bootPromise ??= (async () => {
     installPluginRuntime();
-    installPluginFrontendTeardown();
+    installPluginFrontendPageLifecycle();
     await reconcilePluginFrontends(state, browserReconcileDeps);
   })().catch((error: unknown) => {
     // Inventory fetch/network failure — plugin UI is absent, app unharmed.

--- a/apps/server/src/api-response-compression.ts
+++ b/apps/server/src/api-response-compression.ts
@@ -48,7 +48,10 @@ const API_RESPONSE_ENCODINGS = [
  * streaming body open on purpose, so neither may be buffered here; they keep
  * the streaming gzip fallback.
  */
-const BUFFERED_API_JSON_PATH_PATTERN = /^\/api\/v1\/(?!plugins\/[^/]+\/http\/)/u;
+// Mirrors PLUGIN_WIRE_HTTP_PATH in server.ts: Hono's `/http/*` route also
+// answers the bare `/http` path, so that one must not be buffered either.
+const BUFFERED_API_JSON_PATH_PATTERN =
+  /^\/api\/v1\/(?!plugins\/[^/]+\/http(?:\/|$))/u;
 const NO_TRANSFORM_PATTERN = /(?:^|,)\s*no-transform\s*(?:,|$)/iu;
 
 function isBufferedApiJsonResponse(context: Context): boolean {

--- a/apps/server/src/api-response-compression.ts
+++ b/apps/server/src/api-response-compression.ts
@@ -1,0 +1,142 @@
+import { Buffer } from "node:buffer";
+import { promisify } from "node:util";
+import {
+  brotliCompress,
+  constants as zlibConstants,
+  gzip as gzipCompress,
+} from "node:zlib";
+import type { Context, MiddlewareHandler, Next } from "hono";
+import { rankAcceptedAssetEncodings } from "./asset-content-encoding.js";
+
+const brotliCompressAsync = promisify(brotliCompress);
+const gzipCompressAsync = promisify(gzipCompress);
+
+/**
+ * Below this size the encoding overhead outweighs the savings; the identity
+ * bytes still gain an explicit Content-Length so the fallback middleware
+ * honours the same threshold.
+ */
+export const API_RESPONSE_COMPRESSION_MIN_BYTES = 1_024;
+
+/**
+ * Brotli quality 4 lands near gzip's CPU cost per byte while still beating it
+ * by 10-20% on JSON. Higher levels are for build-time sidecars, not the
+ * request path where the timeline projection already competes for the loop.
+ */
+const API_BROTLI_QUALITY = 4;
+
+const API_RESPONSE_ENCODINGS = [
+  {
+    encoding: "br",
+    compress: (bytes: Buffer) =>
+      brotliCompressAsync(bytes, {
+        params: {
+          [zlibConstants.BROTLI_PARAM_QUALITY]: API_BROTLI_QUALITY,
+          [zlibConstants.BROTLI_PARAM_SIZE_HINT]: bytes.length,
+        },
+      }),
+  },
+  {
+    encoding: "gzip",
+    compress: (bytes: Buffer) => gzipCompressAsync(bytes),
+  },
+] as const;
+
+/**
+ * Core public API JSON only. Plugin `bb.http` handlers return arbitrary
+ * Responses (possibly streamed), and `/internal/*` tool-call responses keep a
+ * streaming body open on purpose, so neither may be buffered here; they keep
+ * the streaming gzip fallback.
+ */
+const BUFFERED_API_JSON_PATH_PATTERN = /^\/api\/v1\/(?!plugins\/[^/]+\/http\/)/u;
+const NO_TRANSFORM_PATTERN = /(?:^|,)\s*no-transform\s*(?:,|$)/iu;
+
+function isBufferedApiJsonResponse(context: Context): boolean {
+  if (context.req.method === "HEAD") {
+    return false;
+  }
+  if (!BUFFERED_API_JSON_PATH_PATTERN.test(context.req.path)) {
+    return false;
+  }
+  const response = context.res;
+  if (response.body === null || response.status === 204) {
+    return false;
+  }
+  const headers = response.headers;
+  if (headers.has("content-encoding") || headers.has("transfer-encoding")) {
+    return false;
+  }
+  const contentType = headers.get("content-type");
+  if (contentType === null || !/^application\/json\b/iu.test(contentType)) {
+    return false;
+  }
+  const cacheControl = headers.get("cache-control");
+  return cacheControl === null || !NO_TRANSFORM_PATTERN.test(cacheControl);
+}
+
+function appendVaryAcceptEncoding(headers: Headers): void {
+  const existing = headers.get("vary");
+  if (
+    existing !== null &&
+    existing
+      .split(",")
+      .some((value) => value.trim().toLowerCase() === "accept-encoding")
+  ) {
+    return;
+  }
+  headers.append("vary", "Accept-Encoding");
+}
+
+async function compressBufferedApiJsonResponse(context: Context): Promise<void> {
+  const original = context.res;
+  const bytes = Buffer.from(await original.arrayBuffer());
+  let body: Uint8Array<ArrayBuffer> = new Uint8Array(bytes);
+  let contentEncoding: string | null = null;
+  const compressible = bytes.length >= API_RESPONSE_COMPRESSION_MIN_BYTES;
+  if (compressible) {
+    const candidate = rankAcceptedAssetEncodings(
+      context.req.header("accept-encoding"),
+      API_RESPONSE_ENCODINGS,
+    )[0];
+    if (candidate !== undefined) {
+      body = new Uint8Array(await candidate.compress(bytes));
+      contentEncoding = candidate.encoding;
+    }
+  }
+
+  // Hono's `res` setter copies the previous response's headers over the new
+  // one, so the encoding headers are applied after the swap.
+  context.res = new Response(body, {
+    headers: original.headers,
+    status: original.status,
+    statusText: original.statusText,
+  });
+  const headers = context.res.headers;
+  headers.set("content-length", String(body.byteLength));
+  if (compressible) {
+    // Anything at or above the threshold varies on the request encoding even
+    // when the client ends up with identity bytes, so shared caches keep the
+    // variants apart.
+    appendVaryAcceptEncoding(headers);
+  }
+  if (contentEncoding !== null) {
+    headers.set("content-encoding", contentEncoding);
+  }
+}
+
+/**
+ * Buffers core API JSON so it can be sent Brotli-encoded (gzip fallback) with
+ * an exact Content-Length and `Vary: Accept-Encoding`. Runs inside a
+ * streaming gzip fallback middleware: responses handled here already carry
+ * Content-Encoding (or a sub-threshold Content-Length), so the fallback
+ * leaves them alone and only compresses what this middleware skips.
+ */
+export function apiJsonCompression(): MiddlewareHandler {
+  return async (context: Context, next: Next) => {
+    await next();
+    if (!isBufferedApiJsonResponse(context)) {
+      return;
+    }
+    await compressBufferedApiJsonResponse(context);
+  };
+}

--- a/apps/server/src/routes/projects.ts
+++ b/apps/server/src/routes/projects.ts
@@ -61,6 +61,7 @@ import {
 import {
   createDaemonFileContentResponse,
   remapDaemonFileRouteError,
+  requestMatchesEntityTag,
 } from "../services/hosts/daemon-file-response.js";
 import { parseBoundedPositiveOptionalInteger } from "../services/lib/validation.js";
 import {
@@ -93,6 +94,9 @@ import {
 type ProjectResponseProjectFields = Omit<ProjectResponse, "sources">;
 type ProjectResponseRow = ProjectResponseProjectFields;
 const PROJECT_CLONE_TIMEOUT_MS = 20 * 60 * 1000;
+// Stored attachment names embed a timestamp and a random suffix, so the bytes
+// behind a name never change: cache for a year but keep it private.
+const ATTACHMENT_CONTENT_CACHE_CONTROL = "private, immutable, max-age=31536000";
 
 function toProjectResponseProjectFields(
   project: ProjectResponseRow,
@@ -645,6 +649,7 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
       });
       return createDaemonFileContentResponse(result, {
         headers: { "x-bb-content-encoding": result.contentEncoding },
+        ifNoneMatch: context.req.header("if-none-match"),
       });
     } catch (error) {
       return remapDaemonFileRouteError(error);
@@ -908,11 +913,27 @@ export function registerProjectRoutes(app: Hono, deps: AppDeps): void {
       context.req.param("id"),
       query.path,
     );
+    const headers = new Headers({
+      // Stored attachment names are unique per upload (timestamp + random
+      // suffix) and the bytes never change, so the browser may keep them for
+      // a year: PWA relaunches and timeline scroll-back reuse the cached
+      // image instead of refetching multi-megabyte screenshots.
+      "cache-control": ATTACHMENT_CONTENT_CACHE_CONTROL,
+      "content-type": attachment.mimeType ?? "application/octet-stream",
+      etag: attachment.etag,
+    });
+    if (
+      requestMatchesEntityTag(
+        context.req.header("if-none-match"),
+        attachment.etag,
+      )
+    ) {
+      return new Response(null, { status: 304, headers });
+    }
+    headers.set("content-length", String(attachment.content.byteLength));
     return new Response(new Uint8Array(attachment.content), {
       status: 200,
-      headers: {
-        "content-type": attachment.mimeType ?? "application/octet-stream",
-      } as HeadersInit,
+      headers,
     });
   });
 }

--- a/apps/server/src/routes/threads/data.ts
+++ b/apps/server/src/routes/threads/data.ts
@@ -679,7 +679,9 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
           rootPath: target.storagePath,
         },
       });
-      return createDaemonFileContentResponse(result);
+      return createDaemonFileContentResponse(result, {
+        ifNoneMatch: context.req.header("if-none-match"),
+      });
     } catch (error) {
       return remapDaemonFileRouteError(error);
     }
@@ -703,7 +705,9 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
           path: query.path,
         },
       });
-      return createDaemonFileContentResponse(result);
+      return createDaemonFileContentResponse(result, {
+        ifNoneMatch: context.req.header("if-none-match"),
+      });
     } catch (error) {
       return remapDaemonFileRouteError(error);
     }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -87,6 +87,7 @@ import {
  */
 const PLUGIN_WIRE_HTTP_PATH = /^\/api\/v1\/plugins\/[^/]+\/http(?:\/|$)/u;
 import { rankAcceptedAssetEncodings } from "./asset-content-encoding.js";
+import { apiJsonCompression } from "./api-response-compression.js";
 
 export type CloseWebSockets = () => Promise<void>;
 type NodeWebSocketServer = ReturnType<typeof createNodeWebSocket>["wss"];
@@ -318,6 +319,7 @@ export function createApp(
     }),
   );
   const compressResponse = compress();
+  const compressApiJson = apiJsonCompression();
   app.use("*", (context, next) => {
     // Plugin JS/CSS negotiates Brotli and gzip itself and caches immutable
     // variants. Letting this outer middleware transform an identity fallback
@@ -325,7 +327,12 @@ export function createApp(
     if (PLUGIN_APP_ASSET_PATH_PATTERN.test(context.req.path)) {
       return next();
     }
-    return compressResponse(context, next);
+    // Core API JSON is buffered and Brotli-encoded (gzip fallback) with an
+    // exact Content-Length by the inner middleware; the streaming gzip
+    // fallback then only touches what the inner one leaves untransformed.
+    return compressResponse(context, async () => {
+      await compressApiJson(context, next);
+    });
   });
   app.onError((error) => errorToResponse(error, deps.logger));
   app.get("/health", (context) => context.json({ ok: true }));

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -138,8 +138,15 @@ interface StaticResponseHeadersArgs {
   urlPath: string;
 }
 
-const STATIC_INDEX_CACHE_CONTROL = "no-store";
+// `no-cache` (not `no-store`): the document is revalidated on every
+// navigation, so a new build is picked up immediately, but WebKit may still
+// keep the page in the back/forward cache and restore it without a reload.
+const STATIC_INDEX_CACHE_CONTROL = "no-cache";
 const STATIC_ASSET_CACHE_CONTROL = "public, max-age=31536000, immutable";
+// Icons and manifests under public/ are not content-hashed but change only
+// with a release; a day of caching keeps favicon/badge flips and PWA
+// relaunches from refetching them.
+const STATIC_PUBLIC_FILE_CACHE_CONTROL = "public, max-age=86400";
 const WEB_SOCKET_SHUTDOWN_CODE = 1001;
 const WEB_SOCKET_SHUTDOWN_FORCE_CLOSE_MS = 1_000;
 const WEB_SOCKET_SHUTDOWN_REASON = "server-shutdown";
@@ -169,15 +176,20 @@ function shouldLogSlowApiRequest(args: ShouldLogSlowApiRequestArgs): boolean {
   return !THREAD_EVENT_WAIT_PATH_PATTERN.test(args.path);
 }
 
+function staticCacheControlForPath(urlPath: string): string {
+  if (urlPath.startsWith("/assets/")) {
+    return STATIC_ASSET_CACHE_CONTROL;
+  }
+  if (urlPath.endsWith(".html")) {
+    return STATIC_INDEX_CACHE_CONTROL;
+  }
+  return STATIC_PUBLIC_FILE_CACHE_CONTROL;
+}
+
 function createStaticResponseHeaders(args: StaticResponseHeadersArgs): Headers {
   const headers = new Headers();
   headers.set("content-type", args.contentType);
-  headers.set(
-    "cache-control",
-    args.urlPath.startsWith("/assets/")
-      ? STATIC_ASSET_CACHE_CONTROL
-      : STATIC_INDEX_CACHE_CONTROL,
-  );
+  headers.set("cache-control", staticCacheControlForPath(args.urlPath));
   if (args.contentEncoding !== undefined) {
     headers.set("content-encoding", args.contentEncoding);
     headers.set("vary", "Accept-Encoding");

--- a/apps/server/src/services/hosts/daemon-file-response.ts
+++ b/apps/server/src/services/hosts/daemon-file-response.ts
@@ -3,6 +3,12 @@ import type { HostDaemonOnlineRpcResultByType } from "@bb/host-daemon-contract";
 import { ApiError } from "../../errors.js";
 
 const OCTET_STREAM_MIME_TYPE = "application/octet-stream";
+/**
+ * Host files change under the agent, so the browser must revalidate on every
+ * use — but it may keep the bytes and send `If-None-Match`, which turns an
+ * unchanged multi-megabyte image into a 304 instead of a re-download.
+ */
+const REVALIDATE_CACHE_CONTROL = "private, no-cache";
 
 export type DaemonFileReadResult =
   | HostDaemonOnlineRpcResultByType["host.read_file"]
@@ -10,6 +16,34 @@ export type DaemonFileReadResult =
 
 interface CreateDaemonFileContentResponseOptions {
   headers?: HeadersInit;
+  /** `If-None-Match` from the request; a match answers 304 without a body. */
+  ifNoneMatch?: string | undefined;
+}
+
+/** Strong validator: the daemon hashes exactly the bytes it returned. */
+export function daemonFileEntityTag(result: DaemonFileReadResult): string {
+  return `"${result.sha256}"`;
+}
+
+/**
+ * RFC 9110 `If-None-Match`: a `*` or any listed tag (weak prefix ignored)
+ * that equals the current one means the client already holds these bytes.
+ */
+export function requestMatchesEntityTag(
+  ifNoneMatch: string | undefined,
+  entityTag: string,
+): boolean {
+  if (ifNoneMatch === undefined) {
+    return false;
+  }
+  const trimmed = ifNoneMatch.trim();
+  if (trimmed === "*") {
+    return true;
+  }
+  return trimmed
+    .split(",")
+    .map((tag) => tag.trim().replace(/^W\//u, ""))
+    .includes(entityTag);
 }
 
 function buildFileContentHeaders(
@@ -19,6 +53,13 @@ function buildFileContentHeaders(
   const headers = new Headers(options.headers);
   if (!headers.has("content-type")) {
     headers.set("content-type", result.mimeType ?? OCTET_STREAM_MIME_TYPE);
+  }
+  if (!headers.has("cache-control")) {
+    headers.set("cache-control", REVALIDATE_CACHE_CONTROL);
+  }
+  headers.set("etag", daemonFileEntityTag(result));
+  if (result.modifiedAtMs !== undefined) {
+    headers.set("last-modified", new Date(result.modifiedAtMs).toUTCString());
   }
   return headers;
 }
@@ -38,9 +79,17 @@ export function createDaemonFileContentResponse(
   result: DaemonFileReadResult,
   options: CreateDaemonFileContentResponseOptions = {},
 ): Response {
-  return new Response(decodeDaemonFileContent(result), {
+  const headers = buildFileContentHeaders(result, options);
+  if (
+    requestMatchesEntityTag(options.ifNoneMatch, daemonFileEntityTag(result))
+  ) {
+    return new Response(null, { status: 304, headers });
+  }
+  const content = decodeDaemonFileContent(result);
+  headers.set("content-length", String(content.byteLength));
+  return new Response(content, {
     status: 200,
-    headers: buildFileContentHeaders(result, options),
+    headers,
   });
 }
 

--- a/apps/server/src/services/projects/attachments.ts
+++ b/apps/server/src/services/projects/attachments.ts
@@ -169,11 +169,22 @@ export async function storeAttachment(
   };
 }
 
+export interface StoredAttachmentContent {
+  content: Buffer;
+  /**
+   * Strong validator for the stored bytes. Stored names embed a timestamp and
+   * a random suffix, so a name never maps to different bytes; the size and
+   * mtime pair still guards a copied file's identity without hashing it.
+   */
+  etag: string;
+  mimeType?: string;
+}
+
 export async function readAttachment(
   dataDir: string,
   projectId: string,
   relativePath: string,
-): Promise<{ content: Buffer; mimeType?: string }> {
+): Promise<StoredAttachmentContent> {
   const dir = projectAttachmentDir(dataDir, projectId);
   const resolved = resolveAttachmentPath(dir, relativePath);
 
@@ -184,6 +195,7 @@ export async function readAttachment(
 
   return {
     content: await readFile(resolved),
+    etag: `"${fileStat.size.toString(16)}-${Math.floor(fileStat.mtimeMs).toString(16)}"`,
     mimeType: mimeTypes.lookup(resolved) || undefined,
   };
 }

--- a/apps/server/src/ws/hub.ts
+++ b/apps/server/src/ws/hub.ts
@@ -9,6 +9,7 @@ import {
   type SystemChangeKind,
   type ThreadChangeKind,
   type ThreadChangeMetadata,
+  type ThreadEventType,
 } from "@bb/domain";
 import type { DbNotifier } from "@bb/db";
 import type {
@@ -35,6 +36,22 @@ const TERMINAL_SOCKET_HIGH_WATER_BYTES = 1024 * 1024;
 // enough bounded headroom for that workload while preventing unbounded growth.
 const TERMINAL_SOCKET_MAX_QUEUE_BYTES = 32 * 1024 * 1024;
 const TERMINAL_SOCKET_DRAIN_POLL_MS = 10;
+/**
+ * A streaming turn appends events ~10 times a second. A client that only
+ * subscribes to the thread list (every open app window, for every thread it
+ * is not viewing) uses `events-appended` for nothing more than a stale mark
+ * on cached timeline/search queries, so it gets the first notification at
+ * once and then at most one coalesced notification per window per thread.
+ * Detail subscribers keep receiving every notification.
+ */
+const THREAD_LIST_EVENTS_APPENDED_COALESCE_MS = 1_000;
+/**
+ * Event types the thread-list client path reacts to individually (prompt
+ * history recall, pull-request refresh), so they bypass coalescing.
+ */
+const LIST_RELEVANT_THREAD_EVENT_TYPES: ReadonlySet<ThreadEventType> = new Set<
+  ThreadEventType
+>(["client/turn/requested", "turn/completed"]);
 
 interface HubSocket {
   close(code?: number, reason?: string): void;
@@ -49,6 +66,39 @@ interface TerminalSocketSendQueue {
 }
 
 type ChangedMessageListener = (message: ChangedMessage) => void;
+
+interface PendingThreadListEventsAppended {
+  eventTypes: Set<ThreadEventType>;
+  merged: boolean;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+type ThreadChangedMessage = Extract<ChangedMessage, { entity: "thread" }>;
+
+/**
+ * True when thread-list subscribers need the change now: any change kind
+ * other than `events-appended`, or metadata the list path reads directly.
+ */
+function isThreadListRelevantChange(
+  message: Pick<ThreadChangedMessage, "changes" | "metadata">,
+): boolean {
+  if (message.changes.some((change) => change !== "events-appended")) {
+    return true;
+  }
+  const metadata = message.metadata;
+  if (metadata === undefined) {
+    return false;
+  }
+  return (
+    metadata.backgroundActivityChanged === true ||
+    metadata.hasPendingInteraction !== undefined ||
+    metadata.projectId !== undefined ||
+    (metadata.eventTypes?.some((eventType) =>
+      LIST_RELEVANT_THREAD_EVENT_TYPES.has(eventType),
+    ) ??
+      false)
+  );
+}
 
 function subscriptionKeysForMessage(message: ChangedMessage): string[] {
   switch (message.entity) {
@@ -187,6 +237,10 @@ export class NotificationHub implements DbNotifier {
   private readonly threadEventWaiters = new Map<
     string,
     Set<ThreadEventWaiter>
+  >();
+  private readonly pendingThreadListEventsAppendedByThread = new Map<
+    string,
+    PendingThreadListEventsAppended
   >();
 
   registerClient(socket: HubSocket): void {
@@ -716,13 +770,18 @@ export class NotificationHub implements DbNotifier {
     changes: ThreadChangeKind[],
     metadata?: ThreadChangeMetadata,
   ): void {
-    this.notifyClients({
+    const message: ThreadChangedMessage = {
       type: "changed",
       entity: "thread",
       id: threadId,
       ...(metadata ? { metadata } : {}),
       changes,
-    });
+    };
+    if (isThreadListRelevantChange(message)) {
+      this.notifyClients(message);
+    } else {
+      this.notifyThreadEventsAppendedCoalesced(threadId, message);
+    }
 
     const threadEventWaiters = this.threadEventWaiters.get(threadId);
     if (threadEventWaiters) {
@@ -940,6 +999,94 @@ export class NotificationHub implements DbNotifier {
       waiter.resolve(true);
     }
     this.daemonRegistrationWaiters.delete(hostId);
+  }
+
+  /**
+   * Plain `events-appended`: detail subscribers of the thread get it now;
+   * sockets that only hold the thread-list subscription get the first one
+   * now and the rest merged into one notification when the window closes.
+   */
+  private notifyThreadEventsAppendedCoalesced(
+    threadId: string,
+    message: ThreadChangedMessage,
+  ): void {
+    const parseResult = serverMessageSchema.safeParse(message);
+    if (!parseResult.success) {
+      console.error("Skipping invalid realtime broadcast", parseResult.error);
+      return;
+    }
+    const payload = JSON.stringify(parseResult.data);
+    const detailSockets = this.clientSocketsByKey.get(
+      subscriptionKey({ kind: "thread-detail", threadId }),
+    );
+    if (detailSockets) {
+      this.notifyClientsByKeySet(detailSockets, payload);
+    }
+    this.notifyChangedMessageListeners(message);
+
+    const eventTypes = message.metadata?.eventTypes ?? [];
+    const pending = this.pendingThreadListEventsAppendedByThread.get(threadId);
+    if (pending) {
+      for (const eventType of eventTypes) {
+        pending.eventTypes.add(eventType);
+      }
+      pending.merged = true;
+      return;
+    }
+
+    this.notifyThreadListOnlySockets(threadId, payload);
+    const timeout = setTimeout(() => {
+      this.flushPendingThreadListEventsAppended(threadId);
+    }, THREAD_LIST_EVENTS_APPENDED_COALESCE_MS);
+    timeout.unref?.();
+    this.pendingThreadListEventsAppendedByThread.set(threadId, {
+      eventTypes: new Set(eventTypes),
+      merged: false,
+      timeout,
+    });
+  }
+
+  private flushPendingThreadListEventsAppended(threadId: string): void {
+    const pending = this.pendingThreadListEventsAppendedByThread.get(threadId);
+    if (!pending) {
+      return;
+    }
+    this.pendingThreadListEventsAppendedByThread.delete(threadId);
+    if (!pending.merged) {
+      return;
+    }
+    const message: ThreadChangedMessage = {
+      type: "changed",
+      entity: "thread",
+      id: threadId,
+      ...(pending.eventTypes.size > 0
+        ? { metadata: { eventTypes: [...pending.eventTypes] } }
+        : {}),
+      changes: ["events-appended"],
+    };
+    const parseResult = serverMessageSchema.safeParse(message);
+    if (!parseResult.success) {
+      console.error("Skipping invalid realtime broadcast", parseResult.error);
+      return;
+    }
+    this.notifyThreadListOnlySockets(threadId, JSON.stringify(parseResult.data));
+  }
+
+  /** Sockets subscribed to the thread list but not to this thread's detail. */
+  private notifyThreadListOnlySockets(threadId: string, payload: string): void {
+    const listSockets = this.clientSocketsByKey.get(
+      subscriptionKey({ kind: "thread-list" }),
+    );
+    if (!listSockets) {
+      return;
+    }
+    const detailKey = subscriptionKey({ kind: "thread-detail", threadId });
+    for (const socket of listSockets) {
+      if (this.clientKeysBySocket.get(socket)?.has(detailKey)) {
+        continue;
+      }
+      socket.send(payload);
+    }
   }
 
   private notifyClients(message: ChangedMessage): void {

--- a/apps/server/test/app/api-json-compression.test.ts
+++ b/apps/server/test/app/api-json-compression.test.ts
@@ -23,7 +23,9 @@ function createHarnessApp(): Hono {
   );
   app.get("/api/v1/large", (context) => context.json(LARGE_PAYLOAD));
   app.get("/api/v1/small", (context) => context.json(SMALL_PAYLOAD));
-  app.get("/api/v1/plugins/demo/http/stream", () => {
+  // Hono's `/http/*` also answers the bare `/http` path, as the real plugin
+  // wire route does.
+  app.get("/api/v1/plugins/demo/http/*", () => {
     let pushed = false;
     const body = new ReadableStream<Uint8Array>({
       pull(controller) {
@@ -95,7 +97,11 @@ describe("API JSON compression", () => {
 
   it("does not buffer plugin http handlers or internal routes", async () => {
     const app = createHarnessApp();
-    for (const path of ["/api/v1/plugins/demo/http/stream", "/internal/tool"]) {
+    for (const path of [
+      "/api/v1/plugins/demo/http/stream",
+      "/api/v1/plugins/demo/http",
+      "/internal/tool",
+    ]) {
       const response = await app.request(path, {
         headers: { "accept-encoding": "gzip, br" },
       });

--- a/apps/server/test/app/api-json-compression.test.ts
+++ b/apps/server/test/app/api-json-compression.test.ts
@@ -1,0 +1,132 @@
+import { Buffer } from "node:buffer";
+import { brotliDecompressSync, gunzipSync } from "node:zlib";
+import { Hono } from "hono";
+import { compress } from "hono/compress";
+import { describe, expect, it } from "vitest";
+import { apiJsonCompression } from "../../src/api-response-compression.js";
+import { withTestHarness } from "../helpers/test-app.js";
+
+const LARGE_PAYLOAD = { rows: Array.from({ length: 200 }, (_, index) => ({
+  id: `row-${index}`,
+  title: `Thread ${index} with a reasonably long title for compression`,
+})) };
+const SMALL_PAYLOAD = { ok: true };
+
+function createHarnessApp(): Hono {
+  const app = new Hono();
+  const compressResponse = compress();
+  const compressApiJson = apiJsonCompression();
+  app.use("*", (context, next) =>
+    compressResponse(context, async () => {
+      await compressApiJson(context, next);
+    }),
+  );
+  app.get("/api/v1/large", (context) => context.json(LARGE_PAYLOAD));
+  app.get("/api/v1/small", (context) => context.json(SMALL_PAYLOAD));
+  app.get("/api/v1/plugins/demo/http/stream", () => {
+    let pushed = false;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (pushed) {
+          controller.close();
+          return;
+        }
+        pushed = true;
+        controller.enqueue(
+          new TextEncoder().encode(JSON.stringify(LARGE_PAYLOAD)),
+        );
+      },
+    });
+    return new Response(body, {
+      headers: { "content-type": "application/json" },
+    });
+  });
+  app.get("/internal/tool", (context) => context.json(LARGE_PAYLOAD));
+  return app;
+}
+
+describe("API JSON compression", () => {
+  it("sends Brotli with an exact Content-Length and Vary for large JSON", async () => {
+    const app = createHarnessApp();
+    const response = await app.request("/api/v1/large", {
+      headers: { "accept-encoding": "gzip, deflate, br" },
+    });
+    expect(response.headers.get("content-encoding")).toBe("br");
+    expect(response.headers.get("vary")).toBe("Accept-Encoding");
+    expect(response.headers.get("content-type")).toContain("application/json");
+    const bytes = Buffer.from(await response.arrayBuffer());
+    expect(response.headers.get("content-length")).toBe(String(bytes.length));
+    expect(JSON.parse(brotliDecompressSync(bytes).toString("utf8"))).toEqual(
+      LARGE_PAYLOAD,
+    );
+  });
+
+  it("falls back to gzip when Brotli is not accepted and honours q=0", async () => {
+    const app = createHarnessApp();
+    const gzipResponse = await app.request("/api/v1/large", {
+      headers: { "accept-encoding": "gzip" },
+    });
+    expect(gzipResponse.headers.get("content-encoding")).toBe("gzip");
+    const gzipBytes = Buffer.from(await gzipResponse.arrayBuffer());
+    expect(gzipResponse.headers.get("content-length")).toBe(
+      String(gzipBytes.length),
+    );
+    expect(JSON.parse(gunzipSync(gzipBytes).toString("utf8"))).toEqual(
+      LARGE_PAYLOAD,
+    );
+
+    const gzipPreferred = await app.request("/api/v1/large", {
+      headers: { "accept-encoding": "br;q=0, gzip;q=1" },
+    });
+    expect(gzipPreferred.headers.get("content-encoding")).toBe("gzip");
+  });
+
+  it("leaves small JSON identity-encoded with a Content-Length", async () => {
+    const app = createHarnessApp();
+    const response = await app.request("/api/v1/small", {
+      headers: { "accept-encoding": "gzip, br" },
+    });
+    expect(response.headers.has("content-encoding")).toBe(false);
+    expect(response.headers.get("content-length")).toBe(
+      String(JSON.stringify(SMALL_PAYLOAD).length),
+    );
+    expect(await response.json()).toEqual(SMALL_PAYLOAD);
+  });
+
+  it("does not buffer plugin http handlers or internal routes", async () => {
+    const app = createHarnessApp();
+    for (const path of ["/api/v1/plugins/demo/http/stream", "/internal/tool"]) {
+      const response = await app.request(path, {
+        headers: { "accept-encoding": "gzip, br" },
+      });
+      // The streaming fallback keeps these gzip-only without a length.
+      expect(response.headers.get("content-encoding")).toBe("gzip");
+      expect(response.headers.has("content-length")).toBe(false);
+      const bytes = Buffer.from(await response.arrayBuffer());
+      expect(JSON.parse(gunzipSync(bytes).toString("utf8"))).toEqual(
+        LARGE_PAYLOAD,
+      );
+    }
+  });
+
+  it("applies to the real app's API routes", async () => {
+    await withTestHarness(async (harness) => {
+      const response = await harness.app.request("/api/v1/system/config", {
+        headers: { "accept-encoding": "br, gzip" },
+      });
+      expect(response.status).toBe(200);
+      const bytes = Buffer.from(await response.arrayBuffer());
+      expect(response.headers.get("content-encoding")).toBe("br");
+      expect(
+        response.headers
+          .get("vary")
+          ?.split(",")
+          .map((value) => value.trim()),
+      ).toContain("Accept-Encoding");
+      expect(response.headers.get("content-length")).toBe(String(bytes.length));
+      expect(() =>
+        JSON.parse(brotliDecompressSync(bytes).toString("utf8")),
+      ).not.toThrow();
+    });
+  });
+});

--- a/apps/server/test/app/hub.test.ts
+++ b/apps/server/test/app/hub.test.ts
@@ -590,3 +590,153 @@ describe("NotificationHub", () => {
     ]);
   });
 });
+
+describe("NotificationHub events-appended thread-list coalescing", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function messagesOf(socket: { messages: string[] }): Array<{
+    changes: string[];
+    id?: string;
+    metadata?: { eventTypes?: string[] };
+  }> {
+    return socket.messages.map((message) => JSON.parse(message));
+  }
+
+  it("delivers every events-appended frame to detail subscribers but coalesces list-only subscribers to one per window", () => {
+    vi.useFakeTimers();
+    const hub = new NotificationHub();
+    const detailSocket = createMockHubSocket();
+    const listSocket = createMockHubSocket();
+    const listAndDetailSocket = createMockHubSocket();
+    hub.subscribe(detailSocket, { kind: "thread-detail", threadId: "thread-1" });
+    hub.subscribe(listSocket, { kind: "thread-list" });
+    hub.subscribe(listAndDetailSocket, { kind: "thread-list" });
+    hub.subscribe(listAndDetailSocket, {
+      kind: "thread-detail",
+      threadId: "thread-1",
+    });
+
+    for (const eventType of ["item/agentMessage/delta", "item/agentMessage/delta", "item/started"] as const) {
+      hub.notifyThread("thread-1", ["events-appended"], {
+        eventTypes: [eventType],
+      });
+    }
+
+    expect(detailSocket.messages).toHaveLength(3);
+    // The socket holding both subscriptions is a detail subscriber: no copy.
+    expect(listAndDetailSocket.messages).toHaveLength(3);
+    // Leading edge only until the window closes.
+    expect(listSocket.messages).toHaveLength(1);
+    expect(messagesOf(listSocket)[0]).toMatchObject({
+      id: "thread-1",
+      changes: ["events-appended"],
+      metadata: { eventTypes: ["item/agentMessage/delta"] },
+    });
+
+    vi.advanceTimersByTime(999);
+    expect(listSocket.messages).toHaveLength(1);
+    vi.advanceTimersByTime(1);
+    expect(listSocket.messages).toHaveLength(2);
+    // The trailing frame carries the union of the merged event types.
+    expect(messagesOf(listSocket)[1]).toMatchObject({
+      id: "thread-1",
+      changes: ["events-appended"],
+      metadata: { eventTypes: ["item/agentMessage/delta", "item/started"] },
+    });
+    expect(detailSocket.messages).toHaveLength(3);
+    expect(listAndDetailSocket.messages).toHaveLength(3);
+
+    // A quiet window sends nothing extra; the next frame is a fresh leading edge.
+    vi.advanceTimersByTime(5_000);
+    expect(listSocket.messages).toHaveLength(2);
+    hub.notifyThread("thread-1", ["events-appended"], {
+      eventTypes: ["item/agentMessage/delta"],
+    });
+    expect(listSocket.messages).toHaveLength(3);
+    vi.advanceTimersByTime(1_000);
+    expect(listSocket.messages).toHaveLength(3);
+  });
+
+  it("bypasses coalescing when metadata carries a list-relevant signal or another change kind", () => {
+    vi.useFakeTimers();
+    const hub = new NotificationHub();
+    const listSocket = createMockHubSocket();
+    hub.subscribe(listSocket, { kind: "thread-list" });
+
+    hub.notifyThread("thread-1", ["events-appended"], {
+      eventTypes: ["item/agentMessage/delta"],
+    });
+    expect(listSocket.messages).toHaveLength(1);
+
+    // Inside the window: each of these must still arrive immediately.
+    hub.notifyThread("thread-1", ["events-appended"], {
+      backgroundActivityChanged: true,
+      eventTypes: ["item/agentMessage/delta"],
+    });
+    hub.notifyThread("thread-1", ["events-appended"], {
+      eventTypes: ["turn/completed"],
+    });
+    hub.notifyThread("thread-1", ["events-appended"], {
+      eventTypes: ["client/turn/requested"],
+    });
+    hub.notifyThread("thread-1", ["events-appended"], {
+      hasPendingInteraction: true,
+    });
+    hub.notifyThread("thread-1", ["events-appended", "read-state-changed"], {
+      eventTypes: ["item/agentMessage/delta"],
+      projectId: "project-1",
+    });
+    hub.notifyThread("thread-1", ["status-changed"]);
+    expect(listSocket.messages).toHaveLength(7);
+    expect(messagesOf(listSocket).map((message) => message.changes)).toEqual([
+      ["events-appended"],
+      ["events-appended"],
+      ["events-appended"],
+      ["events-appended"],
+      ["events-appended"],
+      ["events-appended", "read-state-changed"],
+      ["status-changed"],
+    ]);
+  });
+
+  it("coalesces per thread and resolves thread event waiters for every frame", async () => {
+    vi.useFakeTimers();
+    const hub = new NotificationHub();
+    const listSocket = createMockHubSocket();
+    hub.subscribe(listSocket, { kind: "thread-list" });
+
+    hub.notifyThread("thread-1", ["events-appended"]);
+    hub.notifyThread("thread-2", ["events-appended"]);
+    expect(messagesOf(listSocket).map((message) => message.id)).toEqual([
+      "thread-1",
+      "thread-2",
+    ]);
+
+    const waiter = hub.waitForThreadEvent("thread-1", 10_000);
+    hub.notifyThread("thread-1", ["events-appended"]);
+    await expect(waiter).resolves.toBe(true);
+    // Merged frame without event types omits metadata entirely.
+    vi.advanceTimersByTime(1_000);
+    expect(listSocket.messages).toHaveLength(3);
+    expect(messagesOf(listSocket)[2]).toEqual({
+      type: "changed",
+      entity: "thread",
+      id: "thread-1",
+      changes: ["events-appended"],
+    });
+  });
+
+  it("still tells changed-message listeners about coalesced frames", () => {
+    vi.useFakeTimers();
+    const hub = new NotificationHub();
+    const seen: string[][] = [];
+    hub.onChangedMessage((message) => {
+      seen.push([...message.changes]);
+    });
+    hub.notifyThread("thread-1", ["events-appended"]);
+    hub.notifyThread("thread-1", ["events-appended"]);
+    expect(seen).toEqual([["events-appended"], ["events-appended"]]);
+  });
+});

--- a/apps/server/test/app/static-cache.test.ts
+++ b/apps/server/test/app/static-cache.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import { brotliCompressSync, gzipSync } from "node:zlib";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -29,15 +30,21 @@ describe("production static cache headers", () => {
       join(staticDir, "manifest.webmanifest"),
       JSON.stringify({ name: "bb", icons: [] }),
     );
+    await writeFile(
+      join(staticDir, "favicon-32x32.png"),
+      Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+    );
 
     const harness = await createTestAppHarness();
     const serverApp = createApp(harness.deps, { staticDir });
     try {
+      // `no-cache` revalidates on every navigation but, unlike `no-store`,
+      // leaves the document eligible for the WebKit back/forward cache.
       const rootResponse = await serverApp.app.request("/");
-      expect(rootResponse.headers.get("cache-control")).toBe("no-store");
+      expect(rootResponse.headers.get("cache-control")).toBe("no-cache");
 
       const fallbackResponse = await serverApp.app.request("/threads/thr_123");
-      expect(fallbackResponse.headers.get("cache-control")).toBe("no-store");
+      expect(fallbackResponse.headers.get("cache-control")).toBe("no-cache");
 
       const assetResponse = await serverApp.app.request(
         "/assets/index-test.js",
@@ -98,7 +105,16 @@ describe("production static cache headers", () => {
       expect(manifestResponse.headers.get("content-type")).toBe(
         "application/manifest+json",
       );
-      expect(manifestResponse.headers.get("cache-control")).toBe("no-store");
+      expect(manifestResponse.headers.get("cache-control")).toBe(
+        "public, max-age=86400",
+      );
+
+      const iconResponse = await serverApp.app.request("/favicon-32x32.png");
+      expect(iconResponse.status).toBe(200);
+      expect(iconResponse.headers.get("content-type")).toBe("image/png");
+      expect(iconResponse.headers.get("cache-control")).toBe(
+        "public, max-age=86400",
+      );
 
       const apiMissResponse = await serverApp.app.request(
         "/api/v1/does-not-exist.js",

--- a/apps/server/test/hosts/daemon-file-response.test.ts
+++ b/apps/server/test/hosts/daemon-file-response.test.ts
@@ -1,0 +1,81 @@
+import { Buffer } from "node:buffer";
+import { describe, expect, it } from "vitest";
+import {
+  createDaemonFileContentResponse,
+  requestMatchesEntityTag,
+  type DaemonFileReadResult,
+} from "../../src/services/hosts/daemon-file-response.js";
+
+const IMAGE_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a]);
+const IMAGE_RESULT: DaemonFileReadResult = {
+  path: "/tmp/screenshot.png",
+  content: IMAGE_BYTES.toString("base64"),
+  contentEncoding: "base64",
+  mimeType: "image/png",
+  sizeBytes: IMAGE_BYTES.byteLength,
+  modifiedAtMs: Date.UTC(2026, 0, 2, 3, 4, 5),
+  sha256: "abc123",
+};
+
+describe("createDaemonFileContentResponse", () => {
+  it("adds validators and a revalidate-only cache policy to host file bytes", async () => {
+    const response = createDaemonFileContentResponse(IMAGE_RESULT);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    expect(response.headers.get("cache-control")).toBe("private, no-cache");
+    expect(response.headers.get("etag")).toBe('"abc123"');
+    expect(response.headers.get("last-modified")).toBe(
+      "Fri, 02 Jan 2026 03:04:05 GMT",
+    );
+    expect(response.headers.get("content-length")).toBe(
+      String(IMAGE_BYTES.byteLength),
+    );
+    expect(Buffer.from(await response.arrayBuffer())).toEqual(IMAGE_BYTES);
+  });
+
+  it("keeps caller-provided cache-control and content-type", () => {
+    const response = createDaemonFileContentResponse(IMAGE_RESULT, {
+      headers: { "cache-control": "no-store", "content-type": "text/html" },
+    });
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("content-type")).toBe("text/html");
+    expect(response.headers.get("etag")).toBe('"abc123"');
+  });
+
+  it("answers 304 without a body when If-None-Match carries the current tag", async () => {
+    const response = createDaemonFileContentResponse(IMAGE_RESULT, {
+      ifNoneMatch: 'W/"other", "abc123"',
+    });
+    expect(response.status).toBe(304);
+    expect(response.headers.get("etag")).toBe('"abc123"');
+    expect(response.headers.has("content-length")).toBe(false);
+    expect((await response.arrayBuffer()).byteLength).toBe(0);
+
+    const changed = createDaemonFileContentResponse(IMAGE_RESULT, {
+      ifNoneMatch: '"stale"',
+    });
+    expect(changed.status).toBe(200);
+  });
+
+  it("omits Last-Modified when the daemon has no mtime", () => {
+    const response = createDaemonFileContentResponse({
+      path: IMAGE_RESULT.path,
+      content: IMAGE_RESULT.content,
+      contentEncoding: IMAGE_RESULT.contentEncoding,
+      mimeType: IMAGE_RESULT.mimeType,
+      sizeBytes: IMAGE_RESULT.sizeBytes,
+      sha256: IMAGE_RESULT.sha256,
+    });
+    expect(response.headers.has("last-modified")).toBe(false);
+  });
+});
+
+describe("requestMatchesEntityTag", () => {
+  it("matches wildcard, exact, and weak-prefixed tags", () => {
+    expect(requestMatchesEntityTag(undefined, '"a"')).toBe(false);
+    expect(requestMatchesEntityTag("*", '"a"')).toBe(true);
+    expect(requestMatchesEntityTag('"a"', '"a"')).toBe(true);
+    expect(requestMatchesEntityTag('W/"a"', '"a"')).toBe(true);
+    expect(requestMatchesEntityTag('"b", "c"', '"a"')).toBe(false);
+  });
+});

--- a/apps/server/test/public/public-project-attachments.test.ts
+++ b/apps/server/test/public/public-project-attachments.test.ts
@@ -64,13 +64,28 @@ describe("public project attachments", () => {
           sizeBytes: fixture.bytes.byteLength,
         });
 
-        const content = await harness.app.request(
-          `/api/v1/projects/${project.id}/attachments/content?path=${encodeURIComponent(uploaded.path)}`,
-        );
+        const contentUrl = `/api/v1/projects/${project.id}/attachments/content?path=${encodeURIComponent(uploaded.path)}`;
+        const content = await harness.app.request(contentUrl);
         expect(content.status).toBe(200);
         expect(new Uint8Array(await content.arrayBuffer())).toEqual(
           fixture.bytes,
         );
+        // Stored names are unique per upload, so the bytes are immutable and
+        // the browser may keep them; the validator still answers 304.
+        expect(content.headers.get("cache-control")).toBe(
+          "private, immutable, max-age=31536000",
+        );
+        expect(content.headers.get("content-length")).toBe(
+          String(fixture.bytes.byteLength),
+        );
+        const etag = content.headers.get("etag");
+        expect(etag).toMatch(/^"[^"]+"$/u);
+        const revalidated = await harness.app.request(contentUrl, {
+          headers: { "if-none-match": etag ?? "" },
+        });
+        expect(revalidated.status).toBe(304);
+        expect(revalidated.headers.get("etag")).toBe(etag);
+        expect((await revalidated.arrayBuffer()).byteLength).toBe(0);
       }
     });
   });

--- a/apps/server/test/public/public-projects-local-host.test.ts
+++ b/apps/server/test/public/public-projects-local-host.test.ts
@@ -9,6 +9,7 @@ import { defaultExperiments, PERSONAL_PROJECT_ID } from "@bb/domain";
 import {
   reportQueuedCommandSuccess,
   waitForQueuedCommand,
+  waitForQueuedCommandAfter,
 } from "../helpers/commands.js";
 import { readJson } from "../helpers/json.js";
 import {
@@ -320,7 +321,39 @@ describe("public project local host routes", () => {
       expect(fileResponse.headers.get("content-type")).toContain(
         "application/typescript",
       );
+      expect(fileResponse.headers.get("cache-control")).toBe(
+        "private, no-cache",
+      );
+      expect(fileResponse.headers.get("etag")).toBe(`"${"0".repeat(64)}"`);
+      expect(fileResponse.headers.get("x-bb-content-encoding")).toBe("utf8");
       await expect(fileResponse.text()).resolves.toBe("console.log('ok');");
+
+      // A revalidation with the current tag still reads the file (the daemon
+      // hashes the bytes it returns) but answers 304 without a body.
+      const revalidatePromise = harness.app.request(
+        `/api/v1/projects/${project.id}/files/content?path=${encodeURIComponent("src/app.ts")}`,
+        { headers: { "if-none-match": `"${"0".repeat(64)}"` } },
+      );
+      const revalidateCommand = await waitForQueuedCommandAfter(
+        harness,
+        fileCommand.row.cursor,
+        ({ command }) =>
+          command.type === "host.read_file" &&
+          command.path === "/tmp/project-file-content/src/app.ts",
+      );
+      await reportQueuedCommandSuccess(harness, revalidateCommand, {
+        path: "/tmp/project-file-content/src/app.ts",
+        content: "console.log('ok');",
+        contentEncoding: "utf8",
+        mimeType: "application/typescript",
+        sizeBytes: 18,
+        sha256: "0".repeat(64),
+      });
+      const revalidated = await revalidatePromise;
+      expect(revalidated.status).toBe(304);
+      expect(revalidated.headers.get("etag")).toBe(`"${"0".repeat(64)}"`);
+      expect(revalidated.headers.get("x-bb-content-encoding")).toBe("utf8");
+      expect((await revalidated.arrayBuffer()).byteLength).toBe(0);
     });
   });
 });

--- a/packages/sdk/src/areas/projects.ts
+++ b/packages/sdk/src/areas/projects.ts
@@ -360,9 +360,15 @@ export function createProjectsArea(args: CreateSdkAreaArgs): ProjectsArea {
       const filename = resolveAttachmentFilename(input);
       const mimeType =
         input.mimeType ?? embeddedAttachmentMimeType(input.clientFile) ?? "";
-      const file = new Blob([await attachmentBytes(input.clientFile)], {
-        type: mimeType,
-      });
+      // A Blob/File whose type already matches streams straight into the
+      // form; copying it through arrayBuffer() first doubles the memory of a
+      // multi-megabyte photo on the main thread for nothing.
+      const file =
+        input.clientFile instanceof Blob && input.clientFile.type === mimeType
+          ? input.clientFile
+          : new Blob([await attachmentBytes(input.clientFile)], {
+              type: mimeType,
+            });
       const form = new FormData();
       form.set("file", file, filename);
       const baseUrl = transport.baseUrl.replace(/\/$/u, "");


### PR DESCRIPTION
## What was wrong

- API JSON was gzip-only through hono/compress. It never set Vary and its 1 KB threshold did not apply because Hono JSON has no Content-Length, so every body streamed through gzip. Brotli saves 10-20% on the timeline and sidebar payloads a phone downloads per turn.
- Attachment content had no cache headers although stored names are immutable. Host-file responses ignored the sha256/mtime the daemon returns. iOS purges the memory cache on backgrounding, so PWA relaunches re-downloaded multi-megabyte screenshots. The SDK also copied every upload through arrayBuffer() and the composer preview re-downloaded the image it had just uploaded.
- index.html and all public icons/manifests were served no-store. no-store blocks the WebKit back/forward cache, and icons were refetched on every favicon flip and never edge-cached. The favicon code re-decoded both PNGs on every badge flip, even in an installed PWA where no tab icon exists.
- The plugin-frontend pagehide handler tore everything down even for a bfcache freeze and had no pageshow reboot.
- Every thread-list subscriber received every thread's raw events-appended stream (~10 frames/s per streaming thread) and ran cache walks for threads it was not viewing.

## What changed

- New apps/server/src/api-response-compression.ts buffers core /api/v1 JSON (not plugin bb.http handlers, not /internal streaming) and sends Brotli q4 or gzip with exact Content-Length and Vary: Accept-Encoding; sub-1 KB bodies stay identity. It runs inside the existing streaming gzip fallback.
- Attachment content: private, immutable, max-age=31536000 + ETag + Content-Length + 304. Daemon file responses: ETag (sha256), Last-Modified, Content-Length, default private, no-cache, 304 on If-None-Match; content routes pass If-None-Match through. SDK passes Blob/File to FormData directly. Composer keeps an object URL for a just-picked image (revoked on remove). Images use decoding="async".
- index.html: no-cache. Non-HTML public files: public, max-age=86400. Favicon base glyphs memoized; favicon work skipped in standalone display mode.
- Plugin frontends tear down only on a non-persisted pagehide; a persisted pageshow reconciles or reboots.
- Hub: thread-detail subscribers get every events-appended frame; thread-list-only sockets get the first frame at once and one merged frame per 1 s window per thread. Frames with list-relevant metadata or other change kinds bypass coalescing.

## How you verified

- New tests: apps/server/test/app/api-json-compression.test.ts (br + Content-Length + Vary, gzip fallback and q=0, identity below threshold, plugin/internal paths not buffered, real /api/v1/system/config); apps/server/test/hosts/daemon-file-response.test.ts (validators, caller headers kept, 304, If-None-Match matching); apps/server/test/app/hub.test.ts (detail vs list-only fan-out, trailing merged frame, bypass rules, per-thread windows, waiters and listeners); apps/app/src/components/promptbox/AttachmentPreview.test.tsx (object-URL src, fallback URL, decoding=async, revoke on remove); apps/app/src/lib/favicon-color-preference.test.ts (one decode per glyph, standalone skip); apps/app/src/lib/plugin-frontend.test.ts (page lifecycle policy).
- Updated tests: static-cache.test.ts (no-cache index, max-age=86400 icons/manifest), public-project-attachments.test.ts (cache headers, ETag, 304).
- pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/sdk --filter=@bb/server: pass. lint: 0 errors. Full @bb/server and @bb/sdk suites: all pass except a pre-existing umask-dependent internal-skill-trees test that also fails on baseline.

Fixes: part of the mobile / iOS Safari performance program (verified sweep report in the bb thread; no single issue).


## Stack context

Layer 10 of 22 in the `bb/mobile-perf/*` stack (bottom → top: quick wins first, big rocks last).
- Prerequisite (layer below): `bb/mobile-perf/timeline-delta-ring-and-output-cap` (#1888).
- Next layer: `bb/mobile-perf/boot-shell-quickwins` (#1890).
- Audit findings addressed: see title IDs. Review: approved-with-fixes; 2 review fix commit(s).
- Reviewer notes / follow-ups: Minor (not fixed, by design/bounded): apps/app/src/lib/attachment-local-previews.ts keeps up to 24 object URLs (and thus the picked File/Blob) alive after a draft is sent; only rem | Behavioral note (documented by implementer): SDK/plugin `thread:changed` subscribers without a threadId (thread-list channel) now receive plain events-appended at leading edge + on | Pre-existing, unrelated: apps/server/src/server.ts fails the root eslint `no-restricted-imports` rule for node:fs/promises (present at base dde6cddc5; @bb/server has no lint task s
- Wire/contract: None on the server<->daemon wire (HOST_DAEMON_PROTOCOL_VERSION not bumped): daemon-file-response only consumes fields the daemon already returns (sha256, modifiedAtMs). Client-facing HTTP: API JSON may now be Content-Encoding: br with Content-Length + Vary; attachment content and host-file routes gain ETag/Last-Modified/Cache-Control/Content-Length and can answer 304; index.html no-cache; public f

> AGENT GENERATED: by Claude Opus 5

