### PR TITLE
Keep split-divider drag state off document.body

### DIFF
--- a/apps/app/src/components/secondary-panel/SidebarSplitContainer.test.tsx
+++ b/apps/app/src/components/secondary-panel/SidebarSplitContainer.test.tsx
@@ -128,6 +128,7 @@ describe("SidebarSplitContainer", () => {
   afterEach(() => {
     cleanup();
     vi.restoreAllMocks();
+    document.body.style.cursor = "";
     document.body.style.userSelect = "";
   });
 
@@ -687,12 +688,16 @@ describe("SidebarSplitContainer", () => {
     });
 
     fireEvent.pointerDown(hitTarget, { clientX: 400, pointerId: 3 });
+    expect(
+      screen.getByTestId("iframe-drag-guard-overlay").className,
+    ).toContain("cursor-col-resize");
     fireEvent.pointerMove(hitTarget, { clientX: 520, pointerId: 3 });
     expect(headerPrevious.style.flex).toBe(bodyPrevious.style.flex);
     expect(headerNext.style.flex).toBe(bodyNext.style.flex);
     expect(Number.parseFloat(headerPrevious.style.flex)).toBeCloseTo(0.649, 3);
 
     fireEvent.pointerUp(hitTarget, { clientX: 600, pointerId: 3 });
+    expect(screen.queryByTestId("iframe-drag-guard-overlay")).toBeNull();
     expect(headerPrevious.style.flex).toBe(bodyPrevious.style.flex);
     expect(headerNext.style.flex).toBe(bodyNext.style.flex);
     expect(Number.parseFloat(bodyPrevious.style.flex)).toBeCloseTo(0.749, 3);
@@ -705,6 +710,7 @@ describe("SidebarSplitContainer", () => {
     expect(headerPrevious.style.flex).not.toBe(committedPreviousFlex);
     expect(bodyPrevious.style.flex).toBe(headerPrevious.style.flex);
     fireEvent.pointerCancel(hitTarget, { clientX: 320, pointerId: 4 });
+    expect(screen.queryByTestId("iframe-drag-guard-overlay")).toBeNull();
     expect(headerPrevious.style.flex).toBe(committedPreviousFlex);
     expect(headerNext.style.flex).toBe(committedNextFlex);
     expect(bodyPrevious.style.flex).toBe(committedPreviousFlex);
@@ -752,6 +758,131 @@ describe("SidebarSplitContainer", () => {
     expect(previous.style.flex).toBe(previousFlex);
     expect(next.style.flex).toBe(nextFlex);
     expect(document.body.style.userSelect).toBe("");
+  });
+
+  it("keeps divider drag cursor and selection state off the document root", () => {
+    persistState(createTwoPaneState());
+    renderContainer({
+      renderPane: ({ paneId }) => <div>{paneId}</div>,
+    });
+
+    const separator = screen.getByRole("separator");
+    const hitTarget = separator.firstElementChild;
+    const previous = separator.previousElementSibling;
+    const next = separator.nextElementSibling;
+    if (
+      !(hitTarget instanceof HTMLElement) ||
+      !(previous instanceof HTMLElement) ||
+      !(next instanceof HTMLElement)
+    ) {
+      throw new Error("Expected a split divider and adjacent panes");
+    }
+    Object.defineProperty(hitTarget, "setPointerCapture", { value: vi.fn() });
+    Object.defineProperty(previous, "getBoundingClientRect", {
+      value: () => ({ left: 0, right: 400, top: 0, bottom: 600 }),
+    });
+    Object.defineProperty(next, "getBoundingClientRect", {
+      value: () => ({ left: 401, right: 800, top: 0, bottom: 600 }),
+    });
+    const bodyStyleBefore = document.body.getAttribute("style");
+    const rootStyleBefore = document.documentElement.getAttribute("style");
+
+    expect(
+      fireEvent.pointerDown(hitTarget, { clientX: 400, pointerId: 7 }),
+    ).toBe(false);
+    expect(document.body.getAttribute("style")).toBe(bodyStyleBefore);
+    expect(document.documentElement.getAttribute("style")).toBe(
+      rootStyleBefore,
+    );
+    const overlay = screen.getByTestId("iframe-drag-guard-overlay");
+    expect(overlay.className).toContain("cursor-col-resize");
+    expect(separator.closest("[data-sidebar-split-container]")?.lastChild).toBe(
+      overlay,
+    );
+
+    fireEvent.pointerCancel(hitTarget, { clientX: 400, pointerId: 7 });
+    expect(screen.queryByTestId("iframe-drag-guard-overlay")).toBeNull();
+    expect(document.body.getAttribute("style")).toBe(bodyStyleBefore);
+    expect(document.documentElement.getAttribute("style")).toBe(
+      rootStyleBefore,
+    );
+  });
+
+  it("uses a row-resize drag guard for stacked panes", () => {
+    persistState(createStackedPaneState());
+    renderContainer({
+      renderPane: ({ paneId }) => <div>{paneId}</div>,
+    });
+
+    const separator = screen.getByRole("separator", {
+      name: "Resize stacked right panel panes",
+    });
+    const hitTarget = separator.firstElementChild;
+    const previous = separator.previousElementSibling;
+    const next = separator.nextElementSibling;
+    if (
+      !(hitTarget instanceof HTMLElement) ||
+      !(previous instanceof HTMLElement) ||
+      !(next instanceof HTMLElement)
+    ) {
+      throw new Error("Expected a stacked split divider and adjacent panes");
+    }
+    Object.defineProperty(hitTarget, "setPointerCapture", { value: vi.fn() });
+    Object.defineProperty(previous, "getBoundingClientRect", {
+      value: () => ({ left: 0, right: 800, top: 0, bottom: 400 }),
+    });
+    Object.defineProperty(next, "getBoundingClientRect", {
+      value: () => ({ left: 0, right: 800, top: 401, bottom: 800 }),
+    });
+
+    fireEvent.pointerDown(hitTarget, { clientY: 400, pointerId: 9 });
+    expect(
+      screen.getByTestId("iframe-drag-guard-overlay").className,
+    ).toContain("cursor-row-resize");
+
+    fireEvent.pointerCancel(hitTarget, { clientY: 400, pointerId: 9 });
+    expect(screen.queryByTestId("iframe-drag-guard-overlay")).toBeNull();
+  });
+
+  it("cancels an in-flight divider resize when the split tree unmounts", () => {
+    persistState(createTwoPaneState());
+    const view = renderContainer({
+      renderPane: ({ paneId }) => <div>{paneId}</div>,
+    });
+
+    const separator = screen.getByRole("separator");
+    const hitTarget = separator.firstElementChild;
+    const previous = separator.previousElementSibling;
+    const next = separator.nextElementSibling;
+    if (
+      !(hitTarget instanceof HTMLElement) ||
+      !(previous instanceof HTMLElement) ||
+      !(next instanceof HTMLElement)
+    ) {
+      throw new Error("Expected a split divider and adjacent panes");
+    }
+    Object.defineProperty(hitTarget, "setPointerCapture", { value: vi.fn() });
+    Object.defineProperty(previous, "getBoundingClientRect", {
+      value: () => ({ left: 0, right: 400, top: 0, bottom: 600 }),
+    });
+    Object.defineProperty(next, "getBoundingClientRect", {
+      value: () => ({ left: 401, right: 800, top: 0, bottom: 600 }),
+    });
+    const previousFlex = previous.style.flex;
+    const nextFlex = next.style.flex;
+
+    fireEvent.pointerDown(hitTarget, { clientX: 400, pointerId: 8 });
+    fireEvent.pointerMove(hitTarget, { clientX: 560, pointerId: 8 });
+    expect(previous.style.flex).not.toBe(previousFlex);
+    expect(next.style.flex).not.toBe(nextFlex);
+
+    view.unmount();
+    expect(separator.dataset.dragging).toBeUndefined();
+    expect(previous.style.flex).toBe(previousFlex);
+    expect(next.style.flex).toBe(nextFlex);
+    fireEvent.pointerMove(hitTarget, { clientX: 700, pointerId: 8 });
+    expect(previous.style.flex).toBe(previousFlex);
+    expect(next.style.flex).toBe(nextFlex);
   });
 
   it("does not write a canonical layout or rewrite a focused-pane no-op", () => {

--- a/apps/app/src/components/secondary-panel/SidebarSplitContainer.tsx
+++ b/apps/app/src/components/secondary-panel/SidebarSplitContainer.tsx
@@ -22,7 +22,7 @@ import {
   type SplitSide,
 } from "@/lib/split-layout";
 import { dimInactiveSplitsAtom } from "@/lib/split-layout/atoms";
-import { applyResizeCursor, clearResizeCursor } from "@/lib/resizeCursor";
+import { IframeDragGuardOverlay } from "@/lib/iframe-drag-guard";
 import { MACOS_APP_REGION_NO_DRAG_CLASS } from "@/lib/bb-desktop";
 import {
   PaneContext,
@@ -50,6 +50,7 @@ import {
 import type { SecondaryPanelTabReorderRequest } from "./secondaryPanelFileTab";
 
 const PANE_DRAG_ENGAGE_DISTANCE_PX = 7;
+type SidebarSplitResizeCursor = "col-resize" | "row-resize";
 
 export interface SidebarSplitTabDescriptor {
   id: string;
@@ -123,6 +124,8 @@ export function SidebarSplitContainer({
   });
   const previousActiveTabId = useRef(activeTabId);
   const dimsInactiveSplits = useAtomValue(dimInactiveSplitsAtom);
+  const [resizeCursor, setResizeCursor] =
+    useState<SidebarSplitResizeCursor | null>(null);
   const paneCount = countPanes(state.layout.root);
   const hasMultiplePanes = paneCount > 1;
 
@@ -439,6 +442,7 @@ export function SidebarSplitContainer({
       <SidebarSplitHeaderTree
         node={state.layout.root}
         onResize={resize}
+        onResizeDragChange={setResizeCursor}
         paneRenderArgsById={splitPaneRenderArgsById}
         path={[]}
         renderGroup={renderGroup}
@@ -468,9 +472,14 @@ export function SidebarSplitContainer({
           onMoveActiveTabToSide={activeTabPositionHandler}
           onReorderTab={reorderTab}
           onResize={resize}
+          onResizeDragChange={setResizeCursor}
           onSelectTab={selectTab}
         />
       </div>
+      <IframeDragGuardOverlay
+        active={resizeCursor !== null}
+        cursor={resizeCursor ?? "col-resize"}
+      />
     </div>
   );
 }
@@ -494,6 +503,7 @@ interface SidebarSplitTreeProps {
     request: SecondaryPanelTabReorderRequest,
   ) => void;
   onResize: (path: SplitPath, childIndex: number, fraction: number) => void;
+  onResizeDragChange: (cursor: SidebarSplitResizeCursor | null) => void;
   onSelectTab: (paneId: string, tabId: string) => void;
   path: number[];
   renderPane: (args: SidebarSplitPaneRenderArgs) => ReactNode;
@@ -503,6 +513,7 @@ interface SidebarSplitTreeProps {
 interface SidebarSplitHeaderTreeProps {
   node: LayoutNode;
   onResize: (path: SplitPath, childIndex: number, fraction: number) => void;
+  onResizeDragChange: (cursor: SidebarSplitResizeCursor | null) => void;
   paneRenderArgsById: ReadonlyMap<string, SidebarSplitPaneRenderArgs>;
   path: SplitPath;
   renderGroup: (pane: SidebarSplitPaneRenderArgs) => ReactNode;
@@ -541,6 +552,7 @@ function SidebarSplitHeaderTree(props: SidebarSplitHeaderTreeProps) {
               onResize={(fraction) =>
                 props.onResize(props.path, index - 1, fraction)
               }
+              onResizeDragChange={props.onResizeDragChange}
             />
           ) : null}
           <div
@@ -587,6 +599,7 @@ function SidebarSplitTree(props: SidebarSplitTreeProps) {
               onResize={(fraction) =>
                 props.onResize(props.path, index - 1, fraction)
               }
+              onResizeDragChange={props.onResizeDragChange}
             />
           ) : null}
           <div
@@ -682,6 +695,7 @@ function SidebarSplitDivider({
   dir,
   hidden,
   onResize,
+  onResizeDragChange,
   path,
   surface,
 }: {
@@ -690,13 +704,22 @@ function SidebarSplitDivider({
   dir: "row" | "col";
   hidden: boolean;
   onResize: (fraction: number) => void;
+  onResizeDragChange: (cursor: SidebarSplitResizeCursor | null) => void;
   path: SplitPath;
   surface: "body" | "header";
 }) {
   const horizontal = dir === "row";
+  const finishResizeRef = useRef<(() => void) | null>(null);
+  useEffect(
+    () => () => {
+      finishResizeRef.current?.();
+    },
+    [],
+  );
   const handlePointerDown = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
       event.preventDefault();
+      finishResizeRef.current?.();
       const hitTarget = event.currentTarget;
       const divider = hitTarget.parentElement;
       const previous = divider?.previousElementSibling;
@@ -727,8 +750,6 @@ function SidebarSplitDivider({
       ].filter((pair): pair is SidebarSplitResizePair => pair !== null);
       hitTarget.setPointerCapture(pointerId);
       divider.dataset.dragging = "true";
-      applyResizeCursor(horizontal ? "horizontal" : "vertical");
-      document.body.style.userSelect = "none";
       let pendingFraction: number | null = null;
       let receivedPointerMove = false;
       let finished = false;
@@ -749,12 +770,15 @@ function SidebarSplitDivider({
       const finish = (commit: boolean) => {
         if (finished) return;
         finished = true;
+        finishResizeRef.current = null;
         delete divider.dataset.dragging;
         hitTarget.removeEventListener("pointermove", move);
         hitTarget.removeEventListener("pointerup", onUp);
         hitTarget.removeEventListener("pointercancel", cancel);
-        clearResizeCursor();
-        document.body.style.userSelect = "";
+        if (hitTarget.hasPointerCapture?.(pointerId)) {
+          hitTarget.releasePointerCapture(pointerId);
+        }
+        onResizeDragChange(null);
         if (commit && pendingFraction !== null) {
           onResize(pendingFraction);
           return;
@@ -783,8 +807,10 @@ function SidebarSplitDivider({
       hitTarget.addEventListener("pointermove", move);
       hitTarget.addEventListener("pointerup", onUp);
       hitTarget.addEventListener("pointercancel", cancel);
+      finishResizeRef.current = () => finish(false);
+      onResizeDragChange(horizontal ? "col-resize" : "row-resize");
     },
-    [childIndex, horizontal, onResize, path, surface],
+    [childIndex, horizontal, onResize, onResizeDragChange, path, surface],
   );
   return (
     <div

--- a/apps/app/src/lib/resizeCursor.ts
+++ b/apps/app/src/lib/resizeCursor.ts
@@ -16,28 +16,3 @@ import { disableGlobalCursorStyles } from "react-resizable-panels";
 export function takeOverPanelResizeCursor(): void {
   disableGlobalCursorStyles();
 }
-
-type ResizeOrientation = "horizontal" | "vertical";
-
-const RESIZE_CURSOR_BY_ORIENTATION: Record<ResizeOrientation, string> = {
-  horizontal: "col-resize",
-  vertical: "row-resize",
-};
-
-/**
- * Pin a global resize cursor for the duration of a drag. The pointer spends the
- * drag over panel content rather than the 1px handle, so the handle's own hover
- * cursor no longer applies — the body cursor is what keeps the splitter cursor
- * visible while dragging.
- *
- * `cursor` is inherited, so writing it on body restyles every element in the
- * document at drag start and end. Drags that mount an `IframeDragGuardOverlay`
- * should pass the cursor to the overlay instead and not call this.
- */
-export function applyResizeCursor(orientation: ResizeOrientation): void {
-  document.body.style.cursor = RESIZE_CURSOR_BY_ORIENTATION[orientation];
-}
-
-export function clearResizeCursor(): void {
-  document.body.style.cursor = "";
-}


### PR DESCRIPTION
## What was wrong

[`SidebarSplitDivider`](https://github.com/get-bb/bb/blob/6be45053be92f964895038fc374a45e759087479/apps/app/src/components/secondary-panel/SidebarSplitContainer.tsx#L679-L757), introduced by [#1601](https://github.com/get-bb/bb/pull/1601), wrote both `cursor` and `user-select` to `document.body` at drag start and cleared them at drag finish. Both properties are inherited, so each write invalidated styles across the full app tree. That repeats the root cause measured in [#1992](https://github.com/get-bb/bb/pull/1992), where inherited body/root mutations cost hundreds of milliseconds per recalculation on a roughly 20k-element long-thread DOM. The divider also had no unmount cleanup for its native pointer listeners or temporary flex values.

## What changed

- Keep the active split-divider cursor in local `SidebarSplitContainer` state instead of mutating `document.body` or the document root.
- Mount the existing `IframeDragGuardOverlay` after the split content, with `col-resize` or `row-resize` for the active divider. This keeps the drag captured across iframe/browser-backed pane content without inserting a guard before a large sibling subtree.
- Continue relying on the divider's existing pointer-down `preventDefault()` to prevent text selection, matching #1992.
- Cancel the in-flight resize on divider unmount: remove native pointer listeners, release capture when held, clear drag chrome, and restore uncommitted flex values.
- Remove the now-unused global body cursor helpers, while preserving the panel-library takeover used by main.tsx.

This is an app-only change with no host-daemon protocol or other wire changes. It reuses the existing drag guard and straightforward component state; it does not introduce another split framework or alter the split layout model.

## How you verified

The focused regression coverage failed before the production change and passed after it. Before the fix, the new assertions observed `cursor: col-resize; user-select: none` on `body` during pointer-down and a stuck `data-dragging="true"` state after unmount.

- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/secondary-panel/SidebarSplitContainer.test.tsx src/components/layout/AppLayout.sidebar-resize.test.tsx` — 2 files, 20 tests passed.
- `pnpm exec turbo run build typecheck lint --filter=@bb/app` — build and typecheck passed; lint passed with 0 errors and 156 existing warnings.
- `git diff --check` — passed.

Coverage proves that split drag does not change body/document-root inline styles, pointer-down is default-prevented, the guard mounts after split content with both row and column cursors, pointer-up/cancel remove it, and unmount cancels the drag and removes its native listeners.

## Relationship to #1992 and #2059

This applies #1992's measured performance fix to the internal right-panel divider path that #1992 did not cover. Draft [#2059](https://github.com/get-bb/bb/pull/2059) fixes the separate mirrored split-tree correctness problem. Its current head (`4aca1e08`) still contains both body mutations, so it does not supersede this fix. The changes overlap only in `SidebarSplitContainer.tsx` and its test because #2059 rewrites that component; if #2059 lands first, the rebase should keep its single-tree rendering while retaining this PR's container-local cursor state, final drag guard, and divider cleanup.

> AGENT GENERATED: by GPT-5.6-Sol

