### PR TITLE
Fix terminal pull request pill spacing

### DIFF
--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.stories.tsx
@@ -473,6 +473,18 @@ const pendingPullRequestFixture = buildPullRequestFixture({
   },
   attention: "checks_pending",
 });
+const mergedPullRequestFixture = buildPullRequestFixture({
+  number: 134,
+  state: "merged",
+  checks: {
+    state: "passing",
+    totalCount: 3,
+    passedCount: 3,
+    failedCount: 0,
+    pendingCount: 0,
+  },
+  attention: "merged",
+});
 
 const pullRequestStateRows: readonly {
   label: string;
@@ -587,18 +599,7 @@ const pullRequestStateRows: readonly {
   {
     label: "merged",
     hint: "terminal state",
-    pullRequest: buildPullRequestFixture({
-      number: 134,
-      state: "merged",
-      checks: {
-        state: "passing",
-        totalCount: 3,
-        passedCount: 3,
-        failedCount: 0,
-        pendingCount: 0,
-      },
-      attention: "merged",
-    }),
+    pullRequest: mergedPullRequestFixture,
   },
   {
     label: "closed",
@@ -865,6 +866,12 @@ export function Overview() {
         hint="committed branch changes use the same label with or without PR context"
       >
         <Row pullRequest={pullRequestFixture} section={committedSection} />
+      </StoryRow>
+      <StoryRow
+        label="merged pull request + committed"
+        hint="terminal pull requests reserve space for only their single status glyph"
+      >
+        <Row pullRequest={mergedPullRequestFixture} section={committedSection} />
       </StoryRow>
       <StoryRow
         label="pull request + many committed + actions"

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx
@@ -567,6 +567,60 @@ describe("ThreadPromptContextBanner", () => {
     expect(markup).toContain("Committed");
     expect(markup).toContain("1 file");
   });
+
+  it.each([
+    {
+      label: "checked open",
+      pullRequest: pullRequestFixture,
+      expectedMinWidthClass: "min-w-13",
+    },
+    {
+      label: "merged",
+      pullRequest: {
+        ...pullRequestFixture,
+        state: "merged" as const,
+        attention: "merged" as const,
+      },
+      expectedMinWidthClass: "min-w-8",
+    },
+    {
+      label: "closed",
+      pullRequest: {
+        ...pullRequestFixture,
+        state: "closed" as const,
+        attention: "closed" as const,
+      },
+      expectedMinWidthClass: "min-w-8",
+    },
+  ])(
+    "reserves only the width needed by a $label pull request status pill",
+    ({ pullRequest, expectedMinWidthClass }) => {
+      render(
+        <MemoryRouter>
+          <ThreadPromptContextBanner
+            gitSection={makeGitSection("committed")}
+            gitSectionPending={false}
+            archivedSection={null}
+            environmentGoneSection={null}
+            parentThreadSection={null}
+            childThreadsSection={null}
+            pullRequestSection={{ pullRequest }}
+            expandedSection={null}
+            onToggleSection={noop}
+          />
+        </MemoryRouter>,
+      );
+
+      const pullRequestLink = screen.getByRole("link", {
+        name: /Pull request 128:/,
+      });
+      expect(
+        ["min-w-8", "min-w-13"].filter((className) =>
+          pullRequestLink.classList.contains(className),
+        ),
+      ).toEqual([expectedMinWidthClass]);
+    },
+  );
 });
 
 describe("ThreadPromptContextBanner git section body", () => {

--- a/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadPromptContextBanner.tsx
@@ -33,6 +33,7 @@ import { cn } from "@bb/shared-ui/lib/utils";
 import { Icon, type IconName } from "@bb/shared-ui/icon";
 import {
   getPullRequestAttentionDisplay,
+  getPullRequestGithubCheckStatus,
   PULL_REQUEST_STATE_DISPLAY,
 } from "@/lib/pull-request-display";
 import { PullRequestStatusPill } from "@/components/pull-request/PullRequestStatusPill";
@@ -634,9 +635,12 @@ function PullRequestBannerLink({
       className={cn(
         "flex items-center gap-1.5 text-xs text-muted-foreground no-underline transition-colors hover:bg-state-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
         PROMPT_STACK_INLAY_SEGMENT_CLASS,
-        // Preserve the checked status pill (min-w-9) plus the inlay's px-2.
-        // Labels may still truncate, but the two status glyphs must not clip.
-        "min-w-13 overflow-hidden",
+        // Preserve the status pill plus the inlay's px-2. Open/draft PRs with
+        // checks need two glyphs; terminal/no-check PRs need only one.
+        getPullRequestGithubCheckStatus(pullRequest) !== null
+          ? "min-w-13"
+          : "min-w-8",
+        "overflow-hidden",
       )}
     >
       <PullRequestStatusPill pullRequest={pullRequest} className="h-4" />

--- a/apps/app/src/components/pull-request/PullRequestStatusPill.tsx
+++ b/apps/app/src/components/pull-request/PullRequestStatusPill.tsx
@@ -1,12 +1,10 @@
-import type {
-  PullRequestState,
-  ThreadPullRequest,
-  ThreadPullRequestChecksState,
-} from "@bb/domain";
+import type { PullRequestState, ThreadPullRequest } from "@bb/domain";
 import { Icon, type IconName } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
-
-export type GithubCheckStatus = "success" | "failure" | "pending";
+import {
+  getPullRequestGithubCheckStatus,
+  type GithubCheckStatus,
+} from "@/lib/pull-request-display";
 
 // The check glyph is the bundled GitHub mark with a small status dot in the
 // corner, drawn from theme tokens. It replaces the light + dark favicon PNGs
@@ -63,31 +61,6 @@ const PR_STATUS_ICON: Record<
 
 const CHECKED_PULL_REQUEST_STATUS_MIN_WIDTH_CLASS = "min-w-9";
 const SINGLE_PULL_REQUEST_STATUS_MIN_WIDTH_CLASS = "min-w-4";
-
-function getGithubCheckStatus(
-  state: ThreadPullRequestChecksState,
-): GithubCheckStatus | null {
-  switch (state) {
-    case "passing":
-      return "success";
-    case "failing":
-      return "failure";
-    case "pending":
-      return "pending";
-    case "no_checks":
-    case "unknown":
-      return null;
-  }
-}
-
-function getPullRequestGithubCheckStatus(
-  pullRequest: ThreadPullRequest,
-): GithubCheckStatus | null {
-  if (pullRequest.state !== "open" && pullRequest.state !== "draft") {
-    return null;
-  }
-  return getGithubCheckStatus(pullRequest.checks.state);
-}
 
 export function PullRequestStateIcon({
   state,

--- a/apps/app/src/lib/pull-request-display.ts
+++ b/apps/app/src/lib/pull-request-display.ts
@@ -14,6 +14,8 @@ interface PullRequestDisplay {
   className: string;
 }
 
+export type GithubCheckStatus = "success" | "failure" | "pending";
+
 export interface PullRequestStateDisplay extends PullRequestDisplay {
   dotClass: string;
 }
@@ -180,6 +182,25 @@ export function getPullRequestChecksDisplay(
   pullRequest: ThreadPullRequest,
 ): PullRequestDisplay {
   return CHECKS_DISPLAY[pullRequest.checks.state];
+}
+
+export function getPullRequestGithubCheckStatus(
+  pullRequest: ThreadPullRequest,
+): GithubCheckStatus | null {
+  if (pullRequest.state !== "open" && pullRequest.state !== "draft") {
+    return null;
+  }
+  switch (pullRequest.checks.state) {
+    case "passing":
+      return "success";
+    case "failing":
+      return "failure";
+    case "pending":
+      return "pending";
+    case "no_checks":
+    case "unknown":
+      return null;
+  }
 }
 
 export function getPullRequestReviewDisplay(


### PR DESCRIPTION
## What was wrong

The compact prompt banner applied the 52px minimum needed by an active pull request status plus its GitHub checks badge to every pull request segment. Merged and closed pull requests render only the 16px state glyph, so the extra reserved width appeared as empty space before the git summary.

## What changed

- derive the GitHub checks-badge status once in the pull request display module
- reserve 52px only when the status pill renders both glyphs, and 32px for merged, closed, and other single-glyph states
- add an exact merged-pull-request-plus-committed visual fixture and regression coverage for checked-open, merged, and closed widths
- no host-daemon wire, protocol-version, CLI, guide, configuration, or documentation changes

## How you verified

- pnpm exec turbo run test --filter=@bb/app -- src/components/promptbox/banner/ThreadPromptContextBanner.test.tsx — 22 tests passed; the merged/closed matrix fails against the old unconditional width
- pnpm exec turbo run typecheck --filter=@bb/app
- pnpm exec turbo run lint --filter=@bb/app — 0 errors; 144 existing warnings
- dev-browser QA against the 320px compact fixture: the merged segment shrank from 52px to 32px with no horizontal overflow, while the checked-open minimum remained 52px
- captured matched before/after screenshots in the originating bb thread

Fixes: spacing regression reported in bb thread thr_tu5r5k62m2.

> AGENT GENERATED: by GPT-5
