### PR TITLE
Clone source history into thread forks and honor sourceSeqEnd

### DIFF
--- a/apps/cli/src/commands/thread/fork.ts
+++ b/apps/cli/src/commands/thread/fork.ts
@@ -71,7 +71,10 @@ export function registerForkCommand(
     .description("Fork a thread at its tip or a source event sequence")
     .option("--prompt <prompt>", "Optional first prompt; omit for an idle fork")
     .option("--title <title>", "Thread title")
-    .option("--source-seq-end <seq>", "Last included source event sequence")
+    .option(
+      "--source-seq-end <seq>",
+      "Fork after the source turn containing this event sequence",
+    )
     .option("--workspace <mode>", "Workspace: isolated (default) or reuse")
     .option("--permission-mode <mode>", PERMISSION_MODE_HELP)
     .option("--visibility <visibility>", "Thread visibility: visible or hidden")

--- a/apps/cli/src/commands/thread/spawn.ts
+++ b/apps/cli/src/commands/thread/spawn.ts
@@ -224,7 +224,10 @@ export function registerSpawnCommand(
     )
     .option("--origin-kind <kind>", "Thread origin: fork")
     .option("--source-thread <id>", "Source thread for a fork")
-    .option("--source-seq-end <seq>", "Last source event sequence")
+    .option(
+      "--source-seq-end <seq>",
+      "Fork after the source turn containing this event sequence",
+    )
     .action(
       action(async (opts: ThreadSpawnCommandOptions) => {
         const projectId = resolveExplicitIdFlag({

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -192,10 +192,12 @@ message agents, or inspect projects, providers, and environments.
   flags pass host-readable absolute paths (or relative server-upload tokens)
   through to the runtime; they do not read files on the CLI machine.
 - Spawn creates a root thread unless you pass `--parent-thread`.
-- Use `bb thread fork <source-thread-id>` to clone a provider session. It
-  creates an idle fork by default; add `--prompt`, select `--workspace
-isolated|reuse`, or anchor with `--source-seq-end`. Permission mode inherits
-  the source thread unless explicitly overridden.
+- Use `bb thread fork <source-thread-id>` to clone a provider session. The
+  fork inherits the source conversation in its timeline. It creates an idle
+  fork by default; add `--prompt`, select `--workspace isolated|reuse`, or
+  anchor with `--source-seq-end` on a completed source turn (the clone and the
+  inherited timeline both end with the turn containing that sequence).
+  Permission mode inherits the source thread unless explicitly overridden.
 - Pass `--visibility hidden` for background/plugin workers that should remain
   out of sidebar organization without contributing unread/pending favicon
   attention. `bb thread list` excludes them by

--- a/apps/server/src/services/threads/thread-create.ts
+++ b/apps/server/src/services/threads/thread-create.ts
@@ -23,9 +23,10 @@ import { runtimeErrorLogFields } from "../lib/error-log-fields.js";
 import { throwEnvironmentNotReady } from "../lib/lifecycle-api-errors.js";
 import { buildExecutionOptions } from "./thread-commands.js";
 import {
-  getLastProviderThreadId,
-  getProviderThreadIdAtOrBeforeSequence,
-} from "./thread-events.js";
+  copyForkSourceHistory,
+  resolveThreadForkPoint,
+  type ThreadForkPoint,
+} from "./thread-fork-history.js";
 import {
   rememberProjectExecutionDefaultsForCreate,
   resolveProjectExecutionDefaultsForCreate,
@@ -58,7 +59,6 @@ import {
   requestThreadProvision,
 } from "./thread-provisioning.js";
 import type {
-  ThreadForkDescriptor,
   ThreadProvisionContext,
   ThreadProvisionEnvironmentIntent,
 } from "./thread-provisioning-context.js";
@@ -90,12 +90,12 @@ interface CreateProvisioningThreadArgs {
   executionDefaults: Parameters<
     typeof buildExecutionOptions
   >[2]["projectDefaults"];
-  fork: ThreadForkDescriptor | null;
+  fork: ThreadForkPoint | null;
   request: ThreadCreateServiceRequest;
   providerInput?: ThreadCreateServiceRequestInput["input"];
 }
 
-interface ResolveForkDescriptorArgs {
+interface ResolveForkPointArgs {
   childHostId: string;
   originKind: ThreadOriginKind | null;
   providerId: string;
@@ -152,22 +152,23 @@ async function resolveCatalogExecutionDefaults(
 }
 
 /**
- * Resolve the native-fork descriptor for a source-derived thread, or null when
- * it cannot be provisioned as a fork. Both forks and side chats are native
- * forks: they clone the source thread's provider session at its branch point so
- * the new thread carries the full conversation history (a fork then waits idle;
- * a side chat runs its question turn). Forking requires: a live source thread
- * (any non-null originKind), a provider that supports native fork, a source that
- * already has a provider session, and a new workspace on the same host as the
- * source (a cross-host clone of a provider session is not possible).
+ * Resolve the native-fork point for a source-derived thread, or null when it
+ * cannot be provisioned as a fork. Both forks and side chats are native forks:
+ * they clone the source thread's provider session at its branch point so the
+ * new thread carries the conversation history, and they inherit the source's
+ * timeline through that same point (a fork then waits idle; a side chat runs
+ * its question turn). Forking requires: a live source thread (any non-null
+ * originKind), a provider that supports native fork, a source that already has
+ * a provider session, and a new workspace on the same host as the source (a
+ * cross-host clone of a provider session is not possible).
  * Returns null when the request has no source provenance or the source session
- * cannot be cloned; the consumer treats a null descriptor for a source-derived
+ * cannot be cloned; the consumer treats a null fork point for a source-derived
  * thread as an unforkable error rather than a silent fresh start.
  */
-function resolveForkDescriptor(
+function resolveForkPoint(
   deps: Pick<ThreadCreateDeps, "db" | "providerRegistry">,
-  args: ResolveForkDescriptorArgs,
-): ThreadForkDescriptor | null {
+  args: ResolveForkPointArgs,
+): ThreadForkPoint | null {
   if (args.originKind === null || args.sourceThread === null) {
     return null;
   }
@@ -177,16 +178,6 @@ function resolveForkDescriptor(
   // A provider session ID is opaque to every other provider, so a fork is
   // possible only when the source and the child use the same provider.
   if (args.sourceThread.providerId !== args.providerId) {
-    return null;
-  }
-  const sourceProviderThreadId =
-    args.sourceSeqEnd === undefined
-      ? getLastProviderThreadId(deps, args.sourceThread.id)
-      : getProviderThreadIdAtOrBeforeSequence(deps, {
-          sequence: args.sourceSeqEnd,
-          threadId: args.sourceThread.id,
-        });
-  if (sourceProviderThreadId === null) {
     return null;
   }
   const sourceEnvironmentId = args.sourceThread.environmentId;
@@ -200,7 +191,10 @@ function resolveForkDescriptor(
   ) {
     return null;
   }
-  return { sourceProviderThreadId };
+  return resolveThreadForkPoint(deps, {
+    sourceSeqEnd: args.sourceSeqEnd,
+    sourceThread: args.sourceThread,
+  });
 }
 
 function childHostIdForResolvedEnvironment(
@@ -481,6 +475,23 @@ async function createProvisioningThread(
   let execution: Awaited<ReturnType<typeof buildExecutionOptions>>;
   let context: ThreadProvisionContext;
   try {
+    // The clone the provider makes of the source session is invisible to the
+    // timeline, so a fork inherits the source's conversation rows through the
+    // same branch point before its own thread-start rows are appended. Only a
+    // visible fork does: it is the thread page the user continues on. A hidden
+    // fork is an aside (a side chat) or a plugin worker rendered by its owner
+    // next to the source, so its own timeline holds only what it adds.
+    if (
+      args.fork !== null &&
+      args.fork.historyEndSequence !== null &&
+      args.request.visibility === "visible"
+    ) {
+      copyForkSourceHistory(deps, {
+        fork: thread,
+        historyEndSequence: args.fork.historyEndSequence,
+        sourceThreadId: args.fork.sourceThreadId,
+      });
+    }
     execution = await buildExecutionOptions(deps, args.request, {
       ...(args.executionDefaults
         ? { projectDefaults: args.executionDefaults }
@@ -494,7 +505,7 @@ async function createProvisioningThread(
       thread,
       environmentIntent: args.environmentIntent,
       execution,
-      fork: args.fork,
+      fork: args.fork?.descriptor ?? null,
       input: args.request.input,
       ...(args.providerInput !== undefined
         ? { providerInput: args.providerInput }
@@ -853,7 +864,7 @@ export async function createThreadFromRequest(
     }
   }
 
-  const fork = resolveForkDescriptor(deps, {
+  const fork = resolveForkPoint(deps, {
     childHostId,
     originKind: request.originKind ?? null,
     providerId: request.providerId,

--- a/apps/server/src/services/threads/thread-edit-message.ts
+++ b/apps/server/src/services/threads/thread-edit-message.ts
@@ -174,6 +174,31 @@ function getTurnCompletion(
   return event.type === "turn/completed" ? event : null;
 }
 
+const CODEX_NATIVE_TURN_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * The provider checkpoint a completed root turn can be re-created through:
+ * what `turn/completed` recorded, which rewinds and point-in-time forks hand
+ * back to the bridge. Runtime-assembled Codex timelines have bb-minted turn
+ * ids and persist the native Codex turn id as the checkpoint. Older Codex
+ * timelines used the native UUID directly and have no checkpoint, so retain
+ * that compatibility fallback without ever forwarding a bb-minted id to Codex.
+ */
+export function resolveTurnProviderCheckpointId(args: {
+  providerCheckpointId: string | null | undefined;
+  providerId: string;
+  turnId: string;
+}): string | null {
+  if (args.providerCheckpointId) {
+    return args.providerCheckpointId;
+  }
+  return args.providerId === "codex" &&
+    CODEX_NATIVE_TURN_ID_PATTERN.test(args.turnId)
+    ? args.turnId
+    : null;
+}
+
 function resolveEditableTurnCandidate(
   db: DbQueryConnection,
   thread: Thread,
@@ -260,24 +285,14 @@ function resolveEditableTurnCandidate(
   ) {
     conflict("This earlier turn has no provider history");
   }
-  // Runtime-assembled Codex timelines have bb-minted turn ids and persist the
-  // native Codex turn id as the checkpoint. Older timelines used the native
-  // UUID directly and have no checkpoint, so retain that compatibility
-  // fallback without ever forwarding a bb-minted id to Codex.
-  const legacyCodexCheckpoint =
-    thread.providerId === "codex" &&
-    precedingTurnId !== null &&
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
-      precedingTurnId,
-    )
-      ? precedingTurnId
-      : null;
   const precedingProviderCheckpoint =
     precedingTurnId === null
       ? null
-      : thread.providerId === "codex"
-        ? (precedingCompletion?.providerCheckpointId ?? legacyCodexCheckpoint)
-        : (precedingCompletion?.providerCheckpointId ?? null);
+      : resolveTurnProviderCheckpointId({
+          providerCheckpointId: precedingCompletion?.providerCheckpointId,
+          providerId: thread.providerId,
+          turnId: precedingTurnId,
+        });
   if (precedingTurnId !== null && precedingProviderCheckpoint === null) {
     conflict("This earlier provider turn has no editable history checkpoint");
   }

--- a/apps/server/src/services/threads/thread-events.ts
+++ b/apps/server/src/services/threads/thread-events.ts
@@ -6,7 +6,6 @@ import {
   getLastStoredProviderThreadId,
   getLastStoredTurnRequestEvent,
   getStoredTurnRequestEventForTurn,
-  getStoredProviderThreadIdAtOrBeforeSequence,
   getThread,
   listStoredTurnStartedKeys,
   noopNotifier,
@@ -965,16 +964,6 @@ export function getLastProviderThreadId(
   threadId: string,
 ): string | null {
   return getLastStoredProviderThreadId(deps.db, threadId);
-}
-
-export function getProviderThreadIdAtOrBeforeSequence(
-  deps: ThreadEventReadDeps,
-  args: {
-    sequence: number;
-    threadId: string;
-  },
-): string | null {
-  return getStoredProviderThreadIdAtOrBeforeSequence(deps.db, args);
 }
 
 export function getLastExecutionOptions(

--- a/apps/server/src/services/threads/thread-fork-history.ts
+++ b/apps/server/src/services/threads/thread-fork-history.ts
@@ -1,0 +1,330 @@
+import {
+  copyStoredThreadEventsInTransaction,
+  findLastCompletedRootStoredTurn,
+  findLastRootStoredTurnStarted,
+  listStoredEventRows,
+  listStoredTurnCompletedRowsByTurnIds,
+  type StoredEventRow,
+} from "@bb/db";
+import type { Thread, ThreadEvent, ThreadEventType } from "@bb/domain";
+import type { AppDeps } from "../../types.js";
+import { ApiError } from "../../errors.js";
+import { parseStoredEvent } from "./thread-data.js";
+import {
+  getLastProviderThreadId,
+  parseStoredTurnRequestEvent,
+} from "./thread-events.js";
+import { resolveTurnProviderCheckpointId } from "./thread-edit-message.js";
+import type { ThreadForkDescriptor } from "./thread-provisioning-context.js";
+
+/**
+ * Where a fork branches off its source: the provider session to clone (and
+ * the checkpoint to retain through; none for the tip) plus the last source
+ * sequence whose conversation the fork inherits. `historyEndSequence` is the
+ * `turn/completed` of the turn the clone ends on, so the timeline the fork
+ * shows and the context its model holds describe the same conversation. Null
+ * when the source has not completed a root turn yet.
+ */
+export interface ThreadForkPoint {
+  descriptor: ThreadForkDescriptor;
+  historyEndSequence: number | null;
+  sourceThreadId: string;
+}
+
+function forkPointUnavailable(message: string): never {
+  throw new ApiError(400, "fork_source_session_unavailable", message);
+}
+
+interface StoredTurnCompletion {
+  event: Extract<ThreadEvent, { type: "turn/completed" }>;
+  sequence: number;
+}
+
+function readTurnCompletion(
+  deps: Pick<AppDeps, "db">,
+  args: { threadId: string; turnId: string },
+): StoredTurnCompletion | null {
+  const row = listStoredTurnCompletedRowsByTurnIds(deps.db, {
+    threadId: args.threadId,
+    turnIds: [args.turnId],
+  }).at(-1);
+  if (row === undefined) {
+    return null;
+  }
+  const event = parseStoredEvent(row);
+  if (event.type !== "turn/completed") {
+    throw new Error(`Expected turn/completed event #${row.sequence}`);
+  }
+  return { event, sequence: row.sequence };
+}
+
+/**
+ * The descriptor that re-creates a completed turn's session through the
+ * checkpoint its completion recorded, or null when that turn left no session
+ * or checkpoint to branch from.
+ */
+function resolveCheckpointForkDescriptor(args: {
+  completion: StoredTurnCompletion;
+  providerId: string;
+  turnId: string;
+}): ThreadForkDescriptor | null {
+  if (args.completion.event.providerThreadId === null) {
+    return null;
+  }
+  const sourceProviderCheckpointId = resolveTurnProviderCheckpointId({
+    providerCheckpointId: args.completion.event.providerCheckpointId,
+    providerId: args.providerId,
+    turnId: args.turnId,
+  });
+  if (sourceProviderCheckpointId === null) {
+    return null;
+  }
+  return {
+    sourceProviderThreadId: args.completion.event.providerThreadId,
+    sourceProviderCheckpointId,
+  };
+}
+
+/**
+ * Resolve the branch point for `sourceSeqEnd`. The anchor is the root turn
+ * that contains the sequence, or the last root turn before it when the
+ * sequence sits between turns (a user message row precedes its turn, so
+ * forking at one branches before that message, like editing it does). The
+ * anchor must have completed: a checkpoint is recorded on `turn/completed`,
+ * and a turn still running has no stable point to clone. Providers that can
+ * only clone a whole session (`fork: "tip"`) accept the anchor only when it
+ * is the source's latest turn; otherwise the clone would silently include
+ * turns the caller asked to leave out.
+ */
+function resolveAnchoredForkPoint(
+  deps: Pick<AppDeps, "db" | "providerRegistry">,
+  args: { sourceSeqEnd: number; sourceThread: Thread },
+): ThreadForkPoint {
+  const anchor = findLastRootStoredTurnStarted(deps.db, {
+    atOrBeforeSequence: args.sourceSeqEnd,
+    threadId: args.sourceThread.id,
+  });
+  if (anchor === null) {
+    forkPointUnavailable(
+      `Cannot fork at sequence ${args.sourceSeqEnd}: no turn has started at or before it`,
+    );
+  }
+  const completion = readTurnCompletion(deps, {
+    threadId: args.sourceThread.id,
+    turnId: anchor.turnId,
+  });
+  if (completion === null) {
+    forkPointUnavailable(
+      `Cannot fork at sequence ${args.sourceSeqEnd}: the turn containing it has not completed`,
+    );
+  }
+  if (completion.event.providerThreadId === null) {
+    forkPointUnavailable(
+      `Cannot fork at sequence ${args.sourceSeqEnd}: the turn containing it has no provider session`,
+    );
+  }
+  const latestRootTurn = findLastRootStoredTurnStarted(deps.db, {
+    threadId: args.sourceThread.id,
+  });
+  const anchorIsTip = latestRootTurn?.turnId === anchor.turnId;
+  if (
+    !deps.providerRegistry.supportsSessionRewind(args.sourceThread.providerId)
+  ) {
+    if (!anchorIsTip) {
+      forkPointUnavailable(
+        `Provider ${args.sourceThread.providerId} can only fork at the end of a session, not from an earlier point in it`,
+      );
+    }
+    return {
+      descriptor: {
+        sourceProviderThreadId: completion.event.providerThreadId,
+      },
+      historyEndSequence: completion.sequence,
+      sourceThreadId: args.sourceThread.id,
+    };
+  }
+  const descriptor = resolveCheckpointForkDescriptor({
+    completion,
+    providerId: args.sourceThread.providerId,
+    turnId: anchor.turnId,
+  });
+  if (descriptor === null) {
+    forkPointUnavailable(
+      `Cannot fork at sequence ${args.sourceSeqEnd}: the turn containing it recorded no provider checkpoint`,
+    );
+  }
+  return {
+    descriptor,
+    historyEndSequence: completion.sequence,
+    sourceThreadId: args.sourceThread.id,
+  };
+}
+
+/**
+ * Resolve where a fork of `sourceThread` branches. Without `sourceSeqEnd` the
+ * fork inherits every completed root turn and clones the session tip. When
+ * the source is mid-turn, its session tip already holds the running turn's
+ * prompt and partial output, which the inherited timeline stops short of; a
+ * provider that can branch at a checkpoint then clones through the last
+ * completed turn instead, so model context and timeline describe the same
+ * conversation. Returns null when the source has no provider session to
+ * clone; throws `fork_source_session_unavailable` when `sourceSeqEnd` names a
+ * point the provider cannot branch from.
+ */
+export function resolveThreadForkPoint(
+  deps: Pick<AppDeps, "db" | "providerRegistry">,
+  args: { sourceSeqEnd: number | undefined; sourceThread: Thread },
+): ThreadForkPoint | null {
+  if (args.sourceSeqEnd !== undefined) {
+    return resolveAnchoredForkPoint(deps, {
+      sourceSeqEnd: args.sourceSeqEnd,
+      sourceThread: args.sourceThread,
+    });
+  }
+  const sourceProviderThreadId = getLastProviderThreadId(
+    deps,
+    args.sourceThread.id,
+  );
+  if (sourceProviderThreadId === null) {
+    return null;
+  }
+  const lastCompletedTurn = findLastCompletedRootStoredTurn(deps.db, {
+    threadId: args.sourceThread.id,
+  });
+  const tip: ThreadForkPoint = {
+    descriptor: { sourceProviderThreadId },
+    historyEndSequence: lastCompletedTurn?.completedSequence ?? null,
+    sourceThreadId: args.sourceThread.id,
+  };
+  if (
+    lastCompletedTurn === null ||
+    !deps.providerRegistry.supportsSessionRewind(args.sourceThread.providerId)
+  ) {
+    return tip;
+  }
+  const latestRootTurn = findLastRootStoredTurnStarted(deps.db, {
+    threadId: args.sourceThread.id,
+  });
+  if (latestRootTurn?.turnId === lastCompletedTurn.turnId) {
+    return tip;
+  }
+  const completion = readTurnCompletion(deps, {
+    threadId: args.sourceThread.id,
+    turnId: lastCompletedTurn.turnId,
+  });
+  const descriptor =
+    completion === null
+      ? null
+      : resolveCheckpointForkDescriptor({
+          completion,
+          providerId: args.sourceThread.providerId,
+          turnId: lastCompletedTurn.turnId,
+        });
+  return descriptor === null ? tip : { ...tip, descriptor };
+}
+
+/**
+ * The events that carry the conversation a fork inherits. Everything else the
+ * source recorded is either the source's own bookkeeping (identity,
+ * provisioning, usage snapshots, operations), streaming deltas the completed
+ * items already fold in, or pending-interaction and goal state that belongs to
+ * the source thread alone.
+ */
+const INHERITED_EVENT_TYPES = [
+  "client/turn/requested",
+  "turn/started",
+  "turn/input/accepted",
+  "item/completed",
+  "item/backgroundTask/completed",
+  "turn/completed",
+  "thread/compacted",
+  "system/manager/user_message",
+] as const satisfies readonly ThreadEventType[];
+
+function parseAcceptedClientRequestId(row: StoredEventRow): string {
+  const event = parseStoredEvent(row);
+  if (event.type !== "turn/input/accepted") {
+    throw new Error(`Expected turn/input/accepted event #${row.sequence}`);
+  }
+  return event.clientRequestId;
+}
+
+/**
+ * Select the rows of the source conversation through `historyEndSequence`.
+ * Only turns that completed inside the window come along, so the fork never
+ * shows a turn that is still running; a `client/turn/requested` comes along
+ * only when the window also holds its acceptance, so a message the source had
+ * merely queued does not show as pending in the fork. The rows are read into
+ * memory because each copy is re-parsed to index search segments; the filter
+ * here only drops the few rows of turns and requests still open at the
+ * window's end.
+ */
+function selectInheritedForkEventRows(
+  deps: Pick<AppDeps, "db">,
+  args: { historyEndSequence: number; sourceThreadId: string },
+): StoredEventRow[] {
+  const rows = listStoredEventRows(deps.db, {
+    beforeSequence: args.historyEndSequence + 1,
+    threadId: args.sourceThreadId,
+    types: INHERITED_EVENT_TYPES,
+  });
+  const completedTurnIds = new Set<string>();
+  const acceptedClientRequestIds = new Set<string>();
+  for (const row of rows) {
+    if (row.type === "turn/completed" && row.turnId !== null) {
+      completedTurnIds.add(row.turnId);
+    } else if (row.type === "turn/input/accepted") {
+      acceptedClientRequestIds.add(parseAcceptedClientRequestId(row));
+    }
+  }
+  return rows.filter((row) => {
+    if (row.turnId !== null) {
+      return completedTurnIds.has(row.turnId);
+    }
+    if (row.type !== "client/turn/requested") {
+      return true;
+    }
+    return acceptedClientRequestIds.has(
+      parseStoredTurnRequestEvent(row).requestId,
+    );
+  });
+}
+
+/**
+ * Copy the source conversation through `historyEndSequence` into a fork
+ * before the fork's own thread-start rows are appended, so inherited history
+ * occupies the lowest sequences and renders first. Copied rows carry no
+ * `provider_thread_id` column value: that column names the session a thread
+ * owns and resumes, and the fork owns only the session its own
+ * `thread/identity` will name. The event payloads keep the source session id,
+ * so a later rewind or nested fork anchored on an inherited turn still finds
+ * the session that recorded its checkpoint.
+ */
+export function copyForkSourceHistory(
+  deps: Pick<AppDeps, "db" | "hub">,
+  args: {
+    fork: Pick<Thread, "environmentId" | "id">;
+    historyEndSequence: number;
+    sourceThreadId: string;
+  },
+): void {
+  const rows = selectInheritedForkEventRows(deps, {
+    historyEndSequence: args.historyEndSequence,
+    sourceThreadId: args.sourceThreadId,
+  }).map((row) => ({ ...row, providerThreadId: null }));
+  if (rows.length === 0) {
+    return;
+  }
+  deps.db.transaction(
+    (tx) =>
+      copyStoredThreadEventsInTransaction(tx, {
+        rows,
+        targetEnvironmentId: args.fork.environmentId,
+        targetThreadId: args.fork.id,
+      }),
+    { behavior: "immediate" },
+  );
+  deps.hub.notifyThread(args.fork.id, ["events-appended"], {
+    eventTypes: [...new Set(rows.map((row) => row.type))],
+  });
+}

--- a/apps/server/src/services/threads/thread-provisioning-context.ts
+++ b/apps/server/src/services/threads/thread-provisioning-context.ts
@@ -58,6 +58,8 @@ const threadProvisionEnvironmentIntentSchema = z.discriminatedUnion("type", [
 
 const threadForkDescriptorSchema = z.object({
   sourceProviderThreadId: z.string().min(1),
+  // The provider checkpoint the clone retains through; absent clones the tip.
+  sourceProviderCheckpointId: z.string().min(1).optional(),
 });
 
 const threadProvisionCommonPayloadSchema = z.object({

--- a/apps/server/test/public/public-thread-fork.test.ts
+++ b/apps/server/test/public/public-thread-fork.test.ts
@@ -1,6 +1,16 @@
 import { ensurePersonalProject, getThread, listEvents } from "@bb/db";
-import { PERSONAL_PROJECT_ID, turnRequestEventDataSchema } from "@bb/domain";
-import { threadResponseSchema } from "@bb/server-contract";
+import {
+  PERSONAL_PROJECT_ID,
+  encodeClientTurnRequestIdNumber,
+  threadScope,
+  turnRequestEventDataSchema,
+  turnScope,
+  type ClientTurnRequestId,
+} from "@bb/domain";
+import {
+  threadResponseSchema,
+  threadTimelineResponseSchema,
+} from "@bb/server-contract";
 import { describe, expect, it } from "vitest";
 import {
   reportQueuedCommandSuccess,
@@ -9,6 +19,7 @@ import {
 import { readJson } from "../helpers/json.js";
 import {
   seedEnvironment,
+  seedEvent,
   seedHostSession,
   seedProjectWithSource,
   seedThread,
@@ -220,6 +231,21 @@ describe("public thread fork route", () => {
   it("runs optional input from the requested fork point", async () => {
     await withTestHarness(async (harness) => {
       const { environment, sourceThread } = seedForkSource(harness);
+      // The source session was replaced after turn 1: the earlier turn's
+      // completion names the session (and checkpoint) the fork must clone.
+      seedEvent(harness.deps, {
+        environmentId: environment.id,
+        providerThreadId: "provider-fork-source",
+        sequence: 4,
+        threadId: sourceThread.id,
+        type: "turn/completed",
+        scope: turnScope("turn-fork-source"),
+        data: {
+          providerThreadId: "provider-fork-source",
+          status: "completed",
+          providerCheckpointId: "checkpoint-fork-source",
+        },
+      });
       seedTurnStarted(harness.deps, {
         environmentId: environment.id,
         providerThreadId: "provider-later-source",
@@ -251,6 +277,7 @@ describe("public thread fork route", () => {
       expect(queued.command.input).toEqual(input);
       expect(queued.command.fork).toEqual({
         sourceProviderThreadId: "provider-fork-source",
+        sourceProviderCheckpointId: "checkpoint-fork-source",
       });
     });
   });
@@ -416,7 +443,9 @@ describe("public thread fork route", () => {
             command: "test-agent",
             args: ["acp"],
           },
-          fork: { sourceProviderThreadId: "provider-acp-source" },
+          fork: {
+            sourceProviderThreadId: "provider-acp-source",
+          },
         });
 
         await reportQueuedCommandSuccess(harness, start, {
@@ -451,5 +480,477 @@ describe("public thread fork route", () => {
         });
       },
     );
+  });
+});
+
+const HISTORY_PROVIDER_THREAD_ID = "provider-history-source";
+
+function seedHistoryUserRequest(
+  harness: TestAppHarness,
+  args: {
+    environmentId: string;
+    requestId: ClientTurnRequestId;
+    sequence: number;
+    text: string;
+    threadId: string;
+  },
+): void {
+  seedEvent(harness.deps, {
+    environmentId: args.environmentId,
+    sequence: args.sequence,
+    threadId: args.threadId,
+    type: "client/turn/requested",
+    scope: threadScope(),
+    data: {
+      direction: "outbound",
+      requestId: args.requestId,
+      input: [{ type: "text", text: args.text }],
+      target: { kind: "new-turn" },
+      execution: {
+        model: "gpt-5",
+        serviceTier: "default",
+        reasoningLevel: "medium",
+        permissionMode: "full",
+        source: "client/turn/requested",
+      },
+      initiator: "user",
+      senderThreadId: null,
+      request: { method: "turn/start", params: {} },
+      source: "tell",
+    },
+  });
+}
+
+/**
+ * A source with two completed turns and, by default, a third still running.
+ * Turn 1 spans sequences 3–7 with a message queued at 6 that turn 2 accepts;
+ * turn 2 spans 8–11; turn 3 is requested at 12, started at 13, and has not
+ * completed.
+ */
+function seedConversationForkSource(
+  harness: TestAppHarness,
+  args: { providerId?: string; runningThirdTurn?: boolean } = {},
+) {
+  const { host } = seedHostSession(harness.deps);
+  const { project } = seedProjectWithSource(harness.deps, {
+    hostId: host.id,
+    path: "/tmp/public-thread-fork-history",
+  });
+  const environment = seedEnvironment(harness.deps, {
+    hostId: host.id,
+    projectId: project.id,
+    path: "/tmp/public-thread-fork-history",
+  });
+  const sourceThread = seedThread(harness.deps, {
+    environmentId: environment.id,
+    projectId: project.id,
+    ...(args.providerId === undefined ? {} : { providerId: args.providerId }),
+  });
+  // seq 1: thread/identity, seq 2: client/turn/requested (request id 1)
+  seedThreadRuntimeState(harness.deps, {
+    environmentId: environment.id,
+    inputText: "Reply only with ok.",
+    permissionMode: "full",
+    providerThreadId: HISTORY_PROVIDER_THREAD_ID,
+    threadId: sourceThread.id,
+  });
+  const base = {
+    environmentId: environment.id,
+    providerThreadId: HISTORY_PROVIDER_THREAD_ID,
+    threadId: sourceThread.id,
+  };
+  const firstRequestId = encodeClientTurnRequestIdNumber({ value: 1 });
+  const secondRequestId = encodeClientTurnRequestIdNumber({ value: 2 });
+  const thirdRequestId = encodeClientTurnRequestIdNumber({ value: 3 });
+  seedTurnStarted(harness.deps, { ...base, sequence: 3, turnId: "turn-1" });
+  seedEvent(harness.deps, {
+    ...base,
+    sequence: 4,
+    type: "turn/input/accepted",
+    scope: turnScope("turn-1"),
+    data: {
+      providerThreadId: HISTORY_PROVIDER_THREAD_ID,
+      clientRequestId: firstRequestId,
+    },
+  });
+  seedEvent(harness.deps, {
+    ...base,
+    createdAt: 1_000,
+    sequence: 5,
+    type: "item/completed",
+    scope: turnScope("turn-1"),
+    data: {
+      providerThreadId: HISTORY_PROVIDER_THREAD_ID,
+      item: { type: "agentMessage", id: "msg-1", text: "ok" },
+    },
+  });
+  seedHistoryUserRequest(harness, {
+    ...base,
+    requestId: secondRequestId,
+    sequence: 6,
+    text: "Reply only with the word second.",
+  });
+  seedEvent(harness.deps, {
+    ...base,
+    sequence: 7,
+    type: "turn/completed",
+    scope: turnScope("turn-1"),
+    data: {
+      providerThreadId: HISTORY_PROVIDER_THREAD_ID,
+      status: "completed",
+      providerCheckpointId: "checkpoint-after-turn-1",
+    },
+  });
+  seedTurnStarted(harness.deps, { ...base, sequence: 8, turnId: "turn-2" });
+  seedEvent(harness.deps, {
+    ...base,
+    sequence: 9,
+    type: "turn/input/accepted",
+    scope: turnScope("turn-2"),
+    data: {
+      providerThreadId: HISTORY_PROVIDER_THREAD_ID,
+      clientRequestId: secondRequestId,
+    },
+  });
+  seedEvent(harness.deps, {
+    ...base,
+    sequence: 10,
+    type: "item/completed",
+    scope: turnScope("turn-2"),
+    data: {
+      providerThreadId: HISTORY_PROVIDER_THREAD_ID,
+      item: { type: "agentMessage", id: "msg-2", text: "second" },
+    },
+  });
+  seedEvent(harness.deps, {
+    ...base,
+    sequence: 11,
+    type: "turn/completed",
+    scope: turnScope("turn-2"),
+    data: {
+      providerThreadId: HISTORY_PROVIDER_THREAD_ID,
+      status: "completed",
+      providerCheckpointId: "checkpoint-after-turn-2",
+    },
+  });
+  if (args.runningThirdTurn === false) {
+    return { environment, sourceThread };
+  }
+  seedHistoryUserRequest(harness, {
+    ...base,
+    requestId: thirdRequestId,
+    sequence: 12,
+    text: "Reply only with the word third.",
+  });
+  seedTurnStarted(harness.deps, { ...base, sequence: 13, turnId: "turn-3" });
+  seedEvent(harness.deps, {
+    ...base,
+    sequence: 14,
+    type: "turn/input/accepted",
+    scope: turnScope("turn-3"),
+    data: {
+      providerThreadId: HISTORY_PROVIDER_THREAD_ID,
+      clientRequestId: thirdRequestId,
+    },
+  });
+  return { environment, sourceThread };
+}
+
+async function readConversationTexts(
+  harness: TestAppHarness,
+  threadId: string,
+): Promise<string[]> {
+  const response = await harness.app.request(
+    `/api/v1/threads/${threadId}/timeline`,
+  );
+  expect(response.status).toBe(200);
+  const timeline = threadTimelineResponseSchema.parse(await readJson(response));
+  return timeline.rows.flatMap((row) =>
+    row.kind === "conversation" ? [row.text] : [],
+  );
+}
+
+async function waitForForkStart(harness: TestAppHarness, forkId: string) {
+  const queued = await waitForQueuedCommand(
+    harness,
+    ({ command }) =>
+      command.type === "thread.start" && command.threadId === forkId,
+  );
+  if (queued.command.type !== "thread.start") {
+    throw new Error("Expected thread.start");
+  }
+  return queued.command;
+}
+
+describe("fork branch point and inherited history", () => {
+  it("clones through the anchor turn's checkpoint and inherits its conversation", async () => {
+    await withTestHarness(async (harness) => {
+      const { sourceThread } = seedConversationForkSource(harness);
+
+      // Sequence 5 is turn 1's assistant message: the anchor the app's
+      // per-message Fork button sends for it.
+      const response = await postFork(harness, {
+        sourceThreadId: sourceThread.id,
+        sourceSeqEnd: 5,
+        workspace: "reuse",
+      });
+
+      expect(response.status).toBe(201);
+      const fork = threadResponseSchema.parse(await readJson(response));
+      const start = await waitForForkStart(harness, fork.id);
+      expect(start.fork).toEqual({
+        sourceProviderThreadId: HISTORY_PROVIDER_THREAD_ID,
+        sourceProviderCheckpointId: "checkpoint-after-turn-1",
+      });
+      expect(await readConversationTexts(harness, fork.id)).toEqual([
+        "Reply only with ok.",
+        "ok",
+      ]);
+
+      const forkEvents = listEvents(harness.db, { threadId: fork.id });
+      const inherited = forkEvents.filter((event) => event.sequence <= 5);
+      // Inherited rows come first, keep their own timestamps, and never name
+      // a provider session the fork does not own. The message the source
+      // queued during turn 1 (accepted only by turn 2) stays out.
+      expect(inherited.map((event) => event.type)).toEqual([
+        "client/turn/requested",
+        "turn/started",
+        "turn/input/accepted",
+        "item/completed",
+        "turn/completed",
+      ]);
+      expect(inherited.every((event) => event.providerThreadId === null)).toBe(
+        true,
+      );
+      expect(inherited[3]?.createdAt).toBe(1_000);
+      expect(
+        forkEvents.filter((event) => event.type === "thread/identity"),
+      ).toHaveLength(0);
+      // The fork's own thread-start request follows the inherited history.
+      expect(forkEvents.at(5)?.type).toBe("client/turn/requested");
+    });
+  });
+
+  it("anchors a user message before its own turn", async () => {
+    await withTestHarness(async (harness) => {
+      const { sourceThread } = seedConversationForkSource(harness);
+
+      // Sequence 6 is the request that became turn 2, so forking at it
+      // branches before that message.
+      const response = await postFork(harness, {
+        sourceThreadId: sourceThread.id,
+        sourceSeqEnd: 6,
+        workspace: "reuse",
+      });
+
+      expect(response.status).toBe(201);
+      const fork = threadResponseSchema.parse(await readJson(response));
+      const start = await waitForForkStart(harness, fork.id);
+      expect(start.fork?.sourceProviderCheckpointId).toBe(
+        "checkpoint-after-turn-1",
+      );
+      expect(await readConversationTexts(harness, fork.id)).toEqual([
+        "Reply only with ok.",
+        "ok",
+      ]);
+    });
+  });
+
+  it("clones the tip of an idle source and inherits every completed turn", async () => {
+    await withTestHarness(async (harness) => {
+      const { sourceThread } = seedConversationForkSource(harness, {
+        runningThirdTurn: false,
+      });
+
+      const response = await postFork(harness, {
+        sourceThreadId: sourceThread.id,
+        workspace: "reuse",
+      });
+
+      expect(response.status).toBe(201);
+      const fork = threadResponseSchema.parse(await readJson(response));
+      const start = await waitForForkStart(harness, fork.id);
+      expect(start.fork).toEqual({
+        sourceProviderThreadId: HISTORY_PROVIDER_THREAD_ID,
+      });
+      expect(await readConversationTexts(harness, fork.id)).toEqual([
+        "Reply only with ok.",
+        "ok",
+        "Reply only with the word second.",
+        "second",
+      ]);
+    });
+  });
+
+  it("branches a mid-turn source at its last completed turn's checkpoint", async () => {
+    await withTestHarness(async (harness) => {
+      const { sourceThread } = seedConversationForkSource(harness);
+
+      // Turn 3 is still running: the session tip already holds its prompt,
+      // so a tip clone would know a message the inherited timeline lacks.
+      const response = await postFork(harness, {
+        sourceThreadId: sourceThread.id,
+        workspace: "reuse",
+      });
+
+      expect(response.status).toBe(201);
+      const fork = threadResponseSchema.parse(await readJson(response));
+      const start = await waitForForkStart(harness, fork.id);
+      expect(start.fork).toEqual({
+        sourceProviderThreadId: HISTORY_PROVIDER_THREAD_ID,
+        sourceProviderCheckpointId: "checkpoint-after-turn-2",
+      });
+      expect(await readConversationTexts(harness, fork.id)).toEqual([
+        "Reply only with ok.",
+        "ok",
+        "Reply only with the word second.",
+        "second",
+      ]);
+      expect(
+        listEvents(harness.db, { threadId: fork.id }).some(
+          (event) => event.turnId === "turn-3",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  it("keeps a hidden fork's timeline free of inherited history", async () => {
+    await withTestHarness(async (harness) => {
+      const { sourceThread } = seedConversationForkSource(harness);
+
+      // A side chat is a hidden fork rendered next to the source, so it still
+      // clones the session through the anchor but starts its own timeline
+      // empty.
+      const response = await postFork(harness, {
+        sourceThreadId: sourceThread.id,
+        sourceSeqEnd: 5,
+        visibility: "hidden",
+        workspace: "reuse",
+      });
+
+      expect(response.status).toBe(201);
+      const fork = threadResponseSchema.parse(await readJson(response));
+      const start = await waitForForkStart(harness, fork.id);
+      expect(start.fork).toEqual({
+        sourceProviderThreadId: HISTORY_PROVIDER_THREAD_ID,
+        sourceProviderCheckpointId: "checkpoint-after-turn-1",
+      });
+      expect(await readConversationTexts(harness, fork.id)).toEqual([]);
+      expect(
+        listEvents(harness.db, { threadId: fork.id }).map(
+          (event) => event.type,
+        ),
+      ).not.toContain("item/completed");
+    });
+  });
+
+  it("rejects an anchor inside a running turn or before the first turn", async () => {
+    await withTestHarness(async (harness) => {
+      const { sourceThread } = seedConversationForkSource(harness);
+
+      const running = await postFork(harness, {
+        sourceThreadId: sourceThread.id,
+        sourceSeqEnd: 14,
+        workspace: "reuse",
+      });
+      expect(running.status).toBe(400);
+      expect(await readJson(running)).toMatchObject({
+        code: "fork_source_session_unavailable",
+        message:
+          "Cannot fork at sequence 14: the turn containing it has not completed",
+      });
+
+      const beforeFirstTurn = await postFork(harness, {
+        sourceThreadId: sourceThread.id,
+        sourceSeqEnd: 2,
+        workspace: "reuse",
+      });
+      expect(beforeFirstTurn.status).toBe(400);
+      expect(await readJson(beforeFirstTurn)).toMatchObject({
+        code: "fork_source_session_unavailable",
+        message:
+          "Cannot fork at sequence 2: no turn has started at or before it",
+      });
+    });
+  });
+
+  const TIP_ONLY_PROVIDER_HARNESS = {
+    customAcpAgents: [
+      {
+        id: "test-agent",
+        displayName: "Test Agent",
+        command: "test-agent",
+        args: ["acp"],
+        env: {},
+        supportsManualCompaction: false,
+      },
+    ],
+  };
+
+  it("clones the tip of a mid-turn source when the provider cannot branch at a checkpoint", async () => {
+    await withTestHarness(TIP_ONLY_PROVIDER_HARNESS, async (harness) => {
+      const { sourceThread } = seedConversationForkSource(harness, {
+        providerId: "acp-test-agent",
+      });
+
+      const response = await postFork(harness, {
+        sourceThreadId: sourceThread.id,
+        workspace: "reuse",
+      });
+
+      expect(response.status).toBe(201);
+      const fork = threadResponseSchema.parse(await readJson(response));
+      const start = await waitForForkStart(harness, fork.id);
+      expect(start.fork).toEqual({
+        sourceProviderThreadId: HISTORY_PROVIDER_THREAD_ID,
+      });
+      expect(await readConversationTexts(harness, fork.id)).toEqual([
+        "Reply only with ok.",
+        "ok",
+        "Reply only with the word second.",
+        "second",
+      ]);
+    });
+  });
+
+  it("lets a tip-only provider fork at its latest turn but not earlier", async () => {
+    await withTestHarness(TIP_ONLY_PROVIDER_HARNESS, async (harness) => {
+      const { sourceThread } = seedConversationForkSource(harness, {
+        providerId: "acp-test-agent",
+        runningThirdTurn: false,
+      });
+
+      const earlier = await postFork(harness, {
+        sourceThreadId: sourceThread.id,
+        sourceSeqEnd: 5,
+        workspace: "reuse",
+      });
+      expect(earlier.status).toBe(400);
+      expect(await readJson(earlier)).toMatchObject({
+        code: "fork_source_session_unavailable",
+        message:
+          "Provider acp-test-agent can only fork at the end of a session, not from an earlier point in it",
+      });
+
+      // Sequence 10 sits in turn 2, the source's latest turn: the whole
+      // session is exactly the requested history.
+      const tip = await postFork(harness, {
+        sourceThreadId: sourceThread.id,
+        sourceSeqEnd: 10,
+        workspace: "reuse",
+      });
+      expect(tip.status).toBe(201);
+      const fork = threadResponseSchema.parse(await readJson(tip));
+      const start = await waitForForkStart(harness, fork.id);
+      expect(start.fork).toEqual({
+        sourceProviderThreadId: HISTORY_PROVIDER_THREAD_ID,
+      });
+      expect(await readConversationTexts(harness, fork.id)).toEqual([
+        "Reply only with ok.",
+        "ok",
+        "Reply only with the word second.",
+        "second",
+      ]);
+    });
   });
 });

--- a/apps/server/test/threads/thread-create-seed-without-run.test.ts
+++ b/apps/server/test/threads/thread-create-seed-without-run.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   PERSONAL_PROJECT_ID,
   turnRequestEventDataSchema,
+  turnScope,
   type PermissionMode,
 } from "@bb/domain";
 import { describe, expect, it, vi } from "vitest";
@@ -23,6 +24,7 @@ import {
 import { textInput } from "../helpers/prompt-input.js";
 import {
   seedEnvironment,
+  seedEvent,
   seedHostSession,
   seedPrimaryHost,
   seedProjectWithSource,
@@ -203,6 +205,21 @@ describe("thread creation with startedOnBehalfOf (seed-without-run)", () => {
         providerThreadId: "provider-earlier-source",
         sequence: 5,
       });
+      // The earlier turn's completion names the session that recorded the
+      // checkpoint; the later turn runs in a replacement session.
+      seedEvent(harness.deps, {
+        threadId: sourceThread.id,
+        environmentId: environment.id,
+        providerThreadId: "provider-earlier-source",
+        sequence: 6,
+        type: "turn/completed",
+        scope: turnScope("turn-earlier-source"),
+        data: {
+          providerThreadId: "provider-earlier-source",
+          status: "completed",
+          providerCheckpointId: "checkpoint-earlier-source",
+        },
+      });
       seedTurnStarted(harness.deps, {
         threadId: sourceThread.id,
         turnId: "turn-later-source",
@@ -244,6 +261,7 @@ describe("thread creation with startedOnBehalfOf (seed-without-run)", () => {
       expect(queuedStart.command.input).toEqual(forkInput);
       expect(queuedStart.command.fork).toEqual({
         sourceProviderThreadId: "provider-earlier-source",
+        sourceProviderCheckpointId: "checkpoint-earlier-source",
       });
     });
   });

--- a/docs/provider-bridge-protocol.md
+++ b/docs/provider-bridge-protocol.md
@@ -389,8 +389,10 @@ carries the whole item, so refusing it would lose real content.
    of a session and apply at the next construction.
 4. Fork: absent `sourceProviderCheckpointId` means fork at the tip. A
    `fork: "tip"` bridge rejects checkpoint forks with
-   `FORK_CHECKPOINT_UNSUPPORTED` rather than cloning history the bb timeline
-   does not show.
+   `FORK_CHECKPOINT_UNSUPPORTED`; the server only asks such a bridge for a
+   tip fork. The forked bb thread inherits the source timeline through the
+   same point the clone ends on, so the checkpoint must be the one the
+   bridge reported on that turn's `turn/completed`.
 5. Open work is what the timeline says it is. A `backgroundTask` item and a
    `delegation` item that are still pending are live provider work, and the
    runtime will not reap the session while one is open. Model a native

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -1473,6 +1473,12 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
                 threadId,
                 cwd: options.workspacePath,
                 sourceProviderThreadId: fork.sourceProviderThreadId,
+                ...(fork.sourceProviderCheckpointId !== undefined
+                  ? {
+                      sourceProviderCheckpointId:
+                        fork.sourceProviderCheckpointId,
+                    }
+                  : {}),
                 options: providerExecutionContext,
                 dynamicTools,
                 disallowedTools,

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -235,9 +235,14 @@ export interface StartThreadArgs {
   instructionMode?: InstructionMode;
   /**
    * Present means fork the new thread from this source provider session
-   * instead of starting fresh; absent means a normal start.
+   * instead of starting fresh; absent means a normal start. The clone retains
+   * the source history through `sourceProviderCheckpointId`; an absent
+   * checkpoint clones the session tip.
    */
-  fork?: { sourceProviderThreadId: string };
+  fork?: {
+    sourceProviderThreadId: string;
+    sourceProviderCheckpointId?: string;
+  };
 }
 
 export interface StartThreadResult {

--- a/packages/db/src/data/events.ts
+++ b/packages/db/src/data/events.ts
@@ -808,6 +808,79 @@ export function appendDaemonEventsInTransaction(
   };
 }
 
+export interface CopyStoredThreadEventsArgs {
+  /** Source rows in ascending sequence order. */
+  rows: readonly StoredEventRow[];
+  targetEnvironmentId: string | null;
+  targetThreadId: string;
+}
+
+/**
+ * Append copies of another thread's stored rows to the target thread, in the
+ * given order, after its current high-water mark. Each copy keeps the source
+ * row's type, scope, turn id, item fields, provider thread id, payload, and
+ * original `created_at` (the copied history happened when it happened), and
+ * takes a fresh id and the target's next sequence. Copied rows index search
+ * segments like any other appended event. Returns the number of copied rows.
+ */
+export function copyStoredThreadEventsInTransaction(
+  db: DbTransaction,
+  args: CopyStoredThreadEventsArgs,
+): number {
+  if (args.rows.length === 0) {
+    return 0;
+  }
+  const highWaterMarks = getHighWaterMarks(db, [args.targetThreadId]);
+  let sequence = (highWaterMarks[args.targetThreadId] ?? 0) + 1;
+  const now = Date.now();
+  for (const row of args.rows) {
+    db.run(
+      sql`INSERT INTO events
+        (id, thread_id, environment_id, scope_kind, turn_id, provider_thread_id, sequence, type, item_id, item_kind, parent_tool_call_id, data, created_at)
+        VALUES (
+          ${createEventId()},
+          ${args.targetThreadId},
+          ${args.targetEnvironmentId},
+          ${row.scopeKind},
+          ${row.turnId},
+          ${row.providerThreadId},
+          ${sequence},
+          ${row.type},
+          ${row.itemId},
+          ${row.itemKind},
+          ${row.parentToolCallId},
+          ${row.data},
+          ${row.createdAt}
+        )`,
+    );
+    const event = parseDaemonThreadEvent({
+      data: row.data,
+      environmentId: args.targetEnvironmentId,
+      itemId: row.itemId,
+      itemKind: row.itemKind,
+      parentToolCallId: row.parentToolCallId,
+      providerThreadId: row.providerThreadId,
+      scope:
+        row.turnId === null
+          ? { kind: "thread" }
+          : { kind: "turn", turnId: row.turnId },
+      threadId: args.targetThreadId,
+      type: row.type,
+    });
+    if (event !== null) {
+      upsertThreadSearchSegments(db, {
+        updatedAt: now,
+        segments: listThreadSearchSegmentsForThreadEvent({
+          event,
+          sequence,
+        }),
+      });
+    }
+    sequence += 1;
+  }
+  return args.rows.length;
+}
+
 export function appendStoredThreadEventInTransaction<
   TType extends ThreadEventType,
 >(db: DbTransaction, args: AppendStoredThreadEventArgs<TType>): number;
@@ -1076,6 +1149,23 @@ export interface ListStoredClientTurnRequestIdsInRangeArgs {
 
 export interface GetStoredTurnRequestEventForTurnArgs {
   threadId: string;
+  turnId: string;
+}
+
+export interface FindLastRootStoredTurnStartedArgs {
+  /** Inclusive upper bound on the turn/started sequence; absent means the whole thread. */
+  atOrBeforeSequence?: number;
+  threadId: string;
+}
+
+export interface StoredTurnStartedKey {
+  sequence: number;
+  turnId: string;
+}
+
+export interface CompletedRootStoredTurn {
+  completedSequence: number;
+  startedSequence: number;
   turnId: string;
 }
 
@@ -2401,6 +2491,82 @@ export function hasRootStoredTurnStarted(
   return row !== undefined;
 }
 
+/**
+ * The latest root (non-nested) turn that has both started at or before a
+ * sequence and completed, or the thread's latest completed root turn when no
+ * bound is given. Nested turns record `parentToolCallId` only on
+ * `turn/started`, so the completion is found through the start.
+ */
+export function findLastCompletedRootStoredTurn(
+  db: DbQueryConnection,
+  args: FindLastRootStoredTurnStartedArgs,
+): CompletedRootStoredTurn | null {
+  const completed = alias(events, "completed");
+  const row = db
+    .select({
+      completedSequence: completed.sequence,
+      startedSequence: events.sequence,
+      turnId: events.turnId,
+    })
+    .from(events)
+    .innerJoin(
+      completed,
+      and(
+        eq(completed.threadId, events.threadId),
+        eq(completed.turnId, events.turnId),
+        eq(completed.type, "turn/completed"),
+      ),
+    )
+    .where(
+      and(
+        eq(events.threadId, args.threadId),
+        eq(events.type, "turn/started"),
+        isRootTurnStartedEventData,
+        args.atOrBeforeSequence === undefined
+          ? undefined
+          : lte(events.sequence, args.atOrBeforeSequence),
+      ),
+    )
+    .orderBy(desc(events.sequence), desc(completed.sequence))
+    .limit(1)
+    .get();
+  return row?.turnId
+    ? {
+        completedSequence: row.completedSequence,
+        startedSequence: row.startedSequence,
+        turnId: row.turnId,
+      }
+    : null;
+}
+
+/**
+ * The latest root (non-nested) turn/started at or before a sequence, or the
+ * thread's latest root turn when no bound is given. Null when no root turn has
+ * started in that range.
+ */
+export function findLastRootStoredTurnStarted(
+  db: DbQueryConnection,
+  args: FindLastRootStoredTurnStartedArgs,
+): StoredTurnStartedKey | null {
+  const row = db
+    .select({ sequence: events.sequence, turnId: events.turnId })
+    .from(events)
+    .where(
+      and(
+        eq(events.threadId, args.threadId),
+        eq(events.type, "turn/started"),
+        isRootTurnStartedEventData,
+        args.atOrBeforeSequence === undefined
+          ? undefined
+          : lte(events.sequence, args.atOrBeforeSequence),
+      ),
+    )
+    .orderBy(desc(events.sequence))
+    .limit(1)
+    .get();
+  return row?.turnId ? { sequence: row.sequence, turnId: row.turnId } : null;
+}
+
 export function listRecentStoredEventRows(
   db: DbConnection,
   args: ListRecentStoredEventRowsArgs,
@@ -3139,27 +3305,6 @@ export function getLastStoredProviderThreadId(
   // before the next turn is dispatched through `thread/resume` with the new
   // workspace path, so keep the last provider id available across the switch.
   return latestProviderRow.providerThreadId;
-}
-
-export function getStoredProviderThreadIdAtOrBeforeSequence(
-  db: DbQueryConnection,
-  args: {
-    sequence: number;
-    threadId: string;
-  },
-): string | null {
-  const row = db
-    .select({ providerThreadId: events.providerThreadId })
-    .from(events)
-    .where(
-      sql`${events.threadId} = ${args.threadId}
-        AND ${events.sequence} <= ${args.sequence}
-        AND ${events.providerThreadId} IS NOT NULL`,
-    )
-    .orderBy(sql`${events.sequence} DESC`)
-    .limit(1)
-    .get();
-  return row?.providerThreadId ?? null;
 }
 
 export function listThreadTurnInterruptionEventStates(

--- a/packages/db/src/data/index.ts
+++ b/packages/db/src/data/index.ts
@@ -229,6 +229,9 @@ export {
 export {
   appendDaemonEventsInTransaction,
   appendStoredThreadEvent,
+  copyStoredThreadEventsInTransaction,
+  findLastCompletedRootStoredTurn,
+  findLastRootStoredTurnStarted,
   appendStoredThreadEventsInTransaction,
   deleteThreadEventSuffixInTransaction,
   getHighWaterMarks,
@@ -237,7 +240,6 @@ export {
   hasRootStoredTurnStarted,
   hasStoredTurnStarted,
   getLastStoredProviderThreadId,
-  getStoredProviderThreadIdAtOrBeforeSequence,
   getLastStoredTurnRequestEvent,
   getStoredTurnRequestEventForTurn,
   getLatestThreadOutputEventRow,

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -375,8 +375,15 @@ const threadStartCommandSchema = hostDaemonThreadTargetSchema
     inputGroups: z.array(z.array(promptInputSchema).min(1)).min(1).optional(),
     threadStoragePath: z.string().min(1).optional(),
     /** Present means fork the new thread from this source provider session
-     *  instead of starting fresh; absent means a normal start. */
-    fork: z.object({ sourceProviderThreadId: z.string().min(1) }).optional(),
+     *  instead of starting fresh; absent means a normal start. The clone
+     *  retains the source history through `sourceProviderCheckpointId`; an
+     *  absent checkpoint clones the session tip. */
+    fork: z
+      .object({
+        sourceProviderThreadId: z.string().min(1),
+        sourceProviderCheckpointId: z.string().min(1).optional(),
+      })
+      .optional(),
   })
   .strict()
   .superRefine((value, ctx) => {

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,9 @@
+// Version 153 adds the optional `sourceProviderCheckpointId` to
+// `thread.start.fork`. A fork requested at an earlier source sequence now
+// clones the source session through that turn's recorded checkpoint instead
+// of silently cloning the tip. An older daemon would strip the field and
+// clone the tip, so it must update before it serves such a start.
+//
 // Version 152 records a displayed Pi extension message (`pi.sendMessage` with
 // `triggerTurn`, e.g. a process-completion notification) as the `userMessage`
 // item of the turn it woke, and stops surfacing its `message_start`/
@@ -166,7 +172,7 @@
 //
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 152 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 153 as const;
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -749,6 +749,8 @@ const INTENTIONAL_OPTIONAL_HOST_DAEMON_FIELDS: Record<string, string> = {
     "thread.start may include a storage path so the daemon creates the directory before the agent starts.",
   "hostDaemonCommandSchema.fork":
     "thread.start omits fork unless the new thread should clone an existing provider session; absent means a normal start.",
+  "hostDaemonCommandSchema.fork.sourceProviderCheckpointId":
+    "thread.start.fork names a checkpoint only when the clone should stop at an earlier source turn; absent means clone the session tip.",
   "hostDaemonCommandSchema.inputGroups":
     "thread.start and turn.submit omit inputGroups for ordinary single user-message turns; presence preserves grouped user messages within one turn.",
   "hostDaemonCommandSchema.disallowedTools":
@@ -1131,7 +1133,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(152);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(153);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/packages/server-contract/src/api/threads.ts
+++ b/packages/server-contract/src/api/threads.ts
@@ -167,6 +167,12 @@ const agentOnlyPromptInputSchema = promptInputSchema.and(
 export const forkThreadRequestSchema = z
   .object({
     sourceThreadId: z.string().min(1),
+    /**
+     * Anchor the fork on the completed source turn containing this sequence:
+     * the cloned provider session and the inherited timeline both end with
+     * that turn (a user message row anchors before its own turn). Absent
+     * forks the session tip and inherits every completed turn.
+     */
     sourceSeqEnd: z.number().int().nonnegative().optional(),
     input: z.array(promptInputSchema).min(1).optional(),
     /** Context persisted on the fork start but hidden from user-facing output. */

--- a/packages/templates/src/templates/bb-guide-threads.md
+++ b/packages/templates/src/templates/bb-guide-threads.md
@@ -34,7 +34,7 @@ Spawning:
     --image <path>                 Host-readable absolute or uploaded image path
     --origin-kind <kind>           Create a fork thread
     --source-thread <id>           Source thread for a fork
-    --source-seq-end <seq>         Last included source event sequence
+    --source-seq-end <seq>         Fork after the source turn containing this event sequence
 
   Execution defaults resolve from explicit flags, live parent execution, and
   remembered project defaults. With no remembered model, bb uses the explicitly
@@ -65,7 +65,7 @@ Forking:
   bb thread fork <source-thread-id> [options]
 
     --prompt <prompt>              Optional first prompt; omit for an idle fork
-    --source-seq-end <seq>         Fork at this source event sequence (tip by default)
+    --source-seq-end <seq>         Fork after the source turn containing this event sequence (tip by default)
     --workspace <mode>             isolated (default) or reuse
     --title <title>                Thread title
     --permission-mode <mode>       Inherit source by default; accepts accept-edits, auto, full
@@ -74,7 +74,13 @@ Forking:
     --file <path>                  Host-readable absolute or uploaded file path
     --image <path>                 Host-readable absolute or uploaded image path
 
-  Forks clone the source provider session on the same machine. Isolated forks
+  Forks clone the source provider session on the same machine and inherit the
+  source conversation in their timeline. --source-seq-end anchors the fork on
+  the completed source turn that contains that sequence: the clone and the
+  inherited timeline both end with that turn (an anchor on a user message
+  branches before it, like editing it). Without it a fork clones the session
+  tip and inherits every completed turn. Providers that can only clone a whole
+  session accept an anchor only on the source's latest turn. Isolated forks
   create a fresh managed worktree (or personal workspace for personal threads);
   reuse attaches the source environment. Omit --prompt to create an idle fork.
 

--- a/scripts/provider-literal-baseline.json
+++ b/scripts/provider-literal-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Provider-literal ratchet (G1). Per-file occurrence count of provider-ID references in core. May only go DOWN. Regenerate: node scripts/check-provider-literal-ratchet.mjs --write. Delete this file and the guard when empty.",
-  "total": 148,
+  "total": 147,
   "files": {
     "apps/app/src/components/tools/SkillsCollection.tsx": 3,
     "apps/app/src/lib/provider-icon.ts": 15,
@@ -19,7 +19,7 @@
     "apps/server/src/services/skills/skill-listing.ts": 3,
     "apps/server/src/services/system/provider-bridge-launch.ts": 5,
     "apps/server/src/services/threads/provider-command-typeahead.ts": 2,
-    "apps/server/src/services/threads/thread-edit-message.ts": 2,
+    "apps/server/src/services/threads/thread-edit-message.ts": 1,
     "packages/agent-runtime/src/bridge-protocol-adapter.ts": 1,
     "packages/agent-runtime/src/pi/bridge/model-list.ts": 1,
     "packages/agent-runtime/src/provider-catalog.ts": 2,


### PR DESCRIPTION
## What was wrong

A forked thread came up with an empty timeline (#1500, report: https://get-bb.github.io/reports/issues/1500.html). The provider cloned the source session, so the model held the whole conversation, but nothing in the fork path (`thread-fork.ts` -> `thread-create.ts` `resolveForkDescriptor` -> `thread.start{fork}`) ever wrote that conversation into the fork's events, and the timeline is a projection of a thread's own events. The same path also ignored `sourceSeqEnd` for the model: it only looked up which provider session was current at that sequence (`getProviderThreadIdAtOrBeforeSequence`) and never mapped it to the `providerCheckpointId` recorded on that turn's `turn/completed`. `thread.start.fork` had no checkpoint field, so pi, claude-code, and codex always cloned the session tip regardless of the requested anchor, and the app's per-message Fork button and `bb thread fork --source-seq-end` promised a branch point they did not deliver.

## What changed

- `apps/server/src/services/threads/thread-fork-history.ts` (new): resolves a fork point. With `sourceSeqEnd` the anchor is the completed root turn that contains the sequence (or the last one before it, so a user-message row anchors before its own turn, like editing it). The point carries the session to clone, that turn's checkpoint (`resolveTurnProviderCheckpointId`, shared with edit-message including the legacy codex turn-id fallback), and the sequence of its `turn/completed`. It rejects with 400 `fork_source_session_unavailable` when the anchor is before the first turn, inside a turn that has not completed, has no checkpoint, or is earlier than the latest turn on a provider without `supportsSessionRewind` (tip-only, e.g. ACP) instead of silently forking the tip.
- Tip forks (no `sourceSeqEnd`) inherit every completed root turn. When the source is idle the fork clones the session tip. When the source is mid-turn, its session tip already holds the running turn's prompt and partial output while the inherited timeline stops at the last completed turn, so a checkpoint-capable provider now clones through that last completed turn's checkpoint instead; tip-only providers keep the tip clone. This addresses the reviewer's point that model context and timeline diverged in that window.
- `thread-create.ts`: a visible fork copies the source's conversation rows (`client/turn/requested` with its acceptance, `turn/started`, `turn/input/accepted`, `item/completed`, `item/backgroundTask/completed`, `turn/completed`, `thread/compacted`, `system/manager/user_message`) through that sequence into the fork before its own thread-start rows, so inherited history takes the lowest sequences. Only turns that completed inside the window come along. Copied rows keep their payload and `created_at`, take fresh ids and sequences, index search segments, and carry a null `provider_thread_id` column so the fork's live session stays the one its own `thread/identity` names. Hidden forks (side chats, plugin workers rendered by their owner next to the source) still clone the session but keep their own timeline empty; this also keeps the side-chat plugin's empty-fork sweep from seeing inherited user messages as user work.
- Side-chat behavior change (plugin code untouched): the plugin passes the anchored message's `sourceSeqEnd` to `threads.fork`. On main that anchor only chose a provider session id, so pi/claude-code/codex side chats always cloned the tip. Now a side chat anchored on an earlier completed turn gets a checkpoint fork whose model context ends at that turn, which is what the plugin's own comments describe. An anchor inside a running turn, or an earlier turn on a tip-only (ACP) provider, returns `fork_source_session_unavailable`, which the plugin already handles by falling back to a tip fork (`plugins/side-chat/server.ts`, covered by its existing tests).
- `packages/db/src/data/events.ts`: `copyStoredThreadEventsInTransaction`, `findLastRootStoredTurnStarted`, `findLastCompletedRootStoredTurn`; removes the now-unused `getStoredProviderThreadIdAtOrBeforeSequence`. The row copy reads the selected source rows into memory once (one bounded typed query per inherited type) because each copy is re-parsed to index search segments; the in-memory filter only drops the few rows of turns or queued requests still open at the window's end. Large source threads pay that memory and duplicate storage per fork.
- Wire: `thread.start.fork.sourceProviderCheckpointId?: string` in `@bb/host-daemon-contract` (absent = tip, matching the bridge protocol's `thread/fork`), forwarded by `packages/agent-runtime/src/runtime.ts` to the adapter's `thread/fork`. **`HOST_DAEMON_PROTOCOL_VERSION` 152 -> 153** (146 -> 147, then 151 -> 152, before two rebases onto a moving main). An older daemon would strip the field and clone the tip.
- `thread-edit-message.ts`: uses the shared `resolveTurnProviderCheckpointId` instead of its inline codex fallback (no behavior change).
- CI guard (provider-literal ratchet): `resolveTurnProviderCheckpointId` stays in `thread-edit-message.ts` as an export and `thread-fork-history.ts` imports it from there, instead of moving it into `thread-events.ts`, which would have given that file a new `"codex"` literal; `scripts/provider-literal-baseline.json` is regenerated for the resulting decrease (`thread-edit-message.ts` 2 -> 1, total 148 -> 147).
- Docs/CLI: `--source-seq-end` help text in `bb thread fork` / `bb thread spawn`, `bb-guide-threads.md`, the bb-cli SKILL, `docs/provider-bridge-protocol.md`, and the `forkThreadRequestSchema.sourceSeqEnd` doc now describe the turn-anchored semantics.

Deviation from the issue: the issue also floats an `events.append` / "adopt session" SDK API (#1028). Not done here; copying at fork time covers the fork case with no new plugin surface. The choice to skip history for hidden forks is a server policy decision; an explicit request knob can be added later if a hidden fork ever needs inherited history.

Revision after review: `copyForkSourceHistory` was declared `: number` with a bare `return;`, which failed `@bb/server` typecheck and the CI Checks job; it returns `void` now (its caller never read the count). The mid-turn tip fork behavior above is new in this revision. Rebased onto current main (resolved against #2140's dead-code removal in `@bb/db` and `thread-create.ts`).

## How you verified

New tests in `apps/server/test/public/public-thread-fork.test.ts` ("fork branch point and inherited history": checkpoint + inherited conversation for an anchor on an assistant message, a user-message anchor branching before its turn, idle tip fork inheriting every completed turn, mid-turn tip fork branching at the last completed turn's checkpoint with nothing of the running turn, a mid-turn tip fork on a tip-only provider cloning the tip, hidden fork inheriting nothing, rejections for running-turn/pre-first-turn anchors, tip-only provider accepting only its latest turn) plus checkpoint assertions in `thread-create-seed-without-run.test.ts` and `public-thread-fork.test.ts`'s existing fork-point test.

Fail before (the 14 non-test source files checked out from `origin/main`, new module removed, tests from this branch): 10 failed, e.g.

```
AssertionError: expected { Object (sourceProviderThreadId) } to deeply equal { …(2) }
AssertionError: expected [] to deeply equal [ 'Reply only with ok.', 'ok', …(2) ]
AssertionError: expected 201 to be 400 // Object.is equality
```

Pass after, on the rebased head: `pnpm exec turbo run typecheck` for server, agent-runtime, host-daemon-contract, db, host-daemon, sdk, cli, server-contract, templates green (12/12 tasks). `pnpm exec turbo run lint` green. `pnpm exec turbo run test --filter=@bb/server`: 1829 passed, 2 failed, both unrelated (the known local umask-only `internal-skill-trees` 0644-vs-0664 assertion, and a 5s timeout in `plugin-update.test.ts` under parallel load that passes alone, 27/27). `@bb/host-daemon` 551, `@bb/agent-runtime` 418, `@bb/cli` 453, `@bb/host-daemon-contract` 52, `@bb/server-contract` 58, `@bb/db` 405, `@bb/templates` 41, `bb-plugin-side-chat` 29, all passed.

Manual repro on an own dev instance with the pi provider on the rebased head (two cheap turns "ok" / "second"; `turn/completed` at seq 15 recorded checkpoint `32261d5c`):

- `bb thread fork <src> --workspace reuse` -> `bb thread log` shows all four inherited messages.
- `bb thread fork <src> --workspace reuse --source-seq-end 13` (turn 1's assistant message) -> log shows "Reply only with ok." / "ok" only; the fork's pi session file has `parentSession=<src>` and only turn 1's user and assistant entries (checkpoint inclusive).
- `--source-seq-end 3` -> `HTTP 400: Cannot fork at sequence 3: no turn has started at or before it`.
- Mid-turn: started a third turn that runs `sleep 40`, forked at the tip while `turn/started`=3 and `turn/completed`=2. The fork's log shows the four completed messages; its pi session file has `parentSession=<src>` and only turns 1-2, while the source's session already held turn 3's prompt and its bash tool call.

Fixes #1500

> AGENT GENERATED: by Claude Opus 5



## Independent verification

Verified round 2 at head `96289f260` (origin/main `f6fb434ab` is an ancestor; no rebase needed) in a separate worktree with its own dev instance (ports 13662/21662/29662).

Commands:

- `git checkout origin/main -- <11 non-test source files>` + remove `thread-fork-history.ts`, then `pnpm exec vitest run test/public/public-thread-fork.test.ts test/threads/thread-create-seed-without-run.test.ts` from `apps/server`: **10 failed / 30 passed**. Failing assertions: `expected { Object (sourceProviderThreadId) } to deeply equal { …(2) }`, `expected [] to deeply equal [ 'Reply only with ok.', 'ok', …(2) ]`, `expected 201 to be 400`, `expected undefined to be 'checkpoint-after-turn-1'`.
- `git checkout HEAD -- <same files>`, same command: **40 passed**.
- `pnpm exec turbo run typecheck` for `@bb/server`, `agent-runtime`, `host-daemon-contract`, `db`, `host-daemon`, `sdk`, `cli`, `server-contract`, `templates`, `app`: `Tasks: 13 successful, 13 total`.
- `pnpm exec turbo run test --force` for `@bb/server`, `db`, `host-daemon-contract`, `agent-runtime`, `server-contract`, `cli`, `templates`, `host-daemon`, `bb-plugin-side-chat`: 14/15 tasks green; `@bb/server` 1830 passed / 1 failed, the failure being the known local umask-only `internal-skill-trees` mode 0644-vs-0664 assertion (unrelated, passes in CI).
- CI (`gh pr checks 2142`): all jobs pass (Checks, Package Smoke x2, Tests app-1/2/3, integration, packages, server).

Live repro on the fixed branch (pi provider, source thread with two turns "ok"/"second", turn 1 `turn/completed` at seq 15 with checkpoint `9f0ee844`):

- `bb thread fork <src> --workspace reuse`: timeline has all four conversation rows; fork events are the 10 inherited rows (null `provider_thread_id` column, payload keeps the source session id) followed by the fork's own `client/turn/requested`, `client/thread/start`, `thread/identity`, provisioning.
- `--source-seq-end 13` (turn 1's assistant message): timeline shows "Reply only with ok." / "ok" only; the fork's pi session file has `parentSession=<src>` and only turn 1's two entries.
- `--source-seq-end 3`: `HTTP 400: Cannot fork at sequence 3: no turn has started at or before it`.
- Mid-turn (turn 3 running `sleep 45`): tip fork inherits turns 1-2 only and its pi session holds turns 1-2 while the source's already holds turn 3's prompt; `sourceSeqEnd: 28` (inside the running turn) returns 400 `fork_source_session_unavailable`.
- After turn 3 (with a `commandExecution` tool call) completed, a tip fork renders the inherited tool-call turn as a completed "Worked for" group in both `/timeline` and `bb thread log`; no crash on `item/completed` rows without `item/started`.
- Browser (headless Chrome): the seq-13 fork page renders the inherited user/assistant rows plus the "Forked from" chip.

Residual risks: wire change needs enrolled daemons on protocol 147 (older daemons would strip the checkpoint and clone the tip); checkpoint forks on claude-code/codex reuse the rewind path's checkpoint ids but were not live-tested here (pi was); side chats anchored on an earlier completed turn now get a checkpoint fork rather than a tip clone; `findLastCompletedRootStoredTurn` accepts an `atOrBeforeSequence` bound no caller passes (minor dead parameter). Hidden forks inherit no history by server policy.

> AGENT GENERATED: by Claude Opus 5

## Stack

Layer 2/2 of GitHub stack #2217 (`gh stack`), depends on #2154 (layer 1/2, protocol 151). Base is `bb/fix-1681-pi-notification-wake`; `HOST_DAEMON_PROTOCOL_VERSION` 152. After #2154 merges, GitHub retargets this PR to `main`. Rebased onto #2154's head (itself on main at `75d6fc4d4`): conflicts were `protocol.ts`, `contract.test.ts`, and `docs/provider-bridge-protocol.md` (kept main's rewritten open-work note and this PR's fork note side by side); the two review-round commits are squashed into one. Re-verified on the new base: the fork tests fail with the 14 non-test source files checked out from the base (`9 failed`, e.g. `expected { Object (sourceProviderThreadId) } to deeply equal { …(2) }`, `expected [] to deeply equal [ 'Reply only with ok.', 'ok', …(2) ]`, `expected 201 to be 400`) and pass on this head; `turbo run typecheck test` for host-daemon-contract, host-daemon, agent-runtime, server, db, server-contract, cli and templates is green except the known local-only umask `internal-skill-trees` assertion.

> AGENT GENERATED: by Claude Opus 5



## Independent verification (guards)

Re-verified head `d811c206c` (protocol 152, base `bb/fix-1681-pi-notification-wake` at `bdf47388f`, itself on `origin/main` `27d1017fe`) after the CI-guard amendments, in a separate worktree.

- Guard fix is mechanical: `git range-diff e5224760d~1..e5224760d origin/bb/fix-1681-pi-notification-wake..HEAD` shows only (a) `resolveTurnProviderCheckpointId` + `CODEX_NATIVE_TURN_ID_PATTERN` moved verbatim from `thread-events.ts` to an export in `thread-edit-message.ts`, (b) `thread-fork-history.ts` importing it from `./thread-edit-message.js`, and (c) `scripts/provider-literal-baseline.json` `thread-edit-message.ts` 2 -> 1, total 148 -> 147. The bottom layer's range-diff shows only the `@get-bb/plugin-sdk` 0.4.11 -> 0.4.12 bump (`packages/plugin-sdk/package.json`, `packages/domain/src/plugin-sdk-version.ts`). Everything else in `git diff e5224760d HEAD --stat` is the four unrelated main commits picked up by the rebase.
- No import cycle from the move: `thread-create.ts -> thread-fork-history.ts -> thread-edit-message.ts`, and none of `thread-edit-message.ts`'s local imports (`thread-send`, `thread-turn-dispatch`, `thread-lifecycle`, `thread-commands`, `thread-runtime-config`, `thread-data`, `thread-events`) import `thread-create` or `thread-fork*`.
- `node scripts/check-provider-literal-ratchet.mjs`: `Provider-literal ratchet OK: 147 references across 40 core files.`
- Fail-before: `git checkout origin/bb/fix-1681-pi-notification-wake -- <17 non-test source files>` + `thread-fork-history.ts` removed, then `vitest run test/public/public-thread-fork.test.ts test/threads/thread-create-seed-without-run.test.ts` in `@bb/server`: **10 failed / 30 passed** (`expected [] to deeply equal [ 'Reply only with ok.', 'ok', …(2) ]`, `expected { Object (sourceProviderThreadId) } to deeply equal { …(2) }`, `expected 201 to be 400`, `expected undefined to be 'checkpoint-after-turn-1'`).
- Pass-after: `git checkout HEAD -- .`, same command: **40 passed**.
- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/host-daemon-contract`: `Tasks: 5 successful, 5 total`; `@bb/host-daemon-contract` `contract.test.ts`: 38 passed.
- CI: `gh pr checks 2142` all pass on run `32508211062` (head_sha `d811c206c`): Checks, Package Smoke x2, Tests app-1/2/3, integration, packages, server. `mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`. #2154 (bottom layer) is also fully green and CLEAN on `main`.
- Live repro was not re-run for this guard-only pass; the earlier round's pi-provider repro on the same logic stands (the moved helper's body is byte-identical).


## Rebase (2026-08-21, second)

Rebased onto #2154's new head `9e632c399`. `main` took protocol **151** (#2242), which pushed #2154 to **152**, so this layer is renumbered **152 -> 153**: its comment block sits above #2154's 152 block and the lockstep assertion in `contract.test.ts` moves to `toBe(153)`. `protocol.ts` was the only conflict; the SDK version files no longer appear in the stack's diff, because both layers now adopt main's unpublished `0.4.13`.

Re-verified on the new base: `node scripts/check-provider-literal-ratchet.mjs --base <#2154 head>` -> `OK: 147 references across 40 core files` (the helper stays in `thread-edit-message.ts`). `turbo run typecheck` for cli, server, agent-runtime, db, host-daemon-contract, server-contract, templates: `Tasks: 10 successful, 10 total`. `turbo run test` for the same set: server-contract 7/7 files, host-daemon-contract 3/3, db 28/28, agent-runtime 31/31, cli 48/48, templates 6/6, server 200 passed / 1 skipped with only the known local-only umask failure `internal-skill-trees` (0644 vs 0664 under umask 0002), which passes in CI.

Stack #2217 is unchanged: base is still `bb/fix-1681-pi-notification-wake`, and GitHub retargets this PR to `main` when #2154 merges.

> AGENT GENERATED: by Claude Opus 5

