### PR TITLE
Keep app chrome out of text selection

### DIFF
--- a/apps/app/src/app.css
+++ b/apps/app/src/app.css
@@ -55,6 +55,19 @@
     overscroll-behavior-y: none;
   }
 
+  /*
+   * App chrome (sidebar, page headers, composer toolbars) opts out of text
+   * selection with `select-none` so drags and Select All only pick up
+   * content. `user-select: auto` resolves from the parent, so WebKit would
+   * carry that opt-out into editable controls inside those regions (the
+   * sidebar thread search, the inline thread-title rename) and refuse to
+   * select their text. Restore native selection on the controls themselves.
+   */
+  .select-none
+    :where(input, textarea, [contenteditable]:not([contenteditable="false"])) {
+    user-select: text;
+  }
+
   .chat-prompt-box {
     padding-bottom: 0.5rem;
   }

--- a/apps/app/src/components/layout/AppPageHeader.tsx
+++ b/apps/app/src/components/layout/AppPageHeader.tsx
@@ -95,7 +95,7 @@ export function AppPageHeader({
         CHROME_ROW_HEIGHT_CLASS,
         HEADER_SEAM_CLASS,
         APP_PAGE_HEADER_SURFACE_CLASS,
-        "relative shrink-0 px-4",
+        "relative shrink-0 select-none px-4",
         usesDesktopChrome && isWindowDragRegion && MACOS_WINDOW_DRAG_CLASS,
         className,
       )}

--- a/apps/app/src/components/layout/app-chrome-selection.test.tsx
+++ b/apps/app/src/components/layout/app-chrome-selection.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
+import {
+  Sidebar,
+  SidebarProvider,
+  SidebarTrigger,
+} from "@/components/ui/sidebar";
+import { getSecondaryPanelChromeStackClassName } from "@/components/secondary-panel/ThreadSecondaryPanel";
+import { AppPageHeader } from "./AppPageHeader";
+
+/**
+ * App chrome must not take part in native text selection (#1440). A mouse drag
+ * that starts on a `user-select: none` element never begins a selection, and
+ * Select All skips such elements, so marking the chrome *regions* keeps
+ * sidebar labels, title bars and composer toolbars out of drags and Cmd-A
+ * while conversation content, editors and diagnostics stay selectable.
+ */
+
+afterEach(() => {
+  cleanup();
+});
+
+function getPanel(): HTMLElement {
+  const panel = document.querySelector('[data-sidebar="panel"]');
+  if (!(panel instanceof HTMLElement)) {
+    throw new Error("Expected a sidebar panel");
+  }
+  return panel;
+}
+
+describe("app chrome opts out of text selection", () => {
+  it("marks the desktop sidebar panel, its trigger and the page header", () => {
+    render(
+      <SidebarProvider>
+        <Sidebar>
+          <span>New thread</span>
+        </Sidebar>
+        <SidebarTrigger />
+        <AppPageHeader center={<p>Thread title</p>} />
+      </SidebarProvider>,
+    );
+
+    expect(getPanel().classList.contains("select-none")).toBe(true);
+    expect(
+      screen
+        .getByRole("button", { name: "Toggle Sidebar" })
+        .classList.contains("select-none"),
+    ).toBe(true);
+    const header = document.querySelector("header");
+    expect(header?.classList.contains("select-none")).toBe(true);
+  });
+
+  it("marks the compact-viewport sidebar drawer", () => {
+    render(
+      <CompactViewportOverrideProvider isCompactViewport>
+        <SidebarProvider>
+          <Sidebar>
+            <span>New thread</span>
+          </Sidebar>
+        </SidebarProvider>
+      </CompactViewportOverrideProvider>,
+    );
+
+    expect(getPanel().classList.contains("select-none")).toBe(true);
+  });
+
+  it("marks the right panel's top chrome with and without the diff toolbar", () => {
+    expect(getSecondaryPanelChromeStackClassName(false)).toContain(
+      "select-none",
+    );
+    expect(getSecondaryPanelChromeStackClassName(true)).toContain(
+      "select-none",
+    );
+  });
+
+  it("restores native selection on editable controls inside opted-out chrome", () => {
+    // `user-select: auto` resolves from the parent, so without this rule
+    // WebKit would refuse to select text in the sidebar thread search and the
+    // inline thread-title rename input.
+    const css = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), "../../app.css"),
+      "utf8",
+    );
+    const rule = css.match(
+      /\.select-none\s+:where\(input, textarea, \[contenteditable\]:not\(\[contenteditable="false"\]\)\)\s*\{([^}]*)\}/,
+    );
+    expect(rule?.[1]).toContain("user-select: text;");
+  });
+});

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
@@ -1059,6 +1059,18 @@ describe("FollowUpPromptBox", () => {
     }
   });
 
+  it("keeps the status footer out of text selection", () => {
+    const props = createFollowUpPromptBoxProps({ kind: "ready" });
+    props.environmentSummary = <span>Local environment</span>;
+    render(<FollowUpPromptBox {...props} />);
+
+    const footer = document.querySelector("[data-follow-up-composer-footer]");
+    expect(footer?.classList.contains("select-none")).toBe(true);
+    expect(screen.getByText("Local environment").closest(".select-none")).toBe(
+      footer,
+    );
+  });
+
   it("keeps the full composer visible on desktop", () => {
     const props = createFollowUpPromptBoxProps({ kind: "ready" });
     props.environmentSummary = <span>Local environment</span>;

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -767,7 +767,7 @@ function FollowUpPromptBoxWithComposer({
       {!isMobilePromptBoxCompact ? (
         <div
           data-follow-up-composer-footer=""
-          className="mt-1 flex min-h-6 max-h-6 items-center justify-between gap-2 overflow-hidden pl-[15px] pr-3.5 opacity-100 transition-[max-height,min-height,margin-top,opacity] duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none"
+          className="mt-1 flex min-h-6 max-h-6 select-none items-center justify-between gap-2 overflow-hidden pl-[15px] pr-3.5 opacity-100 transition-[max-height,min-height,margin-top,opacity] duration-[180ms] ease-[cubic-bezier(0.16,1,0.3,1)] motion-reduce:transition-none"
         >
           <div className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
             {environmentSummary}

--- a/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
+++ b/apps/app/src/components/promptbox/NewThreadPromptBox.tsx
@@ -429,7 +429,7 @@ const DefaultNewThreadComposer = memo(function DefaultNewThreadComposer({
           reproduces the 4px gap main got from a
           `space-y-1` wrapper in RootComposeView (now gone since the
           standalone project row was removed). */}
-      <div className="mt-1 flex items-center justify-between gap-2 px-3.5">
+      <div className="mt-1 flex select-none items-center justify-between gap-2 px-3.5">
         <div className="flex min-w-0 flex-1 items-center gap-1">
           {project ? (
             <ProjectSelector

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -3077,6 +3077,14 @@ describe("PromptBoxInternal selection reveal", () => {
 });
 
 describe("PromptBoxInternal prompt actions", () => {
+  it("keeps the action row out of text selection while the editor stays selectable", () => {
+    renderPromptBox("");
+
+    const actionRow = document.querySelector("[data-promptbox-action-row]");
+    expect(actionRow?.classList.contains("select-none")).toBe(true);
+    expect(getPromptEditorElement().closest(".select-none")).toBeNull();
+  });
+
   it("keeps the custom caret reveal for composer-handled text pastes", async () => {
     const { changes, promptBoxRef } = renderPromptBox("");
 

--- a/apps/app/src/components/promptbox/PromptBoxInternal.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.tsx
@@ -3434,7 +3434,7 @@ export function PromptBoxInternal({
             <div
               data-promptbox-action-row=""
               className={cn(
-                "relative flex shrink-0 flex-row items-center gap-3 pb-2 pl-3.5 pr-2 pt-1.5",
+                "relative flex shrink-0 select-none flex-row items-center gap-3 pb-2 pl-3.5 pr-2 pt-1.5",
                 showCompactLayout && "absolute inset-y-0 right-2 gap-0 p-0",
               )}
             >

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -146,7 +146,7 @@ export function getSecondaryPanelChromeStackClassName(
   hasGitDiffToolbar: boolean,
 ): string {
   return cn(
-    "shrink-0",
+    "shrink-0 select-none",
     hasGitDiffToolbar && "flex flex-col",
     SECONDARY_PANEL_TOP_CHROME_BACKGROUND_CLASS,
   );

--- a/apps/app/src/components/ui/sidebar.tsx
+++ b/apps/app/src/components/ui/sidebar.tsx
@@ -912,7 +912,7 @@ const Sidebar = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(
             // The visibility leg hides the fully collapsed offcanvas panel
             // after the slide-out so its mounted rows stop painting (#1261);
             // the zero delay on expand shows it again immediately.
-            "fixed inset-y-0 z-10 flex h-(--bb-shell-height) w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground [transition:left_200ms_linear,right_200ms_linear,width_200ms_linear,visibility_0s_linear_0s]",
+            "fixed inset-y-0 z-10 flex h-(--bb-shell-height) w-(--sidebar-width) select-none flex-col bg-sidebar text-sidebar-foreground [transition:left_200ms_linear,right_200ms_linear,width_200ms_linear,visibility_0s_linear_0s]",
             "group-data-[collapsible=offcanvas]:invisible group-data-[collapsible=offcanvas]:[transition:left_200ms_linear,right_200ms_linear,width_200ms_linear,visibility_0s_linear_200ms]",
             "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]",
             "group-data-[collapsible=icon]:w-(--sidebar-width-icon) border-border-seam group-data-[side=left]:border-r group-data-[side=right]:border-l",
@@ -1519,7 +1519,7 @@ const SidebarMobilePanel = React.forwardRef<
             // initial containing block, so it reads the shell unit directly.
             // touch-pan-y hands horizontal touch moves to the drag-to-close
             // handler while leaving vertical list scrolling native.
-            "group fixed inset-y-0 z-40 flex h-(--bb-shell-height) w-(--sidebar-width-mobile) touch-pan-y flex-col bg-sidebar text-sidebar-foreground outline-none will-change-[translate]",
+            "group fixed inset-y-0 z-40 flex h-(--bb-shell-height) w-(--sidebar-width-mobile) touch-pan-y select-none flex-col bg-sidebar text-sidebar-foreground outline-none will-change-[translate]",
             SIDEBAR_MOBILE_PANEL_TRANSITION_CLASS,
             "left-0 data-[state=closed]:-translate-x-full",
             "border-border-seam data-[side=left]:border-r data-[side=right]:border-l",
@@ -1562,7 +1562,11 @@ const SidebarTrigger = React.forwardRef<
       data-sidebar="trigger"
       variant="ghost"
       size="icon"
-      className={cn(COARSE_POINTER_HEADER_ICON_BUTTON_CLASS, className)}
+      className={cn(
+        COARSE_POINTER_HEADER_ICON_BUTTON_CLASS,
+        "select-none",
+        className,
+      )}
       aria-expanded={ariaExpanded ?? (isCompactViewport ? openMobile : open)}
       onClick={(event) => {
         onClick?.(event);


### PR DESCRIPTION
## What was wrong

The app set no `user-select` policy, so every element kept the browser default (`auto`). Sidebar labels, the page header, the composer toolbar and footer, and the visually hidden "Toggle Sidebar" label all joined mouse-drag selections and Select All alongside the conversation. On main, clicking empty sidebar space and pressing Ctrl-A selects `New thread … Extensions … Automations … Settings … Report a bug … Project: qa … Toggle Sidebar`, and a drag across the sidebar highlights its labels. Issue: #1440. Report: https://get-bb.github.io/reports/issues/1440.html

## What changed

App chrome regions opt out of selection with `select-none`; content keeps the browser default.

- `apps/app/src/components/ui/sidebar.tsx`: both sidebar panels (desktop and compact drawer) and `SidebarTrigger`.
- `apps/app/src/components/layout/AppPageHeader.tsx`: the `<header>` element.
- `apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx`: the right panel's top chrome stack (tab toolbar and diff toolbar).
- `apps/app/src/components/promptbox/PromptBoxInternal.tsx`, `FollowUpPromptBox.tsx`, `NewThreadPromptBox.tsx`: the composer action row and the footer strips below the prompt box. The editor and the banners above it are untouched.
- `apps/app/src/app.css`: `.select-none :where(input, textarea, [contenteditable])` gets `user-select: text`. `auto` resolves from the parent, and WebKit carries a parent's `none` into editable controls; this keeps the sidebar thread search and the inline thread-title rename selectable.

Why opt out of chrome instead of `body { user-select: none }` plus content opt-ins (the approach in #1428): in Blink a drag that starts on a `user-select: none` element never begins a selection, so marking only the chrome leaves gutter drags, multi-message drags, diagnostics (Info panel, settings, toasts, dialogs) and plugin panels exactly as they behave today. A shell-wide `none` needs every content surface to opt in, and each missed surface becomes uncopyable text. The report measured two such regressions in #1428 (gutter drag selects nothing; Ctrl-A highlights the thread but Ctrl-C copies nothing); #1428 has since grown to 115 files including an Electron menu rewrite and a renderer Select All controller, and conflicts with main. This PR covers the issue's title and its first three acceptance criteria with a class on each chrome root.

Not changed: Select All is not scoped to the last-touched pane (a later criterion added to the issue by #1428); Ctrl-A from the sidebar still selects the conversation text, without any chrome. Timeline status rows ("Worked for 7s", "Working...") remain selectable as part of the conversation.

No wire, CLI or plugin API change.

## How you verified

New tests, run against origin/main sources (`git checkout origin/main -- <7 source files>`) fail, and pass on this branch:

- `apps/app/src/components/layout/app-chrome-selection.test.tsx` (4 tests): sidebar panel, drawer, trigger, header, right-panel chrome carry `select-none`; app.css restores selection on editable controls. Before: `AssertionError: expected false to be true`, `expected 'shrink-0 bg-sidebar' to contain 'select-none'`.
- `FollowUpPromptBox.test.tsx` "keeps the status footer out of text selection" and `PromptBoxInternal.test.tsx` "keeps the action row out of text selection while the editor stays selectable". Before: `AssertionError: expected false to be true`.

Commands on the committed tree (`git status --porcelain` empty):

- `pnpm exec turbo run typecheck --filter=@bb/app` → `Tasks: 3 successful, 3 total`
- `pnpm exec turbo run test --filter=@bb/app` → `Tasks: 4 successful, 4 total` (410 test files passed)

Manual check in headless Chromium 145 (Puppeteer via doobie) against my dev instance, thread with one user message and one reply, same gestures as the report's probes:

| gesture | main | this branch |
| --- | --- | --- |
| click empty sidebar, Ctrl-A | 308 chars incl. `New thread … Toggle Sidebar` | 128 chars, conversation only |
| drag from empty sidebar over labels | `Settings\nRemote access\nReport a bug…` | nothing selected |
| drag across composer footer (`Project: qa …`) | `Project:\nqa\nEnvironment:…` | nothing selected |
| drag across header title | `Selection QA` | nothing selected |
| drag from gutter 200 px left of a message into it | `Run the shell command: echo hello-144` | same |
| click message, Ctrl-A, Ctrl-C, paste into editor | whole page incl. chrome | conversation text only (128 chars) |
| Ctrl-A inside the editor with a draft | draft only | draft only |

Computed `user-select`: body `auto`, sidebar label `none`, message `auto`, Info panel directory value `auto`. Before/after screenshots of Ctrl-A from the sidebar are attached to the batch notes. Not verified in Electron or WebKit (no macOS/iOS here); the WebKit restore rule follows the documented `user-select` inheritance behavior.

Fixes #1440

> AGENT GENERATED: by Claude Opus 5


## Independent verification

Verified by a second agent on a fresh worktree (`git fetch origin bb/fix-1440-chrome-user-select && git checkout -b verify-1440-r1 FETCH_HEAD`, head `b728ba309`, `origin/main` is an ancestor, GitHub reports `MERGEABLE`).

Commands run:

- `pnpm install --frozen-lockfile --prefer-offline && pnpm exec turbo run build` → `Tasks: 18 successful, 18 total`
- Fail-before: `git checkout origin/main -- apps/app/src/app.css apps/app/src/components/layout/AppPageHeader.tsx apps/app/src/components/promptbox/{FollowUpPromptBox,NewThreadPromptBox,PromptBoxInternal}.tsx apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx apps/app/src/components/ui/sidebar.tsx`, then `pnpm exec vitest run src/components/layout/app-chrome-selection.test.tsx src/components/promptbox/FollowUpPromptBox.test.tsx src/components/promptbox/PromptBoxInternal.test.tsx` in `apps/app` → `Tests 6 failed | 130 passed (136)`; failing assertions: `AssertionError: expected false to be true` (sidebar panel/trigger/header, compact drawer, footer, action row), `expected 'shrink-0 bg-sidebar' to contain 'select-none'`, and the app.css rule match being `undefined`.
- Pass-after: `git checkout HEAD -- <same files>` and the same vitest command → `Tests 136 passed (136)`.
- `pnpm exec turbo run typecheck --filter=@bb/app` → `Tasks: 3 successful, 3 total`
- `pnpm exec turbo run test --filter=@bb/app --force` → `Tasks: 4 successful, 4 total` (410 test files, 3162 tests passed, 3 skipped)
- Built CSS check: `apps/app/dist/assets/index-*.css` contains `.select-none :where(input,textarea,[contenteditable]:not([contenteditable=false])){-webkit-user-select:text;user-select:text}`, so the WebKit prefix is emitted.

Repro on the fixed branch (headless Chromium 145 via doobie, own dev instance, codex thread with one message + reply), same gestures run against origin/main sources and this branch by swapping the 7 source files under Vite HMR:

| gesture | origin/main sources | this branch |
| --- | --- | --- |
| click empty sidebar, Ctrl-A | 300 chars incl. `New thread … Settings … Report a bug … Project: qa … Toggle Sidebar` | 128 chars, conversation only |
| drag from empty sidebar up over labels | 221 chars (`Settings\nRemote access\nReport a bug…`) | nothing (`type: None`) |
| drag across composer footer | `Project:\nqa\nEnvironment:\nWorking locally\n\nmain\n` | nothing |
| drag from gutter 150 px left of a message into it | `Run the shell command: echo hello-1440. Then reply` | same text |
| click message, Ctrl-A, Ctrl-C, paste into editor | whole page incl. chrome (308 chars) | conversation only (128 chars) |
| type a draft in the editor, Ctrl-A | — | `draft xyz 1440` only, anchor/focus inside the editor |
| sidebar thread search input (computed `user-select`) | — | `text`; Ctrl-A and mouse drag select inside the input |
| header inline title rename input (computed `user-select`) | — | `text` under a `none` header; Ctrl-A, drag (`Selec`) and Shift+End all work |

Computed `user-select` on this branch: body `auto`, sidebar panel `none`, header `none`, composer footer `none`, action row `none`, editor `auto`.

CI: all checks green on `b728ba309` (Checks, Tests app-1/2/3, integration, packages, server, Package Smoke ubuntu/macos, version checks).

Residual risks: the thread title in the page header is now copyable only through the double-click rename input, not by dragging the label; timeline status rows ("Worked for 7s", "Working...") and dialog/settings labels keep the browser default; Select All is not scoped to the interacted pane and the Electron Edit menu is untouched (later acceptance criteria on the issue, out of scope here); Electron and WebKit/iOS were not exercised (Linux host), the WebKit path relies on the prefixed rule in the built CSS.

> AGENT GENERATED: by Claude Opus 5
