### PR TITLE
Show why the Server menu lists no Connect servers

### DIFF
--- a/apps/desktop/src/connect-server-sync.ts
+++ b/apps/desktop/src/connect-server-sync.ts
@@ -34,12 +34,45 @@ const rpcSuccessSchema = z
   })
   .strict();
 
+/**
+ * `{ ok: false, error }` from the plugin route. A string `error` is the
+ * route's own refusal (plugin not running, auth); an object is the structured
+ * handler failure, whose `message` carries the connect plugin's stable code.
+ */
 const rpcFailureSchema = z
   .object({
     ok: z.literal(false),
-    error: z.string().optional(),
+    error: z.union([
+      z.string(),
+      z.object({ code: z.string(), message: z.string() }).passthrough(),
+    ]),
   })
   .passthrough();
+
+/**
+ * Why a sync produced no server list. Every value is actionable from the
+ * Server menu, so the menu can say which one it was.
+ *
+ * - `no-credential`: no local runtime, and the app never enrolled a machine
+ *   credential of its own (it gets one after a Connect sign-in via the local
+ *   server).
+ * - `plugin-disabled`: the local server answered but its connect plugin is
+ *   not running.
+ * - `not-paired`: the local server's connect plugin is on but not paired.
+ * - `unauthorized`: the gate refused the app's cached credential.
+ * - `unavailable`: the local server or the gate could not be reached or
+ *   answered with something unexpected.
+ */
+export type ConnectServerSyncSkipReason =
+  | "no-credential"
+  | "plugin-disabled"
+  | "not-paired"
+  | "unauthorized"
+  | "unavailable";
+
+export type FetchConnectAccountServersResult =
+  | { ok: true; result: ConnectListAccountServersResult }
+  | { ok: false; reason: ConnectServerSyncSkipReason };
 
 const CONNECT_PLUGIN_ID = "connect";
 const LIST_ACCOUNT_SERVERS_RPC = "listAccountServers";
@@ -64,13 +97,15 @@ interface FetchConnectAccountServersArgs {
  * `POST /api/v1/plugins/connect/rpc/listAccountServers`
  *
  * Auth is the plugin route "local" policy: `content-type: application/json`
- * on POST (no Origin required when the header is absent). Returns null when
- * the plugin is unavailable, unpaired, or the server is down — callers treat
- * that as a silent no-op.
+ * on POST (no Origin required when the header is absent). A failure carries
+ * the reason the server gave: HTTP 503 means the plugin is not running,
+ * `{ code: "handler_error", message: "not_paired" }` means it is on but
+ * unpaired, and anything else (server down, non-JSON, unknown shape) is
+ * `unavailable`.
  */
 export async function fetchConnectAccountServers(
   args: FetchConnectAccountServersArgs,
-): Promise<ConnectListAccountServersResult | null> {
+): Promise<FetchConnectAccountServersResult> {
   const fetchImpl = args.fetchImpl ?? globalThis.fetch;
   const base = args.serverUrl.replace(/\/$/u, "");
   const url = `${base}/api/v1/plugins/${encodeURIComponent(CONNECT_PLUGIN_ID)}/rpc/${encodeURIComponent(LIST_ACCOUNT_SERVERS_RPC)}`;
@@ -83,24 +118,34 @@ export async function fetchConnectAccountServers(
       body: "null",
     });
   } catch {
-    return null;
+    return { ok: false, reason: "unavailable" };
   }
 
   let body: unknown;
   try {
     body = await response.json();
   } catch {
-    return null;
+    return { ok: false, reason: "unavailable" };
   }
 
   const success = rpcSuccessSchema.safeParse(body);
   if (success.success) {
-    return success.data.result;
+    return { ok: true, result: success.data.result };
   }
 
-  // ok:false, wrong shape, HTTP error body — all map to silent no-op.
-  rpcFailureSchema.safeParse(body);
-  return null;
+  if (response.status === 503) {
+    return { ok: false, reason: "plugin-disabled" };
+  }
+  const failure = rpcFailureSchema.safeParse(body);
+  if (
+    failure.success &&
+    typeof failure.data.error === "object" &&
+    failure.data.error.code === "handler_error" &&
+    failure.data.error.message === "not_paired"
+  ) {
+    return { ok: false, reason: "not-paired" };
+  }
+  return { ok: false, reason: "unavailable" };
 }
 
 /**
@@ -123,6 +168,8 @@ interface CreateConnectServerSyncArgs {
   getLocalServerUrl: () => string | null;
   /** Fresh targetable server list after every successful sync. */
   onServers: (servers: ConnectAccountServer[]) => void;
+  /** A sync that produced no list, with the reason the Server menu shows. */
+  onSkipped: (reason: ConnectServerSyncSkipReason) => void;
   /** The gate refused the cached credential — the caller must drop it. */
   onUnauthorized: () => void;
   /**
@@ -178,14 +225,14 @@ export function createConnectServerSync(
   let timer: unknown = null;
   let lastSyncAttemptAt = 0;
   let inFlight: Promise<void> | null = null;
-  let loggedFailure = false;
+  let loggedSkipReason: ConnectServerSyncSkipReason | null = null;
 
   /**
    * Prefer the local server: it holds the pairing secret and always reflects
    * whether the plugin is on. Fall back to the app's own credential so a
    * remote target keeps a live server list with no local runtime.
    */
-  async function fetchServers(): Promise<ConnectListAccountServersResult | null> {
+  async function fetchServers(): Promise<FetchConnectAccountServersResult> {
     const serverUrl = args.getLocalServerUrl();
     if (serverUrl !== null) {
       return fetchConnectAccountServers({
@@ -195,33 +242,35 @@ export function createConnectServerSync(
     }
     const credential = args.getCredential();
     if (credential === null) {
-      return null;
+      return { ok: false, reason: "no-credential" };
     }
     try {
-      return await listAccountServers(credential, args.gateFetchImpl);
+      const result = await listAccountServers(credential, args.gateFetchImpl);
+      return { ok: true, result };
     } catch (error) {
       if (error instanceof ConnectListError && error.code === "unauthorized") {
         args.onUnauthorized();
+        return { ok: false, reason: "unauthorized" };
       }
-      return null;
+      return { ok: false, reason: "unavailable" };
     }
   }
 
   async function runSync(): Promise<void> {
     lastSyncAttemptAt = now();
-    const result = await fetchServers();
-    if (result === null) {
-      if (!loggedFailure) {
-        loggedFailure = true;
-        log?.(
-          "connect server sync skipped (plugin disabled, not paired, or no local server and no cached credential)",
-        );
+    const outcome = await fetchServers();
+    if (!outcome.ok) {
+      // One log line per failure streak, plus one when the reason changes.
+      if (loggedSkipReason !== outcome.reason) {
+        loggedSkipReason = outcome.reason;
+        log?.(`connect server sync skipped (${outcome.reason})`);
       }
+      args.onSkipped(outcome.reason);
       return;
     }
 
-    loggedFailure = false;
-    args.onServers(selectTargetableConnectServers(result));
+    loggedSkipReason = null;
+    args.onServers(selectTargetableConnectServers(outcome.result));
   }
 
   function syncNow(): Promise<void> {

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -80,6 +80,7 @@ import {
   createConnectServerSync,
   type ConnectAccountServer,
   type ConnectServerSync,
+  type ConnectServerSyncSkipReason,
 } from "./connect-server-sync.js";
 import {
   createCredentialCookieSource,
@@ -319,6 +320,8 @@ let enrollingDesktopMachine: Promise<void> | null = null;
 let connectSessionRenewal: ConnectSessionRenewal | null = null;
 let serverTargetGeneration = 0;
 let connectAccountServers: ConnectAccountServer[] = [];
+/** Why the last Connect sync listed nothing; null after a successful sync. */
+let connectServerSyncSkipReason: ConnectServerSyncSkipReason | null = null;
 let builtinServerUrl: string = DEFAULT_BB_SERVER_URL;
 let desktopBridgePath: string | null = null;
 let desktopUserDataPath: string | null = null;
@@ -638,7 +641,7 @@ function listMenuConnectServers(): ConnectServerRef[] {
   return servers;
 }
 
-function buildMenuServerItems(): Array<{
+function buildMenuServerItems(connectServers: ConnectServerRef[]): Array<{
   checked: boolean;
   id: string;
   name: string;
@@ -651,7 +654,7 @@ function buildMenuServerItems(): Array<{
       name: BUILTIN_SERVER_NAME,
     },
   ];
-  for (const server of listMenuConnectServers()) {
+  for (const server of connectServers) {
     items.push({
       checked:
         target.kind === "connect" && target.server.handle === server.handle,
@@ -671,8 +674,13 @@ function buildMenuServerItems(): Array<{
 }
 
 function installCurrentApplicationMenu(): void {
+  const connectServers = listMenuConnectServers();
   installApplicationMenu({
     accelerators: currentApplicationMenuAccelerators,
+    // Only explain an empty Connect list; a persisted selection that is still
+    // listed needs no note beneath it.
+    connectServersSkipReason:
+      connectServers.length === 0 ? connectServerSyncSkipReason : null,
     isMac: process.platform === "darwin",
     createNewWindow() {
       void createApplicationWindow({
@@ -759,7 +767,7 @@ function installCurrentApplicationMenu(): void {
       connectServerSync?.onListRequested();
     },
     serverDaemonLogsMenuEnabled: shouldEnableServerDaemonLogsMenu(),
-    servers: buildMenuServerItems(),
+    servers: buildMenuServerItems(connectServers),
   });
 }
 
@@ -2127,8 +2135,14 @@ async function runDesktopApp(): Promise<void> {
     onUnauthorized() {
       void clearCachedConnectCredential();
     },
+    onSkipped(reason) {
+      connectServerSyncSkipReason = reason;
+      // Electron menus are immutable once built: rebuild so the reason shows.
+      refreshApplicationMenu();
+    },
     onServers(servers) {
       connectAccountServers = servers;
+      connectServerSyncSkipReason = null;
       const selected = serverTargetStore?.getConnectServer() ?? null;
       const synced = servers.find(
         (server) => server.handle === selected?.handle,

--- a/apps/desktop/src/menu.ts
+++ b/apps/desktop/src/menu.ts
@@ -5,6 +5,7 @@ import {
   type MenuItemConstructorOptions,
 } from "electron";
 import type { ApplicationMenuAccelerators } from "./desktop-menu-shortcuts.js";
+import type { ConnectServerSyncSkipReason } from "./connect-server-sync.js";
 
 const SERVER_DAEMON_LOGS_MENU_LABEL = "Server & Daemon Logs";
 const OPEN_NEW_TAB_MENU_LABEL = "New Tab";
@@ -19,6 +20,20 @@ const FORCE_RELOAD_ACCELERATOR = "CommandOrControl+Shift+R";
 const SERVER_MENU_LABEL = "Server";
 const SERVER_MENU_ITEM_ID = "bb-server-menu";
 export const SET_SERVER_URL_MENU_LABEL = "Set Server URL…";
+/**
+ * Disabled row shown in place of the Connect server list when the last sync
+ * produced none, so an empty list is not mistaken for an empty account.
+ */
+export const CONNECT_SERVERS_SKIPPED_MENU_LABELS: Record<
+  ConnectServerSyncSkipReason,
+  string
+> = {
+  "no-credential": "No Connect servers — sign in to bb Connect",
+  "not-paired": "No Connect servers — Connect not paired on This Mac",
+  "plugin-disabled": "No Connect servers — Connect plugin disabled",
+  unauthorized: "No Connect servers — sign in to bb Connect again",
+  unavailable: "No Connect servers — could not reach bb Connect",
+};
 
 interface ApplicationMenuServerItem {
   checked: boolean;
@@ -45,6 +60,11 @@ export interface InstallApplicationMenuArgs {
   onServerMenuWillShow?: () => void;
   serverDaemonLogsMenuEnabled: boolean;
   servers: ApplicationMenuServerItem[];
+  /**
+   * Why `servers` lists no Connect servers, or null when it does (or when
+   * the account really has none).
+   */
+  connectServersSkipReason: ConnectServerSyncSkipReason | null;
 }
 
 function createServerDaemonLogsMenuItems(
@@ -75,8 +95,17 @@ function createServerMenuItems(
       type: "radio" as const,
     }),
   );
+  const skipReason = args.connectServersSkipReason;
   return [
     ...serverItems,
+    ...(skipReason === null
+      ? []
+      : [
+          {
+            enabled: false,
+            label: CONNECT_SERVERS_SKIPPED_MENU_LABELS[skipReason],
+          },
+        ]),
     { type: "separator" },
     {
       label: SET_SERVER_URL_MENU_LABEL,

--- a/apps/desktop/test/connect-server-sync.test.ts
+++ b/apps/desktop/test/connect-server-sync.test.ts
@@ -46,11 +46,15 @@ describe("fetchConnectAccountServers", () => {
       serverUrl: "http://127.0.0.1:38886/",
       fetchImpl,
     });
-    expect(result?.selfHandle).toBe("me");
-    expect(result?.servers).toHaveLength(2);
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      throw new Error(`unexpected skip: ${result.reason}`);
+    }
+    expect(result.result.selfHandle).toBe("me");
+    expect(result.result.servers).toHaveLength(2);
   });
 
-  it("returns null on network failure, non-JSON, or ok:false", async () => {
+  it("names the reason on network failure, plugin disabled, or not paired", async () => {
     await expect(
       fetchConnectAccountServers({
         serverUrl: "http://127.0.0.1:1",
@@ -58,31 +62,68 @@ describe("fetchConnectAccountServers", () => {
           throw new Error("ECONNREFUSED");
         },
       }),
-    ).resolves.toBeNull();
+    ).resolves.toEqual({ ok: false, reason: "unavailable" });
 
+    // The plugin route answers 503 with a string error when the plugin is off.
+    await expect(
+      fetchConnectAccountServers({
+        serverUrl: "http://127.0.0.1:38886",
+        fetchImpl: async () => ({
+          ok: false,
+          status: 503,
+          json: async () => ({
+            ok: false,
+            error: 'plugin "connect" is not running (status: disabled)',
+          }),
+          text: async () => "",
+        }),
+      }),
+    ).resolves.toEqual({ ok: false, reason: "plugin-disabled" });
+
+    // The RPC handler rethrows ConnectListError codes as the error message.
     await expect(
       fetchConnectAccountServers({
         serverUrl: "http://127.0.0.1:38886",
         fetchImpl: async () => ({
           ok: false,
           status: 500,
-          json: async () => ({ ok: false, error: "not_paired" }),
+          json: async () => ({
+            ok: false,
+            error: { code: "handler_error", message: "not_paired" },
+          }),
           text: async () => "",
         }),
       }),
-    ).resolves.toBeNull();
+    ).resolves.toEqual({ ok: false, reason: "not-paired" });
 
+    // Any other handler failure, non-JSON body, or unknown shape.
     await expect(
       fetchConnectAccountServers({
         serverUrl: "http://127.0.0.1:38886",
         fetchImpl: async () => ({
           ok: false,
-          status: 422,
-          json: async () => ({ ok: false, error: "plugin disabled" }),
+          status: 500,
+          json: async () => ({
+            ok: false,
+            error: { code: "handler_error", message: "network" },
+          }),
           text: async () => "",
         }),
       }),
-    ).resolves.toBeNull();
+    ).resolves.toEqual({ ok: false, reason: "unavailable" });
+    await expect(
+      fetchConnectAccountServers({
+        serverUrl: "http://127.0.0.1:38886",
+        fetchImpl: async () => ({
+          ok: false,
+          status: 502,
+          json: async () => {
+            throw new SyntaxError("not json");
+          },
+          text: async () => "",
+        }),
+      }),
+    ).resolves.toEqual({ ok: false, reason: "unavailable" });
   });
 });
 
@@ -130,6 +171,7 @@ describe("createConnectServerSync", () => {
       onServers(servers) {
         received = servers;
       },
+      onSkipped: () => undefined,
       onUnauthorized: () => undefined,
       fetchImpl,
       now: () => now,
@@ -167,30 +209,44 @@ describe("createConnectServerSync", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
-  it("does not call onServers on failure and logs the failure only once until a success", async () => {
+  it("reports each skipped sync with its reason and logs once per failure streak", async () => {
     const logs: string[] = [];
+    const skipped: string[] = [];
     let onServersCalls = 0;
-    let fail = true;
-    const fetchImpl = vi.fn(async () => {
-      if (fail) {
-        throw new Error("down");
-      }
-      return {
-        ok: true,
-        status: 200,
-        json: async () => ({
+    let mode: "down" | "disabled" | "up" = "down";
+    const fetchImpl = vi.fn(
+      async (): Promise<Pick<Response, "ok" | "status" | "json" | "text">> => {
+        if (mode === "down") {
+          throw new Error("down");
+        }
+        if (mode === "disabled") {
+          return {
+            ok: false,
+            status: 503,
+            json: async () => ({ ok: false, error: "plugin not running" }),
+            text: async () => "",
+          };
+        }
+        return {
           ok: true,
-          result: { selfHandle: "me", servers: [] },
-        }),
-        text: async () => "",
-      };
-    });
+          status: 200,
+          json: async () => ({
+            ok: true,
+            result: { selfHandle: "me", servers: [] },
+          }),
+          text: async () => "",
+        };
+      },
+    );
 
     const sync = createConnectServerSync({
       getCredential: () => null,
       getLocalServerUrl: () => "http://127.0.0.1:38886",
       onServers() {
         onServersCalls += 1;
+      },
+      onSkipped(reason) {
+        skipped.push(reason);
       },
       onUnauthorized: () => undefined,
       fetchImpl,
@@ -203,15 +259,25 @@ describe("createConnectServerSync", () => {
 
     await sync.syncNow();
     await sync.syncNow();
-    expect(logs).toHaveLength(1);
+    expect(skipped).toEqual(["unavailable", "unavailable"]);
+    expect(logs).toEqual(["connect server sync skipped (unavailable)"]);
     expect(onServersCalls).toBe(0);
 
-    fail = false;
+    // A different reason inside the same streak is logged once more.
+    mode = "disabled";
+    await sync.syncNow();
+    expect(skipped).toEqual(["unavailable", "unavailable", "plugin-disabled"]);
+    expect(logs).toEqual([
+      "connect server sync skipped (unavailable)",
+      "connect server sync skipped (plugin-disabled)",
+    ]);
+
+    mode = "up";
     await sync.syncNow();
     expect(onServersCalls).toBe(1);
-    fail = true;
+    mode = "disabled";
     await sync.syncNow();
-    expect(logs).toHaveLength(2);
+    expect(logs).toHaveLength(3);
   });
 });
 
@@ -243,6 +309,7 @@ describe("createConnectServerSync without a local server", () => {
       onServers(servers) {
         received = servers;
       },
+      onSkipped: () => undefined,
       onUnauthorized: () => undefined,
       setIntervalFn: () => 0,
       clearIntervalFn: () => undefined,
@@ -268,11 +335,15 @@ describe("createConnectServerSync without a local server", () => {
 
   it("reports a refused credential so the caller drops it", async () => {
     let unauthorized = 0;
+    const skipped: string[] = [];
     const sync = createConnectServerSync({
       getCredential: () => credential,
       getLocalServerUrl: () => null,
       gateFetchImpl: async () => new Response("no", { status: 403 }),
       onServers: () => undefined,
+      onSkipped(reason) {
+        skipped.push(reason);
+      },
       onUnauthorized() {
         unauthorized += 1;
       },
@@ -282,21 +353,51 @@ describe("createConnectServerSync without a local server", () => {
 
     await sync.syncNow();
     expect(unauthorized).toBe(1);
+    expect(skipped).toEqual(["unauthorized"]);
   });
 
-  it("stays quiet when the app has no credential", async () => {
-    const gateFetchImpl = vi.fn(async () => new Response("{}"));
+  it("reports a gate outage as unavailable", async () => {
+    const skipped: string[] = [];
     const sync = createConnectServerSync({
-      getCredential: () => null,
+      getCredential: () => credential,
       getLocalServerUrl: () => null,
-      gateFetchImpl,
+      gateFetchImpl: async () => new Response("oops", { status: 502 }),
       onServers: () => undefined,
+      onSkipped(reason) {
+        skipped.push(reason);
+      },
       onUnauthorized: () => undefined,
       setIntervalFn: () => 0,
       clearIntervalFn: () => undefined,
     });
 
     await sync.syncNow();
+    expect(skipped).toEqual(["unavailable"]);
+  });
+
+  it("reports no-credential without calling the gate when the app has none", async () => {
+    const gateFetchImpl = vi.fn(async () => new Response("{}"));
+    const skipped: string[] = [];
+    const logs: string[] = [];
+    const sync = createConnectServerSync({
+      getCredential: () => null,
+      getLocalServerUrl: () => null,
+      gateFetchImpl,
+      onServers: () => undefined,
+      onSkipped(reason) {
+        skipped.push(reason);
+      },
+      onUnauthorized: () => undefined,
+      log: (message) => {
+        logs.push(message);
+      },
+      setIntervalFn: () => 0,
+      clearIntervalFn: () => undefined,
+    });
+
+    await sync.syncNow();
     expect(gateFetchImpl).not.toHaveBeenCalled();
+    expect(skipped).toEqual(["no-credential"]);
+    expect(logs).toEqual(["connect server sync skipped (no-credential)"]);
   });
 });

--- a/apps/desktop/test/menu.test.ts
+++ b/apps/desktop/test/menu.test.ts
@@ -10,6 +10,7 @@ import { Menu } from "electron";
 
 import {
   buildApplicationMenuTemplate,
+  CONNECT_SERVERS_SKIPPED_MENU_LABELS,
   SET_SERVER_URL_MENU_LABEL,
   type InstallApplicationMenuArgs,
 } from "../src/menu.js";
@@ -27,6 +28,7 @@ function menuArgs(
       openSettings: undefined,
     },
     closeWindowOrSideTab: () => {},
+    connectServersSkipReason: null,
     createNewWindow: () => {},
     isMac: true,
     openNewTab: () => {},
@@ -131,6 +133,40 @@ describe("application menu", () => {
     expect(selectServer).toHaveBeenCalledWith("custom");
     serverSubmenu[3]?.click?.({} as never, undefined, {} as never);
     expect(setServerUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it("explains an empty Connect list with a disabled row when the sync was skipped", () => {
+    // A saved custom target with no local runtime and no cached credential:
+    // the sync has nothing to ask, and the menu must say so (#1753).
+    const template = buildApplicationMenuTemplate(
+      menuArgs(() => {}, {
+        connectServersSkipReason: "no-credential",
+        servers: [
+          { checked: false, id: "builtin", name: "This Mac" },
+          {
+            checked: true,
+            id: "custom",
+            name: "old-host.tailnet.ts.net:38886",
+          },
+        ],
+      }),
+    );
+    const serverSubmenu = findServerSubmenu(template);
+
+    expect(serverSubmenu.map((item) => item.label ?? `<${item.type}>`)).toEqual(
+      [
+        "This Mac",
+        "old-host.tailnet.ts.net:38886",
+        CONNECT_SERVERS_SKIPPED_MENU_LABELS["no-credential"],
+        "<separator>",
+        SET_SERVER_URL_MENU_LABEL,
+      ],
+    );
+    const note = serverSubmenu[2];
+    expect(note?.enabled).toBe(false);
+    expect(note?.type).toBeUndefined();
+    expect(note?.click).toBeUndefined();
+    expect(note?.label).toMatch(/sign in to bb Connect/u);
   });
 
   it("builds a native Linux menu with the Linux DevTools accelerator", () => {


### PR DESCRIPTION
## What was wrong

`createConnectServerSync().runSync()` in `apps/desktop/src/connect-server-sync.ts` treated every empty outcome of `fetchServers()` as `null`: no local runtime and no cached credential, connect plugin disabled (HTTP 503), connect plugin unpaired (`{ code: "handler_error", message: "not_paired" }`), server or gate unreachable, and a refused credential. It logged one line and returned, so `main.ts` was never told and never rebuilt the menu. `buildMenuServerItems()` mapped an empty `connectAccountServers` and `createServerMenuItems()` in `menu.ts` has no empty-state row, so Window > Server looked exactly like an account with no servers. `fetchConnectAccountServers()` even parsed `rpcFailureSchema` and discarded the result, although the server says which case it is on the wire.

Issue: #1753. Report: https://get-bb.github.io/reports/issues/1753.html

## What changed

- `apps/desktop/src/connect-server-sync.ts`: `fetchConnectAccountServers()` returns `{ ok: true, result } | { ok: false, reason }` instead of `T | null`. The reason is derived from the response: 503 is `plugin-disabled`, `handler_error`/`not_paired` is `not-paired`, anything else (fetch threw, non-JSON, unknown shape) is `unavailable`. The gate path returns `no-credential` when the app has none, `unauthorized` when the gate refuses the credential (still calls `onUnauthorized`), `unavailable` otherwise. New required callback `onSkipped(reason)` fires for every skipped sync next to `onServers`. The log line now names the reason and is written once per failure streak plus once when the reason changes.
- `apps/desktop/src/main.ts`: stores the reason in `connectServerSyncSkipReason`, clears it in `onServers`, and calls `refreshApplicationMenu()` from `onSkipped` because Electron menus are immutable once built. The menu gets the reason only when `listMenuConnectServers()` is empty, so a persisted Connect selection that is still listed gets no note under it.
- `apps/desktop/src/menu.ts`: `InstallApplicationMenuArgs.connectServersSkipReason: ConnectServerSyncSkipReason | null` (required, not optional). A non-null reason renders one disabled row after the server radio items: `No Connect servers — sign in to bb Connect` / `… Connect not paired on This Mac` / `… Connect plugin disabled` / `… sign in to bb Connect again` / `… could not reach bb Connect`.

No wire change between server and host daemon; the desktop to local-server RPC request is unchanged, only the parse of its failure body. No CLI or doc surfaces.

Deviation from the reporter's prototype (`Joesirven/bb@prototype/connect-server-list-skip-reason`, no PR): the reason is pushed through a callback that rebuilds the menu, instead of a `getSkipReason()` polled at build time, so the row appears after the sync that produced it rather than after the next unrelated rebuild. Plugin-disabled and not-paired are told apart. The reason is set from the outcome, never before the fetch resolves. No clickable "Sign in to bb Connect…" item: that is a product decision and the issue asked for the disabled row as the minimum.

Relation to #1494 / #2161: in the reporter's exact startup flow (saved custom target that no longer answers) `applyServerTarget()` rejects on `loadURL` before the startup `syncNow()` runs, so the first sync fires from `menu-will-show` and the row shows from the second open of the menu. With #2161 the startup sync is reached and the row is there on the first open. This PR does not touch that flow.

## How you verified

Tests (`apps/desktop/test/connect-server-sync.test.ts`, `apps/desktop/test/menu.test.ts`). With `git checkout origin/main -- apps/desktop/src/connect-server-sync.ts apps/desktop/src/menu.ts apps/desktop/src/main.ts` and the new tests: `Tests 7 failed | 8 passed (15)`, including

```
× explains an empty Connect list with a disabled row when the sync was skipped
  TypeError: Cannot read properties of undefined (reading 'no-credential')
× reports no-credential without calling the gate when the app has none
  AssertionError: expected [] to deeply equal [ 'no-credential' ]
× names the reason on network failure, plugin disabled, or not paired
  AssertionError: expected null to deeply equal { ok: false, reason: 'unavailable' }
× reports a refused credential so the caller drops it
  AssertionError: expected [] to deeply equal [ 'unauthorized' ]
```

On this branch the same files pass (`Tests 15 passed (15)`).

`pnpm exec turbo run typecheck test --filter=@bb/desktop --force` on the committed tree (`git status --porcelain` empty): `Tasks: 5 successful, 5 total`, `Test Files 34 passed (34)`, `Tests 224 passed (224)`.

Manual: rendered the real `menu.ts` inside Electron 41 under Xvfb with the report's harness, using the `servers` array `main.ts` produces for the reporter's state (saved custom target, no local runtime, no credential). Before: `This Mac | old-host.tailnet.ts.net:38886 | <separator> | Set Server URL…`. After, with `connectServersSkipReason: "no-credential"` as `main.ts` now passes it after the skipped sync: `This Mac | old-host.tailnet.ts.net:38886 | No Connect servers — sign in to bb Connect | <separator> | Set Server URL…`, the new row greyed out and not clickable.

The server-side shapes the parser matches were checked against `apps/server/src/routes/plugins.ts` (503 + string `error` for a plugin that is not running) and `apps/server/src/services/plugins/plugin-service.ts` + `plugins/connect/src/rpc.ts` (`{ code: "handler_error", message: error.message }` where the handler rethrows `ConnectListError.code`), and match the report's live probe.

Fixes #1753

> AGENT GENERATED: by Claude Opus 5


## Independent verification

Checked out `d4d3412ef` (`origin/main` is an ancestor; `mergeable: MERGEABLE`) in a fresh worktree, read the issue and the report first, and verified the wire shapes the new parser matches against `apps/server/src/routes/plugins.ts` (503 + string `error` for `not-running`), `plugin-service.ts` (`{ code: "handler_error", message }` with the raw thrown message) and `plugins/connect/src/rpc.ts` (`throw new Error(error.code)` for `ConnectListError`).

Fail-before / pass-after:

```
git checkout origin/main -- apps/desktop/src/connect-server-sync.ts apps/desktop/src/main.ts apps/desktop/src/menu.ts
cd apps/desktop && pnpm exec vitest run test/connect-server-sync.test.ts test/menu.test.ts
  Tests  7 failed | 8 passed (15)
  AssertionError: expected null to deeply equal { ok: false, reason: 'unavailable' }
  AssertionError: expected [] to deeply equal [ 'no-credential' ]
  AssertionError: expected [] to deeply equal [ 'unauthorized' ]
  TypeError: Cannot read properties of undefined (reading 'no-credential')
git checkout HEAD -- <same files>
  Tests  15 passed (15)
```

`pnpm exec turbo run typecheck test --filter=@bb/desktop --force` on the clean committed tree: `Tasks: 5 successful, 5 total`, `Test Files 34 passed (34)`, `Tests 224 passed (224)`.

Live wire check (own dev instance, not mocks): ran the branch's `fetchConnectAccountServers` + `createConnectServerSync` with `tsx` against the real local server. Connect enabled but unpaired (HTTP 500 `{"code":"handler_error","message":"not_paired"}`) -> `onSkipped(["not-paired"])`; `bb plugin disable connect` (HTTP 503) -> `onSkipped(["plugin-disabled"])`; closed port -> `onSkipped(["unavailable"])`. One log line each.

Repro on the fixed branch: bundled the branch's real `connect-server-sync.ts` + `menu.ts` into Electron 41 under Xvfb, wired `onSkipped`/`onServers` to rebuild the application menu the way `main.ts` does, and fired `onListRequested()` (the `menu-will-show` trigger, the only one reached in the reporter's flow). Before the sync: `This Mac | old-host.tailnet.ts.net:38886 | <separator> | Set Server URL…`. After: `This Mac | old-host.tailnet.ts.net:38886 | No Connect servers — sign in to bb Connect | <separator> | Set Server URL…`, the new row greyed (`enabled: false`), 2 menu builds. Same harness with the live dev server as the local runtime and the plugin disabled: `This Mac | No Connect servers — Connect plugin disabled | <separator> | Set Server URL…`. No longer reproduces.

CI: all required checks pass (Checks, Tests x6, Package Smoke ubuntu + macos-15, version check); iOS/Node-compat smoke skipped by path filter.

Residual risks (none blocking): every desktop user whose bundled server is not paired to Connect now sees the greyed `Connect not paired on This Mac` row in Window > Server, which is the behaviour the issue asks for but is visible beyond the reporter's case; `onSkipped` rebuilds the menu on every skipped sync (every 10 min and on throttled menu open), mirroring the existing `onServers` path; after switching targets the previous reason can show for the sub-second window until the new sync completes; `main.ts` wiring is verified by reading plus the harness above, not by a unit test. The startup sync is still not reached when the saved custom target is dead (#1494 / #2161), so in that exact flow the row appears from the second open of the menu.

> AGENT GENERATED: by Claude Opus 5
