### PR TITLE
Fix Pi context usage updates during tool loops

### DIFF
--- a/packages/agent-runtime/src/pi/bridge/__tests__/bridge.test.ts
+++ b/packages/agent-runtime/src/pi/bridge/__tests__/bridge.test.ts
@@ -337,6 +337,59 @@ function createAgentEndEvent(): AgentSessionEvent {
   };
 }
 
+function createTurnEndEvent(
+  stopReason: "toolUse" | "stop",
+): AgentSessionEvent {
+  const hasToolResult = stopReason === "toolUse";
+  return {
+    type: "turn_end",
+    message: {
+      role: "assistant",
+      content: hasToolResult
+        ? [
+            {
+              type: "toolCall",
+              id: "call-read-1",
+              name: "read",
+              arguments: { path: "/tmp/example.txt" },
+            },
+          ]
+        : [{ type: "text", text: "done" }],
+      api: "openai-responses",
+      provider: "openai",
+      model: "gpt-5.4",
+      usage: {
+        input: 10,
+        output: 2,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 12,
+        cost: {
+          input: 0,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          total: 0,
+        },
+      },
+      stopReason,
+      timestamp: 0,
+    },
+    toolResults: hasToolResult
+      ? [
+          {
+            role: "toolResult",
+            toolCallId: "call-read-1",
+            toolName: "read",
+            content: [{ type: "text", text: "tool output" }],
+            isError: false,
+            timestamp: 0,
+          },
+        ]
+      : [],
+  };
+}
+
 describe("pi bridge", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -1213,6 +1266,71 @@ describe("pi bridge", () => {
           status: "completed",
         }),
       );
+    } finally {
+      bridge.restore();
+    }
+  });
+
+  it("reports context usage after every Pi turn_end without duplicating agent_end", async () => {
+    const bridge = createBridgeJsonRpcTestHarness(handleLine);
+    const piSession = createControlledPiAgentSession();
+    piSession.getContextUsage
+      .mockReturnValueOnce({
+        tokens: 10_500,
+        contextWindow: 1_050_000,
+        percent: 1,
+      })
+      .mockReturnValueOnce({
+        tokens: 11_750,
+        contextWindow: 1_050_000,
+        percent: (11_750 / 1_050_000) * 100,
+      });
+    piSession.prompt.mockImplementation(async () => {
+      piSession.emit({ type: "agent_start" });
+      piSession.emit(createTurnEndEvent("toolUse"));
+      piSession.emit(createTurnEndEvent("stop"));
+      piSession.emit(createAgentEndEvent());
+    });
+    mockCreateAgentSession.mockResolvedValue({ session: piSession });
+
+    try {
+      bridge.sendRequest(
+        52,
+        "thread/start",
+        sessionParams({ threadId: "thread-context-usage" }),
+      );
+      await bridge.waitForResponse(52);
+
+      bridge.sendRequest(
+        53,
+        "turn/start",
+        turnStartParams("thread-context-usage", [
+          { type: "text", text: "read and respond" },
+        ]),
+      );
+      await bridge.waitForResponse(53);
+      await bridge.flushWork();
+
+      const usageEvents = threadEvents(bridge.messages).filter(
+        (event) => event.type === "thread/contextWindowUsage/updated",
+      );
+      expect(usageEvents).toEqual([
+        expect.objectContaining({
+          contextWindowUsage: {
+            usedTokens: 10_500,
+            modelContextWindow: 1_050_000,
+            estimated: true,
+          },
+        }),
+        expect.objectContaining({
+          contextWindowUsage: {
+            usedTokens: 11_750,
+            modelContextWindow: 1_050_000,
+            estimated: true,
+          },
+        }),
+      ]);
+      expect(piSession.getContextUsage).toHaveBeenCalledTimes(2);
     } finally {
       bridge.restore();
     }

--- a/packages/agent-runtime/src/pi/bridge/bridge.ts
+++ b/packages/agent-runtime/src/pi/bridge/bridge.ts
@@ -470,7 +470,9 @@ function createOnPiEvent(
           ? event
           : { ...event, providerCheckpointId },
     });
-    if (event.type === "agent_end" || event.type === "compaction_end") {
+    // Pi emits turn_end only after the assistant response and its tool results
+    // have entered session context, so this samples what the next request sees.
+    if (event.type === "turn_end" || event.type === "compaction_end") {
       emitContextWindowUsage(args.threadId);
     }
   };

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,8 @@
+// Version 142 ships Pi context-window usage after every SDK turn ends, once
+// its assistant response and tool results are both reflected in the session.
+// Older bundled bridges report only after the full agent run ends, leaving the
+// meter stale throughout multi-tool turns.
+//
 // Version 141 extends the consumed-not-queued acceptance rule to the remaining
 // providers. Pi reports `input.accepted` for a turn only once it read the
 // input: a prompt pi queues behind a live run stays unaccepted, and the
@@ -80,7 +85,7 @@
 //
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 141 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 142 as const;
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1138,7 +1138,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(141);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(142);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 


### PR DESCRIPTION
## What was wrong

Pi sampled context-window usage only on SDK `agent_end`, which fires after the entire agent run. A tool-heavy run contains multiple SDK `turn_end` events—each after an assistant response and its tool results—so bb's context meter stayed stale throughout the tool loop even though Pi's underlying context estimate was changing. See #2023.

## What changed

- Sample and emit Pi context-window usage on every `turn_end`, while retaining the existing `compaction_end` update.
- Stop sampling again at `agent_end`; that event is still forwarded normally for completion and checkpoint handling, but the final `turn_end` already emitted the same context snapshot.
- Add a bridge regression test with an intermediate tool-result turn and a final response. It asserts that both usage snapshots arrive and that `agent_end` does not duplicate the final one.
- Bump `HOST_DAEMON_PROTOCOL_VERSION` from 141 to 142 because the bundled Pi bridge's daemon-to-server event cadence changed and enrolled daemons need to update.

## How you verified

- `pnpm exec turbo run test --filter=@bb/agent-runtime --force -- src/pi/bridge/__tests__/bridge.test.ts` — 27 passed. The new regression fails before the fix because only the `agent_end` sample is emitted.
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime --filter=@bb/host-daemon-contract --force` — passed.
- `pnpm exec turbo run test --filter=@bb/host-daemon-contract --force -- test/contract.test.ts` — 38 passed.
- The full host-daemon-contract suite was also run locally: 51 tests passed and its unrelated fixed gzip-byte measurement test differed under local Node 26.3.1/zlib (`payload-size.test.ts`); the protocol contract itself passed.

Fixes #2023

> AGENT GENERATED: by GPT-5
