### PR TITLE
Resolve Docs project-backed opener sources

### DIFF
--- a/plugins/docs/server.test.ts
+++ b/plugins/docs/server.test.ts
@@ -1151,6 +1151,138 @@ describe("Docs vault operations", () => {
     ]);
   });
 
+  it("routes project-backed workspace files through the selected or primary source", async () => {
+    const host = createFakePluginHost({
+      pluginId: "simple-notes",
+      sdk: {
+        files: {
+          mkdir: async () => ({ ok: true as const }),
+          read: async ({ path: openedPath }) => ({
+            path: openedPath,
+            content: "# Project plan",
+            contentEncoding: "utf8" as const,
+            mimeType: "text/markdown",
+            sizeBytes: 14,
+            modifiedAtMs: 1,
+            sha256: "project-sha",
+          }),
+          write: async () => ({
+            outcome: "written" as const,
+            sha256: "project-written-sha",
+            sizeBytes: 22,
+          }),
+          createPreview: async () => ({
+            baseUrl: "/project-preview",
+            expiresAtMs: Date.now() + 60_000,
+          }),
+        },
+        projects: {
+          get: async () => ({
+            sources: [
+              {
+                hostId: "host_remote",
+                path: "/remote/project",
+                isDefault: true,
+                type: "local_path",
+              },
+              {
+                hostId: "host_primary",
+                path: "/primary/project",
+                isDefault: false,
+                type: "local_path",
+              },
+            ],
+          }),
+        },
+        system: {
+          config: async () => ({ primaryHostId: "host_primary" }),
+        },
+      },
+    });
+    await simpleNotes(host.bb);
+    host.harness.sdk.calls.length = 0;
+    const selectedSource = {
+      kind: "workspace",
+      threadId: null,
+      environmentId: null,
+      projectId: "project_1",
+      experimental_hostId: "host_remote",
+    };
+
+    await expect(
+      host.harness.callRpc("openFile", {
+        source: selectedSource,
+        path: "docs/plan.md",
+      }),
+    ).resolves.toMatchObject({ previewPath: "docs/plan.md" });
+    await expect(
+      host.harness.callRpc("saveOpenedFile", {
+        source: selectedSource,
+        path: "docs/plan.md",
+        content: "# Updated project plan",
+        expectedSha256: "project-sha",
+      }),
+    ).resolves.toMatchObject({ outcome: "written" });
+    await expect(
+      host.harness.callRpc("openFile", {
+        source: {
+          kind: "workspace",
+          threadId: null,
+          environmentId: null,
+          projectId: "project_1",
+        },
+        path: "docs/plan.md",
+      }),
+    ).resolves.toMatchObject({
+      previewPath: "docs/plan.md",
+    });
+    await expect(
+      host.harness.callRpc("openFile", {
+        source: { ...selectedSource, experimental_hostId: "host_missing" },
+        path: "docs/plan.md",
+      }),
+    ).rejects.toThrow("This project has no workspace on the selected host");
+
+    expect(host.harness.sdk.callsTo("projects.get")).toEqual([
+      [{ projectId: "project_1" }],
+      [{ projectId: "project_1" }],
+      [{ projectId: "project_1" }],
+      [{ projectId: "project_1" }],
+    ]);
+    expect(host.harness.sdk.callsTo("system.config")).toEqual([[]]);
+    expect(host.harness.sdk.callsTo("files.read")).toEqual([
+      [
+        {
+          hostId: "host_remote",
+          path: "/remote/project/docs/plan.md",
+          rootPath: "/remote/project",
+        },
+      ],
+      [
+        {
+          hostId: "host_primary",
+          path: "/primary/project/docs/plan.md",
+          rootPath: "/primary/project",
+        },
+      ],
+    ]);
+    expect(host.harness.sdk.callsTo("files.createPreview")).toEqual([
+      [{ hostId: "host_remote", rootPath: "/remote/project" }],
+      [{ hostId: "host_primary", rootPath: "/primary/project" }],
+    ]);
+    expect(host.harness.sdk.callsTo("files.write")).toEqual([
+      [
+        {
+          hostId: "host_remote",
+          path: "/remote/project/docs/plan.md",
+          rootPath: "/remote/project",
+          content: "# Updated project plan",
+          expectedSha256: "project-sha",
+        },
+      ],
+    ]);
+  });
+
   it("opens and saves thread-storage Markdown files on the thread's host", async () => {
     const storageRootPath = String.raw`C:\bb\thread-storage\thread_1`;
     const openedPath = String.raw`C:\bb\thread-storage\thread_1\reports\plan.md`;

--- a/plugins/docs/server.ts
+++ b/plugins/docs/server.ts
@@ -1033,6 +1033,40 @@ export default async function plugin(
         hostId: environment.hostId,
       };
     }
+    if (source.kind === "workspace" && source.projectId) {
+      const hostId =
+        source.experimental_hostId ??
+        (await bb.sdk.system.config()).primaryHostId;
+      if (!hostId) {
+        throw new Error("This project has no primary host");
+      }
+      const project = await bb.sdk.projects.get({
+        projectId: source.projectId,
+      });
+      const matchingSources = project.sources.filter(
+        (projectSource) => projectSource.hostId === hostId,
+      );
+      const [projectSource] = matchingSources;
+      if (!projectSource) {
+        throw new Error(
+          source.experimental_hostId
+            ? "This project has no workspace on the selected host"
+            : "This project has no workspace on the primary host",
+        );
+      }
+      if (matchingSources.length > 1) {
+        throw new Error("This project has multiple workspaces on that host");
+      }
+      const rootPath = normalizeHostRoot(projectSource.path);
+      if (!isAbsoluteHostPath(rootPath)) {
+        throw new Error("This project has no absolute workspace path");
+      }
+      return {
+        path: hostPathApi(rootPath).join(rootPath, ...filePath.split("/")),
+        rootPath,
+        hostId,
+      };
+    }
     if (source.kind === "thread-storage") {
       if (!source.threadId) {
         throw new Error("Thread-storage files require a thread ID");


### PR DESCRIPTION
## What was wrong

PR #2088 correctly preserved `PluginFileOpenerSource.experimental_hostId` through the Docs frontend and private RPC, but `resolveOpenerFile` consumed it only for `source.kind === "host"`. Root Compose opens a project-source Markdown file as `{ kind: "workspace", environmentId: null, projectId, experimental_hostId }`, so Docs accepted the source identity and then skipped its only workspace branch, throwing “Docs can open workspace, host, and thread-storage files only.” The same project-backed file already works in the PDF opener through the core project content route.

## What changed

Docs now resolves a workspace source with no environment and a project ID through the project's authoritative local-path source. An explicit `experimental_hostId` selects that host; omission resolves through `system.config().primaryHostId`, matching the public opener contract and core project-workspace routing. The resolved source root and host feed the existing confined Files SDK read, preview, and optimistic-write calls. Missing, duplicate, or non-absolute project-source identities fail closed instead of selecting another machine.

This is the smallest complete fix: one resolver branch plus one server regression. Environment-backed workspace, absolute host-file, and thread-storage behavior is unchanged. There is no SDK, CLI, guide, configuration, or host-daemon wire change, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

The pre-fix focused regression failed both project-backed cases with the reported error (2 failed, 31 passed):

- `pnpm exec turbo run test --filter=bb-plugin-simple-notes -- server.test.ts`

After the fix and the final rebase onto `deb723091` / merged #2059:

- The focused server suite passed 32 tests. The regression proves selected-host read, preview, and optimistic save routing; omitted-host primary routing even when a different project source is marked default; and rejection of an unknown selected host before file I/O.
- `pnpm exec turbo run test typecheck build --filter=bb-plugin-simple-notes --force` passed: 66 tests, Docs build and typecheck, 7 successful Turbo tasks.
- `git diff --check origin/main...HEAD` passed.

Related to #2088, #2083, and #2059.

> AGENT GENERATED: by GPT-5.6-Sol
