### PR TITLE
Keep script-policy npm config out of plugin install children

### DIFF
--- a/apps/server/src/services/plugins/install-sources.ts
+++ b/apps/server/src/services/plugins/install-sources.ts
@@ -15,7 +15,10 @@ import {
 } from "node:fs/promises";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import semver from "semver";
-import { spawnPortableOutputProcess } from "@bb/process-utils";
+import {
+  omitNpmScriptPolicyEnv,
+  spawnPortableOutputProcess,
+} from "@bb/process-utils";
 
 /**
  * What a `git:` spec asks for.
@@ -675,46 +678,6 @@ export async function promoteGitPluginArtifact(args: {
 export const INSTALL_COMMAND_TIMEOUT_MS = 5 * 60_000;
 
 /**
- * The environment a git/npm child inherits: ours, minus the npm config keys
- * that decide whether package scripts run.
- *
- * npm reads `npm_config_*` environment variables as configuration, and env
- * outranks every `.npmrc` in npm's precedence (cli > env > project > user >
- * global). Script policy is not the operator's to set here: installs pass
- * `--ignore-scripts` because nothing in a freshly fetched plugin's dependency
- * tree may execute, and an inherited value that contradicts that is at best
- * confusing and at worst a bypass attempt.
- *
- * It is also a live footgun. Launching bb through a package manager
- * (`pnpm start`) exports the user's whole `~/.npmrc` as `npm_config_*`, so an
- * ordinary `allow-scripts=@github/keytar,node-pty` line arrived at npm 12 as
- * if it were `--allow-scripts` and made every git and npm plugin install fail
- * with EALLOWSCRIPTS.
- *
- * Every other `npm_config_*` key is left alone on purpose. Env is a supported
- * way to configure bb's npm access — plugin-registration reads
- * `npm_config_registry` as bb's own registry default, and operators point npm
- * at a private registry, a shared cache, or an alternate userconfig the same
- * way. Dropping those would break real deployments while fixing nothing.
- */
-const SCRIPT_POLICY_NPM_CONFIG_ENV_KEYS = new Set([
-  "npm_config_allow_scripts",
-  "npm_config_ignore_scripts",
-  "npm_config_foreground_scripts",
-]);
-
-function packageManagerChildEnv(): NodeJS.ProcessEnv {
-  const env: NodeJS.ProcessEnv = {};
-  for (const [key, value] of Object.entries(process.env)) {
-    if (value === undefined) continue;
-    // npm case-folds config env keys, so normalize before matching.
-    if (SCRIPT_POLICY_NPM_CONFIG_ENV_KEYS.has(key.toLowerCase())) continue;
-    env[key] = value;
-  }
-  return env;
-}
-
-/**
  * Run a materialization command (git/npm), buffering output. Throws a clear
  * error when the binary is missing, the command times out, or it exits
  * non-zero (with the stderr tail — that is where git/npm explain themselves).
@@ -737,7 +700,7 @@ export async function runInstallCommand(
   const child = spawnPortableOutputProcess({
     command,
     args,
-    env: packageManagerChildEnv(),
+    env: omitNpmScriptPolicyEnv(process.env),
   });
   let stderr = "";
   let stdout = "";

--- a/apps/server/src/services/plugins/install-sources.ts
+++ b/apps/server/src/services/plugins/install-sources.ts
@@ -675,6 +675,46 @@ export async function promoteGitPluginArtifact(args: {
 export const INSTALL_COMMAND_TIMEOUT_MS = 5 * 60_000;
 
 /**
+ * The environment a git/npm child inherits: ours, minus the npm config keys
+ * that decide whether package scripts run.
+ *
+ * npm reads `npm_config_*` environment variables as configuration, and env
+ * outranks every `.npmrc` in npm's precedence (cli > env > project > user >
+ * global). Script policy is not the operator's to set here: installs pass
+ * `--ignore-scripts` because nothing in a freshly fetched plugin's dependency
+ * tree may execute, and an inherited value that contradicts that is at best
+ * confusing and at worst a bypass attempt.
+ *
+ * It is also a live footgun. Launching bb through a package manager
+ * (`pnpm start`) exports the user's whole `~/.npmrc` as `npm_config_*`, so an
+ * ordinary `allow-scripts=@github/keytar,node-pty` line arrived at npm 12 as
+ * if it were `--allow-scripts` and made every git and npm plugin install fail
+ * with EALLOWSCRIPTS.
+ *
+ * Every other `npm_config_*` key is left alone on purpose. Env is a supported
+ * way to configure bb's npm access — plugin-registration reads
+ * `npm_config_registry` as bb's own registry default, and operators point npm
+ * at a private registry, a shared cache, or an alternate userconfig the same
+ * way. Dropping those would break real deployments while fixing nothing.
+ */
+const SCRIPT_POLICY_NPM_CONFIG_ENV_KEYS = new Set([
+  "npm_config_allow_scripts",
+  "npm_config_ignore_scripts",
+  "npm_config_foreground_scripts",
+]);
+
+function packageManagerChildEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined) continue;
+    // npm case-folds config env keys, so normalize before matching.
+    if (SCRIPT_POLICY_NPM_CONFIG_ENV_KEYS.has(key.toLowerCase())) continue;
+    env[key] = value;
+  }
+  return env;
+}
+
+/**
  * Run a materialization command (git/npm), buffering output. Throws a clear
  * error when the binary is missing, the command times out, or it exits
  * non-zero (with the stderr tail — that is where git/npm explain themselves).
@@ -694,7 +734,11 @@ export async function runInstallCommand(
   },
 ): Promise<string> {
   const timeoutMs = options?.timeoutMs ?? INSTALL_COMMAND_TIMEOUT_MS;
-  const child = spawnPortableOutputProcess({ command, args });
+  const child = spawnPortableOutputProcess({
+    command,
+    args,
+    env: packageManagerChildEnv(),
+  });
   let stderr = "";
   let stdout = "";
   let stdoutBytes = 0;

--- a/apps/server/test/services/plugins/plugin-install.test.ts
+++ b/apps/server/test/services/plugins/plugin-install.test.ts
@@ -310,6 +310,32 @@ describe("plugin install sources", () => {
     ).rejects.toThrow(/more than 5 bytes/);
   });
 
+  it("keeps script-policy npm config out of git/npm children", async () => {
+    // Launching bb through a package manager exports the user's whole .npmrc
+    // as npm_config_*, and npm reads env above every .npmrc file. An ordinary
+    // allow-scripts entry arrived at npm 12 as --allow-scripts and made every
+    // git and npm plugin install fail with EALLOWSCRIPTS. Installs pass
+    // --ignore-scripts; that policy is not the environment's to override.
+    process.env.npm_config_allow_scripts = "@github/keytar,node-pty";
+    process.env.npm_config_ignore_scripts = "false";
+    // Other npm config is a supported way to point bb at a registry or cache
+    // (plugin-registration reads npm_config_registry itself), so it must pass.
+    const previousRegistry = process.env.npm_config_registry;
+    process.env.npm_config_registry = "https://registry.example.invalid/";
+    try {
+      const seen = await runInstallCommand(process.execPath, [
+        "-e",
+        "process.stdout.write([process.env.npm_config_allow_scripts ?? '-', process.env.npm_config_ignore_scripts ?? '-', process.env.npm_config_registry ?? '-', process.env.PATH === undefined ? 'no-path' : 'path'].join('|'))",
+      ]);
+      expect(seen).toBe("-|-|https://registry.example.invalid/|path");
+    } finally {
+      delete process.env.npm_config_allow_scripts;
+      delete process.env.npm_config_ignore_scripts;
+      if (previousRegistry === undefined) delete process.env.npm_config_registry;
+      else process.env.npm_config_registry = previousRegistry;
+    }
+  });
+
   it("keeps scoped npm and nested git cache paths inside their roots", () => {
     expect(npmArtifactCacheDir("/data", "@acme/plugin", "1.2.3")).toBe(
       "/data/plugins/cache/npm/@acme/plugin/1.2.3",

--- a/apps/server/test/services/plugins/plugin-install.test.ts
+++ b/apps/server/test/services/plugins/plugin-install.test.ts
@@ -313,26 +313,37 @@ describe("plugin install sources", () => {
   it("keeps script-policy npm config out of git/npm children", async () => {
     // Launching bb through a package manager exports the user's whole .npmrc
     // as npm_config_*, and npm reads env above every .npmrc file. An ordinary
-    // allow-scripts entry arrived at npm 12 as --allow-scripts and made every
-    // git and npm plugin install fail with EALLOWSCRIPTS. Installs pass
+    // allow-scripts entry arrived at npm 11/12 as --allow-scripts and made
+    // every git and npm plugin install fail with EALLOWSCRIPTS. Installs pass
     // --ignore-scripts; that policy is not the environment's to override.
-    process.env.npm_config_allow_scripts = "@github/keytar,node-pty";
-    process.env.npm_config_ignore_scripts = "false";
-    // Other npm config is a supported way to point bb at a registry or cache
-    // (plugin-registration reads npm_config_registry itself), so it must pass.
-    const previousRegistry = process.env.npm_config_registry;
-    process.env.npm_config_registry = "https://registry.example.invalid/";
+    // The test runner itself may have been launched that way, so restore
+    // whatever was there rather than deleting.
+    const overrides: Record<string, string> = {
+      npm_config_allow_scripts: "@github/keytar,node-pty",
+      npm_config_ignore_scripts: "false",
+      // npm case-folds config keys; the filter must too.
+      NPM_CONFIG_FOREGROUND_SCRIPTS: "true",
+      // Other npm config is a supported way to point bb at a registry or
+      // cache (plugin-registration reads npm_config_registry itself), so it
+      // must pass.
+      npm_config_registry: "https://registry.example.invalid/",
+    };
+    const previous = new Map<string, string | undefined>();
+    for (const [key, value] of Object.entries(overrides)) {
+      previous.set(key, process.env[key]);
+      process.env[key] = value;
+    }
     try {
       const seen = await runInstallCommand(process.execPath, [
         "-e",
-        "process.stdout.write([process.env.npm_config_allow_scripts ?? '-', process.env.npm_config_ignore_scripts ?? '-', process.env.npm_config_registry ?? '-', process.env.PATH === undefined ? 'no-path' : 'path'].join('|'))",
+        "process.stdout.write(['npm_config_allow_scripts', 'npm_config_ignore_scripts', 'NPM_CONFIG_FOREGROUND_SCRIPTS', 'npm_config_registry'].map((k) => process.env[k] ?? '-').concat(process.env.PATH === undefined ? 'no-path' : 'path').join('|'))",
       ]);
-      expect(seen).toBe("-|-|https://registry.example.invalid/|path");
+      expect(seen).toBe("-|-|-|https://registry.example.invalid/|path");
     } finally {
-      delete process.env.npm_config_allow_scripts;
-      delete process.env.npm_config_ignore_scripts;
-      if (previousRegistry === undefined) delete process.env.npm_config_registry;
-      else process.env.npm_config_registry = previousRegistry;
+      for (const [key, value] of previous) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
     }
   });
 

--- a/packages/plugin-build/package.json
+++ b/packages/plugin-build/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@bb/domain": "workspace:*",
+    "@bb/process-utils": "workspace:*",
     "@get-bb/plugin-sdk": "workspace:*",
     "saxes": "^6.0.0"
   },

--- a/packages/plugin-build/src/toolchain.test.ts
+++ b/packages/plugin-build/src/toolchain.test.ts
@@ -1,6 +1,13 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { basename, join } from "node:path";
+import { basename, delimiter, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { buildPluginApp } from "./build-plugin-app.js";
 import {
@@ -121,6 +128,61 @@ describe("plugin build toolchain", () => {
         expect(css).toContain("--");
       },
       600_000,
+    );
+
+    // The fetch is bb's own npm child and passes --ignore-scripts. A bb
+    // launched through a package manager inherits the user's .npmrc as
+    // npm_config_*, and npm 11/12 refuses an inherited allow-scripts on a
+    // project-scoped install (EALLOWSCRIPTS). A fake npm on PATH records what
+    // the child actually saw; it installs nothing, so the resolve fails after
+    // the spawn, which is all this test needs.
+    it.skipIf(process.platform === "win32")(
+      "keeps script-policy npm config out of the fetch",
+      async () => {
+        const binDir = join(baseDir, "bin");
+        const envDump = join(baseDir, "npm-env.txt");
+        await mkdir(binDir, { recursive: true });
+        const fakeNpm = join(binDir, "npm");
+        await writeFile(fakeNpm, `#!/bin/sh\nenv > "${envDump}"\nexit 0\n`);
+        await chmod(fakeNpm, 0o755);
+
+        const overrides: Record<string, string> = {
+          PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+          npm_config_allow_scripts: "@github/keytar,node-pty",
+          NPM_CONFIG_IGNORE_SCRIPTS: "false",
+          npm_config_registry: "https://registry.example.invalid/",
+        };
+        const previous = new Map<string, string | undefined>();
+        for (const [key, value] of Object.entries(overrides)) {
+          previous.set(key, process.env[key]);
+          process.env[key] = value;
+        }
+        try {
+          await expect(
+            resolvePluginBuildToolchain(baseDir, { ignoreLocal: true }),
+          ).rejects.toThrow(/incomplete or misversioned/);
+        } finally {
+          for (const [key, value] of previous) {
+            if (value === undefined) delete process.env[key];
+            else process.env[key] = value;
+          }
+        }
+
+        const seen = new Map(
+          (await readFile(envDump, "utf8"))
+            .split("\n")
+            .filter((line) => line.includes("="))
+            .map((line) => {
+              const at = line.indexOf("=");
+              return [line.slice(0, at), line.slice(at + 1)] as const;
+            }),
+        );
+        expect(seen.has("npm_config_allow_scripts")).toBe(false);
+        expect(seen.has("NPM_CONFIG_IGNORE_SCRIPTS")).toBe(false);
+        expect(seen.get("npm_config_registry")).toBe(
+          "https://registry.example.invalid/",
+        );
+      },
     );
 
     it("reuses an already-fetched toolchain without reinstalling", async () => {

--- a/packages/plugin-build/src/toolchain.ts
+++ b/packages/plugin-build/src/toolchain.ts
@@ -6,6 +6,7 @@ import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
+import { omitNpmScriptPolicyEnv } from "@bb/process-utils";
 
 const run = promisify(execFile);
 
@@ -222,7 +223,12 @@ export async function resolvePluginBuildToolchain(
           ([name, version]) => `${name}@${version}`,
         ),
       ],
-      { maxBuffer: 1024 * 1024 * 16 },
+      {
+        maxBuffer: 1024 * 1024 * 16,
+        // Script policy is bb's (`--ignore-scripts` above); an inherited
+        // `npm_config_allow_scripts` would make npm refuse the install.
+        env: omitNpmScriptPolicyEnv(process.env),
+      },
     );
     const staged = toolchainFrom(createRequire(join(staging, "noop.js")));
     if (staged === null) {

--- a/packages/process-utils/src/index.ts
+++ b/packages/process-utils/src/index.ts
@@ -543,6 +543,46 @@ export function sanitizeInheritedChildProcessEnv(
   return sanitizedEnv;
 }
 
+/**
+ * The `npm_config_*` keys that decide whether package scripts run. npm reads
+ * `npm_config_<key>` env as configuration above every `.npmrc` file (cli >
+ * env > project > user > global), and it case-folds the key.
+ *
+ * bb's own npm children (plugin installs, the plugin build toolchain fetch)
+ * always pass `--ignore-scripts`: nothing in a freshly fetched tree may
+ * execute, and that policy is bb's, not the environment's. An inherited value
+ * is also a live footgun: launching bb through a package manager (`pnpm
+ * start`) exports the user's whole `~/.npmrc` as `npm_config_*`, so an
+ * ordinary `allow-scripts=@github/keytar,node-pty` line reaches npm 11/12 as
+ * if it were `--allow-scripts`, which npm refuses on project-scoped installs
+ * (`EALLOWSCRIPTS`).
+ *
+ * Every other `npm_config_*` key is left alone on purpose: env is a supported
+ * way to point bb's npm at a private registry, a shared cache, or an
+ * alternate userconfig.
+ */
+export const NPM_SCRIPT_POLICY_ENV_KEYS: ReadonlySet<string> = new Set([
+  "npm_config_allow_scripts",
+  "npm_config_ignore_scripts",
+  "npm_config_foreground_scripts",
+]);
+
+/**
+ * The environment a bb-owned npm child inherits: `env` minus the npm
+ * script-policy keys (matched case-insensitively, as npm does).
+ */
+export function omitNpmScriptPolicyEnv(
+  env: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const childEnv: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (value === undefined) continue;
+    if (NPM_SCRIPT_POLICY_ENV_KEYS.has(key.toLowerCase())) continue;
+    childEnv[key] = value;
+  }
+  return childEnv;
+}
+
 function createCurrentDiagnosticDate(): Date {
   return new Date();
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1702,6 +1702,9 @@ importers:
       '@bb/domain':
         specifier: workspace:*
         version: link:../domain
+      '@bb/process-utils':
+        specifier: workspace:*
+        version: link:../process-utils
       '@get-bb/plugin-sdk':
         specifier: workspace:*
         version: link:../plugin-sdk


### PR DESCRIPTION
Launching bb through a package manager exports the user's whole ~/.npmrc as npm_config_* environment variables, and npm reads env above every .npmrc file in its precedence order. An ordinary `allow-scripts=@github/keytar,node-pty` line therefore reached npm 12 as if it were `--allow-scripts`, which npm refuses on project-scoped installs — so every git and npm plugin install and update failed with EALLOWSCRIPTS on a machine whose npm config was unremarkable.

Installs pass --ignore-scripts because nothing in a freshly fetched plugin's dependency tree may execute. That policy is bb's, so drop the three env keys that contradict it before spawning git or npm.

Deliberately narrow. Every other npm_config_* key still passes through: env is a supported way to configure bb's npm access — plugin-registration reads npm_config_registry as bb's own registry default, and operators point npm at a private registry, a shared cache, or an alternate userconfig the same way. Stripping those broke the npm install test's loopback registry, which is exactly the real deployment shape it stands in for.
