### PR TITLE
[stacked on #2193] Export the canonical event types by name from the provider-bridge testing kit

### DIFF
--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -655,7 +655,7 @@ protocol`'s `assembler`, `conformance`, and `testing` subpaths.
    (`turnId`, `itemId`, `id`, `parentToolCallId`) and drops
    `providerCheckpointId`. Confirm the defaults against a third-party
    bridge's goldens before fixing them.
-3. **Surface size.** 33 value exports plus 43 types. The JSON-RPC harness
+3. **Surface size.** 33 value exports plus 57 types. The JSON-RPC harness
    duplicates a little of the bridge kit's envelope parsing; fold or keep
    deliberately.
 4. **Replay profile shape.** `ReplayProviderProfile` is the three seams the
@@ -676,6 +676,21 @@ protocol`'s `assembler`, `conformance`, and `testing` subpaths.
    recording. It is a textual substitution of a unique temp path; confirm
    no bridge emits that path in a form the substitution misses (URL-encoded,
    JSON-escaped backslashes on Windows).
+7. **The canonical event vocabulary by name.** The kit exports `ThreadEvent`,
+   `ThreadEventItem`, `ThreadEventItemPresentation` (+ its label, icon and
+   tint parts) and the named item kinds (`ThreadEventDelegationItem`,
+   `ThreadEventExtensionItem`, `ThreadEventFileReadItem`,
+   `ThreadEventSearchItem`, `ThreadEventPlanStepsItem`,
+   `ThreadEventWebSearchItem`, `ThreadEventWebFetchItem`,
+   `ThreadEventBackgroundTaskItem`) as types, re-exported from `@bb/domain`
+   and inlined into the bundled declarations. Before this a plugin test named
+   the event type as `ReturnType<BridgeDeltaEventCollector["assembleMessage"]>[number]`.
+   They are types only: a bridge never constructs an event (the assembler
+   does), so no `experimental_` value ships with them. Audit: the persisted
+   vocabulary now has a second public home beside `ProviderInfo` on the root
+   entry; a breaking change to an item shape is a breaking change to the kit.
+   Decide whether the kit should pin a grammar version in its exports (the
+   assembler already names `ASSEMBLER_GRAMMAR_VERSIONS`) before stabilizing.
 
 ## `app.experimental_useProviders` (`@get-bb/plugin-sdk/app`)
 

--- a/examples/plugins/echo-provider/provider-bridge.stream.test.ts
+++ b/examples/plugins/echo-provider/provider-bridge.stream.test.ts
@@ -33,6 +33,7 @@ import type {
   BridgeJsonRpcObject,
   BridgeJsonRpcOutputMessage,
   BridgeJsonRpcTestHarness,
+  ThreadEvent,
 } from "@get-bb/plugin-sdk/provider-bridge/testing";
 
 import { handleLine } from "./src/provider-bridge.js";
@@ -45,16 +46,9 @@ import {
   ECHO_STAMP_TOOL_PRESENTATION,
 } from "./src/vocabulary.js";
 
-/**
- * The canonical event type, derived from the kit's collector. The kit does
- * not export `ThreadEvent` by name (its vocabulary lives in bb's private
- * domain package), so a plugin test names it this way.
- */
-type AssembledEvent = ReturnType<
-  BridgeDeltaEventCollector["assembleMessage"]
->[number];
+/** An item lifecycle event: what the assembler builds from `item.open`/`item.close`. */
 type ItemEvent = Extract<
-  AssembledEvent,
+  ThreadEvent,
   { type: "item/started" | "item/completed" }
 >;
 
@@ -160,13 +154,13 @@ function answerToolCall(
   return params;
 }
 
-function assembledEvents(): AssembledEvent[] {
+function assembledEvents(): ThreadEvent[] {
   return harness.messages.flatMap((message) =>
     collector.assembleMessage(message),
   );
 }
 
-function itemEvents(events: AssembledEvent[]): ItemEvent[] {
+function itemEvents(events: ThreadEvent[]): ItemEvent[] {
   return events.filter(
     (event): event is ItemEvent =>
       event.type === "item/started" || event.type === "item/completed",
@@ -174,7 +168,7 @@ function itemEvents(events: AssembledEvent[]): ItemEvent[] {
 }
 
 function completedItem<T extends ItemEvent["item"]["type"]>(
-  events: AssembledEvent[],
+  events: ThreadEvent[],
   type: T,
 ): Extract<ItemEvent["item"], { type: T }> {
   const event = itemEvents(events).find(

--- a/packages/plugin-sdk/src/__tests__/bundled-types.test.ts
+++ b/packages/plugin-sdk/src/__tests__/bundled-types.test.ts
@@ -91,4 +91,33 @@ describe("bundled plugin SDK declarations", () => {
     );
     expect(declarations[5]).toContain("interface ExperimentalHostEntryHarness");
   });
+
+  it("names the canonical event vocabulary in the provider-bridge testing kit", async () => {
+    // A bridge's tests assert on what the assembler built; the types they
+    // narrow to are re-exported from @bb/domain and must arrive inlined, not
+    // as an import a plugin cannot resolve.
+    const testing = await readFile(
+      new URL(
+        "../../bundled-types/bb-plugin-sdk-provider-bridge-testing.d.ts",
+        import.meta.url,
+      ),
+      "utf8",
+    );
+    expect(testing).not.toMatch(/from ['"]@bb\//u);
+    expect(testing).not.toMatch(/import\(['"]@bb\//u);
+    for (const name of [
+      "ThreadEvent",
+      "ThreadEventItem",
+      "ThreadEventItemPresentation",
+      "ThreadEventDelegationItem",
+      "ThreadEventExtensionItem",
+    ]) {
+      expect(testing).toMatch(
+        new RegExp(`(?:type|interface) ${name}\\b`, "u"),
+      );
+      expect(testing).toMatch(
+        new RegExp(`export type \\{[^}]*\\b${name}\\b[^}]*\\}`, "u"),
+      );
+    }
+  });
 });

--- a/packages/plugin-sdk/src/provider-bridge-testing.ts
+++ b/packages/plugin-sdk/src/provider-bridge-testing.ts
@@ -131,3 +131,26 @@ export type {
   BridgeRecordingDirection,
   BridgeRecordingEntry,
 } from "@bb/provider-bridge-protocol/bridge-kit";
+
+// The canonical event vocabulary, by name. A bridge never constructs these
+// (the assembler does), but a bridge's tests assert on what the assembler
+// built — `ThreadEvent` is what every collector, replay and parity function
+// here returns, and the item and presentation types are what an assertion
+// narrows to. Re-exported from bb's domain package and inlined into the
+// published declarations, like `PromptInput` on the root entry.
+export type {
+  ThreadEvent,
+  ThreadEventBackgroundTaskItem,
+  ThreadEventDelegationItem,
+  ThreadEventExtensionItem,
+  ThreadEventFileReadItem,
+  ThreadEventItem,
+  ThreadEventItemPresentation,
+  ThreadEventItemPresentationIcon,
+  ThreadEventItemPresentationLabel,
+  ThreadEventItemPresentationTint,
+  ThreadEventPlanStepsItem,
+  ThreadEventSearchItem,
+  ThreadEventWebFetchItem,
+  ThreadEventWebSearchItem,
+} from "@bb/domain";


### PR DESCRIPTION
Stacked on #2193 (publish the parity harness). Layer 2 of 3 of the provider-gaps stack (#2193 → #2194 → #2195). Closes gap G-B from #2189.

## What was wrong

A bridge's tests assert on what the runtime's assembler built from the bridge's `thread/delta` stream, but `@get-bb/plugin-sdk/provider-bridge/testing` exported no name for that event. The echo canary spelled it as `ReturnType<BridgeDeltaEventCollector["assembleMessage"]>[number]` and narrowed item events from that. The `@get-bb/plugin-sdk/provider-bridge` entry deliberately does not re-export the event vocabulary (a bridge never constructs a `ThreadEvent`), which is right for the authoring surface and wrong for the testing one.

## What changed

`packages/plugin-sdk/src/provider-bridge-testing.ts` re-exports, as types, from `@bb/domain`: `ThreadEvent`, `ThreadEventItem`, `ThreadEventItemPresentation` (+ `ThreadEventItemPresentationLabel` / `Icon` / `Tint`), and the named item kinds `ThreadEventDelegationItem`, `ThreadEventExtensionItem`, `ThreadEventFileReadItem`, `ThreadEventSearchItem`, `ThreadEventPlanStepsItem`, `ThreadEventWebSearchItem`, `ThreadEventWebFetchItem`, `ThreadEventBackgroundTaskItem`. `rollup-plugin-dts` inlines them into `bundled-types/bb-plugin-sdk-provider-bridge-testing.d.ts`, the same way the root entry ships `PromptInput`.

Types only, no `experimental_` value (AGENTS.md prefixes values; types in this entry are unprefixed by convention). `docs/api_to_audit.md` gets audit item 7 on the testing-kit entry: the persisted vocabulary now has a second public home, and the kit may want to pin a grammar version before stabilizing.

`packages/plugin-sdk/src/__tests__/bundled-types.test.ts` pins that the names arrive inlined (no `from '@bb/…'`, each name declared and in the `export type {}` list). `examples/plugins/echo-provider/provider-bridge.stream.test.ts` uses `ThreadEvent` and drops the `ReturnType` workaround.

No wire change; `HOST_DAEMON_PROTOCOL_VERSION` untouched.

## How you verified

- `pnpm exec turbo run typecheck test --filter=@get-bb/plugin-sdk`: 16 files, 128 tests pass (the new bundled-types assertion included; it fails on the previous commit because the names are absent from the `.d.ts`).
- `pnpm exec turbo run typecheck test --filter=bb-plugin-echo-provider`: 5 files, 21 tests pass with the named type.

> AGENT GENERATED: by Claude Opus 5

