### PR TITLE
Delay transient loading skeletons

### DIFF
--- a/apps/app/src/components/secondary-panel/lazySecondaryPanelComponents.tsx
+++ b/apps/app/src/components/secondary-panel/lazySecondaryPanelComponents.tsx
@@ -3,6 +3,7 @@ import { useAtomValue } from "jotai";
 import { Panel } from "react-resizable-panels";
 import { Skeleton } from "@bb/shared-ui/skeleton";
 import { cn } from "@bb/shared-ui/lib/utils";
+import { DelayedLoadingFallback } from "@/components/ui/delayed-loading-fallback";
 import { PANEL_COLLAPSE_TRANSITION_CLASS } from "./panelTransitionTokens";
 import {
   CONVERSATION_COLLAPSED_PANEL_SIZE_PERCENT,
@@ -91,15 +92,17 @@ const ThreadStorageFilePreviewTabContentChunk = lazy(() =>
 /** Generic "content is on its way" body for a panel tab. */
 export function SecondaryPanelContentSkeleton() {
   return (
-    <div
-      className="space-y-2 px-4 py-4"
-      data-testid="secondary-panel-content-skeleton"
-    >
-      <Skeleton className="h-3 w-3/4 rounded-sm" />
-      <Skeleton className="h-3 w-full rounded-sm" />
-      <Skeleton className="h-3 w-5/6 rounded-sm" />
-      <Skeleton className="h-3 w-2/3 rounded-sm" />
-    </div>
+    <DelayedLoadingFallback>
+      <div
+        className="space-y-2 px-4 py-4"
+        data-testid="secondary-panel-content-skeleton"
+      >
+        <Skeleton className="h-3 w-3/4 rounded-sm" />
+        <Skeleton className="h-3 w-full rounded-sm" />
+        <Skeleton className="h-3 w-5/6 rounded-sm" />
+        <Skeleton className="h-3 w-2/3 rounded-sm" />
+      </div>
+    </DelayedLoadingFallback>
   );
 }
 

--- a/apps/app/src/components/thread/timeline/LazyTimelineFileDiffBlock.tsx
+++ b/apps/app/src/components/thread/timeline/LazyTimelineFileDiffBlock.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense } from "react";
 import { Skeleton } from "@bb/shared-ui/skeleton";
+import { DelayedLoadingFallback } from "@/components/ui/delayed-loading-fallback";
 import type { TimelineFileDiffBlockProps } from "./TimelineFileDiffBlock.js";
 
 /**
@@ -17,14 +18,16 @@ const TimelineFileDiffBlockChunk = lazy(() =>
 
 function TimelineFileDiffBlockSkeleton() {
   return (
-    <div
-      className="mt-1 space-y-1.5 rounded-lg border border-border bg-background px-3 py-3"
-      data-testid="timeline-file-diff-skeleton"
-    >
-      <Skeleton className="h-3 w-full rounded-sm" />
-      <Skeleton className="h-3 w-[93%] rounded-sm" />
-      <Skeleton className="h-3 w-[87%] rounded-sm" />
-    </div>
+    <DelayedLoadingFallback>
+      <div
+        className="mt-1 space-y-1.5 rounded-lg border border-border bg-background px-3 py-3"
+        data-testid="timeline-file-diff-skeleton"
+      >
+        <Skeleton className="h-3 w-full rounded-sm" />
+        <Skeleton className="h-3 w-[93%] rounded-sm" />
+        <Skeleton className="h-3 w-[87%] rounded-sm" />
+      </div>
+    </DelayedLoadingFallback>
   );
 }
 

--- a/apps/app/src/components/thread/timeline/ThreadTimelineSurface.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineSurface.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 import type {
   ActiveThinking,
   ThreadOriginKind,
@@ -9,6 +9,7 @@ import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/pr
 import { Button } from "@bb/shared-ui/button";
 import { ConversationTimeline } from "@/components/ui/conversation.js";
 import { HeightTransition } from "@/components/ui/height-transition.js";
+import { DelayedLoadingFallback } from "@/components/ui/delayed-loading-fallback";
 import { Icon } from "@bb/shared-ui/icon";
 import { Skeleton } from "@bb/shared-ui/skeleton";
 import { usePreferredTheme } from "@/hooks/useTheme";
@@ -319,24 +320,12 @@ function LoadOlderMessages({
   );
 }
 
-// Delay before revealing the loading indicator so fast loads don't flash.
-export const LOADING_INDICATOR_REVEAL_DELAY_MS = 200;
-
 function DelayedThreadLoadingIndicator() {
-  const [visible, setVisible] = useState(false);
-  useEffect(() => {
-    const id = window.setTimeout(
-      () => setVisible(true),
-      LOADING_INDICATOR_REVEAL_DELAY_MS,
-    );
-    return () => window.clearTimeout(id);
-  }, []);
-
-  if (!visible) {
-    return null;
-  }
-
-  return <ThreadTimelineLoadingSkeleton />;
+  return (
+    <DelayedLoadingFallback>
+      <ThreadTimelineLoadingSkeleton />
+    </DelayedLoadingFallback>
+  );
 }
 
 // A lightweight placeholder that mirrors the timeline's real building blocks

--- a/apps/app/src/components/ui/delayed-loading-fallback.test.tsx
+++ b/apps/app/src/components/ui/delayed-loading-fallback.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DelayedLoadingFallback,
+  LOADING_FALLBACK_REVEAL_DELAY_MS,
+} from "./delayed-loading-fallback";
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("DelayedLoadingFallback", () => {
+  it("reveals its fallback only after the loading delay", () => {
+    vi.useFakeTimers();
+    const view = render(
+      <DelayedLoadingFallback>
+        <div data-testid="fallback">Loading</div>
+      </DelayedLoadingFallback>,
+    );
+
+    expect(view.queryByTestId("fallback")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(LOADING_FALLBACK_REVEAL_DELAY_MS - 1);
+    });
+    expect(view.queryByTestId("fallback")).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(view.getByTestId("fallback")).not.toBeNull();
+  });
+});

--- a/apps/app/src/components/ui/delayed-loading-fallback.tsx
+++ b/apps/app/src/components/ui/delayed-loading-fallback.tsx
@@ -1,0 +1,18 @@
+import { useEffect, useState, type ReactNode } from "react";
+
+/** Keep fast loading states from flashing a placeholder for a single frame. */
+export const LOADING_FALLBACK_REVEAL_DELAY_MS = 200;
+
+export function DelayedLoadingFallback({ children }: { children: ReactNode }) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(
+      () => setVisible(true),
+      LOADING_FALLBACK_REVEAL_DELAY_MS,
+    );
+    return () => window.clearTimeout(timeoutId);
+  }, []);
+
+  return visible ? children : null;
+}

--- a/apps/app/src/components/ui/route-loading-skeleton.tsx
+++ b/apps/app/src/components/ui/route-loading-skeleton.tsx
@@ -2,6 +2,7 @@ import { HEADER_SEAM_CLASS } from "@/components/layout/AppPageHeader";
 import { CHROME_ROW_CLASS } from "@/lib/bb-desktop";
 import { Skeleton } from "@bb/shared-ui/skeleton";
 import { cn } from "@bb/shared-ui/lib/utils";
+import { DelayedLoadingFallback } from "./delayed-loading-fallback";
 
 /**
  * Bleed to the edges of the AppLayout <main> padding, the same way PageShell
@@ -17,31 +18,33 @@ const SHELL_BLEED_CLASS =
  * Lightweight stand-in for a thread or new-thread pane while its code or data
  * is still loading: a header row on the shared chrome axis plus the composer
  * footprint at the bottom. Reused as the route-level Suspense fallback and by
- * the views' own loading branches, so the page keeps one silhouette from the
- * first paint until the real content mounts.
+ * the views' own loading branches, so a sustained load keeps one silhouette
+ * from its delayed reveal until the real content mounts.
  */
 export function RouteLoadingSkeleton() {
   return (
-    <div
-      className={SHELL_BLEED_CLASS}
-      role="status"
-      aria-busy="true"
-      aria-label="Loading"
-      data-testid="route-loading-skeleton"
-    >
+    <DelayedLoadingFallback>
       <div
-        className={cn(
-          CHROME_ROW_CLASS,
-          HEADER_SEAM_CLASS,
-          "shrink-0 gap-2 px-3 pl-12",
-        )}
+        className={SHELL_BLEED_CLASS}
+        role="status"
+        aria-busy="true"
+        aria-label="Loading"
+        data-testid="route-loading-skeleton"
       >
-        <Skeleton className="h-4 w-40 max-w-[50%]" />
+        <div
+          className={cn(
+            CHROME_ROW_CLASS,
+            HEADER_SEAM_CLASS,
+            "shrink-0 gap-2 px-3 pl-12",
+          )}
+        >
+          <Skeleton className="h-4 w-40 max-w-[50%]" />
+        </div>
+        <div className="min-h-0 flex-1" />
+        <div className="mx-auto w-full max-w-[760px] shrink-0 px-4 pb-4">
+          <Skeleton className="h-24 w-full rounded-xl" />
+        </div>
       </div>
-      <div className="min-h-0 flex-1" />
-      <div className="mx-auto w-full max-w-[760px] shrink-0 px-4 pb-4">
-        <Skeleton className="h-24 w-full rounded-xl" />
-      </div>
-    </div>
+    </DelayedLoadingFallback>
   );
 }


### PR DESCRIPTION
## What was wrong

Route, secondary-panel, and timeline-diff loading skeletons were rendered as soon as their lazy boundary or data branch became pending. Fast loads could therefore commit an animated placeholder for only a frame or two, creating visible flashes instead of preserving a quiet loading surface.

## What changed

Added a shared `DelayedLoadingFallback` that reveals its children after 200 ms, matching the app's existing thread-timeline loading delay. Applied it to route loading, secondary-panel content, and lazy timeline file-diff skeletons, and migrated the older thread-timeline delay to the shared helper. The underlying imports and data requests still start immediately. There are no wire, CLI, guide, or configuration changes.

## How you verified

- Added a fake-timer test covering the hidden-before-threshold and visible-at-threshold behavior.
- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app --force` — 399 files passed; 3,041 tests passed and 3 skipped.
- Prettier and `git diff --check` passed.

Fixes: no linked issue. Follow-up to #1890 and #1894.

> AGENT GENERATED: by GPT-5
