### PR TITLE
Move a local plugin to a new directory without losing its settings

### DIFF
--- a/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
+++ b/apps/app/src/components/plugin/management/BrowsePluginsTab.tsx
@@ -480,7 +480,7 @@ function BrowseCard({
       >
         <ConfirmDeleteDialogContent
           title={`Uninstall ${entry.displayName}?`}
-          description="The plugin will be removed from this BB host. Plugin data may be retained for a future reinstall."
+          description="The plugin, its installed files, and its settings, secrets, and schedules are removed from this BB host."
           confirmLabel={uninstall.isPending ? "Uninstalling…" : "Uninstall"}
           pending={uninstall.isPending}
           onConfirm={() => uninstall.mutate()}

--- a/apps/app/src/components/tools/PluginDetail.tsx
+++ b/apps/app/src/components/tools/PluginDetail.tsx
@@ -79,6 +79,18 @@ export function pluginRemovalLabel(plugin: PluginListItem): string {
   return pluginIsLocalSource(plugin) ? "Remove from bb" : "Uninstall";
 }
 
+/**
+ * What a removal deletes, matching the server's `remove`: settings, secrets,
+ * and schedules go with the registration on every source kind; only managed
+ * git/npm files are deleted from disk. Moving a local plugin is an install of
+ * the new path, which keeps that configuration.
+ */
+export function pluginRemovalDescription(plugin: PluginListItem): string {
+  return pluginIsLocalSource(plugin)
+    ? `Remove "${plugin.id}" from bb and delete its settings, secrets, and schedules? Its source files stay on disk. To move it to another directory, install the new path instead; that keeps its settings.`
+    : `Uninstall "${plugin.id}" and delete its managed files, settings, secrets, and schedules?`;
+}
+
 function PluginPath({ path }: { path: string }) {
   const { copied, copy } = useClipboardCopy({
     text: path,

--- a/apps/app/src/views/ToolsView.plugin-detail.test.tsx
+++ b/apps/app/src/views/ToolsView.plugin-detail.test.tsx
@@ -551,6 +551,85 @@ describe("BB Official plugin detail routing", () => {
   });
 });
 
+describe("plugin removal confirmation", () => {
+  it("warns that removing a local plugin deletes its settings, secrets, and schedules and names the move path", async () => {
+    // The wire shape of GET /api/v1/plugins (server-contract InstalledPlugin).
+    const localPlugin = {
+      id: "github",
+      source: "path:/Users/you/src/bb-plugin-github",
+      rootDir: "/Users/you/src/bb-plugin-github",
+      version: "0.1.0",
+      provenance: "direct",
+      isOrphanedBuiltin: false,
+      publisherLabel: null,
+      sourceDisplay: "path · /Users/you/src/bb-plugin-github",
+      updateState: {},
+      enabled: true,
+      description: "Browse GitHub issues and pull requests in BB.",
+      name: "GitHub",
+      icon: "Github",
+      iconUrl: null,
+      status: "running",
+      statusDetail: null,
+      handlerStats: { count: 0, totalMs: 0, maxMs: 0, errorCount: 0 },
+      services: [],
+      schedules: [],
+      cliCommand: null,
+      capabilities: [],
+      hasSettings: false,
+      app: { hasApp: false, bundle: null },
+      logoUrl: null,
+      logoDarkUrl: null,
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url === "/api/v1/plugins") {
+          return new Response(
+            JSON.stringify({ enabled: true, plugins: [localPlugin] }),
+            { headers: { "content-type": "application/json" } },
+          );
+        }
+        return new Response(JSON.stringify({ error: "not found" }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        });
+      }),
+    );
+
+    const { wrapper: QueryClientWrapper } = createQueryClientTestHarness();
+    render(
+      <MemoryRouter initialEntries={["/extensions/plugins/github"]}>
+        <Routes>
+          <Route path="/extensions/plugins/:pluginId" element={<ToolsView />} />
+        </Routes>
+      </MemoryRouter>,
+      { wrapper: QueryClientWrapper },
+    );
+
+    expect(await screen.findByRole("heading", { name: "GitHub" })).toBeTruthy();
+    fireEvent.pointerDown(
+      screen.getByRole("button", { name: "GitHub actions" }),
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Remove from bb" }),
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: "Remove plugin from bb?" }),
+    ).toBeTruthy();
+    // The server's remove() deletes settings, secrets, and schedules for every
+    // source kind; only the files of a local plugin stay. Re-pointing the id at
+    // another directory is an install, not a remove, and keeps that state.
+    const description = screen.getByText(/Remove "github" from bb/);
+    expect(description.textContent).toContain(
+      "delete its settings, secrets, and schedules",
+    );
+    expect(description.textContent).toContain("source files stay on disk");
+    expect(description.textContent).toContain("install the new path instead");
+  });
+});
+
 describe("PluginDetail banner precedence", () => {
   const managedPlugin: PluginListItem = {
     ...GITHUB_PLUGIN,

--- a/apps/app/src/views/ToolsView.tsx
+++ b/apps/app/src/views/ToolsView.tsx
@@ -367,7 +367,7 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
                 }
                 description={
                   pluginIsLocalSource(deleteTarget)
-                    ? `Remove "${deleteTarget.id}" from bb? Its source files will stay on disk.`
+                    ? `Remove "${deleteTarget.id}" from bb and delete its settings? Its source files will stay on disk.`
                     : `Uninstall "${deleteTarget.id}" and delete its managed files and settings?`
                 }
                 confirmLabel={pluginRemovalLabel(deleteTarget)}

--- a/apps/app/src/views/ToolsView.tsx
+++ b/apps/app/src/views/ToolsView.tsx
@@ -32,6 +32,7 @@ import {
   PluginDetail,
   PluginDetailBanners,
   pluginIsLocalSource,
+  pluginRemovalDescription,
   pluginRemovalLabel,
 } from "@/components/tools/PluginDetail";
 import {
@@ -365,11 +366,7 @@ function PluginDetailToolView({ pluginId }: { pluginId: string }) {
                     ? "Remove plugin from bb?"
                     : "Uninstall plugin?"
                 }
-                description={
-                  pluginIsLocalSource(deleteTarget)
-                    ? `Remove "${deleteTarget.id}" from bb and delete its settings? Its source files will stay on disk.`
-                    : `Uninstall "${deleteTarget.id}" and delete its managed files and settings?`
-                }
+                description={pluginRemovalDescription(deleteTarget)}
                 confirmLabel={pluginRemovalLabel(deleteTarget)}
                 pending={pluginDelete.isPending}
                 onConfirm={() => pluginDelete.mutate(deleteTarget)}

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -1847,7 +1847,7 @@ export function registerPluginCommands(
   plugin
     .command("remove <id>")
     .description(
-      "Remove an installed plugin (git:/npm: managed files are deleted; local path sources are left alone)",
+      "Remove an installed plugin and delete its settings, secrets, and schedules (git:/npm: managed files are deleted; local path sources stay on disk). To move a local plugin to another directory, install the new path instead",
     )
     .option("--json", "Output JSON")
     .action(

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -1082,6 +1082,21 @@ export function registerPluginCommands(
               const pkg = pluginPackageSummarySchema.parse(raw);
               if (pkg.name !== undefined) {
                 summary = `Installing ${pkg.name}@${pkg.version ?? "?"} from ${path}`;
+                // The same id installed from another local directory is
+                // moved, not refused; name the install being replaced so
+                // the confirmation is about the move, not a fresh install.
+                const pluginId = derivePluginId(pkg.name);
+                const { plugins } = await createCliBbSdk(
+                  getUrl(),
+                ).plugins.list();
+                const installed = plugins.find((p) => p.id === pluginId);
+                if (
+                  installed !== undefined &&
+                  installed.source.startsWith("path:") &&
+                  installed.rootDir !== path
+                ) {
+                  summary = `${summary}\nThis moves "${pluginId}" from ${installed.rootDir}; its settings, secrets, and schedules are kept.`;
+                }
               }
             } catch {
               // fall through to the bare path summary
@@ -1225,7 +1240,7 @@ export function registerPluginCommands(
             if (!shouldAttempt) {
               if (result.outcome === "pinned") {
                 console.log(
-                  `${result.id}: skipped — pinned${detail ? ` (${detail})` : ""}; remove and reinstall with a tracking npm range, git branch, or git semver range to receive updates.`,
+                  `${result.id}: skipped — pinned${detail ? ` (${detail})` : ""}; remove and reinstall with a tracking npm range, git branch, or git semver range to receive updates (remove deletes the plugin's settings, secrets, and schedules). A local path plugin updates with \`bb plugin reload\`; move it with \`bb plugin install path:<new directory>\`.`,
                 );
               } else if (result.outcome === "incompatible") {
                 console.log(

--- a/apps/mobile/src/data/plugins/index.ts
+++ b/apps/mobile/src/data/plugins/index.ts
@@ -14,6 +14,7 @@ export {
   normalizePluginSourceInput,
   pluginDisplayName,
   pluginIsLocalSource,
+  pluginRemovalDescription,
   pluginRemovalLabel,
   pluginRowSignal,
   pluginRuntimeStatusPresentation,

--- a/apps/mobile/src/data/plugins/plugin-model.test.ts
+++ b/apps/mobile/src/data/plugins/plugin-model.test.ts
@@ -8,6 +8,7 @@ import {
   groupCatalogEntries,
   normalizeMarketplaceSourceInput,
   normalizePluginSourceInput,
+  pluginRemovalDescription,
   pluginRowSignal,
   pluginSettingFieldValue,
   pluginSettingsAvailability,
@@ -271,5 +272,27 @@ describe("source input normalization", () => {
       normalizeMarketplaceSourceInput("http://insecure/m.json"),
     ).toBeNull();
     expect(normalizeMarketplaceSourceInput("some words")).toBeNull();
+  });
+});
+
+describe("pluginRemovalDescription", () => {
+  it("states the server's deletion policy for every source kind", () => {
+    // remove() deletes settings, secrets, and schedules regardless of source;
+    // a local plugin's files stay, and a move (install the new path) keeps
+    // its configuration.
+    const local = pluginRemovalDescription(
+      plugin({ source: "path:/Users/you/bb-plugin-github" }),
+    );
+    expect(local).toMatch(/settings, secrets, and schedules/);
+    expect(local).toMatch(/files stay/);
+    expect(local).toMatch(/install the new path/);
+    expect(local).not.toMatch(/kept for a reinstall/);
+    const managed = pluginRemovalDescription(
+      plugin({ source: "npm:@example/github@^1" }),
+    );
+    expect(managed).toMatch(
+      /installed files, settings, secrets, and schedules/,
+    );
+    expect(managed).not.toMatch(/kept/);
   });
 });

--- a/apps/mobile/src/data/plugins/plugin-model.ts
+++ b/apps/mobile/src/data/plugins/plugin-model.ts
@@ -209,6 +209,20 @@ export function pluginRemovalLabel(
   return pluginIsLocalSource(plugin) ? "Remove from bb" : "Uninstall";
 }
 
+/**
+ * What a removal deletes, matching the server's `remove`: settings, secrets,
+ * and schedules go with the registration on every source kind; only managed
+ * git/npm files are deleted from disk. Moving a local plugin is an install of
+ * the new path, which keeps that configuration.
+ */
+export function pluginRemovalDescription(
+  plugin: Pick<InstalledPlugin, "source">,
+): string {
+  return pluginIsLocalSource(plugin)
+    ? "bb stops loading this plugin and deletes its settings, secrets, and schedules. Its files stay where they are. To move it to another directory, install the new path instead; that keeps its settings."
+    : "bb stops the plugin and deletes its installed files, settings, secrets, and schedules.";
+}
+
 /** Display name, falling back to the id. */
 export function pluginDisplayName(
   plugin: Pick<InstalledPlugin, "id" | "name">,

--- a/apps/mobile/src/screens/plugins/PluginDetailScreen.tsx
+++ b/apps/mobile/src/screens/plugins/PluginDetailScreen.tsx
@@ -6,6 +6,7 @@ import { View } from "react-native";
 import {
   describePluginSettingsAvailability,
   pluginDisplayName,
+  pluginRemovalDescription,
   pluginRemovalLabel,
   pluginRuntimeStatusPresentation,
   pluginSettingsAvailability,
@@ -210,11 +211,7 @@ export function PluginDetailScreen() {
       <ActionSheet
         controller={confirmRemove}
         title={plugin ? `${pluginRemovalLabel(plugin)} ${name}?` : undefined}
-        message={
-          plugin && plugin.source.startsWith("path:")
-            ? "bb stops loading this plugin. Its files stay where they are."
-            : "bb stops the plugin and deletes its installed files. Its settings and data are kept for a reinstall."
-        }
+        message={plugin ? pluginRemovalDescription(plugin) : undefined}
         actions={
           plugin
             ? [

--- a/apps/mobile/src/screens/plugins/PluginsScreen.tsx
+++ b/apps/mobile/src/screens/plugins/PluginsScreen.tsx
@@ -6,6 +6,7 @@ import {
   describePluginRow,
   filterPlugins,
   pluginDisplayName,
+  pluginRemovalDescription,
   pluginRemovalLabel,
   pluginRowSignal,
   sortPlugins,
@@ -325,11 +326,7 @@ export function PluginsScreen() {
             ? `${pluginRemovalLabel(target)} ${pluginDisplayName(target)}?`
             : undefined
         }
-        message={
-          target && target.source.startsWith("path:")
-            ? "bb stops loading this plugin. Its files stay where they are."
-            : "bb stops the plugin and deletes its installed files. Its settings and data are kept for a reinstall."
-        }
+        message={target ? pluginRemovalDescription(target) : undefined}
         actions={
           target
             ? [

--- a/apps/server/src/services/plugins/plugin-registration.ts
+++ b/apps/server/src/services/plugins/plugin-registration.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import { isBbManagedWorkspacePath } from "../threads/worktree-paths.js";
 import {
@@ -32,6 +33,7 @@ import {
 } from "./install-sources.js";
 import { gitRefNameForRow, gitSelectorForRow } from "./git-source-intent.js";
 import { readPluginManifest, type PluginManifest } from "./manifest.js";
+import { forgetMutableRoot } from "./plugin-runtime.js";
 import type {
   InstallContext,
   InstallRegistrationIdentity,
@@ -241,6 +243,33 @@ export function createPluginRegistration(context: PluginRegistrationContext) {
     });
   }
 
+  /**
+   * A direct `path:` install of an id that is already registered from another
+   * local directory is a move, not a conflict: both trees are the operator's
+   * own, and the plugin's settings, secrets, and schedules are keyed by id.
+   * Refusing it would force `remove` + `install`, and `remove` deletes that
+   * configuration (#1766).
+   */
+  function isPathSourceMove(
+    existing: InstalledPluginRow,
+    identity: InstallRegistrationIdentity,
+  ): boolean {
+    return (
+      existing.provenance === "direct" &&
+      existing.sourceKind === "path" &&
+      identity.provenance.kind === "direct" &&
+      identity.sourceIntent.kind === "path"
+    );
+  }
+
+  function sameDirectory(a: string, b: string): boolean {
+    try {
+      return realpathSync(a) === realpathSync(b);
+    } catch {
+      return a === b;
+    }
+  }
+
   function assertInstallRegistrationAvailable(
     existing: InstalledPluginRow | undefined,
     identity: InstallRegistrationIdentity,
@@ -252,7 +281,8 @@ export function createPluginRegistration(context: PluginRegistrationContext) {
         existing,
         identity.provenance,
         identity.sourceIntent,
-      )
+      ) &&
+      !isPathSourceMove(existing, identity)
     ) {
       throw new Error(
         `plugin id "${pluginId}" is already installed from ${existing.source}; remove it first`,
@@ -332,6 +362,17 @@ export function createPluginRegistration(context: PluginRegistrationContext) {
           await loadOne(previous);
         }
         throw error;
+      }
+      if (existing !== undefined && existing.rootDir !== args.rootDir) {
+        // The old tree is no longer registered: stop the module resolve hook
+        // from scanning it, exactly as `remove` does. Two paths can name one
+        // directory through a symlink, and that root is still in use.
+        if (!sameDirectory(existing.rootDir, args.rootDir)) {
+          forgetMutableRoot(existing.rootDir);
+        }
+        logger.info(
+          `plugin ${manifest.id} source moved from ${existing.source} to ${args.source}; settings, secrets, and schedules were kept`,
+        );
       }
     });
     await syncCliSkill();

--- a/apps/server/src/services/plugins/plugin-registration.ts
+++ b/apps/server/src/services/plugins/plugin-registration.ts
@@ -41,6 +41,7 @@ import type {
 } from "./managed-plugin-artifacts.js";
 import type {
   PluginListEntry,
+  PluginRuntimeStatus,
   PluginServiceDeps,
 } from "./plugin-service-internal.js";
 import {
@@ -87,6 +88,10 @@ export interface PluginRegistrationContext {
   withLifecycleLock: <T>(id: string, fn: () => Promise<T>) => Promise<T>;
   disposeOne: (id: string) => Promise<void>;
   loadOne: (row: InstalledPluginRow) => Promise<void>;
+  statuses: ReadonlyMap<
+    string,
+    { status: PluginRuntimeStatus; detail: string | null }
+  >;
   validateInstallDir: (args: RegisterInstalledArgs) => Promise<PluginManifest>;
   checkEngineRange: (manifest: PluginManifest) => string | undefined;
   checkPluginSdkRange: (manifest: PluginManifest) => string | undefined;
@@ -102,6 +107,7 @@ export function createPluginRegistration(context: PluginRegistrationContext) {
     withLifecycleLock,
     disposeOne,
     loadOne,
+    statuses,
     validateInstallDir,
     checkEngineRange,
     checkPluginSdkRange,
@@ -244,22 +250,46 @@ export function createPluginRegistration(context: PluginRegistrationContext) {
   }
 
   /**
-   * A direct `path:` install of an id that is already registered from another
-   * local directory is a move, not a conflict: both trees are the operator's
-   * own, and the plugin's settings, secrets, and schedules are keyed by id.
-   * Refusing it would force `remove` + `install`, and `remove` deletes that
-   * configuration (#1766).
+   * A direct `path:` install of an id that is already registered from a
+   * different local directory is a move, not a conflict: both trees are the
+   * operator's own, and the plugin's settings, secrets, and schedules are
+   * keyed by id. Refusing it would force `remove` + `install`, and `remove`
+   * deletes that configuration (#1766). Reinstalling the same directory is
+   * not a move: that stays the "reinstall re-enables" path.
    */
-  function isPathSourceMove(
-    existing: InstalledPluginRow,
+  function pathSourceMoveFrom(
+    existing: InstalledPluginRow | undefined,
     identity: InstallRegistrationIdentity,
-  ): boolean {
-    return (
-      existing.provenance === "direct" &&
-      existing.sourceKind === "path" &&
-      identity.provenance.kind === "direct" &&
-      identity.sourceIntent.kind === "path"
-    );
+  ): InstalledPluginRow | undefined {
+    if (
+      existing === undefined ||
+      existing.provenance !== "direct" ||
+      existing.sourceKind !== "path" ||
+      identity.provenance.kind !== "direct" ||
+      identity.sourceIntent.kind !== "path" ||
+      existing.sourcePath === identity.sourceIntent.canonicalPath
+    ) {
+      return undefined;
+    }
+    return existing;
+  }
+
+  /**
+   * A moved plugin either runs, stays disabled (the move keeps the user's
+   * switch), or loaded and asked for configuration. Any other status means
+   * the new checkout did not start.
+   */
+  function moveStartFailure(pluginId: string): string | null {
+    const runtime = statuses.get(pluginId);
+    if (runtime === undefined) return "plugin reported no status";
+    if (
+      runtime.status === "running" ||
+      runtime.status === "disabled" ||
+      runtime.status === "needs-configuration"
+    ) {
+      return null;
+    }
+    return runtime.detail ?? `plugin status is ${runtime.status}`;
   }
 
   function sameDirectory(a: string, b: string): boolean {
@@ -282,7 +312,7 @@ export function createPluginRegistration(context: PluginRegistrationContext) {
         identity.provenance,
         identity.sourceIntent,
       ) &&
-      !isPathSourceMove(existing, identity)
+      pathSourceMoveFrom(existing, identity) === undefined
     ) {
       throw new Error(
         `plugin id "${pluginId}" is already installed from ${existing.source}; remove it first`,
@@ -337,6 +367,7 @@ export function createPluginRegistration(context: PluginRegistrationContext) {
     await withLifecycleLock(manifest.id, async () => {
       const existing = getInstalledPlugin(deps.db, manifest.id);
       assertInstallRegistrationAvailable(existing, args, manifest.id);
+      const movedFrom = pathSourceMoveFrom(existing, args);
       await disposeOne(manifest.id);
       try {
         await args.beforePersist?.();
@@ -350,28 +381,45 @@ export function createPluginRegistration(context: PluginRegistrationContext) {
           activeArtifactId: args.activeArtifactId ?? null,
           rootDir: args.rootDir,
           version: manifest.version,
-          enabled: true,
+          // A move keeps the user's enable switch; a fresh install and a
+          // same-directory reinstall start the plugin.
+          enabled: movedFrom?.enabled ?? true,
         });
         const row = getInstalledPlugin(deps.db, manifest.id);
         if (row) {
           await loadOne(row);
         }
+        if (movedFrom !== undefined) {
+          // loadOne records a failed factory as status and returns. A move
+          // replaces a working install, so a candidate that does not start
+          // must not take its place.
+          const failure = moveStartFailure(manifest.id);
+          if (failure !== null) {
+            throw new Error(
+              `plugin "${manifest.id}" failed to start from ${args.source}: ${failure}; the install at ${movedFrom.source} was kept`,
+            );
+          }
+        }
       } catch (error) {
+        if (movedFrom !== undefined) {
+          await disposeOne(manifest.id);
+          restoreRegistration(movedFrom);
+        }
         const previous = getInstalledPlugin(deps.db, manifest.id);
         if (previous) {
           await loadOne(previous);
         }
         throw error;
       }
-      if (existing !== undefined && existing.rootDir !== args.rootDir) {
+      if (movedFrom !== undefined) {
         // The old tree is no longer registered: stop the module resolve hook
         // from scanning it, exactly as `remove` does. Two paths can name one
         // directory through a symlink, and that root is still in use.
-        if (!sameDirectory(existing.rootDir, args.rootDir)) {
-          forgetMutableRoot(existing.rootDir);
+        if (!sameDirectory(movedFrom.rootDir, args.rootDir)) {
+          forgetMutableRoot(movedFrom.rootDir);
         }
         logger.info(
-          `plugin ${manifest.id} source moved from ${existing.source} to ${args.source}; settings, secrets, and schedules were kept`,
+          `plugin ${manifest.id} source moved from ${movedFrom.source} to ${args.source}; settings, secrets, and schedules were kept`,
         );
       }
     });

--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -1058,6 +1058,7 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
     withLifecycleLock,
     disposeOne,
     loadOne,
+    statuses,
     validateInstallDir: (args) => managedValidateInstallDir(args),
     checkEngineRange,
     checkPluginSdkRange,

--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -1736,6 +1736,9 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
             recursive: true,
             force: true,
           });
+          logger.info(
+            `plugin ${id} removed from ${row.source}; its settings, secrets, and schedules were deleted`,
+          );
           // Legacy managed installs still own their mutable pre-cache layout.
           // Immutable artifact directories are retained for future GC policy;
           // path: sources are the user's directory and are never deleted.

--- a/apps/server/src/services/plugins/plugin-updates.ts
+++ b/apps/server/src/services/plugins/plugin-updates.ts
@@ -612,7 +612,10 @@ export function createPluginUpdates(
         if (resolution.outcome === "pinned") {
           return {
             ok: false,
-            error: `plugin "${id}" is pinned by its source intent; remove and reinstall it with an npm range, a git branch, or a git semver range to track updates`,
+            error:
+              row.sourceKind === "path"
+                ? `plugin "${id}" is a local path source with no update channel; edit it in place and run \`bb plugin reload ${id}\`, or move it with \`bb plugin install path:<new directory>\` (settings, secrets, and schedules are kept)`
+                : `plugin "${id}" is pinned by its source intent; remove and reinstall it with an npm range, a git branch, or a git semver range to track updates`,
           };
         }
         if (resolution.outcome === "incompatible") {

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -843,7 +843,11 @@ them by mixing ink into canvas), the `--primary` accent, the secondary text tier
     updates for tracking sources, including newer tags that satisfy a Git
     semver range. Same full-trust confirmation as install (`--yes` skips;
     non-TTY refuses without it). Use `bb plugin outdated` to preview available
-    updates; changing a pinned source requires reinstalling it after removal.
+    updates. Changing a pinned git:/npm: source requires `bb plugin remove`
+    (which deletes the plugin's settings, secrets, and schedules) and a fresh
+    install. A local path plugin is never removed to change it: edit it in
+    place and `bb plugin reload <id>`, or `bb plugin install path:<new dir>`
+    to move it; both keep its configuration.
   - `bb plugin list` — status, background services, schedules, handler timings,
     and each plugin's contributed `bb` command.
   - `bb plugin source <id> [--json]` — requested and resolved source, the

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -818,9 +818,12 @@ them by mixing ink into canvas), the `--primary` accent, the secondary text tier
     both exist the install fails — write `@semver:<range>` or `@ref:<name>`.
     Installs prompt for confirmation (plugins are full-trust code);
     pass `--yes` to skip. Reinstalling an already-installed managed plugin is
-    refused — use `bb plugin update`. Plugins that declare a frontend (`bb.app`)
-    are built at install time for path sources and git sources without a
-    prebuilt app when their imported dependencies are already available;
+    refused — use `bb plugin update`. Installing a local path for an id that
+    is already installed from another local path moves the plugin to the new
+    directory and keeps its settings, secrets, and schedules. Plugins that
+    declare a frontend (`bb.app`) are built at install time for path sources
+    and git sources without a prebuilt app when their imported dependencies
+    are already available;
     git/npm packages can also ship a metadata-validated prebuilt `dist/`, and
     npm packages must. Managed git/npm installs refuse `engines.bb` /
     `engines.bbPluginSdk` mismatches, manifest vs. artifact identity mismatches,
@@ -848,7 +851,9 @@ them by mixing ink into canvas), the `--primary` accent, the secondary text tier
     prefix and resolved tag for a Git range install, engine ranges, install
     time, integrity/registry details, and recent activation history.
   - `bb plugin enable|disable <id>`, `bb plugin reload [id]`,
-    `bb plugin remove <id>` (builtin removals are remembered).
+    `bb plugin remove <id>` (deletes the plugin's settings, secrets, and
+    schedules; managed git/npm files are deleted, local path sources stay on
+    disk, builtin removals are remembered).
   - `bb plugin config <id> [set <key> <value> | unset <key>]` — declared
     settings. Reload the plugin after configuring (`bb plugin reload <id>`).
   - `bb plugin logs <id> [-n N] [-f]` — the plugin's `bb.log` output.

--- a/apps/server/test/services/plugins/plugin-service.test.ts
+++ b/apps/server/test/services/plugins/plugin-service.test.ts
@@ -892,6 +892,102 @@ describe("plugin service", () => {
     });
   });
 
+  it("keeps a moved path plugin disabled instead of starting it", async () => {
+    const serverSource = (marker: string) => `
+      export default function plugin() {
+        globalThis.__disabledMoveStarted = "${marker}";
+      }`;
+    const checkoutA = await writePlugin(join(workDir, "a"), {
+      name: "bb-plugin-dormant",
+      serverSource: serverSource("a"),
+    });
+    const checkoutB = await writePlugin(join(workDir, "b"), {
+      name: "bb-plugin-dormant",
+      serverSource: serverSource("b"),
+    });
+    await service.installPath(checkoutA);
+    expect(await service.setEnabled("dormant", false)).toMatchObject({
+      enabled: false,
+      status: "disabled",
+    });
+    delete (globalThis as Record<string, unknown>).__disabledMoveStarted;
+
+    const moved = await service.installPath(checkoutB);
+
+    expect(moved).toMatchObject({
+      id: "dormant",
+      enabled: false,
+      status: "disabled",
+      source: `path:${checkoutB}`,
+    });
+    expect(getInstalledPlugin(db, "dormant")).toMatchObject({
+      enabled: false,
+      rootDir: checkoutB,
+    });
+    expect(
+      (globalThis as Record<string, unknown>).__disabledMoveStarted,
+    ).toBeUndefined();
+    expect(service.getApi("dormant")).toBeUndefined();
+
+    // Re-enabling runs the new checkout.
+    expect(await service.setEnabled("dormant", true)).toMatchObject({
+      status: "running",
+    });
+    expect((globalThis as Record<string, unknown>).__disabledMoveStarted).toBe(
+      "b",
+    );
+  });
+
+  it("rejects a path move whose new checkout fails to start and keeps the old install running", async () => {
+    const checkoutA = await writePlugin(join(workDir, "a"), {
+      name: "bb-plugin-brittle",
+      version: "0.2.0",
+      serverSource: `
+        export default function plugin(bb) {
+          bb.settings.define({
+            token: { type: "string", label: "Token", secret: true },
+          });
+          globalThis.__brittleCheckout = "a";
+        }`,
+    });
+    // A valid package whose factory throws: validation passes, loading fails.
+    const checkoutB = await writePlugin(join(workDir, "b"), {
+      name: "bb-plugin-brittle",
+      version: "0.3.0",
+      serverSource: `
+        export default function plugin() {
+          globalThis.__brittleCheckout = "b";
+          throw new Error("boom at startup");
+        }`,
+    });
+    await service.installPath(checkoutA);
+    await service.updateSettings("brittle", { token: "s3cret" });
+
+    await expect(service.installPath(checkoutB)).rejects.toThrowError(
+      /failed to start from path:.*boom at startup.*was kept/,
+    );
+
+    // The old registration and instance are back, with their configuration.
+    expect(getInstalledPlugin(db, "brittle")).toMatchObject({
+      sourcePath: checkoutA,
+      rootDir: checkoutA,
+      version: "0.2.0",
+      enabled: true,
+    });
+    expect(service.list().find((p) => p.id === "brittle")).toMatchObject({
+      source: `path:${checkoutA}`,
+      version: "0.2.0",
+      status: "running",
+    });
+    expect((globalThis as Record<string, unknown>).__brittleCheckout).toBe(
+      "a",
+    );
+    expect(service.getApi("brittle")).toBeDefined();
+    expect((await service.getSettings("brittle"))?.values).toEqual({
+      token: { set: true },
+    });
+  });
+
   it("warns when a path plugin is installed from inside a managed workspace", async () => {
     const warnSpy = vi.spyOn(logger, "warn");
     // dataDir is <workDir>/data; install from <dataDir>/personal-workspaces/env_X/...

--- a/apps/server/test/services/plugins/plugin-service.test.ts
+++ b/apps/server/test/services/plugins/plugin-service.test.ts
@@ -11,6 +11,7 @@ import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createConnection,
+  getInstalledPlugin,
   migrate,
   upsertInstalledPlugin,
   type DbConnection,
@@ -821,6 +822,74 @@ describe("plugin service", () => {
       status: "running",
     });
     expect(service.getApi("reinstalled")).toBeDefined();
+  });
+
+  it("re-points a path plugin at a new checkout and keeps its settings, secrets, and schedules", async () => {
+    // Two checkouts of the same plugin (same package name, so same id).
+    const serverSource = (marker: string) => `
+      export default function plugin(bb) {
+        bb.settings.define({
+          floor: { type: "string", label: "Floor", default: "60" },
+          token: { type: "string", label: "Token", secret: true },
+        });
+        bb.background.schedule("sweep", "0 * * * *", async () => {});
+        globalThis.__movedCheckout = "${marker}";
+      }`;
+    const checkoutA = await writePlugin(join(workDir, "a"), {
+      name: "bb-plugin-moved",
+      serverSource: serverSource("a"),
+    });
+    const checkoutB = await writePlugin(join(workDir, "b"), {
+      name: "bb-plugin-moved",
+      serverSource: serverSource("b"),
+    });
+    await service.installPath(checkoutA);
+    await service.updateSettings("moved", { floor: "1", token: "s3cret" });
+    expect(
+      db.$client
+        .prepare("SELECT name FROM plugin_schedules WHERE plugin_id = ?")
+        .all("moved"),
+    ).toEqual([{ name: "sweep" }]);
+
+    // The same id from a different local directory replaces the registration
+    // in place instead of demanding a remove (which would delete settings).
+    const moved = await service.installPath(checkoutB);
+
+    expect(moved).toMatchObject({
+      id: "moved",
+      status: "running",
+      source: `path:${checkoutB}`,
+      rootDir: checkoutB,
+    });
+    expect((globalThis as Record<string, unknown>).__movedCheckout).toBe("b");
+    expect(getInstalledPlugin(db, "moved")).toMatchObject({
+      sourceKind: "path",
+      sourcePath: checkoutB,
+      rootDir: checkoutB,
+    });
+    expect((await service.getSettings("moved"))?.values).toEqual({
+      floor: "1",
+      token: { set: true },
+    });
+    expect(
+      db.$client
+        .prepare("SELECT name FROM plugin_schedules WHERE plugin_id = ?")
+        .all("moved"),
+    ).toEqual([{ name: "sweep" }]);
+
+    // A broken new checkout is refused before the live install is touched.
+    const checkoutC = join(workDir, "c", "bb-plugin-moved");
+    await mkdir(checkoutC, { recursive: true });
+    await writeFile(join(checkoutC, "package.json"), "{ not json");
+    await expect(service.installPath(checkoutC)).rejects.toThrowError();
+    expect(getInstalledPlugin(db, "moved")?.rootDir).toBe(checkoutB);
+    expect(service.list().find((p) => p.id === "moved")?.status).toBe(
+      "running",
+    );
+    expect((await service.getSettings("moved"))?.values).toEqual({
+      floor: "1",
+      token: { set: true },
+    });
   });
 
   it("warns when a path plugin is installed from inside a managed workspace", async () => {

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -400,7 +400,12 @@ Reinstalling an already-installed managed plugin is refused — use
 leaves the latest failure visible as needing attention. Exact npm versions,
 git tags and commits, path sources, and bundled official plugins are pinned;
 npm ranges/omitted specs/dist-tags, omitted Git refs (the repository default
-branch), Git branches, and Git semver ranges track compatible updates.
+branch), Git branches, and Git semver ranges track compatible updates. A
+pinned git:/npm: source changes only through `bb plugin remove` (which
+deletes the plugin's settings, secrets, and schedules) and a fresh install. A
+local path plugin is never removed to change it: edit it in place and
+`bb plugin reload <id>`, or `bb plugin install path:<new dir>` to move it to
+another directory; both keep its configuration.
 
 Git semver ranges
 

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -192,6 +192,9 @@ added/updated/unchanged counts.
                                  (the two flags are mutually exclusive)
                                  --tag-prefix <prefix> resolves a git: semver
                                  range over <prefix>vX.Y.Z tags
+                                 Installing a local path for an id that is
+                                 already installed from another local path
+                                 moves it there and keeps its settings
   bb plugin outdated             Check installed plugins for compatible
                                  updates (table; --json for raw results).
                                  Columns: installed, latest compatible,
@@ -220,8 +223,10 @@ added/updated/unchanged counts.
   bb plugin token <id> [--rotate]  Print the token for auth:"token" HTTP
                                  routes; --rotate generates a new token,
                                  invalidating the old one
-  bb plugin remove <id>          Uninstall (managed git:/npm: files deleted;
-                                 builtin removals are remembered)
+  bb plugin remove <id>          Uninstall and delete the plugin's settings,
+                                 secrets, and schedules (managed git:/npm:
+                                 files deleted; local path sources stay on
+                                 disk; builtin removals are remembered)
   bb plugin new <name> [--app]   Scaffold a new plugin and install its npm
                                  dependencies, including @get-bb/plugin-sdk
                                  pinned to this bb's exact SDK version (no


### PR DESCRIPTION
## What was wrong

A plugin installed from a local directory could not be re-pointed at another directory. `assertInstallRegistrationAvailable` in `apps/server/src/services/plugins/plugin-registration.ts` refused a same-id `path:` install whose canonical path differed ("already installed from path:...; remove it first"), and `bb plugin update` is a no-op for path rows. The only route was `bb plugin remove` + `bb plugin install`, and `PluginService.remove()` deletes the plugin's `plugin_settings` rows, `plugin_schedules` rows, and secrets directory. Nothing said so: the CLI help described remove as leaving local sources "alone", the guide and skill did not mention settings, the local-plugin dialog in the app said only "Its source files will stay on disk", both mobile removal sheets said "Its settings and data are kept for a reinstall", and the server logged nothing. Reinstalling from a new checkout silently reset the plugin to defaults.

Issue: #1766. Report: https://get-bb.github.io/reports/issues/1766.html

Review round 1 (SlopCop on `a7b27b219`) reproduced two defects in the first version of the move: a user-disabled plugin started after a move because the upsert forced `enabled: true`, and a valid package whose factory throws replaced the healthy install (loadOne records the error as status and returns) while the CLI reported `Installed`.

## What changed

Server (`apps/server/src/services/plugins/`):

- `plugin-registration.ts`: a *move* is a direct `path:` install of an id that is already registered from a **different** local directory (`pathSourceMoveFrom`). Reinstalling the same directory is not a move and keeps its existing "reinstall re-enables" behavior (covered by the existing test). For a move:
  - the upsert carries the previous row's `enabled` flag, so a disabled plugin stays disabled and does not start (round 1, finding 1);
  - after `loadOne`, any runtime status other than `running`, `disabled`, or `needs-configuration` fails the move: the candidate is disposed, `restoreRegistration()` puts the old row back, the old instance is reloaded, and the install throws `plugin "<id>" failed to start from path:<new>: <detail>; the install at path:<old> was kept`, so the CLI and app report a failure instead of `Installed` (round 1, finding 2). The registration context now receives the runtime `statuses` map for this check. The managed activation flow in `plugin-activation.ts` was not reused: it is artifact-based (`toArtifactId`, on-disk state snapshots, rollback-pending rows) and path sources have no artifacts; the registration module already owns `restoreRegistration`, which is all a path move needs;
  - the old mutable root is forgotten (as `remove` does) unless both paths resolve to the same directory, and the server logs the move.
- `plugin-service.ts`: `remove()` logs what it deleted; passes `statuses` to the registration module.
- `plugin-updates.ts`: `bb plugin update <path plugin>` no longer tells the user to "remove and reinstall"; it says to edit in place + `bb plugin reload`, or `bb plugin install path:<new directory>` to move it (settings kept). The git/npm pinned message is unchanged.

CLI (`apps/cli/src/commands/plugin.ts`):

- `bb plugin remove` describes what it deletes (round 0).
- The install confirmation for a `path:` source names the install it replaces: the CLI already reads the local `package.json` for the summary; it now derives the plugin id, lists installed plugins, and prints `This moves "<id>" from <old dir>; its settings, secrets, and schedules are kept.` before the full-trust prompt. Best effort inside the existing try; a failed list falls back to the plain summary.
- `bb plugin update --all` pinned message now says remove deletes settings and that path plugins reload/move instead (round 1, finding 4). Existing assertion text preserved.

App and mobile (round 1, finding 3): one deletion-policy statement per client, used by every removal dialog.

- `apps/app/src/components/tools/PluginDetail.tsx`: `pluginRemovalDescription()`; used by the desktop detail dialog in `ToolsView.tsx`. `BrowsePluginsTab.tsx` uninstall dialog aligned too (it said "Plugin data may be retained").
- `apps/mobile/src/data/plugins/plugin-model.ts`: `pluginRemovalDescription()`; used by both `PluginsScreen.tsx` and `PluginDetailScreen.tsx` sheets, replacing "Its settings and data are kept for a reinstall".

Docs (round 1, finding 4): `apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md` and `packages/templates/src/templates/bb-guide-plugins.md` now say a pinned git:/npm: source changes through remove (deletes settings) + install, while a local path plugin is never removed to change it: reload in place or install the new path to move it; both keep configuration.

No wire change between server and host daemon, so no `HOST_DAEMON_PROTOCOL_VERSION` bump.

### On the proposed explicit move contract (round 1, finding 5)

Not implemented. The proposal was to carry the expected old canonical path in the install request so a different local plugin that self-declares an installed id cannot inherit its secrets. A local plugin's identity has always been its id: `bb plugin reload` already runs whatever is in the registered directory with the same settings and secrets, and a same-path reinstall does too, so directory contents were never a trust boundary; kv rows and `data.db` are keyed by id and already survive remove + reinstall. The install is an explicit user action behind a full-trust confirmation that now names the exact install being replaced and its old directory, and the server logs the move. An `expectedPreviousPath` request field would be filled only by the CLI (the app has no path-install flow) and would be accepted-but-unused by every other caller, which AGENTS.md forbids. The ungated variant is the one the report listed as acceptable.

## How you verified

Tests in `apps/server/test/services/plugins/plugin-service.test.ts`:

- "re-points a path plugin at a new checkout and keeps its settings, secrets, and schedules" (round 0). Fails on `origin/main` with `Error: plugin id "moved" is already installed from path:.../a/bb-plugin-moved; remove it first` at `plugin-registration.ts:257`.
- "keeps a moved path plugin disabled instead of starting it" (round 1). Against the round-0 source it fails with `AssertionError: expected { id: 'dormant', …(24) } to match object { id: 'dormant', enabled: false, …(2) }` (the moved plugin came back `enabled: true, status: "running"`).
- "rejects a path move whose new checkout fails to start and keeps the old install running" (round 1). Against the round-0 source it fails with `AssertionError: promise resolved "{ id: 'brittle', …(24) }" instead of rejecting`. With the fix it asserts the rejection message, that the DB row is back at checkout A (`version 0.2.0`, `enabled: true`), that checkout A's factory ran again, `getApi()` is defined, and the secret is still set.

App: new test in `apps/app/src/views/ToolsView.plugin-detail.test.tsx` ("warns that removing a local plugin deletes its settings, secrets, and schedules and names the move path") renders `ToolsView` with a `path:` plugin from a stubbed `/api/v1/plugins`, opens the actions menu, clicks "Remove from bb", and asserts the dialog copy. Mobile: `plugin-model.test.ts` asserts `pluginRemovalDescription` for both branches and that the old "kept for a reinstall" wording is gone.

Commands (all from this branch, rebased on `origin/main` `2ff85986e`):

- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/cli --filter=@bb/app --filter=@bb/mobile --filter=@bb/templates`: 8/8 tasks.
- `pnpm exec turbo run test --filter=@bb/server --filter=@bb/templates`: templates 6 files passed; server 194/195 files passed, the one failure is the pre-existing `internal-skill-trees.test.ts` file-mode assertion (local umask 0002 artifact, passes in CI).
- `pnpm exec turbo run test --filter=@bb/cli --filter=@bb/mobile`: cli 48 files passed, mobile 123 files passed.
- `apps/app`: `vitest run src/views/ToolsView.plugin-detail.test.tsx src/components/plugin/management src/components/tools`: 14 files passed.

Manual repro on my own dev instance of this branch (server :22310, CLI built from this branch with `BB_CLI_REEXEC=1` so the daemon's `BB_CLI` hop did not swap in another checkout's binary):

1. `bb plugin install --yes path:.../a/bb-plugin-mover`, `config set floor 7`, `config set token s3cret`, `bb plugin disable mover`.
2. `bb plugin install --yes path:.../b/bb-plugin-mover` → `mover@0.2.0  disabled`, `source: path:.../b/...`; server log `plugin mover source moved from path:.../a/... to path:.../b/...; settings, secrets, and schedules were kept`. (Round 0 started it.)
3. Enabled it; `bb plugin config mover` shows `floor = "7"`, `token = [set]`.
4. `bb plugin install path:.../c/bb-plugin-mover` (valid package, factory throws) prints `This moves "mover" from .../b/bb-plugin-mover; its settings, secrets, and schedules are kept.` at the confirmation, then with `--yes`: `Error: HTTP 422: plugin "mover" failed to start from path:.../c/...: boom at startup; the install at path:.../b/... was kept`. Afterwards `/api/v1/plugins` shows `mover 0.2.0 running path:.../b/...` and `bb plugin config mover` still shows `7` / `[set]`. (Round 0 reported `Installed` with the plugin in `error`.)
5. `POST /api/v1/plugins/mover/update` returns the new path-specific message.

Fixes #1766

> AGENT GENERATED: by Claude Opus 5

## Independent verification (round 0, on `a7b27b219`; findings addressed above)

Checked out `a7b27b219` (this PR's head) into a fresh worktree branched from `FETCH_HEAD`; `origin/main` (`c9aef7514`) is an ancestor, no conflicts.

Commands:

- `pnpm install --frozen-lockfile --prefer-offline && pnpm exec turbo run build` (18/18 tasks).
- Fail-before: `git checkout origin/main -- <the 6 non-test files>` then `pnpm exec vitest run test/services/plugins/plugin-service.test.ts -t "re-points a path plugin"` in `apps/server`. Result: `1 failed`, `Error: plugin id "moved" is already installed from path:/tmp/bb-plugin-test-cJ0tMv/a/bb-plugin-moved; remove it first` at `plugin-registration.ts:258`.
- Pass-after: restored the PR files, full `plugin-service.test.ts`: 25/25 passed.
- Extra ad-hoc probes (not committed): `mv` of the checkout (old dir gone) then install from the new path keeps settings and reloads; installing a symlink alias of the same directory keeps the mutable root live (reload picks up edits); a same-id managed `git:` row still refuses a `path:` install; a new checkout whose factory throws registers in `error` state pointing at the new dir with settings rows intact (same as a same-path reinstall today).
- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/cli --filter=@bb/app --filter=@bb/templates`: 7/7.
- `pnpm exec turbo run test --filter=@bb/server`: 1819/1820 passed; the one failure is `internal-skill-trees.test.ts` mode 420 vs 436 (local umask artifact, passes in CI). `@bb/cli` 453 passed, `@bb/templates` 6 files passed, `@bb/app` 3187 passed with one `TimelineRowDetails.output-preview` 15s timeout that passed on rerun (unrelated to this change).
- Repro on the fixed branch against my own dev instance (server :22063): `bb plugin install --yes path:.../checkout-a`, set `alertFloorMinutes=1`, `staleWindowMinutes=3`, `token=s3cret`; `bb plugin install --yes path:.../checkout-b` succeeded (was HTTP 422 on main); `bb plugin config watchdog` still shows `1` / `3` / `[set]`; `bb plugin source watchdog` shows `path:.../checkout-b`; server log: `plugin watchdog source moved from path:.../checkout-a to path:.../checkout-b; settings, secrets, and schedules were kept`. `bb plugin remove --help` from this branch's CLI build prints the new description. The original bug no longer reproduces.
- CI: all checks pass (Checks, Package Smoke x2, Tests server/app-1..3/integration/packages, version check).

Residual risks noted in round 0 (all addressed in round 1):

- A move to a checkout whose server entry throws was not rolled back. Now rolled back; test added.
- A disabled path plugin became enabled after a move. Now preserved; test added.
- Installing a different local plugin that reuses an installed local id replaces that registration. Still true by design; the CLI confirmation now names the replaced install (see finding 5 above).
- `SKILL.md` said "changing a pinned source requires reinstalling it after removal". Reworded for git/npm vs path.

> AGENT GENERATED: by Claude Opus 5



## Independent verification (round 2, on `8dd601638`)

Checked out `bb/fix-1766-plugin-source-replace` at `8dd601638` in a fresh worktree (based on `2ff85986e`; a trial `git merge origin/main` at `703213a77` is clean). Diff against the merge-base: 16 files, +444/-29. No server/daemon wire change, so no `HOST_DAEMON_PROTOCOL_VERSION` bump is needed. No accepted-but-ignored fields, no casts outside tests, guide template and bb-cli skill updated for the changed `remove` help and the move behavior.

**Fail-before / pass-after.** With `apps/server/src/services/plugins/{plugin-registration,plugin-service,plugin-updates}.ts` reverted to `origin/main`, all three move tests fail (`Error: plugin id "moved" is already installed from path:.../a/bb-plugin-moved; remove it first`; brittle: `expected [Function] to throw error matching /failed to start from path:.*boom at s…/ but got 'plugin id "brittle" is already instal…'`). With those files at the round-0 commit `dfdf9a9d6`, the two round-1 tests still fail: `expected { id: 'dormant', …(24) } to match object { id: 'dormant', enabled: false, …(2) }` and `promise resolved "{ id: 'brittle', …(24) }" instead of rejecting`. Restored to the PR head: 6/6 move-related tests pass. App test against main's `PluginDetail.tsx`/`ToolsView.tsx`: `expected 'Remove "github" from bb? Its source f…' to contain 'delete its settings, secrets, and sch…'`; mobile test against main's `plugin-model.ts`: `TypeError: pluginRemovalDescription is not a function`. Both pass on the PR head.

**Turbo.** `turbo run typecheck` for `@bb/server`, `@bb/cli`, `@bb/app`, `@bb/mobile`, `@bb/templates`: 8/8 pass. `turbo run test`: templates 6/6 files, cli 48/48, mobile 123/123. Server: 25 files timed out at 5s under load (dev instance and build were starting concurrently); re-run in isolation 24/25 pass, the one remaining failure is the pre-existing local `internal-skill-trees` umask (0644 vs 0664) failure, which passes in CI. App: 14 files / 157 tests for `components/plugin/management`, `components/tools`, `ToolsView.plugin-detail` pass. GitHub CI on `8dd601638`: all checks pass (Checks, Package Smoke x2, Tests app-1/2/3, integration, packages, server).

**Manual repro on my own dev instance (server :23641, own data dir, CLI from this branch with `BB_CLI_REEXEC=1`).** Fixture = the report's watchdog plugin in three directories: A (0.1.0), B (0.2.0), C (0.3.0, valid manifest, factory throws `boom at startup`).
- Original bug: install A, set `alertFloorMinutes=1`, `staleWindowMinutes=3`, `token=s3cret`; `bb plugin install --yes path:B` prints `This moves "watchdog" from .../a; its settings, secrets, and schedules are kept.` and `watchdog@0.2.0 running` at `path:.../b`; `bb plugin config watchdog` still shows `1` / `3` / `[set]`, `plugin_schedules` still has `sweep`. Server log: `plugin watchdog source moved from path:.../a to path:.../b; settings, secrets, and schedules were kept`. No longer reproduces.
- Round-1 finding 1 (disabled plugin started by a move): `bb plugin disable watchdog`, then `install --yes path:A` -> `watchdog@0.1.0 disabled`, `plugins.enabled = 0` in the DB, no `loaded` log line for the move.
- Round-1 finding 2 (broken checkout replaces a healthy one): with the plugin running at B, `install --yes path:C` -> `Error: HTTP 422: plugin "watchdog" failed to start from path:.../c: boom at startup; the install at path:.../b was kept`, exit 1; `bb plugin list` shows `watchdog@0.2.0 running` at B, settings `1`/`3`/`[set]`, schedule and secrets file still present, DB row `enabled=1 root_dir=.../b version=0.2.0`.
- Round-1 finding 3 (removal copy): read all four surfaces; desktop detail dialog and mobile sheets go through one `pluginRemovalDescription()` per client and name settings, secrets, and schedules; the browse-tab uninstall dialog no longer claims data may be retained. `bb plugin remove watchdog` logs `... removed from path:.../b; its settings, secrets, and schedules were deleted` and the rows are gone.
- Round-1 finding 4: `POST /plugins/watchdog/update` on a path row returns the new reload-or-install-the-new-path message; `bb plugin update --all` prints the new pinned message.
- Round-1 finding 5: agree with the refutation in the body; no request-level gate is warranted.
- Mutable-root sanity: after A->B->A, editing A and `bb plugin reload` picks up a new setting; after moving back to B (whose root was forgotten), editing B and reloading picks up the change.

**Residual risks.** A move while the plugin is disabled does not validate the new checkout (loadOne short-circuits to `disabled`), so `install path:C` while disabled succeeds and the factory error surfaces only on enable; settings are still kept and this matches how a disabled plugin behaves on reload. The move check covers only the immediate post-load status, as the body notes. A same-id local plugin from a different directory inherits settings and secrets by design; the CLI confirmation names the replaced install, but `--yes` skips it.

> AGENT GENERATED: by Claude Opus 5
