### PR TITLE
Make bb thread log truncation visible and add --all paging

### DIFF
--- a/apps/cli/src/__tests__/command-output/thread-log.test.ts
+++ b/apps/cli/src/__tests__/command-output/thread-log.test.ts
@@ -237,6 +237,252 @@ describe("bb thread log command output", () => {
     expect(getEvents).not.toHaveBeenCalled();
   });
 
+  it("bb thread log --json caps at --limit and warns on stderr when more events exist", async () => {
+    // The server lists ascending by sequence, so a capped page is the OLDEST
+    // events. Without a warning a grep over the default page looks like a
+    // search over the whole thread (#1768).
+    const events = Array.from({ length: 4 }, (_, index) => ({
+      id: `evt-${index + 1}`,
+      scope: { kind: "thread" },
+      threadId: "thread-json-log",
+      type: "system/error",
+      data: { code: "provider_unavailable" },
+      createdAt: 20 + index,
+      seq: index + 1,
+    }));
+    const getEvents = vi.fn(async () => events);
+    stubServerApi({
+      "v1.threads.:id.events.$get": getEvents,
+    });
+
+    await runCommand(
+      ["thread", "log", "thread-json-log", "--json", "--limit", "3"],
+      register,
+    );
+
+    expect(getEvents).toHaveBeenCalledWith({
+      param: { id: "thread-json-log" },
+      query: { limit: "4" },
+    });
+    expect(
+      JSON.parse(String(vi.mocked(console.log).mock.calls[0]?.[0])),
+    ).toEqual(events.slice(0, 3));
+    const stderr = collectLogLines(vi.mocked(console.error)).join("\n");
+    expect(stderr).toContain("oldest 3 events");
+    expect(stderr).toContain("--after-seq 3");
+    expect(stderr).toContain("--all");
+  });
+
+  it("bb thread log --json stays quiet when the page is not full", async () => {
+    const events = [
+      {
+        id: "evt-1",
+        scope: { kind: "thread" },
+        threadId: "thread-json-log",
+        type: "system/error",
+        data: { code: "provider_unavailable" },
+        createdAt: 20,
+        seq: 1,
+      },
+    ];
+    stubServerApi({
+      "v1.threads.:id.events.$get": vi.fn(async () => events),
+    });
+
+    await runCommand(["thread", "log", "thread-json-log", "--json"], register);
+
+    expect(
+      JSON.parse(String(vi.mocked(console.log).mock.calls[0]?.[0])),
+    ).toEqual(events);
+    expect(collectLogLines(vi.mocked(console.error))).toEqual([]);
+  });
+
+  it("bb thread log --json --all pages through every event with --after-seq", async () => {
+    const makeEvent = (seq: number) => ({
+      id: `evt-${seq}`,
+      scope: { kind: "thread" },
+      threadId: "thread-json-log",
+      type: "system/error",
+      data: { code: "provider_unavailable" },
+      createdAt: 20 + seq,
+      seq,
+    });
+    const getEvents = vi.fn(
+      async (input: { query: { afterSeq?: string; limit?: string } }) => {
+        const afterSeq = Number(input.query.afterSeq ?? 0);
+        const limit = Number(input.query.limit);
+        return Array.from({ length: 1203 }, (_, index) => makeEvent(index + 1))
+          .filter((event) => event.seq > afterSeq)
+          .slice(0, limit);
+      },
+    );
+    stubServerApi({
+      "v1.threads.:id.events.$get": getEvents,
+    });
+
+    await runCommand(
+      ["thread", "log", "thread-json-log", "--json", "--all"],
+      register,
+    );
+
+    const printed = JSON.parse(
+      String(vi.mocked(console.log).mock.calls[0]?.[0]),
+    ) as Array<{ seq: number }>;
+    expect(printed).toHaveLength(1203);
+    expect(printed[0]?.seq).toBe(1);
+    expect(printed[1202]?.seq).toBe(1203);
+    expect(getEvents.mock.calls.map((call) => call[0].query.afterSeq)).toEqual([
+      undefined,
+      "1000",
+    ]);
+    expect(collectLogLines(vi.mocked(console.error))).toEqual([]);
+  });
+
+  it("bb thread log prints an older-history notice when the timeline page is cut", async () => {
+    const getTimeline = vi.fn(async () => ({
+      ...fixtures.makeTimelineResponse([
+        fixtures.makePendingSteerTimelineRow(),
+      ]),
+      timelinePage: {
+        kind: "latest" as const,
+        segmentLimit: 20,
+        returnedSegmentCount: 20,
+        hasOlderRows: true,
+        olderCursor: { anchorSeq: 12, anchorId: "pending-steer-1" },
+      },
+    }));
+    stubServerApi({
+      "v1.threads.:id.timeline.$get": getTimeline,
+    });
+
+    await runCommand(["thread", "log", "thread-log"], register);
+
+    const output = String(vi.mocked(console.log).mock.calls[0]?.[0]);
+    expect(output).toContain("Please switch to the safer plan");
+    expect(output).toContain("newest 20 user-message turns");
+    expect(output).toContain("older history omitted");
+    expect(output).toContain("--all");
+  });
+
+  it("bb thread log --limit sets the timeline segment limit for human output", async () => {
+    const getTimeline = vi.fn(async () =>
+      fixtures.makeTimelineResponse([fixtures.makePendingSteerTimelineRow()]),
+    );
+    stubServerApi({
+      "v1.threads.:id.timeline.$get": getTimeline,
+    });
+
+    await runCommand(
+      ["thread", "log", "thread-log", "--format", "verbose", "--limit", "50"],
+      register,
+    );
+
+    expect(getTimeline).toHaveBeenCalledWith({
+      param: { id: "thread-log" },
+      query: { includeNestedRows: "true", segmentLimit: "50" },
+    });
+    const output = String(vi.mocked(console.log).mock.calls[0]?.[0]);
+    expect(output).toContain("Please switch to the safer plan");
+    expect(output).not.toContain("older history omitted");
+  });
+
+  it("bb thread log --all walks older timeline pages and prints them oldest first", async () => {
+    const makeUserRow = (id: string, seq: number, text: string) => ({
+      ...fixtures.makePendingSteerTimelineRow(),
+      ...fixtures.makeTimelineBase({ id, sourceSeqStart: seq }),
+      text,
+      turnRequest: {
+        isGrouped: false,
+        kind: "message" as const,
+        status: "accepted" as const,
+      },
+    });
+    const getTimeline = vi.fn(
+      async (input: {
+        query: { beforeAnchorSeq?: string; beforeAnchorId?: string };
+      }) => {
+        if (input.query.beforeAnchorSeq === undefined) {
+          return {
+            ...fixtures.makeTimelineResponse([
+              makeUserRow("user-3", 30, "third prompt"),
+            ]),
+            timelinePage: {
+              kind: "latest" as const,
+              segmentLimit: 100,
+              returnedSegmentCount: 1,
+              hasOlderRows: true,
+              olderCursor: { anchorSeq: 30, anchorId: "user-3" },
+            },
+          };
+        }
+        if (input.query.beforeAnchorSeq === "30") {
+          return {
+            ...fixtures.makeTimelineResponse([
+              makeUserRow("user-2", 20, "second prompt"),
+            ]),
+            timelinePage: {
+              kind: "older" as const,
+              segmentLimit: 100,
+              returnedSegmentCount: 1,
+              hasOlderRows: true,
+              olderCursor: { anchorSeq: 20, anchorId: "user-2" },
+            },
+          };
+        }
+        return {
+          ...fixtures.makeTimelineResponse([
+            makeUserRow("user-1", 10, "first prompt"),
+          ]),
+          timelinePage: {
+            kind: "older" as const,
+            segmentLimit: 100,
+            returnedSegmentCount: 1,
+            hasOlderRows: false,
+            olderCursor: null,
+          },
+        };
+      },
+    );
+    stubServerApi({
+      "v1.threads.:id.timeline.$get": getTimeline,
+    });
+
+    await runCommand(["thread", "log", "thread-log", "--all"], register);
+
+    expect(getTimeline.mock.calls.map((call) => call[0].query)).toEqual([
+      { segmentLimit: "100" },
+      { segmentLimit: "100", beforeAnchorSeq: "30", beforeAnchorId: "user-3" },
+      { segmentLimit: "100", beforeAnchorSeq: "20", beforeAnchorId: "user-2" },
+    ]);
+    const output = String(vi.mocked(console.log).mock.calls[0]?.[0]);
+    expect(output.indexOf("first prompt")).toBeGreaterThan(-1);
+    expect(output.indexOf("first prompt")).toBeLessThan(
+      output.indexOf("second prompt"),
+    );
+    expect(output.indexOf("second prompt")).toBeLessThan(
+      output.indexOf("third prompt"),
+    );
+    expect(output).not.toContain("older history omitted");
+  });
+
+  it("bb thread log rejects --all combined with --limit", async () => {
+    stubServerApi({
+      "v1.threads.:id.timeline.$get": vi.fn(async () =>
+        fixtures.makeTimelineResponse([]),
+      ),
+    });
+
+    await expect(
+      runCommand(
+        ["thread", "log", "thread-log", "--all", "--limit", "5"],
+        register,
+      ),
+    ).rejects.toThrow("process.exit:1");
+    expect(collectLogLines(vi.mocked(console.error)).join("\n")).toContain(
+      "--all cannot be combined with --limit",
+    );
+  });
+
   it("bb thread log --self resolves from BB_THREAD_ID", async () => {
     vi.stubEnv("BB_THREAD_ID", "thread-log-self");
     const getEvents = vi.fn(async () => []);

--- a/apps/cli/src/commands/thread/show.ts
+++ b/apps/cli/src/commands/thread/show.ts
@@ -7,6 +7,7 @@ import {
   resolveEnvironmentMergeBaseBranch,
   type Environment,
   type Thread,
+  type ThreadEventRow,
   type ThreadGitDiffResponse,
   type ThreadPullRequest,
   type ThreadTimelinePendingTodos,
@@ -48,7 +49,14 @@ interface ThreadLogCommandOptions {
   format?: string;
   limit?: string;
   afterSeq?: string;
+  all?: boolean;
 }
+
+const THREAD_LOG_DEFAULT_EVENT_LIMIT = 100;
+/** Page size for `--json --all`; bounds each response, not the total. */
+const THREAD_LOG_ALL_EVENTS_PAGE_SIZE = 1000;
+/** Server-side `segmentLimit` maximum (THREAD_TIMELINE_SEGMENT_LIMIT_MAX). */
+const THREAD_LOG_TIMELINE_SEGMENT_LIMIT_MAX = 100;
 
 interface ThreadOutputCommandOptions {
   json?: boolean;
@@ -440,11 +448,15 @@ export function registerShowCommand(
     )
     .option(
       "--limit <count>",
-      "Maximum number of events to return; json format only (default 100)",
+      `Maximum entries to print: events for json (oldest first, default ${THREAD_LOG_DEFAULT_EVENT_LIMIT}); user-message turns for minimal/verbose (newest first, default 20, max ${THREAD_LOG_TIMELINE_SEGMENT_LIMIT_MAX})`,
     )
     .option(
       "--after-seq <seq>",
       "Return events after this sequence number; json format only",
+    )
+    .option(
+      "--all",
+      "Print the whole thread by paging through every entry (cannot be combined with --limit)",
     )
     .action(
       action(async (id: string | undefined, opts: ThreadLogCommandOptions) => {
@@ -452,32 +464,78 @@ export function registerShowCommand(
         const sdk = createCliBbSdk(getUrl());
         const format = resolveThreadTimelineTextFormat(opts);
 
-        if (format !== "json" && (opts.limit || opts.afterSeq)) {
-          throw new Error(
-            "--limit and --after-seq are only supported with --format json",
-          );
+        if (opts.all && opts.limit !== undefined) {
+          throw new Error("--all cannot be combined with --limit");
+        }
+        if (format !== "json" && opts.afterSeq !== undefined) {
+          throw new Error("--after-seq is only supported with --format json");
         }
 
         if (format === "json") {
-          const events = await sdk.threads.events.list({
-            threadId,
-            limit: String(opts.limit ?? 100),
-            ...(opts.afterSeq ? { afterSeq: opts.afterSeq } : {}),
-          });
-          console.log(JSON.stringify(events, null, 2));
+          const events = opts.all
+            ? await listAllThreadLogEvents(sdk, threadId, opts.afterSeq)
+            : await listThreadLogEventsPage(sdk, {
+                threadId,
+                limit: parseThreadLogLimit(
+                  opts.limit,
+                  THREAD_LOG_DEFAULT_EVENT_LIMIT,
+                ),
+                afterSeq: opts.afterSeq,
+              });
+          console.log(JSON.stringify(events.rows, null, 2));
+          if (events.hasMore) {
+            const lastSeq = events.rows[events.rows.length - 1]?.seq;
+            console.error(
+              `Showing the oldest ${events.rows.length} events${
+                opts.afterSeq === undefined ? "" : ` after seq ${opts.afterSeq}`
+              }; more exist. Use --after-seq ${lastSeq} for the next page or --all for the whole thread.`,
+            );
+          }
           return;
         }
 
-        const timeline: ThreadTimelineResponse = await sdk.threads.timeline({
+        const segmentLimit = opts.all
+          ? THREAD_LOG_TIMELINE_SEGMENT_LIMIT_MAX
+          : parseThreadLogLimit(opts.limit, null);
+        if (
+          segmentLimit !== null &&
+          segmentLimit > THREAD_LOG_TIMELINE_SEGMENT_LIMIT_MAX
+        ) {
+          throw new Error(
+            `--limit must be at most ${THREAD_LOG_TIMELINE_SEGMENT_LIMIT_MAX} for minimal/verbose formats; use --all for the whole thread.`,
+          );
+        }
+        const timelineQuery = {
           threadId,
-          ...(format === "verbose" ? { includeNestedRows: "true" } : {}),
-        });
+          ...(format === "verbose"
+            ? { includeNestedRows: "true" as const }
+            : {}),
+          ...(segmentLimit === null
+            ? {}
+            : { segmentLimit: String(segmentLimit) }),
+        };
+        const timeline: ThreadTimelineResponse =
+          await sdk.threads.timeline(timelineQuery);
+        let rows = timeline.rows;
+        let page = timeline.timelinePage;
+        while (opts.all && page.hasOlderRows && page.olderCursor !== null) {
+          const older: ThreadTimelineResponse = await sdk.threads.timeline({
+            ...timelineQuery,
+            beforeAnchorSeq: String(page.olderCursor.anchorSeq),
+            beforeAnchorId: page.olderCursor.anchorId,
+          });
+          rows = [...older.rows, ...rows];
+          page = older.timelinePage;
+        }
         const color = process.stdout.isTTY === true && !process.env.NO_COLOR;
-        const text = formatThreadTimelineText(timeline.rows, {
+        const text = formatThreadTimelineText(rows, {
           verbose: format === "verbose",
           color,
         });
-        console.log(text);
+        const notice = page.hasOlderRows
+          ? `(Showing the newest ${page.returnedSegmentCount} user-message turns; older history omitted. Use --limit <n> (max ${THREAD_LOG_TIMELINE_SEGMENT_LIMIT_MAX}) or --all to see more.)`
+          : null;
+        console.log(notice === null ? text : `${text}\n\n${notice}`);
       }),
     );
 
@@ -571,6 +629,63 @@ function printEnvironmentPullRequest(
     `    Review:       ${pr.review.state} (${pr.review.reviewRequestCount} requested)`,
   );
   console.log(`    Merge:        ${pr.mergeability.state}`);
+}
+
+function parseThreadLogLimit<TDefault extends number | null>(
+  value: string | undefined,
+  defaultLimit: TDefault,
+): number | TDefault {
+  if (value === undefined) return defaultLimit;
+  if (!/^\d+$/u.test(value) || Number(value) < 1) {
+    throw new Error("--limit must be a positive integer.");
+  }
+  return Number(value);
+}
+
+interface ThreadLogEventsPage {
+  rows: ThreadEventRow[];
+  /** True when at least one more event follows the last row. */
+  hasMore: boolean;
+}
+
+/**
+ * `/events` lists ascending by sequence and applies LIMIT, so a capped page is
+ * the oldest events. Over-read by one row to know whether the page was cut
+ * instead of guessing from a full page.
+ */
+async function listThreadLogEventsPage(
+  sdk: BbSdk,
+  args: { threadId: string; limit: number; afterSeq: string | undefined },
+): Promise<ThreadLogEventsPage> {
+  const rows = await sdk.threads.events.list({
+    threadId: args.threadId,
+    limit: String(args.limit + 1),
+    ...(args.afterSeq === undefined ? {} : { afterSeq: args.afterSeq }),
+  });
+  const hasMore = rows.length > args.limit;
+  return { rows: hasMore ? rows.slice(0, args.limit) : rows, hasMore };
+}
+
+async function listAllThreadLogEvents(
+  sdk: BbSdk,
+  threadId: string,
+  afterSeq: string | undefined,
+): Promise<ThreadLogEventsPage> {
+  const rows: ThreadEventRow[] = [];
+  let cursor = afterSeq;
+  for (;;) {
+    const page = await sdk.threads.events.list({
+      threadId,
+      limit: String(THREAD_LOG_ALL_EVENTS_PAGE_SIZE),
+      ...(cursor === undefined ? {} : { afterSeq: cursor }),
+    });
+    rows.push(...page);
+    const last = page[page.length - 1];
+    if (last === undefined || page.length < THREAD_LOG_ALL_EVENTS_PAGE_SIZE) {
+      return { rows, hasMore: false };
+    }
+    cursor = String(last.seq);
+  }
 }
 
 function resolveThreadTimelineTextFormat(

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -410,7 +410,13 @@ or artifacts, validation performed, and blockers.
 - Use `bb thread show <thread-id>` for status, parent, environment, pull request
   status, and result.
 - Use `bb thread show <thread-id> --git-diff` to review file changes.
-- Use `bb thread log <thread-id>` to inspect the conversation.
+- Use `bb thread log <thread-id>` to inspect the conversation. The default
+  shows only the newest 20 user-message turns and ends with a notice when older
+  history was omitted; `--limit <n>` (max 100) widens the window and `--all`
+  prints the whole thread. `--json` prints the oldest 100 raw events and warns
+  on stderr when more exist; page with `--after-seq <seq>` or pass `--all`.
+  Grep the `--all` output, not the default page, when checking whether a
+  thread ever received a message.
 - Use `bb thread output <thread-id>` to read the latest final output, or
   `bb thread output --self` for the current thread.
 

--- a/packages/templates/src/templates/bb-guide-threads.md
+++ b/packages/templates/src/templates/bb-guide-threads.md
@@ -133,8 +133,13 @@ Inspecting:
   bb thread log [id]                       Show thread event log
     --self                                 Target current thread
     --format <format>                      Output format: json, minimal, verbose
-    --limit <count>                        Limit entries
-    --after-seq <seq>                      Paginate after sequence number
+    --limit <count>                        Max entries: events for json (oldest first, default 100);
+                                           user-message turns for minimal/verbose (newest first, default 20, max 100)
+    --after-seq <seq>                      Paginate after sequence number (json only)
+    --all                                  Print the whole thread, paging through every entry
+
+  Human formats end with a notice when older history was omitted; --json warns
+  on stderr when more events exist beyond the printed page.
 
   bb thread output [id]                    Get the final output of a thread
     --self                                 Target current thread


### PR DESCRIPTION
## What was wrong

`bb thread log` cut the thread silently in both formats. The human formats (`minimal`, `verbose`) render the timeline API's default page, which is the newest 20 user-message turns, and the CLI ignored the `timelinePage.hasOlderRows` flag the server returns. `--json` reads `GET /threads/:id/events?limit=100`, which lists ascending by sequence with `LIMIT`, so it printed the oldest 100 events and dropped the newest ones. Nothing in either output said the list was cut, and `--limit` was rejected outside `--json`. A grep over either default page looked like a search over the whole thread. Issue: #1768. Report: https://get-bb.github.io/reports/issues/1768.html

## What changed

`apps/cli/src/commands/thread/show.ts`:

- Human formats append a trailer when `timelinePage.hasOlderRows` is true: `(Showing the newest N user-message turns; older history omitted. Use --limit <n> (max 100) or --all to see more.)`.
- `--limit <count>` now works in every format. For `minimal`/`verbose` it maps to the timeline `segmentLimit` (newest first, default 20, max 100). For `json` it stays the event cap (oldest first, default 100).
- `--json` over-reads by one row and, when more events exist, prints the rows up to the limit and warns on stderr: `Showing the oldest 100 events; more exist. Use --after-seq 100 for the next page or --all for the whole thread.` stdout stays valid JSON.
- New `--all` pages through the whole thread: timeline pages via `olderCursor` (`beforeAnchorSeq`/`beforeAnchorId`, 100 segments per page, prepended oldest first) and `/events` via `afterSeq` in pages of 1000. `--all` with `--limit` is an error.
- `--after-seq` remains json-only.

No server, SDK, or wire changes; the timeline and events routes already supported this paging. `HOST_DAEMON_PROTOCOL_VERSION` is untouched.

Discoverable surfaces updated: `packages/templates/src/templates/bb-guide-threads.md` and `apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md` (tells agents to grep `--all`, not the default page, when checking whether a thread ever received a message).

Deviation from the report's proposal: one `--limit` flag per format instead of a separate `--segments`, and the JSON direction is documented plus warned about rather than flipped to newest-first, so existing `--after-seq` paging scripts keep working.

## How you verified

Added 6 tests in `apps/cli/src/__tests__/command-output/thread-log.test.ts`. With `show.ts` checked out from `origin/main` all 6 fail, for example:

```
× bb thread log prints an older-history notice when the timeline page is cut
AssertionError: expected '── User ────…' to contain 'newest 20 user-message turns'
× bb thread log --json caps at --limit and warns on stderr when more events exist
AssertionError: expected "vi.fn()" to be called with arguments: [ { query: { limit: "4" } } ]
× bb thread log rejects --all combined with --limit
AssertionError: expected '' to contain '--all cannot be combined with --limit'
```

With the fix: `Tests 14 passed (14)`.

From the committed tree (`git status --porcelain` empty):

```
pnpm exec turbo run typecheck test --filter=@bb/cli --filter=@bb/templates
 Tasks:    10 successful, 10 total
@bb/cli:test:        Tests 460 passed (460)
@bb/templates:test:  Tests 41 passed (41)
```

Also ran `apps/server` `test/skills` (6 files, 69 passed) for the SKILL.md consumers.

Manual check against my own dev instance with a `seed:perf` thread of 919 events / 25 user turns, running the built CLI with `BB_CLI` unset so it does not re-exec the installed binary:

- default: 20 `── User` blocks, ends with the older-history notice
- `--limit 30`, `--all`, `--all --format verbose`: 25 blocks, no notice; `--all` output is byte-identical to `--limit 30`
- `--limit 5 --format verbose`: 5 blocks plus notice; `--limit 500`: `--limit must be at most 100 ...`; `--limit 0`: `--limit must be a positive integer.`
- `--json`: 100 events seq 1-100, stderr `Showing the oldest 100 events; more exist. Use --after-seq 100 ...`
- `--json --after-seq 850`: 69 events seq 851-919, no warning
- `--json --all`: 919 events, seq 1-919, no duplicates

Fixes #1768

> AGENT GENERATED: by Claude Opus 5


## Independent verification

Checked out `d598b086e` on a fresh worktree (`git merge-base --is-ancestor origin/main HEAD` true; `mergeable: MERGEABLE`).

Fail-before / pass-after (`apps/cli`, `pnpm exec vitest run src/__tests__/command-output/thread-log.test.ts`):

- With `git checkout origin/main -- apps/cli/src/commands/thread/show.ts`: `Tests 6 failed | 8 passed (14)`, e.g. `AssertionError: expected '── User ────…' to contain 'newest 20 user-message turns'` and `expected '' to contain '--all cannot be combined with --limit'`.
- With the PR's `show.ts` restored: `Tests 14 passed (14)`.

`pnpm exec turbo run typecheck test --filter=@bb/cli --filter=@bb/templates --filter=@bb/server`: typecheck green for all three; `@bb/cli` 48 test files passed, `@bb/templates` 6 passed, `@bb/server` 1822/1823 passed. The single server failure is `test/internal/internal-skill-trees.test.ts` (file mode 0644 vs 0664), a known local umask-0002 artifact unrelated to this PR; the same job passes in CI.

Repro on the fixed branch (own dev instance, `seed:perf --projects 1 --threads 3 --events 3000`, thread `thr_rk6a3mv9zq` with 2417 events / 59 user turns, server `timelinePage.hasOlderRows: true`):

- default: 20 `── User` blocks, last line `(Showing the newest 20 user-message turns; older history omitted. Use --limit <n> (max 100) or --all to see more.)`
- `--limit 5 --format verbose`: 5 blocks + notice; `--limit 100`: 40 blocks (timeline event budget) + notice; `--limit 101`: `--limit must be at most 100 ...`; `--limit 0`: `--limit must be a positive integer.`
- `--all`: 59 blocks (matches 59 `client/turn/requested` events in `--json --all`), no notice, first prompt present (absent from the default page); `--all --format verbose`: 59 blocks
- `--all --limit 5` and human `--after-seq 5`: rejected with the expected errors
- `--json`: 100 events seq 1-100 plus stderr `Showing the oldest 100 events; more exist. Use --after-seq 100 for the next page or --all for the whole thread.`; `--json --limit 2416`: warns; `--json --limit 2417`: silent; `--json --after-seq 2400`: 17 events, silent
- `--json --all`: 2417 events, 2417 unique seqs, 1..2417; `--json --all --after-seq 2400`: 17 events

CI: all required checks pass (Checks, Tests app-1/2/3, server, packages, integration, Package Smoke ubuntu/macos, version checks).

Residual risks (minor, not blocking): when the server's event budget cuts a `--limit 100` page, the notice still suggests `--limit <n> (max 100)`; `qa/manual-runbook.md` pipes `--format json | jq '.[-10:]'` expecting the newest events and now gets the stderr warning instead of silent truncation; human `--all` can hit a stale-cursor 400 on a thread written to concurrently.

> AGENT GENERATED: by Claude Opus 5


## Rebase

Rebased onto `origin/main` at `c9aef7514` (was 32 commits behind, base `c942421a4`). No conflicts. Main touched two of the PR's files in unrelated sections: `e0175eb65` (HEIC/HEIF attachment note in `bb-cli/SKILL.md`) and `b0ac28cc6` (`bb tasks detach` note in `bb-cli/SKILL.md`); `show.ts`, `thread-log.test.ts`, and `bb-guide-threads.md` were untouched on main, so the fix applies as-is. Still one commit, same message.

Re-proved on the new base: with `apps/cli/src/commands/thread/show.ts` checked out from `origin/main`, `thread-log.test.ts` gives `Tests 6 failed | 8 passed (14)` (same three assertions quoted above); restored, `Tests 14 passed (14)`. From the committed tree, `pnpm exec turbo run typecheck test --filter=@bb/cli --filter=@bb/templates --filter=@bb/server`: `Tasks: 11 successful, 12 total`; `@bb/cli` `Tests 460 passed (460)`, `@bb/templates` `Tests 41 passed (41)`, `@bb/server` `1893 passed | 4 failed (1897)`. The server failures are the known umask `internal-skill-trees` artifact plus 5s timeouts in `test/services/plugins/plugin-update.test.ts` (git-clone tests, a different case each run, load average 67 on a 16-core box shared with other agents); neither exercises code this PR changes.

> AGENT GENERATED: by Claude Opus 5


## Independent verification (post-rebase)

Verified head `0013bae45` (rebased) in a fresh worktree. Merge base with `origin/main` is `75d6fc4d4`; main has since gained only `85eec4da6` (TestFlight CI), `git merge-tree --write-tree origin/main HEAD` is clean. `apps/cli/src/commands/thread/show.ts`, the `/events` and `/timeline` routes, and the SDK `timelineQuery` pass-through are unchanged on main since the base, so the fix still targets the right code.

Fail-before / pass-after (source files swapped to `origin/main`, tests kept):

- `git checkout origin/main -- apps/cli/src/commands/thread/show.ts apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md packages/templates/src/templates/bb-guide-threads.md` then `pnpm exec vitest run src/__tests__/command-output/thread-log.test.ts` (from `apps/cli`): `Tests 6 failed | 8 passed (14)`. Failing assertions: `expected '── User ────…' to contain 'newest 20 user-message turns'`, `expected '' to contain '--all cannot be combined with --limit'`, `expected "vi.fn()" to be called with arguments: [ { …(2) } ]` (segmentLimit / limit+1 query shapes).
- Restored (`git checkout HEAD -- ...`): `Tests 14 passed (14)`.

From the committed tree (`git status --porcelain` empty): `pnpm exec turbo run typecheck test --filter=@bb/cli --filter=@bb/templates --filter=@bb/server` -> `Tasks: 11 successful, 12 total`; typecheck green for all three; @bb/cli `Tests 460 passed (460)`, @bb/templates `Tests 41 passed (41)`, @bb/server `1 failed | 1896 passed (1897)`. The one server failure is `test/internal/internal-skill-trees.test.ts` (local umask 0664-vs-0644 artifact, unrelated, passes in CI).

Live repro on my own dev instance (PR build, `BB_CLI` unset so the worktree CLI ran instead of the daemon-managed binary): spawned a codex thread with `--model does-not-exist-model` and queued 24 more turns, giving 25 user turns / 158 events.

- `bb thread log <id>`: 20 turns (6..25) and trailer `(Showing the newest 20 user-message turns; older history omitted. Use --limit <n> (max 100) or --all to see more.)`
- `--limit 5`: 5 turns + trailer; `--limit 101`: `Error: --limit must be at most 100 ...`
- `--all` and `--format verbose --all`: all 25 turns, oldest first, no trailer.
- `--json`: 100 events (seq 1..100) on stdout, stderr `Showing the oldest 100 events; more exist. Use --after-seq 100 for the next page or --all for the whole thread.`; `--json --after-seq 100`: 58 events starting at seq 101, no warning; `--json --all`: 158 events, no warning; `--json --limit 158`: 158 events, no warning (over-read by one works at the exact boundary).
- `--all --limit 3` and `--after-seq 3` (human) are rejected with the documented errors.
- Walked `/timeline?segmentLimit=10` through `olderCursor` -> `beforeAnchorSeq/beforeAnchorId` by hand: pages were turns 16-25, 6-15, 1-5 with `hasOlderRows` false at the end; the cursor is exclusive and gap-free, so the `--all` loop cannot duplicate or skip a segment.

CI on `0013bae45`: all checks pass (Checks, Package Smoke x2, Tests app-1/2/3, integration, packages, server). PR is already in ready state; `mergeable: MERGEABLE`.

Residual risks: the human trailer goes to stdout, so a grep for words like "omitted" over minimal output will match the notice; `--json --all` fetches 1000-event pages with full event data, which is slow on very large threads but correct. No wire shape changed (CLI-only plus docs), so no `HOST_DAEMON_PROTOCOL_VERSION` bump is needed.

> AGENT GENERATED: by Claude Opus 5
