### PR TITLE
Load the thread storage file tree on demand

### DIFF
--- a/apps/app/bundle-budget.json
+++ b/apps/app/bundle-budget.json
@@ -39,7 +39,8 @@
     "painted' and 'route content painted'. SplitWorkspaceRoute is every thread,",
     "compose and plugin-panel page, so its closure is the second number that",
     "decides how slow bb feels on a phone. Same 10% ratchet; its forbiddenPackages",
-    "are the diff engine, math and terminal code that only a user action needs.",
+    "are the diff engine, math, file tree and terminal code that only a user",
+    "action needs.",
     "The composer (tiptap/prosemirror) is visible on every thread page and is",
     "allowed until it moves behind a first-focus handoff. Run",
     "`node scripts/why-eager.mjs --from=views/SplitWorkspaceRoute.tsx <package>`",
@@ -70,16 +71,18 @@
     "shiki"
   ],
   "onDemandPackages": {
+    "@pierre/trees": "src/components/secondary-panel/ThreadStorageFileTree.tsx",
     "katex": "src/components/ui/markdown-katex.ts",
     "rehype-katex": "src/components/ui/markdown-katex.ts"
   },
   "routeClosures": {
     "SplitWorkspaceRoute": {
-      "maxBytes": 2533484,
-      "maxBrotliBytes": 671561,
+      "maxBytes": 2268430,
+      "maxBrotliBytes": 605332,
       "forbiddenPackages": [
         "@pierre/diffs",
         "@pierre/theming",
+        "@pierre/trees",
         "@shikijs/core",
         "@shikijs/engine-javascript",
         "@shikijs/engine-oniguruma",

--- a/apps/app/src/components/secondary-panel/ThreadStorageBrowser.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadStorageBrowser.tsx
@@ -1,11 +1,4 @@
-import {
-  useEffect,
-  useMemo,
-  useRef,
-  type CSSProperties,
-  type ReactNode,
-} from "react";
-import { FileTree } from "@pierre/trees/react";
+import { useEffect, useRef, type ReactNode } from "react";
 import { Button } from "@bb/shared-ui/button";
 import {
   COARSE_POINTER_COMPACT_ICON_BUTTON_CLASS,
@@ -16,58 +9,14 @@ import { EmptyState } from "@bb/shared-ui/empty-state";
 import { Icon } from "@bb/shared-ui/icon";
 import { usePointerCoarse } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import { Input } from "@bb/shared-ui/input";
-import { usePreferredTheme } from "@/hooks/useTheme";
 import { cn } from "@bb/shared-ui/lib/utils";
 import {
   describeLifecycleError,
   formatLifecycleErrorDescription,
 } from "@/lib/lifecycle-errors";
 import { getMutationErrorMessage } from "@/lib/mutation-errors";
+import { LazyThreadStorageFileTree } from "./lazySecondaryPanelComponents";
 import type { ThreadStorageBrowserController } from "./useThreadStorageBrowser";
-
-interface FileTreeHostStyle extends CSSProperties {
-  "--trees-accent-override": string;
-  "--trees-bg-muted-override": string;
-  "--trees-bg-override": string;
-  "--trees-border-color-override": string;
-  "--trees-fg-muted-override": string;
-  "--trees-fg-override": string;
-  "--trees-focus-ring-color-override": string;
-  "--trees-font-family-override": string;
-  "--trees-font-size-override": string;
-  "--trees-icon-width-override": string;
-  "--trees-item-margin-x-override": string;
-  "--trees-padding-inline-override": string;
-  "--trees-scrollbar-thumb-override": string;
-  "--trees-selected-bg-override": string;
-  "--trees-selected-fg-override": string;
-  "--trees-selected-focused-border-color-override": string;
-}
-
-const FILE_TREE_BASE_HOST_STYLE: FileTreeHostStyle = {
-  "--trees-accent-override": "var(--ring)",
-  "--trees-bg-muted-override":
-    "color-mix(in srgb, var(--muted) 45%, transparent)",
-  "--trees-bg-override": "transparent",
-  "--trees-border-color-override": "var(--border)",
-  "--trees-fg-muted-override": "var(--muted-foreground)",
-  "--trees-fg-override": "var(--foreground)",
-  "--trees-focus-ring-color-override": "var(--ring)",
-  "--trees-font-family-override": "var(--font-sans)",
-  // Match the info page's compact text-xs rows and the app's smaller icon/caret
-  // scale (the tree's chevron caret + file icons size off --trees-icon-width).
-  "--trees-font-size-override": "var(--text-xs)",
-  "--trees-icon-width-override": "14px",
-  "--trees-item-margin-x-override": "0",
-  "--trees-padding-inline-override": "0",
-  "--trees-scrollbar-thumb-override":
-    "color-mix(in srgb, var(--muted-foreground) 35%, transparent)",
-  "--trees-selected-bg-override":
-    "color-mix(in srgb, var(--accent) 65%, transparent)",
-  "--trees-selected-fg-override": "var(--foreground)",
-  "--trees-selected-focused-border-color-override": "var(--ring)",
-  height: "100%",
-};
 
 interface ThreadStorageBrowserProps {
   controller: ThreadStorageBrowserController;
@@ -89,7 +38,6 @@ export function ThreadStorageBrowser({
     searchQuery,
     setSearchQuery,
   } = controller;
-  const preferredTheme = usePreferredTheme();
   const searchInputRef = useRef<HTMLInputElement>(null);
   const isPointerCoarse = usePointerCoarse();
 
@@ -99,14 +47,13 @@ export function ThreadStorageBrowser({
     }
   }, [isPointerCoarse, isSearchOpen]);
 
-  const fileTreeHostStyle = useMemo<FileTreeHostStyle>(
-    () => ({
-      ...FILE_TREE_BASE_HOST_STYLE,
-      colorScheme: preferredTheme,
-    }),
-    [preferredTheme],
+  const loadingState = (
+    <EmptyState
+      icon="Spinner"
+      message="Loading files..."
+      iconClassName="animate-spin"
+    />
   );
-
   let body: ReactNode;
   if (filesError) {
     const lifecycleErrorDescription = describeLifecycleError({
@@ -129,26 +76,17 @@ export function ThreadStorageBrowser({
       />
     );
   } else if (isFilesLoading && loadedFiles.length === 0) {
-    body = (
-      <EmptyState
-        icon="Spinner"
-        message="Loading files..."
-        iconClassName="animate-spin"
-      />
-    );
+    body = loadingState;
   } else if (loadedFiles.length === 0) {
     body = <EmptyState message="No files yet." />;
   } else if (filteredFiles.length === 0) {
     body = <EmptyState message="No files match search." />;
+  } else if (model === null) {
+    // The tree chunk is still on its way; the controller hands over the model
+    // once it lands.
+    body = loadingState;
   } else {
-    body = (
-      <FileTree
-        aria-label="Thread storage file tree"
-        className="block h-full min-h-0"
-        model={model}
-        style={fileTreeHostStyle}
-      />
-    );
+    body = <LazyThreadStorageFileTree fallback={loadingState} model={model} />;
   }
 
   return (

--- a/apps/app/src/components/secondary-panel/ThreadStorageFileTree.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadStorageFileTree.tsx
@@ -1,0 +1,101 @@
+// The lazy `@pierre/trees` chunk: the only module that imports the tree
+// library at runtime. `useThreadStorageBrowser` imports this module with a
+// dynamic `import()` to build the tree model the first time a thread has
+// storage files to show, and `ThreadStorageBrowser` renders the tree through
+// `React.lazy` (see lazySecondaryPanelComponents.tsx). That keeps ~420 KB raw
+// of tree model, renderer and preact out of the thread route's static closure;
+// `bundle-budget.json` names this file as the package's only gate. Keep
+// anything else out of here: it rides along in the tree chunk.
+import { useMemo, type CSSProperties } from "react";
+import {
+  FileTree as FileTreeModel,
+  type FileTreeSelectionChangeListener,
+} from "@pierre/trees";
+import { FileTree } from "@pierre/trees/react";
+import { usePreferredTheme } from "@/hooks/useTheme";
+
+export type ThreadStorageTreeModel = FileTreeModel;
+
+/**
+ * Builds the storage browser's tree model. The caller owns it and must call
+ * `model.cleanUp()` when done: that unsubscribes the selection listener and
+ * destroys the controller (see render/FileTree.ts in pierrecomputer/pierre).
+ */
+export function createThreadStorageTreeModel(
+  onSelectionChange: FileTreeSelectionChangeListener,
+): ThreadStorageTreeModel {
+  return new FileTreeModel({
+    density: "compact",
+    initialExpansion: "closed",
+    onSelectionChange,
+    paths: [],
+    search: false,
+  });
+}
+
+interface FileTreeHostStyle extends CSSProperties {
+  "--trees-accent-override": string;
+  "--trees-bg-muted-override": string;
+  "--trees-bg-override": string;
+  "--trees-border-color-override": string;
+  "--trees-fg-muted-override": string;
+  "--trees-fg-override": string;
+  "--trees-focus-ring-color-override": string;
+  "--trees-font-family-override": string;
+  "--trees-font-size-override": string;
+  "--trees-icon-width-override": string;
+  "--trees-item-margin-x-override": string;
+  "--trees-padding-inline-override": string;
+  "--trees-scrollbar-thumb-override": string;
+  "--trees-selected-bg-override": string;
+  "--trees-selected-fg-override": string;
+  "--trees-selected-focused-border-color-override": string;
+}
+
+const FILE_TREE_BASE_HOST_STYLE: FileTreeHostStyle = {
+  "--trees-accent-override": "var(--ring)",
+  "--trees-bg-muted-override":
+    "color-mix(in srgb, var(--muted) 45%, transparent)",
+  "--trees-bg-override": "transparent",
+  "--trees-border-color-override": "var(--border)",
+  "--trees-fg-muted-override": "var(--muted-foreground)",
+  "--trees-fg-override": "var(--foreground)",
+  "--trees-focus-ring-color-override": "var(--ring)",
+  "--trees-font-family-override": "var(--font-sans)",
+  // Match the info page's compact text-xs rows and the app's smaller icon/caret
+  // scale (the tree's chevron caret + file icons size off --trees-icon-width).
+  "--trees-font-size-override": "var(--text-xs)",
+  "--trees-icon-width-override": "14px",
+  "--trees-item-margin-x-override": "0",
+  "--trees-padding-inline-override": "0",
+  "--trees-scrollbar-thumb-override":
+    "color-mix(in srgb, var(--muted-foreground) 35%, transparent)",
+  "--trees-selected-bg-override":
+    "color-mix(in srgb, var(--accent) 65%, transparent)",
+  "--trees-selected-fg-override": "var(--foreground)",
+  "--trees-selected-focused-border-color-override": "var(--ring)",
+  height: "100%",
+};
+
+export function ThreadStorageFileTree({
+  model,
+}: {
+  model: ThreadStorageTreeModel;
+}) {
+  const preferredTheme = usePreferredTheme();
+  const fileTreeHostStyle = useMemo<FileTreeHostStyle>(
+    () => ({
+      ...FILE_TREE_BASE_HOST_STYLE,
+      colorScheme: preferredTheme,
+    }),
+    [preferredTheme],
+  );
+  return (
+    <FileTree
+      aria-label="Thread storage file tree"
+      className="block h-full min-h-0"
+      model={model}
+      style={fileTreeHostStyle}
+    />
+  );
+}

--- a/apps/app/src/components/secondary-panel/lazySecondaryPanelComponents.tsx
+++ b/apps/app/src/components/secondary-panel/lazySecondaryPanelComponents.tsx
@@ -35,6 +35,7 @@ type ThreadTerminalPanelModule =
 type BrowserTabDeckModule = typeof import("./BrowserTabDeck");
 type NewTabPageModule = typeof import("./NewTabPage");
 type FilePreviewModule = typeof import("./FilePreview");
+type ThreadStorageFileTreeModule = typeof import("./ThreadStorageFileTree");
 
 const ThreadSecondaryPanelChunk = lazy(() =>
   import("./ThreadSecondaryPanel").then(({ ThreadSecondaryPanel }) => ({
@@ -57,6 +58,11 @@ const NewTabPageChunk = lazy(() =>
 const FilePreviewChunk = lazy(() =>
   import("./FilePreview").then(({ FilePreview }) => ({
     default: FilePreview,
+  })),
+);
+const ThreadStorageFileTreeChunk = lazy(() =>
+  import("./ThreadStorageFileTree").then(({ ThreadStorageFileTree }) => ({
+    default: ThreadStorageFileTree,
   })),
 );
 const WorkspaceFilePreviewTabContentChunk = lazy(() =>
@@ -231,6 +237,25 @@ export function LazyFilePreview(
   return (
     <Suspense fallback={<SecondaryPanelContentSkeleton />}>
       <FilePreviewChunk {...props} />
+    </Suspense>
+  );
+}
+
+/**
+ * The storage browser's `@pierre/trees` tree. Its model comes from the same
+ * chunk (`useThreadStorageBrowser` imports it to build the model), so by the
+ * time a caller has a model to render the chunk is already loaded and the
+ * fallback shows for at most one commit.
+ */
+export function LazyThreadStorageFileTree({
+  fallback,
+  ...props
+}: ComponentProps<ThreadStorageFileTreeModule["ThreadStorageFileTree"]> & {
+  fallback: ReactNode;
+}) {
+  return (
+    <Suspense fallback={fallback}>
+      <ThreadStorageFileTreeChunk {...props} />
     </Suspense>
   );
 }

--- a/apps/app/src/components/secondary-panel/useThreadStorageBrowser.test.tsx
+++ b/apps/app/src/components/secondary-panel/useThreadStorageBrowser.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { WorkspaceFile } from "@bb/server-contract";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useThreadStorageBrowser } from "./useThreadStorageBrowser";
+
+// Records when the tree library is first evaluated. A static import anywhere
+// on the hook's path would fire this while the test file loads, before any
+// thread has files to show; the route budget forbids exactly that. Hoisted so
+// it exists even when such a static import runs before this module body.
+const { treesModuleEvaluated } = vi.hoisted(() => ({
+  treesModuleEvaluated: vi.fn<(specifier: string) => void>(),
+}));
+vi.mock("@pierre/trees", async (importOriginal) => {
+  treesModuleEvaluated("@pierre/trees");
+  return importOriginal();
+});
+vi.mock("@pierre/trees/react", async (importOriginal) => {
+  treesModuleEvaluated("@pierre/trees/react");
+  return importOriginal();
+});
+
+const FILES: readonly WorkspaceFile[] = [
+  { name: "notes.md", path: "docs/notes.md" },
+  { name: "main.ts", path: "src/main.ts" },
+];
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("useThreadStorageBrowser", () => {
+  it("loads the tree library only once there are files to show", async () => {
+    const onSelectPath = vi.fn();
+    const initialProps: { files: readonly WorkspaceFile[] | undefined } = {
+      files: undefined,
+    };
+    const { result, rerender } = renderHook(
+      ({ files }: typeof initialProps) =>
+        useThreadStorageBrowser({ files, onSelectPath, selectedPath: null }),
+      { initialProps },
+    );
+
+    expect(treesModuleEvaluated).not.toHaveBeenCalled();
+    expect(result.current.model).toBeNull();
+
+    rerender({ files: [] });
+    await Promise.resolve();
+    expect(treesModuleEvaluated).not.toHaveBeenCalled();
+    expect(result.current.model).toBeNull();
+
+    rerender({ files: FILES });
+    await waitFor(() => {
+      expect(result.current.model).not.toBeNull();
+    });
+    expect(treesModuleEvaluated).toHaveBeenCalled();
+  });
+
+  it("syncs files and selection into the model once it arrives, then destroys it on unmount", async () => {
+    const onSelectPath = vi.fn();
+    const { result, rerender, unmount } = renderHook(
+      ({ selectedPath }: { selectedPath: string | null }) =>
+        useThreadStorageBrowser({ files: FILES, onSelectPath, selectedPath }),
+      { initialProps: { selectedPath: "src/main.ts" } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.model).not.toBeNull();
+    });
+    const model = result.current.model;
+    if (model === null) throw new Error("model should be loaded");
+    // The files and the selection that arrived before the chunk did are
+    // applied to the model as soon as it exists, not only on the next change.
+    expect(model.getItem("src/main.ts")).not.toBeNull();
+    expect(model.getItem("docs/notes.md")).not.toBeNull();
+    expect(model.getSelectedPaths()).toEqual(["src/main.ts"]);
+
+    rerender({ selectedPath: "docs/notes.md" });
+    expect(model.getSelectedPaths()).toEqual(["docs/notes.md"]);
+    // Reconciling React state into the tree must not echo back as a user
+    // selection.
+    expect(onSelectPath).not.toHaveBeenCalled();
+
+    const cleanUp = vi.spyOn(model, "cleanUp");
+    unmount();
+    expect(cleanUp).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/app/src/components/secondary-panel/useThreadStorageBrowser.ts
+++ b/apps/app/src/components/secondary-panel/useThreadStorageBrowser.ts
@@ -5,10 +5,25 @@ import {
   useRef,
   useState,
 } from "react";
-import { useFileTree, type UseFileTreeResult } from "@pierre/trees/react";
 import type { WorkspaceFile } from "@bb/server-contract";
+import { createRetryingModuleLoader } from "@/lib/plugin-frontend-lazy";
+// Type-only: the runtime edge to `@pierre/trees` is the dynamic `import()`
+// below, so the tree library stays out of the thread route's static closure
+// (bundle-budget.json forbids it there).
+import type { ThreadStorageTreeModel } from "./ThreadStorageFileTree";
 
 const EMPTY_STORAGE_FILES: readonly WorkspaceFile[] = [];
+
+type ThreadStorageFileTreeModule = typeof import("./ThreadStorageFileTree");
+
+/**
+ * Loads the tree chunk once and re-tries after a failed fetch, so a flaky
+ * network cannot leave the storage browser without a tree for good.
+ */
+const loadThreadStorageFileTree =
+  createRetryingModuleLoader<ThreadStorageFileTreeModule>(
+    () => import("./ThreadStorageFileTree"),
+  );
 
 export type ThreadStoragePathSelectHandler = (path: string) => void;
 
@@ -23,7 +38,8 @@ export interface ThreadStorageBrowserController {
   filteredFiles: readonly WorkspaceFile[];
   isSearchOpen: boolean;
   loadedFiles: readonly WorkspaceFile[];
-  model: UseFileTreeResult["model"];
+  /** `null` until the lazily loaded tree chunk has created the model. */
+  model: ThreadStorageTreeModel | null;
   openSearch: () => void;
   searchQuery: string;
   setSearchQuery: (query: string) => void;
@@ -48,13 +64,17 @@ function buildDirectoryPaths(paths: readonly string[]): string[] {
 /**
  * Owns the thread storage browser's tree model and related UI state.
  *
- * Pierre tree's `useFileTree` destroys its model on the owning component's
- * unmount (`model.cleanUp()` unsubscribes the selection listener and destroys
- * the controller — see packages/trees/src/react/useFileTree.ts and
- * render/FileTree.ts in pierrecomputer/pierre). The storage tab content
- * unmounts whenever a file tab covers it, so this hook must live in a parent
- * that survives that toggle (e.g., ThreadDetailView), with the model and
- * search state passed down to the presentational browser.
+ * The tree model is destroyed when this hook's owner unmounts
+ * (`model.cleanUp()` unsubscribes the selection listener and destroys the
+ * controller — see render/FileTree.ts in pierrecomputer/pierre). The storage
+ * tab content unmounts whenever a file tab covers it, so this hook must live
+ * in a parent that survives that toggle (e.g., ThreadDetailView), with the
+ * model and search state passed down to the presentational browser.
+ *
+ * The model arrives asynchronously: the tree chunk is imported on demand,
+ * and only once there are files to show (with no files the browser
+ * renders an empty state and never mounts a tree). `model` is `null` until
+ * then and the sync effects below wait for it.
  */
 export function useThreadStorageBrowser({
   files,
@@ -107,13 +127,31 @@ export function useThreadStorageBrowser({
     [],
   );
 
-  const { model } = useFileTree({
-    density: "compact",
-    initialExpansion: "closed",
-    onSelectionChange: handleTreeSelectionChange,
-    paths: [],
-    search: false,
-  });
+  const [model, setModel] = useState<ThreadStorageTreeModel | null>(null);
+  const shouldLoadTree = loadedFiles.length > 0;
+  useEffect(() => {
+    if (!shouldLoadTree) return;
+    let cancelled = false;
+    let createdModel: ThreadStorageTreeModel | null = null;
+    void loadThreadStorageFileTree().then(
+      ({ createThreadStorageTreeModel }) => {
+        if (cancelled) return;
+        createdModel = createThreadStorageTreeModel(handleTreeSelectionChange);
+        setModel(createdModel);
+      },
+      (error: unknown) => {
+        if (cancelled) return;
+        console.warn(
+          `thread storage tree load failed: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      },
+    );
+    return () => {
+      cancelled = true;
+      createdModel?.cleanUp();
+      setModel(null);
+    };
+  }, [handleTreeSelectionChange, shouldLoadTree]);
 
   const isSearching = searchQuery.trim().length > 0;
   const expandedDirectoryPaths = useMemo(
@@ -121,12 +159,14 @@ export function useThreadStorageBrowser({
     [isSearching, filePaths],
   );
   useEffect(() => {
+    if (model === null) return;
     model.resetPaths(filePaths, {
       initialExpandedPaths: expandedDirectoryPaths,
     });
   }, [expandedDirectoryPaths, filePaths, model]);
 
   useEffect(() => {
+    if (model === null) return;
     const currentSelectedPaths = model.getSelectedPaths();
     const selectedPathIsVisible =
       selectedPath !== null && filePathSet.has(selectedPath);


### PR DESCRIPTION
## What was wrong

Issue #1072 (report: https://get-bb.github.io/reports/issues/1072.html) tracks heavy packages that sit in the static import closure of the lazy thread route (`SplitWorkspaceRoute`), so every thread open downloads and parses them before the timeline paints. Since the report was written, main already cut three of the five edges it names: `FilePreview -> @pierre/diffs` and the secondary-panel surfaces (#1894), `markdown-preview -> rehype-katex` (#1891), and Handlebars (#2080). The budget check in CI now ratchets that closure.

One edge was still open: `useThreadStorageBrowser.ts` imported `@pierre/trees/react` statically, and `ThreadDetailView` calls that hook on every thread page (it has to, so the tree model survives the Info-tab/file-tab toggle). That put the tree model, its renderer and preact (~250 KB raw / ~62 KB brotli emitted) in the route closure, although only the "Thread storage" browser in the Info tab renders a tree, and the storage file list itself is only fetched once the panel opens. `node scripts/why-eager.mjs --from=views/SplitWorkspaceRoute.tsx node_modules/@pierre/trees` on main:

```
0. apps/app/src/views/SplitWorkspaceRoute.tsx
1. apps/app/src/views/thread-detail/SplitThreadArea.tsx
2. apps/app/src/views/thread-detail/ThreadDetailView.tsx
3. apps/app/src/components/secondary-panel/useThreadStorageBrowser.ts
4. node_modules/@pierre/trees/dist/react/index.js
```

## What changed

All in `apps/app`.

- `src/components/secondary-panel/ThreadStorageFileTree.tsx` (new): the only runtime importer of `@pierre/trees`. Exports `createThreadStorageTreeModel(onSelectionChange)` (the `new FileTree(...)` that `useFileTree` wrapped) and the `ThreadStorageFileTree` render component with the host style that used to live in `ThreadStorageBrowser.tsx`.
- `useThreadStorageBrowser.ts`: no static tree import. When a thread has storage files, an effect imports the gate module (through `createRetryingModuleLoader`, the same helper the pierre worker pool uses) and builds the model; `model` is `null` until then, the `resetPaths`/selection sync effects wait for it, and cleanup calls `model.cleanUp()` and ignores a load that resolves after unmount. A failed chunk fetch logs a warning and the next mount retries.
- `ThreadStorageBrowser.tsx`: renders the tree through `LazyThreadStorageFileTree` (new wrapper in `lazySecondaryPanelComponents.tsx`) and shows the existing "Loading files..." state while `model` is `null`.
- `bundle-budget.json`: `@pierre/trees` added to the `SplitWorkspaceRoute` forbidden list and to `onDemandPackages` (gate: `ThreadStorageFileTree.tsx`, so no chunk outside that gate may reach it); route budget ratcheted to 10% above the new measurement (2,268,430 raw / 605,332 brotli, from 2,533,484 / 671,561).

Route closure, `node scripts/check-bundle-budget.mjs`: before 2260.4 KB raw / 599.1 KB brotli, after 2013.9 KB raw / 537.4 KB brotli (-11% raw, -10% brotli). The tree now ships as `ThreadStorageFileTree-*.js` (253,881 B raw / 64,341 B brotli) fetched when the storage browser first has files.

Not in this PR: the composer (`PromptBoxInternal -> tiptap/prosemirror`, ~600 KB raw in the shared `workspace-checkout-display` chunk). It is visible on every thread page, `PromptBoxInternal.tsx` owns the `useEditor` instance across 3,600 lines, and a first-focus handoff has to keep draft restore, autofocus, the mention menu and iOS keyboard-on-tap working. #1894 deliberately left it allowed in the route budget for that reason; it needs its own design.

A previous agent's WIP on this branch (a null-rendering "tree model host" component returned from the hook as a ReactNode) was discarded in favour of the imperative model factory above.

## How you verified

- New `useThreadStorageBrowser.test.tsx` (real `@pierre/trees` in jsdom, `vi.mock` factories only record when the library is first evaluated):
  - "loads the tree library only once there are files to show" fails on main's source files with `AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times ... "@pierre/trees/react"` and passes on this branch.
  - "syncs files and selection into the model once it arrives, then destroys it on unmount": the files and `selectedPath` that arrived before the chunk are applied to the model; reconciling selection does not echo through `onSelectPath`; unmount calls `cleanUp()` once.
- `node scripts/check-bundle-budget.mjs` with the new `bundle-budget.json` against main's build: `@pierre/trees is in the SplitWorkspaceRoute closure (assets/SplitWorkspaceRoute-9lmZmaba.js). It must load on demand`, exit 1. After rebuilding on this branch: `Bundle budget OK` (including the new on-demand gate check).
- `pnpm exec turbo run typecheck --filter=@bb/app --force`, `pnpm exec turbo run lint --filter=@bb/app --force`, `pnpm exec turbo run build --filter=@bb/app`: pass. (The first push of this PR had two TS2322 errors in the new test file: `renderHook(..., { initialProps: { files: undefined } })` inferred the props type as `{ files: undefined }`, so the later `rerender({ files: [] })` calls did not compile and the CI bundle-budget step never ran. The test now declares `initialProps` with an explicit `{ files: readonly WorkspaceFile[] | undefined }` type; the forced typecheck is clean and the fail-before/pass-after result above was re-run with the typed test.)
- `pnpm exec turbo run test --filter=@bb/app --force`: all files pass.
- Manual, own dev instance + headless Chrome: opened a codex thread with two seeded storage files (`docs/notes.md`, `main.ts`); thread painted; opened the right panel, the "Thread storage" tree rendered `docs` and `main.ts`; clicking `main.ts` opened the file preview tab; switching back to Info showed the same tree (model survived the tab toggle).

Fixes #1072

> AGENT GENERATED: by Claude Opus 5




## Independent verification

Round 2, by an independent verifier on a fresh worktree checked out at `3cf9d8d10` (rebased on `origin/main` `2c0b747a5`; `git merge-base --is-ancestor origin/main HEAD` true, `mergeable: MERGEABLE`).

Commands run:

- `pnpm install --frozen-lockfile --prefer-offline && pnpm exec turbo run build` (18/18 tasks).
- `cd apps/app && node scripts/check-bundle-budget.mjs` → `SplitWorkspaceRoute closure: 2013.9 KB raw / 537.4 KB brotli` (budget 2215.3 / 591.1), `Bundle budget OK.` `node scripts/why-eager.mjs --from=views/SplitWorkspaceRoute.tsx node_modules/@pierre/trees` → `0 eagerly reachable module(s) ... only reachable behind a dynamic import (56 modules)`. The tree is emitted as `ThreadStorageFileTree-BVIqkJpc.js` (253,881 B).
- `pnpm exec turbo run typecheck --filter=@bb/app --force` → `Tasks: 3 successful, 3 total`, no `error TS` (the round-1 TS2322 errors in the test file are gone).
- `pnpm exec turbo run lint --filter=@bb/app --force` → `Tasks: 1 successful, 1 total`.
- `pnpm exec turbo run test --filter=@bb/app --force` → `Test Files 415 passed (415)`, `Tests 3191 passed | 3 skipped`.

Fail-before / pass-after (`apps/app`, `pnpm exec vitest run src/components/secondary-panel/useThreadStorageBrowser.test.tsx`):

- With `bundle-budget.json`, `ThreadStorageBrowser.tsx`, `lazySecondaryPanelComponents.tsx`, `useThreadStorageBrowser.ts` checked out from `origin/main` and `ThreadStorageFileTree.tsx` removed: `1 failed | 1 passed` — `AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times` with `1st vi.fn() call: ["@pierre/trees/react"]` at `useThreadStorageBrowser.test.tsx:45:38`.
- Restored to the PR tree: `Tests 2 passed (2)`.

Repro on the fixed branch (own dev instance, production `apps/app/dist` served on a private port with `/api` proxied, headless Chrome, `performance.getEntriesByType("resource")` with an enlarged buffer; codex thread `thr_52anzhhcu7` seeded with `docs/notes.md` and `main.ts` in its thread-storage dir):

- Right panel closed: thread painted; `SplitWorkspaceRoute-BX4iePCW.js` (267,669 B) and `workspace-checkout-display-BuOjOA0-.js` (1,074,222 B) fetched at ~290 ms; no `/thread-storage/files` request and no `ThreadStorageFileTree` chunk at all.
- Right panel open on the Info tab: `/thread-storage/files` at 1087 ms, then `ThreadStorageFileTree-BVIqkJpc.js` at 1207 ms; the "Thread storage" tree rendered `docs` and `main.ts`.

CI on `3cf9d8d10`: all checks pass (Checks incl. `check-bundle-budget.mjs`, Tests app-1/2/3, integration, packages, server, Package Smoke ubuntu/macos).

Residual risks / notes for the maintainer:

- The composer edge (`PromptBoxInternal -> @tiptap/*` / `prosemirror-*`, ~600 KB raw inside `workspace-checkout-display`) is still a static import of the thread route; it is named in the issue title and is the largest remaining item behind "no editor parsing on first paint". `bundle-budget.json` allows it by design (#1894). If you want #1072 to keep tracking that edge, change `Fixes #1072` to `Refs #1072` or open a follow-up issue before merging; otherwise this PR closes it.
- Behavior change is limited to the storage browser: one extra chunk fetch (and the existing "Loading files..." state) the first time a thread shows storage files; a failed chunk fetch leaves that state, logs a `console.warn`, and retries on the next mount. The model is now created per "files non-empty" span instead of once per `ThreadDetailView` mount, so it is rebuilt after the file list empties and refills; `resetPaths` re-applies expansion from the current search state in both designs, so no visible difference.

> AGENT GENERATED: by Claude Opus 5
