### PR TITLE
Add experiment-gated timeline row windowing

### DIFF
--- a/apps/app/src/components/layout/AppLayout.plugin-panel-header.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.plugin-panel-header.test.tsx
@@ -31,6 +31,7 @@ vi.mock("@/hooks/queries/system-queries", () => ({
         editMessages: false,
         mobileApp: false,
         providerSessionReaping: false,
+        timelineWindowing: false,
       },
     },
   }),

--- a/apps/app/src/components/layout/AppLayout.root-compose-project.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.root-compose-project.test.tsx
@@ -36,6 +36,7 @@ vi.mock("@/hooks/queries/system-queries", () => ({
         editMessages: false,
         mobileApp: false,
         providerSessionReaping: false,
+        timelineWindowing: false,
       },
     },
   }),

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx
@@ -10,6 +10,7 @@ import {
   useSyncExternalStore,
 } from "react";
 import type { ReactNode } from "react";
+import { useComposedRefs } from "@radix-ui/react-compose-refs";
 import { useLocation } from "react-router-dom";
 import {
   isBackgroundAgentTaskType,
@@ -44,6 +45,7 @@ import {
   type TimelineViewWorkRow,
 } from "@bb/thread-view";
 import { cn } from "@bb/shared-ui/lib/utils";
+import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
 import {
   collectTimelineAutoExpansionRowIds,
   isNonExpandableSummary,
@@ -84,7 +86,10 @@ import { Button } from "@bb/shared-ui/button";
 import { AutoHeightContainer } from "../../ui/height-transition.js";
 import { Icon, type IconName } from "@bb/shared-ui/icon";
 import type { PromptMentionLinkResolver } from "@/components/promptbox/editor/prompt-mention-link";
-import { useBottomAnchoredScroll } from "@/components/ui/bottom-anchored-scroll-body.js";
+import {
+  TimelineScrollRestoreRowIdContext,
+  useBottomAnchoredScroll,
+} from "@/components/ui/bottom-anchored-scroll-body.js";
 import {
   collectSearchedMessageAncestorRowIds,
   readSearchMessageTarget,
@@ -120,8 +125,16 @@ import {
   buildMessageDirectiveRegistry,
   MessageDirectiveRegistryProvider,
 } from "@/components/ui/markdown-message-directives.js";
+import {
+  TimelineWindowedItemsLoader,
+  TimelineWindowingMeasurementsContext,
+  TimelineWindowingScrollRootContext,
+  type TimelineWindowedItemRenderState,
+} from "./TimelineWindowedItemsLoader.js";
 
 export interface ThreadTimelineRowsProps {
+  /** Enable the opt-in timeline row virtualizer. */
+  timelineWindowingEnabled?: boolean;
   /**
    * Row ids to start expanded on first render. Non-recursive: an id only
    * applies to the row it names — bundle/step/turn children are unaffected.
@@ -444,6 +457,8 @@ const StreamingAssistantMessageIdContext = createContext<string | null>(null);
 const EMPTY_ROW_ID_SET: ReadonlySet<string> = new Set<string>();
 const TimelineSearchExpansionContext =
   createContext<ReadonlySet<string>>(EMPTY_ROW_ID_SET);
+const TimelineWindowingEnabledContext = createContext(false);
+const TIMELINE_TERMINAL_EXPANSION_RETENTION = 24;
 const SKILL_FILE_NAME = "SKILL.md";
 
 function useTimelineRendererStaticContext(): TimelineRendererStaticContextValue {
@@ -1982,25 +1997,69 @@ function buildTimelineRowsListItems({
  * `useArmTopLevelTimelineRowContainment`) and the per-row intrinsic size
  * estimate.
  */
-function TopLevelTimelineRowWrapper({
+function TimelineRowItemWrapper({
   children,
   row,
+  spacing,
+  windowedState,
 }: {
   children: ReactNode;
   row: ThreadTimelineViewRow;
+  spacing: TimelineRowsListSpacing;
+  windowedState: TimelineWindowedItemRenderState;
 }) {
   const wrapperRef = useRef<HTMLDivElement>(null);
-  useArmTopLevelTimelineRowContainment(wrapperRef);
+  const composedRef = useComposedRefs(wrapperRef, windowedState.itemRef);
+  const isTopLevel = spacing === "top-level";
+  useArmTopLevelTimelineRowContainment(
+    wrapperRef,
+    isTopLevel && !windowedState.windowingEnabled,
+  );
   return (
     <div
-      ref={wrapperRef}
+      ref={composedRef}
       data-timeline-row-id={row.id}
-      className={TOP_LEVEL_TIMELINE_ROW_INTRINSIC_SIZE_CLASS_NAME}
-      style={timelineRowContainmentStyle(row)}
+      data-timeline-window-key={row.id}
+      data-index={windowedState.itemIndex}
+      data-timeline-windowed-realized={
+        windowedState.windowingEnabled
+          ? String(windowedState.isRealized)
+          : undefined
+      }
+      className={
+        isTopLevel && !windowedState.windowingEnabled
+          ? TOP_LEVEL_TIMELINE_ROW_INTRINSIC_SIZE_CLASS_NAME
+          : undefined
+      }
+      style={
+        windowedState.itemStyle ??
+        (isTopLevel && !windowedState.windowingEnabled
+          ? timelineRowContainmentStyle(row)
+          : undefined)
+      }
     >
       {children}
     </div>
   );
+}
+
+function estimateTimelineWindowedRowHeight(
+  row: ThreadTimelineViewRow,
+  spacing: TimelineRowsListSpacing,
+): number {
+  if (row.kind !== "conversation") {
+    return spacing === "top-level" ? 20 : spacing === "bundle" ? 24 : 28;
+  }
+  // Estimates only seed never-realized placeholders. ResizeObserver replaces
+  // them with exact stable-id measurements as soon as a row enters overscan.
+  const charsPerLine =
+    spacing === "top-level" ? (row.role === "user" ? 76 : 95) : 64;
+  let lineCount = Math.max(1, Math.ceil(row.text.length / charsPerLine));
+  if (row.role === "user") {
+    lineCount = Math.min(lineCount, 15);
+    return 50 + lineCount * 23;
+  }
+  return 20 + lineCount * 23;
 }
 
 function TimelineRowsList({
@@ -2017,6 +2076,16 @@ function TimelineRowsList({
   unreadDividerPlacement,
 }: TimelineRowsListProps) {
   const { threadId } = useTimelineRendererStaticContext();
+  const isCompactViewport = useIsCompactViewport();
+  const bottomAnchor = useBottomAnchoredScroll();
+  const scrollRestoreRowId = useContext(TimelineScrollRestoreRowIdContext);
+  const detailScrollRoot = useContext(TimelineWindowingScrollRootContext);
+  const timelineWindowingEnabled = useContext(TimelineWindowingEnabledContext);
+  const inheritedMeasurements = useContext(
+    TimelineWindowingMeasurementsContext,
+  );
+  const [standaloneMeasurements] = useState(() => new Map<string, number>());
+  const measurements = inheritedMeasurements ?? standaloneMeasurements;
   const searchExpandedRowIds = useTimelineSearchExpansionRowIds(rows);
   const stableSearchExpandedRowIds = useStableReadonlySet(searchExpandedRowIds);
   useScrollToSearchedMessage(rows, threadId, {
@@ -2032,6 +2101,36 @@ function TimelineRowsList({
     () => buildTimelineRowsListItems({ rows, unreadDividerPlacement }),
     [rows, unreadDividerPlacement],
   );
+  const itemKeys = useMemo(
+    () =>
+      items.map((item) =>
+        item.kind === "row" ? item.row.id : `divider:${item.id}`,
+      ),
+    [items],
+  );
+  const alwaysMountedKeys = useMemo(() => {
+    const keys = new Set<string>();
+    const lastRow = rows.at(-1);
+    if (lastRow !== undefined) {
+      keys.add(lastRow.id);
+    }
+    for (const item of items) {
+      if (item.kind === "unread-divider") {
+        keys.add(`divider:${item.id}`);
+      }
+    }
+    for (const rowId of stableSearchExpandedRowIds) {
+      keys.add(rowId);
+    }
+    if (spacing === "top-level" && scrollRestoreRowId !== null) {
+      keys.add(scrollRestoreRowId);
+    }
+    return keys;
+  }, [items, rows, scrollRestoreRowId, spacing, stableSearchExpandedRowIds]);
+  const getWindowingScrollElement =
+    detailScrollRoot?.getScrollElement ??
+    bottomAnchor?.getScrollElement ??
+    null;
   return (
     <TimelineSearchExpansionContext.Provider value={stableSearchExpandedRowIds}>
       <div
@@ -2042,39 +2141,70 @@ function TimelineRowsList({
         )}
         data-timeline-row-list={spacing}
       >
-        {items.map((item) => {
-          if (item.kind === "unread-divider") {
-            return (
-              <TimelineUnreadDivider
-                key={item.id}
-                autoScroll={unreadDividerAutoScroll}
-              />
-            );
+        <TimelineWindowedItemsLoader
+          enabled={timelineWindowingEnabled}
+          alwaysMountedKeys={alwaysMountedKeys}
+          estimateItemHeight={(index) => {
+            const item = items[index];
+            return item?.kind === "row"
+              ? estimateTimelineWindowedRowHeight(item.row, spacing)
+              : 28;
+          }}
+          gap={spacing === "bundle" ? 0 : 8}
+          getScrollElement={getWindowingScrollElement}
+          itemKeys={itemKeys}
+          measurements={measurements}
+          minItemCount={
+            spacing === "top-level" ? (isCompactViewport ? 40 : 60) : 20
           }
-
-          const rowView = (
-            <MemoizedTimelineRowView
-              activeLatestBundleId={activeLatestBundleId}
-              row={item.row}
-              scopeActive={scopeActive}
-              showAssistantMessageActions={showAssistantMessageActions}
-              spacing={spacing}
-              compactActivityIntents={compactActivityIntents}
-            />
-          );
-          if (spacing === "top-level") {
+          renderItem={(index, windowedState) => {
+            const item = items[index];
+            if (item === undefined) {
+              return null;
+            }
+            if (item.kind === "unread-divider") {
+              return (
+                <div
+                  key={item.id}
+                  ref={windowedState.itemRef}
+                  data-index={windowedState.itemIndex}
+                  data-timeline-window-key={`divider:${item.id}`}
+                  data-timeline-windowed-realized={
+                    windowedState.windowingEnabled
+                      ? String(windowedState.isRealized)
+                      : undefined
+                  }
+                  style={windowedState.itemStyle}
+                >
+                  {windowedState.isRealized ? (
+                    <TimelineUnreadDivider
+                      autoScroll={unreadDividerAutoScroll}
+                    />
+                  ) : null}
+                </div>
+              );
+            }
             return (
-              <TopLevelTimelineRowWrapper key={item.row.id} row={item.row}>
-                {rowView}
-              </TopLevelTimelineRowWrapper>
+              <TimelineRowItemWrapper
+                key={item.row.id}
+                row={item.row}
+                spacing={spacing}
+                windowedState={windowedState}
+              >
+                {windowedState.isRealized ? (
+                  <MemoizedTimelineRowView
+                    activeLatestBundleId={activeLatestBundleId}
+                    row={item.row}
+                    scopeActive={scopeActive}
+                    showAssistantMessageActions={showAssistantMessageActions}
+                    spacing={spacing}
+                    compactActivityIntents={compactActivityIntents}
+                  />
+                ) : null}
+              </TimelineRowItemWrapper>
             );
-          }
-          return (
-            <div key={item.row.id} data-timeline-row-id={item.row.id}>
-              {rowView}
-            </div>
-          );
-        })}
+          }}
+        />
       </div>
     </TimelineSearchExpansionContext.Provider>
   );
@@ -2090,6 +2220,7 @@ function ThreadTimelineRowsComponent(props: ThreadTimelineRowsProps) {
 
 function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
   const getViewRows = useTimelineViewRowsCache();
+  const [windowingMeasurements] = useState(() => new Map<string, number>());
   const rows = useMemo(
     () => getViewRows(props.timelineRows),
     [getViewRows, props.timelineRows],
@@ -2122,8 +2253,27 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
   const liveAutoExpandedRowIds = useStableReadonlySet(
     computedAutoExpansionRowIds.liveFrontierRowIds,
   );
+  // Terminal expansion is a one-shot latch stored in an individual row. Keep
+  // a bounded recent set at the owner so windowed eviction cannot immediately
+  // erase it without growing state forever in a long-lived streaming client.
+  const accumulatedTerminalRowIdsRef = useRef(new Set<string>());
+  const accumulatedTerminalRowIds = useMemo(() => {
+    const accumulated = accumulatedTerminalRowIdsRef.current;
+    for (const id of computedAutoExpansionRowIds.terminalFrontierRowIds) {
+      accumulated.delete(id);
+      accumulated.add(id);
+    }
+    while (accumulated.size > TIMELINE_TERMINAL_EXPANSION_RETENTION) {
+      const oldestId = accumulated.values().next().value;
+      if (oldestId === undefined) {
+        break;
+      }
+      accumulated.delete(oldestId);
+    }
+    return new Set(accumulated);
+  }, [computedAutoExpansionRowIds.terminalFrontierRowIds]);
   const terminalAutoExpandedRowIds = useStableReadonlySet(
-    computedAutoExpansionRowIds.terminalFrontierRowIds,
+    accumulatedTerminalRowIds,
   );
   const initialAutoExpandedRowIds = useStableReadonlySet(
     props.initialExpanded ?? EMPTY_ROW_ID_SET,
@@ -2335,26 +2485,34 @@ function ThreadTimelineRowsForTimelineView(props: ThreadTimelineRowsProps) {
                 <TimelineTurnStateContext.Provider
                   value={turnStateContextValue}
                 >
-                  <AutoHeightContainer snapRevision={heightSnapRevision}>
-                    <TimelineRowsList
-                      hasOlderTimelineRows={props.hasOlderTimelineRows}
-                      isLoadingOlderTimelineRows={
-                        props.isLoadingOlderTimelineRows
-                      }
-                      onLoadOlderRows={props.onLoadOlderRows}
-                      rows={rows}
-                      scopeActive={scopeActive}
-                      showAssistantMessageActions={true}
-                      compactActivityIntents={false}
-                      spacing="top-level"
-                      unreadDividerAutoScroll={
-                        props.unreadDividerAutoScroll ?? true
-                      }
-                      unreadDividerPlacement={
-                        props.unreadDividerPlacement ?? null
-                      }
-                    />
-                  </AutoHeightContainer>
+                  <TimelineWindowingMeasurementsContext.Provider
+                    value={windowingMeasurements}
+                  >
+                    <TimelineWindowingEnabledContext.Provider
+                      value={props.timelineWindowingEnabled ?? false}
+                    >
+                      <AutoHeightContainer snapRevision={heightSnapRevision}>
+                        <TimelineRowsList
+                          hasOlderTimelineRows={props.hasOlderTimelineRows}
+                          isLoadingOlderTimelineRows={
+                            props.isLoadingOlderTimelineRows
+                          }
+                          onLoadOlderRows={props.onLoadOlderRows}
+                          rows={rows}
+                          scopeActive={scopeActive}
+                          showAssistantMessageActions={true}
+                          compactActivityIntents={false}
+                          spacing="top-level"
+                          unreadDividerAutoScroll={
+                            props.unreadDividerAutoScroll ?? true
+                          }
+                          unreadDividerPlacement={
+                            props.unreadDividerPlacement ?? null
+                          }
+                        />
+                      </AutoHeightContainer>
+                    </TimelineWindowingEnabledContext.Provider>
+                  </TimelineWindowingMeasurementsContext.Provider>
                   {hasSelectionActions ? (
                     <TimelineSelectionMenu
                       selection={activeSelection?.selection ?? null}

--- a/apps/app/src/components/thread/timeline/ThreadTimelineRows.windowing.test.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineRows.windowing.test.tsx
@@ -1,0 +1,239 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
+import { buildTimelineViewRows } from "@bb/thread-view";
+import {
+  BottomAnchorContext,
+  type BottomAnchorContextValue,
+} from "@/components/ui/bottom-anchored-scroll-body";
+import {
+  conversationRow,
+  delegationRow,
+} from "@/test/fixtures/thread-timeline-rows";
+import { ThreadTimelineRows } from "./ThreadTimelineRows";
+import { collectSearchedMessageAncestorRowIds } from "./useScrollToSearchedMessage";
+
+function rect(top: number, height: number): DOMRect {
+  return {
+    bottom: top + height,
+    height,
+    left: 0,
+    right: 600,
+    top,
+    width: 600,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  };
+}
+
+class IntersectionObserverStub implements IntersectionObserver {
+  readonly root = null;
+  readonly rootMargin = "0px";
+  readonly scrollMargin = "0px";
+  readonly thresholds = [0];
+  disconnect = vi.fn();
+  observe = vi.fn();
+  takeRecords = vi.fn(() => []);
+  unobserve = vi.fn();
+}
+
+class ResizeObserverStub implements ResizeObserver {
+  disconnect = vi.fn();
+  observe = vi.fn();
+  unobserve = vi.fn();
+}
+
+const nestedRows = Array.from({ length: 30 }, (_, index) =>
+  conversationRow({
+    id: `nested-${index}`,
+    role: index % 2 === 0 ? "assistant" : "user",
+    seq: index + 2,
+    text: `Nested message ${index}`,
+    turnId: `turn-${index}`,
+  }),
+);
+
+function renderDelegation(timelineWindowingEnabled: boolean) {
+  const queryClient = new QueryClient();
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <ThreadTimelineRows
+          initialExpanded={new Set(["large-delegation"])}
+          timelineRows={[
+            delegationRow({
+              childRows: nestedRows,
+              id: "large-delegation",
+              output: "",
+              sourceSeqEnd: 31,
+              sourceSeqStart: 1,
+            }),
+          ]}
+          timelineWindowingEnabled={timelineWindowingEnabled}
+          threadRuntimeDisplayStatus="idle"
+          workspaceRootPath={undefined}
+        />
+      </QueryClientProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal("IntersectionObserver", IntersectionObserverStub);
+  vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: vi.fn(),
+  });
+  vi.spyOn(HTMLElement.prototype, "clientHeight", "get").mockImplementation(
+    function (this: HTMLElement) {
+      if (this.hasAttribute("data-detail-scroll-area")) return 200;
+      if (this.hasAttribute("data-test-main-scroll")) return 800;
+      return 0;
+    },
+  );
+  vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(
+    function (this: HTMLElement) {
+      if (this.hasAttribute("data-detail-scroll-area")) return 200;
+      if (this.hasAttribute("data-test-main-scroll")) return 800;
+      return 0;
+    },
+  );
+  vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(600);
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+    function (this: HTMLElement) {
+      if (this.hasAttribute("data-detail-scroll-area")) {
+        return rect(0, 200);
+      }
+      if (this.hasAttribute("data-test-main-scroll")) {
+        return rect(0, 800);
+      }
+      const rowId = this.dataset.timelineRowId;
+      const match = rowId?.match(/^nested-(\d+)$/);
+      if (match?.[1] !== undefined) {
+        const index = Number(match[1]);
+        return index < 4 ? rect(index * 40, 32) : rect(2_000, 32);
+      }
+      const searchMatch = rowId?.match(/^search-message-(\d+)$/);
+      if (searchMatch?.[1] !== undefined) {
+        return rect(Number(searchMatch[1]) * 100, 32);
+      }
+      return rect(0, 32);
+    },
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  Reflect.deleteProperty(HTMLElement.prototype, "scrollIntoView");
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("ThreadTimelineRows windowing experiment", () => {
+  it("keeps the control timeline fully mounted", () => {
+    const view = renderDelegation(false);
+    const nestedList = view.container.querySelector(
+      '[data-timeline-row-list="nested"]',
+    );
+
+    for (let index = 0; index < 30; index += 1) {
+      expect(nestedList?.textContent).toContain(`Nested message ${index}`);
+    }
+  });
+
+  it("windows the rows inside a large expanded detail", async () => {
+    const view = renderDelegation(true);
+    const detailScroll = view.container.querySelector<HTMLElement>(
+      "[data-detail-scroll-area]",
+    );
+
+    expect(detailScroll?.clientHeight).toBe(200);
+    await waitFor(() => {
+      const nestedList = view.container.querySelector(
+        '[data-timeline-row-list="nested"]',
+      );
+      const wrappers = nestedList?.querySelectorAll(
+        ":scope > [data-timeline-virtual-spacer] > [data-timeline-row-id]",
+      );
+      expect(wrappers?.length).toBeGreaterThan(0);
+      expect(wrappers?.length).toBeLessThan(30);
+      expect(nestedList?.textContent).toContain("Nested message 0");
+      expect(nestedList?.textContent).not.toContain("Nested message 20");
+    });
+  });
+
+  it("keeps an offscreen search target realized and reveals it", async () => {
+    const scrollElement = document.createElement("div");
+    scrollElement.setAttribute("data-test-main-scroll", "");
+    Object.defineProperty(scrollElement, "clientHeight", { value: 800 });
+    Object.defineProperty(scrollElement, "scrollHeight", { value: 8_000 });
+    const scrollElementIntoView = vi.fn();
+    const bottomAnchor: BottomAnchorContextValue = {
+      captureScrollAnchor: vi.fn(),
+      getScrollElement: () => scrollElement,
+      isAtBottom: false,
+      scrollElementIntoView,
+      scrollElementIntoViewClampedToMaxScroll: vi.fn(),
+      scrollToBottom: vi.fn(),
+    };
+    const rows = Array.from({ length: 80 }, (_, index) =>
+      conversationRow({
+        id: `search-message-${index}`,
+        role: index % 2 === 0 ? "user" : "assistant",
+        sourceSeqEnd: index + 1,
+        sourceSeqStart: index + 1,
+        text: `Search message ${index}`,
+        threadId: "thr_large_search",
+      }),
+    );
+    const queryClient = new QueryClient();
+    expect(
+      collectSearchedMessageAncestorRowIds(buildTimelineViewRows(rows), 21),
+    ).toContain("search-message-20");
+    const view = render(
+      <MemoryRouter
+        initialEntries={[
+          {
+            pathname: "/thread",
+            state: {
+              searchMessageSeq: 21,
+              searchThreadId: "thr_large_search",
+            },
+          },
+        ]}
+      >
+        <QueryClientProvider client={queryClient}>
+          <BottomAnchorContext.Provider value={bottomAnchor}>
+            <CompactViewportOverrideProvider isCompactViewport>
+              <ThreadTimelineRows
+                threadId="thr_large_search"
+                timelineRows={rows}
+                timelineWindowingEnabled
+                threadRuntimeDisplayStatus="idle"
+                workspaceRootPath={undefined}
+              />
+            </CompactViewportOverrideProvider>
+          </BottomAnchorContext.Provider>
+        </QueryClientProvider>
+      </MemoryRouter>,
+    );
+    const target = view.container.querySelector<HTMLElement>(
+      '[data-timeline-row-id="search-message-20"]',
+    );
+
+    expect(target?.dataset.timelineWindowedRealized).toBe("true");
+    expect(target?.textContent).toContain("Search message 20");
+    await waitFor(() =>
+      expect(scrollElementIntoView).toHaveBeenCalledWith({
+        element: target,
+        options: { block: "center" },
+      }),
+    );
+  });
+});

--- a/apps/app/src/components/thread/timeline/ThreadTimelineSurface.tsx
+++ b/apps/app/src/components/thread/timeline/ThreadTimelineSurface.tsx
@@ -11,6 +11,7 @@ import { ConversationTimeline } from "@/components/ui/conversation.js";
 import { HeightTransition } from "@/components/ui/height-transition.js";
 import { Icon } from "@bb/shared-ui/icon";
 import { Skeleton } from "@bb/shared-ui/skeleton";
+import { useSystemConfig } from "@/hooks/queries/system-queries";
 import { toUserAttachmentImageSrc } from "@/lib/user-attachment-images";
 import { ThreadTimelineRows } from "./ThreadTimelineRows.js";
 import { useAutoLoadOlderRows } from "./useAutoLoadOlderRows.js";
@@ -177,6 +178,9 @@ export function ThreadTimelineSurface({
   unreadDividerPlacement,
   workspaceRootPath,
 }: ThreadTimelineSurfaceProps) {
+  const systemConfigQuery = useSystemConfig();
+  const timelineWindowingEnabled =
+    systemConfigQuery.data?.experiments.timelineWindowing ?? false;
   const showActiveThinking =
     activeThinking !== null && ongoingIndicatorLabel === undefined;
   const activeThinkingText = activeThinking?.text.trim() ?? "";
@@ -240,6 +244,7 @@ export function ThreadTimelineSurface({
           isLoadingOlderTimelineRows={isLoadingOlderTimelineRows}
           onLoadOlderRows={onLoadOlderRows}
           timelineRows={timelineRowsWithPendingStop}
+          timelineWindowingEnabled={timelineWindowingEnabled}
           threadId={threadId}
           threadRuntimeDisplayStatus={threadRuntimeDisplayStatus}
           unreadDividerAutoScroll={unreadDividerAutoScroll}

--- a/apps/app/src/components/thread/timeline/TimelineDetailScroll.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineDetailScroll.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type ReactNode, type UIEvent } from "react";
+import { useMemo, type ReactNode } from "react";
 import { useComposedRefs } from "@radix-ui/react-compose-refs";
 import { cn } from "@bb/shared-ui/lib/utils";
 import {
@@ -7,6 +7,10 @@ import {
 } from "../../ui/detail-scroll-size.js";
 import { useStickyBottomScroll } from "./useStickyBottomScroll.js";
 import { useScrollOverflowState } from "./useScrollOverflowState.js";
+import {
+  TimelineWindowingScrollRootContext,
+  type TimelineWindowingScrollRoot,
+} from "./TimelineWindowedItemsLoader.js";
 
 export interface TimelineDetailScrollProps {
   size: DetailScrollSize;
@@ -63,16 +67,13 @@ export function TimelineDetailScroll({
   const maxHeightClassName = getDetailScrollMaxHeightClass(size);
   const { aboveOverflow, belowOverflow } = overflow;
 
-  const handleScroll = useCallback(
-    (event: UIEvent<HTMLDivElement>) => {
-      sticky.onScroll(event);
-    },
-    [sticky],
-  );
-
   const refCallback = useComposedRefs<HTMLDivElement>(
     sticky.ref,
     overflow.scrollRef,
+  );
+  const windowingScrollRoot = useMemo<TimelineWindowingScrollRoot>(
+    () => ({ getScrollElement: () => sticky.ref.current }),
+    [sticky.ref],
   );
 
   return (
@@ -82,7 +83,7 @@ export function TimelineDetailScroll({
     >
       <div
         ref={refCallback}
-        onScroll={handleScroll}
+        onScroll={sticky.onScroll}
         onPointerDown={sticky.onPointerDown}
         onTouchMove={sticky.onTouchMove}
         onTouchStart={sticky.onTouchStart}
@@ -103,7 +104,13 @@ export function TimelineDetailScroll({
         {/* Content-only height changes (image loads, disclosure toggles)
             never resize the scroll port; this wrapper gives the sticky
             hook's ResizeObserver a box that tracks them. */}
-        <div ref={sticky.contentRef}>{children}</div>
+        <div ref={sticky.contentRef}>
+          <TimelineWindowingScrollRootContext.Provider
+            value={windowingScrollRoot}
+          >
+            {children}
+          </TimelineWindowingScrollRootContext.Provider>
+        </div>
         <div
           ref={overflow.bottomSentinelRef}
           aria-hidden

--- a/apps/app/src/components/thread/timeline/TimelineWindowedItems.test.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineWindowedItems.test.tsx
@@ -1,0 +1,231 @@
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  TimelineWindowedItems,
+  type TimelineWindowedItemRenderState,
+} from "./TimelineWindowedItems.js";
+
+const ITEM_KEYS = Array.from({ length: 100 }, (_, index) => `row-${index}`);
+
+let scrollElement: HTMLDivElement;
+let itemHeights = new Map<number, number>();
+
+function rect(top: number, height: number): DOMRect {
+  return {
+    bottom: top + height,
+    height,
+    left: 0,
+    right: 320,
+    top,
+    width: 320,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  };
+}
+
+class ResizeObserverStub implements ResizeObserver {
+  disconnect(): void {}
+  observe(): void {}
+  unobserve(): void {}
+}
+
+function renderWindowedItems(options?: {
+  alwaysMountedKeys?: ReadonlySet<string>;
+  clientHeight?: number;
+  enabled?: boolean;
+  measurements?: Map<string, number>;
+}) {
+  const measurements = options?.measurements ?? new Map<string, number>();
+  Object.defineProperty(scrollElement, "clientHeight", {
+    configurable: true,
+    value: options?.clientHeight ?? 96,
+  });
+  Object.defineProperty(scrollElement, "offsetHeight", {
+    configurable: true,
+    value: options?.clientHeight ?? 96,
+  });
+  return {
+    ...render(
+      <TimelineWindowedItems
+        enabled={options?.enabled ?? true}
+        alwaysMountedKeys={options?.alwaysMountedKeys}
+        estimateItemHeight={() => 32}
+        gap={0}
+        getScrollElement={() => scrollElement}
+        itemKeys={ITEM_KEYS}
+        measurements={measurements}
+        renderItem={(index: number, state: TimelineWindowedItemRenderState) => (
+          <div
+            key={ITEM_KEYS[index]}
+            ref={state.itemRef}
+            data-index={state.itemIndex}
+            data-testid={`wrapper-${index}`}
+            data-timeline-window-key={ITEM_KEYS[index]}
+            data-timeline-windowed-realized={String(state.isRealized)}
+            style={state.itemStyle}
+          >
+            {state.isRealized ? (
+              <button type="button" data-testid={`content-${index}`}>
+                row {index}
+              </button>
+            ) : null}
+          </div>
+        )}
+      />,
+      { container: scrollElement },
+    ),
+    measurements,
+  };
+}
+
+beforeEach(() => {
+  itemHeights = new Map();
+  scrollElement = document.createElement("div");
+  document.body.append(scrollElement);
+  Object.defineProperty(scrollElement, "clientWidth", {
+    configurable: true,
+    value: 320,
+  });
+  Object.defineProperty(scrollElement, "offsetWidth", {
+    configurable: true,
+    value: 320,
+  });
+  Object.defineProperty(scrollElement, "scrollHeight", {
+    configurable: true,
+    value: 3_200,
+  });
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+    function (this: HTMLElement) {
+      if (this === scrollElement) return rect(0, scrollElement.clientHeight);
+      if (this.hasAttribute("data-timeline-virtual-spacer")) {
+        return rect(
+          -scrollElement.scrollTop,
+          Number.parseFloat(this.style.height) || 0,
+        );
+      }
+      const index = Number(this.dataset.index);
+      if (Number.isInteger(index)) {
+        return rect(
+          index * 32 - scrollElement.scrollTop,
+          itemHeights.get(index) ?? 32,
+        );
+      }
+      return rect(0, Number.parseFloat(this.style.height) || 0);
+    },
+  );
+  vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("TimelineWindowedItems", () => {
+  it("keeps the control path fully mounted when the experiment is off", () => {
+    renderWindowedItems({ enabled: false });
+
+    expect(screen.getAllByTestId(/^content-/)).toHaveLength(100);
+    expect(
+      scrollElement.querySelector("[data-timeline-virtual-spacer]"),
+    ).toBeNull();
+  });
+
+  it("mounts only the visible TanStack range and removes offscreen wrappers", async () => {
+    renderWindowedItems();
+
+    await waitFor(() => expect(screen.getByTestId("content-0")).toBeTruthy());
+    expect(screen.getAllByTestId(/^wrapper-/).length).toBeLessThan(30);
+    expect(screen.queryByTestId("wrapper-60")).toBeNull();
+    expect(
+      scrollElement.querySelector<HTMLElement>("[data-timeline-virtual-spacer]")
+        ?.style.height,
+    ).toBe("3200px");
+  });
+
+  it("changes ranges on scroll without retaining the old rich rows", async () => {
+    renderWindowedItems();
+    await waitFor(() => expect(screen.getByTestId("content-0")).toBeTruthy());
+
+    scrollElement.scrollTop = 1_600;
+    fireEvent.scroll(scrollElement);
+
+    await waitFor(() => expect(screen.getByTestId("content-50")).toBeTruthy());
+    expect(screen.queryByTestId("wrapper-0")).toBeNull();
+  });
+
+  it("preserves an existing scroll offset when a nested virtualizer mounts", async () => {
+    scrollElement.scrollTop = 1_600;
+
+    renderWindowedItems();
+
+    await waitFor(() => expect(screen.getByTestId("content-50")).toBeTruthy());
+    expect(scrollElement.scrollTop).toBe(1_600);
+  });
+
+  it("keeps search and interacted rows mounted outside the visible range", async () => {
+    renderWindowedItems({ alwaysMountedKeys: new Set(["row-80"]) });
+    await waitFor(() => expect(screen.getByTestId("content-80")).toBeTruthy());
+    fireEvent.click(screen.getByTestId("content-0"));
+
+    scrollElement.scrollTop = 1_600;
+    fireEvent.scroll(scrollElement);
+
+    await waitFor(() => expect(screen.getByTestId("content-50")).toBeTruthy());
+    expect(screen.getByTestId("content-0")).toBeTruthy();
+    expect(screen.getByTestId("content-80")).toBeTruthy();
+  });
+
+  it("defers rich transient rows during a fast traversal until scroll idle", async () => {
+    vi.useFakeTimers();
+    renderWindowedItems();
+    await act(async () => {});
+
+    scrollElement.scrollTop = 1_600;
+    fireEvent.scroll(scrollElement);
+    await act(async () => {});
+
+    expect(
+      scrollElement.querySelectorAll(
+        '[data-timeline-windowed-realized="false"]',
+      ).length,
+    ).toBeGreaterThan(0);
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.getByTestId("content-50")).toBeTruthy();
+  });
+
+  it("seeds its size model from measurements retained by the thread", async () => {
+    const measurements = new Map<string, number>([["row-50", 64]]);
+    renderWindowedItems({ measurements });
+    await waitFor(() =>
+      expect(
+        scrollElement.querySelector<HTMLElement>(
+          "[data-timeline-virtual-spacer]",
+        )?.style.height,
+      ).toBe("3232px"),
+    );
+  });
+
+  it("renders everything when its scrollport has no usable geometry", async () => {
+    renderWindowedItems({ clientHeight: 0 });
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId(/^content-/)).toHaveLength(100),
+    );
+  });
+});

--- a/apps/app/src/components/thread/timeline/TimelineWindowedItems.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineWindowedItems.tsx
@@ -1,0 +1,346 @@
+import {
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type SyntheticEvent,
+} from "react";
+import { useComposedRefs } from "@radix-ui/react-compose-refs";
+import {
+  defaultRangeExtractor,
+  useVirtualizer,
+  type Range,
+  type Virtualizer,
+} from "@tanstack/react-virtual";
+import type { TimelineWindowedItemsProps } from "./TimelineWindowedItemsLoader.js";
+
+export type { TimelineWindowedItemRenderState } from "./TimelineWindowedItemsLoader.js";
+
+/** Rich rows retained on each side of the visible range. */
+const TIMELINE_WINDOW_OVERSCAN_ITEMS = 8;
+/** TanStack's scroll-idle boundary also drives rich-content realization. */
+const TIMELINE_WINDOW_IDLE_DELAY_MS = 300;
+/** Bound row-local interaction state retained across a long-lived session. */
+const TIMELINE_WINDOW_MAX_INTERACTION_PINS = 24;
+/** Bound exact heights that survive nested-list unmounts. */
+const TIMELINE_WINDOW_MAX_MEASUREMENTS = 2_000;
+/** Short lists cost less to keep mounted than to virtualize. */
+export const TIMELINE_WINDOWING_MIN_ITEM_COUNT = 20;
+
+const EMPTY_KEY_SET: ReadonlySet<string> = new Set();
+const GET_NO_SCROLL_ELEMENT = () => null;
+const NOOP_ITEM_REF = () => {};
+
+function recordTimelineMeasurement(
+  measurements: Map<string, number>,
+  key: string,
+  height: number,
+): void {
+  measurements.delete(key);
+  measurements.set(key, height);
+  while (measurements.size > TIMELINE_WINDOW_MAX_MEASUREMENTS) {
+    const oldestKey = measurements.keys().next().value;
+    if (oldestKey === undefined) break;
+    measurements.delete(oldestKey);
+  }
+}
+
+interface ScrollSample {
+  at: number;
+  fast: boolean;
+  offset: number;
+}
+
+function measureBorderBox(
+  element: HTMLElement,
+  entry: ResizeObserverEntry | undefined,
+): number {
+  const observedHeight = entry?.borderBoxSize[0]?.blockSize;
+  return observedHeight ?? element.getBoundingClientRect().height;
+}
+
+function findOwnedWindowKey(
+  target: EventTarget | null,
+  container: HTMLElement,
+  indexByKey: ReadonlyMap<string, number>,
+): string | null {
+  let element = target instanceof Element ? target : null;
+  while (element !== null && element !== container) {
+    const key = element.getAttribute("data-timeline-window-key");
+    if (key !== null && indexByKey.has(key)) return key;
+    element = element.parentElement;
+  }
+  return null;
+}
+
+/**
+ * Timeline adapter around TanStack Virtual.
+ *
+ * TanStack owns range calculation, dynamic measurement, scroll correction,
+ * and iOS momentum safety. This adapter only retains product policy: stable
+ * row keys, nested scroll offsets, search/interaction pins, and cheap
+ * placeholders during a synthetic or high-velocity traversal.
+ */
+export function TimelineWindowedItems({
+  enabled,
+  alwaysMountedKeys = EMPTY_KEY_SET,
+  estimateItemHeight,
+  gap,
+  getScrollElement,
+  itemKeys,
+  measurements,
+  minItemCount = TIMELINE_WINDOWING_MIN_ITEM_COUNT,
+  renderItem,
+}: TimelineWindowedItemsProps) {
+  const configured =
+    enabled && itemKeys.length >= minItemCount && getScrollElement !== null;
+  const [scrollRootUsable, setScrollRootUsable] = useState(true);
+  const [scrollMargin, setScrollMargin] = useState(0);
+  const [interactionPins, setInteractionPins] = useState<readonly string[]>([]);
+  const containerElementRef = useRef<HTMLDivElement>(null);
+  const scrollSampleRef = useRef<ScrollSample>({
+    at: 0,
+    fast: false,
+    offset: 0,
+  });
+  const windowingEnabled = configured && scrollRootUsable;
+  const resolvedGetScrollElement = getScrollElement ?? GET_NO_SCROLL_ELEMENT;
+
+  const indexByKey = useMemo(
+    () => new Map(itemKeys.map((key, index) => [key, index])),
+    [itemKeys],
+  );
+  const forcedIndexes = useMemo(() => {
+    const indexes = new Set<number>();
+    for (const key of alwaysMountedKeys) {
+      const index = indexByKey.get(key);
+      if (index !== undefined) indexes.add(index);
+    }
+    for (const key of interactionPins) {
+      const index = indexByKey.get(key);
+      if (index !== undefined) indexes.add(index);
+    }
+    return indexes;
+  }, [alwaysMountedKeys, indexByKey, interactionPins]);
+
+  const getItemKey = useCallback(
+    (index: number) => itemKeys[index] ?? index,
+    [itemKeys],
+  );
+  const estimateSize = useCallback(
+    (index: number) => {
+      const key = itemKeys[index];
+      return key === undefined
+        ? Math.max(1, estimateItemHeight(index))
+        : (measurements.get(key) ?? Math.max(1, estimateItemHeight(index)));
+    },
+    [estimateItemHeight, itemKeys, measurements],
+  );
+  const measureElement = useCallback(
+    (
+      element: HTMLDivElement,
+      entry: ResizeObserverEntry | undefined,
+    ): number => {
+      const index = Number(element.dataset.index);
+      const height = measureBorderBox(element, entry);
+      const key = Number.isInteger(index) ? itemKeys[index] : undefined;
+      if (
+        key !== undefined &&
+        height > 0 &&
+        element.dataset.timelineWindowedRealized === "true"
+      ) {
+        recordTimelineMeasurement(measurements, key, height);
+      }
+      return height > 0 ? height : estimateSize(index);
+    },
+    [estimateSize, itemKeys, measurements],
+  );
+  const rangeExtractor = useCallback(
+    (range: Range) => {
+      const indexes = new Set(defaultRangeExtractor(range));
+      for (const index of forcedIndexes) indexes.add(index);
+      return [...indexes].sort((left, right) => left - right);
+    },
+    [forcedIndexes],
+  );
+  const handleVirtualizerChange = useCallback(
+    (
+      instance: Virtualizer<HTMLElement, HTMLDivElement>,
+      scrolling: boolean,
+    ) => {
+      const sample = scrollSampleRef.current;
+      if (!scrolling) {
+        sample.fast = false;
+        sample.at = 0;
+        sample.offset = instance.scrollOffset ?? sample.offset;
+        return;
+      }
+      const now = performance.now();
+      const offset = instance.scrollOffset ?? 0;
+      const elapsed = sample.at === 0 ? 0 : now - sample.at;
+      const distance = Math.abs(offset - sample.offset);
+      const viewportSize = instance.scrollRect?.height ?? 0;
+      sample.fast =
+        (sample.at === 0 || elapsed <= 100) &&
+        distance >= Math.max(200, viewportSize * 0.5);
+      sample.at = now;
+      sample.offset = offset;
+    },
+    [],
+  );
+  const initialOffset = useCallback(
+    () => resolvedGetScrollElement()?.scrollTop ?? 0,
+    [resolvedGetScrollElement],
+  );
+
+  const virtualizer = useVirtualizer<HTMLElement, HTMLDivElement>({
+    count: itemKeys.length,
+    directDomUpdates: true,
+    directDomUpdatesMode: "position",
+    enabled: windowingEnabled,
+    estimateSize,
+    gap,
+    getItemKey,
+    getScrollElement: resolvedGetScrollElement,
+    initialOffset,
+    isScrollingResetDelay: TIMELINE_WINDOW_IDLE_DELAY_MS,
+    measureElement,
+    onChange: handleVirtualizerChange,
+    overscan: TIMELINE_WINDOW_OVERSCAN_ITEMS,
+    rangeExtractor,
+    scrollMargin,
+    useFlushSync: false,
+  });
+  const containerRef = useComposedRefs(
+    containerElementRef,
+    virtualizer.containerRef,
+  );
+
+  const updateScrollGeometry = useCallback(() => {
+    if (!configured) return;
+    const container = containerElementRef.current;
+    const scrollElement = resolvedGetScrollElement();
+    if (container === null || scrollElement === null) return;
+    const nextMargin =
+      container.getBoundingClientRect().top -
+      scrollElement.getBoundingClientRect().top +
+      scrollElement.scrollTop -
+      scrollElement.clientTop;
+    setScrollMargin((previous) =>
+      Math.abs(previous - nextMargin) < 0.5 ? previous : nextMargin,
+    );
+  }, [configured, resolvedGetScrollElement]);
+
+  useLayoutEffect(() => {
+    if (!configured) return;
+    const updateRootUsability = () => {
+      const scrollElement = resolvedGetScrollElement();
+      if (scrollElement !== null) {
+        setScrollRootUsable(scrollElement.clientHeight > 0);
+      }
+    };
+    const scrollElement = resolvedGetScrollElement();
+    if (scrollElement === null) {
+      const frame = requestAnimationFrame(() => {
+        updateRootUsability();
+        updateScrollGeometry();
+      });
+      return () => cancelAnimationFrame(frame);
+    }
+    updateRootUsability();
+    updateScrollGeometry();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => {
+      updateRootUsability();
+      updateScrollGeometry();
+    });
+    observer.observe(scrollElement);
+    const containerParent = containerElementRef.current?.parentElement;
+    if (containerParent !== null && containerParent !== undefined) {
+      observer.observe(containerParent);
+    }
+    return () => observer.disconnect();
+  }, [configured, resolvedGetScrollElement, updateScrollGeometry]);
+
+  // A nested list's offset can change when its owning row expands or reflows
+  // without resizing the scroll root itself. Re-read after those React commits.
+  useLayoutEffect(updateScrollGeometry);
+
+  const retainInteractedItem = useCallback(
+    (event: SyntheticEvent<HTMLDivElement>) => {
+      const container = containerElementRef.current;
+      if (container === null) return;
+      const key = findOwnedWindowKey(event.target, container, indexByKey);
+      if (key === null) return;
+      setInteractionPins((previous) => {
+        const next = previous.filter((candidate) => candidate !== key);
+        next.push(key);
+        return next.slice(-TIMELINE_WINDOW_MAX_INTERACTION_PINS);
+      });
+    },
+    [indexByKey],
+  );
+
+  if (!windowingEnabled) {
+    return (
+      <>
+        {itemKeys.map((key, index) =>
+          renderItem(index, {
+            isRealized: true,
+            itemIndex: undefined,
+            itemRef: NOOP_ITEM_REF,
+            itemStyle: undefined,
+            windowingEnabled: false,
+          }),
+        )}
+      </>
+    );
+  }
+
+  const fastScrolling = scrollSampleRef.current.fast;
+  const virtualItemsByIndex = new Map(
+    virtualizer.getVirtualItems().map((item) => [item.index, item]),
+  );
+  // Range calculation starts after the scroll element is measured. Product-
+  // pinned rows must exist in the first commit so navigation search and saved
+  // scroll restoration can find their DOM ids immediately.
+  for (const index of forcedIndexes) {
+    const item = virtualizer.measurementsCache[index];
+    if (item !== undefined) virtualItemsByIndex.set(index, item);
+  }
+  const virtualItems = [...virtualItemsByIndex.values()].sort(
+    (left, right) => left.index - right.index,
+  );
+  return (
+    <div
+      ref={containerRef}
+      className="relative w-full"
+      data-timeline-virtual-spacer=""
+      onClickCapture={retainInteractedItem}
+      onFocusCapture={retainInteractedItem}
+    >
+      {virtualItems.map((item) => {
+        const isRealized = !fastScrolling || forcedIndexes.has(item.index);
+        return renderItem(item.index, {
+          isRealized,
+          itemIndex: item.index,
+          itemRef: virtualizer.measureElement,
+          itemStyle: {
+            position: "absolute",
+            left: 0,
+            width: "100%",
+            ...(isRealized
+              ? undefined
+              : {
+                  height: item.size,
+                  minHeight: item.size,
+                  overflow: "hidden",
+                }),
+          },
+          windowingEnabled: true,
+        });
+      })}
+    </div>
+  );
+}

--- a/apps/app/src/components/thread/timeline/TimelineWindowedItemsLoader.tsx
+++ b/apps/app/src/components/thread/timeline/TimelineWindowedItemsLoader.tsx
@@ -1,0 +1,82 @@
+import {
+  createContext,
+  lazy,
+  Suspense,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+
+const DEFAULT_WINDOWING_MIN_ITEM_COUNT = 20;
+const NOOP_ITEM_REF = () => {};
+
+export interface TimelineWindowingScrollRoot {
+  getScrollElement: () => HTMLElement | null;
+}
+
+/** Nested capped details virtualize against their own scroll element. */
+export const TimelineWindowingScrollRootContext =
+  createContext<TimelineWindowingScrollRoot | null>(null);
+
+/** Exact heights survive while a virtualized parent unmounts a nested list. */
+export const TimelineWindowingMeasurementsContext = createContext<Map<
+  string,
+  number
+> | null>(null);
+
+export interface TimelineWindowedItemRenderState {
+  isRealized: boolean;
+  itemIndex: number | undefined;
+  itemRef: (node: HTMLDivElement | null) => void;
+  itemStyle: CSSProperties | undefined;
+  windowingEnabled: boolean;
+}
+
+export interface TimelineWindowedItemsProps {
+  enabled: boolean;
+  alwaysMountedKeys?: ReadonlySet<string>;
+  estimateItemHeight: (index: number) => number;
+  gap: number;
+  getScrollElement: (() => HTMLElement | null) | null;
+  itemKeys: readonly string[];
+  measurements: Map<string, number>;
+  minItemCount?: number;
+  renderItem: (
+    index: number,
+    state: TimelineWindowedItemRenderState,
+  ) => ReactNode;
+}
+
+const LazyTimelineWindowedItems = lazy(async () => {
+  const module = await import("./TimelineWindowedItems.js");
+  return { default: module.TimelineWindowedItems };
+});
+
+function TimelineWindowedItemsControl({
+  itemKeys,
+  renderItem,
+}: TimelineWindowedItemsProps) {
+  return itemKeys.map((_key, index) =>
+    renderItem(index, {
+      isRealized: true,
+      itemIndex: undefined,
+      itemRef: NOOP_ITEM_REF,
+      itemStyle: undefined,
+      windowingEnabled: false,
+    }),
+  );
+}
+
+/** Keep TanStack Virtual out of the route bundle until the experiment is on. */
+export function TimelineWindowedItemsLoader(props: TimelineWindowedItemsProps) {
+  const configured =
+    props.enabled &&
+    props.getScrollElement !== null &&
+    props.itemKeys.length >=
+      (props.minItemCount ?? DEFAULT_WINDOWING_MIN_ITEM_COUNT);
+  if (!configured) return <TimelineWindowedItemsControl {...props} />;
+  return (
+    <Suspense fallback={<TimelineWindowedItemsControl {...props} />}>
+      <LazyTimelineWindowedItems {...props} />
+    </Suspense>
+  );
+}

--- a/apps/app/src/components/thread/timeline/timeline-row-containment.ts
+++ b/apps/app/src/components/thread/timeline/timeline-row-containment.ts
@@ -49,10 +49,11 @@ export const TOP_LEVEL_TIMELINE_ROW_CLASS_NAME = `${CONTENT_VISIBILITY_CLASS_NAM
  */
 export function useArmTopLevelTimelineRowContainment(
   wrapperRef: RefObject<HTMLElement | null>,
+  enabled = true,
 ): void {
   useEffect(() => {
     const wrapper = wrapperRef.current;
-    if (wrapper === null || !supportsScrollAnchoring()) {
+    if (!enabled || wrapper === null || !supportsScrollAnchoring()) {
       return;
     }
     let cancelled = false;
@@ -74,7 +75,7 @@ export function useArmTopLevelTimelineRowContainment(
         cancelAnimationFrame(secondFrame);
       }
     };
-  }, [wrapperRef]);
+  }, [enabled, wrapperRef]);
 }
 
 /**

--- a/apps/app/src/components/thread/timeline/useScrollToSearchedMessage.ts
+++ b/apps/app/src/components/thread/timeline/useScrollToSearchedMessage.ts
@@ -30,6 +30,7 @@ interface SeqRange {
 
 const FLASH_CLASS_NAME = "bb-search-flash";
 const FLASH_DURATION_MS = 1700;
+const POST_WINDOW_SETTLE_REVEAL_MS = 800;
 
 function escapeTimelineRowId(rowId: string): string {
   if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
@@ -129,7 +130,7 @@ function collectSearchedMessageAncestorRowIdsInRows({
       continue;
     }
     const nestedRows = getNestedRows(row);
-    if (nestedRows === null) {
+    if (nestedRows === null || nestedRows.length === 0) {
       ancestorIds.add(row.id);
       return true;
     }
@@ -201,6 +202,8 @@ export function useScrollToSearchedMessage(
   const bottomAnchor = useBottomAnchoredScroll();
   const handledKeyRef = useRef<string | null>(null);
   const olderLoadAttemptKeyRef = useRef<string | null>(null);
+  const locationKeyRef = useRef(location.key);
+  locationKeyRef.current = location.key;
   const target = readSearchMessageTarget(location.state);
   const targetSeq = target?.seq ?? null;
   const targetThreadId = target?.threadId ?? null;
@@ -247,13 +250,20 @@ export function useScrollToSearchedMessage(
       return;
     }
     const selector = `[data-timeline-row-id="${escapeTimelineRowId(targetLeafRow.id)}"]`;
-    if (document.querySelector(selector) === null) {
+    const renderedTarget = document.querySelector<HTMLElement>(selector);
+    if (
+      renderedTarget === null ||
+      renderedTarget.dataset.timelineWindowedRealized === "false"
+    ) {
       return;
     }
     handledKeyRef.current = location.key;
 
     let flashed = false;
     const revealTarget = () => {
+      if (locationKeyRef.current !== location.key) {
+        return;
+      }
       const element = document.querySelector<HTMLElement>(selector);
       if (element === null) {
         return;
@@ -277,13 +287,12 @@ export function useScrollToSearchedMessage(
       }
     };
 
-    // Reveal on the next frame, then once more after layout settles, so a late
-    // scroll-anchor restore can't leave the target off-screen.
+    // Reveal after initial layout and again after idle placeholder correction.
     const frame = requestAnimationFrame(revealTarget);
-    const settle = window.setTimeout(revealTarget, 320);
+    window.setTimeout(revealTarget, 320);
+    window.setTimeout(revealTarget, POST_WINDOW_SETTLE_REVEAL_MS);
     return () => {
       cancelAnimationFrame(frame);
-      window.clearTimeout(settle);
     };
   }, [
     bottomAnchor,

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.scroll-preservation.test.tsx
@@ -97,6 +97,7 @@ interface RenderArgs {
   rowIds: string[];
   showCapturePrependAnchorControl?: boolean;
   showScrollToBottomControl?: boolean;
+  virtualized?: boolean;
 }
 
 function CapturePrependAnchorControl() {
@@ -122,7 +123,13 @@ function renderTimeline({
   rowIds,
   showCapturePrependAnchorControl = false,
   showScrollToBottomControl = false,
+  virtualized = false,
 }: RenderArgs) {
+  const rows = rowIds.map((rowId) => (
+    <div key={rowId} data-timeline-row-id={rowId}>
+      {rowId}
+    </div>
+  ));
   const view = render(
     <BottomAnchoredScrollBody
       footer={<div>Footer</div>}
@@ -132,11 +139,13 @@ function renderTimeline({
     >
       {showCapturePrependAnchorControl ? <CapturePrependAnchorControl /> : null}
       {showScrollToBottomControl ? <ScrollToBottomControl /> : null}
-      {rowIds.map((rowId) => (
-        <div key={rowId} data-timeline-row-id={rowId}>
-          {rowId}
+      {virtualized ? (
+        <div data-timeline-row-list="top-level">
+          <div data-timeline-virtual-spacer="">{rows}</div>
         </div>
-      ))}
+      ) : (
+        rows
+      )}
     </BottomAnchoredScrollBody>,
   );
 
@@ -230,6 +239,41 @@ describe("BottomAnchoredScrollBody scroll preservation", () => {
     });
 
     // User-intent scroll away from bottom, then a scroll event triggers capture.
+    fireEvent.wheel(scrollArea);
+    fireEvent.scroll(scrollArea);
+
+    expect(readAnchor("thread-a")).toEqual({
+      rowId: "row-b",
+      offsetWithinRow: 20,
+      atBottom: false,
+    });
+  });
+
+  it("captures rows nested in a virtualizer spacer", () => {
+    const { scrollArea, rowElements } = renderTimeline({
+      threadId: "thread-a",
+      rowIds: ["row-a", "row-b", "row-c"],
+      virtualized: true,
+    });
+    mockScrollAreaRect(scrollArea);
+    mockRowRect(requireHTMLElement(rowElements.get("row-a")!), {
+      top: -120,
+      bottom: -20,
+    });
+    mockRowRect(requireHTMLElement(rowElements.get("row-b")!), {
+      top: -20,
+      bottom: 80,
+    });
+    mockRowRect(requireHTMLElement(rowElements.get("row-c")!), {
+      top: 80,
+      bottom: 180,
+    });
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 400,
+      clientHeight: 100,
+      scrollTop: 150,
+    });
+
     fireEvent.wheel(scrollArea);
     fireEvent.scroll(scrollArea);
 

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -98,7 +98,10 @@ const SCROLL_ANCHOR_RESTORE_MAX_ATTEMPTS = 8;
 const TIMELINE_ROW_ID_SELECTOR = "[data-timeline-row-id]";
 const TOP_LEVEL_TIMELINE_ROW_LIST_SELECTOR =
   '[data-timeline-row-list="top-level"]';
-const DIRECT_TIMELINE_ROW_SELECTOR = `:scope > ${TIMELINE_ROW_ID_SELECTOR}`;
+const DIRECT_TIMELINE_ROW_SELECTOR = [
+  `:scope > ${TIMELINE_ROW_ID_SELECTOR}`,
+  `:scope > [data-timeline-virtual-spacer] > ${TIMELINE_ROW_ID_SELECTOR}`,
+].join(", ");
 const SCROLL_INTENT_KEYS = new Set([
   "ArrowDown",
   "ArrowUp",
@@ -111,6 +114,16 @@ const SCROLL_INTENT_KEYS = new Set([
 
 export const BottomAnchorContext =
   createContext<BottomAnchorContextValue | null>(null);
+
+/**
+ * A virtualized timeline pins this one row during initial navigation restore;
+ * otherwise the saved row would not exist in the DOM for the scroll body to
+ * measure. It remains separate from BottomAnchorContext so embedded/test
+ * consumers do not need to implement virtualizer policy.
+ */
+export const TimelineScrollRestoreRowIdContext = createContext<string | null>(
+  null,
+);
 
 export function useBottomAnchoredScroll(): BottomAnchorContextValue | null {
   return useContext(BottomAnchorContext);
@@ -303,6 +316,15 @@ export function BottomAnchoredScrollBody({
   }>({ lastWriteAt: 0, trailingTimeout: null });
   const userDetachedFromBottomRef = useRef(false);
   const [isAtBottom, setIsAtBottom] = useState(true);
+  const initialScrollRestoreRowId = useMemo(() => {
+    if (scrollAnchorThreadId === undefined) return null;
+    const anchor = store.get(
+      threadTimelineScrollAnchorAtomFamily(scrollAnchorThreadId),
+    );
+    return anchor !== null && anchor !== undefined && !anchor.atBottom
+      ? anchor.rowId
+      : null;
+  }, [scrollAnchorThreadId, store]);
 
   const getScrollElement = useCallback(() => scrollAreaRef.current, []);
 
@@ -827,65 +849,69 @@ export function BottomAnchoredScrollBody({
 
   return (
     <BottomAnchorContext.Provider value={bottomAnchorContextValue}>
-      <div className="grid min-h-0 flex-1 overflow-hidden">
-        <div
-          ref={scrollAreaRef}
-          className={cn(
-            "thread-scrollbar @container/page col-start-1 row-start-1 min-h-0 overflow-x-hidden overflow-y-auto",
-            scrollAreaClassName,
-          )}
-        >
+      <TimelineScrollRestoreRowIdContext.Provider
+        value={initialScrollRestoreRowId}
+      >
+        <div className="grid min-h-0 flex-1 overflow-hidden">
           <div
-            ref={scrollContentRef}
-            className="flex min-h-full min-w-0 flex-col"
+            ref={scrollAreaRef}
+            className={cn(
+              "thread-scrollbar @container/page col-start-1 row-start-1 min-h-0 overflow-x-hidden overflow-y-auto",
+              scrollAreaClassName,
+            )}
           >
-            {/* `.scroll-bottom-anchor-content` sets `overflow-anchor: none` on
+            <div
+              ref={scrollContentRef}
+              className="flex min-h-full min-w-0 flex-col"
+            >
+              {/* `.scroll-bottom-anchor-content` sets `overflow-anchor: none` on
                 this wrapper only. Scroll anchoring skips an excluded element's
                 whole subtree, so one class on one element redirects anchoring
                 to the trailing sentinel without a descendant rule that would
                 restyle every timeline node each time the bottom attaches or
                 detaches. Browsers without scroll anchoring (WebKit) never get
                 the class: the toggle would be a pure invalidation cost. */}
-            <div
-              className={cn(
-                "mx-auto flex w-full min-w-0 flex-1 flex-col px-4 pb-4 pt-2",
-                maxWidthClassName,
-                contentClassName,
-                isAtBottom &&
-                  supportsScrollAnchoring() &&
-                  "scroll-bottom-anchor-content",
-              )}
-              style={PAGE_SHELL_CONTENT_STYLE}
-            >
-              {children}
-            </div>
-            <div className="scroll-bottom-anchor" aria-hidden />
-            {footer ? (
-              // The sticky footer is excluded from anchor selection outright:
-              // it moves with the scrollport, so anchoring to it (or to a
-              // control inside it) would turn its own height changes into
-              // scroll jumps. Static exclusion keeps the previous
-              // `.scroll-bottom-anchor-content *` coverage of this subtree
-              // without a toggling class; while the wrapper is not excluded
-              // it always wins selection anyway, so nothing else changes.
               <div
-                data-scroll-footer=""
-                className="sticky bottom-0 z-20 shrink-0 [overflow-anchor:none]"
+                className={cn(
+                  "mx-auto flex w-full min-w-0 flex-1 flex-col px-4 pb-4 pt-2",
+                  maxWidthClassName,
+                  contentClassName,
+                  isAtBottom &&
+                    supportsScrollAnchoring() &&
+                    "scroll-bottom-anchor-content",
+                )}
+                style={PAGE_SHELL_CONTENT_STYLE}
               >
-                {footer}
+                {children}
               </div>
-            ) : null}
+              <div className="scroll-bottom-anchor" aria-hidden />
+              {footer ? (
+                // The sticky footer is excluded from anchor selection outright:
+                // it moves with the scrollport, so anchoring to it (or to a
+                // control inside it) would turn its own height changes into
+                // scroll jumps. Static exclusion keeps the previous
+                // `.scroll-bottom-anchor-content *` coverage of this subtree
+                // without a toggling class; while the wrapper is not excluded
+                // it always wins selection anyway, so nothing else changes.
+                <div
+                  data-scroll-footer=""
+                  className="sticky bottom-0 z-20 shrink-0 [overflow-anchor:none]"
+                >
+                  {footer}
+                </div>
+              ) : null}
+            </div>
           </div>
+          {scrollOverlay ? (
+            <div
+              data-scroll-overlay=""
+              className="pointer-events-none z-30 col-start-1 row-start-1 flex min-h-0 min-w-0 items-center justify-end px-3 py-3"
+            >
+              <div className="pointer-events-auto">{scrollOverlay}</div>
+            </div>
+          ) : null}
         </div>
-        {scrollOverlay ? (
-          <div
-            data-scroll-overlay=""
-            className="pointer-events-none z-30 col-start-1 row-start-1 flex min-h-0 min-w-0 items-center justify-end px-3 py-3"
-          >
-            <div className="pointer-events-auto">{scrollOverlay}</div>
-          </div>
-        ) : null}
-      </div>
+      </TimelineScrollRestoreRowIdContext.Provider>
     </BottomAnchorContext.Provider>
   );
 }

--- a/apps/app/src/lib/system-config-atoms.ts
+++ b/apps/app/src/lib/system-config-atoms.ts
@@ -25,6 +25,7 @@ const unavailableSystemConfig: SystemConfigResponse = {
     editMessages: false,
     mobileApp: false,
     providerSessionReaping: false,
+    timelineWindowing: false,
   },
   appearance: defaultAppTheme,
   customThemes: [],

--- a/apps/app/src/views/SettingsView.experiments.test.tsx
+++ b/apps/app/src/views/SettingsView.experiments.test.tsx
@@ -9,6 +9,7 @@ function renderSection(overrides?: {
   onChangelogPreviewEnabledChange?: (enabled: boolean) => void;
   onMobileAppEnabledChange?: (enabled: boolean) => void;
   onProviderSessionReapingEnabledChange?: (enabled: boolean) => void;
+  onTimelineWindowingEnabledChange?: (enabled: boolean) => void;
 }) {
   return render(
     <ExperimentsSettingsSection
@@ -17,6 +18,7 @@ function renderSection(overrides?: {
       editMessagesEnabled={false}
       mobileAppEnabled={false}
       providerSessionReapingEnabled={false}
+      timelineWindowingEnabled={false}
       onChangelogPreviewEnabledChange={
         overrides?.onChangelogPreviewEnabledChange ?? vi.fn()
       }
@@ -24,6 +26,9 @@ function renderSection(overrides?: {
       onMobileAppEnabledChange={overrides?.onMobileAppEnabledChange ?? vi.fn()}
       onProviderSessionReapingEnabledChange={
         overrides?.onProviderSessionReapingEnabledChange ?? vi.fn()
+      }
+      onTimelineWindowingEnabledChange={
+        overrides?.onTimelineWindowingEnabledChange ?? vi.fn()
       }
     />,
   );
@@ -48,6 +53,13 @@ describe("ExperimentsSettingsSection", () => {
     const onChange = vi.fn();
     renderSection({ onProviderSessionReapingEnabledChange: onChange });
     fireEvent.click(screen.getByLabelText("Idle provider session release"));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("reports timeline windowing changes", () => {
+    const onChange = vi.fn();
+    renderSection({ onTimelineWindowingEnabledChange: onChange });
+    fireEvent.click(screen.getByLabelText("Timeline windowing"));
     expect(onChange).toHaveBeenCalledWith(true);
   });
 });

--- a/apps/app/src/views/SettingsView.stories.tsx
+++ b/apps/app/src/views/SettingsView.stories.tsx
@@ -351,6 +351,7 @@ function ExperimentsStory() {
       editMessagesEnabled={state.experiments.editMessages}
       mobileAppEnabled={state.experiments.mobileApp}
       providerSessionReapingEnabled={state.experiments.providerSessionReaping}
+      timelineWindowingEnabled={state.experiments.timelineWindowing}
       onChangelogPreviewEnabledChange={(enabled) =>
         state.setExperiments((current) => ({
           ...current,
@@ -373,6 +374,12 @@ function ExperimentsStory() {
         state.setExperiments((current) => ({
           ...current,
           providerSessionReaping: enabled,
+        }))
+      }
+      onTimelineWindowingEnabledChange={(enabled) =>
+        state.setExperiments((current) => ({
+          ...current,
+          timelineWindowing: enabled,
         }))
       }
     />

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -213,10 +213,12 @@ export interface ExperimentsSettingsSectionProps {
   editMessagesEnabled: boolean;
   mobileAppEnabled: boolean;
   providerSessionReapingEnabled: boolean;
+  timelineWindowingEnabled: boolean;
   onChangelogPreviewEnabledChange: (enabled: boolean) => void;
   onEditMessagesEnabledChange: (enabled: boolean) => void;
   onMobileAppEnabledChange: (enabled: boolean) => void;
   onProviderSessionReapingEnabledChange: (enabled: boolean) => void;
+  onTimelineWindowingEnabledChange: (enabled: boolean) => void;
 }
 
 const THEME_PREFERENCE_OPTIONS: ReadonlyArray<ThemePreferenceOption> = [
@@ -969,16 +971,19 @@ const EDIT_MESSAGES_EXPERIMENT_LABEL = "Edit messages";
 const MOBILE_APP_EXPERIMENT_LABEL = "Mobile app";
 const PROVIDER_SESSION_REAPING_EXPERIMENT_LABEL =
   "Idle provider session release";
+const TIMELINE_WINDOWING_EXPERIMENT_LABEL = "Timeline windowing";
 export function ExperimentsSettingsSection({
   changelogPreviewEnabled,
   disabled,
   editMessagesEnabled,
   mobileAppEnabled,
   providerSessionReapingEnabled,
+  timelineWindowingEnabled,
   onChangelogPreviewEnabledChange,
   onEditMessagesEnabledChange,
   onMobileAppEnabledChange,
   onProviderSessionReapingEnabledChange,
+  onTimelineWindowingEnabledChange,
 }: ExperimentsSettingsSectionProps) {
   return (
     <SettingsSection
@@ -1031,6 +1036,18 @@ export function ExperimentsSettingsSection({
             disabled={disabled}
             onCheckedChange={onProviderSessionReapingEnabledChange}
             aria-label={PROVIDER_SESSION_REAPING_EXPERIMENT_LABEL}
+          />
+        </SettingsWithControl>
+
+        <SettingsWithControl
+          label={TIMELINE_WINDOWING_EXPERIMENT_LABEL}
+          description="Mount only nearby rows in long timelines and expanded timeline details."
+        >
+          <Switch
+            checked={timelineWindowingEnabled}
+            disabled={disabled}
+            onCheckedChange={onTimelineWindowingEnabledChange}
+            aria-label={TIMELINE_WINDOWING_EXPERIMENT_LABEL}
           />
         </SettingsWithControl>
       </div>
@@ -1217,6 +1234,13 @@ export function SettingsView() {
           updateExperimentsMutation.mutate({
             ...experiments,
             providerSessionReaping: enabled,
+          })
+        }
+        timelineWindowingEnabled={experiments.timelineWindowing}
+        onTimelineWindowingEnabledChange={(enabled) =>
+          updateExperimentsMutation.mutate({
+            ...experiments,
+            timelineWindowing: enabled,
           })
         }
       />

--- a/apps/cli/src/__tests__/command-output/settings.test.ts
+++ b/apps/cli/src/__tests__/command-output/settings.test.ts
@@ -110,6 +110,26 @@ describe("bb settings commands", () => {
     });
   });
 
+  it("updates timeline windowing while preserving every experiment", async () => {
+    const updateExperiments = vi.fn(async ({ json }) => json);
+    stubServerApi({
+      "v1.system.config.$get": vi.fn(async () => ({
+        generalSettings: defaultAppSettings,
+        experiments: defaultExperiments,
+      })),
+      "v1.settings.experiments.$put": updateExperiments,
+    });
+
+    await runCommand(
+      ["settings", "experiment", "timelineWindowing", "true"],
+      register,
+    );
+
+    expect(updateExperiments).toHaveBeenCalledWith({
+      json: { ...defaultExperiments, timelineWindowing: true },
+    });
+  });
+
   it("reads usage from a selected machine", async () => {
     const getUsage = vi.fn(async () => ({
       codex: { status: "unauthenticated" },

--- a/apps/desktop/test/preload-build.test.ts
+++ b/apps/desktop/test/preload-build.test.ts
@@ -131,6 +131,7 @@ async function startDesktopSmokeServer(
             editMessages: false,
             mobileApp: false,
             providerSessionReaping: false,
+            timelineWindowing: false,
           },
           featureFlags: {
             placeholder: false,

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -117,6 +117,9 @@ message agents, or inspect projects, providers, and environments.
   failed or incomplete turns. Submitting an edit to a running thread stops and
   settles the current turn first. Change it with:
   `bb settings experiment editMessages <true|false>`.
+- The default-off `timelineWindowing` experiment mounts only nearby rows in
+  long timelines and large expanded timeline details. Change it with
+  `bb settings experiment timelineWindowing <true|false>`.
 - Thread timeline windows are capped by event count as well as by user-message
   count (`BB_FF_TIMELINE_WINDOW_EVENT_BUDGET`, default 1500), because a thread
   with few user messages but many events would otherwise reproject its whole

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/references/app-settings.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/references/app-settings.md
@@ -63,3 +63,10 @@ every window and client sees the same value.
 - The `changelogPreview` experiment defaults to false.
 - Enable it with `bb settings experiment changelogPreview true` to show the
   latest release notes on Settings → Updates.
+
+## Timeline windowing
+
+- The `timelineWindowing` experiment defaults to false.
+- Enable it with `bb settings experiment timelineWindowing true`.
+- It keeps stable timeline wrappers while mounting only rows near the active
+  main or nested detail scrollport.

--- a/apps/server/test/system/experiments.test.ts
+++ b/apps/server/test/system/experiments.test.ts
@@ -18,6 +18,7 @@ describe("experiments settings", () => {
         editMessages: true,
         mobileApp: false,
         providerSessionReaping: false,
+        timelineWindowing: false,
       });
     });
   });
@@ -32,6 +33,7 @@ describe("experiments settings", () => {
           editMessages: true,
           mobileApp: true,
           providerSessionReaping: true,
+          timelineWindowing: true,
         }),
       });
       expect(put.status).toBe(200);
@@ -40,12 +42,14 @@ describe("experiments settings", () => {
         editMessages: true,
         mobileApp: true,
         providerSessionReaping: true,
+        timelineWindowing: true,
       });
       expect(getExperiments(harness.db)).toEqual({
         changelogPreview: true,
         editMessages: true,
         mobileApp: true,
         providerSessionReaping: true,
+        timelineWindowing: true,
       });
 
       const config = await harness.app.request("/api/v1/system/config");
@@ -56,6 +60,7 @@ describe("experiments settings", () => {
         editMessages: true,
         mobileApp: true,
         providerSessionReaping: true,
+        timelineWindowing: true,
       });
     });
   });
@@ -82,6 +87,7 @@ describe("experiments settings", () => {
           editMessages: true,
           mobileApp: false,
           providerSessionReaping: true,
+          timelineWindowing: false,
         }),
       });
       const updated = await harness.app.request("/internal/runtime-policy", {
@@ -106,6 +112,7 @@ describe("experiments settings", () => {
           editMessages: false,
           mobileApp: false,
           providerSessionReaping: false,
+          timelineWindowing: false,
         }),
       });
       expect(put.status).toBe(200);

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -662,6 +662,11 @@ turns, commands, agents, workflows, and monitors keep their sessions loaded.
 The experiment does not gate release: BB releases idle Codex sessions with the
 experiment off, which is the behavior it had before this setting.
 
+The `timelineWindowing` experiment is off by default. When enabled, long
+timelines and large expanded timeline details retain stable height-preserving
+wrappers while mounting only rows near their active scrollport. Toggle it with
+`bb settings experiment timelineWindowing <true|false>`.
+
 ## Thread Timeline Window
 
 A thread-timeline window is bounded by segment (user-message) count _and_ by

--- a/packages/db/test/experiments.test.ts
+++ b/packages/db/test/experiments.test.ts
@@ -40,6 +40,7 @@ describe("experiments", () => {
         "futureExperiment",
         "mobileApp",
         "providerSessionReaping",
+        "timelineWindowing",
       ]);
     } finally {
       db.$client.close();

--- a/packages/domain/src/experiments.ts
+++ b/packages/domain/src/experiments.ts
@@ -15,6 +15,7 @@ export const experimentKeys = [
   "editMessages",
   "mobileApp",
   "providerSessionReaping",
+  "timelineWindowing",
 ] as const;
 export const experimentKeySchema = z.enum(experimentKeys);
 export type ExperimentKey = z.infer<typeof experimentKeySchema>;
@@ -31,4 +32,5 @@ export const defaultExperiments: Experiments = {
   editMessages: true,
   mobileApp: false,
   providerSessionReaping: false,
+  timelineWindowing: false,
 };

--- a/packages/templates/src/templates/bb-guide-customization.md
+++ b/packages/templates/src/templates/bb-guide-customization.md
@@ -115,6 +115,10 @@ The daemon applies a changed value within five minutes. Active turns, commands,
 agents, workflows, and monitors keep their sessions loaded. BB releases idle
 Codex sessions with the experiment off as well.
 
+The default-off `timelineWindowing` experiment mounts only nearby rows in long
+timelines and large expanded timeline details. Enable it with
+`bb settings experiment timelineWindowing true`.
+
 Thread timeline windows are bounded by event count as well as user-message
 count (`BB_FF_TIMELINE_WINDOW_EVENT_BUDGET`, default 1500), so a long thread
 stops reprojecting its whole history — and blocking the server event loop — on


### PR DESCRIPTION
## What was wrong

Long timelines kept every rich top-level row mounted after older history loaded, and expanded delegation/turn details likewise kept every nested row mounted. A long-lived client that streams across multiple threads therefore accumulated DOM, rich markdown trees, observers, and row-local interaction state even though almost all content was outside the viewport.

The first prototype fixed the resting DOM size with a bespoke 826-line virtualizer, but it added too much custom geometry and gesture policy to land comfortably. Its cold full-history traversal also mounted each rich row once, producing 4.96 s round trips and 66.3 ms p95 frames.

## What changed

Add the default-off `timelineWindowing` experiment using the existing `@tanstack/react-virtual` dependency for range calculation, variable-height measurement, scroll correction, and momentum-safe updates. A thin timeline adapter retains only product policy:

- Window top-level lists at 60 rows on desktop or 40 on compact viewports, and nested/bundle lists at 20 rows.
- Keep eight realized rows of overscan and use measured stable-row heights for distant placeholders.
- Recursively window expanded turn and delegation details against their own capped scroll root; collapsing a group unmounts its detail subtree immediately.
- Keep last-row, unread-divider, searched-row, saved-scroll-anchor, focused, and clicked rows available when they are outside the visible range.
- Bound interaction pins at 24 and retained exact measurements at 2,000 for long-lived streaming sessions.
- Render cheap measured placeholders during high-velocity traversal, then realize the settled viewport.
- Initialize nested virtualizers from the shared scroll element's current offset so expanding or collapsing a nested list cannot reset the parent scroll position.

The experiment-off path renders the existing full list. A small `React.lazy` boundary keeps the 346-line TanStack adapter out of the route closure until windowing is enabled and a list crosses its threshold; the disabled app does not request that module.

The experiment is exposed in Settings, `bb settings experiment timelineWindowing <true|false>`, system defaults, docs, templates, and the built-in CLI skill. This does not alter the server/host-daemon wire contract, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

This PR supersedes #1991 with one experiment that covers top-level and recursive nested rows.

### Complexity reduction

| Scope | Earlier prototype | This PR |
| --- | ---: | ---: |
| Gross additions | 1,856 | 1,370 |
| Net additions | 1,790 | 1,244 |
| Custom windowing implementation | 826 lines | 428 lines (adapter + lazy boundary) |
| Runtime diff | — | +783 / -122 |
| Tests and docs diff | — | +587 / -4 |

The implementation is about 26% smaller in gross additions and the custom windowing layer is about 48% smaller. TanStack owns the difficult virtualizer mechanics; repository code owns the timeline-specific behavior and experiment integration.

## How you verified

Final focused validation after rebasing onto current `origin/main`:

```text
@bb/app timeline windowing + scroll preservation: 3 files, 25 tests passed
@bb/app typecheck: passed
@bb/app lint: passed with 0 errors (pre-existing warnings remain)
@bb/app production build: passed
bundle budget: boot 425.2 / 428.0 KiB Brotli; route closure 654.0 / 655.0 KiB Brotli
```

A full app run before the lazy-boundary-only follow-up passed 3,102 tests with three skipped. The replacement GitHub Actions run validates the exact final revision.

Dev Browser QA used a production-derived SQLite copy containing 620,222 events across 504 threads. The benchmark thread contained 38,946 underlying events, 577 projected top-level rows, and about 134.8k px of history.

Matched full-history benchmark:

| Metric | Control | Windowed | Change |
| --- | ---: | ---: | ---: |
| Elements at rest | 16,450 | 1,420 | -91.4% |
| DOM nodes at rest | 26,380 | 1,998 | -92.4% |
| Used JS heap | 162.9 MiB | 100.3 MiB | -38.4% |
| Embedder heap | 44.0 MiB | 17.4 MiB | -60.5% |
| Style flush p50 | 38.7 ms | 7.0 ms | -81.9% |
| Style flush p95 | 42.5 ms | 8.7 ms | -79.5% |
| Full traversal | 1,168 ms | 1,187 ms | +1.6% |
| Frame p95 | 9.9 ms | 10.0 ms | +0.1 ms |
| Frames over 32 ms | 0 | 0 | unchanged |
| Peak mounted top rows | 577 | 13 | -97.7% |

Real-data nested QA expanded a 103-row turn. It mounted 39 rows at the header and 46 while scrolled through the middle (visible range plus the pinned final row), rather than retaining all 103. Expanding and collapsing it preserved the shared scroll position exactly at `scrollTop=41900`. Compact-viewport QA also crossed the 40-row threshold and windowed correctly.

The CLI toggled the experiment off and on against the same development server. With 188 loaded rows, the disabled path mounted all 188 with no virtual spacer and did not request the adapter module; the enabled path mounted 15 with a virtual spacer preserving the full scroll geometry. No timeline runtime errors were observed.

No enrolled `mbp-intel` host was available for a hardware-specific rerun; the connected machines were M4 and M5. The benchmark above was run on the production-derived dataset on the M4 host.

Fixes: no linked issue.

> AGENT GENERATED: by GPT-5.6 Codex
