### PR TITLE
Require immutable for Connect edge caching

### DIFF
--- a/apps/connect/src/cache.ts
+++ b/apps/connect/src/cache.ts
@@ -11,8 +11,88 @@
 
 import { rebuiltResponse } from "./response-encoding.js";
 
-const CACHE_HOST = "https://bb-connect-asset-cache.internal";
+// Tightening cache admission must also change this host so entries admitted by
+// older code become unreachable without a global Cloudflare purge.
+const CACHE_HOST = "https://bb-connect-asset-cache-v2.internal";
 const MIN_CACHEABLE_MAX_AGE = 300;
+
+interface CacheControlDirective {
+  quoted: boolean;
+  value: string | null;
+}
+
+const CACHE_CONTROL_TOKEN_CHARACTER = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]$/u;
+
+function isTokenCharacter(character: string | undefined): boolean {
+  return (
+    character !== undefined && CACHE_CONTROL_TOKEN_CHARACTER.test(character)
+  );
+}
+
+function isQuotedTextCharacter(character: string): boolean {
+  const code = character.charCodeAt(0);
+  return code === 0x09 || (code >= 0x20 && code !== 0x7f);
+}
+
+/** Parse Cache-Control's comma list without treating quoted commas as syntax. */
+function parseCacheControl(
+  header: string,
+): Map<string, CacheControlDirective> | null {
+  const directives = new Map<string, CacheControlDirective>();
+  let offset = 0;
+
+  while (offset < header.length) {
+    while (header[offset] === " " || header[offset] === "\t") offset++;
+
+    const nameStart = offset;
+    while (isTokenCharacter(header[offset])) offset++;
+    if (offset === nameStart) return null;
+    const name = header.slice(nameStart, offset).toLowerCase();
+
+    let quoted = false;
+    let value: string | null = null;
+    if (header[offset] === "=") {
+      offset++;
+      if (header[offset] === '"') {
+        quoted = true;
+        offset++;
+        const valueStart = offset;
+        let closed = false;
+        while (offset < header.length) {
+          const character = header[offset];
+          if (character === '"') {
+            value = header.slice(valueStart, offset);
+            offset++;
+            closed = true;
+            break;
+          }
+          if (character === "\\") {
+            offset++;
+            if (offset === header.length) return null;
+          }
+          if (!isQuotedTextCharacter(header[offset])) return null;
+          offset++;
+        }
+        if (!closed) return null;
+      } else {
+        const valueStart = offset;
+        while (isTokenCharacter(header[offset])) offset++;
+        if (offset === valueStart) return null;
+        value = header.slice(valueStart, offset);
+      }
+    }
+
+    while (header[offset] === " " || header[offset] === "\t") offset++;
+    if (directives.has(name)) return null;
+    directives.set(name, { quoted, value });
+    if (offset === header.length) break;
+    if (header[offset] !== ",") return null;
+    offset++;
+    if (offset === header.length) return null;
+  }
+
+  return directives;
+}
 
 /** Build the edge-cache Request key for a namespace label + visitor URL. */
 export function cacheKey(namespace: string, url: URL): Request {
@@ -24,10 +104,27 @@ export function cacheKey(namespace: string, url: URL): Request {
 function isCacheable(resp: Response): boolean {
   if (!resp.ok) return false;
   if (resp.headers.has("set-cookie")) return false;
-  const cc = resp.headers.get("cache-control") ?? "";
-  if (/\b(no-store|no-cache|private)\b/i.test(cc)) return false;
-  const maxAge = cc.match(/max-age=(\d+)/i);
-  return maxAge ? Number(maxAge[1]) >= MIN_CACHEABLE_MAX_AGE : false;
+  const directives = parseCacheControl(resp.headers.get("cache-control") ?? "");
+  if (directives === null) return false;
+  if (
+    directives.has("no-store") ||
+    directives.has("no-cache") ||
+    directives.has("private")
+  ) {
+    return false;
+  }
+  const immutable = directives.get("immutable");
+  if (immutable === undefined || immutable.value !== null) return false;
+  const maxAge = directives.get("max-age");
+  if (
+    maxAge === undefined ||
+    maxAge.quoted ||
+    maxAge.value === null ||
+    !/^\d+$/u.test(maxAge.value)
+  ) {
+    return false;
+  }
+  return Number(maxAge.value) >= MIN_CACHEABLE_MAX_AGE;
 }
 
 /**

--- a/apps/connect/src/response-encoding.test.ts
+++ b/apps/connect/src/response-encoding.test.ts
@@ -20,6 +20,23 @@ const HTML = `<!doctype html><title>bb</title>${"<p>relayed body</p>".repeat(50)
 const GZIP = gzipSync(Buffer.from(HTML));
 const IMMUTABLE = "public, max-age=31536000, immutable";
 
+function cacheControlForPolicy(policy: string | null): string {
+  switch (policy) {
+    case "1":
+      return IMMUTABLE;
+    case "mutable":
+      return "public, max-age=300";
+    case "quoted-immutable":
+      return 'public, extension="a,immutable,b", max-age=300';
+    case "quoted-max-age":
+      return 'public, immutable, extension="max-age=300"';
+    case "prefixed-max-age":
+      return "public, immutable, not-max-age=300";
+    default:
+      return "no-store";
+  }
+}
+
 type ClientWebSocket = NonNullable<
   Awaited<ReturnType<Miniflare["dispatchFetch"]>>["webSocket"]
 >;
@@ -55,10 +72,10 @@ function serveOriginOverTunnel(ws: ClientWebSocket): void {
     if (typeof event.data === "string") return;
     const frame = decodeFrame(event.data as ArrayBuffer);
     if (frame.type !== "open-http") return;
-    const cacheable =
-      new URL(frame.path, "http://origin.local").searchParams.get(
-        "cacheable",
-      ) === "1";
+    const cachePolicy = new URL(
+      frame.path,
+      "http://origin.local",
+    ).searchParams.get("cacheable");
     send({
       type: "resp-head",
       streamId: frame.streamId,
@@ -67,7 +84,7 @@ function serveOriginOverTunnel(ws: ClientWebSocket): void {
         ["content-type", "text/html; charset=utf-8"],
         ["content-encoding", "gzip"],
         ["content-length", String(GZIP.byteLength)],
-        ["cache-control", cacheable ? IMMUTABLE : "no-store"],
+        ["cache-control", cacheControlForPolicy(cachePolicy)],
       ],
     });
     send({
@@ -153,6 +170,45 @@ describe("relaying a gzip-encoded origin response", () => {
 });
 
 describe("edge cache", () => {
+  it("does not read mutable entries stored under the legacy cache key", async () => {
+    const target = "/legacy-personalized";
+    const seeded = await mf.dispatchFetch(
+      `https://relay.test/seed-legacy-cache?for=${encodeURIComponent(target)}`,
+    );
+    expect(seeded.status).toBe(204);
+
+    const response = await mf.dispatchFetch(`https://relay.test${target}`);
+    expect(response.headers.get("x-bb-cache")).toBeNull();
+    expect(await response.text()).toBe(HTML);
+  });
+
+  it.each([
+    ["a max-age response without immutable", "mutable"],
+    ["immutable text inside a quoted extension", "quoted-immutable"],
+    ["max-age text inside a quoted extension", "quoted-max-age"],
+    ["a prefixed max-age directive", "prefixed-max-age"],
+  ])("does not cache %s", async (_description, policy) => {
+    const url = `https://relay.test/rejected-${policy}?cacheable=${policy}`;
+
+    const first = await mf.dispatchFetch(url);
+    expect(first.headers.get("x-bb-cache")).toBeNull();
+
+    const second = await mf.dispatchFetch(url);
+    expect(second.headers.get("x-bb-cache")).toBeNull();
+  });
+
+  it("caches a valid immutable asset", async () => {
+    const url = "https://relay.test/valid-asset.js?cacheable=1";
+
+    const miss = await mf.dispatchFetch(url);
+    expect(miss.headers.get("x-bb-cache")).toBe("miss");
+    expect(await miss.text()).toBe(HTML);
+
+    const hit = await mf.dispatchFetch(url);
+    expect(hit.headers.get("x-bb-cache")).toBe("hit");
+    expect(hit.headers.get("cache-control")).toBe(IMMUTABLE);
+  });
+
   it("keeps the body decodable on both the miss and the hit", async () => {
     const miss = await get("/asset.js?cacheable=1");
     expect(miss.body.toString("utf8")).toBe(HTML);

--- a/apps/connect/test/encoding-fixture.ts
+++ b/apps/connect/test/encoding-fixture.ts
@@ -19,6 +19,7 @@ export interface FixtureEnv {
 }
 
 const NAMESPACE = "fixture-label";
+const LEGACY_CACHE_HOST = "https://bb-connect-asset-cache.internal";
 
 function gzipBytes(env: FixtureEnv): Uint8Array {
   const bin = atob(env.GZIP_BODY_B64);
@@ -76,6 +77,20 @@ export default {
       );
       if (!cached) return new Response("not cached", { status: 404 });
       return new Response(cached.body, cached);
+    }
+
+    // Seed the pre-policy-change key exactly as production did, so the test can
+    // prove a deployment cannot read mutable responses admitted by old code.
+    if (url.pathname === "/seed-legacy-cache") {
+      const target = url.searchParams.get("for") ?? "/";
+      const key = new Request(`${LEGACY_CACHE_HOST}/${NAMESPACE}${target}`);
+      await caches.default.put(
+        key,
+        new Response("legacy mutable response", {
+          headers: { "cache-control": "public, max-age=31536000" },
+        }),
+      );
+      return new Response(null, { status: 204 });
     }
 
     return serveWithCache(request, NAMESPACE, ctx, () => stub.fetch(request));


### PR DESCRIPTION
## What was wrong

The Connect relay keyed shared edge-cache entries by namespace, path, and query, but accepted any successful GET with `max-age >= 300` unless it also carried `set-cookie`, `private`, `no-cache`, or `no-store`. A mutable or user-specific HTML/JSON response could therefore enter the shared cache solely because it advertised a five-minute max age, contradicting the intended immutable-static-asset contract documented by the privacy policy. This was identified in the [post-merge review](https://github.com/get-bb/bb/pull/2077#discussion_r3825678361).

The first version of this fix also left two gaps: entries admitted by deployed code remained reachable under the unchanged cache key, and comma splitting plus substring matching could mistake text inside quoted extension values or prefixed directive names for `immutable` or `max-age`.

## What changed

- Require an exact argument-free `immutable` directive and an exact unquoted numeric `max-age` directive before a response is eligible for Connect edge caching, while retaining the existing success, cookie, private/no-cache/no-store, and minimum lifetime checks.
- Parse the Cache-Control directive list locally with quote and escape awareness. Malformed syntax and duplicate directives fail closed.
- Move new entries to the versioned `bb-connect-asset-cache-v2.internal` key host, making every entry admitted under the legacy policy unreachable without a global purge.
- Add real Miniflare regressions for a seeded legacy entry, max-age without immutable, immutable inside a quoted extension, max-age inside a quoted extension, prefixed max-age, and a valid immutable asset miss/hit. The positive test consumes the streamed miss before checking the hit so the asynchronous cache put is deterministic under CI load.

This is the smallest complete guard because every intended production source of hash-addressed core, plugin, and icon assets already emits `immutable`, while mutable public files and installer responses emit finite max ages without it. Path or content-type allowlists would exclude valid immutable plugin assets and duplicate origin policy. There are no wire, CLI, guide, or daemon protocol changes.

## How you verified

- Before the original fix, `pnpm exec turbo run test --filter=@bb/connect --force -- src/response-encoding.test.ts` failed the new max-age-only case with `expected null`, `received "miss"`, proving the response was inserted into the shared cache.
- Before the SlopCop follow-up, the focused suite failed four cases: the seeded legacy response returned `x-bb-cache: hit`, and quoted immutable, quoted max-age, and prefixed max-age responses each returned `x-bb-cache: miss`.
- GitHub Packages job `96608140078` on run `32426062401` then exposed a test-only stream race: all four security regressions passed, but the positive case made its second request before consuming the miss body and observed a second miss. Consuming that body is the one-line synchronization fix.
- The focused Miniflare suite passed 10 consecutive forced runs after that fix, then passed 12/12 again after the final rebase.
- Under the exact CI Packages-shard Turbo command and concurrent package load, `@bb/connect` passed all 110 tests; the broader local command later stopped on an unrelated macOS desktop SIGTERM test.
- After rebasing onto current `origin/main`, `pnpm exec turbo run typecheck test --filter=@bb/connect --force` passed typecheck and all 110 tests across 5 files.
- `pnpm exec turbo run build --filter=@bb/connect --force` completed successfully and reported that `@bb/connect` defines no build task.
- `pnpm exec prettier --check apps/connect/src/cache.ts apps/connect/src/response-encoding.test.ts apps/connect/test/encoding-fixture.ts` and `git diff --check origin/main...HEAD` passed.

> AGENT GENERATED: by GPT-5.6-Sol