### PR TITLE
Fix main: add parentToolCallId to conversation-outline-parity event inserts

### DIFF
--- a/apps/server/test/services/threads/conversation-outline-parity.test.ts
+++ b/apps/server/test/services/threads/conversation-outline-parity.test.ts
@@ -47,6 +47,7 @@ function agentMessage(
     providerThreadId: "provider-thread-1",
     itemId: `message-${sequence}`,
     itemKind: "agentMessage",
+    parentToolCallId: null,
     data: JSON.stringify({
       item: { id: `message-${sequence}`, type: "agentMessage", text },
     }),
@@ -65,6 +66,7 @@ function userQuestionLifecycle(
     scope: turnScope("turn-1"),
     itemId: null,
     itemKind: null,
+    parentToolCallId: null,
     data: JSON.stringify({
       interactionId: "pi-user-question",
       providerId: "claude-code",
@@ -110,6 +112,7 @@ describe("thread conversation outline parity", () => {
         scope: threadScope(),
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({
           direction: "outbound",
           requestId,
@@ -135,6 +138,7 @@ describe("thread conversation outline parity", () => {
         providerThreadId: "provider-thread-1",
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({}),
       },
       {
@@ -145,6 +149,7 @@ describe("thread conversation outline parity", () => {
         providerThreadId: "provider-thread-1",
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ clientRequestId: requestId }),
       },
       userQuestionLifecycle(thread.id, 4, "pending"),
@@ -161,6 +166,7 @@ describe("thread conversation outline parity", () => {
         providerThreadId: "provider-thread-1",
         itemId: null,
         itemKind: null,
+        parentToolCallId: null,
         data: JSON.stringify({ status: "completed" }),
       },
     ]);


### PR DESCRIPTION
## What was wrong

Main CI is red in `Checks` and `Tests (server)` since d9a5934c3 (#1657). #1976 made `parentToolCallId` required in `InsertEventInput`. #1657 was written before that change and merged after it, so `test/services/threads/conversation-outline-parity.test.ts` inserts events without the field. Typecheck reports TS2741 on six literals, and the SQLite insert fails with `near ",": syntax error`.

## What changed

`apps/server/test/services/threads/conversation-outline-parity.test.ts`: `parentToolCallId: null` on each of the six event literals. No product code changes.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/server` passes.
- `pnpm exec turbo run test --filter=@bb/server -- test/services/threads/conversation-outline-parity.test.ts` passes (it fails on main).
- Main runs 32314735170 and 32314935793 show the failure.

> AGENT GENERATED: by Claude Opus 5
