### PR TITLE
fix(acp): resolve dynamic-tool MCP entry from module URL, not argv[1]

### DIFF
--- a/packages/agent-runtime/src/acp/bridge/bridge.test.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.test.ts
@@ -1117,6 +1117,55 @@ describe("acp bridge", () => {
     );
   });
 
+  it("resolves the MCP server entry point from the module URL, not argv[1]", async () => {
+    // Packaged builds execute this code inside bb-provider-bridge-worker.mjs;
+    // argv[1] must not leak into the MCP server command handed to the agent.
+    vi.stubGlobal("process", {
+      ...process,
+      argv: [process.argv[0]!, "/bogus/bb-provider-bridge-worker.mjs"],
+      execArgv: [],
+    });
+    try {
+      const { providerThreadId } = await startThread({
+        dynamicTools: [
+          {
+            name: "update_environment_directory",
+            description: "Move this thread to another environment directory.",
+            inputSchema: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+            },
+          },
+        ],
+      });
+
+      const turnId = sendRequest("turn/start", {
+        threadId: providerThreadId,
+        input: [{ type: "text", text: "echo-mcp-server-config", mentions: [] }],
+      });
+      await waitForResponse(turnId);
+      await waitForTurnCompleted();
+
+      const configPrefix = "mcp-server-config:";
+      const configText = agentMessageTexts().find((text) =>
+        text.startsWith(configPrefix),
+      );
+      if (!configText) {
+        throw new Error("Fake ACP agent did not report MCP server config");
+      }
+      const [mcpServerConfig] = JSON.parse(
+        configText.slice(configPrefix.length),
+      ) as { args: string[] }[];
+      expect(mcpServerConfig?.args.at(-1)).toBe("--mcp-stdio");
+      const entryPoint = mcpServerConfig?.args.at(-2) ?? "";
+      expect(entryPoint).not.toBe("/bogus/bb-provider-bridge-worker.mjs");
+      expect(entryPoint.endsWith("bridge.ts")).toBe(true);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("warns and launches the family id when a reasoning variant is missing", async () => {
     chmodSync(FAKE_AGENT_PATH, 0o755);
     const listCommand = {

--- a/packages/agent-runtime/src/acp/bridge/bridge.ts
+++ b/packages/agent-runtime/src/acp/bridge/bridge.ts
@@ -219,9 +219,11 @@ function sendRuntimeRequest(
 }
 
 function resolveBridgeProcessArgsForMcpServer(): string[] {
-  const entryPoint = process.argv[1]
-    ? resolve(process.argv[1])
-    : fileURLToPath(import.meta.url);
+  // Resolve from this module's URL, not process.argv[1]: in packaged builds
+  // this code runs inside bb-provider-bridge-worker.mjs, whose argv[1] is the
+  // worker bootstrap (it exits with a usage error when re-executed). The
+  // module URL points at the bundled artifact, which handles --mcp-stdio.
+  const entryPoint = fileURLToPath(import.meta.url);
   return [...process.execArgv, entryPoint, "--mcp-stdio"];
 }
 


### PR DESCRIPTION
## Problem

Tools registered via `bb.agents.registerTool` never reach threads on ACP providers (opencode, Cursor, Kimi, Hermes) in packaged builds.

bb delivers registered tools to ACP agents via a stdio MCP server config in `session/new`; the agent spawns that server and discovers the tools via MCP `tools/list`. The server command was built as "re-run `process.argv[1]` with `--mcp-stdio`".

In packaged builds this code runs inside `bb-provider-bridge-worker.mjs`, so the agent was told to launch the worker bootstrap, which exits with a usage error instead of serving MCP. Tool discovery fails silently and no tools appear.

Dev runs and unit tests execute the same code inside a dedicated bridge process where `argv[1]` is correct — which is why tests passed while packaged installs were broken.

## Fix

Resolve the entry point from `import.meta.url` instead: it points at the bundled artifact, which handles `--mcp-stdio`, regardless of which host process executes this code.

## Testing

- New regression test stubs `argv[1]` to a bogus path and asserts the entry resolves from the module URL; fails on `main`, passes here.
- Manually verified the post-fix command answers MCP `initialize`/`tools/list` correctly under Electron-as-node.
- `typecheck` + `test:unit` green (one pre-existing flake in `runtime.process-lifecycle.test.ts` fails on clean `main` too).

Follow-up to #1102, which fixed the `ELECTRON_RUN_AS_NODE` half of packaged-mode tool delivery.