### PR TITLE
[stacked on #2148 ← #2153 ← #2136 ← #2124] Pin provider baselines: corpus row snapshots, timeline perf, permission matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,9 @@ apps/app/bundle-stats.json
 # Raw provider bridge recordings (record mode output) can hold secrets; only
 # the redacted copies under packages/provider-bridge-protocol/recordings ship.
 provider-recordings/raw/
+
+# Private provider corpus (tests read it through BB_PROVIDER_CORPUS_DIR).
+# Only the in-repo harness and scripts directories of that name are tracked.
+**/provider-corpus/**
+!apps/server/test/provider-corpus/**
+!scripts/provider-corpus/**

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,7 +10,8 @@
     "dev": "node --conditions=source --import tsx scripts/dev-supervisor.mjs",
     "clean": "rimraf dist",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run --config vitest.config.ts"
+    "test": "vitest run --config vitest.config.ts",
+    "test:provider-corpus": "vitest run --config vitest.config.ts test/provider-corpus"
   },
   "dependencies": {
     "@bb/config": "workspace:*",

--- a/apps/server/test/permissions/permission-matrix.test.ts
+++ b/apps/server/test/permissions/permission-matrix.test.ts
@@ -1,0 +1,161 @@
+/**
+ * A5 / G12 — the server's half of the permission-decision matrix.
+ *
+ * The runtime matrix (`packages/agent-runtime/src/permission-matrix.test.ts`)
+ * pins what happens to an approval request once it reaches the runtime. The
+ * only server-side inputs to that decision are the escalation the server
+ * attaches to a turn and the shape of the runtime permission policy it builds.
+ * Both are pinned here as literal tables.
+ */
+import {
+  approvalReviewerValues,
+  permissionEscalationValues,
+  permissionModeValues,
+  runtimePermissionPolicySchema,
+  runtimePermissionScopeValues,
+  threadTurnInitiatorValues,
+} from "@bb/domain";
+import type { Thread, ThreadTurnInitiator } from "@bb/domain";
+import { describe, expect, it } from "vitest";
+import { resolvePermissionEscalation } from "../../src/services/threads/thread-runtime-config.js";
+
+// ---------------------------------------------------------------------------
+// Escalation by initiator × thread shape
+// ---------------------------------------------------------------------------
+
+const THREAD_SHAPES = ["root", "delegated-child", "fork"] as const;
+type ThreadShape = (typeof THREAD_SHAPES)[number];
+
+type EscalationCell = `${ThreadTurnInitiator}|${ThreadShape}`;
+
+/**
+ * Only the initiator matters: a user-started turn asks (even on a delegated
+ * child, so a sandbox-blocked action surfaces on the parent), and every
+ * agent- or system-started turn is denied without a prompt.
+ */
+const EXPECTED_ESCALATION = {
+  "user|root": "ask",
+  "user|delegated-child": "ask",
+  "user|fork": "ask",
+  "agent|root": "deny",
+  "agent|delegated-child": "deny",
+  "agent|fork": "deny",
+  "system|root": "deny",
+  "system|delegated-child": "deny",
+  "system|fork": "deny",
+} satisfies Record<EscalationCell, "ask" | "deny">;
+
+function threadOfShape(shape: ThreadShape): Thread {
+  const base: Thread = {
+    id: `thr_${shape}`,
+    projectId: "prj_matrix",
+    environmentId: null,
+    providerId: "codex",
+    title: null,
+    titleFallback: null,
+    sectionId: null,
+    status: "idle",
+    parentThreadId: null,
+    sourceThreadId: null,
+    originKind: null,
+    originPluginId: null,
+    visibility: "visible",
+    archivedAt: null,
+    pinnedAt: null,
+    deletedAt: null,
+    lastReadAt: null,
+    latestAttentionAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+  switch (shape) {
+    case "root":
+      return base;
+    case "delegated-child":
+      return { ...base, parentThreadId: "thr_parent" };
+    case "fork":
+      return { ...base, sourceThreadId: "thr_parent", originKind: "fork" };
+  }
+}
+
+const ESCALATION_CELLS = threadTurnInitiatorValues.flatMap((initiator) =>
+  THREAD_SHAPES.map((shape) => [initiator, shape] as const),
+);
+
+describe("permission escalation by turn initiator", () => {
+  it("covers every initiator", () => {
+    expect(threadTurnInitiatorValues).toEqual(["user", "agent", "system"]);
+    expect(Object.keys(EXPECTED_ESCALATION)).toHaveLength(
+      threadTurnInitiatorValues.length * THREAD_SHAPES.length,
+    );
+  });
+
+  it.each(ESCALATION_CELLS)("%s × %s", (initiator, shape) => {
+    const key: EscalationCell = `${initiator}|${shape}`;
+    expect(
+      resolvePermissionEscalation({ initiator, thread: threadOfShape(shape) }),
+    ).toBe(EXPECTED_ESCALATION[key]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runtime permission policy shape: which (mode, scope, reviewer, escalation)
+// combinations the server is allowed to hand the runtime.
+// ---------------------------------------------------------------------------
+
+const ESCALATION_INPUTS = [...permissionEscalationValues, null] as const;
+const REVIEWER_INPUTS = [...approvalReviewerValues, null] as const;
+
+type PolicyCell =
+  `${(typeof permissionModeValues)[number]}|${(typeof runtimePermissionScopeValues)[number]}|${NonNullable<(typeof REVIEWER_INPUTS)[number]> | "-"}|${NonNullable<(typeof ESCALATION_INPUTS)[number]> | "-"}`;
+
+/**
+ * Exactly five shapes are valid. accept-edits and auto are workspace-scoped
+ * and carry an escalation; accept-edits is reviewed by the user, auto by the
+ * provider's automatic reviewer; full has no scope limit, no reviewer, and no
+ * escalation.
+ */
+const ACCEPTED_POLICY_SHAPES: readonly PolicyCell[] = [
+  "accept-edits|workspace|user|ask",
+  "accept-edits|workspace|user|deny",
+  "auto|workspace|automatic|ask",
+  "auto|workspace|automatic|deny",
+  "full|full|-|-",
+];
+
+const POLICY_CELLS = permissionModeValues.flatMap((permissionMode) =>
+  runtimePermissionScopeValues.flatMap((permissionScope) =>
+    REVIEWER_INPUTS.flatMap((approvalReviewer) =>
+      ESCALATION_INPUTS.map(
+        (permissionEscalation) =>
+          ({
+            permissionMode,
+            permissionScope,
+            approvalReviewer,
+            permissionEscalation,
+          }) as const,
+      ),
+    ),
+  ),
+);
+
+describe("runtime permission policy shapes", () => {
+  it("enumerates the full cross product", () => {
+    expect(permissionModeValues).toEqual(["accept-edits", "auto", "full"]);
+    expect(runtimePermissionScopeValues).toEqual(["workspace", "full"]);
+    expect(approvalReviewerValues).toEqual(["user", "automatic"]);
+    expect(permissionEscalationValues).toEqual(["ask", "deny"]);
+    expect(POLICY_CELLS).toHaveLength(3 * 2 * 3 * 3);
+    expect(runtimePermissionPolicySchema.options).toHaveLength(3);
+  });
+
+  it.each(POLICY_CELLS)(
+    "$permissionMode × $permissionScope × $approvalReviewer × $permissionEscalation",
+    (cell) => {
+      const key: PolicyCell = `${cell.permissionMode}|${cell.permissionScope}|${cell.approvalReviewer ?? "-"}|${cell.permissionEscalation ?? "-"}`;
+      expect(runtimePermissionPolicySchema.safeParse(cell).success).toBe(
+        ACCEPTED_POLICY_SHAPES.includes(key),
+      );
+    },
+  );
+});

--- a/apps/server/test/permissions/permission-matrix.test.ts
+++ b/apps/server/test/permissions/permission-matrix.test.ts
@@ -8,100 +8,76 @@
  * Both are pinned here as literal tables.
  */
 import {
-  approvalReviewerValues,
   permissionEscalationValues,
   permissionModeValues,
   runtimePermissionPolicySchema,
   runtimePermissionScopeValues,
-  threadTurnInitiatorValues,
+  threadTurnInitiatorSchema,
 } from "@bb/domain";
-import type { Thread, ThreadTurnInitiator } from "@bb/domain";
+import type { RuntimePermissionPolicy, ThreadTurnInitiator } from "@bb/domain";
 import { describe, expect, it } from "vitest";
 import { resolvePermissionEscalation } from "../../src/services/threads/thread-runtime-config.js";
 
 // ---------------------------------------------------------------------------
-// Escalation by initiator × thread shape
+// Escalation by initiator
 // ---------------------------------------------------------------------------
-
-const THREAD_SHAPES = ["root", "delegated-child", "fork"] as const;
-type ThreadShape = (typeof THREAD_SHAPES)[number];
-
-type EscalationCell = `${ThreadTurnInitiator}|${ThreadShape}`;
 
 /**
  * Only the initiator matters: a user-started turn asks (even on a delegated
  * child, so a sandbox-blocked action surfaces on the parent), and every
- * agent- or system-started turn is denied without a prompt.
+ * agent- or system-started turn is denied without a prompt. The function
+ * once took the thread as well and never branched on it; the pin on `main`
+ * measured root, delegated-child, and fork threads identically, and the
+ * thread argument has since been removed.
  */
 const EXPECTED_ESCALATION = {
-  "user|root": "ask",
-  "user|delegated-child": "ask",
-  "user|fork": "ask",
-  "agent|root": "deny",
-  "agent|delegated-child": "deny",
-  "agent|fork": "deny",
-  "system|root": "deny",
-  "system|delegated-child": "deny",
-  "system|fork": "deny",
-} satisfies Record<EscalationCell, "ask" | "deny">;
+  user: "ask",
+  agent: "deny",
+  system: "deny",
+} satisfies Record<ThreadTurnInitiator, "ask" | "deny">;
 
-function threadOfShape(shape: ThreadShape): Thread {
-  const base: Thread = {
-    id: `thr_${shape}`,
-    projectId: "prj_matrix",
-    environmentId: null,
-    providerId: "codex",
-    title: null,
-    titleFallback: null,
-    sectionId: null,
-    status: "idle",
-    parentThreadId: null,
-    sourceThreadId: null,
-    originKind: null,
-    originPluginId: null,
-    visibility: "visible",
-    archivedAt: null,
-    pinnedAt: null,
-    deletedAt: null,
-    lastReadAt: null,
-    latestAttentionAt: 1,
-    createdAt: 1,
-    updatedAt: 1,
-  };
-  switch (shape) {
-    case "root":
-      return base;
-    case "delegated-child":
-      return { ...base, parentThreadId: "thr_parent" };
-    case "fork":
-      return { ...base, sourceThreadId: "thr_parent", originKind: "fork" };
-  }
-}
-
-const ESCALATION_CELLS = threadTurnInitiatorValues.flatMap((initiator) =>
-  THREAD_SHAPES.map((shape) => [initiator, shape] as const),
-);
+const threadTurnInitiatorValues = threadTurnInitiatorSchema.options;
 
 describe("permission escalation by turn initiator", () => {
   it("covers every initiator", () => {
     expect(threadTurnInitiatorValues).toEqual(["user", "agent", "system"]);
     expect(Object.keys(EXPECTED_ESCALATION)).toHaveLength(
-      threadTurnInitiatorValues.length * THREAD_SHAPES.length,
+      threadTurnInitiatorValues.length,
     );
   });
 
-  it.each(ESCALATION_CELLS)("%s × %s", (initiator, shape) => {
-    const key: EscalationCell = `${initiator}|${shape}`;
-    expect(
-      resolvePermissionEscalation({ initiator, thread: threadOfShape(shape) }),
-    ).toBe(EXPECTED_ESCALATION[key]);
-  });
+  it.each(threadTurnInitiatorValues.map((initiator) => [initiator] as const))(
+    "%s",
+    (initiator) => {
+      expect(resolvePermissionEscalation({ initiator })).toBe(
+        EXPECTED_ESCALATION[initiator],
+      );
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------
 // Runtime permission policy shape: which (mode, scope, reviewer, escalation)
 // combinations the server is allowed to hand the runtime.
 // ---------------------------------------------------------------------------
+
+/**
+ * The reviewer vocabulary lives only inside the policy union (the domain no
+ * longer exports a value list), so it is spelled out here and pinned to the
+ * union at the type level: a new reviewer literal fails this assignment.
+ */
+const approvalReviewerValues = ["user", "automatic"] as const;
+type ReviewerFromPolicy = NonNullable<
+  RuntimePermissionPolicy["approvalReviewer"]
+>;
+const reviewerValuesCoverUnion: [
+  (typeof approvalReviewerValues)[number],
+] extends [ReviewerFromPolicy]
+  ? [ReviewerFromPolicy] extends [(typeof approvalReviewerValues)[number]]
+    ? true
+    : false
+  : false = true;
+void reviewerValuesCoverUnion;
 
 const ESCALATION_INPUTS = [...permissionEscalationValues, null] as const;
 const REVIEWER_INPUTS = [...approvalReviewerValues, null] as const;

--- a/apps/server/test/provider-corpus/corpus-harness.ts
+++ b/apps/server/test/provider-corpus/corpus-harness.ts
@@ -23,7 +23,7 @@ import {
 } from "@bb/db";
 import type { DbConnection } from "@bb/db";
 import { defaultFeatureFlags } from "@bb/domain";
-import type { ProviderComposerCommand, Thread } from "@bb/domain";
+import type { Thread } from "@bb/domain";
 import type { ThreadTimelineResponse } from "@bb/server-contract";
 import type { CorpusThread } from "@bb/test-helpers";
 import { sql } from "drizzle-orm";
@@ -34,6 +34,8 @@ import {
   type ThreadTimelineBuildProfile,
   type ThreadTimelinePageRequest,
 } from "../../src/services/threads/timeline.js";
+import { resolveProviderPlanCommand } from "../../src/services/providers/provider-plan-command.js";
+import type { ProviderRegistryService } from "../../src/services/providers/provider-registry.js";
 import { previewTimelineResponseOutputs } from "../../src/services/threads/timeline-output-preview.js";
 import {
   DEFAULT_MAX_INLINE_OUTPUT_CHARS,
@@ -145,18 +147,6 @@ export function loadCorpusThreadIntoDb(
 // Route-equivalent projection
 // ---------------------------------------------------------------------------
 
-const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
-  codex: "Codex",
-  "claude-code": "Claude Code",
-};
-
-/** Both first-party providers declare the `plan` composer action. */
-const PLAN_COMMAND: ProviderComposerCommand = {
-  trigger: "/",
-  name: "plan",
-  trailingText: " ",
-};
-
 export type TimelineVariant = "default" | "nested";
 
 export const TIMELINE_VARIANTS: readonly TimelineVariant[] = [
@@ -172,6 +162,12 @@ export interface BuiltTimelinePage {
 export interface BuildRouteTimelinePageArgs {
   db: DbConnection;
   page: ThreadTimelinePageRequest;
+  /**
+   * The first-party providers as their plugins register them
+   * (`createTestProviderRegistry`), so the display name and plan command come
+   * from the same declarations and resolvers the route uses.
+   */
+  registry: ProviderRegistryService;
   thread: Thread;
   variant: TimelineVariant;
 }
@@ -197,10 +193,12 @@ export function buildRouteTimelinePage(
       maxInlineOutputChars: DEFAULT_MAX_INLINE_OUTPUT_CHARS,
       maxSeq,
       page: args.page,
-      providerDisplayName:
-        PROVIDER_DISPLAY_NAMES[args.thread.providerId] ??
+      providerDisplayName: args.registry.get(args.thread.providerId)?.info
+        .displayName,
+      planCommand: resolveProviderPlanCommand(
+        args.registry,
         args.thread.providerId,
-      planCommand: PLAN_COMMAND,
+      ),
       summaryOnly: false,
     },
   );

--- a/apps/server/test/provider-corpus/corpus-harness.ts
+++ b/apps/server/test/provider-corpus/corpus-harness.ts
@@ -1,0 +1,552 @@
+/**
+ * Shared harness for the provider-corpus gates: load one corpus thread into an
+ * in-memory database, project it the way `GET /threads/:id/timeline` does, and
+ * normalize the result for snapshot comparison.
+ *
+ * Nothing here is production code. The route options are copied from
+ * `apps/server/src/routes/threads/data.ts` so that a row produced here is the
+ * row a client would receive.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  createConnection,
+  createProject,
+  getLatestThreadSequence,
+  getThread,
+  migrate,
+  noopNotifier,
+  threads,
+  upsertHost,
+} from "@bb/db";
+import type { DbConnection } from "@bb/db";
+import { defaultFeatureFlags } from "@bb/domain";
+import type { ProviderComposerCommand, Thread } from "@bb/domain";
+import type { ThreadTimelineResponse } from "@bb/server-contract";
+import type { CorpusThread } from "@bb/test-helpers";
+import { sql } from "drizzle-orm";
+import { z } from "zod";
+import {
+  THREAD_TIMELINE_DEFAULT_SEGMENT_LIMIT,
+  buildThreadTimelineWithProfile,
+  type ThreadTimelineBuildProfile,
+  type ThreadTimelinePageRequest,
+} from "../../src/services/threads/timeline.js";
+import { previewTimelineResponseOutputs } from "../../src/services/threads/timeline-output-preview.js";
+import {
+  DEFAULT_MAX_INLINE_OUTPUT_CHARS,
+  truncateTimelineResponseOutputs,
+} from "../../src/services/threads/timeline-output-truncation.js";
+
+export const SNAPSHOT_MODE_ENV = "BB_PROVIDER_CORPUS_SNAPSHOT";
+
+export type SnapshotMode = "write" | "compare";
+
+export function resolveSnapshotMode(
+  env: NodeJS.ProcessEnv = process.env,
+): SnapshotMode {
+  const value = env[SNAPSHOT_MODE_ENV];
+  if (value === undefined || value === "" || value === "compare") {
+    return "compare";
+  }
+  if (value === "write") {
+    return "write";
+  }
+  throw new Error(
+    `${SNAPSHOT_MODE_ENV} must be "write" or "compare" (got ${JSON.stringify(value)})`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Database loading
+// ---------------------------------------------------------------------------
+
+export interface LoadedCorpusThread {
+  db: DbConnection;
+  thread: Thread;
+  close(): void;
+}
+
+/**
+ * Inserts the corpus thread and its events with their original ids, sequences,
+ * and timestamps. The thread hangs off a synthetic host/project because the
+ * extractor kept only the `threads` row; it has no environment, so the
+ * projection sees `workspaceRoot: null` and leaves file paths absolute.
+ */
+export function loadCorpusThreadIntoDb(
+  corpusThread: CorpusThread,
+): LoadedCorpusThread {
+  const db = createConnection(":memory:");
+  migrate(db);
+  const host = upsertHost(db, noopNotifier, {
+    name: "provider-corpus-host",
+    type: "persistent",
+  });
+  const { project } = createProject(db, noopNotifier, {
+    name: "provider-corpus",
+    source: { type: "local_path", hostId: host.id, path: "/provider-corpus" },
+  });
+  const row = corpusThread.thread;
+  db.transaction(
+    (tx) => {
+      tx.insert(threads)
+        .values({
+          id: row.id,
+          projectId: project.id,
+          environmentId: null,
+          providerId: row.providerId,
+          modelOverride: row.modelOverride,
+          reasoningLevelOverride: row.reasoningLevelOverride,
+          title: row.title,
+          titleFallback: null,
+          sectionId: null,
+          status: row.status,
+          // The parent is not part of the corpus, and the FK would reject it.
+          parentThreadId: null,
+          sourceThreadId: null,
+          originKind: row.originKind,
+          originPluginId: null,
+          visibility: row.visibility,
+          archivedAt: row.archivedAt,
+          pinnedAt: null,
+          pinSortKey: null,
+          deletedAt: row.deletedAt,
+          lastReadAt: null,
+          latestAttentionAt: row.updatedAt,
+          createdAt: row.createdAt,
+          updatedAt: row.updatedAt,
+        })
+        .run();
+      for (const event of corpusThread.eventRows) {
+        tx.run(
+          sql`INSERT INTO events (id, thread_id, environment_id, scope_kind, turn_id, provider_thread_id, sequence, type, item_id, item_kind, parent_tool_call_id, data, created_at)
+              VALUES (${event.id}, ${event.threadId}, ${null}, ${event.scopeKind}, ${event.turnId}, ${event.providerThreadId}, ${event.sequence}, ${event.type}, ${event.itemId}, ${event.itemKind}, ${event.parentToolCallId}, ${event.data}, ${event.createdAt})`,
+        );
+      }
+    },
+    { behavior: "immediate" },
+  );
+  const thread = getThread(db, row.id);
+  if (!thread) {
+    throw new Error(`Corpus thread ${row.id} did not load`);
+  }
+  return {
+    db,
+    thread,
+    close: () => {
+      db.$client.close();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Route-equivalent projection
+// ---------------------------------------------------------------------------
+
+const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+  codex: "Codex",
+  "claude-code": "Claude Code",
+};
+
+/** Both first-party providers declare the `plan` composer action. */
+const PLAN_COMMAND: ProviderComposerCommand = {
+  trigger: "/",
+  name: "plan",
+  trailingText: " ",
+};
+
+export type TimelineVariant = "default" | "nested";
+
+export const TIMELINE_VARIANTS: readonly TimelineVariant[] = [
+  "default",
+  "nested",
+];
+
+export interface BuiltTimelinePage {
+  profile: ThreadTimelineBuildProfile;
+  response: ThreadTimelineResponse;
+}
+
+export interface BuildRouteTimelinePageArgs {
+  db: DbConnection;
+  page: ThreadTimelinePageRequest;
+  thread: Thread;
+  variant: TimelineVariant;
+}
+
+/** One page, built and post-processed exactly as the timeline route does. */
+export function buildRouteTimelinePage(
+  args: BuildRouteTimelinePageArgs,
+): BuiltTimelinePage {
+  const includeNestedRows = args.variant === "nested";
+  const maxSeq = getLatestThreadSequence(args.db, {
+    threadId: args.thread.id,
+  });
+  const { profile, response } = buildThreadTimelineWithProfile(
+    args.db,
+    args.thread,
+    {
+      eventBudget: defaultFeatureFlags.timelineWindowEventBudget,
+      // The dev server and the "show unhandled provider events" setting both
+      // turn this on. The snapshot keeps those rows so a later layer that
+      // converts an unhandled event into a typed row shows up as a diff.
+      includeProviderUnhandledOperations: true,
+      includeNestedRows,
+      maxInlineOutputChars: DEFAULT_MAX_INLINE_OUTPUT_CHARS,
+      maxSeq,
+      page: args.page,
+      providerDisplayName:
+        PROVIDER_DISPLAY_NAMES[args.thread.providerId] ??
+        args.thread.providerId,
+      planCommand: PLAN_COMMAND,
+      summaryOnly: false,
+    },
+  );
+  const truncated = truncateTimelineResponseOutputs(
+    response,
+    DEFAULT_MAX_INLINE_OUTPUT_CHARS,
+  );
+  return {
+    profile,
+    response: includeNestedRows
+      ? truncated
+      : previewTimelineResponseOutputs(truncated),
+  };
+}
+
+export function latestTimelinePage(): ThreadTimelinePageRequest {
+  return { kind: "latest", segmentLimit: THREAD_TIMELINE_DEFAULT_SEGMENT_LIMIT };
+}
+
+/**
+ * Walks every page from the latest window back to the oldest, following the
+ * route's own `olderCursor`, and returns them newest first.
+ */
+export function buildAllRouteTimelinePages(
+  args: Omit<BuildRouteTimelinePageArgs, "page">,
+): BuiltTimelinePage[] {
+  const pages: BuiltTimelinePage[] = [];
+  const seenCursors = new Set<string>();
+  let page = latestTimelinePage();
+  for (;;) {
+    const built = buildRouteTimelinePage({ ...args, page });
+    pages.push(built);
+    const { hasOlderRows, olderCursor } = built.response.timelinePage;
+    if (!hasOlderRows || olderCursor === null) {
+      return pages;
+    }
+    const cursorKey = `${olderCursor.anchorId}\0${olderCursor.anchorSeq}`;
+    if (seenCursors.has(cursorKey)) {
+      throw new Error(
+        `Timeline pagination for ${args.thread.id} repeated cursor ${cursorKey}`,
+      );
+    }
+    seenCursors.add(cursorKey);
+    page = {
+      kind: "older",
+      segmentLimit: THREAD_TIMELINE_DEFAULT_SEGMENT_LIMIT,
+      beforeCursor: olderCursor,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Normalization
+// ---------------------------------------------------------------------------
+
+export type JsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+/**
+ * Rebuilds a JSON-serializable value with object keys sorted, so two builds
+ * serialize byte-for-byte when they are structurally equal. `undefined`
+ * properties drop the way `JSON.stringify` drops them.
+ */
+export function normalizeJson(value: unknown): JsonValue {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeJson(entry));
+  }
+  if (typeof value === "object") {
+    const record = z.record(z.string(), z.unknown()).parse(value);
+    const sorted: { [key: string]: JsonValue } = {};
+    for (const key of Object.keys(record).sort()) {
+      const entry = record[key];
+      if (entry !== undefined) {
+        sorted[key] = normalizeJson(entry);
+      }
+    }
+    return sorted;
+  }
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  throw new Error(`Cannot normalize a ${typeof value} for a snapshot`);
+}
+
+// ---------------------------------------------------------------------------
+// Structural diff
+// ---------------------------------------------------------------------------
+
+export interface JsonDiff {
+  /** JSON pointer (RFC 6901) to the differing value. */
+  pointer: string;
+  expected: JsonValue | undefined;
+  actual: JsonValue | undefined;
+}
+
+function escapePointerSegment(segment: string): string {
+  return segment.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
+function isJsonObject(
+  value: JsonValue | undefined,
+): value is { [key: string]: JsonValue } {
+  return (
+    value !== undefined &&
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value)
+  );
+}
+
+/**
+ * Leaf-level differences between two normalized values. Arrays compare by
+ * index; a length change reports the extra entries individually so an
+ * allowlist entry can still name them by path.
+ */
+export function diffJson(
+  expected: JsonValue | undefined,
+  actual: JsonValue | undefined,
+  pointer = "",
+  out: JsonDiff[] = [],
+): JsonDiff[] {
+  if (Array.isArray(expected) && Array.isArray(actual)) {
+    const length = Math.max(expected.length, actual.length);
+    for (let index = 0; index < length; index += 1) {
+      diffJson(expected[index], actual[index], `${pointer}/${index}`, out);
+    }
+    return out;
+  }
+  if (isJsonObject(expected) && isJsonObject(actual)) {
+    const keys = new Set([...Object.keys(expected), ...Object.keys(actual)]);
+    for (const key of [...keys].sort()) {
+      diffJson(
+        expected[key],
+        actual[key],
+        `${pointer}/${escapePointerSegment(key)}`,
+        out,
+      );
+    }
+    return out;
+  }
+  if (JSON.stringify(expected) !== JSON.stringify(actual)) {
+    out.push({ pointer, expected, actual });
+  }
+  return out;
+}
+
+/**
+ * Unified diff of two pretty-printed JSON documents via the system `diff`,
+ * capped to `maxLines`. Only the first few differing threads are printed, so
+ * shelling out is cheaper than carrying a diff library for a local-only tool.
+ */
+export function unifiedJsonDiff(
+  expected: JsonValue,
+  actual: JsonValue,
+  label: string,
+  maxLines = 200,
+): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "bb-corpus-diff-"));
+  try {
+    const expectedPath = path.join(dir, "expected.json");
+    const actualPath = path.join(dir, "actual.json");
+    fs.writeFileSync(expectedPath, `${JSON.stringify(expected, null, 2)}\n`);
+    fs.writeFileSync(actualPath, `${JSON.stringify(actual, null, 2)}\n`);
+    const result = spawnSync(
+      "diff",
+      [
+        "-u",
+        "--label",
+        `${label} (snapshot)`,
+        "--label",
+        `${label} (current)`,
+        expectedPath,
+        actualPath,
+      ],
+      { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+    );
+    if (result.error) {
+      return `(diff unavailable: ${result.error.message})`;
+    }
+    const lines = result.stdout.split("\n");
+    if (lines.length <= maxLines) {
+      return result.stdout;
+    }
+    return `${lines.slice(0, maxLines).join("\n")}\n… ${lines.length - maxLines} more diff lines`;
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Allowlist
+// ---------------------------------------------------------------------------
+
+const allowlistScopeSchema = z.union([
+  z.object({ threadId: z.string().min(1) }),
+  z.object({ provider: z.string().min(1) }),
+  z.object({ "*": z.literal(true) }),
+]);
+
+const allowlistEntrySchema = z
+  .object({
+    /** JSON pointer, or a glob over pointer segments (`*` one, `**` many). */
+    path: z.string().min(1),
+    pr: z.string().regex(/^#\d+$/),
+    reason: z.string().min(1),
+  })
+  .and(allowlistScopeSchema);
+
+export type AllowlistEntry = z.infer<typeof allowlistEntrySchema>;
+
+export const allowlistSchema = z.array(allowlistEntrySchema);
+
+export function describeAllowlistEntry(entry: AllowlistEntry): string {
+  const scope =
+    "threadId" in entry
+      ? `thread ${entry.threadId}`
+      : "provider" in entry
+        ? `provider ${entry.provider}`
+        : "all threads";
+  return `${scope} ${entry.path} (${entry.pr}: ${entry.reason})`;
+}
+
+function allowlistScopeMatches(
+  entry: AllowlistEntry,
+  target: { provider: string; threadId: string },
+): boolean {
+  if ("threadId" in entry) {
+    return entry.threadId === target.threadId;
+  }
+  if ("provider" in entry) {
+    return entry.provider === target.provider;
+  }
+  return true;
+}
+
+function globSegmentsMatch(
+  pattern: readonly string[],
+  segments: readonly string[],
+): boolean {
+  if (pattern.length === 0) {
+    return segments.length === 0;
+  }
+  const [head, ...rest] = pattern;
+  if (head === "**") {
+    for (let skip = 0; skip <= segments.length; skip += 1) {
+      if (globSegmentsMatch(rest, segments.slice(skip))) {
+        return true;
+      }
+    }
+    return false;
+  }
+  if (segments.length === 0) {
+    return false;
+  }
+  if (head !== "*" && head !== segments[0]) {
+    return false;
+  }
+  return globSegmentsMatch(rest, segments.slice(1));
+}
+
+export function allowlistPathMatches(pattern: string, pointer: string): boolean {
+  const patternSegments = pattern.split("/").slice(1);
+  const pointerSegments = pointer.split("/").slice(1);
+  return globSegmentsMatch(patternSegments, pointerSegments);
+}
+
+export interface AllowlistMatchResult {
+  allowed: JsonDiff[];
+  unallowed: JsonDiff[];
+  usedEntryIndexes: Set<number>;
+}
+
+export function applyAllowlist(
+  entries: readonly AllowlistEntry[],
+  target: { provider: string; threadId: string },
+  diffs: readonly JsonDiff[],
+): AllowlistMatchResult {
+  const allowed: JsonDiff[] = [];
+  const unallowed: JsonDiff[] = [];
+  const usedEntryIndexes = new Set<number>();
+  for (const diff of diffs) {
+    let covered = false;
+    entries.forEach((entry, index) => {
+      if (
+        allowlistScopeMatches(entry, target) &&
+        allowlistPathMatches(entry.path, diff.pointer)
+      ) {
+        covered = true;
+        usedEntryIndexes.add(index);
+      }
+    });
+    (covered ? allowed : unallowed).push(diff);
+  }
+  return { allowed, unallowed, usedEntryIndexes };
+}
+
+export function readAllowlist(snapshotsDir: string): AllowlistEntry[] {
+  const allowlistPath = path.join(snapshotsDir, "allowlist.json");
+  if (!fs.existsSync(allowlistPath)) {
+    return [];
+  }
+  return allowlistSchema.parse(
+    JSON.parse(fs.readFileSync(allowlistPath, "utf8")),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Statistics
+// ---------------------------------------------------------------------------
+
+export function percentile(values: readonly number[], fraction: number): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(fraction * sorted.length) - 1),
+  );
+  const value = sorted[index];
+  if (value === undefined) {
+    throw new Error("percentile index out of range");
+  }
+  return value;
+}
+
+export function formatMarkdownTable(
+  header: readonly string[],
+  rows: readonly (readonly (string | number)[])[],
+): string {
+  const lines = [
+    `| ${header.join(" | ")} |`,
+    `| ${header.map(() => "---").join(" | ")} |`,
+    ...rows.map((row) => `| ${row.map(String).join(" | ")} |`),
+  ];
+  return lines.join("\n");
+}

--- a/apps/server/test/provider-corpus/corpus-harness.ts
+++ b/apps/server/test/provider-corpus/corpus-harness.ts
@@ -32,8 +32,8 @@ import {
   THREAD_TIMELINE_DEFAULT_SEGMENT_LIMIT,
   buildThreadTimelineWithProfile,
   type ThreadTimelineBuildProfile,
-  type ThreadTimelinePageRequest,
 } from "../../src/services/threads/timeline.js";
+import type { ThreadTimelinePageRequest } from "../../src/services/threads/timeline-pagination.js";
 import { resolveProviderPlanCommand } from "../../src/services/providers/provider-plan-command.js";
 import type { ProviderRegistryService } from "../../src/services/providers/provider-registry.js";
 import { previewTimelineResponseOutputs } from "../../src/services/threads/timeline-output-preview.js";

--- a/apps/server/test/provider-corpus/corpus-harness.ts
+++ b/apps/server/test/provider-corpus/corpus-harness.ts
@@ -217,7 +217,10 @@ export function buildRouteTimelinePage(
 }
 
 export function latestTimelinePage(): ThreadTimelinePageRequest {
-  return { kind: "latest", segmentLimit: THREAD_TIMELINE_DEFAULT_SEGMENT_LIMIT };
+  return {
+    kind: "latest",
+    segmentLimit: THREAD_TIMELINE_DEFAULT_SEGMENT_LIMIT,
+  };
 }
 
 /**
@@ -473,7 +476,10 @@ function globSegmentsMatch(
   return globSegmentsMatch(rest, segments.slice(1));
 }
 
-export function allowlistPathMatches(pattern: string, pointer: string): boolean {
+export function allowlistPathMatches(
+  pattern: string,
+  pointer: string,
+): boolean {
   const patternSegments = pattern.split("/").slice(1);
   const pointerSegments = pointer.split("/").slice(1);
   return globSegmentsMatch(patternSegments, pointerSegments);
@@ -523,7 +529,10 @@ export function readAllowlist(snapshotsDir: string): AllowlistEntry[] {
 // Statistics
 // ---------------------------------------------------------------------------
 
-export function percentile(values: readonly number[], fraction: number): number {
+export function percentile(
+  values: readonly number[],
+  fraction: number,
+): number {
   if (values.length === 0) {
     return 0;
   }

--- a/apps/server/test/provider-corpus/row-snapshots.test.ts
+++ b/apps/server/test/provider-corpus/row-snapshots.test.ts
@@ -1,0 +1,259 @@
+/**
+ * A4 — production-thread row snapshots.
+ *
+ * Projects every corpus thread through the timeline route path and compares
+ * the rows with the snapshot written at the last accepted baseline. Runs only
+ * when `BB_PROVIDER_CORPUS_DIR` points at the private corpus; see
+ * docs/debugging-and-qa.md ("Provider corpus") for write and compare runs.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import {
+  corpusAvailable,
+  listCorpusThreads,
+  loadCorpusThread,
+  resolveProviderCorpusDir,
+} from "@bb/test-helpers";
+import type { CorpusThread } from "@bb/test-helpers";
+import type { TimelineRow } from "@bb/server-contract";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  TIMELINE_VARIANTS,
+  applyAllowlist,
+  buildAllRouteTimelinePages,
+  describeAllowlistEntry,
+  diffJson,
+  loadCorpusThreadIntoDb,
+  normalizeJson,
+  readAllowlist,
+  resolveSnapshotMode,
+  unifiedJsonDiff,
+  type JsonDiff,
+  type JsonValue,
+  type LoadedCorpusThread,
+} from "./corpus-harness.js";
+
+const PER_THREAD_TIMEOUT_MS = 5 * 60_000;
+const PRINTED_DIFF_THREAD_LIMIT = 3;
+
+interface RowSnapshot {
+  eventRows: number;
+  provider: string;
+  threadId: string;
+  variants: Record<string, { pages: unknown[] }>;
+}
+
+/**
+ * Top-level rows plus the children a completed turn carries in the nested
+ * variant (the default variant summarizes a turn and leaves `children` null).
+ */
+function countTimelineRows(rows: readonly TimelineRow[]): number {
+  let count = 0;
+  for (const row of rows) {
+    count += 1;
+    if (row.kind === "turn" && row.children !== null) {
+      count += countTimelineRows(row.children);
+    }
+  }
+  return count;
+}
+
+function buildRowSnapshot(
+  loaded: LoadedCorpusThread,
+  corpusThread: CorpusThread,
+): { rows: number; snapshot: JsonValue } {
+  let rows = 0;
+  const variants: RowSnapshot["variants"] = {};
+  for (const variant of TIMELINE_VARIANTS) {
+    const pages = buildAllRouteTimelinePages({
+      db: loaded.db,
+      thread: loaded.thread,
+      variant,
+    });
+    for (const page of pages) {
+      rows += countTimelineRows(page.response.rows);
+    }
+    variants[variant] = { pages: pages.map((page) => page.response) };
+  }
+  const snapshot: RowSnapshot = {
+    threadId: corpusThread.id,
+    provider: corpusThread.provider,
+    eventRows: corpusThread.eventRows.length,
+    variants,
+  };
+  return { rows, snapshot: normalizeJson(snapshot) };
+}
+
+function snapshotFilePath(
+  snapshotsDir: string,
+  provider: string,
+  threadId: string,
+): string {
+  return path.join(snapshotsDir, "rows", provider, `${threadId}.json`);
+}
+
+function formatDiffs(diffs: readonly JsonDiff[], limit: number): string {
+  const shown = diffs.slice(0, limit).map((diff) => {
+    const expected = JSON.stringify(diff.expected)?.slice(0, 200);
+    const actual = JSON.stringify(diff.actual)?.slice(0, 200);
+    return `  ${diff.pointer}\n    snapshot: ${expected}\n    current:  ${actual}`;
+  });
+  const more = diffs.length > limit ? `\n  … ${diffs.length - limit} more` : "";
+  return `${shown.join("\n")}${more}`;
+}
+
+const available = corpusAvailable();
+const mode = resolveSnapshotMode();
+const corpusThreads = available ? listCorpusThreads() : [];
+
+describe.skipIf(!available)("provider corpus row snapshots", () => {
+  // The describe body still runs at collection time when the suite is skipped,
+  // so everything here must tolerate a missing corpus.
+  const corpusDir = resolveProviderCorpusDir() ?? "";
+  const snapshotsDir = path.join(corpusDir, "snapshots");
+  const allowlist = available ? readAllowlist(snapshotsDir) : [];
+  const usedAllowlistEntries = new Set<number>();
+  const totals = {
+    bytes: 0,
+    diffThreads: [] as string[],
+    allowedDiffs: 0,
+    printedDiffThreads: 0,
+    rows: 0,
+    startedAt: performance.now(),
+    threads: 0,
+  };
+
+  it.each(
+    corpusThreads.map((thread) => [thread.id, thread.provider] as const),
+  )(
+    "%s (%s)",
+    (threadId, provider) => {
+      const corpusThread = loadCorpusThread(threadId);
+      const loaded = loadCorpusThreadIntoDb(corpusThread);
+      try {
+        const built = buildRowSnapshot(loaded, corpusThread);
+        const serialized = `${JSON.stringify(built.snapshot)}\n`;
+        totals.threads += 1;
+        totals.rows += built.rows;
+        totals.bytes += Buffer.byteLength(serialized);
+        const filePath = snapshotFilePath(snapshotsDir, provider, threadId);
+
+        if (mode === "write") {
+          // A baseline must not depend on the wall clock or on iteration
+          // order: a second projection of the same rows has to match
+          // byte-for-byte before it is worth writing down.
+          const rebuilt = buildRowSnapshot(loaded, corpusThread);
+          expect(JSON.stringify(rebuilt.snapshot)).toBe(
+            JSON.stringify(built.snapshot),
+          );
+          fs.mkdirSync(path.dirname(filePath), { recursive: true });
+          fs.writeFileSync(filePath, serialized);
+          return;
+        }
+
+        if (!fs.existsSync(filePath)) {
+          throw new Error(
+            `No row snapshot for ${threadId} at ${filePath}; run the suite once with BB_PROVIDER_CORPUS_SNAPSHOT=write`,
+          );
+        }
+        const expected = normalizeJson(
+          JSON.parse(fs.readFileSync(filePath, "utf8")),
+        );
+        const diffs = diffJson(expected, built.snapshot);
+        const matched = applyAllowlist(
+          allowlist,
+          { provider, threadId },
+          diffs,
+        );
+        for (const index of matched.usedEntryIndexes) {
+          usedAllowlistEntries.add(index);
+        }
+        totals.allowedDiffs += matched.allowed.length;
+        if (matched.unallowed.length > 0) {
+          totals.diffThreads.push(threadId);
+          if (totals.printedDiffThreads < PRINTED_DIFF_THREAD_LIMIT) {
+            totals.printedDiffThreads += 1;
+            console.log(
+              [
+                `Row snapshot diff for ${threadId} (${provider}): ${matched.unallowed.length} unallowed path(s)`,
+                formatDiffs(matched.unallowed, 20),
+                unifiedJsonDiff(expected, built.snapshot, `${provider}/${threadId}`),
+              ].join("\n"),
+            );
+          }
+          throw new Error(
+            `${threadId} (${provider}) has ${matched.unallowed.length} row diff(s) not covered by snapshots/allowlist.json; first: ${matched.unallowed[0]?.pointer}`,
+          );
+        }
+      } finally {
+        loaded.close();
+      }
+    },
+    PER_THREAD_TIMEOUT_MS,
+  );
+
+  afterAll(() => {
+    if (!available) {
+      return;
+    }
+    const wallMs = Math.round(performance.now() - totals.startedAt);
+    const megabytes = (totals.bytes / (1024 * 1024)).toFixed(1);
+    // The vitest config silences console output of passing tests; stdout
+    // still reaches the terminal, and the JSON file survives the run.
+    process.stdout.write(
+      `Row snapshots (${mode}): ${totals.threads} threads, ${totals.rows} rows, ${megabytes} MB, ${wallMs} ms\n`,
+    );
+    fs.mkdirSync(snapshotsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(snapshotsDir, "rows-last-run.json"),
+      `${JSON.stringify(
+        {
+          mode,
+          threads: totals.threads,
+          rows: totals.rows,
+          bytes: totals.bytes,
+          wallMs,
+          diffThreads: totals.diffThreads,
+          allowedDiffs: totals.allowedDiffs,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    if (mode === "write") {
+      return;
+    }
+    if (totals.diffThreads.length > 0) {
+      console.log(
+        `Row snapshot diffs in ${totals.diffThreads.length} thread(s): ${totals.diffThreads.join(", ")}`,
+      );
+    }
+    const usedEntries = allowlist.filter((_, index) =>
+      usedAllowlistEntries.has(index),
+    );
+    const unusedEntries = allowlist.filter(
+      (_, index) => !usedAllowlistEntries.has(index),
+    );
+    if (usedEntries.length > 0) {
+      console.log(
+        `Allowlist entries used (${totals.allowedDiffs} diff paths):\n${usedEntries
+          .map((entry) => `  ${describeAllowlistEntry(entry)}`)
+          .join("\n")}`,
+      );
+    }
+    if (unusedEntries.length > 0) {
+      console.log(
+        `Stale allowlist entries (matched nothing):\n${unusedEntries
+          .map((entry) => `  ${describeAllowlistEntry(entry)}`)
+          .join("\n")}`,
+      );
+    }
+    // A filtered run (`-t thr_…`) leaves most entries legitimately unused.
+    if (totals.threads === corpusThreads.length) {
+      expect(
+        unusedEntries.map((entry) => describeAllowlistEntry(entry)),
+        "every snapshots/allowlist.json entry must cover at least one diff",
+      ).toEqual([]);
+    }
+  });
+});

--- a/apps/server/test/provider-corpus/row-snapshots.test.ts
+++ b/apps/server/test/provider-corpus/row-snapshots.test.ts
@@ -123,9 +123,7 @@ describe.skipIf(!available)("provider corpus row snapshots", () => {
     threads: 0,
   };
 
-  it.each(
-    corpusThreads.map((thread) => [thread.id, thread.provider] as const),
-  )(
+  it.each(corpusThreads.map((thread) => [thread.id, thread.provider] as const))(
     "%s (%s)",
     (threadId, provider) => {
       const corpusThread = loadCorpusThread(threadId);
@@ -177,7 +175,11 @@ describe.skipIf(!available)("provider corpus row snapshots", () => {
               [
                 `Row snapshot diff for ${threadId} (${provider}): ${matched.unallowed.length} unallowed path(s)`,
                 formatDiffs(matched.unallowed, 20),
-                unifiedJsonDiff(expected, built.snapshot, `${provider}/${threadId}`),
+                unifiedJsonDiff(
+                  expected,
+                  built.snapshot,
+                  `${provider}/${threadId}`,
+                ),
               ].join("\n"),
             );
           }

--- a/apps/server/test/provider-corpus/row-snapshots.test.ts
+++ b/apps/server/test/provider-corpus/row-snapshots.test.ts
@@ -16,7 +16,9 @@ import {
 } from "@bb/test-helpers";
 import type { CorpusThread } from "@bb/test-helpers";
 import type { TimelineRow } from "@bb/server-contract";
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { ProviderRegistryService } from "../../src/services/providers/provider-registry.js";
+import { createTestProviderRegistry } from "../helpers/provider-registry.js";
 import {
   TIMELINE_VARIANTS,
   applyAllowlist,
@@ -61,12 +63,14 @@ function countTimelineRows(rows: readonly TimelineRow[]): number {
 function buildRowSnapshot(
   loaded: LoadedCorpusThread,
   corpusThread: CorpusThread,
+  registry: ProviderRegistryService,
 ): { rows: number; snapshot: JsonValue } {
   let rows = 0;
   const variants: RowSnapshot["variants"] = {};
   for (const variant of TIMELINE_VARIANTS) {
     const pages = buildAllRouteTimelinePages({
       db: loaded.db,
+      registry,
       thread: loaded.thread,
       variant,
     });
@@ -84,12 +88,23 @@ function buildRowSnapshot(
   return { rows, snapshot: normalizeJson(snapshot) };
 }
 
+/**
+ * The reader already restricts ids to one safe path segment; this keeps the
+ * resolved file under the rows root even if that validation ever loosens.
+ */
 function snapshotFilePath(
   snapshotsDir: string,
   provider: string,
   threadId: string,
 ): string {
-  return path.join(snapshotsDir, "rows", provider, `${threadId}.json`);
+  const rowsRoot = path.resolve(snapshotsDir, "rows");
+  const filePath = path.resolve(rowsRoot, provider, `${threadId}.json`);
+  if (!filePath.startsWith(`${rowsRoot}${path.sep}`)) {
+    throw new Error(
+      `Snapshot path for ${provider}/${threadId} escapes ${rowsRoot}`,
+    );
+  }
+  return filePath;
 }
 
 function formatDiffs(diffs: readonly JsonDiff[], limit: number): string {
@@ -113,6 +128,7 @@ describe.skipIf(!available)("provider corpus row snapshots", () => {
   const snapshotsDir = path.join(corpusDir, "snapshots");
   const allowlist = available ? readAllowlist(snapshotsDir) : [];
   const usedAllowlistEntries = new Set<number>();
+  let registry: ProviderRegistryService | null = null;
   const totals = {
     bytes: 0,
     diffThreads: [] as string[],
@@ -123,13 +139,22 @@ describe.skipIf(!available)("provider corpus row snapshots", () => {
     threads: 0,
   };
 
+  beforeAll(async () => {
+    if (available) {
+      registry = await createTestProviderRegistry();
+    }
+  });
+
   it.each(corpusThreads.map((thread) => [thread.id, thread.provider] as const))(
     "%s (%s)",
     (threadId, provider) => {
+      if (registry === null) {
+        throw new Error("provider registry did not load");
+      }
       const corpusThread = loadCorpusThread(threadId);
       const loaded = loadCorpusThreadIntoDb(corpusThread);
       try {
-        const built = buildRowSnapshot(loaded, corpusThread);
+        const built = buildRowSnapshot(loaded, corpusThread, registry);
         const serialized = `${JSON.stringify(built.snapshot)}\n`;
         totals.threads += 1;
         totals.rows += built.rows;
@@ -140,7 +165,7 @@ describe.skipIf(!available)("provider corpus row snapshots", () => {
           // A baseline must not depend on the wall clock or on iteration
           // order: a second projection of the same rows has to match
           // byte-for-byte before it is worth writing down.
-          const rebuilt = buildRowSnapshot(loaded, corpusThread);
+          const rebuilt = buildRowSnapshot(loaded, corpusThread, registry);
           expect(JSON.stringify(rebuilt.snapshot)).toBe(
             JSON.stringify(built.snapshot),
           );

--- a/apps/server/test/provider-corpus/synthetic-thread.ts
+++ b/apps/server/test/provider-corpus/synthetic-thread.ts
@@ -1,0 +1,487 @@
+/**
+ * Deterministic synthetic thread for the CI timeline micro-benchmark: every
+ * item kind the domain schema knows, repeated until the requested event count,
+ * persisted through the same parse + item-field derivation as daemon ingestion.
+ */
+import {
+  createConnection,
+  createProject,
+  createThread,
+  deriveStoredEventItemFields,
+  insertEvents,
+  migrate,
+  noopNotifier,
+  upsertHost,
+} from "@bb/db";
+import type { DbConnection, InsertEventInput } from "@bb/db";
+import {
+  encodeClientTurnRequestIdNumber,
+  parseStoredThreadEvent,
+  threadScope,
+  turnScope,
+} from "@bb/domain";
+import type { Thread, ThreadEventScope, ThreadEventType } from "@bb/domain";
+
+const PROVIDER_THREAD_ID = "synthetic-provider-thread";
+const BASE_CREATED_AT = 1_700_000_000_000;
+
+const execution = {
+  model: "gpt-5",
+  serviceTier: "default",
+  reasoningLevel: "medium",
+  permissionMode: "full",
+  source: "client/turn/requested",
+} as const;
+
+interface SyntheticEventBuilder {
+  sequence: number;
+  events: InsertEventInput[];
+  push(args: {
+    type: ThreadEventType;
+    scope: ThreadEventScope;
+    data: Record<string, unknown>;
+    providerThreadId?: string | null;
+  }): void;
+}
+
+function createSyntheticEventBuilder(threadId: string): SyntheticEventBuilder {
+  const builder: SyntheticEventBuilder = {
+    sequence: 0,
+    events: [],
+    push(args) {
+      builder.sequence += 1;
+      const providerThreadId =
+        args.providerThreadId === undefined
+          ? PROVIDER_THREAD_ID
+          : args.providerThreadId;
+      const event = parseStoredThreadEvent({
+        type: args.type,
+        data: args.data,
+        threadId,
+        providerThreadId,
+        scope: args.scope,
+      });
+      builder.events.push({
+        threadId,
+        environmentId: null,
+        providerThreadId,
+        scope: args.scope,
+        sequence: builder.sequence,
+        type: args.type,
+        ...deriveStoredEventItemFields(event),
+        createdAt: BASE_CREATED_AT + builder.sequence * 1_000,
+        data: JSON.stringify(args.data),
+      });
+    },
+  };
+  return builder;
+}
+
+/** A shell output that is large enough to exercise truncation and previews. */
+function commandOutput(turn: number, item: number): string {
+  const line = `turn ${turn} item ${item}: lorem ipsum dolor sit amet consectetur\n`;
+  return line.repeat(120);
+}
+
+function pushItemPair(
+  builder: SyntheticEventBuilder,
+  scope: ThreadEventScope,
+  started: Record<string, unknown>,
+  completed: Record<string, unknown>,
+): void {
+  builder.push({ type: "item/started", scope, data: { item: started } });
+  builder.push({ type: "item/completed", scope, data: { item: completed } });
+}
+
+/**
+ * One turn: the user message, the turn envelope, and every item kind once
+ * (with their delta / progress events), then usage and completion. About 45
+ * events per turn.
+ */
+function pushSyntheticTurn(
+  builder: SyntheticEventBuilder,
+  threadId: string,
+  turn: number,
+): void {
+  const turnId = `turn-${turn}`;
+  const scope = turnScope(turnId);
+  const clientRequestId = encodeClientTurnRequestIdNumber({ value: turn });
+  const id = (kind: string): string => `${turnId}-${kind}`;
+
+  builder.push({
+    type: "client/turn/requested",
+    scope: threadScope(),
+    providerThreadId: null,
+    data: {
+      direction: "outbound",
+      source: "tell",
+      initiator: "user",
+      request: { method: "turn/start", params: {} },
+      requestId: clientRequestId,
+      senderThreadId: null,
+      input: [
+        {
+          type: "text",
+          text: `User message ${turn}: please make change number ${turn}.`,
+          mentions: [],
+        },
+      ],
+      target: turn === 1 ? { kind: "thread-start" } : { kind: "new-turn" },
+      execution,
+    },
+  });
+  builder.push({ type: "turn/started", scope, data: {} });
+  builder.push({ type: "turn/input/accepted", scope, data: { clientRequestId } });
+
+  // reasoning with deltas
+  builder.push({
+    type: "item/started",
+    scope,
+    data: {
+      item: { type: "reasoning", id: id("reasoning"), summary: [], content: [] },
+    },
+  });
+  for (let delta = 0; delta < 3; delta += 1) {
+    builder.push({
+      type: "item/reasoning/textDelta",
+      scope,
+      data: { itemId: id("reasoning"), delta: `thinking ${delta} ` },
+    });
+  }
+  builder.push({
+    type: "item/completed",
+    scope,
+    data: {
+      item: {
+        type: "reasoning",
+        id: id("reasoning"),
+        summary: [`Summary for turn ${turn}`],
+        content: ["thinking 0 thinking 1 thinking 2"],
+      },
+    },
+  });
+
+  // agent message with deltas
+  builder.push({
+    type: "item/started",
+    scope,
+    data: { item: { type: "agentMessage", id: id("message"), text: "" } },
+  });
+  for (let delta = 0; delta < 3; delta += 1) {
+    builder.push({
+      type: "item/agentMessage/delta",
+      scope,
+      data: { itemId: id("message"), delta: `words ${delta} ` },
+    });
+  }
+  builder.push({
+    type: "item/completed",
+    scope,
+    data: {
+      item: {
+        type: "agentMessage",
+        id: id("message"),
+        text: `I will handle turn ${turn} now. words 0 words 1 words 2`,
+      },
+    },
+  });
+
+  // command execution with output deltas
+  builder.push({
+    type: "item/started",
+    scope,
+    data: {
+      item: {
+        type: "commandExecution",
+        id: id("command"),
+        command: `pnpm test --filter turn-${turn}`,
+        cwd: "/workspace/project",
+        status: "pending",
+        approvalStatus: null,
+      },
+    },
+  });
+  for (let delta = 0; delta < 4; delta += 1) {
+    builder.push({
+      type: "item/commandExecution/outputDelta",
+      scope,
+      data: { itemId: id("command"), delta: commandOutput(turn, delta) },
+    });
+  }
+  builder.push({
+    type: "item/completed",
+    scope,
+    data: {
+      item: {
+        type: "commandExecution",
+        id: id("command"),
+        command: `pnpm test --filter turn-${turn}`,
+        cwd: "/workspace/project",
+        status: "completed",
+        approvalStatus: null,
+        aggregatedOutput: commandOutput(turn, 99),
+        exitCode: 0,
+        durationMs: 1234,
+      },
+    },
+  });
+
+  // file change
+  pushItemPair(
+    builder,
+    scope,
+    {
+      type: "fileChange",
+      id: id("file"),
+      changes: [{ path: `src/module-${turn % 7}.ts`, kind: "update" }],
+      status: "pending",
+      approvalStatus: null,
+    },
+    {
+      type: "fileChange",
+      id: id("file"),
+      changes: [
+        {
+          path: `src/module-${turn % 7}.ts`,
+          kind: "update",
+          diff: `@@ -1,3 +1,3 @@\n-const value = ${turn - 1};\n+const value = ${turn};\n`,
+        },
+        { path: `src/new-${turn}.ts`, kind: "add", diff: "+export {};\n" },
+      ],
+      status: "completed",
+      approvalStatus: null,
+    },
+  );
+
+  // tool call with progress
+  builder.push({
+    type: "item/started",
+    scope,
+    data: {
+      item: {
+        type: "toolCall",
+        id: id("tool"),
+        tool: turn % 2 === 0 ? "Read" : "mcp__bb-bridge__bb_thread_list",
+        arguments: { path: `/workspace/project/src/module-${turn % 7}.ts` },
+        status: "pending",
+      },
+    },
+  });
+  builder.push({
+    type: "item/toolCall/progress",
+    scope,
+    data: { itemId: id("tool"), message: "reading" },
+  });
+  builder.push({
+    type: "item/completed",
+    scope,
+    data: {
+      item: {
+        type: "toolCall",
+        id: id("tool"),
+        tool: turn % 2 === 0 ? "Read" : "mcp__bb-bridge__bb_thread_list",
+        arguments: { path: `/workspace/project/src/module-${turn % 7}.ts` },
+        status: "completed",
+        result: { ok: true, lines: 120 + turn },
+        durationMs: 40,
+      },
+    },
+  });
+
+  // web search, web fetch, image view
+  pushItemPair(
+    builder,
+    scope,
+    { type: "webSearch", id: id("search"), queries: [`query ${turn}`], resultText: null },
+    {
+      type: "webSearch",
+      id: id("search"),
+      queries: [`query ${turn}`],
+      resultText: `Result text for query ${turn}`,
+    },
+  );
+  pushItemPair(
+    builder,
+    scope,
+    {
+      type: "webFetch",
+      id: id("fetch"),
+      url: `https://example.com/${turn}`,
+      prompt: null,
+      pattern: null,
+      resultText: null,
+    },
+    {
+      type: "webFetch",
+      id: id("fetch"),
+      url: `https://example.com/${turn}`,
+      prompt: "summarize",
+      pattern: null,
+      resultText: `Fetched page ${turn}`,
+    },
+  );
+  pushItemPair(
+    builder,
+    scope,
+    { type: "imageView", id: id("image"), path: `/tmp/screenshot-${turn}.png` },
+    { type: "imageView", id: id("image"), path: `/tmp/screenshot-${turn}.png` },
+  );
+
+  // plan with delta, context compaction
+  builder.push({
+    type: "item/started",
+    scope,
+    data: { item: { type: "plan", id: id("plan"), text: "" } },
+  });
+  builder.push({
+    type: "item/plan/delta",
+    scope,
+    data: { itemId: id("plan"), delta: "1. Do the thing\n" },
+  });
+  builder.push({
+    type: "item/completed",
+    scope,
+    data: {
+      item: { type: "plan", id: id("plan"), text: "1. Do the thing\n2. Verify" },
+    },
+  });
+  pushItemPair(
+    builder,
+    scope,
+    { type: "contextCompaction", id: id("compaction") },
+    { type: "contextCompaction", id: id("compaction") },
+  );
+
+  // background task: started in the turn, progress and completion thread-scoped
+  const task = {
+    type: "backgroundTask",
+    id: id("task"),
+    familyId: id("task-family"),
+    taskType: "local_bash",
+    description: `background build ${turn}`,
+    skipTranscript: false,
+  };
+  builder.push({
+    type: "item/started",
+    scope,
+    data: { item: { ...task, status: "pending", taskStatus: "running" } },
+  });
+  builder.push({
+    type: "item/backgroundTask/progress",
+    scope: threadScope(),
+    data: { item: { ...task, status: "pending", taskStatus: "running" } },
+  });
+  builder.push({
+    type: "item/backgroundTask/completed",
+    scope: threadScope(),
+    data: {
+      item: {
+        ...task,
+        status: "completed",
+        taskStatus: "completed",
+        summary: "build ok",
+      },
+    },
+  });
+
+  // turn-level updates
+  builder.push({
+    type: "turn/plan/updated",
+    scope,
+    data: {
+      plan: [
+        { step: "Investigate", status: "completed" },
+        { step: "Implement", status: "active" },
+      ],
+    },
+  });
+  builder.push({
+    type: "turn/diff/updated",
+    scope,
+    data: { diff: `diff --git a/src/module-${turn % 7}.ts b/src/module-${turn % 7}.ts\n` },
+  });
+  builder.push({
+    type: "thread/tokenUsage/updated",
+    scope,
+    data: {
+      tokenUsage: {
+        total: {
+          totalTokens: 1_000 * turn,
+          inputTokens: 800 * turn,
+          cachedInputTokens: 100 * turn,
+          outputTokens: 200 * turn,
+          reasoningOutputTokens: 50 * turn,
+        },
+        last: {
+          totalTokens: 1_000,
+          inputTokens: 800,
+          cachedInputTokens: 100,
+          outputTokens: 200,
+          reasoningOutputTokens: 50,
+        },
+        modelContextWindow: 200_000,
+      },
+    },
+  });
+  builder.push({
+    type: "thread/contextWindowUsage/updated",
+    scope,
+    data: {
+      contextWindowUsage: {
+        usedTokens: 1_000 * turn,
+        modelContextWindow: 200_000,
+        estimated: false,
+      },
+    },
+  });
+  builder.push({
+    type: "turn/completed",
+    scope,
+    data: { status: "completed" },
+  });
+  void threadId;
+}
+
+export interface SyntheticThread {
+  db: DbConnection;
+  eventCount: number;
+  thread: Thread;
+  close(): void;
+}
+
+/** Builds whole turns until at least `minimumEvents` rows exist. */
+export function createSyntheticThread(minimumEvents: number): SyntheticThread {
+  const db = createConnection(":memory:");
+  migrate(db);
+  const host = upsertHost(db, noopNotifier, {
+    name: "synthetic-host",
+    type: "persistent",
+  });
+  const { project } = createProject(db, noopNotifier, {
+    name: "synthetic-project",
+    source: { type: "local_path", hostId: host.id, path: "/workspace/project" },
+  });
+  const thread = createThread(db, noopNotifier, {
+    projectId: project.id,
+    providerId: "codex",
+    status: "idle",
+  });
+  const builder = createSyntheticEventBuilder(thread.id);
+  for (let turn = 1; builder.events.length < minimumEvents; turn += 1) {
+    pushSyntheticTurn(builder, thread.id, turn);
+  }
+  const inserted = insertEvents(db, noopNotifier, builder.events);
+  if (inserted.insertedCount !== builder.events.length) {
+    throw new Error(
+      `Synthetic thread inserted ${inserted.insertedCount} of ${builder.events.length} events`,
+    );
+  }
+  return {
+    db,
+    eventCount: builder.events.length,
+    thread,
+    close: () => {
+      db.$client.close();
+    },
+  };
+}

--- a/apps/server/test/provider-corpus/synthetic-thread.ts
+++ b/apps/server/test/provider-corpus/synthetic-thread.ts
@@ -131,14 +131,23 @@ function pushSyntheticTurn(
     },
   });
   builder.push({ type: "turn/started", scope, data: {} });
-  builder.push({ type: "turn/input/accepted", scope, data: { clientRequestId } });
+  builder.push({
+    type: "turn/input/accepted",
+    scope,
+    data: { clientRequestId },
+  });
 
   // reasoning with deltas
   builder.push({
     type: "item/started",
     scope,
     data: {
-      item: { type: "reasoning", id: id("reasoning"), summary: [], content: [] },
+      item: {
+        type: "reasoning",
+        id: id("reasoning"),
+        summary: [],
+        content: [],
+      },
     },
   });
   for (let delta = 0; delta < 3; delta += 1) {
@@ -292,7 +301,12 @@ function pushSyntheticTurn(
   pushItemPair(
     builder,
     scope,
-    { type: "webSearch", id: id("search"), queries: [`query ${turn}`], resultText: null },
+    {
+      type: "webSearch",
+      id: id("search"),
+      queries: [`query ${turn}`],
+      resultText: null,
+    },
     {
       type: "webSearch",
       id: id("search"),
@@ -342,7 +356,11 @@ function pushSyntheticTurn(
     type: "item/completed",
     scope,
     data: {
-      item: { type: "plan", id: id("plan"), text: "1. Do the thing\n2. Verify" },
+      item: {
+        type: "plan",
+        id: id("plan"),
+        text: "1. Do the thing\n2. Verify",
+      },
     },
   });
   pushItemPair(
@@ -398,7 +416,9 @@ function pushSyntheticTurn(
   builder.push({
     type: "turn/diff/updated",
     scope,
-    data: { diff: `diff --git a/src/module-${turn % 7}.ts b/src/module-${turn % 7}.ts\n` },
+    data: {
+      diff: `diff --git a/src/module-${turn % 7}.ts b/src/module-${turn % 7}.ts\n`,
+    },
   });
   builder.push({
     type: "thread/tokenUsage/updated",

--- a/apps/server/test/provider-corpus/synthetic-thread.ts
+++ b/apps/server/test/provider-corpus/synthetic-thread.ts
@@ -13,7 +13,7 @@ import {
   noopNotifier,
   upsertHost,
 } from "@bb/db";
-import type { DbConnection, InsertEventInput } from "@bb/db";
+import type { DbConnection } from "@bb/db";
 import {
   encodeClientTurnRequestIdNumber,
   parseStoredThreadEvent,
@@ -21,6 +21,9 @@ import {
   turnScope,
 } from "@bb/domain";
 import type { Thread, ThreadEventScope, ThreadEventType } from "@bb/domain";
+
+/** The db package keeps the input row type private; derive it from the call. */
+type InsertEventInput = Parameters<typeof insertEvents>[2][number];
 
 const PROVIDER_THREAD_ID = "synthetic-provider-thread";
 const BASE_CREATED_AT = 1_700_000_000_000;

--- a/apps/server/test/provider-corpus/timeline-perf.test.ts
+++ b/apps/server/test/provider-corpus/timeline-perf.test.ts
@@ -8,20 +8,28 @@
  *    fails when a thread's normalized build cost exceeds its baseline by more
  *    than 10% or its median persisted event size by more than 15%.
  *
- *    Raw wall-clock p50/p95 are recorded and printed, but the gate uses the
- *    minimum of the five samples divided by the minimum of five interleaved
- *    builds of the synthetic calibration thread. Contention only ever adds
- *    time, so the minimum is the estimate closest to the intrinsic cost, and
- *    the in-run calibration cancels machine speed and load. On a loaded
- *    16-core workstation the raw p50 swung by up to 30% between two runs of
- *    the same commit; the normalized minimum stayed within a few percent, with
- *    rare bursts that the per-thread retry (below) absorbs.
+ *    Raw wall-clock p50/p95 from the build profiles are recorded and printed,
+ *    but the gate uses a normalized cost: the minimum build time over the
+ *    samples divided by the minimum time of a fixed CPU workload that shares
+ *    no code with the timeline (JSON codec and sorting over a deterministic
+ *    document), run once per sample right before the builds. Contention only
+ *    ever adds time, so each minimum discards the contended samples on its
+ *    own side and is the estimate closest to intrinsic cost; interleaving
+ *    keeps both minima inside the same short window, so steady load and
+ *    machine speed cancel; and a workload outside the timeline path means a
+ *    uniform timeline regression still moves the ratio. (The minimum of the
+ *    per-sample ratios is recorded as a diagnostic but not gated on: a stall
+ *    on the calibration side drives it spuriously low.) On a 16-core
+ *    workstation at load ~6 the raw p50 swung by up to 30% between two runs
+ *    of the same commit while this ratio stayed within a few percent; the
+ *    per-thread retry absorbs the rare burst.
  *
  * 2. CI micro-benchmark (always runs): every page of a synthetic 10k-event
  *    thread must build under a generous ceiling. It guards against a
  *    pathological regression, not against the budget the corpus baseline pins.
  */
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import {
   corpusAvailable,
@@ -29,9 +37,11 @@ import {
   loadCorpusThread,
   resolveProviderCorpusDir,
 } from "@bb/test-helpers";
-import { afterAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { z } from "zod";
+import type { ProviderRegistryService } from "../../src/services/providers/provider-registry.js";
 import type { ThreadTimelineBuildProfileStage } from "../../src/services/threads/timeline.js";
+import { createTestProviderRegistry } from "../helpers/provider-registry.js";
 import {
   buildAllRouteTimelinePages,
   buildRouteTimelinePage,
@@ -50,9 +60,11 @@ import {
 const BUILD_SAMPLES = 5;
 /**
  * A burst of interference (another suite starting, a GC pause) can still hit
- * all five samples of one thread. Each thread is measured up to this many
- * times: write mode keeps the cheapest attempt, compare mode stops at the first
- * attempt that passes and fails only when every attempt exceeds the budget.
+ * all five samples of one thread. Each thread is measured this many times:
+ * write mode keeps the attempt with the median cost (the cheapest would mint
+ * a lucky baseline that later runs cannot match), compare mode stops at the
+ * first attempt that passes and fails only when every attempt exceeds the
+ * budget.
  */
 const MEASUREMENT_ATTEMPTS = 3;
 const LARGEST_PER_PROVIDER = 10;
@@ -67,14 +79,21 @@ const DATA_BYTES_TOLERANCE = 1.15;
 const PER_THREAD_TIMEOUT_MS = 5 * 60_000;
 
 /**
- * Measured locally at 160–250 ms p50 for the full page walk of the 10k-event
- * synthetic thread (12 pages, default variant) on a 2026 Linux workstation;
- * the ceiling is the top of that range times three so a slow CI runner passes
- * while a pathological regression (an unbounded reprojection, a quadratic
- * pass) still fails.
+ * Bump when the calibration workload changes shape: a baseline normalized
+ * against a different workload is not comparable and must be rewritten.
+ */
+const CALIBRATION_KIND = "json-sort-v1";
+
+/**
+ * Measured locally at 150–170 ms minimum (160–250 ms p50) for the full page
+ * walk of the 10k-event synthetic thread (12 pages, default variant) on a
+ * 2026 Linux workstation. The gate takes the minimum of five walks, which a
+ * loaded runner only exceeds when every sample is slow, and the ceiling is
+ * ~10× the local minimum: a slow CI runner passes, while a pathological
+ * regression (an unbounded reprojection, a quadratic pass) still fails.
  */
 const SYNTHETIC_EVENT_COUNT = 10_000;
-const SYNTHETIC_CEILING_MS = 750;
+const SYNTHETIC_CEILING_MS = 1_500;
 
 const STAGES: readonly ThreadTimelineBuildProfileStage[] = [
   "event-query",
@@ -91,8 +110,10 @@ const buildCostSchema = z.object({
   p50Ms: z.number(),
   p95Ms: z.number(),
   minMs: z.number(),
-  /** `minMs` divided by the calibration thread's `minMs` from the same run. */
+  /** `minMs` ÷ the calibration minimum of the same interleaved samples. */
   normalizedMin: z.number(),
+  /** Minimum over samples of the per-sample ratio; diagnostic only. */
+  pairedRatioMin: z.number(),
 });
 type BuildCost = z.infer<typeof buildCostSchema>;
 
@@ -102,7 +123,7 @@ const perfThreadBaselineSchema = z.object({
   dataBytesMedian: z.number(),
   dataBytesP95: z.number(),
   dataBytesTotal: z.number(),
-  /** Full-walk minimum of the synthetic calibration thread, measured just before. */
+  /** Calibration workload minimum across this thread's samples. */
   calibrationMinMs: z.number(),
   latest: buildCostSchema.extend({
     rowsProduced: z.number(),
@@ -116,12 +137,71 @@ const perfThreadBaselineSchema = z.object({
 });
 type PerfThreadBaseline = z.infer<typeof perfThreadBaselineSchema>;
 
-const perfBaselineSchema = z.object({
+const perfGateSettingsSchema = z.object({
   samplesPerThread: z.number(),
-  calibrationEventCount: z.number(),
+  calibration: z.string(),
+});
+
+const perfBaselineSchema = z.object({
+  gate: perfGateSettingsSchema,
   threads: z.record(z.string(), perfThreadBaselineSchema),
 });
 type PerfBaseline = z.infer<typeof perfBaselineSchema>;
+
+const CURRENT_GATE_SETTINGS = {
+  samplesPerThread: BUILD_SAMPLES,
+  calibration: CALIBRATION_KIND,
+} satisfies z.infer<typeof perfGateSettingsSchema>;
+
+// ---------------------------------------------------------------------------
+// Calibration workload: deterministic CPU work with no timeline code in it.
+// ---------------------------------------------------------------------------
+
+function createLcg(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+    return state / 0x1_0000_0000;
+  };
+}
+
+function buildCalibrationDocument(): string {
+  const random = createLcg(20_260_821);
+  const records = Array.from({ length: 6_000 }, (_, index) => ({
+    id: `rec_${index}`,
+    score: random(),
+    tags: Array.from({ length: 4 }, () => `tag-${Math.floor(random() * 100)}`),
+    text: "lorem ipsum dolor sit amet ".repeat(1 + (index % 5)),
+    nested: { a: random(), b: [random(), random()], c: { d: index } },
+  }));
+  return JSON.stringify(records);
+}
+
+const CALIBRATION_DOCUMENT = buildCalibrationDocument();
+/** Keeps the workload's results alive so the JIT cannot elide the work. */
+let calibrationSink = 0;
+
+/** Runs the fixed workload once and returns its wall time in ms. */
+function runCalibrationWorkload(): number {
+  const startedAt = performance.now();
+  let checksum = 0;
+  for (let round = 0; round < 6; round += 1) {
+    const parsed: unknown = JSON.parse(CALIBRATION_DOCUMENT);
+    checksum += JSON.stringify(parsed).length;
+  }
+  const random = createLcg(7);
+  const numbers = Array.from({ length: 150_000 }, () => random());
+  numbers.sort((left, right) => left - right);
+  checksum += numbers[12_345] ?? 0;
+  const words = CALIBRATION_DOCUMENT.split('"');
+  checksum += words.filter((word) => word.startsWith("tag-")).length;
+  calibrationSink = (calibrationSink + checksum) % 1_000_003;
+  return performance.now() - startedAt;
+}
+
+// ---------------------------------------------------------------------------
+// Measurement
+// ---------------------------------------------------------------------------
 
 function round(value: number, digits = 2): number {
   const factor = 10 ** digits;
@@ -151,25 +231,25 @@ function sample<T>(build: () => T): T[] {
   return samples;
 }
 
-function buildCost(
-  durations: readonly number[],
-  calibrationMinMs: number,
-): BuildCost {
+interface PairedDuration {
+  buildMs: number;
+  calibrationMs: number;
+}
+
+function buildCost(pairs: readonly PairedDuration[]): BuildCost {
+  const durations = pairs.map((pair) => pair.buildMs);
+  const calibrationMin = Math.min(...pairs.map((pair) => pair.calibrationMs));
   const minMs = Math.min(...durations);
   return {
     p50Ms: round(percentile(durations, 0.5)),
     p95Ms: round(percentile(durations, 0.95)),
     minMs: round(minMs),
-    normalizedMin: round(minMs / calibrationMinMs, 4),
+    normalizedMin: round(minMs / calibrationMin, 4),
+    pairedRatioMin: round(
+      Math.min(...pairs.map((pair) => pair.buildMs / pair.calibrationMs)),
+      4,
+    ),
   };
-}
-
-function walkSynthetic(synthetic: SyntheticThread): BuiltTimelinePage[] {
-  return buildAllRouteTimelinePages({
-    db: synthetic.db,
-    thread: synthetic.thread,
-    variant: "default",
-  });
 }
 
 interface InterleavedSample {
@@ -180,31 +260,30 @@ interface InterleavedSample {
 
 function measureCorpusThread(
   threadId: string,
-  synthetic: SyntheticThread,
+  registry: ProviderRegistryService,
 ): PerfThreadBaseline {
   const corpusThread = loadCorpusThread(threadId);
   const loaded = loadCorpusThreadIntoDb(corpusThread);
   try {
-    // Calibration, latest page, and full walk are interleaved per sample so a
-    // change in machine load lands on the calibration and the thread alike.
+    // Each sample runs the calibration workload right before the two builds,
+    // so the minima on both sides come from the same short window.
     const samples = sample(
       (): InterleavedSample => ({
-        calibrationMs: sumProfileDurations(walkSynthetic(synthetic)),
+        calibrationMs: runCalibrationWorkload(),
         latest: buildRouteTimelinePage({
           db: loaded.db,
-          thread: loaded.thread,
           page: latestTimelinePage(),
+          registry,
+          thread: loaded.thread,
           variant: "default",
         }),
         walk: buildAllRouteTimelinePages({
           db: loaded.db,
+          registry,
           thread: loaded.thread,
           variant: "default",
         }),
       }),
-    );
-    const calibrationMinMs = Math.min(
-      ...samples.map((entry) => entry.calibrationMs),
     );
     const latestSamples = samples.map((entry) => entry.latest);
     const walkSamples = samples.map((entry) => entry.walk);
@@ -231,11 +310,15 @@ function measureCorpusThread(
       dataBytesMedian: percentile(dataBytes, 0.5),
       dataBytesP95: percentile(dataBytes, 0.95),
       dataBytesTotal: dataBytes.reduce((total, bytes) => total + bytes, 0),
-      calibrationMinMs: round(calibrationMinMs),
+      calibrationMinMs: round(
+        Math.min(...samples.map((entry) => entry.calibrationMs)),
+      ),
       latest: {
         ...buildCost(
-          latestSamples.map((page) => page.profile.totalDurationMs),
-          calibrationMinMs,
+          samples.map((entry) => ({
+            buildMs: entry.latest.profile.totalDurationMs,
+            calibrationMs: entry.calibrationMs,
+          })),
         ),
         rowsProduced: lastLatest.profile.projectedRowCount,
         selectionStrategy: lastLatest.profile.selectionStrategy,
@@ -243,8 +326,10 @@ function measureCorpusThread(
       },
       walk: {
         ...buildCost(
-          walkSamples.map((pages) => sumProfileDurations(pages)),
-          calibrationMinMs,
+          samples.map((entry) => ({
+            buildMs: sumProfileDurations(entry.walk),
+            calibrationMs: entry.calibrationMs,
+          })),
         ),
         pages: lastWalk.length,
         rowsProduced: lastWalk.reduce(
@@ -317,34 +402,52 @@ interface MeasuredThread {
 
 /**
  * Measures up to `MEASUREMENT_ATTEMPTS` times. Without a baseline (write
- * mode) every attempt runs and the cheapest wins; with one, the first passing
- * attempt wins and otherwise the cheapest failing attempt is reported.
+ * mode) every attempt runs and the median-cost attempt wins; with one, the
+ * first passing attempt wins and otherwise the cheapest failing attempt is
+ * reported.
  */
 function measureThreadWithRetries(
   threadId: string,
-  synthetic: SyntheticThread,
+  registry: ProviderRegistryService,
   expected: PerfThreadBaseline | null,
 ): MeasuredThread {
-  let best: MeasuredThread | null = null;
+  const attempts: MeasuredThread[] = [];
   for (let attempt = 1; attempt <= MEASUREMENT_ATTEMPTS; attempt += 1) {
-    const result = measureCorpusThread(threadId, synthetic);
+    const result = measureCorpusThread(threadId, registry);
     const failures = expected === null ? [] : perfChecks(result, expected);
     const candidate: MeasuredThread = { attempts: attempt, failures, result };
-    if (
-      best === null ||
-      normalizedCost(candidate.result) < normalizedCost(best.result)
-    ) {
-      best = candidate;
-    }
     if (expected !== null && failures.length === 0) {
       return candidate;
     }
-    best.attempts = attempt;
+    attempts.push(candidate);
   }
-  if (best === null) {
+  const byCost = [...attempts].sort(
+    (left, right) => normalizedCost(left.result) - normalizedCost(right.result),
+  );
+  const chosen =
+    expected === null ? byCost[Math.floor(byCost.length / 2)] : byCost[0];
+  if (chosen === undefined) {
     throw new Error("no measurement attempts");
   }
-  return best;
+  return { ...chosen, attempts: attempts.length };
+}
+
+function readBaseline(baselinePath: string): PerfBaseline | null {
+  if (!fs.existsSync(baselinePath)) {
+    return null;
+  }
+  const baseline = perfBaselineSchema.parse(
+    JSON.parse(fs.readFileSync(baselinePath, "utf8")),
+  );
+  if (
+    baseline.gate.samplesPerThread !== CURRENT_GATE_SETTINGS.samplesPerThread ||
+    baseline.gate.calibration !== CURRENT_GATE_SETTINGS.calibration
+  ) {
+    throw new Error(
+      `perf-baseline.json was written with ${JSON.stringify(baseline.gate)} but this suite measures with ${JSON.stringify(CURRENT_GATE_SETTINGS)}; rewrite the baseline with BB_PROVIDER_CORPUS_SNAPSHOT=write`,
+    );
+  }
+  return baseline;
 }
 
 const available = corpusAvailable();
@@ -366,21 +469,25 @@ describe.skipIf(!available)("provider corpus timeline perf baseline", () => {
   const corpusDir = resolveProviderCorpusDir() ?? "";
   const snapshotsDir = path.join(corpusDir, "snapshots");
   const baselinePath = path.join(snapshotsDir, "perf-baseline.json");
-  const baseline: PerfBaseline | null =
-    available && mode === "compare" && fs.existsSync(baselinePath)
-      ? perfBaselineSchema.parse(
-          JSON.parse(fs.readFileSync(baselinePath, "utf8")),
-        )
-      : null;
+  const baseline =
+    available && mode === "compare" ? readBaseline(baselinePath) : null;
   const measured = new Map<string, PerfThreadBaseline>();
   const attemptsByThread = new Map<string, number>();
   const failures: string[] = [];
-  let synthetic: SyntheticThread | null = null;
+  let registry: ProviderRegistryService | null = null;
+
+  beforeAll(async () => {
+    if (available) {
+      registry = await createTestProviderRegistry();
+    }
+  });
 
   it.each(corpusThreads.map((thread) => [thread.id, thread.provider] as const))(
     "%s (%s)",
     (threadId) => {
-      synthetic ??= createSyntheticThread(SYNTHETIC_EVENT_COUNT);
+      if (registry === null) {
+        throw new Error("provider registry did not load");
+      }
       let expected: PerfThreadBaseline | null = null;
       if (mode === "compare") {
         if (baseline === null) {
@@ -395,7 +502,7 @@ describe.skipIf(!available)("provider corpus timeline perf baseline", () => {
           );
         }
       }
-      const outcome = measureThreadWithRetries(threadId, synthetic, expected);
+      const outcome = measureThreadWithRetries(threadId, registry, expected);
       measured.set(threadId, outcome.result);
       attemptsByThread.set(threadId, outcome.attempts);
       for (const failure of outcome.failures) {
@@ -408,7 +515,6 @@ describe.skipIf(!available)("provider corpus timeline perf baseline", () => {
   );
 
   afterAll(() => {
-    synthetic?.close();
     if (!available || measured.size === 0) {
       return;
     }
@@ -455,27 +561,37 @@ describe.skipIf(!available)("provider corpus timeline perf baseline", () => {
       ];
     });
     const table = formatMarkdownTable(header, rows);
+    // A perf gate needs a machine that is not oversubscribed: with more
+    // runnable threads than cores even paired ratios drift by 10–20%.
+    const [loadAverage1m = 0] = os.loadavg();
+    const loadNote = `load average ${loadAverage1m.toFixed(1)} on ${os.cpus().length} cores${
+      loadAverage1m > os.cpus().length
+        ? " — OVERSUBSCRIBED, timings are not trustworthy"
+        : ""
+    }`;
     process.stdout.write(
-      `Timeline perf (${mode}, ${BUILD_SAMPLES} samples/thread, default variant; norm = min ÷ calibration min):\n${table}\n`,
+      `Timeline perf (${mode}, ${BUILD_SAMPLES} samples/thread, default variant; norm = min build ÷ min ${CALIBRATION_KIND} workload over interleaved samples; ${loadNote}):\n${table}\n`,
     );
     fs.mkdirSync(snapshotsDir, { recursive: true });
     fs.writeFileSync(path.join(snapshotsDir, "perf-last-run.md"), `${table}\n`);
     if (mode === "write") {
       const written: PerfBaseline = {
-        samplesPerThread: BUILD_SAMPLES,
-        calibrationEventCount: SYNTHETIC_EVENT_COUNT,
+        gate: CURRENT_GATE_SETTINGS,
         threads: Object.fromEntries(measured),
       };
       fs.writeFileSync(baselinePath, `${JSON.stringify(written, null, 2)}\n`);
       return;
     }
-    expect(failures, "timeline perf regressions").toEqual([]);
+    expect(failures, `timeline perf regressions (${loadNote})`).toEqual([]);
   });
 });
 
 describe("timeline build micro-benchmark", () => {
-  it(`projects every page of a ${SYNTHETIC_EVENT_COUNT}-event thread under ${SYNTHETIC_CEILING_MS} ms`, () => {
-    const synthetic = createSyntheticThread(SYNTHETIC_EVENT_COUNT);
+  it(`projects every page of a ${SYNTHETIC_EVENT_COUNT}-event thread under ${SYNTHETIC_CEILING_MS} ms`, async () => {
+    const registry = await createTestProviderRegistry();
+    const synthetic: SyntheticThread = createSyntheticThread(
+      SYNTHETIC_EVENT_COUNT,
+    );
     try {
       expect(synthetic.eventCount).toBeGreaterThanOrEqual(
         SYNTHETIC_EVENT_COUNT,
@@ -484,9 +600,16 @@ describe("timeline build micro-benchmark", () => {
       // walk is what scales with the thread: every page, default variant,
       // summed over the build profiles (SQLite reads, decode, projection,
       // pagination) rather than wall time, so disk noise does not count.
-      const samples = sample(() => walkSynthetic(synthetic));
+      const samples = sample(() =>
+        buildAllRouteTimelinePages({
+          db: synthetic.db,
+          registry,
+          thread: synthetic.thread,
+          variant: "default",
+        }),
+      );
       const durations = samples.map((pages) => sumProfileDurations(pages));
-      const p50 = percentile(durations, 0.5);
+      const minimum = Math.min(...durations);
       const last = samples[samples.length - 1];
       if (last === undefined) {
         throw new Error("no samples");
@@ -497,10 +620,11 @@ describe("timeline build micro-benchmark", () => {
       );
       process.stdout.write(
         `Synthetic ${synthetic.eventCount}-event thread: ${last.length} pages, ${rowsProjected} rows projected, ` +
-          `full walk p50 ${round(p50)} ms (samples ${durations.map((value) => round(value)).join(", ")})\n`,
+          `full walk min ${round(minimum)} ms, p50 ${round(percentile(durations, 0.5))} ms ` +
+          `(samples ${durations.map((value) => round(value)).join(", ")})\n`,
       );
       expect(last.length).toBeGreaterThan(1);
-      expect(p50).toBeLessThan(SYNTHETIC_CEILING_MS);
+      expect(minimum).toBeLessThan(SYNTHETIC_CEILING_MS);
     } finally {
       synthetic.close();
     }

--- a/apps/server/test/provider-corpus/timeline-perf.test.ts
+++ b/apps/server/test/provider-corpus/timeline-perf.test.ts
@@ -1,0 +1,515 @@
+/**
+ * Timeline-build performance baselines.
+ *
+ * 1. Corpus baseline (needs `BB_PROVIDER_CORPUS_DIR`): the 10 largest threads
+ *    per provider, N=5 profiled builds each of the latest page and of the full
+ *    page walk, after one warm-up build. Write mode records the numbers in
+ *    `$BB_PROVIDER_CORPUS_DIR/snapshots/perf-baseline.json`; compare mode
+ *    fails when a thread's normalized build cost exceeds its baseline by more
+ *    than 10% or its median persisted event size by more than 15%.
+ *
+ *    Raw wall-clock p50/p95 are recorded and printed, but the gate uses the
+ *    minimum of the five samples divided by the minimum of five interleaved
+ *    builds of the synthetic calibration thread. Contention only ever adds
+ *    time, so the minimum is the estimate closest to the intrinsic cost, and
+ *    the in-run calibration cancels machine speed and load. On a loaded
+ *    16-core workstation the raw p50 swung by up to 30% between two runs of
+ *    the same commit; the normalized minimum stayed within a few percent, with
+ *    rare bursts that the per-thread retry (below) absorbs.
+ *
+ * 2. CI micro-benchmark (always runs): every page of a synthetic 10k-event
+ *    thread must build under a generous ceiling. It guards against a
+ *    pathological regression, not against the budget the corpus baseline pins.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import {
+  corpusAvailable,
+  listCorpusThreads,
+  loadCorpusThread,
+  resolveProviderCorpusDir,
+} from "@bb/test-helpers";
+import { afterAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+import type { ThreadTimelineBuildProfileStage } from "../../src/services/threads/timeline.js";
+import {
+  buildAllRouteTimelinePages,
+  buildRouteTimelinePage,
+  formatMarkdownTable,
+  latestTimelinePage,
+  loadCorpusThreadIntoDb,
+  percentile,
+  resolveSnapshotMode,
+  type BuiltTimelinePage,
+} from "./corpus-harness.js";
+import {
+  createSyntheticThread,
+  type SyntheticThread,
+} from "./synthetic-thread.js";
+
+const BUILD_SAMPLES = 5;
+/**
+ * A burst of interference (another suite starting, a GC pause) can still hit
+ * all five samples of one thread. Each thread is measured up to this many
+ * times: write mode keeps the cheapest attempt, compare mode stops at the first
+ * attempt that passes and fails only when every attempt exceeds the budget.
+ */
+const MEASUREMENT_ATTEMPTS = 3;
+const LARGEST_PER_PROVIDER = 10;
+const DURATION_TOLERANCE = 1.1;
+/**
+ * A latest-page build on a well-windowed thread takes ~2–20 ms, where one
+ * timer tick or cache miss is already 10%. The budget is 10% or this many
+ * milliseconds of intrinsic cost, whichever is larger.
+ */
+const DURATION_TOLERANCE_FLOOR_MS = 5;
+const DATA_BYTES_TOLERANCE = 1.15;
+const PER_THREAD_TIMEOUT_MS = 5 * 60_000;
+
+/**
+ * Measured locally at 160–250 ms p50 for the full page walk of the 10k-event
+ * synthetic thread (12 pages, default variant) on a 2026 Linux workstation;
+ * the ceiling is the top of that range times three so a slow CI runner passes
+ * while a pathological regression (an unbounded reprojection, a quadratic
+ * pass) still fails.
+ */
+const SYNTHETIC_EVENT_COUNT = 10_000;
+const SYNTHETIC_CEILING_MS = 750;
+
+const STAGES: readonly ThreadTimelineBuildProfileStage[] = [
+  "event-query",
+  "accepted-client-request-context-query",
+  "event-json-decode",
+  "summary-compaction",
+  "context-window-query",
+  "context-window-json-decode",
+  "thread-view-projection",
+  "pagination-segmentation",
+];
+
+const buildCostSchema = z.object({
+  p50Ms: z.number(),
+  p95Ms: z.number(),
+  minMs: z.number(),
+  /** `minMs` divided by the calibration thread's `minMs` from the same run. */
+  normalizedMin: z.number(),
+});
+type BuildCost = z.infer<typeof buildCostSchema>;
+
+const perfThreadBaselineSchema = z.object({
+  provider: z.string(),
+  eventRows: z.number(),
+  dataBytesMedian: z.number(),
+  dataBytesP95: z.number(),
+  dataBytesTotal: z.number(),
+  /** Full-walk minimum of the synthetic calibration thread, measured just before. */
+  calibrationMinMs: z.number(),
+  latest: buildCostSchema.extend({
+    rowsProduced: z.number(),
+    selectionStrategy: z.string(),
+    stageP50Ms: z.record(z.string(), z.number()),
+  }),
+  walk: buildCostSchema.extend({
+    pages: z.number(),
+    rowsProduced: z.number(),
+  }),
+});
+type PerfThreadBaseline = z.infer<typeof perfThreadBaselineSchema>;
+
+const perfBaselineSchema = z.object({
+  samplesPerThread: z.number(),
+  calibrationEventCount: z.number(),
+  threads: z.record(z.string(), perfThreadBaselineSchema),
+});
+type PerfBaseline = z.infer<typeof perfBaselineSchema>;
+
+function round(value: number, digits = 2): number {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+function stageDuration(
+  page: BuiltTimelinePage,
+  stage: ThreadTimelineBuildProfileStage,
+): number {
+  return page.profile.stageTimings
+    .filter((timing) => timing.stage === stage)
+    .reduce((total, timing) => total + timing.durationMs, 0);
+}
+
+function sumProfileDurations(pages: readonly BuiltTimelinePage[]): number {
+  return pages.reduce(
+    (total, page) => total + page.profile.totalDurationMs,
+    0,
+  );
+}
+
+/** One warm-up build, then `BUILD_SAMPLES` measured builds. */
+function sample<T>(build: () => T): T[] {
+  build();
+  const samples: T[] = [];
+  for (let index = 0; index < BUILD_SAMPLES; index += 1) {
+    samples.push(build());
+  }
+  return samples;
+}
+
+function buildCost(
+  durations: readonly number[],
+  calibrationMinMs: number,
+): BuildCost {
+  const minMs = Math.min(...durations);
+  return {
+    p50Ms: round(percentile(durations, 0.5)),
+    p95Ms: round(percentile(durations, 0.95)),
+    minMs: round(minMs),
+    normalizedMin: round(minMs / calibrationMinMs, 4),
+  };
+}
+
+function walkSynthetic(synthetic: SyntheticThread): BuiltTimelinePage[] {
+  return buildAllRouteTimelinePages({
+    db: synthetic.db,
+    thread: synthetic.thread,
+    variant: "default",
+  });
+}
+
+interface InterleavedSample {
+  calibrationMs: number;
+  latest: BuiltTimelinePage;
+  walk: BuiltTimelinePage[];
+}
+
+function measureCorpusThread(
+  threadId: string,
+  synthetic: SyntheticThread,
+): PerfThreadBaseline {
+  const corpusThread = loadCorpusThread(threadId);
+  const loaded = loadCorpusThreadIntoDb(corpusThread);
+  try {
+    // Calibration, latest page, and full walk are interleaved per sample so a
+    // change in machine load lands on the calibration and the thread alike.
+    const samples = sample(
+      (): InterleavedSample => ({
+        calibrationMs: sumProfileDurations(walkSynthetic(synthetic)),
+        latest: buildRouteTimelinePage({
+          db: loaded.db,
+          thread: loaded.thread,
+          page: latestTimelinePage(),
+          variant: "default",
+        }),
+        walk: buildAllRouteTimelinePages({
+          db: loaded.db,
+          thread: loaded.thread,
+          variant: "default",
+        }),
+      }),
+    );
+    const calibrationMinMs = Math.min(
+      ...samples.map((entry) => entry.calibrationMs),
+    );
+    const latestSamples = samples.map((entry) => entry.latest);
+    const walkSamples = samples.map((entry) => entry.walk);
+    const latestStageP50Ms: Record<string, number> = {};
+    for (const stage of STAGES) {
+      latestStageP50Ms[stage] = round(
+        percentile(
+          latestSamples.map((page) => stageDuration(page, stage)),
+          0.5,
+        ),
+      );
+    }
+    const dataBytes = corpusThread.eventRows.map((row) =>
+      Buffer.byteLength(row.data),
+    );
+    const lastLatest = latestSamples[latestSamples.length - 1];
+    const lastWalk = walkSamples[walkSamples.length - 1];
+    if (lastLatest === undefined || lastWalk === undefined) {
+      throw new Error("no samples");
+    }
+    return {
+      provider: corpusThread.provider,
+      eventRows: corpusThread.eventRows.length,
+      dataBytesMedian: percentile(dataBytes, 0.5),
+      dataBytesP95: percentile(dataBytes, 0.95),
+      dataBytesTotal: dataBytes.reduce((total, bytes) => total + bytes, 0),
+      calibrationMinMs: round(calibrationMinMs),
+      latest: {
+        ...buildCost(
+          latestSamples.map((page) => page.profile.totalDurationMs),
+          calibrationMinMs,
+        ),
+        rowsProduced: lastLatest.profile.projectedRowCount,
+        selectionStrategy: lastLatest.profile.selectionStrategy,
+        stageP50Ms: latestStageP50Ms,
+      },
+      walk: {
+        ...buildCost(
+          walkSamples.map((pages) => sumProfileDurations(pages)),
+          calibrationMinMs,
+        ),
+        pages: lastWalk.length,
+        rowsProduced: lastWalk.reduce(
+          (total, page) => total + page.profile.projectedRowCount,
+          0,
+        ),
+      },
+    };
+  } finally {
+    loaded.close();
+  }
+}
+
+function ratio(current: number, baseline: number): string {
+  if (baseline === 0) {
+    return current === 0 ? "1.00×" : "∞";
+  }
+  return `${(current / baseline).toFixed(2)}×`;
+}
+
+function perfChecks(
+  result: PerfThreadBaseline,
+  expected: PerfThreadBaseline,
+): string[] {
+  // The floor is expressed in the same normalized unit as the gate.
+  const durationFloor = DURATION_TOLERANCE_FLOOR_MS / result.calibrationMinMs;
+  const checks: [string, number, number, number, number][] = [
+    [
+      "latest normalized min",
+      result.latest.normalizedMin,
+      expected.latest.normalizedMin,
+      DURATION_TOLERANCE,
+      durationFloor,
+    ],
+    [
+      "walk normalized min",
+      result.walk.normalizedMin,
+      expected.walk.normalizedMin,
+      DURATION_TOLERANCE,
+      durationFloor,
+    ],
+    [
+      "median data bytes",
+      result.dataBytesMedian,
+      expected.dataBytesMedian,
+      DATA_BYTES_TOLERANCE,
+      0,
+    ],
+  ];
+  return checks
+    .filter(
+      ([, current, base, tolerance, floor]) =>
+        current > Math.max(base * tolerance, base + floor),
+    )
+    .map(
+      ([label, current, base, tolerance]) =>
+        `${label} ${current} exceeds baseline ${base} × ${tolerance}`,
+    );
+}
+
+function normalizedCost(result: PerfThreadBaseline): number {
+  return result.latest.normalizedMin + result.walk.normalizedMin;
+}
+
+interface MeasuredThread {
+  attempts: number;
+  failures: string[];
+  result: PerfThreadBaseline;
+}
+
+/**
+ * Measures up to `MEASUREMENT_ATTEMPTS` times. Without a baseline (write
+ * mode) every attempt runs and the cheapest wins; with one, the first passing
+ * attempt wins and otherwise the cheapest failing attempt is reported.
+ */
+function measureThreadWithRetries(
+  threadId: string,
+  synthetic: SyntheticThread,
+  expected: PerfThreadBaseline | null,
+): MeasuredThread {
+  let best: MeasuredThread | null = null;
+  for (let attempt = 1; attempt <= MEASUREMENT_ATTEMPTS; attempt += 1) {
+    const result = measureCorpusThread(threadId, synthetic);
+    const failures = expected === null ? [] : perfChecks(result, expected);
+    const candidate: MeasuredThread = { attempts: attempt, failures, result };
+    if (
+      best === null ||
+      normalizedCost(candidate.result) < normalizedCost(best.result)
+    ) {
+      best = candidate;
+    }
+    if (expected !== null && failures.length === 0) {
+      return candidate;
+    }
+    best.attempts = attempt;
+  }
+  if (best === null) {
+    throw new Error("no measurement attempts");
+  }
+  return best;
+}
+
+const available = corpusAvailable();
+const mode = resolveSnapshotMode();
+const corpusThreads = available
+  ? listCorpusThreads({ reasons: ["largest"] })
+      .sort((left, right) => right.events - left.events)
+      .filter((thread, _index, all) => {
+        const rank = all
+          .filter((candidate) => candidate.provider === thread.provider)
+          .indexOf(thread);
+        return rank < LARGEST_PER_PROVIDER;
+      })
+  : [];
+
+describe.skipIf(!available)("provider corpus timeline perf baseline", () => {
+  // The describe body runs at collection time even when skipped, so it must
+  // tolerate a missing corpus.
+  const corpusDir = resolveProviderCorpusDir() ?? "";
+  const snapshotsDir = path.join(corpusDir, "snapshots");
+  const baselinePath = path.join(snapshotsDir, "perf-baseline.json");
+  const baseline: PerfBaseline | null =
+    available && mode === "compare" && fs.existsSync(baselinePath)
+      ? perfBaselineSchema.parse(
+          JSON.parse(fs.readFileSync(baselinePath, "utf8")),
+        )
+      : null;
+  const measured = new Map<string, PerfThreadBaseline>();
+  const attemptsByThread = new Map<string, number>();
+  const failures: string[] = [];
+  let synthetic: SyntheticThread | null = null;
+
+  it.each(
+    corpusThreads.map((thread) => [thread.id, thread.provider] as const),
+  )(
+    "%s (%s)",
+    (threadId) => {
+      synthetic ??= createSyntheticThread(SYNTHETIC_EVENT_COUNT);
+      let expected: PerfThreadBaseline | null = null;
+      if (mode === "compare") {
+        if (baseline === null) {
+          throw new Error(
+            `No perf baseline at ${baselinePath}; run once with BB_PROVIDER_CORPUS_SNAPSHOT=write`,
+          );
+        }
+        expected = baseline.threads[threadId] ?? null;
+        if (expected === null) {
+          throw new Error(
+            `${threadId} is missing from perf-baseline.json; rewrite the baseline`,
+          );
+        }
+      }
+      const outcome = measureThreadWithRetries(threadId, synthetic, expected);
+      measured.set(threadId, outcome.result);
+      attemptsByThread.set(threadId, outcome.attempts);
+      for (const failure of outcome.failures) {
+        failures.push(`${threadId} (after ${outcome.attempts} attempts): ${failure}`);
+      }
+    },
+    PER_THREAD_TIMEOUT_MS,
+  );
+
+  afterAll(() => {
+    synthetic?.close();
+    if (!available || measured.size === 0) {
+      return;
+    }
+    const header = [
+      "thread",
+      "provider",
+      "events",
+      "data bytes p50/p95",
+      "latest rows",
+      "latest p50/p95 ms",
+      "latest norm",
+      "pages",
+      "walk rows",
+      "walk p50/p95 ms",
+      "walk norm",
+      "attempts",
+      ...(baseline ? ["latest vs base", "walk vs base"] : []),
+    ];
+    const rows = [...measured.entries()].map(([threadId, result]) => {
+      const base = baseline?.threads[threadId];
+      return [
+        threadId,
+        result.provider,
+        result.eventRows,
+        `${result.dataBytesMedian}/${result.dataBytesP95}`,
+        result.latest.rowsProduced,
+        `${result.latest.p50Ms}/${result.latest.p95Ms}`,
+        result.latest.normalizedMin.toFixed(3),
+        result.walk.pages,
+        result.walk.rowsProduced,
+        `${result.walk.p50Ms}/${result.walk.p95Ms}`,
+        result.walk.normalizedMin.toFixed(3),
+        attemptsByThread.get(threadId) ?? 0,
+        ...(baseline
+          ? [
+              base
+                ? ratio(result.latest.normalizedMin, base.latest.normalizedMin)
+                : "n/a",
+              base
+                ? ratio(result.walk.normalizedMin, base.walk.normalizedMin)
+                : "n/a",
+            ]
+          : []),
+      ];
+    });
+    const table = formatMarkdownTable(header, rows);
+    process.stdout.write(
+      `Timeline perf (${mode}, ${BUILD_SAMPLES} samples/thread, default variant; norm = min ÷ calibration min):\n${table}\n`,
+    );
+    fs.mkdirSync(snapshotsDir, { recursive: true });
+    fs.writeFileSync(path.join(snapshotsDir, "perf-last-run.md"), `${table}\n`);
+    if (mode === "write") {
+      const written: PerfBaseline = {
+        samplesPerThread: BUILD_SAMPLES,
+        calibrationEventCount: SYNTHETIC_EVENT_COUNT,
+        threads: Object.fromEntries(measured),
+      };
+      fs.writeFileSync(baselinePath, `${JSON.stringify(written, null, 2)}\n`);
+      return;
+    }
+    expect(failures, "timeline perf regressions").toEqual([]);
+  });
+});
+
+describe("timeline build micro-benchmark", () => {
+  it(
+    `projects every page of a ${SYNTHETIC_EVENT_COUNT}-event thread under ${SYNTHETIC_CEILING_MS} ms`,
+    () => {
+      const synthetic = createSyntheticThread(SYNTHETIC_EVENT_COUNT);
+      try {
+        expect(synthetic.eventCount).toBeGreaterThanOrEqual(
+          SYNTHETIC_EVENT_COUNT,
+        );
+        // The latest page alone is bounded by segment windowing, so the whole
+        // walk is what scales with the thread: every page, default variant,
+        // summed over the build profiles (SQLite reads, decode, projection,
+        // pagination) rather than wall time, so disk noise does not count.
+        const samples = sample(() => walkSynthetic(synthetic));
+        const durations = samples.map((pages) => sumProfileDurations(pages));
+        const p50 = percentile(durations, 0.5);
+        const last = samples[samples.length - 1];
+        if (last === undefined) {
+          throw new Error("no samples");
+        }
+        const rowsProjected = last.reduce(
+          (total, page) => total + page.profile.projectedRowCount,
+          0,
+        );
+        process.stdout.write(
+          `Synthetic ${synthetic.eventCount}-event thread: ${last.length} pages, ${rowsProjected} rows projected, ` +
+            `full walk p50 ${round(p50)} ms (samples ${durations.map((value) => round(value)).join(", ")})\n`,
+        );
+        expect(last.length).toBeGreaterThan(1);
+        expect(p50).toBeLessThan(SYNTHETIC_CEILING_MS);
+      } finally {
+        synthetic.close();
+      }
+    },
+    120_000,
+  );
+});

--- a/apps/server/test/provider-corpus/timeline-perf.test.ts
+++ b/apps/server/test/provider-corpus/timeline-perf.test.ts
@@ -138,10 +138,7 @@ function stageDuration(
 }
 
 function sumProfileDurations(pages: readonly BuiltTimelinePage[]): number {
-  return pages.reduce(
-    (total, page) => total + page.profile.totalDurationMs,
-    0,
-  );
+  return pages.reduce((total, page) => total + page.profile.totalDurationMs, 0);
 }
 
 /** One warm-up build, then `BUILD_SAMPLES` measured builds. */
@@ -380,9 +377,7 @@ describe.skipIf(!available)("provider corpus timeline perf baseline", () => {
   const failures: string[] = [];
   let synthetic: SyntheticThread | null = null;
 
-  it.each(
-    corpusThreads.map((thread) => [thread.id, thread.provider] as const),
-  )(
+  it.each(corpusThreads.map((thread) => [thread.id, thread.provider] as const))(
     "%s (%s)",
     (threadId) => {
       synthetic ??= createSyntheticThread(SYNTHETIC_EVENT_COUNT);
@@ -404,7 +399,9 @@ describe.skipIf(!available)("provider corpus timeline perf baseline", () => {
       measured.set(threadId, outcome.result);
       attemptsByThread.set(threadId, outcome.attempts);
       for (const failure of outcome.failures) {
-        failures.push(`${threadId} (after ${outcome.attempts} attempts): ${failure}`);
+        failures.push(
+          `${threadId} (after ${outcome.attempts} attempts): ${failure}`,
+        );
       }
     },
     PER_THREAD_TIMEOUT_MS,
@@ -477,39 +474,35 @@ describe.skipIf(!available)("provider corpus timeline perf baseline", () => {
 });
 
 describe("timeline build micro-benchmark", () => {
-  it(
-    `projects every page of a ${SYNTHETIC_EVENT_COUNT}-event thread under ${SYNTHETIC_CEILING_MS} ms`,
-    () => {
-      const synthetic = createSyntheticThread(SYNTHETIC_EVENT_COUNT);
-      try {
-        expect(synthetic.eventCount).toBeGreaterThanOrEqual(
-          SYNTHETIC_EVENT_COUNT,
-        );
-        // The latest page alone is bounded by segment windowing, so the whole
-        // walk is what scales with the thread: every page, default variant,
-        // summed over the build profiles (SQLite reads, decode, projection,
-        // pagination) rather than wall time, so disk noise does not count.
-        const samples = sample(() => walkSynthetic(synthetic));
-        const durations = samples.map((pages) => sumProfileDurations(pages));
-        const p50 = percentile(durations, 0.5);
-        const last = samples[samples.length - 1];
-        if (last === undefined) {
-          throw new Error("no samples");
-        }
-        const rowsProjected = last.reduce(
-          (total, page) => total + page.profile.projectedRowCount,
-          0,
-        );
-        process.stdout.write(
-          `Synthetic ${synthetic.eventCount}-event thread: ${last.length} pages, ${rowsProjected} rows projected, ` +
-            `full walk p50 ${round(p50)} ms (samples ${durations.map((value) => round(value)).join(", ")})\n`,
-        );
-        expect(last.length).toBeGreaterThan(1);
-        expect(p50).toBeLessThan(SYNTHETIC_CEILING_MS);
-      } finally {
-        synthetic.close();
+  it(`projects every page of a ${SYNTHETIC_EVENT_COUNT}-event thread under ${SYNTHETIC_CEILING_MS} ms`, () => {
+    const synthetic = createSyntheticThread(SYNTHETIC_EVENT_COUNT);
+    try {
+      expect(synthetic.eventCount).toBeGreaterThanOrEqual(
+        SYNTHETIC_EVENT_COUNT,
+      );
+      // The latest page alone is bounded by segment windowing, so the whole
+      // walk is what scales with the thread: every page, default variant,
+      // summed over the build profiles (SQLite reads, decode, projection,
+      // pagination) rather than wall time, so disk noise does not count.
+      const samples = sample(() => walkSynthetic(synthetic));
+      const durations = samples.map((pages) => sumProfileDurations(pages));
+      const p50 = percentile(durations, 0.5);
+      const last = samples[samples.length - 1];
+      if (last === undefined) {
+        throw new Error("no samples");
       }
-    },
-    120_000,
-  );
+      const rowsProjected = last.reduce(
+        (total, page) => total + page.profile.projectedRowCount,
+        0,
+      );
+      process.stdout.write(
+        `Synthetic ${synthetic.eventCount}-event thread: ${last.length} pages, ${rowsProjected} rows projected, ` +
+          `full walk p50 ${round(p50)} ms (samples ${durations.map((value) => round(value)).join(", ")})\n`,
+      );
+      expect(last.length).toBeGreaterThan(1);
+      expect(p50).toBeLessThan(SYNTHETIC_CEILING_MS);
+    } finally {
+      synthetic.close();
+    }
+  }, 120_000);
 });

--- a/apps/server/test/provider-corpus/timeline-perf.test.ts
+++ b/apps/server/test/provider-corpus/timeline-perf.test.ts
@@ -40,7 +40,7 @@ import {
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { z } from "zod";
 import type { ProviderRegistryService } from "../../src/services/providers/provider-registry.js";
-import type { ThreadTimelineBuildProfileStage } from "../../src/services/threads/timeline.js";
+import type { ThreadTimelineBuildProfile } from "../../src/services/threads/timeline.js";
 import { createTestProviderRegistry } from "../helpers/provider-registry.js";
 import {
   buildAllRouteTimelinePages,
@@ -94,6 +94,9 @@ const CALIBRATION_KIND = "json-sort-v1";
  */
 const SYNTHETIC_EVENT_COUNT = 10_000;
 const SYNTHETIC_CEILING_MS = 1_500;
+
+type ThreadTimelineBuildProfileStage =
+  ThreadTimelineBuildProfile["stageTimings"][number]["stage"];
 
 const STAGES: readonly ThreadTimelineBuildProfileStage[] = [
   "event-query",

--- a/docs/debugging-and-qa.md
+++ b/docs/debugging-and-qa.md
@@ -155,11 +155,20 @@ covers nothing fails the run because it is stale. Refresh the baseline with
 `write` only when the diff is the intended behavior change, in the PR that
 makes it, and remove the allowlist entries it absorbs.
 
-Perf compare mode passes when each thread's normalized minimum (thread build
-minimum over calibration minimum) is within 10% of the baseline, or within
-5 ms of intrinsic cost for the small latest-page builds, and the median event
-size is within 15%. Each thread gets up to three attempts so a burst of load
-does not fail the run; raw p50/p95 are printed for information.
+Perf compare mode passes when each thread's normalized cost is within 10% of
+the baseline (or within 5 ms of intrinsic cost for the small latest-page
+builds) and the median event size is within 15%. The normalized cost is the
+minimum build time over five samples divided by the minimum time of a fixed
+CPU workload (JSON codec and sorting over a deterministic document) run once
+per sample right before the builds. The workload shares no code with the
+timeline, so a uniform timeline regression still moves the ratio, while
+machine speed and steady load cancel. Each thread gets up to three attempts so
+a burst of load does not fail the run (write mode keeps the median attempt);
+raw p50/p95 are printed for information. The
+baseline records the gate settings and compare mode refuses a baseline
+written with different ones. Run the gate on a machine whose load average is
+below its core count: when the machine is oversubscribed the table header
+says so and even paired ratios drift by 10–20%.
 
 ## Local Cloud
 

--- a/docs/debugging-and-qa.md
+++ b/docs/debugging-and-qa.md
@@ -85,6 +85,72 @@ payloads. Use it to reproduce performance problems that only appear at scale.
   deletes the database file first. Without `--reset` the fixture appends.
 - Example: `pnpm seed:perf -- --reset --events 400000`.
 
+## Provider Corpus
+
+The provider corpus is a private set of real production threads (307 threads,
+330,626 event rows, extracted from a personal `~/.bb/bb.db`). It is the
+regression oracle for the provider-plugin migration: every layer must project
+the same rows and build timelines at the same speed. The corpus contains real
+prompts, code, and paths, so it is **never committed**; `.gitignore` blocks
+every `provider-corpus/` directory except the in-repo harness and scripts.
+
+- Location: `~/.bb/provider-corpus/` by default. Tests read it through
+  `BB_PROVIDER_CORPUS_DIR` and skip when the variable is unset or the directory
+  has no `manifest.json`, so CI and fresh checkouts stay green.
+- Layout: `manifest.json` (thread selection and reasons), `profile.json`,
+  `threads/<provider>/<threadId>/{meta.json,events.ndjson}`, and the generated
+  `snapshots/` directory described below.
+- Reader: `@bb/test-helpers` exports `corpusAvailable()`,
+  `listCorpusThreads({ provider?, reasons? })`, and `loadCorpusThread(id)`.
+  Event rows decode through the same `parseStoredThreadEvent` the server uses.
+
+Gates under `apps/server/test/provider-corpus/`:
+
+- `row-snapshots.test.ts` loads each thread into in-memory SQLite and projects
+  every timeline page the way `GET /threads/:id/timeline` does (default and
+  nested variants), then compares the rows with
+  `snapshots/rows/<provider>/<threadId>.json`.
+- `timeline-perf.test.ts` measures the 10 largest threads per provider (latest
+  page and full page walk, five builds each, calibrated against a synthetic
+  thread built in the same run) and compares with `snapshots/perf-baseline.json`.
+  The CI micro-benchmark in the same file needs no corpus.
+
+Run them:
+
+```bash
+scripts/provider-corpus/snapshot-rows.sh compare   # default mode, fails on diffs
+scripts/provider-corpus/snapshot-rows.sh write     # refresh the baseline
+```
+
+The script wraps `pnpm exec turbo run test:provider-corpus --filter=@bb/server`
+with `BB_PROVIDER_CORPUS_SNAPSHOT=write|compare`. Turbo strips undeclared
+variables, so use that task (not the package `test` task) when you set the
+corpus variables. Each run writes `snapshots/rows-last-run.json` and
+`snapshots/perf-last-run.md` with totals and the perf table.
+
+Compare mode fails on any row diff that `snapshots/allowlist.json` does not
+cover. An entry names a scope, a path, and the PR that made the change:
+
+```json
+[
+  { "threadId": "thr_abc123", "path": "/variants/*/pages/*/rows/*/output", "pr": "#1234", "reason": "…" },
+  { "provider": "codex", "path": "/variants/default/pages/**/planSteps", "pr": "#1235", "reason": "…" },
+  { "*": true, "path": "/variants/**/maxSeq", "pr": "#1236", "reason": "…" }
+]
+```
+
+`path` is a JSON pointer over the snapshot, or a glob where `*` matches one
+segment and `**` any number. The run prints the entries it used; an entry that
+covers nothing fails the run because it is stale. Refresh the baseline with
+`write` only when the diff is the intended behavior change, in the PR that
+makes it, and remove the allowlist entries it absorbs.
+
+Perf compare mode passes when each thread's normalized minimum (thread build
+minimum over calibration minimum) is within 10% of the baseline, or within
+5 ms of intrinsic cost for the small latest-page builds, and the median event
+size is within 15%. Each thread gets up to three attempts so a burst of load
+does not fail the run; raw p50/p95 are printed for information.
+
 ## Local Cloud
 
 Run the Cloud dashboard and Connect worker against one local D1 database:

--- a/docs/debugging-and-qa.md
+++ b/docs/debugging-and-qa.md
@@ -133,8 +133,18 @@ cover. An entry names a scope, a path, and the PR that made the change:
 
 ```json
 [
-  { "threadId": "thr_abc123", "path": "/variants/*/pages/*/rows/*/output", "pr": "#1234", "reason": "…" },
-  { "provider": "codex", "path": "/variants/default/pages/**/planSteps", "pr": "#1235", "reason": "…" },
+  {
+    "threadId": "thr_abc123",
+    "path": "/variants/*/pages/*/rows/*/output",
+    "pr": "#1234",
+    "reason": "…"
+  },
+  {
+    "provider": "codex",
+    "path": "/variants/default/pages/**/planSteps",
+    "pr": "#1235",
+    "reason": "…"
+  },
   { "*": true, "path": "/variants/**/maxSeq", "pr": "#1236", "reason": "…" }
 ]
 ```

--- a/packages/agent-runtime/src/permission-matrix.test.ts
+++ b/packages/agent-runtime/src/permission-matrix.test.ts
@@ -11,6 +11,11 @@
  * for every cell today; a row that changes is a behavior change that needs a
  * PR of its own.
  *
+ * The request travels the real path: a canonical `interaction/request` is
+ * decoded by the bridge-protocol adapter built for the scripted echo bridge
+ * (the same adapter every plugin bridge gets), whose initialize handshake sets
+ * `approvalEnforcedBy`, and a pipe child echoes the runtime's answer back.
+ *
  * Outcomes:
  * - `forward`   the request reaches `onInteractiveRequest` (the user decides)
  * - `auto-deny` the runtime answers `deny` without asking
@@ -20,7 +25,7 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import readline from "node:readline";
 import {
-  pendingInteractionApprovalSubjectSchema,
+  pendingInteractionPayloadSchema,
   permissionEscalationValues,
   permissionModeValues,
   runtimePermissionPolicySchema,
@@ -38,17 +43,16 @@ import {
   parseJsonRpcLine,
   shouldAutoDenyInteractiveRequest,
 } from "@bb/provider-bridge-protocol/bridge-kit";
-import type {
-  DecodedInteractiveRequest,
-  JsonRpcMessage,
-  ProviderInboundRequest,
-} from "@bb/provider-bridge-protocol/bridge-kit";
+import type { JsonRpcMessage } from "@bb/provider-bridge-protocol/bridge-kit";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
-import type { ProviderAdapter } from "./provider-adapter.js";
+import type { BridgeProtocolAdapter } from "./bridge-protocol-adapter.js";
+import { createProviderForId } from "./provider-registry.js";
 import { handleRuntimeProviderRequest } from "./runtime-provider-requests.js";
-import { createFakeAdapter } from "./test/fake-adapter.js";
-import { fullRuntimeOptions } from "./test/runtime-test-harness.js";
+import {
+  createScriptedEchoLaunch,
+  fullRuntimeOptions,
+} from "./test/runtime-test-harness.js";
 import type { AgentRuntimeExecutionOptions } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -73,6 +77,7 @@ const SUBJECT_KINDS = [
   "file_change",
   "permission_grant",
   "plan",
+  "tool_use",
 ] as const;
 type SubjectKind = (typeof SUBJECT_KINDS)[number];
 
@@ -87,7 +92,7 @@ type CellKey = `${PolicyKey}|${SubjectKind}|${Enforcer}|${DenyAvailability}`;
 type Outcome = "forward" | "auto-deny" | "encode-error";
 
 // ---------------------------------------------------------------------------
-// The pinned matrix (80 cells)
+// The pinned matrix (100 cells)
 // ---------------------------------------------------------------------------
 
 /**
@@ -95,6 +100,10 @@ type Outcome = "forward" | "auto-deny" | "encode-error";
  * runtime enforce policy AND the turn's escalation is `deny`. Permission mode
  * on its own never auto-decides anything here; `full` has no escalation at all.
  * The subject kind never matters to the runtime.
+ *
+ * The first 80 cells are the pin taken on `main` before the v3 contract; the
+ * `tool_use` cells were added when that contract added the subject (no bridge
+ * produces it until WS5) and were measured the same way.
  */
 const EXPECTED = {
   // accept-edits, escalation ask
@@ -165,6 +174,26 @@ const EXPECTED = {
   "auto/deny|plan|runtime|deny-unavailable": "encode-error",
   "auto/deny|plan|provider|deny-available": "forward",
   "auto/deny|plan|provider|deny-unavailable": "forward",
+  "accept-edits/ask|tool_use|runtime|deny-available": "forward",
+  "accept-edits/ask|tool_use|runtime|deny-unavailable": "forward",
+  "accept-edits/ask|tool_use|provider|deny-available": "forward",
+  "accept-edits/ask|tool_use|provider|deny-unavailable": "forward",
+  "accept-edits/deny|tool_use|runtime|deny-available": "auto-deny",
+  "accept-edits/deny|tool_use|runtime|deny-unavailable": "encode-error",
+  "accept-edits/deny|tool_use|provider|deny-available": "forward",
+  "accept-edits/deny|tool_use|provider|deny-unavailable": "forward",
+  "auto/ask|tool_use|runtime|deny-available": "forward",
+  "auto/ask|tool_use|runtime|deny-unavailable": "forward",
+  "auto/ask|tool_use|provider|deny-available": "forward",
+  "auto/ask|tool_use|provider|deny-unavailable": "forward",
+  "auto/deny|tool_use|runtime|deny-available": "auto-deny",
+  "auto/deny|tool_use|runtime|deny-unavailable": "encode-error",
+  "auto/deny|tool_use|provider|deny-available": "forward",
+  "auto/deny|tool_use|provider|deny-unavailable": "forward",
+  "full/-|tool_use|runtime|deny-available": "forward",
+  "full/-|tool_use|runtime|deny-unavailable": "forward",
+  "full/-|tool_use|provider|deny-available": "forward",
+  "full/-|tool_use|provider|deny-unavailable": "forward",
   // full (no escalation)
   "full/-|command|runtime|deny-available": "forward",
   "full/-|command|runtime|deny-unavailable": "forward",
@@ -205,7 +234,7 @@ const subjectKindCoversUnion: SameUnion<
 > = true;
 const enforcerCoversUnion: SameUnion<
   Enforcer,
-  ProviderAdapter["approvalEnforcedBy"]
+  BridgeProtocolAdapter["approvalEnforcedBy"]
 > = true;
 const permissionModeCoversUnion: SameUnion<
   PolicyKey extends `${infer Mode}/${string}` ? Mode : never,
@@ -280,6 +309,16 @@ function subjectFor(kind: SubjectKind): PendingInteractionApprovalSubject {
         plan: "1. Do the thing",
         planFilePath: null,
       };
+    case "tool_use":
+      return {
+        kind,
+        itemId: "item-tool-use",
+        tool: "mcp__example__deploy",
+        presentation: {
+          label: { pending: "Deploying", completed: "Deployed" },
+          icon: { glyph: "rocket" },
+        },
+      };
   }
 }
 
@@ -303,29 +342,45 @@ function buildPayload(
   };
 }
 
-function adapterFor(
-  enforcer: Enforcer,
+/**
+ * The adapter every plugin bridge gets, built for the scripted echo launch,
+ * after an initialize handshake that sets where approvals are enforced.
+ */
+function adapterFor(enforcer: Enforcer): BridgeProtocolAdapter {
+  const adapter = createProviderForId("fake", {
+    additionalWorkspaceWriteRoots: [],
+    bridgeLaunch: createScriptedEchoLaunch(),
+  });
+  const [initialize] = adapter.buildPostInitializeRequests();
+  if (initialize === undefined) {
+    throw new Error("bridge adapter exposes no initialize handshake");
+  }
+  initialize.onResult({
+    protocolVersion: 2,
+    capabilities: { grammarVersions: [3, 3], approvalEnforcedBy: enforcer },
+  });
+  if (adapter.approvalEnforcedBy !== enforcer) {
+    throw new Error(
+      `handshake did not set approvalEnforcedBy=${enforcer} (got ${adapter.approvalEnforcedBy})`,
+    );
+  }
+  return adapter;
+}
+
+/** A canonical `interaction/request`, as a bridge sends it on the wire. */
+function interactionRequest(
+  id: number,
   payload: ApprovalPendingInteractionPayload,
-): ProviderAdapter {
+): JsonRpcMessage {
   return {
-    ...createFakeAdapter(),
-    approvalEnforcedBy: enforcer,
-    decodeInteractiveRequest(
-      request: ProviderInboundRequest,
-    ): DecodedInteractiveRequest | null {
-      if (
-        request.method !== "matrix/approval" ||
-        (typeof request.id !== "string" && typeof request.id !== "number")
-      ) {
-        return null;
-      }
-      return {
-        requestId: request.id,
-        method: request.method,
-        providerThreadId: "provider-thread",
-        turnId: "turn-1",
-        payload,
-      };
+    jsonrpc: "2.0",
+    id,
+    method: "interaction/request",
+    params: {
+      providerThreadId: "prov-1",
+      threadId: "thread-1",
+      turnId: "turn-1",
+      payload,
     },
   };
 }
@@ -402,12 +457,7 @@ async function runCell(
     ...fullRuntimeOptions,
     ...policyFor(policyKey),
   };
-  const rawRequest = {
-    jsonrpc: "2.0",
-    id: requestId,
-    method: "matrix/approval",
-    params: {},
-  } satisfies JsonRpcMessage;
+  const rawRequest = interactionRequest(requestId, payload);
   handleRuntimeProviderRequest({
     getActiveTurnId: () => "turn-1",
     getThreadExecutionOptions: () => executionOptions,
@@ -416,10 +466,10 @@ async function runCell(
       contentItems: [{ type: "inputText", text: "unused" }],
       success: true,
     }),
-    parsedId: rawRequest.id,
+    parsedId: requestId,
     parsedMethod: rawRequest.method,
     providerProcess: {
-      adapter: adapterFor(enforcer, payload),
+      adapter: adapterFor(enforcer),
       child: echo.child,
       interactiveRequestScope: `matrix-${requestId}`,
     },
@@ -476,10 +526,16 @@ const CELLS = POLICY_KEYS.flatMap((policyKey) =>
 
 describe("permission decision matrix", () => {
   it("enumerates every cell of the cross product", () => {
-    const subjectKindsInSchema = pendingInteractionApprovalSubjectSchema.options
-      .map((option) => option.shape.kind.value)
-      .sort();
-    expect(subjectKindsInSchema).toEqual([...SUBJECT_KINDS].sort());
+    // The subject union is private to the domain; every local kind must be a
+    // member (the type-level SameUnion guard above proves there are no others).
+    for (const kind of SUBJECT_KINDS) {
+      expect(
+        pendingInteractionPayloadSchema.safeParse(
+          buildPayload(kind, "deny-available"),
+        ).success,
+        `subject kind ${kind}`,
+      ).toBe(true);
+    }
     expect(
       bridgeCapabilitiesSchema.shape.approvalEnforcedBy.def.innerType.options,
     ).toEqual([...ENFORCERS]);
@@ -492,7 +548,7 @@ describe("permission decision matrix", () => {
         ENFORCERS.length *
         DENY_AVAILABILITY.length,
     );
-    expect(CELLS).toHaveLength(80);
+    expect(CELLS).toHaveLength(100);
   });
 
   it("pins the bridge-kit predicate: only escalation=deny auto-denies", () => {

--- a/packages/agent-runtime/src/permission-matrix.test.ts
+++ b/packages/agent-runtime/src/permission-matrix.test.ts
@@ -1,0 +1,540 @@
+/**
+ * A5 / G12 — the permission-decision matrix, pinned before the provider-plugin
+ * migration changes any of the unions involved.
+ *
+ * The runtime decides an approval request in exactly one place:
+ * `handleRuntimeProviderRequest` (runtime-provider-requests.ts), which defers
+ * to the bridge kit's `shouldAutoDenyInteractiveRequest`. Every other input the
+ * server could vary (permission mode, subject, the provider's `approvalEnforcedBy`)
+ * either reaches that function or is translated into provider-native settings
+ * that the provider enforces itself. The matrix below is the literal outcome
+ * for every cell today; a row that changes is a behavior change that needs a
+ * PR of its own.
+ *
+ * Outcomes:
+ * - `forward`   the request reaches `onInteractiveRequest` (the user decides)
+ * - `auto-deny` the runtime answers `deny` without asking
+ * - `encode-error` the runtime wanted to auto-deny but `deny` is not an
+ *   available decision, so the provider gets a JSON-RPC error instead
+ */
+import { spawn, type ChildProcess } from "node:child_process";
+import readline from "node:readline";
+import {
+  pendingInteractionApprovalSubjectSchema,
+  permissionEscalationValues,
+  permissionModeValues,
+  runtimePermissionPolicySchema,
+} from "@bb/domain";
+import type {
+  ApprovalPendingInteractionPayload,
+  PendingInteractionApprovalDecision,
+  PendingInteractionApprovalSubject,
+  PermissionEscalation,
+  PermissionMode,
+  RuntimePermissionPolicy,
+} from "@bb/domain";
+import { bridgeCapabilitiesSchema } from "@bb/provider-bridge-protocol";
+import {
+  parseJsonRpcLine,
+  shouldAutoDenyInteractiveRequest,
+} from "@bb/provider-bridge-protocol/bridge-kit";
+import type {
+  DecodedInteractiveRequest,
+  JsonRpcMessage,
+  ProviderInboundRequest,
+} from "@bb/provider-bridge-protocol/bridge-kit";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import type { ProviderAdapter } from "./provider-adapter.js";
+import { handleRuntimeProviderRequest } from "./runtime-provider-requests.js";
+import { createFakeAdapter } from "./test/fake-adapter.js";
+import { fullRuntimeOptions } from "./test/runtime-test-harness.js";
+import type { AgentRuntimeExecutionOptions } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Dimensions
+// ---------------------------------------------------------------------------
+
+/**
+ * The policy union is a discriminated union on permissionMode: accept-edits and
+ * auto carry an escalation, full carries null. These five are every member.
+ */
+const POLICY_KEYS = [
+  "accept-edits/ask",
+  "accept-edits/deny",
+  "auto/ask",
+  "auto/deny",
+  "full/-",
+] as const;
+type PolicyKey = (typeof POLICY_KEYS)[number];
+
+const SUBJECT_KINDS = [
+  "command",
+  "file_change",
+  "permission_grant",
+  "plan",
+] as const;
+type SubjectKind = (typeof SUBJECT_KINDS)[number];
+
+const ENFORCERS = ["runtime", "provider"] as const;
+type Enforcer = (typeof ENFORCERS)[number];
+
+const DENY_AVAILABILITY = ["deny-available", "deny-unavailable"] as const;
+type DenyAvailability = (typeof DENY_AVAILABILITY)[number];
+
+type CellKey = `${PolicyKey}|${SubjectKind}|${Enforcer}|${DenyAvailability}`;
+
+type Outcome = "forward" | "auto-deny" | "encode-error";
+
+// ---------------------------------------------------------------------------
+// The pinned matrix (80 cells)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read this as: the runtime auto-denies only when the provider lets the
+ * runtime enforce policy AND the turn's escalation is `deny`. Permission mode
+ * on its own never auto-decides anything here; `full` has no escalation at all.
+ * The subject kind never matters to the runtime.
+ */
+const EXPECTED = {
+  // accept-edits, escalation ask
+  "accept-edits/ask|command|runtime|deny-available": "forward",
+  "accept-edits/ask|command|runtime|deny-unavailable": "forward",
+  "accept-edits/ask|command|provider|deny-available": "forward",
+  "accept-edits/ask|command|provider|deny-unavailable": "forward",
+  "accept-edits/ask|file_change|runtime|deny-available": "forward",
+  "accept-edits/ask|file_change|runtime|deny-unavailable": "forward",
+  "accept-edits/ask|file_change|provider|deny-available": "forward",
+  "accept-edits/ask|file_change|provider|deny-unavailable": "forward",
+  "accept-edits/ask|permission_grant|runtime|deny-available": "forward",
+  "accept-edits/ask|permission_grant|runtime|deny-unavailable": "forward",
+  "accept-edits/ask|permission_grant|provider|deny-available": "forward",
+  "accept-edits/ask|permission_grant|provider|deny-unavailable": "forward",
+  "accept-edits/ask|plan|runtime|deny-available": "forward",
+  "accept-edits/ask|plan|runtime|deny-unavailable": "forward",
+  "accept-edits/ask|plan|provider|deny-available": "forward",
+  "accept-edits/ask|plan|provider|deny-unavailable": "forward",
+  // accept-edits, escalation deny
+  "accept-edits/deny|command|runtime|deny-available": "auto-deny",
+  "accept-edits/deny|command|runtime|deny-unavailable": "encode-error",
+  "accept-edits/deny|command|provider|deny-available": "forward",
+  "accept-edits/deny|command|provider|deny-unavailable": "forward",
+  "accept-edits/deny|file_change|runtime|deny-available": "auto-deny",
+  "accept-edits/deny|file_change|runtime|deny-unavailable": "encode-error",
+  "accept-edits/deny|file_change|provider|deny-available": "forward",
+  "accept-edits/deny|file_change|provider|deny-unavailable": "forward",
+  "accept-edits/deny|permission_grant|runtime|deny-available": "auto-deny",
+  "accept-edits/deny|permission_grant|runtime|deny-unavailable": "encode-error",
+  "accept-edits/deny|permission_grant|provider|deny-available": "forward",
+  "accept-edits/deny|permission_grant|provider|deny-unavailable": "forward",
+  "accept-edits/deny|plan|runtime|deny-available": "auto-deny",
+  "accept-edits/deny|plan|runtime|deny-unavailable": "encode-error",
+  "accept-edits/deny|plan|provider|deny-available": "forward",
+  "accept-edits/deny|plan|provider|deny-unavailable": "forward",
+  // auto, escalation ask
+  "auto/ask|command|runtime|deny-available": "forward",
+  "auto/ask|command|runtime|deny-unavailable": "forward",
+  "auto/ask|command|provider|deny-available": "forward",
+  "auto/ask|command|provider|deny-unavailable": "forward",
+  "auto/ask|file_change|runtime|deny-available": "forward",
+  "auto/ask|file_change|runtime|deny-unavailable": "forward",
+  "auto/ask|file_change|provider|deny-available": "forward",
+  "auto/ask|file_change|provider|deny-unavailable": "forward",
+  "auto/ask|permission_grant|runtime|deny-available": "forward",
+  "auto/ask|permission_grant|runtime|deny-unavailable": "forward",
+  "auto/ask|permission_grant|provider|deny-available": "forward",
+  "auto/ask|permission_grant|provider|deny-unavailable": "forward",
+  "auto/ask|plan|runtime|deny-available": "forward",
+  "auto/ask|plan|runtime|deny-unavailable": "forward",
+  "auto/ask|plan|provider|deny-available": "forward",
+  "auto/ask|plan|provider|deny-unavailable": "forward",
+  // auto, escalation deny
+  "auto/deny|command|runtime|deny-available": "auto-deny",
+  "auto/deny|command|runtime|deny-unavailable": "encode-error",
+  "auto/deny|command|provider|deny-available": "forward",
+  "auto/deny|command|provider|deny-unavailable": "forward",
+  "auto/deny|file_change|runtime|deny-available": "auto-deny",
+  "auto/deny|file_change|runtime|deny-unavailable": "encode-error",
+  "auto/deny|file_change|provider|deny-available": "forward",
+  "auto/deny|file_change|provider|deny-unavailable": "forward",
+  "auto/deny|permission_grant|runtime|deny-available": "auto-deny",
+  "auto/deny|permission_grant|runtime|deny-unavailable": "encode-error",
+  "auto/deny|permission_grant|provider|deny-available": "forward",
+  "auto/deny|permission_grant|provider|deny-unavailable": "forward",
+  "auto/deny|plan|runtime|deny-available": "auto-deny",
+  "auto/deny|plan|runtime|deny-unavailable": "encode-error",
+  "auto/deny|plan|provider|deny-available": "forward",
+  "auto/deny|plan|provider|deny-unavailable": "forward",
+  // full (no escalation)
+  "full/-|command|runtime|deny-available": "forward",
+  "full/-|command|runtime|deny-unavailable": "forward",
+  "full/-|command|provider|deny-available": "forward",
+  "full/-|command|provider|deny-unavailable": "forward",
+  "full/-|file_change|runtime|deny-available": "forward",
+  "full/-|file_change|runtime|deny-unavailable": "forward",
+  "full/-|file_change|provider|deny-available": "forward",
+  "full/-|file_change|provider|deny-unavailable": "forward",
+  "full/-|permission_grant|runtime|deny-available": "forward",
+  "full/-|permission_grant|runtime|deny-unavailable": "forward",
+  "full/-|permission_grant|provider|deny-available": "forward",
+  "full/-|permission_grant|provider|deny-unavailable": "forward",
+  "full/-|plan|runtime|deny-available": "forward",
+  "full/-|plan|runtime|deny-unavailable": "forward",
+  "full/-|plan|provider|deny-available": "forward",
+  "full/-|plan|provider|deny-unavailable": "forward",
+} satisfies Record<CellKey, Outcome>;
+
+// ---------------------------------------------------------------------------
+// Exhaustiveness: the local dimension arrays must equal the domain unions
+// ---------------------------------------------------------------------------
+
+/** Resolves to `true` only when `A` and `B` are the same union. */
+type SameUnion<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+const policyKeyCoversPolicyUnion: SameUnion<
+  PolicyKey,
+  `${Extract<RuntimePermissionPolicy, { permissionEscalation: PermissionEscalation }>["permissionMode"]}/${PermissionEscalation}` |
+    `${Extract<RuntimePermissionPolicy, { permissionEscalation: null }>["permissionMode"]}/-`
+> = true;
+const subjectKindCoversUnion: SameUnion<
+  SubjectKind,
+  PendingInteractionApprovalSubject["kind"]
+> = true;
+const enforcerCoversUnion: SameUnion<
+  Enforcer,
+  ProviderAdapter["approvalEnforcedBy"]
+> = true;
+const permissionModeCoversUnion: SameUnion<
+  PolicyKey extends `${infer Mode}/${string}` ? Mode : never,
+  PermissionMode
+> = true;
+void policyKeyCoversPolicyUnion;
+void subjectKindCoversUnion;
+void enforcerCoversUnion;
+void permissionModeCoversUnion;
+
+// ---------------------------------------------------------------------------
+// Cell construction
+// ---------------------------------------------------------------------------
+
+function policyFor(key: PolicyKey): RuntimePermissionPolicy {
+  switch (key) {
+    case "accept-edits/ask":
+    case "accept-edits/deny":
+      return {
+        permissionMode: "accept-edits",
+        permissionScope: "workspace",
+        approvalReviewer: "user",
+        permissionEscalation: key === "accept-edits/ask" ? "ask" : "deny",
+      };
+    case "auto/ask":
+    case "auto/deny":
+      return {
+        permissionMode: "auto",
+        permissionScope: "workspace",
+        approvalReviewer: "automatic",
+        permissionEscalation: key === "auto/ask" ? "ask" : "deny",
+      };
+    case "full/-":
+      return {
+        permissionMode: "full",
+        permissionScope: "full",
+        approvalReviewer: null,
+        permissionEscalation: null,
+      };
+  }
+}
+
+function subjectFor(kind: SubjectKind): PendingInteractionApprovalSubject {
+  switch (kind) {
+    case "command":
+      return {
+        kind,
+        itemId: "item-command",
+        command: "git push",
+        cwd: "/workspace",
+        actions: [],
+        sessionGrant: null,
+      };
+    case "file_change":
+      return {
+        kind,
+        itemId: "item-file-change",
+        writeScope: null,
+        sessionGrant: null,
+      };
+    case "permission_grant":
+      return {
+        kind,
+        itemId: "item-permission-grant",
+        toolName: "WebFetch",
+        permissions: { network: { enabled: true }, fileSystem: null },
+      };
+    case "plan":
+      return {
+        kind,
+        itemId: "item-plan",
+        plan: "1. Do the thing",
+        planFilePath: null,
+      };
+  }
+}
+
+function decisionsFor(
+  availability: DenyAvailability,
+): PendingInteractionApprovalDecision[] {
+  return availability === "deny-available"
+    ? ["allow_once", "allow_for_session", "deny"]
+    : ["allow_once", "allow_for_session"];
+}
+
+function buildPayload(
+  kind: SubjectKind,
+  availability: DenyAvailability,
+): ApprovalPendingInteractionPayload {
+  return {
+    kind: "approval",
+    subject: subjectFor(kind),
+    reason: null,
+    availableDecisions: decisionsFor(availability),
+  };
+}
+
+function adapterFor(
+  enforcer: Enforcer,
+  payload: ApprovalPendingInteractionPayload,
+): ProviderAdapter {
+  return {
+    ...createFakeAdapter(),
+    approvalEnforcedBy: enforcer,
+    decodeInteractiveRequest(
+      request: ProviderInboundRequest,
+    ): DecodedInteractiveRequest | null {
+      if (
+        request.method !== "matrix/approval" ||
+        (typeof request.id !== "string" && typeof request.id !== "number")
+      ) {
+        return null;
+      }
+      return {
+        requestId: request.id,
+        method: request.method,
+        providerThreadId: "provider-thread",
+        turnId: "turn-1",
+        payload,
+      };
+    },
+  };
+}
+
+const jsonRpcResponseSchema = z.union([
+  z.object({ result: z.object({ decision: z.string() }).passthrough() }),
+  z.object({ error: z.object({ message: z.string() }).passthrough() }),
+]);
+type JsonRpcResponse = z.infer<typeof jsonRpcResponseSchema>;
+
+interface CellResult {
+  forwarded: number;
+  response: JsonRpcResponse;
+}
+
+interface EchoChild {
+  child: ChildProcess;
+  nextLine(): Promise<string>;
+}
+
+function startEchoChild(): EchoChild {
+  const child = spawn(process.execPath, [
+    "-e",
+    "process.stdin.pipe(process.stdout)",
+  ]);
+  if (!child.stdout) {
+    throw new Error("echo child has no stdout");
+  }
+  const lines: string[] = [];
+  const waiters: Array<(line: string) => void> = [];
+  readline.createInterface({ input: child.stdout }).on("line", (line) => {
+    const waiter = waiters.shift();
+    if (waiter) {
+      waiter(line);
+    } else {
+      lines.push(line);
+    }
+  });
+  return {
+    child,
+    nextLine: () => {
+      const queued = lines.shift();
+      if (queued !== undefined) {
+        return Promise.resolve(queued);
+      }
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error("no JSON-RPC response within 5s")),
+          5_000,
+        );
+        waiters.push((line) => {
+          clearTimeout(timer);
+          resolve(line);
+        });
+      });
+    },
+  };
+}
+
+async function runCell(
+  echo: EchoChild,
+  requestId: number,
+  policyKey: PolicyKey,
+  kind: SubjectKind,
+  enforcer: Enforcer,
+  availability: DenyAvailability,
+): Promise<CellResult> {
+  const payload = buildPayload(kind, availability);
+  const onInteractiveRequest = vi.fn(async () => ({
+    decision: "allow_once" as const,
+    grantedPermissions: null,
+  }));
+  const executionOptions: AgentRuntimeExecutionOptions = {
+    ...fullRuntimeOptions,
+    ...policyFor(policyKey),
+  };
+  const rawRequest = {
+    jsonrpc: "2.0",
+    id: requestId,
+    method: "matrix/approval",
+    params: {},
+  } satisfies JsonRpcMessage;
+  handleRuntimeProviderRequest({
+    getActiveTurnId: () => "turn-1",
+    getThreadExecutionOptions: () => executionOptions,
+    onInteractiveRequest,
+    onToolCall: async () => ({
+      contentItems: [{ type: "inputText", text: "unused" }],
+      success: true,
+    }),
+    parsedId: rawRequest.id,
+    parsedMethod: rawRequest.method,
+    providerProcess: {
+      adapter: adapterFor(enforcer, payload),
+      child: echo.child,
+      interactiveRequestScope: `matrix-${requestId}`,
+    },
+    rawRequest,
+    resolveThreadId: () => "thread-1",
+  });
+  const parsed = parseJsonRpcLine((await echo.nextLine()).trim());
+  if (parsed.kind !== "response") {
+    throw new Error(`expected a JSON-RPC response, got ${parsed.kind}`);
+  }
+  return {
+    forwarded: onInteractiveRequest.mock.calls.length,
+    response: jsonRpcResponseSchema.parse(parsed.parsed),
+  };
+}
+
+function classify(result: CellResult): Outcome {
+  const { response } = result;
+  if ("error" in response) {
+    if (
+      response.error.message.includes(
+        "cannot be auto-denied because deny is unavailable",
+      )
+    ) {
+      return "encode-error";
+    }
+    throw new Error(`unexpected JSON-RPC error: ${response.error.message}`);
+  }
+  const { decision } = response.result;
+  if (decision === "deny" && result.forwarded === 0) {
+    return "auto-deny";
+  }
+  if (decision === "allow_once" && result.forwarded === 1) {
+    return "forward";
+  }
+  throw new Error(
+    `unclassifiable response ${JSON.stringify(response.result)} (forwarded ${result.forwarded})`,
+  );
+}
+
+const CELLS = POLICY_KEYS.flatMap((policyKey) =>
+  SUBJECT_KINDS.flatMap((kind) =>
+    ENFORCERS.flatMap((enforcer) =>
+      DENY_AVAILABILITY.map(
+        (availability) =>
+          [policyKey, kind, enforcer, availability] as const,
+      ),
+    ),
+  ),
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("permission decision matrix", () => {
+  it("enumerates every cell of the cross product", () => {
+    const subjectKindsInSchema = pendingInteractionApprovalSubjectSchema.options
+      .map((option) => option.shape.kind.value)
+      .sort();
+    expect(subjectKindsInSchema).toEqual([...SUBJECT_KINDS].sort());
+    expect(
+      bridgeCapabilitiesSchema.shape.approvalEnforcedBy.def.innerType.options,
+    ).toEqual([...ENFORCERS]);
+    expect(permissionEscalationValues).toEqual(["ask", "deny"]);
+    expect(permissionModeValues).toEqual(["accept-edits", "auto", "full"]);
+    expect(runtimePermissionPolicySchema.options).toHaveLength(3);
+    expect(Object.keys(EXPECTED)).toHaveLength(
+      POLICY_KEYS.length *
+        SUBJECT_KINDS.length *
+        ENFORCERS.length *
+        DENY_AVAILABILITY.length,
+    );
+    expect(CELLS).toHaveLength(80);
+  });
+
+  it("pins the bridge-kit predicate: only escalation=deny auto-denies", () => {
+    const escalations: (PermissionEscalation | null)[] = [
+      ...permissionEscalationValues,
+      null,
+    ];
+    expect(
+      escalations.map((permissionEscalation) => [
+        permissionEscalation,
+        shouldAutoDenyInteractiveRequest({ permissionEscalation }),
+      ]),
+    ).toEqual([
+      ["ask", false],
+      ["deny", true],
+      [null, false],
+    ]);
+  });
+
+  describe("handleRuntimeProviderRequest", () => {
+    let echo: EchoChild;
+    let nextRequestId = 1;
+
+    beforeAll(() => {
+      echo = startEchoChild();
+    });
+
+    afterAll(() => {
+      echo.child.kill();
+    });
+
+    it.each(CELLS)(
+      "%s × %s × %s × %s",
+      async (policyKey, kind, enforcer, availability) => {
+        const key: CellKey = `${policyKey}|${kind}|${enforcer}|${availability}`;
+        const result = await runCell(
+          echo,
+          nextRequestId++,
+          policyKey,
+          kind,
+          enforcer,
+          availability,
+        );
+        expect(classify(result)).toBe(EXPECTED[key]);
+      },
+    );
+  });
+});

--- a/packages/agent-runtime/src/permission-matrix.test.ts
+++ b/packages/agent-runtime/src/permission-matrix.test.ts
@@ -189,11 +189,15 @@ const EXPECTED = {
 // ---------------------------------------------------------------------------
 
 /** Resolves to `true` only when `A` and `B` are the same union. */
-type SameUnion<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+type SameUnion<A, B> = [A] extends [B]
+  ? [B] extends [A]
+    ? true
+    : false
+  : false;
 const policyKeyCoversPolicyUnion: SameUnion<
   PolicyKey,
-  `${Extract<RuntimePermissionPolicy, { permissionEscalation: PermissionEscalation }>["permissionMode"]}/${PermissionEscalation}` |
-    `${Extract<RuntimePermissionPolicy, { permissionEscalation: null }>["permissionMode"]}/-`
+  | `${Extract<RuntimePermissionPolicy, { permissionEscalation: PermissionEscalation }>["permissionMode"]}/${PermissionEscalation}`
+  | `${Extract<RuntimePermissionPolicy, { permissionEscalation: null }>["permissionMode"]}/-`
 > = true;
 const subjectKindCoversUnion: SameUnion<
   SubjectKind,
@@ -460,8 +464,7 @@ const CELLS = POLICY_KEYS.flatMap((policyKey) =>
   SUBJECT_KINDS.flatMap((kind) =>
     ENFORCERS.flatMap((enforcer) =>
       DENY_AVAILABILITY.map(
-        (availability) =>
-          [policyKey, kind, enforcer, availability] as const,
+        (availability) => [policyKey, kind, enforcer, availability] as const,
       ),
     ),
   ),

--- a/packages/test-helpers/src/index.ts
+++ b/packages/test-helpers/src/index.ts
@@ -11,3 +11,18 @@ export {
   makeWorkspaceStatus,
   makeWorkspaceWorkingTree,
 } from "./workspace-status.js";
+export {
+  PROVIDER_CORPUS_DIR_ENV,
+  corpusAvailable,
+  decodeCorpusStoredEventRow,
+  listCorpusThreads,
+  loadCorpusThread,
+  resolveProviderCorpusDir,
+} from "./provider-corpus.js";
+export type {
+  CorpusManifestThread,
+  CorpusStoredEventRow,
+  CorpusThread,
+  CorpusThreadRow,
+  ListCorpusThreadsArgs,
+} from "./provider-corpus.js";

--- a/packages/test-helpers/src/provider-corpus.ts
+++ b/packages/test-helpers/src/provider-corpus.ts
@@ -1,0 +1,315 @@
+/**
+ * Reader for the private provider corpus: real production threads extracted
+ * from a bb database for the provider-plugin migration regression gates.
+ *
+ * The corpus is never committed. Tests find it through
+ * `BB_PROVIDER_CORPUS_DIR` and must skip when it is absent
+ * (`describe.skipIf(!corpusAvailable())`). Layout:
+ *
+ *   manifest.json                          thread selection and reasons
+ *   threads/<provider>/<threadId>/meta.json      `threads` row + reasons
+ *   threads/<provider>/<threadId>/events.ndjson  raw `events` rows in order
+ *
+ * Event payloads decode through the same `@bb/domain` parser the server uses
+ * for stored rows, so a corpus thread that fails to load here would also fail
+ * to load in production.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import {
+  buildThreadEventRow,
+  parseStoredThreadEvent,
+  reasoningLevelSchema,
+  threadEventScopeKindSchema,
+  threadEventTypeSchema,
+  threadOriginKindSchema,
+  threadScope,
+  threadStatusSchema,
+  threadVisibilitySchema,
+  turnScope,
+} from "@bb/domain";
+import type { ThreadEventRow, ThreadEventScope } from "@bb/domain";
+import { z } from "zod";
+
+export const PROVIDER_CORPUS_DIR_ENV = "BB_PROVIDER_CORPUS_DIR";
+
+const corpusManifestThreadSchema = z.object({
+  id: z.string().min(1),
+  provider: z.string().min(1),
+  events: z.number().int().nonnegative(),
+  reasons: z.array(z.string().min(1)),
+});
+
+const corpusManifestSchema = z.object({
+  providers: z.array(z.string().min(1)),
+  threads: z.array(corpusManifestThreadSchema),
+});
+
+const corpusThreadRowSchema = z.object({
+  id: z.string().min(1),
+  provider_id: z.string().min(1),
+  title: z.string().nullable(),
+  status: threadStatusSchema,
+  created_at: z.number().int(),
+  updated_at: z.number().int(),
+  archived_at: z.number().int().nullable(),
+  deleted_at: z.number().int().nullable(),
+  parent_thread_id: z.string().nullable(),
+  origin_kind: threadOriginKindSchema.nullable(),
+  visibility: threadVisibilitySchema,
+  model_override: z.string().nullable(),
+  reasoning_level_override: reasoningLevelSchema.nullable(),
+});
+
+const corpusMetaSchema = z.object({
+  thread: corpusThreadRowSchema,
+  features: z.record(z.string(), z.union([z.number(), z.string()])),
+  reasons: z.array(z.string().min(1)),
+  event_rows: z.number().int().nonnegative(),
+});
+
+const corpusEventRowSchema = z.object({
+  id: z.string().min(1),
+  thread_id: z.string().min(1),
+  environment_id: z.string().nullable(),
+  scope_kind: threadEventScopeKindSchema,
+  turn_id: z.string().nullable(),
+  provider_thread_id: z.string().nullable(),
+  sequence: z.number().int().nonnegative(),
+  type: threadEventTypeSchema,
+  item_id: z.string().nullable(),
+  item_kind: z.string().nullable(),
+  data: z.string(),
+  created_at: z.number().int(),
+  parent_tool_call_id: z.string().nullable(),
+});
+
+export type CorpusManifestThread = z.infer<typeof corpusManifestThreadSchema>;
+
+/** The `threads` row as extracted, with the column subset the extractor kept. */
+export interface CorpusThreadRow {
+  id: string;
+  providerId: string;
+  title: string | null;
+  status: z.infer<typeof threadStatusSchema>;
+  createdAt: number;
+  updatedAt: number;
+  archivedAt: number | null;
+  deletedAt: number | null;
+  parentThreadId: string | null;
+  originKind: z.infer<typeof threadOriginKindSchema> | null;
+  visibility: z.infer<typeof threadVisibilitySchema>;
+  modelOverride: string | null;
+  reasoningLevelOverride: z.infer<typeof reasoningLevelSchema> | null;
+}
+
+/** One raw `events` row, column-for-column, ready to insert as stored. */
+export interface CorpusStoredEventRow {
+  id: string;
+  threadId: string;
+  environmentId: string | null;
+  scopeKind: z.infer<typeof threadEventScopeKindSchema>;
+  turnId: string | null;
+  providerThreadId: string | null;
+  sequence: number;
+  type: z.infer<typeof threadEventTypeSchema>;
+  itemId: string | null;
+  itemKind: string | null;
+  data: string;
+  createdAt: number;
+  parentToolCallId: string | null;
+}
+
+export interface CorpusThread {
+  id: string;
+  provider: string;
+  reasons: string[];
+  features: Record<string, number | string>;
+  thread: CorpusThreadRow;
+  /** Raw rows in sequence order, for inserting into a test database. */
+  eventRows: CorpusStoredEventRow[];
+  /** The same rows decoded with the server's stored-event parser. */
+  events: ThreadEventRow[];
+}
+
+export interface ListCorpusThreadsArgs {
+  provider?: string;
+  /** Keep threads whose manifest reasons include at least one of these. */
+  reasons?: readonly string[];
+}
+
+export function resolveProviderCorpusDir(
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  const value = env[PROVIDER_CORPUS_DIR_ENV];
+  if (value === undefined || value.trim().length === 0) {
+    return null;
+  }
+  return path.resolve(value);
+}
+
+export function corpusAvailable(env: NodeJS.ProcessEnv = process.env): boolean {
+  const dir = resolveProviderCorpusDir(env);
+  return dir !== null && fs.existsSync(path.join(dir, "manifest.json"));
+}
+
+function requireProviderCorpusDir(): string {
+  const dir = resolveProviderCorpusDir();
+  if (dir === null) {
+    throw new Error(
+      `${PROVIDER_CORPUS_DIR_ENV} is not set; guard the suite with corpusAvailable()`,
+    );
+  }
+  return dir;
+}
+
+function readJsonFile(filePath: string): unknown {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+export function listCorpusThreads(
+  args: ListCorpusThreadsArgs = {},
+): CorpusManifestThread[] {
+  const dir = requireProviderCorpusDir();
+  const manifest = corpusManifestSchema.parse(
+    readJsonFile(path.join(dir, "manifest.json")),
+  );
+  return manifest.threads.filter((thread) => {
+    if (args.provider !== undefined && thread.provider !== args.provider) {
+      return false;
+    }
+    if (
+      args.reasons !== undefined &&
+      !args.reasons.some((reason) => thread.reasons.includes(reason))
+    ) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function toCorpusThreadRow(
+  row: z.infer<typeof corpusThreadRowSchema>,
+): CorpusThreadRow {
+  return {
+    id: row.id,
+    providerId: row.provider_id,
+    title: row.title,
+    status: row.status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    archivedAt: row.archived_at,
+    deletedAt: row.deleted_at,
+    parentThreadId: row.parent_thread_id,
+    originKind: row.origin_kind,
+    visibility: row.visibility,
+    modelOverride: row.model_override,
+    reasoningLevelOverride: row.reasoning_level_override,
+  };
+}
+
+function toCorpusStoredEventRow(
+  row: z.infer<typeof corpusEventRowSchema>,
+): CorpusStoredEventRow {
+  return {
+    id: row.id,
+    threadId: row.thread_id,
+    environmentId: row.environment_id,
+    scopeKind: row.scope_kind,
+    turnId: row.turn_id,
+    providerThreadId: row.provider_thread_id,
+    sequence: row.sequence,
+    type: row.type,
+    itemId: row.item_id,
+    itemKind: row.item_kind,
+    data: row.data,
+    createdAt: row.created_at,
+    parentToolCallId: row.parent_tool_call_id,
+  };
+}
+
+function toStoredEventScope(row: CorpusStoredEventRow): ThreadEventScope {
+  if (row.scopeKind === "thread") {
+    return threadScope();
+  }
+  if (row.turnId === null) {
+    throw new Error(
+      `Corpus event ${row.id} (#${row.sequence}, ${row.type}) has turn scope without turn_id`,
+    );
+  }
+  return turnScope(row.turnId);
+}
+
+/**
+ * Decodes a raw row the way `apps/server` `parseStoredEventRow` does: the
+ * `data` JSON plus the scope columns go through `parseStoredThreadEvent`.
+ */
+export function decodeCorpusStoredEventRow(
+  row: CorpusStoredEventRow,
+): ThreadEventRow {
+  const scope = toStoredEventScope(row);
+  const data: unknown = JSON.parse(row.data);
+  if (data === null || typeof data !== "object" || Array.isArray(data)) {
+    throw new Error(
+      `Corpus event ${row.id} (#${row.sequence}, ${row.type}) has malformed data`,
+    );
+  }
+  const event = parseStoredThreadEvent({
+    type: row.type,
+    data: z.record(z.string(), z.unknown()).parse(data),
+    threadId: row.threadId,
+    providerThreadId: row.providerThreadId,
+    scope,
+  });
+  return buildThreadEventRow({
+    id: row.id,
+    scope,
+    threadId: row.threadId,
+    seq: row.sequence,
+    createdAt: row.createdAt,
+    event,
+  });
+}
+
+function findCorpusThreadDir(dir: string, threadId: string): string {
+  const threadsDir = path.join(dir, "threads");
+  for (const provider of fs.readdirSync(threadsDir)) {
+    const candidate = path.join(threadsDir, provider, threadId);
+    if (fs.existsSync(path.join(candidate, "meta.json"))) {
+      return candidate;
+    }
+  }
+  throw new Error(`Corpus thread ${threadId} not found under ${threadsDir}`);
+}
+
+export function loadCorpusThread(threadId: string): CorpusThread {
+  const dir = requireProviderCorpusDir();
+  const threadDir = findCorpusThreadDir(dir, threadId);
+  const meta = corpusMetaSchema.parse(
+    readJsonFile(path.join(threadDir, "meta.json")),
+  );
+  const ndjson = fs.readFileSync(path.join(threadDir, "events.ndjson"), "utf8");
+  const eventRows: CorpusStoredEventRow[] = [];
+  for (const line of ndjson.split("\n")) {
+    if (line.length === 0) {
+      continue;
+    }
+    eventRows.push(
+      toCorpusStoredEventRow(corpusEventRowSchema.parse(JSON.parse(line))),
+    );
+  }
+  if (eventRows.length !== meta.event_rows) {
+    throw new Error(
+      `Corpus thread ${threadId} has ${eventRows.length} event rows; meta.json says ${meta.event_rows}`,
+    );
+  }
+  return {
+    id: meta.thread.id,
+    provider: meta.thread.provider_id,
+    reasons: meta.reasons,
+    features: meta.features,
+    thread: toCorpusThreadRow(meta.thread),
+    eventRows,
+    events: eventRows.map((row) => decodeCorpusStoredEventRow(row)),
+  };
+}

--- a/packages/test-helpers/src/provider-corpus.ts
+++ b/packages/test-helpers/src/provider-corpus.ts
@@ -20,7 +20,6 @@ import {
   buildThreadEventRow,
   parseStoredThreadEvent,
   reasoningLevelSchema,
-  threadEventScopeKindSchema,
   threadEventTypeSchema,
   threadOriginKindSchema,
   threadScope,
@@ -28,8 +27,24 @@ import {
   threadVisibilitySchema,
   turnScope,
 } from "@bb/domain";
-import type { ThreadEventRow, ThreadEventScope } from "@bb/domain";
+import type {
+  ThreadEventRow,
+  ThreadEventScope,
+  ThreadEventScopeKind,
+} from "@bb/domain";
 import { z } from "zod";
+
+/** The `scope_kind` column; the domain keeps its enum schema private. */
+const corpusScopeKindSchema = z.enum(["thread", "turn"]);
+// Fails to compile if the domain's scope kinds ever diverge from this list.
+const corpusScopeKindCoversDomain: ThreadEventScopeKind extends z.infer<
+  typeof corpusScopeKindSchema
+>
+  ? z.infer<typeof corpusScopeKindSchema> extends ThreadEventScopeKind
+    ? true
+    : false
+  : false = true;
+void corpusScopeKindCoversDomain;
 
 export const PROVIDER_CORPUS_DIR_ENV = "BB_PROVIDER_CORPUS_DIR";
 
@@ -81,7 +96,7 @@ const corpusEventRowSchema = z.object({
   id: z.string().min(1),
   thread_id: z.string().min(1),
   environment_id: z.string().nullable(),
-  scope_kind: threadEventScopeKindSchema,
+  scope_kind: corpusScopeKindSchema,
   turn_id: z.string().nullable(),
   provider_thread_id: z.string().nullable(),
   sequence: z.number().int().nonnegative(),
@@ -117,7 +132,7 @@ export interface CorpusStoredEventRow {
   id: string;
   threadId: string;
   environmentId: string | null;
-  scopeKind: z.infer<typeof threadEventScopeKindSchema>;
+  scopeKind: ThreadEventScopeKind;
   turnId: string | null;
   providerThreadId: string | null;
   sequence: number;

--- a/packages/test-helpers/src/provider-corpus.ts
+++ b/packages/test-helpers/src/provider-corpus.ts
@@ -33,9 +33,18 @@ import { z } from "zod";
 
 export const PROVIDER_CORPUS_DIR_ENV = "BB_PROVIDER_CORPUS_DIR";
 
+/**
+ * Thread and provider ids name directories under the corpus and under the
+ * snapshot tree, so they must be single path segments: no separators, no
+ * `.`/`..`, nothing the filesystem could interpret.
+ */
+const corpusPathSegmentSchema = z
+  .string()
+  .regex(/^[A-Za-z0-9][A-Za-z0-9_-]*$/, "must be one safe path segment");
+
 const corpusManifestThreadSchema = z.object({
-  id: z.string().min(1),
-  provider: z.string().min(1),
+  id: corpusPathSegmentSchema,
+  provider: corpusPathSegmentSchema,
   events: z.number().int().nonnegative(),
   reasons: z.array(z.string().min(1)),
 });
@@ -46,8 +55,8 @@ const corpusManifestSchema = z.object({
 });
 
 const corpusThreadRowSchema = z.object({
-  id: z.string().min(1),
-  provider_id: z.string().min(1),
+  id: corpusPathSegmentSchema,
+  provider_id: corpusPathSegmentSchema,
   title: z.string().nullable(),
   status: threadStatusSchema,
   created_at: z.number().int(),
@@ -271,36 +280,69 @@ export function decodeCorpusStoredEventRow(
   });
 }
 
-function findCorpusThreadDir(dir: string, threadId: string): string {
-  const threadsDir = path.join(dir, "threads");
-  for (const provider of fs.readdirSync(threadsDir)) {
-    const candidate = path.join(threadsDir, provider, threadId);
-    if (fs.existsSync(path.join(candidate, "meta.json"))) {
-      return candidate;
-    }
-  }
-  throw new Error(`Corpus thread ${threadId} not found under ${threadsDir}`);
+function sameStringSet(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    [...left].sort().join("\0") === [...right].sort().join("\0")
+  );
 }
 
+/**
+ * Loads one thread through its manifest entry and checks that the manifest,
+ * `meta.json`, and every event row agree on the thread id, provider, reasons,
+ * and row count. A corpus whose files drifted apart must fail here rather
+ * than produce a plausible baseline for the wrong thread.
+ */
 export function loadCorpusThread(threadId: string): CorpusThread {
   const dir = requireProviderCorpusDir();
-  const threadDir = findCorpusThreadDir(dir, threadId);
+  const entry = listCorpusThreads().find((thread) => thread.id === threadId);
+  if (entry === undefined) {
+    throw new Error(`Corpus thread ${threadId} is not in manifest.json`);
+  }
+  const threadDir = path.join(dir, "threads", entry.provider, entry.id);
   const meta = corpusMetaSchema.parse(
     readJsonFile(path.join(threadDir, "meta.json")),
   );
+  if (meta.thread.id !== entry.id) {
+    throw new Error(
+      `Corpus thread ${threadId}: meta.json names thread ${meta.thread.id}`,
+    );
+  }
+  if (meta.thread.provider_id !== entry.provider) {
+    throw new Error(
+      `Corpus thread ${threadId}: meta.json names provider ${meta.thread.provider_id}; manifest says ${entry.provider}`,
+    );
+  }
+  if (!sameStringSet(meta.reasons, entry.reasons)) {
+    throw new Error(
+      `Corpus thread ${threadId}: meta.json reasons [${meta.reasons.join(", ")}] differ from manifest [${entry.reasons.join(", ")}]`,
+    );
+  }
   const ndjson = fs.readFileSync(path.join(threadDir, "events.ndjson"), "utf8");
   const eventRows: CorpusStoredEventRow[] = [];
   for (const line of ndjson.split("\n")) {
     if (line.length === 0) {
       continue;
     }
-    eventRows.push(
-      toCorpusStoredEventRow(corpusEventRowSchema.parse(JSON.parse(line))),
+    const row = toCorpusStoredEventRow(
+      corpusEventRowSchema.parse(JSON.parse(line)),
     );
+    if (row.threadId !== entry.id) {
+      throw new Error(
+        `Corpus thread ${threadId}: event ${row.id} (#${row.sequence}) belongs to thread ${row.threadId}`,
+      );
+    }
+    eventRows.push(row);
   }
-  if (eventRows.length !== meta.event_rows) {
+  if (
+    eventRows.length !== meta.event_rows ||
+    eventRows.length !== entry.events
+  ) {
     throw new Error(
-      `Corpus thread ${threadId} has ${eventRows.length} event rows; meta.json says ${meta.event_rows}`,
+      `Corpus thread ${threadId} has ${eventRows.length} event rows; meta.json says ${meta.event_rows}, manifest says ${entry.events}`,
     );
   }
   return {

--- a/scripts/provider-corpus/snapshot-rows.sh
+++ b/scripts/provider-corpus/snapshot-rows.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Run the provider-corpus gates (row snapshots + timeline perf baseline).
+#
+#   scripts/provider-corpus/snapshot-rows.sh compare   # default: fail on any
+#                                                      # diff not in allowlist
+#   scripts/provider-corpus/snapshot-rows.sh write     # mint a new baseline
+#
+# Requires BB_PROVIDER_CORPUS_DIR (defaults to ~/.bb/provider-corpus when that
+# directory exists). See docs/debugging-and-qa.md, "Provider corpus".
+set -euo pipefail
+
+mode="${1:-compare}"
+case "${mode}" in
+  write|compare) ;;
+  *)
+    echo "usage: $0 [write|compare]" >&2
+    exit 2
+    ;;
+esac
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd -- "${script_dir}/../.." && pwd -P)"
+
+if [[ -z "${BB_PROVIDER_CORPUS_DIR:-}" && -f "${HOME}/.bb/provider-corpus/manifest.json" ]]; then
+  export BB_PROVIDER_CORPUS_DIR="${HOME}/.bb/provider-corpus"
+fi
+if [[ -z "${BB_PROVIDER_CORPUS_DIR:-}" || ! -f "${BB_PROVIDER_CORPUS_DIR}/manifest.json" ]]; then
+  echo "BB_PROVIDER_CORPUS_DIR must point at a corpus directory with manifest.json" >&2
+  exit 2
+fi
+
+export BB_PROVIDER_CORPUS_SNAPSHOT="${mode}"
+cd "${repo_root}"
+pnpm exec turbo run test:provider-corpus --filter=@bb/server
+
+snapshots_dir="${BB_PROVIDER_CORPUS_DIR}/snapshots"
+if [[ -f "${snapshots_dir}/rows-last-run.json" ]]; then
+  echo
+  echo "Row snapshots: ${snapshots_dir}/rows-last-run.json"
+  cat "${snapshots_dir}/rows-last-run.json"
+fi
+if [[ -f "${snapshots_dir}/perf-last-run.md" ]]; then
+  echo
+  echo "Timeline perf: ${snapshots_dir}/perf-last-run.md"
+  cat "${snapshots_dir}/perf-last-run.md"
+fi

--- a/turbo.json
+++ b/turbo.json
@@ -443,21 +443,6 @@
         "BB_PROVIDER_CORPUS_SNAPSHOT"
       ]
     },
-    // The provider-corpus gates read a private corpus through
-    // BB_PROVIDER_CORPUS_DIR and write snapshots next to it, so the task is
-    // uncacheable and must see those two variables (strict env mode strips
-    // everything undeclared). Without the variable the suites skip.
-    "@bb/server#test:provider-corpus": {
-      "dependsOn": [
-        "//#ensure-native-modules",
-        "topo"
-      ],
-      "cache": false,
-      "passThroughEnv": [
-        "BB_PROVIDER_CORPUS_DIR",
-        "BB_PROVIDER_CORPUS_SNAPSHOT"
-      ]
-    },
     // Builds real plugin host artifacts (the builtin artifacts suite, plus the
     // fixture that pins the published bridge surface as bundled-not-stubbed),
     // so it needs the SDK dist for the same reason as @bb/server#test.

--- a/turbo.json
+++ b/turbo.json
@@ -443,6 +443,21 @@
         "BB_PROVIDER_CORPUS_SNAPSHOT"
       ]
     },
+    // The provider-corpus gates read a private corpus through
+    // BB_PROVIDER_CORPUS_DIR and write snapshots next to it, so the task is
+    // uncacheable and must see those two variables (strict env mode strips
+    // everything undeclared). Without the variable the suites skip.
+    "@bb/server#test:provider-corpus": {
+      "dependsOn": [
+        "//#ensure-native-modules",
+        "topo"
+      ],
+      "cache": false,
+      "passThroughEnv": [
+        "BB_PROVIDER_CORPUS_DIR",
+        "BB_PROVIDER_CORPUS_SNAPSHOT"
+      ]
+    },
     // Builds real plugin host artifacts (the builtin artifacts suite, plus the
     // fixture that pins the published bridge surface as bundled-not-stubbed),
     // so it needs the SDK dist for the same reason as @bb/server#test.

--- a/turbo.json
+++ b/turbo.json
@@ -428,6 +428,21 @@
         "$TURBO_ROOT$/vitest.shared.ts"
       ]
     },
+    // The provider-corpus gates read a private corpus through
+    // BB_PROVIDER_CORPUS_DIR and write snapshots next to it, so the task is
+    // uncacheable and must see those two variables (strict env mode strips
+    // everything undeclared). Without the variable the suites skip.
+    "@bb/server#test:provider-corpus": {
+      "dependsOn": [
+        "//#ensure-native-modules",
+        "topo"
+      ],
+      "cache": false,
+      "passThroughEnv": [
+        "BB_PROVIDER_CORPUS_DIR",
+        "BB_PROVIDER_CORPUS_SNAPSHOT"
+      ]
+    },
     // Builds real plugin host artifacts (the builtin artifacts suite, plus the
     // fixture that pins the published bridge surface as bundled-not-stubbed),
     // so it needs the SDK dist for the same reason as @bb/server#test.


### PR DESCRIPTION
> **Stacked in the chain**: contract #2124 → WS1a #2136 → recordings #2153 → WS2a #2148 → **this PR** → codex #2164 → claude #2178 → acp. Base `bb/ws2a-registry-providerinfo-stack-on-2124-thr_hbi4kggyzb`. WS1a deleted the `ProviderAdapter` interface and the fake adapter, so the runtime permission matrix drives `handleRuntimeProviderRequest` through the real bridge-protocol adapter built for the scripted echo launch (`createProviderForId` + `createScriptedEchoLaunch`), with the initialize handshake setting `approvalEnforcedBy` and a canonical `interaction/request` on the wire. The 80 outcomes pinned on `main` are unchanged; the `tool_use` subject the v3 contract added gets 20 measured cells of its own (the type-level union guard demanded them). `resolvePermissionEscalation` now takes only the initiator, so the server table is 3 initiator cells + the 54 policy-shape cells. The row snapshots minted on `main` compare byte-identical (307/307, 0 diffs) under WS1a, #2153, and WS2a. Pre-stack history: `4af0367`.

## What was wrong

The provider-plugin migration abandons byte-equivalence with the old goldens on purpose, which removes the regression oracle. Before any provider code moves, `main` needs machine checks on real data that every later layer can run: projected rows for the 307 production threads in the private corpus (A4), a timeline-build and event-size baseline, and the permission-decision matrix (A5/G12) pinned as a literal table before WS5 changes the unions. None of these existed.

## What changed

No production code changes. Tests, test helpers, one script, one turbo task, docs.

- **Corpus reader** — `packages/test-helpers/src/provider-corpus.ts`: `corpusAvailable()`, `listCorpusThreads({ provider?, reasons? })`, `loadCorpusThread(id)`. Reads `BB_PROVIDER_CORPUS_DIR` (`manifest.json`, `threads/<provider>/<id>/{meta.json,events.ndjson}`), validates rows at the boundary with zod (ids must be one safe path segment), resolves each thread through its manifest entry and fails unless `meta.json` and every event row agree on id, provider, reasons, and row count, and decodes event payloads with `@bb/domain` `parseStoredThreadEvent` + `buildThreadEventRow` — the same path as the server's `parseStoredEventRow`. `.gitignore` gets `**/provider-corpus/**` with re-includes for the two in-repo directories of that name.
- **Row snapshots** — `apps/server/test/provider-corpus/row-snapshots.test.ts` + `corpus-harness.ts`. Each thread is inserted into in-memory SQLite with its original ids, sequences, and timestamps (raw `INSERT` so nothing is minted), then every timeline page is built via `buildThreadTimelineWithProfile` with the options the route uses — event budget from `defaultFeatureFlags`, inline-output limit from `DEFAULT_MAX_INLINE_OUTPUT_CHARS`, display name and plan command from the real provider registry (`createTestProviderRegistry()` loads the first-party plugin declarations) through `resolveProviderPlanCommand`, unhandled ops included, output truncation + preview — following the route's own `olderCursor`. Two variants per thread: `default` (turn rows summarized) and `nested` (`includeNestedRows`, children materialized). Snapshots go to `$BB_PROVIDER_CORPUS_DIR/snapshots/rows/<provider>/<threadId>.json`, keys sorted. Nothing is blanked: no wall-clock value reaches the rows, and write mode proves it by projecting every thread twice and requiring byte equality. Compare mode fails on any diff not covered by `snapshots/allowlist.json` (`threadId` | `provider` | `"*"` scope, JSON-pointer or `*`/`**` glob path, `pr`, `reason`), prints a unified diff for the first 3 differing threads plus a count, lists the entries it used, and fails on entries that cover nothing.
- **Perf baselines** — `timeline-perf.test.ts`: 10 largest threads per provider, latest page and full page walk, 5 profiled builds each after a warm-up, stage p50s from `ThreadTimelineBuildProfile`, persisted `data` bytes median/p95/total, rows produced. Written to `snapshots/perf-baseline.json`; compare fails at baseline × 1.10 for build cost and × 1.15 for median event size. **Deviation from the brief, with data:** the gate uses a normalized cost — min build time ÷ min time of a fixed CPU workload that shares no code with the timeline (JSON codec + sort over a deterministic document, run once per sample right before the builds) — not raw p50/p95. Raw p50 of the same commit swung up to 30% between two back-to-back runs on this 16-core box at load ~6 (14 of 20 threads tripped a literal 1.10 gate on the very next run); each side's minimum discards its own contended samples, interleaving keeps both minima in one short window, and a workload outside the timeline path means a uniform regression still moves the ratio. Raw p50/p95 are still recorded and printed. Up to 3 attempts per thread (write mode keeps the median attempt; compare stops at the first pass), a 5 ms floor for tiny latest-page builds, and compare mode refuses a baseline written with different gate settings. The table header reports the load average and flags an oversubscribed machine.
- **CI micro-benchmark** — same file, no corpus: `synthetic-thread.ts` builds a 10,019-event thread (every item kind, deltas, background tasks, usage events) and walks all 12 pages. Gate: minimum of 5 walks under 1,500 ms (local minimum 150–170 ms; the ceiling is ~10× so a slow runner passes while a quadratic regression still fails).
- **Permission matrix** — `packages/agent-runtime/src/permission-matrix.test.ts`: the runtime chokepoint `handleRuntimeProviderRequest` over permission policy (5 members of the discriminated union) × approval subject (5: command, file_change, permission_grant, plan, tool_use) × `approvalEnforcedBy` (2) × deny availability (2) = 100 cells, each a literal; `satisfies Record<CellKey, Outcome>` plus `SameUnion` type guards against the domain unions (dropping a row or a union member fails `tsc`, verified on the stack), plus runtime assertions that every local subject kind parses as a payload. The request goes through WS1a's real bridge-protocol adapter. `apps/server/test/permissions/permission-matrix.test.ts`: `resolvePermissionEscalation` over the 3 initiators and the 54-cell runtime-permission-policy shape cross product (5 accepted), with the reviewer vocabulary pinned to the policy union at the type level.
- **Seeds** — `scripts/provider-corpus/snapshot-rows.sh [write|compare]`, `@bb/server#test:provider-corpus` (uncacheable, `passThroughEnv` for the two variables — strict turbo env mode strips them from the plain `test` task), and a "Provider corpus" section in `docs/debugging-and-qa.md`.

### Permission matrix (runtime)

Outcome: `forward` = reaches `onInteractiveRequest` (user decides); `auto-deny` = runtime answers deny; `encode-error` = runtime wants to auto-deny but `deny` is not in `availableDecisions`, so the provider gets a JSON-RPC error. Subject kind (command, file_change, permission_grant, plan, tool_use) never changes the outcome, so the table is collapsed over it (each row below is 5 cells).

| policy (mode/escalation) | approvalEnforcedBy | deny available | outcome |
| --- | --- | --- | --- |
| accept-edits/ask | runtime | yes / no | forward |
| accept-edits/ask | provider | yes / no | forward |
| accept-edits/deny | runtime | yes | **auto-deny** |
| accept-edits/deny | runtime | no | **encode-error** |
| accept-edits/deny | provider | yes / no | forward |
| auto/ask | runtime | yes / no | forward |
| auto/ask | provider | yes / no | forward |
| auto/deny | runtime | yes | **auto-deny** |
| auto/deny | runtime | no | **encode-error** |
| auto/deny | provider | yes / no | forward |
| full/– | runtime | yes / no | forward |
| full/– | provider | yes / no | forward |

Bridge-kit predicate: `shouldAutoDenyInteractiveRequest` → ask: false, deny: true, null: false.

Server escalation by initiator: user → ask; agent → deny; system → deny. (On `main` the function also took the thread and was measured identically for root, delegated-child, and fork threads; WS1a removed the unused argument.)

Accepted runtime policy shapes (5 of 54): accept-edits/workspace/user/{ask,deny}, auto/workspace/automatic/{ask,deny}, full/full/–/–.

Observations (pinned, not fixed):

1. Permission **mode** never auto-decides anything in the runtime or the server. Only escalation does, and escalation is purely a function of the turn initiator. Mode is translated into provider-native settings (codex `approvalPolicy`/sandbox, Claude SDK `permissionMode`) and enforced by the provider. So a runtime-enforced provider in `full` mode that did send an approval would prompt the user.
2. The `encode-error` cells: on an agent- or system-initiated turn, a runtime-enforced provider whose approval omits `deny` receives a JSON-RPC error instead of a decision. Codex forwards the provider's own decision list, so this is reachable in principle; no first-party bridge omits deny today.
3. `plan` approvals are treated like any other subject by the runtime: on a system-initiated turn with a runtime-enforced provider they are auto-denied. Claude is provider-enforced and always forwards `ExitPlanMode`, so only codex plan approvals can hit this.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/test-helpers --filter=@bb/agent-runtime` — 6 tasks successful.
- On the WS1a stack (`--concurrency 4`): `pnpm exec turbo run typecheck --filter=@bb/agent-runtime --filter=@bb/server --filter=@bb/test-helpers` green; `pnpm exec turbo run test --filter=@bb/agent-runtime --filter=@bb/test-helpers` — 31 files, 434 tests passed (102 of them the matrix); `pnpm exec turbo run test --filter=@bb/server` — 197 files, 1,886 tests passed, the one failure again the local umask assertion. With the corpus set, the row snapshots minted on `main` compare byte-identical under WS1a's v3 assembler: 307/307, 0 diffs.
- On `main` before the stack, corpus absent: `pnpm exec turbo run test --filter=@bb/agent-runtime --filter=@bb/test-helpers` — 32 files, 504 tests passed (82 of them the matrix). `pnpm exec turbo run test --filter=@bb/server` — 196 files passed, 1 skipped (the row-snapshot suite), 1,884 tests passed; the single failure is the pre-existing `internal-skill-trees` file-mode assertion (this checkout's umask 0002 yields 0664 where the test expects 0644; it fails on clean `main` here and passes in CI). The two corpus suites report as skipped; the synthetic benchmark runs (`Synthetic 10019-event thread: 12 pages, 1165 rows projected, full walk p50 174 ms`).
- Corpus present: `scripts/provider-corpus/snapshot-rows.sh compare` → 2 files, 328 tests passed (307 row snapshots + 20 perf threads + 1 synthetic).
- Row snapshot write mode: **307 threads, 93,262 rows (top-level + nested children), 270.5 MB (283,656,293 bytes), 96.9 s wall**; compare mode on the same commit: 73.1 s, 0 diffs. After switching the harness from copied provider literals to the real registry, compare was still 307/307 with 0 diffs — the snapshots are byte-identical.
- Perf gate on the final estimator: baseline written at load 9.2, compare on the same commit at load 5.7 passed 20/20 threads on the first attempt, ratios 0.80–1.09× of baseline. Every one of the 330,626 corpus events decodes with today's `parseStoredThreadEvent` (426 MB of `data`).
- Allowlist machinery exercised by mutating one snapshot: compare fails with the unified diff; an entry covering `/variants/*/pages/*/rows/*/text` for that thread passes; a stale entry fails with "every snapshots/allowlist.json entry must cover at least one diff".
- Exhaustiveness guards exercised: deleting one matrix row → `TS2741 Property '"full/-|plan|provider|deny-unavailable"' is missing`; dropping `"provider"` from the enforcer list → `SameUnion` becomes `false` and the `satisfies` rejects the extra keys.

### Perf baseline (write mode, this commit, load 9.2/16 cores; ms; norm = min build ÷ min `json-sort-v1` calibration)

| thread | provider | events | data bytes p50/p95 | latest rows | latest p50/p95 ms | latest norm | pages | walk rows | walk p50/p95 ms | walk norm |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| thr_62bp724ett | claude-code | 10207 | 570/6375 | 18 | 23.3/27 | 0.103 | 8 | 241 | 922.3/1228 | 4.855 |
| thr_zqfgksiw39 | claude-code | 9012 | 365/3587 | 50 | 90.5/119 | 0.388 | 7 | 279 | 532/564.4 | 2.466 |
| thr_zc9yxt8mwk | codex | 8795 | 316/3025 | 10 | 24.9/58.3 | 0.102 | 5 | 45 | 323.1/395.5 | 1.510 |
| thr_j4hfucc5bb | claude-code | 7679 | 331/1285 | 52 | 29.9/35.5 | 0.132 | 8 | 335 | 404.6/472.4 | 1.591 |
| thr_f9jfidwbx8 | claude-code | 6163 | 454/4912 | 26 | 19.5/23.7 | 0.156 | 6 | 132 | 198.7/225.5 | 1.720 |
| thr_w6i678ha85 | claude-code | 5826 | 371/2820 | 19 | 25.7/40 | 0.204 | 3 | 37 | 149.6/172.4 | 1.163 |
| thr_qvau3b2d5b | claude-code | 5685 | 355/3613 | 111 | 36.9/50.4 | 0.298 | 5 | 168 | 154.3/173.4 | 1.311 |
| thr_2pkc3q5imw | codex | 5487 | 316/3642 | 3 | 32.9/36.6 | 0.307 | 4 | 15 | 87/89.5 | 0.808 |
| thr_7wvd28jzpj | claude-code | 5015 | 345/3497 | 36 | 25.8/31.6 | 0.219 | 3 | 94 | 130.7/137.4 | 1.102 |
| thr_nbghhtnurj | codex | 4341 | 316/8824 | 11 | 20.8/27.8 | 0.180 | 4 | 35 | 90.4/94.6 | 0.849 |
| thr_wb9c2q8gm4 | claude-code | 4228 | 378/2469 | 65 | 31.3/36.4 | 0.268 | 3 | 150 | 86.3/89 | 0.801 |
| thr_ksr44swb3q | codex | 4063 | 316/4513 | 10 | 18.7/20.2 | 0.178 | 3 | 23 | 64/67.4 | 0.589 |
| thr_tsfz8rtt72 | codex | 4055 | 316/4571 | 18 | 20.6/22 | 0.185 | 2 | 29 | 71/74.3 | 0.633 |
| thr_qe8y73b26t | claude-code | 3880 | 245/991 | 2 | 2.8/2.9 | 0.026 | 2 | 9 | 54.3/55.5 | 0.520 |
| thr_n3xqyz69nk | claude-code | 3454 | 341/4341 | 42 | 31.6/35.4 | 0.307 | 4 | 59 | 84.8/87.8 | 0.824 |
| thr_nm27yahx34 | codex | 3314 | 174/5030 | 17 | 14.3/17.5 | 0.135 | 3 | 61 | 54.6/56.3 | 0.519 |
| thr_ssix3mhxk5 | codex | 3088 | 316/3703 | 44 | 12.8/15 | 0.122 | 3 | 73 | 50/52.5 | 0.478 |
| thr_72dhrw3s8a | codex | 3067 | 174/1659 | 5 | 35/37.3 | 0.305 | 2 | 14 | 45.6/63.9 | 0.430 |
| thr_u8agadfekn | codex | 2892 | 334/2361 | 5 | 51.2/52.5 | 0.453 | 1 | 5 | 49/49.5 | 0.433 |
| thr_me47xr5c3y | codex | 2466 | 316/4318 | 55 | 21.2/22.1 | 0.202 | 2 | 99 | 35.1/36.5 | 0.347 |

Part of the provider-plugin migration: the Step 0 baselines PR from the design spec's "Regression confidence" section. No tracking issue.

> AGENT GENERATED: by Claude Opus 5


