### PR TITLE
Graduate idle provider session reaping

### DIFF
--- a/apps/app/src/components/layout/AppLayout.plugin-panel-header.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.plugin-panel-header.test.tsx
@@ -26,7 +26,6 @@ vi.mock("@/hooks/queries/system-queries", () => ({
         changelogPreview: false,
         editMessages: false,
         mobileApp: false,
-        providerSessionReaping: false,
         timelineWindowing: false,
       },
     },

--- a/apps/app/src/components/layout/AppLayout.root-compose-project.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.root-compose-project.test.tsx
@@ -31,7 +31,6 @@ vi.mock("@/hooks/queries/system-queries", () => ({
         changelogPreview: false,
         editMessages: false,
         mobileApp: false,
-        providerSessionReaping: false,
         timelineWindowing: false,
       },
     },

--- a/apps/app/src/components/layout/AppLayout.sidebar-resize.test.tsx
+++ b/apps/app/src/components/layout/AppLayout.sidebar-resize.test.tsx
@@ -37,7 +37,6 @@ vi.mock("@/hooks/queries/system-queries", () => ({
     data: {
       experiments: {
         editMessages: false,
-        providerSessionReaping: false,
       },
     },
   }),

--- a/apps/app/src/lib/system-config-atoms.ts
+++ b/apps/app/src/lib/system-config-atoms.ts
@@ -24,7 +24,6 @@ const unavailableSystemConfig: SystemConfigResponse = {
     changelogPreview: false,
     editMessages: false,
     mobileApp: false,
-    providerSessionReaping: false,
     timelineWindowing: false,
   },
   appearance: defaultAppTheme,

--- a/apps/app/src/views/SettingsView.experiments.test.tsx
+++ b/apps/app/src/views/SettingsView.experiments.test.tsx
@@ -8,7 +8,6 @@ afterEach(cleanup);
 function renderSection(overrides?: {
   onChangelogPreviewEnabledChange?: (enabled: boolean) => void;
   onMobileAppEnabledChange?: (enabled: boolean) => void;
-  onProviderSessionReapingEnabledChange?: (enabled: boolean) => void;
   onTimelineWindowingEnabledChange?: (enabled: boolean) => void;
 }) {
   return render(
@@ -17,16 +16,12 @@ function renderSection(overrides?: {
       disabled={false}
       editMessagesEnabled={false}
       mobileAppEnabled={false}
-      providerSessionReapingEnabled={false}
       timelineWindowingEnabled={false}
       onChangelogPreviewEnabledChange={
         overrides?.onChangelogPreviewEnabledChange ?? vi.fn()
       }
       onEditMessagesEnabledChange={vi.fn()}
       onMobileAppEnabledChange={overrides?.onMobileAppEnabledChange ?? vi.fn()}
-      onProviderSessionReapingEnabledChange={
-        overrides?.onProviderSessionReapingEnabledChange ?? vi.fn()
-      }
       onTimelineWindowingEnabledChange={
         overrides?.onTimelineWindowingEnabledChange ?? vi.fn()
       }
@@ -46,13 +41,6 @@ describe("ExperimentsSettingsSection", () => {
     const onChange = vi.fn();
     renderSection({ onMobileAppEnabledChange: onChange });
     fireEvent.click(screen.getByLabelText("Mobile app"));
-    expect(onChange).toHaveBeenCalledWith(true);
-  });
-
-  it("reports idle provider session release changes", () => {
-    const onChange = vi.fn();
-    renderSection({ onProviderSessionReapingEnabledChange: onChange });
-    fireEvent.click(screen.getByLabelText("Idle provider session release"));
     expect(onChange).toHaveBeenCalledWith(true);
   });
 

--- a/apps/app/src/views/SettingsView.stories.tsx
+++ b/apps/app/src/views/SettingsView.stories.tsx
@@ -356,7 +356,6 @@ function ExperimentsStory() {
       disabled={false}
       editMessagesEnabled={state.experiments.editMessages}
       mobileAppEnabled={state.experiments.mobileApp}
-      providerSessionReapingEnabled={state.experiments.providerSessionReaping}
       timelineWindowingEnabled={state.experiments.timelineWindowing}
       onChangelogPreviewEnabledChange={(enabled) =>
         state.setExperiments((current) => ({
@@ -374,12 +373,6 @@ function ExperimentsStory() {
         state.setExperiments((current) => ({
           ...current,
           mobileApp: enabled,
-        }))
-      }
-      onProviderSessionReapingEnabledChange={(enabled) =>
-        state.setExperiments((current) => ({
-          ...current,
-          providerSessionReaping: enabled,
         }))
       }
       onTimelineWindowingEnabledChange={(enabled) =>

--- a/apps/app/src/views/SettingsView.tsx
+++ b/apps/app/src/views/SettingsView.tsx
@@ -186,12 +186,10 @@ interface ExperimentsSettingsSectionProps {
   changelogPreviewEnabled: boolean;
   editMessagesEnabled: boolean;
   mobileAppEnabled: boolean;
-  providerSessionReapingEnabled: boolean;
   timelineWindowingEnabled: boolean;
   onChangelogPreviewEnabledChange: (enabled: boolean) => void;
   onEditMessagesEnabledChange: (enabled: boolean) => void;
   onMobileAppEnabledChange: (enabled: boolean) => void;
-  onProviderSessionReapingEnabledChange: (enabled: boolean) => void;
   onTimelineWindowingEnabledChange: (enabled: boolean) => void;
 }
 
@@ -883,20 +881,16 @@ export function ProviderSettingsSection({
 const CHANGELOG_PREVIEW_EXPERIMENT_LABEL = "Changelog preview";
 const EDIT_MESSAGES_EXPERIMENT_LABEL = "Edit messages";
 const MOBILE_APP_EXPERIMENT_LABEL = "Mobile app";
-const PROVIDER_SESSION_REAPING_EXPERIMENT_LABEL =
-  "Idle provider session release";
 const TIMELINE_WINDOWING_EXPERIMENT_LABEL = "Timeline windowing";
 export function ExperimentsSettingsSection({
   changelogPreviewEnabled,
   disabled,
   editMessagesEnabled,
   mobileAppEnabled,
-  providerSessionReapingEnabled,
   timelineWindowingEnabled,
   onChangelogPreviewEnabledChange,
   onEditMessagesEnabledChange,
   onMobileAppEnabledChange,
-  onProviderSessionReapingEnabledChange,
   onTimelineWindowingEnabledChange,
 }: ExperimentsSettingsSectionProps) {
   return (
@@ -938,18 +932,6 @@ export function ExperimentsSettingsSection({
             disabled={disabled}
             onCheckedChange={onMobileAppEnabledChange}
             aria-label={MOBILE_APP_EXPERIMENT_LABEL}
-          />
-        </SettingsWithControl>
-
-        <SettingsWithControl
-          label={PROVIDER_SESSION_REAPING_EXPERIMENT_LABEL}
-          description="Release restorable provider sessions after 30 idle minutes. A change can take up to five minutes."
-        >
-          <Switch
-            checked={providerSessionReapingEnabled}
-            disabled={disabled}
-            onCheckedChange={onProviderSessionReapingEnabledChange}
-            aria-label={PROVIDER_SESSION_REAPING_EXPERIMENT_LABEL}
           />
         </SettingsWithControl>
 
@@ -1141,13 +1123,6 @@ export function SettingsView() {
           updateExperimentsMutation.mutate({
             ...experiments,
             mobileApp: enabled,
-          })
-        }
-        providerSessionReapingEnabled={experiments.providerSessionReaping}
-        onProviderSessionReapingEnabledChange={(enabled) =>
-          updateExperimentsMutation.mutate({
-            ...experiments,
-            providerSessionReaping: enabled,
           })
         }
         timelineWindowingEnabled={experiments.timelineWindowing}

--- a/apps/desktop/scripts/smoke-packaged-app.mjs
+++ b/apps/desktop/scripts/smoke-packaged-app.mjs
@@ -145,7 +145,6 @@ async function startSmokeServer({
         dataDir,
         experiments: {
           mobileApp: false,
-          providerSessionReaping: false,
         },
         featureFlags: {
           placeholder: false,

--- a/apps/desktop/test/preload-build.test.ts
+++ b/apps/desktop/test/preload-build.test.ts
@@ -130,7 +130,6 @@ async function startDesktopSmokeServer(
             changelogPreview: false,
             editMessages: false,
             mobileApp: false,
-            providerSessionReaping: false,
             timelineWindowing: false,
           },
           featureFlags: {

--- a/apps/host-daemon/src/app.test.ts
+++ b/apps/host-daemon/src/app.test.ts
@@ -632,7 +632,6 @@ describe("createHostDaemonApp", () => {
     const reaper = startIdleProviderSessionReaper({
       logger,
       nowMs: () => nowMs,
-      resolveProviderSessionReapingEnabled: async () => true,
       runtimeManager: {
         reapIdleProviderSessions,
       },
@@ -648,7 +647,6 @@ describe("createHostDaemonApp", () => {
     expect(reapIdleProviderSessions).toHaveBeenNthCalledWith(1, {
       idleForMs: 1_800_000,
       nowMs: 1_000,
-      providerSessionReapingEnabled: true,
     });
 
     nowMs = 2_000;
@@ -688,7 +686,6 @@ describe("createHostDaemonApp", () => {
     expect(reapIdleProviderSessions).toHaveBeenNthCalledWith(2, {
       idleForMs: 1_800_000,
       nowMs: 2_000,
-      providerSessionReapingEnabled: true,
     });
     expect(logger.warn).toHaveBeenCalledWith(
       {

--- a/apps/host-daemon/src/app.ts
+++ b/apps/host-daemon/src/app.ts
@@ -97,7 +97,6 @@ interface IdleProviderSessionReaperRuntimeManager {
 interface StartIdleProviderSessionReaperArgs {
   logger: HostDaemonLogger;
   nowMs: () => number;
-  resolveProviderSessionReapingEnabled: () => Promise<boolean>;
   runtimeManager: IdleProviderSessionReaperRuntimeManager;
   setIntervalFn: IdleProviderSessionReaperIntervalFn;
 }
@@ -161,22 +160,11 @@ export function startIdleProviderSessionReaper(
       return;
     }
     running = true;
-    void args
-      .resolveProviderSessionReapingEnabled()
-      .catch((error) => {
-        args.logger.warn(
-          { ...runtimeErrorLogFields(error) },
-          "Failed to read idle provider session experiment policy",
-        );
-        return false;
+    void args.runtimeManager
+      .reapIdleProviderSessions({
+        idleForMs: IDLE_PROVIDER_SESSION_REAP_AFTER_MS,
+        nowMs: args.nowMs(),
       })
-      .then((providerSessionReapingEnabled) =>
-        args.runtimeManager.reapIdleProviderSessions({
-          idleForMs: IDLE_PROVIDER_SESSION_REAP_AFTER_MS,
-          nowMs: args.nowMs(),
-          providerSessionReapingEnabled,
-        }),
-      )
       .then((result) => {
         if (result.reapedSessions.length === 0) {
           return;
@@ -699,8 +687,6 @@ export async function createHostDaemonApp(
   const idleProviderSessionReaper = startIdleProviderSessionReaper({
     logger: options.logger,
     nowMs: Date.now,
-    resolveProviderSessionReapingEnabled: async () =>
-      (await serverClient.getRuntimePolicy()).providerSessionReaping,
     runtimeManager,
     setIntervalFn: (callback, intervalMs) => {
       const timer = setInterval(callback, intervalMs);

--- a/apps/host-daemon/src/runtime-manager.test.ts
+++ b/apps/host-daemon/src/runtime-manager.test.ts
@@ -421,7 +421,6 @@ describe("RuntimeManager", () => {
       manager.reapIdleProviderSessions({
         idleForMs: 1_000,
         nowMs: 5_000,
-        providerSessionReapingEnabled: false,
       }),
     ).resolves.toEqual({
       reapedSessions: [
@@ -444,13 +443,11 @@ describe("RuntimeManager", () => {
     expect(firstRuntime.reapIdleProviderSessions).toHaveBeenCalledWith({
       idleForMs: 1_000,
       nowMs: 5_000,
-      providerSessionReapingEnabled: false,
       runThreadExclusive: expect.any(Function),
     });
     expect(secondRuntime.reapIdleProviderSessions).toHaveBeenCalledWith({
       idleForMs: 1_000,
       nowMs: 5_000,
-      providerSessionReapingEnabled: false,
       runThreadExclusive: expect.any(Function),
     });
   });
@@ -486,7 +483,6 @@ describe("RuntimeManager", () => {
     const result = await manager.reapIdleProviderSessions({
       idleForMs: 1_000,
       nowMs: 5_000,
-      providerSessionReapingEnabled: true,
     });
 
     expect(result.reapedSessions).toEqual([]);

--- a/apps/host-daemon/src/runtime-manager.ts
+++ b/apps/host-daemon/src/runtime-manager.ts
@@ -225,7 +225,6 @@ export interface RuntimeManagerOptions {
 export interface RuntimeManagerReapIdleProviderSessionsArgs {
   idleForMs: number;
   nowMs: number;
-  providerSessionReapingEnabled: boolean;
 }
 
 interface RuntimeManagerReapedIdleProviderSession extends ReapedIdleProviderSession {

--- a/apps/host-daemon/src/server-client.test.ts
+++ b/apps/host-daemon/src/server-client.test.ts
@@ -42,27 +42,6 @@ function createInteractiveRequest(): PendingInteractionCreate {
 }
 
 describe("createServerClient", () => {
-  it("reads the current runtime policy", async () => {
-    const fetchFn = vi.fn<FetchFn>(async (input, init) => {
-      expect(String(input)).toBe(
-        "https://bb.example.test/internal/runtime-policy",
-      );
-      expect(init?.method).toBe("GET");
-      return Response.json({ providerSessionReaping: true });
-    });
-    const client = createServerClient({
-      fetchFn,
-      getSessionId: () => "session-1",
-      hostKey: "host-key",
-      logger: createLogger(),
-      serverUrl: "https://bb.example.test",
-    });
-
-    await expect(client.getRuntimePolicy()).resolves.toEqual({
-      providerSessionReaping: true,
-    });
-  });
-
   it("narrows a protocol update retry request from error details", async () => {
     const fetchFn = vi.fn<FetchFn>(async () =>
       Response.json(

--- a/apps/host-daemon/src/server-client.ts
+++ b/apps/host-daemon/src/server-client.ts
@@ -4,7 +4,6 @@ import {
   hostDaemonEventBatchResponseSchema,
   hostDaemonInteractiveInterruptResponseSchema,
   hostDaemonInteractiveRequestResponseSchema,
-  hostDaemonRuntimePolicySchema,
   hostDaemonSessionOpenResponseSchema,
   hostDaemonSkillTreeSchema,
   hostDaemonToolCallResponseSchema,
@@ -17,7 +16,6 @@ import {
   type HostDaemonInteractiveInterruptRequest,
   type HostDaemonInteractiveRequest,
   type HostDaemonLoadedEnvironment,
-  type HostDaemonRuntimePolicy,
   type HostDaemonProjectAttachmentContentQuery,
   type HostDaemonSessionOpenRequest,
   type HostDaemonSessionOpenResponse,
@@ -182,7 +180,6 @@ interface OpenSessionArgs {
 }
 
 export interface ServerClient {
-  getRuntimePolicy(): Promise<HostDaemonRuntimePolicy>;
   openSession(args: OpenSessionArgs): Promise<HostDaemonSessionOpenResponse>;
   fetchProjectAttachment(
     args: FetchProjectAttachmentArgs,
@@ -449,17 +446,6 @@ export function createServerClient(
   }
 
   return {
-    async getRuntimePolicy(): Promise<HostDaemonRuntimePolicy> {
-      const response = await fetchFn(buildInternalUrl("/runtime-policy"), {
-        method: "GET",
-        headers: headers(),
-      });
-      if (!response.ok) {
-        throw await createResponseError("get runtime policy", response);
-      }
-      return hostDaemonRuntimePolicySchema.parse(await response.json());
-    },
-
     async openSession(
       args: OpenSessionArgs,
     ): Promise<HostDaemonSessionOpenResponse> {

--- a/apps/host-daemon/src/server-connection.test.ts
+++ b/apps/host-daemon/src/server-connection.test.ts
@@ -84,7 +84,6 @@ function createServerClientFixture(args: CreateServerClientFixtureArgs = {}) {
   };
   const serverClient = {
     openSession,
-    getRuntimePolicy: unused,
     fetchProjectAttachment: unused,
     fetchSkillTree: unused,
     fetchPluginHostArtifact: unused,

--- a/apps/mobile/e2e/scripts/phase7-settings-reset.js
+++ b/apps/mobile/e2e/scripts/phase7-settings-reset.js
@@ -8,7 +8,6 @@ const experiments = http.put(`${SERVER_URL}/api/v1/settings/experiments`, {
     editMessages: true,
     mobileApp: false,
     newOnboarding: false,
-    providerSessionReaping: false,
   }),
 });
 if (!experiments.ok) {

--- a/apps/mobile/src/screens/settings/ExperimentsSettingsScreen.tsx
+++ b/apps/mobile/src/screens/settings/ExperimentsSettingsScreen.tsx
@@ -27,12 +27,6 @@ const EXPERIMENT_ROWS: readonly ExperimentRow[] = [
     description:
       "Pair the bb mobile app over bb connect: shows Add mobile device under Remote access (web and desktop) and enables bb connect machine-code.",
   },
-  {
-    key: "providerSessionReaping",
-    label: "Idle provider session release",
-    description:
-      "Release restorable provider sessions after 30 idle minutes. A change can take up to five minutes.",
-  },
 ];
 
 /** `/settings/experiments`: the server-persisted opt-in toggles (`PUT /settings/experiments`). */

--- a/apps/server/src/internal/session.ts
+++ b/apps/server/src/internal/session.ts
@@ -1,6 +1,5 @@
 import {
   getLatestSessionForHost,
-  getExperiments,
   listRetiredLoadedEnvironmentIdsOnHost,
   openSession,
   upsertHost,
@@ -35,13 +34,6 @@ export function registerInternalSessionRoutes(
 ): void {
   const { get, post } = typedRoutes<HostDaemonInternalSchema>(app, {
     onValidationError: (msg) => new ApiError(400, "invalid_request", msg),
-  });
-
-  get("/runtime-policy", (context) => {
-    getAuthenticatedDaemon(context);
-    return context.json({
-      providerSessionReaping: getExperiments(deps.db).providerSessionReaping,
-    });
   });
 
   post(

--- a/apps/server/test/system/experiments.test.ts
+++ b/apps/server/test/system/experiments.test.ts
@@ -3,8 +3,6 @@ import { getExperiments } from "@bb/db";
 import { experimentsSchema } from "@bb/domain";
 import { systemConfigResponseSchema } from "@bb/server-contract";
 import { readJson } from "../helpers/json.js";
-import { internalAuthHeaders } from "../helpers/commands.js";
-import { seedHostSession } from "../helpers/seed.js";
 import { withTestHarness } from "../helpers/test-app.js";
 
 describe("experiments settings", () => {
@@ -17,7 +15,6 @@ describe("experiments settings", () => {
         changelogPreview: false,
         editMessages: true,
         mobileApp: false,
-        providerSessionReaping: false,
         timelineWindowing: false,
       });
     });
@@ -32,7 +29,6 @@ describe("experiments settings", () => {
           changelogPreview: true,
           editMessages: true,
           mobileApp: true,
-          providerSessionReaping: true,
           timelineWindowing: true,
         }),
       });
@@ -41,14 +37,12 @@ describe("experiments settings", () => {
         changelogPreview: true,
         editMessages: true,
         mobileApp: true,
-        providerSessionReaping: true,
         timelineWindowing: true,
       });
       expect(getExperiments(harness.db)).toEqual({
         changelogPreview: true,
         editMessages: true,
         mobileApp: true,
-        providerSessionReaping: true,
         timelineWindowing: true,
       });
 
@@ -59,42 +53,7 @@ describe("experiments settings", () => {
         changelogPreview: true,
         editMessages: true,
         mobileApp: true,
-        providerSessionReaping: true,
         timelineWindowing: true,
-      });
-    });
-  });
-
-  it("serves the current provider session policy to the daemon", async () => {
-    await withTestHarness(async (harness) => {
-      const { host } = seedHostSession(harness.deps, {
-        id: "host-runtime-policy",
-      });
-      const headers = internalAuthHeaders(harness, { hostId: host.id });
-
-      const initial = await harness.app.request("/internal/runtime-policy", {
-        headers,
-      });
-      expect(initial.status).toBe(200);
-      await expect(readJson(initial)).resolves.toEqual({
-        providerSessionReaping: false,
-      });
-      await harness.app.request("/api/v1/settings/experiments", {
-        method: "PUT",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          changelogPreview: false,
-          editMessages: true,
-          mobileApp: false,
-          providerSessionReaping: true,
-          timelineWindowing: false,
-        }),
-      });
-      const updated = await harness.app.request("/internal/runtime-policy", {
-        headers,
-      });
-      await expect(readJson(updated)).resolves.toEqual({
-        providerSessionReaping: true,
       });
     });
   });
@@ -111,7 +70,6 @@ describe("experiments settings", () => {
           changelogPreview: false,
           editMessages: false,
           mobileApp: false,
-          providerSessionReaping: false,
           timelineWindowing: false,
         }),
       });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -670,12 +670,9 @@ The `mobileApp` experiment turns on pairing for the bb mobile app: the
 `bb connect machine-code` command (see "Pairing the bb mobile app" above). It
 is off by default while the app is in early access.
 
-The `providerSessionReaping` experiment extends idle session release to every
-restorable provider. BB releases those sessions after 30 idle minutes. The
-daemon reads the setting before each five-minute maintenance pass. Active
-turns, commands, agents, workflows, and monitors keep their sessions loaded.
-The experiment does not gate release: BB releases idle Codex sessions with the
-experiment off, which is the behavior it had before this setting.
+BB releases idle restorable provider sessions after 30 minutes. The daemon
+checks every five minutes. Active turns, commands, agents, workflows, and
+monitors keep their sessions loaded.
 
 The `timelineWindowing` experiment is off by default. When enabled, long
 timelines and large expanded timeline details retain stable height-preserving

--- a/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
@@ -1506,7 +1506,6 @@ rl.on("line", (line) => {
       const result = await runtime.reapIdleProviderSessions({
         idleForMs: 0,
         nowMs: Date.now(),
-        providerSessionReapingEnabled: false,
       });
 
       expect(result.reapedSessions).toEqual([
@@ -1586,7 +1585,6 @@ rl.on("line", (line) => {
       const belowThresholdResult = await runtime.reapIdleProviderSessions({
         idleForMs: 30 * 60 * 1000,
         nowMs: Date.now() + 29 * 60 * 1000,
-        providerSessionReapingEnabled: false,
       });
       expect(belowThresholdResult.reapedSessions).toEqual([]);
       expect(runtime.hasThread("t1")).toBe(true);
@@ -1597,7 +1595,6 @@ rl.on("line", (line) => {
       const result = await runtime.reapIdleProviderSessions({
         idleForMs: 30 * 60 * 1000,
         nowMs: Date.now() + 31 * 60 * 1000,
-        providerSessionReapingEnabled: false,
       });
       const reapedSession = result.reapedSessions[0];
       if (!reapedSession) {
@@ -1712,12 +1709,10 @@ rl.on("line", (line) => {
       const firstResult = await runtime.reapIdleProviderSessions({
         idleForMs: 0,
         nowMs: Date.now() + 60 * 60 * 1000,
-        providerSessionReapingEnabled: false,
       });
       const secondResult = await runtime.reapIdleProviderSessions({
         idleForMs: 0,
         nowMs: Date.now() + 60 * 60 * 1000,
-        providerSessionReapingEnabled: false,
       });
 
       expect(firstResult.reapedSessions).toEqual([]);
@@ -1737,7 +1732,7 @@ rl.on("line", (line) => {
   // sessions reapable is the `sessionRestorable` its bridge reports on
   // thread/start. If that wire field stopped being read, idle release would
   // silently stop for every graduated provider.
-  it("reaps a restorable non-Codex session only when the experiment is on", async () => {
+  it("reaps a restorable non-Codex session", async () => {
     const providerScript = join(tmpDir, "claude-idle-reaper-provider.cjs");
     writeThreadScopedProviderScript({
       logPath: join(tmpDir, "claude-idle-reaper-provider.log"),
@@ -1766,19 +1761,9 @@ rl.on("line", (line) => {
         options: fullRuntimeOptions,
       });
 
-      await expect(
-        runtime.reapIdleProviderSessions({
-          idleForMs: 0,
-          nowMs: Date.now(),
-          providerSessionReapingEnabled: false,
-        }),
-      ).resolves.toEqual({ reapedSessions: [] });
-      expect(runtime.hasThread("t1")).toBe(true);
-
       const result = await runtime.reapIdleProviderSessions({
         idleForMs: 0,
         nowMs: Date.now(),
-        providerSessionReapingEnabled: true,
       });
       expect(result.reapedSessions).toEqual([
         expect.objectContaining({
@@ -1827,7 +1812,6 @@ rl.on("line", (line) => {
       const result = await runtime.reapIdleProviderSessions({
         idleForMs: 0,
         nowMs: Date.now(),
-        providerSessionReapingEnabled: true,
       });
 
       expect(result.reapedSessions).toEqual([

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -134,7 +134,6 @@ interface ReapIdleProviderSessionCandidate {
 interface FindReapableIdleProviderSessionArgs {
   idleForMs: number;
   nowMs: number;
-  providerSessionReapingEnabled: boolean;
   threadId: string;
 }
 
@@ -422,7 +421,7 @@ export function createAgentRuntimeWithAdapters(
    * Codex runs one provider process per thread. The codex bridge now owns a
    * per-thread `codex app-server` child internally, so this outer scoping is
    * redundant for isolation — but it is still load-bearing: the account
-   * restart below and the pre-experiment idle reap both key off
+   * restart below and the legacy Codex idle-reap fallback both key off
    * `isThreadScopedCodexProcess`. Collapsing it means routing those through
    * `thread/stop {release}` + resume, which is a refactor, not a deletion.
    */
@@ -758,12 +757,8 @@ export function createAgentRuntimeWithAdapters(
     const runtimeConfig = threadRuntimeConfigs.get(args.threadId);
     if (
       !runtimeConfig ||
-      // The experiment extends release to every restorable provider. It does
-      // not gate release: Codex idle sessions are released without it, which
-      // is the behavior BB shipped before the experiment.
-      (args.providerSessionReapingEnabled
-        ? !runtimeConfig.sessionRestorable
-        : runtimeConfig.providerId !== CODEX_PROVIDER_ID)
+      (runtimeConfig.providerId !== CODEX_PROVIDER_ID &&
+        !runtimeConfig.sessionRestorable)
     ) {
       return null;
     }
@@ -2430,19 +2425,13 @@ export function createAgentRuntimeWithAdapters(
       return threadIdentityRegistry.getProviderSession(threadId);
     },
 
-    async reapIdleProviderSessions({
-      idleForMs,
-      nowMs,
-      providerSessionReapingEnabled,
-      runThreadExclusive,
-    }) {
+    async reapIdleProviderSessions({ idleForMs, nowMs, runThreadExclusive }) {
       const reapedSessions: ReapedIdleProviderSession[] = [];
       for (const threadId of [...threadRuntimeConfigs.keys()]) {
         const release = async (): Promise<ReapedIdleProviderSession | null> => {
           const candidate = findReapableIdleProviderSession({
             idleForMs,
             nowMs,
-            providerSessionReapingEnabled,
             threadId,
           });
           if (!candidate) {
@@ -2458,15 +2447,17 @@ export function createAgentRuntimeWithAdapters(
           } catch {
             return null;
           }
+          const usesCodexRestoreFallback =
+            candidate.runtimeConfig.providerId === CODEX_PROVIDER_ID &&
+            !candidate.runtimeConfig.sessionRestorable;
           if (
-            providerSessionReapingEnabled
-              ? backgroundWorkState.hasOpenThreadWork(candidate.threadId) ||
-                (proc.adapter.hasOpenThreadWork?.({
-                  providerThreadId: candidate.providerThreadId,
-                  threadId: candidate.threadId,
-                }) ??
-                  false)
-              : !isThreadScopedCodexProcess(proc)
+            backgroundWorkState.hasOpenThreadWork(candidate.threadId) ||
+            (proc.adapter.hasOpenThreadWork?.({
+              providerThreadId: candidate.providerThreadId,
+              threadId: candidate.threadId,
+            }) ??
+              false) ||
+            (usesCodexRestoreFallback && !isThreadScopedCodexProcess(proc))
           ) {
             return null;
           }

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -308,7 +308,6 @@ export interface WaitForActiveTurnArgs {
 export interface ReapIdleProviderSessionsArgs {
   idleForMs: number;
   nowMs: number;
-  providerSessionReapingEnabled: boolean;
   runThreadExclusive?: (
     threadId: string,
     work: () => Promise<ReapedIdleProviderSession | null>,

--- a/packages/db/test/experiments.test.ts
+++ b/packages/db/test/experiments.test.ts
@@ -39,7 +39,6 @@ describe("experiments", () => {
         "editMessages",
         "futureExperiment",
         "mobileApp",
-        "providerSessionReaping",
         "timelineWindowing",
       ]);
     } finally {

--- a/packages/domain/src/experiments.ts
+++ b/packages/domain/src/experiments.ts
@@ -14,7 +14,6 @@ export const experimentKeys = [
   "changelogPreview",
   "editMessages",
   "mobileApp",
-  "providerSessionReaping",
   "timelineWindowing",
 ] as const;
 export const experimentKeySchema = z.enum(experimentKeys);
@@ -31,6 +30,5 @@ export const defaultExperiments: Experiments = {
   changelogPreview: false,
   editMessages: true,
   mobileApp: false,
-  providerSessionReaping: false,
   timelineWindowing: false,
 };

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,8 @@
+// Version 147 makes idle release standard for every restorable provider and
+// removes the server-owned runtime-policy endpoint. Older daemons still request
+// that endpoint before each maintenance sweep and skip non-Codex release when
+// it is unavailable, so enrolled machines must update for the new policy.
+//
 // Version 146 adds the lightweight `host.list_branch_options` RPC so branch
 // pickers can read cached refs while the daemon refreshes remotes in the
 // background. Older daemons cannot parse or serve that command.
@@ -110,7 +115,7 @@
 //
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 146 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 147 as const;
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/src/session.ts
+++ b/packages/host-daemon-contract/src/session.ts
@@ -47,15 +47,6 @@ export type HostDaemonLoadedEnvironment = z.infer<
   typeof hostDaemonLoadedEnvironmentSchema
 >;
 
-export const hostDaemonRuntimePolicySchema = z
-  .object({
-    providerSessionReaping: z.boolean(),
-  })
-  .strict();
-export type HostDaemonRuntimePolicy = z.infer<
-  typeof hostDaemonRuntimePolicySchema
->;
-
 const hostDaemonWatchSetWorkspaceTargetSchema = z
   .object({
     environmentId: z.string().min(1),
@@ -823,10 +814,6 @@ export const hostDaemonSkillTreeSchema = z
 export type HostDaemonSkillTree = z.infer<typeof hostDaemonSkillTreeSchema>;
 
 export type HostDaemonInternalSchema = {
-  "/runtime-policy": {
-    /** Returns current server-owned runtime policy before a daemon maintenance sweep. */
-    $get: Endpoint<Record<never, never>, HostDaemonRuntimePolicy, 200>;
-  };
   "/skills/tree/:hash": {
     /** Used by the daemon to pull a missing server-owned injected skill tree. */
     $get: Endpoint<Record<never, never>, HostDaemonSkillTree, 200>;

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1123,7 +1123,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(146);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(147);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/packages/templates/src/templates/bb-guide-customization.md
+++ b/packages/templates/src/templates/bb-guide-customization.md
@@ -114,11 +114,9 @@ client-local; submitting stops and settles a running thread, then replaces the
 selected turn and all later conversation history while retaining workspace side
 effects. Grouped multi-message requests are not yet editable.
 
-The default-off `providerSessionReaping` experiment extends idle release to
-every restorable provider. BB releases those sessions after 30 idle minutes.
-The daemon applies a changed value within five minutes. Active turns, commands,
-agents, workflows, and monitors keep their sessions loaded. BB releases idle
-Codex sessions with the experiment off as well.
+BB releases idle restorable provider sessions after 30 minutes. The daemon
+checks every five minutes. Active turns, commands, agents, workflows, and
+monitors keep their sessions loaded.
 
 The default-off `timelineWindowing` experiment mounts only nearby rows in long
 timelines and large expanded timeline details. Enable it with

--- a/plans/bb-mobile-research/settings-features.md
+++ b/plans/bb-mobile-research/settings-features.md
@@ -5,7 +5,7 @@ Settings buckets are declared in `apps/app/src/components/settings/settings-nav.
 ### Server-persisted (visible to any client)
 All served by `GET /system/config` (`packages/server-contract/src/api/system.ts:197-233`) and written by `PUT /settings/general|keyboard|experiments|appearance` (`packages/server-contract/src/public-api.ts:1332-1358`; SDK `packages/sdk/src/areas/system.ts:207-217`, `theme.ts:53`):
 - `AppSettings` (`packages/domain/src/app-settings.ts:7-51`): showKeyboardHints, steerActiveThreadOnEnter, showUnhandledProviderEvents, codexMemoryEnabled, claudeCodeMemoryEnabled, codexSubagentsDisabled, claudeCodeSubagentsDisabled, claudeCodeWorkflowsDisabled, onboardingCompletedAt. Used by General (`SettingsView.tsx:1256-1299`), Provider pages (`:930-991, 1107-1150`), Debug (`:903-917`).
-- Experiments (`packages/domain/src/experiments.ts:13-34`): claudeCodeMockCliTraffic, editMessages, newOnboarding, providerSessionReaping (`SettingsView.tsx:998-1066`).
+- Experiments (`packages/domain/src/experiments.ts`): changelogPreview, editMessages, mobileApp, timelineWindowing.
 - Appearance palette + favicon color (`packages/domain/src/app-theme.ts:122-134, 145-160`); custom themes are server-resolved CSS strings; built-ins are CSS-with-`color-mix` in `apps/app/src/lib/themes/*.ts` (e.g. `nord.ts:9-45`).
 - Keybinding overrides (`packages/domain/src/app-keybindings.ts:232-249`; `KeyboardSettingsSection.tsx`, uses `navigator.platform` at `:63-65`).
 - Hosts: `GET/PATCH/DELETE /hosts/:id`, `PATCH /hosts/:id/permission-ceiling`, `POST /hosts/:id/retry-update`, `POST /hosts/join-codes` (`packages/server-contract/src/api/hosts.ts:59-100`; `MachinesSettingsSection.tsx:200-375`; `MachineSettingsView.tsx:165-471`).


### PR DESCRIPTION
## What was wrong

Idle release for restorable non-Codex providers remained behind the default-off `providerSessionReaping` experiment added after #1604. Existing installations could also retain a persisted `false` value. As a result, the host daemon skipped otherwise safe release for idle Claude Code, Pi, and ACP sessions under normal settings. The reproduced root cause and alternatives are documented in [issue #1604](https://github.com/get-bb/bb/issues/1604#issuecomment-5324681080).

## What changed

- Graduate idle release into standard behavior for every provider session that reports restore support.
- Preserve the legacy thread-scoped Codex fallback and apply open-turn, command, agent, workflow, and monitor protections to every provider.
- Remove the experiment setting and the server-owned `/internal/runtime-policy` endpoint that existed only to distribute it.
- Bump `HOST_DAEMON_PROTOCOL_VERSION` from 146 to 147 because older daemons still request that removed endpoint and skip non-Codex release when it is unavailable.
- Update web, mobile, desktop, database, contract, documentation, and generated-guide source fixtures that referenced the graduated experiment.

## How you verified

- Added a lifecycle regression that failed before the runtime change because a restorable Claude Code session remained loaded, then passed after the change.
- `pnpm exec turbo run typecheck` for the nine affected packages: 12 tasks passed.
- Agent runtime lifecycle: 36 tests passed.
- Host daemon focused suite: 85 tests passed.
- Host-daemon contract: 38 tests passed.
- Web settings/layout: 9 tests passed. Server experiments: 4 tests passed. Database experiments: 1 test passed.
- Mobile full suite: 123 files and 830 tests passed.
- Templates: 41 tests passed across the local and packed external scaffold suites after building the Plugin SDK prerequisite.
- `git diff --check` passed and no removed experiment or runtime-policy symbols remain.
- Mobile typecheck is not included because the current package script invokes `tsc`, while its TypeScript 6 alias exposes `tsc6`; this is unchanged by this PR.

Controlling BAC work order: [BAC-117](https://linear.app/scale-lean/issue/BAC-117)

Fixes #1604

> AGENT GENERATED: by GPT-5.6
