### PR TITLE
Read each ACP agent's vendor side channels in a profile-keyed dialect

### DIFF
--- a/plugins/provider-acp/server.ts
+++ b/plugins/provider-acp/server.ts
@@ -68,6 +68,11 @@ const ACP_PROVIDERS: readonly PluginProviderDeclaration[] = [
     }),
     experimental_serviceTiers: [...ACP_SERVICE_TIERS],
     experimental_bridgeOptions: {
+      // Which vendor side channels the bridge reads for this agent
+      // (plugins/provider-acp/src/dialect.ts). Declared per registration so
+      // a third-party plugin that registers a known agent gets the same
+      // reporting fidelity a first-party registration does.
+      acpDialect: "cursor",
       acpLaunchSpec: {
         displayName: "Cursor",
         command: "cursor-agent",
@@ -148,6 +153,7 @@ const ACP_PROVIDERS: readonly PluginProviderDeclaration[] = [
     }),
     experimental_serviceTiers: [...ACP_SERVICE_TIERS],
     experimental_bridgeOptions: {
+      acpDialect: "grok",
       acpLaunchSpec: {
         displayName: "Grok Build",
         command: "grok",

--- a/plugins/provider-acp/src/bridge/bridge.ts
+++ b/plugins/provider-acp/src/bridge/bridge.ts
@@ -70,7 +70,7 @@ import {
   createAcpDeltaTranslator,
   type AcpDeltaTranslator,
 } from "../delta-translation.js";
-import { resolveAcpDialect } from "../dialect.js";
+import { resolveAcpDialect, type AcpDialect } from "../dialect.js";
 import {
   buildAcpPermissionInteractionPayload,
   resolveAcpPermissionDecision,
@@ -178,6 +178,8 @@ interface AcpThreadSession {
   providerThreadId: string;
   /** The session's working directory: the agent's cwd and the path root. */
   cwd: string;
+  /** The agent's dialect: its vendor side channels and client methods. */
+  dialect: AcpDialect;
   /** Every session-scoped notification is translated through this. */
   translator: AcpDeltaTranslator;
   connection: AcpAgentConnection;
@@ -1634,9 +1636,13 @@ async function startAgentSession(
     await stopSession(existing);
   }
 
+  const dialect = resolveAcpDialect({
+    ...(params.dialectId === undefined ? {} : { dialectId: params.dialectId }),
+    command: params.agent.command,
+  });
   const translator = createAcpDeltaTranslator({
     cwd: params.cwd,
-    dialect: resolveAcpDialect(params.agent),
+    dialect,
   });
   // The session's bb-injected tools: a proxied call to one is a bb tool and
   // reads the way its definition says (Q31).
@@ -1707,6 +1713,7 @@ async function startAgentSession(
     bbThreadId,
     providerThreadId: "",
     cwd: params.cwd,
+    dialect,
     translator,
     connection,
     supportsImageInput: false,
@@ -2200,8 +2207,36 @@ function handleAgentRequest(
       void handleFsWriteTextFile(session, params, responder);
       return;
     default:
-      responder.error(-32601, `Unsupported ACP client method "${method}"`);
+      handleDialectRequest(session, method, params, responder);
   }
+}
+
+/**
+ * A vendor request the agent's dialect claims (Cursor's `cursor/task`). An
+ * unclaimed method is still an unsupported one — the bridge must not
+ * acknowledge a request it did not act on.
+ */
+function handleDialectRequest(
+  session: AcpThreadSession,
+  method: string,
+  params: unknown,
+  responder: AcpAgentRequestResponder,
+): void {
+  const outcome = session.dialect.handleClientRequest?.(method, params);
+  if (outcome === undefined) {
+    responder.error(-32601, `Unsupported ACP client method "${method}"`);
+    return;
+  }
+  if (outcome.delegation !== undefined) {
+    sendThreadDeltas(
+      session.bbThreadId,
+      session.translator.noteDelegationReport(
+        session.bbThreadId,
+        outcome.delegation,
+      ),
+    );
+  }
+  responder.result(outcome.result);
 }
 
 function handleAgentNotification(
@@ -2366,6 +2401,13 @@ const acpProviderOptionsSchema = z
      * field for it — same delivery as the ACP launch spec.
      */
     additionalWorkspaceWriteRoots: z.array(z.string()).optional(),
+    /**
+     * The agent's dialect: which vendor side channels this bridge should
+     * read for it (see `dialect.ts`). Declared by the plugin that registers
+     * the provider, so a third-party registration of a known agent gets the
+     * same reporting fidelity a first-party one does.
+     */
+    acpDialect: z.string().min(1).optional(),
   })
   .passthrough();
 
@@ -2376,6 +2418,12 @@ function decodeAdditionalWorkspaceWriteRoots(
     acpProviderOptionsSchema.parse(providerOptions ?? {})
       .additionalWorkspaceWriteRoots ?? []
   );
+}
+
+function decodeDialectId(
+  providerOptions: Record<string, unknown> | undefined,
+): string | undefined {
+  return acpProviderOptionsSchema.parse(providerOptions ?? {}).acpDialect;
 }
 
 async function handleRequest(
@@ -2512,6 +2560,7 @@ async function handleRequest(
         additionalWorkspaceWriteRoots: decodeAdditionalWorkspaceWriteRoots(
           params.options.providerOptions,
         ),
+        dialectId: decodeDialectId(params.options.providerOptions),
         cwd: params.cwd,
         dynamicTools: params.dynamicTools,
         options: {

--- a/plugins/provider-acp/src/delta-translation.test.ts
+++ b/plugins/provider-acp/src/delta-translation.test.ts
@@ -1755,6 +1755,172 @@ describe("acp delta translation (raw payloads and real results)", () => {
   });
 });
 
+/**
+ * Sub-agents are not in the protocol (version 1 has no such concept), so the
+ * agent's own dialect is the only thing that can report one.
+ */
+describe("acp delta translation (dialects)", () => {
+  function dialectHarness(dialectId: string): AcpEquivalenceHarness {
+    const translator = createAcpDeltaTranslator({
+      cwd: "/workspace",
+      dialect: resolveAcpDialect({ dialectId, command: "node" }),
+    });
+    const assembler = createDeltaAssembler({
+      providerId: "acp",
+      entropyPrefix: ENTROPY,
+      textDeltaFlushMs: 0,
+    });
+    const harness: AcpEquivalenceHarness = {
+      assembler,
+      translator,
+      translate: (event) =>
+        assembler.assemble({
+          threadId: THREAD_ID,
+          deltas: translator.translateAcpEvent(event, { threadId: THREAD_ID }),
+        }),
+      openTurnId: () => assembler.getOpenTurnId(THREAD_ID) ?? "",
+    };
+    harness.translate(turnStartedEvent());
+    return harness;
+  }
+
+  it("opens a Cursor task call as a delegation and takes the report's detail", () => {
+    const harness = dialectHarness("cursor");
+    const opened = harness.translate(
+      updateEvent({
+        sessionUpdate: "tool_call",
+        toolCallId: "call-task",
+        title: "Task: Subagent task",
+        kind: "other",
+        status: "pending",
+        rawInput: { _toolName: "task" },
+      }),
+    );
+    expect(opened[0]).toMatchObject({
+      type: "item/started",
+      item: { type: "delegation", childRef: "call-task", background: false },
+    });
+    const openedId =
+      opened[0]?.type === "item/started" ? opened[0].item.id : "";
+
+    // `cursor/task` names the child and what it was asked to do; the row is
+    // still open, so it updates in place rather than minting a second row.
+    const reported = harness.assembler.assemble({
+      threadId: THREAD_ID,
+      deltas: harness.translator.noteDelegationReport(THREAD_ID, {
+        toolCallId: "call-task",
+        childRef: "78d1cd3b-94d2-4c87-82a2-c83fe54712f1",
+        label: "Read README first line",
+        detail: "model default",
+      }),
+    });
+    expect(reported).toEqual([
+      expect.objectContaining({
+        type: "item/started",
+        item: expect.objectContaining({
+          id: openedId,
+          type: "delegation",
+          childRef: "78d1cd3b-94d2-4c87-82a2-c83fe54712f1",
+          label: "Read README first line",
+        }),
+      }),
+    ]);
+
+    expect(
+      harness.translate(
+        updateEvent({
+          sessionUpdate: "tool_call_update",
+          toolCallId: "call-task",
+          status: "completed",
+          rawOutput: { durationMs: 4764, isBackground: false },
+        }),
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        type: "item/completed",
+        item: expect.objectContaining({
+          id: openedId,
+          type: "delegation",
+          childRef: "78d1cd3b-94d2-4c87-82a2-c83fe54712f1",
+          label: "Read README first line",
+        }),
+      }),
+    ]);
+  });
+
+  // Cursor sends `cursor/task` after the sub-agent finished, so the report
+  // can arrive once the row has settled. Re-opening it would show the same
+  // work twice.
+  it("ignores a delegation report for a call that already settled", () => {
+    const harness = dialectHarness("cursor");
+    harness.translate(
+      updateEvent({
+        sessionUpdate: "tool_call",
+        toolCallId: "call-task",
+        title: "Task: Subagent task",
+        kind: "other",
+        status: "completed",
+        rawInput: { _toolName: "task" },
+      }),
+    );
+
+    expect(
+      harness.translator.noteDelegationReport(THREAD_ID, {
+        toolCallId: "call-task",
+        childRef: "agent-1",
+        label: "Read README first line",
+      }),
+    ).toEqual([]);
+  });
+
+  it("opens a grok spawn_subagent call as a delegation", () => {
+    expect(
+      dialectHarness("grok").translate(
+        updateEvent({
+          sessionUpdate: "tool_call",
+          toolCallId: "call-spawn",
+          title: "spawn_subagent",
+          status: "pending",
+          rawInput: { description: "Audit the config loader" },
+          _meta: {
+            "x.ai/tool": { name: "spawn_subagent", kind: "other", version: 1 },
+          },
+        }),
+      )[0],
+    ).toMatchObject({
+      type: "item/started",
+      item: {
+        type: "delegation",
+        childRef: "call-spawn",
+        label: "Audit the config loader",
+        presentation: { icon: { glyph: "UserRound" } },
+      },
+    });
+  });
+
+  // A bb-injected tool call is bb's own, whatever the dialect thinks.
+  it("keeps a bb-injected tool binding ahead of the dialect", () => {
+    const harness = dialectHarness("cursor");
+    harness.translator.configureInjectedTools([{ name: "AskUserQuestion" }]);
+    harness.translator.noteInjectedToolCall(THREAD_ID, "AskUserQuestion");
+    expect(
+      harness.translate(
+        updateEvent({
+          sessionUpdate: "tool_call",
+          toolCallId: "call-bb",
+          title: "MCP: AskUserQuestion",
+          kind: "other",
+          status: "pending",
+          rawInput: { _toolName: "task" },
+        }),
+      )[0],
+    ).toMatchObject({
+      type: "item/started",
+      item: { type: "toolCall", tool: "AskUserQuestion", server: "bb" },
+    });
+  });
+});
+
 describe("acp delta translation (bb-injected tools)", () => {
   const ASK_PRESENTATION = {
     label: { pending: "Asking a question", completed: "Asked a question" },

--- a/plugins/provider-acp/src/delta-translation.ts
+++ b/plugins/provider-acp/src/delta-translation.ts
@@ -46,9 +46,14 @@ import {
   acpUpdateNotificationParamsSchema,
   acpWarningNotificationParamsSchema,
 } from "./bridge-protocol.js";
-import { GENERIC_ACP_DIALECT, type AcpDialect } from "./dialect.js";
+import {
+  GENERIC_ACP_DIALECT,
+  type AcpDelegationReport,
+  type AcpDialect,
+} from "./dialect.js";
 import {
   COMPACTION_PRESENTATION,
+  delegationPresentation,
   fileChangePresentation,
   planStepsPresentation,
   presentationTitle,
@@ -212,6 +217,8 @@ interface AcpOpenToolCall {
    * already open (see `notePermissionToolCall`).
    */
   permissionTitle?: string;
+  /** What the agent's dialect reported about a delegated sub-agent. */
+  delegation?: AcpDelegationReport;
 }
 
 export function createAcpDeltaTranslator(
@@ -363,15 +370,26 @@ export function createAcpDeltaTranslator(
   }
 
   /** Classify a call with its bb-tool binding, if it has one. */
+  /**
+   * Classify a call with its bb-tool binding, if it has one. The agent's own
+   * dialect gets the first word — only it can know that a tool call is a
+   * sub-agent, which version 1 of the protocol cannot express — and the
+   * shared classifier decides everything else.
+   */
   function classifyCall(
     context: AcpDeltaTranslationContext | undefined,
     event: AcpToolCallUpdateEvent,
   ): AcpClassifiedToolCall {
-    return classifyAcpToolCall(
-      event,
-      injectedToolBindings.get(callKey(context, event.toolCallId)),
-      pathOptions,
+    const injected = injectedToolBindings.get(
+      callKey(context, event.toolCallId),
     );
+    if (injected === undefined) {
+      const dialectShape = dialect.classifyToolCall?.(event);
+      if (dialectShape !== undefined) {
+        return dialectShape;
+      }
+    }
+    return classifyAcpToolCall(event, injected, pathOptions);
   }
 
   // -------------------------------------------------------------------------
@@ -481,7 +499,30 @@ export function createAcpDeltaTranslator(
     status: ThreadEventItemStatus;
     /** A headline a permission revealed while the row was open. */
     permissionTitle?: string | undefined;
+    /** A sub-agent report the dialect took off a vendor request. */
+    delegation?: AcpDelegationReport | undefined;
     noTurnFallback?: DeltaNoTurnFallback;
+  }
+
+  /** The classified call with what a later report revealed, if anything. */
+  function withDelegationReport(
+    classified: AcpClassifiedToolCall,
+    report: AcpDelegationReport | undefined,
+  ): AcpClassifiedToolCall {
+    if (report === undefined || classified.item.type !== "delegation") {
+      return classified;
+    }
+    return {
+      item: {
+        ...classified.item,
+        childRef: report.childRef,
+        label: report.label,
+      },
+      presentation: delegationPresentation({
+        label: report.label,
+        ...(report.detail === undefined ? {} : { detail: report.detail }),
+      }),
+    };
   }
 
   /** The classified call with a permission's headline, when it had one. */
@@ -511,7 +552,10 @@ export function createAcpDeltaTranslator(
    */
   function toolCallClose(args: AcpCloseArgs): ThreadDelta {
     const classified = withPermissionTitle(
-      classifyCall(args.context, args.event),
+      withDelegationReport(
+        classifyCall(args.context, args.event),
+        args.delegation,
+      ),
       args.permissionTitle,
     );
     injectedToolBindings.delete(callKey(args.context, args.event.toolCallId));
@@ -568,6 +612,7 @@ export function createAcpDeltaTranslator(
           event: open.event,
           status,
           permissionTitle: open.permissionTitle,
+          delegation: open.delegation,
         }),
       );
     }
@@ -698,6 +743,7 @@ export function createAcpDeltaTranslator(
               event: merged,
               status: mapAcpToolCallStatus(merged.status),
               permissionTitle: open?.permissionTitle,
+              delegation: open?.delegation,
               noTurnFallback: noTurnFallbackFor(rawEvent),
             }),
           ];
@@ -709,6 +755,9 @@ export function createAcpDeltaTranslator(
           ...(open?.permissionTitle === undefined
             ? {}
             : { permissionTitle: open.permissionTitle }),
+          ...(open?.delegation === undefined
+            ? {}
+            : { delegation: open.delegation }),
         });
         const progressText = extractAcpToolCallOutputText(event);
         if (progressText === undefined) {
@@ -1100,6 +1149,46 @@ export function createAcpDeltaTranslator(
     return { toolCallId: open.event.toolCallId, event: merged };
   }
 
+  /**
+   * A sub-agent the agent's dialect reported (Cursor's `cursor/task`). It
+   * arrives on a vendor request rather than a session update, and Cursor
+   * sends it once the sub-agent has already finished, so it enriches the
+   * delegation row while the row is still open and is otherwise a no-op:
+   * re-opening a settled row would show the same work twice.
+   */
+  function noteDelegationReport(
+    threadId: string,
+    report: AcpDelegationReport,
+  ): ThreadDelta[] {
+    const context = { threadId };
+    const key = callKey(context, report.toolCallId);
+    const open = mergedToolCalls.get(key);
+    if (open === undefined) {
+      return [];
+    }
+    const classified = classifyCall(context, open.event);
+    if (classified.item.type !== "delegation") {
+      return [];
+    }
+    const item: DeltaItemShape = {
+      ...classified.item,
+      childRef: report.childRef,
+      label: report.label,
+    };
+    mergedToolCalls.set(key, { ...open, delegation: report });
+    return [
+      {
+        kind: "item.open",
+        key: { providerItemId: report.toolCallId },
+        item,
+        presentation: delegationPresentation({
+          label: report.label,
+          ...(report.detail === undefined ? {} : { detail: report.detail }),
+        }),
+      },
+    ];
+  }
+
   /** The bb tool an unsettled call is bound to (Q31), for its permission. */
   function getInjectedToolBinding(
     threadId: string,
@@ -1112,6 +1201,7 @@ export function createAcpDeltaTranslator(
     configureInjectedTools,
     getInjectedToolBinding,
     getMergedToolCall,
+    noteDelegationReport,
     noteInjectedToolCall,
     notePermissionToolCall,
     translateAcpEvent,

--- a/plugins/provider-acp/src/dialect.test.ts
+++ b/plugins/provider-acp/src/dialect.test.ts
@@ -1,23 +1,149 @@
 import { describe, expect, it } from "vitest";
 import {
+  CURSOR_ACP_DIALECT,
   GENERIC_ACP_DIALECT,
   GROK_ACP_DIALECT,
   resolveAcpDialect,
 } from "./dialect.js";
+import type { AcpToolCallUpdateEvent } from "./wire.js";
 
 describe("resolveAcpDialect", () => {
-  it("keys on the launch executable's base name", () => {
+  // The profile names the dialect, so the same agent behind a wrapper
+  // script — or registered by a third-party plugin under another id — still
+  // gets its side channels read.
+  it("takes the dialect the profile named", () => {
+    expect(
+      resolveAcpDialect({ dialectId: "grok", command: "/opt/wrappers/agent" }),
+    ).toBe(GROK_ACP_DIALECT);
+    expect(
+      resolveAcpDialect({ dialectId: "cursor", command: "node" }),
+    ).toBe(CURSOR_ACP_DIALECT);
+  });
+
+  it("falls back to the launch executable's base name", () => {
     expect(resolveAcpDialect({ command: "grok" })).toBe(GROK_ACP_DIALECT);
     expect(resolveAcpDialect({ command: "/usr/local/bin/grok" })).toBe(
       GROK_ACP_DIALECT,
     );
+    expect(resolveAcpDialect({ command: "cursor-agent" })).toBe(
+      CURSOR_ACP_DIALECT,
+    );
   });
 
-  it("gives an unknown agent the generic dialect", () => {
-    expect(resolveAcpDialect({ command: "cursor-agent" })).toBe(
-      GENERIC_ACP_DIALECT,
-    );
-    expect(GENERIC_ACP_DIALECT.toolIdentity).toBeUndefined();
+  it("is generic for a dialect id it does not ship", () => {
+    expect(
+      resolveAcpDialect({ dialectId: "amp", command: "cursor-agent" }),
+    ).toBe(GENERIC_ACP_DIALECT);
+  });
+
+  // Selecting on the launch command, not a bb provider id, is what lets a
+  // user-configured instance of the same agent get the same dialect.
+  it("gives an unknown agent the generic dialect, which answers nothing", () => {
+    const dialect = resolveAcpDialect({ command: "opencode" });
+    expect(dialect).toBe(GENERIC_ACP_DIALECT);
+    expect(dialect.toolIdentity).toBeUndefined();
+    expect(dialect.classifyToolCall).toBeUndefined();
+    expect(dialect.handleClientRequest).toBeUndefined();
+  });
+});
+
+const toolCall = (fields: Partial<AcpToolCallUpdateEvent>) =>
+  ({
+    sessionUpdate: "tool_call",
+    toolCallId: "call-1",
+    ...fields,
+  }) as AcpToolCallUpdateEvent;
+
+describe("grok sub-agents", () => {
+  // Version 1 of the protocol has no sub-agent concept, so only the dialect
+  // can know that this tool call is delegated work.
+  it("maps a spawn_subagent call to a delegation", () => {
+    expect(
+      GROK_ACP_DIALECT.classifyToolCall?.(
+        toolCall({
+          title: "spawn_subagent",
+          rawInput: {
+            description: "Audit the config loader",
+            subagent_type: "explore",
+          },
+          _meta: { "x.ai/tool": { name: "spawn_subagent", kind: "other" } },
+        }),
+      ),
+    ).toEqual({
+      item: {
+        type: "delegation",
+        childRef: "call-1",
+        label: "Audit the config loader",
+        background: false,
+      },
+      presentation: {
+        label: { pending: "Running subagent", completed: "Subagent finished" },
+        icon: { glyph: "UserRound" },
+        title: "Audit the config loader",
+        detail: "explore",
+      },
+    });
+  });
+
+  it("leaves every other grok tool to the shared classifier", () => {
+    expect(
+      GROK_ACP_DIALECT.classifyToolCall?.(
+        toolCall({
+          title: "run_terminal_command",
+          _meta: { "x.ai/tool": { name: "run_terminal_command" } },
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("cursor sub-agents", () => {
+  it("maps a task tool call to a delegation from its rawInput tool name", () => {
+    expect(
+      CURSOR_ACP_DIALECT.classifyToolCall?.(
+        toolCall({
+          title: "Task: Subagent task",
+          kind: "other",
+          rawInput: { _toolName: "task" },
+        }),
+      ),
+    ).toMatchObject({
+      item: { type: "delegation", childRef: "call-1", background: false },
+      presentation: { icon: { glyph: "UserRound" } },
+    });
+  });
+
+  // bb answered cursor/task with -32601: a protocol error for a request the
+  // agent is entitled to send, and the sub-agent detail was thrown away.
+  it("acknowledges cursor/task and reports the sub-agent it names", () => {
+    expect(
+      CURSOR_ACP_DIALECT.handleClientRequest?.("cursor/task", {
+        toolCallId: "call-1",
+        description: "Read README first line",
+        prompt: "Read the file README.md…",
+        subagentType: { custom: { unspecified: {} } },
+        model: "default",
+        agentId: "78d1cd3b-94d2-4c87-82a2-c83fe54712f1",
+        durationMs: 4764,
+      }),
+    ).toEqual({
+      result: {},
+      delegation: {
+        toolCallId: "call-1",
+        childRef: "78d1cd3b-94d2-4c87-82a2-c83fe54712f1",
+        label: "Read README first line",
+        detail: "model default",
+      },
+    });
+  });
+
+  it("still acknowledges a cursor/task it cannot read, and claims nothing else", () => {
+    expect(
+      CURSOR_ACP_DIALECT.handleClientRequest?.("cursor/task", { nope: true }),
+    ).toEqual({ result: {} });
+    expect(
+      CURSOR_ACP_DIALECT.handleClientRequest?.("cursor/other", {}),
+    ).toBeUndefined();
   });
 });
 

--- a/plugins/provider-acp/src/dialect.ts
+++ b/plugins/provider-acp/src/dialect.ts
@@ -2,19 +2,27 @@
  * Per-agent dialects: the vendor side channels of an ACP agent.
  *
  * The ACP wire schema (`wire.ts`) parses only the protocol. What an agent
- * puts beside the protocol — grok's `_meta["x.ai/tool"]`, Cursor's
- * `cursor/task` request — is a dialect: a small, profile-keyed module that
- * reads those channels and answers a few questions the shared translator
- * asks. The shared schema never learns a vendor key; a dialect never changes
- * what the protocol fields mean.
+ * puts beside the protocol is a dialect: grok stamps `_meta["x.ai/tool"]` on
+ * every tool event, Cursor reports its sub-agents through a vendor JSON-RPC
+ * request (`cursor/task`) that the protocol has no place for. A dialect is a
+ * small, profile-keyed module that reads those channels and answers the few
+ * questions the shared translator asks. The shared schema never learns a
+ * vendor key, and a dialect never changes what a protocol field means.
+ *
+ * Version 1 of the protocol has no sub-agent concept at all (`session/fork`
+ * is unstable and unrelated), so every delegation an ACP agent reports is
+ * vendor-specific and belongs here rather than in the classifier.
  *
  * The dialect is selected per session from the agent's launch command. An
  * agent with no dialect of its own gets the generic one, which answers
  * nothing and leaves every decision to the protocol fields.
  */
 
+import type { DeltaItemShape } from "@get-bb/plugin-sdk/provider-bridge";
 import { basename } from "node:path";
 import { z } from "zod";
+import { delegationPresentation } from "./presentation.js";
+import type { AcpClassifiedToolCall } from "./tool-classification.js";
 import {
   acpToolKindSchema,
   type AcpToolCallUpdateEvent,
@@ -33,6 +41,18 @@ export interface AcpToolIdentity {
   kind?: AcpToolKind;
 }
 
+/** What a dialect learned about a sub-agent the agent launched. */
+export interface AcpDelegationReport {
+  /** The tool call the delegation belongs to. */
+  toolCallId: string;
+  /** The child's provider-native id. */
+  childRef: string;
+  /** The row headline: what the sub-agent was asked to do. */
+  label: string;
+  /** A sub-agent type or model the row can name, when the agent says. */
+  detail?: string;
+}
+
 export interface AcpDialect {
   /** Stable id, for logs and tests. */
   readonly id: string;
@@ -42,6 +62,31 @@ export interface AcpDialect {
    * `kind` from it; a protocol value always wins over the dialect's.
    */
   toolIdentity?(event: AcpToolCallUpdateEvent): AcpToolIdentity | undefined;
+  /**
+   * The agent's own classification of a tool call, when its side channel
+   * says something the protocol fields cannot. Returning `undefined` leaves
+   * the shared classifier in charge — which is the normal answer.
+   */
+  classifyToolCall?(
+    event: AcpToolCallUpdateEvent,
+  ): AcpClassifiedToolCall | undefined;
+  /**
+   * A vendor JSON-RPC request the agent sends to the client. A dialect that
+   * answers one returns the JSON-RPC result to reply with (`{}` is a valid
+   * acknowledgement) and, optionally, what the request reported. A request
+   * no dialect claims stays an unsupported method.
+   */
+  handleClientRequest?(
+    method: string,
+    params: unknown,
+  ): AcpClientRequestOutcome | undefined;
+}
+
+export interface AcpClientRequestOutcome {
+  /** The JSON-RPC result the bridge replies with. */
+  result: Record<string, unknown>;
+  /** A sub-agent the request reported, if it reported one. */
+  delegation?: AcpDelegationReport;
 }
 
 /** The dialect of an agent with no side channels bb reads. */
@@ -86,26 +131,183 @@ function grokToolIdentity(
   };
 }
 
+/** grok's sub-agent tool and the argument that describes the work. */
+const GROK_SPAWN_SUBAGENT_TOOL = "spawn_subagent";
+const grokSpawnSubagentInputSchema = z
+  .object({
+    description: z.string().optional(),
+    prompt: z.string().optional(),
+    subagent_type: z.string().optional(),
+  })
+  .passthrough();
+
+/**
+ * grok runs sub-agents through a `spawn_subagent` tool call (with
+ * `get_command_or_subagent_output` and `kill_command_or_subagent` beside it).
+ * The protocol reports it as an ordinary tool call, so only the dialect can
+ * know it is delegated work.
+ */
+function grokClassifyToolCall(
+  event: AcpToolCallUpdateEvent,
+): AcpClassifiedToolCall | undefined {
+  if (grokToolIdentity(event)?.name !== GROK_SPAWN_SUBAGENT_TOOL) {
+    return undefined;
+  }
+  const parsed = grokSpawnSubagentInputSchema.safeParse(event.rawInput);
+  const input = parsed.success ? parsed.data : undefined;
+  const label = input?.description ?? input?.prompt ?? event.title ?? "Subagent";
+  const shape: DeltaItemShape = {
+    type: "delegation",
+    // grok reports no child session id, so the tool call is the child ref:
+    // it is what its output and kill calls name.
+    childRef: event.toolCallId,
+    label,
+    background: false,
+  };
+  return {
+    item: shape,
+    presentation: delegationPresentation({
+      label,
+      ...(input?.subagent_type === undefined
+        ? {}
+        : { detail: input.subagent_type }),
+    }),
+  };
+}
+
 export const GROK_ACP_DIALECT: AcpDialect = {
   id: "grok",
   toolIdentity: grokToolIdentity,
+  classifyToolCall: grokClassifyToolCall,
+};
+
+// ---------------------------------------------------------------------------
+// cursor-agent (`cursor-agent acp`)
+// ---------------------------------------------------------------------------
+
+/** Cursor's own name for the tool behind a sub-agent call. */
+const CURSOR_TASK_TOOL = "task";
+const cursorTaskRawInputSchema = z
+  .object({ _toolName: z.string().optional() })
+  .passthrough();
+
+const CURSOR_TASK_METHOD = "cursor/task";
+const cursorTaskParamsSchema = z
+  .object({
+    toolCallId: z.string(),
+    description: z.string().optional(),
+    prompt: z.string().optional(),
+    agentId: z.string().optional(),
+    model: z.string().optional(),
+  })
+  .passthrough();
+
+/**
+ * Cursor announces a sub-agent as a `kind: "other"` tool call whose rawInput
+ * names the tool (`{_toolName: "task"}`) and whose title is the constant
+ * "Task: Subagent task". The description, prompt, child agent id and duration
+ * arrive later, on the vendor `cursor/task` request.
+ */
+function cursorClassifyToolCall(
+  event: AcpToolCallUpdateEvent,
+): AcpClassifiedToolCall | undefined {
+  const parsed = cursorTaskRawInputSchema.safeParse(event.rawInput);
+  if (!parsed.success || parsed.data._toolName !== CURSOR_TASK_TOOL) {
+    return undefined;
+  }
+  const label = event.title ?? "Subagent task";
+  const shape: DeltaItemShape = {
+    type: "delegation",
+    childRef: event.toolCallId,
+    label,
+    background: false,
+  };
+  return {
+    item: shape,
+    presentation: delegationPresentation({ label }),
+  };
+}
+
+/**
+ * `cursor/task` is Cursor's sub-agent report. bb answered it `-32601`
+ * ("unsupported method"), which is a protocol error for a request the agent
+ * is entitled to send; an empty result acknowledges it. Cursor sends it once
+ * the sub-agent has finished, so the report names the child and what it was
+ * asked to do.
+ */
+function cursorHandleClientRequest(
+  method: string,
+  params: unknown,
+): AcpClientRequestOutcome | undefined {
+  if (method !== CURSOR_TASK_METHOD) {
+    return undefined;
+  }
+  const parsed = cursorTaskParamsSchema.safeParse(params);
+  if (!parsed.success) {
+    return { result: {} };
+  }
+  const task = parsed.data;
+  const label = task.description ?? task.prompt;
+  if (label === undefined) {
+    return { result: {} };
+  }
+  return {
+    result: {},
+    delegation: {
+      toolCallId: task.toolCallId,
+      childRef: task.agentId ?? task.toolCallId,
+      label,
+      ...(task.model === undefined ? {} : { detail: `model ${task.model}` }),
+    },
+  };
+}
+
+export const CURSOR_ACP_DIALECT: AcpDialect = {
+  id: "cursor",
+  classifyToolCall: cursorClassifyToolCall,
+  handleClientRequest: cursorHandleClientRequest,
 };
 
 // ---------------------------------------------------------------------------
 // Selection
 // ---------------------------------------------------------------------------
 
-/** Dialects by the launch command's executable name. */
-const DIALECTS_BY_COMMAND: Readonly<Record<string, AcpDialect>> = {
-  grok: GROK_ACP_DIALECT,
+/** Every dialect this kit ships, by id. */
+const DIALECTS_BY_ID: Readonly<Record<string, AcpDialect>> = {
+  [CURSOR_ACP_DIALECT.id]: CURSOR_ACP_DIALECT,
+  [GROK_ACP_DIALECT.id]: GROK_ACP_DIALECT,
 };
 
+/** The executable name each dialect's agent is normally launched as. */
+const DIALECT_IDS_BY_COMMAND: Readonly<Record<string, string>> = {
+  "cursor-agent": CURSOR_ACP_DIALECT.id,
+  grok: GROK_ACP_DIALECT.id,
+};
+
+/** Every dialect id a profile may name. */
+export const ACP_DIALECT_IDS = Object.keys(DIALECTS_BY_ID);
+
 /**
- * The dialect for an agent launch: keyed by the executable's base name
- * (`/usr/local/bin/grok` and `grok` both select the grok dialect), generic
- * for everything else.
+ * The dialect for an agent launch. The profile names it (the ACP plugin puts
+ * `acpDialect` in its bridge options, and a third-party plugin may name one
+ * of these ids for an agent it registers); an unnamed profile falls back to
+ * the launch executable's base name, so a user-configured `grok` instance
+ * gets grok's dialect without declaring anything. Everything else is
+ * generic, which answers nothing.
+ *
+ * Keying on the profile rather than on a bb provider id is deliberate: the
+ * ACP plugin owns several providers and the same agent can be registered
+ * under any id, so the dialect must not be a provider-id table.
  */
-export function resolveAcpDialect(launch: { command: string }): AcpDialect {
-  const executable = basename(launch.command);
-  return DIALECTS_BY_COMMAND[executable] ?? GENERIC_ACP_DIALECT;
+export function resolveAcpDialect(launch: {
+  dialectId?: string | undefined;
+  command: string;
+}): AcpDialect {
+  if (launch.dialectId !== undefined) {
+    return DIALECTS_BY_ID[launch.dialectId] ?? GENERIC_ACP_DIALECT;
+  }
+  const byCommand = DIALECT_IDS_BY_COMMAND[basename(launch.command)];
+  return byCommand === undefined
+    ? GENERIC_ACP_DIALECT
+    : (DIALECTS_BY_ID[byCommand] ?? GENERIC_ACP_DIALECT);
 }

--- a/plugins/provider-acp/src/presentation.ts
+++ b/plugins/provider-acp/src/presentation.ts
@@ -175,6 +175,27 @@ export function planStepsPresentation(
 }
 
 /**
+ * A sub-agent an ACP agent launched (Cursor's `cursor/task`, grok's
+ * `spawn_subagent`). Version 1 of the protocol has no sub-agent concept, so
+ * the label is whatever the agent's own side channel described.
+ */
+export function delegationPresentation(args: {
+  label: string;
+  detail?: string;
+}): DeltaPresentation {
+  const presentation = withTitle(
+    {
+      label: { pending: "Running subagent", completed: "Subagent finished" },
+      icon: { glyph: "UserRound" },
+    },
+    presentationTitle(args.label),
+  );
+  return args.detail === undefined
+    ? presentation
+    : { ...presentation, detail: args.detail };
+}
+
+/**
  * A bb-injected tool whose definition carries no presentation (a server from
  * before the field existed): a generic label under bb's own glyph.
  */

--- a/plugins/provider-acp/src/session-params.ts
+++ b/plugins/provider-acp/src/session-params.ts
@@ -104,6 +104,8 @@ export interface AcpSessionParams {
   threadId: string;
   cwd: string;
   agent: { command: string; args: string[] };
+  /** The dialect the registering plugin named for this agent, if any. */
+  dialectId?: string | undefined;
   modelSelection?: AcpModelSelection;
   /**
    * Launch-time reasoning level for agents that take reasoning as a global CLI
@@ -271,6 +273,8 @@ function buildAcpModelSelectionParam(
 interface BuildAcpSessionParamsArgs {
   additionalWorkspaceWriteRoots: readonly string[];
   cwd: string;
+  /** The dialect the registering plugin named for this agent, if any. */
+  dialectId?: string | undefined;
   dynamicTools?: readonly DynamicTool[] | undefined;
   options: AcpSessionExecutionOptions;
   profile: AcpAgentProfile;
@@ -302,6 +306,7 @@ export function buildAcpSessionParams(
       command: profile.agentCommand.command,
       args: [...profile.agentCommand.args],
     },
+    ...(args.dialectId === undefined ? {} : { dialectId: args.dialectId }),
     ...buildAcpModelSelectionParam(profile, options),
     ...(profile.reasoningCli !== undefined
       ? { reasoningCli: profile.reasoningCli }


### PR DESCRIPTION
Stacked on #2211.

## What was wrong

Version 1 of the Agent Client Protocol has **no sub-agent concept** (`session/fork` is unstable and unrelated), and it standardizes nothing about `rawInput`. So the things that most distinguish one ACP agent from another live *beside* the protocol, and the bridge read none of them:

- Cursor announces a sub-agent as a `kind: "other"` tool call titled "Task: Subagent task", then sends a vendor JSON-RPC request `cursor/task` carrying the description, the prompt, the child `agentId` and the duration. bb replied **`-32601` "Unsupported ACP client method"** — a protocol error for a request the agent is entitled to send — and threw the report away. (`recordings/acp-cursor/subagent`, seq 2946/2947.)
- grok runs sub-agents through a `spawn_subagent` tool call, which the protocol reports as an ordinary tool call.
- grok stamps `_meta["x.ai/tool"]` (name, kind, namespace, label, read_only) on every tool event.

#2211 read grok's `_meta` from a single hardcoded helper. That does not scale to a second agent, and it does not survive the point of this workstream: a third-party plugin must be able to get the same fidelity for an agent bb has never heard of.

## What changed

`plugins/provider-acp/src/dialect.ts` — a dialect is a small, profile-keyed module with three optional hooks:

```ts
interface AcpDialect {
  readonly id: string;
  toolIdentity?(event): { name?, kind? } | undefined;        // grok's _meta
  classifyToolCall?(event): AcpClassifiedToolCall | undefined; // sub-agents
  handleClientRequest?(method, params): { result, delegation? } | undefined;
}
```

- **The shared wire schema learns no vendor key.** `_meta` stays an opaque passthrough field on the tool-call schema; only a dialect reads it.
- **The classifier is pluggable, not replaced.** A dialect gets the first word — only it can know a tool call is delegated work — and returning `undefined` (the normal answer) leaves every decision to the shared classifier. A bb-injected tool binding still wins over both.
- **Cursor**: `rawInput._toolName === "task"` opens the call as a `delegation`; `cursor/task` is answered `{}` and its report gives the row the child `agentId`, the description and the model while the row is still open. Cursor sends the report *after* the sub-agent finished, so a report for a settled row is ignored rather than re-opening it — the same rule #2211 established for the permission merge.
- **grok**: `spawn_subagent` opens as a `delegation` labelled by its `description`, with `subagent_type` as the row detail.
- **A profile names its dialect** through the plugin's bridge options (`experimental_bridgeOptions: { acpDialect: "cursor" }`), which travel the opaque `providerOptions` path every other provider uses — no daemon schema change, no protocol bump. An unnamed profile falls back to the launch executable's base name, so a user-configured `grok` instance gets grok's dialect without declaring anything. An id the kit does not ship resolves to the generic dialect.

Keying on the profile rather than a bb provider id is the point: the ACP plugin owns several providers, the same agent can be registered under any id, and Amp's own plugin will name a dialect for an agent that has no bb-side id at all.

## How I verified

- `pnpm exec turbo run typecheck test --filter=bb-plugin-provider-acp`: 16 files, **232 tests**. New coverage: dialect selection (profile id, executable fallback, unknown id → generic, generic answers nothing), grok `spawn_subagent` → delegation and "every other grok tool falls through", Cursor `_toolName: "task"` → delegation, `cursor/task` → `{result: {}, delegation}` and "still acknowledges a request it cannot read, claims nothing else", the translator's open → report → close path, "ignores a report for a call that already settled", and "a bb-injected tool binding stays ahead of the dialect".
- Replaying the committed `acp-cursor/subagent` recording with the cursor dialect selected: the "Task: Subagent task" row is now a `delegation` (`childRef`, `background: false`, `UserRound` glyph) instead of a generic `other` tool.
- `pnpm --filter @bb/provider-parity rerecord --provider acp-cursor`: **no lane changed** except one run-varying temp path in the `fork` cell's error text, which I reverted. `pnpm exec turbo run test --filter=@bb/provider-parity --force`: 43/43, counts unchanged.

**What the recorded oracle cannot prove here, stated plainly:** the committed acp-cursor recordings were made before `acpDialect` existed, so their runtime lane carries no dialect id, and the parity replay rewrites the launch command to the replay child (`node …replay-provider-child.mjs`) — so the executable fallback yields the generic dialect and the recorded cells replay exactly as before. That is why parity shows zero diffs for a change that visibly alters the subagent row. Fresh cells recorded against the installed agents (spike §8) are the next layer's task; until then the dialect's coverage is the unit tests and the live replay above.

> AGENT GENERATED: by Claude Opus 5
