### PR TITLE
Reject HEIC/HEIF attachment uploads with a reason

### DIFF
--- a/apps/app/src/components/thread/embedded-chat/useComposerAttachmentUploads.test.tsx
+++ b/apps/app/src/components/thread/embedded-chat/useComposerAttachmentUploads.test.tsx
@@ -4,6 +4,7 @@ import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { InlineQueuedMessageEditState } from "./useInlineQueuedMessageEditing";
 import type { PromptDraftAttachment } from "@bb/client-core";
+import { BbHttpError } from "@bb/sdk/browser";
 import { createDeferredPromise } from "@bb/test-helpers";
 import {
   useComposerAttachmentUploads,
@@ -144,6 +145,38 @@ describe("useComposerAttachmentUploads", () => {
     expect(result.current.isAttachingInlineFiles).toBe(false);
     expect(result.current.inlineAttachmentError).toBeNull();
     expect(commitInlineQueuedMessage).not.toHaveBeenCalled();
+  });
+
+  it("shows the server's reason when it refuses an upload", async () => {
+    const message =
+      "HEIC images are not supported. Convert the image to JPEG or PNG before attaching it.";
+    mocks.upload
+      .mockRejectedValueOnce(
+        new BbHttpError({
+          body: { code: "invalid_request", message },
+          code: "invalid_request",
+          message,
+          status: 400,
+        }),
+      )
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    const { result } = renderHook(() =>
+      useDraftAttachmentUploads({
+        projectId: "proj_1",
+        target: { key: "bottom", addAttachment: vi.fn() },
+      }),
+    );
+
+    await act(async () => {
+      await result.current.handleAttachFiles([
+        new File(["heic"], "IMG_0001.heic", { type: "image/heic" }),
+        new File(["png"], "shot.png", { type: "image/png" }),
+      ]);
+    });
+
+    expect(result.current.attachmentError).toBe(
+      `Failed to attach IMG_0001.heic, shot.png: ${message}`,
+    );
   });
 
   it("does not leak a dismissed upload into a later independent draft", async () => {

--- a/apps/app/src/components/thread/embedded-chat/useComposerAttachmentUploads.ts
+++ b/apps/app/src/components/thread/embedded-chat/useComposerAttachmentUploads.ts
@@ -1,5 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 import { useUploadPromptAttachment } from "@/hooks/mutations/project-mutations";
+import { getMutationErrorMessage } from "@/lib/mutation-errors";
+import { BbHttpError } from "@/lib/sdk";
 import type { PromptDraftAttachment } from "@bb/client-core";
 import type { InlineQueuedMessageEditState } from "./useInlineQueuedMessageEditing";
 
@@ -49,6 +51,26 @@ interface DraftAttachmentOperationState {
   targetKey: string | null;
 }
 
+/**
+ * The server states why it refused an upload (unsupported format, size
+ * limit); transport failures carry nothing a user can act on.
+ */
+function uploadRejectionReason(error: unknown): string | null {
+  return error instanceof BbHttpError
+    ? getMutationErrorMessage({ error, fallbackMessage: "Request failed" })
+    : null;
+}
+
+function attachFailureMessage(
+  failedFiles: readonly string[],
+  reason: string | null,
+): string {
+  const names = failedFiles.join(", ");
+  return reason === null
+    ? `Failed to attach: ${names}`
+    : `Failed to attach ${names}: ${reason}`;
+}
+
 /** Upload state for one independently mounted composer draft. */
 export function useDraftAttachmentUploads({
   projectId,
@@ -90,6 +112,7 @@ export function useDraftAttachmentUploads({
         targetKey: capturedTargetKey,
       }));
       const failedFiles: string[] = [];
+      let rejectionReason: string | null = null;
       try {
         for (const file of files) {
           try {
@@ -101,8 +124,9 @@ export function useDraftAttachmentUploads({
             if (currentTarget?.key === capturedTargetKey) {
               currentTarget.addAttachment(uploaded);
             }
-          } catch {
+          } catch (error) {
             failedFiles.push(file.name);
+            rejectionReason ??= uploadRejectionReason(error);
           }
         }
       } finally {
@@ -112,7 +136,7 @@ export function useDraftAttachmentUploads({
                 error:
                   failedFiles.length > 0 &&
                   targetRef.current?.key === capturedTargetKey
-                    ? `Failed to attach: ${failedFiles.join(", ")}`
+                    ? attachFailureMessage(failedFiles, rejectionReason)
                     : current.error,
                 pendingCount: Math.max(0, current.pendingCount - 1),
                 targetKey: capturedTargetKey,

--- a/apps/server/src/services/projects/attachments.ts
+++ b/apps/server/src/services/projects/attachments.ts
@@ -21,18 +21,20 @@ import { ApiError } from "../../errors.js";
 const IMAGE_LIMIT_BYTES = 10 * 1024 * 1024;
 const FILE_LIMIT_BYTES = 25 * 1024 * 1024;
 
-// HEIC/HEIF (the iPhone camera default) is stored and served verbatim, but
-// nothing downstream can decode it: Chromium (web app and Electron shell) has
-// no HEVC decoder, and no provider image input accepts it, so the composer
-// showed a broken thumbnail while the model silently received nothing. bb
-// ships no transcoder, so refuse the upload with a reason instead.
-const HEIF_MIME_TYPES = new Set([
+// HEIC/HEIF (the iPhone camera default) used to be stored and served verbatim
+// as a localImage, but nothing downstream can decode it: Chromium (web app and
+// Electron shell) has no HEVC decoder, and no provider image input accepts it,
+// so the composer showed a broken thumbnail while the model silently received
+// nothing. bb ships no transcoder, so refuse the image upload with a reason.
+// Only the image MIME types are refused: the same bytes sent with a non-image
+// MIME type still store as a plain localFile, which an agent can convert on
+// the host.
+const HEIF_IMAGE_MIME_TYPES = new Set([
   "image/heic",
   "image/heic-sequence",
   "image/heif",
   "image/heif-sequence",
 ]);
-const HEIF_EXTENSIONS = new Set([".heic", ".heif"]);
 
 type PromptAttachmentInput = Extract<
   PromptInput,
@@ -150,12 +152,9 @@ export async function validatePromptAttachmentReferences(
   }
 }
 
-function isHeifAttachment(file: File): boolean {
+function isHeifImageUpload(file: File): boolean {
   const mimeType = (file.type.split(";")[0] ?? "").trim().toLowerCase();
-  return (
-    HEIF_MIME_TYPES.has(mimeType) ||
-    HEIF_EXTENSIONS.has(extname(file.name).toLowerCase())
-  );
+  return HEIF_IMAGE_MIME_TYPES.has(mimeType);
 }
 
 export async function storeAttachment(
@@ -163,7 +162,7 @@ export async function storeAttachment(
   projectId: string,
   file: File,
 ): Promise<UploadedPromptAttachment> {
-  if (isHeifAttachment(file)) {
+  if (isHeifImageUpload(file)) {
     throw new ApiError(
       400,
       "invalid_request",

--- a/apps/server/src/services/projects/attachments.ts
+++ b/apps/server/src/services/projects/attachments.ts
@@ -21,6 +21,19 @@ import { ApiError } from "../../errors.js";
 const IMAGE_LIMIT_BYTES = 10 * 1024 * 1024;
 const FILE_LIMIT_BYTES = 25 * 1024 * 1024;
 
+// HEIC/HEIF (the iPhone camera default) is stored and served verbatim, but
+// nothing downstream can decode it: Chromium (web app and Electron shell) has
+// no HEVC decoder, and no provider image input accepts it, so the composer
+// showed a broken thumbnail while the model silently received nothing. bb
+// ships no transcoder, so refuse the upload with a reason instead.
+const HEIF_MIME_TYPES = new Set([
+  "image/heic",
+  "image/heic-sequence",
+  "image/heif",
+  "image/heif-sequence",
+]);
+const HEIF_EXTENSIONS = new Set([".heic", ".heif"]);
+
 type PromptAttachmentInput = Extract<
   PromptInput,
   { type: "localFile" | "localImage" }
@@ -137,11 +150,26 @@ export async function validatePromptAttachmentReferences(
   }
 }
 
+function isHeifAttachment(file: File): boolean {
+  const mimeType = (file.type.split(";")[0] ?? "").trim().toLowerCase();
+  return (
+    HEIF_MIME_TYPES.has(mimeType) ||
+    HEIF_EXTENSIONS.has(extname(file.name).toLowerCase())
+  );
+}
+
 export async function storeAttachment(
   dataDir: string,
   projectId: string,
   file: File,
 ): Promise<UploadedPromptAttachment> {
+  if (isHeifAttachment(file)) {
+    throw new ApiError(
+      400,
+      "invalid_request",
+      "HEIC images are not supported. Convert the image to JPEG or PNG before attaching it.",
+    );
+  }
   const isImage = (file.type || "").startsWith("image/");
   const sizeLimit = isImage ? IMAGE_LIMIT_BYTES : FILE_LIMIT_BYTES;
   if (file.size > sizeLimit) {

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -302,8 +302,8 @@ status|install` to inspect or install provider CLIs on a selected machine.
   returning the stable server attachment DTO. Optional `--filename` and
   `--mime-type` override inferred metadata. Pass the returned relative `path`
   to thread `--file` or `--image`; image MIME types are capped at 10MB and
-  other files at 25MB, and HEIC/HEIF images are rejected (convert them to JPEG
-  or PNG first). `bb project attachment download <project-id>
+  other files at 25MB, and image/heic or image/heif uploads are rejected
+  (convert them to JPEG or PNG first). `bb project attachment download <project-id>
 <attachment-path> --client-file <path>` writes existing attachment bytes on
   the CLI machine. There is no project-attachment list or per-file remove API.
 - `bb project history|reorder` exposes project prompt recall and sidebar order.

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -302,7 +302,8 @@ status|install` to inspect or install provider CLIs on a selected machine.
   returning the stable server attachment DTO. Optional `--filename` and
   `--mime-type` override inferred metadata. Pass the returned relative `path`
   to thread `--file` or `--image`; image MIME types are capped at 10MB and
-  other files at 25MB. `bb project attachment download <project-id>
+  other files at 25MB, and HEIC/HEIF images are rejected (convert them to JPEG
+  or PNG first). `bb project attachment download <project-id>
 <attachment-path> --client-file <path>` writes existing attachment bytes on
   the CLI machine. There is no project-attachment list or per-file remove API.
 - `bb project history|reorder` exposes project prompt recall and sidebar order.

--- a/apps/server/test/public/public-project-attachments.test.ts
+++ b/apps/server/test/public/public-project-attachments.test.ts
@@ -139,7 +139,7 @@ describe("public project attachments", () => {
     });
   });
 
-  it("rejects HEIC/HEIF uploads instead of storing an image nothing can render", async () => {
+  it("rejects HEIC/HEIF image uploads instead of storing an image nothing can render", async () => {
     await withTestHarness(async (harness) => {
       const { host } = seedHostSession(harness.deps, {
         id: "host-project-attachment-heic",
@@ -158,23 +158,41 @@ describe("public project attachments", () => {
           "HEIC images are not supported. Convert the image to JPEG or PNG before attaching it.",
       };
 
-      // Chromium labels a dropped or pasted .heic file `image/heic`.
-      const byMimeType = await upload(
+      // Chromium labels a dropped or pasted .heic file `image/heic`, and the
+      // CLI infers the same from the extension.
+      const heic = await upload(
         harness.app,
         project.id,
         new File([heicBytes], "IMG_0001.heic", { type: "image/heic" }),
       );
-      expect(byMimeType.status).toBe(400);
-      await expect(readJson(byMimeType)).resolves.toEqual(rejected);
+      expect(heic.status).toBe(400);
+      await expect(readJson(heic)).resolves.toEqual(rejected);
 
-      // Some platforms hand over the file with no MIME type at all.
-      const byExtension = await upload(
+      const heif = await upload(
         harness.app,
         project.id,
-        new File([heicBytes], "IMG_0002.HEIF"),
+        new File([heicBytes], "IMG_0002.HEIF", {
+          type: "Image/HEIF; charset=binary",
+        }),
       );
-      expect(byExtension.status).toBe(400);
-      await expect(readJson(byExtension)).resolves.toEqual(rejected);
+      expect(heif.status).toBe(400);
+      await expect(readJson(heif)).resolves.toEqual(rejected);
+
+      // Only the image classification is broken. The same bytes sent as a
+      // non-image (`bb project attachment upload photo.heic --mime-type
+      // application/octet-stream`) still store as a plain file chip that an
+      // agent can convert on the host.
+      const asFile = await upload(
+        harness.app,
+        project.id,
+        new File([heicBytes], "IMG_0003.heic", {
+          type: "application/octet-stream",
+        }),
+      );
+      expect(asFile.status).toBe(201);
+      expect(
+        uploadedPromptAttachmentSchema.parse(await readJson(asFile)),
+      ).toMatchObject({ type: "localFile", name: "IMG_0003.heic" });
 
       const stillAcceptsOtherImages = await upload(
         harness.app,

--- a/apps/server/test/public/public-project-attachments.test.ts
+++ b/apps/server/test/public/public-project-attachments.test.ts
@@ -139,6 +139,54 @@ describe("public project attachments", () => {
     });
   });
 
+  it("rejects HEIC/HEIF uploads instead of storing an image nothing can render", async () => {
+    await withTestHarness(async (harness) => {
+      const { host } = seedHostSession(harness.deps, {
+        id: "host-project-attachment-heic",
+      });
+      const { project } = seedProjectWithSource(harness.deps, {
+        hostId: host.id,
+      });
+      // ISO BMFF `ftyp` box with the `heic` brand, as an iPhone photo starts.
+      const heicBytes = new Uint8Array([
+        0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70, 0x68, 0x65, 0x69, 0x63,
+        0x00, 0x00, 0x00, 0x00, 0x6d, 0x69, 0x66, 0x31, 0x68, 0x65, 0x69, 0x63,
+      ]);
+      const rejected = {
+        code: "invalid_request",
+        message:
+          "HEIC images are not supported. Convert the image to JPEG or PNG before attaching it.",
+      };
+
+      // Chromium labels a dropped or pasted .heic file `image/heic`.
+      const byMimeType = await upload(
+        harness.app,
+        project.id,
+        new File([heicBytes], "IMG_0001.heic", { type: "image/heic" }),
+      );
+      expect(byMimeType.status).toBe(400);
+      await expect(readJson(byMimeType)).resolves.toEqual(rejected);
+
+      // Some platforms hand over the file with no MIME type at all.
+      const byExtension = await upload(
+        harness.app,
+        project.id,
+        new File([heicBytes], "IMG_0002.HEIF"),
+      );
+      expect(byExtension.status).toBe(400);
+      await expect(readJson(byExtension)).resolves.toEqual(rejected);
+
+      const stillAcceptsOtherImages = await upload(
+        harness.app,
+        project.id,
+        new File([new Uint8Array([0x89, 0x50, 0x4e, 0x47])], "ok.png", {
+          type: "image/png",
+        }),
+      );
+      expect(stillAcceptsOtherImages.status).toBe(201);
+    });
+  });
+
   it("keeps attachment read tokens scoped to their owning project", async () => {
     await withTestHarness(async (harness) => {
       const { host } = seedHostSession(harness.deps, {

--- a/packages/templates/src/templates/bb-guide-projects.md
+++ b/packages/templates/src/templates/bb-guide-projects.md
@@ -61,8 +61,8 @@ Attachments:
   its relative `path` to thread --file/--image input. Those thread flags never
   read a client path: absolute values remain paths for the execution host.
   image/* uploads are limited to 10MB; other files are limited to 25MB.
-  HEIC/HEIF images are rejected (no renderer or provider can decode them);
-  convert them to JPEG or PNG first.
+  image/heic and image/heif uploads are rejected because no renderer or
+  provider can decode them; convert them to JPEG or PNG first.
 
 Sources:
 

--- a/packages/templates/src/templates/bb-guide-projects.md
+++ b/packages/templates/src/templates/bb-guide-projects.md
@@ -61,6 +61,8 @@ Attachments:
   its relative `path` to thread --file/--image input. Those thread flags never
   read a client path: absolute values remain paths for the execution host.
   image/* uploads are limited to 10MB; other files are limited to 25MB.
+  HEIC/HEIF images are rejected (no renderer or provider can decode them);
+  convert them to JPEG or PNG first.
 
 Sources:
 


### PR DESCRIPTION
## What was wrong

`POST /api/v1/projects/:id/attachments` stored and served a pasted or dropped `.heic` file verbatim and classified it as a `localImage` because its MIME type starts with `image/`. Nothing downstream can decode HEIC/HEIF: Chromium (the web app and the Electron shell) ships no HEVC decoder, so the composer thumbnail and the timeline `<img>` showed the broken-image glyph, and no provider image input accepts HEIC either (Codex replaced it with "image content omitted because it could not be processed"). The user saw a broken picture and the model silently received nothing. Issue: #1670. Report: https://get-bb.github.io/reports/issues/1670.html

**This PR is a stopgap, not the rendering fix the issue asks for.** Rendering HEIC requires an HEVC decoder that bb does not have. The only portable option is libheif/libde265 compiled to WASM (`libheif-js`, LGPL-3.0, ~1.4 MB, a patent-encumbered codec that Chromium itself declines to ship), run either in the browser before upload or in the server process (where a 12 MP photo blocks the event loop for about two seconds unless it moves to a worker; measured 0.1 s decode + 0.1 s encode for a 1.4 MP sample). That dependency and placement decision belongs to the maintainers, so this PR does the safe part: it turns the silent failure into an immediate, explained refusal. The issue stays open for the transcoding work (`Refs`, not `Fixes`).

## What changed

- `apps/server/src/services/projects/attachments.ts`: `storeAttachment` refuses uploads whose MIME type is `image/heic`, `image/heif`, or their `-sequence` variants with `400 invalid_request` and the message `HEIC images are not supported. Convert the image to JPEG or PNG before attaching it.` This is exactly the set of uploads that used to become a broken `localImage`: Chromium labels a pasted or dropped `.heic` `image/heic`, and `bb project attachment upload` infers the same from the extension. The same bytes sent with a non-image MIME type (for example `--mime-type application/octet-stream`) still store as a plain `localFile`, as on main, so a user can hand the raw file to an agent that converts it on the host. Every client (web, desktop, mobile document picker, CLI, SDK) gets the same answer. No wire change between server and daemon.
- `apps/app/src/components/thread/embedded-chat/useComposerAttachmentUploads.ts`: the follow-up and queued-message composers now show the server's reason (`Failed to attach IMG_0001.heic: HEIC images are not supported. ...`) instead of a bare `Failed to attach: IMG_0001.heic`. The new-thread composer already did this through `getMutationErrorMessage`; this brings the other composers in line. Transport errors keep the old generic text.
- CLI guide template (`packages/templates/src/templates/bb-guide-projects.md`) and the bb-cli skill (`apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md`) mention that `image/heic` and `image/heif` uploads are rejected.

Revision after review: the first version also rejected by `.heic`/`.heif` extension alone, which blocked the explicit non-image upload path that main handled correctly as a `localFile`. The rejection is now MIME-only and the test pins the `localFile` path.

Not included: an `onError` fallback tile in `AttachmentPreview`/`ConversationAttachments` for threads that already hold HEIC `localImage` attachments. That is a general broken-image UI concern, independent of HEIC, and is left for a follow-up.

Deviation from the report's proposed fix: it proposed transcoding HEIC to JPEG at upload with a WASM decoder. Not done here for the reasons above. If the maintainers want HEIC to just work, the smallest follow-up is a browser-side conversion before upload (decode with `libheif-js`, encode with `OffscreenCanvas.convertToBlob("image/jpeg")`), mirroring the mobile app, which already asks the iOS picker for JPEG instead of HEIC. The server check then stays as the backstop for programmatic uploads.

## How you verified

New tests, both fail on `origin/main` and pass here:

- `apps/server/test/public/public-project-attachments.test.ts` > `rejects HEIC/HEIF image uploads instead of storing an image nothing can render`. With `attachments.ts` reverted to `origin/main`: `AssertionError: expected 201 to be 400` (the HEIC was stored as a `localImage`). It also asserts that `image/heif; charset=binary` is rejected and that the same bytes as `application/octet-stream` return `201 {"type":"localFile"}`.
- `apps/app/src/components/thread/embedded-chat/useComposerAttachmentUploads.test.tsx` > `shows the server's reason when it refuses an upload`. On main: `Expected: "Failed to attach IMG_0001.heic, shot.png: HEIC images are not supported. ..."`, `Received: "Failed to attach: IMG_0001.heic, shot.png"`.

Run from the committed tree at `d28f3fc34` (`git status --porcelain` empty, `origin/main` at `f6fb434ab`):

- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/app --filter=@bb/templates --filter=@bb/cli`: `Tasks: 7 successful, 7 total`.
- `pnpm exec turbo run test --filter=@bb/server --filter=@bb/templates --filter=@bb/cli`: cli 48/48 files; templates 6/6 files; server 193/195 files. The two server failures are unrelated to this change: `internal-skill-trees.test.ts` asserts file mode 0644 and gets 0664 on this workstation's umask 0002 (fails identically on clean main, passes in CI), and `plugin-update.test.ts > waits one full interval when no plugins are eligible for update checks` hit its 5 s timeout under a load average of 35; it passes alone with `--testTimeout=60000` (test body 1.9 s).
- `pnpm exec turbo run test --filter=@bb/app`: `409 passed (409)` files, `3157 passed | 3 skipped`; vitest also reported one unhandled post-teardown timer from `ThreadTimelineRows.windowing.test.tsx` (`document is not defined` in `useScrollToSearchedMessage.ts`), a file this PR does not touch; that file and the composer test pass cleanly when re-run together.

Manual, on a dev instance of this branch, re-running the report's repro:

- `curl -F "file=@sample.heic;type=image/heic" .../attachments` (nokia `autumn_1440x960.heic`) returns `400 {"code":"invalid_request","message":"HEIC images are not supported. Convert the image to JPEG or PNG before attaching it."}`; `type=image/heif` with an `IMG.HEIF` filename is also rejected; `type=application/octet-stream` returns `201 {"type":"localFile",...}`; a PNG returns `201 {"type":"localImage",...}`.
- `bb project attachment upload <project> --client-file sample.heic` (MIME inferred from the extension) prints `Error: HTTP 400: HEIC images are not supported. ...`; with `--mime-type application/octet-stream` it prints `Attachment uploaded: sample-...heic`.
- Headless Chromium paste of the real HEIC `File` into the new-thread composer and into a thread's follow-up composer (first revision; the app code and the `image/heic` server response are unchanged since): no `<img>` is created, and the composer shows the reason inline.

Refs #1670

> AGENT GENERATED: by Claude Opus 5


## Independent verification

Verified round 2 on `d28f3fc34` (merge-base with `origin/main` `f6fb434ab`; `origin/main` has since gained only the unrelated `c942421a4`), in a separate worktree with its own dev instance.

Commands and results:

- `git checkout origin/main -- apps/app/src/components/thread/embedded-chat/useComposerAttachmentUploads.ts apps/server/src/services/projects/attachments.ts`, then `pnpm exec vitest run test/public/public-project-attachments.test.ts` (apps/server): `AssertionError: expected 201 to be 400` in `rejects HEIC/HEIF image uploads instead of storing an image nothing can render` (1 failed | 3 passed). `pnpm exec vitest run src/components/thread/embedded-chat/useComposerAttachmentUploads.test.tsx` (apps/app): `Expected: "Failed to attach IMG_0001.heic, shot.png: HEIC images are not supported. ..."`, `Received: "Failed to attach: IMG_0001.heic, shot.png"` (1 failed | 3 passed).
- `git checkout HEAD -- <same files>`: both files 4/4 pass.
- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/app --filter=@bb/templates --filter=@bb/cli`: `Tasks: 7 successful, 7 total`.
- `pnpm exec turbo run test --filter=@bb/server --filter=@bb/templates --filter=@bb/cli --filter=@bb/app --force`: app 409/409 files, cli 48/48, templates 6/6, server 194/195 files (1823/1824 tests). The one failure is `internal-skill-trees.test.ts` (0644 vs 0664 file mode under umask 0002), a known local-only failure unrelated to this PR.
- Repro on the fixed branch (own dev instance, nokia `autumn_1440x960.heic`): `curl -F "file=@sample.heic;type=image/heic"` -> `400 {"code":"invalid_request","message":"HEIC images are not supported. ..."}`; `type=image/heif` -> 400; `type="Image/HEIC; charset=binary"` -> 400; `type=application/octet-stream` -> `201 {"type":"localFile",...}`; no explicit type (curl default octet-stream) -> 201 localFile; PNG -> `201 {"type":"localImage",...}`. `bb project attachment upload <proj> --client-file sample.heic` -> `Error: HTTP 400: HEIC images are not supported...`; with `--mime-type application/octet-stream` -> `Attachment uploaded: sample-...heic`.
- Headless Chromium paste of a real `image/heic` `File` into the new-thread composer and into a thread's follow-up composer: no `<img>` pointing at `/attachments/content` is created; the new-thread composer shows `HEIC images are not supported. Convert the image to JPEG or PNG before attaching it.` inline and the follow-up composer shows `Failed to attach IMG_0001.heic: HEIC images are not supported. ...`. The original broken-thumbnail symptom no longer reproduces.
- Checked that `storeAttachment` has a single caller (the upload route), that the mobile document picker surfaces the 400 through its `BbHttpError` toast, and that the mobile photo picker already requests JPEG for HEIC assets, so the new server policy matches the existing mobile stance.
- CI: all checks green (Checks, Package Smoke ubuntu/macos, Tests app-1/2/3, integration, packages, server).

Residual risks (acknowledged by the PR): HEIC still cannot be attached as an image until a transcoder lands (issue stays open via `Refs`); existing threads with stored HEIC `localImage` attachments still render the broken-image glyph; HEIC bytes uploaded with a misleading non-HEIC image MIME type are not sniffed. Minor doc gap: the bb-plugin-authoring skill's SDK attachment paragraph mentions the size caps but not the HEIC rejection.

> AGENT GENERATED: by Claude Opus 5
