### PR TITLE
Key the timeline response cache by request shape, not maxSeq

### DIFF
--- a/apps/server/src/routes/threads/data.ts
+++ b/apps/server/src/routes/threads/data.ts
@@ -56,7 +56,6 @@ import type {
 } from "../../services/threads/timeline-pagination.js";
 import { createSlowThreadTimelineBuildLogger } from "../../services/threads/timeline-build-log.js";
 import {
-  buildThreadTimelineCacheKey,
   buildThreadTimelineParamsKey,
   createThreadTimelineCache,
 } from "../../services/threads/timeline-cache.js";
@@ -355,8 +354,9 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
       summaryOnly,
       includeProviderUnhandledOperations,
     };
+    const paramsKey = buildThreadTimelineParamsKey(keyArgs);
     const full = timelineCache.getOrBuild(
-      buildThreadTimelineCacheKey({ ...keyArgs, maxSeq }),
+      { paramsKey, maxSeq },
       () => {
         const { profile, response } = buildThreadTimelineWithProfile(
           deps.db,
@@ -399,7 +399,6 @@ export function registerThreadDataRoutes(app: Hono, deps: AppDeps): void {
       query.afterSequence,
       "afterSequence",
     );
-    const paramsKey = buildThreadTimelineParamsKey(keyArgs);
     const previous =
       afterSequence === undefined
         ? undefined

--- a/apps/server/src/services/threads/timeline-cache.ts
+++ b/apps/server/src/services/threads/timeline-cache.ts
@@ -13,9 +13,12 @@ import type { ThreadTimelinePageRequest } from "./timeline-pagination.js";
  * (detail view + side-chat tabs), debounced realtime invalidations that fire
  * after the tail already settled, and re-opening a thread.
  *
- * Keying on the thread high-water `maxSeq` makes invalidation implicit: any
- * appended event bumps `maxSeq`, producing a new key and a cold rebuild. The
- * key MUST also include every other input the projection depends on:
+ * Entries are keyed by request shape (`paramsKey`) and store the thread
+ * high-water `maxSeq` they were built at. A request with a different `maxSeq`
+ * is a miss that *replaces* the slot: `maxSeq` never decreases, so the old
+ * revision could never be looked up again and keeping it until global LRU
+ * eviction only pins a dead response per appended event (#2066). The request
+ * shape MUST include every other input the projection depends on:
  * `thread.status` (interrupt flips earlier rows), `environmentId` (workspace
  * root relativizes file paths), provider display name (labels dynamic-provider
  * diagnostic rows), and the row-shape request flags. Event pruning
@@ -23,10 +26,9 @@ import type { ThreadTimelinePageRequest } from "./timeline-pagination.js";
  * and never lowers `maxSeq`, so it cannot stale a cached entry.
  *
  * Entries with many rows are not cached: an expanded active turn (the streaming
- * case) produces hundreds of rows AND a `maxSeq` that changes on every event,
- * so caching it only thrashes the LRU and pins large objects for no reuse. Idle
- * windows collapse completed turns to a handful of rows regardless of thread
- * size, so the cap excludes exactly the entries that would never be reused.
+ * case) produces hundreds of rows that are rebuilt on every event, so storing
+ * them pins a large object for no reuse. The per-shape slot bounds the *count*
+ * of retained revisions; the row cap bounds their *size*.
  */
 
 const DEFAULT_MAX_ENTRIES = 128;
@@ -40,7 +42,7 @@ interface ThreadTimelineCacheOptions {
 
 interface ThreadTimelineCache {
   getOrBuild(
-    key: string,
+    key: { paramsKey: string; maxSeq: number },
     build: () => ThreadTimelineResponse,
   ): ThreadTimelineResponse;
   /** Number of currently cached entries (for tests/metrics). */
@@ -53,21 +55,27 @@ export function createThreadTimelineCache(
   const maxEntries = options.maxEntries ?? DEFAULT_MAX_ENTRIES;
   const maxCacheableRows =
     options.maxCacheableRows ?? DEFAULT_MAX_CACHEABLE_ROWS;
-  const entries = new Map<string, ThreadTimelineResponse>();
+  const entries = new Map<
+    string,
+    { maxSeq: number; value: ThreadTimelineResponse }
+  >();
 
   return {
-    getOrBuild(key, build) {
-      const cached = entries.get(key);
-      if (cached !== undefined) {
+    getOrBuild({ paramsKey, maxSeq }, build) {
+      const cached = entries.get(paramsKey);
+      if (cached?.maxSeq === maxSeq) {
         // Re-insert to mark most-recently-used.
-        entries.delete(key);
-        entries.set(key, cached);
-        return cached;
+        entries.delete(paramsKey);
+        entries.set(paramsKey, cached);
+        return cached.value;
       }
 
       const value = build();
+      // A newer revision supersedes the stored one even when the new value is
+      // too large to cache: the old one can never hit again.
+      entries.delete(paramsKey);
       if (value.rows.length <= maxCacheableRows) {
-        entries.set(key, value);
+        entries.set(paramsKey, { maxSeq, value });
         while (entries.size > maxEntries) {
           const oldest = entries.keys().next().value;
           if (oldest === undefined) {
@@ -86,8 +94,6 @@ export function createThreadTimelineCache(
 
 export interface ThreadTimelineCacheKeyArgs {
   threadId: string;
-  /** Thread high-water event sequence; bumps on every appended event. */
-  maxSeq: number;
   status: ThreadStatus;
   environmentId: string | null;
   providerDisplayName?: string;
@@ -104,12 +110,12 @@ function pageKeyPart(page: ThreadTimelinePageRequest): string {
 }
 
 /**
- * The cache identity *excluding* `maxSeq` — i.e. everything that selects which
- * window is being requested, but not which revision of it. Used to track the
- * latest-sent rows per request shape for delta computation.
+ * The request shape: everything that selects which window is being requested,
+ * but not which revision (`maxSeq`) of it. Shared by the response cache and the
+ * latest-rows delta cache.
  */
 export function buildThreadTimelineParamsKey(
-  args: Omit<ThreadTimelineCacheKeyArgs, "maxSeq">,
+  args: ThreadTimelineCacheKeyArgs,
 ): string {
   return [
     args.threadId,
@@ -121,10 +127,4 @@ export function buildThreadTimelineParamsKey(
     args.summaryOnly ? "1" : "0",
     args.includeProviderUnhandledOperations ? "1" : "0",
   ].join("|");
-}
-
-export function buildThreadTimelineCacheKey(
-  args: ThreadTimelineCacheKeyArgs,
-): string {
-  return `${args.maxSeq}|${buildThreadTimelineParamsKey(args)}`;
 }

--- a/apps/server/test/public/public-thread-timeline-cache-retention.test.ts
+++ b/apps/server/test/public/public-thread-timeline-cache-retention.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Regression for #2066: the timeline response cache used to key entries by
+ * `${maxSeq}|${paramsKey}`, so every appended event stranded the previous
+ * revision of the same request shape in the LRU until global eviction. A
+ * thread's `maxSeq` is monotonic, so those revisions could never be hit again.
+ *
+ * Drives the real `GET /api/v1/threads/:id/timeline` route against in-memory
+ * SQLite. The only instrumentation is wrapping the cache factory so the test
+ * can read `.size` of the instance the route creates.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { threadScope, turnScope } from "@bb/domain";
+import { threadTimelineResponseSchema } from "@bb/server-contract";
+import { readJson } from "../helpers/json.js";
+import { seedEvent, seedThreadFixture } from "../helpers/seed.js";
+import { withTestHarness } from "../helpers/test-app.js";
+import type { TestAppHarness } from "../helpers/test-app.js";
+import type { createThreadTimelineCache as CreateCache } from "../../src/services/threads/timeline-cache.js";
+
+const createdCaches: ReturnType<typeof CreateCache>[] = [];
+
+vi.mock(
+  "../../src/services/threads/timeline-cache.js",
+  async (importOriginal) => {
+    const mod =
+      await importOriginal<
+        typeof import("../../src/services/threads/timeline-cache.js")
+      >();
+    return {
+      ...mod,
+      createThreadTimelineCache: (
+        ...args: Parameters<typeof mod.createThreadTimelineCache>
+      ) => {
+        const cache = mod.createThreadTimelineCache(...args);
+        createdCaches.push(cache);
+        return cache;
+      },
+    };
+  },
+);
+
+async function fetchTimeline(harness: TestAppHarness, threadId: string) {
+  const response = await harness.app.request(
+    `/api/v1/threads/${threadId}/timeline`,
+  );
+  expect(response.status).toBe(200);
+  return threadTimelineResponseSchema.parse(await readJson(response));
+}
+
+describe("GET /threads/:id/timeline response cache retention (#2066)", () => {
+  it("keeps one resident revision per request shape as events are appended", async () => {
+    await withTestHarness(async (harness) => {
+      const cache = createdCaches.at(-1);
+      if (!cache) {
+        throw new Error("route did not create a timeline cache");
+      }
+      const { environment, thread } = seedThreadFixture(harness);
+      const base = {
+        threadId: thread.id,
+        environmentId: environment.id,
+        providerThreadId: "p1",
+      };
+
+      seedEvent(harness.deps, {
+        ...base,
+        scope: threadScope(),
+        sequence: 1,
+        type: "system/manager/user_message",
+        data: { text: "hello" },
+      });
+      seedEvent(harness.deps, {
+        ...base,
+        scope: turnScope("turn-1"),
+        sequence: 2,
+        type: "turn/started",
+        data: {},
+      });
+      seedEvent(harness.deps, {
+        ...base,
+        scope: turnScope("turn-1"),
+        sequence: 3,
+        type: "item/completed",
+        data: { item: { type: "agentMessage", id: "a-1", text: "done" } },
+      });
+      seedEvent(harness.deps, {
+        ...base,
+        scope: turnScope("turn-1"),
+        sequence: 4,
+        type: "turn/completed",
+        data: { status: "completed" },
+      });
+
+      const first = await fetchTimeline(harness, thread.id);
+      expect(first.maxSeq).toBe(4);
+      expect(cache.size).toBe(1);
+
+      // A second, streaming turn: each appended event bumps maxSeq and the
+      // client refetches the same window (same request shape). Enough rounds
+      // to exceed the 128-entry LRU bound if superseded revisions were kept.
+      seedEvent(harness.deps, {
+        ...base,
+        scope: turnScope("turn-2"),
+        sequence: 5,
+        type: "turn/started",
+        data: {},
+      });
+      const rounds = 150;
+      for (let i = 0; i < rounds; i++) {
+        seedEvent(harness.deps, {
+          ...base,
+          scope: turnScope("turn-2"),
+          sequence: 6 + i,
+          type: "item/completed",
+          data: {
+            item: { type: "agentMessage", id: `a-2-${i}`, text: `chunk ${i}` },
+          },
+        });
+        const page = await fetchTimeline(harness, thread.id);
+        expect(page.maxSeq).toBe(6 + i);
+        // Every revision must stay under the row cap so each one is cacheable;
+        // otherwise the assertion below would pass for the wrong reason.
+        expect(page.rows.length).toBeLessThanOrEqual(200);
+      }
+
+      // Only the entry built at the newest maxSeq can ever be hit again.
+      // Before the fix this was 128 (the LRU bound) of dead revisions.
+      expect(cache.size).toBe(1);
+    });
+  });
+});

--- a/apps/server/test/services/threads/timeline-cache.test.ts
+++ b/apps/server/test/services/threads/timeline-cache.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { ThreadTimelineResponse } from "@bb/server-contract";
 import type { ThreadTimelinePageRequest } from "../../../src/services/threads/timeline-pagination.js";
 import {
-  buildThreadTimelineCacheKey,
+  buildThreadTimelineParamsKey,
   createThreadTimelineCache,
   type ThreadTimelineCacheKeyArgs,
 } from "../../../src/services/threads/timeline-cache.js";
@@ -48,7 +48,6 @@ const latestPage: ThreadTimelinePageRequest = {
 
 const baseKeyArgs: ThreadTimelineCacheKeyArgs = {
   threadId: "thr_x",
-  maxSeq: 10,
   status: "idle",
   environmentId: null,
   page: latestPage,
@@ -57,37 +56,68 @@ const baseKeyArgs: ThreadTimelineCacheKeyArgs = {
   includeProviderUnhandledOperations: false,
 };
 
+const k = (paramsKey: string, maxSeq = 1) => ({ paramsKey, maxSeq });
+
 describe("createThreadTimelineCache", () => {
-  it("builds once for the same key and serves cached on repeat", () => {
+  it("builds once for the same shape and revision and serves cached on repeat", () => {
     const cache = createThreadTimelineCache();
     const build = vi.fn(() => makeResponse(3));
 
-    const first = cache.getOrBuild("k", build);
-    const second = cache.getOrBuild("k", build);
+    const first = cache.getOrBuild(k("k"), build);
+    const second = cache.getOrBuild(k("k"), build);
 
     expect(build).toHaveBeenCalledTimes(1);
     expect(second).toBe(first);
     expect(cache.size).toBe(1);
   });
 
-  it("rebuilds when the key changes (e.g. new maxSeq)", () => {
+  it("rebuilds on a new maxSeq and replaces the prior revision of the same shape", () => {
     const cache = createThreadTimelineCache();
     const build = vi.fn(() => makeResponse(3));
 
-    cache.getOrBuild("k1", build);
-    cache.getOrBuild("k2", build);
+    cache.getOrBuild(k("k", 10), build);
+    cache.getOrBuild(k("k", 11), build);
 
     expect(build).toHaveBeenCalledTimes(2);
+    expect(cache.size).toBe(1);
+  });
+
+  it("never returns a newer revision to a request for an older maxSeq", () => {
+    const cache = createThreadTimelineCache();
+    const newer = makeResponse(2);
+    cache.getOrBuild(k("k", 11), () => newer);
+    const rebuilt = makeResponse(1);
+    const served = cache.getOrBuild(k("k", 10), () => rebuilt);
+    expect(served).toBe(rebuilt);
+  });
+
+  it("retains separate request shapes independently", () => {
+    const cache = createThreadTimelineCache();
+    const build = vi.fn(() => makeResponse(3));
+
+    cache.getOrBuild(k("latest", 10), build);
+    cache.getOrBuild(k("older:5", 10), build);
+
+    expect(cache.size).toBe(2);
   });
 
   it("does not cache responses above the row cap (streaming expanded turns)", () => {
     const cache = createThreadTimelineCache({ maxCacheableRows: 5 });
     const build = vi.fn(() => makeResponse(50));
 
-    cache.getOrBuild("k", build);
-    cache.getOrBuild("k", build);
+    cache.getOrBuild(k("k"), build);
+    cache.getOrBuild(k("k"), build);
 
     expect(build).toHaveBeenCalledTimes(2);
+    expect(cache.size).toBe(0);
+  });
+
+  it("drops a cached revision when its replacement is above the row cap", () => {
+    const cache = createThreadTimelineCache({ maxCacheableRows: 5 });
+
+    cache.getOrBuild(k("k", 1), () => makeResponse(3));
+    expect(cache.size).toBe(1);
+    cache.getOrBuild(k("k", 2), () => makeResponse(50));
     expect(cache.size).toBe(0);
   });
 
@@ -95,24 +125,23 @@ describe("createThreadTimelineCache", () => {
     const cache = createThreadTimelineCache({ maxEntries: 2 });
     const build = vi.fn(() => makeResponse(1));
 
-    cache.getOrBuild("a", build); // [a]
-    cache.getOrBuild("b", build); // [a,b]
-    cache.getOrBuild("a", build); // touch a -> [b,a]
-    cache.getOrBuild("c", build); // evict b -> [a,c]
+    cache.getOrBuild(k("a"), build); // [a]
+    cache.getOrBuild(k("b"), build); // [a,b]
+    cache.getOrBuild(k("a"), build); // touch a -> [b,a]
+    cache.getOrBuild(k("c"), build); // evict b -> [a,c]
 
     expect(cache.size).toBe(2);
     const buildAgain = vi.fn(() => makeResponse(1));
-    cache.getOrBuild("a", buildAgain); // still cached
-    cache.getOrBuild("b", buildAgain); // evicted -> rebuild
+    cache.getOrBuild(k("a"), buildAgain); // still cached
+    cache.getOrBuild(k("b"), buildAgain); // evicted -> rebuild
     expect(buildAgain).toHaveBeenCalledTimes(1);
   });
 });
 
-describe("buildThreadTimelineCacheKey", () => {
+describe("buildThreadTimelineParamsKey", () => {
   it("differs when any projection input differs", () => {
-    const base = buildThreadTimelineCacheKey(baseKeyArgs);
+    const base = buildThreadTimelineParamsKey(baseKeyArgs);
     const variants: ThreadTimelineCacheKeyArgs[] = [
-      { ...baseKeyArgs, maxSeq: 11 },
       { ...baseKeyArgs, status: "active" },
       { ...baseKeyArgs, environmentId: "env_1" },
       { ...baseKeyArgs, includeNestedRows: true },
@@ -128,12 +157,12 @@ describe("buildThreadTimelineCacheKey", () => {
       },
     ];
     for (const variant of variants) {
-      expect(buildThreadTimelineCacheKey(variant)).not.toBe(base);
+      expect(buildThreadTimelineParamsKey(variant)).not.toBe(base);
     }
   });
 
   it("distinguishes older-page cursors", () => {
-    const cursorA = buildThreadTimelineCacheKey({
+    const cursorA = buildThreadTimelineParamsKey({
       ...baseKeyArgs,
       page: {
         kind: "older",
@@ -141,7 +170,7 @@ describe("buildThreadTimelineCacheKey", () => {
         beforeCursor: { anchorSeq: 5, anchorId: "a5" },
       },
     });
-    const cursorB = buildThreadTimelineCacheKey({
+    const cursorB = buildThreadTimelineParamsKey({
       ...baseKeyArgs,
       page: {
         kind: "older",


### PR DESCRIPTION
## What was wrong

`createThreadTimelineCache` keyed entries by `${maxSeq}|${paramsKey}`. A thread's `maxSeq` is monotonic (`getLatestThreadSequence` = `MAX(sequence)`), so the moment an event is appended the previous entry for the same request window can never be looked up again, yet it stays strongly referenced until 127 more entries push it out of the LRU. During a streaming turn the web client refetches the same window after every event batch, so a single active thread fills all 128 slots with dead revisions within seconds. Reported by @Yazington in #2066; investigation report: https://get-bb.github.io/reports/issues/2066.html (on a seeded 9,001-event thread, 100 append+refetch rounds grew the post-GC heap by 19-22 MB on main vs ~3.6 MB with per-shape retention).

## What changed

- `apps/server/src/services/threads/timeline-cache.ts`: the cache is now keyed by `paramsKey` (request shape) and stores `{ maxSeq, value }`. A hit requires an equal `maxSeq`. A miss deletes the slot *before* the row-cap check and re-inserts as most-recently-used, so an oversized newer revision (the streaming expanded-turn case) also drops the stale cached one rather than leaving it pinned. `getOrBuild` takes `{ paramsKey, maxSeq }`.
- `apps/server/src/routes/threads/data.ts`: computes `paramsKey` once and passes it to both the response cache and the latest-rows delta cache.
- `buildThreadTimelineCacheKey` and the `maxSeq` field of `ThreadTimelineCacheKeyArgs` are deleted; nothing else used them. `buildThreadTimelineParamsKey` now takes the args type directly instead of `Omit<..., "maxSeq">`.
- No wire change (server-internal only), no CLI/doc surface.

Relation to #2067 (draft, also by @Yazington, same root cause and same per-shape idea; credit to them for the diagnosis and the approach). This PR differs in that: (1) it stores the bare `maxSeq` number instead of a `revisionKey` string that re-embeds the whole params key, which is redundant once the map is already keyed by shape; (2) it removes the now-unused `buildThreadTimelineCacheKey` helper and `maxSeq` key field instead of keeping them; (3) it ships the tests the #2067 body describes but does not contain: a signature-independent route-level regression plus unit coverage for "oversized replacement evicts the stale revision" and "older-maxSeq request never receives the newer value"; (4) it is based on current `main` (#2067 is ~68 commits behind).

## How you verified

- New route test `apps/server/test/public/public-thread-timeline-cache-retention.test.ts` drives the real `GET /api/v1/threads/:id/timeline` against in-memory SQLite through 150 append+refetch rounds with the same request shape and asserts `cache.size === 1`. It only wraps the cache factory to read `.size`; it does not name the `getOrBuild` signature, so it runs unchanged before and after. Before the fix: `AssertionError: expected 128 to be 1`. After: passes.
- `apps/server/test/services/threads/timeline-cache.test.ts` adapted to the new signature, with added cases: new `maxSeq` replaces the prior revision (size stays 1), an over-cap replacement drops the cached revision, an older-`maxSeq` request is never served the newer value, separate shapes are retained independently, LRU eviction still works.
- `pnpm exec turbo run test --filter=@bb/server`: 199 files / 1901 tests passed.
- `pnpm exec turbo run typecheck lint --filter=@bb/server`: clean.

Fixes #2066

> AGENT GENERATED: by Claude Opus 5
