### PR TITLE
Keep the mobile composer typeahead below the native header

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -264,7 +264,9 @@ src/
   theme/                 generated tokens, ThemeProvider, fonts (see src/ui/README.md)
   ui/                    NativeWind primitives (Text, Button, ListRow, Sheet, …;
                          KeyboardPaddingView — JS-state keyboard padding for
-                         bottom-anchored composer screens)
+                         bottom-anchored composer screens; OverlayBounds — the
+                         region under the header the composer's floating
+                         typeahead may cover)
 e2e/flows/               Maestro flows (smoke, phase1-shell, phase3-threads, phase3-compose,
                          phase4a-timeline, phase4a-diff-showcase,
                          phase4a-conversation-rows, phase4a-work-rows,

--- a/apps/mobile/src/composer/Composer.tsx
+++ b/apps/mobile/src/composer/Composer.tsx
@@ -12,6 +12,7 @@ import {
   useRef,
   useState,
   type ReactNode,
+  type RefObject,
 } from "react";
 import { Pressable, View, type StyleProp, type ViewStyle } from "react-native";
 import { haptic } from "@/lib/haptics";
@@ -25,6 +26,7 @@ import {
   Icon,
   SheetPresenceContext,
   Spinner,
+  useOverlayBounds,
   useSheet,
   type ActionSheetAction,
 } from "@/ui";
@@ -45,6 +47,8 @@ import {
   PROMPT_ACTION_PRESENTATION,
   resolvePromptActionInsertion,
   resolveSubmitAffordance,
+  resolveTypeaheadMaxHeight,
+  TYPEAHEAD_GAP,
   type ComposerAction,
   type ComposerPromptAction,
   type ComposerSubmitKind,
@@ -158,6 +162,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(
     const { tokens } = useTheme();
     const { serverUrl } = useProfileClient();
     const inputRef = useRef<ComposerInputHandle>(null);
+    const rootRef = useRef<View>(null);
     const valueRef = useRef(value);
     useEffect(() => {
       valueRef.current = value;
@@ -229,6 +234,15 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(
     });
     const activeTrigger = typeahead.activeTrigger;
     const menu = typeahead.menu;
+    // Only the floating list is bounded by the room above the card; the
+    // inline `below` list is part of the card and must not feed back into
+    // its own anchor.
+    const { spaceAbove, measureSpaceAbove } = useSpaceAboveCard({
+      rootRef,
+      enabled: typeaheadPlacement === "above",
+      menuOpen: menu !== null,
+    });
+    const typeaheadMaxHeight = resolveTypeaheadMaxHeight(spaceAbove);
 
     const applyMention = useCallback(
       (suggestion: PromptMentionSuggestion) => {
@@ -431,13 +445,20 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(
         menu={menu}
         onPickMention={applyMention}
         onPickCommand={applyCommand}
+        maxHeight={typeaheadMaxHeight}
         testID={`${testID}-typeahead`}
       />
     ) : null;
 
     return (
       <SheetPresenceContext.Provider value={sheetPresence}>
-        <View style={{ position: "relative", zIndex: 10 }} testID={testID}>
+        <View
+          ref={rootRef}
+          collapsable={false}
+          onLayout={measureSpaceAbove}
+          style={{ position: "relative", zIndex: 10 }}
+          testID={testID}
+        >
           {menuNode && typeaheadPlacement === "above" ? (
             <View
               style={{
@@ -445,7 +466,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(
                 left: 0,
                 right: 0,
                 bottom: "100%",
-                marginBottom: 6,
+                marginBottom: TYPEAHEAD_GAP,
                 zIndex: 20,
               }}
             >
@@ -651,6 +672,42 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(
     );
   },
 );
+
+/**
+ * The distance from the top of the overlay bounds (the screen content under
+ * the native header) to the top of the composer root, for the typeahead's
+ * height cap. Re-measured on the root's own layout (the card grows with the
+ * text), on the bounds' layout (keyboard frame, rotation) and when the menu
+ * opens. `null` while disabled, without a bounds provider, or before the
+ * first measurement.
+ */
+function useSpaceAboveCard({
+  rootRef,
+  enabled,
+  menuOpen,
+}: {
+  rootRef: RefObject<View | null>;
+  enabled: boolean;
+  menuOpen: boolean;
+}): { spaceAbove: number | null; measureSpaceAbove: () => void } {
+  const { ref: boundsRef, layoutVersion: boundsLayoutVersion } =
+    useOverlayBounds();
+  const [spaceAbove, setSpaceAbove] = useState<number | null>(null);
+  const measureSpaceAbove = useCallback(() => {
+    const root = rootRef.current;
+    const target = boundsRef.current;
+    if (!enabled || !root || !target) return;
+    root.measureLayout(
+      target,
+      (_x, y) => setSpaceAbove(y),
+      () => undefined,
+    );
+  }, [boundsRef, enabled, rootRef]);
+  useEffect(() => {
+    measureSpaceAbove();
+  }, [measureSpaceAbove, boundsLayoutVersion, menuOpen]);
+  return { spaceAbove, measureSpaceAbove };
+}
 
 /**
  * Applies a "+" prompt action at the caret and refocuses the input. Lives

--- a/apps/mobile/src/composer/TypeaheadMenu.tsx
+++ b/apps/mobile/src/composer/TypeaheadMenu.tsx
@@ -10,6 +10,7 @@ import { memo, useMemo } from "react";
 import { Pressable, ScrollView, View } from "react-native";
 import { useTheme } from "@/theme";
 import { Icon, Spinner, Text, type IconName } from "@/ui";
+import { TYPEAHEAD_MAX_HEIGHT } from "./model";
 import type { TypeaheadMenuModel } from "./useComposerTypeahead";
 
 export interface TypeaheadMenuProps {
@@ -150,7 +151,7 @@ export function TypeaheadMenu({
   menu,
   onPickMention,
   onPickCommand,
-  maxHeight = 280,
+  maxHeight = TYPEAHEAD_MAX_HEIGHT,
   testID = "composer-typeahead",
 }: TypeaheadMenuProps) {
   const { tokens } = useTheme();

--- a/apps/mobile/src/composer/model/index.ts
+++ b/apps/mobile/src/composer/model/index.ts
@@ -81,3 +81,10 @@ export {
   type ComposerPromptActionKind,
   type PromptActionInsertion,
 } from "./actions";
+export {
+  resolveTypeaheadMaxHeight,
+  TYPEAHEAD_GAP,
+  TYPEAHEAD_MAX_HEIGHT,
+  TYPEAHEAD_MIN_HEIGHT,
+  TYPEAHEAD_TOP_MARGIN,
+} from "./typeahead-height";

--- a/apps/mobile/src/composer/model/typeahead-height.test.ts
+++ b/apps/mobile/src/composer/model/typeahead-height.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveTypeaheadMaxHeight,
+  TYPEAHEAD_GAP,
+  TYPEAHEAD_MAX_HEIGHT,
+  TYPEAHEAD_MIN_HEIGHT,
+  TYPEAHEAD_TOP_MARGIN,
+} from "./typeahead-height";
+
+describe("resolveTypeaheadMaxHeight", () => {
+  it("keeps the fixed cap while unmeasured", () => {
+    expect(resolveTypeaheadMaxHeight(null)).toBe(TYPEAHEAD_MAX_HEIGHT);
+    expect(resolveTypeaheadMaxHeight(Number.NaN)).toBe(TYPEAHEAD_MAX_HEIGHT);
+  });
+
+  it("fits the list between the bounds top and the card", () => {
+    // The user's report: ~225pt between the header and the card, a 280pt
+    // list → the top rows sat under the header.
+    expect(resolveTypeaheadMaxHeight(225)).toBe(
+      225 - TYPEAHEAD_GAP - TYPEAHEAD_TOP_MARGIN,
+    );
+    expect(resolveTypeaheadMaxHeight(1000)).toBe(TYPEAHEAD_MAX_HEIGHT);
+  });
+
+  it("never shrinks below one row", () => {
+    expect(resolveTypeaheadMaxHeight(20)).toBe(TYPEAHEAD_MIN_HEIGHT);
+    expect(resolveTypeaheadMaxHeight(0)).toBe(TYPEAHEAD_MIN_HEIGHT);
+  });
+});

--- a/apps/mobile/src/composer/model/typeahead-height.ts
+++ b/apps/mobile/src/composer/model/typeahead-height.ts
@@ -1,0 +1,32 @@
+/** The typeahead list's height cap when it has all the room it wants. */
+export const TYPEAHEAD_MAX_HEIGHT = 280;
+/** Gap between the floating list and the top edge of the composer card. */
+export const TYPEAHEAD_GAP = 6;
+/** Room kept between the list and the top of its overlay bounds. */
+export const TYPEAHEAD_TOP_MARGIN = 8;
+/**
+ * Never shrink the list below one row. Under this height the list is not
+ * operable; above it, scrolling reaches every row as long as the list stays
+ * inside its bounds. With less than a row (plus margins) of room above the
+ * card — a landscape phone with a tall draft — the list overlaps the bounds
+ * top by the difference.
+ */
+export const TYPEAHEAD_MIN_HEIGHT = 44;
+
+/**
+ * The height cap for the typeahead list that floats above the composer
+ * card. `spaceAbove` is the distance from the top of the overlay bounds
+ * (the screen content under the native header) to the top of the card;
+ * `null` while unmeasured (no bounds provider, or before the first layout),
+ * which keeps the fixed cap.
+ */
+export function resolveTypeaheadMaxHeight(spaceAbove: number | null): number {
+  if (spaceAbove === null || !Number.isFinite(spaceAbove)) {
+    return TYPEAHEAD_MAX_HEIGHT;
+  }
+  const available = spaceAbove - TYPEAHEAD_GAP - TYPEAHEAD_TOP_MARGIN;
+  return Math.max(
+    TYPEAHEAD_MIN_HEIGHT,
+    Math.min(TYPEAHEAD_MAX_HEIGHT, available),
+  );
+}

--- a/apps/mobile/src/screens/dev/ComposerShowcaseScreen.tsx
+++ b/apps/mobile/src/screens/dev/ComposerShowcaseScreen.tsx
@@ -22,6 +22,7 @@ import {
   EmptyStatePanel,
   COMPOSER_KEYBOARD_GAP,
   KeyboardPaddingView,
+  OverlayBounds,
   Text,
   toast,
 } from "@/ui";
@@ -81,61 +82,65 @@ function ConnectedComposerShowcase() {
         style={{ flex: 1 }}
         keyboardGap={COMPOSER_KEYBOARD_GAP}
       >
-        <ScrollView
-          className="flex-1"
-          contentContainerStyle={{ padding: 16, gap: 12 }}
-          keyboardShouldPersistTaps="handled"
-          keyboardDismissMode="interactive"
-        >
-          <Text variant="caption">
-            Project {projectId ?? "—"}
-            {projectId === PERSONAL_PROJECT_ID ? " (personal)" : ""} · provider{" "}
-            {providerId ?? "—"}
-          </Text>
-          <View className="flex-row flex-wrap gap-2">
-            {MODES.map((entry) => (
-              <Button
-                key={entry.key}
-                size="sm"
-                variant={entry.key === modeKey ? "default" : "outline"}
-                onPress={() => setModeKey(entry.key)}
-                testID={`dev-composer-mode-${entry.key}`}
-              >
-                {entry.label}
-              </Button>
-            ))}
-          </View>
-          <Text variant="sectionLabel">PromptInput</Text>
-          <Text variant="mono" selectable testID="dev-composer-serialized">
-            {serialized}
-          </Text>
-          {lastSubmit ? (
-            <Text variant="caption" testID="dev-composer-last-submit">
-              submitted: {lastSubmit}
+        {/* Same bounds as the product screens, so the showcase exercises
+            the typeahead's height cap. */}
+        <OverlayBounds style={{ flex: 1 }}>
+          <ScrollView
+            className="flex-1"
+            contentContainerStyle={{ padding: 16, gap: 12 }}
+            keyboardShouldPersistTaps="handled"
+            keyboardDismissMode="interactive"
+          >
+            <Text variant="caption">
+              Project {projectId ?? "—"}
+              {projectId === PERSONAL_PROJECT_ID ? " (personal)" : ""} ·
+              provider {providerId ?? "—"}
             </Text>
-          ) : null}
-        </ScrollView>
-        <View
-          className="border-t border-border-hairline bg-background px-3 pt-2"
-          style={{ paddingBottom: Math.max(insets.bottom, 12) }}
-        >
-          <Composer
-            value={value}
-            onChange={setValue}
-            attachments={attachments}
-            onAttachmentsChange={setAttachments}
-            scope={{ projectId, providerId }}
-            submitMode={mode}
-            onSubmit={(kind) => {
-              setLastSubmit(
-                `${kind} ${JSON.stringify(composerValueToPromptInput(value, attachments))}`,
-              );
-              toast.success(`Submit: ${kind}`);
-            }}
-            placeholder="Try @, /, + and the mic…"
-            testID="dev-composer"
-          />
-        </View>
+            <View className="flex-row flex-wrap gap-2">
+              {MODES.map((entry) => (
+                <Button
+                  key={entry.key}
+                  size="sm"
+                  variant={entry.key === modeKey ? "default" : "outline"}
+                  onPress={() => setModeKey(entry.key)}
+                  testID={`dev-composer-mode-${entry.key}`}
+                >
+                  {entry.label}
+                </Button>
+              ))}
+            </View>
+            <Text variant="sectionLabel">PromptInput</Text>
+            <Text variant="mono" selectable testID="dev-composer-serialized">
+              {serialized}
+            </Text>
+            {lastSubmit ? (
+              <Text variant="caption" testID="dev-composer-last-submit">
+                submitted: {lastSubmit}
+              </Text>
+            ) : null}
+          </ScrollView>
+          <View
+            className="border-t border-border-hairline bg-background px-3 pt-2"
+            style={{ paddingBottom: Math.max(insets.bottom, 12) }}
+          >
+            <Composer
+              value={value}
+              onChange={setValue}
+              attachments={attachments}
+              onAttachmentsChange={setAttachments}
+              scope={{ projectId, providerId }}
+              submitMode={mode}
+              onSubmit={(kind) => {
+                setLastSubmit(
+                  `${kind} ${JSON.stringify(composerValueToPromptInput(value, attachments))}`,
+                );
+                toast.success(`Submit: ${kind}`);
+              }}
+              placeholder="Try @, /, + and the mic…"
+              testID="dev-composer"
+            />
+          </View>
+        </OverlayBounds>
       </KeyboardPaddingView>
     </Screen>
   );

--- a/apps/mobile/src/screens/home/HomeScreen.tsx
+++ b/apps/mobile/src/screens/home/HomeScreen.tsx
@@ -24,6 +24,7 @@ import {
   Icon,
   COMPOSER_KEYBOARD_GAP,
   KeyboardPaddingView,
+  OverlayBounds,
   Spinner,
   Text,
 } from "@/ui";
@@ -269,56 +270,63 @@ function HomeBody() {
         style={{ flex: 1 }}
         keyboardGap={COMPOSER_KEYBOARD_GAP}
       >
-        <View className="flex-1">
-          <SidebarThreadList
-            contentContainerStyle={{ paddingBottom: 16 }}
-            testID="home-thread-list"
-          />
-        </View>
-        {/* The scrim dims everything under the card — the list and the
-            dock's own margins — so the expanded card floats over it. */}
-        {scrimMounted ? (
-          <Animated.View
-            pointerEvents={expanded ? "auto" : "none"}
-            style={{
-              position: "absolute",
-              top: 0,
-              left: 0,
-              right: 0,
-              bottom: 0,
-              opacity: scrim,
-              backgroundColor: withAlpha(
-                scrimBaseColor(mode, tokens),
-                SCRIM_ALPHA,
-              ),
-            }}
-          >
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Close composer"
-              onPress={collapse}
-              style={{ flex: 1 }}
-              testID="home-compose-scrim"
+        {/* The dock's typeahead floats up to the top of this region, never
+            under the header. */}
+        <OverlayBounds style={{ flex: 1 }}>
+          <View className="flex-1">
+            <SidebarThreadList
+              contentContainerStyle={{ paddingBottom: 16 }}
+              testID="home-thread-list"
             />
-          </Animated.View>
-        ) : null}
-        <View
-          className="px-3 pt-1"
-          style={{ paddingBottom: Math.max(insets.bottom, 8) }}
-          testID="home-compose-dock"
-        >
-          <ComposeDock
-            controller={controller}
-            onExpandedChange={setDockExpanded}
-            composerRef={composerRef}
-            onCreated={(thread) => {
-              collapse();
-              if (controller.navigateAfterCreate) {
-                router.push(threadHref(thread.id));
-              }
-            }}
-          />
-        </View>
+          </View>
+          {/* The scrim dims everything under the card — the list and the
+              dock's own margins — so the expanded card floats over it. It
+              overhangs the bounds by the keyboard gap: on devices without a
+              home-indicator inset the bounds end that far above the
+              keyboard, and the strip would otherwise show undimmed. */}
+          {scrimMounted ? (
+            <Animated.View
+              pointerEvents={expanded ? "auto" : "none"}
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: -COMPOSER_KEYBOARD_GAP,
+                opacity: scrim,
+                backgroundColor: withAlpha(
+                  scrimBaseColor(mode, tokens),
+                  SCRIM_ALPHA,
+                ),
+              }}
+            >
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Close composer"
+                onPress={collapse}
+                style={{ flex: 1 }}
+                testID="home-compose-scrim"
+              />
+            </Animated.View>
+          ) : null}
+          <View
+            className="px-3 pt-1"
+            style={{ paddingBottom: Math.max(insets.bottom, 8) }}
+            testID="home-compose-dock"
+          >
+            <ComposeDock
+              controller={controller}
+              onExpandedChange={setDockExpanded}
+              composerRef={composerRef}
+              onCreated={(thread) => {
+                collapse();
+                if (controller.navigateAfterCreate) {
+                  router.push(threadHref(thread.id));
+                }
+              }}
+            />
+          </View>
+        </OverlayBounds>
       </KeyboardPaddingView>
     </SidebarActionsProvider>
   );

--- a/apps/mobile/src/screens/thread/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/screens/thread/ThreadDetailScreen.tsx
@@ -38,6 +38,7 @@ import {
   EmptyStatePanel,
   COMPOSER_KEYBOARD_GAP,
   KeyboardPaddingView,
+  OverlayBounds,
   Skeleton,
   Text,
   useSheet,
@@ -428,69 +429,73 @@ function ThreadDetailBody({ threadId }: { threadId: string }) {
         style={{ flex: 1 }}
         keyboardGap={COMPOSER_KEYBOARD_GAP}
       >
-        {(timelineLoading && entries.length === 0) || !threadReady ? (
-          <View className="flex-1">
-            <TimelineSkeleton />
-          </View>
-        ) : timelineError && entries.length === 0 ? (
-          <View className="flex-1 gap-3 p-4" testID="thread-timeline-error">
-            <EmptyStatePanel>
-              <Text className="text-center text-sm text-muted-foreground">
-                Failed to load the timeline.
-              </Text>
-              <Text variant="caption" className="pt-1 text-center">
-                {timelineError.message}
-              </Text>
-            </EmptyStatePanel>
-            <Button
-              variant="outline"
-              icon="RotateCcw"
-              onPress={() => void refetchLatestTimeline()}
-            >
-              Retry
-            </Button>
-          </View>
-        ) : entries.length === 0 && !showWorkingIndicator ? (
-          <View className="flex-1 px-4 pt-6" testID="thread-timeline-empty">
-            <EmptyStatePanel>No messages yet.</EmptyStatePanel>
-          </View>
-        ) : (
-          <TimelineList
-            ref={listRef}
-            entries={entries}
-            unreadDividerIndex={unreadDividerIndex}
-            unreadDividerAutoScroll={unreadDivider.autoScroll}
-            onToggleRow={toggleRow}
+        {/* The composer's typeahead floats up to the top of this region,
+            never under the header. */}
+        <OverlayBounds style={{ flex: 1 }}>
+          {(timelineLoading && entries.length === 0) || !threadReady ? (
+            <View className="flex-1">
+              <TimelineSkeleton />
+            </View>
+          ) : timelineError && entries.length === 0 ? (
+            <View className="flex-1 gap-3 p-4" testID="thread-timeline-error">
+              <EmptyStatePanel>
+                <Text className="text-center text-sm text-muted-foreground">
+                  Failed to load the timeline.
+                </Text>
+                <Text variant="caption" className="pt-1 text-center">
+                  {timelineError.message}
+                </Text>
+              </EmptyStatePanel>
+              <Button
+                variant="outline"
+                icon="RotateCcw"
+                onPress={() => void refetchLatestTimeline()}
+              >
+                Retry
+              </Button>
+            </View>
+          ) : entries.length === 0 && !showWorkingIndicator ? (
+            <View className="flex-1 px-4 pt-6" testID="thread-timeline-empty">
+              <EmptyStatePanel>No messages yet.</EmptyStatePanel>
+            </View>
+          ) : (
+            <TimelineList
+              ref={listRef}
+              entries={entries}
+              unreadDividerIndex={unreadDividerIndex}
+              unreadDividerAutoScroll={unreadDivider.autoScroll}
+              onToggleRow={toggleRow}
+              threadId={threadId}
+              projectId={thread?.projectId ?? ""}
+              hasOlderRows={hasOlderTimelineRows}
+              isLoadingOlderRows={isLoadingOlderTimelineRows}
+              onLoadOlderRows={loadOlderTimelineRows}
+              footer={footer}
+              bottomInset={8}
+              testID="thread-timeline"
+            />
+          )}
+          <ThreadPromptArea
             threadId={threadId}
-            projectId={thread?.projectId ?? ""}
-            hasOlderRows={hasOlderTimelineRows}
-            isLoadingOlderRows={isLoadingOlderTimelineRows}
-            onLoadOlderRows={loadOlderTimelineRows}
-            footer={footer}
-            bottomInset={8}
-            testID="thread-timeline"
+            thread={thread}
+            environmentId={bootstrap.data?.environment?.id ?? null}
+            hostId={bootstrap.data?.host?.id ?? null}
+            composer={composer}
+            composerRef={composerRef}
+            pendingInteraction={pendingInteraction}
+            childPendingInteractions={childPendingInteractions}
+            queuedMessages={queuedMessages}
+            activeWorkflows={activeWorkflows}
+            activeBackgroundCommands={activeBackgroundCommands}
+            activePromptMode={activePromptMode}
+            goal={goal}
+            pendingTodos={pendingTodos}
+            modelFallback={modelFallback}
+            contextWindowUsage={contextWindowUsage}
+            contextBanner={contextBanner.banner}
+            onHandoffToNewThread={contextBanner.handoffToNewThread}
           />
-        )}
-        <ThreadPromptArea
-          threadId={threadId}
-          thread={thread}
-          environmentId={bootstrap.data?.environment?.id ?? null}
-          hostId={bootstrap.data?.host?.id ?? null}
-          composer={composer}
-          composerRef={composerRef}
-          pendingInteraction={pendingInteraction}
-          childPendingInteractions={childPendingInteractions}
-          queuedMessages={queuedMessages}
-          activeWorkflows={activeWorkflows}
-          activeBackgroundCommands={activeBackgroundCommands}
-          activePromptMode={activePromptMode}
-          goal={goal}
-          pendingTodos={pendingTodos}
-          modelFallback={modelFallback}
-          contextWindowUsage={contextWindowUsage}
-          contextBanner={contextBanner.banner}
-          onHandoffToNewThread={contextBanner.handoffToNewThread}
-        />
+        </OverlayBounds>
       </KeyboardPaddingView>
       {thread ? (
         <ThreadActionsSheet

--- a/apps/mobile/src/ui/OverlayBounds.tsx
+++ b/apps/mobile/src/ui/OverlayBounds.tsx
@@ -1,0 +1,75 @@
+import {
+  createContext,
+  createRef,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import { View, type StyleProp, type ViewStyle } from "react-native";
+
+export interface OverlayBoundsValue {
+  /** The native view a floating overlay measures its anchor against. */
+  ref: RefObject<View | null>;
+  /**
+   * Increments on every layout pass of the bounds view (keyboard frame,
+   * rotation), so an anchored overlay re-measures the room it has.
+   */
+  layoutVersion: number;
+}
+
+/** Without a provider the ref stays detached, so a consumer measures nothing. */
+const DETACHED_BOUNDS: OverlayBoundsValue = {
+  ref: createRef<View>(),
+  layoutVersion: 0,
+};
+
+const OverlayBoundsContext = createContext<OverlayBoundsValue>(DETACHED_BOUNDS);
+
+export interface OverlayBoundsProps {
+  children: ReactNode;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+/**
+ * The region a floating overlay anchored to a descendant may cover: the
+ * screen content under the native header and above the keyboard. The
+ * composer's typeahead measures its card against this view so the list
+ * never extends under the header, where the navigator chrome would hide
+ * (and block taps on) its first rows. Without a provider the bounds ref
+ * stays detached and an overlay keeps its fixed maximum height.
+ */
+export function OverlayBounds({ children, style, testID }: OverlayBoundsProps) {
+  const ref = useRef<View>(null);
+  const [layoutVersion, setLayoutVersion] = useState(0);
+  const handleLayout = useCallback(() => {
+    setLayoutVersion((version) => version + 1);
+  }, []);
+  const value = useMemo<OverlayBoundsValue>(
+    () => ({ ref, layoutVersion }),
+    [layoutVersion],
+  );
+  return (
+    <OverlayBoundsContext.Provider value={value}>
+      <View
+        ref={ref}
+        // Android flattens plain Views out of the native tree; the
+        // `measureLayout` target has to exist there.
+        collapsable={false}
+        style={style}
+        onLayout={handleLayout}
+        testID={testID}
+      >
+        {children}
+      </View>
+    </OverlayBoundsContext.Provider>
+  );
+}
+
+export function useOverlayBounds(): OverlayBoundsValue {
+  return useContext(OverlayBoundsContext);
+}

--- a/apps/mobile/src/ui/index.ts
+++ b/apps/mobile/src/ui/index.ts
@@ -41,6 +41,12 @@ export {
   type KeyboardPaddingViewProps,
 } from "./KeyboardPaddingView";
 export { ListRow, type ListRowProps } from "./ListRow";
+export {
+  OverlayBounds,
+  useOverlayBounds,
+  type OverlayBoundsProps,
+  type OverlayBoundsValue,
+} from "./OverlayBounds";
 export { Pill, type PillProps, type PillSize, type PillVariant } from "./Pill";
 export { Separator, type SeparatorProps } from "./Separator";
 export {


### PR DESCRIPTION
## What was wrong

In the native mobile app, the composer's `@` / `/` typeahead floats above the card (`position: absolute`, `bottom: 100%`) with a fixed `maxHeight: 280`. Nothing knew how much room sat between the native stack header and the card. With the keyboard up that room is often ~225pt on a phone, so the list ran under the header and its first rows ("Threads", the top match) were hidden and could not be tapped.

## What changed

- `apps/mobile/src/ui/OverlayBounds.tsx` (new): a provider that marks the region a floating overlay may cover (the screen content under the header, above the keyboard). It exposes a view ref plus a layout counter.
- `apps/mobile/src/composer/model/typeahead-height.ts` (new): `resolveTypeaheadMaxHeight(spaceAbove)` clamps the list to `space − gap − top margin`, between one row (44) and the old 280 cap. `null` (no provider / unmeasured) keeps the fixed cap.
- `apps/mobile/src/composer/Composer.tsx`: measures the card root against the bounds (`measureLayout`) on its own layout, on bounds layout (keyboard frame, rotation), and when the menu opens. Applies the cap only to the floating `above` placement so the inline `below` list cannot feed back into its own anchor.
- `HomeScreen`, `ThreadDetailScreen`, and the dev composer showcase wrap their content in `OverlayBounds`. The home scrim overhangs the bounds by the keyboard gap so devices without a home-indicator inset do not show an undimmed strip above the keyboard.
- `TypeaheadMenu` defaults its `maxHeight` to the shared constant. README `ui/` entry updated.

Known residual: with less than ~58pt above the card (a landscape phone with a tall draft) the one-row floor still overlaps the header by the difference. Documented in `typeahead-height.ts`.

## How you verified

- `pnpm exec turbo run test typecheck lint --filter=@bb/mobile`: 833 tests pass (new `typeahead-height.test.ts` covers the clamp), typecheck and lint clean.
- iOS Simulator (iPhone 17, iOS 26.3) against the fake-provider mobile e2e backend, driven by Maestro. Seeded ten "Complete task N" threads so the `@` menu overflows. Home dock and thread screen, `@` and `/` menus: the list now stops 8pt under the header, and tapping row 0 inserts the pill.

| Before | After |
| --- | --- |
| The list's top rows sit under the header. | "THREADS" and the first row are visible; the first row is tappable. |

Fixes: no issue filed (reported from a device screenshot).

> AGENT GENERATED: by Claude Opus 5
