### PR TITLE
Correct privacy policy data-flow claims

### DIFF
--- a/apps/web/src/landing/analytics.test.ts
+++ b/apps/web/src/landing/analytics.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { posthog } = vi.hoisted(() => ({
+  posthog: {
+    capture: vi.fn(),
+    init: vi.fn(),
+  },
+}));
+
+vi.mock("posthog-js", () => ({ default: posthog }));
+
+describe("landing analytics", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    posthog.capture.mockClear();
+    posthog.init.mockClear();
+  });
+
+  it("avoids browser persistence and disables remote features", async () => {
+    vi.stubGlobal("window", {});
+    vi.stubEnv("VITE_POSTHOG_KEY", "phc_test");
+
+    const { initAnalytics } = await import("./analytics");
+    initAnalytics();
+
+    await vi.waitFor(() => expect(posthog.init).toHaveBeenCalledOnce());
+    expect(posthog.init).toHaveBeenCalledWith(
+      "phc_test",
+      expect.objectContaining({
+        advanced_disable_flags: true,
+        disable_external_dependency_loading: true,
+        disable_persistence: true,
+        disable_session_recording: true,
+        disable_surveys: true,
+      }),
+    );
+  });
+});

--- a/apps/web/src/landing/analytics.ts
+++ b/apps/web/src/landing/analytics.ts
@@ -4,10 +4,12 @@ import type { CtaPlacement } from "./site";
 /**
  * PostHog wiring for the landing page.
  *
- * Autocapture is off; the page emits only the explicit events below. UTM
- * parameters and the referrer are captured automatically by posthog-js on
- * `$pageview` and persisted as initial person properties, which is what links
- * ad campaigns to the download/install funnel.
+ * Interaction autocapture is off; the SDK sends configured page-view and
+ * page-leave events plus the explicit events below. UTM parameters and the
+ * referrer are captured automatically by posthog-js on `$pageview`, which is
+ * what links ad campaigns to the download/install funnel. Browser persistence
+ * and remote configuration are disabled so this event list cannot silently
+ * expand through PostHog project settings.
  *
  * posthog-js is loaded lazily so it stays out of the critical-path bundle of
  * the ad landing page. Events fired before it finishes loading are queued and
@@ -61,11 +63,15 @@ export function initAnalytics(): void {
   // Lazy import keeps posthog-js out of the landing page's main bundle.
   void import("posthog-js").then(({ default: posthog }) => {
     posthog.init(key, {
-      api_host:
-        import.meta.env.VITE_POSTHOG_HOST ?? "https://us.i.posthog.com",
+      api_host: import.meta.env.VITE_POSTHOG_HOST ?? "https://us.i.posthog.com",
+      advanced_disable_flags: true,
       autocapture: false,
       capture_pageview: true,
       capture_pageleave: true,
+      disable_external_dependency_loading: true,
+      disable_persistence: true,
+      disable_session_recording: true,
+      disable_surveys: true,
     });
     client = posthog;
     for (const event of pendingEvents.splice(0)) {

--- a/apps/web/src/routes/privacy.tsx
+++ b/apps/web/src/routes/privacy.tsx
@@ -64,9 +64,11 @@ function PrivacyRoute() {
           <h1>Privacy</h1>
 
           <p className="lede">
-            bb runs on your own machines. Your prompts, your code, and your
-            files go to the bb server that you run, and from there to the AI
-            provider that you choose. They do not come to us.
+            bb runs on your own machines. When you connect to your bb server
+            directly, your prompts, your code, and your files go to that server
+            and from there to the AI provider that you choose. They do not come
+            to us. If you use bb connect, its relay handles that traffic while
+            it is in flight, as described below.
           </p>
 
           <p>
@@ -92,9 +94,11 @@ function PrivacyRoute() {
 
           <p>
             The apps talk to a bb server that you run. We do not operate that
-            server and we do not receive its data. This includes your prompts,
-            your agent conversations, your source code, your files, your
-            terminal output, and your provider API keys.
+            server or keep its data. When you connect directly, we do not
+            receive your prompts, your agent conversations, your source code,
+            your files, your terminal output, or your provider API keys. bb
+            connect is the exception: its relay handles traffic in flight if you
+            choose to use it.
           </p>
 
           <p>The iOS app keeps this on the device:</p>
@@ -118,8 +122,11 @@ function PrivacyRoute() {
 
           <p>
             The app asks for the camera, the microphone, and the photo library
-            only when you attach an image or dictate a prompt. That content goes
-            to your bb server. It does not go to us.
+            when you choose a feature that needs them, such as scanning a
+            pairing code, attaching an image, or recording a prompt. Pairing
+            through bb connect works as described below. Attachments and
+            recorded prompts go to your bb server; the bb connect relay handles
+            them in flight if you use it.
           </p>
 
           <h2>2. bb connect</h2>
@@ -129,6 +136,15 @@ function PrivacyRoute() {
             <code>yourhandle.getbb.app</code>, so the iOS app can reach it from
             a phone network. If you only use bb on your own network, you never
             touch it.
+          </p>
+
+          <p>
+            Pairing also goes through bb connect. When the iOS app scans or you
+            type a one-time pairing code, it sends that code to the connect
+            address named by the pairing flow, normally <code>getbb.app</code>.
+            The service consumes the code and returns a device credential and
+            the server routing details. This exchange reaches bb connect before
+            the app starts relaying traffic to your server.
           </p>
 
           <p>When you sign in to bb connect, we store:</p>
@@ -166,24 +182,29 @@ function PrivacyRoute() {
           </p>
 
           <p>
-            You can revoke any machine at any time from the connect dashboard.
-            Revoking it ends its address immediately.
+            You can revoke an enrolled machine or device at any time from the
+            connect dashboard, which prevents its credential from authenticating
+            again. Disconnecting a server stops its connect address.
           </p>
 
           <h2>3. This website</h2>
 
           <p>
             The marketing pages use PostHog to measure how people find bb.
-            Automatic event capture is off. The pages send page views, the
-            referrer and any campaign parameters in the URL, and a small set of
-            named events, such as a click on a download link or a copy of the
-            install command.
+            Automatic interaction capture is off. The pages send page-view and
+            page-leave events, the referrer and any campaign parameters in the
+            URL, and a small set of named events, such as a click on a download
+            link or a copy of the install command. The browser SDK does not
+            persist analytics data in cookies or browser storage. Remote
+            configuration, session recording, surveys, and external dependency
+            loading are disabled.
           </p>
 
           <p>
-            If you give us your email address to follow releases, we keep it to
-            send you those emails, and nothing else. Every email has an
-            unsubscribe link.
+            If you give us your email address to follow releases, the signup
+            form sends it to Resend, our email delivery provider. Resend stores
+            it in the bb mailing audience and processes it to send those emails.
+            Every email has an unsubscribe link.
           </p>
 
           <h2>What we do not do</h2>
@@ -206,8 +227,12 @@ function PrivacyRoute() {
           </p>
 
           <p>
-            Data held by the bb apps is yours. Deleting the iOS app removes its
-            profiles, preferences, and drafts from the device.
+            Removing a saved server from within the iOS app deletes that profile
+            and its credential copy from the iOS Keychain. Deleting the app
+            removes its ordinary app storage, including preferences and drafts,
+            but iOS can preserve Keychain items after an app is deleted.
+            Deleting the app alone is therefore not guaranteed to remove server
+            profiles or credentials.
           </p>
 
           <h2>Children</h2>


### PR DESCRIPTION
## What was wrong

The privacy page merged in [#2077](https://github.com/get-bb/bb/pull/2077) was written without reconciling several real data flows and persistence boundaries. It said app data did not reach bb and that deleting the iOS app removed profiles, while the product sends mobile pairing codes to the Connect apex, stores profiles and credentials in the iOS Keychain, initializes PostHog with durable browser persistence and remote configuration enabled by default, and sends newsletter addresses to a Resend audience. That made the published policy materially incomplete and contradicted the implementation. PR #2085 is the separate Connect edge-cache correction and does not address these statements.

## What changed

- Correct the privacy policy to distinguish direct connections from Connect relay traffic, describe pairing-code redemption through the Connect apex, and state the limits of iOS app deletion versus explicit profile removal from the Keychain.
- Describe the website analytics events precisely, including page-leave events, and name Resend as the external email processor that stores newsletter contacts.
- Configure the PostHog browser SDK with persistence, remote configuration, session recording, surveys, and external dependency loading disabled. This is the simplest privacy-preserving contract because the site only needs its existing fixed event list; preventing durable browser state and remotely enabled collection is narrower and easier to state truthfully than documenting latent features that the site does not use.
- Add a focused regression that verifies the privacy-sensitive PostHog initialization options. There are no wire, host-daemon protocol, CLI, guide, or public API changes.

## How you verified

- Before the implementation change: `pnpm exec turbo run test --filter=@bb/web --force -- src/landing/analytics.test.ts` failed the new regression. The received PostHog config contained only `api_host`, `autocapture`, `capture_pageview`, and `capture_pageleave`; all five privacy controls were absent.
- After the implementation change: the same focused Turbo test passed.
- After rebasing onto current `origin/main`: `pnpm exec turbo run typecheck test build --filter=@bb/web --force` passed. The full web suite reported 13 test files and 74 tests passed, typecheck passed, and both client and SSR production builds completed. The build emitted only the expected warning that local deployment secrets were not present.
- `pnpm exec prettier --check apps/web/src/landing/analytics.ts apps/web/src/landing/analytics.test.ts apps/web/src/routes/privacy.tsx` passed.
- `git diff --check origin/main...HEAD` passed.

> AGENT GENERATED: by GPT-5.6-Sol
