### PR TITLE
Match the PR check icon to the GitHub favicon geometry

### DIFF
--- a/apps/app/src/components/pull-request/GithubFaviconIcon.tsx
+++ b/apps/app/src/components/pull-request/GithubFaviconIcon.tsx
@@ -1,0 +1,77 @@
+import { cn } from "@bb/shared-ui/lib/utils";
+import type { GithubCheckStatus } from "@/lib/pull-request-display";
+
+// These are the GitHub favicon SVGs (favicon.svg, favicon-success.svg,
+// favicon-failure.svg, favicon-pending.svg from github.githubassets.com),
+// inlined so the glyph matches the favicon geometry exactly without a
+// cross-origin image request. The light and dark favicons share the same
+// paths and differ only in fill, so one path set serves both themes: the mark
+// uses currentColor and the status glyph uses the theme status tokens.
+const GITHUB_MARK_PATH =
+  "M16 0C7.16 0 0 7.16 0 16C0 23.08 4.58 29.06 10.94 31.18C11.74 31.32 12.04 30.84 12.04 30.42C12.04 30.04 12.02 28.78 12.02 27.44C8 28.18 6.96 26.46 6.64 25.56C6.46 25.1 5.68 23.68 5 23.3C4.44 23 3.64 22.26 4.98 22.24C6.24 22.22 7.14 23.4 7.44 23.88C8.88 26.3 11.18 25.62 12.1 25.2C12.24 24.16 12.66 23.46 13.12 23.06C9.56 22.66 5.84 21.28 5.84 15.16C5.84 13.42 6.46 11.98 7.48 10.86C7.32 10.46 6.76 8.82 7.64 6.62C7.64 6.62 8.98 6.2 12.04 8.26C13.32 7.9 14.68 7.72 16.04 7.72C17.4 7.72 18.76 7.9 20.04 8.26C23.1 6.18 24.44 6.62 24.44 6.62C25.32 8.82 24.76 10.46 24.6 10.86C25.62 11.98 26.24 13.4 26.24 15.16C26.24 21.3 22.5 22.66 18.94 23.06C19.52 23.56 20.02 24.52 20.02 26.02C20.02 28.16 20 29.88 20 30.42C20 30.84 20.3 31.34 21.1 31.18C27.42 29.06 32 23.06 32 16C32 7.16 24.84 0 16 0V0Z";
+
+// The status favicons cut the mark away under the glyph, so each status has
+// its own mark path.
+const GITHUB_CHECK_STATUS_PATHS: Record<
+  GithubCheckStatus,
+  { mark: string; glyph: string; glyphClassName: string }
+> = {
+  success: {
+    mark: "M0 16C0 7.16 7.16 0 16 0C23.037 0 29.0094 4.53712 31.1529 10.8471L26.2271 15.773C26.2356 15.5741 26.24 15.3698 26.24 15.16C26.24 13.4 25.62 11.98 24.6 10.86C24.76 10.46 25.32 8.82 24.44 6.62C24.44 6.62 23.1 6.18 20.04 8.26C18.76 7.9 17.4 7.72 16.04 7.72C14.68 7.72 13.32 7.9 12.04 8.26C8.98 6.2 7.64 6.62 7.64 6.62C6.76 8.82 7.32 10.46 7.48 10.86C6.46 11.98 5.84 13.42 5.84 15.16C5.84 20.6387 8.82119 22.3187 12 22.8976V25.2442C11.0224 25.6632 8.83035 26.2166 7.44 23.88C7.14 23.4 6.24 22.22 4.98 22.24C3.64 22.26 4.44 23 5 23.3C5.68 23.68 6.46 25.1 6.64 25.56C6.95947 26.4585 7.99655 28.1743 12 27.4437V30.6814C11.8951 31.0116 11.5751 31.2911 10.94 31.18C4.58 29.06 0 23.08 0 16Z",
+    glyph:
+      "M30.7071 21.2071L20.5 31.4142L15.2929 26.2071L16.7071 24.7929L20.5 28.5858L29.2929 19.7929L30.7071 21.2071Z",
+    glyphClassName: "fill-success",
+  },
+  failure: {
+    mark: "M0 16C0 7.16 7.16 0 16 0C24.1626 0 30.8929 6.10479 31.8764 14H26.1444C25.9339 12.7632 25.3856 11.7226 24.6 10.86C24.76 10.46 25.32 8.82 24.44 6.62C24.44 6.62 23.1 6.18 20.04 8.26C18.76 7.9 17.4 7.72 16.04 7.72C14.68 7.72 13.32 7.9 12.04 8.26C8.98 6.2 7.64 6.62 7.64 6.62C6.76 8.82 7.32 10.46 7.48 10.86C6.46 11.98 5.84 13.42 5.84 15.16C5.84 20.6387 8.82119 22.3187 12 22.8976V25.2442C11.0224 25.6632 8.83035 26.2166 7.44 23.88C7.14 23.4 6.24 22.22 4.98 22.24C3.64 22.26 4.44 23 5 23.3C5.68 23.68 6.46 25.1 6.64 25.56C6.95947 26.4585 7.99655 28.1743 12 27.4437V30.6814C11.8951 31.0116 11.5751 31.2911 10.94 31.18C4.58 29.06 0 23.08 0 16Z",
+    glyph:
+      "M23.0858 24.5L18.2929 29.2929L19.7071 30.7071L24.5 25.9142L29.2929 30.7071L30.7071 29.2929L25.9142 24.5L30.7071 19.7071L29.2929 18.2929L24.5 23.0858L19.7071 18.2929L18.2929 19.7071L23.0858 24.5Z",
+    glyphClassName: "fill-destructive",
+  },
+  pending: {
+    mark: "M0 16C0 7.16 7.16 0 16 0C24.84 0 32 7.16 32 16C32 16.3358 31.9896 16.6693 31.9692 17H26.1121C26.1957 16.44 26.24 15.8283 26.24 15.16C26.24 13.4 25.62 11.98 24.6 10.86C24.76 10.46 25.32 8.82 24.44 6.62C24.44 6.62 23.1 6.18 20.04 8.26C18.76 7.9 17.4 7.72 16.04 7.72C14.68 7.72 13.32 7.9 12.04 8.26C8.98 6.2 7.64 6.62 7.64 6.62C6.76 8.82 7.32 10.46 7.48 10.86C6.46 11.98 5.84 13.42 5.84 15.16C5.84 20.6387 8.82119 22.3187 12 22.8976V25.2442C11.0224 25.6632 8.83035 26.2166 7.44 23.88C7.14 23.4 6.24 22.22 4.98 22.24C3.64 22.26 4.44 23 5 23.3C5.68 23.68 6.46 25.1 6.64 25.56C6.95947 26.4585 7.99655 28.1743 12 27.4437V30.6814C11.8951 31.0116 11.5751 31.2911 10.94 31.18C4.58 29.06 0 23.08 0 16Z",
+    // favicon-pending.svg draws <circle cx="26" cy="26" r="5" />.
+    glyph: "M31 26A5 5 0 1 1 21 26A5 5 0 1 1 31 26Z",
+    glyphClassName: "fill-attention",
+  },
+};
+
+export function GithubFaviconIcon({
+  status = null,
+  className,
+}: {
+  status?: GithubCheckStatus | null;
+  className?: string;
+}) {
+  const paths = status === null ? null : GITHUB_CHECK_STATUS_PATHS[status];
+  return (
+    <svg
+      viewBox="0 0 32 32"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      data-icon="GithubFavicon"
+      data-pull-request-check-status={status ?? undefined}
+      className={cn("size-4 shrink-0", className)}
+    >
+      {paths === null ? (
+        <path
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d={GITHUB_MARK_PATH}
+          fill="currentColor"
+        />
+      ) : (
+        <>
+          <path d={paths.mark} fill="currentColor" />
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d={paths.glyph}
+            className={paths.glyphClassName}
+          />
+        </>
+      )}
+    </svg>
+  );
+}

--- a/apps/app/src/components/pull-request/PullRequestStatusPill.tsx
+++ b/apps/app/src/components/pull-request/PullRequestStatusPill.tsx
@@ -1,22 +1,8 @@
 import type { PullRequestState, ThreadPullRequest } from "@bb/domain";
 import { Icon, type IconName } from "@bb/shared-ui/icon";
 import { cn } from "@bb/shared-ui/lib/utils";
-import {
-  getPullRequestGithubCheckStatus,
-  type GithubCheckStatus,
-} from "@/lib/pull-request-display";
-
-// The check glyph is the bundled GitHub mark with a small status dot in the
-// corner, drawn from theme tokens. It replaces the light + dark favicon PNGs
-// that were fetched from github.githubassets.com on every thread that has a
-// pull request: two cross-origin image requests per pill (and per row on the
-// sidebar/thread list), which on phones over a tunnel meant late-arriving,
-// layout-shifting icons and a third-party request on every cold start.
-const GITHUB_CHECK_STATUS_DOT_CLASS: Record<GithubCheckStatus, string> = {
-  success: "bg-success",
-  failure: "bg-destructive",
-  pending: "bg-attention",
-};
+import { getPullRequestGithubCheckStatus } from "@/lib/pull-request-display";
+import { GithubFaviconIcon } from "./GithubFaviconIcon";
 
 const PR_STATUS_COLOR: Record<PullRequestState, { textClassName: string }> = {
   open: {
@@ -90,21 +76,7 @@ export function PullRequestGithubCheckIcon({
   if (status === null) {
     return null;
   }
-  return (
-    <span
-      data-pull-request-check-status={status}
-      aria-hidden="true"
-      className={cn("relative inline-flex size-4 shrink-0", className)}
-    >
-      <Icon name="Github" className="size-4 shrink-0" aria-hidden="true" />
-      <span
-        className={cn(
-          "absolute -right-px -bottom-px size-2 rounded-full ring-2 ring-background",
-          GITHUB_CHECK_STATUS_DOT_CLASS[status],
-        )}
-      />
-    </span>
-  );
+  return <GithubFaviconIcon status={status} className={className} />;
 }
 
 export function PullRequestStatusPill({

--- a/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadMetadataContent.tsx
@@ -73,6 +73,7 @@ import {
   PullRequestGithubCheckIcon,
   PullRequestStateIcon,
 } from "@/components/pull-request/PullRequestStatusPill";
+import { GithubFaviconIcon } from "@/components/pull-request/GithubFaviconIcon";
 import { useUrlAnchorClickHandler } from "@/lib/url-open-routing";
 
 // ---------------------------------------------------------------------------
@@ -499,7 +500,7 @@ export function PullRequestRow({ pullRequest }: PullRequestRowProps) {
         {showGithubCheckIcon ? (
           <PullRequestGithubCheckIcon pullRequest={pullRequest} />
         ) : (
-          <Icon name="Github" className="size-4 shrink-0" aria-hidden="true" />
+          <GithubFaviconIcon />
         )}
         <span className="shrink-0 text-muted-foreground">
           #{pullRequest.number}


### PR DESCRIPTION
## What was wrong

PR #1900 replaced the GitHub favicon PNGs (fetched from github.githubassets.com) with the bundled hugeicons `Github` outline glyph plus a separate status dot. That outline fills the whole 16px box with a stroked octocat and has a different silhouette, so the PR check icon in tab strips, the sidebar, and the thread metadata panel looked much larger than the favicon it replaced.

## What changed

- New `apps/app/src/components/pull-request/GithubFaviconIcon.tsx` inlines the exact path data from GitHub's `favicon.svg`, `favicon-success.svg`, `favicon-failure.svg`, and `favicon-pending.svg` (the mark with its cut-out plus the check / X / circle glyph). The mark fills with `currentColor`; the glyph uses `fill-success` / `fill-destructive` / `fill-attention`. The light and dark favicons share the same paths, so one SVG serves both themes and still makes no cross-origin request.
- `PullRequestStatusPill.tsx` (`PullRequestGithubCheckIcon`) and `ThreadMetadataContent.tsx` render it in place of the hugeicons glyph.
- No wire, CLI, or plugin API changes.

## How you verified

- Rasterized the new SVGs at 16px next to the real favicon PNGs downscaled to 16px; the pairs are indistinguishable for success, failure, and pending.
- `pnpm exec turbo run typecheck --filter=@bb/app`: pass.
- eslint + prettier on the touched files: clean.
- vitest `src/components/pull-request src/components/secondary-panel src/components/thread-list`: 31 files, 229 tests pass.

Fixes: visual regression from #1900 (no issue filed).

> AGENT GENERATED: by Claude Opus 5