### PR TITLE
Use a no-break narrow space as the mobile inline code pad

### DIFF
--- a/apps/mobile/src/markdown/render-inline.tsx
+++ b/apps/mobile/src/markdown/render-inline.tsx
@@ -174,8 +174,13 @@ function collapseSoftBreaks(value: string): string {
     : value;
 }
 
-/** Padding inside an inline code span: RN nested text cannot pad, so thin spaces. */
-const CODE_PAD = "\u2009";
+/**
+ * Padding inside an inline code span: RN nested text cannot pad, so narrow
+ * spaces. They must be NO-BREAK (U+202F, not U+2009): a breaking pad lets the
+ * line wrap right after the leading space, which strands an empty highlighted
+ * fragment at the end of one line and puts the code on the next.
+ */
+const CODE_PAD = "\u202f";
 
 function renderText(value: string, state: InlineState, key: string): ReactNode {
   const text = collapseSoftBreaks(value);

--- a/apps/mobile/src/screens/dev/MarkdownShowcaseScreen.tsx
+++ b/apps/mobile/src/screens/dev/MarkdownShowcaseScreen.tsx
@@ -44,6 +44,10 @@ a [localhost link](http://localhost:5173/preview) and an autolink
 https://getbb.app. Hard break follows:
 this line was a single newline.
 
+#1670 (HEIC images not rendered) → partial \`FIX\`, PR #2170 (+139/−3). The agent chose not to
+add a transcoder: the only portable decoder is \`libheif-js\` (LGPL-3.0, ~1.4 MB WASM, patent-
+encumbered codec; the repo ships no LGPL runtime deps) and it would block the server event loop.
+
 Mentions: see @thread:${RAW_ID} and the raw id ${RAW_ID} plus \`${RAW_ID}\` in code.
 A time like 13:30 and a key:value stay literal.
 


### PR DESCRIPTION
## What was wrong

The mobile markdown renderer pads each inline code span with U+2009 THIN SPACE on both sides, because nested RN `Text` cannot carry padding. A thin space is a line break opportunity. When the leading pad landed at the end of a line, iOS broke the line right after it. The result was an empty highlighted fragment at the end of one line and the code text on the next line.

## What changed

- `apps/mobile/src/markdown/render-inline.tsx`: `CODE_PAD` is now U+202F NARROW NO-BREAK SPACE. The renderer cannot break between the pad and the code text, so the span moves to the next line as one unit.
- `apps/mobile/src/screens/dev/MarkdownShowcaseScreen.tsx`: added the paragraph from the bug report to the markdown showcase fixture, so the case is easy to check by eye.

No wire change. No CLI or doc change.

## How you verified

- Reproduced in the iOS Simulator (iPhone 17 Pro, iOS 26.3) on the dev markdown showcase at the `extra-large` content size: "strike, ▯" and "partial ▯" each ended a line with an empty highlight, and the code started the next line.
- After the change, the same screen shows ` inline code ` and ` FIX ` whole on the next line.
- `pnpm exec turbo run typecheck lint test --filter=@bb/mobile`: 123 test files, 827 tests pass.
- No new test: there is no RN render harness in `@bb/mobile`, and a test of one constant is trivial.

> AGENT GENERATED: by Claude Opus 5
