### PR TITLE
Fix mobile compose project picker E2E race

### DIFF
--- a/apps/mobile/e2e/flows/phase3-compose.yaml
+++ b/apps/mobile/e2e/flows/phase3-compose.yaml
@@ -55,13 +55,18 @@ env:
     visible:
       id: "compose-top-controls"
     timeout: 15000
-# Project picker → the seeded project.
+# Project picker → the seeded project. Match the option by id as well as text:
+# the same project name is visible in the sidebar behind the sheet.
 - tapOn:
     id: "project-picker"
 - extendedWaitUntil:
-    visible: "(?i)mobile e2e project"
+    visible:
+      id: "project-picker-option-.*"
+      text: "(?i)mobile e2e project"
     timeout: 15000
-- tapOn: "(?i)mobile e2e project"
+- tapOn:
+    id: "project-picker-option-.*"
+    text: "(?i)mobile e2e project"
 - extendedWaitUntil:
     visible:
       id: "project-picker"


### PR DESCRIPTION
## What was wrong

The `phase3-compose` failure was caused by an ambiguous Maestro selector, not by the project trigger being disabled during bootstrap. In the [scheduled failure](https://github.com/get-bb/bb/actions/runs/32356115918), Maestro recorded `project-picker` as `enabled=true`, opened its sheet, then resolved the text-only `tapOn: "(?i)mobile e2e project"` to the matching `sidebar-header-proj_...` element behind the sheet. The sidebar tap left the compose project on Personal, so the following trigger assertion timed out. Which matching accessibility element won made the flow timing-dependent.

## What changed

Scope both project-option readiness and the tap to `project-picker-option-.*` plus the seeded project name. The flow now waits for the actual sheet row and can no longer tap the same-named sidebar header. No sleeps or longer timeouts were added, and the post-selection assertion remains unchanged.

## How you verified

- Before: inspected the failed run's Maestro trace and screenshot; the trace records the enabled picker opening and the subsequent tap targeting `sidebar-header-proj_...` rather than a picker option.
- `pnpm exec turbo run typecheck test lint --filter=@bb/mobile` (123 files / 830 tests passed; typecheck and lint passed).
- Maestro 2.8.0 parsed the edited flow and began device execution locally. Full local execution is blocked because this Mac's Xcode 26.6 installation has only an iOS 18.4 simulator runtime; `xcodebuild` requires the missing iOS 26.5 platform and reports no eligible destination.
- Focused `phase3-compose` Mobile E2E dispatch: [run 32405262799](https://github.com/get-bb/bb/actions/runs/32405262799) passed; Maestro completed the full flow in 91 seconds.

> AGENT GENERATED: by GPT-5.6-Sol
