### PR TITLE
Skip replayed turn/started events at daemon ingestion

### DIFF
--- a/apps/server/test/internal/internal-events-tool-calls.test.ts
+++ b/apps/server/test/internal/internal-events-tool-calls.test.ts
@@ -1010,13 +1010,22 @@ describe("internal event and tool-call routes", () => {
         harness.db.select().from(threads).where(eq(threads.id, thread.id)).get()
           ?.status,
       ).toBe("idle");
+      // The replayed turn/started is the same provider turn, so it is not
+      // stored twice; a second start would break timeline projection.
       expect(
         harness.db
-          .select()
+          .select({ type: events.type })
           .from(events)
           .where(eq(events.threadId, thread.id))
-          .all(),
-      ).toHaveLength(4);
+          .orderBy(events.sequence)
+          .all()
+          .map((event) => event.type),
+      ).toEqual(["turn/started", "turn/completed", "turn/completed"]);
+
+      const timelineResponse = await harness.app.request(
+        `/api/v1/threads/${thread.id}/timeline`,
+      );
+      expect(timelineResponse.status).toBe(200);
     });
   });
 

--- a/apps/server/test/public/public-thread-data.test.ts
+++ b/apps/server/test/public/public-thread-data.test.ts
@@ -445,6 +445,63 @@ describe("public thread data routes", () => {
     });
   });
 
+  it("returns a timeline when a stored history holds a duplicate turn/started from a daemon replay", async () => {
+    await withTestHarness(async (harness) => {
+      const { environment, thread } = seedThreadFixture(harness);
+      const eventBase = {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-thread-retried",
+        scope: turnScope("turn-retried"),
+      };
+
+      seedEvent(harness.deps, {
+        ...eventBase,
+        sequence: 1,
+        type: "turn/started",
+        data: {},
+      });
+      seedEvent(harness.deps, {
+        ...eventBase,
+        sequence: 2,
+        type: "turn/started",
+        data: {},
+      });
+      seedEvent(harness.deps, {
+        ...eventBase,
+        sequence: 3,
+        type: "item/completed",
+        data: {
+          item: {
+            type: "toolCall",
+            id: "tool-call-retried",
+            tool: "read",
+            status: "completed",
+            result: "ok",
+          },
+        },
+      });
+      seedEvent(harness.deps, {
+        ...eventBase,
+        sequence: 4,
+        type: "turn/completed",
+        data: { status: "completed" },
+      });
+
+      const response = await harness.app.request(
+        `/api/v1/threads/${thread.id}/timeline`,
+      );
+
+      expect(response.status).toBe(200);
+      const timeline = threadTimelineResponseSchema.parse(
+        await readJson(response),
+      );
+      expect(timeline.rows.filter((row) => row.kind === "turn")).toHaveLength(
+        1,
+      );
+    });
+  });
+
   it("returns the full conversation outline beyond the paginated timeline window", async () => {
     await withTestHarness(async (harness) => {
       const { environment, thread } = seedThreadFixture(harness);

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -474,9 +474,6 @@ function collectDaemonTurnStartLookupKeys(
   const keys: ThreadTurnKey[] = [];
 
   for (const input of eventInputs) {
-    if (input.type === "turn/started") {
-      continue;
-    }
     const turnId = getThreadEventScopeTurnId(input.scope);
     if (turnId === undefined) {
       continue;
@@ -519,22 +516,30 @@ const ORPHAN_DROPPABLE_TURN_EVENT_TYPES: ReadonlySet<ThreadEventType> = new Set(
   "provider/unhandled",
 ]);
 
-type DaemonTurnStartDisposition = "append" | "skip-orphan-snapshot";
+type DaemonTurnStartDisposition =
+  | "append"
+  | "skip-duplicate-turn-start"
+  | "skip-orphan-snapshot";
 
 function resolveDaemonTurnStartDisposition(
   input: AppendDaemonEventInput,
   startedTurnKeys: ReadonlySet<string>,
 ): DaemonTurnStartDisposition {
-  if (input.type === "turn/started") {
-    return "append";
-  }
-
   const turnId = getThreadEventScopeTurnId(input.scope);
   if (turnId === undefined) {
     return "append";
   }
 
   const key = buildThreadTurnKey({ threadId: input.threadId, turnId });
+  if (input.type === "turn/started") {
+    // Daemon delivery is at-least-once: when the server commits a batch but
+    // the acknowledgement is lost (gateway 502/504, dropped connection), the
+    // daemon reposts the same events. A provider turn starts exactly once, so
+    // a turn/started whose (threadId, turnId) is already stored is that replay,
+    // not a new turn. Storing it twice would break timeline projection.
+    return startedTurnKeys.has(key) ? "skip-duplicate-turn-start" : "append";
+  }
+
   if (startedTurnKeys.has(key)) {
     return "append";
   }
@@ -713,11 +718,15 @@ export function appendDaemonEventsInTransaction(
   );
   const now = Date.now();
   for (const [index, input] of eventInputs.entries()) {
-    if (
-      resolveDaemonTurnStartDisposition(input, startedTurnKeys) ===
-      "skip-orphan-snapshot"
-    ) {
+    const turnStartDisposition = resolveDaemonTurnStartDisposition(
+      input,
+      startedTurnKeys,
+    );
+    if (turnStartDisposition === "skip-orphan-snapshot") {
       skippedTurnUnstartedInputIndexes.push(index);
+      continue;
+    }
+    if (turnStartDisposition === "skip-duplicate-turn-start") {
       continue;
     }
 

--- a/packages/db/test/data/events.test.ts
+++ b/packages/db/test/data/events.test.ts
@@ -653,6 +653,79 @@ describe("events", () => {
     });
   });
 
+  it("skips turn/started when a daemon replays an already-committed batch", () => {
+    const { db, thread } = setup();
+    const turnStarted = {
+      threadId: thread.id,
+      type: "turn/started" as const,
+      ...createTurnEventFields({ turnId: "turn_replayed" }),
+      environmentId: null,
+      providerThreadId: "provider_thr_replayed",
+      data: JSON.stringify({
+        providerThreadId: "provider_thr_replayed",
+        turnId: "turn_replayed",
+      }),
+    };
+    const turnCompleted = {
+      threadId: thread.id,
+      type: "turn/completed" as const,
+      ...createTurnEventFields({ turnId: "turn_replayed" }),
+      environmentId: null,
+      providerThreadId: "provider_thr_replayed",
+      data: JSON.stringify({
+        providerThreadId: "provider_thr_replayed",
+        status: "completed",
+        turnId: "turn_replayed",
+      }),
+    };
+
+    const first = db.transaction(
+      (tx) => appendDaemonEventsInTransaction(tx, [turnStarted, turnCompleted]),
+      { behavior: "immediate" },
+    );
+    // The server committed the batch but the acknowledgement was lost, so the
+    // daemon posts the identical batch again.
+    const replay = db.transaction(
+      (tx) => appendDaemonEventsInTransaction(tx, [turnStarted, turnCompleted]),
+      { behavior: "immediate" },
+    );
+
+    expect(first.insertedInputIndexes).toEqual([0, 1]);
+    expect(replay).toEqual({
+      acceptedEvents: [{ threadId: thread.id, sequence: 3 }],
+      insertedInputIndexes: [1],
+      skippedTurnUnstartedInputIndexes: [],
+    });
+    expect(
+      listEvents(db, { threadId: thread.id }).map((event) => event.type),
+    ).toEqual(["turn/started", "turn/completed", "turn/completed"]);
+  });
+
+  it("skips a turn/started repeated inside one daemon batch", () => {
+    const { db, thread } = setup();
+    const turnStarted = {
+      threadId: thread.id,
+      type: "turn/started" as const,
+      ...createTurnEventFields({ turnId: "turn_twice" }),
+      environmentId: null,
+      providerThreadId: "provider_thr_twice",
+      data: JSON.stringify({
+        providerThreadId: "provider_thr_twice",
+        turnId: "turn_twice",
+      }),
+    };
+
+    const result = db.transaction(
+      (tx) => appendDaemonEventsInTransaction(tx, [turnStarted, turnStarted]),
+      { behavior: "immediate" },
+    );
+
+    expect(result.insertedInputIndexes).toEqual([0]);
+    expect(
+      listEvents(db, { threadId: thread.id }).map((event) => event.type),
+    ).toEqual(["turn/started"]);
+  });
+
   it("rejects daemon turn-scoped events before turn/started is stored", () => {
     const { db, thread } = setup();
 

--- a/packages/thread-view/src/group-event-projection-turns.ts
+++ b/packages/thread-view/src/group-event-projection-turns.ts
@@ -248,11 +248,12 @@ export function groupEventProjectionTurns(
         type: event.type,
         scope: event.scope,
       });
-      const existing = turnsById.get(turnId);
-      if (existing) {
-        throw new Error(
-          `Timeline projection found duplicate turn/started for ${turnId}`,
-        );
+      if (turnsById.has(turnId)) {
+        // Histories stored before ingestion deduplicated turn/started can hold
+        // the same provider turn start twice (a daemon replay after a lost
+        // acknowledgement). The first start is canonical; one replayed
+        // lifecycle marker must not make the whole timeline unreadable.
+        continue;
       }
       turnsById.set(turnId, createProjectionTurn(event, meta));
       entryDrafts.push({

--- a/packages/thread-view/test/build-thread-timeline.test.ts
+++ b/packages/thread-view/test/build-thread-timeline.test.ts
@@ -948,6 +948,28 @@ function fileChangeRowIdByPath(
 }
 
 describe("buildThreadTimelineFromEvents", () => {
+  it("renders one turn when daemon retry history contains duplicate turn starts", () => {
+    const rows = buildTimelineRows([
+      turnStartedEvent({ seq: 1 }),
+      turnStartedEvent({ seq: 2 }),
+      toolCallItemEvent({
+        seq: 3,
+        tool: "read",
+        type: "item/started",
+      }),
+      toolCallItemEvent({
+        result: "ok",
+        seq: 4,
+        tool: "read",
+        type: "item/completed",
+      }),
+      turnCompletedEvent({ seq: 5 }),
+    ]);
+
+    expect(rows.filter((row) => row.kind === "turn")).toHaveLength(1);
+    expect(collectToolRows(rows)).toHaveLength(1);
+  });
+
   const lowercaseStructuredToolCases: LowercaseStructuredToolCase[] = [
     {
       expectedIntent: {


### PR DESCRIPTION
## What was wrong

The host daemon delivers event batches at least once. `apps/host-daemon/src/event-sink.ts` keeps the whole queue on any non-permanent post failure and reposts it on the next flush. When the server had already committed the batch but the acknowledgement was lost (gateway 502/504, dropped connection), the repost carried the same `turn/started` with the same provider turn id. `appendDaemonEventsInTransaction` in `packages/db/src/data/events.ts` assigned every insert a fresh event id and sequence and never checked whether a `turn/started` for that `(threadId, turnId)` was already stored, so the replay persisted a second start. `groupEventProjectionTurns` in `packages/thread-view` requires one start per turn and threw `Timeline projection found duplicate turn/started`, so `GET /api/v1/threads/:id/timeline` answered 500 for a thread whose events were intact.

Issue: #1839. The linked report URL (https://get-bb.github.io/reports/issues/1839.html) returns 404; this PR reproduces the bug from the issue's own steps.

## What changed

- `packages/db/src/data/events.ts`: ingestion now includes `turn/started` inputs in the stored-turn-start lookup and skips a `turn/started` whose `(threadId, turnId)` is already stored (or was already appended earlier in the same batch). This mirrors the terminal-item dedup that already lives in the same transaction. A provider turn starts exactly once (the daemon-side `ThreadEventGrammar` enforces `turnStartsOnce`), so a repeated start is a delivery replay, not a new turn. Skipped starts are not reported in `acceptedEvents`; the daemon already treats a 200 as full delivery, and `shouldApplyEventEffect` in `apps/server/src/internal/events.ts` already re-applies `turn/started` effects for non-inserted events, so a replay still repairs thread status.
- `packages/thread-view/src/group-event-projection-turns.ts`: a second `turn/started` for a turn already in the projection is ignored instead of throwing, so histories persisted before this change stay readable. The first start is canonical.
- No wire change. `HOST_DAEMON_PROTOCOL_VERSION` is unchanged: the request and response shapes of `/session/events` are the same; only which inputs are inserted differs.

Other replayed event types keep their current behavior (a replayed `turn/completed` is still stored twice; projection already tolerates that). This is not a general exactly-once delivery change.

Relation to #1560: that PR takes the same approach but is based on `a83c12946` and now conflicts with `main` (the terminal-item dedup landed in the same function). This PR applies the fix on current `main`, keeps the `turn/started`-in-batch-twice case covered, and extends the existing replay route test to assert both the stored event types and the timeline route.

## How you verified

New or updated tests, each run with the source files checked out from `origin/main` (fail) and on this branch (pass):

- `packages/db/test/data/events.test.ts`
  - `skips turn/started when a daemon replays an already-committed batch` — before: `AssertionError: expected { …(3) } to deeply equal { acceptedEvents: [ { …(2) } ], …(2) }` (replay inserted index 0 as sequence 3 and the completion as 4)
  - `skips a turn/started repeated inside one daemon batch` — before: `AssertionError: expected [ +0, 1 ] to deeply equal [ +0 ]`
- `apps/server/test/internal/internal-events-tool-calls.test.ts`
  - `keeps a thread idle when a started/completed batch is posted again` now asserts stored types are `["turn/started", "turn/completed", "turn/completed"]` and that the timeline route returns 200 — before: `AssertionError: expected [ 'turn/started', …(3) ] to deeply equal [ 'turn/started', …(2) ]`
- `apps/server/test/public/public-thread-data.test.ts`
  - `returns a timeline when a stored history holds a duplicate turn/started from a daemon replay` — before: `AssertionError: expected 500 to be 200`
- `packages/thread-view/test/build-thread-timeline.test.ts`
  - `renders one turn when daemon retry history contains duplicate turn starts` — before: `Error: Timeline projection found duplicate turn/started for turn-1`

Commands:

- `pnpm exec turbo run typecheck --filter=@bb/db --filter=@bb/thread-view --filter=@bb/server` — pass
- `pnpm exec turbo run test --filter=@bb/db --filter=@bb/thread-view --force` — 408 and 380 tests pass
- `pnpm exec turbo run test --filter=@bb/server --filter=@bb/client-core --filter=@bb/cli --force` — client-core 238 pass; server and cli hit 5s vitest timeouts under a load average above 40 on this shared machine, so I re-ran the timed-out server files in isolation: 383 pass, with the one remaining failure being the known local umask 0002 mismatch in `internal-skill-trees.test.ts` (0644 vs 0664), unrelated to this change

Manual check: a lost acknowledgement between daemon and server cannot be forced through the dev app without a fault-injecting proxy, so the route-level test that posts the identical batch twice through the real `/session/events` route and then reads the timeline is the faithful equivalent.

Fixes #1839

> AGENT GENERATED: by Claude Opus 5



## Independent verification

Verified on a fresh worktree at `d7de9e5c3` (branch `bb/fix-1839-duplicate-turn-started`; `origin/main` = `c9aef7514` is an ancestor; GitHub reports `MERGEABLE`).

Own root-cause read before reading this PR: `apps/host-daemon/src/event-sink.ts` `deliverBatch` returns 0 on any non-permanent post failure, so a batch the server committed but whose response was lost is reposted verbatim; on main `collectDaemonTurnStartLookupKeys` skipped `turn/started` inputs and `resolveDaemonTurnStartDisposition` returned `append` for every `turn/started`, so the replay stored a second start; `groupEventProjectionTurns` threw on it. The fix is at the right layer (server-owned ingestion policy in `@bb/db`; no daemon or wire change, so no `HOST_DAEMON_PROTOCOL_VERSION` bump is needed). `shouldApplyEventEffect` in `apps/server/src/internal/events.ts` already re-applies `turn/started` effects for non-inserted inputs, so thread status is still repaired on replay. The daemon grammar (`turnStartsOnce`) and the per-assembler random turn-id prefix (`delta-assembler.ts` `mintTurnId`) mean a repeated `(threadId, turnId)` start is a replay, not a new turn.

Fail-before (`git checkout origin/main -- packages/db/src/data/events.ts packages/thread-view/src/group-event-projection-turns.ts`, tests from the branch):

- `@bb/db` `skips turn/started when a daemon replays an already-committed batch`: `AssertionError: expected { …(3) } to deeply equal { acceptedEvents: [ { …(2) } ], …(2) }`
- `@bb/db` `skips a turn/started repeated inside one daemon batch`: `AssertionError: expected [ +0, 1 ] to deeply equal [ +0 ]`
- `@bb/thread-view` `renders one turn when daemon retry history contains duplicate turn starts`: `Error: Timeline projection found duplicate turn/started for turn-1`
- `@bb/server` `keeps a thread idle when a started/completed batch is posted again`: `AssertionError: expected [ 'turn/started', …(3) ] to deeply equal [ 'turn/started', …(2) ]`
- `@bb/server` `returns a timeline when a stored history holds a duplicate turn/started from a daemon replay`: `AssertionError: expected 500 to be 200`

Pass-after (`git checkout HEAD -- <same files>`): all five pass.

Commands:

- `pnpm exec turbo run typecheck --filter=@bb/db --filter=@bb/thread-view --filter=@bb/server --filter=@bb/client-core`: pass
- `pnpm exec turbo run test --filter=@bb/db --filter=@bb/thread-view --filter=@bb/client-core --force`: 408 / 380 / 238 pass
- `pnpm exec turbo run test --filter=@bb/server --force`: 1819 pass, 1 fail (`internal-skill-trees.test.ts` mode 420 vs 436, the known local umask 0002 mismatch; passes in CI)

Repro on the fixed branch: the issue's own reproduction (two stored `turn/started` rows for one `(threadId, turnId)`, then `GET /api/v1/threads/:id/timeline`) is exactly the `public-thread-data` route test; it returns 500 with main's sources and 200 on this branch. The replay path through the real `/session/events` route stores `[turn/started, turn/completed, turn/completed]` and the timeline returns 200. A lost daemon-to-server acknowledgement cannot be forced on a live dev instance without a fault-injecting proxy, so no dev instance was started.

CI: all test jobs, Package Smoke, and "Build, typecheck, and lint" pass. The `Checks` job is red only on its last step, `Check Actions cache usage`, which timed out connecting to `api.github.com` (infra, unrelated).

Residual risks: a skipped duplicate start is not logged (the orphan-snapshot skip is); replayed non-start events such as `turn/completed` are still stored twice, as on main, and projection tolerates that.

> AGENT GENERATED: by Claude Opus 5
