### PR TITLE
Keep @parcel/watcher out of the daemon bundle's static imports

### DIFF
--- a/apps/host-daemon/test/parcel-watcher-not-loaded-in-parent.test.ts
+++ b/apps/host-daemon/test/parcel-watcher-not-loaded-in-parent.test.ts
@@ -1,0 +1,127 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { build } from "esbuild";
+import { afterAll, describe, expect, it } from "vitest";
+
+// Regression test for get-bb/bb#1873.
+//
+// The host daemon must keep the native @parcel/watcher addon OUT of the parent
+// process: parcel runs in a forked child (see start-host-daemon.ts). The
+// in-process fallback in packages/host-watcher reaches the addon through a
+// dynamic import. esbuild inlines a dynamic import of an INTERNAL module and
+// hoists that module's static `import ... from "@parcel/watcher"` to the top of
+// the daemon bundle, so watcher.node loads at daemon startup, before pty.node.
+//
+// On macOS, dyld coalesces weak template instantiations across images, so
+// node-pty's call to Napi::details::CallbackData<...>::Wrapper binds to
+// watcher.node's copy, which is compiled with NAPI_DISABLE_CPP_EXCEPTIONS and
+// has no try/catch. A failed PtyFork then throws Napi::Error into a frame that
+// cannot catch it -> std::terminate -> SIGABRT.
+//
+// This test bundles @bb/host-watcher with the daemon bundle's esbuild settings,
+// then (1) asserts the output has no static import of @parcel/watcher and
+// (2) imports the bundle in a child node process and asserts that no
+// @parcel/watcher addon is dlopen'ed.
+
+const execFileAsync = promisify(execFile);
+const here = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(here, "..", "..", "..");
+const hostWatcherEntry = resolve(
+  workspaceRoot,
+  "packages",
+  "host-watcher",
+  "src",
+  "index.ts",
+);
+
+// The bundle must live inside the host-daemon package (like dist/daemon-bundle.mjs)
+// so the external @parcel/watcher resolves when the child process imports it.
+const packageTmpDir = resolve(here, "..", ".tmp");
+await mkdir(packageTmpDir, { recursive: true });
+const outDir = await mkdtemp(join(packageTmpDir, "bb-1873-bundle-"));
+const outfile = join(outDir, "host-watcher-bundle.mjs");
+
+afterAll(async () => {
+  await rm(outDir, { recursive: true, force: true });
+});
+
+async function bundleHostWatcherLikeTheDaemon(): Promise<string> {
+  // Mirror apps/host-daemon/scripts/build-bundles.mjs (native addons external,
+  // same format/conditions/target), minus minify so the output stays greppable.
+  await build({
+    bundle: true,
+    conditions: ["source"],
+    entryPoints: [hostWatcherEntry],
+    external: [
+      "@parcel/watcher",
+      "@parcel/watcher/*",
+      "node-pty",
+      "node-pty/*",
+    ],
+    format: "esm",
+    legalComments: "none",
+    minify: false,
+    outfile,
+    platform: "node",
+    sourcemap: false,
+    target: "node22",
+  });
+  return readFile(outfile, "utf8");
+}
+
+describe("daemon bundle keeps @parcel/watcher out of the parent process", () => {
+  it("does not hoist a static import of @parcel/watcher", async () => {
+    const bundle = await bundleHostWatcherLikeTheDaemon();
+    const staticImports = bundle.match(
+      /^import\s+[^;]*?\s+from\s*["']@parcel\/watcher["'];?$/gmu,
+    );
+    expect(
+      staticImports,
+      `static top-level import(s) of @parcel/watcher found in the bundle; ` +
+        `watcher.node would load at daemon startup:\n${(staticImports ?? []).join("\n")}`,
+    ).toBeNull();
+    // The lazy path must stay a real dynamic `import("@parcel/watcher")`.
+    expect(bundle).toMatch(/import\(\s*["']@parcel\/watcher["']\s*\)/u);
+  });
+
+  it("does not dlopen a @parcel/watcher addon when the bundle is imported", async () => {
+    await bundleHostWatcherLikeTheDaemon();
+    // Preload that logs every native addon the process loads.
+    const preload = join(outDir, "log-dlopen.cjs");
+    await writeFile(
+      preload,
+      [
+        "const orig = process.dlopen;",
+        "process.dlopen = function (module, filename, flags) {",
+        "  console.log(`[dlopen] ${filename}`);",
+        "  return flags === undefined",
+        "    ? orig.call(this, module, filename)",
+        "    : orig.call(this, module, filename, flags);",
+        "};",
+        "",
+      ].join("\n"),
+    );
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        "--require",
+        preload,
+        "--input-type=module",
+        "--eval",
+        `await import(${JSON.stringify(outfile)}); console.log("[imported]");`,
+      ],
+      { cwd: workspaceRoot, env: { ...process.env, NODE_PATH: "" } },
+    );
+    expect(stdout).toContain("[imported]");
+    const loadedAddons = stdout
+      .split("\n")
+      .filter((line) => line.startsWith("[dlopen] "));
+    expect(
+      loadedAddons.filter((line) => line.includes("@parcel/watcher")),
+      `@parcel/watcher addon loaded on import:\n${loadedAddons.join("\n")}`,
+    ).toEqual([]);
+  });
+});

--- a/apps/host-daemon/test/parcel-watcher-not-loaded-in-parent.test.ts
+++ b/apps/host-daemon/test/parcel-watcher-not-loaded-in-parent.test.ts
@@ -119,8 +119,10 @@ describe("daemon bundle keeps @parcel/watcher out of the parent process", () => 
     const loadedAddons = stdout
       .split("\n")
       .filter((line) => line.startsWith("[dlopen] "));
+    // Match both the package path (@parcel/watcher-<platform>/watcher.node)
+    // and the pnpm store path (.pnpm/@parcel+watcher-<platform>@<ver>/...).
     expect(
-      loadedAddons.filter((line) => line.includes("@parcel/watcher")),
+      loadedAddons.filter((line) => /@parcel[/+]watcher/u.test(line)),
       `@parcel/watcher addon loaded on import:\n${loadedAddons.join("\n")}`,
     ).toEqual([]);
   });

--- a/packages/host-watcher/src/parcel-watcher-backend.ts
+++ b/packages/host-watcher/src/parcel-watcher-backend.ts
@@ -40,9 +40,16 @@ function createInProcessBackend(): ParcelWatcherBackend {
   return {
     async subscribe(dir, callback, opts) {
       // Lazy import keeps the native addon out of the parent unless we actually
-      // watch in-process.
-      const { realParcelWatcher } = await import("./real-parcel-watcher.js");
-      return realParcelWatcher.subscribe(dir, callback, opts);
+      // watch in-process. Import the EXTERNAL package directly: esbuild inlines
+      // a dynamic import of an internal module (./real-parcel-watcher.js) and
+      // hoists its static `import ... from "@parcel/watcher"` to the top of the
+      // daemon bundle, which loads watcher.node at daemon startup, before
+      // pty.node. On macOS dyld then coalesces node-pty's Napi wrapper symbol
+      // to watcher.node's exception-free copy and a failed pty spawn aborts the
+      // daemon (get-bb/bb#1873). A dynamic import of the external package stays
+      // a real `import("@parcel/watcher")` in the bundle.
+      const { default: parcelWatcher } = await import("@parcel/watcher");
+      return parcelWatcher.subscribe(dir, callback, opts);
     },
   };
 }

--- a/packages/host-watcher/src/real-parcel-watcher.ts
+++ b/packages/host-watcher/src/real-parcel-watcher.ts
@@ -1,7 +1,10 @@
 import parcelWatcher from "@parcel/watcher";
 import type { ParcelWatcherBackend } from "./parcel-watcher-backend.js";
 
-// The only module that loads the native @parcel/watcher addon in the parent
-// process. Kept in its own file so it can be dynamically imported on demand,
-// leaving the parent parcel-free under BB_WATCHER_SUBPROCESS=1.
+// Static handle on the native @parcel/watcher addon for the forked watcher
+// child (parcel-child-entry.ts). Do NOT dynamically import this module from
+// code that ends up in the daemon bundle: esbuild inlines internal dynamic
+// imports and hoists this static import to the bundle's top level, which loads
+// watcher.node in the parent at startup (get-bb/bb#1873). The in-process
+// fallback in parcel-watcher-backend.ts imports "@parcel/watcher" directly.
 export const realParcelWatcher: ParcelWatcherBackend = parcelWatcher;


### PR DESCRIPTION
## What was wrong

The host daemon is supposed to keep the native `@parcel/watcher` addon out of the parent process (parcel runs in a forked child). The in-process fallback in `packages/host-watcher/src/parcel-watcher-backend.ts` reached the addon through `await import("./real-parcel-watcher.js")`. esbuild inlines a dynamic import of an internal module and hoists that module's static `import parcelWatcher from "@parcel/watcher"` to the top level of `dist/daemon-bundle.mjs`. The daemon therefore loaded `watcher.node` (built with `NAPI_DISABLE_CPP_EXCEPTIONS`) before `pty.node` (`NAPI_CPP_EXCEPTIONS`) at startup. On macOS, dyld coalesces the identical weak `Napi::details::CallbackData<...>::Wrapper` symbol across images to watcher.node's try/catch-less copy. When `PtyFork` throws `Napi::Error` on a failed spawn, nothing catches it, `std::terminate` runs, and the app dies with SIGABRT.

Issue: #1873. Investigation report: https://get-bb.github.io/reports/issues/1873.html

## What changed

- `packages/host-watcher/src/parcel-watcher-backend.ts`: the in-process fallback now does `const { default: parcelWatcher } = await import("@parcel/watcher")`. A dynamic import of the external package stays a real `import("@parcel/watcher")` in the esbuild ESM bundle, so `watcher.node` loads only when a watcher is needed in-process.
- `packages/host-watcher/src/real-parcel-watcher.ts`: kept for the forked watcher child entry; its comment now explains why daemon-bundle code must not dynamically import it.
- `apps/host-daemon/test/parcel-watcher-not-loaded-in-parent.test.ts` (new): bundles `@bb/host-watcher` with the daemon bundle's esbuild settings, then asserts (1) the output has no static top-level `@parcel/watcher` import and still has a dynamic `import("@parcel/watcher")`, and (2) importing that bundle in a child `node` with a `process.dlopen` hook loads no `@parcel/watcher` addon.

No wire shapes changed, so `HOST_DAEMON_PROTOCOL_VERSION` was not bumped. No CLI/guide/doc surfaces are affected.

## How you verified

**The new test fails before the fix** (both assertions, for the right reason):

```
 ❯  @bb/host-daemon  test/parcel-watcher-not-loaded-in-parent.test.ts (2 tests | 2 failed) 175ms
     × does not hoist a static import of @parcel/watcher 36ms
     × does not dlopen a @parcel/watcher addon when the bundle is imported 137ms

AssertionError: static top-level import(s) of @parcel/watcher found in the bundle; watcher.node would load at daemon startup:
import parcelWatcher from "@parcel/watcher";: expected [ Array(1) ] to be null

AssertionError: @parcel/watcher addon loaded on import:
[dlopen] <repo>/node_modules/.pnpm/@parcel+watcher-linux-x64-glibc@2.5.6/node_modules/@parcel/watcher-linux-x64-glibc/watcher.node: expected [ Array(1) ] to deeply equal []
```

**After the fix:**

```
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

**Real daemon bundle, rebuilt with the fix** (`pnpm exec turbo run build --filter=@bb/host-daemon`), then run with the report's `process.dlopen` logger and `NODE_PATH` unset:

```
$ grep -c 'from"@parcel/watcher"' dist/daemon-bundle.mjs
0
$ node --require log-dlopen.cjs dist/daemon-bundle.mjs --definitely-not-a-flag
[dlopen #1] <repo>/node_modules/.pnpm/node-pty@1.1.0/node_modules/node-pty/build/Release/pty.node
[exit] code=1 addons loaded=1
```

Before the fix the same bundle contained `import VYr from"@parcel/watcher"` and the report's `daemon-bundle-addon-load-order.log` shows `watcher.node` as dlopen #1 and `pty.node` as #2.

**Package suites and typecheck:** `pnpm exec turbo run test typecheck --filter=@bb/host-daemon --filter=@bb/host-watcher --force` → 5/5 tasks successful; `@bb/host-watcher` 45 tests passed, `@bb/host-daemon` 585 tests passed.

**macOS was not re-run.** This was verified on Linux only. On Linux the symptom differs (the report shows the same symbol coalescing produces a SIGSEGV analog under `RTLD_GLOBAL`, and Node's default `RTLD_LOCAL` dlopen avoids it), so the macOS SIGABRT itself was not reproduced here. The fix is still correct because the crash requires `watcher.node` to be resident in the daemon process before `pty.node` loads, and the root cause of that is the static import in the bundle. The test and the dlopen log above show that with this change the daemon process loads no `@parcel/watcher` addon at startup, so dyld has no watcher.node copy of the `Wrapper` symbol to coalesce with when node-pty's image loads; node-pty then uses its own exception-aware copy, which catches the `Napi::Error` as intended. The forked watcher child (`bb-parcel-watcher-child.mjs`) still loads `watcher.node`, which is the intended isolation.

Fixes #1873

> AGENT GENERATED: by Claude Opus 5
