### PR TITLE
Isolate demo state with random session URLs

### DIFF
--- a/.github/workflows/deploy-demo-server.yml
+++ b/.github/workflows/deploy-demo-server.yml
@@ -73,8 +73,8 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: pnpm --filter @bb/demo-server exec wrangler deploy | tee deploy.log
 
-      # The workers.dev URL is what goes in the App Store review notes. Surface
-      # it on the run so nobody has to open the Cloudflare dashboard for it.
+      # Surface the worker origin so the submitter can mint a private session
+      # URL for the App Store review notes (see apps/mobile/README.md).
       - name: Report the URL
         run: |
           {

--- a/apps/demo-server/src/demo-state.ts
+++ b/apps/demo-server/src/demo-state.ts
@@ -4,6 +4,9 @@
 
 import { DemoWorld } from "./demo-world.js";
 
+/** Set by the public Worker after it validates and strips the session path. */
+export const DEMO_SERVER_URL_HEADER = "x-bb-demo-server-url";
+
 export class DemoStateDO {
   private readonly world = new DemoWorld();
   private readonly sockets = new Set<WebSocket>();
@@ -26,7 +29,10 @@ export class DemoStateDO {
     if (url.pathname.replace(/\/+$/u, "") === "/ws") {
       return this.handleWebSocket(request);
     }
-    return this.world.handle(request);
+    return this.world.handle(
+      request,
+      request.headers.get(DEMO_SERVER_URL_HEADER) ?? url.origin,
+    );
   }
 
   private handleWebSocket(request: Request): Response {

--- a/apps/demo-server/src/demo-world.test.ts
+++ b/apps/demo-server/src/demo-world.test.ts
@@ -157,6 +157,19 @@ describe("demo world routes", () => {
     ).toBe(400);
   });
 
+  it("rejects browser-simple text/plain writes", async () => {
+    const { world } = createWorld();
+    const response = await world.handle(
+      new Request(`${ORIGIN}/api/v1/threads/${THREAD_ID}/send`, {
+        method: "POST",
+        headers: { "content-type": "text/plain" },
+        body: JSON.stringify(sendBody("Cross-site write")),
+      }),
+    );
+
+    expect(response.status).toBe(415);
+  });
+
   it("echoes a tabs write with the next revision", async () => {
     const { send } = createWorld();
     const tabs = await parsed(

--- a/apps/demo-server/src/demo-world.ts
+++ b/apps/demo-server/src/demo-world.ts
@@ -137,6 +137,28 @@ function notFound(threadId: string): Response {
   );
 }
 
+function unsupportedMediaType(): Response {
+  return json(
+    {
+      error: {
+        code: "unsupported_media_type",
+        message: "Demo writes require Content-Type: application/json.",
+      },
+    },
+    415,
+  );
+}
+
+function hasJsonContentType(request: Request): boolean {
+  return (
+    request.headers
+      .get("content-type")
+      ?.split(";", 1)[0]
+      ?.trim()
+      .toLowerCase() === "application/json"
+  );
+}
+
 async function readJson(request: Request): Promise<unknown> {
   try {
     return await request.json();
@@ -193,15 +215,22 @@ export class DemoWorld {
       : null;
   }
 
-  async handle(request: Request): Promise<Response> {
+  async handle(request: Request, serverUrl?: string): Promise<Response> {
     const url = new URL(request.url);
     const path = url.pathname.replace(/\/+$/u, "") || "/";
     if (path === "/health") return json({ ok: true });
     if (!path.startsWith("/api/v1/"))
       return notImplemented(request.method, path);
+    if (request.method !== "GET" && !hasJsonContentType(request)) {
+      return unsupportedMediaType();
+    }
 
     const api = path.slice("/api/v1".length);
-    const response = await this.handleApi(request, api, url.origin);
+    const response = await this.handleApi(
+      request,
+      api,
+      serverUrl ?? url.origin,
+    );
     return response ?? notImplemented(request.method, path);
   }
 

--- a/apps/demo-server/src/worker.test.ts
+++ b/apps/demo-server/src/worker.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { DEMO_SERVER_URL_HEADER } from "./demo-state.js";
+import worker, { type Env } from "./worker.js";
+
+const ORIGIN = "https://demo.example.test";
+const FIRST_ID = "a".repeat(64);
+const SECOND_ID = "b".repeat(64);
+const MINTED_ID = "c".repeat(64);
+
+function durableObjectId(value: string): DurableObjectId {
+  const id: DurableObjectId = {
+    equals: (other) => other.toString() === value,
+    toString: () => value,
+  };
+  return id;
+}
+
+function createEnv() {
+  const forwarded: { id: string; request: Request }[] = [];
+  const env: Env = {
+    DEMO_STATE: {
+      newUniqueId: () => durableObjectId(MINTED_ID),
+      idFromString: (value) => {
+        if (!/^[a-f0-9]{64}$/u.test(value)) throw new Error("Invalid id");
+        return durableObjectId(value);
+      },
+      get: (id) => ({
+        fetch: async (request) => {
+          forwarded.push({ id: id.toString(), request });
+          return new Response("forwarded");
+        },
+      }),
+    },
+  };
+  return { env, forwarded };
+}
+
+describe("demo session routing", () => {
+  it("mints an unguessable Durable Object id as a Direct URL", async () => {
+    const { env } = createEnv();
+    const response = await worker.fetch(
+      new Request(`${ORIGIN}/demo`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      }),
+      env,
+    );
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toEqual({
+      serverUrl: `${ORIGIN}/demo/${MINTED_ID}`,
+    });
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("routes HTTP and WebSocket traffic by credential, never client IP", async () => {
+    const { env, forwarded } = createEnv();
+    const sharedNetwork = { "cf-connecting-ip": "203.0.113.7" };
+
+    await worker.fetch(
+      new Request(`${ORIGIN}/demo/${FIRST_ID}/health`, {
+        headers: sharedNetwork,
+      }),
+      env,
+    );
+    await worker.fetch(
+      new Request(`${ORIGIN}/demo/${SECOND_ID}/api/v1/threads`, {
+        headers: sharedNetwork,
+      }),
+      env,
+    );
+    await worker.fetch(
+      new Request(`${ORIGIN}/demo/${FIRST_ID}/ws`, {
+        headers: {
+          ...sharedNetwork,
+          origin: ORIGIN,
+          upgrade: "websocket",
+        },
+      }),
+      env,
+    );
+
+    expect(forwarded.map((entry) => entry.id)).toEqual([
+      FIRST_ID,
+      SECOND_ID,
+      FIRST_ID,
+    ]);
+    expect(
+      forwarded.map((entry) => new URL(entry.request.url).pathname),
+    ).toEqual(["/health", "/api/v1/threads", "/ws"]);
+    expect(
+      forwarded.map((entry) =>
+        entry.request.headers.get(DEMO_SERVER_URL_HEADER),
+      ),
+    ).toEqual([
+      `${ORIGIN}/demo/${FIRST_ID}`,
+      `${ORIGIN}/demo/${SECOND_ID}`,
+      `${ORIGIN}/demo/${FIRST_ID}`,
+    ]);
+  });
+
+  it("rejects missing credentials and cross-site browser origins", async () => {
+    const { env, forwarded } = createEnv();
+    const missing = await worker.fetch(
+      new Request(`${ORIGIN}/api/v1/threads`),
+      env,
+    );
+    const crossSiteWrite = await worker.fetch(
+      new Request(`${ORIGIN}/demo/${FIRST_ID}/api/v1/threads`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          origin: "https://hostile.example",
+        },
+        body: "{}",
+      }),
+      env,
+    );
+    const crossSiteSocket = await worker.fetch(
+      new Request(`${ORIGIN}/demo/${FIRST_ID}/ws`, {
+        headers: {
+          origin: "https://hostile.example",
+          upgrade: "websocket",
+        },
+      }),
+      env,
+    );
+
+    expect(missing.status).toBe(401);
+    expect(crossSiteWrite.status).toBe(403);
+    expect(crossSiteSocket.status).toBe(403);
+    expect(forwarded).toEqual([]);
+  });
+});

--- a/apps/demo-server/src/worker.ts
+++ b/apps/demo-server/src/worker.ts
@@ -24,28 +24,128 @@
 //
 // ISOLATION
 //
-// Each client address gets its own Durable Object, so the messages a reviewer
-// sends are visible only to that reviewer. The server is public: a shared
-// world would let anyone put text in front of Apple's reviewer, and would
-// let one visitor read what another typed. State is in-memory only and is
-// dropped when the object goes idle.
+// POST /demo mints a random Durable Object id and returns a Direct URL whose
+// path carries that id. The mobile SDK preserves a Direct URL path prefix for
+// both HTTP and WebSocket traffic, so one unguessable credential selects one
+// world without treating a shared network address as identity. State is
+// in-memory only and is dropped when the object goes idle.
 
-import { DemoStateDO } from "./demo-state.js";
+import { DEMO_SERVER_URL_HEADER, DemoStateDO } from "./demo-state.js";
+
+interface DemoStateStub {
+  fetch(request: Request): Promise<Response>;
+}
+
+interface DemoStateNamespace {
+  newUniqueId(): DurableObjectId;
+  idFromString(id: string): DurableObjectId;
+  get(id: DurableObjectId): DemoStateStub;
+}
 
 export interface Env {
-  DEMO_STATE: DurableObjectNamespace;
+  DEMO_STATE: DemoStateNamespace;
 }
 
 export { DemoStateDO };
 
-/** The Durable Object name for a request: its client address, or one shared fallback when none is known (local dev). */
-export function demoStateName(request: Request): string {
-  return request.headers.get("cf-connecting-ip") ?? "local";
+const DEMO_PATH = "/demo";
+const JSON_HEADERS = {
+  "cache-control": "no-store",
+  "content-type": "application/json",
+};
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
+}
+
+function error(status: number, code: string, message: string): Response {
+  return json({ error: { code, message } }, status);
+}
+
+function requestOriginIsSupported(request: Request): boolean {
+  const origin = request.headers.get("origin");
+  return origin === null || origin === new URL(request.url).origin;
+}
+
+function hasJsonContentType(request: Request): boolean {
+  return (
+    request.headers
+      .get("content-type")
+      ?.split(";", 1)[0]
+      ?.trim()
+      .toLowerCase() === "application/json"
+  );
+}
+
+function mintSession(request: Request, env: Env): Response {
+  if (!hasJsonContentType(request)) {
+    return error(
+      415,
+      "unsupported_media_type",
+      "Demo session requests require Content-Type: application/json.",
+    );
+  }
+  const id = env.DEMO_STATE.newUniqueId();
+  const url = new URL(request.url);
+  return json({ serverUrl: `${url.origin}${DEMO_PATH}/${id.toString()}` }, 201);
+}
+
+interface DemoSessionRoute {
+  id: DurableObjectId;
+  serverUrl: string;
+  upstreamUrl: URL;
+}
+
+function demoSessionRoute(request: Request, env: Env): DemoSessionRoute | null {
+  const url = new URL(request.url);
+  if (!url.pathname.startsWith(`${DEMO_PATH}/`)) return null;
+  const [rawId, ...remaining] = url.pathname
+    .slice(`${DEMO_PATH}/`.length)
+    .split("/");
+  if (!rawId) return null;
+
+  let id: DurableObjectId;
+  try {
+    id = env.DEMO_STATE.idFromString(rawId);
+  } catch {
+    return null;
+  }
+
+  const upstreamUrl = new URL(url);
+  upstreamUrl.pathname = `/${remaining.join("/")}`;
+  return {
+    id,
+    serverUrl: `${url.origin}${DEMO_PATH}/${rawId}`,
+    upstreamUrl,
+  };
 }
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
-    const id = env.DEMO_STATE.idFromName(demoStateName(request));
-    return env.DEMO_STATE.get(id).fetch(request);
+    if (!requestOriginIsSupported(request)) {
+      return error(
+        403,
+        "unsupported_origin",
+        "This browser origin cannot access the bb demo server.",
+      );
+    }
+
+    const url = new URL(request.url);
+    if (request.method === "POST" && url.pathname === DEMO_PATH) {
+      return mintSession(request, env);
+    }
+
+    const route = demoSessionRoute(request, env);
+    if (route === null) {
+      return error(
+        401,
+        "demo_session_required",
+        `Mint a private demo Direct URL with POST ${DEMO_PATH}.`,
+      );
+    }
+
+    const upstreamRequest = new Request(route.upstreamUrl, request);
+    upstreamRequest.headers.set(DEMO_SERVER_URL_HEADER, route.serverUrl);
+    return env.DEMO_STATE.get(route.id).fetch(upstreamRequest);
   },
 };

--- a/apps/demo-server/wrangler.jsonc
+++ b/apps/demo-server/wrangler.jsonc
@@ -13,13 +13,13 @@
 // token is zone read-only and cannot create either, so that is a dashboard
 // step. workers.dev is HTTPS and is all a reviewer needs.
 //
-// Per-client isolation keys on the `cf-connecting-ip` header (src/worker.ts).
-// workers.dev sets it; anything that proxies this worker would collapse every
-// visitor into one shared world, so do not put it behind another proxy.
+// POST /demo mints a random Durable Object id and returns a Direct URL under
+// /demo/<id>. That unguessable path is the demo session credential used by
+// both HTTP and WebSocket traffic; never publish or reuse a reviewer's URL.
 //
 // No D1, no secrets, no bindings beyond the Durable Object: the demo holds
-// fixed fixtures and in-memory per-client state only (one object per client
-// address, see src/worker.ts). Nothing here can reach a real bb server, a
+// fixed fixtures and in-memory per-session state only (one object per random
+// Direct URL, see src/worker.ts). Nothing here can reach a real bb server, a
 // machine, or a user's data.
 {
   "$schema": "node_modules/wrangler/config-schema.json",

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -828,10 +828,22 @@ App Store Connect needs all of this:
   commands, so it cannot be on the internet, and connect pairing codes are
   single-use and expire in ten minutes. Give them the **demo server** instead:
   `apps/demo-server` is a Cloudflare Worker that answers the launch-path API
-  from fixed data, runs nothing, and isolates each client address. Deploy it
-  with `pnpm --filter @bb/demo-server deploy`, and rehearse the notes with
-  `e2e/manual/demo-server.yaml` before every submission. Disclose it in the
-  notes: a disclosed demo mode is sanctioned by guideline 2.1.
+  from fixed data, runs nothing, and isolates each random demo session. Deploy
+  it with `pnpm --filter @bb/demo-server deploy`. Before each review, mint a
+  fresh Direct URL and keep it in the private review notes:
+
+  ```sh
+  curl --fail --silent --request POST \
+    --header 'content-type: application/json' \
+    --data '{}' \
+    https://<DEMO-HOST>/demo
+  ```
+
+  The response is `{"serverUrl":"https://<DEMO-HOST>/demo/<SESSION-ID>"}`.
+  That unguessable URL is the reviewer credential: do not publish it or reuse
+  it for another reviewer. Rehearse it with `e2e/manual/demo-server.yaml`
+  before every submission. Disclose the demo in the notes; a disclosed demo
+  mode is sanctioned by guideline 2.1.
 
 Review notes template — keep it literal, and assume the reviewer knows nothing
 about coding agents:
@@ -843,7 +855,7 @@ you. It serves sample conversations and scripted replies; it does not run a
 real coding agent.
 
 1. Open the app. It shows "Connect to a bb server".
-2. Under "Direct URL", in "Server URL", enter: https://<DEMO-HOST>
+2. Under "Direct URL", in "Server URL", enter: https://<DEMO-HOST>/demo/<SESSION-ID>
 3. Tap "Connect".
 4. The app shows a list of conversations. Open any of them to read it.
 5. Type a message and send it. The agent replies after a moment.

--- a/apps/mobile/e2e/manual/demo-server.yaml
+++ b/apps/mobile/e2e/manual/demo-server.yaml
@@ -8,14 +8,17 @@
 # harness backend:
 #
 #   pnpm --filter @bb/demo-server dev        # the worker on 8799
+#   curl --request POST --header 'content-type: application/json' --data '{}' http://127.0.0.1:8799/demo
 #   EXPO_PUBLIC_BB_E2E=1 pnpm --filter @bb/mobile start --port 8082
-#   cd apps/mobile && maestro test e2e/manual/demo-server.yaml
+#   cd apps/mobile && DEMO_SERVER_URL=<returned-serverUrl> maestro test e2e/manual/demo-server.yaml
 #
-# To rehearse against the deployed worker, set SERVER_URL to its https URL.
+# Mint a session with `POST <worker-origin>/demo`, then set SERVER_URL to the
+# returned path-prefixed URL. The mobile SDK keeps that prefix on both API and
+# WebSocket requests.
 appId: app.getbb.mobile
 env:
   METRO_URL: "http://127.0.0.1:8082"
-  SERVER_URL: "http://127.0.0.1:8799"
+  SERVER_URL: "${DEMO_SERVER_URL}"
 ---
 # The E2E build wipes profiles on launch, so the shared subflow lands on
 # "Connect to a bb server" and adds SERVER_URL as a Direct URL. The probe


### PR DESCRIPTION
## What was wrong

The public demo Worker used `cf-connecting-ip` as the Durable Object name, so reviewers behind the same NAT or carrier address shared messages, queues, timers, and realtime notices. That network metadata was acting as tenancy without authenticating either HTTP or WebSocket requests. At the same time, the socket accepted every browser `Origin`, and JSON write routes parsed browser-simple `text/plain` bodies, allowing a hostile site to mutate or subscribe to the IP-shared state.

## What changed

`POST /demo` now mints Cloudflare's own random Durable Object ID and returns a path-prefixed Direct URL under `/demo/<id>`. That unguessable path is the demo session credential: the Worker resolves it with `idFromString`, routes both HTTP and `/ws` to that one object, and strips the prefix before the existing demo routes run. Browser requests with an `Origin` are accepted only when it exactly matches the Worker origin, and demo writes require `Content-Type: application/json` before their bodies are parsed.

This is the smallest complete demo-specific fix: it uses Durable Objects' built-in unique IDs directly, with no session database, cookie lifecycle, compatibility shim, mobile client change, or change to the real bb server protocol. The App Store review instructions and manual flow now mint and use a fresh private Direct URL for each reviewer.

## How you verified

The new regressions failed before the implementation and passed after it:

- shared-IP isolation: before, both requests selected `203.0.113.7`; after, separate random credentials route to separate objects while HTTP and WebSocket traffic for one credential route together
- browser-simple write: before, a `text/plain` send returned 200; after, it returns 415
- unsupported browser origins: HTTP writes and WebSocket upgrades return 403 without reaching a Durable Object

Validation:

- `pnpm exec turbo run typecheck test --filter=@bb/demo-server --force` — passed, 13 tests
- `pnpm --filter @bb/demo-server exec wrangler deploy --dry-run --outdir <temporary-directory>` — passed; 803.30 KiB / 119.93 KiB gzip
- local Wrangler QA — minted two sessions from the same host, sent a unique marker to one, confirmed it was absent from the other, confirmed each config advertised its full session URL, received WebSocket `pong`, and observed missing-session / cross-origin / text-plain responses of 401 / 403 / 415
- Prettier check and `git diff --check` — passed

## Issue

No matching GitHub issue exists; searches for the vulnerable header, demo sessions, NAT isolation, and App Store review found only the merged source PR #2110.

> AGENT GENERATED: by GPT-5.6-Sol
