### PR TITLE
Recover from an unreachable saved remote server target

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -68,6 +68,7 @@ import {
   type CompatibleServerProbeResult,
   type ServerProbeResult,
 } from "./server-probe.js";
+import { loadRemoteServerPage } from "./remote-server-load.js";
 import {
   BUILTIN_SERVER_NAME,
   createServerTargetStore,
@@ -1216,22 +1217,49 @@ async function applyServerTarget(): Promise<void> {
       expiresAt: result.expiresAt,
       remoteServerUrl: target.server.url,
     });
-    bbAppLoaded = true;
-    await loadWindowUrl({ url: target.server.url });
+    const loaded = await loadRemoteServerTarget(target.server.url, isCurrent);
     if (!isCurrent()) {
       return;
     }
-    startRemoteSystemConfigSync(target.server.url);
+    if (!loaded) {
+      // No session to keep alive for a server that is not on screen.
+      connectSessionRenewal?.stop();
+    }
   } else {
     // A custom server is a plain web load with no bb Connect involved.
-    bbAppLoaded = true;
-    await loadWindowUrl({ url: target.url });
+    await loadRemoteServerTarget(target.url, isCurrent);
     if (!isCurrent()) {
       return;
     }
-    startRemoteSystemConfigSync(target.url);
   }
   refreshApplicationMenu();
+}
+
+/**
+ * Load a connect or custom server's page. An unreachable host renders the
+ * startup error view instead of rejecting, so the app never lands on the
+ * crash screen or a blank window. `bbAppLoaded` flips only once the page is
+ * really up. Resolves to whether the page loaded.
+ */
+async function loadRemoteServerTarget(
+  serverUrl: string,
+  isCurrent: () => boolean,
+): Promise<boolean> {
+  const loaded = await loadRemoteServerPage({
+    isCurrent,
+    loadStartupError,
+    loadUrl: loadWindowUrl,
+    logWarning: (message) => {
+      createDesktopLogger().warn(message);
+    },
+    serverUrl,
+  });
+  if (!loaded || !isCurrent()) {
+    return loaded;
+  }
+  bbAppLoaded = true;
+  startRemoteSystemConfigSync(serverUrl);
+  return true;
 }
 
 async function setActiveServerTarget(serverId: string): Promise<void> {

--- a/apps/desktop/src/remote-server-load.ts
+++ b/apps/desktop/src/remote-server-load.ts
@@ -1,0 +1,88 @@
+import { BUILTIN_SERVER_NAME } from "./server-target.js";
+
+const ELECTRON_LOAD_ERROR_CODE = /\bERR_[A-Z_]+ \(-?\d+\)/u;
+
+interface RemoteServerStartupError {
+  details: string;
+  logs: string;
+  title: string;
+}
+
+export interface LoadRemoteServerPageArgs {
+  /** Whether this target is still the one the user wants (generation check). */
+  isCurrent(): boolean;
+  /** Shows the shared startup error screen. */
+  loadStartupError(args: RemoteServerStartupError): Promise<void>;
+  /** Loads a page into the application windows. */
+  loadUrl(args: { url: string }): Promise<void>;
+  logWarning(message: string): void;
+  serverUrl: string;
+}
+
+/**
+ * Name a saved target without repeating anything secret.
+ *
+ * `normalizeCustomServerUrl()` keeps user information and the query string, so
+ * a saved target can hold a password or a token. Neither belongs on a screen
+ * the user photographs for a bug report or in a log they attach to one. Only
+ * the origin is printed; the load request still uses the complete URL.
+ */
+export function describeServerUrl(serverUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(serverUrl);
+  } catch {
+    return "the saved bb server";
+  }
+  return `the bb server at ${parsed.origin}`;
+}
+
+/**
+ * Keep only the Electron error code from a failed load. The full message
+ * repeats the URL it tried, which can carry a credential.
+ */
+function formatLoadFailure(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return ELECTRON_LOAD_ERROR_CODE.exec(message)?.[0] ?? "the page load failed";
+}
+
+/**
+ * Load a remote bb server and keep an unreachable host recoverable.
+ *
+ * `BrowserWindow.loadURL` rejects when the host is asleep, the tunnel is down,
+ * or nothing listens on the port. Left alone, that rejection unwinds to the
+ * top-level startup handler at launch, which prints the Electron stack on a
+ * screen with no way out, and from the Server menu it is an unhandled
+ * rejection that leaves a blank window. Here the detail goes to the log and
+ * the user sees the server name plus the menu path that recovers.
+ *
+ * Resolves true when the page loaded; false when it did not. A load that the
+ * user has already superseded shows nothing, so the newer target keeps the
+ * window.
+ */
+export async function loadRemoteServerPage(
+  args: LoadRemoteServerPageArgs,
+): Promise<boolean> {
+  try {
+    await args.loadUrl({ url: args.serverUrl });
+    return true;
+  } catch (error) {
+    if (!args.isCurrent()) {
+      return false;
+    }
+    const label = describeServerUrl(args.serverUrl);
+    args.logWarning(
+      `[desktop] could not load ${label}: ${formatLoadFailure(error)}`,
+    );
+    await args.loadStartupError({
+      details:
+        `${label.charAt(0).toUpperCase()}${label.slice(1)} did not answer. ` +
+        "Check that the machine is awake and reachable, then choose " +
+        "Window ▸ Server to retry this server or switch to " +
+        `${BUILTIN_SERVER_NAME}.`,
+      logs: "",
+      title: "Could not reach this bb server",
+    });
+    return false;
+  }
+}

--- a/apps/desktop/test/remote-server-load.test.ts
+++ b/apps/desktop/test/remote-server-load.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  describeServerUrl,
+  loadRemoteServerPage,
+  type LoadRemoteServerPageArgs,
+} from "../src/remote-server-load.js";
+
+type StartupErrorView = Parameters<
+  LoadRemoteServerPageArgs["loadStartupError"]
+>[0];
+
+interface TestHarness extends LoadRemoteServerPageArgs {
+  shownErrors: StartupErrorView[];
+  warnings: string[];
+}
+
+// What `BrowserWindow.loadURL` rejects with when nothing answers at the target.
+function createElectronLoadError(url: string): Error {
+  const error = new Error(`ERR_CONNECTION_REFUSED (-102) loading '${url}/'`);
+  error.stack =
+    `Error: ERR_CONNECTION_REFUSED (-102) loading '${url}/'\n` +
+    "    at rejectAndCleanup (node:electron/js2c/browser_init:2:89743)\n" +
+    "    at WebContents.finishListener (node:electron/js2c/browser_init:2:89905)\n" +
+    "    at WebContents.emit (node:events:509:28)";
+  return error;
+}
+
+function createHarness(
+  overrides: Partial<LoadRemoteServerPageArgs> = {},
+): TestHarness {
+  const serverUrl =
+    overrides.serverUrl ?? "http://bb-host.tailnet.ts.net:38886";
+  const shownErrors: StartupErrorView[] = [];
+  const warnings: string[] = [];
+  return {
+    isCurrent: () => true,
+    loadStartupError: async (view) => {
+      shownErrors.push(view);
+    },
+    loadUrl: vi.fn(async () => {
+      throw createElectronLoadError(serverUrl);
+    }),
+    logWarning: (message) => {
+      warnings.push(message);
+    },
+    serverUrl,
+    shownErrors,
+    warnings,
+    ...overrides,
+  };
+}
+
+describe("loadRemoteServerPage", () => {
+  it("turns an unreachable host into a named error view with the way out", async () => {
+    const harness = createHarness();
+
+    await expect(loadRemoteServerPage(harness)).resolves.toBe(false);
+
+    expect(harness.shownErrors).toHaveLength(1);
+    const view = harness.shownErrors[0];
+    expect(view?.title).toBe("Could not reach this bb server");
+    expect(view?.details).toContain("http://bb-host.tailnet.ts.net:38886");
+    expect(view?.details).toContain("Window ▸ Server");
+    expect(view?.details).toContain("This Mac");
+    expect(view?.details).not.toContain("rejectAndCleanup");
+    expect(view?.details).not.toContain("node:electron");
+
+    expect(harness.warnings).toHaveLength(1);
+    expect(harness.warnings[0]).toContain("ERR_CONNECTION_REFUSED (-102)");
+  });
+
+  it("keeps credentials and query tokens off the screen and out of the log", async () => {
+    const harness = createHarness({
+      serverUrl: "https://user:hunter2@bb.example.com:8443/?token=s3cret",
+    });
+
+    await expect(loadRemoteServerPage(harness)).resolves.toBe(false);
+
+    const details = harness.shownErrors[0]?.details ?? "";
+    expect(details).toContain("https://bb.example.com:8443");
+    expect(details).not.toContain("hunter2");
+    expect(details).not.toContain("s3cret");
+    const logged = harness.warnings[0] ?? "";
+    expect(logged).toContain("https://bb.example.com:8443");
+    expect(logged).not.toContain("hunter2");
+    expect(logged).not.toContain("s3cret");
+  });
+
+  it("shows nothing for a load the user already superseded", async () => {
+    const harness = createHarness({ isCurrent: () => false });
+
+    await expect(loadRemoteServerPage(harness)).resolves.toBe(false);
+
+    expect(harness.shownErrors).toHaveLength(0);
+    expect(harness.warnings).toHaveLength(0);
+  });
+
+  it("reports a successful load without touching the error view", async () => {
+    const harness = createHarness({ loadUrl: vi.fn(async () => {}) });
+
+    await expect(loadRemoteServerPage(harness)).resolves.toBe(true);
+
+    expect(harness.shownErrors).toHaveLength(0);
+    expect(harness.warnings).toHaveLength(0);
+  });
+});
+
+describe("describeServerUrl", () => {
+  it("names only the origin", () => {
+    expect(
+      describeServerUrl("http://user:pw@host.ts.net:38886/app?token=x#y"),
+    ).toBe("the bb server at http://host.ts.net:38886");
+  });
+
+  it("falls back to a generic label for an unparseable URL", () => {
+    expect(describeServerUrl("not a url")).toBe("the saved bb server");
+  });
+});


### PR DESCRIPTION
## What was wrong

`applyServerTarget()` in `apps/desktop/src/main.ts` awaited `loadWindowUrl()` for `custom` and `connect` targets with no handler. `BrowserWindow.loadURL` rejects for every network-level failure (`ERR_CONNECTION_REFUSED`, `ERR_CONNECTION_TIMED_OUT`, `ERR_FAILED`, ...). At launch that rejection unwound to `runDesktopApp().catch(...)`, which rendered `error.stack` into the static, script-less error view: "Could not open bb" plus Electron internals and nothing to click. From Window > Server the same rejection was unhandled (`void setActiveServerTarget(...)`), so the window went blank and `bbAppLoaded` stayed `true`. `bbAppLoaded` was also set before the load was known to have succeeded.

Issue: #1494. Report: https://get-bb.github.io/reports/issues/1494.html

## What changed

- `apps/desktop/src/remote-server-load.ts` (new): `loadRemoteServerPage()` loads the remote URL and, on rejection, logs only the Electron error code plus the server origin and renders the shared startup error view: "Could not reach this bb server. The bb server at `<origin>` did not answer. Check that the machine is awake and reachable, then choose Window > Server to retry this server or switch to This Mac." `describeServerUrl()` prints only the origin, because a saved custom URL can carry a credential or a query token. A load the user already superseded (generation check) shows nothing.
- `apps/desktop/src/main.ts`: both remote branches of `applyServerTarget()` go through a small `loadRemoteServerTarget()` wrapper around that helper. `bbAppLoaded` flips and the remote system-config sync starts only after the page loaded. A failed `connect` load stops the session renewal it had just started. `refreshApplicationMenu()` now runs on the failure path too.

Deviation from the issue's proposal: this PR does not add Retry / Use This Mac buttons. The `data:` error view runs under `default-src 'none'` with no preload, so buttons need a new main-process IPC surface (that is what the closed #1519 built, +768 lines). This PR fixes the root cause (an unhandled rejection) and gives the user the server name and the existing menu route; the error view now has parity with the builtin and Connect-authentication failures. Actionable buttons can follow as a separate UI change. No wire, CLI, or doc changes.

## How you verified

Live repro on origin/main with the built desktop shell under Xvfb (Electron, Linux), saved `custom` target `http://127.0.0.1:47771` with nothing listening:

```
BODY TEXT:
Could not open bb
Error: ERR_CONNECTION_REFUSED (-102) loading 'http://127.0.0.1:47771/' at rejectAndCleanup (node:electron/js2c/browser_init:2:89743) ...
interactive controls on page: 0
```

Re-selecting the same target from Window > Server on main: `URL: chrome-error://chromewebdata/`, empty body, 2x `UnhandledPromiseRejectionWarning` on stderr.

Same two steps on this branch:

```
BODY TEXT:
Could not reach this bb server
The bb server at http://127.0.0.1:47771 did not answer. Check that the machine is awake and reachable, then choose Window ▸ Server to retry this server or switch to This Mac. Logs are under .../logs/.
```

stderr: `[desktop] could not load the bb server at http://127.0.0.1:47771: ERR_CONNECTION_REFUSED (-102)`, 0 unhandled rejections. Menu re-select shows the same named error instead of a blank window. Starting a server on 47771 and re-selecting the target from the menu then loads the page (`URL: http://127.0.0.1:47771/`).

Tests: `apps/desktop/test/remote-server-load.test.ts` (6 tests) covers the error view copy and title, that the stack never reaches the screen, credential/query redaction on screen and in the log, the superseded-load path, and the success path. With origin/main's `main.ts` and without the new module the file fails with `Error: Cannot find module '../src/remote-server-load.js'` (the code path under test did not exist; `main.ts` runs on import and is not unit-testable). `apps/desktop/src/main.ts` is exercised by the live repro above.

`pnpm exec turbo run typecheck test --filter=@bb/desktop --force` on the committed tree: `Tasks: 5 successful, 5 total`, `Test Files 35 passed (35)`, `Tests 228 passed (228)`.

Fixes #1494

> AGENT GENERATED: by Claude Opus 5



## Independent verification

Verified by a second agent on a fresh worktree (`git fetch origin bb/fix-1494-remote-target-dead-end && git checkout -b verify-1494-r1 FETCH_HEAD`, HEAD `2bb375108`, `origin/main` is an ancestor, PR reports `MERGEABLE`).

Commands run:

- `pnpm install --frozen-lockfile --prefer-offline && pnpm exec turbo run build`
- Fail-before: `git checkout origin/main -- apps/desktop/src/main.ts && rm apps/desktop/src/remote-server-load.ts`, then `pnpm exec vitest run test/remote-server-load.test.ts` from `apps/desktop` -> `FAIL ... Error: Cannot find module '../src/remote-server-load.js'` (1 failed suite). The helper under test does not exist on main; `main.ts` runs on import, so the call site itself has no unit seam.
- Pass-after: `git checkout HEAD -- <those files>`, same command -> `Test Files 1 passed (1), Tests 6 passed (6)`.
- `pnpm exec turbo run typecheck test --filter=@bb/desktop --force` -> `Tasks: 5 successful, 5 total`, `Test Files 35 passed (35)`, `Tests 228 passed (228)`.

Live repro (built Electron shell under `xvfb-run`, own `--user-data-dir` and `BB_DATA_DIR` under `~/.bb-dev/scratch/1494-verify/`, saved custom target `http://127.0.0.1:47771` with nothing listening, CDP on 49333, main-process inspector on 49334; the report's `run-desktop-unreachable.sh`, `cdp-screenshot.mjs`, and `main-click-server-menu.mjs`):

- Built from origin/main's `main.ts` (bug confirmed): startup body `Could not open bb / Error: ERR_CONNECTION_REFUSED (-102) loading 'http://127.0.0.1:47771/' at rejectAndCleanup (node:electron/js2c/browser_init...)`, 0 interactive controls. Window > Server > re-select same target: URL `http://127.0.0.1:47771/`, empty body, 2x `UnhandledPromiseRejectionWarning` on stderr.
- Built from this branch: startup body `Could not reach this bb server / The bb server at http://127.0.0.1:47771 did not answer. Check that the machine is awake and reachable, then choose Window ▸ Server to retry this server or switch to This Mac.`; stderr `[desktop] could not load the bb server at http://127.0.0.1:47771: ERR_CONNECTION_REFUSED (-102)`; 0 unhandled rejections. Menu re-select shows the same named error (no blank window). After starting an HTTP server on 47771, menu re-select loads `http://127.0.0.1:47771/` (body `fake bb server up`), so the menu route recovers.

CI at verification time: 11 checks pass, 2 skipped (Node Compatibility Smoke, iOS simulator flows), none failing or pending.

Residual risks (none blocking): the unit test proves the helper's contract, not the `applyServerTarget()` call site (covered by the live repro only); the error view still has no clickable Retry / Use This Mac control; a half-open host still waits for Chromium's connect timeout before the named error appears (#1524); the loading view copy still says "Starting local services" for remote targets; the `connect` failure branch was checked by code reading only (no bb Connect server here); verified on Linux/Xvfb, not macOS (no platform branch in the changed code).

> AGENT GENERATED: by Claude Opus 5
