### PR TITLE
Close display math whose $$ delimiters are glued to the TeX

### DIFF
--- a/apps/app/src/components/ui/markdown-math-fences.test.ts
+++ b/apps/app/src/components/ui/markdown-math-fences.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { normalizeMathFences } from "./markdown-math-fences.js";
+
+const SUFFIX = ["", "## After", "", "- item"].join("\n");
+
+describe("normalizeMathFences", () => {
+  it("splits a glued opener and trailing closer onto their own lines", () => {
+    const input = ["$$T_{a}", "\\approx 73$$", SUFFIX].join("\n");
+    expect(normalizeMathFences(input)).toBe(
+      ["$$", "T_{a}", "\\approx 73", "$$", SUFFIX].join("\n"),
+    );
+  });
+
+  it("closes a bare opener at a trailing `$$`", () => {
+    const input = ["$$", "\\frac{1}{2}$$", SUFFIX].join("\n");
+    expect(normalizeMathFences(input)).toBe(
+      ["$$", "\\frac{1}{2}", "$$", SUFFIX].join("\n"),
+    );
+  });
+
+  it("moves opener meta into the block when the closer is bare", () => {
+    const input = ["$$\\frac{1}{2}", "$$", SUFFIX].join("\n");
+    expect(normalizeMathFences(input)).toBe(
+      ["$$", "\\frac{1}{2}", "$$", SUFFIX].join("\n"),
+    );
+  });
+
+  it("closes each block at its own delimiter", () => {
+    const input = ["$$a", "b$$", "", "text", "", "$$", "c$$"].join("\n");
+    expect(normalizeMathFences(input)).toBe(
+      ["$$", "a", "b", "$$", "", "text", "", "$$", "c", "$$"].join("\n"),
+    );
+  });
+
+  it("returns the same string for canonical blocks, inline math, and prose", () => {
+    for (const input of [
+      ["$$", "\\frac{1}{2}", "$$", SUFFIX].join("\n"),
+      ["Mass-energy is $$E = mc^2$$ exactly.", SUFFIX].join("\n"),
+      ["$$a$$ and $$b$$", SUFFIX].join("\n"),
+      "It went from $5 to $10 and costs $$$.",
+      "no math here",
+    ]) {
+      expect(normalizeMathFences(input)).toBe(input);
+    }
+  });
+
+  it("leaves a span with no closing delimiter alone", () => {
+    const input = ["$$T_{a}", "\\approx 73", SUFFIX].join("\n");
+    expect(normalizeMathFences(input)).toBe(input);
+  });
+
+  it("does not rewrite inside fenced code or across a code fence", () => {
+    const inCode = ["```tex", "$$T_{a}", "b$$", "```"].join("\n");
+    expect(normalizeMathFences(inCode)).toBe(inCode);
+    const acrossFence = ["$$T_{a}", "```", "b$$", "```"].join("\n");
+    expect(normalizeMathFences(acrossFence)).toBe(acrossFence);
+  });
+
+  it("leaves indented code alone", () => {
+    const input = ["    $$T_{a}", "    b$$"].join("\n");
+    expect(normalizeMathFences(input)).toBe(input);
+  });
+
+  it("handles CRLF line endings", () => {
+    const input = "$$T_{a}\r\n\\approx 73$$\r\n\r\n## After";
+    expect(normalizeMathFences(input)).toBe(
+      "$$\nT_{a}\n\\approx 73\n$$\n\r\n## After",
+    );
+  });
+});

--- a/apps/app/src/components/ui/markdown-math-fences.ts
+++ b/apps/app/src/components/ui/markdown-math-fences.ts
@@ -1,0 +1,119 @@
+import {
+  isMarkdownFenceClose,
+  type MarkdownFence,
+  parseMarkdownFenceStart,
+  trimMarkdownLineCarriageReturn,
+} from "./markdown-prompt-blockquote-boundaries.js";
+
+// `$$` at line start (≤3 spaces of indent, like any fence) followed by text
+// without another `$`. micromark treats exactly this as a display-math opening
+// fence whose text is the (never rendered) meta string; `$$x$$` on one line has
+// a `$` in the remainder and stays inline math.
+const OPEN_WITH_META_PATTERN = /^( {0,3})\$\$[ \t]*([^$]+?)[ \t]*$/u;
+const BARE_FENCE_PATTERN = /^( {0,3})\$\$[ \t]*$/u;
+// A content line that ends with `$$` but does not start with it. The captured
+// group is the TeX that precedes the glued closing delimiter.
+const TRAILING_CLOSE_PATTERN = /^(.*?[^$\s])[ \t]*\$\$[ \t]*$/u;
+
+interface MathFenceClose {
+  index: number;
+  tex: string | null;
+}
+
+function findMathFenceClose(
+  lines: readonly string[],
+  from: number,
+): MathFenceClose | null {
+  for (let index = from; index < lines.length; index += 1) {
+    const line = trimMarkdownLineCarriageReturn(lines[index] ?? "");
+    if (parseMarkdownFenceStart(line) !== null) {
+      return null;
+    }
+    if (BARE_FENCE_PATTERN.test(line)) {
+      return { index, tex: null };
+    }
+    const trailing = TRAILING_CLOSE_PATTERN.exec(line);
+    if (trailing !== null) {
+      return { index, tex: trailing[1]! };
+    }
+  }
+  return null;
+}
+
+/**
+ * Rewrites LaTeX-style display math whose `$$` delimiters are glued to the
+ * TeX into the fence shape `remark-math` understands.
+ *
+ * `micromark-extension-math` parses `$$` display math like a fenced code
+ * block: the opening line may carry a meta string (`$$T_{a}` opens a block
+ * with meta `T_{a}`, which is dropped from the output) and the closing fence
+ * must be `$$` alone on its own line. Models routinely emit
+ *
+ *     $$T_{a}
+ *     \approx 73$$
+ *
+ * which opens a block that never closes, so everything after it becomes math
+ * content and renders as one `.katex-error` (#1778). This pass turns that
+ * span, plus the `$$\n…$$` and `$$…\n$$` variants, into
+ *
+ *     $$
+ *     T_{a}
+ *     \approx 73
+ *     $$
+ *
+ * before the text reaches the parser. Fenced code blocks are skipped, a span
+ * with no closing delimiter is left alone, and canonical blocks and inline
+ * `$$x$$` come out unchanged.
+ */
+export function normalizeMathFences(markdown: string): string {
+  if (!markdown.includes("$$")) {
+    return markdown;
+  }
+  const lines = markdown.split("\n");
+  const normalized: string[] = [];
+  let activeFence: MarkdownFence | null = null;
+  let index = 0;
+  while (index < lines.length) {
+    const rawLine = lines[index] ?? "";
+    const line = trimMarkdownLineCarriageReturn(rawLine);
+    if (activeFence !== null) {
+      normalized.push(rawLine);
+      if (isMarkdownFenceClose(line, activeFence)) {
+        activeFence = null;
+      }
+      index += 1;
+      continue;
+    }
+    activeFence = parseMarkdownFenceStart(line);
+    if (activeFence !== null) {
+      normalized.push(rawLine);
+      index += 1;
+      continue;
+    }
+
+    const open =
+      OPEN_WITH_META_PATTERN.exec(line) ?? BARE_FENCE_PATTERN.exec(line);
+    const close = open === null ? null : findMathFenceClose(lines, index + 1);
+    if (open === null || close === null) {
+      normalized.push(rawLine);
+      index += 1;
+      continue;
+    }
+
+    const indent = open[1]!;
+    normalized.push(`${indent}$$`);
+    if (open[2] !== undefined) {
+      normalized.push(`${indent}${open[2]}`);
+    }
+    for (let body = index + 1; body < close.index; body += 1) {
+      normalized.push(lines[body] ?? "");
+    }
+    if (close.tex !== null) {
+      normalized.push(close.tex);
+    }
+    normalized.push(`${indent}$$`);
+    index = close.index + 1;
+  }
+  const result = normalized.join("\n");
+  return result === markdown ? markdown : result;
+}

--- a/apps/app/src/components/ui/markdown-preview.test.tsx
+++ b/apps/app/src/components/ui/markdown-preview.test.tsx
@@ -509,4 +509,41 @@ describe("MarkdownPreview", () => {
     );
     expect(container.textContent).toContain("keeps rendering.");
   });
+
+  it("closes a display math block whose `$$` delimiters are glued to the TeX (#1778)", async () => {
+    // `$$T_…` opens a math fence with the TeX as dropped meta and a trailing
+    // `…$$` never closes it, so the rest of the message used to render as one
+    // `.katex-error`.
+    const { container } = render(
+      <MarkdownPreview
+        content={[
+          "Before the formula.",
+          "",
+          "$$T_{\\text{appearance}\\rightarrow\\text{chunk}}",
+          "\\approx73\\text{--}146\\text{ ms}$$",
+          "",
+          "## Content after the formula",
+          "",
+          "- This should remain a list item.",
+          "- [This should remain a link](https://example.com).",
+        ].join("\n")}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(container.querySelector(".katex-display")).not.toBeNull(),
+    );
+    expect(container.querySelector(".katex-error")).toBeNull();
+    // The first formula line is rendered, not dropped as fence meta.
+    expect(
+      container.querySelector(".katex-display annotation")?.textContent,
+    ).toContain("appearance");
+    expect(container.querySelector("h2")?.textContent).toBe(
+      "Content after the formula",
+    );
+    expect(container.querySelectorAll("li")).toHaveLength(2);
+    expect(
+      container.querySelector('a[href="https://example.com"]')?.textContent,
+    ).toBe("This should remain a link");
+  });
 });

--- a/apps/app/src/components/ui/markdown-preview.tsx
+++ b/apps/app/src/components/ui/markdown-preview.tsx
@@ -38,6 +38,7 @@ import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { ImageLightbox } from "./image-lightbox.js";
+import { normalizeMathFences } from "./markdown-math-fences.js";
 import {
   markdownMayContainMath,
   useRehypeKatex,
@@ -1710,10 +1711,13 @@ function MarkdownPreviewComponent({
         : markdownContent,
     [markdownContent, promptMentions],
   );
-  const { frontmatter, body } = useMemo(
-    () => splitMarkdownFrontmatter(promptMarkdownContent),
-    [promptMarkdownContent],
-  );
+  const { frontmatter, body } = useMemo(() => {
+    const split = splitMarkdownFrontmatter(promptMarkdownContent);
+    return {
+      frontmatter: split.frontmatter,
+      body: normalizeMathFences(split.body),
+    };
+  }, [promptMarkdownContent]);
   // The remark transform fills this shared mount table on every parse. Keep it
   // stable while assistant text streams so the custom React component type
   // also stays stable and an already-complete directive does not remount when

--- a/apps/app/src/components/ui/markdown-prompt-blockquote-boundaries.ts
+++ b/apps/app/src/components/ui/markdown-prompt-blockquote-boundaries.ts
@@ -1,11 +1,11 @@
 const MARKDOWN_FENCE_START_PATTERN = /^(?: {0,3})(`{3,}|~{3,})/u;
 
-interface MarkdownFence {
+export interface MarkdownFence {
   character: string;
   length: number;
 }
 
-function trimMarkdownLineCarriageReturn(line: string): string {
+export function trimMarkdownLineCarriageReturn(line: string): string {
   return line.endsWith("\r") ? line.slice(0, -1) : line;
 }
 
@@ -17,7 +17,7 @@ function isPromptMarkdownBlockquoteLine(line: string): boolean {
   return /^ {0,3}>/u.test(trimMarkdownLineCarriageReturn(line));
 }
 
-function parseMarkdownFenceStart(line: string): MarkdownFence | null {
+export function parseMarkdownFenceStart(line: string): MarkdownFence | null {
   const match = MARKDOWN_FENCE_START_PATTERN.exec(
     trimMarkdownLineCarriageReturn(line),
   );
@@ -28,7 +28,10 @@ function parseMarkdownFenceStart(line: string): MarkdownFence | null {
   return { character: marker[0]!, length: marker.length };
 }
 
-function isMarkdownFenceClose(line: string, fence: MarkdownFence): boolean {
+export function isMarkdownFenceClose(
+  line: string,
+  fence: MarkdownFence,
+): boolean {
   const value = trimMarkdownLineCarriageReturn(line);
   const leadingSpaces = /^ {0,3}/u.exec(value)?.[0].length ?? 0;
   let index = leadingSpaces;


### PR DESCRIPTION
## What was wrong

`micromark-extension-math` (behind `remark-math` in `MarkdownPreview`) parses `$$` display math like a fenced code block. `$$T_{a}` at line start opens a block whose TeX is stored as fence meta and never rendered, and the block only closes on a `$$` that sits alone on its own line. A trailing `…$$` is ordinary content, so the block runs to the end of the message and `rehype-katex` renders the heading, list, and links after it as one `.katex-error`. bb did no normalization before handing text to the parser. Issue: #1778. Report: https://get-bb.github.io/reports/issues/1778.html

## What changed

- `apps/app/src/components/ui/markdown-math-fences.ts` (new): `normalizeMathFences` rewrites LaTeX-style display spans into the canonical `$$\n…\n$$` shape before parsing. It handles an opener with glued TeX (`$$x`), a trailing closer (`y$$`), and both together, including the `$$x\n$$` shape whose first line used to vanish as meta. Fenced code blocks are skipped, a span with no closing delimiter is left alone (same unclosed-fence behavior as before, which also covers a block still streaming in), and canonical blocks and inline `$$x$$` come out unchanged.
- `apps/app/src/components/ui/markdown-preview.tsx`: apply the normalizer to the body after the frontmatter split, so parse positions still line up with the string react-markdown receives.
- `apps/app/src/components/ui/markdown-prompt-blockquote-boundaries.ts`: export the existing code-fence helpers so the normalizer reuses them.

Not covered: math blocks inside blockquotes or list items keep their container prefix and are not normalized (status quo). The mobile renderer (`apps/mobile/src/markdown/parse.ts`) has the same parser semantics but renders math as source and slices by source offsets, so it is left for a separate change.

## How you verified

- `apps/app/src/components/ui/markdown-preview.test.tsx`: new case renders the issue body through `MarkdownPreview`. On origin/main it fails with `AssertionError: expected null not to be null` at `expect(container.querySelector(".katex-display")).not.toBeNull()` (the DOM contains a single `.katex-error` holding the heading, list, and link). With the fix it passes: one `.katex-display` whose annotation contains both TeX lines, no `.katex-error`, `h2`, two `li`, and the link.
- `apps/app/src/components/ui/markdown-math-fences.test.ts`: shapes A/B/C, two blocks in one document, unchanged canonical/inline/prose input, unclosed span, fenced and indented code, CRLF.
- `pnpm exec turbo run typecheck --filter=@bb/app`: `Tasks: 3 successful, 3 total`
- `pnpm exec turbo run test --filter=@bb/app`: `Tasks: 4 successful, 4 total` (410 files, 3166 tests passed)
- Manual: spawned a codex thread on a dev instance of this branch with the issue body as the prompt. The user bubble renders the KaTeX display formula (both lines), the `## Content after the formula` heading, two list items, and the link; `document.querySelectorAll(".katex-error").length === 0`.

Fixes #1778

> AGENT GENERATED: by Claude Opus 5


## Independent verification

Verified at head `6df9819a9` (origin/main is an ancestor; `mergeable: MERGEABLE`).

Commands:

- `git checkout origin/main -- apps/app/src/components/ui/markdown-preview.tsx apps/app/src/components/ui/markdown-prompt-blockquote-boundaries.ts`, moved `markdown-math-fences.ts` aside, then `pnpm exec vitest run src/components/ui/markdown-preview.test.tsx -t 1778 src/components/ui/markdown-math-fences.test.ts` in `apps/app`.
  Fail-before: `FAIL markdown-preview.test.tsx > closes a display math block whose $$ delimiters are glued to the TeX (#1778)` — `AssertionError: expected null not to be null` at `expect(container.querySelector(".katex-display")).not.toBeNull()`; DOM dump shows one `span.katex-error` containing `## Content after the formula` and the list/link. `markdown-math-fences.test.ts` fails to import the module.
- Restored the PR files and re-ran both test files: `Test Files 2 passed (2)`, `Tests 27 passed (27)`.
- `pnpm exec turbo run typecheck --filter=@bb/app --force` -> `Tasks: 3 successful, 3 total`.
- `pnpm exec turbo run test --filter=@bb/app --force` -> `Tasks: 4 successful, 4 total` (`Test Files 410 passed`, `Tests 3166 passed | 3 skipped`).
- Ad-hoc parse probe (not committed): ran `remark-parse + remark-gfm + remark-math` on 19 inputs before/after `normalizeMathFences`. Canonical blocks, 2/3-space-indented blocks inside ordered lists, inline `$$x$$` (line start, mid-paragraph, table cell), `$5 to $10`, `\$\$` escapes, `~~~`/backtick fences, blockquote-prefixed spans, and prose ending in `$$` all parse identically. Only the glued shapes A/B/C from the report change, each to a closed math node with the meta line restored as TeX.
- Live repro on my own dev instance (PR branch): spawned a codex thread whose prompt is the issue body. User bubble DOM: `katexDisplay=1`, `katexError=0`, annotation contains both TeX lines, `h2` "Content after the formula", 2 `li`, link "This should remain a link". Before the fix the same DOM is a single `.katex-error` (report screenshot).

CI on head: all required checks pass (Checks, Tests app-1/2/3, packages, server, integration, Package Smoke ubuntu/macos, version check).

Residual risks (non-blocking): spans with a container prefix (`> $$x` / `- $$x`) are not normalized and keep the old behavior; `apps/mobile/src/markdown/parse.ts` shares the parser semantics and still swallows the suffix into one source-rendered math block; a bare `$$` opener followed by a `$$x$$` line now closes at that line (invalid TeX either way).

> AGENT GENERATED: by Claude Opus 5
