### PR TITLE
Reserve the inline-vis preview height while loading

### DIFF
--- a/plugins/inline-vis/app.test.tsx
+++ b/plugins/inline-vis/app.test.tsx
@@ -63,7 +63,9 @@ describe("InlineVisDirective", () => {
       },
     );
 
-    await slot.findByText(/Loading visualization charts\/demo file\.html/i);
+    await slot.findByRole("status", {
+      name: "Loading visualization charts/demo file.html",
+    });
 
     const iframe = await waitFor(() => {
       const el = slot.container.querySelector("iframe");
@@ -114,6 +116,67 @@ describe("InlineVisDirective", () => {
       return el as HTMLIFrameElement;
     });
     expect(iframe.style.height).toBe("480px");
+  });
+
+  it("reserves the preview height while loading so the timeline does not jump", async () => {
+    let resolvePreview = (_result: { file: string }) => {};
+    const pendingPreview = new Promise<{ file: string }>((resolve) => {
+      resolvePreview = resolve;
+    });
+    const slot = renderSlot(
+      app.messageDirectives[0]!,
+      {
+        attributes: { file: "demo.html", height: "480" },
+        source: '::inline-vis{file="demo.html" height="480"}',
+        message,
+        openWorkspaceFile: vi.fn(() => true),
+      },
+      {
+        rpc: {
+          prepareHtmlPreview: () => pendingPreview,
+        },
+      },
+    );
+
+    const loading = await waitFor(() => {
+      const el = slot.container.querySelector('[aria-busy="true"]');
+      if (!(el instanceof HTMLElement)) {
+        throw new Error("Expected the inline visualization loader to render");
+      }
+      return el;
+    });
+    // The loader must occupy the final preview height so the bottom-anchored
+    // timeline does not scroll when the iframe replaces it.
+    expect(loading.style.height).toBe("480px");
+    expect(
+      slot.getByRole("status", { name: "Loading visualization demo.html" }),
+    ).toBe(loading);
+    const loadingCard = loading.parentElement!;
+    const loadingHeader = loadingCard.firstElementChild!;
+    const loadingHeaderHtml = loadingHeader.outerHTML;
+
+    resolvePreview({ file: "demo.html" });
+
+    const iframe = await waitFor(() => {
+      const el = slot.container.querySelector("iframe");
+      if (!(el instanceof HTMLIFrameElement)) {
+        throw new Error("Expected the inline visualization iframe to render");
+      }
+      return el;
+    });
+    expect(iframe.style.height).toBe("480px");
+    expect(slot.queryByRole("status")).toBeNull();
+
+    // Same card, same header geometry: the loaded header only swaps the
+    // placeholder spacer for the same-sized open-in-sidebar button.
+    const readyCard = iframe.parentElement!;
+    expect(readyCard.className).toBe(loadingCard.className);
+    const readyHeader = readyCard.firstElementChild!;
+    expect(readyHeader.className).toBe(loadingHeader.className);
+    expect(readyHeader.lastElementChild!.classList.contains("size-5")).toBe(
+      true,
+    );
+    expect(loadingHeaderHtml).toContain("size-5");
   });
 
   it("rejects an invalid height without calling rpc", async () => {

--- a/plugins/inline-vis/app.tsx
+++ b/plugins/inline-vis/app.tsx
@@ -2,8 +2,9 @@
 // a workspace HTML file through the same path-shaped, sandboxed iframe route
 // as bb's sidebar HTML preview. Scripts, relative assets, and normal web
 // resources work inside an opaque origin that cannot access the host page.
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { Icon } from "@bb/shared-ui/icon";
+import { Skeleton } from "@bb/shared-ui/skeleton";
 import {
   definePluginApp,
   useRpc,
@@ -40,6 +41,32 @@ function parsePreviewHeight(value: string | undefined): number | null {
     height <= MAX_HEIGHT_PX
     ? height
     : null;
+}
+
+// Shared card chrome for the loading and ready states. Both states must render
+// identical geometry: the thread timeline is bottom-anchored, so any height
+// change when the iframe replaces the loader scrolls earlier content away.
+function PreviewCard({
+  file,
+  action,
+  children,
+}: {
+  file: string;
+  action: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="my-2 overflow-hidden rounded-lg border border-border bg-background">
+      <div className="flex items-center gap-2 border-b border-border px-3 py-1.5 text-xs text-muted-foreground">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <span className="shrink-0 font-semibold">inline-vis</span>
+          <span className="truncate opacity-70">{file}</span>
+        </div>
+        {action}
+      </div>
+      {children}
+    </div>
+  );
 }
 
 function InlineVisDirective({
@@ -130,12 +157,24 @@ function InlineVisDirective({
 
   if (state.status === "loading") {
     return (
-      <div
-        className="my-2 rounded-md border border-border bg-muted px-3 py-2 text-sm text-muted-foreground"
-        aria-busy="true"
+      <PreviewCard
+        file={state.file}
+        action={
+          openWorkspaceFile === null ? null : (
+            <span aria-hidden className="size-5 shrink-0" />
+          )
+        }
       >
-        Loading visualization {state.file}…
-      </div>
+        <div
+          role="status"
+          aria-busy="true"
+          aria-label={`Loading visualization ${state.file}`}
+          style={{ height: previewHeight ?? DEFAULT_HEIGHT_PX }}
+          className="w-full p-3"
+        >
+          <Skeleton className="size-full" />
+        </div>
+      </PreviewCard>
     );
   }
 
@@ -154,13 +193,10 @@ function InlineVisDirective({
   const previewUrl = buildWorktreePreviewUrl(message.threadId, state.file);
 
   return (
-    <div className="my-2 overflow-hidden rounded-lg border border-border bg-background">
-      <div className="flex items-center gap-2 border-b border-border px-3 py-1.5 text-xs text-muted-foreground">
-        <div className="flex min-w-0 flex-1 items-center gap-2">
-          <span className="shrink-0 font-semibold">inline-vis</span>
-          <span className="truncate opacity-70">{state.file}</span>
-        </div>
-        {openWorkspaceFile === null ? null : (
+    <PreviewCard
+      file={state.file}
+      action={
+        openWorkspaceFile === null ? null : (
           <button
             type="button"
             aria-label={`Open ${state.file} in sidebar`}
@@ -172,8 +208,9 @@ function InlineVisDirective({
           >
             <Icon name="ExternalLink" aria-hidden className="size-3" />
           </button>
-        )}
-      </div>
+        )
+      }
+    >
       <iframe
         title={`inline-vis: ${state.file}`}
         src={previewUrl}
@@ -183,7 +220,7 @@ function InlineVisDirective({
         style={{ height: previewHeight ?? DEFAULT_HEIGHT_PX }}
         className="block w-full border-0 bg-background"
       />
-    </div>
+    </PreviewCard>
   );
 }
 


### PR DESCRIPTION
## What was wrong

`InlineVisDirective` in `plugins/inline-vis/app.tsx` starts in `loading` and stays there until the `prepareHtmlPreview` RPC resolves. The loading branch rendered a bare one-line "Loading visualization…" box with no height (37px in the app). The ready branch renders a header plus an iframe whose inline height comes from the directive's `height` attribute (default 224px, min 120px). The card therefore grew by hundreds of pixels in one React commit (measured 37px -> 515px for `height="480"`). The thread timeline is bottom-anchored, so that growth scrolled every earlier message upward on every mount of the directive, not only on cold loads. The preview height is known synchronously from the attributes, so the final geometry was knowable in the loading state; it just was not used.

Issue: #1837. Report: https://get-bb.github.io/reports/issues/1837.html

## What changed

- `plugins/inline-vis/app.tsx`: extracted the card chrome (outer card + header row) into a small `PreviewCard` so the loading and ready states cannot drift. The loading branch now renders that card with a `size-5` spacer where the open-in-sidebar button goes, and a `role="status"` / `aria-busy` / `aria-label="Loading visualization <file>"` container with `style.height = previewHeight` holding a plain `<Skeleton className="size-full" />` from `@bb/shared-ui/skeleton`. The ready branch is unchanged except for using `PreviewCard`.
- `plugins/inline-vis/app.test.tsx`: new test pins the behaviour (loader height equals the iframe height, same card/header classes, status role and label); the existing sandbox test now finds the loader by role instead of the removed text.
- Error, missing-file, and invalid-height branches still render compact alerts; loading -> error shrinks the card, which is acceptable for an error path and out of scope here.
- No server, wire, CLI, or doc changes. App-side plugin UI only.

Relation to #1555: that PR also reserves the height, but it duplicates the header markup, uses `.animate-shine-icon` inside an `aria-hidden` grid, which `theme.css` pauses since #1880 (so its advertised shimmer is frozen in the app), and its ~100-line test pins data attributes and class names rather than behaviour. It also predates #2140, which removed the `PrepareHtmlPreviewRpcResult` type it touches. This PR is the ~20-line version the report recommends: shared header, fixed-height `Skeleton` with its built-in pulse (verified running in the app), and a behaviour-only test.

## How you verified

- New test fails on `origin/main` `app.tsx` (`git checkout origin/main -- plugins/inline-vis/app.tsx`, then `pnpm exec vitest run app.test.tsx` in `plugins/inline-vis`):
  ```
  × reserves the preview height while loading so the timeline does not jump
  AssertionError: expected '' to be '480px' // Object.is equality
  ```
- On this branch, from the committed tree (`git status --porcelain` empty): `pnpm exec turbo run typecheck test --filter=bb-plugin-inline-vis --force` -> `Tasks: 6 successful, 6 total`, `Tests 17 passed (17)`.
- Manual repro in a dev instance (`scripts/bb-dev-app current`, claude-code turn that replied with `::inline-vis{file="demo.html" height="480"}`), holding the `prepareHtmlPreview` request in headless Chrome and measuring the card before and after release:
  - main `app.tsx`: loading `boxHeight: 37` -> ready `boxHeight: 515`, `deltaHeight: 478`; the user message above moved from `top: 75` to `top: 17`.
  - this branch: loading `boxHeight: 515` -> ready `boxHeight: 515`, `deltaHeight: 0`; user message stays at `top: 17`; skeleton `animationName: pulse`, `playState: running`.

Fixes #1837

> AGENT GENERATED: by Claude Opus 5


## Independent verification

Checked out `140e23e7f` (`git fetch origin bb/fix-1837-inline-vis-layout-jump && git checkout -b verify-1837-r1 FETCH_HEAD`); `origin/main` is an ancestor, GitHub reports `MERGEABLE`. Diff: `plugins/inline-vis/app.tsx` + `plugins/inline-vis/app.test.tsx` only, +117/-17.

Fail-before: `git checkout origin/main -- plugins/inline-vis/app.tsx`, then `pnpm exec vitest run app.test.tsx` in `plugins/inline-vis`:

```
FAIL app.test.tsx > InlineVisDirective > reserves the preview height while loading so the timeline does not jump
AssertionError: expected '' to be '480px' // Object.is equality
Tests  2 failed | 5 passed (7)
```

(The second failure is the existing sandbox test, which now looks the loader up by `role="status"` name.)

Pass-after: restored `app.tsx` from the PR head (`git status --porcelain` empty), `pnpm exec vitest run app.test.tsx` -> `Tests 7 passed (7)`. `pnpm exec turbo run typecheck test --filter=bb-plugin-inline-vis --force` -> `Tasks: 6 successful, 6 total`, `Tests 17 passed (17)`.

Repro on the fixed branch: own dev instance (`scripts/bb-dev-app current`, app :13647 / server :21647), scratch project with `demo.html`, real claude-code turn replying `::inline-vis{file="demo.html" height="480"}`. Headless Chrome via doobie held the `prepareHtmlPreview` RPC, measured the card, released it, measured again:

```
before: state=loading cardHeight=515 innerHeight=480 userMsgTop=17 role=status label="Loading visualization demo.html" skeleton animation=pulse playState=running
after:  state=ready   cardHeight=515 innerHeight=480 userMsgTop=17
deltaHeight: 0, userMsgShift: 0
```

The report measured 37px -> 515px (delta 478) for the same scenario on main. The issue no longer reproduces.

CI: all required checks green on `140e23e7f` (Checks, Tests app-1/2/3, integration, server, packages, Package Smoke ubuntu/macos, version check).

Residual risks: error / missing-file / invalid-height branches still render compact alerts, so loading -> error shrinks the card (error path, out of scope). The loader no longer shows visible "Loading visualization" text; it is conveyed through `role="status"` + `aria-label`. No wire, CLI, or plugin-API surface changed, so no protocol bump or doc update is required.

> AGENT GENERATED: by Claude Opus 5
