### PR TITLE
Fix Tasks stale-label persistence test race

### DIFF
--- a/plugins/tasks/views/list/list-preference.persistence.test.tsx
+++ b/plugins/tasks/views/list/list-preference.persistence.test.tsx
@@ -490,8 +490,10 @@ describe("list filter/sort preference persistence", () => {
       ).toBe(true);
     });
     // Empty labelIds filter yields no rows (not the full unfiltered list).
-    expect(slot.queryByText("ALP-1")).toBeNull();
-    expect(slot.queryByText("ALP-2")).toBeNull();
+    await waitFor(() => {
+      expect(slot.queryByText("ALP-1")).toBeNull();
+      expect(slot.queryByText("ALP-2")).toBeNull();
+    });
   });
 });
 


### PR DESCRIPTION
## What was wrong

The stale-label persistence test waited only until the mock RPC handler recorded a `listTasks` invocation with empty `labelIds`. That recording happens synchronously at handler entry, before the response crosses the async query path and React commits the empty result, so a loaded CI runner could complete the wait while the prior unfiltered `ALP-1` row was still in the DOM. This produced the exact failures seen in [run 32429333291](https://github.com/get-bb/bb/actions/runs/32429333291) and [run 32429304373](https://github.com/get-bb/bb/actions/runs/32429304373); the production stale-label behavior itself was correct.

## What changed

Kept the RPC assertion that proves stale label names resolve to an active empty ID filter, then made the existing `ALP-1` and `ALP-2` absence assertions wait for the observable DOM result. This changes no production or wire behavior, does not increase a timeout, and does not weaken the assertions.

## How you verified

- Before the fix, a controlled 100 ms delay between the empty-filter RPC invocation and response reproduced the exact `ALP-1` assertion failure. With the fix, the same controlled delay passed; the probe was then removed.
- `pnpm exec turbo run test --filter=bb-plugin-tasks --force -- --run views/list/list-preference.persistence.test.tsx` — 7 passed.
- 64 concurrent focused runs of the stale-label test — 64 passed, 0 failed.
- `pnpm exec turbo run test --filter=bb-plugin-tasks --force` — 35 files and 359 tests passed.
- `pnpm exec turbo run typecheck --filter=bb-plugin-tasks --force` — passed with the plugin SDK type-generation dependency.
- `pnpm exec turbo run build --filter=bb-plugin-tasks --force` — passed with the plugin SDK build dependency.
- `git diff --check` — passed.

> AGENT GENERATED: by GPT-5.6-Sol
