### PR TITLE
[for #2153] parity: rerecord lanes against a v3 assembler + replay timing fixes

### DIFF
--- a/docs/provider-bridge-protocol.md
+++ b/docs/provider-bridge-protocol.md
@@ -390,6 +390,16 @@ the pins and replays every cell through the current bridge on each commit,
 and `UPDATE_PARITY_ROW_COUNTS=1` rewrites the pins deliberately. Raw
 recordings stay out of git.
 
+A recording is never rewritten. When a bridge change alters what the bridge
+emits for a recording, `pnpm --filter @bb/provider-parity rerecord
+[--plan-with <recording-time checkout>]` writes the bridge's current output
+to `bridge→runtime.current.ndjson` beside the recorded lane; the self-suite
+pins and compares against that file when it exists, while `pnpm parity`
+still paces a pre-migration leg from the recorded lane (and the current leg
+from the current one). `pnpm parity --dump-dir <dir>` writes both legs'
+normalized event and row lists per cell, for allowlist entries that must
+name a list index.
+
 The conformance kit runs the same recordings as its recorded-traffic
 scenario set: `replayRecordedCells` replays a bridge's cells and
 `checkRecordedCellReplay` reports `recorded/<cell>/{replays,

--- a/packages/provider-bridge-protocol/src/testing/parity.ts
+++ b/packages/provider-bridge-protocol/src/testing/parity.ts
@@ -36,6 +36,7 @@ import {
   COMMITTED_RECORDINGS_ROOT,
   listRecordedCells,
   readBridgeRecording,
+  withCurrentBridgeLane,
   type BridgeRecording,
   type RecordedCell,
 } from "./recording.js";
@@ -348,6 +349,20 @@ export interface ReplayRecordingOptions {
   recordingDir: string;
   bridge: ParityBridgeSpec;
   createAssembler: CreateParityAssembler;
+  /**
+   * The assembler that plans the replay's gates from the recorded
+   * `bridge→runtime` lane; defaults to `createAssembler`. A re-recording run
+   * on a checkout whose grammar no longer accepts the whole recorded lane
+   * plans with the recording-time checkout's assembler instead.
+   */
+  createPlanAssembler?: CreateParityAssembler;
+  /**
+   * Plan the replay's gates from the cell's current bridge lane
+   * (`bridge→runtime.current.ndjson`, see `withCurrentBridgeLane`) when one
+   * exists, instead of the recorded lane. The leg whose bridge wrote that
+   * lane parses all of it; the recording-time leg parses the recorded lane.
+   */
+  planFromCurrentLane?: boolean;
   /** Per-wait timeout for a gate or a response. */
   timeoutMs?: number;
   /**
@@ -358,6 +373,14 @@ export interface ReplayRecordingOptions {
   orderTimeoutMs?: number;
   /** Quiet period after the last request before the bridge is closed. */
   settleMs?: number;
+  /**
+   * Quiet period a request waits for once the gates are met. The replay child
+   * plays every provider line before the request's cursor point a couple of
+   * milliseconds apart, so a short silence means the bridge has emitted all
+   * that the pre-request stream produces; without it a request the bridge
+   * acknowledges at once (a steer) lands at a load-dependent point.
+   */
+  drainMs?: number;
   /** Mirror the bridge's stderr (and the replay child's logs) here. */
   onStderr?: (text: string) => void;
 }
@@ -375,6 +398,12 @@ export interface ParityRun {
   lines: string[];
   /** When each line arrived, ms since the replay started (diagnostics). */
   lineTimes: number[];
+  /**
+   * For each line, the recorded `runtime→bridge` entry written last before
+   * it arrived (null before any was sent) — where the line sits in the
+   * recording's wire order, for a lane re-recorded through this bridge.
+   */
+  lineAfter: Array<{ run: number; seq: number; ts: number } | null>;
   /** Assembled events, minus the ones the grammar dropped (as the runtime does). */
   events: ThreadEvent[];
   grammarViolations: ParityGrammarViolation[];
@@ -502,6 +531,7 @@ export async function replayRecording(options: ReplayRecordingOptions): Promise<
   // waits this long, while a slow CI runner must never trip it for a healthy one.
   const orderTimeoutMs = options.orderTimeoutMs ?? 5_000;
   const settleMs = options.settleMs ?? 750;
+  const drainMs = options.drainMs ?? 300;
   const providerId = options.bridge.providerId;
   const profile = resolveReplayProfile(providerId);
   const recording = readBridgeRecording(options.recordingDir);
@@ -557,14 +587,19 @@ export async function replayRecording(options: ReplayRecordingOptions): Promise<
   const startedAt = Date.now();
   const lines: string[] = [];
   const lineTimes: number[] = [];
+  const lineAfter: ParityRun["lineAfter"] = [];
+  let lastSentRuntimeEntry: { run: number; seq: number; ts: number } | null = null;
   const events: ThreadEvent[] = [];
   const grammarViolations: ParityGrammarViolation[] = [];
   const stalls: string[] = [];
   let stderr = "";
   const grammar = new ThreadEventGrammar();
   const liveAssembler = options.createAssembler(providerId);
-  const planAssembler = options.createAssembler(providerId);
-  const steps = planRuntimeSteps(recording, planAssembler);
+  const planAssembler = (options.createPlanAssembler ?? options.createAssembler)(providerId);
+  const steps = planRuntimeSteps(
+    options.planFromCurrentLane === true ? withCurrentBridgeLane(recording) : recording,
+    planAssembler,
+  );
 
   const answeredIds = new Set<string>();
   const pendingBridgeRequests: { id: string | number; method: string }[] = [];
@@ -619,6 +654,7 @@ export async function replayRecording(options: ReplayRecordingOptions): Promise<
       lastOutputAt = Date.now();
       lines.push(line);
       lineTimes.push(lastOutputAt - startedAt);
+      lineAfter.push(lastSentRuntimeEntry);
       const message = parseWire(line);
       if (message === null) return;
       if (isResponse(message)) {
@@ -698,6 +734,7 @@ export async function replayRecording(options: ReplayRecordingOptions): Promise<
       // Responses are replayed on demand when the bridge asks; notifications
       // go straight through.
       if (step.message !== null && !isResponse(step.message)) {
+        lastSentRuntimeEntry = { run: step.entry.run, seq: step.entry.seq, ts: step.entry.ts };
         write(step.entry.line);
       }
       continue;
@@ -730,6 +767,12 @@ export async function replayRecording(options: ReplayRecordingOptions): Promise<
       timeoutMs,
       false,
     );
+    await waitFor(
+      `the stream to drain before ${method}`,
+      () => Date.now() - lastOutputAt >= drainMs,
+      timeoutMs,
+      false,
+    );
     if (child.exitCode !== null) break;
     if (
       method === "thread/stop" &&
@@ -746,6 +789,7 @@ export async function replayRecording(options: ReplayRecordingOptions): Promise<
       profile.rewriteRuntimeLine === undefined
         ? rewritten
         : profile.rewriteRuntimeLine(rewritten, { replayCommand });
+    lastSentRuntimeEntry = { run: step.entry.run, seq: step.entry.seq, ts: step.entry.ts };
     write(line);
     sentRequestIds.push(String(request.id));
     // Release the provider lines up to the next runtime request.
@@ -775,6 +819,7 @@ export async function replayRecording(options: ReplayRecordingOptions): Promise<
     recordingDir: options.recordingDir,
     lines,
     lineTimes,
+    lineAfter,
     events,
     grammarViolations,
     stalls,
@@ -1085,8 +1130,11 @@ export async function replayRecordedCells(
   );
   return Promise.all(
     cells.map(async (cell): Promise<RecordedCellReplay> => {
+      // The expectation is this checkout's current bridge lane when a bridge
+      // change wrote one (`pnpm rerecord`), else the recorded lane; the
+      // replay paces itself from the same lane.
       const recorded = assembleRecordedEvents(
-        readBridgeRecording(cell.dir),
+        withCurrentBridgeLane(readBridgeRecording(cell.dir)),
         options.createAssembler,
         cell.provider,
       );
@@ -1094,6 +1142,7 @@ export async function replayRecordedCells(
         recordingDir: cell.dir,
         bridge: { checkoutRoot, providerId: cell.provider },
         createAssembler: options.createAssembler,
+        planFromCurrentLane: true,
         ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
         ...(options.onStderr !== undefined ? { onStderr: options.onStderr } : {}),
       });

--- a/packages/provider-bridge-protocol/src/testing/recording.ts
+++ b/packages/provider-bridge-protocol/src/testing/recording.ts
@@ -92,6 +92,51 @@ export function readBridgeRecordingLane(
   return entries;
 }
 
+/**
+ * The file a bridge change re-records its side of the wire into
+ * (`pnpm rerecord`): the `bridge→runtime` lane as THIS checkout's bridge
+ * emits it for the recording's provider and runtime lanes. The recorded lane
+ * itself is never rewritten — it is the recording, and a pre-migration
+ * checkout paces its replay from it — so the current expectation lives
+ * beside it. Absent until a bridge change first needs one.
+ */
+export const CURRENT_BRIDGE_LANE_FILE = "bridge→runtime.current.ndjson";
+
+export function readCurrentBridgeLane(dir: string): BridgeRecordingEntry[] | null {
+  const file = join(dir, CURRENT_BRIDGE_LANE_FILE);
+  if (!existsSync(file)) {
+    return null;
+  }
+  const entries: BridgeRecordingEntry[] = [];
+  const lines = readFileSync(file, "utf8").split("\n");
+  for (const [index, raw] of lines.entries()) {
+    if (raw.length === 0) continue;
+    const entry = parseEntry(raw, file, index + 1);
+    if (entry.dir !== "bridge→runtime") {
+      throw new Error(`${file}:${index + 1}: entry direction ${entry.dir} in the current bridge lane`);
+    }
+    entries.push(entry);
+  }
+  return entries;
+}
+
+/**
+ * The recording with its `bridge→runtime` lane replaced by the current
+ * expectation when one exists: what the self-suite pins and compares.
+ */
+export function withCurrentBridgeLane(recording: BridgeRecording): BridgeRecording {
+  const current = readCurrentBridgeLane(recording.dir);
+  if (current === null) {
+    return recording;
+  }
+  const entries = [
+    ...recording.entries.filter((entry) => entry.dir !== "bridge→runtime"),
+    ...current,
+  ];
+  entries.sort(compareRecordingEntries);
+  return { ...recording, entries };
+}
+
 export function readBridgeRecording(dir: string): BridgeRecording {
   const manifestPath = join(dir, "manifest.json");
   const manifest = existsSync(manifestPath)

--- a/packages/provider-bridge-protocol/src/testing/replay-provider-child.mjs
+++ b/packages/provider-bridge-protocol/src/testing/replay-provider-child.mjs
@@ -53,6 +53,15 @@ const CURSOR_POLL_MS = 5;
  * them, or the replay reorders what the recording had in order.
  */
 const EMIT_GAP_MS = 2;
+/**
+ * Gap after a response. The bridge continues its request's continuation in
+ * a microtask once the line loop yields; a notification read in the same
+ * chunk is handled first, so under load two milliseconds let a steer's ack
+ * (emitted after `await request("turn/steer")`) land after the next
+ * notification instead of before it, as the recording had it. A response
+ * is rare, so the longer gap costs nothing measurable.
+ */
+const RESPONSE_GAP_MS = 50;
 /** A request that opens or addresses a provider session; see segment release. */
 const SESSION_DEFINING_KEY =
   /^(thread|session)\/(start|resume|fork|new|load|archive|unarchive|name\/set)$/;
@@ -333,12 +342,12 @@ function main() {
     return null;
   }
 
-  function scheduleAdvance() {
+  function scheduleAdvance(gapMs = EMIT_GAP_MS) {
     if (emitTimer !== null) return;
     emitTimer = setTimeout(() => {
       emitTimer = null;
       advance();
-    }, EMIT_GAP_MS);
+    }, gapMs);
   }
 
   function advance() {
@@ -383,7 +392,9 @@ function main() {
         }
         emitRecorded(step);
         position += 1;
-        scheduleAdvance();
+        scheduleAdvance(
+          step.classified.kind === "response" ? RESPONSE_GAP_MS : EMIT_GAP_MS,
+        );
         return;
       }
       // An expectation of what the bridge writes.

--- a/packages/provider-parity/package.json
+++ b/packages/provider-parity/package.json
@@ -15,7 +15,8 @@
     "clean": "rimraf dist tsconfig.tsbuildinfo",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --config vitest.config.ts",
-    "parity": "node --conditions=source --import tsx src/cli.ts"
+    "parity": "node --conditions=source --import tsx src/cli.ts",
+    "rerecord": "node --conditions=source --import tsx src/rerecord.ts"
   },
   "dependencies": {
     "@bb/agent-runtime": "workspace:*",

--- a/packages/provider-parity/src/cli.ts
+++ b/packages/provider-parity/src/cli.ts
@@ -1,7 +1,13 @@
 #!/usr/bin/env node
 /**
  * `pnpm parity --old <checkout> --new . [--provider <id>] [--cell <name>]
- *              [--recordings <dir>] [--allowlist <file>] [--timeout <ms>] [--verbose]`
+ *              [--recordings <dir>] [--allowlist <file>] [--timeout <ms>] [--verbose]
+ *              [--dump-dir <dir>]`
+ *
+ * `--dump-dir` writes each leg's normalized event and row lists per cell
+ * (`<provider>-<cell>.<old|new>.<events|rows>.json`), so an allowlist entry
+ * can name the exact list index of a diff the 160-character CLI rendering
+ * cannot show in full.
  *
  * Replay every committed recording through the bridge of two checkouts and
  * diff the assembled events and projected rows against the allowlist. Exit
@@ -9,7 +15,8 @@
  * gate. With `--old` equal to `--new` the diff must be empty: that is the
  * harness's own acceptance test.
  */
-import { resolve } from "node:path";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
 import {
   ALLOWLIST_PATH,
   RECORDINGS_ROOT,
@@ -26,7 +33,11 @@ import {
   type RecordedCell,
 } from "./index.js";
 import { loadParityLeg } from "./leg.js";
-import { describeParityValue } from "@bb/provider-bridge-protocol/testing/parity";
+import {
+  describeParityValue,
+  normalizeParityEvents,
+  normalizeParityRows,
+} from "@bb/provider-bridge-protocol/testing/parity";
 
 interface CliArgs {
   oldRoot: string;
@@ -37,11 +48,12 @@ interface CliArgs {
   allowlist: string;
   timeoutMs: number | undefined;
   verbose: boolean;
+  dumpDir: string | null;
 }
 
 function usage(): never {
   process.stderr.write(
-    "usage: pnpm parity --old <checkout> --new <checkout> [--provider <id>] [--cell <name>] [--recordings <dir>] [--allowlist <file>] [--timeout <ms>] [--verbose]\n",
+    "usage: pnpm parity --old <checkout> --new <checkout> [--provider <id>] [--cell <name>] [--recordings <dir>] [--allowlist <file>] [--timeout <ms>] [--verbose] [--dump-dir <dir>]\n",
   );
   process.exit(2);
 }
@@ -59,6 +71,7 @@ function parseArgs(argv: string[]): CliArgs {
     allowlist: ALLOWLIST_PATH,
     timeoutMs: undefined,
     verbose: false,
+    dumpDir: null,
   };
   for (let index = 0; index < argv.length; index += 1) {
     const flag = argv[index];
@@ -94,6 +107,10 @@ function parseArgs(argv: string[]): CliArgs {
         break;
       case "--verbose":
         args.verbose = true;
+        break;
+      case "--dump-dir":
+        args.dumpDir = resolve(callerCwd, value ?? usage());
+        index += 1;
         break;
       default:
         usage();
@@ -167,10 +184,21 @@ async function main(): Promise<void> {
     const onStderr = args.verbose
       ? (text: string) => process.stderr.write(text)
       : undefined;
+    // Each leg paces itself from the lane its own assembler parses whole:
+    // the old (recording-time) leg from the recorded lane, the new leg from
+    // the current lane its bridge wrote, when there is one.
     const [oldInputs, newInputs] = await Promise.all([
       replayCell(cell, { ...oldLeg, timeoutMs: args.timeoutMs, onStderr }),
-      replayCell(cell, { ...newLeg, timeoutMs: args.timeoutMs, onStderr }),
+      replayCell(cell, { ...newLeg, timeoutMs: args.timeoutMs, onStderr, planFromCurrentLane: true }),
     ]);
+    if (args.dumpDir !== null) {
+      mkdirSync(args.dumpDir, { recursive: true });
+      const prefix = join(args.dumpDir, `${cell.provider}-${cell.cell}`);
+      writeFileSync(`${prefix}.old.events.json`, JSON.stringify(normalizeParityEvents(oldInputs.events), null, 2));
+      writeFileSync(`${prefix}.new.events.json`, JSON.stringify(normalizeParityEvents(newInputs.events), null, 2));
+      writeFileSync(`${prefix}.old.rows.json`, JSON.stringify(normalizeParityRows(oldInputs.rows), null, 2));
+      writeFileSync(`${prefix}.new.rows.json`, JSON.stringify(normalizeParityRows(newInputs.rows), null, 2));
+    }
     const comparison = compareCell(cell, oldInputs, newInputs, allowlist);
     const oldCounts = countCellInputs(oldInputs);
     const newCounts = countCellInputs(newInputs);

--- a/packages/provider-parity/src/index.ts
+++ b/packages/provider-parity/src/index.ts
@@ -18,6 +18,7 @@ import {
   replayRecording,
   resolveReplayProfile,
   UnreplayableProviderError,
+  withCurrentBridgeLane,
   type CreateParityAssembler,
   type ParityAllowlistEntry,
   type ParityComparison,
@@ -122,7 +123,7 @@ export interface CellInputs {
 
 /** The recording's own view: the recorded bridge output, no bridge in the loop. */
 export function recordedCellInputs(cell: RecordedCell): CellInputs & { invalidDeltas: string[] } {
-  const recording = readBridgeRecording(cell.dir);
+  const recording = withCurrentBridgeLane(readBridgeRecording(cell.dir));
   const assembled = assembleRecordedEvents(recording, createParityAssembler, cell.provider);
   return {
     ...assembled,
@@ -134,6 +135,8 @@ export interface ReplayCellOptions {
   checkoutRoot: string;
   timeoutMs?: number;
   onStderr?: (text: string) => void;
+  /** See `ReplayRecordingOptions.planFromCurrentLane`. */
+  planFromCurrentLane?: boolean;
   /** The leg's own assembler and projector (see `leg.ts`); defaults to this checkout's. */
   createAssembler?: CreateParityAssembler;
   projectRows?: ParityRowProjector;
@@ -159,6 +162,7 @@ export async function replayCell(
     recordingDir: cell.dir,
     bridge: { checkoutRoot: options.checkoutRoot, providerId: cell.provider },
     createAssembler: options.createAssembler ?? createParityAssembler,
+    ...(options.planFromCurrentLane === undefined ? {} : { planFromCurrentLane: options.planFromCurrentLane }),
     ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
     ...(options.onStderr !== undefined ? { onStderr: options.onStderr } : {}),
   });

--- a/packages/provider-parity/src/parity.self.test.ts
+++ b/packages/provider-parity/src/parity.self.test.ts
@@ -56,9 +56,19 @@ describe("recorded fixtures", () => {
     const pinned = readPinned();
     const actual: Record<string, RowCountsEntry> = {};
     const problems: string[] = [];
+    const skipped: string[] = [];
     for (const cell of cells) {
       const key = cellKey(cell);
       const inputs = recordedCellInputs(cell);
+      if (inputs.invalidDeltas.length > 0 && !isReplayable(cell.provider)) {
+        // A lane recorded under a grammar this assembler no longer accepts,
+        // for a provider whose bridge cannot be replayed (in-process SDK) and
+        // so cannot be re-recorded (`pnpm rerecord`). Its pins stand until it
+        // is re-recorded live; the cell is reported, not failed.
+        skipped.push(`${key}: ${inputs.invalidDeltas.length} recorded thread/delta lines predate the current grammar`);
+        if (pinned[key] !== undefined) actual[key] = pinned[key];
+        continue;
+      }
       if (inputs.invalidDeltas.length > 0) {
         problems.push(`${key}: ${inputs.invalidDeltas.length} thread/delta lines no longer parse: ${inputs.invalidDeltas[0]}`);
       }
@@ -85,6 +95,9 @@ describe("recorded fixtures", () => {
     for (const key of Object.keys(pinned)) {
       if (!(key in actual)) problems.push(`${key}: pinned but no recording`);
     }
+    if (skipped.length > 0) {
+      console.warn(`recorded lanes awaiting a live re-recording:\n  ${skipped.join("\n  ")}`);
+    }
     if (process.env.UPDATE_PARITY_ROW_COUNTS === "1") {
       writeFileSync(ROW_COUNTS_PATH, `${JSON.stringify(actual, null, 2)}\n`);
       return;
@@ -94,11 +107,18 @@ describe("recorded fixtures", () => {
 });
 
 describe("allowlist", () => {
-  it("is empty while old and new are the same bridge", () => {
-    // Entries arrive with the migration PRs; an entry that names no real
-    // difference is reported stale by compareParity and must not be committed.
+  it("names a PR and a reason on every entry", () => {
+    // Entries arrive with the migration PRs and describe the diff against
+    // the pre-migration checkout (`pnpm parity --old <main> --new .`), which
+    // reports an entry that masks nothing as stale. This self-suite replays
+    // old == new, so it cannot judge staleness; it holds the entries to
+    // their form.
     const allowlist = readAllowlist();
-    expect(allowlist).toEqual([]);
+    for (const entry of allowlist) {
+      expect(entry.pr).toMatch(/^#\d+$/);
+      expect(entry.reason.trim().length).toBeGreaterThan(0);
+      expect(entry.path.startsWith("/")).toBe(true);
+    }
   });
 
   it("masks only what an entry names and reports unused entries as stale", () => {
@@ -138,7 +158,9 @@ describe("replay through the current bridge", () => {
       const recorded = recordedCellInputs(cell);
       // Generous: a bridge process boots through tsx, and CI runners (and a
       // busy laptop) can take a while to spawn the first one.
-      const replayed = await replayCell(cell, { checkoutRoot, timeoutMs: 60_000 });
+      // This checkout's bridge wrote the current lane, so its gates are exact
+      // for this replay; the recorded lane may predate its grammar.
+      const replayed = await replayCell(cell, { checkoutRoot, timeoutMs: 60_000, planFromCurrentLane: true });
       expect(replayed.run.stalls).toEqual([]);
       const comparison = compareCell(cell, recorded, replayed, []);
       expect({

--- a/packages/provider-parity/src/rerecord.ts
+++ b/packages/provider-parity/src/rerecord.ts
@@ -1,0 +1,252 @@
+#!/usr/bin/env node
+/**
+ * `pnpm rerecord [--plan-with <checkout>] [--provider <id>] [--cell <name>]
+ *                [--recordings <dir>] [--timeout <ms>] [--verbose]`
+ *
+ * Writes each committed recording's `bridge→runtime.current.ndjson`: the
+ * bridge's side of the wire as THIS checkout's bridge emits it for the
+ * recording's provider and runtime lanes. The recording itself (provider
+ * lanes, runtime lane, the recorded bridge lane) is never touched — a
+ * pre-migration checkout paces its replay from the recorded lane — so the
+ * current expectation lives beside it, and `parity.self.test.ts`
+ * ("replaying the recording through the current bridge reproduces the
+ * recorded output") reads it when present. Run `UPDATE_PARITY_ROW_COUNTS=1`
+ * on the self-suite afterwards to re-pin the counts, and explain both diffs
+ * in the PR.
+ *
+ * `--plan-with` names a checkout whose assembler parses the recorded lane
+ * (the recording-time checkout): the replay plans where each runtime
+ * request lands from that lane, which matters when this checkout's grammar
+ * no longer accepts all of it.
+ *
+ * Each re-recorded line is placed right after the runtime entry that was
+ * sent last before it arrived (same `run`, a fractional `seq` between that
+ * entry and the next), which is the wire order the replay and the gates read.
+ * Bridge request ids are rewritten to the recorded ones, matched by method
+ * and order, so the untouched runtime responses still name a request.
+ */
+import { writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import type { BridgeRecordingDirection } from "@bb/provider-bridge-protocol/bridge-kit";
+import {
+  CURRENT_BRIDGE_LANE_FILE,
+  replayRecording,
+  readBridgeRecording,
+} from "@bb/provider-bridge-protocol/testing/parity";
+import {
+  RECORDINGS_ROOT,
+  cellKey,
+  createParityAssembler,
+  isReplayable,
+  listRecordedCells,
+  type RecordedCell,
+} from "./index.js";
+import { loadParityLeg, type ParityLeg } from "./leg.js";
+
+const BRIDGE_TO_RUNTIME: BridgeRecordingDirection = "bridge→runtime";
+
+interface CliArgs {
+  planRoot: string | null;
+  provider: string | null;
+  cell: string | null;
+  recordings: string;
+  timeoutMs: number | undefined;
+  verbose: boolean;
+}
+
+function usage(): never {
+  process.stderr.write(
+    "usage: pnpm rerecord [--plan-with <checkout>] [--provider <id>] [--cell <name>] [--recordings <dir>] [--timeout <ms>] [--verbose]\n",
+  );
+  process.exit(2);
+}
+
+const callerCwd = process.env.INIT_CWD ?? process.cwd();
+const checkoutRoot = resolve(new URL("../../..", import.meta.url).pathname);
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    planRoot: null,
+    provider: null,
+    cell: null,
+    recordings: RECORDINGS_ROOT,
+    timeoutMs: undefined,
+    verbose: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    switch (flag) {
+      case "--plan-with":
+        args.planRoot = resolve(callerCwd, value ?? usage());
+        index += 1;
+        break;
+      case "--provider":
+        args.provider = value ?? usage();
+        index += 1;
+        break;
+      case "--cell":
+        args.cell = value ?? usage();
+        index += 1;
+        break;
+      case "--recordings":
+        args.recordings = resolve(callerCwd, value ?? usage());
+        index += 1;
+        break;
+      case "--timeout":
+        args.timeoutMs = Number(value ?? usage());
+        index += 1;
+        break;
+      case "--verbose":
+        args.verbose = true;
+        break;
+      default:
+        usage();
+    }
+  }
+  return args;
+}
+
+interface WireMessage {
+  id?: string | number;
+  method?: string;
+  [key: string]: unknown;
+}
+
+function parseWireLine(line: string): WireMessage | null {
+  try {
+    const parsed: unknown = JSON.parse(line);
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as WireMessage)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+interface LaneEntry {
+  ts: number;
+  run: number;
+  seq: number;
+  dir: BridgeRecordingDirection;
+  line: string;
+}
+
+async function rerecordCell(
+  cell: RecordedCell,
+  args: CliArgs,
+  planLeg: ParityLeg | null,
+): Promise<string> {
+  const recording = readBridgeRecording(cell.dir);
+  const run = await replayRecording({
+    recordingDir: cell.dir,
+    bridge: { checkoutRoot, providerId: cell.provider },
+    createAssembler: createParityAssembler,
+    ...(planLeg === null
+      ? {}
+      : { createPlanAssembler: planLeg.createAssembler }),
+    ...(args.timeoutMs !== undefined ? { timeoutMs: args.timeoutMs } : {}),
+    ...(args.verbose
+      ? { onStderr: (text: string) => process.stderr.write(text) }
+      : {}),
+  });
+  if (run.stalls.length > 0) {
+    return `STALL ${cellKey(cell)}: ${run.stalls.join("; ")} (current lane left untouched)`;
+  }
+  // The first runtime entry anchors lines that arrive before any request
+  // (a bridge speaks only after `initialize`, so this is a safety net).
+  const firstRuntime = recording.entries.find(
+    (entry) => entry.dir === "runtime→bridge",
+  );
+  // Bridge request ids are per process, and the recorded runtime lane answers
+  // the ids the recording-time process used; a fresh bridge counts from one.
+  const recordedRequestIds = new Map<string, Array<string | number>>();
+  for (const entry of recording.entries) {
+    if (entry.dir !== BRIDGE_TO_RUNTIME) continue;
+    const message = parseWireLine(entry.line);
+    if (message?.method === undefined || message.id === undefined) continue;
+    const queue = recordedRequestIds.get(message.method) ?? [];
+    queue.push(message.id);
+    recordedRequestIds.set(message.method, queue);
+  }
+  const entries: LaneEntry[] = [];
+  const perAnchor = new Map<string, number>();
+  run.lines.forEach((rawLine, index) => {
+    let line = rawLine;
+    const message = parseWireLine(rawLine);
+    if (message?.method !== undefined && message.id !== undefined) {
+      const recordedId = recordedRequestIds.get(message.method)?.shift();
+      if (recordedId !== undefined && recordedId !== message.id) {
+        line = JSON.stringify({ ...message, id: recordedId });
+      }
+    }
+    const anchor =
+      run.lineAfter[index] ??
+      (firstRuntime
+        ? {
+            run: firstRuntime.run,
+            seq: firstRuntime.seq - 1,
+            ts: firstRuntime.ts,
+          }
+        : { run: 0, seq: 0, ts: 0 });
+    const anchorKey = `${anchor.run}:${anchor.seq}`;
+    const ordinal = (perAnchor.get(anchorKey) ?? 0) + 1;
+    perAnchor.set(anchorKey, ordinal);
+    entries.push({
+      ts: anchor.ts + ordinal,
+      run: anchor.run,
+      // Fractional: after the anchoring runtime entry, before the next one.
+      seq: anchor.seq + ordinal / (run.lines.length + 1),
+      dir: BRIDGE_TO_RUNTIME,
+      line,
+    });
+  });
+  writeFileSync(
+    join(cell.dir, CURRENT_BRIDGE_LANE_FILE),
+    entries.map((entry) => JSON.stringify(entry)).join("\n") +
+      (entries.length > 0 ? "\n" : ""),
+  );
+  return `OK ${cellKey(cell)}: ${entries.length} bridge→runtime lines (${run.events.length} events)`;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const planLeg =
+    args.planRoot === null ? null : await loadParityLeg(args.planRoot);
+  process.stdout.write(
+    `record: ${checkoutRoot}\nplan: ${
+      planLeg === null
+        ? "this checkout's assembler over the recorded lane"
+        : `${planLeg.checkoutRoot} (${planLeg.source})`
+    }\n\n`,
+  );
+  const cells = listRecordedCells(args.recordings).filter(
+    (cell: RecordedCell) =>
+      (args.provider === null || cell.provider === args.provider) &&
+      (args.cell === null || cell.cell === args.cell),
+  );
+  let failed = 0;
+  for (const cell of cells) {
+    if (!isReplayable(cell.provider)) {
+      process.stdout.write(
+        `SKIP ${cellKey(cell)}: provider is not replayable\n`,
+      );
+      continue;
+    }
+    if (readBridgeRecording(cell.dir).manifest?.scope === "process") {
+      process.stdout.write(`SKIP ${cellKey(cell)}: process-scoped recording\n`);
+      continue;
+    }
+    const line = await rerecordCell(cell, args, planLeg);
+    if (line.startsWith("STALL")) failed += 1;
+    process.stdout.write(`${line}\n`);
+  }
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(
+    `${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`,
+  );
+  process.exit(1);
+});


### PR DESCRIPTION
For #2153 (`bb/provider-recordings`), so the harness fixes the codex bridge migration (#2164) needed land with the recordings and #2164 can drop its copies on rebase. **Do not merge**; coordinator routes it.

## What was wrong

Stacked on WS1a's v3-only assembler, the recordings' v2 `bridge→runtime` lanes no longer assemble: 38/43 self-suite tests and the claude/acp recorded-conformance suites go red before any bridge changes. A migration PR also cannot satisfy "the allowlist is empty", the CLI's 160-char rendering cannot show the list index a type-changing diff needs, and two timing races moved a steer's `turn/input/accepted` one position under CI load.

## What changed

- **Current bridge lanes.** A recording is never rewritten. `pnpm --filter @bb/provider-parity rerecord [--plan-with <checkout>]` writes `bridge→runtime.current.ndjson` beside the recorded lane; the self-suite and recorded conformance pin/compare against it when present; `pnpm parity` paces the old leg from the recorded lane and the new leg from the current lane. No current lanes are committed here — on this branch the recorded lanes are the bridges' output.
- **`pnpm parity --dump-dir <dir>`** writes both legs' normalized lists per cell.
- **Replay timing**: a 300 ms drain before each runtime request; a 50 ms gap in the replay child after a response line.
- **Self-suite**: allowlist entries are held to their form (PR, reason, path); non-replayable providers with a pre-grammar lane are reported, not failed.

## Verification

On this branch (no current lanes): `@bb/provider-parity` 43/43, `@bb/provider-bridge-protocol` 101/101, codex 173, claude-code 262, acp 182 — all forced. On #2164 (the consumer): self-suite 43/43 in CI after the two timing fixes; `pnpm parity --old <main> --new .` codex 16/0/1, claude-code 13/0/1, acp-cursor 10/0/1.

> AGENT GENERATED: by Claude Opus 5
