### PR TITLE
Keep adjacent assistant answers visible in completed turns

### DIFF
--- a/packages/thread-view/src/completed-turn-grouping.ts
+++ b/packages/thread-view/src/completed-turn-grouping.ts
@@ -142,13 +142,55 @@ function splitCompletedTurnMessages(
   };
 }
 
+function isAssistantResponseMessage(
+  message: EventProjectionMessage | undefined,
+): boolean {
+  return (
+    message?.kind === "assistant-text" && message.isLegacyUserMessage !== true
+  );
+}
+
+/**
+ * Assistant text that the provider followed directly with more assistant
+ * text, with no work in between, was a complete response, not narration about
+ * upcoming tool activity. Providers re-query the model after it stops without
+ * telling bb why (a Claude Code Stop hook injects its reason as a synthetic
+ * user message that never becomes a thread event), so the turn carries two
+ * answers and only the last one is the terminal message. The earlier answer
+ * must stay visible at rest instead of being folded into the collapsed work
+ * summary. Text followed by work keeps the existing collapse.
+ */
+function findVisibleResponseMessageIds(
+  summaryMessages: readonly EventProjectionMessage[],
+  terminalMessage: EventProjectionMessage | undefined,
+): Set<string> {
+  const visibleIds = new Set<string>();
+  for (let index = 0; index < summaryMessages.length; index += 1) {
+    const message = summaryMessages[index];
+    const nextMessage = summaryMessages[index + 1] ?? terminalMessage;
+    if (
+      isAssistantResponseMessage(message) &&
+      isAssistantResponseMessage(nextMessage)
+    ) {
+      visibleIds.add(message.id);
+    }
+  }
+  return visibleIds;
+}
+
 function groupCompletedTurnSummaryMessages(
   turn: EventProjectionTurn,
   summaryMessages: EventProjectionMessage[],
+  terminalMessage: EventProjectionMessage | undefined,
 ): CompletedTurnSummaryItem[] {
   const externalBoundarySeqs = turn.externalUserBoundarySeqs ?? [];
+  const visibleResponseIds = findVisibleResponseMessageIds(
+    summaryMessages,
+    terminalMessage,
+  );
   if (
     externalBoundarySeqs.length === 0 &&
+    visibleResponseIds.size === 0 &&
     !summaryMessages.some(isTimelineUngroupableMessage)
   ) {
     return [
@@ -227,6 +269,14 @@ function groupCompletedTurnSummaryMessages(
 
   for (const message of summaryMessages) {
     flushExternalBoundariesBefore(message);
+    if (visibleResponseIds.has(message.id)) {
+      flushGroupedMessages();
+      items.push({
+        kind: "ungrouped-message",
+        message,
+      });
+      continue;
+    }
     if (isTimelineUngroupableMessage(message)) {
       flushGroupedMessages(
         message.kind === "user" && message.initiator === "user",
@@ -256,7 +306,11 @@ export function groupCompletedTurnMessages(
     splitCompletedTurnMessages(messages, turn.terminalMessage);
   return {
     summaryItems: unwrapSingletonContextManagementGroups(
-      groupCompletedTurnSummaryMessages(turn, summaryMessages),
+      groupCompletedTurnSummaryMessages(
+        turn,
+        summaryMessages,
+        terminalMessages[0],
+      ),
     ),
     terminalMessages,
     trailingMessages,

--- a/packages/thread-view/test/completed-turn-grouping.test.ts
+++ b/packages/thread-view/test/completed-turn-grouping.test.ts
@@ -4,6 +4,7 @@ import { groupCompletedTurnMessages } from "../src/completed-turn-grouping.js";
 import type { CompletedTurnMessageGroups } from "../src/completed-turn-grouping.js";
 import type {
   EventProjectionAssistantTextMessage,
+  EventProjectionCommandMessage,
   EventProjectionMessage,
   EventProjectionOperationMessage,
   EventProjectionTurnRequest,
@@ -35,6 +36,23 @@ function assistantMessage(
     ...messageBase(args),
     kind: "assistant-text",
     text: args.id,
+    status: "completed",
+  };
+}
+
+function commandMessage(args: MessageBaseArgs): EventProjectionCommandMessage {
+  return {
+    ...messageBase(args),
+    kind: "command",
+    callId: args.id,
+    command: "pnpm test",
+    cwd: "/repo",
+    parsedIntents: [],
+    source: null,
+    output: "",
+    exitCode: 0,
+    completedAt: args.seq,
+    approvalStatus: null,
     status: "completed",
   };
 }
@@ -160,7 +178,7 @@ describe("groupCompletedTurnMessages", () => {
   it("uses one summary group when no messages are ungroupable", () => {
     const messages = [
       assistantMessage({ id: "assistant-1", seq: 1 }),
-      assistantMessage({ id: "assistant-2", seq: 2 }),
+      commandMessage({ id: "command-1", seq: 2 }),
     ];
     const groups = groupCompletedTurnMessages(
       completedTurn(messages, undefined),
@@ -176,8 +194,63 @@ describe("groupCompletedTurnMessages", () => {
       },
     ]);
     expect(summarySourceMessageIds(groups)).toEqual([
-      ["assistant-1", "assistant-2"],
+      ["assistant-1", "command-1"],
     ]);
+  });
+
+  it("keeps an assistant response visible when more assistant text follows it directly", () => {
+    const answer = assistantMessage({ id: "answer", seq: 1 });
+    const hookReply = assistantMessage({ id: "hook-reply", seq: 2 });
+    const groups = groupCompletedTurnMessages(
+      completedTurn([answer, hookReply], hookReply),
+    );
+
+    expect(groups.summaryItems).toEqual([
+      { kind: "ungrouped-message", message: answer },
+    ]);
+    expect(groups.terminalMessages).toEqual([hookReply]);
+  });
+
+  it("folds narration that precedes work and keeps the response that precedes the terminal text", () => {
+    const narration = assistantMessage({ id: "narration", seq: 1 });
+    const command = commandMessage({ id: "command", seq: 2 });
+    const answer = assistantMessage({ id: "answer", seq: 3 });
+    const hookReply = assistantMessage({ id: "hook-reply", seq: 4 });
+    const groups = groupCompletedTurnMessages(
+      completedTurn([narration, command, answer, hookReply], hookReply),
+    );
+
+    expect(groups.summaryItems).toMatchObject([
+      {
+        kind: "summary",
+        startedAt: 1,
+        completedAt: 4,
+        segmentIndex: 0,
+        sourceMessages: [{ id: "narration" }, { id: "command" }],
+        summaryCount: 2,
+      },
+      { kind: "ungrouped-message", message: { id: "answer" } },
+    ]);
+    expect(groups.terminalMessages).toEqual([hookReply]);
+  });
+
+  it("keeps every response in a run of adjacent assistant texts", () => {
+    const first = assistantMessage({ id: "first", seq: 1 });
+    const second = assistantMessage({ id: "second", seq: 2 });
+    const command = commandMessage({ id: "command", seq: 3 });
+    const terminal = assistantMessage({ id: "terminal", seq: 4 });
+    const groups = groupCompletedTurnMessages(
+      completedTurn([first, second, command, terminal], terminal),
+    );
+
+    expect(groups.summaryItems).toMatchObject([
+      { kind: "ungrouped-message", message: { id: "first" } },
+      {
+        kind: "summary",
+        sourceMessages: [{ id: "second" }, { id: "command" }],
+      },
+    ]);
+    expect(groups.terminalMessages).toEqual([terminal]);
   });
 
   it("preserves the last assistant message before an ungroupable user message", () => {
@@ -291,7 +364,7 @@ describe("groupCompletedTurnMessages", () => {
   });
 
   it("slices terminal and trailing messages out of the summary groups", () => {
-    const before = assistantMessage({ id: "before", seq: 1 });
+    const before = commandMessage({ id: "before", seq: 1 });
     const terminal = assistantMessage({ id: "terminal", seq: 2 });
     const trailing = assistantMessage({ id: "trailing", seq: 3 });
     const groups = groupCompletedTurnMessages(

--- a/packages/thread-view/test/completed-turn-summary-rendering.test.ts
+++ b/packages/thread-view/test/completed-turn-summary-rendering.test.ts
@@ -109,6 +109,94 @@ describe("completed turn summary rendering", () => {
     expect(rowSignatures(turnRow.children ?? [])).toEqual(["work:command"]);
   });
 
+  it("keeps an assistant answer visible when the provider re-queries and the model answers again", () => {
+    // A Claude Code Stop hook blocks the stop and injects its reason as a
+    // synthetic user message that bb never sees (get-bb/bb#1355). The turn
+    // then holds two assistant texts back to back: the real answer and a
+    // short reply to the hook. Only the reply is the terminal message.
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const request = event.clientTurnRequested({
+      target: { kind: "new-turn" },
+      text: "SQLite vs Postgres for a desktop app? End with a question.",
+    });
+    const answer =
+      "- SQLite is a file, zero ops.\n- Postgres needs a server.\n**Question for you**: multi-user someday?";
+    const hookReply =
+      "The verify gate is open: no fresh fast-loop verdict for HEAD, nothing actionable this turn.";
+
+    const timeline = renderCompletedTimeline({
+      events: [
+        request,
+        event.turnStarted(),
+        event.inputAccepted({ clientRequestId: request.data.requestId }),
+        event.assistantCompleted({ itemId: "assistant-1", text: answer }),
+        event.assistantCompleted({ itemId: "assistant-2", text: hookReply }),
+        event.turnCompleted(),
+      ],
+    });
+
+    expect(rowSignatures(timeline.rows)).toEqual([
+      "conversation:user",
+      "conversation:assistant",
+      "conversation:assistant",
+    ]);
+    expect(
+      timeline.rows.flatMap((row) =>
+        row.kind === "conversation" && row.role === "assistant"
+          ? [row.text]
+          : [],
+      ),
+    ).toEqual([answer, hookReply]);
+    expect(turnRows(timeline.rows)).toHaveLength(0);
+  });
+
+  it("folds narration before work but keeps the answer that precedes a hook reply", () => {
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const request = event.clientTurnRequested({
+      target: { kind: "new-turn" },
+      text: "Is the daemon command blob pruning durable?",
+    });
+
+    const timeline = renderCompletedTimeline({
+      events: [
+        request,
+        event.turnStarted(),
+        event.inputAccepted({ clientRequestId: request.data.requestId }),
+        event.assistantCompleted({
+          itemId: "assistant-1",
+          text: "Let me check the pruning code.",
+        }),
+        event.commandCompleted({ itemId: "tool-1", command: "rg prune" }),
+        event.assistantCompleted({
+          itemId: "assistant-2",
+          text: "Yes: pruning runs inside the daemon transaction, so it is durable.",
+        }),
+        event.assistantCompleted({
+          itemId: "assistant-3",
+          text: "The verify gate is still open for HEAD.",
+        }),
+        event.turnCompleted(),
+      ],
+    });
+
+    expect(rowSignatures(timeline.rows)).toEqual([
+      "conversation:user",
+      "turn:4-5",
+      "conversation:assistant",
+      "conversation:assistant",
+    ]);
+    const turnRow = requireOnlyTurnRow(timeline.rows);
+    expect(turnRow).toMatchObject({
+      startedAt: 2,
+      completedAt: 8,
+      summaryCount: 2,
+    });
+    expect(rowSignatures(turnRow.children ?? [])).toEqual([
+      "conversation:assistant",
+      "work:command",
+    ]);
+  });
+
   it("keeps turn-scoped environment directory update operations inside the completed turn summary", () => {
     const event = createTimelineEventFactory({ threadId: "thread-1" });
     const request = event.clientTurnRequested({


### PR DESCRIPTION
## What was wrong

When a Claude Code Stop hook blocks a stop, Claude Code injects the hook's reason as a synthetic user message and the model answers again. That synthetic message never becomes a bb thread event (`provider-claude-code` only forwards `tool_result` user messages), so one bb turn ends with two `agentMessage` items back to back: the real answer, then a one-line reply to the hook. Completed-turn grouping in `@bb/thread-view` keeps exactly one terminal message per segment (`findLastTerminalTimelineMessage`) and slices everything before it into the collapsed `Worked for` summary. The real answer, including any question for the user, disappears behind a row that reads like a duration stat, in the app and in `bb thread log`.

Issue: #1355. Report: https://get-bb.github.io/reports/issues/1355.html (reproduced live on a fresh instance from 16ceb3a54; the code at the root cause is unchanged on current main).

## What changed

`packages/thread-view/src/completed-turn-grouping.ts`: an assistant text that is directly followed by more assistant text, with no work in between, is a complete response, not narration about upcoming tool activity. `groupCompletedTurnSummaryMessages` now promotes such messages to `ungrouped-message` items (the terminal message counts as the follower of the last summary message). The existing collapse is unchanged for text followed by tool activity, so ordinary `text -> tool -> text` turns still render as `user -> Worked for -> last answer`.

Behavior for the issue's shape (`answer, hook reply`): both assistant rows are visible at rest and no summary row is emitted. For `narration, command, answer, hook reply`: `Worked for` holds the narration and the command, then the answer and the hook reply are both visible.

Deviation from the report's primary proposal: the report suggests surfacing every top-level assistant text. That changes every agentic turn (interim narration such as "Let me check X" would leave the summary), which #320 deliberately collapses, and #1508's review measured a 1,500-event page producing ~1,500 rows (past the 200-row completed-timeline cache limit). This change is scoped to the shape that loses the answer. Remaining gap: a hook that makes the model call a tool before answering (`answer, [hook], tool, reply`) still folds the answer, because nothing in the event stream marks the boundary; fixing that needs `provider-claude-code` to surface the synthetic hook message through the bridge protocol, which is a contract change and a separate PR.

No wire change. The app and `bb thread log` share this row builder, so both pick it up.

## How you verified

New tests, which fail on origin/main and pass with this change:

- `packages/thread-view/test/completed-turn-grouping.test.ts`: `keeps an assistant response visible when more assistant text follows it directly`, `folds narration that precedes work and keeps the response that precedes the terminal text`, `keeps every response in a run of adjacent assistant texts`. Two existing tests that encoded the old behavior with two adjacent assistant texts now use a command message as the folded work.
- `packages/thread-view/test/completed-turn-summary-rendering.test.ts`: `keeps an assistant answer visible when the provider re-queries and the model answers again`, `folds narration before work but keeps the answer that precedes a hook reply`.

With `completed-turn-grouping.ts` checked out from origin/main the rendering test fails with:

```
- Expected
+ Received
  [
    "conversation:user",
-   "conversation:assistant",
+   "turn:4-4",
    "conversation:assistant",
  ]
```

Commands:

- `pnpm exec turbo run typecheck --filter=@bb/thread-view --filter=@bb/server --filter=@bb/app --filter=@bb/cli --filter=@bb/client-core`: 8/8 pass.
- `pnpm exec turbo run test --filter=@bb/thread-view --filter=@bb/server --filter=@bb/cli --filter=@bb/client-core`: thread-view 21/21 files, cli 48/48, client-core 20/20, server 194/195 (the one failure is `internal-skill-trees.test.ts` mode 0644 vs 0664, a pre-existing local umask difference unrelated to this change).
- `apps/app` `vitest run src/components/thread/timeline`: 28/28 files.

Manual: on a dev instance built from this branch, a `claude-code` thread in a scratch repo with a blocking Stop hook (the report's 4a repro) produced events `agentMessage, agentMessage, turn/completed`. `bb thread log` now prints the three-bullet answer with its closing question as an `Assistant` row, followed by the hook reply as a second `Assistant` row, with no `Worked for` row; the app shows the same two rows at rest.

Fixes #1355

> AGENT GENERATED: by Claude Opus 5


## Independent verification

Verified by a second agent on a fresh checkout of this branch (`40224ee60`, origin/main is an ancestor; no conflicts) in its own worktree and dev instance.

Commands:

- `pnpm install --frozen-lockfile --prefer-offline && pnpm exec turbo run build`
- Fail-before: `git checkout origin/main -- packages/thread-view/src/completed-turn-grouping.ts`, then `pnpm exec vitest run test/completed-turn-grouping.test.ts test/completed-turn-summary-rendering.test.ts` in `packages/thread-view`: 5 failed / 19 passed. The five new tests are exactly the ones that fail. Rendering test assertion:

  ```
  - Expected
  + Received
    [
      "conversation:user",
  -   "conversation:assistant",
  +   "turn:4-4",
      "conversation:assistant",
    ]
  ```

  Grouping test: `expected [ { kind: 'summary', …(5) } ] to deeply equal [ { kind: 'ungrouped-message', …(1) } ]`.
- Pass-after: restored the PR file, same command: 24/24 pass.
- `pnpm exec turbo run typecheck --filter=@bb/thread-view --filter=@bb/server --filter=@bb/cli --filter=@bb/client-core --filter=@bb/app --filter=@bb/mobile`: 9/9 successful.
- `pnpm exec turbo run test --filter=@bb/thread-view --filter=@bb/server --filter=@bb/cli --filter=@bb/client-core`: thread-view 21/21 files (385 tests), cli 48/48 (453), client-core 20/20 (238). See the server result note below.
- Ad-hoc probes through `renderTimelineFixture` (not committed): `reasoning, text, reasoning, text` (extended thinking between the answer and the hook reply) still renders both assistant rows at rest; `text, tool, text` still collapses to `user -> Worked for -> assistant` (the deliberate #320 behavior); a steer between two answers keeps the existing per-segment preservation; `text, text, text, tool, text` shows the first two, folds the third with the tool.

Repro on the fixed branch (report section 4a, real `claude-code` turn with a blocking Stop hook on a scratch repo, own dev instance): persisted events were `item/completed agentMessage` (seq 22), `item/completed agentMessage` (seq 29), `turn/completed` (seq 32) with no hook event between, the same shape as the report. `bb thread log` (default minimal format) printed `User`, `Provisioned thread`, then the full three-bullet answer with its closing question as an `Assistant` row, then the hook reply as a second `Assistant` row, with no `Worked for` row. `GET /api/v1/threads/:id/timeline` (what the app renders) returned `conversation:user, system:operation, conversation:assistant, conversation:assistant` and no `turn` row. The bug no longer reproduces. The provider still drops the synthetic hook message (`plugins/provider-claude-code/src/delta-translation.ts` `translateUserMessage` returns `[]` when there are no tool results), so the fix is entirely in the shared row builder, as described.

CI: all required checks green on the PR head (Checks, Tests server/packages/integration/app-1..3, Package Smoke ubuntu+macos, version check).

Residual risks (agreed with the PR body): `answer, [hook], tool, reply` still folds the answer because no event marks the hook boundary; that needs `provider-claude-code` to surface the synthetic user message (wire change, separate PR). Any provider that emits two adjacent assistant items for one response now shows both rows. `answer, answer2, error` shows `answer` at rest but still folds `answer2` before the error row (pre-existing behavior for error terminals, not made worse). Textual merge overlap with #2071 in the same loop of `completed-turn-grouping.ts`.

> AGENT GENERATED: by Claude Opus 5
