### PR TITLE
Defer compact sidebar subtree realization inside the closed drawer (A7)

### DIFF
--- a/apps/app/src/components/ui/sidebar.test.tsx
+++ b/apps/app/src/components/ui/sidebar.test.tsx
@@ -155,20 +155,133 @@ function getMobilePanel(): HTMLElement | null {
   return panel instanceof HTMLElement ? panel : null;
 }
 
-describe("mobile sidebar persistence", () => {
-  it("keeps closed drawer content mounted, inert, and offscreen", () => {
+// Matches SIDEBAR_MOBILE_REALIZE_TIMEOUT_MS: the closed compact drawer
+// realizes its subtree at the latest this long after boot.
+const MOBILE_REALIZE_TIMEOUT_MS = 1000;
+
+function settleMobileRealization() {
+  act(() => {
+    vi.advanceTimersByTime(MOBILE_REALIZE_TIMEOUT_MS);
+  });
+}
+
+function renderCompactSidebarHarness() {
+  render(
+    <CompactViewportOverrideProvider isCompactViewport>
+      <SidebarProvider>
+        <Sidebar>Sidebar content</Sidebar>
+        <SidebarInset>
+          <SidebarTrigger />
+          Main content
+        </SidebarInset>
+      </SidebarProvider>
+    </CompactViewportOverrideProvider>,
+  );
+}
+
+describe("mobile sidebar deferred realization", () => {
+  it("mounts the closed panel empty at boot and realizes it after the settle window", () => {
     vi.useFakeTimers();
-    render(
-      <CompactViewportOverrideProvider isCompactViewport>
+    renderCompactSidebarHarness();
+
+    // The panel element itself is mounted from the first commit (the swipe
+    // helpers select it), but its subtree stays out of the boot critical
+    // path while the drawer is closed.
+    const closedPanel = getMobilePanel();
+    expect(closedPanel).not.toBeNull();
+    expect(closedPanel?.dataset.state).toBe("closed");
+    expect(closedPanel?.hasAttribute("inert")).toBe(true);
+    expect(closedPanel?.textContent).not.toContain("Sidebar content");
+
+    settleMobileRealization();
+
+    // Same panel element; only the subtree was realized (no remount).
+    expect(getMobilePanel()).toBe(closedPanel);
+    expect(closedPanel?.dataset.state).toBe("closed");
+    expect(closedPanel?.textContent).toContain("Sidebar content");
+  });
+
+  it("prefers requestIdleCallback with a bounded timeout when available", () => {
+    vi.useFakeTimers();
+    let idleCallback: (() => void) | null = null;
+    let idleTimeout: number | undefined;
+    const cancelIdle = vi.fn();
+    Object.defineProperty(window, "requestIdleCallback", {
+      configurable: true,
+      value: (callback: () => void, options?: { timeout?: number }) => {
+        idleCallback = callback;
+        idleTimeout = options?.timeout;
+        return 1;
+      },
+    });
+    Object.defineProperty(window, "cancelIdleCallback", {
+      configurable: true,
+      value: cancelIdle,
+    });
+    try {
+      renderCompactSidebarHarness();
+      expect(idleCallback).not.toBeNull();
+      expect(idleTimeout).toBe(MOBILE_REALIZE_TIMEOUT_MS);
+      expect(getMobilePanel()?.textContent).not.toContain("Sidebar content");
+
+      // Frames alone must not realize: idle is the signal in this browser.
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+      expect(getMobilePanel()?.textContent).not.toContain("Sidebar content");
+
+      act(() => {
+        idleCallback?.();
+      });
+      expect(getMobilePanel()?.textContent).toContain("Sidebar content");
+    } finally {
+      Reflect.deleteProperty(window, "requestIdleCallback");
+      Reflect.deleteProperty(window, "cancelIdleCallback");
+    }
+  });
+
+  it("realizes the subtree at the start of a deferred open before idle", () => {
+    vi.useFakeTimers();
+    renderCompactSidebarHarness();
+    expect(getMobilePanel()?.textContent).not.toContain("Sidebar content");
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
+
+    // The slide starts from inline styles while React state stays closed;
+    // the subtree must commit during that window, not after the settle.
+    const openingPanel = getMobilePanel();
+    expect(openingPanel?.dataset.state).toBe("closed");
+    expect(openingPanel?.textContent).toContain("Sidebar content");
+
+    settleMobileToggle();
+    expect(getMobilePanel()?.dataset.state).toBe("open");
+    expect(getMobilePanel()?.textContent).toContain("Sidebar content");
+
+    // Retained across close: the latch never resets.
+    fireEvent.click(screen.getByTestId("sidebar-mobile-backdrop"));
+    settleMobileToggle();
+    expect(getMobilePanel()?.dataset.state).toBe("closed");
+    expect(getMobilePanel()?.textContent).toContain("Sidebar content");
+  });
+
+  it("renders the desktop sidebar subtree synchronously", () => {
+    const markup = renderToString(
+      <CompactViewportOverrideProvider isCompactViewport={false}>
         <SidebarProvider>
           <Sidebar>Sidebar content</Sidebar>
-          <SidebarInset>
-            <SidebarTrigger />
-            Main content
-          </SidebarInset>
         </SidebarProvider>
       </CompactViewportOverrideProvider>,
     );
+
+    expect(markup).toContain("Sidebar content");
+  });
+});
+
+describe("mobile sidebar persistence", () => {
+  it("keeps closed drawer content mounted, inert, and offscreen", () => {
+    vi.useFakeTimers();
+    renderCompactSidebarHarness();
+    settleMobileRealization();
 
     // The rows stay mounted while the drawer is closed, so reopening
     // replays no mount cost (#1261) — but the closed panel must not be
@@ -326,12 +439,13 @@ describe("mobile sidebar persistence", () => {
     );
 
     const trigger = screen.getByRole("button", { name: "Toggle Sidebar" });
-    const row = screen.getByRole("button", { name: "Sidebar row" });
     const insetAction = screen.getByRole("button", { name: "Inset action" });
 
     fireEvent.click(trigger);
     settleMobileToggle();
     expect(getMobilePanel()?.dataset.state).toBe("open");
+    // The row exists only once the open realized the drawer subtree.
+    const row = screen.getByRole("button", { name: "Sidebar row" });
 
     act(() => trigger.focus());
     fireEvent.keyDown(trigger, { key: "Tab" });
@@ -399,6 +513,9 @@ describe("mobile sidebar text-selection arbitration", () => {
     fireTouch(window, "touchmove", createTouch(260, 164));
 
     expect(getMobilePanel()?.dataset.state).toBe("open");
+    // The swipe path flips React state directly; the subtree must realize
+    // in that same commit so the dragged-in panel is not empty.
+    expect(getMobilePanel()?.textContent).toContain("Sidebar content");
   });
 
   it("defers the horizontal-scroll-region probe until horizontal intent", () => {

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -25,6 +25,9 @@ const SIDEBAR_MOBILE_SWIPE_OPEN_RATIO = 0.33;
 const SIDEBAR_MOBILE_SWIPE_OPEN_FLING_MIN_RATIO = 0.12;
 const SIDEBAR_MOBILE_SWIPE_OPEN_FLING_VELOCITY_PX_PER_SEC = 450;
 const SIDEBAR_MOBILE_DRAG_SETTLE_MS = 220;
+// Upper bound on how long the closed compact drawer stays empty after boot
+// before its subtree is realized regardless of main-thread idleness.
+const SIDEBAR_MOBILE_REALIZE_TIMEOUT_MS = 1000;
 const SIDEBAR_MOBILE_DRAG_SETTLE_EASING = "cubic-bezier(0.32, 0.72, 0, 1)";
 // The panel moves on the `translate` property, matching Tailwind v4's
 // `-translate-x-full` utilities. Inline motion styles MUST use the same
@@ -352,6 +355,67 @@ function getTrackedSwipeTouch(
   );
 }
 
+/**
+ * Schedules the one-time realization of the closed compact drawer's subtree
+ * off the boot critical path. It prefers an idle callback so the sidebar
+ * rows, DnD contexts and search hooks mount after the route chunk has been
+ * fetched and evaluated; browsers without `requestIdleCallback` get two
+ * animation frames instead. The timeout bounds the wait (an idle callback
+ * can starve during a long boot, and frames stop in background tabs) so a
+ * later open never finds an unrealized panel. Returns a cancel function.
+ */
+function scheduleSidebarMobileRealization(realize: () => void): () => void {
+  let settled = false;
+  let idleHandle: number | null = null;
+  let firstFrame: number | null = null;
+  let secondFrame: number | null = null;
+  const cancel = () => {
+    if (idleHandle !== null) {
+      window.cancelIdleCallback(idleHandle);
+      idleHandle = null;
+    }
+    if (firstFrame !== null) {
+      window.cancelAnimationFrame(firstFrame);
+      firstFrame = null;
+    }
+    if (secondFrame !== null) {
+      window.cancelAnimationFrame(secondFrame);
+      secondFrame = null;
+    }
+    window.clearTimeout(timeout);
+  };
+  const run = () => {
+    if (settled) {
+      return;
+    }
+    settled = true;
+    cancel();
+    realize();
+  };
+  const timeout = window.setTimeout(run, SIDEBAR_MOBILE_REALIZE_TIMEOUT_MS);
+  if (typeof window.requestIdleCallback === "function") {
+    idleHandle = window.requestIdleCallback(
+      () => {
+        idleHandle = null;
+        run();
+      },
+      { timeout: SIDEBAR_MOBILE_REALIZE_TIMEOUT_MS },
+    );
+  } else {
+    firstFrame = window.requestAnimationFrame(() => {
+      firstFrame = null;
+      secondFrame = window.requestAnimationFrame(() => {
+        secondFrame = null;
+        run();
+      });
+    });
+  }
+  return () => {
+    settled = true;
+    cancel();
+  };
+}
+
 type SidebarContext = {
   state: "expanded" | "collapsed";
   open: boolean;
@@ -361,6 +425,13 @@ type SidebarContext = {
   openMobileSidebar: () => void;
   closeMobileSidebar: () => void;
   isMobileSidebarClosing: boolean;
+  /**
+   * Whether the compact drawer's subtree is mounted. It starts false so the
+   * closed, inert panel adds no render work to boot; the first open (or an
+   * idle window, at most one second after boot) latches it true for the
+   * rest of the session. Always false outside compact viewports.
+   */
+  isMobileSidebarRealized: boolean;
   suppressMobileOpenAnimation: boolean;
   setSuppressMobileOpenAnimation: (suppress: boolean) => void;
   suppressMobileCloseAnimation: boolean;
@@ -450,6 +521,11 @@ const SidebarProvider = React.forwardRef<
       React.useState(false);
     const [isMobileSidebarClosing, setIsMobileSidebarClosing] =
       React.useState(false);
+    const [hasRealizedMobileSidebar, setHasRealizedMobileSidebar] =
+      React.useState(false);
+    const realizeMobileSidebar = React.useCallback(() => {
+      setHasRealizedMobileSidebar(true);
+    }, []);
     const mobileSettleTimeoutRef = React.useRef<number | null>(null);
 
     const clearMobileSettleTimeout = React.useCallback(() => {
@@ -503,6 +579,9 @@ const SidebarProvider = React.forwardRef<
         return;
       }
 
+      // Mount the subtree now if boot has not realized it yet, so it commits
+      // during the slide instead of after the settle.
+      realizeMobileSidebar();
       applySidebarMobileDragStyles({ progress: 1, settling: true });
       mobileSettleTimeoutRef.current = window.setTimeout(() => {
         mobileSettleTimeoutRef.current = null;
@@ -515,7 +594,7 @@ const SidebarProvider = React.forwardRef<
         });
         clearSidebarMobileDragAttributes();
       }, SIDEBAR_MOBILE_DRAG_SETTLE_MS);
-    }, []);
+    }, [realizeMobileSidebar]);
 
     React.useEffect(
       () => () => {
@@ -523,6 +602,23 @@ const SidebarProvider = React.forwardRef<
       },
       [clearMobileSettleTimeout],
     );
+
+    // The latch. An open that bypasses `openMobileSidebar` (the swipe path
+    // and direct `setOpenMobile(true)` callers) realizes the subtree in the
+    // same render (React restarts this render before committing), and a
+    // drawer that stays closed realizes off the boot critical path. Desktop
+    // never schedules; its sidebar renders children directly.
+    if (isCompactViewport && openMobile && !hasRealizedMobileSidebar) {
+      setHasRealizedMobileSidebar(true);
+    }
+    const isMobileSidebarRealized =
+      isCompactViewport && hasRealizedMobileSidebar;
+    React.useEffect(() => {
+      if (!isCompactViewport || hasRealizedMobileSidebar) {
+        return;
+      }
+      return scheduleSidebarMobileRealization(realizeMobileSidebar);
+    }, [hasRealizedMobileSidebar, isCompactViewport, realizeMobileSidebar]);
 
     React.useEffect(() => {
       if (openMobile) {
@@ -580,6 +676,7 @@ const SidebarProvider = React.forwardRef<
         openMobileSidebar,
         closeMobileSidebar,
         isMobileSidebarClosing,
+        isMobileSidebarRealized,
         suppressMobileOpenAnimation,
         setSuppressMobileOpenAnimation,
         suppressMobileCloseAnimation,
@@ -596,6 +693,7 @@ const SidebarProvider = React.forwardRef<
         openMobileSidebar,
         closeMobileSidebar,
         isMobileSidebarClosing,
+        isMobileSidebarRealized,
         suppressMobileOpenAnimation,
         setSuppressMobileOpenAnimation,
         suppressMobileCloseAnimation,
@@ -665,6 +763,7 @@ const Sidebar = React.forwardRef<
       openMobile,
       setOpenMobile,
       closeMobileSidebar,
+      isMobileSidebarRealized,
       suppressMobileOpenAnimation,
       setSuppressMobileOpenAnimation,
       suppressMobileCloseAnimation,
@@ -735,6 +834,8 @@ const Sidebar = React.forwardRef<
       // reopen replays no mount work. While closed the translated panel is
       // `inert`, so it cannot trap focus or taps. It stays style-ready because
       // a visibility flip makes WebKit rebuild the subtree during every open.
+      // The subtree itself is realized once, off the boot critical path or on
+      // the first open, and then retained (the provider owns the latch).
       return (
         <SidebarMobilePanel
           ref={ref}
@@ -750,7 +851,7 @@ const Sidebar = React.forwardRef<
           style={style}
           {...props}
         >
-          {children}
+          {isMobileSidebarRealized ? children : null}
         </SidebarMobilePanel>
       );
     }


### PR DESCRIPTION
## What was wrong

On compact viewports `AppLayout` mounts the sidebar before the lazy route element, and `SidebarMobilePanel` always rendered its children. `ProjectList`, its DnD contexts, search hooks and slot subscriptions therefore ran on the boot critical path for a panel that sits translated off-screen and `inert` (audit finding A7).

## What changed

- `apps/app/src/components/ui/sidebar.tsx`: `SidebarProvider` owns a one-shot realization latch (`isMobileSidebarRealized`). The panel element stays mounted from the first commit (the swipe helpers select it; no visibility flip, per #1261/#1356), but the compact `Sidebar` renders its children only once the latch is set:
  - `openMobileSidebar()` (trigger tap) realizes at slide start so the subtree commits during the slide.
  - The swipe path and direct `setOpenMobile(true)` callers realize in the same render (render-time state adjust).
  - A drawer that stays closed realizes from `requestIdleCallback` with a 1 s timeout; browsers without idle callbacks use two animation frames plus the same 1 s timeout.
  - The latch never resets, so app/settings/tools mode swaps and reopen keep the retained subtree. Desktop renders children directly as before.

## How you verified

- New tests in `apps/app/src/components/ui/sidebar.test.tsx` (fail before, pass after): closed panel is mounted, inert and empty at boot, then realized in place after the settle window; `requestIdleCallback` is preferred with `timeout: 1000` and frames alone do not realize; a deferred open realizes before React state flips and content is retained across close; desktop SSR renders children synchronously; swipe-open realizes in the same commit.
- `pnpm exec turbo run test --filter=@bb/app -- src/components/ui/sidebar.test.tsx src/components/layout/AppLayoutSidebar.test.tsx src/components/plugin/PluginNavSidebarItems.test.tsx` and `-- src/components/layout/ src/components/sidebar/ ...`: all pass (37 files, 289 tests).
- `pnpm exec turbo run typecheck lint --filter=@bb/app`: pass; lint warning count unchanged (148 before and after, none in sidebar.tsx).

Fixes: part of the mobile / iOS Safari performance program (verified sweep report in the bb thread; no single issue).


## Stack context

Layer 14 of 22 in the `bb/mobile-perf/*` stack (bottom → top: quick wins first, big rocks last).
- Prerequisite (layer below): `bb/mobile-perf/icon-core-map` (#1892).
- Next layer: `bb/mobile-perf/pierre-pool-and-route-closure` (#1894).
- Audit findings addressed: see title IDs. Review: approved.
- Wire/contract: None. No server/daemon wire, protocol version, CLI, config, or plugin API changes. SidebarContext (internal, apps/app only) gains `isMobileSidebarRealized: boolean`.

> AGENT GENERATED: by Claude Opus 5

