### PR TITLE
Phone interactions: long-press menu, touch listeners, sidebar across routes, composer retention (E1, E6, E7, E10, D3, J3, J4, I6, B28)

### DIFF
--- a/apps/app/src/components/layout/AppLayoutSidebar.test.tsx
+++ b/apps/app/src/components/layout/AppLayoutSidebar.test.tsx
@@ -1,7 +1,13 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { useState } from "react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { useEffect, useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
 import {
@@ -14,12 +20,28 @@ import {
   type AppLayoutSidebarMode,
 } from "./AppLayoutSidebar";
 
+const mountCounts = vi.hoisted(() => ({ appSidebar: 0 }));
+
 vi.mock("@/components/sidebar/AppSidebar", async () => {
   const { Sidebar } = await vi.importActual<
     typeof import("@/components/ui/sidebar")
   >("@/components/ui/sidebar");
+  const { useEffect } = await vi.importActual<typeof import("react")>("react");
   return {
-    AppSidebar: () => <Sidebar>App sidebar</Sidebar>,
+    AppSidebar: ({ mobileHosted }: { mobileHosted?: { hidden: boolean } }) => {
+      // Stands in for ProjectList: mount work we must not repeat per trip.
+      useEffect(() => {
+        mountCounts.appSidebar += 1;
+      }, []);
+      if (mobileHosted) {
+        return (
+          <div data-testid="app-sidebar-body" hidden={mobileHosted.hidden}>
+            App sidebar
+          </div>
+        );
+      }
+      return <Sidebar>App sidebar</Sidebar>;
+    },
   };
 });
 
@@ -28,7 +50,12 @@ vi.mock("@/components/settings/SettingsSidebar", async () => {
     typeof import("@/components/ui/sidebar")
   >("@/components/ui/sidebar");
   return {
-    SettingsSidebar: () => <Sidebar>Settings sidebar</Sidebar>,
+    SettingsSidebar: ({ mobileHosted }: { mobileHosted?: boolean }) =>
+      mobileHosted ? (
+        <div data-testid="settings-sidebar-body">Settings sidebar</div>
+      ) : (
+        <Sidebar>Settings sidebar</Sidebar>
+      ),
   };
 });
 
@@ -37,7 +64,12 @@ vi.mock("@/components/tools/ToolsSidebar", async () => {
     typeof import("@/components/ui/sidebar")
   >("@/components/ui/sidebar");
   return {
-    ToolsSidebar: () => <Sidebar>Tools sidebar</Sidebar>,
+    ToolsSidebar: ({ mobileHosted }: { mobileHosted?: boolean }) =>
+      mobileHosted ? (
+        <div data-testid="tools-sidebar-body">Tools sidebar</div>
+      ) : (
+        <Sidebar>Tools sidebar</Sidebar>
+      ),
   };
 });
 
@@ -57,9 +89,20 @@ function getMobilePanel(): HTMLElement {
   return panel;
 }
 
-function SidebarModeHarness() {
+function getAppSidebarBody(): HTMLElement {
+  return screen.getByTestId("app-sidebar-body");
+}
+
+function SidebarModeHarness({
+  onMode,
+}: {
+  onMode?: (mode: AppLayoutSidebarMode) => void;
+}) {
   const [mode, setMode] = useState<AppLayoutSidebarMode>("app");
   const closeMobileSidebar = useCloseMobileSidebar();
+  useEffect(() => {
+    onMode?.(mode);
+  }, [mode, onMode]);
   const navigate = (nextMode: AppLayoutSidebarMode) => {
     closeMobileSidebar();
     setMode(nextMode);
@@ -69,6 +112,9 @@ function SidebarModeHarness() {
     <>
       <button type="button" onClick={() => navigate("settings")}>
         Navigate to settings
+      </button>
+      <button type="button" onClick={() => navigate("tools")}>
+        Navigate to tools
       </button>
       <button type="button" onClick={() => navigate("app")}>
         Navigate back to app
@@ -92,10 +138,11 @@ function SidebarModeHarness() {
 afterEach(() => {
   cleanup();
   vi.useRealTimers();
+  mountCounts.appSidebar = 0;
 });
 
 describe("AppLayoutSidebar mobile mode transitions", () => {
-  it("waits for the current drawer to close before swapping sidebar modes", () => {
+  it("keeps one drawer panel and the app sidebar mounted across settings and tools round trips", () => {
     vi.useFakeTimers();
     render(
       <CompactViewportOverrideProvider isCompactViewport>
@@ -108,49 +155,64 @@ describe("AppLayoutSidebar mobile mode transitions", () => {
     fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
     settleMobileToggle();
 
-    const appPanel = getMobilePanel();
-    expect(appPanel.dataset.state).toBe("open");
-    expect(appPanel.textContent).toContain("App sidebar");
+    const panel = getMobilePanel();
+    expect(panel.dataset.state).toBe("open");
+    expect(getAppSidebarBody().hidden).toBe(false);
+    expect(screen.queryByTestId("settings-sidebar-body")).toBeNull();
+    expect(mountCounts.appSidebar).toBe(1);
 
     fireEvent.click(
       screen.getByRole("button", { name: "Navigate to settings" }),
     );
 
-    // The route/mode changes immediately, but the currently visible panel
-    // remains mounted for its one compositor-driven close.
-    expect(getMobilePanel()).toBe(appPanel);
-    expect(appPanel.textContent).toContain("App sidebar");
-    expect(appPanel.style.translate).toBe("-100%");
+    // The route/mode changes immediately, but the visible body is held for
+    // the one compositor-driven close so the slide does not swap content.
+    expect(getMobilePanel()).toBe(panel);
+    expect(getAppSidebarBody().hidden).toBe(false);
+    expect(screen.queryByTestId("settings-sidebar-body")).toBeNull();
+    expect(panel.style.translate).toBe("-100%");
 
     settleMobileToggle();
 
-    const settingsPanel = getMobilePanel();
-    expect(settingsPanel).not.toBe(appPanel);
-    expect(settingsPanel.dataset.state).toBe("closed");
-    expect(settingsPanel.textContent).toContain("Settings sidebar");
+    // Same panel element; the app body is hidden, not unmounted.
+    expect(getMobilePanel()).toBe(panel);
+    expect(panel.dataset.state).toBe("closed");
+    expect(getAppSidebarBody().hidden).toBe(true);
+    expect(screen.getByTestId("settings-sidebar-body").textContent).toBe(
+      "Settings sidebar",
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
     settleMobileToggle();
     expect(getMobilePanel().dataset.state).toBe("open");
 
-    const reopenedSettingsPanel = getMobilePanel();
+    fireEvent.click(screen.getByRole("button", { name: "Navigate to tools" }));
+    settleMobileToggle();
+    expect(screen.queryByTestId("settings-sidebar-body")).toBeNull();
+    expect(screen.getByTestId("tools-sidebar-body")).toBeTruthy();
+    expect(getAppSidebarBody().hidden).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
+    settleMobileToggle();
     fireEvent.click(
       screen.getByRole("button", { name: "Navigate back to app" }),
     );
 
-    expect(getMobilePanel()).toBe(reopenedSettingsPanel);
-    expect(reopenedSettingsPanel.textContent).toContain("Settings sidebar");
-    expect(reopenedSettingsPanel.style.translate).toBe("-100%");
+    // Held during the close ...
+    expect(screen.getByTestId("tools-sidebar-body")).toBeTruthy();
+    expect(getAppSidebarBody().hidden).toBe(true);
+    expect(getMobilePanel().style.translate).toBe("-100%");
 
     settleMobileToggle();
 
-    const returnedAppPanel = getMobilePanel();
-    expect(returnedAppPanel).not.toBe(reopenedSettingsPanel);
-    expect(returnedAppPanel.dataset.state).toBe("closed");
-    expect(returnedAppPanel.textContent).toContain("App sidebar");
+    // ... then the app body shows again without a remount.
+    expect(getMobilePanel()).toBe(panel);
+    expect(screen.queryByTestId("tools-sidebar-body")).toBeNull();
+    expect(getAppSidebarBody().hidden).toBe(false);
+    expect(mountCounts.appSidebar).toBe(1);
   });
 
-  it("swaps modes immediately when navigation does not close the drawer", () => {
+  it("swaps bodies immediately when navigation does not close the drawer", () => {
     vi.useFakeTimers();
     render(
       <CompactViewportOverrideProvider isCompactViewport>
@@ -163,17 +225,38 @@ describe("AppLayoutSidebar mobile mode transitions", () => {
     fireEvent.click(screen.getByRole("button", { name: "Toggle Sidebar" }));
     settleMobileToggle();
 
-    const appPanel = getMobilePanel();
-    expect(appPanel.dataset.state).toBe("open");
-    expect(appPanel.textContent).toContain("App sidebar");
+    const panel = getMobilePanel();
+    expect(panel.dataset.state).toBe("open");
+    expect(getAppSidebarBody().hidden).toBe(false);
 
     fireEvent.click(
       screen.getByRole("button", { name: "Change route without closing" }),
     );
 
-    const settingsPanel = getMobilePanel();
-    expect(settingsPanel).not.toBe(appPanel);
-    expect(settingsPanel.dataset.state).toBe("open");
-    expect(settingsPanel.textContent).toContain("Settings sidebar");
+    expect(getMobilePanel()).toBe(panel);
+    expect(panel.dataset.state).toBe("open");
+    expect(getAppSidebarBody().hidden).toBe(true);
+    expect(screen.getByTestId("settings-sidebar-body")).toBeTruthy();
+  });
+
+  it("keeps separate sidebar shells per mode on wide viewports", () => {
+    render(
+      <CompactViewportOverrideProvider isCompactViewport={false}>
+        <SidebarProvider>
+          <SidebarModeHarness />
+        </SidebarProvider>
+      </CompactViewportOverrideProvider>,
+    );
+
+    expect(screen.getByText("App sidebar")).toBeTruthy();
+    expect(screen.queryByTestId("app-sidebar-body")).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Change route without closing" }),
+    );
+
+    expect(screen.getByText("Settings sidebar")).toBeTruthy();
+    expect(screen.queryByText("App sidebar")).toBeNull();
+    expect(screen.queryByTestId("settings-sidebar-body")).toBeNull();
   });
 });

--- a/apps/app/src/components/layout/AppLayoutSidebar.tsx
+++ b/apps/app/src/components/layout/AppLayoutSidebar.tsx
@@ -2,7 +2,7 @@ import { useState, type MouseEvent as ReactMouseEvent } from "react";
 import { AppSidebar } from "@/components/sidebar/AppSidebar";
 import { SettingsSidebar } from "@/components/settings/SettingsSidebar";
 import { ToolsSidebar } from "@/components/tools/ToolsSidebar";
-import { useSidebar } from "@/components/ui/sidebar.js";
+import { Sidebar, useSidebar } from "@/components/ui/sidebar.js";
 
 export type AppLayoutSidebarMode = "app" | "settings" | "tools";
 
@@ -17,12 +17,18 @@ interface AppLayoutSidebarProps {
 }
 
 /**
- * Keeps the current mobile drawer mounted until its close animation finishes.
+ * Picks the sidebar for the current route mode.
  *
- * Routes such as Settings replace the entire sidebar. Mobile closes are
- * intentionally deferred so the compositor can finish the slide before the
- * expensive React state commit. Swapping sidebar modes during that window
- * would mount a fresh, still-open panel and replay the close animation.
+ * On wide viewports Settings/Tools replace the entire sidebar. On compact
+ * viewports one persistent drawer panel is rendered here and the app sidebar
+ * body stays mounted (hidden) behind a Settings/Tools body: mounting the
+ * thread list costs hundreds of milliseconds of style/layout on a phone, and
+ * every trip through Settings used to pay it again on the way back, in the
+ * same task as the destination page render.
+ *
+ * Mobile closes are intentionally deferred so the compositor can finish the
+ * slide before the expensive React state commit; the visible body is held
+ * during that window so the close does not swap content mid-slide.
  */
 export function AppLayoutSidebar({
   mode,
@@ -42,6 +48,39 @@ export function AppLayoutSidebar({
     setLastVisibleMode(mode);
   }
   const renderedMode = holdCurrentMode ? lastVisibleMode : mode;
+
+  if (isCompactViewport) {
+    return (
+      <Sidebar>
+        <AppSidebar
+          onResizeMouseDown={onResizeMouseDown}
+          isResizing={isResizing}
+          showTopReserve={true}
+          settingsRoutePath={settingsRoutePath}
+          toolsRoutePath={toolsRoutePath}
+          mobileHosted={{ hidden: renderedMode !== "app" }}
+        />
+        {renderedMode === "settings" ? (
+          <SettingsSidebar
+            onResizeMouseDown={onResizeMouseDown}
+            isResizing={isResizing}
+            showTopReserve={true}
+            appRoutePath={appRoutePath}
+            mobileHosted
+          />
+        ) : null}
+        {renderedMode === "tools" ? (
+          <ToolsSidebar
+            onResizeMouseDown={onResizeMouseDown}
+            isResizing={isResizing}
+            showTopReserve={true}
+            appRoutePath={toolsBackRoutePath}
+            mobileHosted
+          />
+        ) : null}
+      </Sidebar>
+    );
+  }
 
   if (renderedMode === "settings") {
     return (

--- a/apps/app/src/components/pickers/ProjectSelector.tsx
+++ b/apps/app/src/components/pickers/ProjectSelector.tsx
@@ -48,6 +48,12 @@ export interface ProjectSelectorProps {
   /** Render as a non-interactive label while preserving the selected project. */
   disabled?: boolean;
   /**
+   * The project list has not loaded yet. The trigger shows a neutral
+   * "Loading projects" label (never the misleading "Work in a project" empty
+   * state) and stays non-interactive until the list settles.
+   */
+  isLoading?: boolean;
+  /**
    * Keep the chevron visible while disabled. Use it when the picker is only
    * transiently locked (submitting, uploading) so the trigger keeps the same
    * width and the pickers beside it don't shift.
@@ -66,20 +72,27 @@ export function ProjectSelector({
   onChange,
   allowNoProject = false,
   createProject,
-  disabled = false,
+  disabled: disabledProp = false,
+  isLoading = false,
   showChevronWhenDisabled = false,
   className,
   defaultOpen,
   modal,
 }: ProjectSelectorProps) {
+  const disabled = disabledProp || isLoading;
   const selected = value !== null ? projects.find((p) => p.id === value) : null;
   // When allowNoProject is false and the caller's value doesn't match any
   // project (shouldn't happen in normal use), the trigger falls back to the
   // first project so it's never blank.
   const fallback = !allowNoProject && !selected ? projects[0] : null;
-  const triggerLabel = selected?.name ?? fallback?.name ?? "Work in a project";
-  const compactTriggerLabel = selected?.name ?? fallback?.name ?? "No project";
-  const triggerIcon = selected || fallback ? "Folder" : "FolderPlus";
+  const triggerLabel = isLoading
+    ? "Loading projects…"
+    : (selected?.name ?? fallback?.name ?? "Work in a project");
+  const compactTriggerLabel = isLoading
+    ? "Loading…"
+    : (selected?.name ?? fallback?.name ?? "No project");
+  const triggerIcon =
+    isLoading || selected || fallback ? "Folder" : "FolderPlus";
   const createProjectAction = createProject;
   const createProjectLabel = createProjectAction?.isCreating
     ? "Creating..."
@@ -95,6 +108,7 @@ export function ProjectSelector({
           variant="ghost"
           size="sm"
           aria-label="Project"
+          aria-busy={isLoading || undefined}
           disabled={disabled}
           data-promptbox-project-control=""
           className={cn(
@@ -150,9 +164,7 @@ export function ProjectSelector({
             />
           </DropdownMenuItem>
         ))}
-        {showActionSeparator ? (
-          <DropdownMenuSeparator />
-        ) : null}
+        {showActionSeparator ? <DropdownMenuSeparator /> : null}
         {createProjectAction ? (
           <DropdownMenuItem
             disabled={createProjectAction.disabled}

--- a/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
+++ b/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
@@ -32,7 +32,10 @@ import {
   NewThreadComposer,
   type NewThreadComposerState,
 } from "@/components/promptbox/NewThreadComposer";
-import { encodeReuseValue } from "@/components/pickers/environment-picker-value";
+import {
+  encodeReuseValue,
+  REUSE_VALUE_WITHOUT_ENVIRONMENT,
+} from "@/components/pickers/environment-picker-value";
 import { useRootComposeReuseEnvironment } from "@/lib/root-compose-selection";
 import { getPromptDraftAccessor } from "@/hooks/usePromptDraftStorage";
 import { buildThreadHandoffLocationState } from "@/lib/thread-handoff-request";
@@ -45,6 +48,8 @@ const mocks = vi.hoisted(() => ({
   copyAttachments: vi.fn(),
   uploadAttachment: vi.fn(),
   projectThreads: [] as ThreadListEntry[],
+  sidebarNavigationSettled: true,
+  promptHistoryQueryOptions: [] as Array<{ enabled?: boolean } | undefined>,
 }));
 
 vi.mock("@/components/promptbox/NewThreadPromptBox", () => ({
@@ -93,20 +98,26 @@ const OTHER_PROJECT = {
 };
 
 vi.mock("@/hooks/queries/sidebar-navigation-query", () => ({
-  useSidebarNavigation: () => ({
-    data: {
-      projects: [{ ...PROJECT, threads: mocks.projectThreads }, OTHER_PROJECT],
-      personalProject: {
-        id: "personal",
-        name: "Personal",
-        sources: [],
-        threads: [],
-      },
-    },
-    isError: false,
-    isLoading: false,
-    isSuccess: true,
-  }),
+  useSidebarNavigation: () =>
+    mocks.sidebarNavigationSettled
+      ? {
+          data: {
+            projects: [
+              { ...PROJECT, threads: mocks.projectThreads },
+              OTHER_PROJECT,
+            ],
+            personalProject: {
+              id: "personal",
+              name: "Personal",
+              sources: [],
+              threads: [],
+            },
+          },
+          isError: false,
+          isLoading: false,
+          isSuccess: true,
+        }
+      : { data: undefined, isError: false, isLoading: true, isSuccess: false },
 }));
 
 vi.mock("@/hooks/queries/host-queries", () => ({
@@ -191,7 +202,13 @@ vi.mock("@/hooks/queries/thread-queries", () => ({
 
 vi.mock("@/hooks/queries/project-queries", () => ({
   stripProjectThreads: (project: unknown) => project,
-  useProjectPromptHistory: () => ({ data: [] }),
+  useProjectPromptHistory: (
+    _projectId: unknown,
+    options?: { enabled?: boolean },
+  ) => {
+    mocks.promptHistoryQueryOptions.push(options);
+    return { data: [] };
+  },
   useProjectSourceBranches: () => ({
     data: {
       branches: ["main", "release"],
@@ -369,9 +386,11 @@ async function submit(): Promise<void> {
 describe("PluginNewThreadComposer seeding", () => {
   beforeEach(() => {
     mocks.promptBoxProps.length = 0;
+    mocks.promptHistoryQueryOptions.length = 0;
     mocks.copyAttachments.mockReset();
     mocks.uploadAttachment.mockReset();
     mocks.projectThreads = [];
+    mocks.sidebarNavigationSettled = true;
     window.localStorage.clear();
     getPromptDraftAccessor({ kind: "new-thread" }).setDraft({
       text: "",
@@ -712,6 +731,132 @@ describe("PluginNewThreadComposer seeding", () => {
       type: "reuse",
       environmentId: "env-source",
     });
+  });
+
+  it("renders the root composer with a loading project picker before the sidebar bootstrap settles", () => {
+    mocks.sidebarNavigationSettled = false;
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    window.localStorage.setItem("bb.root-compose.project-id", "proj_1");
+    const router = createMemoryRouter(
+      [{ path: "/", element: <RootComposeView /> }],
+      { initialEntries: ["/"] },
+    );
+    render(
+      <Provider>
+        <QueryClientProvider client={queryClient}>
+          <RouterProvider router={router} />
+        </QueryClientProvider>
+      </Provider>,
+    );
+
+    // The composer is on screen immediately (no "Loading…" gate) ...
+    expect(screen.getByTestId("new-thread-prompt-box")).toBeTruthy();
+    expect(latestPromptBoxProps().project.isLoading).toBe(true);
+    // ... while the projectId-keyed prompt-history query waits for the
+    // settled project id, so a cold start never fetches history for a
+    // candidate project that may fall back to Personal once the bootstrap
+    // lands. (Worktree-reuse options derive from the bootstrap itself, so
+    // there is no separate threads request to gate.)
+    expect(mocks.promptHistoryQueryOptions.length).toBeGreaterThan(0);
+    expect(
+      mocks.promptHistoryQueryOptions.every(
+        (options) => options?.enabled === false,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps a seeded fork's reuse selection pending until the sidebar bootstrap settles", async () => {
+    // The worktree picker's reuse options come from the sidebar bootstrap.
+    // While it is in flight the options are "loading", not "empty": a seeded
+    // reuse selection must stay pending (`reuse`) instead of being discarded
+    // as unknown, then resolve once the bootstrap holds the source thread.
+    mocks.sidebarNavigationSettled = false;
+    const submitted: NewThreadRequest[] = [];
+    const seed = {
+      initialPrompt: "fork prompt",
+      environment: { type: "reuse" as const, environmentId: "env-source" },
+    };
+    const onSubmit = (request: NewThreadRequest) => {
+      submitted.push(request);
+    };
+    // A fresh element per render so React re-renders the composer (an
+    // identical element reference would bail out) and re-reads the mocks.
+    const element = () => (
+      <Provider>
+        <MemoryRouter>
+          <NewThreadComposer
+            projectId="proj_1"
+            onProjectChange={() => undefined}
+            draftStorage={{ kind: "new-thread" }}
+            selectionScope="new-thread"
+            seed={seed}
+            resetKey="thr_source"
+            onSubmit={onSubmit}
+          >
+            {(composer) => <ForkSeedSurface composer={composer} />}
+          </NewThreadComposer>
+        </MemoryRouter>
+      </Provider>
+    );
+    const { rerender } = render(element());
+
+    await waitFor(() => {
+      expect(latestPromptBoxProps().modeConfig.environment.value).toBe(
+        REUSE_VALUE_WITHOUT_ENVIRONMENT,
+      );
+    });
+    expect(latestPromptBoxProps().modeConfig.worktree.options).toEqual([]);
+
+    mocks.sidebarNavigationSettled = true;
+    mocks.projectThreads = [
+      makeThreadListEntry({
+        id: "thr_source",
+        projectId: "proj_1",
+        environmentId: "env-source",
+        environmentHostId: "host_1",
+        environmentName: "source",
+        environmentBranchName: "feature/source",
+        environmentWorkspaceDisplayKind: "managed-worktree",
+      }),
+    ];
+    rerender(element());
+
+    await waitFor(() => {
+      expect(latestPromptBoxProps().modeConfig.environment.value).toBe(
+        encodeReuseValue("env-source"),
+      );
+      expect(latestPromptBoxProps().disabled).toBe(false);
+    });
+    await submit();
+
+    expect(submitted).toHaveLength(1);
+    expect(submitted[0].environment).toEqual({
+      type: "reuse",
+      environmentId: "env-source",
+    });
+  });
+
+  it("enables the project picker and prompt-history query once the sidebar bootstrap settles", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    window.localStorage.setItem("bb.root-compose.project-id", "proj_1");
+    const router = createMemoryRouter(
+      [{ path: "/", element: <RootComposeView /> }],
+      { initialEntries: ["/"] },
+    );
+    render(
+      <Provider>
+        <QueryClientProvider client={queryClient}>
+          <RouterProvider router={router} />
+        </QueryClientProvider>
+      </Provider>,
+    );
+
+    expect(latestPromptBoxProps().project.isLoading).toBe(false);
+    expect(mocks.promptHistoryQueryOptions.at(-1)?.enabled).toBe(true);
   });
 
   it("keeps an unrelated draft attachment out of a RootComposeView handoff", async () => {

--- a/apps/app/src/components/project/ProjectActionsMenu.tsx
+++ b/apps/app/src/components/project/ProjectActionsMenu.tsx
@@ -19,6 +19,8 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@bb/shared-ui/dropdown-menu";
+import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
+import { CompactLongPressMenu } from "@/components/ui/compact-long-press-menu";
 import { usePathPickerHost } from "@/hooks/useLocalPathPicker";
 import { getProjectSettingsRoutePath } from "@/lib/route-paths";
 import { cn } from "@bb/shared-ui/lib/utils";
@@ -210,7 +212,38 @@ export function ProjectActionsMenu({
   );
 }
 
-export function ProjectActionsContextMenu({
+/**
+ * Row-level actions menu: a right-click context menu on wide viewports, and on
+ * compact viewports a touch long-press (or right-click) that opens the same
+ * items in the persistent responsive drawer instead of a modal Radix menu.
+ */
+export function ProjectActionsContextMenu(
+  props: ProjectActionsContextMenuProps,
+) {
+  const isCompactViewport = useIsCompactViewport();
+  if (isCompactViewport) {
+    return <ProjectActionsCompactLongPressMenu {...props} />;
+  }
+  return <ProjectActionsDesktopContextMenu {...props} />;
+}
+
+function ProjectActionsCompactLongPressMenu({
+  children,
+  project,
+  onOpenChange,
+}: ProjectActionsContextMenuProps) {
+  return (
+    <CompactLongPressMenu
+      label={`${project.name} actions`}
+      onOpenChange={onOpenChange}
+      items={<ProjectActionsMenuItems project={project} surface="dropdown" />}
+    >
+      {children}
+    </CompactLongPressMenu>
+  );
+}
+
+function ProjectActionsDesktopContextMenu({
   children,
   project,
   onOpenChange,

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
@@ -507,6 +507,56 @@ describe("FollowUpPromptBox", () => {
     expect(props.composer?.onSubmit).toHaveBeenCalledOnce();
   });
 
+  it("keeps the editor mounted and hidden while a pending interaction takes its place", () => {
+    const props = createFollowUpPromptBoxProps({ kind: "ready" });
+    const { container, rerender } = render(<FollowUpPromptBox {...props} />);
+    const promptBox = screen.getByTestId("prompt-box");
+    const input = screen.getByLabelText<HTMLInputElement>("Follow-up prompt");
+    input.value = "Draft typed before the approval";
+    const composerShell = container.querySelector<HTMLElement>(
+      "[data-follow-up-composer]",
+    );
+    expect(composerShell?.hidden).toBe(false);
+
+    rerender(
+      <FollowUpPromptBox
+        {...props}
+        composer={{
+          ...props.composer!,
+          submitMode: { kind: "blocked", reason: "pending-interaction" },
+        }}
+        stack={<div data-testid="pending-stack">Plan mode</div>}
+        pendingInteraction={
+          <div data-testid="pending-interaction">Allow file write?</div>
+        }
+      />,
+    );
+
+    // Same component instance and DOM: no TipTap teardown per approval.
+    expect(screen.getByTestId("prompt-box")).toBe(promptBox);
+    expect(screen.getByLabelText("Follow-up prompt")).toBe(input);
+    expect(input.value).toBe("Draft typed before the approval");
+    expect(composerShell?.hidden).toBe(true);
+    // The interaction renders below the (reduced) stack, above the composer.
+    const interaction = screen.getByTestId("pending-interaction");
+    const stackItem = screen.getByTestId("pending-stack");
+    expect(
+      stackItem.compareDocumentPosition(interaction) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
+    expect(
+      interaction.compareDocumentPosition(promptBox) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
+
+    rerender(<FollowUpPromptBox {...props} />);
+
+    expect(screen.getByTestId("prompt-box")).toBe(promptBox);
+    expect(screen.getByLabelText("Follow-up prompt")).toBe(input);
+    expect(composerShell?.hidden).toBe(false);
+    expect(screen.queryByTestId("pending-interaction")).toBeNull();
+  });
+
   it.each([
     ["main-thread", true],
     ["side-chat", false],

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -253,6 +253,15 @@ export interface FollowUpPromptBoxProps {
   isPrimaryComposer?: boolean;
   /** Inline queue editors do not own a timeline scroll control. */
   showScrollToBottomButton?: boolean;
+  /**
+   * A pending interaction (permission request, user question) that takes the
+   * composer's place. The composer editor stays MOUNTED but hidden while this
+   * is set: the previous implementation swapped the whole composer out of the
+   * tree, so every approval tore down and rebuilt the TipTap editor and the
+   * composer's pickers, and the draft-restoring remount landed in the same
+   * task as the approval's timeline update. Rendered as the last stack item.
+   */
+  pendingInteraction?: ReactNode;
 }
 
 type FollowUpPromptBoxWithComposerProps = Omit<
@@ -323,8 +332,11 @@ function FollowUpPromptBoxWithComposer({
   focusEndKey,
   isPrimaryComposer = true,
   showScrollToBottomButton = true,
+  pendingInteraction = null,
 }: FollowUpPromptBoxWithComposerProps) {
   const submitMode = composer.submitMode;
+  const hasPendingInteraction =
+    pendingInteraction !== null && pendingInteraction !== undefined;
   const canQueueFollowUp = submitMode.kind === "queue";
   const canSubmit = submitMode.kind === "ready" || submitMode.kind === "queue";
   const isStopping =
@@ -594,7 +606,11 @@ function FollowUpPromptBoxWithComposer({
       ? composer.onSubmit
       : composer.onModifierSubmit
     : undefined;
-  const executionControlsDisabled = executionReadOnly ?? readOnly ?? false;
+  // While the interaction owns the surface the pickers are hidden with the
+  // editor; keep them disabled too so their keyboard chords (model picker
+  // toggle/cycle) cannot open a popover anchored to a hidden trigger.
+  const executionControlsDisabled =
+    (executionReadOnly ?? readOnly ?? false) || hasPendingInteraction;
   const footerStart = useMemo(
     () => (
       <ExecutionControls {...execution} disabled={executionControlsDisabled} />
@@ -618,7 +634,8 @@ function FollowUpPromptBoxWithComposer({
   const permissionPickerDisabledByPlanMode =
     shouldDisablePermissionPickerForActivePromptMode(activePromptMode) ||
     shouldDisablePermissionPickerForPromptMode(promptModeInput);
-  const permissionReadOnlyResolved = permissionReadOnly ?? readOnly ?? false;
+  const permissionReadOnlyResolved =
+    (permissionReadOnly ?? readOnly ?? false) || hasPendingInteraction;
   const permissionPickerDisabled =
     permissionReadOnlyResolved || permissionPickerDisabledByPlanMode;
   // Side chat and active plan mode render the same permission picker as the
@@ -698,6 +715,9 @@ function FollowUpPromptBoxWithComposer({
       className="relative z-20"
       data-follow-up-composer=""
       data-follow-up-composer-expanded={isInteractionExpanded ? "" : undefined}
+      // Hidden, not unmounted: the editor keeps its DOM, draft, and history
+      // across the interaction (see `pendingInteraction`).
+      hidden={hasPendingInteraction}
       onBlurCapture={scheduleCollapseAfterFocusLoss}
       onFocusCapture={handleComposerFocus}
     >
@@ -797,6 +817,7 @@ function FollowUpPromptBoxWithComposer({
           composerElement={composerElement}
           hasPluginComposerScope={composerScope !== null}
           isPrimaryComposer={isPrimaryComposer}
+          pendingInteraction={pendingInteraction}
           showScrollToBottomButton={showScrollToBottomButton}
           stack={stack}
           stackRef={stackRef}
@@ -811,6 +832,7 @@ interface DefaultFollowUpComposerProps {
   composerElement: ReactNode;
   hasPluginComposerScope: boolean;
   isPrimaryComposer: boolean;
+  pendingInteraction?: ReactNode;
   showScrollToBottomButton: boolean;
   stack: ReactNode | null;
   stackRef: RefObject<HTMLDivElement | null>;
@@ -822,6 +844,7 @@ export function DefaultFollowUpComposer({
   composerElement,
   hasPluginComposerScope,
   isPrimaryComposer,
+  pendingInteraction = null,
   showScrollToBottomButton,
   stack,
   stackRef,
@@ -843,6 +866,7 @@ export function DefaultFollowUpComposer({
           ) : (
             stack
           )}
+          {pendingInteraction}
         </div>
         <div data-follow-up-composer-anchor="">{composerElement}</div>
       </div>

--- a/apps/app/src/components/promptbox/NewThreadComposer.tsx
+++ b/apps/app/src/components/promptbox/NewThreadComposer.tsx
@@ -134,7 +134,6 @@ export interface NewThreadComposerState {
   isProjectless: boolean;
   projects: readonly SidebarProject[] | undefined;
   sidebarNavigation: SidebarBootstrapResponse | undefined;
-  sidebarNavigationSettled: boolean;
   sidebarNavigationError: boolean;
   currentProject: SidebarProject | undefined;
   projectSources: SidebarProject["sources"];
@@ -318,6 +317,12 @@ export function NewThreadComposer({
   const promptBoxRef = useRef<PromptBoxHandle>(null);
 
   const sidebarNavigationQuery = useSidebarNavigation();
+  // Until the sidebar bootstrap settles, `projectId` below is only the
+  // requested candidate: it may not exist and would then fall back to the
+  // personal project. Queries keyed by projectId wait for the settled value
+  // so a cold start does not fetch (and cache) data for the wrong project.
+  const sidebarNavigationSettled =
+    sidebarNavigationQuery.isSuccess || sidebarNavigationQuery.isError;
   const projects = useMemo(
     () => sidebarNavigationQuery.data?.projects.map(stripProjectThreads),
     [sidebarNavigationQuery.data],
@@ -384,8 +389,10 @@ export function NewThreadComposer({
     return navigation.projects.find((project) => project.id === projectId)
       ?.threads;
   }, [isProjectless, projectId, sidebarNavigationQuery.data]);
+  // While the bootstrap is still in flight the picker shows a loading label
+  // and no per-project request is issued (see B28).
   const reuseThreadOptionsLoading =
-    projectThreads === undefined && sidebarNavigationQuery.isLoading;
+    projectThreads === undefined && !sidebarNavigationSettled;
   const reuseThreadOptions = useMemo(
     () => buildReuseThreadOptions(projectThreads ?? [], worktreeHostNameById),
     [projectThreads, worktreeHostNameById],
@@ -913,7 +920,7 @@ export function NewThreadComposer({
   const promptHistoryEnabled = usePromptHistoryEnabled();
   const { data: projectPromptHistory = [] } = useProjectPromptHistory(
     projectId,
-    { enabled: promptHistoryEnabled },
+    { enabled: promptHistoryEnabled && sidebarNavigationSettled },
   );
   const promptHistoryDrafts = useMemo(
     () => promptHistoryEntriesToDrafts(projectPromptHistory),
@@ -1256,6 +1263,7 @@ export function NewThreadComposer({
             onChange: handleProjectChange,
             allowNoProject: options.allowNoProject,
             createProject: options.createProject,
+            isLoading: !sidebarNavigationSettled,
             disabled:
               locks.project ||
               isUploading ||
@@ -1358,6 +1366,7 @@ export function NewThreadComposer({
       selectedProviderId,
       serviceTier,
       serviceTierSupportByProvider,
+      sidebarNavigationSettled,
       supportsPermissionModeSelection,
       supportsServiceTier,
       textEffects,
@@ -1371,8 +1380,6 @@ export function NewThreadComposer({
     isProjectless,
     projects,
     sidebarNavigation: sidebarNavigationQuery.data,
-    sidebarNavigationSettled:
-      sidebarNavigationQuery.isSuccess || sidebarNavigationQuery.isError,
     sidebarNavigationError: sidebarNavigationQuery.isError,
     currentProject,
     projectSources,

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -145,6 +145,8 @@ export interface NewThreadProjectConfig {
   allowNoProject?: boolean;
   createProject?: ProjectSelectorCreateProjectConfig;
   disabled?: boolean;
+  /** The project list is still loading; the picker shows a loading label. */
+  isLoading?: boolean;
   /** Keep the chevron while `disabled`, for transient locks (submitting,
    * uploading) that must not change the trigger's width. */
   showChevronWhenDisabled?: boolean;
@@ -432,6 +434,7 @@ export const DefaultNewThreadComposer = memo(function DefaultNewThreadComposer({
               allowNoProject={project.allowNoProject ?? false}
               createProject={project.createProject}
               disabled={project.disabled}
+              isLoading={project.isLoading}
               showChevronWhenDisabled={project.showChevronWhenDisabled}
               className="shrink-0"
             />

--- a/apps/app/src/components/pull-request/PullRequestStatusPill.tsx
+++ b/apps/app/src/components/pull-request/PullRequestStatusPill.tsx
@@ -6,20 +6,19 @@ import type {
 import { Icon, type IconName } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
 
-const checksSuccessIcon =
-  "https://github.githubassets.com/favicons/favicon-success.png";
-const checksSuccessDarkIcon =
-  "https://github.githubassets.com/favicons/favicon-success-dark.png";
-const checksFailureIcon =
-  "https://github.githubassets.com/favicons/favicon-failure.png";
-const checksFailureDarkIcon =
-  "https://github.githubassets.com/favicons/favicon-failure-dark.png";
-const checksPendingIcon =
-  "https://github.githubassets.com/favicons/favicon-pending.png";
-const checksPendingDarkIcon =
-  "https://github.githubassets.com/favicons/favicon-pending-dark.png";
-
 export type GithubCheckStatus = "success" | "failure" | "pending";
+
+// The check glyph is the bundled GitHub mark with a small status dot in the
+// corner, drawn from theme tokens. It replaces the light + dark favicon PNGs
+// that were fetched from github.githubassets.com on every thread that has a
+// pull request: two cross-origin image requests per pill (and per row on the
+// sidebar/thread list), which on phones over a tunnel meant late-arriving,
+// layout-shifting icons and a third-party request on every cold start.
+const GITHUB_CHECK_STATUS_DOT_CLASS: Record<GithubCheckStatus, string> = {
+  success: "bg-success",
+  failure: "bg-destructive",
+  pending: "bg-attention",
+};
 
 const PR_STATUS_COLOR: Record<PullRequestState, { textClassName: string }> = {
   open: {
@@ -115,62 +114,24 @@ export function PullRequestGithubCheckIcon({
   className?: string;
 }) {
   const status = getPullRequestGithubCheckStatus(pullRequest);
-  const checkStatusClassName = "size-4 shrink-0";
-  switch (status) {
-    case "success":
-      return (
-        <>
-          <img
-            src={checksSuccessIcon}
-            alt=""
-            aria-hidden="true"
-            className={cn(checkStatusClassName, "dark:hidden", className)}
-          />
-          <img
-            src={checksSuccessDarkIcon}
-            alt=""
-            aria-hidden="true"
-            className={cn(checkStatusClassName, "hidden dark:block", className)}
-          />
-        </>
-      );
-    case "failure":
-      return (
-        <>
-          <img
-            src={checksFailureIcon}
-            alt=""
-            aria-hidden="true"
-            className={cn(checkStatusClassName, "dark:hidden", className)}
-          />
-          <img
-            src={checksFailureDarkIcon}
-            alt=""
-            aria-hidden="true"
-            className={cn(checkStatusClassName, "hidden dark:block", className)}
-          />
-        </>
-      );
-    case "pending":
-      return (
-        <>
-          <img
-            src={checksPendingIcon}
-            alt=""
-            aria-hidden="true"
-            className={cn(checkStatusClassName, "dark:hidden", className)}
-          />
-          <img
-            src={checksPendingDarkIcon}
-            alt=""
-            aria-hidden="true"
-            className={cn(checkStatusClassName, "hidden dark:block", className)}
-          />
-        </>
-      );
-    case null:
-      return null;
+  if (status === null) {
+    return null;
   }
+  return (
+    <span
+      data-pull-request-check-status={status}
+      aria-hidden="true"
+      className={cn("relative inline-flex size-4 shrink-0", className)}
+    >
+      <Icon name="Github" className="size-4 shrink-0" aria-hidden="true" />
+      <span
+        className={cn(
+          "absolute -right-px -bottom-px size-2 rounded-full ring-2 ring-background",
+          GITHUB_CHECK_STATUS_DOT_CLASS[status],
+        )}
+      />
+    </span>
+  );
 }
 
 export function PullRequestStatusPill({

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.test.ts
@@ -56,6 +56,7 @@ describe("secondary panel tab-strip edge fades", () => {
         ],
         onReorderTab: vi.fn(),
         usesDesktopChrome: false,
+        isPanelOpen: true,
       }),
     );
 

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.touch-sensor.test.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.touch-sensor.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  SecondaryPanelTabStrip,
+  type SecondaryPanelTabStripProps,
+} from "./SecondaryPanelTabStrip";
+
+function makeTabs(count: number): SecondaryPanelTabStripProps["fileTabs"] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `tab-${index}`,
+    filename: `file-${index}.ts`,
+    isActive: index === 0,
+    isPinned: false,
+    leadingVisual: null,
+    statusLabel: null,
+    onSelect: vi.fn(),
+    onClose: vi.fn(),
+  }));
+}
+
+function touchMoveCalls(spy: {
+  mock: { calls: readonly (readonly unknown[])[] };
+}) {
+  return spy.mock.calls.filter(([type]) => type === "touchmove");
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("SecondaryPanelTabStrip touch sensor scoping", () => {
+  it("installs dnd-kit's window touchmove listener only while the panel is open with tabs to reorder, and removes it on close", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    const baseProps: SecondaryPanelTabStripProps = {
+      fileTabs: makeTabs(2),
+      onReorderTab: vi.fn(),
+      usesDesktopChrome: false,
+      isPanelOpen: false,
+    };
+
+    // Mounted inside a closed (retained) panel: no scroll-blocking listener.
+    const { rerender } = render(<SecondaryPanelTabStrip {...baseProps} />);
+    expect(touchMoveCalls(addSpy)).toHaveLength(0);
+
+    // Opening the panel must actually run the sensor's setup. dnd-kit keys its
+    // setup effect on the sensor classes, so this only works when the sensor
+    // slot keeps its position and swaps class rather than disappearing.
+    rerender(<SecondaryPanelTabStrip {...baseProps} isPanelOpen />);
+    const installs = touchMoveCalls(addSpy);
+    expect(installs).toHaveLength(1);
+    expect(installs[0]?.[2]).toEqual({ capture: false, passive: false });
+
+    // Closing tears it down again instead of leaving it on every page.
+    rerender(<SecondaryPanelTabStrip {...baseProps} isPanelOpen={false} />);
+    expect(touchMoveCalls(removeSpy)).toHaveLength(1);
+    expect(touchMoveCalls(addSpy)).toHaveLength(1);
+
+    // A single tab has nothing to reorder even in an open panel.
+    rerender(
+      <SecondaryPanelTabStrip {...baseProps} fileTabs={makeTabs(1)} isPanelOpen />,
+    );
+    expect(touchMoveCalls(addSpy)).toHaveLength(1);
+  });
+});

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.touch-sensor.test.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.touch-sensor.test.tsx
@@ -61,7 +61,11 @@ describe("SecondaryPanelTabStrip touch sensor scoping", () => {
 
     // A single tab has nothing to reorder even in an open panel.
     rerender(
-      <SecondaryPanelTabStrip {...baseProps} fileTabs={makeTabs(1)} isPanelOpen />,
+      <SecondaryPanelTabStrip
+        {...baseProps}
+        fileTabs={makeTabs(1)}
+        isPanelOpen
+      />,
     );
     expect(touchMoveCalls(addSpy)).toHaveLength(1);
   });

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
@@ -77,6 +77,13 @@ export interface SecondaryPanelTabStripProps {
   fileTabs: SecondaryPanelFileTab[];
   onReorderTab: SecondaryPanelTabReorderHandler;
   usesDesktopChrome: boolean;
+  /**
+   * Whether the hosting panel is open. The strip stays mounted inside a closed
+   * (retained) panel; touch reorder is only wired while it is open so the
+   * dnd-kit touch sensor's scroll-blocking window listener does not exist on
+   * every page.
+   */
+  isPanelOpen: boolean;
   activeTreatment?: "fill" | "underline";
 }
 
@@ -101,6 +108,7 @@ export function SecondaryPanelTabStrip({
   fileTabs,
   onReorderTab,
   usesDesktopChrome,
+  isPanelOpen,
   activeTreatment = "fill",
 }: SecondaryPanelTabStripProps) {
   const stripRef = useRef<HTMLDivElement>(null);
@@ -126,14 +134,23 @@ export function SecondaryPanelTabStrip({
     clearDragClickSuppressionSoon,
     consumeDragClickSuppression,
   } = useDragClickSuppression();
+  const dragDisabled = fileTabs.length < 2;
+  const mouseSensor = useSensor(MouseSensor, {
+    activationConstraint: { distance: 4 },
+  });
+  const touchSensor = useSensor(TouchSensor, {
+    activationConstraint: { delay: 200, tolerance: 6 },
+  });
+  // dnd-kit's TouchSensor keeps a NON-passive window `touchmove` listener
+  // installed while any DndContext using it is mounted, which makes every
+  // scroll start on phones wait for the main thread. Only wire it while there
+  // is something to reorder in an open panel; `useSensors` drops null entries
+  // and DndContext re-runs sensor setup when the list changes.
   const sensors = useSensors(
-    useSensor(MouseSensor, { activationConstraint: { distance: 4 } }),
-    useSensor(TouchSensor, {
-      activationConstraint: { delay: 200, tolerance: 6 },
-    }),
+    mouseSensor,
+    isPanelOpen && !dragDisabled ? touchSensor : null,
   );
   const tabIds = useMemo(() => fileTabs.map((tab) => tab.id), [fileTabs]);
-  const dragDisabled = fileTabs.length < 2;
   const draggingTab =
     draggingTabId === null
       ? null

--- a/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
+++ b/apps/app/src/components/secondary-panel/SecondaryPanelTabStrip.tsx
@@ -58,6 +58,17 @@ const EDGE_EPSILON_PX = 1;
 
 export const SECONDARY_PANEL_TAB_STRIP_FADE_TONE: OverflowFadeTone = "sidebar";
 
+/**
+ * Stand-in for dnd-kit's TouchSensor while the panel is closed or has nothing
+ * to reorder: same activators (so the sensor slot keeps its shape) but no
+ * window `touchmove` listener from `setup`.
+ */
+class InertTouchSensor extends TouchSensor {
+  static override setup(): () => void {
+    return () => {};
+  }
+}
+
 interface TabStripOverflowState {
   /** The intrinsic tab row is wider than the whole strip. */
   hasOverflow: boolean;
@@ -138,18 +149,20 @@ export function SecondaryPanelTabStrip({
   const mouseSensor = useSensor(MouseSensor, {
     activationConstraint: { distance: 4 },
   });
-  const touchSensor = useSensor(TouchSensor, {
-    activationConstraint: { delay: 200, tolerance: 6 },
-  });
   // dnd-kit's TouchSensor keeps a NON-passive window `touchmove` listener
   // installed while any DndContext using it is mounted, which makes every
-  // scroll start on phones wait for the main thread. Only wire it while there
-  // is something to reorder in an open panel; `useSensors` drops null entries
-  // and DndContext re-runs sensor setup when the list changes.
-  const sensors = useSensors(
-    mouseSensor,
-    isPanelOpen && !dragDisabled ? touchSensor : null,
+  // scroll start on phones wait for the main thread. Only wire the real
+  // sensor while there is something to reorder in an open panel. The sensor
+  // list must keep a constant length: DndContext's setup effect uses the
+  // sensor classes as its dependency array, and React skips an effect whose
+  // dependency array merely changed size, so swapping the CLASS (rather than
+  // dropping the entry) is what makes the listener install on open and go
+  // away on close.
+  const touchSensor = useSensor(
+    isPanelOpen && !dragDisabled ? TouchSensor : InertTouchSensor,
+    { activationConstraint: { delay: 200, tolerance: 6 } },
   );
+  const sensors = useSensors(mouseSensor, touchSensor);
   const tabIds = useMemo(() => fileTabs.map((tab) => tab.id), [fileTabs]);
   const draggingTab =
     draggingTabId === null

--- a/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
@@ -82,11 +82,6 @@ import { useUrlAnchorClickHandler } from "@/lib/url-open-routing";
 // without bypassing the production rendering path.
 // ---------------------------------------------------------------------------
 
-const GITHUB_FAVICON_URL =
-  "https://github.githubassets.com/favicons/favicon.png";
-const GITHUB_DARK_FAVICON_URL =
-  "https://github.githubassets.com/favicons/favicon-dark.png";
-
 export interface ParentSelectorRowProps {
   thread: Thread;
   projectId: string;
@@ -504,20 +499,7 @@ export function PullRequestRow({ pullRequest }: PullRequestRowProps) {
         {showGithubCheckIcon ? (
           <PullRequestGithubCheckIcon pullRequest={pullRequest} />
         ) : (
-          <>
-            <img
-              src={GITHUB_FAVICON_URL}
-              alt=""
-              className="size-4 shrink-0 dark:hidden"
-              aria-hidden="true"
-            />
-            <img
-              src={GITHUB_DARK_FAVICON_URL}
-              alt=""
-              className="hidden size-4 shrink-0 dark:block"
-              aria-hidden="true"
-            />
-          </>
+          <Icon name="Github" className="size-4 shrink-0" aria-hidden="true" />
         )}
         <span className="shrink-0 text-muted-foreground">
           #{pullRequest.number}

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -761,6 +761,7 @@ export function ThreadSecondaryPanel({
                 fileTabs={visibleFileTabs}
                 onReorderTab={onFileTabReorder}
                 usesDesktopChrome={usesDesktopChrome}
+                isPanelOpen={isOpen}
                 activeTreatment="fill"
               />
             ) : null}

--- a/apps/app/src/components/settings/SettingsSidebar.tsx
+++ b/apps/app/src/components/settings/SettingsSidebar.tsx
@@ -21,6 +21,8 @@ interface SettingsSidebarProps {
   isResizing: boolean;
   showTopReserve: boolean;
   appRoutePath: string;
+  /** Render the body only, inside a compact drawer panel owned by the caller. */
+  mobileHosted?: boolean;
 }
 
 /** Focused Settings navigation using the shared section-sidebar shell. */
@@ -29,6 +31,7 @@ export function SettingsSidebar({
   isResizing,
   showTopReserve,
   appRoutePath,
+  mobileHosted,
 }: SettingsSidebarProps) {
   const {
     activePluginId,
@@ -44,6 +47,7 @@ export function SettingsSidebar({
       backLabel="Back to app"
       backTo={appRoutePath}
       isResizing={isResizing}
+      mobileHosted={mobileHosted}
       onResizeMouseDown={onResizeMouseDown}
       showTopReserve={showTopReserve}
       testIdPrefix="settings"

--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -227,20 +227,31 @@ export function AppSidebar({
   );
 
   // While hosted-and-hidden (a Settings/Tools body is showing in the drawer)
-  // this sidebar is not the visible one: leave the search shortcut unhandled
-  // rather than opening the drawer onto a hidden search field.
+  // this sidebar is not the visible one: leave its shortcuts unhandled, as
+  // they are on wide viewports where Settings/Tools replace the sidebar,
+  // rather than opening the drawer onto a hidden search field or clicking
+  // rows the user cannot see.
   const isHiddenHostedBody = mobileHosted?.hidden === true;
   useAppCommandHandler("thread.search", () => {
     if (isHiddenHostedBody) return false;
     threadSearch.onActivate();
     return true;
   });
+  const activateVisibleThreadShortcut = useCallback(
+    (index: number) =>
+      isHiddenHostedBody ? false : activateThreadShortcut(index),
+    [activateThreadShortcut, isHiddenHostedBody],
+  );
   useIndexedAppCommandHandlers(
     THREAD_JUMP_APP_COMMAND_IDS,
-    activateThreadShortcut,
+    activateVisibleThreadShortcut,
   );
-  useAppCommandHandler("thread.previous", () => activateAdjacentThread(-1));
-  useAppCommandHandler("thread.next", () => activateAdjacentThread(1));
+  useAppCommandHandler("thread.previous", () =>
+    isHiddenHostedBody ? false : activateAdjacentThread(-1),
+  );
+  useAppCommandHandler("thread.next", () =>
+    isHiddenHostedBody ? false : activateAdjacentThread(1),
+  );
 
   useEffect(() => {
     if (isAppCommandModifierHeld) {

--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -68,6 +68,13 @@ interface AppSidebarProps {
   showTopReserve: boolean;
   settingsRoutePath: string;
   toolsRoutePath?: string;
+  /**
+   * Compact drawer hosting. When set, the sidebar renders its body only,
+   * inside a persistent `<Sidebar>` panel owned by AppLayoutSidebar, and stays
+   * mounted (hidden) while a Settings/Tools body is showing, so returning to
+   * the app never remounts the thread list in the closed drawer.
+   */
+  mobileHosted?: { hidden: boolean };
 }
 
 export function AppSidebar({
@@ -76,6 +83,7 @@ export function AppSidebar({
   showTopReserve,
   settingsRoutePath,
   toolsRoutePath,
+  mobileHosted,
 }: AppSidebarProps) {
   const quickCreateProject = useQuickCreateProjectController();
   // The resolved replacement owns the sidebar's scrolling thread list. It never
@@ -218,7 +226,12 @@ export function AppSidebar({
     [activeThreadId, closeOnMobile, navigate],
   );
 
+  // While hosted-and-hidden (a Settings/Tools body is showing in the drawer)
+  // this sidebar is not the visible one: leave the search shortcut unhandled
+  // rather than opening the drawer onto a hidden search field.
+  const isHiddenHostedBody = mobileHosted?.hidden === true;
   useAppCommandHandler("thread.search", () => {
+    if (isHiddenHostedBody) return false;
     threadSearch.onActivate();
     return true;
   });
@@ -273,11 +286,10 @@ export function AppSidebar({
     />
   );
 
-  return (
-    <SidebarThreadShortcutKeysContext.Provider value={threadShortcutKeysById}>
-      <Sidebar ref={sidebarRef} onKeyDown={threadSearch.onKeyDown}>
-        {showTopReserve ? (
-          /* Top reserve that keeps the sidebar's content (New Thread / New
+  const body = (
+    <>
+      {showTopReserve ? (
+        /* Top reserve that keeps the sidebar's content (New Thread / New
              Projects) anchored below the title-bar chrome, mirroring
              the page-header height on the content side. The sidebar toggle is
              pinned at the app's top-left for every chrome (see AppLayout's
@@ -290,125 +302,144 @@ export function AppSidebar({
              of the pinned toggle/traffic lights on the left and the resize
              handle on the right; they opt out of the desktop drag region so
              clicks register. */
-          <div
-            data-testid="app-sidebar-top-reserve-row"
-            className={cn(
-              CHROME_ROW_CLASS,
-              "shrink-0 justify-end px-2",
-              usesDesktopChrome && MACOS_WINDOW_DRAG_CLASS,
-            )}
-          >
-            <SidebarHistoryNavigationControls
-              onNavigate={closeOnMobile}
-              className={cn(
-                "group-data-[collapsible=icon]:hidden",
-                usesDesktopChrome && MACOS_CHROME_CONTROL_NO_DRAG_CLASS,
-              )}
-            />
-          </div>
-        ) : null}
         <div
-          data-testid="app-sidebar-primary-actions"
-          className="shrink-0 px-2 py-2 group-data-[collapsible=icon]:hidden"
+          data-testid="app-sidebar-top-reserve-row"
+          className={cn(
+            CHROME_ROW_CLASS,
+            "shrink-0 justify-end px-2",
+            usesDesktopChrome && MACOS_WINDOW_DRAG_CLASS,
+          )}
         >
-          <ProjectListActionButtons
-            splitEnabled={threadSplitsEnabled}
-            newThreadSplit={newThreadSplit}
-            onNewChat={handleNewChat}
-            threadSearch={{
-              activeDescendantId: threadSearch.activeDescendantId,
-              inputRef: threadSearch.inputRef,
-              isActive: threadSearch.isActive,
-              onActivate: threadSearch.onActivate,
-              onClose: threadSearch.onClose,
-              onQueryChange: threadSearch.onQueryChange,
-              query: threadSearch.query,
-            }}
+          <SidebarHistoryNavigationControls
+            onNavigate={closeOnMobile}
+            className={cn(
+              "group-data-[collapsible=icon]:hidden",
+              usesDesktopChrome && MACOS_CHROME_CONTROL_NO_DRAG_CLASS,
+            )}
           />
         </div>
-        <PluginNavSidebarItems
-          onNavigate={closeOnMobile}
+      ) : null}
+      <div
+        data-testid="app-sidebar-primary-actions"
+        className="shrink-0 px-2 py-2 group-data-[collapsible=icon]:hidden"
+      >
+        <ProjectListActionButtons
           splitEnabled={threadSplitsEnabled}
-          toolsRoutePath={toolsRoutePath}
+          newThreadSplit={newThreadSplit}
+          onNewChat={handleNewChat}
+          threadSearch={{
+            activeDescendantId: threadSearch.activeDescendantId,
+            inputRef: threadSearch.inputRef,
+            isActive: threadSearch.isActive,
+            onActivate: threadSearch.onActivate,
+            onClose: threadSearch.onClose,
+            onQueryChange: threadSearch.onQueryChange,
+            query: threadSearch.query,
+          }}
         />
-        <SidebarContent>
-          <PluginThreadList
-            replacement={threadListReplacement}
-            original={originalThreadList}
-            searchQuery={threadSearch.query}
-            onNavigate={threadSearch.onExternalThreadOpen}
-          />
-        </SidebarContent>
-        <SidebarFooter className="relative">
-          <OverflowFade placement="above" tone="sidebar" size="sm" />
-          {/* The footer holds a variable number of plugin action buttons, so a
-           * narrowed sidebar plus several plugins can no longer fit the action
-           * row and the update chips on one line. `flex-wrap-reverse` plus the
-           * flexible spacer below handles both layouts without measuring:
-           * while everything fits, the spacer stretches and pushes the chips to
-           * the right of a single row; once it doesn't, the chips wrap onto
-           * their own line, which wrap-reverse renders above the actions, and
-           * they sit flush left because the spacer stays behind on the action
-           * line. */}
-          <SidebarMenu className="flex-row flex-wrap-reverse items-center gap-1">
-            <SidebarMenuItem className="min-w-0">
-              <SidebarMenuButton
-                asChild
-                aria-label={
-                  settingsShortcut
-                    ? `Settings (${settingsShortcut.label})`
-                    : "Settings"
-                }
-                aria-keyshortcuts={settingsShortcut?.ariaKeyshortcuts}
-                tooltip={{
-                  children: settingsShortcut
-                    ? `Settings (${settingsShortcut.label})`
-                    : "Settings",
-                  hidden: false,
-                  side: "top",
-                }}
-                className={SIDEBAR_FOOTER_ACTION_CLASS}
-              >
-                <Link to={settingsRoutePath} onClick={closeOnMobile}>
-                  <Icon name="Settings" />
-                  <span className="sr-only">Settings</span>
-                </Link>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-            <PluginSidebarFooterActions onNavigate={closeOnMobile} />
-            <SidebarMenuItem className="min-w-0">
-              <SidebarMenuButton
-                className={SIDEBAR_FOOTER_ACTION_CLASS}
-                tooltip={{
-                  children: "Report a bug",
-                  hidden: false,
-                  side: "top",
-                }}
-                aria-label="Report a bug"
-                onClick={() => {
-                  closeOnMobile();
-                  openUrlInExternalBrowser(BUG_REPORT_NEW_ISSUE_URL);
-                }}
-              >
-                <Icon name="Bug" />
-                <span className="sr-only">Report a bug</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-            <li aria-hidden="true" className="min-w-0 flex-1" />
-            <SidebarUpdatesBadge onNavigate={closeOnMobile} />
-          </SidebarMenu>
-        </SidebarFooter>
+      </div>
+      <PluginNavSidebarItems
+        onNavigate={closeOnMobile}
+        splitEnabled={threadSplitsEnabled}
+        toolsRoutePath={toolsRoutePath}
+      />
+      <SidebarContent>
+        <PluginThreadList
+          replacement={threadListReplacement}
+          original={originalThreadList}
+          searchQuery={threadSearch.query}
+          onNavigate={threadSearch.onExternalThreadOpen}
+        />
+      </SidebarContent>
+      <SidebarFooter className="relative">
+        <OverflowFade placement="above" tone="sidebar" size="sm" />
+        {/* The footer holds a variable number of plugin action buttons, so a
+         * narrowed sidebar plus several plugins can no longer fit the action
+         * row and the update chips on one line. `flex-wrap-reverse` plus the
+         * flexible spacer below handles both layouts without measuring:
+         * while everything fits, the spacer stretches and pushes the chips to
+         * the right of a single row; once it doesn't, the chips wrap onto
+         * their own line, which wrap-reverse renders above the actions, and
+         * they sit flush left because the spacer stays behind on the action
+         * line. */}
+        <SidebarMenu className="flex-row flex-wrap-reverse items-center gap-1">
+          <SidebarMenuItem className="min-w-0">
+            <SidebarMenuButton
+              asChild
+              aria-label={
+                settingsShortcut
+                  ? `Settings (${settingsShortcut.label})`
+                  : "Settings"
+              }
+              aria-keyshortcuts={settingsShortcut?.ariaKeyshortcuts}
+              tooltip={{
+                children: settingsShortcut
+                  ? `Settings (${settingsShortcut.label})`
+                  : "Settings",
+                hidden: false,
+                side: "top",
+              }}
+              className={SIDEBAR_FOOTER_ACTION_CLASS}
+            >
+              <Link to={settingsRoutePath} onClick={closeOnMobile}>
+                <Icon name="Settings" />
+                <span className="sr-only">Settings</span>
+              </Link>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <PluginSidebarFooterActions onNavigate={closeOnMobile} />
+          <SidebarMenuItem className="min-w-0">
+            <SidebarMenuButton
+              className={SIDEBAR_FOOTER_ACTION_CLASS}
+              tooltip={{
+                children: "Report a bug",
+                hidden: false,
+                side: "top",
+              }}
+              aria-label="Report a bug"
+              onClick={() => {
+                closeOnMobile();
+                openUrlInExternalBrowser(BUG_REPORT_NEW_ISSUE_URL);
+              }}
+            >
+              <Icon name="Bug" />
+              <span className="sr-only">Report a bug</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <li aria-hidden="true" className="min-w-0 flex-1" />
+          <SidebarUpdatesBadge onNavigate={closeOnMobile} />
+        </SidebarMenu>
+      </SidebarFooter>
+      <div
+        data-testid="app-sidebar-resize-handle"
+        className={cn(
+          "absolute -right-1.5 top-0 z-30 hidden h-full w-3 cursor-col-resize md:block",
+          "before:absolute before:inset-y-0 before:left-1/2 before:w-px before:-translate-x-1/2 before:bg-transparent before:transition-colors hover:before:bg-sidebar-border",
+          "group-data-[collapsible=icon]:hidden",
+          isResizing && "before:bg-sidebar-border",
+        )}
+        onMouseDown={onResizeMouseDown}
+      />
+    </>
+  );
+
+  return (
+    <SidebarThreadShortcutKeysContext.Provider value={threadShortcutKeysById}>
+      {mobileHosted ? (
         <div
-          data-testid="app-sidebar-resize-handle"
-          className={cn(
-            "absolute -right-1.5 top-0 z-30 hidden h-full w-3 cursor-col-resize md:block",
-            "before:absolute before:inset-y-0 before:left-1/2 before:w-px before:-translate-x-1/2 before:bg-transparent before:transition-colors hover:before:bg-sidebar-border",
-            "group-data-[collapsible=icon]:hidden",
-            isResizing && "before:bg-sidebar-border",
-          )}
-          onMouseDown={onResizeMouseDown}
-        />
-      </Sidebar>
+          ref={sidebarRef}
+          data-testid="app-sidebar-body"
+          hidden={mobileHosted.hidden}
+          className="flex min-h-0 flex-1 flex-col"
+          onKeyDown={threadSearch.onKeyDown}
+        >
+          {body}
+        </div>
+      ) : (
+        <Sidebar ref={sidebarRef} onKeyDown={threadSearch.onKeyDown}>
+          {body}
+        </Sidebar>
+      )}
     </SidebarThreadShortcutKeysContext.Provider>
   );
 }

--- a/apps/app/src/components/sidebar/SectionSidebar.tsx
+++ b/apps/app/src/components/sidebar/SectionSidebar.tsx
@@ -77,12 +77,20 @@ export function SectionSidebarLabel({ children }: { children: ReactNode }) {
   );
 }
 
-/** Shared shell for focused app sections such as Settings and Tools. */
+/**
+ * Shared shell for focused app sections such as Settings and Tools.
+ *
+ * `mobileHosted` renders the body without its own `<Sidebar>` shell: on
+ * compact viewports AppLayoutSidebar owns one persistent drawer panel and
+ * hosts this body inside it, so switching between the app sidebar and a
+ * section sidebar never remounts the panel or the app sidebar's thread list.
+ */
 export function SectionSidebar({
   backLabel,
   backTo,
   children,
   isResizing,
+  mobileHosted = false,
   onResizeMouseDown,
   showTopReserve,
   testIdPrefix,
@@ -91,6 +99,7 @@ export function SectionSidebar({
   backTo: string;
   children: ReactNode;
   isResizing: boolean;
+  mobileHosted?: boolean;
   onResizeMouseDown: (event: ReactMouseEvent<HTMLDivElement>) => void;
   showTopReserve: boolean;
   testIdPrefix: string;
@@ -99,8 +108,8 @@ export function SectionSidebar({
   const [desktopInfo] = useState(getBbDesktopInfo);
   const usesDesktopChrome = shouldUseMacosDesktopChrome(desktopInfo);
 
-  return (
-    <Sidebar>
+  const body = (
+    <>
       {showTopReserve ? (
         <div
           data-testid={`${testIdPrefix}-sidebar-top-reserve-row`}
@@ -141,6 +150,19 @@ export function SectionSidebar({
         )}
         onMouseDown={onResizeMouseDown}
       />
-    </Sidebar>
+    </>
   );
+
+  if (mobileHosted) {
+    return (
+      <div
+        data-testid={`${testIdPrefix}-sidebar-body`}
+        className="flex min-h-0 flex-1 flex-col"
+      >
+        {body}
+      </div>
+    );
+  }
+
+  return <Sidebar>{body}</Sidebar>;
 }

--- a/apps/app/src/components/sidebar/useSidebarReorderDnd.test.tsx
+++ b/apps/app/src/components/sidebar/useSidebarReorderDnd.test.tsx
@@ -7,7 +7,12 @@ import type {
   DragStartEvent,
 } from "@dnd-kit/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useSidebarReorderDnd } from "./useSidebarReorderDnd";
+import { COMPACT_VIEWPORT_QUERY } from "@bb/shared-ui/hooks/use-compact-viewport";
+import { setCompactSidebarDrawerShowing } from "@/components/ui/sidebar-mobile-drawer-visibility";
+import {
+  SidebarTouchSensor,
+  useSidebarReorderDnd,
+} from "./useSidebarReorderDnd";
 
 const DRAG_START_EVENT = { active: { id: "thread-1" } } as DragStartEvent;
 const DRAG_END_EVENT = {
@@ -68,5 +73,71 @@ describe("useSidebarReorderDnd", () => {
     // A late public callback from dnd-kit must not run owner cleanup twice.
     act(() => result.current.dndContextProps.onDragCancel?.(DRAG_CANCEL_EVENT));
     expect(onDragCancel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("SidebarTouchSensor", () => {
+  function installMatchMedia(matches: boolean) {
+    const listeners = new Set<() => void>();
+    const mql = {
+      matches,
+      media: COMPACT_VIEWPORT_QUERY,
+      addEventListener: (_type: string, listener: () => void) => {
+        listeners.add(listener);
+      },
+      removeEventListener: (_type: string, listener: () => void) => {
+        listeners.delete(listener);
+      },
+    };
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn(() => mql),
+    );
+    return mql;
+  }
+
+  function touchMoveListenerCalls(spy: {
+    mock: { calls: readonly (readonly unknown[])[] };
+  }) {
+    return spy.mock.calls.filter(([type]) => type === "touchmove");
+  }
+
+  afterEach(() => {
+    setCompactSidebarDrawerShowing(false);
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the non-passive window touchmove listener off on compact viewports until the drawer shows", () => {
+    installMatchMedia(true);
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+
+    const teardown = SidebarTouchSensor.setup();
+    // Sidebar mounted at boot inside its closed drawer: no listener yet.
+    expect(touchMoveListenerCalls(addSpy)).toHaveLength(0);
+
+    act(() => setCompactSidebarDrawerShowing(true));
+    const installs = touchMoveListenerCalls(addSpy);
+    expect(installs).toHaveLength(1);
+    expect(installs[0]?.[2]).toEqual({ capture: false, passive: false });
+
+    act(() => setCompactSidebarDrawerShowing(false));
+    expect(touchMoveListenerCalls(removeSpy)).toHaveLength(1);
+
+    teardown();
+    expect(touchMoveListenerCalls(addSpy)).toHaveLength(1);
+  });
+
+  it("installs the listener immediately on wide viewports and removes it on teardown", () => {
+    installMatchMedia(false);
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+
+    const teardown = SidebarTouchSensor.setup();
+    expect(touchMoveListenerCalls(addSpy)).toHaveLength(1);
+
+    teardown();
+    expect(touchMoveListenerCalls(removeSpy)).toHaveLength(1);
   });
 });

--- a/apps/app/src/components/sidebar/useSidebarReorderDnd.ts
+++ b/apps/app/src/components/sidebar/useSidebarReorderDnd.ts
@@ -21,6 +21,15 @@ import {
   type Modifier,
 } from "@dnd-kit/core";
 import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
+import { COMPACT_VIEWPORT_QUERY } from "@bb/shared-ui/hooks/use-compact-viewport";
+import {
+  getMediaQuerySnapshot,
+  subscribeMediaQuery,
+} from "@bb/shared-ui/hooks/use-media-query";
+import {
+  isCompactSidebarDrawerShowing,
+  subscribeCompactSidebarDrawerShowing,
+} from "@/components/ui/sidebar-mobile-drawer-visibility.js";
 import {
   useDragClickSuppression,
   type ConsumeDragClickSuppression,
@@ -98,6 +107,66 @@ interface UseSidebarReorderDndResult {
   onClickCapture: MouseEventHandler<HTMLElement>;
 }
 
+function shouldInstallSidebarTouchMoveListener(): boolean {
+  return (
+    !getMediaQuerySnapshot(COMPACT_VIEWPORT_QUERY) ||
+    isCompactSidebarDrawerShowing()
+  );
+}
+
+/**
+ * dnd-kit's `TouchSensor` with drawer-aware setup.
+ *
+ * `TouchSensor.setup()` registers a permanent NON-passive window `touchmove`
+ * no-op for as long as any `DndContext` using it is mounted; dnd-kit needs it
+ * so a `preventDefault` from a listener added mid-gesture still works on iOS
+ * Safari. The compact sidebar is mounted at boot inside its closed drawer, so
+ * on phones that listener used to exist on every page, and iOS Safari and
+ * Chrome Android then dispatched the first `touchmove` of EVERY scroll gesture
+ * synchronously through the main thread before compositor scrolling could
+ * start. This subclass installs the same listener only while the compact
+ * drawer is showing (touch reorder keeps working there) and always on wide
+ * layouts. It tracks the drawer through a tiny external store instead of the
+ * sidebar context, so no memoized row re-renders on drawer toggles.
+ */
+export class SidebarTouchSensor extends TouchSensor {
+  static override setup(): () => void {
+    if (typeof window === "undefined") {
+      return () => {};
+    }
+    const noop = () => {};
+    let installed = false;
+    const sync = () => {
+      const wanted = shouldInstallSidebarTouchMoveListener();
+      if (wanted && !installed) {
+        // Non-passive and non-capturing, exactly as dnd-kit installs it.
+        window.addEventListener("touchmove", noop, {
+          capture: false,
+          passive: false,
+        });
+        installed = true;
+      } else if (!wanted && installed) {
+        window.removeEventListener("touchmove", noop);
+        installed = false;
+      }
+    };
+    sync();
+    const unsubscribeDrawer = subscribeCompactSidebarDrawerShowing(sync);
+    const unsubscribeViewport = subscribeMediaQuery(
+      COMPACT_VIEWPORT_QUERY,
+      sync,
+    );
+    return () => {
+      unsubscribeDrawer();
+      unsubscribeViewport();
+      if (installed) {
+        window.removeEventListener("touchmove", noop);
+        installed = false;
+      }
+    };
+  }
+}
+
 /**
  * Container-side reorder plumbing shared by every sortable sidebar surface
  * (sections, projects, pinned roots, parent-thread roots): the activation-tuned
@@ -119,7 +188,7 @@ export function useSidebarReorderDnd({
   const isDraggingRef = useRef(false);
   const sensors = useSensors(
     useSensor(MouseSensor, { activationConstraint: { distance: 4 } }),
-    useSensor(TouchSensor, {
+    useSensor(SidebarTouchSensor, {
       activationConstraint: { delay: 200, tolerance: 6 },
     }),
     useSensor(KeyboardSensor, {

--- a/apps/app/src/components/thread/ThreadActionsMenu.tsx
+++ b/apps/app/src/components/thread/ThreadActionsMenu.tsx
@@ -19,6 +19,7 @@ import { Button } from "@bb/shared-ui/button";
 import { COARSE_POINTER_ICON_SIZE_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { cn } from "@bb/shared-ui/lib/utils";
+import { CompactLongPressMenu } from "@/components/ui/compact-long-press-menu";
 import { isThreadRead } from "@/lib/thread-read-state";
 import { useThreadActions } from "./ThreadActionsProvider";
 
@@ -295,7 +296,47 @@ export function ThreadActionsMenu({
   );
 }
 
-export function ThreadActionsContextMenu({
+/**
+ * Row-level actions menu: a right-click context menu on wide viewports, and on
+ * compact viewports a touch long-press (or right-click) that opens the same
+ * items in the persistent responsive drawer. The compact path deliberately
+ * avoids the modal Radix `ContextMenu` (aria-hidden on the app root, scroll
+ * lock, document-wide pointer-events flip) on phones.
+ */
+export function ThreadActionsContextMenu(props: ThreadActionsContextMenuProps) {
+  const isCompactViewport = useIsCompactViewport();
+  if (isCompactViewport) {
+    return <ThreadActionsCompactLongPressMenu {...props} />;
+  }
+  return <ThreadActionsDesktopContextMenu {...props} />;
+}
+
+function ThreadActionsCompactLongPressMenu({
+  children,
+  thread,
+  canDelete = true,
+  onOpenInSplit,
+  onOpenChange,
+}: ThreadActionsContextMenuProps) {
+  return (
+    <CompactLongPressMenu
+      label="Thread actions"
+      onOpenChange={onOpenChange}
+      items={
+        <ThreadActionsMenuItems
+          thread={thread}
+          canDelete={canDelete}
+          onOpenInSplit={onOpenInSplit}
+          surface="dropdown"
+        />
+      }
+    >
+      {children}
+    </CompactLongPressMenu>
+  );
+}
+
+function ThreadActionsDesktopContextMenu({
   children,
   thread,
   canDelete = true,

--- a/apps/app/src/components/tools/ToolsSidebar.tsx
+++ b/apps/app/src/components/tools/ToolsSidebar.tsx
@@ -24,11 +24,14 @@ import {
 export function ToolsSidebar({
   appRoutePath,
   isResizing,
+  mobileHosted,
   onResizeMouseDown,
   showTopReserve,
 }: {
   appRoutePath: string;
   isResizing: boolean;
+  /** Render the body only, inside a compact drawer panel owned by the caller. */
+  mobileHosted?: boolean;
   onResizeMouseDown: (event: ReactMouseEvent<HTMLDivElement>) => void;
   showTopReserve: boolean;
 }) {
@@ -40,6 +43,7 @@ export function ToolsSidebar({
       backLabel="Back to app"
       backTo={appRoutePath}
       isResizing={isResizing}
+      mobileHosted={mobileHosted}
       onResizeMouseDown={onResizeMouseDown}
       showTopReserve={showTopReserve}
       testIdPrefix="tools"

--- a/apps/app/src/components/ui/compact-long-press-menu.test.tsx
+++ b/apps/app/src/components/ui/compact-long-press-menu.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
+import { DropdownMenuItem } from "@bb/shared-ui/dropdown-menu";
+import { CompactLongPressMenu } from "./compact-long-press-menu";
+
+const LONG_PRESS_MS = 700;
+
+function renderRow({
+  onRowClick = vi.fn(),
+  onOpenChange = vi.fn(),
+  onRename = vi.fn(),
+}: {
+  onRowClick?: () => void;
+  onOpenChange?: (open: boolean) => void;
+  onRename?: () => void;
+} = {}) {
+  const root = document.createElement("div");
+  root.id = "root";
+  document.body.appendChild(root);
+  const utils = render(
+    <CompactViewportOverrideProvider isCompactViewport>
+      <CompactLongPressMenu
+        label="Thread actions"
+        onOpenChange={onOpenChange}
+        items={<DropdownMenuItem onSelect={onRename}>Rename</DropdownMenuItem>}
+      >
+        <a href="#thread" onClick={onRowClick} data-testid="row">
+          Thread row
+        </a>
+      </CompactLongPressMenu>
+    </CompactViewportOverrideProvider>,
+    { container: root },
+  );
+  return {
+    ...utils,
+    row: screen.getByTestId("row"),
+    onRowClick,
+    onOpenChange,
+    onRename,
+  };
+}
+
+function touchPointerDown(target: Element, x = 100, y = 100) {
+  fireEvent.pointerDown(target, {
+    pointerId: 1,
+    pointerType: "touch",
+    isPrimary: true,
+    clientX: x,
+    clientY: y,
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  document.getElementById("root")?.remove();
+  vi.useRealTimers();
+});
+
+describe("CompactLongPressMenu", () => {
+  it("mounts nothing for the menu until a long press, then opens the drawer without a modal takeover", () => {
+    vi.useFakeTimers();
+    const { row, onOpenChange } = renderRow();
+
+    // A row costs pointer handlers only: no menu, dialog, or drawer DOM.
+    expect(screen.queryByRole("menuitem")).toBeNull();
+    expect(document.querySelector("[role='dialog']")).toBeNull();
+
+    touchPointerDown(row);
+    act(() => {
+      vi.advanceTimersByTime(LONG_PRESS_MS - 1);
+    });
+    expect(onOpenChange).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+
+    // Drawer content realizes after the shell's frame/timeout fallback.
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(screen.getByRole("menuitem", { name: "Rename" })).toBeTruthy();
+
+    // The persistent drawer never marks the app root inert/hidden or flips
+    // document-wide pointer events (what the modal Radix ContextMenu did).
+    const root = document.getElementById("root");
+    expect(root?.getAttribute("aria-hidden")).toBeNull();
+    expect(root?.hasAttribute("inert")).toBe(false);
+    expect(document.body.style.pointerEvents).toBe("");
+  });
+
+  it("swallows the click that follows a long press so the row does not navigate", () => {
+    vi.useFakeTimers();
+    const { row, onRowClick } = renderRow();
+
+    touchPointerDown(row);
+    act(() => {
+      vi.advanceTimersByTime(LONG_PRESS_MS);
+    });
+    fireEvent.pointerUp(row, { pointerId: 1, pointerType: "touch" });
+    fireEvent.click(row);
+    expect(onRowClick).not.toHaveBeenCalled();
+
+    // A later, ordinary tap still navigates.
+    fireEvent.click(row);
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels the press when the finger moves or lifts early, and ignores mouse pointers", () => {
+    vi.useFakeTimers();
+    const { row, onOpenChange, onRowClick } = renderRow();
+
+    touchPointerDown(row, 100, 100);
+    fireEvent.pointerMove(row, {
+      pointerId: 1,
+      pointerType: "touch",
+      clientX: 100,
+      clientY: 130,
+    });
+    act(() => {
+      vi.advanceTimersByTime(LONG_PRESS_MS);
+    });
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    touchPointerDown(row, 100, 100);
+    fireEvent.pointerUp(row, { pointerId: 1, pointerType: "touch" });
+    act(() => {
+      vi.advanceTimersByTime(LONG_PRESS_MS);
+    });
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    fireEvent.pointerDown(row, {
+      pointerId: 2,
+      pointerType: "mouse",
+      isPrimary: true,
+      button: 0,
+    });
+    act(() => {
+      vi.advanceTimersByTime(LONG_PRESS_MS);
+    });
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    // A plain tap still reaches the row.
+    fireEvent.click(row);
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens from a right-click on a narrow window without the native menu", () => {
+    const { row, onOpenChange } = renderRow();
+    const event = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+    });
+    fireEvent(row, event);
+    expect(event.defaultPrevented).toBe(true);
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/apps/app/src/components/ui/compact-long-press-menu.test.tsx
+++ b/apps/app/src/components/ui/compact-long-press-menu.test.tsx
@@ -154,6 +154,57 @@ describe("CompactLongPressMenu", () => {
     expect(onRowClick).toHaveBeenCalledTimes(1);
   });
 
+  it("lets only the innermost menu open when menus nest (thread row inside a project section)", () => {
+    vi.useFakeTimers();
+    const onProjectOpenChange = vi.fn();
+    const onThreadOpenChange = vi.fn();
+    render(
+      <CompactViewportOverrideProvider isCompactViewport>
+        <CompactLongPressMenu
+          label="Project actions"
+          onOpenChange={onProjectOpenChange}
+          items={<DropdownMenuItem>Rename project</DropdownMenuItem>}
+        >
+          <div data-testid="project-section">
+            <span>Project</span>
+            <CompactLongPressMenu
+              label="Thread actions"
+              onOpenChange={onThreadOpenChange}
+              items={<DropdownMenuItem>Rename thread</DropdownMenuItem>}
+            >
+              <a href="#thread" data-testid="row">
+                Thread row
+              </a>
+            </CompactLongPressMenu>
+          </div>
+        </CompactLongPressMenu>
+      </CompactViewportOverrideProvider>,
+    );
+    const row = screen.getByTestId("row");
+
+    // Touch long press on the row: the bubbling pointerdown must not start
+    // the project section's timer as well.
+    touchPointerDown(row);
+    act(() => {
+      vi.advanceTimersByTime(LONG_PRESS_MS);
+    });
+    expect(onThreadOpenChange).toHaveBeenCalledWith(true);
+    expect(onProjectOpenChange).not.toHaveBeenCalled();
+
+    // Right-click on the row: same, through defaultPrevented.
+    onThreadOpenChange.mockClear();
+    fireEvent.contextMenu(row);
+    expect(onThreadOpenChange).toHaveBeenCalledWith(true);
+    expect(onProjectOpenChange).not.toHaveBeenCalled();
+
+    // A press on the section itself (outside any row) still opens its menu.
+    touchPointerDown(screen.getByText("Project"));
+    act(() => {
+      vi.advanceTimersByTime(LONG_PRESS_MS);
+    });
+    expect(onProjectOpenChange).toHaveBeenCalledWith(true);
+  });
+
   it("opens from a right-click on a narrow window without the native menu", () => {
     const { row, onOpenChange } = renderRow();
     const event = new MouseEvent("contextmenu", {

--- a/apps/app/src/components/ui/compact-long-press-menu.tsx
+++ b/apps/app/src/components/ui/compact-long-press-menu.tsx
@@ -1,0 +1,186 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { DropdownMenu, DropdownMenuContent } from "@bb/shared-ui/dropdown-menu";
+
+// Matches Radix ContextMenu's touch long-press delay so the gesture feels the
+// same as before; the slop lets a finger settle without cancelling.
+const LONG_PRESS_MS = 700;
+const LONG_PRESS_MOVE_SLOP_PX = 10;
+// A long press that opens the menu ends with the finger lifting, and the
+// browser may still synthesize a click on the row underneath. Swallow that
+// click for a short window so the row does not also navigate.
+const POST_LONG_PRESS_CLICK_SUPPRESSION_MS = 1000;
+
+const LONG_PRESS_TARGET_STYLE: CSSProperties = {
+  // Stop iOS from showing its own link callout for the long press.
+  WebkitTouchCallout: "none",
+};
+
+interface CompactLongPressMenuProps {
+  /** The single element that receives the long-press gesture (a row). */
+  children: ReactNode;
+  /** Menu items rendered inside the compact drawer; mounted on first open. */
+  items: ReactNode;
+  /** Screen-reader label for the drawer surface. */
+  label: string;
+  onOpenChange?: (open: boolean) => void;
+}
+
+/**
+ * Compact-viewport replacement for a row's right-click `ContextMenu`.
+ *
+ * On phones the sidebar rows previously mounted a Radix `ContextMenu` root per
+ * row, whose long-press opened a MODAL Radix menu: `hideOthers` set
+ * `aria-hidden` on `#root`, RemoveScroll registered a non-passive `touchmove`,
+ * and `body.style.pointerEvents = "none"` invalidated the whole document with
+ * the full timeline mounted behind the drawer. This component keeps the same
+ * gesture (700 ms touch long-press, or right-click on a narrow desktop window)
+ * but opens the app's persistent responsive drawer instead, through the same
+ * `DropdownMenu` items the row's "..." button uses. Nothing is mounted for the
+ * menu until the first open, so a hundred rows cost a few pointer handlers.
+ */
+export function CompactLongPressMenu({
+  children,
+  items,
+  label,
+  onOpenChange,
+}: CompactLongPressMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [hasOpened, setHasOpened] = useState(false);
+  const timerRef = useRef<number | null>(null);
+  const pressRef = useRef<{ pointerId: number; x: number; y: number } | null>(
+    null,
+  );
+  const suppressClickUntilRef = useRef(0);
+
+  const clearPress = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    pressRef.current = null;
+  }, []);
+
+  useEffect(() => clearPress, [clearPress]);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen);
+      onOpenChange?.(nextOpen);
+    },
+    [onOpenChange],
+  );
+
+  const openMenu = useCallback(() => {
+    clearPress();
+    setHasOpened(true);
+    handleOpenChange(true);
+  }, [clearPress, handleOpenChange]);
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      if (event.pointerType !== "touch" && event.pointerType !== "pen") {
+        return;
+      }
+      if (!event.isPrimary) {
+        return;
+      }
+      clearPress();
+      pressRef.current = {
+        pointerId: event.pointerId,
+        x: event.clientX,
+        y: event.clientY,
+      };
+      timerRef.current = window.setTimeout(() => {
+        timerRef.current = null;
+        if (pressRef.current === null) {
+          return;
+        }
+        pressRef.current = null;
+        suppressClickUntilRef.current =
+          Date.now() + POST_LONG_PRESS_CLICK_SUPPRESSION_MS;
+        openMenu();
+      }, LONG_PRESS_MS);
+    },
+    [clearPress, openMenu],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      const press = pressRef.current;
+      if (press === null || press.pointerId !== event.pointerId) {
+        return;
+      }
+      if (
+        Math.abs(event.clientX - press.x) > LONG_PRESS_MOVE_SLOP_PX ||
+        Math.abs(event.clientY - press.y) > LONG_PRESS_MOVE_SLOP_PX
+      ) {
+        clearPress();
+      }
+    },
+    [clearPress],
+  );
+
+  const handlePointerEnd = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      if (pressRef.current?.pointerId === event.pointerId) {
+        clearPress();
+      }
+    },
+    [clearPress],
+  );
+
+  const handleContextMenu = useCallback(
+    (event: ReactMouseEvent<HTMLElement>) => {
+      // Right-click (or a browser-synthesized contextmenu after a long
+      // press) opens the same drawer and must not show the native menu.
+      event.preventDefault();
+      openMenu();
+    },
+    [openMenu],
+  );
+
+  const handleClickCapture = useCallback(
+    (event: ReactMouseEvent<HTMLElement>) => {
+      if (Date.now() >= suppressClickUntilRef.current) {
+        return;
+      }
+      suppressClickUntilRef.current = 0;
+      event.preventDefault();
+      event.stopPropagation();
+    },
+    [],
+  );
+
+  return (
+    <>
+      <Slot
+        style={LONG_PRESS_TARGET_STYLE}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerEnd}
+        onPointerCancel={handlePointerEnd}
+        onContextMenu={handleContextMenu}
+        onClickCapture={handleClickCapture}
+      >
+        {children}
+      </Slot>
+      {hasOpened ? (
+        <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+          <DropdownMenuContent mobileTitle={label} aria-label={label}>
+            {items}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : null}
+    </>
+  );
+}

--- a/apps/app/src/components/ui/compact-long-press-menu.tsx
+++ b/apps/app/src/components/ui/compact-long-press-menu.tsx
@@ -25,6 +25,12 @@ const LONG_PRESS_TARGET_STYLE: CSSProperties = {
   WebkitTouchCallout: "none",
 };
 
+// These menus nest (a project section wraps its thread rows), and pointer
+// events bubble from the row to the section. The innermost menu handles the
+// press first and claims the native event here so an enclosing menu does not
+// start its own timer and open a second drawer 700 ms later.
+const claimedPressEvents = new WeakSet<Event>();
+
 interface CompactLongPressMenuProps {
   /** The single element that receives the long-press gesture (a row). */
   children: ReactNode;
@@ -94,6 +100,10 @@ export function CompactLongPressMenu({
       if (!event.isPrimary) {
         return;
       }
+      if (claimedPressEvents.has(event.nativeEvent)) {
+        return;
+      }
+      claimedPressEvents.add(event.nativeEvent);
       clearPress();
       pressRef.current = {
         pointerId: event.pointerId,
@@ -141,9 +151,20 @@ export function CompactLongPressMenu({
 
   const handleContextMenu = useCallback(
     (event: ReactMouseEvent<HTMLElement>) => {
+      // An enclosed menu (or another handler) already took this one; the same
+      // rule Radix's ContextMenuTrigger applies through defaultPrevented.
+      if (event.defaultPrevented) {
+        return;
+      }
       // Right-click (or a browser-synthesized contextmenu after a long
       // press) opens the same drawer and must not show the native menu.
       event.preventDefault();
+      if (pressRef.current !== null) {
+        // Chrome Android fires contextmenu from the long press before our own
+        // timer; the lift that follows must not also activate the row.
+        suppressClickUntilRef.current =
+          Date.now() + POST_LONG_PRESS_CLICK_SUPPRESSION_MS;
+      }
       openMenu();
     },
     [openMenu],

--- a/apps/app/src/components/ui/sidebar-mobile-drawer-visibility.ts
+++ b/apps/app/src/components/ui/sidebar-mobile-drawer-visibility.ts
@@ -1,0 +1,34 @@
+/**
+ * Tiny external store for "is the compact sidebar drawer showing right now".
+ *
+ * `SidebarProvider` writes it; non-React consumers that must not subscribe to
+ * the whole `SidebarContext` (which would re-render every memoized sidebar row
+ * on each drawer toggle) read and subscribe here instead. Today the reader is
+ * the sidebar dnd touch sensor, which keeps its scroll-blocking window
+ * `touchmove` listener installed only while the drawer is open.
+ */
+let compactSidebarDrawerShowing = false;
+const listeners = new Set<() => void>();
+
+export function isCompactSidebarDrawerShowing(): boolean {
+  return compactSidebarDrawerShowing;
+}
+
+export function setCompactSidebarDrawerShowing(showing: boolean): void {
+  if (compactSidebarDrawerShowing === showing) {
+    return;
+  }
+  compactSidebarDrawerShowing = showing;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function subscribeCompactSidebarDrawerShowing(
+  listener: () => void,
+): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/apps/app/src/components/ui/sidebar.test.tsx
+++ b/apps/app/src/components/ui/sidebar.test.tsx
@@ -571,6 +571,60 @@ describe("mobile sidebar persistence", () => {
   });
 });
 
+describe("mobile sidebar swipe-open touch listener scoping", () => {
+  function touchMoveRegistrations(spy: {
+    mock: { calls: readonly (readonly unknown[])[] };
+  }) {
+    return spy.mock.calls.filter(([type]) => type === "touchmove");
+  }
+
+  it("registers a passive touchmove for touches that start deep in the content", () => {
+    renderSelectableSwipeHarness();
+    const prose = screen.getByText("Selectable message prose");
+    const addSpy = vi.spyOn(window, "addEventListener");
+
+    // Deeper than the edge zone: this is a scroll far more often than a
+    // swipe, so it must never make the browser wait on the main thread.
+    fireTouch(prose, "touchstart", createTouch(120, 160));
+
+    const registrations = touchMoveRegistrations(addSpy);
+    expect(registrations).toHaveLength(1);
+    expect(registrations[0]?.[2]).toEqual({ passive: true });
+
+    // The passive session still recognizes and completes the swipe.
+    const move = new Event("touchmove", { bubbles: true, cancelable: true });
+    Object.defineProperties(move, {
+      touches: { value: createTouchList(createTouch(260, 164)) },
+      changedTouches: { value: createTouchList(createTouch(260, 164)) },
+    });
+    fireEvent(window, move);
+    expect(getMobilePanel()?.dataset.state).toBe("open");
+    // ... without calling preventDefault from the passive listener.
+    expect(move.defaultPrevented).toBe(false);
+  });
+
+  it("keeps the non-passive touchmove for edge-zone touches so the swipe can claim the gesture", () => {
+    renderSelectableSwipeHarness();
+    const prose = screen.getByText("Selectable message prose");
+    const addSpy = vi.spyOn(window, "addEventListener");
+
+    fireTouch(prose, "touchstart", createTouch(40, 160));
+
+    const registrations = touchMoveRegistrations(addSpy);
+    expect(registrations).toHaveLength(1);
+    expect(registrations[0]?.[2]).toEqual({ passive: false });
+
+    const move = new Event("touchmove", { bubbles: true, cancelable: true });
+    Object.defineProperties(move, {
+      touches: { value: createTouchList(createTouch(180, 164)) },
+      changedTouches: { value: createTouchList(createTouch(180, 164)) },
+    });
+    fireEvent(window, move);
+    expect(getMobilePanel()?.dataset.state).toBe("open");
+    expect(move.defaultPrevented).toBe(true);
+  });
+});
+
 describe("mobile sidebar text-selection arbitration", () => {
   it("opens from a right swipe that starts over selectable message prose", () => {
     renderSelectableSwipeHarness();

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -15,11 +15,17 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@bb/shared-ui/tooltip";
+import { setCompactSidebarDrawerShowing } from "./sidebar-mobile-drawer-visibility.js";
 
 const SIDEBAR_WIDTH = "16rem";
 const SIDEBAR_WIDTH_MOBILE = "min(90vw, 320px)";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_MOBILE_SWIPE_BROWSER_EDGE_GUARD_PX = 24;
+// Touches that start inside this band from the left edge get the scroll-
+// blocking (non-passive) touch path so a horizontal swipe can claim the
+// gesture from the browser; touches deeper in the content still open the
+// drawer, but through a passive listener that never delays a scroll start.
+const SIDEBAR_MOBILE_SWIPE_OPEN_EDGE_ZONE_PX = 72;
 const SIDEBAR_MOBILE_SWIPE_OPEN_INTENT_PX = 12;
 const SIDEBAR_MOBILE_SWIPE_OPEN_RATIO = 0.33;
 const SIDEBAR_MOBILE_SWIPE_OPEN_FLING_MIN_RATIO = 0.12;
@@ -72,6 +78,13 @@ type SidebarInsetSwipeSession = {
   isDragging: boolean;
   selectionRoot: Element | null;
   startTarget: Element | null;
+  /**
+   * Whether the move listener for this session was registered non-passive,
+   * so `preventDefault` can stop the browser from scrolling once the swipe
+   * has horizontal intent. Passive sessions must not call it (the browser
+   * ignores it and Chrome logs an intervention warning).
+   */
+  canPreventDefault: boolean;
 };
 
 const sidebarMobileWidthStyle: SidebarMobileWidthStyle = {
@@ -179,6 +192,7 @@ function createSidebarInsetSwipeSession({
   startY,
   selectionRoot,
   startTarget,
+  canPreventDefault,
 }: {
   kind: "pointer" | "touch";
   id: number;
@@ -186,6 +200,7 @@ function createSidebarInsetSwipeSession({
   startY: number;
   selectionRoot: Element | null;
   startTarget: Element | null;
+  canPreventDefault: boolean;
 }): SidebarInsetSwipeSession {
   const nowMs = Date.now();
   return {
@@ -201,7 +216,20 @@ function createSidebarInsetSwipeSession({
     isDragging: false,
     selectionRoot,
     startTarget,
+    canPreventDefault,
   };
+}
+
+/**
+ * Whether a content-area touch swipe may register the scroll-blocking touch
+ * path. Only touches near the left edge (past the browser's own back-swipe
+ * guard) get it; see SIDEBAR_MOBILE_SWIPE_OPEN_EDGE_ZONE_PX.
+ */
+function isSidebarSwipeEdgeZoneTouch(clientX: number): boolean {
+  return (
+    clientX >= SIDEBAR_MOBILE_SWIPE_BROWSER_EDGE_GUARD_PX &&
+    clientX < SIDEBAR_MOBILE_SWIPE_OPEN_EDGE_ZONE_PX
+  );
 }
 
 function shouldOpenSidebarMobileSwipe(
@@ -548,6 +576,15 @@ const SidebarProvider = React.forwardRef<
     React.useEffect(() => {
       openMobileRef.current = openMobile;
     }, [openMobile]);
+
+    // Publish drawer visibility for non-React readers (see
+    // sidebar-mobile-drawer-visibility.ts) without widening the context.
+    React.useEffect(() => {
+      setCompactSidebarDrawerShowing(isCompactViewport && openMobile);
+      return () => {
+        setCompactSidebarDrawerShowing(false);
+      };
+    }, [isCompactViewport, openMobile]);
 
     // Stable identity: sidebar rows close the drawer on navigation, and an
     // unstable callback would re-render every memoized row on each toggle.
@@ -1738,7 +1775,7 @@ const SidebarInset = React.forwardRef<
         });
       }
 
-      if (event.cancelable) {
+      if (session.canPreventDefault && event.cancelable) {
         event.preventDefault();
       }
 
@@ -1878,6 +1915,13 @@ const SidebarInset = React.forwardRef<
         clearSwipeSession();
       }
 
+      // Only an edge-zone touch may take the non-passive path. A touch that
+      // starts deeper in the timeline is almost always a scroll; registering
+      // a non-passive `touchmove` for it made iOS Safari and Chrome Android
+      // dispatch that scroll's first move synchronously through the main
+      // thread, which under streaming load delayed every scroll start. The
+      // deep touch keeps its swipe recognizer, but on a passive listener.
+      const canPreventDefault = isSidebarSwipeEdgeZoneTouch(touch.clientX);
       swipeSessionRef.current = createSidebarInsetSwipeSession({
         kind: "touch",
         id: touch.identifier,
@@ -1885,6 +1929,7 @@ const SidebarInset = React.forwardRef<
         startY: touch.clientY,
         selectionRoot: getSidebarSwipeSelectionRoot(event.target),
         startTarget: event.target instanceof Element ? event.target : null,
+        canPreventDefault,
       });
 
       const removeListeners = () => {
@@ -1893,7 +1938,7 @@ const SidebarInset = React.forwardRef<
         window.removeEventListener("touchcancel", handleTouchEnd);
       };
       window.addEventListener("touchmove", handleTouchMove, {
-        passive: false,
+        passive: !canPreventDefault,
       });
       window.addEventListener("touchend", handleTouchEnd);
       window.addEventListener("touchcancel", handleTouchEnd);
@@ -1931,6 +1976,8 @@ const SidebarInset = React.forwardRef<
         startY: event.clientY,
         selectionRoot: getSidebarSwipeSelectionRoot(event.target),
         startTarget: event.target instanceof Element ? event.target : null,
+        // `pointermove` is never scroll-blocking, so preventDefault is free.
+        canPreventDefault: true,
       });
 
       const removeListeners = () => {

--- a/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
+++ b/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
@@ -83,6 +83,7 @@ const CACHE_OWNER_QUERY_KEY_IMPORTS: CacheOwnerQueryKeyImportRegistry = {
   ],
   "hooks/cache-owners/environment-diff-patch-cache-owner.ts": [
     "environmentDiffPatchQueryKey",
+    "environmentDiffPatchQueryKeyPrefix",
   ],
   "hooks/cache-owners/environment-workspace-cache-owner.ts": [
     "environmentQueryKey",

--- a/apps/app/src/hooks/cache-owners/environment-diff-patch-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/environment-diff-patch-cache-owner.ts
@@ -1,6 +1,10 @@
 import type { QueryClient } from "@tanstack/react-query";
 import type { DiffPatchEntry } from "@bb/server-contract";
-import { environmentDiffPatchQueryKey } from "../queries/query-keys";
+import { HEAVY_PAYLOAD_GC_TIME_MS } from "../queries/query-policies";
+import {
+  environmentDiffPatchQueryKey,
+  environmentDiffPatchQueryKeyPrefix,
+} from "../queries/query-keys";
 
 /**
  * Identifies the diff-patch cache scope for one environment + diff target.
@@ -88,19 +92,101 @@ interface WriteDiffPatchEntryArgs {
   entry: DiffPatchEntry;
 }
 
-/** Cache one file's patch under the per-(target, path) diff-patch key. */
+/**
+ * Cache one file's patch under the per-(target, path) diff-patch key.
+ *
+ * Patch entries are observer-less (`getPatchState` reads them with
+ * `getQueryData`), so React Query's `gcTime` would count from the write, not
+ * from the last reader, and could drop a patch the panel is still showing.
+ * The query is therefore built without a gc timer; retention is owned by
+ * {@link retainDiffPatchQueries}, which evicts the environment's patches
+ * {@link HEAVY_PAYLOAD_GC_TIME_MS} after the last reader unmounts.
+ */
 export function writeDiffPatchEntry({
   queryClient,
   identity,
   entry,
 }: WriteDiffPatchEntryArgs): void {
-  queryClient.setQueryData<DiffPatchEntry>(
-    environmentDiffPatchQueryKey(
-      identity.environmentId,
-      identity.targetType,
-      identity.targetKey,
-      entry.path,
-    ),
-    entry,
+  const queryKey = environmentDiffPatchQueryKey(
+    identity.environmentId,
+    identity.targetType,
+    identity.targetKey,
+    entry.path,
   );
+  queryClient
+    .getQueryCache()
+    .build(queryClient, { queryKey, gcTime: Infinity });
+  queryClient.setQueryData<DiffPatchEntry>(queryKey, entry);
+}
+
+interface DiffPatchRetentionLease {
+  readers: number;
+  evictionTimer: ReturnType<typeof setTimeout> | null;
+}
+
+const diffPatchRetentionLeases = new WeakMap<
+  QueryClient,
+  Map<string, DiffPatchRetentionLease>
+>();
+
+function getDiffPatchRetentionLeases(
+  queryClient: QueryClient,
+): Map<string, DiffPatchRetentionLease> {
+  let leases = diffPatchRetentionLeases.get(queryClient);
+  if (leases === undefined) {
+    leases = new Map();
+    diffPatchRetentionLeases.set(queryClient, leases);
+  }
+  return leases;
+}
+
+/**
+ * Keep an environment's cached diff patches alive while a reader is mounted.
+ * When the last reader releases its lease, the patches are evicted after
+ * {@link HEAVY_PAYLOAD_GC_TIME_MS} — long enough for a quick thread
+ * back-and-forth to keep its loaded diff, short enough that a browsing session
+ * on a phone does not accumulate every visited thread's patches. A reader that
+ * mounts again inside that window cancels the pending eviction. Returns the
+ * release function.
+ */
+export function retainDiffPatchQueries({
+  queryClient,
+  environmentId,
+}: {
+  queryClient: QueryClient;
+  environmentId: string;
+}): () => void {
+  const leases = getDiffPatchRetentionLeases(queryClient);
+  let lease = leases.get(environmentId);
+  if (lease === undefined) {
+    lease = { readers: 0, evictionTimer: null };
+    leases.set(environmentId, lease);
+  }
+  if (lease.evictionTimer !== null) {
+    clearTimeout(lease.evictionTimer);
+    lease.evictionTimer = null;
+  }
+  lease.readers += 1;
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    lease.readers -= 1;
+    if (lease.readers > 0) {
+      return;
+    }
+    lease.evictionTimer = setTimeout(() => {
+      lease.evictionTimer = null;
+      if (lease.readers > 0) {
+        return;
+      }
+      leases.delete(environmentId);
+      bumpDiffPatchEvictionGeneration(environmentId);
+      queryClient.removeQueries({
+        queryKey: environmentDiffPatchQueryKeyPrefix(environmentId),
+      });
+    }, HEAVY_PAYLOAD_GC_TIME_MS);
+  };
 }

--- a/apps/app/src/hooks/queries/environment-queries.ts
+++ b/apps/app/src/hooks/queries/environment-queries.ts
@@ -39,6 +39,7 @@ import {
 import { requireEnabledQueryArg } from "./query-helpers";
 import {
   EXPENSIVE_MANUAL_QUERY_POLICY,
+  HEAVY_PAYLOAD_QUERY_POLICY,
   REALTIME_OWNED_MOUNT_BASELINE_QUERY_POLICY,
   REALTIME_OWNED_NO_FOCUS_QUERY_POLICY,
   TYPEAHEAD_QUERY_POLICY,
@@ -292,6 +293,7 @@ export function useEnvironmentFilePreview(
     },
     enabled,
     ...EXPENSIVE_MANUAL_QUERY_POLICY,
+    ...HEAVY_PAYLOAD_QUERY_POLICY,
   });
 }
 

--- a/apps/app/src/hooks/queries/project-queries.ts
+++ b/apps/app/src/hooks/queries/project-queries.ts
@@ -28,6 +28,7 @@ import {
 } from "./query-helpers";
 import {
   EXPENSIVE_MANUAL_QUERY_POLICY,
+  HEAVY_PAYLOAD_QUERY_POLICY,
   REALTIME_OWNED_NO_FOCUS_QUERY_POLICY,
   TYPEAHEAD_QUERY_POLICY,
 } from "./query-policies";
@@ -271,6 +272,7 @@ export function useProjectFilePreview(
     },
     enabled,
     ...EXPENSIVE_MANUAL_QUERY_POLICY,
+    ...HEAVY_PAYLOAD_QUERY_POLICY,
   });
 }
 

--- a/apps/app/src/hooks/queries/query-policies.ts
+++ b/apps/app/src/hooks/queries/query-policies.ts
@@ -54,3 +54,19 @@ export const REALTIME_OWNED_MOUNT_BASELINE_QUERY_POLICY = {
   refetchOnMount: "always",
   refetchOnWindowFocus: false,
 } as const;
+
+/**
+ * Heavy per-thread payloads (turn-summary details, file previews, diff
+ * patches) are read once and then only useful while their consumer is on
+ * screen. The default five-minute `gcTime` kept several such payloads per
+ * visited thread resident, which on phones is memory the timeline and the
+ * next thread need. One minute after the last observer leaves is enough for a
+ * quick back-and-forth and short enough that a browsing session stays bounded.
+ * Timeline windows are deliberately NOT on this tier: delta refetch depends on
+ * the cached window surviving a thread leave.
+ */
+export const HEAVY_PAYLOAD_GC_TIME_MS = 60_000;
+
+export const HEAVY_PAYLOAD_QUERY_POLICY = {
+  gcTime: HEAVY_PAYLOAD_GC_TIME_MS,
+} as const;

--- a/apps/app/src/hooks/queries/thread-queries.ts
+++ b/apps/app/src/hooks/queries/thread-queries.ts
@@ -55,6 +55,7 @@ import {
   TRANSIENT_READ_RETRY_DELAY_MS,
 } from "./query-helpers";
 import {
+  HEAVY_PAYLOAD_QUERY_POLICY,
   REALTIME_OWNED_MOUNT_BASELINE_QUERY_POLICY,
   REALTIME_OWNED_NO_FOCUS_QUERY_POLICY,
   RESUME_REFETCH_QUERY_POLICY,
@@ -855,6 +856,7 @@ export function useThreadStorageFilePreview(
       ),
     enabled,
     ...REALTIME_OWNED_MOUNT_BASELINE_QUERY_POLICY,
+    ...HEAVY_PAYLOAD_QUERY_POLICY,
   });
 }
 
@@ -881,6 +883,7 @@ export function useThreadHostFilePreview(
       ),
     enabled,
     ...RESUME_REFETCH_QUERY_POLICY,
+    ...HEAVY_PAYLOAD_QUERY_POLICY,
   });
 }
 
@@ -1045,6 +1048,7 @@ export function useThreadTimelineTurnSummaryDetails(
     },
     refetchOnMount: options?.refetchOnMount ?? true,
     staleTime: options?.staleTime ?? Infinity,
+    ...HEAVY_PAYLOAD_QUERY_POLICY,
   });
 }
 

--- a/apps/app/src/hooks/queries/use-environment-diff-patches.test.tsx
+++ b/apps/app/src/hooks/queries/use-environment-diff-patches.test.tsx
@@ -12,6 +12,7 @@ import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { removeEnvironmentDiffPatchQueries } from "../cache-owners/query-cache";
 import { bumpAllDiffPatchEvictionGenerations } from "../cache-owners/environment-diff-patch-cache-owner";
 import { environmentDiffPatchQueryKey } from "./query-keys";
+import { HEAVY_PAYLOAD_GC_TIME_MS } from "./query-policies";
 import { useEnvironmentDiffPatches } from "./use-environment-diff-patches";
 
 vi.mock("@/lib/sdk", () => ({
@@ -333,5 +334,71 @@ describe("useEnvironmentDiffPatches", () => {
       expect(state.patch).toBe(patch.patch);
     });
     expect(queryClient.getQueryData<DiffPatchEntry>(patchKey())).toEqual(patch);
+  });
+});
+
+describe("useEnvironmentDiffPatches cache retention", () => {
+  it("keeps patches while a reader is mounted and evicts them one minute after the last reader leaves", () => {
+    vi.useFakeTimers();
+    try {
+      const { wrapper, queryClient } = createQueryClientTestHarness();
+      const patch: DiffPatchEntry = {
+        path: PATH,
+        patch: "diff --git a/file.ts b/file.ts\n+kept\n",
+        truncated: false,
+      };
+
+      const first = renderHook(
+        () => useEnvironmentDiffPatches(ENVIRONMENT_ID, { target: TARGET }),
+        { wrapper },
+      );
+      act(() => {
+        first.result.current.seedInitialPatches([patch]);
+      });
+      expect(queryClient.getQueryData(patchKey())).toEqual(patch);
+
+      // Observer-less entries must not gc out from under a mounted reader.
+      act(() => {
+        vi.advanceTimersByTime(HEAVY_PAYLOAD_GC_TIME_MS * 10);
+      });
+      expect(queryClient.getQueryData(patchKey())).toEqual(patch);
+
+      // A second reader (split pane) then the first leaving keeps the cache.
+      const second = renderHook(
+        () => useEnvironmentDiffPatches(ENVIRONMENT_ID, { target: TARGET }),
+        { wrapper },
+      );
+      first.unmount();
+      act(() => {
+        vi.advanceTimersByTime(HEAVY_PAYLOAD_GC_TIME_MS * 2);
+      });
+      expect(queryClient.getQueryData(patchKey())).toEqual(patch);
+
+      // Last reader leaves: still cached inside the retention window (a quick
+      // thread back-and-forth reuses the loaded diff) ...
+      second.unmount();
+      act(() => {
+        vi.advanceTimersByTime(HEAVY_PAYLOAD_GC_TIME_MS - 1);
+      });
+      expect(queryClient.getQueryData(patchKey())).toEqual(patch);
+
+      // ... and a remount inside the window cancels the pending eviction.
+      const third = renderHook(
+        () => useEnvironmentDiffPatches(ENVIRONMENT_ID, { target: TARGET }),
+        { wrapper },
+      );
+      act(() => {
+        vi.advanceTimersByTime(HEAVY_PAYLOAD_GC_TIME_MS * 2);
+      });
+      expect(queryClient.getQueryData(patchKey())).toEqual(patch);
+
+      third.unmount();
+      act(() => {
+        vi.advanceTimersByTime(HEAVY_PAYLOAD_GC_TIME_MS);
+      });
+      expect(queryClient.getQueryData(patchKey())).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/app/src/hooks/queries/use-environment-diff-patches.ts
+++ b/apps/app/src/hooks/queries/use-environment-diff-patches.ts
@@ -12,6 +12,7 @@ import {
   type PatchQueryIdentity,
   getDiffPatchEvictionGeneration,
   readDiffPatchEntry,
+  retainDiffPatchQueries,
   writeDiffPatchEntry,
 } from "../cache-owners/environment-diff-patch-cache-owner";
 import { environmentDiffTargetKey } from "./query-keys";
@@ -205,6 +206,15 @@ export function useEnvironmentDiffPatches(
       abortPatchRequests(abortControllers);
     };
   }, []);
+
+  // Cached patches have no query observers, so this reader lease is what keeps
+  // them resident; the last release schedules the bounded eviction.
+  useEffect(() => {
+    if (!environmentId) {
+      return;
+    }
+    return retainDiffPatchQueries({ queryClient, environmentId });
+  }, [environmentId, queryClient]);
 
   const fetchPage = useCallback(
     async (paths: string[], generationTarget: string) => {

--- a/apps/app/src/lib/fixed-panel-tabs-state.ts
+++ b/apps/app/src/lib/fixed-panel-tabs-state.ts
@@ -1060,15 +1060,51 @@ export function pruneFixedPanelTabsStorage({
   }
 
   for (const key of keys) {
-    const result = parseFixedPanelTabsStateForStorage({
-      initialValue: EMPTY_FIXED_PANEL_TABS_STATE,
-      now,
-      storedValue: localStorage.getItem(key),
-    });
-    if (result.shouldPrune) {
+    if (shouldPruneStoredFixedPanelTabsState(localStorage.getItem(key), now)) {
       localStorage.removeItem(key);
     }
   }
+}
+
+/**
+ * Prune decision for one stored blob. The idle-expiry check reads only
+ * `lastUsedAt` from the parsed JSON, so an expired blob (the common case in a
+ * long-lived browser profile) is dropped without a full schema parse; only
+ * blobs that are still fresh, or that carry no usable timestamp, go through
+ * the schema.
+ */
+function shouldPruneStoredFixedPanelTabsState(
+  storedValue: string | null,
+  now: number,
+): boolean {
+  if (storedValue === null) {
+    return false;
+  }
+  let parsedValue: unknown;
+  try {
+    parsedValue = JSON.parse(storedValue);
+  } catch {
+    return true;
+  }
+  if (typeof parsedValue !== "object" || parsedValue === null) {
+    return true;
+  }
+  const lastUsedAt = Reflect.get(parsedValue, "lastUsedAt");
+  if (
+    typeof lastUsedAt === "number" &&
+    Number.isInteger(lastUsedAt) &&
+    lastUsedAt >= 0
+  ) {
+    if (now - lastUsedAt > FIXED_PANEL_TABS_IDLE_EXPIRY_MS) {
+      return true;
+    }
+    return !fixedPanelTabsStateSchema.safeParse(parsedValue).success;
+  }
+  return parseFixedPanelTabsStateForStorage({
+    initialValue: EMPTY_FIXED_PANEL_TABS_STATE,
+    now,
+    storedValue,
+  }).shouldPrune;
 }
 
 export function areFixedPanelTabsEquivalent(

--- a/apps/app/src/lib/fixed-panel-tabs-sync.test.ts
+++ b/apps/app/src/lib/fixed-panel-tabs-sync.test.ts
@@ -15,7 +15,9 @@ import {
 } from "./fixed-panel-tabs-state";
 import {
   resetFixedPanelTabsStateForTest,
+  resetFixedPanelTabsStorageMaintenanceForTest,
   useFixedPanelTabsState,
+  useFixedPanelTabsStorageMaintenance,
   useUpdateFixedPanelTabsState,
 } from "./fixed-panel-tabs";
 import { BbHttpError } from "./sdk";
@@ -422,6 +424,42 @@ describe("fixed panel tab storage churn", () => {
       expect(setItem).not.toHaveBeenCalledWith(storageKey, expect.anything());
     } finally {
       setItem.mockRestore();
+    }
+  });
+
+  it("schedules the storage prune once per page load, off the mount task", () => {
+    vi.useFakeTimers();
+    resetFixedPanelTabsStorageMaintenanceForTest();
+    try {
+      const now = Date.now();
+      const expiredBlob = serializeFixedPanelTabsState({
+        state: createEmptyFixedPanelTabsState({
+          lastUsedAt: now - FIXED_PANEL_TABS_IDLE_EXPIRY_MS - 1,
+        }),
+      });
+      const firstKey = getFixedPanelTabsStateStorageKey({ threadId: "one" });
+      window.localStorage.setItem(firstKey, expiredBlob);
+
+      const first = renderHook(() => useFixedPanelTabsStorageMaintenance());
+      // Never in the same task as the route change that mounted the view.
+      expect(window.localStorage.getItem(firstKey)).not.toBeNull();
+      act(() => {
+        vi.runAllTimers();
+      });
+      expect(window.localStorage.getItem(firstKey)).toBeNull();
+      first.unmount();
+
+      // A later thread navigation mounts the hook again: no second scan.
+      const secondKey = getFixedPanelTabsStateStorageKey({ threadId: "two" });
+      window.localStorage.setItem(secondKey, expiredBlob);
+      renderHook(() => useFixedPanelTabsStorageMaintenance());
+      act(() => {
+        vi.runAllTimers();
+      });
+      expect(window.localStorage.getItem(secondKey)).not.toBeNull();
+    } finally {
+      vi.useRealTimers();
+      resetFixedPanelTabsStorageMaintenanceForTest();
     }
   });
 

--- a/apps/app/src/lib/fixed-panel-tabs-sync.test.ts
+++ b/apps/app/src/lib/fixed-panel-tabs-sync.test.ts
@@ -8,10 +8,13 @@ import {
   createBrowserFixedPanelTab,
   createEmptyFixedPanelTabsState,
   createThreadInfoFixedPanelTab,
+  FIXED_PANEL_TABS_IDLE_EXPIRY_MS,
   getFixedPanelTabsStateStorageKey,
+  pruneFixedPanelTabsStorage,
   serializeFixedPanelTabsState,
 } from "./fixed-panel-tabs-state";
 import {
+  resetFixedPanelTabsStateForTest,
   useFixedPanelTabsState,
   useUpdateFixedPanelTabsState,
 } from "./fixed-panel-tabs";
@@ -362,5 +365,105 @@ describe("fixed panel tab server sync", () => {
       ]);
     });
     expect(apiMocks.updateThreadTabs).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("fixed panel tab storage churn", () => {
+  it("does not rewrite localStorage when hydration and reconciliation leave the state unchanged", async () => {
+    resetFixedPanelTabsStateForTest();
+    const threadId = "sync-no-rewrite";
+    const remoteTab = createBrowserFixedPanelTab({
+      environmentId: null,
+      url: "https://remote.example.com",
+    });
+    const storageKey = getFixedPanelTabsStateStorageKey({ threadId });
+    window.localStorage.setItem(
+      storageKey,
+      serializeFixedPanelTabsState({
+        state: createEmptyFixedPanelTabsState({
+          lastUsedAt: Date.now(),
+          secondary: {
+            activeTabId: remoteTab.id,
+            isOpen: true,
+            tabs: [remoteTab],
+          },
+        }),
+      }),
+    );
+    apiMocks.getThreadTabs.mockResolvedValue({
+      revision: 4,
+      tabs: [remoteTab],
+    });
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
+    try {
+      const queryClient = createTestQueryClient();
+      const { result } = renderHook(
+        () => ({
+          state: useFixedPanelTabsState(threadId, threadId),
+          update: useUpdateFixedPanelTabsState(threadId, threadId),
+        }),
+        { wrapper: createQueryWrapper(queryClient) },
+      );
+
+      await waitFor(() => {
+        expect(apiMocks.getThreadTabs).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(result.current.state.secondary.tabs).toEqual([remoteTab]);
+      });
+      // Server tabs match the persisted tabs: reconciliation must not touch
+      // storage on mount.
+      expect(setItem).not.toHaveBeenCalledWith(storageKey, expect.anything());
+
+      // A no-op updater must not reach the storage atom either.
+      act(() => {
+        result.current.update((current) => current);
+      });
+      expect(setItem).not.toHaveBeenCalledWith(storageKey, expect.anything());
+    } finally {
+      setItem.mockRestore();
+    }
+  });
+
+  it("prunes expired and malformed blobs and keeps fresh ones", () => {
+    const now = Date.now();
+    const freshKey = getFixedPanelTabsStateStorageKey({ threadId: "fresh" });
+    const expiredKey = getFixedPanelTabsStateStorageKey({
+      threadId: "expired",
+    });
+    const garbageKey = getFixedPanelTabsStateStorageKey({
+      threadId: "garbage",
+    });
+    const staleShapeKey = getFixedPanelTabsStateStorageKey({
+      threadId: "stale-shape",
+    });
+    window.localStorage.setItem(
+      freshKey,
+      serializeFixedPanelTabsState({
+        state: createEmptyFixedPanelTabsState({ lastUsedAt: now }),
+      }),
+    );
+    window.localStorage.setItem(
+      expiredKey,
+      serializeFixedPanelTabsState({
+        state: createEmptyFixedPanelTabsState({
+          lastUsedAt: now - FIXED_PANEL_TABS_IDLE_EXPIRY_MS - 1,
+        }),
+      }),
+    );
+    window.localStorage.setItem(garbageKey, "{not json");
+    window.localStorage.setItem(
+      staleShapeKey,
+      JSON.stringify({ lastUsedAt: now, secondary: "nope" }),
+    );
+    window.localStorage.setItem("unrelated", "keep");
+
+    pruneFixedPanelTabsStorage({ now });
+
+    expect(window.localStorage.getItem(freshKey)).not.toBeNull();
+    expect(window.localStorage.getItem(expiredKey)).toBeNull();
+    expect(window.localStorage.getItem(garbageKey)).toBeNull();
+    expect(window.localStorage.getItem(staleShapeKey)).toBeNull();
+    expect(window.localStorage.getItem("unrelated")).toBe("keep");
   });
 });

--- a/apps/app/src/lib/fixed-panel-tabs.ts
+++ b/apps/app/src/lib/fixed-panel-tabs.ts
@@ -7,7 +7,7 @@ import {
 } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { atom } from "jotai";
-import { useAtomValue, useSetAtom } from "jotai";
+import { useAtomValue, useSetAtom, useStore } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import { atomFamily } from "jotai-family";
 import type { TerminalCreateTarget } from "@bb/server-contract";
@@ -227,13 +227,48 @@ function closeFixedSecondaryPanelState(
   };
 }
 
+let hasScheduledFixedPanelTabsStoragePrune = false;
+
+/**
+ * Prunes expired per-thread fixed-panel blobs from localStorage once per page
+ * load, from idle time. Previously every thread navigation re-scanned and
+ * schema-parsed every stored blob on the mount path; the scan only needs to
+ * run once per session, and never in the same task as a route change.
+ */
 export function useFixedPanelTabsStorageMaintenance(
-  panelStateId: FixedPanelTabsPanelStateId,
+  _panelStateId: FixedPanelTabsPanelStateId,
 ): void {
   useEffect(() => {
-    const now = Date.now();
-    pruneFixedPanelTabsStorage({ now });
-  }, [panelStateId]);
+    if (hasScheduledFixedPanelTabsStoragePrune) {
+      return;
+    }
+    hasScheduledFixedPanelTabsStoragePrune = true;
+    scheduleIdleFixedPanelTabsStoragePrune();
+  }, []);
+}
+
+const FIXED_PANEL_TABS_STORAGE_PRUNE_IDLE_TIMEOUT_MS = 5_000;
+const FIXED_PANEL_TABS_STORAGE_PRUNE_FALLBACK_DELAY_MS = 1_500;
+
+function scheduleIdleFixedPanelTabsStoragePrune(): void {
+  const run = () => {
+    pruneFixedPanelTabsStorage({ now: Date.now() });
+  };
+  if (typeof window === "undefined") {
+    return;
+  }
+  if (typeof window.requestIdleCallback === "function") {
+    window.requestIdleCallback(run, {
+      timeout: FIXED_PANEL_TABS_STORAGE_PRUNE_IDLE_TIMEOUT_MS,
+    });
+    return;
+  }
+  window.setTimeout(run, FIXED_PANEL_TABS_STORAGE_PRUNE_FALLBACK_DELAY_MS);
+}
+
+/** Test-only: allow the once-per-page-load prune to be scheduled again. */
+export function resetFixedPanelTabsStorageMaintenanceForTest(): void {
+  hasScheduledFixedPanelTabsStoragePrune = false;
 }
 
 export function useFixedPanelTabsState(
@@ -241,6 +276,7 @@ export function useFixedPanelTabsState(
   syncThreadId: FixedPanelTabsSyncThreadId,
 ): FixedPanelTabsState {
   const stateAtom = getFixedPanelTabsStateAtom(panelStateId);
+  const store = useStore();
   const state = useAtomValue(stateAtom);
   const setState = useSetAtom(stateAtom);
   const queryClient = useQueryClient();
@@ -264,16 +300,23 @@ export function useFixedPanelTabsState(
       });
       return;
     }
-    setState((current) =>
-      ensureOpenFixedPanelHasActiveTab(
-        reconcileFixedPanelTabsState(current, tabsQuery.data.tabs),
-      ),
+    // Writing through the storage atom serializes and re-writes localStorage
+    // even when the reconciled value is the current one, so skip the write
+    // (and the store notification) when nothing changed.
+    const current = store.get(stateAtom);
+    const next = ensureOpenFixedPanelHasActiveTab(
+      reconcileFixedPanelTabsState(current, tabsQuery.data.tabs),
     );
+    if (next !== current) {
+      setState(next);
+    }
   }, [
     queryClient,
     resolvedThreadId,
     setState,
     state.secondary.tabs,
+    stateAtom,
+    store,
     tabsQuery.data,
   ]);
 
@@ -284,38 +327,38 @@ export function useUpdateFixedPanelTabsState(
   panelStateId: FixedPanelTabsPanelStateId,
   syncThreadId: FixedPanelTabsSyncThreadId,
 ): (update: FixedPanelTabsStateUpdater) => void {
-  const setState = useSetAtom(getFixedPanelTabsStateAtom(panelStateId));
+  const stateAtom = getFixedPanelTabsStateAtom(panelStateId);
+  const store = useStore();
+  const setState = useSetAtom(stateAtom);
   const queryClient = useQueryClient();
   return useCallback(
     (update: FixedPanelTabsStateUpdater) => {
       if (!hasThreadId(panelStateId)) return;
       const now = Date.now();
-      let tabsToPersist: readonly FixedPanelTab[] | null = null;
-      setState((current) => {
-        const next = ensureOpenFixedPanelHasActiveTab(update(current));
-        if (next === current) {
-          return current;
-        }
-        const touched = touchFixedPanelTabsState(next, now);
-        if (
-          !areThreadTabListsEquivalent(
-            current.secondary.tabs,
-            touched.secondary.tabs,
-          )
-        ) {
-          tabsToPersist = touched.secondary.tabs;
-        }
-        return touched;
-      });
-      if (tabsToPersist !== null && hasThreadId(syncThreadId)) {
+      // Read the atom directly so a no-op update never reaches the storage
+      // atom (a write always serializes and re-writes localStorage).
+      const current = store.get(stateAtom);
+      const next = ensureOpenFixedPanelHasActiveTab(update(current));
+      if (next === current) {
+        return;
+      }
+      const touched = touchFixedPanelTabsState(next, now);
+      setState(touched);
+      if (
+        hasThreadId(syncThreadId) &&
+        !areThreadTabListsEquivalent(
+          current.secondary.tabs,
+          touched.secondary.tabs,
+        )
+      ) {
         scheduleThreadTabsPersistence({
-          tabs: tabsToPersist,
+          tabs: touched.secondary.tabs,
           queryClient,
           threadId: syncThreadId,
         });
       }
     },
-    [panelStateId, queryClient, setState, syncThreadId],
+    [panelStateId, queryClient, setState, stateAtom, store, syncThreadId],
   );
 }
 

--- a/apps/app/src/lib/fixed-panel-tabs.ts
+++ b/apps/app/src/lib/fixed-panel-tabs.ts
@@ -235,9 +235,7 @@ let hasScheduledFixedPanelTabsStoragePrune = false;
  * schema-parsed every stored blob on the mount path; the scan only needs to
  * run once per session, and never in the same task as a route change.
  */
-export function useFixedPanelTabsStorageMaintenance(
-  _panelStateId: FixedPanelTabsPanelStateId,
-): void {
+export function useFixedPanelTabsStorageMaintenance(): void {
   useEffect(() => {
     if (hasScheduledFixedPanelTabsStoragePrune) {
       return;

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -766,7 +766,6 @@ function RootComposeSurface({
     isProjectless,
     projects,
     sidebarNavigation,
-    sidebarNavigationSettled,
     sidebarNavigationError,
     currentProject,
     projectSources,
@@ -2271,9 +2270,10 @@ function RootComposeSurface({
     runningJobKey,
   ]);
 
-  if (!sidebarNavigationSettled) {
-    return <RouteLoadingSkeleton />;
-  }
+  // The composer renders immediately with loading pickers; only a failed
+  // bootstrap with no projects at all replaces it (see B28). While the
+  // bootstrap is in flight the project picker shows a loading label and the
+  // projectId-dependent queries inside NewThreadComposer stay disabled.
   if (!projects && sidebarNavigationError) {
     return (
       <PageShell contentClassName="min-h-full items-center justify-center">

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -971,7 +971,7 @@ function RootComposeSurface({
     startInstall({ hostId: composeHostId, issue: codexCliIssue });
   }, [codexCliIssue, composeHostId, startInstall]);
 
-  useFixedPanelTabsStorageMaintenance(ROOT_COMPOSE_FIXED_PANEL_STATE_ID);
+  useFixedPanelTabsStorageMaintenance();
   const fixedPanelTabsState = useFixedPanelTabsState(
     ROOT_COMPOSE_FIXED_PANEL_STATE_ID,
     null,

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
@@ -80,166 +80,196 @@ vi.mock("react-router-dom", async (importOriginal) => {
   };
 });
 
-vi.mock("@/components/promptbox/FollowUpPromptBox", () => ({
-  FollowUpPromptBox: ({
-    attachments,
-    composer,
-    execution,
-    executionReadOnly,
-    permission,
-    permissionReadOnly,
-    pluginComposerHost,
-    showScrollToBottomButton,
-    stack,
-    suppressPluginComposerCustomizations,
-    textEffects,
-  }: {
-    attachments: {
-      items: readonly unknown[];
-      onAttachFiles: (files: File[]) => void | Promise<void>;
-    };
-    composer: {
-      message: string;
-      onChangeMessage: (message: string, mentions: []) => void;
-      onSubmit: () => void;
-      submitTitle?: string;
-      submitMode: { kind: string; reason?: string };
-    } | null;
-    execution: {
-      footerAction?: {
-        label: string;
-        onClick: () => void;
+vi.mock("@/components/promptbox/FollowUpPromptBox", async () => {
+  const { ComposerBannersSlot } = await vi.importActual<
+    typeof import("@/components/plugin/PluginComposerBanners")
+  >("@/components/plugin/PluginComposerBanners");
+  return {
+    FollowUpPromptBox: ({
+      attachments,
+      composer,
+      execution,
+      executionReadOnly,
+      pendingInteraction,
+      permission,
+      permissionReadOnly,
+      pluginComposerHost,
+      showScrollToBottomButton,
+      stack,
+      suppressPluginComposerCustomizations,
+      textEffects,
+    }: {
+      attachments: {
+        items: readonly unknown[];
+        onAttachFiles: (files: File[]) => void | Promise<void>;
       };
-      model: {
-        active?: { model: string } | null;
+      composer: {
+        message: string;
+        onChangeMessage: (message: string, mentions: []) => void;
+        onSubmit: () => void;
+        submitTitle?: string;
+        submitMode: { kind: string; reason?: string };
+      } | null;
+      execution: {
+        footerAction?: {
+          label: string;
+          onClick: () => void;
+        };
+        model: {
+          active?: { model: string } | null;
+        };
+        reasoning: { value: string };
+        serviceTier?: { value?: string };
       };
-      reasoning: { value: string };
-      serviceTier?: { value?: string };
-    };
-    executionReadOnly?: boolean;
-    permission: { value?: string };
-    permissionReadOnly?: boolean;
-    pluginComposerHost?: PluginComposerHost | null;
-    showScrollToBottomButton?: boolean;
-    stack: ReactNode;
-    suppressPluginComposerCustomizations?: boolean;
-    textEffects?: readonly {
-      effect: { className: string };
-    }[];
-  }) => (
-    <div data-testid="follow-up-prompt-box">
-      <div data-testid="prompt-stack">{stack}</div>
-      <div data-testid="composer-boundary" />
-      <div data-testid="submit-mode">
-        {composer?.submitMode.kind}:{composer?.submitMode.reason ?? ""}
-      </div>
-      <div data-testid="submit-title">{composer?.submitTitle ?? "Submit"}</div>
-      <div data-testid="plugin-customizations-suppressed">
-        {suppressPluginComposerCustomizations ? "true" : "false"}
-      </div>
-      <div data-testid="selected-model">{execution.model.active?.model}</div>
-      <div data-testid="selected-reasoning">{execution.reasoning.value}</div>
-      <div data-testid="selected-service-tier">
-        {execution.serviceTier?.value}
-      </div>
-      <div data-testid="selected-permission">{permission.value}</div>
-      <div data-testid="execution-read-only">
-        {executionReadOnly ? "true" : "false"}
-      </div>
-      <div data-testid="permission-read-only">
-        {permissionReadOnly ? "true" : "false"}
-      </div>
-      <div data-testid="attachment-count">{attachments.items.length}</div>
-      <div data-testid="composer-text-effect">
-        {textEffects && textEffects.length > 0
-          ? textEffects.map(({ effect }) => effect.className).join(",")
-          : "none"}
-      </div>
-      <div data-testid="composer-location">
-        {showScrollToBottomButton === false ? "inline" : "bottom"}
-      </div>
-      <div data-testid="plugin-composer-scope">
-        {pluginComposerHost
-          ? `${pluginComposerHost.scope.kind}:${
-              pluginComposerHost.scope.kind === "queued-message"
-                ? pluginComposerHost.scope.queuedMessageId
-                : pluginComposerHost.scope.kind === "thread"
-                  ? pluginComposerHost.scope.threadId
-                  : (pluginComposerHost.scope.projectId ?? "null")
-            }`
-          : "route"}
-      </div>
-      {pluginComposerHost ? (
-        <>
-          <button
-            type="button"
-            onClick={() =>
-              pluginComposerHost.setDraft({
-                ...pluginComposerHost.draft,
-                text: "Plugin-enhanced queued message",
-              })
-            }
-          >
-            Simulate plugin replacement
+      executionReadOnly?: boolean;
+      pendingInteraction?: ReactNode;
+      permission: { value?: string };
+      permissionReadOnly?: boolean;
+      pluginComposerHost?: PluginComposerHost | null;
+      showScrollToBottomButton?: boolean;
+      stack: ReactNode;
+      suppressPluginComposerCustomizations?: boolean;
+      textEffects?: readonly {
+        effect: { className: string };
+      }[];
+    }) => (
+      <div data-testid="follow-up-prompt-box">
+        {/* Mirrors the real stack: plugin banners for the composer scope, then
+          the caller's stack, then the pending interaction (if any). */}
+        <div data-testid="prompt-stack">
+          {pluginComposerHost ? (
+            <ComposerBannersSlot
+              view={{
+                scope: pluginComposerHost.scope,
+                layout: "expanded",
+                draft: { text: "", isEmpty: true, attachmentCount: 0 },
+                run: { isRunning: false, isSubmitting: false },
+              }}
+            >
+              {stack}
+            </ComposerBannersSlot>
+          ) : (
+            stack
+          )}
+          {pendingInteraction}
+        </div>
+        <div data-testid="composer-boundary" />
+        <div data-testid="composer-hidden">
+          {pendingInteraction ? "true" : "false"}
+        </div>
+        <div data-testid="submit-mode">
+          {composer?.submitMode.kind}:{composer?.submitMode.reason ?? ""}
+        </div>
+        <div data-testid="submit-title">
+          {composer?.submitTitle ?? "Submit"}
+        </div>
+        <div data-testid="plugin-customizations-suppressed">
+          {suppressPluginComposerCustomizations ? "true" : "false"}
+        </div>
+        <div data-testid="selected-model">{execution.model.active?.model}</div>
+        <div data-testid="selected-reasoning">{execution.reasoning.value}</div>
+        <div data-testid="selected-service-tier">
+          {execution.serviceTier?.value}
+        </div>
+        <div data-testid="selected-permission">{permission.value}</div>
+        <div data-testid="execution-read-only">
+          {executionReadOnly ? "true" : "false"}
+        </div>
+        <div data-testid="permission-read-only">
+          {permissionReadOnly ? "true" : "false"}
+        </div>
+        <div data-testid="attachment-count">{attachments.items.length}</div>
+        <div data-testid="composer-text-effect">
+          {textEffects && textEffects.length > 0
+            ? textEffects.map(({ effect }) => effect.className).join(",")
+            : "none"}
+        </div>
+        <div data-testid="composer-location">
+          {showScrollToBottomButton === false ? "inline" : "bottom"}
+        </div>
+        <div data-testid="plugin-composer-scope">
+          {pluginComposerHost
+            ? `${pluginComposerHost.scope.kind}:${
+                pluginComposerHost.scope.kind === "queued-message"
+                  ? pluginComposerHost.scope.queuedMessageId
+                  : pluginComposerHost.scope.kind === "thread"
+                    ? pluginComposerHost.scope.threadId
+                    : (pluginComposerHost.scope.projectId ?? "null")
+              }`
+            : "route"}
+        </div>
+        {pluginComposerHost ? (
+          <>
+            <button
+              type="button"
+              onClick={() =>
+                pluginComposerHost.setDraft({
+                  ...pluginComposerHost.draft,
+                  text: "Plugin-enhanced queued message",
+                })
+              }
+            >
+              Simulate plugin replacement
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                pluginComposerHost.setDraft({
+                  ...pluginComposerHost.getCurrent(),
+                  text: "First plugin update",
+                });
+                const current = pluginComposerHost.getCurrent();
+                pluginComposerHost.setDraft({
+                  ...current,
+                  text: `${current.text} + second plugin update`,
+                });
+              }}
+            >
+              Simulate chained plugin updates
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                mocks.pluginComposerHost = pluginComposerHost;
+              }}
+            >
+              Capture plugin host
+            </button>
+          </>
+        ) : null}
+        {composer ? (
+          <>
+            <input
+              aria-label="Composer message"
+              value={composer.message}
+              onChange={(event) =>
+                composer.onChangeMessage(event.currentTarget.value, [])
+              }
+            />
+            <button type="button" onClick={composer.onSubmit}>
+              Submit composer
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                void attachments.onAttachFiles([
+                  new File(["queued"], "queued.txt", { type: "text/plain" }),
+                ])
+              }
+            >
+              Attach file
+            </button>
+          </>
+        ) : null}
+        {execution.footerAction ? (
+          <button type="button" onClick={execution.footerAction.onClick}>
+            {execution.footerAction.label}
           </button>
-          <button
-            type="button"
-            onClick={() => {
-              pluginComposerHost.setDraft({
-                ...pluginComposerHost.getCurrent(),
-                text: "First plugin update",
-              });
-              const current = pluginComposerHost.getCurrent();
-              pluginComposerHost.setDraft({
-                ...current,
-                text: `${current.text} + second plugin update`,
-              });
-            }}
-          >
-            Simulate chained plugin updates
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              mocks.pluginComposerHost = pluginComposerHost;
-            }}
-          >
-            Capture plugin host
-          </button>
-        </>
-      ) : null}
-      {composer ? (
-        <>
-          <input
-            aria-label="Composer message"
-            value={composer.message}
-            onChange={(event) =>
-              composer.onChangeMessage(event.currentTarget.value, [])
-            }
-          />
-          <button type="button" onClick={composer.onSubmit}>
-            Submit composer
-          </button>
-          <button
-            type="button"
-            onClick={() =>
-              void attachments.onAttachFiles([
-                new File(["queued"], "queued.txt", { type: "text/plain" }),
-              ])
-            }
-          >
-            Attach file
-          </button>
-        </>
-      ) : null}
-      {execution.footerAction ? (
-        <button type="button" onClick={execution.footerAction.onClick}>
-          {execution.footerAction.label}
-        </button>
-      ) : null}
-    </div>
-  ),
-}));
+        ) : null}
+      </div>
+    ),
+  };
+});
 
 vi.mock("@/components/promptbox/ThreadEnvironmentSummary", () => ({
   ThreadEnvironmentSummary: () => <div />,
@@ -1535,6 +1565,14 @@ describe("ThreadDetailPromptArea", () => {
     expect(screen.queryByRole("button", { name: "Editor action" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Prompt actions" })).toBeNull();
     expect(document.querySelector(".pending-rule")).toBeNull();
+    // The composer is retained (blocked, hidden) rather than swapped out, so
+    // approving does not rebuild the editor.
+    expect(screen.getByTestId("composer-hidden").textContent).toBe("true");
+    expect(screen.getByTestId("submit-mode").textContent).toBe(
+      "blocked:pending-interaction",
+    );
+    // The reduced pending stack keeps the queued drawer and todo card out.
+    expect(screen.queryByTestId("queued-message-list")).toBeNull();
   });
 
   it("wires the Plan exit action to the current thread", () => {

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -35,9 +35,7 @@ import type {
 import type { ChildThreadPendingAttention } from "@/hooks/queries/child-thread-pending-interactions";
 import { ThreadPendingInteractionBanner } from "@/components/thread/pending-interactions/ThreadPendingInteractionBanner";
 import { PluginPendingInteractionComposer } from "@/components/plugin/PluginPendingInteractionComposer";
-import { ComposerBannersSlot } from "@/components/plugin/PluginComposerBanners";
 import {
-  PluginComposerHostProvider,
   type PluginComposerHost,
   usePublishPluginComposerHost,
 } from "@/components/plugin/plugin-composer-host";
@@ -1670,60 +1668,65 @@ export function ThreadDetailPromptArea({
     ],
   );
 
-  const bottomContent =
-    activePendingInteraction && !shouldHideComposer ? (
-      <div className="grid gap-2">
+  // A pending permission/question takes the composer's place, but the
+  // composer itself stays mounted (hidden) inside FollowUpPromptBox so the
+  // TipTap editor, draft and pickers survive every approval instead of being
+  // rebuilt per interaction (submitMode is already "blocked" here). The
+  // interaction shows as the last stack item above a reduced stack: child
+  // banners, plan mode and goal cards, plus plugin banners.
+  const pendingInteractionNode = useMemo(() => {
+    if (!activePendingInteraction || shouldHideComposer) {
+      return null;
+    }
+    return isPluginPendingInteraction(activePendingInteraction) ? (
+      <PluginPendingInteractionComposer
+        interaction={activePendingInteraction}
+      />
+    ) : (
+      <ThreadPendingInteractionBanner
+        interaction={activePendingInteraction}
+        threadId={thread.id}
+      />
+    );
+  }, [activePendingInteraction, shouldHideComposer, thread.id]);
+  const pendingInteractionStack = useMemo(
+    () => (
+      <>
         {childPendingInteractionBanners}
         {activePromptMode ? activePromptModeCard : null}
         {goal ? activeGoalCard : null}
-        <PluginComposerHostProvider value={normalPluginComposerHost}>
-          <ComposerBannersSlot
-            view={{
-              scope: normalPluginComposerHost.scope,
-              layout: "expanded",
-              draft: {
-                text: normalPluginComposerHost.draft.text,
-                isEmpty:
-                  normalPluginComposerHost.draft.text.trim().length === 0 &&
-                  normalPluginComposerHost.draft.attachments.length === 0,
-                attachmentCount:
-                  normalPluginComposerHost.draft.attachments.length,
-              },
-              run: { isRunning: false, isSubmitting: false },
-            }}
-          />
-        </PluginComposerHostProvider>
-        {isPluginPendingInteraction(activePendingInteraction) ? (
-          <PluginPendingInteractionComposer
-            interaction={activePendingInteraction}
-          />
-        ) : (
-          <ThreadPendingInteractionBanner
-            interaction={activePendingInteraction}
-            threadId={thread.id}
-          />
-        )}
-      </div>
-    ) : (
-      <FollowUpPromptBox
-        id={THREAD_DETAIL_COMPOSER_TEXTAREA_ID}
-        attachments={bottomAttachmentsConfig}
-        stack={promptStack}
-        activePromptMode={activePromptMode}
-        composer={shouldHideComposer ? null : bottomComposerConfig}
-        pluginComposerHost={normalPluginComposerHost}
-        pluginComposerScope={normalPluginComposerHost.scope}
-        textEffects={promptTextEffects}
-        zenModeResetKey={thread.id}
-        focusEndKey={bottomFocusEndKey}
-        environmentSummary={environmentSummary}
-        contextWindowUsage={contextWindowUsage ?? null}
-        execution={bottomExecutionConfig}
-        permission={bottomPermissionConfig}
-        typeahead={typeaheadConfig}
-        promptActions={promptActions}
-      />
-    );
+      </>
+    ),
+    [
+      activeGoalCard,
+      activePromptMode,
+      activePromptModeCard,
+      childPendingInteractionBanners,
+      goal,
+    ],
+  );
+
+  const bottomContent = (
+    <FollowUpPromptBox
+      id={THREAD_DETAIL_COMPOSER_TEXTAREA_ID}
+      attachments={bottomAttachmentsConfig}
+      stack={pendingInteractionNode ? pendingInteractionStack : promptStack}
+      pendingInteraction={pendingInteractionNode}
+      activePromptMode={activePromptMode}
+      composer={shouldHideComposer ? null : bottomComposerConfig}
+      pluginComposerHost={normalPluginComposerHost}
+      pluginComposerScope={normalPluginComposerHost.scope}
+      textEffects={promptTextEffects}
+      zenModeResetKey={thread.id}
+      focusEndKey={bottomFocusEndKey}
+      environmentSummary={environmentSummary}
+      contextWindowUsage={contextWindowUsage ?? null}
+      execution={bottomExecutionConfig}
+      permission={bottomPermissionConfig}
+      typeahead={typeaheadConfig}
+      promptActions={promptActions}
+    />
+  );
 
   return (
     <>

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -517,7 +517,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
   const { isFocused, navigateInPane, onRequestClose, isBoundedPane } =
     usePaneContext();
   const navigate = useNavigate();
-  useFixedPanelTabsStorageMaintenance(threadId);
+  useFixedPanelTabsStorageMaintenance();
   const systemConfigQuery = useSystemConfig();
   const threadDetailBootstrapQuery = useThreadDetailBootstrap(threadId ?? "");
   const hasThreadDetailBootstrapSettled =


### PR DESCRIPTION
## What was wrong

On phones (iOS Safari, compact viewports) several app-side patterns made every page and every thread heavier than it needed to be:

- Sidebar rows wrapped each row in a modal Radix ContextMenu whose 700 ms long-press set aria-hidden on #root, registered a non-passive touchmove and flipped body pointer-events with the timeline mounted behind the drawer (E1).
- dnd-kit's TouchSensor kept a permanent non-passive window touchmove listener from sidebar DndContexts mounted at boot, and the SidebarInset swipe-open registered another one for every content touch. Both make the first move of every scroll wait for the main thread (E6, E7).
- Settings/Tools routes swapped the whole AppSidebar out; returning remounted ProjectList in the closed drawer (E10).
- A pending permission/question swapped FollowUpPromptBox out of the tree, rebuilding TipTap per approval (D3).
- The collapsed compact composer built the full TipTap editor during thread mount (D5 (reverted, see below)).
- Fixed-panel storage was scanned and zod-parsed on every navigation and re-written on mount (J3).
- Heavy per-thread caches used the default 5-minute gcTime (J4).
- PR check icons and the GitHub logo fetched light+dark PNGs from github.githubassets.com (I6).
- Root compose showed only "Loading…" until the sidebar bootstrap settled (B28).

## What changed

- E1: `CompactLongPressMenu` (long-press/right-click detector, nothing mounted until first open) opens the existing responsive drawer with the same DropdownMenu items; desktop keeps the context menu.
- E6: `SidebarTouchSensor` installs dnd-kit's listener only while the compact drawer shows (external store written by SidebarProvider, no context subscription); tab strip wires TouchSensor only when open with 2+ tabs.
- E7: only edge-zone touches (24-72 px) get the non-passive swipe path; deeper touches keep the recognizer on a passive listener without preventDefault.
- E10: on compact one persistent `<Sidebar>` panel hosts the AppSidebar body (hidden while Settings/Tools body shows); `mobileHosted` mode on AppSidebar/SectionSidebar; 220 ms close hold preserved.
- D3: `pendingInteraction` prop on FollowUpPromptBox keeps the editor shell mounted and hidden, interaction as last stack item, footer pickers read-only.
- D5 (reverted, see below): static 48 px compact row on compact + coarse pointer; editor realizes after paint (idle/timeout, transition) or at first tap (pointerdown mounts under an overlay, click focuses via `focusEndForTap`); Stop/voice/drafted submit work from the row; #1771 handoff untouched.
- J3: prune once per page load from idle, lastUsedAt checked before schema parse, no-op storage writes skipped.
- J4: `HEAVY_PAYLOAD_QUERY_POLICY` (60 s gc) on turn-summary details and file previews; diff patches use a reader lease with a 60 s post-unmount eviction (observer-less entries no longer gc while shown).
- I6: bundled GitHub glyph + theme-token status dot; logo via the shared icon.
- B28: composer renders immediately with a loading project picker; projectId-keyed queries gate on the settled bootstrap.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/app`: pass.
- `pnpm exec turbo run lint --filter=@bb/app`: 0 errors (147 pre-existing warnings, unchanged count).
- `pnpm exec turbo run test --filter=@bb/app --force`: 364 files, 2906 passed, 3 skipped (one registry boundary test fixed in the last commit and re-run green).
- New/updated tests: compact-long-press-menu.test.tsx, useSidebarReorderDnd.test.tsx (sensor install/remove), sidebar.test.tsx (passive vs non-passive registration), AppLayoutSidebar.test.tsx (single panel + single mount across app -> settings -> tools -> app), FollowUpPromptBox.test.tsx (editor DOM identity across pending interaction; deferred compact editor lifecycle), ThreadDetailPromptArea.test.tsx (composer retained + stack ordering), fixed-panel-tabs-sync.test.ts (no rewrite, prune decisions), use-environment-diff-patches.test.tsx (retention lease), PluginNewThreadComposer.test.tsx (root composer before settle, gated queries).

Fixes: mobile perf sweep findings E1, E6, E7, E10, D3, D5 (reverted, see below), J3, J4, I6, B28.

## Update (2026-08-19)

The deferred compact follow-up editor (D5: static stand-in row + pointerdown/click focus handoff) was removed from this PR after a device test on iPhone showed the caret rendering above the composer after the first tap and a ~11 px footer shift when the real editor replaced the stand-in. The compact composer keeps the previously verified always-mounted behavior (#1263, #1381, #1771). D5 stays open as a follow-up once it can be verified on iOS.

Fixes: part of the mobile / iOS Safari performance program (verified sweep report in the bb thread; no single issue).


## Stack context

Layer 21 of 22 in the `bb/mobile-perf/*` stack (bottom → top: quick wins first, big rocks last).
- Prerequisite (layer below): `bb/mobile-perf/markdown-streaming-and-containment` (#1899).
- Next layer: `bb/mobile-perf/diff-and-file-preview` (#1901).
- Audit findings addressed: see title IDs. Review: approved-with-fixes; 5 review fix commit(s).
- Deliberately not done here: D5: reverted after an iPhone test showed a mispositioned caret and a footer shift; needs a device-verified handoff before it returns
- Reviewer notes / follow-ups: Device/iOS Simulator verification still needed for: D5 tap handoff (pointerdown-cancel + click focus with real TipTap; jsdom mocks PromptBoxInternal), E7 deep-content passive swipe | E1: ThreadActionsContextMenu/ProjectActionsContextMenu now branch on useIsCompactViewport, so crossing the compact breakpoint (tablet rotation, window resize) remounts every row's  | J4: diff patches now refetch after >60 s away from a thread; turn-summary details/file previews gc after 60 s without observers (by design per audit).
- Wire/contract: None. No server/daemon wire, protocol, CLI, plugin API, or DB changes; HOST_DAEMON_PROTOCOL_VERSION untouched. All changes are in apps/app.

> AGENT GENERATED: by Claude Opus 5

