### PR TITLE
Preserve Docs opener host routing

### DIFF
--- a/plugins/docs/app.test.tsx
+++ b/plugins/docs/app.test.tsx
@@ -1273,31 +1273,72 @@ describe("Docs nav panel", () => {
     });
   });
 
-  it("opens arbitrary Markdown files without exposing composer actions", async () => {
+  it("preserves an explicit host for file opener reads and autosaves", async () => {
     const slot = renderSlot(
       app.fileOpeners[0]!,
       {
-        path: "notes/plan.mdx",
+        path: "/Users/shared/notes/plan.mdx",
         source: {
-          kind: "workspace",
+          kind: "host",
           threadId: "thr_1",
-          environmentId: "env_1",
+          environmentId: null,
           projectId: "project_1",
+          experimental_hostId: "host_remote",
         },
         experimental_Original: () => null,
       },
       {
         rpc: {
           openFile: () => ({
-            file: { content: "# Workspace plan", sha256: "sha" },
+            file: { content: "# Remote plan", sha256: "sha" },
             preview,
             previewPath: "notes/plan.mdx",
+          }),
+          saveOpenedFile: () => ({
+            outcome: "written",
+            sha256: "updated-sha",
           }),
         },
       },
     );
 
-    await slot.findByText("Workspace plan");
+    const body = await slot.findByText("Remote plan");
+    expect(slot.rpcCalls).toContainEqual({
+      method: "openFile",
+      input: {
+        source: {
+          kind: "host",
+          threadId: "thr_1",
+          environmentId: null,
+          projectId: "project_1",
+          experimental_hostId: "host_remote",
+        },
+        path: "/Users/shared/notes/plan.mdx",
+      },
+    });
+
+    body.textContent = "Updated remote plan";
+    fireEvent.input(body);
+    await waitFor(
+      () => {
+        expect(slot.rpcCalls).toContainEqual({
+          method: "saveOpenedFile",
+          input: {
+            source: {
+              kind: "host",
+              threadId: "thr_1",
+              environmentId: null,
+              projectId: "project_1",
+              experimental_hostId: "host_remote",
+            },
+            path: "/Users/shared/notes/plan.mdx",
+            content: "# Updated remote plan",
+            expectedSha256: "sha",
+          },
+        });
+      },
+      { timeout: 2_000 },
+    );
     expect(slot.queryByRole("button", { name: "Add to chat" })).toBeNull();
     expect(slot.queryByRole("button", { name: "Mention in chat" })).toBeNull();
   });

--- a/plugins/docs/app.tsx
+++ b/plugins/docs/app.tsx
@@ -1172,8 +1172,17 @@ function DocsFileOpener({ path: filePath, source }: PluginFileOpenerProps) {
       threadId: source.threadId,
       environmentId: source.environmentId,
       projectId: source.projectId,
+      ...(source.experimental_hostId === undefined
+        ? {}
+        : { experimental_hostId: source.experimental_hostId }),
     }),
-    [source.environmentId, source.kind, source.projectId, source.threadId],
+    [
+      source.environmentId,
+      source.experimental_hostId,
+      source.kind,
+      source.projectId,
+      source.threadId,
+    ],
   );
   const [state, setState] = useState<
     | { content: string; lease: PreviewLease; previewPath: string }

--- a/plugins/docs/server.test.ts
+++ b/plugins/docs/server.test.ts
@@ -281,6 +281,7 @@ describe("Docs RPC contract", () => {
         threadId: string | null;
         environmentId: string | null;
         projectId: string | null;
+        experimental_hostId?: string;
       };
       path: string;
     }>();
@@ -1056,6 +1057,97 @@ describe("Docs vault operations", () => {
         content: "# Updated",
         expectedSha256: "test-sha",
       },
+    ]);
+  });
+
+  it("routes explicit host opener reads, previews, and saves to that host", async () => {
+    const rootPath = "/shared";
+    const filePath = "/shared/plan.md";
+    const host = createFakePluginHost({
+      pluginId: "simple-notes",
+      sdk: {
+        files: {
+          mkdir: async () => ({ ok: true as const }),
+          read: async ({ hostId, path: openedPath }) => ({
+            path: openedPath,
+            content:
+              hostId === "host_remote" ? "# Remote plan" : "# Primary plan",
+            contentEncoding: "utf8" as const,
+            mimeType: "text/markdown",
+            sizeBytes: 13,
+            modifiedAtMs: 1,
+            sha256: hostId === "host_remote" ? "remote-sha" : "primary-sha",
+          }),
+          write: async ({ hostId }) => ({
+            outcome: "written" as const,
+            sha256:
+              hostId === "host_remote"
+                ? "remote-written-sha"
+                : "primary-written-sha",
+            sizeBytes: 21,
+          }),
+          createPreview: async ({ hostId }) => ({
+            baseUrl:
+              hostId === "host_remote" ? "/remote-preview" : "/primary-preview",
+            expiresAtMs: Date.now() + 60_000,
+          }),
+        },
+      },
+    });
+    await simpleNotes(host.bb);
+    host.harness.sdk.calls.length = 0;
+    const source = {
+      kind: "host",
+      threadId: "thread_1",
+      environmentId: null,
+      projectId: "project_1",
+      experimental_hostId: "host_remote",
+    };
+
+    await expect(
+      host.harness.callRpc("openFile", { source, path: filePath }),
+    ).resolves.toEqual({
+      file: {
+        path: filePath,
+        content: "# Remote plan",
+        contentEncoding: "utf8",
+        mimeType: "text/markdown",
+        sizeBytes: 13,
+        modifiedAtMs: 1,
+        sha256: "remote-sha",
+      },
+      preview: expect.objectContaining({ baseUrl: "/remote-preview" }),
+      previewPath: "plan.md",
+    });
+    await expect(
+      host.harness.callRpc("saveOpenedFile", {
+        source,
+        path: filePath,
+        content: "# Updated remote plan",
+        expectedSha256: "remote-sha",
+      }),
+    ).resolves.toEqual({
+      outcome: "written",
+      sha256: "remote-written-sha",
+      sizeBytes: 21,
+    });
+
+    expect(host.harness.sdk.callsTo("files.read")).toEqual([
+      [{ hostId: "host_remote", path: filePath, rootPath }],
+    ]);
+    expect(host.harness.sdk.callsTo("files.createPreview")).toEqual([
+      [{ hostId: "host_remote", rootPath }],
+    ]);
+    expect(host.harness.sdk.callsTo("files.write")).toEqual([
+      [
+        {
+          hostId: "host_remote",
+          path: filePath,
+          rootPath,
+          content: "# Updated remote plan",
+          expectedSha256: "remote-sha",
+        },
+      ],
     ]);
   });
 

--- a/plugins/docs/server.ts
+++ b/plugins/docs/server.ts
@@ -134,6 +134,7 @@ interface OpenerSource {
   threadId: string | null;
   environmentId: string | null;
   projectId: string | null;
+  experimental_hostId?: string;
 }
 
 interface ResolvedOpenerFile {
@@ -171,6 +172,7 @@ const openerSourceSchema = z
     threadId: z.string().nullable(),
     environmentId: z.string().nullable(),
     projectId: z.string().nullable(),
+    experimental_hostId: z.string().min(1).optional(),
   })
   .strict();
 const fileReadSchema = z
@@ -500,6 +502,9 @@ function parseOpenerSource(value: unknown): OpenerSource {
     environmentId:
       typeof source.environmentId === "string" ? source.environmentId : null,
     projectId: typeof source.projectId === "string" ? source.projectId : null,
+    ...(typeof source.experimental_hostId === "string"
+      ? { experimental_hostId: source.experimental_hostId }
+      : {}),
   };
 }
 
@@ -1012,7 +1017,7 @@ export default async function plugin(
       return {
         path: normalized,
         rootPath: pathApi.dirname(normalized),
-        hostId: null,
+        hostId: source.experimental_hostId ?? null,
       };
     }
     if (source.kind === "workspace" && source.environmentId) {


### PR DESCRIPTION
## What was wrong

The Docs file opener rebuilt the SDK's `PluginFileOpenerSource` for its private RPC contract but dropped `experimental_hostId`. Its backend schema could not accept that field, and host-file resolution hardcoded `hostId: null`, so opening, previewing, or autosaving a file selected on remote host A could read or overwrite the same absolute path on the primary host.

## What changed

The Docs app now carries the existing optional `experimental_hostId` through its opener source for both `openFile` and `saveOpenedFile`. The Docs RPC schema and parser preserve that value, and host-file resolution returns it to the existing Files SDK read, preview, and write calls. When the field is omitted, resolution still returns `null`, intentionally preserving primary-host behavior.

This is the smallest complete fix because it extends the direct data flow for the existing SDK source identity; it does not add a parallel host field or refactor unrelated routing. PR #2083 is now merged, and this branch is rebased on top of it; that PR changes persisted app-tab source routing, while this change fixes the separate Docs app/server RPC hop.

There is no host-daemon wire change: the plugin RPC is server-owned and the Files SDK already supports its host selector, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged. There are no CLI, guide, SDK, or user-facing configuration changes.

## How you verified

The regressions failed before the implementation with the exact routing break: the app test received an opener source without `experimental_hostId`, while the server test rejected it as an unrecognized schema key (2 failed, 56 passed):

- `pnpm exec turbo run test --filter=bb-plugin-simple-notes -- app.test.tsx server.test.ts`

After the fix:

- The same focused command passed 58 tests. The app regression verifies read and autosave RPC identities, and the two-host server regression gives the primary and remote hosts different content, preview URLs, and write results, then proves read, preview, and save all selected `host_remote`.
- `pnpm exec turbo run test typecheck build --filter=bb-plugin-simple-notes --force` passed after the final rebase: 65 tests passed; the Docs typecheck and build passed; 7 Turbo tasks succeeded.
- `git diff --check origin/main...HEAD` passed.

Related to #2005 and #2083.

> AGENT GENERATED: by GPT-5.6-Sol
