### PR TITLE
Add a one-click Archive button to hovered sidebar thread rows

### DIFF
--- a/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
@@ -11,6 +11,7 @@ import type { ThreadListEntry } from "@bb/domain";
 import type { ProjectResponse } from "@bb/server-contract";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
+import { TooltipProvider } from "@bb/shared-ui/tooltip";
 import { Provider, createStore } from "jotai";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
@@ -141,21 +142,23 @@ function renderProjectRow(
 ) {
   const onToggleEnvironmentCollapsed = vi.fn();
   const result = render(
-    <MemoryRouter>
-      <ProjectRow
-        project={makeProject()}
-        threadListState={threadListState}
-        isActive={isActive}
-        isCollapsed={isCollapsed}
-        compareThreads={() => 0}
-        collapsedThreadIds={new Set()}
-        collapsedEnvironmentIds={collapsedEnvironmentIds}
-        isLocalPathInvalid={false}
-        onToggleProjectCollapsed={onToggleProjectCollapsed}
-        onToggleThreadCollapsed={vi.fn()}
-        onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
-      />
-    </MemoryRouter>,
+    <TooltipProvider>
+      <MemoryRouter>
+        <ProjectRow
+          project={makeProject()}
+          threadListState={threadListState}
+          isActive={isActive}
+          isCollapsed={isCollapsed}
+          compareThreads={() => 0}
+          collapsedThreadIds={new Set()}
+          collapsedEnvironmentIds={collapsedEnvironmentIds}
+          isLocalPathInvalid={false}
+          onToggleProjectCollapsed={onToggleProjectCollapsed}
+          onToggleThreadCollapsed={vi.fn()}
+          onToggleEnvironmentCollapsed={onToggleEnvironmentCollapsed}
+        />
+      </MemoryRouter>
+    </TooltipProvider>,
   );
   return { ...result, onToggleEnvironmentCollapsed, onToggleProjectCollapsed };
 }
@@ -315,28 +318,30 @@ describe("ProjectRow interactions", () => {
     });
 
     render(
-      <Provider store={store}>
-        <QueryClientProvider client={queryClient}>
-          <MemoryRouter>
-            <ChronologicalSectionThreadSections
-              threadListState={{ status: "ready", threads: [activeThread] }}
-              compareThreads={() => 0}
-              sections={[{ id: sectionId, name: "Active work" }]}
-              collapsedThreadIds={new Set()}
-              collapsedEnvironmentIds={new Set()}
-              onToggleThreadCollapsed={vi.fn()}
-              onToggleEnvironmentCollapsed={vi.fn()}
-              topLevelSectionOrder={[
-                buildSidebarEntitySectionId("section", sectionId),
-              ]}
-              onTopLevelSectionOrderChange={vi.fn()}
-              pinnedReorderPending={false}
-              pinnedThreads={[]}
-              onReorderPinnedThread={vi.fn()}
-            />
-          </MemoryRouter>
-        </QueryClientProvider>
-      </Provider>,
+      <TooltipProvider>
+        <Provider store={store}>
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+              <ChronologicalSectionThreadSections
+                threadListState={{ status: "ready", threads: [activeThread] }}
+                compareThreads={() => 0}
+                sections={[{ id: sectionId, name: "Active work" }]}
+                collapsedThreadIds={new Set()}
+                collapsedEnvironmentIds={new Set()}
+                onToggleThreadCollapsed={vi.fn()}
+                onToggleEnvironmentCollapsed={vi.fn()}
+                topLevelSectionOrder={[
+                  buildSidebarEntitySectionId("section", sectionId),
+                ]}
+                onTopLevelSectionOrderChange={vi.fn()}
+                pinnedReorderPending={false}
+                pinnedThreads={[]}
+                onReorderPinnedThread={vi.fn()}
+              />
+            </MemoryRouter>
+          </QueryClientProvider>
+        </Provider>
+      </TooltipProvider>,
     );
 
     fireEvent.click(
@@ -375,28 +380,30 @@ describe("ProjectRow interactions", () => {
     mockDraftThreadIds.current = new Set([activeThread.id]);
 
     render(
-      <Provider store={store}>
-        <QueryClientProvider client={queryClient}>
-          <MemoryRouter>
-            <ChronologicalSectionThreadSections
-              threadListState={{ status: "ready", threads: [activeThread] }}
-              compareThreads={() => 0}
-              sections={[{ id: sectionId, name: "Draft work" }]}
-              collapsedThreadIds={new Set()}
-              collapsedEnvironmentIds={new Set()}
-              onToggleThreadCollapsed={vi.fn()}
-              onToggleEnvironmentCollapsed={vi.fn()}
-              topLevelSectionOrder={[
-                buildSidebarEntitySectionId("section", sectionId),
-              ]}
-              onTopLevelSectionOrderChange={vi.fn()}
-              pinnedReorderPending={false}
-              pinnedThreads={[]}
-              onReorderPinnedThread={vi.fn()}
-            />
-          </MemoryRouter>
-        </QueryClientProvider>
-      </Provider>,
+      <TooltipProvider>
+        <Provider store={store}>
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+              <ChronologicalSectionThreadSections
+                threadListState={{ status: "ready", threads: [activeThread] }}
+                compareThreads={() => 0}
+                sections={[{ id: sectionId, name: "Draft work" }]}
+                collapsedThreadIds={new Set()}
+                collapsedEnvironmentIds={new Set()}
+                onToggleThreadCollapsed={vi.fn()}
+                onToggleEnvironmentCollapsed={vi.fn()}
+                topLevelSectionOrder={[
+                  buildSidebarEntitySectionId("section", sectionId),
+                ]}
+                onTopLevelSectionOrderChange={vi.fn()}
+                pinnedReorderPending={false}
+                pinnedThreads={[]}
+                onReorderPinnedThread={vi.fn()}
+              />
+            </MemoryRouter>
+          </QueryClientProvider>
+        </Provider>
+      </TooltipProvider>,
     );
 
     fireEvent.click(

--- a/apps/app/src/components/sidebar/ThreadRow.test.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.test.tsx
@@ -55,6 +55,7 @@ vi.mock("@/components/thread/ThreadActionsMenu", () => ({
     <>{children}</>
   ),
   ThreadActionsMenu: () => null,
+  ThreadArchiveQuickAction: () => null,
 }));
 
 function createThread(

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -61,6 +61,8 @@ import {
   SIDEBAR_ROW_INTERACTIVE_STATE_CLASS,
   SIDEBAR_ROW_SELECTED_STATE_CLASS,
   SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
+  SIDEBAR_PAIRED_ACTION_LEADING_TARGET_CLASS,
+  SIDEBAR_PAIRED_ACTION_TRAILING_TARGET_CLASS,
   SIDEBAR_ROW_OPEN_IN_SPLIT_STATE_CLASS,
   SIDEBAR_SUCCESS_STATUS_COLOR_CLASS,
   SIDEBAR_SUCCESS_STATUS_DOT_CLASS,
@@ -840,6 +842,7 @@ function ThreadRowComponent({
                     // Tighter than two full margins: a half step between the
                     // two glyphs reads as one control group.
                     "-mr-0.5",
+                    SIDEBAR_PAIRED_ACTION_LEADING_TARGET_CLASS,
                   )}
                 />
                 <ThreadActionsMenu
@@ -847,6 +850,7 @@ function ThreadRowComponent({
                   triggerClassName={cn(
                     "text-subtle-foreground hover:bg-transparent hover:text-foreground",
                     SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
+                    SIDEBAR_PAIRED_ACTION_TRAILING_TARGET_CLASS,
                   )}
                   onOpenInSplit={splitAvailable ? openInSplit : undefined}
                   onOpenChange={setIsDropdownActionsOpen}

--- a/apps/app/src/components/sidebar/ThreadRow.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.tsx
@@ -19,6 +19,7 @@ import { NavLink } from "react-router-dom";
 import {
   ThreadActionsContextMenu,
   ThreadActionsMenu,
+  ThreadArchiveQuickAction,
 } from "@/components/thread/ThreadActionsMenu";
 import { useThreadActions } from "@/components/thread/ThreadActionsProvider";
 import { useInlineThreadTitle } from "@/components/thread/InlineThreadTitle";
@@ -32,6 +33,7 @@ import {
 import {
   SIDEBAR_HOVER_ACTIONS_CLASS,
   SIDEBAR_HOVER_ACTIONS_FADE_CLASS,
+  SIDEBAR_HOVER_ACTIONS_INSET_CLASS,
   SIDEBAR_HOVER_ACTIONS_ROW_CLASS,
 } from "@/components/ui/sidebar-hover-actions.js";
 import {
@@ -716,7 +718,14 @@ function ThreadRowComponent({
         aria-keyshortcuts={shortcut?.ariaKeyshortcuts}
         className="absolute inset-0 rounded-md outline-none ring-sidebar-ring focus-visible:ring-2"
       />
-      <span className="flex min-w-0 flex-1 items-center gap-1.5">
+      <span
+        className={cn(
+          "flex min-w-0 flex-1 items-center gap-1.5",
+          // The hover actions overlay grows leftward past the trailing slot;
+          // this reserves room so the title never runs under the extra button.
+          !shortcut && SIDEBAR_HOVER_ACTIONS_INSET_CLASS,
+        )}
+      >
         {isEditing ? (
           <span className="relative z-10 min-w-0 flex-1 overflow-visible">
             {editor}
@@ -818,9 +827,21 @@ function ThreadRowComponent({
                 }
                 className={cn(
                   SIDEBAR_HOVER_ACTIONS_CLASS,
-                  "absolute inset-0 z-10 flex items-center justify-end max-md:pointer-coarse:hidden",
+                  // Anchored to the right edge only, so a second action can sit
+                  // left of the menu without widening the rest slot.
+                  "absolute inset-y-0 right-0 z-10 flex items-center justify-end max-md:pointer-coarse:hidden",
                 )}
               >
+                <ThreadArchiveQuickAction
+                  thread={thread}
+                  className={cn(
+                    "text-subtle-foreground hover:bg-transparent hover:text-foreground",
+                    SIDEBAR_MORE_ACTION_TRIGGER_CLASS,
+                    // Tighter than two full margins: a half step between the
+                    // two glyphs reads as one control group.
+                    "-mr-0.5",
+                  )}
+                />
                 <ThreadActionsMenu
                   thread={thread}
                   triggerClassName={cn(

--- a/apps/app/src/components/sidebar/sidebarRowClasses.ts
+++ b/apps/app/src/components/sidebar/sidebarRowClasses.ts
@@ -67,8 +67,7 @@ export const SIDEBAR_ROW_INTERACTIVE_STATE_CLASS =
 export const SIDEBAR_ROW_STATIC_STATE_CLASS =
   "text-sidebar-foreground/85 dark:text-sidebar-foreground";
 
-export const SIDEBAR_ROW_SELECTED_STATE_CLASS =
-  `${CONTEXT_SELECTION_SURFACE_CLASS} bb-sidebar-selected-row text-sidebar-foreground`;
+export const SIDEBAR_ROW_SELECTED_STATE_CLASS = `${CONTEXT_SELECTION_SURFACE_CLASS} bb-sidebar-selected-row text-sidebar-foreground`;
 
 /**
  * A quieter marker for a thread that is open in an unfocused split pane.
@@ -80,6 +79,19 @@ export const SIDEBAR_ROW_OPEN_IN_SPLIT_STATE_CLASS =
 
 export const SIDEBAR_MORE_ACTION_TRIGGER_CLASS =
   "relative m-1 h-5 w-5 after:absolute after:left-1/2 after:top-1/2 after:h-7 after:w-7 after:-translate-x-1/2 after:-translate-y-1/2 after:content-[''] max-md:pointer-coarse:m-0 max-md:pointer-coarse:h-9 max-md:pointer-coarse:w-9 max-md:pointer-coarse:after:hidden";
+
+/**
+ * When two `SIDEBAR_MORE_ACTION_TRIGGER_CLASS` buttons sit side by side, their
+ * centered 28px pseudo-targets would overlap and the later sibling would win
+ * clicks aimed at the earlier one. These variants re-anchor each target to
+ * stretch 4px outward but stop 1px short of the shared edge (the midpoint of
+ * a 2px gap), so every point between the glyphs belongs to exactly one button.
+ */
+export const SIDEBAR_PAIRED_ACTION_LEADING_TARGET_CLASS =
+  "after:-left-1 after:-right-px after:w-auto after:translate-x-0";
+
+export const SIDEBAR_PAIRED_ACTION_TRAILING_TARGET_CLASS =
+  "after:-left-px after:-right-1 after:w-auto after:translate-x-0";
 
 /**
  * Hairline that runs through an expanded project's thread list, sitting

--- a/apps/app/src/components/thread/ThreadActionsMenu.tsx
+++ b/apps/app/src/components/thread/ThreadActionsMenu.tsx
@@ -16,6 +16,7 @@ import {
 } from "@bb/shared-ui/dropdown-menu";
 import { Icon, type IconName } from "@bb/shared-ui/icon";
 import { Button } from "@bb/shared-ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
 import { COARSE_POINTER_ICON_SIZE_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { cn } from "@bb/shared-ui/lib/utils";
@@ -248,6 +249,51 @@ function ThreadActionsMenuItems({
         </ThreadActionMenuItem>
       ) : null}
     </>
+  );
+}
+
+/**
+ * One-click archive (or unarchive) button for hover-revealed row actions. It
+ * runs the same lifecycle as the menu's Archive entry, so undo, navigation,
+ * and child cascade behave identically.
+ */
+export function ThreadArchiveQuickAction({
+  thread,
+  className,
+}: {
+  thread: Thread;
+  className?: string;
+}) {
+  const { archiveThreadAndChildren, unarchiveThread } = useThreadActions();
+  const isArchived = thread.archivedAt != null;
+  const label = isArchived ? "Unarchive" : "Archive";
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className={cn("rounded-md p-0", className)}
+          aria-label={`${label} thread`}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            if (isArchived) {
+              unarchiveThread(thread);
+              return;
+            }
+            archiveThreadAndChildren(thread);
+          }}
+        >
+          <Icon
+            name={isArchived ? "ArchiveRestore" : "Archive"}
+            className={COARSE_POINTER_ICON_SIZE_CLASS}
+          />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{label}</TooltipContent>
+    </Tooltip>
   );
 }
 

--- a/apps/app/src/components/thread/ThreadActionsProvider.tsx
+++ b/apps/app/src/components/thread/ThreadActionsProvider.tsx
@@ -122,7 +122,11 @@ export function ThreadActionsProvider({
   // renders. Depending on the full mutation objects would churn callback
   // identities on every isPending flip and force every useThreadActions()
   // consumer to re-render whenever any mutation fires.
-  const { mutate: archiveThreadAndChildrenMutate } =
+  // `mutateAsync` for archive: its promise settles per call, while the
+  // per-call `mutate` callbacks only fire for the latest call on this shared
+  // observer. Two quick archives (one-click hover buttons make this easy)
+  // must each keep their own Undo toast, pane closure, and error report.
+  const { mutateAsync: archiveThreadAndChildrenMutateAsync } =
     archiveThreadAndChildrenMutation;
   const { mutate: unarchiveMutate } = unarchiveThreadMutation;
   const { mutate: markReadMutate } = markThreadRead;
@@ -328,66 +332,63 @@ export function ThreadActionsProvider({
 
   const archiveThreadAndChildrenAction = useCallback(
     (thread: Thread) => {
-      archiveThreadAndChildrenMutate(
-        { id: thread.id },
-        {
-          onSuccess: (response) => {
-            const navigateAwayIfArchived = () => {
-              const viewed = viewedThreadIdRef.current;
-              if (viewed && response.archivedThreadIds.includes(viewed)) {
-                navigate(getRootComposeRoutePath());
-              }
-            };
-            // Close any split panes showing archived threads and sync the URL
-            // to the surviving focused pane; only navigate the window away
-            // when nothing closed and the viewed thread was archived.
-            syncNavigationAfterClose(
-              closePanesForThreads(response.archivedThreadIds),
-              navigateAwayIfArchived,
-            );
-            const toastId = `thread-archived-${thread.id}`;
-            appToast.success(
-              <ArchivedThreadToastTitle
-                archivedThreadCount={response.archivedThreadIds.length}
-                threadTitle={getThreadDisplayTitle(thread)}
-                onOpenThread={() => {
-                  navigate(
-                    getThreadRoutePath({
-                      projectId: thread.projectId,
-                      threadId: thread.id,
-                    }),
-                  );
-                  appToast.dismiss(toastId);
-                }}
-              />,
-              {
-                action: {
-                  label: "Undo",
-                  onClick: () => {
-                    for (const threadId of response.archivedThreadIds) {
-                      unarchiveMutate({ id: threadId });
-                    }
-                  },
+      archiveThreadAndChildrenMutateAsync({ id: thread.id }).then(
+        (response) => {
+          const navigateAwayIfArchived = () => {
+            const viewed = viewedThreadIdRef.current;
+            if (viewed && response.archivedThreadIds.includes(viewed)) {
+              navigate(getRootComposeRoutePath());
+            }
+          };
+          // Close any split panes showing archived threads and sync the URL
+          // to the surviving focused pane; only navigate the window away
+          // when nothing closed and the viewed thread was archived.
+          syncNavigationAfterClose(
+            closePanesForThreads(response.archivedThreadIds),
+            navigateAwayIfArchived,
+          );
+          const toastId = `thread-archived-${thread.id}`;
+          appToast.success(
+            <ArchivedThreadToastTitle
+              archivedThreadCount={response.archivedThreadIds.length}
+              threadTitle={getThreadDisplayTitle(thread)}
+              onOpenThread={() => {
+                navigate(
+                  getThreadRoutePath({
+                    projectId: thread.projectId,
+                    threadId: thread.id,
+                  }),
+                );
+                appToast.dismiss(toastId);
+              }}
+            />,
+            {
+              action: {
+                label: "Undo",
+                onClick: () => {
+                  for (const threadId of response.archivedThreadIds) {
+                    unarchiveMutate({ id: threadId });
+                  }
                 },
-                duration: ARCHIVE_UNDO_TOAST_DURATION_MS,
-                id: toastId,
               },
-            );
-          },
-          onError: (error) => {
-            appToast.error(
-              getMutationErrorMessage({
-                error,
-                fallbackMessage: "Failed to archive thread and children",
-                lifecycleOperation: "archive_thread",
-              }),
-            );
-          },
+              duration: ARCHIVE_UNDO_TOAST_DURATION_MS,
+              id: toastId,
+            },
+          );
+        },
+        (error: unknown) => {
+          appToast.error(
+            getMutationErrorMessage({
+              error,
+              fallbackMessage: "Failed to archive thread and children",
+              lifecycleOperation: "archive_thread",
+            }),
+          );
         },
       );
     },
     [
-      archiveThreadAndChildrenMutate,
+      archiveThreadAndChildrenMutateAsync,
       closePanesForThreads,
       navigate,
       syncNavigationAfterClose,

--- a/apps/app/src/components/thread/ThreadArchiveQuickAction.test.tsx
+++ b/apps/app/src/components/thread/ThreadArchiveQuickAction.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { Thread } from "@bb/domain";
+import { TooltipProvider } from "@bb/shared-ui/tooltip";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ThreadArchiveQuickAction } from "./ThreadActionsMenu";
+
+const mocks = vi.hoisted(() => ({
+  archiveThreadAndChildren: vi.fn(),
+  unarchiveThread: vi.fn(),
+}));
+
+vi.mock("./ThreadActionsProvider", () => ({
+  useThreadActions: () => ({
+    archiveThreadAndChildren: mocks.archiveThreadAndChildren,
+    unarchiveThread: mocks.unarchiveThread,
+  }),
+}));
+
+function createThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: "thr_test",
+    archivedAt: null,
+    ...overrides,
+  } as Thread;
+}
+
+afterEach(() => {
+  cleanup();
+  mocks.archiveThreadAndChildren.mockReset();
+  mocks.unarchiveThread.mockReset();
+});
+
+describe("ThreadArchiveQuickAction", () => {
+  it("archives the thread on one click without bubbling to the row", () => {
+    const onRowClick = vi.fn();
+    const thread = createThread();
+    render(
+      <TooltipProvider>
+        <div onClick={onRowClick}>
+          <ThreadArchiveQuickAction thread={thread} />
+        </div>
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Archive thread" }));
+
+    expect(mocks.archiveThreadAndChildren).toHaveBeenCalledWith(thread);
+    expect(mocks.unarchiveThread).not.toHaveBeenCalled();
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+
+  it("unarchives an archived thread instead", () => {
+    const thread = createThread({ archivedAt: 5 });
+    render(
+      <TooltipProvider>
+        <ThreadArchiveQuickAction thread={thread} />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Unarchive thread" }));
+
+    expect(mocks.unarchiveThread).toHaveBeenCalledWith(thread);
+    expect(mocks.archiveThreadAndChildren).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/components/ui/sidebar-hover-actions.ts
+++ b/apps/app/src/components/ui/sidebar-hover-actions.ts
@@ -4,7 +4,14 @@ export const SIDEBAR_HOVER_ACTIONS_CLASS = "bb-sidebar-hover-actions";
 
 export const SIDEBAR_HOVER_ACTIONS_GAP_CLASS = "gap-0.5";
 
-export const SIDEBAR_HOVER_ACTIONS_FADE_CLASS =
-  "bb-sidebar-hover-actions-fade";
+/**
+ * Row content that must give way when the hover actions overlay extends past
+ * its rest slot. Reserves one extra action width while the row is hovered,
+ * focused, or has an open menu.
+ */
+export const SIDEBAR_HOVER_ACTIONS_INSET_CLASS =
+  "bb-sidebar-hover-actions-inset";
+
+export const SIDEBAR_HOVER_ACTIONS_FADE_CLASS = "bb-sidebar-hover-actions-fade";
 
 export const SIDEBAR_HOVER_ACTIONS_MOBILE_ALWAYS_VALUE = "always";

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -298,6 +298,24 @@
     opacity: 1;
   }
 
+  /* Row content beside a hover-actions overlay that grows past its rest slot
+   * (the thread row's archive button sits left of the menu trigger). Reserve
+   * one action width under the same row states that reveal the overlay, so the
+   * title truncates instead of running under the button. */
+  .bb-sidebar-hover-actions-inset {
+    transition-property: padding;
+    transition-duration: 0ms;
+  }
+
+  .bb-sidebar-hover-actions-row:is(:hover, :has(:focus-visible))
+    .bb-sidebar-hover-actions-inset,
+  .bb-sidebar-hover-actions-row:has(
+      .bb-sidebar-hover-actions[data-sidebar-hover-actions-open="true"]
+    )
+    .bb-sidebar-hover-actions-inset {
+    padding-right: 1.5rem;
+  }
+
   .bb-sidebar-hover-actions-fade {
     opacity: 1;
     transition-property: opacity;
@@ -311,6 +329,11 @@
   }
 
   @media (max-width: 767px) and (pointer: coarse) {
+    /* The overlay is hidden on coarse phones, so no room is reserved. */
+    .bb-sidebar-hover-actions-row .bb-sidebar-hover-actions-inset {
+      padding-right: 0;
+    }
+
     .bb-sidebar-hover-actions-row:hover:not(:has(:focus-visible))
       .bb-sidebar-hover-actions:not(
         [data-sidebar-hover-actions-open="true"]


### PR DESCRIPTION
## What was wrong

Archiving a thread from the sidebar took two or three actions: open the `…` menu or the right-click menu, then pick Archive. Users who clean up many threads a day asked for a one-click hover button like Cursor has (#1958, which supersedes #1159; the keyboard shortcut from #1172 is opt-in and not discoverable from the list).

## What changed

- `apps/app/src/components/thread/ThreadActionsMenu.tsx`: new `ThreadArchiveQuickAction`, an icon button with a tooltip that calls the same `archiveThreadAndChildren` / `unarchiveThread` actions as the menu entry. It uses the existing `Archive` / `ArchiveRestore` icons and stops propagation so the row link does not navigate.
- `apps/app/src/components/sidebar/ThreadRow.tsx`: the hover overlay is anchored `inset-y-0 right-0` so it can hold two actions; the archive button sits left of the `MoreHorizontal` trigger with a 2px gap.
- `apps/app/src/components/ui/theme.css` + `sidebar-hover-actions.ts`: new `bb-sidebar-hover-actions-inset` class reserves one action width on the title under the same row states that reveal the overlay (hover, focus-visible, open menu), so long titles truncate instead of running under the button. Reset to 0 on coarse phones where the overlay is hidden. Not applied when the row shows a shortcut pill instead of hover actions.

No wire, CLI, or doc changes; no new icon registered.

## How you verified

- New `ThreadArchiveQuickAction.test.tsx`: one click archives without bubbling to the row; an archived thread unarchives instead.
- Updated `ThreadRow.test.tsx` mock and wrapped `ProjectRow.interactions.test.tsx` renders in `TooltipProvider`.
- `pnpm exec turbo run typecheck lint test --filter=@bb/app`: 404 files, 3100 tests pass.
- Manual: dev app in headless Chromium — hover shows the button left of `…`, click removed the row and set `archived_at` in the dev DB; long title truncates before the button.

Fixes #1958

> AGENT GENERATED: by Claude Opus 5
