### PR TITLE
Restart Claude sessions after authentication failures

### DIFF
--- a/packages/agent-runtime/src/bridge-protocol-adapter.test.ts
+++ b/packages/agent-runtime/src/bridge-protocol-adapter.test.ts
@@ -365,8 +365,21 @@ describe("translateEvent", () => {
     expect(adapter.hasOpenThreadWork?.(work)).toBe(false);
   });
 
-  it("surfaces session/replaced as a visible warning with the context fate", () => {
+  it("only surfaces session/replaced when provider context was lost", () => {
     const adapter = makeAdapter();
+    expect(
+      adapter.translateEvent({
+        jsonrpc: "2.0",
+        method: "session/replaced",
+        params: {
+          threadId: "thr_1",
+          providerThreadId: "p_2",
+          reason: "authentication recovery required a new process",
+          contextLost: false,
+        },
+      }),
+    ).toStrictEqual([]);
+
     const events = adapter.translateEvent({
       jsonrpc: "2.0",
       method: "session/replaced",

--- a/packages/agent-runtime/src/bridge-protocol-adapter.ts
+++ b/packages/agent-runtime/src/bridge-protocol-adapter.ts
@@ -639,7 +639,11 @@ export function createBridgeProtocolAdapter(
         const parsed = sessionReplacedNotificationParamsSchema.safeParse(
           event.params,
         );
-        if (!parsed.success || parsed.data.providerThreadId === null) {
+        if (
+          !parsed.success ||
+          parsed.data.providerThreadId === null ||
+          !parsed.data.contextLost
+        ) {
           return [];
         }
         return [
@@ -648,9 +652,8 @@ export function createBridgeProtocolAdapter(
             threadId: parsed.data.threadId,
             providerThreadId: parsed.data.providerThreadId,
             category: "general",
-            summary: parsed.data.contextLost
-              ? "Provider session was replaced; provider-side context was lost."
-              : "Provider session was replaced.",
+            summary:
+              "Provider session was replaced; provider-side context was lost.",
             details: parsed.data.reason,
             scope: { kind: "thread" },
           },

--- a/plugins/provider-claude-code/src/bridge/__tests__/bridge.test.ts
+++ b/plugins/provider-claude-code/src/bridge/__tests__/bridge.test.ts
@@ -428,6 +428,35 @@ function createStaleResumeErrorMessage(
   };
 }
 
+function createAuthenticationErrorMessage(sessionId: string): SDKMessage {
+  return {
+    type: "assistant",
+    error: "authentication_failed",
+    message: {
+      id: "authentication-error-message",
+      type: "message",
+      role: "assistant",
+      container: null,
+      content: [
+        {
+          type: "text",
+          text: "Failed to authenticate: OAuth session expired and could not be refreshed",
+          citations: null,
+        },
+      ],
+      context_management: null,
+      model: "<synthetic>",
+      stop_details: null,
+      stop_reason: "stop_sequence",
+      stop_sequence: "",
+      usage: createResultUsage(),
+    },
+    parent_tool_use_id: null,
+    uuid: "00000000-0000-4000-8000-000000000002",
+    session_id: sessionId,
+  };
+}
+
 function createAssistantToolUseMessage(
   args: AssistantToolUseMessageArgs,
 ): SDKMessage {
@@ -3440,6 +3469,101 @@ describe("bridge", () => {
       queries[1]?.finish();
       await bridge.waitForResponse(3);
     } finally {
+      bridge.restore();
+    }
+  });
+
+  it("restarts a Claude session before the next turn after an authentication failure", async () => {
+    const bridge = createBridgeJsonRpcTestHarness(handleLine);
+    const queries: ControlledClaudeQuery[] = [];
+    queryMock.mockImplementation(() => {
+      const query = createControlledClaudeQuery();
+      queries.push(query);
+      return query;
+    });
+
+    try {
+      const threadId = "thread-authentication-failure";
+      const providerThreadId = "provider-thread-authentication-failure";
+      sendResumeThread({
+        bridge,
+        providerThreadId,
+        requestId: 1,
+        threadId,
+      });
+      await bridge.waitForResponse(1);
+
+      bridge.sendRequest(
+        2,
+        "turn/start",
+        canonicalTurnParams({
+          threadId,
+          providerThreadId,
+          input: [{ type: "text", text: "before reauthentication" }],
+        }),
+      );
+      await expect(readNextPromptText(getLatestQueryCall())).resolves.toBe(
+        "before reauthentication",
+      );
+      await bridge.waitForResponse(2);
+
+      queries[0]?.emit(createAuthenticationErrorMessage(providerThreadId));
+      queries[0]?.emit({
+        type: "result",
+        subtype: "error_during_execution",
+        duration_ms: 0,
+        duration_api_ms: 0,
+        is_error: true,
+        num_turns: 0,
+        stop_reason: null,
+        total_cost_usd: 0,
+        usage: createResultUsage(),
+        modelUsage: {},
+        permission_denials: [],
+        errors: [
+          "Failed to authenticate: OAuth session expired and could not be refreshed",
+        ],
+        uuid: "00000000-0000-4000-8000-000000000003",
+        session_id: providerThreadId,
+      });
+      await bridge.flushWork();
+
+      expect(getFailedTurns(bridge.messages)).toHaveLength(1);
+      expect(queries).toHaveLength(1);
+      expect(queries[0]?.close).not.toHaveBeenCalled();
+
+      bridge.sendRequest(
+        3,
+        "turn/start",
+        canonicalTurnParams({
+          threadId,
+          providerThreadId,
+          input: [{ type: "text", text: "after reauthentication" }],
+        }),
+      );
+      await bridge.flushWork();
+
+      expect(queries).toHaveLength(2);
+      expect(queries[0]?.close).toHaveBeenCalledOnce();
+      expect(getLatestQueryOptions()).toMatchObject({
+        resume: providerThreadId,
+      });
+      await expect(readNextPromptText(getLatestQueryCall())).resolves.toBe(
+        "after reauthentication",
+      );
+      await bridge.waitForResponse(3);
+
+      bridge.sendRequest(4, "thread/stop", {
+        threadId,
+        providerThreadId,
+        intent: "interrupt",
+        activeTurnId: null,
+      });
+      await bridge.flushWork();
+      queries[1]?.finish();
+      await bridge.waitForResponse(4);
+    } finally {
+      queries.forEach((query) => query.finish());
       bridge.restore();
     }
   });

--- a/plugins/provider-claude-code/src/bridge/bridge.ts
+++ b/plugins/provider-claude-code/src/bridge/bridge.ts
@@ -231,6 +231,12 @@ interface ThreadSession {
   sessionOptions: SdkSessionOptions;
   sessionSerial: number;
   closing: boolean;
+  /**
+   * Claude can report a terminal authentication error while leaving its CLI
+   * stream open. Preserve the failed turn, then rebuild the child before the
+   * next turn so a terminal reauthentication can take effect.
+   */
+  restartBeforeNextTurnReason: string | null;
   streamEnded: boolean;
   /** Every session-scoped notification is translated through this. */
   translator: ClaudeDeltaTranslator;
@@ -325,7 +331,8 @@ interface ReplaceThreadSessionArgs {
   threadSession: ThreadSession;
 }
 
-interface ReplaceEndedThreadSessionArgs {
+interface ReplaceThreadSessionBeforeNextTurnArgs {
+  reason: string;
   threadId: string;
   threadSession: ThreadSession;
 }
@@ -870,6 +877,7 @@ function createThreadSession(args: CreateThreadSessionArgs): ThreadSession {
     sessionOptions: args.sessionOptions,
     sessionSerial,
     closing: false,
+    restartBeforeNextTurnReason: null,
     streamEnded: false,
     translator: createClaudeDeltaTranslator(),
     pendingInteractiveRequests: new Map(),
@@ -1184,8 +1192,8 @@ function replaceThreadSession(args: ReplaceThreadSessionArgs): void {
   sendSessionReset(args.threadId);
 }
 
-function replaceEndedThreadSession(
-  args: ReplaceEndedThreadSessionArgs,
+function replaceThreadSessionBeforeNextTurn(
+  args: ReplaceThreadSessionBeforeNextTurnArgs,
 ): ThreadSession | undefined {
   const providerThreadId =
     args.threadSession.providerThreadId ??
@@ -1211,22 +1219,52 @@ function replaceEndedThreadSession(
   replaceThreadSession({
     providerThreadId,
     replacementSession,
-    reason: "Thread session replaced after Claude SDK stream ended",
+    reason: args.reason,
     threadId: args.threadId,
     threadSession: args.threadSession,
   });
   return replacementSession;
 }
 
-function getWritableThreadSession(threadId: string): ThreadSession | undefined {
+function getWritableThreadSession(
+  threadId: string,
+  intent: "new-turn" | "steer",
+): ThreadSession | undefined {
   const threadSession = sessions.get(threadId);
   if (!threadSession || threadSession.closing) {
     return undefined;
   }
-  if (!threadSession.streamEnded) {
+  const replacementReason = threadSession.streamEnded
+    ? "Thread session replaced after Claude SDK stream ended"
+    : intent === "new-turn"
+      ? threadSession.restartBeforeNextTurnReason
+      : null;
+  if (replacementReason === null) {
     return threadSession;
   }
-  return replaceEndedThreadSession({ threadId, threadSession });
+  return replaceThreadSessionBeforeNextTurn({
+    reason: replacementReason,
+    threadId,
+    threadSession,
+  });
+}
+
+function getAuthenticationFailureRestartReason(
+  message: SDKMessage,
+): string | null {
+  // Unlike an SDK stream failure, these terminal synthetic messages leave the
+  // old Claude CLI child alive with its pre-reauthentication credentials.
+  if (message.type !== "assistant") {
+    return null;
+  }
+  switch (message.error) {
+    case "authentication_failed":
+      return "Claude session restarted after authentication failed";
+    case "oauth_org_not_allowed":
+      return "Claude session restarted after OAuth organization authorization failed";
+    default:
+      return null;
+  }
 }
 
 function getCurrentThreadSession(
@@ -1259,6 +1297,12 @@ function createOnSdkMessage(
     ) {
       threadSession.providerThreadId = providerThreadId;
       sendThreadIdentity(args.threadIdRef.current, providerThreadId);
+    }
+    const authenticationFailureRestartReason =
+      getAuthenticationFailureRestartReason(message);
+    if (authenticationFailureRestartReason !== null) {
+      threadSession.restartBeforeNextTurnReason =
+        authenticationFailureRestartReason;
     }
     trackSdkAssistantPermissionEscalation(threadSession, message);
     emitForSession(threadSession, args.threadIdRef.current, "sdk/message", {
@@ -2201,7 +2245,7 @@ async function runTurnStart(
     return;
   }
 
-  const threadSession = getWritableThreadSession(params.threadId);
+  const threadSession = getWritableThreadSession(params.threadId, "new-turn");
   if (!threadSession) {
     sendError(id, -32000, "No active session");
     return;
@@ -2273,7 +2317,7 @@ async function runTurnSteer(
     return;
   }
 
-  const threadSession = getWritableThreadSession(params.threadId);
+  const threadSession = getWritableThreadSession(params.threadId, "steer");
   if (!threadSession) {
     sendError(id, -32000, "No active session");
     return;


### PR DESCRIPTION
## What was wrong

Claude Code can emit terminal `authentication_failed` or `oauth_org_not_allowed` assistant errors without ending its SDK stream. The Claude bridge treated any still-open stream as writable, so after terminal reauthentication the next turn in the affected bb thread was sent to the old CLI child with stale credentials instead of starting a process that could see the refreshed authentication. This is the root cause reproduced in #2097 and the [reported bb thread](https://ymichael.getbb.app/projects/proj_qrv2s45kmq/threads/thr_ughdhvdcdz).

## What changed

- Mark a per-thread Claude session for replacement when the SDK emits either terminal authorization error.
- Before the next new turn, close that stale query and create a replacement session that resumes the same Claude provider conversation ID.
- Preserve the failed turn and avoid replacing the session during steering; recovery occurs at the next normal turn boundary.
- Keep context-preserving session replacements out of the timeline while retaining the warning when provider-side context is actually lost.
- Add bridge regression coverage for the full failed-message/result and next-turn replacement flow.

This is internal to the Claude provider bridge. There are no host-daemon wire, public plugin API, CLI, configuration, or documentation changes, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

The new regression test fails before the fix because the bridge retains one query, never closes it, and does not create a resumed replacement for the next turn. It passes after the change and verifies that the failed turn remains, the stale query closes exactly once, a second query is launched with the same `resume` ID, and the next prompt reaches it.

- `pnpm exec turbo run test --filter=bb-plugin-provider-claude-code --force` — 18 files and 263 tests passed.
- `pnpm exec turbo run typecheck --filter=bb-plugin-provider-claude-code` — 5 Turbo tasks passed.
- `pnpm exec turbo run test --filter=@bb/agent-runtime --force` — 31 files and 422 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime` — 4 Turbo tasks passed.
- `git diff --check origin/main...HEAD`

Fixes #2097

> AGENT GENERATED: by GPT-5
