### PR TITLE
Add bb tasks detach and list live task threads first

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -527,7 +527,10 @@ For review or fix pipelines, get the environment ID from
 add <key-or-comment-id> --file <path>` (task key = task-level; comment ID
   = that comment). Avoid progress spam.
 - Delegated threads are attached automatically. For work started independently,
-  run `bb tasks attach <key-or-id>` from the working thread.
+  run `bb tasks attach <key-or-id>` from the working thread. When a thread is
+  done with a task or a respawned worker replaced it, run `bb tasks detach
+<key-or-id> [--thread <thread-id>]`. `bb tasks threads <key>` lists live
+  threads first, newest first.
 - When implementation is ready for review, run `bb tasks update <key-or-id>
 --status in_review`; if blocked, leave the status accurate and explain the
   blocker in a comment.

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -137,14 +137,17 @@ and the `bb tasks` command. Common agent operations are:
   bb tasks comment <key-or-id> (--body <markdown> | --body-file <path>) [--json]
   bb tasks attachment add <key-or-comment-id> --file <path> [--json]
   bb tasks attachment get <attachment-id> --out <path> [--json]
-  bb tasks attach <key-or-id> [--json]
+  bb tasks attach <key-or-id> [--thread <thread-id>] [--json]
+  bb tasks detach <key-or-id> [--thread <thread-id>] [--json]
   bb tasks update <key-or-id> --status in_review [--json]
   bb tasks update <key-or-id> (--parent <parent-key-or-id> | --no-parent) [--json]
 
 Run `bb tasks --help` for project, folder, task, label, attachment, and demo-data
 commands, plus preset management, delegation, and attached-thread inspection.
 Delegated threads are attached automatically; use `bb tasks attach` only when
-work started outside Tasks. Task update resolves both task keys and IDs for
+work started outside Tasks, and `bb tasks detach` when a thread is done with a
+task or a respawned worker replaced it. `bb tasks threads <key>` lists live
+threads first, newest first. Task update resolves both task keys and IDs for
 `--parent`; use `--no-parent` to promote a subtask to the top level. File paths
 in tasks commands resolve on the invoking machine (the thread's machine inside
 an agent thread, otherwise the server's); pass `--machine <id-or-name>` to

--- a/plugins/tasks/README.md
+++ b/plugins/tasks/README.md
@@ -79,7 +79,8 @@ target another enrolled machine.
 | `bb tasks preset list\|create\|update\|delete` | Manage reusable agent execution presets.                                                                                                   |
 | `bb tasks delegate <key>`                      | Start and attach a new agent thread using a preset.                                                                                        |
 | `bb tasks attach <key-or-id>`                  | Attach the current bb thread to a task when it was not delegated from Tasks.                                                               |
-| `bb tasks threads <key>`                       | List the bb threads attached to a task.                                                                                                    |
+| `bb tasks detach <key-or-id>`                  | Detach the current bb thread (or `--thread <id>`) from a task, for example a dead predecessor after a respawn.                             |
+| `bb tasks threads <key>`                       | List the bb threads attached to a task: live threads first, newest first.                                                                  |
 | `bb tasks label create\|list\|delete`          | Manage project-scoped labels.                                                                                                              |
 | `bb tasks seed-demo --yes`                     | Create sample folders, projects, labels, tasks, and comments for evaluation.                                                               |
 
@@ -110,7 +111,11 @@ skill tells it to inspect the task, leave substantive milestone comments,
 attach artifacts, and move completed work to `in_review`.
 
 If work begins outside the Delegate action, the agent can associate its current
-thread with `bb tasks attach KEY`.
+thread with `bb tasks attach KEY`. The inverse is `bb tasks detach KEY
+[--thread <id>]`, and each thread card on the task page has a detach control;
+use either to drop a thread that died or moved on to other work. The task
+page and `bb tasks threads` list live threads before completed or failed ones,
+newest first.
 
 ## Task mentions
 

--- a/plugins/tasks/cli/cli.test.ts
+++ b/plugins/tasks/cli/cli.test.ts
@@ -1180,6 +1180,96 @@ describe("bb tasks CLI", () => {
     await harness.dispose();
   });
 
+  it("detaches a thread with `bb tasks detach` and lists live threads first", async () => {
+    const { bb, harness } = createFakePluginHost({
+      pluginId: "tasks",
+      sdk: {
+        threads: {
+          get: async ({ threadId }: { threadId: string }) => ({
+            id: threadId,
+            title: `Worker ${threadId}`,
+            titleFallback: null,
+            status: threadId === "thr_dead_worker" ? "error" : "idle",
+          }),
+          send: async () => undefined,
+        },
+      },
+    });
+    await plugin(bb);
+    stdout(
+      await harness.runCli([
+        "project",
+        "create",
+        "--name",
+        "Detach",
+        "--prefix",
+        "DET",
+      ]),
+    );
+    stdout(
+      await harness.runCli(["create", "--project", "DET", "--title", "Work"]),
+    );
+
+    expect(stdout(await harness.runCli(["--help"]))).toContain(
+      "detach                         Detach an agent thread from a task",
+    );
+
+    // An orchestrator attaches a worker, it dies, and a replacement is
+    // attached: the list must lead with the live replacement.
+    stdout(
+      await harness.runCli(["attach", "DET-1", "--thread", "thr_dead_worker"]),
+    );
+    stdout(
+      await harness.runCli(["attach", "DET-1", "--thread", "thr_live_worker"]),
+    );
+    const listed = JSON.parse(
+      stdout(await harness.runCli(["threads", "DET-1", "--json"])),
+    );
+    expect(
+      listed.taskThreads.map((thread: { threadId: string }) => thread.threadId),
+    ).toEqual(["thr_live_worker", "thr_dead_worker"]);
+
+    expect(
+      stdout(
+        await harness.runCli([
+          "detach",
+          "DET-1",
+          "--thread",
+          "thr_dead_worker",
+        ]),
+      ),
+    ).toBe("Detached thr_dead_worker from DET-1");
+    await expect(
+      harness.runCli(["detach", "DET-1", "--thread", "thr_dead_worker"]),
+    ).resolves.toMatchObject({
+      exitCode: 1,
+      stderr: "Thread thr_dead_worker is not attached to DET-1",
+    });
+
+    // Without --thread the command targets the invoking thread, like attach.
+    const previousThreadId = process.env.BB_THREAD_ID;
+    process.env.BB_THREAD_ID = "thr_live_worker";
+    try {
+      expect(
+        JSON.parse(stdout(await harness.runCli(["detach", "DET-1", "--json"]))),
+      ).toMatchObject({ task: { key: "DET-1" }, threadId: "thr_live_worker" });
+      delete process.env.BB_THREAD_ID;
+      await expect(harness.runCli(["detach", "DET-1"])).resolves.toMatchObject({
+        exitCode: 1,
+        stderr: "missing --thread and BB_THREAD_ID is not set",
+      });
+    } finally {
+      if (previousThreadId === undefined) delete process.env.BB_THREAD_ID;
+      else process.env.BB_THREAD_ID = previousThreadId;
+    }
+    expect(
+      JSON.parse(stdout(await harness.runCli(["threads", "DET-1", "--json"])))
+        .taskThreads,
+    ).toEqual([]);
+
+    await harness.dispose();
+  });
+
   it("creates a task with --attach files after validating every source path", async () => {
     const directory = await mkdtemp(join(tmpdir(), "bb-tasks-cli-"));
     const notesPath = join(directory, "notes.txt");

--- a/plugins/tasks/cli/index.ts
+++ b/plugins/tasks/cli/index.ts
@@ -70,6 +70,7 @@ Commands:
   preset list|show|create|update|delete
   dispatch                       Dispatch a task to a new agent thread
   attach                         Attach an agent thread to a task
+  detach                         Detach an agent thread from a task
   threads                        List threads attached to a task
   seed-demo                      Create sample data (requires --yes)
 
@@ -121,6 +122,8 @@ const DISPATCH_HELP =
   "Usage: bb tasks dispatch <key> --preset <name> [--instructions <extra>] [--json]";
 const ATTACH_HELP =
   "Usage: bb tasks attach <key> [--thread <thread-id>] [--json]";
+const DETACH_HELP =
+  "Usage: bb tasks detach <key> [--thread <thread-id>] [--json]";
 const THREADS_HELP = "Usage: bb tasks threads <key> [--json]";
 
 interface PluginStatus {
@@ -1825,6 +1828,19 @@ async function runDispatch(
     : result.threadId;
 }
 
+/** `--thread` wins; otherwise the invoking agent thread (env, then CLI ctx). */
+function resolveInvokingThreadId(
+  args: ParsedArgs,
+  ctx: PluginCliContext,
+): string {
+  const threadId =
+    option(args, "thread") ?? process.env.BB_THREAD_ID ?? ctx.threadId;
+  if (!threadId) {
+    throw new CliError("missing --thread and BB_THREAD_ID is not set");
+  }
+  return threadId;
+}
+
 async function runAttach(
   bb: BbPluginApi,
   store: TasksApiStore,
@@ -1837,11 +1853,7 @@ async function runAttach(
   assertAllowed(args, ["thread"]);
   const [address] = requirePositionals(args, 1, ATTACH_HELP);
   const task = await resolveTask(domain, address!);
-  const threadId =
-    option(args, "thread") ?? process.env.BB_THREAD_ID ?? ctx.threadId;
-  if (!threadId) {
-    throw new CliError("missing --thread and BB_THREAD_ID is not set");
-  }
+  const threadId = resolveInvokingThreadId(args, ctx);
   const result = delegationRpcContract.taskThreadsAttach.output.parse(
     await delegationHandlers(bb, store).taskThreadsAttach(
       delegationRpcContract.taskThreadsAttach.input.parse({
@@ -1853,6 +1865,32 @@ async function runAttach(
   return args.flags.has("json")
     ? JSON.stringify({ task, ...result })
     : `Attached ${result.threadId} to ${task.key}`;
+}
+
+async function runDetach(
+  bb: BbPluginApi,
+  store: TasksApiStore,
+  domain: TasksDomain,
+  ctx: PluginCliContext,
+  argv: string[],
+): Promise<string> {
+  const args = parseArgs(argv);
+  if (args.flags.has("help")) return DETACH_HELP;
+  assertAllowed(args, ["thread"]);
+  const [address] = requirePositionals(args, 1, DETACH_HELP);
+  const task = await resolveTask(domain, address!);
+  const threadId = resolveInvokingThreadId(args, ctx);
+  const result = delegationRpcContract.taskThreadsDetach.output.parse(
+    await delegationHandlers(bb, store).taskThreadsDetach(
+      delegationRpcContract.taskThreadsDetach.input.parse({
+        taskId: task.id,
+        threadId,
+      }),
+    ),
+  );
+  return args.flags.has("json")
+    ? JSON.stringify({ task, ...result })
+    : `Detached ${result.threadId} from ${task.key}`;
 }
 
 async function runThreads(
@@ -1986,6 +2024,11 @@ export function registerTasksCli(
         usage: ATTACH_HELP,
       },
       {
+        name: "detach",
+        summary: "Detach an agent thread from a task",
+        usage: DETACH_HELP,
+      },
+      {
         name: "threads",
         summary: "List agent threads attached to a task",
         usage: THREADS_HELP,
@@ -2055,6 +2098,9 @@ export function registerTasksCli(
             break;
           case "attach":
             stdout = await runAttach(bb, store, domain, ctx, rest);
+            break;
+          case "detach":
+            stdout = await runDetach(bb, store, domain, ctx, rest);
             break;
           case "threads":
             stdout = await runThreads(domain, rest);

--- a/plugins/tasks/db.test.ts
+++ b/plugins/tasks/db.test.ts
@@ -648,6 +648,55 @@ describe("tasks storage", () => {
     }
   });
 
+  it("lists live task threads before terminal ones, newest first", async () => {
+    const { db, harness, store } = setup();
+    try {
+      const project = createProject(store, "THR");
+      const task = store.createTask({ projectId: project.id, title: "Work" });
+      const setAttachedAt = db.prepare<[string, string]>(
+        "UPDATE task_threads SET attached_at = ? WHERE id = ?",
+      );
+      const attach = (
+        threadId: string,
+        liveStatus: "idle" | "working" | "failed" | "completed",
+        attachedAt: string,
+      ) => {
+        const row = store.upsertTaskThread({
+          taskId: task.id,
+          threadId,
+          presetName: "Attached",
+          title: threadId,
+          liveStatus,
+        });
+        setAttachedAt.run(attachedAt, row.id);
+      };
+      // An orchestrator respawns workers: the dead predecessors are the
+      // oldest rows, the live replacement is the newest.
+      attach("thr_dead_first", "failed", "2026-07-15T09:00:00.000Z");
+      attach("thr_live_old", "idle", "2026-07-15T10:00:00.000Z");
+      attach("thr_dead_later", "completed", "2026-07-15T11:00:00.000Z");
+      attach("thr_live_new", "working", "2026-07-15T12:00:00.000Z");
+
+      expect(
+        store.listTaskThreads(task.id).map((thread) => thread.threadId),
+      ).toEqual([
+        "thr_live_new",
+        "thr_live_old",
+        "thr_dead_later",
+        "thr_dead_first",
+      ]);
+
+      // Detaching removes exactly that (task, thread) row.
+      const detached = store.getTaskThreadByThreadId(task.id, "thr_dead_first");
+      expect(store.deleteTaskThread(detached!.id)).toBe(true);
+      expect(
+        store.listTaskThreads(task.id).map((thread) => thread.threadId),
+      ).toEqual(["thr_live_new", "thr_live_old", "thr_dead_later"]);
+    } finally {
+      await harness.dispose();
+    }
+  });
+
   it("finds the latest agent comment by reply time and ignores other activity", async () => {
     const { db, harness, store } = setup();
     try {

--- a/plugins/tasks/db/store.ts
+++ b/plugins/tasks/db/store.ts
@@ -1652,11 +1652,19 @@ export function createTasksStore(db: PluginDatabase) {
     return thread;
   }
 
+  // Live threads first, newest first within each group: after an
+  // orchestrator respawns a worker, the thread holding the work leads the
+  // list and the dead predecessors trail it.
   function listTaskThreads(taskId: string): TaskThread[] {
     return db
       .prepare<[string], TaskThreadRow>(
         `
-        SELECT * FROM task_threads WHERE task_id = ? ORDER BY attached_at, id
+        SELECT * FROM task_threads
+        WHERE task_id = ?
+        ORDER BY
+          CASE WHEN live_status IN ('completed', 'failed') THEN 1 ELSE 0 END,
+          attached_at DESC,
+          id DESC
       `,
       )
       .all(taskId)

--- a/plugins/tasks/delegate/contract.ts
+++ b/plugins/tasks/delegate/contract.ts
@@ -23,6 +23,12 @@ export const delegationRpcContract = defineRpcContract({
     input: z.object({ taskId: idSchema, threadId: threadIdSchema }).strict(),
     output: z.object({ threadId: threadIdSchema }).strict(),
   },
+  // Inverse of taskThreadsAttach: removes the (task, thread) row. Fails when
+  // the thread is not attached to the task.
+  taskThreadsDetach: {
+    input: z.object({ taskId: idSchema, threadId: threadIdSchema }).strict(),
+    output: z.object({ threadId: threadIdSchema }).strict(),
+  },
 });
 
 export type DelegationRpcContract = typeof delegationRpcContract;

--- a/plugins/tasks/delegate/delegate.test.ts
+++ b/plugins/tasks/delegate/delegate.test.ts
@@ -409,6 +409,88 @@ describe("task delegation", () => {
   });
 });
 
+describe("task thread detach", () => {
+  it("detaches an attached thread through taskThreadsDetach and invalidates", async () => {
+    const { bb, harness } = createFakePluginHost({
+      pluginId: "tasks",
+      sdk: {
+        threads: {
+          get: async ({ threadId }: { threadId: string }) => ({
+            id: threadId,
+            title: `Worker ${threadId}`,
+            titleFallback: null,
+            status: threadId === "thr_dead" ? "error" : "idle",
+          }),
+        },
+      },
+    });
+    const store = createStore(bb);
+    const project = store.tasks.createProject({
+      name: "Manual",
+      prefix: "MAN",
+      color: "blue",
+    });
+    const task = store.tasks.createTask({
+      projectId: project.id,
+      title: "Respawned work",
+    });
+    const otherTask = store.tasks.createTask({
+      projectId: project.id,
+      title: "Other work",
+    });
+    registerDelegation(bb, store);
+
+    await harness.callRpc("taskThreadsAttach", {
+      taskId: task.id,
+      threadId: "thr_dead",
+    });
+    await harness.callRpc("taskThreadsAttach", {
+      taskId: task.id,
+      threadId: "thr_live",
+    });
+    // The same thread attached to a second task must survive a detach from
+    // the first one.
+    await harness.callRpc("taskThreadsAttach", {
+      taskId: otherTask.id,
+      threadId: "thr_dead",
+    });
+    harness.realtimeSignals.length = 0;
+
+    await expect(
+      harness.callRpc("taskThreadsDetach", {
+        taskId: task.id,
+        threadId: "thr_dead",
+      }),
+    ).resolves.toEqual({ threadId: "thr_dead" });
+
+    expect(
+      store.tasks.listTaskThreads(task.id).map((thread) => thread.threadId),
+    ).toEqual(["thr_live"]);
+    expect(
+      store.tasks
+        .listTaskThreads(otherTask.id)
+        .map((thread) => thread.threadId),
+    ).toEqual(["thr_dead"]);
+    expect(harness.realtimeSignals).toEqual([
+      { channel: "threads:changed", payload: { taskId: task.id } },
+      {
+        channel: "tasks:changed",
+        payload: { taskId: task.id, projectId: project.id },
+      },
+    ]);
+
+    // Detaching a thread that is not attached is an error, not a no-op.
+    await expect(
+      harness.callRpc("taskThreadsDetach", {
+        taskId: task.id,
+        threadId: "thr_dead",
+      }),
+    ).rejects.toThrow(`Thread thr_dead is not attached to ${task.key}`);
+
+    await harness.dispose();
+  });
+});
+
 describe("delegation seed prompt", () => {
   it("captures task context and the complete report-back contract", () => {
     const project: Project = {

--- a/plugins/tasks/delegate/index.ts
+++ b/plugins/tasks/delegate/index.ts
@@ -411,6 +411,24 @@ export function handlers(
       publishTasksChanged(bb, task.id, task.projectId);
       return { threadId: thread.id };
     },
+
+    async taskThreadsDetach(input) {
+      const task = requireTask(store.tasks, input.taskId);
+      const taskThread = store.tasks.getTaskThreadByThreadId(
+        task.id,
+        input.threadId,
+      );
+      if (!taskThread) {
+        throw new Error(
+          `Thread ${input.threadId} is not attached to ${task.key}`,
+        );
+      }
+      store.tasks.deleteTaskThread(taskThread.id);
+
+      publishThreadsChanged(bb, task.id);
+      publishTasksChanged(bb, task.id, task.projectId);
+      return { threadId: taskThread.threadId };
+    },
   };
 }
 

--- a/plugins/tasks/skills/tasks/SKILL.md
+++ b/plugins/tasks/skills/tasks/SKILL.md
@@ -119,6 +119,14 @@ not already exist. Dispatch requires an existing preset.
    bb tasks attach ABC-12
    ```
 
+   When a thread is done with a task (hand-off, respawned replacement, or a
+   predecessor that died), detach it so `bb tasks threads ABC-12` stays
+   accurate. Omit `--thread` to detach the current thread:
+
+   ```sh
+   bb tasks detach ABC-12 --thread thr_dead_predecessor
+   ```
+
 ## Link tasks in responses
 
 When your answer refers the user to a task — including a task you just

--- a/plugins/tasks/views/detail/index.tsx
+++ b/plugins/tasks/views/detail/index.tsx
@@ -2,7 +2,8 @@ import { useEffect, useRef, useState } from "react";
 import { HugeiconsIcon } from "@hugeicons/react";
 import { SmilePlusIcon } from "@hugeicons/core-free-icons";
 import type { Task } from "../../shared/contract.js";
-import { useBbNavigate } from "@get-bb/plugin-sdk/app";
+import type { DelegationRpcContract } from "../../delegate/contract.js";
+import { useBbNavigate, useRpc } from "@get-bb/plugin-sdk/app";
 import {
   listAllTasks,
   useMentionItems,
@@ -196,6 +197,7 @@ function DetailSkeleton() {
 
 function TaskDetail({ task }: { task: Task }) {
   const rpc = useTasksRpc();
+  const delegationRpc = useRpc<DelegationRpcContract>();
   const navigation = useTasksNavigation();
   const { toasts, push, dismiss } = useDetailToasts();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -482,6 +484,15 @@ function TaskDetail({ task }: { task: Task }) {
                 unavailableThreadIds={
                   pullRequests.data?.unavailableThreadIds ?? []
                 }
+                onDetach={async (thread) => {
+                  await delegationRpc.call("taskThreadsDetach", {
+                    taskId: task.id,
+                    threadId: thread.threadId,
+                  });
+                  threads.refresh();
+                  pullRequests.refresh();
+                }}
+                onError={(message) => push(message)}
               />
             </div>
           ) : null}

--- a/plugins/tasks/views/detail/threads.test.tsx
+++ b/plugins/tasks/views/detail/threads.test.tsx
@@ -158,6 +158,39 @@ describe("task detail pull request pills", () => {
     expect(slot.queryByRole("link")).toBeNull();
   });
 
+  it("detaches a thread from its card after confirmation and refetches the list", async () => {
+    let detached = false;
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: "task/TSK-5" },
+      {
+        rpc: detailRpc({
+          listTaskThreads: () => ({
+            taskThreads: detached
+              ? []
+              : [taskThreadRow(THREAD_ROW_ID, "thr_worker000", "Worker")],
+          }),
+          taskThreadsDetach: (input: { threadId: string }) => {
+            detached = true;
+            return { threadId: input.threadId };
+          },
+        }),
+      },
+    );
+
+    fireEvent.click(await slot.findByRole("button", { name: "Detach Worker" }));
+    fireEvent.click(await slot.findByRole("button", { name: "Detach" }));
+
+    await waitFor(() => {
+      expect(slot.rpcCalls).toContainEqual({
+        method: "taskThreadsDetach",
+        input: { taskId: TASK_ID, threadId: "thr_worker000" },
+      });
+    });
+    // The section disappears with its last thread.
+    await waitFor(() => expect(slot.queryByText("Worker")).toBeNull());
+  });
+
   it("revalidates PR state on window focus without a task-thread mutation", async () => {
     const basePullRequest = {
       url: "https://github.com/acme/bb/pull/12",

--- a/plugins/tasks/views/detail/threads.tsx
+++ b/plugins/tasks/views/detail/threads.tsx
@@ -17,6 +17,7 @@ import {
   isActiveThread,
 } from "./meta.js";
 import { PresetDialog, savePresetDraft } from "../manage/preset-dialog.js";
+import { ConfirmDialog } from "../../components/confirm-dialog.js";
 import { useTasksRpc } from "../../shell/data.js";
 import { Button } from "@bb/shared-ui/button";
 import {
@@ -76,10 +77,14 @@ function ThreadCard({
   thread,
   pullRequest,
   pullRequestUnavailable,
+  busy,
+  onDetach,
 }: {
   thread: TaskThread;
   pullRequest: TaskPullRequest | undefined;
   pullRequestUnavailable: boolean;
+  busy: boolean;
+  onDetach: () => void;
 }) {
   const navigate = useBbNavigate();
   const meta = THREAD_STATUS_META[thread.liveStatus];
@@ -114,6 +119,16 @@ function ThreadCard({
       >
         Open thread
         <Icon name="ArrowUpRight" className="size-3" />
+      </button>
+      <button
+        type="button"
+        aria-label={`Detach ${thread.title}`}
+        title="Detach from task"
+        disabled={busy}
+        className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-state-hover hover:text-foreground disabled:opacity-70"
+        onClick={onDetach}
+      >
+        <Icon name="X" className="size-3" />
       </button>
     </div>
   );
@@ -284,6 +299,9 @@ interface ThreadsSectionProps {
   /** Undefined while the PR lookup is in flight (cards render without pills). */
   pullRequests: TaskPullRequest[] | undefined;
   unavailableThreadIds: string[];
+  /** Removes the thread's attachment row; rejects with the server message. */
+  onDetach: (thread: TaskThread) => Promise<void>;
+  onError: (message: string) => void;
 }
 
 /** Attached-thread list; the caller skips it entirely when there are none.
@@ -293,7 +311,29 @@ export function ThreadsSection({
   threads,
   pullRequests,
   unavailableThreadIds,
+  onDetach,
+  onError,
 }: ThreadsSectionProps) {
+  // Snapshot of the thread awaiting confirmation; the row may vanish from
+  // `threads` (realtime refetch) while the dialog is open.
+  const [confirm, setConfirm] = useState<TaskThread | null>(null);
+  const [pending, setPending] = useState<ReadonlySet<string>>(new Set());
+
+  const performDetach = async (thread: TaskThread) => {
+    setPending((current) => new Set(current).add(thread.id));
+    try {
+      await onDetach(thread);
+    } catch (error) {
+      onError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setPending((current) => {
+        const next = new Set(current);
+        next.delete(thread.id);
+        return next;
+      });
+    }
+  };
+
   const activeCount = threads.filter(isActiveThread).length;
   const pullRequestByThread = new Map<string, TaskPullRequest>();
   for (const pullRequest of pullRequests ?? []) {
@@ -317,8 +357,26 @@ export function ThreadsSection({
           thread={thread}
           pullRequest={pullRequestByThread.get(thread.threadId)}
           pullRequestUnavailable={unavailable.has(thread.threadId)}
+          busy={pending.has(thread.id)}
+          onDetach={() => setConfirm(thread)}
         />
       ))}
+      <ConfirmDialog
+        open={confirm !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirm(null);
+        }}
+        title="Detach thread?"
+        description={
+          confirm
+            ? `"${confirm.title}" will no longer be listed on this task. The thread itself is not deleted; re-attach it with bb tasks attach.`
+            : ""
+        }
+        confirmLabel="Detach"
+        onConfirm={() => {
+          if (confirm) void performDetach(confirm);
+        }}
+      />
     </section>
   );
 }


### PR DESCRIPTION
## What was wrong

Task thread attachments in the Tasks plugin were append-only. `upsertTaskThread` inserts one row per `(task_id, thread_id)` and the store's `deleteTaskThread` was dead code: no RPC in `delegationRpcContract`, no CLI command, and no UI control reached it. An orchestrator that respawns a worker and attaches each replacement therefore accumulates every dead predecessor on the task, and a thread that moves on to another task keeps its row on the old one. On top of that, `listTaskThreads` ordered rows `ORDER BY attached_at, id` (oldest first), so the first row in `bb tasks threads`, `bb tasks show`, `--json`, and the task page's "Agent threads" section was the dead predecessor. Issue: #1761. Report: https://get-bb.github.io/reports/issues/1761.html

## What changed

- `plugins/tasks/db/store.ts`: `listTaskThreads` now orders live threads (`starting`/`working`/`idle`) before terminal ones (`completed`/`failed`), newest first within each group (`attached_at DESC, id DESC`). This is the single read path, so the CLI table, `--json`, `bb tasks show`, the detail page cards, the PR-pill ordering, and task mentions all follow.
- `plugins/tasks/delegate/contract.ts`, `plugins/tasks/delegate/index.ts`: new `taskThreadsDetach` RPC, the inverse of `taskThreadsAttach`. It deletes the `(task, thread)` row via the existing `getTaskThreadByThreadId` + `deleteTaskThread`, publishes `threads:changed` and `tasks:changed` like attach, and fails with `Thread <id> is not attached to <KEY>` when there is no row. Detaching from one task leaves the same thread's rows on other tasks alone. The reconcile service reads `task_threads`, so a detached thread is no longer tracked.
- `plugins/tasks/cli/index.ts`: `bb tasks detach <key> [--thread <thread-id>] [--json]`. Thread resolution is shared with `attach` (`--thread`, then `BB_THREAD_ID`, then the CLI context thread) through a small `resolveInvokingThreadId` helper. Root help and the registered command list include `detach`.
- `plugins/tasks/views/detail/threads.tsx`, `plugins/tasks/views/detail/index.tsx`: each thread card gets an X "Detach <title>" control that opens the plugin's `ConfirmDialog` and then calls `taskThreadsDetach`; the detail view refreshes the thread and PR queries. Errors surface through the existing detail toasts.
- Docs: `plugins/tasks/README.md` (command table + delegation section), `plugins/tasks/skills/tasks/SKILL.md` (step 6 tells agents to detach on hand-off/respawn), `packages/templates/src/templates/bb-guide-plugins.md`, and `apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md`.

Plugin-internal only: nothing on the server/host-daemon wire changes, so no `HOST_DAEMON_PROTOCOL_VERSION` bump. `attached_at` is left untouched on re-attach (it still means "first attached"); a revived thread moves to the live group because the upsert refreshes `live_status`.

## How you verified

New tests (all fail on origin/main, pass on this branch):

- `plugins/tasks/db.test.ts` "lists live task threads before terminal ones, newest first" — before: `AssertionError: expected [ 'thr_dead_first', …(3) ] to deeply equal [ Array(4) ]`.
- `plugins/tasks/delegate/delegate.test.ts` "detaches an attached thread through taskThreadsDetach and invalidates" — before: `plugin "tasks" has no rpc method "taskThreadsDetach"`.
- `plugins/tasks/cli/cli.test.ts` "detaches a thread with `bb tasks detach` and lists live threads first" — before: `expected 'Usage: bb tasks <command> [options]\n…' to contain 'detach …'`.
- `plugins/tasks/views/detail/threads.test.tsx` "detaches a thread from its card after confirmation and refetches the list" — before: `Unable to find role="button" and name "Detach Worker"`.

Fail-before was produced by checking out the six source files from `origin/main` with the new tests in place (`4 failed | 1 passed`), then restoring the branch (`4 passed`).

From the committed tree (`git status --porcelain` empty):

- `pnpm exec turbo run typecheck --filter=bb-plugin-tasks --filter=@bb/templates --filter=@bb/server --filter=@bb/cli` → `Tasks: 8 successful, 8 total`
- `pnpm exec turbo run test --filter=bb-plugin-tasks --filter=@bb/cli --force` → `Tasks: 7 successful, 7 total` (tasks: 35 test files passed; cli: 48 passed)

Manual repro on my own dev instance with the builtin tasks plugin installed from this branch, mirroring the issue's transcript (one codex thread forced into `error` with a bogus model, one real idle thread, both attached to SC-1 in that order):

```
$ bb tasks threads SC-1
THREAD          STATUS  PRESET    TITLE
thr_tjd3ztqcgd  idle    Attached  Resuming SC-1 after predecessor died
thr_hxiffdtdpf  failed  Attached  SC-1 worker (phase 1)
$ bb tasks detach SC-1 --thread thr_hxiffdtdpf
Detached thr_hxiffdtdpf from SC-1
$ bb tasks detach SC-1 --thread thr_hxiffdtdpf
Thread thr_hxiffdtdpf is not attached to SC-1        (exit 1)
$ bb tasks attach SC-2 --thread thr_tjd3ztqcgd && bb tasks detach SC-1 --thread thr_tjd3ztqcgd
$ bb tasks threads SC-1
No attached threads.
```

In the app (headless Chrome via doobie), the SC-2 page listed the Idle thread above the Failed one, the X control opened "Detach thread?", and confirming removed the card; `bb tasks threads SC-2` then showed only the live thread.

Fixes #1761

> AGENT GENERATED: by Claude Opus 5


## Independent verification

Verified on a fresh worktree at `4db9a918b` (branch is directly on top of `origin/main` `f6fb434ab`; `git merge-base --is-ancestor origin/main HEAD` exit 0).

Commands:

- `pnpm install --frozen-lockfile --prefer-offline && pnpm exec turbo run build` -> `Tasks: 18 successful, 18 total`
- Fail-before: `git checkout origin/main -- plugins/tasks/cli/index.ts plugins/tasks/db/store.ts plugins/tasks/delegate/contract.ts plugins/tasks/delegate/index.ts plugins/tasks/views/detail/index.tsx plugins/tasks/views/detail/threads.tsx`, then from `plugins/tasks`: `pnpm exec vitest run db.test.ts delegate/delegate.test.ts cli/cli.test.ts views/detail/threads.test.tsx -t "live task threads before terminal|taskThreadsDetach|bb tasks detach|detaches a thread from its card"` -> `4 failed`:
  - `AssertionError: expected [ 'thr_dead_first', …(3) ] to deeply equal [ Array(4) ]` (received `thr_dead_first` first, expected `thr_live_new`)
  - `Error: plugin "tasks" has no rpc method "taskThreadsDetach"` (`code: 'unknown_method'`)
  - `AssertionError: expected 'Usage: bb tasks <command> [options]\n…' to contain 'detach …'`
  - `TestingLibraryElementError: Unable to find role="button" and name "Detach Worker"`
- Pass-after: `git checkout HEAD -- <same files>` (tree clean), same vitest command -> `4 passed`.
- `pnpm exec turbo run typecheck --filter=bb-plugin-tasks --filter=@bb/templates --filter=@bb/server --filter=@bb/cli` -> `Tasks: 8 successful, 8 total`
- `pnpm exec turbo run test --filter=bb-plugin-tasks --filter=@bb/cli --force` -> `Tasks: 7 successful, 7 total` (tasks 35 files / 363 tests, cli 48 files / 453 tests)

Repro of the issue on the fixed branch (own dev instance, `builtin:tasks` installed from this branch, codex thread with a bogus model -> `error`, then a real idle thread; both attached to SC-1 dead-first):

```
$ bb tasks threads SC-1
THREAD          STATUS  PRESET    TITLE
thr_pty8zbfby4  idle    Attached  Resuming SC-1 after a machine crash killed your predecessor
thr_ymbbpzywuq  failed  Attached  SC-1 · OSS divergence audit (phase 1)
$ bb tasks attach SC-2 --thread thr_ymbbpzywuq
$ bb tasks detach SC-1 --thread thr_ymbbpzywuq
Detached thr_ymbbpzywuq from SC-1
$ bb tasks detach SC-1 --thread thr_ymbbpzywuq      # exit 1
Thread thr_ymbbpzywuq is not attached to SC-1
$ bb tasks threads SC-1    -> only thr_pty8zbfby4 (idle)
$ bb tasks threads SC-2    -> thr_ymbbpzywuq still attached (cross-task row untouched)
```

Headless Chrome (doobie) on the SC-2 task page: the Idle card renders above the Failed card although it was attached later; each card has an `aria-label="Detach <title>"` X control; clicking it opens the "Detach thread?" ConfirmDialog; confirming calls `taskThreadsDetach` and the Failed card disappears, confirmed by `bb tasks threads SC-2` afterwards.

Review notes: fixes the root cause (ordering query plus the missing inverse at RPC/CLI/UI), plugin-internal so no `HOST_DAEMON_PROTOCOL_VERSION` change is needed, no casts, no accepted-but-ignored fields, doc surfaces per `docs/cli-guide-and-skill.md` updated. No consumer of `listTaskThreads` depends on chronological order (PR resolution dedupes by URL; board/list meta filter by status; mentions just format). Reuses the plugin's existing `ConfirmDialog` and `useRpc<DelegationRpcContract>` patterns.

CI: all checks green (`gh pr checks 2167`: Checks, Package Smoke x2, Tests app-1/2/3, integration, packages, server all pass).

Residual risks: a row reconciled into `completed`/`failed` moves down the list on the next refetch (cosmetic; lists are short). Re-attaching does not refresh `attached_at`. A reconcile tick in flight when a row is detached throws `Task thread not found` inside `transitionThread`; it is caught and logged as a warning and creates no comment. No in-app undo for detach; the dialog points at `bb tasks attach`.

> AGENT GENERATED: by Claude Opus 5
