### PR TITLE
Omit a null hostId from thread tabs responses so older mobile builds still sync

### DIFF
--- a/apps/server/src/routes/threads/tabs.ts
+++ b/apps/server/src/routes/threads/tabs.ts
@@ -4,12 +4,48 @@ import {
   threadTabsSchema,
   typedRoutes,
   type PublicApiSchema,
+  type ThreadTab,
   type ThreadTabsResponse,
+  type ThreadTabsWireResponse,
 } from "@bb/server-contract";
 import type { Hono } from "hono";
 import { ApiError } from "../../errors.js";
 import { requirePublicThread } from "../../services/lib/entity-lookup.js";
 import type { AppDeps } from "../../types.js";
+
+type WireThreadTab = ThreadTabsWireResponse["tabs"][number];
+
+/**
+ * Omit `hostId` from the wire when it is `null`. The field arrived with a
+ * `.default(null)` after mobile builds had already shipped a `.strict()` copy
+ * of this schema, and installed apps cannot update with the server: an
+ * unknown key makes their SDK reject every tabs response, and the panel
+ * stops syncing ("Couldn't sync tabs"). Current clients parse the omission
+ * back to `null` through the default, so nothing is lost on the wire.
+ */
+function toWireThreadTab(tab: ThreadTab): WireThreadTab {
+  if (tab.kind === "host-file-preview") {
+    const { hostId, ...rest } = tab;
+    return hostId === null ? rest : tab;
+  }
+  if (
+    tab.kind === "plugin-panel" &&
+    tab.fileOpenerOwner?.kind === "host-file-preview"
+  ) {
+    const { hostId, ...owner } = tab.fileOpenerOwner;
+    return hostId === null ? { ...tab, fileOpenerOwner: owner } : tab;
+  }
+  return tab;
+}
+
+function toWireThreadTabsResponse(
+  response: ThreadTabsResponse,
+): ThreadTabsWireResponse {
+  return {
+    revision: response.revision,
+    tabs: response.tabs.map(toWireThreadTab),
+  };
+}
 
 function readThreadTabs(deps: AppDeps, threadId: string): ThreadTabsResponse {
   const stored = getStoredThreadTabs(deps.db, threadId);
@@ -33,7 +69,9 @@ export function registerThreadTabRoutes(app: Hono, deps: AppDeps): void {
 
   get(routes.tabs, (context) => {
     const thread = requirePublicThread(deps.db, context.req.param("id"));
-    return context.json(readThreadTabs(deps, thread.id));
+    return context.json(
+      toWireThreadTabsResponse(readThreadTabs(deps, thread.id)),
+    );
   });
 
   put(routes.updateTabs, (context, payload) => {
@@ -52,6 +90,11 @@ export function registerThreadTabRoutes(app: Hono, deps: AppDeps): void {
       );
     }
     deps.hub.notifyThread(thread.id, ["tabs-changed"]);
-    return context.json({ revision: result.revision, tabs: payload.tabs });
+    return context.json(
+      toWireThreadTabsResponse({
+        revision: result.revision,
+        tabs: payload.tabs,
+      }),
+    );
   });
 }

--- a/apps/server/test/public/public-thread-tabs.test.ts
+++ b/apps/server/test/public/public-thread-tabs.test.ts
@@ -132,6 +132,69 @@ describe("public thread tabs", () => {
     });
   });
 
+  it("omits a null hostId on the wire so strict older clients still parse", async () => {
+    await withTestHarness(async (harness) => {
+      const { thread } = seedThreadFixture(harness);
+      const tabs: readonly ThreadTab[] = [
+        {
+          environmentId: "env_1",
+          hostId: null,
+          id: "host-file-default",
+          kind: "host-file-preview",
+          lineRange: null,
+          path: "/tmp/default.png",
+          threadId: thread.id,
+        },
+        {
+          environmentId: null,
+          hostId: "host_1",
+          id: "host-file-explicit",
+          kind: "host-file-preview",
+          lineRange: null,
+          path: "/tmp/explicit.png",
+          threadId: null,
+        },
+        {
+          actionId: "inspect",
+          fileOpenerOwner: {
+            environmentId: "env_1",
+            hostId: null,
+            kind: "host-file-preview",
+            tab: { lineRange: null, path: "/tmp/owned.png" },
+            threadId: thread.id,
+          },
+          id: "plugin-panel",
+          kind: "plugin-panel",
+          paramsJson: null,
+          pluginId: "example",
+          title: "Inspector",
+        },
+      ];
+
+      const updateResponse = await putTabs(harness, thread.id, {
+        expectedRevision: 0,
+        tabs,
+      });
+      expect(updateResponse.status).toBe(200);
+      const getResponse = await getTabs(harness, thread.id);
+      expect(getResponse.status).toBe(200);
+
+      for (const body of [
+        await readJson(updateResponse),
+        await readJson(getResponse),
+      ]) {
+        const wire = body as {
+          tabs: Array<Record<string, unknown> & { fileOpenerOwner?: object }>;
+        };
+        expect(wire.tabs[0]).not.toHaveProperty("hostId");
+        expect(wire.tabs[1]).toHaveProperty("hostId", "host_1");
+        expect(wire.tabs[2]?.fileOpenerOwner).not.toHaveProperty("hostId");
+        // Current clients still read the omission back as null.
+        expect(threadTabsResponseSchema.parse(body).tabs).toEqual(tabs);
+      }
+    });
+  });
+
   it("rejects duplicate tab ids and unknown threads", async () => {
     await withTestHarness(async (harness) => {
       const { thread } = seedThreadFixture(harness);

--- a/packages/server-contract/src/api/thread-tabs.ts
+++ b/packages/server-contract/src/api/thread-tabs.ts
@@ -204,6 +204,11 @@ export const threadTabsResponseSchema = z
   })
   .strict();
 export type ThreadTabsResponse = z.infer<typeof threadTabsResponseSchema>;
+/**
+ * The JSON the tabs routes send: defaulted fields (`hostId`) may be absent.
+ * Clients parse it with `threadTabsResponseSchema`, which fills them in.
+ */
+export type ThreadTabsWireResponse = z.input<typeof threadTabsResponseSchema>;
 
 export const updateThreadTabsRequestSchema = z
   .object({

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -211,7 +211,7 @@ import type {
   WorkspacePathListResponse,
 } from "./api-types.js";
 import type {
-  ThreadTabsResponse,
+  ThreadTabsWireResponse,
   UpdateThreadTabsRequest,
 } from "./api/thread-tabs.js";
 import { updateThreadTabsRequestSchema } from "./api/thread-tabs.js";
@@ -1106,7 +1106,7 @@ export const publicApiRoutes = {
       path: "/threads/:id/tabs",
       method: "get",
       request: noRequest<PathId>(),
-      response: jsonResponse<ThreadTabsResponse>(),
+      response: jsonResponse<ThreadTabsWireResponse>(),
     }),
     updateTabs: defineRoute({
       path: "/threads/:id/tabs",
@@ -1115,7 +1115,7 @@ export const publicApiRoutes = {
         updateThreadTabsRequestSchema,
       ),
       response: [
-        jsonResponse<ThreadTabsResponse>(),
+        jsonResponse<ThreadTabsWireResponse>(),
         jsonResponse<ApiError>({ status: 409 }),
       ],
     }),


### PR DESCRIPTION
## What was wrong

Image links in the mobile app failed with a "Couldn't sync tabs" toast. The links and the image routes were fine. A tap opens a `host-file-preview` panel tab, and the app then syncs the tab strip with `GET`/`PUT /threads/:id/tabs`. #2005 added `hostId` to `host-file-preview` tabs with `.default(null)`, so the server now emits `hostId: null` in every tabs response. Installed mobile builds bundle a `.strict()` copy of `threadTabsResponseSchema` that predates the field, so their SDK rejects the whole response (`Unrecognized key: hostId`), the mutation errors, and the tab never settles. Phones cannot update in step with the server, so the server must stay readable by the shipped schema.

## What changed

- `apps/server/src/routes/threads/tabs.ts`: the GET and PUT responses omit `hostId` when it is `null`, on `host-file-preview` tabs and on `host-file-preview` file-opener owners of plugin-panel tabs. A non-null `hostId` still travels. Current clients parse the omission back to `null` through the schema default.
- `packages/server-contract`: added `ThreadTabsWireResponse` (`z.input` of the response schema) and typed both tabs routes with it.

No daemon wire change, so no `HOST_DAEMON_PROTOCOL_VERSION` bump.

## How you verified

- New test in `apps/server/test/public/public-thread-tabs.test.ts` that fails before the route change (`expected … to not have property "hostId"`) and passes after it.
- `pnpm exec turbo run test --filter=@bb/server -- test/public/public-thread-tabs.test.ts`: 3/3 pass. `@bb/server-contract` tests: 58/58 pass.
- `pnpm exec turbo run typecheck` for `@bb/server`, `@bb/sdk`, `@bb/app`, `@bb/mobile`, `@bb/demo-server`: pass.
- Manual: paired the iOS simulator with the live `bee.getbb.app` server on a current Metro bundle; storage and host-file image links open the panel tab and the lightbox.

Fixes #

> AGENT GENERATED: by Claude Opus 5
