### PR TITLE
Preserve retained demo turn identity

### DIFF
--- a/apps/demo-server/src/demo-world.test.ts
+++ b/apps/demo-server/src/demo-world.test.ts
@@ -85,6 +85,27 @@ function texts(timeline: ThreadTimelineResponse): string[] {
   );
 }
 
+function sentUserRow(timeline: ThreadTimelineResponse, text: string) {
+  return timeline.rows.find(
+    (row) =>
+      row.kind === "conversation" && row.role === "user" && row.text === text,
+  );
+}
+
+function rowIdentities(
+  timeline: ThreadTimelineResponse,
+  turnId: string | null | undefined,
+) {
+  return timeline.rows
+    .filter((row) => row.turnId === turnId)
+    .map((row) => ({
+      id: row.id,
+      turnId: row.turnId,
+      sourceSeqStart: row.sourceSeqStart,
+      sourceSeqEnd: row.sourceSeqEnd,
+    }));
+}
+
 describe("demo world routes", () => {
   it("answers every launch-path route with a body the contract accepts", async () => {
     const { get } = createWorld();
@@ -328,6 +349,56 @@ describe("sending a message", () => {
     expect(texts(timeline).at(-2)).toBe(
       `user: turn ${MAX_TURNS_PER_THREAD + 4}`,
     );
+  });
+
+  it("preserves retained turn identity and sequence through eviction", async () => {
+    const { get, send, advance } = createWorld();
+    for (let index = 0; index < MAX_TURNS_PER_THREAD; index += 1) {
+      await send(
+        "POST",
+        `/api/v1/threads/${THREAD_ID}/send`,
+        sendBody(`turn ${index}`),
+      );
+      advance(REPLY_DELAY_MS);
+    }
+
+    const before = await parsed(
+      get(`/api/v1/threads/${THREAD_ID}/timeline`),
+      threadTimelineResponseSchema,
+    );
+    const retainedBefore = sentUserRow(before, "turn 1");
+    const latestBefore = sentUserRow(
+      before,
+      `turn ${MAX_TURNS_PER_THREAD - 1}`,
+    );
+    expect(retainedBefore).toBeDefined();
+    expect(latestBefore).toBeDefined();
+
+    await send(
+      "POST",
+      `/api/v1/threads/${THREAD_ID}/send`,
+      sendBody(`turn ${MAX_TURNS_PER_THREAD}`),
+    );
+    const pending = await parsed(
+      get(`/api/v1/threads/${THREAD_ID}/timeline`),
+      threadTimelineResponseSchema,
+    );
+    const latestPending = sentUserRow(pending, `turn ${MAX_TURNS_PER_THREAD}`);
+    expect(latestPending).toBeDefined();
+    expect(latestPending?.turnId).not.toBe(latestBefore?.turnId);
+    expect(pending.maxSeq).toBeGreaterThan(before.maxSeq);
+
+    advance(REPLY_DELAY_MS);
+    const after = await parsed(
+      get(`/api/v1/threads/${THREAD_ID}/timeline`),
+      threadTimelineResponseSchema,
+    );
+    const retainedAfter = sentUserRow(after, "turn 1");
+    expect(retainedAfter).toBeDefined();
+    expect(rowIdentities(after, retainedAfter?.turnId)).toEqual(
+      rowIdentities(before, retainedBefore?.turnId),
+    );
+    expect(after.maxSeq).toBeGreaterThan(pending.maxSeq);
   });
 });
 

--- a/apps/demo-server/src/demo-world.ts
+++ b/apps/demo-server/src/demo-world.ts
@@ -85,6 +85,8 @@ const THREAD_PATH =
   /^\/threads\/(thr_[a-z0-9]+)(?:\/([a-z-]+(?:\/[a-z0-9_-]+)*))?$/u;
 
 interface SentTurn {
+  turnId: string;
+  sourceSeq: number;
   text: string;
   sentAt: number;
 }
@@ -92,6 +94,8 @@ interface SentTurn {
 interface ThreadState {
   seed: DemoThreadSeed;
   turns: SentTurn[];
+  nextTurnNumber: number;
+  nextSourceSeq: number;
 }
 
 export interface DemoWorldOptions {
@@ -157,7 +161,15 @@ export class DemoWorld {
   private readonly now: () => number;
   private readonly schedule: (fn: () => void, ms: number) => void;
   private readonly threads = new Map<string, ThreadState>(
-    DEMO_THREADS.map((seed) => [seed.id, { seed, turns: [] }]),
+    DEMO_THREADS.map((seed): [string, ThreadState] => [
+      seed.id,
+      {
+        seed,
+        turns: [],
+        nextTurnNumber: 1,
+        nextSourceSeq: seed.rows(seed.id, 0).length + 1,
+      },
+    ]),
   );
   private readonly queued = new Map<string, ThreadQueuedMessage[]>();
   private readonly listeners = new Set<
@@ -402,41 +414,42 @@ export class DemoWorld {
   private timeline(state: ThreadState, now: number): ThreadTimelineResponse {
     const threadId = state.seed.id;
     const rows = state.seed.rows(threadId, seedStartedAt(state.seed, now));
-    let seq = rows.length;
-    for (const [index, turn] of state.turns.entries()) {
-      const turnId = `${threadId}-sent-${index + 1}`;
+    let maxSeq = rows.length;
+    for (const turn of state.turns) {
       rows.push(
         conversationRow({
           threadId,
-          turnId,
-          seq: ++seq,
+          turnId: turn.turnId,
+          seq: turn.sourceSeq,
           at: turn.sentAt,
           role: "user",
           text: turn.text,
         }),
       );
+      maxSeq = turn.sourceSeq;
       if (this.replyPending(turn, now)) continue;
       rows.push(
         commandRow({
           threadId,
-          turnId,
-          seq: ++seq,
+          turnId: turn.turnId,
+          seq: turn.sourceSeq + 1,
           at: turn.sentAt + 400,
           ...DEMO_REPLY_COMMAND,
         }),
         conversationRow({
           threadId,
-          turnId,
-          seq: ++seq,
+          turnId: turn.turnId,
+          seq: turn.sourceSeq + 2,
           at: turn.sentAt + REPLY_DELAY_MS,
           role: "assistant",
           text: DEMO_REPLY,
         }),
       );
+      maxSeq = turn.sourceSeq + 2;
     }
     return {
       rows,
-      maxSeq: seq,
+      maxSeq,
       activePromptMode: null,
       activeThinking: null,
       activeWorkflows: [],
@@ -467,7 +480,13 @@ export class DemoWorld {
    * lost timer only delays the second notice.
    */
   private appendTurn(state: ThreadState, text: string, now: number): void {
-    state.turns.push({ text, sentAt: now });
+    state.turns.push({
+      turnId: `${state.seed.id}-sent-${state.nextTurnNumber++}`,
+      sourceSeq: state.nextSourceSeq,
+      text,
+      sentAt: now,
+    });
+    state.nextSourceSeq += 3;
     if (state.turns.length > MAX_TURNS_PER_THREAD) {
       state.turns.splice(0, state.turns.length - MAX_TURNS_PER_THREAD);
     }


### PR DESCRIPTION
## What was wrong

`DemoWorld` retained only message text and send time, then rebuilt each sent turn's `turnId` and source sequence from its current array index. Once the 20-turn cap evicted the oldest turn, unchanged retained rows received new identities and lower sequences, the newest content could reuse an existing identifier, and `maxSeq` stopped being a monotonic high-water mark. That violates the timeline identity contract used for client reconciliation and pagination. This follows the finding in [PR #2110's review](https://github.com/get-bb/bb/pull/2110#discussion_r3826327335).

## What changed

Sent turns now receive a permanent `turnId` and a reserved three-row source-sequence block when they enter per-thread state. Timeline rendering uses those stored values, while per-thread counters continue increasing after eviction. This is the smallest complete fix: it adds identity to the existing state object and leaves the 20-turn retention splice, response schema, scripted timing, and all external contracts unchanged. There is no host-daemon wire change or user-facing configuration change.

## How you verified

- Before the production change, `pnpm exec turbo run test --filter=@bb/demo-server --force` failed the new regression: unchanged `turn 1` moved from `sent-2` / source sequence 7 to `sent-1` / source sequence 4 after eviction (1 failed, 9 passed).
- On the final commit, `pnpm exec turbo run typecheck test --filter=@bb/demo-server --force` passed all 3 Turbo tasks and all 10 demo-server tests.
- `pnpm exec prettier apps/demo-server/src/demo-world.ts apps/demo-server/src/demo-world.test.ts --check` passed.
- `git diff --check origin/main...HEAD` passed.
- `@bb/demo-server` does not define a separate build task; its Turbo typecheck and Vitest suite both compile/import the Worker TypeScript.

## Related

Follow-up to merged PR #2110. No matching GitHub issue or overlapping open pull request was found, so this PR intentionally has no `Fixes` line.

> AGENT GENERATED: by GPT-5.6-Sol