### PR TITLE
Bold option titles in pickers to distinguish them from descriptions

### DIFF
--- a/apps/app/src/components/pickers/OptionPicker.tsx
+++ b/apps/app/src/components/pickers/OptionPicker.tsx
@@ -215,7 +215,7 @@ export function OptionPicker<T extends string>({
                 ) : null}
                 <span className="min-w-0 flex-1">
                   <span
-                    className="block whitespace-normal break-words"
+                    className="block whitespace-normal break-words font-medium"
                     title={option.label}
                   >
                     {option.label}


### PR DESCRIPTION
## Human comments

This was bothering me

Before:
<img width="698" height="612" alt="image" src="https://github.com/user-attachments/assets/7ede0a73-38a6-4a82-8476-e409648e8bce" />

After:
<img width="698" height="612" alt="image" src="https://github.com/user-attachments/assets/7e7967b3-7479-4ead-98a7-739e91e485d8" />



## What was wrong

In dropdown pickers such as the PermissionModePicker, each option shows a title (e.g. "Accept Edits") followed by description text. Both rendered at the same font weight, making the title hard to distinguish from the description at a glance.

## What changed

Added `font-medium` to the option label in the shared `OptionPicker` component (`apps/app/src/components/pickers/OptionPicker.tsx`), so titles stand out slightly from their descriptions across all pickers that use it.

## How verified

Visual: the label/description hierarchy in the PermissionModePicker menu now reads clearly.

> AGENT GENERATED: by Kimi K3