### PR TITLE
Reduce conversation outline refetches during streaming

### DIFF
--- a/apps/app/src/components/thread/toc/ThreadTableOfContents.test.tsx
+++ b/apps/app/src/components/thread/toc/ThreadTableOfContents.test.tsx
@@ -687,6 +687,45 @@ describe("ThreadTableOfContents", () => {
     expect(screen.getByText("Agent messages")).not.toBeNull();
   });
 
+  it("merges live timeline messages into the cached full outline", async () => {
+    setOutline([
+      {
+        id: "row_user_1",
+        role: "user",
+        preview: "First cached question",
+        attachmentSummary: null,
+      },
+      {
+        id: "row_user_2",
+        role: "user",
+        preview: "Second cached question",
+        attachmentSummary: null,
+      },
+      {
+        id: "row_user_3",
+        role: "user",
+        preview: "Stale third question",
+        attachmentSummary: null,
+      },
+    ]);
+
+    render(
+      <TocHost
+        timelineRows={[userConversationRow(3), userConversationRow(4)]}
+      />,
+    );
+    openTocPanel();
+
+    expect(await screen.findByText("First cached question")).not.toBeNull();
+    expect(
+      screen.getByText("Loaded after client-side navigation 3"),
+    ).not.toBeNull();
+    expect(
+      screen.getByText("Loaded after client-side navigation 4"),
+    ).not.toBeNull();
+    expect(screen.queryByText("Stale third question")).toBeNull();
+  });
+
   it("renders an agent-to-agent message source as a thread mention", async () => {
     setOutline([
       {

--- a/apps/app/src/components/thread/toc/ThreadTableOfContents.tsx
+++ b/apps/app/src/components/thread/toc/ThreadTableOfContents.tsx
@@ -102,6 +102,20 @@ function outlineItemToTocItem(item: ThreadConversationOutlineItem): TocItem {
   };
 }
 
+function mergeLiveTocItems(
+  outlineItems: readonly TocItem[],
+  timelineItems: readonly TocItem[],
+): TocItem[] {
+  const timelineItemsById = new Map(
+    timelineItems.map((item) => [item.id, item]),
+  );
+  const outlineItemIds = new Set(outlineItems.map((item) => item.id));
+  return [
+    ...outlineItems.map((item) => timelineItemsById.get(item.id) ?? item),
+    ...timelineItems.filter((item) => !outlineItemIds.has(item.id)),
+  ];
+}
+
 export function selectTocRailItems({
   activeId,
   items,
@@ -224,9 +238,10 @@ function TocItemPreview({
 
 /**
  * Builds the user/agent item lists for the minimap. Prefers the full
- * conversation outline (the whole thread, independent of pagination); falls
- * back to the loaded timeline window so the minimap still renders on first
- * paint and in environments without the outline endpoint (e.g. stories).
+ * conversation outline (the whole thread, independent of pagination), then
+ * overlays the loaded timeline window so the current turn stays live between
+ * full-outline refreshes. Falls back to the timeline alone on first paint and
+ * in environments without the outline endpoint (e.g. stories).
  */
 function useConversationTocItems({
   outlineItems,
@@ -270,7 +285,19 @@ function useConversationTocItems({
     return { agentItems, userItems };
   }, [timelineRows]);
 
-  return outlineTocItems ?? timelineTocItems;
+  return useMemo(() => {
+    if (!outlineTocItems) return timelineTocItems;
+    return {
+      agentItems: mergeLiveTocItems(
+        outlineTocItems.agentItems,
+        timelineTocItems.agentItems,
+      ),
+      userItems: mergeLiveTocItems(
+        outlineTocItems.userItems,
+        timelineTocItems.userItems,
+      ),
+    };
+  }, [outlineTocItems, timelineTocItems]);
 }
 
 /**

--- a/apps/app/src/hooks/cache-owners/cache-invalidation-groups.ts
+++ b/apps/app/src/hooks/cache-owners/cache-invalidation-groups.ts
@@ -117,28 +117,29 @@ export function getThreadTimelineInvalidationQueryKeys({
       ];
 }
 
+export function getThreadConversationOutlineInvalidationQueryKeys({
+  threadId,
+}: ThreadScopedInvalidationArgs): QueryKey[] {
+  return threadId
+    ? [threadConversationOutlineQueryKeyPrefix(threadId)]
+    : [allThreadConversationOutlineQueryKeyPrefix()];
+}
+
 /**
- * Timeline-window-only invalidation for realtime `events-appended` /
- * `thread-created` / `thread-deleted`. Deliberately excludes the
- * turn-summary-details prefix: a completed turn's expanded detail is a fixed
- * `sourceSeqStart..sourceSeqEnd` range and never changes once the turn is done,
- * so re-fetching every open detail panel on every appended-event batch is pure
- * waste during streaming. Mutations that can rewrite history (fork/retry/edit)
- * still use {@link getThreadTimelineInvalidationQueryKeys}, which invalidates
- * both prefixes.
+ * Timeline-window-only invalidation for realtime `events-appended`. The full
+ * conversation outline is refreshed separately at turn boundaries because
+ * rebuilding it for every streaming delta is disproportionately expensive.
+ * Turn-summary details are also excluded: a completed turn's expanded detail
+ * is a fixed `sourceSeqStart..sourceSeqEnd` range and never changes once the
+ * turn is done. Mutations that can rewrite history (fork/retry/edit) still use
+ * {@link getThreadTimelineInvalidationQueryKeys}, which invalidates all three.
  */
 export function getThreadTimelineWindowInvalidationQueryKeys({
   threadId,
 }: ThreadScopedInvalidationArgs): QueryKey[] {
   return threadId
-    ? [
-        threadTimelineQueryKeyPrefix(threadId),
-        threadConversationOutlineQueryKeyPrefix(threadId),
-      ]
-    : [
-        allThreadTimelineQueryKeyPrefix(),
-        allThreadConversationOutlineQueryKeyPrefix(),
-      ];
+    ? [threadTimelineQueryKeyPrefix(threadId)]
+    : [allThreadTimelineQueryKeyPrefix()];
 }
 
 export function getThreadQueueContentInvalidationQueryKeys({

--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -101,6 +101,7 @@ import {
   getProjectListInvalidationQueryKeys,
   getProjectPromptHistoryInvalidationQueryKeys,
   getProjectSourceDependentInvalidationQueryKeys,
+  getThreadConversationOutlineInvalidationQueryKeys,
   getThreadDetailInvalidationQueryKeys,
   getThreadListInvalidationQueryKeys,
   getThreadPendingInteractionInvalidationQueryKeys,
@@ -902,7 +903,13 @@ function dirtyThreadTimelineQueries({
 }: ThreadRealtimeDirtyContext): void {
   // Window only: completed turn-summary-details are immutable, so realtime
   // event batches must not refetch open detail panels (see helper docs).
-  const queryKeys = getThreadTimelineWindowInvalidationQueryKeys({ threadId });
+  const timelineQueryKeys = getThreadTimelineWindowInvalidationQueryKeys({
+    threadId,
+  });
+  const outlineQueryKeys =
+    getThreadConversationOutlineInvalidationQueryKeys({ threadId });
+  const outlineMayHaveChanged =
+    eventTypes === undefined || eventTypes.includes("turn/completed");
   if (
     threadId !== undefined &&
     !hasActiveQueries(queryClient, threadTimelineQueryKeyPrefix(threadId))
@@ -910,16 +917,28 @@ function dirtyThreadTimelineQueries({
     // Nobody is viewing this thread: mark the cached window stale so a remount
     // refetches, but skip the fetch pacing/cancel machinery. List
     // subscriptions deliver every streaming thread's batches to every client.
-    for (const queryKey of queryKeys) {
+    for (const queryKey of [...timelineQueryKeys, ...outlineQueryKeys]) {
       queryClient.invalidateQueries({ queryKey, refetchType: "none" });
     }
     return;
   }
   if (eventTypes?.includes("turn/completed")) {
-    invalidateTerminalTimelineQueryKeys({ queryClient, queryKeys });
+    invalidateTerminalTimelineQueryKeys({
+      queryClient,
+      queryKeys: [...timelineQueryKeys, ...outlineQueryKeys],
+    });
     return;
   }
-  invalidateQueryKeysWithoutCancelingActiveFetches({ queryClient, queryKeys });
+  invalidateQueryKeysWithoutCancelingActiveFetches({
+    queryClient,
+    queryKeys: timelineQueryKeys,
+  });
+  if (outlineMayHaveChanged) {
+    invalidateQueryKeysWithoutCancelingActiveFetches({
+      queryClient,
+      queryKeys: outlineQueryKeys,
+    });
+  }
 }
 
 function dirtyThreadTimelineRewriteQueries({

--- a/apps/app/src/hooks/queries/thread-queries.ts
+++ b/apps/app/src/hooks/queries/thread-queries.ts
@@ -997,8 +997,9 @@ export function useThreadTimeline(
  * table-of-contents minimap. Unlike {@link useThreadTimeline}, this is not
  * paginated — it always reflects the whole thread — so the minimap can show
  * messages that have not yet been scrolled/paged into the loaded window. It is
- * invalidated by the same realtime `events-appended` signal as the timeline
- * window, so it stays in sync as new messages arrive.
+ * refreshed when a turn completes. The table of contents merges the live
+ * timeline window into this full-history snapshot while a turn is streaming,
+ * avoiding a full outline request for every appended text delta.
  */
 export function useThreadConversationOutline(
   id: string,

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -26,6 +26,7 @@ import {
   systemExecutionOptionsQueryKey,
   systemProvidersQueryKey,
   threadDefaultExecutionOptionsQueryKey,
+  threadConversationOutlineQueryKey,
   threadQueuedMessagesQueryKey,
   threadListQueryKey,
   threadPromptHistoryQueryKey,
@@ -605,6 +606,65 @@ describe("createRealtimeCacheEffects", () => {
 
     invalidateSpy.mockRestore();
     unsubscribeViewed();
+    effects.dispose();
+  });
+
+  it("refreshes the full conversation outline once at turn completion, not for streaming deltas", async () => {
+    vi.useFakeTimers();
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const threadId = "thr_outline";
+    const timelineKey = threadTimelineQueryKey(threadId);
+    const outlineKey = threadConversationOutlineQueryKey(threadId);
+    const timelineQueryFn = vi.fn(async () => ({ rows: [] }));
+    const outlineQueryFn = vi.fn(async () => ({ items: [], maxSeq: 1 }));
+    const timelineObserver = new QueryObserver(queryClient, {
+      queryKey: timelineKey,
+      queryFn: timelineQueryFn,
+      staleTime: Infinity,
+    });
+    const outlineObserver = new QueryObserver(queryClient, {
+      queryKey: outlineKey,
+      queryFn: outlineQueryFn,
+      staleTime: Infinity,
+    });
+    const unsubscribeTimeline = timelineObserver.subscribe(() => {});
+    const unsubscribeOutline = outlineObserver.subscribe(() => {});
+    await vi.advanceTimersByTimeAsync(0);
+    timelineQueryFn.mockClear();
+    outlineQueryFn.mockClear();
+
+    effects.handleChanged({
+      type: "changed",
+      entity: "thread",
+      id: threadId,
+      metadata: {
+        eventTypes: ["item/agentMessage/delta"],
+        projectId: "project-1",
+      },
+      changes: ["events-appended"],
+    });
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(timelineQueryFn).toHaveBeenCalledTimes(1);
+    expect(outlineQueryFn).not.toHaveBeenCalled();
+
+    effects.handleChanged({
+      type: "changed",
+      entity: "thread",
+      id: threadId,
+      metadata: {
+        eventTypes: ["item/completed", "turn/completed"],
+        projectId: "project-1",
+      },
+      changes: ["events-appended"],
+    });
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(timelineQueryFn).toHaveBeenCalledTimes(2);
+    expect(outlineQueryFn).toHaveBeenCalledTimes(1);
+
+    unsubscribeOutline();
+    unsubscribeTimeline();
     effects.dispose();
   });
 

--- a/apps/server/src/routes/threads/data.ts
+++ b/apps/server/src/routes/threads/data.ts
@@ -319,9 +319,11 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
   // The conversation outline reprojects the entire thread, so memoize it by
   // the newest event that can affect the outline. Command output, reasoning,
   // and usage events still advance maxSeq in the response but do not invalidate
-  // the expensive projection. The key includes thread metadata that can affect
-  // grouping; add provider/env inputs if the outline ever surfaces them. A
-  // small LRU bounds memory across many viewed threads.
+  // the expensive projection. The client also refreshes this full projection
+  // at turn boundaries and overlays the live timeline window while a turn
+  // streams. The key includes thread metadata that can affect grouping; add
+  // provider/env inputs if the outline ever surfaces them. A small LRU bounds
+  // memory across many viewed threads.
   const conversationOutlineCache = new Map<
     string,
     ThreadConversationOutlineResponse["items"]


### PR DESCRIPTION
## What was wrong

The active thread timeline and the full-history conversation outline shared the same realtime invalidation group, so every events-appended streaming batch sent another /conversation-outline request. The server cache hardening now on main from #2025 avoids rebuilding for outline-irrelevant events, but the client still performs redundant HTTP reads at streaming cadence, and assistant text deltas can still invalidate the full projection. The outline does not need sub-second route refreshes because the incremental timeline already carries the live conversation rows.

## What changed

- Split realtime timeline-window invalidation from conversation-outline invalidation.
- Refresh the full outline at the terminal turn boundary instead of for every streaming delta; unknown lifecycle notifications still invalidate it conservatively, and history rewrites retain the existing full invalidation path.
- Overlay live timeline conversation rows onto the cached full outline so current user and assistant messages remain fresh while a turn streams.
- Reconciled the server cache documentation with the outline-aware cache added by #2025 and the new client refresh policy.
- Added regressions proving streaming deltas do not refetch the outline, turn completion does, and live timeline labels replace or extend a cached outline.

This implements the client-side pacing direction from #1972 using a turn boundary plus live-row overlay instead of a timed debounce. It does not change the API contract or the server/daemon wire format, so HOST_DAEMON_PROTOCOL_VERSION is unchanged.

## How you verified

The new realtime invalidation test fails before the change because an assistant delta refetches the active outline query. The TOC merge test also fails before the change because a loaded outline always wins over newer timeline rows.

After rebasing onto origin/main at 0b2723a28:

- pnpm exec turbo run test --filter=@bb/app -- src/hooks/cache-owners/cache-owner-registry.test.ts src/hooks/realtime-cache-effects.test.ts src/components/thread/toc/ThreadTableOfContents.test.tsx — 80 tests passed
- pnpm exec turbo run typecheck --filter=@bb/app — passed
- git diff --check origin/main...HEAD — passed

Fixes #1972

> AGENT GENERATED: by GPT-5