### PR TITLE
Redact all GitHub token formats from provider recordings

### DIFF
--- a/packages/provider-bridge-protocol/test/provider-recordings-redact.test.ts
+++ b/packages/provider-bridge-protocol/test/provider-recordings-redact.test.ts
@@ -1,0 +1,52 @@
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, it } from "vitest";
+
+const REDACT_SCRIPT = new URL(
+  "../../../scripts/provider-recordings/redact.mjs",
+  import.meta.url,
+);
+
+it("redacts every documented GitHub token prefix", () => {
+  const root = mkdtempSync(join(tmpdir(), "bb-recording-redact-"));
+  const inputDir = join(root, "input");
+  const outputDir = join(root, "output");
+  const tokens = [
+    `ghp_${"a".repeat(36)}`,
+    `gho_${"b".repeat(36)}`,
+    `ghu_${"c".repeat(36)}`,
+    `ghs_${"d".repeat(36)}`,
+    `ghs_12345_${"e".repeat(12)}.${"f".repeat(12)}.${"g".repeat(12)}`,
+    `ghr_${"h".repeat(36)}`,
+    `github_pat_${"i".repeat(82)}`,
+  ];
+
+  try {
+    mkdirSync(inputDir);
+    writeFileSync(
+      join(inputDir, "github.ndjson"),
+      `${JSON.stringify({ line: JSON.stringify({ tokens }) })}\n`,
+    );
+
+    const stdout = execFileSync(
+      process.execPath,
+      [REDACT_SCRIPT.pathname, inputDir, outputDir, "--home", "/home/tester"],
+      { encoding: "utf8" },
+    );
+    const output = readFileSync(join(outputDir, "github.ndjson"), "utf8");
+
+    expect(stdout).toContain("0 survivors");
+    for (const token of tokens) expect(output).not.toContain(token);
+    expect(output.match(/REDACTED/g)).toHaveLength(tokens.length);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/provider-recordings/redact.mjs
+++ b/scripts/provider-recordings/redact.mjs
@@ -15,8 +15,9 @@
  *      MAX_STRING_CHARS keeps its head and tail around a marker;
  *   2. textually: absolute paths under the home directory become
  *      `/home/user`, emails become `user@example.com`, and token shapes
- *      (bbde_, ghp_, github_pat_, sk-, sk-ant-, xox?-, JWTs, bearer values,
- *      Authorization headers) are replaced by `<prefix>REDACTED`.
+ *      (bbde_, GitHub gh[pousr]_/github_pat_, sk-, sk-ant-, xox?-, JWTs,
+ *      bearer values, Authorization headers) are replaced by
+ *      `<prefix>REDACTED`.
  *
  * The script is idempotent: a redacted file rewrites to itself. After writing
  * it sweeps the output for every pattern again and exits 3 if anything
@@ -38,7 +39,7 @@ const REDACTED_EMAIL = "user@example.com";
  * `-` run) plus `REDACTED`, so a reader still sees what kind of secret it was. */
 const TOKEN_PATTERNS = [
   /bbde_[A-Za-z0-9]{16,}/g,
-  /ghp_[A-Za-z0-9]{20,}/g,
+  /gh[pousr]_[A-Za-z0-9._-]{20,}/g,
   /github_pat_[A-Za-z0-9_]{20,}/g,
   /sk-ant-[A-Za-z0-9_-]{20,}/g,
   /(?<![A-Za-z0-9])sk-[A-Za-z0-9_-]{20,}/g,


### PR DESCRIPTION
## What was wrong

The provider-recording redactor only recognized classic and fine-grained personal access tokens. Documented OAuth and GitHub App token prefixes could survive both replacement and the final survivor sweep while the command reported zero survivors.

## What changed

Expand the shared GitHub token pattern to cover `ghp_`, `gho_`, `ghu_`, `ghs_`, and `ghr_`, including the newer URL-safe `ghs_` form, while retaining `github_pat_`. Add a CLI-level regression for every documented family. This is not a wire change; `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

The new regression failed before the production change and passes after it. The full `@bb/provider-bridge-protocol` Turbo suite passes 218 tests, Turbo typecheck passes, and re-redacting all 241 committed recording files reports zero survivors with byte-identical output.

Fixes none.

> AGENT GENERATED: by GPT-5.6-Sol