### PR TITLE
Read the thread TOC breakpoint off the ResizeObserver entry

### DIFF
--- a/apps/app/src/components/thread/toc/ThreadTableOfContents.test.tsx
+++ b/apps/app/src/components/thread/toc/ThreadTableOfContents.test.tsx
@@ -43,8 +43,33 @@ import {
 } from "./ThreadTableOfContents";
 import { ThreadTitleMentionResourcesProvider } from "@/components/thread/ThreadTitleMentions";
 
+/**
+ * Models the part of ResizeObserver the TOC depends on: `observe` delivers the
+ * target's current content box immediately, and the content box is the border
+ * box minus horizontal padding. The TOC reads that entry instead of forcing a
+ * style recalculation, so the arithmetic belongs here in the platform stand-in
+ * rather than in the component.
+ */
 class ResizeObserverMock implements ResizeObserver {
-  observe: ResizeObserver["observe"] = vi.fn();
+  constructor(private readonly callback: ResizeObserverCallback) {}
+
+  observe: ResizeObserver["observe"] = (target) => {
+    const element = target as HTMLElement;
+    const paddingX =
+      (Number.parseFloat(element.style.paddingLeft) || 0) +
+      (Number.parseFloat(element.style.paddingRight) || 0);
+    const inlineSize = Math.max(0, element.clientWidth - paddingX);
+    this.callback(
+      [
+        {
+          target,
+          contentBoxSize: [{ inlineSize, blockSize: 0 }],
+          contentRect: { width: inlineSize } as DOMRectReadOnly,
+        } as unknown as ResizeObserverEntry,
+      ],
+      this,
+    );
+  };
   unobserve: ResizeObserver["unobserve"] = vi.fn();
   disconnect: ResizeObserver["disconnect"] = vi.fn();
 }
@@ -386,8 +411,9 @@ describe("ThreadTableOfContents", () => {
     );
   });
 
-  // The overlay pads itself, so `clientWidth` runs 24px ahead of the content
-  // box the `@container` rule measures. Both boundaries must agree with CSS.
+  // The overlay pads itself, so its border box runs 24px ahead of the content
+  // box both the `@container` rule and the ResizeObserver entry report. The JS
+  // boundary and the CSS breakpoint must agree.
   it("does not request the outline when padding hides the TOC", () => {
     render(
       <TocHost

--- a/apps/app/src/components/thread/toc/ThreadTableOfContents.tsx
+++ b/apps/app/src/components/thread/toc/ThreadTableOfContents.tsx
@@ -274,20 +274,25 @@ function useConversationTocItems({
 }
 
 /**
- * Returns the width a container query sees for `host`.
+ * Whether the scroll overlay is wide enough for the TOC, tracked against the
+ * same width the `@container` rule sees.
  *
- * An inline-size container query resolves against the content box, but
- * `clientWidth` also counts horizontal padding. The scroll overlay pads itself,
- * so the raw `clientWidth` would report the TOC as visible for a padding-wide
- * band below the CSS breakpoint.
+ * The width comes off the ResizeObserver entry's content box, which is exactly
+ * what an inline-size container query resolves against — padding excluded, so
+ * this boundary and the CSS breakpoint agree. (`clientWidth` counts the
+ * overlay's own horizontal padding, and would report the TOC visible for a
+ * padding-wide band below the breakpoint.)
+ *
+ * Reading the entry rather than measuring the element is the point. The
+ * previous `getComputedStyle(host)` + `clientWidth` pair forced a synchronous
+ * style recalculation, and it ran inside a `requestAnimationFrame` callback —
+ * which fires before the frame's style and layout phase, so the recalculation
+ * was unavoidable and full-document. In Safari that single call cost 750ms on
+ * one profiled thread and 67% of all script time on another, and the resulting
+ * `setVisible` re-triggered the observer ("ResizeObserver loop completed with
+ * undelivered notifications"). ResizeObserver callbacks already run after
+ * layout, so the entry is free and the animation-frame hop is unnecessary.
  */
-function containerInlineSize(host: HTMLElement): number {
-  const style = window.getComputedStyle(host);
-  const paddingLeft = Number.parseFloat(style.paddingLeft) || 0;
-  const paddingRight = Number.parseFloat(style.paddingRight) || 0;
-  return host.clientWidth - paddingLeft - paddingRight;
-}
-
 function useThreadTocVisible(rootElement: HTMLElement | null): boolean {
   const [visible, setVisible] = useState(
     () => typeof ResizeObserver === "undefined",
@@ -305,23 +310,16 @@ function useThreadTocVisible(rootElement: HTMLElement | null): boolean {
       return;
     }
 
-    let frame: number | null = null;
-    const measure = () => {
-      frame = null;
-      setVisible(containerInlineSize(host) >= TOC_MIN_VISIBLE_WIDTH_PX);
-    };
-    const scheduleMeasure = () => {
-      if (frame !== null) return;
-      frame = window.requestAnimationFrame(measure);
-    };
-
-    scheduleMeasure();
-    const resizeObserver = new ResizeObserver(scheduleMeasure);
-    resizeObserver.observe(host);
-    return () => {
-      if (frame !== null) window.cancelAnimationFrame(frame);
-      resizeObserver.disconnect();
-    };
+    // `observe` delivers the current content box straight away, so there is no
+    // separate initial measurement to make.
+    const resizeObserver = new ResizeObserver(([entry]) => {
+      if (!entry) return;
+      const inlineSize =
+        entry.contentBoxSize[0]?.inlineSize ?? entry.contentRect.width;
+      setVisible(inlineSize >= TOC_MIN_VISIBLE_WIDTH_PX);
+    });
+    resizeObserver.observe(host, { box: "content-box" });
+    return () => resizeObserver.disconnect();
   }, [rootElement]);
 
   return visible;


### PR DESCRIPTION
useThreadTocVisible measured the scroll overlay with `getComputedStyle(host)` plus `clientWidth`, inside a requestAnimationFrame callback. rAF runs before the frame's style and layout phase, so that pairing forced a full-document style recalculation every time it fired — 750ms per call on one profiled thread, and 67% of all script time on another. The resulting setVisible re-triggered the observer, which is the "ResizeObserver loop completed with undelivered notifications" warning seen in the console.

The observer entry already carries the number: contentBoxSize[0].inlineSize is exactly what an inline-size container query resolves against, so the padding correction the old code reconstructed by hand comes for free. ResizeObserver callbacks run after layout, so reading the entry costs nothing and the animation-frame hop is unnecessary. containerInlineSize is deleted.

Behavior on display:none is unchanged — a box-less element gets no entry, so visibility stays false exactly as the old clientWidth === 0 path did, and the observer fires normally once the element is shown.

The test's ResizeObserverMock now models the platform instead: observe() delivers the target's current content box (border box minus horizontal padding). The three breakpoint tests still assert the same numbers, 876px hidden and 896px shown.
