### PR TITLE
Preserve persisted file opener source routing

### DIFF
--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.test.ts
@@ -15,6 +15,7 @@ import {
   serializeFixedPanelTabsState,
   FIXED_PANEL_TABS_STATE_STORAGE_VERSION,
 } from "@/lib/fixed-panel-tabs-state";
+import { buildFileOpenerPanelTab } from "@/components/plugin/file-opener-tabs";
 import { useThreadFileTabs } from "./useThreadFileTabs";
 import {
   resetPluginSlotStoreForTest,
@@ -202,6 +203,77 @@ describe("useThreadFileTabs terminal pruning", () => {
 });
 
 describe("useThreadFileTabs active owners", () => {
+  it("restores a project opener from its persisted file source", () => {
+    const panelStateId = "restored-project-file-opener";
+    const openerTab = buildFileOpenerPanelTab(
+      { id: "pdf", pluginId: "pdf-preview" },
+      {
+        path: "reports/quarterly.pdf",
+        source: {
+          kind: "workspace",
+          threadId: null,
+          environmentId: null,
+          projectId: "proj_opened",
+          experimental_hostId: "host_opened",
+        },
+      },
+      {
+        environmentId: null,
+        kind: "workspace-file-preview",
+        projectId: "proj_opened",
+        tab: {
+          lineRange: null,
+          path: "reports/quarterly.pdf",
+          source: { kind: "working-tree" },
+          statusLabel: null,
+        },
+        threadId: null,
+      },
+    );
+    window.localStorage.setItem(
+      getFixedPanelTabsStateStorageKey({ threadId: panelStateId }),
+      serializeFixedPanelTabsState({
+        state: createEmptyFixedPanelTabsState({
+          secondary: {
+            activeTabId: openerTab.id,
+            isOpen: true,
+            tabs: [openerTab],
+          },
+          lastUsedAt: Date.now(),
+        }),
+      }),
+    );
+
+    const { result } = renderThreadHook(() =>
+      useThreadFileTabs({
+        panelStateId,
+        syncThreadId: null,
+        environmentId: "env_selected",
+        preserveWorkspaceTabsAcrossContexts: true,
+        projectHostId: "host_selected",
+        projectId: "proj_selected",
+        storageFiles: undefined,
+        terminalSessions: undefined,
+      }),
+    );
+
+    expect(result.current.activeFileOpenerFile).toEqual({
+      path: "reports/quarterly.pdf",
+      source: {
+        kind: "workspace",
+        threadId: null,
+        environmentId: null,
+        projectId: "proj_opened",
+        experimental_hostId: "host_opened",
+      },
+    });
+    expect(result.current.activeWorkspaceFileEnvironmentId).toBeNull();
+    expect(result.current.activeWorkspaceFileProjectId).toBe("proj_opened");
+    expect(result.current.activeWorkspaceFilePath).toBe(
+      "reports/quarterly.pdf",
+    );
+  });
+
   it("returns owner ids for an active restored host file tab", () => {
     const threadId = "root-compose-ownerful";
     const hostTab = createHostFilePreviewFixedPanelTab({

--- a/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
+++ b/apps/app/src/components/secondary-panel/useThreadFileTabs.ts
@@ -24,6 +24,7 @@ import { useFileOpenerPreferenceValue } from "@/lib/file-opener-preference";
 import {
   createFileOpenerTabForRequest,
   fileOpenerIdFromActionId,
+  parseFileOpenerParams,
   type FileTabViewerOverride,
 } from "@/components/plugin/file-opener-tabs";
 import type { OpenPluginPanelArgs } from "@/components/plugin/PluginPanelActions";
@@ -620,56 +621,67 @@ export function useThreadFileTabs({
     fileOpenerIdFromActionId(activePluginPanelTab.actionId) !== null
       ? (activePluginPanelTab.fileOpenerOwner ?? null)
       : null;
+  // Params own the routed file identity; the owner only restores native
+  // presentation state such as line range and workspace status.
+  const activeFileOpenerFile =
+    activeFileOpenerOwner === null || activePluginPanelTab === null
+      ? null
+      : parseFileOpenerParams(activePluginPanelTab.paramsJson);
+  const activeWorkspaceFileOpener =
+    activeFileOpenerOwner?.kind === "workspace-file-preview" &&
+    activeFileOpenerFile?.source.kind === "workspace"
+      ? activeFileOpenerFile
+      : null;
+  const activeHostFileOpener =
+    activeFileOpenerOwner?.kind === "host-file-preview" &&
+    activeFileOpenerFile?.source.kind === "host"
+      ? activeFileOpenerFile
+      : null;
+  const activeStorageFileOpener =
+    activeFileOpenerOwner?.kind === "thread-storage-file-preview" &&
+    activeFileOpenerFile?.source.kind === "thread-storage"
+      ? activeFileOpenerFile
+      : null;
 
   return {
     activateTab,
     activeBrowserTab,
+    activeFileOpenerFile,
     activeFileOpenerOwner,
     activeHostFileEnvironmentId:
       activeHostFileTab?.environmentId ??
-      (activeFileOpenerOwner?.kind === "host-file-preview"
-        ? activeFileOpenerOwner.environmentId
-        : null),
+      activeHostFileOpener?.source.environmentId ??
+      null,
     activeHostFileHostId:
       activeHostFileTab?.hostId ??
-      (activeFileOpenerOwner?.kind === "host-file-preview"
-        ? activeFileOpenerOwner.hostId
-        : null),
+      activeHostFileOpener?.source.experimental_hostId ??
+      null,
     activeHostFileLineRange:
       activeHostFileTab?.lineRange ??
       (activeFileOpenerOwner?.kind === "host-file-preview"
         ? activeFileOpenerOwner.tab.lineRange
         : null),
     activeHostFilePath:
-      activeHostFileTab?.path ??
-      (activeFileOpenerOwner?.kind === "host-file-preview"
-        ? activeFileOpenerOwner.tab.path
-        : null),
+      activeHostFileTab?.path ?? activeHostFileOpener?.path ?? null,
     activeHostFileThreadId:
       activeHostFileTab?.threadId ??
-      (activeFileOpenerOwner?.kind === "host-file-preview"
-        ? activeFileOpenerOwner.threadId
-        : null),
+      activeHostFileOpener?.source.threadId ??
+      null,
     activeStorageFileEnvironmentId:
       activeStorageFileTab?.environmentId ??
-      (activeFileOpenerOwner?.kind === "thread-storage-file-preview"
-        ? activeFileOpenerOwner.environmentId
-        : null),
+      activeStorageFileOpener?.source.environmentId ??
+      null,
     activeStorageFileLineRange:
       activeStorageFileTab?.lineRange ??
       (activeFileOpenerOwner?.kind === "thread-storage-file-preview"
         ? activeFileOpenerOwner.tab.lineRange
         : null),
     activeStorageFilePath:
-      activeStorageFileTab?.path ??
-      (activeFileOpenerOwner?.kind === "thread-storage-file-preview"
-        ? activeFileOpenerOwner.tab.path
-        : null),
+      activeStorageFileTab?.path ?? activeStorageFileOpener?.path ?? null,
     activeStorageFileThreadId:
       activeStorageFileTab?.threadId ??
-      (activeFileOpenerOwner?.kind === "thread-storage-file-preview"
-        ? activeFileOpenerOwner.threadId
-        : null),
+      activeStorageFileOpener?.source.threadId ??
+      null,
     activeWorkspaceFileLineRange:
       activeWorkspaceFileTab?.lineRange ??
       (activeFileOpenerOwner?.kind === "workspace-file-preview"
@@ -677,19 +689,14 @@ export function useThreadFileTabs({
         : null),
     activeWorkspaceFileEnvironmentId:
       activeWorkspaceFileTab?.environmentId ??
-      (activeFileOpenerOwner?.kind === "workspace-file-preview"
-        ? activeFileOpenerOwner.environmentId
-        : null),
+      activeWorkspaceFileOpener?.source.environmentId ??
+      null,
     activeWorkspaceFilePath:
-      activeWorkspaceFileTab?.path ??
-      (activeFileOpenerOwner?.kind === "workspace-file-preview"
-        ? activeFileOpenerOwner.tab.path
-        : null),
+      activeWorkspaceFileTab?.path ?? activeWorkspaceFileOpener?.path ?? null,
     activeWorkspaceFileProjectId:
       activeWorkspaceFileTab?.projectId ??
-      (activeFileOpenerOwner?.kind === "workspace-file-preview"
-        ? activeFileOpenerOwner.projectId
-        : null),
+      activeWorkspaceFileOpener?.source.projectId ??
+      null,
     activeWorkspaceFileSource:
       activeWorkspaceFileTab?.source ??
       (activeFileOpenerOwner?.kind === "workspace-file-preview"

--- a/apps/app/src/views/RootComposeView.test.ts
+++ b/apps/app/src/views/RootComposeView.test.ts
@@ -34,6 +34,7 @@ import {
   readRootComposeSectionTargetFromLocationState,
   readInitialPromptFromLocationState,
   requestRootComposePluginFocus,
+  resolveRootComposeProjectFileRouting,
   resolveRootComposePanelThreadId,
   shouldReplaceInitialPromptFromLocationState,
   shouldStartComposingFromLocationState,
@@ -80,6 +81,52 @@ describe("new-thread right-panel tabs", () => {
     expect(tab.isHidden).toBeUndefined();
     expect(tab.onClose).toBe(onClose);
     expect(tab.onSelect).toBe(onSelect);
+  });
+});
+
+describe("root-compose project file routing", () => {
+  it("uses a persisted opener host instead of the newly selected context", () => {
+    expect(
+      resolveRootComposeProjectFileRouting({
+        fileOpenerSource: {
+          kind: "workspace",
+          threadId: null,
+          environmentId: null,
+          projectId: "proj_opened",
+          experimental_hostId: "host_opened",
+        },
+        selectedEnvironmentId: "env_selected",
+        selectedHostId: "host_selected",
+      }),
+    ).toEqual({ environmentId: null, hostId: "host_opened" });
+  });
+
+  it("keeps primary-host routing when a persisted opener omits a host", () => {
+    expect(
+      resolveRootComposeProjectFileRouting({
+        fileOpenerSource: {
+          kind: "workspace",
+          threadId: null,
+          environmentId: null,
+          projectId: "proj_opened",
+        },
+        selectedEnvironmentId: null,
+        selectedHostId: "host_selected",
+      }),
+    ).toEqual({ environmentId: null, hostId: null });
+  });
+
+  it("retains live routing for a native project file tab", () => {
+    expect(
+      resolveRootComposeProjectFileRouting({
+        fileOpenerSource: null,
+        selectedEnvironmentId: "env_selected",
+        selectedHostId: "host_selected",
+      }),
+    ).toEqual({
+      environmentId: "env_selected",
+      hostId: "host_selected",
+    });
   });
 });
 

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -17,7 +17,10 @@ import {
   type ThreadListEntry,
 } from "@bb/domain";
 import type { OpenInTargetContext } from "@bb/host-daemon-contract";
-import type { NewThreadRequest } from "@get-bb/plugin-sdk";
+import type {
+  NewThreadRequest,
+  PluginFileOpenerSource,
+} from "@get-bb/plugin-sdk";
 import type {
   SidebarBootstrapResponse,
   TerminalSession,
@@ -246,6 +249,33 @@ export function readSectionIdFromLocationState(state: unknown): string | null {
   }
   const sectionId = state.sectionId.trim();
   return sectionId.length > 0 ? sectionId : null;
+}
+
+export function resolveRootComposeProjectFileRouting({
+  fileOpenerSource,
+  selectedEnvironmentId,
+  selectedHostId,
+}: {
+  fileOpenerSource: PluginFileOpenerSource | null;
+  selectedEnvironmentId: string | null;
+  selectedHostId: string | null;
+}): { environmentId: string | null; hostId: string | null } {
+  // Root file tabs survive compose context changes, so a plugin opener's
+  // persisted project route must outrank the newly selected environment/host.
+  if (
+    fileOpenerSource?.kind === "workspace" &&
+    fileOpenerSource.environmentId === null &&
+    fileOpenerSource.projectId !== null
+  ) {
+    return {
+      environmentId: null,
+      hostId: fileOpenerSource.experimental_hostId ?? null,
+    };
+  }
+  return {
+    environmentId: selectedEnvironmentId,
+    hostId: selectedHostId,
+  };
 }
 
 export type RootComposeSectionTarget =
@@ -1187,6 +1217,7 @@ function RootComposeSurface({
     usePluginSlots();
   const {
     activePluginPanelTab,
+    activeFileOpenerFile,
     activeFileOpenerOwner,
     activeHostFileEnvironmentId,
     activeHostFileLineRange,
@@ -1879,7 +1910,9 @@ function RootComposeSurface({
   const activeWorkspaceFileProjectPreviewId =
     activeWorkspaceFilePath !== null &&
     activeWorkspaceFileEnvironmentId === null
-      ? (activeWorkspaceFileProjectId ?? projectId)
+      ? activeFileOpenerFile?.source.kind === "workspace"
+        ? activeFileOpenerFile.source.projectId
+        : (activeWorkspaceFileProjectId ?? projectId)
       : null;
   const serverOrigin = window.location.origin;
   const activeWorkspaceOpenContext = resolveEnvironmentOpenContext({
@@ -1898,22 +1931,33 @@ function RootComposeSurface({
         : (projects?.find(
             (project) => project.id === activeWorkspaceFileProjectPreviewId,
           )?.sources ?? []);
+  const projectFilePreviewRouting = resolveRootComposeProjectFileRouting({
+    fileOpenerSource: activeFileOpenerFile?.source ?? null,
+    selectedEnvironmentId: rootPanelEnvironmentId,
+    selectedHostId: rootProjectHostId,
+  });
+  const projectSourceRoutingHostId =
+    projectFilePreviewRouting.environmentId === null
+      ? (projectFilePreviewRouting.hostId ?? primaryHostId)
+      : null;
   const projectSourcePreviewRootPath =
     activeWorkspaceFileEnvironmentId === null &&
     activeWorkspaceFileProjectPreviewId !== null
-      ? rootPanelEnvironmentId !== null
+      ? projectFilePreviewRouting.environmentId !== null
         ? (rootPanelEnvironment?.path ?? null)
-        : rootProjectHostId !== null
+        : projectSourceRoutingHostId !== null
           ? (findLocalPathProjectSourceForHost(
               activeProjectSources,
-              rootProjectHostId,
+              projectSourceRoutingHostId,
             )?.path ?? null)
           : null
       : null;
   const projectSourcePreviewHostId =
     projectSourcePreviewRootPath === null
       ? null
-      : (rootPanelEnvironment?.hostId ?? rootProjectHostId);
+      : projectFilePreviewRouting.environmentId !== null
+        ? (rootPanelEnvironment?.hostId ?? null)
+        : projectSourceRoutingHostId;
   const projectSourceOpenContext = resolveHostOpenContext({
     hostId: projectSourcePreviewHostId,
     isLocal: isLocalDaemonHost(projectSourcePreviewHostId),
@@ -2136,8 +2180,8 @@ function RootComposeSurface({
         <LazyProjectFilePreviewTabContent
           activePath={activeWorkspaceFilePath}
           copyPath={projectFileCopyPath}
-          environmentId={rootPanelEnvironmentId}
-          hostId={rootProjectHostId}
+          environmentId={projectFilePreviewRouting.environmentId}
+          hostId={projectFilePreviewRouting.hostId}
           isPanelOpen={isSecondaryPanelOpen}
           lineRange={activeWorkspaceFileLineRange}
           onOpenInEditor={handleOpenProjectFileInEditor}


### PR DESCRIPTION
## What was wrong

PR #1979 correctly persisted the selected host for a project-backed file in the file-opener params, and the PDF plugin read that source. Root Compose did not: it reconstructed `experimental_Original`, copy-path resolution, and Open in editor from the currently selected environment/host plus `fileOpenerOwner`. Because Root Compose intentionally preserves file tabs across context changes, a PDF opened on host A could keep rendering from host A while those native surfaces routed to host or environment B.

## What changed

`useThreadFileTabs` now parses the persisted opener params once and treats them as the routed file identity. `fileOpenerOwner` remains responsible only for native presentation state that is not part of the plugin source, such as line ranges and workspace status.

Root Compose gives a persisted project-backed opener source precedence over the live compose selection. The same resolved routing now drives the host-rendered project preview, source root and absolute copy path, and editor-open context. An explicit persisted host stays explicit; an omitted host continues to mean primary-host routing. Native file tabs still follow the existing live compose selection.

This is direct data flow from the existing persisted source, so it does not add a second host field or change the tab/server/daemon contract. `HOST_DAEMON_PROTOCOL_VERSION` is unchanged. There are no CLI, guide, SDK, or documentation changes because the documented plugin contract already requires this behavior.

## How you verified

Regression coverage demonstrates the old behavior and the fix:

- With the old live-context route restored, `pnpm exec turbo run test --filter=@bb/app -- src/views/RootComposeView.test.ts` failed the two new routing cases: explicit host A resolved as selected environment/host B, and omitted-primary routing resolved as host B (67 passed, 2 failed).
- `pnpm exec turbo run test --filter=@bb/app -- src/components/secondary-panel/useThreadFileTabs.test.ts src/views/RootComposeView.test.ts` — 88 passed. This includes persisted-tab reload under a different project/environment, explicit-host retention, primary-host omission, and unchanged native-tab routing.
- `pnpm exec turbo run test --filter=@bb/app --force` — 404 files passed; 3,126 tests passed and 3 skipped.
- `pnpm exec turbo run typecheck build --filter=@bb/app` — passed.
- `pnpm exec turbo run lint --filter=@bb/app` — passed with 0 errors and 156 existing warnings outside the changed lines.

After rebasing onto `origin/main` at `a77a391a48003f364fd4d26bd8cde95e051eee3b`, the focused opener/Root Compose/shared-panel set passed (3 files, 101 tests), and the Turbo app typecheck and build passed.

Related to #1979.

> AGENT GENERATED: by GPT-5.6-Sol

