### PR TITLE
Record Pi extension messages as provider input

### DIFF
--- a/apps/server/test/services/threads/timeline-provider-input.test.ts
+++ b/apps/server/test/services/threads/timeline-provider-input.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import {
+  encodeClientTurnRequestIdNumber,
+  threadScope,
+  turnScope,
+} from "@bb/domain";
+import type { Thread } from "@bb/domain";
+import {
+  createConnection,
+  createProject,
+  createThread,
+  insertEvents,
+  migrate,
+  noopNotifier,
+  upsertHost,
+} from "@bb/db";
+import type { DbConnection } from "@bb/db";
+import type { TimelineRow } from "@bb/server-contract";
+import { buildThreadTimelineWithProfile } from "../../../src/services/threads/timeline.js";
+
+const providerThreadId = "pi-thread-1";
+const PROCESS_EVENT =
+  '<process_event kind="success" process_id="proc_551c">Process completed successfully</process_event>';
+
+function setup(): { db: DbConnection; thread: Thread } {
+  const db = createConnection(":memory:");
+  migrate(db);
+  const host = upsertHost(db, noopNotifier, {
+    name: "test-host",
+    type: "persistent",
+  });
+  const { project } = createProject(db, noopNotifier, {
+    name: "test-project",
+    source: { type: "local_path", hostId: host.id, path: "/tmp/test" },
+  });
+  const thread = createThread(db, noopNotifier, {
+    projectId: project.id,
+    providerId: "pi",
+  });
+  return { db, thread };
+}
+
+type EventInput = Parameters<typeof insertEvents>[2][number];
+
+/**
+ * A thread the user started once, followed by a turn a Pi extension opened on
+ * its own: the only `client/turn/requested` is the first message, and the
+ * second turn's input is the provider-recorded `userMessage` item.
+ */
+function seedExtensionTriggeredTurn(db: DbConnection, thread: Thread): void {
+  const events: EventInput[] = [];
+  let sequence = 0;
+  const push = (event: Omit<EventInput, "sequence" | "threadId">): void => {
+    sequence += 1;
+    events.push({ ...event, sequence, threadId: thread.id });
+  };
+  const clientRequestId = encodeClientTurnRequestIdNumber({ value: 1 });
+  const providerEvent = (
+    type: EventInput["type"],
+    turnId: string,
+    data: Record<string, unknown>,
+    item?: { itemId: string; itemKind: EventInput["itemKind"] },
+  ): void => {
+    push({
+      type,
+      scope: turnScope(turnId),
+      providerThreadId,
+      itemId: item?.itemId ?? null,
+      itemKind: item?.itemKind ?? null,
+      parentToolCallId: null,
+      data: JSON.stringify(data),
+    });
+  };
+
+  push({
+    type: "client/turn/requested",
+    scope: threadScope(),
+    itemId: null,
+    itemKind: null,
+    parentToolCallId: null,
+    data: JSON.stringify({
+      direction: "outbound",
+      source: "spawn",
+      initiator: "user",
+      request: { method: "thread/start", params: {} },
+      requestId: clientRequestId,
+      senderThreadId: null,
+      input: [{ type: "text", text: "Reply only with ok.", mentions: [] }],
+      target: { kind: "thread-start" },
+      execution: {
+        model: "gpt-5",
+        serviceTier: "default",
+        reasoningLevel: "medium",
+        permissionMode: "full",
+        source: "client/turn/requested",
+      },
+    }),
+  });
+  providerEvent("turn/started", "turn-1", {});
+  providerEvent("turn/input/accepted", "turn-1", { clientRequestId });
+  providerEvent(
+    "item/completed",
+    "turn-1",
+    { item: { type: "agentMessage", id: "assistant-1", text: "ok" } },
+    { itemId: "assistant-1", itemKind: "agentMessage" },
+  );
+  providerEvent("turn/completed", "turn-1", {
+    status: "completed",
+    providerThreadId,
+  });
+
+  providerEvent("turn/started", "turn-2", {});
+  providerEvent(
+    "item/completed",
+    "turn-2",
+    {
+      item: {
+        type: "userMessage",
+        id: "provider-input-1",
+        content: [{ type: "text", text: PROCESS_EVENT }],
+      },
+    },
+    { itemId: "provider-input-1", itemKind: "userMessage" },
+  );
+  providerEvent(
+    "item/completed",
+    "turn-2",
+    {
+      item: {
+        type: "agentMessage",
+        id: "assistant-2",
+        text: "The process finished.",
+      },
+    },
+    { itemId: "assistant-2", itemKind: "agentMessage" },
+  );
+  providerEvent("turn/completed", "turn-2", {
+    status: "completed",
+    providerThreadId,
+  });
+
+  insertEvents(db, noopNotifier, events);
+}
+
+function conversationTexts(rows: readonly TimelineRow[]): string[] {
+  return rows.flatMap((row) => {
+    if (row.kind === "conversation") {
+      return [`${row.role}:${row.text}`];
+    }
+    if (row.kind === "turn") {
+      return conversationTexts(row.children ?? []);
+    }
+    return [];
+  });
+}
+
+describe("timeline pages with provider-recorded input", () => {
+  it("keeps the user's earlier turn on the latest page and nests the provider input in its turn", () => {
+    const { db, thread } = setup();
+    seedExtensionTriggeredTurn(db, thread);
+
+    const { response } = buildThreadTimelineWithProfile(db, thread, {
+      eventBudget: 1_000_000,
+      includeProviderUnhandledOperations: false,
+      includeNestedRows: true,
+      maxInlineOutputChars: 32_000,
+      maxSeq: 0,
+      page: { kind: "latest", segmentLimit: 20 },
+    });
+
+    // The page is anchored on stored `client/turn/requested` rows, of which
+    // there is one. A provider input row that counted as a second anchor would
+    // make the page drop the first turn and report nothing older to load.
+    expect(response.timelinePage).toEqual({
+      kind: "latest",
+      segmentLimit: 20,
+      returnedSegmentCount: 1,
+      hasOlderRows: false,
+      olderCursor: null,
+    });
+    expect(conversationTexts(response.rows)).toEqual([
+      "user:Reply only with ok.",
+      "assistant:ok",
+      `user:${PROCESS_EVENT}`,
+      "assistant:The process finished.",
+    ]);
+    const turnRow = response.rows.find(
+      (row) => row.kind === "turn" && row.turnId === "turn-2",
+    );
+    expect(turnRow?.kind === "turn" ? turnRow.children : undefined).toEqual([
+      expect.objectContaining({
+        kind: "conversation",
+        role: "user",
+        initiator: "system",
+        turnRequest: { isGrouped: false, kind: "steer", status: "accepted" },
+        text: PROCESS_EVENT,
+      }),
+    ]);
+  });
+});

--- a/packages/agent-runtime/src/pi/delta-translation.test.ts
+++ b/packages/agent-runtime/src/pi/delta-translation.test.ts
@@ -79,6 +79,29 @@ function createHarness(options?: {
   };
 }
 
+function sdkMessage(message: unknown) {
+  return {
+    jsonrpc: "2.0" as const,
+    method: "sdk/message",
+    params: { threadId: "pi-thread-1", message },
+  };
+}
+
+/** Pi's `CustomMessage`: what an extension's `pi.sendMessage` injects. */
+function createPiCustomMessage(args: {
+  content: string | Array<Record<string, unknown>>;
+  display?: boolean;
+}) {
+  return {
+    role: "custom",
+    customType: "ad-process:notification",
+    content: args.content,
+    display: args.display ?? true,
+    details: { attention: "turn", kind: "success", processId: "proc_551c" },
+    timestamp: 1_786_919_243_630,
+  };
+}
+
 function createPiAgentErrorEvent(
   errorMessage: string,
   willRetry: boolean,
@@ -267,6 +290,109 @@ describe("pi delta translation equivalence", () => {
     expect(events.some((event) => event.type === "provider/unhandled")).toBe(
       false,
     );
+  });
+
+  it("records a displayed Pi custom message as the input of the turn it triggered", () => {
+    // The order Pi emits for an idle `sendMessage(..., { triggerTurn: true })`:
+    // agent_start opens the run, then the custom message's own boundaries.
+    const harness = createHarness();
+    harness.translate(sdkMessage(loadFixture("agent-start.json")));
+    const turnId = harness.openTurnId();
+    const message = createPiCustomMessage({
+      content:
+        '<process_event kind="success" process_id="proc_551c">Process completed successfully</process_event>',
+    });
+
+    const startEvents = harness.translate(
+      sdkMessage({ type: "message_start", message }),
+    );
+    const endEvents = harness.translate(
+      sdkMessage({ type: "message_end", message }),
+    );
+
+    expect(startEvents).toEqual([
+      {
+        type: "item/completed",
+        threadId: "",
+        providerThreadId: "",
+        scope: turnScope(turnId),
+        item: {
+          type: "userMessage",
+          id: expect.stringMatching(ITEM_ID_PATTERN),
+          content: [
+            {
+              type: "text",
+              text: '<process_event kind="success" process_id="proc_551c">Process completed successfully</process_event>',
+            },
+          ],
+        },
+      },
+    ]);
+    expect(endEvents).toEqual([]);
+    expect(harness.openTurnId()).toBe(turnId);
+  });
+
+  it("joins the text blocks of an array-content Pi custom message", () => {
+    const harness = createHarness();
+    harness.translate(sdkMessage(loadFixture("agent-start.json")));
+
+    const events = harness.translate(
+      sdkMessage({
+        type: "message_start",
+        message: createPiCustomMessage({
+          content: [
+            { type: "text", text: "first" },
+            { type: "image", data: "AAAA", mimeType: "image/png" },
+            { type: "text", text: "second" },
+          ],
+        }),
+      }),
+    );
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "item/completed",
+        item: expect.objectContaining({
+          type: "userMessage",
+          content: [{ type: "text", text: "first\nsecond" }],
+        }),
+      }),
+    ]);
+  });
+
+  it("drops hidden and idle Pi custom messages without surfacing them as unhandled", () => {
+    const harness = createHarness();
+
+    // Idle `attention: context` notes: Pi appends them without running the
+    // agent, so there is no bb turn to record them in.
+    const idleMessage = createPiCustomMessage({ content: "idle context note" });
+    expect(
+      harness.translate(
+        sdkMessage({ type: "message_start", message: idleMessage }),
+      ),
+    ).toEqual([]);
+    expect(
+      harness.translate(
+        sdkMessage({ type: "message_end", message: idleMessage }),
+      ),
+    ).toEqual([]);
+    expect(harness.openTurnId()).toBe("");
+
+    harness.translate(sdkMessage(loadFixture("agent-start.json")));
+    const hiddenMessage = createPiCustomMessage({
+      content: "hidden",
+      display: false,
+    });
+    expect(
+      harness.translate(
+        sdkMessage({ type: "message_start", message: hiddenMessage }),
+      ),
+    ).toEqual([]);
+    expect(
+      harness.translate(
+        sdkMessage({ type: "message_end", message: hiddenMessage }),
+      ),
+    ).toEqual([]);
   });
 
   it("agent_end surfaces Pi assistant stop errors as failed turns", () => {

--- a/packages/agent-runtime/src/pi/delta-translation.ts
+++ b/packages/agent-runtime/src/pi/delta-translation.ts
@@ -65,6 +65,8 @@ const piEventTypeSchema = z
       "agent_start",
       "compaction_end",
       "compaction_start",
+      "message_end",
+      "message_start",
       "message_update",
       "tool_execution_end",
       "tool_execution_start",
@@ -137,6 +139,26 @@ const piConversationMessageSchema = z
     provider: z.string().optional(),
     model: z.string().optional(),
     usage: piAssistantUsageSchema.optional(),
+  })
+  .passthrough();
+
+/**
+ * Pi's `message_start`/`message_end` for an extension-injected message
+ * (`pi.sendMessage`, Pi's `CustomMessage`). Only this role is parsed: bb
+ * already owns the user, assistant, and tool-result boundaries through its own
+ * input lifecycle and the streamed/terminal assistant payloads. `display`
+ * is the extension's own statement of whether the message is meant to be seen.
+ */
+const piCustomMessageBoundaryEventSchema = z
+  .object({
+    type: z.enum(["message_end", "message_start"]),
+    message: z
+      .object({
+        role: z.literal("custom"),
+        content: z.union([z.string(), z.array(piMessageContentBlockSchema)]),
+        display: z.boolean(),
+      })
+      .passthrough(),
   })
   .passthrough();
 
@@ -670,6 +692,27 @@ export function createPiDeltaTranslator(
         return [{ kind: "turn.open" }];
       }
 
+      case "message_end":
+      case "message_start": {
+        const piEvent = piCustomMessageBoundaryEventSchema.safeParse(event);
+        // Non-custom boundaries translate to nothing on purpose; the
+        // visibility metadata rates them noise (known roles) or unknown.
+        if (!piEvent.success) {
+          return [];
+        }
+        if (
+          piEvent.data.type === "message_end" ||
+          !piEvent.data.message.display
+        ) {
+          return [];
+        }
+        const text = extractCustomMessageText(piEvent.data.message.content);
+        if (text === undefined) {
+          return [];
+        }
+        return [{ kind: "input.provider", text, ...parentRefField }];
+      }
+
       case "compaction_start": {
         const parsed = piCompactionStartEventSchema.safeParse(event);
         if (!parsed.success) {
@@ -1016,6 +1059,24 @@ function extractAssistantText(message: PiAssistantMessage): string | undefined {
     }
   }
   const text = chunks.join("\n").trim();
+  return text.length > 0 ? text : undefined;
+}
+
+function extractCustomMessageText(
+  content: z.infer<
+    typeof piCustomMessageBoundaryEventSchema
+  >["message"]["content"],
+): string | undefined {
+  const text = (
+    typeof content === "string"
+      ? content
+      : content
+          .flatMap((block) => {
+            const parsedBlock = textBlockSchema.safeParse(block);
+            return parsedBlock.success ? [parsedBlock.data.text] : [];
+          })
+          .join("\n")
+  ).trim();
   return text.length > 0 ? text : undefined;
 }
 

--- a/packages/agent-runtime/src/pi/visibility.ts
+++ b/packages/agent-runtime/src/pi/visibility.ts
@@ -22,7 +22,12 @@ type PiAssistantEventType =
   | "toolcall_start"
   | "unknown";
 
-type PiMessageBoundaryRole = "assistant" | "toolResult" | "user" | "unknown";
+type PiMessageBoundaryRole =
+  | "assistant"
+  | "custom"
+  | "toolResult"
+  | "user"
+  | "unknown";
 
 type PiSdkEventType =
   | "agent_end"
@@ -134,6 +139,7 @@ function toPiMessageBoundaryRole(
 ): PiMessageBoundaryRole {
   switch (role) {
     case "assistant":
+    case "custom":
     case "toolResult":
     case "user":
       return role;
@@ -318,6 +324,11 @@ function describeParsedPiRawEvent(
         );
       switch (event.role) {
         case "assistant":
+          return { kind, coverage: "noise" };
+        // Extension-injected messages: the translator records a displayed
+        // `message_start` as provider input; every other custom boundary
+        // (its `message_end`, hidden messages) carries nothing for bb.
+        case "custom":
           return { kind, coverage: "noise" };
         case "toolResult":
         case "user":

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,9 @@
+// Version 152 records a displayed Pi extension message (`pi.sendMessage` with
+// `triggerTurn`, e.g. a process-completion notification) as the `userMessage`
+// item of the turn it woke, and stops surfacing its `message_start`/
+// `message_end` boundaries as `provider/unhandled`. Older daemons emit the
+// unhandled rows and no input for extension-triggered turns.
+//
 // Version 151 lets the daemon re-resolve an auto/steer turn target from its
 // live runtime after the server observed an active thread but before it had a
 // turn id. A command that an older daemon reports as `appliedAs: "new-turn"`
@@ -160,7 +166,7 @@
 //
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 151 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 152 as const;
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1131,7 +1131,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(151);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(152);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/packages/provider-bridge-protocol/src/assembler/delta-assembler.ts
+++ b/packages/provider-bridge-protocol/src/assembler/delta-assembler.ts
@@ -1490,6 +1490,26 @@ export function createDeltaAssembler(
         return;
       }
 
+      case "input.provider": {
+        if (state.currentTurnId === undefined) {
+          return;
+        }
+        const parentToolCallId = mapParentRef(state, delta.parentRef);
+        events.push({
+          type: "item/completed",
+          threadId: UNSTAMPED_THREAD_ID,
+          providerThreadId: "",
+          scope: turnScope(state.currentTurnId),
+          item: {
+            type: "userMessage",
+            id: mintItemId(),
+            content: [{ type: "text", text: delta.text }],
+            ...(parentToolCallId === undefined ? {} : { parentToolCallId }),
+          },
+        });
+        return;
+      }
+
       case "turn.open": {
         if (delta.providerTurnId !== undefined) {
           // Keyed turn space: several provider turns may be open at once

--- a/packages/provider-bridge-protocol/src/contract-tests/provider-bridge-grammar.v2.snapshot.json
+++ b/packages/provider-bridge-protocol/src/contract-tests/provider-bridge-grammar.v2.snapshot.json
@@ -33,6 +33,11 @@
       "clientRequestId": "required",
       "providerTurnId": "optional"
     },
+    "input.provider": {
+      "kind": "required",
+      "text": "required",
+      "parentRef": "optional"
+    },
     "item.close": {
       "kind": "required",
       "key": "required",

--- a/packages/provider-bridge-protocol/src/thread-delta.ts
+++ b/packages/provider-bridge-protocol/src/thread-delta.ts
@@ -408,6 +408,21 @@ export const threadDeltaSchema = z.discriminatedUnion("kind", [
   }),
 
   /**
+   * Input the provider itself injected into the conversation, with no bb
+   * client request behind it (a pi extension's `sendMessage` custom message
+   * that triggered or steered a turn). The assembler records it as a
+   * `userMessage` item in the open turn so the transcript shows what the
+   * model was answering. Dropped silently when no turn is open: the provider
+   * appended it to its own context without running the agent, so there is no
+   * bb turn to attach it to.
+   */
+  z.object({
+    kind: z.literal("input.provider"),
+    text: z.string().min(1),
+    parentRef: deltaKeyPartSchema.optional(),
+  }),
+
+  /**
    * An explicit provider signal opened work (pi `agent_start`, codex
    * `turn/started`). With `providerTurnId` the turn lives in the keyed
    * provider-turn space: several may be open at once (codex multiplexes

--- a/packages/thread-view/src/build-event-projection.ts
+++ b/packages/thread-view/src/build-event-projection.ts
@@ -46,6 +46,7 @@ import {
   parseRejectedUsersFromClientRequest,
   parseUsersFromClientRequest,
   parseLegacyUserMessage,
+  parseProviderUserMessage,
 } from "./user-message-parsing.js";
 import { isTerminalBufferedTextFlushEvent } from "./assistant-buffering.js";
 import {
@@ -842,6 +843,12 @@ function buildFlatProjectionData(
       for (const userFromClientRequest of usersFromClientRequest) {
         appendProjectedUserMessage(state, userFromClientRequest);
       }
+      continue;
+    }
+
+    const providerUserMessage = parseProviderUserMessage(decoded, meta);
+    if (providerUserMessage) {
+      appendProjectedUserMessage(state, providerUserMessage);
       continue;
     }
 

--- a/packages/thread-view/src/user-message-parsing.ts
+++ b/packages/thread-view/src/user-message-parsing.ts
@@ -469,6 +469,56 @@ export function parseRejectedUsersFromClientRequest(
   return messages;
 }
 
+/**
+ * Input the provider injected into the turn on its own (a Pi extension's
+ * `sendMessage` custom message that woke or steered the agent). There is no
+ * `client/turn/requested` behind it, so the runtime records it as a
+ * `userMessage` item; project it as a system-initiated row so the transcript
+ * shows what the model was answering.
+ *
+ * The row is an accepted `steer`, never a `message`: the runtime only records
+ * provider input inside an already-open turn, and the server's timeline
+ * pagination anchors segments on `message` rows backed by a stored
+ * `client/turn/requested` event. A `message` row with no such event would
+ * make the page drop every segment before it.
+ */
+export function parseProviderUserMessage(
+  decoded: ThreadEvent,
+  meta: EventMeta,
+): EventProjectionUserMessage | null {
+  if (
+    decoded.type !== "item/completed" ||
+    decoded.item.type !== "userMessage"
+  ) {
+    return null;
+  }
+  const text = decoded.item.content
+    .flatMap((part) => (part.type === "text" ? [part.text] : []))
+    .join("");
+  if (text.length === 0) {
+    return null;
+  }
+  return {
+    kind: "user",
+    id: messageId(decoded.threadId, "provider-input", decoded.item.id),
+    threadId: decoded.threadId,
+    sourceSeqStart: meta.seq,
+    sourceSeqEnd: meta.seq,
+    createdAt: meta.createdAt,
+    scope: decoded.scope,
+    ...(decoded.item.parentToolCallId
+      ? { parentToolCallId: decoded.item.parentToolCallId }
+      : {}),
+    initiator: "system",
+    senderThreadId: null,
+    systemMessageKind: "unlabeled",
+    systemMessageSubject: null,
+    turnRequest: { isGrouped: false, kind: "steer", status: "accepted" },
+    text,
+    mentions: [],
+  };
+}
+
 export function parseLegacyUserMessage(
   decoded: ThreadEvent,
   meta: EventMeta,

--- a/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
+++ b/packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts
@@ -165,6 +165,98 @@ describe("timeline CLI rendering snapshots", () => {
     `);
   });
 
+  it("shows provider-injected input as a system-initiated steer of its turn", () => {
+    // A Pi extension woke the thread (`pi.sendMessage` with `triggerTurn`):
+    // no client request exists, the runtime recorded a `userMessage` item.
+    // It must not become a `message` row: timeline pagination anchors pages on
+    // those and only knows the ones backed by `client/turn/requested`.
+    const event = createTimelineEventFactory({ threadId: "thread-1" });
+    const events: TimelineFixtureEvent[] = [
+      event.clientTurnRequested({
+        target: { kind: "new-turn" },
+        text: "Reply only with ok.",
+      }),
+      event.turnStarted({ turnId: "turn-1" }),
+      event.assistantCompleted({
+        itemId: "assistant-1",
+        text: "ok",
+        turnId: "turn-1",
+      }),
+      event.turnCompleted({ turnId: "turn-1" }),
+      event.turnStarted({ turnId: "turn-2" }),
+      event.providerUserMessage({
+        text: '<process_event kind="success">Process completed successfully</process_event>',
+        turnId: "turn-2",
+      }),
+      event.assistantCompleted({
+        itemId: "assistant-2",
+        text: "The sleep process finished.",
+        turnId: "turn-2",
+      }),
+      event.turnCompleted({ turnId: "turn-2" }),
+    ];
+    const timeline = renderIdleTimeline(events);
+
+    expect(
+      timeline.messages.flatMap((message) =>
+        message.kind === "user"
+          ? [
+              {
+                initiator: message.initiator,
+                scope: message.scope,
+                text: message.text,
+              },
+            ]
+          : [],
+      ),
+    ).toEqual([
+      {
+        initiator: "user",
+        scope: { kind: "thread" },
+        text: "Reply only with ok.",
+      },
+      {
+        initiator: "system",
+        scope: { kind: "turn", turnId: "turn-2" },
+        text: '<process_event kind="success">Process completed successfully</process_event>',
+      },
+    ]);
+    expect(timeline.rows).toContainEqual(
+      expect.objectContaining({
+        kind: "turn",
+        turnId: "turn-2",
+        children: [
+          expect.objectContaining({
+            kind: "conversation",
+            role: "user",
+            initiator: "system",
+            turnRequest: {
+              isGrouped: false,
+              kind: "steer",
+              status: "accepted",
+            },
+            text: '<process_event kind="success">Process completed successfully</process_event>',
+          }),
+        ],
+      }),
+    );
+    expect(timeline.text).toMatchInlineSnapshot(`
+      "── User ────────────────────────────────────────────────────
+      Reply only with ok.
+
+      ── Assistant ───────────────────────────────────────────────
+      ok
+
+      ── Worked for (3ms) ────────────────────────────────────────
+        ── User
+        <process_event kind="success">Process completed successfully</process_event>
+        steer
+
+      ── Assistant ───────────────────────────────────────────────
+      The sleep process finished."
+    `);
+  });
+
   it("snapshots streaming CLI prefixes before the final idle state", () => {
     const event = createTimelineEventFactory({ threadId: "thread-1" });
     const events = [

--- a/packages/thread-view/test/timeline-test-harness.ts
+++ b/packages/thread-view/test/timeline-test-harness.ts
@@ -108,6 +108,11 @@ interface AssistantCompletedArgs extends ProviderTurnEventOptions {
   text: string;
 }
 
+interface ProviderUserMessageArgs extends ProviderTurnEventOptions {
+  itemId?: string;
+  text: string;
+}
+
 interface ClientTurnRejectedArgs extends EventFactoryRowOptions {
   message?: string;
   reason?: string;
@@ -336,6 +341,9 @@ export interface TimelineEventFactory {
   providerUnhandled(
     args?: ProviderUnhandledArgs,
   ): ThreadEventRowOfType<"provider/unhandled">;
+  providerUserMessage(
+    args: ProviderUserMessageArgs,
+  ): ThreadEventRowOfType<"item/completed">;
   providerWarning(
     args?: ProviderWarningArgs,
   ): ThreadEventRowOfType<"provider/warning">;
@@ -546,6 +554,24 @@ export function createTimelineEventFactory(
             type: "agentMessage",
             id: args.itemId ?? `assistant-${base.seq}`,
             text: args.text,
+            ...(args.parentToolCallId
+              ? { parentToolCallId: args.parentToolCallId }
+              : {}),
+          },
+        },
+      };
+    },
+    providerUserMessage(args) {
+      const base = nextProviderTurnScopedRowBase("provider-user-message", args);
+      return {
+        ...base,
+        type: "item/completed",
+        data: {
+          ...providerFields(args),
+          item: {
+            type: "userMessage",
+            id: args.itemId ?? `provider-input-${base.seq}`,
+            content: [{ type: "text", text: args.text }],
             ...(args.parentToolCallId
               ? { parentToolCallId: args.parentToolCallId }
               : {}),


### PR DESCRIPTION
## What was wrong

A Pi extension can inject a custom message and trigger a turn on its own (`pi.sendMessage(..., { triggerTurn: true })`; this is how `@aliou/pi-processes` wakes a thread when a background command finishes). Pi emits `agent_start`, then `message_start`/`message_end` with `role: "custom"` for that message. bb's Pi translator had no case for custom-role boundaries and its visibility metadata rated the role `unknown`, so both envelopes surfaced as `provider/unhandled` ("Unhandled Pi event" rows in dev builds or with the setting on), and the message itself was never recorded. The extension-triggered turn therefore showed an assistant answer with no input in front of it, in the app and in `bb thread log`. bb also had no grammar for provider-originated input at all: the narrow-grammar `thread/delta` has no delta for it, and nothing in `@bb/thread-view` projected a `userMessage` item.

The second half of the issue (Pi's `agent_end.messages` carrying string content, which stranded the turn as "Working...") already landed in #1663.

Issue: #1681. Report: https://get-bb.github.io/reports/issues/1681.html

PR #1682 attacks the same gap but was written against `event-translation.ts`, which #1834 replaced with `delta-translation.ts`; it no longer applies to main. This PR implements the equivalent on the narrow-grammar path and keeps the generic `role: "custom"` handling the report asked for.

## What changed

- `packages/provider-bridge-protocol/src/thread-delta.ts`: new `input.provider` delta (`text`, optional `parentRef`) for input the provider injected without a bb client request. Additive, so no bridge protocol version change; the G3 grammar guardrail snapshot (`provider-bridge-grammar.v2.snapshot.json`) gains the new kind.
- `packages/provider-bridge-protocol/src/assembler/delta-assembler.ts` (moved there from `@bb/agent-runtime` on main): `input.provider` records an `item/completed` `userMessage` item (assembler-minted id) in the open turn; with no turn open it is dropped, because Pi appends idle `attention: context` notes to its own context without running the agent and there is no bb turn to attach them to.
- `packages/agent-runtime/src/pi/delta-translation.ts`: parses `message_start`/`message_end` for `role: "custom"` (any `customType`, string or block-array content). A displayed `message_start` becomes `input.provider`; `message_end`, hidden messages, and empty text translate to nothing.
- `packages/agent-runtime/src/pi/visibility.ts`: custom-role boundaries are `noise`, so the silent cases never reach the unhandled fallback.
- `packages/thread-view/src/user-message-parsing.ts`, `build-event-projection.ts`: project the `userMessage` item as a system-initiated accepted steer of its turn. It renders as the existing "System Message" row in the app (inside the turn's "Worked for" group in summary mode) and as a `User` row in `bb thread log`. It is a `steer`, not a `message`, on purpose: the server pages the timeline on `message` rows backed by stored `client/turn/requested` events (`timelineSegmentAnchorConditions` in `@bb/db` vs `isTimelineSegmentAnchorRow` in `timeline-pagination.ts`). With a `message` row here the latest page silently dropped every earlier turn and reported `hasOlderRows: false`; I hit this live before switching.
- `HOST_DAEMON_PROTOCOL_VERSION` 151 -> 152 (146 -> 147, then 150 -> 151, before two rebases onto a moving main): the daemon now sends a `userMessage` item it never emitted before. The shape already existed in the shared schema, so the bump is for the semantic change and to roll the fix to enrolled daemons.

- CI guard: this PR no longer carries an `@get-bb/plugin-sdk` version change. `thread-delta.ts` and the assembler are bundled into the SDK's published provider-bridge entry points, so the npm version guard (`check-npm-version-guard.mjs`) needs an unpublished version; `main` has since moved the SDK to `0.4.13`, which npm has not published (npm latest is `0.4.12`), so this PR adopts `main`'s version and the guard passes with no further bump.

Not done, deliberately: the issue's "empty assistant output produces an explicit warning". Nothing in bb promises that today and #1682's version never fired on real Pi (it assumed `message_start` before `agent_start`).

## How you verified

New tests, all fail on `origin/main` source and pass with the fix:

- `packages/agent-runtime/src/pi/delta-translation.test.ts`
  - "records a displayed Pi custom message as the input of the turn it triggered" (real order: `agent_start` -> `message_start` -> `message_end`). On main: `AssertionError: expected [ Array(1) ] to deeply equal [ { type: 'item/completed', ... } ]` with a `provider/unhandled rawType: "sdk/message_start"` received.
  - "joins the text blocks of an array-content Pi custom message"
  - "drops hidden and idle Pi custom messages without surfacing them as unhandled". On main: `expected [ Array(1) ] to deeply equal []`.
- `packages/thread-view/test/timeline-cli-rendering.snapshots.test.ts` "shows provider-injected input as a system-initiated steer of its turn". On main: `expected [ { initiator: 'user', ... } ] to deeply equal [ { initiator: 'user', ... }, ...(1) ]` (no provider row projected).
- `apps/server/test/services/threads/timeline-provider-input.test.ts`: latest page keeps the user's first turn, `returnedSegmentCount: 1`, `hasOlderRows: false`, provider input nested in turn 2. Fails if the row is projected as a `message` (first turn dropped: `expected [ ...(2) ] to deeply equal [ 'user:Reply only with ok.', ...(3) ]`).

Commands, run from the committed tree (`git status --porcelain` empty):

- `pnpm exec turbo run typecheck --filter=@bb/provider-bridge-protocol --filter=@bb/agent-runtime --filter=@bb/thread-view --filter=@bb/host-daemon-contract --filter=@bb/host-daemon --filter=@bb/server --filter=@bb/cli --filter=@bb/app --filter=bb-plugin-provider-acp --filter=bb-plugin-provider-codex --filter=bb-plugin-provider-claude-code` -> `Tasks: 15 successful, 15 total`
- `pnpm exec turbo run test --filter=@bb/provider-bridge-protocol --filter=@bb/agent-runtime --filter=@bb/thread-view --filter=@bb/host-daemon-contract --filter=bb-plugin-provider-acp --filter=bb-plugin-provider-codex --filter=bb-plugin-provider-claude-code` -> `Tasks: 11 successful, 11 total` (agent-runtime 31 files, thread-view 21 files, protocol 10 files)
- `pnpm exec turbo run test --filter=@bb/server` -> 195/196 files pass; the one failure is `internal-skill-trees.test.ts` expecting file mode 0644 on a umask 0002 machine (pre-existing local-only failure, passes in CI). `timeline-provider-input.test.ts` passes.

Manual, on my own dev instance with the report's 30-line stand-in extension (same message shape as pi-processes 0.10.9, `PI_CODING_AGENT_DIR` pointing at a trust-listed copy of the Pi agent dir), real Pi session, prompt "Reply only with ok.":

```
16 turn/started        turn da6731fd37-t2
17 item/completed      turn da6731fd37-t2  userMessage [{"type":"text","text":"<process_event type=\"lifecycle\" kind=\"success\" process_id=\"proc_551c\" name=\"sleep-done\">Process completed ..."}]
18 item/started        turn da6731fd37-t2  agentMessage
...
21 item/completed      turn da6731fd37-t2  agentMessage "ok"
23 turn/completed      turn da6731fd37-t2  status=completed
thread status: idle
```

No `provider/unhandled` events (main produced two for `sdk/message_start`/`sdk/message_end`). `bb thread log` shows the process event as a `User` row before the `ok`. The app shows the first turn, then "Worked for 1s" containing a "System Message" row with the process event, then `ok`.

Fixes #1681

> AGENT GENERATED: by Claude Opus 5


## Independent verification

Verified by a second agent on a fresh checkout (`git fetch origin bb/fix-1681-pi-notification-wake && git checkout -b verify-1681-r1 FETCH_HEAD`, head `ce123f38e`; `origin/main` is an ancestor, and main is still at protocol 146 so the 147 bump does not collide).

Fail-before / pass-after (checked out the `origin/main` versions of the 6 non-test source files, ran the new tests, then restored):

- `packages/agent-runtime` `vitest run src/pi/delta-translation.test.ts -t "custom message"`: 3 failed on main. First assertion: `AssertionError: expected [ Array(1) ] to deeply equal [ { type: 'item/completed', …(4) } ]`, received a `provider/unhandled` whose `rawEvent.params.message.message.role` is `"custom"`. Third: `expected [ Array(1) ] to deeply equal []`. All 3 pass on the PR tree.
- `packages/thread-view` `vitest run test/timeline-cli-rendering.snapshots.test.ts -t "provider-injected"`: fails on main with `expected [ { initiator: 'user', …(2) } ] to deeply equal [ { initiator: 'user', …(2) }, …(1) ]`; passes on the PR tree.
- `apps/server` `vitest run test/services/threads/timeline-provider-input.test.ts`: fails on main (`- "user:<process_event …>"` missing from the page); passes on the PR tree. Also re-checked the guard: patching `parseProviderUserMessage` to `kind: "message"` makes it fail with the first turn dropped (`expected [ …(2) ] to deeply equal [ 'user:Reply only with ok.', …(3) ]`).

Turbo, from the committed tree:

- `turbo run typecheck` for provider-bridge-protocol, agent-runtime, thread-view, host-daemon-contract, host-daemon, server, cli, app, provider-acp, provider-codex, provider-claude-code: `Tasks: 15 successful, 15 total`.
- `turbo run test --force` for provider-bridge-protocol (10 files), agent-runtime (31), thread-view (21), host-daemon-contract (3), provider-acp (14), provider-codex (16), provider-claude-code (18): `Tasks: 11 successful, 11 total`.
- `turbo run test --filter=@bb/server --force`: 195/196 files; the one failure is `internal-skill-trees.test.ts` (file mode 436 vs 420, local umask 0002; passes in CI).

Repro on the fixed branch: own dev instance with `PI_CODING_AGENT_DIR` pointing at a trust-listed copy of the Pi agent dir and the report's 30-line stand-in extension, real Pi session (`thread spawn --provider pi --permission-mode full --prompt "Reply only with ok."`, thread `thr_byejnv6paz`). Events: `16 turn/started t2`, `17 item/completed userMessage <process_event …>`, reasoning, `agentMessage "ok"`, `27 turn/completed status=completed`, thread `status=idle`, zero `provider/unhandled` (main produced two, for `sdk/message_start` and `sdk/message_end`). The app shows the first turn intact, then "Worked for 3s" which expands to a "System Message" row with the process event, then `ok`. `bb thread log --format verbose` shows the nested `User` row with the process event and `steer`.

CI at verification time: all ubuntu checks green (Checks, Package Smoke, Tests app-1/2/3, integration, packages, server); macOS Package Smoke pending.

Residual risks / notes for the reviewer:

- In the default views the provider input is hidden until expanded: the app folds it into the collapsed "Worked for" group (existing policy for system-initiated steers) and `bb thread log` in its default `minimal` format prints an empty `── Worked for (3s)` header with no input row; only `--format verbose` shows it. The PR body's "`bb thread log` shows the process event as a `User` row" holds for verbose only. Making provider input ungrouped without turning it into a pagination anchor needs a product decision (a distinct initiator, or teaching the DB anchor query about `userMessage` items).
- Idle `attention: context` notes (no open turn) are dropped, not persisted; image blocks in custom messages are ignored.
- Linked PR #1682 is `mergeable=CONFLICTING` and edits `event-translation.ts`, which #1834 deleted; it cannot land on main.

> AGENT GENERATED: by Claude Opus 5

## Stack

Layer 1/2 of GitHub stack #2217 (`gh stack`), lands first. Base `main`, `HOST_DAEMON_PROTOCOL_VERSION` 151. Rebased onto main at `75d6fc4d4` (protocol 150): the only conflicts were `protocol.ts` and `contract.test.ts`; the rebase also regenerated the bridge grammar snapshot for the new `input.provider` delta kind. Re-verified on the new base: the three new test files fail with the six non-test source files checked out from `origin/main` (`expected [ Array(1) ] to deeply equal [ { type: 'item/completed', …(4) } ]`, `expected [ 'user:Reply only with ok.', …(2) ] to deeply equal [ 'user:Reply only with ok.', …(3) ]`) and pass on this head; `turbo run typecheck test` for host-daemon-contract, host-daemon, agent-runtime, provider-bridge-protocol, thread-view and server is green except the known local-only umask `internal-skill-trees` assertion. #2142 (layer 2/2, protocol 152) is stacked on this branch.

> AGENT GENERATED: by Claude Opus 5



## Independent verification (guards)

Re-verified head `bdf47388f` (rebased onto `origin/main` `27d1017fe`, `@get-bb/plugin-sdk` 0.4.12) against the previously verified head `3158939df` on a fresh checkout (`verify-2154-g`).

- `git range-diff 75d6fc4d4..3158939df origin/main..bdf47388f`: the single commit differs only in `packages/domain/src/plugin-sdk-version.ts` (`0.4.11` -> `0.4.12`) and `packages/plugin-sdk/package.json` (`0.4.11` -> `0.4.12`). Every other hunk is identical. `origin/main` and npm (`npm view @get-bb/plugin-sdk version`) are both still at 0.4.11 and main is still at protocol 150, so neither bump collides.
- Guards on this head: `node packages/plugin-sdk/scripts/check-npm-version-guard.mjs` -> `PASS — @get-bb/plugin-sdk@0.4.12 is not on npm yet`; `node scripts/check-provider-literal-ratchet.mjs` -> `OK: 148 references across 40 core files`.
- Fail-before / pass-after, re-run once on this head (checked out the `origin/main` copies of the 9 existing non-test source files and deleted the new `delta-translation.ts`, rebuilt, ran, restored; `git status --porcelain` empty afterwards):
  - `agent-runtime` `delta-translation.test.ts`: cannot load on main (`Cannot find module './delta-translation.js'`); passes on the PR tree.
  - `thread-view` `timeline-cli-rendering.snapshots.test.ts`: `AssertionError: expected [ { initiator: 'user', …(2) } ] to deeply equal [ { initiator: 'user', …(2) }, …(1) ]` on main; 50/50 pass on the PR tree.
  - `server` `timeline-provider-input.test.ts`: `AssertionError: expected [ 'user:Reply only with ok.', …(2) ] to deeply equal [ 'user:Reply only with ok.', …(3) ]` on main; passes on the PR tree.
  - `host-daemon-contract` `contract.test.ts`: `expected 150 to be 151` on main; 52/52 pass on the PR tree.
- `turbo run typecheck test --force` for agent-runtime, thread-view, host-daemon-contract, provider-bridge-protocol, domain, @get-bb/plugin-sdk: `Tasks: 17 successful, 17 total` (442 + 391 + 52 + 218 + 150 + 127 tests). `turbo run typecheck --filter=@bb/server`: `Tasks: 4 successful, 4 total`.
- CI for `bdf47388f` (run 32508210319): Checks, Package Smoke (ubuntu + macOS), Tests app-1/2/3, integration, packages, server all pass; `mergeable=MERGEABLE`, `mergeStateStatus=CLEAN` against `main`.
- The live Pi repro was not re-run in this pass: the diff against the previously verified head (where it was run with a real Pi extension turn) is the two version strings above, which do not reach the runtime path.


## Rebase (2026-08-21, second)

Rebased onto `main` at `d41d1abee`. Two collisions, both from `main` moving under the PR:

- `main` took protocol **151** (#2242, the auto/steer turn-target re-resolution), so this PR's change is renumbered **151 -> 152**. Its comment block now sits above main's 151 block, and the lockstep assertion in `contract.test.ts` moves to `toBe(152)`. No other file hardcodes the constant; every other consumer reads it symbolically.
- `main` moved the SDK to `0.4.13`, so `plugin-sdk-version.ts` and `plugin-sdk/package.json` resolve to main's values and drop out of this PR's diff.

Re-verified on the new base: `check-npm-version-guard.mjs` -> `PASS - @get-bb/plugin-sdk@0.4.13 is not on npm yet`. `turbo run typecheck` for server, agent-runtime, host-daemon-contract, provider-bridge-protocol, thread-view: `Tasks: 8 successful, 8 total`. `turbo run test` for the same set: host-daemon-contract 3/3 files, provider-bridge-protocol 16/16, thread-view 23/23, agent-runtime 31/31, server 200 passed / 1 skipped with the single known local-only failure `internal-skill-trees` (`mode 420` vs `436`, i.e. 0644 vs 0664 under this machine's umask 0002); it passes in CI and this PR does not touch skill trees.

**#2142 (layer 2/2) is renumbered to protocol 153 and rebased on this head.**

> AGENT GENERATED: by Claude Opus 5

