### PR TITLE
Allow branch checkout after workspace threads are archived

### DIFF
--- a/apps/server/test/threads/workspace-path-claims.test.ts
+++ b/apps/server/test/threads/workspace-path-claims.test.ts
@@ -1,4 +1,4 @@
-import { archiveThread } from "@bb/db";
+import { archiveThread, markThreadDeleted, unarchiveThread } from "@bb/db";
 import { describe, expect, it } from "vitest";
 import { unmanagedAttachRefusal } from "../../src/services/threads/workspace-path-claims.js";
 import {
@@ -94,56 +94,64 @@ describe("unmanagedAttachRefusal", () => {
     });
   });
 
-  it("ignores live threads unless the request checks out a branch", async () => {
-    await withTestHarness(async (harness) => {
-      const { host } = seedHostSession(harness.deps, {
-        id: "host-claims-busy",
-      });
-      const sharedPath = "/tmp/busy-shared";
-      const { project: busy } = seedProjectWithSource(harness.deps, {
-        hostId: host.id,
-        name: "Busy",
-        path: sharedPath,
-      });
-      const busyEnvironment = seedEnvironment(harness.deps, {
-        hostId: host.id,
-        projectId: busy.id,
-        path: sharedPath,
-      });
-      seedThread(harness.deps, {
-        projectId: busy.id,
-        environmentId: busyEnvironment.id,
-        status: "active",
-      });
-      const { project } = seedProjectWithSource(harness.deps, {
-        hostId: host.id,
-        name: "Joiner",
-        path: sharedPath,
-      });
+  it.each([
+    { status: "starting", visibility: "visible" },
+    { status: "idle", visibility: "visible" },
+    { status: "active", visibility: "hidden" },
+  ] as const)(
+    "blocks a $visibility $status thread only for branch checkout",
+    async ({ status, visibility }) => {
+      await withTestHarness(async (harness) => {
+        const { host } = seedHostSession(harness.deps, {
+          id: `host-claims-busy-${status}`,
+        });
+        const sharedPath = `/tmp/busy-shared-${status}`;
+        const { project: busy } = seedProjectWithSource(harness.deps, {
+          hostId: host.id,
+          name: "Busy",
+          path: sharedPath,
+        });
+        const busyEnvironment = seedEnvironment(harness.deps, {
+          hostId: host.id,
+          projectId: busy.id,
+          path: sharedPath,
+        });
+        seedThread(harness.deps, {
+          projectId: busy.id,
+          environmentId: busyEnvironment.id,
+          status,
+          visibility,
+        });
+        const { project } = seedProjectWithSource(harness.deps, {
+          hostId: host.id,
+          name: "Joiner",
+          path: sharedPath,
+        });
 
-      const args = {
-        dataDir: HOST_DATA_DIR,
-        hostId: host.id,
-        path: sharedPath,
-        projectId: project.id,
-      };
-      // Sharing a directory is allowed; only rewriting the tree is not.
-      expect(
-        unmanagedAttachRefusal(harness.deps.db, {
-          ...args,
-          checksOutBranch: false,
-        }),
-      ).toBeNull();
-      expect(
-        unmanagedAttachRefusal(harness.deps.db, {
-          ...args,
-          checksOutBranch: true,
-        }),
-      ).toMatchObject({ reason: "live-thread" });
-    });
-  });
+        const args = {
+          dataDir: HOST_DATA_DIR,
+          hostId: host.id,
+          path: sharedPath,
+          projectId: project.id,
+        };
+        // Sharing a directory is allowed; only rewriting the tree is not.
+        expect(
+          unmanagedAttachRefusal(harness.deps.db, {
+            ...args,
+            checksOutBranch: false,
+          }),
+        ).toBeNull();
+        expect(
+          unmanagedAttachRefusal(harness.deps.db, {
+            ...args,
+            checksOutBranch: true,
+          }),
+        ).toMatchObject({ reason: "live-thread" });
+      });
+    },
+  );
 
-  it("allows branch checkout after every thread at the path is archived", async () => {
+  it("releases archived and deleted claims but restores an unarchived claim", async () => {
     await withTestHarness(async (harness) => {
       const { host } = seedHostSession(harness.deps, {
         id: "host-claims-archived",
@@ -164,17 +172,26 @@ describe("unmanagedAttachRefusal", () => {
         environmentId: environment.id,
         status: "idle",
       });
-      archiveThread(harness.deps.db, harness.deps.hub, thread.id);
+      const args = {
+        checksOutBranch: true,
+        dataDir: HOST_DATA_DIR,
+        hostId: host.id,
+        path: sharedPath,
+        projectId: project.id,
+      };
 
-      expect(
-        unmanagedAttachRefusal(harness.deps.db, {
-          checksOutBranch: true,
-          dataDir: HOST_DATA_DIR,
-          hostId: host.id,
-          path: sharedPath,
-          projectId: project.id,
-        }),
-      ).toBeNull();
+      archiveThread(harness.deps.db, harness.deps.hub, thread.id);
+      expect(unmanagedAttachRefusal(harness.deps.db, args)).toBeNull();
+
+      unarchiveThread(harness.deps.db, harness.deps.hub, thread.id);
+      expect(unmanagedAttachRefusal(harness.deps.db, args)).toMatchObject({
+        reason: "live-thread",
+      });
+
+      markThreadDeleted(harness.deps.db, harness.deps.hub, {
+        threadId: thread.id,
+      });
+      expect(unmanagedAttachRefusal(harness.deps.db, args)).toBeNull();
     });
   });
 });

--- a/apps/server/test/threads/workspace-path-claims.test.ts
+++ b/apps/server/test/threads/workspace-path-claims.test.ts
@@ -1,3 +1,4 @@
+import { archiveThread } from "@bb/db";
 import { describe, expect, it } from "vitest";
 import { unmanagedAttachRefusal } from "../../src/services/threads/workspace-path-claims.js";
 import {
@@ -139,6 +140,41 @@ describe("unmanagedAttachRefusal", () => {
           checksOutBranch: true,
         }),
       ).toMatchObject({ reason: "live-thread" });
+    });
+  });
+
+  it("allows branch checkout after every thread at the path is archived", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-claims-archived",
+      });
+      const sharedPath = "/tmp/archived-shared";
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+        name: "Archived",
+        path: sharedPath,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+        path: sharedPath,
+      });
+      const thread = seedThread(harness.deps, {
+        projectId: project.id,
+        environmentId: environment.id,
+        status: "idle",
+      });
+      archiveThread(harness.deps.db, harness.deps.hub, thread.id);
+
+      expect(
+        unmanagedAttachRefusal(harness.deps.db, {
+          checksOutBranch: true,
+          dataDir: HOST_DATA_DIR,
+          hostId: host.id,
+          path: sharedPath,
+          projectId: project.id,
+        }),
+      ).toBeNull();
     });
   });
 });

--- a/packages/db/src/data/threads.ts
+++ b/packages/db/src/data/threads.ts
@@ -1411,7 +1411,7 @@ export function hasLiveThreadAtHostPath(
       and(
         eq(environments.hostId, args.hostId),
         eq(environments.path, args.path),
-        nonDeletedThreads(
+        liveThreads(
           inArray(threads.status, [...NON_TERMINAL_THREAD_STATUSES]),
         ),
       ),


### PR DESCRIPTION
## What was wrong

The physical-workspace checkout guard treated every non-deleted `idle` thread as a live workspace user, even after the thread was archived. Because archiving preserves `idle` status, a project could archive all of its threads and still be unable to create a new branch-backed thread in that workspace.

## What changed

The host-path query now applies the existing live-thread predicate, which excludes archived and deleted rows, while retaining the `starting`, `idle`, and `active` status check that protects workspaces used by unarchived threads. The guard remains host/path-wide across projects and applies only when the request checks out a branch.

Focused in-memory SQLite coverage now verifies archived and deleted release, unarchive reclaim, all protected statuses, hidden threads, cross-project physical paths, and branch-checkout-only behavior.

## How you verified

- The deterministic in-memory harness reproduced the archived-idle refusal before the fix and returned no refusal afterward.
- `pnpm exec turbo run test --filter=@bb/server -- test/threads/workspace-path-claims.test.ts` — 1 file, 7 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/db --filter=@bb/server` — 5 Turbo tasks succeeded.
- Actual web workflow in a disposable unmanaged Git project:
  - archived-only holder: branch-backed creation changed from HTTP 409 to HTTP 201;
  - unarchived idle holder: branch-backed creation still returned HTTP 409.

Fixes #2068

> AGENT GENERATED
