### PR TITLE
Make plugin file openers reachable and give them a real height

### DIFF
--- a/apps/app/src/components/plugin/PluginPanelActions.tsx
+++ b/apps/app/src/components/plugin/PluginPanelActions.tsx
@@ -383,7 +383,11 @@ function FileOpenerTabContent({
     >
       {(opener, BoundOriginal) => (
         <div
-          className="flex min-h-0 flex-1 flex-col overflow-hidden"
+          // `h-full` matters: the region this mounts into is a block box, so
+          // `flex-1` alone leaves the wrapper at content height and an opener
+          // that sizes itself with `flex-1` collapses to nothing. Same shape
+          // as the action-tab wrapper above.
+          className="flex h-full min-h-0 flex-1 flex-col overflow-hidden"
           data-testid="plugin-file-opener-tab-content"
         >
           <opener.component

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
@@ -615,6 +615,104 @@ describe("useThreadFileTabs file opener diversion", () => {
     expect(result.current.activeWorkspaceFilePath).toBe("src/index.ts");
   });
 
+  // The file search builds its tab through its own path (it replaces the
+  // new-tab screen rather than appending a tab), so diversion has to be
+  // applied there too. It was not, and every file picked from the "+" screen
+  // silently got the built-in preview while links and `bb thread open`
+  // diverted correctly.
+  it("diverts a workspace file picked from the file search", () => {
+    registerNotesOpener();
+    const { result } = renderThreadHook(() =>
+      useThreadFileTabs({
+        panelStateId: "opener-search",
+        syncThreadId: "opener-search",
+        environmentId: "env_1",
+        storageFiles: undefined,
+        terminalSessions: undefined,
+      }),
+    );
+
+    act(() => result.current.openTab({ kind: "new-tab" }));
+    act(() =>
+      result.current.selectFileSearchResult({
+        source: "workspace",
+        path: "notes/todo.md",
+      }),
+    );
+
+    expect(result.current.activePluginPanelTab).toMatchObject({
+      kind: "plugin-panel",
+      pluginId: "notes",
+      actionId: "file-opener:editor",
+      title: "todo.md",
+    });
+    const params = JSON.parse(
+      result.current.activePluginPanelTab?.paramsJson ?? "null",
+    ) as { path: string; source: { kind: string; environmentId: string | null } };
+    expect(params.path).toBe("notes/todo.md");
+    expect(params.source).toMatchObject({
+      kind: "workspace",
+      environmentId: "env_1",
+    });
+    // The new-tab screen is replaced, not appended to.
+    expect(result.current.isNewTabActive).toBe(false);
+    expect(
+      result.current.orderedSecondaryFileTabs.map((tab) => tab.kind),
+    ).toEqual(["plugin-panel"]);
+  });
+
+  it("keeps the built-in preview for an unmatched file search extension", () => {
+    registerNotesOpener();
+    const { result } = renderThreadHook(() =>
+      useThreadFileTabs({
+        panelStateId: "opener-search-unmatched",
+        syncThreadId: "opener-search-unmatched",
+        environmentId: "env_1",
+        storageFiles: undefined,
+        terminalSessions: undefined,
+      }),
+    );
+
+    act(() => result.current.openTab({ kind: "new-tab" }));
+    act(() =>
+      result.current.selectFileSearchResult({
+        source: "workspace",
+        path: "src/main.rs",
+      }),
+    );
+
+    expect(result.current.activePluginPanelTab).toBeNull();
+    expect(result.current.activeWorkspaceFilePath).toBe("src/main.rs");
+  });
+
+  it("honors a pinned built-in preference from the file search", () => {
+    window.localStorage.setItem(
+      "bb.fileOpenerByExtension",
+      JSON.stringify({ md: "__builtin__" }),
+    );
+    registerNotesOpener();
+    const { result } = renderThreadHook(() =>
+      useThreadFileTabs({
+        panelStateId: "opener-search-pinned",
+        syncThreadId: "opener-search-pinned",
+        environmentId: "env_1",
+        storageFiles: undefined,
+        terminalSessions: undefined,
+      }),
+    );
+
+    act(() => result.current.openTab({ kind: "new-tab" }));
+    act(() =>
+      result.current.selectFileSearchResult({
+        source: "workspace",
+        path: "notes/todo.md",
+      }),
+    );
+
+    expect(result.current.activePluginPanelTab).toBeNull();
+    expect(result.current.activeWorkspaceFilePath).toBe("notes/todo.md");
+  });
+
   it("falls back to the built-in preview when no opener is registered", () => {
     const { result } = renderThreadHook(() =>
       useThreadFileTabs({

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
@@ -516,12 +516,41 @@ export function useThreadFileTabs({
 
   const selectFileSearchResult = useCallback(
     (selection: FileSearchSelection) => {
-      const tab = createTabForFileSearchSelection({
+      // Opener diversion, same as `openTab`. The file search builds its tab
+      // through its own path (it replaces the new-tab screen rather than
+      // appending a tab), so without this a plugin `fileOpener` was skipped
+      // for every file picked from the "+" screen while still applying to
+      // links and `bb thread open`.
+      const openerTab = createFileOpenerTabForRequest({
+        fileOpeners,
+        preference: fileOpenerPreference,
         projectId,
+        request:
+          selection.source === "workspace"
+            ? {
+                kind: "workspace-file-preview",
+                tab: {
+                  lineRange: null,
+                  path: selection.path,
+                  source: { kind: "working-tree" },
+                  statusLabel: null,
+                },
+              }
+            : {
+                kind: "thread-storage-file-preview",
+                tab: { lineRange: null, path: selection.path },
+              },
         resolvedEnvironmentId,
-        selection,
         threadId: resolvedFileOwnerThreadId,
       });
+      const tab =
+        openerTab ??
+        createTabForFileSearchSelection({
+          projectId,
+          resolvedEnvironmentId,
+          selection,
+          threadId: resolvedFileOwnerThreadId,
+        });
       if (tab === null) return;
 
       if (selection.source === "workspace") {
@@ -535,6 +564,8 @@ export function useThreadFileTabs({
       );
     },
     [
+      fileOpenerPreference,
+      fileOpeners,
       projectId,
       recordRecentItem,
       resolvedEnvironmentId,

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -2358,11 +2358,14 @@ function RootComposeSurface({
             fileTabContent,
             fileTabContentFillsRegion:
               activePluginPanelTab !== null &&
-              rootPanelNewThreadPanelActions.find(
-                (candidate) =>
-                  candidate.pluginId === activePluginPanelTab.pluginId &&
-                  candidate.id === activePluginPanelTab.actionId,
-              )?.layout === "flush",
+              // See ThreadDetailView: a `fileOpener` tab owns its layout, and
+              // its `file-opener:<id>` actionId never matches a panel action.
+              (activePluginPanelTab.fileOpenerOwner !== undefined ||
+                rootPanelNewThreadPanelActions.find(
+                  (candidate) =>
+                    candidate.pluginId === activePluginPanelTab.pluginId &&
+                    candidate.id === activePluginPanelTab.actionId,
+                )?.layout === "flush"),
             renderBrowserDeck,
             isBrowserTabActive,
             isOpen: isSecondaryPanelOpen,

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -2896,21 +2896,28 @@ function ThreadDetailViewInternal(props: ThreadDetailViewInternalProps) {
             fileTabContent,
             fileTabContentFillsRegion:
               activePluginPanelTab !== null &&
-              pluginThreadPanelActions.find(
-                (candidate) =>
-                  candidate.pluginId === activePluginPanelTab.pluginId &&
-                  candidate.id === activePluginPanelTab.actionId,
-              )?.layout === "flush",
+              // A plugin `fileOpener` owns its own layout and scrolling, so it
+              // gets the definite-height region rather than the preview's
+              // scroll container — the same treatment as a "flush" action tab.
+              // Its actionId is `file-opener:<id>`, which never matches a
+              // threadPanelAction, so it needs its own arm here.
+              (activePluginPanelTab.fileOpenerOwner !== undefined ||
+                pluginThreadPanelActions.find(
+                  (candidate) =>
+                    candidate.pluginId === activePluginPanelTab.pluginId &&
+                    candidate.id === activePluginPanelTab.actionId,
+                )?.layout === "flush"),
             splitPanelStateId: thread.id,
             splitTabModels: syncedOrderedSecondaryFileTabs,
             renderSplitTabContent,
             splitTabContentFillsRegion: (tab) =>
               tab.kind === "plugin-panel" &&
-              pluginThreadPanelActions.find(
-                (candidate) =>
-                  candidate.pluginId === tab.pluginId &&
-                  candidate.id === tab.actionId,
-              )?.layout === "flush",
+              (tab.fileOpenerOwner !== undefined ||
+                pluginThreadPanelActions.find(
+                  (candidate) =>
+                    candidate.pluginId === tab.pluginId &&
+                    candidate.id === tab.actionId,
+                )?.layout === "flush"),
             renderBrowserDeck,
             isBrowserTabActive,
             isOpen: isSecondaryPanelOpen,


### PR DESCRIPTION
## Human comments

Before this, (1) custom file openers did not work on files opened via CMD+P, and (2) a custom file opener would render with nearly 0px height:
<img width="666" height="815" alt="Screenshot 2026-08-20 at 1 14 41 AM" src="https://github.com/user-attachments/assets/54a8b8b5-f903-49ce-a940-e9f8bdac5c16" />


-----

## What was wrong

The `fileOpener` plugin slot could not work end to end — three independent defects, each of which alone made the slot unusable. **Reachability:** the secondary panel's file search built its tab through `createTabForFileSearchSelection` and never called `createFileOpenerTabForRequest`, so a file picked from the "+"/quick-open screen always got the built-in preview regardless of the user's Settings → File openers choice; diversion applied only to file links and `bb thread open`, contradicting the comment on `openTab` that claims every file-open flow funnels through it. **Sizing:** `fileTabContentFillsRegion` resolved the active tab's `actionId` against `threadPanelActions`, but a file-opener tab's actionId is `file-opener:<id>` (`FILE_OPENER_ACTION_ID_PREFIX`) and never matched, so opener tabs always landed in the preview's scroll container rather than the definite-height region; and the file-opener wrapper was `min-h-0 flex-1` where the action-tab wrapper 90 lines above it is `h-full min-h-0 flex-1`. Since that region is a block box, `flex-1` was inert and the wrapper collapsed to content height, so an opener that sizes itself with `flex-1` rendered at zero height.

Found while building a Monaco-based editor plugin against the slot: the opener registered, appeared in Settings, was explicitly selected for `.ts` and `.json`, and still never rendered — and once forced to render, occupied ~10px.

## What changed

- `apps/app/src/components/secondary-panel/useThreadFileTabs.ts` — `selectFileSearchResult` now runs the same opener diversion as `openTab`, falling back to the built-in tab when no opener matches. The replace-the-new-tab-screen behavior is unchanged.
- `apps/app/src/views/thread-detail/ThreadDetailView.tsx`, `apps/app/src/views/RootComposeView.tsx` — `fileTabContentFillsRegion` now also returns true for file-opener tabs, keyed off `fileOpenerOwner` (already set on exactly these tabs). A plugin opener owns its own layout and scrolling, so it gets the definite-height region, matching a `layout: "flush"` action tab.
- `apps/app/src/components/plugin/PluginPanelActions.tsx` — the file-opener wrapper gains `h-full`, matching the action-tab wrapper.

No wire changes, so `HOST_DAEMON_PROTOCOL_VERSION` is untouched. No CLI, guide, or doc surfaces are affected: this restores documented behavior rather than adding any.

Both sizing changes are required. Without the region fix the opener fills a scroll container and overflows by its `pb-3`; without `h-full` the wrapper stays content-sized however tall the region is.

## How you verified

Three tests added to `useThreadFileTabs.test.ts`, alongside the existing `openTab` diversion coverage:

- `diverts a workspace file picked from the file search` — **fails before, passes after**. Verified by restoring the pre-fix `useThreadFileTabs.ts` with the new tests in place: 17 pass, this one fails; with the fix, 18 pass.
- `keeps the built-in preview for an unmatched file search extension` and `honors a pinned built-in preference from the file search` — pass both before and after. They are guards, not regression proofs: they pin the fallbacks so a future change cannot start diverting files the user asked BB to keep.

```
pnpm exec turbo run test --filter=@bb/app -- useThreadFileTabs   # 18 passed
pnpm exec turbo run typecheck --filter=@bb/app                   # clean
```

The two sizing defects are **not** covered by automated tests. They are CSS-in-DOM-context failures — the wrapper collapses only because its ancestor is a block box — and the only cheap unit test available would assert a Tailwind class string, which is the kind of test AGENTS.md discourages. Testing them for real would mean extracting the `fileTabContentFillsRegion` computation out of both views into a helper; happy to do that if reviewers want it covered.

Verified manually against a dev server on this checkout with a Monaco `fileOpener` plugin installed. Before: quick-open a `.ts` file → built-in preview, with the plugin's registration confirmed live in the console and "Automatic (Monaco)" selected in Settings; pinning `.json` to Monaco explicitly changed nothing. Walking the DOM from `[data-testid="plugin-file-opener-tab-content"]` showed the wrapper at `clientHeight: 38` inside a `display: block` scroll container at 775px. After: quick-open renders the plugin editor, filling the panel, with editing, saving, and find working.

Fixes #

> AGENT GENERATED: by Claude Opus 5