### PR TITLE
Surface incompatible, failed, and missing plugins instead of unloading them silently

### DIFF
--- a/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.test.tsx
@@ -25,6 +25,15 @@ import {
 import { PluginNavSidebarItems } from "./PluginNavSidebarItems";
 import { pluginNavPanelOrderAtom } from "./pluginNavSidebarAtoms";
 
+const usePluginAttentionMock = vi.hoisted(() =>
+  vi.fn(() => ({ count: 0, plugins: [] })),
+);
+
+vi.mock("@/hooks/usePluginAttention", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/usePluginAttention")>()),
+  usePluginAttention: usePluginAttentionMock,
+}));
+
 function registrationSet(
   overrides: Partial<PluginRegistrationSet>,
 ): PluginRegistrationSet {
@@ -105,6 +114,7 @@ function panelRowNames(): string[] {
 
 beforeEach(() => {
   window.localStorage.clear();
+  usePluginAttentionMock.mockReturnValue({ count: 0, plugins: [] });
   resetAllCrashedPluginSlotsForTest();
   // React reports errors caught by the slot boundary; keep expected crashes
   // from obscuring the regression assertions below.
@@ -404,6 +414,25 @@ describe("PluginNavSidebarItems", () => {
     expect(
       window.localStorage.getItem("bb.sidebar.pluginPanelOrder") ?? "",
     ).not.toContain("__builtin__/tools");
+  });
+
+  it("badges the Extensions row with the count of plugins that need attention", () => {
+    usePluginAttentionMock.mockReturnValue({ count: 2, plugins: [] });
+    registerPanel("docs", "Docs");
+
+    renderSidebarItems({ toolsRoutePath: "/extensions/plugins" });
+
+    const badge = screen.getByTestId("tools-nav-plugin-attention");
+    expect(badge.textContent).toBe("2");
+    expect(badge.getAttribute("aria-label")).toBe("2 plugins need attention");
+    // Plugin rows never carry the badge; only the host's Extensions row does.
+    expect(screen.getAllByTestId("tools-nav-plugin-attention").length).toBe(1);
+  });
+
+  it("renders no attention badge on the Extensions row when every plugin runs", () => {
+    renderSidebarItems({ toolsRoutePath: "/extensions/plugins" });
+
+    expect(screen.queryByTestId("tools-nav-plugin-attention")).toBeNull();
   });
 
   it("carries both Extensions glyphs so hover swaps without reflow", () => {

--- a/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
+++ b/apps/app/src/components/plugin/PluginNavSidebarItems.tsx
@@ -34,6 +34,10 @@ import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { PluginIcon } from "@/components/plugin/PluginIcon";
 import { PluginSlotMount } from "@/components/plugin/PluginSlotMount";
 import { PROJECT_LIST_ACTION_BUTTON_CLASS } from "@/components/sidebar/ProjectList";
+import {
+  pluginAttentionLabel,
+  usePluginAttention,
+} from "@/hooks/usePluginAttention";
 import { getPluginPanelRoutePath } from "@/lib/route-paths";
 import { usePluginSlots } from "@/lib/plugin-slots";
 import { cn } from "@bb/shared-ui/lib/utils";
@@ -425,12 +429,27 @@ function ToolsNavSidebarItem({
   row: Extract<SidebarNavRow, { kind: "tools" }>;
 }) {
   const navigate = useNavigate();
+  const pluginAttention = usePluginAttention();
+  // Installed plugins that are enabled but not running (incompatible after a
+  // bb upgrade, failed, missing). The count rides in the row's accessory slot,
+  // the same bounded trailing value plugin rows use (#1915).
+  const attentionBadge =
+    pluginAttention.count > 0 ? (
+      <span
+        data-testid="tools-nav-plugin-attention"
+        aria-label={pluginAttentionLabel(pluginAttention.count)}
+        className="inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-warning/15 px-1 text-2xs font-medium tabular-nums text-warning-text"
+      >
+        {pluginAttention.count}
+      </span>
+    ) : null;
   return (
     <SidebarNavRowChrome
       {...props}
       rowKey={getPluginNavPanelKey(row)}
       title={row.title}
       icon={<ToolsNavSidebarItemIcon />}
+      accessory={attentionBadge}
       // Never active: AppLayout swaps AppSidebar out for ToolsSidebar on every
       // Extensions route, so this row is only on screen while Extensions is
       // closed.

--- a/apps/app/src/components/plugin/management/InstalledPluginsTab.test.tsx
+++ b/apps/app/src/components/plugin/management/InstalledPluginsTab.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import {
+  EMPTY_PLUGIN_UPDATE_STATE,
+  type PluginListItem,
+} from "@/hooks/queries/plugin-settings-queries";
+import { InstalledPluginRow } from "./InstalledPluginsTab";
+
+function plugin(overrides: Partial<PluginListItem> = {}): PluginListItem {
+  return {
+    id: "notify",
+    source: "path:/tmp/bb-plugin-notify",
+    rootDir: "/tmp/bb-plugin-notify",
+    version: "0.2.1",
+    enabled: true,
+    status: "running",
+    statusDetail: null,
+    description: "Desktop notifications when a thread needs you.",
+    name: "Notify",
+    icon: null,
+    compactIconUrl: null,
+    logoUrl: null,
+    logoDarkUrl: null,
+    hasSettings: false,
+    provenance: "direct",
+    isOrphanedBuiltin: false,
+    catalogEntryId: null,
+    publisherLabel: null,
+    sourceDisplay: "path · /tmp/bb-plugin-notify",
+    updateState: EMPTY_PLUGIN_UPDATE_STATE,
+    handlerStats: { count: 0, totalMs: 0, maxMs: 0, errorCount: 0 },
+    services: [],
+    schedules: [],
+    cliCommand: null,
+    capabilities: [],
+    app: { hasApp: false, bundle: null },
+    ...overrides,
+  };
+}
+
+function renderRow(item: PluginListItem) {
+  const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
+  return render(
+    <MemoryRouter>
+      <QueryClientWrapper>
+        <InstalledPluginRow plugin={item} onUpdateClick={vi.fn()} />
+      </QueryClientWrapper>
+    </MemoryRouter>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("InstalledPluginRow", () => {
+  it("shows the status word and detail at rest and marks the switch when a plugin is incompatible", () => {
+    renderRow(
+      plugin({
+        status: "incompatible",
+        statusDetail: "requires bb >=0.38.0 <0.39.0, this is 0.39.0",
+      }),
+    );
+
+    expect(screen.getByTestId("plugin-runtime-status-notify").textContent).toBe(
+      "Incompatible",
+    );
+    // The server's detail replaces the marketing description.
+    expect(
+      screen.getByText("requires bb >=0.38.0 <0.39.0, this is 0.39.0"),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText("Desktop notifications when a thread needs you."),
+    ).toBeNull();
+    // The switch is still "on" (the user enabled it) but says so honestly.
+    expect(screen.getByTestId("plugin-not-running-notify").textContent).toBe(
+      "not running",
+    );
+    const toggle = screen.getByRole("switch", {
+      name: "Disable notify (incompatible, not running)",
+    });
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("keeps a running plugin's row quiet", () => {
+    renderRow(plugin());
+
+    expect(screen.queryByTestId("plugin-runtime-status-notify")).toBeNull();
+    expect(screen.queryByTestId("plugin-not-running-notify")).toBeNull();
+    expect(
+      screen.getByText("Desktop notifications when a thread needs you."),
+    ).toBeTruthy();
+    expect(screen.getByRole("switch", { name: "Disable notify" })).toBeTruthy();
+  });
+
+  it("does not call a needs-configuration plugin not running", () => {
+    renderRow(
+      plugin({
+        status: "needs-configuration",
+        statusDetail: "Set an API token.",
+      }),
+    );
+
+    expect(screen.getByTestId("plugin-runtime-status-notify").textContent).toBe(
+      "Needs configuration",
+    );
+    expect(screen.getByText("Set an API token.")).toBeTruthy();
+    expect(screen.queryByTestId("plugin-not-running-notify")).toBeNull();
+  });
+});

--- a/apps/app/src/components/plugin/management/InstalledPluginsTab.tsx
+++ b/apps/app/src/components/plugin/management/InstalledPluginsTab.tsx
@@ -15,8 +15,8 @@ import {
   setPluginEnabled,
   type PluginListItem,
 } from "@/hooks/queries/plugin-settings-queries";
+import { pluginNeedsAttention } from "@bb/server-contract";
 import { cn } from "@bb/shared-ui/lib/utils";
-import { pluginNeedsAttention } from "@/hooks/usePluginAttention";
 import { getPluginDetailRoutePath } from "@/lib/route-paths";
 import {
   pluginRowSignal,
@@ -113,7 +113,10 @@ export function InstalledPluginRow({
   // Runtime health only (not a rolled-back update).
   const runtimeStatus = pluginRuntimeStatusPresentation(plugin);
   // Enabled, but the server never loaded it (incompatible, error, missing).
-  const notRunning = enabled && pluginNeedsAttention(plugin);
+  const notRunning = pluginNeedsAttention({
+    enabled: enabled === true,
+    status: plugin.status,
+  });
   const runtimeStatusToneClass =
     runtimeStatus?.tone === "error"
       ? "text-destructive-text"

--- a/apps/app/src/components/plugin/management/InstalledPluginsTab.tsx
+++ b/apps/app/src/components/plugin/management/InstalledPluginsTab.tsx
@@ -15,8 +15,13 @@ import {
   setPluginEnabled,
   type PluginListItem,
 } from "@/hooks/queries/plugin-settings-queries";
+import { cn } from "@bb/shared-ui/lib/utils";
+import { pluginNeedsAttention } from "@/hooks/usePluginAttention";
 import { getPluginDetailRoutePath } from "@/lib/route-paths";
-import { pluginRowSignal } from "./plugin-status";
+import {
+  pluginRowSignal,
+  pluginRuntimeStatusPresentation,
+} from "./plugin-status";
 import { PluginRowSignalView, PluginSignalLogo } from "./PluginRowSignal";
 import { UpdatePluginDialog } from "./UpdatePluginDialog";
 import { PluginLogo } from "./plugin-ui";
@@ -28,6 +33,11 @@ import { PluginLogo } from "./plugin-ui";
  * while abnormal runtime health is an icon action that opens plugin details.
  * Newer-incompatible and pinned never badge. Hover reveals the chevron; the
  * row navigates to the plugin's detail page where depth lives.
+ *
+ * A plugin that is enabled but not running is the one case a row says more
+ * at rest: the status word sits beside the name, the server's status detail
+ * replaces the description, and the enable switch is marked "not running" so
+ * an "on" switch never claims the plugin works (#1915).
  */
 export function InstalledPluginsTab({
   plugins,
@@ -100,6 +110,14 @@ export function InstalledPluginRow({
   const signal = pluginRowSignal(plugin);
   const statusSignal = signal?.kind === "status" ? signal : null;
   const updateSignal = signal?.kind === "update" ? signal : null;
+  // Runtime health only (not a rolled-back update).
+  const runtimeStatus = pluginRuntimeStatusPresentation(plugin);
+  // Enabled, but the server never loaded it (incompatible, error, missing).
+  const notRunning = enabled && pluginNeedsAttention(plugin);
+  const runtimeStatusToneClass =
+    runtimeStatus?.tone === "error"
+      ? "text-destructive-text"
+      : "text-warning-text";
 
   const openDetail = () =>
     navigate(
@@ -119,7 +137,24 @@ export function InstalledPluginRow({
             <ProvenancePill label={plugin.publisherLabel} />
           )
         }
-        description={plugin.description}
+        status={
+          runtimeStatus === null ? undefined : (
+            <span
+              data-testid={`plugin-runtime-status-${plugin.id}`}
+              className={cn(
+                "shrink-0 text-xs font-medium",
+                runtimeStatusToneClass,
+              )}
+            >
+              {runtimeStatus.label}
+            </span>
+          )
+        }
+        description={
+          runtimeStatus === null
+            ? plugin.description
+            : (plugin.statusDetail ?? runtimeStatus.condition)
+        }
         openLabel={`${plugin.name ?? plugin.id} plugin details`}
         onOpen={openDetail}
         trailingMeta={
@@ -134,12 +169,29 @@ export function InstalledPluginRow({
           ) : undefined
         }
         persistentActions={
-          <Switch
-            checked={enabled}
-            disabled={toggle.isPending}
-            onCheckedChange={(next) => toggle.mutate(next)}
-            aria-label={`${enabled ? "Disable" : "Enable"} ${plugin.id}`}
-          />
+          <>
+            {runtimeStatus !== null && notRunning ? (
+              <span
+                data-testid={`plugin-not-running-${plugin.id}`}
+                className={cn(
+                  "mr-1 text-2xs font-medium",
+                  runtimeStatusToneClass,
+                )}
+              >
+                not running
+              </span>
+            ) : null}
+            <Switch
+              checked={enabled}
+              disabled={toggle.isPending}
+              onCheckedChange={(next) => toggle.mutate(next)}
+              aria-label={`${enabled ? "Disable" : "Enable"} ${plugin.id}${
+                runtimeStatus !== null && notRunning
+                  ? ` (${runtimeStatus.label.toLowerCase()}, not running)`
+                  : ""
+              }`}
+            />
+          </>
         }
         trailingVisual={<ResourceRowDetailChevron />}
       />

--- a/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
@@ -210,6 +210,7 @@ function makeInventory(overrides: Partial<UpdateInventory>): UpdateInventory {
     appUpdateAvailable: false,
     desktopUpdateReady: false,
     machines: [],
+    pluginAttentionCount: 0,
     actionableCount: 0,
     hasAttention: false,
     lastCheckedAt: null,

--- a/apps/app/src/components/sidebar/SidebarUpdatesBadge.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarUpdatesBadge.test.tsx
@@ -117,6 +117,7 @@ function renderBadge(inventory: Partial<UpdateInventory>) {
     appUpdateAvailable: false,
     desktopUpdateReady: false,
     machines: [],
+    pluginAttentionCount: 0,
     actionableCount: 0,
     hasAttention: false,
     ...inventory,
@@ -190,6 +191,26 @@ describe("SidebarUpdatesBadge", () => {
 
     expect(screen.getByTestId("sidebar-updates-badge-bb")).toBeTruthy();
     expect(screen.queryByTestId("sidebar-updates-badge-providers")).toBeNull();
+  });
+
+  it("shows a plugins chip that opens Installed plugins when a plugin is not running", () => {
+    renderBadge({ pluginAttentionCount: 1 });
+
+    const chip = screen.getByTestId("sidebar-updates-badge-plugins");
+    expect(chip.textContent).toContain("1 plugin needs attention");
+    expect(chip.getAttribute("href")).toBe(
+      "/extensions/plugins?view=installed",
+    );
+    expect(screen.queryByTestId("sidebar-updates-badge-bb")).toBeNull();
+    expect(screen.queryByTestId("sidebar-updates-badge-providers")).toBeNull();
+  });
+
+  it("pluralizes the plugins chip", () => {
+    renderBadge({ pluginAttentionCount: 3 });
+
+    expect(
+      screen.getByTestId("sidebar-updates-badge-plugins").textContent,
+    ).toContain("3 plugins need attention");
   });
 
   it("renders one mark per provider in a stable order when the same CLI is stale on several machines", () => {

--- a/apps/app/src/components/sidebar/SidebarUpdatesBadge.tsx
+++ b/apps/app/src/components/sidebar/SidebarUpdatesBadge.tsx
@@ -3,7 +3,9 @@ import type { ProviderCliKey } from "@bb/host-daemon-contract";
 import { Icon } from "@bb/shared-ui/icon";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
 import { cn } from "@bb/shared-ui/lib/utils";
+import { getToolsOwnedCollectionRoutePath } from "@/components/tools/tools-navigation";
 import { SidebarMenuItem } from "@/components/ui/sidebar.js";
+import { pluginAttentionLabel } from "@/hooks/usePluginAttention";
 import { useUpdateInventory } from "@/hooks/useUpdateInventory";
 import {
   getProviderIconColorClass,
@@ -56,7 +58,10 @@ interface StaleProvider {
  * (app release, downloaded desktop update, or a daemon stuck on an old
  * protocol) and the agent CLIs, which carry their own brand marks so it is
  * clear which agent is stale without hovering. Both chips open the
- * consolidated Settings → Updates view.
+ * consolidated Settings → Updates view. A third chip counts installed plugins
+ * that are enabled but not running (incompatible after a bb upgrade, failed,
+ * or missing) and opens Extensions → Installed plugins, so a plugin that
+ * unloads does not vanish silently (#1915).
  *
  * A CLI that is not installed at all is not an update and gets no chip here:
  * there is no installed version to stale against, and the Settings → Updates
@@ -95,7 +100,13 @@ export function SidebarUpdatesBadge({ onNavigate }: SidebarUpdatesBadgeProps) {
     return stale === undefined ? [] : [stale];
   });
 
-  if (bbUpdateCount === 0 && staleProviders.length === 0) {
+  const pluginAttentionCount = inventory.pluginAttentionCount;
+
+  if (
+    bbUpdateCount === 0 &&
+    staleProviders.length === 0 &&
+    pluginAttentionCount === 0
+  ) {
     return null;
   }
 
@@ -105,6 +116,7 @@ export function SidebarUpdatesBadge({ onNavigate }: SidebarUpdatesBadgeProps) {
   const providerLabel = `${joinNames(
     staleProviders.map((stale) => stale.displayName),
   )} ${staleProviders.length === 1 ? "update" : "updates"} available`;
+  const pluginLabel = pluginAttentionLabel(pluginAttentionCount);
 
   return (
     // Right-alignment on a single row comes from the flexible spacer the
@@ -162,6 +174,23 @@ export function SidebarUpdatesBadge({ onNavigate }: SidebarUpdatesBadgeProps) {
             </Link>
           </TooltipTrigger>
           <TooltipContent side="top">{providerLabel}</TooltipContent>
+        </Tooltip>
+      ) : null}
+      {pluginAttentionCount > 0 ? (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Link
+              to={getToolsOwnedCollectionRoutePath("plugins")}
+              onClick={onNavigate}
+              aria-label={pluginLabel}
+              data-testid="sidebar-updates-badge-plugins"
+              className={CHIP_CLASS}
+            >
+              <Icon name="AlertTriangle" className="size-3 text-warning-text" />
+              {pluginLabel}
+            </Link>
+          </TooltipTrigger>
+          <TooltipContent side="top">{pluginLabel}</TooltipContent>
         </Tooltip>
       ) : null}
     </SidebarMenuItem>

--- a/apps/app/src/hooks/queries/plugin-settings-queries.ts
+++ b/apps/app/src/hooks/queries/plugin-settings-queries.ts
@@ -6,7 +6,11 @@ import type {
 import { pluginSettingsUpdateRequestSchema } from "@bb/server-contract";
 import { useQuery } from "@tanstack/react-query";
 import { createPluginsClient } from "./plugin-client";
-import { pluginListQueryKey, pluginSettingsViewQueryKey } from "./query-keys";
+import {
+  pluginAttentionQueryKey,
+  pluginListQueryKey,
+  pluginSettingsViewQueryKey,
+} from "./query-keys";
 
 type FetchLike = typeof fetch;
 
@@ -199,6 +203,20 @@ export function usePluginList(args: { enabled: boolean }) {
   return useQuery({
     queryKey: pluginListQueryKey(args.enabled),
     queryFn: () => fetchPluginList(fetch),
+    enabled: args.enabled,
+    staleTime: 30_000,
+  });
+}
+
+/**
+ * Enabled plugins the server did not load (incompatible after a bb upgrade,
+ * failed, missing). A small server-owned summary, so the sidebar can poll it
+ * on every page load without the full inventory (#1915).
+ */
+export function usePluginAttention(args: { enabled: boolean }) {
+  return useQuery({
+    queryKey: pluginAttentionQueryKey(),
+    queryFn: () => createPluginsClient(fetch).listAttention(),
     enabled: args.enabled,
     staleTime: 30_000,
   });

--- a/apps/app/src/hooks/queries/query-keys.ts
+++ b/apps/app/src/hooks/queries/query-keys.ts
@@ -1162,6 +1162,15 @@ export function allPluginListQueryKeyPrefix() {
   return [PLUGIN_LIST_QUERY_KEY] as const;
 }
 
+/**
+ * Shares the plugin-list prefix on purpose: every writer that refreshes the
+ * list (enable/disable, install, realtime `plugins-changed`) refreshes the
+ * attention summary with it.
+ */
+export function pluginAttentionQueryKey() {
+  return [PLUGIN_LIST_QUERY_KEY, "attention"] as const;
+}
+
 export function pluginSettingsViewQueryKey(pluginId: string) {
   return [PLUGIN_SETTINGS_VIEW_QUERY_KEY, pluginId] as const;
 }

--- a/apps/app/src/hooks/usePluginAttention.test.ts
+++ b/apps/app/src/hooks/usePluginAttention.test.ts
@@ -1,37 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { PluginRuntimeStatus } from "@bb/server-contract";
-import {
-  pluginAttentionLabel,
-  pluginsNeedingAttention,
-} from "./usePluginAttention";
-
-function plugin(id: string, status: PluginRuntimeStatus) {
-  return { id, status };
-}
-
-describe("pluginsNeedingAttention", () => {
-  it("counts only plugins that are enabled but not running", () => {
-    const plugins = [
-      plugin("notify", "incompatible"),
-      plugin("broken", "error"),
-      plugin("gone", "missing"),
-      plugin("ok", "running"),
-      plugin("off", "disabled"),
-      plugin("setup", "needs-configuration"),
-      plugin("slow", "degraded"),
-    ];
-
-    expect(pluginsNeedingAttention(plugins).map((p) => p.id)).toEqual([
-      "notify",
-      "broken",
-      "gone",
-    ]);
-  });
-
-  it("is empty when every plugin runs", () => {
-    expect(pluginsNeedingAttention([plugin("ok", "running")])).toEqual([]);
-  });
-});
+import { pluginAttentionLabel } from "./usePluginAttention";
 
 describe("pluginAttentionLabel", () => {
   it("pluralizes", () => {

--- a/apps/app/src/hooks/usePluginAttention.test.ts
+++ b/apps/app/src/hooks/usePluginAttention.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import type { PluginRuntimeStatus } from "@bb/server-contract";
+import {
+  pluginAttentionLabel,
+  pluginsNeedingAttention,
+} from "./usePluginAttention";
+
+function plugin(id: string, status: PluginRuntimeStatus) {
+  return { id, status };
+}
+
+describe("pluginsNeedingAttention", () => {
+  it("counts only plugins that are enabled but not running", () => {
+    const plugins = [
+      plugin("notify", "incompatible"),
+      plugin("broken", "error"),
+      plugin("gone", "missing"),
+      plugin("ok", "running"),
+      plugin("off", "disabled"),
+      plugin("setup", "needs-configuration"),
+      plugin("slow", "degraded"),
+    ];
+
+    expect(pluginsNeedingAttention(plugins).map((p) => p.id)).toEqual([
+      "notify",
+      "broken",
+      "gone",
+    ]);
+  });
+
+  it("is empty when every plugin runs", () => {
+    expect(pluginsNeedingAttention([plugin("ok", "running")])).toEqual([]);
+  });
+});
+
+describe("pluginAttentionLabel", () => {
+  it("pluralizes", () => {
+    expect(pluginAttentionLabel(1)).toBe("1 plugin needs attention");
+    expect(pluginAttentionLabel(2)).toBe("2 plugins need attention");
+  });
+});

--- a/apps/app/src/hooks/usePluginAttention.ts
+++ b/apps/app/src/hooks/usePluginAttention.ts
@@ -1,32 +1,6 @@
 import { useMemo } from "react";
-import type { PluginRuntimeStatus } from "@bb/server-contract";
-import {
-  usePluginList,
-  type PluginListItem,
-} from "@/hooks/queries/plugin-settings-queries";
-
-/**
- * Runtime statuses that mean an installed, enabled plugin is not doing its
- * job and the user has to act: an `engines.bb` mismatch after a host upgrade,
- * a factory crash, or a deleted plugin directory. `disabled` is a user
- * choice, `needs-configuration` and `degraded` already have their own
- * in-product prompts, so neither counts here (#1915).
- */
-const PLUGIN_ATTENTION_STATUSES: ReadonlySet<PluginRuntimeStatus> =
-  new Set<PluginRuntimeStatus>(["incompatible", "error", "missing"]);
-
-export function pluginNeedsAttention(plugin: {
-  status: PluginRuntimeStatus;
-}): boolean {
-  return PLUGIN_ATTENTION_STATUSES.has(plugin.status);
-}
-
-/** Installed plugins that are not running and need the user to act. */
-export function pluginsNeedingAttention<
-  T extends { status: PluginRuntimeStatus },
->(plugins: readonly T[]): T[] {
-  return plugins.filter(pluginNeedsAttention);
-}
+import type { PluginAttentionEntry } from "@bb/server-contract";
+import { usePluginAttention as usePluginAttentionQuery } from "@/hooks/queries/plugin-settings-queries";
 
 export function pluginAttentionLabel(count: number): string {
   return count === 1
@@ -36,20 +10,26 @@ export function pluginAttentionLabel(count: number): string {
 
 export interface PluginAttention {
   count: number;
-  plugins: PluginListItem[];
+  plugins: PluginAttentionEntry[];
 }
 
 interface UsePluginAttentionOptions {
   enabled?: boolean;
 }
 
+/**
+ * Installed plugins that are enabled but not running. The server decides
+ * which statuses count (`pluginNeedsAttention` in `@bb/server-contract`);
+ * this hook only reads the summary for the sidebar chip and the Extensions
+ * badge.
+ */
 export function usePluginAttention(
   options?: UsePluginAttentionOptions,
 ): PluginAttention {
   const enabled = options?.enabled ?? true;
-  const listQuery = usePluginList({ enabled });
+  const query = usePluginAttentionQuery({ enabled });
   return useMemo(() => {
-    const plugins = pluginsNeedingAttention(listQuery.data?.plugins ?? []);
+    const plugins = query.data?.plugins ?? [];
     return { count: plugins.length, plugins };
-  }, [listQuery.data?.plugins]);
+  }, [query.data?.plugins]);
 }

--- a/apps/app/src/hooks/usePluginAttention.ts
+++ b/apps/app/src/hooks/usePluginAttention.ts
@@ -1,0 +1,55 @@
+import { useMemo } from "react";
+import type { PluginRuntimeStatus } from "@bb/server-contract";
+import {
+  usePluginList,
+  type PluginListItem,
+} from "@/hooks/queries/plugin-settings-queries";
+
+/**
+ * Runtime statuses that mean an installed, enabled plugin is not doing its
+ * job and the user has to act: an `engines.bb` mismatch after a host upgrade,
+ * a factory crash, or a deleted plugin directory. `disabled` is a user
+ * choice, `needs-configuration` and `degraded` already have their own
+ * in-product prompts, so neither counts here (#1915).
+ */
+const PLUGIN_ATTENTION_STATUSES: ReadonlySet<PluginRuntimeStatus> =
+  new Set<PluginRuntimeStatus>(["incompatible", "error", "missing"]);
+
+export function pluginNeedsAttention(plugin: {
+  status: PluginRuntimeStatus;
+}): boolean {
+  return PLUGIN_ATTENTION_STATUSES.has(plugin.status);
+}
+
+/** Installed plugins that are not running and need the user to act. */
+export function pluginsNeedingAttention<
+  T extends { status: PluginRuntimeStatus },
+>(plugins: readonly T[]): T[] {
+  return plugins.filter(pluginNeedsAttention);
+}
+
+export function pluginAttentionLabel(count: number): string {
+  return count === 1
+    ? "1 plugin needs attention"
+    : `${count} plugins need attention`;
+}
+
+export interface PluginAttention {
+  count: number;
+  plugins: PluginListItem[];
+}
+
+interface UsePluginAttentionOptions {
+  enabled?: boolean;
+}
+
+export function usePluginAttention(
+  options?: UsePluginAttentionOptions,
+): PluginAttention {
+  const enabled = options?.enabled ?? true;
+  const listQuery = usePluginList({ enabled });
+  return useMemo(() => {
+    const plugins = pluginsNeedingAttention(listQuery.data?.plugins ?? []);
+    return { count: plugins.length, plugins };
+  }, [listQuery.data?.plugins]);
+}

--- a/apps/app/src/hooks/useUpdateInventory.ts
+++ b/apps/app/src/hooks/useUpdateInventory.ts
@@ -11,6 +11,7 @@ import {
   type ProviderCliIssue,
 } from "@/components/provider-cli/provider-cli-install";
 import { useDesktopUpdateInfo } from "@/hooks/useDesktopUpdateInfo";
+import { usePluginAttention } from "@/hooks/usePluginAttention";
 import { selectPrimaryHost, useHosts } from "@/hooks/queries/host-queries";
 import { hostProviderCliStatusQueryKey } from "@/hooks/queries/query-keys";
 import { SESSION_STATIC_QUERY_POLICY } from "@/hooks/queries/query-policies";
@@ -42,6 +43,12 @@ export interface UpdateInventory {
   /** Desktop shell downloaded an update; a relaunch applies it. */
   desktopUpdateReady: boolean;
   machines: UpdateInventoryMachine[];
+  /**
+   * Installed plugins that are enabled but not running (incompatible, error,
+   * or missing). Not an update, but the same quiet attention surface: an
+   * `engines.bb` mismatch after a bb upgrade otherwise vanishes silently.
+   */
+  pluginAttentionCount: number;
   /** Count of things a user can act on right now. */
   actionableCount: number;
   hasAttention: boolean;
@@ -61,9 +68,10 @@ interface UseUpdateInventoryOptions {
 /**
  * One consolidated view of every update bb knows about: the bb app itself
  * (npm registry / desktop feed) plus provider CLIs on every connected
- * machine. Remote daemons follow the server version automatically via
- * protocol self-update, so per-machine bb rows only surface when a daemon is
- * stuck and needs a manual retry.
+ * machine, plus installed plugins that stopped running. Remote daemons
+ * follow the server version automatically via protocol self-update, so
+ * per-machine bb rows only surface when a daemon is stuck and needs a manual
+ * retry.
  */
 export function useUpdateInventory(
   options?: UseUpdateInventoryOptions,
@@ -73,6 +81,7 @@ export function useUpdateInventory(
   const systemConfigQuery = useSystemConfig({ enabled });
   const hostsQuery = useHosts({ enabled });
   const { desktopInfo, isDesktop } = useDesktopUpdateInfo();
+  const pluginAttention = usePluginAttention({ enabled });
 
   const hosts = useMemo(() => hostsQuery.data ?? [], [hostsQuery.data]);
   const connectedHosts = useMemo(
@@ -140,7 +149,8 @@ export function useUpdateInventory(
       0,
     ) +
     (appUpdateAvailable ? 1 : 0) +
-    (desktopUpdateReady ? 1 : 0);
+    (desktopUpdateReady ? 1 : 0) +
+    pluginAttention.count;
 
   const desktopLastCheckedAt =
     desktopInfo?.lastCheckedAt === null ||
@@ -165,6 +175,7 @@ export function useUpdateInventory(
     appUpdateAvailable,
     desktopUpdateReady,
     machines,
+    pluginAttentionCount: pluginAttention.count,
     actionableCount,
     hasAttention: actionableCount > 0,
     lastCheckedAt,

--- a/apps/cli/src/__tests__/command-output/status.test.ts
+++ b/apps/cli/src/__tests__/command-output/status.test.ts
@@ -94,38 +94,6 @@ describe("bb status command output", () => {
   });
 });
 
-const installedPlugin = (
-  id: string,
-  status: string,
-  statusDetail: string | null,
-  enabled = true,
-) => ({
-  id,
-  source: `path:/plugins/${id}`,
-  rootDir: `/plugins/${id}`,
-  version: "0.2.1",
-  provenance: "direct",
-  publisherLabel: null,
-  isOrphanedBuiltin: false,
-  sourceDisplay: `path · /plugins/${id}`,
-  updateState: {},
-  enabled,
-  description: null,
-  name: null,
-  icon: null,
-  iconUrl: null,
-  status,
-  statusDetail,
-  handlerStats: { count: 0, totalMs: 0, maxMs: 0, errorCount: 0 },
-  services: [],
-  schedules: [],
-  cliCommand: null,
-  hasSettings: false,
-  app: { hasApp: false, bundle: null },
-  logoUrl: null,
-  logoDarkUrl: null,
-});
-
 function jsonResponse(value: object): Response {
   return new Response(JSON.stringify(value), {
     status: 200,
@@ -133,14 +101,20 @@ function jsonResponse(value: object): Response {
   });
 }
 
-function stubServer(plugins: readonly object[]): void {
+function stubServer(
+  attention: ReadonlyArray<{
+    id: string;
+    status: string;
+    statusDetail: string | null;
+  }>,
+): void {
   vi.mocked(fetch).mockImplementation(async (input) => {
     const url = String(input instanceof Request ? input.url : input);
     if (url.endsWith("/api/v1/system/config")) {
       return jsonResponse({ dataDir: "/data/bb" });
     }
-    if (url.endsWith("/api/v1/plugins")) {
-      return jsonResponse({ plugins });
+    if (url.endsWith("/api/v1/plugins/attention")) {
+      return jsonResponse({ plugins: attention });
     }
     throw new Error(`unexpected fetch ${url}`);
   });
@@ -156,17 +130,14 @@ describe("bb status plugin attention", () => {
       () => ({ serverUrl: "http://server" }),
     );
 
-  it("reports enabled plugins the server did not load, grouped by status", async () => {
+  it("reports the server's attention summary, grouped by status", async () => {
     stubServer([
-      installedPlugin("automations", "running", null),
-      installedPlugin(
-        "notify",
-        "incompatible",
-        "requires bb >=0.38.0 <0.39.0, this is 0.39.0",
-      ),
-      installedPlugin("foo", "error", "boom"),
-      // Disabled is a user choice, not a problem.
-      installedPlugin("old", "disabled", null, false),
+      {
+        id: "notify",
+        status: "incompatible",
+        statusDetail: "requires bb >=0.38.0 <0.39.0, this is 0.39.0",
+      },
+      { id: "foo", status: "error", statusDetail: "boom" },
     ]);
 
     await runCommand(["status"], register);
@@ -179,7 +150,7 @@ describe("bb status plugin attention", () => {
   });
 
   it("prints no plugin line when every plugin runs", async () => {
-    stubServer([installedPlugin("automations", "running", null)]);
+    stubServer([]);
 
     await runCommand(["status"], register);
 
@@ -190,11 +161,11 @@ describe("bb status plugin attention", () => {
 
   it("includes the plugins in --json output", async () => {
     stubServer([
-      installedPlugin(
-        "notify",
-        "incompatible",
-        "requires bb >=0.38.0 <0.39.0, this is 0.39.0",
-      ),
+      {
+        id: "notify",
+        status: "incompatible",
+        statusDetail: "requires bb >=0.38.0 <0.39.0, this is 0.39.0",
+      },
     ]);
 
     await runCommand(["status", "--json"], register);

--- a/apps/cli/src/__tests__/command-output/status.test.ts
+++ b/apps/cli/src/__tests__/command-output/status.test.ts
@@ -2,12 +2,16 @@ import { describe, expect, it, vi } from "vitest";
 import {
   setupCommandOutputTestEnvironment,
   collectLogLines,
+  collectLogPayloads,
   runCommand,
   stubServerApi,
 } from "../helpers/command-output-harness.js";
 import type { CommandRegistrar } from "../helpers/command-output-harness.js";
 import * as fixtures from "../helpers/command-output-fixtures.js";
-import { registerStatusCommand } from "../../commands/status.js";
+import {
+  formatPluginAttentionLine,
+  registerStatusCommand,
+} from "../../commands/status.js";
 
 describe("bb status command output", () => {
   setupCommandOutputTestEnvironment();
@@ -87,5 +91,133 @@ describe("bb status command output", () => {
 
     const lines = collectLogLines(vi.mocked(console.log));
     expect(lines.some((line) => line.includes("Pinned:"))).toBe(true);
+  });
+});
+
+const installedPlugin = (
+  id: string,
+  status: string,
+  statusDetail: string | null,
+  enabled = true,
+) => ({
+  id,
+  source: `path:/plugins/${id}`,
+  rootDir: `/plugins/${id}`,
+  version: "0.2.1",
+  provenance: "direct",
+  publisherLabel: null,
+  isOrphanedBuiltin: false,
+  sourceDisplay: `path · /plugins/${id}`,
+  updateState: {},
+  enabled,
+  description: null,
+  name: null,
+  icon: null,
+  iconUrl: null,
+  status,
+  statusDetail,
+  handlerStats: { count: 0, totalMs: 0, maxMs: 0, errorCount: 0 },
+  services: [],
+  schedules: [],
+  cliCommand: null,
+  hasSettings: false,
+  app: { hasApp: false, bundle: null },
+  logoUrl: null,
+  logoDarkUrl: null,
+});
+
+function jsonResponse(value: object): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function stubServer(plugins: readonly object[]): void {
+  vi.mocked(fetch).mockImplementation(async (input) => {
+    const url = String(input instanceof Request ? input.url : input);
+    if (url.endsWith("/api/v1/system/config")) {
+      return jsonResponse({ dataDir: "/data/bb" });
+    }
+    if (url.endsWith("/api/v1/plugins")) {
+      return jsonResponse({ plugins });
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  });
+}
+
+describe("bb status plugin attention", () => {
+  setupCommandOutputTestEnvironment();
+
+  const register: CommandRegistrar = (program) =>
+    registerStatusCommand(
+      program,
+      () => "http://server",
+      () => ({ serverUrl: "http://server" }),
+    );
+
+  it("reports enabled plugins the server did not load, grouped by status", async () => {
+    stubServer([
+      installedPlugin("automations", "running", null),
+      installedPlugin(
+        "notify",
+        "incompatible",
+        "requires bb >=0.38.0 <0.39.0, this is 0.39.0",
+      ),
+      installedPlugin("foo", "error", "boom"),
+      // Disabled is a user choice, not a problem.
+      installedPlugin("old", "disabled", null, false),
+    ]);
+
+    await runCommand(["status"], register);
+
+    const output = collectLogPayloads(vi.mocked(console.log)).join("\n");
+    expect(output).toContain("Data dir: /data/bb");
+    expect(output).toContain(
+      "2 plugins need attention (incompatible: notify; error: foo). Run bb plugin list.",
+    );
+  });
+
+  it("prints no plugin line when every plugin runs", async () => {
+    stubServer([installedPlugin("automations", "running", null)]);
+
+    await runCommand(["status"], register);
+
+    const output = collectLogPayloads(vi.mocked(console.log)).join("\n");
+    expect(output).not.toContain("need attention");
+    expect(output).not.toContain("needs attention");
+  });
+
+  it("includes the plugins in --json output", async () => {
+    stubServer([
+      installedPlugin(
+        "notify",
+        "incompatible",
+        "requires bb >=0.38.0 <0.39.0, this is 0.39.0",
+      ),
+    ]);
+
+    await runCommand(["status", "--json"], register);
+
+    const payload = JSON.parse(collectLogPayloads(vi.mocked(console.log))[0]);
+    expect(payload.pluginsNeedingAttention).toEqual([
+      {
+        id: "notify",
+        status: "incompatible",
+        statusDetail: "requires bb >=0.38.0 <0.39.0, this is 0.39.0",
+      },
+    ]);
+  });
+});
+
+describe("formatPluginAttentionLine", () => {
+  it("uses the singular for one plugin", () => {
+    expect(
+      formatPluginAttentionLine([
+        { id: "notify", status: "incompatible", statusDetail: null },
+      ]),
+    ).toBe(
+      "1 plugin needs attention (incompatible: notify). Run bb plugin list.",
+    );
   });
 });

--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -1,6 +1,9 @@
 import { Command } from "commander";
 import type { ThreadTimelinePendingTodos } from "@bb/domain";
-import type { InstalledPlugin, PluginRuntimeStatus } from "@bb/server-contract";
+import type {
+  PluginAttentionEntry,
+  PluginRuntimeStatus,
+} from "@bb/server-contract";
 import { action } from "../action.js";
 import {
   resolveContextSnapshot,
@@ -38,31 +41,6 @@ interface StatusPayload {
    * upgrade otherwise unloads a plugin with no visible trace (#1915).
    */
   pluginsNeedingAttention: PluginAttentionEntry[] | null;
-}
-
-interface PluginAttentionEntry {
-  id: string;
-  status: PluginRuntimeStatus;
-  statusDetail: string | null;
-}
-
-const PLUGIN_ATTENTION_STATUSES: ReadonlySet<PluginRuntimeStatus> =
-  new Set<PluginRuntimeStatus>(["incompatible", "error", "missing"]);
-
-/** Same bucket the app's sidebar chip counts: enabled but not running. */
-export function pluginsNeedingAttention(
-  plugins: readonly InstalledPlugin[],
-): PluginAttentionEntry[] {
-  return plugins
-    .filter(
-      (plugin) =>
-        plugin.enabled && PLUGIN_ATTENTION_STATUSES.has(plugin.status),
-    )
-    .map((plugin) => ({
-      id: plugin.id,
-      status: plugin.status,
-      statusDetail: plugin.statusDetail,
-    }));
 }
 
 /**
@@ -115,42 +93,45 @@ export function registerStatusCommand(
         };
 
         let serverAvailable = false;
+        const sdk = createCliBbSdk(getUrl());
 
         // Best-effort: the data dir comes from system config (where theme/,
         // plugins, and the DB live). Works without any project/thread context.
-        try {
-          const response = await cliFetch(`${getUrl()}/api/v1/system/config`);
-          if (response.ok) {
+        const dataDirRequest = cliFetch(`${getUrl()}/api/v1/system/config`)
+          .then(async (response) => {
+            if (!response.ok) return null;
             const config = (await response.json()) as { dataDir?: unknown };
-            if (typeof config.dataDir === "string") {
-              payload.dataDir = config.dataDir;
-              serverAvailable = true;
-            }
-          }
-        } catch {
-          // Server unreachable — leave dataDir null.
-        }
+            return typeof config.dataDir === "string" ? config.dataDir : null;
+          })
+          .catch(() => null); // Server unreachable — leave dataDir null.
 
         // Best-effort too: a plugin that silently stopped loading should show
         // up here without the user having to know to run bb plugin list.
-        if (serverAvailable) {
-          try {
-            const list = await createCliBbSdk(getUrl()).plugins.list();
-            payload.pluginsNeedingAttention = pluginsNeedingAttention(
-              list.plugins,
-            );
-          } catch {
-            // Plugin list unavailable — leave null.
-          }
-        }
+        const attentionRequest = sdk.plugins
+          .listAttention()
+          .then((result) => result.plugins)
+          .catch(() => null); // Older server or unreachable — leave null.
+
+        // The context lookup is independent of the two above; start all three
+        // together so `bb status` costs one round trip, not three.
+        const statusRequest =
+          context.projectId || context.threadId
+            ? sdk.status.get({
+                projectId: context.projectId,
+                threadId: context.threadId,
+              })
+            : null;
+        // Mark the rejection handled while the other requests settle; the
+        // `await` below still rethrows it so the user sees the error.
+        statusRequest?.catch(() => {});
+
+        payload.dataDir = await dataDirRequest;
+        if (payload.dataDir !== null) serverAvailable = true;
+        payload.pluginsNeedingAttention = await attentionRequest;
 
         // Try to fetch enriched data from the server
-        if (context.projectId || context.threadId) {
-          const sdk = createCliBbSdk(getUrl());
-          const status = await sdk.status.get({
-            projectId: context.projectId,
-            threadId: context.threadId,
-          });
+        if (statusRequest !== null) {
+          const status = await statusRequest;
 
           if (status.project) {
             payload.project = {

--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import type { ThreadTimelinePendingTodos } from "@bb/domain";
+import type { InstalledPlugin, PluginRuntimeStatus } from "@bb/server-contract";
 import { action } from "../action.js";
 import {
   resolveContextSnapshot,
@@ -31,6 +32,57 @@ interface StatusPayload {
     title: string | null;
   }> | null;
   pendingTodos: ThreadTimelinePendingTodos | null;
+  /**
+   * Enabled plugins the server did not load (incompatible, error, missing).
+   * Null while the server is unreachable. An `engines.bb` mismatch after a bb
+   * upgrade otherwise unloads a plugin with no visible trace (#1915).
+   */
+  pluginsNeedingAttention: PluginAttentionEntry[] | null;
+}
+
+interface PluginAttentionEntry {
+  id: string;
+  status: PluginRuntimeStatus;
+  statusDetail: string | null;
+}
+
+const PLUGIN_ATTENTION_STATUSES: ReadonlySet<PluginRuntimeStatus> =
+  new Set<PluginRuntimeStatus>(["incompatible", "error", "missing"]);
+
+/** Same bucket the app's sidebar chip counts: enabled but not running. */
+export function pluginsNeedingAttention(
+  plugins: readonly InstalledPlugin[],
+): PluginAttentionEntry[] {
+  return plugins
+    .filter(
+      (plugin) =>
+        plugin.enabled && PLUGIN_ATTENTION_STATUSES.has(plugin.status),
+    )
+    .map((plugin) => ({
+      id: plugin.id,
+      status: plugin.status,
+      statusDetail: plugin.statusDetail,
+    }));
+}
+
+/**
+ * One line, grouped by status in a stable order, e.g.
+ * `2 plugins need attention (incompatible: notify; error: foo). Run bb plugin list.`
+ */
+export function formatPluginAttentionLine(
+  entries: readonly PluginAttentionEntry[],
+): string {
+  const byStatus = new Map<PluginRuntimeStatus, string[]>();
+  for (const entry of entries) {
+    const ids = byStatus.get(entry.status) ?? [];
+    ids.push(entry.id);
+    byStatus.set(entry.status, ids);
+  }
+  const groups = [...byStatus.entries()]
+    .map(([status, ids]) => `${status}: ${ids.join(", ")}`)
+    .join("; ");
+  const noun = entries.length === 1 ? "plugin needs" : "plugins need";
+  return `${entries.length} ${noun} attention (${groups}). Run bb plugin list.`;
 }
 
 interface StatusCommandOptions {
@@ -59,6 +111,7 @@ export function registerStatusCommand(
           thread: null,
           childThreads: null,
           pendingTodos: null,
+          pluginsNeedingAttention: null,
         };
 
         let serverAvailable = false;
@@ -76,6 +129,19 @@ export function registerStatusCommand(
           }
         } catch {
           // Server unreachable — leave dataDir null.
+        }
+
+        // Best-effort too: a plugin that silently stopped loading should show
+        // up here without the user having to know to run bb plugin list.
+        if (serverAvailable) {
+          try {
+            const list = await createCliBbSdk(getUrl()).plugins.list();
+            payload.pluginsNeedingAttention = pluginsNeedingAttention(
+              list.plugins,
+            );
+          } catch {
+            // Plugin list unavailable — leave null.
+          }
         }
 
         // Try to fetch enriched data from the server
@@ -177,6 +243,16 @@ export function registerStatusCommand(
         if (payload.dataDir) {
           console.log("");
           console.log(`Data dir: ${payload.dataDir}`);
+        }
+
+        if (
+          payload.pluginsNeedingAttention !== null &&
+          payload.pluginsNeedingAttention.length > 0
+        ) {
+          console.log("");
+          console.log(
+            formatPluginAttentionLine(payload.pluginsNeedingAttention),
+          );
         }
 
         if (!context.projectId && !context.threadId) {

--- a/apps/server/src/routes/plugins.ts
+++ b/apps/server/src/routes/plugins.ts
@@ -195,6 +195,12 @@ export function registerPluginRoutes(
 
   app.get("/plugins", (context) => context.json({ plugins: plugins.list() }));
 
+  // Enabled plugins that are not running. The sidebar chip, the Extensions
+  // badge, and `bb status` poll this instead of the full inventory (#1915).
+  app.get("/plugins/attention", (context) =>
+    context.json({ plugins: plugins.listAttention() }),
+  );
+
   // Fast metadata for the bb CLI's help/proxy path and the app's
   // host-rendered UI contributions: no plugin code runs; empty (not an
   // error) while the experiment is off.

--- a/apps/server/src/services/plugins/plugin-runtime.ts
+++ b/apps/server/src/services/plugins/plugin-runtime.ts
@@ -1282,21 +1282,26 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
       status: PluginRuntimeStatus,
       detail: string,
     ): void {
+      // Every non-running outcome must leave a log line: without one, an
+      // engines mismatch after a host upgrade leaves the plugin gone with
+      // no trace outside the in-memory status (#1915).
       if (previous !== undefined) {
         setStatus(row.id, "running", `reload failed: ${detail}`);
+        logger.warn(
+          `plugin ${row.id} reload failed (kept previous instance): ${detail}`,
+        );
       } else {
         setStatus(row.id, status, detail);
+        logger.warn(`plugin ${row.id} not loaded (${status}): ${detail}`);
       }
     }
     const hung = hungServices.get(row.id);
     if (hung !== undefined && hung.size > 0) {
       // A previous instance's service never stopped; loading now would
       // double-start it (design §3: degraded rather than double-starting).
-      setStatus(
-        row.id,
-        "degraded",
-        `service ${[...hung].join(", ")} did not stop`,
-      );
+      const detail = `service ${[...hung].join(", ")} did not stop`;
+      setStatus(row.id, "degraded", detail);
+      logger.warn(`plugin ${row.id} not loaded (degraded): ${detail}`);
       return;
     }
     try {

--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -44,7 +44,9 @@ import {
 } from "../plugin-catalog/marketplace-publishers.js";
 import { deleteSecretFile, readOrCreateSecretFile } from "@bb/secret-storage";
 import {
+  pluginNeedsAttention,
   ROOT_PLUGIN_SOURCE_SELECTION,
+  type PluginAttentionEntry,
   type PluginCapabilitySummary,
   type PluginSourceSelection,
 } from "@bb/server-contract";
@@ -175,6 +177,12 @@ export interface PluginService {
   /** Dispose all loaded plugins (server shutdown). */
   stop(): Promise<void>;
   list(): PluginListEntry[];
+  /**
+   * Enabled plugins the server did not load (incompatible, error, missing):
+   * the small subset attention surfaces poll for, without the schedule,
+   * publisher, and update-state work `list()` does per row.
+   */
+  listAttention(): PluginAttentionEntry[];
   /** Palettes declared by currently loaded plugins, ordered by plugin id. */
   listThemes(): PluginThemeMeta[];
   /** Read a loaded plugin palette by its globally namespaced id. */
@@ -1295,6 +1303,28 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
     return capabilities;
   }
 
+  function listAttention(): PluginAttentionEntry[] {
+    return listInstalledPlugins(deps.db)
+      .sort((a, b) => a.id.localeCompare(b.id))
+      .flatMap((row) => {
+        // Same fallback as list(): an enabled row with no runtime status yet
+        // is an error ("not loaded"), a disabled one is just disabled.
+        const runtime = statuses.get(row.id);
+        const entry: PluginAttentionEntry = {
+          id: row.id,
+          status: runtime?.status ?? (row.enabled ? "error" : "disabled"),
+          statusDetail: runtime
+            ? runtime.detail
+            : row.enabled
+              ? "not loaded"
+              : null,
+        };
+        return pluginNeedsAttention({ enabled: row.enabled, ...entry })
+          ? [entry]
+          : [];
+      });
+  }
+
   function list(): PluginListEntry[] {
     const scheduleRows = listPluginSchedules(deps.db);
     const rows = listInstalledPlugins(deps.db);
@@ -1591,6 +1621,7 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
     },
 
     list,
+    listAttention,
 
     async install(source, selection) {
       return withPluginOperationLock(REGISTRATION_MUTATION_KEY, async () => {

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -11,6 +11,8 @@ message agents, or inspect projects, providers, and environments.
 ## Start With Context
 
 - Use `bb status` to identify the current project, thread, and environment.
+  It also lists enabled plugins that are not running (incompatible, error,
+  missing); `bb plugin list` shows each plugin's status detail.
 - Prefer `--json` when command output will drive follow-up work.
 - Run `bb guide` for the system overview and `bb guide <chapter>` for full
   command reference.

--- a/apps/server/test/services/plugins/plugin-service.test.ts
+++ b/apps/server/test/services/plugins/plugin-service.test.ts
@@ -551,6 +551,60 @@ describe("plugin service", () => {
     expect(service.getApi("vanishing")).toBeDefined();
   });
 
+  it("logs a warning when a host upgrade makes an installed plugin incompatible (#1915)", async () => {
+    const lines: string[] = [];
+    const push = (level: string) => (message: unknown) => {
+      lines.push(`${level} ${String(message)}`);
+    };
+    const capturing = {
+      debug: push("debug"),
+      info: push("info"),
+      warn: push("warn"),
+      error: push("error"),
+    } as unknown as Logger;
+    const makeService = (appVersion: string) =>
+      createPluginService({
+        telemetry: createNoopTelemetryService(),
+        db,
+        hub: {
+          getDaemonSessionIdForHost: () => null,
+          notifyPluginSignal: () => 0,
+          notifySystem: () => {},
+        },
+        logger: capturing,
+        dataDir: join(workDir, "data"),
+        appVersion,
+        loadTimeoutMs: 2000,
+      });
+    const rootDir = await writePlugin(workDir, {
+      name: "bb-plugin-notify",
+      version: "0.2.1",
+      engines: ">=0.38.0 <0.39.0",
+      serverSource: `export default function plugin() {}`,
+    });
+
+    // bb 0.38.5: the plugin installs, loads, and the server logs it.
+    const before = makeService("0.38.5");
+    const installed = await before.installPath(rootDir);
+    expect(installed.status).toBe("running");
+    expect(lines).toContain("info plugin notify@0.2.1 loaded");
+    await before.stop();
+    lines.length = 0;
+
+    // bb 0.39.0 starts against the same database (= the user upgraded bb).
+    const after = makeService("0.39.0");
+    await after.start();
+    const entry = after.list().find((p) => p.id === "notify");
+    expect(entry?.status).toBe("incompatible");
+    expect(entry?.statusDetail).toBe(
+      "requires bb >=0.38.0 <0.39.0, this is 0.39.0",
+    );
+    expect(lines).toContain(
+      "warn plugin notify not loaded (incompatible): requires bb >=0.38.0 <0.39.0, this is 0.39.0",
+    );
+    await after.stop();
+  });
+
   it("skips the engines gate on 0.0.0 dev builds instead of marking everything incompatible", async () => {
     const devService = createPluginService({
       telemetry: createNoopTelemetryService(),

--- a/apps/server/test/services/plugins/plugin-service.test.ts
+++ b/apps/server/test/services/plugins/plugin-service.test.ts
@@ -602,6 +602,19 @@ describe("plugin service", () => {
     expect(lines).toContain(
       "warn plugin notify not loaded (incompatible): requires bb >=0.38.0 <0.39.0, this is 0.39.0",
     );
+    // The attention summary (GET /plugins/attention) names the plugin with
+    // its status and detail, and drops it once the user disables it.
+    const attention = () =>
+      after.listAttention().filter((plugin) => plugin.id === "notify");
+    expect(attention()).toEqual([
+      {
+        id: "notify",
+        status: "incompatible",
+        statusDetail: "requires bb >=0.38.0 <0.39.0, this is 0.39.0",
+      },
+    ]);
+    await after.setEnabled("notify", false);
+    expect(attention()).toEqual([]);
     await after.stop();
   });
 

--- a/packages/sdk/src/areas/plugins.ts
+++ b/packages/sdk/src/areas/plugins.ts
@@ -13,6 +13,7 @@ import {
   pluginMarketplaceRemoveResponseSchema,
   pluginApplyUpdateRequestSchema,
   pluginApplyUpdateResultSchema,
+  pluginAttentionResponseSchema,
   pluginInstallResponseSchema,
   pluginInstallSourceRequestSchema,
   pluginListResponseSchema,
@@ -33,6 +34,7 @@ import {
   type PluginMarketplaceRefreshResult as PluginMarketplaceRefreshContract,
   type PluginCatalogStatus as PluginCatalogStatusContract,
   type PluginApplyUpdateResult as PluginApplyUpdateContract,
+  type PluginAttentionResponse,
   type PluginListResponse,
   type PluginReloadResponse,
   type PluginRemoveResponse,
@@ -163,11 +165,16 @@ export interface PluginListUpdateResultsArgs {
   signal?: AbortSignal;
 }
 
+export interface PluginAttentionArgs {
+  signal?: AbortSignal;
+}
+
 export type PluginDisableResult = InstalledPlugin;
 export type PluginEnableResult = InstalledPlugin;
 export type PluginGetSettingsResult = PluginSettingsResponse;
 export type PluginInstallResult = InstalledPlugin;
 export type PluginListResult = PluginListResponse;
+export type PluginAttentionResult = PluginAttentionResponse;
 export type PluginReloadResult = PluginReloadResponse;
 export type PluginRemoveResult = PluginRemoveResponse;
 export type PluginTokenResult = PluginTokenResponse;
@@ -224,6 +231,8 @@ export interface PluginsArea {
   getSource(args: PluginGetSourceArgs): Promise<PluginGetSourceResult>;
   install(args: PluginInstallArgs): Promise<PluginInstallResult>;
   list(args?: PluginListArgs): Promise<PluginListResult>;
+  /** Enabled plugins the server did not load (incompatible, error, missing). */
+  listAttention(args?: PluginAttentionArgs): Promise<PluginAttentionResult>;
   listUpdateResults(
     args?: PluginListUpdateResultsArgs,
   ): Promise<PluginCheckUpdatesResult>;
@@ -451,6 +460,13 @@ export function createPluginsArea(args: CreateSdkAreaArgs): PluginsArea {
       return requestParsed("/api/v1/plugins", pluginListResponseSchema, {
         signal: input.signal,
       });
+    },
+    async listAttention(input = {}) {
+      return requestParsed(
+        "/api/v1/plugins/attention",
+        pluginAttentionResponseSchema,
+        { signal: input.signal },
+      );
     },
     async listUpdateResults(input = {}) {
       const response = await requestParsed(

--- a/packages/sdk/test/public-types.test.ts
+++ b/packages/sdk/test/public-types.test.ts
@@ -294,6 +294,7 @@ type ExpectedPluginsKey =
   | "getSource"
   | "install"
   | "list"
+  | "listAttention"
   | "listUpdateResults"
   | "marketplaces"
   | "reload"

--- a/packages/server-contract/src/api/plugins.ts
+++ b/packages/server-contract/src/api/plugins.ts
@@ -226,6 +226,47 @@ export const pluginListResponseSchema = z.object({
 export type PluginListResponse = z.infer<typeof pluginListResponseSchema>;
 
 /**
+ * Runtime statuses that mean an enabled plugin is not doing its job and the
+ * user has to act: an `engines.bb` mismatch after a bb upgrade, a factory
+ * crash, or a deleted plugin directory. `disabled` is a user choice, and
+ * `needs-configuration` and `degraded` have their own in-product prompts, so
+ * neither counts (#1915). The server applies this policy in
+ * `GET /plugins/attention`; the app and CLI read the result.
+ */
+export const PLUGIN_ATTENTION_STATUSES = [
+  "incompatible",
+  "error",
+  "missing",
+] as const satisfies readonly PluginRuntimeStatus[];
+
+export function pluginNeedsAttention(plugin: {
+  enabled: boolean;
+  status: PluginRuntimeStatus;
+}): boolean {
+  return (
+    plugin.enabled &&
+    (PLUGIN_ATTENTION_STATUSES as readonly PluginRuntimeStatus[]).includes(
+      plugin.status,
+    )
+  );
+}
+
+export const pluginAttentionEntrySchema = z.object({
+  id: z.string(),
+  status: pluginRuntimeStatusSchema,
+  statusDetail: z.string().nullable(),
+});
+export type PluginAttentionEntry = z.infer<typeof pluginAttentionEntrySchema>;
+
+/** Enabled plugins the server did not load; a small subset of the list. */
+export const pluginAttentionResponseSchema = z.object({
+  plugins: z.array(pluginAttentionEntrySchema),
+});
+export type PluginAttentionResponse = z.infer<
+  typeof pluginAttentionResponseSchema
+>;
+
+/**
  * Which plugin of a source an install selects. A repository can hold several
  * plugins, indexed by a `.bb/plugins.json` collection manifest: "subdirectory"
  * is the primitive, "entry" resolves a manifest entry name, and "root" installs

--- a/packages/templates/src/templates/bb-guide-overview.md
+++ b/packages/templates/src/templates/bb-guide-overview.md
@@ -26,6 +26,8 @@ Context variables set automatically inside a thread environment:
 - BB_CLI — absolute path to the daemon-managed `bb` executable (prefer this if bare `bb` is wrong; official entrypoints also re-exec to it)
 
 Run `bb status` to see your current context (resolved project and thread IDs).
+It also warns when an enabled plugin is not running (incompatible after a bb
+upgrade, failed to load, or missing); run `bb plugin list` for the detail.
 
 All commands support --json for machine-readable output.
 

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -204,7 +204,9 @@ added/updated/unchanged counts.
                                  install (--yes skips; non-TTY refuses without
                                  --yes). Use outdated to preview; pinned
                                  installs stay put
-  bb plugin list                 Status, services, schedules, handler timings
+  bb plugin list                 Status, services, schedules, handler timings.
+                                 `bb status` also names enabled plugins that
+                                 are incompatible, failed, or missing
   bb plugin source <id> [--json] Show requested/resolved source, subdirectory,
                                  semver range with its tag prefix and resolved
                                  tag, engine ranges, install time, and recent


### PR DESCRIPTION
## What was wrong

A plugin that declares an `engines.bb` range (for example `>=0.38.0 <0.39.0`) stops loading as soon as bb is upgraded past that range. The server computed the right verdict (`status: "incompatible"`, `statusDetail: "requires bb >=0.38.0 <0.39.0, this is 0.39.0"`), but `loadOne()`'s pre-factory failure branch (`failBeforeFactory` in `apps/server/src/services/plugins/plugin-runtime.ts`) only called `setStatus()` and returned. A successful load logs `plugin <id>@<v> loaded` and a factory crash logs `plugin <id> failed to load: …`, but an engines mismatch, a missing directory, or a manifest error logged nothing. No app or CLI surface aggregated or volunteered the status either: the home screen and the Extensions nav showed nothing, the Installed plugins row still read as enabled (toggle ON) with only a small red dot on the logo, and `bb status` said nothing. The plugin's contributions simply vanished. Report: https://get-bb.github.io/reports/issues/1915.html (reproduction report for #1915).

## What changed

1. **Server** (`apps/server/src/services/plugins/plugin-runtime.ts`): `failBeforeFactory` now logs `plugin <id> not loaded (<status>): <detail>` (and `plugin <id> reload failed (kept previous instance): <detail>` for the reload case). The hung-service `degraded` branch logs `plugin <id> not loaded (degraded): <detail>`. Every non-running load outcome now leaves a log line. Test added in `apps/server/test/services/plugins/plugin-service.test.ts` (install on 0.38.5 → start on 0.39.0 → expect the warning).
2. **Attention summary + app attention model**: new `GET /api/v1/plugins/attention` (`apps/server/src/routes/plugins.ts`, `PluginService.listAttention()`) returns `{ plugins: [{ id, status, statusDetail }] }` for enabled plugins with status `incompatible | error | missing`; the policy is `pluginNeedsAttention` in `@bb/server-contract`, and the SDK exposes `plugins.listAttention()`. `apps/app/src/hooks/usePluginAttention.ts` / `useUpdateInventory.ts` read that summary (`pluginAttentionCount`) instead of the full plugin inventory, which the deferred plugin frontend boot already fetches. `SidebarUpdatesBadge.tsx` renders one extra chip, "1 plugin needs attention" / "N plugins need attention", that links to Extensions → Installed plugins. `PluginNavSidebarItems.tsx` shows a count badge on the built-in Extensions row (theme tokens `bg-warning/15 text-warning-text`). Unit tests cover the count derivation, the chip, and the badge.
3. **Installed plugins row** (`apps/app/src/components/plugin/management/InstalledPluginsTab.tsx`): the status word sits beside the plugin name, the server's `statusDetail` replaces the description, and the enable switch is marked "not running" (its accessible name says `Disable notify (incompatible, not running)`), so an ON switch never claims a plugin works. `needs-configuration`/`degraded` keep the status word and detail but are not called "not running". Test added.
4. **CLI** (`apps/cli/src/commands/status.ts`): `bb status` reads the attention summary (started together with the config and context requests) and prints `N plugins need attention (incompatible: notify; error: foo). Run bb plugin list.` when any enabled plugin is not running, and `--json` gains `pluginsNeedingAttention`. Guide templates (`bb-guide-overview.md`, `bb-guide-plugins.md`, regenerated) and the bb-cli skill are updated per `docs/cli-guide-and-skill.md`. Tests added in `apps/cli/src/__tests__/command-output/status.test.ts`.

No wire change between the server and the host daemon, so `HOST_DAEMON_PROTOCOL_VERSION` is not bumped. The new route is server ↔ app/CLI only; an older server without it leaves `bb status` silent on plugins (best-effort request).

SlopCop review (two performance findings: second full inventory request on app load, and a serial full inventory request in `bb status`) addressed in the second commit by adding the summary route above.

## How you verified

Server test fails before / passes after (`apps/server`, `vitest run test/services/plugins/plugin-service.test.ts -t 1915`):

```
before: × logs a warning when a host upgrade makes an installed plugin incompatible (#1915)
        AssertionError: expected [ …(13) ] to include 'warn plugin notify not loaded (incomp…'
after:  Tests  1 passed | 22 skipped (23)
```

`pnpm exec turbo run typecheck test --filter=@bb/server --filter=@bb/app --filter=@bb/cli --filter=@bb/templates`: typecheck green; `@bb/app` 3105 passed, `@bb/cli` 454 passed, `@bb/templates` 44 passed, `@bb/server` 1773 passed. Three server failures were load/env related and not from this change: two 5 s timeouts in `plugin-service.test.ts` under the full parallel run (the file passes 23/23 alone), and `internal-skill-trees.test.ts` which also fails on the base commit on this machine (umask 0002 → file mode 436 vs 420). Lint: 0 errors.

Reproduced after the fix on a dev instance: start with `BB_APP_VERSION=0.38.5`, `bb plugin install /tmp/bb-1915-notify --yes` (running), stop, restart with `BB_APP_VERSION=0.39.0`.

Server log:

```
[19:59:25] WARN: [server] plugin notify not loaded (incompatible): requires bb >=0.38.0 <0.39.0, this is 0.39.0
```

`bb status`:

```
Project: proj_personal

Thread: (not set)

Data dir: /home/sawyer/.bb-dev/bb-worktrees-env_84gnh597zf-bb-08942bb65f4b

1 plugin needs attention (incompatible: notify). Run bb plugin list.
```

Screenshots (saved under `/home/sawyer/.bb/thread-storage/thr_xdry6hxdgt/1915-shots/` and `/tmp/1915-shots/` on the dev machine):

- `1915-a-footer-chip.png` — sidebar footer chip "1 plugin needs attention"
- `1915-b-extensions-badge.png` — Extensions nav row with the count badge
- `1915-c-installed-row.png` / `1915-c-installed-scrolled.png` — Installed plugins row: "Notify **Incompatible** / requires bb >=0.38.0 <0.39.0, this is 0.39.0 / not running [switch]"
- `1915-home-after.png` — home screen with both surfaces

Fixes #1915

> AGENT GENERATED: by Claude Opus 5
