### PR TITLE
Avoid plugin update timer overflow with no eligible plugins

### DIFF
--- a/apps/server/src/services/plugins/plugin-updates.ts
+++ b/apps/server/src/services/plugins/plugin-updates.ts
@@ -422,6 +422,7 @@ export function createPluginUpdates(
         (row) => row.sourceKind !== "path" && row.sourceKind !== "builtin",
       )
       .map((row) => row.lastUpdateCheckAt);
+    if (stamps.length === 0) return PLUGIN_UPDATE_CHECK_INTERVAL_MS;
     if (stamps.includes(null)) return 0;
     const oldest = Math.min(...stamps.filter((stamp) => stamp !== null));
     return Math.max(0, PLUGIN_UPDATE_CHECK_INTERVAL_MS - (now() - oldest));

--- a/apps/server/test/services/plugins/plugin-update.test.ts
+++ b/apps/server/test/services/plugins/plugin-update.test.ts
@@ -776,6 +776,16 @@ describe("plugin update service and routes", () => {
     return scheduled;
   }
 
+  it("waits one full interval when no plugins are eligible for update checks", async () => {
+    const HOUR = 60 * 60 * 1_000;
+    await service.remove("updater");
+    const scheduled = await restartWithScheduler(Date.now);
+
+    service.startPeriodicUpdateChecks();
+
+    expect(scheduled.map((entry) => entry.delayMs)).toEqual([6 * HOUR]);
+  });
+
   it("sweeps on start when a plugin was never checked, then waits out the interval across restarts", async () => {
     const HOUR = 60 * 60 * 1_000;
     let clock = Date.now();


### PR DESCRIPTION
## What was wrong

`periodicCheckDelay()` filters installed plugins to network-reachable sources and then takes `Math.min()` over their update-check timestamps. When only builtin/path plugins are installed, or no plugins are installed, that list is empty and `Math.min(...[])` returns `Infinity`. Passing that value to Node `setTimeout()` emits `TimeoutOverflowWarning`, clamps the timer to 1 ms, and starts an unintended immediate update sweep instead of following the six-hour policy.

## What changed

Return the existing six-hour update-check interval directly when the eligible timestamp list is empty. Existing behavior remains unchanged for never-checked plugins and for plugins whose next check is derived from the stalest timestamp. This is the smallest policy-level fix: it reuses the established interval at the point where the empty-set decision belongs and adds no scheduler abstraction, wire change, CLI surface, or documentation requirement.

Added a regression test that removes the only network-reachable plugin, starts periodic checks with the injected scheduler, and verifies the scheduled delay is exactly six hours.

## How you verified

- Before the implementation change, the new focused regression failed with `expected [ Infinity ] to deeply equal [ 21600000 ]`.
- A direct Node reproduction emitted `TimeoutOverflowWarning: Infinity does not fit into a 32-bit signed integer`, clamped the duration to 1 ms, and fired the callback.
- `pnpm exec turbo run test --filter=@bb/server -- test/services/plugins/plugin-update.test.ts` — 27 tests passed.
- `pnpm exec turbo run test --filter=@bb/server` — 191 test files and 1,795 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/server` — passed.
- `pnpm exec turbo run build --filter=@bb/server` — passed.
- Rebased onto current `origin/main`, then reran the focused no-eligible-plugin regression — passed.
- `pnpm exec prettier --check apps/server/src/services/plugins/plugin-updates.ts apps/server/test/services/plugins/plugin-update.test.ts` and `git diff --check` — passed.

No matching GitHub issue was found, so this PR does not include a `Fixes #N` reference.

> AGENT GENERATED: by GPT-5.6-Sol