### PR TITLE
Pin the nightly iOS marketing version so TestFlight skips re-review

### DIFF
--- a/.github/workflows/mobile-ios-eas.yml
+++ b/.github/workflows/mobile-ios-eas.yml
@@ -107,8 +107,8 @@ jobs:
           set -euo pipefail
 
           # iOS accepts only numeric dotted versions, so a prerelease version
-          # (0.38.1-nightly.N.M from the nightly publish) carries its base
-          # 0.38.1; the remote EAS build number tells builds apart.
+          # (0.38.1-nightly.N.M) carries its base 0.38.1; the remote EAS
+          # build number tells builds apart.
           MOBILE_VERSION="${MOBILE_VERSION%%-*}"
           if [[ ! "$MOBILE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Marketing version must be numeric (X.Y.Z), got '${MOBILE_VERSION}'."

--- a/.github/workflows/publish-bb-app.yml
+++ b/.github/workflows/publish-bb-app.yml
@@ -735,9 +735,14 @@ jobs:
     with:
       profile: production
       submit: true
-      # The reusable workflow keeps the numeric base (0.38.1 for
-      # 0.38.1-nightly.N.M); iOS rejects prerelease version strings.
-      version: ${{ needs.publish-nightly.outputs.version || needs.publish.outputs.version }}
+      # An empty version keeps the marketing version committed in
+      # apps/mobile/app.json. TestFlight needs a Beta App Review for the
+      # first build of each new marketing version, so a nightly that tracked
+      # the bb-app version (0.39.0, 0.39.1, ...) blocked external testers
+      # every time the base version moved. With a pinned version, the remote
+      # EAS build number tells nightly builds apart and later builds skip
+      # the review.
+      version: ""
     secrets:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -794,7 +794,12 @@ push key); nobody needs a local Xcode signing setup to ship.
   Run it alone from the Actions tab ("Mobile iOS (EAS)") or
   `gh workflow run mobile-ios-eas.yml -f profile=production -f submit=true`.
   The nightly `publish-bb-app.yml` calls the same workflow after the npm
-  nightly publish with the numeric base of the nightly version. Repo
+  nightly publish with an empty `version`, so every nightly keeps the
+  marketing version committed in `app.json` and only the EAS build number
+  moves. This is deliberate: TestFlight needs a Beta App Review for the
+  first build of each new marketing version, and later builds of the same
+  version skip it. Bump `app.json` `version` only when you want a new
+  review, for example for a store release. Repo
   secrets: `EXPO_TOKEN` (a robot token from the `bb-team` Expo org) and
   `ASC_API_KEY_P8` (the `.p8` contents).
 - The `expo-modules-jsi` pnpm patch and the `lightningcss` override ship
@@ -814,8 +819,12 @@ push key); nobody needs a local Xcode signing setup to ship.
 App Store Connect finishes processing it, usually within 30 minutes. The group
 `bb team` exists and the nightly feeds it.
 
-**External testers** need a Beta App Review on the first build, and Apple
-usually auto-approves later builds. Before a build can go to an external group,
+**External testers** need a Beta App Review on the first build of each
+marketing version, and Apple usually auto-approves later builds of that
+version. The nightly keeps one marketing version for this reason (see "CI"
+above). Turn on "Automatically distribute builds" on the external group so new
+nightly builds reach it without a manual step. Before a build can go to an
+external group,
 App Store Connect needs all of this:
 
 - **Test Information** (`betaAppLocalizations`): a feedback email, a beta

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -3,7 +3,7 @@
     "name": "bb",
     "slug": "bb-app",
     "owner": "bb-team",
-    "version": "0.0.1",
+    "version": "0.39.0",
     "scheme": "bb",
     "orientation": "default",
     "icon": "./assets/icon.png",


### PR DESCRIPTION
## What was wrong

TestFlight needs a Beta App Review for the first build of each new marketing version. The nightly iOS job in `publish-bb-app.yml` passed the bb-app nightly version to `mobile-ios-eas.yml`, which wrote its numeric base into `app.json`. Each base bump (0.39.0 → 0.39.1 → …) created a new TestFlight version, and external testers had to wait for a new review every time.

## What changed

- `.github/workflows/publish-bb-app.yml`: the nightly iOS job passes `version: ""`. The reusable workflow skips the "Apply the marketing version" step, so every nightly keeps the committed `app.json` version and only the remote EAS build number moves.
- `apps/mobile/app.json`: `expo.version` is pinned to `0.39.0`, the version TestFlight has already approved. New builds of an approved version skip the review.
- `.github/workflows/mobile-ios-eas.yml`: comment cleanup. Manual dispatch still accepts a `version` input for a real release.
- `apps/mobile/README.md`: the CI and "TestFlight testers" sections explain the pinned version, when to bump it, and the "Automatically distribute builds" toggle.

No wire changes.

## How you verified

- `app.json` parses (`node -e 'JSON.parse(...)'`).
- `actionlint` on both workflows reports only pre-existing warnings (custom Blacksmith runner labels, one shellcheck info line), none from this change.
- The `version` input of `mobile-ios-eas.yml` is `required: true, type: string`; an empty string is valid and the apply step is gated on `inputs.version != ''`.
- Manual check of the next nightly: it should upload as 0.39.0 with a build number above 4 and reach the external group without a new review.

Fixes #

> AGENT GENERATED: by Claude Opus 5
