### PR TITLE
Reveal the selection head in the prompt input, not the anchor

### DIFF
--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import type { PromptTextMention } from "@bb/domain";
+import { TextSelection } from "@tiptap/pm/state";
 import { EditorView } from "@tiptap/pm/view";
 import {
   createRef,
@@ -2997,6 +2998,81 @@ describe("PromptBoxInternal mention triggers", () => {
     await waitFor(() =>
       expect(threadButton.className).toContain("bg-state-active"),
     );
+  });
+});
+
+describe("PromptBoxInternal selection reveal", () => {
+  async function nextAnimationFrame() {
+    await act(
+      () =>
+        new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
+    );
+  }
+
+  it("reveals the moving selection head, not the anchor, when a selection extends upward", async () => {
+    const lines = Array.from({ length: 40 }, (_, index) => `line ${index}`);
+    const { promptBoxRef } = renderPromptBox(lines.join("\n"));
+
+    await focusPromptEnd(promptBoxRef);
+    await nextAnimationFrame();
+
+    const scrollContainer = document.querySelector(
+      "[data-promptbox-editor-scroll]",
+    );
+    if (!(scrollContainer instanceof HTMLElement)) {
+      throw new Error("Prompt editor scroll container was not rendered");
+    }
+    // jsdom does not lay out, so emulate a 100px viewport scrolled to the
+    // middle of the document. The selection anchor sits below the viewport
+    // (where the drag started) and the head sits above it (where the pointer
+    // is now). The browser's own drag autoscroll has already moved the
+    // viewport up toward the head.
+    let scrollTop = 500;
+    Object.defineProperty(scrollContainer, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (next: number) => {
+        scrollTop = next;
+      },
+    });
+    const scrollRectSpy = vi
+      .spyOn(scrollContainer, "getBoundingClientRect")
+      .mockReturnValue(new DOMRect(0, 0, 320, 100));
+    let view: EditorView | null = null;
+    const coordsAtPosSpy = vi
+      .spyOn(EditorView.prototype, "coordsAtPos")
+      .mockImplementation(function (this: EditorView, pos: number) {
+        view = this;
+        const { selection } = this.state;
+        if (pos === selection.head && selection.head !== selection.anchor) {
+          return { left: 0, right: 0, top: -30, bottom: -14 };
+        }
+        return { left: 0, right: 0, top: 160, bottom: 176 };
+      });
+
+    try {
+      await waitFor(() => expect(view).not.toBeNull());
+      const liveView = view as unknown as EditorView;
+      const { doc } = liveView.state;
+      // The focusEnd reveal above captured `view`; reset the baseline it set.
+      scrollTop = 500;
+      await act(async () => {
+        liveView.dispatch(
+          liveView.state.tr.setSelection(
+            TextSelection.create(doc, doc.content.size - 1, 1),
+          ),
+        );
+      });
+      await nextAnimationFrame();
+
+      // The reveal must follow the head upward (scrollTop decreases). Before
+      // the fix it revealed `selection.to` (the anchor) and yanked the
+      // viewport back down, fighting the drag autoscroll on every pointer move.
+      expect(scrollTop).toBeLessThan(500);
+    } finally {
+      coordsAtPosSpy.mockRestore();
+      scrollRectSpy.mockRestore();
+    }
   });
 });
 

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -905,9 +905,13 @@ function revealPromptEditorSelection({
   const scrollContainerRect = scrollContainer.getBoundingClientRect();
   if (scrollContainerRect.height <= 0) return;
 
+  // Reveal the head, not `to`. While the user drags or Shift+Arrows a
+  // selection upward, the anchor stays below and `to` is the anchor. The
+  // browser autoscrolls toward the head; revealing `to` scrolled back toward
+  // the anchor on every selection update and the prompt jittered.
   let selectionRect: ReturnType<Editor["view"]["coordsAtPos"]>;
   try {
-    selectionRect = editor.view.coordsAtPos(editor.state.selection.to);
+    selectionRect = editor.view.coordsAtPos(editor.state.selection.head);
   } catch {
     return;
   }


### PR DESCRIPTION
## What was wrong

`revealPromptEditorSelection` scrolled `editor.state.selection.to` into the prompt scroll container on every selection update. When you drag or Shift+Arrow a selection upward, the anchor stays below and `to` is the anchor, not the moving head. The browser autoscrolled up toward the head; the reveal scrolled back down toward the anchor; the prompt jittered and you could not select text above the viewport.

## What changed

Reveal `selection.head` instead of `selection.to`. For a caret both are equal, so caret behavior does not change. For a selection the head is the end the user moves.

## How I verified

Added `PromptBoxInternal selection reveal` test: a 100px viewport at `scrollTop = 500`, anchor below and head above. Before the fix one selection update moved `scrollTop` to 588 (toward the anchor); after the fix it moves up. `@bb/app` PromptBoxInternal tests: 101 passed. `@bb/app` typecheck passes.

Fixes #2051

> AGENT GENERATED: by Claude Opus 5