### PR TITLE
Fetch diff-card context on demand; virtualize and cap the file preview (G2, G3)

### DIFF
--- a/apps/app/src/components/git-diff/GitDiffCardBody.tsx
+++ b/apps/app/src/components/git-diff/GitDiffCardBody.tsx
@@ -19,6 +19,7 @@ import { useRequirePierreWorkerPool } from "@/lib/pierre-worker-pool-gate";
 import { FileDiff as DiffView } from "@pierre/diffs/react";
 import { useIntersectionObserver } from "usehooks-ts";
 import { Button } from "@bb/shared-ui/button";
+import { usePointerCoarse } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import { usePierreLineSelectionActions } from "./PierreLineSelectionActions.js";
 import {
   getWrappedImageIndex,
@@ -104,6 +105,62 @@ type DiffFileEnrichmentState =
     }
   | { status: "unavailable" }
   | { status: "error" };
+
+/**
+ * The app-owned expand-context affordance for a text card. Full old/new file
+ * contents are only needed so `@pierre/diffs` can offer expand-context buttons
+ * between hunks; fetching them eagerly costs two whole-file reads and a second
+ * tokenize/render pass per card, which phones cannot afford. So the card
+ * renders from the patch alone and fetches the contents on demand (`request`),
+ * or during idle time on fine-pointer devices where the eager behavior is
+ * cheap enough to keep.
+ *
+ * - `unavailable`: no fetcher, no patch text, or the change kind has nothing
+ *   to expand (added/deleted files already carry every line) — render nothing.
+ * - `idle`: offer the "Expand context" action.
+ * - `loading` / `error`: show progress or a retry.
+ * - `ready`: pierre now owns expansion; the affordance retires.
+ */
+export type DiffContextExpansionStatus =
+  | "unavailable"
+  | "idle"
+  | "loading"
+  | "ready"
+  | "error";
+
+export interface DiffContextExpansionState {
+  status: DiffContextExpansionStatus;
+  request: () => void;
+}
+
+/**
+ * Change kinds whose patch omits lines the user might want to see. Added and
+ * deleted files carry the whole file in the patch, so there is no surrounding
+ * context to reach for.
+ */
+function canExpandContextForChangeKind(
+  changeKind: GitDiffFileChangeKind,
+): boolean {
+  return (
+    changeKind === "modified" ||
+    changeKind === "renamed" ||
+    changeKind === "copied"
+  );
+}
+
+/**
+ * Run `work` when the main thread is idle. Falls back to a short timeout where
+ * `requestIdleCallback` is unavailable so the fine-pointer auto-expansion still
+ * happens, just after the current paint.
+ */
+function scheduleIdleWork(work: () => void): () => void {
+  if (typeof window.requestIdleCallback === "function") {
+    const handle = window.requestIdleCallback(work, { timeout: 2_000 });
+    return () => window.cancelIdleCallback(handle);
+  }
+  const handle = window.setTimeout(work, 200);
+  return () => window.clearTimeout(handle);
+}
 
 function buildDiffFileContentPlan(
   fileDiff: ParsedGitDiffFile,
@@ -233,6 +290,8 @@ export interface GitDiffCardBodyState {
   loadDeletedDiff: () => void;
   /** The header's `+/-` byte delta for an image card; `null` for text cards. */
   imageSizeStat: DiffImageSizeStat | null;
+  /** On-demand full-file context for text cards; see {@link DiffContextExpansionState}. */
+  contextExpansion: DiffContextExpansionState;
 }
 
 /**
@@ -280,6 +339,11 @@ export function useGitDiffCardBody({
   const enrichmentStatusRef = useRef<DiffFileEnrichmentState["status"]>("idle");
   const [hasBodyEnteredViewport, setHasBodyEnteredViewport] = useState(false);
   const [hasLoadedDeletedDiff, setHasLoadedDeletedDiff] = useState(false);
+  // Bumped by each explicit (or idle-scheduled) expand-context request. Zero
+  // means nobody has asked for context yet; the fetch effect keys on the
+  // version so a retry after an error re-runs it.
+  const [contextRequestVersion, setContextRequestVersion] = useState(0);
+  const isPointerCoarse = usePointerCoarse();
   // Reset cached enrichment when the body swaps to different diff contents. Keep
   // the viewport-entry flag: an already-visible sentinel does not emit another
   // intersection change when only the diff hunk identity changes.
@@ -287,6 +351,7 @@ export function useGitDiffCardBody({
     enrichmentStatusRef.current = "idle";
     setEnrichment({ status: "idle" });
     setHasLoadedDeletedDiff(false);
+    setContextRequestVersion(0);
   }, [fileContentPlan.identity, isImageCard, isSvgCard]);
   useEffect(() => {
     if (isBodyVisible) {
@@ -301,11 +366,46 @@ export function useGitDiffCardBody({
     isDeletedFile && !isImageCard && !isSvgCard && !hasLoadedDeletedDiff;
   const shouldRenderDiffView =
     hasBodyEnteredViewport && !isRendering && !shouldGateDeletedDiff;
-  // Fire the fetch once the diff view is actually renderable. Effect deps
-  // deliberately exclude `onRequestFileContents` (we read the latest via the
-  // ref) so stable visibility doesn't re-trigger when the panel re-renders.
+  // Image and SVG cards cannot render anything without the file contents, so
+  // they fetch on viewport entry. Text cards render from the patch alone; their
+  // contents are only fetched once context expansion is requested.
+  const needsContentsToRender = isImageCard || isSvgCard;
+  const canExpandContext =
+    !needsContentsToRender &&
+    onRequestFileContents !== undefined &&
+    patchText !== undefined &&
+    fileDiff.hunks.length > 0 &&
+    canExpandContextForChangeKind(changeKind);
+  const shouldFetchContents =
+    shouldRenderDiffView &&
+    (needsContentsToRender || (canExpandContext && contextRequestVersion > 0));
+  // Fine-pointer devices keep the zero-click expand-context experience: once
+  // the card is renderable, request the contents during idle time. Coarse
+  // pointers (phones, tablets) wait for the explicit affordance.
   useEffect(() => {
-    if (!shouldRenderDiffView || enrichmentStatusRef.current !== "idle") {
+    if (
+      isPointerCoarse ||
+      !shouldRenderDiffView ||
+      !canExpandContext ||
+      contextRequestVersion > 0
+    ) {
+      return;
+    }
+    return scheduleIdleWork(() => {
+      setContextRequestVersion((version) => (version === 0 ? 1 : version));
+    });
+  }, [
+    canExpandContext,
+    contextRequestVersion,
+    isPointerCoarse,
+    shouldRenderDiffView,
+  ]);
+  // Fire the fetch once the diff view is actually renderable and the contents
+  // are wanted. Effect deps deliberately exclude `onRequestFileContents` (we
+  // read the latest via the ref) so stable visibility doesn't re-trigger when
+  // the panel re-renders.
+  useEffect(() => {
+    if (!shouldFetchContents || enrichmentStatusRef.current !== "idle") {
       return;
     }
     const fetcher = fetcherRef.current;
@@ -373,7 +473,33 @@ export function useGitDiffCardBody({
         enrichmentStatusRef.current = "idle";
       }
     };
-  }, [fileContentPlan, fileDiff, isSvgCard, patchText, shouldRenderDiffView]);
+  }, [
+    contextRequestVersion,
+    fileContentPlan,
+    fileDiff,
+    isSvgCard,
+    patchText,
+    shouldFetchContents,
+  ]);
+
+  const requestContextExpansion = useCallback(() => {
+    // A retry after a failed fetch must clear the terminal error first so the
+    // fetch effect sees an idle slot when the version bump re-runs it.
+    if (enrichmentStatusRef.current === "error") {
+      enrichmentStatusRef.current = "idle";
+      setEnrichment({ status: "idle" });
+    }
+    setContextRequestVersion((version) => version + 1);
+  }, []);
+  const contextExpansionStatus = getDiffContextExpansionStatus({
+    canExpandContext,
+    contextRequested: contextRequestVersion > 0,
+    enrichmentStatus: enrichment.status,
+  });
+  const contextExpansion = useMemo<DiffContextExpansionState>(
+    () => ({ status: contextExpansionStatus, request: requestContextExpansion }),
+    [contextExpansionStatus, requestContextExpansion],
+  );
 
   const enrichedFileDiff = useMemo<ParsedGitDiffFile>(() => {
     if (enrichment.status !== "ready" && enrichment.status !== "ready-svg") {
@@ -402,7 +528,38 @@ export function useGitDiffCardBody({
     shouldRenderDiffView,
     loadDeletedDiff,
     imageSizeStat,
+    contextExpansion,
   };
+}
+
+function getDiffContextExpansionStatus({
+  canExpandContext,
+  contextRequested,
+  enrichmentStatus,
+}: {
+  canExpandContext: boolean;
+  contextRequested: boolean;
+  enrichmentStatus: DiffFileEnrichmentState["status"];
+}): DiffContextExpansionStatus {
+  if (!canExpandContext) return "unavailable";
+  switch (enrichmentStatus) {
+    case "idle":
+      return contextRequested ? "loading" : "idle";
+    case "loading":
+      return "loading";
+    case "ready":
+      return "ready";
+    case "error":
+      return "error";
+    case "ready-image":
+    case "ready-svg":
+    case "unavailable":
+      return "unavailable";
+    default: {
+      const _exhaustive: never = enrichmentStatus;
+      return _exhaustive;
+    }
+  }
 }
 
 function GitDiffCardBodySkeleton() {
@@ -1268,6 +1425,7 @@ export function GitDiffCardBody({
     shouldGateDeletedDiff,
     shouldRenderDiffView,
     loadDeletedDiff,
+    contextExpansion,
   } = state;
   const codeTheme = useResolvedCodeThemePair();
   const fileDiffOptions = useMemo<DiffViewOptions>(
@@ -1320,12 +1478,69 @@ export function GitDiffCardBody({
           onSelectionAddToChat={onSelectionAddToChat}
         />
       ) : (
-        <GitDiffCardRawDiffBody
-          fileDiff={enrichedFileDiff}
-          fileDiffOptions={fileDiffOptions}
-          onSelectionAddToChat={onSelectionAddToChat}
-        />
+        <>
+          <GitDiffCardRawDiffBody
+            fileDiff={enrichedFileDiff}
+            fileDiffOptions={fileDiffOptions}
+            onSelectionAddToChat={onSelectionAddToChat}
+          />
+          <GitDiffCardContextExpansionFooter
+            contextExpansion={contextExpansion}
+            reservesCollapseGutter={reservesCollapseGutter}
+          />
+        </>
       )}
+    </div>
+  );
+}
+
+interface GitDiffCardContextExpansionFooterProps {
+  contextExpansion: DiffContextExpansionState;
+  reservesCollapseGutter: boolean;
+}
+
+/**
+ * The on-demand "Expand context" row under a text diff. Once the contents are
+ * in (`ready`) pierre renders its own expand buttons between hunks, so the row
+ * retires; when there is nothing to expand (`unavailable`) it never shows.
+ */
+function GitDiffCardContextExpansionFooter({
+  contextExpansion,
+  reservesCollapseGutter,
+}: GitDiffCardContextExpansionFooterProps) {
+  const { status, request } = contextExpansion;
+  if (status === "unavailable" || status === "ready") {
+    return null;
+  }
+  return (
+    <div className="flex items-center py-2 pl-2 pr-3 text-xs text-muted-foreground">
+      {reservesCollapseGutter ? (
+        <span aria-hidden className="w-8 shrink-0" />
+      ) : null}
+      <span className="pl-[1ch]">
+        {status === "loading" ? (
+          <span role="status">Loading context…</span>
+        ) : (
+          <>
+            {status === "error" ? (
+              <>
+                <span className="text-destructive">
+                  Couldn&apos;t load surrounding context.
+                </span>{" "}
+              </>
+            ) : null}
+            <Button
+              type="button"
+              variant="link"
+              size="sm"
+              className="h-auto p-0 text-xs underline underline-offset-4 hover:underline"
+              onClick={request}
+            >
+              {status === "error" ? "Retry" : "Expand context"}
+            </Button>
+          </>
+        )}
+      </span>
     </div>
   );
 }

--- a/apps/app/src/components/secondary-panel/FilePreview.stories.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.stories.tsx
@@ -142,6 +142,19 @@ const SAMPLE_IMAGE_URL =
     </svg>`,
   );
 
+// A generated source file well past the code-preview cap, so the story
+// exercises the capped prefix, the "Load full file" action, and virtualized
+// deep-link scrolling in one place.
+const LARGE_FILE_LINE_COUNT = 8_000;
+const LARGE_FILE_TARGET_LINE = 6_500;
+const SAMPLE_LARGE_TS = Array.from({ length: LARGE_FILE_LINE_COUNT }, (_, i) =>
+  i % 40 === 0
+    ? `export function block${i / 40}(input: number): number {`
+    : i % 40 === 39
+      ? "}"
+      : `  const step${i % 40} = input * ${i} + ${(i * 7) % 13}; // line ${i + 1}`,
+).join("\n");
+
 function noopOpenInEditor(path: string) {
   // Stories don't actually open anything; the prop is wired so the
   // open-in-editor affordance renders in the header.
@@ -226,6 +239,79 @@ export function Overview() {
             }}
           />
         </PreviewStage>
+      </StoryRow>
+      <StoryRow
+        label="large file (capped)"
+        hint={`${LARGE_FILE_LINE_COUNT.toLocaleString()} lines: only the leading prefix renders until "Load full file"; rows are virtualized inside the code viewport`}
+      >
+        <PreviewStage>
+          <FilePreview
+            path="src/generated/large.ts"
+            copyPath={copyPathFor("src/generated/large.ts")}
+            onOpenInEditor={noopOpenInEditor}
+            state={{
+              kind: "ready",
+              lineRange: null,
+              textPreviewKind: null,
+              file: {
+                cacheKey: "story:large.ts",
+                name: "large.ts",
+                contents: SAMPLE_LARGE_TS,
+                lang: "ts",
+              },
+            }}
+          />
+        </PreviewStage>
+      </StoryRow>
+      <StoryRow
+        label="large file (line link past the cap)"
+        hint={`Opened at line ${LARGE_FILE_TARGET_LINE.toLocaleString()}: the whole file renders and the virtualized viewport scrolls the target into view`}
+      >
+        <PreviewStage>
+          <FilePreview
+            path="src/generated/large.ts"
+            copyPath={copyPathFor("src/generated/large.ts")}
+            onOpenInEditor={noopOpenInEditor}
+            state={{
+              kind: "ready",
+              lineRange: {
+                startLineNumber: LARGE_FILE_TARGET_LINE,
+                endLineNumber: LARGE_FILE_TARGET_LINE,
+              },
+              textPreviewKind: null,
+              file: {
+                cacheKey: "story:large.ts",
+                name: "large.ts",
+                contents: SAMPLE_LARGE_TS,
+                lang: "ts",
+              },
+            }}
+          />
+        </PreviewStage>
+      </StoryRow>
+      <StoryRow
+        label="code in a content-sized scroller"
+        hint="Skill detail embeds headerless code previews in a max-height scroller with no fixed height; the code viewport grows with its content and the outer box scrolls"
+      >
+        <div className="w-full max-w-[640px] bg-background px-4 py-2">
+          <div className="max-h-[300px] overflow-y-auto overscroll-contain rounded-md border border-border">
+            <FilePreview
+              path="skills/writing-voice/scripts/lint.ts"
+              headerMode="none"
+              state={{
+                kind: "ready",
+                lineRange: null,
+                textPreviewKind: null,
+                file: {
+                  cacheKey: "story:skill-script",
+                  name: "lint.ts",
+                  contents: SAMPLE_LARGE_TS.split("\n").slice(0, 400).join("\n"),
+                  lang: "ts",
+                },
+              }}
+            />
+          </div>
+        </div>
       </StoryRow>
       <StoryRow
         label="deleted file"

--- a/apps/app/src/components/secondary-panel/FilePreview.test.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.test.tsx
@@ -10,6 +10,7 @@ import {
 import { act, type ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  FILE_PREVIEW_CODE_MAX_LINES,
   FilePreview,
   buildCsvPreviewData,
   getCsvTruncationNote,
@@ -156,6 +157,8 @@ vi.mock("@pierre/diffs/react", async () => {
       });
     },
     WorkerPoolContext: React.createContext(undefined),
+    useWorkerPool: () => pierreMock.workerPool,
+    VirtualizerContext: React.createContext(undefined),
   };
 });
 
@@ -348,9 +351,16 @@ describe("FilePreview", () => {
     );
 
     const pierreFile = await screen.findByTestId("pierre-file");
+    // The code view scrolls its own virtualized viewport (which sits at the
+    // origin in jsdom), not the surrounding panel scroller.
+    const codeViewport = scrollViewport.querySelector<HTMLElement>(
+      "[data-file-preview-code-viewport]",
+    );
+    expect(codeViewport).not.toBeNull();
     await waitFor(() => {
-      expect(scrollViewport.scrollTop).toBe(577);
+      expect(codeViewport?.scrollTop).toBe(727);
     });
+    expect(scrollViewport.scrollTop).toBe(100);
     expect(
       pierreFile.shadowRoot?.querySelector<HTMLElement>("[data-code]")
         ?.scrollLeft,
@@ -362,7 +372,7 @@ describe("FilePreview", () => {
     ).toBe(true);
   });
 
-  it("remounts the code view when the highlighted file cache resolves", async () => {
+  it("keeps a single code view mount when the highlighted file cache resolves", async () => {
     const cacheKey =
       "file-preview:/api/v1/projects/proj/files/content:thread-read-state.ts";
 
@@ -383,9 +393,9 @@ describe("FilePreview", () => {
       />,
     );
 
-    const firstInstanceId = Number(
-      (await screen.findByTestId("pierre-file")).dataset.instanceId,
-    );
+    const pierreFile = await screen.findByTestId("pierre-file");
+    const firstInstanceId = Number(pierreFile.dataset.instanceId);
+    const renderCountBeforeHighlight = Number(pierreFile.dataset.renderCount);
 
     act(() => {
       pierreMock.state.cachedFileKeys.add(cacheKey);
@@ -394,11 +404,115 @@ describe("FilePreview", () => {
       );
     });
 
+    // Pierre repaints the highlighted AST in place; a React remount would
+    // throw away its DOM (and the user's scroll position) for nothing.
     await waitFor(() => {
-      expect(Number(screen.getByTestId("pierre-file").dataset.instanceId)).toBe(
-        firstInstanceId + 1,
-      );
+      expect(
+        Number(screen.getByTestId("pierre-file").dataset.renderCount),
+      ).toBeGreaterThan(renderCountBeforeHighlight);
     });
+    expect(Number(screen.getByTestId("pierre-file").dataset.instanceId)).toBe(
+      firstInstanceId,
+    );
+  });
+
+  it("caps oversized code previews to a leading prefix until the full file is requested", async () => {
+    const totalLineCount = FILE_PREVIEW_CODE_MAX_LINES + 1_500;
+    const contents = Array.from(
+      { length: totalLineCount },
+      (_, index) => `line ${index + 1}`,
+    ).join("\n");
+
+    render(
+      <FilePreview
+        headerMode="none"
+        path="src/generated.ts"
+        state={{
+          kind: "ready",
+          file: {
+            cacheKey: "file-preview:generated",
+            name: "generated.ts",
+            contents,
+          },
+          lineRange: null,
+          textPreviewKind: null,
+        }}
+      />,
+    );
+
+    await screen.findByTestId("pierre-file");
+    expect(pierreMock.state.lastFile?.contents.split("\n")).toHaveLength(
+      FILE_PREVIEW_CODE_MAX_LINES,
+    );
+    // The capped prefix must not share the full file's highlight cache slot.
+    expect(pierreMock.state.lastFile?.cacheKey).toBe(
+      "file-preview:generated:head",
+    );
+    expect(
+      screen.getByText(
+        `Showing the first ${FILE_PREVIEW_CODE_MAX_LINES.toLocaleString()} of ${totalLineCount.toLocaleString()} lines.`,
+      ),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Load full file" }));
+
+    await waitFor(() => {
+      expect(pierreMock.state.lastFile?.contents).toBe(contents);
+    });
+    expect(pierreMock.state.lastFile?.cacheKey).toBe("file-preview:generated");
+    expect(screen.queryByRole("button", { name: "Load full file" })).toBeNull();
+  });
+
+  it("caps code previews by size even when they have few lines", () => {
+    const longLine = "x".repeat(200_000);
+    const contents = [longLine, longLine, longLine, "tail"].join("\n");
+
+    render(
+      <FilePreview
+        headerMode="none"
+        path="assets/blob.txt"
+        state={{
+          kind: "ready",
+          file: { name: "blob.txt", contents },
+          lineRange: null,
+          textPreviewKind: null,
+        }}
+      />,
+    );
+
+    // 512 KB budget: two 200k-char lines fit, the third would exceed it.
+    expect(pierreMock.state.lastFile?.contents).toBe(
+      [longLine, longLine].join("\n"),
+    );
+    expect(screen.getByRole("button", { name: "Load full file" })).toBeTruthy();
+  });
+
+  it("shows the whole file when a line link points past the capped prefix", async () => {
+    const totalLineCount = FILE_PREVIEW_CODE_MAX_LINES + 20;
+    const contents = Array.from(
+      { length: totalLineCount },
+      (_, index) => `line ${index + 1}`,
+    ).join("\n");
+
+    render(
+      <FilePreview
+        headerMode="none"
+        path="src/generated.ts"
+        state={{
+          kind: "ready",
+          file: { name: "generated.ts", contents },
+          lineRange: {
+            startLineNumber: FILE_PREVIEW_CODE_MAX_LINES + 10,
+            endLineNumber: FILE_PREVIEW_CODE_MAX_LINES + 10,
+          },
+          textPreviewKind: null,
+        }}
+      />,
+    );
+
+    await screen.findByTestId("pierre-file");
+    expect(pierreMock.state.lastFile?.contents).toBe(contents);
+    expect(screen.queryByRole("button", { name: "Load full file" })).toBeNull();
   });
 
   it("toggles source line wrap from the header button", async () => {

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -8,11 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
-import {
-  File as PierreFile,
-  VirtualizerContext,
-  useWorkerPool,
-} from "@pierre/diffs/react";
+import { File as PierreFile, VirtualizerContext } from "@pierre/diffs/react";
 import type { FileOptions } from "@pierre/diffs/react";
 import {
   DIFFS_TAG_NAME,

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -1,17 +1,25 @@
 import {
   type CSSProperties,
+  type ReactNode,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
-import { File as PierreFile } from "@pierre/diffs/react";
+import {
+  File as PierreFile,
+  VirtualizerContext,
+  useWorkerPool,
+} from "@pierre/diffs/react";
 import type { FileOptions } from "@pierre/diffs/react";
 import {
   DIFFS_TAG_NAME,
+  Virtualizer as PierreVirtualizer,
   type SelectedLineRange,
   type SupportedLanguages,
+  type VirtualFileMetrics,
 } from "@pierre/diffs";
 import type { UrlTransform } from "react-markdown";
 import { Button } from "@bb/shared-ui/button";
@@ -214,14 +222,102 @@ type IframeLoadState = "loading" | "loaded" | "error";
 const CSV_PREVIEW_MAX_COLUMNS = 100;
 const CSV_PREVIEW_MAX_ROWS = 500;
 
+/**
+ * Code previews above either budget render only a leading prefix until the
+ * user asks for the whole file. Tokenizing and laying out a 20k-line source
+ * file is what stalls iOS Safari; the prefix keeps the first paint bounded and
+ * the full file stays one tap away.
+ */
+export const FILE_PREVIEW_CODE_MAX_LINES = 5_000;
+export const FILE_PREVIEW_CODE_MAX_CHARS = 512 * 1024;
+
+const FILE_PREVIEW_CODE_LINE_HEIGHT_PX = 18;
+const FILE_PREVIEW_CODE_GAP_BLOCK_PX = 16;
+
 const FILE_PREVIEW_VIEW_STYLE = {
   "--diffs-font-size": "12px",
-  "--diffs-line-height": "18px",
+  "--diffs-line-height": `${FILE_PREVIEW_CODE_LINE_HEIGHT_PX}px`,
   // Pierre paints its theme bg inside this gap, so the top breathing room of
   // the code body lives on Pierre's bg — not on the panel's bg-background.
   // Without this, the gap above Pierre would show a visible bg-color seam.
-  "--diffs-gap-block": "16px",
+  "--diffs-gap-block": `${FILE_PREVIEW_CODE_GAP_BLOCK_PX}px`,
 } as CSSProperties;
+
+// Pierre's virtualizer estimates row positions from these before it measures
+// them; they mirror the CSS variables above so the first layout guess is exact
+// in `scroll` overflow mode (fixed-height rows) and close in `wrap` mode.
+const FILE_PREVIEW_VIRTUAL_FILE_METRICS: VirtualFileMetrics = {
+  hunkLineCount: 50,
+  lineHeight: FILE_PREVIEW_CODE_LINE_HEIGHT_PX,
+  diffHeaderHeight: 0,
+  spacing: FILE_PREVIEW_CODE_GAP_BLOCK_PX,
+};
+
+export interface FilePreviewCodeTruncation {
+  /** The rendered prefix, cut at a line boundary. */
+  contents: string;
+  renderedLineCount: number;
+  totalLineCount: number;
+}
+
+// FNV-1a over the contents; only used to derive a mount key for previews
+// whose caller did not supply a `cacheKey`.
+function hashFilePreviewContents(contents: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < contents.length; index += 1) {
+    hash ^= contents.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return `${contents.length}:${(hash >>> 0).toString(36)}`;
+}
+
+function countLines(contents: string): number {
+  if (contents.length === 0) return 0;
+  let count = 1;
+  for (let index = contents.indexOf("\n"); index !== -1; ) {
+    count += 1;
+    index = contents.indexOf("\n", index + 1);
+  }
+  return contents.endsWith("\n") ? count - 1 : count;
+}
+
+/**
+ * Decide whether a code preview exceeds {@link FILE_PREVIEW_CODE_MAX_LINES} or
+ * {@link FILE_PREVIEW_CODE_MAX_CHARS} and, if so, return the leading prefix
+ * that fits both budgets. Returns `null` when the whole file fits.
+ */
+export function truncateFilePreviewCode(
+  contents: string,
+): FilePreviewCodeTruncation | null {
+  const totalLineCount = countLines(contents);
+  if (
+    contents.length <= FILE_PREVIEW_CODE_MAX_CHARS &&
+    totalLineCount <= FILE_PREVIEW_CODE_MAX_LINES
+  ) {
+    return null;
+  }
+  let renderedLineCount = 0;
+  let cutIndex = 0;
+  for (
+    let lineStart = 0;
+    lineStart < contents.length &&
+    renderedLineCount < FILE_PREVIEW_CODE_MAX_LINES;
+  ) {
+    const newlineIndex = contents.indexOf("\n", lineStart);
+    const lineEnd = newlineIndex === -1 ? contents.length : newlineIndex;
+    if (lineEnd > FILE_PREVIEW_CODE_MAX_CHARS && renderedLineCount > 0) {
+      break;
+    }
+    renderedLineCount += 1;
+    cutIndex = lineEnd;
+    lineStart = lineEnd + 1;
+  }
+  return {
+    contents: contents.slice(0, cutIndex),
+    renderedLineCount,
+    totalLineCount,
+  };
+}
 
 // `--md-content-w` tells MarkdownPreview the surrounding text-column width so
 // narrow tables sit flush with the prose on the left instead of centering in
@@ -505,8 +601,12 @@ export function FilePreview({
     state.kind === "ready" &&
     state.textPreviewKind === "csv" &&
     bodyViewMode === "preview";
-  const usesFullHeightLayout = usesIframeLayout || usesCsvPreviewLayout;
-  const usesContentHeightLayout = usesCodeLayout || usesMarkdownPreviewLayout;
+  // The code view owns its own scroller too: pierre's virtualizer needs the
+  // scroll container to be the code viewport so it can render only the rows
+  // near it, which the outer panel scroller (shared with the header) cannot be.
+  const usesFullHeightLayout =
+    usesIframeLayout || usesCsvPreviewLayout || usesCodeLayout;
+  const usesContentHeightLayout = usesMarkdownPreviewLayout;
 
   // Establish a `@container/page` scope so MarkdownPreview's `100cqw`-based
   // table breakout sizes against this panel, not the viewport.
@@ -1157,7 +1257,103 @@ function findPreviewTargetLine(
   return null;
 }
 
+function findVirtualizedCodeViewport(
+  container: HTMLElement,
+): HTMLElement | null {
+  return container.querySelector<HTMLElement>(
+    "[data-file-preview-code-viewport]",
+  );
+}
+
+/**
+ * Nudge the virtualized code viewport toward `lineNumber` when that row is not
+ * realized yet. With rendered rows in hand the distance is measured from the
+ * nearest one (rows are at least one line tall, so the step never overshoots
+ * in `wrap` mode); with none rendered the offset is estimated from the fixed
+ * line metrics. Each call moves at most to the estimate; the caller retries on
+ * the next frame once pierre has rendered the new window.
+ */
+function approachVirtualizedTargetLine(
+  container: HTMLElement,
+  lineNumber: number,
+) {
+  const viewport = findVirtualizedCodeViewport(container);
+  if (viewport === null) return;
+  const viewportRect = viewport.getBoundingClientRect();
+  const centerOffset = viewportRect.height / 2;
+  const renderedBounds = getRenderedPreviewLineBounds(container);
+  if (renderedBounds === null) {
+    const estimatedTop =
+      FILE_PREVIEW_CODE_GAP_BLOCK_PX +
+      (lineNumber - 1) * FILE_PREVIEW_CODE_LINE_HEIGHT_PX;
+    viewport.scrollTop = Math.max(0, estimatedTop - centerOffset);
+    return;
+  }
+  const { firstLineNumber, firstTop, lastLineNumber, lastBottom } =
+    renderedBounds;
+  if (lineNumber > lastLineNumber) {
+    const distance =
+      lastBottom -
+      viewportRect.top +
+      (lineNumber - lastLineNumber - 1) * FILE_PREVIEW_CODE_LINE_HEIGHT_PX;
+    viewport.scrollTop += Math.max(0, distance - centerOffset);
+  } else if (lineNumber < firstLineNumber) {
+    const distance =
+      viewportRect.top -
+      firstTop +
+      (firstLineNumber - lineNumber) * FILE_PREVIEW_CODE_LINE_HEIGHT_PX;
+    viewport.scrollTop = Math.max(
+      0,
+      viewport.scrollTop - distance - centerOffset,
+    );
+  }
+}
+
+interface RenderedPreviewLineBounds {
+  firstLineNumber: number;
+  firstTop: number;
+  lastLineNumber: number;
+  lastBottom: number;
+}
+
+function getRenderedPreviewLineBounds(
+  container: HTMLElement,
+): RenderedPreviewLineBounds | null {
+  let bounds: RenderedPreviewLineBounds | null = null;
+  for (const root of getPreviewTargetRoots(container)) {
+    for (const line of root.querySelectorAll<HTMLElement>(
+      "[data-line][data-line-index]",
+    )) {
+      const lineNumber = Number(line.dataset.line);
+      if (!Number.isFinite(lineNumber)) continue;
+      const rect = line.getBoundingClientRect();
+      if (bounds === null) {
+        bounds = {
+          firstLineNumber: lineNumber,
+          firstTop: rect.top,
+          lastLineNumber: lineNumber,
+          lastBottom: rect.bottom,
+        };
+        continue;
+      }
+      if (lineNumber < bounds.firstLineNumber) {
+        bounds.firstLineNumber = lineNumber;
+        bounds.firstTop = rect.top;
+      }
+      if (lineNumber > bounds.lastLineNumber) {
+        bounds.lastLineNumber = lineNumber;
+        bounds.lastBottom = rect.bottom;
+      }
+    }
+  }
+  return bounds;
+}
+
 function findPreviewScrollViewport(container: HTMLElement): HTMLElement | null {
+  const virtualizedViewport = findVirtualizedCodeViewport(container);
+  if (virtualizedViewport !== null) {
+    return virtualizedViewport;
+  }
   const view = container.ownerDocument.defaultView;
   if (view === null) return null;
 
@@ -1260,6 +1456,17 @@ function FilePreviewCode({
   const [workerPoolStats, setWorkerPoolStats] =
     useState<FilePreviewWorkerPoolStats | null>(null);
   const [, rerenderAfterWorkerPoolChange] = useState(0);
+  const fileIdentity = file.cacheKey ?? file.name;
+  const truncation = useMemo(
+    () => truncateFilePreviewCode(file.contents),
+    [file.contents],
+  );
+  // Which file the user asked to see in full. Keyed by identity rather than a
+  // boolean so opening a different large file goes back to the capped view
+  // without an effect resetting state.
+  const [fullFileRequestedFor, setFullFileRequestedFor] = useState<
+    string | null
+  >(null);
   const buildSelectionText = useCallback(
     (range: SelectedLineRange) =>
       buildFilePreviewLineSelectionText({
@@ -1318,6 +1525,65 @@ function FilePreviewCode({
         };
   }, [lineRange, lineSelectionActions.selectedRange]);
   const targetLineNumber = selectedLines?.start ?? null;
+  // A deep link past the capped prefix is an implicit request for the whole
+  // file: the target line has to exist in the DOM to be scrolled to.
+  const showsFullFile =
+    truncation === null ||
+    fullFileRequestedFor === fileIdentity ||
+    (targetLineNumber !== null &&
+      targetLineNumber > truncation.renderedLineCount);
+  const renderedFile = useMemo<FilePreviewFile>(() => {
+    if (showsFullFile || truncation === null) {
+      return file;
+    }
+    return {
+      ...file,
+      // The worker highlight cache is keyed by `cacheKey`; the capped prefix
+      // must not collide with the full file's entry.
+      cacheKey:
+        file.cacheKey === undefined ? undefined : `${file.cacheKey}:head`,
+      contents: truncation.contents,
+    };
+  }, [file, showsFullFile, truncation]);
+  // Pierre's virtualized file instance keeps the contents it was hydrated
+  // with (`VirtualizedFile.render` ignores a later `file`), so a content swap
+  // — the capped prefix giving way to the full file, or a refetch — needs a
+  // fresh mount. Callers that supply a `cacheKey` already fold the content
+  // hash into it; otherwise hash here.
+  const renderedFileMountKey = useMemo(
+    () =>
+      renderedFile.cacheKey ??
+      `${renderedFile.name}:${hashFilePreviewContents(renderedFile.contents)}`,
+    [renderedFile],
+  );
+  // "Load full file" remounts pierre with the whole file; carry the reader's
+  // scroll offset across so the prefix they were looking at stays put.
+  const pendingViewportScrollTopRef = useRef<number | null>(null);
+  const handleLoadFullFile = () => {
+    const viewport =
+      containerRef.current === null
+        ? null
+        : findVirtualizedCodeViewport(containerRef.current);
+    pendingViewportScrollTopRef.current = viewport?.scrollTop ?? null;
+    setFullFileRequestedFor(fileIdentity);
+  };
+  useLayoutEffect(() => {
+    const scrollTop = pendingViewportScrollTopRef.current;
+    if (scrollTop === null) return;
+    pendingViewportScrollTopRef.current = null;
+    const viewport =
+      containerRef.current === null
+        ? null
+        : findVirtualizedCodeViewport(containerRef.current);
+    if (viewport === null) return;
+    viewport.scrollTop = scrollTop;
+    // The virtualizer sizes the fresh instance on its next frame; reapply once
+    // that height exists so the offset is not clamped away.
+    const frame = window.requestAnimationFrame(() => {
+      viewport.scrollTop = scrollTop;
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [renderedFileMountKey]);
 
   useEffect(() => {
     if (!workerPool) {
@@ -1349,12 +1615,13 @@ function FilePreviewCode({
     workerPoolStats?.managerState !== "initialized" &&
     workerPoolStats?.workersFailed !== true;
   // Pierre can mount an empty zero-height <pre> while its worker highlighter is
-  // still initializing, and the imperative instance does not always recover
-  // when the highlighted AST is cached later. Wait for readiness, then remount
-  // once the cache entry for this exact file appears so syntax highlighting
-  // replaces the plain-text fallback.
+  // still initializing, so the code view waits for pool readiness. After that
+  // a single mount is enough: pierre paints the plain-text AST first and
+  // repaints in place when the worker delivers the highlighted one. That
+  // repaint swaps the line elements, so the target-line effect below re-runs
+  // when the highlight cache entry for this file appears.
   const workerHighlightCacheState =
-    workerPool?.getFileResultCache(file) !== undefined
+    workerPool?.getFileResultCache(renderedFile) !== undefined
       ? "highlighted"
       : "plain";
 
@@ -1385,8 +1652,13 @@ function FilePreviewCode({
         return;
       }
 
+      // The virtualizer only realizes rows near the scroll window, so a
+      // target outside it is not in the DOM yet. Move the viewport toward the
+      // line's estimated offset and let pierre render that window before the
+      // next attempt.
+      approachVirtualizedTargetLine(container, targetLineNumber);
       attempts += 1;
-      if (attempts < 8) {
+      if (attempts < FILE_PREVIEW_TARGET_LINE_MAX_ATTEMPTS) {
         scheduleRetry();
       }
     }
@@ -1401,8 +1673,8 @@ function FilePreviewCode({
       }
     };
   }, [
-    file.contents,
-    file.name,
+    renderedFile.contents,
+    renderedFile.name,
     shouldWaitForWorkerPool,
     targetLineNumber,
     workerHighlightCacheState,
@@ -1415,7 +1687,7 @@ function FilePreviewCode({
   return (
     <div
       ref={containerRef}
-      className="min-h-0 flex-auto"
+      className="flex min-h-0 flex-1 flex-col"
       style={FILE_PREVIEW_VIEW_STYLE}
       data-file-preview-line-number={targetLineNumber ?? undefined}
       onPointerDownCapture={lineSelectionActions.onPointerDownCapture}
@@ -1423,15 +1695,86 @@ function FilePreviewCode({
       onPointerUpCapture={lineSelectionActions.onPointerUpCapture}
     >
       <PierreWorkerPoolBoundary>
-        <PierreFile
-          key={`${file.cacheKey ?? file.name}:${workerHighlightCacheState}`}
-          disableWorkerPool={workerPoolStats?.workersFailed === true}
-          file={file}
-          options={options}
-          selectedLines={selectedLines}
-        />
+        <FilePreviewCodeViewport>
+          <PierreFile
+            key={renderedFileMountKey}
+            disableWorkerPool={workerPoolStats?.workersFailed === true}
+            file={renderedFile}
+            metrics={FILE_PREVIEW_VIRTUAL_FILE_METRICS}
+            options={options}
+            selectedLines={selectedLines}
+          />
+          {truncation !== null && !showsFullFile ? (
+            <FilePreviewCodeTruncationNotice
+              truncation={truncation}
+              onLoadFullFile={handleLoadFullFile}
+            />
+          ) : null}
+        </FilePreviewCodeViewport>
       </PierreWorkerPoolBoundary>
       {lineSelectionActions.menu}
+    </div>
+  );
+}
+
+const FILE_PREVIEW_TARGET_LINE_MAX_ATTEMPTS = 40;
+
+/**
+ * The code view's own scroll container, registered as pierre's virtualizer
+ * root so `PierreFile` mounts a `VirtualizedFile` that renders only the rows
+ * near the viewport. This mirrors `@pierre/diffs/react`'s `<Virtualizer>`,
+ * inlined so the scroller carries a ref and a data marker the target-line
+ * scrolling can find without walking the tree by class name.
+ */
+function FilePreviewCodeViewport({ children }: { children: ReactNode }) {
+  const [virtualizer] = useState(() =>
+    typeof window === "undefined" ? undefined : new PierreVirtualizer(),
+  );
+  const viewportRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (node !== null) {
+        virtualizer?.setup(node);
+      } else {
+        virtualizer?.cleanUp();
+      }
+    },
+    [virtualizer],
+  );
+  return (
+    <VirtualizerContext.Provider value={virtualizer}>
+      <div
+        ref={viewportRef}
+        className="min-h-0 flex-1 overflow-y-auto"
+        data-file-preview-code-viewport
+      >
+        <div>{children}</div>
+      </div>
+    </VirtualizerContext.Provider>
+  );
+}
+
+function FilePreviewCodeTruncationNotice({
+  truncation,
+  onLoadFullFile,
+}: {
+  truncation: FilePreviewCodeTruncation;
+  onLoadFullFile: () => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 px-4 py-3 text-xs text-muted-foreground">
+      <span>
+        Showing the first {truncation.renderedLineCount.toLocaleString()} of{" "}
+        {truncation.totalLineCount.toLocaleString()} lines.
+      </span>
+      <Button
+        type="button"
+        variant="link"
+        size="sm"
+        className="h-auto p-0 text-xs underline underline-offset-4 hover:underline"
+        onClick={onLoadFullFile}
+      >
+        Load full file
+      </Button>
     </div>
   );
 }

--- a/apps/app/src/components/secondary-panel/GitDiffCard.stories.tsx
+++ b/apps/app/src/components/secondary-panel/GitDiffCard.stories.tsx
@@ -298,8 +298,9 @@ export function Overview() {
 // Aligned-fixture builders. Each takes a real-looking source file plus an
 // edit list and produces the FileContents pair AND the unified diff that
 // describes the change between them. Once GitDiffCard tags the file lines
-// onto the parsed fileDiff, the library shows expand-context buttons in
-// every gap between hunks.
+// onto the parsed fileDiff (during idle time on a fine pointer, or after the
+// card's "Expand context" action on touch devices), the library shows
+// expand-context buttons in every gap between hunks.
 // ---------------------------------------------------------------------------
 
 interface AlignedDiffEdit {

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.panelGate.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanelTabContent.panelGate.test.tsx
@@ -23,10 +23,14 @@ vi.mock("@/lib/sdk", () => ({
 }));
 
 // The preview body is not under test; keep pierre out of jsdom.
-vi.mock("@pierre/diffs/react", () => ({
-  File: () => null,
-  useWorkerPool: () => null,
-}));
+vi.mock("@pierre/diffs/react", async () => {
+  const React = await import("react");
+  return {
+    File: () => null,
+    VirtualizerContext: React.createContext(undefined),
+    useWorkerPool: () => null,
+  };
+});
 
 const ENVIRONMENT_ID = "env-1";
 const TARGET: WorkspaceDiffTarget = { type: "all", mergeBaseBranch: "main" };

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.contextExpansion.test.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.contextExpansion.test.tsx
@@ -1,0 +1,284 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DiffFileEntry } from "@bb/server-contract";
+import { POINTER_COARSE_QUERY } from "@bb/shared-ui/hooks/use-pointer-coarse";
+import type {
+  DiffFileContentsResult,
+  RequestDiffFileContents,
+} from "@/components/git-diff/GitDiffCardBody";
+import { DiffFileCard } from "./DiffFileCard";
+
+// The real `@pierre/diffs` renderer needs a worker pool and shadow-DOM layout
+// that jsdom cannot provide. Only the data layer is under test here: which
+// `fileDiff` reaches the renderer and when the file contents are requested.
+const diffViewMock = vi.hoisted(() => ({
+  renderedFileDiffs: [] as unknown[],
+}));
+
+vi.mock("@pierre/diffs/react", () => ({
+  FileDiff: ({ fileDiff }: { fileDiff: unknown }) => {
+    diffViewMock.renderedFileDiffs.push(fileDiff);
+    return <div data-testid="diff-view" />;
+  },
+}));
+
+const MODIFIED_PATCH = [
+  "diff --git a/src/file.ts b/src/file.ts",
+  "index 1111111..2222222 100644",
+  "--- a/src/file.ts",
+  "+++ b/src/file.ts",
+  "@@ -2,3 +2,3 @@",
+  " const a = 1;",
+  "-const b = 2;",
+  "+const b = 3;",
+  " const c = 4;",
+  "",
+].join("\n");
+
+const OLD_FILE_CONTENTS = [
+  "// header",
+  "const a = 1;",
+  "const b = 2;",
+  "const c = 4;",
+  "// footer",
+  "",
+].join("\n");
+const NEW_FILE_CONTENTS = OLD_FILE_CONTENTS.replace(
+  "const b = 2;",
+  "const b = 3;",
+);
+
+const ADDED_PATCH = [
+  "diff --git a/src/new.ts b/src/new.ts",
+  "new file mode 100644",
+  "index 0000000..2222222",
+  "--- /dev/null",
+  "+++ b/src/new.ts",
+  "@@ -0,0 +1,2 @@",
+  "+const a = 1;",
+  "+const b = 2;",
+  "",
+].join("\n");
+
+function buildEntry(overrides: Partial<DiffFileEntry> = {}): DiffFileEntry {
+  return {
+    path: "src/file.ts",
+    previousPath: null,
+    changeKind: "modified",
+    additions: 1,
+    deletions: 1,
+    binary: false,
+    origin: "tracked",
+    loadMode: "auto",
+    ...overrides,
+  };
+}
+
+function textResult(contents: string, name: string): DiffFileContentsResult {
+  return { kind: "text", file: { name, contents } };
+}
+
+const intersectionCallbacks = new Set<IntersectionObserverCallback>();
+
+function revealCardBodies() {
+  act(() => {
+    for (const callback of intersectionCallbacks) {
+      callback(
+        [
+          {
+            isIntersecting: true,
+            intersectionRatio: 1,
+          } as IntersectionObserverEntry,
+        ],
+        { thresholds: [0] } as unknown as IntersectionObserver,
+      );
+    }
+  });
+}
+
+function stubPointer(kind: "coarse" | "fine") {
+  vi.spyOn(window, "matchMedia").mockImplementation((query: string) => ({
+    matches: kind === "coarse" && query === POINTER_COARSE_QUERY,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }));
+}
+
+function renderModifiedCard(onRequestFileContents: RequestDiffFileContents) {
+  render(
+    <DiffFileCard
+      entry={buildEntry()}
+      diffViewOptions={{}}
+      isCollapsed={false}
+      onToggleCollapsed={() => {}}
+      patchState={{ status: "loaded", patch: MODIFIED_PATCH, truncated: false }}
+      onLoadPatch={() => {}}
+      onRetry={() => {}}
+      onRequestFileContents={onRequestFileContents}
+    />,
+  );
+}
+
+describe("DiffFileCard context expansion", () => {
+  beforeEach(() => {
+    diffViewMock.renderedFileDiffs.length = 0;
+    intersectionCallbacks.clear();
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class IntersectionObserverMock {
+        readonly thresholds = [0];
+        constructor(private readonly callback: IntersectionObserverCallback) {
+          intersectionCallbacks.add(this.callback);
+        }
+        observe() {}
+        unobserve() {}
+        disconnect() {
+          intersectionCallbacks.delete(this.callback);
+        }
+      },
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("renders a modified text diff from the patch alone on coarse pointers and fetches contents only on demand", async () => {
+    stubPointer("coarse");
+    const onRequestFileContents = vi.fn<RequestDiffFileContents>(
+      async (path, side) =>
+        textResult(
+          side === "old" ? OLD_FILE_CONTENTS : NEW_FILE_CONTENTS,
+          path,
+        ),
+    );
+
+    renderModifiedCard(onRequestFileContents);
+    revealCardBodies();
+
+    await screen.findByTestId("diff-view");
+    const expandButton = await screen.findByRole("button", {
+      name: "Expand context",
+    });
+    // Nothing was fetched just because the card scrolled into view.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    expect(onRequestFileContents).not.toHaveBeenCalled();
+    const patchOnlyRenderCount = diffViewMock.renderedFileDiffs.length;
+    expect(patchOnlyRenderCount).toBeGreaterThan(0);
+
+    fireEvent.click(expandButton);
+
+    await waitFor(() => {
+      expect(onRequestFileContents).toHaveBeenCalledTimes(2);
+    });
+    expect(onRequestFileContents).toHaveBeenCalledWith("src/file.ts", "old");
+    expect(onRequestFileContents).toHaveBeenCalledWith("src/file.ts", "new");
+    // Once the contents are in, pierre owns expansion and the affordance goes.
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "Expand context" }),
+      ).toBeNull();
+    });
+    // The renderer received the context-enriched diff, which is a different
+    // parse than the patch-only one it started with.
+    const lastRenderedFileDiff = diffViewMock.renderedFileDiffs.at(-1);
+    expect(lastRenderedFileDiff).not.toBe(diffViewMock.renderedFileDiffs[0]);
+  });
+
+  it("requests the contents during idle time on fine pointers without an explicit action", async () => {
+    stubPointer("fine");
+    const onRequestFileContents = vi.fn<RequestDiffFileContents>(
+      async (path, side) =>
+        textResult(
+          side === "old" ? OLD_FILE_CONTENTS : NEW_FILE_CONTENTS,
+          path,
+        ),
+    );
+
+    renderModifiedCard(onRequestFileContents);
+    revealCardBodies();
+
+    await waitFor(() => {
+      expect(onRequestFileContents).toHaveBeenCalledTimes(2);
+    });
+    expect(
+      screen.queryByRole("button", { name: "Expand context" }),
+    ).toBeNull();
+  });
+
+  it("offers a retry when the context fetch fails", async () => {
+    stubPointer("coarse");
+    let shouldFail = true;
+    const onRequestFileContents = vi.fn<RequestDiffFileContents>(
+      async (path, side) => {
+        if (shouldFail) {
+          throw new Error("offline");
+        }
+        return textResult(
+          side === "old" ? OLD_FILE_CONTENTS : NEW_FILE_CONTENTS,
+          path,
+        );
+      },
+    );
+
+    renderModifiedCard(onRequestFileContents);
+    revealCardBodies();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Expand context" }),
+    );
+    const retryButton = await screen.findByRole("button", { name: "Retry" });
+    expect(onRequestFileContents).toHaveBeenCalledTimes(2);
+
+    shouldFail = false;
+    fireEvent.click(retryButton);
+
+    await waitFor(() => {
+      expect(onRequestFileContents).toHaveBeenCalledTimes(4);
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    });
+  });
+
+  it("never fetches contents for an added file, whose patch already carries every line", async () => {
+    stubPointer("fine");
+    const onRequestFileContents = vi.fn<RequestDiffFileContents>(
+      async (path) => textResult("const a = 1;\nconst b = 2;\n", path),
+    );
+
+    render(
+      <DiffFileCard
+        entry={buildEntry({
+          path: "src/new.ts",
+          changeKind: "added",
+          additions: 2,
+          deletions: 0,
+        })}
+        diffViewOptions={{}}
+        isCollapsed={false}
+        onToggleCollapsed={() => {}}
+        patchState={{ status: "loaded", patch: ADDED_PATCH, truncated: false }}
+        onLoadPatch={() => {}}
+        onRetry={() => {}}
+        onRequestFileContents={onRequestFileContents}
+      />,
+    );
+    revealCardBodies();
+
+    await screen.findByTestId("diff-view");
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(onRequestFileContents).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("button", { name: "Expand context" }),
+    ).toBeNull();
+  });
+});

--- a/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.stories.tsx
+++ b/apps/app/src/components/secondary-panel/git-diff/DiffFileCard.stories.tsx
@@ -54,6 +54,45 @@ const imageContentsRequester: RequestDiffFileContents = async () => ({
   sizeBytes: 20_480,
 });
 
+// A hunk in the middle of a longer file, plus both full sides, so the card's
+// on-demand "Expand context" affordance has surrounding lines to reach for.
+const CONTEXT_FILE_LINES = Array.from(
+  { length: 24 },
+  (_, index) => `export const line${index + 1} = ${index + 1};`,
+);
+const CONTEXT_OLD_FILE = `${CONTEXT_FILE_LINES.join("\n")}\n`;
+const CONTEXT_NEW_FILE = CONTEXT_OLD_FILE.replace(
+  "export const line12 = 12;",
+  "export const line12 = 1200;",
+);
+const CONTEXT_PATCH = [
+  "diff --git a/src/context.ts b/src/context.ts",
+  "index 1111111..2222222 100644",
+  "--- a/src/context.ts",
+  "+++ b/src/context.ts",
+  "@@ -11,3 +11,3 @@",
+  " export const line11 = 11;",
+  "-export const line12 = 12;",
+  "+export const line12 = 1200;",
+  " export const line13 = 13;",
+  "",
+].join("\n");
+
+// Resolves after a short delay so the loading state is visible on click.
+const contextContentsRequester: RequestDiffFileContents = async (
+  path,
+  side,
+) => {
+  await new Promise((resolve) => setTimeout(resolve, 600));
+  return {
+    kind: "text",
+    file: {
+      name: path,
+      contents: side === "old" ? CONTEXT_OLD_FILE : CONTEXT_NEW_FILE,
+    },
+  };
+};
+
 function buildEntry(overrides: Partial<DiffFileEntry> = {}): DiffFileEntry {
   return {
     path: "src/file.ts",
@@ -133,10 +172,26 @@ export function Overview() {
         />
       </StoryRow>
       <StoryRow
+        label="expand context on demand"
+        hint="text card with a contents fetcher: on a fine pointer the full file loads during idle time and pierre's gap buttons appear; on touch the card renders from the patch and offers Expand context under the diff"
+      >
+        <CardStage
+          entry={{ path: "src/context.ts" }}
+          patchState={{
+            status: "loaded",
+            patch: CONTEXT_PATCH,
+            truncated: false,
+          }}
+          onRequestFileContents={contextContentsRequester}
+        />
+      </StoryRow>
+      <StoryRow
         label="load on demand"
         hint="on_demand tier (large or binary): header + a Load diff CTA that triggers the fetch"
       >
-        <CardStage entry={{ loadMode: "on_demand", additions: 820, deletions: 140 }} />
+        <CardStage
+          entry={{ loadMode: "on_demand", additions: 820, deletions: 140 }}
+        />
       </StoryRow>
       <StoryRow
         label="too large"
@@ -226,11 +281,19 @@ export function StickyHeader() {
         >
           <CardStage
             entry={{ path: "src/first.ts" }}
-            patchState={{ status: "loaded", patch: TALL_PATCH, truncated: false }}
+            patchState={{
+              status: "loaded",
+              patch: TALL_PATCH,
+              truncated: false,
+            }}
           />
           <CardStage
             entry={{ path: "src/second.ts" }}
-            patchState={{ status: "loaded", patch: TALL_PATCH, truncated: false }}
+            patchState={{
+              status: "loaded",
+              patch: TALL_PATCH,
+              truncated: false,
+            }}
           />
         </div>
       </StoryRow>

--- a/apps/app/src/hooks/queries/environment-queries.test.tsx
+++ b/apps/app/src/hooks/queries/environment-queries.test.tsx
@@ -8,6 +8,7 @@ import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { environmentPullRequestQueryKey } from "./query-keys";
 import {
+  buildEnvironmentFilePreview,
   getEnvironmentPullRequestRefetchInterval,
   getEnvironmentPullRequestStaleTime,
   useEnvironmentPullRequest,
@@ -187,5 +188,47 @@ describe("useEnvironmentPullRequest", () => {
         staleTime: expect.any(Function),
       }),
     );
+  });
+});
+
+describe("buildEnvironmentFilePreview", () => {
+  const CONTENT_URL = "/api/v1/environments/env-1/diff/file?path=src%2Fa.ts";
+
+  it("keeps text previews on the route URL instead of a base64 data URL", () => {
+    const content = "export const marker = true;\n".repeat(64);
+    const preview = buildEnvironmentFilePreview({
+      contentUrl: CONTENT_URL,
+      path: "src/a.ts",
+      response: {
+        path: "src/a.ts",
+        content,
+        contentEncoding: "utf8",
+        mimeType: "text/typescript",
+        sizeBytes: content.length,
+      },
+    });
+
+    expect(preview.kind).toBe("text");
+    expect(preview.url).toBe(CONTENT_URL);
+    expect(preview.url.startsWith("data:")).toBe(false);
+  });
+
+  it("builds a data URL only for previews that render through a media element", () => {
+    const pngBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/Qo3AAAAAElFTkSuQmCC";
+    const preview = buildEnvironmentFilePreview({
+      contentUrl: CONTENT_URL,
+      path: "assets/logo.png",
+      response: {
+        path: "assets/logo.png",
+        content: pngBase64,
+        contentEncoding: "base64",
+        mimeType: "image/png",
+        sizeBytes: 68,
+      },
+    });
+
+    expect(preview.kind).toBe("image");
+    expect(preview.url).toBe(`data:image/png;base64,${pngBase64}`);
   });
 });

--- a/apps/app/src/hooks/queries/environment-queries.ts
+++ b/apps/app/src/hooks/queries/environment-queries.ts
@@ -5,6 +5,7 @@ import type {
   WorkspaceDiffTarget,
 } from "@bb/domain";
 import type {
+  EnvironmentDiffFileQuery,
   EnvironmentDiffFileResponse,
   EnvironmentDiffBranchesResponse,
   EnvironmentDiffFilesResponse,
@@ -19,6 +20,7 @@ import {
   type EnvironmentFilePreviewSource,
   type FilePreview,
 } from "@/lib/file-preview";
+import { buildEnvironmentDiffFileContentUrl } from "@/lib/file-content-urls";
 import { sdk } from "@/lib/sdk";
 import { useEnvironmentDetailRealtimeSubscription } from "@/hooks/useRealtimeSubscription";
 import {
@@ -274,22 +276,27 @@ export function useEnvironmentFilePreview(
         hookName: "useEnvironmentFilePreview",
         argName: "source",
       });
+      const resolvedEnvironmentId = requireEnvironmentId(
+        environmentId,
+        "useEnvironmentFilePreview",
+      );
+      const query = buildEnvironmentFilePreviewQuery(
+        resolvedPath,
+        resolvedSource,
+      );
       const response = await sdk.environments.diffFile({
-        environmentId: requireEnvironmentId(
-          environmentId,
-          "useEnvironmentFilePreview",
+        environmentId: resolvedEnvironmentId,
+        signal,
+        ...query,
+      });
+      return buildEnvironmentFilePreview({
+        contentUrl: buildEnvironmentDiffFileContentUrl(
+          resolvedEnvironmentId,
+          query,
         ),
         path: resolvedPath,
-        side: resolvedSource.kind === "working-tree" ? "new" : "old",
-        signal,
-        ...(resolvedSource.kind === "merge-base"
-          ? {
-              target: "branch_committed" as const,
-              mergeBaseRef: resolvedSource.ref,
-            }
-          : { target: "uncommitted" as const }),
+        response,
       });
-      return buildEnvironmentFilePreview(resolvedPath, response);
     },
     enabled,
     ...EXPENSIVE_MANUAL_QUERY_POLICY,
@@ -433,24 +440,52 @@ function encodeBase64Bytes(bytes: Uint8Array): string {
   return btoa(binaryChunks.join(""));
 }
 
-function buildEnvironmentFilePreview(
+function buildEnvironmentFilePreviewQuery(
   path: string,
-  response: EnvironmentDiffFileResponse,
-): FilePreview {
+  source: EnvironmentFilePreviewSource,
+): EnvironmentDiffFileQuery {
+  const side = source.kind === "working-tree" ? "new" : "old";
+  return source.kind === "merge-base"
+    ? { target: "branch_committed", mergeBaseRef: source.ref, path, side }
+    : { target: "uncommitted", path, side };
+}
+
+/**
+ * Build the preview for a `/diff/file` read. Only image and video previews
+ * need a browser-loadable `url` (the `<img>` / `<video>` src), so only those
+ * pay for a base64 `data:` URL. Text previews carry their content inline and
+ * point `url` at the JSON route the bytes came from; building a `data:` URL
+ * for them would re-encode the whole file to base64 (a second copy of a
+ * multi-megabyte source file on a phone) and then bloat every cache key that
+ * embeds the URL.
+ */
+export function buildEnvironmentFilePreview({
+  contentUrl,
+  path,
+  response,
+}: {
+  contentUrl: string;
+  path: string;
+  response: EnvironmentDiffFileResponse;
+}): FilePreview {
   const contentBytes =
     response.contentEncoding === "base64"
       ? decodeBase64Bytes(response.content)
       : new TextEncoder().encode(response.content);
   const mimeType = normalizeFilePreviewMimeType(response.mimeType ?? null);
-  const base64Content =
-    response.contentEncoding === "base64"
-      ? response.content
-      : encodeBase64Bytes(contentBytes);
-  return buildFilePreview({
+  const preview = buildFilePreview({
     contentBytes,
     mimeType,
     name: path.split("/").at(-1),
     path,
-    url: `data:${mimeType};base64,${base64Content}`,
+    url: contentUrl,
   });
+  if (preview.kind !== "image" && preview.kind !== "video") {
+    return preview;
+  }
+  const base64Content =
+    response.contentEncoding === "base64"
+      ? response.content
+      : encodeBase64Bytes(contentBytes);
+  return { ...preview, url: `data:${mimeType};base64,${base64Content}` };
 }

--- a/apps/app/src/lib/file-content-urls.ts
+++ b/apps/app/src/lib/file-content-urls.ts
@@ -1,3 +1,4 @@
+import type { EnvironmentDiffFileQuery } from "@bb/server-contract";
 import { apiClient, toRelativeUrl } from "./api-server";
 
 /**
@@ -88,6 +89,24 @@ export function buildThreadWorktreeRawContentUrl(
   return toRelativeUrl(
     apiClient.threads[":id"].worktree.files[":filePath{.+}"].$url({
       param: { id: threadId, filePath: encodePathSegments(path) },
+    }),
+  );
+}
+
+/**
+ * The `/environments/:id/diff/file` JSON route a workspace file preview was
+ * read from. Text previews use it as their `url` identity; it is not a raw
+ * byte stream (the route wraps content in JSON), so callers that need an
+ * `<img>`/`<video>` source must build a `data:` URL from the response instead.
+ */
+export function buildEnvironmentDiffFileContentUrl(
+  environmentId: string,
+  query: EnvironmentDiffFileQuery,
+): string {
+  return toRelativeUrl(
+    apiClient.environments[":id"].diff.file.$url({
+      param: { id: environmentId },
+      query,
     }),
   );
 }


### PR DESCRIPTION
## What was wrong
Diff-tab text cards fetched the full old and new file for every modified card as soon as it came within 200 px of the viewport, only so pierre could show expand-context buttons; the enriched diff was then tokenized and rendered a second time. The file preview rendered whole files un-virtualized with no size cap, remounted pierre when the highlighted AST arrived (throwing away DOM and scroll position), and re-encoded every text file to a base64 `data:` URL that only ever fed a cache key.

## What changed
- Diff cards render from the patch alone. An app-owned "Expand context" row requests the contents on demand (with retry); fine-pointer devices still request them during idle time so desktop keeps zero-click expansion. Image/SVG cards keep fetching on viewport entry. Added/deleted files never offer the row.
- The file preview code view owns its scroll container and registers it as pierre's virtualizer root, so only rows near the viewport render. Deep links scroll the virtualized viewport toward the target until the row exists.
- Files over 5,000 lines or 512 KB render a prefix with "Load full file"; a line link past the prefix loads the whole file; loading keeps the scroll offset.
- Pierre mounts once per file; plain->highlighted no longer remounts.
- Workspace previews build a `data:` URL only for image/video; text previews carry the `/diff/file` route URL.
- New stories for the capped view, a deep link past the cap, and a content-sized scroller.

## How you verified
- New tests: `DiffFileCard.contextExpansion.test.tsx` (coarse pointer: no fetch on reveal, fetch on click, affordance retires; fine pointer: idle auto-fetch; error -> Retry; added file never fetches — 3 of 4 fail before), `FilePreview.test.tsx` (single mount on highlight, 5,000-line cap + Load full file + `:head` cacheKey, 512 KB cap, line link past the cap shows whole file, target-line scroll on the virtualized viewport), `environment-queries.test.tsx` (text preview has no data URL; image does).
- `pnpm exec turbo run typecheck --filter=@bb/app`, `pnpm exec turbo run lint --filter=@bb/app` (pre-existing warnings only), `pnpm exec turbo run test --filter=@bb/app -- src/components/secondary-panel src/components/git-diff src/hooks/queries src/lib/file-preview.test.ts` (39 files, 256 tests pass).
- Visual: ladle static build of FilePreview stories served locally and driven with headless Chromium — virtualized row counts, deep-link scroll to line 6,500, capped notice, Load full file (scroll offset preserved), wrap mode scrolling, and the content-sized (skill detail) container all behaved as intended.

Fixes: part of the mobile / iOS Safari performance program (verified sweep report in the bb thread; no single issue).


## Stack context

Layer 22 of 22 in the `bb/mobile-perf/*` stack (bottom → top: quick wins first, big rocks last).
- Prerequisite (layer below): `bb/mobile-perf/mobile-interactions` (#1900).
- Audit findings addressed: see title IDs. Review: approved-with-fixes; 1 review fix commit(s).
- Deliberately not done here: G2 optional `maxBytes` param on /environments/:id/diff/file: not added. The route was not touched (the fix is on-demand fetching in the client), and a real cap 
- Reviewer notes / follow-ups: Non-blocking, pre-existing: `GitDiffCard` (timeline/thread surface) never passes `patchText` to `useGitDiffCardBody`, so its text cards never get context expansion (before this bra | Non-blocking: on fine pointers, when a text card's patch identity changes while contents are already loaded, the fetch effect briefly starts and cancels one fetch before the idle r | Not done by design (per implementer): the `maxBytes` route param from G2 was skipped because it needs a daemon change; no wire changes on this branch, so no HOST_DAEMON_PROTOCOL_VE | Small UX change on desktop worth knowing: code previews now own their scroller (`usesFullHeightLayout`), so the file header stays fixed while code scrolls, matching iframe/CSV prev
- Wire/contract: None. No server-contract, route, SDK, or host-daemon protocol changes; HOST_DAEMON_PROTOCOL_VERSION untouched.

> AGENT GENERATED: by Claude Opus 5

