### PR TITLE
Mobile: dark-safe scrims, keyboard gap, project folder icon, round stop button

### DIFF
--- a/apps/mobile/app/(drawer)/_layout.tsx
+++ b/apps/mobile/app/(drawer)/_layout.tsx
@@ -1,10 +1,11 @@
 import { Drawer } from "expo-router/drawer";
 import { useProfiles } from "@/app-shell";
 import { DrawerContent } from "@/screens";
-import { useTheme } from "@/theme";
+import { withAlpha } from "@/markdown/colors";
+import { scrimBaseColor, useTheme } from "@/theme";
 
 export default function DrawerLayout() {
-  const { tokens, fonts } = useTheme();
+  const { tokens, fonts, mode } = useTheme();
   const { activeProfile } = useProfiles();
   return (
     <Drawer
@@ -21,6 +22,7 @@ export default function DrawerLayout() {
         },
         drawerStyle: { backgroundColor: tokens.sidebar, width: 300 },
         drawerType: "front",
+        overlayColor: withAlpha(scrimBaseColor(mode, tokens), 0.45),
         sceneStyle: { backgroundColor: tokens.background },
         swipeEdgeWidth: 48,
       }}

--- a/apps/mobile/src/composer/Composer.tsx
+++ b/apps/mobile/src/composer/Composer.tsx
@@ -13,7 +13,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { Pressable, View } from "react-native";
+import { Pressable, View, type StyleProp, type ViewStyle } from "react-native";
 import { haptic } from "@/lib/haptics";
 import { useProfileClient } from "@/app-shell/ProfilesProvider";
 import { buildProjectAttachmentContentUrl } from "@/data/thread-detail";
@@ -521,13 +521,9 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(
               {/* Collapsed right slot: Stop while a turn runs (it must stay
                   reachable without expanding), else the mic, else a spacer. */}
               {collapsed && affordance.stop ? (
-                <Button
-                  variant="secondary"
-                  size="icon"
-                  icon="Square"
-                  accessibilityLabel="Stop"
-                  haptic
+                <StopButton
                   onPress={affordance.stop}
+                  style={{ marginRight: 4 }}
                   testID={`${testID}-stop`}
                 />
               ) : collapsed && showVoicePrimary ? (
@@ -578,12 +574,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(
                 </View>
                 {footerAccessory}
                 {affordance.stop ? (
-                  <Button
-                    variant="secondary"
-                    size="icon"
-                    icon="Square"
-                    accessibilityLabel="Stop"
-                    haptic
+                  <StopButton
                     onPress={affordance.stop}
                     testID={`${testID}-stop`}
                   />
@@ -687,5 +678,55 @@ function usePromptActionApplier({
       inputRef.current?.focus();
     },
     [commit, inputRef, valueRef],
+  );
+}
+
+/**
+ * Round "stop the run" button, the same 36pt circle as the send button so the
+ * collapsed pill and the expanded footer keep one silhouette. A filled square
+ * (web: `Square` with `fill-current`), not the stroked icon, reads as stop.
+ */
+function StopButton({
+  onPress,
+  style,
+  testID,
+}: {
+  onPress: () => void;
+  style?: StyleProp<ViewStyle>;
+  testID: string;
+}) {
+  const { tokens } = useTheme();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel="Stop"
+      hitSlop={4}
+      onPress={() => {
+        haptic("impact-medium");
+        onPress();
+      }}
+      testID={testID}
+      style={({ pressed }) => [
+        {
+          width: 36,
+          height: 36,
+          borderRadius: 18,
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: tokens.secondary,
+          opacity: pressed ? 0.8 : 1,
+        },
+        style,
+      ]}
+    >
+      <View
+        style={{
+          width: 12,
+          height: 12,
+          borderRadius: 2,
+          backgroundColor: tokens.secondaryForeground,
+        }}
+      />
+    </Pressable>
   );
 }

--- a/apps/mobile/src/screens/dev/ComposerShowcaseScreen.tsx
+++ b/apps/mobile/src/screens/dev/ComposerShowcaseScreen.tsx
@@ -20,6 +20,7 @@ import { useSystemProviders } from "@/data/system";
 import {
   Button,
   EmptyStatePanel,
+  COMPOSER_KEYBOARD_GAP,
   KeyboardPaddingView,
   Text,
   toast,
@@ -76,7 +77,10 @@ function ConnectedComposerShowcase() {
   );
   return (
     <Screen scroll={false} testID="dev-composer-screen">
-      <KeyboardPaddingView style={{ flex: 1 }}>
+      <KeyboardPaddingView
+        style={{ flex: 1 }}
+        keyboardGap={COMPOSER_KEYBOARD_GAP}
+      >
         <ScrollView
           className="flex-1"
           contentContainerStyle={{ padding: 16, gap: 12 }}

--- a/apps/mobile/src/screens/home/HomeScreen.tsx
+++ b/apps/mobile/src/screens/home/HomeScreen.tsx
@@ -17,11 +17,12 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useProfiles } from "@/app-shell";
 import type { ComposerHandle } from "@/composer";
 import { blendOver, withAlpha } from "@/markdown/colors";
-import { useTheme } from "@/theme";
+import { scrimBaseColor, useTheme } from "@/theme";
 import {
   Button,
   EmptyStatePanel,
   Icon,
+  COMPOSER_KEYBOARD_GAP,
   KeyboardPaddingView,
   Spinner,
   Text,
@@ -40,7 +41,7 @@ import {
 } from "../sidebar";
 
 const SCRIM_DURATION_MS = 180;
-/** Opacity of the ink scrim over the list while the dock is expanded. */
+/** Opacity of the scrim over the list while the dock is expanded. */
 const SCRIM_ALPHA = 0.35;
 
 /**
@@ -52,13 +53,14 @@ const SCRIM_ALPHA = 0.35;
 function HomeHeaderActions({ dimmed }: { dimmed: boolean }) {
   const navigation = useNavigation();
   const router = useRouter();
-  const { tokens, fonts } = useTheme();
+  const { tokens, fonts, mode } = useTheme();
   const actions = useSidebarActions();
+  const scrimColor = scrimBaseColor(mode, tokens);
   const background = dimmed
-    ? blendOver(tokens.background, tokens.ink, SCRIM_ALPHA)
+    ? blendOver(tokens.background, scrimColor, SCRIM_ALPHA)
     : tokens.background;
   const foreground = dimmed
-    ? blendOver(tokens.foreground, tokens.ink, SCRIM_ALPHA)
+    ? blendOver(tokens.foreground, scrimColor, SCRIM_ALPHA)
     : tokens.foreground;
   useLayoutEffect(() => {
     navigation.setOptions({
@@ -180,7 +182,7 @@ function useNewThreadRouteParams(): {
 function HomeBody() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
-  const { tokens } = useTheme();
+  const { tokens, mode } = useTheme();
   const route = useNewThreadRouteParams();
   const controller = useComposeController(route.params);
   const composerRef = useRef<ComposerHandle | null>(null);
@@ -244,7 +246,10 @@ function HomeBody() {
   return (
     <SidebarActionsProvider onCreateThread={createThreadInDock}>
       <HomeHeaderActions dimmed={expanded} />
-      <KeyboardPaddingView style={{ flex: 1 }}>
+      <KeyboardPaddingView
+        style={{ flex: 1 }}
+        keyboardGap={COMPOSER_KEYBOARD_GAP}
+      >
         <View className="flex-1">
           <SidebarThreadList
             contentContainerStyle={{ paddingBottom: 16 }}
@@ -263,7 +268,10 @@ function HomeBody() {
               right: 0,
               bottom: 0,
               opacity: scrim,
-              backgroundColor: withAlpha(tokens.ink, SCRIM_ALPHA),
+              backgroundColor: withAlpha(
+                scrimBaseColor(mode, tokens),
+                SCRIM_ALPHA,
+              ),
             }}
           >
             <Pressable

--- a/apps/mobile/src/screens/sidebar/SidebarRows.tsx
+++ b/apps/mobile/src/screens/sidebar/SidebarRows.tsx
@@ -48,11 +48,19 @@ function CountChip({ count }: { count: number }) {
   );
 }
 
+export type SidebarRowSubtitle =
+  | { kind: "project"; name: string }
+  | { kind: "snippet"; text: string };
+
 export interface SidebarThreadRowViewProps {
   row: SidebarThreadRow;
   selected: boolean;
-  /** Second line: the project name outside project mode, or nothing. */
-  subtitle: string | null;
+  /**
+   * Second line: the project name outside project mode (with a folder icon
+   * so it reads as a project, not a second title), a search snippet, or
+   * nothing.
+   */
+  subtitle: SidebarRowSubtitle | null;
   onPress: (row: SidebarThreadRow) => void;
   onLongPress: (row: SidebarThreadRow) => void;
   onToggleCollapsed: (threadId: string) => void;
@@ -66,6 +74,7 @@ export const SidebarThreadRowView = memo(function SidebarThreadRowView({
   onLongPress,
   onToggleCollapsed,
 }: SidebarThreadRowViewProps) {
+  const { tokens } = useTheme();
   const { thread } = row;
   const title = getThreadDisplayTitle(thread);
   const unread = !isThreadRead(thread) && thread.parentThreadId === null;
@@ -73,7 +82,7 @@ export const SidebarThreadRowView = memo(function SidebarThreadRowView({
     <Pressable
       accessibilityRole="button"
       accessibilityLabel={title}
-      accessibilityHint={subtitle ?? undefined}
+      accessibilityHint={subtitleText(subtitle)}
       accessibilityState={{ selected }}
       onPress={() => onPress(row)}
       onLongPress={() => onLongPress(row)}
@@ -111,9 +120,20 @@ export const SidebarThreadRowView = memo(function SidebarThreadRowView({
         >
           {title}
         </Text>
-        {subtitle ? (
+        {subtitle?.kind === "project" ? (
+          <View className="flex-row items-center gap-1">
+            <Icon name="Folder" size={12} color={tokens.mutedForeground} />
+            <Text
+              variant="caption"
+              numberOfLines={1}
+              className="min-w-0 shrink"
+            >
+              {subtitle.name}
+            </Text>
+          </View>
+        ) : subtitle?.kind === "snippet" ? (
           <Text variant="caption" numberOfLines={1}>
-            {subtitle}
+            {subtitle.text}
           </Text>
         ) : null}
       </View>
@@ -123,6 +143,18 @@ export const SidebarThreadRowView = memo(function SidebarThreadRowView({
     </Pressable>
   );
 });
+
+/** The project-name subtitle for a row, or nothing when there is no name. */
+export function projectSubtitle(
+  name: string | null,
+): SidebarRowSubtitle | null {
+  return name === null ? null : { kind: "project", name };
+}
+
+function subtitleText(subtitle: SidebarRowSubtitle | null): string | undefined {
+  if (subtitle === null) return undefined;
+  return subtitle.kind === "project" ? subtitle.name : subtitle.text;
+}
 
 export interface SidebarHeaderRowViewProps {
   row: SidebarHeaderRow;

--- a/apps/mobile/src/screens/sidebar/SidebarThreadList.tsx
+++ b/apps/mobile/src/screens/sidebar/SidebarThreadList.tsx
@@ -15,6 +15,7 @@ import {
   SidebarEmptyRowView,
   SidebarEnvironmentRowView,
   SidebarHeaderRowView,
+  projectSubtitle,
   SidebarThreadRowView,
 } from "./SidebarRows";
 import {
@@ -179,11 +180,11 @@ export function SidebarThreadList({
             <SidebarThreadRowView
               row={item}
               selected={thread.id === selectedThreadId}
-              subtitle={
+              subtitle={projectSubtitle(
                 showProject
                   ? (projectNamesById.get(thread.projectId) ?? null)
-                  : null
-              }
+                  : null,
+              )}
               onPress={onThreadPress}
               onLongPress={onThreadLongPress}
               onToggleCollapsed={onToggleThread}

--- a/apps/mobile/src/screens/sidebar/index.ts
+++ b/apps/mobile/src/screens/sidebar/index.ts
@@ -9,7 +9,9 @@ export {
   type SidebarThreadListProps,
 } from "./SidebarThreadList";
 export {
+  projectSubtitle,
   SidebarThreadRowView,
+  type SidebarRowSubtitle,
   type SidebarThreadRowViewProps,
 } from "./SidebarRows";
 export { ThreadStatusGlyph } from "./ThreadStatusGlyph";

--- a/apps/mobile/src/screens/thread/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/screens/thread/ThreadDetailScreen.tsx
@@ -36,6 +36,7 @@ import {
 import {
   Button,
   EmptyStatePanel,
+  COMPOSER_KEYBOARD_GAP,
   KeyboardPaddingView,
   Skeleton,
   Text,
@@ -423,7 +424,10 @@ function ThreadDetailBody({ threadId }: { threadId: string }) {
         }}
       />
       {turnLoaders}
-      <KeyboardPaddingView style={{ flex: 1 }}>
+      <KeyboardPaddingView
+        style={{ flex: 1 }}
+        keyboardGap={COMPOSER_KEYBOARD_GAP}
+      >
         {(timelineLoading && entries.length === 0) || !threadReady ? (
           <View className="flex-1">
             <TimelineSkeleton />

--- a/apps/mobile/src/screens/threads/ArchivedThreadsScreen.tsx
+++ b/apps/mobile/src/screens/threads/ArchivedThreadsScreen.tsx
@@ -29,7 +29,9 @@ import { Screen } from "../shell/Screen";
 import {
   resolveThreadRowIndicator,
   SidebarActionsProvider,
+  projectSubtitle,
   SidebarThreadRowView,
+  type SidebarRowSubtitle,
   useSidebarActions,
   type SidebarThreadRow,
 } from "../sidebar";
@@ -63,7 +65,7 @@ function ArchivedRow({
   pending,
 }: {
   row: SidebarThreadRow;
-  subtitle: string | null;
+  subtitle: SidebarRowSubtitle | null;
   onPress: (row: SidebarThreadRow) => void;
   onLongPress: (row: SidebarThreadRow) => void;
   onUnarchive: (thread: ThreadListEntry) => void;
@@ -161,11 +163,11 @@ function ArchivedBody({
     ({ item }: ListRenderItemInfo<SidebarThreadRow>) => (
       <ArchivedRow
         row={item}
-        subtitle={
+        subtitle={projectSubtitle(
           projectId === null
             ? (projectNamesById.get(item.thread.projectId) ?? null)
-            : null
-        }
+            : null,
+        )}
         onPress={onPress}
         onLongPress={onLongPress}
         onUnarchive={onUnarchive}

--- a/apps/mobile/src/screens/threads/ThreadSearchScreen.tsx
+++ b/apps/mobile/src/screens/threads/ThreadSearchScreen.tsx
@@ -19,7 +19,9 @@ import { Screen } from "../shell/Screen";
 import {
   resolveThreadRowIndicator,
   SidebarActionsProvider,
+  projectSubtitle,
   SidebarThreadRowView,
+  type SidebarRowSubtitle,
   useSidebarActions,
   type SidebarThreadRow,
 } from "../sidebar";
@@ -157,8 +159,12 @@ function SearchBody() {
           </Text>
         );
       }
-      const projectName = projectNamesById.get(item.row.thread.projectId);
-      const subtitle = item.snippet ?? projectName ?? null;
+      const subtitle: SidebarRowSubtitle | null =
+        item.snippet !== null && item.snippet !== undefined
+          ? { kind: "snippet", text: item.snippet }
+          : projectSubtitle(
+              projectNamesById.get(item.row.thread.projectId) ?? null,
+            );
       return (
         <SidebarThreadRowView
           row={item.row}

--- a/apps/mobile/src/theme/index.ts
+++ b/apps/mobile/src/theme/index.ts
@@ -25,6 +25,7 @@ export {
   type ThemeModePreference,
   type ThemePreferenceStorage,
 } from "./theme-preference";
+export { scrimBaseColor } from "./scrim";
 export { buildThemeVars, tokenKeyToCssVar } from "./theme-vars";
 export {
   nativeRadii,

--- a/apps/mobile/src/theme/scrim.test.ts
+++ b/apps/mobile/src/theme/scrim.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { blendOver } from "@/markdown/colors";
+import { scrimBaseColor } from "./scrim";
+import { nativeThemes } from "./theme.native";
+
+function luminance(color: string): number {
+  const match = /^rgb\((\d+), (\d+), (\d+)\)$/u.exec(color);
+  if (!match) throw new Error(`unexpected color ${color}`);
+  return (
+    0.2126 * Number(match[1]) +
+    0.7152 * Number(match[2]) +
+    0.0722 * Number(match[3])
+  );
+}
+
+describe("scrimBaseColor", () => {
+  it("darkens the background in every palette and mode", () => {
+    for (const [palette, modes] of Object.entries(nativeThemes)) {
+      for (const mode of ["light", "dark"] as const) {
+        const tokens = modes[mode];
+        const scrim = scrimBaseColor(mode, tokens);
+        const before = luminance(blendOver(tokens.background, scrim, 0));
+        const after = luminance(blendOver(tokens.background, scrim, 0.35));
+        expect(after, `${palette}/${mode}`).toBeLessThan(before);
+      }
+    }
+  });
+});

--- a/apps/mobile/src/theme/scrim.ts
+++ b/apps/mobile/src/theme/scrim.ts
@@ -1,0 +1,17 @@
+import type { ThemeMode } from "./theme-preference";
+import type { NativeThemeTokens } from "./theme.native";
+
+/**
+ * The base color of every dimming overlay (the home compose scrim, sheet
+ * backdrops). A scrim must darken what is under it in both modes: `ink` does
+ * that in light mode, but dark palettes have a light `ink` (`#cdd6f4`,
+ * `#f8f8f2`, …) and an ink scrim washes the screen out to gray. Dark mode
+ * therefore dims toward black, which every palette reads as "darker than the
+ * canvas". Callers apply their own alpha with `withAlpha`.
+ */
+export function scrimBaseColor(
+  mode: ThemeMode,
+  tokens: Pick<NativeThemeTokens, "ink">,
+): string {
+  return mode === "dark" ? "#000000" : tokens.ink;
+}

--- a/apps/mobile/src/ui/KeyboardPaddingView.tsx
+++ b/apps/mobile/src/ui/KeyboardPaddingView.tsx
@@ -11,9 +11,18 @@ import {
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
+/** Gap kept between a composer and the open keyboard. */
+export const COMPOSER_KEYBOARD_GAP = 8;
+
 export interface KeyboardPaddingViewProps {
   children: ReactNode;
   style?: StyleProp<ViewStyle>;
+  /**
+   * Extra bottom padding while the keyboard is open, so a composer that sits
+   * on the home-indicator inset when the keyboard is closed keeps a small gap
+   * above the keyboard instead of touching it. Defaults to 0.
+   */
+  keyboardGap?: number;
   testID?: string;
 }
 
@@ -33,6 +42,7 @@ export interface KeyboardPaddingViewProps {
 export function KeyboardPaddingView({
   children,
   style,
+  keyboardGap = 0,
   testID,
 }: KeyboardPaddingViewProps) {
   const { height: windowHeight } = useWindowDimensions();
@@ -44,8 +54,12 @@ export function KeyboardPaddingView({
     if (Platform.OS !== "ios") return;
     const apply = (event: KeyboardEvent, keyboardScreenY: number) => {
       const keyboardHeight = Math.max(0, windowHeight - keyboardScreenY);
-      // The keyboard covers the home-indicator inset the content already pads.
-      const next = Math.max(0, keyboardHeight - bottomInset);
+      // The keyboard covers the home-indicator inset the content already pads;
+      // `keyboardGap` keeps a little of it as a gap above the keyboard.
+      const next =
+        keyboardHeight > 0
+          ? Math.max(0, keyboardHeight - bottomInset + keyboardGap)
+          : 0;
       if (event.duration > 0) {
         LayoutAnimation.configureNext({
           duration: event.duration,
@@ -69,7 +83,7 @@ export function KeyboardPaddingView({
     return () => {
       for (const subscription of subscriptions) subscription.remove();
     };
-  }, [bottomInset, windowHeight]);
+  }, [bottomInset, keyboardGap, windowHeight]);
 
   return (
     <View style={[style, { paddingBottom }]} testID={testID}>

--- a/apps/mobile/src/ui/Sheet.tsx
+++ b/apps/mobile/src/ui/Sheet.tsx
@@ -22,6 +22,7 @@ import {
 import { Keyboard, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useTheme } from "@/theme/ThemeProvider";
+import { scrimBaseColor } from "@/theme/scrim";
 import { Text } from "./Text";
 import { useDeferredRealization } from "./useDeferredRealization";
 
@@ -119,7 +120,8 @@ export function Sheet({
   deferContent = true,
 }: SheetProps) {
   const modalRef = useRef<BottomSheetModal>(null);
-  const { tokens, radii } = useTheme();
+  const { tokens, radii, mode } = useTheme();
+  const scrimColor = scrimBaseColor(mode, tokens);
   const insets = useSafeAreaInsets();
   const [presented, setPresented] = useState(false);
   const realized = useDeferredRealization(presented);
@@ -156,9 +158,10 @@ export function Sheet({
         disappearsOnIndex={-1}
         opacity={0.45}
         pressBehavior="close"
+        style={[props.style, { backgroundColor: scrimColor }]}
       />
     ),
-    [],
+    [scrimColor],
   );
 
   const dynamic = enableDynamicSizing ?? snapPoints === undefined;

--- a/apps/mobile/src/ui/index.ts
+++ b/apps/mobile/src/ui/index.ts
@@ -36,6 +36,7 @@ export {
 } from "./Icon";
 export { Input, type InputProps } from "./Input";
 export {
+  COMPOSER_KEYBOARD_GAP,
   KeyboardPaddingView,
   type KeyboardPaddingViewProps,
 } from "./KeyboardPaddingView";


### PR DESCRIPTION
## What was wrong

Four mobile polish issues from dogfooding on a phone:

- Every dimming overlay (home compose scrim, sheet backdrops) used `tokens.ink` at 35%. Dark palettes have a light `ink`, so the overlay lightened the screen to gray instead of dimming it.
- `KeyboardPaddingView` subtracted the full home-indicator inset when the keyboard opened, so composers sat flush against the keyboard.
- In the flat thread list the project name under a title was plain text and read like a second title.
- The collapsed composer's Stop control was a square `secondary` button with a stroked square icon, flush with the pill edge.

## What changed

- `apps/mobile/src/theme/scrim.ts`: `scrimBaseColor(mode, tokens)` — `ink` in light mode, black in dark mode. Used by the home compose scrim + dimmed header (`HomeScreen.tsx`), the bottom-sheet backdrop (`ui/Sheet.tsx`), and the navigation drawer overlay (`app/(drawer)/_layout.tsx`).
- `ui/KeyboardPaddingView.tsx`: new `keyboardGap` prop and `COMPOSER_KEYBOARD_GAP = 8`; applied to the home dock, thread composer, and composer showcase.
- `screens/sidebar/SidebarRows.tsx`: thread-row subtitle is now `{kind:"project"} | {kind:"snippet"}`; project subtitles render a `Folder` icon. Search snippets stay plain. Archived/search screens updated.
- `composer/Composer.tsx`: `StopButton` — a 36pt round `secondary` circle with a filled square, used in both the collapsed pill and the expanded footer.

## How you verified

- `pnpm exec turbo run typecheck lint --filter=@bb/mobile` pass.
- New `scrim.test.ts` asserts the scrim darkens `background` for every palette × mode (fails with the old `ink` scrim in dark mode).
- Simulator (iPhone 17 Pro, dark mode) against the local dev server: home compose scrim, display-options sheet backdrop, keyboard gap, project folder subtitle, and collapsed Stop button during a live turn.
- Release build installed on a physical iPhone for the scrim/gap/folder changes.

> AGENT GENERATED: by Claude Opus 5
