### PR TITLE
Fix Cursor ACP dynamic tools

### DIFF
--- a/plugins/provider-acp/src/bridge/bridge.test.ts
+++ b/plugins/provider-acp/src/bridge/bridge.test.ts
@@ -4,6 +4,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
 } from "node:fs";
 import { createConnection } from "node:net";
 import { tmpdir } from "node:os";
@@ -418,6 +419,7 @@ function callDynamicToolBridge(args: {
     socket.on("connect", () => {
       socket.write(
         `${JSON.stringify({
+          kind: "toolCall",
           arguments: args.toolArguments,
           callId: args.callId,
           threadId: args.threadId,
@@ -1308,6 +1310,44 @@ describe("acp bridge", () => {
 
     expect(agentMessageTexts()).toContain(
       `mcp-servers:${ACP_BRIDGE_MCP_SERVER_NAME}`,
+    );
+  });
+
+  it("approves Cursor session MCP servers for the session lifetime (#2018)", async () => {
+    const cursorAgent = join(workspaceDir, "cursor-agent");
+    const cursorDataDir = join(workspaceDir, "cursor-data");
+    symlinkSync(process.execPath, cursorAgent);
+    const { providerThreadId } = await startThread({
+      agent: { command: cursorAgent, args: [FAKE_AGENT_PATH] },
+      envVars: { CURSOR_DATA_DIR: cursorDataDir },
+      dynamicTools: [
+        {
+          name: "update_environment_directory",
+          description: "Move this thread to another environment directory.",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ],
+    });
+    const projectSlug = workspaceDir
+      .replace(/[^a-zA-Z0-9]/gu, "-")
+      .replace(/-+/gu, "-")
+      .replace(/^-+|-+$/gu, "");
+    const approvalPath = join(
+      cursorDataDir,
+      "projects",
+      projectSlug,
+      "mcp-approvals.json",
+    );
+    const approvals = JSON.parse(
+      readFileSync(approvalPath, "utf8"),
+    ) as unknown;
+    expect(approvals).toEqual([
+      expect.stringMatching(`^${ACP_BRIDGE_MCP_SERVER_NAME}-[a-f0-9]{16}$`),
+    ]);
+
+    await stopThread(providerThreadId);
+    expect(JSON.parse(readFileSync(approvalPath, "utf8")) as unknown).toEqual(
+      [],
     );
   });
 

--- a/plugins/provider-acp/src/bridge/bridge.ts
+++ b/plugins/provider-acp/src/bridge/bridge.ts
@@ -104,6 +104,11 @@ import {
   type AcpAgentRequestResponder,
 } from "./agent-connection.js";
 import {
+  approveCursorSessionMcpServer,
+  revokeCursorSessionMcpServer,
+  type CursorMcpApproval,
+} from "./cursor-mcp-approval.js";
+import {
   buildAgentModelCatalog,
   buildAcpNativeReasoningSupport,
   buildModelCatalogFromConfigOptions,
@@ -117,6 +122,7 @@ import {
   type AgentModelCatalog,
 } from "./model-catalog.js";
 import {
+  ACP_BRIDGE_MCP_SERVER_NAME,
   buildAcpMcpServerConfig,
   runAcpDynamicToolMcpServer,
   type AcpMcpServerConfig,
@@ -166,6 +172,7 @@ interface AcpThreadSession {
   /** Resolves when the in-flight turn or maintenance prompt fully settles. */
   turnSettled: Promise<void> | undefined;
   pendingPermissions: Set<PendingAcpPermission>;
+  cursorMcpApproval: CursorMcpApproval | undefined;
 }
 
 const sessionsByBbThreadId = new Map<string, AcpThreadSession>();
@@ -385,6 +392,13 @@ function handleDynamicToolBridgeSocket(
       );
       return;
     }
+    if (request.data.kind === "initialized") {
+      process.stderr.write(
+        `acp bridge: "${ACP_BRIDGE_MCP_SERVER_NAME}" answered initialize for thread "${request.data.threadId}" (${request.data.toolCount} tools)\n`,
+      );
+      socket.end(`${JSON.stringify({ ok: true, content: "" })}\n`);
+      return;
+    }
     void forwardDynamicToolCall(request.data).then((response) => {
       socket.end(`${JSON.stringify(response)}\n`);
     });
@@ -432,18 +446,20 @@ async function buildSessionMcpServers(
     return [];
   }
   const bridge = await ensureDynamicToolBridge();
-  return [
-    buildAcpMcpServerConfig({
-      bridgeArgs: resolveBridgeProcessArgsForMcpServer(),
-      command: process.execPath,
-      dynamicTools,
-      host: bridge.host,
-      port: bridge.port,
-      runtimeEnv: resolveBridgeProcessEnvForMcpServer(),
-      threadId: params.threadId,
-      token: bridge.token,
-    }),
-  ];
+  const config = buildAcpMcpServerConfig({
+    bridgeArgs: resolveBridgeProcessArgsForMcpServer(),
+    command: process.execPath,
+    dynamicTools,
+    host: bridge.host,
+    port: bridge.port,
+    runtimeEnv: resolveBridgeProcessEnvForMcpServer(),
+    threadId: params.threadId,
+    token: bridge.token,
+  });
+  process.stderr.write(
+    `acp bridge: built "${config.name}" session MCP config for thread "${params.threadId}" (${dynamicTools.length} tools)\n`,
+  );
+  return [config];
 }
 
 // ---------------------------------------------------------------------------
@@ -679,13 +695,22 @@ interface AcpDynamicToolBridge {
   token: string;
 }
 
-const dynamicToolBridgeRequestSchema = z.object({
-  arguments: z.record(z.string(), z.unknown()).default({}),
-  callId: z.string().min(1),
-  threadId: z.string().min(1),
-  token: z.string().min(1),
-  tool: z.string().min(1),
-});
+const dynamicToolBridgeRequestSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("initialized"),
+    threadId: z.string().min(1),
+    token: z.string().min(1),
+    toolCount: z.number().int().nonnegative(),
+  }),
+  z.object({
+    kind: z.literal("toolCall"),
+    arguments: z.record(z.string(), z.unknown()).default({}),
+    callId: z.string().min(1),
+    threadId: z.string().min(1),
+    token: z.string().min(1),
+    tool: z.string().min(1),
+  }),
+]);
 
 let cachedModelCatalog: { key: string; catalog: AgentModelCatalog } | null =
   null;
@@ -1519,6 +1544,25 @@ function removeSession(session: AcpThreadSession): void {
   }
 }
 
+async function releaseCursorMcpApproval(
+  session: AcpThreadSession,
+): Promise<void> {
+  const approval = session.cursorMcpApproval;
+  session.cursorMcpApproval = undefined;
+  if (!approval) {
+    return;
+  }
+  try {
+    await revokeCursorSessionMcpServer(approval);
+  } catch (error) {
+    process.stderr.write(
+      `acp bridge: failed to remove Cursor session MCP approval for thread "${session.bbThreadId}": ${
+        error instanceof Error ? error.message : String(error)
+      }\n`,
+    );
+  }
+}
+
 function getSessionByProviderThreadId(
   providerThreadId: string,
 ): AcpThreadSession | undefined {
@@ -1598,6 +1642,7 @@ async function startAgentSession(
       if (!wasCurrent || session.stopping) {
         return;
       }
+      void releaseCursorMcpApproval(session);
       emitSessionError(
         session,
         `ACP agent "${agentLabel}" exited unexpectedly` +
@@ -1631,6 +1676,7 @@ async function startAgentSession(
     stopping: false,
     turnSettled: undefined,
     pendingPermissions: new Set(),
+    cursorMcpApproval: undefined,
   };
 
   try {
@@ -1664,6 +1710,20 @@ async function startAgentSession(
     }
     session.supportsLoadSession = supportsLoadSession;
     const mcpServers = await buildSessionMcpServers(params);
+    const mcpServer = mcpServers[0];
+    if (mcpServer) {
+      session.cursorMcpApproval = await approveCursorSessionMcpServer({
+        agentCommand: params.agent.command,
+        config: mcpServer,
+        cwd: params.cwd,
+        env: childEnv,
+      });
+      if (session.cursorMcpApproval?.installedByBb) {
+        process.stderr.write(
+          `acp bridge: installed Cursor session MCP approval for thread "${bbThreadId}"\n`,
+        );
+      }
+    }
 
     let sessionId: string | undefined;
     let loadedConfigOptions: readonly AcpConfigOption[] | undefined;
@@ -1784,6 +1844,7 @@ async function startAgentSession(
     session.stopping = true;
     connection.kill();
     removeSession(session);
+    await releaseCursorMcpApproval(session);
     throw error;
   }
 }
@@ -1812,6 +1873,7 @@ async function stopSession(session: AcpThreadSession): Promise<void> {
 
   session.connection.kill();
   removeSession(session);
+  await releaseCursorMcpApproval(session);
 }
 
 /**
@@ -1820,7 +1882,7 @@ async function stopSession(session: AcpThreadSession): Promise<void> {
  * any in-flight prompt rejection is swallowed by the turn loop because
  * `stopping` is already set.
  */
-function releaseSession(session: AcpThreadSession): void {
+async function releaseSession(session: AcpThreadSession): Promise<void> {
   if (session.stopping) {
     return;
   }
@@ -1829,6 +1891,7 @@ function releaseSession(session: AcpThreadSession): void {
   cancelPendingPermissions(session);
   session.connection.kill();
   removeSession(session);
+  await releaseCursorMcpApproval(session);
 }
 
 // ---------------------------------------------------------------------------
@@ -2368,7 +2431,7 @@ async function handleRequest(
       const session = sessionsByBbThreadId.get(request.params.threadId);
       if (session) {
         if (request.params.intent === "release") {
-          releaseSession(session);
+          await releaseSession(session);
         } else {
           await stopSession(session);
         }

--- a/plugins/provider-acp/src/bridge/cursor-mcp-approval.test.ts
+++ b/plugins/provider-acp/src/bridge/cursor-mcp-approval.test.ts
@@ -1,0 +1,140 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  approveCursorSessionMcpServer,
+  buildCursorMcpApprovalIdentifier,
+  revokeCursorSessionMcpServer,
+} from "./cursor-mcp-approval.js";
+import type { AcpMcpServerConfig } from "./tool-proxy-mcp.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+  const path = mkdtempSync(join(tmpdir(), prefix));
+  tempDirs.push(path);
+  return path;
+}
+
+function mcpConfig(threadId = "thread-1"): AcpMcpServerConfig {
+  return {
+    name: "bb-bridge",
+    command: "/usr/local/bin/node",
+    args: ["/app/bridge.js", "--mcp-stdio"],
+    env: [
+      { name: "BB_TOKEN", value: "secret" },
+      { name: "BB_THREAD", value: threadId },
+    ],
+  };
+}
+
+afterEach(() => {
+  for (const path of tempDirs.splice(0)) {
+    rmSync(path, { recursive: true, force: true });
+  }
+});
+
+describe("Cursor ACP session MCP approvals", () => {
+  it("matches Cursor's approval fingerprint for a normalized stdio server", () => {
+    expect(
+      buildCursorMcpApprovalIdentifier({
+        config: mcpConfig(),
+        projectRoot: "/workspace/project",
+      }),
+    ).toBe("bb-bridge-d4709a3db84ddb48");
+  });
+
+  it("does not touch Cursor data for other ACP agents", async () => {
+    const cursorDataDir = makeTempDir("bb-cursor-data-");
+    const workspace = makeTempDir("bb-cursor-workspace-");
+
+    await expect(
+      approveCursorSessionMcpServer({
+        agentCommand: "opencode",
+        config: mcpConfig(),
+        cwd: workspace,
+        env: { CURSOR_DATA_DIR: cursorDataDir },
+      }),
+    ).resolves.toBeUndefined();
+    expect(() => readFileSync(join(cursorDataDir, "projects"))).toThrow();
+  });
+
+  it("preserves unrelated approvals and removes its session approval on release", async () => {
+    const cursorDataDir = makeTempDir("bb-cursor-data-");
+    const workspace = makeTempDir("bb-cursor-workspace-");
+    const env = { CURSOR_DATA_DIR: cursorDataDir };
+    const first = await approveCursorSessionMcpServer({
+      agentCommand: "/opt/cursor/cursor-agent",
+      config: mcpConfig(),
+      cwd: workspace,
+      env,
+    });
+    if (!first) {
+      throw new Error("Cursor approval was not installed");
+    }
+    await revokeCursorSessionMcpServer(first);
+    writeFileSync(first.path, '["user-approved-server"]\n', "utf8");
+
+    const approvals = await Promise.all([
+      approveCursorSessionMcpServer({
+        agentCommand: "cursor-agent",
+        config: mcpConfig("thread-a"),
+        cwd: workspace,
+        env,
+      }),
+      approveCursorSessionMcpServer({
+        agentCommand: "cursor-agent.exe",
+        config: mcpConfig("thread-b"),
+        cwd: workspace,
+        env,
+      }),
+    ]);
+    expect(approvals.every(Boolean)).toBe(true);
+    const installed = approvals.flatMap((approval) =>
+      approval ? [approval] : [],
+    );
+    const stored = JSON.parse(readFileSync(first.path, "utf8")) as string[];
+    expect(stored[0]).toBe("user-approved-server");
+    expect(stored.slice(1).sort()).toEqual(
+      installed.map((approval) => approval.approval).sort(),
+    );
+
+    await Promise.all(installed.map(revokeCursorSessionMcpServer));
+    expect(JSON.parse(readFileSync(first.path, "utf8")) as unknown).toEqual([
+      "user-approved-server",
+    ]);
+    expect(() => readFileSync(`${first.path}.bb-lock`)).toThrow();
+  });
+
+  it("does not remove an approval Cursor already had", async () => {
+    const cursorDataDir = makeTempDir("bb-cursor-data-");
+    const workspace = makeTempDir("bb-cursor-workspace-");
+    const env = { CURSOR_DATA_DIR: cursorDataDir };
+    const installed = await approveCursorSessionMcpServer({
+      agentCommand: "cursor-agent",
+      config: mcpConfig(),
+      cwd: workspace,
+      env,
+    });
+    if (!installed) {
+      throw new Error("Cursor approval was not installed");
+    }
+    await revokeCursorSessionMcpServer(installed);
+    writeFileSync(installed.path, JSON.stringify([installed.approval]), "utf8");
+
+    const existing = await approveCursorSessionMcpServer({
+      agentCommand: "cursor-agent",
+      config: mcpConfig(),
+      cwd: workspace,
+      env,
+    });
+    expect(existing?.installedByBb).toBe(false);
+    if (existing) {
+      await revokeCursorSessionMcpServer(existing);
+    }
+    expect(JSON.parse(readFileSync(installed.path, "utf8")) as unknown).toEqual(
+      [installed.approval],
+    );
+  });
+});

--- a/plugins/provider-acp/src/bridge/cursor-mcp-approval.ts
+++ b/plugins/provider-acp/src/bridge/cursor-mcp-approval.ts
@@ -1,0 +1,236 @@
+import { execFile } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import {
+  ACP_BRIDGE_MCP_SERVER_NAME,
+  type AcpMcpServerConfig,
+} from "./tool-proxy-mcp.js";
+
+const CURSOR_MCP_APPROVAL_FILE = "mcp-approvals.json";
+const CURSOR_APPROVAL_LOCK_STALE_MS = 30_000;
+const CURSOR_APPROVAL_LOCK_TIMEOUT_MS = 5_000;
+
+export interface CursorMcpApproval {
+  approval: string;
+  installedByBb: boolean;
+  path: string;
+}
+
+function errorCode(error: unknown): unknown {
+  return error instanceof Error && "code" in error ? error.code : undefined;
+}
+
+function cursorAgentCommand(command: string): boolean {
+  return (
+    basename(command)
+      .toLowerCase()
+      .replace(/\.(?:bat|cmd|exe)$/u, "") === "cursor-agent"
+  );
+}
+
+function cursorProjectSlug(projectRoot: string): string {
+  return projectRoot
+    .replace(/[^a-zA-Z0-9]/gu, "-")
+    .replace(/-+/gu, "-")
+    .replace(/^-+|-+$/gu, "");
+}
+
+function cursorDataDirectory(
+  env: Readonly<Record<string, string | undefined>>,
+): string {
+  const configured = env.CURSOR_DATA_DIR?.trim();
+  if (configured) {
+    return configured;
+  }
+  const home = env.HOME?.trim() || env.USERPROFILE?.trim() || homedir();
+  return join(home, ".cursor");
+}
+
+function cursorMcpServerConfig(config: AcpMcpServerConfig): {
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+} {
+  return {
+    command: config.command,
+    args: config.args,
+    env: Object.fromEntries(config.env.map(({ name, value }) => [name, value])),
+  };
+}
+
+/**
+ * Cursor hashes the project root and normalized MCP server config into the
+ * approval identifier stored in its project data. Its ACP adapter applies
+ * this approval gate to client-supplied session MCP servers, but ACP has no
+ * permission round-trip through which bb can answer that gate (#2018).
+ */
+export function buildCursorMcpApprovalIdentifier(args: {
+  config: AcpMcpServerConfig;
+  projectRoot: string;
+}): string {
+  const fingerprint = createHash("sha256")
+    .update(
+      JSON.stringify({
+        path: args.projectRoot,
+        server: cursorMcpServerConfig(args.config),
+      }),
+    )
+    .digest("hex")
+    .slice(0, 16);
+  return `${args.config.name}-${fingerprint}`;
+}
+
+async function resolveCursorProjectRoot(args: {
+  cwd: string;
+  env: Readonly<Record<string, string | undefined>>;
+}): Promise<string> {
+  return new Promise((resolveRoot) => {
+    execFile(
+      "git",
+      ["rev-parse", "--show-toplevel"],
+      { cwd: args.cwd, env: args.env, windowsHide: true },
+      (error, stdout) => {
+        const root = stdout.trim();
+        resolveRoot(error === null && root !== "" ? root : resolve(args.cwd));
+      },
+    );
+  });
+}
+
+async function readApprovals(path: string): Promise<string[]> {
+  let text: string;
+  try {
+    text = await readFile(path, "utf8");
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+  const value: unknown = JSON.parse(text);
+  if (
+    !Array.isArray(value) ||
+    !value.every((item) => typeof item === "string")
+  ) {
+    throw new Error(`Cursor MCP approval file is not a string array: ${path}`);
+  }
+  return value;
+}
+
+async function writeApprovals(path: string, approvals: readonly string[]) {
+  await mkdir(dirname(path), { recursive: true });
+  const tempPath = `${path}.bb-${process.pid}-${randomBytes(6).toString("hex")}.tmp`;
+  try {
+    await writeFile(tempPath, `${JSON.stringify(approvals, null, 2)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await rename(tempPath, path);
+  } catch (error) {
+    await rm(tempPath, { force: true });
+    throw error;
+  }
+}
+
+async function acquireApprovalLock(path: string): Promise<() => Promise<void>> {
+  const lockPath = `${path}.bb-lock`;
+  const deadline = Date.now() + CURSOR_APPROVAL_LOCK_TIMEOUT_MS;
+  await mkdir(dirname(path), { recursive: true });
+  for (;;) {
+    try {
+      await mkdir(lockPath, { mode: 0o700 });
+      return () => rm(lockPath, { recursive: true, force: true });
+    } catch (error) {
+      if (errorCode(error) !== "EEXIST") {
+        throw error;
+      }
+    }
+
+    try {
+      const lockStat = await stat(lockPath);
+      if (Date.now() - lockStat.mtimeMs > CURSOR_APPROVAL_LOCK_STALE_MS) {
+        await rm(lockPath, { recursive: true, force: true });
+        continue;
+      }
+    } catch (error) {
+      if (errorCode(error) === "ENOENT") {
+        continue;
+      }
+      throw error;
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out updating Cursor MCP approvals: ${path}`);
+    }
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 25));
+  }
+}
+
+async function mutateApprovals(
+  path: string,
+  mutate: (approvals: string[]) => string[],
+): Promise<void> {
+  const releaseLock = await acquireApprovalLock(path);
+  try {
+    const approvals = await readApprovals(path);
+    const nextApprovals = mutate(approvals);
+    if (
+      approvals.length !== nextApprovals.length ||
+      approvals.some((approval, index) => approval !== nextApprovals[index])
+    ) {
+      await writeApprovals(path, nextApprovals);
+    }
+  } finally {
+    await releaseLock();
+  }
+}
+
+export async function approveCursorSessionMcpServer(args: {
+  agentCommand: string;
+  config: AcpMcpServerConfig;
+  cwd: string;
+  env: Readonly<Record<string, string | undefined>>;
+}): Promise<CursorMcpApproval | undefined> {
+  if (
+    !cursorAgentCommand(args.agentCommand) ||
+    args.config.name !== ACP_BRIDGE_MCP_SERVER_NAME
+  ) {
+    return undefined;
+  }
+  const projectRoot = await resolveCursorProjectRoot({
+    cwd: args.cwd,
+    env: args.env,
+  });
+  const path = join(
+    cursorDataDirectory(args.env),
+    "projects",
+    cursorProjectSlug(projectRoot),
+    CURSOR_MCP_APPROVAL_FILE,
+  );
+  const approval = buildCursorMcpApprovalIdentifier({
+    config: args.config,
+    projectRoot,
+  });
+  let installedByBb = false;
+  await mutateApprovals(path, (approvals) => {
+    if (approvals.includes(approval)) {
+      return approvals;
+    }
+    installedByBb = true;
+    return [...approvals, approval];
+  });
+  return { approval, installedByBb, path };
+}
+
+export async function revokeCursorSessionMcpServer(
+  approval: CursorMcpApproval,
+): Promise<void> {
+  if (!approval.installedByBb) {
+    return;
+  }
+  await mutateApprovals(approval.path, (approvals) =>
+    approvals.filter((candidate) => candidate !== approval.approval),
+  );
+}

--- a/plugins/provider-acp/src/bridge/mcp-server-entry.test.ts
+++ b/plugins/provider-acp/src/bridge/mcp-server-entry.test.ts
@@ -45,6 +45,7 @@ interface AdvertisedMcpServer {
 const children: ChildProcess[] = [];
 const tempDirs: string[] = [];
 const bridgeLines: BridgeLine[] = [];
+let bridgeStderr = "";
 let nextRequestId = 1;
 
 function makeTempDir(prefix: string): string {
@@ -104,6 +105,7 @@ function spawnBridgeLikeTheAgentRuntime(dataDir: string): ChildProcess {
   );
   children.push(bridge);
   bridge.stderr?.on("data", (chunk: Buffer) => {
+    bridgeStderr += chunk.toString();
     process.stderr.write(`[bridge] ${chunk.toString()}`);
   });
   if (!bridge.stdout) {
@@ -261,6 +263,7 @@ afterEach(() => {
     rmSync(dir, { recursive: true, force: true });
   }
   bridgeLines.length = 0;
+  bridgeStderr = "";
 });
 
 describe("bb-bridge MCP server entry point (#1918)", () => {
@@ -278,6 +281,15 @@ describe("bb-bridge MCP server entry point (#1918)", () => {
     expect(exitCode).toBeUndefined();
     expect(stdoutLines[0]).toContain(
       `"serverInfo":{"name":"${ACP_BRIDGE_MCP_SERVER_NAME}"`,
+    );
+    await waitFor(
+      () =>
+        bridgeStderr.includes(
+          `"${ACP_BRIDGE_MCP_SERVER_NAME}" answered initialize`,
+        )
+          ? true
+          : undefined,
+      "bridge-side MCP initialize diagnostic",
     );
     // The entry must be the bridge module itself, never the bootstrap.
     expect(config.args.some((arg) => arg.includes("bridge-worker"))).toBe(

--- a/plugins/provider-acp/src/bridge/tool-proxy-mcp.test.ts
+++ b/plugins/provider-acp/src/bridge/tool-proxy-mcp.test.ts
@@ -43,7 +43,14 @@ async function listenFakeBridge(args: {
       buffer += chunk;
       const newline = buffer.indexOf("\n");
       if (newline === -1) return;
-      requests.push(JSON.parse(buffer.slice(0, newline)));
+      const request = JSON.parse(buffer.slice(0, newline)) as {
+        kind?: unknown;
+      };
+      if (request.kind === "initialized") {
+        socket.end(`${JSON.stringify({ ok: true, content: "" })}\n`);
+        return;
+      }
+      requests.push(request);
       setTimeout(() => {
         socket.end(
           `${JSON.stringify({ ok: true, content: '{"answers":{"Which?":"B"}}' })}\n`,

--- a/plugins/provider-acp/src/bridge/tool-proxy-mcp.ts
+++ b/plugins/provider-acp/src/bridge/tool-proxy-mcp.ts
@@ -34,13 +34,30 @@ export interface BuildAcpMcpServerConfigArgs {
   token: string;
 }
 
-interface BridgeToolCallRequest {
-  arguments: Record<string, unknown>;
-  callId: string;
+interface BridgeRequestBase {
   threadId: string;
   token: string;
-  tool: string;
 }
+
+type BridgeRequest = BridgeRequestBase &
+  (
+    | { kind: "initialized"; toolCount: number }
+    | {
+        kind: "toolCall";
+        arguments: Record<string, unknown>;
+        callId: string;
+        tool: string;
+      }
+  );
+
+type BridgeRequestPayload =
+  | { kind: "initialized"; toolCount: number }
+  | {
+      kind: "toolCall";
+      arguments: Record<string, unknown>;
+      callId: string;
+      tool: string;
+    };
 
 type BridgeToolCallResponse =
   | { ok: true; content: string; isError?: boolean }
@@ -147,14 +164,14 @@ function mcpToolCallId(toolName: string): string {
 
 function callBridge(
   env: McpServerEnvironment,
-  request: Omit<BridgeToolCallRequest, "threadId" | "token">,
+  request: BridgeRequestPayload,
 ): Promise<BridgeToolCallResponse> {
   return new Promise((resolve, reject) => {
     const socket = createConnection({ host: env.host, port: env.port });
     let buffer = "";
     socket.setEncoding("utf8");
     socket.on("connect", () => {
-      const payload: BridgeToolCallRequest = {
+      const payload: BridgeRequest = {
         ...request,
         threadId: env.threadId,
         token: env.token,
@@ -237,6 +254,16 @@ async function handleRequest(
         capabilities: { tools: {} },
         serverInfo: { name: ACP_BRIDGE_MCP_SERVER_NAME, version: "1.0.0" },
       });
+      void callBridge(env, {
+        kind: "initialized",
+        toolCount: env.tools.length,
+      }).catch((error) => {
+        process.stderr.write(
+          `bb-bridge MCP: failed to report initialize: ${
+            error instanceof Error ? error.message : String(error)
+          }\n`,
+        );
+      });
       return;
 
     case "tools/list":
@@ -274,6 +301,7 @@ async function handleRequest(
             });
       try {
         const result = await callBridge(env, {
+          kind: "toolCall",
           arguments: toolArguments,
           callId: mcpToolCallId(tool.name),
           tool: tool.name,


### PR DESCRIPTION
## What was wrong

Cursor ACP applies its project MCP approval gate to client-supplied session MCP servers. ACP has no client permission round trip for that gate, so Cursor rejected the valid `bb-bridge` stdio config before spawning it. The same config-advertisement path exists before and after #1834, and the #1932 bootstrap fix remains valid; the missing Cursor approval was the separate root cause.

## What changed

The ACP bridge now installs the exact bb-owned session MCP fingerprint in the Cursor project approval store before `session/new`, `session/load`, or `session/fork`. It limits the workaround to `cursor-agent` plus the `bb-bridge` config, preserves existing approvals, serializes concurrent updates, and removes approvals that bb installed when the session ends.

The MCP child also reports `initialize` back to the bridge, giving host-side diagnostics for both config construction and successful child startup. No server/host-daemon wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` does not need a bump.

## How you verified

Added fingerprint, approval-file preservation/concurrency, session-lifecycle, and MCP initialize diagnostic regressions. These expose the missing approval before the fix and pass afterward.

- `pnpm exec turbo run test --filter=bb-plugin-provider-acp --force` — 175 passed
- `pnpm exec turbo run typecheck --filter=bb-plugin-provider-acp`
- Isolated manual run against Cursor CLI `2026.06.19-20-24-33-653a7fb`, with approval installed after ACP `initialize` and before `session/new`; Cursor spawned and initialized the MCP server

Fixes #2018

> AGENT GENERATED: by GPT-5