### PR TITLE
Report the real app surface for desktop and API telemetry

### DIFF
--- a/apps/server/src/request-context.ts
+++ b/apps/server/src/request-context.ts
@@ -1,8 +1,8 @@
 import { getConnInfo } from "@hono/node-server/conninfo";
 import {
+  APP_SURFACE_API,
   APP_SURFACE_HEADER_NAME,
   parseRequestAppSurface,
-  type AppSurface,
   type RequestAppSurface,
 } from "@bb/config/app-surface";
 import type { Context } from "hono";
@@ -55,12 +55,15 @@ export function getGateMachineId(context: GateAuthHeaderReader): string | null {
   return value ? value : null;
 }
 
-export function resolveRequestAppSurface(
-  context: Context,
-  fallback: AppSurface,
-): RequestAppSurface {
+/**
+ * The surface that made this request. A request without the header comes from
+ * the bb CLI, the SDK, an automation, or an agent, so it is `api`. It must not
+ * inherit the server surface: that counted headless traffic as desktop or web
+ * users.
+ */
+export function resolveRequestAppSurface(context: Context): RequestAppSurface {
   return (
     parseRequestAppSurface(context.req.header(APP_SURFACE_HEADER_NAME)) ??
-    fallback
+    APP_SURFACE_API
   );
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -304,11 +304,7 @@ export function createApp(
 
   app.use("*", async (context, next) => {
     captureTrustedRemoteAddress(context);
-    const appSurface = resolveRequestAppSurface(
-      context,
-      deps.config.appSurface,
-    );
-    return runWithTelemetryAppSurface(appSurface, next);
+    return runWithTelemetryAppSurface(resolveRequestAppSurface(context), next);
   });
   app.use("*", async (context, next) => {
     const path = context.req.path;

--- a/apps/server/src/services/system/telemetry.ts
+++ b/apps/server/src/services/system/telemetry.ts
@@ -11,7 +11,14 @@ import type { ServerLogger } from "../../types.js";
  * user message counts, and plugin installs) to PostHog so install/activation
  * funnels can be measured.
  * Identification is a random per-install id persisted in the data dir — no
- * user, host, project, workspace, or message content is ever attached.
+ * user, host, project, workspace, or message content is ever attached. One
+ * install can use more than one surface, so a per-surface unique count of
+ * `distinct_id` counts that install in each surface it used.
+ *
+ * Every event carries `app_surface`. For a request-scoped event that is the
+ * client that made the request (`desktop`, `web`, `mobile`, or `api` for the
+ * CLI, SDK, automations, and agents). For an event outside a request, such as
+ * `app_started`, it is the surface the server itself runs as.
  *
  * Delivery is intentionally fire-and-forget: events are analytics, not
  * workflow state, so lost sends (offline, PostHog outage, process exit

--- a/apps/server/test/request-context.test.ts
+++ b/apps/server/test/request-context.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   captureTrustedRemoteAddress,
   getTrustedRemoteAddress,
+  resolveRequestAppSurface,
   TRUSTED_REMOTE_ADDRESS_CONTEXT_KEY,
 } from "../src/request-context.js";
 
@@ -47,5 +48,29 @@ describe("request context", () => {
     await expect(response.json()).resolves.toEqual({
       hasAddress: false,
     });
+  });
+  it("resolves the app surface from the client header and falls back to api", async () => {
+    const app = new Hono();
+    app.get("/", (context) =>
+      context.json({ surface: resolveRequestAppSurface(context) }),
+    );
+
+    const surfaceFor = async (header: string | undefined): Promise<unknown> => {
+      const response = await app.request(
+        "/",
+        header === undefined
+          ? undefined
+          : { headers: { "x-bb-app-surface": header } },
+      );
+      const body = (await response.json()) as { surface: string };
+      return body.surface;
+    };
+
+    await expect(surfaceFor("desktop")).resolves.toBe("desktop");
+    await expect(surfaceFor("mobile")).resolves.toBe("mobile");
+    // The bb CLI, the SDK, automations, and agents send no header. They must
+    // not count as desktop or web users.
+    await expect(surfaceFor(undefined)).resolves.toBe("api");
+    await expect(surfaceFor("tv")).resolves.toBe("api");
   });
 });

--- a/packages/bb-app/src/launcher.ts
+++ b/packages/bb-app/src/launcher.ts
@@ -28,6 +28,7 @@ import {
   APP_SURFACE_WEB,
   DEFAULT_APP_SURFACE,
   parseAppSurface,
+  type AppSurface,
 } from "@bb/config/app-surface";
 import {
   BB_APP_MANAGED_CONFIG_KEYS,
@@ -494,7 +495,7 @@ interface CreateSharedEnvArgs {
   env: NodeJS.ProcessEnv;
 }
 
-interface CreateServerEnvArgs {
+export interface CreateServerEnvArgs {
   context: BbAppStartContext;
   env: NodeJS.ProcessEnv;
 }
@@ -2558,11 +2559,21 @@ function createSharedEnv(args: CreateSharedEnvArgs): NodeJS.ProcessEnv {
   };
 }
 
-function createServerEnv(args: CreateServerEnvArgs): NodeJS.ProcessEnv {
+/**
+ * Surface the server reports for telemetry. The desktop shell spawns this
+ * launcher with `BB_APP_SURFACE=desktop`, so an inherited (or env.json) value
+ * wins; a plain `bb-app` start has none and is the web surface. Overwriting
+ * this with `web` unconditionally made every desktop launch report `web`.
+ */
+function resolveServerAppSurface(env: NodeJS.ProcessEnv): AppSurface {
+  return parseAppSurface(env[APP_SURFACE_ENV_NAME]) ?? APP_SURFACE_WEB;
+}
+
+export function createServerEnv(args: CreateServerEnvArgs): NodeJS.ProcessEnv {
   return {
     ...args.env,
     BB_APP_VERSION: args.context.appVersion,
-    [APP_SURFACE_ENV_NAME]: APP_SURFACE_WEB,
+    [APP_SURFACE_ENV_NAME]: resolveServerAppSurface(args.env),
     // The daemon bundle holds the bb CLI. Server-side features that shell out
     // — script automations put it on the script's PATH — otherwise have no way
     // to find it: bb lives in the bundle directory, which is on no shell PATH.

--- a/packages/bb-app/test/index.test.ts
+++ b/packages/bb-app/test/index.test.ts
@@ -33,6 +33,7 @@ import {
 import {
   completeFullStackSupervision,
   createDaemonEnv,
+  createServerEnv,
   createHostDaemonJoinEnv,
   readBbAppPackageVersion,
   resolveServerListenerUrl,
@@ -2155,5 +2156,23 @@ describe("bb-app launcher", () => {
       "host-daemon/dist/bb-plugin-host-worker.mjs",
     );
     expect(metadata.os).toEqual(["darwin", "linux"]);
+  });
+
+  it("keeps the desktop app surface the desktop shell passes to the server", () => {
+    const context = createTestStartContext();
+
+    const desktopServerEnv = createServerEnv({
+      context,
+      env: { BB_APP_SURFACE: "desktop" },
+    });
+    const webServerEnv = createServerEnv({ context, env: {} });
+    const invalidSurfaceServerEnv = createServerEnv({
+      context,
+      env: { BB_APP_SURFACE: "bogus" },
+    });
+
+    expect(desktopServerEnv.BB_APP_SURFACE).toBe("desktop");
+    expect(webServerEnv.BB_APP_SURFACE).toBe("web");
+    expect(invalidSurfaceServerEnv.BB_APP_SURFACE).toBe("web");
   });
 });

--- a/packages/config/src/app-surface.ts
+++ b/packages/config/src/app-surface.ts
@@ -10,16 +10,23 @@ export type AppSurface = (typeof APP_SURFACE_VALUES)[number];
 
 /**
  * Surfaces a client may declare on a request (`x-bb-app-surface`). Includes
- * the native mobile app, which is never a server-side surface.
+ * the native mobile app and `api`, neither of which is a server-side surface.
+ *
+ * `api` is the surface of a request that declares no header: the bb CLI, the
+ * SDK, automations, and agent-driven work. Those callers must not land in the
+ * `desktop` or `web` buckets, because that makes headless traffic look like a
+ * person at a user interface.
  */
 export const REQUEST_APP_SURFACE_VALUES = [
   ...APP_SURFACE_VALUES,
+  "api",
   "mobile",
 ] as const;
 export type RequestAppSurface = (typeof REQUEST_APP_SURFACE_VALUES)[number];
 
 export const APP_SURFACE_DESKTOP: AppSurface = "desktop";
 export const APP_SURFACE_WEB: AppSurface = "web";
+export const APP_SURFACE_API: RequestAppSurface = "api";
 export const APP_SURFACE_MOBILE: RequestAppSurface = "mobile";
 export const DEFAULT_APP_SURFACE: AppSurface = APP_SURFACE_WEB;
 

--- a/packages/config/test/app-surface.test.ts
+++ b/packages/config/test/app-surface.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from "vitest";
 import { parseAppSurface, parseRequestAppSurface } from "../src/app-surface.js";
 
 describe("app surface parsing", () => {
-  it("accepts mobile only as a request surface", () => {
-    // `mobile` is a client declaration (x-bb-app-surface); a bb server can
-    // never be configured as the mobile surface (BB_APP_SURFACE).
+  it("accepts mobile and api only as request surfaces", () => {
+    // `mobile` and `api` are client declarations (x-bb-app-surface); a bb
+    // server can never run as either surface (BB_APP_SURFACE).
     expect(parseRequestAppSurface("mobile")).toBe("mobile");
+    expect(parseRequestAppSurface("api")).toBe("api");
     expect(parseRequestAppSurface(" web ")).toBe("web");
     expect(parseAppSurface("mobile")).toBeUndefined();
+    expect(parseAppSurface("api")).toBeUndefined();
     expect(parseAppSurface("desktop")).toBe("desktop");
   });
 


### PR DESCRIPTION
## What was wrong

Desktop usage reported as web, so the desktop app looked unused.

The desktop shell spawns `bb-app` with `BB_APP_SURFACE=desktop`, but the launcher's `createServerEnv` wrote `BB_APP_SURFACE=web` into the server environment unconditionally (`packages/bb-app/src/launcher.ts`, added in d09e2116d). The marker never reached the server, so every desktop launch sent `app_started` with `app_surface: "web"`. The same line silently ignored `BB_APP_SURFACE` in `env.json`, which the launcher lists as a startup-only managed env key.

A second path polluted the split. `resolveRequestAppSurface` fell back to the server's own surface when a request carried no `x-bb-app-surface` header. Only the web app and the mobile app send that header, so the bb CLI, the SDK, automations, and agent-created threads landed in the `web` bucket — and would have landed in `desktop` on a desktop-spawned server once the launcher bug was fixed. Headless traffic counted as people at a user interface.

## What changed

- `packages/bb-app/src/launcher.ts`: `createServerEnv` keeps an inherited or configured surface through the new `resolveServerAppSurface` helper, and still defaults to `web`. `createServerEnv` and `CreateServerEnvArgs` are exported for the test.
- `packages/config/src/app-surface.ts`: adds the `api` request surface and `APP_SURFACE_API`. It is a request surface only; a bb server can never run as `api`, so `parseAppSurface` still rejects it.
- `apps/server/src/request-context.ts`: `resolveRequestAppSurface` takes no fallback argument and resolves a headerless or unknown-header request to `api`.
- `apps/server/src/server.ts`: the telemetry middleware drops the server-surface fallback.
- `apps/server/src/services/system/telemetry.ts`: documents what `app_surface` means per event, and that `distinct_id` is per install, so one install that uses two surfaces counts in both.

No wire change between the server and the host daemon, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged. `BB_APP_SURFACE` stays an internal launcher marker, and its `docs/configuration.md` entry stays correct.

Read the desktop-vs-web split from `user_message_sent` or `thread_created` broken down by `app_surface`. Those are per-client events. `app_started` reports the surface the server runs as, which misses the case where the desktop shell adopts an already-running `bb-app`.

## How you verified

- `packages/bb-app/test/index.test.ts`: new test asserts an inherited `desktop` survives, an absent value gives `web`, and a bogus value gives `web`. It fails before the launcher fix (`BB_APP_SURFACE` came back as `web`) and passes after.
- `apps/server/test/request-context.test.ts`: new test asserts `desktop` and `mobile` headers pass through and that an absent or unknown header gives `api`.
- `packages/config/test/app-surface.test.ts`: extends the request-vs-server parser test to cover `api`.
- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/config --filter=@bb/app --filter=bb-app --filter=@bb/desktop` — passes.
- `pnpm exec turbo run test --filter=@bb/config --filter=bb-app` — passes. `pnpm exec turbo run test --filter=@bb/app -- --run src/lib/app-surface.test.ts` — passes.
- `pnpm exec turbo run test --filter=@bb/server` — 1814 passed, 1 failed. The failure is `test/internal/internal-skill-trees.test.ts`, which expects file mode `0o644` while the local umask is `0002`. It is unrelated to this change.

No issue filed; reported directly.

> AGENT GENERATED: by Claude Opus 5
