### PR TITLE
Align the mobile thread list with the web sidebar and add section reorder

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -9,7 +9,8 @@ M5 (SPA-in-WebView plugin surfaces, tablet layout, store releases) is
 deferred. Direct-mode and bb connect server profiles (QR / code pairing, desktop-session
 cookie, re-pair), the app shell (root stack, connection banner, settings),
 theme/design system, the per-profile SDK/realtime/query layer, the grouped
-thread list (home, long-press menus, organize/sort, search, archived),
+thread list (home, long-press menus, organize/sort, drag-to-reorder
+sections per organize mode under the web localStorage keys, search, archived),
 thread creation on the shared composer (mentions, attachments, voice, fork /
 handoff seeds), the thread detail screen (`/threads/[id]`: the virtualized
 timeline with every row kind, markdown, inline diffs, terminal output, images +

--- a/apps/mobile/src/data/sidebar/index.ts
+++ b/apps/mobile/src/data/sidebar/index.ts
@@ -39,6 +39,13 @@ export {
   type SidebarSortMode,
 } from "./sidebar-preferences";
 export {
+  listSidebarSectionOrderEntries,
+  mergeHiddenSectionOrder,
+  resolveSidebarSectionOrder,
+  useSidebarSectionOrder,
+  type SidebarSectionOrderEntry,
+} from "./sidebar-section-order";
+export {
   getSidebarPreferencesStore,
   useSidebarCollapsedSets,
   useSidebarPreferences,

--- a/apps/mobile/src/data/sidebar/sidebar-preferences.test.ts
+++ b/apps/mobile/src/data/sidebar/sidebar-preferences.test.ts
@@ -33,6 +33,7 @@ describe("createSidebarPreferencesStore", () => {
       collapsedSectionKeys: [],
       collapsedMachineKeys: [],
       collapsedBuiltInSections: [],
+      sectionOrder: { project: [], manual: [], machine: [] },
     });
     const store = createSidebarPreferencesStore(
       memoryStorage({
@@ -41,6 +42,7 @@ describe("createSidebarPreferencesStore", () => {
         "bb.sidebar.collapsedProjects": '["p1","p1",7,"p2"]',
         "bb.sidebar.collapsedSections": '["pinned","bogus"]',
         "bb.sidebar.collapsedThreads": "not json",
+        "bb.sidebar.manualSectionOrder": '["pinned","sections","threads"]',
       }),
     );
     expect(store.getSnapshot()).toMatchObject({
@@ -49,7 +51,34 @@ describe("createSidebarPreferencesStore", () => {
       collapsedProjectIds: ["p1", "p2"],
       collapsedBuiltInSections: ["pinned"],
       collapsedThreadIds: [],
+      sectionOrder: {
+        project: [],
+        manual: ["pinned", "sections", "threads"],
+        machine: [],
+      },
     });
+  });
+
+  it("stores each mode's section order under the web key and drops an empty order", () => {
+    const storage = memoryStorage();
+    const store = createSidebarPreferencesStore(storage);
+    const listener = vi.fn();
+    store.subscribe(listener);
+    store.setSectionOrder("project", ["threads", "project:p1", "pinned"]);
+    expect(storage.getString("bb.sidebar.sectionOrder")).toBe(
+      '["threads","project:p1","pinned"]',
+    );
+    expect(store.getSnapshot().sectionOrder.project).toEqual([
+      "threads",
+      "project:p1",
+      "pinned",
+    ]);
+    // Same order again: no write, no notification.
+    store.setSectionOrder("project", ["threads", "project:p1", "pinned"]);
+    expect(listener).toHaveBeenCalledTimes(1);
+    store.setSectionOrder("project", []);
+    expect(storage.getString("bb.sidebar.sectionOrder")).toBeUndefined();
+    expect(store.getSnapshot().sectionOrder.manual).toEqual([]);
   });
 
   it("persists writes, notifies subscribers once per change, and removes defaults", () => {

--- a/apps/mobile/src/data/sidebar/sidebar-preferences.ts
+++ b/apps/mobile/src/data/sidebar/sidebar-preferences.ts
@@ -31,6 +31,12 @@ export interface SidebarPreferences {
   /** Host ids plus `NO_MACHINE_GROUP_KEY`. */
   collapsedMachineKeys: readonly string[];
   collapsedBuiltInSections: readonly CollapsibleSidebarSectionId[];
+  /**
+   * Top-level section order per organize mode, as the web stores it (raw
+   * section ids plus legacy anchors); `resolveSidebarSectionOrder` reconciles
+   * it with the live sections.
+   */
+  sectionOrder: Readonly<Record<SidebarOrganizeMode, readonly string[]>>;
 }
 
 export interface SidebarPreferencesStorage {
@@ -48,9 +54,19 @@ export interface SidebarPreferencesStore {
   toggleCollapsed(kind: SidebarCollapseKind, id: string): void;
   /** Ensure every id is expanded (used to reveal the selected thread). */
   expand(kind: SidebarCollapseKind, ids: Iterable<string>): void;
+  setSectionOrder(mode: SidebarOrganizeMode, order: readonly string[]): void;
 }
 
 export const SIDEBAR_ORGANIZE_STORAGE_KEY = "bb.sidebar.organizationMode";
+/** Web `sidebarCollapsedAtoms.ts`: one order per organize mode. */
+export const SIDEBAR_SECTION_ORDER_STORAGE_KEYS: Record<
+  SidebarOrganizeMode,
+  string
+> = {
+  project: "bb.sidebar.sectionOrder",
+  manual: "bb.sidebar.manualSectionOrder",
+  machine: "bb.sidebar.machineSectionOrder",
+};
 export const SIDEBAR_SORT_STORAGE_KEY = "bb.sidebar.chronologicalSort";
 const COLLAPSED_STORAGE_KEYS: Record<SidebarCollapseKind, string> = {
   project: "bb.sidebar.collapsedProjects",
@@ -189,6 +205,17 @@ function readPreferences(
     collapsedBuiltInSections: parseStringList(
       storage.getString(COLLAPSED_STORAGE_KEYS.builtIn),
     ).filter(isCollapsibleSidebarSectionId),
+    sectionOrder: {
+      project: parseStringList(
+        storage.getString(SIDEBAR_SECTION_ORDER_STORAGE_KEYS.project),
+      ),
+      manual: parseStringList(
+        storage.getString(SIDEBAR_SECTION_ORDER_STORAGE_KEYS.manual),
+      ),
+      machine: parseStringList(
+        storage.getString(SIDEBAR_SECTION_ORDER_STORAGE_KEYS.machine),
+      ),
+    },
   };
 }
 
@@ -264,6 +291,22 @@ export function createSidebarPreferencesStore(
       const next = current.filter((item) => !remove.has(item));
       if (next.length === current.length) return;
       writeList(kind, next);
+    },
+    setSectionOrder(mode, order) {
+      const current = snapshot.sectionOrder[mode];
+      if (
+        current.length === order.length &&
+        current.every((id, index) => id === order[index])
+      ) {
+        return;
+      }
+      const key = SIDEBAR_SECTION_ORDER_STORAGE_KEYS[mode];
+      if (order.length === 0) storage.remove(key);
+      else storage.set(key, JSON.stringify(order));
+      commit({
+        ...snapshot,
+        sectionOrder: { ...snapshot.sectionOrder, [mode]: [...order] },
+      });
     },
   };
 }

--- a/apps/mobile/src/data/sidebar/sidebar-section-order.test.ts
+++ b/apps/mobile/src/data/sidebar/sidebar-section-order.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { mergeHiddenSectionOrder } from "./sidebar-section-order";
+
+describe("mergeHiddenSectionOrder", () => {
+  it("applies the visible reorder while hidden sections keep their index", () => {
+    expect(
+      mergeHiddenSectionOrder(
+        ["project:a", "pinned", "project:b", "threads"],
+        ["threads", "project:b", "project:a"],
+      ),
+    ).toEqual(["threads", "pinned", "project:b", "project:a"]);
+  });
+
+  it("is the identity when nothing is hidden", () => {
+    expect(
+      mergeHiddenSectionOrder(
+        ["pinned", "project:a", "threads"],
+        ["project:a", "threads", "pinned"],
+      ),
+    ).toEqual(["project:a", "threads", "pinned"]);
+  });
+});

--- a/apps/mobile/src/data/sidebar/sidebar-section-order.ts
+++ b/apps/mobile/src/data/sidebar/sidebar-section-order.ts
@@ -1,0 +1,140 @@
+import {
+  normalizeSidebarSectionOrder,
+  type LegacySidebarEntityAnchor,
+  type SidebarSectionId,
+} from "@bb/client-core";
+import { useEffect, useMemo } from "react";
+import type { SidebarModel } from "./sidebar-model";
+import type {
+  SidebarOrganizeMode,
+  SidebarPreferences,
+} from "./sidebar-preferences";
+import type { SidebarPreferenceActions } from "./use-sidebar-preferences";
+
+/**
+ * Web `useSidebarModeSectionOrder`: the stored order of each mode can still
+ * hold the old aggregate token ("projects" / "sections" / "machines") that
+ * stood for every entity section at once.
+ */
+const LEGACY_ENTITY_ANCHOR: Record<
+  SidebarOrganizeMode,
+  LegacySidebarEntityAnchor
+> = {
+  project: "projects",
+  manual: "sections",
+  machine: "machines",
+};
+
+/**
+ * The top-level sections of a model in display order: the stored order
+ * reconciled with the live groups (new sections join after the last entity;
+ * Pinned stays in the order even while nothing is pinned so its placement
+ * survives). Pure; the hook below persists the result back like the web.
+ */
+export function resolveSidebarSectionOrder(
+  model: Pick<SidebarModel, "organize" | "groups">,
+  storedOrder: readonly string[],
+): SidebarSectionId[] {
+  return normalizeSidebarSectionOrder({
+    storedOrder,
+    entitySectionIds: model.groups
+      .map((group) => group.id)
+      .filter(
+        (id): id is Exclude<SidebarSectionId, "threads"> => id !== "threads",
+      ),
+    legacyEntityAnchor: LEGACY_ENTITY_ANCHOR[model.organize],
+    hasPinnedSection: true,
+    hasThreadsSection: true,
+  });
+}
+
+export interface SidebarSectionOrderEntry {
+  id: SidebarSectionId;
+  label: string;
+  threadCount: number;
+}
+
+/**
+ * The sections the user can reorder, labelled, in the given order. Pinned is
+ * listed only while something is pinned (it is hidden in the list too);
+ * `mergeHiddenSectionOrder` keeps its stored slot across a reorder.
+ */
+export function listSidebarSectionOrderEntries(
+  model: SidebarModel,
+  order: readonly SidebarSectionId[],
+): SidebarSectionOrderEntry[] {
+  const groupsById = new Map(model.groups.map((group) => [group.id, group]));
+  const entries: SidebarSectionOrderEntry[] = [];
+  for (const id of order) {
+    if (id === "pinned") {
+      if (model.pinned) {
+        entries.push({
+          id,
+          label: "Pinned",
+          threadCount: model.pinned.threads.length,
+        });
+      }
+      continue;
+    }
+    const group = groupsById.get(id);
+    if (!group) continue;
+    entries.push({ id, label: group.label, threadCount: group.threads.length });
+  }
+  return entries;
+}
+
+/**
+ * A reorder of the visible sections applied to the full order: sections the
+ * user could not see (hidden Pinned) stay at their previous index, so moving
+ * what is visible never silently relocates what is not.
+ */
+export function mergeHiddenSectionOrder(
+  fullOrder: readonly SidebarSectionId[],
+  visibleOrder: readonly SidebarSectionId[],
+): SidebarSectionId[] {
+  const visible = new Set(visibleOrder);
+  const merged: SidebarSectionId[] = [];
+  let nextVisible = 0;
+  for (const id of fullOrder) {
+    if (visible.has(id)) {
+      const replacement = visibleOrder[nextVisible];
+      nextVisible += 1;
+      if (replacement !== undefined) merged.push(replacement);
+    } else {
+      merged.push(id);
+    }
+  }
+  return merged;
+}
+
+function haveSameOrder(left: readonly string[], right: readonly string[]) {
+  return (
+    left.length === right.length &&
+    left.every((id, index) => id === right[index])
+  );
+}
+
+/**
+ * The resolved section order for the model's organize mode. Once the model is
+ * ready, the normalized order is written back so the stored value stops
+ * carrying legacy anchors and stale ids (web `usePersistedSidebarSectionOrder`).
+ */
+export function useSidebarSectionOrder(
+  model: SidebarModel,
+  preferences: SidebarPreferences,
+  actions: Pick<SidebarPreferenceActions, "setSectionOrder">,
+): SidebarSectionId[] {
+  const storedOrder = preferences.sectionOrder[model.organize];
+  const order = useMemo(
+    () => resolveSidebarSectionOrder(model, storedOrder),
+    [model, storedOrder],
+  );
+  const { setSectionOrder } = actions;
+  const organize = model.organize;
+  const isReady = model.isReady;
+  useEffect(() => {
+    if (!isReady || haveSameOrder(storedOrder, order)) return;
+    setSectionOrder(organize, order);
+  }, [isReady, order, organize, setSectionOrder, storedOrder]);
+  return order;
+}

--- a/apps/mobile/src/data/sidebar/use-sidebar-preferences.ts
+++ b/apps/mobile/src/data/sidebar/use-sidebar-preferences.ts
@@ -25,6 +25,7 @@ export interface SidebarPreferenceActions {
   setCollapsed(kind: SidebarCollapseKind, id: string, collapsed: boolean): void;
   toggleCollapsed(kind: SidebarCollapseKind, id: string): void;
   expand(kind: SidebarCollapseKind, ids: Iterable<string>): void;
+  setSectionOrder(mode: SidebarOrganizeMode, order: readonly string[]): void;
 }
 
 /** Persisted organize/sort/collapsed state plus the setters (stable identity). */
@@ -43,6 +44,7 @@ export function useSidebarPreferences(
       setCollapsed: store.setCollapsed,
       toggleCollapsed: store.toggleCollapsed,
       expand: store.expand,
+      setSectionOrder: store.setSectionOrder,
     }),
     [store],
   );

--- a/apps/mobile/src/screens/sidebar/SectionReorderList.tsx
+++ b/apps/mobile/src/screens/sidebar/SectionReorderList.tsx
@@ -1,0 +1,232 @@
+import type { SidebarSectionId } from "@bb/client-core";
+import { useCallback, useEffect, useMemo } from "react";
+import { View } from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+  type SharedValue,
+} from "react-native-reanimated";
+import type { SidebarSectionOrderEntry } from "@/data/sidebar";
+import { haptic } from "@/lib/haptics/haptics";
+import { useTheme } from "@/theme";
+import { Icon, Text } from "@/ui";
+
+/** Fixed so a row's slot is `index × height` and the drag math stays in a worklet. */
+export const SECTION_REORDER_ROW_HEIGHT = 48;
+const LIFT_SCALE = 1.02;
+const SPRING = { damping: 22, stiffness: 260, mass: 0.8 };
+
+export interface SectionReorderListProps {
+  entries: readonly SidebarSectionOrderEntry[];
+  /** Fires once per drop with the full new order. */
+  onReorder: (order: SidebarSectionId[]) => void;
+}
+
+/**
+ * Drag-to-reorder list of the top-level sidebar sections (web: dragging a
+ * section label in the sidebar). Rows live in absolute slots; the active row
+ * follows the finger and the others spring into their new slot as the finger
+ * crosses a row midpoint. The order commits on drop only, so the caller can
+ * persist without chatter. Touch the handle to lift at once; the rest of the
+ * row lifts after a short hold so taps still pass through.
+ */
+export function SectionReorderList({
+  entries,
+  onReorder,
+}: SectionReorderListProps) {
+  const ids = useMemo(() => entries.map((entry) => entry.id), [entries]);
+  // id -> slot index. Shared so every row's style reads it on the UI thread.
+  const slots = useSharedValue<Record<string, number>>(
+    Object.fromEntries(ids.map((id, index) => [id, index])),
+  );
+  const activeId = useSharedValue<string | null>(null);
+  const dragY = useSharedValue(0);
+
+  // New entries (or a reorder coming back from the store) reset the slots.
+  useEffect(() => {
+    slots.value = Object.fromEntries(ids.map((id, index) => [id, index]));
+  }, [ids, slots]);
+
+  const commit = useCallback(
+    (nextSlots: Record<string, number>) => {
+      const order = [...ids].sort(
+        (left, right) => (nextSlots[left] ?? 0) - (nextSlots[right] ?? 0),
+      );
+      if (order.some((id, index) => id !== ids[index])) onReorder(order);
+    },
+    [ids, onReorder],
+  );
+  const tick = useCallback(() => haptic("selection"), []);
+  const lift = useCallback(() => haptic("impact-light"), []);
+
+  return (
+    <View
+      style={{ height: ids.length * SECTION_REORDER_ROW_HEIGHT }}
+      testID="section-reorder-list"
+    >
+      {entries.map((entry) => (
+        <SectionReorderRow
+          key={entry.id}
+          entry={entry}
+          count={ids.length}
+          slots={slots}
+          activeId={activeId}
+          dragY={dragY}
+          onCommit={commit}
+          onTick={tick}
+          onLift={lift}
+        />
+      ))}
+    </View>
+  );
+}
+
+interface SectionReorderRowProps {
+  entry: SidebarSectionOrderEntry;
+  count: number;
+  slots: SharedValue<Record<string, number>>;
+  activeId: SharedValue<string | null>;
+  dragY: SharedValue<number>;
+  onCommit: (slots: Record<string, number>) => void;
+  onTick: () => void;
+  onLift: () => void;
+}
+
+function SectionReorderRow({
+  entry,
+  count,
+  slots,
+  activeId,
+  dragY,
+  onCommit,
+  onTick,
+  onLift,
+}: SectionReorderRowProps) {
+  const { tokens, radii } = useTheme();
+  const id = entry.id;
+  const startSlot = useSharedValue(0);
+
+  const moveTo = (nextIndex: number) => {
+    "worklet";
+    const current = slots.value[id] ?? 0;
+    if (nextIndex === current) return;
+    const next = { ...slots.value };
+    for (const [otherId, otherIndex] of Object.entries(next)) {
+      if (otherId === id) continue;
+      if (
+        current < nextIndex &&
+        otherIndex > current &&
+        otherIndex <= nextIndex
+      )
+        next[otherId] = otherIndex - 1;
+      else if (
+        current > nextIndex &&
+        otherIndex >= nextIndex &&
+        otherIndex < current
+      )
+        next[otherId] = otherIndex + 1;
+    }
+    next[id] = nextIndex;
+    slots.value = next;
+    runOnJS(onTick)();
+  };
+
+  const begin = () => {
+    "worklet";
+    startSlot.value = slots.value[id] ?? 0;
+    activeId.value = id;
+    dragY.value = startSlot.value * SECTION_REORDER_ROW_HEIGHT;
+    runOnJS(onLift)();
+  };
+  const update = (translationY: number) => {
+    "worklet";
+    const y = startSlot.value * SECTION_REORDER_ROW_HEIGHT + translationY;
+    dragY.value = y;
+    const target = Math.min(
+      count - 1,
+      Math.max(0, Math.round(y / SECTION_REORDER_ROW_HEIGHT)),
+    );
+    moveTo(target);
+  };
+  const finish = () => {
+    "worklet";
+    activeId.value = null;
+    runOnJS(onCommit)(slots.value);
+  };
+
+  // The handle lifts at once; the row body after a short hold, so a tap on
+  // the row body does nothing and a scroll gesture above us is not stolen.
+  const handlePan = Gesture.Pan()
+    .onBegin(begin)
+    .onUpdate((event) => update(event.translationY))
+    .onFinalize(finish);
+  const rowPan = Gesture.Pan()
+    .activateAfterLongPress(180)
+    // A touch that lands on the handle belongs to the handle pan alone.
+    .requireExternalGestureToFail(handlePan)
+    .onStart(begin)
+    .onUpdate((event) => update(event.translationY))
+    .onFinalize(() => {
+      if (activeId.value === id) finish();
+    });
+
+  const style = useAnimatedStyle(() => {
+    const isActive = activeId.value === id;
+    const slotY = (slots.value[id] ?? 0) * SECTION_REORDER_ROW_HEIGHT;
+    return {
+      transform: [
+        { translateY: isActive ? dragY.value : withSpring(slotY, SPRING) },
+        { scale: withTiming(isActive ? LIFT_SCALE : 1, { duration: 120 }) },
+      ],
+      zIndex: isActive ? 2 : 0,
+      shadowOpacity: withTiming(isActive ? 0.18 : 0, { duration: 120 }),
+      backgroundColor: isActive ? tokens.popover : "transparent",
+    };
+  });
+
+  return (
+    <GestureDetector gesture={rowPan}>
+      <Animated.View
+        accessibilityRole="button"
+        accessibilityLabel={`${entry.label}, ${entry.threadCount} threads`}
+        accessibilityHint="Drag to reorder"
+        className="absolute left-0 right-0 flex-row items-center pr-4"
+        style={[
+          {
+            height: SECTION_REORDER_ROW_HEIGHT,
+            borderRadius: radii.md,
+            shadowColor: "#000",
+            shadowRadius: 12,
+            shadowOffset: { width: 0, height: 6 },
+          },
+          style,
+        ]}
+        testID={`section-reorder-row-${id}`}
+      >
+        <GestureDetector gesture={handlePan}>
+          <View
+            className="h-full w-12 items-center justify-center"
+            accessibilityLabel={`Reorder ${entry.label}`}
+            testID={`section-reorder-handle-${id}`}
+          >
+            <Icon
+              name="DragDropVertical"
+              size={18}
+              color={tokens.subtleForeground}
+            />
+          </View>
+        </GestureDetector>
+        <Text variant="label" numberOfLines={1} className="min-w-0 flex-1">
+          {entry.label}
+        </Text>
+        <View className="rounded-sm bg-surface-selected px-1.5 py-px">
+          <Text variant="chrome">{entry.threadCount}</Text>
+        </View>
+      </Animated.View>
+    </GestureDetector>
+  );
+}

--- a/apps/mobile/src/screens/sidebar/SidebarActionsProvider.tsx
+++ b/apps/mobile/src/screens/sidebar/SidebarActionsProvider.tsx
@@ -1,4 +1,8 @@
-import { isThreadRead, type SidebarSectionDefinition } from "@bb/client-core";
+import {
+  isThreadRead,
+  type SidebarSectionDefinition,
+  type SidebarSectionId,
+} from "@bb/client-core";
 import type { ThreadListEntry } from "@bb/domain";
 import { BbHttpError } from "@bb/sdk/browser";
 import { useRouter } from "expo-router";
@@ -18,9 +22,15 @@ import {
   useRenameSection,
 } from "@/data/sections";
 import {
+  listSidebarSectionOrderEntries,
+  mergeHiddenSectionOrder,
   useSidebarBootstrap,
+  useSidebarModel,
   useSidebarPreferences,
+  useSidebarSectionOrder,
   type SidebarOrganizeMode,
+  type SidebarPreferenceActions,
+  type SidebarPreferences,
   type SidebarProject,
   type SidebarSortMode,
 } from "@/data/sidebar";
@@ -54,6 +64,7 @@ import {
   projectSettingsHref,
   threadHref,
 } from "../shell/hrefs";
+import { SectionReorderList } from "./SectionReorderList";
 import { SheetNameForm } from "./SheetNameForm";
 
 /**
@@ -86,13 +97,16 @@ type SheetState =
       moveThread: ThreadListEntry | null;
     }
   | { kind: "section-delete"; section: SidebarSectionDefinition }
-  | { kind: "display-options" };
+  | { kind: "display-options" }
+  | { kind: "section-reorder" };
 
 export interface SidebarActions {
   openThreadMenu(thread: ThreadListEntry): void;
   openProjectMenu(project: SidebarProject): void;
   openSectionMenu(section: SidebarSectionDefinition): void;
   openDisplayOptions(): void;
+  /** The drag-to-reorder list of top-level sections for the current mode. */
+  openSectionReorder(): void;
   openCreateSection(): void;
   /** Navigate to the thread detail. */
   openThread(thread: Pick<ThreadListEntry, "id">): void;
@@ -345,6 +359,7 @@ export function SidebarActionsProvider({
       openProjectMenu: (project) => present({ kind: "project-menu", project }),
       openSectionMenu: (section) => present({ kind: "section-menu", section }),
       openDisplayOptions: () => present({ kind: "display-options" }),
+      openSectionReorder: () => present({ kind: "section-reorder" }),
       openCreateSection: () =>
         present({ kind: "section-create", moveThread: null }),
       openThread: (thread) => navigate(threadHref(thread.id)),
@@ -638,6 +653,12 @@ export function SidebarActionsProvider({
             },
           },
           {
+            key: "reorder",
+            label: "Reorder sections",
+            icon: "ArrowUpDown",
+            onPress: () => setState({ kind: "section-reorder" }),
+          },
+          {
             key: "remove",
             label: "Remove",
             icon: "Trash2",
@@ -708,6 +729,12 @@ export function SidebarActionsProvider({
             label: "Rename",
             icon: "Edit",
             onPress: () => setState({ kind: "section-rename", section }),
+          },
+          {
+            key: "reorder",
+            label: "Reorder sections",
+            icon: "ArrowUpDown",
+            onPress: () => setState({ kind: "section-reorder" }),
           },
           {
             key: "delete",
@@ -858,10 +885,36 @@ export function SidebarActionsProvider({
               }
               testID="sidebar-new-section"
             />
+            <ListRow
+              title="Reorder sections…"
+              leading="ArrowUpDown"
+              onPress={() => setState({ kind: "section-reorder" })}
+              testID="sidebar-reorder-sections"
+            />
             <CenteredRow
               label="Done"
               onPress={dismiss}
               testID="sidebar-display-done"
+            />
+          </>
+        );
+      case "section-reorder":
+        return (
+          <>
+            <SheetHeader
+              title="Reorder sections"
+              message="Drag a section to move it. The order is saved for this organize mode."
+            />
+            <SectionReorderSheetBody
+              organize={preferences.organize}
+              sort={preferences.sort}
+              preferences={preferences}
+              preferenceActions={preferenceActions}
+            />
+            <CenteredRow
+              label="Done"
+              onPress={dismiss}
+              testID="sidebar-reorder-done"
             />
           </>
         );
@@ -873,7 +926,10 @@ export function SidebarActionsProvider({
       {children}
       <Sheet
         controller={sheet}
-        layout="scroll"
+        // The reorder list owns vertical drags, so it gets a plain view body
+        // and the sheet stops following the finger.
+        layout={state?.kind === "section-reorder" ? "view" : "scroll"}
+        enableContentPanningGesture={state?.kind !== "section-reorder"}
         deferContent={false}
         onDismiss={() => {
           setState(null);
@@ -884,5 +940,42 @@ export function SidebarActionsProvider({
         {renderContent()}
       </Sheet>
     </SidebarActionsContext.Provider>
+  );
+}
+
+/**
+ * Mounted only while the reorder sheet is open: builds the model for the
+ * current mode to label the sections, and writes each drop back to the
+ * per-mode order.
+ */
+function SectionReorderSheetBody({
+  organize,
+  sort,
+  preferences,
+  preferenceActions,
+}: {
+  organize: SidebarOrganizeMode;
+  sort: SidebarSortMode;
+  preferences: SidebarPreferences;
+  preferenceActions: SidebarPreferenceActions;
+}) {
+  const { model } = useSidebarModel({ organize, sort });
+  const order = useSidebarSectionOrder(model, preferences, preferenceActions);
+  const entries = useMemo(
+    () => listSidebarSectionOrderEntries(model, order),
+    [model, order],
+  );
+  const onReorder = useCallback(
+    (visibleOrder: SidebarSectionId[]) =>
+      preferenceActions.setSectionOrder(
+        organize,
+        mergeHiddenSectionOrder(order, visibleOrder),
+      ),
+    [order, organize, preferenceActions],
+  );
+  return (
+    <View className="py-2">
+      <SectionReorderList entries={entries} onReorder={onReorder} />
+    </View>
   );
 }

--- a/apps/mobile/src/screens/sidebar/SidebarRows.tsx
+++ b/apps/mobile/src/screens/sidebar/SidebarRows.tsx
@@ -13,22 +13,36 @@ import {
 } from "./sidebar-list-rows";
 import { ThreadStatusGlyph } from "./ThreadStatusGlyph";
 
-/** Web `getSidebarThreadRowPaddingLeft`: base + a step per nesting level. */
-const ROW_BASE_PADDING = 12;
-const ROW_DEPTH_STEP = 18;
+/**
+ * One left text edge per depth, shared by headers, thread rows, environment
+ * rows, and empty rows (web `getSidebarThreadRowPaddingLeft`: base + a step
+ * per nesting level). Nothing leads the text: the disclosure chevron sits
+ * after the label, so a parent row and a leaf row start at the same x.
+ */
+const ROW_BASE_PADDING = 16;
+const ROW_DEPTH_STEP = 24;
+/** Right inset of every row; the trailing slot ends here. */
+const ROW_PADDING_RIGHT = 8;
 const ROW_MIN_HEIGHT = 44;
 const HEADER_MIN_HEIGHT = 36;
+/**
+ * Distance from a row's text edge to the center of the hairline that ties
+ * its children to it (web `SIDEBAR_THREAD_ROW_GLYPH_CENTER_OFFSET_PX`).
+ */
+const GROUP_LINE_OFFSET = 8;
+/** The single trailing column: status glyph, or the header "+" action. */
+const TRAILING_SLOT_CLASS = "h-9 w-9 items-center justify-center";
 
-function rowPaddingLeft(depth: number): number {
+export function rowPaddingLeft(depth: number): number {
   return ROW_BASE_PADDING + depth * ROW_DEPTH_STEP;
 }
 
 function DisclosureChevron({
   collapsed,
-  size = 16,
+  size,
 }: {
   collapsed: boolean;
-  size?: number;
+  size: number;
 }) {
   const { tokens } = useTheme();
   return (
@@ -48,6 +62,22 @@ function CountChip({ count }: { count: number }) {
   );
 }
 
+/**
+ * Hairline under the parent's text edge that runs the height of a nested row
+ * (web `SIDEBAR_PROJECT_GROUP_LINE_CLASS`). Rows are flat list items, so each
+ * nested row paints its own segment; contiguous rows read as one line.
+ */
+function GroupLine({ depth }: { depth: number }) {
+  if (depth === 0) return null;
+  return (
+    <View
+      pointerEvents="none"
+      className="absolute bottom-0 top-0 w-px bg-border-hairline opacity-70"
+      style={{ left: rowPaddingLeft(depth - 1) + GROUP_LINE_OFFSET }}
+    />
+  );
+}
+
 export type SidebarRowSubtitle =
   | { kind: "project"; name: string }
   | { kind: "snippet"; text: string };
@@ -55,9 +85,9 @@ export type SidebarRowSubtitle =
 export interface SidebarThreadRowViewProps {
   row: SidebarThreadRow;
   /**
-   * Second line: the project name outside project mode (with a folder icon
-   * so it reads as a project, not a second title), a search snippet, or
-   * nothing.
+   * Optional second line. The home list passes null (one line per row, like
+   * the web sidebar); search passes a snippet or the project name, and the
+   * archive passes the project name.
    */
   subtitle: SidebarRowSubtitle | null;
   onPress: (row: SidebarThreadRow) => void;
@@ -84,36 +114,40 @@ export const SidebarThreadRowView = memo(function SidebarThreadRowView({
       onPress={() => onPress(row)}
       onLongPress={() => onLongPress(row)}
       delayLongPress={350}
-      className="flex-row items-center gap-2 pr-3 active:bg-state-hover"
+      className="flex-row items-center gap-1 active:bg-state-hover"
       style={{
         minHeight: ROW_MIN_HEIGHT,
         paddingLeft: rowPaddingLeft(row.depth),
+        paddingRight: ROW_PADDING_RIGHT,
       }}
       testID={`thread-row-${thread.id}`}
     >
-      {row.childCount > 0 ? (
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel={
-            row.collapsed ? "Show child threads" : "Hide child threads"
-          }
-          hitSlop={8}
-          onPress={() => onToggleCollapsed(thread.id)}
-          className="h-8 w-6 items-center justify-center rounded-sm active:bg-state-active"
-          testID={`thread-row-toggle-${thread.id}`}
-        >
-          <DisclosureChevron collapsed={row.collapsed} />
-        </Pressable>
-      ) : null}
+      <GroupLine depth={row.depth} />
       <View className="min-w-0 flex-1 py-1.5">
-        <Text
-          variant="body"
-          weight={unread ? "medium" : undefined}
-          numberOfLines={1}
-          className={cn(!unread && "text-foreground/90")}
-        >
-          {title}
-        </Text>
+        <View className="flex-row items-center gap-1">
+          <Text
+            variant="body"
+            weight={unread ? "medium" : undefined}
+            numberOfLines={1}
+            className={cn("min-w-0 shrink", !unread && "text-foreground/90")}
+          >
+            {title}
+          </Text>
+          {row.childCount > 0 ? (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={
+                row.collapsed ? "Show child threads" : "Hide child threads"
+              }
+              hitSlop={10}
+              onPress={() => onToggleCollapsed(thread.id)}
+              className="h-6 w-6 items-center justify-center rounded-sm active:bg-state-active"
+              testID={`thread-row-toggle-${thread.id}`}
+            >
+              <DisclosureChevron collapsed={row.collapsed} size={14} />
+            </Pressable>
+          ) : null}
+        </View>
         {subtitle?.kind === "project" ? (
           <View className="flex-row items-center gap-1">
             <Icon name="Folder" size={12} color={tokens.mutedForeground} />
@@ -131,7 +165,7 @@ export const SidebarThreadRowView = memo(function SidebarThreadRowView({
           </Text>
         ) : null}
       </View>
-      <View className="w-5 items-center justify-center">
+      <View className={TRAILING_SLOT_CLASS}>
         <ThreadStatusGlyph kind={row.indicator} />
       </View>
     </Pressable>
@@ -170,8 +204,6 @@ export const SidebarHeaderRowView = memo(function SidebarHeaderRowView({
         getCollapsedActivityIndicatorState(row.activity),
       )
     : "none";
-  const isBuiltIn =
-    row.target.kind === "pinned" || row.target.kind === "threads";
   const testIdSuffix =
     row.target.kind === "project"
       ? row.target.project.id
@@ -186,30 +218,35 @@ export const SidebarHeaderRowView = memo(function SidebarHeaderRowView({
       accessibilityLabel={row.label}
       accessibilityState={{ expanded: !row.collapsed }}
       onPress={() => onToggleCollapsed(row)}
-      onLongPress={isBuiltIn ? undefined : () => onLongPress(row)}
+      onLongPress={() => onLongPress(row)}
       delayLongPress={350}
-      className="flex-row items-center gap-1.5 pr-1 active:bg-state-hover"
+      className="flex-row items-center gap-1 active:bg-state-hover"
       style={{
         minHeight: HEADER_MIN_HEIGHT,
-        paddingLeft: rowPaddingLeft(row.depth) - 4,
+        paddingLeft: rowPaddingLeft(row.depth),
+        paddingRight: ROW_PADDING_RIGHT,
         marginTop: row.depth === 0 ? 6 : 0,
       }}
       testID={`sidebar-header-${testIdSuffix}`}
     >
-      <DisclosureChevron collapsed={row.collapsed} size={14} />
+      <GroupLine depth={row.depth} />
       {row.target.kind === "machine" ? (
         <Icon name="Laptop" size={14} color={tokens.subtleForeground} />
       ) : row.target.kind === "pinned" ? (
         <Icon name="Pin" size={14} color={tokens.subtleForeground} />
       ) : null}
-      <Text variant="sectionLabel" numberOfLines={1} className="min-w-0 flex-1">
+      <Text variant="sectionLabel" numberOfLines={1} className="min-w-0 shrink">
         {row.label}
       </Text>
+      <View className="h-6 w-6 items-center justify-center">
+        <DisclosureChevron collapsed={row.collapsed} size={12} />
+      </View>
+      <View className="flex-1" />
       {row.collapsed && row.threadCount > 0 ? (
         <CountChip count={row.threadCount} />
       ) : null}
       {indicator !== "none" ? (
-        <View className="w-5 items-center justify-center">
+        <View className={TRAILING_SLOT_CLASS}>
           <ThreadStatusGlyph kind={indicator} />
         </View>
       ) : null}
@@ -219,7 +256,10 @@ export const SidebarHeaderRowView = memo(function SidebarHeaderRowView({
           accessibilityLabel={`New thread in ${row.label}`}
           hitSlop={6}
           onPress={() => onCreateThread(row)}
-          className="h-8 w-8 items-center justify-center rounded-md active:bg-state-active"
+          className={cn(
+            TRAILING_SLOT_CLASS,
+            "rounded-md active:bg-state-active",
+          )}
           testID={`sidebar-header-new-thread-${testIdSuffix}`}
         >
           <Icon
@@ -255,26 +295,31 @@ export const SidebarEnvironmentRowView = memo(
         accessibilityLabel={row.label}
         accessibilityState={{ expanded: !row.collapsed }}
         onPress={() => onToggleCollapsed(row.environmentId)}
-        className="flex-row items-center gap-2 pr-3 active:bg-state-hover"
+        className="flex-row items-center gap-1 active:bg-state-hover"
         style={{
           minHeight: HEADER_MIN_HEIGHT,
           paddingLeft: rowPaddingLeft(row.depth),
+          paddingRight: ROW_PADDING_RIGHT,
         }}
         testID={`environment-row-${row.environmentId}`}
       >
-        <DisclosureChevron collapsed={row.collapsed} size={14} />
-        <Icon name="GitBranch" size={16} color={tokens.subtleForeground} />
+        <GroupLine depth={row.depth} />
+        <Icon name="GitBranch" size={14} color={tokens.subtleForeground} />
         <Text
           variant="label"
           tone="muted"
           numberOfLines={1}
-          className="min-w-0 flex-1"
+          className="min-w-0 shrink"
         >
           {row.label}
         </Text>
+        <View className="h-6 w-6 items-center justify-center">
+          <DisclosureChevron collapsed={row.collapsed} size={12} />
+        </View>
+        <View className="flex-1" />
         {row.collapsed ? <CountChip count={row.threadCount} /> : null}
         {indicator !== "none" ? (
-          <View className="w-5 items-center justify-center">
+          <View className={TRAILING_SLOT_CLASS}>
             <ThreadStatusGlyph kind={indicator} />
           </View>
         ) : null}
@@ -286,12 +331,14 @@ export const SidebarEnvironmentRowView = memo(
 export function SidebarEmptyRowView({ row }: { row: SidebarEmptyRow }) {
   return (
     <View
-      className="justify-center pr-3"
+      className="justify-center"
       style={{
         minHeight: HEADER_MIN_HEIGHT,
-        paddingLeft: rowPaddingLeft(row.depth) + 6,
+        paddingLeft: rowPaddingLeft(row.depth),
+        paddingRight: ROW_PADDING_RIGHT,
       }}
     >
+      <GroupLine depth={row.depth} />
       <Text variant="caption" numberOfLines={1}>
         {row.label}
       </Text>

--- a/apps/mobile/src/screens/sidebar/SidebarThreadList.tsx
+++ b/apps/mobile/src/screens/sidebar/SidebarThreadList.tsx
@@ -8,6 +8,7 @@ import {
   useSidebarCollapsedSets,
   useSidebarModel,
   useSidebarPreferences,
+  useSidebarSectionOrder,
 } from "@/data/sidebar";
 import { Button, EmptyStatePanel, Skeleton, Text } from "@/ui";
 import { useSidebarActions } from "./SidebarActionsProvider";
@@ -15,7 +16,6 @@ import {
   SidebarEmptyRowView,
   SidebarEnvironmentRowView,
   SidebarHeaderRowView,
-  projectSubtitle,
   SidebarThreadRowView,
 } from "./SidebarRows";
 import {
@@ -80,9 +80,14 @@ export function SidebarThreadList({
   const actions = useSidebarActions();
   const [refreshing, setRefreshing] = useState(false);
 
+  const sectionOrder = useSidebarSectionOrder(
+    model,
+    preferences,
+    preferenceActions,
+  );
   const rows = useMemo(
-    () => buildSidebarListRows({ model, collapsed }),
-    [model, collapsed],
+    () => buildSidebarListRows({ model, collapsed, sectionOrder }),
+    [model, collapsed, sectionOrder],
   );
 
   const bootstrapRefetch = bootstrap.refetch;
@@ -120,10 +125,19 @@ export function SidebarThreadList({
   );
   const onHeaderLongPress = useCallback(
     (row: SidebarHeaderRow) => {
-      if (row.target.kind === "project")
-        actions.openProjectMenu(row.target.project);
-      else if (row.target.kind === "section") {
-        actions.openSectionMenu(row.target.section);
+      switch (row.target.kind) {
+        case "project":
+          actions.openProjectMenu(row.target.project);
+          return;
+        case "section":
+          actions.openSectionMenu(row.target.section);
+          return;
+        case "pinned":
+        case "threads":
+        case "machine":
+          // No menu of their own: a long-press goes straight to reordering.
+          actions.openSectionReorder();
+          return;
       }
     },
     [actions],
@@ -148,9 +162,6 @@ export function SidebarThreadList({
     [actions],
   );
 
-  const organize = preferences.organize;
-  const projectNamesById = model.projectNamesById;
-
   const renderItem = useCallback(
     ({ item }: ListRenderItemInfo<SidebarListRow>) => {
       switch (item.type) {
@@ -167,26 +178,18 @@ export function SidebarThreadList({
               }
             />
           );
-        case "thread": {
-          const { thread } = item;
-          const showProject =
-            (item.groupProjectId === null || organize !== "project") &&
-            thread.projectId !== PERSONAL_PROJECT_ID &&
-            item.depth === 0;
+        case "thread":
+          // One line per row, like the web sidebar: the project name lives
+          // on the group header, not under every thread.
           return (
             <SidebarThreadRowView
               row={item}
-              subtitle={projectSubtitle(
-                showProject
-                  ? (projectNamesById.get(thread.projectId) ?? null)
-                  : null,
-              )}
+              subtitle={null}
               onPress={onThreadPress}
               onLongPress={onThreadLongPress}
               onToggleCollapsed={onToggleThread}
             />
           );
-        }
         case "environment":
           return (
             <SidebarEnvironmentRowView
@@ -206,8 +209,6 @@ export function SidebarThreadList({
       onToggleEnvironment,
       onToggleHeader,
       onToggleThread,
-      organize,
-      projectNamesById,
     ],
   );
 
@@ -253,7 +254,6 @@ export function SidebarThreadList({
       keyExtractor={keyExtractor}
       getItemType={getItemType}
       renderItem={renderItem}
-      extraData={{ organize }}
       maintainVisibleContentPosition={DISABLE_MAINTAIN_POSITION}
       refreshing={refreshing}
       onRefresh={onRefresh}

--- a/apps/mobile/src/screens/sidebar/sidebar-list-rows.test.ts
+++ b/apps/mobile/src/screens/sidebar/sidebar-list-rows.test.ts
@@ -1,6 +1,8 @@
 import { NO_MACHINE_GROUP_KEY } from "@bb/client-core";
+import { PERSONAL_PROJECT_ID } from "@bb/domain";
 import { describe, expect, it } from "vitest";
 import { buildSidebarModel } from "@/data/sidebar/sidebar-model";
+import { resolveSidebarSectionOrder } from "@/data/sidebar/sidebar-section-order";
 import {
   host,
   project,
@@ -8,12 +10,25 @@ import {
   threadListEntry,
 } from "@/data/test/fixtures";
 import {
-  buildSidebarListRows,
+  buildSidebarListRows as buildRows,
   getHeaderCollapseTarget,
   resolveThreadRowIndicator,
   type SidebarCollapsedState,
   type SidebarListRow,
 } from "./sidebar-list-rows";
+
+type BuildRowsArgs = Parameters<typeof buildRows>[0];
+
+/** The rows in the model's natural section order (no stored order). */
+function buildSidebarListRows(
+  args: Omit<BuildRowsArgs, "sectionOrder"> &
+    Partial<Pick<BuildRowsArgs, "sectionOrder">>,
+): SidebarListRow[] {
+  return buildRows({
+    sectionOrder: resolveSidebarSectionOrder(args.model, []),
+    ...args,
+  });
+}
 
 function collapsedState(
   overrides: Partial<SidebarCollapsedState> = {},
@@ -136,7 +151,6 @@ describe("buildSidebarListRows", () => {
     const worktreeThread = rows.find((row) => row.key === "thread:t_wt_a");
     expect(worktreeThread).toMatchObject({
       depth: 1,
-      groupProjectId: "proj_1",
     });
     // The personal "Threads" bucket is empty and there are other groups: hidden.
     expect(rowKeys(rows)).not.toContain("header:threads");
@@ -366,5 +380,63 @@ describe("resolveThreadRowIndicator", () => {
         childActivity,
       }),
     ).toBe("runtime");
+  });
+});
+
+describe("buildSidebarListRows section order", () => {
+  it("emits top-level sections in the stored order and keeps unknown ones after", () => {
+    const model = buildSidebarModel({
+      bootstrap: sidebarBootstrap({
+        projects: [
+          project({
+            id: "proj_1",
+            name: "One",
+            threads: [threadListEntry({ id: "t_pinned", pinnedAt: 100 })],
+          }),
+          project({
+            id: "proj_2",
+            name: "Two",
+            threads: [threadListEntry({ id: "t_two", projectId: "proj_2" })],
+          }),
+        ],
+        personalProject: project({
+          id: PERSONAL_PROJECT_ID,
+          kind: "personal",
+          name: "Personal",
+          threads: [
+            threadListEntry({
+              id: "t_personal",
+              projectId: PERSONAL_PROJECT_ID,
+            }),
+          ],
+        }),
+      }),
+      hosts: [],
+      organize: "project",
+      sort: "updated",
+    });
+    const headers = (order: readonly string[]) =>
+      buildRows({
+        model,
+        collapsed: collapsedState(),
+        sectionOrder: resolveSidebarSectionOrder(model, order),
+      })
+        .filter((row) => row.type === "header")
+        .map((row) => row.key);
+    // Threads moved above the projects; Pinned stays first by default.
+    expect(headers(["threads", "project:proj_2", "project:proj_1"])).toEqual([
+      "header:pinned",
+      "header:threads",
+      "header:project:proj_2",
+      "header:project:proj_1",
+    ]);
+    // Pinned can move too, and a section the order never named joins right
+    // after the last entity section the order does name.
+    expect(headers(["project:proj_2", "pinned", "threads"])).toEqual([
+      "header:project:proj_2",
+      "header:project:proj_1",
+      "header:pinned",
+      "header:threads",
+    ]);
   });
 });

--- a/apps/mobile/src/screens/sidebar/sidebar-list-rows.ts
+++ b/apps/mobile/src/screens/sidebar/sidebar-list-rows.ts
@@ -12,6 +12,7 @@ import {
   type ProjectThreadItem,
   type ProjectThreadNode,
   type SidebarSectionDefinition,
+  type SidebarSectionId,
   type ThreadListIndicatorKind,
   type ThreadListIndicatorState,
 } from "@bb/client-core";
@@ -71,8 +72,6 @@ export interface SidebarThreadRow {
   collapsed: boolean;
   /** The single trailing status glyph for this row (own state + hidden children). */
   indicator: ThreadListIndicatorKind;
-  /** Project the row renders under in project mode; null in other modes. */
-  groupProjectId: string | null;
 }
 
 export interface SidebarEnvironmentRow {
@@ -204,7 +203,6 @@ export function resolveThreadRowIndicator({
 
 interface FlattenContext {
   collapsed: SidebarCollapsedState;
-  groupProjectId: string | null;
   rows: SidebarListRow[];
 }
 
@@ -228,7 +226,6 @@ function pushThreadNode(
       hasHiddenChildren: collapsed,
       childActivity: node.stats.childActivity,
     }),
-    groupProjectId: context.groupProjectId,
   });
   if (childCount > 0 && !collapsed) {
     pushItems(node.children, depth + 1, context);
@@ -334,6 +331,11 @@ function headerTarget(group: SidebarGroup): SidebarHeaderTarget {
 export interface BuildSidebarListRowsArgs {
   model: SidebarModel;
   collapsed: SidebarCollapsedState;
+  /**
+   * Top-level section order (`resolveSidebarSectionOrder`). Sections the
+   * order does not name keep the model's order after the named ones.
+   */
+  sectionOrder: readonly SidebarSectionId[];
   /** Copy under an expanded project with no threads. */
   emptyProjectLabel?: string;
 }
@@ -342,76 +344,107 @@ export interface BuildSidebarListRowsArgs {
 export function buildSidebarListRows({
   model,
   collapsed,
+  sectionOrder,
   emptyProjectLabel = "No threads yet",
 }: BuildSidebarListRowsArgs): SidebarListRow[] {
   const rows: SidebarListRow[] = [];
   if (!model.isReady) return rows;
 
-  if (model.pinned) {
-    const pinnedCollapsed = collapsed.builtInSections.has(PINNED_SECTION_KEY);
-    rows.push({
-      type: "header",
-      key: "header:pinned",
-      label: "Pinned",
-      target: { kind: "pinned" },
-      depth: 0,
-      collapsed: pinnedCollapsed,
-      threadCount: model.pinned.threads.length,
-      activity: pinnedCollapsed
-        ? model.pinned.activity
-        : NO_COLLAPSED_CHILD_ACTIVITY,
-    });
-    if (!pinnedCollapsed) {
-      const context: FlattenContext = {
-        collapsed,
-        groupProjectId: null,
-        rows,
-      };
-      for (const node of model.pinned.rootNodes) {
-        pushThreadNode(node, 0, context);
-      }
-    }
+  for (const sectionId of orderTopLevelSections(model, sectionOrder)) {
+    if (sectionId === "pinned") pushPinnedRows(model, collapsed, rows);
+    else pushGroupRows(model, sectionId, collapsed, emptyProjectLabel, rows);
   }
-
-  for (const group of model.groups) {
-    // The built-in trailing bucket only earns a header when it has rows, except
-    // when it is the only thing the sidebar could show.
-    if (
-      group.kind === "threads" &&
-      group.items.length === 0 &&
-      (model.groups.length > 1 || model.pinned !== null)
-    ) {
-      continue;
-    }
-    const isCollapsed = isGroupCollapsed(group, collapsed);
-    rows.push({
-      type: "header",
-      key: `header:${group.id}`,
-      label: group.label,
-      target: headerTarget(group),
-      depth: 0,
-      collapsed: isCollapsed,
-      threadCount: group.threads.length,
-      activity: isCollapsed ? group.activity : NO_COLLAPSED_CHILD_ACTIVITY,
-    });
-    if (isCollapsed) continue;
-    if (group.items.length === 0) {
-      rows.push({
-        type: "empty",
-        key: `empty:${group.id}`,
-        label: emptyProjectLabel,
-        depth: 0,
-      });
-      continue;
-    }
-    pushItems(group.items, 0, {
-      collapsed,
-      groupProjectId: group.kind === "project" ? group.project.id : null,
-      rows,
-    });
-  }
-
   return rows;
+}
+
+/** Pinned (when shown) plus every group, sorted by the section order. */
+function orderTopLevelSections(
+  model: SidebarModel,
+  sectionOrder: readonly SidebarSectionId[],
+): SidebarSectionId[] {
+  const present: SidebarSectionId[] = [
+    ...(model.pinned ? (["pinned"] as const) : []),
+    ...model.groups.map((group) => group.id),
+  ];
+  const rank = new Map(sectionOrder.map((id, index) => [id, index]));
+  return present
+    .map((id, index) => ({ id, index }))
+    .sort((left, right) => {
+      const leftRank = rank.get(left.id) ?? Number.POSITIVE_INFINITY;
+      const rightRank = rank.get(right.id) ?? Number.POSITIVE_INFINITY;
+      return leftRank === rightRank
+        ? left.index - right.index
+        : leftRank - rightRank;
+    })
+    .map((entry) => entry.id);
+}
+
+function pushPinnedRows(
+  model: SidebarModel,
+  collapsed: SidebarCollapsedState,
+  rows: SidebarListRow[],
+): void {
+  if (!model.pinned) return;
+  const pinnedCollapsed = collapsed.builtInSections.has(PINNED_SECTION_KEY);
+  rows.push({
+    type: "header",
+    key: "header:pinned",
+    label: "Pinned",
+    target: { kind: "pinned" },
+    depth: 0,
+    collapsed: pinnedCollapsed,
+    threadCount: model.pinned.threads.length,
+    activity: pinnedCollapsed
+      ? model.pinned.activity
+      : NO_COLLAPSED_CHILD_ACTIVITY,
+  });
+  if (pinnedCollapsed) return;
+  const context: FlattenContext = { collapsed, rows };
+  for (const node of model.pinned.rootNodes) {
+    pushThreadNode(node, 0, context);
+  }
+}
+
+function pushGroupRows(
+  model: SidebarModel,
+  sectionId: SidebarSectionId,
+  collapsed: SidebarCollapsedState,
+  emptyProjectLabel: string,
+  rows: SidebarListRow[],
+): void {
+  const group = model.groups.find((candidate) => candidate.id === sectionId);
+  if (!group) return;
+  // The built-in trailing bucket only earns a header when it has rows, except
+  // when it is the only thing the sidebar could show.
+  if (
+    group.kind === "threads" &&
+    group.items.length === 0 &&
+    (model.groups.length > 1 || model.pinned !== null)
+  ) {
+    return;
+  }
+  const isCollapsed = isGroupCollapsed(group, collapsed);
+  rows.push({
+    type: "header",
+    key: `header:${group.id}`,
+    label: group.label,
+    target: headerTarget(group),
+    depth: 0,
+    collapsed: isCollapsed,
+    threadCount: group.threads.length,
+    activity: isCollapsed ? group.activity : NO_COLLAPSED_CHILD_ACTIVITY,
+  });
+  if (isCollapsed) return;
+  if (group.items.length === 0) {
+    rows.push({
+      type: "empty",
+      key: `empty:${group.id}`,
+      label: emptyProjectLabel,
+      depth: 0,
+    });
+    return;
+  }
+  pushItems(group.items, 0, { collapsed, rows });
 }
 
 /** Collapse toggle target for a header row (kind + persisted id). */

--- a/apps/mobile/src/screens/threads/ArchivedThreadsScreen.tsx
+++ b/apps/mobile/src/screens/threads/ArchivedThreadsScreen.tsx
@@ -52,7 +52,6 @@ function toThreadRow(thread: ThreadListEntry): SidebarThreadRow {
       hasHiddenChildren: false,
       childActivity: NO_COLLAPSED_CHILD_ACTIVITY,
     }),
-    groupProjectId: null,
   };
 }
 

--- a/apps/mobile/src/screens/threads/ThreadSearchScreen.tsx
+++ b/apps/mobile/src/screens/threads/ThreadSearchScreen.tsx
@@ -51,7 +51,6 @@ function toThreadRow(thread: ThreadListEntry): SidebarThreadRow {
       hasHiddenChildren: false,
       childActivity: NO_COLLAPSED_CHILD_ACTIVITY,
     }),
-    groupProjectId: null,
   };
 }
 

--- a/apps/mobile/src/ui/Sheet.tsx
+++ b/apps/mobile/src/ui/Sheet.tsx
@@ -79,6 +79,7 @@ export interface SheetProps extends Pick<
   | "onDismiss"
   | "name"
   | "stackBehavior"
+  | "enableContentPanningGesture"
 > {
   controller: SheetController;
   children: ReactNode;
@@ -117,6 +118,7 @@ export function Sheet({
   onOpenChange,
   name,
   stackBehavior,
+  enableContentPanningGesture,
   deferContent = true,
 }: SheetProps) {
   const modalRef = useRef<BottomSheetModal>(null);
@@ -203,6 +205,9 @@ export function Sheet({
       enableDynamicSizing={dynamic}
       maxDynamicContentSize={maxDynamicContentSize}
       enablePanDownToClose
+      // Off while the body hosts its own vertical drag (reorder lists), so
+      // the sheet does not follow the finger; the handle still closes it.
+      enableContentPanningGesture={enableContentPanningGesture}
       // The library marks the content container as one accessibility element
       // ("Bottom Sheet"), which hides every row from VoiceOver and from UI
       // automation. Expose the children instead.


### PR DESCRIPTION
## What was wrong

The mobile home thread list did not line up. It had four left text edges (section labels, parent threads pushed by a leading chevron, child threads, leaf threads), 20px section labels that outweighed the 17px titles, a count chip and "+" action in different columns from the status glyph, no tree line under nested rows, and a project line under every thread. Sections also had no order control: the web sidebar lets the user drag sections, the mobile app did not.

## What changed

- `apps/mobile/src/screens/sidebar/SidebarRows.tsx`: rows follow the web sidebar rules. One text edge per depth (`16 + 24 × depth`, web `getSidebarThreadRowPaddingLeft`), the disclosure chevron after the label (header 12px, thread 14px), a hairline group line under nested rows (web `SIDEBAR_PROJECT_GROUP_LINE_CLASS`), one 36px trailing slot for the status glyph and the header "+", 12px uppercase `sectionLabel` headers.
- `SidebarThreadList.tsx`: the home list passes no subtitle (one line per row). Search and Archive keep theirs. The dead `groupProjectId` row field is removed.
- Section reorder:
  - `data/sidebar/sidebar-preferences.ts`: `sectionOrder` per organize mode under the web keys (`bb.sidebar.sectionOrder`, `bb.sidebar.manualSectionOrder`, `bb.sidebar.machineSectionOrder`) plus `setSectionOrder`.
  - `data/sidebar/sidebar-section-order.ts`: `resolveSidebarSectionOrder` (client-core `normalizeSidebarSectionOrder`), `useSidebarSectionOrder` (writes the normalized order back like the web), `listSidebarSectionOrderEntries`, `mergeHiddenSectionOrder`.
  - `sidebar-list-rows.ts`: `buildSidebarListRows` takes `sectionOrder` and emits Pinned and groups in that order.
  - `SectionReorderList.tsx`: drag-to-reorder list (reanimated + gesture-handler), commits on drop, haptic ticks.
  - `SidebarActionsProvider.tsx`: "Reorder sections…" in the display options, "Reorder sections" in project and section menus, a long-press on a built-in or machine header opens the sheet. `ui/Sheet.tsx` exposes `enableContentPanningGesture` so the list owns vertical drags.
- `apps/mobile/README.md`: one line for the feature.

No wire change. Client-local preference only, so no CLI surface (same as the web).

## How you verified

- `pnpm exec turbo run typecheck lint test --filter=@bb/mobile`: pass (829 tests). New tests: section-order persistence and keys (`sidebar-preferences.test.ts`), section ordering in `buildSidebarListRows` (`sidebar-list-rows.test.ts`), `mergeHiddenSectionOrder` (`sidebar-section-order.test.ts`).
- iOS 26.3 simulator (iPhone 17 Pro) against the fake-provider mobile e2e backend: project and manual modes render with one left edge, chevrons after labels, the group line, and one trailing column; the reorder sheet opens from the display options and from a long-press on a built-in header; drags in both directions reorder the sheet and the list behind it; Pinned stays hidden while nothing is pinned.

Fixes #

> AGENT GENERATED: by Claude Opus 5
