### PR TITLE
Resolve a named default base branch against origin when spawning

### DIFF
--- a/apps/cli/src/commands/thread/spawn.ts
+++ b/apps/cli/src/commands/thread/spawn.ts
@@ -178,7 +178,7 @@ export function registerSpawnCommand(
     )
     .option(
       "--base-branch <branch>",
-      "Base branch for new managed worktrees. Omit to let bb choose the project's default worktree base.",
+      "Base branch for new managed worktrees. Omit to let bb choose the project's default worktree base; naming the default branch fetches and prefers origin the same way.",
     )
     .option(
       "--machine <id-or-name>",

--- a/apps/server/src/services/projects/worktree-base-branch.ts
+++ b/apps/server/src/services/projects/worktree-base-branch.ts
@@ -38,3 +38,27 @@ export function resolveManagedDefaultBaseBranchSpec(
 
   return { kind: "default" };
 }
+
+/**
+ * Resolve an explicitly named base branch against the checkout the daemon
+ * reported. Naming the checkout's default branch (`--base-branch main`) means
+ * the same thing as omitting the flag, so it gets the same local-vs-origin
+ * policy: base on `origin/<default>` when the local branch is equal or behind,
+ * keep the local branch when it is ahead or diverged. The daemon only fetches
+ * remote-qualified bases before `git worktree add`, so a plain name that stays
+ * local would otherwise seed the worktree from a stale ref without a fetch.
+ * Any other plain name is left untouched: the daemon reports no remote
+ * relation for it, so bb cannot tell whether its upstream is ahead.
+ */
+export function resolveManagedNamedBaseBranchSpec(
+  spec: Extract<BaseBranchSpec, { kind: "named" }>,
+  checkout: ResolveDefaultWorktreeBaseBranchArgs,
+): BaseBranchSpec {
+  if (spec.name !== checkout.defaultBranch) {
+    return spec;
+  }
+  const resolved = resolveDefaultWorktreeBaseBranch(checkout);
+  return resolved && resolved !== spec.name
+    ? { kind: "named", name: resolved }
+    : spec;
+}

--- a/apps/server/src/services/threads/thread-create.ts
+++ b/apps/server/src/services/threads/thread-create.ts
@@ -62,7 +62,10 @@ import type {
   ThreadProvisionContext,
   ThreadProvisionEnvironmentIntent,
 } from "./thread-provisioning-context.js";
-import { resolveManagedDefaultBaseBranchSpec } from "../projects/worktree-base-branch.js";
+import {
+  resolveManagedDefaultBaseBranchSpec,
+  resolveManagedNamedBaseBranchSpec,
+} from "../projects/worktree-base-branch.js";
 import { applyLoggedEnvironmentLifecycleEvent } from "../environments/lifecycle-outcome.js";
 import { resolveSystemProviderModels } from "../system/execution-options.js";
 
@@ -230,9 +233,10 @@ function modelCatalogCwdForResolvedEnvironment(
   }
 }
 
-interface ResolveManagedDefaultBaseBranchForCreateArgs {
+interface ResolveManagedBaseBranchForCreateArgs {
   baseBranch: BaseBranchSpec;
   hostId: string;
+  originKind: ThreadOriginKind | null;
   sourcePath: string;
 }
 
@@ -330,11 +334,18 @@ function requireLiveSourceThread(
   return sourceThread;
 }
 
-async function resolveManagedDefaultBaseBranchForCreate(
+/**
+ * Pick the ref a new managed worktree starts from. `host.list_branches`
+ * refreshes the remote-tracking refs and reports how the local default branch
+ * relates to origin; the default spec and a plain name that is the default
+ * branch both prefer origin when local is equal or behind. A fork names the
+ * branch its source environment is on, so it keeps that branch verbatim.
+ */
+async function resolveManagedBaseBranchForCreate(
   deps: ThreadCreateDeps,
-  args: ResolveManagedDefaultBaseBranchForCreateArgs,
+  args: ResolveManagedBaseBranchForCreateArgs,
 ): Promise<BaseBranchSpec> {
-  if (args.baseBranch.kind === "named") {
+  if (args.baseBranch.kind === "named" && args.originKind !== null) {
     return args.baseBranch;
   }
 
@@ -348,7 +359,9 @@ async function resolveManagedDefaultBaseBranchForCreate(
         limit: 1,
       },
     });
-    return resolveManagedDefaultBaseBranchSpec(result);
+    return args.baseBranch.kind === "named"
+      ? resolveManagedNamedBaseBranchSpec(args.baseBranch, result)
+      : resolveManagedDefaultBaseBranchSpec(result);
   } catch (error) {
     deps.logger.warn(
       {
@@ -356,7 +369,7 @@ async function resolveManagedDefaultBaseBranchForCreate(
         sourcePath: args.sourcePath,
         ...runtimeErrorLogFields(deps.config, error),
       },
-      "Failed to resolve smart worktree base branch; using source default",
+      "Failed to resolve smart worktree base branch; using requested base",
     );
     return args.baseBranch;
   }
@@ -820,9 +833,10 @@ export async function createThreadFromRequest(
         type: "direct-managed",
         hostId,
         sourcePath: managedSource.path,
-        baseBranch: await resolveManagedDefaultBaseBranchForCreate(deps, {
+        baseBranch: await resolveManagedBaseBranchForCreate(deps, {
           baseBranch: workspace.baseBranch,
           hostId,
+          originKind,
           sourcePath: managedSource.path,
         }),
         workspaceProvisionType: workspace.type,

--- a/apps/server/test/helpers/commands.ts
+++ b/apps/server/test/helpers/commands.ts
@@ -129,6 +129,8 @@ const testRpcCursorByHost = new Map<string, number>();
 interface RegisterTestHostRpcCaptureArgs {
   hostId: string;
   sessionId: string;
+  /** Checkout the fake daemon reports for `host.list_branches`. */
+  listBranchesResult?: HostDaemonOnlineRpcResult<"host.list_branches">;
 }
 
 interface TestHostRpcSocket {
@@ -386,7 +388,9 @@ export function registerTestHostRpcCapture(
             requestId: message.requestId,
             commandType: command.type,
             ok: true,
-            result: buildDefaultBranchListResult(command.selectedBranch),
+            result:
+              args.listBranchesResult ??
+              buildDefaultBranchListResult(command.selectedBranch),
           }),
           sessionId: args.sessionId,
         });

--- a/apps/server/test/public/public-threads.named-base-branch.test.ts
+++ b/apps/server/test/public/public-threads.named-base-branch.test.ts
@@ -1,0 +1,188 @@
+import { getThread } from "@bb/db";
+import { threadSchema, type ProjectSourceCheckout } from "@bb/domain";
+import { threadResponseSchema } from "@bb/server-contract";
+import { describe, expect, it } from "vitest";
+import {
+  registerTestHostRpcCapture,
+  requireManagedWorktreeEnvironmentProvisionLiveCommand,
+  waitForQueuedCommand,
+} from "../helpers/commands.js";
+import { readJson } from "../helpers/json.js";
+import {
+  seedEnvironment,
+  seedHostSession,
+  seedPrimaryHost,
+  seedProjectWithSource,
+  seedThread,
+  seedThreadRuntimeState,
+  seedTurnStarted,
+} from "../helpers/seed.js";
+import { withTestHarness, type TestAppHarness } from "../helpers/test-app.js";
+
+const SOURCE_PATH = "/tmp/named-base-branch-source";
+
+function buildCheckout(
+  defaultBranchRelation: ProjectSourceCheckout["defaultBranchRelation"],
+): ProjectSourceCheckout {
+  return {
+    branches: ["main"],
+    branchesTruncated: false,
+    checkout: { kind: "branch", branchName: "main", headSha: "abc123" },
+    defaultBranch: "main",
+    defaultBranchRelation,
+    hasUncommittedChanges: false,
+    operation: { kind: "none" },
+    originDefaultBranch: "origin/main",
+    remoteBranches: ["origin/main"],
+    remoteBranchesTruncated: false,
+    selectedBranch: null,
+  };
+}
+
+async function createNamedBaseBranchThread(
+  harness: TestAppHarness,
+  args: {
+    baseBranch: string;
+    defaultBranchRelation: ProjectSourceCheckout["defaultBranchRelation"];
+  },
+): Promise<string | null> {
+  const { host, session } = seedHostSession(harness.deps);
+  seedPrimaryHost(harness.deps, host.id);
+  registerTestHostRpcCapture(harness, {
+    hostId: host.id,
+    sessionId: session.id,
+    listBranchesResult: buildCheckout(args.defaultBranchRelation),
+  });
+  const { project } = seedProjectWithSource(harness.deps, {
+    hostId: host.id,
+    path: SOURCE_PATH,
+  });
+
+  const response = await harness.app.request("/api/v1/threads", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      origin: "sdk",
+      projectId: project.id,
+      providerId: "codex",
+      input: [{ type: "text", text: "Spawn a thread" }],
+      environment: {
+        type: "host",
+        hostId: host.id,
+        workspace: {
+          type: "managed-worktree",
+          baseBranch: { kind: "named", name: args.baseBranch },
+        },
+      },
+    }),
+  });
+  expect(response.status).toBe(201);
+  threadSchema.parse(await readJson(response));
+  const queued = await waitForQueuedCommand(
+    harness,
+    ({ command }) => command.type === "environment.provision",
+  );
+  return requireManagedWorktreeEnvironmentProvisionLiveCommand(queued).command
+    .baseBranch;
+}
+
+describe("named managed-worktree base branch", () => {
+  // Issue #1770: `--base-branch main` used to reach the daemon verbatim, and
+  // the daemon only fetches remote-qualified bases, so a checkout whose local
+  // main was behind origin seeded every new worktree from the stale commit.
+  it("bases on origin when the named default branch is behind origin", async () => {
+    await withTestHarness(async (harness) => {
+      await expect(
+        createNamedBaseBranchThread(harness, {
+          baseBranch: "main",
+          defaultBranchRelation: "local-behind",
+        }),
+      ).resolves.toBe("origin/main");
+    });
+  });
+
+  it("keeps the named default branch when local is ahead of origin", async () => {
+    await withTestHarness(async (harness) => {
+      await expect(
+        createNamedBaseBranchThread(harness, {
+          baseBranch: "main",
+          defaultBranchRelation: "local-ahead",
+        }),
+      ).resolves.toBe("main");
+    });
+  });
+
+  it("passes a named non-default branch through unchanged", async () => {
+    await withTestHarness(async (harness) => {
+      await expect(
+        createNamedBaseBranchThread(harness, {
+          baseBranch: "release/2026-05",
+          defaultBranchRelation: "local-behind",
+        }),
+      ).resolves.toBe("release/2026-05");
+    });
+  });
+
+  it("keeps a fork on its source branch even when local main is behind origin", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps);
+      registerTestHostRpcCapture(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        listBranchesResult: buildCheckout("local-behind"),
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+        path: SOURCE_PATH,
+      });
+      // An unmanaged checkout sitting on local main. A fork continues that
+      // conversation, so it must start from the branch the source is on.
+      const environment = seedEnvironment(harness.deps, {
+        branchName: "main",
+        hostId: host.id,
+        path: SOURCE_PATH,
+        projectId: project.id,
+      });
+      const sourceThread = seedThread(harness.deps, {
+        environmentId: environment.id,
+        projectId: project.id,
+      });
+      seedThreadRuntimeState(harness.deps, {
+        environmentId: environment.id,
+        permissionMode: "full",
+        providerThreadId: "provider-fork-source",
+        threadId: sourceThread.id,
+      });
+      seedTurnStarted(harness.deps, {
+        environmentId: environment.id,
+        providerThreadId: "provider-fork-source",
+        sequence: 3,
+        threadId: sourceThread.id,
+        turnId: "turn-fork-source",
+      });
+
+      const response = await harness.app.request("/api/v1/threads/fork", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          sourceThreadId: sourceThread.id,
+          workspace: "isolated",
+        }),
+      });
+      expect(response.status).toBe(201);
+      const fork = threadResponseSchema.parse(await readJson(response));
+      const forkEnvironmentId = getThread(harness.db, fork.id)?.environmentId;
+      expect(forkEnvironmentId).not.toBeNull();
+      const queued = await waitForQueuedCommand(
+        harness,
+        ({ command }) =>
+          command.type === "environment.provision" &&
+          command.environmentId === forkEnvironmentId,
+      );
+      expect(
+        requireManagedWorktreeEnvironmentProvisionLiveCommand(queued).command
+          .baseBranch,
+      ).toBe("main");
+    });
+  });
+});

--- a/apps/server/test/services/worktree-base-branch.test.ts
+++ b/apps/server/test/services/worktree-base-branch.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   resolveDefaultWorktreeBaseBranch,
   resolveManagedDefaultBaseBranchSpec,
+  resolveManagedNamedBaseBranchSpec,
 } from "../../src/services/projects/worktree-base-branch.js";
 
 describe("resolveDefaultWorktreeBaseBranch", () => {
@@ -71,5 +72,62 @@ describe("resolveManagedDefaultBaseBranchSpec", () => {
         originDefaultBranch: "origin/main",
       }),
     ).toEqual({ kind: "named", name: "origin/main" });
+  });
+});
+
+describe("resolveManagedNamedBaseBranchSpec", () => {
+  it("prefers origin when the named default branch is equal or behind", () => {
+    for (const relation of ["equal", "local-behind"] as const) {
+      expect(
+        resolveManagedNamedBaseBranchSpec(
+          { kind: "named", name: "main" },
+          {
+            defaultBranch: "main",
+            defaultBranchRelation: relation,
+            originDefaultBranch: "origin/main",
+          },
+        ),
+      ).toEqual({ kind: "named", name: "origin/main" });
+    }
+  });
+
+  it("keeps the named default branch when local is ahead, diverged, unknown, or has no origin", () => {
+    for (const relation of ["local-ahead", "diverged", "unknown"] as const) {
+      expect(
+        resolveManagedNamedBaseBranchSpec(
+          { kind: "named", name: "main" },
+          {
+            defaultBranch: "main",
+            defaultBranchRelation: relation,
+            originDefaultBranch: "origin/main",
+          },
+        ),
+      ).toEqual({ kind: "named", name: "main" });
+    }
+    expect(
+      resolveManagedNamedBaseBranchSpec(
+        { kind: "named", name: "main" },
+        {
+          defaultBranch: "main",
+          defaultBranchRelation: null,
+          originDefaultBranch: null,
+        },
+      ),
+    ).toEqual({ kind: "named", name: "main" });
+  });
+
+  it("leaves names that are not the default branch untouched", () => {
+    for (const name of ["develop", "origin/main", "feature/x"]) {
+      expect(
+        resolveManagedNamedBaseBranchSpec(
+          { kind: "named", name },
+          {
+            defaultBranch: "main",
+            defaultBranchRelation: "local-behind",
+            originDefaultBranch: "origin/main",
+          },
+        ),
+      ).toEqual({ kind: "named", name });
+    }
   });
 });

--- a/docs/worktrees.md
+++ b/docs/worktrees.md
@@ -40,7 +40,11 @@ pnpm bb thread spawn \
 
 When you omit `--base-branch`, bb chooses the project's default worktree base,
 preferring the origin default branch when safe. Pass `--base-branch <name>`
-only when you need a specific base.
+only when you need a specific base. Naming the default branch (`--base-branch
+main`) behaves like omitting the flag: bb fetches and starts from
+`origin/main` unless your local `main` is ahead or has diverged. Any other
+plain name starts from that local branch as it is; pass `origin/<name>` to
+fetch and start from the remote branch.
 
 ## Copy local files with `.worktreeinclude`
 


### PR DESCRIPTION
## What was wrong

`bb thread spawn --new-environment worktree --base-branch main` sent the plain name `main` straight through the server to the host daemon. The server's local-vs-origin resolution (`resolveManagedDefaultBaseBranchForCreate`) returned early for any `{ kind: "named" }` spec, and the daemon's `createWorktree` only fetches remote-qualified bases (`origin/main`) before `git worktree add`. Git resolved the bare `main` to the local `refs/heads/main`, so a project checkout that had not been pulled seeded every spawned worktree from the stale commit, with no fetch and no warning. Omitting the flag or passing `origin/main` was already fresh; the plain name was the one input that got neither treatment.

Issue: #1770. Report: https://get-bb.github.io/reports/issues/1770.html

## What changed

- `apps/server/src/services/projects/worktree-base-branch.ts`: new `resolveManagedNamedBaseBranchSpec`. When the named branch is the checkout's default branch, it applies the same policy the default spec uses: `origin/<default>` when local is equal or behind, the local branch when it is ahead, diverged, or unknown. Any other plain name is returned unchanged.
- `apps/server/src/services/threads/thread-create.ts`: `resolveManagedDefaultBaseBranchForCreate` is now `resolveManagedBaseBranchForCreate`. It calls `host.list_branches` for named specs too (that RPC already runs a throttled `git fetch --all --prune` on the daemon) and routes the result through the named or default resolver. A fork (`originKind !== null`) keeps its source environment's branch verbatim and makes no RPC, since it continues the conversation from the branch the source is on.
- The resolved spec is stored on the environment as before, so `bb thread show` now reports `baseBranch: "origin/main"` for a spawn that was redirected, and the provisioning transcript shows the `Fetching origin/main` step.
- Docs: `docs/worktrees.md` and the `--base-branch` help text in `apps/cli/src/commands/thread/spawn.ts` now say what a plain name resolves to.
- Test helper: `registerTestHostRpcCapture` accepts an optional `listBranchesResult` so a route test can set the default-branch relation without swapping the capture socket.

No wire change: `host.list_branches` and `environment.provision` are unchanged, so no `HOST_DAEMON_PROTOCOL_VERSION` bump. This is server-only policy, per the server/daemon split.

Deviation from the report's proposals: I did not add upstream tracking for arbitrary non-default names. The daemon only reports the relation for the default branch; doing it for any branch needs a new result field (protocol bump) or daemon-side policy. The reported case (`--base-branch main`) and its `master`/`develop`-as-default equivalents are fixed; other plain names keep today's local-only behaviour and the docs now say so.

## How you verified

New tests:

- `apps/server/test/public/public-threads.named-base-branch.test.ts` (route level, real in-memory DB, fake daemon): named `main` with `local-behind` -> provision `baseBranch` is `origin/main`; named `main` with `local-ahead` -> `main`; named `release/2026-05` -> unchanged; an isolated fork from an environment on `main` with `local-behind` -> still `main`.
- `apps/server/test/services/worktree-base-branch.test.ts`: unit cases for `resolveManagedNamedBaseBranchSpec` (equal/behind -> origin; ahead/diverged/unknown/no-origin -> local; non-default names untouched).

Fail before / pass after (checked out `origin/main` versions of the two source files, ran the route test):

```
× bases on origin when the named default branch is behind origin
AssertionError: expected 'main' to be 'origin/main' // Object.is equality
Tests  1 failed | 3 passed (4)
```

With the fix: `Tests  11 passed (11)` across both files.

Turbo, from the committed tree (`git status --porcelain` empty, after rebase on `origin/main`):

```
pnpm exec turbo run typecheck test --filter=@bb/server --filter=@bb/cli
@bb/cli:test:     Tests  453 passed (453)
@bb/server:test:  Tests  1830 passed (1830)
Tasks:    10 successful, 10 total
```

Manual repro on my own dev instance (this branch): bare `origin` at commit B, project checkout at commit A (1 behind, `origin/main` ref stale), `bb thread spawn --project ... --new-environment worktree --base-branch main --provider codex --prompt "Reply only with ok."`. Result: worktree HEAD = B (`f412fb6 B: pushed by someone else`), `remote.txt` present, `bb thread show` reports `"baseBranch": "origin/main"`, and the provisioning transcript contains `Fetching origin/main` / `Fetched origin/main`. On `origin/main` code the report shows the same setup landing on A with no fetch step.

Fixes #1770

> AGENT GENERATED: by Claude Opus 5


## Independent verification

Verified by a separate agent in its own worktree (`verify-1770-r1` at 11fc8fedd, `origin/main` is an ancestor; PR is mergeable).

Commands run:

- `pnpm install --frozen-lockfile --prefer-offline && pnpm exec turbo run build` (18/18 tasks).
- Fail-before: `git checkout origin/main -- apps/server/src/services/projects/worktree-base-branch.ts apps/server/src/services/threads/thread-create.ts`, then `pnpm exec vitest run test/public/public-threads.named-base-branch.test.ts` in `apps/server`: `× bases on origin when the named default branch is behind origin — AssertionError: expected 'main' to be 'origin/main'` (1 failed | 3 passed).
- Pass-after: restored the PR files and ran `test/public/public-threads.named-base-branch.test.ts` + `test/services/worktree-base-branch.test.ts`: 2 files, 11/11 passed.
- `umask 022 && pnpm exec turbo run typecheck test --filter=@bb/server --filter=@bb/cli`: `Tasks: 10 successful, 10 total` (server 196 test files passed, cli 48 test files passed).
- CI on 11fc8fedd: 11 checks pass, 2 skipped, none failing.

Repro on the fixed branch (own dev instance, ports 16163/24163/32163, bare remote + checkout one commit behind):

- `bb thread spawn --new-environment worktree --base-branch main --provider codex --prompt "Reply only with ok."` -> `thread show` reports `baseBranch: "origin/main"`, worktree HEAD is the remote tip (`a549651 B: pushed by someone else`), `remote.txt` present, checkout's `origin/main` refreshed, provisioning transcript shows `Fetching origin/main` / `Fetched origin/main`. On `origin/main` (per the report) the same spawn lands on the stale local commit with no fetch step. No longer reproduces.
- Guard case: after making local `main` one commit ahead of origin, the same spawn keeps `baseBranch: "main"` and the worktree contains the local-only commit (`C: local only`).

Review notes: server-only policy change; no host-protocol shapes changed, so no `HOST_DAEMON_PROTOCOL_VERSION` bump is needed. Forks (`originKind !== null`) skip the resolution and keep the source branch verbatim (covered by a test).

Residual risks (minor, non-blocking):

- A plain non-default name (`--base-branch develop`) still resolves to the local branch without a fetch; documented in `docs/worktrees.md`.
- `resolveDefaultThreadEnvironment` (thread-default-policy) pins a named base from its own `host.list_branches` call, then `createThreadFromRequest` now calls `host.list_branches` a second time for that named spec. The result is identical and the daemon throttles the fetch, so this is one extra cheap RPC.
- `packages/templates/src/templates/bb-guide-threads.md` and the bb-cli skill still describe `--base-branch` as "Base branch for a new managed worktree"; still accurate, just terser than the new `--help` text.

> AGENT GENERATED: by Claude Opus 5


## Rebase

Rebased onto `origin/main` at `75d6fc4d4` (was 33 commits behind, based on `f6fb434ab`) and squashed the two commits into one (`94d0324e8`); the resulting tree is identical to the pre-squash rebased tree. No conflicts: none of the 33 commits on main touched the seven files in this PR. The only nearby change on main was #2158 (bare repositories as worktree sources), which changes `detectGitRepo` in `packages/host-workspace`; it does not alter `host.list_branches` result shapes or the server-side base-branch resolution this PR adds, so the fix applies unchanged.

Re-verified on the new base:

- Fail-before: with `worktree-base-branch.ts` and `thread-create.ts` checked out from `origin/main`, the two new test files give `Tests 4 failed | 7 passed (11)` (`AssertionError: expected 'main' to be 'origin/main'`). Restored: `Tests 11 passed (11)`.
- From the committed tree (`git status --porcelain` empty), `umask 022`, `--force`:
  - `turbo run typecheck test --filter=@bb/server`: `Tests 1904 passed (1904)`, `Tasks: 8 successful, 8 total`
  - `turbo run typecheck test --filter=@bb/cli --filter=@bb/host-daemon`: cli `453 passed (453)`, host-daemon `555 passed (555)`, `Tasks: 10 successful, 10 total`
  - `turbo run typecheck test --filter=@bb/integration-tests`: `55 passed (55)`, `Tasks: 8 successful, 8 total`

> AGENT GENERATED: by Claude Opus 5



## Independent verification (post-rebase)

Re-verified by a separate agent after the rebase, in its own worktree (`verify-2152-rb` at `94d0324e8`, merge base `75d6fc4d4`; `git merge-tree` against the current `origin/main` `27d1017fe` is conflict-free, and none of the commits on main since the rebase touch the PR's files or the `host.list_branches` / `createWorktree` paths).

Commands run:

- `pnpm install --frozen-lockfile --prefer-offline && pnpm exec turbo run build` (18/18 tasks).
- Fail-before: `git checkout 75d6fc4d4 -- apps/server/src/services/projects/worktree-base-branch.ts apps/server/src/services/threads/thread-create.ts`, then `pnpm exec vitest run test/public/public-threads.named-base-branch.test.ts test/services/worktree-base-branch.test.ts` in `apps/server`: `Tests 4 failed | 7 passed (11)`; the route test fails with `AssertionError: expected 'main' to be 'origin/main'` (the other three fail because `resolveManagedNamedBaseBranchSpec` does not exist on main).
- Pass-after: restored the PR files (`git status --porcelain` empty): `Tests 11 passed (11)`.
- `umask 022 && pnpm exec turbo run typecheck test --filter=@bb/server --filter=@bb/cli --force --concurrency=1`: cli `Tests 453 passed (453)`; server `Tests 1904 passed (1904)`, `Tasks: 8 successful, 8 total` on the clean re-run. (A first server run had one unrelated failure, `test/services/plugins/plugin-update.test.ts`, from `disk quota exceeded` on this machine's shared `/tmp` tmpfs at 98% inodes; it passes with `TMPDIR` elsewhere and on the re-run.)
- CI on `94d0324e8`: all 10 required checks pass, 2 skipped, none failing.

Repro on the fixed branch (own dev instance, ports 18795/26795/34795, bare remote + checkout one commit behind):

- `bb thread spawn --project ... --new-environment worktree --base-branch main --provider codex --prompt "Reply only with ok."` -> `thread show` reports `baseBranch: "origin/main"`, worktree HEAD is the remote tip (`f0ac52f B: pushed by someone else`), `remote.txt` present, the checkout's `origin/main` was refreshed, and the thread events contain `Fetching origin/main` / `Fetched origin/main`. No longer reproduces.
- Guard case: after making local `main` one commit ahead (`afef38b C: local only`), the same spawn keeps `baseBranch: "main"` and the worktree contains `local.txt`.

Residual risks: unchanged from the earlier verification section (non-default plain names still resolve locally, documented; one extra cheap `host.list_branches` RPC when the default policy already pinned a named base).

> AGENT GENERATED: by Claude Opus 5
