### PR TITLE
Stop advertising fork for acp-cursor and acp-grok

### DIFF
--- a/apps/server/test/services/plugins/first-party-provider-plugins.test.ts
+++ b/apps/server/test/services/plugins/first-party-provider-plugins.test.ts
@@ -26,6 +26,7 @@ const FIRST_PARTY_PROVIDER_DECLARATIONS = [
     displayName: "Codex",
     supportsThreadArchive: true,
     supportsThreadRename: true,
+    fork: "checkpoint",
     supportsManualCompaction: true,
     supportsUsage: true,
     visibility: "always",
@@ -38,6 +39,7 @@ const FIRST_PARTY_PROVIDER_DECLARATIONS = [
     displayName: "Claude Code",
     supportsThreadArchive: false,
     supportsThreadRename: false,
+    fork: "checkpoint",
     supportsManualCompaction: true,
     supportsUsage: true,
     visibility: "always",
@@ -50,6 +52,7 @@ const FIRST_PARTY_PROVIDER_DECLARATIONS = [
     displayName: "Pi",
     supportsThreadArchive: false,
     supportsThreadRename: false,
+    fork: "checkpoint",
     supportsManualCompaction: true,
     supportsUsage: false,
     visibility: "always",
@@ -62,6 +65,7 @@ const FIRST_PARTY_PROVIDER_DECLARATIONS = [
     displayName: "Cursor",
     supportsThreadArchive: false,
     supportsThreadRename: false,
+    fork: "none",
     supportsManualCompaction: false,
     supportsUsage: true,
     visibility: "always",
@@ -74,6 +78,7 @@ const FIRST_PARTY_PROVIDER_DECLARATIONS = [
     displayName: "opencode",
     supportsThreadArchive: false,
     supportsThreadRename: false,
+    fork: "tip",
     supportsManualCompaction: true,
     supportsUsage: false,
     visibility: "installed",
@@ -86,6 +91,7 @@ const FIRST_PARTY_PROVIDER_DECLARATIONS = [
     displayName: "omp",
     supportsThreadArchive: false,
     supportsThreadRename: false,
+    fork: "tip",
     supportsManualCompaction: false,
     supportsUsage: false,
     visibility: "installed",
@@ -98,6 +104,7 @@ const FIRST_PARTY_PROVIDER_DECLARATIONS = [
     displayName: "Grok Build",
     supportsThreadArchive: false,
     supportsThreadRename: false,
+    fork: "none",
     supportsManualCompaction: false,
     supportsUsage: false,
     visibility: "installed",
@@ -110,6 +117,7 @@ const FIRST_PARTY_PROVIDER_DECLARATIONS = [
     displayName: "Hermes Agent",
     supportsThreadArchive: false,
     supportsThreadRename: false,
+    fork: "tip",
     supportsManualCompaction: false,
     supportsUsage: false,
     visibility: "installed",
@@ -191,6 +199,16 @@ describe("first-party provider plugins", () => {
           expect(registry.supportsManualCompaction(plugin.providerId)).toBe(
             plugin.supportsManualCompaction,
           );
+          // Fork is declared per agent, not per tier: the ACP bridge refuses
+          // `session/fork` for agents whose `initialize` reply does not
+          // advertise it (cursor-agent, grok), so a declaration above what the
+          // agent answers makes POST /threads/fork create a thread that dies
+          // on start (#1833). The declaration is the server's fork gate and
+          // the app's fork affordance, so it must match the agent.
+          expect(registration.serverCapabilities.fork, label).toBe(plugin.fork);
+          expect(registry.supportsFork(plugin.providerId), label).toBe(
+            plugin.fork !== "none",
+          );
           expect(registration.info.experimental_providerUsage, label).toBe(
             plugin.supportsUsage,
           );
@@ -206,6 +224,15 @@ describe("first-party provider plugins", () => {
         );
         expect(infos.map((info) => info.logoUrl)).toEqual(
           ALWAYS_VISIBLE_PROVIDER_IDS.map(expectedLogoUrl),
+        );
+        // The client-facing fork flag (the app's "Fork into new thread"
+        // affordance) agrees with the declaration.
+        expect(
+          infos.map((info) => [info.id, info.capabilities.supportsFork]),
+        ).toEqual(
+          FIRST_PARTY_PROVIDER_DECLARATIONS.filter(
+            (plugin) => plugin.visibility === "always",
+          ).map((plugin) => [plugin.providerId, plugin.fork !== "none"]),
         );
       },
     );
@@ -327,7 +354,8 @@ describe("first-party provider plugins", () => {
             supportsServiceTier: true,
             supportsNativeUserQuestion: false,
             permissionModes: ["accept-edits", "full"],
-            supportsFork: true,
+            // cursor-agent does not advertise ACP session/fork (#1833).
+            supportsFork: false,
             supportsSessionRewind: false,
           },
           composerActions: [skills],

--- a/plugins/provider-acp/server.ts
+++ b/plugins/provider-acp/server.ts
@@ -9,6 +9,14 @@ const ACP_BASE_CAPABILITIES = {
   experimental_providerInstallation: false,
   supportsServiceTier: true,
   supportsNativeUserQuestion: false,
+  // ACP session/fork clones a whole session (tip only, no checkpoint rewind),
+  // and it is an unstable ACP extension that not every agent implements. The
+  // bridge refuses `session/fork` for an agent whose `initialize` reply does
+  // not advertise `sessionCapabilities.fork`, but only after the server has
+  // already created and started the fork thread. So this declaration, which
+  // is the server's fork gate and the app's fork affordance, must match what
+  // the agent actually advertises: override it with "none" for agents that
+  // do not (#1833).
   fork: "tip" as const,
   supportsManualCompaction: false,
   supportsThreadArchive: false,
@@ -76,6 +84,9 @@ const ACP_PROVIDERS: readonly PluginProviderDeclaration[] = [
       ...ACP_BASE_CAPABILITIES,
       experimental_providerUsage: true,
       experimental_providerInstallation: true,
+      // cursor-agent (2026.08.11) advertises `sessionCapabilities: { list }`
+      // only; no session/fork.
+      fork: "none",
     },
     composerActions: [],
   },
@@ -166,6 +177,9 @@ const ACP_PROVIDERS: readonly PluginProviderDeclaration[] = [
     },
     capabilities: {
       ...ACP_BASE_CAPABILITIES,
+      // `grok agent stdio` advertises `sessionCapabilities: { list, resume,
+      // close }`; no session/fork.
+      fork: "none",
       reasoningLevels: ["low", "medium", "high"],
     },
     composerActions: [],


### PR DESCRIPTION
## What was wrong

`plugins/provider-acp/server.ts` declared `fork: "tip"` for every built-in ACP agent through `ACP_BASE_CAPABILITIES`. The server projects that to `supportsFork: true` (the `POST /api/v1/threads/fork` gate and the app's "Fork into new thread" action). But neither `cursor-agent acp` (2026.08.11) nor `grok agent stdio` advertises `sessionCapabilities.fork` in its ACP `initialize` reply, so the bridge's per-session guard (`bridge.ts`: "does not advertise session/fork support") rejected the fork only after the server had already created and started the fork thread. The thread landed in `status: error` with `system/error { code: thread_command_failed }`. Issue: #1833. Report: https://get-bb.github.io/reports/issues/1833.html

The issue suggested deriving fork per agent at initialize time. That is not a drop-in: the agent's `initialize` happens per session inside the bridge after the server has created the thread, and there is no daemon-to-server capability channel. The declaration is the server-side source of truth (same as `supportsManualCompaction`), so it has to match the agent.

## What changed

- `plugins/provider-acp/server.ts`: `acp-cursor` and `acp-grok` now declare `fork: "none"`. The base stays `"tip"`; opencode, omp (oh-my-pi), and hermes-agent all advertise `sessionCapabilities.fork` in their ACP adapters (checked upstream sources: `packages/opencode/src/acp/service.ts`, `packages/coding-agent/src/modes/acp/acp-agent.ts`, `acp_adapter/server.py`). Added a comment on the base capability explaining why the declaration must match the agent.
- `apps/server/test/services/plugins/first-party-provider-plugins.test.ts`: the golden pin now records the fork ladder per first-party provider and asserts `registration.serverCapabilities.fork`, `registry.supportsFork()`, and the composed `ProviderInfo.capabilities.supportsFork` against it.

Effects: `POST /threads/fork` on a Cursor or Grok thread returns HTTP 400 `Provider acp-cursor does not support thread forks` without creating a thread; the app hides the fork action for those providers; the declared ceiling that rides `bridgeLaunch.capabilities.fork` to the daemon also becomes `"none"`, so the runtime rejects `thread/fork` before spawning the agent.

No wire shape changes (the existing `fork` field just carries a different value), so no `HOST_DAEMON_PROTOCOL_VERSION` bump. No CLI or config surface changes. Custom `acp-*` agents still fall back to the tier-wide `"tip"`; giving them a per-agent `fork` config field is a separate change.

## How you verified

Probed the agents directly (same `initialize` request the bridge sends):

```
$ node probe.mjs cursor-agent acp     -> sessionCapabilities: { list: {} }                 fork advertised: false
$ node probe.mjs grok agent stdio     -> sessionCapabilities: { list, resume, close }      fork advertised: false
```

New test fails on origin/main with the test file applied and the plugin unchanged:

```
FAIL test/services/plugins/first-party-provider-plugins.test.ts > first-party provider plugins > are the sole source of the built-in providers
AssertionError: acp-cursor: expected 'tip' to be 'none' // Object.is equality
```

Passes on this branch (`Tests 2 passed (2)`).

From the committed tree (`git status --porcelain` empty):

```
pnpm exec turbo run typecheck --filter=@bb/server --filter=bb-plugin-provider-acp
 Tasks:    6 successful, 6 total
pnpm exec turbo run test --filter=@bb/server --filter=bb-plugin-provider-acp
 bb-plugin-provider-acp: Tests 181 passed (181)
 @bb/server: Test Files 1 failed | 194 passed (195); Tests 1 failed | 1822 passed (1823)
```

The one server failure is `test/internal/internal-skill-trees.test.ts` (`mode: 420` vs `436`), the known local umask 0002 failure unrelated to this change; it passes here under `umask 022` and in CI.

Manual repro on this branch against a dev instance of this worktree:

```
$ curl -s $BB_SERVER_URL/api/v1/system/providers | ... supportsFork
codex True / claude-code True / pi True / acp-cursor False / acp-grok False
$ pnpm bb:dev thread spawn --provider acp-cursor ... --prompt "Reply only with ok."   -> thr_7u6gb8ppn2, reached idle
$ pnpm bb:dev thread fork thr_7u6gb8ppn2 --workspace reuse --prompt "Reply only with ok." --json
Error: Failed to fork thread thr_7u6gb8ppn2: HTTP 400: Provider acp-cursor does not support thread forks
$ GET /threads?projectId=...   -> only thr_7u6gb8ppn2 (idle); no fork thread created
```

Fixes #1833

> AGENT GENERATED: by Claude Opus 5


## Rebase

Rebased onto `origin/main` (`cf00cfe06`) after the grammar-v3 bridge stack (#2148 `bb.providers.register` + single `ProviderInfo`, #2179 WS1b-acp) rewrote both touched files. The fix maps 1:1 onto the new code:

- `plugins/provider-acp/server.ts`: the declarations now carry `experimental_strings` / `experimental_serviceTiers` and register through `bb.providers.register`, but `ACP_BASE_CAPABILITIES.fork: "tip"` and the per-agent `capabilities` spreads are unchanged, so the `fork: "none"` overrides for `acp-cursor` and `acp-grok` and the base comment apply as before. Still no wire-shape change, so no `HOST_DAEMON_PROTOCOL_VERSION` bump.
- `apps/server/test/services/plugins/first-party-provider-plugins.test.ts`: main dropped `supportsWorkflows` from the golden pin (conflict resolved by adding only the `fork` ladder), and #2148 added a new test, "pins the client-read ProviderInfo fields of the four core providers", that pinned `acp-cursor` at `supportsFork: true`. That pin now reads `supportsFork: false` with a `#1833` comment; `supportsSessionRewind: false` is unchanged. The fork-ladder assertions in the first test (`registration.serverCapabilities.fork`, `registry.supportsFork()`, composed `ProviderInfo.capabilities.supportsFork`) carried over verbatim; `serverCapabilities.fork` still exists on main (`plugin-provider-registration.ts` projects `supportsFork: capabilities.fork !== "none"`).

Re-verified on the new base. With `plugins/provider-acp/server.ts` reverted to `origin/main` and the test file in place, the tests fail (so main does not already cover the bug):

```
FAIL ... > are the sole source of the built-in providers
AssertionError: acp-cursor: expected 'tip' to be 'none' // Object.is equality
FAIL ... > pins the client-read ProviderInfo fields of the four core providers
AssertionError: expected { id: 'acp-cursor', …(8) } to strictly equal { id: 'acp-cursor', …(8) }
Tests 2 failed | 1 passed (3)
```

With the fix restored: `Tests 3 passed (3)`. From the committed tree (`git status --porcelain` empty):

```
pnpm exec turbo run typecheck --filter=@bb/server --filter=bb-plugin-provider-acp
 Tasks:    6 successful, 6 total
pnpm exec turbo run test --filter=@bb/server --filter=bb-plugin-provider-acp
 bb-plugin-provider-acp: Test Files 15 passed (15); Tests 196 passed (196)
 @bb/server: Test Files 1 failed | 197 passed | 1 skipped (199); Tests 1 failed | 1896 passed (1897)
```

The one server failure is again `test/internal/internal-skill-trees.test.ts` (`mode: 420` vs `436`), the known local umask 0002 failure; it passes in CI.

## Independent verification

Verified by a second agent on a separate worktree (branch `verify-1833-r1` = `ece689920`, `origin/main` is an ancestor, `mergeable: MERGEABLE`).

Commands run:

```
git fetch origin main && git fetch origin bb/fix-1833-acp-cursor-fork && git checkout -b verify-1833-r1 FETCH_HEAD
pnpm install --frozen-lockfile --prefer-offline && pnpm exec turbo run build
node probe.mjs cursor-agent acp   -> cursor-agent sessionCapabilities: {"list":{}} fork advertised: false
node probe.mjs grok agent stdio   -> grok sessionCapabilities: {"list":{},"resume":{},"close":{}} fork advertised: false
git checkout origin/main -- plugins/provider-acp/server.ts
cd apps/server && pnpm exec vitest run test/services/plugins/first-party-provider-plugins.test.ts
git checkout HEAD -- plugins/provider-acp/server.ts
cd apps/server && pnpm exec vitest run test/services/plugins/first-party-provider-plugins.test.ts
pnpm exec turbo run typecheck --filter=@bb/server --filter=bb-plugin-provider-acp
pnpm exec turbo run test --filter=@bb/server --filter=bb-plugin-provider-acp --force
```

Fail-before / pass-after:

- With `plugins/provider-acp/server.ts` reverted to `origin/main` and the PR's test file in place: `Tests 1 failed | 1 passed (2)` with `AssertionError: acp-cursor: expected 'tip' to be 'none' // Object.is equality`.
- With the PR's source restored: `Tests 2 passed (2)`.

Typecheck and tests:

- `turbo typecheck` for `@bb/server` and `bb-plugin-provider-acp`: `Tasks: 6 successful, 6 total`.
- `turbo test`: `bb-plugin-provider-acp` 14 files passed; `@bb/server` 1822 passed, 1 failed. The single failure is `test/internal/internal-skill-trees.test.ts` (`mode: 420` vs `436`), the known umask-0002 environment failure on this workstation; it also fails on clean `main` here and passes in CI.

Repro on the fixed branch (own dev instance, server :20051, data dir under `~/.bb-dev`, deleted afterwards):

- `GET /api/v1/system/providers` -> `acp-cursor False`, `acp-grok False` (codex/claude-code/pi still `True`).
- Spawned an `acp-cursor` thread (`thr_4gh8bikbv6`), waited to `idle`, then `pnpm bb:dev thread fork thr_4gh8bikbv6 --workspace reuse --prompt "Reply only with ok." --json` -> `HTTP 400: Provider acp-cursor does not support thread forks`. Thread list for the project still holds only the source thread (`idle`); no errored fork thread was created. The original symptom no longer reproduces.

CI: 11 checks pass, 2 skipped (Node Compatibility Smoke, iOS simulator flows), none failing.

Review notes:

- Root-cause fix at the right layer: the server-side declaration is the fork gate and the app affordance, and its value also rides `bridgeLaunch.capabilities.fork` to the runtime adapter's `effectiveFork()` ceiling, so `thread/fork` is refused before the agent is spawned. No wire shape change, so no protocol bump is needed.
- Residual risk: custom `acp-*` agents configured through `customAcpAgents` still inherit the tier-wide `ACP_TIER_CAPABILITIES.supportsFork: true` (`apps/server/src/services/providers/acp-provider-tier.ts`), so a custom agent without `session/fork` still hits the errored-thread path. A per-agent `fork` field on that config is a sensible follow-up, not a blocker for this PR. opencode/omp/hermes fork support was checked from upstream sources only (not installed here).

> AGENT GENERATED: by Claude Opus 5



## Independent verification (post-rebase)

Re-verified by a second agent after the rebase onto the grammar-v3 bridge rewrite (branch `verify-2150-rb` = `2d84751d9`, one commit on `cf00cfe06`). `origin/main` had moved one more commit (`fcada5a3b`, #2120 provider-literal ratchet) by the time of this check; a local `git merge --no-commit origin/main` was clean (the ratchet scans core only and excludes `plugins/provider-*`), and GitHub reports `mergeable: MERGEABLE`.

Does the fix still target the right code path after the v3 rewrite? Yes:

- `apps/server/src/services/threads/thread-fork.ts:39` (`requireForkCapableProvider`) still gates `POST /threads/fork` on `providerRegistry.supportsFork()`, which for a registered plugin provider reads `registration.info.capabilities.supportsFork` = `fork !== "none"` (`plugin-provider-registration.ts:211`).
- The app still reads `ProviderInfo.capabilities.supportsFork` (`useForkThreadFromMessage.ts:54`, `ThreadDetailView.tsx:977`, `RootComposeView.tsx:538`).
- `provider-bridge-launch.ts:48-50` still forwards `registration.serverCapabilities.fork` to the daemon, and `packages/agent-runtime/src/bridge-protocol-adapter.ts` `effectiveFork()` still takes the declaration as a ceiling over the handshake, so `thread/fork` is refused before cursor-agent is spawned.
- The v3 bridge (`plugins/provider-acp/src/bridge/bridge.ts`) still advertises `fork: "tip"` unconditionally in its handshake (line ~2372) and only checks `agentCapabilities.sessionCapabilities.fork` per session at agent initialize (lines 1718-1721, "does not advertise session/fork support"). Nothing in the rewrite made the static declaration redundant; it is still the only up-front gate.

Commands run:

```
git fetch origin main && git fetch origin bb/fix-1833-acp-cursor-fork && git checkout -b verify-2150-rb FETCH_HEAD
pnpm install --frozen-lockfile --prefer-offline && pnpm exec turbo run build
git checkout origin/main -- plugins/provider-acp/server.ts
cd apps/server && pnpm exec vitest run test/services/plugins/first-party-provider-plugins.test.ts
git checkout HEAD -- plugins/provider-acp/server.ts
cd apps/server && pnpm exec vitest run test/services/plugins/first-party-provider-plugins.test.ts
pnpm exec turbo run typecheck --filter=@bb/server --filter=bb-plugin-provider-acp
pnpm exec turbo run test --filter=@bb/server --filter=bb-plugin-provider-acp --force
```

Fail-before / pass-after (only non-test source file is `plugins/provider-acp/server.ts`):

- With `server.ts` from `origin/main` and the PR's test file: `Tests 2 failed | 1 passed (3)`. Failing assertions: `AssertionError: acp-cursor: expected 'tip' to be 'none' // Object.is equality` and, in the #2148 pin test, `AssertionError: expected { id: 'acp-cursor', …(8) } to strictly equal { id: 'acp-cursor', …(8) }` (supportsFork true vs false).
- With the PR's source restored: `Tests 3 passed (3)`.

Typecheck and tests (from the committed tree, `git status --porcelain` empty):

- `turbo typecheck`: `Tasks: 6 successful, 6 total`.
- `turbo test`: `bb-plugin-provider-acp` Test Files 15 passed (15); `@bb/server` Tests 1 failed | 1896 passed (1897). The single failure is `test/internal/internal-skill-trees.test.ts` (`mode: 420` vs `436`), the known umask-0002 local failure; it passes in CI.

Repro on the fixed branch (own dev instance, server :26547, data dir under `~/.bb-dev`, deleted afterwards):

- `GET /api/v1/system/providers` -> `codex True`, `claude-code True`, `pi True`, `acp-cursor False`, `acp-grok False`.
- Spawned an `acp-cursor` thread (`thr_2c8kkaj7rz`) with cursor-agent 2026.08.11, waited to `idle`, then `pnpm bb:dev thread fork thr_2c8kkaj7rz --workspace reuse --prompt "Reply only with ok." --json` -> `HTTP 400: Provider acp-cursor does not support thread forks`. A direct `POST /api/v1/threads/fork` also returned 400. The project's thread list still holds only the source thread (`idle`); no errored fork thread was created. The original symptom no longer reproduces.

CI on `2d84751d9`: all checks pass (server, packages, integration, app-1/2/3, both Package Smoke runners, Checks, version check); iOS simulator flows and Node Compatibility Smoke skipped; none pending or failing.

Residual risks (unchanged from the pre-rebase review): custom `acp-*` agents configured through `customAcpAgents` still fall back to `ACP_TIER_CAPABILITIES.supportsFork: true` (`apps/server/src/services/providers/acp-provider-tier.ts:43`) and can still hit the errored-thread path; a per-agent `fork` field on that config is a follow-up. No wire shape change (the `fork` field already rides `bridgeLaunch.capabilities`; only its value for two providers changes), so no `HOST_DAEMON_PROTOCOL_VERSION` bump is needed.

> AGENT GENERATED: by Claude Opus 5
