### PR TITLE
Add an app-shell service worker for cold PWA launches (A11)

### DIFF
--- a/apps/app/index.html
+++ b/apps/app/index.html
@@ -99,6 +99,9 @@
       })();
     </script>
   </head>
+  <!-- The service worker identifies the real app shell by this exact body
+       class attribute (src/service-worker/sw-manifest.ts APP_SHELL_MARKER);
+       the build fails if it changes. -->
   <body class="bb-app-shell">
     <div id="root"></div>
     <script>

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf dist bundle-stats.json",
     "storybook": "ladle serve",
     "storybook:build": "ladle build",
-    "lint": "eslint src vite.config.ts vite.dev.config.ts vite-bundle-stats.ts vite-font-preload.ts vite-shared-ui-seam.ts --ext .ts,.tsx",
+    "lint": "eslint src vite.config.ts vite.dev.config.ts vite-bundle-stats.ts vite-font-preload.ts vite-shared-ui-seam.ts vite-service-worker.ts --ext .ts,.tsx",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.node.json",
     "test": "node scripts/generate-pwa-icons.mjs --check && vitest run --config vitest.config.ts"
   },

--- a/apps/app/src/lib/chunk-load-failure-reload.test.ts
+++ b/apps/app/src/lib/chunk-load-failure-reload.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CHUNK_LOAD_FAILURE_RELOAD_WINDOW_MS,
+  createChunkLoadFailureHandler,
+} from "./chunk-load-failure-reload";
+
+function fakeEvent() {
+  const event = {
+    defaultPrevented: false,
+    payload: new Error("Failed to fetch dynamically imported module"),
+    preventDefault() {
+      event.defaultPrevented = true;
+    },
+  };
+  return event;
+}
+
+function createStorage(): Pick<Storage, "getItem" | "setItem"> {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => {
+      values.set(key, value);
+    },
+  };
+}
+
+describe("createChunkLoadFailureHandler", () => {
+  it("reloads once and swallows the error, then lets a repeat inside the window propagate", () => {
+    let now = 1_000_000;
+    const storage = createStorage();
+    const reload = vi.fn();
+    const deps = { now: () => now, reload, storage, warn: () => undefined };
+
+    // First failure on a fresh tab: reload and prevent the throw.
+    const first = fakeEvent();
+    createChunkLoadFailureHandler(deps)(first);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(first.defaultPrevented).toBe(true);
+
+    // The reloaded page fails again seconds later (broken deploy / offline):
+    // no second reload, the error reaches the boundary.
+    now += 5_000;
+    const second = fakeEvent();
+    createChunkLoadFailureHandler(deps)(second);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(second.defaultPrevented).toBe(false);
+
+    // Well after the window a new update may legitimately break chunks again.
+    now += CHUNK_LOAD_FAILURE_RELOAD_WINDOW_MS + 1;
+    const third = fakeEvent();
+    createChunkLoadFailureHandler(deps)(third);
+    expect(reload).toHaveBeenCalledTimes(2);
+    expect(third.defaultPrevented).toBe(true);
+  });
+
+  it("collapses concurrent failures of one page into a single reload", () => {
+    const reload = vi.fn();
+    const handler = createChunkLoadFailureHandler({
+      now: () => 42,
+      reload,
+      storage: null,
+      warn: () => undefined,
+    });
+    const first = fakeEvent();
+    const second = fakeEvent();
+    handler(first);
+    handler(second);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(second.defaultPrevented).toBe(true);
+  });
+});

--- a/apps/app/src/lib/chunk-load-failure-reload.ts
+++ b/apps/app/src/lib/chunk-load-failure-reload.ts
@@ -1,0 +1,103 @@
+/**
+ * `bb update` swaps `dist/` wholesale, so every content-hashed chunk an open
+ * page has not loaded yet disappears from the server. The next `lazy()` route
+ * or dynamic `import()` then 404s and Vite raises `vite:preloadError`. Before
+ * this handler that surfaced as a blank route inside a page that could not
+ * recover on its own; now the page reloads once so it picks up the new
+ * index.html and hashes.
+ *
+ * The one-shot guard keeps a genuinely broken deploy (or an offline device)
+ * from turning into a reload loop: a second failure inside the window lets the
+ * error propagate to the error boundary instead.
+ */
+const RELOAD_STAMP_STORAGE_KEY = "bb.chunkLoadFailureReloadAt";
+export const CHUNK_LOAD_FAILURE_RELOAD_WINDOW_MS = 60_000;
+
+export interface ChunkLoadFailureReloadDeps {
+  now: () => number;
+  reload: () => void;
+  /** Per-tab stamp store; `null` when sessionStorage is unavailable. */
+  storage: Pick<Storage, "getItem" | "setItem"> | null;
+  warn: (message: string, error: unknown) => void;
+}
+
+interface PreloadErrorEventLike {
+  defaultPrevented: boolean;
+  payload: unknown;
+  preventDefault(): void;
+}
+
+function readLastReloadAt(deps: ChunkLoadFailureReloadDeps): number | null {
+  try {
+    const raw = deps.storage?.getItem(RELOAD_STAMP_STORAGE_KEY) ?? null;
+    if (raw === null) return null;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeLastReloadAt(
+  deps: ChunkLoadFailureReloadDeps,
+  now: number,
+): void {
+  try {
+    deps.storage?.setItem(RELOAD_STAMP_STORAGE_KEY, String(now));
+  } catch {
+    // Storage unavailable: the in-memory `reloading` latch below still keeps
+    // this page load from reloading more than once.
+  }
+}
+
+export function createChunkLoadFailureHandler(
+  deps: ChunkLoadFailureReloadDeps,
+): (event: PreloadErrorEventLike) => void {
+  let reloading = false;
+  return (event) => {
+    if (reloading) {
+      // Reload already requested; swallow the follow-up failures of the same
+      // page instead of throwing into React while the navigation is pending.
+      event.preventDefault();
+      return;
+    }
+    const now = deps.now();
+    const lastReloadAt = readLastReloadAt(deps);
+    if (
+      lastReloadAt !== null &&
+      now - lastReloadAt <= CHUNK_LOAD_FAILURE_RELOAD_WINDOW_MS
+    ) {
+      // Reloaded for this reason moments ago and it did not help: let the
+      // error reach the error boundary rather than loop.
+      return;
+    }
+    reloading = true;
+    event.preventDefault();
+    deps.warn(
+      "[bb] a code chunk failed to load; reloading to pick up the current build",
+      event.payload,
+    );
+    writeLastReloadAt(deps, now);
+    deps.reload();
+  };
+}
+
+function sessionStorageOrNull(): Storage | null {
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function installChunkLoadFailureReload(): void {
+  window.addEventListener(
+    "vite:preloadError",
+    createChunkLoadFailureHandler({
+      now: () => Date.now(),
+      reload: () => window.location.reload(),
+      storage: sessionStorageOrNull(),
+      warn: (message, error) => console.warn(message, error),
+    }),
+  );
+}

--- a/apps/app/src/lib/service-worker-registration.test.ts
+++ b/apps/app/src/lib/service-worker-registration.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { shouldRegisterServiceWorker } from "./service-worker-registration";
+
+const enabled = {
+  hasServiceWorkerApi: true,
+  isDesktopShell: false,
+  isProduction: true,
+  isSecureContext: true,
+};
+
+describe("shouldRegisterServiceWorker", () => {
+  it("registers only for a production build on a secure origin outside the desktop shell", () => {
+    expect(shouldRegisterServiceWorker(enabled)).toBe(true);
+    // Dev serves unbundled source modules; nothing to precache and a stale
+    // worker would shadow HMR.
+    expect(
+      shouldRegisterServiceWorker({ ...enabled, isProduction: false }),
+    ).toBe(false);
+    // Plain http on a LAN address: the browser would reject the registration
+    // and log an error on every boot.
+    expect(
+      shouldRegisterServiceWorker({ ...enabled, isSecureContext: false }),
+    ).toBe(false);
+    expect(
+      shouldRegisterServiceWorker({ ...enabled, hasServiceWorkerApi: false }),
+    ).toBe(false);
+    // Electron reads the bundle from disk; a worker only adds an update seam.
+    expect(
+      shouldRegisterServiceWorker({ ...enabled, isDesktopShell: true }),
+    ).toBe(false);
+  });
+});

--- a/apps/app/src/lib/service-worker-registration.ts
+++ b/apps/app/src/lib/service-worker-registration.ts
@@ -1,0 +1,56 @@
+import { getBbDesktopInfo } from "./bb-desktop";
+
+/** Root-relative URL the build writes the worker to (see vite-service-worker.ts). */
+export const SERVICE_WORKER_SCRIPT_URL = "/sw.js";
+
+export interface ServiceWorkerRegistrationEnvironment {
+  /** Production build: dev serves source modules that the worker cannot precache. */
+  isProduction: boolean;
+  /** `window.isSecureContext`: https or loopback. Browsers refuse to register otherwise. */
+  isSecureContext: boolean;
+  hasServiceWorkerApi: boolean;
+  /** The Electron shell reads the app from local disk; a worker adds nothing there. */
+  isDesktopShell: boolean;
+}
+
+export function shouldRegisterServiceWorker(
+  env: ServiceWorkerRegistrationEnvironment,
+): boolean {
+  return (
+    env.isProduction &&
+    env.isSecureContext &&
+    env.hasServiceWorkerApi &&
+    !env.isDesktopShell
+  );
+}
+
+/**
+ * Registers the app-shell service worker after the page has finished loading,
+ * so the precache install never competes with the boot fetches it will later
+ * serve. No-op in dev, on insecure origins (plain http on a LAN address),
+ * without the API, and inside the desktop shell.
+ */
+export function registerAppServiceWorker(): void {
+  if (
+    !shouldRegisterServiceWorker({
+      hasServiceWorkerApi: "serviceWorker" in navigator,
+      isDesktopShell: getBbDesktopInfo() !== null,
+      isProduction: import.meta.env.PROD,
+      isSecureContext: window.isSecureContext,
+    })
+  ) {
+    return;
+  }
+  const register = (): void => {
+    navigator.serviceWorker
+      .register(SERVICE_WORKER_SCRIPT_URL, { scope: "/" })
+      .catch((error: unknown) => {
+        console.warn("[bb] service worker registration failed", error);
+      });
+  };
+  if (document.readyState === "complete") {
+    register();
+  } else {
+    window.addEventListener("load", register, { once: true });
+  }
+}

--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -7,6 +7,7 @@ import { AppErrorBoundary } from "./components/AppErrorBoundary";
 import { AppToaster } from "./components/AppToaster";
 import { registerProviderCliInstallQueryClient } from "./components/provider-cli/provider-cli-install-store";
 import { initializePreferredTheme } from "./hooks/useTheme";
+import { installChunkLoadFailureReload } from "./lib/chunk-load-failure-reload";
 import { initializeFavicon } from "./lib/favicon-color-preference";
 import { installForeignDomMutationGuard } from "./lib/foreign-dom-mutation-guard";
 import { restorePersistedQueryCacheIfEnabled } from "./lib/persisted-query-cache/persisted-query-cache";
@@ -20,6 +21,7 @@ import {
   installAppQueryClientBrowserEvents,
 } from "./lib/query-client";
 import { takeOverPanelResizeCursor } from "./lib/resizeCursor";
+import { registerAppServiceWorker } from "./lib/service-worker-registration";
 import { applyCachedAppThemeCss } from "./lib/themes";
 import "./app.css";
 
@@ -34,6 +36,10 @@ installForeignDomMutationGuard();
 // costs anything when an Error is actually constructed.
 Error.stackTraceLimit = 50;
 
+// `bb update` rotates every chunk hash under the feet of an open page; a lazy
+// import that 404s reloads once instead of leaving a blank route.
+installChunkLoadFailureReload();
+
 const queryClient = createAppQueryClient();
 installAppQueryClientBrowserEvents(queryClient);
 // The provider CLI install store outlives every component, so it takes the
@@ -47,6 +53,9 @@ initializePreferredTheme();
 applyCachedAppThemeCss();
 initializeFavicon();
 takeOverPanelResizeCursor();
+// Production + secure origin only. Precaches the app shell after `load` so a
+// cold PWA launch on a phone stops re-fetching ~40 assets through the tunnel.
+registerAppServiceWorker();
 
 /**
  * When the persisted-cache experiment was on at the last visit, hydrate the

--- a/apps/app/src/service-worker/precache-manifest.test.ts
+++ b/apps/app/src/service-worker/precache-manifest.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildServiceWorkerPrecacheManifest,
+  type ManifestBundle,
+  type ManifestBundleChunk,
+} from "../../vite-service-worker.js";
+
+function chunk(
+  fileName: string,
+  overrides: Partial<Omit<ManifestBundleChunk, "type" | "fileName">> = {},
+): ManifestBundleChunk {
+  return {
+    type: "chunk",
+    fileName,
+    isEntry: false,
+    facadeModuleId: null,
+    imports: [],
+    dynamicImports: [],
+    ...overrides,
+  };
+}
+
+const ROUTE_ID = "/repo/apps/app/src/views/SplitWorkspaceRoute.tsx";
+
+function fixtureBundle(): ManifestBundle {
+  return {
+    "assets/index-AAA.js": chunk("assets/index-AAA.js", {
+      isEntry: true,
+      facadeModuleId: "/repo/apps/app/src/main.tsx",
+      imports: ["assets/boot-BBB.js"],
+      dynamicImports: [
+        "assets/SplitWorkspaceRoute-CCC.js",
+        "assets/SettingsView-DDD.js",
+      ],
+      viteMetadata: { importedCss: new Set(["assets/index-EEE.css"]) },
+    }),
+    "assets/boot-BBB.js": chunk("assets/boot-BBB.js", {
+      imports: ["assets/shared-FFF.js"],
+    }),
+    "assets/shared-FFF.js": chunk("assets/shared-FFF.js"),
+    "assets/SplitWorkspaceRoute-CCC.js": chunk(
+      "assets/SplitWorkspaceRoute-CCC.js",
+      {
+        facadeModuleId: `${ROUTE_ID}?some=query`,
+        imports: ["assets/shared-FFF.js", "assets/route-only-GGG.js"],
+        dynamicImports: ["assets/lazy-panel-HHH.js"],
+        viteMetadata: { importedCss: new Set(["assets/markdown-III.css"]) },
+      },
+    ),
+    "assets/route-only-GGG.js": chunk("assets/route-only-GGG.js"),
+    "assets/lazy-panel-HHH.js": chunk("assets/lazy-panel-HHH.js"),
+    "assets/SettingsView-DDD.js": chunk("assets/SettingsView-DDD.js", {
+      facadeModuleId: "/repo/apps/app/src/views/SettingsView.tsx",
+      imports: ["assets/settings-only-JJJ.js"],
+    }),
+    "assets/settings-only-JJJ.js": chunk("assets/settings-only-JJJ.js"),
+    "assets/index-EEE.css": { type: "asset", fileName: "assets/index-EEE.css" },
+    "assets/markdown-III.css": {
+      type: "asset",
+      fileName: "assets/markdown-III.css",
+    },
+    "assets/inter-latin-wght-normal-KKK.woff2": {
+      type: "asset",
+      fileName: "assets/inter-latin-wght-normal-KKK.woff2",
+    },
+    "assets/inter-cyrillic-wght-normal-LLL.woff2": {
+      type: "asset",
+      fileName: "assets/inter-cyrillic-wght-normal-LLL.woff2",
+    },
+    "index.html": { type: "asset", fileName: "index.html" },
+  };
+}
+
+const options = {
+  assetFileNamePatterns: [/^assets\/inter-latin-wght-normal-[^/]*\.woff2$/u],
+  indexHtml: '<!doctype html><body class="bb-app-shell"></body>',
+  routeModuleIds: [ROUTE_ID],
+};
+
+describe("buildServiceWorkerPrecacheManifest", () => {
+  it("precaches the boot closure, the route closure, their CSS and the latin font only", () => {
+    const manifest = buildServiceWorkerPrecacheManifest(
+      fixtureBundle(),
+      options,
+    );
+    expect(manifest.assetUrls).toEqual([
+      "/assets/SplitWorkspaceRoute-CCC.js",
+      "/assets/boot-BBB.js",
+      "/assets/index-AAA.js",
+      "/assets/index-EEE.css",
+      "/assets/inter-latin-wght-normal-KKK.woff2",
+      "/assets/markdown-III.css",
+      "/assets/route-only-GGG.js",
+      "/assets/shared-FFF.js",
+    ]);
+    // Other lazy views, the route's own lazy panels, non-latin fonts and the
+    // html itself (fetched fresh at install) stay out of the precache list.
+    expect(manifest.assetUrls).not.toContain("/assets/SettingsView-DDD.js");
+    expect(manifest.assetUrls).not.toContain("/assets/settings-only-JJJ.js");
+    expect(manifest.assetUrls).not.toContain("/assets/lazy-panel-HHH.js");
+    expect(manifest.assetUrls).not.toContain(
+      "/assets/inter-cyrillic-wght-normal-LLL.woff2",
+    );
+    expect(manifest.assetUrls).not.toContain("/index.html");
+  });
+
+  it("derives a build id that changes with the asset list or the shell html", () => {
+    const base = buildServiceWorkerPrecacheManifest(fixtureBundle(), options);
+    const same = buildServiceWorkerPrecacheManifest(fixtureBundle(), options);
+    expect(same.buildId).toBe(base.buildId);
+    expect(base.buildId).toMatch(/^[0-9a-f]{16}$/u);
+
+    const rotated = fixtureBundle();
+    delete rotated["assets/route-only-GGG.js"];
+    rotated["assets/route-only-ZZZ.js"] = chunk("assets/route-only-ZZZ.js");
+    const routeChunk = rotated["assets/SplitWorkspaceRoute-CCC.js"];
+    if (routeChunk?.type !== "chunk") throw new Error("fixture drift");
+    routeChunk.imports = ["assets/shared-FFF.js", "assets/route-only-ZZZ.js"];
+    expect(
+      buildServiceWorkerPrecacheManifest(rotated, options).buildId,
+    ).not.toBe(base.buildId);
+
+    expect(
+      buildServiceWorkerPrecacheManifest(fixtureBundle(), {
+        ...options,
+        indexHtml: `${options.indexHtml}<!-- changed -->`,
+      }).buildId,
+    ).not.toBe(base.buildId);
+  });
+
+  it("fails the build when a configured route module has no chunk", () => {
+    expect(() =>
+      buildServiceWorkerPrecacheManifest(fixtureBundle(), {
+        ...options,
+        routeModuleIds: ["/repo/apps/app/src/views/Renamed.tsx"],
+      }),
+    ).toThrow(/no chunk for route module/u);
+  });
+});

--- a/apps/app/src/service-worker/precache-manifest.test.ts
+++ b/apps/app/src/service-worker/precache-manifest.test.ts
@@ -128,6 +128,15 @@ describe("buildServiceWorkerPrecacheManifest", () => {
     ).not.toBe(base.buildId);
   });
 
+  it("fails the build when index.html lost the app-shell marker the worker installs by", () => {
+    expect(() =>
+      buildServiceWorkerPrecacheManifest(fixtureBundle(), {
+        ...options,
+        indexHtml: '<!doctype html><body class="dark bb-app-shell"></body>',
+      }),
+    ).toThrow(/does not contain class="bb-app-shell"/u);
+  });
+
   it("fails the build when a configured route module has no chunk", () => {
     expect(() =>
       buildServiceWorkerPrecacheManifest(fixtureBundle(), {

--- a/apps/app/src/service-worker/sw-core.test.ts
+++ b/apps/app/src/service-worker/sw-core.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, it } from "vitest";
+import {
+  APP_SHELL_MARKER,
+  appShellCacheName,
+  installAppServiceWorker,
+  type CacheLike,
+  type CacheStorageLike,
+  type ServiceWorkerEventMapLike,
+  type ServiceWorkerScopeLike,
+} from "./sw-core.js";
+
+const ORIGIN = "https://bee.getbb.app";
+const SHELL_HTML = `<!doctype html><html><body ${APP_SHELL_MARKER}><div id="root"></div></body></html>`;
+const SIGN_IN_HTML =
+  "<!doctype html><html><body><h1>Sign in to bb</h1></body></html>";
+
+function keyOf(request: RequestInfo | URL): string {
+  if (typeof request === "string") return new URL(request, ORIGIN).href;
+  if (request instanceof URL) return request.href;
+  return request.url;
+}
+
+class FakeCache implements CacheLike {
+  readonly entries = new Map<string, Response>();
+  async match(request: RequestInfo | URL): Promise<Response | undefined> {
+    return this.entries.get(keyOf(request))?.clone();
+  }
+  async put(request: RequestInfo | URL, response: Response): Promise<void> {
+    this.entries.set(keyOf(request), response);
+  }
+}
+
+class FakeCacheStorage implements CacheStorageLike {
+  readonly caches = new Map<string, FakeCache>();
+  async delete(cacheName: string): Promise<boolean> {
+    return this.caches.delete(cacheName);
+  }
+  async keys(): Promise<string[]> {
+    return [...this.caches.keys()];
+  }
+  async open(cacheName: string): Promise<CacheLike> {
+    let cache = this.caches.get(cacheName);
+    if (cache === undefined) {
+      cache = new FakeCache();
+      this.caches.set(cacheName, cache);
+    }
+    return cache;
+  }
+}
+
+type FetchImpl = (
+  input: Request | string,
+  init?: RequestInit,
+) => Promise<Response>;
+
+interface Harness {
+  scope: ServiceWorkerScopeLike;
+  cacheStorage: FakeCacheStorage;
+  fetchLog: string[];
+  skipWaitingCalls: number;
+  claimCalls: number;
+  dispatchInstall(): Promise<void>;
+  dispatchActivate(): Promise<void>;
+  /** Returns the worker's response, or `null` when it did not call respondWith. */
+  dispatchFetch(request: Request): Promise<Response | null>;
+}
+
+function createHarness(fetchImpl: FetchImpl): Harness {
+  const listeners: {
+    [K in keyof ServiceWorkerEventMapLike]: Array<
+      (event: ServiceWorkerEventMapLike[K]) => void
+    >;
+  } = { activate: [], fetch: [], install: [] };
+  const cacheStorage = new FakeCacheStorage();
+  const fetchLog: string[] = [];
+  const harness: Harness = {
+    cacheStorage,
+    claimCalls: 0,
+    fetchLog,
+    skipWaitingCalls: 0,
+    scope: {
+      addEventListener(type, listener) {
+        listeners[type].push(listener);
+      },
+      caches: cacheStorage,
+      clients: {
+        claim: async () => {
+          harness.claimCalls += 1;
+        },
+      },
+      fetch: (input, init) => {
+        fetchLog.push(typeof input === "string" ? input : input.url);
+        return fetchImpl(input, init);
+      },
+      location: { origin: ORIGIN },
+      skipWaiting: async () => {
+        harness.skipWaitingCalls += 1;
+      },
+    },
+    async dispatchInstall() {
+      const pending: Promise<unknown>[] = [];
+      for (const listener of listeners.install) {
+        listener({ waitUntil: (promise) => pending.push(promise) });
+      }
+      await Promise.all(pending);
+    },
+    async dispatchActivate() {
+      const pending: Promise<unknown>[] = [];
+      for (const listener of listeners.activate) {
+        listener({ waitUntil: (promise) => pending.push(promise) });
+      }
+      await Promise.all(pending);
+    },
+    async dispatchFetch(request) {
+      let responded: Promise<Response> | null = null;
+      for (const listener of listeners.fetch) {
+        listener({
+          request,
+          respondWith: (response) => {
+            responded = Promise.resolve(response);
+          },
+          waitUntil: () => undefined,
+        });
+      }
+      return responded === null ? null : await responded;
+    },
+  };
+  return harness;
+}
+
+function navigationRequest(url: string): Request {
+  // `new Request(..., { mode: "navigate" })` is not constructible per spec;
+  // shadow the accessor on the instance the way the browser reports it.
+  const request = new Request(url);
+  Object.defineProperty(request, "mode", { value: "navigate" });
+  return request;
+}
+
+const MANIFEST = {
+  assetUrls: ["/assets/index-AAA.js", "/assets/inter-latin-BBB.woff2"],
+  buildId: "build0000000001",
+};
+
+function okServer(overrides: Record<string, () => Response> = {}): FetchImpl {
+  return async (input) => {
+    const url = new URL(typeof input === "string" ? input : input.url, ORIGIN);
+    const override = overrides[url.pathname];
+    if (override !== undefined) return override();
+    if (url.pathname === "/index.html") {
+      return new Response(SHELL_HTML, {
+        headers: { "content-type": "text/html" },
+      });
+    }
+    if (url.pathname.startsWith("/assets/")) {
+      return new Response(`asset ${url.pathname}`, {
+        headers: { "content-type": "application/javascript" },
+      });
+    }
+    return new Response("not found", { status: 404 });
+  };
+}
+
+describe("app service worker", () => {
+  it("precaches the shell and the manifest assets on install, then takes over", async () => {
+    const harness = createHarness(okServer());
+    installAppServiceWorker(harness.scope, MANIFEST);
+    await harness.dispatchInstall();
+
+    const cache = harness.cacheStorage.caches.get(
+      appShellCacheName(MANIFEST.buildId),
+    );
+    expect(cache).toBeDefined();
+    expect([...(cache?.entries.keys() ?? [])].sort()).toEqual([
+      `${ORIGIN}/assets/index-AAA.js`,
+      `${ORIGIN}/assets/inter-latin-BBB.woff2`,
+      `${ORIGIN}/index.html`,
+    ]);
+    expect(harness.skipWaitingCalls).toBe(1);
+  });
+
+  it("refuses to install when the shell fetch returns something other than the app", async () => {
+    // Through bb connect an expired session answers /index.html with the
+    // sign-in page (HTTP 200). Precaching that would brick offline launches.
+    const harness = createHarness(
+      okServer({
+        "/index.html": () =>
+          new Response(SIGN_IN_HTML, {
+            headers: { "content-type": "text/html" },
+          }),
+      }),
+    );
+    installAppServiceWorker(harness.scope, MANIFEST);
+    await expect(harness.dispatchInstall()).rejects.toThrow(/not the app/u);
+    expect(harness.skipWaitingCalls).toBe(0);
+  });
+
+  it("fails install when any precached asset is missing", async () => {
+    const harness = createHarness(
+      okServer({
+        "/assets/inter-latin-BBB.woff2": () =>
+          new Response("gone", { status: 404 }),
+      }),
+    );
+    installAppServiceWorker(harness.scope, MANIFEST);
+    await expect(harness.dispatchInstall()).rejects.toThrow(/HTTP 404/u);
+  });
+
+  it("serves navigations from the network and falls back to the shell only when the fetch fails", async () => {
+    let online = true;
+    const harness = createHarness(async (input, init) => {
+      if (!online) throw new TypeError("Failed to fetch");
+      return okServer({
+        "/threads/thr_1": () =>
+          new Response(SIGN_IN_HTML, {
+            headers: { "content-type": "text/html" },
+          }),
+        "/api/v1/threads": () => new Response("{}", { status: 503 }),
+      })(input, init);
+    });
+    installAppServiceWorker(harness.scope, MANIFEST);
+    await harness.dispatchInstall();
+
+    // Online: whatever the server (or the connect gate) says wins, even a
+    // sign-in page, so an expired session is never masked by the cache.
+    const gated = await harness.dispatchFetch(
+      navigationRequest(`${ORIGIN}/threads/thr_1`),
+    );
+    expect(await gated?.text()).toBe(SIGN_IN_HTML);
+
+    // A navigation to a non-app path is not the worker's business at all.
+    expect(
+      await harness.dispatchFetch(
+        navigationRequest(`${ORIGIN}/api/v1/threads`),
+      ),
+    ).toBeNull();
+    expect(
+      await harness.dispatchFetch(navigationRequest(`${ORIGIN}/__tunnel`)),
+    ).toBeNull();
+
+    // Offline: the precached shell boots the app.
+    online = false;
+    const offline = await harness.dispatchFetch(
+      navigationRequest(`${ORIGIN}/threads/thr_1`),
+    );
+    expect(await offline?.text()).toBe(SHELL_HTML);
+  });
+
+  it("serves precached assets from the cache and caches other hashed assets on first load", async () => {
+    const harness = createHarness(
+      okServer({
+        "/assets/old-DDD.js": () => new Response("gone", { status: 404 }),
+      }),
+    );
+    installAppServiceWorker(harness.scope, MANIFEST);
+    await harness.dispatchInstall();
+    harness.fetchLog.length = 0;
+
+    const precached = await harness.dispatchFetch(
+      new Request(`${ORIGIN}/assets/index-AAA.js`),
+    );
+    expect(await precached?.text()).toBe("asset /assets/index-AAA.js");
+    expect(harness.fetchLog).toEqual([]);
+
+    const lazy = await harness.dispatchFetch(
+      new Request(`${ORIGIN}/assets/mermaid-CCC.js`),
+    );
+    expect(await lazy?.text()).toBe("asset /assets/mermaid-CCC.js");
+    expect(harness.fetchLog).toEqual([`${ORIGIN}/assets/mermaid-CCC.js`]);
+    // Second load of the lazy chunk is a cache hit.
+    await Promise.resolve();
+    const again = await harness.dispatchFetch(
+      new Request(`${ORIGIN}/assets/mermaid-CCC.js`),
+    );
+    expect(await again?.text()).toBe("asset /assets/mermaid-CCC.js");
+    expect(harness.fetchLog).toEqual([`${ORIGIN}/assets/mermaid-CCC.js`]);
+
+    // A stale hash after `bb update` (404) is returned but never cached.
+    const stale = await harness.dispatchFetch(
+      new Request(`${ORIGIN}/assets/old-DDD.js`),
+    );
+    expect(stale?.status).toBe(404);
+    const cache = harness.cacheStorage.caches.get(
+      appShellCacheName(MANIFEST.buildId),
+    );
+    expect(cache?.entries.has(`${ORIGIN}/assets/old-DDD.js`)).toBe(false);
+  });
+
+  it("never stores an HTML page under an asset URL (captive portal, proxy gate)", async () => {
+    const portal = () =>
+      new Response("<html>Sign in to the airport wifi</html>", {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    const harness = createHarness(okServer({ "/assets/lazy-EEE.js": portal }));
+    installAppServiceWorker(harness.scope, MANIFEST);
+    await harness.dispatchInstall();
+
+    const response = await harness.dispatchFetch(
+      new Request(`${ORIGIN}/assets/lazy-EEE.js`),
+    );
+    expect(response?.status).toBe(200);
+    await Promise.resolve();
+    const cache = harness.cacheStorage.caches.get(
+      appShellCacheName(MANIFEST.buildId),
+    );
+    expect(cache?.entries.has(`${ORIGIN}/assets/lazy-EEE.js`)).toBe(false);
+
+    // Same at install: a precache that would pin a portal page must fail.
+    const poisoned = createHarness(
+      okServer({ "/assets/index-AAA.js": portal }),
+    );
+    installAppServiceWorker(poisoned.scope, MANIFEST);
+    await expect(poisoned.dispatchInstall()).rejects.toThrow(
+      /asset precache failed/u,
+    );
+  });
+
+  it("leaves API, websocket, plugin-asset, cross-origin and non-GET requests to the browser", async () => {
+    const harness = createHarness(okServer());
+    installAppServiceWorker(harness.scope, MANIFEST);
+    await harness.dispatchInstall();
+    harness.fetchLog.length = 0;
+
+    for (const url of [
+      `${ORIGIN}/api/v1/threads`,
+      `${ORIGIN}/api/v1/plugins/tasks/assets/app.js`,
+      `${ORIGIN}/ws`,
+      `${ORIGIN}/sw.js`,
+      `${ORIGIN}/manifest.webmanifest`,
+      "https://cdn.example.com/assets/index-AAA.js",
+    ]) {
+      expect(await harness.dispatchFetch(new Request(url))).toBeNull();
+    }
+    expect(
+      await harness.dispatchFetch(
+        new Request(`${ORIGIN}/assets/index-AAA.js`, { method: "POST" }),
+      ),
+    ).toBeNull();
+    expect(harness.fetchLog).toEqual([]);
+  });
+
+  it("drops the caches of previous builds on activate and claims open pages", async () => {
+    const harness = createHarness(okServer());
+    await harness.cacheStorage.open(appShellCacheName("build-previous"));
+    await harness.cacheStorage.open("unrelated-cache");
+    installAppServiceWorker(harness.scope, MANIFEST);
+    await harness.dispatchInstall();
+    await harness.dispatchActivate();
+
+    expect((await harness.cacheStorage.keys()).sort()).toEqual([
+      appShellCacheName(MANIFEST.buildId),
+      "unrelated-cache",
+    ]);
+    expect(harness.claimCalls).toBe(1);
+  });
+});

--- a/apps/app/src/service-worker/sw-core.ts
+++ b/apps/app/src/service-worker/sw-core.ts
@@ -19,15 +19,16 @@
  *    build, so `bb update` (which rotates every asset hash) cannot leave the
  *    worker serving a mixed build.
  */
-import type { ServiceWorkerPrecacheManifest } from "./sw-manifest.js";
+import {
+  APP_SHELL_MARKER,
+  type ServiceWorkerPrecacheManifest,
+} from "./sw-manifest.js";
 import {
   APP_SHELL_URL_PATH,
   classifyServiceWorkerRequest,
 } from "./sw-routing.js";
 
-/** Text that only the real app shell contains; a sign-in or offline page
- * proxied by connect never does, so a shell precache that lacks it is refused. */
-export const APP_SHELL_MARKER = 'class="bb-app-shell"';
+export { APP_SHELL_MARKER };
 
 const CACHE_NAME_PREFIX = "bb-app-";
 

--- a/apps/app/src/service-worker/sw-core.ts
+++ b/apps/app/src/service-worker/sw-core.ts
@@ -1,0 +1,226 @@
+/**
+ * The app service worker's behaviour, written against a small structural
+ * subset of `ServiceWorkerGlobalScope` so it can run under vitest with a fake
+ * scope. `sw.ts` is the thin production entry that binds it to `self`.
+ *
+ * Why this exists: a cold PWA launch on a phone (through bb connect) pays one
+ * tunnel round trip for index.html and then ~40 asset fetches whenever iOS has
+ * evicted the HTTP cache or the phone lands on a new edge colo. Precaching the
+ * boot closure, the thread-route closure and the latin font in Cache Storage
+ * turns that into one HTML round trip.
+ *
+ * Deliberate limits:
+ *  - Navigations stay network-first. The precached shell is served only when
+ *    the fetch itself fails, never on an HTTP error, so the connect sign-in
+ *    gate and the connect offline page keep working unchanged.
+ *  - Nothing under `/api`, `/ws`, `/internal`, `/__` or plugin assets is ever
+ *    intercepted (see sw-routing.ts).
+ *  - Every cache is namespaced by build id and dropped on activate of the next
+ *    build, so `bb update` (which rotates every asset hash) cannot leave the
+ *    worker serving a mixed build.
+ */
+import type { ServiceWorkerPrecacheManifest } from "./sw-manifest.js";
+import {
+  APP_SHELL_URL_PATH,
+  classifyServiceWorkerRequest,
+} from "./sw-routing.js";
+
+/** Text that only the real app shell contains; a sign-in or offline page
+ * proxied by connect never does, so a shell precache that lacks it is refused. */
+export const APP_SHELL_MARKER = 'class="bb-app-shell"';
+
+const CACHE_NAME_PREFIX = "bb-app-";
+
+export function appShellCacheName(buildId: string): string {
+  return `${CACHE_NAME_PREFIX}${buildId}`;
+}
+
+export interface ExtendableEventLike {
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+export interface FetchEventLike extends ExtendableEventLike {
+  request: Request;
+  respondWith(response: Response | Promise<Response>): void;
+}
+
+/** The parts of the Cache API the worker uses; `caches` satisfies it. */
+export interface CacheLike {
+  match(
+    request: RequestInfo | URL,
+    options?: CacheQueryOptions,
+  ): Promise<Response | undefined>;
+  put(request: RequestInfo | URL, response: Response): Promise<void>;
+}
+
+export interface CacheStorageLike {
+  delete(cacheName: string): Promise<boolean>;
+  keys(): Promise<string[]>;
+  open(cacheName: string): Promise<CacheLike>;
+}
+
+export interface ServiceWorkerEventMapLike {
+  activate: ExtendableEventLike;
+  fetch: FetchEventLike;
+  install: ExtendableEventLike;
+}
+
+export interface ServiceWorkerScopeLike {
+  addEventListener<K extends keyof ServiceWorkerEventMapLike>(
+    type: K,
+    listener: (event: ServiceWorkerEventMapLike[K]) => void,
+  ): void;
+  caches: CacheStorageLike;
+  clients: { claim(): Promise<void> };
+  fetch(input: Request | string, init?: RequestInit): Promise<Response>;
+  location: { origin: string };
+  skipWaiting(): Promise<void>;
+}
+
+const MATCH_OPTIONS: CacheQueryOptions = { ignoreVary: true };
+
+/**
+ * A hashed asset response is worth caching only when it is a success that is
+ * not an HTML document: a captive portal, or a proxy gate that answers every
+ * path with a page, must never be stored under a chunk URL, because that entry
+ * would then be served for the life of the build.
+ */
+export function isCacheableAssetResponse(response: Response): boolean {
+  if (!response.ok || response.redirected) return false;
+  const contentType = response.headers.get("content-type") ?? "";
+  return !/^\s*text\/html\b/iu.test(contentType);
+}
+
+async function precacheAppShell(
+  scope: ServiceWorkerScopeLike,
+  cache: CacheLike,
+): Promise<void> {
+  // `no-store` on the request keeps a stale HTTP-cached copy out of the
+  // precache; the server marks index.html uncacheable anyway.
+  const response = await scope.fetch(APP_SHELL_URL_PATH, {
+    cache: "no-store",
+    credentials: "same-origin",
+  });
+  if (!response.ok) {
+    throw new Error(`app shell precache failed: HTTP ${response.status}`);
+  }
+  const html = await response.clone().text();
+  if (!html.includes(APP_SHELL_MARKER)) {
+    throw new Error("app shell precache refused: response is not the app");
+  }
+  await cache.put(APP_SHELL_URL_PATH, response);
+}
+
+async function precacheAssets(
+  scope: ServiceWorkerScopeLike,
+  cache: CacheLike,
+  assetUrls: string[],
+): Promise<void> {
+  // Assets are content-hashed and immutable, so the default cache mode lets
+  // the browser reuse the bytes the page just downloaded instead of pulling
+  // the whole boot closure through the tunnel a second time.
+  await Promise.all(
+    assetUrls.map(async (url) => {
+      const response = await scope.fetch(url, { credentials: "same-origin" });
+      if (!isCacheableAssetResponse(response)) {
+        throw new Error(
+          `asset precache failed: ${url} HTTP ${response.status} ${response.headers.get("content-type") ?? ""}`,
+        );
+      }
+      await cache.put(url, response);
+    }),
+  );
+}
+
+async function deleteStaleCaches(
+  scope: ServiceWorkerScopeLike,
+  keep: string,
+): Promise<void> {
+  const names = await scope.caches.keys();
+  await Promise.all(
+    names
+      .filter((name) => name.startsWith(CACHE_NAME_PREFIX) && name !== keep)
+      .map((name) => scope.caches.delete(name)),
+  );
+}
+
+async function respondToNavigation(
+  scope: ServiceWorkerScopeLike,
+  cacheName: string,
+  request: Request,
+): Promise<Response> {
+  try {
+    return await scope.fetch(request);
+  } catch (error) {
+    const cache = await scope.caches.open(cacheName);
+    const shell = await cache.match(APP_SHELL_URL_PATH, MATCH_OPTIONS);
+    if (shell !== undefined) return shell;
+    throw error;
+  }
+}
+
+async function respondToAsset(
+  scope: ServiceWorkerScopeLike,
+  cacheName: string,
+  request: Request,
+): Promise<Response> {
+  const cache = await scope.caches.open(cacheName);
+  const cached = await cache.match(request, MATCH_OPTIONS);
+  if (cached !== undefined) return cached;
+  const response = await scope.fetch(request);
+  // A 404 here is a stale hash after `bb update`; the page's preload-error
+  // handler reloads for it, and it must not be pinned in the cache.
+  if (isCacheableAssetResponse(response)) {
+    // Fire-and-forget: the response goes to the page first.
+    void cache.put(request, response.clone()).catch(() => undefined);
+  }
+  return response;
+}
+
+export function installAppServiceWorker(
+  scope: ServiceWorkerScopeLike,
+  manifest: ServiceWorkerPrecacheManifest,
+): void {
+  const cacheName = appShellCacheName(manifest.buildId);
+  const scopeOrigin = scope.location.origin;
+
+  scope.addEventListener("install", (event) => {
+    event.waitUntil(
+      (async () => {
+        const cache = await scope.caches.open(cacheName);
+        await Promise.all([
+          precacheAppShell(scope, cache),
+          precacheAssets(scope, cache, manifest.assetUrls),
+        ]);
+        // A new build takes over immediately; the page's chunk-load-failure
+        // handler covers the (already possible) window where an old page asks
+        // for a hash the updated server no longer has.
+        await scope.skipWaiting();
+      })(),
+    );
+  });
+
+  scope.addEventListener("activate", (event) => {
+    event.waitUntil(
+      (async () => {
+        await deleteStaleCaches(scope, cacheName);
+        await scope.clients.claim();
+      })(),
+    );
+  });
+
+  scope.addEventListener("fetch", (event) => {
+    const requestClass = classifyServiceWorkerRequest({
+      method: event.request.method,
+      mode: event.request.mode,
+      scopeOrigin,
+      url: event.request.url,
+    });
+    if (requestClass === "navigation") {
+      event.respondWith(respondToNavigation(scope, cacheName, event.request));
+    } else if (requestClass === "asset") {
+      event.respondWith(respondToAsset(scope, cacheName, event.request));
+    }
+    // passthrough: no respondWith, the browser fetches as if no worker ran.
+  });
+}

--- a/apps/app/src/service-worker/sw-manifest.ts
+++ b/apps/app/src/service-worker/sw-manifest.ts
@@ -1,0 +1,12 @@
+/**
+ * Contract between the build (vite-service-worker.ts computes it from the
+ * bundle graph and inlines it as `__BB_SW_MANIFEST__`) and the worker
+ * (sw-core.ts precaches it). Kept import-free so both tsconfig projects can
+ * list it.
+ */
+export interface ServiceWorkerPrecacheManifest {
+  /** Stable hash of the precache list + shell html; namespaces one build's caches. */
+  buildId: string;
+  /** Root-relative URLs of the immutable assets to precache (`/assets/...`). */
+  assetUrls: string[];
+}

--- a/apps/app/src/service-worker/sw-manifest.ts
+++ b/apps/app/src/service-worker/sw-manifest.ts
@@ -10,3 +10,12 @@ export interface ServiceWorkerPrecacheManifest {
   /** Root-relative URLs of the immutable assets to precache (`/assets/...`). */
   assetUrls: string[];
 }
+
+/**
+ * Text that only the real app shell contains (the `<body>` class in
+ * apps/app/index.html). The build refuses to emit a worker whose shell lacks
+ * it, and the worker refuses to precache a shell response without it, so a
+ * connect sign-in or offline page proxied at the app URL is never installed
+ * as the offline fallback.
+ */
+export const APP_SHELL_MARKER = 'class="bb-app-shell"';

--- a/apps/app/src/service-worker/sw-routing.test.ts
+++ b/apps/app/src/service-worker/sw-routing.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { classifyServiceWorkerRequest } from "./sw-routing.js";
+
+const scopeOrigin = "https://bee.getbb.app";
+const classify = (url: string, mode = "cors", method = "GET") =>
+  classifyServiceWorkerRequest({ method, mode, scopeOrigin, url });
+
+describe("classifyServiceWorkerRequest", () => {
+  it("routes app navigations and hashed assets, nothing else", () => {
+    expect(classify(`${scopeOrigin}/`, "navigate")).toBe("navigation");
+    expect(
+      classify(`${scopeOrigin}/threads/thr_1?panel=diff`, "navigate"),
+    ).toBe("navigation");
+    expect(classify(`${scopeOrigin}/assets/index-AAA.js`)).toBe("asset");
+    expect(classify(`${scopeOrigin}/assets/inter-latin-BBB.woff2`)).toBe(
+      "asset",
+    );
+  });
+
+  it("passes through API, realtime, host, connect, plugin, root-file and foreign requests", () => {
+    for (const url of [
+      `${scopeOrigin}/api/v1/threads`,
+      `${scopeOrigin}/api/v1/plugins/tasks/assets/app.js`,
+      `${scopeOrigin}/api/v1/plugins/tasks/assets/app.css`,
+      `${scopeOrigin}/ws`,
+      `${scopeOrigin}/internal/hosts/enroll-key`,
+      `${scopeOrigin}/__tunnel`,
+      `${scopeOrigin}/sw.js`,
+      `${scopeOrigin}/manifest.webmanifest`,
+      `${scopeOrigin}/icon-192.png`,
+      `${scopeOrigin}/assets/`,
+      "https://cdn.example.com/assets/index-AAA.js",
+      "not a url",
+    ]) {
+      expect(classify(url), url).toBe("passthrough");
+    }
+    expect(classify(`${scopeOrigin}/assets/index-AAA.js`, "cors", "POST")).toBe(
+      "passthrough",
+    );
+  });
+
+  it("never answers a navigation to a non-app path from the shell", () => {
+    for (const path of [
+      "/api",
+      "/api/v1/threads/thr_1/attachments/att_1/download",
+      "/ws",
+      "/internal/status",
+      "/__tunnel",
+      "/install.sh",
+      "/install/version",
+    ]) {
+      expect(classify(`${scopeOrigin}${path}`, "navigate"), path).toBe(
+        "passthrough",
+      );
+    }
+  });
+});

--- a/apps/app/src/service-worker/sw-routing.ts
+++ b/apps/app/src/service-worker/sw-routing.ts
@@ -1,0 +1,74 @@
+/**
+ * Request classification for the app service worker. Pure so the strategy
+ * table can be unit-tested without a service-worker global.
+ *
+ * Only two request classes are handled by the worker:
+ *  - `navigation`: a top-level document load for an app route. Network-first
+ *    so the connect sign-in gate, the connect offline page and a freshly
+ *    updated index.html always win; the precached shell is served only when
+ *    the network itself fails.
+ *  - `asset`: an immutable content-hashed file under `/assets/`. Cache-first
+ *    from the precache (boot + thread route closure + latin font) with an
+ *    on-demand runtime cache for lazily loaded chunks.
+ *
+ * Everything else — `/api`, `/ws`, host daemon `/internal`, plugin assets
+ * (`/api/v1/plugins/*`), the connect `/__*` namespace, the install script,
+ * root PWA files, the worker script itself and every non-GET or cross-origin
+ * request — is `passthrough`: the worker does not call `respondWith`, so the
+ * request behaves exactly as if no worker were installed.
+ */
+export type ServiceWorkerRequestClass = "navigation" | "asset" | "passthrough";
+
+export const APP_SHELL_URL_PATH = "/index.html";
+export const SERVICE_WORKER_URL_PATH = "/sw.js";
+export const IMMUTABLE_ASSET_URL_PREFIX = "/assets/";
+
+/**
+ * Navigations to these prefixes are never answered from the shell: they are
+ * API/tunnel/host endpoints or connect-owned pages, not client routes.
+ */
+const NON_APP_NAVIGATION_PREFIXES = [
+  "/api/",
+  "/ws",
+  "/internal",
+  "/__",
+  "/install",
+] as const;
+
+export interface ClassifyRequestArgs {
+  method: string;
+  mode: string;
+  /** Origin of the worker's own scope, e.g. `https://bee.getbb.app`. */
+  scopeOrigin: string;
+  url: string;
+}
+
+export function isNonAppNavigationPath(pathname: string): boolean {
+  if (pathname === "/api") return true;
+  return NON_APP_NAVIGATION_PREFIXES.some((prefix) =>
+    pathname.startsWith(prefix),
+  );
+}
+
+export function classifyServiceWorkerRequest(
+  args: ClassifyRequestArgs,
+): ServiceWorkerRequestClass {
+  if (args.method !== "GET") return "passthrough";
+  let url: URL;
+  try {
+    url = new URL(args.url);
+  } catch {
+    return "passthrough";
+  }
+  if (url.origin !== args.scopeOrigin) return "passthrough";
+  if (args.mode === "navigate") {
+    return isNonAppNavigationPath(url.pathname) ? "passthrough" : "navigation";
+  }
+  if (
+    url.pathname.startsWith(IMMUTABLE_ASSET_URL_PREFIX) &&
+    url.pathname.length > IMMUTABLE_ASSET_URL_PREFIX.length
+  ) {
+    return "asset";
+  }
+  return "passthrough";
+}

--- a/apps/app/src/service-worker/sw.ts
+++ b/apps/app/src/service-worker/sw.ts
@@ -1,0 +1,18 @@
+/**
+ * Production entry of the app service worker. Built by vite-service-worker.ts
+ * as a single classic script at `/sw.js`; the precache manifest is injected as
+ * the `__BB_SW_MANIFEST__` constant at build time. Registered from main.tsx via
+ * lib/service-worker-registration.ts.
+ */
+import {
+  installAppServiceWorker,
+  type ServiceWorkerScopeLike,
+} from "./sw-core.js";
+import type { ServiceWorkerPrecacheManifest } from "./sw-manifest.js";
+
+declare const __BB_SW_MANIFEST__: ServiceWorkerPrecacheManifest;
+// Module-scoped shadow of the DOM `self`: this file runs in a worker global,
+// which the app tsconfig (DOM lib) has no declaration for.
+declare const self: ServiceWorkerScopeLike;
+
+installAppServiceWorker(self, __BB_SW_MANIFEST__);

--- a/apps/app/tsconfig.node.json
+++ b/apps/app/tsconfig.node.json
@@ -12,6 +12,8 @@
     "vite.dev.config.ts",
     "vite-bundle-stats.ts",
     "vite-font-preload.ts",
-    "vite-shared-ui-seam.ts"
+    "vite-shared-ui-seam.ts",
+    "vite-service-worker.ts",
+    "src/service-worker/sw-manifest.ts"
   ]
 }

--- a/apps/app/vite-service-worker.ts
+++ b/apps/app/vite-service-worker.ts
@@ -1,0 +1,169 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build, type Plugin } from "vite";
+import type { ServiceWorkerPrecacheManifest } from "./src/service-worker/sw-manifest.js";
+
+const appDir = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * The structural subset of Vite's `OutputBundle` the manifest builder reads.
+ * Declared locally so tests can hand in small literal bundles.
+ */
+export interface ManifestBundleChunk {
+  type: "chunk";
+  fileName: string;
+  isEntry: boolean;
+  facadeModuleId: string | null;
+  imports: string[];
+  dynamicImports: string[];
+  viteMetadata?: { importedCss: Set<string> } | undefined;
+}
+
+export interface ManifestBundleAsset {
+  type: "asset";
+  fileName: string;
+}
+
+export type ManifestBundle = Record<
+  string,
+  ManifestBundleChunk | ManifestBundleAsset
+>;
+
+export interface BuildPrecacheManifestOptions {
+  /**
+   * Absolute module ids of lazily imported route modules whose static-import
+   * closure joins the precache (the thread route). Other `lazy()` views stay
+   * on demand and are cached at runtime the first time they load.
+   */
+  routeModuleIds: string[];
+  /** Emitted assets (not chunks) to precache, matched by output file name. */
+  assetFileNamePatterns: RegExp[];
+  /** Built `index.html` text; folded into the build id so a shell-only change
+   * still rolls the worker. */
+  indexHtml: string;
+}
+
+function stripQuery(moduleId: string): string {
+  const queryStart = moduleId.indexOf("?");
+  return queryStart === -1 ? moduleId : moduleId.slice(0, queryStart);
+}
+
+/**
+ * Precache = the entry chunk's static-import closure (the boot payload the
+ * page modulepreloads anyway) + the static closure of each configured route
+ * module + the CSS those chunks import + explicitly listed assets.
+ */
+export function buildServiceWorkerPrecacheManifest(
+  bundle: ManifestBundle,
+  options: BuildPrecacheManifestOptions,
+): ServiceWorkerPrecacheManifest {
+  const chunks = Object.values(bundle).filter(
+    (output): output is ManifestBundleChunk => output.type === "chunk",
+  );
+  const entry = chunks.find((chunk) => chunk.isEntry);
+  if (entry === undefined) {
+    throw new Error("service worker precache: bundle has no entry chunk");
+  }
+  const byFileName = new Map(chunks.map((chunk) => [chunk.fileName, chunk]));
+
+  const roots = [entry];
+  const wantedRouteIds = new Set(options.routeModuleIds.map(stripQuery));
+  for (const chunk of chunks) {
+    if (chunk.facadeModuleId === null) continue;
+    if (wantedRouteIds.delete(stripQuery(chunk.facadeModuleId))) {
+      roots.push(chunk);
+    }
+  }
+  if (wantedRouteIds.size > 0) {
+    throw new Error(
+      `service worker precache: no chunk for route module(s) ${[...wantedRouteIds].join(", ")}`,
+    );
+  }
+
+  const files = new Set<string>();
+  const walk = (chunk: ManifestBundleChunk): void => {
+    if (files.has(chunk.fileName)) return;
+    files.add(chunk.fileName);
+    for (const css of chunk.viteMetadata?.importedCss ?? []) files.add(css);
+    for (const imported of chunk.imports) {
+      const next = byFileName.get(imported);
+      if (next !== undefined) walk(next);
+    }
+  };
+  for (const root of roots) walk(root);
+
+  for (const output of Object.values(bundle)) {
+    if (output.type !== "asset") continue;
+    if (
+      options.assetFileNamePatterns.some((pattern) =>
+        pattern.test(output.fileName),
+      )
+    ) {
+      files.add(output.fileName);
+    }
+  }
+
+  const assetUrls = [...files].sort().map((fileName) => `/${fileName}`);
+  const buildId = createHash("sha256")
+    .update(JSON.stringify(assetUrls))
+    .update("\0")
+    .update(options.indexHtml)
+    .digest("hex")
+    .slice(0, 16);
+  return { buildId, assetUrls };
+}
+
+export interface ServiceWorkerPluginOptions {
+  routeModuleIds: string[];
+  assetFileNamePatterns: RegExp[];
+}
+
+/**
+ * Builds `dist/sw.js` after the app bundle is written: computes the precache
+ * manifest from the bundle graph, then compiles src/service-worker/sw.ts as a
+ * single classic script with the manifest inlined. Runs `enforce: "post"` so
+ * the html plugin has already emitted the final index.html.
+ */
+export function serviceWorker(options: ServiceWorkerPluginOptions): Plugin {
+  return {
+    name: "bb:service-worker",
+    apply: "build",
+    enforce: "post",
+    async writeBundle(outputOptions, bundle) {
+      const hasEntry = Object.values(bundle).some(
+        (output) => output.type === "chunk" && output.isEntry,
+      );
+      if (!hasEntry) return;
+      const outDir = outputOptions.dir ?? resolve(appDir, "dist");
+      const indexHtml = await readFile(resolve(outDir, "index.html"), "utf8");
+      const manifest = buildServiceWorkerPrecacheManifest(bundle, {
+        assetFileNamePatterns: options.assetFileNamePatterns,
+        indexHtml,
+        routeModuleIds: options.routeModuleIds,
+      });
+      await build({
+        configFile: false,
+        envFile: false,
+        logLevel: "warn",
+        publicDir: false,
+        root: appDir,
+        define: { __BB_SW_MANIFEST__: JSON.stringify(manifest) },
+        build: {
+          copyPublicDir: false,
+          emptyOutDir: false,
+          lib: {
+            entry: resolve(appDir, "src/service-worker/sw.ts"),
+            fileName: () => "sw.js",
+            formats: ["iife"],
+            name: "bbServiceWorker",
+          },
+          outDir,
+          reportCompressedSize: false,
+          sourcemap: false,
+        },
+      });
+    },
+  };
+}

--- a/apps/app/vite-service-worker.ts
+++ b/apps/app/vite-service-worker.ts
@@ -3,7 +3,10 @@ import { readFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build, type Plugin } from "vite";
-import type { ServiceWorkerPrecacheManifest } from "./src/service-worker/sw-manifest.js";
+import {
+  APP_SHELL_MARKER,
+  type ServiceWorkerPrecacheManifest,
+} from "./src/service-worker/sw-manifest.js";
 
 const appDir = dirname(fileURLToPath(import.meta.url));
 
@@ -59,6 +62,14 @@ export function buildServiceWorkerPrecacheManifest(
   bundle: ManifestBundle,
   options: BuildPrecacheManifestOptions,
 ): ServiceWorkerPrecacheManifest {
+  if (!options.indexHtml.includes(APP_SHELL_MARKER)) {
+    // The worker only installs a shell that carries this marker; a build
+    // whose index.html lost it would ship a worker that silently never
+    // installs. Fail loudly here instead.
+    throw new Error(
+      `service worker precache: index.html does not contain ${APP_SHELL_MARKER}`,
+    );
+  }
   const chunks = Object.values(bundle).filter(
     (output): output is ManifestBundleChunk => output.type === "chunk",
   );

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -6,6 +6,7 @@ import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { bundleStats } from "./vite-bundle-stats.js";
 import { fontPreload } from "./vite-font-preload.js";
+import { serviceWorker } from "./vite-service-worker.js";
 import { sharedUiEnvSeam } from "./vite-shared-ui-seam.js";
 
 const appDir = dirname(fileURLToPath(import.meta.url));
@@ -20,6 +21,15 @@ export const sharedViteConfig = {
     bundleStats(),
     // Build-only: <link rel="preload"> for the Inter latin woff2.
     fontPreload(),
+    // Build-only: writes dist/sw.js, the app-shell service worker that
+    // precaches the boot closure, the thread route closure and the latin font
+    // so a cold PWA launch on a phone pays one HTML round trip, not ~40.
+    serviceWorker({
+      routeModuleIds: [resolve(appDir, "src/views/SplitWorkspaceRoute.tsx")],
+      assetFileNamePatterns: [
+        /^assets\/inter-latin-wght-normal-[^/]*\.woff2$/u,
+      ],
+    }),
   ],
   // Keep app and Ladle dep optimization metadata from clobbering each other.
   cacheDir: "node_modules/.vite/app",

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -699,7 +699,14 @@ export function createApp(
       // single-page-app fallback would answer it with index.html at status
       // 200, and the browser would report a confusing MIME type error for a
       // script instead of a plain 404. Mirrors the /api/v1/* guard above.
-      if (urlPath.startsWith("/assets/")) {
+      // The service worker script gets the same treatment: a build without
+      // one must answer its update check with a 404 (which retires the
+      // registration) rather than a 200 HTML page the browser rejects and
+      // keeps the stale worker for.
+      if (
+        urlPath.startsWith("/assets/") ||
+        urlPath === SERVICE_WORKER_URL_PATH
+      ) {
         return context.notFound();
       }
       const indexHtml = await readFile(join(root, "index.html"), "utf8");

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -148,6 +148,13 @@ const STATIC_ASSET_CACHE_CONTROL = "public, max-age=31536000, immutable";
 // with a release; a day of caching keeps favicon/badge flips and PWA
 // relaunches from refetching them.
 const STATIC_PUBLIC_FILE_CACHE_CONTROL = "public, max-age=86400";
+// The app-shell service worker script. Browsers re-fetch it on their own
+// update schedule; `no-cache` lets a conditional request answer that cheaply
+// while guaranteeing a `bb update` is seen at the next check, and it keeps the
+// connect edge (which caches only long max-age responses) from pinning an old
+// worker.
+const SERVICE_WORKER_URL_PATH = "/sw.js";
+const SERVICE_WORKER_CACHE_CONTROL = "no-cache";
 const WEB_SOCKET_SHUTDOWN_CODE = 1001;
 const WEB_SOCKET_SHUTDOWN_FORCE_CLOSE_MS = 1_000;
 const WEB_SOCKET_SHUTDOWN_REASON = "server-shutdown";
@@ -180,6 +187,9 @@ function shouldLogSlowApiRequest(args: ShouldLogSlowApiRequestArgs): boolean {
 function staticCacheControlForPath(urlPath: string): string {
   if (urlPath.startsWith("/assets/")) {
     return STATIC_ASSET_CACHE_CONTROL;
+  }
+  if (urlPath === SERVICE_WORKER_URL_PATH) {
+    return SERVICE_WORKER_CACHE_CONTROL;
   }
   if (urlPath.endsWith(".html")) {
     return STATIC_INDEX_CACHE_CONTROL;

--- a/apps/server/test/app/static-cache.test.ts
+++ b/apps/server/test/app/static-cache.test.ts
@@ -34,6 +34,10 @@ describe("production static cache headers", () => {
       join(staticDir, "favicon-32x32.png"),
       Buffer.from([0x89, 0x50, 0x4e, 0x47]),
     );
+    await writeFile(
+      join(staticDir, "sw.js"),
+      "self.addEventListener('fetch', () => {});",
+    );
 
     const harness = await createTestAppHarness();
     const serverApp = createApp(harness.deps, { staticDir });
@@ -114,6 +118,18 @@ describe("production static cache headers", () => {
       expect(iconResponse.headers.get("content-type")).toBe("image/png");
       expect(iconResponse.headers.get("cache-control")).toBe(
         "public, max-age=86400",
+      );
+
+      // The service worker script must be revalidated on every update check
+      // (never immutable, never pinned by the connect edge) but is allowed a
+      // conditional request, unlike the no-store shell.
+      const serviceWorkerResponse = await serverApp.app.request("/sw.js");
+      expect(serviceWorkerResponse.status).toBe(200);
+      expect(serviceWorkerResponse.headers.get("content-type")).toBe(
+        "application/javascript",
+      );
+      expect(serviceWorkerResponse.headers.get("cache-control")).toBe(
+        "no-cache",
       );
 
       const apiMissResponse = await serverApp.app.request(

--- a/apps/server/test/app/static-cache.test.ts
+++ b/apps/server/test/app/static-cache.test.ts
@@ -154,6 +154,17 @@ describe("production static cache headers", () => {
       );
       expect(assetMissResponse.status).toBe(404);
       expect(await assetMissResponse.text()).not.toContain("index-test.js");
+
+      // A build without a worker script must answer the browser's update
+      // check with a 404 (which retires the registration), never with the
+      // shell at status 200 that the browser rejects while keeping the old
+      // worker alive.
+      await rm(join(staticDir, "sw.js"));
+      const serviceWorkerMissResponse = await serverApp.app.request("/sw.js");
+      expect(serviceWorkerMissResponse.status).toBe(404);
+      expect(await serviceWorkerMissResponse.text()).not.toContain(
+        "index-test.js",
+      );
     } finally {
       await serverApp.closeWebSockets();
       await harness.cleanup();

--- a/docs/debugging-and-qa.md
+++ b/docs/debugging-and-qa.md
@@ -58,6 +58,22 @@ payloads. Use it to reproduce performance problems that only appear at scale.
   deletes the database file first. Without `--reset` the fixture appends.
 - Example: `pnpm seed:perf -- --reset --events 400000`.
 
+## App Shell Service Worker
+
+Production builds register `/sw.js` (built by `apps/app/vite-service-worker.ts`
+from `apps/app/src/service-worker/`) on secure origins outside the desktop
+shell. It precaches the boot closure, the thread route closure and the latin
+font, serves `/assets/*` cache-first, and answers app navigations network-first
+with the precached shell only when the network fails. `/api`, `/ws`,
+`/internal`, `/__*` and plugin assets are never intercepted. Dev never registers
+it.
+
+- Caches are named `bb-app-<buildId>`; a new build drops the old ones on
+  activate. When a QA session shows stale assets, check Application > Service
+  Workers (Chrome) or Develop > Service Workers (Safari) and unregister there.
+- The server serves `/sw.js` with `Cache-Control: no-cache` so an update is
+  seen at the browser's next check; the shell stays `no-store`.
+
 ## Local Cloud
 
 Run the Cloud dashboard and Connect worker against one local D1 database:


### PR DESCRIPTION
## What was wrong

A cold launch of the bb PWA on a phone through bb connect paid one tunnel round trip for index.html and then ~40 asset fetches (~450 KB brotli boot payload) whenever iOS evicted the HTTP cache or the phone reached a new edge colo. The app registered no service worker; only `/assets/*` was cacheable, and the connect edge refuses `no-store` HTML. A lazy chunk that 404s after `bb update` rotates hashes also left a blank route with no recovery (audit finding A11).

## What changed

- `apps/app/vite-service-worker.ts` (new, `bb:service-worker` plugin, `enforce: "post"`, `writeBundle`): builds the precache manifest from the bundle graph (entry static closure + `src/views/SplitWorkspaceRoute.tsx` static closure + imported CSS + `inter-latin-wght-normal-*.woff2`), derives a build id from the URL list and the built index.html, then compiles `src/service-worker/sw.ts` with a nested lib-mode Vite build into a single classic script `dist/sw.js` (5 KB raw / 2 KB br, precompressed by the existing step). The build fails if the route module has no chunk.
- `apps/app/src/service-worker/sw-core.ts`, `sw-routing.ts`, `sw-manifest.ts`, `sw.ts` (new): install precaches the manifest and `/index.html`, refuses to install when the shell response lacks the `class="bb-app-shell"` marker (connect sign-in page) or an asset answers with HTML (captive portal), then `skipWaiting`. Navigations: network-first, precached shell only when `fetch` rejects; navigations to `/api`, `/ws`, `/internal`, `/__*`, `/install*` are never intercepted. `/assets/*` GET: cache-first, on-demand runtime cache in the same build-scoped cache, never stores 404/HTML/redirects. Everything else passes through (no `respondWith`). Activate deletes `bb-app-*` caches of other builds and claims clients.
- `apps/app/src/lib/service-worker-registration.ts` (new): registers `/sw.js` after `load` only when `import.meta.env.PROD && window.isSecureContext && "serviceWorker" in navigator && !window.bbDesktop`.
- `apps/app/src/lib/chunk-load-failure-reload.ts` (new): `vite:preloadError` handler reloads once (sessionStorage stamp, 60 s window, in-memory latch), otherwise lets the error reach the boundary.
- `apps/app/src/main.tsx`: installs the reload handler and calls the registration.
- `apps/server/src/server.ts`: `/sw.js` gets `Cache-Control: no-cache`; index.html and other root files stay `no-store`.
- `docs/debugging-and-qa.md`: short section on the worker and how to unregister it during QA.
- `apps/app/tsconfig.node.json`, `apps/app/package.json` (lint list), `apps/app/vite.config.ts` wiring.

## How you verified

- New tests (fail before / pass after): `apps/app/src/service-worker/precache-manifest.test.ts` (closure selection, CSS, font pattern, exclusions, deterministic build id that changes with assets or html, missing route module throws), `apps/app/src/service-worker/sw-core.test.ts` (fake scope + fake Cache Storage: install precache + skipWaiting, sign-in shell refused, missing asset fails install, navigation network-first / shell fallback offline / non-app navigations untouched, asset cache-first + runtime cache + 404 not cached, captive-portal HTML never cached, passthrough classes, activate cleanup + claim), `apps/app/src/service-worker/sw-routing.test.ts`, `apps/app/src/lib/service-worker-registration.test.ts` (gating), `apps/app/src/lib/chunk-load-failure-reload.test.ts` (one-shot + window + concurrent collapse), and `apps/server/test/app/static-cache.test.ts` extended for `/sw.js` (200, application/javascript, no-cache).
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/server`: 2 successful.
- `pnpm exec turbo run lint --filter=@bb/app`: 0 errors (147 pre-existing warnings, none in changed files).
- `pnpm exec turbo run test --filter=@bb/app -- src/service-worker src/lib/service-worker-registration.test.ts src/lib/chunk-load-failure-reload.test.ts`: 5 files, 17 tests passed. `pnpm exec turbo run test --filter=@bb/server -- test/app/static-cache.test.ts`: passed.
- `pnpm exec turbo run build --filter=@bb/app --force`: emits `dist/sw.js` (+ .br/.gz); manifest has 77 URLs (~1.4 MB br) and covers every `/assets/` href/src in the built index.html; `node scripts/check-bundle-budget.mjs`: 449.2 KB br boot, budget OK.
- Not exercised in a real browser/iOS Simulator (no dev server per task rules); see risks.

Fixes: part of the mobile / iOS Safari performance program (verified sweep report in the bb thread; no single issue).


## Stack context

Layer 28 of 28 in the `bb/mobile-perf/*` stack (bottom → top: quick wins first, big rocks last).
- Prerequisite (layer below): `bb/mobile-perf/persisted-query-cache` (#1906).
- Audit findings addressed: see title IDs. Review: approved-with-fixes; 2 review fix commit(s).
- Reviewer notes / follow-ups: Not exercised in a real browser / iOS Simulator (dev server forbidden in this review as well); a manual pass over https/localhost is still recommended before merge, especially conn | Navigations are intercepted without navigation preload, so a cold PWA launch serializes SW startup before the index.html tunnel RTT (tens of ms desktop, ~100 ms+ on iOS). Deliberat | install() fetches all 77 precache URLs at once (mostly HTTP-cache hits after load); could be staged on idle later, as the implementer noted. | /sw.js is served without ETag/Last-Modified, so the per-launch update check is a full 2 KB br refetch through the tunnel; cheap, but a conditional 304 would be cheaper.
- Wire/contract: None. No server<->daemon wire, RPC, session payload or WebSocket message changed; HOST_DAEMON_PROTOCOL_VERSION not bumped. Only new HTTP surface: the static file /sw.js is now served with `Cache-Control: no-cache` (all other non-/assets/ static files keep `no-store`). No env var / CLI flag / config knob added.

> AGENT GENERATED: by Claude Opus 5

