### PR TITLE
Keep sidebar resize off the app-root style path

### DIFF
--- a/apps/app/src/components/layout/AppLayout.sidebar-resize.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.sidebar-resize.test.tsx
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
+import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AppLayout } from "./AppLayout";
+
+const SIDEBAR_WIDTH_STORAGE_KEY = "bb.sidebar.width";
+
+vi.mock("@/components/commands/AppCommandProvider", () => ({
+  useAppCommandHandler: () => {},
+  useAppCommandShortcut: () => null,
+  useIsAppCommandModifierHeld: () => false,
+}));
+
+vi.mock("@/components/sidebar/AppSidebar", async () => {
+  const { Sidebar } = await vi.importActual<
+    typeof import("@/components/ui/sidebar")
+  >("@/components/ui/sidebar");
+  return {
+    AppSidebar: ({
+      onResizeMouseDown,
+    }: {
+      onResizeMouseDown: (event: ReactMouseEvent<HTMLDivElement>) => void;
+    }) => (
+      <Sidebar>
+        <div data-testid="sidebar-body">App sidebar</div>
+        <div data-testid="resize-handle" onMouseDown={onResizeMouseDown} />
+      </Sidebar>
+    ),
+  };
+});
+
+vi.mock("@/hooks/useThreadSplitsEnabled", () => ({
+  useThreadSplitsEnabled: () => false,
+}));
+
+vi.mock("@/hooks/queries/system-queries", () => ({
+  useSystemConfig: () => ({
+    data: {
+      experiments: {
+        claudeCodeMockCliTraffic: false,
+        editMessages: false,
+        newOnboarding: false,
+        providerSessionReaping: false,
+      },
+    },
+  }),
+}));
+
+vi.mock("@/components/project/ProjectActionsProvider", () => ({
+  ProjectActionsProvider: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("@/components/thread/ThreadActionsProvider", () => ({
+  ThreadActionsProvider: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("@/components/dialogs/ProjectPathDialog", () => ({
+  ProjectPathDialog: () => null,
+}));
+
+vi.mock("./AppPageHeader", () => ({
+  HEADER_ICON_BUTTON_CLASS: "header-icon-button",
+  AppPageHeader: () => <header />,
+}));
+
+vi.mock("@/lib/bb-desktop", () => ({
+  BROWSER_SIDEBAR_TRIGGER_INSET_CLASS: "",
+  CHROME_ROW_CLASS: "",
+  DEFAULT_DESKTOP_WINDOW_STATE: { isFullScreen: false },
+  MACOS_CHROME_CONTROL_AXIS_CLASS: "",
+  MACOS_CHROME_CONTROL_NO_DRAG_CLASS: "",
+  MACOS_CHROME_TRAFFIC_LIGHT_AXIS_NUDGE_CLASS: "",
+  MACOS_TRAFFIC_LIGHT_RESERVE_OFFSET_CLASS: "",
+  MACOS_WINDOW_DRAG_CLASS: "",
+  MACOS_WINDOW_NO_DRAG_CLASS: "",
+  getBbDesktopInfo: () => null,
+  shouldReserveMacosTrafficLights: () => false,
+  shouldUseMacosDesktopChrome: () => false,
+}));
+
+vi.mock("@/lib/favicon-color-preference", () => ({
+  useFaviconBadge: vi.fn(),
+}));
+
+vi.mock("@/hooks/useQuickCreateProject", () => ({
+  useQuickCreateProjectController: () => ({
+    hostId: null,
+    hostName: null,
+    isCreating: false,
+    platform: "darwin",
+    projectPathDialog: { onOpenChange: vi.fn(), target: null },
+    submitProjectPath: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/queries/sidebar-navigation-query", () => ({
+  useSidebarNavigation: () => ({
+    data: {
+      sections: [],
+      personalProject: {
+        id: "proj_personal",
+        kind: "personal",
+        name: "Personal",
+        sources: [],
+        threads: [],
+        defaultExecutionOptions: null,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      projects: [],
+    },
+    isError: false,
+    isSuccess: true,
+  }),
+}));
+
+vi.mock("@/hooks/queries/thread-queries", () => ({
+  didThreadDetailBootstrapRefreshAfterMount: () => true,
+  useThread: () => ({ data: undefined }),
+  useThreadDetailBootstrap: () => ({ isError: false, isSuccess: false }),
+  useThreadPendingInteractions: () => ({ data: undefined }),
+  getLatestPendingInteraction: () => null,
+}));
+
+function widthVar(element: Element | null): string {
+  if (!(element instanceof HTMLElement)) throw new Error("missing element");
+  return element.style.getPropertyValue("--sidebar-width");
+}
+
+function getRoot(): HTMLElement {
+  const root = document.querySelector('[data-testid="app-layout-root"]');
+  if (!(root instanceof HTMLElement)) throw new Error("missing app root");
+  return root;
+}
+
+// A resize drag must touch only the two elements that read the width. Writing
+// the live width on the app root (an inherited custom property), or setting
+// `cursor`/`user-select` on body, restyles every element in the document on
+// every frame — in a long thread that was ~50-400 ms per mouse move.
+describe("AppLayout sidebar resize drag", () => {
+  let frameCallbacks: FrameRequestCallback[];
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    frameCallbacks = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      frameCallbacks.push(cb);
+      return frameCallbacks.length;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  function flushFrames() {
+    const callbacks = frameCallbacks;
+    frameCallbacks = [];
+    act(() => {
+      for (const callback of callbacks) callback(0);
+    });
+  }
+
+  function renderLayout() {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <AppLayout>
+          <div data-testid="route-content">Route</div>
+        </AppLayout>
+      </MemoryRouter>,
+    );
+  }
+
+  it("writes the live width on the sidebar gap and panel only, never on the app root or body", () => {
+    window.localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, "320");
+    renderLayout();
+
+    const root = getRoot();
+    const gap = document.querySelector('[data-sidebar="gap"]');
+    const panel = document.querySelector('[data-sidebar="panel"]');
+    expect(widthVar(gap)).toBe("320px");
+    expect(widthVar(panel)).toBe("320px");
+    expect(widthVar(root)).toBe("");
+    const rootStyleBefore = root.getAttribute("style");
+
+    const handle = document.querySelector('[data-testid="resize-handle"]');
+    if (!handle) throw new Error("missing handle");
+    act(() => {
+      fireEvent.mouseDown(handle, { clientX: 320 });
+    });
+    act(() => {
+      fireEvent.mouseMove(window, { clientX: 360 });
+    });
+    flushFrames();
+
+    expect(widthVar(gap)).toBe("360px");
+    expect(widthVar(panel)).toBe("360px");
+    expect(widthVar(root)).toBe("");
+    expect(root.getAttribute("style")).toBe(rootStyleBefore);
+    expect(document.body.style.cursor).toBe("");
+    expect(document.body.style.userSelect).toBe("");
+    // Not committed until mouseup.
+    expect(window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)).toBe("320");
+
+    act(() => {
+      fireEvent.mouseUp(window);
+    });
+
+    expect(widthVar(gap)).toBe("360px");
+    expect(widthVar(panel)).toBe("360px");
+    expect(widthVar(root)).toBe("");
+    expect(window.localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)).toBe("360");
+    expect(document.body.classList.contains("sidebar-resizing")).toBe(false);
+  });
+
+  it("mounts the drag-guard overlay after the app root and gives it the resize cursor", () => {
+    renderLayout();
+    const root = getRoot();
+    expect(
+      document.querySelector('[data-testid="iframe-drag-guard-overlay"]'),
+    ).toBeNull();
+
+    const handle = document.querySelector('[data-testid="resize-handle"]');
+    if (!handle) throw new Error("missing handle");
+    act(() => {
+      fireEvent.mouseDown(handle, { clientX: 320 });
+    });
+
+    const overlay = document.querySelector(
+      '[data-testid="iframe-drag-guard-overlay"]',
+    );
+    if (!overlay) throw new Error("overlay did not mount");
+    expect(overlay.className).toContain("cursor-col-resize");
+    // Inserting a node before a sibling invalidates that sibling's whole
+    // subtree; after it, nothing.
+    expect(
+      root.compareDocumentPosition(overlay) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(root.contains(overlay)).toBe(false);
+
+    act(() => {
+      fireEvent.mouseUp(window);
+    });
+    expect(
+      document.querySelector('[data-testid="iframe-drag-guard-overlay"]'),
+    ).toBeNull();
+  });
+});

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -735,9 +735,11 @@ export function AppLayout({ children }: AppLayoutProps) {
     : "none";
   useFaviconBadge(faviconBadge);
 
-  // Drag-time document state is deliberately minimal. `preventDefault` on the
-  // mousedown stops a text selection from starting, and the drag-guard overlay
-  // (the pointer target for the whole drag) carries the resize cursor. Setting
+  // Drag-time document state is deliberately minimal: only the
+  // `sidebar-resizing` body class (matched by selector, so its invalidation is
+  // scoped to `[data-sidebar]` elements). `preventDefault` on the mousedown
+  // stops a text selection from starting, and the drag-guard overlay (the
+  // pointer target for the whole drag) carries the resize cursor. Setting
   // `user-select` or `cursor` on `body` instead would change an inherited
   // property on the document root and restyle every element on mousedown and
   // again on mouseup.
@@ -810,6 +812,9 @@ export function AppLayout({ children }: AppLayoutProps) {
         window.cancelAnimationFrame(animationFrameRef.current);
         animationFrameRef.current = null;
       }
+      // Unmount mid-drag: drop the in-flight width so a remount shows the
+      // committed one.
+      store.set(sidebarLiveWidthAtom, null);
       resetSidebarResizeDocumentState();
     };
   }, [finishSidebarResize, isSidebarResizing, store]);

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -1,11 +1,11 @@
 import {
-  type CSSProperties,
   type MouseEvent as ReactMouseEvent,
   type Ref,
   type ReactNode,
 } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useAtom, useStore } from "jotai";
+import { flushSync } from "react-dom";
+import { atom, useAtom, useAtomValue, useStore } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import { Link, matchPath, useLocation, useNavigate } from "react-router-dom";
 import type { ProjectResponse } from "@bb/server-contract";
@@ -40,7 +40,6 @@ import {
 } from "@/hooks/queries/thread-queries";
 import { useRouteState } from "@/hooks/useRouteState";
 import { getThreadDisplayTitle } from "@/lib/thread-title";
-import { applyResizeCursor, clearResizeCursor } from "@/lib/resizeCursor";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { ProjectPathDialog } from "@/components/dialogs/ProjectPathDialog";
 import { ProjectActionsMenu } from "@/components/project/ProjectActionsMenu";
@@ -130,6 +129,13 @@ const sidebarWidthAtom = atomWithStorage<number>(
   sidebarWidthStorage,
   { getOnInit: true },
 );
+// The in-flight width while the resize handle is dragged, or null at rest.
+// Written from the drag's animation-frame callback and read only by the
+// bridge below, so a frame of dragging re-renders the bridge and the
+// `Sidebar` element (which writes `--sidebar-width` on the two elements that
+// use it) and nothing else: not AppLayout, not the route subtree, and no
+// ancestor of the thread timeline changes style.
+const sidebarLiveWidthAtom = atom<number | null>(null);
 
 // Held in jotai (rather than as `useState` inside AppLayout) so that toggling
 // the sidebar does not re-render AppLayout — only the small bridge below
@@ -154,24 +160,20 @@ const sidebarOpenAtom = atomWithStorage<boolean>(
 interface SidebarStateBridgeProps {
   className?: string;
   providerRef: Ref<HTMLDivElement>;
-  style: CSSProperties;
   children: ReactNode;
 }
 
 type SidebarResizeMouseEvent = ReactMouseEvent<HTMLDivElement>;
 type SidebarOpenChangeHandler = (open: boolean) => void;
 
-type SidebarProviderStyle = CSSProperties & {
-  "--sidebar-width": string;
-};
-
 function SidebarStateBridge({
   className,
   providerRef,
-  style,
   children,
 }: SidebarStateBridgeProps) {
   const [open, setOpen] = useAtom(sidebarOpenAtom);
+  const sidebarWidth = useAtomValue(sidebarWidthAtom);
+  const sidebarLiveWidth = useAtomValue(sidebarLiveWidthAtom);
   const handleOpenChange = useCallback<SidebarOpenChangeHandler>(
     (nextOpen) => {
       setOpen(nextOpen);
@@ -186,7 +188,7 @@ function SidebarStateBridge({
   return (
     <SidebarProvider
       ref={providerRef}
-      style={style}
+      width={`${sidebarLiveWidth ?? sidebarWidth}px`}
       className={className}
       data-testid="app-layout-root"
       open={open}
@@ -199,8 +201,6 @@ function SidebarStateBridge({
 
 function resetSidebarResizeDocumentState(): void {
   document.body.classList.remove("sidebar-resizing");
-  clearResizeCursor();
-  document.body.style.userSelect = "";
 }
 
 interface SidebarTriggerOverlayProps {
@@ -564,11 +564,12 @@ export function AppLayout({ children }: AppLayoutProps) {
   });
   const hasThreadDetailBootstrapSettled =
     threadDetailBootstrapQuery.isSuccess || threadDetailBootstrapQuery.isError;
-  const [sidebarWidth, setSidebarWidth] = useAtom(sidebarWidthAtom);
+  // The committed width is read and written through the store, not
+  // subscribed to: AppLayout must not re-render when a resize commits.
   const [isSidebarResizing, setIsSidebarResizing] = useState(false);
   const startXRef = useRef(0);
   const startWidthRef = useRef(0);
-  const liveWidthRef = useRef(sidebarWidth);
+  const liveWidthRef = useRef(0);
   const animationFrameRef = useRef<number | null>(null);
   // Plugin pages own the same page header + secondary-panel frame whether they
   // render alone or in a split. Avoid drawing the global header above it.
@@ -580,10 +581,6 @@ export function AppLayout({ children }: AppLayoutProps) {
     desktopInfo,
     windowState: desktopWindowState,
   });
-  const sidebarProviderStyle: SidebarProviderStyle = {
-    "--sidebar-width": `${sidebarWidth}px`,
-  };
-
   const project = projectId
     ? projects?.find((candidate) => candidate.id === projectId)
     : undefined;
@@ -738,17 +735,22 @@ export function AppLayout({ children }: AppLayoutProps) {
     : "none";
   useFaviconBadge(faviconBadge);
 
+  // Drag-time document state is deliberately minimal. `preventDefault` on the
+  // mousedown stops a text selection from starting, and the drag-guard overlay
+  // (the pointer target for the whole drag) carries the resize cursor. Setting
+  // `user-select` or `cursor` on `body` instead would change an inherited
+  // property on the document root and restyle every element on mousedown and
+  // again on mouseup.
   const handleResizeMouseDown = useCallback(
     (event: SidebarResizeMouseEvent) => {
       event.preventDefault();
       setIsSidebarResizing(true);
       startXRef.current = event.clientX;
-      startWidthRef.current = liveWidthRef.current;
+      startWidthRef.current = store.get(sidebarWidthAtom);
+      liveWidthRef.current = startWidthRef.current;
       document.body.classList.add("sidebar-resizing");
-      applyResizeCursor("horizontal");
-      document.body.style.userSelect = "none";
     },
-    [],
+    [store],
   );
 
   const finishSidebarResize = useCallback(() => {
@@ -756,25 +758,27 @@ export function AppLayout({ children }: AppLayoutProps) {
       window.cancelAnimationFrame(animationFrameRef.current);
       animationFrameRef.current = null;
     }
-    providerRef.current?.style.setProperty(
-      "--sidebar-width",
-      `${liveWidthRef.current}px`,
-    );
+    // flushSync so the sidebar is at its final width in the DOM before the
+    // bounds sync below measures it.
+    flushSync(() => {
+      store.set(sidebarWidthAtom, liveWidthRef.current);
+      store.set(sidebarLiveWidthAtom, null);
+    });
     dispatchBrowserViewBoundsSync();
-    setSidebarWidth(liveWidthRef.current);
     setIsSidebarResizing(false);
     resetSidebarResizeDocumentState();
-  }, [setSidebarWidth]);
+  }, [store]);
 
   useEffect(() => {
     if (!isSidebarResizing) return;
 
     const applyLiveWidth = () => {
       animationFrameRef.current = null;
-      providerRef.current?.style.setProperty(
-        "--sidebar-width",
-        `${liveWidthRef.current}px`,
-      );
+      // flushSync commits the new width to the DOM inside this frame, so the
+      // bounds sync measures the moved content rect rather than last frame's.
+      flushSync(() => {
+        store.set(sidebarLiveWidthAtom, liveWidthRef.current);
+      });
       dispatchBrowserViewBoundsSync();
     };
 
@@ -808,11 +812,7 @@ export function AppLayout({ children }: AppLayoutProps) {
       }
       resetSidebarResizeDocumentState();
     };
-  }, [finishSidebarResize, isSidebarResizing]);
-
-  useEffect(() => {
-    liveWidthRef.current = sidebarWidth;
-  }, [sidebarWidth]);
+  }, [finishSidebarResize, isSidebarResizing, store]);
 
   useEffect(() => {
     if (typeof document === "undefined") return;
@@ -823,11 +823,7 @@ export function AppLayout({ children }: AppLayoutProps) {
     <ProjectActionsProvider>
       <ThreadTitleMentionResourcesProvider {...titleMentionResources}>
         <ThreadActionsProvider>
-          <IframeDragGuardOverlay active={isSidebarResizing} />
-          <SidebarStateBridge
-            providerRef={providerRef}
-            style={sidebarProviderStyle}
-          >
+          <SidebarStateBridge providerRef={providerRef}>
             <AppLayoutSidebar
               mode={
                 isGlobalSettingsView
@@ -874,6 +870,10 @@ export function AppLayout({ children }: AppLayoutProps) {
               usesDesktopChrome={usesDesktopChrome}
             />
           </SidebarStateBridge>
+          <IframeDragGuardOverlay
+            active={isSidebarResizing}
+            cursor="col-resize"
+          />
           <ProjectPathDialog
             target={quickCreateProject.projectPathDialog.target}
             pending={quickCreateProject.isCreating}

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -1257,7 +1257,6 @@ export function ThreadSecondaryPanel({
         ],
       )}
     >
-      <IframeDragGuardOverlay active={isSecondaryPanelResizing} />
       {shouldEnableSidebarSplits ? (
         panelSurface
       ) : (
@@ -1515,6 +1514,10 @@ export function ThreadSecondaryPanel({
           </div>
         </>
       )}
+      <IframeDragGuardOverlay
+        active={isSecondaryPanelResizing}
+        cursor="col-resize"
+      />
     </aside>
   );
 

--- a/apps/app/src/components/secondary-panel/useSecondaryPanelResize.ts
+++ b/apps/app/src/components/secondary-panel/useSecondaryPanelResize.ts
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 import type { ImperativePanelHandle } from "react-resizable-panels";
 import { useResizeObserver } from "usehooks-ts";
-import { applyResizeCursor, clearResizeCursor } from "@/lib/resizeCursor";
 import {
   secondaryPanelWidthPercentAtom,
   threadSecondaryPanelResizingAtom,
@@ -70,7 +69,6 @@ export function useSecondaryPanelResize({
     isSecondaryPanelDraggingRef.current = false;
     setIsSecondaryPanelDragging(false);
     setIsResizing(false);
-    clearResizeCursor();
 
     // Drag finished — persist the user's chosen width.
     if (lastSecondaryPanelSizeRef.current > 0) {
@@ -84,8 +82,9 @@ export function useSecondaryPanelResize({
         if (isDragging) {
           isSecondaryPanelDraggingRef.current = true;
           setIsSecondaryPanelDragging(true);
+          // The drag-guard overlay that `isResizing` mounts carries the
+          // resize cursor; nothing is written on body.
           setIsResizing(true);
-          applyResizeCursor("horizontal");
           return;
         }
 
@@ -101,7 +100,6 @@ export function useSecondaryPanelResize({
       }
       isSecondaryPanelDraggingRef.current = false;
       setIsResizing(false);
-      clearResizeCursor();
     },
     [setIsResizing],
   );

--- a/apps/app/src/components/ui/sidebar.test.tsx
+++ b/apps/app/src/components/ui/sidebar.test.tsx
@@ -331,6 +331,30 @@ describe("mobile sidebar deferred realization", () => {
     expect(getMobilePanel()?.textContent).toContain("Sidebar content");
   });
 
+  // The width is an inherited custom property unless registered otherwise
+  // (theme.css registers it non-inherited). Either way it must be written on
+  // the elements that read it and never on the provider wrapper: the wrapper
+  // is the app root, and a per-frame change there restyles the whole app.
+  it("writes the desktop width on the gap and panel, not on the provider wrapper", () => {
+    render(
+      <CompactViewportOverrideProvider isCompactViewport={false}>
+        <SidebarProvider width="333px" data-testid="wrapper">
+          <Sidebar>Sidebar content</Sidebar>
+        </SidebarProvider>
+      </CompactViewportOverrideProvider>,
+    );
+
+    const wrapper = screen.getByTestId("wrapper");
+    const gap = document.querySelector('[data-sidebar="gap"]');
+    const panel = document.querySelector('[data-sidebar="panel"]');
+    if (!(gap instanceof HTMLElement) || !(panel instanceof HTMLElement)) {
+      throw new Error("Expected desktop gap and panel");
+    }
+    expect(gap.style.getPropertyValue("--sidebar-width")).toBe("333px");
+    expect(panel.style.getPropertyValue("--sidebar-width")).toBe("333px");
+    expect(wrapper.style.getPropertyValue("--sidebar-width")).toBe("");
+  });
+
   it("renders the desktop sidebar subtree synchronously", () => {
     const markup = renderToString(
       <CompactViewportOverrideProvider isCompactViewport={false}>

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -836,10 +836,7 @@ const Sidebar = React.forwardRef<
     } = useSidebar();
     const width = React.useContext(SidebarWidthContext);
     // Written on the consuming elements themselves (see SidebarWidthContext).
-    const widthStyle = React.useMemo<React.CSSProperties>(
-      () => ({ "--sidebar-width": width }) as React.CSSProperties,
-      [width],
-    );
+    const widthStyle = { "--sidebar-width": width } as React.CSSProperties;
     const handleOpenMobileChange = React.useCallback(
       (nextOpen: boolean) => {
         if (nextOpen) {

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -471,6 +471,17 @@ type SidebarContext = {
 const SidebarContext = React.createContext<SidebarContext | null>(null);
 
 /**
+ * The desktop sidebar width, as a CSS length. Its own context (not a field of
+ * {@link SidebarContext}) because a resize drag updates it on every animation
+ * frame, and only {@link Sidebar} needs to re-render for that. `Sidebar` writes
+ * it as `--sidebar-width` directly on the two elements that consume it, never
+ * on an ancestor: `--sidebar-width` is registered as non-inherited in
+ * theme.css, so a per-frame change restyles those two elements instead of the
+ * whole app subtree.
+ */
+const SidebarWidthContext = React.createContext<string>(SIDEBAR_WIDTH);
+
+/**
  * "Is the sidebar visible" as its own boolean context. The full
  * {@link SidebarContext} value changes on every provider commit (the mobile
  * close flips the closing flag, then four states), and its readers include
@@ -536,6 +547,8 @@ const SidebarProvider = React.forwardRef<
     defaultOpen?: boolean;
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
+    /** Desktop sidebar width as a CSS length. Defaults to 16rem. */
+    width?: string;
   }
 >(
   (
@@ -543,6 +556,7 @@ const SidebarProvider = React.forwardRef<
       defaultOpen = true,
       open: openProp,
       onOpenChange: setOpenProp,
+      width = SIDEBAR_WIDTH,
       className,
       style,
       children,
@@ -753,33 +767,34 @@ const SidebarProvider = React.forwardRef<
     return (
       <SidebarContext.Provider value={contextValue}>
         <SidebarShowingContext.Provider value={isSidebarShowing}>
-          {/* Match the agent message action bar's tooltip timing (300ms open
+          <SidebarWidthContext.Provider value={width}>
+            {/* Match the agent message action bar's tooltip timing (300ms open
             delay + Radix's default skip window) so sidebar icon tooltips feel
             the same instead of flashing instantly on hover. disableHoverableContent
             dismisses the tooltip the moment the pointer leaves the trigger, so it
             never lingers/floats while the mouse moves on. */}
-          <TooltipProvider delayDuration={300} disableHoverableContent>
-            <div
-              style={
-                {
-                  "--sidebar-width": SIDEBAR_WIDTH,
-                  "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
-                  ...style,
-                } as React.CSSProperties
-              }
-              className={cn(
-                // Fill the app root instead of re-measuring the viewport here.
-                // app.css owns the browser-mode-specific root height, while fixed
-                // sidebar panels read the shared --bb-shell-height override.
-                "group/sidebar-wrapper flex h-full min-h-0 w-full has-[[data-variant=inset]]:bg-sidebar",
-                className,
-              )}
-              ref={ref}
-              {...props}
-            >
-              {children}
-            </div>
-          </TooltipProvider>
+            <TooltipProvider delayDuration={300} disableHoverableContent>
+              <div
+                style={
+                  {
+                    "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+                    ...style,
+                  } as React.CSSProperties
+                }
+                className={cn(
+                  // Fill the app root instead of re-measuring the viewport here.
+                  // app.css owns the browser-mode-specific root height, while fixed
+                  // sidebar panels read the shared --bb-shell-height override.
+                  "group/sidebar-wrapper flex h-full min-h-0 w-full has-[[data-variant=inset]]:bg-sidebar",
+                  className,
+                )}
+                ref={ref}
+                {...props}
+              >
+                {children}
+              </div>
+            </TooltipProvider>
+          </SidebarWidthContext.Provider>
         </SidebarShowingContext.Provider>
       </SidebarContext.Provider>
     );
@@ -819,6 +834,12 @@ const Sidebar = React.forwardRef<
       suppressMobileCloseAnimation,
       setSuppressMobileCloseAnimation,
     } = useSidebar();
+    const width = React.useContext(SidebarWidthContext);
+    // Written on the consuming elements themselves (see SidebarWidthContext).
+    const widthStyle = React.useMemo<React.CSSProperties>(
+      () => ({ "--sidebar-width": width }) as React.CSSProperties,
+      [width],
+    );
     const handleOpenMobileChange = React.useCallback(
       (nextOpen: boolean) => {
         if (nextOpen) {
@@ -870,7 +891,7 @@ const Sidebar = React.forwardRef<
             className,
           )}
           ref={ref}
-          style={style}
+          style={{ ...widthStyle, ...style }}
           {...props}
         >
           {children}
@@ -918,6 +939,7 @@ const Sidebar = React.forwardRef<
         {/* This is what handles the sidebar gap on desktop */}
         <div
           data-sidebar="gap"
+          style={widthStyle}
           className={cn(
             "relative hidden h-full w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear md:block",
             "group-data-[collapsible=offcanvas]:w-0",
@@ -946,7 +968,7 @@ const Sidebar = React.forwardRef<
               : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) border-border-seam group-data-[side=left]:border-r group-data-[side=right]:border-l",
             className,
           )}
-          style={style}
+          style={{ ...widthStyle, ...style }}
           {...props}
         >
           <div

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -914,6 +914,22 @@
   }
 }
 
+/*
+ * Non-inherited on purpose. The sidebar resize drag rewrites this length on
+ * every animation frame; an inherited custom property change makes the
+ * engine restyle every descendant of the element it is set on (measured at
+ * ~20-45 µs per element, so a long thread cost 50-400 ms per frame).
+ * `Sidebar` therefore sets it directly on the two elements that read it (the
+ * desktop gap and panel), and a change touches only those. The initial value
+ * mirrors the 16rem default in sidebar.tsx (`@property` requires an absolute
+ * length here).
+ */
+@property --sidebar-width {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 256px;
+}
+
 body.sidebar-resizing [data-sidebar="gap"],
 body.sidebar-resizing [data-sidebar="panel"] {
   transition-duration: 0ms !important;

--- a/apps/app/src/components/ui/theme.test.ts
+++ b/apps/app/src/components/ui/theme.test.ts
@@ -141,9 +141,7 @@ describe("theme.css neutral ramp", () => {
     expect(rule).toContain(
       "linear-gradient(var(--state-active), var(--state-active))",
     );
-    expect(rule).toContain(
-      "linear-gradient(var(--sidebar), var(--sidebar))",
-    );
+    expect(rule).toContain("linear-gradient(var(--sidebar), var(--sidebar))");
   });
 
   it("resolves the open-in-split thread tint to an opaque sidebar color", () => {
@@ -320,6 +318,21 @@ describe("theme.css desktop portal hit testing", () => {
     expect(rule).toBeDefined();
     expect(rule).toMatch(/(?:^|\s)app-region:\s*no-drag;/);
     expect(rule).toMatch(/-webkit-app-region:\s*no-drag;/);
+  });
+});
+
+// The sidebar resize drag rewrites --sidebar-width every frame. Registered
+// non-inherited, the change restyles only the elements it is set on; inherited,
+// it restyles their whole subtrees (AppLayout.sidebar-resize.test.tsx covers
+// where it is set).
+describe("theme.css sidebar width registration", () => {
+  it("registers --sidebar-width as a non-inherited length", () => {
+    const rule = css.match(/@property --sidebar-width\s*\{([^}]*)\}/)?.[1];
+
+    expect(rule).toBeDefined();
+    expect(rule).toMatch(/syntax:\s*"<length>";/);
+    expect(rule).toMatch(/inherits:\s*false;/);
+    expect(rule).toMatch(/initial-value:\s*\d+px;/);
   });
 });
 

--- a/apps/app/src/lib/iframe-drag-guard.tsx
+++ b/apps/app/src/lib/iframe-drag-guard.tsx
@@ -1,5 +1,14 @@
+import { cn } from "@bb/shared-ui/lib/utils";
+
 export interface IframeDragGuardOverlayProps {
   active: boolean;
+  /**
+   * Cursor to show for the whole drag. The overlay is the pointer target for
+   * the duration of the drag, so the cursor lives here rather than on `body`:
+   * `cursor` is inherited, and setting it on `body` restyles every element in
+   * the document (hundreds of milliseconds in a long thread).
+   */
+  cursor: "col-resize" | "row-resize";
 }
 
 /**
@@ -16,8 +25,17 @@ export interface IframeDragGuardOverlayProps {
  * pointer target, while its `pointer-events` stay untouched. `position: fixed`
  * means it covers everything regardless of where it mounts and is not clipped
  * by an ancestor's `overflow`.
+ *
+ * Mount it AFTER its large siblings, never before them. Mounting and
+ * unmounting an element invalidates the style of every following sibling's
+ * subtree; placed before the app root, the toggle at drag start and drag end
+ * restyled the whole app (~400 ms in a long thread). Placed last it costs
+ * nothing, and `fixed` plus the same z-index keeps it on top either way.
  */
-export function IframeDragGuardOverlay({ active }: IframeDragGuardOverlayProps) {
+export function IframeDragGuardOverlay({
+  active,
+  cursor,
+}: IframeDragGuardOverlayProps) {
   if (!active) {
     return null;
   }
@@ -25,7 +43,10 @@ export function IframeDragGuardOverlay({ active }: IframeDragGuardOverlayProps) 
     <div
       aria-hidden
       data-testid="iframe-drag-guard-overlay"
-      className="fixed inset-0 z-50"
+      className={cn(
+        "fixed inset-0 z-50",
+        cursor === "col-resize" ? "cursor-col-resize" : "cursor-row-resize",
+      )}
     />
   );
 }

--- a/apps/app/src/lib/resizeCursor.ts
+++ b/apps/app/src/lib/resizeCursor.ts
@@ -29,6 +29,10 @@ const RESIZE_CURSOR_BY_ORIENTATION: Record<ResizeOrientation, string> = {
  * drag over panel content rather than the 1px handle, so the handle's own hover
  * cursor no longer applies — the body cursor is what keeps the splitter cursor
  * visible while dragging.
+ *
+ * `cursor` is inherited, so writing it on body restyles every element in the
+ * document at drag start and end. Drags that mount an `IframeDragGuardOverlay`
+ * should pass the cursor to the overlay instead and not call this.
  */
 export function applyResizeCursor(orientation: ResizeOrientation): void {
   document.body.style.cursor = RESIZE_CURSOR_BY_ORIENTATION[orientation];


### PR DESCRIPTION
## What was wrong

Dragging the left sidebar in a long thread was slow (DevTools profile: 2.2 s of style recalculation, ~50 ms per frame, vs 78 ms of layout). Three things in `AppLayout` each forced a restyle of the whole document:

1. Per frame: the live width was written as `--sidebar-width` on the app root (`SidebarProvider`). A custom property is inherited, so a change on the root invalidates every descendant, including the timeline. Cost scales with thread size (~20–45 µs per element).
2. At mousedown/mouseup: `body.style.userSelect` and `body.style.cursor` (both inherited) → two more full restyles each.
3. At mousedown/mouseup: `IframeDragGuardOverlay` mounted as a sibling *before* the app root. Inserting/removing a node invalidates every following sibling's subtree → one more full restyle each.

Items 1–2 date from the initial sidebar implementation; item 3 came with the iframe guard (#57). Nothing regressed recently; it only becomes visible in large threads.

## What changed

- `ui/sidebar.tsx`: new `SidebarWidthContext` and a `width` prop on `SidebarProvider`. `Sidebar` writes `--sidebar-width` directly on the two elements that read it (gap and panel), not on the wrapper.
- `ui/theme.css`: `@property --sidebar-width { inherits: false }`, so a change restyles only those two elements.
- `layout/AppLayout.tsx`: the live width flows through a non-persisted `sidebarLiveWidthAtom`; only the bridge and `Sidebar` re-render per frame (`flushSync` keeps the browser-view bounds sync measuring the updated DOM). Removed body `cursor`/`user-select`: mousedown `preventDefault` already blocks selection, and the overlay now carries the resize cursor. The overlay mounts after the app root.
- `lib/iframe-drag-guard.tsx`: required `cursor` prop, placement note. `ThreadSecondaryPanel` moves its overlay after the panel content for the same reason.

## How you verified

Repro: dev app with `pnpm seed:perf -- --projects 2 --threads 20 --events 60000`, open the 9k-event thread in headless Chromium, scroll to the top until ~20k DOM elements are mounted, run a 60-step scripted drag on the resize handle under a CDP trace.

| | Style recalcs | Recalc total | Max per recalc | Elements/recalc | Layout total |
|---|---|---|---|---|---|
| Before | 50 | 19,444 ms | 419 ms | 19,423 | 1,087 ms |
| After | 2 | 5 ms | 2.9 ms | 31 | 199 ms |

Manual checks in the browser: width tracks the drag, commits to localStorage and survives reload, collapse/expand still works, no text selection during drag, overlay shows `col-resize`.

Tests (fail before, pass after): `AppLayout.sidebar-resize.test.tsx` (drag writes only gap/panel, never root or body; overlay mounts after the root with the cursor), `sidebar.test.tsx` (width lands on gap/panel, not the wrapper), `theme.test.ts` (`@property` non-inherited). `pnpm exec turbo run typecheck lint --filter=@bb/app` passes; 110 test files / 888 tests pass in the touched areas.

> AGENT GENERATED: by Claude Opus 5