### PR TITLE
Preserve thread scroll position when older rows load

### DIFF
--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.height.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.height.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, expect, it, vi } from "vitest";
+import { conversationRow, turnRow } from "@/test/fixtures/thread-timeline-rows";
+import { ThreadTimelineRows } from "./ThreadTimelineRows";
+
+class ResizeObserverStub implements ResizeObserver {
+  constructor(readonly callback: ResizeObserverCallback) {}
+
+  observe: ResizeObserver["observe"] = vi.fn();
+  unobserve: ResizeObserver["unobserve"] = vi.fn();
+  disconnect: ResizeObserver["disconnect"] = vi.fn();
+}
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+it("snap-syncs the timeline height when older rows are prepended", () => {
+  vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+  vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(
+    function (this: HTMLElement) {
+      return (
+        this.querySelectorAll(
+          '[data-timeline-row-list="top-level"] > [data-timeline-row-id]',
+        ).length * 100
+      );
+    },
+  );
+
+  const latestRows = [
+    conversationRow({
+      id: "newer_user",
+      role: "user",
+      seq: 20,
+      text: "Newest request",
+    }),
+    turnRow({ id: "newest_turn", seq: 21, status: "completed" }),
+  ];
+  const olderRows = [
+    conversationRow({
+      id: "older_user",
+      role: "user",
+      seq: 10,
+      text: "Older request",
+    }),
+    turnRow({ id: "older_turn", seq: 11, status: "completed" }),
+  ];
+  const queryClient = new QueryClient();
+  const timeline = (rows: typeof latestRows) => (
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <ThreadTimelineRows
+          threadId="thr_main"
+          timelineRows={rows}
+          threadRuntimeDisplayStatus="idle"
+          workspaceRootPath={undefined}
+        />
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+  const view = render(timeline(latestRows));
+  const rowList = view.container.querySelector<HTMLElement>(
+    '[data-timeline-row-list="top-level"]',
+  );
+  const heightWrapper = rowList?.parentElement?.parentElement;
+
+  expect(heightWrapper?.style.height).toBe("200px");
+
+  // Loading an older page changes the leading row while the latest completed
+  // turn stays the same. The wrapper must snap now, before ResizeObserver, so
+  // the parent scroll body's layout effect sees the full prepend delta.
+  view.rerender(timeline([...olderRows, ...latestRows]));
+
+  expect(heightWrapper?.style.height).toBe("400px");
+  expect(heightWrapper?.style.transitionDuration).toBe("0s");
+});

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -654,17 +654,28 @@ function timelineRowsOwnerKey({
 }
 
 function timelineHeightSnapRevision(rows: readonly TimelineRow[]): string {
+  // Prepending an older page must finalize the new height during this commit.
+  // The parent scroll body restores its captured prepend anchor in a layout
+  // effect; if AutoHeightContainer waits for ResizeObserver, the scroll body
+  // only sees the old wrapper height and cannot compensate for the added rows.
+  const firstRowId = rows[0]?.id;
+
   // Active turns render their work rows directly. Completion replaces those
-  // rows with one or more turn summaries plus the terminal message. Key the
-  // height container by the newest completed summary so that authoritative
-  // topology replacement snaps instead of looking like a second stream.
+  // rows with one or more turn summaries plus the terminal message. Include
+  // the newest completed summary so that authoritative topology replacement
+  // also snaps instead of looking like a second stream.
   for (let index = rows.length - 1; index >= 0; index -= 1) {
     const row = rows[index];
     if (row?.kind === "turn") {
-      return `${row.id}:${row.sourceSeqStart}:${row.sourceSeqEnd}`;
+      return joinSignatureParts([
+        firstRowId,
+        row.id,
+        row.sourceSeqStart,
+        row.sourceSeqEnd,
+      ]);
     }
   }
-  return "active";
+  return joinSignatureParts([firstRowId, "active"]);
 }
 
 function useTimelineViewRowsCache(): GetTimelineViewRows {


### PR DESCRIPTION
## What was wrong

When an older timeline page was prepended, `BottomAnchoredScrollBody` tried to restore the captured viewport in its layout effect while `AutoHeightContainer` still exposed the previous wrapper height. The later `ResizeObserver` height update happened after that compensation opportunity, so Chromium clamped the scroll position to the old maximum and left the viewport on an older message as the full prepended height appeared.

## What changed

The timeline height snap revision now includes the leading row identity. A paginated prepend therefore snap-syncs `AutoHeightContainer` during the same commit, before the parent scroll body's layout effect measures the added height. Streaming growth and the existing completed-turn topology revision remain unchanged. A focused regression test covers a leading-row prepend while the latest completed turn stays constant.

No wire, daemon protocol, CLI, or configuration changes.

## Before and after

| Before | After |
| --- | --- |
| ![Before: loading older rows moves the viewport](https://github.com/user-attachments/assets/3ce9f2b7-15e8-47fb-86cf-874c81b8c502) | ![After: loading older rows preserves the viewport](https://github.com/user-attachments/assets/3632112d-cc6d-4bd2-a37b-0c784a236ab1) |

## How you verified

- The new regression test fails on the previous code (`200px` remained stale instead of snap-syncing to `400px`) and passes with this change.
- Reproduced against a worktree-local SQLite copy of the affected 9,753-event thread, without navigating to or mutating the production thread.
  - Before: six prepended rows changed `scrollTop` from 553 to 1,353 and replaced the visible row.
  - After: `scrollTop` compensates from 553 to 2,923 while the same visible row remains at exactly -426px.
- `pnpm exec turbo run test --filter=@bb/app --force`: 410 files passed, 3,138 tests passed, 3 skipped.
- Focused scroll/height suite: 5 files passed, 28 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app`.
- `pnpm exec turbo run lint --filter=@bb/app` (0 errors; existing warnings only).
- Manual Chromium before/after recording on the isolated worktree dev app.

Fixes: no linked issue.

> AGENT GENERATED: by GPT-5.6 Codex