### PR TITLE
Isolate provider installation status failures

### DIFF
--- a/apps/server/src/services/system/provider-installations.ts
+++ b/apps/server/src/services/system/provider-installations.ts
@@ -1,4 +1,7 @@
-import type { ProviderCliStatusResponse } from "@bb/host-daemon-contract";
+import type {
+  ProviderCliStatus,
+  ProviderCliStatusResponse,
+} from "@bb/host-daemon-contract";
 import type { AppDeps } from "../../types.js";
 import { COMMAND_TIMEOUT_MS } from "../../constants.js";
 import { callHostRetryableOnlineRpc } from "../hosts/online-rpc.js";
@@ -18,30 +21,54 @@ export async function getProviderInstallations(
   });
   const entries = await mapProviderMaintenanceRequests(
     providers,
-    async (provider) => {
+    async (provider): Promise<[string, ProviderCliStatus] | null> => {
       const bridgeLaunch = resolveBridgeLaunchForProviderId(deps, provider.id);
       if (bridgeLaunch === null) {
-        throw new Error(`Provider bridge unavailable for ${provider.id}`);
+        deps.logger.warn(
+          {
+            failure: "bridge_unavailable",
+            hostId: args.hostId,
+            providerId: provider.id,
+          },
+          "Failed to load provider installation status; omitting provider",
+        );
+        return null;
       }
       const acpLaunchSpec = resolveAcpLaunchSpecForProviderId(
         deps,
         provider.id,
       );
-      const status = await callHostRetryableOnlineRpc(deps, {
-        hostId: args.hostId,
-        timeoutMs: COMMAND_TIMEOUT_MS,
-        command: {
-          type: "provider.installation.status",
-          providerId: provider.id,
-          bridgeLaunch,
-          ...(acpLaunchSpec === undefined ? {} : { acpLaunchSpec }),
-        },
-      });
-      return [
-        provider.id,
-        { displayName: provider.displayName, ...status },
-      ] as const;
+      try {
+        const status = await callHostRetryableOnlineRpc(deps, {
+          hostId: args.hostId,
+          timeoutMs: COMMAND_TIMEOUT_MS,
+          command: {
+            type: "provider.installation.status",
+            providerId: provider.id,
+            bridgeLaunch,
+            ...(acpLaunchSpec === undefined ? {} : { acpLaunchSpec }),
+          },
+        });
+        return [
+          provider.id,
+          { displayName: provider.displayName, ...status },
+        ];
+      } catch {
+        deps.logger.warn(
+          {
+            failure: "status_request_failed",
+            hostId: args.hostId,
+            providerId: provider.id,
+          },
+          "Failed to load provider installation status; omitting provider",
+        );
+        return null;
+      }
     },
   );
-  return Object.fromEntries(entries);
+  return Object.fromEntries(
+    entries.filter(
+      (entry): entry is [string, ProviderCliStatus] => entry !== null,
+    ),
+  );
 }

--- a/apps/server/src/services/system/provider-installations.ts
+++ b/apps/server/src/services/system/provider-installations.ts
@@ -2,19 +2,38 @@ import type {
   ProviderCliStatus,
   ProviderCliStatusResponse,
 } from "@bb/host-daemon-contract";
+import { ZodError } from "zod";
 import type { AppDeps } from "../../types.js";
 import { COMMAND_TIMEOUT_MS } from "../../constants.js";
-import { callHostRetryableOnlineRpc } from "../hosts/online-rpc.js";
+import { ApiError } from "../../errors.js";
+import {
+  callHostRetryableOnlineRpc,
+  isHostUnavailableApiError,
+} from "../hosts/online-rpc.js";
 import { resolveAcpLaunchSpecForProviderId } from "./acp-launch-spec.js";
 import { listSystemProviderInfos } from "./execution-options.js";
 import { resolveBridgeLaunchForProviderId } from "./provider-bridge-launch.js";
 import { mapProviderMaintenanceRequests } from "./provider-maintenance-concurrency.js";
+
+// Leave five seconds for HTTP response delivery before the Node SDK's
+// 75-second default request timeout.
+const PROVIDER_INSTALLATION_STATUS_TIMEOUT_MS = 70_000;
+
+function canOmitProviderInstallationStatusError(error: unknown): boolean {
+  if (error instanceof ZodError) return true;
+  return (
+    error instanceof ApiError &&
+    !isHostUnavailableApiError(error) &&
+    (error.status === 502 || error.status === 504)
+  );
+}
 
 /** Aggregate provider-owned installation state in registry order. */
 export async function getProviderInstallations(
   deps: AppDeps,
   args: { hostId: string },
 ): Promise<ProviderCliStatusResponse> {
+  const deadline = Date.now() + PROVIDER_INSTALLATION_STATUS_TIMEOUT_MS;
   const providers = await listSystemProviderInfos(deps, {
     hostId: args.hostId,
     capability: "installation",
@@ -38,10 +57,22 @@ export async function getProviderInstallations(
         deps,
         provider.id,
       );
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        deps.logger.warn(
+          {
+            failure: "aggregate_deadline_exceeded",
+            hostId: args.hostId,
+            providerId: provider.id,
+          },
+          "Failed to load provider installation status; omitting provider",
+        );
+        return null;
+      }
       try {
         const status = await callHostRetryableOnlineRpc(deps, {
           hostId: args.hostId,
-          timeoutMs: COMMAND_TIMEOUT_MS,
+          timeoutMs: Math.min(COMMAND_TIMEOUT_MS, remainingMs),
           command: {
             type: "provider.installation.status",
             providerId: provider.id,
@@ -53,7 +84,10 @@ export async function getProviderInstallations(
           provider.id,
           { displayName: provider.displayName, ...status },
         ];
-      } catch {
+      } catch (error) {
+        if (!canOmitProviderInstallationStatusError(error)) {
+          throw error;
+        }
         deps.logger.warn(
           {
             failure: "status_request_failed",

--- a/apps/server/test/public/public-provider-installations.test.ts
+++ b/apps/server/test/public/public-provider-installations.test.ts
@@ -2,13 +2,63 @@ import type {
   HostDaemonOnlineRpcRequestMessage,
   ProviderCliStatusResponse,
 } from "@bb/host-daemon-contract";
+import { DEFAULT_BB_REQUEST_TIMEOUT_MS } from "@bb/sdk";
+import {
+  validatePluginProviderDeclaration,
+} from "@get-bb/plugin-sdk/internal/host-policy";
 import { describe, expect, it, vi } from "vitest";
+import { COMMAND_TIMEOUT_MS } from "../../src/constants.js";
+import { ApiError } from "../../src/errors.js";
+import { buildPluginProviderRegistration } from "../../src/services/providers/plugin-provider-registration.js";
 import { registerHostRpcResponder } from "../helpers/host-rpc.js";
 import { readJson } from "../helpers/json.js";
 import { seedHostSession } from "../helpers/seed.js";
-import { withTestHarness } from "../helpers/test-app.js";
+import {
+  type TestAppHarness,
+  withTestHarness,
+} from "../helpers/test-app.js";
 
 const API = "/api/v1";
+
+function registerInstallationProviders(
+  harness: TestAppHarness,
+  providerIds: readonly string[],
+): void {
+  const bridgeArtifact = harness.deps.pluginHostArtifacts.get("provider-acp");
+  if (bridgeArtifact === undefined) {
+    throw new Error("Expected the test ACP provider bridge artifact");
+  }
+  for (const providerId of providerIds) {
+    const pluginId = `provider-${providerId}`;
+    harness.deps.providerRegistry.register({
+      ...buildPluginProviderRegistration({
+        available: true,
+        pluginId,
+        declaration: validatePluginProviderDeclaration({
+          id: providerId,
+          displayName: providerId,
+          capabilities: {
+            experimental_providerHealth: false,
+            experimental_providerUsage: false,
+            experimental_providerInstallation: true,
+            supportsServiceTier: false,
+            supportsNativeUserQuestion: false,
+            fork: "none",
+            supportsManualCompaction: false,
+            supportsThreadArchive: false,
+            supportsThreadRename: false,
+            supportsWorkflows: false,
+            permissionModes: ["full"],
+            reasoningLevels: ["medium"],
+          },
+          composerActions: [],
+        }),
+      }),
+      pluginId,
+    });
+    harness.deps.pluginHostArtifacts.set(pluginId, bridgeArtifact);
+  }
+}
 
 function installationStatus(providerId: string) {
   const executableName =
@@ -177,6 +227,98 @@ describe("public provider installation routes", () => {
         },
         "Failed to load provider installation status; omitting provider",
       );
+    });
+  });
+
+  it("preserves the host unavailable route error when the target host is offline", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "provider-installation-offline-host",
+      });
+      harness.hub.unregisterDaemon(session.id);
+
+      const response = await harness.app.request(
+        `${API}/hosts/${host.id}/provider-clis/status`,
+      );
+
+      expect(response.status).toBe(502);
+      expect(await readJson(response)).toMatchObject({
+        code: "host_unavailable",
+      });
+    });
+  });
+
+  it("finishes stalled provider aggregation before the SDK request timeout", async () => {
+    await withTestHarness(async (harness) => {
+      registerInstallationProviders(
+        harness,
+        Array.from(
+          { length: 7 },
+          (_, index) => `stalled-installation-${index + 1}`,
+        ),
+      );
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "provider-installation-deadline-host",
+      });
+      registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: handleProviderInstallationRpc,
+      });
+      const requestHostOnlineRpc = harness.hub.requestHostOnlineRpc.bind(
+        harness.hub,
+      );
+      const statusTimeouts: number[] = [];
+      vi.spyOn(harness.hub, "requestHostOnlineRpc").mockImplementation(
+        async (args) => {
+          if (args.message.command.type !== "provider.installation.status") {
+            return requestHostOnlineRpc(args);
+          }
+          statusTimeouts.push(args.timeoutMs);
+          return new Promise((_, reject) => {
+            setTimeout(
+              () =>
+                reject(
+                  new ApiError(
+                    504,
+                    "command_timeout",
+                    "Timed out waiting for command result",
+                  ),
+                ),
+              args.timeoutMs,
+            );
+          });
+        },
+      );
+
+      vi.useFakeTimers();
+      try {
+        const startedAt = Date.now();
+        let resolvedAt: number | null = null;
+        const responsePromise = Promise.resolve(
+          harness.app.request(
+            `${API}/hosts/${host.id}/provider-clis/status`,
+          ),
+        ).then((response) => {
+          resolvedAt = Date.now();
+          return response;
+        });
+
+        await vi.advanceTimersByTimeAsync(150_000);
+        const response = await responsePromise;
+
+        expect(response.status).toBe(200);
+        expect(await readJson(response)).toEqual({});
+        expect(resolvedAt).not.toBeNull();
+        expect(resolvedAt! - startedAt).toBeLessThan(
+          DEFAULT_BB_REQUEST_TIMEOUT_MS,
+        );
+        expect(statusTimeouts).toHaveLength(9);
+        expect(statusTimeouts.some((timeout) => timeout < COMMAND_TIMEOUT_MS))
+          .toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/apps/server/test/public/public-provider-installations.test.ts
+++ b/apps/server/test/public/public-provider-installations.test.ts
@@ -2,7 +2,7 @@ import type {
   HostDaemonOnlineRpcRequestMessage,
   ProviderCliStatusResponse,
 } from "@bb/host-daemon-contract";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { registerHostRpcResponder } from "../helpers/host-rpc.js";
 import { readJson } from "../helpers/json.js";
 import { seedHostSession } from "../helpers/seed.js";
@@ -130,6 +130,53 @@ describe("public provider installation routes", () => {
               : null,
           ),
       ).toEqual(["codex", "claude-code", "acp-cursor"]);
+    });
+  });
+
+  it("preserves healthy providers in registry order when one status request fails", async () => {
+    await withTestHarness(async (harness) => {
+      const warn = vi.fn();
+      harness.deps.logger = { ...harness.deps.logger, warn };
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "provider-installation-partial-status-host",
+      });
+      registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: (request) => {
+          if (
+            request.command.type === "provider.installation.status" &&
+            request.command.providerId === "claude-code"
+          ) {
+            return {
+              ok: false,
+              errorCode: "provider_status_failed",
+              errorMessage: "provider status failed",
+            };
+          }
+          return handleProviderInstallationRpc(request);
+        },
+      });
+
+      const response = await harness.app.request(
+        `${API}/hosts/${host.id}/provider-clis/status`,
+      );
+
+      expect(response.status).toBe(200);
+      const body = (await readJson(response)) as ProviderCliStatusResponse;
+      expect(Object.keys(body)).toEqual(["codex", "acp-cursor"]);
+      expect(Object.values(body).map((status) => status.displayName)).toEqual([
+        "Codex",
+        "Cursor",
+      ]);
+      expect(warn).toHaveBeenCalledWith(
+        {
+          failure: "status_request_failed",
+          hostId: host.id,
+          providerId: "claude-code",
+        },
+        "Failed to load provider installation status; omitting provider",
+      );
     });
   });
 


### PR DESCRIPTION
## What was wrong

`getProviderInstallations` aggregated every installation-capable provider with one `Promise.all`-backed map, but its per-provider callback threw when a bridge was unavailable and propagated rejected or malformed `provider.installation.status` RPCs. One failing third-party provider therefore rejected the public host status route and hid every healthy provider's installation/update status.

The first partial-failure fix caught too broadly: a fully offline host became HTTP 200 with `{}` instead of preserving `host_unavailable`/502. Continuing after every 30-second provider timeout also allowed a large provider roster to exceed the Node SDK's 75-second request timeout.

## What changed

- Omit only provider-local 502/504 status failures and malformed provider results; rethrow `host_unavailable` and unexpected errors.
- Omit providers with unavailable bridges while preserving healthy providers in registry order.
- Bound the whole aggregation to 70 seconds, pass each RPC only `min(30 seconds, remaining time)`, and stop starting RPCs after the deadline.
- Log only the host ID, provider ID, and a non-sensitive failure category.
- Add route regressions for a failing middle provider, an offline target host, and ten stalled installation-capable providers.

This remains a service-local policy fix. It changes no provider, server, or host-daemon wire contract, so no protocol version bump or CLI/docs update is needed. The branch is rebased on the separately merged provider-filtering change from #2078 and does not duplicate that work.

## How you verified

- Before the original production fix, the partial-failure regression failed with `expected 502 to be 200`.
- Before the review fixes, the offline-host regression failed with `expected 200 to be 502`, and the fake-time regression measured 120,000 ms against the SDK's 75,000 ms timeout.
- After the final rebase, `pnpm exec turbo run test --filter=@bb/server -- test/public/public-provider-installations.test.ts` passed: 1 file, 5 tests.
- `pnpm exec turbo run test --filter=@bb/server --force` passed: 195 files, 1,814 tests.
- `pnpm exec turbo run typecheck build --filter=@bb/server` passed both tasks.
- `git diff --check` passed.

> AGENT GENERATED: by GPT-5.6-Sol
