### PR TITLE
Link marketplace plugin cards and detail pages to the plugin repository

### DIFF
--- a/apps/app/src/components/plugin/management/AddPluginDialog.test.tsx
+++ b/apps/app/src/components/plugin/management/AddPluginDialog.test.tsx
@@ -421,7 +421,12 @@ describe("AddPluginDialog", () => {
       expect(screen.getByText("v1.2.3")).toBeTruthy();
     });
     expect(screen.getByText("a".repeat(40))).toBeTruthy();
-    expect(screen.getByText("https://github.com/acme/plugins.git")).toBeTruthy();
+    // The repository row opens the code the confirmation describes.
+    expect(
+      screen
+        .getByRole("link", { name: "https://github.com/acme/plugins.git" })
+        .getAttribute("href"),
+    ).toBe("https://github.com/acme/plugins.git");
     expect(screen.getByText("^1.0.0")).toBeTruthy();
     expect(screen.getByText(/third-party marketplace/)).toBeTruthy();
     expect(screen.getByText("Acme Plugins")).toBeTruthy();
@@ -431,7 +436,9 @@ describe("AddPluginDialog", () => {
       ),
     ).toBe(true);
 
-    fireEvent.click(screen.getByRole("button", { name: /install acme notes/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /install acme notes/i }),
+    );
     await vi.waitFor(() => {
       const post = requests.find(
         (request) => request.url === "/api/v1/plugin-catalog/install",

--- a/apps/app/src/components/plugin/management/AddPluginDialog.tsx
+++ b/apps/app/src/components/plugin/management/AddPluginDialog.tsx
@@ -126,7 +126,7 @@ function buildRequest(
 /** One labelled fact of the resolved source, rendered as a definition row. */
 function resolvedSourceRows(
   source: PluginCatalogResolvedSource,
-): { label: string; value: string }[] {
+): { label: string; value: string; href?: string }[] {
   if (source.kind === "npm") {
     return [
       {
@@ -139,7 +139,9 @@ function resolvedSourceRows(
     ];
   }
   return [
-    { label: "repository", value: source.url },
+    // The repository row is a link so a reader can inspect the code that
+    // the confirmation describes before it installs.
+    { label: "repository", value: source.url, href: source.url },
     ...(source.subdir === undefined
       ? []
       : [{ label: "subdirectory", value: source.subdir }]),
@@ -233,7 +235,18 @@ function ThirdPartySourceDisclosure({
               {row.label}
             </dt>
             <dd className="min-w-0 break-all font-mono text-2xs text-foreground">
-              {row.value}
+              {row.href === undefined ? (
+                row.value
+              ) : (
+                <a
+                  href={row.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline underline-offset-2 hover:text-foreground"
+                >
+                  {row.value}
+                </a>
+              )}
             </dd>
           </div>
         ))}
@@ -257,8 +270,7 @@ function AddPluginDialogContent({
   // Only a third-party listing needs its source resolved before confirming:
   // the official catalog is BB's own and installs without a round trip.
   const thirdParty =
-    initial !== null &&
-    initial.marketplace !== CURATED_PLUGIN_MARKETPLACE_NAME;
+    initial !== null && initial.marketplace !== CURATED_PLUGIN_MARKETPLACE_NAME;
   const planQuery = useCatalogInstallPlan(
     thirdParty && initial !== null
       ? { entryId: initial.entryId, marketplace: initial.marketplace }

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.test.tsx
@@ -34,6 +34,7 @@ const MEMORY_ENTRY: PluginCatalogSearchEntry = {
   iconTinted: false,
   category: "Context & knowledge",
   source: "builtin:memory",
+  repositoryUrl: null,
   marketplaceDisplayName: "BB Community",
   publisherKey: "builtin",
   publisherLabel: "BB Official",
@@ -184,6 +185,7 @@ describe("BrowsePluginsTab", () => {
         publisherLabel: "Acme Plugins",
         official: false,
         author: { name: "Acme", url: "https://github.com/acme" },
+        repositoryUrl: "https://github.com/acme/notes",
       },
     ];
     vi.stubGlobal(
@@ -222,6 +224,16 @@ describe("BrowsePluginsTab", () => {
     expect(screen.getByText("third-party marketplace")).toBeTruthy();
     // Cards carry the author with the "By:" prefix.
     expect(screen.getByText("By: Acme")).toBeTruthy();
+    // The card links the repository; a bundled entry has none to link.
+    const repositoryLink = screen.getByRole("link", {
+      name: "Open Acme Notes repository",
+    });
+    expect(repositoryLink.getAttribute("href")).toBe(
+      "https://github.com/acme/notes",
+    );
+    expect(
+      screen.queryByRole("link", { name: "Open Memory repository" }),
+    ).toBeNull();
   });
 
   it("keeps a marketplace that copies a publisher label in its own group", async () => {

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
@@ -397,11 +397,30 @@ function BrowseCard({
   // The publisher label, not the marketplace's raw display name: a third-party
   // manifest names itself, and the raw name would print a reserved BB label on
   // the card that the server already refused to grant.
-  const footerMeta = entry.official ? undefined : (
-    <span className="text-2xs text-subtle-foreground">
-      {entry.publisherLabel}
-    </span>
-  );
+  // The repository link sits with the publisher label: both say where the
+  // plugin comes from. The card footer ignores pointer events so clicks fall
+  // through to the open button; the link opts back in to take its own click.
+  const repositoryLink =
+    entry.repositoryUrl === null ? null : (
+      <a
+        href={entry.repositoryUrl}
+        target="_blank"
+        rel="noreferrer"
+        aria-label={`Open ${entry.displayName} repository`}
+        className="pointer-events-auto inline-flex items-center gap-0.5 underline underline-offset-2 hover:text-foreground"
+      >
+        repo
+        <Icon name="ExternalLink" className="size-2.5" aria-hidden />
+      </a>
+    );
+  const footerMeta =
+    entry.official && repositoryLink === null ? undefined : (
+      <span className="text-2xs text-subtle-foreground">
+        {entry.official ? null : entry.publisherLabel}
+        {!entry.official && repositoryLink !== null ? " · " : null}
+        {repositoryLink}
+      </span>
+    );
   const headerAction =
     installedPluginId !== null ? (
       <ResourceInstallControl

--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
@@ -407,10 +407,16 @@ function BrowseCard({
         target="_blank"
         rel="noreferrer"
         aria-label={`Open ${entry.displayName} repository`}
-        className="pointer-events-auto inline-flex items-center gap-0.5 underline underline-offset-2 hover:text-foreground"
+        className="pointer-events-auto inline-flex items-center gap-0.5 leading-none underline underline-offset-2 hover:text-foreground"
       >
         repo
-        <Icon name="ExternalLink" className="size-2.5" aria-hidden />
+        {/* Optical nudge: centered against the line box, the glyph sits a
+            pixel above the x-height of the lowercase label beside it. */}
+        <Icon
+          name="ExternalLink"
+          className="size-2.5 shrink-0 translate-y-px"
+          aria-hidden
+        />
       </a>
     );
   const footerMeta =

--- a/apps/app/src/components/tools/ExtensionsDetailStates.stories.tsx
+++ b/apps/app/src/components/tools/ExtensionsDetailStates.stories.tsx
@@ -568,6 +568,7 @@ const UNINSTALLED_CATALOG_PLUGIN = {
   iconTinted: false,
   category: "Developer tools",
   source: "builtin:github",
+  repositoryUrl: null,
   marketplaceDisplayName: "BB Community",
   publisherKey: "builtin",
   publisherLabel: "BB Official",

--- a/apps/app/src/components/tools/PluginDetail.tsx
+++ b/apps/app/src/components/tools/PluginDetail.tsx
@@ -110,6 +110,14 @@ function PluginPath({ path }: { path: string }) {
 }
 
 /**
+ * The repository link's text: the URL without its scheme, so a GitHub entry
+ * reads as `github.com/owner/repo` and a reader knows the destination.
+ */
+export function repositoryLinkLabel(url: string): string {
+  return url.replace(/^https?:\/\//u, "").replace(/\/+$/u, "");
+}
+
+/**
  * Read-only detail for an uninstalled catalog entry.
  *
  * The catalog exposes identity, category, description, and compatibility. It
@@ -147,6 +155,19 @@ export function CatalogPluginDetail({
                   {entry.author.name}
                 </a>
               )}
+            </span>
+          )}
+          {entry.repositoryUrl === null ? null : (
+            <span>
+              {" · "}
+              <a
+                href={entry.repositoryUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="underline underline-offset-2"
+              >
+                {repositoryLinkLabel(entry.repositoryUrl)}
+              </a>
             </span>
           )}
         </>

--- a/apps/app/src/hooks/queries/plugin-catalog-queries.test.ts
+++ b/apps/app/src/hooks/queries/plugin-catalog-queries.test.ts
@@ -155,6 +155,8 @@ describe("plugin catalog queries", () => {
         iconTinted: false,
         category: "Project management",
         source: "npm:@bb-plugins/todoist",
+        // A server from before the field defaults to no link.
+        repositoryUrl: null,
         marketplace: "acme-plugins",
         marketplaceDisplayName: "Acme Plugins",
         publisherKey: "acme-plugins",

--- a/apps/app/src/hooks/queries/plugin-catalog-queries.ts
+++ b/apps/app/src/hooks/queries/plugin-catalog-queries.ts
@@ -237,6 +237,8 @@ export interface PluginCatalogSearchEntry {
   iconTinted: boolean;
   category: string;
   source: string;
+  /** Public repository or package page of the entry's code; null when none. */
+  repositoryUrl: string | null;
   marketplace: string;
   marketplaceDisplayName: string;
   /** Stable publisher identity, for grouping; never the label, which a
@@ -264,6 +266,7 @@ function toPluginCatalogSearchEntry(
     iconTinted: data.iconTinted,
     category: data.category,
     source: data.source,
+    repositoryUrl: data.repositoryUrl,
     marketplace: data.marketplace,
     marketplaceDisplayName: data.marketplaceDisplayName,
     publisherKey: data.publisherKey,

--- a/apps/app/src/views/ToolsView.plugin-detail.test.tsx
+++ b/apps/app/src/views/ToolsView.plugin-detail.test.tsx
@@ -72,6 +72,7 @@ const GITHUB_CATALOG_ENTRY = {
   iconTinted: false,
   category: "Developer tools",
   source: "builtin:github",
+  repositoryUrl: null,
   marketplaceDisplayName: "BB Official",
   publisherKey: "builtin",
   publisherLabel: "BB Official",
@@ -110,6 +111,24 @@ describe("PluginDetail official catalog lifecycle", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Install GitHub" }));
     expect(onInstall).toHaveBeenCalledWith(GITHUB_CATALOG_ENTRY);
+  });
+
+  it("links the catalog entry's repository from the metadata line", () => {
+    render(
+      <CatalogPluginDetail
+        entry={{
+          ...GITHUB_CATALOG_ENTRY,
+          repositoryUrl: "https://github.com/acme/bb-github",
+        }}
+        onInstall={() => {}}
+      />,
+    );
+
+    const link = screen.getByRole("link", {
+      name: "github.com/acme/bb-github",
+    });
+    expect(link.getAttribute("href")).toBe("https://github.com/acme/bb-github");
+    expect(link.getAttribute("target")).toBe("_blank");
   });
 
   it("explains why an incompatible official plugin cannot be installed", () => {

--- a/apps/cli/src/__tests__/command-output/plugin-catalog.test.ts
+++ b/apps/cli/src/__tests__/command-output/plugin-catalog.test.ts
@@ -19,6 +19,7 @@ const searchResult = {
   iconTinted: false,
   category: "Developer tools",
   source: "builtin:linear",
+  repositoryUrl: null,
   marketplace: "bb-community",
   marketplaceDisplayName: "BB Official",
   publisherKey: "builtin",
@@ -340,7 +341,10 @@ describe("bb plugin catalog", () => {
       .mockResolvedValueOnce(json({ plan: thirdPartyPlan }))
       .mockResolvedValueOnce(json({ ok: true, plugin: installedPlugin }));
 
-    await runCommand(["plugin", "install", "notes@acme-plugins", "--yes"], register);
+    await runCommand(
+      ["plugin", "install", "notes@acme-plugins", "--yes"],
+      register,
+    );
 
     expect(fetchMock.mock.calls[0]?.[0]).toBe(
       "http://server/api/v1/plugin-catalog/install-plan?entryId=notes&marketplace=acme-plugins",
@@ -381,7 +385,10 @@ describe("bb plugin catalog", () => {
       )
       .mockResolvedValueOnce(json({ ok: true, plugin: installedPlugin }));
 
-    await runCommand(["plugin", "install", "notes@acme-plugins", "--yes"], register);
+    await runCommand(
+      ["plugin", "install", "notes@acme-plugins", "--yes"],
+      register,
+    );
 
     const output = collectLogPayloads(vi.mocked(console.log)).join("\n");
     expect(output).toContain("npm package: bb-plugin-notes@beta");
@@ -406,7 +413,10 @@ describe("bb plugin catalog", () => {
       )
       .mockResolvedValueOnce(json({ ok: true, plugin: installedPlugin }));
 
-    await runCommand(["plugin", "install", "notes@acme-plugins", "--yes"], register);
+    await runCommand(
+      ["plugin", "install", "notes@acme-plugins", "--yes"],
+      register,
+    );
 
     expect(collectLogPayloads(vi.mocked(console.log)).join("\n")).toContain(
       "not resolved right now: no release tag matches ^1.0.0",

--- a/apps/server/src/services/plugin-catalog/marketplace-manifest.ts
+++ b/apps/server/src/services/plugin-catalog/marketplace-manifest.ts
@@ -424,6 +424,27 @@ export function resolveEntryIcon(
   };
 }
 
+/**
+ * Where a person can read an entry's code before an install. A git entry
+ * links its repository; a subdirectory links the directory on GitHub, and the
+ * repository root elsewhere, because only GitHub's tree URL shape is known. An
+ * npm entry on the default registry links its public package page. A private
+ * registry has no public page bb can name, so that entry gets null.
+ */
+export function entryRepositoryUrl(entry: MarketplaceEntry): string | null {
+  if ("npm" in entry.source) {
+    return entry.source.npm.registry === undefined
+      ? `https://www.npmjs.com/package/${entry.source.npm.package}`
+      : null;
+  }
+  const git = entry.source.git;
+  const repository = git.url.replace(/\.git$/u, "");
+  if (git.subdir === undefined) return repository;
+  return new URL(repository).host === "github.com"
+    ? `${repository}/tree/HEAD/${git.subdir}`
+    : repository;
+}
+
 /** Human-readable source of an entry, shown before anything is installed. */
 export function entrySourceDisplay(entry: MarketplaceEntry): string {
   if ("npm" in entry.source) {

--- a/apps/server/src/services/plugin-catalog/marketplace-manifest.ts
+++ b/apps/server/src/services/plugin-catalog/marketplace-manifest.ts
@@ -440,8 +440,11 @@ export function entryRepositoryUrl(entry: MarketplaceEntry): string | null {
   const git = entry.source.git;
   const repository = git.url.replace(/\.git$/u, "");
   if (git.subdir === undefined) return repository;
+  // The schema accepts `#` and `?` in a subdirectory; raw interpolation would
+  // turn them into a fragment or a query, so each segment is encoded.
+  const path = git.subdir.split("/").map(encodeURIComponent).join("/");
   return new URL(repository).host === "github.com"
-    ? `${repository}/tree/HEAD/${git.subdir}`
+    ? `${repository}/tree/HEAD/${path}`
     : repository;
 }
 

--- a/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
+++ b/apps/server/src/services/plugin-catalog/plugin-catalog-service.ts
@@ -55,6 +55,7 @@ import {
   BUILTIN_PUBLISHER_LABEL,
   entryIconName,
   entryIconTinted,
+  entryRepositoryUrl,
   entrySourceDisplay,
   CURATED_MARKETPLACE_NAME,
   parseMarketplaceManifestJson,
@@ -419,6 +420,8 @@ export function createPluginCatalogService(deps: {
       iconTinted: iconHash !== null,
       category: entry.category,
       source: builtinPluginSource(entry.name),
+      // The build ships the code; there is no separate repository to open.
+      repositoryUrl: null,
       // Plugins bundled with the app are BB's own, so the store groups them
       // with the official marketplace rather than inventing a fourth origin.
       marketplace: CURATED_MARKETPLACE_NAME,
@@ -496,6 +499,7 @@ export function createPluginCatalogService(deps: {
       ...entryIconAsset(row.name, entry.id),
       category: entryCategory(entry, official),
       source: entrySourceDisplay(entry),
+      repositoryUrl: entryRepositoryUrl(entry),
       marketplace: row.name,
       marketplaceDisplayName: catalog.displayName,
       publisherKey: row.name,

--- a/apps/server/test/services/plugin-catalog/marketplace-manifest.test.ts
+++ b/apps/server/test/services/plugin-catalog/marketplace-manifest.test.ts
@@ -412,6 +412,22 @@ describe("marketplace manifest schema", () => {
       expect(entryRepositoryUrl(gitlab)).toBe(
         "https://gitlab.com/acme/plugins",
       );
+      // `#` and `?` pass the subdirectory check; raw they would change the
+      // URL's meaning.
+      const reserved = firstEntry([
+        entry({
+          source: {
+            git: {
+              url: "https://github.com/acme/plugins",
+              ref: "v1.0.0",
+              subdir: "plugins/c#/what?",
+            },
+          },
+        }),
+      ]);
+      expect(entryRepositoryUrl(reserved)).toBe(
+        "https://github.com/acme/plugins/tree/HEAD/plugins/c%23/what%3F",
+      );
     });
 
     it("links the public npm page only for the default registry", () => {

--- a/apps/server/test/services/plugin-catalog/marketplace-manifest.test.ts
+++ b/apps/server/test/services/plugin-catalog/marketplace-manifest.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import {
+  entryRepositoryUrl,
   entrySourceDisplay,
   parseMarketplaceManifest,
   resolveEntryIcon,
@@ -375,6 +376,68 @@ describe("marketplace manifest schema", () => {
     });
   });
 
+  describe("repository url", () => {
+    it("links a git repository without its .git suffix", () => {
+      expect(entryRepositoryUrl(firstEntry([entry()]))).toBe(
+        "https://github.com/acme/plugins",
+      );
+    });
+
+    it("links a GitHub subdirectory to its tree, other hosts to the root", () => {
+      const github = firstEntry([
+        entry({
+          source: {
+            git: {
+              url: "https://github.com/acme/plugins.git",
+              ref: "v1.0.0",
+              subdir: "plugins/widgets",
+            },
+          },
+        }),
+      ]);
+      expect(entryRepositoryUrl(github)).toBe(
+        "https://github.com/acme/plugins/tree/HEAD/plugins/widgets",
+      );
+      const gitlab = firstEntry([
+        entry({
+          source: {
+            git: {
+              url: "https://gitlab.com/acme/plugins",
+              ref: "v1.0.0",
+              subdir: "plugins/widgets",
+            },
+          },
+        }),
+      ]);
+      expect(entryRepositoryUrl(gitlab)).toBe(
+        "https://gitlab.com/acme/plugins",
+      );
+    });
+
+    it("links the public npm page only for the default registry", () => {
+      const publicPackage = firstEntry([
+        entry({
+          source: { npm: { package: "@acme/widgets", range: "^1.0.0" } },
+        }),
+      ]);
+      expect(entryRepositoryUrl(publicPackage)).toBe(
+        "https://www.npmjs.com/package/@acme/widgets",
+      );
+      const privatePackage = firstEntry([
+        entry({
+          source: {
+            npm: {
+              package: "bb-plugin-widgets",
+              range: "^1.0.0",
+              registry: "https://npm.acme.test",
+            },
+          },
+        }),
+      ]);
+      expect(entryRepositoryUrl(privatePackage)).toBeNull();
+    });
+  });
+
   describe("engines policy", () => {
     // A listing no longer declares compatibility: the ranges live in the
     // plugin's own package.json and the install pipeline enforces them there.
@@ -393,10 +456,7 @@ describe("marketplace manifest schema", () => {
 
   it("validates the bundled seed snapshot", () => {
     expect(() =>
-      parseMarketplaceManifest(
-        BUNDLED_CURATED_MARKETPLACE,
-        "bundled snapshot",
-      ),
+      parseMarketplaceManifest(BUNDLED_CURATED_MARKETPLACE, "bundled snapshot"),
     ).not.toThrow();
   });
 });

--- a/packages/server-contract/src/api/plugins.ts
+++ b/packages/server-contract/src/api/plugins.ts
@@ -422,6 +422,14 @@ export const pluginCatalogSearchResultSchema = z.object({
   iconTinted: z.boolean().default(false),
   category: z.string(),
   source: z.string(),
+  /**
+   * Where a person can read the plugin's code before an install: the git
+   * repository of a git-sourced entry, or the public npm package page of an
+   * npm-sourced entry on the default registry. Null for plugins bundled with
+   * the app and for packages on a private registry. Older servers do not
+   * send it; those entries show no link.
+   */
+  repositoryUrl: z.string().nullable().default(null),
   /** Marketplace that lists the entry; plugins bundled with the app use `bb-community`. */
   marketplace: z.string(),
   marketplaceDisplayName: z.string(),


### PR DESCRIPTION
## What was wrong

The marketplace Browse card and the catalog detail page showed the plugin name, publisher, author, and About text, but no link to the plugin's source repository. A user could not read the code or README before an install. The catalog already knew the git URL and npm package of every entry; the search result just did not carry it to the app. Reported in Discord; tracked in #1968.

## What changed

- `packages/server-contract/src/api/plugins.ts`: `repositoryUrl: string | null` on the catalog search result. It defaults to `null` when an older server omits it, like `iconTinted`. `bb plugin search --json` now includes it.
- `apps/server/src/services/plugin-catalog/marketplace-manifest.ts`: `entryRepositoryUrl()`. A git entry links its repository with the `.git` suffix removed; a GitHub subdirectory links `/tree/HEAD/<subdir>`, other hosts link the root. An npm entry on the default registry links its npmjs page. Bundled plugins and private registries get `null`.
- `apps/app/src/components/tools/PluginDetail.tsx`: the catalog detail metadata line shows the link after the author, as `github.com/owner/repo`.
- `apps/app/src/components/plugin/management/BrowsePluginsTab.tsx`: a small `repo ↗` link in the card footer next to the publisher label. The footer ignores pointer events so clicks fall through to the open button; the link opts back in with `pointer-events-auto`.

No wire change between server and host daemon.

## How you verified

- New tests: `repository url` cases in `apps/server/test/services/plugin-catalog/marketplace-manifest.test.ts` (git, GitHub subdir, GitLab subdir, public npm, private npm); detail link in `ToolsView.plugin-detail.test.tsx`; card link and no link on a bundled entry in `BrowsePluginsTab.test.tsx`; old-server default in `plugin-catalog-queries.test.ts`. They fail before and pass after.
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/server` passes. `test` for `@bb/app` (plugin suites), `@bb/server` (plugin-catalog), `@bb/cli`, `@bb/sdk`, `@bb/server-contract` passes.
- Dev app: `GET /api/v1/plugin-catalog/search` returns links for every marketplace entry. Screenshots below.

### Screenshots

Browse cards with the `repo ↗` footer link:

![Browse cards](https://raw.githubusercontent.com/get-bb/reports/main/prs/assets/1969-browse.png)

Catalog detail page with the repository in the metadata line:

![Detail page](https://raw.githubusercontent.com/get-bb/reports/main/prs/assets/1969-detail.png)

Fixes #1968

> AGENT GENERATED: by Claude Opus 5
