### PR TITLE
fix(tasks): support ultra reasoning in presets

### DIFF
--- a/plugins/tasks/api/api.test.ts
+++ b/plugins/tasks/api/api.test.ts
@@ -463,6 +463,7 @@ describe("Tasks RPC domain API", () => {
                 supportedReasoningEfforts: [
                   { reasoningEffort: "medium" },
                   { reasoningEffort: "high" },
+                  { reasoningEffort: "ultra" },
                 ],
               },
               {
@@ -502,7 +503,7 @@ describe("Tasks RPC domain API", () => {
         { id: "gpt-5.6-sol", name: "GPT-5.6", isDefault: true },
         { id: "gpt-5.5", name: "GPT-5.5", isDefault: false },
       ],
-      reasoningLevels: ["low", "medium", "high"],
+      reasoningLevels: ["low", "medium", "high", "ultra"],
     });
     expect(harness.sdk.callsTo("providers.list")).toEqual([[]]);
     expect(harness.sdk.callsTo("providers.models")).toEqual([
@@ -567,7 +568,7 @@ describe("Tasks RPC domain API", () => {
     await expect(
       harness.callRpc("listProviderModels", { providerId: "test" }),
     ).resolves.toMatchObject({
-      reasoningLevels: ["low", "medium", "high", "xhigh", "max"],
+      reasoningLevels: ["low", "medium", "high", "xhigh", "max", "ultra"],
     });
     await harness.dispose();
   });

--- a/plugins/tasks/api/index.ts
+++ b/plugins/tasks/api/index.ts
@@ -54,6 +54,7 @@ const PRESET_REASONING_LEVELS = [
   "high",
   "xhigh",
   "max",
+  "ultra",
 ] as const;
 
 const MAX_THREAD_SEARCH_RESULTS = 10;

--- a/plugins/tasks/cli/cli.test.ts
+++ b/plugins/tasks/cli/cli.test.ts
@@ -840,7 +840,7 @@ describe("bb tasks CLI", () => {
           "update",
           "CLI worker",
           "--reasoning",
-          "xhigh",
+          "ultra",
           "--name",
           "CLI reviewer",
           "--environment",
@@ -852,7 +852,7 @@ describe("bb tasks CLI", () => {
     expect(updated).toMatchObject({
       id: created.id,
       name: "CLI reviewer",
-      reasoningLevel: "xhigh",
+      reasoningLevel: "ultra",
       environmentKind: "project-default",
       baseBranch: null,
       machineId: null,

--- a/plugins/tasks/package.json
+++ b/plugins/tasks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bb-plugin-tasks",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Plan and track work in BB, delegate tasks to agents, and keep task context connected to worker threads.",
   "private": true,
   "license": "MIT",

--- a/plugins/tasks/server.ts
+++ b/plugins/tasks/server.ts
@@ -9,7 +9,7 @@ import { registerLifecycle } from "./lifecycle";
 import { registerMentions } from "./mentions";
 
 export const TASKS_PLUGIN_NAME = "Tasks";
-export const TASKS_PLUGIN_VERSION = "0.1.1";
+export const TASKS_PLUGIN_VERSION = "0.1.2";
 
 export const tasksRpcContract = defineRpcContract({
   ping: {

--- a/plugins/tasks/shared/contract.ts
+++ b/plugins/tasks/shared/contract.ts
@@ -48,6 +48,7 @@ const presetReasoningLevelSchema = z.enum([
   "high",
   "xhigh",
   "max",
+  "ultra",
 ]);
 export const PRESET_PERMISSION_MODES = [
   "accept-edits",

--- a/plugins/tasks/views/manage/manage.test.tsx
+++ b/plugins/tasks/views/manage/manage.test.tsx
@@ -704,7 +704,7 @@ describe("PresetDialog environment section", () => {
             models: [
               { id: "claude-sonnet-5", name: "Sonnet", isDefault: true },
             ],
-            reasoningLevels: ["low", "medium", "high"],
+            reasoningLevels: ["low", "medium", "high", "ultra"],
           }),
           listMachines: () => ({ machines: MACHINES }),
         },
@@ -713,7 +713,7 @@ describe("PresetDialog environment section", () => {
   }
 
   it("shows the environment column and hydrates a worktree preset", async () => {
-    const slot = renderManagePresets([presetRow()]);
+    const slot = renderManagePresets([presetRow({ reasoningLevel: "ultra" })]);
     fireEvent.mouseDown(await slot.findByRole("tab", { name: "Presets" }));
     // Manage table resolves the machine name via listMachines.
     await slot.findByText("Worktree · main · Sawyer Air");
@@ -726,6 +726,9 @@ describe("PresetDialog environment section", () => {
     expect(branch.value).toBe("main");
     expect(branch.placeholder).toBe("project default base — leave empty");
     expect(slot.getByLabelText("Machine")).toBeDefined();
+    await waitFor(() =>
+      expect(slot.getByLabelText("Reasoning").textContent).toContain("ultra"),
+    );
   });
 
   it("hides worktree fields for project-default presets", async () => {

--- a/plugins/tasks/views/manage/preset-dialog.tsx
+++ b/plugins/tasks/views/manage/preset-dialog.tsx
@@ -36,6 +36,7 @@ export const REASONING_LEVELS = [
   "high",
   "xhigh",
   "max",
+  "ultra",
 ] as const;
 export const PERMISSION_MODES = PRESET_PERMISSION_MODES;
 export type ReasoningLevel = (typeof REASONING_LEVELS)[number];


### PR DESCRIPTION
## What was wrong

The Codex provider and bb domain already support `ultra`, but Tasks kept stale preset allowlists that ended at `max` in three separate boundaries. The API therefore filtered `ultra` out of provider metadata, the RPC schema rejected it during preset create/update, and the preset dialog could neither offer nor retain it. This is the root cause described in #1922; it is separate from the host/provider support added by #580.

## What changed

- Append `ultra` to the Tasks preset RPC schema, API metadata/fallback allowlist, and preset-dialog allowlist.
- Extend the existing API, CLI CRUD, and UI hydration cases to cover `ultra`; no new test files or `test`/`it` blocks were added.
- Bump the user-visible official Tasks plugin version from `0.1.1` to `0.1.2` in both its manifest and runtime status constant, as required by the official-plugin release process.

This does not change the host-daemon wire contract, provider implementation, database schema, or model-selection policy, so no `HOST_DAEMON_PROTOCOL_VERSION` bump is needed.

## How you verified

Before the production changes, the focused regression command failed in all four selected cases: API metadata omitted `ultra`, fallback omitted it, CLI/RPC validation rejected it, and UI hydration normalized it to `medium`. After the change, those four cases passed.

Fresh verification on commit `6559c27ba640441f72f0b1fbcdd49ec20fb6e101`:

```bash
pnpm exec turbo run typecheck --filter=bb-plugin-tasks --force
pnpm exec turbo run test --filter=bb-plugin-tasks --force
pnpm exec turbo run build --filter=bb-plugin-tasks --force
```

- Typecheck: 1/1 task successful.
- Tests: 35 files and 339 tests passed.
- Build: 2/2 tasks successful; generated artifacts reported Tasks `0.1.2` and remained ignored.
- `git diff --check upstream/main...HEAD`: passed.
- Isolated source-dev validation created and read back a `gpt-5.6-sol` preset with `reasoningLevel: "ultra"`; the official builtin loaded from this worktree.

Fixes #1922

> AGENT GENERATED: by GPT-5
