### PR TITLE
Port the web sound-wave recording bar to the mobile composer

### DIFF
--- a/apps/mobile/app/dev/ui.tsx
+++ b/apps/mobile/app/dev/ui.tsx
@@ -2,10 +2,11 @@
 // can be eyeballed per palette × mode on the simulator. Not product UI.
 import { BUILTIN_THEME_IDS } from "@bb/domain";
 import { Redirect } from "expo-router";
-import { useState, type ReactNode } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import { ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { e2eModeEnabled } from "@/app-shell";
+import { VoiceBar, type VoiceBarController } from "@/composer";
 import { useTheme } from "@/theme/ThemeProvider";
 import type { ThemeModePreference } from "@/theme/theme-preference";
 import {
@@ -41,12 +42,37 @@ function Section({ title, children }: { title: string; children: ReactNode }) {
 
 const MODES: ThemeModePreference[] = ["system", "light", "dark"];
 
+/**
+ * Speech-like synthetic input levels for the voice bar showcase: a slow
+ * syllable envelope with jitter, so the waveform scrolls without a mic.
+ */
+function syntheticVoiceLevel(): number {
+  const t = Date.now() / 1000;
+  const syllable =
+    Math.max(0, Math.sin(t * 5.3)) * (0.6 + 0.4 * Math.sin(t * 0.7));
+  const pause = Math.sin(t * 0.45) > 0.75 ? 0 : 1;
+  const jitter = 0.75 + Math.random() * 0.25;
+  return Math.min(1, 0.06 + syllable * jitter * pause);
+}
+
 function UiGalleryScreen() {
   const insets = useSafeAreaInsets();
   const theme = useTheme();
   const [checked, setChecked] = useState(true);
   const [text, setText] = useState("");
   const [pressed, setPressed] = useState(false);
+  const [voiceState, setVoiceState] = useState<"recording" | "transcribing">(
+    "recording",
+  );
+  const voice = useMemo(
+    (): VoiceBarController => ({
+      state: voiceState,
+      readLevel: syntheticVoiceLevel,
+      stop: async () => setVoiceState("transcribing"),
+      cancel: () => setVoiceState("recording"),
+    }),
+    [voiceState],
+  );
   const sheet = useSheet();
   const scrollSheet = useSheet();
   const menu = useSheet();
@@ -275,6 +301,18 @@ function UiGalleryScreen() {
         </View>
         <Text variant="caption">
           Long-press the first row for an ActionSheet.
+        </Text>
+      </Section>
+
+      <Section title="Voice bar (synthetic levels)">
+        <View
+          className="rounded-2xl border border-border bg-card"
+          testID="dev-ui-voice-bar"
+        >
+          <VoiceBar voice={voice} />
+        </View>
+        <Text variant="caption">
+          Check → transcribing (frozen, breathing); X → back to recording.
         </Text>
       </Section>
 

--- a/apps/mobile/src/composer/VoiceBar.tsx
+++ b/apps/mobile/src/composer/VoiceBar.tsx
@@ -1,63 +1,83 @@
+import { useEffect } from "react";
 import { View } from "react-native";
-import { useTheme } from "@/theme";
-import { Button, Spinner, Text } from "@/ui";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from "react-native-reanimated";
+import { Button } from "@/ui";
 import type { ComposerVoiceController } from "./useComposerVoice";
+import { VoiceWaveform } from "./VoiceWaveform";
 
-function formatElapsed(seconds: number): string {
-  const minutes = Math.floor(seconds / 60);
-  const rest = seconds % 60;
-  return `${minutes}:${rest.toString().padStart(2, "0")}`;
-}
+export type VoiceBarController = Pick<
+  ComposerVoiceController,
+  "state" | "readLevel" | "stop" | "cancel"
+>;
 
-/** Replaces the footer while recording / transcribing (web `VoiceRecordingBar`). */
-export function VoiceBar({ voice }: { voice: ComposerVoiceController }) {
-  const { tokens } = useTheme();
-  const recording = voice.state === "recording";
+/**
+ * Replaces the footer while recording / transcribing (web `VoiceRecordingBar`):
+ * cancel · the live sound-wave bars · confirm. While transcribing the bars
+ * freeze and breathe (the web `animate-shine-icon`) and the confirm button
+ * shows a spinner.
+ */
+export function VoiceBar({ voice }: { voice: VoiceBarController }) {
+  const transcribing = voice.state === "transcribing";
+  const opacity = useSharedValue(1);
+  useEffect(() => {
+    if (!transcribing) {
+      opacity.set(withTiming(1, { duration: 150 }));
+      return;
+    }
+    opacity.set(
+      withRepeat(
+        withSequence(
+          withTiming(0.35, { duration: 700 }),
+          withTiming(1, { duration: 700 }),
+        ),
+        -1,
+      ),
+    );
+  }, [opacity, transcribing]);
+  const breathe = useAnimatedStyle(() => ({ opacity: opacity.get() }));
+
   return (
     <View
-      className="flex-row items-center gap-3 px-2 py-1"
+      className="flex-row items-center gap-2 px-2 py-1"
+      accessibilityLiveRegion="polite"
+      accessibilityLabel={transcribing ? "Transcribing" : "Recording"}
       testID="composer-voice-bar"
     >
       <Button
         variant="ghost"
         size="icon"
         icon="X"
-        accessibilityLabel="Cancel voice input"
+        className="rounded-full"
+        accessibilityLabel={
+          transcribing ? "Cancel transcription" : "Cancel recording"
+        }
         onPress={voice.cancel}
         testID="composer-voice-cancel"
       />
-      <View className="flex-1 flex-row items-center gap-2">
-        {recording ? (
-          <View
-            style={{
-              width: 10,
-              height: 10,
-              borderRadius: 5,
-              backgroundColor: tokens.destructive,
-            }}
-          />
-        ) : (
-          <Spinner />
-        )}
-        <Text variant="label">
-          {recording ? "Listening…" : "Transcribing…"}
-        </Text>
-        {recording ? (
-          <Text variant="caption" mono>
-            {formatElapsed(voice.elapsedSeconds)}
-          </Text>
-        ) : null}
-      </View>
-      {recording ? (
-        <Button
-          size="icon"
-          icon="Check"
-          accessibilityLabel="Stop and transcribe"
-          haptic
-          onPress={() => void voice.stop()}
-          testID="composer-voice-stop"
-        />
-      ) : null}
+      <Animated.View
+        style={[{ flex: 1, minWidth: 0, height: 28 }, breathe]}
+        testID="composer-voice-waveform"
+      >
+        <VoiceWaveform readLevel={voice.readLevel} active={!transcribing} />
+      </Animated.View>
+      <Button
+        size="icon"
+        icon="Check"
+        className="rounded-full"
+        accessibilityLabel={
+          transcribing ? "Transcribing voice input" : "Stop and transcribe"
+        }
+        loading={transcribing}
+        haptic
+        onPress={() => void voice.stop()}
+        testID="composer-voice-stop"
+      />
     </View>
   );
 }

--- a/apps/mobile/src/composer/VoiceWaveform.tsx
+++ b/apps/mobile/src/composer/VoiceWaveform.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  View,
+  type LayoutChangeEvent,
+  type StyleProp,
+  type ViewStyle,
+} from "react-native";
+import { useReducedMotion } from "react-native-reanimated";
+import Svg, { Defs, LinearGradient, Path, Stop } from "react-native-svg";
+import { useTheme } from "@/theme";
+import {
+  buildWaveformPath,
+  idleWaveformBars,
+  pushWaveformBar,
+  trimWaveformBars,
+  WAVEFORM_BAR_WIDTH,
+  WAVEFORM_EDGE_FADE_FRACTION,
+  WAVEFORM_SAMPLE_INTERVAL_MS,
+  waveformBarCount,
+} from "./voice-waveform-model";
+
+export interface VoiceWaveformProps {
+  /**
+   * Reads the current input level as a bar amplitude in `0..1` (see
+   * `meteringToAmplitude`). Called ~30× per second while `active`.
+   */
+  readLevel: () => number;
+  /** Sample and scroll while true; freeze the last bars while false. */
+  active: boolean;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+/**
+ * The scrolling sound-wave bars from the web `WaveformVisualizer`: one bar per
+ * sample, newest at the right edge, older bars fading out on the left. Drawn
+ * as one SVG path so a frame is a single prop update. With reduce-motion on
+ * (or before any sample) it shows the flat idle bars.
+ */
+export function VoiceWaveform({
+  readLevel,
+  active,
+  style,
+  testID,
+}: VoiceWaveformProps) {
+  const { tokens } = useTheme();
+  const reduceMotion = useReducedMotion();
+  const [size, setSize] = useState({ width: 0, height: 0 });
+  const barsRef = useRef<number[]>([]);
+  const [path, setPath] = useState("");
+  const readLevelRef = useRef(readLevel);
+  useEffect(() => {
+    readLevelRef.current = readLevel;
+  }, [readLevel]);
+
+  const { width, height } = size;
+  const barCount = waveformBarCount(width);
+  const animate = active && !reduceMotion && width > 0;
+
+  useEffect(() => {
+    if (width <= 0) return;
+    if (barsRef.current.length === 0) {
+      barsRef.current = idleWaveformBars(barCount);
+    } else {
+      barsRef.current = trimWaveformBars(barsRef.current, barCount);
+    }
+    setPath(buildWaveformPath(barsRef.current, width, height));
+    if (!animate) return;
+    const timer = setInterval(() => {
+      const amplitude = readLevelRef.current();
+      barsRef.current = pushWaveformBar(barsRef.current, amplitude, barCount);
+      setPath(buildWaveformPath(barsRef.current, width, height));
+    }, WAVEFORM_SAMPLE_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [animate, barCount, height, width]);
+
+  const onLayout = (event: LayoutChangeEvent) => {
+    const next = event.nativeEvent.layout;
+    setSize((prev) =>
+      prev.width === next.width && prev.height === next.height
+        ? prev
+        : { width: next.width, height: next.height },
+    );
+  };
+
+  return (
+    <View
+      style={[{ flex: 1, alignSelf: "stretch" }, style]}
+      onLayout={onLayout}
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+      testID={testID}
+    >
+      {width > 0 && height > 0 ? (
+        <Svg width={width} height={height} pointerEvents="none">
+          <Defs>
+            <LinearGradient
+              id="bb-voice-waveform-fade"
+              x1="0"
+              y1="0"
+              x2={String(width * WAVEFORM_EDGE_FADE_FRACTION)}
+              y2="0"
+              gradientUnits="userSpaceOnUse"
+            >
+              <Stop
+                offset="0"
+                stopColor={tokens.foreground}
+                stopOpacity={0.15}
+              />
+              <Stop offset="1" stopColor={tokens.foreground} stopOpacity={1} />
+            </LinearGradient>
+          </Defs>
+          <Path
+            d={path}
+            stroke="url(#bb-voice-waveform-fade)"
+            strokeWidth={WAVEFORM_BAR_WIDTH}
+            strokeLinecap="round"
+            fill="none"
+          />
+        </Svg>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/composer/index.ts
+++ b/apps/mobile/src/composer/index.ts
@@ -30,5 +30,8 @@ export {
   type ComposerVoiceController,
   type UseComposerVoiceArgs,
 } from "./useComposerVoice";
+export { VoiceBar, type VoiceBarController } from "./VoiceBar";
+export { VoiceWaveform, type VoiceWaveformProps } from "./VoiceWaveform";
+export { meteringToAmplitude } from "./voice-waveform-model";
 export { useComposerDraft, type ComposerDraft } from "@/data/composer";
 export * from "./model";

--- a/apps/mobile/src/composer/useComposerVoice.ts
+++ b/apps/mobile/src/composer/useComposerVoice.ts
@@ -18,8 +18,14 @@ import {
   type VoiceInputState,
 } from "@/data/composer";
 import { toast } from "@/ui";
+import { meteringToAmplitude } from "./voice-waveform-model";
 
 const KEEP_AWAKE_TAG = "bb-composer-voice";
+/** The web preset plus metering so the recording bar can draw sound waves. */
+const RECORDING_OPTIONS = {
+  ...RecordingPresets.HIGH_QUALITY,
+  isMeteringEnabled: true,
+};
 
 export interface UseComposerVoiceArgs {
   /** `/system/config` `voiceTranscriptionEnabled`. */
@@ -32,8 +38,11 @@ export interface UseComposerVoiceArgs {
 export interface ComposerVoiceController {
   enabled: boolean;
   state: VoiceInputState;
-  /** Seconds recorded so far (for the recording bar). */
-  elapsedSeconds: number;
+  /**
+   * Current input level as a waveform bar amplitude in `0..1` (the recorder's
+   * metering; 0 outside a recording). Polled by `VoiceWaveform`.
+   */
+  readLevel: () => number;
   start: () => Promise<void>;
   stop: () => Promise<void>;
   cancel: () => void;
@@ -52,13 +61,11 @@ export function useComposerVoice({
   getPromptContext,
   onTranscript,
 }: UseComposerVoiceArgs): ComposerVoiceController {
-  const recorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);
+  const recorder = useAudioRecorder(RECORDING_OPTIONS);
   const transcription = useVoiceTranscription();
   const [state, setState] = useState<VoiceInputState>("idle");
-  const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const startedAtRef = useRef<number | null>(null);
   const abortRef = useRef<AbortController | null>(null);
-  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const stateRef = useRef<VoiceInputState>("idle");
   stateRef.current = state;
 
@@ -67,30 +74,26 @@ export function useComposerVoice({
     toast.error("Voice input failed", { description: message });
   }, []);
 
-  const stopTicking = useCallback(() => {
-    if (tickRef.current !== null) {
-      clearInterval(tickRef.current);
-      tickRef.current = null;
-    }
-  }, []);
+  const readLevel = useCallback(() => {
+    if (stateRef.current !== "recording") return 0;
+    return meteringToAmplitude(recorder.getStatus().metering);
+  }, [recorder]);
 
   const releaseRecording = useCallback(async () => {
-    stopTicking();
     deactivateKeepAwake(KEEP_AWAKE_TAG);
     try {
       await setAudioModeAsync({ allowsRecording: false });
     } catch {
       // Audio mode restore is best-effort.
     }
-  }, [stopTicking]);
+  }, []);
 
   useEffect(
     () => () => {
-      stopTicking();
       deactivateKeepAwake(KEEP_AWAKE_TAG);
       abortRef.current?.abort();
     },
-    [stopTicking],
+    [],
   );
 
   const start = useCallback(async () => {
@@ -117,13 +120,6 @@ export function useComposerVoice({
       await recorder.prepareToRecordAsync();
       recorder.record();
       startedAtRef.current = Date.now();
-      setElapsedSeconds(0);
-      tickRef.current = setInterval(() => {
-        const startedAt = startedAtRef.current;
-        if (startedAt !== null) {
-          setElapsedSeconds(Math.floor((Date.now() - startedAt) / 1000));
-        }
-      }, 500);
       await activateKeepAwakeAsync(KEEP_AWAKE_TAG).catch(() => undefined);
       setState("recording");
     } catch (error) {
@@ -209,5 +205,5 @@ export function useComposerVoice({
     if (stateRef.current === "error") setState("idle");
   }, [recorder, releaseRecording]);
 
-  return { enabled, state, elapsedSeconds, start, stop, cancel };
+  return { enabled, state, readLevel, start, stop, cancel };
 }

--- a/apps/mobile/src/composer/voice-waveform-model.test.ts
+++ b/apps/mobile/src/composer/voice-waveform-model.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildWaveformPath,
+  idleWaveformBars,
+  meteringToAmplitude,
+  pushWaveformBar,
+  trimWaveformBars,
+  WAVEFORM_BAR_PITCH,
+  waveformBarCount,
+} from "./voice-waveform-model";
+
+describe("meteringToAmplitude", () => {
+  it("maps silence, missing metering, and the -160 floor to 0", () => {
+    expect(meteringToAmplitude(undefined)).toBe(0);
+    expect(meteringToAmplitude(null)).toBe(0);
+    expect(meteringToAmplitude(-160)).toBe(0);
+    expect(meteringToAmplitude(Number.NEGATIVE_INFINITY)).toBe(0);
+    expect(meteringToAmplitude(Number.NaN)).toBe(0);
+  });
+
+  it("keeps room noise below the floor and clamps loud input to 1", () => {
+    // -50 dBFS ≈ 0.003 linear: under the web noise floor (0.006).
+    expect(meteringToAmplitude(-50)).toBe(0);
+    expect(meteringToAmplitude(0)).toBe(1);
+    expect(meteringToAmplitude(5)).toBe(1);
+  });
+
+  it("is monotonic through the speaking range", () => {
+    const quiet = meteringToAmplitude(-40);
+    const normal = meteringToAmplitude(-25);
+    const loud = meteringToAmplitude(-10);
+    expect(quiet).toBeGreaterThan(0);
+    expect(normal).toBeGreaterThan(quiet);
+    expect(loud).toBeGreaterThan(normal);
+    expect(loud).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("waveform bar buffer", () => {
+  it("fits one bar per pitch and at least one bar", () => {
+    expect(waveformBarCount(0)).toBe(1);
+    expect(waveformBarCount(WAVEFORM_BAR_PITCH * 10 + 3)).toBe(10);
+  });
+
+  it("scrolls: the newest sample is last and old bars fall off the front", () => {
+    let bars = idleWaveformBars(3);
+    bars = pushWaveformBar(bars, 0.5, 3);
+    bars = pushWaveformBar(bars, 0.9, 3);
+    expect(bars).toEqual([0.06, 0.5, 0.9]);
+    bars = pushWaveformBar(bars, 0.2, 3);
+    expect(bars).toEqual([0.5, 0.9, 0.2]);
+  });
+
+  it("keeps the newest bars when the view shrinks", () => {
+    expect(trimWaveformBars([1, 2, 3, 4], 2)).toEqual([3, 4]);
+    expect(trimWaveformBars([1, 2], 4)).toEqual([1, 2]);
+  });
+});
+
+describe("buildWaveformPath", () => {
+  it("draws the newest bar at the right edge, centered vertically", () => {
+    // height 28 → maxHalf = (26.6 - 3) / 2 = 11.8; amplitude 1 → 2.2..25.8.
+    expect(buildWaveformPath([0.5, 1], 100, 28)).toBe(
+      "M98.5 2.2L98.5 25.8M93.5 8.1L93.5 19.9",
+    );
+  });
+
+  it("skips bars that fall off the left edge", () => {
+    const bars = Array.from({ length: 50 }, () => 1);
+    const path = buildWaveformPath(bars, 20, 28);
+    // 20px wide → bars at x 18.5, 13.5, 8.5, 3.5, -1.5 (still partly
+    // visible); the 6th (-6.5) is fully off the edge and cut.
+    expect(path.match(/M/g)?.length).toBe(5);
+  });
+});

--- a/apps/mobile/src/composer/voice-waveform-model.ts
+++ b/apps/mobile/src/composer/voice-waveform-model.ts
@@ -1,0 +1,96 @@
+// Pure model for the recording waveform (port of the web
+// `WaveformVisualizer` math): metering dB → bar amplitude, the scrolling bar
+// buffer, and the SVG path for one frame. No react-native imports (vitest).
+
+export const WAVEFORM_BAR_WIDTH = 3;
+export const WAVEFORM_BAR_GAP = 2;
+export const WAVEFORM_BAR_PITCH = WAVEFORM_BAR_WIDTH + WAVEFORM_BAR_GAP;
+/** Web samples every second animation frame (~30 Hz). */
+export const WAVEFORM_SAMPLE_INTERVAL_MS = 33;
+/** Fraction of the width over which the oldest bars fade out. */
+export const WAVEFORM_EDGE_FADE_FRACTION = 0.15;
+
+const NOISE_FLOOR = 0.006;
+const AMPLITUDE_GAIN = 8;
+const AMPLITUDE_GAMMA = 0.6;
+const IDLE_AMPLITUDE = 0.06;
+/** Below this the recorder reports silence (iOS floor is -160 dBFS). */
+const SILENCE_DB = -160;
+
+/**
+ * expo-audio metering (average power in dBFS, `-160..0`) → the bar amplitude
+ * in `0..1`. The dB value is converted back to a linear RMS, then boosted and
+ * gamma-compressed exactly like the web's time-domain RMS so a speaking voice
+ * fills most of the bar and room noise stays at the floor.
+ */
+export function meteringToAmplitude(
+  meteringDb: number | null | undefined,
+): number {
+  if (meteringDb === null || meteringDb === undefined) return 0;
+  if (!Number.isFinite(meteringDb) || meteringDb <= SILENCE_DB) return 0;
+  const rms = 10 ** (Math.min(0, meteringDb) / 20);
+  const boosted = Math.max(0, rms - NOISE_FLOOR) * AMPLITUDE_GAIN;
+  return Math.min(1, boosted ** AMPLITUDE_GAMMA);
+}
+
+/** How many bars fit in `width` (at least one). */
+export function waveformBarCount(width: number): number {
+  return Math.max(1, Math.floor(width / WAVEFORM_BAR_PITCH));
+}
+
+/** The resting waveform: every bar at the idle amplitude. */
+export function idleWaveformBars(barCount: number): number[] {
+  return Array.from({ length: barCount }, () => IDLE_AMPLITUDE);
+}
+
+/**
+ * Appends one sample; the newest bar sits at the right edge and the buffer
+ * never holds more than `barCount` bars. Returns a new array.
+ */
+export function pushWaveformBar(
+  bars: readonly number[],
+  amplitude: number,
+  barCount: number,
+): number[] {
+  const next = [...bars, amplitude];
+  return next.length > barCount ? next.slice(next.length - barCount) : next;
+}
+
+/** Drops the oldest bars when the view shrinks; keeps the newest ones. */
+export function trimWaveformBars(
+  bars: readonly number[],
+  barCount: number,
+): number[] {
+  return bars.length > barCount
+    ? bars.slice(bars.length - barCount)
+    : [...bars];
+}
+
+/**
+ * One SVG path (`M x y1 L x y2` per bar) for the bars, newest at the right
+ * edge. Each bar is centered vertically with a height of `amplitude × 95 %`
+ * of the box, minus the round caps. Bars that fall off the left edge are
+ * skipped.
+ */
+export function buildWaveformPath(
+  bars: readonly number[],
+  width: number,
+  height: number,
+): string {
+  const midY = height / 2;
+  const maxHalf = Math.max(0, (height * 0.95 - WAVEFORM_BAR_WIDTH) / 2);
+  const segments: string[] = [];
+  for (let i = 0; i < bars.length; i++) {
+    const amplitude = bars[bars.length - 1 - i] ?? 0;
+    const cx = width - WAVEFORM_BAR_WIDTH / 2 - i * WAVEFORM_BAR_PITCH;
+    if (cx + WAVEFORM_BAR_WIDTH < 0) break;
+    const half = amplitude * maxHalf;
+    const x = round(cx);
+    segments.push(`M${x} ${round(midY - half)}L${x} ${round(midY + half)}`);
+  }
+  return segments.join("");
+}
+
+function round(value: number): number {
+  return Math.round(value * 100) / 100;
+}


### PR DESCRIPTION
## What was wrong

The mobile composer's voice bar (`apps/mobile/src/composer/VoiceBar.tsx`) showed a red dot, a "Listening…" label, and an elapsed timer. It gave no live audio feedback and did not look like the web `VoiceRecordingBar`, which draws scrolling sound-wave bars from the microphone level.

## What changed

- `apps/mobile/src/composer/voice-waveform-model.ts` (new): pure port of the web `WaveformVisualizer` math. `meteringToAmplitude` converts expo-audio metering (dBFS) to a bar amplitude with the same noise floor, gain, and gamma as the web RMS path; plus the scrolling bar buffer and the SVG path builder.
- `apps/mobile/src/composer/VoiceWaveform.tsx` (new): draws the bars as one `react-native-svg` path (3px bars, 2px gaps, round caps, newest at the right, oldest fading on the left via a gradient stroke). Samples `readLevel()` at ~30 Hz while active, freezes when inactive, shows flat idle bars under reduce-motion.
- `apps/mobile/src/composer/VoiceBar.tsx`: web layout — round ghost cancel · waveform · round primary confirm. While transcribing the bars freeze and breathe (the `animate-shine-icon` stand-in) and the confirm button shows a spinner.
- `apps/mobile/src/composer/useComposerVoice.ts`: records with `isMeteringEnabled: true` and exposes `readLevel()`; the elapsed-seconds ticker is removed.
- `apps/mobile/app/dev/ui.tsx`: a "Voice bar (synthetic levels)" gallery section so the bar can be exercised without a mic.

No wire changes.

## How you verified

- New `voice-waveform-model.test.ts` (dB mapping floor/clamp/monotonic, scroll buffer, path geometry). `pnpm exec turbo run test typecheck lint --filter=@bb/mobile` pass.
- iOS Simulator (iPhone 17 Pro) through the dev client and the UI gallery: recording scrolls right→left with the left-edge fade; Check → transcribing freezes and breathes with a spinner; X → recording resumes. Checked dark and light.

Fixes #

> AGENT GENERATED: by Claude Opus 5