### PR TITLE
Group Settings updates by machine

### DIFF
--- a/apps/app/.ladle/story-fixtures.ts
+++ b/apps/app/.ladle/story-fixtures.ts
@@ -7,6 +7,10 @@ import type {
   ThreadListEntry,
   WorkspaceStatus,
 } from "@bb/domain";
+import type {
+  ProviderCliKey,
+  ProviderCliStatus,
+} from "@bb/host-daemon-contract";
 import type { ProjectResponse } from "@bb/server-contract";
 import { ClaudeIcon } from "../src/components/icons/ClaudeIcon";
 import { OpenAiIcon } from "../src/components/icons/OpenAiIcon";
@@ -411,6 +415,33 @@ export function makeHost(overrides: Partial<Host> = {}): Host {
     updatedAt: 100,
   };
   return { ...base, ...overrides };
+}
+
+export function makeProviderCliStatus(
+  provider: ProviderCliKey,
+  overrides: Partial<ProviderCliStatus> = {},
+): ProviderCliStatus {
+  const identity = {
+    codex: { displayName: "Codex", executableName: "codex" },
+    claudeCode: { displayName: "Claude Code", executableName: "claude" },
+    cursor: { displayName: "Cursor", executableName: "agent" },
+  }[provider];
+  return {
+    displayName: identity.displayName,
+    executableName: identity.executableName,
+    executablePath: `/usr/local/bin/${identity.executableName}`,
+    installed: true,
+    installSource: "npmGlobal",
+    currentVersion: "1.0.0",
+    latestVersion: "1.0.0",
+    minimumSupportedVersion: null,
+    npmPackageName: null,
+    npmGlobalPackageVersion: null,
+    installAction: null,
+    needsUpdate: false,
+    versionUnsupported: false,
+    ...overrides,
+  };
 }
 
 export function makeEnvironment(

--- a/apps/app/.ladle/story-settings-chrome.tsx
+++ b/apps/app/.ladle/story-settings-chrome.tsx
@@ -1,0 +1,117 @@
+import type { CSSProperties, ReactNode } from "react";
+import { matchPath, useLocation } from "react-router-dom";
+import { AppPageHeader } from "@/components/layout/AppPageHeader";
+import { SettingsSidebarContent } from "@/components/settings/SettingsSidebar";
+import {
+  SETTINGS_NAV_SECTIONS,
+  SETTINGS_PROVIDER_ENTRIES,
+  type SettingsSectionId,
+} from "@/components/settings/settings-nav";
+import {
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+} from "@/components/ui/sidebar";
+import { PageShell } from "@/components/ui/page-shell";
+import {
+  SETTINGS_ROUTE_PATH,
+  SETTINGS_MACHINE_ROUTE_PATH,
+  getSettingsProviderRoutePath,
+  getSettingsRoutePath,
+} from "@/lib/route-paths";
+
+export type SettingsStoryRoute =
+  | { kind: "machine"; id: string }
+  | { kind: "provider"; id: (typeof SETTINGS_PROVIDER_ENTRIES)[number]["id"] }
+  | { kind: "section"; id: SettingsSectionId };
+
+/** Resolve the story's real Settings links without depending on live app data. */
+export function useSettingsStoryRoute(): SettingsStoryRoute {
+  const { pathname } = useLocation();
+  const machineMatch = matchPath(SETTINGS_MACHINE_ROUTE_PATH, pathname);
+  if (machineMatch?.params.hostId !== undefined) {
+    return { kind: "machine", id: machineMatch.params.hostId };
+  }
+  const provider = SETTINGS_PROVIDER_ENTRIES.find(
+    (entry) => getSettingsProviderRoutePath(entry.id) === pathname,
+  );
+  if (provider !== undefined) {
+    return { kind: "provider", id: provider.id };
+  }
+
+  const section = SETTINGS_NAV_SECTIONS.find((entry) =>
+    entry.id === "general"
+      ? pathname === SETTINGS_ROUTE_PATH
+      : getSettingsRoutePath(entry.id) === pathname,
+  );
+  return { kind: "section", id: section?.id ?? "general" };
+}
+
+/** Production application chrome around full-page Settings stories. */
+export function SettingsStoryChrome({
+  activeSection,
+  children,
+  contentOwnsPageShell = false,
+}: {
+  activeSection?: SettingsSectionId;
+  children: ReactNode;
+  /** Detail routes already render their production PageShell. */
+  contentOwnsPageShell?: boolean;
+}) {
+  const route = useSettingsStoryRoute();
+  const resolvedActiveSection =
+    activeSection ??
+    (route.kind === "section"
+      ? route.id
+      : route.kind === "machine"
+        ? "machines"
+        : null);
+  const activeProviderId =
+    activeSection === undefined && route.kind === "provider" ? route.id : null;
+
+  return (
+    <SidebarProvider
+      className="h-screen min-h-[640px] bg-background"
+      style={{ "--bb-shell-height": "100vh" } as CSSProperties}
+    >
+      <SettingsSidebarContent
+        appRoutePath="/"
+        isResizing={false}
+        navigation={{
+          activePluginId: null,
+          activeProviderId,
+          activeSection: resolvedActiveSection,
+          pluginEntries: [],
+          providerEntries: SETTINGS_PROVIDER_ENTRIES,
+          sections: SETTINGS_NAV_SECTIONS,
+        }}
+        onResizeMouseDown={() => {}}
+        showTopReserve
+        testIdPrefix="settings-story"
+      />
+      <SidebarInset>
+        <div className="relative flex h-full min-h-0 min-w-0 flex-col">
+          <AppPageHeader
+            center={
+              <div className="flex min-w-0 items-center gap-2">
+                <SidebarTrigger className="-ml-2" />
+                <span className="truncate text-sm font-semibold">Settings</span>
+              </div>
+            }
+          />
+          <main className="flex min-h-0 flex-1 flex-col p-4 md:p-5">
+            {contentOwnsPageShell ? (
+              children
+            ) : (
+              <PageShell contentClassName="pt-4 md:pt-5">
+                <div className="mx-auto w-full max-w-3xl space-y-10">
+                  {children}
+                </div>
+              </PageShell>
+            )}
+          </main>
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}

--- a/apps/app/src/components/provider-cli/provider-cli-install.tsx
+++ b/apps/app/src/components/provider-cli/provider-cli-install.tsx
@@ -45,6 +45,36 @@ export function providerCliEntries(
   }));
 }
 
+const PROVIDER_CLI_UPDATE_PROVIDERS = [
+  "codex",
+  "claudeCode",
+  "cursor",
+] as const satisfies readonly ProviderCliKey[];
+
+/** Provider rows Settings → Updates owns, including Cursor. */
+export function providerCliUpdateEntries(
+  status: ProviderCliStatusResponse,
+): ProviderCliStatusEntry[] {
+  return PROVIDER_CLI_UPDATE_PROVIDERS.map((provider) => ({
+    provider,
+    status: status[provider],
+  }));
+}
+
+/**
+ * Whether an issue is an *update* rather than a first install.
+ *
+ * `buildProviderCliIssue` deliberately reports a missing CLI too — onboarding
+ * and the compose box both need it to offer the install. Settings → Updates is
+ * not one of those surfaces: a CLI you never installed has no update, and
+ * listing it there put a permanent install prompt on an update page, counted it
+ * in "Update all", and made a fresh single-agent install look perpetually
+ * behind. The sidebar chips have always drawn this line; this is the same one.
+ */
+export function isProviderCliUpdateIssue(issue: ProviderCliIssue): boolean {
+  return issue.status.installed;
+}
+
 export function buildProviderCliIssue(
   entry: ProviderCliStatusEntry,
 ): ProviderCliIssue | null {

--- a/apps/app/src/components/settings/SettingsSidebar.tsx
+++ b/apps/app/src/components/settings/SettingsSidebar.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/route-paths";
 import { getProviderIconInfo } from "@/lib/provider-icon";
 import { useSettingsNavState } from "./settings-nav";
+import type { SettingsNavState } from "./settings-nav";
 
 interface SettingsSidebarProps {
   onResizeMouseDown: (event: ReactMouseEvent<HTMLDivElement>) => void;
@@ -25,14 +26,31 @@ interface SettingsSidebarProps {
   mobileHosted?: boolean;
 }
 
-/** Focused Settings navigation using the shared section-sidebar shell. */
-export function SettingsSidebar({
+export type SettingsSidebarNavigation = Pick<
+  SettingsNavState,
+  | "activePluginId"
+  | "activeProviderId"
+  | "activeSection"
+  | "pluginEntries"
+  | "providerEntries"
+  | "sections"
+>;
+
+interface SettingsSidebarContentProps extends SettingsSidebarProps {
+  navigation: SettingsSidebarNavigation;
+  testIdPrefix?: string;
+}
+
+/** Shared Settings navigation renderer for production and full-page stories. */
+export function SettingsSidebarContent({
   onResizeMouseDown,
   isResizing,
   showTopReserve,
   appRoutePath,
   mobileHosted,
-}: SettingsSidebarProps) {
+  navigation,
+  testIdPrefix = "settings",
+}: SettingsSidebarContentProps) {
   const {
     activePluginId,
     activeProviderId,
@@ -40,7 +58,7 @@ export function SettingsSidebar({
     pluginEntries,
     providerEntries,
     sections,
-  } = useSettingsNavState();
+  } = navigation;
 
   return (
     <SectionSidebar
@@ -50,7 +68,7 @@ export function SettingsSidebar({
       mobileHosted={mobileHosted}
       onResizeMouseDown={onResizeMouseDown}
       showTopReserve={showTopReserve}
-      testIdPrefix="settings"
+      testIdPrefix={testIdPrefix}
     >
       <SectionSidebarLabel>Settings</SectionSidebarLabel>
       <div className="mt-1 space-y-0.5">
@@ -138,5 +156,27 @@ export function SettingsSidebar({
         </>
       ) : null}
     </SectionSidebar>
+  );
+}
+
+/** Focused Settings navigation using the shared section-sidebar shell. */
+export function SettingsSidebar({
+  onResizeMouseDown,
+  isResizing,
+  showTopReserve,
+  appRoutePath,
+  mobileHosted,
+}: SettingsSidebarProps) {
+  const navigation = useSettingsNavState();
+
+  return (
+    <SettingsSidebarContent
+      appRoutePath={appRoutePath}
+      isResizing={isResizing}
+      mobileHosted={mobileHosted}
+      navigation={navigation}
+      onResizeMouseDown={onResizeMouseDown}
+      showTopReserve={showTopReserve}
+    />
   );
 }

--- a/apps/app/src/components/settings/UpdatesSettingsSection.stories.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.stories.tsx
@@ -1,15 +1,24 @@
 import type { ReactNode } from "react";
 import type { Host } from "@bb/domain";
-import { Button } from "@bb/shared-ui/button";
-import { Icon } from "@bb/shared-ui/icon";
-import { HOST_DAEMON_PROTOCOL_VERSION } from "@bb/host-daemon-contract";
+import { UPDATE_ACTION_ICON } from "@bb/domain/update-state";
+import {
+  HOST_DAEMON_PROTOCOL_VERSION,
+  type ProviderCliKey,
+} from "@bb/host-daemon-contract";
 import type { ProviderCliIssue } from "@/components/provider-cli/provider-cli-install";
 import type { UpdateInventoryMachine } from "@/hooks/useUpdateInventory";
+import { SettingsStoryChrome } from "../../../.ladle/story-settings-chrome";
+import {
+  makeHost,
+  makeProviderCliStatus,
+} from "../../../.ladle/story-fixtures";
 import {
   BbAppUpdateRows,
+  BbDaemonUpdateRow,
   MachineUpdatesRows,
-  UpdatesRowList,
-  UpdatesSection,
+  MachineUpdatesSection,
+  ProviderCliCheckRow,
+  UpdateActionButton,
 } from "./UpdatesSettingsSection";
 
 export default {
@@ -18,541 +27,222 @@ export default {
 
 const noop = () => {};
 const NO_JOBS: ReadonlySet<string> = new Set();
+const STORY_NOW = 1_800_000_000_000;
 
-function Stage({ children }: { children: ReactNode }) {
-  return <div className="w-full max-w-2xl space-y-6 p-4">{children}</div>;
-}
+const NPM_VERSION = {
+  currentVersion: "0.38.0",
+  latestVersion: "0.38.0",
+  source: "npm" as const,
+  updateAvailable: false,
+  isDevelopment: false,
+  upgradeCommand: "npx bb-app@latest",
+};
 
-function makeHost(overrides: Partial<Host> & Pick<Host, "id" | "name">): Host {
-  return {
-    type: "persistent",
-    status: "connected",
-    lastSeenAt: 1_700_000_000_000,
-    maxPermissionMode: "full",
-    lastRejectedProtocolVersion: null,
-    createdAt: 1,
-    updatedAt: 2,
-    ...overrides,
-  };
-}
+const DESKTOP_UPDATE = {
+  lastCheckedAt: "2026-07-19T00:00:00.000Z",
+  latestVersion: "0.39.0",
+  pendingVersion: "0.39.0",
+  platform: "macos" as const,
+  updateAvailable: true,
+  updateDownloaded: true,
+  downloadState: "downloaded" as const,
+  version: "0.38.0",
+};
 
-interface ProviderStatusOverrides {
-  installed?: boolean;
-  currentVersion?: string | null;
-  latestVersion?: string | null;
-  needsUpdate?: boolean;
-  versionUnsupported?: boolean;
-  withAction?: boolean;
-}
-
-function providerStatus(
-  provider: "codex" | "claudeCode",
-  overrides: ProviderStatusOverrides = {},
-) {
-  const displayName = provider === "codex" ? "Codex" : "Claude Code";
-  const executableName = provider === "codex" ? "codex" : "claude";
-  const installed = overrides.installed ?? true;
-  const needsUpdate = overrides.needsUpdate ?? false;
-  const withAction = overrides.withAction ?? (needsUpdate || !installed);
-  return {
-    displayName,
-    executableName,
-    executablePath: installed ? `/usr/local/bin/${executableName}` : null,
-    installed,
-    installSource: installed
-      ? ("npmGlobal" as const)
-      : ("notInstalled" as const),
-    currentVersion:
-      overrides.currentVersion !== undefined
-        ? overrides.currentVersion
-        : installed
-          ? "1.0.0"
-          : null,
-    latestVersion:
-      overrides.latestVersion !== undefined ? overrides.latestVersion : "1.0.1",
-    minimumSupportedVersion: null,
-    npmPackageName: null,
-    npmGlobalPackageVersion: null,
-    installAction: withAction
-      ? {
-          kind: installed ? ("update" as const) : ("install" as const),
-          label: installed ? ("Update" as const) : ("Install" as const),
-          commandKind: "exec" as const,
-          command: installed
-            ? `${executableName} update`
-            : `npm install -g ${executableName}`,
-        }
-      : null,
-    needsUpdate,
-    versionUnsupported: overrides.versionUnsupported ?? false,
-  };
-}
-
-function issueFor(
-  provider: "codex" | "claudeCode",
-  overrides: ProviderStatusOverrides = {},
+function updateIssue(
+  provider: ProviderCliKey,
+  currentVersion: string,
+  latestVersion: string,
 ): ProviderCliIssue {
-  const status = providerStatus(provider, overrides);
+  const base = makeProviderCliStatus(provider);
+  const action = {
+    kind: "update" as const,
+    label: "Update" as const,
+    commandKind: "exec" as const,
+    command: `${base.executableName} update`,
+  };
   return {
     provider,
-    status,
-    action: status.installAction,
-    title: `${status.displayName} update available`,
-    description: "story",
-    fingerprint: `${provider}:story`,
+    status: {
+      ...base,
+      currentVersion,
+      latestVersion,
+      installAction: action,
+      needsUpdate: true,
+    },
+    action,
+    title: `${base.displayName} update available`,
+    description: `${currentVersion} -> ${latestVersion}`,
+    fingerprint: `${provider}:${currentVersion}:${latestVersion}`,
   };
 }
 
-function machineOf(args: {
+function machineOf({
+  host,
+  isPrimary = false,
+  issues = [],
+  statusError = false,
+  canRetryDaemonUpdate = false,
+}: {
   host: Host;
-  statuses?: {
-    codex: ReturnType<typeof providerStatus>;
-    claudeCode: ReturnType<typeof providerStatus>;
-  };
+  isPrimary?: boolean;
   issues?: ProviderCliIssue[];
-  statusPending?: boolean;
   statusError?: boolean;
   canRetryDaemonUpdate?: boolean;
 }): UpdateInventoryMachine {
+  const statusFor = (provider: ProviderCliKey) =>
+    issues.find((issue) => issue.provider === provider)?.status ??
+    makeProviderCliStatus(provider);
   return {
-    host: args.host,
-    isPrimary: args.host.id === "host-primary",
+    host,
+    isPrimary,
     providerStatus:
-      args.statuses === undefined
-        ? null
-        : {
-            ...args.statuses,
-            cursor: {
-              ...providerStatus("codex", { installed: false }),
-              displayName: "Cursor",
-              executableName: "agent",
-              latestVersion: null,
-              installAction: null,
-            },
-          },
-    statusPending: args.statusPending ?? false,
-    statusError: args.statusError ?? false,
-    issues: args.issues ?? [],
-    canRetryDaemonUpdate: args.canRetryDaemonUpdate ?? false,
+      host.status === "connected"
+        ? {
+            codex: statusFor("codex"),
+            claudeCode: statusFor("claudeCode"),
+            cursor: statusFor("cursor"),
+          }
+        : null,
+    statusPending: false,
+    statusFetching: false,
+    statusError,
+    issues,
+    canRetryDaemonUpdate,
   };
 }
 
-function MachineSection({ machine }: { machine: UpdateInventoryMachine }) {
+function StoryPage({ children }: { children: ReactNode }) {
   return (
-    <UpdatesSection title="Machines">
-      <UpdatesRowList>
-        <MachineUpdatesRows
-          machine={machine}
-          runningJobKey={null}
-          queuedJobKeys={NO_JOBS}
-          retryUpdatePending={false}
-          onStartInstall={noop}
-          onRetryDaemonUpdate={noop}
+    <SettingsStoryChrome activeSection="updates">
+      <div className="space-y-6">{children}</div>
+    </SettingsStoryChrome>
+  );
+}
+
+function StoryMachineSection({
+  machine,
+  app = false,
+  appUpdate = false,
+  action,
+}: {
+  machine: UpdateInventoryMachine;
+  app?: boolean;
+  appUpdate?: boolean;
+  action?: ReactNode;
+}) {
+  const showDaemon =
+    machine.canRetryDaemonUpdate || machine.host.status !== "connected";
+  return (
+    <MachineUpdatesSection machine={machine} action={action}>
+      {app ? (
+        <BbAppUpdateRows
+          systemVersion={appUpdate ? undefined : NPM_VERSION}
+          desktopInfo={appUpdate ? DESKTOP_UPDATE : null}
+          isDesktop={appUpdate}
+          onRelaunchDesktop={noop}
+          onRetryDesktop={noop}
         />
-      </UpdatesRowList>
-    </UpdatesSection>
-  );
-}
-
-function StoryActionButton({ children }: { children: ReactNode }) {
-  return (
-    <Button
-      type="button"
-      variant="outline"
-      size="sm"
-      className="h-6 px-2 text-xs"
-    >
-      {children}
-    </Button>
-  );
-}
-
-export function HealthyFleet() {
-  const statuses = {
-    codex: providerStatus("codex", {
-      currentVersion: "0.146.0",
-      latestVersion: "0.146.0",
-    }),
-    claudeCode: providerStatus("claudeCode", {
-      currentVersion: "2.1.0",
-      latestVersion: "2.1.0",
-    }),
-  };
-  return (
-    <Stage>
-      <UpdatesSection
-        title="bb"
-        footnote="Connected machines follow the server version automatically."
-        action={
-          <>
-            <span className="text-xs text-subtle-foreground">
-              Checked 2m ago
-            </span>
-            <StoryActionButton>What's new</StoryActionButton>
-          </>
-        }
-      >
-        <UpdatesRowList>
-          <BbAppUpdateRows
-            systemVersion={{
-              currentVersion: "0.0.33",
-              latestVersion: "0.0.33",
-              source: "npm",
-              updateAvailable: false,
-              isDevelopment: false,
-              upgradeCommand: "npx bb-app@latest",
-            }}
-            desktopInfo={null}
-            isDesktop={false}
-            onRelaunchDesktop={null}
-            onRetryDesktop={null}
-          />
-        </UpdatesRowList>
-      </UpdatesSection>
-      <UpdatesSection
-        title="Machines"
-        action={
-          <span className="text-xs text-subtle-foreground">
-            2 machines, all in sync
-          </span>
-        }
-      >
-        <UpdatesRowList>
-          <MachineUpdatesRows
-            machine={machineOf({
-              host: makeHost({ id: "host-primary", name: "workstation" }),
-              statuses,
-            })}
-            runningJobKey={null}
-            queuedJobKeys={NO_JOBS}
-            retryUpdatePending={false}
-            onStartInstall={noop}
-            onRetryDaemonUpdate={noop}
-          />
-          <MachineUpdatesRows
-            machine={machineOf({
-              host: makeHost({ id: "host-remote", name: "studio-mac" }),
-              statuses,
-            })}
-            runningJobKey={null}
-            queuedJobKeys={NO_JOBS}
-            retryUpdatePending={false}
-            onStartInstall={noop}
-            onRetryDaemonUpdate={noop}
-          />
-        </UpdatesRowList>
-      </UpdatesSection>
-    </Stage>
-  );
-}
-
-export function MixedFleet() {
-  const codex = providerStatus("codex", {
-    currentVersion: "0.145.0",
-    latestVersion: "0.146.0",
-    needsUpdate: true,
-  });
-  const claude = providerStatus("claudeCode", {
-    currentVersion: "2.1.0",
-    latestVersion: "2.1.0",
-  });
-  return (
-    <Stage>
-      <UpdatesSection
-        title="bb"
-        footnote="Connected machines follow the server version automatically."
-        action={
-          <>
-            <span className="text-xs text-subtle-foreground">
-              Checked just now
-            </span>
-            <StoryActionButton>What's new</StoryActionButton>
-          </>
-        }
-      >
-        <UpdatesRowList>
-          <BbAppUpdateRows
-            systemVersion={{
-              currentVersion: "0.0.32",
-              latestVersion: "0.0.33",
-              source: "npm",
-              updateAvailable: true,
-              isDevelopment: false,
-              upgradeCommand: "npx bb-app@latest",
-            }}
-            desktopInfo={null}
-            isDesktop={false}
-            onRelaunchDesktop={null}
-            onRetryDesktop={null}
-          />
-        </UpdatesRowList>
-      </UpdatesSection>
-      <UpdatesSection
-        title="Machines"
-        action={
-          <>
-            <span className="text-xs text-subtle-foreground">
-              1 machine can't connect
-            </span>
-            <StoryActionButton>Update all (1)</StoryActionButton>
-          </>
-        }
-      >
-        <UpdatesRowList>
-          <MachineUpdatesRows
-            machine={machineOf({
-              host: makeHost({ id: "host-primary", name: "workstation" }),
-              statuses: { codex, claudeCode: claude },
-              issues: [
-                issueFor("codex", {
-                  currentVersion: "0.145.0",
-                  latestVersion: "0.146.0",
-                  needsUpdate: true,
-                }),
-              ],
-            })}
-            runningJobKey={null}
-            queuedJobKeys={NO_JOBS}
-            retryUpdatePending={false}
-            onStartInstall={noop}
-            onRetryDaemonUpdate={noop}
-          />
-          <MachineUpdatesRows
-            machine={machineOf({
-              host: makeHost({
-                id: "host-remote",
-                name: "homelab",
-                status: "disconnected",
-                lastRejectedProtocolVersion: HOST_DAEMON_PROTOCOL_VERSION - 1,
-              }),
-              canRetryDaemonUpdate: true,
-            })}
-            runningJobKey={null}
-            queuedJobKeys={NO_JOBS}
-            retryUpdatePending={false}
-            onStartInstall={noop}
-            onRetryDaemonUpdate={noop}
-          />
-        </UpdatesRowList>
-      </UpdatesSection>
-    </Stage>
-  );
-}
-
-export function WebAppUpdateAvailable() {
-  return (
-    <Stage>
-      <UpdatesSection title="bb">
-        <UpdatesRowList>
-          <BbAppUpdateRows
-            systemVersion={{
-              currentVersion: "0.0.32",
-              latestVersion: "0.0.33",
-              source: "npm",
-              updateAvailable: true,
-              isDevelopment: false,
-              upgradeCommand: "npx bb-app@latest",
-            }}
-            desktopInfo={null}
-            isDesktop={false}
-            onRelaunchDesktop={null}
-            onRetryDesktop={null}
-          />
-        </UpdatesRowList>
-      </UpdatesSection>
-    </Stage>
-  );
-}
-
-export function DesktopUpdateReady() {
-  return (
-    <Stage>
-      <UpdatesSection title="bb">
-        <UpdatesRowList>
-          <BbAppUpdateRows
-            systemVersion={undefined}
-            desktopInfo={{
-              downloadState: "downloaded",
-              lastCheckedAt: "2026-07-19T00:00:00.000Z",
-              latestVersion: "0.0.33",
-              pendingVersion: "0.0.33",
-              platform: "macos",
-              updateAvailable: true,
-              updateDownloaded: true,
-              version: "0.0.32",
-            }}
-            isDesktop
-            onRelaunchDesktop={noop}
-            onRetryDesktop={noop}
-          />
-        </UpdatesRowList>
-      </UpdatesSection>
-    </Stage>
-  );
-}
-
-export function DesktopDownloading() {
-  return (
-    <Stage>
-      <UpdatesSection title="bb">
-        <UpdatesRowList>
-          <BbAppUpdateRows
-            systemVersion={undefined}
-            desktopInfo={{
-              downloadState: "downloading",
-              lastCheckedAt: "2026-07-19T00:00:00.000Z",
-              latestVersion: "0.0.33",
-              pendingVersion: null,
-              platform: "macos",
-              updateAvailable: true,
-              updateDownloaded: false,
-              version: "0.0.32",
-            }}
-            isDesktop
-            onRelaunchDesktop={noop}
-            onRetryDesktop={noop}
-          />
-        </UpdatesRowList>
-      </UpdatesSection>
-    </Stage>
-  );
-}
-
-export function MachineWithUpdateAndInstall() {
-  const codex = providerStatus("codex", {
-    currentVersion: "0.140.0",
-    latestVersion: "0.141.0",
-    needsUpdate: true,
-  });
-  const claude = providerStatus("claudeCode", { installed: false });
-  return (
-    <Stage>
-      <MachineSection
-        machine={machineOf({
-          host: makeHost({ id: "host-primary", name: "workstation" }),
-          statuses: { codex, claudeCode: claude },
-          issues: [
-            issueFor("codex", {
-              currentVersion: "0.140.0",
-              latestVersion: "0.141.0",
-              needsUpdate: true,
-            }),
-            issueFor("claudeCode", { installed: false }),
-          ],
-        })}
+      ) : null}
+      {showDaemon ? (
+        <BbDaemonUpdateRow
+          machine={machine}
+          now={STORY_NOW}
+          retryUpdatePending={false}
+          onRetryDaemonUpdate={noop}
+          onOpenMachine={noop}
+        />
+      ) : null}
+      {machine.statusError ? (
+        <ProviderCliCheckRow
+          machine={machine}
+          onRecheckClis={noop}
+          onOpenMachine={noop}
+        />
+      ) : null}
+      <MachineUpdatesRows
+        machine={machine}
+        runningJobKey={null}
+        queuedJobKeys={NO_JOBS}
+        onStartInstall={noop}
+        onOpenProvider={noop}
       />
-    </Stage>
+    </MachineUpdatesSection>
   );
 }
 
-export function MachineRunningAndQueued() {
-  const codex = providerStatus("codex", {
-    currentVersion: "0.140.0",
-    latestVersion: "0.141.0",
-    needsUpdate: true,
-  });
-  const claude = providerStatus("claudeCode", {
-    currentVersion: "2.0.9",
-    latestVersion: "2.1.0",
-    needsUpdate: true,
-  });
-  const machine = machineOf({
+/** Multiple machines, each owning its app, daemon, or provider update rows. */
+export function MultiMachine() {
+  const workstation = machineOf({
     host: makeHost({ id: "host-primary", name: "workstation" }),
-    statuses: { codex, claudeCode: claude },
+    isPrimary: true,
     issues: [
-      issueFor("codex", { needsUpdate: true }),
-      issueFor("claudeCode", { needsUpdate: true }),
+      updateIssue("codex", "0.145.0", "0.146.0"),
+      updateIssue("cursor", "0.48.0", "0.49.0"),
     ],
   });
-  return (
-    <Stage>
-      <UpdatesSection title="Machines">
-        <UpdatesRowList>
-          <MachineUpdatesRows
-            machine={machine}
-            runningJobKey="host-primary:codex"
-            queuedJobKeys={new Set(["host-primary:claudeCode"])}
-            retryUpdatePending={false}
-            onStartInstall={noop}
-            onRetryDaemonUpdate={noop}
-          />
-        </UpdatesRowList>
-      </UpdatesSection>
-    </Stage>
-  );
-}
+  const studioMac = machineOf({
+    host: makeHost({ id: "host-studio", name: "studio-mac" }),
+    issues: [updateIssue("claudeCode", "2.0.1", "2.1.0")],
+  });
+  const ciRunner = machineOf({
+    host: makeHost({
+      id: "host-ci",
+      name: "ci-runner-3",
+      status: "disconnected",
+      lastRejectedProtocolVersion: HOST_DAEMON_PROTOCOL_VERSION - 1,
+      updatedAt: STORY_NOW - 6 * 60_000,
+    }),
+    canRetryDaemonUpdate: true,
+  });
 
-export function MachineOffline() {
   return (
-    <Stage>
-      <MachineSection
-        machine={machineOf({
-          host: makeHost({
-            id: "host-remote",
-            name: "homelab",
-            status: "disconnected",
-          }),
-        })}
+    <StoryPage>
+      <StoryMachineSection
+        machine={workstation}
+        app
+        appUpdate
+        action={
+          <div role="toolbar" aria-label="Bulk update actions">
+            <UpdateActionButton
+              label="Update all 3 CLI tools"
+              tooltipLabel="Update all"
+              icon={UPDATE_ACTION_ICON}
+              variant="default"
+              onClick={noop}
+            />
+          </div>
+        }
       />
-    </Stage>
+      <StoryMachineSection machine={studioMac} />
+      <StoryMachineSection machine={ciRunner} />
+    </StoryPage>
   );
 }
 
-export function MachineDaemonNeedsUpdate() {
+/** The same hierarchy without a redundant all-machines wrapper. */
+export function SingleMachine() {
+  const workstation = machineOf({
+    host: makeHost({ id: "host-primary", name: "workstation" }),
+    isPrimary: true,
+    issues: [updateIssue("claudeCode", "2.0.1", "2.1.0")],
+  });
   return (
-    <Stage>
-      <MachineSection
-        machine={machineOf({
-          host: makeHost({
-            id: "host-remote",
-            name: "homelab",
-            status: "disconnected",
-            lastRejectedProtocolVersion: HOST_DAEMON_PROTOCOL_VERSION - 1,
-          }),
-          canRetryDaemonUpdate: true,
-        })}
-      />
-    </Stage>
+    <StoryPage>
+      <StoryMachineSection machine={workstation} app />
+    </StoryPage>
   );
 }
 
-export function MachineStatusFailed() {
+/** A settled machine keeps the existing explicit bb app confirmation. */
+export function NoUpdatesAvailable() {
+  const workstation = machineOf({
+    host: makeHost({ id: "host-primary", name: "workstation" }),
+    isPrimary: true,
+  });
   return (
-    <Stage>
-      <MachineSection
-        machine={machineOf({
-          host: makeHost({ id: "host-remote", name: "homelab" }),
-          statusError: true,
-        })}
-      />
-    </Stage>
-  );
-}
-
-export function MachineChecking() {
-  return (
-    <Stage>
-      <MachineSection
-        machine={machineOf({
-          host: makeHost({ id: "host-remote", name: "homelab" }),
-          statusPending: true,
-        })}
-      />
-    </Stage>
-  );
-}
-
-export function SidebarBadge() {
-  return (
-    <Stage>
-      <div className="flex w-72 items-center gap-4 rounded-md bg-sidebar p-2">
-        <Icon name="Settings" className="size-4 text-muted-foreground" />
-        <Icon name="Bug" className="size-4 text-muted-foreground" />
-        <span className="ml-auto flex h-6 items-center gap-1.5 rounded-full bg-primary px-2.5 text-xs font-medium text-primary-foreground">
-          <Icon name="PackageReceive" className="size-3.5" />
-          Updates
-        </span>
-      </div>
-    </Stage>
+    <StoryPage>
+      <StoryMachineSection machine={workstation} app />
+    </StoryPage>
   );
 }

--- a/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
@@ -6,13 +6,17 @@ import {
   render,
   screen,
   waitFor,
-  within,
 } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Host } from "@bb/domain";
 import type { BbDesktopApi, BbDesktopInfo } from "@bb/desktop-contract";
-import { HOST_DAEMON_PROTOCOL_VERSION } from "@bb/host-daemon-contract";
+import {
+  HOST_DAEMON_PROTOCOL_VERSION,
+  type ProviderCliKey,
+} from "@bb/host-daemon-contract";
+import { TooltipProvider } from "@bb/shared-ui/tooltip";
 import type {
   ProviderCliIssue,
   ProviderCliActionableIssue,
@@ -97,10 +101,14 @@ function makeHost(overrides: Partial<Host> & Pick<Host, "id" | "name">): Host {
 }
 
 function makeUpdateIssue(args: {
-  provider: "codex" | "claudeCode";
+  provider: ProviderCliKey;
 }): ProviderCliActionableIssue {
-  const displayName = args.provider === "codex" ? "Codex" : "Claude Code";
-  const executableName = args.provider === "codex" ? "codex" : "claude";
+  const identity = {
+    codex: { displayName: "Codex", executableName: "codex" },
+    claudeCode: { displayName: "Claude Code", executableName: "claude" },
+    cursor: { displayName: "Cursor", executableName: "agent" },
+  }[args.provider];
+  const { displayName, executableName } = identity;
   const action = {
     kind: "update" as const,
     label: "Update" as const,
@@ -155,7 +163,7 @@ function makeMachine(args: {
   canRetryDaemonUpdate?: boolean;
 }): UpdateInventoryMachine {
   const issues = args.issues ?? [];
-  const upToDate = (provider: "codex" | "claudeCode") => {
+  const upToDate = (provider: ProviderCliKey) => {
     const issue = issues.find((entry) => entry.provider === provider);
     if (issue !== undefined) {
       return issue.status;
@@ -167,16 +175,17 @@ function makeMachine(args: {
       needsUpdate: false,
     };
   };
-  const cursorStatus = {
-    ...makeUpdateIssue({ provider: "codex" }).status,
-    displayName: "Cursor",
-    executableName: "agent",
-    installed: false,
-    currentVersion: null,
-    latestVersion: null,
-    needsUpdate: false,
-    installAction: null,
-  };
+  const cursorIssue = issues.find((entry) => entry.provider === "cursor");
+  const cursorStatus =
+    cursorIssue?.status ??
+    ({
+      ...makeUpdateIssue({ provider: "cursor" }).status,
+      installed: false,
+      currentVersion: null,
+      latestVersion: null,
+      needsUpdate: false,
+      installAction: null,
+    } as const);
   return {
     host: args.host,
     isPrimary: args.isPrimary ?? false,
@@ -189,6 +198,7 @@ function makeMachine(args: {
           }
         : null,
     statusPending: args.statusPending ?? false,
+    statusFetching: args.statusPending ?? false,
     statusError: args.statusError ?? false,
     issues,
     canRetryDaemonUpdate: args.canRetryDaemonUpdate ?? false,
@@ -209,7 +219,12 @@ function makeInventory(overrides: Partial<UpdateInventory>): UpdateInventory {
     desktopInfo: null,
     appUpdateAvailable: false,
     desktopUpdateReady: false,
-    machines: [],
+    machines: [
+      makeMachine({
+        host: makeHost({ id: "host_primary", name: "workstation" }),
+        isPrimary: true,
+      }),
+    ],
     actionableCount: 0,
     hasAttention: false,
     lastCheckedAt: null,
@@ -219,13 +234,17 @@ function makeInventory(overrides: Partial<UpdateInventory>): UpdateInventory {
 
 function renderSection(): void {
   render(
-    <QueryClientProvider
-      client={
-        new QueryClient({ defaultOptions: { queries: { retry: false } } })
-      }
-    >
-      <UpdatesSettingsSection />
-    </QueryClientProvider>,
+    <MemoryRouter>
+      <TooltipProvider>
+        <QueryClientProvider
+          client={
+            new QueryClient({ defaultOptions: { queries: { retry: false } } })
+          }
+        >
+          <UpdatesSettingsSection />
+        </QueryClientProvider>
+      </TooltipProvider>
+    </MemoryRouter>,
   );
 }
 
@@ -250,7 +269,79 @@ afterEach(() => {
 });
 
 describe("UpdatesSettingsSection", () => {
-  it("keeps a recently checked healthy fleet quiet and accessible", () => {
+  it("checks for updates once when the view mounts", async () => {
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    const host = makeHost({ id: "host_1", name: "workstation" });
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({ machines: [makeMachine({ host })] }),
+    );
+    vi.mocked(sdk.system.version).mockResolvedValue(
+      makeInventory({}).systemVersion!,
+    );
+
+    renderSection();
+
+    // Visiting the page is the request to check — there is no button for it.
+    expect(screen.queryByRole("button", { name: /check/i })).toBeNull();
+    await waitFor(() => {
+      expect(sdk.system.version).toHaveBeenCalledWith({ force: true });
+    });
+    // Exactly one: re-renders must not re-fire it, and the store's own
+    // single-flight guard must not be the only thing preventing a loop.
+    expect(sdk.system.version).toHaveBeenCalledTimes(1);
+  });
+
+  it("aligns Update all with the first machine heading", () => {
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        machines: [
+          makeMachine({
+            host: makeHost({ id: "host_1", name: "workstation" }),
+            issues: [makeUpdateIssue({ provider: "codex" })],
+          }),
+          makeMachine({
+            host: makeHost({ id: "host_2", name: "homelab" }),
+            issues: [makeUpdateIssue({ provider: "claudeCode" })],
+          }),
+        ],
+      }),
+    );
+
+    renderSection();
+
+    const bulkActions = screen.getByRole("toolbar", {
+      name: "Bulk update actions",
+    });
+    const updateAll = bulkActions.querySelector(
+      '[aria-label="Update all 2 CLI tools"]',
+    );
+    expect(updateAll).not.toBeNull();
+    expect(updateAll?.className).toContain("bg-primary");
+    expect(updateAll?.className).toContain("text-primary-foreground");
+    const workstationHeading = screen.getByRole("heading", {
+      name: "workstation",
+    });
+    const homelabHeading = screen.getByRole("heading", { name: "homelab" });
+    const workstationSection = workstationHeading.closest(
+      "[data-updates-machine]",
+    );
+    const homelabSection = homelabHeading.closest("[data-updates-machine]");
+    expect(workstationSection?.contains(bulkActions)).toBe(true);
+    expect(homelabSection?.contains(bulkActions)).toBe(false);
+    expect(bulkActions.querySelector('[data-icon="Download"]')).not.toBeNull();
+    expect(bulkActions.parentElement?.className).toContain("pr-4");
+  });
+
+  it("keeps a recently checked healthy fleet quiet and accessible", async () => {
     useDesktopUpdateInfoMock.mockReturnValue({
       desktopApi: null,
       desktopInfo: null,
@@ -273,16 +364,48 @@ describe("UpdatesSettingsSection", () => {
 
     renderSection();
 
-    expect(screen.getByText("Checked 2m ago")).toBeDefined();
-    expect(screen.getByText("2 machines, all in sync")).toBeDefined();
-    expect(screen.queryByText("Up to date")).toBeNull();
+    // A settled row is a mark, named only to a screen reader and on hover.
+    // Opening the page runs the check, so there is no freshness stamp: the age
+    // of the claim is always "since you got here".
+    await waitFor(() => {
+      expect(screen.getByText("Up to date").className).toContain("sr-only");
+    });
+    expect(screen.queryByText("2 up to date")).toBeNull();
+    expect(screen.getByRole("heading", { name: /workstation/ })).toBeDefined();
+    expect(screen.getByText("This machine")).toBeDefined();
+    expect(screen.queryByText("studio-mac")).toBeNull();
+    expect(screen.queryByText(/Checked/)).toBeNull();
+    expect(screen.queryByText(/ago$/)).toBeNull();
     expect(screen.queryByText(/^In sync$/)).toBeNull();
+    expect(screen.queryByText("workstation, studio-mac")).toBeNull();
+    // Opening the page is the request to check, so there is no button to press
+    // and no freshness stamp to justify one.
+    expect(screen.queryByRole("button", { name: /check/i })).toBeNull();
+    // Nothing needs updating, so the page drops the "Updates" title entirely
+    // and the settled sentence is the heading.
+    expect(screen.queryByRole("heading", { name: "Updates" })).toBeNull();
+    // Being up to date is the state every row is expected to be in, so it
+    // carries no indicator: the page spends its dots on exceptions only.
+    const settled = screen.getByText(/^Up to date/);
+    expect(settled.parentElement?.querySelector(".bg-success")).toBeNull();
+    expect(document.querySelector(".bg-success")).toBeNull();
     expect(
-      screen.getByRole("group", { name: /workstation, Connected/ }),
-    ).toBeDefined();
+      document
+        .querySelector(
+          '[data-update-state="up-to-date"] [data-icon="CircleCheck"]',
+        )
+        ?.getAttribute("class"),
+    ).toContain("text-input");
+    expect(
+      document
+        .querySelector(
+          '[data-update-state="up-to-date"] [data-icon="CircleCheck"]',
+        )
+        ?.getAttribute("class"),
+    ).not.toContain("opacity-");
   });
 
-  it("does not call an offline fleet all in sync", () => {
+  it("does not call an offline fleet all in sync", async () => {
     useDesktopUpdateInfoMock.mockReturnValue({
       desktopApi: null,
       desktopInfo: null,
@@ -304,16 +427,91 @@ describe("UpdatesSettingsSection", () => {
 
     renderSection();
 
-    expect(screen.getByText("1 machine was not checked")).toBeDefined();
-    expect(screen.queryByText(/all in sync/)).toBeNull();
+    expect(screen.getByText("homelab")).toBeDefined();
+    expect(screen.queryByText("1 offline")).toBeNull();
+    expect(screen.getByText("Offline")).toBeDefined();
+    const offlineIcon = document.querySelector(
+      '[data-update-state="offline"] [data-icon="CircleX"]',
+    );
+    expect(offlineIcon?.getAttribute("class")).toContain(
+      "text-subtle-foreground",
+    );
+    expect(offlineIcon?.getAttribute("class")).not.toContain("text-input");
+    const daemonRow = screen
+      .getByText("bb daemon")
+      .closest("[data-resource-row]");
+    expect(daemonRow).not.toBeNull();
+    expect(screen.getByText("bb app")).toBeDefined();
     expect(
-      within(screen.getByRole("group", { name: /homelab, Offline/ })).getByText(
-        "Offline — connect to check for updates",
-      ),
+      screen.getByRole("button", { name: "Open homelab settings" }),
+    ).toBeDefined();
+    // App and daemon rows use the bb identity mark; machine ownership comes
+    // from the section heading rather than a laptop glyph in the row.
+    expect(
+      daemonRow?.querySelector('[data-bb-update-role="daemon"]'),
+    ).not.toBeNull();
+    expect(
+      document.querySelector('[data-bb-update-role="app"]'),
+    ).not.toBeNull();
+    expect(daemonRow?.querySelector('[data-icon="Laptop"]')).toBeNull();
+    // An unreachable machine is not pending update work, so the page still
+    // leads with the settled answer instead of going silent.
+    // Every row states its own condition, and a settled one says when that was
+    // established rather than going blank.
+    await waitFor(() => {
+      expect(screen.getByText(/^Up to date/)).toBeDefined();
+    });
+    expect(screen.queryByText(/all in sync/)).toBeNull();
+  });
+
+  it("shows only machines with relevant health status in a mixed fleet", () => {
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    const stalledHost = makeHost({
+      id: "host_3",
+      name: "homelab",
+      status: "disconnected",
+      lastRejectedProtocolVersion: HOST_DAEMON_PROTOCOL_VERSION - 1,
+      updatedAt: Date.now() - 3 * 60 * 1000,
+    });
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        machines: [
+          makeMachine({
+            host: makeHost({ id: "host_1", name: "workstation" }),
+          }),
+          makeMachine({
+            host: makeHost({
+              id: "host_2",
+              name: "studio-mac",
+              status: "disconnected",
+            }),
+          }),
+          makeMachine({
+            host: stalledHost,
+            canRetryDaemonUpdate: true,
+          }),
+        ],
+      }),
+    );
+
+    renderSection();
+
+    expect(document.querySelectorAll("[data-updates-machine]")).toHaveLength(3);
+    expect(screen.queryByText("Needs attention")).toBeNull();
+    expect(screen.getByText("workstation")).toBeDefined();
+    expect(screen.getByText("studio-mac")).toBeDefined();
+    expect(screen.getByText("Offline")).toBeDefined();
+    expect(screen.getByText("homelab")).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: /^Failed · Retry on/ }),
     ).toBeDefined();
   });
 
-  it("explains and retries a stranded daemon update", () => {
+  it("treats a recent daemon protocol mismatch as an automatic update", () => {
     useDesktopUpdateInfoMock.mockReturnValue({
       desktopApi: null,
       desktopInfo: null,
@@ -338,21 +536,438 @@ describe("UpdatesSettingsSection", () => {
 
     renderSection();
 
-    expect(screen.getByText("1 machine can't connect")).toBeDefined();
+    expect(screen.getByText("homelab")).toBeDefined();
+    expect(screen.queryByText("1 updating")).toBeNull();
+    // The machine owns the section; the row identifies the daemon explicitly.
+    expect(screen.getByText("bb daemon")).toBeDefined();
+    expect(screen.getAllByText("In progress").length).toBeGreaterThan(0);
     expect(
-      screen.getByText("Can't connect — its bb agent is out of date"),
-    ).toBeDefined();
-    expect(
-      screen.getByText(
-        `Needs update · daemon protocol ${HOST_DAEMON_PROTOCOL_VERSION - 1} · server protocol ${HOST_DAEMON_PROTOCOL_VERSION}`,
-      ),
-    ).toBeDefined();
+      document.querySelector('[data-updates-machine="host_1"]'),
+    ).not.toBeNull();
+    expect(screen.queryByText("1 machine is updating bb")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Retry update" })).toBeNull();
+    expect(screen.queryByText(/can't connect/i)).toBeNull();
+  });
 
-    fireEvent.click(screen.getByRole("button", { name: "Retry update" }));
+  it("explains and retries a daemon update that has stalled", () => {
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    const host = makeHost({
+      id: "host_1",
+      name: "homelab",
+      status: "disconnected",
+      lastRejectedProtocolVersion: HOST_DAEMON_PROTOCOL_VERSION - 1,
+      updatedAt: Date.now() - 3 * 60 * 1000,
+    });
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        machines: [
+          makeMachine({
+            host,
+            canRetryDaemonUpdate: true,
+          }),
+        ],
+      }),
+    );
+
+    renderSection();
+
+    expect(screen.getByText("homelab")).toBeDefined();
+    expect(screen.queryByText("1 needs attention")).toBeNull();
+    // Not "stalled": that names an internal step and gives the reader nothing
+    // to weigh. How long it has been waiting is what makes it judgeable.
+    expect(
+      screen.getByRole("button", { name: "Failed · Retry on homelab now" }),
+    ).toBeDefined();
+    expect(screen.queryByText("1 machine needs attention")).toBeNull();
+    expect(screen.queryByText(/daemon protocol/)).toBeNull();
+    expect(
+      screen.getByText("bb daemon").closest("[data-resource-row]")?.className,
+    ).not.toContain("bg-surface-destructive");
+    // A stalled bb update is outstanding update work, so the page must not
+    // claim everything is settled while that row sits under the claim.
+    expect(screen.queryByText(/^Up to date/)).toBeNull();
+    // The row states the condition once; no banner repeats it above.
+    expect(
+      screen.getAllByRole("button", { name: /^Failed · Retry on/ }),
+    ).toHaveLength(1);
+
+    // One stuck machine already has its own Retry on the row, so a bulk sweep
+    // beside it would be two controls doing the same thing.
+    expect(
+      screen.queryByRole("button", { name: /Update all .* machines now/ }),
+    ).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Failed · Retry on homelab now",
+      }),
+    );
     expect(retryHostUpdateMutateMock).toHaveBeenCalledWith(
       host.id,
       expect.objectContaining({ onSuccess: expect.any(Function) }),
     );
+  });
+
+  it("names a machine running a newer bb than the server", () => {
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        machines: [
+          makeMachine({
+            host: makeHost({
+              id: "host_1",
+              name: "homelab",
+              status: "disconnected",
+              // Ahead of the server, so the machine cannot fix itself and no
+              // retry can help — the server is what has to move.
+              lastRejectedProtocolVersion: HOST_DAEMON_PROTOCOL_VERSION + 1,
+            }),
+            canRetryDaemonUpdate: false,
+          }),
+        ],
+      }),
+    );
+
+    renderSection();
+
+    // "Offline" alone was true here and useless: it sends the reader to check
+    // a network that is working perfectly. The mark still says offline — that
+    // is the condition — but the row now names the fix beside the machine.
+    expect(screen.getByText("Update this app to reconnect")).toBeDefined();
+    // Nothing on this machine can resolve it, so the row offers no action.
+    expect(
+      screen.queryByRole("button", { name: /Update homelab now/ }),
+    ).toBeNull();
+  });
+
+  it("sweeps every machine stalled on the same bb update", () => {
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    // A server protocol bump rejects every enrolled daemon at once, so a
+    // broken rollout stalls the whole fleet rather than one machine.
+    const stalled = ["workstation", "studio-mac", "homelab"].map(
+      (name, index) =>
+        makeHost({
+          id: `host_${index}`,
+          name,
+          status: "disconnected",
+          lastRejectedProtocolVersion: HOST_DAEMON_PROTOCOL_VERSION - 1,
+          updatedAt: Date.now() - 3 * 60 * 1000,
+        }),
+    );
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        machines: stalled.map((host) =>
+          makeMachine({ host, canRetryDaemonUpdate: true }),
+        ),
+      }),
+    );
+
+    renderSection();
+
+    expect(screen.queryByText(/^Up to date/)).toBeNull();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Update all 3 machines now",
+      }),
+    );
+    expect(retryHostUpdateMutateMock).toHaveBeenCalledTimes(3);
+    for (const host of stalled) {
+      expect(retryHostUpdateMutateMock).toHaveBeenCalledWith(host.id);
+    }
+    // Each row keeps its own Retry: the sweep is an addition, not a takeover.
+    expect(
+      screen.getByRole("button", {
+        name: "Failed · Retry on studio-mac now",
+      }),
+    ).toBeDefined();
+  });
+
+  it("shows only provider CLIs that need attention", () => {
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    const host = makeHost({ id: "host_1", name: "workstation" });
+    const codexIssue = makeUpdateIssue({ provider: "codex" });
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        machines: [
+          makeMachine({ host, issues: [codexIssue], isPrimary: true }),
+        ],
+      }),
+    );
+
+    renderSection();
+
+    const machineHeading = screen.getByRole("heading", {
+      name: /workstation/,
+    });
+    const machineSection = machineHeading.closest("section");
+    expect(machineSection).not.toBeNull();
+    // Settings chrome: the same caption weight every other settings section
+    // uses, so Updates does not read as a differently-built page.
+    expect(machineHeading.className).toContain("font-semibold");
+    expect(machineHeading.className).toContain("text-foreground");
+    const machineName = screen.getByText("workstation");
+    const thisMachine = screen.getByText("This machine");
+    expect(machineHeading.querySelector('[data-icon="Laptop"]')).not.toBeNull();
+    expect(machineName.nextElementSibling).toBe(thisMachine);
+    // No summary banner above the rows: with work outstanding the rows are
+    // the statement, and with none the settled card is the only thing shown.
+    expect(screen.getByText("bb app")).toBeDefined();
+    expect(screen.queryByLabelText(/available update/)).toBeNull();
+    expect(screen.getAllByText("workstation")).toHaveLength(1);
+    expect(screen.getByText("Codex")).toBeDefined();
+    expect(screen.queryByText("Claude Code")).toBeNull();
+    expect(screen.queryByText(/^Update available/)).toBeNull();
+    expect(screen.queryByText("Choose an update below.")).toBeNull();
+    const providerIcon = document.querySelector('[data-provider-icon="codex"]');
+    expect(providerIcon).not.toBeNull();
+    expect(providerIcon?.querySelector("svg")?.className.baseVal).toContain(
+      "text-muted-foreground",
+    );
+    // Icon-only. The accessible name is the state and the verb — the row
+    // already prints the CLI, its versions, and the machine above it. Row and
+    // bulk actions share the same quiet treatment so neither competes with the
+    // update inventory itself.
+    const updateButton = screen.getAllByRole("button", {
+      name: "Update available · Update Codex on workstation",
+    })[0];
+    expect(updateButton.textContent).toBe("");
+    // Drawn by the shared `ResourceActionButton`, so it carries that atom's
+    // muted treatment rather than a colour this page picked for itself.
+    expect(updateButton.className).toContain("text-muted-foreground");
+    expect(updateButton.className).not.toContain("bg-secondary");
+    expect(updateButton.className).not.toContain("bg-foreground");
+    // Versions sit inline after the name rather than flushed to the right
+    // edge, and only the version you'd move to is recoloured and weighted.
+    const versionMetadata = machineSection
+      ?.querySelector('[data-provider-icon="codex"]')
+      ?.closest("[data-resource-row]")
+      ?.querySelector("[data-version-metadata]");
+    expect(versionMetadata?.className).toContain("text-2xs");
+    expect(versionMetadata?.className).not.toContain("text-right");
+    expect(versionMetadata?.className).not.toContain("ml-auto");
+    // Not `font-mono`: that stack resolves to one face, so the target
+    // version's heavier weight rendered identically to the version you are on.
+    expect(versionMetadata?.className).not.toContain("font-mono");
+    const upgrade = versionMetadata?.querySelector(".text-version-upgrade");
+    expect(upgrade?.textContent).toBe("1.0.1");
+    expect(upgrade?.className).toContain("font-semibold");
+    expect(screen.queryByText("1 up to date")).toBeNull();
+  });
+
+  it("lists Cursor updates with the other provider CLIs", () => {
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    const host = makeHost({ id: "host_1", name: "workstation" });
+    const cursorIssue = makeUpdateIssue({ provider: "cursor" });
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        machines: [makeMachine({ host, issues: [cursorIssue] })],
+      }),
+    );
+
+    renderSection();
+
+    expect(
+      screen.getByRole("button", { name: "Open Cursor settings" }),
+    ).toBeDefined();
+    expect(
+      document.querySelector('[data-provider-icon="acp-cursor"]'),
+    ).not.toBeNull();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Update available · Update Cursor on workstation",
+      }),
+    );
+    expect(startInstallMock).toHaveBeenCalledWith({
+      hostId: "host_1",
+      issue: cursorIssue,
+    });
+  });
+
+  it("names a machine once above all of its CLI updates", () => {
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    const host = makeHost({ id: "host_1", name: "workstation" });
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        machines: [
+          makeMachine({
+            host,
+            issues: [
+              makeUpdateIssue({ provider: "codex" }),
+              makeUpdateIssue({ provider: "claudeCode" }),
+            ],
+          }),
+        ],
+      }),
+    );
+
+    renderSection();
+
+    // The machine heads the group; its rows name only the tool. Repeating the
+    // hostname on every row was the redundancy this grouping removes.
+    expect(screen.getAllByText("workstation")).toHaveLength(1);
+    expect(screen.getByText("Codex")).toBeDefined();
+    expect(screen.getByText("Claude Code")).toBeDefined();
+    // Versions stay per row: the same CLI is routinely a different version on
+    // each host, which is why the rows cannot collapse to one per provider.
+    expect(
+      document
+        .querySelector('[data-updates-machine="host_1"]')
+        ?.querySelectorAll("[data-resource-row] [data-version-metadata]")
+        .length,
+    ).toBe(2);
+    // Each row still drives its own host-scoped install.
+    fireEvent.click(
+      screen.getAllByRole("button", {
+        name: /^Update available · Update/,
+      })[0],
+    );
+    expect(startInstallMock).toHaveBeenCalledTimes(1);
+    expect(startInstallMock.mock.calls[0]?.[0]).toMatchObject({
+      hostId: "host_1",
+    });
+  });
+
+  it("keeps background provider checks out of the compact view", async () => {
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    const host = makeHost({ id: "host_1", name: "workstation" });
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        machines: [makeMachine({ host, statusPending: true })],
+      }),
+    );
+
+    renderSection();
+
+    // Every row states its own condition, and a settled one says when that was
+    // established rather than going blank.
+    await waitFor(() => {
+      expect(screen.getByText(/^Up to date/)).toBeDefined();
+    });
+    expect(screen.queryByText("1 up to date")).toBeNull();
+    expect(screen.getByRole("heading", { name: "workstation" })).toBeDefined();
+    expect(screen.queryByText("Checking provider CLIs…")).toBeNull();
+  });
+
+  it("offers a way out of a failed CLI check", async () => {
+    // The status query is session-static (staleTime Infinity, no refetch on
+    // mount/focus/reconnect), so an errored row used to be permanent for the
+    // life of the page: it named a problem with no affordance to clear it.
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    const host = makeHost({ id: "host_1", name: "workstation" });
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        machines: [makeMachine({ host, statusError: true })],
+      }),
+    );
+
+    renderSection();
+
+    await waitFor(() => {
+      expect(screen.getByText("Couldn't check for updates")).toBeDefined();
+    });
+    const retry = screen.getByRole("button", {
+      name: /Check workstation's CLIs again/,
+    });
+    expect(retry.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("keeps error red on the reason and off the recovery", () => {
+    // One rule for the whole page: red states what is wrong, never what fixes
+    // it. A destructive-tinted Retry reads as a second failure rather than a
+    // way out, and it drifted before because three branches each decided tone
+    // for themselves.
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    const host = makeHost({ id: "host_1", name: "workstation" });
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        machines: [makeMachine({ host, statusError: true })],
+      }),
+    );
+
+    renderSection();
+
+    expect(screen.getByText("Couldn't check for updates").className).toContain(
+      "text-destructive",
+    );
+    expect(
+      screen.getByRole("button", { name: /Check workstation's CLIs again/ })
+        .className,
+    ).not.toContain("text-destructive");
+  });
+
+  it("leaves never-installed CLIs off an update page", () => {
+    // An update page lists things that have an update. A CLI you never
+    // installed has no version to be behind, so it is a first-install decision
+    // and belongs on Providers — it used to sit here permanently with a
+    // Download control and count toward "Update all".
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    const host = makeHost({ id: "host_1", name: "workstation" });
+    const missingCodex = makeUpdateIssue({ provider: "codex" });
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        machines: [
+          makeMachine({
+            host,
+            issues: [
+              {
+                ...missingCodex,
+                status: {
+                  ...missingCodex.status,
+                  installed: false,
+                  currentVersion: null,
+                },
+              },
+              makeUpdateIssue({ provider: "claudeCode" }),
+            ],
+          }),
+        ],
+      }),
+    );
+
+    renderSection();
+
+    expect(screen.getByText("Claude Code")).toBeDefined();
+    expect(screen.queryByText("Codex")).toBeNull();
   });
 
   it("removes running and queued provider jobs from Update all", () => {
@@ -379,9 +994,21 @@ describe("UpdatesSettingsSection", () => {
     renderSection();
 
     expect(screen.queryByRole("button", { name: /Update all/ })).toBeNull();
-    expect(screen.getByText("2 updates in progress")).toBeDefined();
-    expect(screen.getByText("Running…")).toBeDefined();
-    expect(screen.getByText("Queued")).toBeDefined();
+    expect(screen.queryByText("2 updates in progress")).toBeNull();
+    // Running and queued are the same spinner: one is not a state the reader
+    // can act on differently from the other.
+    expect(
+      document.querySelectorAll(
+        '[data-updates-machine="host_1"] [data-resource-row] [data-update-state="in-progress"]',
+      ).length,
+    ).toBe(2);
+    for (const providerId of ["codex", "claude-code"]) {
+      expect(
+        document
+          .querySelector(`[data-provider-icon="${providerId}"] svg`)
+          ?.getAttribute("class"),
+      ).toContain("text-muted-foreground");
+    }
   });
 
   it("keeps a provider update failure and its command log on the row", () => {
@@ -421,8 +1048,14 @@ describe("UpdatesSettingsSection", () => {
     expect(screen.getByRole("alert").textContent).toBe(
       "Command exited with code 1",
     );
-    expect(screen.getByRole("button", { name: "Retry" })).toBeDefined();
-    fireEvent.click(screen.getByRole("button", { name: "View log" }));
+    expect(
+      screen.getByRole("button", {
+        name: "Failed · Retry Claude Code on workstation",
+      }),
+    ).toBeDefined();
+    fireEvent.click(
+      screen.getByRole("button", { name: "View Claude Code update log" }),
+    );
     expect(getProviderCliInstallSnapshot().logDialogState).toEqual(
       logDialogState,
     );
@@ -455,8 +1088,24 @@ describe("UpdatesSettingsSection", () => {
     renderSection();
     expect(screen.getByText("npx bb-app@latest")).toBeDefined();
     expect(screen.getByText("0.0.6")).toBeDefined();
+    // Icon-only row action: the accessible name carries what the label used to.
+    const copyButton = screen.getByRole("button", {
+      name: "Update available · Copy the upgrade command",
+    });
+    expect(copyButton.textContent).toBe("");
+    // Row actions are plain regardless of domain.
+    expect(copyButton.className).not.toContain("bg-secondary");
+    const updateSurface = document.querySelector(
+      '[data-updates-machine="host_primary"]',
+    );
+    // The house settings card, with its rows on the house divider — the same
+    // chrome every other section of Settings is drawn in.
+    expect(updateSurface?.querySelector(".bg-card")).not.toBeNull();
+    expect(updateSurface?.querySelector(".divide-y")).not.toBeNull();
+    expect(screen.queryByText(/^Update available/)).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Check for updates" }));
+    // Opening the page is the check. Nothing to click, and the forced refresh
+    // still bypasses the cached version.
     await waitFor(() => {
       expect(sdk.system.version).toHaveBeenCalledWith({ force: true });
     });
@@ -474,8 +1123,9 @@ describe("UpdatesSettingsSection", () => {
       version: "0.0.5",
     };
     const checkForUpdates = vi.fn().mockResolvedValue(desktopInfo);
+    const installUpdate = vi.fn().mockResolvedValue(undefined);
     useDesktopUpdateInfoMock.mockReturnValue({
-      desktopApi: { checkForUpdates } as unknown as BbDesktopApi,
+      desktopApi: { checkForUpdates, installUpdate } as unknown as BbDesktopApi,
       desktopInfo,
       isDesktop: true,
     });
@@ -489,9 +1139,16 @@ describe("UpdatesSettingsSection", () => {
     );
 
     renderSection();
-    expect(screen.getByRole("button", { name: "Relaunch" })).toBeDefined();
+    const relaunch = screen.getByRole("button", {
+      name: /Relaunch bb to finish updating/,
+    });
+    expect(relaunch.querySelector("img")?.className).toContain("size-3");
+    expect(relaunch.className).toContain("border");
+    fireEvent.click(relaunch);
+    expect(installUpdate).toHaveBeenCalledOnce();
 
-    fireEvent.click(screen.getByRole("button", { name: "Check for updates" }));
+    // On a desktop shell the load-time check goes through the bridge, not the
+    // server's version endpoint.
     await waitFor(() => {
       expect(checkForUpdates).toHaveBeenCalledTimes(1);
     });
@@ -517,7 +1174,7 @@ describe("UpdatesSettingsSection", () => {
 
     renderSection();
 
-    expect(screen.getByText("Available")).toBeDefined();
+    expect(screen.getByText("Update available")).toBeDefined();
     expect(screen.queryByText("Downloading in the background…")).toBeNull();
   });
 
@@ -541,14 +1198,20 @@ describe("UpdatesSettingsSection", () => {
     useUpdateInventoryMock.mockReturnValue(makeInventory({ desktopInfo }));
 
     renderSection();
-    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
-
+    // The page already checked once on load; Retry is a second, explicit run.
     await waitFor(() => {
       expect(checkForUpdates).toHaveBeenCalledTimes(1);
     });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Failed · Retry the download" }),
+    );
+
+    await waitFor(() => {
+      expect(checkForUpdates).toHaveBeenCalledTimes(2);
+    });
   });
 
-  it("runs every actionable provider update across machines from Update all", () => {
+  it("runs every actionable provider update across machines from Update all", async () => {
     useDesktopUpdateInfoMock.mockReturnValue({
       desktopApi: null,
       desktopInfo: null,
@@ -571,8 +1234,19 @@ describe("UpdatesSettingsSection", () => {
 
     renderSection();
     expect(useProviderCliInstallRunnerMock).toHaveBeenCalled();
+    expect(screen.getByRole("heading", { name: "laptop" })).toBeDefined();
+    expect(screen.getByRole("heading", { name: "homelab" })).toBeDefined();
+    // The count stays in the accessible name while the compact visible
+    // treatment uses the established update glyph and a concise tooltip.
+    const updateAll = screen.getByRole("button", {
+      name: "Update all 2 CLI tools",
+    });
+    expect(updateAll.textContent).toBe("");
+    expect(updateAll.querySelector('[data-icon="Download"]')).not.toBeNull();
+    fireEvent.focus(updateAll);
+    expect((await screen.findByRole("tooltip")).textContent).toBe("Update all");
 
-    fireEvent.click(screen.getByRole("button", { name: "Update all (2)" }));
+    fireEvent.click(updateAll);
     expect(startInstallMock).toHaveBeenCalledTimes(2);
     expect(startInstallMock).toHaveBeenNthCalledWith(1, {
       hostId: "host_1",
@@ -602,9 +1276,26 @@ describe("UpdatesSettingsSection", () => {
 
     renderSection();
 
-    expect(screen.getByText("Update manually")).toBeDefined();
-    expect(screen.getByText("1 update needs manual action")).toBeDefined();
+    // Where to do it, not the category: bb has no installer it can drive for
+    // this install, so the next step is a terminal.
+    expect(screen.getAllByText("Update in terminal").length).toBeGreaterThan(0);
+    expect(screen.queryByText("1 update needs manual action")).toBeNull();
     expect(screen.queryByRole("button", { name: "Update" })).toBeNull();
     expect(screen.queryByRole("button", { name: /Update all/ })).toBeNull();
+  });
+
+  it("omits an empty machine container", async () => {
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    useUpdateInventoryMock.mockReturnValue(makeInventory({ machines: [] }));
+
+    renderSection();
+
+    expect(document.querySelector("[data-updates-machine]")).toBeNull();
+    expect(screen.queryByText("No machines yet.")).toBeNull();
+    expect(screen.getByText("No machines available.")).toBeDefined();
   });
 });

--- a/apps/app/src/components/settings/UpdatesSettingsSection.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.tsx
@@ -1,18 +1,38 @@
 import {
   useEffect,
-  useId,
+  useRef,
   useState,
   useSyncExternalStore,
   type ReactNode,
 } from "react";
+import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import type { BbDesktopInfo } from "@bb/desktop-contract";
+import type { ProviderCliKey } from "@bb/host-daemon-contract";
 import type { SystemVersionResponse } from "@bb/server-contract";
+import {
+  RETRY_ACTION_ICON,
+  UPDATE_ACTION_ICON,
+  UPDATE_STATE_PRESENTATION,
+  type UpdateState,
+} from "@bb/domain/update-state";
 import { Button, type ButtonProps } from "@bb/shared-ui/button";
-import { Icon } from "@bb/shared-ui/icon";
+import { Icon, type IconName } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@bb/shared-ui/tooltip";
+import {
+  ResourceActionButton,
+  ResourceListState,
+  ResourceRow,
+} from "@bb/shared-ui/resource-list";
+import {
   hasProviderCliAction,
+  isProviderCliUpdateIssue,
   useProviderCliInstallRunner,
   type ProviderCliActionableIssue,
   type ProviderCliIssue,
@@ -27,9 +47,13 @@ import {
   startAppUpdateCheck,
   subscribeAppUpdateCheck,
 } from "@/components/settings/app-update-check-store";
-import { MachineStatusDot } from "@/components/machines/MachineStatusDot";
-import { SettingsBadge } from "@/components/ui/settings-section";
 import { appToast } from "@/components/ui/app-toast";
+import { BbLogo } from "@/components/ui/bb-logo";
+import {
+  SettingsBadge,
+  SettingsRowList,
+  SettingsSection,
+} from "@/components/ui/settings-section";
 import { invalidateHostProviderCliStatus } from "@/hooks/cache-owners/provider-cli-status-cache-owner";
 import { hydrateSystemVersionCache } from "@/hooks/cache-owners/system-version-cache-owner";
 import { useRetryHostUpdate } from "@/hooks/mutations/host-mutations";
@@ -39,25 +63,36 @@ import {
 } from "@/hooks/useUpdateInventory";
 import { useDesktopUpdateInfo } from "@/hooks/useDesktopUpdateInfo";
 import { copyToClipboardWithToast } from "@/lib/clipboard";
-import { formatHostUpdateStatus } from "@/lib/host-update-status";
-import { formatRelativeTime } from "@/lib/relative-time";
-import { openUrlInExternalBrowser } from "@/lib/url-open-routing";
+import {
+  hostCanRetryUpdate,
+  hostNeedsUpdate,
+  hostUpdateIsStalled,
+} from "@/lib/host-update-status";
+import {
+  getSettingsMachineRoutePath,
+  getSettingsProviderRoutePath,
+} from "@/lib/route-paths";
+import { getProviderIconInfo } from "@/lib/provider-icon";
 import { sdk } from "@/lib/sdk";
 
-const CHANGELOG_URL = "https://github.com/get-bb/bb/blob/main/CHANGELOG.md";
 const EMPTY_PROVIDER_CLI_FAILURES: ReadonlyMap<
   string,
   ProviderCliInstallFailure
 > = new Map();
+/** Stalled machines needed before the page offers a bulk retry. */
+const BULK_RETRY_THRESHOLD = 1;
 
-/**
- * The rows and the machine bands above them share one text edge: names start
- * at `pl-7` (28px), and the status dot sits centred on `left-3.5` (14px) —
- * the same column the child rows' hairline spine runs down. The dot therefore
- * caps the spine instead of pushing the machine name out of alignment.
- */
-const GUTTER_TEXT = "pl-7";
-const GUTTER_MARK = "absolute left-3.5 top-0 flex h-8 w-0 items-center";
+const PROVIDER_CLI_AGENT_PROVIDER_ID = {
+  codex: "codex",
+  claudeCode: "claude-code",
+  cursor: "acp-cursor",
+} as const satisfies Record<ProviderCliKey, string>;
+
+const PROVIDER_CLI_DISPLAY_ORDER = [
+  "codex",
+  "claudeCode",
+  "cursor",
+] as const satisfies readonly ProviderCliKey[];
 
 function updateCheckErrorDescription(error: unknown): string {
   if (error instanceof Error && error.message.length > 0) {
@@ -66,168 +101,437 @@ function updateCheckErrorDescription(error: unknown): string {
   return "The update check did not complete.";
 }
 
-function RowButton({ className, ...props }: ButtonProps) {
+/**
+ * A row action. The icon-only form delegates to the shared
+ * `ResourceActionButton`, which already owns the tooltip, the loading
+ * spinner, and a `disabledReason` that explains a blocked action rather than
+ * only greying it out. Labelled forms stay local — the shared atom is
+ * icon-only by design.
+ */
+export function UpdateActionButton({
+  label,
+  tooltipLabel,
+  icon,
+  visibleLabel,
+  className,
+  variant,
+  loading = false,
+  disabled = false,
+  disabledReason,
+  onClick,
+}: {
+  label: string;
+  /** Short tooltip when the accessible label is a full sentence. */
+  tooltipLabel?: string;
+  icon: IconName;
+  visibleLabel?: string;
+  className?: string;
+  variant?: ButtonProps["variant"];
+  loading?: boolean;
+  disabled?: boolean;
+  disabledReason?: ReactNode;
+  onClick?: () => void;
+}) {
+  if (visibleLabel === undefined) {
+    return (
+      <ResourceActionButton
+        label={label}
+        tooltipLabel={tooltipLabel}
+        icon={icon}
+        loading={loading}
+        disabled={disabled}
+        disabledReason={disabledReason}
+        className={cn(
+          "size-7",
+          variant === "default" &&
+            "bg-primary text-primary-foreground hover:bg-primary/90 hover:text-primary-foreground",
+          className,
+        )}
+        onClick={() => onClick?.()}
+      />
+    );
+  }
+  // Only a quiet button gets the quiet text colour. Applying it regardless
+  // painted `text-subtle-foreground` over a filled variant's own foreground —
+  // mid-grey on near-black, which is unreadable rather than merely quiet.
+  const isQuiet = variant === undefined || variant === "ghost";
   return (
     <Button
       type="button"
-      variant="outline"
+      variant={variant ?? "ghost"}
       size="sm"
-      className={cn("h-6 px-2 text-xs", className)}
-      {...props}
-    />
+      aria-label={label}
+      aria-busy={loading}
+      disabled={disabled}
+      className={cn(
+        "h-7 gap-1.5 px-2.5 font-normal",
+        isQuiet && "text-subtle-foreground hover:text-foreground",
+        className,
+      )}
+      onClick={onClick}
+    >
+      <Icon
+        aria-hidden
+        name={loading ? "Spinner" : icon}
+        className={cn("size-3.5", loading && "animate-spin")}
+      />
+      {visibleLabel}
+    </Button>
   );
 }
 
 export interface UpdatesSectionProps {
-  title: string;
-  /** Right-hand slot: the freshness stamp and any section-wide action. */
+  /** Which machine or supporting domain this block covers. */
+  domain: string;
+  title: ReactNode;
+  /** Right-hand slot for compact identity or contextual actions. */
   action?: ReactNode;
-  /** Quiet line below the card, for the one caveat worth stating. */
-  footnote?: string;
   children: ReactNode;
 }
 
 /**
- * A settings section whose card is flush — rows run edge to edge so their
- * separators and machine bands are full-bleed. Deliberately not
- * `SettingsSection`, whose padded card would inset every row.
+ * One machine or supporting update block, using the same settings chrome as
+ * the rest of Settings.
  */
 export function UpdatesSection({
+  domain,
   title,
   action,
-  footnote,
   children,
 }: UpdatesSectionProps) {
-  const titleId = useId();
-
   return (
-    <section aria-labelledby={titleId} className="space-y-2.5">
-      <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
-        <h2 id={titleId} className="text-sm font-semibold text-foreground">
-          {title}
-        </h2>
-        {action !== undefined ? (
-          <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-1.5">
-            {action}
-          </div>
-        ) : null}
-      </div>
-      <div className="overflow-hidden rounded-lg border border-border bg-card">
+    <div data-updates-domain={domain}>
+      <SettingsSection title={title} action={action}>
         {children}
-      </div>
-      {footnote !== undefined ? (
-        <p className="text-xs text-subtle-foreground">{footnote}</p>
-      ) : null}
-    </section>
-  );
-}
-
-/** Groups rows so the first one drops its top separator. */
-export function UpdatesRowList({ children }: { children: ReactNode }) {
-  return (
-    <div className="[&>*:first-child]:border-t-0 [&>*:first-child>*:first-child]:border-t-0">
-      {children}
+      </SettingsSection>
     </div>
   );
 }
 
-type RowTone = "default" | "attention" | "destructive";
+/** Rows owned by one machine, on the settings card's own divider. */
+export function UpdatesRowList({ children }: { children: ReactNode }) {
+  return <SettingsRowList>{children}</SettingsRowList>;
+}
 
+/**
+ * The grid every line in a card sits on: mark, content, trailing controls.
+ *
+ * One constant rather than one string per caller, because the whole point is
+ * that they agree — `ResourceRow` uses this template internally, so a row, a
+ * caption and bb's own row all end their content column in the same place and
+ * truncate long text at the same point.
+ */
+const ROW_GRID =
+  "grid min-w-0 grid-cols-[1.5rem_minmax(0,1fr)_auto] items-center gap-3";
+
+/**
+ * A row with no destination — bb itself, which has no page of its own to open.
+ * It borrows `ResourceRow`'s grid rather than its behaviour so its mark, name
+ * and action land on the same three columns as the rows that are navigable;
+ * a plain flex row put bb's name half a mark to the left of every CLI's.
+ */
 function UpdatesRow({
-  tone = "default",
-  indent = false,
+  leading,
   children,
+  className,
 }: {
-  tone?: RowTone;
-  indent?: boolean;
+  leading?: ReactNode;
   children: ReactNode;
+  className?: string;
 }) {
   return (
     <div
-      className={cn(
-        "relative flex flex-wrap items-center justify-between gap-x-3 gap-y-1.5 border-t border-border/70 py-2 pr-3 text-sm",
-        indent ? GUTTER_TEXT : "pl-3",
-        tone === "attention" && "bg-surface-attention",
-        tone === "destructive" && "bg-surface-destructive",
-      )}
+      className={cn(ROW_GRID, "py-2.5 text-sm first:pt-0 last:pb-0", className)}
     >
-      {indent ? (
-        <span
-          aria-hidden
-          className="absolute inset-y-0 left-3.5 w-px -translate-x-1/2 bg-border/85"
-        />
-      ) : null}
+      <span className="flex size-6 shrink-0 items-center justify-center">
+        {leading}
+      </span>
       {children}
     </div>
   );
 }
 
 /**
- * Name and version read as one phrase ("Codex 0.146.0") instead of being split
- * across a wide gutter; the right edge belongs to state and actions only.
+ * Versions read as part of the name's own phrase — "Codex 0.145.0 → 0.146.0" —
+ * rather than as a right-aligned column. Sitting in the same line box as the
+ * name is what keeps the baselines shared no matter how long the name is; a
+ * right-flushed column drifted away from the text it described and had to be
+ * re-anchored every time an action's width changed.
+ *
+ * Not `font-mono`. The mono stack resolves to a single face here, so
+ * `font-medium` on the target version rendered at exactly the same weight as
+ * the version you are on — measured identical widths at 400 through 700 — and
+ * the pair lost the contrast that makes it scannable. Mono is still right for
+ * the upgrade *command*, which is text you retype; a version number is prose.
+ *
+ * No current version means nothing is installed here; showing `latest` alone
+ * would read as the version you have, so the row's status label says it.
+ */
+function RowVersions({
+  current,
+  latest,
+}: {
+  current: string | null;
+  latest: string | null;
+}) {
+  if (current === null) {
+    return null;
+  }
+  return (
+    <span
+      data-version-metadata
+      className="min-w-0 shrink text-2xs text-muted-foreground"
+    >
+      {current}
+      {latest !== null && latest !== current ? (
+        <>
+          <span className="px-1">→</span>
+          {/* The only recoloured half of the pair: what you'd move to reads
+              louder than what you're on, so the row is scannable without
+              parsing two version numbers. Semibold, not medium — at 10px a
+              single step buys almost no contrast, and small text needs more
+              weight than body text to hold the same emphasis. */}
+          <span className="font-semibold text-version-upgrade">{latest}</span>
+        </>
+      ) : null}
+    </span>
+  );
+}
+
+/**
+ * The bb app's row. `detail` carries the same weight as a machine row's
+ * provider name: secondary to the thing's identity, ahead of its versions.
  */
 function RowName({
   name,
+  detail,
   current,
   latest,
 }: {
   name: string;
+  detail?: ReactNode;
   current: string | null;
   latest: string | null;
 }) {
   return (
-    <span className="flex min-w-40 flex-1 items-baseline gap-2">
-      <span className="truncate font-medium text-foreground">{name}</span>
-      {/* No current version means nothing is installed here; showing `latest`
-          alone would read as the version you have. The row's label says it. */}
-      {current === null ? null : (
-        <span className="shrink-0 font-mono text-xs text-readback-foreground">
-          {current}
-          {latest !== null && latest !== current ? (
-            <>
-              <span className="px-1 text-subtle-foreground">→</span>
-              <span className="font-semibold text-foreground">{latest}</span>
-            </>
-          ) : null}
-        </span>
-      )}
+    <span className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-1">
+      <span className="truncate text-sm font-medium text-foreground">
+        {name}
+      </span>
+      {detail}
+      <RowVersions current={current} latest={latest} />
     </span>
   );
 }
 
 /**
- * The right-hand slot. A healthy row passes nothing: "Up to date" repeated
- * down a column carried no information, so the settled state is now the
- * absence of a label and only exceptions speak.
+ * A row's condition as one mark, named on hover.
+ *
+ * The bb card reports condition; the Providers card reports decisions. A
+ * condition is the same handful of words on every row — "Up to date", "Offline"
+ * — so spelling it out down a column reads as a wall of repetition that says
+ * nothing about which row differs. A mark says which row differs at a glance.
+ *
+ * The tooltip is the state's name and nothing more. It does not repeat what the
+ * row already prints (the CLI, the versions, the machine), and it never carries
+ * something the reader has to act on — that is a visible caption's job. The
+ * label is always in the accessibility tree, so nothing is hover-only for a
+ * screen reader.
  */
-function RowStatus({
-  tone = "subtle",
-  live = false,
+/**
+ * Red belongs to the statement of what is wrong, and to nothing else.
+ *
+ * A row says its condition exactly once — as words (`RowStateCaption`) or, when
+ * it has no words, as the inert glyph. That one element carries the error tone.
+ * Controls never do: a button is the way out of the problem, not part of it, and
+ * a destructive-red "Retry" reads as a second failure rather than a recovery.
+ *
+ * So there are two red surfaces on this page and no others. Anything that takes
+ * a click stays untinted, whatever state it belongs to.
+ */
+function stateTextClass(state: UpdateState): string {
+  return UPDATE_STATE_PRESENTATION[state].tone === "error"
+    ? "text-destructive"
+    : "text-muted-foreground";
+}
+
+/**
+ * A state's words, placed beside the version rather than beside its control.
+ *
+ * The trailing column is the control spine: one thing per row sits on it. When
+ * a row has both something to say and something to press, the words belong to
+ * the row's identity — left, flush after the version — and the control keeps
+ * the spine to itself.
+ */
+function RowStateCaption({
+  state,
   children,
 }: {
-  tone?: "subtle" | "attention" | "destructive";
-  live?: boolean;
+  state: UpdateState;
   children: ReactNode;
 }) {
   return (
-    <span
-      role={live ? "status" : undefined}
-      aria-live={live ? "polite" : undefined}
-      className={cn(
-        "text-xs",
-        tone === "subtle" && "text-subtle-foreground",
-        tone === "attention" && "text-warning-text",
-        tone === "destructive" && "text-destructive-text",
-      )}
-    >
+    <span className={cn("shrink-0 text-xs", stateTextClass(state))}>
       {children}
     </span>
   );
 }
 
+function RowStateControl({
+  state,
+  actionIcon,
+  actionLabel,
+  actionTooltip,
+  buttonLeading,
+  buttonLabel,
+  loading = false,
+  live = false,
+  onClick,
+}: {
+  state: UpdateState;
+  /**
+   * Overrides the state's glyph when the control does something other than the
+   * state implies — the web bb row copies an upgrade command rather than
+   * fetching anything, and a Download arrow there promises an install that
+   * never happens.
+   */
+  actionIcon?: IconName;
+  /**
+   * What clicking does. This is the accessible name, so it stays specific —
+   * two "Retry" buttons in a fleet are indistinguishable to a screen reader
+   * without the machine in them.
+   */
+  actionLabel?: string;
+  /**
+   * The visible tooltip, when it should be shorter than the accessible name.
+   * A tooltip sits next to the row that already prints the CLI, its versions
+   * and its machine, so repeating them there is noise; a screen reader has no
+   * such context and needs the long form.
+   */
+  actionTooltip?: string;
+  /** Optional decorative mark before a labelled action. */
+  buttonLeading?: ReactNode;
+  /** Renders the control as a labelled button carrying the state's glyph. */
+  buttonLabel?: string;
+  loading?: boolean;
+  live?: boolean;
+  onClick?: () => void;
+}) {
+  const presentation = UPDATE_STATE_PRESENTATION[state];
+  const icon = actionIcon ?? (presentation.icon as IconName | null);
+  // A retryable failure defaults to the shared retry glyph. A caller can
+  // provide a product mark when the action is specifically about that product.
+  const buttonIcon =
+    state === "failed" ? (RETRY_ACTION_ICON as IconName) : null;
+  const spin = loading || presentation.inFlight === true;
+  const srLabel = presentation.label;
+  // A spinner is self-evident on sight, so it gets no tooltip — but it still
+  // needs its words in the accessibility tree, where nothing is self-evident.
+  const explainOnHover = presentation.inFlight !== true;
+
+  // A state with a resolution is ONE labelled control carrying its mark — not
+  // a mark beside a button repeating it.
+  if (onClick !== undefined && buttonLabel !== undefined) {
+    return (
+      <span className="flex min-w-0 items-center gap-1.5">
+        {/* Untinted by rule — see `stateTextClass`. A failure's control wears
+            the reload glyph; everything else is label-only. */}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          aria-label={[srLabel, actionLabel].filter(Boolean).join(" · ")}
+          aria-busy={loading}
+          disabled={loading}
+          className="h-6 shrink-0 gap-1.5 px-2 text-xs"
+          onClick={onClick}
+        >
+          {loading ? (
+            <Icon aria-hidden name="Loading" className="size-3 animate-spin" />
+          ) : buttonLeading !== undefined ? (
+            buttonLeading
+          ) : buttonIcon === null ? null : (
+            <Icon aria-hidden name={buttonIcon} className="size-3" />
+          )}
+          {buttonLabel}
+        </Button>
+      </span>
+    );
+  }
+
+  if (onClick !== undefined && icon !== null) {
+    return (
+      <span className="flex min-w-0 items-center gap-1.5">
+        <UpdateActionButton
+          label={[srLabel, actionLabel].filter(Boolean).join(" · ")}
+          tooltipLabel={actionTooltip ?? actionLabel ?? presentation.label}
+          icon={icon}
+          loading={loading}
+          onClick={onClick}
+        />
+      </span>
+    );
+  }
+
+  // A glyph-less state still holds the spine, so a column of rows keeps one
+  // right edge whether each row ends in an icon or a button.
+  if (icon === null) {
+    return <span className="flex h-7 shrink-0 items-center" />;
+  }
+
+  const mark = (
+    <span
+      role={live ? "status" : undefined}
+      aria-live={live ? "polite" : undefined}
+      data-update-state={state}
+      className="flex size-7 shrink-0 items-center justify-center"
+    >
+      <Icon
+        aria-hidden
+        name={icon}
+        className={cn(
+          "size-4",
+          spin && "animate-spin",
+          presentation.tone === "muted" &&
+            (state === "up-to-date" ? "text-input" : "text-subtle-foreground"),
+          presentation.tone === "error" && "text-destructive",
+        )}
+      />
+      <span className="sr-only">{srLabel}</span>
+    </span>
+  );
+
+  if (!explainOnHover) {
+    return <span className="flex min-w-0 items-center gap-1.5">{mark}</span>;
+  }
+
+  return (
+    <span className="flex min-w-0 items-center gap-1.5">
+      <TooltipProvider delayDuration={250}>
+        <Tooltip>
+          <TooltipTrigger asChild>{mark}</TooltipTrigger>
+          {/* The state and nothing else. Anything a reader has to act on is a
+              visible caption; anything the row already shows is not repeated. */}
+          <TooltipContent>{presentation.label}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </span>
+  );
+}
+
+/**
+ * The trailing column, flush to the card's inner edge. Section bulk actions
+ * land on the same edge, so every control on the page — per-row and
+ * per-section — shares one right spine against the content's left one.
+ */
+
 function RowActions({ children }: { children: ReactNode }) {
   return (
-    <span className="ml-auto flex shrink-0 items-center gap-2">{children}</span>
+    // `gap-1` is `ResourceRow`'s own gap between a row's meta and its action,
+    // so a bb row's status lands on the same spine as every machine row's.
+    <span className="ml-auto flex shrink-0 items-center justify-end gap-1">
+      {children}
+    </span>
   );
 }
 
@@ -237,6 +541,8 @@ export interface BbAppUpdateRowsProps {
   isDesktop: boolean;
   onRelaunchDesktop: (() => void) | null;
   onRetryDesktop: (() => void) | null;
+  /** A check is in flight; the row says so instead of asserting a result. */
+  isChecking?: boolean;
 }
 
 /**
@@ -250,15 +556,44 @@ export function BbAppUpdateRows({
   isDesktop,
   onRelaunchDesktop,
   onRetryDesktop,
+  isChecking = false,
 }: BbAppUpdateRowsProps) {
+  // No "checked 2m ago": opening this page runs the check, so the age of the
+  // claim is always "since you got here" and printing it just gives the reader
+  // a number to evaluate instead of an answer.
+  const settledStatus = isChecking ? (
+    <RowStateControl live state="in-progress" />
+  ) : (
+    <RowStateControl state="up-to-date" />
+  );
+  // Every branch below ends in the same shape — mark, name, status, action
+  // slot — so no branch can quietly drop a column and knock the row out of the
+  // page's spines.
+  // One indicator per row. The state's mark *is* the control where the state
+  // has a resolution, so a row never shows a condition beside a separate
+  // button that means the same thing.
+  const row = (name: ReactNode, indicator: ReactNode, caption?: ReactNode) => (
+    <UpdatesRow
+      leading={
+        <span data-bb-update-role="app" aria-hidden>
+          <BbLogo className="size-4" />
+        </span>
+      }
+    >
+      <span className="flex min-w-0 items-baseline gap-2">
+        {name}
+        {caption}
+      </span>
+      <RowActions>{indicator}</RowActions>
+    </UpdatesRow>
+  );
   if (isDesktop && desktopInfo === null) {
-    return (
-      <UpdatesRow>
-        <RowName name="bb desktop" current={null} latest={null} />
-        <RowActions>
-          <RowStatus live>Checking…</RowStatus>
-        </RowActions>
-      </UpdatesRow>
+    return row(
+      // One bb, however it happens to be packaged. The desktop shell and a
+      // web/npm install are two ways to reach the same thing to update, not
+      // two things, so the row does not rename itself per surface.
+      <RowName name="bb app" current={null} latest={null} />,
+      <RowStateControl live state="in-progress" />,
     );
   }
 
@@ -267,76 +602,66 @@ export function BbAppUpdateRows({
       desktopInfo.pendingVersion ?? desktopInfo.latestVersion;
     const latest = desktopInfo.updateAvailable ? pendingVersion : null;
     const name = (
-      <RowName
-        name="bb desktop"
-        current={desktopInfo.version}
-        latest={latest}
-      />
+      <RowName name="bb app" current={desktopInfo.version} latest={latest} />
     );
 
     if (desktopInfo.updateDownloaded) {
-      return (
-        <UpdatesRow tone="attention">
-          {name}
-          <RowActions>
-            <RowStatus tone="attention">Downloaded</RowStatus>
-            <RowButton onClick={() => onRelaunchDesktop?.()}>
-              Relaunch
-            </RowButton>
-          </RowActions>
-        </UpdatesRow>
+      return row(
+        name,
+        // One control: a small bb mark inside its own outlined labelled button.
+        <RowStateControl
+          state="restart-required"
+          buttonLeading={<BbLogo className="size-3" />}
+          buttonLabel="Relaunch"
+          actionLabel="Relaunch bb to finish updating"
+          onClick={() => onRelaunchDesktop?.()}
+        />,
       );
     }
     if (desktopInfo.downloadState === "downloading") {
-      return (
-        <UpdatesRow tone="attention">
-          {name}
-          <RowActions>
-            <RowStatus live tone="attention">
-              Downloading in the background…
-            </RowStatus>
-          </RowActions>
-        </UpdatesRow>
-      );
+      return row(name, <RowStateControl live state="in-progress" />);
     }
     if (desktopInfo.downloadState === "failed") {
-      return (
-        <UpdatesRow tone="destructive">
-          {name}
-          <RowActions>
-            <RowStatus tone="destructive">Download failed</RowStatus>
-            <RowButton onClick={() => onRetryDesktop?.()}>Retry</RowButton>
-          </RowActions>
-        </UpdatesRow>
+      return row(
+        name,
+        <RowStateControl
+          state="failed"
+          buttonLabel="Retry"
+          actionLabel="Retry the download"
+          onClick={() => onRetryDesktop?.()}
+        />,
+        <RowStateCaption state="failed">Download failed</RowStateCaption>,
       );
     }
     if (desktopInfo.updateAvailable) {
-      return (
-        <UpdatesRow tone="attention">
-          {name}
-          <RowActions>
-            <RowStatus tone="attention">Available</RowStatus>
-          </RowActions>
-        </UpdatesRow>
-      );
+      // The shell downloads on its own; the version pair in the name already
+      // says what is coming, so the mark only says it is in hand.
+      return row(name, <RowStateControl state="update-available" />);
     }
-    return <UpdatesRow>{name}</UpdatesRow>;
+    return row(name, settledStatus);
   }
 
   if (systemVersion === undefined) {
-    return (
-      <UpdatesRow>
-        <RowName name="bb-app" current={null} latest={null} />
-        <RowActions>
-          <RowStatus>Checking…</RowStatus>
-        </RowActions>
-      </UpdatesRow>
+    return row(
+      <RowName name="bb app" current={null} latest={null} />,
+      <RowStateControl state="in-progress" />,
     );
   }
 
   const name = (
     <RowName
-      name="bb-app"
+      name="bb app"
+      detail={
+        systemVersion.updateAvailable ? (
+          // The command is a readback of what the button copies, so it sits in
+          // the same slot a machine row gives its provider name — secondary to
+          // the thing's identity — instead of as a filled block competing with
+          // the version column for the right edge.
+          <span className="hidden truncate font-mono text-2xs text-muted-foreground sm:inline">
+            {systemVersion.upgradeCommand}
+          </span>
+        ) : undefined
+      }
       current={systemVersion.currentVersion}
       latest={
         systemVersion.updateAvailable ? systemVersion.latestVersion : null
@@ -344,44 +669,25 @@ export function BbAppUpdateRows({
     />
   );
 
-  if (systemVersion.isDevelopment) {
-    return (
-      <UpdatesRow>
-        {name}
-        <RowActions>
-          <RowStatus>Development mode</RowStatus>
-        </RowActions>
-      </UpdatesRow>
-    );
-  }
-
   if (systemVersion.updateAvailable) {
-    return (
-      <UpdatesRow tone="attention">
-        {name}
-        <RowActions>
-          <RowStatus tone="attention">Available</RowStatus>
-          {/* The command sits with the button that copies it, rather than
-              crowding the app name on the left. */}
-          <code className="hidden rounded-sm bg-muted/40 px-1.5 py-0.5 font-mono text-xs text-muted-foreground sm:inline">
-            {systemVersion.upgradeCommand}
-          </code>
-          <RowButton
-            onClick={() => {
-              void copyToClipboardWithToast(systemVersion.upgradeCommand, {
-                successMessage: "Upgrade command copied",
-                errorMessage: "Couldn't copy upgrade command",
-              });
-            }}
-          >
-            Copy
-          </RowButton>
-        </RowActions>
-      </UpdatesRow>
+    return row(
+      name,
+      <RowStateControl
+        state="update-available"
+        actionIcon="Copy"
+        actionLabel="Copy the upgrade command"
+        actionTooltip="Copy command"
+        onClick={() => {
+          void copyToClipboardWithToast(systemVersion.upgradeCommand, {
+            successMessage: "Upgrade command copied",
+            errorMessage: "Couldn't copy upgrade command",
+          });
+        }}
+      />,
     );
   }
 
-  return <UpdatesRow>{name}</UpdatesRow>;
+  return row(name, settledStatus);
 }
 
 export interface MachineUpdatesRowsProps {
@@ -389,282 +695,344 @@ export interface MachineUpdatesRowsProps {
   runningJobKey: string | null;
   queuedJobKeys: ReadonlySet<string>;
   failuresByJobKey?: ReadonlyMap<string, ProviderCliInstallFailure>;
-  retryUpdatePending: boolean;
   onStartInstall: (hostId: string, issue: ProviderCliActionableIssue) => void;
-  onRetryDaemonUpdate: (hostId: string) => void;
+  /** Opens that provider's own settings page — the row's real destination. */
+  onOpenProvider: (providerId: string) => void;
 }
 
-interface ProviderRowState {
-  label: string;
-  rowTone: RowTone;
-  statusTone: "subtle" | "attention" | "destructive";
-}
-
-function providerRowState({
-  issue,
-  installed,
-}: {
-  issue: ProviderCliIssue | null;
-  installed: boolean;
-}): ProviderRowState | null {
-  if (!installed) {
-    return { label: "Not installed", rowTone: "default", statusTone: "subtle" };
-  }
-  // Up to date: the version alone says it. No label, no tint.
-  if (issue === null) {
-    return null;
-  }
-  if (issue.action === null) {
-    return {
-      label: "Update manually",
-      rowTone: issue.status.versionUnsupported ? "destructive" : "attention",
-      statusTone: issue.status.versionUnsupported ? "destructive" : "attention",
-    };
-  }
-  if (issue.status.versionUnsupported) {
-    return {
-      label: "Update needed",
-      rowTone: "destructive",
-      statusTone: "destructive",
-    };
-  }
-  return { label: "Available", rowTone: "attention", statusTone: "attention" };
-}
-
-/** The band that heads a machine's rows. */
-function MachineBand({
-  connected,
-  name,
-  headingId,
-  statusLabel,
-  badge,
-  detail,
-  tone = "default",
-  children,
-}: {
-  connected: boolean;
-  name: string;
-  headingId: string;
-  statusLabel: string;
-  badge?: ReactNode;
-  detail?: ReactNode;
-  tone?: "default" | "destructive";
-  children?: ReactNode;
-}) {
+function machineHasRelevantHealthStatus(
+  machine: UpdateInventoryMachine,
+): boolean {
   return (
-    <div
-      className={cn(
-        "relative flex items-center justify-between gap-3 border-t text-sm",
-        GUTTER_TEXT,
-        "pr-3",
-        tone === "destructive"
-          ? "border-surface-destructive-border bg-surface-destructive"
-          : "border-border/70 bg-surface-recessed",
-        children === undefined ? "h-8" : "py-2",
-      )}
-    >
-      <span aria-hidden className={GUTTER_MARK}>
-        <MachineStatusDot
-          connected={connected}
-          className={cn(
-            "-translate-x-1/2",
-            // A stranded daemon is offline *and* broken; the shared hollow
-            // ring alone reads as merely idle.
-            tone === "destructive" && "border-destructive bg-destructive",
-          )}
-        />
-      </span>
-      <span className="flex min-w-0 flex-col">
-        <span className="flex min-w-0 items-center gap-2">
-          <h3
-            id={headingId}
-            className="truncate text-xs font-semibold text-foreground"
-          >
-            {name}
-            <span className="sr-only">, {statusLabel}</span>
-          </h3>
-          {badge}
-        </span>
-        {children}
-      </span>
-      {detail !== undefined ? <span className="shrink-0">{detail}</span> : null}
-    </div>
+    machine.statusError ||
+    machine.canRetryDaemonUpdate ||
+    machine.host.status !== "connected"
   );
 }
 
-/** One machine's rows: a header band, then a row per provider CLI. */
+function visibleProviderUpdateIssues(
+  machine: UpdateInventoryMachine,
+): ProviderCliIssue[] {
+  if (
+    machine.canRetryDaemonUpdate ||
+    machine.host.status !== "connected" ||
+    machine.statusError ||
+    machine.statusPending ||
+    machine.providerStatus === null
+  ) {
+    return [];
+  }
+  return machine.issues.filter(isProviderCliUpdateIssue);
+}
+
+/**
+ * A machine's bb daemon condition. The machine name now owns the section, so
+ * the row names the software that needs attention and uses the same bb mark as
+ * the app row. App-versus-daemon is text, never an unexplained icon swap.
+ */
+export function BbDaemonUpdateRow({
+  machine,
+  now,
+  retryUpdatePending,
+  onRetryDaemonUpdate,
+  onOpenMachine,
+}: {
+  machine: UpdateInventoryMachine;
+  now: number;
+  retryUpdatePending: boolean;
+  onRetryDaemonUpdate: (hostId: string) => void;
+  onOpenMachine: (hostId: string) => void;
+}) {
+  const { host } = machine;
+  const updateStalled =
+    machine.canRetryDaemonUpdate && hostUpdateIsStalled(host, now);
+  const updating = machine.canRetryDaemonUpdate && !updateStalled;
+  // The daemon is ahead of this server, so no amount of retrying on the
+  // machine can fix it — the server is the thing that has to move. Left
+  // unnamed, the row said only "Offline", which is true and useless: it sends
+  // the reader to check a network that is working. The caption says "this app"
+  // rather than "bb" because the opposite direction — a machine whose daemon
+  // is behind — is a different row entirely (it self-updates, with a Retry),
+  // and "Update bb" reads as an instruction to go touch the remote machine.
+  const machineIsAhead = hostNeedsUpdate(host) && !hostCanRetryUpdate(host);
+  const offline = host.status !== "connected";
+
+  // Words beside the name; the trailing column stays the control spine.
+  const daemonCaption = updateStalled ? (
+    <RowStateCaption state="failed">Update didn&apos;t finish</RowStateCaption>
+  ) : machineIsAhead ? (
+    <RowStateCaption state="offline">
+      Update this app to reconnect
+    </RowStateCaption>
+  ) : null;
+
+  return (
+    <ResourceRow
+      className="py-2"
+      actionsVisibility="always"
+      openLabel={`Open ${host.name} settings`}
+      onOpen={() => onOpenMachine(host.id)}
+      leading={
+        <span data-bb-update-role="daemon" aria-hidden>
+          <BbLogo className="size-4" />
+        </span>
+      }
+      title="bb daemon"
+      titleMeta={daemonCaption}
+      trailingMeta={null}
+      actions={
+        // One indicator. `waiting-to-retry` is the only machine state with a
+        // resolution here, so it is the only one drawn as a control; the rest
+        // are conditions and say so on hover.
+        updating ? (
+          <RowStateControl live state="in-progress" />
+        ) : updateStalled ? (
+          <RowStateControl
+            state="failed"
+            buttonLabel="Retry"
+            actionLabel={`Retry on ${host.name} now`}
+            loading={retryUpdatePending}
+            onClick={() => onRetryDaemonUpdate(host.id)}
+          />
+        ) : machineIsAhead ? (
+          // No "needs attention": that names a feeling, not a fix. The row
+          // says what is true (unreachable) and what resolves it (update the
+          // app it is talking to).
+          <RowStateControl state="offline" />
+        ) : offline ? (
+          <RowStateControl state="offline" />
+        ) : null
+      }
+    />
+  );
+}
+
+/** A recoverable provider status failure, kept distinct from bb's daemon. */
+export function ProviderCliCheckRow({
+  machine,
+  onRecheckClis,
+  onOpenMachine,
+}: {
+  machine: UpdateInventoryMachine;
+  onRecheckClis: (hostId: string) => void;
+  onOpenMachine: (hostId: string) => void;
+}) {
+  const { host } = machine;
+  return (
+    <ResourceRow
+      className="py-2"
+      actionsVisibility="always"
+      openLabel={`Open ${host.name} settings`}
+      onOpen={() => onOpenMachine(host.id)}
+      leading={
+        <Icon
+          aria-hidden
+          name="Terminal"
+          className="size-3.5 text-muted-foreground"
+        />
+      }
+      title="Provider CLIs"
+      titleMeta={
+        <RowStateCaption state="failed">
+          Couldn&apos;t check for updates
+        </RowStateCaption>
+      }
+      trailingMeta={null}
+      actions={
+        <RowStateControl
+          state="failed"
+          buttonLabel="Retry"
+          actionLabel={`Check ${host.name}'s CLIs again`}
+          loading={machine.statusFetching}
+          onClick={() => onRecheckClis(host.id)}
+        />
+      }
+    />
+  );
+}
+
+/**
+ * The one update state a CLI row is in.
+ *
+ * Keyed off the same vocabulary the bb rows and `bb updates` use, so a CLI
+ * that reads "update available" in Settings reads "update available" in the
+ * terminal too. A CLI with nothing wrong produces no issue and so no row.
+ *
+ * `not-installed` is absent on purpose: this page filters to update issues, so
+ * a CLI without an installed version never reaches a row here. The state still
+ * exists in the shared vocabulary because `bb updates` prints a full status
+ * table and does report it.
+ */
+function providerRowState({
+  issue,
+}: {
+  issue: ProviderCliIssue | null;
+}): UpdateState | null {
+  if (issue === null) {
+    return "up-to-date";
+  }
+  if (issue.action === null) {
+    return "update-manually";
+  }
+  return "update-available";
+}
+
+/** Provider update rows owned by the surrounding machine section. */
 export function MachineUpdatesRows({
   machine,
   runningJobKey,
   queuedJobKeys,
   failuresByJobKey = EMPTY_PROVIDER_CLI_FAILURES,
-  retryUpdatePending,
   onStartInstall,
-  onRetryDaemonUpdate,
+  onOpenProvider,
 }: MachineUpdatesRowsProps) {
   const { host } = machine;
-  const headingId = useId();
+  const updateIssues = visibleProviderUpdateIssues(machine);
   const issuesByProvider = new Map(
-    machine.issues.map((issue) => [issue.provider, issue]),
+    updateIssues.map((issue) => [issue.provider, issue]),
   );
 
-  /*
-   * A protocol-rejected daemon is disconnected, so this machine has no
-   * provider rows at all — the band has to carry the whole story on its own,
-   * which is why it is the one header allowed to run multi-line. The raw
-   * protocol numbers stay, demoted below the plain-language cause.
-   */
-  if (machine.canRetryDaemonUpdate) {
-    const daemonStatus = formatHostUpdateStatus(host);
-    return (
-      <div role="group" aria-labelledby={headingId}>
-        <MachineBand
-          connected={false}
-          tone="destructive"
-          name={host.name}
-          headingId={headingId}
-          statusLabel="Agent update required"
-          badge={
-            machine.isPrimary ? (
-              <SettingsBadge>this machine</SettingsBadge>
-            ) : null
-          }
-          detail={
-            <RowButton
-              aria-busy={retryUpdatePending}
-              disabled={retryUpdatePending}
-              onClick={() => onRetryDaemonUpdate(host.id)}
-            >
-              {retryUpdatePending ? "Retrying…" : "Retry update"}
-            </RowButton>
-          }
-        >
-          <span className="text-xs text-destructive-text">
-            Can't connect — its bb agent is out of date
-          </span>
-          <span className="text-2xs text-subtle-foreground">
-            Usually it updates itself.
-          </span>
-          {daemonStatus === null ? null : (
-            <span className="text-2xs text-subtle-foreground">
-              {daemonStatus}
-            </span>
-          )}
-        </MachineBand>
-      </div>
-    );
+  if (updateIssues.length === 0) {
+    return null;
   }
 
-  return (
-    <div role="group" aria-labelledby={headingId}>
-      <MachineBand
-        connected={host.status === "connected"}
-        name={host.name}
-        headingId={headingId}
-        statusLabel={host.status === "connected" ? "Connected" : "Offline"}
-        badge={
-          machine.isPrimary ? <SettingsBadge>this machine</SettingsBadge> : null
+  const rows = PROVIDER_CLI_DISPLAY_ORDER.filter((provider) =>
+    issuesByProvider.has(provider),
+  ).map((provider) => {
+    const status = machine.providerStatus?.[provider];
+    if (status === undefined) {
+      return null;
+    }
+    const issue = issuesByProvider.get(provider) ?? null;
+    const state = providerRowState({ issue });
+    const jobKey = providerCliJobKey(host.id, provider);
+    const running = runningJobKey === jobKey;
+    const queued = queuedJobKeys.has(jobKey);
+    const storedFailure = failuresByJobKey.get(jobKey) ?? null;
+    const failure =
+      issue !== null &&
+      storedFailure?.issueFingerprint === issue.fingerprint
+        ? storedFailure
+        : null;
+    const actionable =
+      issue !== null && hasProviderCliAction(issue) && !running && !queued;
+    const providerId = PROVIDER_CLI_AGENT_PROVIDER_ID[provider];
+    const ProviderIcon = getProviderIconInfo(providerId)?.icon;
+    return (
+      <ResourceRow
+        key={provider}
+        className="py-2"
+        actionsVisibility="always"
+        openLabel={`Open ${status.displayName} settings`}
+        onOpen={() => onOpenProvider(providerId)}
+        leading={
+          ProviderIcon === undefined ? null : (
+            <span data-provider-icon={providerId} aria-hidden>
+              <ProviderIcon className="size-3.5 text-muted-foreground" />
+            </span>
+          )
         }
-        detail={
-          host.status === "connected" ? undefined : (
-            <RowStatus>Offline — connect to check for updates</RowStatus>
+        title={status.displayName}
+        titleMeta={
+          <span className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-1">
+            <RowVersions
+              current={status.currentVersion}
+              latest={issue !== null ? status.latestVersion : null}
+            />
+            {failure === null ? null : (
+              <>
+                <RowStateCaption state="failed">Failed</RowStateCaption>
+                <span role="alert" className="text-xs text-destructive">
+                  {failure.logDialogState.message}
+                </span>
+              </>
+            )}
+          </span>
+        }
+        trailingMeta={null}
+        actions={
+          running ? (
+            <RowStateControl live state="in-progress" />
+          ) : queued ? (
+            <RowStateControl live state="in-progress" />
+          ) : failure !== null ? (
+            <span className="flex items-center gap-1">
+              <UpdateActionButton
+                label={`View ${status.displayName} update log`}
+                tooltipLabel="View log"
+                icon="File"
+                onClick={() =>
+                  openProviderCliInstallLog(failure.logDialogState)
+                }
+              />
+              {actionable ? (
+                <RowStateControl
+                  state="failed"
+                  actionLabel={`Retry ${status.displayName} on ${host.name}`}
+                  actionTooltip="Retry"
+                  onClick={() => onStartInstall(host.id, issue)}
+                />
+              ) : null}
+            </span>
+          ) : state === null ? null : (
+            <RowStateControl
+              state={state}
+              actionLabel={
+                actionable
+                  ? `${issue.action.label} ${status.displayName} on ${host.name}`
+                  : undefined
+              }
+              // Just the verb on hover. The row already carries the CLI's
+              // name, its versions, and the machine heading above it.
+              actionTooltip={actionable ? issue.action.label : undefined}
+              onClick={
+                actionable ? () => onStartInstall(host.id, issue) : undefined
+              }
+            />
           )
         }
       />
-      {host.status !== "connected" ? null : machine.statusError ? (
-        <UpdatesRow indent>
-          <RowStatus tone="destructive">
-            Couldn't check provider CLIs on this machine.
-          </RowStatus>
-        </UpdatesRow>
-      ) : machine.statusPending || machine.providerStatus === null ? (
-        <UpdatesRow indent>
-          <RowStatus live>Checking provider CLIs…</RowStatus>
-        </UpdatesRow>
-      ) : (
-        (["codex", "claudeCode"] as const).map((provider) => {
-          const status = machine.providerStatus?.[provider];
-          if (status === undefined) {
-            return null;
-          }
-          const issue = issuesByProvider.get(provider) ?? null;
-          const state = providerRowState({
-            issue,
-            installed: status.installed,
-          });
-          const jobKey = providerCliJobKey(host.id, provider);
-          const running = runningJobKey === jobKey;
-          const queued = queuedJobKeys.has(jobKey);
-          const storedFailure = failuresByJobKey.get(jobKey) ?? null;
-          const failure =
-            issue !== null &&
-            storedFailure?.issueFingerprint === issue.fingerprint
-              ? storedFailure
-              : null;
-          const actionable =
-            issue !== null &&
-            hasProviderCliAction(issue) &&
-            !running &&
-            !queued;
-          return (
-            <UpdatesRow
-              key={provider}
-              indent
-              tone={
-                running || queued
-                  ? "default"
-                  : failure !== null
-                    ? "destructive"
-                    : (state?.rowTone ?? "default")
-              }
-            >
-              <RowName
-                name={status.displayName}
-                current={status.currentVersion}
-                latest={issue !== null ? status.latestVersion : null}
-              />
-              <RowActions>
-                {failure !== null ? (
-                  <RowStatus tone="destructive">Failed</RowStatus>
-                ) : running ? (
-                  <RowStatus live tone="attention">
-                    <span className="inline-flex items-center gap-1.5">
-                      <Icon name="Spinner" className="size-3 animate-spin" />
-                      Running…
-                    </span>
-                  </RowStatus>
-                ) : queued ? (
-                  <RowStatus live>Queued</RowStatus>
-                ) : state === null ? null : (
-                  <RowStatus tone={state.statusTone}>{state.label}</RowStatus>
-                )}
-                {failure !== null ? (
-                  <RowButton
-                    onClick={() =>
-                      openProviderCliInstallLog(failure.logDialogState)
-                    }
-                  >
-                    View log
-                  </RowButton>
-                ) : null}
-                {actionable ? (
-                  <RowButton onClick={() => onStartInstall(host.id, issue)}>
-                    {failure === null ? issue.action.label : "Retry"}
-                  </RowButton>
-                ) : null}
-              </RowActions>
-              {failure !== null ? (
-                <p
-                  role="alert"
-                  className="basis-full text-xs text-destructive-text"
-                >
-                  {failure.logDialogState.message}
-                </p>
-              ) : null}
-            </UpdatesRow>
-          );
-        })
-      )}
+    );
+  });
+
+  return <>{rows}</>;
+}
+
+/** One machine owns one settings section; the badge makes local scope explicit. */
+export function MachineUpdatesSection({
+  machine,
+  action,
+  children,
+}: {
+  machine: UpdateInventoryMachine;
+  action?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div data-updates-machine={machine.host.id}>
+      <UpdatesSection
+        domain="machine"
+        title={
+          <span className="flex min-w-0 items-center gap-2">
+            <Icon
+              name="Laptop"
+              className="size-4 shrink-0 text-muted-foreground"
+              aria-hidden
+            />
+            <span className="truncate">{machine.host.name}</span>
+            {machine.isPrimary ? (
+              <SettingsBadge>This machine</SettingsBadge>
+            ) : null}
+          </span>
+        }
+        action={
+          action === undefined ? undefined : (
+            <div className="pr-4">{action}</div>
+          )
+        }
+      >
+        <UpdatesRowList>{children}</UpdatesRowList>
+      </UpdatesSection>
     </div>
   );
 }
@@ -685,9 +1053,12 @@ function useNow(intervalMs: number): number {
  */
 export function UpdatesSettingsSection() {
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
   const inventory = useUpdateInventory();
   const { desktopApi, desktopInfo, isDesktop } = useDesktopUpdateInfo();
   const retryHostUpdate = useRetryHostUpdate();
+  // The check store outlives this view, so an in-flight check stays visible
+  // across navigation and a failure still toasts even if we unmount.
   const isChecking = useSyncExternalStore(
     subscribeAppUpdateCheck,
     getAppUpdateCheckSnapshot,
@@ -696,43 +1067,28 @@ export function UpdatesSettingsSection() {
   const { failuresByJobKey, queuedJobKeys, runningJobKey, startInstall } =
     useProviderCliInstallRunner();
 
-  const allActionableIssues: {
+  const visibleProviderIssues: {
     hostId: string;
-    issue: ProviderCliActionableIssue;
+    issue: ProviderCliIssue;
   }[] = inventory.machines.flatMap((machine) =>
-    machine.issues
-      .filter(hasProviderCliAction)
-      .map((issue) => ({ hostId: machine.host.id, issue })),
+    visibleProviderUpdateIssues(machine).map((issue) => ({
+      hostId: machine.host.id,
+      issue,
+    })),
   );
-  const actionableIssues = allActionableIssues.filter(({ hostId, issue }) => {
-    const jobKey = providerCliJobKey(hostId, issue.provider);
-    return runningJobKey !== jobKey && !queuedJobKeys.has(jobKey);
-  });
-  const manualIssueCount = inventory.machines.reduce(
-    (count, machine) =>
-      count +
-      machine.issues.filter(
-        (issue) => issue.status.installed && !hasProviderCliAction(issue),
-      ).length,
-    0,
-  );
-
-  const strandedMachines = inventory.machines.filter(
-    (machine) => machine.canRetryDaemonUpdate,
-  ).length;
-  const checkingMachines = inventory.machines.filter(
-    (machine) =>
-      machine.host.status === "connected" &&
-      !machine.statusError &&
-      (machine.statusPending || machine.providerStatus === null),
-  ).length;
-  const uncheckedMachines = inventory.machines.filter(
-    (machine) =>
-      !machine.canRetryDaemonUpdate &&
-      (machine.host.status !== "connected" || machine.statusError),
-  ).length;
-  const activeInstallCount =
-    (runningJobKey === null ? 0 : 1) + queuedJobKeys.size;
+  const actionableIssues = visibleProviderIssues
+    .filter(
+      (
+        entry,
+      ): entry is {
+        hostId: string;
+        issue: ProviderCliActionableIssue;
+      } => hasProviderCliAction(entry.issue),
+    )
+    .filter(({ hostId, issue }) => {
+      const jobKey = providerCliJobKey(hostId, issue.provider);
+      return runningJobKey !== jobKey && !queuedJobKeys.has(jobKey);
+    });
 
   // Snapshot the hosts at click time: the check runs in a module-level store
   // so it survives navigating away, and must not read React state afterwards.
@@ -756,171 +1112,207 @@ export function UpdatesSettingsSection() {
     });
   }
 
-  /*
-   * "Up to date" is only credible next to a time, so the stamp — not the
-   * button — is what the section header leads with; checking is a quiet icon
-   * beside it.
-   */
-  const checkedLabel =
-    inventory.lastCheckedAt === null
-      ? null
-      : `Checked ${formatRelativeTime({ timestamp: inventory.lastCheckedAt, now })}`;
+  // Opening the page is the request to check, so there is no button to press.
+  // This waits for the host list rather than firing on the first render: the
+  // check invalidates each connected machine's CLI status, and on mount that
+  // list is still empty, so an immediate run would refresh the app version and
+  // silently skip every machine.
+  const hostsSettled = !inventory.isLoading;
+  const checkedOnLoad = useRef(false);
+  useEffect(() => {
+    if (checkedOnLoad.current || !hostsSettled) {
+      return;
+    }
+    checkedOnLoad.current = true;
+    handleCheckForUpdates();
+    // Deliberately runs once per mount; `handleCheckForUpdates` closes over the
+    // host snapshot taken at that moment, which is what the check should use.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hostsSettled]);
 
-  const machineSummary =
-    inventory.machines.length === 0
-      ? null
-      : strandedMachines > 0
-        ? `${strandedMachines} ${strandedMachines === 1 ? "machine" : "machines"} can't connect`
-        : uncheckedMachines > 0
-          ? `${uncheckedMachines} ${uncheckedMachines === 1 ? "machine was" : "machines were"} not checked`
-          : checkingMachines > 0
-            ? `Checking ${checkingMachines} ${checkingMachines === 1 ? "machine" : "machines"}…`
-            : activeInstallCount > 0
-              ? `${activeInstallCount} ${activeInstallCount === 1 ? "update" : "updates"} in progress`
-              : manualIssueCount > 0
-                ? `${manualIssueCount} ${manualIssueCount === 1 ? "update needs" : "updates need"} manual action`
-                : actionableIssues.length === 0
-                  ? `${inventory.machines.length} ${inventory.machines.length === 1 ? "machine" : "machines"}, all in sync`
-                  : null;
+  const appUpdateVisible =
+    desktopInfo?.updateAvailable === true ||
+    inventory.systemVersion?.updateAvailable === true ||
+    inventory.appUpdateAvailable;
+  const relevantFleetMachines = inventory.machines.filter(
+    machineHasRelevantHealthStatus,
+  );
+  // A machine whose own bb update has stalled is outstanding update work, not
+  // just fleet trivia: it is the third update domain, and the page would claim
+  // everything is settled while a stalled row sat under it.
+  const stalledMachines = relevantFleetMachines.filter(
+    (machine) =>
+      machine.canRetryDaemonUpdate && hostUpdateIsStalled(machine.host, now),
+  );
+  const appMachine =
+    inventory.machines.find((machine) => machine.isPrimary) ??
+    inventory.machines[0] ??
+    null;
+  const visibleMachines = inventory.machines.filter(
+    (machine) =>
+      machine.host.id === appMachine?.host.id ||
+      machineHasRelevantHealthStatus(machine) ||
+      visibleProviderUpdateIssues(machine).length > 0,
+  );
+  const hasUpdateWork =
+    appUpdateVisible ||
+    visibleProviderIssues.length > 0 ||
+    stalledMachines.length > 0;
+  const fleetIsHealthy = relevantFleetMachines.length === 0;
+  const showFallbackBbStatus =
+    !hasUpdateWork && !fleetIsHealthy && isDesktop && desktopInfo === null;
+
+  function retryDaemonUpdate(hostId: string): void {
+    retryHostUpdate.mutate(hostId, {
+      onSuccess: () => {
+        const machine = inventory.machines.find(
+          (candidate) => candidate.host.id === hostId,
+        );
+        appToast.success(
+          `Retrying the update on ${machine?.host.name ?? "this machine"}`,
+        );
+      },
+    });
+  }
+
+  // One toast for the whole sweep: a per-machine confirmation would stack as
+  // many toasts as there are stalled machines, which is exactly the pile the
+  // consolidated Updates page replaced.
+  function retryAllStalledDaemonUpdates(): void {
+    for (const machine of stalledMachines) {
+      retryHostUpdate.mutate(machine.host.id);
+    }
+    appToast.success(
+      `Retrying the update on ${stalledMachines.length} machines`,
+    );
+  }
+
+  const updateAllButton =
+    actionableIssues.length > 1 ? (
+      <UpdateActionButton
+        label={`Update all ${actionableIssues.length} CLI tools`}
+        tooltipLabel="Update all"
+        icon={UPDATE_ACTION_ICON}
+        variant="default"
+        onClick={() => {
+          for (const { hostId, issue } of actionableIssues) {
+            startInstall({ hostId, issue });
+          }
+        }}
+      />
+    ) : null;
+  const retryAllButton =
+    stalledMachines.length > BULK_RETRY_THRESHOLD ? (
+      <UpdateActionButton
+        label={`Update all ${stalledMachines.length} machines now`}
+        visibleLabel="Retry all"
+        icon="RotateCcw"
+        variant="default"
+        className="font-medium"
+        onClick={retryAllStalledDaemonUpdates}
+      />
+    ) : null;
+  const bulkActions =
+    retryAllButton !== null || updateAllButton !== null ? (
+      <div
+        role="toolbar"
+        aria-label="Bulk update actions"
+        className="flex flex-wrap items-center justify-end gap-2"
+      >
+        {retryAllButton}
+        {updateAllButton}
+      </div>
+    ) : null;
 
   return (
-    <>
-      <UpdatesSection
-        title="bb"
-        footnote="Connected machines follow the server version automatically."
-        action={
-          <>
-            {isChecking || checkedLabel !== null ? (
-              <span
-                role="status"
-                aria-atomic="true"
-                aria-live="polite"
-                className="text-xs text-subtle-foreground"
-              >
-                {isChecking ? "Checking…" : checkedLabel}
-              </span>
-            ) : null}
-            <RowButton
-              variant="ghost"
-              aria-label="Check for updates"
-              aria-busy={isChecking}
-              disabled={isChecking}
-              className="px-1.5 text-muted-foreground hover:text-foreground"
-              onClick={handleCheckForUpdates}
+    <div className="space-y-6">
+      {visibleMachines.length === 0 ? (
+        <ResourceListState state="empty" message="No machines available." />
+      ) : (
+        visibleMachines.map((machine, index) => {
+          const ownsApp = machine.host.id === appMachine?.host.id;
+          const showDaemon =
+            machine.canRetryDaemonUpdate || machine.host.status !== "connected";
+          return (
+            <MachineUpdatesSection
+              key={machine.host.id}
+              machine={machine}
+              action={index === 0 ? bulkActions : null}
             >
-              <Icon
-                aria-hidden
-                name={isChecking ? "Spinner" : "RotateCcw"}
-                className={cn("size-3.5", isChecking && "animate-spin")}
-              />
-            </RowButton>
-            <RowButton
-              variant="ghost"
-              className="text-muted-foreground hover:text-foreground"
-              onClick={() => openUrlInExternalBrowser(CHANGELOG_URL)}
-            >
-              What's new
-            </RowButton>
-          </>
-        }
-      >
-        <UpdatesRowList>
-          <BbAppUpdateRows
-            systemVersion={inventory.systemVersion}
-            desktopInfo={desktopInfo}
-            isDesktop={isDesktop}
-            onRelaunchDesktop={
-              desktopApi === null
-                ? null
-                : () => {
-                    void desktopApi.installUpdate().catch((error: unknown) => {
-                      appToast.error("Relaunch failed", {
-                        description: updateCheckErrorDescription(error),
-                      });
-                    });
+              {ownsApp ? (
+                <BbAppUpdateRows
+                  systemVersion={inventory.systemVersion}
+                  desktopInfo={desktopInfo}
+                  isDesktop={isDesktop}
+                  isChecking={isChecking}
+                  onRelaunchDesktop={
+                    desktopApi === null || showFallbackBbStatus
+                      ? null
+                      : () => {
+                          void desktopApi.installUpdate().catch((error) => {
+                            appToast.error("Relaunch failed", {
+                              description: updateCheckErrorDescription(error),
+                            });
+                          });
+                        }
                   }
-            }
-            onRetryDesktop={
-              desktopApi === null
-                ? null
-                : () => {
-                    void desktopApi
-                      .checkForUpdates()
-                      .catch((error: unknown) => {
-                        appToast.error("Update retry failed", {
-                          description: updateCheckErrorDescription(error),
-                        });
-                      });
+                  onRetryDesktop={
+                    desktopApi === null || showFallbackBbStatus
+                      ? null
+                      : () => {
+                          void desktopApi.checkForUpdates().catch((error) => {
+                            appToast.error("Update retry failed", {
+                              description: updateCheckErrorDescription(error),
+                            });
+                          });
+                        }
                   }
-            }
-          />
-        </UpdatesRowList>
-      </UpdatesSection>
-
-      <UpdatesSection
-        title="Machines"
-        action={
-          machineSummary === null &&
-          actionableIssues.length === 0 ? undefined : (
-            <>
-              {machineSummary === null ? null : (
-                <span
-                  role="status"
-                  aria-live="polite"
-                  className="text-xs text-subtle-foreground"
-                >
-                  {machineSummary}
-                </span>
-              )}
-              {actionableIssues.length > 0 ? (
-                <RowButton
-                  onClick={() => {
-                    for (const { hostId, issue } of actionableIssues) {
-                      startInstall({ hostId, issue });
-                    }
-                  }}
-                >
-                  Update all ({actionableIssues.length})
-                </RowButton>
+                />
               ) : null}
-            </>
-          )
-        }
-      >
-        {inventory.machines.length === 0 ? (
-          <p className="px-3 py-2.5 text-sm text-subtle-foreground">
-            {inventory.isLoading ? "Loading…" : "No machines yet."}
-          </p>
-        ) : (
-          <UpdatesRowList>
-            {inventory.machines.map((machine) => (
+              {showDaemon ? (
+                <BbDaemonUpdateRow
+                  machine={machine}
+                  now={now}
+                  retryUpdatePending={
+                    retryHostUpdate.isPending &&
+                    retryHostUpdate.variables === machine.host.id
+                  }
+                  onRetryDaemonUpdate={retryDaemonUpdate}
+                  onOpenMachine={(hostId) =>
+                    navigate(getSettingsMachineRoutePath(hostId))
+                  }
+                />
+              ) : null}
+              {machine.statusError ? (
+                <ProviderCliCheckRow
+                  machine={machine}
+                  onRecheckClis={(hostId) => {
+                    void invalidateHostProviderCliStatus({
+                      queryClient,
+                      hostId,
+                    });
+                  }}
+                  onOpenMachine={(hostId) =>
+                    navigate(getSettingsMachineRoutePath(hostId))
+                  }
+                />
+              ) : null}
               <MachineUpdatesRows
-                key={machine.host.id}
                 machine={machine}
                 runningJobKey={runningJobKey}
                 queuedJobKeys={queuedJobKeys}
                 failuresByJobKey={failuresByJobKey}
-                retryUpdatePending={
-                  retryHostUpdate.isPending &&
-                  retryHostUpdate.variables === machine.host.id
-                }
                 onStartInstall={(hostId, issue) =>
                   startInstall({ hostId, issue })
                 }
-                onRetryDaemonUpdate={(hostId) =>
-                  retryHostUpdate.mutate(hostId, {
-                    onSuccess: () => {
-                      appToast.success(
-                        `Update retry requested for ${machine.host.name}`,
-                      );
-                    },
-                  })
+                onOpenProvider={(providerId) =>
+                  navigate(getSettingsProviderRoutePath(providerId))
                 }
               />
-            ))}
-          </UpdatesRowList>
-        )}
-      </UpdatesSection>
-    </>
+            </MachineUpdatesSection>
+          );
+        })
+      )}
+    </div>
   );
 }

--- a/apps/app/src/components/sidebar/SidebarUpdatesBadge.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarUpdatesBadge.test.tsx
@@ -102,6 +102,7 @@ function machine(
     isPrimary: true,
     providerStatus: null,
     statusPending: false,
+    statusFetching: false,
     statusError: false,
     issues: [],
     canRetryDaemonUpdate: false,

--- a/apps/app/src/components/tools/ExtensionsDetailStates.stories.tsx
+++ b/apps/app/src/components/tools/ExtensionsDetailStates.stories.tsx
@@ -36,10 +36,10 @@ import {
   PluginProvenancePill,
 } from "@/components/tools/PluginDetail";
 import {
-  BbLogo,
   ProviderLogo,
   SkillProvenanceTooltip,
 } from "@/components/tools/SkillsCollection";
+import { BbLogo } from "@/components/ui/bb-logo";
 import {
   SkillDetailView,
   SkillOwnershipBadge,

--- a/apps/app/src/components/tools/SkillsCollection.tsx
+++ b/apps/app/src/components/tools/SkillsCollection.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import type { SkillProvider, SkillSummary } from "@bb/server-contract";
-import bbLogoUrl from "../../../../../assets/bb-logo.svg";
 import {
   ResourceInfiniteScrollSentinel,
   useResourceInfiniteItems,
@@ -20,6 +19,7 @@ import {
   ResourceToolbar,
 } from "@bb/shared-ui/resource-list";
 import { cn } from "@bb/shared-ui/lib/utils";
+import { BbLogo } from "@/components/ui/bb-logo";
 import {
   ConfirmDeleteDialog,
   ConfirmDeleteDialogContent,
@@ -128,17 +128,6 @@ export function ProviderLogo({
   return (
     <LogoIcon
       className={cn(getProviderIconColorClass(providerId), className)}
-    />
-  );
-}
-
-export function BbLogo({ className = "size-4" }: { className?: string }) {
-  return (
-    <img
-      src={bbLogoUrl}
-      alt=""
-      aria-hidden="true"
-      className={cn(className, "object-contain dark:invert")}
     />
   );
 }

--- a/apps/app/src/components/ui/bb-logo.tsx
+++ b/apps/app/src/components/ui/bb-logo.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@bb/shared-ui/lib/utils";
+import bbLogoUrl from "../../../../../assets/bb-logo.svg";
+
+/**
+ * bb's own mark, for rows where bb is one listed thing among others — beside a
+ * provider's logo in Updates, or beside a provider's skills in the tools list.
+ * Decorative in every one of those places: the row already names it.
+ */
+export function BbLogo({ className = "size-4" }: { className?: string }) {
+  return (
+    <img
+      src={bbLogoUrl}
+      alt=""
+      aria-hidden="true"
+      className={cn(className, "object-contain dark:invert")}
+    />
+  );
+}

--- a/apps/app/src/components/ui/settings-section.tsx
+++ b/apps/app/src/components/ui/settings-section.tsx
@@ -5,7 +5,9 @@ export interface SettingsSectionProps {
   action?: ReactNode;
   children: ReactNode;
   description?: string;
-  title: string;
+  title: ReactNode;
+  /** A compact utility that belongs directly beside the section title. */
+  titleAction?: ReactNode;
 }
 
 export function SettingsSection({
@@ -13,6 +15,7 @@ export function SettingsSection({
   children,
   description,
   title,
+  titleAction,
 }: SettingsSectionProps) {
   return (
     <section className="space-y-3">
@@ -22,8 +25,13 @@ export function SettingsSection({
           description ? "items-start" : "items-center",
         )}
       >
-        <div>
-          <h2 className="text-sm font-semibold text-foreground">{title}</h2>
+        <div className="min-w-0">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <h2 className="min-w-0 text-sm font-semibold text-foreground">
+              {title}
+            </h2>
+            {titleAction ? <div className="shrink-0">{titleAction}</div> : null}
+          </div>
           {description ? (
             <p className="mt-0.5 text-xs leading-snug text-subtle-foreground/75">
               {description}

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -38,6 +38,7 @@
    * settled/closed-turn machinery, and a text-only destructive that clears AA in
    * dark mode (the --destructive fill is below the 4.5:1 text floor there). */
   --color-readback-foreground: var(--readback-foreground);
+  --color-version-upgrade: var(--version-upgrade);
   --color-timeline-accent: var(--timeline-accent);
   --color-file-accent: var(--file-accent);
   --color-accent: var(--accent);
@@ -434,6 +435,11 @@
   --subtle-foreground: oklch(0.5 0 0);
   /* Recede tier between muted (7.77:1) and subtle (6.00:1); ~6.83:1 on white. */
   --readback-foreground: oklch(0.47 0 0);
+  /* The version an update would move you to. Its own role rather than plain
+   * body text so the "this is the one you'd get" emphasis can be tuned without
+   * touching every other foreground, and derived from the anchors so custom
+   * palettes tint it instead of stranding it neutral beside their own text. */
+  --version-upgrade: color-mix(in oklch, var(--ink) 96%, var(--canvas));
   /* Soft "paper blue" timeline accent — the one tint in the otherwise
    * achromatic timeline. ~5.0:1 on white. */
   --timeline-accent: oklch(0.55 0.1 250);
@@ -680,6 +686,8 @@
   --subtle-foreground: oklch(0.68 0 0);
   /* Recede tier between muted (9.14:1) and subtle (6.35:1); ~7.24:1 on canvas. */
   --readback-foreground: oklch(0.715 0 0);
+  /* See the light block: the version an update would move you to. */
+  --version-upgrade: color-mix(in oklch, var(--ink) 96%, var(--canvas));
   /* Soft "paper blue" timeline accent, lifted for the dark canvas (~6:1). */
   --timeline-accent: oklch(0.72 0.09 250);
   --file-accent: var(--timeline-accent);

--- a/apps/app/src/hooks/useUpdateInventory.test.ts
+++ b/apps/app/src/hooks/useUpdateInventory.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ProviderCliStatus,
+  ProviderCliStatusResponse,
+} from "@bb/host-daemon-contract";
+import { buildUpdateInventoryProviderIssues } from "./useUpdateInventory";
+
+function providerStatus(
+  displayName: string,
+  overrides: Partial<ProviderCliStatus> = {},
+): ProviderCliStatus {
+  return {
+    displayName,
+    executableName: displayName.toLowerCase(),
+    executablePath: `/usr/local/bin/${displayName.toLowerCase()}`,
+    installed: true,
+    installSource: "npmGlobal",
+    currentVersion: "1.0.0",
+    latestVersion: "1.0.0",
+    minimumSupportedVersion: null,
+    npmPackageName: null,
+    npmGlobalPackageVersion: null,
+    installAction: null,
+    needsUpdate: false,
+    versionUnsupported: false,
+    ...overrides,
+  };
+}
+
+describe("buildUpdateInventoryProviderIssues", () => {
+  it("includes Cursor updates in the machine inventory", () => {
+    const status: ProviderCliStatusResponse = {
+      codex: providerStatus("Codex"),
+      claudeCode: providerStatus("Claude Code"),
+      cursor: providerStatus("Cursor", {
+        latestVersion: "1.1.0",
+        needsUpdate: true,
+      }),
+    };
+
+    expect(buildUpdateInventoryProviderIssues(status)).toMatchObject([
+      {
+        provider: "cursor",
+        title: "Cursor update available",
+      },
+    ]);
+  });
+});

--- a/apps/app/src/hooks/useUpdateInventory.ts
+++ b/apps/app/src/hooks/useUpdateInventory.ts
@@ -7,7 +7,8 @@ import type { BbDesktopInfo } from "@bb/desktop-contract";
 import {
   buildProviderCliIssue,
   isProviderCliIssue,
-  providerCliEntries,
+  isProviderCliUpdateIssue,
+  providerCliUpdateEntries,
   type ProviderCliIssue,
 } from "@/components/provider-cli/provider-cli-install";
 import { useDesktopUpdateInfo } from "@/hooks/useDesktopUpdateInfo";
@@ -28,6 +29,12 @@ export interface UpdateInventoryMachine {
   providerStatus: ProviderCliStatusResponse | null;
   statusPending: boolean;
   statusError: boolean;
+  /**
+   * A re-check is in flight. Distinct from `statusPending`: a query that has
+   * already errored stays in the error status while it refetches, so the row's
+   * Retry needs this to show it is working.
+   */
+  statusFetching: boolean;
   issues: ProviderCliIssue[];
   /** Daemon stuck on an old protocol version; the server can force a retry. */
   canRetryDaemonUpdate: boolean;
@@ -58,12 +65,21 @@ interface UseUpdateInventoryOptions {
   enabled?: boolean;
 }
 
+/** Build the per-machine provider inventory once at the query boundary. */
+export function buildUpdateInventoryProviderIssues(
+  providerStatus: ProviderCliStatusResponse,
+): ProviderCliIssue[] {
+  return providerCliUpdateEntries(providerStatus)
+    .map(buildProviderCliIssue)
+    .filter(isProviderCliIssue);
+}
+
 /**
  * One consolidated view of every update bb knows about: the bb app itself
  * (npm registry / desktop feed) plus provider CLIs on every connected
  * machine. Remote daemons follow the server version automatically via
- * protocol self-update, so per-machine bb rows only surface when a daemon is
- * stuck and needs a manual retry.
+ * protocol self-update. Per-machine bb rows show that automatic handoff while
+ * it is running, then offer manual recovery only if the update stalls.
  */
 export function useUpdateInventory(
   options?: UseUpdateInventoryOptions,
@@ -109,15 +125,14 @@ export function useUpdateInventory(
     const issues =
       providerStatus === null
         ? []
-        : providerCliEntries(providerStatus)
-            .map(buildProviderCliIssue)
-            .filter(isProviderCliIssue);
+        : buildUpdateInventoryProviderIssues(providerStatus);
     return {
       host,
       isPrimary: host.id === primaryHostId,
       providerStatus,
       statusPending: statusQuery?.isPending ?? false,
       statusError: statusQuery?.isError ?? false,
+      statusFetching: statusQuery?.isFetching ?? false,
       issues,
       canRetryDaemonUpdate: hostCanRetryUpdate(host),
     };
@@ -133,10 +148,15 @@ export function useUpdateInventory(
     !systemVersion.isDevelopment &&
     systemVersion.updateAvailable;
   const desktopUpdateReady = desktopInfo?.updateDownloaded === true;
+  // Counts what Settings → Updates actually lists. A never-installed CLI is an
+  // install prompt, not an update, and inflating this made a fresh single-agent
+  // setup read as permanently behind.
   const actionableCount =
     machines.reduce(
       (count, machine) =>
-        count + machine.issues.length + (machine.canRetryDaemonUpdate ? 1 : 0),
+        count +
+        machine.issues.filter(isProviderCliUpdateIssue).length +
+        (machine.canRetryDaemonUpdate ? 1 : 0),
       0,
     ) +
     (appUpdateAvailable ? 1 : 0) +

--- a/apps/app/src/lib/host-update-status.ts
+++ b/apps/app/src/lib/host-update-status.ts
@@ -1,6 +1,9 @@
 import type { Host } from "@bb/domain";
 import { HOST_DAEMON_PROTOCOL_VERSION } from "@bb/host-daemon-contract/protocol";
 
+/** A normal self-update needs time to download, install, and restart. */
+export const HOST_UPDATE_STALL_THRESHOLD_MS = 2 * 60 * 1000;
+
 export function hostNeedsUpdate(host: Host): boolean {
   return (
     host.status === "disconnected" &&
@@ -14,6 +17,13 @@ export function hostCanRetryUpdate(host: Host): boolean {
     hostNeedsUpdate(host) &&
     host.lastRejectedProtocolVersion !== null &&
     host.lastRejectedProtocolVersion < HOST_DAEMON_PROTOCOL_VERSION
+  );
+}
+
+export function hostUpdateIsStalled(host: Host, now: number): boolean {
+  return (
+    hostCanRetryUpdate(host) &&
+    now - host.updatedAt >= HOST_UPDATE_STALL_THRESHOLD_MS
   );
 }
 

--- a/packages/plugin-build/src/generated/plugin-theme.generated.ts
+++ b/packages/plugin-build/src/generated/plugin-theme.generated.ts
@@ -29,6 +29,7 @@ export const PLUGIN_THEME_CSS = `@theme inline reference {
    * settled/closed-turn machinery, and a text-only destructive that clears AA in
    * dark mode (the --destructive fill is below the 4.5:1 text floor there). */
   --color-readback-foreground: var(--readback-foreground);
+  --color-version-upgrade: var(--version-upgrade);
   --color-timeline-accent: var(--timeline-accent);
   --color-file-accent: var(--file-accent);
   --color-accent: var(--accent);

--- a/packages/shared-ui/src/components/ui/resource/collection.tsx
+++ b/packages/shared-ui/src/components/ui/resource/collection.tsx
@@ -553,7 +553,7 @@ export function ResourceBrowseCard({
       {headerAction ? (
         <span
           data-row-action
-          className="relative col-start-2 row-start-1 flex shrink-0 items-center justify-end whitespace-nowrap"
+          className="relative col-start-2 row-start-1 flex shrink-0 cursor-default items-center justify-end whitespace-nowrap"
         >
           {headerAction}
         </span>

--- a/packages/shared-ui/src/components/ui/resource/row.tsx
+++ b/packages/shared-ui/src/components/ui/resource/row.tsx
@@ -286,7 +286,12 @@ export function ResourceRow({
             <span
               data-row-action
               className={cn(
-                "flex shrink-0 items-center gap-0.5 transition-opacity",
+                // The row is clickable and sets `cursor-pointer` on itself, but
+                // `targetsResourceAction` exempts this slot from that click. An
+                // inert status glyph here would promise a click that goes
+                // nowhere. Real controls inside are buttons or links and
+                // reassert `cursor-pointer` on themselves.
+                "flex shrink-0 cursor-default items-center gap-0.5 transition-opacity",
                 actionsVisibility === "hover" &&
                   "opacity-0 group-hover:opacity-100 focus-within:opacity-100 [@media(hover:none)]:opacity-100",
               )}
@@ -297,7 +302,7 @@ export function ResourceRow({
           {persistentActions ? (
             <span
               data-row-action
-              className="flex shrink-0 items-center gap-0.5"
+              className="flex shrink-0 cursor-default items-center gap-0.5"
             >
               {persistentActions}
             </span>


### PR DESCRIPTION
## Summary

- make machines the top-level grouping on Settings → Updates
- preserve bb app/daemon and provider CLI update actions, failure logs, retries, badges, and filtering
- include Cursor in provider rows and keep every machine row available without an experiment
- add multi-machine, single-machine, and no-updates Ladle coverage in the shared Settings chrome

Depends on the shared update-state vocabulary in the parent layer. The changelog preview now lives in its own child experiment layer.

## Visual evidence

Before:

![Before: provider-first Updates layout](https://raw.githubusercontent.com/get-bb/bb/0fc2e77206c8d8972549868d04736594287ab5d1/evidence/settings-ui-stack/layer2-before-updates.png)

After:

![After: machine-grouped Updates layout](https://raw.githubusercontent.com/get-bb/bb/abc56c12ac0e6a3e59cc48d289526196592a5bd0/evidence/settings-ui-stack/layer2-after-updates.png)

## Verification

- Turbo typecheck: `@bb/app`
- Updates, inventory, and sidebar badge tests: 33 passed
- multi-machine, single-machine, and no-updates Ladle states verified in shared Settings chrome
- diff check passed

BB-Thread-ID: thr_qwah76hjqr

> AGENT GENERATED: by GPT-5.6
