### PR TITLE
Harden plugin validation and hot reload paths

### DIFF
--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -160,6 +160,18 @@ export interface PluginSkillRootContribution {
   rootPath: string;
 }
 
+/**
+ * `fs.watch` is allowed to omit the changed filename. The dev loop still has
+ * to reload in that case; `.` is a non-ignored synthetic path representing an
+ * unknown change somewhere below the watched plugin root.
+ */
+export function dispatchPluginSourceWatchChange(
+  handleChange: (relativePath: string) => void,
+  filename: string | null,
+): void {
+  handleChange(filename === null || filename.length === 0 ? "." : filename);
+}
+
 export interface PluginService {
   /** Whether this installed plugin has builtin provenance. */
   isBuiltin(id: string): boolean;
@@ -1573,9 +1585,7 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
             bundled.rootDir,
             { recursive: true },
             (_event, filename) => {
-              if (typeof filename === "string" && filename.length > 0) {
-                loop.handleChange(filename);
-              }
+              dispatchPluginSourceWatchChange(loop.handleChange, filename);
             },
           );
           watcher.on("close", () => loop.dispose());

--- a/apps/server/test/services/plugins/builtin-plugins.test.ts
+++ b/apps/server/test/services/plugins/builtin-plugins.test.ts
@@ -22,6 +22,7 @@ import { PLUGIN_SDK_MAJOR, PLUGIN_SDK_VERSION } from "@bb/domain";
 import type { Logger } from "@bb/logger";
 import {
   createPluginService,
+  dispatchPluginSourceWatchChange,
   type PluginService,
 } from "../../../src/services/plugins/plugin-service.js";
 import { readPluginManifest } from "../../../src/services/plugins/manifest.js";
@@ -178,6 +179,14 @@ describe("builtin plugin reconciliation", () => {
   let db: DbConnection;
   let workDir: string;
   let service: PluginService | undefined;
+
+  it("reloads when the source watcher omits the changed filename", () => {
+    const changes: string[] = [];
+
+    dispatchPluginSourceWatchChange((path) => changes.push(path), null);
+
+    expect(changes).toEqual(["."]);
+  });
 
   beforeEach(async () => {
     delete globals.__builtinFixtureLoads;

--- a/apps/server/test/services/plugins/plugin-service.test.ts
+++ b/apps/server/test/services/plugins/plugin-service.test.ts
@@ -622,7 +622,7 @@ describe("plugin service", () => {
       "warn plugin notify not loaded (incompatible): requires bb >=0.38.0 <0.39.0, this is 0.39.0",
     );
     await after.stop();
-  });
+  }, 15_000);
 
   it("skips the engines gate on 0.0.0 dev builds instead of marking everything incompatible", async () => {
     const devService = createPluginService({

--- a/apps/server/test/services/plugins/plugin-service.test.ts
+++ b/apps/server/test/services/plugins/plugin-service.test.ts
@@ -9,7 +9,12 @@ import {
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createConnection, migrate, type DbConnection } from "@bb/db";
+import {
+  createConnection,
+  migrate,
+  upsertInstalledPlugin,
+  type DbConnection,
+} from "@bb/db";
 import type { SystemChangeKind } from "@bb/domain";
 import type { Logger } from "@bb/logger";
 import {
@@ -594,6 +599,7 @@ describe("plugin service", () => {
         dataDir: join(workDir, "data"),
         appVersion,
         loadTimeoutMs: 2000,
+        bundledPlugins: [],
       });
     const rootDir = await writePlugin(workDir, {
       name: "bb-plugin-notify",
@@ -602,13 +608,26 @@ describe("plugin service", () => {
       serverSource: `export default function plugin() {}`,
     });
 
-    // bb 0.38.5: the plugin installs, loads, and the server logs it.
-    const before = makeService("0.38.5");
-    const installed = await before.installPath(rootDir);
-    expect(installed.status).toBe("running");
-    expect(lines).toContain("info plugin notify@0.2.1 loaded");
-    await before.stop();
-    lines.length = 0;
+    // Persist the registration left behind by bb 0.38.5. Loading plugin source
+    // belongs to install-path coverage; this regression is specifically about
+    // compatibility being re-evaluated when the host version changes.
+    upsertInstalledPlugin(db, {
+      id: "notify",
+      source: `path:${rootDir}`,
+      provenance: { kind: "direct" },
+      sourceIntent: { kind: "path", canonicalPath: rootDir },
+      exactResolution: { kind: "path" },
+      updateState: {
+        lastCheckAt: null,
+        availableCompatibleVersion: null,
+        newestIncompatibleVersion: null,
+        statusDetail: null,
+      },
+      activeArtifactId: null,
+      rootDir,
+      version: "0.2.1",
+      enabled: true,
+    });
 
     // bb 0.39.0 starts against the same database (= the user upgraded bb).
     const after = makeService("0.39.0");
@@ -622,7 +641,7 @@ describe("plugin service", () => {
       "warn plugin notify not loaded (incompatible): requires bb >=0.38.0 <0.39.0, this is 0.39.0",
     );
     await after.stop();
-  }, 15_000);
+  });
 
   it("skips the engines gate on 0.0.0 dev builds instead of marking everything incompatible", async () => {
     const devService = createPluginService({

--- a/packages/plugin-build/src/build-plugin-app.test.ts
+++ b/packages/plugin-build/src/build-plugin-app.test.ts
@@ -413,8 +413,18 @@ describe("plugin app runtime shim", () => {
       'export const ownUnimported = "leading-tight";\n',
     );
 
+    // Build through another symlink too. On platforms where the temp root is
+    // not itself an alias, this still proves the metafile and Tailwind scan
+    // compare canonical paths rather than two spellings of the same file.
+    const aliasContainer = await mkdtemp(
+      join(tmpdir(), "bb-plugin-scan-alias-"),
+    );
+    tempDirs.push(aliasContainer);
+    const aliasedRoot = join(aliasContainer, "fixture");
+    await symlink(dir, aliasedRoot);
+
     const result = await buildPluginApp(
-      pluginDir,
+      join(aliasedRoot, "plugin"),
       "0.9.0-test",
       await testToolchain(),
     );

--- a/packages/plugin-build/src/build-plugin-app.ts
+++ b/packages/plugin-build/src/build-plugin-app.ts
@@ -569,17 +569,23 @@ async function buildTailwindCss(
  * Absolute paths of every file esbuild bundled into app.js, from its
  * metafile. Runtime shims and disabled modules are virtual and skipped.
  */
-function bundledInputPaths(
+async function bundledInputPaths(
   metafile: Metafile,
   absWorkingDir: string,
-): Set<string> {
+): Promise<Set<string>> {
   const paths = new Set<string>();
-  for (const input of Object.keys(metafile.inputs)) {
-    if (input.startsWith(`${SHIM_NAMESPACE}:`) || input.startsWith("(")) {
-      continue;
-    }
-    paths.add(resolve(absWorkingDir, input));
-  }
+  await Promise.all(
+    Object.keys(metafile.inputs).map(async (input) => {
+      if (input.startsWith(`${SHIM_NAMESPACE}:`) || input.startsWith("(")) {
+        return;
+      }
+      // The Tailwind scanner resolves dependency roots through realpath.
+      // Normalize esbuild's inputs the same way so OS path aliases (macOS
+      // exposes /tmp through /private/tmp) and symlinked plugin roots cannot
+      // make a bundled dependency look absent from the metafile.
+      paths.add(await realpath(resolve(absWorkingDir, input)));
+    }),
+  );
   return paths;
 }
 
@@ -679,7 +685,7 @@ export async function buildPluginApp(
         rootDir,
         pluginId,
         toolchain,
-        bundledInputPaths(bundle.metafile, rootDir),
+        await bundledInputPaths(bundle.metafile, rootDir),
       )
     ).trimEnd();
     // Tailwind's own optimizer (lightningcss, the same pass the host's Vite


### PR DESCRIPTION
## What was wrong

The full validation pass exposed three independent boundary and fixture defects: esbuild metafile inputs and Tailwind scanner dependencies could use different canonical path spellings on macOS or through symlinked plugin roots, causing opted-in dependency CSS to be omitted; `fs.watch` events without a filename were silently dropped, so a builtin source edit could miss hot reload; and the host-upgrade compatibility regression fixture loaded every real bundled plugin and timed out under full-suite contention.

## What changed

- Canonicalize every bundled esbuild input with `realpath` before intersecting it with Tailwind dependency scans, with a symlinked-root regression fixture.
- Treat a filename-less builtin source watch event as an unknown change below the plugin root so the normal debounced reload path still runs.
- Persist the minimal installed-plugin row needed by the host-upgrade compatibility test and disable unrelated bundled plugins in that fixture.
- No host-daemon wire contract, CLI surface, guide, or configuration behavior changed.

## How you verified

- `pnpm lint` — passed with 0 errors (144 existing warnings).
- `pnpm build` — 12/12 Turbo tasks passed.
- `pnpm typecheck` — 69/69 Turbo tasks passed.
- `pnpm test` — 65/65 Turbo tasks passed, including 25 fake integration files / 55 tests.
- `pnpm test:integration` — 64 agent-runtime real-provider tests and 11 server/daemon E2E tests passed across Codex, Claude Code, and Pi.
- Forced `@bb/server` stress run — 191 files / 1,786 tests passed together.
- Completed `qa/manual-runbook.md` against an isolated standalone server and daemon: attachments, parent/child threads, shared and managed environments, archive lifecycle, daemon restart/offline/hot-replace recovery, all provider passes, and approve/deny/grant interactions passed. SQLite integrity returned `ok`; the final log audit found no unexpected fatal or protocol-mismatch signatures.
- After rebasing onto current `main`, forced typechecks for `@bb/server` and `@bb/plugin-build`, the complete `@bb/plugin-build` test suite, and both affected server test files all passed.

Fixes #1915 (regression hardening; the issue was already closed)

> AGENT GENERATED: by GPT-5 Codex
