### PR TITLE
Build source CLI before host daemon startup

### DIFF
--- a/apps/host-daemon/src/runtime-shell-env.test.ts
+++ b/apps/host-daemon/src/runtime-shell-env.test.ts
@@ -23,10 +23,12 @@ interface FakeCliPackageOptions {
   executablePath?: string;
   executable?: boolean;
   writeEntry?: boolean;
+  writeRuntime?: boolean;
 }
 
 interface FakeCliPackage {
   cliEntryPath: string;
+  cliRuntimePath: string;
 }
 
 interface FakeShellEnvSpawn {
@@ -76,6 +78,7 @@ async function createFakeCliPackage(
   const cliPackageRoot = await makeTempDir("bb-cli-package-");
   const executablePath = options.executablePath ?? "./dist/bin/bb";
   const cliEntryPath = path.resolve(cliPackageRoot, executablePath);
+  const cliRuntimePath = path.resolve(cliPackageRoot, "dist/index.js");
 
   if (options.writeEntry ?? true) {
     await fs.mkdir(path.dirname(cliEntryPath), { recursive: true });
@@ -87,8 +90,14 @@ async function createFakeCliPackage(
     await fs.chmod(cliEntryPath, options.executable ? 0o755 : 0o644);
   }
 
+  if (options.writeRuntime) {
+    await fs.mkdir(path.dirname(cliRuntimePath), { recursive: true });
+    await fs.writeFile(cliRuntimePath, "process.stdout.write('bb')\n", "utf8");
+  }
+
   return {
     cliEntryPath,
+    cliRuntimePath,
   };
 }
 
@@ -146,15 +155,32 @@ afterEach(async () => {
 
 describe("resolveLocalBbExecutablePath", () => {
   it("returns the built CLI executable path", async () => {
-    const { cliEntryPath } = await createFakeCliPackage({
+    const { cliEntryPath, cliRuntimePath } = await createFakeCliPackage({
+      executable: true,
+      writeRuntime: true,
+    });
+
+    await expect(
+      resolveLocalBbExecutablePath({
+        cliExecutablePath: cliEntryPath,
+        cliRuntimePath,
+      }),
+    ).resolves.toBe(cliEntryPath);
+  });
+
+  it("fails before startup when the source CLI runtime is unbuilt", async () => {
+    const { cliEntryPath, cliRuntimePath } = await createFakeCliPackage({
       executable: true,
     });
 
     await expect(
       resolveLocalBbExecutablePath({
         cliExecutablePath: cliEntryPath,
+        cliRuntimePath,
       }),
-    ).resolves.toBe(cliEntryPath);
+    ).rejects.toThrow(
+      `Missing built bb CLI runtime at ${cliRuntimePath}. Build @bb/cli before starting the host daemon.`,
+    );
   });
 
   it("fails clearly when the built CLI entry is missing", async () => {

--- a/apps/host-daemon/src/runtime-shell-env.ts
+++ b/apps/host-daemon/src/runtime-shell-env.ts
@@ -8,6 +8,7 @@ import { assignIfDefined } from "@bb/config/objects";
 
 interface ResolveLocalBbExecutablePathOptions {
   cliExecutablePath?: string;
+  cliRuntimePath?: string;
 }
 
 export interface PrepareRuntimeShellEnvOptions {
@@ -63,6 +64,10 @@ function getDefaultCliExecutablePath(): string {
   return fileURLToPath(new URL("../../cli/bin/bb", import.meta.url));
 }
 
+function getDefaultCliRuntimePath(): string {
+  return fileURLToPath(new URL("../../cli/dist/index.js", import.meta.url));
+}
+
 function getErrorCode(error: unknown): string | undefined {
   if (
     error &&
@@ -105,6 +110,26 @@ async function resolveCliEntryPath(cliExecutablePath: string): Promise<string> {
   }
 
   return cliEntryPath;
+}
+
+async function requireCliRuntimePath(cliRuntimePath: string): Promise<void> {
+  const resolvedCliRuntimePath = resolve(cliRuntimePath);
+
+  try {
+    const stats = await fs.stat(resolvedCliRuntimePath);
+    if (!stats.isFile()) {
+      throw new Error(
+        `Resolved bb CLI runtime is not a file: ${resolvedCliRuntimePath}`,
+      );
+    }
+  } catch (error) {
+    if (getErrorCode(error) === "ENOENT") {
+      throw new Error(
+        `Missing built bb CLI runtime at ${resolvedCliRuntimePath}. Build @bb/cli before starting the host daemon.`,
+      );
+    }
+    throw error;
+  }
 }
 
 function prependPath(
@@ -344,7 +369,16 @@ export async function resolveLocalBbExecutablePath(
 ): Promise<string> {
   const resolvedCliExecutablePath =
     options.cliExecutablePath ?? getDefaultCliExecutablePath();
-  return resolveCliEntryPath(resolvedCliExecutablePath);
+  const cliEntryPath = await resolveCliEntryPath(resolvedCliExecutablePath);
+  const cliRuntimePath =
+    options.cliRuntimePath ??
+    (options.cliExecutablePath === undefined
+      ? getDefaultCliRuntimePath()
+      : undefined);
+  if (cliRuntimePath !== undefined) {
+    await requireCliRuntimePath(cliRuntimePath);
+  }
+  return cliEntryPath;
 }
 
 /** Platform-stable name of the bb CLI file inside `BB_CLI_DIR` / daemon dist. */

--- a/turbo.json
+++ b/turbo.json
@@ -246,7 +246,11 @@
       ]
     },
     "@bb/host-daemon#dev": {
+      // The source daemon injects apps/cli/bin/bb into agent shells. Build its
+      // gitignored runtime before the daemon starts so a sandboxed thread never
+      // has to write back into the daemon's checkout to bootstrap `bb`.
       "dependsOn": [
+        "@bb/cli#build",
         "@bb/templates#generate:templates",
         "@bb/plugin-build#generate"
       ],


### PR DESCRIPTION
## What was wrong

The source host daemon injected `apps/cli/bin/bb` into agent shells without ensuring its gitignored `dist/index.js` runtime had been built. From a fresh daemon worktree, the first `bb` invocation therefore attempted the wrapper lazy build inside that separate checkout; sandboxed threads could not write its `.turbo` directories and every injected CLI command failed.

## What changed

- Made `@bb/host-daemon#dev` depend on `@bb/cli#build`, so Turbo restores or builds the CLI runtime before starting the source daemon.
- Added a source-startup guard that reports a missing CLI runtime immediately rather than publishing a wrapper that will fail later inside a thread.
- Added regression coverage for both built and missing runtime states.
- No host-daemon wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged. No CLI command, flag, or configuration surface changed, so guide documentation is unchanged.

The added host-daemon critical-path cost measured about 9 ms on a local Turbo cache hit and about 230 ms for a cold CLI build on the test machine; app and server startup remain parallel.

## How you verified

- `pnpm exec turbo run test typecheck --filter=@bb/host-daemon --force` — 48 test files and 587 tests passed; typecheck passed.
- `pnpm exec turbo run dev --filter=@bb/host-daemon --dry=json --no-update-notifier` — confirmed `@bb/cli#build` is a direct prerequisite of `@bb/host-daemon#dev`.
- `pnpm exec turbo run build --filter=@bb/cli --force` followed by `env -u BB_CLI ./apps/cli/bin/bb --version` — built and launched successfully (`0.39.0`).
- The new missing-runtime test reproduces the prior unbuilt state and verifies the daemon now fails before startup with an actionable error.

Fixes #1970

> AGENT GENERATED: by GPT-5