### PR TITLE
Move the mobile attachment remove button onto the thumbnail and open a lightbox

### DIFF
--- a/apps/mobile/src/composer/AttachmentChips.tsx
+++ b/apps/mobile/src/composer/AttachmentChips.tsx
@@ -1,6 +1,14 @@
 import type { PromptDraftAttachment } from "@bb/client-core";
 import { Image } from "expo-image";
+import { useState } from "react";
 import { Pressable, ScrollView, View } from "react-native";
+import {
+  ImageLightbox,
+  openLightbox,
+  stepLightbox,
+  type LightboxImage,
+  type LightboxState,
+} from "@/screens/thread/timeline";
 import { useTheme } from "@/theme";
 import { Icon, Spinner, Text } from "@/ui";
 import type { PendingAttachment } from "./useComposerAttachments";
@@ -17,7 +25,90 @@ export interface AttachmentChipsProps {
   testID?: string;
 }
 
-const THUMB = 56;
+const THUMB = 64;
+const THUMB_RADIUS = 12;
+/** The corner remove button on an image thumbnail. */
+const REMOVE_BUTTON = 20;
+// The remove button sits on the photograph, so it is black/white like the
+// lightbox chrome (web `bg-black/55 text-white`), not a palette token.
+const REMOVE_BUTTON_BACKGROUND = "rgba(0, 0, 0, 0.6)";
+const REMOVE_BUTTON_PRESSED_BACKGROUND = "rgba(0, 0, 0, 0.8)";
+const REMOVE_BUTTON_FOREGROUND = "#ffffff";
+
+/**
+ * An image thumbnail with a small remove button in its top-right corner. A
+ * tap on the picture opens the lightbox.
+ */
+function ImageChip({
+  uri,
+  label,
+  onPress,
+  onRemove,
+  testID,
+}: {
+  uri: string;
+  label: string;
+  onPress: () => void;
+  onRemove?: () => void;
+  testID: string;
+}) {
+  const { tokens } = useTheme();
+  return (
+    <View
+      testID={testID}
+      accessibilityLabel={label}
+      style={{ width: THUMB, height: THUMB }}
+    >
+      <Pressable
+        onPress={onPress}
+        accessibilityRole="imagebutton"
+        accessibilityLabel={`Preview ${label}`}
+        testID={`${testID}-preview`}
+        style={({ pressed }) => ({
+          width: THUMB,
+          height: THUMB,
+          borderRadius: THUMB_RADIUS,
+          borderWidth: 1,
+          borderColor: tokens.border,
+          backgroundColor: tokens.surfaceRaisedSolid,
+          overflow: "hidden",
+          opacity: pressed ? 0.8 : 1,
+        })}
+      >
+        <Image
+          source={{ uri }}
+          style={{ width: "100%", height: "100%" }}
+          contentFit="cover"
+          accessible={false}
+        />
+      </Pressable>
+      {onRemove ? (
+        <Pressable
+          onPress={onRemove}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel={`Remove ${label}`}
+          testID={`${testID}-remove`}
+          style={({ pressed }) => ({
+            position: "absolute",
+            top: 4,
+            right: 4,
+            width: REMOVE_BUTTON,
+            height: REMOVE_BUTTON,
+            borderRadius: REMOVE_BUTTON / 2,
+            alignItems: "center",
+            justifyContent: "center",
+            backgroundColor: pressed
+              ? REMOVE_BUTTON_PRESSED_BACKGROUND
+              : REMOVE_BUTTON_BACKGROUND,
+          })}
+        >
+          <Icon name="X" size={12} color={REMOVE_BUTTON_FOREGROUND} />
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
 
 function ChipFrame({
   children,
@@ -72,7 +163,16 @@ function ChipFrame({
   );
 }
 
-/** Horizontal strip of attached files (image thumbnails, file chips, uploads in flight). */
+interface ResolvedAttachment {
+  attachment: PromptDraftAttachment;
+  /** Loadable image URI; null for files and for images without a source. */
+  uri: string | null;
+}
+
+/**
+ * Horizontal strip of attached files (image thumbnails, file chips, uploads
+ * in flight). Image thumbnails open the same lightbox as timeline images.
+ */
 export function AttachmentChips({
   attachments,
   pending,
@@ -83,40 +183,69 @@ export function AttachmentChips({
   testID = "composer-attachments",
 }: AttachmentChipsProps) {
   const { tokens } = useTheme();
+  const [lightbox, setLightbox] = useState<LightboxState | null>(null);
   if (attachments.length === 0 && pending.length === 0) return null;
+
+  const resolved: ResolvedAttachment[] = attachments.map((attachment) => ({
+    attachment,
+    uri:
+      attachment.type === "localImage"
+        ? (previewUriByPath.get(attachment.path) ??
+          resolveImageUrl?.(attachment) ??
+          null)
+        : null,
+  }));
+  const lightboxImages: LightboxImage[] = resolved.flatMap(
+    ({ attachment, uri }) =>
+      uri === null ? [] : [{ src: uri, alt: attachment.name }],
+  );
+
   return (
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      keyboardShouldPersistTaps="handled"
-      contentContainerStyle={{ gap: 8, paddingHorizontal: 12, paddingTop: 10 }}
-      testID={testID}
-    >
-      {attachments.map((attachment, index) => {
-        const isImage = attachment.type === "localImage";
-        const uri = isImage
-          ? (previewUriByPath.get(attachment.path) ??
-            resolveImageUrl?.(attachment) ??
-            null)
-          : null;
-        return (
-          <ChipFrame
-            key={attachment.path}
-            label={attachment.name}
-            onRemove={disabled ? undefined : () => onRemove(attachment.path)}
-            testID={`${testID}-${index}`}
-          >
-            {isImage && uri ? (
-              <Image
-                source={{ uri }}
-                style={{ width: THUMB, height: THUMB }}
-                contentFit="cover"
-                accessibilityLabel={attachment.name}
+    <>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+        contentContainerStyle={{
+          gap: 8,
+          paddingHorizontal: 12,
+          paddingTop: 10,
+        }}
+        testID={testID}
+      >
+        {resolved.map(({ attachment, uri }, index) => {
+          const remove = disabled
+            ? undefined
+            : () => onRemove(attachment.path);
+          if (uri !== null) {
+            const imageIndex = lightboxImages.findIndex(
+              (image) => image.src === uri,
+            );
+            return (
+              <ImageChip
+                key={attachment.path}
+                uri={uri}
+                label={attachment.name}
+                onPress={() =>
+                  setLightbox(openLightbox(lightboxImages, imageIndex))
+                }
+                onRemove={remove}
+                testID={`${testID}-${index}`}
               />
-            ) : (
+            );
+          }
+          return (
+            <ChipFrame
+              key={attachment.path}
+              label={attachment.name}
+              onRemove={remove}
+              testID={`${testID}-${index}`}
+            >
               <View className="flex-row items-center gap-2 py-2 pl-2">
                 <Icon
-                  name={isImage ? "Eye" : "FileAttachment"}
+                  name={
+                    attachment.type === "localImage" ? "Eye" : "FileAttachment"
+                  }
                   size={16}
                   color={tokens.mutedForeground}
                 />
@@ -124,21 +253,28 @@ export function AttachmentChips({
                   {attachment.name}
                 </Text>
               </View>
-            )}
-          </ChipFrame>
-        );
-      })}
-      {pending.map((entry) => (
-        <ChipFrame
-          key={entry.id}
-          label={`Uploading ${entry.name}`}
-          testID={`${testID}-pending`}
-        >
-          {entry.previewUri ? (
-            <View style={{ width: THUMB, height: THUMB }}>
+            </ChipFrame>
+          );
+        })}
+        {pending.map((entry) =>
+          entry.previewUri ? (
+            <View
+              key={entry.id}
+              accessibilityLabel={`Uploading ${entry.name}`}
+              testID={`${testID}-pending`}
+              style={{
+                width: THUMB,
+                height: THUMB,
+                borderRadius: THUMB_RADIUS,
+                borderWidth: 1,
+                borderColor: tokens.border,
+                backgroundColor: tokens.surfaceRaisedSolid,
+                overflow: "hidden",
+              }}
+            >
               <Image
                 source={{ uri: entry.previewUri }}
-                style={{ width: THUMB, height: THUMB, opacity: 0.5 }}
+                style={{ width: "100%", height: "100%", opacity: 0.5 }}
                 contentFit="cover"
               />
               <View
@@ -153,15 +289,30 @@ export function AttachmentChips({
               </View>
             </View>
           ) : (
-            <View className="flex-row items-center gap-2 py-2 pl-2">
-              <Spinner />
-              <Text variant="caption" numberOfLines={1} className="max-w-36">
-                {entry.name}
-              </Text>
-            </View>
-          )}
-        </ChipFrame>
-      ))}
-    </ScrollView>
+            <ChipFrame
+              key={entry.id}
+              label={`Uploading ${entry.name}`}
+              testID={`${testID}-pending`}
+            >
+              <View className="flex-row items-center gap-2 py-2 pl-2">
+                <Spinner />
+                <Text variant="caption" numberOfLines={1} className="max-w-36">
+                  {entry.name}
+                </Text>
+              </View>
+            </ChipFrame>
+          ),
+        )}
+      </ScrollView>
+      <ImageLightbox
+        state={lightbox}
+        onClose={() => setLightbox(null)}
+        onStep={(direction) =>
+          setLightbox((current) =>
+            current === null ? current : stepLightbox(current, direction),
+          )
+        }
+      />
+    </>
   );
 }


### PR DESCRIPTION
## What was wrong

Image attachments in the mobile composer rendered as a pill: the thumbnail sat next to a gray X in a bordered frame. This looks different from the ChatGPT style the user asked for (a small X in the corner of the picture). A tap on the thumbnail did nothing, so there was no way to see the full picture before you send it.

## What changed

`apps/mobile/src/composer/AttachmentChips.tsx`:

- Image attachments are a 64px rounded thumbnail with a small dark circle remove button in the top-right corner (white X, black/white like the lightbox chrome so it reads on any photo).
- A tap on the thumbnail opens the existing mobile `ImageLightbox` (pinch zoom, swipe, previous/next, counter) with all image attachments in the strip.
- A pending upload with a preview uses the same rounded thumbnail with the spinner overlay.
- File chips keep the pill style with the X on the right.

No wire changes.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/mobile` and `pnpm exec turbo run lint --filter=@bb/mobile` pass.
- Ran the dev client on an iPhone 17 Pro simulator (iOS 26.3) against this worktree's dev server, attached two library photos, and opened the lightbox from a thumbnail. Screenshots:

| Composer | Lightbox |
| --- | --- |
| two rounded thumbnails with a corner X | full-screen image, `1 / 2` counter, previous/next |


> AGENT GENERATED: by Claude Opus 5
