### PR TITLE
Harden TestFlight reviewer credential guidance

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -819,17 +819,27 @@ App Store Connect needs all of this:
   name, phone, and email. Apple uses these, testers never see them.
 - **A way for the reviewer to use the app.** This is the part that fails. bb
   opens on "Add server", and a reviewer has no bb server, so without help they
-  cannot get past the first screen and will reject the build. Give them a bb
-  server reachable over the internet through connect, and a pairing code that
-  is still valid, and step-by-step notes. Codes expire, so re-issue the code if
-  a review takes longer than expected.
+  cannot get past the first screen and will reject the build. Create a separate
+  Connect account used only for review, attach a sanitized server with
+  sanitized test data, and configure only a limited provider credential that
+  cannot reach production resources. Never pair the reviewer with a production
+  Connect account: the phone's credential can reach every server on its
+  account.
+
+The pairing code is one-time and expires after ten minutes, but redeeming it
+stores a durable credential on the phone. Code expiry prevents a later
+redemption; it does not revoke a credential that was already redeemed. After
+every review, the review-account owner must revoke the reviewer phone at
+<https://getbb.app/dashboard> under **Machines → Revoke**. `bb machine remove`
+manages a bb host-daemon machine, not the reviewer phone, so it is not a
+substitute for dashboard revocation. Mint a new code for the next review.
 
 Review notes template — keep it literal, and assume the reviewer knows nothing
 about coding agents:
 
 ```text
 bb is a client for a bb server that a developer runs on their own computer.
-The app has no accounts of its own, so we have prepared a server for you.
+We have prepared an isolated review account and server for you.
 
 1. Open the app. It shows "Add server".
 2. Select "Pair with a code".
@@ -838,8 +848,10 @@ The app has no accounts of its own, so we have prepared a server for you.
 5. Open any conversation to read it. Type a message and send it to see a
    reply from the coding agent.
 
-The code is valid until <DATE>. Write to <EMAIL> if it stops working and we
-will send a new one within a few hours.
+The one-time code is valid until <DATE>. Its expiry does not revoke a phone that
+already redeemed it; the account owner revokes that access after every review.
+Write to <EMAIL> if the code stops working and we will send a new one within a
+few hours.
 ```
 
 Rehearse it before submitting: hand a colleague a phone that has never run bb,

--- a/apps/mobile/src/testflight-review-notes.test.ts
+++ b/apps/mobile/src/testflight-review-notes.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const README = readFileSync(new URL("../README.md", import.meta.url), "utf8");
+
+describe("TestFlight review notes", () => {
+  it("requires isolated reviewer access and explicit credential revocation", () => {
+    const match = README.match(
+      /## TestFlight testers\n([\s\S]*?)\n## Local state/u,
+    );
+    if (!match) throw new Error("TestFlight testers section is missing");
+
+    const section = match[1]?.replace(/\s+/gu, " ");
+    if (!section) throw new Error("TestFlight testers section is empty");
+    expect(section).toContain("separate Connect account");
+    expect(section).toContain("sanitized server");
+    expect(section).toContain("sanitized test data");
+    expect(section).toContain("limited provider credential");
+    expect(section).toContain("does not revoke");
+    expect(section).toContain("<https://getbb.app/dashboard>");
+    expect(section).toContain("Machines → Revoke");
+    expect(section).toContain("after every review");
+  });
+});


### PR DESCRIPTION
## What was wrong

The TestFlight review notes treated the ten-minute, one-time pairing code as the reviewer access boundary. Redemption actually creates a durable `bbcm_` machine credential, stores it in iOS secure storage, and records a Connect machine with revocation state but no expiry. That credential authenticates the Connect account, lists every enrolled server, and can mint sessions for them, so pairing a reviewer with a production account can leave durable access after the code expires. This follows up on [the high-severity review finding in #2077](https://github.com/get-bb/bb/pull/2077#discussion_r3825678305).

## What changed

- Require a separate Connect account used only for review, a sanitized server and test data, and a limited provider credential that cannot reach production resources.
- State explicitly that code expiry does not revoke an already-redeemed phone credential and require dashboard revocation after every review.
- Name the real owner flow, `getbb.app/dashboard` → **Machines → Revoke**, and distinguish it from `bb machine remove`, which manages a bb host-daemon machine.
- Update the literal reviewer-notes template and add a focused regression test for the security-critical checklist.

This is the smallest complete fix because the defect is in the operational review guidance; it changes no pairing protocol, credential behavior, CLI surface, or host-daemon wire contract.

## How you verified

- Before the README fix, `pnpm exec turbo run test --filter=@bb/mobile --force` failed only the new reviewer-notes regression test: 1 failed, 830 passed.
- After the fix and a rebase check against current `origin/main`, `pnpm exec turbo run build typecheck lint test --filter=@bb/mobile --force` completed all 6 Turbo tasks; all 124 test files and 831 tests passed.
- `pnpm exec prettier --check apps/mobile/README.md apps/mobile/src/testflight-review-notes.test.ts` passed.
- `git diff --check` passed.

> AGENT GENERATED: by GPT-5.6-Sol
