### PR TITLE
Make machine settings text-first and responsive

### DIFF
--- a/apps/app/src/components/machines/MachineStatusDot.tsx
+++ b/apps/app/src/components/machines/MachineStatusDot.tsx
@@ -1,12 +1,4 @@
-import type { ReactNode } from "react";
-import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@bb/shared-ui/tooltip";
 
 /**
  * Connection-status dot for a machine (host): filled success dot when the
@@ -29,38 +21,5 @@ export function MachineStatusDot({
         className,
       )}
     />
-  );
-}
-
-/** Accessible connection state for surfaces where a dot alone is ambiguous. */
-export function MachineStatusIcon({
-  connected,
-  tooltip,
-  className,
-}: {
-  connected: boolean;
-  tooltip?: ReactNode;
-  className?: string;
-}) {
-  const label = connected ? "Online" : "Offline";
-  const icon = connected ? "Cloud" : "CloudOff";
-  return (
-    <TooltipProvider delayDuration={250}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            role="img"
-            aria-label={label}
-            className={cn(
-              "inline-flex size-5 shrink-0 items-center justify-center text-muted-foreground",
-              className,
-            )}
-          >
-            <Icon aria-hidden name={icon} className="size-4" />
-          </span>
-        </TooltipTrigger>
-        <TooltipContent>{tooltip ?? label}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
   );
 }

--- a/apps/app/src/components/settings/MachinesSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/MachinesSettingsSection.test.tsx
@@ -152,7 +152,7 @@ afterEach(() => {
 });
 
 describe("MachinesSettingsSection", () => {
-  it("renders machine status, project, and permission metadata as accessible icons", async () => {
+  it("renders machine status, project, and permission metadata as visible text", async () => {
     vi.mocked(sdk.system.config).mockResolvedValue(systemConfig());
     vi.mocked(sdk.hosts.list).mockResolvedValue([primaryHost, offlineHost]);
     stubSidebarBootstrapFetch();
@@ -163,27 +163,17 @@ describe("MachinesSettingsSection", () => {
     expect(screen.getByText("dev-vm")).toBeDefined();
     expect(screen.getByText("this machine")).toBeDefined();
     expect(screen.getByText("primary")).toBeDefined();
-    await waitFor(() => {
-      expect(screen.getByRole("img", { name: "Online" })).toBeDefined();
-    });
-    expect(
-      screen
-        .getByRole("img", { name: "Online" })
-        .querySelector('[data-icon="Cloud"]'),
-    ).not.toBeNull();
-    expect(
-      screen
-        .getByRole("img", { name: "Offline" })
-        .querySelector('[data-icon="CloudOff"]'),
-    ).not.toBeNull();
-    const primaryProjects = screen.getByRole("img", { name: "2 projects" });
-    expect(
-      primaryProjects.querySelector('[data-icon="FolderGit"]'),
-    ).not.toBeNull();
-    expect(screen.getByRole("img", { name: "1 project" })).toBeDefined();
-    expect(screen.getAllByRole("img", { name: "Full Access" })).toHaveLength(2);
+    expect(screen.getByText("Online")).toBeDefined();
+    expect(screen.getByText(/^Offline · last seen/u)).toBeDefined();
+    expect(screen.getByText("2 projects")).toBeDefined();
+    expect(screen.getByText("1 project")).toBeDefined();
+    expect(screen.getAllByText("Full Access")).toHaveLength(2);
     expect(screen.getByText("macOS")).toBeDefined();
-    expect(screen.queryByText(/Online ·/u)).toBeNull();
+    expect(
+      screen
+        .getByRole("link", { name: "Open MacBook Pro" })
+        .querySelector("[data-icon]"),
+    ).toBeNull();
   });
 
   it("distinguishes the client-local daemon from the primary machine", async () => {
@@ -255,11 +245,11 @@ describe("MachinesSettingsSection", () => {
 
     renderSection();
 
-    expect(
-      await screen.findByRole("img", {
-        name: `Needs update · daemon protocol ${HOST_DAEMON_PROTOCOL_VERSION - 1} · server protocol ${HOST_DAEMON_PROTOCOL_VERSION}`,
-      }),
-    ).toBeDefined();
+    const updateStatus = await screen.findByText(
+      `Needs update · daemon protocol ${HOST_DAEMON_PROTOCOL_VERSION - 1} · server protocol ${HOST_DAEMON_PROTOCOL_VERSION}`,
+    );
+    expect(updateStatus.className).toContain("min-w-0");
+    expect(updateStatus.className).not.toContain("shrink-0");
     // The action lives in the row menu so the rows keep one shape.
     await openHostMenu("dev-vm");
     const renameItem = await screen.findByRole("menuitem", { name: "Rename" });
@@ -309,7 +299,7 @@ describe("MachinesSettingsSection", () => {
     });
   });
 
-  it("uses a compact accessible Add machine action", async () => {
+  it("uses a labeled Add a machine action", async () => {
     vi.mocked(sdk.system.config).mockResolvedValue(systemConfig());
     vi.mocked(sdk.hosts.list).mockResolvedValue([primaryHost, offlineHost]);
     stubSidebarBootstrapFetch();
@@ -317,15 +307,14 @@ describe("MachinesSettingsSection", () => {
     renderSection();
 
     const addMachine = await screen.findByRole("button", {
-      name: "Add machine",
+      name: "Add a machine",
     });
-    expect(addMachine.textContent).toBe("");
-    expect(addMachine.className).toContain("size-7");
+    expect(addMachine.textContent).toBe("Add a machine");
     expect(addMachine.querySelector('[data-icon="Plus"]')).not.toBeNull();
-    fireEvent.pointerMove(addMachine);
-    expect((await screen.findByRole("tooltip")).textContent).toBe(
-      "Add machine",
-    );
+    const action = addMachine.parentElement;
+    expect(action?.className).toContain("self-start");
+    expect(action?.parentElement?.className).toContain("flex-col");
+    expect(action?.parentElement?.className).toContain("sm:flex-row");
     fireEvent.click(addMachine);
     expect(
       await screen.findByRole("heading", { name: "Add a machine" }),
@@ -359,7 +348,7 @@ describe("MachinesSettingsSection", () => {
     });
   });
 
-  it("keeps permission metadata left-aligned and reserves a hover caret", async () => {
+  it("shows permission metadata as text and reserves a hover caret", async () => {
     vi.mocked(sdk.system.config).mockResolvedValue(systemConfig());
     vi.mocked(sdk.hosts.list).mockResolvedValue([
       primaryHost,
@@ -369,14 +358,8 @@ describe("MachinesSettingsSection", () => {
 
     renderSection();
 
-    expect(
-      await screen.findByRole("img", {
-        name: "Accept Edits",
-      }),
-    ).toBeDefined();
-    expect(screen.getByRole("img", { name: "Full Access" })).toBeDefined();
-    expect(screen.queryByText("Accept Edits")).toBeNull();
-    expect(screen.queryByText("Full Access")).toBeNull();
+    expect(await screen.findByText("Accept Edits")).toBeDefined();
+    expect(screen.getByText("Full Access")).toBeDefined();
     // The control itself lives on the machine page.
     expect(
       screen.queryByRole("button", { name: /Permission limit for/ }),
@@ -390,12 +373,6 @@ describe("MachinesSettingsSection", () => {
     expect(row?.className).toContain("focus-within:bg-state-hover");
     expect(row?.className).toContain("px-2");
     expect(row?.className).toContain("py-2");
-    const permission = screen.getByRole("img", { name: "Accept Edits" });
-    expect(permission.querySelector('[data-icon="FolderEdit"]')).not.toBeNull();
-    fireEvent.pointerMove(permission);
-    expect((await screen.findByRole("tooltip")).textContent).toBe(
-      "Accept Edits",
-    );
     const caret = row?.querySelector('[data-icon="ChevronRight"]');
     expect(caret?.classList.contains("opacity-0")).toBe(true);
     expect(caret?.classList.contains("size-3.5")).toBe(true);

--- a/apps/app/src/components/settings/MachinesSettingsSection.tsx
+++ b/apps/app/src/components/settings/MachinesSettingsSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ReactNode } from "react";
+import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import type { Host, PermissionMode } from "@bb/domain";
 import { RETRY_ACTION_ICON } from "@bb/domain/update-state";
@@ -16,7 +16,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@bb/shared-ui/dropdown-menu";
-import { Icon, type IconName } from "@bb/shared-ui/icon";
+import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { ResourceRowDetailChevron } from "@bb/shared-ui/resource-list";
 import {
@@ -28,7 +28,7 @@ import {
 import { AddMachineDialog } from "@/components/dialogs/AddMachineDialog";
 import { ConfirmDeleteDialog } from "@/components/dialogs/ConfirmDeleteDialog";
 import { appToast } from "@/components/ui/app-toast";
-import { MachineStatusIcon } from "@/components/machines/MachineStatusDot";
+import { MachineStatusDot } from "@/components/machines/MachineStatusDot";
 import { MachineRenameDialog } from "@/components/settings/MachineRenameDialog";
 import {
   SettingsBadge,
@@ -45,7 +45,6 @@ import { useHosts } from "@/hooks/queries/host-queries";
 import { useSidebarNavigation } from "@/hooks/queries/sidebar-navigation-query";
 import { useSystemConfig } from "@/hooks/queries/system-queries";
 import { useHostDaemon } from "@/hooks/useHostDaemon";
-import { PersistentHostIconName } from "@/lib/host-display";
 import { getSettingsMachineRoutePath } from "@/lib/route-paths";
 import { PERMISSION_MODE_OPTIONS } from "@/lib/permission-mode-options";
 import { getMutationErrorMessage } from "@/lib/mutation-errors";
@@ -76,39 +75,6 @@ const PLATFORM_LABELS: Record<HostPlatform, string | null> = {
   unknown: null,
 };
 
-function MachineMetadataIcon({
-  icon,
-  label,
-  children,
-  className,
-}: {
-  icon: IconName;
-  label: string;
-  children?: ReactNode;
-  className?: string;
-}) {
-  return (
-    <TooltipProvider delayDuration={250}>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            role="img"
-            aria-label={label}
-            className={cn(
-              "inline-flex shrink-0 items-center gap-1 text-subtle-foreground/75",
-              className,
-            )}
-          >
-            <Icon aria-hidden name={icon} className="size-3.5" />
-            {children}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent>{label}</TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-}
-
 interface MachineRowProps {
   host: Host;
   isPrimary: boolean;
@@ -138,10 +104,12 @@ function MachineRow({
 }: MachineRowProps) {
   const permission = PERMISSION_MODE_PRESENTATION[host.maxPermissionMode];
   const projectLabel = `${projectCount} ${projectCount === 1 ? "project" : "projects"}`;
-  const offlineTooltip =
-    host.lastSeenAt === null
-      ? "Offline"
-      : `Offline · last seen ${formatRelativeTime({ timestamp: host.lastSeenAt, now })}`;
+  const connectionLabel =
+    host.status === "connected"
+      ? "Online"
+      : host.lastSeenAt === null
+        ? "Offline"
+        : `Offline · last seen ${formatRelativeTime({ timestamp: host.lastSeenAt, now })}`;
   const updateStatus = formatHostUpdateStatus(host);
   const removeItem = (
     <DropdownMenuItem
@@ -173,12 +141,8 @@ function MachineRow({
         <Link
           to={getSettingsMachineRoutePath(host.id)}
           aria-label={`Open ${host.name}`}
-          className="flex min-w-0 flex-1 items-center gap-3 rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className="flex min-w-0 flex-1 items-center rounded-md outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
-          <Icon
-            name={PersistentHostIconName}
-            className="size-4 shrink-0 text-muted-foreground"
-          />
           <div className="min-w-0 flex-1 space-y-1">
             <div className="flex min-w-0 items-center gap-1.5">
               <span className="min-w-0 truncate text-sm font-medium text-foreground">
@@ -189,35 +153,27 @@ function MachineRow({
               ) : null}
               {showPrimaryBadge ? <SettingsBadge>primary</SettingsBadge> : null}
             </div>
-            <div className="flex min-w-0 items-center gap-2 text-xs text-subtle-foreground/75">
-              <MachineStatusIcon
-                connected={host.status === "connected"}
-                tooltip={
-                  host.status === "connected" ? "Online" : offlineTooltip
-                }
-                className="size-3.5 [&_[data-icon]]:size-3.5"
-              />
+            <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-subtle-foreground/75">
+              <span className="inline-flex shrink-0 items-center gap-1.5">
+                <MachineStatusDot connected={host.status === "connected"} />
+                {connectionLabel}
+              </span>
               {platformLabel === null ? null : (
                 <span className="truncate">{platformLabel}</span>
               )}
-              <MachineMetadataIcon icon="FolderGit" label={projectLabel}>
-                <span aria-hidden>{projectCount}</span>
-              </MachineMetadataIcon>
-              <MachineMetadataIcon
-                icon={permission.iconName}
-                label={permission.label}
-                className={
-                  permission.tone === "warning"
-                    ? "text-warning-text"
-                    : undefined
-                }
-              />
+              <span className="shrink-0">{projectLabel}</span>
+              <span
+                className={cn(
+                  "shrink-0",
+                  permission.tone === "warning" && "text-warning-text",
+                )}
+              >
+                {permission.label}
+              </span>
               {updateStatus === null ? null : (
-                <MachineMetadataIcon
-                  icon="AlertTriangle"
-                  label={updateStatus}
-                  className="text-warning-text"
-                />
+                <span className="min-w-0 text-warning-text">
+                  {updateStatus}
+                </span>
               )}
             </div>
           </div>
@@ -315,22 +271,14 @@ export function MachinesSettingsSection() {
         title="Machines"
         description={MACHINES_SECTION_DESCRIPTION}
         action={
-          <TooltipProvider delayDuration={250}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  className="size-7 text-muted-foreground hover:text-foreground"
-                  aria-label="Add machine"
-                  onClick={() => setAddDialogOpen(true)}
-                >
-                  <Icon name="Plus" className="size-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Add machine</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setAddDialogOpen(true)}
+          >
+            <Icon name="Plus" className="size-3.5" />
+            Add a machine
+          </Button>
         }
       >
         {hosts === undefined ? (

--- a/apps/app/src/components/ui/settings-section.tsx
+++ b/apps/app/src/components/ui/settings-section.tsx
@@ -27,8 +27,8 @@ export function SettingsSection({
     <section className="space-y-3">
       <div
         className={cn(
-          "flex justify-between gap-4",
-          description ? "items-start" : "items-center",
+          "flex flex-col gap-3 sm:flex-row sm:justify-between sm:gap-4",
+          description ? "sm:items-start" : "sm:items-center",
         )}
       >
         <div className="min-w-0">
@@ -44,7 +44,7 @@ export function SettingsSection({
             </p>
           ) : null}
         </div>
-        {action ? <div className="shrink-0">{action}</div> : null}
+        {action ? <div className="shrink-0 self-start">{action}</div> : null}
       </div>
       <div
         className={cn(

--- a/apps/app/src/views/MachineSettingsView.test.tsx
+++ b/apps/app/src/views/MachineSettingsView.test.tsx
@@ -177,9 +177,10 @@ describe("MachineSettingsView", () => {
 
     renderView();
 
-    expect(
-      await screen.findByRole("heading", { name: /dev-vm/u }),
-    ).toBeDefined();
+    const machineHeading = await screen.findByRole("heading", {
+      name: /dev-vm/u,
+    });
+    expect(machineHeading.tagName).toBe("H1");
     const checkedByMode = Object.fromEntries(
       (await screen.findAllByRole("radio")).map((option) => [
         option.textContent?.startsWith("Accept Edits")
@@ -197,21 +198,23 @@ describe("MachineSettingsView", () => {
     });
     expect(
       screen
-        .getByRole("radio", { name: /Accept Edits/u })
-        .querySelector('[data-icon="FolderEdit"]'),
-    ).not.toBeNull();
+        .getAllByRole("radio")
+        .every((option) => option.querySelector("[data-icon]") === null),
+    ).toBe(true);
+    const machineSubtitle = screen.getByText(/^Online ·/u);
+    expect(machineSubtitle.closest("section")).toBeNull();
+    expect(screen.queryByRole("img", { name: "Online" })).toBeNull();
     expect(
       screen
-        .getByRole("radio", { name: /Approve for me/u })
-        .querySelector('[data-icon="SecurityCheck"]'),
-    ).not.toBeNull();
+        .getByRole("heading", { name: /dev-vm/u })
+        .querySelector("[data-icon]"),
+    ).toBeNull();
     expect(
       screen
-        .getByRole("radio", { name: /Full Access/u })
-        .querySelector('[data-icon="SquareUnlock02"]'),
-    ).not.toBeNull();
-    expect(screen.getByRole("img", { name: "Online" })).toBeDefined();
-    expect(document.querySelector('[data-icon="FolderGit"]')).not.toBeNull();
+        .getByRole("heading", { name: "Machine information" })
+        .closest("section")
+        ?.querySelector("[data-icon]"),
+    ).toBeNull();
     expect(
       document.querySelector('[data-provider-icon="codex"]'),
     ).not.toBeNull();
@@ -226,6 +229,15 @@ describe("MachineSettingsView", () => {
         .getByRole("heading", { name: "Provider CLIs" })
         .querySelector("[data-icon]"),
     ).toBeNull();
+    const installedLabel = screen.getByText("Installed");
+    expect(installedLabel.parentElement?.className).toContain("flex-col");
+    expect(installedLabel.parentElement?.className).toContain("sm:flex-row");
+    expect(installedLabel.nextElementSibling?.className).toContain(
+      "justify-start",
+    );
+    expect(installedLabel.nextElementSibling?.className).toContain(
+      "sm:justify-end",
+    );
     // The page exists so the modes can explain themselves.
     expect(screen.getByText(/No sandbox and no approvals/u)).toBeDefined();
   });
@@ -247,7 +259,7 @@ describe("MachineSettingsView", () => {
     expect(screen.queryByRole("button", { name: "Rename" })).toBeNull();
   });
 
-  it("names an offline machine's status icon", async () => {
+  it("shows an offline machine's status as text", async () => {
     vi.mocked(sdk.system.config).mockResolvedValue(systemConfig());
     vi.mocked(sdk.hosts.list).mockResolvedValue([
       host({ status: "disconnected", lastSeenAt: Date.now() - 60_000 }),
@@ -256,8 +268,8 @@ describe("MachineSettingsView", () => {
 
     renderView();
 
-    expect(await screen.findByRole("img", { name: "Offline" })).toBeDefined();
-    expect(screen.queryByText(/^Offline ·/u)).toBeNull();
+    expect(await screen.findByText(/^Offline · last seen/u)).toBeDefined();
+    expect(screen.queryByRole("img", { name: "Offline" })).toBeNull();
   });
 
   it("links update issues to Updates in a warning pill", async () => {

--- a/apps/app/src/views/MachineSettingsView.tsx
+++ b/apps/app/src/views/MachineSettingsView.tsx
@@ -5,7 +5,6 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 // so those icons never flash blank waiting for an on-demand load.
 import "@bb/shared-ui/icon-extended";
 import type { Host, PermissionMode } from "@bb/domain";
-import { UPDATE_ACTION_ICON } from "@bb/domain/update-state";
 import {
   providerCliKeyValues,
   type HostPlatform,
@@ -14,12 +13,12 @@ import {
 import { Button } from "@bb/shared-ui/button";
 import { DialogFooter, DialogHeader, DialogTitle } from "@bb/shared-ui/dialog";
 import { DialogDescription } from "@bb/shared-ui/dialog";
-import { Icon, type IconName } from "@bb/shared-ui/icon";
+import { Icon } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
 import { Pill } from "@bb/shared-ui/pill";
 import { ResourceOverflowMenu } from "@bb/shared-ui/resource-list";
 import { ConfirmDeleteDialog } from "@/components/dialogs/ConfirmDeleteDialog";
-import { MachineStatusIcon } from "@/components/machines/MachineStatusDot";
+import { MachineStatusDot } from "@/components/machines/MachineStatusDot";
 import { PageShell } from "@/components/ui/page-shell.js";
 import {
   SettingsBadge,
@@ -46,7 +45,6 @@ import {
   hostCanRetryUpdate,
 } from "@/lib/host-update-status";
 import { getMutationErrorMessage } from "@/lib/mutation-errors";
-import { PersistentHostIconName } from "@/lib/host-display";
 import { PERMISSION_MODE_OPTIONS } from "@/lib/permission-mode-options";
 import { formatRelativeTime } from "@/lib/relative-time";
 import {
@@ -90,7 +88,7 @@ function headerMeta({
   platformLabel: string | null;
   now: number;
 }): string {
-  const parts: string[] = [];
+  const parts: string[] = [host.status === "connected" ? "Online" : "Offline"];
   if (host.status !== "connected" && host.lastSeenAt !== null) {
     parts.push(
       `last seen ${formatRelativeTime({ timestamp: host.lastSeenAt, now })}`,
@@ -145,14 +143,6 @@ function PermissionLimitCards({
                     <span className="size-2 rounded-full bg-foreground" />
                   ) : null}
                 </span>
-                <Icon
-                  aria-hidden
-                  name={option.iconName}
-                  className={cn(
-                    "mt-0.5 size-4 shrink-0 text-muted-foreground",
-                    option.tone === "warning" && "text-warning-text",
-                  )}
-                />
                 <span className="min-w-0 flex-1">
                   <span className="block text-sm text-foreground">
                     {option.label}
@@ -174,24 +164,14 @@ function PermissionLimitCards({
 
 interface DetailRowProps {
   label: string;
-  icon?: IconName;
   children: ReactNode;
 }
 
-function DetailRow({ label, icon, children }: DetailRowProps) {
+function DetailRow({ label, children }: DetailRowProps) {
   return (
-    <SettingsRow className="items-start sm:items-center">
-      <span className="flex min-w-0 items-center gap-2 text-foreground">
-        {icon ? (
-          <Icon
-            aria-hidden
-            name={icon}
-            className="size-4 shrink-0 text-muted-foreground"
-          />
-        ) : null}
-        <span>{label}</span>
-      </span>
-      <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-2 text-right text-subtle-foreground">
+    <SettingsRow className="flex-col items-stretch gap-1.5 sm:flex-row sm:items-center sm:gap-3">
+      <span className="shrink-0 text-foreground">{label}</span>
+      <div className="flex min-w-0 flex-wrap items-center justify-start gap-2 text-left text-subtle-foreground sm:ml-auto sm:justify-end sm:text-right">
         {children}
       </div>
     </SettingsRow>
@@ -308,48 +288,40 @@ export function MachineSettingsView() {
             <Icon name="ChevronLeft" className="size-3.5" />
             Machines
           </Link>
-          <SettingsSection
-            title={
-              <span className="flex min-w-0 items-center gap-2">
-                <Icon
-                  name={PersistentHostIconName}
-                  className="size-4 shrink-0 text-muted-foreground"
-                  aria-hidden
-                />
-                <span className="truncate">{host.name}</span>
+          <div className="flex min-w-0 items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="flex min-w-0 items-center gap-2">
+                <h1 className="min-w-0 truncate text-sm font-semibold text-foreground">
+                  {host.name}
+                </h1>
                 {isThisMachine ? (
                   <SettingsBadge>This machine</SettingsBadge>
                 ) : null}
                 {showMachineIdentityBadges && isPrimary ? (
                   <SettingsBadge>Primary</SettingsBadge>
                 ) : null}
-              </span>
-            }
-            titleAction={
-              <ResourceOverflowMenu
-                label={`${host.name} actions`}
-                items={[
-                  {
-                    label: "Rename",
-                    icon: "Edit",
-                    onSelect: () => {
-                      renameHost.reset();
-                      setRenameOpen(true);
-                    },
-                  },
-                ]}
-              />
-            }
-          >
-            <SettingsRowList>
-              <SettingsRow>
-                <MachineStatusIcon connected={host.status === "connected"} />
+              </div>
+              <div className="mt-1 flex min-w-0 items-center gap-2">
+                <MachineStatusDot connected={host.status === "connected"} />
                 <p className="min-w-0 text-xs text-subtle-foreground/75">
                   {headerMeta({ host, platformLabel, now })}
                 </p>
-              </SettingsRow>
-            </SettingsRowList>
-          </SettingsSection>
+              </div>
+            </div>
+            <ResourceOverflowMenu
+              label={`${host.name} actions`}
+              items={[
+                {
+                  label: "Rename",
+                  icon: "Edit",
+                  onSelect: () => {
+                    renameHost.reset();
+                    setRenameOpen(true);
+                  },
+                },
+              ]}
+            />
+          </div>
         </div>
 
         <SettingsSection
@@ -389,7 +361,7 @@ export function MachineSettingsView() {
               ) : (
                 <>
                   {installedProviders.length > 0 ? (
-                    <span className="flex min-w-0 flex-wrap items-center justify-end gap-x-3 gap-y-1">
+                    <span className="flex min-w-0 flex-wrap items-center justify-start gap-x-3 gap-y-1 sm:justify-end">
                       {installedProviders.map((entry) => (
                         <span
                           key={entry.providerId}
@@ -438,7 +410,7 @@ export function MachineSettingsView() {
 
         <SettingsSection title="Machine information">
           <SettingsRowList>
-            <DetailRow label="Projects" icon="FolderGit">
+            <DetailRow label="Projects">
               {projects.length === 0 ? (
                 <span>None</span>
               ) : (
@@ -457,7 +429,7 @@ export function MachineSettingsView() {
                 </span>
               )}
             </DetailRow>
-            <DetailRow label="Updates" icon={UPDATE_ACTION_ICON}>
+            <DetailRow label="Updates">
               <span>{updateStatus ?? "Up to date"}</span>
               {hostCanRetryUpdate(host) ? (
                 <Button

--- a/apps/app/src/views/MachineSettingsView.tsx
+++ b/apps/app/src/views/MachineSettingsView.tsx
@@ -1,9 +1,5 @@
 import { useMemo, useState, type ReactNode } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-// Route views render icons outside the shell's core set. Importing the
-// extended registry here ships it as a static dependency of this route chunk,
-// so those icons never flash blank waiting for an on-demand load.
-import "@bb/shared-ui/icon-extended";
 import type { Host, PermissionMode } from "@bb/domain";
 import {
   providerCliKeyValues,


### PR DESCRIPTION
## What was wrong

The machine list and detail redesign in [#1996](https://github.com/get-bb/bb/pull/1996) compressed status, project count, permissions, and update state into a dense set of glyphs and tooltips. That made common metadata slower to scan, turned the add action into an ambiguous bare plus, and put the detail identity subtitle inside a card that implied a separate section. Several flex items were also forced to remain unshrinkable, so long metadata and detail key/value groups became cramped on phone-width screens. Tracks #2049.

## What changed

- Replaced decorative machine, project, permission, and update glyphs with visible metadata text while retaining status dots, provider marks, and action icons.
- Restored the labeled “Add a machine” button.
- Moved connection state, platform, and pairing age directly below the machine heading instead of wrapping that subtitle in a card.
- Made section actions and detail key/value rows stack on compact screens, and allowed long update status text to wrap.
- Added focused regression coverage for visible status/metadata, the labeled action, the subtitle header structure, and compact layout classes.
- No wire, daemon protocol, CLI, persistence, or documentation contract changes.

### Machine list

| Original | After #1996 | This PR |
| --- | --- | --- |
| ![Original machine list](https://github.com/user-attachments/assets/77cb6e87-9225-4dfd-94ee-a689e6820a6e) | ![Machine list after PR 1996](https://github.com/user-attachments/assets/603e6f8d-22c7-4a34-b2ee-b568c8f862ec) | ![Text-first machine list](https://github.com/user-attachments/assets/866a07d8-aaf3-4e8e-bc18-5162e6fb2d7e) |

### Machine detail

| Original | After #1996 | This PR |
| --- | --- | --- |
| ![Original machine detail](https://github.com/user-attachments/assets/12a2ba39-3b3c-4bbc-a0d6-05d165c74bf0) | ![Machine detail after PR 1996](https://github.com/user-attachments/assets/5d41a136-fcdb-4da6-ae26-7bfe7bb5ed43) | ![Text-first machine detail](https://github.com/user-attachments/assets/6002a866-5335-4b80-ad88-4103d6b6bf68) |

### Narrow screens at 320px

| Page | Before | After |
| --- | --- | --- |
| List | ![Narrow machine list before](https://github.com/user-attachments/assets/9beaabec-ec93-406a-bfd4-5cafc2b54cb4) | ![Narrow machine list after](https://github.com/user-attachments/assets/5a307a92-39a3-4825-92a5-beaf86d5fb7f) |
| Detail | ![Narrow machine detail before](https://github.com/user-attachments/assets/7128a6a9-ab48-4c3a-9d24-41f7baf86608) | ![Narrow machine detail after](https://github.com/user-attachments/assets/7930edd8-a302-4b27-92b9-85013e2afb31) |

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- src/components/settings/MachinesSettingsSection.test.tsx src/views/MachineSettingsView.test.tsx` — 21 tests passed. The new assertions fail against the previous icon-only and card-based markup.
- `pnpm exec turbo run typecheck --filter=@bb/app` — passed.
- `pnpm exec turbo run lint --filter=@bb/app` — passed.
- Rendered the real Settings story at true 320px, 390px, 768px, and 1440px viewports. Both pages stayed within the viewport at 320px and 390px with no visible horizontal overflow.

Fixes #2049

> AGENT GENERATED: by GPT-5.6 Codex