### PR TITLE
Add navigable full-page Settings story

### DIFF
--- a/apps/app/.ladle/settings-story-fixtures.tsx
+++ b/apps/app/.ladle/settings-story-fixtures.tsx
@@ -1,0 +1,237 @@
+import { useState, type ReactNode } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
+import {
+  PERSONAL_PROJECT_ID,
+  defaultAppSettings,
+  defaultAppTheme,
+  defaultExperiments,
+} from "@bb/domain";
+import { UPDATE_ACTION_ICON } from "@bb/domain/update-state";
+import type {
+  SidebarBootstrapResponse,
+  SystemConfigResponse,
+  SystemVersionResponse,
+} from "@bb/server-contract";
+import type { ProviderCliStatusResponse } from "@bb/host-daemon-contract";
+import {
+  hostProviderCliStatusQueryKey,
+  hostsQueryKey,
+  pluginListQueryKey,
+  pluginMarketplacesQueryKey,
+  systemConfigQueryKey,
+  systemVersionQueryKey,
+} from "../src/hooks/queries/query-keys";
+import { sidebarNavigationQueryKey } from "../src/hooks/queries/sidebar-navigation-query";
+import {
+  buildUpdateInventoryProviderIssues,
+  type UpdateInventoryMachine,
+} from "../src/hooks/useUpdateInventory";
+import { createAppQueryClient } from "../src/lib/query-client";
+import {
+  BbAppUpdateRows,
+  MachineUpdatesRows,
+  MachineUpdatesSection,
+  UpdateActionButton,
+} from "../src/components/settings/UpdatesSettingsSection";
+import {
+  HOST_IDS,
+  HOST_NAMES,
+  PROJECT_IDS,
+  STORY_PROJECT_SOURCES,
+  makeHost,
+  makeProject,
+  makeProviderCliStatus,
+} from "./story-fixtures";
+
+const SETTINGS_STORY_NOW = Date.parse("2026-08-19T08:00:00.000Z");
+
+export const SETTINGS_STORY_PRIMARY_HOST = makeHost({
+  createdAt: SETTINGS_STORY_NOW - 45 * 24 * 60 * 60_000,
+  lastSeenAt: SETTINGS_STORY_NOW,
+});
+
+export const SETTINGS_STORY_HOSTS = [
+  SETTINGS_STORY_PRIMARY_HOST,
+  makeHost({
+    id: HOST_IDS.remote,
+    name: HOST_NAMES.remote,
+    maxPermissionMode: "auto",
+    createdAt: SETTINGS_STORY_NOW - 18 * 24 * 60 * 60_000,
+    lastSeenAt: SETTINGS_STORY_NOW - 3 * 60_000,
+  }),
+];
+
+const localProviderStatus = {
+  codex: makeProviderCliStatus("codex", {
+    currentVersion: "0.145.0",
+    latestVersion: "0.146.0",
+    needsUpdate: true,
+    installAction: {
+      kind: "update",
+      label: "Update",
+      commandKind: "exec",
+      command: "codex update",
+    },
+  }),
+  claudeCode: makeProviderCliStatus("claudeCode", {
+    currentVersion: "2.1.0",
+    latestVersion: "2.1.0",
+  }),
+  cursor: makeProviderCliStatus("cursor", {
+    currentVersion: "0.49.0",
+    latestVersion: "0.49.0",
+  }),
+} satisfies ProviderCliStatusResponse;
+
+const remoteProviderStatus = {
+  codex: makeProviderCliStatus("codex", {
+    currentVersion: "0.146.0",
+    latestVersion: "0.146.0",
+  }),
+  claudeCode: makeProviderCliStatus("claudeCode", {
+    currentVersion: "2.1.0",
+    latestVersion: "2.1.0",
+  }),
+  cursor: makeProviderCliStatus("cursor", {
+    installed: false,
+    executablePath: null,
+    currentVersion: null,
+    latestVersion: "0.49.0",
+    installSource: undefined,
+  }),
+} satisfies ProviderCliStatusResponse;
+
+const project = makeProject({
+  id: PROJECT_IDS.bb,
+  sources: [...STORY_PROJECT_SOURCES],
+});
+const personalProject = makeProject({
+  id: PERSONAL_PROJECT_ID,
+  kind: "personal",
+  name: "Personal",
+  sources: [],
+});
+
+const sidebarNavigation = {
+  sections: [],
+  projects: [{ ...project, defaultExecutionOptions: null, threads: [] }],
+  personalProject: {
+    ...personalProject,
+    defaultExecutionOptions: null,
+    threads: [],
+  },
+} satisfies SidebarBootstrapResponse;
+
+const systemConfig = {
+  generalSettings: defaultAppSettings,
+  keybindings: [],
+  defaultKeybindings: [],
+  keybindingOverrides: [],
+  experiments: defaultExperiments,
+  appearance: defaultAppTheme,
+  customThemes: [],
+  pluginThemes: [],
+  featureFlags: { placeholder: false, timelineWindowEventBudget: 1_500 },
+  hostDaemonPort: null,
+  serverUrl: "http://localhost:38886",
+  primaryHostId: HOST_IDS.local,
+  primaryHostPlatform: "darwin",
+  voiceTranscriptionEnabled: true,
+  dataDir: "/Users/michael/.bb",
+} satisfies SystemConfigResponse;
+
+const systemVersion = {
+  currentVersion: "0.39.0",
+  latestVersion: "0.39.0",
+  source: "npm",
+  updateAvailable: false,
+  isDevelopment: false,
+  upgradeCommand: "npx bb-app@latest",
+} satisfies SystemVersionResponse;
+
+const settingsUpdateMachine = {
+  host: SETTINGS_STORY_PRIMARY_HOST,
+  isPrimary: true,
+  providerStatus: localProviderStatus,
+  statusPending: false,
+  statusError: false,
+  statusFetching: false,
+  issues: buildUpdateInventoryProviderIssues(localProviderStatus),
+  canRetryDaemonUpdate: false,
+} satisfies UpdateInventoryMachine;
+
+const noJobs: ReadonlySet<string> = new Set();
+const noop = () => {};
+
+/** The representative, side-effect-free Updates route inside the Settings story. */
+export function SettingsUpdatesStory() {
+  return (
+    <div className="space-y-6">
+      <MachineUpdatesSection
+        machine={settingsUpdateMachine}
+        action={
+          <div role="toolbar" aria-label="Bulk update actions">
+            <UpdateActionButton
+              label="Update all 1 CLI tool"
+              tooltipLabel="Update all"
+              icon={UPDATE_ACTION_ICON}
+              onClick={noop}
+            />
+          </div>
+        }
+      >
+        <BbAppUpdateRows
+          systemVersion={systemVersion}
+          desktopInfo={null}
+          isDesktop={false}
+          onRelaunchDesktop={null}
+          onRetryDesktop={null}
+        />
+        <MachineUpdatesRows
+          machine={settingsUpdateMachine}
+          runningJobKey={null}
+          queuedJobKeys={noJobs}
+          onStartInstall={noop}
+          onOpenProvider={noop}
+        />
+      </MachineUpdatesSection>
+    </div>
+  );
+}
+
+function createSettingsStoryQueryClient() {
+  const queryClient = createAppQueryClient({
+    showMutationErrorToasts: false,
+    defaultOptions: {
+      mutations: { retry: false },
+      queries: {
+        gcTime: Infinity,
+        retry: false,
+        staleTime: Infinity,
+      },
+    },
+  });
+  queryClient.setQueryData(hostsQueryKey(), SETTINGS_STORY_HOSTS);
+  queryClient.setQueryData(systemConfigQueryKey(), systemConfig);
+  queryClient.setQueryData(systemVersionQueryKey(), systemVersion);
+  queryClient.setQueryData(sidebarNavigationQueryKey(), sidebarNavigation);
+  queryClient.setQueryData(pluginMarketplacesQueryKey(), []);
+  queryClient.setQueryData(
+    hostProviderCliStatusQueryKey(HOST_IDS.local),
+    localProviderStatus,
+  );
+  queryClient.setQueryData(
+    hostProviderCliStatusQueryKey(HOST_IDS.remote),
+    remoteProviderStatus,
+  );
+  queryClient.setQueryData(pluginListQueryKey(true), { plugins: [] });
+  return queryClient;
+}
+
+/** Deterministic production-query fixtures shared by every Settings route. */
+export function SettingsStoryFixtures({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(createSettingsStoryQueryClient);
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/apps/app/.ladle/vite.config.ts
+++ b/apps/app/.ladle/vite.config.ts
@@ -51,6 +51,8 @@ export default defineConfig({
   // mutations as the app. Proxy them to this checkout's isolated dev server
   // instead of reconstructing server state with Ladle-only fixtures.
   server: {
+    // bb Connect shares use authenticated `<machine>--<port>.getbb.app` hosts.
+    allowedHosts: [".getbb.app"],
     proxy: {
       "/api": {
         target: devInstance.serverUrl,

--- a/apps/app/src/components/settings/UsageLimitsSettingsSection.stories.tsx
+++ b/apps/app/src/components/settings/UsageLimitsSettingsSection.stories.tsx
@@ -7,7 +7,7 @@ import {
 } from "./UsageLimitsSettingsSection";
 
 export default {
-  title: "settings/Settings Page",
+  title: "settings/Usage Limits",
 };
 
 type Usage = UsageLimitsSettingsSectionContentProps["usage"];

--- a/apps/app/src/views/SettingsView.stories.test.tsx
+++ b/apps/app/src/views/SettingsView.stories.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { TooltipProvider } from "@bb/shared-ui/tooltip";
+import {
+  SettingsStoryChrome,
+  useSettingsStoryRoute,
+} from "../../.ladle/story-settings-chrome";
+
+function NavigableSettingsStory() {
+  const route = useSettingsStoryRoute();
+  const label =
+    route.kind === "machine"
+      ? route.id
+      : route.kind === "provider"
+        ? route.id === "codex"
+          ? "Codex"
+          : "Claude Code"
+        : route.id;
+
+  return (
+    <SettingsStoryChrome>
+      <h2>{label}</h2>
+    </SettingsStoryChrome>
+  );
+}
+
+afterEach(cleanup);
+
+describe("settings/Settings/Full Page story chrome", () => {
+  it("navigates between Settings sections and provider pages", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <TooltipProvider>
+          <NavigableSettingsStory />
+        </TooltipProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("heading", { name: "general" })).toBeDefined();
+    expect(
+      screen
+        .getByRole("link", { name: "General" })
+        .getAttribute("aria-current"),
+    ).toBe("page");
+
+    fireEvent.click(screen.getByRole("link", { name: "Appearance" }));
+    expect(screen.getByRole("heading", { name: "appearance" })).toBeDefined();
+    expect(
+      screen
+        .getByRole("link", { name: "Appearance" })
+        .getAttribute("aria-current"),
+    ).toBe("page");
+
+    fireEvent.click(screen.getByRole("link", { name: /Codex/ }));
+    expect(screen.getByRole("heading", { name: "Codex" })).toBeDefined();
+    expect(
+      screen.getByRole("link", { name: /Codex/ }).getAttribute("aria-current"),
+    ).toBe("page");
+    expect(
+      screen
+        .getByRole("link", { name: "Appearance" })
+        .getAttribute("aria-current"),
+    ).toBeNull();
+  });
+
+  it("keeps Machines selected on a machine detail route", () => {
+    render(
+      <MemoryRouter initialEntries={["/settings/machines/host_local"]}>
+        <TooltipProvider>
+          <NavigableSettingsStory />
+        </TooltipProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("heading", { name: "host_local" })).toBeDefined();
+    expect(
+      screen
+        .getByRole("link", { name: "Machines" })
+        .getAttribute("aria-current"),
+    ).toBe("page");
+  });
+});

--- a/apps/app/src/views/SettingsView.stories.tsx
+++ b/apps/app/src/views/SettingsView.stories.tsx
@@ -1,4 +1,5 @@
-import { useState, type ReactNode } from "react";
+import { useEffect, useState } from "react";
+import { Route, Routes, useNavigate } from "react-router-dom";
 import {
   defaultAppTheme,
   defaultExperiments,
@@ -13,21 +14,38 @@ import type {
 } from "@bb/host-daemon-contract";
 import { UsageLimitsSettingsSectionContent } from "@/components/settings/UsageLimitsSettingsSection";
 import { VoiceInputSettingsSectionContent } from "@/components/settings/VoiceInputSettingsSection";
-import { PageShell } from "@/components/ui/page-shell";
+import { ArchivedThreadsSettingsSection } from "@/components/settings/ArchivedThreadsSettingsSection";
+import { CommunitySettingsSection } from "@/components/settings/CommunitySettingsSection";
+import { KeyboardSettingsSection } from "@/components/settings/KeyboardSettingsSection";
+import { MarketplacesSettingsSection } from "@/components/settings/MarketplacesSettingsSection";
+import { MachinesSettingsSection } from "@/components/settings/MachinesSettingsSection";
+import type { SettingsProviderId } from "@/components/settings/settings-nav";
+import {
+  SettingsStoryChrome,
+  type SettingsStoryRoute,
+  useSettingsStoryRoute,
+} from "../../.ladle/story-settings-chrome";
+import {
+  SettingsStoryFixtures,
+  SettingsUpdatesStory,
+} from "../../.ladle/settings-story-fixtures";
 import type { ThemePreference } from "@/hooks/useTheme";
 import type { AudioInputDeviceOption } from "@/hooks/useAudioInputDevices";
 import type { PreferredAudioInputDeviceId } from "@/lib/audio-input-device-preference";
+import { SETTINGS_MACHINE_ROUTE_PATH } from "@/lib/route-paths";
 import {
   AppearanceSettingsSection,
   DebugSettingsSection,
   ExperimentsSettingsSection,
   GeneralSettingsSection,
   LocalOpenTargetSettingsSection,
+  ProviderSettingsSection,
   type LocalOpenTargetSettingsSectionProps,
 } from "./SettingsView";
+import { MachineSettingsView } from "./MachineSettingsView";
 
 export default {
-  title: "settings/Settings Page",
+  title: "settings/Settings",
 };
 
 type StoredTargetId = LocalOpenTargetSettingsSectionProps["directoryTargetId"];
@@ -386,72 +404,93 @@ function UsageLimitsStory() {
   );
 }
 
-function SettingsStoryFrame({
-  children,
-  useShell = false,
+function ProviderSettingsStory({
+  providerId,
 }: {
-  children: ReactNode;
-  useShell?: boolean;
+  providerId: SettingsProviderId;
 }) {
-  if (useShell) {
+  const [memoryEnabled, setMemoryEnabled] = useState(true);
+  const [subagentsDisabled, setSubagentsDisabled] = useState(false);
+  const [workflowsDisabled, setWorkflowsDisabled] = useState(false);
+
+  return (
+    <ProviderSettingsSection
+      providerId={providerId}
+      memoryEnabled={memoryEnabled}
+      subagentsDisabled={subagentsDisabled}
+      workflowsDisabled={workflowsDisabled}
+      disabled={false}
+      onMemoryEnabledChange={setMemoryEnabled}
+      onSubagentsDisabledChange={setSubagentsDisabled}
+      onWorkflowsDisabledChange={setWorkflowsDisabled}
+    />
+  );
+}
+
+function SettingsStoryContent({ route }: { route: SettingsStoryRoute }) {
+  if (route.kind === "machine") {
     return (
-      <div className="h-[1120px] bg-background p-4 md:p-5">
-        <PageShell contentClassName="pt-4 md:pt-5">
-          <div className="mx-auto w-full max-w-3xl space-y-6">{children}</div>
-        </PageShell>
-      </div>
+      <Routes>
+        <Route
+          path={SETTINGS_MACHINE_ROUTE_PATH}
+          element={<MachineSettingsView />}
+        />
+      </Routes>
     );
   }
+  if (route.kind === "provider") {
+    return <ProviderSettingsStory providerId={route.id} />;
+  }
 
-  return (
-    <div className="bg-background p-4 md:p-6">
-      <div className="mx-auto w-full max-w-3xl space-y-6">{children}</div>
-    </div>
-  );
+  switch (route.id) {
+    case "appearance":
+      return <AppearanceSettingsStory />;
+    case "keyboard":
+      return <KeyboardSettingsSection />;
+    case "usage":
+      return <UsageLimitsStory />;
+    case "files":
+      return <FilePreferencesStory />;
+    case "machines":
+      return <MachinesSettingsSection />;
+    case "updates":
+      return <SettingsUpdatesStory />;
+    case "experiments":
+      return <ExperimentsStory />;
+    case "marketplaces":
+      return <MarketplacesSettingsSection />;
+    case "community":
+      return <CommunitySettingsSection />;
+    case "archived":
+      return <ArchivedThreadsSettingsSection />;
+    case "general":
+      return (
+        <>
+          <GeneralSettingsStory desktopBrowserAvailable />
+          <VoiceInputStory />
+        </>
+      );
+  }
 }
 
-export function Overview() {
-  return (
-    <SettingsStoryFrame useShell>
-      <GeneralSettingsStory />
-      <AppearanceSettingsStory />
-      <UsageLimitsStory />
-      <VoiceInputStory />
-      <FilePreferencesStory />
-      <ExperimentsStory />
-    </SettingsStoryFrame>
-  );
-}
+/** One chrome-wrapped story with real navigation between Settings subpages. */
+export function FullPage() {
+  const navigate = useNavigate();
+  const route = useSettingsStoryRoute();
+  useEffect(() => {
+    const storyPath =
+      new URLSearchParams(window.location.hash.slice(1)).get("settingsPath") ??
+      new URLSearchParams(window.location.search).get("settingsPath");
+    if (storyPath?.startsWith("/settings") === true) {
+      navigate(storyPath, { replace: true });
+    }
+  }, [navigate]);
 
-export function General() {
   return (
-    <SettingsStoryFrame>
-      <GeneralSettingsStory desktopBrowserAvailable />
-      <VoiceInputStory />
-    </SettingsStoryFrame>
-  );
-}
-
-export function Appearance() {
-  return (
-    <SettingsStoryFrame>
-      <AppearanceSettingsStory />
-    </SettingsStoryFrame>
-  );
-}
-
-export function Files() {
-  return (
-    <SettingsStoryFrame>
-      <FilePreferencesStory />
-    </SettingsStoryFrame>
-  );
-}
-
-export function Experiments() {
-  return (
-    <SettingsStoryFrame>
-      <ExperimentsStory />
-    </SettingsStoryFrame>
+    <SettingsStoryFixtures>
+      <SettingsStoryChrome contentOwnsPageShell={route.kind === "machine"}>
+        <SettingsStoryContent route={route} />
+      </SettingsStoryChrome>
+    </SettingsStoryFixtures>
   );
 }


### PR DESCRIPTION
## Summary

- replace fragmented Settings fixtures with one representative full-page story
- keep Settings, plugin marketplace, Automations, Machines, and Updates states navigable inside shared application chrome
- retain the focused Usage Limits story while sharing current `origin/main` fixtures and query contracts

Depends on the parent layers' final Settings surfaces; it changes story infrastructure only.

## Visual evidence

Before:

![Before: isolated Settings story](https://raw.githubusercontent.com/get-bb/bb/0fc2e77206c8d8972549868d04736594287ab5d1/evidence/settings-ui-stack/layer4-before-settings-stories.png)

After:

![After: navigable full-page Settings story](https://raw.githubusercontent.com/get-bb/bb/abc56c12ac0e6a3e59cc48d289526196592a5bd0/evidence/settings-ui-stack/layer4-after-settings-stories.png)

## Verification

- Turbo typecheck: `@bb/app`
- Settings story tests: 2 passed
- Ladle registration and navigation verified at desktop and compact widths

BB-Thread-ID: thr_qwah76hjqr

> AGENT GENERATED: by GPT-5.6
