### PR TITLE
Send the composer's execution selection with steers

### DIFF
--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
@@ -553,6 +553,7 @@ function EmbeddedThreadChatWithComposer({
         id: threadId,
         input: submittedInput,
         mode: "steer-if-active",
+        ...executionRequestFields,
       })
       .catch((error) => {
         if (!isMountedRef.current) {
@@ -576,6 +577,7 @@ function EmbeddedThreadChatWithComposer({
     canSubmitModifierShortcut,
     currentPromptDraft,
     currentPromptDraftInput,
+    executionRequestFields,
     handleSendQueuedImmediately,
     labels.sendError,
     promptDraft,

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -912,6 +912,7 @@ export function ThreadDetailPromptArea({
     const submittedDraft = currentPromptDraft;
     const submittedInput = currentPromptDraftInput;
     const shortcutRequest = buildFollowUpShortcutRequest({
+      execution: followUpExecutionSelection,
       input: submittedInput,
       queuedMessages: queuedMessagesRef.current,
       threadId: thread.id,
@@ -961,6 +962,7 @@ export function ThreadDetailPromptArea({
     canSubmitModifierShortcut,
     currentPromptDraft,
     currentPromptDraftInput,
+    followUpExecutionSelection,
     promptDraft,
     queuedMessagesRef,
     sendMessage,

--- a/apps/mobile/src/screens/thread/prompt-area/follow-up-submission.test.ts
+++ b/apps/mobile/src/screens/thread/prompt-area/follow-up-submission.test.ts
@@ -123,7 +123,17 @@ describe("buildFollowUpSubmission", () => {
       }),
     ).toEqual({
       kind: "steer",
-      request: { id: "t1", input: INPUT, mode: "steer-if-active" },
+      // get-bb/bb#1860: the steer carries the picker selection like a send.
+      request: {
+        id: "t1",
+        input: INPUT,
+        mode: "steer-if-active",
+        model: "fake-model",
+        permissionMode: "auto",
+        reasoningLevel: "medium",
+        serviceTier: "fast",
+        executionInputSources: { model: "explicit" },
+      },
     });
     expect(
       buildFollowUpSubmission({

--- a/apps/mobile/src/screens/thread/prompt-area/follow-up-submission.ts
+++ b/apps/mobile/src/screens/thread/prompt-area/follow-up-submission.ts
@@ -69,6 +69,7 @@ export function buildFollowUpSubmission({
 }: BuildFollowUpSubmissionArgs): FollowUpSubmission | null {
   if (intent === "steer") {
     const shortcut = buildFollowUpShortcutRequest({
+      execution,
       input,
       queuedMessages,
       threadId,

--- a/packages/client-core/src/prompt/threadDetailPromptSubmission.ts
+++ b/packages/client-core/src/prompt/threadDetailPromptSubmission.ts
@@ -64,7 +64,12 @@ interface BuildSendQueuedMessageByIdRequestArgs {
   threadId: string;
 }
 
+interface BuildSteerFollowUpRequestArgs extends BaseFollowUpRequestArgs {
+  execution: FollowUpExecutionSelection;
+}
+
 interface BuildFollowUpShortcutRequestArgs extends BaseFollowUpRequestArgs {
+  execution: FollowUpExecutionSelection;
   queuedMessages: readonly QueuedMessageForSend[];
 }
 
@@ -222,17 +227,22 @@ export function buildAutoFollowUpRequest({
 }
 
 function buildSteerFollowUpRequest({
+  execution,
   input,
   threadId,
-}: BaseFollowUpRequestArgs): SendMessageMutationRequest | null {
+}: BuildSteerFollowUpRequestArgs): SendMessageMutationRequest | null {
   if (input.length === 0) {
     return null;
   }
 
+  // The composer picker stays editable while a turn runs. Without the
+  // selection the server resolves the steer from the thread's last execution,
+  // i.e. the active turn's tuple, and silently ignores the new pick.
   return {
     id: threadId,
     input,
     mode: "steer-if-active",
+    ...buildSharedThreadExecutionRequestFields(execution),
   };
 }
 
@@ -269,11 +279,16 @@ function buildSendQueuedMessageByIdRequest({
  * head through the same auto path as the queued-card "Send now" action.
  */
 export function buildFollowUpShortcutRequest({
+  execution,
   input,
   queuedMessages,
   threadId,
 }: BuildFollowUpShortcutRequestArgs): FollowUpShortcutRequest | null {
-  const draftRequest = buildSteerFollowUpRequest({ input, threadId });
+  const draftRequest = buildSteerFollowUpRequest({
+    execution,
+    input,
+    threadId,
+  });
   if (draftRequest) {
     return { kind: "draft", request: draftRequest };
   }

--- a/packages/client-core/test/threadDetailPromptSubmission.test.ts
+++ b/packages/client-core/test/threadDetailPromptSubmission.test.ts
@@ -19,6 +19,7 @@ describe("threadDetailPromptSubmission", () => {
   it("prioritizes current prompt input over queued messages for the follow-up shortcut", () => {
     expect(
       buildFollowUpShortcutRequest({
+        execution: null,
         input: textInput,
         queuedMessages: [{ id: "queued-1" }, { id: "queued-2" }],
         threadId: "thread-1",
@@ -33,9 +34,50 @@ describe("threadDetailPromptSubmission", () => {
     });
   });
 
+  // get-bb/bb#1860: the picker can change mid-turn. The steer must carry the
+  // selection like the normal send does, or the server falls back to the
+  // active turn's execution tuple.
+  it("steers with the selected execution options", () => {
+    expect(
+      buildFollowUpShortcutRequest({
+        execution: {
+          model: "gpt-5.6-luna",
+          permissionMode: "full",
+          reasoningLevel: "low",
+          serviceTier: "fast",
+          supportsServiceTier: false,
+          executionInputSources: {
+            model: "explicit",
+            reasoningLevel: "explicit",
+            permissionMode: "explicit",
+          },
+        },
+        input: textInput,
+        queuedMessages: [{ id: "queued-1" }],
+        threadId: "thread-1",
+      }),
+    ).toEqual({
+      kind: "draft",
+      request: {
+        id: "thread-1",
+        input: textInput,
+        mode: "steer-if-active",
+        model: "gpt-5.6-luna",
+        permissionMode: "full",
+        reasoningLevel: "low",
+        executionInputSources: {
+          model: "explicit",
+          reasoningLevel: "explicit",
+          permissionMode: "explicit",
+        },
+      },
+    });
+  });
+
   it("uses only the next queued message for an empty follow-up shortcut", () => {
     expect(
       buildFollowUpShortcutRequest({
+        execution: null,
         input: [],
         queuedMessages: [{ id: "queued-1" }, { id: "queued-2" }],
         threadId: "thread-1",
@@ -53,6 +95,7 @@ describe("threadDetailPromptSubmission", () => {
   it("does not build an empty follow-up shortcut without queued messages", () => {
     expect(
       buildFollowUpShortcutRequest({
+        execution: null,
         input: [],
         queuedMessages: [],
         threadId: "thread-1",


### PR DESCRIPTION
## What was wrong

The follow-up composer keeps its model / reasoning / permission-mode picker editable while a turn runs, but the steer gesture (Cmd+Enter on web, long-press on mobile, Cmd+Enter in the side chat) posted only `{input, mode: "steer-if-active"}`. `buildSteerFollowUpRequest` in `packages/client-core/src/prompt/threadDetailPromptSubmission.ts` was the only follow-up builder that did not spread `buildSharedThreadExecutionRequestFields(execution)`; its siblings `buildAutoFollowUpRequest` and `buildCreateQueuedFollowUpRequest` do. With `model`/`reasoningLevel` omitted, the server's `buildExecutionOptions` resolves them from the thread's last execution, which is the active turn's tuple, so the steer was stored in `client/turn/requested` and dispatched with the previous selection while the picker showed the new one. Issue: #1860. Report: https://get-bb.github.io/reports/issues/1860.html

## What changed

- `packages/client-core/src/prompt/threadDetailPromptSubmission.ts`: `buildSteerFollowUpRequest` and `buildFollowUpShortcutRequest` take the same `execution: FollowUpExecutionSelection` argument as the other builders and spread it into the `steer-if-active` request.
- `apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx`: `handleModifierSubmit` passes `followUpExecutionSelection` (already computed for `handleSend`).
- `apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx`: the side-chat steer spreads `executionRequestFields` like its normal send/queue requests.
- `apps/mobile/src/screens/thread/prompt-area/follow-up-submission.ts`: the steer intent passes the `execution` it already receives.

No server, host daemon, or wire change: `SendMessageRequest` already accepts these fields for every mode (the queued "Send now" path and `bb thread tell --mode steer --model ...` already send them), so no `HOST_DAEMON_PROTOCOL_VERSION` bump. No CLI or doc surface changes.

Provider note (from the report): Claude Code applies model/reasoning changes to a live session on steer. Codex cannot change model inside a running turn, so for Codex the steer is now recorded with the selected tuple and the running turn keeps its model; the selection takes effect at the next `turn/start`. Making the picker read-only for such providers is a separate product decision.

## How you verified

New test `steers with the selected execution options` in `packages/client-core/test/threadDetailPromptSubmission.test.ts`. On origin/main source it fails:

```
AssertionError: expected { kind: 'draft', request: { …(3) } } to deeply equal { kind: 'draft', request: { …(7) } }
-     "executionInputSources": { "model": "explicit", "permissionMode": "explicit", "reasoningLevel": "explicit" },
-     "model": "gpt-5.6-luna",
-     "permissionMode": "full",
-     "reasoningLevel": "low",
```

With the fix it passes. The mobile `buildFollowUpSubmission` steer test now also asserts the tuple is present.

Commands (run from the committed tree, `git status --porcelain` empty):

```
pnpm exec turbo run typecheck test --filter=@bb/client-core --filter=@bb/mobile --filter=@bb/app
 Tasks:    9 successful, 9 total
@bb/client-core:test: Tests 239 passed (239)
@bb/mobile:test:      Tests 827 passed (827)
@bb/app:test:         Tests 3156 passed | 3 skipped (3159)
```

Manual end-to-end on an isolated dev instance (`scripts/bb-dev-app current`, real Codex): spawned a thread with `gpt-5.6-terra` / `high` running `sleep 120`, switched the picker to `5.6-Luna · Low` mid-turn in headless Chromium, typed a steer and pressed Meta+Enter. A `window.fetch` hook captured the body:

```
POST /api/v1/threads/thr_mkjycvscnv/send
{"input":[…],"mode":"steer-if-active","model":"gpt-5.6-luna","permissionMode":"full","reasoningLevel":"low","serviceTier":"default","executionInputSources":{…all "explicit"}}
```

Stored `client/turn/requested` rows for the thread:

```
1  | thread-start | gpt-5.6-terra | high
21 | steer        | gpt-5.6-luna  | low
```

The steer joined the running turn (`turn/input/accepted`), the agent replied `steered`, and the turn completed without error.

Fixes #1860

> AGENT GENERATED: by Claude Opus 5


## Independent verification

Verified by a separate agent in its own worktree (branch checked out from `bb/fix-1860-steer-model-change` at 725c36f72; `origin/main` f6fb434ab is an ancestor, `mergeable: MERGEABLE`).

**Fail-before / pass-after.** Restored the four non-test source files to `origin/main` (`git checkout origin/main -- apps/app/.../EmbeddedThreadChat.tsx apps/app/.../ThreadDetailPromptArea.tsx apps/mobile/.../follow-up-submission.ts packages/client-core/src/prompt/threadDetailPromptSubmission.ts`) and ran the PR's tests:

- `packages/client-core`: `pnpm exec vitest run test/threadDetailPromptSubmission.test.ts` -> `1 failed | 14 passed`. Failing assertion: `steers with the selected execution options` — received `{ id, input, mode: "steer-if-active" }`, missing `model: "gpt-5.6-luna"`, `reasoningLevel: "low"`, `permissionMode: "full"`, `executionInputSources`.
- `apps/mobile`: `pnpm exec vitest run src/screens/thread/prompt-area/follow-up-submission.test.ts` -> `1 failed | 8 passed`, same missing fields on the `kind: "steer"` request.

Restored the PR source (`git checkout HEAD -- <same files>`, `git status --porcelain` empty) and re-ran: `15 passed` and `9 passed`.

**Turbo (cache bypassed).** `pnpm exec turbo run typecheck test --filter=@bb/client-core --filter=@bb/mobile --filter=@bb/app --force` -> `Tasks: 9 successful, 9 total`, `Cached: 0 cached`. client-core 20 test files, mobile 123, app 409, all passed.

**Live repro on the fixed branch (own isolated dev instance, real Codex 0.149.0).** Spawned a Codex thread and started a turn with `gpt-5.6-terra`/`high` running `sleep 240`. In headless Chromium (doobie) with a `window.fetch` hook, switched the composer picker to `5.6-Luna · Low` while the turn was running, typed a steer, pressed Meta+Enter. Captured body of `POST /api/v1/threads/thr_cywmjkjaxg/send`:

```
{"input":[...],"mode":"steer-if-active","model":"gpt-5.6-luna","permissionMode":"full","reasoningLevel":"low","serviceTier":"default","executionInputSources":{"model":"explicit","serviceTier":"explicit","reasoningLevel":"explicit","permissionMode":"explicit"}}
```

Stored `client/turn/requested` rows: seq 63 `new-turn` terra/high, seq 73 `steer` **luna/low** (on main the report shows the steer stored with the previous turn's tuple). Steer was accepted (`turn/input/accepted`), agent replied `steered`, `turn/completed` with no error or session-replaced event. The bug no longer reproduces.

**Hostile review.** Client-only; fixes the root cause (the steer builder omitted the selection while its sibling send/queue builders spread it). Server already reads `payload.model` for every mode (`recoverThreadModelOverride` + `buildExecutionOptions` in `thread-send.ts`), so no server/daemon/wire change and no `HOST_DAEMON_PROTOCOL_VERSION` bump needed. All three callers of `buildFollowUpShortcutRequest` (web, mobile) and the side-chat steer now pass the selection; remaining `steer-if-active` senders are plugin-programmatic (workflows/automations/tasks) and out of scope. Checked that the steer path's `reconfigureThreadIfNeeded` cannot replace a session mid-turn: the single `bridge-protocol-adapter` always classifies settings changes as `"live"`. No casts, no ignored fields, no CLI/doc surface change.

**CI.** All checks pass (Checks, Tests app-1/2/3, integration, packages, server, Package Smoke ubuntu + macOS, version checks); iOS simulator and Node compat smoke skipped as usual.

**Residual risk.** As the report notes, Codex cannot retarget a running turn, so for Codex the recorded tuple applies at the next turn/start; Claude Code applies it live. Making the picker read-only for such providers is a separate product decision.

> AGENT GENERATED: by Claude Opus 5
