### PR TITLE
Support thread-storage files in Docs opener

### DIFF
--- a/plugins/docs/README.md
+++ b/plugins/docs/README.md
@@ -25,8 +25,9 @@ provider, and directive are all Docs.
   to polling.
 - **Default Markdown editor:** Docs registers for `.md`, `.mdx`, and
   `.markdown` files, so it can be selected under Settings → File openers or
-  chosen from a file link's Open with menu. Workspace and absolute host files
-  retain compare-and-swap saves even when they are outside a Docs vault.
+  chosen from a file link's Open with menu. Workspace, absolute host, and
+  thread-storage files retain compare-and-swap saves even when they are outside
+  a Docs vault.
 - **YAML frontmatter:** an opening fenced block that parses as a YAML mapping
   supplies the document title when it has a string `title`, stays out of the
   rendered body and search preview, and is preserved byte-for-byte when the

--- a/plugins/docs/server.test.ts
+++ b/plugins/docs/server.test.ts
@@ -5,7 +5,10 @@ import path from "node:path";
 import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import { defineRpcContract } from "@get-bb/plugin-sdk";
 import type { PluginRpcClient, PluginRpcHandlers } from "@get-bb/plugin-sdk";
-import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
+import {
+  createFakePluginHost,
+  makeThreadResponse,
+} from "@get-bb/plugin-sdk/testing";
 import simpleNotes, { docsRpcContract } from "./server";
 
 const temporaryDirectories: string[] = [];
@@ -1054,6 +1057,130 @@ describe("Docs vault operations", () => {
         expectedSha256: "test-sha",
       },
     ]);
+  });
+
+  it("opens and saves thread-storage Markdown files on the thread's host", async () => {
+    const storageRootPath = String.raw`C:\bb\thread-storage\thread_1`;
+    const openedPath = String.raw`C:\bb\thread-storage\thread_1\reports\plan.md`;
+    const host = createFakePluginHost({
+      pluginId: "simple-notes",
+      sdk: {
+        files: {
+          mkdir: async () => ({ ok: true as const }),
+          read: async ({ path: filePath }) => ({
+            path: filePath,
+            content: "# Thread plan",
+            contentEncoding: "utf8" as const,
+            mimeType: "text/markdown",
+            sizeBytes: 13,
+            modifiedAtMs: 1,
+            sha256: "thread-sha",
+          }),
+          write: async () => ({
+            outcome: "written" as const,
+            sha256: "updated-thread-sha",
+            sizeBytes: 17,
+          }),
+          createPreview: async () => ({
+            baseUrl: "/api/v1/file-previews/thread-storage",
+            expiresAtMs: Date.now() + 60_000,
+          }),
+        },
+        threads: {
+          get: async () => ({
+            ...makeThreadResponse({
+              id: "thread_1",
+              environmentId: "environment_1",
+            }),
+            environment: { hostId: "host_remote" },
+          }),
+          storageFiles: async () => ({
+            files: [],
+            truncated: false,
+            storageRootPath,
+          }),
+        },
+      },
+    });
+    await simpleNotes(host.bb);
+    host.harness.sdk.calls.length = 0;
+    const source = {
+      kind: "thread-storage",
+      threadId: "thread_1",
+      environmentId: "stale_environment",
+      projectId: "project_1",
+    };
+
+    await expect(
+      host.harness.callRpc("openFile", {
+        source,
+        path: "reports/plan.md",
+      }),
+    ).resolves.toMatchObject({
+      file: { content: "# Thread plan", sha256: "thread-sha" },
+      previewPath: "reports/plan.md",
+    });
+    await expect(
+      host.harness.callRpc("saveOpenedFile", {
+        source,
+        path: "reports/plan.md",
+        content: "# Updated thread",
+        expectedSha256: "thread-sha",
+      }),
+    ).resolves.toMatchObject({
+      outcome: "written",
+      sha256: "updated-thread-sha",
+    });
+
+    expect(host.harness.sdk.callsTo("threads.get")).toEqual([
+      [{ threadId: "thread_1", include: "environment" }],
+      [{ threadId: "thread_1", include: "environment" }],
+    ]);
+    expect(host.harness.sdk.callsTo("threads.storageFiles")).toEqual([
+      [{ threadId: "thread_1", limit: "1" }],
+      [{ threadId: "thread_1", limit: "1" }],
+    ]);
+    expect(host.harness.sdk.callsTo("files.read")).toEqual([
+      [
+        {
+          hostId: "host_remote",
+          path: openedPath,
+          rootPath: storageRootPath,
+        },
+      ],
+    ]);
+    expect(host.harness.sdk.callsTo("files.createPreview")).toEqual([
+      [{ hostId: "host_remote", rootPath: storageRootPath }],
+    ]);
+    expect(host.harness.sdk.callsTo("files.write")).toEqual([
+      [
+        {
+          hostId: "host_remote",
+          path: openedPath,
+          rootPath: storageRootPath,
+          content: "# Updated thread",
+          expectedSha256: "thread-sha",
+        },
+      ],
+    ]);
+  });
+
+  it("rejects thread-storage paths that escape the confined root", async () => {
+    const { harness } = await loadNotebook({ "plan.md": "# Plan" });
+
+    await expect(
+      harness.callRpc("openFile", {
+        source: {
+          kind: "thread-storage",
+          threadId: "thread_1",
+          environmentId: "environment_1",
+          projectId: "project_1",
+        },
+        path: "../outside.md",
+      }),
+    ).rejects.toThrow("Invalid thread-storage path");
+    expect(harness.sdk.callsTo("threads.get")).toEqual([]);
+    expect(harness.sdk.callsTo("threads.storageFiles")).toEqual([]);
   });
 
   it("publishes watched filesystem changes without waiting for the poll", async () => {

--- a/plugins/docs/server.ts
+++ b/plugins/docs/server.ts
@@ -545,6 +545,19 @@ function requireOptionalDirectory(value: unknown): string {
   return requireVaultPath(value);
 }
 
+function requireThreadStoragePath(value: unknown): string {
+  const raw = requireString(value, "path").replace(/\\/g, "/");
+  if (
+    path.posix.isAbsolute(raw) ||
+    path.win32.isAbsolute(raw) ||
+    raw.includes("\0") ||
+    raw.split("/").includes("..")
+  ) {
+    throw new Error(`Invalid thread-storage path: ${raw}`);
+  }
+  return path.posix.normalize(raw);
+}
+
 function absolutePath(vault: Vault, relativePath: string): string {
   const parts = relativePath.split("/");
   return /^[a-zA-Z]:[\\/]/.test(vault.rootPath) ||
@@ -1015,7 +1028,44 @@ export default async function plugin(
         hostId: environment.hostId,
       };
     }
-    throw new Error("Docs can open workspace and host files only");
+    if (source.kind === "thread-storage") {
+      if (!source.threadId) {
+        throw new Error("Thread-storage files require a thread ID");
+      }
+      const relativePath = requireThreadStoragePath(filePath);
+      const [thread, storage] = await Promise.all([
+        bb.sdk.threads.get({
+          threadId: source.threadId,
+          include: "environment",
+        }),
+        // The bounded listing is the SDK surface that also resolves the
+        // thread's absolute storage root on its owning host.
+        bb.sdk.threads.storageFiles({
+          threadId: source.threadId,
+          limit: "1",
+        }),
+      ]);
+      const environment =
+        "environment" in thread ? thread.environment : undefined;
+      if (!environment) {
+        throw new Error("This thread has no environment");
+      }
+      if (!isAbsoluteHostPath(storage.storageRootPath)) {
+        throw new Error("This thread has no absolute storage path");
+      }
+      const rootPath = normalizeHostRoot(storage.storageRootPath);
+      return {
+        path: hostPathApi(rootPath).join(
+          rootPath,
+          ...relativePath.split("/"),
+        ),
+        rootPath,
+        hostId: environment.hostId,
+      };
+    }
+    throw new Error(
+      "Docs can open workspace, host, and thread-storage files only",
+    );
   }
 
   async function createNote(


### PR DESCRIPTION
## What was wrong

The Docs file opener accepted thread-storage sources through the shared file-opener contract but only resolved workspace and absolute host paths. Markdown artifacts in thread storage therefore selected Docs and failed before reading the file.

## What changed

Docs now resolves thread-storage files through the owning thread and environment, uses the bounded SDK storage listing to obtain the confined host root, and reuses the existing read, preview, and compare-and-swap save flow. Relative storage paths are validated against absolute paths and parent traversal, and host path joining works for POSIX and Windows roots. The Docs README now documents thread-storage editing support. This does not change the server/daemon wire protocol.

## How you verified

- Added regression coverage for opening, previewing, and saving a thread-storage Markdown file on a remote Windows host.
- Added coverage that rejects parent traversal before any thread or host lookup.
- pnpm exec turbo run test --filter=bb-plugin-simple-notes --force (64 tests passed)
- pnpm exec turbo run typecheck --filter=bb-plugin-simple-notes
- git diff --check

## Fixes

No linked issue; reproduced directly in a BB thread.

> AGENT GENERATED: by GPT-5