### PR TITLE
Rank exact matches across mention sources

### DIFF
--- a/apps/app/src/hooks/usePromptMentions.ts
+++ b/apps/app/src/hooks/usePromptMentions.ts
@@ -22,7 +22,10 @@ import {
   usePathSuggestions,
   PATH_SUGGESTION_DEBOUNCE_MS,
 } from "./usePathSuggestions";
-import type { PromptMentionSuggestion } from "@bb/client-core";
+import {
+  orderMentionSuggestions,
+  type PromptMentionSuggestion,
+} from "@bb/client-core";
 import {
   DEFAULT_PLUGIN_MENTION_TRIGGER,
   PLUGIN_MENTION_TRIGGER_VALUES,
@@ -64,11 +67,9 @@ interface BuildPromptMentionSuggestionsArgs {
 function buildPromptMentionSuggestions(
   args: BuildPromptMentionSuggestionsArgs,
 ): PromptMentionSuggestion[] {
-  // A query containing "/" reads as a file path, so paths lead; otherwise the
-  // named entities (threads then projects) lead and paths trail. Plugin
-  // provider rows always trail the built-in sources (they render in their
-  // own labeled sections at the bottom of the menu).
-  return args.trimmedQuery.includes("/")
+  // A query containing "/" reads as a file path, so paths win relevance ties;
+  // otherwise the existing named-entity order remains the fallback.
+  const sourceOrdered = args.trimmedQuery.includes("/")
     ? [
         ...args.pathSuggestions,
         ...args.threadSuggestions,
@@ -83,6 +84,7 @@ function buildPromptMentionSuggestions(
         ...args.pathSuggestions,
         ...args.pluginSuggestions,
       ];
+  return orderMentionSuggestions(sourceOrdered, args.trimmedQuery);
 }
 
 function buildProjectNamesById(

--- a/apps/mobile/src/composer/model/suggestions.test.ts
+++ b/apps/mobile/src/composer/model/suggestions.test.ts
@@ -110,6 +110,53 @@ describe("buildPathMentionSuggestions", () => {
 });
 
 describe("mergeMentionSuggestions", () => {
+  it("promotes the section with an exact match without splitting its rows", () => {
+    const thread = {
+      kind: "thread" as const,
+      path: "thread:t",
+      replacement: "thread:t",
+      projectId: "p",
+      threadId: "t",
+      title: "Plugin migration",
+    };
+    const installedExact = {
+      kind: "plugin" as const,
+      pluginId: "at-plugin",
+      providerId: "installed",
+      itemId: "installed:plugin",
+      providerLabel: "Installed",
+      title: "Plugin",
+      subtitle: null,
+      icon: null,
+      replacement: "Plugin",
+    };
+    const installedWeaker = {
+      ...installedExact,
+      itemId: "installed:plugin-guide",
+      title: "Plugin Guide",
+      replacement: "Plugin Guide",
+    };
+    const communityPrefix = {
+      ...installedExact,
+      providerId: "community",
+      itemId: "community:plugin-shop",
+      providerLabel: "Community",
+      title: "Plugin Shop",
+      replacement: "Plugin Shop",
+    };
+
+    expect(
+      mergeMentionSuggestions({
+        query: "plugin",
+        threads: [thread],
+        projects: [],
+        sections: [],
+        paths: [],
+        plugins: [installedExact, installedWeaker, communityPrefix],
+      }),
+    ).toEqual([installedExact, installedWeaker, thread, communityPrefix]);
+  });
+
   it("leads with paths when the query looks like a path", () => {
     const path = {
       kind: "path" as const,

--- a/apps/mobile/src/composer/model/suggestions.ts
+++ b/apps/mobile/src/composer/model/suggestions.ts
@@ -2,6 +2,7 @@ import {
   compareCodepoint,
   DEFAULT_PLUGIN_MENTION_TRIGGER,
   orderCommandSuggestions,
+  orderMentionSuggestions,
   PLUGIN_MENTION_TRIGGER_VALUES,
   toProviderCommandSuggestion,
   type PluginMentionTrigger,
@@ -343,8 +344,8 @@ export function buildPluginMentionTriggers(
 // --- Merge -------------------------------------------------------------------
 
 /**
- * Menu order: a query containing "/" reads as a path, so paths lead;
- * otherwise threads, projects, sections, then paths. Plugin rows always trail.
+ * A query containing "/" makes paths win relevance ties; otherwise the
+ * existing source order remains the fallback after cross-source match quality.
  */
 export function mergeMentionSuggestions(args: {
   query: string;
@@ -354,7 +355,7 @@ export function mergeMentionSuggestions(args: {
   paths: readonly PromptMentionSuggestion[];
   plugins: readonly PromptMentionSuggestion[];
 }): PromptMentionSuggestion[] {
-  return args.query.trim().includes("/")
+  const sourceOrdered = args.query.trim().includes("/")
     ? [
         ...args.paths,
         ...args.threads,
@@ -369,6 +370,7 @@ export function mergeMentionSuggestions(args: {
         ...args.paths,
         ...args.plugins,
       ];
+  return orderMentionSuggestions(sourceOrdered, args.query);
 }
 
 // --- Commands ----------------------------------------------------------------

--- a/packages/client-core/src/prompt/mentions/types.ts
+++ b/packages/client-core/src/prompt/mentions/types.ts
@@ -72,6 +72,76 @@ export type PromptMentionSuggestion =
       replacement: string;
     };
 
+function mentionSuggestionSearchNames(
+  suggestion: PromptMentionSuggestion,
+): string[] {
+  if (suggestion.kind === "thread") {
+    return [suggestion.title ?? "", suggestion.threadId];
+  }
+  if (suggestion.kind === "project") {
+    return [suggestion.name, suggestion.projectId];
+  }
+  if (suggestion.kind === "section") {
+    return [suggestion.name, suggestion.sectionId];
+  }
+  if (suggestion.kind === "plugin") {
+    return [suggestion.title];
+  }
+  return [suggestion.name, suggestion.path, suggestion.replacement];
+}
+
+function mentionSuggestionMatchRank(
+  suggestion: PromptMentionSuggestion,
+  normalizedQuery: string,
+): number {
+  if (normalizedQuery.length === 0) return 0;
+  const names = mentionSuggestionSearchNames(suggestion).map((name) =>
+    name.trim().toLowerCase(),
+  );
+  if (names.includes(normalizedQuery)) return 0;
+  return names.some((name) => name.startsWith(normalizedQuery)) ? 1 : 2;
+}
+
+function mentionSuggestionSectionKey(
+  suggestion: PromptMentionSuggestion,
+): string {
+  if (suggestion.kind === "path") return `path:${suggestion.source}`;
+  if (suggestion.kind === "plugin") {
+    return `plugin:${suggestion.pluginId}:${suggestion.providerId}`;
+  }
+  return suggestion.kind;
+}
+
+/**
+ * Rank mention rows by how directly the query names them, then keep every
+ * rendered section contiguous under its strongest row. Stable input order is
+ * the tie-breaker, so callers retain their default source order when match
+ * quality is equal.
+ */
+export function orderMentionSuggestions(
+  suggestions: readonly PromptMentionSuggestion[],
+  query: string,
+): PromptMentionSuggestion[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  const ranked = [...suggestions].sort(
+    (left, right) =>
+      mentionSuggestionMatchRank(left, normalizedQuery) -
+      mentionSuggestionMatchRank(right, normalizedQuery),
+  );
+
+  const bySection = new Map<string, PromptMentionSuggestion[]>();
+  for (const suggestion of ranked) {
+    const section = mentionSuggestionSectionKey(suggestion);
+    const existing = bySection.get(section);
+    if (existing) {
+      existing.push(suggestion);
+      continue;
+    }
+    bySection.set(section, [suggestion]);
+  }
+  return [...bySection.values()].flat();
+}
+
 /**
  * One row in the command typeahead menu, derived from a {@link ProviderCommand}
  * returned by `GET /projects/:id/commands`. The `kind: "command"` discriminant

--- a/packages/client-core/test/mention-suggestion-order.test.ts
+++ b/packages/client-core/test/mention-suggestion-order.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  orderMentionSuggestions,
+  type PromptMentionSuggestion,
+} from "../src/index.js";
+
+function thread(title: string): PromptMentionSuggestion {
+  return {
+    kind: "thread",
+    path: "thread:t",
+    replacement: "thread:t",
+    projectId: "p",
+    threadId: "t",
+    title,
+  };
+}
+
+function plugin(
+  title: string,
+  providerId = "installed",
+): PromptMentionSuggestion {
+  return {
+    kind: "plugin",
+    pluginId: "at-plugin",
+    providerId,
+    itemId: `${providerId}:${title}`,
+    providerLabel: providerId,
+    title,
+    subtitle: null,
+    icon: null,
+    replacement: title,
+  };
+}
+
+describe("orderMentionSuggestions", () => {
+  it("puts an exact match above a prefix match from an earlier section", () => {
+    expect(
+      orderMentionSuggestions(
+        [thread("Plugin migration"), plugin("Plugin")],
+        "  PLUGIN ",
+      ).map((suggestion) => suggestion.replacement),
+    ).toEqual(["Plugin", "thread:t"]);
+  });
+
+  it("keeps sections contiguous under their strongest match", () => {
+    expect(
+      orderMentionSuggestions(
+        [
+          thread("Plugin migration"),
+          plugin("Plugin"),
+          plugin("Plugin Guide"),
+          plugin("Plugin Shop", "community"),
+        ],
+        "plugin",
+      ).map((suggestion) => suggestion.replacement),
+    ).toEqual(["Plugin", "Plugin Guide", "thread:t", "Plugin Shop"]);
+  });
+});


### PR DESCRIPTION
## What was wrong

The composer merged mention sources in a fixed order and put plugin-provider rows last, so a weaker built-in match could outrank an exact plugin match. For example, `@automations` showed the prefix-matching project “Automations project” above the exact installed plugin “Automations.” Desktop and mobile each encoded that same source-first policy independently.

## What changed

`@bb/client-core` now provides one stable cross-source ordering policy: exact title or identity matches, then prefix matches, then remaining provider results. Existing source order remains the tie-breaker, and rows from each rendered section stay contiguous beneath that section’s strongest match.

The desktop and mobile composer merge paths both apply that shared policy after assembling their existing sources. Path-like queries still put paths first when relevance is tied.

This does **not** add or change a public plugin SDK, wire protocol, CLI contract, or compatibility version. Plugins continue to use the existing `bb.ui.registerMentionProvider` API; bb owns cross-source ordering.

## How you verified

- Added `packages/client-core/test/mention-suggestion-order.test.ts` for exact-over-prefix ranking and contiguous provider sections.
- Added a mobile regression proving an exact plugin result outranks a prefix project result.
- `pnpm exec turbo run test --filter=@bb/client-core --filter=@bb/mobile` — client-core 240 tests and mobile 828 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/client-core --filter=@bb/mobile` — passed.
- Focused app mention/composer tests — 102 tests passed.
- Exact merge-base/head dev apps, identical isolated fixture, `@automations` query: five repeated query cycles and transition widths 389/390/391, 767/768/769, 1023/1024/1025, and 1919/1920/1921 all preserved the expected order with no horizontal overflow. Full evidence record: [visual evidence JSON](https://raw.githubusercontent.com/get-bb/bb/1fdbb9071a0feeaab9ca5a4234aa9ac55cf33127/qa/at-plugin-core-stack/core-mention-relevance-visual-evidence.json).

**Before — fixed source order puts the prefix project first**

![Before: Projects / Automations project appears above Installed / Automations](https://raw.githubusercontent.com/get-bb/bb/1fdbb9071a0feeaab9ca5a4234aa9ac55cf33127/qa/at-plugin-core-stack/core-relevance-before-normal-desktop.png)

**After — the exact installed-plugin match is first**

![After: Installed / Automations appears above Projects / Automations project](https://raw.githubusercontent.com/get-bb/bb/1fdbb9071a0feeaab9ca5a4234aa9ac55cf33127/qa/at-plugin-core-stack/core-relevance-after-normal-desktop.png)

Fixes: no issue; this is the host-policy foundation for the `@Plugin` reference stack.

BB-Thread-ID: thr_94xb8a4nk2

> AGENT GENERATED: by GPT-5.6
