### PR TITLE
Trigger demo deploys for bundled dependency changes

### DIFF
--- a/.github/workflows/deploy-demo-server.yml
+++ b/.github/workflows/deploy-demo-server.yml
@@ -6,10 +6,11 @@ name: Deploy Demo Server
 # and test, deploy. It serves from workers.dev; see the wrangler config for
 # why it is not on demo.getbb.app.
 #
-# Paths: the worker bundles @bb/server-contract from source, and the
-# contract is what its tests check the fixtures against, so a contract change
-# redeploys the demo too. That is the point: a demo that has drifted from the
-# contract is a demo that crashes in front of a reviewer.
+# Paths: the worker bundles its workspace dependencies from source, and the
+# contract is what its tests check the fixtures against, so a dependency change
+# redeploys the demo too. The frozen lockfile also controls the bundled external
+# dependency graph. A demo that has drifted from either crashes in front of a
+# reviewer.
 
 on:
   push:
@@ -17,8 +18,12 @@ on:
       - main
     paths:
       - "apps/demo-server/**"
+      - "packages/domain/**"
+      - "packages/host-daemon-contract/**"
+      - "packages/provider-bridge-protocol/**"
       - "packages/server-contract/**"
       - ".github/workflows/deploy-demo-server.yml"
+      - "pnpm-lock.yaml"
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## What was wrong

At `origin/main` `65f9e0a4e76f7deeb92562e6ffacc11200c3ff70`, `.github/workflows/deploy-demo-server.yml` installed `pnpm-lock.yaml` with `--frozen-lockfile` and deployed the Wrangler bundle for `@bb/demo-server`, but its `push.paths` filter omitted deploy-affecting inputs. The app directly imports `@bb/domain`, and a Wrangler metafile also confirmed runtime bytes from `@bb/host-daemon-contract` and `@bb/provider-bridge-protocol` through `@bb/server-contract`; none of those three package roots triggered the workflow. A lockfile-only dependency graph change also skipped deployment. The result was that the deployed demo Worker could silently lag behind `main`, as identified in the merged #2110 review at https://github.com/get-bb/bb/pull/2110#discussion_r3826327334.

## What changed

The existing deployment filter now includes `packages/domain/**`, `packages/host-daemon-contract/**`, `packages/provider-bridge-protocol/**`, and `pnpm-lock.yaml`, alongside the already-covered demo app and server contract. The nearby comment now documents both workspace-source bundling and the frozen external dependency graph.

This is the smallest complete fix: one workflow directly names the current positive-byte workspace inputs from Wrangler's bundle plus the lockfile it installs. It does not broaden CI to unrelated paths or introduce an abstraction for one path filter. The repository has no general workflow-path validation convention, so no config-duplicating test was added. PR #2115 touches only the later deploy-summary comment in this workflow; I coordinated the independent overlap at https://github.com/get-bb/bb/pull/2115#issuecomment-5363810724.

## How you verified

Before the change, a focused trigger assertion failed and reported all four missing entries. After the change, it passed, and a Wrangler metafile comparison confirmed coverage for every workspace package contributing runtime bytes (`domain`, `host-daemon-contract`, `provider-bridge-protocol`, and `server-contract`) plus `pnpm-lock.yaml`.

- `pnpm exec turbo run build --filter=@bb/demo-server --force` — passed with zero tasks; the package intentionally has no build script
- `pnpm exec turbo run typecheck --filter=@bb/demo-server --force` — passed, 1 task
- `pnpm exec turbo run test --filter=@bb/demo-server --force` — passed, 9 tests
- `pnpm --filter @bb/demo-server exec wrangler deploy --dry-run --outdir <temporary-directory> --metafile <temporary-directory>/meta.json` — passed, 800.30 KiB / 119.19 KiB gzip
- `pnpm exec prettier --check .github/workflows/deploy-demo-server.yml` and `git diff --check origin/main...HEAD` — passed

## Issue

No matching GitHub issue exists; open PR and issue searches for the workflow, lockfile, domain dependency, and demo deployment found no owner for this root cause.

> AGENT GENERATED: by GPT-5.6-Sol