### PR TITLE
Batch initial timeline geometry measurements

### DIFF
--- a/apps/app/src/components/thread/timeline/GeneratedConversationMessage.test.tsx
+++ b/apps/app/src/components/thread/timeline/GeneratedConversationMessage.test.tsx
@@ -214,7 +214,52 @@ function renderAgentMessage(
   );
 }
 
-function mockInnerPreviewTextOverflow(text: string): void {
+function mockResizeObserverDeliveries(): () => void {
+  const observers: Array<{
+    callback: ResizeObserverCallback;
+    instance: ResizeObserver;
+    targets: Set<Element>;
+  }> = [];
+
+  class ResizeObserverMock {
+    private readonly record: (typeof observers)[number];
+    constructor(callback: ResizeObserverCallback) {
+      this.record = {
+        callback,
+        instance: this as unknown as ResizeObserver,
+        targets: new Set(),
+      };
+      observers.push(this.record);
+    }
+    observe(target: Element): void {
+      this.record.targets.add(target);
+    }
+    unobserve(target: Element): void {
+      this.record.targets.delete(target);
+    }
+    disconnect(): void {
+      this.record.targets.clear();
+    }
+  }
+
+  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  return () => {
+    act(() => {
+      for (const { callback, instance, targets } of observers) {
+        callback(
+          Array.from(
+            targets,
+            (target) => ({ target }) as unknown as ResizeObserverEntry,
+          ),
+          instance,
+        );
+      }
+    });
+  };
+}
+
+function mockInnerPreviewTextOverflow(text: string): () => void {
+  const notifyResize = mockResizeObserverDeliveries();
   vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(20);
   vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(20);
   vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(100);
@@ -226,23 +271,11 @@ function mockInnerPreviewTextOverflow(text: string): void {
         : 100;
     },
   );
+  return notifyResize;
 }
 
 function mockContinuationSensitiveOverflow(): () => void {
-  const resizeCallbacks: Array<() => void> = [];
-
-  class ResizeObserverMock {
-    constructor(callback: ResizeObserverCallback) {
-      resizeCallbacks.push(() =>
-        callback([], this as unknown as ResizeObserver),
-      );
-    }
-
-    observe(): void {}
-    disconnect(): void {}
-  }
-
-  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  const notifyResize = mockResizeObserverDeliveries();
   vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(20);
   vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(20);
   vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockImplementation(
@@ -255,11 +288,7 @@ function mockContinuationSensitiveOverflow(): () => void {
   );
   vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(100);
 
-  return () => {
-    act(() => {
-      for (const callback of resizeCallbacks) callback();
-    });
-  };
+  return notifyResize;
 }
 
 describe("GeneratedConversationMessage markdown body", () => {
@@ -542,8 +571,11 @@ describe("GeneratedConversationMessage markdown body", () => {
   });
 
   it("expands a one-line agent message when its preview text overflows", () => {
-    mockInnerPreviewTextOverflow(OVERFLOWING_ONE_LINE_AGENT_BODY);
+    const notifyResize = mockInnerPreviewTextOverflow(
+      OVERFLOWING_ONE_LINE_AGENT_BODY,
+    );
     renderAgentMessage(OVERFLOWING_ONE_LINE_AGENT_BODY);
+    notifyResize();
 
     const toggle = screen.getByRole("button", { name: /Message from Worker/u });
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
@@ -615,6 +647,7 @@ describe("GeneratedConversationMessage markdown body (system)", () => {
   it("keeps the continuation width stable when it makes the preview overflow", () => {
     const notifyResize = mockContinuationSensitiveOverflow();
     renderChildCompleted();
+    notifyResize();
 
     const continuation = screen.getByText("...");
     expect(continuation.className).toContain("invisible");

--- a/apps/app/src/components/thread/timeline/conversation-message-overflow.test.tsx
+++ b/apps/app/src/components/thread/timeline/conversation-message-overflow.test.tsx
@@ -8,6 +8,7 @@ import { useOverflowMeasurement } from "./conversation-message-overflow";
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 function OverflowProbe({ name }: { name: string }) {
@@ -17,9 +18,7 @@ function OverflowProbe({ name }: { name: string }) {
     enabled: true,
     measurementKey: name,
   });
-  return (
-    <div ref={ref} data-testid={name} data-measurement={measurement} />
-  );
+  return <div ref={ref} data-testid={name} data-measurement={measurement} />;
 }
 
 describe("useOverflowMeasurement", () => {
@@ -41,6 +40,20 @@ describe("useOverflowMeasurement", () => {
         disconnect = disconnect;
       },
     );
+    const scrollHeight = vi
+      .spyOn(HTMLElement.prototype, "scrollHeight", "get")
+      .mockImplementation(function (this: HTMLElement) {
+        return this.dataset.testid === "first" ? 80 : 20;
+      });
+    const clientHeight = vi
+      .spyOn(HTMLElement.prototype, "clientHeight", "get")
+      .mockReturnValue(20);
+    const scrollWidth = vi
+      .spyOn(HTMLElement.prototype, "scrollWidth", "get")
+      .mockReturnValue(20);
+    const clientWidth = vi
+      .spyOn(HTMLElement.prototype, "clientWidth", "get")
+      .mockReturnValue(20);
 
     render(
       <>
@@ -51,18 +64,12 @@ describe("useOverflowMeasurement", () => {
 
     const first = screen.getByTestId("first");
     const second = screen.getByTestId("second");
-    Object.defineProperties(first, {
-      scrollHeight: { configurable: true, value: 80 },
-      clientHeight: { configurable: true, value: 20 },
-      scrollWidth: { configurable: true, value: 20 },
-      clientWidth: { configurable: true, value: 20 },
-    });
-    Object.defineProperties(second, {
-      scrollHeight: { configurable: true, value: 20 },
-      clientHeight: { configurable: true, value: 20 },
-      scrollWidth: { configurable: true, value: 20 },
-      clientWidth: { configurable: true, value: 20 },
-    });
+    expect(first.dataset.measurement).toBe("unmeasured");
+    expect(second.dataset.measurement).toBe("unmeasured");
+    expect(scrollHeight).not.toHaveBeenCalled();
+    expect(clientHeight).not.toHaveBeenCalled();
+    expect(scrollWidth).not.toHaveBeenCalled();
+    expect(clientWidth).not.toHaveBeenCalled();
 
     act(() => {
       observerCallback?.(
@@ -76,6 +83,11 @@ describe("useOverflowMeasurement", () => {
 
     expect(constructorSpy).toHaveBeenCalledOnce();
     expect(observe).toHaveBeenCalledTimes(2);
+    expect(scrollHeight).toHaveBeenCalledTimes(2);
+    expect(clientHeight).toHaveBeenCalledTimes(2);
+    // The overflowing first row short-circuits before the width reads.
+    expect(scrollWidth).toHaveBeenCalledOnce();
+    expect(clientWidth).toHaveBeenCalledOnce();
     expect(first.dataset.measurement).toBe("overflowing");
     expect(second.dataset.measurement).toBe("fits");
   });

--- a/apps/app/src/components/thread/timeline/conversation-message-overflow.tsx
+++ b/apps/app/src/components/thread/timeline/conversation-message-overflow.tsx
@@ -132,9 +132,12 @@ export function useOverflowMeasurement({
       if (!element.isConnected) return;
       setMeasurement(nextMeasurement);
     };
-    applyMeasurement(readOverflowMeasurement(element));
-
     if (typeof ResizeObserver === "undefined") {
+      // Modern browsers deliver one initial ResizeObserver batch for every
+      // observed element. Waiting for that batch lets the shared observer
+      // complete all sibling layout reads before any React state write. A
+      // synchronous read here would instead force layout once per message.
+      applyMeasurement(readOverflowMeasurement(element));
       return;
     }
 

--- a/apps/app/src/components/ui/markdown-preview.test.tsx
+++ b/apps/app/src/components/ui/markdown-preview.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -35,18 +36,65 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-describe("MarkdownPreview", () => {
-  it("observes content width only when the preview renders a table", () => {
-    const observed: Element[] = [];
-    class ResizeObserverMock {
-      constructor(_callback: ResizeObserverCallback) {}
-      observe(target: Element) {
-        observed.push(target);
-      }
-      unobserve() {}
-      disconnect() {}
+function mockResizeObserverDeliveries(): {
+  notifyResize: () => void;
+  observerCount: () => number;
+  observed: Element[];
+} {
+  const observed: Element[] = [];
+  const observers: Array<{
+    callback: ResizeObserverCallback;
+    instance: ResizeObserver;
+    targets: Set<Element>;
+  }> = [];
+
+  class ResizeObserverMock {
+    private readonly record: (typeof observers)[number];
+    constructor(callback: ResizeObserverCallback) {
+      this.record = {
+        callback,
+        instance: this as unknown as ResizeObserver,
+        targets: new Set(),
+      };
+      observers.push(this.record);
     }
-    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    observe(target: Element): void {
+      observed.push(target);
+      this.record.targets.add(target);
+    }
+    unobserve(target: Element): void {
+      this.record.targets.delete(target);
+    }
+    disconnect(): void {
+      this.record.targets.clear();
+    }
+  }
+
+  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  return {
+    observed,
+    observerCount: () => observers.length,
+    notifyResize: () => {
+      act(() => {
+        for (const { callback, instance, targets } of observers) {
+          if (targets.size === 0) continue;
+          callback(
+            Array.from(
+              targets,
+              (target) => ({ target }) as unknown as ResizeObserverEntry,
+            ),
+            instance,
+          );
+        }
+      });
+    },
+  };
+}
+
+describe("MarkdownPreview", () => {
+  it("shares one observer and observes content width only for table previews", () => {
+    const { notifyResize, observed, observerCount } =
+      mockResizeObserverDeliveries();
     vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
       bottom: 100,
       height: 100,
@@ -64,24 +112,39 @@ describe("MarkdownPreview", () => {
     plain.unmount();
 
     const { container } = render(
-      <MarkdownPreview content={"| A |\n| - |\n| B |"} />,
+      <>
+        <MarkdownPreview content={"| A |\n| - |\n| B |"} />
+        <MarkdownPreview content={"| C |\n| - |\n| D |"} />
+      </>,
     );
-    const table = container.querySelector("table");
-    const breakout = table?.parentElement?.parentElement;
+    const breakouts = Array.from(
+      container.querySelectorAll("table"),
+      (table) => table.parentElement?.parentElement,
+    );
 
-    expect(observed).toHaveLength(1);
-    expect(observed[0]?.hasAttribute("data-markdown-preview")).toBe(true);
-    expect(breakout?.style.getPropertyValue("--md-content-w")).toBe("320px");
+    expect(observerCount()).toBe(1);
+    expect(observed).toHaveLength(2);
+    expect(
+      observed.every((element) =>
+        element.hasAttribute("data-markdown-preview"),
+      ),
+    ).toBe(true);
+    expect(
+      breakouts.every(
+        (breakout) => breakout?.style.getPropertyValue("--md-content-w") === "",
+      ),
+    ).toBe(true);
+    notifyResize();
+    expect(
+      breakouts.every(
+        (breakout) =>
+          breakout?.style.getPropertyValue("--md-content-w") === "320px",
+      ),
+    ).toBe(true);
   });
 
   it("caps the table breakout at the nearest horizontally clipped ancestor", () => {
-    class ResizeObserverMock {
-      constructor(_callback: ResizeObserverCallback) {}
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    }
-    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    const { notifyResize } = mockResizeObserverDeliveries();
     // Every element is 300px wide at x=100 unless it sets data-left/data-width.
     vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
       function (this: HTMLElement) {
@@ -121,6 +184,7 @@ describe("MarkdownPreview", () => {
     const flush = renderClipped(400);
     const flushBreakout =
       flush.container.querySelector("table")?.parentElement?.parentElement;
+    notifyResize();
     expect(
       flushBreakout?.style.getPropertyValue("--md-table-breakout-max"),
     ).toBe("300px");
@@ -130,6 +194,7 @@ describe("MarkdownPreview", () => {
     const roomy = renderClipped(600);
     const roomyBreakout =
       roomy.container.querySelector("table")?.parentElement?.parentElement;
+    notifyResize();
     expect(
       roomyBreakout?.style.getPropertyValue("--md-table-breakout-max"),
     ).toBe("500px");
@@ -149,6 +214,7 @@ describe("MarkdownPreview", () => {
     );
     const rootedBreakout =
       rooted.container.querySelector("table")?.parentElement?.parentElement;
+    notifyResize();
     expect(
       rootedBreakout?.style.getPropertyValue("--md-table-breakout-max"),
     ).toBe("300px");
@@ -156,16 +222,7 @@ describe("MarkdownPreview", () => {
   });
 
   it("skips height-only resize events for tables", () => {
-    let callback: ResizeObserverCallback | null = null;
-    class ResizeObserverMock {
-      constructor(cb: ResizeObserverCallback) {
-        callback = cb;
-      }
-      observe() {}
-      unobserve() {}
-      disconnect() {}
-    }
-    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    const { notifyResize } = mockResizeObserverDeliveries();
     let width = 320;
     vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
       () => ({
@@ -186,17 +243,18 @@ describe("MarkdownPreview", () => {
     );
     const breakout = container.querySelector("table")?.parentElement
       ?.parentElement as HTMLElement;
+    expect(breakout.style.getPropertyValue("--md-content-w")).toBe("");
+    notifyResize();
     expect(breakout.style.getPropertyValue("--md-content-w")).toBe("320px");
-    expect(callback).not.toBeNull();
 
     // Same width, different height: no style write.
     breakout.style.setProperty("--md-content-w", "sentinel");
-    callback!([], {} as ResizeObserver);
+    notifyResize();
     expect(breakout.style.getPropertyValue("--md-content-w")).toBe("sentinel");
 
     // A width change re-measures.
     width = 480;
-    callback!([], {} as ResizeObserver);
+    notifyResize();
     expect(breakout.style.getPropertyValue("--md-content-w")).toBe("480px");
   });
 

--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -1370,6 +1370,116 @@ function setMarkdownContentWidthVariable({
   element.style.setProperty(MARKDOWN_CONTENT_WIDTH_VARIABLE, `${width}px`);
 }
 
+interface MarkdownTableGeometryRegistration {
+  breakout: HTMLElement;
+  clip: HTMLElement | null;
+  content: HTMLElement;
+  lastClipWidth: number;
+  lastContentWidth: number;
+}
+
+type MarkdownTableBreakoutLimitMeasurement =
+  | { kind: "remove" }
+  | { kind: "set"; value: string }
+  | { kind: "unchanged" };
+
+interface MarkdownTableGeometryMeasurement {
+  breakout: HTMLElement;
+  breakoutLimit: MarkdownTableBreakoutLimitMeasurement;
+  contentWidth: number;
+}
+
+const markdownTableRegistrationsByElement = new Map<
+  HTMLElement,
+  Set<MarkdownTableGeometryRegistration>
+>();
+let sharedMarkdownTableResizeObserver: ResizeObserver | null = null;
+
+function measureMarkdownTableGeometry(
+  registrations: Iterable<MarkdownTableGeometryRegistration>,
+): void {
+  // Complete every geometry read before writing either CSS variable. Writing
+  // one table's variables first would make the next table's read recalculate
+  // layout while a long timeline's initial observer delivery is in progress.
+  const measurements: MarkdownTableGeometryMeasurement[] = [];
+  for (const registration of registrations) {
+    const { breakout, clip, content } = registration;
+    const contentWidth = content.getBoundingClientRect().width;
+    const clipWidth = clip?.clientWidth ?? -1;
+    if (
+      contentWidth === registration.lastContentWidth &&
+      clipWidth === registration.lastClipWidth
+    ) {
+      continue;
+    }
+    registration.lastContentWidth = contentWidth;
+    registration.lastClipWidth = clipWidth;
+    measurements.push({
+      breakout,
+      breakoutLimit: readMarkdownTableBreakoutLimit({ breakout, clip }),
+      contentWidth,
+    });
+  }
+
+  for (const { breakout, breakoutLimit, contentWidth } of measurements) {
+    setMarkdownContentWidthVariable({
+      element: breakout,
+      width: contentWidth,
+    });
+    applyMarkdownTableBreakoutLimit({ breakout, measurement: breakoutLimit });
+  }
+}
+
+function getSharedMarkdownTableResizeObserver(): ResizeObserver {
+  sharedMarkdownTableResizeObserver ??= new ResizeObserver((entries) => {
+    const registrations = new Set<MarkdownTableGeometryRegistration>();
+    for (const entry of entries) {
+      if (!(entry.target instanceof HTMLElement)) continue;
+      for (const registration of markdownTableRegistrationsByElement.get(
+        entry.target,
+      ) ?? []) {
+        registrations.add(registration);
+      }
+    }
+    measureMarkdownTableGeometry(registrations);
+  });
+  return sharedMarkdownTableResizeObserver;
+}
+
+function observeMarkdownTableGeometry(
+  registration: MarkdownTableGeometryRegistration,
+): () => void {
+  const elements =
+    registration.clip === null || registration.clip === registration.content
+      ? [registration.content]
+      : [registration.content, registration.clip];
+  const observer = getSharedMarkdownTableResizeObserver();
+  for (const element of elements) {
+    let registrations = markdownTableRegistrationsByElement.get(element);
+    if (!registrations) {
+      registrations = new Set();
+      markdownTableRegistrationsByElement.set(element, registrations);
+      observer.observe(element);
+    }
+    registrations.add(registration);
+  }
+
+  return () => {
+    for (const element of elements) {
+      const registrations = markdownTableRegistrationsByElement.get(element);
+      registrations?.delete(registration);
+      if (registrations?.size === 0) {
+        markdownTableRegistrationsByElement.delete(element);
+        sharedMarkdownTableResizeObserver?.unobserve(element);
+      }
+    }
+    if (markdownTableRegistrationsByElement.size === 0) {
+      sharedMarkdownTableResizeObserver?.disconnect();
+      sharedMarkdownTableResizeObserver = null;
+    }
+  };
+}
+
 function useMarkdownTableContentWidthVariable() {
   const breakoutRef = useRef<HTMLDivElement>(null);
 
@@ -1380,38 +1490,22 @@ function useMarkdownTableContentWidthVariable() {
       return;
     }
     const clip = findHorizontalClipAncestor(content);
-
-    // Streamed text grows the preview and the clip ancestor in height only.
-    // Skip those events: every table would otherwise read layout and write a
-    // style, and the write forces the next table's read to recalculate.
-    let lastContentWidth = -1;
-    let lastClipWidth = -1;
-    const measure = () => {
-      const contentWidth = content.getBoundingClientRect().width;
-      const clipWidth = clip?.clientWidth ?? -1;
-      if (contentWidth === lastContentWidth && clipWidth === lastClipWidth) {
-        return;
-      }
-      lastContentWidth = contentWidth;
-      lastClipWidth = clipWidth;
-      setMarkdownContentWidthVariable({
-        element: breakout,
-        width: contentWidth,
-      });
-      setMarkdownTableBreakoutLimitVariable({ breakout, clip });
+    const registration: MarkdownTableGeometryRegistration = {
+      breakout,
+      clip,
+      content,
+      lastClipWidth: -1,
+      lastContentWidth: -1,
     };
-    measure();
 
     if (typeof ResizeObserver === "undefined") {
+      measureMarkdownTableGeometry([registration]);
       return;
     }
 
-    const observer = new ResizeObserver(measure);
-    observer.observe(content);
-    if (clip) {
-      observer.observe(clip);
-    }
-    return () => observer.disconnect();
+    // The initial observer delivery gives us the geometry before paint without
+    // a synchronous layout read for every table while a long timeline mounts.
+    return observeMarkdownTableGeometry(registration);
   }, []);
 
   return breakoutRef;
@@ -1445,21 +1539,20 @@ function findHorizontalClipAncestor(element: HTMLElement): HTMLElement | null {
 }
 
 /**
- * Sets the widest breakout that keeps the table inside `clip`. The breakout is
- * centered on its containing block (the breakout's parent), so the usable
+ * Reads the widest breakout that keeps the table inside `clip`. The breakout
+ * is centered on its containing block (the breakout's parent), so the usable
  * width is the parent content width plus twice the smaller side gap.
  */
-function setMarkdownTableBreakoutLimitVariable({
+function readMarkdownTableBreakoutLimit({
   breakout,
   clip,
 }: {
   breakout: HTMLElement;
   clip: HTMLElement | null;
-}): void {
+}): MarkdownTableBreakoutLimitMeasurement {
   const parent = breakout.parentElement;
   if (!clip || !parent) {
-    breakout.style.removeProperty(MARKDOWN_TABLE_BREAKOUT_LIMIT_VARIABLE);
-    return;
+    return { kind: "remove" };
   }
   // Positions are taken at scroll offset 0 of `clip`, so a horizontally
   // scrolled container does not change the result.
@@ -1473,7 +1566,7 @@ function setMarkdownTableBreakoutLimitVariable({
     cssPixels(parentStyle.paddingRight);
   const parentWidth = parentRight - parentLeft;
   if (parentWidth <= 0) {
-    return;
+    return { kind: "unchanged" };
   }
   const clipLeft = clip.getBoundingClientRect().left + clip.clientLeft;
   const clipRight = clipLeft + clip.clientWidth;
@@ -1481,10 +1574,24 @@ function setMarkdownTableBreakoutLimitVariable({
     0,
     Math.min(parentLeft - clipLeft, clipRight - parentRight),
   );
-  breakout.style.setProperty(
-    MARKDOWN_TABLE_BREAKOUT_LIMIT_VARIABLE,
-    `${parentWidth + 2 * room}px`,
-  );
+  return { kind: "set", value: `${parentWidth + 2 * room}px` };
+}
+
+function applyMarkdownTableBreakoutLimit({
+  breakout,
+  measurement,
+}: {
+  breakout: HTMLElement;
+  measurement: MarkdownTableBreakoutLimitMeasurement;
+}): void {
+  if (measurement.kind === "remove") {
+    breakout.style.removeProperty(MARKDOWN_TABLE_BREAKOUT_LIMIT_VARIABLE);
+  } else if (measurement.kind === "set") {
+    breakout.style.setProperty(
+      MARKDOWN_TABLE_BREAKOUT_LIMIT_VARIABLE,
+      measurement.value,
+    );
+  }
 }
 
 function cssPixels(value: string): number {


### PR DESCRIPTION
## What was wrong

Timeline messages and Markdown tables performed synchronous initial geometry reads from separate `useLayoutEffect` instances, then repeated those reads when the browser delivered the initial `ResizeObserver` notifications. On a large rendered timeline, the per-component reads and writes repeatedly forced layout instead of letting the browser deliver one geometry batch. The exact-base diagnostic rendered 78 timeline rows, 33 Markdown previews, and 13 wide tables: it observed 80 synchronous message scroll/client-size reads and 26 synchronous Markdown-root rectangle reads before observer delivery.

## What changed

- Modern browsers now use the initial `ResizeObserver` delivery for message overflow and table geometry; synchronous measurement remains only as the no-`ResizeObserver` fallback.
- Markdown table geometry uses one shared observer. Each callback deduplicates affected registrations, completes all content/clip geometry reads, and only then writes `--md-content-w` and `--md-table-breakout-max`.
- Focused tests model initial observer delivery, assert that nothing reads geometry before that delivery, cover shared batching, and retain resize, overflow, clipping, continuation-marker, and cleanup behavior.
- No daemon protocol, CLI, server policy, virtualization, or unrelated performance behavior changes.

This reconstructs assigned source commit `1d23f56a2b4fca7f775fc5a82e38c28c9f10a4a8` on current main. The shared message observer from `5fcb4b3b1` and table clipping from `da1470261` were already upstream. I retained those implementations and adapted the table path to batch the newer clipping geometry; the source commit's per-table observer was therefore not copied literally.

## How you verified

Base/head: `a873435d32dbcf24e28408ae315823c333ed858f` → `bf85e71daed8ba37791e371d6fe27a033720b865`.

Production fixture command:

```sh
pnpm seed:perf -- --data-dir /tmp/bb-perf-pr4/data --reset --projects 1 --threads 1 --events 1400 --seed 41
```

The resulting thread had 1,406 events and 47 completed agent-message items. I appended the same six-column wide Markdown table to each completed agent message, then copied the resulting SQLite fixture for baseline and after. The common desktop path rendered 78 rows / 33 previews / 13 tables / 2,520 DOM elements; compact mobile rendered 33 / 13 / 5 / 1,248. Headline runs used production `pnpm start` servers, DevBrowser-managed Chromium, cold disabled cache on every repetition, 100 ms network latency, 524,288 B/s down, 131,072 B/s up, 4× CPU throttling, one warmup plus seven measured repetitions, and 2,000 ms post-ready settle. Baseline and after were alternated run-by-run while both servers were up; odd/even order was reversed to limit drift. Hardware: Apple M4 Max, 48 GiB RAM, macOS 26.5.1, Node 22.23.1, pnpm 9.15.0.

Median / nearest-rank p95 (with seven samples, p95 is the observed maximum):

| Metric | Desktop baseline | Desktop after | Median delta | Mobile baseline | Mobile after | Median delta |
|---|---:|---:|---:|---:|---:|---:|
| Scripting (ms) | 739.1 / 753.9 | 721.0 / 772.0 | -2.4% | 534.8 / 571.6 | 555.9 / 625.9 | +3.9% |
| Layout (ms) | 125.3 / 180.1 | 84.5 / 87.7 | -32.6% | 59.6 / 66.4 | 47.5 / 51.1 | -20.2% |
| Style recalc (ms) | 545.6 / 560.2 | 554.2 / 580.1 | +1.6% | 260.9 / 322.4 | 257.6 / 297.0 | -1.3% |
| Total task time (ms) | 1,662.4 / 1,769.1 | 1,598.4 / 1,703.6 | -3.9% | 1,086.6 / 1,198.2 | 1,078.5 / 1,238.1 | -0.7% |
| Long task count | 9 / 9 | 9 / 10 | 0 | 4 / 4 | 4 / 4 | 0 |
| Long task total (ms) | 1,112 / 1,126 | 1,027 / 1,086 | -7.6% | 364 / 442 | 428 / 460 | +17.6% |
| Max long task (ms) | 308 / 343 | 245 / 257 | -20.5% | 157 / 164 | 160 / 178 | +1.9% |
| Timeline ready (ms) | 3,555 / 3,575 | 3,492 / 3,563 | -1.8% | 3,393 / 3,419 | 3,381 / 3,418 | -0.4% |
| LCP (ms) | 3,552 / 3,576 | 3,496 / 3,572 | -1.6% | 3,384 / 3,416 | 3,376 / 3,400 | -0.2% |
| Layout count | 46 / 46 | 31 / 32 | -32.6% | 47 / 48 | 42 / 42 | -10.6% |
| Style count | 253 / 260 | 225 / 257 | -11.1% | 248 / 259 | 239 / 242 | -3.6% |
| DOM elements | 2,520 / 2,520 | 2,520 / 2,520 | unchanged | 1,248 / 1,248 | 1,248 / 1,248 | unchanged |

The exact diagnostic moved all targeted message/table reads into observer callbacks and reduced observer delivery from 21 callbacks / 54 entries to 9 / 42. It left the same DOM size. Manual production checks passed for initial desktop render, resizing 1440→900 px, clipped table breakout variables, contained mobile horizontal table overflow (358 px client / 485 px scroll width with no page overflow), and a streaming-style height update/removal (319.375→2,207.5→319.375 px while width/limit stayed 532/580 px).

Validation commands:

```sh
pnpm exec turbo run test --filter=@bb/app --force -- src/components/thread/timeline/GeneratedConversationMessage.test.tsx src/components/thread/timeline/conversation-message-overflow.test.tsx src/components/ui/markdown-preview.test.tsx
pnpm exec turbo run typecheck build --filter=@bb/app --force
pnpm exec turbo run test --filter=@bb/app --force
```

Results: focused 3 files / 37 tests passed; typecheck and production build passed; full app suite 411 files / 3,142 tests passed with 3 skipped.

Caveat: DevBrowser provides Chromium here. The compact/mobile run used Chromium device metrics and touch emulation; Safari/iOS WebKit was not profiled, so these results do not extrapolate to Safari.

Fixes: none (standalone performance follow-up).

> AGENT GENERATED: by GPT-5
