### PR TITLE
Keep markdown table breakout inside the nearest clipping ancestor

### DIFF
--- a/apps/app/src/components/ui/markdown-preview.test.tsx
+++ b/apps/app/src/components/ui/markdown-preview.test.tsx
@@ -74,6 +74,67 @@ describe("MarkdownPreview", () => {
     expect(breakout?.style.getPropertyValue("--md-content-w")).toBe("320px");
   });
 
+  it("caps the table breakout at the nearest horizontally clipped ancestor", () => {
+    class ResizeObserverMock {
+      constructor(_callback: ResizeObserverCallback) {}
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    // Every element is 300px wide at x=100 unless it sets data-left/data-width.
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        const left = Number(this.dataset.left ?? 100);
+        const width = Number(this.dataset.width ?? 300);
+        return {
+          bottom: 10,
+          height: 10,
+          left,
+          right: left + width,
+          top: 0,
+          width,
+          x: left,
+          y: 0,
+          toJSON: () => ({}),
+        };
+      },
+    );
+    vi.spyOn(Element.prototype, "clientWidth", "get").mockImplementation(
+      function (this: Element) {
+        return Number((this as HTMLElement).dataset.width ?? 300);
+      },
+    );
+
+    const renderClipped = (clipWidth: number) =>
+      render(
+        <div
+          data-left="0"
+          data-width={String(clipWidth)}
+          style={{ overflowX: "hidden" }}
+        >
+          <MarkdownPreview content={"| A |\n| - |\n| B |"} />
+        </div>,
+      );
+
+    // The clip ends where the content ends: no room on the right, no breakout.
+    const flush = renderClipped(400);
+    const flushBreakout =
+      flush.container.querySelector("table")?.parentElement?.parentElement;
+    expect(
+      flushBreakout?.style.getPropertyValue("--md-table-breakout-max"),
+    ).toBe("300px");
+    flush.unmount();
+
+    // 100px free on the left and 200px on the right: grow by the smaller side.
+    const roomy = renderClipped(600);
+    const roomyBreakout =
+      roomy.container.querySelector("table")?.parentElement?.parentElement;
+    expect(
+      roomyBreakout?.style.getPropertyValue("--md-table-breakout-max"),
+    ).toBe("500px");
+  });
+
   it("keeps the starting number of an ordered list", () => {
     const { container } = render(
       <MarkdownPreview content={"> 2. What happens if debt is unpaid?"} />,

--- a/apps/app/src/components/ui/markdown-preview.test.tsx
+++ b/apps/app/src/components/ui/markdown-preview.test.tsx
@@ -133,6 +133,71 @@ describe("MarkdownPreview", () => {
     expect(
       roomyBreakout?.style.getPropertyValue("--md-table-breakout-max"),
     ).toBe("500px");
+    roomy.unmount();
+
+    // The preview root itself clips: the table must not leave the preview.
+    const sheet = document.createElement("style");
+    sheet.textContent = ".overflow-x-hidden { overflow-x: hidden; }";
+    document.head.appendChild(sheet);
+    const rooted = render(
+      <div data-left="0" data-width="600">
+        <MarkdownPreview
+          className="overflow-x-hidden"
+          content={"| A |\n| - |\n| B |"}
+        />
+      </div>,
+    );
+    const rootedBreakout =
+      rooted.container.querySelector("table")?.parentElement?.parentElement;
+    expect(
+      rootedBreakout?.style.getPropertyValue("--md-table-breakout-max"),
+    ).toBe("300px");
+    sheet.remove();
+  });
+
+  it("skips height-only resize events for tables", () => {
+    let callback: ResizeObserverCallback | null = null;
+    class ResizeObserverMock {
+      constructor(cb: ResizeObserverCallback) {
+        callback = cb;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    let width = 320;
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      () => ({
+        bottom: 0,
+        height: 0,
+        left: 0,
+        right: width,
+        top: 0,
+        width,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }),
+    );
+
+    const { container } = render(
+      <MarkdownPreview content={"| A |\n| - |\n| B |"} />,
+    );
+    const breakout = container.querySelector("table")?.parentElement
+      ?.parentElement as HTMLElement;
+    expect(breakout.style.getPropertyValue("--md-content-w")).toBe("320px");
+    expect(callback).not.toBeNull();
+
+    // Same width, different height: no style write.
+    breakout.style.setProperty("--md-content-w", "sentinel");
+    callback!([], {} as ResizeObserver);
+    expect(breakout.style.getPropertyValue("--md-content-w")).toBe("sentinel");
+
+    // A width change re-measures.
+    width = 480;
+    callback!([], {} as ResizeObserver);
+    expect(breakout.style.getPropertyValue("--md-content-w")).toBe("480px");
   });
 
   it("keeps the starting number of an ordered list", () => {

--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -300,7 +300,13 @@ type MarkdownTableHeaderProps = ComponentPropsWithoutRef<"th"> & ExtraProps;
 type MarkdownUnorderedListProps = ComponentPropsWithoutRef<"ul"> & ExtraProps;
 type MarkdownRehypePlugins = NonNullable<ReactMarkdownOptions["rehypePlugins"]>;
 
-const MARKDOWN_TABLE_BREAKOUT_WIDTH = "max(100%, min(1100px, 100cqw - 2rem))";
+// A table may grow past its text column up to the container width, but never
+// past the nearest ancestor that clips or scrolls horizontally. The limit
+// variable is measured in `useMarkdownTableContentWidthVariable`; without it a
+// negative `marginInline` moves the table left of the scroll origin, where no
+// scroll can reach it (plan approval cards, message bubbles, side chat).
+const MARKDOWN_TABLE_BREAKOUT_LIMIT_VARIABLE = "--md-table-breakout-max";
+const MARKDOWN_TABLE_BREAKOUT_WIDTH = `max(100%, min(1100px, 100cqw - 2rem, var(${MARKDOWN_TABLE_BREAKOUT_LIMIT_VARIABLE}, 100cqw)))`;
 const MARKDOWN_CONTENT_WIDTH_VARIABLE = "--md-content-w";
 const MARKDOWN_SOURCE_COLOR_SCHEME_MEDIA_PATTERN =
   /^\(\s*prefers-color-scheme\s*:\s*(dark|light)\s*\)$/iu;
@@ -1373,31 +1379,104 @@ function useMarkdownTableContentWidthVariable() {
     if (!breakout || !content) {
       return;
     }
+    const clip = findHorizontalClipAncestor(content);
 
-    setMarkdownContentWidthVariable({
-      element: breakout,
-      width: content.getBoundingClientRect().width,
-    });
+    const measure = () => {
+      setMarkdownContentWidthVariable({
+        element: breakout,
+        width: content.getBoundingClientRect().width,
+      });
+      setMarkdownTableBreakoutLimitVariable({ breakout, clip });
+    };
+    measure();
 
     if (typeof ResizeObserver === "undefined") {
       return;
     }
 
-    const observer = new ResizeObserver((entries) => {
-      const entry = entries[0];
-      if (!entry) {
-        return;
-      }
-      setMarkdownContentWidthVariable({
-        element: breakout,
-        width: entry.contentRect.width,
-      });
-    });
+    const observer = new ResizeObserver(measure);
     observer.observe(content);
+    if (clip) {
+      observer.observe(clip);
+    }
     return () => observer.disconnect();
   }, []);
 
   return breakoutRef;
+}
+
+const HORIZONTAL_CLIP_OVERFLOW_VALUES = new Set([
+  "hidden",
+  "clip",
+  "auto",
+  "scroll",
+]);
+
+/**
+ * The nearest ancestor whose horizontal overflow is clipped or scrolled. A
+ * table breakout that extends past this element's padding box is lost: the
+ * clipped side is invisible and a scroll container cannot scroll to a
+ * negative offset.
+ */
+function findHorizontalClipAncestor(element: HTMLElement): HTMLElement | null {
+  let current = element.parentElement;
+  while (current && current !== document.body) {
+    if (
+      HORIZONTAL_CLIP_OVERFLOW_VALUES.has(getComputedStyle(current).overflowX)
+    ) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}
+
+/**
+ * Sets the widest breakout that keeps the table inside `clip`. The breakout is
+ * centered on its containing block (the breakout's parent), so the usable
+ * width is the parent content width plus twice the smaller side gap.
+ */
+function setMarkdownTableBreakoutLimitVariable({
+  breakout,
+  clip,
+}: {
+  breakout: HTMLElement;
+  clip: HTMLElement | null;
+}): void {
+  const parent = breakout.parentElement;
+  if (!clip || !parent) {
+    breakout.style.removeProperty(MARKDOWN_TABLE_BREAKOUT_LIMIT_VARIABLE);
+    return;
+  }
+  // Positions are taken at scroll offset 0 of `clip`, so a horizontally
+  // scrolled container does not change the result.
+  const parentStyle = getComputedStyle(parent);
+  const parentPaddingLeft =
+    parent.getBoundingClientRect().left + parent.clientLeft + clip.scrollLeft;
+  const parentLeft = parentPaddingLeft + cssPixels(parentStyle.paddingLeft);
+  const parentRight =
+    parentPaddingLeft +
+    parent.clientWidth -
+    cssPixels(parentStyle.paddingRight);
+  const parentWidth = parentRight - parentLeft;
+  if (parentWidth <= 0) {
+    return;
+  }
+  const clipLeft = clip.getBoundingClientRect().left + clip.clientLeft;
+  const clipRight = clipLeft + clip.clientWidth;
+  const room = Math.max(
+    0,
+    Math.min(parentLeft - clipLeft, clipRight - parentRight),
+  );
+  breakout.style.setProperty(
+    MARKDOWN_TABLE_BREAKOUT_LIMIT_VARIABLE,
+    `${parentWidth + 2 * room}px`,
+  );
+}
+
+function cssPixels(value: string): number {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 const FRONTMATTER_PATTERN =

--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -1381,10 +1381,22 @@ function useMarkdownTableContentWidthVariable() {
     }
     const clip = findHorizontalClipAncestor(content);
 
+    // Streamed text grows the preview and the clip ancestor in height only.
+    // Skip those events: every table would otherwise read layout and write a
+    // style, and the write forces the next table's read to recalculate.
+    let lastContentWidth = -1;
+    let lastClipWidth = -1;
     const measure = () => {
+      const contentWidth = content.getBoundingClientRect().width;
+      const clipWidth = clip?.clientWidth ?? -1;
+      if (contentWidth === lastContentWidth && clipWidth === lastClipWidth) {
+        return;
+      }
+      lastContentWidth = contentWidth;
+      lastClipWidth = clipWidth;
       setMarkdownContentWidthVariable({
         element: breakout,
-        width: content.getBoundingClientRect().width,
+        width: contentWidth,
       });
       setMarkdownTableBreakoutLimitVariable({ breakout, clip });
     };
@@ -1413,13 +1425,14 @@ const HORIZONTAL_CLIP_OVERFLOW_VALUES = new Set([
 ]);
 
 /**
- * The nearest ancestor whose horizontal overflow is clipped or scrolled. A
- * table breakout that extends past this element's padding box is lost: the
- * clipped side is invisible and a scroll container cannot scroll to a
- * negative offset.
+ * The nearest element, starting at `element` itself, whose horizontal overflow
+ * is clipped or scrolled. A table breakout that extends past this element's
+ * padding box is lost: the clipped side is invisible and a scroll container
+ * cannot scroll to a negative offset. The preview root counts because callers
+ * can clip it through `className`.
  */
 function findHorizontalClipAncestor(element: HTMLElement): HTMLElement | null {
-  let current = element.parentElement;
+  let current: HTMLElement | null = element;
   while (current && current !== document.body) {
     if (
       HORIZONTAL_CLIP_OVERFLOW_VALUES.has(getComputedStyle(current).overflowX)


### PR DESCRIPTION
## What was wrong

`MarkdownTable` widens every table to `max(100%, min(1100px, 100cqw - 2rem))` and centers it with a negative `marginInline`. That is fine in the main chat column, where the page scroller has spare room on both sides. Inside a container that clips or scrolls horizontally — the Plan approval card (`overflow-auto`), a user message bubble (`overflow-hidden`), the side chat panel — the negative margin moves the first columns left of the scroll origin. A scroll container cannot reach a negative offset, so those columns are gone. Reported on Discord ("Tables in Plan view overflowing — no way to see the left column") and reproduced in #1951.

## What changed

- `apps/app/src/components/ui/markdown-preview.tsx`: the existing `useMarkdownTableContentWidthVariable` hook now also finds the nearest ancestor whose `overflow-x` is `hidden`, `clip`, `auto`, or `scroll`, measures how much room the breakout's containing block has on each side inside that ancestor's padding box, and writes `--md-table-breakout-max` on the breakout element. The breakout width formula adds this variable to its `min()`, with `100cqw` as the fallback when no clip ancestor exists. The observer also watches the clip ancestor so the limit follows pane resizes.
- No behavior change in the main chat column: at 1280px the assistant table still measures a 928px breakout (`100cqw - 2rem`) with a 960px limit.

## How you verified

- New test in `markdown-preview.test.tsx`: a table inside an `overflow-x: hidden` container gets `--md-table-breakout-max` equal to the content width when there is no room, and content width plus twice the smaller side gap when there is. Fails before (the variable is never set), passes after.
- `pnpm exec turbo run typecheck --filter=@bb/app`, `vitest run src/components/ui/markdown-preview.test.tsx` (16 passed), eslint on both files.
- Manual, dev app at 1280×900 with the #1951 repro threads:
  - User bubble: before `marginLeft: -236px`, first column hidden; after `-0.2px`, table inside the bubble.
  - Plan card with a table in a list item: before `-24px` and the card scrolled horizontally (`scrollWidth` 704 / `clientWidth` 692); after `-12px`, `scrollWidth == clientWidth == 692`, all columns visible. ![plan card after](https://raw.githubusercontent.com/get-bb/reports/main/issues/assets/1951-fixed-plan-card.png)
  - Side chat plan card: before table started 8px left of the card; after flush inside.
  - Main chat assistant table: breakout unchanged (928px wide, limit 960px). ![main chat after](https://raw.githubusercontent.com/get-bb/reports/main/issues/assets/1951-fixed-main-chat.png)

Fixes #1951

> AGENT GENERATED: by Claude Opus 5
