### PR TITLE
Add pnpm dev:remote for direct network access

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,18 @@ Then open `https://<machine>.<tailnet>.ts.net`. Source dev binds both the Vite
 app and main server to loopback by default; Vite continues to proxy API and
 WebSocket traffic.
 
+For direct access at `http://<tailscale-ip>:<app-port>` instead, run:
+
+```bash
+pnpm dev:remote
+```
+
+This binds the Vite app and main server to all IPv4 interfaces. The remote
+browser must be able to reach both the printed app and server ports for realtime
+updates. The server API is unauthenticated and permits command execution and
+file reads, so use this only behind a trusted network boundary and restrict the
+ports to Tailscale traffic with the host firewall when the LAN is not trusted.
+
 To use the component storybook from another machine, run:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cli:prepare": "pnpm exec turbo run build --filter=@bb/scripts --filter=@bb/cli --output-logs=none --log-prefix=none --summarize=false",
     "ensure-native-modules": "node scripts/ensure-native-modules.mjs",
     "dev": "node scripts/ensure-native-modules.mjs && cross-env NODE_ENV=development dotenv -c development -- node --conditions=source --import tsx packages/scripts/src/commands/run-dev.ts",
+    "dev:remote": "cross-env BB_DEV_APP_HOST=0.0.0.0 BB_SERVER_BIND_HOST=0.0.0.0 pnpm run dev",
     "cloud:dev": "node --conditions=source --import tsx scripts/bb-cloud-dev.mjs",
     "dev:desktop": "scripts/bb-dev-app current --desktop",
     "dev:status": "scripts/bb-dev-app status",


### PR DESCRIPTION
## What was wrong

Direct access to the source dev app from another Tailscale or LAN device requires two independent environment overrides: Vite must accept remote connections and the main server must expose its realtime WebSocket port. There was no memorable command that applied both settings together, making the workflow easy to misconfigure.

## What changed

Added a `pnpm dev:remote` root script that sets `BB_DEV_APP_HOST=0.0.0.0` and `BB_SERVER_BIND_HOST=0.0.0.0` before delegating to the existing dev launcher. Updated the README with the direct-IP workflow, the requirement that both printed ports be reachable, and the unauthenticated API security warning. There are no server/daemon wire changes.

## How you verified

- Parsed `package.json` as JSON and confirmed `dev:remote` is the canonical shortcut.
- Verified both remote binding variables survive the nested `pnpm` and dotenv launch path.
- Ran `pnpm exec prettier package.json README.md --check`.
- Ran `git diff --check origin/main...HEAD`.

Fixes: N/A — no linked issue.

> AGENT GENERATED: by GPT-5