### PR TITLE
Do not link removed pull request files

### DIFF
--- a/plugins/github/app.test.tsx
+++ b/plugins/github/app.test.tsx
@@ -77,4 +77,78 @@ describe("GitHub app navigation", () => {
     expect(slot.container.firstElementChild?.className).not.toContain("p-3");
     slot.lifecycle.unmount();
   });
+
+  it("keeps removed pull-request files out of live workspace navigation", async () => {
+    const slot = renderSlot(
+      app.threadPanelActions[0]!,
+      { threadId: "thr-1", params: null },
+      {
+        rpc: {
+          pullForThread: () => ({
+            pull: {
+              repo: "get-bb/bb",
+              number: 42,
+              environmentId: "env-1",
+            },
+          }),
+          getPull: () => ({
+            pull: {
+              repo: "get-bb/bb",
+              number: 42,
+              title: "Navigation fix",
+              state: "OPEN",
+              author: "octocat",
+              body: "",
+              url: "https://github.com/get-bb/bb/pull/42",
+              createdAt: "2026-08-20T00:00:00.000Z",
+              updatedAt: "2026-08-20T00:00:00.000Z",
+              baseRefName: "main",
+              headRefName: "fix-navigation",
+              additions: 1,
+              deletions: 1,
+              changedFiles: 2,
+              labels: [],
+              assignees: [],
+              reviewDecision: "",
+              mergeStateStatus: "CLEAN",
+              reviewRequests: [],
+              checks: [],
+              comments: [],
+              reviews: [],
+              reviewThreads: [],
+              files: [
+                {
+                  path: "removed.ts",
+                  status: "removed",
+                  additions: 0,
+                  deletions: 1,
+                  patch: "@@ -1 +0,0 @@\n-removed",
+                },
+                {
+                  path: "modified.ts",
+                  status: "modified",
+                  additions: 1,
+                  deletions: 0,
+                  patch: "@@ -0,0 +1 @@\n+added",
+                },
+              ],
+            },
+          }),
+          listLinks: () => ({ links: {} }),
+        },
+      },
+    );
+
+    await slot.findByText("Navigation fix");
+    expect(slot.queryByRole("link", { name: "removed.ts" })).toBeNull();
+    expect(slot.getByRole("link", { name: "modified.ts" })).toBeDefined();
+
+    slot.getByRole("button", { name: "Expand removed.ts diff" }).click();
+    const diff = await slot.findByTestId("bb-diff");
+    expect(diff.getAttribute("data-path")).toBe("removed.ts");
+    expect(
+      slot.getByRole("button", { name: "Collapse removed.ts diff" }),
+    ).toBeDefined();
+    slot.lifecycle.unmount();
+  });
 });

--- a/plugins/github/app.tsx
+++ b/plugins/github/app.tsx
@@ -1407,7 +1407,7 @@ function FileDiffCard({
         >
           {open ? "▾" : "▸"}
         </button>
-        {environmentId === null ? (
+        {environmentId === null || file.status === "removed" ? (
           <span className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">
             {file.path}
           </span>


### PR DESCRIPTION
## What was wrong

`FileDiffCard` rendered every pull-request file path as a live workspace link whenever the thread had an environment, without considering `file.status`. A removed file normally no longer exists in that workspace, so its filename advertised a preview target guaranteed to fail even though the separate diff control already exposed the deletion. This confirms the [post-merge review finding](https://github.com/get-bb/bb/pull/2005#discussion_r3824543487).

## What changed

- Reused the existing non-interactive filename rendering when `file.status` is `removed`, while retaining `experimental_FileLink` for statuses whose path can exist.
- Added one focused thread-panel regression covering the complete behavior: removed paths are not links, modified paths remain links, and the removed file's accessible expand/collapse control still reveals its diff.
- Kept the fix to the existing render condition; no abstraction, wire change, protocol bump, CLI, guide, or documentation change was needed.

## How you verified

- Before the implementation change, `pnpm exec turbo run test --filter=bb-plugin-github --force -- app.test.tsx` failed the new regression with `removed.ts` rendered as `<a href="removed.ts">` (1 failed, 2 passed).
- After the change, that focused command passed all 3 tests.
- After rebasing onto current `origin/main`, `pnpm exec turbo run test --filter=bb-plugin-github --force` passed 6 files / 25 tests.
- `pnpm exec turbo run typecheck --filter=bb-plugin-github` passed.
- `pnpm exec turbo run build --filter=bb-plugin-github` passed and built the GitHub plugin's server and app artifacts.
- `pnpm exec prettier --check plugins/github/app.test.tsx` and `git diff --check origin/main...HEAD` passed.

Fixes: no matching issue.

> AGENT GENERATED: by GPT-5.6-Sol
