### PR TITLE
Detect bare repositories as worktree sources

### DIFF
--- a/apps/host-daemon/src/command-handlers/host-branches.ts
+++ b/apps/host-daemon/src/command-handlers/host-branches.ts
@@ -1,7 +1,11 @@
 import path from "node:path";
-import type { GitBranchRefClassification } from "@bb/domain";
+import type {
+  GitBranchRefClassification,
+  WorkspaceGitOperation,
+} from "@bb/domain";
 import {
   detectGitRepo,
+  detectGitRepoKind,
   fetchRemoteBranches,
   getCheckoutRef,
   getGitCommonDir,
@@ -47,6 +51,7 @@ interface ReadBranchOptionsArgs {
 
 const REMOTE_BRANCH_FETCH_THROTTLE_MS = 30_000;
 const REMOTE_BRANCH_FETCH_TIMEOUT_MS = 5_000;
+const NO_GIT_OPERATION: WorkspaceGitOperation = { kind: "none" };
 
 const remoteBranchFetchStateByCommonDir = new Map<
   string,
@@ -212,7 +217,11 @@ export async function listHostBranches(
     throw new CommandDispatchError("invalid_path", "Path must be absolute");
   }
 
-  if (!(await detectGitRepo(command.path))) {
+  // A project source can be a bare repository whose checkouts are sibling
+  // worktrees (`<root>/.bare` + `<root>/.git` gitdir file). It has refs and
+  // can seed new worktrees, but has no work tree to be dirty or mid-operation.
+  const repoKind = await detectGitRepoKind(command.path);
+  if (repoKind === "none") {
     return {
       branches: [],
       branchesTruncated: false,
@@ -240,8 +249,10 @@ export async function listHostBranches(
       listRemoteBranches(command.path),
       getCheckoutRef(command.path),
       readDefaultBranchRefs(command.path),
-      hasUncommittedChanges(command.path),
-      getWorkspaceGitOperation(command.path),
+      repoKind === "work-tree" ? hasUncommittedChanges(command.path) : false,
+      repoKind === "work-tree"
+        ? getWorkspaceGitOperation(command.path)
+        : NO_GIT_OPERATION,
     ]);
   const defaultBranch = defaultRefs.defaultBranch;
   const originDefaultBranch = defaultRefs.originDefaultBranch;

--- a/apps/host-daemon/test/command/host-branches-dispatch.test.ts
+++ b/apps/host-daemon/test/command/host-branches-dispatch.test.ts
@@ -275,6 +275,31 @@ describe("host.list_branches dispatch", () => {
     expect(result.operation).toEqual({ kind: "none" });
   });
 
+  it("lists branches for a bare repository root that holds sibling worktrees", async () => {
+    const origin = await initBranchRepo();
+    const root = await makeTempDir("bb-host-branches-bare-root-");
+    await runGitCommand(["clone", "--bare", origin, ".bare"], { cwd: root });
+    await fs.writeFile(path.join(root, ".git"), "gitdir: ./.bare\n", "utf8");
+    await runGitCommand(["worktree", "add", "main", "main"], { cwd: root });
+    const harness = createHarness();
+
+    const result = await dispatchOnlineRpcCommand(
+      { type: "host.list_branches", path: root, limit: 50 },
+      harness.dispatchOptions(),
+    );
+
+    expect(result.checkout).toMatchObject({
+      kind: "branch",
+      branchName: "develop",
+    });
+    expect(result.defaultBranch).toBe("main");
+    expect(result.branches).toEqual(
+      expect.arrayContaining(["main", "develop", "release/1.2"]),
+    );
+    expect(result.hasUncommittedChanges).toBe(false);
+    expect(result.operation).toEqual({ kind: "none" });
+  });
+
   it("returns an empty list for non-git directories", async () => {
     const dirPath = await makeTempDir("bb-host-branches-nongit-");
     const harness = createHarness();

--- a/packages/host-workspace/src/git.ts
+++ b/packages/host-workspace/src/git.ts
@@ -588,23 +588,69 @@ async function findWorkspaceGitOperationMarker(
   return undefined;
 }
 
+export type GitRepoKind = "work-tree" | "bare" | "none";
+
+/**
+ * Classifies `cwd` as inside a work tree, at or inside a bare repository, or
+ * not a git repository at all. A bare repository includes the "bare clone +
+ * sibling worktrees" layout where `<root>/.git` is a gitdir file pointing at
+ * `<root>/.bare`: git answers `--is-inside-work-tree` with `false` (exit 0)
+ * there, so that flag alone cannot tell it apart from a plain directory.
+ */
+export async function detectGitRepoKind(
+  cwd: string,
+  options: GitTimeoutOptions = {},
+): Promise<GitRepoKind> {
+  const result = await runGit(
+    ["rev-parse", "--is-inside-work-tree", "--is-bare-repository"],
+    { cwd, allowFailure: true, timeoutMs: options.timeoutMs },
+  );
+  if (result.exitCode !== 0) {
+    return "none";
+  }
+  const [insideWorkTree, bare] = trimOutput(result.stdout).split("\n");
+  if (insideWorkTree === "true") {
+    return "work-tree";
+  }
+  if (bare === "true") {
+    return "bare";
+  }
+  return "none";
+}
+
+/**
+ * True when `cwd` is inside a git work tree, which is what a workspace needs
+ * for status, diffs, commits, and checkouts. A bare repository root is not a
+ * work tree; use {@link detectGitSource} for worktree-source semantics.
+ */
 export async function detectGitRepo(
   cwd: string,
   options: GitTimeoutOptions = {},
 ): Promise<boolean> {
-  const result = await runGit(["rev-parse", "--is-inside-work-tree"], {
-    cwd,
-    allowFailure: true,
-    timeoutMs: options.timeoutMs,
-  });
-  return result.exitCode === 0 && trimOutput(result.stdout) === "true";
+  return (await detectGitRepoKind(cwd, options)) === "work-tree";
 }
 
+/**
+ * True when `cwd` is a git repository that can serve as the source of a
+ * worktree or a branch listing: a checkout or a bare repository.
+ */
+export async function detectGitSource(
+  cwd: string,
+  options: GitTimeoutOptions = {},
+): Promise<boolean> {
+  return (await detectGitRepoKind(cwd, options)) !== "none";
+}
+
+/**
+ * Throws `not_git_repo` unless `cwd` is a git repository (checkout or bare).
+ * Callers that need a work tree, such as `git status`, get git's own
+ * "must be run in a work tree" failure on a bare path.
+ */
 export async function ensureGitRepo(
   cwd: string,
   options: GitTimeoutOptions = {},
 ): Promise<void> {
-  if (await detectGitRepo(cwd, options)) {
+  if (await detectGitSource(cwd, options)) {
     return;
   }
 
@@ -620,7 +666,7 @@ export async function readGitRepositoryState(
   cwd: string,
   options: GitTimeoutOptions = {},
 ): Promise<GitRepositoryState> {
-  if (!(await detectGitRepo(cwd, options))) {
+  if (!(await detectGitSource(cwd, options))) {
     return "not_git";
   }
   const result = await runGit(["rev-list", "--all", "--max-count=1"], {
@@ -672,7 +718,7 @@ export async function getCheckoutRef(
   cwd: string,
   options: GitTimeoutOptions = {},
 ): Promise<GitCheckoutRef> {
-  if (!(await detectGitRepo(cwd, options))) {
+  if (!(await detectGitSource(cwd, options))) {
     return { kind: "unknown", reason: "Path is not a git repository" };
   }
 

--- a/packages/host-workspace/src/index.ts
+++ b/packages/host-workspace/src/index.ts
@@ -10,6 +10,7 @@ export type { PullRequestActionOptions } from "./workspace.js";
 export {
   WorkspaceError,
   detectGitRepo,
+  detectGitRepoKind,
   fetchRemoteBranches,
   getCheckoutRef,
   getCurrentBranch,

--- a/packages/host-workspace/test/git.test.ts
+++ b/packages/host-workspace/test/git.test.ts
@@ -3,6 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  detectGitRepo,
+  detectGitRepoKind,
   getCheckoutRef,
   getWorkspaceGitOperation,
   parseNameStatusEntries,
@@ -10,6 +12,7 @@ import {
   parsePorcelainEntries,
   readDefaultBranchRefs,
   readGitBlob,
+  readGitRepositoryState,
   runGit,
   runGitWithNullRecordLimit,
   runShellPipeline,
@@ -88,6 +91,23 @@ async function pushRemoteMainCommit(remotePath: string) {
   await runGit(["add", "."], { cwd: clonePath });
   await runGit(["commit", "-m", "Remote edit"], { cwd: clonePath });
   await runGit(["push", "origin", "main"], { cwd: clonePath });
+}
+
+/**
+ * The "bare clone + sibling worktrees" layout: `<root>/.bare` holds the bare
+ * clone, `<root>/.git` is a gitdir file pointing at it, and each branch lives
+ * in a sibling directory created with `git worktree add`. The root is a git
+ * repository but not a work tree.
+ */
+async function initBareWorktreeLayout() {
+  const origin = await initReadGitBlobRepo();
+  await runGit(["branch", "feature-a"], { cwd: origin });
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "bb-bare-layout-"));
+  tempDirs.push(root);
+  await runGit(["clone", "--bare", origin, ".bare"], { cwd: root });
+  await fs.writeFile(path.join(root, ".git"), "gitdir: ./.bare\n", "utf8");
+  await runGit(["worktree", "add", "feature-a", "feature-a"], { cwd: root });
+  return { root, worktreePath: path.join(root, "feature-a") };
 }
 
 afterEach(async () => {
@@ -200,7 +220,48 @@ describe("runGitWithNullRecordLimit", () => {
   });
 });
 
+describe("detectGitRepoKind", () => {
+  it("tells a bare repository root apart from its worktrees and plain directories", async () => {
+    const { root, worktreePath } = await initBareWorktreeLayout();
+    const plainDir = await fs.mkdtemp(path.join(os.tmpdir(), "bb-plain-dir-"));
+    tempDirs.push(plainDir);
+
+    await expect(detectGitRepoKind(root)).resolves.toBe("bare");
+    await expect(detectGitRepoKind(path.join(root, ".bare"))).resolves.toBe(
+      "bare",
+    );
+    await expect(detectGitRepoKind(worktreePath)).resolves.toBe("work-tree");
+    await expect(detectGitRepoKind(plainDir)).resolves.toBe("none");
+  });
+
+  it("keeps detectGitRepo scoped to work trees so bare roots get no checkout UI", async () => {
+    const { root, worktreePath } = await initBareWorktreeLayout();
+
+    await expect(detectGitRepo(root)).resolves.toBe(false);
+    await expect(detectGitRepo(worktreePath)).resolves.toBe(true);
+  });
+});
+
+describe("readGitRepositoryState", () => {
+  it("treats a bare repository root as a repository with commits", async () => {
+    const { root } = await initBareWorktreeLayout();
+
+    await expect(readGitRepositoryState(root)).resolves.toBe("has_commits");
+  });
+});
+
 describe("getCheckoutRef", () => {
+  it("reports the HEAD branch of a bare repository root", async () => {
+    const { root } = await initBareWorktreeLayout();
+    const head = await runGit(["rev-parse", "HEAD"], { cwd: root });
+
+    await expect(getCheckoutRef(root)).resolves.toEqual({
+      kind: "branch",
+      branchName: "main",
+      headSha: head.stdout.trim(),
+    });
+  });
+
   it("reports branch checkouts with HEAD sha", async () => {
     const repoPath = await initReadGitBlobRepo();
     const head = await runGit(["rev-parse", "HEAD"], { cwd: repoPath });

--- a/packages/host-workspace/test/provisioning.test.ts
+++ b/packages/host-workspace/test/provisioning.test.ts
@@ -171,6 +171,34 @@ describe("workspace provisioning", () => {
     expect(await new Workspace(targetPath).currentBranch).toBe("feature");
   });
 
+  it("creates worktrees from a bare repository root that holds sibling worktrees", async () => {
+    const origin = await initRepoWithOptionalSetup();
+    const root = await makeTempDir("bb-worktree-bare-root-");
+    await runGit(["clone", "--bare", origin, ".bare"], { cwd: root });
+    await fs.writeFile(path.join(root, ".git"), "gitdir: ./.bare\n", "utf8");
+    await runGit(["worktree", "add", "existing", "-b", "existing"], {
+      cwd: root,
+    });
+    const parentDir = await makeTempDir("bb-worktree-bare-parent-");
+    const targetPath = path.join(parentDir, "feature");
+
+    await expect(
+      createWorktree({
+        sourcePath: root,
+        targetPath,
+        branchName: "feature",
+        baseBranch: null,
+        timeoutMs: 900000,
+      }),
+    ).resolves.toEqual({ path: targetPath });
+
+    expect(await new Workspace(targetPath).currentBranch).toBe("feature");
+    const worktrees = await runGit(["worktree", "list", "--porcelain"], {
+      cwd: root,
+    });
+    expect(worktrees.stdout).toContain(`worktree ${targetPath}`);
+  });
+
   it("fetches remote base branches before creating worktrees", async () => {
     const { remotePath, repoPath } = await initRemoteBackedRepo();
     const parentDir = await makeTempDir("bb-worktree-remote-parent-");


### PR DESCRIPTION
## What was wrong

`detectGitRepo()` in `packages/host-workspace/src/git.ts` asked `git rev-parse --is-inside-work-tree` and treated `false` as "not a git repository". A bare repository answers `false` with exit code 0. The "bare clone + sibling worktrees" layout from #1595 (`<root>/.bare` bare clone, `<root>/.git` file containing `gitdir: ./.bare`, one sibling directory per worktree) therefore read as a non-git path everywhere that helper was used as a gate: `host.list_branches` returned `checkout.kind: "unknown"` with no branches, the app disabled "New worktree" in the environment picker, and `bb thread spawn --new-environment worktree` failed in `createWorktree` with `not_git_repo` ("Cannot create a worktree because the source is not a Git repository").

Two notions were conflated in one boolean: "this path is a git repository and can seed worktrees / list refs" (a bare repo qualifies) and "this path is a checkout that can be diffed, committed, and switched" (it cannot).

Issue: #1595. Report: https://get-bb.github.io/reports/issues/1595.html

## What changed

`packages/host-workspace/src/git.ts`

- New `detectGitRepoKind(cwd)` returns `"work-tree" | "bare" | "none"` from a single `git rev-parse --is-inside-work-tree --is-bare-repository`.
- `detectGitRepo()` keeps work-tree semantics (now implemented via the kind helper). `provision.ts` and `Workspace` still use it, so a "Work locally" thread at a bare root keeps `isGitRepo: false` and gets no status/diff/commit UI.
- New `detectGitSource()` is true for a checkout or a bare repository. It now gates `ensureGitRepo`, `readGitRepositoryState` (feeds `createWorktree`), and `getCheckoutRef`.

`apps/host-daemon/src/command-handlers/host-branches.ts`

- `listHostBranches` classifies the path once, returns the empty payload only for `"none"`, and skips the two work-tree-only probes (`hasUncommittedChanges`, `getWorkspaceGitOperation`) for a bare source, reporting `false` / `{ kind: "none" }` instead of running `git status` where there is no work tree.
- `host.list_branch_options` is unchanged: it is called with environment (checkout) paths.

No wire shape changes, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged. No CLI or docs surfaces change. The report's prototype matched this shape; I kept `ensureGitRepo` widened (its message already says "not a git repository") and moved the bare special-casing into the one handler that needs it instead of into the two primitives.

Not in scope: the issue's second half ("Existing worktree" lists only bb environments, not `git worktree list`) is a feature request tracked in #1624.

## How you verified

New tests (5 in `@bb/host-workspace`, 1 in `@bb/host-daemon`) build the layout from the issue in a temp dir. With the source files checked out from `origin/main` they fail:

```
FAIL test/git.test.ts > readGitRepositoryState > treats a bare repository root as a repository with commits
AssertionError: expected 'not_git' to be 'has_commits'
FAIL test/git.test.ts > getCheckoutRef > reports the HEAD branch of a bare repository root
AssertionError: expected { kind: 'unknown', …(1) } to deeply equal { kind: 'branch', …(2) }
FAIL test/provisioning.test.ts > creates worktrees from a bare repository root that holds sibling worktrees
Caused by: WorkspaceError: Cannot create a worktree because the source is not a Git repository: … { code: 'not_git_repo' }
FAIL test/command/host-branches-dispatch.test.ts > lists branches for a bare repository root that holds sibling worktrees
AssertionError: expected { kind: 'unknown', …(1) } to match object { kind: 'branch', …(1) }
```

(`detectGitRepoKind` test fails with `TypeError: detectGitRepoKind is not a function` there.) All pass on this branch.

Run from the committed tree (`git status --porcelain` empty):

- `pnpm exec turbo run typecheck --filter=@bb/host-workspace --filter=@bb/host-daemon` → `Tasks: 5 successful, 5 total`
- `pnpm exec turbo run test --filter=@bb/host-workspace --filter=@bb/host-daemon --force` → `Tasks: 6 successful, 6 total` (host-workspace 214 passed, host-daemon 552 passed)

Manual, against my own dev instance with the rebuilt daemon, project source = a bare layout built exactly like the issue (`cosmos/.bare`, `cosmos/.git` = `gitdir: ./.bare`, worktrees `feature-a`, `feature-b`):

- `GET /api/v1/projects/:id/branches` now returns `{"branches":["main","feature-a","feature-b"],"checkout":{"kind":"branch","branchName":"main","headSha":"6d25f68…"},"defaultBranch":"main","hasUncommittedChanges":false,"operation":{"kind":"none"},…,"defaultWorktreeBaseBranch":"main"}` (on main: `checkout.kind: "unknown"`, `branches: []`).
- `bb thread spawn --new-environment worktree --provider codex --prompt "Reply only with ok."` provisioned (`Created worktree`, `Using branch: bb/bare-wt-thr_…`) and the assistant answered `ok`; `git worktree list` in the bare root shows the new bb worktree next to `feature-a` and `feature-b`.

Fixes #1595

> AGENT GENERATED: by Claude Opus 5


## Independent verification

Verified by a separate agent in its own worktree (`git fetch origin bb/fix-1595-bare-repo-worktree-detection && git checkout -b verify-1595-r1 FETCH_HEAD`, head `ec7fd0665`, `origin/main` is an ancestor, `mergeable: MERGEABLE`).

Fail-before: with `apps/host-daemon/src/command-handlers/host-branches.ts`, `packages/host-workspace/src/git.ts`, and `packages/host-workspace/src/index.ts` checked out from `origin/main`:

- `pnpm exec vitest run test/git.test.ts test/provisioning.test.ts` in `packages/host-workspace`: 4 failed / 60 passed. Assertions: `TypeError: detectGitRepoKind is not a function`; `AssertionError: expected 'not_git' to be 'has_commits'`; `AssertionError: expected { kind: 'unknown', …(1) } to deeply equal { kind: 'branch', …(2) }`; `promise rejected "WorkspaceError: Cannot create a worktree …" { code: 'not_git_repo' }`.
- `pnpm exec vitest run test/command/host-branches-dispatch.test.ts` in `apps/host-daemon`: 1 failed / 13 passed. `AssertionError: expected { kind: 'unknown', …(1) } to match object { kind: 'branch', …(1) }`.

Pass-after (files restored, `git status --porcelain` empty): the same runs give 64/64 and 14/14 passed.

- `pnpm exec turbo run typecheck --filter=@bb/host-workspace --filter=@bb/host-daemon --filter=@bb/server`: Tasks: 6 successful, 6 total.
- `pnpm exec turbo run test --filter=@bb/host-workspace --filter=@bb/host-daemon --force`: Tasks: 6 successful, 6 total (host-workspace 214 passed, host-daemon 552 passed).

Repro on the fixed branch (own dev instance, ports 12936/20936/28936): built the issue's layout (`<root>/.bare` bare clone, `<root>/.git` = `gitdir: ./.bare`, sibling worktrees `feature-a`, `feature-b`; `git rev-parse --is-inside-work-tree --is-bare-repository` prints `false` / `true`), registered it as a `local_path` project. `GET /api/v1/projects/:id/branches?hostId=...` returned `branches: ["main","feature-a","feature-b"]`, `checkout: {kind: "branch", branchName: "main"}`, `hasUncommittedChanges: false`, `operation: {kind: "none"}`, `defaultWorktreeBaseBranch: "main"`. `bb thread spawn --new-environment worktree --provider codex --prompt "Reply only with ok."` provisioned (`Created worktree`, `Using branch: bb/bare-wt-thr_…`), `git worktree list` in the bare root shows the new bb worktree next to `feature-a`/`feature-b`, and the thread answered `ok`. No longer reproduces.

CI at verification time: all Linux checks, tests, and package smoke green; macOS package smoke pending.

Residual risks reviewed: `ensureGitRepo` now admits bare paths, but every daemon workspace command is gated by `requireGit` on `workspace.isGitRepo` (`apps/host-daemon/src/workspace-resolution.ts`), which still comes from the work-tree-only `detectGitRepo`, so `Workspace` status/diff/commit cannot reach a bare path. `host.list_branch_options` keeps the work-tree gate, which is correct because its callers are environment-scoped. No wire shape changed, so no `HOST_DAEMON_PROTOCOL_VERSION` bump is needed. The `.worktreeinclude` copy would fail `git ls-files` at a bare root, but `copyIncludedFiles` already reports that in the transcript without failing provisioning.

> AGENT GENERATED: by Claude Opus 5
