### PR TITLE
Stabilize changed-declaration bridge lifecycle test

### DIFF
--- a/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
@@ -1354,6 +1354,11 @@ rl.on("line", (line) => {
   it("gives a changed declaration its own bridge process at the same artifact hash", async () => {
     const capturedBridgeLaunches: Array<AgentRuntimeBridgeLaunch | undefined> =
       [];
+    const declarationProviderScript = join(tmpDir, "declaration-provider.cjs");
+    writeThreadScopedProviderScript({
+      logPath: join(tmpDir, "declaration-provider.log"),
+      scriptPath: declarationProviderScript,
+    });
     const bridgeLaunch: AgentRuntimeBridgeLaunch = {
       pluginId: "provider-fixture",
       dataDir: "/data/plugins/provider-fixture/bridge-data",
@@ -1381,7 +1386,7 @@ rl.on("line", (line) => {
       }),
       adapterFactory: (_providerId, options) => {
         capturedBridgeLaunches.push(options.bridgeLaunch);
-        return createFakeAdapter(scriptPath);
+        return createFakeAdapter(declarationProviderScript);
       },
     });
 


### PR DESCRIPTION
## What was wrong

The packages CI shard runs nearly every package test concurrently on a 4-vCPU runner. This lifecycle test serially starts three real bridge processes, but it used the shared TypeScript fake provider, so every launch paid a fresh `tsx` transform under that CPU contention. The process-key assertions were already synchronous and correct; the avoidable fixture compilation pushed the test past Vitest's 5-second default in [run 32420576377](https://github.com/get-bb/bb/actions/runs/32420576377) and [run 32293912651](https://github.com/get-bb/bb/actions/runs/32293912651).

## What changed

The test now reuses this file's existing plain-JavaScript thread-scoped provider fixture. It still starts and shuts down three real bridge processes and exercises the same runtime process-key behavior, but does not compile a TypeScript fixture for each launch. Assertions and timeouts are unchanged. This is test-only; there are no wire, runtime-product, CLI, guide, or documentation changes.

## How you verified

- Reproduced before the change under controlled CPU contention: the focused test failed with the same 5000ms timeout (reported duration 5005ms).
- Repeated the identical contention after the change: passed in 2812ms.
- Ran 25 fresh-process focused repetitions: 25/25 passed.
- `pnpm exec turbo run test --filter=@bb/agent-runtime --force --output-logs=full -- --project '@bb/agent-runtime:isolated' src/runtime.process-lifecycle.test.ts -t 'gives a changed declaration its own bridge process at the same artifact hash'` (1 passed; 85ms test time).
- `pnpm exec turbo run test --filter=@bb/agent-runtime --force --output-logs=full` (31 files, 422 tests passed).
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime --force --output-logs=full` (passed).
- `pnpm exec turbo run build --filter=@bb/agent-runtime --force --output-logs=full` (upstream generation tasks passed; this source-only package has no build task).
- `pnpm exec turbo run lint --filter=@bb/agent-runtime --force --output-logs=full` (the package has no lint task), plus `pnpm exec eslint packages/agent-runtime/src/runtime.process-lifecycle.test.ts` (passed).

> AGENT GENERATED: by GPT-5.6-Sol
