### PR TITLE
Make ‘This machine’ mean the client-local daemon

### DIFF
--- a/apps/app/.ladle/settings-story-fixtures.tsx
+++ b/apps/app/.ladle/settings-story-fixtures.tsx
@@ -179,6 +179,7 @@ export function SettingsUpdatesStory() {
     <div className="space-y-6">
       <MachineUpdatesSection
         machine={settingsUpdateMachine}
+        isThisMachine={false}
         action={
           <div role="toolbar" aria-label="Bulk update actions">
             <UpdateActionButton

--- a/apps/app/src/components/settings/InstallCliSkillsDialog.tsx
+++ b/apps/app/src/components/settings/InstallCliSkillsDialog.tsx
@@ -72,7 +72,7 @@ export function InstallCliSkillsDialogContent({
         <DialogDescription>
           {choosable
             ? "Choose the machines to install them onto. Each one gets the skills in ~/.agents/skills and ~/.claude/skills, replacing any copy already there."
-            : `The skills go in ~/.agents/skills and ~/.claude/skills on ${hosts[0]?.name ?? "this machine"}, replacing any copy already there.`}
+            : `The skills go in ~/.agents/skills and ~/.claude/skills on ${hosts[0]?.name ?? "the selected machine"}, replacing any copy already there.`}
         </DialogDescription>
       </DialogHeader>
 

--- a/apps/app/src/components/settings/MachinesSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/MachinesSettingsSection.test.tsx
@@ -17,7 +17,7 @@ import {
 } from "@bb/domain";
 import type { SystemConfigResponse } from "@bb/server-contract";
 import { MemoryRouter } from "react-router-dom";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sdk } from "@/lib/sdk";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { MachinesSettingsSection } from "./MachinesSettingsSection";
@@ -36,6 +36,18 @@ vi.mock("@/lib/sdk", () => ({
 
 vi.mock("@/lib/ws", () => ({
   wsManager: { subscribe: vi.fn(), unsubscribe: vi.fn() },
+}));
+
+const hostDaemon = vi.hoisted(() => ({
+  localDaemonHostId: "host_primary" as string | null,
+  platform: "darwin" as "darwin" | "linux" | "wsl" | "unknown" | null,
+}));
+
+vi.mock("@/hooks/useHostDaemon", () => ({
+  useHostDaemon: () => ({
+    localDaemonHostId: hostDaemon.localDaemonHostId,
+    platform: hostDaemon.platform,
+  }),
 }));
 
 const NOW = Date.now();
@@ -127,6 +139,11 @@ async function openHostMenu(hostName: string): Promise<void> {
   );
 }
 
+beforeEach(() => {
+  hostDaemon.localDaemonHostId = "host_primary";
+  hostDaemon.platform = "darwin";
+});
+
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
@@ -144,6 +161,7 @@ describe("MachinesSettingsSection", () => {
     expect(await screen.findByText("MacBook Pro")).toBeDefined();
     expect(screen.getByText("dev-vm")).toBeDefined();
     expect(screen.getByText("this machine")).toBeDefined();
+    expect(screen.getByText("primary")).toBeDefined();
     await waitFor(() => {
       expect(screen.getByRole("img", { name: "Online" })).toBeDefined();
     });
@@ -165,6 +183,62 @@ describe("MachinesSettingsSection", () => {
     expect(screen.getAllByRole("img", { name: "Full Access" })).toHaveLength(2);
     expect(screen.getByText("macOS")).toBeDefined();
     expect(screen.queryByText(/Online ·/u)).toBeNull();
+  });
+
+  it("distinguishes the client-local daemon from the primary machine", async () => {
+    hostDaemon.localDaemonHostId = "host_remote";
+    hostDaemon.platform = "linux";
+    vi.mocked(sdk.system.config).mockResolvedValue(systemConfig());
+    vi.mocked(sdk.hosts.list).mockResolvedValue([primaryHost, offlineHost]);
+    stubSidebarBootstrapFetch();
+
+    renderSection();
+
+    const primaryName = await screen.findByText("MacBook Pro");
+    const localName = screen.getByText("dev-vm");
+    expect(primaryName.parentElement?.textContent).toContain("primary");
+    expect(primaryName.parentElement?.textContent).not.toContain(
+      "this machine",
+    );
+    expect(localName.parentElement?.textContent).toContain("this machine");
+    expect(localName.parentElement?.textContent).not.toContain("primary");
+    expect(screen.getByText("Linux")).toBeDefined();
+  });
+
+  it("does not infer client-local identity when no daemon is reachable", async () => {
+    hostDaemon.localDaemonHostId = null;
+    hostDaemon.platform = null;
+    vi.mocked(sdk.system.config).mockResolvedValue(systemConfig());
+    vi.mocked(sdk.hosts.list).mockResolvedValue([primaryHost, offlineHost]);
+    stubSidebarBootstrapFetch();
+
+    renderSection();
+
+    await screen.findByText("MacBook Pro");
+    expect(screen.queryByText("this machine")).toBeNull();
+    expect(screen.getByText("primary")).toBeDefined();
+  });
+
+  it("does not promote a fallback host to primary policy", async () => {
+    hostDaemon.localDaemonHostId = null;
+    vi.mocked(sdk.system.config).mockResolvedValue({
+      ...systemConfig(),
+      primaryHostId: null,
+      primaryHostPlatform: null,
+    });
+    vi.mocked(sdk.hosts.list).mockResolvedValue([primaryHost, offlineHost]);
+    stubSidebarBootstrapFetch();
+
+    renderSection();
+
+    await screen.findByText("MacBook Pro");
+    expect(screen.queryByText("primary")).toBeNull();
+    await openHostMenu("MacBook Pro");
+    expect(
+      screen
+        .getByRole("menuitem", { name: "Remove machine" })
+        .getAttribute("aria-disabled"),
+    ).toBeNull();
   });
 
   it("shows protocol versions when a machine needs an update", async () => {
@@ -412,7 +486,7 @@ describe("MachinesSettingsSection", () => {
     fireEvent.focus(removeItem);
     expect(
       await screen.findByRole("tooltip", {
-        name: "This machine runs bb and can't be removed.",
+        name: "bb's primary machine can't be removed.",
       }),
     ).toBeDefined();
     fireEvent.click(removeItem);

--- a/apps/app/src/components/settings/MachinesSettingsSection.tsx
+++ b/apps/app/src/components/settings/MachinesSettingsSection.tsx
@@ -41,9 +41,10 @@ import {
   useRenameHost,
   useRetryHostUpdate,
 } from "@/hooks/mutations/host-mutations";
-import { selectPrimaryHost, useHosts } from "@/hooks/queries/host-queries";
+import { useHosts } from "@/hooks/queries/host-queries";
 import { useSidebarNavigation } from "@/hooks/queries/sidebar-navigation-query";
 import { useSystemConfig } from "@/hooks/queries/system-queries";
+import { useHostDaemon } from "@/hooks/useHostDaemon";
 import { PersistentHostIconName } from "@/lib/host-display";
 import { getSettingsMachineRoutePath } from "@/lib/route-paths";
 import { PERMISSION_MODE_OPTIONS } from "@/lib/permission-mode-options";
@@ -64,8 +65,7 @@ const PERMISSION_MODE_PRESENTATION: Record<
 const MACHINES_SECTION_DESCRIPTION =
   "Computers that can run your tasks. Pair a machine to run projects and threads on it.";
 
-const PRIMARY_REMOVE_DISABLED_REASON =
-  "This machine runs bb and can't be removed.";
+const PRIMARY_REMOVE_DISABLED_REASON = "bb's primary machine can't be removed.";
 
 const MACHINE_MENU_ITEM_CLASS = "min-h-9 px-2.5 py-2";
 
@@ -112,6 +112,8 @@ function MachineMetadataIcon({
 interface MachineRowProps {
   host: Host;
   isPrimary: boolean;
+  isThisMachine: boolean;
+  showPrimaryBadge: boolean;
   platformLabel: string | null;
   projectCount: number;
   now: number;
@@ -124,6 +126,8 @@ interface MachineRowProps {
 function MachineRow({
   host,
   isPrimary,
+  isThisMachine,
+  showPrimaryBadge,
   platformLabel,
   projectCount,
   now,
@@ -180,7 +184,10 @@ function MachineRow({
               <span className="min-w-0 truncate text-sm font-medium text-foreground">
                 {host.name}
               </span>
-              {isPrimary ? <SettingsBadge>this machine</SettingsBadge> : null}
+              {isThisMachine ? (
+                <SettingsBadge>this machine</SettingsBadge>
+              ) : null}
+              {showPrimaryBadge ? <SettingsBadge>primary</SettingsBadge> : null}
             </div>
             <div className="flex min-w-0 items-center gap-2 text-xs text-subtle-foreground/75">
               <MachineStatusIcon
@@ -275,6 +282,7 @@ function MachineRow({
 export function MachinesSettingsSection() {
   const systemConfig = useSystemConfig();
   const hostsQuery = useHosts();
+  const { localDaemonHostId, platform: localDaemonPlatform } = useHostDaemon();
   const sidebarNavigationQuery = useSidebarNavigation();
   const renameHost = useRenameHost();
   const removeHost = useRemoveHost();
@@ -285,10 +293,6 @@ export function MachinesSettingsSection() {
 
   const hosts = hostsQuery.data;
   const serverPrimaryHostId = systemConfig.data?.primaryHostId ?? null;
-  const primaryHostId = useMemo(
-    () => selectPrimaryHost(hosts, serverPrimaryHostId)?.id ?? null,
-    [hosts, serverPrimaryHostId],
-  );
   const projects = sidebarNavigationQuery.data?.projects;
   const projectCountByHostId = useMemo(() => {
     const counts = new Map<string, number>();
@@ -303,6 +307,7 @@ export function MachinesSettingsSection() {
 
   const now = Date.now();
   const primaryHostPlatform = systemConfig.data?.primaryHostPlatform ?? null;
+  const showMachineIdentityBadges = (hosts?.length ?? 0) > 1;
 
   return (
     <>
@@ -338,11 +343,20 @@ export function MachinesSettingsSection() {
               <MachineRow
                 key={host.id}
                 host={host}
-                isPrimary={host.id === primaryHostId}
+                isPrimary={host.id === serverPrimaryHostId}
+                isThisMachine={
+                  showMachineIdentityBadges && host.id === localDaemonHostId
+                }
+                showPrimaryBadge={
+                  showMachineIdentityBadges && host.id === serverPrimaryHostId
+                }
                 platformLabel={
-                  host.id === primaryHostId && primaryHostPlatform !== null
-                    ? PLATFORM_LABELS[primaryHostPlatform]
-                    : null
+                  host.id === localDaemonHostId && localDaemonPlatform !== null
+                    ? PLATFORM_LABELS[localDaemonPlatform]
+                    : host.id === serverPrimaryHostId &&
+                        primaryHostPlatform !== null
+                      ? PLATFORM_LABELS[primaryHostPlatform]
+                      : null
                 }
                 projectCount={projectCountByHostId.get(host.id) ?? 0}
                 now={now}

--- a/apps/app/src/components/settings/UpdatesSettingsSection.stories.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.stories.tsx
@@ -154,7 +154,11 @@ function StoryMachineSection({
   const showDaemon =
     machine.canRetryDaemonUpdate || machine.host.status !== "connected";
   return (
-    <MachineUpdatesSection machine={machine} action={action}>
+    <MachineUpdatesSection
+      machine={machine}
+      isThisMachine={false}
+      action={action}
+    >
       {app ? (
         <BbAppUpdateRows
           systemVersion={appUpdate ? undefined : NPM_VERSION}
@@ -212,7 +216,9 @@ function StoryAppState({ children }: { children: ReactNode }) {
     isPrimary: true,
   });
   return (
-    <MachineUpdatesSection machine={machine}>{children}</MachineUpdatesSection>
+    <MachineUpdatesSection machine={machine} isThisMachine={false}>
+      {children}
+    </MachineUpdatesSection>
   );
 }
 
@@ -473,7 +479,10 @@ export function UpdateStates() {
           name="Installing"
           note="The provider update is currently running."
         >
-          <MachineUpdatesSection machine={providerInstalling}>
+          <MachineUpdatesSection
+            machine={providerInstalling}
+            isThisMachine={false}
+          >
             <MachineUpdatesRows
               machine={providerInstalling}
               runningJobKey="state-provider-installing:claudeCode"

--- a/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
@@ -61,6 +61,16 @@ vi.mock("@/hooks/useDesktopUpdateInfo", () => ({
   useDesktopUpdateInfo: vi.fn(),
 }));
 
+const hostDaemon = vi.hoisted(() => ({
+  localDaemonHostId: null as string | null,
+}));
+
+vi.mock("@/hooks/useHostDaemon", () => ({
+  useHostDaemon: () => ({
+    localDaemonHostId: hostDaemon.localDaemonHostId,
+  }),
+}));
+
 const openUrlInExternalBrowserMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/url-open-routing", () => ({
@@ -264,6 +274,7 @@ const useDesktopUpdateInfoMock = vi.mocked(useDesktopUpdateInfo);
 const useProviderCliInstallRunnerMock = vi.mocked(useProviderCliInstallRunner);
 
 beforeEach(() => {
+  hostDaemon.localDaemonHostId = null;
   vi.stubGlobal(
     "fetch",
     vi.fn().mockRejectedValue(new Error("Changelog unavailable offline")),
@@ -431,7 +442,8 @@ The canonical release summary.
     });
     expect(screen.queryByText("2 up to date")).toBeNull();
     expect(screen.getByRole("heading", { name: /workstation/ })).toBeDefined();
-    expect(screen.getByText("This machine")).toBeDefined();
+    expect(screen.queryByText("Primary")).toBeNull();
+    expect(screen.queryByText("This machine")).toBeNull();
     expect(screen.queryByText("studio-mac")).toBeNull();
     expect(screen.queryByText(/Checked/)).toBeNull();
     expect(screen.queryByText(/ago$/)).toBeNull();
@@ -935,9 +947,8 @@ The canonical release summary.
     expect(machineHeading.className).toContain("font-semibold");
     expect(machineHeading.className).toContain("text-foreground");
     const machineName = screen.getByText("workstation");
-    const thisMachine = screen.getByText("This machine");
     expect(machineHeading.querySelector('[data-icon="Laptop"]')).not.toBeNull();
-    expect(machineName.nextElementSibling).toBe(thisMachine);
+    expect(machineName.nextElementSibling).toBeNull();
     // No summary banner above the rows: with work outstanding the rows are
     // the statement, and with none the settled card is the only thing shown.
     expect(screen.getByText("bb app")).toBeDefined();
@@ -981,6 +992,43 @@ The canonical release summary.
     expect(upgrade?.textContent).toBe("1.0.1");
     expect(upgrade?.className).toContain("font-semibold");
     expect(screen.queryByText("1 up to date")).toBeNull();
+  });
+
+  it("badges the client-local daemon independently from the primary update owner", () => {
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    const primary = makeHost({ id: "host_primary", name: "workstation" });
+    const local = makeHost({ id: "host_local", name: "studio-mac" });
+    hostDaemon.localDaemonHostId = local.id;
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        machines: [
+          makeMachine({
+            host: primary,
+            issues: [makeUpdateIssue({ provider: "codex" })],
+            isPrimary: true,
+          }),
+          makeMachine({
+            host: local,
+            issues: [makeUpdateIssue({ provider: "claudeCode" })],
+          }),
+        ],
+      }),
+    );
+
+    renderSection();
+
+    const primaryHeading = screen.getByRole("heading", {
+      name: /workstation/u,
+    });
+    const localHeading = screen.getByRole("heading", { name: /studio-mac/u });
+    expect(primaryHeading.textContent).not.toContain("Primary");
+    expect(primaryHeading.textContent).not.toContain("This machine");
+    expect(localHeading.textContent).toContain("This machine");
+    expect(localHeading.textContent).not.toContain("Primary");
   });
 
   it("lists Cursor updates with the other provider CLIs", () => {

--- a/apps/app/src/components/settings/UpdatesSettingsSection.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.tsx
@@ -70,6 +70,7 @@ import {
   useUpdateInventory,
   type UpdateInventoryMachine,
 } from "@/hooks/useUpdateInventory";
+import { useHostDaemon } from "@/hooks/useHostDaemon";
 import { useDesktopUpdateInfo } from "@/hooks/useDesktopUpdateInfo";
 import { copyToClipboardWithToast } from "@/lib/clipboard";
 import {
@@ -1360,10 +1361,12 @@ export function MachineUpdatesRows({
 /** One machine owns one settings section; the badge makes local scope explicit. */
 export function MachineUpdatesSection({
   machine,
+  isThisMachine,
   action,
   children,
 }: {
   machine: UpdateInventoryMachine;
+  isThisMachine: boolean;
   action?: ReactNode;
   children: ReactNode;
 }) {
@@ -1379,9 +1382,7 @@ export function MachineUpdatesSection({
               aria-hidden
             />
             <span className="truncate">{machine.host.name}</span>
-            {machine.isPrimary ? (
-              <SettingsBadge>This machine</SettingsBadge>
-            ) : null}
+            {isThisMachine ? <SettingsBadge>This machine</SettingsBadge> : null}
           </span>
         }
         action={
@@ -1421,6 +1422,7 @@ export function UpdatesSettingsSection({
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const inventory = useUpdateInventory();
+  const { localDaemonHostId } = useHostDaemon();
   const { desktopApi, desktopInfo, isDesktop } = useDesktopUpdateInfo();
   const retryHostUpdate = useRetryHostUpdate();
   // The check store outlives this view, so an in-flight check stays visible
@@ -1535,7 +1537,7 @@ export function UpdatesSettingsSection({
           (candidate) => candidate.host.id === hostId,
         );
         appToast.success(
-          `Retrying the update on ${machine?.host.name ?? "this machine"}`,
+          `Retrying the update on ${machine?.host.name ?? "the requested machine"}`,
         );
       },
     });
@@ -1608,6 +1610,10 @@ export function UpdatesSettingsSection({
             <MachineUpdatesSection
               key={machine.host.id}
               machine={machine}
+              isThisMachine={
+                inventory.machines.length > 1 &&
+                machine.host.id === localDaemonHostId
+              }
               action={index === 0 ? bulkActions : null}
             >
               {ownsApp ? (

--- a/apps/app/src/hooks/useThreadCreationOptions.ts
+++ b/apps/app/src/hooks/useThreadCreationOptions.ts
@@ -64,7 +64,7 @@ const EMPTY_COMPOSER_ACTIONS: ProviderComposerAction[] = [];
 const DEFAULT_SUPPORTED_PERMISSION_MODES: readonly PermissionMode[] = ["full"];
 
 const PERMISSION_CEILING_REASON =
-  "Above this machine's permission limit. Change it in Settings → Machines.";
+  "Above the selected machine's permission limit. Change it in Settings → Machines.";
 
 type StringSelectionSetter = (value: string) => void;
 type ServiceTierSelectionSetter = (value: ServiceTier | undefined) => void;

--- a/apps/app/src/views/MachineSettingsView.test.tsx
+++ b/apps/app/src/views/MachineSettingsView.test.tsx
@@ -20,7 +20,7 @@ import type {
   ProviderCliStatusResponse,
 } from "@bb/host-daemon-contract";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sdk } from "@/lib/sdk";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { MachineSettingsView } from "./MachineSettingsView";
@@ -40,6 +40,18 @@ vi.mock("@/lib/sdk", () => ({
 
 vi.mock("@/lib/ws", () => ({
   wsManager: { subscribe: vi.fn(), unsubscribe: vi.fn() },
+}));
+
+const hostDaemon = vi.hoisted(() => ({
+  localDaemonHostId: null as string | null,
+  platform: null as "darwin" | "linux" | "wsl" | "unknown" | null,
+}));
+
+vi.mock("@/hooks/useHostDaemon", () => ({
+  useHostDaemon: () => ({
+    localDaemonHostId: hostDaemon.localDaemonHostId,
+    platform: hostDaemon.platform,
+  }),
 }));
 
 const HOST_ID = "host_remote";
@@ -142,6 +154,11 @@ function stubSupportingFetches(): void {
     ),
   );
 }
+
+beforeEach(() => {
+  hostDaemon.localDaemonHostId = null;
+  hostDaemon.platform = null;
+});
 
 afterEach(() => {
   cleanup();
@@ -326,7 +343,40 @@ describe("MachineSettingsView", () => {
     expect(remove.hasAttribute("disabled")).toBe(true);
     expect(remove.className).toContain("bg-destructive");
     expect(remove.parentElement?.className).not.toContain("justify-end");
-    expect(screen.getAllByText("This machine")).toHaveLength(1);
+    expect(screen.queryByText("This machine")).toBeNull();
+    expect(screen.queryByText("Primary")).toBeNull();
+    expect(
+      screen.getByText("bb's primary machine can't be removed."),
+    ).toBeDefined();
+  });
+
+  it("shows client-local identity only when several machines need disambiguation", async () => {
+    hostDaemon.localDaemonHostId = HOST_ID;
+    hostDaemon.platform = "linux";
+    vi.mocked(sdk.system.config).mockResolvedValue(systemConfig());
+    vi.mocked(sdk.hosts.list).mockResolvedValue([
+      host(),
+      host({ id: "host_primary", name: "workstation" }),
+    ]);
+    stubSupportingFetches();
+
+    renderView();
+
+    expect(await screen.findByText("This machine")).toBeDefined();
+    expect(screen.queryByText("Primary")).toBeNull();
+    expect(screen.getByText(/Linux/u)).toBeDefined();
+  });
+
+  it("suppresses the client-local badge when there is only one machine", async () => {
+    hostDaemon.localDaemonHostId = HOST_ID;
+    vi.mocked(sdk.system.config).mockResolvedValue(systemConfig());
+    vi.mocked(sdk.hosts.list).mockResolvedValue([host()]);
+    stubSupportingFetches();
+
+    renderView();
+
+    await screen.findByRole("heading", { name: /dev-vm/u });
+    expect(screen.queryByText("This machine")).toBeNull();
   });
 
   it("explains a machine that is no longer paired", async () => {
@@ -337,7 +387,7 @@ describe("MachineSettingsView", () => {
     renderView();
 
     expect(
-      await screen.findByText("This machine is no longer paired."),
+      await screen.findByText("That machine is no longer paired."),
     ).toBeDefined();
   });
 });

--- a/apps/app/src/views/MachineSettingsView.test.tsx
+++ b/apps/app/src/views/MachineSettingsView.test.tsx
@@ -387,7 +387,7 @@ describe("MachineSettingsView", () => {
     renderView();
 
     expect(
-      await screen.findByText("That machine is no longer paired."),
+      await screen.findByText("Machine is no longer paired."),
     ).toBeDefined();
   });
 });

--- a/apps/app/src/views/MachineSettingsView.tsx
+++ b/apps/app/src/views/MachineSettingsView.tsx
@@ -35,11 +35,12 @@ import {
   useRetryHostUpdate,
   useUpdateHostPermissionCeiling,
 } from "@/hooks/mutations/host-mutations";
-import { selectPrimaryHost, useHosts } from "@/hooks/queries/host-queries";
+import { useHosts } from "@/hooks/queries/host-queries";
 import { useSidebarNavigation } from "@/hooks/queries/sidebar-navigation-query";
 import { useSystemConfig } from "@/hooks/queries/system-queries";
 import { isProviderCliUpdateIssue } from "@/components/provider-cli/provider-cli-install";
 import { useUpdateInventory } from "@/hooks/useUpdateInventory";
+import { useHostDaemon } from "@/hooks/useHostDaemon";
 import {
   formatHostUpdateStatus,
   hostCanRetryUpdate,
@@ -57,11 +58,10 @@ import {
   getSettingsRoutePath,
 } from "@/lib/route-paths";
 
-const PRIMARY_REMOVE_DISABLED_REASON =
-  "This machine runs bb and can't be removed.";
+const PRIMARY_REMOVE_DISABLED_REASON = "bb's primary machine can't be removed.";
 
 const PERMISSION_LIMIT_DESCRIPTION =
-  "Highest permission mode any thread on this machine may run with. Threads that ask for more resolve down to it, and a provider that supports nothing this low can't run here.";
+  "Highest permission mode any thread on the selected machine may run with. Threads that ask for more resolve down to it, and a provider that supports nothing this low can't run here.";
 
 const PLATFORM_LABELS: Record<HostPlatform, string | null> = {
   darwin: "macOS",
@@ -203,6 +203,7 @@ export function MachineSettingsView() {
   const navigate = useNavigate();
   const hostsQuery = useHosts();
   const systemConfig = useSystemConfig();
+  const { localDaemonHostId, platform: localDaemonPlatform } = useHostDaemon();
   const sidebarNavigationQuery = useSidebarNavigation();
   const updateInventory = useUpdateInventory();
   const renameHost = useRenameHost();
@@ -214,10 +215,11 @@ export function MachineSettingsView() {
 
   const hosts = hostsQuery.data;
   const host = hosts?.find((candidate) => candidate.id === hostId) ?? null;
-  const primaryHostId =
-    selectPrimaryHost(hosts, systemConfig.data?.primaryHostId ?? null)?.id ??
-    null;
+  const primaryHostId = systemConfig.data?.primaryHostId ?? null;
   const isPrimary = host !== null && host.id === primaryHostId;
+  const showMachineIdentityBadges = (hosts?.length ?? 0) > 1;
+  const isThisMachine =
+    showMachineIdentityBadges && host !== null && host.id === localDaemonHostId;
 
   const projects: MachineProject[] = useMemo(() => {
     const navigation = sidebarNavigationQuery.data?.projects ?? [];
@@ -256,9 +258,13 @@ export function MachineSettingsView() {
 
   const now = Date.now();
   const platformLabel =
-    isPrimary && systemConfig.data?.primaryHostPlatform
-      ? PLATFORM_LABELS[systemConfig.data.primaryHostPlatform]
-      : null;
+    host !== null &&
+    host.id === localDaemonHostId &&
+    localDaemonPlatform !== null
+      ? PLATFORM_LABELS[localDaemonPlatform]
+      : isPrimary && systemConfig.data?.primaryHostPlatform
+        ? PLATFORM_LABELS[systemConfig.data.primaryHostPlatform]
+        : null;
 
   if (hosts === undefined) {
     return (
@@ -282,7 +288,7 @@ export function MachineSettingsView() {
             Machines
           </Link>
           <p className="text-sm text-muted-foreground">
-            This machine is no longer paired.
+            That machine is no longer paired.
           </p>
         </div>
       </PageShell>
@@ -311,7 +317,12 @@ export function MachineSettingsView() {
                   aria-hidden
                 />
                 <span className="truncate">{host.name}</span>
-                {isPrimary ? <SettingsBadge>This machine</SettingsBadge> : null}
+                {isThisMachine ? (
+                  <SettingsBadge>This machine</SettingsBadge>
+                ) : null}
+                {showMachineIdentityBadges && isPrimary ? (
+                  <SettingsBadge>Primary</SettingsBadge>
+                ) : null}
               </span>
             }
             titleAction={

--- a/apps/app/src/views/MachineSettingsView.tsx
+++ b/apps/app/src/views/MachineSettingsView.tsx
@@ -288,7 +288,7 @@ export function MachineSettingsView() {
             Machines
           </Link>
           <p className="text-sm text-muted-foreground">
-            That machine is no longer paired.
+            Machine is no longer paired.
           </p>
         </div>
       </PageShell>

--- a/apps/mobile/src/data/compose/execution-options.ts
+++ b/apps/mobile/src/data/compose/execution-options.ts
@@ -61,7 +61,7 @@ export const REASONING_LABELS: Record<ReasoningLevel, string> = {
 };
 
 export const PERMISSION_CEILING_REASON =
-  "Above this machine's permission limit. Change it in Settings → Machines.";
+  "Above the selected machine's permission limit. Change it in Settings → Machines.";
 
 const DEFAULT_SUPPORTED_PERMISSION_MODES: readonly PermissionMode[] = ["full"];
 

--- a/apps/mobile/src/data/hosts/host-display.ts
+++ b/apps/mobile/src/data/hosts/host-display.ts
@@ -17,13 +17,13 @@ export const PERMISSION_MODE_SHORT_LABELS: Record<PermissionMode, string> = {
 };
 
 export const PRIMARY_HOST_REMOVE_DISABLED_REASON =
-  "This machine runs bb and can't be removed.";
+  "bb's primary machine can't be removed.";
 
 export const MACHINES_SECTION_DESCRIPTION =
   "Computers that can run your tasks. Pair a machine to run projects and threads on it.";
 
 export const PERMISSION_LIMIT_DESCRIPTION =
-  "Highest permission mode any thread on this machine may run with. Threads that ask for more resolve down to it, and a provider that supports nothing this low can't run here.";
+  "Highest permission mode any thread on the selected machine may run with. Threads that ask for more resolve down to it, and a provider that supports nothing this low can't run here.";
 
 const MINUTE_MS = 60_000;
 const HOUR_MS = 60 * MINUTE_MS;

--- a/apps/mobile/src/data/updates/use-update-inventory.ts
+++ b/apps/mobile/src/data/updates/use-update-inventory.ts
@@ -12,7 +12,6 @@ import {
   useHostsProviderCliStatus,
   useServerProtocolVersion,
 } from "../hosts/host-queries";
-import { selectPrimaryHost } from "../hosts/select-primary-host";
 import { useSystemConfig, useSystemVersion } from "../system/system-queries";
 import {
   buildUpdateInventory,
@@ -48,9 +47,7 @@ export function useUpdateInventory(
   const providerStatuses = useHostsProviderCliStatus(connectedHostIds, {
     enabled,
   });
-  const primaryHostId =
-    selectPrimaryHost(hosts, configQuery.data?.primaryHostId ?? null)?.id ??
-    null;
+  const primaryHostId = configQuery.data?.primaryHostId ?? null;
   const inventory = useMemo(
     () =>
       buildUpdateInventory({

--- a/apps/mobile/src/screens/extensions/SkillDetailScreen.tsx
+++ b/apps/mobile/src/screens/extensions/SkillDetailScreen.tsx
@@ -208,7 +208,7 @@ export function SkillDetailScreen() {
               {isSkillDeletable(skill) ? (
                 <ListRow
                   title="Delete skill"
-                  subtitle="Removes the skill folder from this machine"
+                  subtitle="Removes the installed skill folder"
                   leading="Trash2"
                   destructive
                   onPress={confirmDelete.present}

--- a/apps/mobile/src/screens/machines/MachineDetailScreen.tsx
+++ b/apps/mobile/src/screens/machines/MachineDetailScreen.tsx
@@ -128,7 +128,7 @@ function ConnectedMachineDetailScreen({ hostId }: { hostId: string }) {
   if (host === null) {
     return (
       <Screen testID="machine-detail-screen">
-        <EmptyStatePanel>That machine is no longer paired.</EmptyStatePanel>
+        <EmptyStatePanel>Machine is no longer paired.</EmptyStatePanel>
         <Button variant="outline" onPress={() => router.back()}>
           Back to machines
         </Button>

--- a/apps/mobile/src/screens/machines/MachineDetailScreen.tsx
+++ b/apps/mobile/src/screens/machines/MachineDetailScreen.tsx
@@ -13,7 +13,6 @@ import {
   PERMISSION_MODE_SHORT_LABELS,
   PRIMARY_HOST_REMOVE_DISABLED_REASON,
   providerCliIssues,
-  selectPrimaryHost,
   useHostProviderCliStatus,
   useHosts,
   useProviderCliInstallRunner,
@@ -82,9 +81,7 @@ function ConnectedMachineDetailScreen({ hostId }: { hostId: string }) {
   const bootstrap = useSidebarBootstrap();
   const hosts = hostsQuery.data;
   const host = hosts?.find((candidate) => candidate.id === hostId) ?? null;
-  const primaryHostId =
-    selectPrimaryHost(hosts, configQuery.data?.primaryHostId ?? null)?.id ??
-    null;
+  const primaryHostId = configQuery.data?.primaryHostId ?? null;
   const isPrimary = host !== null && host.id === primaryHostId;
   const online = host?.status === "connected";
 
@@ -131,7 +128,7 @@ function ConnectedMachineDetailScreen({ hostId }: { hostId: string }) {
   if (host === null) {
     return (
       <Screen testID="machine-detail-screen">
-        <EmptyStatePanel>This machine is no longer paired.</EmptyStatePanel>
+        <EmptyStatePanel>That machine is no longer paired.</EmptyStatePanel>
         <Button variant="outline" onPress={() => router.back()}>
           Back to machines
         </Button>
@@ -178,9 +175,9 @@ function ConnectedMachineDetailScreen({ hostId }: { hostId: string }) {
             >
               {host.name}
             </Text>
-            {isPrimary ? (
+            {hosts.length > 1 && isPrimary ? (
               <Pill variant="outline" size="sm">
-                this machine
+                Primary
               </Pill>
             ) : null}
           </View>
@@ -233,7 +230,7 @@ function ConnectedMachineDetailScreen({ hostId }: { hostId: string }) {
           />
         </SettingsSection>
 
-        <SettingsSection title="Projects on this machine">
+        <SettingsSection title={`Projects on ${host.name}`}>
           {projects.length === 0 ? (
             <SettingsValueRow label="Projects" value="None" />
           ) : (

--- a/apps/mobile/src/screens/machines/MachinesScreen.tsx
+++ b/apps/mobile/src/screens/machines/MachinesScreen.tsx
@@ -11,7 +11,6 @@ import {
   machineMetaLine,
   PERMISSION_MODE_SHORT_LABELS,
   PRIMARY_HOST_REMOVE_DISABLED_REASON,
-  selectPrimaryHost,
   useHosts,
   useAddMachineSession,
   useRemoveHost,
@@ -76,12 +75,7 @@ function ConnectedMachinesScreen() {
   const retryUpdate = useRetryHostUpdate();
 
   const hosts = hostsQuery.data;
-  const primaryHostId = useMemo(
-    () =>
-      selectPrimaryHost(hosts, configQuery.data?.primaryHostId ?? null)?.id ??
-      null,
-    [hosts, configQuery.data?.primaryHostId],
-  );
+  const primaryHostId = configQuery.data?.primaryHostId ?? null;
   const projectCounts = useMemo(
     () => countProjectsByHost(bootstrap.data?.projects ?? []),
     [bootstrap.data?.projects],
@@ -139,7 +133,7 @@ function ConnectedMachinesScreen() {
                   key={host.id}
                   title={host.name}
                   titleLines={1}
-                  subtitle={`${isPrimary ? "This machine · " : ""}${machineMetaLine(
+                  subtitle={`${hosts.length > 1 && isPrimary ? "Primary · " : ""}${machineMetaLine(
                     {
                       host,
                       platformLabel:

--- a/apps/mobile/src/screens/machines/ProviderCliRows.tsx
+++ b/apps/mobile/src/screens/machines/ProviderCliRows.tsx
@@ -182,7 +182,7 @@ export function ProviderCliRows({
     return (
       <View className="px-4 py-3">
         <Text variant="caption" tone="destructive">
-          Couldn't check provider CLIs on this machine.
+          Couldn't check provider CLIs on {host.name}.
         </Text>
       </View>
     );

--- a/apps/mobile/src/screens/pickers/EnvironmentPicker.tsx
+++ b/apps/mobile/src/screens/pickers/EnvironmentPicker.tsx
@@ -142,7 +142,7 @@ export function EnvironmentPicker({
     hostUnavailableReason ??
     (isPersonalProject || hostHasSource
       ? null
-      : `${host?.name ?? "This machine"} has no checkout of this project`);
+      : `${host?.name ?? "The selected machine"} has no checkout of this project`);
   const worktreeReason = isPersonalProject
     ? "Personal threads have no repository"
     : (workspaceDisabledReason ?? worktreeDisabledReason);

--- a/apps/mobile/src/screens/pickers/HostPicker.tsx
+++ b/apps/mobile/src/screens/pickers/HostPicker.tsx
@@ -112,7 +112,7 @@ export function HostPicker({
               ? onRequestSetup
                 ? "Not set up for this project · tap to set up"
                 : "Not set up for this project"
-              : isPrimary
+              : hosts.length > 1 && isPrimary
                 ? "Primary machine"
                 : undefined;
           return (

--- a/apps/mobile/src/screens/pickers/PathPicker.tsx
+++ b/apps/mobile/src/screens/pickers/PathPicker.tsx
@@ -56,7 +56,9 @@ export function PathPicker({
       >
         <ListRow
           title="Project checkout"
-          subtitle={defaultPath ?? "The project's folder on this machine"}
+          subtitle={
+            defaultPath ?? "The project's folder on the selected machine"
+          }
           leading="FolderGit"
           selected={value === null}
           onPress={() => {

--- a/apps/mobile/src/screens/pickers/ProviderPicker.tsx
+++ b/apps/mobile/src/screens/pickers/ProviderPicker.tsx
@@ -49,7 +49,7 @@ export function ProviderPicker({
           ),
         description: option.available
           ? undefined
-          : "Not available on this machine",
+          : "Not available on the selected machine",
       })),
     [options, tokens.foreground, tokens.subtleForeground],
   );

--- a/apps/mobile/src/screens/projects/NewProjectScreen.tsx
+++ b/apps/mobile/src/screens/projects/NewProjectScreen.tsx
@@ -122,7 +122,7 @@ function ConnectedNewProjectScreen() {
             subtitle={
               host
                 ? host.status === "connected"
-                  ? host.id === primaryHost?.id
+                  ? hosts.length > 1 && host.id === primaryHost?.id
                     ? "Primary machine"
                     : undefined
                   : "Offline"

--- a/apps/mobile/src/screens/projects/ProjectSettingsScreen.tsx
+++ b/apps/mobile/src/screens/projects/ProjectSettingsScreen.tsx
@@ -280,7 +280,7 @@ function ConnectedProjectSettingsScreen({ projectId }: { projectId: string }) {
         title="Remove this source?"
         message={
           sourceForMenu
-            ? `bb stops using ${sourceForMenu.path} on ${hostById.get(sourceForMenu.hostId)?.name ?? "this machine"} for this project. The folder stays on disk.`
+            ? `bb stops using ${sourceForMenu.path} on ${hostById.get(sourceForMenu.hostId)?.name ?? "that machine"} for this project. The folder stays on disk.`
             : undefined
         }
         actions={[

--- a/apps/mobile/src/screens/settings/UpdatesScreen.tsx
+++ b/apps/mobile/src/screens/settings/UpdatesScreen.tsx
@@ -131,12 +131,14 @@ function BbAppRow({
 
 function MachineUpdatesBlock({
   machine,
+  showPrimaryBadge,
   serverProtocolVersion,
   runner,
   retryPending,
   onRetry,
 }: {
   machine: UpdateInventoryMachine;
+  showPrimaryBadge: boolean;
   serverProtocolVersion: number | null;
   runner: ReturnType<typeof useProviderCliInstallRunner>;
   retryPending: boolean;
@@ -152,9 +154,9 @@ function MachineUpdatesBlock({
         <Text variant="label" numberOfLines={1} className="shrink">
           {host.name}
         </Text>
-        {machine.isPrimary ? (
+        {showPrimaryBadge ? (
           <Pill variant="outline" size="sm">
-            this machine
+            Primary
           </Pill>
         ) : null}
         <View className="flex-1" />
@@ -455,6 +457,9 @@ function ConnectedUpdatesScreen() {
                 {index > 0 ? <Separator /> : null}
                 <MachineUpdatesBlock
                   machine={machine}
+                  showPrimaryBadge={
+                    inventory.machines.length > 1 && machine.isPrimary
+                  }
                   serverProtocolVersion={inventory.serverProtocolVersion}
                   runner={runner}
                   retryPending={


### PR DESCRIPTION
## What was wrong

The UI reused the server-resolved primary host as the meaning of “This machine” in Machines and Updates. On remote and multi-host clients, that could label an execution default or server host as the device running the client. The primary-host fallback could also leak into removal policy.

## What changed

- Drive “This machine” only from the daemon reachable on the client device, and suppress the badge when only one host is known.
- Keep authoritative primary-host policy and primary markers separate from client-local identity.
- Avoid promoting the first-connected fallback into primary-host removal policy.
- On mobile, use “Primary” only where multi-host disambiguation is useful and never claim the phone is a bb machine.
- Clarify nearby copy that means the selected or primary machine. No server/daemon wire contract changed, so the protocol version is unchanged.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- src/components/settings/MachinesSettingsSection.test.tsx src/views/MachineSettingsView.test.tsx src/components/settings/UpdatesSettingsSection.test.tsx` (48 tests passed)
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/mobile`
- `pnpm exec turbo run test --filter=@bb/app --filter=@bb/mobile` (3,858 tests passed, 3 skipped)
- `pnpm exec turbo run lint --filter=@bb/app --filter=@bb/mobile` (0 errors; existing warnings only)
- `git diff --check`

Fixes: N/A (no linked issue)

> AGENT GENERATED: by GPT-5