### PR TITLE
Fix queued external file dispatch

### DIFF
--- a/apps/app/src/components/plugin/AppFileExternalNavigationHost.test.tsx
+++ b/apps/app/src/components/plugin/AppFileExternalNavigationHost.test.tsx
@@ -12,11 +12,12 @@ import { useAppNavigationHost } from "@/lib/app-navigation-host";
 import { AppFileExternalNavigationHost } from "./AppFileExternalNavigationHost";
 
 const openPreferred = vi.hoisted(() => vi.fn());
+const recordAccepted = vi.fn();
 
 vi.mock("@/hooks/useResolvedLiveFileTarget", () => ({
-  useResolvedLiveFileTarget: () => ({
+  useResolvedLiveFileTarget: (target: { path: string }) => ({
     status: "available",
-    absolutePath: "/workspace/src/example.ts",
+    absolutePath: `/workspace/${target.path}`,
     hostId: "host_1",
     openContext: { kind: "local" },
   }),
@@ -32,21 +33,47 @@ vi.mock("@/hooks/useLocalOpenTargets", () => ({
 function Probe() {
   const navigation = useAppNavigationHost();
   return (
-    <button
-      type="button"
-      onClick={() =>
-        navigation.openFileExternally({
-          target: {
-            kind: "workspace",
-            environmentId: "env_1",
-            path: "src/example.ts",
-          },
-          location: { kind: "line", line: 12, column: 3 },
-        })
-      }
-    >
-      Open external
-    </button>
+    <>
+      <button
+        type="button"
+        onClick={() =>
+          navigation.openFileExternally({
+            target: {
+              kind: "workspace",
+              environmentId: "env_1",
+              path: "src/example.ts",
+            },
+            location: { kind: "line", line: 12, column: 3 },
+          })
+        }
+      >
+        Open external
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          const firstAccepted = navigation.openFileExternally({
+            target: {
+              kind: "workspace",
+              environmentId: "env_1",
+              path: "src/first.ts",
+            },
+            location: { kind: "line", line: 10, column: 2 },
+          });
+          const secondAccepted = navigation.openFileExternally({
+            target: {
+              kind: "workspace",
+              environmentId: "env_1",
+              path: "src/second.ts",
+            },
+            location: { kind: "line", line: 20, column: 4 },
+          });
+          recordAccepted(firstAccepted, secondAccepted);
+        }}
+      >
+        Open two external
+      </button>
+    </>
   );
 }
 
@@ -54,6 +81,7 @@ afterEach(() => {
   cleanup();
   openPreferred.mockReset();
   openPreferred.mockResolvedValue(true);
+  recordAccepted.mockReset();
 });
 
 describe("AppFileExternalNavigationHost", () => {
@@ -73,5 +101,29 @@ describe("AppFileExternalNavigationHost", () => {
         }),
       { timeout: 5_000 },
     );
+  });
+
+  it("dispatches queued intents once each in FIFO order", async () => {
+    render(
+      <AppFileExternalNavigationHost>
+        <Probe />
+      </AppFileExternalNavigationHost>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Open two external" }));
+
+    expect(recordAccepted).toHaveBeenCalledWith(true, true);
+    await waitFor(() => expect(openPreferred).toHaveBeenCalledTimes(2), {
+      timeout: 5_000,
+    });
+    expect(openPreferred).toHaveBeenNthCalledWith(1, {
+      columnNumber: 2,
+      lineNumber: 10,
+      path: "/workspace/src/first.ts",
+    });
+    expect(openPreferred).toHaveBeenNthCalledWith(2, {
+      columnNumber: 4,
+      lineNumber: 20,
+      path: "/workspace/src/second.ts",
+    });
   });
 });

--- a/apps/app/src/components/plugin/AppFileExternalNavigationHost.tsx
+++ b/apps/app/src/components/plugin/AppFileExternalNavigationHost.tsx
@@ -19,15 +19,21 @@ const LazyAppFileExternalNavigationDispatcher = lazy(() =>
   ),
 );
 
+interface ExternalFileIntentRequest {
+  id: number;
+  intent: ExperimentalFileOpenOptions;
+}
+
 /** App-wide preferred-external file dispatcher; discovery starts on activation. */
 export function AppFileExternalNavigationHost({
   children,
 }: {
   children: ReactNode;
 }) {
-  const [queue, setQueue] = useState<ExperimentalFileOpenOptions[]>([]);
+  const [queue, setQueue] = useState<ExternalFileIntentRequest[]>([]);
   const queueRef = useRef(queue);
-  const replaceQueue = useCallback((next: ExperimentalFileOpenOptions[]) => {
+  const nextRequestIdRef = useRef(0);
+  const replaceQueue = useCallback((next: ExternalFileIntentRequest[]) => {
     queueRef.current = next;
     setQueue(next);
   }, []);
@@ -38,7 +44,9 @@ export function AppFileExternalNavigationHost({
       }
       // Public SDK callers are parsed by useBbNavigate before capabilities are
       // invoked; this host only queues that already-normalized internal value.
-      replaceQueue([...queueRef.current, intent]);
+      const request = { id: nextRequestIdRef.current, intent };
+      nextRequestIdRef.current += 1;
+      replaceQueue([...queueRef.current, request]);
       return true;
     },
     [replaceQueue],
@@ -58,7 +66,8 @@ export function AppFileExternalNavigationHost({
       {current === null ? null : (
         <Suspense fallback={null}>
           <LazyAppFileExternalNavigationDispatcher
-            intent={current}
+            key={current.id}
+            intent={current.intent}
             onSettled={settleCurrent}
           />
         </Suspense>


### PR DESCRIPTION
## What was wrong

PR #2005 queued normalized external-file intents but rendered one unkeyed `AppFileExternalNavigationDispatcher`. After the first request settled, React reused that component for the next queue item, so its `didSettleRef` remained `true`; the second accepted request neither dispatched nor left the queue, and every later request remained blocked behind it. This is the verified [post-merge review finding](https://github.com/get-bb/bb/pull/2005#discussion_r3824540680).

## What changed

- Queue entries now pair each intent with a host-local monotonic request ID.
- The lazy dispatcher is keyed by that ID, giving every accepted FIFO item an independent settle lifecycle while preserving the activation-only dynamic import.
- The host regression submits two requests in the same event, confirms both were accepted, and verifies exactly-once dispatch in FIFO order.

This is intentionally limited to internal React state and identity. It does not change the experimental plugin SDK signature, public plugin API, server/daemon wire data, or host RPC contracts, so no API audit entry or `HOST_DAEMON_PROTOCOL_VERSION` bump is needed.

## How you verified

Before the production change, the new focused regression failed with one dispatch: `expected "vi.fn()" to be called 2 times, but got 1 times`.

After the fix and a clean rebase onto current `origin/main` (`7f3d2ac66`):

- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/plugin/AppFileExternalNavigationHost.test.tsx` — 2 passed.
- `pnpm exec turbo run test --filter=@bb/app --force` — 411 files passed; 3,157 tests passed and 3 skipped.
- `pnpm exec turbo run typecheck --filter=@bb/app --force` — passed.
- `pnpm exec turbo run lint --filter=@bb/app --force` — passed with 0 errors (156 existing warnings).
- `pnpm exec turbo run build --filter=@bb/app --force` — passed.
- `node apps/app/scripts/check-bundle-budget.mjs` — passed (boot payload 428.7 KB Brotli vs. 467.8 KB budget).

> AGENT GENERATED: by GPT-5.6-Sol
