### PR TITLE
Let stale daemons reach protocol self-update

### DIFF
--- a/apps/server/test/internal/internal-session-protocol-version.test.ts
+++ b/apps/server/test/internal/internal-session-protocol-version.test.ts
@@ -21,6 +21,47 @@ describe("internal session protocol version", () => {
       });
       const daemonClient = createHostDaemonClient(server.baseUrl, hostKey);
       const staleProtocolVersion = HOST_DAEMON_PROTOCOL_VERSION - 1;
+
+      // Keep this request shaped like a daemon from before protocol 140 added
+      // localApiPort. It must reach the version check instead of failing full
+      // payload validation, because only protocol_version_mismatch activates
+      // the daemon's self-updater.
+      const preLocalApiPortProtocolVersion = 139;
+      const oldDaemonResponse = await fetch(
+        `${server.baseUrl}/internal/session/open`,
+        {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${hostKey}`,
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            hostId: "host-protocol",
+            instanceId: "instance-pre-local-api-port",
+            hostName: "Protocol Host",
+            hostType: "persistent",
+            hasMachineCredential: false,
+            platform: "darwin",
+            dataDir: "/tmp/host-protocol-data",
+            protocolVersion: preLocalApiPortProtocolVersion,
+            activeThreads: [],
+            loadedEnvironments: [],
+          }),
+        },
+      );
+      expect(oldDaemonResponse.status).toBe(400);
+      expect(await oldDaemonResponse.json()).toMatchObject({
+        code: "protocol_version_mismatch",
+        details: {
+          retryUpdate: false,
+          serverProtocolVersion: HOST_DAEMON_PROTOCOL_VERSION,
+        },
+        message: `Daemon protocol version ${preLocalApiPortProtocolVersion} does not match server protocol version ${HOST_DAEMON_PROTOCOL_VERSION}`,
+      });
+      expect(
+        getHost(server.db, "host-protocol")?.lastRejectedProtocolVersion,
+      ).toBe(preLocalApiPortProtocolVersion);
+
       const response = await daemonClient.session.open.$post({
         json: {
           hostId: "host-protocol",
@@ -33,6 +74,7 @@ describe("internal session protocol version", () => {
           localApiPort: 38_888,
           protocolVersion: staleProtocolVersion,
           activeThreads: [],
+          loadedEnvironments: [],
         },
       });
 
@@ -69,6 +111,7 @@ describe("internal session protocol version", () => {
           localApiPort: 38_888,
           protocolVersion: staleProtocolVersion,
           activeThreads: [],
+          loadedEnvironments: [],
         },
       });
       expect(await forcedRetry.json()).toMatchObject({
@@ -87,6 +130,7 @@ describe("internal session protocol version", () => {
           localApiPort: 38_888,
           protocolVersion: staleProtocolVersion,
           activeThreads: [],
+          loadedEnvironments: [],
         },
       });
       expect(await consumedRetry.json()).toMatchObject({
@@ -105,6 +149,7 @@ describe("internal session protocol version", () => {
           localApiPort: 38_888,
           protocolVersion: HOST_DAEMON_PROTOCOL_VERSION,
           activeThreads: [],
+          loadedEnvironments: [],
         },
       });
       expect(accepted.status).toBe(201);

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,8 @@
+// Version 143 lets daemons from before session-open's `localApiPort` field
+// reach the protocol-version check by defaulting that field at the server
+// boundary. Without it, those daemons receive `invalid_request` instead of
+// `protocol_version_mismatch`, so their protocol self-updater never runs.
+//
 // Version 142 ships Pi context-window usage after every SDK turn ends, once
 // its assistant response and tool results are both reflected in the session.
 // Older bundled bridges report only after the full agent run ends, leaving the
@@ -85,7 +90,7 @@
 //
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 142 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 143 as const;
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/src/session.ts
+++ b/packages/host-daemon-contract/src/session.ts
@@ -114,15 +114,21 @@ export const hostDaemonSessionOpenRequestSchema = z.object({
   hasMachineCredential: z.boolean(),
   platform: hostPlatformSchema,
   dataDir: z.string().min(1),
-  /** Loopback editor-helper port, or null when this daemon exposes no full local API. */
-  localApiPort: z.number().int().min(1).max(65_535).nullable(),
+  /**
+   * Loopback editor-helper port, or null when this daemon exposes no full
+   * local API. The default preserves the protocol-mismatch response for
+   * daemons from before this field existed, so they can reach self-update.
+   */
+  localApiPort: z.number().int().min(1).max(65_535).nullable().default(null),
   // Accept any version at the schema boundary so the server can return an
   // actionable protocol mismatch instead of an opaque validation failure.
   protocolVersion: z.number().int().positive(),
   activeThreads: z.array(hostDaemonActiveThreadSchema),
   loadedEnvironments: z.array(hostDaemonLoadedEnvironmentSchema).default([]),
 });
-export type HostDaemonSessionOpenRequest = z.input<
+// Current daemon code must send every server-defaulted field explicitly. The
+// schema's wider input remains a compatibility boundary for older daemons.
+export type HostDaemonSessionOpenRequest = z.output<
   typeof hostDaemonSessionOpenRequestSchema
 >;
 

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1138,7 +1138,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(142);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(143);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 


### PR DESCRIPTION
## What was wrong

Session-open validation required the newer `localApiPort` field before comparing daemon and server protocol versions. Daemons from before that field existed therefore received `400 invalid_request: Required` instead of `protocol_version_mismatch`; because the daemon only invokes its protocol self-updater for the latter response, an enrolled older daemon could retry forever while the server reported it offline.

## What changed

- Default a missing `localApiPort` to `null` at the server boundary so pre-field session payloads reach the protocol-version check.
- Keep the current daemon-side request type explicit by exporting the schema's parsed output type.
- Add a regression request frozen to the pre-`localApiPort` wire shape, which protects future required session fields from bypassing the mismatch response.
- Bump `HOST_DAEMON_PROTOCOL_VERSION` from 142 to 143 for the wire-boundary behavior change.

## How you verified

The new server regression reproduces the old daemon payload without `localApiPort` and now receives `protocol_version_mismatch`; before the fix, the live equivalent received `invalid_request: Required`.

- `pnpm exec turbo run test --filter=@bb/host-daemon-contract --force -- --run test/contract.test.ts`
- `pnpm exec turbo run test --filter=@bb/server --force -- --run test/internal/internal-session-protocol-version.test.ts`
- `pnpm exec turbo run test --filter=@bb/host-daemon --force -- --run src/server-client.test.ts src/protocol-self-update.test.ts`
- `pnpm exec turbo run test --filter=@bb/scripts --force -- --run test/request-dev-restart.test.ts`
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon-contract --filter=@bb/host-daemon --filter=@bb/server`
- `pnpm exec prettier --check packages/host-daemon-contract/src/session.ts packages/host-daemon-contract/src/protocol.ts packages/host-daemon-contract/test/contract.test.ts apps/server/test/internal/internal-session-protocol-version.test.ts`
- `git diff --check`

Fixes: N/A (no linked issue).

> AGENT GENERATED: by GPT-5
