### PR TITLE
Skip unrelated provider probes for installation status

### DIFF
--- a/apps/server/src/services/system/execution-options.ts
+++ b/apps/server/src/services/system/execution-options.ts
@@ -85,10 +85,15 @@ type AppendCustomModelsResult = Pick<
   "models" | "selectedOnlyModels"
 >;
 
-type ListSystemProviderInfosRequest = SystemProvidersQuery;
-type ProviderCapabilityFilter = NonNullable<
-  ListSystemProviderInfosRequest["capability"]
->;
+type ProviderCapabilityFilter =
+  | NonNullable<SystemProvidersQuery["capability"]>
+  | "installation";
+type ListSystemProviderInfosRequest = Omit<
+  SystemProvidersQuery,
+  "capability"
+> & {
+  capability?: ProviderCapabilityFilter;
+};
 
 interface ListSystemProviderInfosResult {
   hostId: string | null;
@@ -120,6 +125,8 @@ function providerMatchesCapability(
   capability: ProviderCapabilityFilter | undefined,
 ): boolean {
   switch (capability) {
+    case "installation":
+      return provider.experimental_providerInstallation;
     case "usage":
       return provider.experimental_providerUsage;
     case undefined:

--- a/apps/server/src/services/system/host-lookup.ts
+++ b/apps/server/src/services/system/host-lookup.ts
@@ -6,7 +6,10 @@ import {
   requireConnectedPrimaryHostId,
 } from "../hosts/primary-host.js";
 
-export type SystemHostLookupQuery = SystemProvidersQuery;
+export type SystemHostLookupQuery = Pick<
+  SystemProvidersQuery,
+  "environmentId" | "hostId"
+>;
 
 export function resolveSystemLookupHostId(
   deps: WorkSessionDeps,

--- a/apps/server/src/services/system/provider-installations.ts
+++ b/apps/server/src/services/system/provider-installations.ts
@@ -12,11 +12,10 @@ export async function getProviderInstallations(
   deps: AppDeps,
   args: { hostId: string },
 ): Promise<ProviderCliStatusResponse> {
-  const providers = (
-    await listSystemProviderInfos(deps, {
-      hostId: args.hostId,
-    })
-  ).filter((provider) => provider.experimental_providerInstallation);
+  const providers = await listSystemProviderInfos(deps, {
+    hostId: args.hostId,
+    capability: "installation",
+  });
   const entries = await mapProviderMaintenanceRequests(
     providers,
     async (provider) => {

--- a/apps/server/test/public/public-provider-installations.test.ts
+++ b/apps/server/test/public/public-provider-installations.test.ts
@@ -111,6 +111,15 @@ describe("public provider installation routes", () => {
       ]);
       expect(
         responder.requests
+          .filter((request) => request.command.type === "provider.health")
+          .map((request) =>
+            request.command.type === "provider.health"
+              ? request.command.providerId
+              : null,
+          ),
+      ).toEqual([]);
+      expect(
+        responder.requests
           .filter(
             (request) =>
               request.command.type === "provider.installation.status",


### PR DESCRIPTION
## What was wrong

`getProviderInstallations` called `listSystemProviderInfos` without a capability filter and only filtered for `experimental_providerInstallation` afterward. Installed-only discovery therefore sent `provider.health` to every installed-only registration before discarding non-installation providers. With the first-party registry, every provider CLI status request unnecessarily probed `acp-opencode`, `acp-omp`, `acp-grok`, and `acp-hermes-agent`, even though none declares installation support.

## What changed

- Add `"installation"` as an internal-only provider discovery filter while leaving the public `SystemProvidersQuery` schema unchanged.
- Apply that filter before installed-only discovery, preserving registry order and keeping always-visible installation-capable providers in the inventory even when they are not installed.
- Narrow the host lookup input type to the host selectors it actually reads, so the internal filter does not leak into that contract.
- Extend the public route regression test to assert that installation status sends no unrelated `provider.health` RPCs while retaining the existing provider order assertions.

This is the smallest complete fix because it reuses the same pre-probe filtering path already used for usage inventory instead of adding a second registry traversal or a public query capability. No host/server wire payload, command, or result changed, so `HOST_DAEMON_PROTOCOL_VERSION` does not need a bump. This is distinct from #2076, which isolates per-provider installation status failures.

## How you verified

- Before the production change, `pnpm exec turbo run test --filter=@bb/server --force -- test/public/public-provider-installations.test.ts` failed the new assertion with the four unexpected health probes: `acp-opencode`, `acp-omp`, `acp-grok`, and `acp-hermes-agent`.
- After the change, the focused Turbo test passed: 1 file, 2 tests.
- Forced server build, typecheck, and full test validation passed: 9 Turbo tasks; 195 test files and 1,811 tests.
- After the final rebase onto `origin/main` at `af868d96a`, forced server build and typecheck passed (5 Turbo tasks), and the focused route test passed again (1 file, 2 tests).
- `git diff --check` passed.

> AGENT GENERATED: by GPT-5.6-Sol
