### PR TITLE
Set app bundle budgets to 10% headroom

### DIFF
--- a/apps/app/bundle-budget.json
+++ b/apps/app/bundle-budget.json
@@ -8,7 +8,7 @@
     "Chunks behind a dynamic import are deliberately not counted. Moving code",
     "behind React.lazy or import() is the fix this budget exists to encourage.",
     "",
-    "maxBootBytes / maxBootBrotliBytes are a ratchet set 3% above the measured",
+    "maxBootBytes / maxBootBrotliBytes are a ratchet set 10% above the measured",
     "payload: enough for a normal feature's worth of shell code and for build",
     "noise, tight enough that a barrel regression cannot hide inside it. Lower",
     "them when a change wins headroom. Raising one is a deliberate decision",
@@ -38,15 +38,15 @@
     "route chunk minus the boot chunks: the JavaScript between 'app shell",
     "painted' and 'route content painted'. SplitWorkspaceRoute is every thread,",
     "compose and plugin-panel page, so its closure is the second number that",
-    "decides how slow bb feels on a phone. Same 3% ratchet; its forbiddenPackages",
+    "decides how slow bb feels on a phone. Same 10% ratchet; its forbiddenPackages",
     "are the diff engine, math and terminal code that only a user action needs.",
     "The composer (tiptap/prosemirror) is visible on every thread page and is",
     "allowed until it moves behind a first-focus handoff. Run",
     "`node scripts/why-eager.mjs --from=views/SplitWorkspaceRoute.tsx <package>`",
     "to print the static chain that pulled a package into the closure."
   ],
-  "maxBootBytes": 1626679,
-  "maxBootBrotliBytes": 438233,
+  "maxBootBytes": 1723617,
+  "maxBootBrotliBytes": 479067,
   "forbiddenBootPackages": [
     "@pierre/diffs",
     "@pierre/theming",
@@ -75,8 +75,8 @@
   },
   "routeClosures": {
     "SplitWorkspaceRoute": {
-      "maxBytes": 2559064,
-      "maxBrotliBytes": 670688,
+      "maxBytes": 2533484,
+      "maxBrotliBytes": 671561,
       "forbiddenPackages": [
         "@pierre/diffs",
         "@pierre/theming",


### PR DESCRIPTION
## What was wrong

The app bundle ratchets were set only 3% above a measured production build, leaving too little room for normal feature work and build variation. The intended policy is 10% headroom for both the boot payload and the first-paint thread-route closure.

## What changed

- Recalculate the boot raw/Brotli ceilings at exactly 10% above the current production measurements: 1,566,924 / 435,515 bytes measured and 1,723,617 / 479,067 bytes budgeted.
- Recalculate the SplitWorkspaceRoute raw/Brotli ceilings the same way: 2,303,167 / 610,510 bytes measured and 2,533,484 / 671,561 bytes budgeted.
- Update the in-file policy explanation from 3% to 10%.
- Rebase onto current main. #2080 removed the unreachable git-failure prompt flow and its Handlebars dependency entirely, so this PR drops the now-redundant lazy-loading change and calibrates the budgets after that cleanup.
- No wire-protocol, CLI, guide, or host-daemon behavior changed.

## How you verified

- `pnpm exec turbo run build typecheck --filter=@bb/app --cache-dir=.turbo/cache --output-logs=new-only`
- `pnpm exec turbo run test --filter=@bb/app --cache-dir=.turbo/cache --output-logs=new-only` — 404 files and 3,122 tests passed; 3 skipped.
- `node apps/app/scripts/check-bundle-budget.mjs` — both measured closures pass their exact 10% ratchets.
- `git diff --check`

Fixes: N/A — performance maintenance requested directly.

> AGENT GENERATED: by GPT-5
