### PR TITLE
Route plugin service uncaught exceptions to the service supervisor

### DIFF
--- a/apps/server/src/services/plugins/plugin-runtime.ts
+++ b/apps/server/src/services/plugins/plugin-runtime.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { createHash, randomUUID } from "node:crypto";
 import {
   createReadStream,
@@ -324,6 +325,15 @@ const SERVICE_RESTART_MAX_MS = 60_000;
 /** A crash after this much healthy runtime resets the backoff sequence. */
 const SERVICE_HEALTHY_RESET_MS = 5 * 60_000;
 
+/** One run of a background service, from runService to its settlement. */
+interface ServiceInstance {
+  id: string;
+  service: ServiceRuntime;
+  controller: AbortController;
+  /** Set once an uncaught exception from this run has been claimed. */
+  uncaughtError: { error: unknown } | undefined;
+}
+
 export interface PluginRuntimeContext {
   deps: PluginServiceDeps;
   nextCronRunAt: (cron: string, now: number) => number;
@@ -553,22 +563,94 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
     return undefined;
   }
 
+  /**
+   * The service instance whose async context is executing. Plugins run
+   * in-process, so an error a service raises outside its start() promise
+   * (an unlistened EventEmitter 'error', a throw in a timer callback, a
+   * detached rejection) reaches the process as an uncaught exception, not
+   * the promise chain runService watches. The store follows every timer,
+   * socket callback, and promise the service creates, so
+   * handleUncaughtException can hand the error back to the supervisor.
+   */
+  const serviceContext = new AsyncLocalStorage<ServiceInstance>();
+
   /** Start (or restart) one background service instance. */
   function runService(id: string, service: ServiceRuntime): void {
     const controller = new AbortController();
     service.controller = controller;
     service.state = "running";
     service.startedAt = Date.now();
+    const instance: ServiceInstance = {
+      id,
+      service,
+      controller,
+      uncaughtError: undefined,
+    };
     // The async wrapper normalizes sync throws from start() into rejections.
-    const current = (async () => {
+    const current = serviceContext.run(instance, async () => {
       await service.record.start(controller.signal);
-    })();
+    });
     service.current = current;
     current.then(
-      () => onServiceSettled(id, service, { crashed: false }),
+      () =>
+        instance.uncaughtError === undefined
+          ? onServiceSettled(id, service, { crashed: false })
+          : onServiceSettled(id, service, {
+              crashed: true,
+              error: instance.uncaughtError.error,
+            }),
       (error: unknown) =>
-        onServiceSettled(id, service, { crashed: true, error }),
+        onServiceSettled(id, service, {
+          crashed: true,
+          // The out-of-band error came first; a rejection after the abort
+          // is its consequence.
+          error: instance.uncaughtError?.error ?? error,
+        }),
     );
+  }
+
+  /**
+   * Claims an uncaught exception raised from a service's async context.
+   * Returns false when no service owns it, so the caller keeps Node's
+   * default and exits. A live instance is aborted; its settlement then
+   * takes the crash path (backoff + restart) with this error as the cause.
+   */
+  function handleUncaughtException(error: unknown): boolean {
+    const instance = serviceContext.getStore();
+    if (instance === undefined) return false;
+    const { id, service, controller } = instance;
+    const name = service.record.name;
+    const message = error instanceof Error ? error.message : String(error);
+    if (service.controller !== controller || service.disposed) {
+      // A previous run (restarted or disposed) left a timer or emitter behind.
+      logger.warn(
+        `[plugin:${id}] service ${name} raised an uncaught exception from a stopped run: ${message}`,
+      );
+      return true;
+    }
+    if (instance.uncaughtError !== undefined) return true;
+    instance.uncaughtError = { error };
+    logger.warn(
+      { err: error },
+      `[plugin:${id}] service ${name} raised an uncaught exception outside start(): ${message} — aborting it`,
+    );
+    const current = service.current;
+    controller.abort();
+    if (current === null) return true;
+    void settledWithin(current, serviceStopTimeoutMs).then((settled) => {
+      if (settled || service.controller !== controller || service.disposed) {
+        return;
+      }
+      setStatus(
+        id,
+        "degraded",
+        `service ${name} did not stop after an uncaught exception`,
+      );
+      logger.warn(
+        `[plugin:${id}] service ${name} did not stop within ${serviceStopTimeoutMs}ms of its uncaught exception — plugin degraded until it does`,
+      );
+    });
+    return true;
   }
 
   function onServiceSettled(
@@ -1789,6 +1871,7 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
     disposeOne,
     emitThreadEvent,
     handlerStats,
+    handleUncaughtException,
     hungServices,
     invokeWrapped,
     isBuiltinPluginId,

--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -186,6 +186,14 @@ export interface PluginService {
   start(): Promise<void>;
   /** Dispose all loaded plugins (server shutdown). */
   stop(): Promise<void>;
+  /**
+   * Route a process-level uncaught exception raised from a background
+   * service's async context (an unlistened EventEmitter 'error', a timer
+   * throw, a detached rejection) back to that service's supervisor, which
+   * aborts and restarts it with backoff. Returns false when no service owns
+   * the error; the caller then keeps Node's default and exits.
+   */
+  handleUncaughtException(error: unknown): boolean;
   list(): PluginListEntry[];
   /** Palettes declared by currently loaded plugins, ordered by plugin id. */
   listThemes(): PluginThemeMeta[];
@@ -1003,6 +1011,7 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
     disposeOne,
     emitThreadEvent,
     handlerStats,
+    handleUncaughtException,
     hungServices,
     hostArtifacts,
     identities,
@@ -1602,6 +1611,8 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
       await syncCliSkill();
       notifyPluginsChanged();
     },
+
+    handleUncaughtException,
 
     list,
 

--- a/apps/server/src/start-server.ts
+++ b/apps/server/src/start-server.ts
@@ -291,6 +291,21 @@ export async function runServer(serverConfig: ServerConfig): Promise<void> {
     return shutdownPromise;
   };
 
+  // Plugins run in-process. An error a plugin service raises outside its
+  // start() promise (an unlistened EventEmitter 'error', a throw in a timer
+  // callback, a detached rejection) arrives here, not in the service
+  // supervisor; without this listener Node exits, the process manager
+  // restarts the server, the plugin reloads, and the crash loops. A claimed
+  // error restarts that one service. Anything else keeps Node's default:
+  // the diagnostics monitor in index.ts has already written its report.
+  process.on("uncaughtException", (error: unknown) => {
+    if (pluginService.handleUncaughtException(error)) return;
+    const message =
+      error instanceof Error ? (error.stack ?? error.message) : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exit(1);
+  });
+
   process.once("SIGINT", () => {
     void runShutdown().finally(() => process.exit(0));
   });

--- a/apps/server/test/services/plugins/plugin-background.test.ts
+++ b/apps/server/test/services/plugins/plugin-background.test.ts
@@ -319,6 +319,71 @@ describe("plugin background services", () => {
     });
   });
 
+  it("routes an uncaught exception from a service's async context to the supervisor", async () => {
+    // An unlistened EventEmitter 'error' fired from a timer never reaches the
+    // start() promise: Node raises it as a process-level uncaughtException.
+    // Without attribution the server exits and crash-loops (#1746).
+    const rootDir = await writePlugin(workDir, {
+      name: "bb-plugin-emitter",
+      serverSource: `
+        import { EventEmitter } from "node:events";
+        export default function plugin(bb: any) {
+          const g = globalThis as any;
+          g.__emitterStarts = 0;
+          g.__emitterAborts = 0;
+          bb.background.service("imap", {
+            async start(signal: any) {
+              g.__emitterStarts += 1;
+              if (g.__emitterStarts === 1) {
+                const client = new EventEmitter(); // no client.on("error")
+                setTimeout(() => client.emit("error", new Error("Socket timeout")), 5);
+              }
+              await new Promise<void>((resolve) =>
+                signal.addEventListener("abort", () => {
+                  g.__emitterAborts += 1;
+                  resolve();
+                }));
+            },
+          });
+        }
+      `,
+    });
+    // Stand in for the server's process listener (start-server.ts). vitest's
+    // own listener would report the exception as an unhandled error, so it
+    // steps aside for the duration of this test.
+    const vitestListeners = process.listeners("uncaughtException");
+    process.removeAllListeners("uncaughtException");
+    const unclaimed: unknown[] = [];
+    process.on("uncaughtException", (error) => {
+      if (!service.handleUncaughtException(error)) unclaimed.push(error);
+    });
+    try {
+      await service.installPath(rootDir);
+      await vi.waitFor(
+        () => {
+          expect(globals.__emitterStarts).toBe(2);
+        },
+        { timeout: 2000 },
+      );
+      // The first instance was aborted before the second one started.
+      expect(globals.__emitterAborts).toBe(1);
+      await vi.waitFor(() => {
+        expect(
+          service.list().find((p) => p.id === "emitter")?.services,
+        ).toEqual([{ name: "imap", state: "running" }]);
+      });
+      expect(unclaimed).toEqual([]);
+      expect(service.list().find((p) => p.id === "emitter")?.status).toBe(
+        "running",
+      );
+    } finally {
+      process.removeAllListeners("uncaughtException");
+      for (const listener of vitestListeners) {
+        process.on("uncaughtException", listener);
+      }
+    }
+  });
+
   it("NeedsConfigurationError maps to needs-configuration and stops restarts", async () => {
     const rootDir = await writePlugin(workDir, {
       name: "bb-plugin-needy",

--- a/packages/plugin-sdk/src/backend-contract.ts
+++ b/packages/plugin-sdk/src/backend-contract.ts
@@ -226,7 +226,10 @@ export interface PluginBackground {
    * factory completes and should resolve when `signal` aborts
    * (dispose/reload/disable/shutdown). A crash restarts it with capped
    * exponential backoff; throwing NeedsConfigurationError marks the plugin
-   * `needs-configuration` and stops restarting until the next load.
+   * `needs-configuration` and stops restarting until the next load. An
+   * error raised outside the `start` promise (an unlistened EventEmitter
+   * 'error', a throw in a timer callback, a detached rejection) counts as
+   * a crash too: the run is aborted and restarted the same way.
    */
   service(
     name: string,


### PR DESCRIPTION
## What was wrong

Plugins run inside the server process. A plugin background service is supervised only through the promise its `start(signal)` returns (`runService` → `onServiceSettled` in `apps/server/src/services/plugins/plugin-runtime.ts`). An error the service raises outside that promise — an unlistened `EventEmitter` `'error'` (ImapFlow socket timeout), a throw in a timer callback, a detached rejection — becomes a process-level uncaught exception. The server only registered an observe-only `uncaughtExceptionMonitor`, so Node exited, the process manager restarted the server, the plugin reloaded, and the crash looped; the service reported `running` the whole time and every restart replaced the host daemon session ("Thread interrupted because the host daemon disconnected").

Issue: #1746. Report: https://get-bb.github.io/reports/issues/1746.html

## What changed

- `apps/server/src/services/plugins/plugin-runtime.ts`: `runService` runs each service instance inside an `AsyncLocalStorage` scope that carries `{ pluginId, service, controller }`. The store follows every timer, socket callback, and promise the service creates. New `handleUncaughtException(error)` reads that store: no store → returns `false`; a stale run (already restarted or disposed) → logs with plugin and service name, returns `true`; the live run → aborts its controller and records the error so the run's settlement takes the existing crash path (`onServiceSettled` → backoff → restart). If the run ignores the abort for `serviceStopTimeoutMs`, the plugin is marked `degraded` like `stopServices` does.
- `apps/server/src/services/plugins/plugin-service.ts`: exposes `handleUncaughtException` on `PluginService`.
- `apps/server/src/start-server.ts`: installs `process.on("uncaughtException")`. A claimed error restarts that one service. Anything unattributed keeps Node's default: stack to stderr, exit 1 (the diagnostics monitor in `index.ts` has already written its report).
- `packages/plugin-sdk/src/backend-contract.ts`: one sentence in the `bb.background.service` doc comment stating that out-of-band errors count as a crash.

No wire change. No CLI change. Deviation from the report's proposal: no attribution field in the process-utils dump and no per-plugin crash counter / auto-disable; the attributed error is logged with plugin and service name and recovery reuses the existing backoff, which already escalates to a 60 s cap. The scope covers services only (factory, schedule ticks, and handlers are not wrapped): services are the long-lived surface that owns sockets, and they are the only surface with a defined recovery.

Verified the attribution mechanism outside the test too: `AsyncLocalStorage.getStore()` inside an `uncaughtException` listener returns the service's store for an unlistened emitter error, a timer throw, a detached rejection (arrives with `origin=unhandledRejection`), a `nextTick` throw and a `setImmediate` throw, and `undefined` for a throw outside the scope, on Node 24.18 (AsyncContextFrame), Node 24 with `--no-async-context-frame` (the async_hooks path Node 22 uses), and Node 26.5.

## How you verified

New test `apps/server/test/services/plugins/plugin-background.test.ts` › "routes an uncaught exception from a service's async context to the supervisor": a service creates an `EventEmitter` with no `'error'` listener and emits `'error'` from a timer. The test swaps out vitest's `uncaughtException` listener for the same listener shape `start-server.ts` installs, then asserts the service was aborted once and started twice, its state is back to `running`, and nothing reached the process unclaimed.

- Before (origin/main sources, listener only records): `AssertionError: expected 1 to be 2` at `expect(globals.__emitterStarts).toBe(2)` — the service is never restarted and the error reaches the process listener. (With the committed test as-is, main fails earlier because `service.handleUncaughtException` does not exist and the worker exits.)
- After: the test passes; full file 15/15.
- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@get-bb/plugin-sdk`: pass.
- `pnpm exec turbo run test --filter=@bb/server`: 1819/1820 pass; the one failure is `internal-skill-trees` mode 420 vs 436, the known local umask 0002 artifact, unrelated to this change. (A first run under load average 42 had 51 five-second timeouts spread across unrelated files; the affected files all passed on rerun.)
- Manual, on my dev instance with the report's 18-line repro plugin installed: the server log shows one `Server listening`, then per cycle `service imap-poller raised an uncaught exception outside start(): Socket timeout — aborting it` followed by `service imap-poller crashed: Socket timeout — restarting in 1000ms` … `32000ms`; `GET /api/v1/plugins` reports the service as `backoff`; the dev-supervisor log has zero `Child exited` lines; `host_daemon_sessions` holds one `active` row and none closed as `replaced`; `bb plugin remove crashy-service` stops the cycle. On main the report shows the same plugin killing the server every few seconds with 14 dumps and 4 replaced daemon sessions.

Known trade-off: the observe-only `uncaughtExceptionMonitor` still writes a `process-server-uncaughtException-*.json` report for every contained error (the monitor fires before the listener can attribute it). The stack is now also in the server log via `{ err }`. Suppressing the report for attributed errors would need the diagnostics hook to consult the plugin runtime; left for a follow-up if the reports turn out to be noise.

Fixes #1746

> AGENT GENERATED: by Claude Opus 5


## Independent verification

Checked out `2048b0d11` (this PR's head) as `verify-1746-r1`; `origin/main` (`c9aef7514`) is an ancestor, GitHub reports MERGEABLE.

**Root cause review.** Agrees with the issue and the report: `runService` only watched the `start()` promise and the server process only had the observe-only `uncaughtExceptionMonitor`. The fix is at the root (per-run `AsyncLocalStorage` scope + a `process.on("uncaughtException")` that claims attributed errors and otherwise keeps Node's exit) and in the right layer (server owns plugin runtime policy). No wire change, so no `HOST_DAEMON_PROTOCOL_VERSION` bump is needed; no new public plugin API member (only a JSDoc update on `PluginBackground.service`). I independently confirmed, in an actual `uncaughtException` listener on Node 24.18, that the ALS store is visible for an unlistened emitter `'error'`, a timer throw, a detached rejection (`origin=unhandledRejection`), and a `nextTick` throw, and absent for a throw outside the scope; and that a `.then` continuation attached outside `run()` (the path `onServiceSettled` and the backoff timer take) sees no store under both the AsyncContextFrame and `--no-async-context-frame` implementations.

**Fail-before / pass-after.**
- `git checkout origin/main -- apps/server/src/services/plugins/plugin-runtime.ts apps/server/src/services/plugins/plugin-service.ts apps/server/src/start-server.ts packages/plugin-sdk/src/backend-contract.ts`, then `pnpm exec vitest run test/services/plugins/plugin-background.test.ts -t "routes an uncaught exception"` in `apps/server`: the test listener throws `TypeError: service.handleUncaughtException is not a function` and the vitest worker exits (the uncaught exception does reach the process). With the listener reduced to record-only: `AssertionError: expected 1 to be 2 // Object.is equality` at `expect(globals.__emitterStarts).toBe(2)` — the service is never restarted on main.
- Restored PR sources: `plugin-background.test.ts` 15/15; the new test passed 5/5 consecutive runs.

**Turbo.** `pnpm exec turbo run typecheck --filter=@bb/server --filter=@get-bb/plugin-sdk` passes. `pnpm exec turbo run test --filter=@bb/server --filter=@get-bb/plugin-sdk --force`: plugin-sdk 14/14 files; server 1819/1820, the single failure is `internal-skill-trees.test.ts` mode 420 vs 436 (known local umask 0002 artifact, unrelated, green in CI).

**Repro on the fixed branch.** Own dev instance (`scripts/bb-dev-app current`, server :23506), installed the report's 18-line crashy plugin with `pnpm bb:dev plugin install ... --yes`. Server log: `raised an uncaught exception outside start(): Socket timeout — aborting it` followed by `crashed: Socket timeout — restarting in 1000ms`, then 2000/4000/8000ms. `Server listening` appears once; dev-supervisor `Child exited` count 0; `host_daemon_sessions` has one `active` row and no `replaced`; `/api/v1/plugins` shows `imap-poller` in state `backoff` (no longer lies as `running`). No longer reproduces.

**CI.** All checks on `2048b0d11` pass (Checks, Package Smoke x2, Tests app-1/2/3, integration, packages, server on Node 22.x).

**Residual risks (non-blocking).**
- `uncaughtExceptionMonitor` still writes a `process-server-uncaughtException-*.json` dump per contained error (I observed 4 for 4 contained crashes) and nothing prunes that directory; a service that fails immediately every cycle produces one dump per 60s at the backoff cap. Follow-up: let the diagnostics hook consult the runtime, or rotate dumps.
- Only background services are scoped; an out-of-band throw from a plugin factory, schedule tick, or handler still exits the server. Server code a service calls synchronously in-process (`bb.log`, kv, etc.; `bb.sdk` is loopback HTTP so it is unaffected) runs inside the plugin's scope and would be attributed to the plugin.
- After a service ignores its abort following an uncaught exception, the plugin stays `degraded` even once the run settles and restarts (same semantics as the existing stop-timeout path), and further uncaught errors from that same claimed run are swallowed without a log line. No per-plugin crash counter / auto-disable (issue point 3) — a permanently broken service cycles at the 60s cap with a warning each time.

> AGENT GENERATED: by Claude Opus 5
