### PR TITLE
Make bb-app verify its server child's identity on /health

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -326,7 +326,16 @@ export function createApp(
     });
   });
   app.onError((error) => errorToResponse(error, deps.logger));
-  app.get("/health", (context) => context.json({ ok: true }));
+  // The launch id lets the bb-app launcher prove that the process answering on
+  // its port is the child it just spawned, not another bb server that already
+  // owned the port (its own child then dies with EADDRINUSE a moment later).
+  app.get("/health", (context) =>
+    context.json(
+      deps.config.launchId === undefined
+        ? { ok: true }
+        : { ok: true, launchId: deps.config.launchId },
+    ),
+  );
   app.get("/install.sh", async (context) => {
     const script = await readFile(INSTALL_MACHINE_SCRIPT_PATH);
     return new Response(script, {

--- a/apps/server/src/start-server.ts
+++ b/apps/server/src/start-server.ts
@@ -106,6 +106,9 @@ export async function runServer(serverConfig: ServerConfig): Promise<void> {
   if (serverConfig.BB_DEV_APP_PORT !== undefined) {
     runtimeConfig.devAppPort = serverConfig.BB_DEV_APP_PORT;
   }
+  if (serverConfig.BB_SERVER_LAUNCH_ID !== undefined) {
+    runtimeConfig.launchId = serverConfig.BB_SERVER_LAUNCH_ID;
+  }
   const terminalSessions = new TerminalSessionLifecycle({
     config: runtimeConfig,
     db,

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -49,6 +49,12 @@ export interface ServerRuntimeConfig {
   transcriptionModel: string;
   appUrl?: string;
   devAppPort?: number;
+  /**
+   * Per-spawn identity from the bb-app launcher, echoed on /health so the
+   * launcher can tell this server from another one that owns the same port.
+   * Absent when the server was not started by the launcher.
+   */
+  launchId?: string;
 }
 
 export interface AppDeps {

--- a/apps/server/test/app/skeleton.test.ts
+++ b/apps/server/test/app/skeleton.test.ts
@@ -97,6 +97,22 @@ describe("server skeleton", () => {
     }
   });
 
+  it("echoes the launcher's launch id on /health only when one was given", async () => {
+    await withTestHarness({ launchId: "launch-123" }, async (harness) => {
+      const response = await harness.app.request("/health");
+      expect(response.status).toBe(200);
+      await expect(readJson(response)).resolves.toEqual({
+        ok: true,
+        launchId: "launch-123",
+      });
+    });
+    await withTestHarness(async (harness) => {
+      await expect(
+        readJson(await harness.app.request("/health")),
+      ).resolves.toEqual({ ok: true });
+    });
+  });
+
   it("serves public routes without auth", async () => {
     await withTestHarness(async (harness) => {
       const response = await harness.app.request("/api/v1/hosts");

--- a/packages/bb-app/src/launcher.ts
+++ b/packages/bb-app/src/launcher.ts
@@ -103,8 +103,9 @@ const MANAGED_CONFIG_KEYS = BB_APP_MANAGED_CONFIG_KEYS;
 const MANAGED_CONFIG_KEY_VALUES = new Set<string>(MANAGED_CONFIG_KEYS);
 const STARTUP_ONLY_MANAGED_CONFIG_KEYS = new Set<string>(["BB_LOG_LEVEL"]);
 // Keep this in sync with loadServerConfig and direct process.env reads made
-// while assembling the server. BB_APP_VERSION and NODE_ENV are omitted because
-// the launcher owns and overwrites them rather than applying env.json values.
+// while assembling the server. BB_APP_VERSION, BB_SERVER_LAUNCH_ID, and
+// NODE_ENV are omitted because the launcher owns and overwrites them rather
+// than applying env.json values.
 const STARTUP_ONLY_MANAGED_ENV_KEYS = new Set<string>([
   "BB_APP_SURFACE",
   "BB_APP_URL",
@@ -151,6 +152,13 @@ const hostDaemonStatusSchema = z
     connected: z.boolean(),
     hostId: z.string().min(1),
     serverUrl: z.string().min(1),
+  })
+  .passthrough();
+
+const serverHealthResponseSchema = z
+  .object({
+    ok: z.boolean(),
+    launchId: z.string().min(1).optional(),
   })
   .passthrough();
 
@@ -436,8 +444,10 @@ export interface DelayMillisecondsArgs {
   ms: number;
 }
 
-interface WaitForHealthArgs {
+interface WaitForServerHealthArgs {
   childProcess: ChildProcess | null;
+  /** Launch id handed to the server child; only a /health echoing it counts. */
+  expectedLaunchId: string;
   timeoutMs?: number;
   url: string;
 }
@@ -2253,28 +2263,64 @@ async function maybeAddAutoJoinEnv(
   };
 }
 
-async function waitForHealth(args: WaitForHealthArgs): Promise<void> {
+async function readServerHealthLaunchId(
+  response: Response,
+): Promise<string | null> {
+  try {
+    const health = serverHealthResponseSchema.safeParse(await response.json());
+    return health.success ? (health.data.launchId ?? null) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Polls the server child's /health until it answers with the launch id the
+ * launcher handed it. A 200 alone proves only that something listens on the
+ * port: when another bb server already owns it, that server answers on the
+ * first poll while the child is still booting and about to die with
+ * EADDRINUSE. Accepting it would make the launcher enroll its daemon against
+ * the wrong server (get-bb/bb#1558).
+ */
+export async function waitForServerHealth(
+  args: WaitForServerHealthArgs,
+): Promise<void> {
   const timeoutMs = args.timeoutMs ?? HEALTH_CHECK_TIMEOUT_MS;
   const deadline = Date.now() + timeoutMs;
+  let foreignServerAnswered = false;
+  const describeFailure = (reason: string): string =>
+    foreignServerAnswered
+      ? `${reason}: another server is already answering at ${args.url}`
+      : reason;
   while (Date.now() <= deadline) {
     if (
       args.childProcess &&
       (args.childProcess.exitCode !== null ||
         args.childProcess.signalCode !== null)
     ) {
-      throw new Error("Process exited before becoming healthy");
+      throw new Error(
+        describeFailure("Process exited before becoming healthy"),
+      );
     }
     try {
-      const response = await fetch(args.url);
+      const response = await fetch(args.url, {
+        signal: AbortSignal.timeout(HEALTH_CHECK_REQUEST_TIMEOUT_MS),
+      });
       if (response.ok) {
-        return;
+        const launchId = await readServerHealthLaunchId(response);
+        if (launchId === args.expectedLaunchId) {
+          return;
+        }
+        foreignServerAnswered = true;
       }
     } catch {}
     await new Promise<void>((resolvePromise) => {
       setTimeout(resolvePromise, HEALTH_CHECK_INTERVAL_MS);
     });
   }
-  throw new Error(`Timed out waiting for health at ${args.url}`);
+  throw new Error(
+    describeFailure(`Timed out waiting for health at ${args.url}`),
+  );
 }
 
 function normalizeServerUrlForComparison(serverUrl: string): string {
@@ -2984,25 +3030,28 @@ function logManagedProcessStartupFailureContext(
   log(" ", dim(`logs: ${args.context.logDir}/`));
 }
 
-async function startFullStackServerProcess(
+export async function startFullStackServerProcess(
   args: StartFullStackServerProcessArgs,
 ): Promise<ManagedProcessRun> {
+  // Fresh per spawn: the probe must match this child, not any earlier one.
+  const launchId = randomUUID();
   const serverRun = spawnNamedManagedProcess({
     args: [args.context.serverEntry],
     command: process.execPath,
-    env: args.env,
+    env: { ...args.env, BB_SERVER_LAUNCH_ID: launchId },
     outputBuffer: args.outputBuffer,
     processName: "server",
   });
   args.processes.serverRun = serverRun;
 
   try {
-    await waitForHealth({
+    await waitForServerHealth({
       childProcess: serverRun.childProcess,
+      expectedLaunchId: launchId,
       url: `${args.context.serverUrl}/health`,
     });
     return serverRun;
-  } catch {
+  } catch (error) {
     await terminateProcessIfRunning({
       childProcess: serverRun.childProcess,
       processName: "server",
@@ -3011,7 +3060,9 @@ async function startFullStackServerProcess(
     if (args.processes.serverRun === serverRun) {
       args.processes.serverRun = null;
     }
-    throw new Error("Server failed to become healthy");
+    throw new Error(
+      `Server failed to become healthy: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
 }
 
@@ -3430,8 +3481,9 @@ export async function runBbApp(
     beginStep("Starting server");
     try {
       await startServer();
-    } catch {
-      endStep(red("✗"), "Server failed to start (health check timed out)");
+    } catch (error) {
+      endStep(red("✗"), "Server failed to start");
+      log(" ", dim(error instanceof Error ? error.message : String(error)));
       logManagedProcessStartupFailureContext({
         context,
         processName: "server",

--- a/packages/bb-app/test/server-health-identity.test.ts
+++ b/packages/bb-app/test/server-health-identity.test.ts
@@ -1,0 +1,274 @@
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type {
+  BbAppStartContext,
+  ManagedFullStackProcesses,
+} from "../src/launcher.js";
+import {
+  startFullStackServerProcess,
+  waitForProcessExit,
+  waitForServerHealth,
+} from "../src/launcher.js";
+
+interface ListeningServer {
+  close(): Promise<void>;
+  port: number;
+}
+
+type RequestHandler = (
+  request: IncomingMessage,
+  response: ServerResponse,
+) => void;
+
+async function listen(handler: RequestHandler): Promise<ListeningServer> {
+  const server = createServer(handler);
+  await new Promise<void>((resolvePromise, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolvePromise);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("Expected the test server to have a TCP address");
+  }
+  return {
+    port: address.port,
+    close: () =>
+      new Promise<void>((resolvePromise, reject) => {
+        server.close((error) => (error ? reject(error) : resolvePromise()));
+      }),
+  };
+}
+
+async function reserveFreePort(): Promise<number> {
+  const server = await listen(() => {});
+  await server.close();
+  return server.port;
+}
+
+function answerHealth(response: ServerResponse, body: object): void {
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+// Stands in for apps/server: binds BB_SERVER_PORT and echoes the launch id the
+// launcher put in its env. When another process owns the port it dies the way
+// the real server does (EADDRINUSE, non-zero exit) instead of serving.
+const FAKE_SERVER_ENTRY_SOURCE = `
+import { createServer } from "node:http";
+const server = createServer((request, response) => {
+  response.writeHead(200, { "content-type": "application/json" });
+  response.end(JSON.stringify({ ok: true, launchId: process.env.BB_SERVER_LAUNCH_ID }));
+});
+server.on("error", () => process.exit(1));
+setTimeout(() => {
+  server.listen(Number(process.env.BB_SERVER_PORT), "127.0.0.1");
+}, 300);
+`;
+
+function createStartContext(args: {
+  serverEntry: string;
+  serverPort: number;
+}): BbAppStartContext {
+  const dataDir = "/tmp/bb-app-health-test";
+  return {
+    appDistDir: `${dataDir}/app/dist`,
+    appVersion: "0.0.0-test",
+    configFile: `${dataDir}/config.json`,
+    daemonBundleDir: `${dataDir}/host-daemon/dist`,
+    daemonEntry: `${dataDir}/host-daemon/dist/daemon-bundle.mjs`,
+    daemonLockDir: `${dataDir}/daemon.lock.lock`,
+    daemonLockFile: `${dataDir}/daemon.lock`,
+    daemonPort: args.serverPort + 1,
+    dataDir,
+    dbPath: `${dataDir}/bb.db`,
+    envFile: `${dataDir}/env.json`,
+    logDir: `${dataDir}/logs`,
+    packageRoot: `${dataDir}/package`,
+    serverEntry: args.serverEntry,
+    serverPort: args.serverPort,
+    serverUrl: `http://127.0.0.1:${args.serverPort}`,
+  };
+}
+
+const silentOutputBuffer = {
+  flush(): void {},
+  handler(): void {},
+};
+
+describe("waitForServerHealth", () => {
+  it("does not accept another server's /health while the child is still booting", async () => {
+    let healthRequests = 0;
+    const foreign = await listen((_request, response) => {
+      healthRequests += 1;
+      answerHealth(response, { ok: true });
+    });
+    // The launcher's own child: boots for a moment, then dies on EADDRINUSE.
+    const child = spawn(
+      process.execPath,
+      ["-e", "setTimeout(() => process.exit(1), 400)"],
+      { stdio: "ignore" },
+    );
+
+    try {
+      const outcome = await waitForServerHealth({
+        childProcess: child,
+        expectedLaunchId: "launch-expected",
+        timeoutMs: 5_000,
+        url: `http://127.0.0.1:${foreign.port}/health`,
+      }).then(
+        () => "healthy" as const,
+        (error: unknown) =>
+          error instanceof Error ? error.message : String(error),
+      );
+      await waitForProcessExit(child);
+
+      expect(child.exitCode).toBe(1);
+      expect(healthRequests).toBeGreaterThan(0);
+      expect(outcome).toBe(
+        `Process exited before becoming healthy: another server is already answering at http://127.0.0.1:${foreign.port}/health`,
+      );
+    } finally {
+      if (child.exitCode === null) child.kill("SIGKILL");
+      await foreign.close();
+    }
+  });
+
+  it("keeps polling past foreign answers until the child echoes its launch id", async () => {
+    let healthRequests = 0;
+    const server = await listen((_request, response) => {
+      healthRequests += 1;
+      answerHealth(
+        response,
+        healthRequests < 3
+          ? { ok: true }
+          : { ok: true, launchId: "launch-expected" },
+      );
+    });
+
+    try {
+      await waitForServerHealth({
+        childProcess: null,
+        expectedLaunchId: "launch-expected",
+        timeoutMs: 5_000,
+        url: `http://127.0.0.1:${server.port}/health`,
+      });
+      expect(healthRequests).toBe(3);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("times out when the responder never echoes the launch id", async () => {
+    const server = await listen((_request, response) => {
+      answerHealth(response, { ok: true, launchId: "launch-other" });
+    });
+
+    try {
+      await expect(
+        waitForServerHealth({
+          childProcess: null,
+          expectedLaunchId: "launch-expected",
+          timeoutMs: 250,
+          url: `http://127.0.0.1:${server.port}/health`,
+        }),
+      ).rejects.toThrow(
+        `Timed out waiting for health at http://127.0.0.1:${server.port}/health: another server is already answering`,
+      );
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe("startFullStackServerProcess", () => {
+  const scratchDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of scratchDirs.splice(0)) {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  function writeFakeServerEntry(): string {
+    const dir = mkdtempSync(join(tmpdir(), "bb-app-health-"));
+    scratchDirs.push(dir);
+    const entry = join(dir, "fake-server.mjs");
+    writeFileSync(entry, FAKE_SERVER_ENTRY_SOURCE);
+    return entry;
+  }
+
+  it("hands the child a launch id and accepts its /health once it listens", async () => {
+    const serverPort = await reserveFreePort();
+    const context = createStartContext({
+      serverEntry: writeFakeServerEntry(),
+      serverPort,
+    });
+    const processes: ManagedFullStackProcesses = {
+      daemonRun: null,
+      serverRun: null,
+    };
+
+    const serverRun = await startFullStackServerProcess({
+      context,
+      env: {
+        BB_SERVER_PORT: String(context.serverPort),
+        PATH: process.env.PATH,
+      },
+      outputBuffer: silentOutputBuffer,
+      processes,
+    });
+    try {
+      expect(processes.serverRun).toBe(serverRun);
+      const health = await fetch(`${context.serverUrl}/health`).then(
+        (response) => response.json(),
+      );
+      expect(health).toEqual({
+        ok: true,
+        launchId: expect.stringMatching(/^[0-9a-f-]{36}$/u),
+      });
+    } finally {
+      await serverRun.terminate("SIGTERM");
+    }
+  });
+
+  it("fails startup instead of adopting a server that already owns the port", async () => {
+    const foreign = await listen((_request, response) => {
+      answerHealth(response, { ok: true });
+    });
+    const context = createStartContext({
+      serverEntry: writeFakeServerEntry(),
+      serverPort: foreign.port,
+    });
+    const processes: ManagedFullStackProcesses = {
+      daemonRun: null,
+      serverRun: null,
+    };
+
+    try {
+      await expect(
+        startFullStackServerProcess({
+          context,
+          env: {
+            BB_SERVER_PORT: String(context.serverPort),
+            PATH: process.env.PATH,
+          },
+          outputBuffer: silentOutputBuffer,
+          processes,
+        }),
+      ).rejects.toThrow(
+        `Server failed to become healthy: Process exited before becoming healthy: another server is already answering at ${context.serverUrl}/health`,
+      );
+      expect(processes.serverRun).toBeNull();
+    } finally {
+      await foreign.close();
+    }
+  });
+});

--- a/packages/config/src/env-vars.ts
+++ b/packages/config/src/env-vars.ts
@@ -190,6 +190,13 @@ export const BB_APP_VERSION_ENV = defineEnvVar<string>({
   parse: parseNonEmptyStringEnvValue,
 });
 
+export const BB_SERVER_LAUNCH_ID_ENV = defineEnvVar<string>({
+  description:
+    "Internal per-spawn identity the bb-app launcher hands its server child. The server echoes it on /health so the launcher can tell its own child apart from another bb server that already owns the port.",
+  name: "BB_SERVER_LAUNCH_ID",
+  parse: parseNonEmptyStringEnvValue,
+});
+
 export const BB_APP_SURFACE_ENV = defineEnvVar<AppSurface>({
   description:
     "Internal launcher marker for telemetry attribution. Set by bb-app and desktop launchers.",

--- a/packages/config/src/server.ts
+++ b/packages/config/src/server.ts
@@ -7,7 +7,11 @@ import {
 } from "./common.js";
 import { loadDatabaseConfig, type DatabaseConfig } from "./database.js";
 import { loadDevAppConfig } from "./dev-app.js";
-import { readEnvVarWithDefault, resolveEnvLoader } from "./env.js";
+import {
+  readEnvVarWithDefault,
+  readOptionalEnvVar,
+  resolveEnvLoader,
+} from "./env.js";
 import {
   BB_APP_URL_ENV,
   BB_APP_SURFACE_ENV,
@@ -19,6 +23,7 @@ import {
   BB_MARKETPLACE_URL_ENV,
   BB_POSTHOG_API_KEY_ENV,
   BB_SERVER_BIND_HOST_ENV,
+  BB_SERVER_LAUNCH_ID_ENV,
   BB_TELEMETRY_ENV,
   BB_TRANSCRIPTION_ENV,
   DEFAULT_BB_APP_URL,
@@ -56,6 +61,11 @@ export interface ServerConfig
   BB_POSTHOG_API_KEY: string;
   BB_MARKETPLACE_URL: string;
   BB_SERVER_BIND_HOST: ServerBindHost;
+  /**
+   * Present only when the bb-app launcher spawned this server. The launcher's
+   * readiness probe accepts a /health response only when it echoes this value.
+   */
+  BB_SERVER_LAUNCH_ID?: string;
   BB_TELEMETRY: boolean;
   BB_TRANSCRIPTION: string;
   OPENAI_API_KEY: string;
@@ -194,6 +204,15 @@ export function loadServerConfig(
     key: "BB_DEV_APP_PORT",
     target: config,
     value: devAppConfig.BB_DEV_APP_PORT,
+  });
+  assignIfDefined({
+    key: "BB_SERVER_LAUNCH_ID",
+    target: config,
+    value: readOptionalEnvVar({
+      context: loader.context,
+      definition: BB_SERVER_LAUNCH_ID_ENV,
+      env: loader.env,
+    }),
   });
 
   return config;

--- a/packages/config/test/config.test.ts
+++ b/packages/config/test/config.test.ts
@@ -314,6 +314,19 @@ describe("consumer-specific config", () => {
     });
   });
 
+  it("carries the launcher's server launch id only when it is set", () => {
+    expect(
+      loadServerConfig({
+        env: createServerRuntimeEnv({ BB_SERVER_LAUNCH_ID: undefined }),
+      }),
+    ).not.toHaveProperty("BB_SERVER_LAUNCH_ID");
+    expect(
+      loadServerConfig({
+        env: createServerRuntimeEnv({ BB_SERVER_LAUNCH_ID: "launch-123" }),
+      }).BB_SERVER_LAUNCH_ID,
+    ).toBe("launch-123");
+  });
+
   it("defaults the server bind host to loopback", () => {
     const serverConfig = loadServerConfig({
       env: createServerRuntimeEnv({


### PR DESCRIPTION
## What was wrong

The bb-app launcher decided its server child was up as soon as `GET /health` on the configured port returned 200 (`waitForHealth` in `packages/bb-app/src/launcher.ts`). It never checked who answered. `/health` is a constant `{ ok: true }`, and a bb server takes seconds to boot, so when another bb server already owned the port (a second `npx bb-app` with a different `BB_DATA_DIR` and default ports), the foreign server satisfied the first 100 ms poll every time. The launcher printed `Server listening`, called `maybeAddAutoJoinEnv`, minted an enroll key from the foreign server, and its daemon wrote the resulting host key into the second data dir before its own server child died with `EADDRINUSE`. Once the foreign server was gone, that data dir failed every start with `401` / `INVALID_API_KEY` until `auth.json` was deleted. The daemon probe (`waitForHostDaemonStatus`) already checks `hostId`/`serverUrl`; the server probe had no identity check at all.

Issue: #1558. Report: https://get-bb.github.io/reports/issues/1558.html

## What changed

- `packages/bb-app/src/launcher.ts`: `startFullStackServerProcess` generates a fresh `BB_SERVER_LAUNCH_ID` (`randomUUID()`) per spawn and passes it in the server child's env. `waitForHealth` became `waitForServerHealth`: it parses the `/health` body and accepts a 200 only when it echoes that launch id. A foreign 200 keeps the poll going, so the child's `EADDRINUSE` exit surfaces as `Process exited before becoming healthy: another server is already answering at <url>`. The probe now also uses the same per-request timeout as the daemon probe. The startup failure line prints the real reason instead of the fixed `(health check timed out)`.
- `packages/config/src/env-vars.ts`, `packages/config/src/server.ts`: new optional `BB_SERVER_LAUNCH_ID` read at the server's env boundary. It is launcher-owned and overwritten per spawn, so it is not a user knob and is not added to the startup-only env key list or docs (same treatment as `BB_APP_VERSION`).
- `apps/server/src/types.ts`, `apps/server/src/start-server.ts`, `apps/server/src/server.ts`: `ServerRuntimeConfig.launchId` (absent when the server was not spawned by the launcher); `/health` returns `{ ok: true, launchId }` when set and `{ ok: true }` otherwise. Additive only; the desktop and mobile probes parse `/health` with non-strict schemas.
- No wire change between server and host daemon, so no `HOST_DAEMON_PROTOCOL_VERSION` bump. Launcher and server ship in the same bb-app package.

This follows the report's proposed fix. The report's optional follow-ups (give the supervision restart loop an exit, add a recovery hint to the daemon's 401 message) are not in this PR; with the identity probe the launcher never reaches enrollment or supervision when the port is taken.

## How you verified

New tests:

- `packages/bb-app/test/server-health-identity.test.ts`
  - `waitForServerHealth` rejects a foreign `/health` while the child is booting and exits (the report's repro). On `origin/main` (with `waitForHealth` exported) it fails with `AssertionError: expected 'healthy' not to be 'healthy'`.
  - keeps polling past foreign answers until the launch id matches; times out with the "another server is already answering" reason when it never does.
  - `startFullStackServerProcess` against a fake server entry: hands the child a launch id and accepts its `/health` once it listens; with another listener on the port it rejects with `Server failed to become healthy: Process exited before becoming healthy: another server is already answering at ...` and leaves `processes.serverRun` null.
- `apps/server/test/app/skeleton.test.ts`: `/health` echoes `launchId` only when configured.
- `packages/config/test/config.test.ts`: `BB_SERVER_LAUNCH_ID` is carried only when set.

Commands (from the committed tree, `git status --porcelain` empty):

- `pnpm exec turbo run typecheck` — `Tasks: 72 successful, 72 total`
- `pnpm exec turbo run test --filter=@bb/config --filter=bb-app --filter=@bb/server` — config 108/108, bb-app 70/70, server 1823/1824. The one server failure is `internal-skill-trees.test.ts` expecting file mode 0644 and getting 0664; it is the known local umask 0002 artifact, unrelated to this change, and passes here under `umask 022`.

Manual repro (report steps, built `packages/bb-app/dist/bb-app.js` from this branch, ports 47886/47887, data dirs under `~/.bb-dev/scratch/1558/`):

1. Instance one starts; `/health` returns `{"ok":true,"launchId":"ff964df3-..."}`.
2. Instance two (different data dir, same ports) now exits 1 with `✗ Server failed to start` / `Server failed to become healthy: Process exited before becoming healthy: another server is already answering at http://127.0.0.1:47886/health`. Its data dir has no `auth.json` and no `host-id`; `select id from hosts` on instance one's db lists only its own host. Before the fix the report shows `✓ Server listening`, an `auth.json` in the second data dir, and the host row in the first db.
3. Stop instance one, start instance two alone: `bb is ready`, its host is enrolled in its own db.

Fixes #1558

> AGENT GENERATED: by Claude Opus 5


## Independent verification

Verified on a fresh worktree at `1353c6477` (branch contains current `origin/main`; `git merge-base --is-ancestor origin/main HEAD` true; `mergeable: MERGEABLE`).

Root cause check: the report and fix agree with my own reading of `origin/main` — `waitForHealth` returned on any 200 from `/health` (a constant `{ok:true}`), so a foreign bb server on the port satisfied the probe before the child reached `listen()`, and `maybeAddAutoJoinEnv` then enrolled the daemon there. The fix is launcher-to-server only (`BB_SERVER_LAUNCH_ID` env -> `/health` echo -> probe match); nothing on the server/host-daemon wire changes, so no `HOST_DAEMON_PROTOCOL_VERSION` bump is needed. Every other in-repo `/health` consumer (desktop `server-probe.ts`, mobile `profiles/probe.ts`, `packages/scripts/wait-for-server-health.ts`) uses a tolerant schema, so the additive `launchId` field is safe. The `bb-app server` (server-only) path has no health probe and is untouched.

Fail-before / pass-after (swapped the six non-test source files to `origin/main` with `git checkout origin/main -- ...`, ran the PR's tests, then restored with `git checkout HEAD -- ...`):

- `packages/config` `config.test.ts -t "launch id"`: before `AssertionError: expected undefined to be 'launch-123'`; after 1 passed.
- `apps/server` `skeleton.test.ts -t "launch id"`: before `AssertionError: expected { ok: true } to deeply equal { ok: true, launchId: 'launch-123' }`; after 1 passed.
- `packages/bb-app` `server-health-identity.test.ts`: before, as-is, 5/5 fail with `TypeError: waitForServerHealth is not a function`. To prove the failures are behavioral and not just missing exports, I also exported main's `waitForHealth`/`startFullStackServerProcess` and pointed a copy of the test at them: 5/5 still fail, with `expected 'healthy' to be 'Process exited before becoming health…'`, `expected 1 to be 3`, `promise resolved "undefined" instead of rejecting`, `expected { ok: true } to deeply equal { ok: true, …(1) }`, and `promise resolved "{ …(3) }" instead of rejecting`. After restoring the PR sources: 5/5 pass.

Turbo (from the clean committed tree):

- `pnpm exec turbo run typecheck --filter=@bb/config --filter=bb-app --filter=@bb/server --filter=@bb/host-daemon --filter=@bb/desktop` -> `Tasks: 8 successful, 8 total`
- `pnpm exec turbo run test --filter=@bb/config --filter=bb-app --filter=@bb/server --force` -> config 108/108, bb-app 70/70, server 1823/1824; the single failure is `internal-skill-trees.test.ts` (mode 420 vs 436), the known local umask 0002 artifact, unrelated and green in CI.

Repro on the fixed branch (built `packages/bb-app/dist/bb-app.js`, ports 47890/47891, data dirs under `~/.bb-dev/scratch/1558-verify/`):

1. Instance one: `bb is ready`; `/health` -> `{"ok":true,"launchId":"46f5a30b-..."}`.
2. Instance two (different data dir, same ports): exits with `✗ Server failed to start` / `Server failed to become healthy: Process exited before becoming healthy: another server is already answering at http://127.0.0.1:47890/health`. Its data dir contains only `auth-secret bb.db bb.db-shm bb.db-wal launcher.log logs` (no `auth.json`, no `host-id`); instance one's `hosts` table holds only its own `host_w5qw5tqrvh`; instance two's `hosts` table is empty.
3. Stop one, restart two on the freed ports: `bb is ready`, enrolled in its own db (`host_9c6qb6u6qj`). No 401 / INVALID_API_KEY.
4. Report variant (only the server port collides, daemon port 47893): also fails fast at the server step with the same message; no `bb is ready`, no restart loop, no enrollment.

CI: all checks pass (Checks, Package Smoke x2, Tests app-1/2/3, integration, packages, server; iOS and Node compat matrix skipped as usual).

Residual risks (not blocking): the server still logs `[server] Server listening` before the socket is bound (report's adjacent defect (a)), so an EADDRINUSE child prints a misleading INFO line; the supervision loop still retries a server child that cannot bind after a mid-run crash; the two `startFullStackServerProcess` tests reserve a free port and bind it ~300 ms later, a small theoretical race under heavy parallel load.

> AGENT GENERATED: by Claude Opus 5
