### PR TITLE
Keep T3 Sidebar child menus inside compact viewports

### DIFF
--- a/examples/plugins/t3sidebar/src/SubagentsChip.position.test.tsx
+++ b/examples/plugins/t3sidebar/src/SubagentsChip.position.test.tsx
@@ -68,9 +68,11 @@ function renderCompact() {
 
 function mockCompactGeometry({
   triggerRight,
+  triggerBottom = 48,
   menuWidth,
 }: {
   triggerRight: number;
+  triggerBottom?: number;
   menuWidth: number;
 }) {
   vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
@@ -79,7 +81,7 @@ function mockCompactGeometry({
         this instanceof HTMLButtonElement &&
         this.getAttribute("aria-label")?.endsWith("child threads")
       ) {
-        return { right: triggerRight } as DOMRect;
+        return { right: triggerRight, bottom: triggerBottom } as DOMRect;
       }
       if (this.getAttribute("role") === "menu") {
         return { width: menuWidth } as DOMRect;
@@ -91,26 +93,44 @@ function mockCompactGeometry({
 
 function stubVisualViewport({
   left = 0,
+  top = 0,
   width,
+  height = 844,
 }: {
   left?: number;
+  top?: number;
   width: number;
+  height?: number;
 }) {
   vi.stubGlobal("visualViewport", {
     offsetLeft: left,
+    offsetTop: top,
     width,
+    height,
     addEventListener: vi.fn(),
     removeEventListener: vi.fn(),
   });
 }
 
-function setSafeArea(left: number, right: number) {
+function setSafeArea({
+  left = 0,
+  top = 0,
+  right = 0,
+  bottom = 0,
+}: {
+  left?: number;
+  top?: number;
+  right?: number;
+  bottom?: number;
+}) {
   const probe = document.querySelector<HTMLElement>(
     "[data-child-menu-safe-area-probe]",
   );
   if (!probe) throw new Error("Missing safe-area probe");
   probe.style.paddingLeft = `${left}px`;
+  probe.style.paddingTop = `${top}px`;
   probe.style.paddingRight = `${right}px`;
+  probe.style.paddingBottom = `${bottom}px`;
 }
 
 afterEach(() => {
@@ -159,7 +179,7 @@ describe("SubagentsChip menu position", () => {
   it("keeps the menu inside horizontal safe-area insets", () => {
     renderCompact();
     stubVisualViewport({ width: 390 });
-    setSafeArea(44, 20);
+    setSafeArea({ left: 44, right: 20 });
     mockCompactGeometry({ triggerRight: 380, menuWidth: 310 });
 
     fireEvent.click(screen.getByRole("button", { name: "1 child threads" }));
@@ -167,6 +187,23 @@ describe("SubagentsChip menu position", () => {
     const menu = screen.getByRole("menu", { name: "Child threads" });
     expect(menu.style.maxWidth).toBe("310px");
     expect(menu.style.left).toBe("52px");
+  });
+
+  it("keeps the menu inside the visual viewport height", () => {
+    renderCompact();
+    stubVisualViewport({ top: 200, width: 390, height: 300 });
+    setSafeArea({ top: 10, bottom: 20 });
+    mockCompactGeometry({
+      triggerRight: 380,
+      triggerBottom: 260,
+      menuWidth: 320,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "1 child threads" }));
+
+    const menu = screen.getByRole("menu", { name: "Child threads" });
+    expect(menu.style.top).toBe("268px");
+    expect(menu.style.maxHeight).toBe("min(32rem, 204px)");
   });
 
   it("keeps the desktop menu anchored to its header chip", () => {

--- a/examples/plugins/t3sidebar/src/SubagentsChip.position.test.tsx
+++ b/examples/plugins/t3sidebar/src/SubagentsChip.position.test.tsx
@@ -1,0 +1,198 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { loadPluginApp, renderSlot } from "@get-bb/plugin-sdk/testing/app";
+import type { PluginSidebarThread } from "@get-bb/plugin-sdk";
+
+const app = await loadPluginApp(() => import("../app"));
+const childrenChip = app.threadHeaderActions.find(
+  (slot) => slot.id === "children",
+)!;
+
+function thread(
+  overrides: Partial<PluginSidebarThread> = {},
+): PluginSidebarThread {
+  return {
+    id: "thr_1",
+    projectId: "proj_1",
+    title: "A thread",
+    titleFallback: null,
+    parentThreadId: null,
+    sectionId: null,
+    originKind: null,
+    originPluginId: null,
+    providerId: "codex",
+    hasPendingInteraction: false,
+    activity: {
+      workflows: 0,
+      backgroundAgents: 0,
+      backgroundCommands: 0,
+      planMode: 0,
+      goals: 0,
+    },
+    indicator: "none",
+    indicatorLabel: null,
+    isUnread: false,
+    isPinned: false,
+    isArchived: false,
+    environment: null,
+    host: null,
+    createdAt: 100,
+    updatedAt: 100,
+    lastReadAt: 100,
+    latestAttentionAt: 100,
+    ...overrides,
+  };
+}
+
+function renderCompact() {
+  return renderSlot(
+    childrenChip,
+    {
+      threadId: "parent",
+      projectId: "proj_1",
+      isCompactViewport: true,
+    },
+    {
+      sidebarThreads: {
+        status: "ready",
+        threads: [
+          thread({ id: "parent" }),
+          thread({ id: "child", parentThreadId: "parent" }),
+        ],
+        projects: [{ id: "proj_1", name: "bb", isPersonal: false }],
+      },
+    },
+  );
+}
+
+function mockCompactGeometry({
+  triggerRight,
+  menuWidth,
+}: {
+  triggerRight: number;
+  menuWidth: number;
+}) {
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+    function (this: HTMLElement) {
+      if (
+        this instanceof HTMLButtonElement &&
+        this.getAttribute("aria-label")?.endsWith("child threads")
+      ) {
+        return { right: triggerRight } as DOMRect;
+      }
+      if (this.getAttribute("role") === "menu") {
+        return { width: menuWidth } as DOMRect;
+      }
+      return { width: 0 } as DOMRect;
+    },
+  );
+}
+
+function stubVisualViewport({
+  left = 0,
+  width,
+}: {
+  left?: number;
+  width: number;
+}) {
+  vi.stubGlobal("visualViewport", {
+    offsetLeft: left,
+    width,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+}
+
+function setSafeArea(left: number, right: number) {
+  const probe = document.querySelector<HTMLElement>(
+    "[data-child-menu-safe-area-probe]",
+  );
+  if (!probe) throw new Error("Missing safe-area probe");
+  probe.style.paddingLeft = `${left}px`;
+  probe.style.paddingRight = `${right}px`;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("SubagentsChip menu position", () => {
+  it("measures the rendered rem-sized menu before clamping", () => {
+    renderCompact();
+    stubVisualViewport({ width: 390 });
+    mockCompactGeometry({ triggerRight: 380, menuWidth: 374 });
+
+    fireEvent.click(screen.getByRole("button", { name: "1 child threads" }));
+
+    const menu = screen.getByRole("menu", { name: "Child threads" });
+    expect(menu.style.maxWidth).toBe("374px");
+    expect(menu.style.left).toBe("8px");
+  });
+
+  it("stays right-aligned to the chip while the menu fits on screen", () => {
+    renderCompact();
+    stubVisualViewport({ width: 390 });
+    mockCompactGeometry({ triggerRight: 380, menuWidth: 320 });
+
+    fireEvent.click(screen.getByRole("button", { name: "1 child threads" }));
+
+    expect(screen.getByRole("menu", { name: "Child threads" }).style.left).toBe(
+      "60px",
+    );
+  });
+
+  it("uses the visual viewport offset and width", () => {
+    renderCompact();
+    stubVisualViewport({ left: 100, width: 300 });
+    mockCompactGeometry({ triggerRight: 380, menuWidth: 284 });
+
+    fireEvent.click(screen.getByRole("button", { name: "1 child threads" }));
+
+    const menu = screen.getByRole("menu", { name: "Child threads" });
+    expect(menu.style.maxWidth).toBe("284px");
+    expect(menu.style.left).toBe("108px");
+  });
+
+  it("keeps the menu inside horizontal safe-area insets", () => {
+    renderCompact();
+    stubVisualViewport({ width: 390 });
+    setSafeArea(44, 20);
+    mockCompactGeometry({ triggerRight: 380, menuWidth: 310 });
+
+    fireEvent.click(screen.getByRole("button", { name: "1 child threads" }));
+
+    const menu = screen.getByRole("menu", { name: "Child threads" });
+    expect(menu.style.maxWidth).toBe("310px");
+    expect(menu.style.left).toBe("52px");
+  });
+
+  it("keeps the desktop menu anchored to its header chip", () => {
+    renderSlot(
+      childrenChip,
+      {
+        threadId: "parent",
+        projectId: "proj_1",
+        isCompactViewport: false,
+      },
+      {
+        sidebarThreads: {
+          status: "ready",
+          threads: [
+            thread({ id: "parent" }),
+            thread({ id: "child", parentThreadId: "parent" }),
+          ],
+          projects: [{ id: "proj_1", name: "bb", isPersonal: false }],
+        },
+      },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "1 child threads" }));
+    const menu = screen.getByRole("menu", { name: "Child threads" });
+    expect(menu.classList.contains("absolute")).toBe(true);
+    expect(menu.classList.contains("right-0")).toBe(true);
+    expect(menu.classList.contains("w-80")).toBe(true);
+  });
+});

--- a/examples/plugins/t3sidebar/src/SubagentsChip.test.tsx
+++ b/examples/plugins/t3sidebar/src/SubagentsChip.test.tsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, screen } from "@testing-library/react";
+import { loadPluginApp, renderSlot } from "@get-bb/plugin-sdk/testing/app";
+import type { PluginSidebarThread } from "@get-bb/plugin-sdk";
+
+const app = await loadPluginApp(() => import("../app"));
+const childrenChip = app.threadHeaderActions.find(
+  (slot) => slot.id === "children",
+)!;
+
+function thread(
+  overrides: Partial<PluginSidebarThread> = {},
+): PluginSidebarThread {
+  return {
+    id: "thr_1",
+    projectId: "proj_1",
+    title: "A thread",
+    titleFallback: null,
+    parentThreadId: null,
+    sectionId: null,
+    originKind: null,
+    originPluginId: null,
+    providerId: "codex",
+    hasPendingInteraction: false,
+    activity: {
+      workflows: 0,
+      backgroundAgents: 0,
+      backgroundCommands: 0,
+      planMode: 0,
+      goals: 0,
+    },
+    indicator: "none",
+    indicatorLabel: null,
+    isUnread: false,
+    isPinned: false,
+    isArchived: false,
+    environment: null,
+    host: null,
+    createdAt: 100,
+    updatedAt: 100,
+    lastReadAt: 100,
+    latestAttentionAt: 100,
+    ...overrides,
+  };
+}
+
+function renderCompact() {
+  return renderSlot(
+    childrenChip,
+    {
+      threadId: "parent",
+      projectId: "proj_1",
+      isCompactViewport: true,
+    },
+    {
+      sidebarThreads: {
+        status: "ready",
+        threads: [
+          thread({ id: "parent" }),
+          thread({ id: "child", parentThreadId: "parent" }),
+        ],
+        projects: [{ id: "proj_1", name: "bb", isPersonal: false }],
+      },
+    },
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("SubagentsChip menu position", () => {
+  it("clamps only when right alignment would cross the viewport gutter", () => {
+    renderCompact();
+    vi.stubGlobal("innerWidth", 390);
+    const trigger = screen.getByRole("button", { name: "1 child threads" });
+    vi.spyOn(trigger, "getBoundingClientRect").mockReturnValue({
+      right: 250,
+    } as DOMRect);
+
+    fireEvent.click(trigger);
+
+    const menu = screen.getByRole("menu", { name: "Child threads" });
+    expect(menu.classList.contains("fixed")).toBe(true);
+    expect(menu.classList.contains("w-80")).toBe(true);
+    expect(menu.classList.contains("max-w-[calc(100vw-1rem)]")).toBe(true);
+    expect(menu.style.left).toBe("8px");
+  });
+
+  it("stays right-aligned to the chip while the menu fits on screen", () => {
+    renderCompact();
+    vi.stubGlobal("innerWidth", 390);
+    const trigger = screen.getByRole("button", { name: "1 child threads" });
+    vi.spyOn(trigger, "getBoundingClientRect").mockReturnValue({
+      right: 380,
+    } as DOMRect);
+
+    fireEvent.click(trigger);
+
+    expect(
+      screen.getByRole("menu", { name: "Child threads" }).style.left,
+    ).toBe("60px");
+  });
+
+  it("keeps the desktop menu anchored to its header chip", () => {
+    renderSlot(
+      childrenChip,
+      {
+        threadId: "parent",
+        projectId: "proj_1",
+        isCompactViewport: false,
+      },
+      {
+        sidebarThreads: {
+          status: "ready",
+          threads: [
+            thread({ id: "parent" }),
+            thread({ id: "child", parentThreadId: "parent" }),
+          ],
+          projects: [{ id: "proj_1", name: "bb", isPersonal: false }],
+        },
+      },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "1 child threads" }));
+    const menu = screen.getByRole("menu", { name: "Child threads" });
+    expect(menu.classList.contains("absolute")).toBe(true);
+    expect(menu.classList.contains("right-0")).toBe(true);
+    expect(menu.classList.contains("w-80")).toBe(true);
+  });
+});

--- a/examples/plugins/t3sidebar/src/SubagentsChip.test.tsx
+++ b/examples/plugins/t3sidebar/src/SubagentsChip.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { cleanup, fireEvent, screen } from "@testing-library/react";
 import { loadPluginApp, renderSlot } from "@get-bb/plugin-sdk/testing/app";
 import type { PluginSidebarThread } from "@get-bb/plugin-sdk";
@@ -45,90 +45,51 @@ function thread(
   };
 }
 
-function renderCompact() {
-  return renderSlot(
-    childrenChip,
-    {
-      threadId: "parent",
-      projectId: "proj_1",
-      isCompactViewport: true,
-    },
-    {
-      sidebarThreads: {
-        status: "ready",
-        threads: [
-          thread({ id: "parent" }),
-          thread({ id: "child", parentThreadId: "parent" }),
-        ],
-        projects: [{ id: "proj_1", name: "bb", isPersonal: false }],
-      },
-    },
-  );
-}
+afterEach(cleanup);
 
-afterEach(() => {
-  cleanup();
-  vi.restoreAllMocks();
-  vi.unstubAllGlobals();
-});
-
-describe("SubagentsChip menu position", () => {
-  it("clamps only when right alignment would cross the viewport gutter", () => {
-    renderCompact();
-    vi.stubGlobal("innerWidth", 390);
-    const trigger = screen.getByRole("button", { name: "1 child threads" });
-    vi.spyOn(trigger, "getBoundingClientRect").mockReturnValue({
-      right: 250,
-    } as DOMRect);
-
-    fireEvent.click(trigger);
-
-    const menu = screen.getByRole("menu", { name: "Child threads" });
-    expect(menu.classList.contains("fixed")).toBe(true);
-    expect(menu.classList.contains("w-80")).toBe(true);
-    expect(menu.classList.contains("max-w-[calc(100vw-1rem)]")).toBe(true);
-    expect(menu.style.left).toBe("8px");
-  });
-
-  it("stays right-aligned to the chip while the menu fits on screen", () => {
-    renderCompact();
-    vi.stubGlobal("innerWidth", 390);
-    const trigger = screen.getByRole("button", { name: "1 child threads" });
-    vi.spyOn(trigger, "getBoundingClientRect").mockReturnValue({
-      right: 380,
-    } as DOMRect);
-
-    fireEvent.click(trigger);
-
-    expect(
-      screen.getByRole("menu", { name: "Child threads" }).style.left,
-    ).toBe("60px");
-  });
-
-  it("keeps the desktop menu anchored to its header chip", () => {
+describe("SubagentsChip child list", () => {
+  it("caps a long menu and makes the child list scrollable", () => {
     renderSlot(
       childrenChip,
       {
         threadId: "parent",
         projectId: "proj_1",
-        isCompactViewport: false,
+        isCompactViewport: true,
       },
       {
         sidebarThreads: {
           status: "ready",
           threads: [
-            thread({ id: "parent" }),
-            thread({ id: "child", parentThreadId: "parent" }),
+            thread({ id: "parent", title: "Parent" }),
+            ...Array.from({ length: 26 }, (_, index) =>
+              thread({
+                id: `child_${index}`,
+                title: `Child ${index + 1}`,
+                parentThreadId: "parent",
+                createdAt: index,
+              }),
+            ),
           ],
           projects: [{ id: "proj_1", name: "bb", isPersonal: false }],
         },
       },
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "1 child threads" }));
+    fireEvent.click(screen.getByRole("button", { name: "26 child threads" }));
+
     const menu = screen.getByRole("menu", { name: "Child threads" });
-    expect(menu.classList.contains("absolute")).toBe(true);
-    expect(menu.classList.contains("right-0")).toBe(true);
-    expect(menu.classList.contains("w-80")).toBe(true);
+    const list = menu.querySelector("ul");
+    expect(menu.classList.contains("flex")).toBe(true);
+    expect(
+      menu.classList.contains("max-h-[min(32rem,calc(100dvh-6rem))]"),
+    ).toBe(true);
+    expect(list?.classList.contains("min-h-0")).toBe(true);
+    expect(list?.classList.contains("overflow-y-auto")).toBe(true);
+    expect(list?.classList.contains("overscroll-contain")).toBe(true);
+    expect(list?.classList.contains("touch-pan-y")).toBe(true);
+    expect(list?.classList.contains("[-webkit-overflow-scrolling:touch]")).toBe(
+      true,
+    );
+    expect(screen.getAllByRole("menuitem")).toHaveLength(26);
   });
 });

--- a/examples/plugins/t3sidebar/src/SubagentsChip.tsx
+++ b/examples/plugins/t3sidebar/src/SubagentsChip.tsx
@@ -11,20 +11,40 @@ import { StatusGlyph } from "./StatusGlyph";
 import { childrenOf, threadDisplayTitle } from "./inbox";
 
 const MAX_DISCS = 3;
-const CHILD_MENU_WIDTH = 320;
 const CHILD_MENU_VIEWPORT_GUTTER = 8;
 
-function clampCompactMenuLeft(triggerRight: number, viewportWidth: number) {
-  const menuWidth = Math.min(
-    CHILD_MENU_WIDTH,
-    Math.max(0, viewportWidth - CHILD_MENU_VIEWPORT_GUTTER * 2),
-  );
-  const minLeft = CHILD_MENU_VIEWPORT_GUTTER;
+interface CompactViewportBounds {
+  left: number;
+  width: number;
+  safeAreaLeft: number;
+  safeAreaRight: number;
+}
+
+function clampCompactMenuLeft({
+  triggerRight,
+  menuWidth,
+  viewport,
+}: {
+  triggerRight: number;
+  menuWidth: number;
+  viewport: CompactViewportBounds;
+}) {
+  const minLeft =
+    viewport.left + viewport.safeAreaLeft + CHILD_MENU_VIEWPORT_GUTTER;
   const maxLeft = Math.max(
     minLeft,
-    viewportWidth - menuWidth - CHILD_MENU_VIEWPORT_GUTTER,
+    viewport.left +
+      viewport.width -
+      viewport.safeAreaRight -
+      CHILD_MENU_VIEWPORT_GUTTER -
+      menuWidth,
   );
   return Math.min(Math.max(triggerRight - menuWidth, minLeft), maxLeft);
+}
+
+function parsePixelValue(value: string) {
+  const parsed = Number.parseFloat(value);
+  return Number.isFinite(parsed) ? parsed : 0;
 }
 
 /**
@@ -43,32 +63,64 @@ export function SubagentsChip({
   const actions = useSidebarThreadActions();
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const safeAreaProbeRef = useRef<HTMLSpanElement>(null);
+  const [compactViewport, setCompactViewport] =
+    useState<CompactViewportBounds | null>(null);
   const [compactMenuLeft, setCompactMenuLeft] = useState(
     CHILD_MENU_VIEWPORT_GUTTER,
   );
 
-  const updateCompactMenuLeft = useCallback(() => {
-    const trigger = triggerRef.current;
-    if (!trigger) return;
-    setCompactMenuLeft(
-      clampCompactMenuLeft(trigger.getBoundingClientRect().right, innerWidth),
+  const updateCompactViewport = useCallback(() => {
+    const visualViewport = window.visualViewport;
+    const safeAreaProbe = safeAreaProbeRef.current;
+    const safeArea = safeAreaProbe ? getComputedStyle(safeAreaProbe) : null;
+    const next: CompactViewportBounds = {
+      left: visualViewport?.offsetLeft ?? 0,
+      width: visualViewport?.width ?? window.innerWidth,
+      safeAreaLeft: parsePixelValue(safeArea?.paddingLeft ?? ""),
+      safeAreaRight: parsePixelValue(safeArea?.paddingRight ?? ""),
+    };
+    setCompactViewport((current) =>
+      current?.left === next.left &&
+      current.width === next.width &&
+      current.safeAreaLeft === next.safeAreaLeft &&
+      current.safeAreaRight === next.safeAreaRight
+        ? current
+        : next,
     );
   }, []);
 
   useLayoutEffect(() => {
     if (!open || !isCompactViewport) return;
 
-    updateCompactMenuLeft();
+    updateCompactViewport();
     const viewport = window.visualViewport;
-    window.addEventListener("resize", updateCompactMenuLeft);
-    viewport?.addEventListener("resize", updateCompactMenuLeft);
-    viewport?.addEventListener("scroll", updateCompactMenuLeft);
+    window.addEventListener("resize", updateCompactViewport);
+    viewport?.addEventListener("resize", updateCompactViewport);
+    viewport?.addEventListener("scroll", updateCompactViewport);
     return () => {
-      window.removeEventListener("resize", updateCompactMenuLeft);
-      viewport?.removeEventListener("resize", updateCompactMenuLeft);
-      viewport?.removeEventListener("scroll", updateCompactMenuLeft);
+      window.removeEventListener("resize", updateCompactViewport);
+      viewport?.removeEventListener("resize", updateCompactViewport);
+      viewport?.removeEventListener("scroll", updateCompactViewport);
     };
-  }, [isCompactViewport, open, updateCompactMenuLeft]);
+  }, [isCompactViewport, open, updateCompactViewport]);
+
+  useLayoutEffect(() => {
+    if (!open || !isCompactViewport || !compactViewport) return;
+    const trigger = triggerRef.current;
+    const menu = menuRef.current;
+    if (!trigger || !menu) return;
+    const menuWidth = menu.getBoundingClientRect().width;
+    if (menuWidth <= 0) return;
+    setCompactMenuLeft(
+      clampCompactMenuLeft({
+        triggerRight: trigger.getBoundingClientRect().right,
+        menuWidth,
+        viewport: compactViewport,
+      }),
+    );
+  }, [compactViewport, isCompactViewport, open]);
 
   const children = childrenOf(threads, threadId);
   if (children.length === 0) return null;
@@ -84,7 +136,7 @@ export function SubagentsChip({
         aria-expanded={open}
         aria-label={`${children.length} child threads`}
         onClick={() => {
-          if (!open && isCompactViewport) updateCompactMenuLeft();
+          if (!open && isCompactViewport) updateCompactViewport();
           setOpen((value) => !value);
         }}
         className={cn(
@@ -96,6 +148,18 @@ export function SubagentsChip({
         <DiscCluster threads={children} />
         {isCompactViewport ? null : <span className="truncate">{label}</span>}
       </button>
+      {isCompactViewport ? (
+        <span
+          ref={safeAreaProbeRef}
+          data-child-menu-safe-area-probe=""
+          aria-hidden
+          className="pointer-events-none fixed invisible size-0"
+          style={{
+            paddingLeft: "env(safe-area-inset-left)",
+            paddingRight: "env(safe-area-inset-right)",
+          }}
+        />
+      ) : null}
       {open ? (
         <>
           {/* Click-away. Wide headers anchor the menu to this chip; compact
@@ -106,15 +170,31 @@ export function SubagentsChip({
             aria-hidden
           />
           <div
+            ref={menuRef}
             role="menu"
             aria-label="Child threads"
             className={cn(
-              "z-50 w-80 max-w-[calc(100vw-1rem)] overflow-hidden rounded-xl border border-border bg-popover shadow-lg",
+              "z-50 flex max-h-[min(32rem,calc(100dvh-6rem))] w-80 max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-xl border border-border bg-popover shadow-lg",
               isCompactViewport
                 ? "fixed top-[calc(env(safe-area-inset-top)+3.5rem)]"
                 : "absolute right-0 top-9",
             )}
-            style={isCompactViewport ? { left: compactMenuLeft } : undefined}
+            style={
+              isCompactViewport
+                ? {
+                    left: compactMenuLeft,
+                    maxWidth: compactViewport
+                      ? Math.max(
+                          0,
+                          compactViewport.width -
+                            compactViewport.safeAreaLeft -
+                            compactViewport.safeAreaRight -
+                            CHILD_MENU_VIEWPORT_GUTTER * 2,
+                        )
+                      : undefined,
+                  }
+                : undefined
+            }
           >
             <div className="flex items-center gap-2 px-3 pb-1 pt-2.5">
               <span className="text-xs font-semibold">Children</span>
@@ -122,7 +202,7 @@ export function SubagentsChip({
                 {children.length}
               </span>
             </div>
-            <ul className="flex flex-col gap-px p-1.5 pt-0.5">
+            <ul className="flex min-h-0 touch-pan-y flex-col gap-px overflow-y-auto overscroll-contain p-1.5 pt-0.5 [-webkit-overflow-scrolling:touch]">
               {children.map((child) => (
                 <li key={child.id} className="list-none">
                   <button

--- a/examples/plugins/t3sidebar/src/SubagentsChip.tsx
+++ b/examples/plugins/t3sidebar/src/SubagentsChip.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import {
   experimental_useSidebarThreadActions as useSidebarThreadActions,
   experimental_useSidebarThreads as useSidebarThreads,
@@ -11,6 +11,21 @@ import { StatusGlyph } from "./StatusGlyph";
 import { childrenOf, threadDisplayTitle } from "./inbox";
 
 const MAX_DISCS = 3;
+const CHILD_MENU_WIDTH = 320;
+const CHILD_MENU_VIEWPORT_GUTTER = 8;
+
+function clampCompactMenuLeft(triggerRight: number, viewportWidth: number) {
+  const menuWidth = Math.min(
+    CHILD_MENU_WIDTH,
+    Math.max(0, viewportWidth - CHILD_MENU_VIEWPORT_GUTTER * 2),
+  );
+  const minLeft = CHILD_MENU_VIEWPORT_GUTTER;
+  const maxLeft = Math.max(
+    minLeft,
+    viewportWidth - menuWidth - CHILD_MENU_VIEWPORT_GUTTER,
+  );
+  return Math.min(Math.max(triggerRight - menuWidth, minLeft), maxLeft);
+}
 
 /**
  * The home for child threads the flat list hides: a chip in the thread header
@@ -27,6 +42,33 @@ export function SubagentsChip({
   const { threads } = useSidebarThreads();
   const actions = useSidebarThreadActions();
   const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [compactMenuLeft, setCompactMenuLeft] = useState(
+    CHILD_MENU_VIEWPORT_GUTTER,
+  );
+
+  const updateCompactMenuLeft = useCallback(() => {
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+    setCompactMenuLeft(
+      clampCompactMenuLeft(trigger.getBoundingClientRect().right, innerWidth),
+    );
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open || !isCompactViewport) return;
+
+    updateCompactMenuLeft();
+    const viewport = window.visualViewport;
+    window.addEventListener("resize", updateCompactMenuLeft);
+    viewport?.addEventListener("resize", updateCompactMenuLeft);
+    viewport?.addEventListener("scroll", updateCompactMenuLeft);
+    return () => {
+      window.removeEventListener("resize", updateCompactMenuLeft);
+      viewport?.removeEventListener("resize", updateCompactMenuLeft);
+      viewport?.removeEventListener("scroll", updateCompactMenuLeft);
+    };
+  }, [isCompactViewport, open, updateCompactMenuLeft]);
 
   const children = childrenOf(threads, threadId);
   if (children.length === 0) return null;
@@ -37,10 +79,14 @@ export function SubagentsChip({
   return (
     <span className="relative">
       <button
+        ref={triggerRef}
         type="button"
         aria-expanded={open}
         aria-label={`${children.length} child threads`}
-        onClick={() => setOpen((value) => !value)}
+        onClick={() => {
+          if (!open && isCompactViewport) updateCompactMenuLeft();
+          setOpen((value) => !value);
+        }}
         className={cn(
           "flex h-7 items-center gap-1.5 rounded-full border border-border px-2 text-2xs text-muted-foreground",
           "hover:bg-accent hover:text-foreground",
@@ -52,8 +98,8 @@ export function SubagentsChip({
       </button>
       {open ? (
         <>
-          {/* Click-away. The header is a short row, so the list itself is
-              absolutely positioned rather than inline. */}
+          {/* Click-away. Wide headers anchor the menu to this chip; compact
+              headers pin it to the viewport so it cannot run off-screen. */}
           <span
             className="fixed inset-0 z-40"
             onClick={() => setOpen(false)}
@@ -62,7 +108,13 @@ export function SubagentsChip({
           <div
             role="menu"
             aria-label="Child threads"
-            className="absolute right-0 top-9 z-50 w-80 overflow-hidden rounded-xl border border-border bg-popover shadow-lg"
+            className={cn(
+              "z-50 w-80 max-w-[calc(100vw-1rem)] overflow-hidden rounded-xl border border-border bg-popover shadow-lg",
+              isCompactViewport
+                ? "fixed top-[calc(env(safe-area-inset-top)+3.5rem)]"
+                : "absolute right-0 top-9",
+            )}
+            style={isCompactViewport ? { left: compactMenuLeft } : undefined}
           >
             <div className="flex items-center gap-2 px-3 pb-1 pt-2.5">
               <span className="text-xs font-semibold">Children</span>

--- a/examples/plugins/t3sidebar/src/SubagentsChip.tsx
+++ b/examples/plugins/t3sidebar/src/SubagentsChip.tsx
@@ -15,9 +15,13 @@ const CHILD_MENU_VIEWPORT_GUTTER = 8;
 
 interface CompactViewportBounds {
   left: number;
+  top: number;
   width: number;
+  height: number;
   safeAreaLeft: number;
+  safeAreaTop: number;
   safeAreaRight: number;
+  safeAreaBottom: number;
 }
 
 function clampCompactMenuLeft({
@@ -70,6 +74,12 @@ export function SubagentsChip({
   const [compactMenuLeft, setCompactMenuLeft] = useState(
     CHILD_MENU_VIEWPORT_GUTTER,
   );
+  const [compactMenuTop, setCompactMenuTop] = useState(
+    CHILD_MENU_VIEWPORT_GUTTER,
+  );
+  const [compactMenuMaxHeight, setCompactMenuMaxHeight] = useState<
+    string | undefined
+  >();
 
   const updateCompactViewport = useCallback(() => {
     const visualViewport = window.visualViewport;
@@ -77,15 +87,23 @@ export function SubagentsChip({
     const safeArea = safeAreaProbe ? getComputedStyle(safeAreaProbe) : null;
     const next: CompactViewportBounds = {
       left: visualViewport?.offsetLeft ?? 0,
+      top: visualViewport?.offsetTop ?? 0,
       width: visualViewport?.width ?? window.innerWidth,
+      height: visualViewport?.height ?? window.innerHeight,
       safeAreaLeft: parsePixelValue(safeArea?.paddingLeft ?? ""),
+      safeAreaTop: parsePixelValue(safeArea?.paddingTop ?? ""),
       safeAreaRight: parsePixelValue(safeArea?.paddingRight ?? ""),
+      safeAreaBottom: parsePixelValue(safeArea?.paddingBottom ?? ""),
     };
     setCompactViewport((current) =>
       current?.left === next.left &&
+      current.top === next.top &&
       current.width === next.width &&
+      current.height === next.height &&
       current.safeAreaLeft === next.safeAreaLeft &&
-      current.safeAreaRight === next.safeAreaRight
+      current.safeAreaTop === next.safeAreaTop &&
+      current.safeAreaRight === next.safeAreaRight &&
+      current.safeAreaBottom === next.safeAreaBottom
         ? current
         : next,
     );
@@ -111,14 +129,32 @@ export function SubagentsChip({
     const trigger = triggerRef.current;
     const menu = menuRef.current;
     if (!trigger || !menu) return;
+    const triggerRect = trigger.getBoundingClientRect();
     const menuWidth = menu.getBoundingClientRect().width;
     if (menuWidth <= 0) return;
     setCompactMenuLeft(
       clampCompactMenuLeft({
-        triggerRight: trigger.getBoundingClientRect().right,
+        triggerRight: triggerRect.right,
         menuWidth,
         viewport: compactViewport,
       }),
+    );
+    const minTop =
+      compactViewport.top +
+      compactViewport.safeAreaTop +
+      CHILD_MENU_VIEWPORT_GUTTER;
+    const viewportBottom =
+      compactViewport.top +
+      compactViewport.height -
+      compactViewport.safeAreaBottom -
+      CHILD_MENU_VIEWPORT_GUTTER;
+    const top = Math.min(
+      Math.max(triggerRect.bottom + CHILD_MENU_VIEWPORT_GUTTER, minTop),
+      Math.max(minTop, viewportBottom),
+    );
+    setCompactMenuTop(top);
+    setCompactMenuMaxHeight(
+      `min(32rem, ${Math.max(0, viewportBottom - top)}px)`,
     );
   }, [compactViewport, isCompactViewport, open]);
 
@@ -156,7 +192,9 @@ export function SubagentsChip({
           className="pointer-events-none fixed invisible size-0"
           style={{
             paddingLeft: "env(safe-area-inset-left)",
+            paddingTop: "env(safe-area-inset-top)",
             paddingRight: "env(safe-area-inset-right)",
+            paddingBottom: "env(safe-area-inset-bottom)",
           }}
         />
       ) : null}
@@ -175,14 +213,14 @@ export function SubagentsChip({
             aria-label="Child threads"
             className={cn(
               "z-50 flex max-h-[min(32rem,calc(100dvh-6rem))] w-80 max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-xl border border-border bg-popover shadow-lg",
-              isCompactViewport
-                ? "fixed top-[calc(env(safe-area-inset-top)+3.5rem)]"
-                : "absolute right-0 top-9",
+              isCompactViewport ? "fixed" : "absolute right-0 top-9",
             )}
             style={
               isCompactViewport
                 ? {
                     left: compactMenuLeft,
+                    top: compactMenuTop,
+                    maxHeight: compactMenuMaxHeight,
                     maxWidth: compactViewport
                       ? Math.max(
                           0,


### PR DESCRIPTION
## What was wrong

T3 Sidebar unconditionally positioned its `20rem` child menu with `absolute right-0` relative to the header chip. Compact headers can place that chip farther left than the menu width, producing a negative left edge and clipping the menu outside the viewport. Fixes #2104. Standalone counterpart: https://github.com/SawyerHood/bb-plugin-t3sidebar/issues/3.

## What changed

- Keep desktop placement unchanged (`absolute right-0`).
- On compact viewports, preserve the `20rem` maximum width and the trigger's preferred right alignment.
- Clamp the computed left coordinate only when the preferred position would cross the 8px viewport gutter.
- Recompute on window and visual-viewport resize/scroll so rotation and browser chrome changes stay aligned.
- Carry the bounded vertical scroll contract from the companion fix so this branch remains independently usable; keep scroll and position coverage in separate test files.
- Measure the rendered menu width, clamp against `visualViewport.width`/`offsetLeft`, and include horizontal safe-area insets.
- Keep the menu below its trigger when possible, then bound its top and maximum height against `visualViewport.offsetTop`/`height` and the vertical safe-area insets.
- Add regression coverage for rem-sized width, unclamped and clamped positions, horizontal and vertical visual-viewport bounds, safe areas, and the desktop branch.
- No host-daemon wire, public plugin API, CLI, configuration, guide, or documentation changes.

## How you verified

- `pnpm exec turbo run test typecheck --filter=bb-plugin-t3sidebar` — 87 tests passed across 7 files; typecheck passed.
- Compact geometry at 390px:
  - trigger right 380px → preferred/aligned left 60px remains 60px
  - trigger right 250px → negative preferred left clamps to 8px
- The desktop regression keeps `absolute right-0 w-80`.
- iPhone 17 / iOS 26.4 Simulator Safari reproduced the pre-fix clipping.

Fixes #2104

> AGENT GENERATED: by GPT-5.6
