### PR TITLE
Virtualize the CSV preview rows and remote path browser entries

### DIFF
--- a/apps/app/src/components/dialogs/RemotePathBrowser.createFolder.test.tsx
+++ b/apps/app/src/components/dialogs/RemotePathBrowser.createFolder.test.tsx
@@ -8,7 +8,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import type { HostDirectoryListing } from "@bb/server-contract";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { sdk } from "@/lib/sdk";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import {
@@ -40,9 +40,24 @@ function listing(path: string, entries: string[]): HostDirectoryListing {
   };
 }
 
+/**
+ * jsdom has no layout, so the entry list's virtualizer would see a 0px scroll
+ * box and mount nothing. Give every scroll box a 224px (h-56) viewport and
+ * every entry row its real single-line height.
+ */
+const ENTRY_TEST_ROW_HEIGHT_PX = 28;
+beforeEach(() => {
+  vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(
+    function (this: HTMLElement) {
+      return this.tagName === "LI" ? ENTRY_TEST_ROW_HEIGHT_PX : 224;
+    },
+  );
+});
+
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
+  vi.restoreAllMocks();
 });
 
 describe("joinHostPath", () => {
@@ -234,5 +249,44 @@ describe("RemotePathBrowser new folder", () => {
 
     expect(await screen.findByText(/already exists/)).toBeTruthy();
     expect(onDirectoryChange).not.toHaveBeenCalledWith("/home/me/existing");
+  });
+});
+
+describe("RemotePathBrowser entry list", () => {
+  it("mounts only the entries near the viewport for a huge directory", async () => {
+    const names = Array.from(
+      { length: 5000 },
+      (_, i) => `file_${String(i).padStart(5, "0")}`,
+    );
+    directory.mockResolvedValue(listing("/home/me/manyfiles", names));
+    const { wrapper: Wrapper } = createQueryClientTestHarness();
+
+    const { container } = render(
+      <Wrapper>
+        <RemotePathBrowser
+          hostId="host_atum"
+          allowCreateFolder={false}
+          onDirectoryChange={vi.fn()}
+        />
+      </Wrapper>,
+    );
+
+    await screen.findByText("file_00000");
+    // 224px / 28px is 8 visible rows; with overscan the mounted set stays a
+    // small constant instead of one row per directory entry.
+    const mountedRows = container.querySelectorAll("li");
+    expect(mountedRows.length).toBeLessThan(60);
+    expect(mountedRows.length).toBeGreaterThanOrEqual(8);
+    expect(screen.queryByText("file_04999")).toBeNull();
+
+    // Scrolling to the bottom mounts the last rows and unmounts the first.
+    const list = container.querySelector("ul");
+    const scrollBox = list?.parentElement;
+    if (!(scrollBox instanceof HTMLElement)) throw new Error("no scroll box");
+    scrollBox.scrollTop = 4_999 * ENTRY_TEST_ROW_HEIGHT_PX;
+    fireEvent.scroll(scrollBox);
+    expect(await screen.findByText("file_04999")).not.toBeNull();
+    expect(screen.queryByText("file_00000")).toBeNull();
+    expect(container.querySelectorAll("li").length).toBeLessThan(60);
   });
 });

--- a/apps/app/src/components/dialogs/RemotePathBrowser.tsx
+++ b/apps/app/src/components/dialogs/RemotePathBrowser.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { normalizeProjectPathInput } from "@bb/domain";
+import type { HostDirectoryListing } from "@bb/server-contract";
 import { Button } from "@bb/shared-ui/button";
 import { EmptyState } from "@bb/shared-ui/empty-state";
 import { Icon } from "@bb/shared-ui/icon";
@@ -64,6 +66,21 @@ export function getFolderNameValidationMessage(name: string): string | null {
   return null;
 }
 
+/**
+ * Every entry row is one truncated `text-sm` line with `py-1`, so this
+ * estimate is exact; `measureElement` still corrects it for zoom or font
+ * changes.
+ */
+const DIRECTORY_ENTRY_ROW_HEIGHT_PX = 28;
+/**
+ * Also covers the "new folder" form that sits above the list inside the same
+ * scroll box (at most ~3 rows tall), so the virtualizer can treat the list as
+ * starting at scroll offset 0 without a `scrollMargin` measurement.
+ */
+const DIRECTORY_ENTRY_OVERSCAN_ROWS = 10;
+
+const NO_ENTRIES: HostDirectoryListing["entries"] = [];
+
 interface RemotePathBrowserProps {
   hostId: string;
   /** Directory to open at; null starts at the host's home directory. */
@@ -102,6 +119,20 @@ export function RemotePathBrowser({
 
   const directory = data?.directory ?? null;
   const crumbs = directory ? toBreadcrumb(directory) : [];
+
+  // The daemon lists the whole directory, so a build output or home folder
+  // can hold thousands of entries. The list box shows ~8 rows; mounting every
+  // entry made that box cost one DOM row per file (#1615). Mount only the rows
+  // near the viewport instead.
+  const entries = data?.entries ?? NO_ENTRIES;
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const entryVirtualizer = useVirtualizer({
+    count: entries.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => DIRECTORY_ENTRY_ROW_HEIGHT_PX,
+    getItemKey: (index) => entries[index]?.path ?? index,
+    overscan: DIRECTORY_ENTRY_OVERSCAN_ROWS,
+  });
 
   const startCreatingFolder = () => {
     if (
@@ -234,17 +265,25 @@ export function RemotePathBrowser({
         className="px-2 py-3"
       />
     );
-  } else if (data.entries.length === 0) {
+  } else if (entries.length === 0) {
     body = <EmptyState message="This folder is empty." className="px-2 py-3" />;
   } else {
     body = (
-      <ul className="flex flex-col">
-        {data.entries.map((entry) => {
+      <ul
+        className="relative"
+        style={{ height: entryVirtualizer.getTotalSize() }}
+      >
+        {entryVirtualizer.getVirtualItems().map((virtualItem) => {
+          const entry = entries[virtualItem.index];
+          if (!entry) return null;
           if (entry.kind === "file") {
             return (
               <li
                 key={entry.path}
-                className="flex items-center gap-2 px-2 py-1 text-sm text-muted-foreground"
+                data-index={virtualItem.index}
+                ref={entryVirtualizer.measureElement}
+                className="absolute left-0 flex w-full items-center gap-2 px-2 py-1 text-sm text-muted-foreground"
+                style={{ top: virtualItem.start }}
               >
                 <Icon name="File" className="size-4 shrink-0" />
                 <span className="min-w-0 truncate" title={entry.name}>
@@ -254,7 +293,13 @@ export function RemotePathBrowser({
             );
           }
           return (
-            <li key={entry.path}>
+            <li
+              key={entry.path}
+              data-index={virtualItem.index}
+              ref={entryVirtualizer.measureElement}
+              className="absolute left-0 w-full"
+              style={{ top: virtualItem.start }}
+            >
               <button
                 type="button"
                 disabled={interactionDisabled}
@@ -383,6 +428,7 @@ export function RemotePathBrowser({
       </div>
 
       <div
+        ref={scrollRef}
         className={cn(
           "h-56 min-h-0 overflow-y-auto px-1.5 py-1",
           isPlaceholderData && "opacity-60",

--- a/apps/app/src/components/secondary-panel/FilePreview.test.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.test.tsx
@@ -182,6 +182,20 @@ function renderWithWorkerPool(ui: ReactElement) {
   );
 }
 
+/**
+ * jsdom has no layout, so the CSV table's row virtualizer would see a 0px
+ * scroll box and mount nothing. Give every scroll box a 400px viewport and
+ * every table row its real single-line height.
+ */
+const CSV_TEST_ROW_HEIGHT_PX = 29;
+function mockCsvTableLayout() {
+  vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(
+    function (this: HTMLElement) {
+      return this.tagName === "TR" ? CSV_TEST_ROW_HEIGHT_PX : 400;
+    },
+  );
+}
+
 describe("FilePreview", () => {
   beforeEach(() => {
     pierreMock.state.cachedFileKeys.clear();
@@ -198,6 +212,7 @@ describe("FilePreview", () => {
   afterEach(() => {
     cleanup();
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("offers a manual file refresh action", () => {
@@ -579,6 +594,7 @@ describe("FilePreview", () => {
   });
 
   it("renders CSV previews as a table by default", () => {
+    mockCsvTableLayout();
     render(
       <FilePreview
         path="reports/customers.csv"
@@ -666,7 +682,54 @@ describe("FilePreview", () => {
     expect(getCsvTruncationNote(preview, preview.rows.length - 1)).toBeNull();
   });
 
+  it("mounts only the CSV rows near the viewport, not the whole 500x100 window", () => {
+    mockCsvTableLayout();
+    const columnCount = 120;
+    const header = Array.from({ length: columnCount }, (_, i) => `col_${i}`);
+    const lines = [header.join(",")];
+    for (let rowIndex = 0; rowIndex < 600; rowIndex += 1) {
+      lines.push(header.map((_, c) => `r${rowIndex}c${c}`).join(","));
+    }
+
+    render(
+      <FilePreview
+        path="data/big.csv"
+        state={{
+          kind: "ready",
+          file: { name: "big.csv", contents: lines.join("\n") },
+          lineRange: null,
+          textPreviewKind: "csv",
+        }}
+      />,
+    );
+
+    const table = screen.getByRole("table", { name: "big.csv CSV preview" });
+    expect(screen.getByText("r0c0")).not.toBeNull();
+    // 400px / 29px is ~14 visible rows; with overscan the mounted set stays
+    // far below the 500-row parse cap (50,000 cells when fully mounted).
+    expect(table.querySelectorAll("td").length).toBeLessThan(6_000);
+    const mountedRows = table.querySelectorAll("tbody tr[data-index]");
+    expect(mountedRows.length).toBeGreaterThanOrEqual(14);
+    expect(mountedRows.length).toBeLessThan(60);
+    expect(screen.queryByText("r499c0")).toBeNull();
+
+    // Scrolling to the bottom mounts the last rows and unmounts the first.
+    const scrollBox = table.parentElement;
+    if (!(scrollBox instanceof HTMLElement)) throw new Error("no scroll box");
+    scrollBox.scrollTop = 499 * CSV_TEST_ROW_HEIGHT_PX;
+    fireEvent.scroll(scrollBox);
+    expect(screen.getByText("r499c0")).not.toBeNull();
+    expect(screen.queryByText("r0c0")).toBeNull();
+    expect(table.querySelectorAll("tbody tr[data-index]").length).toBeLessThan(
+      60,
+    );
+    expect(
+      screen.getByText("Showing the first 500 rows and 100 columns."),
+    ).not.toBeNull();
+  });
+
   it("uses the CSV table preview for loaded CSV text files", () => {
+    mockCsvTableLayout();
     render(
       <SecondaryPanelFilePreview
         activePath="exports/scores.csv"

--- a/apps/app/src/components/secondary-panel/FilePreview.tsx
+++ b/apps/app/src/components/secondary-panel/FilePreview.tsx
@@ -1,5 +1,12 @@
-import { type CSSProperties, useEffect, useMemo, useState } from "react";
+import {
+  type CSSProperties,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { UrlTransform } from "react-markdown";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { Button } from "@bb/shared-ui/button";
 import { SourceCodeHost } from "@/components/code/SourceCodeHost";
 import { COARSE_POINTER_TEXT_SM_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
@@ -179,6 +186,13 @@ type IframeLoadState = "loading" | "loaded" | "error";
 
 const CSV_PREVIEW_MAX_COLUMNS = 100;
 const CSV_PREVIEW_MAX_ROWS = 500;
+/**
+ * Every CSV body row is one truncated `leading-5` line with `py-1` and a
+ * bottom border, so this estimate is exact; `measureElement` still corrects
+ * it for zoom or font changes.
+ */
+const CSV_PREVIEW_ROW_HEIGHT_PX = 29;
+const CSV_PREVIEW_OVERSCAN_ROWS = 8;
 
 /**
  * Code previews above either budget render only a leading prefix until the
@@ -902,6 +916,28 @@ function CsvFilePreview({ file, onSelectionAddToChat }: CsvFilePreviewProps) {
   const tableWidth = `max(100%, ${3 + columns.length * 18}rem)`;
   const truncationNote = getCsvTruncationNote(preview, bodyRows.length);
 
+  // The parse cap still allows 500 x 100 = 50,000 cells, and a scroll box only
+  // clips painting, not DOM: mounting every row blocked the main thread for
+  // seconds and cost ~150k nodes (#1615). Mount only the rows near the
+  // viewport; spacer rows keep the table's natural height so the scrollbar,
+  // sticky header and sticky row-number gutter behave as before.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const rowVirtualizer = useVirtualizer({
+    count: bodyRows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => CSV_PREVIEW_ROW_HEIGHT_PX,
+    overscan: CSV_PREVIEW_OVERSCAN_ROWS,
+  });
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const totalRowsHeight = rowVirtualizer.getTotalSize();
+  const firstVirtualRow = virtualRows[0];
+  const lastVirtualRow = virtualRows[virtualRows.length - 1];
+  const spacerTopHeight = firstVirtualRow?.start ?? 0;
+  const spacerBottomHeight =
+    lastVirtualRow === undefined
+      ? totalRowsHeight
+      : totalRowsHeight - lastVirtualRow.end;
+
   return (
     <SecondaryPanelSelectionActions onSelectionAddToChat={onSelectionAddToChat}>
       {/* Single scroll container for both axes: the sticky header row and
@@ -912,7 +948,10 @@ function CsvFilePreview({ file, onSelectionAddToChat }: CsvFilePreviewProps) {
         {/* overscroll-contain: panning a wide table past its edge must not
             chain into the browser back/forward gesture (kept alive globally —
             see app.css overscroll notes) or scroll an ancestor. */}
-        <div className="persistent-scrollbar min-h-0 overflow-auto overscroll-contain rounded-md border border-border bg-background">
+        <div
+          ref={scrollRef}
+          className="persistent-scrollbar min-h-0 overflow-auto overscroll-contain rounded-md border border-border bg-background"
+        >
           <table
             className="min-w-full table-fixed border-separate border-spacing-0 font-mono text-xs leading-5"
             aria-label={`${file.name} CSV preview`}
@@ -947,30 +986,48 @@ function CsvFilePreview({ file, onSelectionAddToChat }: CsvFilePreviewProps) {
               </tr>
             </thead>
             <tbody>
-              {bodyRows.map((row, rowIndex) => (
-                <tr key={rowIndex}>
-                  <th
-                    scope="row"
-                    className="sticky left-0 z-10 w-12 min-w-12 border-b border-r border-border bg-surface-recessed-solid px-2 py-1 text-right font-medium text-muted-foreground"
-                  >
-                    {rowIndex + 2}
-                  </th>
-                  {columns.map((column) => {
-                    const cell = row[column.index] ?? "";
-                    return (
-                      <td
-                        key={column.index}
-                        className="w-72 max-w-72 overflow-hidden border-b border-r border-border px-2 py-1 align-top text-foreground"
-                        title={cell}
-                      >
-                        <span className="block max-w-full truncate">
-                          {cell}
-                        </span>
-                      </td>
-                    );
-                  })}
+              {spacerTopHeight > 0 ? (
+                <tr aria-hidden style={{ height: spacerTopHeight }}>
+                  <td colSpan={columns.length + 1} className="p-0" />
                 </tr>
-              ))}
+              ) : null}
+              {virtualRows.map((virtualRow) => {
+                const rowIndex = virtualRow.index;
+                const row = bodyRows[rowIndex] ?? [];
+                return (
+                  <tr
+                    key={virtualRow.key}
+                    data-index={rowIndex}
+                    ref={rowVirtualizer.measureElement}
+                  >
+                    <th
+                      scope="row"
+                      className="sticky left-0 z-10 w-12 min-w-12 border-b border-r border-border bg-surface-recessed-solid px-2 py-1 text-right font-medium text-muted-foreground"
+                    >
+                      {rowIndex + 2}
+                    </th>
+                    {columns.map((column) => {
+                      const cell = row[column.index] ?? "";
+                      return (
+                        <td
+                          key={column.index}
+                          className="w-72 max-w-72 overflow-hidden border-b border-r border-border px-2 py-1 align-top text-foreground"
+                          title={cell}
+                        >
+                          <span className="block max-w-full truncate">
+                            {cell}
+                          </span>
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+              {spacerBottomHeight > 0 ? (
+                <tr aria-hidden style={{ height: spacerBottomHeight }}>
+                  <td colSpan={columns.length + 1} className="p-0" />
+                </tr>
+              ) : null}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## What was wrong

Two of the three surfaces in #1615 still mounted every row of a large array into a small scroll box. A scroll box clips painting, not DOM, so WebKit still styled, laid out and kept every row in memory. `CsvFilePreview` mapped its whole 500x100 parse window into `<tr><td><span>` (50,000 `td`, ~101k elements in the table, a 2-8 s main-thread block and +33 MB heap, per the [report](https://get-bb.github.io/reports/issues/1615.html)). `RemotePathBrowser` mapped every `readdir` entry into an `<li>` inside its `h-56` box (5,000 rows / 20,000 elements for a 5,000-file folder) because the daemon listing has no cap. The third surface, the prompt-banner `WorkspaceChangesList`, was already fixed on main by #1783 (200-row cap and lazy mount of collapsed bodies).

## What changed

- `apps/app/src/components/secondary-panel/FilePreview.tsx`: the CSV table mounts only the body rows near the viewport with `useVirtualizer` (the pattern `DiffFilesPanel` already uses) on the existing scroll container. Spacer `<tr>`s above and below the mounted window keep the table's natural height, so the scrollbar, the sticky header row and the sticky row-number gutter behave exactly as before. Row height is a fixed 29px estimate (`leading-5` + `py-1` + border) corrected by `measureElement`. Columns are not virtualized; a mounted row still has up to 101 cells, so the bound is roughly 35-45 rows x 101 cells instead of 500 x 101.
- `apps/app/src/components/dialogs/RemotePathBrowser.tsx`: the entry list mounts only the rows near the viewport, positioned absolutely inside a `ul` sized to the virtual total. The "new folder" form stays inside the same scroll box above the list; the 10-row overscan covers its height so no `scrollMargin` measurement is needed (documented in the code).
- No wire, CLI or protocol change. The daemon still returns the full directory listing and full CSV file; this PR bounds the DOM, which is what the issue and report measured. Capping the listing at the daemon (the report's optional step) would change the `host.browse_directory` result shape and need a `HOST_DAEMON_PROTOCOL_VERSION` bump, so it is left out of this focused change.

## How you verified

New tests (jsdom, with `offsetHeight` mocked so the virtualizer has a viewport):

- `FilePreview.test.tsx` > "mounts only the CSV rows near the viewport, not the whole 500x100 window": a 600x120 CSV mounts fewer than 6,000 `td` and 14-59 rows, the first row is visible and the last is not; scrolling the box to the bottom mounts `r499c0`, unmounts `r0c0`, and the truncation note still reads "Showing the first 500 rows and 100 columns."
- `RemotePathBrowser.createFolder.test.tsx` > "mounts only the entries near the viewport for a huge directory": a 5,000-entry listing mounts 8-59 `li`; scrolling to the bottom mounts `file_04999` and unmounts `file_00000`.

Fail before (source files checked out from `origin/main`, tests from this branch):

```
× mounts only the entries near the viewport for a huge directory
  AssertionError: expected 5000 to be less than 60
× mounts only the CSV rows near the viewport, not the whole 500x100 window
  AssertionError: expected 50000 to be less than 6000
```

Pass after, from the committed tree (`git status --porcelain` empty):

```
pnpm exec turbo run typecheck --filter=@bb/app   ->  Tasks: 3 successful, 3 total
pnpm exec turbo run test --filter=@bb/app --force ->  Tasks: 4 successful, 4 total
                                                    Test Files 409 passed (409), Tests 3158 passed | 3 skipped (3161)
```

Manual check on my own dev instance (headless Chromium 1400x900, fixture from the report: 600x120 `data/big.csv` plus 5,000 untracked files):

- CSV preview (before, from the report at the same viewport: `td: 50000`, `tableNodes: 101306`, 3.2 s to table-in-DOM): after, `td: 3401`, `tableNodes: 7176`, 34 body rows, 597 ms from Enter to table-in-DOM including the file fetch. Scroll size unchanged at 28,848x14,529 px. Scrolled to the bottom: rows 467-499 mounted, last cell `r499c0`, sticky header still at the top of the box. Scrolled to (6000, 5000): rows 198-240 mounted, sticky `#` gutter still at the left edge.
- Folder browser on the 5,000-file directory (before: 5,000 `li`, 20,001 nodes in the box): after, 19 `li`, 77 nodes in the box, 108 ms; scrolled to the bottom shows `file_04982`-`file_04999`.

Fixes #1615

> AGENT GENERATED: by Claude Opus 5



## Independent verification

Checked out `bb/fix-1615-bounded-lists` at `bf3a653a2` (one commit over `origin/main`, which is an ancestor; GitHub reports MERGEABLE/CLEAN) in a separate worktree with its own dev instance.

Commands:

```
git fetch origin main && git fetch origin bb/fix-1615-bounded-lists && git checkout -b verify-1615-r1 FETCH_HEAD
git checkout origin/main -- apps/app/src/components/secondary-panel/FilePreview.tsx apps/app/src/components/dialogs/RemotePathBrowser.tsx
(cd apps/app && pnpm exec vitest run --config vitest.config.ts src/components/secondary-panel/FilePreview.test.tsx src/components/dialogs/RemotePathBrowser.createFolder.test.tsx)
git checkout HEAD -- <same two files>   # then the same vitest command again
pnpm exec turbo run typecheck --filter=@bb/app
pnpm exec turbo run test --filter=@bb/app --force
```

Fail before (PR tests against `origin/main` sources):

```
× mounts only the entries near the viewport for a huge directory
  AssertionError: expected 5000 to be less than 60
× mounts only the CSV rows near the viewport, not the whole 500x100 window
  AssertionError: expected 50000 to be less than 6000
Test Files  2 failed (2)   Tests  2 failed | 26 passed (28)
```

Pass after (PR sources restored, `git status --porcelain` empty): `Test Files 2 passed (2), Tests 28 passed (28)`. `turbo typecheck --filter=@bb/app`: `Tasks: 3 successful, 3 total`. `turbo test --filter=@bb/app --force`: `Tasks: 4 successful, 4 total`, `Test Files 409 passed (409)`.

Repro on the fixed branch (own dev instance, headless Chromium 1400x900 via doobie, report fixture: 600x120 `data/big.csv` committed plus 5,000 untracked files, one "Reply only with ok." codex turn to provision the workspace):

- CSV preview, after pressing Enter in the secondary-panel file search: `td: 3401`, `th: 135`, `tableNodes: 7176`, 34 body rows (indexes 0-33), 995 ms Enter-to-table; scroll box 505x742, scroll size unchanged at 28,848x14,529, note "Showing the first 500 rows and 100 columns." Scrolled to the bottom: rows 467-499 mounted, last cell `r499c0`, sticky header still at the top of the box. Scrolled to (6000, 5000): rows 164-206 mounted, sticky row gutter still at the left edge. The report measured `td: 50000`, `tableNodes: 101306`, 3.2 s on main. No longer reproduces.
- Add-project folder browser on the 5,000-file directory: 19 `li`, 77 nodes in the 224 px box (report on main: 5,000 `li`, 20,001 nodes), `ul` height 139,981 px. Scrolled to the bottom: 18 `li` mounted, `file_04991`-`file_04999` visible. Scrolled to the middle: `file_02500`-`file_02508` visible with the viewport fully covered. With the "New folder" form open above the list, top and bottom still show `file_00000` and `file_04999` with no gap. No longer reproduces.
- Third surface in the issue (prompt-banner `WorkspaceChangesList`) confirmed already bounded on `origin/main`: `WORKSPACE_CHANGES_LIST_MAX_ROWS = 200` and `AnimatedBody` mounts children only after the first expand. The banner on my instance exposes a single "Changed files: Untracked, 5000 files" button while collapsed.

CI at verification time: all required checks pass (app-1/2/3, server, packages, integration tests; Package Smoke on ubuntu and macos-15; version check). iOS simulator flows and Node compatibility smoke skipped by path filter.

Residual risks (none blocking):

- `RemotePathBrowser` does not pass `scrollMargin`, so the virtualizer treats the list as starting at scroll offset 0 while the box's `py-1` padding and the optional "New folder" form (28 px + 4 px margin, plus an error line) sit above it. The 10-row (280 px) overscan absorbs that offset today; a taller element above the list would need `scrollMargin`.
- CSV columns are not virtualized: each mounted row still carries up to 101 cells, so a 100-column file mounts ~3.4k `td` instead of 50k. Text selection for "Add to chat" spans only mounted rows, the same limitation the virtualized code view already has.
- The daemon still returns unbounded directory listings and the status route still returns every changed file on the wire; capping those needs a protocol bump and is out of scope here.

> AGENT GENERATED: by Claude Opus 5
