### PR TITLE
Patch sidebar rows from status-changed pushes instead of refetching

### DIFF
--- a/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
+++ b/apps/app/src/hooks/cache-owners/cache-owner-registry.test.ts
@@ -117,6 +117,7 @@ const CACHE_OWNER_QUERY_KEY_IMPORTS: CacheOwnerQueryKeyImportRegistry = {
     "ArchivedThreadsListFilters",
     "ENVIRONMENT_WORK_STATUS_QUERY_KEY",
     "EnvironmentWorkStatusQueryKey",
+    "SIDEBAR_NAVIGATION_QUERY_KEY",
     "THREADS_QUERY_KEY",
     "ThreadListQueryFilters",
     "environmentDiffFilesQueryKeyPrefix",

--- a/apps/app/src/hooks/cache-owners/query-cache.ts
+++ b/apps/app/src/hooks/cache-owners/query-cache.ts
@@ -1,5 +1,10 @@
 import type { QueryClient, QueryKey } from "@tanstack/react-query";
-import type { Thread, ThreadListEntry, ThreadWithRuntime } from "@bb/domain";
+import type {
+  Thread,
+  ThreadListEntry,
+  ThreadStatusChangeMetadata,
+  ThreadWithRuntime,
+} from "@bb/domain";
 import {
   applyToCachedThreadLists,
   getCachedThreadLists,
@@ -23,6 +28,7 @@ import {
   environmentQueryKey,
   environmentWorkStatusQueryKey,
   environmentWorkStatusQueryKeyPrefix,
+  SIDEBAR_NAVIGATION_QUERY_KEY,
   sidebarNavigationQueryKey,
   THREADS_QUERY_KEY,
   threadQueryKey,
@@ -703,4 +709,46 @@ export function updateCachedThreadListPendingInteractionState(
       thread.id === threadId ? { ...thread, hasPendingInteraction } : thread,
     );
   });
+}
+
+/**
+ * Writes the row fields a lifecycle transition rewrites (status, runtime,
+ * activity, attention and update times) into every cached thread list and
+ * the sidebar bootstrap. Status never changes list membership (lists filter
+ * on project, parent, archive state), so a row that is not cached needs
+ * nothing: the query that will load it reads the current status.
+ */
+export function updateCachedThreadListStatusState(
+  queryClient: QueryClient,
+  threadId: string,
+  statusChange: ThreadStatusChangeMetadata,
+): void {
+  applyToCachedThreadListsAndSidebarNavigation(queryClient, (list) => {
+    if (!list.some((thread) => thread.id === threadId)) {
+      return list;
+    }
+    return list.map((thread) =>
+      thread.id === threadId ? { ...thread, ...statusChange } : thread,
+    );
+  });
+}
+
+/**
+ * Thread list and sidebar queries with a fetch in flight. Such a fetch read
+ * the database before the change that is being patched in, so its response
+ * would overwrite the patch when it lands.
+ */
+export function getFetchingThreadListQueryKeys(
+  queryClient: QueryClient,
+): QueryKey[] {
+  return queryClient
+    .getQueryCache()
+    .findAll({ fetchStatus: "fetching" })
+    .map((query) => query.queryKey)
+    .filter(
+      (queryKey) =>
+        queryKey[0] === SIDEBAR_NAVIGATION_QUERY_KEY ||
+        getThreadListFiltersFromQueryKey(queryKey) !== undefined ||
+        getArchivedThreadListFiltersFromQueryKey(queryKey) !== undefined,
+    );
 }

--- a/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
+++ b/apps/app/src/hooks/cache-owners/realtime-cache-registry.ts
@@ -41,6 +41,7 @@ import type {
   SystemChangeKind,
   ThreadChangeKind,
   ThreadEventType,
+  ThreadStatusChangeMetadata,
   ThreadWithRuntime,
 } from "@bb/domain";
 import {
@@ -54,9 +55,11 @@ import {
   getEnvironmentBranchListInvalidationQueryKeys,
   getEnvironmentRecordInvalidationQueryKeys,
   getEnvironmentWorkspaceStateInvalidationQueryKeys,
+  getFetchingThreadListQueryKeys,
   isArchivedThreadListQueryKey,
   removeEnvironmentDiffPatchQueries,
   updateCachedThreadListPendingInteractionState,
+  updateCachedThreadListStatusState,
 } from "./query-cache";
 import {
   getCachedThreadLists,
@@ -207,8 +210,7 @@ function hasActiveQueries(
   queryKey: QueryKey,
 ): boolean {
   return (
-    queryClient.getQueryCache().findAll({ queryKey, type: "active" }).length >
-    0
+    queryClient.getQueryCache().findAll({ queryKey, type: "active" }).length > 0
   );
 }
 
@@ -430,7 +432,7 @@ export const REALTIME_THREAD_CHANGE_REGISTRY = {
   "status-changed": {
     flush: "immediate",
     dirty: [
-      dirtyActiveThreadListQueries, // List rows render status/runtime badges; archived pages only go stale.
+      patchThreadListStatusState, // List rows patch status/runtime from notification metadata; refetch only without it.
       dirtyThreadDetailQueries, // Detail controls and banners depend on status.
     ],
   },
@@ -649,6 +651,7 @@ interface ThreadRealtimeDirtyContext extends RealtimeDirtyContext {
   flushOnce: (key: string) => boolean;
   hasPendingInteraction: boolean | undefined;
   projectId: string | undefined;
+  statusChange: ThreadStatusChangeMetadata | undefined;
   threadId: string | undefined;
 }
 
@@ -903,8 +906,9 @@ function dirtyThreadTimelineQueries({
   const timelineQueryKeys = getThreadTimelineWindowInvalidationQueryKeys({
     threadId,
   });
-  const outlineQueryKeys =
-    getThreadConversationOutlineInvalidationQueryKeys({ threadId });
+  const outlineQueryKeys = getThreadConversationOutlineInvalidationQueryKeys({
+    threadId,
+  });
   const outlineMayHaveChanged =
     eventTypes === undefined || eventTypes.includes("turn/completed");
   if (
@@ -1078,6 +1082,32 @@ function patchThreadListPendingInteractionState({
     threadId,
     hasPendingInteraction,
   );
+}
+
+/**
+ * A status change rewrites a handful of row fields and never moves a thread
+ * between lists, so when the notification carries them the cached rows are
+ * patched in place. The alternative is what the fallback still does for
+ * pushes without the row (older servers, writers inside a transaction that
+ * cannot resolve the runtime): refetch every active thread list plus the
+ * sidebar bootstrap, which is ~1 KB per unarchived thread, twice per turn.
+ *
+ * A list fetch already in flight read the database before this transition
+ * and would overwrite the patch when it lands, so those queries are
+ * invalidated, which cancels and restarts them.
+ */
+function patchThreadListStatusState(
+  context: ThreadRealtimeDirtyContext,
+): QueryKey[] {
+  const { queryClient, statusChange, threadId } = context;
+  if (!threadId || !statusChange) {
+    return dirtyActiveThreadListQueries(context);
+  }
+  updateCachedThreadListStatusState(queryClient, threadId, statusChange);
+  for (const queryKey of getFetchingThreadListQueryKeys(queryClient)) {
+    queryClient.invalidateQueries({ exact: true, queryKey });
+  }
+  return [threadSearchQueryKeyPrefix()]; // Result rows render status but are not list-shaped.
 }
 
 function dirtyEnvironmentRecordQueries(

--- a/apps/app/src/hooks/realtime-cache-effects.test.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.test.ts
@@ -81,6 +81,14 @@ interface FakeVisibility extends RealtimeCacheEffectsVisibility {
   setVisible: (visible: boolean) => void;
 }
 
+const NO_THREAD_ACTIVITY = {
+  activeBackgroundAgentCount: 0,
+  activeBackgroundCommandCount: 0,
+  activeGoalCount: 0,
+  activePlanModeCount: 0,
+  activeWorkflowCount: 0,
+} as const;
+
 function createFakeVisibility(): FakeVisibility {
   let visible = true;
   const listeners = new Set<() => void>();
@@ -584,9 +592,9 @@ describe("createRealtimeCacheEffects", () => {
     await vi.advanceTimersByTimeAsync(50);
 
     // The unviewed thread's cached window is stale for its next mount...
-    expect(
-      queryClient.getQueryState(unviewedTimelineKey)?.isInvalidated,
-    ).toBe(true);
+    expect(queryClient.getQueryState(unviewedTimelineKey)?.isInvalidated).toBe(
+      true,
+    );
     const unviewedInvalidations = invalidateSpy.mock.calls.filter(
       ([filters]) =>
         JSON.stringify(filters?.queryKey) ===
@@ -1825,6 +1833,227 @@ describe("createRealtimeCacheEffects", () => {
     effects.dispose();
   });
 
+  it("patches cached thread list status from notification metadata instead of refetching the sidebar bootstrap", async () => {
+    vi.useFakeTimers();
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const threadListKey = threadListQueryKey({
+      archived: false,
+      projectId: "project-1",
+    });
+    const sidebarNavigationKey = sidebarNavigationQueryKey();
+    const idleRow = {
+      activity: NO_THREAD_ACTIVITY,
+      id: "thr_1",
+      latestAttentionAt: 100,
+      runtime: { displayStatus: "idle", hostReconnectGraceExpiresAt: null },
+      status: "idle",
+      updatedAt: 100,
+    };
+    const otherRow = {
+      activity: NO_THREAD_ACTIVITY,
+      id: "thr_2",
+      latestAttentionAt: 50,
+      runtime: { displayStatus: "idle", hostReconnectGraceExpiresAt: null },
+      status: "idle",
+      updatedAt: 50,
+    };
+    const threadListQueryFn = vi.fn(async () => [idleRow, otherRow]);
+    const sidebarQueryFn = vi.fn(async () => ({
+      projects: [{ threads: [idleRow, otherRow] }],
+      personalProject: { threads: [] },
+    }));
+    const observers = [
+      new QueryObserver(queryClient, {
+        queryKey: threadListKey,
+        queryFn: threadListQueryFn,
+        staleTime: Infinity,
+      }),
+      new QueryObserver(queryClient, {
+        queryKey: sidebarNavigationKey,
+        queryFn: sidebarQueryFn,
+        staleTime: Infinity,
+      }),
+    ];
+    const unsubscribers = observers.map((observer) =>
+      observer.subscribe(() => {}),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(sidebarQueryFn).toHaveBeenCalledTimes(1);
+    expect(threadListQueryFn).toHaveBeenCalledTimes(1);
+
+    // The plan-mode and goal indicators are server-computed and gated on the
+    // status, so the push carries the activity of the post-transition row.
+    const statusChange = {
+      activity: { ...NO_THREAD_ACTIVITY, activePlanModeCount: 1 },
+      latestAttentionAt: 100,
+      runtime: {
+        displayStatus: "active",
+        hostReconnectGraceExpiresAt: null,
+      },
+      status: "active",
+      updatedAt: 200,
+    } as const;
+    effects.handleChanged({
+      type: "changed",
+      entity: "thread",
+      id: "thr_1",
+      metadata: { projectId: "project-1", statusChange },
+      changes: ["status-changed"],
+    });
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(sidebarQueryFn).toHaveBeenCalledTimes(1);
+    expect(threadListQueryFn).toHaveBeenCalledTimes(1);
+    expect(
+      queryClient.getQueryState(sidebarNavigationKey)?.isInvalidated,
+    ).not.toBe(true);
+    const sidebarThreads = queryClient.getQueryData<{
+      projects: { threads: (typeof idleRow)[] }[];
+    }>(sidebarNavigationKey)?.projects[0]?.threads;
+    expect(sidebarThreads?.[0]).toEqual({ id: "thr_1", ...statusChange });
+    // Untouched rows keep their identity so memoized sidebar rows skip work.
+    expect(sidebarThreads?.[1]).toBe(otherRow);
+    expect(
+      queryClient.getQueryData<(typeof idleRow)[]>(threadListKey)?.[0],
+    ).toEqual({ id: "thr_1", ...statusChange });
+
+    for (const unsubscribe of unsubscribers) {
+      unsubscribe();
+    }
+    effects.dispose();
+  });
+
+  it("refetches thread lists for a status change that carries no row metadata", async () => {
+    vi.useFakeTimers();
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const sidebarNavigationKey = sidebarNavigationQueryKey();
+    const sidebarQueryFn = vi.fn(async () => ({
+      projects: [{ threads: [{ id: "thr_1", status: "idle" }] }],
+      personalProject: { threads: [] },
+    }));
+    const observer = new QueryObserver(queryClient, {
+      queryKey: sidebarNavigationKey,
+      queryFn: sidebarQueryFn,
+      staleTime: Infinity,
+    });
+    const unsubscribe = observer.subscribe(() => {});
+    await vi.advanceTimersByTimeAsync(0);
+    expect(sidebarQueryFn).toHaveBeenCalledTimes(1);
+
+    effects.handleChanged({
+      type: "changed",
+      entity: "thread",
+      id: "thr_1",
+      metadata: { projectId: "project-1" },
+      changes: ["status-changed"],
+    });
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(sidebarQueryFn).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    effects.dispose();
+  });
+
+  it("restarts a sidebar fetch already in flight so its stale snapshot cannot overwrite the patched status", async () => {
+    vi.useFakeTimers();
+    const { effects, queryClient } = createRealtimeEffectsTestContext();
+    const sidebarNavigationKey = sidebarNavigationQueryKey();
+    const idleRow = {
+      activity: NO_THREAD_ACTIVITY,
+      id: "thr_1",
+      latestAttentionAt: 100,
+      runtime: { displayStatus: "idle", hostReconnectGraceExpiresAt: null },
+      status: "idle",
+      updatedAt: 100,
+    };
+    const activeRow = {
+      ...idleRow,
+      runtime: { displayStatus: "active", hostReconnectGraceExpiresAt: null },
+      status: "active",
+      updatedAt: 200,
+    };
+    // The first fetch (driven by an earlier title change) was answered by the
+    // server before the thread became active; a fetch started after the
+    // status push sees the active row.
+    let activated = false;
+    const responses: { activated: boolean; resolve: () => void }[] = [];
+    const sidebarQueryFn = vi.fn(
+      () =>
+        new Promise<{
+          projects: { threads: (typeof idleRow)[] }[];
+          personalProject: { threads: never[] };
+        }>((resolve) => {
+          const snapshot = activated ? activeRow : idleRow;
+          responses.push({
+            activated,
+            resolve: () =>
+              resolve({
+                projects: [{ threads: [snapshot] }],
+                personalProject: { threads: [] },
+              }),
+          });
+        }),
+    );
+    const observer = new QueryObserver(queryClient, {
+      queryKey: sidebarNavigationKey,
+      queryFn: sidebarQueryFn,
+      staleTime: Infinity,
+    });
+    const unsubscribe = observer.subscribe(() => {});
+    responses.shift()?.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(sidebarQueryFn).toHaveBeenCalledTimes(1);
+
+    effects.handleChanged({
+      type: "changed",
+      entity: "thread",
+      id: "thr_1",
+      metadata: { projectId: "project-1" },
+      changes: ["title-changed"],
+    });
+    await vi.advanceTimersByTimeAsync(50);
+    expect(sidebarQueryFn).toHaveBeenCalledTimes(2);
+    const staleResponse = responses.shift();
+
+    activated = true;
+    effects.handleChanged({
+      type: "changed",
+      entity: "thread",
+      id: "thr_1",
+      metadata: {
+        projectId: "project-1",
+        statusChange: {
+          activity: NO_THREAD_ACTIVITY,
+          latestAttentionAt: 100,
+          runtime: {
+            displayStatus: "active",
+            hostReconnectGraceExpiresAt: null,
+          },
+          status: "active",
+          updatedAt: 200,
+        },
+      },
+      changes: ["status-changed"],
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The in-flight fetch was superseded by one started after the transition.
+    expect(sidebarQueryFn).toHaveBeenCalledTimes(3);
+    staleResponse?.resolve();
+    responses.shift()?.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(
+      queryClient.getQueryData<{
+        projects: { threads: (typeof idleRow)[] }[];
+      }>(sidebarNavigationKey)?.projects[0]?.threads[0]?.status,
+    ).toBe("active");
+
+    unsubscribe();
+    effects.dispose();
+  });
+
   it("invalidates thread list and detail but not timeline for parent changes", () => {
     vi.useFakeTimers();
     const { effects, queryClient } = createRealtimeEffectsTestContext();
@@ -2080,6 +2309,67 @@ describe("createRealtimeCacheEffects", () => {
 
       expect(queryClient.getQueryState(threadKey)?.isInvalidated).toBe(true);
       expect(queryClient.getQueryState(timelineKey)?.isInvalidated).toBe(true);
+      expect(
+        queryClient.getQueryState(sidebarNavigationKey)?.isInvalidated,
+      ).toBe(true);
+      effects.dispose();
+    });
+
+    it("refetches when a bare status-changed follows one that carried the row", () => {
+      // Stop requests, command failures and host interruptions still push the
+      // bare kind. Merged behind an earlier push's row snapshot, the resume
+      // flush must not patch the row to that earlier, now-stale status.
+      vi.useFakeTimers();
+      const visibility = createFakeVisibility();
+      const { effects, queryClient } =
+        createRealtimeEffectsTestContext(visibility);
+      const sidebarNavigationKey = sidebarNavigationQueryKey();
+      const idleRow = {
+        activity: NO_THREAD_ACTIVITY,
+        id: "thr_1",
+        latestAttentionAt: 100,
+        runtime: { displayStatus: "idle", hostReconnectGraceExpiresAt: null },
+        status: "idle",
+        updatedAt: 100,
+      };
+      queryClient.setQueryData(sidebarNavigationKey, {
+        projects: [{ threads: [idleRow] }],
+        personalProject: { threads: [] },
+      });
+
+      visibility.setVisible(false);
+      effects.handleChanged({
+        type: "changed",
+        entity: "thread",
+        id: "thr_1",
+        metadata: {
+          projectId: "project-1",
+          statusChange: {
+            activity: NO_THREAD_ACTIVITY,
+            latestAttentionAt: 100,
+            runtime: {
+              displayStatus: "active",
+              hostReconnectGraceExpiresAt: null,
+            },
+            status: "active",
+            updatedAt: 200,
+          },
+        },
+        changes: ["status-changed"],
+      });
+      effects.handleChanged({
+        type: "changed",
+        entity: "thread",
+        id: "thr_1",
+        changes: ["status-changed"],
+      });
+      visibility.setVisible(true);
+
+      expect(
+        queryClient.getQueryData<{
+          projects: { threads: (typeof idleRow)[] }[];
+        }>(sidebarNavigationKey)?.projects[0]?.threads[0],
+      ).toBe(idleRow);
       expect(
         queryClient.getQueryState(sidebarNavigationKey)?.isInvalidated,
       ).toBe(true);

--- a/apps/app/src/hooks/realtime-cache-effects.ts
+++ b/apps/app/src/hooks/realtime-cache-effects.ts
@@ -111,16 +111,33 @@ function mergeEventTypes(
   return Array.from(new Set([...current, ...next]));
 }
 
-function mergeThreadChangeMetadata(
-  current: ThreadChangeMetadata | undefined,
-  next: ThreadChangeMetadata,
-): ThreadChangeMetadata {
+interface MergeThreadChangeMetadataArgs {
+  current: ThreadChangeMetadata | undefined;
+  next: ThreadChangeMetadata;
+  /**
+   * The message carries `status-changed`. Its row snapshot (or the lack of
+   * one) supersedes any earlier snapshot merged while the document was
+   * hidden: a later bare `status-changed` (stop, command failure, host
+   * interruption) must make the flush refetch, not patch the row to the
+   * earlier, now-stale status.
+   */
+  statusChanged: boolean;
+}
+
+function mergeThreadChangeMetadata({
+  current,
+  next,
+  statusChanged,
+}: MergeThreadChangeMetadataArgs): ThreadChangeMetadata {
   const eventTypes = mergeEventTypes(current?.eventTypes, next.eventTypes);
   const backgroundActivityChanged =
     next.backgroundActivityChanged ?? current?.backgroundActivityChanged;
   const hasPendingInteraction =
     next.hasPendingInteraction ?? current?.hasPendingInteraction;
   const projectId = next.projectId ?? current?.projectId;
+  const statusChange = statusChanged
+    ? next.statusChange
+    : (next.statusChange ?? current?.statusChange);
   const metadata: ThreadChangeMetadata = {};
   if (eventTypes) {
     metadata.eventTypes = eventTypes;
@@ -133,6 +150,9 @@ function mergeThreadChangeMetadata(
   }
   if (projectId !== undefined) {
     metadata.projectId = projectId;
+  }
+  if (statusChange !== undefined) {
+    metadata.statusChange = statusChange;
   }
   return metadata;
 }
@@ -180,6 +200,7 @@ function flushThreadInvalidations(
         hasPendingInteraction: undefined,
         projectId: undefined,
         queryClient,
+        statusChange: undefined,
         threadId: undefined,
       },
       handlers: REALTIME_THREAD_CHANGE_REGISTRY[changeKind].dirty,
@@ -197,6 +218,7 @@ function flushThreadInvalidations(
           hasPendingInteraction: metadata?.hasPendingInteraction,
           projectId: metadata?.projectId,
           queryClient,
+          statusChange: metadata?.statusChange,
           threadId,
         },
         handlers: REALTIME_THREAD_CHANGE_REGISTRY[changeKind].dirty,
@@ -221,13 +243,15 @@ function recordThreadChange(
       state,
       threadId: message.id,
     });
-    if (message.metadata) {
+    const statusChanged = message.changes.includes("status-changed");
+    if (message.metadata || statusChanged) {
       state.metadataByThreadId.set(
         message.id,
-        mergeThreadChangeMetadata(
-          state.metadataByThreadId.get(message.id),
-          message.metadata,
-        ),
+        mergeThreadChangeMetadata({
+          current: state.metadataByThreadId.get(message.id),
+          next: message.metadata ?? {},
+          statusChanged,
+        }),
       );
     }
     return;

--- a/apps/server/src/internal/turn-completed-events.ts
+++ b/apps/server/src/internal/turn-completed-events.ts
@@ -31,7 +31,7 @@ function lifecycleEventForTurnCompletion(
 }
 
 export function applyTurnCompletedEvent(
-  deps: Pick<AppDeps, "db" | "hub" | "logger">,
+  deps: Pick<AppDeps, "db" | "hub" | "logger" | "providerRegistry">,
   payload: Extract<ThreadEvent, { type: "turn/completed" }>,
 ): ApplyTurnCompletedEventResult {
   const thread = getThread(deps.db, payload.threadId);

--- a/apps/server/src/services/threads/lifecycle-outcome.ts
+++ b/apps/server/src/services/threads/lifecycle-outcome.ts
@@ -4,16 +4,19 @@ import {
   type ApplyThreadLifecycleEventArgs,
   type ApplyThreadLifecycleEventOutcome,
   type DbConnection,
-  type DbNotifier,
   type DbTransaction,
 } from "@bb/db";
 import type { ServerLogger } from "../../types.js";
+import type { NotificationHub } from "../../ws/hub.js";
 import { emitPluginThreadLifecycleOutcome } from "../plugins/plugin-thread-events.js";
+import type { ProviderRegistryService } from "../providers/provider-registry.js";
+import { buildThreadStatusChangeMetadata } from "./thread-runtime-display.js";
 
 interface ApplyLoggedThreadLifecycleEventDeps {
   db: DbConnection;
-  hub: DbNotifier;
+  hub: Pick<NotificationHub, "getDaemonSessionIdForHost" | "notifyThread">;
   logger: ServerLogger;
+  providerRegistry: ProviderRegistryService;
 }
 
 interface ApplyLoggedThreadLifecycleEventTransactionDeps {
@@ -41,15 +44,23 @@ function logUnappliedThreadLifecycleEvent(
 }
 
 /**
- * Applies a thread lifecycle event in its own transaction (the db writer
- * notifies status-changed when applied) and logs every non-applied outcome so
- * stale events are observable instead of silently swallowed.
+ * Applies a thread lifecycle event in its own transaction, notifies
+ * status-changed with the post-transition row when applied, and logs every
+ * non-applied outcome so stale events are observable instead of silently
+ * swallowed.
  */
 export function applyLoggedThreadLifecycleEvent(
   deps: ApplyLoggedThreadLifecycleEventDeps,
   args: ApplyThreadLifecycleEventArgs,
 ): ApplyThreadLifecycleEventOutcome {
-  const outcome = applyThreadLifecycleEvent(deps.db, deps.hub, args);
+  const outcome = applyThreadLifecycleEvent(deps.db, args);
+  if (outcome.applied) {
+    deps.hub.notifyThread(
+      args.threadId,
+      ["status-changed"],
+      buildThreadStatusChangeMetadata(deps, outcome.thread),
+    );
+  }
   logUnappliedThreadLifecycleEvent(deps.logger, args, outcome);
   emitPluginThreadLifecycleOutcome(outcome);
   return outcome;

--- a/apps/server/src/services/threads/parent-system-messages.ts
+++ b/apps/server/src/services/threads/parent-system-messages.ts
@@ -27,6 +27,7 @@ import {
   prepareReadyThreadTurnCommand,
 } from "./thread-lifecycle.js";
 import { applyLoggedThreadLifecycleEventInTransaction } from "./lifecycle-outcome.js";
+import { buildThreadStatusChangeMetadata } from "./thread-runtime-display.js";
 import {
   appendClientTurnEventInTransaction,
   appendPreparedClientTurnRequestedEventWithNotificationInTransaction,
@@ -337,8 +338,8 @@ async function queueReadyParentSystemMessage(
     providerId: args.thread.providerId,
     syncGeneratedTitle: false,
   });
-  let transitioned = false;
-  deps.db.transaction(
+  // The post-transition row when dispatching the message activated the thread.
+  const activeThread: Thread | null = deps.db.transaction(
     (tx) => {
       ensureThreadCanStartRequest(args.thread);
       appendPreparedClientTurnRequestedEventWithNotificationInTransaction(tx, {
@@ -357,15 +358,15 @@ async function queueReadyParentSystemMessage(
         requestId,
       });
       const dispatchKind = command.mode;
-      if (dispatchKind === "turn.submit") {
-        requireThreadLifecycleEventApplied(
-          applyLoggedThreadLifecycleEventInTransaction(
-            { db: tx, logger: deps.logger },
-            { event: { type: "run.started" }, threadId: args.thread.id },
-          ),
-        );
-        transitioned = true;
+      if (dispatchKind !== "turn.submit") {
+        return null;
       }
+      return requireThreadLifecycleEventApplied(
+        applyLoggedThreadLifecycleEventInTransaction(
+          { db: tx, logger: deps.logger },
+          { event: { type: "run.started" }, threadId: args.thread.id },
+        ),
+      );
     },
     { behavior: "immediate" },
   );
@@ -383,10 +384,12 @@ async function queueReadyParentSystemMessage(
       );
     },
   });
-  if (transitioned) {
-    deps.hub.notifyThread(args.thread.id, ["status-changed"], {
-      projectId: args.thread.projectId,
-    });
+  if (activeThread) {
+    deps.hub.notifyThread(
+      args.thread.id,
+      ["status-changed"],
+      buildThreadStatusChangeMetadata(deps, activeThread),
+    );
   }
   return true;
 }

--- a/apps/server/src/services/threads/queued-messages.ts
+++ b/apps/server/src/services/threads/queued-messages.ts
@@ -57,6 +57,7 @@ import {
 import { recordAcceptedPromptHistoryEntry } from "../prompt-history.js";
 import { requireThreadCommandEnvironment } from "./thread-command-environment.js";
 import { applyLoggedThreadLifecycleEventInTransaction } from "./lifecycle-outcome.js";
+import { buildThreadStatusChangeMetadata } from "./thread-runtime-display.js";
 import { applyLoggedEnvironmentLifecycleEvent } from "../environments/lifecycle-outcome.js";
 
 interface SendQueuedMessageArgs {
@@ -330,7 +331,7 @@ async function sendClaimedQueuedMessageForIdleProviderThread(
     thread,
   });
 
-  const command = deps.db.transaction(
+  const { activeThread, command } = deps.db.transaction(
     (tx) => {
       const consumed = deleteClaimedQueuedThreadMessageBatchInTransaction(tx, {
         queuedMessages: args.queuedMessages,
@@ -379,8 +380,7 @@ async function sendClaimedQueuedMessageForIdleProviderThread(
         // guard skips the thread on the next sweep tick.
         throw createQueuedMessageClaimLostError();
       }
-      deps.hub.notifyThread(thread.id, ["status-changed"]);
-      return command;
+      return { activeThread: outcome.thread, command };
     },
     { behavior: "immediate" },
   );
@@ -390,6 +390,7 @@ async function sendClaimedQueuedMessageForIdleProviderThread(
     ["events-appended", "queue-changed", "status-changed"],
     {
       eventTypes: ["client/turn/requested"],
+      ...buildThreadStatusChangeMetadata(deps, activeThread),
     },
   );
   startLiveHostCommand(deps, {

--- a/apps/server/src/services/threads/thread-provisioning-environment.ts
+++ b/apps/server/src/services/threads/thread-provisioning-environment.ts
@@ -74,7 +74,10 @@ import {
 
 export type ThreadProvisioningDeps = CommandResultSideEffectsDeps;
 
-type ThreadProvisionWriteDeps = Pick<AppDeps, "db" | "hub" | "logger">;
+type ThreadProvisionWriteDeps = Pick<
+  AppDeps,
+  "db" | "hub" | "logger" | "providerRegistry"
+>;
 type DirectUnmanagedIntent = Extract<
   ThreadProvisionEnvironmentIntent,
   { type: "direct-unmanaged" }
@@ -364,7 +367,7 @@ export function ensureWorkspaceReadyEventInTransaction(
 }
 
 export function failThreadProvisioning(
-  deps: Pick<AppDeps, "db" | "hub" | "logger">,
+  deps: Pick<AppDeps, "db" | "hub" | "logger" | "providerRegistry">,
   args: FailThreadProvisioningArgs,
 ): void {
   forgetActiveThreadProvisionContext(args.thread.id);

--- a/apps/server/src/services/threads/thread-runtime-display.ts
+++ b/apps/server/src/services/threads/thread-runtime-display.ts
@@ -17,6 +17,7 @@ import { LEGACY_CODEX_GOAL_EXTENSION_KIND } from "@bb/domain";
 import type {
   Thread,
   ThreadActivityState,
+  ThreadChangeMetadata,
   ThreadListEntry,
   ThreadRuntimeState,
   ThreadStatus,
@@ -243,6 +244,37 @@ function resolveThreadEnvironmentHostId(
   return getEnvironment(deps.db, thread.environmentId)?.hostId ?? null;
 }
 
+/**
+ * Metadata for a `status-changed` notification: the post-transition row
+ * fields plus the runtime and activity the thread's list row would render
+ * with right now, built by the same helpers as the list endpoints. Clients
+ * patch their cached list rows from it instead of refetching every thread
+ * list. Activity rides along because the plan-mode and goal counts are gated
+ * on the status and were previously only synced by that refetch. Producers
+ * without a hub (writes inside a transaction that buffer notifications) send
+ * the bare change kind and clients refetch as before.
+ */
+export function buildThreadStatusChangeMetadata(
+  deps: ThreadPromptBannerDeps,
+  thread: Thread,
+): ThreadChangeMetadata {
+  return {
+    projectId: thread.projectId,
+    statusChange: {
+      status: thread.status,
+      runtime: resolveThreadRuntimeState(deps, {
+        environmentHostId: resolveThreadEnvironmentHostId(deps, thread),
+        status: thread.status,
+      }),
+      activity: buildThreadActivityStateByThreadId(deps, [thread]).get(
+        thread.id,
+      ) ?? EMPTY_THREAD_ACTIVITY,
+      latestAttentionAt: thread.latestAttentionAt,
+      updatedAt: thread.updatedAt,
+    },
+  };
+}
+
 function toThreadResponseWithHost(
   deps: ThreadRuntimeDisplayDeps,
   args: ToThreadResponseWithHostArgs,
@@ -388,17 +420,58 @@ export function getThreadPromptBannerActivity(
   );
 }
 
+/**
+ * The list-row activity for each thread: background task counts from the
+ * task rows plus the plan-mode and goal counts the prompt banner derives from
+ * the event log. Threads with no activity at all are absent.
+ */
+function buildThreadActivityStateByThreadId(
+  deps: ThreadPromptBannerDeps,
+  threads: readonly Thread[],
+): Map<string, ThreadActivityState> {
+  const backgroundTaskActivityByThreadId = new Map(
+    listActiveBackgroundTaskCountsByThreadIds(deps.db, {
+      threadIds: threads.map((thread) => thread.id),
+    }).map((activity) => [activity.threadId, activity]),
+  );
+  const promptBannerActivityByThreadId =
+    buildThreadPromptBannerActivityByThreadId(deps, threads);
+  const result = new Map<string, ThreadActivityState>();
+  for (const thread of threads) {
+    const backgroundActivity = backgroundTaskActivityByThreadId.get(thread.id);
+    const promptBannerActivity = promptBannerActivityByThreadId.get(thread.id);
+    if (!backgroundActivity && !promptBannerActivity) {
+      continue;
+    }
+    result.set(thread.id, {
+      activeBackgroundAgentCount:
+        backgroundActivity?.activeBackgroundAgentCount ??
+        EMPTY_THREAD_ACTIVITY.activeBackgroundAgentCount,
+      activeBackgroundCommandCount:
+        backgroundActivity?.activeBackgroundCommandCount ??
+        EMPTY_THREAD_ACTIVITY.activeBackgroundCommandCount,
+      activeGoalCount:
+        promptBannerActivity?.activeGoalCount ??
+        EMPTY_THREAD_ACTIVITY.activeGoalCount,
+      activePlanModeCount:
+        promptBannerActivity?.activePlanModeCount ??
+        EMPTY_THREAD_ACTIVITY.activePlanModeCount,
+      activeWorkflowCount:
+        backgroundActivity?.activeWorkflowCount ??
+        EMPTY_THREAD_ACTIVITY.activeWorkflowCount,
+    });
+  }
+  return result;
+}
+
 export function toThreadListEntryResponses(
   deps: ThreadPromptBannerDeps,
   args: ToThreadListEntryResponsesArgs,
 ): ThreadListEntry[] {
-  const backgroundTaskActivityByThreadId = new Map(
-    listActiveBackgroundTaskCountsByThreadIds(deps.db, {
-      threadIds: args.threads.map((thread) => thread.id),
-    }).map((activity) => [activity.threadId, activity]),
+  const activityByThreadId = buildThreadActivityStateByThreadId(
+    deps,
+    args.threads,
   );
-  const promptBannerActivityByThreadId =
-    buildThreadPromptBannerActivityByThreadId(deps, args.threads);
   const activeHostIds = [
     ...new Set(
       args.threads.flatMap((thread) =>
@@ -420,26 +493,8 @@ export function toThreadListEntryResponses(
   );
 
   return args.threads.map((thread) => {
-    const backgroundActivity = backgroundTaskActivityByThreadId.get(thread.id);
-    const promptBannerActivity = promptBannerActivityByThreadId.get(thread.id);
     return toThreadListEntryResponseFromLatestSession({
-      activity: {
-        activeBackgroundAgentCount:
-          backgroundActivity?.activeBackgroundAgentCount ??
-          EMPTY_THREAD_ACTIVITY.activeBackgroundAgentCount,
-        activeBackgroundCommandCount:
-          backgroundActivity?.activeBackgroundCommandCount ??
-          EMPTY_THREAD_ACTIVITY.activeBackgroundCommandCount,
-        activeGoalCount:
-          promptBannerActivity?.activeGoalCount ??
-          EMPTY_THREAD_ACTIVITY.activeGoalCount,
-        activePlanModeCount:
-          promptBannerActivity?.activePlanModeCount ??
-          EMPTY_THREAD_ACTIVITY.activePlanModeCount,
-        activeWorkflowCount:
-          backgroundActivity?.activeWorkflowCount ??
-          EMPTY_THREAD_ACTIVITY.activeWorkflowCount,
-      },
+      activity: activityByThreadId.get(thread.id) ?? EMPTY_THREAD_ACTIVITY,
       hostConnected:
         thread.environmentHostId !== null &&
         connectedActiveHostIds.has(thread.environmentHostId),

--- a/apps/server/src/services/threads/thread-send.ts
+++ b/apps/server/src/services/threads/thread-send.ts
@@ -43,7 +43,10 @@ import {
   requireReadyThreadEnvironment,
 } from "./thread-turn-dispatch.js";
 import { resolvePermissionEscalation } from "./thread-runtime-config.js";
-import { resolveThreadRuntimeState } from "./thread-runtime-display.js";
+import {
+  buildThreadStatusChangeMetadata,
+  resolveThreadRuntimeState,
+} from "./thread-runtime-display.js";
 import { recordAcceptedPromptHistoryEntry } from "../prompt-history.js";
 import { ensureHostSessionReadyForWork } from "../hosts/host-lifecycle.js";
 import {
@@ -110,7 +113,8 @@ interface SendThreadMessageQueueRequestArgs {
 }
 
 interface SendThreadMessageQueueRequestResult {
-  threadBecameActive: boolean;
+  /** The post-transition row when queueing the request activated the thread. */
+  activeThread: Thread | null;
 }
 
 interface SendThreadMessageTransactionPreflight {
@@ -139,8 +143,8 @@ interface AppendAndQueueSendThreadMessageArgs {
 }
 
 interface AppendAndQueueSendThreadMessageResult {
+  activeThread: Thread | null;
   request: AppendedClientTurnRequestWithNotification;
-  threadBecameActive: boolean;
 }
 
 export function ensureThreadIsNotAwaitingUserInteraction(
@@ -337,7 +341,7 @@ function appendAndQueueSendThreadMessageInTransaction({
   target,
   thread,
 }: AppendAndQueueSendThreadMessageArgs): AppendAndQueueSendThreadMessageResult {
-  let threadBecameActive = false;
+  let activeThread: Thread | null = null;
   const request = db.transaction(
     (tx) => {
       beforeAppendInTransaction?.({ tx });
@@ -373,14 +377,14 @@ function appendAndQueueSendThreadMessageInTransaction({
         requestEventSequence: appended.sequence,
         tx,
       });
-      threadBecameActive = queueResult.threadBecameActive;
+      activeThread = queueResult.activeThread;
       return appended;
     },
     { behavior: "immediate" },
   );
   return {
+    activeThread,
     request,
-    threadBecameActive,
   };
 }
 
@@ -571,15 +575,16 @@ export async function sendThreadMessage(
           currentThread?.status === "error" ||
           currentThread?.status === "idle"
         ) {
-          requireThreadLifecycleEventApplied(
-            applyLoggedThreadLifecycleEventInTransaction(
-              { db: tx, logger: deps.logger },
-              { event: { type: "run.started" }, threadId: thread.id },
+          return {
+            activeThread: requireThreadLifecycleEventApplied(
+              applyLoggedThreadLifecycleEventInTransaction(
+                { db: tx, logger: deps.logger },
+                { event: { type: "run.started" }, threadId: thread.id },
+              ),
             ),
-          );
-          return { threadBecameActive: true };
+          };
         }
-        return { threadBecameActive: false };
+        return { activeThread: null };
       },
       requestId,
       senderThreadId,
@@ -605,10 +610,12 @@ export async function sendThreadMessage(
         );
       },
     });
-    if (queuedRequest.threadBecameActive) {
-      deps.hub.notifyThread(thread.id, ["status-changed"], {
-        projectId: thread.projectId,
-      });
+    if (queuedRequest.activeThread) {
+      deps.hub.notifyThread(
+        thread.id,
+        ["status-changed"],
+        buildThreadStatusChangeMetadata(deps, queuedRequest.activeThread),
+      );
     }
     if (shouldCaptureUserMessageSent) {
       captureUserMessageSentTelemetry(deps, thread);
@@ -650,7 +657,7 @@ export async function sendThreadMessage(
     input,
     inputGroups,
     queueInTransaction: () => {
-      return { threadBecameActive: false };
+      return { activeThread: null };
     },
     requestId,
     senderThreadId,

--- a/apps/server/test/services/plugins/heroes.test.ts
+++ b/apps/server/test/services/plugins/heroes.test.ts
@@ -283,6 +283,7 @@ describe("hero plugin: slack-bot", () => {
         db: server.db,
         hub: server.hub,
         logger: testLogger,
+        providerRegistry: server.deps.providerRegistry,
       };
       applyLoggedThreadLifecycleEvent(lifecycleDeps, {
         threadId: threadId as string,

--- a/apps/server/test/services/plugins/plugin-thread-events.test.ts
+++ b/apps/server/test/services/plugins/plugin-thread-events.test.ts
@@ -67,7 +67,12 @@ async function setUpPluginHarness(serverSource: string): Promise<{
 }
 
 function lifecycleDeps(harness: TestAppHarness) {
-  return { db: harness.db, hub: harness.hub, logger: testLogger };
+  return {
+    db: harness.db,
+    hub: harness.hub,
+    logger: testLogger,
+    providerRegistry: harness.deps.providerRegistry,
+  };
 }
 
 describe("plugin thread lifecycle events", () => {

--- a/apps/server/test/services/threads/lifecycle-outcome.test.ts
+++ b/apps/server/test/services/threads/lifecycle-outcome.test.ts
@@ -1,0 +1,282 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  appendStoredThreadEvent,
+  createConnection,
+  createEnvironment,
+  createProject,
+  createThread,
+  getThread,
+  migrate,
+  noopNotifier,
+  openSession,
+  upsertHost,
+  type DbConnection,
+} from "@bb/db";
+import {
+  changedMessageSchema,
+  formatClientTurnRequestIdSuffix,
+  threadScope,
+  turnScope,
+  type PromptInput,
+  type ThreadChangedMessage,
+  type ThreadStatus,
+} from "@bb/domain";
+import { applyLoggedThreadLifecycleEvent } from "../../../src/services/threads/lifecycle-outcome.js";
+import { NotificationHub } from "../../../src/ws/hub.js";
+import { createMockHubSocket } from "../../helpers/mock-hub-socket.js";
+import { createTestProviderRegistry } from "../../helpers/provider-registry.js";
+import { testLogger } from "../../helpers/test-app.js";
+
+// Plan-mode activity is gated on the provider's declared plan command, so the
+// broadcast needs the real first-party declarations.
+const providerRegistry = await createTestProviderRegistry();
+
+const NO_ACTIVITY = {
+  activeBackgroundAgentCount: 0,
+  activeBackgroundCommandCount: 0,
+  activeGoalCount: 0,
+  activePlanModeCount: 0,
+  activeWorkflowCount: 0,
+};
+
+const planPromptInput: PromptInput[] = [
+  {
+    type: "text",
+    text: "/plan inspect the failing command",
+    mentions: [
+      {
+        start: 0,
+        end: 5,
+        resource: {
+          kind: "command",
+          trigger: "/",
+          name: "plan",
+          source: "command",
+          origin: "user",
+          label: "plan",
+          argumentHint: null,
+        },
+      },
+    ],
+  },
+];
+
+/** Records an accepted, still-open plan turn and an active goal for the thread. */
+function seedOpenPlanTurnWithGoal(db: DbConnection, threadId: string): void {
+  const requestId = formatClientTurnRequestIdSuffix({ suffix: "23456789ab" });
+  appendStoredThreadEvent(db, noopNotifier, {
+    threadId,
+    scope: threadScope(),
+    type: "client/turn/requested",
+    data: {
+      direction: "outbound",
+      source: "tell",
+      initiator: "user",
+      senderThreadId: null,
+      requestId,
+      input: planPromptInput,
+      target: { kind: "new-turn" },
+      request: { method: "turn/start", params: {} },
+      execution: {
+        model: "gpt-5",
+        reasoningLevel: "medium",
+        permissionMode: "workspace-write",
+        source: "client/turn/requested",
+        serviceTier: "default",
+      },
+    },
+  });
+  appendStoredThreadEvent(db, noopNotifier, {
+    threadId,
+    scope: turnScope("turn-plan"),
+    providerThreadId: "provider-plan",
+    type: "turn/input/accepted",
+    data: { providerThreadId: "provider-plan", clientRequestId: requestId },
+  });
+  appendStoredThreadEvent(db, noopNotifier, {
+    threadId,
+    scope: threadScope(),
+    providerThreadId: "provider-plan",
+    type: "thread/goal/updated",
+    data: {
+      providerThreadId: "provider-plan",
+      objective: "Finish the sidebar activity indicator",
+      status: "active",
+      tokenBudget: null,
+      tokensUsed: 64,
+      timeUsedSeconds: 5,
+    },
+  });
+}
+
+interface Setup {
+  db: DbConnection;
+  hostId: string;
+  hub: NotificationHub;
+  threadId: string;
+  projectId: string;
+}
+
+function setup(status: ThreadStatus): Setup {
+  const db = createConnection(":memory:");
+  migrate(db);
+  const hub = new NotificationHub();
+  const host = upsertHost(db, noopNotifier, {
+    id: "host-lifecycle-outcome",
+    name: "Lifecycle Outcome Host",
+    type: "persistent",
+  });
+  const { project } = createProject(db, noopNotifier, {
+    name: "Lifecycle Outcome Project",
+    source: { type: "local_path", hostId: host.id, path: "/tmp/lifecycle" },
+  });
+  const environment = createEnvironment(db, noopNotifier, {
+    hostId: host.id,
+    projectId: project.id,
+    workspaceProvisionType: "unmanaged",
+    path: "/tmp/lifecycle/env",
+    status: "ready",
+  });
+  const thread = createThread(db, noopNotifier, {
+    projectId: project.id,
+    environmentId: environment.id,
+    providerId: "codex",
+    status,
+  });
+  return {
+    db,
+    hostId: host.id,
+    hub,
+    projectId: project.id,
+    threadId: thread.id,
+  };
+}
+
+function connectDaemon(db: DbConnection, hub: NotificationHub, hostId: string) {
+  const session = openSession(db, {
+    hostId,
+    instanceId: `instance-${randomUUID()}`,
+    hostName: "Lifecycle Outcome Host",
+    hostType: "persistent",
+    dataDir: `/tmp/${hostId}`,
+    protocolVersion: 1,
+    heartbeatIntervalMs: 5_000,
+    leaseTimeoutMs: 30_000,
+  });
+  hub.registerDaemon(session.id, hostId, { close() {}, send() {} });
+}
+
+function lastThreadListMessage(
+  messages: readonly string[],
+): ThreadChangedMessage {
+  const last = messages.at(-1);
+  if (last === undefined) {
+    throw new Error("no realtime message was broadcast");
+  }
+  const message = changedMessageSchema.parse(JSON.parse(last));
+  if (message.entity !== "thread") {
+    throw new Error(`expected a thread message, got ${message.entity}`);
+  }
+  return message;
+}
+
+describe("applyLoggedThreadLifecycleEvent", () => {
+  it("broadcasts status-changed with the post-transition row and runtime", () => {
+    const { db, hostId, hub, projectId, threadId } = setup("idle");
+    connectDaemon(db, hub, hostId);
+    const socket = createMockHubSocket();
+    hub.subscribe(socket, { kind: "thread-list" });
+
+    const outcome = applyLoggedThreadLifecycleEvent(
+      { db, hub, logger: testLogger, providerRegistry },
+      { event: { type: "run.started" }, threadId },
+    );
+
+    expect(outcome.applied).toBe(true);
+    const row = getThread(db, threadId);
+    expect(row?.status).toBe("active");
+    expect(socket.messages).toHaveLength(1);
+    expect(lastThreadListMessage(socket.messages)).toEqual({
+      type: "changed",
+      entity: "thread",
+      id: threadId,
+      metadata: {
+        projectId,
+        statusChange: {
+          status: "active",
+          runtime: {
+            displayStatus: "active",
+            hostReconnectGraceExpiresAt: null,
+          },
+          activity: NO_ACTIVITY,
+          latestAttentionAt: row?.latestAttentionAt,
+          updatedAt: row?.updatedAt,
+        },
+      },
+      changes: ["status-changed"],
+    });
+  });
+
+  it("reports the host-derived runtime when the thread activates without a connected daemon", () => {
+    const { db, hub, threadId } = setup("idle");
+    const socket = createMockHubSocket();
+    hub.subscribe(socket, { kind: "thread-list" });
+
+    applyLoggedThreadLifecycleEvent(
+      { db, hub, logger: testLogger, providerRegistry },
+      { event: { type: "run.started" }, threadId },
+    );
+
+    expect(
+      lastThreadListMessage(socket.messages).metadata?.statusChange?.runtime
+        .displayStatus,
+    ).toBe("waiting-for-host");
+  });
+
+  it("carries the status-gated plan and goal activity of the post-transition row", () => {
+    // The sidebar's plan-mode and goal indicators come from this activity
+    // and nothing else pushes them to list rows: without it the patch would
+    // leave a finished plan turn's indicator lit until some unrelated refetch.
+    const { db, hostId, hub, threadId } = setup("idle");
+    connectDaemon(db, hub, hostId);
+    seedOpenPlanTurnWithGoal(db, threadId);
+    const socket = createMockHubSocket();
+    hub.subscribe(socket, { kind: "thread-list" });
+
+    applyLoggedThreadLifecycleEvent(
+      { db, hub, logger: testLogger, providerRegistry },
+      { event: { type: "run.started" }, threadId },
+    );
+    expect(
+      lastThreadListMessage(socket.messages).metadata?.statusChange?.activity,
+    ).toEqual({ ...NO_ACTIVITY, activeGoalCount: 1, activePlanModeCount: 1 });
+
+    applyLoggedThreadLifecycleEvent(
+      { db, hub, logger: testLogger, providerRegistry },
+      { event: { type: "run.succeeded" }, threadId },
+    );
+    // Plan mode is gated on an active thread; the goal outlives the turn.
+    expect(
+      lastThreadListMessage(socket.messages).metadata?.statusChange,
+    ).toMatchObject({
+      status: "idle",
+      activity: { ...NO_ACTIVITY, activeGoalCount: 1, activePlanModeCount: 0 },
+    });
+  });
+
+  it("does not broadcast when the event is not applied", () => {
+    const { db, hub, threadId } = setup("idle");
+    const socket = createMockHubSocket();
+    hub.subscribe(socket, { kind: "thread-list" });
+
+    const outcome = applyLoggedThreadLifecycleEvent(
+      { db, hub, logger: testLogger, providerRegistry },
+      // idle has no run.succeeded cell.
+      { event: { type: "run.succeeded" }, threadId },
+    );
+
+    expect(outcome.applied).toBe(false);
+    expect(socket.messages).toHaveLength(0);
+  });
+});

--- a/packages/db/src/data/threads.ts
+++ b/packages/db/src/data/threads.ts
@@ -2001,22 +2001,16 @@ export function applyThreadLifecycleEventInTransaction(
  * event against THREAD_LIFECYCLE and its supersession predicates, and applies
  * the transition with a status compare-and-set — all in one transaction.
  * Never throws on stale or illegal events; returns a typed outcome for the
- * caller to log. Use applyThreadLifecycleEventInTransaction from inside an
- * existing transaction (the caller then owns notification).
+ * caller to log. The caller owns the `status-changed` notification: its
+ * metadata carries the post-transition runtime, which only the server can
+ * resolve (host connectivity lives outside the database).
  */
 export function applyThreadLifecycleEvent(
   db: DbConnection,
-  notifier: DbNotifier,
   args: ApplyThreadLifecycleEventArgs,
 ): ApplyThreadLifecycleEventOutcome {
-  const outcome = db.transaction(
+  return db.transaction(
     (tx) => applyThreadLifecycleEventInTransaction(tx, args),
     { behavior: "immediate" },
   );
-  if (outcome.applied) {
-    notifier.notifyThread(args.threadId, ["status-changed"], {
-      projectId: outcome.thread.projectId,
-    });
-  }
-  return outcome;
 }

--- a/packages/db/test/data/environment-lifecycle.test.ts
+++ b/packages/db/test/data/environment-lifecycle.test.ts
@@ -286,7 +286,7 @@ describe("applyEnvironmentLifecycleEvent", () => {
 
     // A stopping thread blocks the claim even after deletion intent.
     requireThreadLifecycleEventApplied(
-      applyThreadLifecycleEvent(db, noopNotifier, {
+      applyThreadLifecycleEvent(db, {
         event: { type: "stop.requested" },
         threadId: thread.id,
       }),

--- a/packages/db/test/data/thread-lifecycle.test.ts
+++ b/packages/db/test/data/thread-lifecycle.test.ts
@@ -4,7 +4,6 @@ import { createConnection } from "../../src/connection.js";
 import type { DbTransaction } from "../../src/connection.js";
 import { migrate } from "../../src/migrate.js";
 import { noopNotifier } from "../../src/notifier.js";
-import type { DbNotifier } from "../../src/notifier.js";
 import { threads } from "../../src/schema.js";
 import {
   applyThreadLifecycleEvent,
@@ -33,27 +32,16 @@ function setup() {
   return { db, host, project };
 }
 
-function spyNotifier(): DbNotifier {
-  return {
-    notifyThread: vi.fn(),
-    notifyEnvironment: vi.fn(),
-    notifyHost: vi.fn(),
-    notifyProject: vi.fn(),
-    notifySystem: vi.fn(),
-  };
-}
-
 describe("applyThreadLifecycleEvent", () => {
-  it("applies a legal event, persists the row, and notifies", () => {
+  it("applies a legal event and persists the row", () => {
     const { db, project } = setup();
-    const spy = spyNotifier();
     const thread = createThread(db, noopNotifier, {
       projectId: project.id,
       providerId: "codex",
       status: "starting",
     });
 
-    const outcome = applyThreadLifecycleEvent(db, spy, {
+    const outcome = applyThreadLifecycleEvent(db, {
       event: { type: "run.started" },
       threadId: thread.id,
     });
@@ -63,11 +51,6 @@ describe("applyThreadLifecycleEvent", () => {
       expect(outcome.thread.status).toBe("active");
     }
     expect(getThread(db, thread.id)?.status).toBe("active");
-    expect(spy.notifyThread).toHaveBeenCalledExactlyOnceWith(
-      thread.id,
-      ["status-changed"],
-      { projectId: project.id },
-    );
   });
 
   it("applies events inside an existing transaction", () => {
@@ -94,7 +77,6 @@ describe("applyThreadLifecycleEvent", () => {
     try {
       vi.setSystemTime(1_000);
       const { db, project } = setup();
-      const spy = spyNotifier();
       const thread = createThread(db, noopNotifier, {
         projectId: project.id,
         providerId: "codex",
@@ -103,7 +85,7 @@ describe("applyThreadLifecycleEvent", () => {
 
       vi.setSystemTime(2_000);
       // idle has no run.succeeded cell.
-      const outcome = applyThreadLifecycleEvent(db, spy, {
+      const outcome = applyThreadLifecycleEvent(db, {
         event: { type: "run.succeeded" },
         threadId: thread.id,
       });
@@ -114,7 +96,6 @@ describe("applyThreadLifecycleEvent", () => {
         reason: "illegal-transition",
       });
       expect(getThread(db, thread.id)).toEqual(thread);
-      expect(spy.notifyThread).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }
@@ -122,7 +103,6 @@ describe("applyThreadLifecycleEvent", () => {
 
   it("no-ops as superseded when the thread is deleted", () => {
     const { db, project } = setup();
-    const spy = spyNotifier();
     const thread = createThread(db, noopNotifier, {
       projectId: project.id,
       providerId: "codex",
@@ -131,7 +111,7 @@ describe("applyThreadLifecycleEvent", () => {
     markThreadDeleted(db, noopNotifier, { threadId: thread.id });
     const beforeRow = getThread(db, thread.id);
 
-    const outcome = applyThreadLifecycleEvent(db, spy, {
+    const outcome = applyThreadLifecycleEvent(db, {
       event: { type: "run.started" },
       threadId: thread.id,
     });
@@ -142,7 +122,6 @@ describe("applyThreadLifecycleEvent", () => {
       reason: "superseded",
     });
     expect(getThread(db, thread.id)).toEqual(beforeRow);
-    expect(spy.notifyThread).not.toHaveBeenCalled();
   });
 
   it("refuses to reactivate a stopping thread and settles it to idle", () => {
@@ -155,7 +134,7 @@ describe("applyThreadLifecycleEvent", () => {
 
     // Enter the stopping phase via the stop.requested event.
     const stopping = requireThreadLifecycleEventApplied(
-      applyThreadLifecycleEvent(db, noopNotifier, {
+      applyThreadLifecycleEvent(db, {
         event: { type: "stop.requested" },
         threadId: thread.id,
       }),
@@ -165,7 +144,7 @@ describe("applyThreadLifecycleEvent", () => {
 
     // A stopping thread structurally accepts no "begin new work" event. This
     // is the replacement for the old notStopRequested supersession guard.
-    const outcome = applyThreadLifecycleEvent(db, noopNotifier, {
+    const outcome = applyThreadLifecycleEvent(db, {
       event: { type: "run.started" },
       threadId: thread.id,
     });
@@ -178,7 +157,7 @@ describe("applyThreadLifecycleEvent", () => {
 
     // The stop landing settles the thread to idle.
     const settled = requireThreadLifecycleEventApplied(
-      applyThreadLifecycleEvent(db, noopNotifier, {
+      applyThreadLifecycleEvent(db, {
         event: { type: "stop.settled" },
         threadId: thread.id,
       }),
@@ -188,7 +167,7 @@ describe("applyThreadLifecycleEvent", () => {
 
   it("no-ops as not-found for a missing thread", () => {
     const { db } = setup();
-    const outcome = applyThreadLifecycleEvent(db, noopNotifier, {
+    const outcome = applyThreadLifecycleEvent(db, {
       event: { type: "run.started" },
       threadId: "thr_nonexistent",
     });
@@ -207,11 +186,11 @@ describe("applyThreadLifecycleEvent", () => {
       status: "starting",
     });
 
-    const first = applyThreadLifecycleEvent(db, noopNotifier, {
+    const first = applyThreadLifecycleEvent(db, {
       event: { type: "run.started" },
       threadId: thread.id,
     });
-    const second = applyThreadLifecycleEvent(db, noopNotifier, {
+    const second = applyThreadLifecycleEvent(db, {
       event: { type: "run.started" },
       threadId: thread.id,
     });
@@ -313,7 +292,7 @@ describe("applyThreadLifecycleEvent", () => {
 
         now += 1_000;
         vi.setSystemTime(now);
-        const outcome = applyThreadLifecycleEvent(db, noopNotifier, {
+        const outcome = applyThreadLifecycleEvent(db, {
           event: testCase.event,
           threadId: thread.id,
         });
@@ -344,7 +323,7 @@ describe("requireThreadLifecycleEventApplied", () => {
     });
 
     const updated = requireThreadLifecycleEventApplied(
-      applyThreadLifecycleEvent(db, noopNotifier, {
+      applyThreadLifecycleEvent(db, {
         event: { type: "run.started" },
         threadId: thread.id,
       }),
@@ -360,7 +339,7 @@ describe("requireThreadLifecycleEventApplied", () => {
       status: "idle",
     });
 
-    const outcome = applyThreadLifecycleEvent(db, noopNotifier, {
+    const outcome = applyThreadLifecycleEvent(db, {
       event: { type: "run.succeeded" },
       threadId: thread.id,
     });

--- a/packages/db/test/data/threads.test.ts
+++ b/packages/db/test/data/threads.test.ts
@@ -1275,7 +1275,7 @@ describe("threads", () => {
     });
 
     const stopping = requireThreadLifecycleEventApplied(
-      applyThreadLifecycleEvent(db, noopNotifier, {
+      applyThreadLifecycleEvent(db, {
         event: { type: "stop.requested" },
         threadId: thread.id,
       }),
@@ -1284,7 +1284,7 @@ describe("threads", () => {
     expect(getThread(db, thread.id)?.status).toBe("stopping");
 
     const settled = requireThreadLifecycleEventApplied(
-      applyThreadLifecycleEvent(db, noopNotifier, {
+      applyThreadLifecycleEvent(db, {
         event: { type: "stop.settled" },
         threadId: thread.id,
       }),
@@ -1415,7 +1415,7 @@ describe("threads", () => {
       providerId: "codex",
     });
     requireThreadLifecycleEventApplied(
-      applyThreadLifecycleEvent(db, noopNotifier, {
+      applyThreadLifecycleEvent(db, {
         event: { type: "stop.requested" },
         threadId: stoppingThread.id,
       }),
@@ -1505,7 +1505,7 @@ describe("thread lifecycle transitions and read state", () => {
 
       vi.setSystemTime(2_000);
       const idleThread = requireThreadLifecycleEventApplied(
-        applyThreadLifecycleEvent(db, noopNotifier, {
+        applyThreadLifecycleEvent(db, {
           event: { type: "run.succeeded" },
           threadId: activeThread.id,
         }),
@@ -1520,7 +1520,7 @@ describe("thread lifecycle transitions and read state", () => {
       });
       vi.setSystemTime(3_000);
       const activeAgainThread = requireThreadLifecycleEventApplied(
-        applyThreadLifecycleEvent(db, noopNotifier, {
+        applyThreadLifecycleEvent(db, {
           event: { type: "run.started" },
           threadId: activeThread.id,
         }),
@@ -1555,7 +1555,7 @@ describe("thread lifecycle transitions and read state", () => {
 
       vi.setSystemTime(2_000);
       const idleThread = requireThreadLifecycleEventApplied(
-        applyThreadLifecycleEvent(db, noopNotifier, {
+        applyThreadLifecycleEvent(db, {
           event: { type: "run.succeeded" },
           threadId: childThread.id,
         }),
@@ -1586,7 +1586,7 @@ describe("thread lifecycle transitions and read state", () => {
 
       vi.setSystemTime(2_000);
       const erroredThread = requireThreadLifecycleEventApplied(
-        applyThreadLifecycleEvent(db, noopNotifier, {
+        applyThreadLifecycleEvent(db, {
           event: { type: "run.failed" },
           threadId: stoppingThread.id,
         }),

--- a/packages/domain/src/change-kinds.ts
+++ b/packages/domain/src/change-kinds.ts
@@ -4,6 +4,11 @@ import {
   threadEventTypeValues,
   type ThreadEventType,
 } from "./provider-event.js";
+import {
+  threadActivityStateSchema,
+  threadRuntimeStateSchema,
+  threadStatusSchema,
+} from "./thread.js";
 
 export const THREAD_CHANGE_KINDS = [
   "thread-created",
@@ -194,12 +199,35 @@ export function realtimeSubscriptionTargetKey(
   }
 }
 
+/**
+ * The thread list row fields a lifecycle transition rewrites, carried on a
+ * `status-changed` notification so clients patch the cached row instead of
+ * refetching every thread list (the sidebar bootstrap is ~1 KB per thread).
+ * `activity` is included because the plan-mode and goal counts are gated on
+ * the thread status server-side and nothing else pushes them to list rows.
+ * Producers that cannot resolve the post-transition runtime omit the whole
+ * field; clients then fall back to refetching.
+ */
+export const threadStatusChangeMetadataSchema = z
+  .object({
+    status: threadStatusSchema,
+    runtime: threadRuntimeStateSchema,
+    activity: threadActivityStateSchema,
+    latestAttentionAt: z.number(),
+    updatedAt: z.number(),
+  })
+  .strict();
+export type ThreadStatusChangeMetadata = z.infer<
+  typeof threadStatusChangeMetadataSchema
+>;
+
 export const threadChangeMetadataSchema = z
   .object({
     backgroundActivityChanged: z.boolean().optional(),
     eventTypes: z.array(threadEventTypeSchema).readonly().optional(),
     hasPendingInteraction: z.boolean().optional(),
     projectId: z.string().optional(),
+    statusChange: threadStatusChangeMetadataSchema.optional(),
   })
   .strict();
 export type ThreadChangeMetadata = z.infer<typeof threadChangeMetadataSchema>;
@@ -308,6 +336,10 @@ const threadChangeMetadataLenientSchema = z.object({
     .optional(),
   hasPendingInteraction: z.boolean().optional(),
   projectId: z.string().optional(),
+  // A newer server may emit a status or runtime display value this client
+  // does not know. Dropping just this field keeps the message and makes the
+  // client fall back to a refetch for the row.
+  statusChange: threadStatusChangeMetadataSchema.optional().catch(undefined),
 });
 
 const threadChangedMessageLenientSchema = z.object({

--- a/packages/domain/src/thread.ts
+++ b/packages/domain/src/thread.ts
@@ -31,13 +31,13 @@ export type ThreadRuntimeDisplayStatus = z.infer<
   typeof threadRuntimeDisplayStatusSchema
 >;
 
-const threadRuntimeStateSchema = z.object({
+export const threadRuntimeStateSchema = z.object({
   displayStatus: threadRuntimeDisplayStatusSchema,
   hostReconnectGraceExpiresAt: z.number().nullable(),
 });
 export type ThreadRuntimeState = z.infer<typeof threadRuntimeStateSchema>;
 
-const threadActivityStateSchema = z.object({
+export const threadActivityStateSchema = z.object({
   activeWorkflowCount: z.number().int().nonnegative(),
   activeBackgroundAgentCount: z.number().int().nonnegative(),
   activeBackgroundCommandCount: z.number().int().nonnegative(),

--- a/packages/domain/test/change-kinds.test.ts
+++ b/packages/domain/test/change-kinds.test.ts
@@ -38,6 +38,19 @@ const maximalThreadMetadata: ThreadChangeMetadata = {
   eventTypes: [...threadEventTypeValues],
   hasPendingInteraction: true,
   projectId: "proj_1",
+  statusChange: {
+    status: "active",
+    runtime: { displayStatus: "active", hostReconnectGraceExpiresAt: null },
+    activity: {
+      activeBackgroundAgentCount: 1,
+      activeBackgroundCommandCount: 1,
+      activeGoalCount: 1,
+      activePlanModeCount: 1,
+      activeWorkflowCount: 1,
+    },
+    latestAttentionAt: 1_000,
+    updatedAt: 2_000,
+  },
 };
 
 /**
@@ -113,6 +126,44 @@ describe("lenient changed-message schema parity", () => {
       expect(changedMessageLenientSchema.parse(message)).toEqual(message);
     },
   );
+
+  it("drops a status change a stale client cannot parse but keeps the message", () => {
+    // A newer server may ship a runtime display status this client does not
+    // know. The client must still learn that the status changed (and refetch)
+    // rather than lose the whole notification.
+    const parsed = changedMessageLenientSchema.parse({
+      type: "changed",
+      entity: "thread",
+      id: "thr_1",
+      metadata: {
+        projectId: "proj_1",
+        statusChange: {
+          status: "active",
+          runtime: {
+            displayStatus: "teleporting",
+            hostReconnectGraceExpiresAt: null,
+          },
+          activity: {
+            activeBackgroundAgentCount: 0,
+            activeBackgroundCommandCount: 0,
+            activeGoalCount: 0,
+            activePlanModeCount: 0,
+            activeWorkflowCount: 0,
+          },
+          latestAttentionAt: 1_000,
+          updatedAt: 2_000,
+        },
+      },
+      changes: ["status-changed"],
+    });
+    expect(parsed).toEqual({
+      type: "changed",
+      entity: "thread",
+      id: "thr_1",
+      metadata: { projectId: "proj_1" },
+      changes: ["status-changed"],
+    });
+  });
 
   it("keeps the maximal fixtures covering every declared strict field", () => {
     const strictOptions = strictOptionsByEntity();

--- a/tests/integration/fake/recovery/idle-error-reconciliation.test.ts
+++ b/tests/integration/fake/recovery/idle-error-reconciliation.test.ts
@@ -45,13 +45,13 @@ describe.sequential(
         );
 
         requireThreadLifecycleEventApplied(
-          applyThreadLifecycleEvent(harness.db, harness.hub, {
+          applyThreadLifecycleEvent(harness.db, {
             event: { type: "run.started" },
             threadId: thread.id,
           }),
         );
         requireThreadLifecycleEventApplied(
-          applyThreadLifecycleEvent(harness.db, harness.hub, {
+          applyThreadLifecycleEvent(harness.db, {
             event: { type: "run.failed" },
             threadId: thread.id,
           }),


### PR DESCRIPTION
## What was wrong

Every thread lifecycle transition broadcast `status-changed` as a bare dirty flag (metadata carried at most `projectId`). The app's registry rule for it (`dirtyActiveThreadListQueries`, flush `immediate`) invalidated the single `sidebarNavigation` query plus every cached thread list for the project. The sidebar query is always active (`AppLayout` observes it with `staleTime: Infinity`), so each push re-downloaded the whole `GET /api/v1/sidebar-bootstrap` document: about 1 KB per unarchived thread, 134 KB on the seeded database, twice per turn (turn start, turn end), for every thread that runs a turn. Nothing in the push let the client patch the one row that changed. Issue: #1302. Report: https://get-bb.github.io/reports/issues/1302.html

## What changed

Server-to-app realtime contract (no daemon change; the host daemon does not consume thread change notifications, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged):

- `packages/domain/src/change-kinds.ts`: `threadChangeMetadataSchema` gains optional `statusChange: { status, runtime, activity, latestAttentionAt, updatedAt }` (the list-row fields a lifecycle transition rewrites). The lenient inbound twin parses it with `.catch(undefined)` so a client that does not know a future status or runtime value drops just that field and falls back to a refetch. `threadRuntimeStateSchema` and `threadActivityStateSchema` are now exported from `thread.ts`.
- `apps/server/src/services/threads/thread-runtime-display.ts`: `buildThreadStatusChangeMetadata(deps, thread)` builds the metadata in one place. Runtime is resolved from host connectivity the same way list rows do. Activity (background task counts plus the plan-mode and goal counts) is built by the new `buildThreadActivityStateByThreadId`, which `toThreadListEntryResponses` now also uses, so a pushed row and a fetched row cannot disagree. The builder therefore takes the prompt-banner deps (`db`, `hub`, `providerRegistry`); every caller already had them through `AppDeps`/`WorkSessionDeps` (`failThreadProvisioning` and `applyTurnCompletedEvent` widen their `Pick`).
- `packages/db/src/data/threads.ts`: `applyThreadLifecycleEvent(db, args)` no longer takes a notifier or notifies. The db package cannot resolve the runtime (host connectivity lives in the hub), so the server wrapper `applyLoggedThreadLifecycleEvent` (`lifecycle-outcome.ts`) now owns the `status-changed` push and attaches the metadata. This covers turn start (`run.started` from the daemon's `turn/started`), turn end (`turn/completed`), provisioning, reconciliation and failure paths.
- `thread-send.ts`, `queued-messages.ts`, `parent-system-messages.ts`: the three post-commit producers that activate a thread now carry the activated row out of the transaction (`activeThread: Thread | null` replaces `threadBecameActive: boolean`) and attach the metadata. `queued-messages.ts` also drops a redundant `status-changed` notify that fired inside the transaction, before commit; the post-commit notify on the next line already sent the same kind.
- `packages/domain/src/plugin-sdk-version.ts` + `packages/plugin-sdk/package.json`: no longer changed by this PR. The new `statusChange` field does change the SDK's bundled types and `dist/provider-bridge.js`, so the npm version guard (`check-npm-version-guard.mjs`) needs an unpublished version. `main` has since moved the SDK to `0.4.13`, which npm has not published (npm latest is `0.4.12`), so this PR adopts `main`'s version and the guard passes without a further bump.
- In-transaction writers whose hub is a `NotificationBuffer` (stop requested, command failure, thread-start success, finalize, host-wide interruption, environment cleanup, host reconnect fan-out) still send the bare kind. The client falls back to today's refetch for those; they are not on the per-turn hot path.
- `apps/app`: `realtime-cache-effects.ts` merges `statusChange` into the dirty context. A `status-changed` message is last-writer-wins for it: a later message that carries no row snapshot replaces (drops) an earlier one merged while the document was hidden, so the resume flush refetches instead of patching the row to the earlier, now-stale status. `realtime-cache-registry.ts` replaces `dirtyActiveThreadListQueries` in the `status-changed` rule with `patchThreadListStatusState`: with metadata it writes the five fields into every cached thread list row and the sidebar bootstrap (`updateCachedThreadListStatusState` in `query-cache.ts`, same shape as the existing pending-interaction patch), invalidates only list/sidebar queries that have a fetch in flight (that fetch read the database before the transition and would overwrite the patch when it lands), and still dirties the search prefix. Without metadata it behaves exactly as before. Thread detail invalidation is unchanged (about 600 B when the thread is open).

Revision after review (two findings, both fixed here):

1. The first draft's patch left `ThreadListEntry.activity` stale. The plan-mode and goal counts are server-computed, gated on `status === "active"`, and were only synced by the list refetch the patch removed, so a finished plan turn kept its sidebar indicator lit. The push now carries the post-transition activity and the app patches it with the rest of the row.
2. The hidden-document merge kept an earlier `statusChange` when a later bare `status-changed` arrived (stop, command failure, interruption), so on resume the row was patched to `active` and never refetched. `statusChange` is now last-writer-wins per `status-changed` message.

Deviation from the report's proposal: the report suggested `status` + `runtime` only. `latestAttentionAt` and `updatedAt` are included because the lifecycle writer rewrites them and the sidebar sorts inactive rows by `latestAttentionAt`; `activity` for the reason above. The report's parts 2 (trim the bootstrap wire shape) and 3 (per-project sidebar keys) are not in this PR; with no refetch per turn, the payload size only matters on initial load and on membership changes.

Known, pre-existing: the sidebar learns that a plan turn is active only from a list row fetched after the provider's `turn/input/accepted` lands. The turn-start push (and on `main`, the turn-start refetch) is built at send time, before that event exists, and `events-appended` does not refetch lists, so the plan-mode glyph at turn start was already a race on `main`. This PR keeps that behavior and fixes the indicator turning off at turn end. Pushing an activity patch on the accepted/goal events is a separate follow-up.

## How you verified

Tests added:

- `apps/app/src/hooks/realtime-cache-effects.test.ts`: "patches cached thread list status from notification metadata instead of refetching the sidebar bootstrap". Fails on `origin/main` app sources with `AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times` (the sidebar query fn was refetched); passes after. The pushed `statusChange` in this test carries `activity.activePlanModeCount: 1` and the row assertion covers it. Also: "refetches thread lists for a status change that carries no row metadata" (guards the fallback), "restarts a sidebar fetch already in flight so its stale snapshot cannot overwrite the patched status", and (hidden document) "refetches when a bare status-changed follows one that carried the row". The last fails on the first draft's merge with `AssertionError: expected { activity: { …(5) }, …(5) } to be { activity: { …(5) }, …(5) } // Object.is equality` (the idle row had been replaced by the patched active row); passes after.
- `apps/server/test/services/threads/lifecycle-outcome.test.ts` (new): `applyLoggedThreadLifecycleEvent` broadcasts `status-changed` with `projectId` and the full `statusChange` (runtime `active` with a registered daemon, `waiting-for-host` without), nothing when the event is not applied, and "carries the status-gated plan and goal activity of the post-transition row": with an open accepted `/plan` turn and an active goal on record, `run.started` pushes `activePlanModeCount: 1, activeGoalCount: 1` and `run.succeeded` pushes `status: idle` with `activePlanModeCount: 0, activeGoalCount: 1`. On the first draft's server builder the broadcast is rejected by the strict schema (`ZodError: Invalid input: expected object, received undefined` for `activity`); on `main` the first assertion fails because the db notify carried only `projectId`.
- `packages/domain/test/change-kinds.test.ts`: maximal fixture extended (the parity guard requires it) plus "drops a status change a stale client cannot parse but keeps the message".
- `packages/db/test/data/thread-lifecycle.test.ts`: the notify assertion moved to the server test; call sites updated for the new signature (also `tests/integration/fake/recovery/idle-error-reconciliation.test.ts`, which polls the API and does not depend on the push; ran it, passes).

Commands (on the committed tree, rebased on current `origin/main`, `git status --porcelain` empty):

- `pnpm exec turbo run typecheck` (whole repo): `Tasks: 72 successful, 72 total`.
- `pnpm exec turbo run test --filter=@bb/domain --filter=@bb/db --filter=@bb/server --filter=@bb/app --continue`: `Tasks: 9 successful, 10 total`. domain 136 passed; db 405 passed; app 3160 passed (3 skipped); server 1825 passed, 2 failed: `test/internal/internal-skill-trees.test.ts` (`mode: 420` vs `436`, a local umask 0002 artifact unrelated to this change, passes with `umask 022`) and `test/services/plugins/plugin-update.test.ts` "waits one full interval" (`Test timed out in 5000ms` under the full parallel run; passes alone, 27/27).

Manual check on my dev instance (scratch project, one codex thread, a dedicated headless Chromium profile with a `window.fetch` logger installed after load, then `POST /api/v1/threads/:id/send` with a `/plan Reply only with ok.` command mention from the driving script, sampling the sidebar row's indicator labels every 100 ms):

- Before (report, same experiment with plain `tell`): 19 requests, 2 × `GET /api/v1/sidebar-bootstrap` at 134,865 B and 134,861 B (96% of bytes), plus child/fork list refetches at turn start and end.
- After: 10 requests, **0** `sidebar-bootstrap` calls, no thread list refetches; the turn traffic is the thread detail (588/584 B), timeline deltas, outline, prompt history, PR state and read receipt. The sidebar row showed `Thread working` 123 ms after the send and cleared it at turn end (2.3 s), from the pushed patch alone. At 1.5 s `GET /threads?projectId=` reported `status: active, activePlanModeCount: 1`; after the turn the row carried no stale plan indicator. Log saved at `/tmp/bb-fix-batch/issues/1302/revise-plan-turn-api-log.json`.

Fixes #1302

> AGENT GENERATED: by Claude Opus 5


## Independent verification

Verified round 2 at head `1e1e56ff7` (rebased on `origin/main` `c942421a4`; `git merge-base --is-ancestor origin/main HEAD` true, GitHub reports MERGEABLE) in a fresh worktree.

Commands:

- `git fetch origin main && git fetch origin bb/fix-1302-sidebar-bootstrap && git checkout -b verify-1302-r2 FETCH_HEAD`; `pnpm install --frozen-lockfile --prefer-offline`; `pnpm exec turbo run build`.
- Fail-before: `git checkout origin/main -- <13 non-test source files>` then `pnpm exec vitest run src/hooks/realtime-cache-effects.test.ts` (apps/app): 1 failed / 56 passed, `AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times` ("patches cached thread list status from notification metadata instead of refetching the sidebar bootstrap"). `pnpm exec vitest run test/services/threads/lifecycle-outcome.test.ts` (apps/server): 3 failed / 1 passed; the broadcast metadata was `{ projectId }` only (`- "statusChange": { … }` in the assertion diff), `expected undefined to be 'waiting-for-host'`, `expected undefined to deeply equal { activeGoalCount: 1, activePlanModeCount: 1, … }`.
- Revision check: with the first draft's `realtime-cache-effects.ts` (`fdfaec771`) checked out, `-t "bare status-changed follows"` fails with `AssertionError: expected { activity: { …(5) }, …(5) } to be { activity: { …(5) }, …(5) } // Object.is equality`.
- Pass-after (`git checkout HEAD -- …`, tree clean): app file 57/57, server file 4/4.
- `pnpm exec turbo run typecheck --filter=@bb/domain --filter=@bb/db --filter=@bb/server --filter=@bb/app --filter=@bb/integration-tests --filter=@bb/mobile --filter=@bb/sdk --filter=@bb/desktop`: `Tasks: 12 successful, 12 total`.
- `pnpm exec turbo run test --filter=@bb/domain --filter=@bb/db --filter=@bb/server --filter=@bb/app --continue`: domain 136, db 405, app 3160 (3 skipped) passed; server 1826 passed / 1 failed = `test/internal/internal-skill-trees.test.ts` (`mode: 420` vs `436`, the known local umask 0002 artifact; passes in CI).
- CI on the PR: all checks pass (Checks, Package Smoke x2, Tests app-1/2/3, integration, packages, server).

Repro on the fixed branch (own dev instance :18681/:26681/:34681, scratch project, one codex thread, headless Chromium with a `window.fetch` logger installed after load, `pnpm bb:dev thread tell <id> "Reply only with ok."` from the shell, 100 ms DOM poll of the sidebar row): three sends, each 9-10 API requests and **0** `GET /api/v1/sidebar-bootstrap` (report on main: 19 requests, 2 bootstrap downloads = 96% of bytes). The sidebar row showed `Thread working` about 100 ms after the send, `Unread thread succeeded` at turn end and cleared after the read receipt, all from the pushed patch. No longer reproduces.

Review notes: server-to-app contract only; the host daemon does not consume thread `changed` messages, so no `HOST_DAEMON_PROTOCOL_VERSION` bump is needed; every inbound consumer (app, mobile, desktop, sdk) uses the lenient schema; thread lists are ordered by pin/createdAt and not filtered on status, so patching cannot change membership; all `applyThreadLifecycleEvent` callers updated. Residual (documented in the body): in-transaction producers (stop, command failure, thread-start success, interruption, env cleanup, host reconnect) still push the bare kind and refetch the whole bootstrap; the plan-mode glyph at turn start stays a pre-existing race; the 138 KB payload shape and single sidebar key (report parts 2 and 3) are untouched, so a reviewer may prefer to keep #1302 open for the payload trim. Nit: `thread-runtime-display.ts` L268-270 is not prettier-formatted (CI does not enforce it).

> AGENT GENERATED: by Claude Opus 5


## Rebase

Rebased onto `origin/main` `75d6fc4d4` (was 32 commits behind at `c942421a4`) and squashed the two commits into one (`766f1928f`); the commit message keeps the original subject and body and folds in the revision-round notes (activity on the push, last-writer-wins merge). `git rebase` applied cleanly with no conflicts: none of the 32 commits on main touched the 23 files in this diff. The commits on main in the neighbouring areas (`apps/server/src/services/threads`, `packages/domain/src`, `apps/app/src/hooks`) are the provider v3 contract stack (#2124, #2136, #2148, #2164, #2179), the late tool-call completion fix (#2176) and the acp fork capability change (#2150); they do not touch the lifecycle writer, the thread change-kind schema, or the realtime cache registry, so the fix maps onto the new base unchanged. `origin/main` still has no `statusChange` in `change-kinds.ts` or `realtime-cache-registry.ts`.

Re-proved on the new base (committed tree, `git status --porcelain` empty):

- Fail-before: with the 13 non-test source files checked out from `origin/main`, `apps/app` `realtime-cache-effects.test.ts`: 1 failed / 56 passed, `AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times`; `apps/server` `lifecycle-outcome.test.ts`: 3 failed / 1 passed (`expected undefined to be 'waiting-for-host'`, `expected undefined to deeply equal { Object (activeBackgroundAgentCount, ...) }`). Pass-after: 57/57 and 4/4.
- `pnpm exec turbo run typecheck --filter=@bb/domain --filter=@bb/db --filter=@bb/server --filter=@bb/app --filter=@bb/integration-tests --filter=@bb/mobile --filter=@bb/sdk --filter=@bb/desktop --filter=@bb/host-daemon --filter=@bb/cli`: `Tasks: 14 successful, 14 total`.
- `pnpm exec turbo run test --filter=@bb/domain --filter=@bb/db --filter=@bb/server --filter=@bb/app --continue`: domain 27/27 files, db 28/28 files; server 1899 passed / 2 failed; app 3190 passed / 3 failed (3 skipped). The machine was under a load average of 40-70 from parallel agents: every app failure and the `plugin-update.test.ts` server failure were `Test timed out` in files unrelated to this change (different files on each of two runs), and each passes when rerun alone (135/135, 27/27). The one remaining server failure is `test/internal/internal-skill-trees.test.ts` (`mode: 420` vs `436`), the known local umask 0002 artifact that passes in CI.

> AGENT GENERATED: by Claude Opus 5




## Independent verification (guards)

Verified head `17746125f` (rebased onto `origin/main` `27d1017fe`; `git merge-base --is-ancestor origin/main HEAD` true; GitHub reports `MERGEABLE` / `CLEAN`) in a fresh worktree. Scope: confirm the post-verification change is only the CI-guard fix, re-prove fail-before/pass-after on the new head, confirm CI.

- Interdiff: `git diff 75d6fc4d4 766f1928f` (previously verified patch) vs `git diff origin/main 17746125f` differ by exactly two hunks: `packages/domain/src/plugin-sdk-version.ts` `PLUGIN_SDK_VERSION = "0.4.11"` → `"0.4.12"` and `packages/plugin-sdk/package.json` `"version": "0.4.11"` → `"0.4.12"`. No other line of the PR changed. `origin/main` and `npm view @get-bb/plugin-sdk version` are both `0.4.11`; `@get-bb/plugin-sdk@0.4.12` is 404 on npm, so the patch bump targets the next unpublished version. The commit keeps the original subject, body, and `Co-Authored-By` trailer.
- CI on `17746125f`: all checks pass (Checks, Package Smoke x2, Tests app-1/2/3, integration, packages, server, Version Lockstep x2; Node Compatibility Smoke and iOS simulator flows skipped by design). The `Check plugin SDK npm version guard` step logs `npm version guard: PASS — @get-bb/plugin-sdk@0.4.12 is not on npm yet. The publish job will ship this version.`
- Fail-before on the new head (`git checkout origin/main -- <15 non-test source files>`): `packages/domain` `change-kinds.test.ts` 2 failed / 6 passed (`ZodError` on the maximal strict `thread` fixture, `expected [ 'backgroundActivityChanged', …(4) ] to deeply equal [ …(3) ]`); `apps/server` `lifecycle-outcome.test.ts` 3 failed / 1 passed (assertion diff shows the broadcast `metadata` is `{ projectId }` only, `- "statusChange": { activity, latestAttentionAt, runtime, status, updatedAt }`); `apps/app` `realtime-cache-effects.test.ts` + `cache-owner-registry.test.ts` 2 failed / 59 passed (`AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times` at `realtime-cache-effects.test.ts:1905`).
- Pass-after (`git checkout HEAD -- …`, `git status --porcelain` empty): domain 8/8, server 4/4, app 61/61. `pnpm exec turbo run typecheck --filter=@bb/domain --filter=@get-bb/plugin-sdk`: `Tasks: 5 successful, 5 total`. `pnpm exec turbo run build`: `Tasks: 18 successful, 18 total`.
- Repro on the fixed branch: not re-run this round; the fix code is byte-identical to the head whose browser repro (0 `GET /api/v1/sidebar-bootstrap` per send) is recorded above.

Residual risks unchanged from the sections above. This PR no longer carries an SDK version change; `main`'s unpublished `0.4.13` covers it.


## Rebase (2026-08-21)

Rebased onto `main` at `d41d1abee`. Only `packages/domain/src/plugin-sdk-version.ts` and `packages/plugin-sdk/package.json` conflicted, because `main` moved the SDK from `0.4.12` to `0.4.13`. Both were resolved to `main`'s values, so the version files have dropped out of this PR's diff entirely (25 changed files -> 23). No other line of the fix changed.

Re-verified on the new base: `node packages/plugin-sdk/scripts/check-npm-version-guard.mjs` -> `PASS - @get-bb/plugin-sdk@0.4.13 is not on npm yet`. `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/server --filter=@bb/db --filter=@bb/domain --filter=@bb/integration-tests`: `Tasks: 9 successful, 9 total`. `pnpm exec turbo run test` for app/server/db/domain: domain 27/27 files, db 28/28, server pass; `@bb/app` reported one failure in `PromptBoxInternal.test.tsx > selection reveal`, which passes on its own re-run and touches no file in this PR (the app changes are confined to `src/hooks/cache-owners/`). Treated as load-dependent flake; CI is the arbiter.

> AGENT GENERATED: by Claude Opus 5

