### PR TITLE
Report a failed plugin reload instead of exit 0

### DIFF
--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -1653,7 +1653,8 @@ export function registerPluginCommands(
           if (!result.ok) process.exit(1);
           return;
         }
-        if (!result.ok) exitWithError(result);
+        // A failed reload still carries the inventory: print the targeted
+        // entries (status and detail) before the error and the exit code.
         const reloaded =
           id === undefined
             ? (result.plugins ?? [])
@@ -1661,6 +1662,7 @@ export function registerPluginCommands(
         for (const entry of reloaded) {
           printPlugin(entry);
         }
+        if (!result.ok) exitWithError(result);
       }),
     );
 

--- a/apps/server/src/routes/plugins.ts
+++ b/apps/server/src/routes/plugins.ts
@@ -450,8 +450,14 @@ export function registerPluginRoutes(
 
   app.post("/plugins/reload", async (context) => {
     const id = context.req.query("id") ?? undefined;
-    await plugins.reload(id);
-    return context.json({ ok: true, plugins: plugins.list() });
+    const outcome = await plugins.reload(id);
+    // A reload that left a targeted plugin without its current sources
+    // running (degraded after a hung service, or the previous instance kept)
+    // is a failure the caller must see: `bb plugin reload` exits 1 on it and
+    // the dev loop logs it. The inventory rides along so the status detail
+    // is visible either way.
+    if (!outcome.ok) return context.json(outcome, 422);
+    return context.json(outcome);
   });
 
   app.post("/plugins/:id/enable", async (context) => {

--- a/apps/server/src/services/plugins/plugin-activation.ts
+++ b/apps/server/src/services/plugins/plugin-activation.ts
@@ -55,7 +55,8 @@ interface PluginActivationContext {
   withArtifactLock: <T>(key: string, fn: () => Promise<T>) => Promise<T>;
   withLifecycleLock: <T>(id: string, fn: () => Promise<T>) => Promise<T>;
   disposeOne: (id: string) => Promise<void>;
-  loadOne: (row: InstalledPluginRow) => Promise<void>;
+  /** Resolves the load problem, or null once the row's sources are loaded. */
+  loadOne: (row: InstalledPluginRow) => Promise<string | null>;
   restoreRegistration: (row: InstalledPluginRow) => void;
   provenanceForRow: (row: InstalledPluginRow) => PluginProvenance;
   registrationMatchesForActivation: (

--- a/apps/server/src/services/plugins/plugin-registration.ts
+++ b/apps/server/src/services/plugins/plugin-registration.ts
@@ -86,7 +86,8 @@ interface PluginRegistrationContext {
   bundledPlugins: readonly BundledPluginRegistration[];
   withLifecycleLock: <T>(id: string, fn: () => Promise<T>) => Promise<T>;
   disposeOne: (id: string) => Promise<void>;
-  loadOne: (row: InstalledPluginRow) => Promise<void>;
+  /** Resolves the load problem, or null once the row's sources are loaded. */
+  loadOne: (row: InstalledPluginRow) => Promise<string | null>;
   statuses: ReadonlyMap<
     string,
     { status: PluginRuntimeStatus; detail: string | null }

--- a/apps/server/src/services/plugins/plugin-runtime.ts
+++ b/apps/server/src/services/plugins/plugin-runtime.ts
@@ -321,6 +321,12 @@ const DEV_BUILD_PROBLEM_LABELS: Record<PluginDevBuildKind, string> = {
   host: "host bundle build failed",
 };
 
+/**
+ * Suffix on a reload problem when the new sources did not load and the
+ * previous instance keeps serving (status stays "running").
+ */
+const PREVIOUS_INSTANCE_KEPT = "the previous instance is still running";
+
 const DEFAULT_LOAD_TIMEOUT_MS = 30_000;
 const DEFAULT_SERVICE_STOP_TIMEOUT_MS = 5_000;
 const DEFAULT_SERVICE_RESTART_BASE_MS = 1_000;
@@ -1354,19 +1360,32 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
     }
   }
 
-  async function loadOne(row: InstalledPluginRow): Promise<void> {
+  function hungServicesDetail(hung: ReadonlySet<string>): string {
+    return `service ${[...hung].join(", ")} did not stop`;
+  }
+
+  /**
+   * Load `row`'s current sources. Resolves null when they are now the running
+   * instance (or the plugin stays disabled by the user's switch), else the
+   * reason they are not: a failed first load, a failed reload that kept the
+   * previous instance serving, or a hung service that blocks the load. The
+   * status is recorded either way; the return value lets the caller that
+   * asked for this load (`bb plugin reload`) report the outcome instead of
+   * success (#2029).
+   */
+  async function loadOne(row: InstalledPluginRow): Promise<string | null> {
     // Refresh identity first so even a disabled/incompatible/errored plugin
     // keeps its name, icon, and logo in the list.
     await populateIdentity(row);
     if (!row.enabled) {
       setStatus(row.id, "disabled");
-      return;
+      return null;
     }
     const previous = loaded.get(row.id);
     function failBeforeFactory(
       status: PluginRuntimeStatus,
       detail: string,
-    ): void {
+    ): string {
       // Every non-running outcome must leave a log line: without one, an
       // engines mismatch after a host upgrade leaves the plugin gone with
       // no trace outside the in-memory status (#1915).
@@ -1375,49 +1394,46 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
         logger.warn(
           `plugin ${row.id} reload failed (kept previous instance): ${detail}`,
         );
-      } else {
-        setStatus(row.id, status, detail);
-        logger.warn(`plugin ${row.id} not loaded (${status}): ${detail}`);
+        return `${detail} (${PREVIOUS_INSTANCE_KEPT})`;
       }
+      setStatus(row.id, status, detail);
+      logger.warn(`plugin ${row.id} not loaded (${status}): ${detail}`);
+      return detail;
     }
     const hung = hungServices.get(row.id);
     if (hung !== undefined && hung.size > 0) {
       // A previous instance's service never stopped; loading now would
       // double-start it (design §3: degraded rather than double-starting).
-      const detail = `service ${[...hung].join(", ")} did not stop`;
+      const detail = hungServicesDetail(hung);
       setStatus(row.id, "degraded", detail);
       logger.warn(`plugin ${row.id} not loaded (degraded): ${detail}`);
-      return;
+      return detail;
     }
     try {
       await stat(row.rootDir);
     } catch {
-      failBeforeFactory(
+      return failBeforeFactory(
         "missing",
         `plugin directory not found: ${row.rootDir} (reinstall)`,
       );
-      return;
     }
     let manifest: PluginManifest;
     try {
       manifest = await readPluginManifest(row.rootDir);
     } catch (error) {
-      failBeforeFactory(
+      return failBeforeFactory(
         "error",
         error instanceof Error ? error.message : String(error),
       );
-      return;
     }
     const engineProblem =
       checkEngineRange(manifest) ?? checkPluginSdkRange(manifest);
     if (engineProblem) {
-      failBeforeFactory("incompatible", engineProblem);
-      return;
+      return failBeforeFactory("incompatible", engineProblem);
     }
     const artifactProblem = await packagedBuiltinArtifactProblem(row, manifest);
     if (artifactProblem !== null) {
-      failBeforeFactory("incompatible", artifactProblem);
-      return;
+      return failBeforeFactory("incompatible", artifactProblem);
     }
     // Build candidate assets without publishing them; a failed reload keeps
     // the previous backend and frontend registration sets together.
@@ -1430,8 +1446,7 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
       hostArtifactProblem =
         error instanceof Error ? error.message : String(error);
       if (previous !== undefined) {
-        failBeforeFactory("error", hostArtifactProblem);
-        return;
+        return failBeforeFactory("error", hostArtifactProblem);
       }
     }
     // Branding refresh rides every load too, so `bb plugin reload` picks up a
@@ -1615,7 +1630,9 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
       logger.warn(
         `plugin ${row.id} failed to load: ${statuses.get(row.id)?.detail}`,
       );
-      return;
+      return previous !== undefined
+        ? `${message} (${PREVIOUS_INSTANCE_KEPT})`
+        : message;
     }
     if (hostArtifactProblem !== null) {
       rollbackGeneration?.();
@@ -1640,7 +1657,7 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
       handle.invalidate();
       setStatus(row.id, "error", hostArtifactProblem);
       logger.warn(`plugin ${row.id} failed to load: ${hostArtifactProblem}`);
-      return;
+      return hostArtifactProblem;
     }
     const plugin: LoadedPlugin = {
       manifest,
@@ -1658,7 +1675,8 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
     };
     if (previous !== undefined) {
       await disposePluginInstance(row.id, previous);
-      if ((hungServices.get(row.id)?.size ?? 0) > 0) {
+      const hungAfterDispose = hungServices.get(row.id);
+      if (hungAfterDispose !== undefined && hungAfterDispose.size > 0) {
         loaded.delete(row.id);
         deps.sharedPorts?.clearDeclarationsForOwner(row.id);
         for (const database of handle.databaseHandles.splice(0)) {
@@ -1669,7 +1687,7 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
           }
         }
         handle.invalidate();
-        return;
+        return hungServicesDetail(hungAfterDispose);
       }
     }
     // One map replacement is the registration commit point. Until this line,
@@ -1720,6 +1738,7 @@ export function createPluginRuntime(context: PluginRuntimeContext) {
       );
     }
     logger.info(`plugin ${row.id}@${manifest.version} loaded`);
+    return null;
   }
 
   async function disposePluginInstance(

--- a/apps/server/src/services/plugins/plugin-service.ts
+++ b/apps/server/src/services/plugins/plugin-service.ts
@@ -146,6 +146,18 @@ export interface PluginSkillRootContribution {
 }
 
 /**
+ * Result of `reload`. `plugins` is the full inventory after the reload. A
+ * reload fails when any targeted plugin is not running its current sources
+ * afterwards: the new sources did not load (the previous instance keeps
+ * serving), or a service of the previous instance never stopped and the
+ * plugin is degraded with nothing loaded (#2029). A plugin the user disabled
+ * stays disabled and is not a failure.
+ */
+export type PluginReloadOutcome =
+  | { ok: true; plugins: PluginListEntry[] }
+  | { ok: false; error: string; plugins: PluginListEntry[] };
+
+/**
  * `fs.watch` is allowed to omit the changed filename. The dev loop still has
  * to reload in that case; `.` is a non-ignored synthetic path representing an
  * unknown change somewhere below the watched plugin root.
@@ -256,7 +268,8 @@ export interface PluginService {
     id: string,
     enabled: boolean,
   ): Promise<PluginListEntry | undefined>;
-  reload(id?: string): Promise<void>;
+  /** Reload one plugin, or every plugin; see PluginReloadOutcome. */
+  reload(id?: string): Promise<PluginReloadOutcome>;
   /** Live API handle for a running plugin (used by later phases and tests). */
   getApi(id: string): BbPluginApi | undefined;
   /**
@@ -1610,14 +1623,17 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
               }
             },
             reloadPlugin: async () => {
-              await withLifecycleLock(row.id, async () => {
+              const problem = await withLifecycleLock(row.id, async () => {
                 const current = getInstalledPlugin(deps.db, row.id);
-                if (current === undefined) return;
+                if (current === undefined) return null;
                 await disposeOne(row.id);
-                await loadOne(current);
+                return loadOne(current);
               });
               await syncCliSkill();
               notifyPluginsChanged();
+              // The dev loop logs a thrown reload as "reload failed: …"
+              // instead of "reloaded" while the plugin is not running.
+              if (problem !== null) throw new Error(problem);
             },
             log: (message) => logger.info(`plugin ${row.id}: ${message}`),
           });
@@ -1824,11 +1840,19 @@ export function createPluginService(deps: PluginServiceDeps): PluginService {
       const rows = listInstalledPlugins(deps.db).filter(
         (row) => id === undefined || row.id === id,
       );
+      const failures: string[] = [];
       for (const row of rows.sort((a, b) => a.id.localeCompare(b.id))) {
-        await withLifecycleLock(row.id, () => loadOne(row));
+        const problem = await withLifecycleLock(row.id, () => loadOne(row));
+        if (problem !== null) {
+          failures.push(`plugin "${row.id}" reload failed: ${problem}`);
+        }
       }
       await syncCliSkill();
       notifyPluginsChanged();
+      const plugins = list();
+      return failures.length === 0
+        ? { ok: true, plugins }
+        : { ok: false, error: failures.join("; "), plugins };
     },
 
     getApi(id) {

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -858,7 +858,9 @@ them by mixing ink into canvas), the `--primary` accent, the secondary text tier
     repository subdirectory for a nested plugin, the semver range with its tag
     prefix and resolved tag for a Git range install, engine ranges, install
     time, integrity/registry details, and recent activation history.
-  - `bb plugin enable|disable <id>`, `bb plugin reload [id]`,
+  - `bb plugin enable|disable <id>`, `bb plugin reload [id]` (exits 1 when a
+    reloaded plugin does not come up on its current sources: the previous
+    instance was kept, or it is degraded because a service ignored its abort),
     `bb plugin remove <id>` (deletes the plugin's settings, secrets, and
     schedules; managed git/npm files are deleted, local path sources stay on
     disk, builtin removals are remembered).

--- a/apps/server/test/services/plugins/plugin-background.test.ts
+++ b/apps/server/test/services/plugins/plugin-background.test.ts
@@ -273,18 +273,70 @@ describe("plugin background services", () => {
       `,
     });
     await service.installPath(rootDir);
-    await service.reload("stubborn");
+    const outcome = await service.reload("stubborn");
     const entry = service.list().find((p) => p.id === "stubborn");
     expect(entry?.status).toBe("degraded");
     expect(entry?.statusDetail).toContain("service socket did not stop");
     // Not re-loaded: that would double-start the hung service.
     expect(service.getApi("stubborn")).toBeUndefined();
+    // The plugin is unusable after this reload (#2029): the outcome must say
+    // so instead of resolving as success while `bb stubborn` is gone.
+    expect(outcome).toEqual({
+      ok: false,
+      error: 'plugin "stubborn" reload failed: service socket did not stop',
+      plugins: service.list(),
+    });
 
     // Still degraded on a second reload attempt.
-    await service.reload("stubborn");
+    const again = await service.reload("stubborn");
     expect(service.list().find((p) => p.id === "stubborn")?.status).toBe(
       "degraded",
     );
+    expect(again.ok).toBe(false);
+  });
+
+  it("reports a failed reload that kept the previous instance", async () => {
+    const rootDir = await writePlugin(workDir, {
+      name: "bb-plugin-keeper",
+      serverSource: `
+        export default function plugin(bb: any) {
+          bb.cli.register({ name: "keeper", summary: "keeper", run() { return { exitCode: 0, stdout: "ok" }; } });
+        }
+      `,
+    });
+    const installed = await service.installPath(rootDir);
+    expect(installed.status).toBe("running");
+    const healthy = await service.reload("keeper");
+    expect(healthy.ok).toBe(true);
+
+    // A broken edit: the new sources do not load, so the host keeps the
+    // previous instance serving. The reload still did not apply.
+    await writeFile(
+      join(rootDir, "server.ts"),
+      `export default function plugin() { throw new Error("boom on load"); }`,
+    );
+    const outcome = await service.reload("keeper");
+    const entry = service.list().find((p) => p.id === "keeper");
+    expect(entry?.status).toBe("running");
+    expect(entry?.statusDetail).toBe("reload failed: boom on load");
+    expect(service.getApi("keeper")).toBeDefined();
+    expect(outcome.ok).toBe(false);
+    if (outcome.ok) throw new Error("unreachable");
+    expect(outcome.error).toBe(
+      'plugin "keeper" reload failed: boom on load (the previous instance is still running)',
+    );
+
+    // Reloading every plugin reports the same failure; the fixed plugin
+    // reloads cleanly.
+    expect((await service.reload()).ok).toBe(false);
+    await writeFile(
+      join(rootDir, "server.ts"),
+      `export default function plugin(bb: any) { bb.cli.register({ name: "keeper", summary: "keeper", run() { return { exitCode: 0, stdout: "ok" }; } }); }`,
+    );
+    expect((await service.reload("keeper")).ok).toBe(true);
+    expect(
+      service.list().find((p) => p.id === "keeper")?.statusDetail,
+    ).toBeNull();
   });
 
   it("restarts a crashed service with backoff", async () => {

--- a/apps/server/test/services/plugins/plugin-reload-route.test.ts
+++ b/apps/server/test/services/plugins/plugin-reload-route.test.ts
@@ -1,0 +1,88 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createTestAppHarness,
+  type TestAppHarness,
+} from "../../helpers/test-app.js";
+
+// The harness config uses serverPort 3334, so this host is on the local-app
+// origin allowlist the "local" auth mode enforces.
+const BASE = "http://127.0.0.1:3334";
+
+const HEALTHY_SOURCE = `export default function plugin(bb: any) {
+  bb.cli.register({ name: "keeper", summary: "keeper", run() { return { exitCode: 0, stdout: "ok" }; } });
+}
+`;
+const BROKEN_SOURCE = `export default function plugin() { throw new Error("boom on load"); }
+`;
+
+describe("POST /plugins/reload outcome", () => {
+  let harness: TestAppHarness;
+  let rootDir: string;
+
+  beforeEach(async () => {
+    harness = await createTestAppHarness();
+    rootDir = join(harness.config.dataDir, "fixtures", "bb-plugin-keeper");
+    await mkdir(rootDir, { recursive: true });
+    await writeFile(
+      join(rootDir, "package.json"),
+      JSON.stringify({
+        name: "bb-plugin-keeper",
+        version: "0.1.0",
+        bb: {
+          name: "Keeper",
+          description: "Reload outcome fixture.",
+          branding: { icon: "Zap" },
+          server: "./server.ts",
+        },
+      }),
+    );
+    await writeFile(join(rootDir, "server.ts"), HEALTHY_SOURCE);
+    const entry = await harness.pluginService.installPath(rootDir);
+    expect(entry.status).toBe("running");
+  });
+
+  afterEach(async () => {
+    await harness.cleanup();
+  });
+
+  it("answers ok with the plugin list when the reload applied", async () => {
+    const response = await harness.app.request(
+      `${BASE}/api/v1/plugins/reload?id=keeper`,
+      { method: "POST" },
+    );
+    expect(response.status).toBe(200);
+    const body: unknown = await response.json();
+    expect(body).toMatchObject({ ok: true });
+    expect(body).toMatchObject({
+      plugins: expect.arrayContaining([
+        expect.objectContaining({ id: "keeper", status: "running" }),
+      ]),
+    });
+  });
+
+  it("answers ok:false with the load problem when the new sources did not load (#2029)", async () => {
+    await writeFile(join(rootDir, "server.ts"), BROKEN_SOURCE);
+    const response = await harness.app.request(
+      `${BASE}/api/v1/plugins/reload?id=keeper`,
+      { method: "POST" },
+    );
+    // `bb plugin reload` exits 1 through this structured failure; the
+    // previous instance keeps serving, which the entry list shows.
+    expect(response.status).toBe(422);
+    const body: unknown = await response.json();
+    expect(body).toMatchObject({
+      ok: false,
+      error:
+        'plugin "keeper" reload failed: boom on load (the previous instance is still running)',
+      plugins: expect.arrayContaining([
+        expect.objectContaining({
+          id: "keeper",
+          status: "running",
+          statusDetail: "reload failed: boom on load",
+        }),
+      ]),
+    });
+  });
+});

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -218,7 +218,10 @@ added/updated/unchanged counts.
                                  tag, engine ranges, install time, and recent
                                  activation history
   bb plugin enable|disable <id>  Load or unload an installed plugin
-  bb plugin reload [id]          Re-run factories against current sources
+  bb plugin reload [id]          Re-run factories against current sources.
+                                 Exits 1 when a plugin does not come up on
+                                 them (previous instance kept, or degraded
+                                 because a service ignored its abort)
   bb plugin config <id> [set <key> <value> | unset <key>]
                                  Show or change a plugin's declared settings
   bb plugin logs <id> [-n N] [-f]  Print (or follow) a plugin's bb.log output


### PR DESCRIPTION
## What was wrong

`bb plugin reload` reported success for a reload that left the plugin unusable. `PluginService.reload()` returned `void`, `POST /api/v1/plugins/reload` answered `{ ok: true }` unconditionally, and the CLI exited 1 only on `ok: false` or an unknown id. So when a background service ignored its abort signal, the runtime correctly refused to double-start it, marked the plugin `degraded`, closed the old instance's database handles, and unloaded it (its `bb` command gone, the orphaned service ticking `The database connection is not open` every second), and the reload still returned exit 0 / `ok: true`. The same held when the new sources failed to load and the runtime kept the previous instance (`running` with `reload failed: …`). Issue: #2029 (defect 2). Report: https://get-bb.github.io/reports/issues/2029.html

Defect 1 in the issue (the host rebuilding `dist/app.*` into a path-installed plugin root) is the documented path-install cache policy (`isMutableAppBundleStale`, covered by existing tests) and is tracked by #1863; this PR does not change it.

## What changed

- `apps/server/src/services/plugins/plugin-runtime.ts`: `loadOne(row)` resolves the load problem (`string | null`) instead of `void`. Null means the row's current sources are running now, or the plugin stays disabled by the user's switch. Every failure exit returns its reason; a reload that kept the previous instance says so (`… (the previous instance is still running)`); the two hung-service exits share `hungServicesDetail`. Statuses and log lines are unchanged.
- `apps/server/src/services/plugins/plugin-service.ts`: `reload(id?)` returns `PluginReloadOutcome`: `{ ok: true, plugins }` or `{ ok: false, error, plugins }` where `error` lists each targeted plugin that did not come up and `plugins` is the inventory after the reload. The builtin source-watcher's `reloadPlugin` throws the same problem so the dev loop logs `reload failed: …` instead of `reloaded`.
- `apps/server/src/routes/plugins.ts`: the route answers `422 { ok: false, error, plugins }` on failure; success body is unchanged (`pluginReloadResponseSchema` still matches). SDK callers (web `PluginHealthBanner`, mobile `useReloadPlugins`) already surface a thrown `BbHttpError` with the server's message. No host daemon wire change, so no `HOST_DAEMON_PROTOCOL_VERSION` bump.
- `apps/cli/src/commands/plugin.ts`: `bb plugin reload` prints the targeted entries (status and detail) before the error and exit 1; `--json` already exited 1 on `ok: false`. `bb plugin dev` already throws on `!ok` and its loop logs it.
- Guide (`packages/templates/src/templates/bb-guide-plugins.md`) and bb-cli skill (`apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md`): document the exit code.
- `plugin-registration.ts`, `plugin-activation.ts`: `loadOne` dep type follows.

## How you verified

Tests that fail on `origin/main` and pass here:

- `apps/server/test/services/plugins/plugin-background.test.ts`
  - `marks the plugin degraded when a service ignores its abort` now asserts the outcome. Before: `AssertionError: expected undefined to deeply equal { ok: false, …(2) }`.
  - `reports a failed reload that kept the previous instance` (new): broken edit → `running` + `reload failed: boom on load`, outcome `ok: false` with `plugin "keeper" reload failed: boom on load (the previous instance is still running)`; reload-all reports it; a fixed edit reloads `ok: true`.
- `apps/server/test/services/plugins/plugin-reload-route.test.ts` (new, real app harness): success → 200 `{ ok: true, plugins }`; broken sources → 422 `{ ok: false, error, plugins: [{ status: "running", statusDetail: "reload failed: boom on load" }] }`. Before: `AssertionError: expected 200 to be 422`.

Commands (from the committed tree):

- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/cli --filter=@bb/templates` → `Tasks: 6 successful, 6 total`
- `pnpm exec turbo run test --filter=@bb/cli --filter=@bb/templates` → `Tasks: 8 successful, 8 total` (453 + 41 tests)
- `pnpm exec turbo run test --filter=@bb/server` → 1825 passed, 1 failed: `test/internal/internal-skill-trees.test.ts` (`mode: 420` vs `436`), the known local umask-0002 failure unrelated to this change; it passes in CI.

Manual repro on my own dev instance with the report's fixture (a path plugin whose `lane-watcher` service captures `bb.storage.database()` and ignores abort):

```
$ bb plugin reload collab-fixture
collab-fixture@0.1.0  degraded  (service lane-watcher did not stop)
  source: path:/home/sawyer/.bb-dev/scratch/2029/bb-plugin-collab
plugin "collab-fixture" reload failed: service lane-watcher did not stop
exit=1
$ bb plugin reload --json collab-fixture   # "ok": false, same error, exit=1
$ curl -X POST $BB_SERVER_URL/api/v1/plugins/reload?id=collab-fixture   # HTTP 422
```

Before this change the same reload printed the degraded entry and exited 0 with `"ok": true` (report step 3).

Fixes #2029

> AGENT GENERATED: by Claude Opus 5



## Independent verification

Checked out `bb/fix-2029-plugin-reload-orphans` (8d1939770, one commit on top of origin/main f6fb434ab; origin/main has not moved since) in a separate worktree and dev instance.

Commands:

- `pnpm install --frozen-lockfile --prefer-offline && pnpm exec turbo run build` (18/18 tasks).
- Fail-before: `git checkout origin/main -- apps/cli/src/commands/plugin.ts apps/server/src/routes/plugins.ts apps/server/src/services/plugins/{plugin-activation,plugin-registration,plugin-runtime,plugin-service}.ts`, then `pnpm exec vitest run test/services/plugins/plugin-background.test.ts test/services/plugins/plugin-reload-route.test.ts` from `apps/server`: 3 failed / 15 passed.
  - `marks the plugin degraded when a service ignores its abort`: `AssertionError: expected undefined to deeply equal { ok: false, …(2) }`
  - `reports a failed reload that kept the previous instance`: `TypeError: Cannot read properties of undefined (reading 'ok')` at `expect(healthy.ok).toBe(true)`
  - `answers ok:false with the load problem when the new sources did not load (#2029)`: `AssertionError: expected 200 to be 422`
- Pass-after: `git checkout HEAD -- <same files>`, same vitest run: 18/18 passed.
- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/cli --filter=@bb/templates`: `Tasks: 6 successful, 6 total`.
- `pnpm exec turbo run test --filter=@bb/server --filter=@bb/cli --filter=@bb/templates`: cli 453/453, templates 41/41, server 1825 passed / 1 failed (`test/internal/internal-skill-trees.test.ts` mode 420 vs 436, the known local umask-0002 failure; unrelated, green in CI).
- CI on the PR: all checks pass (Checks, Package Smoke x2, Tests app-1/2/3, integration, packages, server).

Repro on the fixed branch (own dev instance, report fixture: path plugin whose `lane-watcher` service captures `bb.storage.database()` and ignores abort):

```
$ bb plugin install <fixture> --yes      -> collab-fixture@0.1.0 running; bb collab -> "collab ok", exit=0
$ bb plugin reload collab-fixture
collab-fixture@0.1.0  degraded  (service lane-watcher did not stop)
  source: path:.../bb-plugin-collab
plugin "collab-fixture" reload failed: service lane-watcher did not stop
exit=1
$ bb plugin reload --json collab-fixture -> {"ok":false,"error":"plugin \"collab-fixture\" reload failed: service lane-watcher did not stop"}, exit=1
$ curl -X POST $BB_SERVER_URL/api/v1/plugins/reload?id=collab-fixture -> http=422
$ bb plugin reload                        -> exit=1, prints the degraded entry then the error
$ bb plugin reload automations            -> running, exit=0; raw POST -> http=200
```

On main the same reload exits 0 with `ok: true` (report step 3). The orphaned service still logs `The database connection is not open` every tick, which is the documented degraded contract and out of scope here.

Review notes: root cause (reload outcome never propagated) is fixed in the server, which owns the policy; no host-daemon wire change, so no protocol bump needed. CLI `callPlugins` already passes 422 bodies through, the dev loop catches the thrown reload, and the SDK surfaces the 422 as `BbHttpError` with the server message (web banner toasts, mobile mutation toasts). Guide and bb-cli skill document the exit code. Minor, non-blocking: `pluginReloadResponseSchema` in server-contract still types only the success body, so SDK callers see the failure via `BbHttpError.body` untyped; web `PluginHealthBanner` does not invalidate the plugin list on error and relies on the `plugins-changed` broadcast for the refreshed status. Defect 1 (rebuild into a path plugin root) is intentionally left to #1863.

> AGENT GENERATED: by Claude Opus 5


## Rebase

Rebased onto origin/main `85eec4da6` (was 33 commits behind; still one commit, now `c7cd438b3`). `git rebase origin/main` applied with no conflicts. Main's changes in the touched files are orthogonal to this fix: `plugin-runtime.ts` gained provider `installRank` and per-command settings reads (#2148), `plugin-service.ts` gained agent-tool presentation for grammar v3 (#2164), and the guide/skill docs gained unrelated lines. None of that touches `loadOne`'s exits or `reload`, so the `string | null` load problem and the `PluginReloadOutcome` plumbing map onto the new code unchanged.

Re-proved on the new base. With the six non-test source files reverted to origin/main, `plugin-background.test.ts` + `plugin-reload-route.test.ts`: 3 failed / 15 passed (`expected undefined to deeply equal { ok: false, …(2) }`, `Cannot read properties of undefined (reading 'ok')`, `expected 200 to be 422`); restored: 18/18 passed. From the committed tree: `turbo typecheck --filter=@bb/server --filter=@bb/cli --filter=@bb/templates --filter=@bb/host-daemon --filter=@bb/sdk` → `Tasks: 8 successful, 8 total`; `turbo test --filter=@bb/cli --filter=@bb/templates` → `Tasks: 8 successful, 8 total` (453 + 41 tests); `turbo test --filter=@bb/server` → 1898 passed, 2 failed: the known local umask `internal-skill-trees` failure and a 5s timeout in `plugin-update.test.ts` (`waits one full interval…`) on a box at load average 128 with swap full; that file passes 27/27 when run alone.

> AGENT GENERATED: by Claude Opus 5



## Independent verification (post-rebase)

Re-verified the rebased head `c7cd438b3` (one commit; merge base with origin/main is `75d6fc4d4`, and the only newer main commit, `85eec4da6`, is a TestFlight CI change) in a fresh worktree and own dev instance. `git merge --no-commit origin/main` is clean. Main's intervening changes to `plugin-runtime.ts` (#2148 provider `installRank`, per-command settings reads) and `plugin-service.ts` (#2164 grammar-v3 agent-tool presentation) do not add any exit to `loadOne`; every exit in the rebased `loadOne` returns its problem (`string | null`) and the final path returns `null`. No provider-bridge-protocol, provider plugin, or agent-runtime file is touched, so no parity run was needed and no `HOST_DAEMON_PROTOCOL_VERSION` bump is required.

Commands:

- `pnpm install --frozen-lockfile --prefer-offline && pnpm exec turbo run build` (18/18 tasks).
- Fail-before: `git checkout origin/main -- apps/cli/src/commands/plugin.ts apps/server/src/routes/plugins.ts apps/server/src/services/plugins/{plugin-activation,plugin-registration,plugin-runtime,plugin-service}.ts`, then `pnpm exec vitest run test/services/plugins/plugin-background.test.ts test/services/plugins/plugin-reload-route.test.ts` from `apps/server`: 3 failed / 15 passed.
  - `marks the plugin degraded when a service ignores its abort`: `AssertionError: expected undefined to deeply equal { ok: false, …(2) }`
  - `reports a failed reload that kept the previous instance`: `TypeError: Cannot read properties of undefined (reading 'ok')`
  - `answers ok:false with the load problem when the new sources did not load (#2029)`: `AssertionError: expected 200 to be 422`
- Pass-after: `git checkout HEAD -- <same files>`, same run: 18/18 passed.
- From the committed tree (`git status --porcelain` empty): `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/cli --filter=@bb/templates --filter=@bb/sdk --filter=@bb/host-daemon` → `Tasks: 8 successful, 8 total`.
- `pnpm exec turbo run test --filter=@bb/server --filter=@bb/cli --filter=@bb/templates`: cli 453/453, templates 41/41, server 1899 passed / 1 failed (`test/internal/internal-skill-trees.test.ts` mode 420 vs 436, the known local umask-0002 failure; unrelated, green in CI).
- CI on `c7cd438b3`: all checks pass (Checks, Package Smoke ubuntu + macos, Tests app-1/2/3, integration, packages, server, version check); iOS simulator and Node compat smoke are conditional skips.

Repro on the rebased branch (own dev instance, report fixture: path plugin whose `lane-watcher` captures `bb.storage.database()` and ignores abort):

```
$ bb plugin install <fixture> --yes   -> collab-fixture@0.1.0 running; bb collab -> "collab ok", exit=0
$ bb plugin reload collab-fixture
plugin "collab-fixture" reload failed: service lane-watcher did not stop
exit=1
$ bb plugin reload --json collab-fixture -> {"ok":false,"error":"plugin \"collab-fixture\" reload failed: service lane-watcher did not stop", ...}, exit=1
$ curl -X POST $BB_SERVER_URL/api/v1/plugins/reload?id=collab-fixture -> http=422, same body
$ bb collab                            -> error: unknown command 'collab' (degraded, as designed)
$ bb plugin reload                     -> exit=1 (reports the degraded plugin)
$ bb plugin reload automations         -> running, exit=0; raw POST -> http=200
```

On main the same reload exits 0 with `ok: true` (report step 3). Residual, unchanged from the first verification: the orphaned service still logs `The database connection is not open` every tick (documented degraded contract); `pluginReloadResponseSchema` types only the success body, so SDK callers see the 422 as a `BbHttpError` with the server message; defect 1 (rebuild into a path plugin root) is left to #1863.

> AGENT GENERATED: by Claude Opus 5
