### PR TITLE
Unify update and run state vocabulary

### DIFF
--- a/apps/app/src/components/plugin/management/PluginRowSignal.stories.tsx
+++ b/apps/app/src/components/plugin/management/PluginRowSignal.stories.tsx
@@ -61,7 +61,7 @@ function StateRow({
 /**
  * Every state of the installed row's status/action slot around updates,
  * following the multi-state pattern: scroll one story, review the surface.
- * The control is a quiet neutral button whose tinted up-arrow carries the
+ * The control is a quiet neutral button whose tinted download mark carries the
  * tone; it names a version only when the version is readable — git sources
  * report commit hashes, which belong (shortened) in the dialog, not the row.
  */

--- a/apps/app/src/components/plugin/management/PluginRowSignal.test.tsx
+++ b/apps/app/src/components/plugin/management/PluginRowSignal.test.tsx
@@ -8,6 +8,24 @@ import { displayPluginVersion } from "./plugin-ui";
 afterEach(cleanup);
 
 describe("PluginRowSignalView", () => {
+  it("uses the shared update-action icon", () => {
+    render(
+      <PluginRowSignalView
+        signal={{ kind: "update", version: "1.9.0" }}
+        onUpdateClick={vi.fn()}
+        onStatusClick={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen
+        .getByRole("button", {
+          name: "Update available: version 1.9.0",
+        })
+        .querySelector('[data-icon="Download"]'),
+    ).not.toBeNull();
+  });
+
   it("keeps runtime health icon-only until hover or focus and opens details", async () => {
     const onStatusClick = vi.fn();
     render(

--- a/apps/app/src/components/plugin/management/PluginRowSignal.tsx
+++ b/apps/app/src/components/plugin/management/PluginRowSignal.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { UPDATE_ACTION_ICON } from "@bb/domain/update-state";
 import { Button } from "@bb/shared-ui/button";
 import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
@@ -71,7 +72,7 @@ export function PluginRowSignalView({
           style={UPDATE_ICON_STYLE}
           aria-hidden
         >
-          <Icon name="ArrowUp" className="size-3.5" />
+          <Icon name={UPDATE_ACTION_ICON} className="size-3.5" />
         </span>
         {readableVersion === null ? "Update" : `Update to ${readableVersion}`}
       </button>

--- a/apps/app/src/components/plugin/management/PluginUpdatesCard.test.tsx
+++ b/apps/app/src/components/plugin/management/PluginUpdatesCard.test.tsx
@@ -95,9 +95,11 @@ describe("PluginDetailReleaseControl", () => {
       { wrapper },
     );
 
-    expect(
-      screen.getByRole("button", { name: "Update Linear to 1.9.0" }),
-    ).toBeTruthy();
+    const update = screen.getByRole("button", {
+      name: "Update Linear to 1.9.0",
+    });
+    expect(update).toBeTruthy();
+    expect(update.querySelector('[data-icon="Download"]')).not.toBeNull();
     expect(screen.queryByText("Compatible with your bb.")).toBeNull();
   });
 

--- a/apps/app/src/components/plugin/management/PluginUpdatesCard.tsx
+++ b/apps/app/src/components/plugin/management/PluginUpdatesCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { UPDATE_ACTION_ICON } from "@bb/domain/update-state";
 import { Button } from "@bb/shared-ui/button";
 import { Icon } from "@bb/shared-ui/icon";
 import { PluginBannerBar } from "@/components/tools/plugin-detail-banner";
@@ -70,6 +71,7 @@ export function PluginUpdateBanner({ plugin }: { plugin: PluginListItem }) {
             className="h-7 px-2.5 text-xs"
             onClick={() => setUpdateOpen(true)}
           >
+            <Icon name={UPDATE_ACTION_ICON} className="size-3.5" aria-hidden />
             Update
           </Button>
         }
@@ -180,7 +182,7 @@ export function PluginDetailReleaseControl({
         aria-label={`Update ${plugin.name ?? plugin.id} to ${displayPluginVersion(availableVersion)}`}
         onClick={() => setDetailsOpen(true)}
       >
-        <Icon name="PackageReceive" className="size-3.5" aria-hidden />
+        <Icon name={UPDATE_ACTION_ICON} className="size-3.5" aria-hidden />
         Update
       </Button>
       <UpdatePluginDialog

--- a/apps/app/src/components/plugin/management/UpdatePluginDialog.tsx
+++ b/apps/app/src/components/plugin/management/UpdatePluginDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { UPDATE_ACTION_ICON } from "@bb/domain/update-state";
 import { Button } from "@bb/shared-ui/button";
 import {
   Dialog,
@@ -237,7 +238,9 @@ function UpdatePluginDialogContent({
           >
             {update.isPending ? (
               <Icon name="Spinner" className="animate-spin" />
-            ) : null}
+            ) : (
+              <Icon name={UPDATE_ACTION_ICON} aria-hidden />
+            )}
             Update
           </Button>
         </DialogFooter>
@@ -303,6 +306,7 @@ function UpdatePluginDialogContent({
             Close
           </Button>
           <Button type="button" disabled>
+            <Icon name={UPDATE_ACTION_ICON} aria-hidden />
             Update
           </Button>
         </DialogFooter>

--- a/apps/app/src/components/plugin/management/plugin-ui.tsx
+++ b/apps/app/src/components/plugin/management/plugin-ui.tsx
@@ -23,7 +23,7 @@ import type { PluginListItem } from "@/hooks/queries/plugin-settings-queries";
  */
 
 /**
- * The update control's icon accent: a quiet neutral button whose up-arrow
+ * The update control's icon accent: a quiet neutral button whose download mark
  * carries the "improvement available" tone, instead of a full green pill
  * shouting over the row.
  */

--- a/apps/cli/src/__tests__/command-output/updates.test.ts
+++ b/apps/cli/src/__tests__/command-output/updates.test.ts
@@ -115,11 +115,11 @@ describe("bb updates command output", () => {
     const output = collectLogPayloads(vi.mocked(console.log)).join("\n");
     expect(output).toContain("bb-app");
     expect(output).toContain("0.0.32 -> 0.0.33");
-    expect(output).toContain("update available (run: npx bb-app@latest)");
+    expect(output).toContain("Update available (run: npx bb-app@latest)");
     expect(output).toContain("workstation · Codex");
     expect(output).toContain("0.140.0 -> 0.141.0");
     expect(output).toContain("workstation · Claude Code");
-    expect(output).toContain("up to date");
+    expect(output).toContain("Up to date");
     expect(output).toContain("laptop");
     expect(output).toContain("offline");
   });
@@ -208,7 +208,7 @@ describe("bb updates command output", () => {
 
     await runCommand(["updates"], register);
     expect(collectLogPayloads(vi.mocked(console.log)).join("\n")).toContain(
-      "update manually",
+      "Update in terminal",
     );
 
     vi.mocked(console.log).mockClear();

--- a/apps/cli/src/commands/updates.ts
+++ b/apps/cli/src/commands/updates.ts
@@ -1,5 +1,9 @@
 import { Command } from "commander";
 import type { Host } from "@bb/domain";
+import {
+  UPDATE_STATE_PRESENTATION,
+  type UpdateState,
+} from "@bb/domain/update-state";
 import type { HostProviderCliStatusResponse } from "@bb/server-contract";
 import { action } from "../action.js";
 import { createCliBbSdk } from "../client.js";
@@ -30,15 +34,27 @@ interface MachineUpdatesEntry {
   statusError: string | null;
 }
 
-function providerStateLabel(status: ProviderCliStatus): string {
-  if (!status.installed) return "not installed";
-  if (status.versionUnsupported) return "update needed";
-  if (status.needsUpdate) {
+/**
+ * The same state ladder Settings → Updates draws, printed as words.
+ *
+ * Both surfaces read `UPDATE_STATE_PRESENTATION` so a CLI that reads "Update
+ * in terminal" reads the same way in the app. This used to
+ * be a second, hand-maintained list of phrases here, and the two had already
+ * drifted — the app said "Update needed" where the CLI said "update needed"
+ * for one case and "update manually" for another.
+ */
+function providerState(status: ProviderCliStatus): UpdateState {
+  if (!status.installed) return "not-installed";
+  if (status.needsUpdate || status.versionUnsupported) {
     return status.installAction === null
-      ? "update manually"
-      : "update available";
+      ? "update-manually"
+      : "update-available";
   }
-  return "up to date";
+  return "up-to-date";
+}
+
+function providerStateLabel(status: ProviderCliStatus): string {
+  return UPDATE_STATE_PRESENTATION[providerState(status)].label;
 }
 
 function providerVersionLabel(status: ProviderCliStatus): string {
@@ -186,8 +202,8 @@ export function registerUpdatesCommands(
         const appState = version.isDevelopment
           ? "development mode"
           : version.updateAvailable
-            ? `update available (run: ${version.upgradeCommand})`
-            : "up to date";
+            ? `${UPDATE_STATE_PRESENTATION["update-available"].label} (run: ${version.upgradeCommand})`
+            : UPDATE_STATE_PRESENTATION["up-to-date"].label;
         const appVersionLabel =
           version.latestVersion !== null &&
           version.latestVersion !== version.currentVersion
@@ -271,8 +287,7 @@ export function registerUpdatesCommands(
               hostName: target.host.name,
               provider: target.provider,
               success,
-              message:
-                errorEvent?.type === "error" ? errorEvent.message : null,
+              message: errorEvent?.type === "error" ? errorEvent.message : null,
             });
             if (!opts.json) {
               console.log(

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -24,6 +24,11 @@
       "types": "./src/thread-visibility.ts",
       "default": "./src/thread-visibility.ts"
     },
+    "./update-state": {
+      "source": "./src/update-state.ts",
+      "types": "./src/update-state.ts",
+      "default": "./src/update-state.ts"
+    },
     "./plugin-cli": {
       "source": "./src/plugin-cli.ts",
       "types": "./src/plugin-cli.ts",

--- a/packages/domain/src/update-state.ts
+++ b/packages/domain/src/update-state.ts
@@ -1,0 +1,123 @@
+/**
+ * One vocabulary for "how is this piece of work going", shared by every
+ * surface that reports on background work: Settings → Updates, `bb updates`,
+ * and the Automations run history. One map to maintain, so a mark learned in
+ * one part of bb cannot mean something else in another.
+ *
+ * Icon names are `@bb/shared-ui` icon keys kept as plain strings, so this
+ * module stays framework-free and the CLI can import it.
+ */
+
+/**
+ * The generic lifecycle every kind of run shares. Automations' run statuses
+ * and the Updates states both draw from this core rather than keeping their
+ * own copies of the same three glyphs.
+ */
+export const RUN_STATE_PRESENTATION = {
+  "in-progress": { icon: "Loading", label: "In progress", inFlight: true },
+  succeeded: { icon: "CircleCheck", label: "Succeeded", inFlight: false },
+  failed: { icon: "CircleX", label: "Failed", inFlight: false },
+  // Not CircleDashed: icon.tsx aliases it to the same DashedLineCircleIcon as
+  // Spinner, so a passed-over item would draw the identical shape to a
+  // running one. ArrowTurnForward is the one glyph that reads as "skipped"
+  // and is shape-distinct from check, cross and spinner.
+  skipped: { icon: "ArrowTurnForward", label: "Skipped", inFlight: false },
+} as const satisfies Record<
+  string,
+  { icon: string; label: string; inFlight: boolean }
+>;
+
+export type RunState = keyof typeof RUN_STATE_PRESENTATION;
+
+/** The update-specific ladder. */
+export const UPDATE_STATES = [
+  "up-to-date",
+  "in-progress",
+  "update-available",
+  "restart-required",
+  "not-installed",
+  "update-manually",
+  "failed",
+  "offline",
+] as const;
+
+export type UpdateState = (typeof UPDATE_STATES)[number];
+
+/**
+ * Colour is the page's scarcest signal, so there are exactly two tones: muted
+ * for everything the reader has no decision to make about, error for a
+ * failure. Nothing here is orange — a state either failed or it did not.
+ */
+export type UpdateStateTone = "muted" | "error";
+
+export interface UpdateStatePresentation {
+  /** `@bb/shared-ui` icon key, or null when the state is text-only. */
+  icon: string | null;
+  /** The sentence a UI puts on hover and the CLI prints in its State column. */
+  label: string;
+  tone: UpdateStateTone;
+  /** Spin the mark: the state is work in flight, not a resting condition. */
+  inFlight?: boolean;
+}
+
+/**
+ * The glyph a retryable failure's control wears. The control is neutral: the
+ * caption beside it already states the failure, so colouring the button too
+ * would say it twice and make a recovery action read as another error.
+ */
+export const RETRY_ACTION_ICON = "RotateCcw";
+
+/** The established glyph for an action that fetches an available update. */
+export const UPDATE_ACTION_ICON = "Download";
+
+export const UPDATE_STATE_PRESENTATION: Record<
+  UpdateState,
+  UpdateStatePresentation
+> = {
+  // The shared succeeded glyph, but muted: being current is the state every
+  // row is expected to be in, and colour is spent on exceptions.
+  "up-to-date": {
+    icon: RUN_STATE_PRESENTATION.succeeded.icon,
+    label: "Up to date",
+    tone: "muted",
+  },
+  // The shared running indicator, verbatim. Covers checking, downloading, a
+  // daemon updating itself and a CLI installing — one condition, four names.
+  "in-progress": {
+    icon: RUN_STATE_PRESENTATION["in-progress"].icon,
+    label: "In progress",
+    tone: "muted",
+    inFlight: true,
+  },
+  // The sidebar update chip's own mark: something is there to fetch.
+  "update-available": {
+    icon: UPDATE_ACTION_ICON,
+    label: "Update available",
+    tone: "muted",
+  },
+  // The desktop relaunch control's own glyph, worn inside its button.
+  "restart-required": {
+    icon: "ArrowReloadHorizontal",
+    label: "Downloaded",
+    tone: "muted",
+  },
+  "not-installed": { icon: "Download", label: "Not installed", tone: "muted" },
+  // Real state, quiet tone: the CLI was installed outside bb (Homebrew, a
+  // manual npm -g), so bb can see a newer release but has no installer to
+  // run. Informational, not a warning — nothing is wrong.
+  // bb has no installer it can run for this CLI, so the row points at where
+  // the work happens instead of offering a control that would do nothing.
+  "update-manually": {
+    icon: "Terminal",
+    label: "Update in terminal",
+    tone: "muted",
+  },
+  failed: {
+    icon: RUN_STATE_PRESENTATION.failed.icon,
+    label: "Failed",
+    tone: "error",
+  },
+  // Reuse the established closed-state glyph, but keep it muted and label it
+  // "Offline" so it cannot be mistaken for the red failure state.
+  offline: { icon: "CircleX", label: "Offline", tone: "muted" },
+};

--- a/plugins/automations/detail-view.tsx
+++ b/plugins/automations/detail-view.tsx
@@ -10,6 +10,7 @@ import type {
   PermissionMode,
 } from "./src/rpc-types";
 import { AUTOMATION_PROMPT_MAX_LENGTH } from "./src/rpc-types";
+import { RUN_STATE_PRESENTATION } from "@bb/domain/update-state";
 import { Button } from "@bb/shared-ui/button";
 import { DelayedLoading } from "./delayed-loading.js";
 import { Icon, type IconName } from "@bb/shared-ui/icon";
@@ -497,6 +498,13 @@ function isSilentRun(run: AutomationRunResponse): boolean {
   );
 }
 
+/**
+ * Glyphs and labels come from the shared run-state vocabulary in `@bb/domain`
+ * — the same map Settings → Updates and `bb updates` read — so the two
+ * surfaces cannot drift. Only the colour classes are local: a run history
+ * colours success green because a succeeded run is its headline, where the
+ * Updates page mutes it because up-to-date is its resting state.
+ */
 export const AUTOMATION_RUN_STATUS_VISUALS: Record<
   AutomationRunStatus,
   {
@@ -507,26 +515,22 @@ export const AUTOMATION_RUN_STATUS_VISUALS: Record<
 > = {
   running: {
     label: "Running",
-    icon: "Loading",
+    icon: RUN_STATE_PRESENTATION["in-progress"].icon as IconName,
     className: "animate-spin text-muted-foreground",
   },
   failed: {
-    label: "Failed",
-    icon: "CircleX",
+    label: RUN_STATE_PRESENTATION.failed.label,
+    icon: RUN_STATE_PRESENTATION.failed.icon as IconName,
     className: "text-destructive",
   },
   skipped: {
-    label: "Skipped",
-    // Not CircleDashed: icon.tsx aliases it to the same DashedLineCircleIcon as
-    // Spinner, so a skipped run rendered an identical shape to a running one.
-    // ArrowTurnForward is the only glyph in the map that reads as "passed
-    // over", and it is shape-distinct from check, x, spinner, clock and pause.
-    icon: "ArrowTurnForward",
+    label: RUN_STATE_PRESENTATION.skipped.label,
+    icon: RUN_STATE_PRESENTATION.skipped.icon as IconName,
     className: "text-subtle-foreground",
   },
   succeeded: {
-    label: "Succeeded",
-    icon: "CircleCheck",
+    label: RUN_STATE_PRESENTATION.succeeded.label,
+    icon: RUN_STATE_PRESENTATION.succeeded.icon as IconName,
     className: "text-success",
   },
 };

--- a/plugins/automations/package.json
+++ b/plugins/automations/package.json
@@ -36,7 +36,8 @@
     "@radix-ui/react-slot": "^1.3.0",
     "cron-parser": "^5.5.0",
     "cronstrue": "^3.14.0",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "@bb/domain": "workspace:*"
   },
   "devDependencies": {
     "@get-bb/plugin-sdk": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1275,7 +1275,7 @@ importers:
         version: typescript@7.0.2
       vitest:
         specifier: ^4.1.1
-        version: 4.1.1(@opentelemetry/api@1.9.1)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/bb-app:
     dependencies:
@@ -2455,6 +2455,9 @@ importers:
 
   plugins/automations:
     dependencies:
+      '@bb/domain':
+        specifier: workspace:*
+        version: link:../../packages/domain
       '@bb/shared-ui':
         specifier: workspace:*
         version: link:../../packages/shared-ui
@@ -21381,6 +21384,35 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.1
+      '@vitest/mocker': 4.1.1(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.1
+      '@vitest/runner': 4.1.1
+      '@vitest/snapshot': 4.1.1
+      '@vitest/spy': 4.1.1
+      '@vitest/utils': 4.1.1
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.0.3
+      vite: 8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 22.19.10
+      jsdom: 29.0.1(@noble/hashes@2.0.1)
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.1(@opentelemetry/api@1.9.1)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.19.12)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## Summary

- define one shared update/run-state presentation vocabulary in `@bb/domain`
- reuse the established update action icon across Settings, plugin management, Automations, and `bb updates`
- keep state labels, tooltips, accessibility names, and destructive/error semantics consistent

This is the foundation layer. It has no dependency on the later Settings UI work.

## Visual evidence

Before:

![Before: plugin update action](https://raw.githubusercontent.com/get-bb/bb/0fc2e77206c8d8972549868d04736594287ab5d1/evidence/settings-ui-stack/layer1-before-plugin-update-states.png)

After:

![After: shared update action icon](https://raw.githubusercontent.com/get-bb/bb/0fc2e77206c8d8972549868d04736594287ab5d1/evidence/settings-ui-stack/layer1-after-plugin-update-states.png)

## Verification

- Turbo typecheck: `@bb/app`, `@bb/cli`, `bb-plugin-automations`
- plugin SDK npm-version guard passed for unreleased `0.4.9`
- app focused tests: 10 passed
- CLI updates tests: 5 passed
- Automations tests: 78 passed

BB-Thread-ID: thr_qwah76hjqr

> AGENT GENERATED: by GPT-5.6
