### PR TITLE
Add each submitted TestFlight build to the external group from CI

### DIFF
--- a/.github/workflows/mobile-ios-eas.yml
+++ b/.github/workflows/mobile-ios-eas.yml
@@ -26,6 +26,11 @@ on:
         required: false
         type: string
         default: ""
+      external_group:
+        description: TestFlight external group that receives the submitted build. Empty skips this step.
+        required: false
+        type: string
+        default: External testers
   workflow_call:
     inputs:
       profile:
@@ -35,6 +40,9 @@ on:
         required: true
         type: boolean
       version:
+        required: true
+        type: string
+      external_group:
         required: true
         type: string
     secrets:
@@ -134,6 +142,7 @@ jobs:
           printf '%s\n' "$ASC_API_KEY_P8" > asc-api-key.p8
 
       - name: Build on EAS and wait for the result
+        id: eas_build
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           EAS_PROFILE: ${{ inputs.profile }}
@@ -146,9 +155,8 @@ jobs:
         # holds the build and submission logs; the run summary links to them.
         run: |
           set -euo pipefail
-          trap 'rm -f asc-api-key.p8' EXIT
 
-          args=(build --platform ios --profile "$EAS_PROFILE" --non-interactive)
+          args=(build --platform ios --profile "$EAS_PROFILE" --non-interactive --json)
           if [[ "$EAS_SUBMIT" == "true" ]]; then
             if [[ "$EAS_PROFILE" != "production" ]]; then
               echo "::error::Only the production profile has a submit profile; got '${EAS_PROFILE}'."
@@ -157,9 +165,49 @@ jobs:
             args+=(--auto-submit)
           fi
 
-          pnpm exec eas "${args[@]}" | tee eas-build.log
+          # --json puts the finished build records on stdout and the progress
+          # log on stderr. The records carry the marketing version and the
+          # remote build number that the distribute step needs.
+          pnpm exec eas "${args[@]}" 2> >(tee eas-build.log >&2) > eas-build.json
           {
             echo "## EAS build"
             echo
             grep -Eo 'https://expo\.dev/[^ ]+' eas-build.log | sed 's/^/- /' || true
           } >> "$GITHUB_STEP_SUMMARY"
+
+          node --input-type=module -e '
+            import { readFileSync, appendFileSync } from "node:fs";
+            const builds = JSON.parse(readFileSync("eas-build.json", "utf8"));
+            const build = Array.isArray(builds) ? builds[0] : builds;
+            const { appVersion, appBuildVersion } = build ?? {};
+            if (typeof appVersion !== "string" || typeof appBuildVersion !== "string") {
+              throw new Error(`eas build --json returned no appVersion/appBuildVersion: ${JSON.stringify(build)}`);
+            }
+            appendFileSync(process.env.GITHUB_OUTPUT, `app_version=${appVersion}\nbuild_number=${appBuildVersion}\n`);
+            console.log(`EAS built ${appVersion} (${appBuildVersion}).`);
+          '
+
+      - name: Add the build to the TestFlight external group
+        if: ${{ inputs.submit && inputs.external_group != '' }}
+        env:
+          APP_VERSION: ${{ steps.eas_build.outputs.app_version }}
+          BUILD_NUMBER: ${{ steps.eas_build.outputs.build_number }}
+          EXTERNAL_GROUP: ${{ inputs.external_group }}
+        working-directory: apps/mobile
+        # Apple offers automatic distribution only for internal groups. This
+        # waits for App Store Connect to finish processing the upload, submits
+        # the build for Beta App Review when the build has none, and adds it to
+        # the external group. A later build of an approved marketing version
+        # usually clears review in minutes with no human step.
+        run: |
+          set -euo pipefail
+          node scripts/testflight-distribute.mjs \
+            --version "$APP_VERSION" \
+            --build "$BUILD_NUMBER" \
+            --group "$EXTERNAL_GROUP" \
+            --key-path ./asc-api-key.p8
+
+      - name: Remove the App Store Connect API key
+        if: ${{ always() }}
+        working-directory: apps/mobile
+        run: rm -f asc-api-key.p8

--- a/.github/workflows/publish-bb-app.yml
+++ b/.github/workflows/publish-bb-app.yml
@@ -743,6 +743,7 @@ jobs:
       # EAS build number tells nightly builds apart and later builds skip
       # the review.
       version: ""
+      external_group: External testers
     secrets:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -790,7 +790,13 @@ push key); nobody needs a local Xcode signing setup to ship.
   `eas build -p ios --profile <profile> [--auto-submit]` with
   `EXPO_TOKEN`. EAS builds, then uploads to TestFlight; the job waits for
   both and fails when either fails. Logs are on expo.dev under the project's
-  Builds and Submissions (the run summary links them).
+  Builds and Submissions (the run summary links them). After a submit, the
+  job runs `scripts/testflight-distribute.mjs`, which waits for App Store
+  Connect to process the build, submits it for Beta App Review when it has
+  none, and adds it to the external group named by the `external_group`
+  input (default `External testers`; empty skips the step). Run the script
+  by hand with `node scripts/testflight-distribute.mjs --version X.Y.Z
+  --build N` from `apps/mobile` with the `.p8` in place.
   Run it alone from the Actions tab ("Mobile iOS (EAS)") or
   `gh workflow run mobile-ios-eas.yml -f profile=production -f submit=true`.
   The nightly `publish-bb-app.yml` calls the same workflow after the npm
@@ -822,10 +828,10 @@ App Store Connect finishes processing it, usually within 30 minutes. The group
 **External testers** need a Beta App Review on the first build of each
 marketing version, and Apple usually auto-approves later builds of that
 version. The nightly keeps one marketing version for this reason (see "CI"
-above). Turn on "Automatically distribute builds" on the external group so new
-nightly builds reach it without a manual step. Before a build can go to an
-external group,
-App Store Connect needs all of this:
+above). Apple offers "Automatically distribute builds" only for internal
+groups, so the CI distribute step adds each submitted build to the external
+group through the App Store Connect API. Before a build can go to an external
+group, App Store Connect needs all of this:
 
 - **Test Information** (`betaAppLocalizations`): a feedback email, a beta
   description, and the privacy policy URL <https://getbb.app/privacy>. Per
@@ -865,11 +871,9 @@ Write to <EMAIL> if the server does not respond.
 Rehearse it before submitting: hand a colleague a phone that has never run bb,
 give them only these notes, and check that they reach a thread.
 
-The marketing version climbs on every nightly, because the EAS job writes the
-npm version into `app.json`. A new version string is more likely to trigger a
-fresh Beta App Review than another build of the same version. If external
-testers become the main audience, pin the TestFlight marketing version and let
-the EAS build number tell nightlies apart.
+The nightly keeps the marketing version in `app.json` and lets the EAS build
+number tell nightlies apart, because a new version string triggers a fresh
+Beta App Review and another build of the same version usually does not.
 
 ## Local state
 

--- a/apps/mobile/scripts/testflight-distribute.mjs
+++ b/apps/mobile/scripts/testflight-distribute.mjs
@@ -1,0 +1,257 @@
+#!/usr/bin/env node
+// Add one TestFlight build to an external beta group through the App Store
+// Connect API.
+//
+// Apple only offers "Automatically distribute builds" for internal groups.
+// An external group needs each build added by hand, and the first build of a
+// new marketing version goes to Beta App Review at that moment. This script
+// is the automatic path: the EAS workflow runs it after `eas submit` so every
+// nightly reaches the external group without a click in App Store Connect.
+//
+// Usage (from apps/mobile):
+//   node scripts/testflight-distribute.mjs --version 0.39.0 --build 5 \
+//     [--group "External testers"] [--key-path ./asc-api-key.p8] \
+//     [--timeout-minutes 45]
+//
+// The key id, issuer id, and app id come from eas.json
+// (submit.production.ios). The private key is the gitignored .p8 file that
+// the submit profile also reads. No npm dependencies: the JWT is signed with
+// node:crypto.
+
+import { readFileSync } from "node:fs";
+import { createSign } from "node:crypto";
+import { setTimeout as sleep } from "node:timers/promises";
+
+const ASC_BASE_URL = "https://api.appstoreconnect.apple.com";
+const POLL_INTERVAL_MS = 30_000;
+
+function parseArgs(argv) {
+  const options = {
+    version: "",
+    build: "",
+    group: "External testers",
+    keyPath: "./asc-api-key.p8",
+    timeoutMinutes: 45,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    switch (flag) {
+      case "--version":
+        options.version = value ?? "";
+        break;
+      case "--build":
+        options.build = value ?? "";
+        break;
+      case "--group":
+        options.group = value ?? "";
+        break;
+      case "--key-path":
+        options.keyPath = value ?? "";
+        break;
+      case "--timeout-minutes":
+        options.timeoutMinutes = Number(value);
+        break;
+      default:
+        throw new Error(`Unknown argument: ${flag}`);
+    }
+    index += 1;
+  }
+  if (!/^\d+\.\d+\.\d+$/u.test(options.version)) {
+    throw new Error(`--version must be X.Y.Z, got '${options.version}'.`);
+  }
+  if (!/^\d+$/u.test(options.build)) {
+    throw new Error(`--build must be a build number, got '${options.build}'.`);
+  }
+  if (!options.group) {
+    throw new Error("--group must be a beta group name.");
+  }
+  if (!Number.isFinite(options.timeoutMinutes) || options.timeoutMinutes <= 0) {
+    throw new Error("--timeout-minutes must be a positive number.");
+  }
+  return options;
+}
+
+function readSubmitConfig() {
+  const easConfig = JSON.parse(readFileSync("eas.json", "utf8"));
+  const ios = easConfig?.submit?.production?.ios;
+  const keyId = ios?.ascApiKeyId;
+  const issuerId = ios?.ascApiKeyIssuerId;
+  const appId = ios?.ascAppId;
+  if (
+    typeof keyId !== "string" ||
+    typeof issuerId !== "string" ||
+    typeof appId !== "string"
+  ) {
+    throw new Error(
+      "eas.json submit.production.ios needs ascApiKeyId, ascApiKeyIssuerId, and ascAppId.",
+    );
+  }
+  return { keyId, issuerId, appId };
+}
+
+function signJwt({ keyId, issuerId, privateKey }) {
+  const base64url = (value) =>
+    Buffer.from(JSON.stringify(value)).toString("base64url");
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64url({ alg: "ES256", kid: keyId, typ: "JWT" });
+  const payload = base64url({
+    iss: issuerId,
+    iat: now,
+    // Apple rejects tokens that live longer than 20 minutes.
+    exp: now + 15 * 60,
+    aud: "appstoreconnect-v1",
+  });
+  const signature = createSign("SHA256")
+    .update(`${header}.${payload}`)
+    .sign({ key: privateKey, dsaEncoding: "ieee-p1363" })
+    .toString("base64url");
+  return `${header}.${payload}.${signature}`;
+}
+
+function createClient(auth) {
+  let token = signJwt(auth);
+  let tokenIssuedAt = Date.now();
+  return async function request(method, path, body) {
+    if (Date.now() - tokenIssuedAt > 10 * 60 * 1000) {
+      token = signJwt(auth);
+      tokenIssuedAt = Date.now();
+    }
+    const response = await fetch(`${ASC_BASE_URL}${path}`, {
+      method,
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(`${method} ${path} -> ${response.status}: ${text}`);
+    }
+    return text ? JSON.parse(text) : null;
+  };
+}
+
+async function findBetaGroup(request, appId, groupName) {
+  const result = await request(
+    "GET",
+    `/v1/betaGroups?filter[app]=${appId}&fields[betaGroups]=name,isInternalGroup&limit=200`,
+  );
+  const group = result.data.find(
+    (entry) => entry.attributes.name === groupName,
+  );
+  if (!group) {
+    const names = result.data.map((entry) => entry.attributes.name);
+    throw new Error(
+      `Beta group '${groupName}' not found. Groups: ${names.join(", ") || "(none)"}.`,
+    );
+  }
+  return {
+    id: group.id,
+    isInternal: group.attributes.isInternalGroup === true,
+  };
+}
+
+async function waitForBuild(
+  request,
+  { appId, version, build, timeoutMinutes },
+) {
+  const deadline = Date.now() + timeoutMinutes * 60 * 1000;
+  const query = new URLSearchParams({
+    "filter[app]": appId,
+    "filter[preReleaseVersion.version]": version,
+    "filter[version]": build,
+    "fields[builds]":
+      "version,processingState,expired,betaAppReviewSubmission,betaGroups",
+    include: "betaAppReviewSubmission,betaGroups",
+    "fields[betaAppReviewSubmissions]": "betaReviewState",
+    "fields[betaGroups]": "name",
+  });
+  for (;;) {
+    const result = await request("GET", `/v1/builds?${query}`);
+    const found = result.data.find((entry) => !entry.attributes.expired);
+    if (found) {
+      const state = found.attributes.processingState;
+      if (state === "VALID") {
+        const included = result.included ?? [];
+        const submission = included.find(
+          (entry) =>
+            entry.type === "betaAppReviewSubmissions" &&
+            entry.id === found.relationships.betaAppReviewSubmission?.data?.id,
+        );
+        return {
+          id: found.id,
+          reviewState: submission?.attributes.betaReviewState ?? null,
+          groupIds: (found.relationships.betaGroups?.data ?? []).map(
+            (entry) => entry.id,
+          ),
+        };
+      }
+      if (state === "FAILED" || state === "INVALID") {
+        throw new Error(
+          `Build ${version} (${build}) has processingState ${state}.`,
+        );
+      }
+      console.log(`Build ${version} (${build}) is ${state}; waiting.`);
+    } else {
+      console.log(
+        `Build ${version} (${build}) is not in App Store Connect yet; waiting.`,
+      );
+    }
+    if (Date.now() > deadline) {
+      throw new Error(
+        `Build ${version} (${build}) did not become VALID within ${timeoutMinutes} minutes.`,
+      );
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const { keyId, issuerId, appId } = readSubmitConfig();
+  const privateKey = readFileSync(options.keyPath, "utf8");
+  const request = createClient({ keyId, issuerId, privateKey });
+
+  const group = await findBetaGroup(request, appId, options.group);
+  const build = await waitForBuild(request, {
+    appId,
+    version: options.version,
+    build: options.build,
+    timeoutMinutes: options.timeoutMinutes,
+  });
+  console.log(
+    `Build ${options.version} (${options.build}) is VALID; review state: ${build.reviewState ?? "none"}.`,
+  );
+
+  if (build.groupIds.includes(group.id)) {
+    console.log(`Build is already in '${options.group}'. Nothing to do.`);
+    return;
+  }
+
+  // An external group needs a Beta App Review submission. Apple usually
+  // approves a later build of an approved marketing version in minutes. An
+  // internal group has no review, so it skips this step.
+  if (!group.isInternal && build.reviewState === null) {
+    await request("POST", "/v1/betaAppReviewSubmissions", {
+      data: {
+        type: "betaAppReviewSubmissions",
+        relationships: { build: { data: { type: "builds", id: build.id } } },
+      },
+    });
+    console.log("Submitted the build for Beta App Review.");
+  }
+
+  await request("POST", `/v1/betaGroups/${group.id}/relationships/builds`, {
+    data: [{ type: "builds", id: build.id }],
+  });
+  console.log(
+    `Added build ${options.version} (${options.build}) to '${options.group}'.`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## What was wrong

After #2202 the nightly keeps one TestFlight marketing version, but a new build still reaches only the internal group. Apple offers "Automatically distribute builds" only for internal groups (`hasAccessToAllBuilds` is `null` on the external group in the App Store Connect API). Each build must be added to the external group by hand, and the README wrongly told readers to turn on a toggle that does not exist for external groups.

## What changed

- `apps/mobile/scripts/testflight-distribute.mjs` (new, no npm dependencies): signs an App Store Connect JWT with the `.p8` the submit profile already uses, waits for the build (`--version`, `--build`) to reach `processingState: VALID`, submits it for Beta App Review when it has no submission, and adds it to the beta group (`--group`, default `External testers`). Idempotent: a build already in the group is a no-op.
- `.github/workflows/mobile-ios-eas.yml`: `eas build` now runs with `--json`; stdout goes to `eas-build.json` and the progress log still goes to `eas-build.log` and the step summary. The step exports `app_version` and `build_number`. A new step runs the distribute script when `submit` is true and the new `external_group` input (default `External testers`, empty skips) is set. The `.p8` cleanup moved to an `always()` step because the distribute step needs the key.
- `.github/workflows/publish-bb-app.yml`: the nightly passes `external_group: External testers`.
- `apps/mobile/README.md`: CI and "TestFlight testers" sections describe the distribute step; removed the stale "marketing version climbs on every nightly" paragraph and the wrong "Automatically distribute builds" advice.

No wire changes.

## How you verified

- Ran the script against the live app with the local `.p8`: `node scripts/testflight-distribute.mjs --version 0.39.0 --build 3` printed `Build 0.39.0 (3) is VALID; review state: APPROVED.` and `Build is already in 'External testers'. Nothing to do.` (the idempotent path; build 3 is the approved build).
- `eas build:list --json` confirms the build records carry `appVersion` and `appBuildVersion`, which the workflow reads from `eas build --json`.
- `actionlint` on both workflows: only the pre-existing warnings (custom runner labels, one SC2016 info line).
- `prettier --write` and `node --check` on the script.
- The first real run is the next nightly; it should add the new 0.39.0 build to External testers with no manual step.

> AGENT GENERATED: by Claude Opus 5
