### PR TITLE
Fix intermittent new-thread submit blockers

### DIFF
--- a/apps/app/src/components/promptbox/NewThreadComposer.tsx
+++ b/apps/app/src/components/promptbox/NewThreadComposer.tsx
@@ -19,6 +19,7 @@ import type { NewThreadRequest } from "@get-bb/plugin-sdk";
 import type {
   CreateExecutionInputSources,
   SidebarBootstrapResponse,
+  SystemExecutionOptionsModelLoadError,
 } from "@bb/server-contract";
 import type { ProjectSelectorCreateProjectConfig } from "@/components/pickers/ProjectSelector";
 import {
@@ -26,6 +27,7 @@ import {
   encodeReuseValue,
   parseEnvironmentValue,
 } from "@/components/pickers/environment-picker-value";
+import { formatModelLoadErrorText } from "@/components/pickers/model-load-error-message";
 import {
   NewThreadPromptBox,
   type NewThreadPromptBoxProps,
@@ -115,7 +117,8 @@ export interface NewThreadComposerPromptOptions {
   zenModeStorageKey: string;
   banner?: ReactNode;
   header?: ReactNode;
-  externallyBlocked?: boolean;
+  /** When present, submission is blocked and this reason is shown on the submit button. */
+  blockedReason?: string;
   resolveMentionLink?: PromptMentionLinkResolver;
   /** Override the host bound to this prompt box; omission uses this Composer's host. */
   pluginComposerHost?: PluginComposerHost;
@@ -184,6 +187,84 @@ type ProjectDefaultsState =
   | { status: "pending" }
   | { status: "error" }
   | { status: "resolved"; defaults: ProjectExecutionDefaults | null };
+
+export interface ResolveNewThreadSubmitDisabledReasonArgs {
+  branchMutationBlockerTitle: string | null;
+  isCopyingAttachments: boolean;
+  isLoadingModels: boolean;
+  isResolvingInitialProvider: boolean;
+  isSubmitting: boolean;
+  isUploading: boolean;
+  managedWorktreeAvailabilityPending: boolean;
+  managedWorktreeUnavailableReason: string | null;
+  modelLoadError: SystemExecutionOptionsModelLoadError | null;
+  projectDefaultsStatus: ProjectDefaultsState["status"];
+  projectDefaultsUnavailable: boolean;
+  promptInputEmpty: boolean;
+  providerDisplayName: string;
+  selectedProviderId: string;
+  selectedThreadModel: string;
+  submissionEnvironmentUnavailable: boolean;
+}
+
+export function resolveNewThreadSubmitDisabledReason({
+  branchMutationBlockerTitle,
+  isCopyingAttachments,
+  isLoadingModels,
+  isResolvingInitialProvider,
+  isSubmitting,
+  isUploading,
+  managedWorktreeAvailabilityPending,
+  managedWorktreeUnavailableReason,
+  modelLoadError,
+  projectDefaultsStatus,
+  projectDefaultsUnavailable,
+  promptInputEmpty,
+  providerDisplayName,
+  selectedProviderId,
+  selectedThreadModel,
+  submissionEnvironmentUnavailable,
+}: ResolveNewThreadSubmitDisabledReasonArgs): string | null {
+  if (isSubmitting) return "Starting thread...";
+  if (isCopyingAttachments) {
+    return "Moving attachments to the selected project...";
+  }
+  if (isUploading) return "Uploading attachments...";
+  if (projectDefaultsUnavailable) {
+    return projectDefaultsStatus === "error"
+      ? "Could not load the project's execution defaults."
+      : "Loading the project's execution defaults...";
+  }
+  if (isResolvingInitialProvider) {
+    return "Selecting a provider for the selected machine...";
+  }
+  if (!selectedProviderId) return "Select a provider.";
+  if (isLoadingModels) {
+    return "Loading models from the selected machine...";
+  }
+
+  const fatalModelLoadError =
+    modelLoadError?.code === "provider_unavailable" ||
+    modelLoadError?.code === "missing_executable" ||
+    modelLoadError?.code === "auth_required";
+  if (modelLoadError && (fatalModelLoadError || !selectedThreadModel)) {
+    return formatModelLoadErrorText({
+      error: modelLoadError,
+      providerLabel: providerDisplayName || selectedProviderId,
+    });
+  }
+  if (!selectedThreadModel) return "Select a model.";
+  if (submissionEnvironmentUnavailable) return "Select an environment.";
+  if (managedWorktreeAvailabilityPending) {
+    return "Checking worktree availability on the selected machine...";
+  }
+  if (managedWorktreeUnavailableReason) {
+    return managedWorktreeUnavailableReason;
+  }
+  if (branchMutationBlockerTitle) return branchMutationBlockerTitle;
+  if (promptInputEmpty) return "Enter a prompt or attach a file.";
+  return null;
+}
 
 export function resolveNewThreadProjectDefaultsState({
   cachedDefaults,
@@ -512,6 +593,7 @@ export function NewThreadComposer({
     reasoningOptions,
     selectedModel,
     selectedProviderComposerActions,
+    selectedProviderDisplayName,
     selectedProviderId,
     serviceTier,
     serviceTierSupportByProvider,
@@ -1003,32 +1085,36 @@ export function NewThreadComposer({
     selectedEnvironment ??
     (selectionScope === "new-thread" ? seed?.environment : undefined) ??
     null;
-  const baseSubmitDisabled =
-    !selectedProviderId ||
-    isLoadingModels ||
-    isResolvingInitialProvider ||
-    modelLoadError?.code === "provider_unavailable" ||
-    modelLoadError?.code === "missing_executable" ||
-    modelLoadError?.code === "auth_required" ||
-    !selectedThreadModel ||
-    isSubmitting ||
-    isCopyingAttachments ||
-    isUploading ||
-    projectDefaultsUnavailable ||
-    promptInput.length === 0 ||
-    submissionEnvironment === null ||
-    managedWorktreeAvailabilityPending ||
-    managedWorktreeUnavailable ||
-    (branchEnvironmentMode === "local" &&
-      selectedBranch !== null &&
-      branchUiState.mutationBlocker !== null);
+  const submitDisabledReason = resolveNewThreadSubmitDisabledReason({
+    branchMutationBlockerTitle:
+      branchEnvironmentMode === "local" && selectedBranch !== null
+        ? (branchUiState.mutationBlocker?.title ?? null)
+        : null,
+    isCopyingAttachments,
+    isLoadingModels,
+    isResolvingInitialProvider,
+    isSubmitting,
+    isUploading,
+    managedWorktreeAvailabilityPending,
+    managedWorktreeUnavailableReason: managedWorktreeUnavailable
+      ? worktreeDisabledReason
+      : null,
+    modelLoadError,
+    projectDefaultsStatus: projectDefaultsState.status,
+    projectDefaultsUnavailable,
+    promptInputEmpty: promptInput.length === 0,
+    providerDisplayName: selectedProviderDisplayName,
+    selectedProviderId,
+    selectedThreadModel,
+    submissionEnvironmentUnavailable: submissionEnvironment === null,
+  });
   const handleSubmit = useCallback(
-    async (externallyBlocked: boolean) => {
+    async (blockedReason: string | null) => {
       const submittedDraft = promptDraft.getCurrent();
       const input = promptDraftToInput(submittedDraft);
       if (
-        externallyBlocked ||
-        baseSubmitDisabled ||
+        blockedReason !== null ||
+        submitDisabledReason !== null ||
         input.length === 0 ||
         isSubmittingRef.current ||
         projectDefaultsUnavailable ||
@@ -1071,7 +1157,6 @@ export function NewThreadComposer({
       }
     },
     [
-      baseSubmitDisabled,
       clearReuseEnvironment,
       executionInputSources,
       managedWorktreeAvailabilityPending,
@@ -1083,6 +1168,7 @@ export function NewThreadComposer({
       promptDraft,
       reasoningLevel,
       seededExecutionInputSources,
+      submitDisabledReason,
       submissionEnvironment,
       selectedProviderId,
       selectedThreadModel,
@@ -1152,7 +1238,7 @@ export function NewThreadComposer({
   const renderPromptBox = useCallback(
     (options: NewThreadComposerPromptOptions) => {
       const locks = options.locks ?? {};
-      const externallyBlocked = options.externallyBlocked ?? false;
+      const disabledReason = options.blockedReason ?? submitDisabledReason;
       return (
         <NewThreadPromptBox
           id={options.id}
@@ -1160,9 +1246,10 @@ export function NewThreadComposer({
           value={promptDraft.text}
           mentionRanges={promptDraft.mentions}
           onChange={promptDraft.setTextAndMentions}
-          onSubmit={() => void handleSubmit(externallyBlocked)}
+          onSubmit={() => void handleSubmit(options.blockedReason ?? null)}
           isSubmitting={isSubmitting}
-          disabled={baseSubmitDisabled || externallyBlocked}
+          disabled={disabledReason !== null}
+          disabledReason={disabledReason ?? undefined}
           placeholder={options.placeholder}
           autoFocus={options.autoFocus}
           pluginComposerHost={options.pluginComposerHost ?? pluginComposerHost}
@@ -1319,7 +1406,6 @@ export function NewThreadComposer({
     [
       activeModel,
       attachmentError,
-      baseSubmitDisabled,
       branchEnvironmentMode,
       branchOptions,
       branchUiState,
@@ -1379,6 +1465,7 @@ export function NewThreadComposer({
       sidebarNavigationSettled,
       supportsPermissionModeSelection,
       supportsServiceTier,
+      submitDisabledReason,
       textEffects,
       worktreeDisabledReason,
       worktreeUnavailable,

--- a/apps/app/src/components/promptbox/NewThreadComposer.tsx
+++ b/apps/app/src/components/promptbox/NewThreadComposer.tsx
@@ -192,10 +192,8 @@ export interface ResolveNewThreadSubmitDisabledReasonArgs {
   branchMutationBlockerTitle: string | null;
   isCopyingAttachments: boolean;
   isLoadingModels: boolean;
-  isResolvingInitialProvider: boolean;
   isSubmitting: boolean;
   isUploading: boolean;
-  managedWorktreeAvailabilityPending: boolean;
   managedWorktreeUnavailableReason: string | null;
   modelLoadError: SystemExecutionOptionsModelLoadError | null;
   projectDefaultsStatus: ProjectDefaultsState["status"];
@@ -211,10 +209,8 @@ export function resolveNewThreadSubmitDisabledReason({
   branchMutationBlockerTitle,
   isCopyingAttachments,
   isLoadingModels,
-  isResolvingInitialProvider,
   isSubmitting,
   isUploading,
-  managedWorktreeAvailabilityPending,
   managedWorktreeUnavailableReason,
   modelLoadError,
   projectDefaultsStatus,
@@ -235,9 +231,6 @@ export function resolveNewThreadSubmitDisabledReason({
       ? "Could not load the project's execution defaults."
       : "Loading the project's execution defaults...";
   }
-  if (isResolvingInitialProvider) {
-    return "Selecting a provider for the selected machine...";
-  }
   if (!selectedProviderId) return "Select a provider.";
   if (isLoadingModels) {
     return "Loading models from the selected machine...";
@@ -255,9 +248,6 @@ export function resolveNewThreadSubmitDisabledReason({
   }
   if (!selectedThreadModel) return "Select a model.";
   if (submissionEnvironmentUnavailable) return "Select an environment.";
-  if (managedWorktreeAvailabilityPending) {
-    return "Checking worktree availability on the selected machine...";
-  }
   if (managedWorktreeUnavailableReason) {
     return managedWorktreeUnavailableReason;
   }
@@ -581,7 +571,6 @@ export function NewThreadComposer({
     environmentSelectionValue,
     hasMultipleProviders,
     isLoadingModels,
-    isResolvingInitialProvider,
     modelLoadError,
     modelLoadFailed,
     modelOptions,
@@ -713,10 +702,12 @@ export function NewThreadComposer({
   const worktreeUnavailable = worktreeDisabledReason !== null;
   const requestsManagedWorktree =
     isHostMode && parsedEnvironment.mode === "worktree";
-  const managedWorktreeAvailabilityPending =
-    requestsManagedWorktree && !isProjectless && branchesQuery.isLoading;
   const managedWorktreeUnavailable =
     requestsManagedWorktree && worktreeUnavailable;
+  // Branch data enriches the picker and can downgrade a confirmed non-Git or
+  // commitless source, but loading it is not a creation prerequisite. A
+  // default worktree request is resolved authoritatively by the server during
+  // thread creation, including another host.list_branches inspection.
   useEffect(() => {
     if (
       !worktreeUnavailable ||
@@ -1092,10 +1083,8 @@ export function NewThreadComposer({
         : null,
     isCopyingAttachments,
     isLoadingModels,
-    isResolvingInitialProvider,
     isSubmitting,
     isUploading,
-    managedWorktreeAvailabilityPending,
     managedWorktreeUnavailableReason: managedWorktreeUnavailable
       ? worktreeDisabledReason
       : null,
@@ -1121,7 +1110,6 @@ export function NewThreadComposer({
         submissionEnvironment === null ||
         !selectedProviderId ||
         !selectedThreadModel ||
-        managedWorktreeAvailabilityPending ||
         managedWorktreeUnavailable
       ) {
         return;
@@ -1159,7 +1147,6 @@ export function NewThreadComposer({
     [
       clearReuseEnvironment,
       executionInputSources,
-      managedWorktreeAvailabilityPending,
       managedWorktreeUnavailable,
       onSubmit,
       permissionMode,

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -176,6 +176,8 @@ export interface NewThreadPromptBoxUIProps {
   promptBoxRef?: Ref<PromptBoxHandle>;
   isSubmitting: boolean;
   disabled: boolean;
+  /** Explains a disabled submit action on hover and to assistive technology. */
+  disabledReason?: string;
   /** Whether the editor should take passive focus when it mounts. */
   autoFocus?: boolean;
   /** Active root-composer binding for plugin composer hooks and customizations. */
@@ -231,6 +233,7 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
   promptBoxRef: externalPromptBoxRef,
   isSubmitting,
   disabled,
+  disabledReason,
   autoFocus,
   pluginComposerHost,
   textEffects,
@@ -302,6 +305,7 @@ export const NewThreadPromptBoxUI = memo(function NewThreadPromptBoxUI({
           promptBoxRef={promptBoxRef}
           isSubmitting={isSubmitting}
           disabled={disabled}
+          disabledReason={disabledReason}
           autoFocus={autoFocus}
           textEffects={textEffects}
           zenModeStorageKey={zenModeStorageKey}
@@ -340,6 +344,7 @@ export const DefaultNewThreadComposer = memo(function DefaultNewThreadComposer({
   promptBoxRef,
   isSubmitting,
   disabled,
+  disabledReason,
   autoFocus,
   textEffects,
   zenModeStorageKey,
@@ -407,6 +412,7 @@ export const DefaultNewThreadComposer = memo(function DefaultNewThreadComposer({
         submission={{
           isSubmitting,
           disabled,
+          disabledReason,
           title: submitTitle,
         }}
         autoFocus={autoFocus}

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -1190,6 +1190,31 @@ describe("PromptBoxInternal controlled value sync", () => {
 });
 
 describe("PromptBoxInternal submit shortcuts", () => {
+  it("exposes the disabled submit reason as its label and hover tooltip", async () => {
+    const reason = "Loading models from the selected machine...";
+    render(
+      <PromptBoxInternal
+        {...createPromptBoxProps({
+          value: "Investigate this",
+          submission: { disabled: true, disabledReason: reason },
+        })}
+      />,
+    );
+
+    const submit = screen.getByRole("button", { name: reason });
+    expect(submit.hasAttribute("disabled")).toBe(true);
+
+    const tooltipTrigger = submit.closest(
+      "[data-promptbox-submit-disabled-reason]",
+    );
+    expect(tooltipTrigger).not.toBeNull();
+    fireEvent.pointerMove(tooltipTrigger!, { pointerType: "mouse" });
+
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip").textContent).toBe(reason);
+    });
+  });
+
   it("continues to submit unmodified Enter on a fine-pointer device", () => {
     const restoreMatchMedia = mockPointerCoarse(false);
     try {

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -44,6 +44,12 @@ import { findActiveTrigger } from "@/components/promptbox/mentions/find-active-t
 import { canLoadMoreCommandResults } from "@/components/promptbox/mentions/mention-menu-scroll";
 import { Button } from "@bb/shared-ui/button";
 import { Icon } from "@bb/shared-ui/icon";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@bb/shared-ui/tooltip";
 import { ComposerActionsSlot } from "@/components/plugin/PluginComposerActions";
 import { useResolvedComposerEditor } from "@/components/plugin/composer-slot-hooks";
 import {
@@ -211,10 +217,76 @@ function shouldFinishVoiceCompletionTransitionImmediately(): boolean {
 export interface PromptBoxSubmissionConfig {
   isSubmitting?: boolean;
   disabled?: boolean;
+  /** Explains why submission is disabled. Shown on hover and used as the action's accessible label. */
+  disabledReason?: string;
   title?: string;
   isRunning?: boolean;
   onStop?: () => void;
   onModifierSubmit?: () => void;
+}
+
+interface PromptSubmitButtonProps {
+  canSubmit: boolean;
+  className: string;
+  disabledReason: string | undefined;
+  isCompact: boolean;
+  isSubmitting: boolean;
+  isZenMode: boolean;
+  onClick: (event: ReactMouseEvent<HTMLButtonElement>) => void;
+  onPointerDown: (event: ReactPointerEvent<HTMLButtonElement>) => void;
+  title: string;
+}
+
+function PromptSubmitButton({
+  canSubmit,
+  className,
+  disabledReason,
+  isCompact,
+  isSubmitting,
+  isZenMode,
+  onClick,
+  onPointerDown,
+  title,
+}: PromptSubmitButtonProps) {
+  const button = (
+    <Button
+      data-promptbox-submit-action=""
+      type="submit"
+      size={isCompact ? "icon" : "sm"}
+      variant="default"
+      aria-label={title}
+      disabled={!canSubmit}
+      onPointerDown={onPointerDown}
+      onClick={onClick}
+      className={className}
+    >
+      {isSubmitting ? (
+        <Icon name="Spinner" className="size-4 animate-spin" />
+      ) : isZenMode ? (
+        <Icon name="ArrowUp" className="size-4" />
+      ) : (
+        <Icon name="CornerDownLeft" className="size-4" />
+      )}
+    </Button>
+  );
+
+  if (!disabledReason) return button;
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            data-promptbox-submit-disabled-reason=""
+            className="inline-flex shrink-0"
+          >
+            {button}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top">{disabledReason}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
 }
 
 /**
@@ -1175,6 +1247,7 @@ export function PromptBoxInternal({
   const {
     isSubmitting = false,
     disabled: submitDisabled = false,
+    disabledReason: submitDisabledReason,
     title: submitTitle = "Submit (Enter)",
     isRunning = false,
     onStop,
@@ -2679,9 +2752,13 @@ export function PromptBoxInternal({
     setVoiceActionTransition("exiting");
     voice?.cancel();
   }, [voice]);
-  const effectiveSubmitTitle = isZenMode
+  const actionSubmitTitle = isZenMode
     ? submitTitle.replace(/^Submit\s+/, "")
     : submitTitle;
+  const effectiveSubmitTitle =
+    !canSubmit && submitDisabledReason
+      ? submitDisabledReason
+      : actionSubmitTitle;
 
   const emitAttachmentFiles = useCallback(
     (files: File[]) => {
@@ -3493,15 +3570,8 @@ export function PromptBoxInternal({
                         <Icon name="Mic" className="size-4" />
                       </Button>
                     ) : (
-                      <Button
-                        data-promptbox-submit-action=""
-                        type="submit"
-                        size={showCompactLayout ? "icon" : "sm"}
-                        variant="default"
-                        aria-label={effectiveSubmitTitle}
-                        disabled={!canSubmit}
-                        onPointerDown={handleSubmitPointerDown}
-                        onClick={handleSubmitClick}
+                      <PromptSubmitButton
+                        canSubmit={canSubmit}
                         className={cn(
                           showCompactLayout
                             ? COMPACT_PROMPT_ACTION_BUTTON_CLASS
@@ -3515,18 +3585,16 @@ export function PromptBoxInternal({
                           // stays pinned while the prompt height animates.
                           "transition-colors",
                         )}
-                      >
-                        {isSubmitting ? (
-                          <Icon
-                            name="Spinner"
-                            className="size-4 animate-spin"
-                          />
-                        ) : isZenMode ? (
-                          <Icon name="ArrowUp" className="size-4" />
-                        ) : (
-                          <Icon name="CornerDownLeft" className="size-4" />
-                        )}
-                      </Button>
+                        disabledReason={
+                          !canSubmit ? submitDisabledReason : undefined
+                        }
+                        isCompact={showCompactLayout}
+                        isSubmitting={isSubmitting}
+                        isZenMode={isZenMode}
+                        onPointerDown={handleSubmitPointerDown}
+                        onClick={handleSubmitClick}
+                        title={effectiveSubmitTitle}
+                      />
                     )}
                   </div>
                 </ComposerActionsSlot>

--- a/apps/app/src/hooks/useThreadCreationOptions.test.tsx
+++ b/apps/app/src/hooks/useThreadCreationOptions.test.tsx
@@ -1049,7 +1049,7 @@ describe("useThreadCreationOptions", () => {
     });
   });
 
-  it("uses the connected provider from the selected machine as create provenance", async () => {
+  it("latches the initial connected provider instead of resolving it again after a machine switch", async () => {
     window.localStorage.setItem(
       "bb.promptbox.environment",
       "host:remote-host:local",
@@ -1076,12 +1076,33 @@ describe("useThreadCreationOptions", () => {
         signal: expect.any(AbortSignal),
       });
       expect(result.current.selectedProviderId).toBe(PROJECT_PROVIDER_ID);
-      expect(result.current.isResolvingInitialProvider).toBe(false);
       expect(result.current.executionInputSources).toMatchObject({
         providerId: "client-preference",
       });
       expect(result.current.executionInputSources.model).toBeUndefined();
     });
+    const initialDiscoveryCallCount = vi.mocked(sdk.system.onboardingAgents)
+      .mock.calls.length;
+
+    act(() => {
+      result.current.setEnvironmentSelectionValue("host:second-host:local");
+    });
+
+    await waitFor(() => {
+      expect(sdk.system.executionOptions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hostId: "second-host",
+          providerId: PROJECT_PROVIDER_ID,
+        }),
+      );
+      expect(result.current.selectedProviderId).toBe(PROJECT_PROVIDER_ID);
+    });
+    expect(sdk.system.onboardingAgents).toHaveBeenCalledTimes(
+      initialDiscoveryCallCount,
+    );
+    expect(sdk.system.onboardingAgents).not.toHaveBeenCalledWith(
+      expect.objectContaining({ hostId: "second-host" }),
+    );
   });
 
   it("routes reusable root-composer worktrees through their environment", async () => {

--- a/apps/app/src/hooks/useThreadCreationOptions.ts
+++ b/apps/app/src/hooks/useThreadCreationOptions.ts
@@ -1,4 +1,11 @@
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type {
   AvailableModel,
   PermissionMode,
@@ -109,7 +116,6 @@ export interface UseThreadCreationOptionsResult<TExecutionInputSources> {
   modelOptions: ModelPickerOption[];
   moreModelOptions: ModelPickerOption[];
   isLoadingModels: boolean;
-  isResolvingInitialProvider: boolean;
   modelLoadFailed: boolean;
   modelLoadError: SystemExecutionOptionsModelLoadError | null;
   reasoningOptions: PickerOption<ReasoningLevel>[];
@@ -163,6 +169,10 @@ export function resolveThreadCreationProviderRouting({
 }
 
 const NO_MODEL_LOAD_ERROR: SystemExecutionOptionsModelLoadError | null = null;
+
+type InitialConnectedProviderResolution =
+  | { status: "unresolved" }
+  | { status: "resolved"; providerId: string | null };
 
 function sanitizeStoredEnvironmentValue(stored: string): string {
   // Legacy guard: earlier iterations briefly persisted `reuse:<envId>` to
@@ -230,6 +240,8 @@ export function useThreadCreationOptions(
         initialServiceTier,
       }),
     );
+  const [initialConnectedProvider, setInitialConnectedProvider] =
+    useState<InitialConnectedProviderResolution>({ status: "unresolved" });
   const localProviderSelectionsRef = useRef<
     Map<string, ModelReasoningSelection>
   >(new Map());
@@ -309,20 +321,47 @@ export function useThreadCreationOptions(
         providerId: selectedProviderIdBeforeConnectedFallback,
         scope,
       });
-  const shouldResolveConnectedProvider =
+  const canResolveConnectedProvider =
     executionOptionsQueryEnabled &&
     scope === "new-thread" &&
     preferConnectedProviderWhenUnset &&
     selectedProviderIdBeforeConnectedFallback.length === 0;
+  const shouldResolveConnectedProvider =
+    canResolveConnectedProvider &&
+    initialConnectedProvider.status === "unresolved";
   const connectedAgentsQuery = useOnboardingAgents({
     enabled: shouldResolveConnectedProvider,
     ...executionOptionsRouting,
   });
-  const connectedProviderId = shouldResolveConnectedProvider
+  const queriedConnectedProviderId = shouldResolveConnectedProvider
     ? connectedAgentsQuery.data?.agents.find(
         (agent) => agent.status === "connected",
       )?.providerId
     : undefined;
+  const connectedProviderId =
+    initialConnectedProvider.status === "resolved"
+      ? (initialConnectedProvider.providerId ?? undefined)
+      : queriedConnectedProviderId;
+  // This is an initial default, not a host-scoped live selection. Once the
+  // first routed probe settles, retain its answer so changing machines does
+  // not silently reselect the provider or wait on onboarding health checks.
+  useEffect(() => {
+    if (!shouldResolveConnectedProvider || connectedAgentsQuery.isPending) {
+      return;
+    }
+    setInitialConnectedProvider((current) =>
+      current.status === "resolved"
+        ? current
+        : {
+            status: "resolved",
+            providerId: queriedConnectedProviderId ?? null,
+          },
+    );
+  }, [
+    connectedAgentsQuery.isPending,
+    queriedConnectedProviderId,
+    shouldResolveConnectedProvider,
+  ]);
   const rawSelectedProviderId =
     selectedProviderIdBeforeConnectedFallback || connectedProviderId || "";
   // Omission delegates the no-selection fallback to the server, whose product
@@ -343,8 +382,6 @@ export function useThreadCreationOptions(
     (executionOptionsQuery.isLoading ||
       (executionOptionsQuery.isPlaceholderData &&
         (executionOptionsQuery.data?.models.length ?? 0) === 0));
-  const isResolvingInitialProvider =
-    shouldResolveConnectedProvider && connectedAgentsQuery.isPending;
   const modelLoadError =
     executionOptionsQuery.data?.modelLoadError ?? NO_MODEL_LOAD_ERROR;
   const modelLoadFailed =
@@ -654,7 +691,7 @@ export function useThreadCreationOptions(
   const touchedFieldsPendingReset =
     usesLocalThreadSelections && threadResetKeyRef.current !== resetKey;
   const effectiveInitialProviderSource: ExecutionInputFieldSource | undefined =
-    shouldResolveConnectedProvider &&
+    canResolveConnectedProvider &&
     connectedProviderId !== undefined &&
     effectiveProviderId === connectedProviderId
       ? "client-preference"
@@ -989,7 +1026,6 @@ export function useThreadCreationOptions(
     modelOptions,
     moreModelOptions,
     isLoadingModels,
-    isResolvingInitialProvider,
     modelLoadFailed,
     modelLoadError,
     reasoningOptions,

--- a/apps/app/src/views/RootComposeView.test.ts
+++ b/apps/app/src/views/RootComposeView.test.ts
@@ -17,7 +17,9 @@ import {
   hasPromptOptionValueChanged,
   mergeMissingPromptDraftAttachments,
   resolveNewThreadProjectDefaultsState,
+  resolveNewThreadSubmitDisabledReason,
   restorePromptDraftAfterOptionChange,
+  type ResolveNewThreadSubmitDisabledReasonArgs,
 } from "@/components/promptbox/NewThreadComposer";
 import { subscribeComposerFocusRequests } from "@/lib/composer-focus-requests";
 import { getProjectStoredPromptAttachmentPaths } from "@/lib/prompt-draft";
@@ -140,6 +142,109 @@ describe("resolveNewThreadProjectDefaultsState", () => {
         queryIsSuccess: true,
       }),
     ).toEqual({ status: "pending" });
+  });
+});
+
+describe("resolveNewThreadSubmitDisabledReason", () => {
+  const readyState = {
+    branchMutationBlockerTitle: null,
+    isCopyingAttachments: false,
+    isLoadingModels: false,
+    isResolvingInitialProvider: false,
+    isSubmitting: false,
+    isUploading: false,
+    managedWorktreeAvailabilityPending: false,
+    managedWorktreeUnavailableReason: null,
+    modelLoadError: null,
+    projectDefaultsStatus: "resolved",
+    projectDefaultsUnavailable: false,
+    promptInputEmpty: false,
+    providerDisplayName: "Codex",
+    selectedProviderId: "codex",
+    selectedThreadModel: "gpt-5.6-sol",
+    submissionEnvironmentUnavailable: false,
+  } satisfies ResolveNewThreadSubmitDisabledReasonArgs;
+
+  it.each<
+    [
+      label: string,
+      change: Partial<ResolveNewThreadSubmitDisabledReasonArgs>,
+      reason: string,
+    ]
+  >([
+    [
+      "provider resolution after a machine switch",
+      { isResolvingInitialProvider: true },
+      "Selecting a provider for the selected machine...",
+    ],
+    [
+      "model loading after a machine switch",
+      { isLoadingModels: true },
+      "Loading models from the selected machine...",
+    ],
+    [
+      "worktree validation after a machine switch",
+      { managedWorktreeAvailabilityPending: true },
+      "Checking worktree availability on the selected machine...",
+    ],
+    [
+      "provider setup failure",
+      {
+        modelLoadError: {
+          providerId: "codex",
+          code: "auth_required",
+        },
+      },
+      "Could not load models for Codex. Authentication is required.",
+    ],
+    [
+      "project-default failure",
+      {
+        projectDefaultsStatus: "error",
+        projectDefaultsUnavailable: true,
+      },
+      "Could not load the project's execution defaults.",
+    ],
+    [
+      "an incomplete environment selection",
+      { submissionEnvironmentUnavailable: true },
+      "Select an environment.",
+    ],
+    [
+      "an unavailable worktree",
+      {
+        managedWorktreeUnavailableReason:
+          "Project source has no commits. Create an initial commit before creating a worktree",
+      },
+      "Project source has no commits. Create an initial commit before creating a worktree",
+    ],
+    [
+      "a blocked branch checkout",
+      { branchMutationBlockerTitle: "Checkout blocked by uncommitted changes" },
+      "Checkout blocked by uncommitted changes",
+    ],
+    [
+      "an empty prompt",
+      { promptInputEmpty: true },
+      "Enter a prompt or attach a file.",
+    ],
+  ])("reports %s", (_label, change, reason) => {
+    expect(
+      resolveNewThreadSubmitDisabledReason({ ...readyState, ...change }),
+    ).toBe(reason);
+  });
+
+  it("returns no reason when every submission requirement is ready", () => {
+    expect(resolveNewThreadSubmitDisabledReason(readyState)).toBeNull();
+  });
+
+  it("allows a selected fallback model after a transient model-list failure", () => {
+    expect(
+      resolveNewThreadSubmitDisabledReason({
+        ...readyState,
+        modelLoadError: { providerId: "claude-code", code: "timeout" },
+      }),
+    ).toBeNull();
   });
 });
 

--- a/apps/app/src/views/RootComposeView.test.ts
+++ b/apps/app/src/views/RootComposeView.test.ts
@@ -150,10 +150,8 @@ describe("resolveNewThreadSubmitDisabledReason", () => {
     branchMutationBlockerTitle: null,
     isCopyingAttachments: false,
     isLoadingModels: false,
-    isResolvingInitialProvider: false,
     isSubmitting: false,
     isUploading: false,
-    managedWorktreeAvailabilityPending: false,
     managedWorktreeUnavailableReason: null,
     modelLoadError: null,
     projectDefaultsStatus: "resolved",
@@ -173,19 +171,9 @@ describe("resolveNewThreadSubmitDisabledReason", () => {
     ]
   >([
     [
-      "provider resolution after a machine switch",
-      { isResolvingInitialProvider: true },
-      "Selecting a provider for the selected machine...",
-    ],
-    [
       "model loading after a machine switch",
       { isLoadingModels: true },
       "Loading models from the selected machine...",
-    ],
-    [
-      "worktree validation after a machine switch",
-      { managedWorktreeAvailabilityPending: true },
-      "Checking worktree availability on the selected machine...",
     ],
     [
       "provider setup failure",

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -2303,7 +2303,9 @@ function RootComposeSurface({
     ),
     banner: promptBanner,
     header: promptHeader,
-    externallyBlocked: isCodexCliVersionBlocked,
+    blockedReason: isCodexCliVersionBlocked
+      ? "Update the Codex CLI before starting a thread."
+      : undefined,
     resolveMentionLink,
     pluginComposerHost,
     textEffects: promptTextEffects,

--- a/apps/app/src/views/root-compose-thread-environment.test.ts
+++ b/apps/app/src/views/root-compose-thread-environment.test.ts
@@ -87,6 +87,23 @@ describe("resolveRootComposeThreadEnvironment", () => {
     });
   });
 
+  it("can submit the server-resolved default while branch metadata is still loading", () => {
+    expect(
+      resolveRootComposeThreadEnvironment({
+        defaultBranch: undefined,
+        defaultWorktreeBaseBranch: undefined,
+        environmentValue: hostWorktreeEnvironmentValue,
+        projectId,
+        selectedBranch: null,
+      }),
+    ).toMatchObject({
+      workspace: {
+        type: "managed-worktree",
+        baseBranch: { kind: "default" },
+      },
+    });
+  });
+
   it("sends smart remote default base branch for managed worktrees without an explicit pick", () => {
     expect(
       resolveRootComposeThreadEnvironment({


### PR DESCRIPTION
## What was wrong

The new-thread composer treated two background discovery requests as hard submission prerequisites. Connected-provider discovery is host-keyed, so changing machines restarted an expensive onboarding probe and disabled an otherwise complete composer; it could also silently change the automatic provider choice. Project branch metadata loading also disabled managed-worktree submission even though the create path independently resolves and validates the default base branch on the selected host. The composer additionally collapsed all remaining blockers into one unexplained disabled boolean.

## What changed

Connected-provider discovery is now used only to establish the initial automatic provider default. Its first settled result is retained across machine switches, and the background probe no longer gates submission. Managed-worktree submission can now proceed with `{ kind: "default" }` while branch metadata is loading; the server resolves that default authoritatively during thread creation. A confirmed non-Git or commitless project source still disables managed-worktree creation, and the branch query still enriches the branch picker.

The composer also resolves the remaining legitimate eligibility checks into a prioritized disabled reason. The prompt submit action exposes that reason through its accessible label and a tooltip on a pointer-capable wrapper. This is an app-only behavior change with no host-daemon wire, CLI, guide, or documentation changes.

## How you verified

- Added hook coverage proving that switching machines retains the initial connected-provider selection and does not issue another onboarding probe; this fails against the previous behavior.
- Added coverage proving that a managed-worktree request can use the server-resolved default while branch metadata is absent.
- Added resolver and prompt-box interaction coverage for the remaining disabled reasons and tooltip behavior.
- `pnpm exec turbo run test --filter=@bb/app -- src/hooks/useThreadCreationOptions.test.tsx src/views/RootComposeView.test.ts src/views/root-compose-thread-environment.test.ts src/components/promptbox/PromptBoxInternal.test.tsx` — 197 tests passed.
- `pnpm exec turbo run typecheck lint --filter=@bb/app` — all tasks passed; lint reported zero errors and the existing warning baseline.
- `git diff --check` — passed.

Fixes: no linked issue.

> AGENT GENERATED: by GPT-5