### PR TITLE
Allow archiving a thread after its environment row is pruned

### DIFF
--- a/apps/server/src/routes/threads/actions.ts
+++ b/apps/server/src/routes/threads/actions.ts
@@ -75,6 +75,7 @@ import {
 import {
   requireThreadCommandEnvironment,
   requireThreadHostCommandEnvironment,
+  resolveThreadHostCommandEnvironment,
 } from "../../services/threads/thread-command-environment.js";
 import {
   LIVE_DAEMON_COMMAND_TIMEOUT_MS,
@@ -462,13 +463,10 @@ export function registerThreadActionRoutes(app: Hono, deps: AppDeps): void {
 
   post(routes.stop, async (context) => {
     const thread = requirePublicThread(deps.db, context.req.param("id"));
-    const environment =
-      thread.environmentId === null
-        ? null
-        : requireThreadHostCommandEnvironment({
-            db: deps.db,
-            thread,
-          });
+    const environment = resolveThreadHostCommandEnvironment({
+      db: deps.db,
+      thread,
+    });
     await stopThreadForCurrentState(deps, thread, environment);
     return context.json({ ok: true });
   });
@@ -652,7 +650,7 @@ export function registerThreadActionRoutes(app: Hono, deps: AppDeps): void {
       environmentId: thread.environmentId,
       excludeThreadId: thread.id,
     });
-    const environment = requireThreadHostCommandEnvironment({
+    const environment = resolveThreadHostCommandEnvironment({
       db: deps.db,
       thread,
     });

--- a/apps/server/src/routes/threads/actions.ts
+++ b/apps/server/src/routes/threads/actions.ts
@@ -71,6 +71,7 @@ import {
 import {
   archiveThreadAndChildren,
   archiveThreadAndHiddenSourceForks,
+  resolveArchiveThreadEnvironment,
 } from "../../services/threads/thread-archive.js";
 import {
   requireThreadCommandEnvironment,
@@ -650,10 +651,7 @@ export function registerThreadActionRoutes(app: Hono, deps: AppDeps): void {
       environmentId: thread.environmentId,
       excludeThreadId: thread.id,
     });
-    const environment = resolveThreadHostCommandEnvironment({
-      db: deps.db,
-      thread,
-    });
+    const environment = resolveArchiveThreadEnvironment(deps, { thread });
     const archiveResult = archiveThreadAndHiddenSourceForks(deps, {
       environment,
       thread,

--- a/apps/server/src/services/threads/thread-archive.ts
+++ b/apps/server/src/services/threads/thread-archive.ts
@@ -6,6 +6,10 @@ import {
 import type { Environment, Thread } from "@bb/domain";
 import type { AppDeps } from "../../types.js";
 import {
+  threadEnvironmentUnavailableDetails,
+  throwThreadEnvironmentUnavailable,
+} from "../lib/lifecycle-api-errors.js";
+import {
   requestEnvironmentCleanup,
   requestEnvironmentCleanupAdvance,
   wouldCleanupEnvironment,
@@ -20,14 +24,22 @@ import {
   requestActiveRuntimeThreadStopIfNeeded,
 } from "./thread-lifecycle.js";
 import { archiveThreadAndReleaseChildren } from "./thread-ownership.js";
-import { resolveThreadHostCommandEnvironment } from "./thread-command-environment.js";
+import { requireThreadHostCommandEnvironment } from "./thread-command-environment.js";
+import { getActiveThreadProvisionContext } from "./thread-provisioning-active-context.js";
+import { isPreStartThreadStatus } from "./thread-status.js";
+
+interface ArchiveThreadEnvironment {
+  hostId: string;
+  id: string;
+}
 
 interface ArchiveThreadWithLifecycleEffectsArgs {
-  environment: {
-    hostId: string;
-    id: string;
-  } | null;
+  environment: ArchiveThreadEnvironment | null;
   thread: Pick<Thread, "environmentId" | "id" | "status">;
+}
+
+interface ResolveArchiveThreadEnvironmentArgs {
+  thread: ArchiveThreadWithLifecycleEffectsArgs["thread"];
 }
 
 interface ArchiveEnvironmentThreadsArgs {
@@ -36,6 +48,37 @@ interface ArchiveEnvironmentThreadsArgs {
 
 interface ArchiveThreadAndChildrenArgs {
   parentThread: Thread;
+}
+
+/**
+ * Resolve the environment archive needs to stop the thread's live work, or
+ * null when there is nothing to stop. A thread loses its environment pointer
+ * when the environment row is pruned (threads.environment_id is ON DELETE SET
+ * NULL); that thread is settled and archivable without an environment. A
+ * pointer-less thread whose setup is still in flight (its environment row does
+ * not exist yet) keeps the refusal: archive does not cancel setup, so admitting
+ * it would let setup create an environment for an archived thread.
+ */
+export function resolveArchiveThreadEnvironment(
+  deps: Pick<AppDeps, "db">,
+  args: ResolveArchiveThreadEnvironmentArgs,
+): ArchiveThreadEnvironment | null {
+  if (args.thread.environmentId !== null) {
+    return requireThreadHostCommandEnvironment({
+      db: deps.db,
+      thread: args.thread,
+    });
+  }
+  if (
+    isPreStartThreadStatus(args.thread.status) ||
+    args.thread.status === "stopping" ||
+    getActiveThreadProvisionContext(args.thread.id) !== null
+  ) {
+    throwThreadEnvironmentUnavailable(
+      threadEnvironmentUnavailableDetails("never_attached", null),
+    );
+  }
+  return null;
 }
 
 export function archiveThreadWithLifecycleEffects(
@@ -93,10 +136,7 @@ export function archiveThreadAndHiddenSourceForks(
     sourceThreadId: archivedThread.id,
   })) {
     archiveThreadWithLifecycleEffects(deps, {
-      environment: resolveThreadHostCommandEnvironment({
-        db: deps.db,
-        thread: fork,
-      }),
+      environment: resolveArchiveThreadEnvironment(deps, { thread: fork }),
       thread: fork,
     });
   }
@@ -163,10 +203,7 @@ export function archiveThreadAndChildren(
   const affectedEnvironmentIds = new Set<string>();
 
   for (const thread of threads) {
-    const environment = resolveThreadHostCommandEnvironment({
-      db: deps.db,
-      thread,
-    });
+    const environment = resolveArchiveThreadEnvironment(deps, { thread });
     const result = archiveThreadWithLifecycleEffects(deps, {
       environment,
       thread,

--- a/apps/server/src/services/threads/thread-archive.ts
+++ b/apps/server/src/services/threads/thread-archive.ts
@@ -20,13 +20,13 @@ import {
   requestActiveRuntimeThreadStopIfNeeded,
 } from "./thread-lifecycle.js";
 import { archiveThreadAndReleaseChildren } from "./thread-ownership.js";
-import { requireThreadHostCommandEnvironment } from "./thread-command-environment.js";
+import { resolveThreadHostCommandEnvironment } from "./thread-command-environment.js";
 
 interface ArchiveThreadWithLifecycleEffectsArgs {
   environment: {
     hostId: string;
     id: string;
-  };
+  } | null;
   thread: Pick<Thread, "environmentId" | "id" | "status">;
 }
 
@@ -53,12 +53,15 @@ export function archiveThreadWithLifecycleEffects(
     threadId: archivedThread.id,
   });
   // Archive only stops active runtime work; manual stop is the pre-start
-  // provisioning cancellation entrypoint.
-  requestActiveRuntimeThreadStopIfNeeded(
-    deps,
-    archivedThread,
-    args.environment,
-  );
+  // provisioning cancellation entrypoint. A thread whose environment row was
+  // pruned has no runtime left to stop.
+  if (args.environment !== null) {
+    requestActiveRuntimeThreadStopIfNeeded(
+      deps,
+      archivedThread,
+      args.environment,
+    );
+  }
   dispatchSettledArchivedThreadProviderArchiveCommand(deps, {
     threadId: archivedThread.id,
   });
@@ -90,7 +93,7 @@ export function archiveThreadAndHiddenSourceForks(
     sourceThreadId: archivedThread.id,
   })) {
     archiveThreadWithLifecycleEffects(deps, {
-      environment: requireThreadHostCommandEnvironment({
+      environment: resolveThreadHostCommandEnvironment({
         db: deps.db,
         thread: fork,
       }),
@@ -160,7 +163,7 @@ export function archiveThreadAndChildren(
   const affectedEnvironmentIds = new Set<string>();
 
   for (const thread of threads) {
-    const environment = requireThreadHostCommandEnvironment({
+    const environment = resolveThreadHostCommandEnvironment({
       db: deps.db,
       thread,
     });
@@ -172,7 +175,9 @@ export function archiveThreadAndChildren(
       continue;
     }
     archivedThreadIds.push(result.id);
-    affectedEnvironmentIds.add(environment.id);
+    if (environment !== null) {
+      affectedEnvironmentIds.add(environment.id);
+    }
   }
 
   for (const environmentId of affectedEnvironmentIds) {

--- a/apps/server/src/services/threads/thread-command-environment.ts
+++ b/apps/server/src/services/threads/thread-command-environment.ts
@@ -27,8 +27,8 @@ interface ThreadHostCommandEnvironment {
 /**
  * Resolve the host command environment for a thread, or null when the thread
  * has no environment pointer. A thread loses its pointer when its environment
- * row is pruned (threads.environment_id is ON DELETE SET NULL), so callers
- * that only need the environment to stop live runtime work must tolerate null.
+ * row is pruned (threads.environment_id is ON DELETE SET NULL). Callers decide
+ * what a missing pointer means for their command.
  */
 export function resolveThreadHostCommandEnvironment(
   args: RequireThreadHostCommandEnvironmentArgs,
@@ -46,12 +46,9 @@ export function resolveThreadHostCommandEnvironment(
 export function requireThreadHostCommandEnvironment(
   args: RequireThreadHostCommandEnvironmentArgs,
 ): ThreadHostCommandEnvironment {
-  if (args.thread.environmentId !== null) {
-    const environment = requireEnvironment(args.db, args.thread.environmentId);
-    return {
-      id: environment.id,
-      hostId: environment.hostId,
-    };
+  const environment = resolveThreadHostCommandEnvironment(args);
+  if (environment !== null) {
+    return environment;
   }
 
   throwThreadEnvironmentUnavailable(

--- a/apps/server/src/services/threads/thread-command-environment.ts
+++ b/apps/server/src/services/threads/thread-command-environment.ts
@@ -24,6 +24,25 @@ interface ThreadHostCommandEnvironment {
   id: string;
 }
 
+/**
+ * Resolve the host command environment for a thread, or null when the thread
+ * has no environment pointer. A thread loses its pointer when its environment
+ * row is pruned (threads.environment_id is ON DELETE SET NULL), so callers
+ * that only need the environment to stop live runtime work must tolerate null.
+ */
+export function resolveThreadHostCommandEnvironment(
+  args: RequireThreadHostCommandEnvironmentArgs,
+): ThreadHostCommandEnvironment | null {
+  if (args.thread.environmentId === null) {
+    return null;
+  }
+  const environment = requireEnvironment(args.db, args.thread.environmentId);
+  return {
+    id: environment.id,
+    hostId: environment.hostId,
+  };
+}
+
 export function requireThreadHostCommandEnvironment(
   args: RequireThreadHostCommandEnvironmentArgs,
 ): ThreadHostCommandEnvironment {

--- a/apps/server/test/threads/archive-pruned-environment.test.ts
+++ b/apps/server/test/threads/archive-pruned-environment.test.ts
@@ -1,7 +1,13 @@
 // Regression for get-bb/bb#1924: archiving a thread must succeed after
 // pruneDestroyedEnvironments removed its environment row. threads.environment_id
 // is ON DELETE SET NULL, so the live thread keeps no environment pointer.
+//
+// A pointer-less thread whose setup is still in flight is different: its
+// environment row does not exist yet. Archive keeps refusing that state so setup
+// cannot create an environment for an archived thread.
 import { environments, getThread, pruneDestroyedEnvironments } from "@bb/db";
+import type { ThreadStatus } from "@bb/domain";
+import { apiErrorSchema } from "@bb/server-contract";
 import { eq } from "drizzle-orm";
 import { describe, expect, it } from "vitest";
 import { readJson } from "../helpers/json.js";
@@ -11,7 +17,7 @@ import {
   seedProjectWithSource,
   seedThread,
 } from "../helpers/seed.js";
-import { withTestHarness } from "../helpers/test-app.js";
+import { withTestHarness, type TestAppHarness } from "../helpers/test-app.js";
 
 const EIGHT_DAYS_MS = 8 * 24 * 60 * 60_000;
 
@@ -46,6 +52,32 @@ function seedThreadWithPrunedEnvironment(
   return { thread };
 }
 
+function seedPointerlessThread(
+  deps: Parameters<typeof seedThread>[0],
+  status: ThreadStatus,
+) {
+  const { host } = seedHostSession(deps);
+  const { project } = seedProjectWithSource(deps, { hostId: host.id });
+  return seedThread(deps, { projectId: project.id, status });
+}
+
+async function expectArchiveRefused(
+  harness: TestAppHarness,
+  threadId: string,
+  route: "archive" | "archive-all",
+): Promise<void> {
+  const response = await harness.app.request(
+    `/api/v1/threads/${threadId}/${route}`,
+    { method: "POST" },
+  );
+  expect(response.status).toBe(409);
+  expect(apiErrorSchema.parse(await readJson(response))).toMatchObject({
+    code: "thread_environment_unavailable",
+    details: { reason: "never_attached" },
+  });
+  expect(getThread(harness.deps.db, threadId)?.archivedAt).toBeNull();
+}
+
 describe("archive after environment prune", () => {
   it("POST /threads/:id/archive succeeds for a thread whose environment was pruned", async () => {
     await withTestHarness(async (harness) => {
@@ -75,4 +107,15 @@ describe("archive after environment prune", () => {
       expect(getThread(harness.deps.db, thread.id)?.archivedAt).not.toBeNull();
     });
   });
+
+  it.each<ThreadStatus>(["starting", "stopping"])(
+    "keeps refusing archive for a %s thread that has no environment yet",
+    async (status) => {
+      await withTestHarness(async (harness) => {
+        const thread = seedPointerlessThread(harness.deps, status);
+        await expectArchiveRefused(harness, thread.id, "archive");
+        await expectArchiveRefused(harness, thread.id, "archive-all");
+      });
+    },
+  );
 });

--- a/apps/server/test/threads/archive-pruned-environment.test.ts
+++ b/apps/server/test/threads/archive-pruned-environment.test.ts
@@ -1,0 +1,78 @@
+// Regression for get-bb/bb#1924: archiving a thread must succeed after
+// pruneDestroyedEnvironments removed its environment row. threads.environment_id
+// is ON DELETE SET NULL, so the live thread keeps no environment pointer.
+import { environments, getThread, pruneDestroyedEnvironments } from "@bb/db";
+import { eq } from "drizzle-orm";
+import { describe, expect, it } from "vitest";
+import { readJson } from "../helpers/json.js";
+import {
+  seedEnvironment,
+  seedHostSession,
+  seedProjectWithSource,
+  seedThread,
+} from "../helpers/seed.js";
+import { withTestHarness } from "../helpers/test-app.js";
+
+const EIGHT_DAYS_MS = 8 * 24 * 60 * 60_000;
+
+function seedThreadWithPrunedEnvironment(
+  deps: Parameters<typeof seedThread>[0],
+) {
+  const { host } = seedHostSession(deps);
+  const { project } = seedProjectWithSource(deps, { hostId: host.id });
+  const environment = seedEnvironment(deps, {
+    hostId: host.id,
+    projectId: project.id,
+    managed: true,
+    workspaceProvisionType: "managed-worktree",
+  });
+  const thread = seedThread(deps, {
+    environmentId: environment.id,
+    projectId: project.id,
+    status: "idle",
+  });
+  // The environment was destroyed while the thread stayed unarchived, and the
+  // 7-day prune TTL elapsed.
+  deps.db
+    .update(environments)
+    .set({ status: "destroyed", updatedAt: Date.now() - EIGHT_DAYS_MS })
+    .where(eq(environments.id, environment.id))
+    .run();
+  expect(pruneDestroyedEnvironments(deps.db, deps.hub).deleted).toBe(1);
+
+  const threadAfterPrune = getThread(deps.db, thread.id);
+  expect(threadAfterPrune?.environmentId).toBeNull();
+  expect(threadAfterPrune?.archivedAt).toBeNull();
+  return { thread };
+}
+
+describe("archive after environment prune", () => {
+  it("POST /threads/:id/archive succeeds for a thread whose environment was pruned", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedThreadWithPrunedEnvironment(harness.deps);
+      const response = await harness.app.request(
+        `/api/v1/threads/${thread.id}/archive`,
+        { method: "POST" },
+      );
+      expect(response.status).toBe(200);
+      expect(await readJson(response)).toEqual({ ok: true });
+      expect(getThread(harness.deps.db, thread.id)?.archivedAt).not.toBeNull();
+    });
+  });
+
+  it("POST /threads/:id/archive-all succeeds for a thread whose environment was pruned", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedThreadWithPrunedEnvironment(harness.deps);
+      const response = await harness.app.request(
+        `/api/v1/threads/${thread.id}/archive-all`,
+        { method: "POST" },
+      );
+      expect(response.status).toBe(200);
+      expect(await readJson(response)).toEqual({
+        ok: true,
+        archivedThreadIds: [thread.id],
+      });
+      expect(getThread(harness.deps.db, thread.id)?.archivedAt).not.toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## What was wrong

A thread can never be archived once its environment row is gone. `pruneDestroyedEnvironments` hard-deletes `destroyed` environment rows after 7 days with no live-thread guard. `threads.environment_id` is `ON DELETE SET NULL`, so a still-unarchived thread silently loses its pointer. `POST /threads/:id/archive` and `/archive-all` then call `requireThreadHostCommandEnvironment`, which throws `409 thread_environment_unavailable` (`never_attached`). The app shows "Workspace is not available yet." and the thread stays in the sidebar. Delete was the only way out.

The archive path only uses the environment for `requestActiveRuntimeThreadStopIfNeeded`, which is a no-op for an idle thread with no environment. The requirement is not load-bearing.

Report: https://get-bb.github.io/reports/issues/1924.html

## What changed

Server only. No wire shape change, so no `HOST_DAEMON_PROTOCOL_VERSION` bump.

- `thread-command-environment.ts`: add `resolveThreadHostCommandEnvironment`. It returns `null` for a `null` pointer and still throws for a dangling non-null id.
- `thread-archive.ts`: `ArchiveThreadWithLifecycleEffectsArgs.environment` is nullable. Skip the runtime stop when `null`. Hidden forks and `archiveThreadAndChildren` use the resolver; only non-null environments enter `affectedEnvironmentIds`.
- `routes/threads/actions.ts`: `routes.archive` uses the resolver. `routes.stop` uses the resolver in place of its inline null branch (same behavior).

Not changed: the prune sweep still removes rows that live threads point at. That is a separate behavior decision; this PR makes archive tolerate the state.

## How I verified

- New test `apps/server/test/threads/archive-pruned-environment.test.ts` seeds a thread, marks its environment destroyed 8 days ago, runs `pruneDestroyedEnvironments`, and archives via `/archive` and `/archive-all`. Both cases fail with 409 before this change and pass after.
- `pnpm exec turbo run test typecheck --filter=@bb/server`: typecheck clean; 1795/1796 tests pass. The one failure is `internal-skill-trees.test.ts` (file mode 420 vs 436, umask) and fails identically without this change.

Fixes #1924

> AGENT GENERATED: by Claude Opus 5
