### PR TITLE
Send MCP progress during ACP dynamic tool calls so AskUserQuestion does not time out

### DIFF
--- a/plugins/provider-acp/package.json
+++ b/plugins/provider-acp/package.json
@@ -27,6 +27,7 @@
     "@bb/domain": "workspace:*",
     "@bb/host-daemon-contract": "workspace:*",
     "@bb/provider-bridge-protocol": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@types/node": "^22.0.0",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "typescript-7": "npm:typescript@^7.0.2",

--- a/plugins/provider-acp/src/bridge/tool-proxy-mcp.test.ts
+++ b/plugins/provider-acp/src/bridge/tool-proxy-mcp.test.ts
@@ -1,0 +1,143 @@
+/**
+ * The `bb-bridge` MCP server proxies bb's dynamic tools (AskUserQuestion and
+ * friends) to ACP agents such as OpenCode. Those agents use the MCP TypeScript
+ * SDK client, whose `callTool` request times out after 60 seconds unless the
+ * server sends `notifications/progress` for the call's `progressToken`
+ * (OpenCode passes `resetTimeoutOnProgress: true`). A user answering a
+ * question takes longer than that, so the server must keep the call alive.
+ *
+ * This test drives the MCP server exactly the way OpenCode does: the real SDK
+ * client over stdio, a short request timeout, `resetTimeoutOnProgress`, and an
+ * `onprogress` hook (which is what makes the SDK attach a progress token).
+ */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import { createServer, type Server } from "node:net";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildAcpMcpServerConfig } from "./tool-proxy-mcp.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const BRIDGE_MODULE = resolve(here, "bridge.ts");
+const TSX_LOADER = import.meta.resolve("tsx");
+
+const cleanups: Array<() => Promise<void> | void> = [];
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).reverse()) {
+    await cleanup();
+  }
+});
+
+/** A stand-in for the bridge's TCP dynamic-tool socket that answers late. */
+async function listenFakeBridge(args: {
+  responseDelayMs: number;
+}): Promise<{ port: number; server: Server; requests: unknown[] }> {
+  const requests: unknown[] = [];
+  const server = createServer((socket) => {
+    let buffer = "";
+    socket.setEncoding("utf8");
+    socket.on("data", (chunk) => {
+      buffer += chunk;
+      const newline = buffer.indexOf("\n");
+      if (newline === -1) return;
+      requests.push(JSON.parse(buffer.slice(0, newline)));
+      setTimeout(() => {
+        socket.end(
+          `${JSON.stringify({ ok: true, content: '{"answers":{"Which?":"B"}}' })}\n`,
+        );
+      }, args.responseDelayMs);
+    });
+  });
+  await new Promise<void>((resolveListen) =>
+    server.listen(0, "127.0.0.1", () => resolveListen()),
+  );
+  cleanups.push(
+    () =>
+      new Promise<void>((resolveClose) => server.close(() => resolveClose())),
+  );
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("fake bridge did not bind a port");
+  }
+  return { port: address.port, server, requests };
+}
+
+async function connectLikeOpenCode(port: number): Promise<Client> {
+  const config = buildAcpMcpServerConfig({
+    bridgeArgs: [
+      "--conditions=source",
+      "--import",
+      TSX_LOADER,
+      BRIDGE_MODULE,
+      "--mcp-stdio",
+    ],
+    command: process.execPath,
+    dynamicTools: [
+      {
+        name: "AskUserQuestion",
+        description: "Ask the user a question.",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ],
+    host: "127.0.0.1",
+    port,
+    runtimeEnv: [],
+    threadId: "thread-ask",
+    token: "secret-token",
+  });
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) env[key] = value;
+  }
+  for (const { name, value } of config.env) env[name] = value;
+  // Heartbeat faster than the scaled-down client timeout below.
+  env.BB_ACP_DYNAMIC_TOOL_PROGRESS_INTERVAL_MS = "200";
+  const transport = new StdioClientTransport({
+    command: config.command,
+    args: config.args,
+    env,
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "opencode-like", version: "0" });
+  await client.connect(transport);
+  transport.stderr?.on("data", (chunk: Buffer) => {
+    process.stderr.write(`[bb-bridge mcp] ${chunk.toString()}`);
+  });
+  cleanups.push(() => client.close());
+  return client;
+}
+
+describe("bb-bridge MCP server keeps long tool calls alive", () => {
+  it("sends progress notifications so an OpenCode-style client does not time out while the user answers", async () => {
+    const fakeBridge = await listenFakeBridge({ responseDelayMs: 2_500 });
+    const client = await connectLikeOpenCode(fakeBridge.port);
+
+    let progressCount = 0;
+    const result = await client.callTool(
+      {
+        name: "AskUserQuestion",
+        arguments: { questions: [] },
+      },
+      CallToolResultSchema,
+      {
+        // OpenCode's defaults are the SDK's 60s timeout with resets on
+        // progress; scale the timeout down so the test stays fast.
+        timeout: 1_000,
+        resetTimeoutOnProgress: true,
+        onprogress: () => {
+          progressCount += 1;
+        },
+      },
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual([
+      { type: "text", text: '{"answers":{"Which?":"B"}}' },
+    ]);
+    expect(progressCount).toBeGreaterThan(0);
+    expect(fakeBridge.requests).toHaveLength(1);
+  }, 20_000);
+});

--- a/plugins/provider-acp/src/bridge/tool-proxy-mcp.ts
+++ b/plugins/provider-acp/src/bridge/tool-proxy-mcp.ts
@@ -13,6 +13,8 @@ const ENV_PORT = "BB_ACP_DYNAMIC_TOOL_PORT";
 const ENV_TOKEN = "BB_ACP_DYNAMIC_TOOL_TOKEN";
 const ENV_THREAD_ID = "BB_ACP_DYNAMIC_TOOL_THREAD_ID";
 const ENV_TOOLS = "BB_ACP_DYNAMIC_TOOLS";
+/** Test-only override for the progress heartbeat interval (milliseconds). */
+const ENV_PROGRESS_INTERVAL_MS = "BB_ACP_DYNAMIC_TOOL_PROGRESS_INTERVAL_MS";
 
 export interface AcpMcpServerConfig {
   name: string;
@@ -62,12 +64,22 @@ interface JsonRpcMessage {
 interface McpServerEnvironment {
   host: string;
   port: number;
+  progressIntervalMs: number | undefined;
   threadId: string;
   token: string;
   tools: DynamicTool[];
 }
 
 let nextMcpToolCallId = 0;
+
+/**
+ * Interval between `notifications/progress` messages for a pending tools/call.
+ * The MCP TypeScript SDK client (OpenCode, and most ACP agents) fails a request
+ * after 60 seconds unless a progress notification for its `progressToken`
+ * resets the timer. AskUserQuestion waits on the user for minutes, so the call
+ * must send progress well inside that window (#1944).
+ */
+export const TOOL_CALL_PROGRESS_INTERVAL_MS = 15_000;
 
 export function buildAcpMcpServerConfig(
   args: BuildAcpMcpServerConfigArgs,
@@ -101,9 +113,15 @@ function readEnvironment(): McpServerEnvironment {
   }
   const parsedTools = JSON.parse(toolsJson) as unknown;
   const tools = dynamicToolSchema.array().parse(parsedTools);
+  const rawProgressInterval = process.env[ENV_PROGRESS_INTERVAL_MS];
+  const progressIntervalMs =
+    rawProgressInterval !== undefined && Number(rawProgressInterval) > 0
+      ? Number(rawProgressInterval)
+      : undefined;
   return {
     host,
     port,
+    progressIntervalMs,
     threadId,
     token,
     tools,
@@ -172,6 +190,35 @@ function objectParams(params: unknown): Record<string, unknown> {
     : {};
 }
 
+/** The `_meta.progressToken` of a request, when the client asked for one. */
+export function readProgressToken(params: unknown): string | number | null {
+  const meta = objectParams(objectParams(params)._meta).progressToken;
+  return typeof meta === "string" || typeof meta === "number" ? meta : null;
+}
+
+/**
+ * Sends `notifications/progress` for `progressToken` every `intervalMs` until
+ * the returned stop function runs. Progress is a counter: the MCP spec only
+ * requires it to increase, and the total is unknown while a user is typing.
+ */
+export function startProgressHeartbeat(args: {
+  intervalMs?: number;
+  progressToken: string | number;
+  write?: (message: unknown) => void;
+}): () => void {
+  const write = args.write ?? writeJson;
+  let progress = 0;
+  const timer = setInterval(() => {
+    progress += 1;
+    write({
+      jsonrpc: "2.0",
+      method: "notifications/progress",
+      params: { progressToken: args.progressToken, progress },
+    });
+  }, args.intervalMs ?? TOOL_CALL_PROGRESS_INTERVAL_MS);
+  return () => clearInterval(timer);
+}
+
 async function handleRequest(
   env: McpServerEnvironment,
   message: JsonRpcMessage,
@@ -217,12 +264,21 @@ async function handleRequest(
         !Array.isArray(rawArguments)
           ? (rawArguments as Record<string, unknown>)
           : {};
+      const progressToken = readProgressToken(message.params);
+      const stopHeartbeat =
+        progressToken === null
+          ? () => {}
+          : startProgressHeartbeat({
+              intervalMs: env.progressIntervalMs,
+              progressToken,
+            });
       try {
         const result = await callBridge(env, {
           arguments: toolArguments,
           callId: mcpToolCallId(tool.name),
           tool: tool.name,
         });
+        stopHeartbeat();
         if (!result.ok) {
           writeResult(message.id, {
             content: [{ type: "text", text: result.error }],
@@ -235,6 +291,7 @@ async function handleRequest(
           ...(result.isError ? { isError: true } : {}),
         });
       } catch (error) {
+        stopHeartbeat();
         writeResult(message.id, {
           content: [
             {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2947,6 +2947,9 @@ importers:
       '@bb/provider-bridge-protocol':
         specifier: workspace:*
         version: link:../../packages/provider-bridge-protocol
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.10


### PR DESCRIPTION
## What was wrong

The `bb-bridge` MCP server that exposes bb's dynamic tools to ACP agents answered `tools/call` only when the plugin tool returned. OpenCode (and other agents on the MCP TypeScript SDK) fail a request after 60 seconds unless the server sends `notifications/progress` for the call's `progressToken`. `AskUserQuestion` waits on the user for minutes, so the agent got `MCP error -32001: Request timed out`, reported that the user did not answer, and the later answer went nowhere. Issue: #1944.

## What changed

- `plugins/provider-acp/src/bridge/tool-proxy-mcp.ts`: when a `tools/call` request carries `_meta.progressToken`, the server sends a `notifications/progress` heartbeat every 15 seconds until the bridge round trip settles. Requests without a token behave as before.
- `BB_ACP_DYNAMIC_TOOL_PROGRESS_INTERVAL_MS` is an internal env override that the test uses to shrink the interval. The ACP bridge never sets it.
- `plugins/provider-acp/package.json`: `@modelcontextprotocol/sdk` as a devDependency so the test drives the server with the real client that OpenCode uses.

No wire change between server and daemon.

## How you verified

- New `plugins/provider-acp/src/bridge/tool-proxy-mcp.test.ts`: real MCP SDK `Client` over stdio with `resetTimeoutOnProgress: true`, `onprogress`, and a 1 s timeout, against the `--mcp-stdio` server and a fake bridge socket that answers after 2.5 s. Before the fix it fails with `MCP error -32001: Request timed out`; after the fix the call returns the answer and progress notifications arrive.
- `pnpm exec turbo run typecheck test --filter=bb-plugin-provider-acp`: 166 tests pass.

Fixes #1944

> AGENT GENERATED: by Claude Opus 5
