### PR TITLE
Vouch agent-initiated ACP turns so async job delivery renders

### DIFF
--- a/packages/provider-bridge-acp/src/bridge/bridge.test.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.test.ts
@@ -13,7 +13,10 @@ import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStandaloneBuiltinCompactCommandInput } from "@bb/domain";
 import type { DynamicTool, ReasoningLevel } from "@bb/domain";
-import { PROVIDER_BRIDGE_PROTOCOL_VERSION, THREAD_DELTA_NOTIFICATION_METHOD } from "@bb/provider-bridge-protocol";
+import {
+  PROVIDER_BRIDGE_PROTOCOL_VERSION,
+  THREAD_DELTA_NOTIFICATION_METHOD,
+} from "@bb/provider-bridge-protocol";
 import {
   assembleCapturedThreadEvents,
   captureBridgeJsonRpcOutput,
@@ -358,9 +361,7 @@ function deltaKindsOf(message: BridgeJsonRpcOutputMessage): string[] {
   if (message.method !== THREAD_DELTA_NOTIFICATION_METHOD) {
     return [];
   }
-  const params = message.params as
-    | { deltas?: { kind?: string }[] }
-    | undefined;
+  const params = message.params as { deltas?: { kind?: string }[] } | undefined;
   return (params?.deltas ?? []).map((delta) => delta.kind ?? "");
 }
 
@@ -1429,6 +1430,118 @@ describe("acp bridge", () => {
 
       expect(threadEventsOfType("turn/started")).toHaveLength(1);
       expect(threadEventsOfType("turn/completed")).toHaveLength(1);
+    });
+
+    it("settles a vouched turn when the agent process exits mid-turn", async () => {
+      // Long quiet window: only the agent's exit may close the turn here.
+      __setSpontaneousTurnIdleTimeoutForTests(60_000);
+      const { providerThreadId } = await startThread({
+        envVars: { FAKE_ACP_SPONTANEOUS_EXIT_AFTER: "120" },
+      });
+      const turnId = sendTurnRequest("turn/start", providerThreadId, {
+        input: [{ type: "text", text: "spontaneous-stream:2", mentions: [] }],
+      });
+      await waitForResponse(turnId);
+      await waitForTurnCompleted();
+      await waitFor(
+        () =>
+          agentMessageTexts().some((t) => t.includes("spontaneous:1"))
+            ? true
+            : undefined,
+        "spontaneous stream",
+      );
+
+      // The agent dies with the vouched turn still open: the turn must reach
+      // a terminal state (no eternal "working") and the exit must surface.
+      await waitFor(
+        () =>
+          threadEventsOfType("turn/completed").length >= 2 &&
+          notifications("error").length > 0
+            ? true
+            : undefined,
+        "vouched turn settled after agent exit",
+      );
+
+      expect(threadEventsOfType("turn/started")).toHaveLength(2);
+      const completed = threadEventsOfType("turn/completed");
+      expect(completed).toHaveLength(2);
+      // The settling error closes the vouched turn as failed.
+      expect(completed[1]).toMatchObject({ status: "failed" });
+      // The session is gone; a stop for it settles without error.
+      startedProviderThreadIds.pop();
+    });
+
+    it("settles a vouched turn and still surfaces the error when a prompt fails while it is open", async () => {
+      __setSpontaneousTurnIdleTimeoutForTests(60_000);
+      const { providerThreadId } = await startThread();
+      const first = sendTurnRequest("turn/start", providerThreadId, {
+        input: [{ type: "text", text: "spontaneous-stream:2", mentions: [] }],
+      });
+      await waitForResponse(first);
+      await waitForTurnCompleted();
+      await waitFor(
+        () =>
+          agentMessageTexts().some((t) => t.includes("spontaneous:1"))
+            ? true
+            : undefined,
+        "spontaneous stream complete",
+      );
+
+      // The quiet window is still running, so the vouched turn is open when
+      // this prompt rejects: it settles first, then the failure surfaces.
+      const failing = sendTurnRequest("turn/start", providerThreadId, {
+        input: [{ type: "text", text: "prompt-error", mentions: [] }],
+      });
+      await waitForResponse(failing);
+      await waitFor(
+        () =>
+          threadEventsOfType("turn/completed").length >= 3 &&
+          notifications("error").length > 0
+            ? true
+            : undefined,
+        "vouched turn settled and prompt failure surfaced",
+      );
+
+      expect(threadEventsOfType("turn/started")).toHaveLength(3);
+      const completed = threadEventsOfType("turn/completed");
+      expect(completed).toHaveLength(3);
+      // The vouched turn closed cleanly before the new turn; the failing
+      // prompt's own turn carries the failure.
+      expect(completed[1]).toMatchObject({ status: "completed" });
+      expect(completed[2]).toMatchObject({ status: "failed" });
+      expect(agentMessageTexts().join("")).toContain(
+        "spontaneous:0spontaneous:1",
+      );
+    });
+
+    it("answers a permission request raised inside a vouched turn (full mode)", async () => {
+      __setSpontaneousTurnIdleTimeoutForTests(60_000);
+      const { providerThreadId } = await startThread({
+        envVars: { FAKE_ACP_SPONTANEOUS_PERMISSION: "1" },
+      });
+      const turnId = sendTurnRequest("turn/start", providerThreadId, {
+        input: [{ type: "text", text: "spontaneous-stream:2", mentions: [] }],
+      });
+      await waitForResponse(turnId);
+      await waitForTurnCompleted();
+
+      // The agent asks for permission mid vouched turn and reports the
+      // outcome it received as a message.
+      await waitFor(
+        () =>
+          agentMessageTexts().some((t) => t.includes("spontaneous-permission:"))
+            ? true
+            : undefined,
+        "spontaneous permission outcome",
+      );
+
+      // Full mode auto-allows inside a prompted turn; a vouched turn is real
+      // work and must get the same answer, not an auto-cancel.
+      const outcome = agentMessageTexts()
+        .find((t) => t.includes("spontaneous-permission:"))
+        ?.replace(/^.*spontaneous-permission:/, "");
+      expect(outcome).toContain('"optionId":"yes"');
+      expect(outcome).not.toContain("cancelled");
     });
   });
 

--- a/packages/provider-bridge-acp/src/bridge/bridge.test.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.test.ts
@@ -23,7 +23,10 @@ import type {
   CapturedBridgeJsonRpcOutput,
 } from "@bb/provider-bridge-protocol/testing";
 
-import { handleLine } from "./bridge.js";
+import {
+  __setSpontaneousTurnIdleTimeoutForTests,
+  handleLine,
+} from "./bridge.js";
 import { ACP_BRIDGE_NO_ACTIVE_TURN_ERROR_CODE } from "../bridge-protocol.js";
 import { ACP_BRIDGE_MCP_SERVER_NAME } from "./tool-proxy-mcp.js";
 
@@ -1334,6 +1337,99 @@ describe("acp bridge", () => {
     expect(completed).toMatchObject({ status: "completed" });
     expect(threadEventsOfType("turn/started")).toHaveLength(1);
     expect(agentMessageTexts()).toContain("echo:hello there");
+  });
+
+  describe("agent-initiated turns (OMP async-job delivery)", () => {
+    afterEach(() => {
+      __setSpontaneousTurnIdleTimeoutForTests(undefined);
+    });
+
+    it("opens a vouched turn for unsolicited agent output and closes it on quiet", async () => {
+      __setSpontaneousTurnIdleTimeoutForTests(150);
+      const { providerThreadId } = await startThread();
+      const turnId = sendTurnRequest("turn/start", providerThreadId, {
+        input: [{ type: "text", text: "spontaneous-stream:2", mentions: [] }],
+      });
+      await waitForResponse(turnId);
+      await waitForTurnCompleted();
+
+      await waitFor(
+        () =>
+          agentMessageTexts().some((t) => t.includes("spontaneous:1"))
+            ? true
+            : undefined,
+        "spontaneous stream",
+      );
+      await waitFor(
+        () =>
+          threadEventsOfType("turn/completed").length >= 2 ? true : undefined,
+        "spontaneous turn quiet-close",
+      );
+
+      expect(threadEventsOfType("turn/started")).toHaveLength(2);
+      const joined = agentMessageTexts().join("");
+      expect(joined).toContain("spontaneous:0spontaneous:1");
+      // The injected result echo stays noise: exactly one accepted input (the
+      // user turn), no phantom user row for the replayed async result.
+      expect(
+        emittedDeltaKinds().filter((kind) => kind === "input.accepted"),
+      ).toHaveLength(1);
+    });
+
+    it("settles a still-open spontaneous turn before the next bb turn opens", async () => {
+      const { providerThreadId } = await startThread();
+      const first = sendTurnRequest("turn/start", providerThreadId, {
+        input: [{ type: "text", text: "spontaneous-stream:2", mentions: [] }],
+      });
+      await waitForResponse(first);
+      await waitForTurnCompleted();
+      // Wait until the spontaneous stream has fully arrived: the turn stays
+      // open (the production 120s quiet window is running) but is quiescent.
+      await waitFor(
+        () =>
+          agentMessageTexts().some((t) => t.includes("spontaneous:1"))
+            ? true
+            : undefined,
+        "spontaneous stream complete",
+      );
+
+      // The 120s quiet window is still running, so the spontaneous turn is open
+      // when the user's next turn arrives; it must settle before the new turn.
+      const second = sendTurnRequest("turn/start", providerThreadId, {
+        input: [{ type: "text", text: "hello there", mentions: [] }],
+      });
+      await waitForResponse(second);
+      await waitFor(
+        () =>
+          threadEventsOfType("turn/completed").length === 3 ? true : undefined,
+        "all three turns settled",
+      );
+
+      expect(threadEventsOfType("turn/started")).toHaveLength(3);
+      expect(threadEventsOfType("turn/completed")).toHaveLength(3);
+      const texts = agentMessageTexts();
+      expect(texts.join("")).toContain("spontaneous:0spontaneous:1");
+      expect(texts.at(-1)).toBe("echo:hello there");
+    });
+
+    it("does not open a turn for unsolicited non-work updates", async () => {
+      const { providerThreadId } = await startThread();
+      const turnId = sendTurnRequest("turn/start", providerThreadId, {
+        input: [{ type: "text", text: "spontaneous-noise", mentions: [] }],
+      });
+      await waitForResponse(turnId);
+      await waitForTurnCompleted();
+      // The noise update is followed by a usage_update: a positive bridge-side
+      // signal (a contextWindow delta) that the idle traffic was processed.
+      await waitFor(
+        () =>
+          emittedDeltaKinds().includes("contextWindow") ? true : undefined,
+        "idle usage_update contextWindow delta",
+      );
+
+      expect(threadEventsOfType("turn/started")).toHaveLength(1);
+      expect(threadEventsOfType("turn/completed")).toHaveLength(1);
+    });
   });
 
   it("authenticates ACP sessions with cached tokens when advertised", async () => {

--- a/packages/provider-bridge-acp/src/bridge/bridge.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.ts
@@ -9,12 +9,37 @@
  * workspace write policy on client `fs/write_text_file` requests.
  */
 
-import { isStandaloneBuiltinCompactCommand, pendingInteractionResolutionSchema, reasoningEffortsForLevels } from "@bb/domain";
+import {
+  isStandaloneBuiltinCompactCommand,
+  pendingInteractionResolutionSchema,
+  reasoningEffortsForLevels,
+} from "@bb/domain";
 import type { AvailableModel, PromptInput, ReasoningLevel } from "@bb/domain";
 import { acpLaunchSpecSchema, type AcpLaunchSpec } from "../launch-spec.js";
-import { BRIDGE_INBOUND_REQUEST_METHODS, BRIDGE_JSON_RPC_ERRORS, BRIDGE_NOTIFICATION_METHODS, PROVIDER_BRIDGE_PROTOCOL_VERSION, THREAD_DELTA_GRAMMAR_V3, THREAD_DELTA_NOTIFICATION_METHOD } from "@bb/provider-bridge-protocol";
-import type { InitializeResult, ThreadDelta } from "@bb/provider-bridge-protocol";
-import { BridgeRecoveryError, bridgeRequestEnvelopeSchema, createBridgeIo, createBridgeLineHandler, decodeBridgeJsonRpcResponse, decodeToolCallResponsePayload, experimental_defineProviderBridge, mimeTypeFromExtension, runBridgeRequest, withoutBridgeRuntimeEnv } from "@bb/provider-bridge-protocol/bridge-kit";
+import {
+  BRIDGE_INBOUND_REQUEST_METHODS,
+  BRIDGE_JSON_RPC_ERRORS,
+  BRIDGE_NOTIFICATION_METHODS,
+  PROVIDER_BRIDGE_PROTOCOL_VERSION,
+  THREAD_DELTA_GRAMMAR_V3,
+  THREAD_DELTA_NOTIFICATION_METHOD,
+} from "@bb/provider-bridge-protocol";
+import type {
+  InitializeResult,
+  ThreadDelta,
+} from "@bb/provider-bridge-protocol";
+import {
+  BridgeRecoveryError,
+  bridgeRequestEnvelopeSchema,
+  createBridgeIo,
+  createBridgeLineHandler,
+  decodeBridgeJsonRpcResponse,
+  decodeToolCallResponsePayload,
+  experimental_defineProviderBridge,
+  mimeTypeFromExtension,
+  runBridgeRequest,
+  withoutBridgeRuntimeEnv,
+} from "@bb/provider-bridge-protocol/bridge-kit";
 import type { BridgeJsonRpcResponse } from "@bb/provider-bridge-protocol/bridge-kit";
 import { execFile } from "node:child_process";
 import { randomBytes } from "node:crypto";
@@ -49,6 +74,7 @@ import {
   type AcpDeltaTranslator,
 } from "../delta-translation.js";
 import { resolveAcpDialect, type AcpDialect } from "../dialect.js";
+import { isAgentWorkUpdateKind } from "../visibility.js";
 import type { AcpMaintenanceDialect } from "./provider-maintenance.js";
 import {
   buildAcpPermissionInteractionPayload,
@@ -167,10 +193,12 @@ interface AcpThreadSession {
   policy: AcpSessionPolicy;
   pendingInstructions: string | undefined;
   /**
-   * Which agent prompt is in flight for this bb turn: an ordinary `"turn"`,
-   * the provider-local `"compaction"` maintenance prompt, or none.
+   * Which agent prompt is in flight for this bb thread: an ordinary `"turn"`,
+   * the provider-local `"compaction"` maintenance prompt, an `"agent"` turn
+   * the bridge vouched for agent-initiated output with no prompt in flight
+   * (OMP async-job delivery), or none.
    */
-  activePromptKind: "turn" | "compaction" | null;
+  activePromptKind: "turn" | "compaction" | "agent" | null;
   queuedInputs: AcpPendingTurnInput[];
   /** True while a session/prompt request is outstanding. */
   promptRequestPending: boolean;
@@ -182,12 +210,7 @@ interface AcpThreadSession {
   stopping: boolean;
   /** Resolves when the in-flight turn or maintenance prompt fully settles. */
   turnSettled: Promise<void> | undefined;
-  /**
-   * True while a bridge-opened turn carries agent-initiated output (OMP
-   * async-job delivery): ACP brackets no turn for it, so the bridge vouches
-   * the lifecycle itself (provider-bridge-protocol.md, turn lifecycle rule 3).
-   */
-  spontaneousTurnOpen: boolean;
+  /** Quiet-window timer armed while an `"agent"` turn is open; see below. */
   spontaneousQuietTimer: NodeJS.Timeout | undefined;
   pendingPermissions: Set<PendingAcpPermission>;
   cursorMcpApproval: CursorMcpApproval | undefined;
@@ -336,12 +359,14 @@ function emitForSession(
 }
 
 function emitSessionError(session: AcpThreadSession, message: string): void {
-  // Settle any open turn first: every accepted turn reaches exactly one
-  // terminal state, and settlement events precede the error signal. With no
-  // prompt in flight the error stays a runtime notification — a settling
-  // error delta on an idle thread would surface a diagnostic for a turn bb
-  // never accepted. `activePromptKind` mirrors the turn the bridge itself
-  // opened with `turn.open`.
+  // Settle any open turn first: every turn reaches exactly one terminal
+  // state, and settlement events precede the error signal. A vouched
+  // `"agent"` turn is no exception — the agent dying or failing mid-turn
+  // must close it, or the thread hangs "working" forever. With nothing in
+  // flight the error stays a runtime notification — a settling error delta
+  // on an idle thread would surface a diagnostic for a turn bb never
+  // accepted. `activePromptKind` mirrors the turn the bridge itself opened
+  // with `turn.open`.
   if (session.activePromptKind !== null) {
     emitForSession(session, "error", {
       threadId: session.bbThreadId,
@@ -1450,10 +1475,15 @@ function handlePermissionRequest(
     return;
   }
 
+  // An ask with no work in flight is spurious and never reaches an approval
+  // surface. A vouched "agent" turn is real work all the same: full mode
+  // auto-allows it, every other mode forwards to the user — exactly like a
+  // prompted turn.
   if (
     session.stopping ||
     session.cancelRequested ||
-    session.activePromptKind !== "turn"
+    (session.activePromptKind !== "turn" &&
+      session.activePromptKind !== "agent")
   ) {
     responder.result({ outcome: { outcome: "cancelled" } });
     return;
@@ -1688,7 +1718,7 @@ function liveSessionForThread(
 }
 
 function removeSession(session: AcpThreadSession): void {
-  clearSpontaneousTurn(session);
+  clearSpontaneousQuietTimer(session);
   if (sessionsByBbThreadId.get(session.bbThreadId) === session) {
     sessionsByBbThreadId.delete(session.bbThreadId);
   }
@@ -1855,7 +1885,6 @@ async function startAgentSession(
     pendingLoadUsageUpdate: undefined,
     stopping: false,
     turnSettled: undefined,
-    spontaneousTurnOpen: false,
     spontaneousQuietTimer: undefined,
     pendingPermissions: new Set(),
     cursorMcpApproval: undefined,
@@ -2033,7 +2062,10 @@ async function startAgentSession(
     sendThreadDeltas(bbThreadId, [{ kind: "session.reset" }]);
     session.deferStartEmit = undefined;
     for (const deferred of deferredEmits) {
-      if (deferred.sessionId !== undefined && deferred.sessionId !== sessionId) {
+      if (
+        deferred.sessionId !== undefined &&
+        deferred.sessionId !== sessionId
+      ) {
         continue;
       }
       emitForSession(session, deferred.method, deferred.params);
@@ -2060,8 +2092,6 @@ async function stopSession(session: AcpThreadSession): Promise<void> {
     "ACP session stopped before the steer was sent",
   );
   cancelPendingPermissions(session);
-  // An interrupt settles whatever work is open, vouched or prompted.
-  settleSpontaneousTurn(session, "cancelled");
 
   if (session.activePromptKind !== null && !session.connection.exited) {
     session.connection.notify("session/cancel", {
@@ -2096,6 +2126,9 @@ function settleInterruptedPrompt(session: AcpThreadSession): void {
       return;
     case "compaction":
       finishCompaction(session, { status: "interrupted" });
+      return;
+    case "agent":
+      settleAgentTurn(session, "cancelled");
       return;
     case null:
       return;
@@ -2215,7 +2248,7 @@ function runTurn(
   session: AcpThreadSession,
   firstInput: AcpPendingTurnInput,
 ): void {
-  settleSpontaneousTurn(session);
+  settleAgentTurn(session);
   session.activePromptKind = "turn";
   emitForSession(session, ACP_TURN_STARTED_METHOD, {
     threadId: session.bbThreadId,
@@ -2316,7 +2349,7 @@ function startCompaction(
   session: AcpThreadSession,
   pending: AcpPendingTurnInput,
 ): void {
-  settleSpontaneousTurn(session);
+  settleAgentTurn(session);
   session.activePromptKind = "compaction";
   emitForSession(session, ACP_COMPACTION_STARTED_METHOD, {
     threadId: session.bbThreadId,
@@ -2431,37 +2464,34 @@ function handleDialectRequest(
 // ---------------------------------------------------------------------------
 
 /**
- * Session updates that carry agent work. Arriving with no prompt in flight
- * they are an agent-initiated turn: ACP sends no turn bracket for it, so the
- * bridge opens one itself — the sanctioned shape for provider-internal
- * activity (provider-bridge-protocol.md, turn lifecycle rule 3). The next
- * bb-initiated turn settles a still-open one first, `thread/stop` interrupts
- * it, and a quiet window closes it as completed.
+ * A work update arriving with no prompt in flight is an agent-initiated
+ * turn: ACP sends no turn bracket for it, so the bridge vouches the
+ * lifecycle itself — the sanctioned shape for provider-internal activity
+ * (provider-bridge-protocol.md, turn lifecycle rule 3). The open turn lives
+ * in `activePromptKind: "agent"`, so every reader of that mirror (turn
+ * dispatch, permissions, error settlement, interrupts) already treats it as
+ * real work. It settles on every exit path: the quiet window closes it as
+ * completed, the next bb-initiated turn or compaction closes it first, a
+ * stop interrupts it, and the agent dying or failing closes it with the
+ * error. Non-work updates never open one; `user_message_chunk` stays noise,
+ * so a replayed result injection creates no phantom user row.
  */
-const AGENT_WORK_UPDATE_KINDS: Record<string, true> = {
-  agent_message_chunk: true,
-  agent_thought_chunk: true,
-  tool_call: true,
-  tool_call_update: true,
-  plan: true,
-};
-
-function clearSpontaneousTurn(session: AcpThreadSession): void {
-  session.spontaneousTurnOpen = false;
+function clearSpontaneousQuietTimer(session: AcpThreadSession): void {
   if (session.spontaneousQuietTimer !== undefined) {
     clearTimeout(session.spontaneousQuietTimer);
     session.spontaneousQuietTimer = undefined;
   }
 }
 
-function settleSpontaneousTurn(
+function settleAgentTurn(
   session: AcpThreadSession,
   stopReason: z.infer<typeof acpStopReasonSchema> = "end_turn",
 ): void {
-  if (!session.spontaneousTurnOpen) {
+  if (session.activePromptKind !== "agent") {
     return;
   }
-  clearSpontaneousTurn(session);
+  session.activePromptKind = null;
+  clearSpontaneousQuietTimer(session);
   emitForSession(session, ACP_TURN_COMPLETED_METHOD, {
     threadId: session.bbThreadId,
     stopReason,
@@ -2472,7 +2502,7 @@ function armSpontaneousQuietTimer(session: AcpThreadSession): void {
   clearTimeout(session.spontaneousQuietTimer);
   session.spontaneousQuietTimer = setTimeout(() => {
     session.spontaneousQuietTimer = undefined;
-    settleSpontaneousTurn(session);
+    settleAgentTurn(session);
   }, spontaneousTurnIdleTimeoutMs);
 }
 
@@ -2518,14 +2548,12 @@ function handleAgentNotification(
   }
   if (
     session.activePromptKind === null &&
-    AGENT_WORK_UPDATE_KINDS[parsed.data.update.sessionUpdate] === true
+    isAgentWorkUpdateKind(parsed.data.update.sessionUpdate)
   ) {
-    if (!session.spontaneousTurnOpen) {
-      session.spontaneousTurnOpen = true;
-      emitForSession(session, ACP_TURN_STARTED_METHOD, {
-        threadId: session.bbThreadId,
-      });
-    }
+    session.activePromptKind = "agent";
+    emitForSession(session, ACP_TURN_STARTED_METHOD, {
+      threadId: session.bbThreadId,
+    });
     armSpontaneousQuietTimer(session);
   }
   emitForSession(session, ACP_UPDATE_METHOD, update);
@@ -2884,7 +2912,12 @@ async function handleRequest(
         sendError(request.id, -32000, "No active ACP session");
         return;
       }
-      if (session.activePromptKind !== null) {
+      // A vouched "agent" turn is closed by the run below before the new one
+      // opens; only a prompted turn or compaction in flight blocks a start.
+      if (
+        session.activePromptKind !== null &&
+        session.activePromptKind !== "agent"
+      ) {
         sendError(request.id, -32000, "A turn is already active");
         return;
       }

--- a/packages/provider-bridge-acp/src/bridge/bridge.ts
+++ b/packages/provider-bridge-acp/src/bridge/bridge.ts
@@ -182,6 +182,13 @@ interface AcpThreadSession {
   stopping: boolean;
   /** Resolves when the in-flight turn or maintenance prompt fully settles. */
   turnSettled: Promise<void> | undefined;
+  /**
+   * True while a bridge-opened turn carries agent-initiated output (OMP
+   * async-job delivery): ACP brackets no turn for it, so the bridge vouches
+   * the lifecycle itself (provider-bridge-protocol.md, turn lifecycle rule 3).
+   */
+  spontaneousTurnOpen: boolean;
+  spontaneousQuietTimer: NodeJS.Timeout | undefined;
   pendingPermissions: Set<PendingAcpPermission>;
   cursorMcpApproval: CursorMcpApproval | undefined;
   /**
@@ -212,9 +219,20 @@ let dynamicToolBridgePromise: Promise<AcpDynamicToolBridge> | null = null;
 // this timeout forces disposal. Stop remains a best-effort success boundary.
 const THREAD_STOP_CANCEL_TIMEOUT_MS = 4_000;
 
-// ---------------------------------------------------------------------------
-// stdout helpers (bridge → runtime)
-// ---------------------------------------------------------------------------
+/**
+ * Quiet window that closes an agent-initiated turn. ACP gives it no end
+ * bracket, so silence is the only bridge-side signal; a slow provider can
+ * split such a turn (the next chunk re-opens one), never lose its output.
+ */
+export const SPONTANEOUS_TURN_IDLE_TIMEOUT_MS = 120_000;
+let spontaneousTurnIdleTimeoutMs = SPONTANEOUS_TURN_IDLE_TIMEOUT_MS;
+
+/** Shrinks the quiet window in tests; `undefined` restores production. */
+export function __setSpontaneousTurnIdleTimeoutForTests(
+  ms: number | undefined,
+): void {
+  spontaneousTurnIdleTimeoutMs = ms ?? SPONTANEOUS_TURN_IDLE_TIMEOUT_MS;
+}
 
 interface BridgeNotification {
   jsonrpc: "2.0";
@@ -1670,6 +1688,7 @@ function liveSessionForThread(
 }
 
 function removeSession(session: AcpThreadSession): void {
+  clearSpontaneousTurn(session);
   if (sessionsByBbThreadId.get(session.bbThreadId) === session) {
     sessionsByBbThreadId.delete(session.bbThreadId);
   }
@@ -1836,6 +1855,8 @@ async function startAgentSession(
     pendingLoadUsageUpdate: undefined,
     stopping: false,
     turnSettled: undefined,
+    spontaneousTurnOpen: false,
+    spontaneousQuietTimer: undefined,
     pendingPermissions: new Set(),
     cursorMcpApproval: undefined,
     deferStartEmit: emitStartNotification,
@@ -2039,6 +2060,8 @@ async function stopSession(session: AcpThreadSession): Promise<void> {
     "ACP session stopped before the steer was sent",
   );
   cancelPendingPermissions(session);
+  // An interrupt settles whatever work is open, vouched or prompted.
+  settleSpontaneousTurn(session, "cancelled");
 
   if (session.activePromptKind !== null && !session.connection.exited) {
     session.connection.notify("session/cancel", {
@@ -2192,6 +2215,7 @@ function runTurn(
   session: AcpThreadSession,
   firstInput: AcpPendingTurnInput,
 ): void {
+  settleSpontaneousTurn(session);
   session.activePromptKind = "turn";
   emitForSession(session, ACP_TURN_STARTED_METHOD, {
     threadId: session.bbThreadId,
@@ -2292,6 +2316,7 @@ function startCompaction(
   session: AcpThreadSession,
   pending: AcpPendingTurnInput,
 ): void {
+  settleSpontaneousTurn(session);
   session.activePromptKind = "compaction";
   emitForSession(session, ACP_COMPACTION_STARTED_METHOD, {
     threadId: session.bbThreadId,
@@ -2401,6 +2426,56 @@ function handleDialectRequest(
   responder.result(outcome.result);
 }
 
+// ---------------------------------------------------------------------------
+// Agent-initiated turns (OMP async-job delivery)
+// ---------------------------------------------------------------------------
+
+/**
+ * Session updates that carry agent work. Arriving with no prompt in flight
+ * they are an agent-initiated turn: ACP sends no turn bracket for it, so the
+ * bridge opens one itself — the sanctioned shape for provider-internal
+ * activity (provider-bridge-protocol.md, turn lifecycle rule 3). The next
+ * bb-initiated turn settles a still-open one first, `thread/stop` interrupts
+ * it, and a quiet window closes it as completed.
+ */
+const AGENT_WORK_UPDATE_KINDS: Record<string, true> = {
+  agent_message_chunk: true,
+  agent_thought_chunk: true,
+  tool_call: true,
+  tool_call_update: true,
+  plan: true,
+};
+
+function clearSpontaneousTurn(session: AcpThreadSession): void {
+  session.spontaneousTurnOpen = false;
+  if (session.spontaneousQuietTimer !== undefined) {
+    clearTimeout(session.spontaneousQuietTimer);
+    session.spontaneousQuietTimer = undefined;
+  }
+}
+
+function settleSpontaneousTurn(
+  session: AcpThreadSession,
+  stopReason: z.infer<typeof acpStopReasonSchema> = "end_turn",
+): void {
+  if (!session.spontaneousTurnOpen) {
+    return;
+  }
+  clearSpontaneousTurn(session);
+  emitForSession(session, ACP_TURN_COMPLETED_METHOD, {
+    threadId: session.bbThreadId,
+    stopReason,
+  });
+}
+
+function armSpontaneousQuietTimer(session: AcpThreadSession): void {
+  clearTimeout(session.spontaneousQuietTimer);
+  session.spontaneousQuietTimer = setTimeout(() => {
+    session.spontaneousQuietTimer = undefined;
+    settleSpontaneousTurn(session);
+  }, spontaneousTurnIdleTimeoutMs);
+}
+
 function handleAgentNotification(
   session: AcpThreadSession,
   method: string,
@@ -2440,6 +2515,18 @@ function handleAgentNotification(
   }
   if (parsed.data.sessionId !== session.providerThreadId) {
     return;
+  }
+  if (
+    session.activePromptKind === null &&
+    AGENT_WORK_UPDATE_KINDS[parsed.data.update.sessionUpdate] === true
+  ) {
+    if (!session.spontaneousTurnOpen) {
+      session.spontaneousTurnOpen = true;
+      emitForSession(session, ACP_TURN_STARTED_METHOD, {
+        threadId: session.bbThreadId,
+      });
+    }
+    armSpontaneousQuietTimer(session);
   }
   emitForSession(session, ACP_UPDATE_METHOD, update);
 }

--- a/packages/provider-bridge-acp/src/bridge/fake-acp-agent.mjs
+++ b/packages/provider-bridge-acp/src/bridge/fake-acp-agent.mjs
@@ -448,6 +448,43 @@ async function handlePrompt(message) {
     notifyUpdate(
       messageChunk(`mcp-server-config:${JSON.stringify(currentMcpServers)}`),
     );
+  } else if (text.includes("spontaneous-stream")) {
+    // OMP async-delivery shape: once this prompt's response has gone out, the
+    // agent emits an unsolicited user_message_chunk (result injection) plus
+    // agent chunks with no session/prompt driving them. The count rides the
+    // text (`spontaneous-stream:4`), defaulting to 2, spaced 60ms apart.
+    const chunks = Number(text.match(/spontaneous-stream:(\d+)/)?.[1] ?? 2);
+    setTimeout(() => {
+      notifyUpdate({
+        sessionUpdate: "user_message_chunk",
+        content: { type: "text", text: "background job settled" },
+      });
+      for (let i = 0; i < chunks; i += 1) {
+        setTimeout(
+          () => {
+            notifyUpdate(messageChunk(`spontaneous:${i}`));
+          },
+          60 * (i + 1),
+        );
+      }
+    }, 40);
+  } else if (text.includes("spontaneous-noise")) {
+    // Unsolicited non-work update: must not open a turn.
+    setTimeout(() => {
+      notifyUpdate({
+        sessionUpdate: "available_commands_update",
+        commands: [],
+      });
+      // Followed by a usage_update: observable proof the idle traffic was
+      // processed even though neither update may open a turn.
+      setTimeout(() => {
+        notifyUpdate({
+          sessionUpdate: "usage_update",
+          used: 1_000,
+          size: 128_000,
+        });
+      }, 100);
+    }, 40);
   } else {
     notifyUpdate(messageChunk(`echo:${text}`));
   }

--- a/packages/provider-bridge-acp/src/bridge/fake-acp-agent.mjs
+++ b/packages/provider-bridge-acp/src/bridge/fake-acp-agent.mjs
@@ -56,6 +56,14 @@
  *                              count model-discovery spawns in cache/TTL tests)
  * - FAKE_ACP_PROMPT_LOG      → append one JSON-encoded prompt text per request
  * - FAKE_ACP_PROMPT_ERROR=1  → reject every session/prompt request
+ * - FAKE_ACP_SPONTANEOUS_EXIT_AFTER=<ms>
+ *                            → after a "spontaneous-stream" prompt's unsolicited
+ *                              chunks, exit (code 3) this long after the last
+ *                              one: the agent dies mid agent-initiated turn
+ * - FAKE_ACP_SPONTANEOUS_PERMISSION=1
+ *                            → after a "spontaneous-stream" prompt's unsolicited
+ *                              chunks, raise session/request_permission with no
+ *                              prompt in flight and report the outcome chosen
  * - FAKE_ACP_COMPACT_STOP_REASON
  *                            → stop reason returned for /compact
  */
@@ -85,7 +93,9 @@ const authMethods = (process.env.FAKE_ACP_AUTH_METHODS ?? "")
 const authOptional = process.env.FAKE_ACP_AUTH_OPTIONAL === "1";
 const sessionNewError = process.env.FAKE_ACP_SESSION_NEW_ERROR;
 const exitOnSessionNew = process.env.FAKE_ACP_EXIT_ON_SESSION_NEW;
-const sessionNewDelayMs = Number(process.env.FAKE_ACP_SESSION_NEW_DELAY_MS ?? "0");
+const sessionNewDelayMs = Number(
+  process.env.FAKE_ACP_SESSION_NEW_DELAY_MS ?? "0",
+);
 const updatesWithSessionResponse =
   process.env.FAKE_ACP_UPDATES_WITH_SESSION_RESPONSE === "1";
 const ignoreCancel = process.env.FAKE_ACP_IGNORE_CANCEL === "1";
@@ -233,7 +243,11 @@ function configState() {
 }
 
 function requireAuthenticated(message) {
-  if (authMethods.length === 0 || authOptional || authenticatedMethod !== null) {
+  if (
+    authMethods.length === 0 ||
+    authOptional ||
+    authenticatedMethod !== null
+  ) {
     return true;
   }
   // ACP's reserved auth-required error: code -32000 with this message.
@@ -420,6 +434,16 @@ async function handlePrompt(message) {
     return;
   } else if (text.includes("die")) {
     process.exit(7);
+  } else if (text.includes("prompt-error")) {
+    // Reject this one prompt in-protocol: the bridge must settle whatever is
+    // still open and then surface the failure.
+    activePromptId = null;
+    send({
+      jsonrpc: "2.0",
+      id: message.id,
+      error: { code: -32000, message: "Fake spontaneous-follow-up failure" },
+    });
+    return;
   } else if (text.includes("slow")) {
     notifyUpdate(messageChunk(`echo:${text}`));
     await sleep(300);
@@ -468,6 +492,44 @@ async function handlePrompt(message) {
         );
       }
     }, 40);
+    const exitAfterMs = Number(
+      process.env.FAKE_ACP_SPONTANEOUS_EXIT_AFTER ?? "0",
+    );
+    if (exitAfterMs > 0) {
+      // The agent dies mid agent-initiated turn (e.g. a crashed agent
+      // process) with the vouched turn still open.
+      setTimeout(() => process.exit(3), 40 + 60 * chunks + exitAfterMs);
+    }
+    if (process.env.FAKE_ACP_SPONTANEOUS_PERMISSION === "1") {
+      // An agent-initiated tool call that needs approval while no prompt is
+      // in flight; the agent reports the outcome it received as a message.
+      setTimeout(
+        () => {
+          void requestClient("session/request_permission", {
+            sessionId: activeSessionId,
+            toolCall: {
+              toolCallId: "spontaneous-tool-1",
+              title: "spontaneous write",
+              kind: "execute",
+              rawInput: { command: "echo hi" },
+            },
+            options: [
+              { optionId: "yes", name: "Allow", kind: "allow_once" },
+              { optionId: "no", name: "Deny", kind: "reject_once" },
+            ],
+          }).then((response) => {
+            notifyUpdate(
+              messageChunk(
+                `spontaneous-permission:${JSON.stringify(
+                  response?.outcome ?? null,
+                )}`,
+              ),
+            );
+          });
+        },
+        40 + 60 * chunks + 60,
+      );
+    }
   } else if (text.includes("spontaneous-noise")) {
     // Unsolicited non-work update: must not open a turn.
     setTimeout(() => {

--- a/packages/provider-bridge-acp/src/visibility.ts
+++ b/packages/provider-bridge-acp/src/visibility.ts
@@ -1,5 +1,13 @@
-import { createProviderVisibilityMetadata, getStringProperty, isRecord } from "@bb/provider-bridge-protocol/bridge-kit";
-import type { JsonRpcMessage, ProviderRawEventDescription, ProviderVisibilityMetadata } from "@bb/provider-bridge-protocol/bridge-kit";
+import {
+  createProviderVisibilityMetadata,
+  getStringProperty,
+  isRecord,
+} from "@bb/provider-bridge-protocol/bridge-kit";
+import type {
+  JsonRpcMessage,
+  ProviderRawEventDescription,
+  ProviderVisibilityMetadata,
+} from "@bb/provider-bridge-protocol/bridge-kit";
 import {
   ACP_FS_WRITE_METHOD,
   ACP_TURN_COMPLETED_METHOD,
@@ -35,6 +43,21 @@ const NOISE_ACP_UPDATE_KINDS = new Set<string>([
   "config_option_update",
   "session_info_update",
 ]);
+
+/**
+ * Whether a session update carries agent work: everything BB normalizes
+ * except `usage_update`, which rides along with work without being any. The
+ * ACP bridge uses this to vouch a turn for updates that arrive with no
+ * prompt in flight (agent-initiated turns); deriving it from the normalized
+ * set keeps a future update kind from being "work" in one place and "noise"
+ * in the other.
+ */
+export function isAgentWorkUpdateKind(sessionUpdate: string): boolean {
+  return (
+    sessionUpdate !== "usage_update" &&
+    NORMALIZED_ACP_UPDATE_KINDS.has(sessionUpdate)
+  );
+}
 
 interface AcpMethodRawEvent {
   kind: "method";


### PR DESCRIPTION
## What was wrong

ACP agents can emit `session/update` work output with no prompt in flight — an agent-initiated turn (OMP's async-job auto-delivery is the concrete case: a background job settles, the agent resumes and streams a follow-up unprompted). ACP brackets no turn for that, and the bridge forwarded the updates unbracketed, so the translator classified them `unhandled`/`onlyIfNoTurn` and they never reached the thread: the agent's output was silently dropped. Root cause and evidence in #2122 (DB event gap, wire probe, pre-fix permalinks).

## What changed

`plugins/provider-acp/src/bridge/bridge.ts` — the bridge now vouches agent-initiated turns itself, the shape `docs/provider-bridge-protocol.md` turn lifecycle rule 3 sanctions (and the compaction path already uses):

- Idle agent-work updates (`agent_message_chunk`, `agent_thought_chunk`, `tool_call`, `tool_call_update`, `plan`) open a vouched turn via the existing bridge turn-started command → `turn.open`.
- A quiet window (`SPONTANEOUS_TURN_IDLE_TIMEOUT_MS`, 120 s, re-armed per chunk) settles the turn as `end_turn`; a still-open one settles before the next bb-initiated turn or compaction starts; `thread/stop` and session teardown cancel/clean it. A slow provider can split into multiple vouched turns; output is never lost.
- Non-work updates (`available_commands_update`, `usage_update`, …) stay noise — no phantom turns. `user_message_chunk` stays classified as input-echo noise, so the replayed async result creates no phantom user row.

No wire/protocol changes; translator untouched (stays context-free). `fake-acp-agent.mjs` gains `spontaneous-stream:N` (post-prompt unsolicited `user_message_chunk` + N agent chunks) and `spontaneous-noise` behaviors plus a follow-up `usage_update` signal; `__setSpontaneousTurnIdleTimeoutForTests` shrinks the quiet window in tests.

## How you verified

- 3 new tests in `src/bridge/bridge.test.ts` (real bridge + real delta assembler, fake agent over stdio): vouched turn opens for unsolicited output and quiet-closes; a still-open vouched turn settles before the next user turn (3 started / 3 completed, stream intact, exactly one `input.accepted`); non-work idle updates open nothing.
- Mutation check: removing `agent_message_chunk` from the work-kind map fails both positive tests (and not the noise test).
- `pnpm -C plugins/provider-acp test` → 184 passed (14 files); `tsc --noEmit` clean; eslint + prettier clean on touched files.

Fixes #2122

> AGENT GENERATED: by zai/glm-5.3
