### PR TITLE
Guard timeline migration and byte preflight

### DIFF
--- a/packages/db/drizzle/0103_wandering_mongoose.sql
+++ b/packages/db/drizzle/0103_wandering_mongoose.sql
@@ -4,5 +4,6 @@ SET `parent_tool_call_id` = COALESCE(
   NULLIF(json_extract(`data`, '$.item.parentToolCallId'), ''),
   NULLIF(json_extract(`data`, '$.parentToolCallId'), '')
 )
-WHERE instr(`data`, '"parentToolCallId"') > 0;--> statement-breakpoint
+WHERE json_valid(`data`)
+  AND instr(`data`, '"parentToolCallId"') > 0;--> statement-breakpoint
 CREATE INDEX `events_parent_tool_call_thread_parent_sequence_idx` ON `events` (`thread_id`,`parent_tool_call_id`,`sequence`) WHERE "events"."parent_tool_call_id" IS NOT NULL;

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -61,6 +61,12 @@ import {
 } from "./threads.js";
 
 const STORED_EVENT_SEQUENCE_LOOKUP_CHUNK_SIZE = 250;
+/**
+ * Keep the scalar byte-total fast path above the default 1,500-event timeline
+ * window without letting a client-selected details range aggregate an entire
+ * thread before the byte-limited iterator gets a chance to stop early.
+ */
+export const STORED_TIMELINE_BYTE_PREFLIGHT_EVENT_LIMIT = 2_000;
 const SQLITE_MAX_VARIABLE_NUMBER = 32_766;
 // This OR query prepares with 995 keys. A 996th key reaches the configured
 // SQLite expression-depth limit of 1,000.
@@ -2897,6 +2903,32 @@ export function getStoredTimelineWindowEventDataBytes(
   return row?.dataBytes ?? 0;
 }
 
+function getStoredTimelineWindowEventDataBytesPreflight(
+  db: DbConnection,
+  args: GetStoredTimelineWindowEventDataBytesArgs,
+): { dataBytes: number; isComplete: boolean } {
+  const data = storedTimelineWindowDataColumn(args.maxInlineOutputChars);
+  const boundedWindow = db
+    .select({ data: sql<string>`${data}`.as("data") })
+    .from(events)
+    .where(and(...storedTimelineWindowConditions(args)))
+    .orderBy(desc(events.sequence))
+    .limit(STORED_TIMELINE_BYTE_PREFLIGHT_EVENT_LIMIT + 1)
+    .as("bounded_timeline_byte_window");
+  const row = db
+    .select({
+      dataBytes: sql<number>`COALESCE(SUM(length(CAST(${boundedWindow.data} AS BLOB))), 0)`,
+      eventCount: sql<number>`COUNT(*)`,
+    })
+    .from(boundedWindow)
+    .get();
+  return {
+    dataBytes: row?.dataBytes ?? 0,
+    isComplete:
+      (row?.eventCount ?? 0) <= STORED_TIMELINE_BYTE_PREFLIGHT_EVENT_LIMIT,
+  };
+}
+
 /**
  * Finds the oldest row in the newest suffix that fits the byte budget.
  * Iteration returns only a sequence and a byte count for each row, and stops
@@ -2906,19 +2938,20 @@ export function findStoredTimelineWindowByteBudgetFloor(
   db: DbConnection,
   args: FindStoredTimelineWindowByteBudgetFloorArgs,
 ): StoredTimelineWindowByteBudgetFloor {
-  // The common case is a window that fits. Let SQLite total it and return one
-  // scalar instead of crossing the native boundary once per event merely to
-  // rediscover that no floor is needed. Oversized windows still take the
-  // ordered iterator below so they retain the exact cutoff/placeholder rules.
-  const windowDataBytes = getStoredTimelineWindowEventDataBytes(db, {
+  // The common case is a normal-sized window that fits. Let SQLite total it
+  // and return one scalar instead of crossing the native boundary once per
+  // event merely to rediscover that no floor is needed. Client-selected detail
+  // ranges can span a whole thread, so cap this preflight and let oversized or
+  // unusually long ranges take the early-stopping iterator below.
+  const preflight = getStoredTimelineWindowEventDataBytesPreflight(db, {
     beforeSequence: args.beforeSequence,
     excludedTypes: args.excludedTypes,
     maxInlineOutputChars: args.maxInlineOutputChars,
     sequenceStart: args.sequenceStart,
     threadId: args.threadId,
   });
-  if (windowDataBytes <= args.maxDataBytes) {
-    return { eventDataBytes: windowDataBytes, kind: "fits" };
+  if (preflight.isComplete && preflight.dataBytes <= args.maxDataBytes) {
+    return { eventDataBytes: preflight.dataBytes, kind: "fits" };
   }
 
   const data = storedTimelineWindowDataColumn(args.maxInlineOutputChars);

--- a/packages/db/src/migration-history.ts
+++ b/packages/db/src/migration-history.ts
@@ -26,6 +26,11 @@ export const compatibleMigrationHashes = [
     when: 1781660000001,
     hash: "025358fe89253aec7f5bd970dc3eb88d0e834f0d58fb9d75329a5d39899340f4",
   },
+  {
+    tag: "0103_wandering_mongoose",
+    when: 1787181956957,
+    hash: "79d39e7b68d1db8ba02614fe4cc227cc0c154d77c7183f2e37ed2d8475412993",
+  },
 ] as const satisfies readonly CompatibleMigrationHash[];
 
 export const publishedMigrationWhensByTag: ReadonlyMap<string, number> =

--- a/packages/db/test/data/events.test.ts
+++ b/packages/db/test/data/events.test.ts
@@ -59,6 +59,7 @@ import {
   pruneResolvedItemDeltas,
   pruneThreadEventsBeforeSequence,
   listLatestOpenBackgroundTaskStateRowsForThread,
+  STORED_TIMELINE_BYTE_PREFLIGHT_EVENT_LIMIT,
 } from "../../src/data/events.js";
 import { createEnvironment } from "../../src/data/environments.js";
 import { createProject } from "../../src/data/projects.js";
@@ -4623,6 +4624,44 @@ describe("timeline read-boundary output truncation", () => {
       sequenceStart: 3,
       turnId: null,
     }));
+  });
+
+  it("bounds the byte-total preflight before using the early-stopping iterator", () => {
+    const { db, thread } = setup();
+    const validData = JSON.stringify({ message: "valid" });
+    insertEvents(
+      db,
+      noopNotifier,
+      Array.from(
+        { length: STORED_TIMELINE_BYTE_PREFLIGHT_EVENT_LIMIT + 2 },
+        (_, index) => ({
+          threadId: thread.id,
+          sequence: index + 1,
+          type: "system/error" as const,
+          ...threadEventFields,
+          data: validData,
+        }),
+      ),
+    );
+    db.$client
+      .prepare("UPDATE events SET data = ? WHERE thread_id = ? AND sequence = 1")
+      .run(`{"item":{"resultText":"${"x".repeat(1_100)}`, thread.id);
+
+    expect(
+      findStoredTimelineWindowByteBudgetFloor(db, {
+        maxDataBytes: 1,
+        maxInlineOutputChars: 1_000,
+        sequenceStart: 1,
+        threadId: thread.id,
+      }),
+    ).toEqual({
+      createdAt: expect.any(Number),
+      eventDataBytes: Buffer.byteLength(validData),
+      hasOlderRows: true,
+      kind: "single-event-too-large",
+      sequenceStart: STORED_TIMELINE_BYTE_PREFLIGHT_EVENT_LIMIT + 2,
+      turnId: null,
+    });
   });
 
   it.each(["floor", "single-event-too-large"] as const)(

--- a/packages/db/test/migrate.test.ts
+++ b/packages/db/test/migrate.test.ts
@@ -413,6 +413,8 @@ const pendingInteractionsMigrationWhen = 1783626227375;
 const permissionModesMigrationWhen = 1784311522462;
 const branchLocalThreadTabsMigrationWhen = 1783633750817;
 const eventParentToolCallMigrationWhen = 1787181956957;
+const eventParentToolCallPreJsonValidMigrationHash =
+  "79d39e7b68d1db8ba02614fe4cc227cc0c154d77c7183f2e37ed2d8475412993";
 const eventLargeValuesPreOptimizationHash =
   "bc111f5134183c37cf135af70231ec5a79823f9868818fdd8377e1ab3c05a23f";
 const queuedMessageSortKeyMigrationPath = resolve(
@@ -4394,6 +4396,26 @@ describe("migrate", () => {
     }
   });
 
+  it("accepts the event parent migration hash from before its JSON guard", () => {
+    const db = createConnection(":memory:");
+
+    try {
+      migrate(db);
+      db.$client
+        .prepare(
+          "UPDATE __drizzle_migrations SET hash = ? WHERE created_at = ?",
+        )
+        .run(
+          eventParentToolCallPreJsonValidMigrationHash,
+          eventParentToolCallMigrationWhen,
+        );
+
+      expect(() => migrate(db)).not.toThrow();
+    } finally {
+      closeConnection(db);
+    }
+  });
+
   it("fails clearly before provider-request uniqueness migration when pending interaction duplicates exist", () => {
     const db = createConnection(":memory:");
 
@@ -5107,6 +5129,18 @@ describe("migrate", () => {
             NULL,
             '{"message":"parentToolCallId is only text here"}',
             3
+          ),
+          (
+            'evt_malformed_parent',
+            '${thread.id}',
+            'thread',
+            NULL,
+            4,
+            'system/error',
+            NULL,
+            NULL,
+            '{"parentToolCallId":',
+            4
           );
       `);
 
@@ -5125,6 +5159,7 @@ describe("migrate", () => {
           .all(),
       ).toEqual([
         { id: "evt_item_parent", parentToolCallId: "parent-item" },
+        { id: "evt_malformed_parent", parentToolCallId: null },
         { id: "evt_no_parent", parentToolCallId: null },
         { id: "evt_top_level_parent", parentToolCallId: "parent-top-level" },
       ]);


### PR DESCRIPTION
## What was wrong

The parent-tool-call backfill added in #1976 evaluated `json_extract` for any historic event payload containing the parent key text, so malformed stored JSON aborted migration 0103 and prevented server startup. The byte-budget optimization from the same PR also aggregated every matching payload in a client-selected turn-details range before its early-stopping iterator ran, allowing a very wide range to add one or two unbounded synchronous scans.

## What changed

- Guard migration 0103 with `json_valid(data)` so malformed historic payloads remain unbackfilled instead of aborting the upgrade.
- Accept the original merged 0103 hash so development databases that already applied it continue to pass migration-history validation.
- Limit the scalar byte-total preflight to 2,001 matching events, which keeps the aggregate fast path for normal event-budgeted timeline windows and falls back to the existing exact, early-stopping iterator for unusually long ranges.
- Add regressions for malformed matching JSON, the historical migration hash, and a wide byte range whose older payload must not be visited by the aggregate.

This is a database/server implementation fix only. There is no server/host-daemon wire change, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/db --force`
- `pnpm exec turbo run test --filter=@bb/db --force` — 29 files, 406 tests passed
- `pnpm exec prettier --check packages/db/src/data/events.ts packages/db/src/migration-history.ts packages/db/test/data/events.test.ts packages/db/test/migrate.test.ts`
- `git diff --check`

Follow-up to #1976 and its [migration finding](https://github.com/get-bb/bb/pull/1976#discussion_r3817588245) and [range-scan finding](https://github.com/get-bb/bb/pull/1976#discussion_r3817588317).

> AGENT GENERATED: by GPT-5
