### PR TITLE
Register start-bb signal handlers before spawning

### DIFF
--- a/scripts/start-bb.mjs
+++ b/scripts/start-bb.mjs
@@ -26,12 +26,7 @@ function waitForProcess(child) {
 }
 
 export async function runBuildProcess(request) {
-  const child = spawn(request.command, request.args, {
-    cwd: request.cwd,
-    detached: supportsProcessGroups(),
-    env: request.env,
-    stdio: "inherit",
-  });
+  let child;
   let stopPromise;
   const stopChild = () => {
     stopPromise ??= stopProcessGroupLeaderFirst({
@@ -42,10 +37,18 @@ export async function runBuildProcess(request) {
   };
   const handleSigint = () => stopChild();
   const handleSigterm = () => stopChild();
+  // Register before spawn so a child that becomes ready immediately cannot
+  // prompt another process to signal us before the handlers exist.
   process.on("SIGINT", handleSigint);
   process.on("SIGTERM", handleSigterm);
 
   try {
+    child = spawn(request.command, request.args, {
+      cwd: request.cwd,
+      detached: supportsProcessGroups(),
+      env: request.env,
+      stdio: "inherit",
+    });
     const result = await waitForProcess(child);
     await stopPromise;
     return result;


### PR DESCRIPTION
## What was wrong

runBuildProcess spawned its build process before registering SIGINT and SIGTERM handlers. A fast child could become externally observable during that window, allowing another process to send SIGTERM while Node still had its default signal behavior. The parent then exited with signal=SIGTERM instead of cleaning up the build leader and grandchild, which caused the flaky packages job on PR #2050.

## What changed

Register the build signal handlers before spawning the child. Keep spawn inside the existing try/finally lifecycle so synchronous startup failures also remove both handlers. There are no wire, daemon protocol, CLI, persistence, or documentation contract changes.

## How you verified

- The first CI attempt on PR #2050 failed in test/start-bb.test.mjs with code=null and signal=SIGTERM; its rerun passed, confirming the timing-dependent behavior.
- Repeated the focused @bb/scripts process-group integration test 100 times with Turbo cache bypass; all 100 passed without Vitest retries.
- pnpm exec turbo run test --filter=@bb/scripts --force — 18 files and 97 tests passed.
- pnpm exec turbo run typecheck --filter=@bb/scripts — passed.
- git diff --check — passed.

Follow-up to #2050.

> AGENT GENERATED: by GPT-5.6 Codex