### PR TITLE
Keep Shiki's RegExp feature probes out of the bundler's reach

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -137,6 +137,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "lightningcss": "^1.32.0",
     "mdast-util-to-hast": "^13.2.1",
+    "oniguruma-to-es": "^4.3.4",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.3.0",
     "typescript": "npm:@typescript/typescript6@^6.0.2",

--- a/apps/app/src/regex-engine-feature-probes.test.ts
+++ b/apps/app/src/regex-engine-feature-probes.test.ts
@@ -1,0 +1,131 @@
+// Shiki's JavaScript regex engine (oniguruma-to-es) probes the runtime at
+// module top level with
+// `try { new RegExp("[[]]", "v") } catch { return false } return true`.
+// Rolldown and the oxc minifier treat `new RegExp(<literal>, <literal>)` as
+// pure, drop it from the try block and fold the probe to `true`. The next
+// statement then calls `RegExp("[[^a]]", "v")` unguarded and throws on every
+// engine without the `v` flag (Safari/iOS 16.x), which rejects the whole
+// route chunk and blanks the app (#1603). patches/oniguruma-to-es and
+// patches/@pierre__diffs (whose worker-portable.js inlines its own copy of
+// oniguruma-to-es) rewrite the probes as `Reflect.construct(RegExp, [...])`,
+// which the bundler cannot prove pure. These tests bundle that code the way
+// the app build does and evaluate the result on a Safari 16-like RegExp.
+import vm from "node:vm";
+import { build } from "vite";
+import { describe, expect, it } from "vitest";
+
+/** Bundles one entry with the app's Vite/Rolldown build, minified. */
+async function bundle(input: string): Promise<string> {
+  const result = await build({
+    configFile: false,
+    root: import.meta.dirname,
+    logLevel: "silent",
+    build: {
+      write: false,
+      minify: true,
+      rollupOptions: {
+        input,
+        preserveEntrySignatures: "strict",
+        output: { format: "cjs", entryFileNames: "entry.cjs" },
+      },
+    },
+  });
+  const outputs = Array.isArray(result) ? result : [result];
+  for (const output of outputs) {
+    if (!("output" in output)) continue;
+    for (const chunk of output.output) {
+      if (chunk.type === "chunk" && chunk.isEntry) return chunk.code;
+    }
+  }
+  throw new Error("vite build produced no entry chunk");
+}
+
+// `(?i:...)` / `(?-i:...)` pattern modifiers, the other feature the engine
+// probes for. Safari 16 has neither modifiers nor the `v` flag.
+const PATTERN_MODIFIER = /\(\?(?:[ims]+|[ims]*-[ims]+):/;
+
+/**
+ * Evaluates a CommonJS bundle in a context whose `RegExp` constructor behaves
+ * like Safari 16.x: it rejects the `v` flag and pattern modifiers. Regex
+ * literals keep working because they use the context's intrinsic, not the
+ * global binding. Returns the bundle's `module.exports`.
+ */
+function evaluateOnSafariSixteen(
+  code: string,
+  globals: Record<string, unknown>,
+): Record<string, unknown> {
+  const context = vm.createContext({ ...globals });
+  const IntrinsicRegExp: RegExpConstructor = vm.runInContext("RegExp", context);
+  function SafariSixteenRegExp(
+    this: unknown,
+    pattern: string | RegExp,
+    flags?: string,
+  ) {
+    if (flags?.includes("v")) {
+      throw new SyntaxError("Invalid flags supplied to RegExp constructor.");
+    }
+    if (typeof pattern === "string" && PATTERN_MODIFIER.test(pattern)) {
+      throw new SyntaxError(
+        "Invalid regular expression: invalid group specifier name",
+      );
+    }
+    return flags === undefined
+      ? new IntrinsicRegExp(pattern)
+      : new IntrinsicRegExp(pattern, flags);
+  }
+  SafariSixteenRegExp.prototype = IntrinsicRegExp.prototype;
+  context.RegExp = SafariSixteenRegExp;
+  const module: { exports: Record<string, unknown> } = { exports: {} };
+  context.module = module;
+  context.exports = module.exports;
+  vm.runInContext(code, context, { filename: "bundle.cjs" });
+  return module.exports;
+}
+
+function isRegExpLike(
+  value: unknown,
+): value is { flags: string; test: (input: string) => boolean } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "flags" in value &&
+    typeof value.flags === "string" &&
+    "test" in value &&
+    typeof value.test === "function"
+  );
+}
+
+describe("regex engine feature probes survive the app bundler", () => {
+  it("oniguruma-to-es loads and picks a v-less target on Safari 16", async () => {
+    const code = await bundle("oniguruma-to-es");
+
+    const { toRegExp } = evaluateOnSafariSixteen(code, {});
+    if (typeof toRegExp !== "function") {
+      throw new Error("bundle did not export toRegExp");
+    }
+    // The result is a RegExp from the vm realm, so `instanceof` cannot see it.
+    const compiled: unknown = toRegExp("[a-c]+");
+    if (!isRegExpLike(compiled)) {
+      throw new Error("toRegExp did not return a RegExp");
+    }
+
+    expect(compiled.flags).not.toContain("v");
+    expect(compiled.test("abc")).toBe(true);
+  }, 60_000);
+
+  it("the @pierre/diffs portable worker evaluates on Safari 16", async () => {
+    // diff-worker-pool.ts loads this file as a module worker; it inlines its
+    // own oniguruma-to-es, so the package patch alone does not cover it.
+    const code = await bundle("@pierre/diffs/worker/worker-portable.js");
+
+    const listeners: string[] = [];
+    const self = {
+      addEventListener: (type: string) => {
+        listeners.push(type);
+      },
+    };
+    evaluateOnSafariSixteen(code, { self, postMessage: () => {} });
+
+    expect(listeners).toContain("message");
+  }, 60_000);
+});

--- a/package.json
+++ b/package.json
@@ -78,7 +78,9 @@
       "@expo/metro-config>lightningcss": "1.30.1"
     },
     "patchedDependencies": {
-      "expo-modules-jsi@57.0.4": "patches/expo-modules-jsi@57.0.4.patch"
+      "expo-modules-jsi@57.0.4": "patches/expo-modules-jsi@57.0.4.patch",
+      "oniguruma-to-es@4.3.4": "patches/oniguruma-to-es@4.3.4.patch",
+      "@pierre/diffs@1.2.9": "patches/@pierre__diffs@1.2.9.patch"
     }
   }
 }

--- a/patches/@pierre__diffs@1.2.9.patch
+++ b/patches/@pierre__diffs@1.2.9.patch
@@ -1,0 +1,31 @@
+diff --git a/dist/worker/worker-portable.js b/dist/worker/worker-portable.js
+index 6da26a75fe78bd260c7b1292bc2d5062e6552d55..7d96564e225f2f4c560d02bd0d671a19ebfb0dd2 100644
+--- a/dist/worker/worker-portable.js
++++ b/dist/worker/worker-portable.js
+@@ -9987,7 +9987,7 @@ var r = String.raw;
+ var envFlags = {
+ 	flagGroups: (() => {
+ 		try {
+-			new RegExp("(?i:)");
++			Reflect.construct(RegExp, ["(?i:)"]);
+ 		} catch {
+ 			return false;
+ 		}
+@@ -9995,7 +9995,7 @@ var envFlags = {
+ 	})(),
+ 	unicodeSets: (() => {
+ 		try {
+-			new RegExp("[[]]", "v");
++			Reflect.construct(RegExp, ["[[]]", "v"]);
+ 		} catch {
+ 			return false;
+ 		}
+@@ -10004,7 +10004,7 @@ var envFlags = {
+ };
+ envFlags.bugFlagVLiteralHyphenIsRange = envFlags.unicodeSets ? (() => {
+ 	try {
+-		new RegExp(r`[\d\-a]`, "v");
++		Reflect.construct(RegExp, [r`[\d\-a]`, "v"]);
+ 	} catch {
+ 		return true;
+ 	}

--- a/patches/oniguruma-to-es@4.3.4.patch
+++ b/patches/oniguruma-to-es@4.3.4.patch
@@ -1,0 +1,62 @@
+diff --git a/dist/cjs/index.js b/dist/cjs/index.js
+index 221b21a34f9681afd54840a5d8f725fe69b890a3..16cdbf6502c4d5f969442c6e410a2df797b8def7 100644
+--- a/dist/cjs/index.js
++++ b/dist/cjs/index.js
+@@ -31,7 +31,7 @@ var r = String.raw;
+ var envFlags = {
+   flagGroups: (() => {
+     try {
+-      new RegExp("(?i:)");
++      Reflect.construct(RegExp, ["(?i:)"]);
+     } catch {
+       return false;
+     }
+@@ -39,7 +39,7 @@ var envFlags = {
+   })(),
+   unicodeSets: (() => {
+     try {
+-      new RegExp("[[]]", "v");
++      Reflect.construct(RegExp, ["[[]]", "v"]);
+     } catch {
+       return false;
+     }
+@@ -48,7 +48,7 @@ var envFlags = {
+ };
+ envFlags.bugFlagVLiteralHyphenIsRange = envFlags.unicodeSets ? (() => {
+   try {
+-    new RegExp(r`[\d\-a]`, "v");
++    Reflect.construct(RegExp, [r`[\d\-a]`, "v"]);
+   } catch {
+     return true;
+   }
+diff --git a/dist/esm/index.js b/dist/esm/index.js
+index eb64720c4918d4afeece67ccd8fd3c1b8e4997ce..b898d4d9726b9cb1bfccac45646f17789ea37636 100644
+--- a/dist/esm/index.js
++++ b/dist/esm/index.js
+@@ -4,7 +4,7 @@ var r = String.raw;
+ var envFlags = {
+   flagGroups: (() => {
+     try {
+-      new RegExp("(?i:)");
++      Reflect.construct(RegExp, ["(?i:)"]);
+     } catch {
+       return false;
+     }
+@@ -12,7 +12,7 @@ var envFlags = {
+   })(),
+   unicodeSets: (() => {
+     try {
+-      new RegExp("[[]]", "v");
++      Reflect.construct(RegExp, ["[[]]", "v"]);
+     } catch {
+       return false;
+     }
+@@ -21,7 +21,7 @@ var envFlags = {
+ };
+ envFlags.bugFlagVLiteralHyphenIsRange = envFlags.unicodeSets ? (() => {
+   try {
+-    new RegExp(r`[\d\-a]`, "v");
++    Reflect.construct(RegExp, [r`[\d\-a]`, "v"]);
+   } catch {
+     return true;
+   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,9 +9,15 @@ overrides:
   '@expo/metro-config>lightningcss': 1.30.1
 
 patchedDependencies:
+  '@pierre/diffs@1.2.9':
+    hash: wdjikkl65wfpocm6wrflymrtdq
+    path: patches/@pierre__diffs@1.2.9.patch
   expo-modules-jsi@57.0.4:
     hash: raucdrgf3mznkb7qkl7fkzjw5u
     path: patches/expo-modules-jsi@57.0.4.patch
+  oniguruma-to-es@4.3.4:
+    hash: f5db5z5xon23qqwgpdyyzpga5u
+    path: patches/oniguruma-to-es@4.3.4.patch
 
 importers:
 
@@ -118,7 +124,7 @@ importers:
         version: 1.1.6(react@19.2.4)
       '@pierre/diffs':
         specifier: ^1.2.9
-        version: 1.2.9(@shikijs/themes@3.23.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 1.2.9(patch_hash=wdjikkl65wfpocm6wrflymrtdq)(@shikijs/themes@3.23.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@pierre/trees':
         specifier: ^1.0.0-beta.3
         version: 1.0.0-beta.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -408,6 +414,9 @@ importers:
       mdast-util-to-hast:
         specifier: ^13.2.1
         version: 13.2.1
+      oniguruma-to-es:
+        specifier: ^4.3.4
+        version: 4.3.4(patch_hash=f5db5z5xon23qqwgpdyyzpga5u)
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
@@ -18380,7 +18389,7 @@ snapshots:
 
   '@petamoriken/float16@3.9.3': {}
 
-  '@pierre/diffs@1.2.9(@shikijs/themes@3.23.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@pierre/diffs@1.2.9(patch_hash=wdjikkl65wfpocm6wrflymrtdq)(@shikijs/themes@3.23.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@pierre/theme': 1.0.3
       '@pierre/theming': 0.0.1(@pierre/theme@1.0.3)(@shikijs/themes@3.23.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(shiki@3.23.0)
@@ -19440,7 +19449,7 @@ snapshots:
     dependencies:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 4.3.4
+      oniguruma-to-es: 4.3.4(patch_hash=f5db5z5xon23qqwgpdyyzpga5u)
 
   '@shikijs/engine-oniguruma@3.23.0':
     dependencies:
@@ -26163,7 +26172,7 @@ snapshots:
 
   oniguruma-parser@0.12.1: {}
 
-  oniguruma-to-es@4.3.4:
+  oniguruma-to-es@4.3.4(patch_hash=f5db5z5xon23qqwgpdyyzpga5u):
     dependencies:
       oniguruma-parser: 0.12.1
       regex: 6.1.0


### PR DESCRIPTION
## What was wrong

Issue #1603 reports the web app on an iPhone 8 Plus (iOS 16.x, so Safari 16.x) loading and then hiding its UI, including the Remote access entry. The reproduction report (https://get-bb.github.io/reports/issues/1603.html) found it is not CSS. Shiki's JavaScript regex engine, `oniguruma-to-es` (pulled in through `@pierre/diffs`), detects RegExp `v`-flag and modifier support at module top level with `try { new RegExp("[[]]", "v") } catch { return false } return true`. Rolldown and the oxc minifier treat `new RegExp(<literal>, <literal>)` as pure, delete it from the `try` block and fold the probe to `true`. The very next statement, `envFlags.unicodeSets && RegExp("[[^a]]", "v").test("a")`, then runs unguarded and throws `Invalid flags supplied to RegExp constructor.` on every engine without the `v` flag (Safari/iOS 16.4-16.6; Vite's default build target is `safari16.4`). The library degrades gracefully on its own; the bundler removes the guard. Neither `treeshake: false` nor `moduleSideEffects: "no-treeshake"` helps, because the minifier applies the same purity model.

On current `main` the chunk that carries this code (`dist-*.js`) is no longer in the home route's static closure, so the whole app no longer blanks as in the report. It is still imported statically by `plugin-frontend-*.js`, `BbSourceCode`, `TimelineFileDiffBlock`, `FileDiff`, `File` and the diff worker pool. On a Safari 16.x engine the plugin runtime therefore fails to load (`plugin runtime load failed: Invalid flags supplied to RegExp constructor.`), so plugin-contributed UI such as Remote access and Automations never renders, and any view that renders a diff or source code trips the app error boundary.

## What changed

- `patches/oniguruma-to-es@4.3.4.patch`: the three probes in `dist/esm/index.js` and `dist/cjs/index.js` construct the RegExp through `Reflect.construct(RegExp, [...])`, which the bundler cannot prove pure. Verified shapes: `new RegExp(...)` and `RegExp(...)` get folded; `Reflect.construct(RegExp, ...)` and `new globalThis.RegExp(...)` survive.
- `patches/@pierre__diffs@1.2.9.patch`: `dist/worker/worker-portable.js` (loaded by `src/lib/diff-worker-pool.ts` as a module worker) inlines its own copy of `oniguruma-to-es`, so the package patch alone does not reach it. Same three-line rewrite.
- `package.json` registers the two patches under `pnpm.patchedDependencies`; `pnpm-lock.yaml` picks up the patch hashes.
- `apps/app/package.json` adds `oniguruma-to-es` as a devDependency so the new test can bundle it directly.
- `apps/app/src/regex-engine-feature-probes.test.ts`: bundles `oniguruma-to-es` and `@pierre/diffs/worker/worker-portable.js` with the app's Vite/Rolldown build (minified) and evaluates the output in a `vm` context whose `RegExp` rejects the `v` flag and pattern modifiers like Safari 16. Asserts that the engine loads and compiles a pattern without the `v` flag, and that the worker reaches its `message` listener registration.

Deviation from the report's proposal: the report also suggests patching `regex@6.1.0`. The app reaches that package only through `regex/internals` (`atomic`, `possessive`, `RegExpSubclass`), which does not include its probes, so patching it would change nothing in the built output; I left it alone. Cause 1 from the report (regex lookbehind literals in `@pierre/diffs` and `mdast-util-gfm-autolink-literal`, Safari 16.0-16.3) is below Vite's declared `safari16.4` floor and is out of scope here; the app still shows the error card on a Safari 16.0-era engine. No wire changes; no CLI or doc surfaces.

## How you verified

Test fails before (patches removed from `package.json`, `pnpm install`), both cases at module top level of the bundle:

```
× oniguruma-to-es loads and picks a v-less target on Safari 16
× the @pierre/diffs portable worker evaluates on Safari 16
SyntaxError: Invalid flags supplied to RegExp constructor.
  ❯ SafariSixteenRegExp src/regex-engine-feature-probes.test.ts:65:13
  ❯ bundle.cjs:48:4094
```

Test passes after (`pnpm exec turbo run test --filter=@bb/app -- src/regex-engine-feature-probes.test.ts`): `Tests 2 passed (2)`.

Built output: `pnpm exec turbo run build --filter=bb-app --force`, then `grep -l "unicodeSets:!0" packages/bb-app/app/dist/assets/*.js` finds nothing (before: `dist-DdvSMfIo.js` and `worker-portable-DaFcwpf8.js`); both chunks now contain the `try{Reflect.construct(RegExp,[...])}catch{return!1}return!0` probes.

Browser check with the report's harness (Playwright webkit-1837, iPhone 8 Plus emulation, init script that makes the `RegExp` constructor reject flag `v` like Safari 16.4-16.6) against the packaged app on isolated ports:

- before: sidebar shows `New thread, Extensions, Threads, Settings`; console: `plugin runtime load failed: Invalid flags supplied to RegExp constructor.`; `has Remote access: false, has Automations: false`
- after: sidebar shows `New thread, Extensions, Automations, Threads, Settings, Remote access`; no errors; `has Remote access: true, has Automations: true`

Turbo, run from the committed tree after the final commit:

- `pnpm exec turbo run typecheck lint --filter=@bb/app`: `Tasks: 4 successful, 4 total`
- `pnpm exec turbo run test --filter=@bb/app --force`: `Tasks: 4 successful, 4 total` (`Test Files 410 passed (410)`, `Tests 3158 passed | 3 skipped (3161)`). One earlier full run had an unrelated flake in `TimelineRowDetails.output-preview.test.tsx` that passed on rerun.

Only `@bb/app` depends on the patched packages.

Fixes #1603

> AGENT GENERATED: by Claude Opus 5


## Independent verification

Checked out `bb/fix-1603-mobile-remote-access` (c3ed8ad84, one commit on top of current `origin/main`, no conflicts) in a separate worktree; `pnpm install --frozen-lockfile --prefer-offline` applied both patches (`node_modules/.pnpm/oniguruma-to-es@4.3.4_patch_hash=...`, `@pierre+diffs@1.2.9_patch_hash=...`).

Root cause: agrees with the report. `regex/internals` (`atomic.js`, `subclass.js`, `utils-internals.js`) never imports `regex/src/utils.js`, where that package's probes live, so leaving `regex` unpatched is correct. `@pierre/diffs` inlines the probe only in `dist/worker/worker-portable.js`. Only `apps/app` consumes either package in the workspace.

Fail-before / pass-after (same test file, `pnpm exec vitest run src/regex-engine-feature-probes.test.ts` in `apps/app`):

- before (root `package.json` + `pnpm-lock.yaml` from `origin/main`, `pnpm install`): both tests fail at bundle top level with `SyntaxError: Invalid flags supplied to RegExp constructor.` at `bundle.cjs:48:4094` and `bundle.cjs:59:4114`.
- after (PR files restored, frozen install): `Tests 2 passed (2)`.

`pnpm exec turbo run typecheck lint test --filter=@bb/app --force`: `Tasks: 6 successful, 6 total`; `Test Files 410 passed (410)`, `Tests 3158 passed | 3 skipped (3161)`; lint 0 errors (155 pre-existing warnings, none in the new file).

Built output: on the PR branch `grep -l "unicodeSets:!0" packages/bb-app/app/dist/assets/*.js` finds nothing and a scan for `RegExp(<literal>, "v")` calls finds only the two `unicodeSets && RegExp("[[^a]]","v")` statements, now behind a real runtime probe. The unpatched rebuild still contains the folded probe in `dist-DdvSMfIo.js` and `worker-portable-DaFcwpf8.js`.

Browser repro (report's harness: Playwright 1.33.0 webkit-1837, iPhone 8 Plus emulation, init script making `RegExp` reject flag `v` like Safari 16.4-16.6) against the packaged app on isolated ports 45231/45232 with a scratch data dir:

- unpatched build: `plugin runtime load failed: Invalid flags supplied to RegExp constructor.`; sidebar `New thread Extensions Threads Settings`; `hasRemoteAccess: false, hasAutomations: false`.
- PR build: no errors or warnings beyond WebKit preload notices; sidebar `New thread Extensions Automations Threads Settings Remote access`; `hasRemoteAccess: true, hasAutomations: true`, error boundary not shown.

CI: all checks green (Checks, app-1/2/3, integration, packages, server, both Package Smoke jobs).

Residual risks: the patches are pinned to `oniguruma-to-es@4.3.4` and `@pierre/diffs@1.2.9`; a version bump drops them (pnpm errors on the stale `patchedDependencies` entry, and the new test fails on the rebuilt output). Safari 16.0-16.3 still fails on regex lookbehind literals, below Vite's `safari16.4` target. The test emulates Safari 16 with a `vm` RegExp wrapper rather than a real WebKit build.

> AGENT GENERATED: by Claude Opus 5
