### PR TITLE
Move the collapsed mobile stop button flush with the pill corner

### DIFF
--- a/apps/mobile/src/composer/Composer.tsx
+++ b/apps/mobile/src/composer/Composer.tsx
@@ -544,7 +544,11 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(
               {collapsed && affordance.stop ? (
                 <StopButton
                   onPress={affordance.stop}
-                  style={{ marginRight: 4 }}
+                  // The 44pt input row leaves 4pt above and below the 36pt
+                  // circle. Pull the circle 2pt into the card's 6pt padding so
+                  // the right gap is also 4pt and the circle sits concentric
+                  // with the pill's corner.
+                  style={{ marginRight: -2 }}
                   testID={`${testID}-stop`}
                 />
               ) : collapsed && showVoicePrimary ? (


### PR DESCRIPTION
## What was wrong

In the native mobile app, the collapsed follow-up composer pill is a 44pt row with a 36pt round Stop button. The row leaves a 4pt gap above and below the circle, but the card's 6pt horizontal padding plus a `marginRight: 4` left a 10pt gap on the right. The circle looked pushed in from the pill's rounded corner.

## What changed

`apps/mobile/src/composer/Composer.tsx`: the collapsed `StopButton` now uses `marginRight: -2`, so the right gap is 4pt and matches the top and bottom gaps. A comment records the geometry. No wire, CLI, or doc changes.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/mobile` passes.
- Ran the mobile e2e harness (fake provider backend + Metro + Maestro) on the iPhone 17 Pro simulator, sent `delay:120000 first`, swiped the timeline to collapse the pill, and captured the screen. Measured on the 3x capture: the gap from the Stop circle to the pill border is 12px (4pt) on the top, right, and bottom.



> AGENT GENERATED: by Claude Opus 5
