### PR TITLE
Add bb thread --plan for CLI/SDK parity with the composer's plan action

### DIFF
--- a/apps/cli/src/__tests__/command-output/thread-spawn.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-spawn.test.ts
@@ -92,6 +92,51 @@ describe("bb thread spawn command output", () => {
     });
   });
 
+  it("bb thread spawn --plan opens the thread with the composer's /plan command mention", async () => {
+    const thread: domain.Thread = fixtures.makeThread({
+      id: "thread-plan",
+      projectId: "proj-1",
+      providerId: "claude-code",
+    });
+    const post = vi.fn(async () => thread);
+    stubServerApi({ "v1.threads.$post": post });
+
+    await runCommand(
+      [
+        "thread",
+        "spawn",
+        "--project",
+        "proj-1",
+        "--prompt",
+        "add a README",
+        "--plan",
+      ],
+      register,
+    );
+
+    expect(post).toHaveBeenCalledWith({
+      json: expect.objectContaining({
+        input: [
+          {
+            type: "text",
+            text: "/plan add a README",
+            mentions: [
+              expect.objectContaining({
+                start: 0,
+                end: 5,
+                resource: expect.objectContaining({
+                  kind: "command",
+                  trigger: "/",
+                  name: "plan",
+                }),
+              }),
+            ],
+          },
+        ],
+      }),
+    });
+  });
+
   it("bb thread spawn requires an explicit --project", async () => {
     vi.stubEnv("BB_PROJECT_ID", undefined);
     const post = vi.fn();

--- a/apps/cli/src/__tests__/command-output/thread-tell.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-tell.test.ts
@@ -128,6 +128,56 @@ describe("bb thread tell command output", () => {
     });
   });
 
+  // Plan mode is keyed on the structured /plan command mention the composer
+  // sends, never on literal text; without the mention the Claude CLI answers
+  // "/plan isn't available in this environment" (#2019).
+  it("bb thread tell --plan sends the composer's /plan command mention", async () => {
+    const post = vi.fn(async () => ({ ok: true }));
+    stubServerApi({ "v1.threads.:id.send.$post": post });
+
+    await runCommand(
+      [
+        "thread",
+        "tell",
+        "thread-plan",
+        "add a README",
+        "--plan",
+        "--file",
+        "/tmp/report.pdf",
+      ],
+      register,
+    );
+
+    expect(post).toHaveBeenCalledWith({
+      param: { id: "thread-plan" },
+      json: {
+        input: [
+          {
+            type: "text",
+            text: "/plan add a README",
+            mentions: [
+              {
+                start: 0,
+                end: 5,
+                resource: {
+                  kind: "command",
+                  trigger: "/",
+                  name: "plan",
+                  source: "command",
+                  origin: "builtin",
+                  label: "plan",
+                  argumentHint: null,
+                },
+              },
+            ],
+          },
+          { type: "localFile", path: "/tmp/report.pdf" },
+        ],
+        mode: "steer-if-active",
+      },
+    });
+  });
+
   it("bb thread tell forwards host-readable paths without reading them on the CLI machine", async () => {
     const post = vi.fn(async () => ({ ok: true }));
     stubServerApi({ "v1.threads.:id.send.$post": post });

--- a/apps/cli/src/commands/thread/actions.ts
+++ b/apps/cli/src/commands/thread/actions.ts
@@ -24,6 +24,7 @@ import {
   parsePermissionMode,
   parseServiceTier,
   PERMISSION_MODE_HELP,
+  PLAN_HELP,
   buildPromptInputs,
   collectOption,
 } from "./helpers.js";
@@ -69,6 +70,7 @@ interface ThreadTellCommandOptions {
   reasoningLevel?: string;
   serviceTier?: string;
   mode?: string;
+  plan?: boolean;
   file?: string[];
   image?: string[];
 }
@@ -97,6 +99,7 @@ interface PostThreadMessageArgs {
   reasoningLevel?: ReasoningLevel;
   serviceTier?: ServiceTier;
   senderThreadId?: string;
+  plan?: boolean;
   files?: readonly string[];
   images?: readonly string[];
 }
@@ -423,6 +426,7 @@ export function registerActionsCommands(
     )
     .option("--permission-mode <mode>", PERMISSION_MODE_HELP)
     .option("--mode <mode>", "Message mode: steer (default), queue, or auto")
+    .option("--plan", PLAN_HELP)
     .option(
       "--file <path>",
       "Pass a host-readable absolute or uploaded attachment file path (repeatable)",
@@ -448,6 +452,7 @@ export function registerActionsCommands(
             reasoningLevel: parseReasoningLevel(opts.reasoningLevel),
             serviceTier: parseServiceTier(opts.serviceTier),
             senderThreadId: resolveSenderThreadId(id),
+            plan: opts.plan,
             files: opts.file,
             images: opts.image,
           });
@@ -530,6 +535,7 @@ async function postThreadMessage(
     threadId: args.threadId,
     input: buildPromptInputs({
       message: args.message,
+      plan: args.plan,
       files: args.files,
       images: args.images,
     }),

--- a/apps/cli/src/commands/thread/helpers.ts
+++ b/apps/cli/src/commands/thread/helpers.ts
@@ -1,4 +1,5 @@
 import {
+  createBuiltinPlanCommandTextInput,
   permissionModeInputSchema,
   type PermissionMode,
   type PromptInput,
@@ -20,6 +21,8 @@ export const DEFAULT_THREAD_WAIT_TIMEOUT_SECONDS =
 const SERVICE_TIERS: ServiceTier[] = ["fast", "default"];
 export const PERMISSION_MODE_HELP =
   "Permission mode: accept-edits, auto, or full";
+export const PLAN_HELP =
+  "Send the message as the provider's /plan action so the agent proposes a plan for approval before executing";
 
 export function collectOption(value: string, previous: string[]): string[] {
   return [...previous, value];
@@ -29,9 +32,13 @@ export function buildPromptInputs(args: {
   message: string;
   files?: readonly string[];
   images?: readonly string[];
+  /** Open the provider's plan action (`/plan`) instead of executing. */
+  plan?: boolean;
 }): PromptInput[] {
   return [
-    { type: "text", text: args.message, mentions: [] },
+    args.plan
+      ? createBuiltinPlanCommandTextInput(args.message)
+      : { type: "text", text: args.message, mentions: [] },
     ...(args.files ?? []).map(
       (path): PromptInput => ({ type: "localFile", path }),
     ),

--- a/apps/cli/src/commands/thread/spawn.ts
+++ b/apps/cli/src/commands/thread/spawn.ts
@@ -26,6 +26,7 @@ import {
   buildPromptInputs,
   collectOption,
   PERMISSION_MODE_HELP,
+  PLAN_HELP,
   parseServiceTier,
 } from "./helpers.js";
 
@@ -43,6 +44,7 @@ interface ThreadSpawnCommandOptions {
   title?: string;
   serviceTier?: string;
   permissionMode?: string;
+  plan?: boolean;
   parentSelf?: boolean;
   machine?: string;
   host?: string;
@@ -202,6 +204,7 @@ export function registerSpawnCommand(
     .option("--title <title>", "Thread title")
     .option("--service-tier <tier>", "Service tier: fast or default")
     .option("--permission-mode <mode>", PERMISSION_MODE_HELP)
+    .option("--plan", PLAN_HELP)
     .option(
       "--file <path>",
       "Pass a host-readable absolute or uploaded attachment file path (repeatable)",
@@ -300,6 +303,7 @@ export function registerSpawnCommand(
             ...(opts.model ? { model: opts.model } : {}),
             input: buildPromptInputs({
               message: opts.prompt,
+              plan: opts.plan,
               files: opts.file,
               images: opts.image,
             }),

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -385,6 +385,13 @@ or artifacts, validation performed, and blockers.
 <seconds>` when you need a shorter or longer budget.
 - Use `bb thread tell <thread-id> "..."` when requirements change, a blocker
   needs clarification, or follow-up work is needed.
+- Add `--plan` to `bb thread spawn` or `bb thread tell` to send the prompt as
+  the provider's structured `/plan` action: the agent proposes a plan for
+  approval before executing (Claude Code and Codex). Plain `/plan ...` text is
+  not recognized and reaches the provider as literal text. Review the proposed
+  plan with `bb thread interactions`; `bb thread cancel-plan` leaves Plan mode
+  early. The SDK equivalent is `input: [createBuiltinPlanCommandTextInput(text)]`
+  (exported by `@bb/sdk`) on `threads.spawn` / `threads.send`.
 - Use `bb thread edit-message <thread-id> --message "..."` to replace and rerun
   the latest eligible user message in a Codex, Claude Code, or Pi thread. Pass
   `--expected-request-sequence <sequence>` to select an earlier message. Failed

--- a/packages/domain/src/shared-types.ts
+++ b/packages/domain/src/shared-types.ts
@@ -356,6 +356,42 @@ export function createStandaloneBuiltinCompactCommandInput(): PromptInput[] {
   ];
 }
 
+const BUILTIN_PLAN_COMMAND_TEXT = "/plan";
+
+/**
+ * Text prompt input that opens the provider's plan action for `text`: the
+ * same `/plan` command mention the composer's plan action produces, so a CLI
+ * or SDK caller reaches plan mode without hand-building a mention. Plan mode
+ * is keyed on the mention, not on the literal text: plain `/plan ...` text is
+ * forwarded to the provider unchanged.
+ */
+export function createBuiltinPlanCommandTextInput(
+  text: string,
+): TextPromptInput {
+  return {
+    type: "text",
+    text:
+      text.length > 0
+        ? `${BUILTIN_PLAN_COMMAND_TEXT} ${text}`
+        : BUILTIN_PLAN_COMMAND_TEXT,
+    mentions: [
+      {
+        start: 0,
+        end: BUILTIN_PLAN_COMMAND_TEXT.length,
+        resource: {
+          kind: "command",
+          trigger: "/",
+          name: "plan",
+          source: "command",
+          origin: "builtin",
+          label: "plan",
+          argumentHint: null,
+        },
+      },
+    ],
+  };
+}
+
 export function promptInputHasCommandMention(
   input: readonly PromptInput[],
   selector: PromptCommandSelector,

--- a/packages/domain/test/shared-types.test.ts
+++ b/packages/domain/test/shared-types.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  createBuiltinPlanCommandTextInput,
   permissionModeInputSchema,
   permissionModeSchema,
   promptInputHasCommandMention,
@@ -228,5 +229,28 @@ describe("prompt command input helpers", () => {
         name: "plan",
       }),
     ).toEqual(input);
+  });
+
+  // The CLI/SDK plan input must round-trip through the same selector the
+  // server keys plan mode on, and strip back to the bare request.
+  it("builds plan command input the plan selector recognizes and strips", () => {
+    const input = [createBuiltinPlanCommandTextInput("review the diff")];
+
+    expect(input[0]?.text).toBe("/plan review the diff");
+    expect(
+      promptInputHasCommandMention(input, { trigger: "/", name: "plan" }),
+    ).toBe(true);
+    expect(
+      removeCommandMentionsFromPromptInput(input, {
+        trigger: "/",
+        name: "plan",
+      }),
+    ).toEqual([{ type: "text", text: "review the diff", mentions: [] }]);
+    expect(
+      removeCommandMentionsFromPromptInput(
+        [createBuiltinPlanCommandTextInput("")],
+        { trigger: "/", name: "plan" },
+      ),
+    ).toEqual([{ type: "text", text: "", mentions: [] }]);
   });
 });

--- a/packages/sdk/src/browser.ts
+++ b/packages/sdk/src/browser.ts
@@ -1,4 +1,9 @@
-import { createBbSdk, type BbSdk, type BbSdkAreas } from "./core.js";
+import {
+  createBbSdk,
+  createBuiltinPlanCommandTextInput,
+  type BbSdk,
+  type BbSdkAreas,
+} from "./core.js";
 import { createHttpTransport } from "./transport-http.js";
 import type {
   BbRealtimeSocketFactory,
@@ -49,7 +54,7 @@ export const bb = createBrowserBbSdk();
 
 export { BbHttpError, BbRequestTimeoutError } from "./response.js";
 export type { BbHttpErrorArgs } from "./response.js";
-export { createBbSdk, createHttpTransport };
+export { createBbSdk, createBuiltinPlanCommandTextInput, createHttpTransport };
 export type { BbSdk, BbSdkAreas, BbSdkContext, BbSdkTransport };
 export type * from "./areas/skills.js";
 export type * from "./public-types.js";

--- a/packages/sdk/src/core.ts
+++ b/packages/sdk/src/core.ts
@@ -23,6 +23,9 @@ import {
 } from "./areas/thread-sections.js";
 
 export type * from "./public-types.js";
+// Structured prompt input for the provider's plan action; pass it as
+// `input` to `threads.spawn` / `threads.send` (the CLI's `--plan`).
+export { createBuiltinPlanCommandTextInput } from "@bb/domain";
 
 export interface CreateBbSdkArgs {
   context?: BbSdkContext;

--- a/packages/sdk/src/node.ts
+++ b/packages/sdk/src/node.ts
@@ -96,6 +96,7 @@ export {
   DEFAULT_BB_REQUEST_TIMEOUT_MS,
 };
 export { BbHttpError, BbRequestTimeoutError } from "./response.js";
+export { createBuiltinPlanCommandTextInput } from "./core.js";
 export { createGuideArea } from "./areas/guide.js";
 export {
   DEFAULT_THREAD_WAIT_POLL_INTERVAL_MS,

--- a/packages/templates/src/templates/bb-guide-threads.md
+++ b/packages/templates/src/templates/bb-guide-threads.md
@@ -27,6 +27,7 @@ Spawning:
     --machine <id-or-name>         Run on a machine (--host is an alias)
     --service-tier <tier>          Service tier: fast, default
     --permission-mode <mode>       Permission mode: accept-edits, auto, or full
+    --plan                         Send the prompt as the provider's /plan action (plan first, execute after approval)
     --section <id>                 Create the thread in a section
     --visibility <visibility>      visible or hidden; a child inherits its parent by default
     --file <path>                  Host-readable absolute or uploaded file path
@@ -173,12 +174,22 @@ Messaging:
     --mode <mode>                          Message mode: steer (default), queue, or auto
     --model <model>                        Model override for this turn
     --reasoning-level <level>              Reasoning level override
+    --plan                                 Send the message as the provider's /plan action
     --file <path>                          Host-readable absolute or uploaded file path
     --image <path>                         Host-readable absolute or uploaded image path
 
   Tell steers by default, delivering the message immediately into the active
   turn. Use --mode queue for non-urgent follow-ups that can wait until the agent
   is free.
+
+  --plan sends the same structured /plan command the composer's plan action
+  sends, so the agent proposes a plan for approval before executing (Claude
+  Code and Codex threads). Plain "/plan ..." text is not recognized; it reaches
+  the provider as literal text. Approve or deny the proposed plan with
+  `bb thread interactions`; `bb thread cancel-plan` leaves Plan mode early.
+  SDK callers build the same input with
+  `createBuiltinPlanCommandTextInput(text)` from `@bb/sdk` and pass it as
+  `input` to `threads.spawn` or `threads.send`.
 
   bb thread stop [id]                      Stop work and release the agent runtime
   bb thread compact [id]                   Request compaction of an idle or errored thread's context

--- a/plugins/provider-claude-code/src/bridge/__tests__/bridge.test.ts
+++ b/plugins/provider-claude-code/src/bridge/__tests__/bridge.test.ts
@@ -546,6 +546,7 @@ function canonicalOptions(args?: {
 function canonicalTurnParams(args: {
   threadId: string;
   providerThreadId?: string;
+  expectedTurnId?: string;
   input: JsonValue[];
   permissionEscalation?: "ask" | "deny";
   providerOptions?: Record<string, JsonValue>;
@@ -553,10 +554,38 @@ function canonicalTurnParams(args: {
   return {
     threadId: args.threadId,
     providerThreadId: args.providerThreadId ?? args.threadId,
+    ...(args.expectedTurnId !== undefined
+      ? { expectedTurnId: args.expectedTurnId }
+      : {}),
     clientRequestId: "creq_abcdefghjk",
     input: args.input,
     options: canonicalOptions(args),
   };
+}
+
+/** The prompt input the composer's `/plan` action produces for `text`. */
+function planCommandInput(text: string): JsonValue[] {
+  return [
+    {
+      type: "text",
+      text: `/plan ${text}`,
+      mentions: [
+        {
+          start: 0,
+          end: "/plan".length,
+          resource: {
+            kind: "command",
+            trigger: "/",
+            name: "plan",
+            source: "command",
+            origin: "builtin",
+            label: "plan",
+            argumentHint: null,
+          },
+        },
+      ],
+    },
+  ];
 }
 
 async function startBridgeThread(args: StartBridgeThreadArgs): Promise<void> {
@@ -1987,6 +2016,178 @@ describe("bridge", () => {
 
       await stopBridgeThread({ bridge, queries, threadId });
     } finally {
+      bridge.restore();
+    }
+  });
+
+  // `bb thread tell --plan` on a busy thread lands as turn/steer. The steer
+  // path shares enterPlanModeIfRequested with turn/start; this covers what the
+  // turn/start test above does not: entering Plan mode from a steer, staying
+  // in it across a plain turn and a repeated /plan, and re-entering it after
+  // an approved plan restored the preset.
+  it("enters Plan mode from a /plan steer and only re-requests it after the plan is approved", async () => {
+    const bridge = createBridgeJsonRpcTestHarness(handleLine);
+    const queries: ControlledClaudeQuery[] = [];
+    queryMock.mockImplementation(() => {
+      const query = createControlledClaudeQuery();
+      queries.push(query);
+      return query;
+    });
+
+    try {
+      const threadId = "thread-plan-live-steer";
+      await startBridgeThread({ bridge, threadId });
+      const query = queries[0];
+      const call = getLatestQueryCall();
+      if (!query) {
+        throw new Error("Expected live Claude query");
+      }
+      expect(call.options.permissionMode).toBe("acceptEdits");
+
+      bridge.sendRequest(
+        2,
+        "turn/steer",
+        canonicalTurnParams({
+          threadId,
+          expectedTurnId: "turn-1",
+          input: planCommandInput("add a README"),
+          providerOptions: { claudeCodePermissionMode: "plan" },
+        }),
+      );
+      expect(await readNextPromptText(call)).toBe("add a README");
+      await bridge.waitForResponse(2);
+      expect(queries).toHaveLength(1);
+      expect(query.close).not.toHaveBeenCalled();
+      expect(query.setPermissionMode).toHaveBeenCalledTimes(1);
+      expect(query.setPermissionMode).toHaveBeenCalledWith("plan");
+
+      // A follow-up turn without /plan keeps Plan mode: only an approved
+      // plan leaves it.
+      bridge.sendRequest(
+        3,
+        "turn/start",
+        canonicalTurnParams({
+          threadId,
+          input: [{ type: "text", text: "keep planning", mentions: [] }],
+        }),
+      );
+      expect(await readNextPromptText(call)).toBe("keep planning");
+      await bridge.waitForResponse(3);
+      expect(query.setPermissionMode).toHaveBeenCalledTimes(1);
+
+      // A /plan steer while already in Plan mode is a no-op.
+      bridge.sendRequest(
+        4,
+        "turn/steer",
+        canonicalTurnParams({
+          threadId,
+          expectedTurnId: "turn-2",
+          input: planCommandInput("also consider tests"),
+          providerOptions: { claudeCodePermissionMode: "plan" },
+        }),
+      );
+      expect(await readNextPromptText(call)).toBe("also consider tests");
+      await bridge.waitForResponse(4);
+      expect(query.setPermissionMode).toHaveBeenCalledTimes(1);
+
+      const canUseTool = getLastCanUseTool();
+      const planPromise = canUseTool(
+        "ExitPlanMode",
+        { plan: "# Plan" },
+        { signal: new AbortController().signal, toolUseID: "tool-plan" },
+      );
+      await bridge.flushWork();
+      const approvalRequest = bridge.messages.find((message) =>
+        isApprovalInteraction(message),
+      );
+      if (approvalRequest?.id === undefined) {
+        throw new Error("Expected ExitPlanMode to request user approval");
+      }
+      handleLine(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: approvalRequest.id,
+          result: { decision: "allow_once", grantedPermissions: null },
+        }),
+      );
+      await expect(planPromise).resolves.toMatchObject({ behavior: "allow" });
+      await bridge.flushWork();
+      expect(query.setPermissionMode).toHaveBeenLastCalledWith("acceptEdits");
+
+      // A later /plan steer re-enters Plan mode on the same live session.
+      bridge.sendRequest(
+        5,
+        "turn/steer",
+        canonicalTurnParams({
+          threadId,
+          expectedTurnId: "turn-3",
+          input: planCommandInput("plan the follow-up"),
+          providerOptions: { claudeCodePermissionMode: "plan" },
+        }),
+      );
+      expect(await readNextPromptText(call)).toBe("plan the follow-up");
+      await bridge.waitForResponse(5);
+      expect(queries).toHaveLength(1);
+      expect(query.setPermissionMode).toHaveBeenCalledTimes(3);
+      expect(query.setPermissionMode).toHaveBeenLastCalledWith("plan");
+
+      bridge.sendRequest(6, "thread/stop", {
+        threadId,
+        providerThreadId: threadId,
+        intent: "interrupt",
+        activeTurnId: null,
+      });
+      await bridge.flushWork();
+      query.finish();
+      await bridge.waitForResponse(6);
+    } finally {
+      queries.forEach((query) => query.finish());
+      bridge.restore();
+    }
+  });
+
+  it("fails a /plan turn instead of running it in the old mode when the SDK refuses the switch", async () => {
+    const bridge = createBridgeJsonRpcTestHarness(handleLine);
+    const queries: ControlledClaudeQuery[] = [];
+    queryMock.mockImplementation(() => {
+      const query = createControlledClaudeQuery();
+      query.setPermissionMode.mockRejectedValue(
+        new Error("control request refused"),
+      );
+      queries.push(query);
+      return query;
+    });
+
+    try {
+      const threadId = "thread-plan-live-session-refused";
+      await startBridgeThread({ bridge, threadId });
+      const query = queries[0];
+      const call = getLatestQueryCall();
+      if (!query) {
+        throw new Error("Expected live Claude query");
+      }
+
+      // Stand in for the SDK reading its prompt stream: the prompt must never
+      // arrive, so this read only settles when the session closes.
+      const promptRead = readNextPromptText(call).catch(() => undefined);
+      bridge.sendRequest(
+        2,
+        "turn/start",
+        canonicalTurnParams({
+          threadId,
+          input: planCommandInput("add a README"),
+          providerOptions: { claudeCodePermissionMode: "plan" },
+        }),
+      );
+      await expect(bridge.waitForResponse(2)).resolves.toMatchObject({
+        error: { message: expect.stringContaining("control request refused") },
+      });
+      expect(query.close).not.toHaveBeenCalled();
+
+      await stopBridgeThread({ bridge, queries, threadId });
+      expect(await promptRead).toBeUndefined();
+    } finally {
+      queries.forEach((query) => query.finish());
       bridge.restore();
     }
   });

--- a/plugins/provider-claude-code/src/session-params.test.ts
+++ b/plugins/provider-claude-code/src/session-params.test.ts
@@ -440,5 +440,24 @@ describe("buildClaudeTurnParams", () => {
     expect(params.input).toEqual([
       { type: "text", text: "inspect the failing test", mentions: [] },
     ]);
+    // The bridge switches an already-loaded session into plan mode from this
+    // flag; without it the stripped prompt ran under the session's old mode.
+    expect(params.claudeCodePermissionMode).toBe("plan");
+  });
+
+  it("omits claudeCodePermissionMode when the turn does not open plan mode", () => {
+    const params = buildClaudeTurnParams({
+      threadId: "thread-1",
+      providerThreadId: "provider-1",
+      input: [{ type: "text", text: "hi", mentions: [] }],
+      options: {
+        permissionMode: "full",
+        permissionScope: "full",
+        approvalReviewer: null,
+        permissionEscalation: null,
+        providerOptions: { workflowsEnabled: true },
+      },
+    });
+    expect(params).not.toHaveProperty("claudeCodePermissionMode");
   });
 });


### PR DESCRIPTION
## What was wrong

Issue #2019 (report: https://get-bb.github.io/reports/issues/2019.html) had two parts.

1. **`/plan` was ignored on an already-loaded Claude Code session.** This half landed in #2157 (`eec134dc6`): `buildClaudeTurnParams` forwards `claudeCodePermissionMode`, the bridge turn schemas accept it, and `enterPlanModeIfRequested` switches the live SDK session into Plan mode before the prompt is pushed on both `turn/start` and `turn/steer`. This PR no longer touches that code.
2. **No CLI/SDK way into plan mode.** Plan mode is keyed on the structured `/plan` command mention the composer sends (`promptInputHasCommandMention`), and `bb thread tell`/`spawn` always sent `mentions: []`, so a literal `/plan ...` reached the Claude CLI, which answered "/plan isn't available in this environment." Agents driving bb through the CLI or SDK had no parity path. This PR fixes that.

## What changed

- `packages/domain/src/shared-types.ts`: `createBuiltinPlanCommandTextInput(text)` builds the same `/plan` command mention the composer's plan action produces. `@bb/sdk` re-exports it (core/node/browser) so SDK callers pass it as `input` to `threads.spawn`/`threads.send`.
- `apps/cli`: `--plan` on `bb thread tell` and `bb thread spawn` uses that helper. Plain `/plan ...` text is deliberately not parsed (the report's recommendation): that would silently change meaning for providers where `/plan` is a real slash command.
- Docs: `packages/templates/src/templates/bb-guide-threads.md` and the bb-cli `SKILL.md` document `--plan` and the SDK helper.
- Bridge tests only, covering what #2157 left untested (its verifier noted "only `turn/start` is unit-tested"): `bridge.test.ts` gains a `turn/steer` case (which is what `bb thread tell --plan` on a busy thread becomes): entering Plan mode from a steer, a plain follow-up turn and a repeated `/plan` steer not re-requesting it, re-entry after an approved plan restored the preset; and a case where a refused `setPermissionMode("plan")` fails the turn instead of running it in the old mode. `session-params.test.ts` asserts `buildClaudeTurnParams` forwards the flag and omits it otherwise. No bridge source changes.

No wire change between server and host daemon, no `HOST_DAEMON_PROTOCOL_VERSION` or `PROVIDER_BRIDGE_PROTOCOL_VERSION` bump, no new plugin API members.

## How you verified

Fail-before / pass-after on top of current `origin/main` (`git checkout origin/main -- <the 7 non-test source files>`, run, restore):

- `apps/cli/src/__tests__/command-output/thread-tell.test.ts` "bb thread tell --plan sends the composer's /plan command mention" and `thread-spawn.test.ts` "bb thread spawn --plan opens the thread with the composer's /plan command mention": on main `error: unknown option '--plan'` (`Tests 2 failed | 35 skipped`); restored `37 passed (37)`.
- `packages/domain/test/shared-types.test.ts` "builds plan command input the plan selector recognizes and strips": on main `TypeError: createBuiltinPlanCommandTextInput is not a function`; restored `11 passed (11)`.
- `plugins/provider-claude-code`: bridge + session-params `84 passed (84)` (the new bridge cases exercise code that is already on main via #2157, so they pass on main too; they are coverage, not the proof).

From the committed tree (`git status --porcelain` empty):

- `pnpm exec turbo run typecheck --filter=@bb/domain --filter=@bb/sdk --filter=@bb/cli --filter=@bb/templates --filter=bb-plugin-provider-claude-code --filter=@bb/server --filter=@bb/agent-runtime` -> `Tasks: 11 successful, 11 total`
- `pnpm exec turbo run test --filter=@bb/domain --filter=@bb/sdk --filter=@bb/cli --filter=@bb/templates --filter=bb-plugin-provider-claude-code` -> `Tasks: 11 successful, 11 total` (domain 151, sdk 96, cli 455, templates 41, claude plugin 326)
- `pnpm exec turbo run test --filter=@bb/provider-parity --force` -> `Tasks: 2 successful, 2 total` (43 passed)
- `apps/server` skill tests (`builtin-skills-copy`, `injected-skills`, `install-cli-skills`): 22 passed.

Manual (earlier revision of this branch, before #2157 merged; the CLI path is unchanged): against my own dev instance with a real Claude Code session (`claude-haiku-4-5`), spawned a claude-code thread in accept-edits, let `Reply only with ok.` finish, then `bb thread tell <thr> --plan "Create a file named hello.txt ..."` on the loaded session. The DB `client/turn/requested` event carried the structured `/plan` command mention, Claude entered Plan mode, `ExitPlanMode` produced a pending `plan` interaction, no file was written; `bb thread interactions approve` restored accept-edits and created the file.

Fixes #2019

> AGENT GENERATED: by Claude Opus 5

## Rebase

Rebased onto `origin/main` at `75d6fc4d4` (was 33 commits behind; conflicted in `bridge.ts` and `bridge.test.ts`). #2157 (`eec134dc6`) landed the same bridge fix this PR originally carried (`enterRequestedPlanMode` here, `enterPlanModeIfRequested` there; identical body, same call sites, same schema and `buildClaudeTurnParams` hunks). Dropped every bridge source hunk (`bridge.ts`, `commands.ts`, `session-params.ts`) and this PR's copy of the `turn/start` regression test in favour of main's. Kept: the CLI `--plan` flag, the domain helper and SDK export, guide/skill text, and the bridge test cases #2157 lacks (steer path, plan re-entry, refused switch, turn-params forwarding). Title, commit message, and this body were rewritten for the reduced scope; the fail-before/pass-after proof is now the CLI flag and domain helper.


## Independent verification (post-rebase)

Verified at `69f036642` (PR head) against `origin/main` `85eec4da6` (one unrelated mobile-workflow commit past the rebase base `75d6fc4d4`; `gh` reports MERGEABLE).

Root cause check: plan mode is keyed on a `/plan` command mention (`resolvePromptMode` -> `promptInputHasCommandMention` in `apps/server/src/services/threads/thread-commands.ts`); the plan composer action's command is always `{trigger: "/", name: "plan"}` (`plugin-provider-registration.ts`), so the hardcoded mention the helper builds matches both Claude Code and Codex. The loaded-session half is on main via #2157 (`enterPlanModeIfRequested` in `bridge.ts`); this PR adds no bridge source.

Fail-before / pass-after (`git checkout origin/main -- <9 non-test source files>`, run, `git checkout HEAD -- ...`):

- `apps/cli` thread-tell/thread-spawn `--plan` tests on main sources: `error: unknown option '--plan'`, `Tests 2 failed | 35 skipped (37)`; restored: pass.
- `packages/domain/test/shared-types.test.ts`: `TypeError: createBuiltinPlanCommandTextInput is not a function`, `1 failed | 10 passed`; restored: pass.

From the committed tree (`git status --porcelain` empty), all with `--force` (no turbo cache):

- `turbo run typecheck --filter=@bb/domain,@bb/sdk,@bb/cli,@bb/templates,bb-plugin-provider-claude-code,@bb/server,@bb/agent-runtime` -> `Tasks: 11 successful, 11 total`
- `turbo run test` for domain/sdk/cli/templates/claude plugin -> `Tasks: 11 successful, 11 total` (domain 151, sdk 96, cli 455, templates 41, claude plugin 326)
- `turbo run test --filter=@bb/provider-parity --force` -> `Tasks: 2 successful, 2 total` (43 passed)
- `apps/server` skill tests (builtin-skills-copy, injected-skills, install-cli-skills): 22 passed.

Live repro on the PR branch (own dev instance, real Claude Code, `BB_CLI` unset so the worktree CLI runs instead of re-execing the installed binary):

1. `bb thread spawn --provider claude-code --permission-mode accept-edits --plan --prompt ...`: the `client/turn/requested` event carries the structured `/plan` mention, the Claude session started in Plan mode (its reasoning quotes the "Plan mode is active" reminder), the literal `/plan` was stripped, and there was no "/plan isn't available in this environment".
2. `bb thread stop`, a plain `bb thread tell ... "Reply only with ok."` (session reloaded in accept-edits), then `bb thread tell <thr> "Add a LICENSE file (MIT)..." --plan` on that loaded session: `bb thread interactions list` shows `plan | pending | Plan ready for review`, no file written. `bb thread tell --plan` and `--help` both show and accept the flag.

CI: all checks green on `69f036642` (Checks, Package Smoke x2, Tests app-1..3/integration/packages/server).

Residual notes (minor, not blocking): `--plan` on a provider that declares no plan composer action (pi, ACP agents) is not rejected by the server; the `/plan ...` text reaches the provider verbatim, same as typing it in the composer. The helper tags the mention `origin: "builtin"` while the composer's plan action uses `origin: "user"`; nothing keys plan mode on `origin`.

> AGENT GENERATED: by Claude Opus 5
