### PR TITLE
Speed up timeline pagination queries

### DIFF
--- a/apps/server/src/services/threads/thread-edit-message.ts
+++ b/apps/server/src/services/threads/thread-edit-message.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
-import { and, desc, eq, lt, sql } from "drizzle-orm";
+import { and, desc, eq, isNull, lt, sql } from "drizzle-orm";
 import {
   deleteThreadEventSuffixInTransaction,
   events,
@@ -242,7 +242,7 @@ function resolveEditableTurnCandidate(
         eq(events.threadId, thread.id),
         eq(events.type, "turn/started"),
         lt(events.sequence, requestRow.sequence),
-        sql`COALESCE(json_extract(${events.data}, '$.parentToolCallId'), '') = ''`,
+        isNull(events.parentToolCallId),
       ),
     )
     .orderBy(desc(events.sequence))

--- a/apps/server/src/services/threads/timeline.ts
+++ b/apps/server/src/services/threads/timeline.ts
@@ -404,41 +404,11 @@ function mergeStoredEventRowsById(
   );
 }
 
-function asRecord(value: unknown): Record<string, unknown> | null {
-  return typeof value === "object" && value !== null
-    ? (value as Record<string, unknown>)
-    : null;
-}
-
-function parseStoredEventData(row: StoredEventRow): Record<string, unknown> {
-  return asRecord(JSON.parse(row.data)) ?? {};
-}
-
-const PARENT_TOOL_CALL_ID_JSON_KEY = '"parentToolCallId"';
-
 function getStoredEventParentToolCallId(
   row: StoredEventRow,
 ): string | undefined {
-  // Persisted event JSON is produced by JSON.stringify, so an event that can
-  // carry parent context always contains this exact property key. Most events
-  // do not. Avoid decoding every row once here and then again for projection.
-  if (!row.data.includes(PARENT_TOOL_CALL_ID_JSON_KEY)) {
-    return undefined;
-  }
-  const data = parseStoredEventData(row);
-  const item = asRecord(data.item);
-  const itemParentToolCallId = item?.parentToolCallId;
-  if (
-    typeof itemParentToolCallId === "string" &&
-    itemParentToolCallId.length > 0
-  ) {
-    return itemParentToolCallId;
-  }
-
-  const eventParentToolCallId = data.parentToolCallId;
-  return typeof eventParentToolCallId === "string" &&
-    eventParentToolCallId.length > 0
-    ? eventParentToolCallId
+  return row.parentToolCallId !== null && row.parentToolCallId.length > 0
+    ? row.parentToolCallId
     : undefined;
 }
 

--- a/apps/server/src/services/threads/timeline.ts
+++ b/apps/server/src/services/threads/timeline.ts
@@ -414,9 +414,17 @@ function parseStoredEventData(row: StoredEventRow): Record<string, unknown> {
   return asRecord(JSON.parse(row.data)) ?? {};
 }
 
+const PARENT_TOOL_CALL_ID_JSON_KEY = '"parentToolCallId"';
+
 function getStoredEventParentToolCallId(
   row: StoredEventRow,
 ): string | undefined {
+  // Persisted event JSON is produced by JSON.stringify, so an event that can
+  // carry parent context always contains this exact property key. Most events
+  // do not. Avoid decoding every row once here and then again for projection.
+  if (!row.data.includes(PARENT_TOOL_CALL_ID_JSON_KEY)) {
+    return undefined;
+  }
   const data = parseStoredEventData(row);
   const item = asRecord(data.item);
   const itemParentToolCallId = item?.parentToolCallId;

--- a/apps/server/test/helpers/seed.ts
+++ b/apps/server/test/helpers/seed.ts
@@ -55,6 +55,7 @@ export interface SeedStoredEventArgs {
   environmentId?: string | null;
   itemId?: string | null;
   itemKind?: ThreadEventItemType | null;
+  parentToolCallId?: string | null;
   providerThreadId?: string | null;
   scope: ThreadEventScope;
   sequence: number;
@@ -392,6 +393,7 @@ export function seedStoredEvent(
       type: args.type,
       itemId: args.itemId ?? null,
       itemKind: args.itemKind ?? null,
+      parentToolCallId: args.parentToolCallId ?? null,
       data: JSON.stringify(args.data),
     },
   ]);

--- a/apps/server/test/public/public-thread-data.test.ts
+++ b/apps/server/test/public/public-thread-data.test.ts
@@ -1537,6 +1537,7 @@ describe("public thread data routes", () => {
           type: "turn/started",
           itemId: null,
           itemKind: null,
+          parentToolCallId: null,
           data: JSON.stringify({}),
         });
         push({
@@ -1545,6 +1546,7 @@ describe("public thread data routes", () => {
           type: "item/started",
           itemId: parentToolCallId,
           itemKind: "toolCall",
+          parentToolCallId: null,
           data: JSON.stringify({
             item: {
               type: "toolCall",
@@ -1564,6 +1566,7 @@ describe("public thread data routes", () => {
             type: "item/started",
             itemId,
             itemKind: "commandExecution",
+            parentToolCallId,
             data: JSON.stringify({
               item: {
                 type: "commandExecution",
@@ -1582,6 +1585,7 @@ describe("public thread data routes", () => {
             type: "item/completed",
             itemId,
             itemKind: "commandExecution",
+            parentToolCallId,
             data: JSON.stringify({
               item: {
                 type: "commandExecution",
@@ -1603,6 +1607,7 @@ describe("public thread data routes", () => {
           type: "item/completed",
           itemId: parentToolCallId,
           itemKind: "toolCall",
+          parentToolCallId: null,
           data: JSON.stringify({
             item: {
               type: "toolCall",
@@ -1620,6 +1625,7 @@ describe("public thread data routes", () => {
           type: "turn/completed",
           itemId: null,
           itemKind: null,
+          parentToolCallId: null,
           data: JSON.stringify({ status: "completed", providerThreadId }),
         });
         insertEvents(harness.deps.db, harness.deps.hub, eventInputs);

--- a/apps/server/test/services/threads/conversation-outline-performance.test.ts
+++ b/apps/server/test/services/threads/conversation-outline-performance.test.ts
@@ -49,6 +49,7 @@ describe("thread conversation outline performance", () => {
         scope: threadScope(),
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ text: "Visible response" }),
       },
       {
@@ -59,6 +60,7 @@ describe("thread conversation outline performance", () => {
         providerThreadId: "provider-thread-1",
         itemId: "command-1",
         itemKind: "commandExecution",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: {
             id: "command-1",
@@ -100,6 +102,7 @@ describe("thread conversation outline performance", () => {
         providerThreadId: "provider-thread-1",
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({}),
       },
       {
@@ -110,6 +113,7 @@ describe("thread conversation outline performance", () => {
         providerThreadId: "provider-thread-1",
         itemId: "message-1",
         itemKind: "agentMessage",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: {
             id: "message-1",
@@ -126,6 +130,7 @@ describe("thread conversation outline performance", () => {
         providerThreadId: "provider-thread-1",
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ message: "Provider failed" }),
       },
       {
@@ -136,6 +141,7 @@ describe("thread conversation outline performance", () => {
         providerThreadId: "provider-thread-1",
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ status: "failed" }),
       },
     ]);

--- a/apps/server/test/services/threads/timeline-event-budget.test.ts
+++ b/apps/server/test/services/threads/timeline-event-budget.test.ts
@@ -76,6 +76,7 @@ function insertTurns(
       scope: threadScope(),
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({
         direction: "outbound",
         source: "tell",
@@ -97,6 +98,7 @@ function insertTurns(
       providerThreadId,
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({}),
     });
     sequence += 1;
@@ -108,6 +110,7 @@ function insertTurns(
       providerThreadId,
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({ clientRequestId }),
     });
     const items =
@@ -124,6 +127,7 @@ function insertTurns(
         providerThreadId,
         itemId: `${turnId}-item-${item}`,
         itemKind: "agentMessage",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: {
             type: "agentMessage",
@@ -168,6 +172,7 @@ function insertTurnsWithReusedFileChangeItemId(
       scope: threadScope(),
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({
         direction: "outbound",
         source: "tell",
@@ -187,6 +192,7 @@ function insertTurnsWithReusedFileChangeItemId(
       providerThreadId,
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({}),
     });
     push({
@@ -196,6 +202,7 @@ function insertTurnsWithReusedFileChangeItemId(
       providerThreadId,
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({ clientRequestId }),
     });
     for (let item = 0; item < fillerItemsPerTurn; item += 1) {
@@ -206,6 +213,7 @@ function insertTurnsWithReusedFileChangeItemId(
         providerThreadId,
         itemId: `${turnId}-item-${item}`,
         itemKind: "agentMessage",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: {
             type: "agentMessage",
@@ -230,6 +238,7 @@ function insertTurnsWithReusedFileChangeItemId(
         providerThreadId,
         itemId: reusedItemId,
         itemKind: "fileChange",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: {
             type: "fileChange",

--- a/apps/server/test/services/threads/timeline-head-state.test.ts
+++ b/apps/server/test/services/threads/timeline-head-state.test.ts
@@ -70,6 +70,7 @@ function seedThreadWithEarlyHeadState(
       scope: threadScope(),
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({
         direction: "outbound",
         source: "tell",
@@ -90,6 +91,7 @@ function seedThreadWithEarlyHeadState(
       providerThreadId,
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({}),
     });
     events.push({
@@ -100,6 +102,7 @@ function seedThreadWithEarlyHeadState(
       providerThreadId,
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({ clientRequestId }),
     });
 
@@ -111,6 +114,7 @@ function seedThreadWithEarlyHeadState(
         scope: threadScope(),
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({
           threadId: thread.id,
           providerThreadId,
@@ -129,6 +133,7 @@ function seedThreadWithEarlyHeadState(
         providerThreadId,
         itemId: "todo-1",
         itemKind: "toolCall",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: {
             type: "toolCall",
@@ -158,6 +163,7 @@ function seedThreadWithEarlyHeadState(
         providerThreadId,
         itemId: "wf-1",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: JSON.stringify({
           providerThreadId,
           item: {
@@ -184,6 +190,7 @@ function seedThreadWithEarlyHeadState(
         providerThreadId,
         itemId: `${turnId}-item-${item}`,
         itemKind: "agentMessage",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: {
             type: "agentMessage",
@@ -251,6 +258,7 @@ describe("timeline head state under a budgeted window", () => {
       scope: threadScope(),
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({
         direction: "outbound",
         source: "tell",

--- a/apps/server/test/services/threads/timeline-in-turn-window.test.ts
+++ b/apps/server/test/services/threads/timeline-in-turn-window.test.ts
@@ -142,6 +142,7 @@ function seedTurns(
       scope: threadScope(),
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({
         direction: "outbound",
         source: "tell",
@@ -160,6 +161,7 @@ function seedTurns(
       providerThreadId,
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({}),
     });
     push({
@@ -168,6 +170,7 @@ function seedTurns(
       providerThreadId,
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({ clientRequestId }),
     });
 
@@ -178,6 +181,7 @@ function seedTurns(
         providerThreadId,
         itemId: BACKGROUND_TASK_ITEM_ID,
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: backgroundTaskData("pending"),
       });
       if (options.backgroundTask === "completed") {
@@ -187,6 +191,7 @@ function seedTurns(
           providerThreadId,
           itemId: BACKGROUND_TASK_ITEM_ID,
           itemKind: "backgroundTask",
+          parentToolCallId: null,
           data: backgroundTaskData("completed"),
         });
       }
@@ -201,6 +206,7 @@ function seedTurns(
         providerThreadId,
         itemId: parentToolCallId,
         itemKind: "toolCall",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: {
             type: "toolCall",
@@ -229,6 +235,7 @@ function seedTurns(
         providerThreadId,
         itemId,
         itemKind: "commandExecution",
+        parentToolCallId,
         data: JSON.stringify({
           item: {
             type: "commandExecution",
@@ -258,6 +265,7 @@ function seedTurns(
           // deriveStoredEventItemFieldsFromSource); seeding a kind here would
           // exercise a row shape production can never write.
           itemKind: null,
+          parentToolCallId: null,
           data: JSON.stringify({
             threadId: thread.id,
             providerThreadId,
@@ -272,6 +280,7 @@ function seedTurns(
         providerThreadId,
         itemId,
         itemKind: "commandExecution",
+        parentToolCallId,
         data: JSON.stringify({
           item: {
             type: "commandExecution",
@@ -298,6 +307,7 @@ function seedTurns(
         providerThreadId,
         itemId,
         itemKind: "commandExecution",
+        parentToolCallId,
         data: JSON.stringify({
           item: {
             type: "commandExecution",
@@ -327,6 +337,7 @@ function seedTurns(
         providerThreadId,
         itemId: parentToolCallId,
         itemKind: "toolCall",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: {
             type: "toolCall",
@@ -347,6 +358,7 @@ function seedTurns(
         providerThreadId,
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ status: "completed", providerThreadId }),
       });
     }
@@ -376,6 +388,7 @@ function appendCommandItems(
       providerThreadId,
       itemId,
       itemKind: "commandExecution",
+      parentToolCallId: null,
       data: JSON.stringify({
         item: {
           type: "commandExecution",
@@ -393,6 +406,7 @@ function appendCommandItems(
       providerThreadId,
       itemId,
       itemKind: "commandExecution",
+      parentToolCallId: null,
       data: JSON.stringify({
         item: {
           type: "commandExecution",
@@ -552,6 +566,7 @@ describe("in-turn timeline windows", () => {
         providerThreadId,
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ status: "completed", providerThreadId }),
       },
     ]);
@@ -806,6 +821,7 @@ describe("in-turn timeline windows", () => {
         scope: threadScope(),
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({
           message: "x".repeat(THREAD_TIMELINE_EVENT_DATA_BYTE_LIMIT),
         }),
@@ -981,6 +997,7 @@ describe("timeline segment anchors", () => {
         scope: threadScope(),
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({
           direction: "outbound",
           source: "tell",
@@ -1001,6 +1018,7 @@ describe("timeline segment anchors", () => {
         providerThreadId,
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({}),
       },
     ]);
@@ -1028,6 +1046,7 @@ describe("timeline window event exclusions", () => {
         providerThreadId,
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ diff: "x".repeat(50_000) }),
       },
     ]);
@@ -1056,6 +1075,7 @@ describe("timeline inline output reads", () => {
         providerThreadId,
         itemId: "big-item",
         itemKind: "commandExecution",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: {
             type: "commandExecution",
@@ -1203,6 +1223,7 @@ describe("in-turn windows and items that only stream", () => {
               providerThreadId,
               itemId,
               itemKind: "agentMessage",
+              parentToolCallId: null,
               data: JSON.stringify({
                 item: { type: "agentMessage", id: itemId, text: "" },
                 providerThreadId,
@@ -1221,6 +1242,7 @@ describe("in-turn windows and items that only stream", () => {
           providerThreadId,
           itemId,
           itemKind: null,
+          parentToolCallId: null,
           data: JSON.stringify({
             delta,
             itemId,
@@ -1252,6 +1274,7 @@ describe("in-turn windows and items that only stream", () => {
           providerThreadId,
           itemId,
           itemKind: null,
+          parentToolCallId: null,
           data: JSON.stringify({
             delta,
             itemId,

--- a/apps/server/test/services/threads/timeline-parented-pagination.test.ts
+++ b/apps/server/test/services/threads/timeline-parented-pagination.test.ts
@@ -70,6 +70,7 @@ function insertCrossWindowSubagentEvents(
       scope: threadScope(),
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({
         direction: "outbound",
         source: "spawn",
@@ -90,6 +91,7 @@ function insertCrossWindowSubagentEvents(
       providerThreadId,
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({}),
     },
     {
@@ -100,6 +102,7 @@ function insertCrossWindowSubagentEvents(
       providerThreadId,
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({ clientRequestId: firstRequestId }),
     },
     {
@@ -110,6 +113,7 @@ function insertCrossWindowSubagentEvents(
       providerThreadId,
       itemId: "toolu_agent_1",
       itemKind: "toolCall",
+      parentToolCallId: null,
       data: JSON.stringify({
         item: {
           type: "toolCall",
@@ -131,6 +135,7 @@ function insertCrossWindowSubagentEvents(
       providerThreadId,
       itemId: "toolu_agent_1",
       itemKind: "toolCall",
+      parentToolCallId: null,
       data: JSON.stringify({
         item: {
           type: "toolCall",
@@ -152,6 +157,7 @@ function insertCrossWindowSubagentEvents(
       scope: threadScope(),
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({
         direction: "outbound",
         source: "tell",
@@ -172,6 +178,7 @@ function insertCrossWindowSubagentEvents(
       providerThreadId,
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({}),
     },
     {
@@ -182,6 +189,7 @@ function insertCrossWindowSubagentEvents(
       providerThreadId,
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({ clientRequestId: secondRequestId }),
     },
     {
@@ -192,6 +200,7 @@ function insertCrossWindowSubagentEvents(
       providerThreadId,
       itemId: "middle-message",
       itemKind: "agentMessage",
+      parentToolCallId: null,
       data: JSON.stringify({
         item: {
           type: "agentMessage",
@@ -207,6 +216,7 @@ function insertCrossWindowSubagentEvents(
       scope: threadScope(),
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({
         direction: "outbound",
         source: "tell",
@@ -227,6 +237,7 @@ function insertCrossWindowSubagentEvents(
       providerThreadId,
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({}),
     },
     {
@@ -237,6 +248,7 @@ function insertCrossWindowSubagentEvents(
       providerThreadId,
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
       data: JSON.stringify({ clientRequestId: thirdRequestId }),
     },
     {
@@ -247,6 +259,7 @@ function insertCrossWindowSubagentEvents(
       providerThreadId,
       itemId: "newest-message",
       itemKind: "agentMessage",
+      parentToolCallId: null,
       data: JSON.stringify({
         item: {
           type: "agentMessage",
@@ -263,6 +276,7 @@ function insertCrossWindowSubagentEvents(
       providerThreadId,
       itemId: null,
       itemKind: null,
+      parentToolCallId: "toolu_agent_1",
       data: JSON.stringify({ parentToolCallId: "toolu_agent_1" }),
     },
     {
@@ -273,6 +287,7 @@ function insertCrossWindowSubagentEvents(
       providerThreadId,
       itemId: "child-message",
       itemKind: "agentMessage",
+      parentToolCallId: "toolu_agent_1",
       data: JSON.stringify({
         item: {
           type: "agentMessage",

--- a/apps/server/test/services/threads/timeline-workflow-progress-window.test.ts
+++ b/apps/server/test/services/threads/timeline-workflow-progress-window.test.ts
@@ -128,6 +128,7 @@ function seedWorkflowThread(
     scope: threadScope(),
     itemId: null,
     itemKind: null,
+    parentToolCallId: null,
     data: JSON.stringify({
       direction: "outbound",
       source: "tell",
@@ -146,6 +147,7 @@ function seedWorkflowThread(
     providerThreadId,
     itemId: null,
     itemKind: null,
+    parentToolCallId: null,
     data: JSON.stringify({}),
   });
   push({
@@ -154,6 +156,7 @@ function seedWorkflowThread(
     providerThreadId,
     itemId: null,
     itemKind: null,
+    parentToolCallId: null,
     data: JSON.stringify({ clientRequestId }),
   });
   push({
@@ -162,6 +165,7 @@ function seedWorkflowThread(
     providerThreadId,
     itemId: WORKFLOW_CALL_ID,
     itemKind: "toolCall",
+    parentToolCallId: null,
     data: JSON.stringify({
       providerThreadId,
       item: {
@@ -179,6 +183,7 @@ function seedWorkflowThread(
     providerThreadId,
     itemId: WORKFLOW_TASK_ID,
     itemKind: "backgroundTask",
+    parentToolCallId: WORKFLOW_CALL_ID,
     data: workflowTaskData({ status: "pending", padding: 0 }),
   });
   push({
@@ -187,6 +192,7 @@ function seedWorkflowThread(
     providerThreadId,
     itemId: WORKFLOW_CALL_ID,
     itemKind: "toolCall",
+    parentToolCallId: null,
     data: JSON.stringify({
       providerThreadId,
       item: {
@@ -205,6 +211,7 @@ function seedWorkflowThread(
     providerThreadId,
     itemId: "assistant-1",
     itemKind: "agentMessage",
+    parentToolCallId: null,
     data: JSON.stringify({
       providerThreadId,
       item: {
@@ -221,6 +228,7 @@ function seedWorkflowThread(
     providerThreadId,
     itemId: null,
     itemKind: null,
+    parentToolCallId: null,
     data: JSON.stringify({ status: "completed", providerThreadId }),
   });
   push({
@@ -229,6 +237,7 @@ function seedWorkflowThread(
     providerThreadId,
     itemId: null,
     itemKind: null,
+    parentToolCallId: null,
     data: JSON.stringify({}),
   });
   for (let index = 0; index < (options.pendingTurnItems ?? 0); index += 1) {
@@ -240,6 +249,7 @@ function seedWorkflowThread(
       providerThreadId,
       itemId,
       itemKind: "commandExecution",
+      parentToolCallId: null,
       data: JSON.stringify({
         item: {
           type: "commandExecution",
@@ -257,6 +267,7 @@ function seedWorkflowThread(
       providerThreadId,
       itemId,
       itemKind: "commandExecution",
+      parentToolCallId: null,
       data: JSON.stringify({
         item: {
           type: "commandExecution",
@@ -278,6 +289,7 @@ function seedWorkflowThread(
       providerThreadId,
       itemId: WORKFLOW_TASK_ID,
       itemKind: "backgroundTask",
+      parentToolCallId: WORKFLOW_CALL_ID,
       data: workflowTaskData({ status: "pending", padding: SNAPSHOT_BYTES }),
     });
   }

--- a/packages/db/drizzle/0103_wandering_mongoose.sql
+++ b/packages/db/drizzle/0103_wandering_mongoose.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `events` ADD `parent_tool_call_id` text;--> statement-breakpoint
+UPDATE `events`
+SET `parent_tool_call_id` = COALESCE(
+  NULLIF(json_extract(`data`, '$.item.parentToolCallId'), ''),
+  NULLIF(json_extract(`data`, '$.parentToolCallId'), '')
+)
+WHERE instr(`data`, '"parentToolCallId"') > 0;--> statement-breakpoint
+CREATE INDEX `events_parent_tool_call_thread_parent_sequence_idx` ON `events` (`thread_id`,`parent_tool_call_id`,`sequence`) WHERE "events"."parent_tool_call_id" IS NOT NULL;

--- a/packages/db/drizzle/meta/0103_snapshot.json
+++ b/packages/db/drizzle/meta/0103_snapshot.json
@@ -1,0 +1,3712 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "67842c38-c4d3-43d1-ac01-87a19a58edd4",
+  "prevId": "151a7bac-dce9-47d7-99fd-3c96bac7f3bf",
+  "tables": {
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caffeinate": {
+          "name": "caffeinate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "show_keyboard_hints": {
+          "name": "show_keyboard_hints",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "steer_active_thread_on_enter": {
+          "name": "steer_active_thread_on_enter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "show_unhandled_provider_events": {
+          "name": "show_unhandled_provider_events",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "codex_memory_enabled": {
+          "name": "codex_memory_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "claude_code_memory_enabled": {
+          "name": "claude_code_memory_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "codex_subagents_disabled": {
+          "name": "codex_subagents_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "claude_code_subagents_disabled": {
+          "name": "claude_code_subagents_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "claude_code_workflows_disabled": {
+          "name": "claude_code_workflows_disabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "keybinding_overrides": {
+          "name": "keybinding_overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_settings_values": {
+      "name": "app_settings_values",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_theme": {
+      "name": "app_theme",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "theme_id": {
+          "name": "theme_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "favicon_color": {
+          "name": "favicon_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apikey": {
+      "name": "apikey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start": {
+          "name": "start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "referenceId": {
+          "name": "referenceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refillInterval": {
+          "name": "refillInterval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refillAmount": {
+          "name": "refillAmount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastRefillAt": {
+          "name": "lastRefillAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitEnabled": {
+          "name": "rateLimitEnabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitTimeWindow": {
+          "name": "rateLimitTimeWindow",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rateLimitMax": {
+          "name": "rateLimitMax",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requestCount": {
+          "name": "requestCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remaining": {
+          "name": "remaining",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lastRequest": {
+          "name": "lastRequest",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configId": {
+          "name": "configId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "apikey_key_unique": {
+          "name": "apikey_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "apikey_reference_id_idx": {
+          "name": "apikey_reference_id_idx",
+          "columns": [
+            "referenceId"
+          ],
+          "isUnique": false
+        },
+        "apikey_config_id_idx": {
+          "name": "apikey_config_id_idx",
+          "columns": [
+            "configId"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "apikey_referenceId_user_id_fk": {
+          "name": "apikey_referenceId_user_id_fk",
+          "tableFrom": "apikey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "referenceId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "environments": {
+      "name": "environments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "managed": {
+          "name": "managed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_git_repo": {
+          "name": "is_git_repo",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_worktree": {
+          "name": "is_worktree",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "branch_name": {
+          "name": "branch_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "base_branch": {
+          "name": "base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "merge_base_branch": {
+          "name": "merge_base_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "destroy_attempt_id": {
+          "name": "destroy_attempt_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retire_requested_at": {
+          "name": "retire_requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_provision_type": {
+          "name": "workspace_provision_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'provisioning'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "environments_project_host_path_idx": {
+          "name": "environments_project_host_path_idx",
+          "columns": [
+            "project_id",
+            "host_id",
+            "path"
+          ],
+          "isUnique": true
+        },
+        "environments_host_path_lookup_idx": {
+          "name": "environments_host_path_lookup_idx",
+          "columns": [
+            "host_id",
+            "path"
+          ],
+          "isUnique": false
+        },
+        "environments_project_idx": {
+          "name": "environments_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "environments_status_idx": {
+          "name": "environments_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "environments_project_id_projects_id_fk": {
+          "name": "environments_project_id_projects_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "environments_host_id_hosts_id_fk": {
+          "name": "environments_host_id_hosts_id_fk",
+          "tableFrom": "environments",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope_kind": {
+          "name": "scope_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sequence": {
+          "name": "sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_tool_call_id": {
+          "name": "parent_tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "data": {
+          "name": "data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "events_thread_sequence_idx": {
+          "name": "events_thread_sequence_idx",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": true
+        },
+        "events_tool_call_parent_lookup_idx": {
+          "name": "events_tool_call_parent_lookup_idx",
+          "columns": [
+            "thread_id",
+            "item_id",
+            "sequence"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"item_kind\" = 'toolCall'"
+        },
+        "events_parent_tool_call_thread_parent_sequence_idx": {
+          "name": "events_parent_tool_call_thread_parent_sequence_idx",
+          "columns": [
+            "thread_id",
+            "parent_tool_call_id",
+            "sequence"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"parent_tool_call_id\" IS NOT NULL"
+        },
+        "events_thread_type_item_kind_sequence_idx": {
+          "name": "events_thread_type_item_kind_sequence_idx",
+          "columns": [
+            "thread_id",
+            "type",
+            "item_kind",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_background_task_thread_type_item_sequence_idx": {
+          "name": "events_background_task_thread_type_item_sequence_idx",
+          "columns": [
+            "thread_id",
+            "type",
+            "item_id",
+            "sequence"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"item_kind\" = 'backgroundTask'"
+        },
+        "events_thread_type_sequence_idx": {
+          "name": "events_thread_type_sequence_idx",
+          "columns": [
+            "thread_id",
+            "type",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_thread_turn_type_item_sequence_idx": {
+          "name": "events_thread_turn_type_item_sequence_idx",
+          "columns": [
+            "thread_id",
+            "turn_id",
+            "type",
+            "item_id",
+            "sequence"
+          ],
+          "isUnique": false
+        },
+        "events_item_lifecycle_thread_item_sequence_idx": {
+          "name": "events_item_lifecycle_thread_item_sequence_idx",
+          "columns": [
+            "thread_id",
+            "item_id",
+            "sequence"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"type\" IN ('item/started', 'item/completed', 'item/backgroundTask/completed')"
+        },
+        "events_environment_idx": {
+          "name": "events_environment_idx",
+          "columns": [
+            "environment_id"
+          ],
+          "isUnique": false
+        },
+        "events_completed_item_truncation_idx": {
+          "name": "events_completed_item_truncation_idx",
+          "columns": [
+            "item_kind",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"type\" = 'item/completed'"
+        },
+        "events_goal_thread_sequence_idx": {
+          "name": "events_goal_thread_sequence_idx",
+          "columns": [
+            "thread_id",
+            "sequence"
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"type\" IN ('thread/goal/updated', 'thread/goal/cleared')"
+        }
+      },
+      "foreignKeys": {
+        "events_thread_id_threads_id_fk": {
+          "name": "events_thread_id_threads_id_fk",
+          "tableFrom": "events",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_environment_id_environments_id_fk": {
+          "name": "events_environment_id_environments_id_fk",
+          "tableFrom": "events",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "events_scope_shape_check": {
+          "name": "events_scope_shape_check",
+          "value": "(\n        (\"events\".\"scope_kind\" = 'turn' AND \"events\".\"turn_id\" IS NOT NULL)\n        OR\n        (\"events\".\"scope_kind\" = 'thread' AND \"events\".\"turn_id\" IS NULL)\n      )"
+        }
+      }
+    },
+    "host_daemon_sessions": {
+      "name": "host_daemon_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_name": {
+          "name": "host_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_type": {
+          "name": "host_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "data_dir": {
+          "name": "data_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "protocol_version": {
+          "name": "protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heartbeat_interval_ms": {
+          "name": "heartbeat_interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lease_timeout_ms": {
+          "name": "lease_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "host_daemon_sessions_host_status_idx": {
+          "name": "host_daemon_sessions_host_status_idx",
+          "columns": [
+            "host_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "host_daemon_sessions_host_latest_idx": {
+          "name": "host_daemon_sessions_host_latest_idx",
+          "columns": [
+            "host_id",
+            "updated_at",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "host_daemon_sessions_closed_prune_idx": {
+          "name": "host_daemon_sessions_closed_prune_idx",
+          "columns": [
+            "status",
+            "closed_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "host_daemon_sessions_host_id_hosts_id_fk": {
+          "name": "host_daemon_sessions_host_id_hosts_id_fk",
+          "tableFrom": "host_daemon_sessions",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hosts": {
+      "name": "hosts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "connect_machine_id": {
+          "name": "connect_machine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_permission_mode": {
+          "name": "max_permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'full'"
+        },
+        "destroyed_at": {
+          "name": "destroyed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_rejected_protocol_version": {
+          "name": "last_rejected_protocol_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "hosts_last_seen_idx": {
+          "name": "hosts_last_seen_idx",
+          "columns": [
+            "last_seen_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugins": {
+      "name": "plugins",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'direct'"
+        },
+        "catalog_entry_id": {
+          "name": "catalog_entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "catalog_marketplace_name": {
+          "name": "catalog_marketplace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'path'"
+        },
+        "source_path": {
+          "name": "source_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_builtin_name": {
+          "name": "source_builtin_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_npm_package": {
+          "name": "source_npm_package",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_npm_registry": {
+          "name": "source_npm_registry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_npm_requested_spec": {
+          "name": "source_npm_requested_spec",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_npm_spec_kind": {
+          "name": "source_npm_spec_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_url": {
+          "name": "source_git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_subdirectory": {
+          "name": "source_git_subdirectory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_requested_ref": {
+          "name": "source_git_requested_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_ref_kind": {
+          "name": "source_git_ref_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_range": {
+          "name": "source_git_range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_tag_prefix": {
+          "name": "source_git_tag_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_resolved_tag": {
+          "name": "source_git_resolved_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "npm_resolved_version": {
+          "name": "npm_resolved_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "npm_integrity": {
+          "name": "npm_integrity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_resolved_commit": {
+          "name": "git_resolved_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_update_check_at": {
+          "name": "last_update_check_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "available_compatible_version": {
+          "name": "available_compatible_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "newest_incompatible_version": {
+          "name": "newest_incompatible_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "update_status_detail": {
+          "name": "update_status_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_failure_version": {
+          "name": "last_failure_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_failure_at": {
+          "name": "last_failure_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_failure_detail": {
+          "name": "last_failure_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_artifact_id": {
+          "name": "active_artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "normalization_version": {
+          "name": "normalization_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "root_dir": {
+          "name": "root_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "removed_at": {
+          "name": "removed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "plugins_active_artifact_id_plugin_artifacts_id_fk": {
+          "name": "plugins_active_artifact_id_plugin_artifacts_id_fk",
+          "tableFrom": "plugins",
+          "tableTo": "plugin_artifacts",
+          "columnsFrom": [
+            "active_artifact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "maintenance_scan_cursors": {
+      "name": "maintenance_scan_cursors",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_kind": {
+          "name": "item_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "output_path": {
+          "name": "output_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_created_at": {
+          "name": "last_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "maintenance_scan_cursors_path_idx": {
+          "name": "maintenance_scan_cursors_path_idx",
+          "columns": [
+            "policy",
+            "version",
+            "item_kind",
+            "output_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pending_interactions": {
+      "name": "pending_interactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'provider'"
+        },
+        "turn_id": {
+          "name": "turn_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_thread_id": {
+          "name": "provider_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_request_id": {
+          "name": "provider_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "renderer_id": {
+          "name": "renderer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_reason": {
+          "name": "status_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pending_interactions_provider_request_idx": {
+          "name": "pending_interactions_provider_request_idx",
+          "columns": [
+            "provider_id",
+            "provider_thread_id",
+            "provider_request_id"
+          ],
+          "isUnique": true
+        },
+        "pending_interactions_thread_created_idx": {
+          "name": "pending_interactions_thread_created_idx",
+          "columns": [
+            "thread_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pending_interactions_thread_status_created_idx": {
+          "name": "pending_interactions_thread_status_created_idx",
+          "columns": [
+            "thread_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pending_interactions_status_created_idx": {
+          "name": "pending_interactions_status_created_idx",
+          "columns": [
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "pending_interactions_plugin_status_created_idx": {
+          "name": "pending_interactions_plugin_status_created_idx",
+          "columns": [
+            "plugin_id",
+            "status",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pending_interactions_thread_id_threads_id_fk": {
+          "name": "pending_interactions_thread_id_threads_id_fk",
+          "tableFrom": "pending_interactions",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_artifacts": {
+      "name": "plugin_artifacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "npm_resolved_version": {
+          "name": "npm_resolved_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_resolved_commit": {
+          "name": "git_resolved_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "git_checkout_root": {
+          "name": "git_checkout_root",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_result": {
+          "name": "validation_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_artifacts_plugin_idx": {
+          "name": "plugin_artifacts_plugin_idx",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_kv": {
+      "name": "plugin_kv",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_kv_plugin_id_key_pk": {
+          "columns": [
+            "plugin_id",
+            "key"
+          ],
+          "name": "plugin_kv_plugin_id_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_marketplace_icons": {
+      "name": "plugin_marketplace_icons",
+      "columns": {
+        "marketplace_name": {
+          "name": "marketplace_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_marketplace_icons_marketplace_name_entry_id_pk": {
+          "columns": [
+            "marketplace_name",
+            "entry_id"
+          ],
+          "name": "plugin_marketplace_icons_marketplace_name_entry_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_marketplaces": {
+      "name": "plugin_marketplaces",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'https'"
+        },
+        "manifest_url": {
+          "name": "manifest_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_git_ref": {
+          "name": "source_git_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_git_commit": {
+          "name": "source_git_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "manifest_json": {
+          "name": "manifest_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_modified": {
+          "name": "last_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_successful_refresh_at": {
+          "name": "last_successful_refresh_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_attempted_refresh_at": {
+          "name": "last_attempted_refresh_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_schedules": {
+      "name": "plugin_schedules",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cron": {
+          "name": "cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_schedules_plugin_id_name_pk": {
+          "columns": [
+            "plugin_id",
+            "name"
+          ],
+          "name": "plugin_schedules_plugin_id_name_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_settings": {
+      "name": "plugin_settings",
+      "columns": {
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plugin_settings_plugin_id_key_pk": {
+          "columns": [
+            "plugin_id",
+            "key"
+          ],
+          "name": "plugin_settings_plugin_id_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_state_snapshots": {
+      "name": "plugin_state_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plugin_id": {
+          "name": "plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "from_artifact_id": {
+          "name": "from_artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "to_artifact_id": {
+          "name": "to_artifact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot_path": {
+          "name": "snapshot_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "database_path": {
+          "name": "database_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_path": {
+          "name": "state_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secrets_path": {
+          "name": "secrets_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "registration_path": {
+          "name": "registration_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rollback_candidate_version": {
+          "name": "rollback_candidate_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_source_fingerprint": {
+          "name": "rollback_source_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_bb_version": {
+          "name": "rollback_bb_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_sdk_version": {
+          "name": "rollback_sdk_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rollback_detail": {
+          "name": "rollback_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retained_until": {
+          "name": "retained_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plugin_state_snapshots_plugin_idx": {
+          "name": "plugin_state_snapshots_plugin_idx",
+          "columns": [
+            "plugin_id"
+          ],
+          "isUnique": false
+        },
+        "plugin_state_snapshots_retention_idx": {
+          "name": "plugin_state_snapshots_retention_idx",
+          "columns": [
+            "retained_until"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_execution_defaults": {
+      "name": "project_execution_defaults",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_execution_defaults_project_idx": {
+          "name": "project_execution_defaults_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_execution_defaults_project_id_projects_id_fk": {
+          "name": "project_execution_defaults_project_id_projects_id_fk",
+          "tableFrom": "project_execution_defaults",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_sources": {
+      "name": "project_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "project_sources_project_idx": {
+          "name": "project_sources_project_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "project_sources_host_idx": {
+          "name": "project_sources_host_idx",
+          "columns": [
+            "host_id"
+          ],
+          "isUnique": false
+        },
+        "project_sources_project_host_idx": {
+          "name": "project_sources_project_host_idx",
+          "columns": [
+            "project_id",
+            "host_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_sources_project_id_projects_id_fk": {
+          "name": "project_sources_project_id_projects_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_sources_host_id_hosts_id_fk": {
+          "name": "project_sources_host_id_hosts_id_fk",
+          "tableFrom": "project_sources",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "project_sources_shape_check": {
+          "name": "project_sources_shape_check",
+          "value": "(\n        \"project_sources\".\"type\" = 'local_path' AND \"project_sources\".\"host_id\" IS NOT NULL AND \"project_sources\".\"path\" IS NOT NULL\n      )"
+        }
+      }
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'standard'"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "git_remote_url": {
+          "name": "git_remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_key": {
+          "name": "sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'V'"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_updated_idx": {
+          "name": "projects_updated_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "projects_deleted_idx": {
+          "name": "projects_deleted_idx",
+          "columns": [
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "projects_sort_idx": {
+          "name": "projects_sort_idx",
+          "columns": [
+            "sort_key",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "projects_personal_singleton_idx": {
+          "name": "projects_personal_singleton_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": true,
+          "where": "\"projects\".\"kind\" = 'personal'"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "prompt_history_entries": {
+      "name": "prompt_history_entries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "request_sequence": {
+          "name": "request_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input": {
+          "name": "input",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "prompt_history_entries_thread_request_idx": {
+          "name": "prompt_history_entries_thread_request_idx",
+          "columns": [
+            "thread_id",
+            "request_sequence"
+          ],
+          "isUnique": true
+        },
+        "prompt_history_entries_project_scope_created_idx": {
+          "name": "prompt_history_entries_project_scope_created_idx",
+          "columns": [
+            "project_id",
+            "scope",
+            "created_at",
+            "request_sequence",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "prompt_history_entries_thread_scope_created_idx": {
+          "name": "prompt_history_entries_thread_scope_created_idx",
+          "columns": [
+            "thread_id",
+            "scope",
+            "created_at",
+            "request_sequence",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "prompt_history_entries_project_id_projects_id_fk": {
+          "name": "prompt_history_entries_project_id_projects_id_fk",
+          "tableFrom": "prompt_history_entries",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "prompt_history_entries_thread_id_threads_id_fk": {
+          "name": "prompt_history_entries_thread_id_threads_id_fk",
+          "tableFrom": "prompt_history_entries",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queued_thread_messages": {
+      "name": "queued_thread_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender_thread_id": {
+          "name": "sender_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_level": {
+          "name": "reasoning_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_with_next": {
+          "name": "group_with_next",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_key": {
+          "name": "sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "queued_thread_messages_thread_created_idx": {
+          "name": "queued_thread_messages_thread_created_idx",
+          "columns": [
+            "thread_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "queued_thread_messages_thread_sort_idx": {
+          "name": "queued_thread_messages_thread_sort_idx",
+          "columns": [
+            "thread_id",
+            "sort_key",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "queued_thread_messages_thread_id_threads_id_fk": {
+          "name": "queued_thread_messages_thread_id_threads_id_fk",
+          "tableFrom": "queued_thread_messages",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "system_experiments": {
+      "name": "system_experiments",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terminal_sessions": {
+      "name": "terminal_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "daemon_session_id": {
+          "name": "daemon_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "initial_cwd": {
+          "name": "initial_cwd",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cols": {
+          "name": "cols",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rows": {
+          "name": "rows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_user_input_at": {
+          "name": "last_user_input_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "terminal_sessions_thread_status_updated_idx": {
+          "name": "terminal_sessions_thread_status_updated_idx",
+          "columns": [
+            "thread_id",
+            "status",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_environment_status_idx": {
+          "name": "terminal_sessions_environment_status_idx",
+          "columns": [
+            "environment_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_host_status_idx": {
+          "name": "terminal_sessions_host_status_idx",
+          "columns": [
+            "host_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "terminal_sessions_daemon_session_idx": {
+          "name": "terminal_sessions_daemon_session_idx",
+          "columns": [
+            "daemon_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminal_sessions_thread_id_threads_id_fk": {
+          "name": "terminal_sessions_thread_id_threads_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_environment_id_environments_id_fk": {
+          "name": "terminal_sessions_environment_id_environments_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_host_id_hosts_id_fk": {
+          "name": "terminal_sessions_host_id_hosts_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "hosts",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminal_sessions_daemon_session_id_host_daemon_sessions_id_fk": {
+          "name": "terminal_sessions_daemon_session_id_host_daemon_sessions_id_fk",
+          "tableFrom": "terminal_sessions",
+          "tableTo": "host_daemon_sessions",
+          "columnsFrom": [
+            "daemon_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_dynamic_context_file_states": {
+      "name": "thread_dynamic_context_file_states",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_status": {
+          "name": "content_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shown_at": {
+          "name": "shown_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "thread_dynamic_context_file_states_thread_file_idx": {
+          "name": "thread_dynamic_context_file_states_thread_file_idx",
+          "columns": [
+            "thread_id",
+            "file_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "thread_dynamic_context_file_states_thread_id_threads_id_fk": {
+          "name": "thread_dynamic_context_file_states_thread_id_threads_id_fk",
+          "tableFrom": "thread_dynamic_context_file_states",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_search_segments": {
+      "name": "thread_search_segments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_seq": {
+          "name": "source_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "thread_search_segments_source_idx": {
+          "name": "thread_search_segments_source_idx",
+          "columns": [
+            "thread_id",
+            "source_kind",
+            "source_key"
+          ],
+          "isUnique": true
+        },
+        "thread_search_segments_thread_source_seq_idx": {
+          "name": "thread_search_segments_thread_source_seq_idx",
+          "columns": [
+            "thread_id",
+            "source_seq"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "thread_search_segments_thread_id_threads_id_fk": {
+          "name": "thread_search_segments_thread_id_threads_id_fk",
+          "tableFrom": "thread_search_segments",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_sections": {
+      "name": "thread_sections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "thread_sections_name_idx": {
+          "name": "thread_sections_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "thread_tabs": {
+      "name": "thread_tabs",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tabs_json": {
+          "name": "tabs_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "thread_tabs_thread_id_threads_id_fk": {
+          "name": "thread_tabs_thread_id_threads_id_fk",
+          "tableFrom": "thread_tabs",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "threads": {
+      "name": "threads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment_id": {
+          "name": "environment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_override": {
+          "name": "model_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_level_override": {
+          "name": "reasoning_level_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title_fallback": {
+          "name": "title_fallback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'starting'"
+        },
+        "parent_thread_id": {
+          "name": "parent_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_thread_id": {
+          "name": "source_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_plugin_id": {
+          "name": "origin_plugin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'visible'"
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pin_sort_key": {
+          "name": "pin_sort_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "latest_attention_at": {
+          "name": "latest_attention_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "threads_project_updated_idx": {
+          "name": "threads_project_updated_idx",
+          "columns": [
+            "project_id",
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "threads_project_archived_deleted_idx": {
+          "name": "threads_project_archived_deleted_idx",
+          "columns": [
+            "project_id",
+            "archived_at",
+            "deleted_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "threads_pin_sort_idx": {
+          "name": "threads_pin_sort_idx",
+          "columns": [
+            "archived_at",
+            "deleted_at",
+            "pin_sort_key",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "\"threads\".\"pinned_at\" IS NOT NULL"
+        },
+        "threads_environment_idx": {
+          "name": "threads_environment_idx",
+          "columns": [
+            "environment_id"
+          ],
+          "isUnique": false
+        },
+        "threads_parent_idx": {
+          "name": "threads_parent_idx",
+          "columns": [
+            "parent_thread_id"
+          ],
+          "isUnique": false
+        },
+        "threads_source_origin_idx": {
+          "name": "threads_source_origin_idx",
+          "columns": [
+            "source_thread_id",
+            "origin_kind"
+          ],
+          "isUnique": false
+        },
+        "threads_origin_plugin_archived_idx": {
+          "name": "threads_origin_plugin_archived_idx",
+          "columns": [
+            "origin_plugin_id",
+            "archived_at"
+          ],
+          "isUnique": false
+        },
+        "threads_section_archived_deleted_idx": {
+          "name": "threads_section_archived_deleted_idx",
+          "columns": [
+            "section_id",
+            "archived_at",
+            "deleted_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "threads_archived_status_idx": {
+          "name": "threads_archived_status_idx",
+          "columns": [
+            "archived_at",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "threads_environment_archived_deleted_idx": {
+          "name": "threads_environment_archived_deleted_idx",
+          "columns": [
+            "environment_id",
+            "archived_at",
+            "deleted_at"
+          ],
+          "isUnique": false
+        },
+        "threads_active_maintenance_idx": {
+          "name": "threads_active_maintenance_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false,
+          "where": "\"threads\".\"deleted_at\" IS NULL"
+        }
+      },
+      "foreignKeys": {
+        "threads_project_id_projects_id_fk": {
+          "name": "threads_project_id_projects_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "threads_environment_id_environments_id_fk": {
+          "name": "threads_environment_id_environments_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "environments",
+          "columnsFrom": [
+            "environment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "threads_section_id_thread_sections_id_fk": {
+          "name": "threads_section_id_thread_sections_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "thread_sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "threads_parent_thread_id_threads_id_fk": {
+          "name": "threads_parent_thread_id_threads_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "parent_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "threads_source_thread_id_threads_id_fk": {
+          "name": "threads_source_thread_id_threads_id_fk",
+          "tableFrom": "threads",
+          "tableTo": "threads",
+          "columnsFrom": [
+            "source_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -722,6 +722,13 @@
       "when": 1787163393338,
       "tag": "0102_app_settings_key_value",
       "breakpoints": true
+    },
+    {
+      "idx": 103,
+      "version": "6",
+      "when": 1787181956957,
+      "tag": "0103_wandering_mongoose",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -103,14 +103,14 @@ function queryInSqliteVariableBatches<TValue, TRow>(
   return rows;
 }
 
-const isRootTurnStartedEventData = sql`COALESCE(json_extract(${events.data}, '$.parentToolCallId'), '') = ''`;
+const isRootTurnStartedEventData = isNull(events.parentToolCallId);
 const isNotNestedTurnUsageEvent = sql`NOT EXISTS (
   SELECT 1
   FROM events AS nested_turn_started
   WHERE nested_turn_started.thread_id = ${events.threadId}
     AND nested_turn_started.turn_id = ${events.turnId}
     AND nested_turn_started.type = 'turn/started'
-    AND COALESCE(json_extract(nested_turn_started.data, '$.parentToolCallId'), '') <> ''
+    AND nested_turn_started.parent_tool_call_id IS NOT NULL
 )`;
 
 /**
@@ -144,6 +144,7 @@ export interface InsertEventInput {
   type: ThreadEventType;
   itemId: string | null;
   itemKind: ThreadEventItemType | null;
+  parentToolCallId: string | null;
   createdAt?: number;
   data: string;
 }
@@ -158,6 +159,7 @@ export interface AppendDaemonEventInput {
   environmentId: string | null;
   itemId: string | null;
   itemKind: ThreadEventItemType | null;
+  parentToolCallId: string | null;
   providerThreadId: string | null;
   scope: ThreadEventScope;
   threadId: string;
@@ -407,8 +409,8 @@ export function insertEvents(
     const createdAt = input.createdAt ?? Date.now();
     const turnId = getThreadEventScopeTurnId(input.scope) ?? null;
     const result = db.run(
-      sql`INSERT OR IGNORE INTO events (id, thread_id, environment_id, scope_kind, turn_id, provider_thread_id, sequence, type, item_id, item_kind, data, created_at)
-          VALUES (${id}, ${input.threadId}, ${input.environmentId ?? null}, ${input.scope.kind}, ${turnId}, ${input.providerThreadId ?? null}, ${input.sequence}, ${input.type}, ${input.itemId}, ${input.itemKind}, ${input.data}, ${createdAt})`,
+      sql`INSERT OR IGNORE INTO events (id, thread_id, environment_id, scope_kind, turn_id, provider_thread_id, sequence, type, item_id, item_kind, parent_tool_call_id, data, created_at)
+          VALUES (${id}, ${input.threadId}, ${input.environmentId ?? null}, ${input.scope.kind}, ${turnId}, ${input.providerThreadId ?? null}, ${input.sequence}, ${input.type}, ${input.itemId}, ${input.itemKind}, ${input.parentToolCallId}, ${input.data}, ${createdAt})`,
     );
     if (result.changes > 0) {
       insertedCount++;
@@ -735,7 +737,7 @@ export function appendDaemonEventsInTransaction(
     }
     db.run(
       sql`INSERT INTO events
-        (id, thread_id, environment_id, scope_kind, turn_id, provider_thread_id, sequence, type, item_id, item_kind, data, created_at)
+        (id, thread_id, environment_id, scope_kind, turn_id, provider_thread_id, sequence, type, item_id, item_kind, parent_tool_call_id, data, created_at)
         VALUES (
           ${createEventId()},
           ${input.threadId},
@@ -747,6 +749,7 @@ export function appendDaemonEventsInTransaction(
           ${input.type},
           ${input.itemId},
           ${input.itemKind},
+          ${input.parentToolCallId},
           ${input.data},
           ${now}
         )`,
@@ -829,12 +832,16 @@ export function appendStoredThreadEventsInTransaction(
       type: args.type,
       item: "item" in args.data ? args.data.item : undefined,
       itemId: "itemId" in args.data ? args.data.itemId : undefined,
+      parentToolCallId:
+        "parentToolCallId" in args.data
+          ? args.data.parentToolCallId
+          : undefined,
     });
     const turnId = getThreadEventScopeTurnId(args.scope) ?? null;
 
     db.run(
       sql`INSERT INTO events
-        (id, thread_id, environment_id, scope_kind, turn_id, provider_thread_id, sequence, type, item_id, item_kind, data, created_at)
+        (id, thread_id, environment_id, scope_kind, turn_id, provider_thread_id, sequence, type, item_id, item_kind, parent_tool_call_id, data, created_at)
         VALUES (
           ${createEventId()},
           ${args.threadId},
@@ -846,6 +853,7 @@ export function appendStoredThreadEventsInTransaction(
           ${args.type},
           ${itemFields.itemId},
           ${itemFields.itemKind},
+          ${itemFields.parentToolCallId},
           ${JSON.stringify(args.data)},
           ${now}
         )`,
@@ -941,6 +949,7 @@ const storedEventRowFields = {
   id: events.id,
   itemId: events.itemId,
   itemKind: events.itemKind,
+  parentToolCallId: events.parentToolCallId,
   providerThreadId: events.providerThreadId,
   scopeKind: events.scopeKind,
   sequence: events.sequence,
@@ -1534,19 +1543,10 @@ function storedEventRowsByParentToolCallIdsConditions(
     return null;
   }
 
-  const eventParentToolCallId = sql<string>`json_extract(${events.data}, '$.parentToolCallId')`;
-  const itemParentToolCallId = sql<string>`json_extract(${events.data}, '$.item.parentToolCallId')`;
-  // The snapshot check goes before the JSON parent tests: it is a type
-  // comparison for most rows and an indexed probe for progress rows, while
-  // each `json_extract` parses the whole payload — hundreds of KB for a
-  // workflow snapshot. SQLite evaluates these terms in order.
   const conditions: SQL[] = [
     eq(events.threadId, args.threadId),
     isNotSupersededBackgroundTaskProgress,
-    or(
-      inArray(eventParentToolCallId, parentToolCallIds),
-      inArray(itemParentToolCallId, parentToolCallIds),
-    )!,
+    inArray(events.parentToolCallId, parentToolCallIds),
   ];
   if (args.excludedTypes && args.excludedTypes.length > 0) {
     conditions.push(notInArray(events.type, [...args.excludedTypes]));
@@ -2706,10 +2706,6 @@ export function hasParentedEventCrossingSequence(
   db: DbConnection,
   args: TimelineTurnBoundaryLookupArgs,
 ): boolean {
-  const parentToolCallId = sql<string | null>`COALESCE(
-    NULLIF(json_extract(${events.data}, '$.item.parentToolCallId'), ''),
-    NULLIF(json_extract(${events.data}, '$.parentToolCallId'), '')
-  )`;
   const row = db
     .select({ sequence: events.sequence })
     .from(events)
@@ -2717,12 +2713,12 @@ export function hasParentedEventCrossingSequence(
       and(
         eq(events.threadId, args.threadId),
         gte(events.sequence, args.sequence),
-        sql`${parentToolCallId} IS NOT NULL`,
+        isNotNull(events.parentToolCallId),
         sql`EXISTS (
           SELECT 1
           FROM events AS parent_event
           WHERE parent_event.thread_id = ${events.threadId}
-            AND parent_event.item_id = ${parentToolCallId}
+            AND parent_event.item_id = ${events.parentToolCallId}
             AND parent_event.item_kind = 'toolCall'
             AND parent_event.sequence < ${args.sequence}
         )`,

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -2910,6 +2910,21 @@ export function findStoredTimelineWindowByteBudgetFloor(
   db: DbConnection,
   args: FindStoredTimelineWindowByteBudgetFloorArgs,
 ): StoredTimelineWindowByteBudgetFloor {
+  // The common case is a window that fits. Let SQLite total it and return one
+  // scalar instead of crossing the native boundary once per event merely to
+  // rediscover that no floor is needed. Oversized windows still take the
+  // ordered iterator below so they retain the exact cutoff/placeholder rules.
+  const windowDataBytes = getStoredTimelineWindowEventDataBytes(db, {
+    beforeSequence: args.beforeSequence,
+    excludedTypes: args.excludedTypes,
+    maxInlineOutputChars: args.maxInlineOutputChars,
+    sequenceStart: args.sequenceStart,
+    threadId: args.threadId,
+  });
+  if (windowDataBytes <= args.maxDataBytes) {
+    return { eventDataBytes: windowDataBytes, kind: "fits" };
+  }
+
   const data = storedTimelineWindowDataColumn(args.maxInlineOutputChars);
   const query = db
     .select({

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -737,6 +737,7 @@ export const events = sqliteTable(
     type: text("type").$type<ThreadEventType>().notNull(),
     itemId: text("item_id"),
     itemKind: text("item_kind").$type<ThreadEventItemType>(),
+    parentToolCallId: text("parent_tool_call_id"),
     data: text("data").notNull().default("{}"),
     createdAt: integer("created_at").notNull(),
   },
@@ -752,6 +753,9 @@ export const events = sqliteTable(
     index("events_tool_call_parent_lookup_idx")
       .on(table.threadId, table.itemId, table.sequence)
       .where(sql`${table.itemKind} = 'toolCall'`),
+    index("events_parent_tool_call_thread_parent_sequence_idx")
+      .on(table.threadId, table.parentToolCallId, table.sequence)
+      .where(sql`${table.parentToolCallId} IS NOT NULL`),
     index("events_thread_type_item_kind_sequence_idx").on(
       table.threadId,
       table.type,

--- a/packages/db/src/stored-event-item-fields.ts
+++ b/packages/db/src/stored-event-item-fields.ts
@@ -7,27 +7,32 @@ import type {
 export interface StoredEventItemFields {
   itemId: string | null;
   itemKind: ThreadEventItemType | null;
+  parentToolCallId: string | null;
 }
 
 interface StoredEventItemIdentity {
   id: string;
+  parentToolCallId?: string;
   type: ThreadEventItemType;
 }
 
 export interface StoredEventItemFieldSource {
   item?: StoredEventItemIdentity;
   itemId?: string;
+  parentToolCallId?: string;
   type: ThreadEventType;
 }
 
-function fromItem(args: StoredEventItemIdentity): StoredEventItemFields {
+type StoredEventOwnItemFields = Omit<StoredEventItemFields, "parentToolCallId">;
+
+function fromItem(args: StoredEventItemIdentity): StoredEventOwnItemFields {
   return {
     itemId: args.id,
     itemKind: args.type,
   };
 }
 
-function fromItemId(itemId: string | undefined): StoredEventItemFields {
+function fromItemId(itemId: string | undefined): StoredEventOwnItemFields {
   return {
     itemId: itemId ?? null,
     itemKind: null,
@@ -37,30 +42,41 @@ function fromItemId(itemId: string | undefined): StoredEventItemFields {
 export function deriveStoredEventItemFieldsFromSource(
   source: StoredEventItemFieldSource,
 ): StoredEventItemFields {
-  switch (source.type) {
-    case "item/started":
-    case "item/completed":
-    case "item/backgroundTask/progress":
-    case "item/backgroundTask/completed":
-      if (!source.item) {
-        throw new Error(`Missing item payload for ${source.type}`);
-      }
-      return fromItem(source.item);
-    case "item/agentMessage/delta":
-    case "item/commandExecution/outputDelta":
-    case "item/fileChange/outputDelta":
-    case "item/reasoning/summaryTextDelta":
-    case "item/reasoning/textDelta":
-    case "item/plan/delta":
-    case "item/mcpToolCall/progress":
-    case "item/toolCall/progress":
-      return fromItemId(source.itemId);
-    default:
-      return {
-        itemId: null,
-        itemKind: null,
-      };
-  }
+  const ownItemFields: StoredEventOwnItemFields = (() => {
+    switch (source.type) {
+      case "item/started":
+      case "item/completed":
+      case "item/backgroundTask/progress":
+      case "item/backgroundTask/completed":
+        if (!source.item) {
+          throw new Error(`Missing item payload for ${source.type}`);
+        }
+        return fromItem(source.item);
+      case "item/agentMessage/delta":
+      case "item/commandExecution/outputDelta":
+      case "item/fileChange/outputDelta":
+      case "item/reasoning/summaryTextDelta":
+      case "item/reasoning/textDelta":
+      case "item/plan/delta":
+      case "item/mcpToolCall/progress":
+      case "item/toolCall/progress":
+        return fromItemId(source.itemId);
+      default:
+        return {
+          itemId: null,
+          itemKind: null,
+        };
+    }
+  })();
+  const parentToolCallId =
+    source.item?.parentToolCallId ?? source.parentToolCallId;
+  return {
+    ...ownItemFields,
+    parentToolCallId:
+      parentToolCallId !== undefined && parentToolCallId.length > 0
+        ? parentToolCallId
+        : null,
+  };
 }
 
 export function deriveStoredEventItemFields(
@@ -70,5 +86,7 @@ export function deriveStoredEventItemFields(
     type: event.type,
     item: "item" in event ? event.item : undefined,
     itemId: "itemId" in event ? event.itemId : undefined,
+    parentToolCallId:
+      "parentToolCallId" in event ? event.parentToolCallId : undefined,
   });
 }

--- a/packages/db/test/data/events.test.ts
+++ b/packages/db/test/data/events.test.ts
@@ -86,6 +86,7 @@ function setup() {
 const emptyItemFields = {
   itemId: null,
   itemKind: null,
+  parentToolCallId: null,
 } as const;
 
 const threadEventFields = {
@@ -218,6 +219,7 @@ describe("events", () => {
         scope: turnScope("turn-1"),
         itemId: "msg-1",
         itemKind: "agentMessage",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: {
             id: "msg-1",
@@ -233,6 +235,7 @@ describe("events", () => {
     expect(all[0]).toMatchObject({
       itemId: "msg-1",
       itemKind: "agentMessage",
+      parentToolCallId: null,
     });
   });
 
@@ -386,6 +389,7 @@ describe("events", () => {
         scope: turnScope(turnId),
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         providerThreadId: "provider-thread-denied-approval",
         data: JSON.stringify({
           providerThreadId: "provider-thread-denied-approval",
@@ -398,6 +402,7 @@ describe("events", () => {
         scope: turnScope(turnId),
         itemId,
         itemKind: "commandExecution",
+        parentToolCallId: null,
         providerThreadId: "provider-thread-denied-approval",
         data: JSON.stringify({
           providerThreadId: "provider-thread-denied-approval",
@@ -417,6 +422,7 @@ describe("events", () => {
         scope: turnScope(turnId),
         itemId,
         itemKind: "commandExecution",
+        parentToolCallId: null,
         providerThreadId: "provider-thread-denied-approval",
         data: JSON.stringify({
           providerThreadId: "provider-thread-denied-approval",
@@ -442,6 +448,7 @@ describe("events", () => {
             scope: turnScope(turnId),
             itemId,
             itemKind: "commandExecution",
+            parentToolCallId: null,
             providerThreadId: "provider-thread-denied-approval",
             data: JSON.stringify({
               providerThreadId: "provider-thread-denied-approval",
@@ -462,6 +469,7 @@ describe("events", () => {
             scope: turnScope(turnId),
             itemId,
             itemKind: "commandExecution",
+            parentToolCallId: null,
             providerThreadId: "provider-thread-after-restart",
             data: JSON.stringify({
               providerThreadId: "provider-thread-after-restart",
@@ -481,6 +489,7 @@ describe("events", () => {
             scope: turnScope(turnId),
             itemId,
             itemKind: "commandExecution",
+            parentToolCallId: null,
             providerThreadId: "provider-thread-after-restart",
             data: JSON.stringify({
               providerThreadId: "provider-thread-after-restart",
@@ -556,6 +565,7 @@ describe("events", () => {
         scope: turnScope(turnId),
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         providerThreadId,
         data: JSON.stringify({ providerThreadId }),
       },
@@ -566,6 +576,7 @@ describe("events", () => {
         scope: turnScope(turnId),
         itemId,
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         providerThreadId,
         data: JSON.stringify({ providerThreadId, item: backgroundItem }),
       },
@@ -576,6 +587,7 @@ describe("events", () => {
         scope: threadScope(),
         itemId,
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         providerThreadId,
         data: JSON.stringify({
           providerThreadId,
@@ -594,6 +606,7 @@ describe("events", () => {
             scope: threadScope(),
             itemId,
             itemKind: "backgroundTask",
+            parentToolCallId: null,
             providerThreadId,
             data: JSON.stringify({
               providerThreadId,
@@ -607,6 +620,7 @@ describe("events", () => {
             scope: turnScope(turnId),
             itemId,
             itemKind: "backgroundTask",
+            parentToolCallId: null,
             providerThreadId,
             data: JSON.stringify({ providerThreadId, item: backgroundItem }),
           },
@@ -617,6 +631,7 @@ describe("events", () => {
             scope: threadScope(),
             itemId,
             itemKind: "backgroundTask",
+            parentToolCallId: null,
             providerThreadId,
             data: JSON.stringify({
               providerThreadId,
@@ -1028,6 +1043,7 @@ describe("events", () => {
         scope: turnScope("turn-1"),
         itemId: "msg_1",
         itemKind: "agentMessage",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: { id: "msg_1", type: "agentMessage", text: "assistant output" },
         }),
@@ -1039,6 +1055,7 @@ describe("events", () => {
         scope: turnScope("turn-1"),
         itemId: "call_1",
         itemKind: "toolCall",
+        parentToolCallId: null,
         data: JSON.stringify({ item: { id: "call_1", type: "toolCall" } }),
       },
       {
@@ -1055,6 +1072,7 @@ describe("events", () => {
     ).toMatchObject({
       sequence: 2,
       itemKind: "agentMessage",
+      parentToolCallId: null,
       type: "item/completed",
     });
   });
@@ -1077,6 +1095,7 @@ describe("events", () => {
         scope: turnScope("turn-1"),
         itemId: "msg_1",
         itemKind: "agentMessage",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: { id: "msg_1", type: "agentMessage", text: "" },
         }),
@@ -1173,6 +1192,7 @@ describe("events", () => {
         sequence: 3,
         type: "turn/started",
         ...createTurnEventFields({ turnId: "turn-subagent" }),
+        parentToolCallId: "call-subagent",
         data: JSON.stringify({ parentToolCallId: "call-subagent" }),
       },
       {
@@ -1485,6 +1505,7 @@ describe("events", () => {
       type: "item/backgroundTask/progress" as const,
       itemId,
       itemKind: "backgroundTask" as const,
+      parentToolCallId: null,
       data: taskData(itemId, "pending"),
     });
 
@@ -1496,6 +1517,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:wf-1",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData("task:wf-1", "pending"),
       },
       {
@@ -1505,6 +1527,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:wf-2",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData("task:wf-2", "pending"),
       },
       // wf-1: 3 and 4 are superseded by 6; wf-2: 5 is superseded by the
@@ -1520,6 +1543,7 @@ describe("events", () => {
         type: "item/backgroundTask/completed",
         itemId: "task:wf-2",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData("task:wf-2", "completed"),
       },
     ]);
@@ -2310,6 +2334,7 @@ describe("events", () => {
         type: "turn/completed",
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({
           providerThreadId: "provider_a",
           turnId: "turn_a",
@@ -2323,6 +2348,7 @@ describe("events", () => {
         type: "turn/completed",
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({
           providerThreadId: "provider_b",
           turnId: "turn_b",
@@ -2363,6 +2389,7 @@ describe("events", () => {
         type: "turn/started",
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({
           providerThreadId: "provider_active",
           turnId: "turn_active",
@@ -2376,6 +2403,7 @@ describe("events", () => {
         type: "turn/started",
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({
           providerThreadId: "provider_done",
           turnId: "turn_done",
@@ -2389,6 +2417,7 @@ describe("events", () => {
         type: "turn/completed",
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({
           providerThreadId: "provider_done",
           turnId: "turn_done",
@@ -2403,6 +2432,7 @@ describe("events", () => {
         type: "turn/started",
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({
           providerThreadId: null,
           turnId: "turn_no_provider",
@@ -2455,6 +2485,7 @@ describe("events", () => {
         type: "turn/started",
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({
           providerThreadId: "provider_thr_1",
           turnId: "root_turn",
@@ -2468,6 +2499,7 @@ describe("events", () => {
         type: "turn/started",
         itemId: null,
         itemKind: null,
+        parentToolCallId: "delegation-1",
         data: JSON.stringify({
           providerThreadId: "provider_thr_1",
           turnId: "child_turn",
@@ -2749,6 +2781,7 @@ describe("events", () => {
         sequence: 3,
         type: "turn/started",
         ...createTurnEventFields({ turnId: "turn-subagent" }),
+        parentToolCallId: "call-subagent",
         data: JSON.stringify({ parentToolCallId: "call-subagent" }),
       },
       {
@@ -2842,6 +2875,7 @@ describe("events", () => {
         type: "item/agentMessage/delta",
         itemId: "msg-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "msg-1", delta: "Hel" }),
       },
       {
@@ -2851,6 +2885,7 @@ describe("events", () => {
         type: "item/agentMessage/delta",
         itemId: "msg-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "msg-1", delta: "lo" }),
       },
       {
@@ -2860,6 +2895,7 @@ describe("events", () => {
         type: "item/agentMessage/delta",
         itemId: "msg-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "msg-1", delta: "!" }),
       },
       {
@@ -2869,6 +2905,7 @@ describe("events", () => {
         type: "item/completed",
         itemId: "msg-1",
         itemKind: "agentMessage",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: {
             id: "msg-1",
@@ -2900,6 +2937,7 @@ describe("events", () => {
         type: "item/agentMessage/delta",
         itemId: "msg-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "msg-1", delta: "Hel" }),
       },
       {
@@ -2909,6 +2947,7 @@ describe("events", () => {
         type: "item/agentMessage/delta",
         itemId: "msg-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "msg-1", delta: "lo" }),
       },
     ]);
@@ -2934,6 +2973,7 @@ describe("events", () => {
         type: "item/agentMessage/delta",
         itemId: "msg-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "msg-1", delta: "Hel" }),
       },
       {
@@ -2943,6 +2983,7 @@ describe("events", () => {
         type: "item/agentMessage/delta",
         itemId: "msg-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "msg-1", delta: "lo" }),
       },
       {
@@ -2952,6 +2993,7 @@ describe("events", () => {
         type: "item/completed",
         itemId: "msg-1",
         itemKind: "agentMessage",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: {
             id: "msg-1",
@@ -2967,6 +3009,7 @@ describe("events", () => {
         type: "item/agentMessage/delta",
         itemId: "msg-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "msg-1", delta: "New " }),
       },
       {
@@ -2976,6 +3019,7 @@ describe("events", () => {
         type: "item/agentMessage/delta",
         itemId: "msg-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "msg-1", delta: "answer" }),
       },
     ]);
@@ -3001,6 +3045,7 @@ describe("events", () => {
         type: "item/agentMessage/delta",
         itemId: "msg-1",
         itemKind: null,
+        parentToolCallId: "tool-1",
         data: JSON.stringify({
           itemId: "msg-1",
           parentToolCallId: "tool-1",
@@ -3014,6 +3059,7 @@ describe("events", () => {
         type: "item/agentMessage/delta",
         itemId: "msg-1",
         itemKind: null,
+        parentToolCallId: "tool-1",
         data: JSON.stringify({
           itemId: "msg-1",
           parentToolCallId: "tool-1",
@@ -3027,6 +3073,7 @@ describe("events", () => {
         type: "item/completed",
         itemId: "msg-1",
         itemKind: "agentMessage",
+        parentToolCallId: "tool-1",
         data: JSON.stringify({
           item: {
             id: "msg-1",
@@ -3043,6 +3090,7 @@ describe("events", () => {
         type: "item/agentMessage/delta",
         itemId: "msg-1",
         itemKind: null,
+        parentToolCallId: "tool-2",
         data: JSON.stringify({
           itemId: "msg-1",
           parentToolCallId: "tool-2",
@@ -3056,6 +3104,7 @@ describe("events", () => {
         type: "item/agentMessage/delta",
         itemId: "msg-1",
         itemKind: null,
+        parentToolCallId: "tool-2",
         data: JSON.stringify({
           itemId: "msg-1",
           parentToolCallId: "tool-2",
@@ -3085,6 +3134,7 @@ describe("events", () => {
         type: "item/commandExecution/outputDelta",
         itemId: "cmd-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "cmd-1", delta: "Hel" }),
       },
       {
@@ -3094,6 +3144,7 @@ describe("events", () => {
         type: "item/commandExecution/outputDelta",
         itemId: "cmd-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "cmd-1", delta: "lo" }),
       },
       {
@@ -3103,6 +3154,7 @@ describe("events", () => {
         type: "item/completed",
         itemId: "cmd-1",
         itemKind: "commandExecution",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: {
             id: "cmd-1",
@@ -3139,6 +3191,7 @@ describe("events", () => {
         type: "item/commandExecution/outputDelta",
         itemId: "cmd-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "cmd-1", delta: "Hel" }),
       },
       {
@@ -3148,6 +3201,7 @@ describe("events", () => {
         type: "item/commandExecution/outputDelta",
         itemId: "cmd-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "cmd-1", delta: "lo" }),
       },
       {
@@ -3157,6 +3211,7 @@ describe("events", () => {
         type: "item/completed",
         itemId: "cmd-1",
         itemKind: "commandExecution",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: {
             id: "cmd-1",
@@ -3192,6 +3247,7 @@ describe("events", () => {
         type: "item/commandExecution/outputDelta",
         itemId: "cmd-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "cmd-1", delta: "Hel" }),
       },
       {
@@ -3201,6 +3257,7 @@ describe("events", () => {
         type: "item/commandExecution/outputDelta",
         itemId: "cmd-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "cmd-1", delta: "lo" }),
       },
       {
@@ -3210,6 +3267,7 @@ describe("events", () => {
         type: "item/completed",
         itemId: "cmd-1",
         itemKind: "commandExecution",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: {
             id: "cmd-1",
@@ -3230,6 +3288,7 @@ describe("events", () => {
         type: "item/commandExecution/outputDelta",
         itemId: "cmd-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "cmd-1", delta: "New " }),
       },
       {
@@ -3239,6 +3298,7 @@ describe("events", () => {
         type: "item/commandExecution/outputDelta",
         itemId: "cmd-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "cmd-1", delta: "output" }),
       },
     ]);
@@ -3264,6 +3324,7 @@ describe("events", () => {
         type: "item/commandExecution/outputDelta",
         itemId: "cmd-1",
         itemKind: null,
+        parentToolCallId: "tool-1",
         data: JSON.stringify({
           itemId: "cmd-1",
           parentToolCallId: "tool-1",
@@ -3277,6 +3338,7 @@ describe("events", () => {
         type: "item/commandExecution/outputDelta",
         itemId: "cmd-1",
         itemKind: null,
+        parentToolCallId: "tool-1",
         data: JSON.stringify({
           itemId: "cmd-1",
           parentToolCallId: "tool-1",
@@ -3290,6 +3352,7 @@ describe("events", () => {
         type: "item/completed",
         itemId: "cmd-1",
         itemKind: "commandExecution",
+        parentToolCallId: "tool-1",
         data: JSON.stringify({
           item: {
             id: "cmd-1",
@@ -3311,6 +3374,7 @@ describe("events", () => {
         type: "item/commandExecution/outputDelta",
         itemId: "cmd-1",
         itemKind: null,
+        parentToolCallId: "tool-2",
         data: JSON.stringify({
           itemId: "cmd-1",
           parentToolCallId: "tool-2",
@@ -3324,6 +3388,7 @@ describe("events", () => {
         type: "item/commandExecution/outputDelta",
         itemId: "cmd-1",
         itemKind: null,
+        parentToolCallId: "tool-2",
         data: JSON.stringify({
           itemId: "cmd-1",
           parentToolCallId: "tool-2",
@@ -3353,6 +3418,7 @@ describe("events", () => {
         type: "item/reasoning/textDelta",
         itemId: "reasoning-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "reasoning-1", delta: "raw " }),
       },
       {
@@ -3362,6 +3428,7 @@ describe("events", () => {
         type: "item/reasoning/textDelta",
         itemId: "reasoning-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "reasoning-1", delta: "content" }),
       },
       {
@@ -3371,6 +3438,7 @@ describe("events", () => {
         type: "item/reasoning/summaryTextDelta",
         itemId: "reasoning-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "reasoning-1", delta: "summary " }),
       },
       {
@@ -3380,6 +3448,7 @@ describe("events", () => {
         type: "item/reasoning/summaryTextDelta",
         itemId: "reasoning-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "reasoning-1", delta: "content" }),
       },
       {
@@ -3389,6 +3458,7 @@ describe("events", () => {
         type: "item/completed",
         itemId: "reasoning-1",
         itemKind: "reasoning",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: {
             id: "reasoning-1",
@@ -3421,6 +3491,7 @@ describe("events", () => {
         type: "item/reasoning/textDelta",
         itemId: "reasoning-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "reasoning-1", delta: "raw " }),
       },
       {
@@ -3430,6 +3501,7 @@ describe("events", () => {
         type: "item/reasoning/textDelta",
         itemId: "reasoning-1",
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ itemId: "reasoning-1", delta: "content" }),
       },
     ]);
@@ -3468,6 +3540,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:wf-1",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: progressData("running"),
       },
       {
@@ -3477,6 +3550,7 @@ describe("events", () => {
         type: "item/backgroundTask/progress",
         itemId: "task:wf-1",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: progressData("running"),
       },
       {
@@ -3486,6 +3560,7 @@ describe("events", () => {
         type: "item/backgroundTask/progress",
         itemId: "task:wf-1",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: progressData("running"),
       },
       {
@@ -3495,6 +3570,7 @@ describe("events", () => {
         type: "item/backgroundTask/progress",
         itemId: "task:wf-1",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: progressData("running"),
       },
     ]);
@@ -3533,6 +3609,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:wf-1",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: itemData("running"),
       },
       {
@@ -3542,6 +3619,7 @@ describe("events", () => {
         type: "item/backgroundTask/progress",
         itemId: "task:wf-1",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: itemData("running"),
       },
       {
@@ -3551,6 +3629,7 @@ describe("events", () => {
         type: "item/backgroundTask/progress",
         itemId: "task:wf-1",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: itemData("running"),
       },
       {
@@ -3560,6 +3639,7 @@ describe("events", () => {
         type: "item/backgroundTask/completed",
         itemId: "task:wf-1",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: itemData("completed"),
       },
     ]);
@@ -3598,6 +3678,7 @@ describe("events", () => {
         type: "item/backgroundTask/progress",
         itemId: "task:wf-1",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData("task:wf-1"),
       },
       {
@@ -3607,6 +3688,7 @@ describe("events", () => {
         type: "item/backgroundTask/progress",
         itemId: "task:wf-2",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData("task:wf-2"),
       },
       {
@@ -3616,6 +3698,7 @@ describe("events", () => {
         type: "item/backgroundTask/completed",
         itemId: "task:wf-1",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData("task:wf-1"),
       },
     ]);
@@ -3654,6 +3737,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:wf-1",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData("task:wf-1", "running"),
       },
       {
@@ -3663,6 +3747,7 @@ describe("events", () => {
         type: "item/backgroundTask/progress",
         itemId: "task:wf-1",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData("task:wf-1", "running"),
       },
       {
@@ -3672,6 +3757,7 @@ describe("events", () => {
         type: "item/backgroundTask/progress",
         itemId: "task:wf-2",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData("task:wf-2", "running"),
       },
       {
@@ -3681,6 +3767,7 @@ describe("events", () => {
         type: "item/backgroundTask/completed",
         itemId: "task:wf-1",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData("task:wf-1", "completed"),
       },
       // Unrelated item id: must not appear in the result.
@@ -3691,6 +3778,7 @@ describe("events", () => {
         type: "item/backgroundTask/progress",
         itemId: "task:wf-other",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData("task:wf-other", "running"),
       },
     ]);
@@ -3760,6 +3848,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:wf-start-only",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:wf-start-only",
           itemStatus: "pending",
@@ -3774,6 +3863,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:wf-progress",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:wf-progress",
           itemStatus: "pending",
@@ -3788,6 +3878,7 @@ describe("events", () => {
         type: "item/backgroundTask/progress",
         itemId: "task:wf-progress",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:wf-progress",
           itemStatus: "pending",
@@ -3802,6 +3893,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:wf-terminal-progress",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:wf-terminal-progress",
           itemStatus: "pending",
@@ -3816,6 +3908,7 @@ describe("events", () => {
         type: "item/backgroundTask/progress",
         itemId: "task:wf-terminal-progress",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:wf-terminal-progress",
           itemStatus: "completed",
@@ -3830,6 +3923,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:wf-completed",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:wf-completed",
           itemStatus: "pending",
@@ -3844,6 +3938,7 @@ describe("events", () => {
         type: "item/backgroundTask/completed",
         itemId: "task:wf-completed",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:wf-completed",
           itemStatus: "completed",
@@ -3858,6 +3953,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:cmd-open",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:cmd-open",
           itemStatus: "pending",
@@ -3872,6 +3968,7 @@ describe("events", () => {
         type: "item/backgroundTask/progress",
         itemId: "task:cmd-open",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:cmd-open",
           itemStatus: "pending",
@@ -3886,6 +3983,7 @@ describe("events", () => {
         type: "item/backgroundTask/progress",
         itemId: "task:other-thread",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:other-thread",
           itemStatus: "pending",
@@ -3954,6 +4052,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:wf-active",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:wf-active",
           itemStatus: "pending",
@@ -3968,6 +4067,7 @@ describe("events", () => {
         type: "item/backgroundTask/progress",
         itemId: "task:wf-active",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:wf-active",
           itemStatus: "pending",
@@ -3982,6 +4082,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:wf-terminal-progress",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:wf-terminal-progress",
           itemStatus: "pending",
@@ -3996,6 +4097,7 @@ describe("events", () => {
         type: "item/backgroundTask/progress",
         itemId: "task:wf-terminal-progress",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:wf-terminal-progress",
           itemStatus: "completed",
@@ -4010,6 +4112,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:wf-completed",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:wf-completed",
           itemStatus: "pending",
@@ -4024,6 +4127,7 @@ describe("events", () => {
         type: "item/backgroundTask/completed",
         itemId: "task:wf-completed",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:wf-completed",
           itemStatus: "completed",
@@ -4038,6 +4142,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:wf-skip-transcript",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:wf-skip-transcript",
           itemStatus: "pending",
@@ -4053,6 +4158,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:cmd-active",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:cmd-active",
           itemStatus: "pending",
@@ -4067,6 +4173,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:agent-active",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:agent-active",
           itemStatus: "pending",
@@ -4081,6 +4188,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:subagent-active",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData({
           itemId: "task:subagent-active",
           itemStatus: "pending",
@@ -4143,6 +4251,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:workflow",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData("task:workflow", LOCAL_WORKFLOW_TASK_TYPE),
       },
       {
@@ -4152,6 +4261,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:command",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData("task:command", LOCAL_BASH_TASK_TYPE),
       },
     ]);
@@ -4214,6 +4324,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:wf-open",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData("task:wf-open", "running"),
       },
       {
@@ -4224,6 +4335,7 @@ describe("events", () => {
         type: "item/backgroundTask/progress",
         itemId: "task:wf-open",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData("task:wf-open", "running"),
       },
       {
@@ -4234,6 +4346,7 @@ describe("events", () => {
         type: "item/backgroundTask/progress",
         itemId: "task:wf-open",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData("task:wf-open", "paused"),
       },
       // Settled item: excluded entirely.
@@ -4245,6 +4358,7 @@ describe("events", () => {
         type: "item/started",
         itemId: "task:wf-done",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData("task:wf-done", "running"),
       },
       {
@@ -4255,6 +4369,7 @@ describe("events", () => {
         type: "item/backgroundTask/completed",
         itemId: "task:wf-done",
         itemKind: "backgroundTask",
+        parentToolCallId: null,
         data: taskData("task:wf-done", "completed"),
       },
     ]);
@@ -4422,6 +4537,7 @@ describe("timeline read-boundary output truncation", () => {
         ...threadEventFields,
         itemId: "cmd-bytes",
         itemKind: "commandExecution",
+        parentToolCallId: null,
         data: JSON.stringify({
           note: "Unicode: 🐝",
           item: {
@@ -4461,6 +4577,7 @@ describe("timeline read-boundary output truncation", () => {
         ...threadEventFields,
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ message: "x".repeat(messageChars) }),
       })),
     );
@@ -4522,6 +4639,7 @@ describe("timeline read-boundary output truncation", () => {
           ...threadEventFields,
           itemId: null,
           itemKind: null,
+          parentToolCallId: null,
           data: JSON.stringify({ message: "x".repeat(messageChars) }),
         })),
       );
@@ -4551,6 +4669,7 @@ describe("timeline read-boundary output truncation", () => {
           ...threadEventFields,
           itemId: null,
           itemKind: null,
+          parentToolCallId: null,
           data: JSON.stringify({ message: "write after byte-cut read" }),
         },
       ]);
@@ -4569,6 +4688,7 @@ describe("timeline read-boundary output truncation", () => {
         ...threadEventFields,
         itemId: "cmd-1",
         itemKind: "commandExecution",
+        parentToolCallId: null,
         data: JSON.stringify({
           providerThreadId: "provider-root",
           item: {
@@ -4615,6 +4735,7 @@ describe("timeline read-boundary output truncation", () => {
         ...threadEventFields,
         itemId: "tool-1",
         itemKind: "toolCall",
+        parentToolCallId: null,
         data: JSON.stringify({
           providerThreadId: "provider-root",
           item: {
@@ -4642,6 +4763,7 @@ describe("timeline read-boundary output truncation", () => {
         ...threadEventFields,
         itemId: "cmd-2",
         itemKind: "commandExecution",
+        parentToolCallId: null,
         data: JSON.stringify({
           providerThreadId: "provider-root",
           item: {
@@ -4816,6 +4938,7 @@ describe("hasParentedEventCrossingSequence", () => {
         ...createTurnEventFields({ turnId: "turn-open" }),
         itemId: "parent-call",
         itemKind: "toolCall",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: {
             type: "toolCall",
@@ -4834,6 +4957,7 @@ describe("hasParentedEventCrossingSequence", () => {
         ...createTurnEventFields({ turnId: "child-turn" }),
         itemId: "child-message",
         itemKind: "agentMessage",
+        parentToolCallId: "parent-call",
         data: JSON.stringify({
           item: {
             type: "agentMessage",
@@ -4869,6 +4993,7 @@ describe("hasParentedEventCrossingSequence", () => {
         ...createTurnEventFields({ turnId: "turn-open" }),
         itemId: "parent-call",
         itemKind: "toolCall",
+        parentToolCallId: null,
         data: JSON.stringify({
           item: {
             type: "toolCall",
@@ -4887,6 +5012,7 @@ describe("hasParentedEventCrossingSequence", () => {
         ...createTurnEventFields({ turnId: "child-turn" }),
         itemId: "child-message",
         itemKind: "agentMessage",
+        parentToolCallId: "parent-call",
         data: JSON.stringify({
           item: {
             type: "agentMessage",

--- a/packages/db/test/data/thread-search.test.ts
+++ b/packages/db/test/data/thread-search.test.ts
@@ -130,6 +130,7 @@ describe("thread search data", () => {
           scope: threadScope(),
           itemId: null,
           itemKind: null,
+          parentToolCallId: null,
           data: JSON.stringify(
             turnRequestData([
               textInput("visiblebackfill"),
@@ -144,6 +145,7 @@ describe("thread search data", () => {
           scope: turnScope("turn-1"),
           itemId: "msg-1",
           itemKind: "agentMessage",
+          parentToolCallId: null,
           data: JSON.stringify({
             item: {
               id: "msg-1",
@@ -159,6 +161,7 @@ describe("thread search data", () => {
           scope: threadScope(),
           itemId: null,
           itemKind: null,
+          parentToolCallId: null,
           data: JSON.stringify({ text: "legacybackfill" }),
         },
       ]);

--- a/packages/db/test/migrate.test.ts
+++ b/packages/db/test/migrate.test.ts
@@ -144,6 +144,11 @@ interface MigratedEventDataRow {
   data: string;
 }
 
+interface MigratedEventParentRow {
+  id: string;
+  parentToolCallId: string | null;
+}
+
 interface MigratedExperimentRow {
   key: string;
   updatedAt: number;
@@ -305,6 +310,7 @@ function dropRewindAddedTables(db: DbConnection): void {
   db.$client.prepare("DROP TABLE IF EXISTS plugin_catalog").run();
   db.$client.prepare("DROP TABLE IF EXISTS marketplaces").run();
   dropMarketplaceCatalogSchema(db);
+  dropEventParentToolCallIdColumn(db);
   db.$client.prepare("DROP TABLE IF EXISTS plugins").run();
   db.$client.prepare("DROP TABLE IF EXISTS plugin_kv").run();
   db.$client.prepare("DROP TABLE IF EXISTS plugin_settings").run();
@@ -406,6 +412,7 @@ const queuedMessageGroupingMigrationWhen = 1782273194188;
 const pendingInteractionsMigrationWhen = 1783626227375;
 const permissionModesMigrationWhen = 1784311522462;
 const branchLocalThreadTabsMigrationWhen = 1783633750817;
+const eventParentToolCallMigrationWhen = 1787181956957;
 const eventLargeValuesPreOptimizationHash =
   "bc111f5134183c37cf135af70231ec5a79823f9868818fdd8377e1ab3c05a23f";
 const queuedMessageSortKeyMigrationPath = resolve(
@@ -671,6 +678,20 @@ function dropMarketplaceCatalogSchema(db: DbConnection): void {
   }
 }
 
+function dropEventParentToolCallIdColumn(db: DbConnection): void {
+  const columns = db.$client
+    .prepare<[], TableInfoRow>("PRAGMA table_info(events)")
+    .all();
+  if (columns.some((column) => column.name === "parent_tool_call_id")) {
+    db.$client.exec(
+      "DROP INDEX IF EXISTS events_parent_tool_call_thread_parent_sequence_idx",
+    );
+    db.$client
+      .prepare("ALTER TABLE events DROP COLUMN parent_tool_call_id")
+      .run();
+  }
+}
+
 function dropEnvironmentNameColumn(db: DbConnection): void {
   db.$client.prepare("ALTER TABLE environments DROP COLUMN name").run();
 }
@@ -763,6 +784,7 @@ function dropQueuedMessageSenderThreadIdColumn(db: DbConnection): void {
 
 /** Tables created by migrations after 0023, dropped so migrate() re-applies. */
 function dropPost0023Tables(db: DbConnection): void {
+  dropEventParentToolCallIdColumn(db);
   dropEnvironmentRetireRequestedAtColumn(db);
   dropPluginArtifactGitCheckoutRootColumn(db);
   dropProjectGitRemoteUrlColumn(db);
@@ -1672,6 +1694,7 @@ describe("migrate", () => {
     dropEnvironmentRetireRequestedAtColumn(db);
     dropPluginArtifactGitCheckoutRootColumn(db);
     dropMarketplaceCatalogSchema(db);
+    dropEventParentToolCallIdColumn(db);
     // Delete by the journal timestamp, not a hash substring: migration hashes
     // are hex and can contain "0085" by coincidence.
     db.$client
@@ -1966,6 +1989,7 @@ describe("migrate", () => {
       dropEnvironmentRetireRequestedAtColumn(db);
       dropPluginArtifactGitCheckoutRootColumn(db);
       dropMarketplaceCatalogSchema(db);
+      dropEventParentToolCallIdColumn(db);
 
       restoreLegacyThreadOriginColumn(db);
       migrate(db);
@@ -2369,6 +2393,7 @@ describe("migrate", () => {
       dropEnvironmentRetireRequestedAtColumn(db);
       dropPluginArtifactGitCheckoutRootColumn(db);
       dropMarketplaceCatalogSchema(db);
+      dropEventParentToolCallIdColumn(db);
 
       restoreLegacyThreadOriginColumn(db);
       expect(
@@ -2469,6 +2494,7 @@ describe("migrate", () => {
       dropEnvironmentRetireRequestedAtColumn(db);
       dropPluginArtifactGitCheckoutRootColumn(db);
       dropMarketplaceCatalogSchema(db);
+      dropEventParentToolCallIdColumn(db);
 
       restoreLegacyThreadOriginColumn(db);
       expect(() => migrate(db)).not.toThrow();
@@ -3999,6 +4025,7 @@ describe("migrate", () => {
         "item_kind",
         "data",
         "created_at",
+        "parent_tool_call_id",
       ]);
       const eventIndexNames = readIndexNames({
         db,
@@ -4010,6 +4037,7 @@ describe("migrate", () => {
         "events_environment_idx",
         "events_goal_thread_sequence_idx",
         "events_item_lifecycle_thread_item_sequence_idx",
+        "events_parent_tool_call_thread_parent_sequence_idx",
         "events_thread_sequence_idx",
         "events_thread_turn_type_item_sequence_idx",
         "events_thread_type_item_kind_sequence_idx",
@@ -5006,6 +5034,102 @@ describe("migrate", () => {
           { id: legacyOriginSideChat.id, visibility: "hidden" },
           { id: fork.id, visibility: "visible" },
         ].sort((left, right) => left.id.localeCompare(right.id)),
+      );
+    } finally {
+      closeConnection(db);
+    }
+  });
+
+  it("backfills normalized parent tool-call ids from legacy event payloads", () => {
+    const db = createConnection(":memory:");
+
+    try {
+      migrate(db);
+      const host = upsertHost(db, noopNotifier, {
+        name: "event-parent-migration-host",
+        type: "persistent",
+      });
+      const { project } = createProject(db, noopNotifier, {
+        name: "event-parent-migration-project",
+        source: {
+          type: "local_path",
+          hostId: host.id,
+          path: "/tmp/event-parent-migration",
+        },
+      });
+      const thread = createThread(db, noopNotifier, {
+        projectId: project.id,
+        providerId: "codex",
+      });
+
+      dropEventParentToolCallIdColumn(db);
+      db.$client
+        .prepare<DeleteMigrationParameters>(
+          "DELETE FROM __drizzle_migrations WHERE created_at >= ?",
+        )
+        .run(eventParentToolCallMigrationWhen);
+      db.$client.exec(`
+        INSERT INTO events (
+          id, thread_id, scope_kind, turn_id, sequence, type, item_id, item_kind, data, created_at
+        ) VALUES
+          (
+            'evt_top_level_parent',
+            '${thread.id}',
+            'turn',
+            'legacy-turn',
+            1,
+            'turn/started',
+            NULL,
+            NULL,
+            '{"parentToolCallId":"parent-top-level"}',
+            1
+          ),
+          (
+            'evt_item_parent',
+            '${thread.id}',
+            'turn',
+            'legacy-turn',
+            2,
+            'item/completed',
+            'child-message',
+            'agentMessage',
+            '{"item":{"id":"child-message","type":"agentMessage","parentToolCallId":"parent-item"}}',
+            2
+          ),
+          (
+            'evt_no_parent',
+            '${thread.id}',
+            'thread',
+            NULL,
+            3,
+            'system/error',
+            NULL,
+            NULL,
+            '{"message":"parentToolCallId is only text here"}',
+            3
+          );
+      `);
+
+      migrate(db);
+
+      expect(
+        db.$client
+          .prepare<[], MigratedEventParentRow>(
+            `
+              SELECT id, parent_tool_call_id AS parentToolCallId
+              FROM events
+              WHERE id LIKE 'evt_%_parent'
+              ORDER BY id
+            `,
+          )
+          .all(),
+      ).toEqual([
+        { id: "evt_item_parent", parentToolCallId: "parent-item" },
+        { id: "evt_no_parent", parentToolCallId: null },
+        { id: "evt_top_level_parent", parentToolCallId: "parent-top-level" },
+      ]);
+      expect(readIndexNames({ db, tableName: "events" })).toContain(
+        "events_parent_tool_call_thread_parent_sequence_idx",
       );
     } finally {
       closeConnection(db);

--- a/packages/db/test/query-plans.test.ts
+++ b/packages/db/test/query-plans.test.ts
@@ -21,6 +21,7 @@ import {
   listLatestOpenBackgroundTaskStateRowsForThread,
   listStoredConversationOutlineEventRows,
   listStoredEventRows,
+  listStoredEventRowsByParentToolCallIds,
   pruneContextWindowUsageEventsBeforeSequence,
   pruneResolvedItemDeltas,
 } from "../src/data/events.js";
@@ -262,6 +263,7 @@ describe("slow query index plans", () => {
         scope: turnScope(turnId),
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ providerThreadId: "provider-plan" }),
       },
       {
@@ -271,6 +273,7 @@ describe("slow query index plans", () => {
         scope: turnScope(turnId),
         itemId,
         itemKind: "agentMessage",
+        parentToolCallId: null,
         data: JSON.stringify({
           providerThreadId: "provider-plan",
           item: { type: "agentMessage", id: itemId, text: "done" },
@@ -288,6 +291,7 @@ describe("slow query index plans", () => {
             scope: turnScope(turnId),
             itemId,
             itemKind: "agentMessage",
+            parentToolCallId: null,
             providerThreadId: "provider-plan",
             data: JSON.stringify({
               providerThreadId: "provider-plan",
@@ -346,6 +350,30 @@ describe("slow query index plans", () => {
     });
     expect(details).toMatch(
       /SEARCH parent_event .*USING COVERING INDEX events_tool_call_parent_lookup_idx/u,
+    );
+
+    db.$client.close();
+  });
+
+  it("loads parented timeline rows through the normalized parent index", () => {
+    const { db, thread } = setup();
+
+    const [query] = captureStatements(db, () => {
+      expect(
+        listStoredEventRowsByParentToolCallIds(db, {
+          maxInlineOutputChars: null,
+          parentToolCallIds: ["parent-tool-call"],
+          threadId: thread.id,
+        }),
+      ).toEqual([]);
+    });
+    if (!query) {
+      throw new Error("Expected the parented timeline row lookup SQL");
+    }
+    expect(
+      queryPlanDetails({ db, params: query.params, sql: query.sql }),
+    ).toMatch(
+      /SEARCH events USING INDEX events_parent_tool_call_thread_parent_sequence_idx/u,
     );
 
     db.$client.close();
@@ -574,6 +602,7 @@ describe("slow query index plans", () => {
         }),
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         scope: turnScope("turn_query_plan"),
         sequence: 1,
         threadId: thread.id,
@@ -588,6 +617,7 @@ describe("slow query index plans", () => {
         }),
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         scope: turnScope("turn_query_plan"),
         sequence: 2,
         threadId: thread.id,
@@ -597,6 +627,7 @@ describe("slow query index plans", () => {
         data: "{}",
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         scope: threadScope(),
         sequence: 3,
         threadId: thread.id,
@@ -723,6 +754,7 @@ describe("slow query index plans", () => {
         }),
         itemId: "cmd-truncation-query-plan",
         itemKind: "commandExecution",
+        parentToolCallId: null,
         scope: turnScope("turn_truncation_query_plan"),
         sequence: 1,
         threadId: thread.id,
@@ -770,6 +802,7 @@ describe("slow query index plans", () => {
         data: JSON.stringify({ output: "first", parentToolCallId: "parent" }),
         itemId,
         itemKind: null,
+        parentToolCallId: "parent",
         scope: turnScope(turnId),
         sequence: 1,
         threadId: thread.id,
@@ -779,6 +812,7 @@ describe("slow query index plans", () => {
         data: JSON.stringify({ output: "second", parentToolCallId: "parent" }),
         itemId,
         itemKind: null,
+        parentToolCallId: "parent",
         scope: turnScope(turnId),
         sequence: 2,
         threadId: thread.id,
@@ -795,6 +829,7 @@ describe("slow query index plans", () => {
         }),
         itemId,
         itemKind: "commandExecution",
+        parentToolCallId: "parent",
         scope: turnScope(turnId),
         sequence: 3,
         threadId: thread.id,
@@ -854,6 +889,7 @@ describe("slow query index plans", () => {
         data: JSON.stringify({ goal: "guard the query plan" }),
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         scope: threadScope(),
         sequence: 1,
         threadId: thread.id,

--- a/packages/db/test/stored-event-item-fields.test.ts
+++ b/packages/db/test/stored-event-item-fields.test.ts
@@ -20,6 +20,7 @@ describe("deriveStoredEventItemFields", () => {
     ).toEqual({
       itemId: "tool-1",
       itemKind: "toolCall",
+      parentToolCallId: null,
     });
   });
 
@@ -39,6 +40,7 @@ describe("deriveStoredEventItemFields", () => {
     ).toEqual({
       itemId: "msg-1",
       itemKind: "agentMessage",
+      parentToolCallId: null,
     });
   });
 
@@ -64,6 +66,7 @@ describe("deriveStoredEventItemFields", () => {
     ).toEqual({
       itemId: "task:wf-1",
       itemKind: "backgroundTask",
+      parentToolCallId: null,
     });
 
     expect(
@@ -77,6 +80,7 @@ describe("deriveStoredEventItemFields", () => {
     ).toEqual({
       itemId: "task:wf-1",
       itemKind: "backgroundTask",
+      parentToolCallId: null,
     });
   });
 
@@ -88,11 +92,13 @@ describe("deriveStoredEventItemFields", () => {
         providerThreadId: "provider-1",
         scope: turnScope("turn-1"),
         itemId: "tool-1",
+        parentToolCallId: "parent-tool-1",
         message: "still running",
       }),
     ).toEqual({
       itemId: "tool-1",
       itemKind: null,
+      parentToolCallId: "parent-tool-1",
     });
   });
 
@@ -109,6 +115,7 @@ describe("deriveStoredEventItemFields", () => {
     ).toEqual({
       itemId: "msg-1",
       itemKind: null,
+      parentToolCallId: null,
     });
   });
 
@@ -124,6 +131,7 @@ describe("deriveStoredEventItemFields", () => {
     ).toEqual({
       itemId: null,
       itemKind: null,
+      parentToolCallId: null,
     });
   });
 });


### PR DESCRIPTION
## What was wrong

Timeline pagination paid three avoidable costs on its synchronous request path. Parent-context discovery decoded every selected event payload before normal projection decoded it again; child lookup parsed JSON across an entire thread because the parent relationship existed only inside `events.data`; and the byte-budget check crossed the better-sqlite3 boundary once per candidate row even when the whole window fit (the common case). Large concurrent threads therefore held the event loop longer than the rows returned by the API required.

## What changed

- Normalize `parentToolCallId` into `events.parent_tool_call_id` at the event-write boundaries and read that typed field for root-turn, nested-turn, parent-closure, and parent-crossing decisions.
- Add generated migration `0103_wandering_mongoose`: backfill the new column from both legacy JSON shapes, then add the one partial `(thread_id, parent_tool_call_id, sequence)` index required by the changed lookup.
- Ask SQLite for one aggregate window byte count first. Fitting windows return one scalar; only oversized windows take the existing newest-first iterator needed to preserve the exact cutoff and single-event-placeholder rules.
- Add migration/backfill coverage, parent-field derivation coverage, and a query-plan assertion that parented timeline lookup selects the new index.

Current main already had two adjacent optimizations: superseded workflow snapshots/out-of-window turn filtering from #1872, and `events_tool_call_parent_lookup_idx` for parent-crossing tool-call probes. This change preserves both; the new index serves the inverse child-by-parent lookup. Main also gained `0102_app_settings_key_value` while this work was in progress, so the event migration and snapshot were regenerated as `0103` rather than retaining the source branch's colliding `0102` name. The initial string-presence guard from the first source commit is intentionally absent from the final diff because the normalized column removes that JSON decode entirely. No other performance commits from the source branch are included. There is no server/host-daemon wire change, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## Performance

Final comparison was run from exact base `35732c53922906a6f6684f684461077b685a812b` to head `919e28b4cc4bb09a674f3e2d8ffc2c6bd7639f72` on an Apple M4 Max / 48 GiB Mac (`Darwin 25.5.0`), Node `22.23.1`, SQLite `3.51.0`. Both refs used forced production server builds, private loopback ports `45321`/`45322`, and private copies of the same deterministic fixture: 12 projects, 240 threads, 480,450 events, 270.5 MiB event JSON, 582 MiB SQLite database, plus 48 deterministic cross-window parent relationships in the largest threads.

Each of five repetitions pre-read all event data to control OS-cache ordering, restarted the production server to clear response caches, warmed 19 disjoint threads (38 timeline requests), then issued distinct cold-response-cache URLs at timeline concurrency 16 while four workers continuously requested `GET /api/v1/projects`. Initial and older-page scenarios used 160 distinct threads; parent-context used 48. Values below are the median of the five per-run medians/p95s (raw JSON and server logs retained under `/tmp/bb-pr2-perf.IeuChw`).

| Scenario | response median | response p95 | throughput | server CPU / batch | competing projects p95 |
| --- | ---: | ---: | ---: | ---: | ---: |
| Initial page (160) | 142.3 → 127.0 ms (-10.7%) | 239.9 → 193.8 ms (-19.2%) | 99.5 → 114.6 req/s (+15.2%) | 2.15 → 1.95 s (-9.3%) | 242.5 → 196.6 ms (-18.9%) |
| Older page (160) | 130.4 → 115.6 ms (-11.3%) | 179.9 → 131.0 ms (-27.2%) | 115.4 → 137.5 req/s (+19.2%) | 1.67 → 1.46 s (-12.6%) | 179.5 → 133.2 ms (-25.8%) |
| Parent context (48) | 166.1 → 132.9 ms (-20.0%) | 184.4 → 136.5 ms (-26.0%) | 95.1 → 120.7 req/s (+26.8%) | 0.59 → 0.49 s (-16.9%) | 187.4 → 138.8 ms (-25.9%) |

Median response sizes were unchanged: 37,609 bytes initial, 36,592 bytes older, and 36,320 bytes parent-context.

Representative query evidence:

- A fitting latest window held 276 rows / 158,900 payload bytes. Before, the byte check materialized 276 iterator rows (27,658 serialized bytes in the diagnostic capture); after, it materialized one 24-byte aggregate scalar. Both plans correctly use `events_thread_sequence_idx`; the gain is fewer native-boundary crossings/materialized result rows.
- A parent-context sample had 7,747 thread rows / 4,709,745 payload bytes and returned one 111-byte child row. Before, `EXPLAIN QUERY PLAN` selected `events_thread_sequence_idx (thread_id=?)` and evaluated JSON parent expressions across the thread. After, it selects `events_parent_tool_call_thread_parent_sequence_idx (thread_id=? AND parent_tool_call_id=?)` and visits the one matching index entry.

Exact setup/build commands included:

```sh
pnpm seed:perf -- --data-dir /tmp/bb-pr2-perf.IeuChw/baseline-data --reset --projects 12 --threads 240 --events 480000 --seed 20260819
git switch --detach 35732c53922906a6f6684f684461077b685a812b
pnpm exec turbo run build --filter=@bb/server --filter=@bb/scripts --force
env NODE_ENV=production BB_DATA_DIR=/tmp/bb-pr2-perf.IeuChw/final-baseline-data BB_SERVER_PORT=45321 BB_HOST_DAEMON_PORT=45322 BB_SERVER_BIND_HOST=127.0.0.1 BB_TELEMETRY=false node apps/server/dist/index.js
sqlite3 /tmp/bb-pr2-perf.IeuChw/final-baseline-data/bb.db 'SELECT sum(length(CAST(data AS BLOB))) FROM events;'
node tmp-perf-pr2-run.mjs /tmp/bb-pr2-perf.IeuChw/targets.json "$server_pid"
```

The same commands/settings were repeated after switching to the head and changing only the private data-dir copy. Absolute values are local loopback/warm-data results; the comparison is intended to isolate CPU, materialization, and event-loop effects, not model production network latency.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/db --filter=@bb/server --force` — passed.
- `pnpm exec turbo run test --filter=@bb/db --force` — 29 files, 404 tests passed, including migration and query-plan coverage.
- `pnpm exec turbo run test --filter=@bb/server --force -- test/services/threads/timeline-parented-pagination.test.ts test/services/threads/timeline-event-budget.test.ts test/services/threads/timeline-workflow-progress-window.test.ts test/public/public-thread-data.test.ts` — 4 files, 86 tests passed.
- `pnpm exec turbo run build --filter=@bb/server --filter=@bb/scripts --force` — passed on both exact baseline and head production builds.
- Clean migration: empty database reached all 104 migrations and contained the new column/index.
- Upgrade migration: the pre-change 480,450-event fixture reached all 104 migrations; 48/48 parent rows were backfilled with zero JSON/column mismatches (the logged backfill took 940 ms on this machine).
- Full `@bb/server` run completed 1,780/1,781 tests; the unrelated plugin compatibility warning test exceeded its 5 s timeout under full-suite load. Its isolated Turbo rerun passed all 24 tests (the timed-out case completed in 1.73 s).

> AGENT GENERATED: by GPT-5
