### PR TITLE
Bound public demo server resource use

### DIFF
--- a/apps/demo-server/src/demo-state.test.ts
+++ b/apps/demo-server/src/demo-state.test.ts
@@ -1,0 +1,97 @@
+import { pongMessageSchema } from "@bb/domain";
+import { describe, expect, it, vi } from "vitest";
+import {
+  DemoStateDO,
+  MAX_SESSION_SOCKETS,
+  MAX_SOCKET_FRAME_BYTES,
+} from "./demo-state.js";
+import { DEMO_THREADS } from "./fixtures/timelines.js";
+
+const ORIGIN = "https://demo.example.test";
+const THREAD_ID = DEMO_THREADS[0].id;
+
+function fakeSocket() {
+  const send = vi.fn();
+  const close = vi.fn();
+  return {
+    socket: { send, close } as unknown as WebSocket,
+    send,
+    close,
+  };
+}
+
+function createState(sockets: WebSocket[]) {
+  const acceptWebSocket = vi.fn();
+  const getWebSockets = vi.fn(() => sockets);
+  return {
+    object: new DemoStateDO({ acceptWebSocket, getWebSockets }),
+    acceptWebSocket,
+    getWebSockets,
+  };
+}
+
+describe("demo Durable Object resource boundaries", () => {
+  it("fans changes out through the hibernation API's live socket list", async () => {
+    const live = fakeSocket();
+    const { object, getWebSockets } = createState([live.socket]);
+    const response = await object.fetch(
+      new Request(`${ORIGIN}/api/v1/threads/${THREAD_ID}/queued-messages`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          input: [{ type: "text", text: "Later.", mentions: [] }],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(getWebSockets).toHaveBeenCalledOnce();
+    expect(live.send).toHaveBeenCalledOnce();
+    expect(JSON.parse(live.send.mock.calls[0][0])).toMatchObject({
+      type: "changed",
+      entity: "thread",
+      id: THREAD_ID,
+      changes: ["queue-changed"],
+    });
+  });
+
+  it("rejects a WebSocket upgrade once the small session cap is reached", async () => {
+    const sockets = Array.from(
+      { length: MAX_SESSION_SOCKETS },
+      () => fakeSocket().socket,
+    );
+    const { object, acceptWebSocket } = createState(sockets);
+    const response = await object.fetch(
+      new Request(`${ORIGIN}/ws`, {
+        headers: { upgrade: "WebSocket" },
+      }),
+    );
+
+    expect(response.status).toBe(429);
+    expect(await response.json()).toMatchObject({
+      code: "too_many_connections",
+    });
+    expect(acceptWebSocket).not.toHaveBeenCalled();
+  });
+
+  it("closes oversized frames before parsing them", () => {
+    const peer = fakeSocket();
+    const { object } = createState([]);
+
+    object.webSocketMessage(
+      peer.socket,
+      "x".repeat(MAX_SOCKET_FRAME_BYTES + 1),
+    );
+    expect(peer.close).toHaveBeenCalledWith(
+      1009,
+      "Demo WebSocket frame is too large",
+    );
+    expect(peer.send).not.toHaveBeenCalled();
+
+    peer.close.mockClear();
+    object.webSocketMessage(peer.socket, JSON.stringify({ type: "ping" }));
+    expect(peer.close).not.toHaveBeenCalled();
+    expect(peer.send).toHaveBeenCalledOnce();
+    pongMessageSchema.parse(JSON.parse(peer.send.mock.calls[0][0]));
+  });
+});

--- a/apps/demo-server/src/demo-state.ts
+++ b/apps/demo-server/src/demo-state.ts
@@ -4,18 +4,34 @@
 
 import { DemoWorld } from "./demo-world.js";
 
+/** Reconnect overlap is normal; more sockets only amplify a public session. */
+export const MAX_SESSION_SOCKETS = 4;
+
+/** Realtime messages are pings and subscriptions, both far smaller than this. */
+export const MAX_SOCKET_FRAME_BYTES = 16 * 1024;
+
+interface DemoStateContext {
+  acceptWebSocket(socket: WebSocket): void;
+  getWebSockets(): WebSocket[];
+}
+
+const TEXT_ENCODER = new TextEncoder();
+
 export class DemoStateDO {
   private readonly world = new DemoWorld();
-  private readonly sockets = new Set<WebSocket>();
 
-  constructor() {
+  constructor(private readonly state: DemoStateContext) {
     this.world.onChanged((message) => {
       const raw = JSON.stringify(message);
-      for (const socket of this.sockets) {
+      for (const socket of this.state.getWebSockets()) {
         try {
           socket.send(raw);
         } catch {
-          this.sockets.delete(socket);
+          try {
+            socket.close(1011, "Failed to send demo update");
+          } catch {
+            // The hibernation API drops dead sockets from getWebSockets().
+          }
         }
       }
     });
@@ -30,20 +46,61 @@ export class DemoStateDO {
   }
 
   private handleWebSocket(request: Request): Response {
-    if (request.headers.get("upgrade") !== "websocket") {
+    if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
       return new Response("Expected a WebSocket upgrade", { status: 426 });
+    }
+    if (this.state.getWebSockets().length >= MAX_SESSION_SOCKETS) {
+      return new Response(
+        JSON.stringify({
+          code: "too_many_connections",
+          message: `A demo session accepts at most ${MAX_SESSION_SOCKETS} WebSocket connections`,
+        }),
+        {
+          status: 429,
+          headers: { "content-type": "application/json" },
+        },
+      );
     }
     const pair = new WebSocketPair();
     const [client, server] = Object.values(pair);
-    server.accept();
-    this.sockets.add(server);
-    server.addEventListener("close", () => this.sockets.delete(server));
-    server.addEventListener("error", () => this.sockets.delete(server));
-    server.addEventListener("message", (event) => {
-      if (typeof event.data !== "string") return;
-      const reply = this.world.socketReply(event.data);
-      if (reply !== null) server.send(reply);
-    });
+    this.state.acceptWebSocket(server);
     return new Response(null, { status: 101, webSocket: client });
+  }
+
+  webSocketMessage(socket: WebSocket, message: string | ArrayBuffer): void {
+    if (typeof message !== "string") {
+      socket.close(
+        message.byteLength > MAX_SOCKET_FRAME_BYTES ? 1009 : 1003,
+        message.byteLength > MAX_SOCKET_FRAME_BYTES
+          ? "Demo WebSocket frame is too large"
+          : "Demo WebSocket accepts text frames only",
+      );
+      return;
+    }
+    if (
+      message.length > MAX_SOCKET_FRAME_BYTES ||
+      TEXT_ENCODER.encode(message).byteLength > MAX_SOCKET_FRAME_BYTES
+    ) {
+      socket.close(1009, "Demo WebSocket frame is too large");
+      return;
+    }
+    const reply = this.world.socketReply(message);
+    if (reply !== null) socket.send(reply);
+  }
+
+  webSocketClose(socket: WebSocket, code: number, reason: string): void {
+    try {
+      socket.close(code, reason);
+    } catch {
+      // The peer may already have completed the close handshake.
+    }
+  }
+
+  webSocketError(socket: WebSocket): void {
+    try {
+      socket.close(1011, "Demo WebSocket error");
+    } catch {
+      // The runtime will discard a socket that is already gone.
+    }
   }
 }

--- a/apps/demo-server/src/demo-world.test.ts
+++ b/apps/demo-server/src/demo-world.test.ts
@@ -32,6 +32,10 @@ import { DEMO_THREADS } from "./fixtures/timelines.js";
 
 const ORIGIN = "https://demo.example.test";
 const THREAD_ID = DEMO_THREADS[0].id;
+const EXPECTED_MAX_REQUEST_BYTES = 64 * 1024;
+const EXPECTED_MAX_INPUT_PARTS = 32;
+const EXPECTED_MAX_QUEUED_MESSAGES = 16;
+const EXPECTED_MAX_QUEUED_BYTES = 64 * 1024;
 
 /** A world on a manual clock, so the scripted reply lands when the test says so. */
 function createWorld() {
@@ -61,7 +65,15 @@ function createWorld() {
         body: JSON.stringify(body),
       }),
     );
-  return { world, get, send, advance, notices, clock: () => now };
+  const sendRaw = (method: string, path: string, body: string) =>
+    world.handle(
+      new Request(`${ORIGIN}${path}`, {
+        method,
+        headers: { "content-type": "application/json" },
+        body,
+      }),
+    );
+  return { world, get, send, sendRaw, advance, notices, clock: () => now };
 }
 
 async function parsed<T>(
@@ -171,6 +183,36 @@ describe("demo world routes", () => {
 });
 
 describe("sending a message", () => {
+  it("rejects request bodies and prompt part arrays beyond the demo limits", async () => {
+    const { send, sendRaw } = createWorld();
+    const oversizedBody = await sendRaw(
+      "POST",
+      `/api/v1/threads/${THREAD_ID}/send`,
+      JSON.stringify(sendBody("x".repeat(EXPECTED_MAX_REQUEST_BYTES))),
+    );
+    expect(oversizedBody.status).toBe(413);
+    expect(await oversizedBody.json()).toMatchObject({
+      code: "invalid_request",
+    });
+
+    const tooManyParts = await send(
+      "POST",
+      `/api/v1/threads/${THREAD_ID}/send`,
+      {
+        input: Array.from({ length: EXPECTED_MAX_INPUT_PARTS + 1 }, () => ({
+          type: "text" as const,
+          text: "x",
+          mentions: [],
+        })),
+        mode: "auto",
+      },
+    );
+    expect(tooManyParts.status).toBe(413);
+    expect(await tooManyParts.json()).toMatchObject({
+      code: "invalid_request",
+    });
+  });
+
   it("shows the user row at once, then the scripted reply after the delay", async () => {
     const { get, send, advance, notices, clock } = createWorld();
     const sentAt = clock();
@@ -293,6 +335,55 @@ describe("sending a message", () => {
       "queue-changed",
       "events-appended",
     ]);
+  });
+
+  it("rejects queued messages before retained entry or byte limits are exceeded", async () => {
+    const { get, send } = createWorld();
+    for (let index = 0; index < EXPECTED_MAX_QUEUED_MESSAGES; index += 1) {
+      expect(
+        (
+          await send("POST", `/api/v1/threads/${THREAD_ID}/queued-messages`, {
+            input: [{ type: "text", text: `Later ${index}.`, mentions: [] }],
+          })
+        ).status,
+      ).toBe(200);
+    }
+    const full = await send(
+      "POST",
+      `/api/v1/threads/${THREAD_ID}/queued-messages`,
+      { input: [{ type: "text", text: "One too many.", mentions: [] }] },
+    );
+    expect(full.status).toBe(409);
+    expect(await full.json()).toMatchObject({ code: "queue_full" });
+    expect(
+      await parsed(
+        get(`/api/v1/threads/${THREAD_ID}/queued-messages`),
+        threadQueuedMessageListResponseSchema,
+      ),
+    ).toHaveLength(EXPECTED_MAX_QUEUED_MESSAGES);
+
+    const otherThreadId = DEMO_THREADS[1].id;
+    const halfLimit = "x".repeat(EXPECTED_MAX_QUEUED_BYTES / 2);
+    expect(
+      (
+        await send("POST", `/api/v1/threads/${otherThreadId}/queued-messages`, {
+          input: [{ type: "text", text: halfLimit, mentions: [] }],
+        })
+      ).status,
+    ).toBe(200);
+    const tooManyBytes = await send(
+      "POST",
+      `/api/v1/threads/${otherThreadId}/queued-messages`,
+      { input: [{ type: "text", text: halfLimit, mentions: [] }] },
+    );
+    expect(tooManyBytes.status).toBe(409);
+    expect(await tooManyBytes.json()).toMatchObject({ code: "queue_full" });
+    expect(
+      await parsed(
+        get(`/api/v1/threads/${otherThreadId}/queued-messages`),
+        threadQueuedMessageListResponseSchema,
+      ),
+    ).toHaveLength(1);
   });
 
   it("caps message length and the number of turns it keeps", async () => {

--- a/apps/demo-server/src/demo-world.ts
+++ b/apps/demo-server/src/demo-world.ts
@@ -81,6 +81,18 @@ export const MAX_MESSAGE_CHARS = 4_000;
 /** Sent turns kept per thread. Older ones fall off so a session cannot grow without bound. */
 export const MAX_TURNS_PER_THREAD = 20;
 
+/** Largest JSON request the public demo will buffer. */
+export const MAX_REQUEST_BYTES = 64 * 1024;
+
+/** Prompt parts accepted by send and queue routes. */
+export const MAX_INPUT_PARTS = 32;
+
+/** Queued messages retained for one demo thread. */
+export const MAX_QUEUED_MESSAGES = 16;
+
+/** Serialized queued-message bytes retained for one demo thread. */
+export const MAX_QUEUED_BYTES = 64 * 1024;
+
 const THREAD_PATH =
   /^\/threads\/(thr_[a-z0-9]+)(?:\/([a-z-]+(?:\/[a-z0-9_-]+)*))?$/u;
 
@@ -94,6 +106,10 @@ interface ThreadState {
   turns: SentTurn[];
 }
 
+type ReadJsonResult =
+  | { ok: true; value: unknown }
+  | { ok: false; response: Response };
+
 export interface DemoWorldOptions {
   now?: () => number;
   /** Runs `fn` after `ms`; swapped for a manual scheduler in tests. */
@@ -101,9 +117,14 @@ export interface DemoWorldOptions {
 }
 
 const JSON_HEADERS = { "content-type": "application/json" };
+const TEXT_ENCODER = new TextEncoder();
 
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
+}
+
+function apiError(status: number, code: string, message: string): Response {
+  return json({ code, message }, status);
 }
 
 /**
@@ -137,12 +158,89 @@ function notFound(threadId: string): Response {
   );
 }
 
-async function readJson(request: Request): Promise<unknown> {
-  try {
-    return await request.json();
-  } catch {
-    return null;
+async function readJson(request: Request): Promise<ReadJsonResult> {
+  const declaredLength = request.headers.get("content-length");
+  if (declaredLength !== null && Number(declaredLength) > MAX_REQUEST_BYTES) {
+    return {
+      ok: false,
+      response: apiError(
+        413,
+        "invalid_request",
+        `Request body exceeds ${MAX_REQUEST_BYTES / 1024} KiB`,
+      ),
+    };
   }
+
+  if (request.body === null) return { ok: true, value: null };
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let receivedBytes = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      receivedBytes += value.byteLength;
+      if (receivedBytes > MAX_REQUEST_BYTES) {
+        try {
+          await reader.cancel();
+        } catch {
+          // The response is still 413 if the sender closed while cancellation raced it.
+        }
+        return {
+          ok: false,
+          response: apiError(
+            413,
+            "invalid_request",
+            `Request body exceeds ${MAX_REQUEST_BYTES / 1024} KiB`,
+          ),
+        };
+      }
+      chunks.push(value);
+    }
+  } catch {
+    return { ok: true, value: null };
+  }
+
+  const bytes = new Uint8Array(receivedBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return {
+      ok: true,
+      value: JSON.parse(new TextDecoder().decode(bytes)),
+    };
+  } catch {
+    return { ok: true, value: null };
+  }
+}
+
+function promptInputLimit(value: unknown): Response | null {
+  return typeof value === "object" &&
+    value !== null &&
+    "input" in value &&
+    Array.isArray(value.input) &&
+    value.input.length > MAX_INPUT_PARTS
+    ? apiError(
+        413,
+        "invalid_request",
+        `Prompt input exceeds ${MAX_INPUT_PARTS} parts`,
+      )
+    : null;
+}
+
+function jsonBytes(value: unknown): number {
+  return TEXT_ENCODER.encode(JSON.stringify(value)).byteLength;
+}
+
+function queueFull(): Response {
+  return apiError(
+    409,
+    "queue_full",
+    "The demo queue is full. Send a queued message before adding another.",
+  );
 }
 
 /** The text of a prompt, as the composer sends it: text parts joined, attachments dropped. */
@@ -290,7 +388,11 @@ export class DemoWorld {
   ): Promise<Response | null> {
     const threadId = state.seed.id;
     if (sub === "send") {
-      const body = sendMessageRequestSchema.safeParse(await readJson(request));
+      const rawBody = await readJson(request);
+      if (!rawBody.ok) return rawBody.response;
+      const inputLimit = promptInputLimit(rawBody.value);
+      if (inputLimit) return inputLimit;
+      const body = sendMessageRequestSchema.safeParse(rawBody.value);
       if (!body.success) return badRequest(body.error);
       this.appendTurn(state, promptText(body.data.input), now);
       return json({ ok: true });
@@ -309,38 +411,42 @@ export class DemoWorld {
       return json({ ok: true });
     }
     if (sub === "queued-messages") {
-      const body = createQueuedMessageRequestSchema.safeParse(
-        await readJson(request),
-      );
+      const rawBody = await readJson(request);
+      if (!rawBody.ok) return rawBody.response;
+      const inputLimit = promptInputLimit(rawBody.value);
+      if (inputLimit) return inputLimit;
+      const body = createQueuedMessageRequestSchema.safeParse(rawBody.value);
       if (!body.success) return badRequest(body.error);
+      const queue = this.queuedFor(threadId);
+      if (queue.length >= MAX_QUEUED_MESSAGES) return queueFull();
       const message = queuedMessage({
-        id: `qm_demo${this.nextQueuedId++}`,
+        id: `qm_demo${this.nextQueuedId}`,
         content: body.data.input,
         now,
       });
-      this.queued.set(threadId, [...this.queuedFor(threadId), message]);
+      if (jsonBytes([...queue, message]) > MAX_QUEUED_BYTES) return queueFull();
+      this.nextQueuedId += 1;
+      queue.push(message);
+      this.queued.set(threadId, queue);
       this.emit(threadId, ["queue-changed"]);
       return json(message);
     }
     const sendQueued = /^queued-messages\/([a-z0-9_]+)\/send$/u.exec(sub);
     if (sendQueued) {
-      const body = sendQueuedMessageRequestSchema.safeParse(
-        await readJson(request),
-      );
+      const rawBody = await readJson(request);
+      if (!rawBody.ok) return rawBody.response;
+      const body = sendQueuedMessageRequestSchema.safeParse(rawBody.value);
       if (!body.success) return badRequest(body.error);
       const queuedMessageId = sendQueued[1];
-      const message = this.queuedFor(threadId).find(
+      const queue = this.queuedFor(threadId);
+      const queuedIndex = queue.findIndex(
         (entry) => entry.id === queuedMessageId,
       );
-      if (!message) {
+      if (queuedIndex === -1) {
         return json({ message: "Queued message not found" }, 404);
       }
-      this.queued.set(
-        threadId,
-        this.queuedFor(threadId).filter(
-          (entry) => entry.id !== queuedMessageId,
-        ),
-      );
+      const [message] = queue.splice(queuedIndex, 1);
+      if (queue.length === 0) this.queued.delete(threadId);
       this.emit(threadId, ["queue-changed"]);
       this.appendTurn(state, promptText(message.content), now);
       return json({
@@ -358,9 +464,9 @@ export class DemoWorld {
    * demo accepts the write and echoes it back without storing it.
    */
   private async handleUpdateTabs(request: Request): Promise<Response> {
-    const body = updateThreadTabsRequestSchema.safeParse(
-      await readJson(request),
-    );
+    const rawBody = await readJson(request);
+    if (!rawBody.ok) return rawBody.response;
+    const body = updateThreadTabsRequestSchema.safeParse(rawBody.value);
     if (!body.success) return badRequest(body.error);
     const response: ThreadTabsResponse = {
       revision: body.data.expectedRevision + 1,


### PR DESCRIPTION
## What was wrong

The public App Store demo Durable Object accepted standard, non-hibernating WebSockets without a per-session socket cap, so any unauthenticated client could keep an object billable and open many connections. Its JSON routes also buffered arbitrary request bodies before validation, accepted unbounded PromptInput arrays, and retained an unbounded per-thread queue while copying that queue on every insert. Together, those paths allowed trivial memory, parsing CPU, and Durable Object duration amplification. This follows the post-merge findings in [the WebSocket review](https://github.com/get-bb/bb/pull/2110#discussion_r3826329741) and [the queue review](https://github.com/get-bb/bb/pull/2110#discussion_r3826327337); Cloudflare recommends the [Hibernation WebSocket API](https://developers.cloudflare.com/durable-objects/best-practices/websockets/) so connected clients do not accrue idle duration.

## What changed

- `DemoStateDO` now accepts sockets with `DurableObjectState.acceptWebSocket()`, enumerates them with `getWebSockets()`, and handles hibernatable message/close/error callbacks. A demo session accepts at most four sockets, and frames over 16 KiB close with WebSocket code 1009 before JSON parsing.
- `DemoWorld` now streams at most 64 KiB into memory for every parsed JSON request and rejects PromptInput arrays over 32 parts before schema traversal.
- Each thread retains at most 16 queued messages and 64 KiB of serialized queue data. Admission is checked before insertion, and accepted entries are appended and removed in place.
- Rejections use machine-readable, top-level API errors: HTTP 413 `invalid_request`, HTTP 409 `queue_full`, or HTTP 429 `too_many_connections`.

These are fixed per-session boundaries at the public-demo boundary, which is the simplest complete fix for the observed amplification paths. This deliberately does not add a general rate-limiting framework. The change is isolated to the Cloudflare demo and does not alter the server/host-daemon wire contract, CLI, SDK, or user configuration, so `HOST_DAEMON_PROTOCOL_VERSION` and documentation are unchanged.

## How you verified

Before the implementation, the new world boundary tests failed with `expected 200 to be 413` for an oversized request and `expected 200 to be 409` for the seventeenth queued message. After the implementation:

- `pnpm exec turbo run test typecheck --filter=@bb/demo-server --force` — 14 tests passed; Turbo test and typecheck completed successfully.
- `pnpm exec turbo run build --filter=@bb/demo-server --force` — Turbo confirmed this package defines no standalone build task (0 tasks); deployment bundling is the applicable build validation.
- `pnpm --dir apps/demo-server exec wrangler deploy --dry-run --outdir <temp>` — bundled successfully (804.34 KiB, 120.30 KiB gzip) with the `DemoStateDO` binding.
- `pnpm exec eslint apps/demo-server/src/demo-state.ts apps/demo-server/src/demo-state.test.ts apps/demo-server/src/demo-world.ts apps/demo-server/src/demo-world.test.ts` — passed.
- `pnpm exec prettier apps/demo-server/src/demo-state.ts apps/demo-server/src/demo-state.test.ts apps/demo-server/src/demo-world.ts apps/demo-server/src/demo-world.test.ts --check` — passed.
- Local Wrangler smoke test — four WebSockets upgraded, the fifth returned HTTP 429, application ping returned `{"type":"pong"}`, and a 16,385-byte frame closed with code 1009 and reason `Demo WebSocket frame is too large`.

## Related review

No issue is filed for this post-merge finding, so this PR intentionally has no `Fixes #N` line. It addresses the two linked review findings from merged PR #2110.

> AGENT GENERATED: by GPT-5.6-Sol
