### PR TITLE
Polish machine Settings hierarchy

### DIFF
--- a/apps/app/src/components/dialogs/AddMachineDialog.test.tsx
+++ b/apps/app/src/components/dialogs/AddMachineDialog.test.tsx
@@ -145,10 +145,16 @@ describe("AddMachineDialog", () => {
     expect(command.textContent).toContain("--server https://example.getbb.app");
     expect(command.textContent).toContain("--machine-code mc_test456");
     expect(command.textContent).not.toContain(window.location.origin);
-    expect(screen.getByText(/Code expires in \d+:\d{2}/)).toBeDefined();
+    expect(command.closest("[data-add-machine-command]")).not.toBeNull();
     expect(
-      screen.getByText("Waiting for the machine to connect…"),
+      screen.getByText(
+        /It installs bb and keeps the machine connected to this server/u,
+      ),
     ).toBeDefined();
+    expect(screen.getByText(/Code expires in \d+:\d{2}/)).toBeDefined();
+    const waiting = screen.getByText("Waiting for the machine to connect…");
+    expect(waiting).toBeDefined();
+    expect(waiting.parentElement?.className).not.toContain("border-border");
 
     fireEvent.click(screen.getByRole("button", { name: "Copy" }));
     await waitFor(() => {

--- a/apps/app/src/components/dialogs/AddMachineDialog.tsx
+++ b/apps/app/src/components/dialogs/AddMachineDialog.tsx
@@ -322,10 +322,10 @@ function AddMachineDialogContent({
         <DialogDescription>
           {unreachable !== null
             ? "Pair a machine to run projects and threads on it."
-            : "Run this on the machine you want to add. It pairs the machine to this server and keeps it available for your projects."}
-        </DialogDescription>
-      </DialogHeader>
-      <div className="space-y-4">
+            : "Run this command on the machine you want to add. It installs bb and keeps the machine connected to this server."}
+         </DialogDescription>
+       </DialogHeader>
+       <div className="space-y-3">
         {mintJoinCode.isError || connectUnavailable ? (
           <div className="space-y-2">
             <p className="text-sm text-destructive">
@@ -351,21 +351,14 @@ function AddMachineDialogContent({
             reason={unreachable.reason}
           />
         ) : command !== null ? (
-          <div className="space-y-2">
-            <pre className="overflow-x-auto whitespace-pre-wrap break-all rounded-md border border-border bg-muted/40 p-3 font-mono text-xs text-foreground">
+          <div
+            data-add-machine-command
+            className="overflow-hidden rounded-md border border-border bg-muted/30"
+          >
+            <pre className="overflow-x-auto whitespace-pre-wrap break-all p-3 font-mono text-xs text-foreground">
               {command}
             </pre>
-            <div className="flex items-center gap-2">
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                className="h-7 px-2.5 text-xs"
-                disabled={expired}
-                onClick={() => void copy()}
-              >
-                {copied ? "Copied" : "Copy"}
-              </Button>
+            <div className="flex flex-wrap items-center gap-2 border-t border-border px-3 py-2">
               {expired ? (
                 <>
                   <span className="text-xs text-subtle-foreground">
@@ -387,11 +380,17 @@ function AddMachineDialogContent({
                   Code expires in {formatCountdown(remainingMs)}
                 </span>
               ) : null}
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="ml-auto h-7 px-2.5 text-xs"
+                disabled={expired}
+                onClick={() => void copy()}
+              >
+                {copied ? "Copied" : "Copy"}
+              </Button>
             </div>
-            <p className="text-xs text-subtle-foreground/75">
-              This installs bb, enrolls the daemon, and configures it to
-              reconnect automatically on the other machine.
-            </p>
           </div>
         ) : (
           <p className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -400,7 +399,7 @@ function AddMachineDialogContent({
           </p>
         )}
         {unreachable !== null ? null : (
-          <div className="flex items-center gap-2.5 rounded-md border border-border bg-muted/40 px-3 py-2.5">
+          <div className="flex items-center gap-2.5 rounded-md bg-muted/40 px-3 py-2.5">
             {connectedNewHost !== null ? (
               <>
                 <MachineStatusDot connected />

--- a/apps/app/src/components/settings/MachinesSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/MachinesSettingsSection.test.tsx
@@ -8,6 +8,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import type { Host } from "@bb/domain";
+import { RETRY_ACTION_ICON } from "@bb/domain/update-state";
 import { HOST_DAEMON_PROTOCOL_VERSION } from "@bb/host-daemon-contract";
 import {
   defaultAppSettings,
@@ -171,9 +172,45 @@ describe("MachinesSettingsSection", () => {
     ).toBeDefined();
     // The action lives in the row menu so the rows keep one shape.
     await openHostMenu("dev-vm");
+    const renameItem = await screen.findByRole("menuitem", { name: "Rename" });
+    const retryItem = await screen.findByRole("menuitem", {
+      name: "Retry update",
+    });
+    const removeItem = await screen.findByRole("menuitem", {
+      name: "Remove machine",
+    });
+    const menu = screen.getByRole("menu");
+    expect(menu.className).toContain("w-max");
+    expect(menu.className).toContain("min-w-0");
+    for (const item of [renameItem, retryItem, removeItem]) {
+      expect(item.className).toContain("min-h-9");
+      expect(item.className).toContain("px-2.5");
+      expect(item.className).toContain("py-2");
+    }
+    expect(renameItem.querySelector('[data-icon="Edit"]')).not.toBeNull();
     expect(
-      await screen.findByRole("menuitem", { name: "Retry update" }),
-    ).toBeDefined();
+      retryItem.querySelector(`[data-icon="${RETRY_ACTION_ICON}"]`),
+    ).not.toBeNull();
+    expect(removeItem.querySelector('[data-icon="Trash2"]')).not.toBeNull();
+  });
+
+  it("opens the row menu from the keyboard and focuses its first action", async () => {
+    vi.mocked(sdk.system.config).mockResolvedValue(systemConfig());
+    vi.mocked(sdk.hosts.list).mockResolvedValue([primaryHost, offlineHost]);
+    stubSidebarBootstrapFetch();
+
+    renderSection();
+
+    const trigger = await screen.findByRole("button", {
+      name: "dev-vm actions",
+    });
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "ArrowDown" });
+
+    const renameItem = await screen.findByRole("menuitem", { name: "Rename" });
+    await waitFor(() => {
+      expect(document.activeElement).toBe(renameItem);
+    });
   });
 
   it("requests an immediate daemon update retry", async () => {
@@ -220,9 +257,16 @@ describe("MachinesSettingsSection", () => {
     expect(
       screen.queryByRole("button", { name: /Permission limit for/ }),
     ).toBeNull();
-    expect(
-      screen.getByRole("link", { name: "Open dev-vm" }).getAttribute("href"),
-    ).toBe("/settings/machines/host_remote");
+    const machineLink = screen.getByRole("link", { name: "Open dev-vm" });
+    expect(machineLink.getAttribute("href")).toBe(
+      "/settings/machines/host_remote",
+    );
+    expect(machineLink.parentElement?.className).toContain(
+      "hover:bg-state-hover",
+    );
+    expect(machineLink.parentElement?.className).toContain(
+      "focus-within:bg-state-hover",
+    );
   });
 
   it("renames a machine through the row menu", async () => {
@@ -288,9 +332,20 @@ describe("MachinesSettingsSection", () => {
     await openHostMenu("MacBook Pro");
 
     const removeItem = await screen.findByRole("menuitem", {
-      name: /Remove machine/,
+      name: "Remove machine",
     });
     expect(removeItem.getAttribute("aria-disabled")).toBe("true");
+    expect(removeItem.textContent).toBe("Remove machine");
+    fireEvent.focus(removeItem);
+    expect(
+      await screen.findByRole("tooltip", {
+        name: "This machine runs bb and can't be removed.",
+      }),
+    ).toBeDefined();
+    fireEvent.click(removeItem);
+    expect(
+      screen.queryByRole("heading", { name: "Remove MacBook Pro?" }),
+    ).toBeNull();
     expect(vi.mocked(sdk.hosts.delete)).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/components/settings/MachinesSettingsSection.tsx
+++ b/apps/app/src/components/settings/MachinesSettingsSection.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import type { Host, PermissionMode } from "@bb/domain";
+import { RETRY_ACTION_ICON } from "@bb/domain/update-state";
 import type { HostPlatform } from "@bb/host-daemon-contract";
 import { Button } from "@bb/shared-ui/button";
 import {
@@ -17,6 +18,12 @@ import {
 } from "@bb/shared-ui/dropdown-menu";
 import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@bb/shared-ui/tooltip";
 import { AddMachineDialog } from "@/components/dialogs/AddMachineDialog";
 import { ConfirmDeleteDialog } from "@/components/dialogs/ConfirmDeleteDialog";
 import { appToast } from "@/components/ui/app-toast";
@@ -59,6 +66,8 @@ const MACHINES_SECTION_DESCRIPTION =
 
 const PRIMARY_REMOVE_DISABLED_REASON =
   "This machine runs bb and can't be removed.";
+
+const MACHINE_MENU_ITEM_CLASS = "min-h-9 px-2.5 py-2";
 
 const PLATFORM_LABELS: Record<HostPlatform, string | null> = {
   darwin: "macOS",
@@ -121,8 +130,29 @@ function MachineRow({
   onRetryUpdate,
   retryUpdatePending,
 }: MachineRowProps) {
+  const removeItem = (
+    <DropdownMenuItem
+      variant="destructive"
+      aria-disabled={isPrimary || undefined}
+      className={cn(
+        MACHINE_MENU_ITEM_CLASS,
+        isPrimary && "cursor-not-allowed focus:bg-transparent",
+      )}
+      onSelect={(event) => {
+        if (isPrimary) {
+          event.preventDefault();
+          return;
+        }
+        onRemove();
+      }}
+    >
+      <Icon name="Trash2" aria-hidden />
+      <span className="min-w-0 truncate">Remove machine</span>
+    </DropdownMenuItem>
+  );
+
   return (
-    <SettingsRow className="group relative">
+    <SettingsRow className="group relative -mx-2 rounded-md px-2 transition-colors hover:bg-state-hover focus-within:bg-state-hover">
       {/* Stretched link: the whole row opens the machine page, while the
           controls above it keep their own click targets. */}
       <Link
@@ -148,47 +178,57 @@ function MachineRow({
       </div>
       {/* Read-only here on purpose: the machine page owns the control, but the
           list still has to answer "which machines are capped?" at a glance. */}
-      <span className={cn(MACHINE_LIMIT_COLUMN, "text-sm text-foreground")}>
+      <span
+        aria-label={`Permission limit: ${PERMISSION_MODE_LABELS[host.maxPermissionMode]}`}
+        className={cn(MACHINE_LIMIT_COLUMN, "text-sm text-foreground")}
+      >
         {PERMISSION_MODE_LABELS[host.maxPermissionMode]}
       </span>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="relative -mr-1 h-7 w-7 shrink-0 data-[state=open]:bg-state-active data-[state=open]:text-foreground"
-            aria-label={`${host.name} actions`}
-          >
-            <Icon name="MoreHorizontal" className="size-4" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="end" className="w-52">
-          <DropdownMenuItem onSelect={onRename}>Rename</DropdownMenuItem>
-          {hostCanRetryUpdate(host) ? (
-            <DropdownMenuItem
-              disabled={retryUpdatePending}
-              onSelect={onRetryUpdate}
+      <TooltipProvider delayDuration={250}>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="relative -mr-1 h-7 w-7 shrink-0 data-[state=open]:bg-state-active data-[state=open]:text-foreground"
+              aria-label={`${host.name} actions`}
             >
-              {retryUpdatePending ? "Retrying update…" : "Retry update"}
+              <Icon name="MoreHorizontal" className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-max min-w-0">
+            <DropdownMenuItem
+              className={MACHINE_MENU_ITEM_CLASS}
+              onSelect={onRename}
+            >
+              <Icon name="Edit" aria-hidden />
+              <span className="min-w-0 truncate">Rename</span>
             </DropdownMenuItem>
-          ) : null}
-          <DropdownMenuItem
-            className="text-destructive focus:text-destructive"
-            disabled={isPrimary}
-            title={isPrimary ? PRIMARY_REMOVE_DISABLED_REASON : undefined}
-            onSelect={onRemove}
-          >
-            <span className="min-w-0 flex-1">
-              Remove machine
-              {isPrimary ? (
-                <span className="block text-2xs text-subtle-foreground">
-                  {PRIMARY_REMOVE_DISABLED_REASON}
+            {hostCanRetryUpdate(host) ? (
+              <DropdownMenuItem
+                className={MACHINE_MENU_ITEM_CLASS}
+                disabled={retryUpdatePending}
+                onSelect={onRetryUpdate}
+              >
+                <Icon name={RETRY_ACTION_ICON} aria-hidden />
+                <span className="min-w-0 truncate">
+                  {retryUpdatePending ? "Retrying update…" : "Retry update"}
                 </span>
-              ) : null}
-            </span>
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+              </DropdownMenuItem>
+            ) : null}
+            {isPrimary ? (
+              <Tooltip>
+                <TooltipTrigger asChild>{removeItem}</TooltipTrigger>
+                <TooltipContent side="left">
+                  {PRIMARY_REMOVE_DISABLED_REASON}
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              removeItem
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </TooltipProvider>
     </SettingsRow>
   );
 }
@@ -250,53 +290,43 @@ export function MachinesSettingsSection() {
         ) : hosts.length === 0 ? (
           <p className="text-sm text-subtle-foreground">No machines yet.</p>
         ) : (
-          <>
-            <div className="flex items-center gap-3 border-b border-border pb-2.5 text-2xs uppercase tracking-wide text-subtle-foreground">
-              <span className="size-4 shrink-0" aria-hidden />
-              <span className="min-w-0 flex-1">Machine</span>
-              <span className={MACHINE_LIMIT_COLUMN}>Permission limit</span>
-              <span className="w-6 shrink-0" aria-hidden />
-            </div>
-            <div className="pt-2.5">
-              <SettingsRowList>
-                {hosts.map((host) => (
-                  <MachineRow
-                    key={host.id}
-                    host={host}
-                    isPrimary={host.id === primaryHostId}
-                    platformLabel={
-                      host.id === primaryHostId && primaryHostPlatform !== null
-                        ? PLATFORM_LABELS[primaryHostPlatform]
-                        : null
-                    }
-                    projectCount={projectCountByHostId.get(host.id) ?? 0}
-                    now={now}
-                    onRename={() => {
-                      renameHost.reset();
-                      setRenameTarget(host);
-                    }}
-                    onRemove={() => {
-                      removeHost.reset();
-                      setRemoveTarget(host);
-                    }}
-                    onRetryUpdate={() =>
-                      retryHostUpdate.mutate(host.id, {
-                        onSuccess: () => {
-                          appToast.success(
-                            `Update retry requested for ${host.name}`,
-                          );
-                        },
-                      })
-                    }
-                    retryUpdatePending={
-                      retryHostUpdate.isPending &&
-                      retryHostUpdate.variables === host.id
-                    }
-                  />
-                ))}
-              </SettingsRowList>
-            </div>
-          </>
+          <SettingsRowList>
+            {hosts.map((host) => (
+              <MachineRow
+                key={host.id}
+                host={host}
+                isPrimary={host.id === primaryHostId}
+                platformLabel={
+                  host.id === primaryHostId && primaryHostPlatform !== null
+                    ? PLATFORM_LABELS[primaryHostPlatform]
+                    : null
+                }
+                projectCount={projectCountByHostId.get(host.id) ?? 0}
+                now={now}
+                onRename={() => {
+                  renameHost.reset();
+                  setRenameTarget(host);
+                }}
+                onRemove={() => {
+                  removeHost.reset();
+                  setRemoveTarget(host);
+                }}
+                onRetryUpdate={() =>
+                  retryHostUpdate.mutate(host.id, {
+                    onSuccess: () => {
+                      appToast.success(
+                        `Update retry requested for ${host.name}`,
+                      );
+                    },
+                  })
+                }
+                retryUpdatePending={
+                  retryHostUpdate.isPending &&
+                  retryHostUpdate.variables === host.id
+                }
+              />
+            ))}
+          </SettingsRowList>
         )}
       </SettingsSection>
 

--- a/apps/app/src/lib/relative-time.test.ts
+++ b/apps/app/src/lib/relative-time.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatRelativeTime } from "./relative-time";
+import { formatCompactDuration, formatRelativeTime } from "./relative-time";
 
 const NOW = 1_700_000_000_000;
 const MINUTE = 60 * 1000;
@@ -53,5 +53,22 @@ describe("formatRelativeTime", () => {
         day: "numeric",
       }),
     );
+  });
+});
+
+describe("formatCompactDuration", () => {
+  it("floors a sub-minute span to a minute rather than to zero", () => {
+    // A status that renders "0m" reads as "no time has passed", which is the
+    // opposite of what a row saying it is still waiting means.
+    expect(formatCompactDuration({ ms: 0 })).toBe("1m");
+    expect(formatCompactDuration({ ms: 45 * 1000 })).toBe("1m");
+  });
+
+  it("steps up a unit at each boundary", () => {
+    expect(formatCompactDuration({ ms: 3 * MINUTE })).toBe("3m");
+    expect(formatCompactDuration({ ms: 59 * MINUTE })).toBe("59m");
+    expect(formatCompactDuration({ ms: HOUR })).toBe("1h");
+    expect(formatCompactDuration({ ms: 23 * HOUR })).toBe("23h");
+    expect(formatCompactDuration({ ms: DAY })).toBe("1d");
   });
 });

--- a/apps/app/src/lib/relative-time.ts
+++ b/apps/app/src/lib/relative-time.ts
@@ -16,7 +16,10 @@ const WEEK_MS = 7 * DAY_MS;
  * date once the gap exceeds a few weeks. Future timestamps collapse to
  * "just now" so a small clock skew never renders a negative duration.
  */
-export function formatRelativeTime({ timestamp, now }: FormatRelativeTimeArgs): string {
+export function formatRelativeTime({
+  timestamp,
+  now,
+}: FormatRelativeTimeArgs): string {
   const diffMs = now - timestamp;
   if (diffMs < MINUTE_MS) {
     return "just now";
@@ -41,4 +44,20 @@ export function formatRelativeTime({ timestamp, now }: FormatRelativeTimeArgs): 
     month: "short",
     day: "numeric",
   });
+}
+
+/**
+ * Formats an elapsed span as a compact duration ("1m", "12m", "3h", "2d") for
+ * a label that says how long something has been going on rather than when it
+ * started. Anything under a minute rounds up to "1m": a status that has to be
+ * read is not helped by watching seconds tick.
+ */
+export function formatCompactDuration({ ms }: { ms: number }): string {
+  if (ms < HOUR_MS) {
+    return `${Math.max(1, Math.floor(ms / MINUTE_MS))}m`;
+  }
+  if (ms < DAY_MS) {
+    return `${Math.floor(ms / HOUR_MS)}h`;
+  }
+  return `${Math.floor(ms / DAY_MS)}d`;
 }

--- a/apps/app/src/views/MachineSettingsView.test.tsx
+++ b/apps/app/src/views/MachineSettingsView.test.tsx
@@ -14,6 +14,11 @@ import {
   defaultExperiments,
 } from "@bb/domain";
 import type { SystemConfigResponse } from "@bb/server-contract";
+import type {
+  ProviderCliKey,
+  ProviderCliStatus,
+  ProviderCliStatusResponse,
+} from "@bb/host-daemon-contract";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { sdk } from "@/lib/sdk";
@@ -74,6 +79,39 @@ function systemConfig(): SystemConfigResponse {
   };
 }
 
+function providerCliStatus(
+  provider: ProviderCliKey,
+  currentVersion: string,
+): ProviderCliStatus {
+  const identity = {
+    codex: { displayName: "Codex", executableName: "codex" },
+    claudeCode: { displayName: "Claude Code", executableName: "claude" },
+    cursor: { displayName: "Cursor", executableName: "agent" },
+  }[provider];
+  return {
+    ...identity,
+    executablePath: `/usr/local/bin/${identity.executableName}`,
+    installed: true,
+    installSource: "npmGlobal",
+    currentVersion,
+    latestVersion: currentVersion,
+    minimumSupportedVersion: null,
+    npmPackageName: null,
+    npmGlobalPackageVersion: null,
+    installAction: null,
+    needsUpdate: false,
+    versionUnsupported: false,
+  };
+}
+
+function providerCliStatusResponse(): ProviderCliStatusResponse {
+  return {
+    codex: providerCliStatus("codex", "0.148.0"),
+    claudeCode: providerCliStatus("claudeCode", "2.1.235"),
+    cursor: providerCliStatus("cursor", "1.4.6"),
+  };
+}
+
 function renderView() {
   const { wrapper } = createQueryClientTestHarness();
   return render(
@@ -91,6 +129,9 @@ function renderView() {
 
 /** Everything except the hosts list; the view also reads projects and versions. */
 function stubSupportingFetches(): void {
+  vi.mocked(sdk.hosts.providerCliStatus).mockResolvedValue(
+    providerCliStatusResponse(),
+  );
   vi.stubGlobal(
     "fetch",
     vi.fn().mockResolvedValue(
@@ -119,7 +160,7 @@ describe("MachineSettingsView", () => {
     renderView();
 
     expect(
-      await screen.findByRole("heading", { name: "dev-vm" }),
+      await screen.findByRole("heading", { name: /dev-vm/u }),
     ).toBeDefined();
     const checkedByMode = Object.fromEntries(
       (await screen.findAllByRole("radio")).map((option) => [
@@ -136,8 +177,57 @@ describe("MachineSettingsView", () => {
       auto: "true",
       full: "false",
     });
+    for (const option of await screen.findAllByRole("radio")) {
+      expect(option.querySelector("[data-icon]")).toBeNull();
+    }
+    expect(screen.getByRole("img", { name: "Online" })).toBeDefined();
+    expect(document.querySelector('[data-icon="FolderGit"]')).not.toBeNull();
+    expect(
+      document.querySelector('[data-provider-icon="codex"]'),
+    ).not.toBeNull();
+    expect(
+      document.querySelector('[data-provider-icon="claude-code"]'),
+    ).not.toBeNull();
+    expect(
+      document.querySelector('[data-provider-icon="acp-cursor"]'),
+    ).not.toBeNull();
+    expect(
+      screen
+        .getByRole("heading", { name: "Provider CLIs" })
+        .querySelector("[data-icon]"),
+    ).toBeNull();
     // The page exists so the modes can explain themselves.
     expect(screen.getByText(/No sandbox and no approvals/u)).toBeDefined();
+  });
+
+  it("keeps Rename in the machine title menu", async () => {
+    vi.mocked(sdk.system.config).mockResolvedValue(systemConfig());
+    vi.mocked(sdk.hosts.list).mockResolvedValue([host()]);
+    stubSupportingFetches();
+
+    renderView();
+
+    fireEvent.pointerDown(
+      await screen.findByRole("button", { name: "dev-vm actions" }),
+      { button: 0 },
+    );
+    expect(
+      await screen.findByRole("menuitem", { name: "Rename" }),
+    ).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Rename" })).toBeNull();
+  });
+
+  it("names an offline machine's status icon", async () => {
+    vi.mocked(sdk.system.config).mockResolvedValue(systemConfig());
+    vi.mocked(sdk.hosts.list).mockResolvedValue([
+      host({ status: "disconnected", lastSeenAt: Date.now() - 60_000 }),
+    ]);
+    stubSupportingFetches();
+
+    renderView();
+
+    expect(await screen.findByRole("img", { name: "Offline" })).toBeDefined();
+    expect(screen.queryByText(/^Offline ·/u)).toBeNull();
   });
 
   it("writes the selected limit to the owner-only route", async () => {
@@ -193,7 +283,9 @@ describe("MachineSettingsView", () => {
       name: "Remove machine",
     });
     expect(remove.hasAttribute("disabled")).toBe(true);
-    expect(screen.getByText("this machine")).toBeDefined();
+    expect(remove.className).toContain("bg-destructive");
+    expect(remove.parentElement?.className).not.toContain("justify-end");
+    expect(screen.getAllByText("This machine")).toHaveLength(1);
   });
 
   it("explains a machine that is no longer paired", async () => {

--- a/apps/app/src/views/MachineSettingsView.tsx
+++ b/apps/app/src/views/MachineSettingsView.tsx
@@ -5,17 +5,30 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 // so those icons never flash blank waiting for an on-demand load.
 import "@bb/shared-ui/icon-extended";
 import type { Host, PermissionMode } from "@bb/domain";
-import type { HostPlatform } from "@bb/host-daemon-contract";
+import { UPDATE_ACTION_ICON } from "@bb/domain/update-state";
+import {
+  providerCliKeyValues,
+  type HostPlatform,
+  type ProviderCliKey,
+} from "@bb/host-daemon-contract";
 import { Button } from "@bb/shared-ui/button";
 import { DialogFooter, DialogHeader, DialogTitle } from "@bb/shared-ui/dialog";
 import { DialogDescription } from "@bb/shared-ui/dialog";
-import { Icon } from "@bb/shared-ui/icon";
+import { Icon, type IconName } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
+import { ResourceOverflowMenu } from "@bb/shared-ui/resource-list";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@bb/shared-ui/tooltip";
 import { ConfirmDeleteDialog } from "@/components/dialogs/ConfirmDeleteDialog";
-import { MachineStatusDot } from "@/components/machines/MachineStatusDot";
 import { PageShell } from "@/components/ui/page-shell.js";
 import {
   SettingsBadge,
+  SettingsRow,
+  SettingsRowList,
   SettingsSection,
 } from "@/components/ui/settings-section";
 import { appToast } from "@/components/ui/app-toast";
@@ -29,14 +42,20 @@ import {
 import { selectPrimaryHost, useHosts } from "@/hooks/queries/host-queries";
 import { useSidebarNavigation } from "@/hooks/queries/sidebar-navigation-query";
 import { useSystemConfig } from "@/hooks/queries/system-queries";
+import { isProviderCliUpdateIssue } from "@/components/provider-cli/provider-cli-install";
 import { useUpdateInventory } from "@/hooks/useUpdateInventory";
 import {
   formatHostUpdateStatus,
   hostCanRetryUpdate,
 } from "@/lib/host-update-status";
 import { getMutationErrorMessage } from "@/lib/mutation-errors";
+import { PersistentHostIconName } from "@/lib/host-display";
 import { PERMISSION_MODE_OPTIONS } from "@/lib/permission-mode-options";
 import { formatRelativeTime } from "@/lib/relative-time";
+import {
+  getProviderIconColorClass,
+  getProviderIconInfo,
+} from "@/lib/provider-icon";
 import {
   getProjectSettingsRoutePath,
   getSettingsRoutePath,
@@ -55,6 +74,12 @@ const PLATFORM_LABELS: Record<HostPlatform, string | null> = {
   unknown: null,
 };
 
+const PROVIDER_CLI_AGENT_PROVIDER_ID = {
+  codex: "codex",
+  claudeCode: "claude-code",
+  cursor: "acp-cursor",
+} as const satisfies Record<ProviderCliKey, string>;
+
 interface MachineProject {
   id: string;
   name: string;
@@ -70,14 +95,10 @@ function headerMeta({
   now: number;
 }): string {
   const parts: string[] = [];
-  if (host.status === "connected") {
-    parts.push("Online");
-  } else if (host.lastSeenAt !== null) {
+  if (host.status !== "connected" && host.lastSeenAt !== null) {
     parts.push(
-      `Offline · last seen ${formatRelativeTime({ timestamp: host.lastSeenAt, now })}`,
+      `last seen ${formatRelativeTime({ timestamp: host.lastSeenAt, now })}`,
     );
-  } else {
-    parts.push("Offline");
   }
   if (platformLabel !== null) parts.push(platformLabel);
   parts.push(
@@ -86,83 +107,117 @@ function headerMeta({
   return parts.join(" · ");
 }
 
+function MachineStatusIcon({ connected }: { connected: boolean }) {
+  const label = connected ? "Online" : "Offline";
+  return (
+    <TooltipProvider delayDuration={250}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            role="img"
+            aria-label={label}
+            className={cn(
+              "inline-flex size-5 shrink-0 items-center justify-center",
+              connected ? "text-success" : "text-muted-foreground",
+            )}
+          >
+            <Icon
+              aria-hidden
+              name={connected ? "CircleCheck" : "CircleX"}
+              className="size-4"
+            />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>{label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
 interface PermissionLimitCardProps {
   disabled: boolean;
   onSelect: (permissionMode: PermissionMode) => void;
   value: PermissionMode;
 }
 
-/**
- * Radio cards rather than a picker: this page has room for each mode's
- * description, which is the whole reason the limit lives here.
- */
+/** The page has room to explain each mode, so keep the choices visible. */
 function PermissionLimitCards({
   disabled,
   onSelect,
   value,
 }: PermissionLimitCardProps) {
   return (
-    <div className="space-y-2" role="radiogroup" aria-label="Permission limit">
-      {PERMISSION_MODE_OPTIONS.map((option) => {
-        const selected = option.value === value;
-        return (
-          <button
-            key={option.value}
-            type="button"
-            role="radio"
-            aria-checked={selected}
-            disabled={disabled}
-            onClick={() => {
-              if (!selected) onSelect(option.value);
-            }}
-            className={cn(
-              "flex w-full items-start gap-2.5 rounded-lg border px-3.5 py-3 text-left transition-colors",
-              selected
-                ? "border-foreground/40 bg-state-hover"
-                : "border-border hover:bg-state-hover",
-              disabled && "opacity-70",
-            )}
-          >
-            <span
-              className={cn(
-                "mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border",
-                selected ? "border-foreground" : "border-input",
-              )}
-            >
-              {selected ? (
-                <span className="size-2 rounded-full bg-foreground" />
-              ) : null}
-            </span>
-            <span className="min-w-0 flex-1">
-              <span className="block text-sm text-foreground">
-                {option.label}
-              </span>
-              {option.description ? (
-                <span className="mt-0.5 block text-xs leading-snug text-subtle-foreground/85">
-                  {option.description}
+    <div role="radiogroup" aria-label="Permission limit">
+      <SettingsRowList>
+        {PERMISSION_MODE_OPTIONS.map((option) => {
+          const selected = option.value === value;
+          return (
+            <SettingsRow key={option.value} className="items-start">
+              <button
+                type="button"
+                role="radio"
+                aria-checked={selected}
+                disabled={disabled}
+                onClick={() => {
+                  if (!selected) onSelect(option.value);
+                }}
+                className={cn(
+                  "flex w-full items-start gap-3 rounded-md text-left outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  disabled && "opacity-70",
+                )}
+              >
+                <span
+                  className={cn(
+                    "mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border",
+                    selected ? "border-foreground" : "border-input",
+                  )}
+                >
+                  {selected ? (
+                    <span className="size-2 rounded-full bg-foreground" />
+                  ) : null}
                 </span>
-              ) : null}
-            </span>
-          </button>
-        );
-      })}
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm text-foreground">
+                    {option.label}
+                  </span>
+                  {option.description ? (
+                    <span className="mt-0.5 block text-xs leading-snug text-subtle-foreground/75">
+                      {option.description}
+                    </span>
+                  ) : null}
+                </span>
+              </button>
+            </SettingsRow>
+          );
+        })}
+      </SettingsRowList>
     </div>
   );
 }
 
 interface DetailRowProps {
   label: string;
+  icon?: IconName;
   children: ReactNode;
 }
 
-function DetailRow({ label, children }: DetailRowProps) {
+function DetailRow({ label, icon, children }: DetailRowProps) {
   return (
-    <div className="flex items-center justify-between gap-4 py-2.5 text-sm first:pt-0 last:pb-0">
-      <span className="text-foreground">{label}</span>
-      <div className="flex min-w-0 items-center gap-2 text-right text-subtle-foreground">
+    <SettingsRow className="items-start sm:items-center">
+      <span className="flex min-w-0 items-center gap-2 text-foreground">
+        {icon ? (
+          <Icon
+            aria-hidden
+            name={icon}
+            className="size-4 shrink-0 text-muted-foreground"
+          />
+        ) : null}
+        <span>{label}</span>
+      </span>
+      <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-2 text-right text-subtle-foreground">
         {children}
       </div>
-    </div>
+    </SettingsRow>
   );
 }
 
@@ -199,17 +254,27 @@ export function MachineSettingsView() {
   const machine = updateInventory.machines.find(
     (candidate) => candidate.host.id === hostId,
   );
-  const providerSummary = useMemo(() => {
+  // This links to Settings → Updates, so it must count what that page lists —
+  // updates, not install prompts — or it sends the reader to a page that has
+  // nothing matching the number they just clicked.
+  const updateIssueCount = (machine?.issues ?? []).filter(
+    isProviderCliUpdateIssue,
+  ).length;
+  const installedProviders = useMemo(() => {
     const status = machine?.providerStatus;
-    if (!status) return null;
-    return Object.values(status)
-      .filter((entry) => entry.installed)
-      .map((entry) =>
-        entry.currentVersion
-          ? `${entry.displayName} ${entry.currentVersion}`
-          : entry.displayName,
-      )
-      .join(" · ");
+    if (!status) return [];
+    return providerCliKeyValues.flatMap((provider) => {
+      const entry = status[provider];
+      if (!entry.installed) return [];
+      const providerId = PROVIDER_CLI_AGENT_PROVIDER_ID[provider];
+      return [
+        {
+          ...entry,
+          providerId,
+          ProviderIcon: getProviderIconInfo(providerId)?.icon,
+        },
+      ];
+    });
   }, [machine?.providerStatus]);
 
   const now = Date.now();
@@ -260,31 +325,43 @@ export function MachineSettingsView() {
             <Icon name="ChevronLeft" className="size-3.5" />
             Machines
           </Link>
-          <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0">
-              <div className="flex min-w-0 items-center gap-2">
-                <MachineStatusDot connected={host.status === "connected"} />
-                <h1 className="min-w-0 truncate text-xl font-semibold text-foreground">
-                  {host.name}
-                </h1>
-                {isPrimary ? <SettingsBadge>this machine</SettingsBadge> : null}
-              </div>
-              <p className="mt-1 text-xs text-subtle-foreground/75">
-                {headerMeta({ host, platformLabel, now })}
-              </p>
-            </div>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                renameHost.reset();
-                setRenameOpen(true);
-              }}
-            >
-              Rename
-            </Button>
-          </div>
+          <SettingsSection
+            title={
+              <span className="flex min-w-0 items-center gap-2">
+                <Icon
+                  name={PersistentHostIconName}
+                  className="size-4 shrink-0 text-muted-foreground"
+                  aria-hidden
+                />
+                <span className="truncate">{host.name}</span>
+                {isPrimary ? <SettingsBadge>This machine</SettingsBadge> : null}
+              </span>
+            }
+            titleAction={
+              <ResourceOverflowMenu
+                label={`${host.name} actions`}
+                items={[
+                  {
+                    label: "Rename",
+                    icon: "Edit",
+                    onSelect: () => {
+                      renameHost.reset();
+                      setRenameOpen(true);
+                    },
+                  },
+                ]}
+              />
+            }
+          >
+            <SettingsRowList>
+              <SettingsRow>
+                <MachineStatusIcon connected={host.status === "connected"} />
+                <p className="min-w-0 text-xs text-subtle-foreground/75">
+                  {headerMeta({ host, platformLabel, now })}
+                </p>
+              </SettingsRow>
+            </SettingsRowList>
+          </SettingsSection>
         </div>
 
         <SettingsSection
@@ -312,9 +389,62 @@ export function MachineSettingsView() {
           />
         </SettingsSection>
 
-        <SettingsSection title="This machine">
-          <div className="divide-y divide-border">
-            <DetailRow label="Projects">
+        <SettingsSection title="Provider CLIs">
+          <SettingsRowList>
+            <DetailRow label="Installed">
+              {host.status !== "connected" ? (
+                <span>Unavailable while offline</span>
+              ) : machine?.statusPending ? (
+                <span>Checking…</span>
+              ) : machine?.statusError ? (
+                <span>Status unavailable</span>
+              ) : (
+                <>
+                  {installedProviders.length > 0 ? (
+                    <span className="flex min-w-0 flex-wrap items-center justify-end gap-x-3 gap-y-1">
+                      {installedProviders.map((entry) => (
+                        <span
+                          key={entry.providerId}
+                          className="inline-flex min-w-0 items-center gap-1.5"
+                        >
+                          {entry.ProviderIcon ? (
+                            <span
+                              data-provider-icon={entry.providerId}
+                              aria-hidden
+                              className={getProviderIconColorClass(
+                                entry.providerId,
+                              )}
+                            >
+                              <entry.ProviderIcon className="size-3.5" />
+                            </span>
+                          ) : null}
+                          <span>{entry.displayName}</span>
+                          {entry.currentVersion ? (
+                            <span>{entry.currentVersion}</span>
+                          ) : null}
+                        </span>
+                      ))}
+                    </span>
+                  ) : (
+                    <span>None installed</span>
+                  )}
+                  {updateIssueCount > 0 ? (
+                    <Link
+                      to={getSettingsRoutePath("updates")}
+                      className="shrink-0 text-warning-text hover:text-foreground"
+                    >
+                      {updateIssueCount} to fix
+                    </Link>
+                  ) : null}
+                </>
+              )}
+            </DetailRow>
+          </SettingsRowList>
+        </SettingsSection>
+
+        <SettingsSection title="Machine information">
+          <SettingsRowList>
+            <DetailRow label="Projects" icon="FolderGit">
               {projects.length === 0 ? (
                 <span>None</span>
               ) : (
@@ -333,32 +463,7 @@ export function MachineSettingsView() {
                 </span>
               )}
             </DetailRow>
-            <DetailRow label="Provider CLIs">
-              {host.status !== "connected" ? (
-                <span>Unavailable while offline</span>
-              ) : machine?.statusPending ? (
-                <span>Checking…</span>
-              ) : machine?.statusError ? (
-                <span>Status unavailable</span>
-              ) : (
-                <>
-                  <span className="min-w-0 truncate">
-                    {providerSummary && providerSummary.length > 0
-                      ? providerSummary
-                      : "None installed"}
-                  </span>
-                  {machine && machine.issues.length > 0 ? (
-                    <Link
-                      to={getSettingsRoutePath("updates")}
-                      className="shrink-0 text-warning-text hover:text-foreground"
-                    >
-                      {machine.issues.length} to fix
-                    </Link>
-                  ) : null}
-                </>
-              )}
-            </DetailRow>
-            <DetailRow label="Updates">
+            <DetailRow label="Updates" icon={UPDATE_ACTION_ICON}>
               <span>{updateStatus ?? "Up to date"}</span>
               {hostCanRetryUpdate(host) ? (
                 <Button
@@ -381,7 +486,7 @@ export function MachineSettingsView() {
                 </Button>
               ) : null}
             </DetailRow>
-          </div>
+          </SettingsRowList>
         </SettingsSection>
 
         <SettingsSection
@@ -392,19 +497,22 @@ export function MachineSettingsView() {
               : `Revokes ${host.name}'s access to this server. Project checkouts stay on its disk.`
           }
         >
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={isPrimary}
-            className="text-destructive-text hover:text-destructive-text"
-            onClick={() => {
-              removeHost.reset();
-              setRemoveOpen(true);
-            }}
-          >
-            Remove machine
-          </Button>
+          <SettingsRowList>
+            <SettingsRow>
+              <Button
+                type="button"
+                variant="destructive"
+                size="sm"
+                disabled={isPrimary}
+                onClick={() => {
+                  removeHost.reset();
+                  setRemoveOpen(true);
+                }}
+              >
+                Remove machine
+              </Button>
+            </SettingsRow>
+          </SettingsRowList>
         </SettingsSection>
       </div>
 


### PR DESCRIPTION
## Summary

- align Machines list and detail hierarchy with the updated Settings surfaces
- simplify Add Machine while preserving enrollment behavior
- add navigable row treatment, accessible machine/permission status, provider logos, and a content-sized action menu
- keep Rename and Remove behavior intact, with the primary-machine removal reason moved to a tooltip

Depends on the Settings chrome and shared atoms introduced by the parent Updates layer.

## Visual evidence

Machines list before:

![Before: Machines list](https://raw.githubusercontent.com/get-bb/bb/0fc2e77206c8d8972549868d04736594287ab5d1/evidence/settings-ui-stack/layer3-before-machines-list.png)

Machines list after:

![After: Machines list](https://raw.githubusercontent.com/get-bb/bb/0fc2e77206c8d8972549868d04736594287ab5d1/evidence/settings-ui-stack/layer3-after-machines-list.png)

Machine detail before:

![Before: Machine detail](https://raw.githubusercontent.com/get-bb/bb/0fc2e77206c8d8972549868d04736594287ab5d1/evidence/settings-ui-stack/layer3-before-machine-detail.png)

Machine detail after:

![After: Machine detail](https://raw.githubusercontent.com/get-bb/bb/0fc2e77206c8d8972549868d04736594287ab5d1/evidence/settings-ui-stack/layer3-after-machine-detail.png)

## Verification

- Turbo typecheck: `@bb/app`
- Add Machine, Machines list/detail, and relative-time tests: 25 passed
- real dev app checked at 390×844, 768×900, 1440×900, and 3440×1440

BB-Thread-ID: thr_qwah76hjqr

> AGENT GENERATED: by GPT-5.6
