### PR TITLE
Enable provider retry by default

### DIFF
--- a/apps/mobile/e2e/manual/phase7-plugins-devserver.yaml
+++ b/apps/mobile/e2e/manual/phase7-plugins-devserver.yaml
@@ -2,9 +2,9 @@
 # current`; server port 20304 for this worktree — edit SERVER_URL for another
 # checkout), which runs the real builtin plugins. Read-mostly: opens the
 # Automations detail (settings-less builtin → "no settings" state, Updates →
-# "bundled" note, logs viewer), the disabled provider-retry detail ("Enable
-# this plugin to edit its settings"), and Browse (BB Official group). Not part
-# of `pnpm e2e:ios` (e2e/flows) because it needs a running dev server.
+# "bundled" note, logs viewer), the default-enabled provider-retry settings,
+# and Browse (BB Official group). Not part of `pnpm e2e:ios` (e2e/flows)
+# because it needs a running dev server.
 appId: app.getbb.mobile
 env:
   METRO_URL: "http://127.0.0.1:8082"
@@ -87,8 +87,7 @@ env:
     visible:
       id: "plugins-screen"
     timeout: 10000
-# A disabled plugin: the server cannot report its schema until its factory
-# runs, so the settings card points at Enable instead of claiming none.
+# A default-enabled plugin with a host-rendered settings schema.
 - scrollUntilVisible:
     element:
       id: "plugin-row-provider-retry"
@@ -101,10 +100,12 @@ env:
     timeout: 15000
 - scrollUntilVisible:
     element:
-      id: "plugin-settings-disabled"
+      id: "plugin-settings-form"
     direction: DOWN
-- assertVisible: "Enable this plugin to see and edit its settings."
-- takeScreenshot: p7-plugins-dev-disabled-settings
+- assertVisible:
+    id: "plugin-setting-maximumWait"
+    text: "6 hours"
+- takeScreenshot: p7-plugins-dev-settings
 - tapOn:
     id: "BackButton"
 - extendedWaitUntil:

--- a/apps/server/src/services/plugins/builtin-registry.ts
+++ b/apps/server/src/services/plugins/builtin-registry.ts
@@ -108,7 +108,7 @@ export const BUILTIN_PLUGINS = [
   {
     name: "provider-retry",
     pluginId: "provider-retry",
-    defaultEnabled: false,
+    defaultEnabled: true,
     category: "Agent interaction",
   },
   {

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -466,12 +466,11 @@ For review or fix pipelines, get the environment ID from
 - For failed threads, inspect `bb thread show <id> --json` and
   `bb thread log <id>` before deciding whether to retry, clarify, or update the
   user.
-- The opt-in Provider retry plugin automatically waits for structured Codex and
-  Claude Code subscription-window resets when the failed turn was accepted and
-  its execution settings remain available. Prior output or tool activity does
-  not block recovery. Enable it with
-  `bb plugin enable provider-retry` or under Extensions → Plugins. Its timers
-  last only while the current bb server/plugin process is running. Inspect it
+- The Provider retry plugin is enabled on fresh installations and automatically
+  waits for structured Codex and Claude Code subscription-window resets when
+  the failed turn was accepted and its execution settings remain available.
+  Prior output or tool activity does not block recovery. Its timers last only
+  while the current bb server/plugin process is running. Inspect it
   with `bb provider-retry status [thread-id]`, or cancel one with
   `bb provider-retry cancel <thread-id>`. Automatic waits default to six hours;
   configure longer waits with

--- a/apps/server/test/services/plugins/builtin-plugins.test.ts
+++ b/apps/server/test/services/plugins/builtin-plugins.test.ts
@@ -416,6 +416,28 @@ describe("builtin plugin reconciliation", () => {
     ]);
   });
 
+  it("preserves an installed builtin's choice when its default changes", async () => {
+    service = createService({
+      db,
+      dataDir: join(workDir, "data"),
+      defaultEnabled: false,
+    });
+    await service.start();
+    await service.stop();
+
+    service = createService({
+      db,
+      dataDir: join(workDir, "data"),
+      defaultEnabled: true,
+    });
+    await service.start();
+
+    expect(service.list()).toMatchObject([
+      { id: "builtin-fixture", enabled: false, status: "disabled" },
+    ]);
+    expect(loadCount()).toBe(0);
+  });
+
   it("ships Workflows disabled on a fresh database", async () => {
     const workflows = BUILTIN_PLUGINS.find(
       (builtin) => builtin.name === "workflows",
@@ -441,11 +463,11 @@ describe("builtin plugin reconciliation", () => {
     ]);
   });
 
-  it("ships Provider retry disabled on a fresh database", async () => {
+  it("ships Provider retry enabled on a fresh database", async () => {
     const providerRetry = BUILTIN_PLUGINS.find(
       (builtin) => builtin.name === "provider-retry",
     );
-    expect(providerRetry?.defaultEnabled).toBe(false);
+    expect(providerRetry?.defaultEnabled).toBe(true);
 
     service = createService({
       db,
@@ -460,8 +482,8 @@ describe("builtin plugin reconciliation", () => {
       {
         id: "provider-retry",
         source: "builtin:provider-retry",
-        enabled: false,
-        status: "disabled",
+        enabled: true,
+        status: "running",
       },
     ]);
   });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -789,13 +789,13 @@ the plugin so it can be surfaced as needing attention.
 
 ### Provider retry plugin
 
-The builtin Provider retry plugin is disabled on fresh installations. Enable
-it under Extensions → Plugins or with `bb plugin enable provider-retry`. It
+The builtin Provider retry plugin is enabled on fresh installations. It
 automatically waits for structured Codex and Claude Code subscription-window
 resets when the failed turn was accepted, the provider has stopped its own
 retries, and the original execution settings remain available. Prior output or
 tool activity does not block recovery. Recovery sends one agent-only
-`Please continue.` turn on the existing provider conversation.
+`Please continue.` turn on the existing provider conversation. Disable it
+under Extensions → Plugins or with `bb plugin disable provider-retry`.
 The `maximumWait` setting defaults to `6 hours`; resets beyond that horizon are
 not scheduled. Choose `24 hours` or `No limit` under the plugin settings, or
 configure it from the CLI:

--- a/packages/bb-app/scripts/smoke-tarball.mjs
+++ b/packages/bb-app/scripts/smoke-tarball.mjs
@@ -33,6 +33,7 @@ const EXPECTED_RUNNING_BUILTIN_PLUGINS = [
   "custom-instructions",
   "inline-vis",
   "keep-awake",
+  "provider-retry",
   "secrets",
 ];
 // The smoke drives every bridge as a canonical Provider Bridge Protocol

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -39,11 +39,11 @@ It reconciles when the plugin starts, a host connects, its configuration
 changes, or a worker exits unexpectedly. Disabling the plugin disposes its host
 workers and their child processes.
 
-The opt-in builtin Provider retry plugin continues Codex and Claude Code
-turns after a structured subscription window resets. Enable it under
-Extensions → Plugins or run `bb plugin enable provider-retry`. It keeps its
-timers in memory, coordinates waits by machine/provider subscription, and adds
-a composer banner with a Cancel action while an automatic retry is pending.
+The builtin Provider retry plugin is enabled on fresh installations. It
+continues Codex and Claude Code turns after a structured subscription window
+resets, keeps its timers in memory, coordinates waits by machine/provider
+subscription, and adds a composer banner with a Cancel action while an
+automatic retry is pending.
 The banner disappears when the retry starts, is cancelled, or the user
 continues the thread. A server restart or plugin reload clears pending timers
 without changing the original failed thread. Inspect it with

--- a/packages/templates/src/templates/bb-guide-providers.md
+++ b/packages/templates/src/templates/bb-guide-providers.md
@@ -42,15 +42,15 @@ provider's global configuration.
 
 Subscription limit recovery
 
-The opt-in builtin Provider retry plugin recognizes structured Codex and Claude
-Code subscription windows. Enable it under Extensions → Plugins or run
-`bb plugin enable provider-retry`. If a provider terminally rejects an accepted
-turn whose execution settings remain available, the plugin waits in memory
-until the reported reset plus a short buffer, then starts one agent-only
-`Please continue.` turn on the existing provider conversation. Prior output or
-tool activity does not block recovery. Threads sharing a machine/provider
-subscription are released one at a time. Provider-native retries remain
-authoritative while the provider reports that it will retry on its own.
+The builtin Provider retry plugin is enabled on fresh installations and
+recognizes structured Codex and Claude Code subscription windows. If a provider
+terminally rejects an accepted turn whose execution settings remain available,
+the plugin waits in memory until the reported reset plus a short buffer, then
+starts one agent-only `Please continue.` turn on the existing provider
+conversation. Prior output or tool activity does not block recovery. Threads
+sharing a machine/provider subscription are released one at a time.
+Provider-native retries remain authoritative while the provider reports that
+it will retry on its own.
 
 Automatic waits default to a maximum of six hours. Longer reset windows are not
 scheduled. Set `maximumWait` to `24 hours` or `No limit` under the plugin

--- a/qa/manual-runbook.md
+++ b/qa/manual-runbook.md
@@ -46,7 +46,7 @@ commands.
 
 - Thread recovery is validated with the existing lifecycle commands:
   `bb thread stop`, `bb thread tell`, `bb thread spawn`, archive/unarchive, and
-  the recovery checks below. When the provider-retry plugin is installed,
+  the recovery checks below. When the provider-retry plugin is enabled,
   `bb provider-retry retry <thread-id>` is the manual path for a failed,
   accepted provider rate-limit turn; inspect the thread before using it. For
   other failed or interrupted threads, send a fresh turn with `bb thread tell`,


### PR DESCRIPTION
## What was wrong

The builtin Provider retry plugin was explicitly registered with `defaultEnabled: false`, so fresh installations shipped automatic subscription-limit recovery disabled even though the plugin is bundled and auto-installed.

## What changed

- Enable `provider-retry` when its builtin registration is first installed while preserving the stored choice for existing installations.
- Add focused coverage for the fresh-install default and for preserving an existing disabled choice.
- Require the plugin to reach `running` in the packaged-app smoke test.
- Update configuration docs, CLI guides, the bb-cli skill, and the QA runbook to describe the new default.
- No server/host-daemon wire behavior changed; `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/server`
- `pnpm exec turbo run test --filter=@bb/server -- test/services/plugins/builtin-plugins.test.ts -t 'Provider retry enabled|preserves an installed builtin'` (2 passed)
- Prettier check across all changed files
- The full builtin-plugin test file also passed the 22 unaffected/new cases; two existing source-watcher cases hit the local sandbox's `EMFILE: too many open files, watch` limit.

Fixes: no linked issue.

> AGENT GENERATED: by GPT-5
