### PR TITLE
Close ACP stdin failures and isolate GitHub panel logic

### DIFF
--- a/plugins/github/app-logic.ts
+++ b/plugins/github/app-logic.ts
@@ -1,0 +1,257 @@
+export interface Item {
+  repo: string;
+  number: number;
+  kind: "issue" | "pr";
+  title: string;
+  state: string;
+  author: string;
+  labels: string[];
+  assignees: string[];
+  url: string;
+  body: string;
+  updatedAt: string;
+}
+
+export type Route =
+  | { view: "issues" }
+  | { view: "pulls" }
+  | { view: "new" }
+  | { view: "issue"; repo: string; number: number }
+  | { view: "pull"; repo: string; number: number };
+
+export function parseSubPath(subPath: string): Route {
+  const parts = subPath.split("/").filter((part) => part.length > 0);
+  if (parts[0] === "pulls" && parts.length === 4) {
+    const number = Number(parts[3]);
+    if (Number.isFinite(number)) {
+      return { view: "pull", repo: `${parts[1]}/${parts[2]}`, number };
+    }
+  }
+  if (parts[0] === "pulls") return { view: "pulls" };
+  if (parts[0] === "new") return { view: "new" };
+  if (parts[0] === "issues" && parts.length === 4) {
+    const number = Number(parts[3]);
+    if (Number.isFinite(number)) {
+      return { view: "issue", repo: `${parts[1]}/${parts[2]}`, number };
+    }
+  }
+  return { view: "issues" };
+}
+
+export function routeToSubPath(route: Route): string {
+  switch (route.view) {
+    case "issues":
+      return "issues";
+    case "pulls":
+      return "pulls";
+    case "new":
+      return "new";
+    case "issue":
+      return `issues/${route.repo}/${route.number}`;
+    case "pull":
+      return `pulls/${route.repo}/${route.number}`;
+  }
+}
+
+// GitHub-style qualifiers parsed and matched client-side:
+// is:open, is:closed, is:merged, assignee:<login>, assignee:@me,
+// author:<login>, label:<name>, repo:<owner/name>, no:assignee, no:label.
+export interface ParsedQuery {
+  states: string[];
+  assignees: string[];
+  authors: string[];
+  labels: string[];
+  repos: string[];
+  noAssignee: boolean;
+  noLabel: boolean;
+  text: string[];
+}
+
+function tokenizeQuery(query: string): string[] {
+  return query.match(/(?:[^\s"]+|"[^"]*")+/g) ?? [];
+}
+
+function unquote(value: string): string {
+  return value.replace(/"/g, "");
+}
+
+const STATE_VALUES: Record<string, string> = {
+  open: "OPEN",
+  closed: "CLOSED",
+  merged: "MERGED",
+};
+
+export function parseQuery(query: string): ParsedQuery {
+  const parsed: ParsedQuery = {
+    states: [],
+    assignees: [],
+    authors: [],
+    labels: [],
+    repos: [],
+    noAssignee: false,
+    noLabel: false,
+    text: [],
+  };
+  for (const token of tokenizeQuery(query)) {
+    const idx = token.indexOf(":");
+    const key = idx > 0 ? token.slice(0, idx).toLowerCase() : "";
+    const value = idx > 0 ? unquote(token.slice(idx + 1)) : "";
+    // A dangling "key:" (still being typed) filters nothing.
+    if (idx > 0 && value.length === 0) continue;
+    if (key === "is" || key === "state") {
+      parsed.states.push(
+        STATE_VALUES[value.toLowerCase()] ?? value.toUpperCase(),
+      );
+    } else if (key === "assignee") {
+      parsed.assignees.push(value.toLowerCase());
+    } else if (key === "author") {
+      parsed.authors.push(value.toLowerCase());
+    } else if (key === "label") {
+      parsed.labels.push(value.toLowerCase());
+    } else if (key === "repo") {
+      parsed.repos.push(value.toLowerCase());
+    } else if (key === "no") {
+      if (value.toLowerCase() === "assignee") parsed.noAssignee = true;
+      if (value.toLowerCase() === "label") parsed.noLabel = true;
+    } else {
+      parsed.text.push(unquote(token).toLowerCase());
+    }
+  }
+  return parsed;
+}
+
+export function matchesQuery(
+  item: Item,
+  query: ParsedQuery,
+  viewer: string | null,
+): boolean {
+  if (query.states.length > 0 && !query.states.includes(item.state)) {
+    return false;
+  }
+  if (query.assignees.length > 0) {
+    const wanted = query.assignees.map((login) =>
+      login === "@me" ? (viewer?.toLowerCase() ?? "\u0000") : login,
+    );
+    if (!item.assignees.some((login) => wanted.includes(login.toLowerCase()))) {
+      return false;
+    }
+  }
+  if (query.authors.length > 0) {
+    const author = item.author.toLowerCase();
+    const wanted = query.authors.map((login) =>
+      login === "@me" ? (viewer?.toLowerCase() ?? "\u0000") : login,
+    );
+    if (!wanted.includes(author)) return false;
+  }
+  if (query.labels.length > 0) {
+    const labels = item.labels.map((label) => label.toLowerCase());
+    if (!query.labels.some((label) => labels.includes(label))) return false;
+  }
+  if (
+    query.repos.length > 0 &&
+    !query.repos.includes(item.repo.toLowerCase())
+  ) {
+    return false;
+  }
+  if (query.noAssignee && item.assignees.length > 0) return false;
+  if (query.noLabel && item.labels.length > 0) return false;
+  if (query.text.length > 0) {
+    const haystack = `${item.title} #${item.number} ${item.repo}`.toLowerCase();
+    if (!query.text.every((term) => haystack.includes(term))) return false;
+  }
+  return true;
+}
+
+export type SuggestionIcon =
+  | { kind: "state"; itemKind: "issue" | "pr"; state: string }
+  | { kind: "avatar"; login: string };
+
+export interface Suggestion {
+  /** Replaces the token being typed. */
+  insert: string;
+  label: string;
+  hint?: string;
+  icon?: SuggestionIcon;
+}
+
+const QUALIFIER_KEYS: Array<{ key: string; hint: string }> = [
+  { key: "is:", hint: "state — open, closed, merged" },
+  { key: "assignee:", hint: "assigned user, or @me" },
+  { key: "author:", hint: "opened by" },
+  { key: "label:", hint: "has label" },
+  { key: "repo:", hint: "in repository" },
+  { key: "no:", hint: "missing — assignee, label" },
+];
+
+function quoteValue(value: string): string {
+  return /\s/.test(value) ? `"${value}"` : value;
+}
+
+export function buildSuggestions(
+  token: string,
+  vocab: { users: string[]; labels: string[]; repos: string[] },
+  kind: "issue" | "pr",
+  viewer: string | null,
+): Suggestion[] {
+  const idx = token.indexOf(":");
+  if (idx <= 0) {
+    const prefix = token.toLowerCase();
+    return QUALIFIER_KEYS.filter((entry) => entry.key.startsWith(prefix)).map(
+      (entry) => ({
+        insert: entry.key,
+        label: entry.key,
+        hint: entry.hint,
+      }),
+    );
+  }
+  const key = token.slice(0, idx).toLowerCase();
+  const partial = unquote(token.slice(idx + 1)).toLowerCase();
+  const matches = (value: string) => value.toLowerCase().includes(partial);
+  if (key === "is" || key === "state") {
+    const states =
+      kind === "pr" ? ["open", "closed", "merged"] : ["open", "closed"];
+    return states.filter(matches).map((state) => ({
+      insert: `${key}:${state} `,
+      label: state,
+      icon: {
+        kind: "state",
+        itemKind: kind,
+        state: STATE_VALUES[state] ?? "OPEN",
+      },
+    }));
+  }
+  if (key === "assignee" || key === "author") {
+    const users = ["@me", ...vocab.users];
+    return users.filter(matches).map((login) => {
+      const avatarLogin = login === "@me" ? viewer : login;
+      const icon: SuggestionIcon | undefined =
+        avatarLogin === null
+          ? undefined
+          : { kind: "avatar", login: avatarLogin };
+      return {
+        insert: `${key}:${login} `,
+        label: login === "@me" && viewer !== null ? `@me (${viewer})` : login,
+        ...(icon === undefined ? {} : { icon }),
+      };
+    });
+  }
+  if (key === "label") {
+    return vocab.labels.filter(matches).map((label) => ({
+      insert: `${key}:${quoteValue(label)} `,
+      label,
+    }));
+  }
+  if (key === "repo") {
+    return vocab.repos.filter(matches).map((repo) => ({
+      insert: `${key}:${repo} `,
+      label: repo,
+    }));
+  }
+  if (key === "no") {
+    return ["assignee", "label"].filter(matches).map((field) => ({
+      insert: `${key}:${field} `,
+      label: `no:${field}`,
+    }));
+  }
+  return [];
+}

--- a/plugins/github/app.logic.test.ts
+++ b/plugins/github/app.logic.test.ts
@@ -1,17 +1,13 @@
-// @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
-import { installTestPluginRuntime } from "@get-bb/plugin-sdk/testing/app";
-import type { Item, Route } from "./app";
-
-installTestPluginRuntime();
-
-const {
+import {
   buildSuggestions,
   matchesQuery,
   parseQuery,
   parseSubPath,
   routeToSubPath,
-} = await import("./app");
+  type Item,
+  type Route,
+} from "./app-logic.js";
 
 const issue: Item = {
   repo: "acme/widgets",
@@ -118,5 +114,13 @@ describe("github panel query engine", () => {
       { insert: "no:label ", label: "no:label" },
     ]);
     expect(compact("unknown:value", "issue")).toEqual([]);
+    expect(buildSuggestions("is:o", vocab, "pr", "octocat")[0]?.icon).toEqual({
+      kind: "state",
+      itemKind: "pr",
+      state: "OPEN",
+    });
+    expect(
+      buildSuggestions("author:ali", vocab, "issue", "octocat")[0]?.icon,
+    ).toEqual({ kind: "avatar", login: "alice" });
   });
 });

--- a/plugins/github/app.tsx
+++ b/plugins/github/app.tsx
@@ -25,6 +25,17 @@ import {
   type PluginNavPanelProps,
   type PluginThreadPanelProps,
 } from "@get-bb/plugin-sdk/app";
+import {
+  buildSuggestions,
+  matchesQuery,
+  parseQuery,
+  parseSubPath,
+  routeToSubPath,
+  type Item,
+  type Route,
+  type Suggestion,
+  type SuggestionIcon,
+} from "./app-logic.js";
 import type { githubRpcContract } from "./server.js";
 // Shimmed to the host's copy at build time (shared worker-pool context +
 // shiki stays out of the plugin bundle) — diffs render with the same syntax
@@ -58,20 +69,6 @@ import { Textarea } from "@bb/shared-ui/textarea";
 import { EmptyState } from "@/components/empty-state";
 import { Markdown } from "@/components/markdown-lite";
 import { PageBody } from "@/components/page-body";
-
-export interface Item {
-  repo: string;
-  number: number;
-  kind: "issue" | "pr";
-  title: string;
-  state: string;
-  author: string;
-  labels: string[];
-  assignees: string[];
-  url: string;
-  body: string;
-  updatedAt: string;
-}
 
 interface IssueComment {
   author: string;
@@ -179,47 +176,6 @@ function relativeTime(iso: string): string {
 // ---------------------------------------------------------------------------
 
 const PANEL_PATH = "github";
-
-export type Route =
-  | { view: "issues" }
-  | { view: "pulls" }
-  | { view: "new" }
-  | { view: "issue"; repo: string; number: number }
-  | { view: "pull"; repo: string; number: number };
-
-export function parseSubPath(subPath: string): Route {
-  const parts = subPath.split("/").filter((p) => p.length > 0);
-  if (parts[0] === "pulls" && parts.length === 4) {
-    const number = Number(parts[3]);
-    if (Number.isFinite(number)) {
-      return { view: "pull", repo: `${parts[1]}/${parts[2]}`, number };
-    }
-  }
-  if (parts[0] === "pulls") return { view: "pulls" };
-  if (parts[0] === "new") return { view: "new" };
-  if (parts[0] === "issues" && parts.length === 4) {
-    const number = Number(parts[3]);
-    if (Number.isFinite(number)) {
-      return { view: "issue", repo: `${parts[1]}/${parts[2]}`, number };
-    }
-  }
-  return { view: "issues" };
-}
-
-export function routeToSubPath(route: Route): string {
-  switch (route.view) {
-    case "issues":
-      return "issues";
-    case "pulls":
-      return "pulls";
-    case "new":
-      return "new";
-    case "issue":
-      return `issues/${route.repo}/${route.number}`;
-    case "pull":
-      return `pulls/${route.repo}/${route.number}`;
-  }
-}
 
 function useSubPathRoute(subPath: string): [Route, (route: Route) => void] {
   const bbNavigate = useBbNavigate();
@@ -475,186 +431,14 @@ function useIssueMutations() {
 }
 
 // ---------------------------------------------------------------------------
-// Query engine — GitHub-style qualifiers parsed and matched client-side.
-//   is:open · is:closed · is:merged · assignee:<login> · assignee:@me
-//   author:<login> · label:<name> ("quoted" for spaces) · repo:<owner/name>
-//   no:assignee · no:label · anything else matches title / number / repo
-// ---------------------------------------------------------------------------
-
-export interface ParsedQuery {
-  states: string[];
-  assignees: string[];
-  authors: string[];
-  labels: string[];
-  repos: string[];
-  noAssignee: boolean;
-  noLabel: boolean;
-  text: string[];
-}
-
-function tokenizeQuery(query: string): string[] {
-  return query.match(/(?:[^\s"]+|"[^"]*")+/g) ?? [];
-}
-
-function unquote(value: string): string {
-  return value.replace(/"/g, "");
-}
-
-const STATE_VALUES: Record<string, string> = {
-  open: "OPEN",
-  closed: "CLOSED",
-  merged: "MERGED",
-};
-
-export function parseQuery(query: string): ParsedQuery {
-  const parsed: ParsedQuery = {
-    states: [],
-    assignees: [],
-    authors: [],
-    labels: [],
-    repos: [],
-    noAssignee: false,
-    noLabel: false,
-    text: [],
-  };
-  for (const token of tokenizeQuery(query)) {
-    const idx = token.indexOf(":");
-    const key = idx > 0 ? token.slice(0, idx).toLowerCase() : "";
-    const value = idx > 0 ? unquote(token.slice(idx + 1)) : "";
-    // A dangling "key:" (still being typed) filters nothing.
-    if (idx > 0 && value.length === 0) continue;
-    if (key === "is" || key === "state") {
-      parsed.states.push(STATE_VALUES[value.toLowerCase()] ?? value.toUpperCase());
-    } else if (key === "assignee") {
-      parsed.assignees.push(value.toLowerCase());
-    } else if (key === "author") {
-      parsed.authors.push(value.toLowerCase());
-    } else if (key === "label") {
-      parsed.labels.push(value.toLowerCase());
-    } else if (key === "repo") {
-      parsed.repos.push(value.toLowerCase());
-    } else if (key === "no") {
-      if (value.toLowerCase() === "assignee") parsed.noAssignee = true;
-      if (value.toLowerCase() === "label") parsed.noLabel = true;
-    } else {
-      parsed.text.push(unquote(token).toLowerCase());
-    }
-  }
-  return parsed;
-}
-
-export function matchesQuery(item: Item, query: ParsedQuery, viewer: string | null): boolean {
-  if (query.states.length > 0 && !query.states.includes(item.state)) return false;
-  if (query.assignees.length > 0) {
-    const wanted = query.assignees.map((login) =>
-      login === "@me" ? (viewer?.toLowerCase() ?? "\u0000") : login,
-    );
-    if (!item.assignees.some((login) => wanted.includes(login.toLowerCase()))) return false;
-  }
-  if (query.authors.length > 0) {
-    const author = item.author.toLowerCase();
-    const wanted = query.authors.map((login) =>
-      login === "@me" ? (viewer?.toLowerCase() ?? "\u0000") : login,
-    );
-    if (!wanted.includes(author)) return false;
-  }
-  if (query.labels.length > 0) {
-    const labels = item.labels.map((label) => label.toLowerCase());
-    if (!query.labels.some((label) => labels.includes(label))) return false;
-  }
-  if (query.repos.length > 0 && !query.repos.includes(item.repo.toLowerCase())) return false;
-  if (query.noAssignee && item.assignees.length > 0) return false;
-  if (query.noLabel && item.labels.length > 0) return false;
-  if (query.text.length > 0) {
-    const haystack = `${item.title} #${item.number} ${item.repo}`.toLowerCase();
-    if (!query.text.every((term) => haystack.includes(term))) return false;
-  }
-  return true;
-}
-
-// ---------------------------------------------------------------------------
 // The filter bar: one input, GitHub-style typeahead over keys and values.
 // ---------------------------------------------------------------------------
 
-export interface Suggestion {
-  /** Replaces the token being typed. */
-  insert: string;
-  label: string;
-  hint?: string;
-  icon?: React.ReactNode;
-}
-
-const QUALIFIER_KEYS: Array<{ key: string; hint: string }> = [
-  { key: "is:", hint: "state — open, closed, merged" },
-  { key: "assignee:", hint: "assigned user, or @me" },
-  { key: "author:", hint: "opened by" },
-  { key: "label:", hint: "has label" },
-  { key: "repo:", hint: "in repository" },
-  { key: "no:", hint: "missing — assignee, label" },
-];
-
-function quoteValue(value: string): string {
-  return /\s/.test(value) ? `"${value}"` : value;
-}
-
-export function buildSuggestions(
-  token: string,
-  vocab: { users: string[]; labels: string[]; repos: string[] },
-  kind: "issue" | "pr",
-  viewer: string | null,
-): Suggestion[] {
-  const idx = token.indexOf(":");
-  if (idx <= 0) {
-    const prefix = token.toLowerCase();
-    return QUALIFIER_KEYS.filter((entry) => entry.key.startsWith(prefix)).map((entry) => ({
-      insert: entry.key,
-      label: entry.key,
-      hint: entry.hint,
-    }));
+function FilterSuggestionIcon({ icon }: { icon: SuggestionIcon }) {
+  if (icon.kind === "state") {
+    return <StateDot kind={icon.itemKind} state={icon.state} />;
   }
-  const key = token.slice(0, idx).toLowerCase();
-  const partial = unquote(token.slice(idx + 1)).toLowerCase();
-  const matches = (value: string) => value.toLowerCase().includes(partial);
-  if (key === "is" || key === "state") {
-    const states = kind === "pr" ? ["open", "closed", "merged"] : ["open", "closed"];
-    return states.filter(matches).map((state) => ({
-      insert: `${key}:${state} `,
-      label: state,
-      icon: <StateDot kind={kind} state={STATE_VALUES[state] ?? "OPEN"} />,
-    }));
-  }
-  if (key === "assignee" || key === "author") {
-    const users = ["@me", ...vocab.users];
-    return users.filter(matches).map((login) => ({
-      insert: `${key}:${login} `,
-      label: login === "@me" && viewer !== null ? `@me (${viewer})` : login,
-      icon:
-        login === "@me" ? (
-          viewer !== null ? <Avatar login={viewer} size="size-4" /> : undefined
-        ) : (
-          <Avatar login={login} size="size-4" />
-        ),
-    }));
-  }
-  if (key === "label") {
-    return vocab.labels.filter(matches).map((label) => ({
-      insert: `${key}:${quoteValue(label)} `,
-      label,
-    }));
-  }
-  if (key === "repo") {
-    return vocab.repos.filter(matches).map((repo) => ({
-      insert: `${key}:${repo} `,
-      label: repo,
-    }));
-  }
-  if (key === "no") {
-    return ["assignee", "label"].filter(matches).map((field) => ({
-      insert: `${key}:${field} `,
-      label: `no:${field}`,
-    }));
-  }
-  return [];
+  return <Avatar login={icon.login} size="size-4" />;
 }
 
 function FilterBar({
@@ -788,7 +572,9 @@ function FilterBar({
               }}
               onMouseEnter={() => setHighlight(index)}
             >
-              {suggestion.icon}
+              {suggestion.icon !== undefined ? (
+                <FilterSuggestionIcon icon={suggestion.icon} />
+              ) : null}
               <span className="min-w-0 truncate font-medium">{suggestion.label}</span>
               {suggestion.hint !== undefined ? (
                 <span className="ml-auto shrink-0 pl-4 text-xs text-muted-foreground">

--- a/plugins/provider-acp/src/bridge/agent-connection.test.ts
+++ b/plugins/provider-acp/src/bridge/agent-connection.test.ts
@@ -2,6 +2,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import {
+  AcpAgentExitedError,
   createAcpAgentConnection,
   formatAgentError,
   type AcpAgentConnection,
@@ -75,7 +76,7 @@ describe("ACP agent stdio lifecycle", () => {
       args: [
         "-e",
         [
-          "process.stdin.destroy();",
+          'require("node:fs").closeSync(0);',
           'process.stdout.write(JSON.stringify({ jsonrpc: "2.0", method: "ready" }) + "\\n");',
           "setTimeout(() => process.exit(0), 1000);",
         ].join(" "),
@@ -95,6 +96,62 @@ describe("ACP agent stdio lifecycle", () => {
         payload: "x".repeat(EPIPE_PAYLOAD_SIZE),
       });
       await delay(50);
+    } finally {
+      await stopConnection(connection, exited.promise);
+    }
+  });
+
+  it("rejects requests and stops an agent that closes stdin but stays alive", async () => {
+    const ready = deferred<void>();
+    const exited = deferred<AcpAgentExitInfo>();
+    const connection = createAcpAgentConnection({
+      command: process.execPath,
+      args: [
+        "-e",
+        [
+          'require("node:fs").closeSync(0);',
+          'process.stdout.write(JSON.stringify({ jsonrpc: "2.0", method: "ready" }) + "\\n");',
+          "setInterval(() => {}, 1000);",
+        ].join(" "),
+      ],
+      cwd: process.cwd(),
+      env: process.env,
+      onNotification(method) {
+        if (method === "ready") ready.resolve();
+      },
+      onRequest() {},
+      onExit: exited.resolve,
+    });
+
+    try {
+      await ready.promise;
+      const pendingRequest = connection.request({
+        method: "fixture/pending",
+        params: { payload: "x".repeat(EPIPE_PAYLOAD_SIZE) },
+        resultSchema: z.unknown(),
+      });
+      const requestWithDeadline = Promise.race([
+        pendingRequest,
+        delay(500).then(() => {
+          throw new Error("ACP request remained pending after stdin closed");
+        }),
+      ]);
+
+      await expect(requestWithDeadline).rejects.toBeInstanceOf(
+        AcpAgentExitedError,
+      );
+      expect(connection.exited).toBe(true);
+      await expect(
+        connection.request({
+          method: "fixture/future",
+          params: null,
+          resultSchema: z.unknown(),
+        }),
+      ).rejects.toBeInstanceOf(AcpAgentExitedError);
+      await expect(exited.promise).resolves.toMatchObject({
+        code: null,
+        signal: null,
+      });
     } finally {
       await stopConnection(connection, exited.promise);
     }

--- a/plugins/provider-acp/src/bridge/agent-connection.ts
+++ b/plugins/provider-acp/src/bridge/agent-connection.ts
@@ -77,15 +77,12 @@ interface AgentErrorObject {
   data?: unknown;
 }
 
-function handleAgentStdinError(error: Error): void {
-  if (
+function isClosedAgentStdinError(error: Error): boolean {
+  return (
     "code" in error &&
     typeof error.code === "string" &&
     CLOSED_STDIN_ERROR_CODES.has(error.code)
-  ) {
-    return;
-  }
-  throw error;
+  );
 }
 
 /**
@@ -154,26 +151,52 @@ export function createAcpAgentConnection(
   let nextRequestId = 1;
   let exited = false;
 
-  // The agent can close its read end between the writable check in writeLine
-  // and the kernel accepting the write. Node reports that race asynchronously
-  // on the stream; without a listener it becomes an uncaught EPIPE and can
-  // crash the bridge worker while the normal child-exit path is settling.
-  child.stdin?.on("error", handleAgentStdinError);
-
-  function writeLine(message: object): void {
-    const stdin = child.stdin;
-    if (!stdin || stdin.destroyed || !stdin.writable) {
-      return;
-    }
-    stdin.write(JSON.stringify(message) + "\n");
-  }
-
   function rejectAllPending(error: Error): void {
     for (const [, request] of pending) {
       request.reject(error);
     }
     pending.clear();
   }
+
+  function closeForAgentStdin(error: Error): void {
+    if (exited) {
+      return;
+    }
+    exited = true;
+    const code =
+      "code" in error && typeof error.code === "string"
+        ? ` (${error.code})`
+        : "";
+    const detail = `stdin closed${code}: ${error.message}`;
+    rejectAllPending(
+      new AcpAgentExitedError(`ACP agent "${options.command}" ${detail}`),
+    );
+    // The protocol cannot recover once the agent stops reading requests.
+    // Kill immediately so a child that keeps other handles open cannot leak.
+    child.kill("SIGKILL");
+    const stderrTail = [...stderrChunks, detail].join("\n");
+    options.onExit({ code: null, signal: null, stderrTail });
+  }
+
+  function writeLine(message: object): void {
+    const stdin = child.stdin;
+    if (!stdin || stdin.destroyed || !stdin.writable) {
+      closeForAgentStdin(new Error("stdin is not writable"));
+      return;
+    }
+    stdin.write(JSON.stringify(message) + "\n");
+  }
+
+  // The agent can close its read end between the writable check in writeLine
+  // and the kernel accepting the write. Node reports that race asynchronously
+  // on the stream. A closed input is an irrecoverable transport failure: all
+  // requests must settle even when the child keeps other handles open.
+  child.stdin?.on("error", (error) => {
+    if (!isClosedAgentStdinError(error)) {
+      throw error;
+    }
+    closeForAgentStdin(error);
+  });
 
   if (child.stdout) {
     const stdoutLines = createInterface({


### PR DESCRIPTION
## What was wrong

The post-merge review on [#1967](https://github.com/get-bb/bb/pull/1967#pullrequestreview-4977553039) identified two valid root causes. The ACP connection suppressed expected EPIPE / ERR_STREAM_DESTROYED events without changing connection state, so an agent that closed stdin but kept another handle alive could leave pending requests unresolved forever and continue accepting future requests. Separately, five pure GitHub route and query tests imported the 2,508-line panel entrypoint, initializing its React, plugin SDK, and UI dependency graph just to exercise synchronous logic.

## What changed

- Treat a closed ACP stdin as a fatal transport closure: make the connection unavailable, reject pending requests, force-stop the child, and report the exit. The regression fixture closes fd 0 while deliberately keeping the process alive and checks both pending and future requests.
- Move GitHub item, route, query, and suggestion logic into app-logic.ts. The pure module returns serializable icon descriptors; app.tsx alone renders them into the existing state-dot and avatar UI.
- Point the logic tests directly at the pure module and remove their jsdom and plugin-runtime setup.
- No server/daemon wire contract, CLI, user-facing configuration, guide, or protocol-version changes are involved.
- I did not consolidate the two fake-gh fixtures noted by the review: they share only temporary PATH plumbing, while their command behavior and failure controls are intentionally different.

## How you verified

- The new ACP persistent-child regression failed before the fix because the request remained pending past its deadline; it passes after the connection teardown change.
- pnpm exec turbo run test typecheck --filter=bb-plugin-github --filter=bb-plugin-provider-acp — 21 GitHub tests and 169 ACP tests passed; both typechecks passed.
- pnpm exec turbo run build --filter=bb-plugin-github — the production server, app JavaScript, and app CSS bundles built successfully.
- git diff --check origin/main...HEAD passed.
- In the focused GitHub logic test, Vitest import time dropped from 2.75 s to 27 ms and total file duration dropped from 3.53 s to 129 ms.

Fixes: N/A — post-merge review follow-up to #1967.

> AGENT GENERATED: by GPT-5