### PR TITLE
Fix sent-message editing across Codex and older browsers

### DIFF
--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -6,6 +6,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { createSentMessageEditOperationId } from "./sent-message-edit-operation-id";
 import { useCachedProviderInfo } from "@/hooks/queries/system-queries";
 import { useNavigate } from "react-router-dom";
 import { useAtom } from "jotai";
@@ -1055,7 +1056,7 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
       setSentMessageEditHostElement(null);
       setSentMessageEditSession({
         draft: editDraft,
-        operationId: crypto.randomUUID(),
+        operationId: createSentMessageEditOperationId(),
         target,
         threadId: current.thread.id,
       });

--- a/apps/app/src/views/thread-detail/sent-message-edit-operation-id.test.ts
+++ b/apps/app/src/views/thread-detail/sent-message-edit-operation-id.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSentMessageEditOperationId } from "./sent-message-edit-operation-id";
+
+describe("createSentMessageEditOperationId", () => {
+  it("does not require crypto.randomUUID", () => {
+    const originalCrypto = globalThis.crypto;
+    vi.stubGlobal("crypto", {
+      getRandomValues: originalCrypto.getRandomValues.bind(originalCrypto),
+      randomUUID: undefined,
+      subtle: originalCrypto.subtle,
+    });
+
+    try {
+      const first = createSentMessageEditOperationId();
+      const second = createSentMessageEditOperationId();
+
+      expect(first).not.toBe(second);
+      expect(first.length).toBeGreaterThan(0);
+    } finally {
+      vi.stubGlobal("crypto", originalCrypto);
+    }
+  });
+});

--- a/apps/app/src/views/thread-detail/sent-message-edit-operation-id.ts
+++ b/apps/app/src/views/thread-detail/sent-message-edit-operation-id.ts
@@ -1,0 +1,5 @@
+import { nanoid } from "nanoid";
+
+export function createSentMessageEditOperationId(): string {
+  return nanoid();
+}

--- a/apps/server/src/services/threads/thread-edit-message.ts
+++ b/apps/server/src/services/threads/thread-edit-message.ts
@@ -260,11 +260,14 @@ function resolveEditableTurnCandidate(
   ) {
     conflict("This earlier turn has no provider history");
   }
+  // Runtime-assembled Codex timelines have bb-minted turn ids and persist the
+  // native Codex turn id as the checkpoint. Older timelines used the native
+  // id directly and have no checkpoint, so retain that compatibility fallback.
   const precedingProviderCheckpoint =
     precedingTurnId === null
       ? null
       : thread.providerId === "codex"
-        ? precedingTurnId
+        ? (precedingCompletion?.providerCheckpointId ?? precedingTurnId)
         : (precedingCompletion?.providerCheckpointId ?? null);
   if (precedingTurnId !== null && precedingProviderCheckpoint === null) {
     conflict("This earlier provider turn has no editable history checkpoint");

--- a/apps/server/src/services/threads/thread-edit-message.ts
+++ b/apps/server/src/services/threads/thread-edit-message.ts
@@ -262,12 +262,21 @@ function resolveEditableTurnCandidate(
   }
   // Runtime-assembled Codex timelines have bb-minted turn ids and persist the
   // native Codex turn id as the checkpoint. Older timelines used the native
-  // id directly and have no checkpoint, so retain that compatibility fallback.
+  // UUID directly and have no checkpoint, so retain that compatibility
+  // fallback without ever forwarding a bb-minted id to Codex.
+  const legacyCodexCheckpoint =
+    thread.providerId === "codex" &&
+    precedingTurnId !== null &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      precedingTurnId,
+    )
+      ? precedingTurnId
+      : null;
   const precedingProviderCheckpoint =
     precedingTurnId === null
       ? null
       : thread.providerId === "codex"
-        ? (precedingCompletion?.providerCheckpointId ?? precedingTurnId)
+        ? (precedingCompletion?.providerCheckpointId ?? legacyCodexCheckpoint)
         : (precedingCompletion?.providerCheckpointId ?? null);
   if (precedingTurnId !== null && precedingProviderCheckpoint === null) {
     conflict("This earlier provider turn has no editable history checkpoint");

--- a/apps/server/test/threads/thread-edit-message.test.ts
+++ b/apps/server/test/threads/thread-edit-message.test.ts
@@ -192,6 +192,7 @@ function seedEditableThread(
     firstCompletionStatus?: ThreadEventTurnStatus | null;
     firstProviderCheckpoint?: string | null;
     firstProviderThreadId?: string;
+    firstTurnId?: string;
     includeIdentity?: boolean;
     includeSecondTurn?: boolean;
     providerId?: string;
@@ -238,7 +239,7 @@ function seedEditableThread(
     requestSequence: 2,
     text: "First message",
     threadId: thread.id,
-    turnId: "turn-first",
+    turnId: args.firstTurnId ?? "turn-first",
     ...(args.firstCompletionStatus !== undefined
       ? { completionStatus: args.firstCompletionStatus }
       : {}),
@@ -1195,8 +1196,10 @@ describe("editThreadMessage", () => {
 
   it("falls back to a legacy Codex turn id when history has no checkpoint", async () => {
     await withTestHarness(async (harness) => {
+      const legacyCodexTurnId = "019f1234-5678-7abc-8def-0123456789ab";
       const { environment, thread } = seedEditableThread(harness, {
         firstProviderCheckpoint: null,
+        firstTurnId: legacyCodexTurnId,
       });
       const editPromise = editThreadMessage(harness.deps, {
         environment,
@@ -1213,7 +1216,7 @@ describe("editThreadMessage", () => {
         (queued) => queued.command.type === "thread.rewind.prepare",
       );
       expect(rewind.command).toMatchObject({
-        retainThroughProviderCheckpoint: "turn-first",
+        retainThroughProviderCheckpoint: legacyCodexTurnId,
       });
       if (rewind.command.type !== "thread.rewind.prepare") {
         throw new Error("Expected a thread.rewind.prepare command");
@@ -1224,6 +1227,34 @@ describe("editThreadMessage", () => {
       await expect(editPromise).resolves.toMatchObject({ ok: true });
     });
   });
+
+  it.each(["completed", "failed", "interrupted"] as const)(
+    "does not send a bb turn id to Codex when a %s turn has no checkpoint",
+    async (firstCompletionStatus) => {
+      await withTestHarness(async (harness) => {
+        const { environment, thread } = seedEditableThread(harness, {
+          firstCompletionStatus,
+          firstProviderCheckpoint: null,
+          firstTurnId: "da2f291120-t3",
+        });
+
+        await expect(
+          editThreadMessage(harness.deps, {
+            environment,
+            thread,
+            payload: {
+              operationId: `edit-op-missing-${firstCompletionStatus}-codex-checkpoint`,
+              expectedRequestSequence: 7,
+              input: [{ type: "text", text: "Replacement", mentions: [] }],
+            },
+          }),
+        ).rejects.toThrow("no editable history checkpoint");
+        expect(
+          listQueuedThreadCommands(harness, "thread.rewind.prepare", thread.id),
+        ).toHaveLength(0);
+      });
+    },
+  );
 
   it("leaves the original suffix untouched when Codex cannot stage the rewind", async () => {
     await withTestHarness(async (harness) => {

--- a/apps/server/test/threads/thread-edit-message.test.ts
+++ b/apps/server/test/threads/thread-edit-message.test.ts
@@ -383,7 +383,7 @@ describe("editThreadMessage", () => {
         (queued) => queued.command.type === "thread.rewind.prepare",
       );
       expect(rewind.command).toMatchObject({
-        retainThroughProviderCheckpoint: "turn-first",
+        retainThroughProviderCheckpoint: "checkpoint-first",
       });
       if (rewind.command.type !== "thread.rewind.prepare") {
         throw new Error("Expected a thread.rewind.prepare command");
@@ -532,7 +532,7 @@ describe("editThreadMessage", () => {
       );
       expect(rewind.command).toMatchObject({
         sourceProviderThreadId: "provider-original",
-        retainThroughProviderCheckpoint: "turn-first",
+        retainThroughProviderCheckpoint: "checkpoint-first",
         threadId: thread.id,
       });
       expect(listEvents(harness.db, { threadId: thread.id })).toHaveLength(11);
@@ -724,8 +724,7 @@ describe("editThreadMessage", () => {
         );
         expect(rewind.command).toMatchObject({
           providerId,
-          retainThroughProviderCheckpoint:
-            providerId === "codex" ? "turn-first" : "checkpoint-first",
+          retainThroughProviderCheckpoint: "checkpoint-first",
           sourceProviderThreadId: "provider-original",
         });
         if (rewind.command.type !== "thread.rewind.prepare") {
@@ -907,9 +906,9 @@ describe("editThreadMessage", () => {
         (queued) => queued.command.type === "thread.rewind.prepare",
       );
       // Resolving skips the ineligible grouped candidate and lands on
-      // sequence 7, whose preceding root turn is turn-first.
+      // sequence 7, whose preceding root turn has checkpoint-first.
       expect(rewind.command).toMatchObject({
-        retainThroughProviderCheckpoint: "turn-first",
+        retainThroughProviderCheckpoint: "checkpoint-first",
       });
       await reportQueuedCommandError(harness, rewind, {
         errorCode: "provider_error",
@@ -1193,6 +1192,38 @@ describe("editThreadMessage", () => {
       });
     },
   );
+
+  it("falls back to a legacy Codex turn id when history has no checkpoint", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedEditableThread(harness, {
+        firstProviderCheckpoint: null,
+      });
+      const editPromise = editThreadMessage(harness.deps, {
+        environment,
+        thread,
+        payload: {
+          operationId: "edit-op-legacy-codex",
+          expectedRequestSequence: 7,
+          input: [{ type: "text", text: "Replacement", mentions: [] }],
+        },
+      });
+
+      const rewind = await waitForQueuedCommand(
+        harness,
+        (queued) => queued.command.type === "thread.rewind.prepare",
+      );
+      expect(rewind.command).toMatchObject({
+        retainThroughProviderCheckpoint: "turn-first",
+      });
+      if (rewind.command.type !== "thread.rewind.prepare") {
+        throw new Error("Expected a thread.rewind.prepare command");
+      }
+      await reportQueuedCommandSuccess(harness, rewind, {
+        providerThreadId: "provider-staged-legacy-codex",
+      });
+      await expect(editPromise).resolves.toMatchObject({ ok: true });
+    });
+  });
 
   it("leaves the original suffix untouched when Codex cannot stage the rewind", async () => {
     await withTestHarness(async (harness) => {

--- a/plugins/provider-codex/src/bridge/bridge.ts
+++ b/plugins/provider-codex/src/bridge/bridge.ts
@@ -18,8 +18,8 @@
  *   delta assembler mints the bb ids and reverse-maps command-plane ids, so
  *   steer's expectedTurnId and interrupt's activeTurnId arrive here already
  *   provider-native and the bridge does zero id translation. `turn.boundary`
- *   carries the Codex turn id as `providerCheckpointId` on every terminal turn
- *   so checkpoint forks survive bridge and runtime restarts.
+ *   carries the Codex turn id as `providerCheckpointId` on completed and
+ *   interrupted turns so checkpoint forks survive bridge and runtime restarts.
  * - Canonical → codex method mapping: `thread/stop {intent: "interrupt"}` →
  *   `turn/interrupt`; `{intent: "release"}` → kill that thread's child (no
  *   fabricated interruption — the rollout stays resumable, #1584);

--- a/plugins/provider-codex/src/bridge/bridge.ts
+++ b/plugins/provider-codex/src/bridge/bridge.ts
@@ -18,8 +18,8 @@
  *   delta assembler mints the bb ids and reverse-maps command-plane ids, so
  *   steer's expectedTurnId and interrupt's activeTurnId arrive here already
  *   provider-native and the bridge does zero id translation. `turn.boundary`
- *   carries the Codex turn id as `providerCheckpointId` on completed turns so
- *   checkpoint forks survive bridge and runtime restarts.
+ *   carries the Codex turn id as `providerCheckpointId` on every terminal turn
+ *   so checkpoint forks survive bridge and runtime restarts.
  * - Canonical → codex method mapping: `thread/stop {intent: "interrupt"}` →
  *   `turn/interrupt`; `{intent: "release"}` → kill that thread's child (no
  *   fabricated interruption — the rollout stays resumable, #1584);

--- a/plugins/provider-codex/src/bridge/bridge.zero-work-turn.test.ts
+++ b/plugins/provider-codex/src/bridge/bridge.zero-work-turn.test.ts
@@ -132,6 +132,43 @@ it("settles a prompt the app-server accepts without any turn activity", async ()
   ]);
 }, 30_000);
 
+it("preserves the native checkpoint when thread/stop interrupts a turn", async () => {
+  const providerThreadId = await startSession();
+  harness.sendRequest(2, "turn/start", {
+    threadId: THREAD_ID,
+    providerThreadId,
+    input: [{ type: "text", text: "/wait-for-interrupt", mentions: [] }],
+    clientRequestId: "creq_a2b3c4d5e6",
+    options: { ...sessionOptions },
+  });
+  await harness.waitForResponse(2);
+  await waitForEvents((events) =>
+    events.some((event) => event.type === "turn/started"),
+  );
+
+  harness.sendRequest(3, "thread/stop", {
+    threadId: THREAD_ID,
+    providerThreadId,
+    intent: "interrupt",
+    activeTurnId: "turn-fx-1",
+  });
+  await harness.waitForResponse(3);
+
+  const events = await waitForEvents((all) =>
+    all.some(
+      (event) =>
+        event.type === "turn/completed" && event.status === "interrupted",
+    ),
+  );
+  expect(events).toContainEqual(
+    expect.objectContaining({
+      type: "turn/completed",
+      status: "interrupted",
+      providerCheckpointId: "turn-fx-1",
+    }),
+  );
+}, 30_000);
+
 it("lets a turn/started that lands after the turn/start response win the race", async () => {
   const providerThreadId = await startSession();
   harness.sendRequest(2, "turn/start", {

--- a/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
+++ b/plugins/provider-codex/src/bridge/fake-codex-app-server.mjs
@@ -60,6 +60,9 @@ const ZERO_WORK_PROMPT_TEXT = "/clear";
 const LATE_TURN_START_PROMPT_TEXT = "/late-start";
 const LATE_TURN_START_DELAY_MS = 60;
 
+/** A prompt that stays open until the client sends turn/interrupt. */
+const INTERRUPTIBLE_PROMPT_TEXT = "/wait-for-interrupt";
+
 /**
  * A prompt that spawns a native subagent (open thread work) and then dies with
  * the subagent still running — the crash/OOM shape. The bridge has to settle
@@ -327,6 +330,17 @@ async function handleRequest(message) {
           () => runScriptedTurn(params.threadId),
           LATE_TURN_START_DELAY_MS,
         );
+        return;
+      }
+      if (firstInputText(params.input) === INTERRUPTIBLE_PROMPT_TEXT) {
+        turnCounter += 1;
+        const turnId = `turn-fx-${turnCounter}`;
+        openTurnIdsByThreadId.set(params.threadId, turnId);
+        notify("turn/started", {
+          threadId: params.threadId,
+          turn: { id: turnId, status: "inProgress" },
+        });
+        respond(id, {});
         return;
       }
       if (scriptedTurns) {

--- a/plugins/provider-codex/src/delta-translation.test.ts
+++ b/plugins/provider-codex/src/delta-translation.test.ts
@@ -185,7 +185,7 @@ describe("codex turn lifecycle translation", () => {
     }
   });
 
-  it("translates turn/completed with status and error", () => {
+  it("translates a failed turn/completed with its fork checkpoint", () => {
     const harness = createHarness();
     const events = harness.translate(
       codexEvent("turn/completed", {
@@ -207,10 +207,9 @@ describe("codex turn lifecycle translation", () => {
         scope: turnScope(harness.turnId("turn-1")),
         status: "failed",
         error: { message: "rate limited" },
+        providerCheckpointId: "turn-1",
       }),
     );
-    // Only completed turns are fork points.
-    expect(events[0]).not.toHaveProperty("providerCheckpointId");
   });
 
   it("stamps the codex turn id as providerCheckpointId on completed turns", () => {
@@ -230,7 +229,7 @@ describe("codex turn lifecycle translation", () => {
     ]);
   });
 
-  it("maps interrupted turn status", () => {
+  it("maps interrupted turn status with its fork checkpoint", () => {
     const harness = createHarness();
     const events = harness.translate(
       codexEvent("turn/completed", {
@@ -242,6 +241,7 @@ describe("codex turn lifecycle translation", () => {
       expect.objectContaining({
         type: "turn/completed",
         status: "interrupted",
+        providerCheckpointId: "turn-1",
       }),
     );
   });

--- a/plugins/provider-codex/src/delta-translation.test.ts
+++ b/plugins/provider-codex/src/delta-translation.test.ts
@@ -185,7 +185,7 @@ describe("codex turn lifecycle translation", () => {
     }
   });
 
-  it("translates a failed turn/completed with its fork checkpoint", () => {
+  it("translates a failed turn/completed without claiming a fork checkpoint", () => {
     const harness = createHarness();
     const events = harness.translate(
       codexEvent("turn/completed", {
@@ -207,9 +207,9 @@ describe("codex turn lifecycle translation", () => {
         scope: turnScope(harness.turnId("turn-1")),
         status: "failed",
         error: { message: "rate limited" },
-        providerCheckpointId: "turn-1",
       }),
     );
+    expect(events[0]).not.toHaveProperty("providerCheckpointId");
   });
 
   it("stamps the codex turn id as providerCheckpointId on completed turns", () => {

--- a/plugins/provider-codex/src/delta-translation.ts
+++ b/plugins/provider-codex/src/delta-translation.ts
@@ -765,10 +765,12 @@ export function translateCodexEventToDeltas(
             : {}),
           // The Codex turn id is the value codex thread/fork accepts as
           // lastTurnId, and unlike any in-memory map it survives bridge and
-          // runtime restarts. turn/completed is terminal even when the status
-          // is failed or interrupted, so all of its native ids are fork
-          // checkpoints.
-          providerCheckpointId: handledEvent.params.turn.id,
+          // runtime restarts. Completed and interrupted turns are persisted
+          // fork points. Failed turns can be absent from older Codex rollouts,
+          // so do not claim a checkpoint for those without equivalent proof.
+          ...(status === "completed" || status === "interrupted"
+            ? { providerCheckpointId: handledEvent.params.turn.id }
+            : {}),
         },
       ];
     }

--- a/plugins/provider-codex/src/delta-translation.ts
+++ b/plugins/provider-codex/src/delta-translation.ts
@@ -765,11 +765,10 @@ export function translateCodexEventToDeltas(
             : {}),
           // The Codex turn id is the value codex thread/fork accepts as
           // lastTurnId, and unlike any in-memory map it survives bridge and
-          // runtime restarts. Only completed turns are fork points — a failed
-          // or interrupted turn may be absent from the rollout.
-          ...(status === "completed"
-            ? { providerCheckpointId: handledEvent.params.turn.id }
-            : {}),
+          // runtime restarts. turn/completed is terminal even when the status
+          // is failed or interrupted, so all of its native ids are fork
+          // checkpoints.
+          providerCheckpointId: handledEvent.params.turn.id,
         },
       ];
     }


### PR DESCRIPTION
## What was wrong

Sent-message editing had three related compatibility assumptions:

- After the narrow provider-bridge grammar moved canonical timeline assembly into the runtime, bb turn IDs and native Codex turn IDs became intentionally different, but the server still sent the bb timeline ID as the Codex rewind checkpoint.
- The Codex bridge only persisted checkpoints for successfully completed turns, even though Codex also persists and accepts interrupted turn IDs as fork boundaries. Editing after a stopped turn therefore fell back to a bb ID such as `da2f291120-t3`, which Codex correctly rejected as absent from its source thread.
- The web client called `crypto.randomUUID` directly even though some supported browser contexts expose Web Crypto `getRandomValues` without `randomUUID`, causing the edit action to throw before the editor opened.

The failures were reproduced from the originally reported thread and from the interrupted-turn repro in `thr_kfzu8tqu2d`.

## What changed

Codex rewinds now use the persisted native `providerCheckpointId`. The compatibility fallback is restricted to UUID-shaped turn IDs from legacy Codex timelines, so a runtime-minted bb ID can never be forwarded to Codex.

The Codex bridge now persists the native checkpoint for completed and interrupted `turn/completed` statuses. This makes edits after a stopped Codex turn use the fork point Codex actually emitted. Failed turns remain unstamped because older Codex rollouts may omit them and no equivalent fork proof exists for that status.

Web edit sessions now create operation IDs through `nanoid`, which is already an app dependency and works when `crypto.randomUUID` is unavailable. ID generation remains inside the edit click handler.

These changes populate and validate the existing `providerCheckpointId` / `retainThroughProviderCheckpoint` fields; they do not change the server/daemon wire contract, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged. There are no CLI, guide, or configuration changes.

## How you verified

- Direct `codex app-server` `thread/read` showed the interrupted native turn ID, and an ephemeral `thread/fork` using it as `lastTurnId` succeeded.
- Before the original server implementation change, the focused suite failed 8 Codex cases with `checkpoint-first` expected and `turn-first` received.
- `pnpm exec turbo run test --filter=@bb/server -- --run test/threads/thread-edit-message.test.ts` — 42 passed.
- `pnpm exec turbo run test --filter=bb-plugin-provider-codex -- --run src/delta-translation.test.ts src/bridge/bridge.zero-work-turn.test.ts` — 61 passed, including the full `thread/stop` → interrupted completion checkpoint path.
- `pnpm exec turbo run typecheck --filter=@bb/server` — passed.
- `pnpm exec turbo run typecheck --filter=bb-plugin-provider-codex` — passed.
- Before the web implementation change, the compatibility test failed with `TypeError: crypto.randomUUID is not a function`.
- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/views/thread-detail/sent-message-edit-operation-id.test.ts` — passed.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.
- `pnpm exec turbo run lint --filter=@bb/app` — passed with 0 errors and 144 existing warnings.

Fixes the reported sent-message edit failures.

> AGENT GENERATED: by GPT-5
