### PR TITLE
Classify Cloudflare challenges on Codex requests as transient

### DIFF
--- a/apps/host-daemon/src/codex-chatgpt-client.test.ts
+++ b/apps/host-daemon/src/codex-chatgpt-client.test.ts
@@ -690,6 +690,97 @@ describe("Codex ChatGPT client", () => {
     expect(retryHeaders.get("authorization")).toBe(`Bearer ${accessToken}`);
   });
 
+  it("classifies a persistent Cloudflare challenge as transient without leaking the challenge page", async () => {
+    const homeDir = await makeTempHome();
+    const accessToken = createAccessToken({
+      accountId: "account-123",
+      expSeconds: Math.floor(Date.now() / 1000) + 3600,
+    });
+    await writeCodexAuth({
+      homeDir,
+      accessToken,
+      refreshToken: "refresh-token",
+    });
+    const fetchMock = setupFetchMock();
+    fetchMock.mockImplementation(
+      async () =>
+        new Response(
+          `<html>\n<head>\n<meta name="viewport" content="width=device-width" />\n<title>Just a moment...</title>\n<style>body{font-family:Arial}</style>\n</head><body>${"x".repeat(2000)}</body></html>`,
+          {
+            status: 403,
+            headers: {
+              "content-type": "text/html; charset=UTF-8",
+              "cf-mitigated": "challenge",
+              server: "cloudflare",
+              "set-cookie":
+                "__cf_bm=cloudflare-cookie; Path=/; Secure; HttpOnly",
+            },
+          },
+        ),
+    );
+
+    let thrown: Error | null = null;
+    try {
+      await transcribeCodexVoice({
+        type: "codex.voice.transcribe",
+        model: "gpt-4o-mini-transcribe",
+        audioBase64: Buffer.from("audio").toString("base64"),
+        mimeType: "audio/webm",
+        filename: "prompt.webm",
+        prompt: null,
+        timeoutMs: 30000,
+      });
+    } catch (error) {
+      if (!(error instanceof Error)) {
+        throw new Error("Expected Error from challenged transcription");
+      }
+      thrown = error;
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(thrown).toMatchObject({
+      code: "codex_service_unavailable",
+      message:
+        "Codex transcription request failed with HTTP 403: chatgpt.com answered with a Cloudflare challenge that bb cannot solve. Retry, or set BB_TRANSCRIPTION to an openai/ model with OPENAI_API_KEY.",
+    });
+  });
+
+  it("omits HTML error pages from Codex error messages", async () => {
+    const homeDir = await makeTempHome();
+    const accessToken = createAccessToken({
+      accountId: "account-123",
+      expSeconds: Math.floor(Date.now() / 1000) + 3600,
+    });
+    await writeCodexAuth({
+      homeDir,
+      accessToken,
+      refreshToken: "refresh-token",
+    });
+    const fetchMock = setupFetchMock();
+    fetchMock.mockResolvedValueOnce(
+      new Response("<html><body>Access denied (error 1020)</body></html>", {
+        status: 403,
+        headers: { "content-type": "text/html; charset=UTF-8" },
+      }),
+    );
+
+    await expect(
+      transcribeCodexVoice({
+        type: "codex.voice.transcribe",
+        model: "gpt-4o-mini-transcribe",
+        audioBase64: Buffer.from("audio").toString("base64"),
+        mimeType: "audio/webm",
+        filename: "prompt.webm",
+        prompt: null,
+        timeoutMs: 30000,
+      }),
+    ).rejects.toMatchObject({
+      code: "codex_request_failed",
+      message: "Codex transcription request failed with HTTP 403",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("transcribes voice with Codex API key auth from ~/.codex/auth.json", async () => {
     const homeDir = await makeTempHome();
     await writeCodexApiKeyAuth({

--- a/apps/host-daemon/src/codex-chatgpt-client.ts
+++ b/apps/host-daemon/src/codex-chatgpt-client.ts
@@ -453,18 +453,42 @@ function extractProviderErrorMessage(rawText: string): string | null {
   }
 }
 
+function isHtmlResponse(response: Response): boolean {
+  return (
+    response.headers
+      .get("content-type")
+      ?.toLowerCase()
+      .startsWith("text/html") ?? false
+  );
+}
+
+const CODEX_API_KEY_ROUTE_HINT: Record<CodexRequestOperation, string> = {
+  inference: "BB_INFERENCE",
+  transcription: "BB_TRANSCRIPTION",
+};
+
 async function createCodexHttpError({
   deadline,
   operation,
   response,
 }: CodexHttpErrorArgs): Promise<ExpectedCommandDispatchError> {
-  const providerMessage = extractProviderErrorMessage(
-    await readErrorText(response, deadline),
-  );
+  const prefix = `Codex ${operation} request failed with HTTP ${response.status}`;
+  if (isCloudflareChallenge(response)) {
+    // Cloudflare bot management decides per network and per request whether
+    // to challenge; a Node client cannot solve the JavaScript challenge, so
+    // the failure is transient and the HTML page is not a useful message.
+    return new ExpectedCommandDispatchError(
+      "codex_service_unavailable",
+      `${prefix}: chatgpt.com answered with a Cloudflare challenge that bb cannot solve. Retry, or set ${CODEX_API_KEY_ROUTE_HINT[operation]} to an openai/ model with OPENAI_API_KEY.`,
+    );
+  }
+  const providerMessage = isHtmlResponse(response)
+    ? null
+    : extractProviderErrorMessage(await readErrorText(response, deadline));
   const details = providerMessage ? `: ${providerMessage}` : "";
   return new ExpectedCommandDispatchError(
     codexRequestErrorCode(response.status),
-    `Codex ${operation} request failed with HTTP ${response.status}${details}`,
+    `${prefix}${details}`,
   );
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,6 +143,14 @@ By default, helper inference and voice transcription use Codex credentials from
 the host daemon. Run `codex login` on the host for the default path. Set
 provider env keys only when opting into a non-Codex provider route.
 
+With a ChatGPT subscription login, `codex/` voice transcription posts to a
+`chatgpt.com` endpoint that sits behind Cloudflare bot protection. On some
+networks Cloudflare challenges that request; bb retries, then reports
+"Voice transcription is temporarily unavailable" and logs the Cloudflare
+challenge on the server. If that happens often, route transcription through an
+API key instead: `codex login --with-api-key`, or set `BB_TRANSCRIPTION` to
+`openai/gpt-transcribe` with `OPENAI_API_KEY`.
+
 The microphone picker in Settings → Voice Input is client-local. It stores the
 selected browser `MediaDevices` device id in localStorage as
 `bb.voiceInput.audioInputDeviceId`; it does not change `bb-app config` or the


### PR DESCRIPTION
## What was wrong

With a ChatGPT subscription login (`~/.codex/auth.json` `auth_mode: "chatgpt"`), the host daemon posts `codex/` voice transcription to `https://chatgpt.com/backend-api/transcribe`. That endpoint sits behind Cloudflare bot management and answers some networks with a managed challenge (HTTP 403, `cf-mitigated: challenge`, a "Just a moment..." HTML page). The daemon already retries once with the Cloudflare cookies, but when the retry is challenged too, `createCodexHttpError` falls through to the permanent code `codex_request_failed` and appends the first 400 characters of the challenge HTML to the message. The server's `isTransientInferenceError` does not recognise that code, so it makes one attempt out of two and re-throws the daemon error as-is. The user sees `HTTP 502: Codex transcription request failed with HTTP 403: <html> <head> <meta name="viewport" ...`.

Issue: #1587. Report: https://get-bb.github.io/reports/issues/1587.html

## What changed

- `apps/host-daemon/src/codex-chatgpt-client.ts`: `createCodexHttpError` now maps a Cloudflare challenge response (`isCloudflareChallenge`) to `codex_service_unavailable` with a clean, actionable message ("chatgpt.com answered with a Cloudflare challenge that bb cannot solve. Retry, or set BB_TRANSCRIPTION to an openai/ model with OPENAI_API_KEY."; the hint names `BB_INFERENCE` for the inference route). It also never appends `text/html` error bodies to Codex error messages, so other HTML error pages (Cloudflare block pages and the like) stay out of user-facing errors.
- Server: no code change. `codex_service_unavailable` is already transient for `inferenceCompleteWithFallback` (one retry after 250 ms, so a challenged network gets four fetches instead of two) and already maps to the 503 `transcription_unavailable` error "Voice transcription is temporarily unavailable. Please try again in a moment." The daemon's message with the Cloudflare detail lands in the server's "Voice transcription failed" log entry.
- `docs/configuration.md`: documents that subscription-mode `codex/` transcription can be challenged by Cloudflare and how to route through an API key (`codex login --with-api-key`, or `BB_TRANSCRIPTION=openai/gpt-transcribe` with `OPENAI_API_KEY`).
- No wire change: the error code and message are existing free-form strings and `codex_service_unavailable` is a code the server already handles, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.
- Deviation from the report's proposal: it also suggested falling back to `openai/<model>` on the server when `OPENAI_API_KEY` happens to be configured. I left that out. Silently spending API credit for a user who chose a subscription route is a product decision, and `docs/configuration.md` says `OPENAI_API_KEY` only affects explicit `openai/` routes.

## How you verified

New tests in `apps/host-daemon/src/codex-chatgpt-client.test.ts`:

- "classifies a persistent Cloudflare challenge as transient without leaking the challenge page". Fails on origin/main with `expected ExpectedCommandDispatchError ... "code": "codex_request_failed"` against the expected `"code": "codex_service_unavailable"`; passes with the fix (two fetches, clean message).
- "omits HTML error pages from Codex error messages". Fails on origin/main because the message carries `: <html><body>Access denied (error 1020)</body></html>`; passes with the fix.

Commands (run from the committed tree, `git status --porcelain` empty):

- `pnpm exec turbo run typecheck test --filter=@bb/host-daemon`: `Tasks: 6 successful, 6 total`; `Test Files 46 passed (46)`, `Tests 553 passed (553)`.

Manual repro on my own dev instance using the report's `cf-challenge-preload.mjs` (a Node `--import` preload that feeds the daemon the real captured Cloudflare challenge response for `POST https://chatgpt.com/backend-api/transcribe`):

- origin/main daemon code: `bb voice transcribe tone.mp3` printed `Error: HTTP 502: Codex transcription request failed with HTTP 403: <html> <head> <meta name="viewport" ...`, exit 1; preload log showed 2 fetches; server log `"attempts":1,"maxAttempts":2`.
- with this fix: `Error: HTTP 503: Voice transcription is temporarily unavailable. Please try again in a moment.`, exit 1; preload log showed 4 fetches (2 per server attempt); server log `Voice transcription failed transiently; using fallback model {"attempt":1,"errorCode":"codex_service_unavailable",...}` then `"attempts":2`, with the Cloudflare message in the logged error. Baseline (preload disarmed, real network) still transcribes, exit 0.

Fixes #1587

> AGENT GENERATED: by Claude Opus 5


## Independent verification

Verified on a fresh worktree at `065ade267` (PR head), `origin/main` is an ancestor, `mergeable: MERGEABLE`.

Commands:

- `git fetch origin main && git fetch origin bb/fix-1587-codex-transcription-403 && git checkout -b verify-1587-r1 FETCH_HEAD`
- `pnpm install --frozen-lockfile --prefer-offline && pnpm exec turbo run build` (18/18 tasks)
- Fail-before: `git checkout origin/main -- apps/host-daemon/src/codex-chatgpt-client.ts docs/configuration.md`, then `cd apps/host-daemon && pnpm exec vitest run src/codex-chatgpt-client.test.ts -t "Cloudflare challenge as transient|omits HTML error pages"` -> 2 failed: `expected ... "code": "codex_service_unavailable"` received `"code": "codex_request_failed"` (line 741), and `message: "Codex transcription request failed with HTTP 403"` did not match because the HTML body was appended (line 777).
- Pass-after: `git checkout HEAD -- <same files>`, same vitest run -> 16 passed (16).
- `pnpm exec turbo run typecheck test --filter=@bb/host-daemon --force` -> `Tasks: 6 successful, 6 total`; `Test Files 46 passed (46)`, `Tests 553 passed (553)`.
- Manual repro on my own dev instance (server :21549, daemon :29549) started with the report's `cf-challenge-preload.mjs` (`CF_PRELOAD_DIR` isolated under `~/.bb-dev/scratch/1587-verify/preload`) and codex `auth_mode: chatgpt`:
  - baseline (preload disarmed): `bb voice transcribe tone.mp3` exit=0
  - challenge: `Error: HTTP 503: Voice transcription is temporarily unavailable. Please try again in a moment.` exit=1, 4 intercepted daemon fetches (2 server attempts x 1 cookie retry each); server log `Voice transcription failed transiently; using fallback model {"attempt":1,"errorCode":"codex_service_unavailable",...}` then `Voice transcription failed {"attempts":2,...}` with the clean Cloudflare message (no HTML) in the logged error.
  - baseline again: exit=0 on the same instance.
- CI: all checks pass (Checks, Tests server/packages/integration/app-1..3, Package Smoke ubuntu + macOS, version checks); iOS and Node-compat jobs skipped as usual.

Review notes: the fix sits in the daemon (response classification is a host-local primitive), reuses the existing `codex_service_unavailable` code that the server already treats as transient and maps to the 503 `transcription_unavailable` error, so no wire shape or meaning changes and no `HOST_DAEMON_PROTOCOL_VERSION` bump is needed. `BB_INFERENCE`/`BB_TRANSCRIPTION`, `openai/gpt-transcribe`, and `codex login --with-api-key` in the message and docs all exist.

Residual risks (not blocking): on a network that is challenged every time the user sees only the generic "temporarily unavailable" 503; the actionable hint (API-key route) lives in server logs and `docs/configuration.md`. The Cloudflare/HTML error paths now return without consuming the response body, matching the pre-existing discard of the first challenged response in `fetchChatGpt`.

> AGENT GENERATED: by Claude Opus 5
