### PR TITLE
Load branch picker options before remote refresh

### DIFF
--- a/apps/host-daemon/src/command-dispatch.ts
+++ b/apps/host-daemon/src/command-dispatch.ts
@@ -24,7 +24,10 @@ import {
   cancelEnvironmentProvision,
   provisionEnvironment,
 } from "./command-handlers/environment.js";
-import { listHostBranches } from "./command-handlers/host-branches.js";
+import {
+  listHostBranchOptions,
+  listHostBranches,
+} from "./command-handlers/host-branches.js";
 import {
   installGlobalSkills,
   readGlobalSkillsStatus,
@@ -609,6 +612,7 @@ const onlineRpcHandlers: OnlineRpcHandlerMap = {
   "host.install_global_skills": installGlobalSkills,
   "host.global_skills_status": async (command) =>
     readGlobalSkillsStatus(command, {}),
+  "host.list_branch_options": listHostBranchOptions,
   "host.list_branches": listHostBranches,
   "host.file_metadata": readHostFileMetadata,
   "host.read_file": readHostFile,

--- a/apps/host-daemon/src/command-handlers/host-branches.ts
+++ b/apps/host-daemon/src/command-handlers/host-branches.ts
@@ -7,6 +7,7 @@ import {
   getGitCommonDir,
   getWorkspaceGitOperation,
   hasUncommittedChanges,
+  listBranchRefsWithDefaults,
   listBranches,
   listRemoteBranches,
   readDefaultBranchRefs,
@@ -145,13 +146,18 @@ async function readBranchOptions({
 }: ReadBranchOptionsArgs): Promise<
   HostDaemonOnlineRpcResult<"host.list_branch_options">
 > {
-  const [branches, remoteBranches] = await Promise.all([
-    listBranches(cwd),
-    listRemoteBranches(cwd),
-  ]);
-  const limitedBranches = limitBranchList({ branches, limit, query });
+  const { branches, defaultBranch, originDefaultBranch, remoteBranches } =
+    await listBranchRefsWithDefaults(cwd);
+  const limitedBranches = limitBranchList({
+    branches: pinBranch({ branches, branch: defaultBranch }),
+    limit,
+    query,
+  });
   const limitedRemoteBranches = limitBranchList({
-    branches: remoteBranches,
+    branches: pinBranch({
+      branches: remoteBranches,
+      branch: originDefaultBranch,
+    }),
     limit,
     query,
   });

--- a/apps/host-daemon/src/command-handlers/host-branches.ts
+++ b/apps/host-daemon/src/command-handlers/host-branches.ts
@@ -37,6 +37,13 @@ interface ClassifySelectedBranchArgs {
   selectedBranch?: string;
 }
 
+interface ReadBranchOptionsArgs {
+  path: string;
+  limit: number;
+  query?: string;
+  selectedBranch?: string;
+}
+
 const REMOTE_BRANCH_FETCH_THROTTLE_MS = 30_000;
 const REMOTE_BRANCH_FETCH_TIMEOUT_MS = 5_000;
 
@@ -128,6 +135,68 @@ async function refreshRemoteBranches(cwd: string): Promise<void> {
   });
 
   await inFlight;
+}
+
+async function readBranchOptions({
+  path: cwd,
+  limit,
+  query,
+  selectedBranch: requestedBranch,
+}: ReadBranchOptionsArgs): Promise<
+  HostDaemonOnlineRpcResult<"host.list_branch_options">
+> {
+  const [branches, remoteBranches] = await Promise.all([
+    listBranches(cwd),
+    listRemoteBranches(cwd),
+  ]);
+  const limitedBranches = limitBranchList({ branches, limit, query });
+  const limitedRemoteBranches = limitBranchList({
+    branches: remoteBranches,
+    limit,
+    query,
+  });
+  return {
+    branches: limitedBranches.branches,
+    branchesTruncated: limitedBranches.truncated,
+    remoteBranches: limitedRemoteBranches.branches,
+    remoteBranchesTruncated: limitedRemoteBranches.truncated,
+    selectedBranch: classifySelectedBranch({
+      branches,
+      remoteBranches,
+      selectedBranch: requestedBranch,
+    }),
+  };
+}
+
+export async function listHostBranchOptions(
+  command: CommandOf<"host.list_branch_options">,
+): Promise<HostDaemonOnlineRpcResult<"host.list_branch_options">> {
+  if (!path.isAbsolute(command.path)) {
+    throw new CommandDispatchError("invalid_path", "Path must be absolute");
+  }
+
+  if (!(await detectGitRepo(command.path))) {
+    return {
+      branches: [],
+      branchesTruncated: false,
+      remoteBranches: [],
+      remoteBranchesTruncated: false,
+      selectedBranch: classifySelectedBranch({
+        branches: [],
+        remoteBranches: [],
+        selectedBranch: command.selectedBranch,
+      }),
+    };
+  }
+
+  if (command.remoteRefresh === "background") {
+    // Return cached refs immediately. A successful fetch updates shared Git
+    // refs, whose workspace watcher event invalidates the observed picker
+    // query so the refreshed options arrive without blocking this response.
+    void refreshRemoteBranches(command.path).catch(() => undefined);
+  }
+
+  return readBranchOptions(command);
 }
 
 export async function listHostBranches(

--- a/apps/host-daemon/test/command/host-branches-dispatch.test.ts
+++ b/apps/host-daemon/test/command/host-branches-dispatch.test.ts
@@ -26,6 +26,40 @@ async function initBranchRepo(): Promise<string> {
   return repoPath;
 }
 
+async function expectResolvesWithin<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () =>
+            reject(new Error(`Promise did not resolve within ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout !== undefined) clearTimeout(timeout);
+  }
+}
+
+async function waitForFile(filePath: string): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    try {
+      await fs.access(filePath);
+      return;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  throw new Error(`File did not appear within 2000ms: ${filePath}`);
+}
+
 describe("host.list_branches dispatch", () => {
   it("lists branches for a git repo and pins the default branch first", async () => {
     const repoPath = await initBranchRepo();
@@ -290,6 +324,113 @@ describe("host.list_branches dispatch", () => {
       remoteBranches: [],
       remoteBranchesTruncated: false,
       selectedBranch: null,
+    });
+  });
+});
+
+describe("host.list_branch_options dispatch", () => {
+  it("returns cached refs while a remote refresh continues in the background", async () => {
+    const repoPath = await initBranchRepo();
+    const remotePath = await makeTempDir("bb-host-branch-options-remote-");
+    await runGitCommand(["init", "--bare"], { cwd: remotePath });
+    await runGitCommand(["remote", "add", "origin", remotePath], {
+      cwd: repoPath,
+    });
+    await runGitCommand(["push", "origin", "main"], { cwd: repoPath });
+    await runGitCommand(["fetch", "origin"], { cwd: repoPath });
+
+    const cloneParent = await makeTempDir("bb-host-branch-options-clone-");
+    const clonePath = path.join(cloneParent, "repo");
+    await runGitCommand(["clone", remotePath, clonePath], { cwd: cloneParent });
+    await runGitCommand(["config", "user.name", "BB Tests"], {
+      cwd: clonePath,
+    });
+    await runGitCommand(["config", "user.email", "bb@example.com"], {
+      cwd: clonePath,
+    });
+    await runGitCommand(["switch", "-c", "feature/remote-only"], {
+      cwd: clonePath,
+    });
+    await fs.writeFile(path.join(clonePath, "remote.txt"), "remote\n", "utf8");
+    await runGitCommand(["add", "."], { cwd: clonePath });
+    await runGitCommand(["commit", "-m", "Remote branch"], { cwd: clonePath });
+    await runGitCommand(["push", "origin", "feature/remote-only"], {
+      cwd: clonePath,
+    });
+
+    const refreshStartedPath = path.join(repoPath, "refresh-started");
+    const releaseRefreshPath = path.join(repoPath, "release-refresh");
+    const uploadPackPath = path.join(repoPath, "delayed-upload-pack.sh");
+    await fs.writeFile(
+      uploadPackPath,
+      `#!/bin/sh\ntouch ${JSON.stringify(refreshStartedPath)}\nwhile [ ! -f ${JSON.stringify(releaseRefreshPath)} ]; do sleep 0.01; done\nexec git-upload-pack "$@"\n`,
+      { encoding: "utf8", mode: 0o755 },
+    );
+    await runGitCommand(
+      ["config", "remote.origin.uploadpack", uploadPackPath],
+      {
+        cwd: repoPath,
+      },
+    );
+    const harness = createHarness();
+
+    const resultPromise = dispatchOnlineRpcCommand(
+      {
+        type: "host.list_branch_options",
+        path: repoPath,
+        query: "remote-only",
+        selectedBranch: "origin/feature/remote-only",
+        limit: 50,
+        remoteRefresh: "background",
+      },
+      harness.dispatchOptions(),
+    );
+
+    try {
+      const result = await expectResolvesWithin(resultPromise, 2_000);
+      expect(result).toEqual({
+        branches: [],
+        branchesTruncated: false,
+        remoteBranches: [],
+        remoteBranchesTruncated: false,
+        selectedBranch: {
+          kind: "missing",
+          name: "origin/feature/remote-only",
+        },
+      });
+      await waitForFile(refreshStartedPath);
+    } finally {
+      await fs.writeFile(releaseRefreshPath, "release\n", "utf8");
+    }
+
+    const refreshed = await dispatchOnlineRpcCommand(
+      { type: "host.list_branches", path: repoPath, limit: 50 },
+      harness.dispatchOptions(),
+    );
+    expect(refreshed.remoteBranches).toContain("origin/feature/remote-only");
+  });
+
+  it("does not start a remote refresh when the caller opts out", async () => {
+    const repoPath = await initBranchRepo();
+    const harness = createHarness();
+
+    const result = await dispatchOnlineRpcCommand(
+      {
+        type: "host.list_branch_options",
+        path: repoPath,
+        selectedBranch: "main",
+        limit: 1,
+        remoteRefresh: "none",
+      },
+      harness.dispatchOptions(),
+    );
+
+    expect(result).toEqual({
+      branches: ["develop"],
+      branchesTruncated: true,
+      remoteBranches: [],
+      remoteBranchesTruncated: false,
+      selectedBranch: { kind: "local", name: "main" },
     });
   });
 });

--- a/apps/host-daemon/test/command/host-branches-dispatch.test.ts
+++ b/apps/host-daemon/test/command/host-branches-dispatch.test.ts
@@ -329,6 +329,36 @@ describe("host.list_branches dispatch", () => {
 });
 
 describe("host.list_branch_options dispatch", () => {
+  it("pins local and remote defaults before applying the page limit", async () => {
+    const repoPath = await initBranchRepo();
+    const remotePath = await makeTempDir("bb-host-branch-options-origin-");
+    await runGitCommand(["init", "--bare"], { cwd: remotePath });
+    await runGitCommand(["remote", "add", "origin", remotePath], {
+      cwd: repoPath,
+    });
+    await runGitCommand(["branch", "bb/aardvark"], { cwd: repoPath });
+    await runGitCommand(["push", "origin", "bb/aardvark", "main"], {
+      cwd: repoPath,
+    });
+    await runGitCommand(["fetch", "origin"], { cwd: repoPath });
+    const harness = createHarness();
+
+    const result = await dispatchOnlineRpcCommand(
+      {
+        type: "host.list_branch_options",
+        path: repoPath,
+        limit: 1,
+        remoteRefresh: "none",
+      },
+      harness.dispatchOptions(),
+    );
+
+    expect(result.branches).toEqual(["main"]);
+    expect(result.branchesTruncated).toBe(true);
+    expect(result.remoteBranches).toEqual(["origin/main"]);
+    expect(result.remoteBranchesTruncated).toBe(true);
+  });
+
   it("returns cached refs while a remote refresh continues in the background", async () => {
     const repoPath = await initBranchRepo();
     const remotePath = await makeTempDir("bb-host-branch-options-remote-");
@@ -426,7 +456,7 @@ describe("host.list_branch_options dispatch", () => {
     );
 
     expect(result).toEqual({
-      branches: ["develop"],
+      branches: ["main"],
       branchesTruncated: true,
       remoteBranches: [],
       remoteBranchesTruncated: false,

--- a/apps/server/src/routes/environments.ts
+++ b/apps/server/src/routes/environments.ts
@@ -590,11 +590,12 @@ export function registerEnvironmentRoutes(app: Hono, deps: AppDeps): void {
       hostId: environment.hostId,
       timeoutMs: COMMAND_TIMEOUT_MS,
       command: {
-        type: "host.list_branches",
+        type: "host.list_branch_options",
         path: environment.path,
         ...(branchQuery ? { query: branchQuery } : {}),
         ...(selectedBranch ? { selectedBranch } : {}),
         limit: parseBranchListLimit(query.limit),
+        remoteRefresh: "background",
       },
     });
     return context.json({
@@ -742,10 +743,11 @@ export function registerEnvironmentRoutes(app: Hono, deps: AppDeps): void {
             hostId: environment.hostId,
             timeoutMs: COMMAND_TIMEOUT_MS,
             command: {
-              type: "host.list_branches",
+              type: "host.list_branch_options",
               path: environment.path,
               selectedBranch: targetBranch,
               limit: 1,
+              remoteRefresh: "none",
             },
           });
           assertSquashMergeTargetIsLocal({

--- a/apps/server/test/public/public-environments.test.ts
+++ b/apps/server/test/public/public-environments.test.ts
@@ -13,6 +13,56 @@ import {
 import { withTestHarness } from "../helpers/test-app.js";
 
 describe("public environments", () => {
+  it("lists cached branch options while remotes refresh in the background", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-environment-branch-options",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      const environment = seedEnvironment(harness.deps, {
+        hostId: host.id,
+        projectId: project.id,
+        path: "/tmp/branch-options-env",
+        workspaceProvisionType: "managed-worktree",
+      });
+
+      const responsePromise = harness.app.request(
+        `/api/v1/environments/${environment.id}/diff/branches?query=feature&selectedBranch=origin%2Fmain&limit=10`,
+      );
+      const branchOptionsCommand = await waitForQueuedCommand(
+        harness,
+        ({ command }) => command.type === "host.list_branch_options",
+      );
+      expect(branchOptionsCommand.command).toEqual({
+        type: "host.list_branch_options",
+        path: "/tmp/branch-options-env",
+        query: "feature",
+        selectedBranch: "origin/main",
+        limit: 10,
+        remoteRefresh: "background",
+      });
+      await reportQueuedCommandSuccess(harness, branchOptionsCommand, {
+        branches: ["feature/local"],
+        branchesTruncated: false,
+        remoteBranches: ["origin/feature/remote"],
+        remoteBranchesTruncated: false,
+        selectedBranch: { kind: "remote", name: "origin/main" },
+      });
+
+      const response = await responsePromise;
+      expect(response.status).toBe(200);
+      await expect(readJson(response)).resolves.toEqual({
+        branches: ["feature/local"],
+        branchesTruncated: false,
+        remoteBranches: ["origin/feature/remote"],
+        remoteBranchesTruncated: false,
+        selectedBranch: { kind: "remote", name: "origin/main" },
+      });
+    });
+  });
+
   it("propagates a bounded truncated diff table of contents", async () => {
     await withTestHarness(async (harness) => {
       const { host } = seedHostSession(harness.deps, {

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -1008,6 +1008,29 @@ const hostListBranchesCommandSchema = z.object({
   limit: z.number().int().positive().max(BRANCH_LIST_LIMIT_MAX),
 });
 
+/**
+ * List cached branch options without coupling picker latency to a remote
+ * refresh or to the checkout metadata needed by project/worktree flows.
+ */
+const hostListBranchOptionsCommandSchema = z
+  .object({
+    type: z.literal("host.list_branch_options"),
+    path: z.string().min(1),
+    query: z.string().max(BRANCH_LIST_QUERY_MAX_LENGTH).optional(),
+    selectedBranch: gitBranchNameSchema.optional(),
+    limit: z.number().int().positive().max(BRANCH_LIST_LIMIT_MAX),
+    remoteRefresh: z.enum(["background", "none"]),
+  })
+  .strict();
+
+const hostBranchOptionsResultSchema = projectSourceCheckoutSchema.pick({
+  branches: true,
+  branchesTruncated: true,
+  remoteBranches: true,
+  remoteBranchesTruncated: true,
+  selectedBranch: true,
+});
+
 const providerListModelsCommandSchema = z.object({
   type: z.literal("provider.list_models"),
   providerId: z.string().min(1),
@@ -2003,6 +2026,15 @@ export const hostDaemonCommandRegistry = {
     type: "host.list_branches",
     schema: hostListBranchesCommandSchema,
     resultSchema: projectSourceCheckoutSchema,
+    transport: "onlineRpc",
+    retryable: true,
+    flushEventsBeforeResult: false,
+    envLane: null,
+  }),
+  "host.list_branch_options": defineHostDaemonCommandDescriptor({
+    type: "host.list_branch_options",
+    schema: hostListBranchOptionsCommandSchema,
+    resultSchema: hostBranchOptionsResultSchema,
     transport: "onlineRpc",
     retryable: true,
     flushEventsBeforeResult: false,

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,7 @@
+// Version 146 adds the lightweight `host.list_branch_options` RPC so branch
+// pickers can read cached refs while the daemon refreshes remotes in the
+// background. Older daemons cannot parse or serve that command.
+//
 // Version 145 adds provider-owned static options and installation capability
 // metadata to bridge launches, forwards typed installation requirements, and
 // removes the core `known_acp_agents.status` RPC. Older daemons reject the new
@@ -106,7 +110,7 @@
 //
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 145 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 146 as const;
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/src/session.ts
+++ b/packages/host-daemon-contract/src/session.ts
@@ -458,6 +458,7 @@ const hostDaemonOnlineRpcResponseSuccessSchema = z.discriminatedUnion(
     onlineRpcResponseSuccessSchemaFor("host.install_global_skills"),
     onlineRpcResponseSuccessSchemaFor("host.global_skills_status"),
     onlineRpcResponseSuccessSchemaFor("host.file_metadata"),
+    onlineRpcResponseSuccessSchemaFor("host.list_branch_options"),
     onlineRpcResponseSuccessSchemaFor("host.list_branches"),
     onlineRpcResponseSuccessSchemaFor("host.read_file"),
     onlineRpcResponseSuccessSchemaFor("host.read_file_relative"),

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -297,6 +297,16 @@ const ONLINE_RPC_RESPONSE_RESULT_FIXTURES: OnlineRpcResponseResultFixtures = {
       kind: "local",
     },
   },
+  "host.list_branch_options": {
+    branches: ["main"],
+    branchesTruncated: false,
+    remoteBranches: ["origin/main"],
+    remoteBranchesTruncated: false,
+    selectedBranch: {
+      name: "main",
+      kind: "local",
+    },
+  },
   "host.file_metadata": {
     path: "/tmp/report.html",
     modifiedAtMs: 1234,
@@ -1113,7 +1123,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(145);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(146);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 
@@ -1501,6 +1511,24 @@ describe("host-daemon command schemas", () => {
 
     expect(
       hostDaemonOnlineRpcCommandSchema.parse({
+        type: "host.list_branch_options",
+        path: "/tmp/workspace",
+        query: "release",
+        selectedBranch: "origin/main",
+        limit: 50,
+        remoteRefresh: "background",
+      }),
+    ).toMatchObject({
+      type: "host.list_branch_options",
+      path: "/tmp/workspace",
+      query: "release",
+      selectedBranch: "origin/main",
+      limit: 50,
+      remoteRefresh: "background",
+    });
+
+    expect(
+      hostDaemonOnlineRpcCommandSchema.parse({
         type: "host.list_branches",
         path: "/tmp/workspace",
         query: "release",
@@ -1696,6 +1724,12 @@ describe("host-daemon command schemas", () => {
         limit: 100,
         includeFiles: true,
         includeDirectories: true,
+      },
+      {
+        type: "host.list_branch_options",
+        path: "/tmp/workspace",
+        limit: 50,
+        remoteRefresh: "none",
       },
       {
         type: "host.list_branches",

--- a/packages/host-workspace/src/git.ts
+++ b/packages/host-workspace/src/git.ts
@@ -50,6 +50,13 @@ export interface DefaultBranchRefs {
   originDefaultBranch: string | undefined;
 }
 
+export interface BranchRefsWithDefaults {
+  branches: string[];
+  defaultBranch: string | undefined;
+  originDefaultBranch: string | undefined;
+  remoteBranches: string[];
+}
+
 export interface RunShellPipelineOptions extends GitTimeoutOptions {
   cwd: string;
   allowFailure?: boolean;
@@ -1463,6 +1470,34 @@ export async function listRemoteBranches(cwd: string): Promise<string[]> {
     })
     .filter((ref) => ref.branch.length > 0 && ref.symref.length === 0)
     .map((ref) => ref.branch);
+}
+
+export async function listBranchRefsWithDefaults(
+  cwd: string,
+): Promise<BranchRefsWithDefaults> {
+  const [branches, remoteBranches, originHeadBranch] = await Promise.all([
+    listBranches(cwd),
+    listRemoteBranches(cwd),
+    readOriginHeadBranchName(cwd),
+  ]);
+  const defaultBranch = resolvePreferredLocalDefaultBranch(
+    branches,
+    originHeadBranch,
+  );
+  const originDefaultBranch = [
+    originHeadBranch ? `origin/${originHeadBranch}` : undefined,
+    defaultBranch ? `origin/${defaultBranch}` : undefined,
+  ].find(
+    (branch): branch is string =>
+      branch !== undefined && remoteBranches.includes(branch),
+  );
+
+  return {
+    branches,
+    defaultBranch,
+    originDefaultBranch,
+    remoteBranches,
+  };
 }
 
 export async function hasUncommittedChanges(cwd: string): Promise<boolean> {

--- a/packages/host-workspace/src/index.ts
+++ b/packages/host-workspace/src/index.ts
@@ -37,6 +37,7 @@ export {
   getGitCommonDir,
   gitBlobSize,
   hasUncommittedChanges,
+  listBranchRefsWithDefaults,
   listBranches,
   listRemoteBranches,
   readDefaultBranch,
@@ -45,6 +46,7 @@ export {
   runGit,
 } from "./git.js";
 export type {
+  BranchRefsWithDefaults,
   DefaultBranchRefs,
   FetchRemoteBranchesResult,
   ReadGitBlobResult,


### PR DESCRIPTION
## What was wrong

The Info and Diff merge-base pickers reused `host.list_branches`, which awaited `git fetch --all --prune` before returning any options and also computed checkout, dirty-state, operation, and default-branch metadata that the picker discarded. Repositories with many remotes therefore paid the five-second fetch timeout on a cold open; this project measured 6.295 seconds cold.

## What changed

- Added a lightweight `host.list_branch_options` online RPC that returns only cached local and remote branch pages plus selected-ref classification.
- Made remote freshness explicit: picker requests start the existing single-flight refresh in the background, while squash-target validation skips it. The existing blocking `host.list_branches` flow remains unchanged for project/new-worktree defaults that require fresh remote state.
- Relied on the existing `git-refs-changed` watcher invalidation to refetch an open picker after the background fetch updates refs.
- Bumped `HOST_DAEMON_PROTOCOL_VERSION` to 146 for the new wire command.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/host-daemon-contract --filter=@bb/host-daemon --filter=@bb/server`
- `pnpm exec turbo run test --filter=@bb/host-daemon-contract --filter=@bb/host-daemon --force` — 52 contract tests and 555 daemon tests passed.
- `pnpm exec turbo run test --filter=@bb/server --force` — 1,811 server tests passed.
- Added a daemon regression test that blocks Git upload-pack and proves cached branch options return before the remote refresh is released.
- Added a public-route regression test asserting the environment branch endpoint requests background refresh through the lightweight RPC.
- Measured the lightweight handler on this 601-local/469-remote-ref repository at 92.8 ms, down from the previous 6.295-second cold API path.

Fixes: no linked issue; reported directly in bb.

> AGENT GENERATED: by GPT-5