### PR TITLE
Cancel an inline sent-message edit with Escape

### DIFF
--- a/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
@@ -56,6 +56,7 @@ vi.mock("@/components/promptbox/PromptBoxInternal", () => ({
     footerStart,
     compact,
     onSubmit,
+    onEscape,
     blurOnPointerSubmit,
     promptBoxRef,
     submission,
@@ -71,6 +72,7 @@ vi.mock("@/components/promptbox/PromptBoxInternal", () => ({
       placeholder?: string;
     };
     onSubmit: () => void;
+    onEscape?: () => void;
     blurOnPointerSubmit?: boolean;
     promptBoxRef?: {
       current: {
@@ -133,6 +135,11 @@ vi.mock("@/components/promptbox/PromptBoxInternal", () => ({
       {onCollapse ? (
         <button type="button" onClick={onCollapse}>
           Collapse prompt box
+        </button>
+      ) : null}
+      {onEscape ? (
+        <button type="button" onClick={onEscape}>
+          Escape
         </button>
       ) : null}
     </div>
@@ -654,6 +661,18 @@ describe("FollowUpPromptBox", () => {
 
     expect(props.composer?.onSubmit).toHaveBeenCalledOnce();
     expect(mocks.scrollToBottom).toHaveBeenCalledOnce();
+  });
+
+  it("forwards the composer's host Escape action", () => {
+    const props = createFollowUpPromptBoxProps({ kind: "ready" });
+    const onEscape = vi.fn();
+    if (!props.composer) throw new Error("Expected follow-up composer props");
+    props.composer.onEscape = onEscape;
+
+    render(<FollowUpPromptBox {...props} />);
+    fireEvent.click(screen.getByRole("button", { name: "Escape" }));
+
+    expect(onEscape).toHaveBeenCalledOnce();
   });
 
   it.each([

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -144,6 +144,12 @@ export interface FollowUpComposerProps {
   onChangeMessage: (value: string, mentionRanges: PromptTextMention[]) => void;
   onModifierSubmit: () => void;
   onSubmit: () => void;
+  /**
+   * Escape pressed in the editor with no higher-priority consumer open.
+   * Inline message editors pass their cancel action; when omitted, Escape
+   * blurs the editor (the bottom composer's behavior).
+   */
+  onEscape?: () => void;
   /** Accessible label and tooltip for the primary submit action. */
   submitTitle?: string;
   compactPromptPlaceholder: string;
@@ -725,6 +731,7 @@ function FollowUpPromptBoxWithComposer({
         mentionRanges={composer.mentionRanges}
         onChange={composer.onChangeMessage}
         onSubmit={onPrimarySubmit}
+        onEscape={composer.onEscape}
         blurOnPointerSubmit={isCompactViewport && isPointerCoarse}
         textEffects={textEffects}
         onComposerLayoutChange={setComposerLayout}

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -146,8 +146,8 @@ export interface FollowUpComposerProps {
   onSubmit: () => void;
   /**
    * Escape pressed in the editor with no higher-priority consumer open.
-   * Inline message editors pass their cancel action; when omitted, Escape
-   * blurs the editor (the bottom composer's behavior).
+   * The sent-message editor passes its cancel action; when omitted, Escape
+   * blurs the editor (the bottom and queued-message composers' behavior).
    */
   onEscape?: () => void;
   /** Accessible label and tooltip for the primary submit action. */

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -1544,6 +1544,23 @@ describe("PromptBoxInternal submit shortcuts", () => {
 });
 
 describe("PromptBoxInternal escape", () => {
+  it("blurs the editor when no host Escape action is provided", async () => {
+    const promptBoxRef = createRef<PromptBoxHandle>();
+    render(
+      <PromptBoxInternal
+        {...createPromptBoxProps({ value: "Follow-up message" })}
+        promptBoxRef={promptBoxRef}
+      />,
+    );
+    await focusPromptEnd(promptBoxRef);
+    const editor = getPromptEditorElement();
+
+    const wasNotCanceled = fireEvent.keyDown(editor, { key: "Escape" });
+
+    expect(wasNotCanceled).toBe(false);
+    expect(document.activeElement).not.toBe(editor);
+  });
+
   it("routes Escape to onEscape instead of blurring the editor", async () => {
     const onEscape = vi.fn();
     const promptBoxRef = createRef<PromptBoxHandle>();

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -1543,6 +1543,67 @@ describe("PromptBoxInternal submit shortcuts", () => {
   });
 });
 
+describe("PromptBoxInternal escape", () => {
+  it("routes Escape to onEscape instead of blurring the editor", async () => {
+    const onEscape = vi.fn();
+    const promptBoxRef = createRef<PromptBoxHandle>();
+    render(
+      <PromptBoxInternal
+        {...createPromptBoxProps({ onEscape, value: "Edited message" })}
+        promptBoxRef={promptBoxRef}
+      />,
+    );
+    await focusPromptEnd(promptBoxRef);
+
+    const wasNotCanceled = fireEvent.keyDown(getPromptEditorElement(), {
+      key: "Escape",
+    });
+
+    expect(onEscape).toHaveBeenCalledTimes(1);
+    expect(wasNotCanceled).toBe(false);
+    // The cancel action owns what happens next; the editor must not also blur.
+    expect(document.activeElement).toBe(getPromptEditorElement());
+  });
+
+  it("dismisses an open typeahead before Escape reaches onEscape", async () => {
+    const onEscape = vi.fn();
+    const promptBoxRef = createRef<PromptBoxHandle>();
+    render(
+      <PromptBoxInternal
+        {...createPromptBoxProps({
+          onEscape,
+          value: "/re",
+          typeahead: buildTypeaheadConfig({
+            commandSuggestions: [
+              {
+                kind: "command",
+                name: "review",
+                source: "command",
+                origin: "user",
+                description: null,
+                argumentHint: null,
+              },
+            ],
+          }),
+        })}
+        promptBoxRef={promptBoxRef}
+      />,
+    );
+    await focusPromptEnd(promptBoxRef);
+    await screen.findByRole("button", { name: "review" });
+
+    fireEvent.keyDown(getPromptEditorElement(), { key: "Escape" });
+
+    expect(onEscape).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: "review" })).toBeNull(),
+    );
+
+    fireEvent.keyDown(getPromptEditorElement(), { key: "Escape" });
+    expect(onEscape).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("PromptBoxInternal size controls", () => {
   it.each([
     ["thread", "calc(50dvh - 3rem)"],

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -406,6 +406,13 @@ interface PromptBoxInternalProps {
   mentionRanges: readonly PromptTextMention[];
   onChange: (value: string, mentionRanges: PromptTextMention[]) => void;
   onSubmit: () => void;
+  /**
+   * Replaces the default Escape behavior (blurring the editor). Inline
+   * message editors pass their cancel action so Escape closes the editor.
+   * Higher-priority Escape consumers (typeahead dismissal, voice-recording
+   * cancel) still run first.
+   */
+  onEscape?: () => void;
   /** Blur the editor after a pointer-activated primary submission. */
   blurOnPointerSubmit?: boolean;
   placeholder?: string;
@@ -1184,6 +1191,7 @@ export function PromptBoxInternal({
   mentionRanges,
   onChange,
   onSubmit,
+  onEscape,
   blurOnPointerSubmit = false,
   placeholder = "Ask anything. @ to mention files, folders, or sections",
   autoFocus = true,
@@ -2941,11 +2949,17 @@ export function PromptBoxInternal({
       }
 
       // Escape releases the composer so the keyboard can reach the rest of the
-      // app. Higher-priority Escape behavior still runs first: the typeahead
-      // menu above dismisses itself, and voice recording cancels from a window
-      // capture listener that stops the event before the editor sees it. A
-      // locked editor never reaches here — see the editor container below.
+      // app — or cancels the hosting editor when `onEscape` is provided (the
+      // inline message editors). Higher-priority Escape behavior still runs
+      // first: the typeahead menu above dismisses itself, and voice recording
+      // cancels from a window capture listener that stops the event before the
+      // editor sees it. A locked editor never reaches here — see the editor
+      // container below.
       if (event.key === "Escape") {
+        if (onEscape) {
+          onEscape();
+          return true;
+        }
         blurPromptEditor(currentEditor);
         return true;
       }
@@ -3076,6 +3090,7 @@ export function PromptBoxInternal({
       isPointerCoarse,
       loadMoreCommands,
       onCommandQueryChange,
+      onEscape,
       onMentionQueryChange,
       onModifierSubmit,
       postCompositionKeyDownEvents,

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -407,8 +407,8 @@ interface PromptBoxInternalProps {
   onChange: (value: string, mentionRanges: PromptTextMention[]) => void;
   onSubmit: () => void;
   /**
-   * Replaces the default Escape behavior (blurring the editor). Inline
-   * message editors pass their cancel action so Escape closes the editor.
+   * Replaces the default Escape behavior (blurring the editor). The
+   * sent-message editor passes its cancel action so Escape closes the editor.
    * Higher-priority Escape consumers (typeahead dismissal, voice-recording
    * cancel) still run first.
    */
@@ -2949,12 +2949,11 @@ export function PromptBoxInternal({
       }
 
       // Escape releases the composer so the keyboard can reach the rest of the
-      // app — or cancels the hosting editor when `onEscape` is provided (the
-      // inline message editors). Higher-priority Escape behavior still runs
-      // first: the typeahead menu above dismisses itself, and voice recording
-      // cancels from a window capture listener that stops the event before the
-      // editor sees it. A locked editor never reaches here — see the editor
-      // container below.
+      // app — or cancels the sent-message editor when `onEscape` is provided.
+      // Higher-priority Escape behavior still runs first: the typeahead menu
+      // above dismisses itself, and voice recording cancels from a window
+      // capture listener that stops the event before the editor sees it. A
+      // locked editor never reaches here — see the editor container below.
       if (event.key === "Escape") {
         if (onEscape) {
           onEscape();

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
@@ -107,6 +107,7 @@ vi.mock("@/components/promptbox/FollowUpPromptBox", async () => {
       composer: {
         message: string;
         onChangeMessage: (message: string, mentions: []) => void;
+        onEscape?: () => void;
         onSubmit: () => void;
         submitTitle?: string;
         submitMode: { kind: string; reason?: string };
@@ -250,6 +251,11 @@ vi.mock("@/components/promptbox/FollowUpPromptBox", async () => {
             <button type="button" onClick={composer.onSubmit}>
               Submit composer
             </button>
+            {composer.onEscape ? (
+              <button type="button" onClick={composer.onEscape}>
+                Escape composer
+              </button>
+            ) : null}
             <button
               type="button"
               onClick={() =>
@@ -842,6 +848,18 @@ describe("ThreadDetailPromptArea", () => {
       }),
     );
     expect(onCancel).toHaveBeenCalledTimes(1);
+
+    // Escape in the edit composer cancels too; the bottom composer keeps its
+    // default Escape behavior (no onEscape).
+    expect(
+      within(bottomComposer!).queryByRole("button", {
+        name: "Escape composer",
+      }),
+    ).toBeNull();
+    fireEvent.click(
+      inlineEditor.getByRole("button", { name: "Escape composer" }),
+    );
+    expect(onCancel).toHaveBeenCalledTimes(2);
   });
 
   it("blocks a staged sent-message edit when the thread becomes ineligible", () => {

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -239,6 +239,8 @@ interface InlineDraftComposerOptions {
   historyResetKey: string;
   isSubmitting: boolean;
   onChangeMessage: FollowUpComposerProps["onChangeMessage"];
+  /** Escape pressed in the editor; passes the editor's cancel action. */
+  onEscape?: FollowUpComposerProps["onEscape"];
   onSelectHistoryEntry: (draft: PromptDraftState) => void;
   permission: FollowUpPromptBoxProps["permission"];
   pluginComposerHost: PluginComposerHost;
@@ -280,6 +282,7 @@ function buildInlineDraftComposer(options: InlineDraftComposerOptions) {
         onChangeMessage: options.onChangeMessage,
         onModifierSubmit: options.submit,
         onSubmit: options.submit,
+        onEscape: options.onEscape,
         submitTitle: options.submitTitle,
         compactPromptPlaceholder: options.compactPromptPlaceholder,
         promptPlaceholder: options.promptPlaceholder,
@@ -1437,6 +1440,7 @@ export function ThreadDetailPromptArea({
               text,
               mentions,
             })),
+          onEscape: sentMessageEdit.onCancel,
           onSelectHistoryEntry: (nextDraft) =>
             sentMessageEdit.updateDraft(() => nextDraft),
           permission: bottomPermissionConfig,


### PR DESCRIPTION
## What was wrong

Pressing Escape inside the sent-message inline editor only blurred the composer — the standard Escape-to-release behavior every composer shares. The editor could only be closed with its X button, so an edit opened by mistake could not be dismissed from the keyboard.

## What changed

- `PromptBoxInternal` gains an optional `onEscape` prop that replaces the default Escape-to-blur when provided. Higher-priority Escape consumers are unchanged: the typeahead menu still dismisses itself first, and voice recording still cancels from its window capture listener.
- `FollowUpComposerProps` carries `onEscape` through to the internal box.
- `ThreadDetailPromptArea` passes the sent-message editor's existing cancel action as `onEscape`, so Escape now cancels the edit exactly like the frame's X button. The queued-message inline editor and the bottom composer are unchanged (no `onEscape` → blur as before).

No wire changes; no CLI/guide surfaces affected.

## How you verified

- New tests in `PromptBoxInternal.test.tsx` verify that Escape calls `onEscape` without blurring, omission retains the default blur behavior, and an open typeahead consumes the first Escape before the host callback.
- A new `FollowUpPromptBox.test.tsx` regression test verifies that the composer forwards its host Escape action to `PromptBoxInternal`.
- The sent-message edit test in `ThreadDetailPromptArea.test.tsx` verifies that Escape calls `onCancel` while the bottom composer receives no `onEscape`.
- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/promptbox/PromptBoxInternal.test.tsx src/components/promptbox/FollowUpPromptBox.test.tsx src/views/thread-detail/ThreadDetailPromptArea.test.tsx` passes all 162 tests across the three focused files, including the existing voice-recording Escape-priority coverage.
- `pnpm exec turbo run typecheck --filter=@bb/app --force` passes.
- Browser QA with `sawyerhood/dev-browser` reproduces the pre-fix behavior on `main` (Escape leaves the edit frame open after blurring) and confirms the fixed behavior (Escape closes the edit frame and restores the sent message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> AGENT GENERATED: by Claude Fable 5
