### PR TITLE
Reactivate threads when a provider resumes root work on a settled turn

### DIFF
--- a/apps/server/src/internal/events.ts
+++ b/apps/server/src/internal/events.ts
@@ -2,7 +2,6 @@ import { and, desc, eq, gt, isNull, lt, sql } from "drizzle-orm";
 import {
   appendDaemonEventsInTransaction,
   deriveStoredEventItemFields,
-  getRootStoredTurnStartedSequence,
   getThread,
   listCompletedTurnsByThreadIds,
   listThreadEnvironmentAssignmentsOnHost,
@@ -173,6 +172,8 @@ interface HasThreadStopSinceTurnRequestedArgs {
 
 interface ResolveReopenedRootTurnIdArgs {
   event: Extract<HostDaemonEventEnvelope["event"], { type: "item/started" }>;
+  /** Per-batch thread row cache; see `applyEventEffects`. */
+  threadRowsById: Map<string, ReturnType<typeof getThread>>;
   threadId: string;
 }
 
@@ -388,6 +389,11 @@ async function applyEventEffects(
   // work stay deferred to avoid command waits inside daemon ingress.
   const followUps: EventEffectFollowUp[] = [];
   const failedParentNotificationThreadIds = new Set<string>();
+  // Thread rows read by the reopen check below, memoized for the batch so the
+  // common case (root items streaming on an active thread) costs one lookup
+  // per thread instead of one per item. Every branch that changes a thread's
+  // lifecycle evicts its row so later items in the batch see the new status.
+  const threadRowsById = new Map<string, ReturnType<typeof getThread>>();
   for (const entry of events) {
     try {
       const event = entry.event;
@@ -412,6 +418,7 @@ async function applyEventEffects(
         if (!isRootTurnStartedEvent(event)) {
           continue;
         }
+        threadRowsById.delete(entry.threadId);
         applyLoggedThreadLifecycleEvent(deps, {
           event: { type: "run.started" },
           threadId: entry.threadId,
@@ -422,12 +429,13 @@ async function applyEventEffects(
       if (event.type === "item/started") {
         // Thread status is otherwise derived from root turn lifecycle events
         // alone. A provider can stream root work on a turn the thread already
-        // settled (Codex continues a completed turn after hooks/compaction, or
+        // settled (Codex continues a completed turn after hooks, or
         // an unlinked auxiliary turn's completion settled the thread while the
         // root turn kept running, #1646). That work is real: the thread must
         // read as active again until the provider settles the turn.
         const reopenedTurnId = resolveReopenedRootTurnId(deps, {
           event,
+          threadRowsById,
           threadId: entry.threadId,
         });
         if (reopenedTurnId === null) {
@@ -441,6 +449,7 @@ async function applyEventEffects(
           },
           "Provider resumed root work on a settled turn; reactivating thread",
         );
+        threadRowsById.delete(entry.threadId);
         applyLoggedThreadLifecycleEvent(deps, {
           event: { type: "run.started" },
           threadId: entry.threadId,
@@ -462,6 +471,7 @@ async function applyEventEffects(
         ) {
           continue;
         }
+        threadRowsById.delete(entry.threadId);
         const turnCompleted = applyTurnCompletedEvent(deps, {
           ...event,
           threadId: entry.threadId,
@@ -511,6 +521,7 @@ async function applyEventEffects(
         if (!thread) {
           continue;
         }
+        threadRowsById.delete(entry.threadId);
         deps.pendingInteractions.interruptPendingInteractionsForThreadIds({
           threadIds: [entry.threadId],
           reason:
@@ -728,7 +739,11 @@ function resolveReopenedRootTurnId(
   if (turnId === undefined) {
     return null;
   }
-  const thread = getThread(deps.db, args.threadId);
+  let thread = args.threadRowsById.get(args.threadId);
+  if (thread === undefined) {
+    thread = getThread(deps.db, args.threadId);
+    args.threadRowsById.set(args.threadId, thread);
+  }
   if (
     !thread ||
     (thread.status !== "idle" && thread.status !== "error") ||
@@ -737,13 +752,24 @@ function resolveReopenedRootTurnId(
   ) {
     return null;
   }
-  const turnStartedSequence = getRootStoredTurnStartedSequence(deps.db, {
-    threadId: args.threadId,
-    turnId,
-  });
-  if (turnStartedSequence === null) {
+  const rootTurnStarted = deps.db
+    .select({ sequence: storedEvents.sequence })
+    .from(storedEvents)
+    .where(
+      and(
+        eq(storedEvents.threadId, args.threadId),
+        eq(storedEvents.turnId, turnId),
+        eq(storedEvents.type, "turn/started"),
+        isNull(storedEvents.parentToolCallId),
+      ),
+    )
+    .orderBy(storedEvents.sequence)
+    .limit(1)
+    .get();
+  if (rootTurnStarted === undefined) {
     return null;
   }
+  const turnStartedSequence = rootTurnStarted.sequence;
   const turnCompleted = deps.db
     .select({ id: storedEvents.id })
     .from(storedEvents)

--- a/apps/server/src/internal/events.ts
+++ b/apps/server/src/internal/events.ts
@@ -1,7 +1,8 @@
-import { and, desc, eq, gt, lt, sql } from "drizzle-orm";
+import { and, desc, eq, gt, isNull, lt, sql } from "drizzle-orm";
 import {
   appendDaemonEventsInTransaction,
   deriveStoredEventItemFields,
+  getRootStoredTurnStartedSequence,
   getThread,
   listCompletedTurnsByThreadIds,
   listThreadEnvironmentAssignmentsOnHost,
@@ -23,6 +24,8 @@ import {
   type HostDaemonRejectedEvent,
 } from "@bb/host-daemon-contract";
 import {
+  getThreadEventScopeTurnId,
+  isRootTurnWorkItem,
   requireThreadEventScopeTurnId,
   type ThreadEventType,
   type ThreadEventTurnStatus,
@@ -159,6 +162,18 @@ interface HasThreadCommandFailureSystemErrorForTurnArgs {
 interface HasThreadStopBeforeTurnStartedArgs {
   threadId: string;
   turnId: string;
+}
+
+interface HasThreadStopSinceTurnRequestedArgs {
+  /** Exclusive upper bound on the stop's sequence. */
+  beforeSequence?: number;
+  threadId: string;
+  turnStartedSequence: number;
+}
+
+interface ResolveReopenedRootTurnIdArgs {
+  event: Extract<HostDaemonEventEnvelope["event"], { type: "item/started" }>;
+  threadId: string;
 }
 
 interface ActivePruneCandidate {
@@ -404,6 +419,35 @@ async function applyEventEffects(
         continue;
       }
 
+      if (event.type === "item/started") {
+        // Thread status is otherwise derived from root turn lifecycle events
+        // alone. A provider can stream root work on a turn the thread already
+        // settled (Codex continues a completed turn after hooks/compaction, or
+        // an unlinked auxiliary turn's completion settled the thread while the
+        // root turn kept running, #1646). That work is real: the thread must
+        // read as active again until the provider settles the turn.
+        const reopenedTurnId = resolveReopenedRootTurnId(deps, {
+          event,
+          threadId: entry.threadId,
+        });
+        if (reopenedTurnId === null) {
+          continue;
+        }
+        deps.logger.warn(
+          {
+            itemType: event.item.type,
+            threadId: entry.threadId,
+            turnId: reopenedTurnId,
+          },
+          "Provider resumed root work on a settled turn; reactivating thread",
+        );
+        applyLoggedThreadLifecycleEvent(deps, {
+          event: { type: "run.started" },
+          threadId: entry.threadId,
+        });
+        continue;
+      }
+
       if (event.type === "turn/completed") {
         const turnId = requireThreadEventScopeTurnId({
           type: event.type,
@@ -611,7 +655,23 @@ function hasThreadStopBeforeTurnStarted(
   if (!turnStarted) {
     return false;
   }
+  return hasThreadStopSinceTurnRequested(deps, {
+    beforeSequence: turnStarted.sequence,
+    threadId: args.threadId,
+    turnStartedSequence: turnStarted.sequence,
+  });
+}
 
+/**
+ * True when a stop was recorded after the turn request that produced the turn
+ * started at `turnStartedSequence`. Only a newer turn request clears the
+ * user's stop intent. `beforeSequence` bounds the search (exclusive); omit it
+ * to consider every stop since the request.
+ */
+function hasThreadStopSinceTurnRequested(
+  deps: Pick<AppDeps, "db">,
+  args: HasThreadStopSinceTurnRequestedArgs,
+): boolean {
   const latestTurnRequest = deps.db
     .select({ sequence: storedEvents.sequence })
     .from(storedEvents)
@@ -619,7 +679,7 @@ function hasThreadStopBeforeTurnStarted(
       and(
         eq(storedEvents.threadId, args.threadId),
         eq(storedEvents.type, "client/turn/requested"),
-        lt(storedEvents.sequence, turnStarted.sequence),
+        lt(storedEvents.sequence, args.turnStartedSequence),
       ),
     )
     .orderBy(desc(storedEvents.sequence))
@@ -636,12 +696,90 @@ function hasThreadStopBeforeTurnStarted(
           eq(storedEvents.threadId, args.threadId),
           eq(storedEvents.type, "system/thread/interrupted"),
           gt(storedEvents.sequence, lowerSequence),
-          lt(storedEvents.sequence, turnStarted.sequence),
+          ...(args.beforeSequence === undefined
+            ? []
+            : [lt(storedEvents.sequence, args.beforeSequence)]),
         ),
       )
       .limit(1)
       .get() !== undefined
   );
+}
+
+/**
+ * Returns the turn id when `event` is root provider work on a root turn while
+ * the thread is not running, and that work must reactivate the thread. The
+ * turn qualifies when it is still open (an auxiliary turn's completion settled
+ * the thread out from under it) or when it is the thread's latest root turn
+ * (the provider continued a turn it already settled and will settle it again).
+ * Work on an older settled turn is stale: nothing is left to settle the thread
+ * again, so it must not reactivate. A stop since the turn's request wins over
+ * any late work.
+ */
+function resolveReopenedRootTurnId(
+  deps: Pick<AppDeps, "db">,
+  args: ResolveReopenedRootTurnIdArgs,
+): string | null {
+  const { event } = args;
+  if (!isRootTurnWorkItem(event.item)) {
+    return null;
+  }
+  const turnId = getThreadEventScopeTurnId(event.scope);
+  if (turnId === undefined) {
+    return null;
+  }
+  const thread = getThread(deps.db, args.threadId);
+  if (
+    !thread ||
+    (thread.status !== "idle" && thread.status !== "error") ||
+    thread.archivedAt !== null ||
+    thread.deletedAt !== null
+  ) {
+    return null;
+  }
+  const turnStartedSequence = getRootStoredTurnStartedSequence(deps.db, {
+    threadId: args.threadId,
+    turnId,
+  });
+  if (turnStartedSequence === null) {
+    return null;
+  }
+  const turnCompleted = deps.db
+    .select({ id: storedEvents.id })
+    .from(storedEvents)
+    .where(
+      and(
+        eq(storedEvents.threadId, args.threadId),
+        eq(storedEvents.turnId, turnId),
+        eq(storedEvents.type, "turn/completed"),
+      ),
+    )
+    .limit(1)
+    .get();
+  if (turnCompleted !== undefined) {
+    const newerRootTurnStarted = deps.db
+      .select({ id: storedEvents.id })
+      .from(storedEvents)
+      .where(
+        and(
+          eq(storedEvents.threadId, args.threadId),
+          eq(storedEvents.type, "turn/started"),
+          isNull(storedEvents.parentToolCallId),
+          gt(storedEvents.sequence, turnStartedSequence),
+        ),
+      )
+      .limit(1)
+      .get();
+    if (newerRootTurnStarted !== undefined) {
+      return null;
+    }
+  }
+  return hasThreadStopSinceTurnRequested(deps, {
+    threadId: args.threadId,
+    turnStartedSequence,
+  })
+    ? null
+    : turnId;
 }
 
 function hasThreadAlreadyStartedRun(

--- a/apps/server/test/internal/internal-events-turn-reopen.test.ts
+++ b/apps/server/test/internal/internal-events-turn-reopen.test.ts
@@ -1,0 +1,236 @@
+import { getThread } from "@bb/db";
+import { threadScope, turnScope } from "@bb/domain";
+import {
+  groupHostDaemonEvents,
+  type HostDaemonEventEnvelope,
+} from "@bb/host-daemon-contract";
+import { describe, expect, it } from "vitest";
+import { internalAuthHeaders } from "../helpers/commands.js";
+import {
+  seedEnvironment,
+  seedHostSession,
+  seedProjectWithSource,
+  seedThread,
+} from "../helpers/seed.js";
+import { createTestAppHarness } from "../helpers/test-app.js";
+
+const PROVIDER_THREAD_ID = "codex-thread-reopen";
+
+async function setup() {
+  const harness = await createTestAppHarness();
+  const { host, session } = seedHostSession(harness.deps, {});
+  const { project } = seedProjectWithSource(harness.deps, { hostId: host.id });
+  const environment = seedEnvironment(harness.deps, {
+    hostId: host.id,
+    projectId: project.id,
+  });
+  const thread = seedThread(harness.deps, {
+    projectId: project.id,
+    environmentId: environment.id,
+    status: "active",
+  });
+  const post = (events: HostDaemonEventEnvelope[]) =>
+    harness.app.request("/internal/session/events", {
+      method: "POST",
+      headers: internalAuthHeaders(harness),
+      body: JSON.stringify({
+        sessionId: session.id,
+        eventGroups: groupHostDaemonEvents(events),
+      }),
+    });
+  const status = () => getThread(harness.db, thread.id)?.status;
+  return { harness, thread, post, status };
+}
+
+function turnStarted(
+  threadId: string,
+  turnId: string,
+  options: { parentToolCallId?: string } = {},
+): HostDaemonEventEnvelope {
+  return {
+    threadId,
+    event: {
+      type: "turn/started",
+      threadId,
+      providerThreadId: PROVIDER_THREAD_ID,
+      scope: turnScope(turnId),
+      ...(options.parentToolCallId
+        ? { parentToolCallId: options.parentToolCallId }
+        : {}),
+    },
+  };
+}
+
+function turnCompleted(
+  threadId: string,
+  turnId: string,
+): HostDaemonEventEnvelope {
+  return {
+    threadId,
+    event: {
+      type: "turn/completed",
+      threadId,
+      providerThreadId: PROVIDER_THREAD_ID,
+      scope: turnScope(turnId),
+      status: "completed",
+    },
+  };
+}
+
+function commandStarted(
+  threadId: string,
+  turnId: string,
+  id: string,
+  options: { parentToolCallId?: string } = {},
+): HostDaemonEventEnvelope {
+  return {
+    threadId,
+    event: {
+      type: "item/started",
+      threadId,
+      providerThreadId: PROVIDER_THREAD_ID,
+      scope: turnScope(turnId),
+      item: {
+        type: "commandExecution",
+        id,
+        command: "npm test",
+        cwd: "/repo",
+        status: "pending",
+        approvalStatus: null,
+        ...(options.parentToolCallId
+          ? { parentToolCallId: options.parentToolCallId }
+          : {}),
+      },
+    },
+  };
+}
+
+function interrupted(threadId: string): HostDaemonEventEnvelope {
+  return {
+    threadId,
+    event: {
+      type: "system/thread/interrupted",
+      threadId,
+      scope: threadScope(),
+      reason: "manual-stop",
+    },
+  };
+}
+
+describe("root provider work on a turn the thread already settled (#1646)", () => {
+  it("reactivates the thread when work resumes on a completed turn and settles on its re-completion", async () => {
+    const { harness, thread, post, status } = await setup();
+    try {
+      expect(
+        (
+          await post([
+            turnStarted(thread.id, "turn-x"),
+            turnCompleted(thread.id, "turn-x"),
+          ])
+        ).status,
+      ).toBe(200);
+      expect(status()).toBe("idle");
+
+      expect(
+        (await post([commandStarted(thread.id, "turn-x", "cmd-1")])).status,
+      ).toBe(200);
+      expect(status()).toBe("active");
+
+      expect((await post([turnCompleted(thread.id, "turn-x")])).status).toBe(
+        200,
+      );
+      expect(status()).toBe("idle");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("reactivates the thread when an unlinked auxiliary turn settles it while the root turn is still open", async () => {
+    const { harness, thread, post, status } = await setup();
+    try {
+      expect(
+        (
+          await post([
+            turnStarted(thread.id, "turn-a"),
+            turnStarted(thread.id, "turn-b"),
+            turnCompleted(thread.id, "turn-b"),
+          ])
+        ).status,
+      ).toBe(200);
+      expect(status()).toBe("idle");
+
+      expect(
+        (await post([commandStarted(thread.id, "turn-a", "cmd-1")])).status,
+      ).toBe(200);
+      expect(status()).toBe("active");
+
+      expect((await post([turnCompleted(thread.id, "turn-a")])).status).toBe(
+        200,
+      );
+      expect(status()).toBe("idle");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("keeps a stopped thread idle when late work arrives on the stopped turn", async () => {
+    const { harness, thread, post, status } = await setup();
+    try {
+      expect(
+        (
+          await post([
+            turnStarted(thread.id, "turn-x"),
+            turnCompleted(thread.id, "turn-x"),
+            interrupted(thread.id),
+          ])
+        ).status,
+      ).toBe(200);
+      expect(status()).toBe("idle");
+
+      expect(
+        (await post([commandStarted(thread.id, "turn-x", "cmd-1")])).status,
+      ).toBe(200);
+      expect(status()).toBe("idle");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("ignores delegated child work and work on a superseded completed turn", async () => {
+    const { harness, thread, post, status } = await setup();
+    try {
+      expect(
+        (
+          await post([
+            turnStarted(thread.id, "turn-1"),
+            turnCompleted(thread.id, "turn-1"),
+            turnStarted(thread.id, "turn-2"),
+            turnCompleted(thread.id, "turn-2"),
+          ])
+        ).status,
+      ).toBe(200);
+      expect(status()).toBe("idle");
+
+      // A stale item on turn-1: turn-2 ran after it, so nothing will settle
+      // turn-1 again.
+      expect(
+        (await post([commandStarted(thread.id, "turn-1", "cmd-stale")])).status,
+      ).toBe(200);
+      expect(status()).toBe("idle");
+
+      // Delegated child work on the latest turn is not root activity.
+      expect(
+        (
+          await post([
+            commandStarted(thread.id, "turn-2", "cmd-child", {
+              parentToolCallId: "tool-1",
+            }),
+          ])
+        ).status,
+      ).toBe(200);
+      expect(status()).toBe("idle");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+});

--- a/apps/server/test/internal/internal-events-turn-reopen.test.ts
+++ b/apps/server/test/internal/internal-events-turn-reopen.test.ts
@@ -105,6 +105,35 @@ function commandStarted(
   };
 }
 
+function compactionItem(
+  threadId: string,
+  turnId: string,
+  phase: "started" | "completed",
+): HostDaemonEventEnvelope {
+  return {
+    threadId,
+    event: {
+      type: phase === "started" ? "item/started" : "item/completed",
+      threadId,
+      providerThreadId: PROVIDER_THREAD_ID,
+      scope: turnScope(turnId),
+      item: { type: "contextCompaction", id: "compaction-1" },
+    },
+  };
+}
+
+function compacted(threadId: string, turnId: string): HostDaemonEventEnvelope {
+  return {
+    threadId,
+    event: {
+      type: "thread/compacted",
+      threadId,
+      providerThreadId: PROVIDER_THREAD_ID,
+      scope: turnScope(turnId),
+    },
+  };
+}
+
 function interrupted(threadId: string): HostDaemonEventEnvelope {
   return {
     threadId,
@@ -133,6 +162,31 @@ describe("root provider work on a turn the thread already settled (#1646)", () =
 
       expect(
         (await post([commandStarted(thread.id, "turn-x", "cmd-1")])).status,
+      ).toBe(200);
+      expect(status()).toBe("active");
+
+      expect((await post([turnCompleted(thread.id, "turn-x")])).status).toBe(
+        200,
+      );
+      expect(status()).toBe("idle");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("reactivates within one batch when the completion and the late work arrive together", async () => {
+    const { harness, thread, post, status } = await setup();
+    try {
+      expect(
+        (
+          await post([
+            turnStarted(thread.id, "turn-x"),
+            commandStarted(thread.id, "turn-x", "cmd-0"),
+            turnCompleted(thread.id, "turn-x"),
+            commandStarted(thread.id, "turn-x", "cmd-1"),
+            commandStarted(thread.id, "turn-x", "cmd-2"),
+          ])
+        ).status,
       ).toBe(200);
       expect(status()).toBe("active");
 
@@ -189,6 +243,40 @@ describe("root provider work on a turn the thread already settled (#1646)", () =
 
       expect(
         (await post([commandStarted(thread.id, "turn-x", "cmd-1")])).status,
+      ).toBe(200);
+      expect(status()).toBe("idle");
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it("stays idle through post-turn context compaction on the completed turn", async () => {
+    // Pi's threshold compaction runs after agent_end and attaches its item to
+    // the turn that just closed; no second turn/completed follows (#1542).
+    const { harness, thread, post, status } = await setup();
+    try {
+      expect(
+        (
+          await post([
+            turnStarted(thread.id, "turn-x"),
+            turnCompleted(thread.id, "turn-x"),
+          ])
+        ).status,
+      ).toBe(200);
+      expect(status()).toBe("idle");
+
+      expect(
+        (await post([compactionItem(thread.id, "turn-x", "started")])).status,
+      ).toBe(200);
+      expect(status()).toBe("idle");
+
+      expect(
+        (
+          await post([
+            compactionItem(thread.id, "turn-x", "completed"),
+            compacted(thread.id, "turn-x"),
+          ])
+        ).status,
       ).toBe(200);
       expect(status()).toBe("idle");
     } finally {

--- a/packages/agent-runtime/src/runtime-turn-state.test.ts
+++ b/packages/agent-runtime/src/runtime-turn-state.test.ts
@@ -225,4 +225,20 @@ describe("RuntimeTurnState reopened turns (#1646)", () => {
     state.observe(commandStarted("turn-1"));
     expect(state.getActiveTurnId("t1")).toBe("turn-2");
   });
+
+  it("does not reopen a settled turn for post-turn context compaction", () => {
+    // Pi threshold compaction attaches to the turn that just closed and no
+    // second turn/completed follows (#1542); the session must stay idle.
+    const state = new RuntimeTurnState();
+    state.observe(turnStarted("turn-1"));
+    state.observe(turnCompleted("turn-1"));
+    state.observe({
+      type: "item/started",
+      threadId: "t1",
+      providerThreadId: "p1",
+      scope: turnScope("turn-1"),
+      item: { type: "contextCompaction", id: "compaction-1" },
+    });
+    expect(state.getActiveTurnId("t1")).toBeNull();
+  });
 });

--- a/packages/agent-runtime/src/runtime-turn-state.test.ts
+++ b/packages/agent-runtime/src/runtime-turn-state.test.ts
@@ -168,3 +168,61 @@ describe("RuntimeTurnState", () => {
   });
 });
 
+describe("RuntimeTurnState reopened turns (#1646)", () => {
+  function commandStarted(
+    turnId: string,
+    options: { parentToolCallId?: string } = {},
+  ): ThreadEvent {
+    return {
+      type: "item/started",
+      threadId: "t1",
+      providerThreadId: "p1",
+      scope: turnScope(turnId),
+      item: {
+        type: "commandExecution",
+        id: `${turnId}-cmd`,
+        command: "npm test",
+        cwd: "/repo",
+        status: "pending",
+        approvalStatus: null,
+        ...(options.parentToolCallId
+          ? { parentToolCallId: options.parentToolCallId }
+          : {}),
+      },
+    };
+  }
+
+  it("reopens the active turn when root work resumes on a settled turn", () => {
+    const state = new RuntimeTurnState();
+    state.observe(turnStarted("turn-1"));
+    state.observe(turnCompleted("turn-1"));
+    expect(state.getActiveTurnId("t1")).toBeNull();
+
+    state.observe(commandStarted("turn-1"));
+    expect(state.getActiveTurnId("t1")).toBe("turn-1");
+
+    state.observe(turnCompleted("turn-1"));
+    expect(state.getActiveTurnId("t1")).toBeNull();
+  });
+
+  it("reopens the root turn an unlinked auxiliary turn displaced", () => {
+    const state = new RuntimeTurnState();
+    state.observe(turnStarted("turn-a"));
+    state.observe(turnStarted("turn-b"));
+    state.observe(turnCompleted("turn-b"));
+    expect(state.getActiveTurnId("t1")).toBeNull();
+
+    state.observe(commandStarted("turn-a"));
+    expect(state.getActiveTurnId("t1")).toBe("turn-a");
+  });
+
+  it("does not reopen from delegated child work or while a turn is active", () => {
+    const state = new RuntimeTurnState();
+    state.observe(commandStarted("child-turn", { parentToolCallId: "tool-1" }));
+    expect(state.getActiveTurnId("t1")).toBeNull();
+
+    state.observe(turnStarted("turn-2"));
+    state.observe(commandStarted("turn-1"));
+    expect(state.getActiveTurnId("t1")).toBe("turn-2");
+  });
+});

--- a/packages/agent-runtime/src/runtime-turn-state.ts
+++ b/packages/agent-runtime/src/runtime-turn-state.ts
@@ -1,5 +1,9 @@
 import type { ThreadEvent } from "@bb/domain";
-import { requireThreadEventScopeTurnId } from "@bb/domain";
+import {
+  getThreadEventScopeTurnId,
+  isRootTurnWorkItem,
+  requireThreadEventScopeTurnId,
+} from "@bb/domain";
 
 interface PendingActiveTurnWaiter {
   resolve: (turnId: string | null) => void;
@@ -92,6 +96,25 @@ export class RuntimeTurnState {
       if (this.activeTurnIdByThreadId.get(event.threadId) === turnId) {
         this.activeTurnIdByThreadId.delete(event.threadId);
       }
+      return;
+    }
+
+    if (event.type === "item/started") {
+      // Root work while no turn is active means the provider resumed a turn
+      // it already settled (#1646). Track it as the active turn again so
+      // thread/stop interrupts that work instead of releasing the session.
+      if (
+        this.activeTurnIdByThreadId.has(event.threadId) ||
+        !isRootTurnWorkItem(event.item)
+      ) {
+        return;
+      }
+      const turnId = getThreadEventScopeTurnId(event.scope);
+      if (turnId === undefined) {
+        return;
+      }
+      this.activeTurnIdByThreadId.set(event.threadId, turnId);
+      this.resolveWaiters(event.threadId, turnId);
     }
   }
 

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -741,6 +741,17 @@ export function createAgentRuntimeWithAdapters(
     if (event.type === "provider/error" && event.willRetry !== true) {
       pendingTurnStarts.delete(event.threadId);
       markHostedProviderSessionIdle(event.threadId);
+      return;
+    }
+
+    // Root work that reopened a settled turn (RuntimeTurnState) means the
+    // provider session is busy again: its idle clock must restart from the
+    // turn's next settlement, not from the one the provider walked back.
+    if (
+      event.type === "item/started" &&
+      turnState.getActiveTurnId(event.threadId) !== null
+    ) {
+      markProviderSessionNotIdle(event.threadId);
     }
   }
 

--- a/packages/domain/src/provider-event.ts
+++ b/packages/domain/src/provider-event.ts
@@ -385,6 +385,22 @@ export type ThreadEventItem = z.infer<typeof threadEventItemSchema>;
 export type ThreadEventItemType = ThreadEventItem["type"];
 
 /**
+ * True when a started item is the agent's own foreground work on its turn:
+ * not echoed user input, not a background task that outlives turns by design,
+ * and not delegated child work. A provider that streams such an item on a turn
+ * it already settled has reopened that turn (Codex continues on a completed
+ * turn id after hooks/compaction, #1646); the host grammar, the runtime's
+ * active-turn state, and the server's thread status all key off this one rule.
+ */
+export function isRootTurnWorkItem(item: ThreadEventItem): boolean {
+  return (
+    item.type !== "userMessage" &&
+    item.type !== "backgroundTask" &&
+    item.parentToolCallId === undefined
+  );
+}
+
+/**
  * Events originating from a provider process via the agent runtime.
  * These carry `providerThreadId` — the provider's internal session/thread ID.
  */

--- a/packages/domain/src/provider-event.ts
+++ b/packages/domain/src/provider-event.ts
@@ -387,15 +387,24 @@ export type ThreadEventItemType = ThreadEventItem["type"];
 /**
  * True when a started item is the agent's own foreground work on its turn:
  * not echoed user input, not a background task that outlives turns by design,
- * and not delegated child work. A provider that streams such an item on a turn
- * it already settled has reopened that turn (Codex continues on a completed
- * turn id after hooks/compaction, #1646); the host grammar, the runtime's
- * active-turn state, and the server's thread status all key off this one rule.
+ * not context compaction, and not delegated child work. A provider that
+ * streams such an item on a turn it already settled has reopened that turn
+ * (Codex continues on a completed turn id after hooks, #1646); the host
+ * grammar, the runtime's active-turn state, and the server's thread status
+ * all key off this one rule.
+ *
+ * Context compaction is provider maintenance, not agent work, and it attaches
+ * to a settled turn by design: pi's threshold compaction runs after
+ * `agent_end` and pins its item to the turn that just closed (`attach:
+ * "currentOrLast"`, #1542) with no second `turn/completed` to follow. Counting
+ * it as a reopen would leave every compacted pi thread active until a manual
+ * stop.
  */
 export function isRootTurnWorkItem(item: ThreadEventItem): boolean {
   return (
     item.type !== "userMessage" &&
     item.type !== "backgroundTask" &&
+    item.type !== "contextCompaction" &&
     item.parentToolCallId === undefined
   );
 }

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,10 @@
+// Version 147 lets the daemon forward a provider's second `turn/completed`
+// for a turn that root work reopened after its first completion (#1646). The
+// server now reactivates a thread on such work and relies on that re-completion
+// to settle it again; an older daemon's intake grammar still drops the event
+// (turn/settles-once), which would leave the reactivated thread active until a
+// manual stop.
+//
 // Version 146 adds the lightweight `host.list_branch_options` RPC so branch
 // pickers can read cached refs while the daemon refreshes remotes in the
 // background. Older daemons cannot parse or serve that command.
@@ -110,7 +117,7 @@
 //
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 146 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 147 as const;
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1122,8 +1122,11 @@ describe("host-daemon command schemas", () => {
   // against its Pi provider ladder, so enrolled machines must not run that
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
+  // Version 147 lets the daemon forward a provider's re-completion of a turn
+  // that root work reopened (#1646). Older daemons drop it at intake, which
+  // leaves a thread the server reactivated on that work active until a stop.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(146);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(147);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/packages/provider-bridge-protocol/src/thread-event-grammar.ts
+++ b/packages/provider-bridge-protocol/src/thread-event-grammar.ts
@@ -129,7 +129,8 @@ export class ThreadEventGrammar {
         state.settledItemIds.delete(event.item.id);
         trim(state.openItemIds);
         // Root work on a turn the provider already settled reopens that turn
-        // (Codex continues a completed turn after hooks/compaction, #1646).
+        // (Codex continues a completed turn after hooks, #1646). Provider
+        // maintenance such as compaction is not root work (isRootTurnWorkItem).
         // The provider settles it again when that work ends, and that second
         // turn/completed is the only signal that the thread is idle again, so
         // it must pass turn/settles-once.

--- a/packages/provider-bridge-protocol/src/thread-event-grammar.ts
+++ b/packages/provider-bridge-protocol/src/thread-event-grammar.ts
@@ -12,7 +12,7 @@
  * reconstructs item payloads or turn history.
  */
 import type { ThreadEvent } from "@bb/domain";
-import { getThreadEventScopeTurnId } from "@bb/domain";
+import { getThreadEventScopeTurnId, isRootTurnWorkItem } from "@bb/domain";
 
 /**
  * Every ThreadEvent that streams into an already-open item by `itemId`. Listed
@@ -128,6 +128,19 @@ export class ThreadEventGrammar {
         state.openItemIds.add(event.item.id);
         state.settledItemIds.delete(event.item.id);
         trim(state.openItemIds);
+        // Root work on a turn the provider already settled reopens that turn
+        // (Codex continues a completed turn after hooks/compaction, #1646).
+        // The provider settles it again when that work ends, and that second
+        // turn/completed is the only signal that the thread is idle again, so
+        // it must pass turn/settles-once.
+        const turnId = turnIdOf(event);
+        if (
+          turnId !== undefined &&
+          isRootTurnWorkItem(event.item) &&
+          state.completedTurnIds.delete(turnId)
+        ) {
+          state.startedTurnIds.add(turnId);
+        }
         return OK;
       }
       case "item/completed":

--- a/packages/provider-bridge-protocol/test/protocol.test.ts
+++ b/packages/provider-bridge-protocol/test/protocol.test.ts
@@ -233,6 +233,66 @@ describe("streaming thread event grammar", () => {
     expect(results[3]).toMatchObject({ rule: "turn/starts-once" });
   });
 
+  // Codex can keep working on a turn it already settled (#1646). That root
+  // work reopens the turn, so the provider's second completion is the thread's
+  // idle signal and must pass; a restart of the reopened turn still must not.
+  it("lets a turn that root work reopened settle again", () => {
+    const turnScoped = (turnId: string, event: ThreadEvent): ThreadEvent => ({
+      ...event,
+      scope: { kind: "turn", turnId },
+    });
+    const results = observeAll([
+      turnStarted("turn_1"),
+      turnCompleted("turn_1"),
+      turnScoped("turn_1", started("item_1")),
+      turnStarted("turn_1"),
+      turnCompleted("turn_1"),
+      turnCompleted("turn_1"),
+    ]);
+    expect(results.map((result) => result.kind)).toEqual([
+      "ok",
+      "ok",
+      "ok",
+      "violation",
+      "ok",
+      "violation",
+    ]);
+    expect(results[3]).toMatchObject({ rule: "turn/starts-once" });
+    expect(results[5]).toMatchObject({ rule: "turn/settles-once" });
+  });
+
+  it("does not reopen a settled turn for user input or delegated child work", () => {
+    const results = observeAll([
+      turnStarted("turn_1"),
+      turnCompleted("turn_1"),
+      {
+        type: "item/started",
+        ...identity,
+        item: { type: "userMessage", id: "item_u", content: [] },
+        scope: { kind: "turn", turnId: "turn_1" },
+      },
+      {
+        type: "item/started",
+        ...identity,
+        item: {
+          type: "agentMessage",
+          id: "item_c",
+          text: "",
+          parentToolCallId: "call_1",
+        },
+        scope: { kind: "turn", turnId: "turn_1" },
+      },
+      turnCompleted("turn_1"),
+    ]);
+    expect(results.map((result) => result.kind)).toEqual([
+      "ok",
+      "ok",
+      "ok",
+      "ok",
+      "violation",
+    ]);
+  });
+
   it("keeps each thread's items and turns separate", () => {
     const grammar = new ThreadEventGrammar();
     expect(grammar.observe(started("item_1")).kind).toBe("ok");

--- a/packages/provider-bridge-protocol/test/protocol.test.ts
+++ b/packages/provider-bridge-protocol/test/protocol.test.ts
@@ -261,7 +261,7 @@ describe("streaming thread event grammar", () => {
     expect(results[5]).toMatchObject({ rule: "turn/settles-once" });
   });
 
-  it("does not reopen a settled turn for user input or delegated child work", () => {
+  it("does not reopen a settled turn for user input, delegated child work, or post-turn compaction", () => {
     const results = observeAll([
       turnStarted("turn_1"),
       turnCompleted("turn_1"),
@@ -282,9 +282,17 @@ describe("streaming thread event grammar", () => {
         },
         scope: { kind: "turn", turnId: "turn_1" },
       },
+      // Pi threshold compaction attaches to the turn that just closed (#1542).
+      {
+        type: "item/started",
+        ...identity,
+        item: { type: "contextCompaction", id: "item_k" },
+        scope: { kind: "turn", turnId: "turn_1" },
+      },
       turnCompleted("turn_1"),
     ]);
     expect(results.map((result) => result.kind)).toEqual([
+      "ok",
       "ok",
       "ok",
       "ok",


### PR DESCRIPTION
## What was wrong

Thread status was derived from root `turn/started` and `turn/completed` alone (`applyEventEffects` in `apps/server/src/internal/events.ts`). Codex can keep streaming root work (`commandExecution`, `fileChange`, `agentMessage`, `reasoning`) on a turn id it already reported complete, then complete it a second time. The store accepts that work because the turn had a stored `turn/started`, but nothing re-evaluated status from it. The thread read `idle` (no spinner, `bb thread wait` returned early, all activity counters 0) while commands ran.

Two more layers had the same blind spot:

- Since #1640 the host daemon's intake grammar (`ThreadEventGrammar`) silently dropped the provider's second `turn/completed` for that turn (`turn/settles-once`), so even a server that reactivated the thread had no settle signal.
- `RuntimeTurnState` held no active turn after the first completion, so `thread/stop` became a session release (kills the Codex child) instead of `turn/interrupt`, and the idle-session reaper could target a busy session.

Issue: #1646. Report: https://get-bb.github.io/reports/issues/1646.html

Relation to #1697: that PR has the right server diagnosis but settles the reactivated thread only through the second `turn/completed`, which current main's daemon grammar drops. The report verified live that a reactivated thread under #1697 stays active forever. It also reactivates on any previously completed turn (a stale item on an old turn after newer turns ran) and is based on a pre-#1640 main with a conflicting test file. This PR supersedes it.

## What changed

- `packages/domain/src/provider-event.ts`: `isRootTurnWorkItem` names the one rule all three layers share: not echoed user input, not a background task, not context compaction, not delegated child work. Compaction is excluded because pi's threshold compaction runs after `agent_end` and attaches its `contextCompaction` item to the turn that just closed (`attach: "currentOrLast"`, #1542) with no second `turn/completed`; counting it as a reopen would leave every compacted pi thread active until a manual stop (the verifier's blocker on the first revision of this PR).
- `apps/server/src/internal/events.ts`: a root `item/started` on an idle or error thread applies `run.started` when its turn has a stored root `turn/started` and either is still open (an unlinked auxiliary turn's completion settled the thread while the root turn kept running) or is the thread's latest root turn (the provider continued a turn it already settled and will settle it again). Work on an older settled turn is stale and does not reactivate. A `system/thread/interrupted` since that turn's request wins over any late work. The server logs a warning with provider item type and turn id when it reactivates. `hasThreadStopBeforeTurnStarted` now shares `hasThreadStopSinceTurnRequested` (same query, optional upper bound). Thread rows read by the reopen check are memoized per event batch and evicted whenever the loop applies a lifecycle change, so root items streaming on an active thread cost one primary-key lookup per thread per batch rather than one per item. The root `turn/started` lookup is inlined because main removed the unused `@bb/db` helper in #2140.
- `packages/provider-bridge-protocol/src/thread-event-grammar.ts`: root work on a completed turn moves it back to `startedTurnIds`, so the provider's re-completion passes `turn/settles-once` and settles the thread. A re-`turn/started` for the reopened turn is still a violation.
- `packages/agent-runtime/src/runtime-turn-state.ts`, `runtime.ts`: root work with no active turn reopens that turn as the active one, so `thread/stop` sends `turn/interrupt` with the right turn id, and the provider session is marked busy again.
- `packages/host-daemon-contract/src/protocol.ts`: `HOST_DAEMON_PROTOCOL_VERSION` 146 -> 147. No payload shapes change, but the daemon now forwards an event it used to drop, and the server depends on it. A new server paired with an old daemon would leave reactivated threads active until a manual stop; the bump forces enrolled daemons to update.

Deviation from the report's proposal and the verifier's suggestion to settle the thread when the reopened work's last open item completes: `item/completed` is not a settle signal. Between one root item's completion and the next item's start there is model latency (the report's real-Codex control run streamed six sequential `item/started`+`item/completed` pairs over ten seconds on one turn), so settling there would flip the thread idle in every such gap, make `bb thread wait` return early inside the continuation, and fire queued-message auto-send mid-work: the symptom this PR fixes, reintroduced for the reactivated window. Settlement stays tied to the provider's `turn/completed`, which the grammar now lets through; the case where a provider reopens a turn and never re-completes it is the same failure mode as a provider that hangs mid-turn and is handled by the user's stop. The only first-party flow that produces root-looking work on a closed turn without a re-completion is compaction, which is now excluded by type.

Verifier minor not changed: `RuntimeTurnState` does not need to remember interrupted turns. A bb stop goes through `stopThread`, which calls `forgetThreadRuntimeStateForProviderState` (`runtime.ts`): that clears the thread's turn state, grammar state, and identity registration, and late provider events for a forgotten thread are dropped at identity resolution (`resolveProviderEventThreadId`), so the daemon cannot hold a reopened turn after a stop. The live check below confirms the stop path (`turn/interrupt` sent, then the thread forgotten). Blocking reopen only on provider-originated `interrupted` completions would desynchronize the daemon from the server, whose stop guard keys on `system/thread/interrupted`, not on the provider's completion status.

Not changed: grammar drops are still only reported through the runtime's `onStderr`, which the host daemon does not wire to its logger. That observability gap is separate from this fix.

## How you verified

Fail before / pass after (sources swapped with `git checkout <rev> -- <src files>`, tests from this branch):

- Against `origin/main`: `apps/server/test/internal/internal-events-turn-reopen.test.ts` fails 3 of 6 with `AssertionError: expected 'idle' to be 'active'` (reactivation on a re-completed turn; completion and late work in one batch; reactivation when an auxiliary turn settled the thread). `packages/provider-bridge-protocol/test/protocol.test.ts` "lets a turn that root work reopened settle again" fails (the second completion is a `turn/settles-once` violation). `packages/agent-runtime/src/runtime-turn-state.test.ts` reopened-turn cases fail with `expected null to be 'turn-1'` / `'turn-a'`.
- Against the first revision of this PR (46d102b41, before the compaction exclusion): the new compaction cases fail at all three layers: server `stays idle through post-turn context compaction on the completed turn` with `AssertionError: expected 'active' to be 'idle'`; runtime `does not reopen a settled turn for post-turn context compaction` with `expected 'turn-1' to be null`; grammar `does not reopen a settled turn for user input, delegated child work, or post-turn compaction` (the second completion passed instead of being a violation).
- All pass on this branch.

Turbo, run from the committed tree (`git status --porcelain` empty): `typecheck` for `@bb/server @bb/host-daemon @bb/agent-runtime @bb/provider-bridge-protocol @bb/domain @bb/host-daemon-contract ./plugins/provider-*`: `Tasks: 15 successful, 15 total`. `test` for `@bb/host-daemon @bb/agent-runtime @bb/provider-bridge-protocol @bb/domain @bb/host-daemon-contract ./plugins/provider-* @bb/integration-tests`: `Tasks: 16 successful, 16 total` (host-daemon 46 files, agent-runtime 31, provider-bridge-protocol 10, domain 24, integration-tests 25). `@bb/server` test: 195/196 files pass; the one failure is `internal-skill-trees.test.ts` file-mode 0644 vs 0664, which fails on clean main under this machine's umask 0002 and passes in CI.

End to end on a dev instance with the report's scripted `codex app-server` (PATH shim), scenario: `turn/started`, message, `turn/completed`, 8 s pause, `commandExecution` on the same turn for 12 s, message, second `turn/completed`, 8 s pause, then `item/started {contextCompaction}` on the same completed turn, 6 s, `item/completed` + `thread/compacted`:

- Status polled every 2 s: `idle` after the first completion; `active` from the late `commandExecution` `item/started` (server log: `Provider resumed root work on a settled turn; reactivating thread {"itemType":"commandExecution",...}`); `idle` within 2 s of the provider's second `turn/completed` (stored, not dropped); `idle` throughout the post-turn compaction and after it (no second reactivation warning).
- `bb thread stop` on the idle, compacted thread released the session (no `turn/interrupt` in the fake's log; the child exited), so the daemon held no active turn after the compaction item.
- `bb thread stop` on a reactivated thread (scenario M1, stopped 15 s into the late work): the fake received `turn/interrupt {"turnId":"turn-X-1"}`, the server recorded `system/thread/interrupted`, the thread settled `idle`, and it stayed idle.

Real-data check against a private corpus of 307 recorded bb threads (166 Codex, 141 Claude Code): zero normal-flow cases of root work after a `completed` turn, so the new branch does not misfire on ordinary sessions. The 14 cases of root work after a completion were all `host-daemon-restarted` interruptions (server-synthesized `turn/completed interrupted` + `system/thread/interrupted`), which the stop guard excludes.

Fixes #1646

> AGENT GENERATED: by Claude Opus 5



## Independent verification

Verified by a second agent on `e7dfa09bc` (rebased on `origin/main` `f6fb434ab`; `git merge-base --is-ancestor origin/main HEAD` holds) in a separate worktree with its own dev instance.

Fail before / pass after (sources swapped with `git checkout origin/main -- apps/server/src/internal/events.ts packages/agent-runtime/src/runtime-turn-state.ts packages/agent-runtime/src/runtime.ts packages/domain/src/provider-event.ts packages/provider-bridge-protocol/src/thread-event-grammar.ts packages/host-daemon-contract/src/protocol.ts`, tests from this branch):

- `apps/server`: `pnpm exec vitest run test/internal/internal-events-turn-reopen.test.ts` -> 3 failed / 3 passed; all three reactivation cases fail with `AssertionError: expected 'idle' to be 'active'`.
- `packages/agent-runtime`: `pnpm exec vitest run src/runtime-turn-state.test.ts` -> 2 failed / 11 passed: `expected null to be 'turn-1'`, `expected null to be 'turn-a'`.
- `packages/provider-bridge-protocol`: `pnpm exec vitest run test/protocol.test.ts` -> 1 failed / 33 passed: "lets a turn that root work reopened settle again" (second completion is a violation on main).
- After `git checkout HEAD -- <same files>`: 6/6, 13/13, 34/34 pass.

Turbo on the committed tree: `typecheck` for `@bb/server @bb/host-daemon @bb/agent-runtime @bb/provider-bridge-protocol @bb/domain @bb/host-daemon-contract ./plugins/provider-*` -> `Tasks: 15 successful, 15 total`. `test` for `@bb/host-daemon @bb/agent-runtime @bb/provider-bridge-protocol @bb/domain @bb/host-daemon-contract ./plugins/provider-*` -> `Tasks: 13 successful, 13 total`. `@bb/server` test: 195/196 files, 1828/1829 tests; the only failure is the known umask-dependent `internal-skill-trees.test.ts` (fails on clean main locally, passes in CI). `gh pr checks`: all required checks green (server, packages, integration, app-1..3, package smoke x2, checks).

Repro on the fixed branch (dev instance on its own ports/data dir, real codex bridge driven by the report's scripted `codex app-server` via PATH shim plus `model/list`, scenario: complete turn X, 8 s pause, `commandExecution` on X for 20 s, message, second `turn/completed`, 8 s pause, post-turn `item/started {contextCompaction}` on X, `item/completed` + `thread/compacted`):

```
05:25:42 status=idle   -> 05:25:44 status=active   (late commandExecution item/started on the completed turn)
server: WARN Provider resumed root work on a settled turn; reactivating thread {"itemType":"commandExecution",...}
05:26:00 status=active -> 05:26:02 status=idle     (second turn/completed stored, not dropped by the daemon grammar)
05:26:10..05:26:50     status=idle                  (post-turn compaction item on the same turn; no second reactivation)
```

On main the report shows `idle` for the whole run. Stop during the reactivated window (report scenario M1, stopped 26 s into the late work): `bb thread wait --timeout 10` timed out (thread correctly active), `bb thread stop` returned in 2 s, the fake received `turn/interrupt {"turnId":"turn-X-1"}`, the thread read `idle` and stayed idle for the next 30 s, and the child process emitted nothing further (session released).

Residual risks, none blocking: a provider that streams root work on its latest settled turn and never re-completes it stays active until a manual stop (only bridges that vouch provider turn ids, i.e. Codex, can place an item on a closed turn; the delta assembler falls back to "no turn" for everyone else, and pi's post-turn compaction is excluded by type). `getActiveStoredTurnId` is still null during the reactivated window, so an in-app send dispatches a new `turn/start` into the busy session instead of a steer, same as main. Grammar drops remain unlogged by the daemon.

> AGENT GENERATED: by Claude Opus 5
