### PR TITLE
Speed up stored event parsing

### DIFF
--- a/packages/domain/src/provider-event.ts
+++ b/packages/domain/src/provider-event.ts
@@ -634,7 +634,7 @@ export const providerEventTypeValues = unscopedProviderEventSchema.options.map(
  * Events originating from the server/system layer (not from a provider process).
  * These do NOT carry `providerThreadId`.
  */
-const unscopedSystemEventSchema = z.union([
+const unscopedSystemEventSchema = z.discriminatedUnion("type", [
   z
     .object({
       type: z.literal("client/thread/start"),

--- a/packages/domain/src/provider-event.ts
+++ b/packages/domain/src/provider-event.ts
@@ -712,17 +712,22 @@ export const systemEventSchema = unscopedSystemEventSchema.and(
   scopedEventDataSchema,
 );
 
-const eventPropertyBagSchema = z.record(z.string(), z.unknown());
 const legacyClientRequestKey = ["clientRequest", "Sequence"].join("");
+
+function isEventPropertyBag(
+  value: unknown,
+): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 const rejectLegacyClientRequestSequenceSchema = z
   .unknown()
   .superRefine((value, ctx) => {
-    const eventResult = eventPropertyBagSchema.safeParse(value);
-    if (!eventResult.success) {
+    if (!isEventPropertyBag(value)) {
       return;
     }
 
-    if (Object.hasOwn(eventResult.data, legacyClientRequestKey)) {
+    if (Object.hasOwn(value, legacyClientRequestKey)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "legacy request sequence field is no longer accepted",
@@ -730,11 +735,11 @@ const rejectLegacyClientRequestSequenceSchema = z
       });
     }
 
-    const itemResult = eventPropertyBagSchema.safeParse(eventResult.data.item);
+    const item = value.item;
     if (
-      itemResult.success &&
-      itemResult.data.type === "userMessage" &&
-      Object.hasOwn(itemResult.data, legacyClientRequestKey)
+      isEventPropertyBag(item) &&
+      item.type === "userMessage" &&
+      Object.hasOwn(item, legacyClientRequestKey)
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,


### PR DESCRIPTION
## What was wrong

Persisted thread-event validation paid for two nested `z.record(...).safeParse(...)` calls before the real event schema parse: one for every event object and another for `item`, which also constructed a failed Zod result for the many events without an item. System/client events then went through a 12-way plain union that retried schemas linearly instead of using their existing `type` discriminator. Both costs sit in the synchronous timeline decode path.

## What changed

- Replace the legacy-field guard's nested record schemas with an equivalent direct property-bag narrowing. The outer `threadEventSchema` still performs complete event/scope validation, and legacy top-level and user-message fields are still rejected.
- Change the system/client half of the event schema to `z.discriminatedUnion("type", ...)`, matching provider-event dispatch.
- Keep the diff to `packages/domain/src/provider-event.ts`. No wire fields or accepted event shapes changed, so `HOST_DAEMON_PROTOCOL_VERSION` does not need a bump.

Assigned source commit `687929854` only refreshed three generated declaration files. Current main removed those tracked artifacts in `328d5a8d4` and now regenerates/ignores them through Turbo, so this PR deliberately does not resurrect them. `@get-bb/plugin-sdk#build:types` and `@bb/templates#generate:plugin-scaffold` regenerate the expected `ZodDiscriminatedUnion` declarations successfully.

## How you verified

Final branch base: `35732c53922906a6f6684f684461077b685a812b`; final head: `ef6a92a5d9314aa1ec894c79f6b6fac9cdcdecb8`. Performance comparison used the independently built pre-rebase baseline/after SHAs `1654d0f001559aeecb0b9d4f3891e71e653a77eb` and `0efde9a6db628866c6e684ba9a03944f83e52f65`. Main advanced while profiling; the four intervening commits did not touch `provider-event.ts`, the stored-event parser, timeline builder/query, or fixture generator. The final rebased diff is identical.

Hardware/build: Apple M4 Max (16 cores: 12 performance + 4 efficiency), 48 GB RAM, Darwin 25.5.0, Node 22.23.1. Both variants were bundled separately in production mode and run as fresh Node processes on the same machine.

Fixture command:

```sh
pnpm seed:perf -- --data-dir /tmp/bb-stored-event-perf.6Kj75O/data --projects 12 --threads 1200 --events 400000 --seed 20260819 --reset
```

The deterministic fixture contains 1,200 threads and 402,266 event rows in a 496 MB SQLite database (SHA-256 `7b70b433b72d79aaf092a987c9ef892b81a52d7d590e6878367a70928de6b40e`).

Direct parsing used a fixed 10,000-row/43.3 MB mixed corpus: 5,000 large `item/completed` rows, 2,500 large `turn/diff/updated` rows, and 2,500 client/system rows (`client/thread/start`, `client/turn/requested`, and `system/thread-provisioning`). Each process performed three warmups and parsed 50,000 events in its measured batch. Seven A/B pairs alternated execution order:

```sh
NODE_ENV=production node /tmp/bb-stored-event-perf.6Kj75O/run-paired.mjs micro /tmp/bb-stored-event-perf.6Kj75O/data/bb.db 7
```

| Direct stored-event parse | Baseline | After | Change |
| --- | ---: | ---: | ---: |
| Median time/event | 12.938 µs | 6.961 µs | -46.2% |
| p95 time/event | 14.185 µs | 8.071 µs | -43.1% |
| Median throughput | 77,293 events/s | 143,650 events/s | +85.9% |
| Median paired throughput ratio | — | 1.882× | +88.2% |

The representative server path called `buildThreadTimelineWithProfile` without the response cache for the 200 largest seeded threads (median/p95 1,023/1,466 events and 595/848 KB stored event JSON per thread). Each fresh process fully warmed all 200 threads, then measured one 200-request pass; seven A/B pairs alternated order. Settings were identical: event budget 1,500, latest-page segment limit 100, 32,000-character inline-output cap, nested rows off.

```sh
NODE_ENV=production node /tmp/bb-stored-event-perf.6Kj75O/run-paired.mjs server /tmp/bb-stored-event-perf.6Kj75O/data/bb.db 7
```

| Uncached timeline common path | Baseline | After | Change |
| --- | ---: | ---: | ---: |
| Median event-decode stage | 10.039 ms | 3.153 ms | -68.6% |
| Median request latency | 20.810 ms | 12.033 ms | -42.2% |
| Median throughput | 48.255 req/s | 63.976 req/s | +32.6% |
| Median paired throughput ratio | — | 1.281× | +28.1% |

The shared host had unrelated browser/build workloads and load averages ranging roughly 17–36 during profiling. Alternating fresh-process pairs control order bias, but whole-request tails remained noisy: the median of each run's p95 was 26.978 ms baseline vs. 34.502 ms after, and one of seven pairs reversed under a load spike. I therefore use the stable direct parse result, parser-stage timings, and medians as evidence—not the server p95. Earlier non-alternating pilot/contended outputs were retained under `/tmp/bb-stored-event-perf.6Kj75O` but excluded from the table.

CPU profiles used the same 10,000-row corpus for 500,000 parses per variant:

```sh
BENCH_LABEL=baseline BENCH_SHA=1654d0f001559aeecb0b9d4f3891e71e653a77eb NODE_ENV=production node --expose-gc --cpu-prof --cpu-prof-dir=/tmp/bb-stored-event-perf.6Kj75O --cpu-prof-name=baseline.cpuprofile /tmp/bb-stored-event-perf.6Kj75O/stored-event-benchmark-baseline.mjs micro-profile /tmp/bb-stored-event-perf.6Kj75O/data/bb.db
BENCH_LABEL=after BENCH_SHA=0efde9a6db628866c6e684ba9a03944f83e52f65 NODE_ENV=production node --expose-gc --cpu-prof --cpu-prof-dir=/tmp/bb-stored-event-perf.6Kj75O --cpu-prof-name=after.cpuprofile /tmp/bb-stored-event-perf.6Kj75O/stored-event-benchmark-after.mjs micro-profile /tmp/bb-stored-event-perf.6Kj75O/data/bb.db
```

The baseline `inst.safeParse` stack accounted for 1,782 inclusive samples out of 6,156 (28.9%); after it accounted for 44/4,440 (1.0%), with the remaining calls belonging to required boundary parsing. Statically, the removed property-bag guard made exactly two redundant record `safeParse` calls per valid event: 1,000,000 calls in the 500,000-event profile workload before, zero after.

Validation:

```sh
pnpm exec turbo run build:types --filter=@get-bb/plugin-sdk --force
pnpm exec turbo run generate:plugin-scaffold --filter=@bb/templates --force
pnpm exec turbo run test --filter=@bb/domain --filter=@bb/server --force
pnpm exec turbo run typecheck --filter=@bb/domain --filter=@bb/server --force
pnpm exec turbo run build --filter=@bb/server --force
```

- Rebased full suite: 190 server files / 1,781 tests passed; all domain tasks passed.
- Turbo typecheck: 5/5 tasks passed.
- Production server build: 4/4 tasks passed.
- Focused parser tests also passed: `test/provider-event.test.ts` (5) and `test/threads/thread-data.test.ts` (2).

> AGENT GENERATED: by GPT-5
