### PR TITLE
Fix main: drop the removed claudeCodeMockCliTraffic experiment from mobile

### DIFF
--- a/apps/mobile/e2e/scripts/phase7-settings-reset.js
+++ b/apps/mobile/e2e/scripts/phase7-settings-reset.js
@@ -5,7 +5,6 @@ const headers = { "Content-Type": "application/json" };
 const experiments = http.put(`${SERVER_URL}/api/v1/settings/experiments`, {
   headers,
   body: JSON.stringify({
-    claudeCodeMockCliTraffic: false,
     editMessages: true,
     mobileApp: false,
     newOnboarding: false,

--- a/apps/mobile/src/screens/settings/ExperimentsSettingsScreen.tsx
+++ b/apps/mobile/src/screens/settings/ExperimentsSettingsScreen.tsx
@@ -16,12 +16,6 @@ interface ExperimentRow {
 /** Same copy as the web Experiments section (SettingsView.tsx). */
 const EXPERIMENT_ROWS: readonly ExperimentRow[] = [
   {
-    key: "claudeCodeMockCliTraffic",
-    label: "Mock CLI Traffic",
-    badge: "dev-only",
-    description: "Route Claude Code through CLI-style traffic.",
-  },
-  {
     key: "editMessages",
     label: "Edit messages",
     description:


### PR DESCRIPTION
## What was wrong

#1993 removed the `claudeCodeMockCliTraffic` experiment key from `@bb/domain` while #1988 (the mobile app) was in flight. After both merged, `main` fails `@bb/mobile` typecheck: `apps/mobile/src/screens/settings/ExperimentsSettingsScreen.tsx` still lists the key, and `apps/mobile/e2e/scripts/phase7-settings-reset.js` still PUTs it to `/api/v1/settings/experiments` (the experiments record is exhaustive under zod 4, so the reset would 400 and the nightly Mobile E2E would fail).

## What changed

- Removed the row from the mobile Experiments screen.
- Removed the key from the e2e settings-reset payload.

## How you verified

- `pnpm exec turbo run typecheck lint test --filter=@bb/mobile` on `main` + this change: all green (119 test files). Typecheck fails on `main` without it.
- `git grep claudeCodeMockCliTraffic` leaves only historical migration/test references.

> AGENT GENERATED: by Claude Opus 5