### PR TITLE
Fix macOS bare worktree test path assertion

### DIFF
--- a/packages/host-workspace/test/provisioning.test.ts
+++ b/packages/host-workspace/test/provisioning.test.ts
@@ -196,7 +196,9 @@ describe("workspace provisioning", () => {
     const worktrees = await runGit(["worktree", "list", "--porcelain"], {
       cwd: root,
     });
-    expect(worktrees.stdout).toContain(`worktree ${targetPath}`);
+    expect(worktrees.stdout.split("\n")).toContain(
+      `worktree ${await fs.realpath(targetPath)}`,
+    );
   });
 
   it("fetches remote base branches before creating worktrees", async () => {


### PR DESCRIPTION
## What was wrong

PR #2158's bare-repository provisioning regression test compared `git worktree list --porcelain` with the lexical temp path passed to `createWorktree`. On macOS, `os.tmpdir()` yields `/tmp` while Git canonicalizes that symlink to `/private/tmp`, so the feature assertions pass but the package suite fails on path spelling.

## What changed

`packages/host-workspace/test/provisioning.test.ts` now canonicalizes the created target with `fs.realpath()` before comparing it with Git porcelain, and compares exact output lines.

This is test-only. No production behavior, CLI/guide/docs, SDK/plugin API, or host-daemon wire shape changed; `HOST_DAEMON_PROTOCOL_VERSION` remains unchanged.

## How you verified

- Before the change, the required macOS Turbo suite failed with 213 passed / 1 failed.
- The focused bare-worktree regression passes after the change.
- The full `@bb/host-workspace` Turbo suite passes with 214/214 tests.
- The package Turbo typecheck passes; the package has no Turbo build task.
- `git diff --check` passes.

Follow-up to #2158.

> AGENT GENERATED: by GPT-5.6-Sol