### PR TITLE
Include project dot paths in file listings

### DIFF
--- a/apps/host-daemon/src/command-handlers/file-list.test.ts
+++ b/apps/host-daemon/src/command-handlers/file-list.test.ts
@@ -236,6 +236,42 @@ describe("listPathsRecursively", () => {
     }
   });
 
+  it("includes project dot paths without traversing Git internals or dependencies", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "bb-file-list-"));
+    try {
+      await fs.mkdir(path.join(root, ".github", "workflows"), {
+        recursive: true,
+      });
+      await fs.writeFile(path.join(root, ".github", "workflows", "ci.yml"), "");
+      await fs.writeFile(path.join(root, ".env"), "");
+      await fs.mkdir(path.join(root, ".git"));
+      await fs.writeFile(path.join(root, ".git", "config"), "");
+      await fs.mkdir(path.join(root, "node_modules", "dependency"), {
+        recursive: true,
+      });
+      await fs.writeFile(
+        path.join(root, "node_modules", "dependency", "index.js"),
+        "",
+      );
+
+      const result = await listPathsRecursively({
+        dir: root,
+        root,
+        includeFiles: true,
+        includeDirectories: true,
+      });
+
+      expect(result.map((entry) => entry.path).sort()).toEqual([
+        ".env",
+        ".github",
+        ".github/workflows",
+        ".github/workflows/ci.yml",
+      ]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("does not return symlinked files as regular path entries", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "bb-file-list-"));
     try {

--- a/apps/host-daemon/src/command-handlers/file-list.ts
+++ b/apps/host-daemon/src/command-handlers/file-list.ts
@@ -49,6 +49,8 @@ export interface ListPathsRecursivelyArgs extends PathListInclusion {
   root: string;
 }
 
+const RECURSIVE_PATH_SKIP_NAMES = new Set([".git", "node_modules"]);
+
 function shouldIncludePath(
   pathKind: HostPathEntryKind,
   inclusion: PathListInclusion,
@@ -140,8 +142,7 @@ export async function listPathsRecursively(
   const entries = await fs.readdir(args.dir, { withFileTypes: true });
   const results: ListedPath[] = [];
   for (const entry of entries) {
-    if (entry.name.startsWith(".")) continue;
-    if (entry.name === "node_modules") continue;
+    if (RECURSIVE_PATH_SKIP_NAMES.has(entry.name)) continue;
     if (entry.isSymbolicLink()) continue;
 
     const fullPath = path.join(args.dir, entry.name);

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,7 @@
+// Version 147 includes ordinary project dot paths in recursive file listings
+// while continuing to exclude `.git`, `node_modules`, and symlinks. Older
+// daemons silently omit paths such as `.github/workflows/ci.yml`.
+//
 // Version 146 adds the lightweight `host.list_branch_options` RPC so branch
 // pickers can read cached refs while the daemon refreshes remotes in the
 // background. Older daemons cannot parse or serve that command.
@@ -110,7 +114,7 @@
 //
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 146 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 147 as const;
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1123,7 +1123,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(146);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(147);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 


### PR DESCRIPTION
## What was wrong

The host daemon's shared recursive file walker skipped every entry whose name started with `.`. Both `host.list_paths` and `host.list_files` use that walker, so ordinary project files such as `.github/workflows/ci.yml` never reached file search even though the file read API could read them. See #2093.

## What changed

- Replace the broad dot-name exclusion with explicit exclusions for `.git` and `node_modules`.
- Continue to skip recursive symlinks.
- Add a regression test that includes `.github/workflows/ci.yml` and `.env` while excluding `.git/config` and a dependency file under `node_modules`.
- Increase `HOST_DAEMON_PROTOCOL_VERSION` from 146 to 147 because the returned RPC path set changes.
- Leave `host.browse_directory` unchanged. That single-level remote folder picker starts at the host home directory and should continue hiding home dot entries.

This deliberately does not add the issue's proposed caller-configurable wire fields. The narrower policy fixes normal project discovery without expanding the public API. No CLI, guide, SDK, or route shape changed.

## How you verified

- Before implementation, the new regression test failed with no dot paths returned. After implementation, `pnpm exec turbo run test --filter=@bb/host-daemon -- --run src/command-handlers/file-list.test.ts` passed 15 tests.
- `pnpm exec turbo run test --filter=@bb/host-daemon-contract -- --run test/contract.test.ts` passed 38 tests.
- `pnpm exec turbo run typecheck build --filter=@bb/host-daemon --filter=@bb/host-daemon-contract --force` passed all 7 Turbo tasks.
- A manual post-fix walker probe returned `.github/workflows/ci.yml` and omitted `.git/config` and `node_modules/pkg/index.js`.
- `git diff --check` passed.

Two unrelated full-suite assertions remain environment-sensitive in this managed worktree. The host-daemon suite passed 556 tests and failed the detached-process cleanup test, which also failed alone. The host-daemon-contract suite passed 51 tests and failed an exact gzip-size fixture by 1 to 4 bytes under the local zlib runtime. Neither failure imports or exercises the changed listing behavior.

Fixes #2093

> AGENT GENERATED: by GPT-5
