### PR TITLE
Match mobile unread divider to web styling

### DIFF
--- a/apps/mobile/src/screens/thread/timeline/TimelineList.tsx
+++ b/apps/mobile/src/screens/thread/timeline/TimelineList.tsx
@@ -90,11 +90,14 @@ function UnreadDividerRow() {
       className="flex-row items-center gap-2 px-4 py-1"
       testID="timeline-unread-divider"
     >
-      <View className="h-px flex-1 bg-attention" />
-      <Text variant="chrome" className="text-attention">
+      <Text
+        variant="chrome"
+        weight="medium"
+        className="uppercase tracking-wider text-timeline-accent"
+      >
         New
       </Text>
-      <View className="h-px flex-1 bg-attention" />
+      <View className="h-px flex-1 bg-timeline-accent" />
     </View>
   );
 }


### PR DESCRIPTION
## What was wrong

The iOS unread divider used the `attention` token (yellow), a centered label, and two rules. The web app uses `timeline-accent` (blue), a left label, and one rule. The two apps did not match.

## What changed

`apps/mobile/src/screens/thread/timeline/TimelineList.tsx`: the divider now uses `text-timeline-accent` / `bg-timeline-accent`, an uppercase medium-weight "New" label on the left, and one rule on the right. This matches `UnreadDivider` in `apps/app/src/components/thread/timeline/ThreadTimelineRows.tsx`.

## How you verified

`pnpm exec turbo run typecheck --filter=@bb/mobile` passes. Visual change only; no new tests.

> AGENT GENERATED: by Claude Opus 5