### PR TITLE
Fix short user message bubble resizing

### DIFF
--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
@@ -498,7 +498,7 @@ function UserConversationMessage({
 
   return (
     <div className="w-full">
-      <div className="group/message ml-auto w-fit max-w-[70%]">
+      <div className="group/message ml-auto flex w-fit max-w-[70%] flex-col items-end">
         {requestLabel ? (
           <div className="mb-1 flex justify-end">
             <TurnRequestLabel
@@ -507,7 +507,7 @@ function UserConversationMessage({
             />
           </div>
         ) : null}
-        <div className="rounded-xl border border-border-seam bg-surface-recessed px-4 py-2.5 text-sm leading-relaxed text-foreground">
+        <div className="max-w-full rounded-xl border border-border-seam bg-surface-recessed px-4 py-2.5 text-sm leading-relaxed text-foreground">
           {messageText ? (
             <CollapsibleMessageText
               mentions={mentions}

--- a/apps/app/src/components/thread/timeline/rows/UserMessage.stories.tsx
+++ b/apps/app/src/components/thread/timeline/rows/UserMessage.stories.tsx
@@ -72,6 +72,7 @@ const acceptedSteer = {
   kind: "steer" as const,
   status: "accepted" as const,
 };
+const handleStoryMessageEdit = () => undefined;
 
 interface StoryMentionArgs {
   resource: PromptMentionResource;
@@ -538,6 +539,29 @@ export function Overview() {
 
   return (
     <StoryCard>
+      <StoryRow
+        label="short with actions"
+        hint="a short accepted message keeps its bubble width when edit becomes available"
+      >
+        <TimelineStage revealMessageActions>
+          <ConversationMessageContent
+            role="user"
+            originKind={null}
+            initiator="user"
+            senderThreadId={null}
+            senderThreadTitle={null}
+            senderIsPluginSideChat={false}
+            systemMessageKind="unlabeled"
+            systemMessageSubject={null}
+            text="hi"
+            attachments={null}
+            mentions={[]}
+            turnRequest={acceptedMessage}
+            onAddToChat={handleAddToChat}
+            onEdit={handleStoryMessageEdit}
+          />
+        </TimelineStage>
+      </StoryRow>
       <StoryRow
         label="raw thread ID"
         hint="known IDs become linked pills in prose and exact inline-code spans"


### PR DESCRIPTION
## What was wrong

Short user-message bubbles and their hover action footers shared one shrink-to-fit block wrapper. The opacity-hidden footer still participates in layout, so replacing a pending optimistic row with its accepted server row added the Edit action, widened the footer, and stretched short bubbles such as `hi` along with it.

## What changed

- Render the shared user-message wrapper as a right-aligned flex column so the bubble and footer keep independent intrinsic widths while the footer remains in normal flow.
- Cap the bubble at the wrapper width so long and attachment-heavy messages retain the existing 70% maximum and wrapping behavior.
- Add a focused Ladle fixture for a short accepted message with Copy, Edit, and Add to chat actions.

No wire, CLI, configuration, or protocol changes.

## How you verified

The before/after images were captured from the same Ladle fixture with [`dev-browser`](https://github.com/sawyerhood/dev-browser), at the same viewport and crop.

### Before

The 76px hidden action footer stretches the `hi` bubble to 76px.

<img width="851" alt="Before: the short hi bubble is stretched to the width of its three message actions" src="https://raw.githubusercontent.com/get-bb/bb/f3fad20f94b1cf88e9afe77e22787312b389f27e/pr-assets/short-message-bubble/before.png" />

### After

The footer remains 76px and right-aligned, while the `hi` bubble keeps its intrinsic 44.84px width.

<img width="851" alt="After: the short hi bubble keeps its intrinsic width above the wider action footer" src="https://raw.githubusercontent.com/get-bb/bb/f3fad20f94b1cf88e9afe77e22787312b389f27e/pr-assets/short-message-bubble/after.png" />

Also verified with `dev-browser` that regular short, long, image, and mixed-attachment messages stayed within their wrappers without overflow.

- `pnpm exec turbo run test --filter=@bb/app --force -- ConversationMessageContent.test.tsx MessageActionBar.test.tsx ThreadTimelineRows.actions.test.tsx` — 60 tests passed
- `pnpm exec turbo run typecheck --filter=@bb/app --force` — passed
- `pnpm exec turbo run lint --filter=@bb/app --force` — passed with zero errors (existing warning baseline only)

Fixes: no linked issue (reported directly).

> AGENT GENERATED: by GPT-5
