### PR TITLE
Tint marketplace catalog SVG icons so they stay visible on dark themes

### DIFF
--- a/apps/app/src/components/plugin/management/AddPluginDialog.test.tsx
+++ b/apps/app/src/components/plugin/management/AddPluginDialog.test.tsx
@@ -222,6 +222,7 @@ describe("AddPluginDialog", () => {
       displayName: "Linear",
       icon: "Github",
       iconUrl: null,
+      iconTinted: false,
       source: "builtin:linear",
     });
     expect(
@@ -238,6 +239,7 @@ describe("AddPluginDialog", () => {
       displayName: "Thread Hover Cards",
       icon: "Github",
       iconUrl: null,
+      iconTinted: false,
       source: "git:https://github.com/brsbl/bb-plugins@b173b67",
     });
     expect(
@@ -255,6 +257,7 @@ describe("AddPluginDialog", () => {
       displayName: "Widgets",
       icon: "Zap",
       iconUrl: null,
+      iconTinted: false,
       source: "npm:bb-plugin-widgets@^1.0.0",
     });
     expect(
@@ -273,6 +276,7 @@ describe("AddPluginDialog", () => {
       displayName: "Widgets",
       icon: "Zap",
       iconUrl: null,
+      iconTinted: false,
       marketplace: "bb-community",
       publisherLabel: "BB Community",
       source: "npm:bb-plugin-widgets@^1.0.0 (registry https://npm.acme.test)",
@@ -294,6 +298,7 @@ describe("AddPluginDialog", () => {
       displayName: "Linear",
       icon: "Github",
       iconUrl: null,
+      iconTinted: false,
       source: "builtin:linear",
     });
 
@@ -325,6 +330,7 @@ describe("AddPluginDialog", () => {
       displayName: "Widgets",
       icon: null,
       iconUrl,
+      iconTinted: false,
       source: "npm:bb-plugin-widgets@1.0.0",
     });
 
@@ -349,6 +355,7 @@ describe("AddPluginDialog", () => {
           displayName: "Linear",
           icon: "Github",
           iconUrl: null,
+          iconTinted: false,
           source: "builtin:linear",
         }}
         onInstalled={(plugin) => {
@@ -404,6 +411,7 @@ describe("AddPluginDialog", () => {
       displayName: "Acme Notes",
       icon: "Zap",
       iconUrl: null,
+      iconTinted: false,
       source: "git:https://github.com/acme/plugins.git@semver:^1.0.0",
     });
 
@@ -451,6 +459,7 @@ describe("AddPluginDialog", () => {
       displayName: "Linear",
       icon: "Github",
       iconUrl: null,
+      iconTinted: false,
       source: "builtin:linear",
     });
 

--- a/apps/app/src/components/plugin/management/AddPluginDialog.tsx
+++ b/apps/app/src/components/plugin/management/AddPluginDialog.tsx
@@ -44,6 +44,7 @@ export type AddPluginInitial = {
   displayName: string;
   icon: string | null;
   iconUrl: string | null;
+  iconTinted: boolean;
   /** The entry's install source; decides how the dialog describes the install. */
   source: string;
 };

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
@@ -31,6 +31,7 @@ const MEMORY_ENTRY: PluginCatalogSearchEntry = {
   description: "Provider-independent durable memory for agents.",
   icon: "Brain",
   iconUrl: null,
+  iconTinted: false,
   category: "Context & knowledge",
   source: "builtin:memory",
   marketplaceDisplayName: "BB Community",
@@ -68,6 +69,7 @@ const GITHUB_ENTRY: PluginCatalogSearchEntry = {
   description: "Browse GitHub issues and pull requests in BB.",
   icon: "Github",
   iconUrl: null,
+  iconTinted: false,
   category: "Developer tools",
   source: "builtin:github",
 };
@@ -443,6 +445,7 @@ describe("BrowsePluginsTab", () => {
       displayName: "Memory",
       icon: "Brain",
       iconUrl: null,
+      iconTinted: false,
       source: "builtin:memory",
     });
     fireEvent.click(

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
@@ -427,6 +427,7 @@ function BrowseCard({
             displayName: entry.displayName,
             icon: entry.icon,
             iconUrl: entry.iconUrl,
+            iconTinted: entry.iconTinted,
             source: entry.source,
           })
         }

--- a/apps/app/src/components/plugin/management/plugin-ui.test.tsx
+++ b/apps/app/src/components/plugin/management/plugin-ui.test.tsx
@@ -6,14 +6,15 @@ import { CatalogEntryIcon } from "./plugin-ui";
 
 afterEach(cleanup);
 
-it("masks a plugin-owned compact icon instead of embedding it as an image", () => {
-  const iconUrl = "/api/v1/plugin-catalog/icons/bb-community/provider-acp?h=ab";
+it("masks a tinted icon instead of embedding it as an image", () => {
+  const iconUrl = "/api/v1/plugin-catalog/icons/bb-community/agent-proxy?h=ab";
   const view = render(
     <CatalogEntryIcon
       entry={{
-        displayName: "ACP providers",
-        icon: "./icons/acp.svg",
+        displayName: "Agent Proxy",
+        icon: null,
         iconUrl,
+        iconTinted: true,
       }}
       className="size-6"
     />,
@@ -27,11 +28,11 @@ it("masks a plugin-owned compact icon instead of embedding it as an image", () =
   ).toBeTruthy();
 });
 
-it("embeds a marketplace listing's own artwork as an image", () => {
+it("embeds a marketplace listing's logo as an image", () => {
   const iconUrl = "/api/v1/plugin-catalog/icons/acme/widgets?h=cd";
   const view = render(
     <CatalogEntryIcon
-      entry={{ displayName: "Widgets", icon: null, iconUrl }}
+      entry={{ displayName: "Widgets", icon: null, iconUrl, iconTinted: false }}
       className="size-6"
     />,
   );

--- a/apps/app/src/components/plugin/management/plugin-ui.tsx
+++ b/apps/app/src/components/plugin/management/plugin-ui.tsx
@@ -1,5 +1,4 @@
 import { useState, type ReactNode } from "react";
-import { isPluginOwnedIconPath } from "@bb/domain";
 import { Icon, type IconName } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
 import {
@@ -121,13 +120,19 @@ export function CatalogEntryIcon({
   entry,
   className,
 }: {
-  entry: { displayName: string; icon: string | null; iconUrl: string | null };
+  entry: {
+    displayName: string;
+    icon: string | null;
+    iconUrl: string | null;
+    iconTinted: boolean;
+  };
   className: string;
 }) {
   const [failedIconUrl, setFailedIconUrl] = useState<string | null>(null);
-  // A path-shaped branding.icon is the plugin's own compact SVG: single-color
-  // artwork meant to take the surrounding text color, not a logo image.
-  if (entry.iconUrl !== null && isPluginOwnedIconPath(entry.icon ?? "")) {
+  // The server marks single-color artwork (a bundled compact icon or a catalog
+  // SVG not declared a logo) for masking with the surrounding text color, so a
+  // black-on-transparent glyph stays visible on a dark theme.
+  if (entry.iconUrl !== null && entry.iconTinted) {
     return <PluginCompactIconMask url={entry.iconUrl} className={className} />;
   }
   if (entry.iconUrl === null || entry.iconUrl === failedIconUrl) {

--- a/apps/app/src/components/tools/ExtensionsDetailStates.stories.tsx
+++ b/apps/app/src/components/tools/ExtensionsDetailStates.stories.tsx
@@ -565,6 +565,7 @@ const UNINSTALLED_CATALOG_PLUGIN = {
   description: "Browse GitHub issues and pull requests without leaving bb.",
   icon: "Github",
   iconUrl: null,
+  iconTinted: false,
   category: "Developer tools",
   source: "builtin:github",
   marketplaceDisplayName: "BB Community",
@@ -700,6 +701,7 @@ function CatalogPlugin({
           displayName: entry.displayName,
           icon: entry.icon,
           iconUrl: entry.iconUrl,
+          iconTinted: entry.iconTinted,
           source: entry.source,
         }}
         onOpenChange={setInstallOpen}

--- a/apps/app/src/hooks/queries/plugin-catalog-queries.test.ts
+++ b/apps/app/src/hooks/queries/plugin-catalog-queries.test.ts
@@ -152,6 +152,7 @@ describe("plugin catalog queries", () => {
         description: "Personal task capture",
         icon: "CheckList",
         iconUrl: null,
+        iconTinted: false,
         category: "Project management",
         source: "npm:@bb-plugins/todoist",
         marketplace: "acme-plugins",

--- a/apps/app/src/hooks/queries/plugin-catalog-queries.ts
+++ b/apps/app/src/hooks/queries/plugin-catalog-queries.ts
@@ -233,6 +233,8 @@ export interface PluginCatalogSearchEntry {
   description: string;
   icon: string | null;
   iconUrl: string | null;
+  /** Mask `iconUrl` with the text color instead of showing its own colors. */
+  iconTinted: boolean;
   category: string;
   source: string;
   marketplace: string;
@@ -259,6 +261,7 @@ function toPluginCatalogSearchEntry(
     description: data.description,
     icon: data.icon,
     iconUrl: data.iconUrl,
+    iconTinted: data.iconTinted,
     category: data.category,
     source: data.source,
     marketplace: data.marketplace,

--- a/apps/app/src/views/ToolsView.plugin-detail.test.tsx
+++ b/apps/app/src/views/ToolsView.plugin-detail.test.tsx
@@ -69,6 +69,7 @@ const GITHUB_CATALOG_ENTRY = {
   description: "Browse GitHub issues and pull requests in BB.",
   icon: "Github",
   iconUrl: null,
+  iconTinted: false,
   category: "Developer tools",
   source: "builtin:github",
   marketplaceDisplayName: "BB Official",

--- a/apps/app/src/views/ToolsView.tsx
+++ b/apps/app/src/views/ToolsView.tsx
@@ -389,6 +389,7 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
                     displayName: installTarget.displayName,
                     icon: installTarget.icon,
                     iconUrl: installTarget.iconUrl,
+                    iconTinted: installTarget.iconTinted,
                     source: installTarget.source,
                   }
             }

--- a/apps/cli/src/__tests__/command-output/plugin-catalog.test.ts
+++ b/apps/cli/src/__tests__/command-output/plugin-catalog.test.ts
@@ -16,6 +16,7 @@ const searchResult = {
   description: "Linear issue tools",
   icon: null,
   iconUrl: null,
+  iconTinted: false,
   category: "Developer tools",
   source: "builtin:linear",
   marketplace: "bb-community",

--- a/apps/server/src/services/plugin-catalog/marketplace-manifest.ts
+++ b/apps/server/src/services/plugin-catalog/marketplace-manifest.ts
@@ -112,16 +112,18 @@ const iconUrlSchema = z
   });
 
 /**
- * An image icon is single-color artwork by default: BB masks an SVG with the
- * surrounding text color, the same way it renders a plugin's own compact
- * `branding.icon`, so a black-on-transparent glyph stays visible on a dark
- * theme. `logo: true` opts out for multi-color artwork that must keep its own
- * colors. Raster icons (PNG, WebP) are always logos: a mask reads alpha only
- * and would flatten an opaque image into a solid block.
+ * An SVG icon is single-color artwork: BB masks it with the surrounding text
+ * color, the same way it renders a plugin's own compact `branding.icon`, so a
+ * black-on-transparent glyph stays visible on a dark theme. Raster icons
+ * (PNG, WebP) keep their own colors: a mask reads alpha only and would
+ * flatten an opaque image into a solid block, and a raster is the form for
+ * multi-color artwork. The object stays strict: an older desktop rejects the
+ * whole manifest on an unknown field, so a per-entry opt-out needs a new
+ * schemaVersion.
  */
 const iconSchema = z.union([
   z.string().regex(ICON_NAME_PATTERN, "must be a host icon name"),
-  z.object({ url: iconUrlSchema, logo: z.boolean().default(false) }).strict(),
+  z.object({ url: iconUrlSchema }).strict(),
 ]);
 
 const authorSchema = z
@@ -362,20 +364,12 @@ export function entryIconName(entry: MarketplaceEntry): string | null {
 }
 
 /**
- * Whether BB masks the entry's cached image icon with the surrounding text
- * color. Only an SVG the listing did not mark as a logo is tinted; see
- * {@link iconSchema}. `contentType` is the validated type BB serves the cached
- * bytes as.
+ * Whether BB masks a cached image icon with the surrounding text color. Only
+ * an SVG is tinted; see {@link iconSchema}. `contentType` is the validated
+ * type BB serves the cached bytes as.
  */
-export function entryIconTinted(
-  entry: MarketplaceEntry,
-  contentType: string,
-): boolean {
-  return (
-    typeof entry.icon !== "string" &&
-    !entry.icon.logo &&
-    contentType === "image/svg+xml"
-  );
+export function entryIconTinted(contentType: string): boolean {
+  return contentType === "image/svg+xml";
 }
 
 /**

--- a/apps/server/src/services/plugin-catalog/marketplace-manifest.ts
+++ b/apps/server/src/services/plugin-catalog/marketplace-manifest.ts
@@ -111,9 +111,17 @@ const iconUrlSchema = z
     if (problem !== null) ctx.addIssue({ code: "custom", message: problem });
   });
 
+/**
+ * An image icon is single-color artwork by default: BB masks an SVG with the
+ * surrounding text color, the same way it renders a plugin's own compact
+ * `branding.icon`, so a black-on-transparent glyph stays visible on a dark
+ * theme. `logo: true` opts out for multi-color artwork that must keep its own
+ * colors. Raster icons (PNG, WebP) are always logos: a mask reads alpha only
+ * and would flatten an opaque image into a solid block.
+ */
 const iconSchema = z.union([
   z.string().regex(ICON_NAME_PATTERN, "must be a host icon name"),
-  z.object({ url: iconUrlSchema }).strict(),
+  z.object({ url: iconUrlSchema, logo: z.boolean().default(false) }).strict(),
 ]);
 
 const authorSchema = z
@@ -351,6 +359,23 @@ export function parseMarketplaceManifestJson(
 /** The entry's declared host icon name, or null when it ships an image. */
 export function entryIconName(entry: MarketplaceEntry): string | null {
   return typeof entry.icon === "string" ? entry.icon : null;
+}
+
+/**
+ * Whether BB masks the entry's cached image icon with the surrounding text
+ * color. Only an SVG the listing did not mark as a logo is tinted; see
+ * {@link iconSchema}. `contentType` is the validated type BB serves the cached
+ * bytes as.
+ */
+export function entryIconTinted(
+  entry: MarketplaceEntry,
+  contentType: string,
+): boolean {
+  return (
+    typeof entry.icon !== "string" &&
+    !entry.icon.logo &&
+    contentType === "image/svg+xml"
+  );
 }
 
 /**

--- a/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
+++ b/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
@@ -54,6 +54,7 @@ import {
   BUILTIN_PUBLISHER_KEY,
   BUILTIN_PUBLISHER_LABEL,
   entryIconName,
+  entryIconTinted,
   entrySourceDisplay,
   CURATED_MARKETPLACE_NAME,
   parseMarketplaceManifestJson,
@@ -413,6 +414,9 @@ export function createPluginCatalogService(deps: {
         iconHash === null
           ? null
           : entryIconAssetUrl(CURATED_MARKETPLACE_NAME, entry.name, iconHash),
+      // A bundled icon is the plugin's own compact SVG, authored to take the
+      // surrounding text color.
+      iconTinted: iconHash !== null,
       category: entry.category,
       source: builtinPluginSource(entry.name),
       // Plugins bundled with the app are BB's own, so the store groups them
@@ -459,11 +463,18 @@ export function createPluginCatalogService(deps: {
     return `/api/v1/plugin-catalog/icons/${encodeURIComponent(marketplace)}/${encodeURIComponent(entryId)}?h=${contentHash}`;
   }
 
-  function entryIconUrl(marketplace: string, entryId: string): string | null {
-    const icon = getPluginMarketplaceIcon(deps.db, marketplace, entryId);
+  /** The cached icon's same-origin URL and how the app paints it. */
+  function entryIconAsset(
+    marketplace: string,
+    entry: MarketplaceEntry,
+  ): { iconUrl: string | null; iconTinted: boolean } {
+    const icon = getPluginMarketplaceIcon(deps.db, marketplace, entry.id);
     return icon === undefined
-      ? null
-      : entryIconAssetUrl(marketplace, entryId, icon.contentHash);
+      ? { iconUrl: null, iconTinted: false }
+      : {
+          iconUrl: entryIconAssetUrl(marketplace, entry.id, icon.contentHash),
+          iconTinted: entryIconTinted(entry, icon.contentType),
+        };
   }
 
   function catalogSearchResult(args: {
@@ -482,7 +493,7 @@ export function createPluginCatalogService(deps: {
       displayName: entry.displayName,
       description: entry.description,
       icon: entryIconName(entry),
-      iconUrl: entryIconUrl(row.name, entry.id),
+      ...entryIconAsset(row.name, entry),
       category: entryCategory(entry, official),
       source: entrySourceDisplay(entry),
       marketplace: row.name,

--- a/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
+++ b/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
@@ -466,14 +466,14 @@ export function createPluginCatalogService(deps: {
   /** The cached icon's same-origin URL and how the app paints it. */
   function entryIconAsset(
     marketplace: string,
-    entry: MarketplaceEntry,
+    entryId: string,
   ): { iconUrl: string | null; iconTinted: boolean } {
-    const icon = getPluginMarketplaceIcon(deps.db, marketplace, entry.id);
+    const icon = getPluginMarketplaceIcon(deps.db, marketplace, entryId);
     return icon === undefined
       ? { iconUrl: null, iconTinted: false }
       : {
-          iconUrl: entryIconAssetUrl(marketplace, entry.id, icon.contentHash),
-          iconTinted: entryIconTinted(entry, icon.contentType),
+          iconUrl: entryIconAssetUrl(marketplace, entryId, icon.contentHash),
+          iconTinted: entryIconTinted(icon.contentType),
         };
   }
 
@@ -493,7 +493,7 @@ export function createPluginCatalogService(deps: {
       displayName: entry.displayName,
       description: entry.description,
       icon: entryIconName(entry),
-      ...entryIconAsset(row.name, entry),
+      ...entryIconAsset(row.name, entry.id),
       category: entryCategory(entry, official),
       source: entrySourceDisplay(entry),
       marketplace: row.name,

--- a/apps/server/src/services/skills/builtin-skills/submit-a-plugin/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/submit-a-plugin/SKILL.md
@@ -280,6 +280,8 @@ Use `.svg`, `.png`, or `.webp` for an icon file. Keep the file at or below 256 K
 
 Prefer a simple square image with clear contrast at small sizes.
 
+BB masks an SVG icon with the surrounding text color by default, so a single-color SVG follows the user's theme. If the SVG is multi-color artwork that must keep its own colors, set `"icon": { "url": "./icons/<file>.svg", "logo": true }`. PNG and WebP icons always keep their own colors.
+
 Do not include scripts, remote resources, or private data in an SVG.
 
 Copy the file into `icons/`. Use a content hash in the filename to prevent stale cached icons.

--- a/apps/server/src/services/skills/builtin-skills/submit-a-plugin/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/submit-a-plugin/SKILL.md
@@ -280,7 +280,7 @@ Use `.svg`, `.png`, or `.webp` for an icon file. Keep the file at or below 256 K
 
 Prefer a simple square image with clear contrast at small sizes.
 
-BB masks an SVG icon with the surrounding text color by default, so a single-color SVG follows the user's theme. If the SVG is multi-color artwork that must keep its own colors, set `"icon": { "url": "./icons/<file>.svg", "logo": true }`. PNG and WebP icons always keep their own colors.
+BB masks an SVG icon with the surrounding text color, so a single-color SVG follows the user's theme. PNG and WebP icons keep their own colors. Use PNG or WebP for multi-color artwork.
 
 Do not include scripts, remote resources, or private data in an SVG.
 

--- a/apps/server/test/services/plugin-catalog/marketplace-schema-parity.test.ts
+++ b/apps/server/test/services/plugin-catalog/marketplace-schema-parity.test.ts
@@ -147,6 +147,16 @@ const fixtures: readonly Fixture[] = [
   iconFixture("javascript URL icon", "javascript:a.svg", false),
   iconFixture("unsupported extension", "https://cdn.example.com/a.gif", false),
   iconFixture("no extension", "https://cdn.example.com/a", false),
+  {
+    label: "image icon marked as a logo",
+    valid: true,
+    manifest: manifestWith({ icon: { url: "./acme.svg", logo: true } }),
+  },
+  {
+    label: "logo flag that is not a boolean",
+    valid: false,
+    manifest: manifestWith({ icon: { url: "./acme.svg", logo: "yes" } }),
+  },
 
   rangeFixture("caret range", "^1.2.3", true),
   rangeFixture("comparator pair", ">=1.0.0 <2.0.0", true),

--- a/apps/server/test/services/plugin-catalog/marketplace-schema-parity.test.ts
+++ b/apps/server/test/services/plugin-catalog/marketplace-schema-parity.test.ts
@@ -148,14 +148,9 @@ const fixtures: readonly Fixture[] = [
   iconFixture("unsupported extension", "https://cdn.example.com/a.gif", false),
   iconFixture("no extension", "https://cdn.example.com/a", false),
   {
-    label: "image icon marked as a logo",
-    valid: true,
-    manifest: manifestWith({ icon: { url: "./acme.svg", logo: true } }),
-  },
-  {
-    label: "logo flag that is not a boolean",
+    label: "unknown icon field",
     valid: false,
-    manifest: manifestWith({ icon: { url: "./acme.svg", logo: "yes" } }),
+    manifest: manifestWith({ icon: { url: "./acme.svg", logo: true } }),
   },
 
   rangeFixture("caret range", "^1.2.3", true),

--- a/apps/server/test/services/plugin-catalog/plugin-catalog-service.test.ts
+++ b/apps/server/test/services/plugin-catalog/plugin-catalog-service.test.ts
@@ -296,12 +296,58 @@ describe("plugin catalog service", () => {
       `/api/v1/plugin-catalog/icons/bb-community/${withSvg.name}?h=${icon?.hash}`,
     );
     expect(new TextDecoder().decode(icon?.bytes)).toContain("<svg");
+    // The compact icon is single-color artwork; the app masks it.
+    expect(svgEntry?.iconTinted).toBe(true);
 
     expect(glyphEntry?.iconUrl).toBeNull();
+    expect(glyphEntry?.iconTinted).toBe(false);
     expect(await catalog.icon("bb-community", withGlyph.name)).toBeUndefined();
   });
 
   describe("refresh", () => {
+    it("keeps a logo's own colors: a listing marked logo or a raster icon is not tinted", async () => {
+      const PNG = Buffer.from([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0,
+      ]);
+      const fetchImpl: MarketplaceFetch = async (url) => {
+        if (url === MANIFEST_URL) {
+          return jsonResponse(
+            manifest([
+              remoteEntry({
+                id: "brand",
+                icon: { url: "./icons/brand.svg", logo: true },
+              }),
+              remoteEntry({ id: "raster", icon: { url: "./icons/raster.png" } }),
+              remoteEntry({ id: "glyph", icon: { url: "./icons/glyph.svg" } }),
+            ]),
+          );
+        }
+        return url.endsWith(".png")
+          ? new Response(PNG, {
+              status: 200,
+              headers: { "content-type": "image/png" },
+            })
+          : new Response(VALID_SVG, {
+              status: 200,
+              headers: { "content-type": "image/svg+xml" },
+            });
+      };
+      const catalog = service({ fetch: fetchImpl });
+
+      await catalog.refresh(1_000);
+      const tinted = Object.fromEntries(
+        (await catalog.search("")).map((entry) => [
+          entry.entryId,
+          { iconUrl: entry.iconUrl !== null, iconTinted: entry.iconTinted },
+        ]),
+      );
+      expect(tinted).toMatchObject({
+        brand: { iconUrl: true, iconTinted: false },
+        raster: { iconUrl: true, iconTinted: false },
+        glyph: { iconUrl: true, iconTinted: true },
+      });
+    });
+
     it("replaces the catalog, caches icons, and revalidates with the ETag", async () => {
       const requests: Array<{ url: string; headers: Headers }> = [];
       const fetchImpl: MarketplaceFetch = async (url, init) => {
@@ -337,6 +383,9 @@ describe("plugin catalog service", () => {
       expect(await catalog.icon("bb-community", "widgets")).toMatchObject({
         contentType: "image/svg+xml",
       });
+      // A catalog SVG is tinted by default, like a plugin's own compact icon,
+      // so a black-on-transparent glyph stays visible on a dark theme (#1941).
+      expect(results[0]?.iconTinted).toBe(true);
       // The seeded entries are gone: the published manifest is authoritative.
       expect((await catalog.search("thread-hover-cards")).length).toBe(0);
       expect(requests[1]?.url).toBe(ICON_URL);

--- a/apps/server/test/services/plugin-catalog/plugin-catalog-service.test.ts
+++ b/apps/server/test/services/plugin-catalog/plugin-catalog-service.test.ts
@@ -305,7 +305,7 @@ describe("plugin catalog service", () => {
   });
 
   describe("refresh", () => {
-    it("keeps a logo's own colors: a listing marked logo or a raster icon is not tinted", async () => {
+    it("tints a catalog SVG but keeps a raster icon's own colors", async () => {
       const PNG = Buffer.from([
         0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0,
       ]);
@@ -313,10 +313,6 @@ describe("plugin catalog service", () => {
         if (url === MANIFEST_URL) {
           return jsonResponse(
             manifest([
-              remoteEntry({
-                id: "brand",
-                icon: { url: "./icons/brand.svg", logo: true },
-              }),
               remoteEntry({ id: "raster", icon: { url: "./icons/raster.png" } }),
               remoteEntry({ id: "glyph", icon: { url: "./icons/glyph.svg" } }),
             ]),
@@ -342,7 +338,6 @@ describe("plugin catalog service", () => {
         ]),
       );
       expect(tinted).toMatchObject({
-        brand: { iconUrl: true, iconTinted: false },
         raster: { iconUrl: true, iconTinted: false },
         glyph: { iconUrl: true, iconTinted: true },
       });

--- a/apps/web/public/schemas/marketplace.schema.json
+++ b/apps/web/public/schemas/marketplace.schema.json
@@ -78,13 +78,8 @@
                 "url": {
                   "type": "string",
                   "minLength": 1,
-                  "$comment": "Absolute https URL, or a URL relative to this manifest. The path must end in .svg, .png, or .webp.",
+                  "$comment": "Absolute https URL, or a URL relative to this manifest. The path must end in .svg, .png, or .webp. BB masks an SVG with the surrounding text color, so single-color artwork follows the theme; PNG and WebP keep their own colors.",
                   "pattern": "^(?:(?![A-Za-z][A-Za-z0-9+.-]*:)|(?=[Hh][Tt][Tt][Pp][Ss]:))[^\\s]*\\.(?:[Ss][Vv][Gg]|[Pp][Nn][Gg]|[Ww][Ee][Bb][Pp])(?:[?#][^\\s]*)?$"
-                },
-                "logo": {
-                  "type": "boolean",
-                  "default": false,
-                  "$comment": "By default BB masks an SVG icon with the surrounding text color, so single-color artwork follows the theme. Set true for multi-color artwork that must keep its own colors. PNG and WebP icons always keep their own colors."
                 }
               }
             }

--- a/apps/web/public/schemas/marketplace.schema.json
+++ b/apps/web/public/schemas/marketplace.schema.json
@@ -80,6 +80,11 @@
                   "minLength": 1,
                   "$comment": "Absolute https URL, or a URL relative to this manifest. The path must end in .svg, .png, or .webp.",
                   "pattern": "^(?:(?![A-Za-z][A-Za-z0-9+.-]*:)|(?=[Hh][Tt][Tt][Pp][Ss]:))[^\\s]*\\.(?:[Ss][Vv][Gg]|[Pp][Nn][Gg]|[Ww][Ee][Bb][Pp])(?:[?#][^\\s]*)?$"
+                },
+                "logo": {
+                  "type": "boolean",
+                  "default": false,
+                  "$comment": "By default BB masks an SVG icon with the surrounding text color, so single-color artwork follows the theme. Set true for multi-color artwork that must keep its own colors. PNG and WebP icons always keep their own colors."
                 }
               }
             }

--- a/docs/plugin-marketplace-plan.md
+++ b/docs/plugin-marketplace-plan.md
@@ -128,6 +128,13 @@ Entry `icon` accepts the same shapes the plugin manifest supports today:
   a relative URL resolves against the manifest's own URL, which lets a
   git-hosted marketplace keep icons next to the manifest. Plain `http:` is
   rejected.
+- By default bb masks an SVG icon with the surrounding text color, the same
+  way it renders a plugin's own compact `bb.branding.icon`. Most catalog icons
+  are single-color glyphs, and an unmasked black-on-transparent SVG is
+  invisible on a dark theme. Set `{ "url": ..., "logo": true }` for
+  multi-color artwork that must keep its own colors. PNG and WebP icons always
+  keep their own colors: a mask reads alpha only and would flatten an opaque
+  image into a solid block.
 
 Handling:
 

--- a/docs/plugin-marketplace-plan.md
+++ b/docs/plugin-marketplace-plan.md
@@ -128,13 +128,14 @@ Entry `icon` accepts the same shapes the plugin manifest supports today:
   a relative URL resolves against the manifest's own URL, which lets a
   git-hosted marketplace keep icons next to the manifest. Plain `http:` is
   rejected.
-- By default bb masks an SVG icon with the surrounding text color, the same
-  way it renders a plugin's own compact `bb.branding.icon`. Most catalog icons
-  are single-color glyphs, and an unmasked black-on-transparent SVG is
-  invisible on a dark theme. Set `{ "url": ..., "logo": true }` for
-  multi-color artwork that must keep its own colors. PNG and WebP icons always
-  keep their own colors: a mask reads alpha only and would flatten an opaque
-  image into a solid block.
+- bb masks an SVG icon with the surrounding text color, the same way it
+  renders a plugin's own compact `bb.branding.icon`. Most catalog icons are
+  single-color glyphs, and an unmasked black-on-transparent SVG is invisible
+  on a dark theme. PNG and WebP icons keep their own colors: a mask reads
+  alpha only and would flatten an opaque image into a solid block. Use a
+  raster for multi-color artwork. A per-entry opt-out would be an unknown
+  field to older desktops, which reject the whole manifest, so it needs a new
+  `schemaVersion`.
 
 Handling:
 

--- a/packages/server-contract/src/api/plugins.ts
+++ b/packages/server-contract/src/api/plugins.ts
@@ -412,6 +412,14 @@ export const pluginCatalogSearchResultSchema = z.object({
    * names a host icon. The app never requests the marketplace's own URL.
    */
   iconUrl: z.string().nullable(),
+  /**
+   * Whether the app masks `iconUrl` with the surrounding text color, as it
+   * does a plugin's own compact `branding.icon`, instead of showing the
+   * image's own colors. True for bundled compact icons and for catalog SVGs
+   * not marked `logo`. Servers before bb-app 0.40.0 do not send it; those
+   * icons render untinted.
+   */
+  iconTinted: z.boolean().default(false),
   category: z.string(),
   source: z.string(),
   /** Marketplace that lists the entry; plugins bundled with the app use `bb-community`. */

--- a/packages/server-contract/src/api/plugins.ts
+++ b/packages/server-contract/src/api/plugins.ts
@@ -415,9 +415,9 @@ export const pluginCatalogSearchResultSchema = z.object({
   /**
    * Whether the app masks `iconUrl` with the surrounding text color, as it
    * does a plugin's own compact `branding.icon`, instead of showing the
-   * image's own colors. True for bundled compact icons and for catalog SVGs
-   * not marked `logo`. Servers before bb-app 0.40.0 do not send it; those
-   * icons render untinted.
+   * image's own colors. True for bundled compact icons and for catalog SVGs;
+   * false for PNG and WebP. Servers before bb-app 0.40.0 do not send it;
+   * those icons render untinted.
    */
   iconTinted: z.boolean().default(false),
   category: z.string(),


### PR DESCRIPTION
## What was wrong

**Browse plugins** rendered a marketplace entry's image icon as a plain `<img>`, so the SVG's own colour showed. Most BB Community icons are black-on-transparent, so they were invisible on a dark theme. **Installed plugins** masks the same icon with the text colour.

Root cause: `CatalogEntryIcon` tinted only when `entry.iconUrl !== null && isPluginOwnedIconPath(entry.icon)`. For a catalog entry those two conditions never hold at once: `{ "url": ... }` icons set `icon` to `null`, and a path string never gets an `iconUrl`. Only bundled plugins satisfied both.

## What changed

- The server decides how the app paints a catalog icon and sends `iconTinted: boolean` on each `PluginCatalogSearchResult` (`packages/server-contract`, default `false` for older servers).
  - Bundled compact icons: tinted.
  - Catalog SVG icons: tinted.
  - Catalog PNG/WebP icons: never tinted (a mask reads alpha only and flattens an opaque raster into a block). A raster is the form for multi-colour artwork.
- `CatalogEntryIcon` masks when `iconTinted` is true and no longer inspects `entry.icon`.
- The published `marketplace.schema.json` comment, `docs/plugin-marketplace-plan.md`, and the `submit-a-plugin` skill document the rule.
- The manifest schema is unchanged. A per-entry opt-out would be an unknown field to older desktops, which reject the whole manifest, so it needs a new `schemaVersion` and is out of scope here.

## How I verified

- `plugin-catalog-service.test.ts`: a refreshed catalog SVG reports `iconTinted: true` (fails before; the field did not exist and the app never tinted); a PNG reports `iconTinted: false`; the bundled compact icon test asserts `iconTinted: true`.
- `marketplace-schema-parity.test.ts`: the published schema and the runtime parser both reject an unknown icon field.
- `plugin-ui.test.tsx`: masks a tinted icon, embeds an untinted logo as `<img>`.
- `pnpm exec turbo run typecheck` for server, app, cli; server plugin-catalog, app plugin management, and cli plugin-catalog test suites pass.
- Dev app on this branch: all 32 BB Community image icons render as text-coloured masks on a dark theme.

Fixes #1941

> AGENT GENERATED: by Claude Opus 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)