### PR TITLE
Fix symlinked dependency Tailwind source matching

### DIFF
--- a/packages/plugin-build/src/build-plugin-app.test.ts
+++ b/packages/plugin-build/src/build-plugin-app.test.ts
@@ -346,7 +346,7 @@ describe("plugin app runtime shim", () => {
     expect(readableCss.length).toBeGreaterThan(minifiedCss.length);
   });
 
-  it("scans only the bundled files of a dependency that opts into Tailwind content", async () => {
+  it("scans bundled Tailwind content from a symlinked workspace dependency by filesystem identity", async () => {
     const dir = await mkdtemp(join(tmpdir(), "bb-plugin-scan-"));
     tempDirs.push(dir);
     // The dependency lives outside node_modules behind a symlink, the way a
@@ -354,6 +354,7 @@ describe("plugin app runtime shim", () => {
     // reports the real path, so the scan must match on real paths too.
     const uiPackageDir = join(dir, "packages", "fixture-ui");
     await mkdir(join(uiPackageDir, "src", "excluded"), { recursive: true });
+    await mkdir(join(uiPackageDir, "actual-src"), { recursive: true });
     await writeFile(
       join(uiPackageDir, "package.json"),
       JSON.stringify({
@@ -364,8 +365,15 @@ describe("plugin app runtime shim", () => {
       }),
     );
     await writeFile(
-      join(uiPackageDir, "src", "used.ts"),
+      join(uiPackageDir, "actual-src", "used.ts"),
       'export const usedClass = "tracking-widest";\n',
+    );
+    // A workspace package may itself expose generated/shared source through a
+    // symlink. Tailwind reports the matched link while esbuild reports its
+    // target, so both sides must be compared by filesystem identity.
+    await symlink(
+      "../actual-src/used.ts",
+      join(uiPackageDir, "src", "used.ts"),
     );
     await writeFile(
       join(uiPackageDir, "src", "unused.ts"),

--- a/packages/plugin-build/src/build-plugin-app.ts
+++ b/packages/plugin-build/src/build-plugin-app.ts
@@ -545,10 +545,19 @@ async function buildTailwindCss(
   const dependencySources = await readDependencyTailwindSources(rootDir);
   if (dependencySources.length > 0) {
     // `files` resolves the globs without reading anything; only the bundled
-    // subset is read and scanned.
-    const bundledDependencyFiles = new Scanner({
-      sources: dependencySources,
-    }).files.filter((file) => bundledInputs.has(file));
+    // subset is read and scanned. Compare by filesystem identity: a workspace
+    // package can itself expose source through a symlink, in which case the
+    // scanner reports the link while esbuild reports its target.
+    const dependencyFileIdentities = await Promise.all(
+      new Scanner({ sources: dependencySources }).files.map((file) =>
+        realpath(file),
+      ),
+    );
+    const bundledDependencyFiles = [
+      ...new Set(
+        dependencyFileIdentities.filter((file) => bundledInputs.has(file)),
+      ),
+    ];
     const contents = await Promise.all(
       bundledDependencyFiles.map(async (file) => ({
         content: await readFile(file, "utf8"),


### PR DESCRIPTION
## What was wrong

Plugin-build already canonicalized esbuild metafile inputs and dependency package roots, but Tailwind's scanner can still return a symlink path for a matched source file while esbuild records the symlink target. The raw string intersection treated those two spellings of the same file as different, so a bundled workspace/package-manager dependency that declared `bb.pluginTailwindContent` could silently lose utilities used from symlinked source entries.

## What changed

- Canonicalize every Tailwind-matched dependency file with `realpath` before intersecting it with the already-canonical esbuild input set, and deduplicate files by filesystem identity.
- Harden the real plugin-build fixture so the plugin consumes a workspace dependency linked through `node_modules`, that dependency declares `bb.pluginTailwindContent`, and its bundled source entry is itself a symlink. The test still verifies that unbundled and explicitly excluded dependency files do not add utilities.
- No host-daemon wire contract, public plugin API, CLI/configuration surface, guide, or runtime CSS scoping behavior changed; no protocol bump or migration is needed.

## How you verified

Regression proof against the exact baseline:

- Baseline: freshly fetched `origin/main` at `6b7c58fd1bac2bad20c5d6beed3d0c1032824e82`.
- With only the strengthened test applied, `pnpm exec turbo run test --filter=@bb/plugin-build --force` failed because generated `app.css` did not contain `.tracking-widest{`.
- With the fix applied, `pnpm exec turbo run typecheck test --filter=@bb/plugin-build --force` passed all 8 Turbo tasks; plugin-build reported 7 test files passed, 41 tests passed, and 1 existing toolchain/platform skip.
- `git diff --check` passed.

Isolated before/after profile:

- Device/configuration: Mac16,6 (Apple M4 Max, 48 GiB), arm64, macOS 26.5.1 (25F80), Node 26.3.1, pnpm 9.15.0.
- Scenario: a minified `buildPluginApp` of the same temporary fixture used by the regression: symlinked plugin root, workspace dependency linked through `node_modules`, dependency `bb.pluginTailwindContent: ["src/**/*"]`, and a bundled `src/used.ts` symlink targeting `actual-src/used.ts`.
- Method: one excluded warmup followed by 10 measured builds in one process for each revision. Wall time came from `performance.now()`, CPU/max RSS from `process.resourceUsage()`, and process peak RSS was cross-checked with `/usr/bin/time -lp`.

| Metric | `origin/main` before | This PR after |
| --- | ---: | ---: |
| Measured builds | 10 | 10 |
| Mean wall/build | 7.319 ms | 9.849 ms |
| Median wall/build | 6.827 ms | 8.775 ms |
| p95 wall/build | 9.637 ms | 15.304 ms |
| User CPU, 10 builds | 99.675 ms | 111.322 ms |
| System CPU, 10 builds | 35.664 ms | 40.924 ms |
| Process max RSS | 200,400 KiB | 196,384 KiB |
| `/usr/bin/time` max RSS | 205,291,520 B | 201,162,752 B |
| Generated `app.css` | 2,274 B | 2,647 B |
| Dependency `.tracking-widest` | absent | present |
| Plugin `.leading-loose` | present | present |

The correctness delta is the emitted dependency utility (and its required theme token), which explains the CSS-byte increase. These sub-15 ms samples also include the extra filesystem lookup and CSS work; the timing and peak-RSS differences are small-run noise, not a claimed speedup or Safari runtime gain. This is a build-time correctness fix only.

Fixes: N/A (no linked issue).

> AGENT GENERATED: by GPT-5 Codex
