### PR TITLE
Stabilize TipTap editor test teardown

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -501,8 +501,13 @@ function mockIPadOSWebKit(): () => void {
   });
 }
 
-afterEach(() => {
+afterEach(async () => {
   cleanup();
+  // TipTap's React hook defers editor destruction by 1 ms so a Strict Mode
+  // remount can reuse the instance. Let that teardown finish while this
+  // test's jsdom window is still alive instead of leaking it into the next
+  // test (or the environment shutdown after the final test).
+  await new Promise<void>((resolve) => setTimeout(resolve, 2));
   resetPluginLogoStoreForTest();
   resetPluginSlotStoreForTest();
   resetAllCrashedPluginSlotsForTest();


### PR DESCRIPTION
## What was wrong

The [failing main CI run](https://github.com/get-bb/bb/actions/runs/32336675998) passed all 1,089 app-shard assertions, then reported an unhandled `scrollContainer.removeEventListener is not a function` exception from `PromptBoxInternal.test.tsx`. TipTap React intentionally destroys editor instances on a 1 ms timer after unmount so Strict Mode can reuse them. The suite returned from `afterEach` immediately after React cleanup, allowing the final delayed editor destruction to race Vitest jsdom environment shutdown on a loaded CI worker.

## What changed

Wait for TipTap deferred editor destruction after cleaning up each `PromptBoxInternal` test. This keeps editor and scroll-listener teardown inside the jsdom environment that created them and prevents state from leaking across tests or into environment shutdown. There are no product, wire-protocol, CLI, guide, or documentation changes.

## How you verified

- Fail-before evidence: main CI app shard completed 132 files and 1,089 assertions, then failed during delayed TipTap destruction.
- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/promptbox/PromptBoxInternal.test.tsx` — 99 tests passed.
- `pnpm exec turbo run test --filter=@bb/app --force -- --shard=3/3` under concurrent typecheck load — 132 files and 1,089 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.
- `git diff --check` — passed.

Fixes: N/A — CI teardown flake.

> AGENT GENERATED: by GPT-5