### PR TITLE
Highlight shell and other chat fences with sugar-high v2

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -110,7 +110,7 @@
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "sonner": "^1.7.4",
-    "sugar-high": "^1.2.1",
+    "sugar-high": "^2.0.1",
     "tailwind-merge": "^3.4.0",
     "tw-animate-css": "^1.4.0",
     "unist-util-visit": "^5.1.0",

--- a/apps/app/src/components/ui/markdown-code-highlight.test.ts
+++ b/apps/app/src/components/ui/markdown-code-highlight.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { highlightMarkdownCode } from "./markdown-code-highlight.js";
+
+function tokens(html: string): Array<[string, string]> {
+  return [
+    ...html.matchAll(/class="sh__token--(\w+)"[^>]*>([^<]*)<\/span>/g),
+  ].map((match) => [match[1]!, match[2]!]);
+}
+
+function tokenTypes(html: string): string[] {
+  return tokens(html).map(([type]) => type);
+}
+
+describe("highlightMarkdownCode", () => {
+  const shell = "# install the plugin\nbb plugin install ./plugins/monokai";
+
+  it.each(["sh", "bash", "shell", "zsh", "console", "shellscript"])(
+    "lexes a `#` comment in a %s fence as a comment, not a JS sign",
+    (language) => {
+      const html = highlightMarkdownCode({ code: shell, language });
+      expect(tokens(html)).toContainEqual(["comment", "# install the plugin"]);
+      // The JS lexer reads `/plugins/monokai` as a regex literal (string).
+      expect(tokenTypes(html)).not.toContain("string");
+    },
+  );
+
+  it("keeps the JavaScript lexer for fences without a language", () => {
+    const html = highlightMarkdownCode({
+      code: "const a = 1 // hi",
+      language: null,
+    });
+    expect(tokens(html)).toContainEqual(["keyword", "const"]);
+    expect(tokens(html)).toContainEqual(["comment", "// hi"]);
+  });
+
+  it("keeps the previously mapped aliases highlighted", () => {
+    expect(
+      tokens(highlightMarkdownCode({ code: "# c\nx = 1", language: "py" })),
+    ).toContainEqual(["comment", "# c"]);
+    expect(
+      tokens(
+        highlightMarkdownCode({ code: "int main() {}", language: "hpp" }),
+      ),
+    ).toContainEqual(["class", "int"]);
+    expect(
+      tokens(highlightMarkdownCode({ code: "a { color: red }", language: "less" })),
+    ).toContainEqual(["property", "color"]);
+    expect(
+      tokens(highlightMarkdownCode({ code: "fun f() {}", language: "kt" })),
+    ).toContainEqual(["keyword", "fun"]);
+  });
+
+  it("highlights languages agents emit that v1 never mapped", () => {
+    expect(
+      tokens(highlightMarkdownCode({ code: "# top\nkey: v", language: "yaml" })),
+    ).toContainEqual(["comment", "# top"]);
+    expect(
+      tokens(highlightMarkdownCode({ code: "-- c\nSELECT 1", language: "sql" })),
+    ).toContainEqual(["comment", "-- c"]);
+  });
+});

--- a/apps/app/src/components/ui/markdown-code-highlight.test.ts
+++ b/apps/app/src/components/ui/markdown-code-highlight.test.ts
@@ -24,14 +24,17 @@ describe("highlightMarkdownCode", () => {
     },
   );
 
-  it("keeps the JavaScript lexer for fences without a language", () => {
-    const html = highlightMarkdownCode({
-      code: "const a = 1 // hi",
-      language: null,
-    });
-    expect(tokens(html)).toContainEqual(["keyword", "const"]);
-    expect(tokens(html)).toContainEqual(["comment", "// hi"]);
-  });
+  it.each([null, "ruby"])(
+    "keeps the JavaScript lexer for a fence with language %j",
+    (language) => {
+      const html = highlightMarkdownCode({
+        code: "const a = 1 // hi",
+        language,
+      });
+      expect(tokens(html)).toContainEqual(["keyword", "const"]);
+      expect(tokens(html)).toContainEqual(["comment", "// hi"]);
+    },
+  );
 
   it("keeps the previously mapped aliases highlighted", () => {
     expect(

--- a/apps/app/src/components/ui/markdown-code-highlight.ts
+++ b/apps/app/src/components/ui/markdown-code-highlight.ts
@@ -1,28 +1,19 @@
-import { highlight } from "sugar-high";
-import { c, css, go, java, python, rust } from "sugar-high/presets";
+import { highlight, type LanguageName } from "sugar-high";
+import { lang } from "sugar-high/lang";
 
-// sugar-high's core highlighter targets JavaScript/JSX/TypeScript. These presets
-// extend it to the other languages agents emit most often. A language without a
-// preset falls through to the core highlighter, which still tokenizes
+// sugar-high resolves fence aliases it knows (`sh`/`bash`/`zsh` -> shell,
+// `py` -> python, `c++`/`cc` -> cpp, `yml` -> yaml, ...). These cover the
+// aliases agents emit that it does not know. A language it cannot resolve
+// falls through to the core JavaScript highlighter, which still tokenizes
 // identifiers, strings, and comments rather than failing.
-const PRESET_BY_LANGUAGE: Record<string, typeof rust> = {
-  rust,
-  rs: rust,
-  python,
-  py: python,
-  go,
-  c,
-  "c++": c,
-  cpp: c,
-  cc: c,
-  h: c,
-  hpp: c,
-  java,
-  kotlin: java,
-  kt: java,
-  css,
-  scss: css,
-  less: css,
+const EXTRA_LANGUAGE_ALIASES: Record<string, LanguageName> = {
+  console: "shell",
+  shellscript: "shell",
+  h: "c",
+  hpp: "cpp",
+  hh: "cpp",
+  hxx: "cpp",
+  less: "css",
 };
 
 interface HighlightMarkdownCodeArgs {
@@ -41,6 +32,9 @@ export function highlightMarkdownCode({
   code,
   language,
 }: HighlightMarkdownCodeArgs): string {
-  const preset = language === null ? undefined : PRESET_BY_LANGUAGE[language];
-  return highlight(code, preset);
+  const resolved =
+    language === null
+      ? undefined
+      : (lang(language) ?? EXTRA_LANGUAGE_ALIASES[language]);
+  return highlight(code, { lang: resolved });
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -81,7 +81,7 @@
     "remark-math": "^6.0.0",
     "remark-parse": "^11.0.0",
     "sonner-native": "^0.27.0",
-    "sugar-high": "^1.2.1",
+    "sugar-high": "^2.0.1",
     "tailwind-merge": "^3.4.0",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0",

--- a/apps/mobile/src/markdown/code.test.ts
+++ b/apps/mobile/src/markdown/code.test.ts
@@ -45,10 +45,25 @@ describe("tokenizeCodeLines", () => {
     ]);
   });
 
+  it.each(["sh", "bash", "zsh", "shell", "console"])(
+    "lexes a `#` comment in a %s fence as a comment, not JS punctuation",
+    (language) => {
+      const lines = tokenizeCodeLines(
+        "# install the plugin\nbb plugin install ./plugins/monokai",
+        language,
+      );
+      expect(lines[0]).toEqual([
+        { text: "# install the plugin", type: "comment" },
+      ]);
+      // The JS lexer reads `/plugins/monokai` as a regex literal (string).
+      expect(lines[1]!.some((span) => span.type === "string")).toBe(false);
+    },
+  );
+
   it("renders an unknown language through the core tokenizer", () => {
-    const lines = tokenizeCodeLines('echo "hi" # c', "bash");
+    const lines = tokenizeCodeLines('puts "hi" # c', "ruby");
     expect(lines).toHaveLength(1);
-    expect(lines[0]!.map((span) => span.text).join("")).toBe('echo "hi" # c');
+    expect(lines[0]!.map((span) => span.text).join("")).toBe('puts "hi" # c');
     expect(lines[0]!.some((span) => span.type === "string")).toBe(true);
   });
 });

--- a/apps/mobile/src/markdown/code.test.ts
+++ b/apps/mobile/src/markdown/code.test.ts
@@ -60,12 +60,19 @@ describe("tokenizeCodeLines", () => {
     },
   );
 
-  it("renders an unknown language through the core tokenizer", () => {
-    const lines = tokenizeCodeLines('puts "hi" # c', "ruby");
-    expect(lines).toHaveLength(1);
-    expect(lines[0]!.map((span) => span.text).join("")).toBe('puts "hi" # c');
-    expect(lines[0]!.some((span) => span.type === "string")).toBe(true);
-  });
+  it.each([null, "ruby"])(
+    "lexes a fence with language %j with the JavaScript tokenizer",
+    (language) => {
+      const lines = tokenizeCodeLines(
+        "const a = 'x' // hi\nfunction f() { return a }",
+        language,
+      );
+      expect(lines).toHaveLength(2);
+      expect(lines[0]![0]).toEqual({ text: "const", type: "keyword" });
+      expect(lines[0]!.at(-1)).toEqual({ text: "// hi", type: "comment" });
+      expect(lines[1]![0]).toEqual({ text: "function", type: "keyword" });
+    },
+  );
 });
 
 describe("codeTokenColor", () => {

--- a/apps/mobile/src/markdown/code.ts
+++ b/apps/mobile/src/markdown/code.ts
@@ -5,9 +5,11 @@ import { lang, languages } from "sugar-high/lang";
 /**
  * Fenced-code tokenization for the native renderer. `sugar-high` ships
  * tokenizer configs for the languages agents emit most often and resolves
- * the fence aliases it knows (`sh`/`bash`/`zsh` -> shell, `py` -> python, ...);
- * a language it cannot resolve falls through to the core JavaScript
- * tokenizer, which still tokenizes identifiers, strings, and comments.
+ * the fence aliases it knows (`sh`/`bash`/`zsh` -> shell, `py` -> python, ...).
+ * A fence with no language, or one it cannot resolve, uses the JavaScript
+ * tokenizer, exactly like sugar-high's own `highlight()`; `sugar-high/core`'s
+ * bare `tokenize(code, undefined)` is a generic lexer with no keywords or
+ * comments, so it is never called without a config.
  * Mirrors the web's `markdown-code-highlight.ts`, but returns a span model
  * instead of HTML.
  */
@@ -44,11 +46,12 @@ const EXTRA_LANGUAGE_ALIASES: Record<string, LanguageName> = {
   less: "css",
 };
 
-function tokenizerConfigFor(language: string) {
-  const resolved = lang(language) ?? EXTRA_LANGUAGE_ALIASES[language];
-  return resolved === undefined
-    ? undefined
-    : languages.find(({ id }) => id === resolved)?.config;
+function tokenizerConfigFor(language: string | null) {
+  const resolved =
+    language === null
+      ? "javascript"
+      : (lang(language) ?? EXTRA_LANGUAGE_ALIASES[language] ?? "javascript");
+  return languages.find(({ id }) => id === resolved)?.config;
 }
 
 /**
@@ -125,10 +128,9 @@ export function tokenizeCodeLines(
   ) {
     return plainLines(code);
   }
-  const config = language === null ? undefined : tokenizerConfigFor(language);
   let tokens: Array<[number, string]>;
   try {
-    tokens = tokenize(code, config);
+    tokens = tokenize(code, tokenizerConfigFor(language));
   } catch {
     return plainLines(code);
   }

--- a/apps/mobile/src/markdown/code.ts
+++ b/apps/mobile/src/markdown/code.ts
@@ -1,12 +1,15 @@
-import { SugarHigh, tokenize } from "sugar-high";
-import { c, css, go, java, python, rust } from "sugar-high/presets";
+import type { LanguageName } from "sugar-high";
+import { SugarHigh, tokenize } from "sugar-high/core";
+import { lang, languages } from "sugar-high/lang";
 
 /**
- * Fenced-code tokenization for the native renderer. `sugar-high` targets
- * JS/TS and ships presets for the other languages agents emit most often; a
- * language without a preset falls through to the core highlighter, which
- * still tokenizes identifiers, strings, and comments. Mirrors the web's
- * `markdown-code-highlight.ts`, but returns a span model instead of HTML.
+ * Fenced-code tokenization for the native renderer. `sugar-high` ships
+ * tokenizer configs for the languages agents emit most often and resolves
+ * the fence aliases it knows (`sh`/`bash`/`zsh` -> shell, `py` -> python, ...);
+ * a language it cannot resolve falls through to the core JavaScript
+ * tokenizer, which still tokenizes identifiers, strings, and comments.
+ * Mirrors the web's `markdown-code-highlight.ts`, but returns a span model
+ * instead of HTML.
  */
 
 export type CodeTokenType =
@@ -30,27 +33,23 @@ export interface CodeSpan {
 /** One source line as spans (no trailing newline). */
 export type CodeLine = CodeSpan[];
 
-type Preset = typeof rust;
-
-const PRESET_BY_LANGUAGE: Record<string, Preset> = {
-  rust,
-  rs: rust,
-  python,
-  py: python,
-  go,
-  c,
-  "c++": c,
-  cpp: c,
-  cc: c,
-  h: c,
-  hpp: c,
-  java,
-  kotlin: java,
-  kt: java,
-  css,
-  scss: css,
-  less: css,
+/** Fence aliases agents emit that sugar-high's `lang()` does not resolve. */
+const EXTRA_LANGUAGE_ALIASES: Record<string, LanguageName> = {
+  console: "shell",
+  shellscript: "shell",
+  h: "c",
+  hpp: "cpp",
+  hh: "cpp",
+  hxx: "cpp",
+  less: "css",
 };
+
+function tokenizerConfigFor(language: string) {
+  const resolved = lang(language) ?? EXTRA_LANGUAGE_ALIASES[language];
+  return resolved === undefined
+    ? undefined
+    : languages.find(({ id }) => id === resolved)?.config;
+}
 
 /**
  * Beyond this size a block renders as plain monospace text: a single RN
@@ -59,12 +58,8 @@ const PRESET_BY_LANGUAGE: Record<string, Preset> = {
  */
 export const CODE_HIGHLIGHT_CHAR_LIMIT = 20_000;
 
-const TOKEN_TYPE_NAMES: readonly string[] = SugarHigh.TokenTypes as unknown as
-  | string[]
-  | readonly string[];
-
 function tokenTypeName(index: number): CodeTokenType {
-  const name = TOKEN_TYPE_NAMES[index];
+  const name: string | undefined = SugarHigh.TokenTypes[index];
   switch (name) {
     case "identifier":
     case "keyword":
@@ -130,10 +125,10 @@ export function tokenizeCodeLines(
   ) {
     return plainLines(code);
   }
-  const preset = language === null ? undefined : PRESET_BY_LANGUAGE[language];
+  const config = language === null ? undefined : tokenizerConfigFor(language);
   let tokens: Array<[number, string]>;
   try {
-    tokens = tokenize(code, preset);
+    tokens = tokenize(code, config);
   } catch {
     return plainLines(code);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9328,7 +9328,7 @@ packages:
 
   bunyan@1.8.15:
     resolution: {integrity: sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
     hasBin: true
 
   bytes@3.1.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,8 +333,8 @@ importers:
         specifier: ^1.7.4
         version: 1.7.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       sugar-high:
-        specifier: ^1.2.1
-        version: 1.2.1
+        specifier: ^2.0.1
+        version: 2.0.1
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -987,8 +987,8 @@ importers:
         specifier: ^0.27.0
         version: 0.27.0(ytus57gfkrxml7qskqnrmg44xq)
       sugar-high:
-        specifier: ^1.2.1
-        version: 1.2.1
+        specifier: ^2.0.1
+        version: 2.0.1
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -9328,7 +9328,7 @@ packages:
 
   bunyan@1.8.15:
     resolution: {integrity: sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
     hasBin: true
 
   bytes@3.1.2:
@@ -14320,8 +14320,8 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
-  sugar-high@1.2.1:
-    resolution: {integrity: sha512-C2E0iSC0Gwv+7t32ATFxgiH6fxskoSfd/nF5z11pQSrgJHYjY8/U11K+X0izV9ZyPNPwaomtn6uF7y11MxVNQA==}
+  sugar-high@2.0.1:
+    resolution: {integrity: sha512-scKbPz1/VAta3pTimoyhUB9CLYiQPvwsfE01tEcUoPuE3TfWnum8fl+0muGfUOXiBCjjmclMbEq8LBXu2smkYg==}
 
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
@@ -27848,7 +27848,7 @@ snapshots:
       pirates: 4.0.7
       ts-interface-checker: 0.1.13
 
-  sugar-high@1.2.1: {}
+  sugar-high@2.0.1: {}
 
   sumchecker@3.0.1:
     dependencies:


### PR DESCRIPTION
## What was wrong

Fenced code blocks in chat are highlighted client-side by sugar-high 1.2.1, whose core lexer only knows JavaScript. `apps/app/src/components/ui/markdown-code-highlight.ts` mapped only rust/python/go/c/java/css fences to v1 presets. Every other fence language (`sh`, `bash`, `zsh`, `console`, `yaml`, `toml`, `sql`, `diff`, `json`, ...) got `preset = undefined` and ran through the JavaScript lexer. In a ```` ```sh ```` block, `# install the plugin` became a `sign` plus three `identifier`s painted in the full foreground color, and `./plugins/monokai` became a green `string` because the JS lexer read `/plugins/monokai` as a regex literal. v1 ships no shell preset, so the map could not be extended without writing a lexer. The mobile renderer (`apps/mobile/src/markdown/code.ts`) mirrored the same map and had the same gap.

Issue: #1751. Report: https://get-bb.github.io/reports/issues/1751.html

## What changed

- `apps/app/package.json`, `apps/mobile/package.json`, `pnpm-lock.yaml`: bump `sugar-high` from `^1.2.1` to `^2.0.1`. v2 ships 25 language tokenizers (shell, yaml, toml, sql, json, diff, html, markdown, dockerfile, kotlin, cpp, ...) and a `lang()` alias resolver. It is a major version: the root export dropped `tokenize`/`SugarHigh` (now in `sugar-high/core`) and `sugar-high/presets` is gone. These two files are the only importers in the repo. The lockfile diff is only the two `sugar-high` entries.
- `apps/app/src/components/ui/markdown-code-highlight.ts`: replace the preset map with `lang(language)` plus a small `EXTRA_LANGUAGE_ALIASES` table for fence names v2 does not resolve but the old map (or agents) use: `console`/`shellscript` -> shell, `h` -> c, `hpp`/`hh`/`hxx` -> cpp, `less` -> css. A fence with no language or an unresolved language still goes through the JavaScript lexer as before (sugar-high's root `highlight()` maps `lang: undefined` to its `javascript` config).
- `apps/mobile/src/markdown/code.ts`: same resolution, using `tokenize` from `sugar-high/core` and the per-language `config` from `sugar-high/lang`. A fence with no language or an unresolved language resolves to the `javascript` config explicitly. This matters in v2: `tokenize(code, undefined)` from `sugar-high/core` is now a generic lexer with an empty keyword set and no comment handlers (in v1 it was the JavaScript lexer), so passing `undefined` would have stripped keyword and comment highlighting from every plain ```` ``` ```` block on mobile. The first revision of this PR did exactly that; the verifier caught it and this revision fixes it. Also drops the `as unknown as string[]` cast on `SugarHigh.TokenTypes`, which v2 types as `{ [key: number]: string }`.
- v2 output keeps the `sh__line` / `sh__token--*` classes and `--sh-*` variables, so `markdown-code-highlight.css` and the mobile palette are unchanged.

No wire change, no CLI change.

## How you verified

New test `apps/app/src/components/ui/markdown-code-highlight.test.ts` and new cases in `apps/mobile/src/markdown/code.test.ts`. Both files include a `null` / `ruby` (unknown language) case asserting `const` is a `keyword` and `// hi` is a `comment`.

On origin/main source with sugar-high 1.2.1 installed (`git checkout origin/main -- <source files + package.json + lockfile>` + `pnpm install --frozen-lockfile`), only the shell/new-language cases fail; the `null`/`ruby` cases pass, so they guard v1 behavior:

```
@bb/app    Tests  8 failed | 2 passed (10)
AssertionError: expected [ [ 'sign', '#' ], …(14) ] to deep equally contain [ 'comment', '# install the plugin' ]
@bb/mobile Tests  5 failed | 6 passed (11)
AssertionError: expected [ { text: '#', type: 'sign' }, …(6) ] to deeply equal [ { …(2) } ]
```

On the first revision of this branch (46ba725f5, `undefined` config on mobile), the new mobile `null`/`ruby` cases fail:

```
@bb/mobile Tests  2 failed | 9 passed (11)
AssertionError: expected { text: 'const', type: 'identifier' } to deeply equal { text: 'const', type: 'keyword' }
```

On this branch both files pass (10/10 and 11/11). From the committed tree (`git status --porcelain` empty):

```
pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/mobile   # Tasks: 4 successful, 4 total
pnpm exec turbo run test --filter=@bb/app --filter=@bb/mobile        # Tasks: 5 successful, 5 total
                                                                      # @bb/app 3166 passed | 3 skipped; @bb/mobile 833 passed
```

`pnpm install --frozen-lockfile` passes with the lockfile containing only the `sugar-high` hunks.

Manual (web, first revision; the web source is unchanged since): started my own dev instance, spawned a claude-code thread whose prompt held a ```` ```sh ```` and a ```` ```python ```` fence with the same `# install the plugin` first line, and dumped the DOM with doobie. Both blocks render the first line as one `sh__token--comment` (computed color `oklch(0.5 0 0)`, the subtle tier) and the `sh` block has no `sh__token--string` for `./plugins/monokai`. Before the fix the report shows the same line as `sign` + identifiers at full foreground and the path in green.

Fixes #1751

> AGENT GENERATED: by Claude Opus 5


## Independent verification

Verified at `b09884bfe` (round 2) in a separate worktree, rebased state confirmed with `git merge-base --is-ancestor origin/main HEAD`.

**Root cause check.** Confirmed independently against sugar-high 1.2.1 and 2.0.1 sources: v1 `highlight(code, undefined)` is the JS lexer and v1 ships no shell preset; v2 `lib/index.js` `configFor(name)` resolves `name || 'javascript'`, while `lib/core.js` `tokenize(code, undefined)` is the generic no-keyword/no-comment lexer. The revised mobile `tokenizerConfigFor` resolves `null`/unknown to the `javascript` config, matching the web path. v2 still emits `sh__line` / `sh__token--*` / `var(--sh-*)` with identical shape for empty lines and still HTML-escapes (`<script>` -> `&lt;script&gt;`), so `markdown-code-highlight.css` and `dangerouslySetInnerHTML` are unaffected. Metro already resolves sugar-high subpath exports (`./presets` on v1), so `./core` and `./lang` resolve the same way. No other importers of sugar-high exist in the repo.

**Fail-before / pass-after.**
- `git checkout origin/main -- apps/app/src/components/ui/markdown-code-highlight.ts apps/mobile/src/markdown/code.ts apps/app/package.json apps/mobile/package.json pnpm-lock.yaml && pnpm install --frozen-lockfile --prefer-offline` (sugar-high 1.2.1 installed), then `pnpm exec vitest run` on the PR's two test files: app `8 failed | 2 passed (10)` with `AssertionError: expected [ [ 'sign', '#' ], …(14) ] to deep equally contain [ 'comment', '# install the plugin' ]`; mobile `5 failed | 6 passed (11)` with `expected [ { text: '#', type: 'sign' }, …(6) ] to deeply equal [ { …(2) } ]`. The null/ruby cases pass on main, so they guard v1 behavior.
- Round-1 regression guard: with only `apps/mobile/src/markdown/code.ts` at `46ba725f5` (v2 installed), mobile `2 failed | 9 passed` with `expected { text: 'const', type: 'identifier' } to deeply equal { text: 'const', type: 'keyword' }`.
- Restored `HEAD` files, reinstalled (2.0.1): mobile `11 passed (11)`, app `10 passed (10)`.

**Turbo (forced, from the committed tree, `git status --porcelain` empty).**
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/mobile --force` -> `Tasks: 4 successful, 4 total`
- `pnpm exec turbo run test --filter=@bb/app --filter=@bb/mobile --force` -> `Tasks: 5 successful, 5 total` (@bb/app 3166 passed | 3 skipped, @bb/mobile 833 passed)

**Repro on the fixed branch.** Own dev instance (`scripts/bb-dev-app current`, app :17771), project `proj_w583gwhs6b`, thread `thr_qaybud2d5f` (claude-code, "Reply only with ok." plus the report's ```sh and ```python fences). Headless Chromium DOM dump of the rendered user message: SH block first line is a single `sh__token--comment` "# install the plugin" with computed color `oklch(0.5 0 0)` (same as the PYTHON control), and the block contains no `sh__token--string` (`./plugins/monokai` is no longer a regex literal). No longer reproduces.

**CI.** All checks on `b09884bfe` pass (Checks, Package Smoke ubuntu + macOS, Tests app-1/2/3, integration, server, packages, version check); iOS simulator flows and Node compatibility smoke skipped as usual.

**Residual risks.** Major bump of sugar-high: token assignment for already-mapped languages can shift slightly (colors, not content). Languages v2 still lacks (ruby, lua, ini, ...) stay on the JS lexer as before. v2 emits an empty `sh__token--comment` span at the start of the line after a `#` comment; harmless markup. Bundle grows by 25 small language tables.

> AGENT GENERATED: by Claude Opus 5
