### PR TITLE
Add a privacy policy page for App Store review

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -802,6 +802,55 @@ push key); nobody needs a local Xcode signing setup to ship.
 - `eas update` (JS-only fixes over the air) is deferred: `expo-updates` is
   not installed, so the profiles define no update channels.
 
+## TestFlight testers
+
+**Internal testers** need no Apple review. A build reaches the group as soon as
+App Store Connect finishes processing it, usually within 30 minutes. The group
+`bb team` exists and the nightly feeds it.
+
+**External testers** need a Beta App Review on the first build, and Apple
+usually auto-approves later builds. Before a build can go to an external group,
+App Store Connect needs all of this:
+
+- **Test Information** (`betaAppLocalizations`): a feedback email, a beta
+  description, and the privacy policy URL <https://getbb.app/privacy>. Per
+  build, a "What to test" note.
+- **Beta App Review Details** (`betaAppReviewDetail`): contact first name, last
+  name, phone, and email. Apple uses these, testers never see them.
+- **A way for the reviewer to use the app.** This is the part that fails. bb
+  opens on "Add server", and a reviewer has no bb server, so without help they
+  cannot get past the first screen and will reject the build. Give them a bb
+  server reachable over the internet through connect, and a pairing code that
+  is still valid, and step-by-step notes. Codes expire, so re-issue the code if
+  a review takes longer than expected.
+
+Review notes template — keep it literal, and assume the reviewer knows nothing
+about coding agents:
+
+```text
+bb is a client for a bb server that a developer runs on their own computer.
+The app has no accounts of its own, so we have prepared a server for you.
+
+1. Open the app. It shows "Add server".
+2. Select "Pair with a code".
+3. Enter this code: <CODE>
+4. The app connects and shows a list of conversations.
+5. Open any conversation to read it. Type a message and send it to see a
+   reply from the coding agent.
+
+The code is valid until <DATE>. Write to <EMAIL> if it stops working and we
+will send a new one within a few hours.
+```
+
+Rehearse it before submitting: hand a colleague a phone that has never run bb,
+give them only these notes, and check that they reach a thread.
+
+The marketing version climbs on every nightly, because the EAS job writes the
+npm version into `app.json`. A new version string is more likely to trigger a
+fresh Beta App Review than another build of the same version. If external
+testers become the main audience, pin the TestFlight marketing version and let
+the EAS build number tell nightlies apart.
+
 ## Local state
 
 - Server profiles: `expo-secure-store`, one key per profile

--- a/apps/web/src/blog/blog.css
+++ b/apps/web/src/blog/blog.css
@@ -166,6 +166,25 @@
   background: color-mix(in oklab, var(--ink) 26%, var(--bg));
 }
 
+/* Ordered lists carry their own number, so suppress the square marker that
+   `.post-body li::before` draws for bulleted lists. Without this a numbered
+   item shows both. */
+.post-body ol {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding-left: 22px;
+}
+
+.post-body ol li {
+  padding-left: 2px;
+}
+
+.post-body ol li::before {
+  content: none;
+}
+
 .post-body .release-link {
   color: var(--ink);
   text-decoration: underline;

--- a/apps/web/src/landing/site-chrome.tsx
+++ b/apps/web/src/landing/site-chrome.tsx
@@ -42,6 +42,8 @@ export function SiteFooter() {
         {" · "}
         <a href="/changelog">Changelog</a>
         {" · "}
+        <a href="/privacy">Privacy</a>
+        {" · "}
         <GitHubLink placement="footer">GitHub</GitHubLink>
         {" · "}
         <XLink placement="footer">X</XLink>

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as ChangelogRouteImport } from './routes/changelog'
 import { Route as BlogRouteImport } from './routes/blog'
@@ -25,6 +26,11 @@ import { Route as ApiConnectRedeemRouteImport } from './routes/api.connect.redee
 import { Route as ApiConnectMachineCodeRouteImport } from './routes/api.connect.machine-code'
 import { Route as ApiAuthSplatRouteImport } from './routes/api.auth.$'
 
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DashboardRoute = DashboardRouteImport.update({
   id: '/dashboard',
   path: '/dashboard',
@@ -108,6 +114,7 @@ export interface FileRoutesByFullPath {
   '/blog': typeof BlogRoute
   '/changelog': typeof ChangelogRoute
   '/dashboard': typeof DashboardRoute
+  '/privacy': typeof PrivacyRoute
   '/.well-known/apple-app-site-association': typeof DotwellKnownAppleAppSiteAssociationRoute
   '/.well-known/assetlinks.json': typeof DotwellKnownAssetlinksDotjsonRoute
   '/api/subscribe': typeof ApiSubscribeRoute
@@ -125,6 +132,7 @@ export interface FileRoutesByTo {
   '/blog': typeof BlogRoute
   '/changelog': typeof ChangelogRoute
   '/dashboard': typeof DashboardRoute
+  '/privacy': typeof PrivacyRoute
   '/.well-known/apple-app-site-association': typeof DotwellKnownAppleAppSiteAssociationRoute
   '/.well-known/assetlinks.json': typeof DotwellKnownAssetlinksDotjsonRoute
   '/api/subscribe': typeof ApiSubscribeRoute
@@ -143,6 +151,7 @@ export interface FileRoutesById {
   '/blog': typeof BlogRoute
   '/changelog': typeof ChangelogRoute
   '/dashboard': typeof DashboardRoute
+  '/privacy': typeof PrivacyRoute
   '/.well-known/apple-app-site-association': typeof DotwellKnownAppleAppSiteAssociationRoute
   '/.well-known/assetlinks.json': typeof DotwellKnownAssetlinksDotjsonRoute
   '/api/subscribe': typeof ApiSubscribeRoute
@@ -162,6 +171,7 @@ export interface FileRouteTypes {
     | '/blog'
     | '/changelog'
     | '/dashboard'
+    | '/privacy'
     | '/.well-known/apple-app-site-association'
     | '/.well-known/assetlinks.json'
     | '/api/subscribe'
@@ -179,6 +189,7 @@ export interface FileRouteTypes {
     | '/blog'
     | '/changelog'
     | '/dashboard'
+    | '/privacy'
     | '/.well-known/apple-app-site-association'
     | '/.well-known/assetlinks.json'
     | '/api/subscribe'
@@ -196,6 +207,7 @@ export interface FileRouteTypes {
     | '/blog'
     | '/changelog'
     | '/dashboard'
+    | '/privacy'
     | '/.well-known/apple-app-site-association'
     | '/.well-known/assetlinks.json'
     | '/api/subscribe'
@@ -214,6 +226,7 @@ export interface RootRouteChildren {
   BlogRoute: typeof BlogRoute
   ChangelogRoute: typeof ChangelogRoute
   DashboardRoute: typeof DashboardRoute
+  PrivacyRoute: typeof PrivacyRoute
   DotwellKnownAppleAppSiteAssociationRoute: typeof DotwellKnownAppleAppSiteAssociationRoute
   DotwellKnownAssetlinksDotjsonRoute: typeof DotwellKnownAssetlinksDotjsonRoute
   ApiSubscribeRoute: typeof ApiSubscribeRoute
@@ -229,6 +242,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/dashboard': {
       id: '/dashboard'
       path: '/dashboard'
@@ -342,6 +362,7 @@ const rootRouteChildren: RootRouteChildren = {
   BlogRoute: BlogRoute,
   ChangelogRoute: ChangelogRoute,
   DashboardRoute: DashboardRoute,
+  PrivacyRoute: PrivacyRoute,
   DotwellKnownAppleAppSiteAssociationRoute:
     DotwellKnownAppleAppSiteAssociationRoute,
   DotwellKnownAssetlinksDotjsonRoute: DotwellKnownAssetlinksDotjsonRoute,

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -1,0 +1,241 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useEffect } from "react";
+
+import { initAnalytics } from "../landing/analytics";
+import { SiteFooter, SiteNav } from "../landing/site-chrome";
+import { unfurlMeta } from "../landing/site";
+import interWoff2 from "@fontsource-variable/inter/files/inter-latin-wght-normal.woff2?url";
+import landingCss from "../landing/landing.css?url";
+import blogCss from "../blog/blog.css?url";
+
+// App Store Connect requires a reachable privacy policy URL before a build can
+// go to external TestFlight testers, and the App Store requires one to list the
+// app at all. This page is that URL: https://getbb.app/privacy.
+//
+// It describes three separate things, because a bb user meets them separately:
+// the app on their own devices, the optional bb connect relay, and this
+// website. Keep it that way — most bb users never sign in to connect, and the
+// policy should make clear how little leaves their machine.
+
+const PAGE_TITLE = "Privacy — bb";
+const PAGE_DESCRIPTION =
+  "What bb collects, what stays on your own machines, and what bb connect can see.";
+
+const LAST_UPDATED = "August 20, 2026";
+const CONTACT_EMAIL = "privacy@getbb.app";
+
+export const Route = createFileRoute("/privacy")({
+  head: () => ({
+    meta: [
+      { title: PAGE_TITLE },
+      { name: "description", content: PAGE_DESCRIPTION },
+      ...unfurlMeta(PAGE_TITLE, PAGE_DESCRIPTION, "/privacy"),
+      { name: "theme-color", content: "#ffffff" },
+    ],
+    links: [
+      {
+        rel: "preload",
+        href: interWoff2,
+        as: "font",
+        type: "font/woff2",
+        crossOrigin: "anonymous",
+      },
+      { rel: "stylesheet", href: landingCss },
+      { rel: "stylesheet", href: blogCss },
+    ],
+  }),
+  component: PrivacyRoute,
+});
+
+function PrivacyRoute() {
+  useEffect(() => {
+    initAnalytics();
+  }, []);
+
+  return (
+    <div className="wrap">
+      <SiteNav />
+
+      <article className="post article">
+        <div className="post-body">
+          <time className="date-pill" dateTime="2026-08-20">
+            Last updated {LAST_UPDATED}
+          </time>
+          <h1>Privacy</h1>
+
+          <p className="lede">
+            bb runs on your own machines. Your prompts, your code, and your
+            files go to the bb server that you run, and from there to the AI
+            provider that you choose. They do not come to us.
+          </p>
+
+          <p>
+            This policy covers three separate things. You can use the first one
+            alone.
+          </p>
+          <ol>
+            <li>
+              <strong>The bb apps</strong> — the desktop app, the CLI, and the
+              iOS app.
+            </li>
+            <li>
+              <strong>bb connect</strong> — the optional relay at{" "}
+              <code>getbb.app</code> that lets you reach your own machine from
+              somewhere else.
+            </li>
+            <li>
+              <strong>This website</strong> — <code>getbb.app</code>.
+            </li>
+          </ol>
+
+          <h2>1. The bb apps</h2>
+
+          <p>
+            The apps talk to a bb server that you run. We do not operate that
+            server and we do not receive its data. This includes your prompts,
+            your agent conversations, your source code, your files, your
+            terminal output, and your provider API keys.
+          </p>
+
+          <p>The iOS app keeps this on the device:</p>
+          <ul>
+            <li>
+              <strong>Server profiles</strong> — the address of each bb server
+              you added, and the credential that reaches it. These live in the
+              iOS Keychain.
+            </li>
+            <li>
+              <strong>Preferences and drafts</strong> — your theme, your list
+              order, and unsent message drafts. These live in the app&rsquo;s
+              own storage.
+            </li>
+          </ul>
+
+          <p>
+            The iOS app sends no analytics, no telemetry, and no crash reports
+            to us.
+          </p>
+
+          <p>
+            The app asks for the camera, the microphone, and the photo library
+            only when you attach an image or dictate a prompt. That content goes
+            to your bb server. It does not go to us.
+          </p>
+
+          <h2>2. bb connect</h2>
+
+          <p>
+            bb connect is optional. It gives your machine an address such as{" "}
+            <code>yourhandle.getbb.app</code>, so the iOS app can reach it from
+            a phone network. If you only use bb on your own network, you never
+            touch it.
+          </p>
+
+          <p>When you sign in to bb connect, we store:</p>
+          <ul>
+            <li>
+              Your GitHub account details: name, email address, GitHub login,
+              and avatar URL.
+            </li>
+            <li>
+              The access tokens that keep you signed in to GitHub, and your bb
+              sign-in sessions. A session record includes the IP address and the
+              browser user agent that created it.
+            </li>
+            <li>
+              Your handle, and a record of each machine and server you enroll:
+              its name, its subdomain, and a hash of its credential. We do not
+              store the credential itself.
+            </li>
+            <li>
+              Short-lived pairing codes, and an audit log of account actions
+              such as enrolling or revoking a machine.
+            </li>
+          </ul>
+
+          <p>
+            <strong>What the relay can see.</strong> Traffic between the app and
+            your machine passes through the relay while it is in flight. TLS
+            protects it from the network, but the relay terminates that TLS, so
+            the relay handles the content. We do not record it and we do not
+            store it. The only thing the relay keeps is an edge cache of
+            immutable static assets, such as the app&rsquo;s own JavaScript and
+            images. Treat the relay as a trusted intermediary rather than as
+            end-to-end encryption, and do not use it if your threat model
+            forbids that.
+          </p>
+
+          <p>
+            You can revoke any machine at any time from the connect dashboard.
+            Revoking it ends its address immediately.
+          </p>
+
+          <h2>3. This website</h2>
+
+          <p>
+            The marketing pages use PostHog to measure how people find bb.
+            Automatic event capture is off. The pages send page views, the
+            referrer and any campaign parameters in the URL, and a small set of
+            named events, such as a click on a download link or a copy of the
+            install command.
+          </p>
+
+          <p>
+            If you give us your email address to follow releases, we keep it to
+            send you those emails, and nothing else. Every email has an
+            unsubscribe link.
+          </p>
+
+          <h2>What we do not do</h2>
+          <ul>
+            <li>We do not sell your data.</li>
+            <li>We do not share it with advertisers.</li>
+            <li>
+              We do not read, store, or train on your prompts, your code, or
+              your agent conversations.
+            </li>
+          </ul>
+
+          <h2>Keeping and deleting data</h2>
+
+          <p>
+            We keep your bb connect account data until you delete the account.
+            Sign-in sessions and pairing codes expire on their own. Write to us
+            at the address below to delete your account, and we will remove your
+            account record, your machines, and your handle.
+          </p>
+
+          <p>
+            Data held by the bb apps is yours. Deleting the iOS app removes its
+            profiles, preferences, and drafts from the device.
+          </p>
+
+          <h2>Children</h2>
+
+          <p>
+            bb is a developer tool. It is not directed at children under 13, and
+            we do not knowingly collect their data.
+          </p>
+
+          <h2>Changes</h2>
+
+          <p>
+            We will update this page when the product changes, and we will move
+            the date at the top. bb is open source, so you can also read the
+            history of this page in the repository.
+          </p>
+
+          <h2>Contact</h2>
+
+          <p>
+            Write to <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>{" "}
+            with any question about this policy, or open an issue on{" "}
+            <a href="https://github.com/get-bb/bb">GitHub</a>.
+          </p>
+        </div>
+      </article>
+
+      <SiteFooter />
+    </div>
+  );
+}

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -22,7 +22,7 @@ const PAGE_DESCRIPTION =
   "What bb collects, what stays on your own machines, and what bb connect can see.";
 
 const LAST_UPDATED = "August 20, 2026";
-const CONTACT_EMAIL = "privacy@getbb.app";
+const CONTACT_EMAIL = "sawyer@terragonlabs.com";
 
 export const Route = createFileRoute("/privacy")({
   head: () => ({


### PR DESCRIPTION
## What was wrong

App Store Connect needs a reachable privacy policy URL before a build can go to external TestFlight testers, and before the app can be listed at all. The app record has `privacyPolicyUrl: null`, and the marketing site had no such page.

## What changed

- `apps/web/src/routes/privacy.tsx` serves `https://getbb.app/privacy`. It covers the three things a bb user meets separately: the apps on their own machines, the optional bb connect relay, and the website.
- The site footer links to it.
- `blog.css` suppresses the square bullet that `.post-body li::before` drew next to the number on ordered list items. Blog posts share that stylesheet, so any numbered list in a post had the same double marker.
- `apps/mobile/README.md` gains a "TestFlight testers" section: what internal and external groups each need, and a review-notes template.

The content comes from the code, not from a template:

- `apps/mobile` contains no analytics or crash reporting, so the claim that the iOS app sends no telemetry is checked rather than assumed.
- Server profiles live in the iOS Keychain through `expo-secure-store`.
- The connect fields listed match `packages/connect-db/src/schema.ts`: user, session (IP address, user agent), account tokens, profile handle, machine and server records with credential hashes, connect codes, audit log.
- The relay section states plainly that `apps/connect` terminates TLS and handles the content in flight, and that only immutable static assets are edge-cached. It does not claim end-to-end encryption, because that would be false.

## How verified

- `pnpm exec turbo run typecheck lint test --filter=@bb/web --force`: green. `routeTree.gen.ts` is regenerated, so `/privacy` is a known route.
- Rendered at `http://localhost:5199/privacy` and read in a browser: title, headings, list markers and the footer link all correct.

## Before merging

The contact address on the page is `privacy@getbb.app`. That mailbox must exist, because Apple and testers will write to it. Merging deploys the page — `deploy-web.yml` runs on any push to `main` that touches `apps/web/**`.

> AGENT GENERATED: by Claude Opus 5