### PR TITLE
Add a Check for updates button and a 6-hour plugin update sweep

### DIFF
--- a/apps/app/src/components/plugin/PluginsOverview.tsx
+++ b/apps/app/src/components/plugin/PluginsOverview.tsx
@@ -22,6 +22,7 @@ import {
   type AddPluginInitial,
 } from "@/components/plugin/management/AddPluginDialog";
 import { BrowsePluginsTab } from "@/components/plugin/management/BrowsePluginsTab";
+import { CheckPluginUpdatesButton } from "@/components/plugin/management/CheckPluginUpdatesButton";
 import { InstalledPluginsTab } from "@/components/plugin/management/InstalledPluginsTab";
 import {
   pluginPublisherFilterId,
@@ -164,20 +165,24 @@ export function PluginsOverview() {
   };
 
   // Browse renders no page shell at all — its actions live in the hero's CTA
-  // row. Installed keeps the New plugin button, which starts a thread.
+  // row. Installed keeps the New plugin button, which starts a thread, plus
+  // an on-demand update check beside it (the server also sweeps every 6h).
   const installedActions = (
-    <CreateWithTemplatesButton
-      kind="plugin"
-      label="New plugin"
-      menuActions={[
-        {
-          label: "Install from source",
-          icon: "Download",
-          onSelect: () => setAddDialog({ open: true, initial: null }),
-        },
-      ]}
-      onCreate={startCreatePlugin}
-    />
+    <>
+      {plugins.length > 0 ? <CheckPluginUpdatesButton /> : null}
+      <CreateWithTemplatesButton
+        kind="plugin"
+        label="New plugin"
+        menuActions={[
+          {
+            label: "Install from source",
+            icon: "Download",
+            onSelect: () => setAddDialog({ open: true, initial: null }),
+          },
+        ]}
+        onCreate={startCreatePlugin}
+      />
+    </>
   );
 
   let content: ReactNode;

--- a/apps/app/src/components/plugin/management/CheckPluginUpdatesButton.test.tsx
+++ b/apps/app/src/components/plugin/management/CheckPluginUpdatesButton.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import { allPluginListQueryKeyPrefix } from "@/hooks/queries/query-keys";
+import {
+  CheckPluginUpdatesButton,
+  summarizeUpdateCheck,
+} from "./CheckPluginUpdatesButton";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const installed = { version: "1.0.0", display: "1.0.0" };
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("summarizeUpdateCheck", () => {
+  it("counts available updates and names them", () => {
+    expect(
+      summarizeUpdateCheck([
+        {
+          id: "b",
+          outcome: "update-available",
+          devMode: false,
+          installed,
+          candidate: { version: "1.1.0", display: "1.1.0" },
+          blocked: null,
+          detail: null,
+        },
+        {
+          id: "a",
+          outcome: "update-available",
+          devMode: false,
+          installed,
+          candidate: { version: "2.0.0", display: "2.0.0" },
+          blocked: null,
+          detail: null,
+        },
+        {
+          id: "c",
+          outcome: "current",
+          devMode: false,
+          installed,
+          candidate: null,
+          blocked: null,
+          detail: null,
+        },
+      ]),
+    ).toEqual({
+      tone: "success",
+      title: "2 plugin updates available",
+      description: "a, b",
+    });
+  });
+
+  it("reports up to date and mentions incompatible newer releases", () => {
+    expect(
+      summarizeUpdateCheck([
+        {
+          id: "a",
+          outcome: "incompatible",
+          devMode: false,
+          installed,
+          candidate: null,
+          blocked: { version: "3.0.0", reasons: ["needs bb >=9"] },
+          detail: null,
+        },
+      ]),
+    ).toEqual({
+      tone: "message",
+      title: "All plugins are up to date",
+      description: "a has a newer release that needs a newer bb.",
+    });
+  });
+});
+
+describe("CheckPluginUpdatesButton", () => {
+  it("posts a check for every plugin and refetches the plugin list", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        results: [
+          { id: "a", outcome: "current", installed },
+          {
+            id: "b",
+            outcome: "update-available",
+            installed,
+            candidate: { version: "1.1.0", display: "1.1.0" },
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { wrapper, queryClient } = createQueryClientTestHarness();
+    const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+    render(<CheckPluginUpdatesButton />, { wrapper });
+
+    fireEvent.click(screen.getByRole("button", { name: "Check for updates" }));
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(url).toContain("/plugins/updates/check");
+    expect(init.method).toBe("POST");
+    expect(init.body).toBe("{}");
+    await vi.waitFor(() =>
+      expect(invalidate).toHaveBeenCalledWith({
+        queryKey: allPluginListQueryKeyPrefix(),
+      }),
+    );
+    expect(
+      screen.getByRole("button", { name: "Check for updates" }),
+    ).toBeTruthy();
+  });
+
+  it("scopes the check to one plugin when given an id", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ results: [{ id: "a", outcome: "current", installed }] }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { wrapper } = createQueryClientTestHarness();
+    render(<CheckPluginUpdatesButton pluginId="a" appearance="inline" />, {
+      wrapper,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Check for updates" }));
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const [, init] = fetchMock.mock.calls[0] as unknown as [
+      string,
+      RequestInit,
+    ];
+    expect(JSON.parse(String(init.body))).toEqual({ id: "a" });
+  });
+});

--- a/apps/app/src/components/plugin/management/CheckPluginUpdatesButton.test.tsx
+++ b/apps/app/src/components/plugin/management/CheckPluginUpdatesButton.test.tsx
@@ -80,6 +80,53 @@ describe("summarizeUpdateCheck", () => {
     expect(summarizeUpdateCheck([blocked], { pluginId: "a" })).toMatchObject({
       title: "a is up to date",
     });
+    // A blocked newer release also rides on a `current` result.
+    expect(
+      summarizeUpdateCheck([
+        { ...blocked, outcome: "current" },
+        { ...blocked, id: "b", outcome: "current" },
+      ]),
+    ).toMatchObject({
+      description: "2 plugins have newer releases that need a newer bb.",
+    });
+  });
+
+  it("warns instead of reporting up to date when a check did not complete", () => {
+    const unavailable = {
+      id: "offline",
+      outcome: "unavailable" as const,
+      devMode: false,
+      installed,
+      candidate: null,
+      blocked: null,
+      detail: "registry request failed: network unreachable",
+    };
+    const current = { ...unavailable, id: "ok", outcome: "current" as const, detail: null };
+    expect(summarizeUpdateCheck([unavailable, current])).toEqual({
+      tone: "warning",
+      title: "Update check incomplete",
+      description: "Could not check 1 plugin: offline.",
+    });
+    expect(summarizeUpdateCheck([unavailable], { pluginId: "offline" })).toEqual({
+      tone: "warning",
+      title: "Could not check offline for updates",
+      description: "registry request failed: network unreachable",
+    });
+    expect(
+      summarizeUpdateCheck([
+        unavailable,
+        {
+          ...current,
+          id: "fresh",
+          outcome: "update-available",
+          candidate: { version: "2.0.0", display: "2.0.0" },
+        },
+      ]),
+    ).toEqual({
+      tone: "warning",
+      title: "1 plugin update available",
+      description: "fresh Could not check 1 plugin: offline.",
+    });
   });
 });
 

--- a/apps/app/src/components/plugin/management/CheckPluginUpdatesButton.test.tsx
+++ b/apps/app/src/components/plugin/management/CheckPluginUpdatesButton.test.tsx
@@ -63,22 +63,22 @@ describe("summarizeUpdateCheck", () => {
   });
 
   it("reports up to date and mentions incompatible newer releases", () => {
-    expect(
-      summarizeUpdateCheck([
-        {
-          id: "a",
-          outcome: "incompatible",
-          devMode: false,
-          installed,
-          candidate: null,
-          blocked: { version: "3.0.0", reasons: ["needs bb >=9"] },
-          detail: null,
-        },
-      ]),
-    ).toEqual({
+    const blocked = {
+      id: "a",
+      outcome: "incompatible" as const,
+      devMode: false,
+      installed,
+      candidate: null,
+      blocked: { version: "3.0.0", reasons: ["needs bb >=9"] },
+      detail: null,
+    };
+    expect(summarizeUpdateCheck([blocked])).toEqual({
       tone: "message",
       title: "All plugins are up to date",
       description: "a has a newer release that needs a newer bb.",
+    });
+    expect(summarizeUpdateCheck([blocked], { pluginId: "a" })).toMatchObject({
+      title: "a is up to date",
     });
   });
 });

--- a/apps/app/src/components/plugin/management/CheckPluginUpdatesButton.test.tsx
+++ b/apps/app/src/components/plugin/management/CheckPluginUpdatesButton.test.tsx
@@ -4,19 +4,35 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { allPluginListQueryKeyPrefix } from "@/hooks/queries/query-keys";
+import type { PluginUpdatesEntry } from "@/hooks/queries/plugin-catalog-queries";
 import {
   CheckPluginUpdatesButton,
   summarizeUpdateCheck,
 } from "./CheckPluginUpdatesButton";
 
-function jsonResponse(body: unknown, status = 200): Response {
+const installed = { version: "1.0.0", display: "1.0.0" };
+
+function entry(
+  id: string,
+  outcome: PluginUpdatesEntry["outcome"],
+  detail: string | null = null,
+): PluginUpdatesEntry {
+  return {
+    id,
+    outcome,
+    devMode: false,
+    installed,
+    candidate: null,
+    blocked: null,
+    detail,
+  };
+}
+
+function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
-    status,
     headers: { "content-type": "application/json" },
   });
 }
-
-const installed = { version: "1.0.0", display: "1.0.0" };
 
 afterEach(() => {
   cleanup();
@@ -24,104 +40,37 @@ afterEach(() => {
 });
 
 describe("summarizeUpdateCheck", () => {
-  it("counts available updates and names them", () => {
+  it("counts and names available updates", () => {
     expect(
       summarizeUpdateCheck([
-        {
-          id: "b",
-          outcome: "update-available",
-          devMode: false,
-          installed,
-          candidate: { version: "1.1.0", display: "1.1.0" },
-          blocked: null,
-          detail: null,
-        },
-        {
-          id: "a",
-          outcome: "update-available",
-          devMode: false,
-          installed,
-          candidate: { version: "2.0.0", display: "2.0.0" },
-          blocked: null,
-          detail: null,
-        },
-        {
-          id: "c",
-          outcome: "current",
-          devMode: false,
-          installed,
-          candidate: null,
-          blocked: null,
-          detail: null,
-        },
+        entry("b", "update-available"),
+        entry("a", "update-available"),
+        entry("c", "current"),
       ]),
     ).toEqual({
       tone: "success",
       title: "2 plugin updates available",
       description: "a, b",
     });
-  });
-
-  it("reports up to date and mentions incompatible newer releases", () => {
-    const blocked = {
-      id: "a",
-      outcome: "incompatible" as const,
-      devMode: false,
-      installed,
-      candidate: null,
-      blocked: { version: "3.0.0", reasons: ["needs bb >=9"] },
-      detail: null,
-    };
-    expect(summarizeUpdateCheck([blocked])).toEqual({
-      tone: "message",
-      title: "All plugins are up to date",
-      description: "a has a newer release that needs a newer bb.",
-    });
-    expect(summarizeUpdateCheck([blocked], { pluginId: "a" })).toMatchObject({
-      title: "a is up to date",
-    });
-    // A blocked newer release also rides on a `current` result.
     expect(
-      summarizeUpdateCheck([
-        { ...blocked, outcome: "current" },
-        { ...blocked, id: "b", outcome: "current" },
-      ]),
-    ).toMatchObject({
-      description: "2 plugins have newer releases that need a newer bb.",
-    });
+      summarizeUpdateCheck([entry("a", "current")], { pluginId: "a" }),
+    ).toMatchObject({ title: "a is up to date" });
   });
 
   it("warns instead of reporting up to date when a check did not complete", () => {
-    const unavailable = {
-      id: "offline",
-      outcome: "unavailable" as const,
-      devMode: false,
-      installed,
-      candidate: null,
-      blocked: null,
-      detail: "registry request failed: network unreachable",
-    };
-    const current = { ...unavailable, id: "ok", outcome: "current" as const, detail: null };
-    expect(summarizeUpdateCheck([unavailable, current])).toEqual({
+    const offline = entry("offline", "unavailable", "network unreachable");
+    expect(summarizeUpdateCheck([offline, entry("ok", "current")])).toEqual({
       tone: "warning",
       title: "Update check incomplete",
       description: "Could not check 1 plugin: offline.",
     });
-    expect(summarizeUpdateCheck([unavailable], { pluginId: "offline" })).toEqual({
+    expect(summarizeUpdateCheck([offline], { pluginId: "offline" })).toEqual({
       tone: "warning",
       title: "Could not check offline for updates",
-      description: "registry request failed: network unreachable",
+      description: "network unreachable",
     });
     expect(
-      summarizeUpdateCheck([
-        unavailable,
-        {
-          ...current,
-          id: "fresh",
-          outcome: "update-available",
-          candidate: { version: "2.0.0", display: "2.0.0" },
-        },
-      ]),
+      summarizeUpdateCheck([offline, entry("fresh", "update-available")]),
     ).toEqual({
       tone: "warning",
       title: "1 plugin update available",
@@ -131,62 +80,40 @@ describe("summarizeUpdateCheck", () => {
 });
 
 describe("CheckPluginUpdatesButton", () => {
-  it("posts a check for every plugin and refetches the plugin list", async () => {
+  it("posts a full or scoped check and refetches the plugin list", async () => {
     const fetchMock = vi.fn(async () =>
-      jsonResponse({
-        results: [
-          { id: "a", outcome: "current", installed },
-          {
-            id: "b",
-            outcome: "update-available",
-            installed,
-            candidate: { version: "1.1.0", display: "1.1.0" },
-          },
-        ],
-      }),
+      jsonResponse({ results: [{ id: "a", outcome: "current", installed }] }),
     );
     vi.stubGlobal("fetch", fetchMock);
     const { wrapper, queryClient } = createQueryClientTestHarness();
     const invalidate = vi.spyOn(queryClient, "invalidateQueries");
-    render(<CheckPluginUpdatesButton />, { wrapper });
+    render(
+      <>
+        <CheckPluginUpdatesButton />
+        <CheckPluginUpdatesButton pluginId="a" appearance="inline" />
+      </>,
+      { wrapper },
+    );
+    const [toolbar, inline] = screen.getAllByRole("button", {
+      name: "Check for updates",
+    });
 
-    fireEvent.click(screen.getByRole("button", { name: "Check for updates" }));
-
+    fireEvent.click(toolbar!);
     await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
-    const [url, init] = fetchMock.mock.calls[0] as unknown as [
-      string,
-      RequestInit,
-    ];
-    expect(url).toContain("/plugins/updates/check");
-    expect(init.method).toBe("POST");
-    expect(init.body).toBe("{}");
+    fireEvent.click(inline!);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    const bodies = fetchMock.mock.calls.map((call) => {
+      const [url, init] = call as unknown as [string, RequestInit];
+      expect(url).toContain("/plugins/updates/check");
+      expect(init.method).toBe("POST");
+      return JSON.parse(String(init.body));
+    });
+    expect(bodies).toEqual([{}, { id: "a" }]);
     await vi.waitFor(() =>
       expect(invalidate).toHaveBeenCalledWith({
         queryKey: allPluginListQueryKeyPrefix(),
       }),
     );
-    expect(
-      screen.getByRole("button", { name: "Check for updates" }),
-    ).toBeTruthy();
-  });
-
-  it("scopes the check to one plugin when given an id", async () => {
-    const fetchMock = vi.fn(async () =>
-      jsonResponse({ results: [{ id: "a", outcome: "current", installed }] }),
-    );
-    vi.stubGlobal("fetch", fetchMock);
-    const { wrapper } = createQueryClientTestHarness();
-    render(<CheckPluginUpdatesButton pluginId="a" appearance="inline" />, {
-      wrapper,
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: "Check for updates" }));
-
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
-    const [, init] = fetchMock.mock.calls[0] as unknown as [
-      string,
-      RequestInit,
-    ];
-    expect(JSON.parse(String(init.body))).toEqual({ id: "a" });
   });
 });

--- a/apps/app/src/components/plugin/management/CheckPluginUpdatesButton.tsx
+++ b/apps/app/src/components/plugin/management/CheckPluginUpdatesButton.tsx
@@ -16,30 +16,67 @@ import {
 } from "@/hooks/queries/plugin-catalog-queries";
 import { pluginAdminErrorMessage } from "@/lib/plugin-admin-error";
 
-/** One-line toast summary of a full update check. */
+function namePlugins(ids: readonly string[]): string {
+  return [...ids].sort().join(", ");
+}
+
+function countPlugins(count: number): string {
+  return count === 1 ? "1 plugin" : `${count} plugins`;
+}
+
+/**
+ * One-line toast summary of an update check. Anything the check could not
+ * resolve (registry offline, moved tag, retired source) is a warning, never
+ * folded into "up to date": a 200 response still carries per-plugin failures.
+ */
 export function summarizeUpdateCheck(
   results: readonly PluginUpdatesEntry[],
   scope: { pluginId?: string } = {},
 ): {
-  tone: "success" | "message";
+  tone: "success" | "message" | "warning";
   title: string;
   description?: string;
 } {
   const available = results.filter(
     (result) => result.outcome === "update-available",
   );
-  const blocked = results.filter((result) => result.outcome === "incompatible");
+  const unavailable = results.filter(
+    (result) => result.outcome === "unavailable",
+  );
+  // A blocked newer release rides on `current` and `update-available` results
+  // too, so read the field rather than the `incompatible` outcome alone.
+  const blocked = results.filter(
+    (result) => result.outcome === "incompatible" || result.blocked !== null,
+  );
+  const unavailableNote =
+    unavailable.length === 0
+      ? null
+      : scope.pluginId !== undefined
+        ? (unavailable[0]?.detail ?? "The update check did not complete.")
+        : `Could not check ${countPlugins(unavailable.length)}: ${namePlugins(unavailable.map((result) => result.id))}.`;
   if (available.length > 0) {
     return {
-      tone: "success",
+      tone: unavailableNote === null ? "success" : "warning",
       title:
         available.length === 1
           ? "1 plugin update available"
           : `${available.length} plugin updates available`,
-      description: available
-        .map((result) => result.id)
-        .sort()
-        .join(", "),
+      description: [
+        namePlugins(available.map((result) => result.id)),
+        unavailableNote,
+      ]
+        .filter((part) => part !== null)
+        .join(" "),
+    };
+  }
+  if (unavailableNote !== null) {
+    return {
+      tone: "warning",
+      title:
+        scope.pluginId === undefined
+          ? "Update check incomplete"
+          : `Could not check ${scope.pluginId} for updates`,
+      description: unavailableNote,
     };
   }
   return {
@@ -53,7 +90,7 @@ export function summarizeUpdateCheck(
           description:
             blocked.length === 1
               ? `${blocked[0]?.id} has a newer release that needs a newer bb.`
-              : `${blocked.length} plugins have newer releases that need a newer bb.`,
+              : `${countPlugins(blocked.length)} have newer releases that need a newer bb.`,
         }
       : {}),
   };

--- a/apps/app/src/components/plugin/management/CheckPluginUpdatesButton.tsx
+++ b/apps/app/src/components/plugin/management/CheckPluginUpdatesButton.tsx
@@ -1,0 +1,142 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@bb/shared-ui/button";
+import { Icon } from "@bb/shared-ui/icon";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@bb/shared-ui/tooltip";
+import { cn } from "@bb/shared-ui/lib/utils";
+import { appToast } from "@/components/ui/app-toast";
+import { invalidatePluginList } from "@/hooks/cache-owners/plugin-cache-owner";
+import {
+  checkPluginUpdates,
+  type PluginUpdatesEntry,
+} from "@/hooks/queries/plugin-catalog-queries";
+import { pluginAdminErrorMessage } from "@/lib/plugin-admin-error";
+
+/** One-line toast summary of a full update check. */
+export function summarizeUpdateCheck(results: readonly PluginUpdatesEntry[]): {
+  tone: "success" | "message";
+  title: string;
+  description?: string;
+} {
+  const available = results.filter(
+    (result) => result.outcome === "update-available",
+  );
+  const blocked = results.filter((result) => result.outcome === "incompatible");
+  if (available.length > 0) {
+    return {
+      tone: "success",
+      title:
+        available.length === 1
+          ? "1 plugin update available"
+          : `${available.length} plugin updates available`,
+      description: available
+        .map((result) => result.id)
+        .sort()
+        .join(", "),
+    };
+  }
+  return {
+    tone: "message",
+    title: "All plugins are up to date",
+    ...(blocked.length > 0
+      ? {
+          description:
+            blocked.length === 1
+              ? `${blocked[0]?.id} has a newer release that needs a newer bb.`
+              : `${blocked.length} plugins have newer releases that need a newer bb.`,
+        }
+      : {}),
+  };
+}
+
+/**
+ * Toolbar key that checks every installed plugin for updates. The server
+ * persists what it finds, and the invalidated plugin list surfaces it as the
+ * row "Update x.y.z" pills; the toast only summarizes the sweep. Same 32px
+ * outline box as the filter and sort keys beside it.
+ */
+export function CheckPluginUpdatesButton({
+  pluginId,
+  appearance = "toolbar",
+  className,
+}: {
+  /** Check one plugin instead of all of them. */
+  pluginId?: string;
+  /** `toolbar`: 32px icon key. `inline`: compact labeled detail-section button. */
+  appearance?: "toolbar" | "inline";
+  className?: string;
+}) {
+  const queryClient = useQueryClient();
+  const check = useMutation({
+    mutationFn: () =>
+      checkPluginUpdates(fetch, pluginId === undefined ? {} : { id: pluginId }),
+    onSuccess: (results) => {
+      const summary = summarizeUpdateCheck(results);
+      appToast[summary.tone](summary.title, {
+        description: summary.description,
+      });
+    },
+    onError: (error) => {
+      appToast.error("Checking for plugin updates failed", {
+        description: pluginAdminErrorMessage(error),
+      });
+    },
+    onSettled: () => invalidatePluginList({ queryClient }),
+  });
+  const label = check.isPending ? "Checking for updates…" : "Check for updates";
+  if (appearance === "inline") {
+    return (
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        data-testid="check-plugin-updates"
+        className={cn("h-6 px-2 text-xs", className)}
+        aria-label={label}
+        aria-busy={check.isPending}
+        disabled={check.isPending}
+        onClick={() => check.mutate()}
+      >
+        <Icon
+          name={check.isPending ? "Spinner" : "RotateCcw"}
+          className={cn("size-3.5", check.isPending && "animate-spin")}
+          aria-hidden
+        />
+        Check
+      </Button>
+    );
+  }
+  return (
+    <TooltipProvider delayDuration={250}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            data-testid="check-plugin-updates"
+            className={cn(
+              "size-8 shrink-0 rounded-md border border-input bg-background p-0 text-muted-foreground",
+              className,
+            )}
+            aria-label={label}
+            aria-busy={check.isPending}
+            disabled={check.isPending}
+            onClick={() => check.mutate()}
+          >
+            <Icon
+              name={check.isPending ? "Spinner" : "RotateCcw"}
+              className={cn("size-4", check.isPending && "animate-spin")}
+              aria-hidden
+            />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">{label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/apps/app/src/components/plugin/management/CheckPluginUpdatesButton.tsx
+++ b/apps/app/src/components/plugin/management/CheckPluginUpdatesButton.tsx
@@ -17,7 +17,10 @@ import {
 import { pluginAdminErrorMessage } from "@/lib/plugin-admin-error";
 
 /** One-line toast summary of a full update check. */
-export function summarizeUpdateCheck(results: readonly PluginUpdatesEntry[]): {
+export function summarizeUpdateCheck(
+  results: readonly PluginUpdatesEntry[],
+  scope: { pluginId?: string } = {},
+): {
   tone: "success" | "message";
   title: string;
   description?: string;
@@ -41,7 +44,10 @@ export function summarizeUpdateCheck(results: readonly PluginUpdatesEntry[]): {
   }
   return {
     tone: "message",
-    title: "All plugins are up to date",
+    title:
+      scope.pluginId === undefined
+        ? "All plugins are up to date"
+        : `${scope.pluginId} is up to date`,
     ...(blocked.length > 0
       ? {
           description:
@@ -75,7 +81,10 @@ export function CheckPluginUpdatesButton({
     mutationFn: () =>
       checkPluginUpdates(fetch, pluginId === undefined ? {} : { id: pluginId }),
     onSuccess: (results) => {
-      const summary = summarizeUpdateCheck(results);
+      const summary = summarizeUpdateCheck(
+        results,
+        pluginId === undefined ? {} : { pluginId },
+      );
       appToast[summary.tone](summary.title, {
         description: summary.description,
       });

--- a/apps/app/src/components/plugin/management/CheckPluginUpdatesButton.tsx
+++ b/apps/app/src/components/plugin/management/CheckPluginUpdatesButton.tsx
@@ -16,18 +16,10 @@ import {
 } from "@/hooks/queries/plugin-catalog-queries";
 import { pluginAdminErrorMessage } from "@/lib/plugin-admin-error";
 
-function namePlugins(ids: readonly string[]): string {
-  return [...ids].sort().join(", ");
-}
-
-function countPlugins(count: number): string {
-  return count === 1 ? "1 plugin" : `${count} plugins`;
-}
-
 /**
- * One-line toast summary of an update check. Anything the check could not
- * resolve (registry offline, moved tag, retired source) is a warning, never
- * folded into "up to date": a 200 response still carries per-plugin failures.
+ * One-line toast summary of an update check. A 200 response still carries
+ * per-plugin failures (`unavailable`), so those warn instead of folding into
+ * "up to date".
  */
 export function summarizeUpdateCheck(
   results: readonly PluginUpdatesEntry[],
@@ -37,46 +29,34 @@ export function summarizeUpdateCheck(
   title: string;
   description?: string;
 } {
-  const available = results.filter(
-    (result) => result.outcome === "update-available",
-  );
-  const unavailable = results.filter(
-    (result) => result.outcome === "unavailable",
-  );
-  // A blocked newer release rides on `current` and `update-available` results
-  // too, so read the field rather than the `incompatible` outcome alone.
-  const blocked = results.filter(
-    (result) => result.outcome === "incompatible" || result.blocked !== null,
-  );
-  const unavailableNote =
+  const ids = (outcome: PluginUpdatesEntry["outcome"]) =>
+    results
+      .filter((result) => result.outcome === outcome)
+      .map((result) => result.id)
+      .sort();
+  const available = ids("update-available");
+  const unavailable = ids("unavailable");
+  const problem =
     unavailable.length === 0
       ? null
       : scope.pluginId !== undefined
-        ? (unavailable[0]?.detail ?? "The update check did not complete.")
-        : `Could not check ${countPlugins(unavailable.length)}: ${namePlugins(unavailable.map((result) => result.id))}.`;
+        ? (results[0]?.detail ?? "The update check did not complete.")
+        : `Could not check ${unavailable.length === 1 ? "1 plugin" : `${unavailable.length} plugins`}: ${unavailable.join(", ")}.`;
   if (available.length > 0) {
     return {
-      tone: unavailableNote === null ? "success" : "warning",
-      title:
-        available.length === 1
-          ? "1 plugin update available"
-          : `${available.length} plugin updates available`,
-      description: [
-        namePlugins(available.map((result) => result.id)),
-        unavailableNote,
-      ]
-        .filter((part) => part !== null)
-        .join(" "),
+      tone: problem === null ? "success" : "warning",
+      title: `${available.length} plugin update${available.length === 1 ? "" : "s"} available`,
+      description: [available.join(", "), problem].filter(Boolean).join(" "),
     };
   }
-  if (unavailableNote !== null) {
+  if (problem !== null) {
     return {
       tone: "warning",
       title:
         scope.pluginId === undefined
           ? "Update check incomplete"
           : `Could not check ${scope.pluginId} for updates`,
-      description: unavailableNote,
+      description: problem,
     };
   }
   return {
@@ -85,43 +65,29 @@ export function summarizeUpdateCheck(
       scope.pluginId === undefined
         ? "All plugins are up to date"
         : `${scope.pluginId} is up to date`,
-    ...(blocked.length > 0
-      ? {
-          description:
-            blocked.length === 1
-              ? `${blocked[0]?.id} has a newer release that needs a newer bb.`
-              : `${countPlugins(blocked.length)} have newer releases that need a newer bb.`,
-        }
-      : {}),
   };
 }
 
 /**
- * Toolbar key that checks every installed plugin for updates. The server
- * persists what it finds, and the invalidated plugin list surfaces it as the
- * row "Update x.y.z" pills; the toast only summarizes the sweep. Same 32px
- * outline box as the filter and sort keys beside it.
+ * Checks installed plugins for updates. The server persists what it finds and
+ * the invalidated plugin list surfaces it as the row update buttons; the toast
+ * only summarizes the sweep.
  */
 export function CheckPluginUpdatesButton({
   pluginId,
   appearance = "toolbar",
-  className,
 }: {
   /** Check one plugin instead of all of them. */
   pluginId?: string;
-  /** `toolbar`: 32px icon key. `inline`: compact labeled detail-section button. */
+  /** `toolbar`: 32px icon key like the filter keys. `inline`: compact labeled button. */
   appearance?: "toolbar" | "inline";
-  className?: string;
 }) {
   const queryClient = useQueryClient();
   const check = useMutation({
     mutationFn: () =>
       checkPluginUpdates(fetch, pluginId === undefined ? {} : { id: pluginId }),
     onSuccess: (results) => {
-      const summary = summarizeUpdateCheck(
-        results,
-        pluginId === undefined ? {} : { pluginId },
-      );
+      const summary = summarizeUpdateCheck(results, { pluginId });
       appToast[summary.tone](summary.title, {
         description: summary.description,
       });
@@ -134,53 +100,39 @@ export function CheckPluginUpdatesButton({
     onSettled: () => invalidatePluginList({ queryClient }),
   });
   const label = check.isPending ? "Checking for updates…" : "Check for updates";
-  if (appearance === "inline") {
-    return (
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        data-testid="check-plugin-updates"
-        className={cn("h-6 px-2 text-xs", className)}
-        aria-label={label}
-        aria-busy={check.isPending}
-        disabled={check.isPending}
-        onClick={() => check.mutate()}
-      >
-        <Icon
-          name={check.isPending ? "Spinner" : "RotateCcw"}
-          className={cn("size-3.5", check.isPending && "animate-spin")}
-          aria-hidden
-        />
-        Check
-      </Button>
-    );
-  }
+  const inline = appearance === "inline";
+  const button = (
+    <Button
+      type="button"
+      variant="outline"
+      size={inline ? "sm" : "icon"}
+      data-testid="check-plugin-updates"
+      className={
+        inline
+          ? "h-6 px-2 text-xs"
+          : "size-8 shrink-0 rounded-md border border-input bg-background p-0 text-muted-foreground"
+      }
+      aria-label={label}
+      aria-busy={check.isPending}
+      disabled={check.isPending}
+      onClick={() => check.mutate()}
+    >
+      <Icon
+        name={check.isPending ? "Spinner" : "RotateCcw"}
+        className={cn(
+          inline ? "size-3.5" : "size-4",
+          check.isPending && "animate-spin",
+        )}
+        aria-hidden
+      />
+      {inline ? "Check" : null}
+    </Button>
+  );
+  if (inline) return button;
   return (
     <TooltipProvider delayDuration={250}>
       <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            data-testid="check-plugin-updates"
-            className={cn(
-              "size-8 shrink-0 rounded-md border border-input bg-background p-0 text-muted-foreground",
-              className,
-            )}
-            aria-label={label}
-            aria-busy={check.isPending}
-            disabled={check.isPending}
-            onClick={() => check.mutate()}
-          >
-            <Icon
-              name={check.isPending ? "Spinner" : "RotateCcw"}
-              className={cn("size-4", check.isPending && "animate-spin")}
-              aria-hidden
-            />
-          </Button>
-        </TooltipTrigger>
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
         <TooltipContent side="bottom">{label}</TooltipContent>
       </Tooltip>
     </TooltipProvider>

--- a/apps/app/src/components/plugin/management/PluginRowSignal.test.tsx
+++ b/apps/app/src/components/plugin/management/PluginRowSignal.test.tsx
@@ -46,10 +46,7 @@ describe("PluginRowSignalView", () => {
         onStatusClick={vi.fn()}
       />,
     );
-    expect(
-      screen.getByRole("button", { name: "Update available: version 1.2.0" })
-        .textContent,
-    ).toBe("Update to 1.2.0");
+    expect(screen.getByRole("button", { name: "Update to 1.2.0" })).toBeTruthy();
 
     rerender(
       <PluginRowSignalView
@@ -62,8 +59,7 @@ describe("PluginRowSignalView", () => {
       />,
     );
     const button = screen.getByRole("button", { name: "Update available" });
-    expect(button.textContent).toBe("Update");
-    expect(button.textContent).not.toContain("a985e1d");
+    expect(button.getAttribute("aria-label")).not.toContain("a985e1d");
   });
 });
 

--- a/apps/app/src/components/plugin/management/PluginRowSignal.tsx
+++ b/apps/app/src/components/plugin/management/PluginRowSignal.tsx
@@ -51,30 +51,33 @@ export function PluginRowSignalView({
 }) {
   if (signal.kind === "update") {
     // The row only ever says what is offered — a readable version when there
-    // is one — and the dialog carries the (shortened) hash detail.
+    // is one — and the dialog carries the (shortened) hash detail. The control
+    // is an icon key like the status one beside it; the tooltip and the
+    // accessible name carry the words.
     const readableVersion = isReadablePluginVersion(signal.version)
       ? signal.version
       : null;
+    const updateDescription =
+      readableVersion === null ? "Update available" : `Update to ${readableVersion}`;
     return (
-      <button
-        type="button"
-        className={cn(
-          "flex shrink-0 cursor-pointer items-center gap-1 rounded-md border border-border",
-          "bg-transparent px-2 py-1 text-2xs font-medium text-foreground",
-          "hover:bg-state-hover focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none",
-        )}
-        aria-label={`Update available${readableVersion === null ? "" : `: version ${readableVersion}`}`}
-        onClick={onUpdateClick}
-      >
-        <span
-          className="flex shrink-0 items-center"
-          style={UPDATE_ICON_STYLE}
-          aria-hidden
-        >
-          <Icon name="ArrowUp" className="size-3.5" />
-        </span>
-        {readableVersion === null ? "Update" : `Update to ${readableVersion}`}
-      </button>
+      <TooltipProvider delayDuration={250}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="size-7 shrink-0 rounded-full"
+              style={UPDATE_ICON_STYLE}
+              aria-label={updateDescription}
+              onClick={onUpdateClick}
+            >
+              <Icon name="ArrowUp" className="size-4" aria-hidden />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{updateDescription}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     );
   }
 

--- a/apps/app/src/components/plugin/management/PluginRowSignal.tsx
+++ b/apps/app/src/components/plugin/management/PluginRowSignal.tsx
@@ -72,7 +72,7 @@ export function PluginRowSignalView({
               aria-label={updateDescription}
               onClick={onUpdateClick}
             >
-              <Icon name="ArrowUp" className="size-4" aria-hidden />
+              <Icon name="PackageReceive" className="size-4" aria-hidden />
             </Button>
           </TooltipTrigger>
           <TooltipContent>{updateDescription}</TooltipContent>

--- a/apps/app/src/components/tools/PluginDetail.tsx
+++ b/apps/app/src/components/tools/PluginDetail.tsx
@@ -22,6 +22,7 @@ import { formatHomePathForDisplay } from "@bb/shared-ui/lib/utils";
 import { Icon } from "@bb/shared-ui/icon";
 import { Link } from "react-router-dom";
 import { getPluginConfigurationRoutePath } from "@/lib/route-paths";
+import { CheckPluginUpdatesButton } from "@/components/plugin/management/CheckPluginUpdatesButton";
 import {
   PluginDetailReleaseControl,
   PluginDetailReleaseStatus,
@@ -436,6 +437,11 @@ export function PluginDetail({
           actions={
             hasReleaseControl ? (
               <PluginDetailReleaseControl plugin={plugin} />
+            ) : hasUpdateManagement ? (
+              <CheckPluginUpdatesButton
+                pluginId={plugin.id}
+                appearance="inline"
+              />
             ) : undefined
           }
         >

--- a/apps/server/src/services/plugins/managed-plugin-artifacts.ts
+++ b/apps/server/src/services/plugins/managed-plugin-artifacts.ts
@@ -206,6 +206,31 @@ async function installNpmCandidate(args: {
   );
 }
 
+/**
+ * The npm resolver for a marketplace listing's registry: the guarded
+ * marketplace transport (public address only, no redirects, timeout) plus a
+ * bounded JSON reader. The URL check runs inside the request so an update
+ * sweep over a bad registry yields an `unavailable` result, not a crash.
+ */
+export function createListedRegistryNpmResolverRun(listedRegistry: string) {
+  return createNpmResolverRun({
+    fetch: (input, init) => {
+      assertPublicMarketplaceUrl(listedRegistry);
+      return publicMarketplaceFetch(input, {
+        ...init,
+        redirect: "error",
+        signal: AbortSignal.timeout(MARKETPLACE_FETCH_TIMEOUT_MS),
+      });
+    },
+    readJson: (response) =>
+      boundedResponseJson(
+        response,
+        MARKETPLACE_PACKUMENT_MAX_BYTES,
+        "npm registry metadata",
+      ),
+  });
+}
+
 export function createManagedPluginArtifacts(
   context: ManagedPluginArtifactsContext,
 ) {
@@ -228,21 +253,10 @@ export function createManagedPluginArtifacts(
   /** Use the guarded network and byte policy only for a listing's registry. */
   function npmResolverRun(listedRegistry: string | undefined) {
     if (listedRegistry === undefined) return createNpmResolverRun();
+    // Installs refuse a non-public registry up front; the run below re-checks
+    // on every request so a later DNS or redirect answer cannot widen it.
     assertPublicMarketplaceUrl(listedRegistry);
-    return createNpmResolverRun({
-      fetch: (input, init) =>
-        publicMarketplaceFetch(input, {
-          ...init,
-          redirect: "error",
-          signal: AbortSignal.timeout(MARKETPLACE_FETCH_TIMEOUT_MS),
-        }),
-      readJson: (response) =>
-        boundedResponseJson(
-          response,
-          MARKETPLACE_PACKUMENT_MAX_BYTES,
-          "npm registry metadata",
-        ),
-    });
+    return createListedRegistryNpmResolverRun(listedRegistry);
   }
 
   function assertExpectedPluginId(

--- a/apps/server/src/services/plugins/plugin-service-internal.ts
+++ b/apps/server/src/services/plugins/plugin-service-internal.ts
@@ -142,6 +142,8 @@ export interface PluginServiceDeps {
     durationMs: number,
     onElapsed: () => void,
   ) => () => void;
+  /** Test seam for the periodic update-check timer. */
+  scheduleUpdateCheck?: (delayMs: number, onElapsed: () => void) => () => void;
   /** Test failpoint after state replay but before pointer restoration. */
   afterPluginRollbackStateRestored?: (args: {
     pluginId: string;

--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -242,7 +242,7 @@ export interface PluginService {
   checkForUpdates(id?: string): Promise<PluginUpdateCheckEntry[]>;
   /** Check every plugin for updates every 6 hours; see PluginUpdates. */
   startPeriodicUpdateChecks(): void;
-  stopPeriodicUpdateChecks(): void;
+  stopPeriodicUpdateChecks(): Promise<void>;
   listUpdateResults(): PluginUpdateCheckEntry[];
   getSource(id: string): Promise<PluginSourceView | undefined>;
   applyUpdate(id: string): Promise<PluginApplyUpdateOutcome>;

--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -240,6 +240,9 @@ export interface PluginService {
   >;
   installPath(path: string): Promise<PluginListEntry>;
   checkForUpdates(id?: string): Promise<PluginUpdateCheckEntry[]>;
+  /** Check every plugin for updates every 6 hours; see PluginUpdates. */
+  startPeriodicUpdateChecks(): void;
+  stopPeriodicUpdateChecks(): void;
   listUpdateResults(): PluginUpdateCheckEntry[];
   getSource(id: string): Promise<PluginSourceView | undefined>;
   applyUpdate(id: string): Promise<PluginApplyUpdateOutcome>;

--- a/apps/server/src/services/plugins/plugin-updates.ts
+++ b/apps/server/src/services/plugins/plugin-updates.ts
@@ -39,8 +39,20 @@ import type {
   PluginUpdateCheckEntry,
 } from "./plugin-service-internal.js";
 
+export const PLUGIN_UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1_000;
+
 export interface PluginUpdates {
   checkForUpdates(id?: string): Promise<PluginUpdateCheckEntry[]>;
+  /**
+   * Check every installed plugin for updates on a fixed interval. The first
+   * check runs at once when no plugin has a recorded check, or when the
+   * newest recorded check is older than the interval; otherwise it waits
+   * for the remainder, so a restart does not trigger a check. Bundled and
+   * path installs resolve locally, so a sweep only reaches the network for
+   * npm, git, and marketplace installs.
+   */
+  startPeriodicUpdateChecks(): void;
+  stopPeriodicUpdateChecks(): void;
   listUpdateResults(): PluginUpdateCheckEntry[];
   getSource(id: string): Promise<PluginSourceView | undefined>;
   applyUpdate(id: string): Promise<PluginApplyUpdateOutcome>;
@@ -77,6 +89,7 @@ export function createPluginUpdates(
     managedArtifacts: { applyNpmCandidate, stageGitCandidate },
     runArtifactGc,
   } = context;
+  const now = deps.now ?? Date.now;
   // A commit is immutable. Keep its manifest compatibility result for this
   // server process so the six-hour sweep does not clone the same releases.
   const gitCandidateProbeCache = new Map<string, GitCandidateProbeResult>();
@@ -127,7 +140,7 @@ export function createPluginUpdates(
 
   function persistUpdateEntry(entry: PluginUpdateCheckEntry): void {
     const changed = setInstalledPluginUpdateState(deps.db, entry.id, {
-      lastCheckAt: Date.now(),
+      lastCheckAt: now(),
       availableCompatibleVersion: entry.candidate?.version ?? null,
       newestIncompatibleVersion: entry.blocked?.version ?? null,
       statusDetail: JSON.stringify(entry),
@@ -372,7 +385,75 @@ export function createPluginUpdates(
     };
   }
 
-  return {
+  const scheduleUpdateCheck =
+    deps.scheduleUpdateCheck ??
+    ((delayMs: number, onElapsed: () => void) => {
+      const timer = setTimeout(onElapsed, delayMs);
+      timer.unref();
+      return () => clearTimeout(timer);
+    });
+  let cancelPeriodicCheck: (() => void) | null = null;
+  let periodicChecksStopped = true;
+
+  function scheduleNextPeriodicCheck(): void {
+    if (periodicChecksStopped) return;
+    cancelPeriodicCheck?.();
+    const lastCheckAt = listInstalledPlugins(deps.db).reduce<number | null>(
+      (newest, row) =>
+        row.lastUpdateCheckAt === null
+          ? newest
+          : Math.max(newest ?? 0, row.lastUpdateCheckAt),
+      null,
+    );
+    const delay =
+      lastCheckAt === null
+        ? 0
+        : Math.max(
+            0,
+            PLUGIN_UPDATE_CHECK_INTERVAL_MS - Math.max(0, now() - lastCheckAt),
+          );
+    cancelPeriodicCheck = scheduleUpdateCheck(delay, runPeriodicCheck);
+  }
+
+  function runPeriodicCheck(): void {
+    if (periodicChecksStopped) return;
+    cancelPeriodicCheck = null;
+    const startedAt = now();
+    void updates
+      .checkForUpdates()
+      .catch((error: unknown) => {
+        deps.logger.warn(
+          { err: error },
+          "periodic plugin update check failed",
+        );
+      })
+      .finally(() => {
+        if (periodicChecksStopped) return;
+        // A failed sweep persists nothing, so the recorded check time would
+        // schedule an immediate retry loop; wait a full interval instead.
+        cancelPeriodicCheck = scheduleUpdateCheck(
+          Math.max(
+            0,
+            PLUGIN_UPDATE_CHECK_INTERVAL_MS - Math.max(0, now() - startedAt),
+          ),
+          runPeriodicCheck,
+        );
+      });
+  }
+
+  const updates: PluginUpdates = {
+    startPeriodicUpdateChecks() {
+      if (!periodicChecksStopped) return;
+      periodicChecksStopped = false;
+      scheduleNextPeriodicCheck();
+    },
+
+    stopPeriodicUpdateChecks() {
+      periodicChecksStopped = true;
+      cancelPeriodicCheck?.();
+      cancelPeriodicCheck = null;
+    },
+
     async checkForUpdates(id) {
       const rows =
         id === undefined
@@ -634,4 +715,5 @@ export function createPluginUpdates(
       });
     },
   };
+  return updates;
 }

--- a/apps/server/src/services/plugins/plugin-updates.ts
+++ b/apps/server/src/services/plugins/plugin-updates.ts
@@ -45,81 +45,30 @@ import type {
 } from "./plugin-service-internal.js";
 
 export const PLUGIN_UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1_000;
-/**
- * Plugins resolved at once in one check. A git range check can stage several
- * candidate clones per plugin, so an unbounded sweep over a large install
- * set could fan out into dozens of concurrent clones and registry requests.
- */
+/** A git range check can stage several clones per plugin; bound the fan-out. */
 const UPDATE_CHECK_CONCURRENCY = 4;
-/** Direct-registry packument requests are time-boxed like marketplace ones. */
-const NPM_REGISTRY_TIMEOUT_MS = MARKETPLACE_FETCH_TIMEOUT_MS;
-
-/** Run `fn` over `items` in order with at most `limit` in flight; results keep item order. */
-async function mapWithConcurrency<T, R>(
-  items: readonly T[],
-  limit: number,
-  fn: (item: T) => Promise<R>,
-): Promise<R[]> {
-  const results: R[] = new Array<R>(items.length);
-  let next = 0;
-  const workers = Array.from(
-    { length: Math.min(limit, items.length) },
-    async () => {
-      while (next < items.length) {
-        const index = next;
-        next += 1;
-        results[index] = await fn(items[index] as T);
-      }
-    },
-  );
-  await Promise.all(workers);
-  return results;
-}
-
-interface NpmResolverRuns {
-  forRow(row: InstalledPluginRow): NpmResolverRun;
-}
 
 /**
- * One packument cache per check, split by trust. A catalog listing named its
- * registry, so its rows use the guarded marketplace transport and bounded
- * reader exactly as installation did; direct `npm:` installs keep the
- * registry the user configured and the default transport.
+ * A catalog listing named its registry, so its rows use the guarded
+ * marketplace transport exactly as installation did. Direct `npm:` installs
+ * keep the user's registry on the default transport, time-boxed.
  */
-function createNpmResolverRuns(): NpmResolverRuns {
-  const direct = createNpmResolverRun({
-    fetch: (input, init) =>
-      fetch(input, {
-        ...init,
-        signal: AbortSignal.timeout(NPM_REGISTRY_TIMEOUT_MS),
-      }),
-  });
-  const listed = new Map<string, NpmResolverRun>();
-  return {
-    forRow(row) {
-      const registry =
-        row.provenance === "catalog" ? row.sourceNpmRegistry : null;
-      if (registry === null) return direct;
-      let run = listed.get(registry);
-      if (run === undefined) {
-        run = createListedRegistryNpmResolverRun(registry);
-        listed.set(registry, run);
-      }
-      return run;
-    },
-  };
+function npmRunForRow(row: InstalledPluginRow): NpmResolverRun {
+  const registry = row.provenance === "catalog" ? row.sourceNpmRegistry : null;
+  return registry === null
+    ? createNpmResolverRun({
+        fetch: (input, init) =>
+          fetch(input, {
+            ...init,
+            signal: AbortSignal.timeout(MARKETPLACE_FETCH_TIMEOUT_MS),
+          }),
+      })
+    : createListedRegistryNpmResolverRun(registry);
 }
 
 export interface PluginUpdates {
   checkForUpdates(id?: string): Promise<PluginUpdateCheckEntry[]>;
-  /**
-   * Check every installed plugin for updates on a fixed interval. The first
-   * check runs at once when a plugin has no recorded check, or when the
-   * oldest recorded check is older than the interval; otherwise it waits
-   * for the remainder, so a restart does not trigger a check. Bundled and
-   * path installs resolve locally, so a sweep only reaches the network for
-   * npm, git, and marketplace installs.
-   */
+  /** Sweep every plugin on a fixed interval, due from the stalest check. */
   startPeriodicUpdateChecks(): void;
   /** Cancels the next sweep and waits for one in flight to finish. */
   stopPeriodicUpdateChecks(): Promise<void>;
@@ -349,7 +298,7 @@ export function createPluginUpdates(
 
   async function resolveUpdateForRow(args: {
     row: InstalledPluginRow;
-    npmRuns: NpmResolverRuns;
+    npmRun: NpmResolverRun;
     npmIntentOverride?: NpmSourceIntentForResolution;
   }): Promise<PluginUpdateResolution> {
     const installed = installedUpdateVersion(args.row);
@@ -375,7 +324,7 @@ export function createPluginUpdates(
         intent: args.npmIntentOverride ?? npmIntentForRow(args.row),
         current: installed,
         appVersion: deps.appVersion,
-        run: args.npmRuns.forRow(args.row),
+        run: args.npmRun,
         includePinned: args.npmIntentOverride !== undefined,
       });
     }
@@ -464,97 +413,75 @@ export function createPluginUpdates(
     });
   let cancelPeriodicCheck: (() => void) | null = null;
   let periodicChecksStopped = true;
+  let inFlightSweep: Promise<PluginUpdateCheckEntry[]> | null = null;
 
-  function scheduleNextPeriodicCheck(): void {
-    if (periodicChecksStopped) return;
-    cancelPeriodicCheck?.();
-    // The sweep is due when its stalest plugin is: a scoped check of one
-    // plugin must not push out the others, and a never-checked plugin is due
-    // now. Rows that never reach the network (path, builtin) do not count.
-    let oldestCheckAt = Number.POSITIVE_INFINITY;
-    for (const row of listInstalledPlugins(deps.db)) {
-      if (row.sourceKind === "path" || row.sourceKind === "builtin") continue;
-      if (row.lastUpdateCheckAt === null) {
-        oldestCheckAt = Number.NEGATIVE_INFINITY;
-        break;
-      }
-      oldestCheckAt = Math.min(oldestCheckAt, row.lastUpdateCheckAt);
-    }
-    const delay =
-      oldestCheckAt === Number.POSITIVE_INFINITY
-        ? PLUGIN_UPDATE_CHECK_INTERVAL_MS
-        : oldestCheckAt === Number.NEGATIVE_INFINITY
-          ? 0
-          : Math.max(
-              0,
-              PLUGIN_UPDATE_CHECK_INTERVAL_MS -
-                Math.max(0, now() - oldestCheckAt),
-            );
-    cancelPeriodicCheck = scheduleUpdateCheck(delay, runPeriodicCheck);
+  /** Delay until the stalest network-reachable plugin is due; null rows are due now. */
+  function periodicCheckDelay(): number {
+    const stamps = listInstalledPlugins(deps.db)
+      .filter(
+        (row) => row.sourceKind !== "path" && row.sourceKind !== "builtin",
+      )
+      .map((row) => row.lastUpdateCheckAt);
+    if (stamps.includes(null)) return 0;
+    const oldest = Math.min(...stamps.filter((stamp) => stamp !== null));
+    return Math.max(0, PLUGIN_UPDATE_CHECK_INTERVAL_MS - (now() - oldest));
   }
 
   function runPeriodicCheck(): void {
     if (periodicChecksStopped) return;
-    cancelPeriodicCheck = null;
-    const startedAt = now();
     void updates
       .checkForUpdates()
       .catch((error: unknown) => {
-        deps.logger.warn(
-          { err: error },
-          "periodic plugin update check failed",
-        );
+        deps.logger.warn({ err: error }, "periodic plugin update check failed");
       })
       .finally(() => {
-        if (periodicChecksStopped) return;
-        // A failed sweep persists nothing, so the recorded check time would
-        // schedule an immediate retry loop; wait a full interval instead.
-        cancelPeriodicCheck = scheduleUpdateCheck(
-          Math.max(
-            0,
-            PLUGIN_UPDATE_CHECK_INTERVAL_MS - Math.max(0, now() - startedAt),
-          ),
-          runPeriodicCheck,
-        );
+        // A full interval, not periodicCheckDelay(): a failed sweep persists
+        // nothing and would otherwise retry at once.
+        if (!periodicChecksStopped) {
+          cancelPeriodicCheck = scheduleUpdateCheck(
+            PLUGIN_UPDATE_CHECK_INTERVAL_MS,
+            runPeriodicCheck,
+          );
+        }
       });
-  }
-
-  let inFlightSweep: Promise<PluginUpdateCheckEntry[]> | null = null;
-
-  function requireRow(id: string): InstalledPluginRow {
-    const row = getInstalledPlugin(deps.db, id);
-    if (!row) throw new Error(`unknown plugin "${id}"`);
-    return row;
   }
 
   async function checkRows(
     rows: InstalledPluginRow[],
   ): Promise<PluginUpdateCheckEntry[]> {
-    const npmRuns = createNpmResolverRuns();
-    const results = await mapWithConcurrency(
-      rows.sort((a, b) => a.id.localeCompare(b.id)),
-      UPDATE_CHECK_CONCURRENCY,
-      (row) =>
-        withLifecycleLock(row.id, async () => {
+    rows.sort((a, b) => a.id.localeCompare(b.id));
+    const results: PluginUpdateCheckEntry[] = [];
+    let next = 0;
+    const worker = async () => {
+      while (next < rows.length) {
+        const index = next++;
+        const row = rows[index] as InstalledPluginRow;
+        results[index] = await withLifecycleLock(row.id, async () => {
           const current = getInstalledPlugin(deps.db, row.id);
           if (!current) {
             throw new Error(
               `plugin "${row.id}" disappeared during update check`,
             );
           }
-          const installed = installedUpdateVersion(current);
           const resolution = await resolveUpdateForRow({
             row: current,
-            npmRuns,
+            npmRun: npmRunForRow(current),
           });
           const checked = checkEntryFromResolution(
             current.id,
-            installed,
+            installedUpdateVersion(current),
             resolution,
           );
           persistUpdateEntry(checked);
           return checked;
-        }),
+        });
+      }
+    };
+    await Promise.all(
+      Array.from(
+        { length: Math.min(UPDATE_CHECK_CONCURRENCY, rows.length) },
+        worker,
+      ),
     );
     notifyPluginsChanged();
     return results;
@@ -564,31 +491,30 @@ export function createPluginUpdates(
     startPeriodicUpdateChecks() {
       if (!periodicChecksStopped) return;
       periodicChecksStopped = false;
-      scheduleNextPeriodicCheck();
+      cancelPeriodicCheck = scheduleUpdateCheck(
+        periodicCheckDelay(),
+        runPeriodicCheck,
+      );
     },
 
     async stopPeriodicUpdateChecks() {
       periodicChecksStopped = true;
       cancelPeriodicCheck?.();
       cancelPeriodicCheck = null;
-      // A sweep in flight holds per-plugin lifecycle locks; let it drain so
-      // plugin shutdown does not queue behind it. Every request in it is
-      // time-boxed, so this wait is bounded.
+      // Let a sweep drain so plugin shutdown does not queue behind its locks.
       await inFlightSweep?.catch(() => undefined);
     },
 
     checkForUpdates(id) {
-      if (id !== undefined) return checkRows([requireRow(id)]);
-      // One full sweep at a time: a click during the periodic sweep (or a
-      // second click) joins it instead of queueing duplicate network work
-      // behind every lifecycle lock.
-      if (inFlightSweep === null) {
-        inFlightSweep = checkRows(listInstalledPlugins(deps.db)).finally(
-          () => {
-            inFlightSweep = null;
-          },
-        );
+      if (id !== undefined) {
+        const row = getInstalledPlugin(deps.db, id);
+        if (!row) throw new Error(`unknown plugin "${id}"`);
+        return checkRows([row]);
       }
+      // Concurrent full sweeps join the one in flight instead of re-fetching.
+      inFlightSweep ??= checkRows(listInstalledPlugins(deps.db)).finally(() => {
+        inFlightSweep = null;
+      });
       return inFlightSweep;
     },
 
@@ -672,12 +598,12 @@ export function createPluginUpdates(
         const row = getInstalledPlugin(deps.db, id);
         if (!row) return { ok: false, error: `unknown plugin "${id}"` };
         const from = installedUpdateVersion(row);
-        const npmRuns = createNpmResolverRuns();
+        const npmRun = npmRunForRow(row);
         const selectionNpmIntent =
           row.sourceKind === "npm" ? npmIntentForRow(row) : undefined;
         const resolution = await resolveUpdateForRow({
           row,
-          npmRuns,
+          npmRun,
         });
         const checked = checkEntryFromResolution(id, from, resolution);
         persistUpdateEntry(checked);
@@ -717,7 +643,7 @@ export function createPluginUpdates(
             const selected = await selectNpmCandidate({
               intent: selectionNpmIntent,
               appVersion: deps.appVersion,
-              run: npmRuns.forRow(row),
+              run: npmRun,
             });
             if (selected.outcome !== "selected") {
               throw new Error(

--- a/apps/server/src/services/plugins/plugin-updates.ts
+++ b/apps/server/src/services/plugins/plugin-updates.ts
@@ -17,6 +17,7 @@ import {
 import { readPluginManifest } from "./manifest.js";
 import {
   createNpmResolverRun,
+  type NpmResolverRun,
   resolveGitRef,
   resolveGitUpdate,
   resolveNpmUpdate,
@@ -30,7 +31,11 @@ import {
 } from "./update-resolver.js";
 import { PluginActivationRolledBackError } from "./plugin-activation.js";
 import type { createPluginActivation } from "./plugin-activation.js";
-import type { createManagedPluginArtifacts } from "./managed-plugin-artifacts.js";
+import {
+  createListedRegistryNpmResolverRun,
+  type createManagedPluginArtifacts,
+} from "./managed-plugin-artifacts.js";
+import { MARKETPLACE_FETCH_TIMEOUT_MS } from "../plugin-catalog/marketplace-http.js";
 import { pluginUpdateCheckEntrySchema } from "./plugin-service-internal.js";
 import type {
   PluginApplyUpdateOutcome,
@@ -40,19 +45,84 @@ import type {
 } from "./plugin-service-internal.js";
 
 export const PLUGIN_UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1_000;
+/**
+ * Plugins resolved at once in one check. A git range check can stage several
+ * candidate clones per plugin, so an unbounded sweep over a large install
+ * set could fan out into dozens of concurrent clones and registry requests.
+ */
+const UPDATE_CHECK_CONCURRENCY = 4;
+/** Direct-registry packument requests are time-boxed like marketplace ones. */
+const NPM_REGISTRY_TIMEOUT_MS = MARKETPLACE_FETCH_TIMEOUT_MS;
+
+/** Run `fn` over `items` in order with at most `limit` in flight; results keep item order. */
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array<R>(items.length);
+  let next = 0;
+  const workers = Array.from(
+    { length: Math.min(limit, items.length) },
+    async () => {
+      while (next < items.length) {
+        const index = next;
+        next += 1;
+        results[index] = await fn(items[index] as T);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+interface NpmResolverRuns {
+  forRow(row: InstalledPluginRow): NpmResolverRun;
+}
+
+/**
+ * One packument cache per check, split by trust. A catalog listing named its
+ * registry, so its rows use the guarded marketplace transport and bounded
+ * reader exactly as installation did; direct `npm:` installs keep the
+ * registry the user configured and the default transport.
+ */
+function createNpmResolverRuns(): NpmResolverRuns {
+  const direct = createNpmResolverRun({
+    fetch: (input, init) =>
+      fetch(input, {
+        ...init,
+        signal: AbortSignal.timeout(NPM_REGISTRY_TIMEOUT_MS),
+      }),
+  });
+  const listed = new Map<string, NpmResolverRun>();
+  return {
+    forRow(row) {
+      const registry =
+        row.provenance === "catalog" ? row.sourceNpmRegistry : null;
+      if (registry === null) return direct;
+      let run = listed.get(registry);
+      if (run === undefined) {
+        run = createListedRegistryNpmResolverRun(registry);
+        listed.set(registry, run);
+      }
+      return run;
+    },
+  };
+}
 
 export interface PluginUpdates {
   checkForUpdates(id?: string): Promise<PluginUpdateCheckEntry[]>;
   /**
    * Check every installed plugin for updates on a fixed interval. The first
-   * check runs at once when no plugin has a recorded check, or when the
-   * newest recorded check is older than the interval; otherwise it waits
+   * check runs at once when a plugin has no recorded check, or when the
+   * oldest recorded check is older than the interval; otherwise it waits
    * for the remainder, so a restart does not trigger a check. Bundled and
    * path installs resolve locally, so a sweep only reaches the network for
    * npm, git, and marketplace installs.
    */
   startPeriodicUpdateChecks(): void;
-  stopPeriodicUpdateChecks(): void;
+  /** Cancels the next sweep and waits for one in flight to finish. */
+  stopPeriodicUpdateChecks(): Promise<void>;
   listUpdateResults(): PluginUpdateCheckEntry[];
   getSource(id: string): Promise<PluginSourceView | undefined>;
   applyUpdate(id: string): Promise<PluginApplyUpdateOutcome>;
@@ -279,7 +349,7 @@ export function createPluginUpdates(
 
   async function resolveUpdateForRow(args: {
     row: InstalledPluginRow;
-    npmRun: ReturnType<typeof createNpmResolverRun>;
+    npmRuns: NpmResolverRuns;
     npmIntentOverride?: NpmSourceIntentForResolution;
   }): Promise<PluginUpdateResolution> {
     const installed = installedUpdateVersion(args.row);
@@ -305,7 +375,7 @@ export function createPluginUpdates(
         intent: args.npmIntentOverride ?? npmIntentForRow(args.row),
         current: installed,
         appVersion: deps.appVersion,
-        run: args.npmRun,
+        run: args.npmRuns.forRow(args.row),
         includePinned: args.npmIntentOverride !== undefined,
       });
     }
@@ -398,20 +468,28 @@ export function createPluginUpdates(
   function scheduleNextPeriodicCheck(): void {
     if (periodicChecksStopped) return;
     cancelPeriodicCheck?.();
-    const lastCheckAt = listInstalledPlugins(deps.db).reduce<number | null>(
-      (newest, row) =>
-        row.lastUpdateCheckAt === null
-          ? newest
-          : Math.max(newest ?? 0, row.lastUpdateCheckAt),
-      null,
-    );
+    // The sweep is due when its stalest plugin is: a scoped check of one
+    // plugin must not push out the others, and a never-checked plugin is due
+    // now. Rows that never reach the network (path, builtin) do not count.
+    let oldestCheckAt = Number.POSITIVE_INFINITY;
+    for (const row of listInstalledPlugins(deps.db)) {
+      if (row.sourceKind === "path" || row.sourceKind === "builtin") continue;
+      if (row.lastUpdateCheckAt === null) {
+        oldestCheckAt = Number.NEGATIVE_INFINITY;
+        break;
+      }
+      oldestCheckAt = Math.min(oldestCheckAt, row.lastUpdateCheckAt);
+    }
     const delay =
-      lastCheckAt === null
-        ? 0
-        : Math.max(
-            0,
-            PLUGIN_UPDATE_CHECK_INTERVAL_MS - Math.max(0, now() - lastCheckAt),
-          );
+      oldestCheckAt === Number.POSITIVE_INFINITY
+        ? PLUGIN_UPDATE_CHECK_INTERVAL_MS
+        : oldestCheckAt === Number.NEGATIVE_INFINITY
+          ? 0
+          : Math.max(
+              0,
+              PLUGIN_UPDATE_CHECK_INTERVAL_MS -
+                Math.max(0, now() - oldestCheckAt),
+            );
     cancelPeriodicCheck = scheduleUpdateCheck(delay, runPeriodicCheck);
   }
 
@@ -441,6 +519,47 @@ export function createPluginUpdates(
       });
   }
 
+  let inFlightSweep: Promise<PluginUpdateCheckEntry[]> | null = null;
+
+  function requireRow(id: string): InstalledPluginRow {
+    const row = getInstalledPlugin(deps.db, id);
+    if (!row) throw new Error(`unknown plugin "${id}"`);
+    return row;
+  }
+
+  async function checkRows(
+    rows: InstalledPluginRow[],
+  ): Promise<PluginUpdateCheckEntry[]> {
+    const npmRuns = createNpmResolverRuns();
+    const results = await mapWithConcurrency(
+      rows.sort((a, b) => a.id.localeCompare(b.id)),
+      UPDATE_CHECK_CONCURRENCY,
+      (row) =>
+        withLifecycleLock(row.id, async () => {
+          const current = getInstalledPlugin(deps.db, row.id);
+          if (!current) {
+            throw new Error(
+              `plugin "${row.id}" disappeared during update check`,
+            );
+          }
+          const installed = installedUpdateVersion(current);
+          const resolution = await resolveUpdateForRow({
+            row: current,
+            npmRuns,
+          });
+          const checked = checkEntryFromResolution(
+            current.id,
+            installed,
+            resolution,
+          );
+          persistUpdateEntry(checked);
+          return checked;
+        }),
+    );
+    notifyPluginsChanged();
+    return results;
+  }
+
   const updates: PluginUpdates = {
     startPeriodicUpdateChecks() {
       if (!periodicChecksStopped) return;
@@ -448,50 +567,29 @@ export function createPluginUpdates(
       scheduleNextPeriodicCheck();
     },
 
-    stopPeriodicUpdateChecks() {
+    async stopPeriodicUpdateChecks() {
       periodicChecksStopped = true;
       cancelPeriodicCheck?.();
       cancelPeriodicCheck = null;
+      // A sweep in flight holds per-plugin lifecycle locks; let it drain so
+      // plugin shutdown does not queue behind it. Every request in it is
+      // time-boxed, so this wait is bounded.
+      await inFlightSweep?.catch(() => undefined);
     },
 
-    async checkForUpdates(id) {
-      const rows =
-        id === undefined
-          ? listInstalledPlugins(deps.db)
-          : (() => {
-              const row = getInstalledPlugin(deps.db, id);
-              if (!row) throw new Error(`unknown plugin "${id}"`);
-              return [row];
-            })();
-      const npmRun = createNpmResolverRun();
-      const results = await Promise.all(
-        rows
-          .sort((a, b) => a.id.localeCompare(b.id))
-          .map((row) =>
-            withLifecycleLock(row.id, async () => {
-              const current = getInstalledPlugin(deps.db, row.id);
-              if (!current) {
-                throw new Error(
-                  `plugin "${row.id}" disappeared during update check`,
-                );
-              }
-              const installed = installedUpdateVersion(current);
-              const resolution = await resolveUpdateForRow({
-                row: current,
-                npmRun,
-              });
-              const checked = checkEntryFromResolution(
-                current.id,
-                installed,
-                resolution,
-              );
-              persistUpdateEntry(checked);
-              return checked;
-            }),
-          ),
-      );
-      notifyPluginsChanged();
-      return results;
+    checkForUpdates(id) {
+      if (id !== undefined) return checkRows([requireRow(id)]);
+      // One full sweep at a time: a click during the periodic sweep (or a
+      // second click) joins it instead of queueing duplicate network work
+      // behind every lifecycle lock.
+      if (inFlightSweep === null) {
+        inFlightSweep = checkRows(listInstalledPlugins(deps.db)).finally(
+          () => {
+            inFlightSweep = null;
+          },
+        );
+      }
+      return inFlightSweep;
     },
 
     listUpdateResults() {
@@ -574,12 +672,12 @@ export function createPluginUpdates(
         const row = getInstalledPlugin(deps.db, id);
         if (!row) return { ok: false, error: `unknown plugin "${id}"` };
         const from = installedUpdateVersion(row);
-        const npmRun = createNpmResolverRun();
+        const npmRuns = createNpmResolverRuns();
         const selectionNpmIntent =
           row.sourceKind === "npm" ? npmIntentForRow(row) : undefined;
         const resolution = await resolveUpdateForRow({
           row,
-          npmRun,
+          npmRuns,
         });
         const checked = checkEntryFromResolution(id, from, resolution);
         persistUpdateEntry(checked);
@@ -619,7 +717,7 @@ export function createPluginUpdates(
             const selected = await selectNpmCandidate({
               intent: selectionNpmIntent,
               appVersion: deps.appVersion,
-              run: npmRun,
+              run: npmRuns.forRow(row),
             });
             if (selected.outcome !== "selected") {
               throw new Error(

--- a/apps/server/src/start-server.ts
+++ b/apps/server/src/start-server.ts
@@ -250,6 +250,9 @@ export async function runServer(serverConfig: ServerConfig): Promise<void> {
       // Success or failure, the registry now holds whatever loaded: release
       // the requests waiting for providers rather than stalling them out.
       providerRegistry.markRegistrationsSettled();
+      // Check installed plugins for updates every 6 hours. A check only
+      // records what is available; it never installs or runs plugin code.
+      pluginService.startPeriodicUpdateChecks();
     });
   // Discovery metadata only: a refresh never installs, updates, or runs
   // plugin code, and a failure keeps the last-known-good catalog.
@@ -269,6 +272,7 @@ export async function runServer(serverConfig: ServerConfig): Promise<void> {
       eventLoopStallMonitor.stop();
       clearInterval(sweepInterval);
       pluginCatalogService.stopPeriodicRefresh();
+      pluginService.stopPeriodicUpdateChecks();
       await pluginService.stop().catch((error: unknown) => {
         logger.warn({ err: error }, "Plugin shutdown failed");
       });

--- a/apps/server/src/start-server.ts
+++ b/apps/server/src/start-server.ts
@@ -272,7 +272,7 @@ export async function runServer(serverConfig: ServerConfig): Promise<void> {
       eventLoopStallMonitor.stop();
       clearInterval(sweepInterval);
       pluginCatalogService.stopPeriodicRefresh();
-      pluginService.stopPeriodicUpdateChecks();
+      await pluginService.stopPeriodicUpdateChecks();
       await pluginService.stop().catch((error: unknown) => {
         logger.warn({ err: error }, "Plugin shutdown failed");
       });

--- a/apps/server/test/services/plugins/plugin-update.test.ts
+++ b/apps/server/test/services/plugins/plugin-update.test.ts
@@ -706,6 +706,78 @@ describe("plugin update service and routes", () => {
     ]);
   }, 60_000);
 
+  it("sweeps for updates on start, then waits a full interval across restarts", async () => {
+    await service.stop();
+    let clock = Date.now();
+    const scheduled: Array<{ delayMs: number; onElapsed: () => void }> = [];
+    const makeService = () =>
+      createPluginService({
+        telemetry: createNoopTelemetryService(),
+        db,
+        hub: {
+          getDaemonSessionIdForHost: () => null,
+          notifyPluginSignal: () => 0,
+          notifySystem: () => {},
+        },
+        logger,
+        dataDir: join(workDir, "data"),
+        appVersion: "1.0.0",
+        stabilizationWindowMs: 0,
+        now: () => clock,
+        scheduleUpdateCheck: (delayMs, onElapsed) => {
+          const entry = { delayMs, onElapsed };
+          scheduled.push(entry);
+          return () => {
+            const index = scheduled.indexOf(entry);
+            if (index !== -1) scheduled.splice(index, 1);
+          };
+        },
+      });
+    const settle = async () => {
+      // The sweep runs off the timer callback; wait for its persisted state.
+      for (let i = 0; i < 200; i += 1) {
+        if (getInstalledPlugin(db, "updater")?.lastUpdateCheckAt !== null) {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+    };
+    expect(getInstalledPlugin(db, "updater")?.lastUpdateCheckAt).toBeNull();
+
+    // No plugin has been checked: the first sweep is due at once.
+    service = makeService();
+    await service.start();
+    const nextCommit = await commitPlugin(repo, "1.1.0");
+    service.startPeriodicUpdateChecks();
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]?.delayMs).toBe(0);
+    scheduled.shift()?.onElapsed();
+    await settle();
+    expect(getInstalledPlugin(db, "updater")).toMatchObject({
+      lastUpdateCheckAt: clock,
+      availableCompatibleVersion: nextCommit,
+    });
+    // Wait for the sweep's follow-up to be scheduled a full interval out.
+    for (let i = 0; i < 200 && scheduled.length === 0; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]?.delayMs).toBe(6 * 60 * 60 * 1_000);
+
+    // Stop cancels the pending timer; a restart 2h later waits the remaining 4h
+    // instead of checking again.
+    service.stopPeriodicUpdateChecks();
+    expect(scheduled).toHaveLength(0);
+    await service.stop();
+    clock += 2 * 60 * 60 * 1_000;
+    service = makeService();
+    await service.start();
+    service.startPeriodicUpdateChecks();
+    expect(scheduled).toHaveLength(1);
+    expect(scheduled[0]?.delayMs).toBe(4 * 60 * 60 * 1_000);
+    service.stopPeriodicUpdateChecks();
+  }, 60_000);
+
   it("retains rollback state through the grace period and collects it afterward", async () => {
     await service.stop();
     let clock = Date.now();

--- a/apps/server/test/services/plugins/plugin-update.test.ts
+++ b/apps/server/test/services/plugins/plugin-update.test.ts
@@ -778,6 +778,138 @@ describe("plugin update service and routes", () => {
     service.stopPeriodicUpdateChecks();
   }, 60_000);
 
+  it("schedules the sweep from the stalest plugin, not a recent scoped check", async () => {
+    await service.stop();
+    let clock = Date.now();
+    const scheduled: Array<{ delayMs: number; onElapsed: () => void }> = [];
+    const makeService = () =>
+      createPluginService({
+        telemetry: createNoopTelemetryService(),
+        db,
+        hub: {
+          getDaemonSessionIdForHost: () => null,
+          notifyPluginSignal: () => 0,
+          notifySystem: () => {},
+        },
+        logger,
+        dataDir: join(workDir, "data"),
+        appVersion: "1.0.0",
+        stabilizationWindowMs: 0,
+        now: () => clock,
+        scheduleUpdateCheck: (delayMs, onElapsed) => {
+          scheduled.push({ delayMs, onElapsed });
+          return () => {};
+        },
+      });
+    // A second, never-checked npm plugin beside the git fixture.
+    upsertInstalledPlugin(db, {
+      id: "never-checked",
+      source: "npm:bb-plugin-never-checked",
+      provenance: { kind: "direct" },
+      sourceIntent: {
+        kind: "npm",
+        packageName: "bb-plugin-never-checked",
+        registry: "https://never-checked.test",
+        requestedSpec: "",
+        specKind: "default",
+      },
+      exactResolution: {
+        kind: "npm",
+        version: "1.0.0",
+        integrity: "sha512-current",
+      },
+      updateState: {
+        lastCheckAt: null,
+        availableCompatibleVersion: null,
+        newestIncompatibleVersion: null,
+        statusDetail: null,
+      },
+      activeArtifactId: null,
+      rootDir: join(workDir, "never-checked"),
+      version: "1.0.0",
+      enabled: false,
+    });
+    service = makeService();
+    await service.start();
+
+    // A scoped check stamps only the git plugin.
+    await service.checkForUpdates("updater");
+    expect(getInstalledPlugin(db, "updater")?.lastUpdateCheckAt).toBe(clock);
+    expect(getInstalledPlugin(db, "never-checked")?.lastUpdateCheckAt).toBeNull();
+
+    // The sweep is still due now because one plugin was never checked.
+    service.startPeriodicUpdateChecks();
+    expect(scheduled.map((entry) => entry.delayMs)).toEqual([0]);
+    await service.stopPeriodicUpdateChecks();
+
+    // Once both are stamped, the oldest stamp drives the delay.
+    clock += 60_000;
+    db.$client
+      .prepare("UPDATE plugins SET last_update_check_at = ? WHERE id = ?")
+      .run(clock, "never-checked");
+    scheduled.length = 0;
+    service.startPeriodicUpdateChecks();
+    expect(scheduled.map((entry) => entry.delayMs)).toEqual([
+      6 * 60 * 60 * 1_000 - 60_000,
+    ]);
+    await service.stopPeriodicUpdateChecks();
+  }, 60_000);
+
+  it("shares one in-flight full sweep between concurrent callers", async () => {
+    const first = service.checkForUpdates();
+    const second = service.checkForUpdates();
+    expect(second).toBe(first);
+    await first;
+    // After it settles, a new call starts a new sweep.
+    expect(service.checkForUpdates()).not.toBe(first);
+  }, 60_000);
+
+  it("keeps the guarded registry policy for catalog installs during a check", async () => {
+    upsertInstalledPlugin(db, {
+      id: "listed",
+      source: "npm:bb-plugin-listed",
+      provenance: { kind: "catalog", marketplace: "bb-community", entryId: "listed" },
+      sourceIntent: {
+        kind: "npm",
+        packageName: "bb-plugin-listed",
+        // A listing that names a loopback registry must never be fetched.
+        registry: "https://127.0.0.1",
+        requestedSpec: "",
+        specKind: "default",
+      },
+      exactResolution: {
+        kind: "npm",
+        version: "1.0.0",
+        integrity: "sha512-current",
+      },
+      updateState: {
+        lastCheckAt: null,
+        availableCompatibleVersion: null,
+        newestIncompatibleVersion: null,
+        statusDetail: null,
+      },
+      activeArtifactId: null,
+      rootDir: join(workDir, "listed"),
+      version: "1.0.0",
+      enabled: false,
+    });
+    const fetchMock = vi.fn(async () => {
+      throw new Error("unexpected unguarded fetch");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const results = await service.checkForUpdates("listed");
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        id: "listed",
+        outcome: "unavailable",
+        detail: expect.stringContaining("non-public address 127.0.0.1"),
+      }),
+    ]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("retains rollback state through the grace period and collects it afterward", async () => {
     await service.stop();
     let clock = Date.now();

--- a/apps/server/test/services/plugins/plugin-update.test.ts
+++ b/apps/server/test/services/plugins/plugin-update.test.ts
@@ -706,110 +706,25 @@ describe("plugin update service and routes", () => {
     ]);
   }, 60_000);
 
-  it("sweeps for updates on start, then waits a full interval across restarts", async () => {
-    await service.stop();
-    let clock = Date.now();
-    const scheduled: Array<{ delayMs: number; onElapsed: () => void }> = [];
-    const makeService = () =>
-      createPluginService({
-        telemetry: createNoopTelemetryService(),
-        db,
-        hub: {
-          getDaemonSessionIdForHost: () => null,
-          notifyPluginSignal: () => 0,
-          notifySystem: () => {},
-        },
-        logger,
-        dataDir: join(workDir, "data"),
-        appVersion: "1.0.0",
-        stabilizationWindowMs: 0,
-        now: () => clock,
-        scheduleUpdateCheck: (delayMs, onElapsed) => {
-          const entry = { delayMs, onElapsed };
-          scheduled.push(entry);
-          return () => {
-            const index = scheduled.indexOf(entry);
-            if (index !== -1) scheduled.splice(index, 1);
-          };
-        },
-      });
-    const settle = async () => {
-      // The sweep runs off the timer callback; wait for its persisted state.
-      for (let i = 0; i < 200; i += 1) {
-        if (getInstalledPlugin(db, "updater")?.lastUpdateCheckAt !== null) {
-          break;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 25));
-      }
-    };
-    expect(getInstalledPlugin(db, "updater")?.lastUpdateCheckAt).toBeNull();
-
-    // No plugin has been checked: the first sweep is due at once.
-    service = makeService();
-    await service.start();
-    const nextCommit = await commitPlugin(repo, "1.1.0");
-    service.startPeriodicUpdateChecks();
-    expect(scheduled).toHaveLength(1);
-    expect(scheduled[0]?.delayMs).toBe(0);
-    scheduled.shift()?.onElapsed();
-    await settle();
-    expect(getInstalledPlugin(db, "updater")).toMatchObject({
-      lastUpdateCheckAt: clock,
-      availableCompatibleVersion: nextCommit,
-    });
-    // Wait for the sweep's follow-up to be scheduled a full interval out.
-    for (let i = 0; i < 200 && scheduled.length === 0; i += 1) {
-      await new Promise((resolve) => setTimeout(resolve, 25));
-    }
-    expect(scheduled).toHaveLength(1);
-    expect(scheduled[0]?.delayMs).toBe(6 * 60 * 60 * 1_000);
-
-    // Stop cancels the pending timer; a restart 2h later waits the remaining 4h
-    // instead of checking again.
-    service.stopPeriodicUpdateChecks();
-    expect(scheduled).toHaveLength(0);
-    await service.stop();
-    clock += 2 * 60 * 60 * 1_000;
-    service = makeService();
-    await service.start();
-    service.startPeriodicUpdateChecks();
-    expect(scheduled).toHaveLength(1);
-    expect(scheduled[0]?.delayMs).toBe(4 * 60 * 60 * 1_000);
-    service.stopPeriodicUpdateChecks();
-  }, 60_000);
-
-  it("schedules the sweep from the stalest plugin, not a recent scoped check", async () => {
-    await service.stop();
-    let clock = Date.now();
-    const scheduled: Array<{ delayMs: number; onElapsed: () => void }> = [];
-    const makeService = () =>
-      createPluginService({
-        telemetry: createNoopTelemetryService(),
-        db,
-        hub: {
-          getDaemonSessionIdForHost: () => null,
-          notifyPluginSignal: () => 0,
-          notifySystem: () => {},
-        },
-        logger,
-        dataDir: join(workDir, "data"),
-        appVersion: "1.0.0",
-        stabilizationWindowMs: 0,
-        now: () => clock,
-        scheduleUpdateCheck: (delayMs, onElapsed) => {
-          scheduled.push({ delayMs, onElapsed });
-          return () => {};
-        },
-      });
-    // A second, never-checked npm plugin beside the git fixture.
+  /** An npm row with no recorded check; registry and provenance vary per test. */
+  function upsertNpmRow(
+    id: string,
+    registry: string,
+    provenance:
+      | { kind: "direct" }
+      | { kind: "catalog"; marketplace: string; entryId: string } = {
+      kind: "direct",
+    },
+  ): void {
+    const packageName = `bb-plugin-${id}`;
     upsertInstalledPlugin(db, {
-      id: "never-checked",
-      source: "npm:bb-plugin-never-checked",
-      provenance: { kind: "direct" },
+      id,
+      source: `npm:${packageName}`,
+      provenance,
       sourceIntent: {
         kind: "npm",
-        packageName: "bb-plugin-never-checked",
-        registry: "https://never-checked.test",
+        packageName,
+        registry,
         requestedSpec: "",
         specKind: "default",
       },
@@ -825,82 +740,99 @@ describe("plugin update service and routes", () => {
         statusDetail: null,
       },
       activeArtifactId: null,
-      rootDir: join(workDir, "never-checked"),
+      rootDir: join(workDir, id),
       version: "1.0.0",
       enabled: false,
     });
-    service = makeService();
+  }
+
+  /** Replaces `service` with one whose clock and sweep timer the test drives. */
+  async function restartWithScheduler(clock: () => number) {
+    const scheduled: Array<{ delayMs: number; onElapsed: () => void }> = [];
+    await service.stop();
+    service = createPluginService({
+      telemetry: createNoopTelemetryService(),
+      db,
+      hub: {
+        getDaemonSessionIdForHost: () => null,
+        notifyPluginSignal: () => 0,
+        notifySystem: () => {},
+      },
+      logger,
+      dataDir: join(workDir, "data"),
+      appVersion: "1.0.0",
+      stabilizationWindowMs: 0,
+      now: clock,
+      scheduleUpdateCheck: (delayMs, onElapsed) => {
+        const entry = { delayMs, onElapsed };
+        scheduled.push(entry);
+        return () => {
+          const index = scheduled.indexOf(entry);
+          if (index !== -1) scheduled.splice(index, 1);
+        };
+      },
+    });
     await service.start();
+    return scheduled;
+  }
 
-    // A scoped check stamps only the git plugin.
-    await service.checkForUpdates("updater");
-    expect(getInstalledPlugin(db, "updater")?.lastUpdateCheckAt).toBe(clock);
-    expect(getInstalledPlugin(db, "never-checked")?.lastUpdateCheckAt).toBeNull();
+  it("sweeps on start when a plugin was never checked, then waits out the interval across restarts", async () => {
+    const HOUR = 60 * 60 * 1_000;
+    let clock = Date.now();
+    let scheduled = await restartWithScheduler(() => clock);
+    const nextCommit = await commitPlugin(repo, "1.1.0");
 
-    // The sweep is still due now because one plugin was never checked.
     service.startPeriodicUpdateChecks();
     expect(scheduled.map((entry) => entry.delayMs)).toEqual([0]);
+    scheduled.shift()?.onElapsed();
+    await vi.waitFor(() =>
+      expect(getInstalledPlugin(db, "updater")).toMatchObject({
+        lastUpdateCheckAt: clock,
+        availableCompatibleVersion: nextCommit,
+      }),
+    );
+    await vi.waitFor(() =>
+      expect(scheduled.map((entry) => entry.delayMs)).toEqual([6 * HOUR]),
+    );
+    await service.stopPeriodicUpdateChecks();
+    expect(scheduled).toHaveLength(0);
+
+    // A restart 2h later waits the remaining 4h instead of checking again.
+    clock += 2 * HOUR;
+    scheduled = await restartWithScheduler(() => clock);
+    service.startPeriodicUpdateChecks();
+    expect(scheduled.map((entry) => entry.delayMs)).toEqual([4 * HOUR]);
     await service.stopPeriodicUpdateChecks();
 
-    // Once both are stamped, the oldest stamp drives the delay.
-    clock += 60_000;
-    db.$client
-      .prepare("UPDATE plugins SET last_update_check_at = ? WHERE id = ?")
-      .run(clock, "never-checked");
-    scheduled.length = 0;
+    // The stalest plugin drives the delay: a scoped check of one plugin does
+    // not push out a never-checked one.
+    upsertNpmRow("never-checked", "https://never-checked.test");
+    await service.checkForUpdates("updater");
     service.startPeriodicUpdateChecks();
-    expect(scheduled.map((entry) => entry.delayMs)).toEqual([
-      6 * 60 * 60 * 1_000 - 60_000,
-    ]);
+    expect(scheduled.map((entry) => entry.delayMs)).toEqual([0]);
     await service.stopPeriodicUpdateChecks();
   }, 60_000);
 
   it("shares one in-flight full sweep between concurrent callers", async () => {
     const first = service.checkForUpdates();
-    const second = service.checkForUpdates();
-    expect(second).toBe(first);
+    expect(service.checkForUpdates()).toBe(first);
     await first;
-    // After it settles, a new call starts a new sweep.
     expect(service.checkForUpdates()).not.toBe(first);
   }, 60_000);
 
   it("keeps the guarded registry policy for catalog installs during a check", async () => {
-    upsertInstalledPlugin(db, {
-      id: "listed",
-      source: "npm:bb-plugin-listed",
-      provenance: { kind: "catalog", marketplace: "bb-community", entryId: "listed" },
-      sourceIntent: {
-        kind: "npm",
-        packageName: "bb-plugin-listed",
-        // A listing that names a loopback registry must never be fetched.
-        registry: "https://127.0.0.1",
-        requestedSpec: "",
-        specKind: "default",
-      },
-      exactResolution: {
-        kind: "npm",
-        version: "1.0.0",
-        integrity: "sha512-current",
-      },
-      updateState: {
-        lastCheckAt: null,
-        availableCompatibleVersion: null,
-        newestIncompatibleVersion: null,
-        statusDetail: null,
-      },
-      activeArtifactId: null,
-      rootDir: join(workDir, "listed"),
-      version: "1.0.0",
-      enabled: false,
+    // A listing that names a loopback registry must never be fetched.
+    upsertNpmRow("listed", "https://127.0.0.1", {
+      kind: "catalog",
+      marketplace: "bb-community",
+      entryId: "listed",
     });
     const fetchMock = vi.fn(async () => {
       throw new Error("unexpected unguarded fetch");
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const results = await service.checkForUpdates("listed");
-
-    expect(results).toEqual([
+    await expect(service.checkForUpdates("listed")).resolves.toEqual([
       expect.objectContaining({
         id: "listed",
         outcome: "unavailable",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -741,9 +741,10 @@ Bundled builtin and official plugins update with BB app releases. For direct
 the "Check for updates" key on the Plugins page checks tracking sources, and
 `bb plugin update <id>` / `bb plugin update --all` or the "Update x.y.z" pill
 applies compatible candidates. The server also checks every installed plugin
-every 6 hours (the first check runs when no check has been recorded or the
-last one is older than 6 hours); a check only records what is available and
-never installs or runs plugin code. There is no automatic plugin update
+every 6 hours (the first check runs when any plugin has no recorded check or
+the oldest one is older than 6 hours), at most four plugins at a time, and a
+manual check joins a sweep already in flight; a check only records what is
+available and never installs or runs plugin code. There is no automatic plugin update
 application or update audit feed. Reinstalling an already-installed managed plugin is
 refused — use `bb plugin update`. Before activation bb snapshots the plugin
 database, host-managed settings/storage/schedules, secrets, and registration.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -737,9 +737,13 @@ an unselected install and lists its entry names.
 ### Plugin updates
 
 Bundled builtin and official plugins update with BB app releases. For direct
-`git:`/`npm:` installs, updates are manual: `bb plugin outdated` checks
-tracking sources and `bb plugin update <id>` / `bb plugin update --all`
-applies compatible candidates; there is no automatic plugin update
+`git:`/`npm:` installs, update application is manual: `bb plugin outdated` or
+the "Check for updates" key on the Plugins page checks tracking sources, and
+`bb plugin update <id>` / `bb plugin update --all` or the "Update x.y.z" pill
+applies compatible candidates. The server also checks every installed plugin
+every 6 hours (the first check runs when no check has been recorded or the
+last one is older than 6 hours); a check only records what is available and
+never installs or runs plugin code. There is no automatic plugin update
 application or update audit feed. Reinstalling an already-installed managed plugin is
 refused — use `bb plugin update`. Before activation bb snapshots the plugin
 database, host-managed settings/storage/schedules, secrets, and registration.


### PR DESCRIPTION
## What was wrong

The plugin update UI (the "Update x.y.z" pill, the update dialog, and the detail-page banner) shipped in #1474, but nothing ever triggered an update check. `checkForUpdates` only ran when a user ran `bb plugin outdated` or `bb plugin update`. The app had a `checkPluginUpdates()` helper with no caller, and the server only refreshed marketplace catalog metadata on a timer, not installed-plugin update state. So the pills never appeared for users who do not use the CLI.

## What changed

Server:
- `apps/server/src/services/plugins/plugin-updates.ts`: new `startPeriodicUpdateChecks()` / `stopPeriodicUpdateChecks()` with `PLUGIN_UPDATE_CHECK_INTERVAL_MS = 6h`. The first sweep runs at once when no plugin has a recorded check or the newest one is older than 6h; otherwise it waits the remainder, so a restart does not re-check. A failed sweep waits a full interval. `lastCheckAt` now uses the injected `deps.now` clock.
- `plugin-service-internal.ts`: `scheduleUpdateCheck` test seam on `PluginServiceDeps`.
- `start-server.ts`: starts the sweep after plugin startup settles; stops it on shutdown.
- No wire change between server and host daemon; `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

App:
- New `CheckPluginUpdatesButton`: a toolbar key (same 32px outline style as the filter/sort keys) that POSTs `/plugins/updates/check`, invalidates the plugin list so the pills appear, and toasts a summary.
- `PluginsOverview`: the button sits in the Installed toolbar beside "New plugin".
- `PluginDetail`: an inline "Check" button in the Release section for updatable plugins when no update is known yet.
- `PluginRowSignal`: the row's "Update x.y.z" text pill is now a round icon button (`PackageReceive`, the app's update icon) that matches the status icon beside it; the version lives in the tooltip and the accessible name.

Docs: `docs/configuration.md` "Plugin updates" now describes the button and the 6-hour sweep. No CLI command changed.

## How you verified

- New server test `sweeps for updates on start, then waits a full interval across restarts` in `plugin-update.test.ts` (fails before: `startPeriodicUpdateChecks` does not exist). All 24 tests in that file pass.
- New `CheckPluginUpdatesButton.test.tsx` (4 tests): toast summary, full check request shape + plugin list invalidation, scoped single-plugin check.
- `pnpm exec turbo run typecheck lint --filter=@bb/app --filter=@bb/server` pass.
- E2E in the dev app: installed a local `git:` plugin, committed a newer version, clicked the toolbar key → toast "1 plugin update available: updater-demo" and the row pill appeared; detail page showed the candidate; applied the update through the dialog; clicked the inline "Check" → "updater-demo is up to date". Server log/DB confirmed the startup sweep stamped `lastCheckAt` on every installed plugin.

Toolbar key after a check (toast + pill):

![after check](https://raw.githubusercontent.com/get-bb/reports/main/assets/plugin-update-check/02-after-check.png)

Row icon button (hovered):

![icon row](https://raw.githubusercontent.com/get-bb/reports/main/assets/plugin-update-check/08-icon-row.png)

Detail page with the found candidate:

![detail](https://raw.githubusercontent.com/get-bb/reports/main/assets/plugin-update-check/04-detail.png)

Detail page after applying, inline Check:

![detail check](https://raw.githubusercontent.com/get-bb/reports/main/assets/plugin-update-check/07-detail-check-uptodate.png)

> AGENT GENERATED: by Claude Opus 5


