### PR TITLE
Fix mobile smoke deep-link startup race

### DIFF
--- a/apps/mobile/e2e/subflows/launch-app.yaml
+++ b/apps/mobile/e2e/subflows/launch-app.yaml
@@ -20,6 +20,13 @@ appId: app.getbb.mobile
       true: ${typeof BB_E2E_EMBEDDED_BUNDLE !== "undefined" && BB_E2E_EMBEDDED_BUNDLE === "1"}
     commands:
       - launchApp
+      # `launchApp` returns when the process starts, before the embedded JS
+      # bundle and Expo Router necessarily mount. Wait for the first React
+      # screen so callers can safely deliver a live custom-scheme link.
+      - extendedWaitUntil:
+          visible:
+            id: "add-server-screen"
+          timeout: 30000
 - runFlow:
     when:
       true: ${typeof BB_E2E_EMBEDDED_BUNDLE === "undefined" || BB_E2E_EMBEDDED_BUNDLE !== "1"}


### PR DESCRIPTION
## What was wrong

The embedded Release branch of `launch-app.yaml` returned as soon as Maestro's `launchApp` started the native process, before the embedded JavaScript bundle and Expo Router had necessarily mounted. With the E2E profile reset, the initial `/` route redirects to Add server while the live custom-scheme handler is coming online. The smoke flow therefore delivered `bb://dev/spike` into a race between that initial redirect and the incoming URL.

The failed artifact from [Mobile E2E run 32470089883](https://github.com/get-bb/bb/actions/runs/32470089883) makes the race visible: iOS delivered `UIOpenURLAction` at 10:06:54.564, and the same app PID rendered and focused the Add server URL field about 154 ms later. The passing artifacts from runs [32356115918](https://github.com/get-bb/bb/actions/runs/32356115918) and [32445580667](https://github.com/get-bb/bb/actions/runs/32445580667) never rendered that field for the smoke PID before reaching the spike route. The backend, simulator, and app build were healthy in the failed run; all five later flows passed.

## What changed

The embedded-bundle launch subflow now waits for the first React screen (`add-server-screen`) before returning to callers. That readiness condition establishes that app boot, the initial router mount, and the empty-profile redirect have completed before smoke delivers a live deep link. This is a state-based gate rather than a sleep or an increase to the smoke assertion timeout.

The smoke flow and its Phase 0, workspace probe, HTTP, raw WebSocket, realtime, and config-change assertions are unchanged. There are no wire, CLI, guide, or protocol changes.

## How you verified

- Inspected the failed artifact's screenshots, Maestro command trace, screen hierarchy, simulator logs, launch subflow, router boot, empty-profile redirect, and native-intent handling; compared them with both passing artifacts above.
- Parsed `launch-app.yaml` and `smoke.yaml` as two-document YAML files.
- `pnpm exec turbo run build --filter=@bb/mobile`
- `pnpm exec turbo run typecheck --filter=@bb/mobile`
- `pnpm exec turbo run lint --filter=@bb/mobile`
- `pnpm exec turbo run test --filter=@bb/mobile --force` — 124 files and 839 tests passed.
- [Mobile E2E stress run 32502973878](https://github.com/get-bb/bb/actions/runs/32502973878) built and installed the Release app on the pinned Xcode 26 runner, then passed 10 consecutive cold-start smoke flows against one simulator and backend. The artifacts record all 10 readiness gates completing in 3.05–4.36 seconds and all 10 Phase 0 assertions completing in 170–278 ms, with the full downstream probe assertions preserved.

> AGENT GENERATED: by GPT-5.6-Sol
