### PR TITLE
Run the ACP bb-bridge MCP server from the bridge module, not the bootstrap

### DIFF
--- a/plugins/provider-acp/src/bridge/agent-connection.test.ts
+++ b/plugins/provider-acp/src/bridge/agent-connection.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { formatAgentError } from "./agent-connection.js";
+
+describe("formatAgentError", () => {
+  it("appends error.data.details to the generic JSON-RPC message", () => {
+    expect(
+      formatAgentError({
+        code: -32603,
+        message: "Internal error",
+        data: { details: "bb-bridge: Transport closed" },
+      }),
+    ).toBe("Internal error: bb-bridge: Transport closed");
+  });
+
+  it("keeps the message alone when there is no usable data", () => {
+    expect(formatAgentError({ message: "Internal error" })).toBe(
+      "Internal error",
+    );
+    expect(formatAgentError({ message: "Internal error", data: "  " })).toBe(
+      "Internal error",
+    );
+    expect(formatAgentError({ code: -32600 })).toBe(
+      "ACP agent returned error code -32600",
+    );
+  });
+
+  it("serializes structured data without a details string", () => {
+    expect(
+      formatAgentError({ message: "Invalid params", data: { field: "cwd" } }),
+    ).toBe('Invalid params: {"field":"cwd"}');
+  });
+});

--- a/plugins/provider-acp/src/bridge/agent-connection.ts
+++ b/plugins/provider-acp/src/bridge/agent-connection.ts
@@ -66,8 +66,50 @@ interface ParsedAgentMessage {
   id?: string | number;
   method?: string;
   result?: unknown;
-  error?: { code?: number; message?: string };
+  error?: AgentErrorObject;
   params?: unknown;
+}
+
+interface AgentErrorObject {
+  code?: number;
+  message?: string;
+  data?: unknown;
+}
+
+/**
+ * ACP agents answer a failed request with a generic JSON-RPC message such as
+ * "Internal error" and put the real cause in `error.data` (for example
+ * `{ details: "bb-bridge: Transport closed" }`). Carry that cause into the
+ * rejection so agent-side failures are diagnosable from bb logs.
+ */
+export function formatAgentError(error: AgentErrorObject): string {
+  const message =
+    error.message ??
+    `ACP agent returned error code ${error.code ?? "unknown"}`;
+  const details = formatAgentErrorData(error.data);
+  return details === undefined ? message : `${message}: ${details}`;
+}
+
+function formatAgentErrorData(data: unknown): string | undefined {
+  if (data === undefined || data === null) {
+    return undefined;
+  }
+  if (typeof data === "string") {
+    return data.trim() === "" ? undefined : data;
+  }
+  if (
+    typeof data === "object" &&
+    "details" in data &&
+    typeof data.details === "string" &&
+    data.details.trim() !== ""
+  ) {
+    return data.details;
+  }
+  try {
+    return JSON.stringify(data);
+  } catch {
+    return undefined;
+  }
 }
 
 function parseAgentLine(line: string): ParsedAgentMessage | null {
@@ -139,12 +181,7 @@ export function createAcpAgentConnection(
         }
         pending.delete(numericId);
         if (message.error) {
-          request.reject(
-            new Error(
-              message.error.message ??
-                `ACP agent returned error code ${message.error.code ?? "unknown"}`,
-            ),
-          );
+          request.reject(new Error(formatAgentError(message.error)));
         } else {
           request.resolve(message.result);
         }

--- a/plugins/provider-acp/src/bridge/bridge.ts
+++ b/plugins/provider-acp/src/bridge/bridge.ts
@@ -326,10 +326,11 @@ function emitSessionError(session: AcpThreadSession, message: string): void {
 }
 
 function resolveBridgeProcessArgsForMcpServer(): string[] {
-  const entryPoint = process.argv[1]
-    ? resolve(process.argv[1])
-    : fileURLToPath(import.meta.url);
-  return [...process.execArgv, entryPoint, "--mcp-stdio"];
+  // process.argv[1] is the provider-bridge bootstrap, not this module: the
+  // bootstrap imports this artifact, so only import.meta.url names the file
+  // that understands `--mcp-stdio`. The bootstrap rejects the flag with a
+  // usage error, which the ACP agent reports as "bb-bridge: Transport closed".
+  return [...process.execArgv, fileURLToPath(import.meta.url), "--mcp-stdio"];
 }
 
 function resolveBridgeProcessEnvForMcpServer(): AcpMcpServerConfig["env"] {

--- a/plugins/provider-acp/src/bridge/mcp-server-entry.test.ts
+++ b/plugins/provider-acp/src/bridge/mcp-server-entry.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Regression test for get-bb/bb#1918.
+ *
+ * bridge.test.ts imports the bridge in-process, so process.argv[1] there is
+ * vitest. The agent runtime runs the bridge through the provider-bridge
+ * bootstrap (`node <bridge-worker-entry> <bridge module> <pluginId>
+ * <dataDir>`), so inside the real bridge process.argv[1] is the bootstrap, not
+ * the bridge module. This test spawns the bridge that way and then executes the
+ * `bb-bridge` MCP server command the bridge advertises to the ACP agent.
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { createInterface } from "node:readline";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { ACP_BRIDGE_MCP_SERVER_NAME } from "./tool-proxy-mcp.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const BRIDGE_MODULE = resolve(here, "bridge.ts");
+const FAKE_AGENT_PATH = resolve(here, "fake-acp-agent.mjs");
+const WORKER_ENTRY = fileURLToPath(
+  import.meta.resolve("@bb/provider-bridge-protocol/bridge-worker-entry"),
+);
+const TSX_LOADER = import.meta.resolve("tsx");
+
+interface BridgeLine {
+  id?: number | string;
+  method?: string;
+  params?: { event?: { type?: string; delta?: unknown } };
+  result?: { providerThreadId?: unknown };
+  error?: { message?: string };
+}
+
+interface AdvertisedMcpServer {
+  name: string;
+  command: string;
+  args: string[];
+  env: { name: string; value: string }[];
+}
+
+const children: ChildProcess[] = [];
+const tempDirs: string[] = [];
+const bridgeLines: BridgeLine[] = [];
+let nextRequestId = 1;
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function waitFor<T>(
+  pick: () => T | undefined,
+  what: string,
+  timeoutMs = 20_000,
+): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const value = pick();
+    if (value !== undefined) {
+      return value;
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for ${what}`);
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 20));
+  }
+}
+
+function agentMessageTexts(): string[] {
+  const texts: string[] = [];
+  for (const line of bridgeLines) {
+    if (line.method !== "thread/event") {
+      continue;
+    }
+    const event = line.params?.event;
+    if (event?.type === "item/agentMessage/delta") {
+      texts.push(String(event.delta));
+    }
+  }
+  return texts;
+}
+
+function spawnBridgeLikeTheAgentRuntime(dataDir: string): ChildProcess {
+  const bridge = spawn(
+    process.execPath,
+    [
+      "--conditions=source",
+      "--import",
+      TSX_LOADER,
+      WORKER_ENTRY,
+      BRIDGE_MODULE,
+      "provider-acp",
+      dataDir,
+    ],
+    { stdio: ["pipe", "pipe", "pipe"] },
+  );
+  children.push(bridge);
+  bridge.stderr?.on("data", (chunk: Buffer) => {
+    process.stderr.write(`[bridge] ${chunk.toString()}`);
+  });
+  if (!bridge.stdout) {
+    throw new Error("Bridge child has no stdout");
+  }
+  createInterface({ input: bridge.stdout }).on("line", (line) => {
+    try {
+      bridgeLines.push(JSON.parse(line) as BridgeLine);
+    } catch {
+      // Ignore non-JSON bridge output.
+    }
+  });
+  return bridge;
+}
+
+function sendToBridge(
+  bridge: ChildProcess,
+  method: string,
+  params: unknown,
+): number {
+  const id = nextRequestId++;
+  if (!bridge.stdin) {
+    throw new Error("Bridge child has no stdin");
+  }
+  bridge.stdin.write(
+    `${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`,
+  );
+  return id;
+}
+
+async function readAdvertisedMcpServer(
+  bridge: ChildProcess,
+  workspaceDir: string,
+): Promise<AdvertisedMcpServer> {
+  const startId = sendToBridge(bridge, "thread/start", {
+    threadId: "thread-1918",
+    cwd: workspaceDir,
+    instructionMode: "append",
+    options: {
+      permissionMode: "full",
+      permissionScope: "full",
+      approvalReviewer: null,
+      permissionEscalation: null,
+      providerOptions: {
+        acpLaunchSpec: {
+          displayName: "Fake ACP",
+          command: process.execPath,
+          args: [FAKE_AGENT_PATH],
+          env: {},
+        },
+      },
+    },
+    dynamicTools: [
+      {
+        name: "update_environment_directory",
+        description: "Move this thread to another environment directory.",
+        inputSchema: {
+          type: "object",
+          properties: { path: { type: "string" } },
+          required: ["path"],
+        },
+      },
+    ],
+  });
+  const startResponse = await waitFor(
+    () =>
+      bridgeLines.find(
+        (line) => line.id === startId && line.method === undefined,
+      ),
+    "thread/start response",
+  );
+  expect(startResponse.error).toBeUndefined();
+  const providerThreadId = String(startResponse.result?.providerThreadId);
+
+  sendToBridge(bridge, "turn/start", {
+    threadId: "thread-1918",
+    providerThreadId,
+    clientRequestId: "creq_abcdefghjk",
+    options: {
+      permissionMode: "full",
+      permissionScope: "full",
+      approvalReviewer: null,
+      permissionEscalation: null,
+    },
+    input: [{ type: "text", text: "echo-mcp-server-config", mentions: [] }],
+  });
+  const configPrefix = "mcp-server-config:";
+  const configText = await waitFor(
+    () => agentMessageTexts().find((text) => text.startsWith(configPrefix)),
+    "mcp-server-config echo",
+  );
+  const [config] = JSON.parse(
+    configText.slice(configPrefix.length),
+  ) as AdvertisedMcpServer[];
+  if (!config) {
+    throw new Error("Fake ACP agent reported no MCP server config");
+  }
+  return config;
+}
+
+async function runMcpInitialize(config: AdvertisedMcpServer): Promise<{
+  exitCode: number | null | undefined;
+  stderr: string;
+  stdoutLines: string[];
+}> {
+  const env = { ...process.env };
+  for (const { name, value } of config.env) {
+    env[name] = value;
+  }
+  const mcp = spawn(config.command, config.args, {
+    env,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  children.push(mcp);
+  let stderr = "";
+  mcp.stderr?.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString();
+  });
+  const stdoutLines: string[] = [];
+  if (!mcp.stdout || !mcp.stdin) {
+    throw new Error("MCP child has no stdio");
+  }
+  createInterface({ input: mcp.stdout }).on("line", (line) =>
+    stdoutLines.push(line),
+  );
+  let exitCode: number | null | undefined;
+  mcp.on("exit", (code) => {
+    exitCode = code;
+  });
+  mcp.stdin.write(
+    `${JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "bb-test", version: "0" },
+      },
+    })}\n`,
+  );
+  await waitFor(
+    () => (stdoutLines.length > 0 || exitCode !== undefined ? true : undefined),
+    "MCP initialize response or child exit",
+    15_000,
+  );
+  return { exitCode, stderr, stdoutLines };
+}
+
+afterEach(() => {
+  for (const child of children.splice(0)) {
+    child.kill("SIGKILL");
+  }
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  bridgeLines.length = 0;
+});
+
+describe("bb-bridge MCP server entry point (#1918)", () => {
+  it("advertises an MCP server command that answers MCP initialize when the bridge runs under the bootstrap", async () => {
+    const dataDir = makeTempDir("bb-acp-mcp-entry-data-");
+    const workspaceDir = makeTempDir("bb-acp-mcp-entry-ws-");
+    const bridge = spawnBridgeLikeTheAgentRuntime(dataDir);
+
+    const config = await readAdvertisedMcpServer(bridge, workspaceDir);
+    expect(config.name).toBe(ACP_BRIDGE_MCP_SERVER_NAME);
+    expect(config.args).toContain("--mcp-stdio");
+
+    const { exitCode, stderr, stdoutLines } = await runMcpInitialize(config);
+    expect(stderr).not.toMatch(/provider bridge bootstrap usage/u);
+    expect(exitCode).toBeUndefined();
+    expect(stdoutLines[0]).toContain(
+      `"serverInfo":{"name":"${ACP_BRIDGE_MCP_SERVER_NAME}"`,
+    );
+    // The entry must be the bridge module itself, never the bootstrap.
+    expect(config.args.some((arg) => arg.includes("bridge-worker"))).toBe(
+      false,
+    );
+  }, 60_000);
+});


### PR DESCRIPTION
## What was wrong

Since #1640 the agent runtime starts every provider bridge through the provider-bridge bootstrap (`node <bridge-worker-entry> <bridge module> <pluginId> <dataDir>`), so inside the ACP bridge `process.argv[1]` is the bootstrap, not the bridge module. `resolveBridgeProcessArgsForMcpServer()` in `plugins/provider-acp/src/bridge/bridge.ts` still used `process.argv[1]` as the entry for the `bb-bridge` MCP server child. The child ran the bootstrap with `--mcp-stdio`, printed `provider bridge bootstrap usage: ...` and exited 1. ACP agents (omp, Cursor, Grok, Pi ACP) then rejected `session/new` with `bb-bridge: Transport closed`, and bb showed only `Internal error` because `agent-connection.ts` dropped `error.data`. Root-cause report: https://get-bb.github.io/reports/issues/1918.html

## What changed

- `plugins/provider-acp/src/bridge/bridge.ts`: the MCP server entry is now `fileURLToPath(import.meta.url)` (the bridge's own module/artifact in every launch mode), with `process.execArgv` and `--mcp-stdio` as before.
- `plugins/provider-acp/src/bridge/agent-connection.ts`: new `formatAgentError()` appends `error.data.details` (or a string / JSON `data`) to the rejected `Error`, so agent-side failures such as `Internal error: bb-bridge: Transport closed` are diagnosable from bb logs.
- New test `src/bridge/mcp-server-entry.test.ts`: spawns the bridge under the real bootstrap, reads the advertised `bb-bridge` MCP server config from the fake ACP agent, and executes that command; it must answer MCP `initialize`. Existing tests only hit the TCP side channel and import the bridge in-process (argv[1] is vitest there), so they did not catch this.
- New test `src/bridge/agent-connection.test.ts` for `formatAgentError()`.

No wire change between server and host daemon, so no `HOST_DAEMON_PROTOCOL_VERSION` bump.

## How you verified

`mcp-server-entry.test.ts` fails on `main` (a76bab06a):

```

 ❯  bb-plugin-provider-acp  src/bridge/mcp-server-entry.test.ts (1 test | 1 failed) 418ms
     × advertises an MCP server command that answers MCP initialize when the bridge runs under the bootstrap 417ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 1 ⎯⎯⎯⎯⎯⎯⎯

 FAIL   bb-plugin-provider-acp  src/bridge/mcp-server-entry.test.ts > bb-bridge MCP server entry point (#1918) > advertises an MCP server command that answers MCP initialize when the bridge runs under the bootstrap
AssertionError: expected 'provider bridge bootstrap usage: <bri…' not to match /provider bridge bootstrap usage/u

- Expected:
/provider bridge bootstrap usage/u

+ Received:
"provider bridge bootstrap usage: <bridgeModulePath> <pluginId> <pluginDataDir> (absolute paths)
"

 ❯ src/bridge/mcp-server-entry.test.ts:272:24
    270|
    271|     const { exitCode, stderr, stdoutLines } = await runMcpInitialize(c…
    272|     expect(stderr).not.toMatch(/provider bridge bootstrap usage/u);
```

After the fix:

```

 Test Files  2 passed (2)
      Tests  4 passed (4)
   Start at  15:58:07
   Duration  3.09s (transform 876ms, setup 0ms, import 1.38s, tests 1.55s, environment 0ms)
```

`pnpm exec turbo run test typecheck --filter=bb-plugin-provider-acp --force`:

```
bb-plugin-provider-acp:test:  Test Files  11 passed (11)
bb-plugin-provider-acp:test:       Tests  165 passed (165)
 Tasks:    3 successful, 3 total
```

Live check on a dev instance from this branch (`scripts/bb-dev-app current`) with `acp-grok`: `bb thread spawn --provider acp-grok` reaches `idle` (before the fix this failed at thread start with `Internal error`), and the agent reports `FOUND bb-bridge/update_environment_directory` with the tool description when asked to search its MCP tools.

Fixes #1918

> AGENT GENERATED: by Claude Opus 5
