### PR TITLE
Enforce automation length caps at the CLI boundary, not on stored rows

### DIFF
--- a/plugins/automations/src/automations.test.ts
+++ b/plugins/automations/src/automations.test.ts
@@ -22,11 +22,18 @@ import {
   listAutomationsForProject,
   listAutomationRuns,
   migrations,
+  parseAutomationExecution,
   setAutomationEnabled,
   setAutomationRunThread,
   AUTOMATION_RETRY_BASE_MS,
   type Db,
 } from "./data.js";
+import {
+  AUTOMATION_PROMPT_MAX_LENGTH,
+  automationExecutionSchema,
+  createAutomationInputSchema,
+  updateAutomationInputSchema,
+} from "./rpc-types.js";
 import { ingestLegacyImport } from "./legacy-import.js";
 import {
   computeInitialNextRunAt,
@@ -1453,6 +1460,294 @@ describe("automation CLI --script-file", () => {
     } finally {
       await t.cleanup();
     }
+  });
+});
+
+describe("automation CLI length caps (#2166)", () => {
+  // Regression for get-bb/bb#2166: the CLI skipped the request-side length
+  // caps, so `update --prompt <over-cap>` wrote the row and only failed when
+  // the stored row was re-parsed. Every later list/show/update for the project
+  // then failed with the same `too_big` issue. Caps must be enforced at the
+  // argv boundary before anything is persisted, and rows that already exceed a
+  // cap must stay readable and repairable.
+  const overCapPrompt = "x".repeat(AUTOMATION_PROMPT_MAX_LENGTH + 39);
+  const ctx = { cwd: "/", threadId: undefined } as never;
+
+  async function setup() {
+    const db = createTestDb();
+    const pluginDataDir = await mkdtemp(join(tmpdir(), "bb-2166-data-"));
+    const warnings: string[] = [];
+    const serviceBb = createAutomationServiceBb();
+    const service = createAutomationService({
+      bb: {
+        ...serviceBb,
+        log: {
+          ...serviceBb.log,
+          warn: (message: string) => {
+            warnings.push(message);
+          },
+        },
+      },
+      db,
+      pluginDataDir,
+      serverUrl: "http://127.0.0.1:1",
+    });
+    let cli: PluginCliRegistration | undefined;
+    registerAutomationCli({
+      bb: {
+        sdk: { ...serviceBb.sdk, hosts: { list: async () => [] } } as never,
+        cli: {
+          register: (registration) => {
+            cli = registration;
+          },
+        },
+      },
+      service,
+    });
+    if (!cli) throw new Error("automation CLI was not registered");
+    return {
+      cli,
+      db,
+      service,
+      pluginDataDir,
+      warnings,
+      async cleanup() {
+        await rm(pluginDataDir, { recursive: true, force: true });
+      },
+    };
+  }
+
+  async function createAgent(cli: PluginCliRegistration): Promise<string> {
+    const created = await cli.run(
+      [
+        "create",
+        "--project",
+        "proj_test",
+        "--name",
+        "issue-2166",
+        "--cron",
+        "*/5 * * * *",
+        "--timezone",
+        "UTC",
+        "--prompt",
+        "Reply only with ok.",
+        "--provider",
+        "codex",
+        "--model",
+        "gpt-5",
+      ],
+      ctx,
+    );
+    expect(created.exitCode, created.stderr).toBe(0);
+    const id = /Automation created: (\S+)/.exec(created.stdout ?? "")?.[1];
+    if (!id) throw new Error(`no id in: ${created.stdout}`);
+    return id;
+  }
+
+  function storedPrompt(db: Db, id: string): string {
+    const row = getAutomation(db, id);
+    if (!row) throw new Error(`missing automation ${id}`);
+    const execution = parseAutomationExecution(row.execution);
+    if (execution.mode !== "agent") throw new Error("not an agent automation");
+    return execution.prompt;
+  }
+
+  it("rejects an over-cap --prompt on update without persisting it", async () => {
+    const t = await setup();
+    try {
+      const id = await createAgent(t.cli);
+      const update = await t.cli.run(
+        ["update", id, "--project", "proj_test", "--prompt", overCapPrompt],
+        ctx,
+      );
+      expect(update.exitCode).toBe(1);
+      expect(update.stderr).toContain("too_big");
+      expect(storedPrompt(t.db, id)).toBe("Reply only with ok.");
+
+      // The project is still fully usable afterwards.
+      const list = await t.cli.run(["list", "--project", "proj_test"], ctx);
+      expect(list.exitCode, list.stderr).toBe(0);
+      expect(list.stdout).toContain(id);
+      const show = await t.cli.run(["show", id, "--project", "proj_test"], ctx);
+      expect(show.exitCode, show.stderr).toBe(0);
+      const repair = await t.cli.run(
+        ["update", id, "--project", "proj_test", "--prompt", "short again"],
+        ctx,
+      );
+      expect(repair.exitCode, repair.stderr).toBe(0);
+      expect(storedPrompt(t.db, id)).toBe("short again");
+    } finally {
+      await t.cleanup();
+    }
+  });
+
+  it("rejects an over-cap --prompt on create without persisting it", async () => {
+    const t = await setup();
+    try {
+      const created = await t.cli.run(
+        [
+          "create",
+          "--project",
+          "proj_test",
+          "--name",
+          "issue-2166",
+          "--in",
+          "30m",
+          "--prompt",
+          overCapPrompt,
+          "--provider",
+          "codex",
+          "--model",
+          "gpt-5",
+        ],
+        ctx,
+      );
+      expect(created.exitCode).toBe(1);
+      expect(created.stderr).toContain("too_big");
+      expect(t.service.list({ projectId: "proj_test" })).toEqual([]);
+    } finally {
+      await t.cleanup();
+    }
+  });
+
+  it("rejects an over-cap inline --script on create and update before writing the snapshot", async () => {
+    const t = await setup();
+    try {
+      const overCapScript = `#!/bin/sh\n# ${"y".repeat(262_144)}\n`;
+      const created = await t.cli.run(
+        [
+          "create",
+          "--project",
+          "proj_test",
+          "--name",
+          "issue-2166",
+          "--in",
+          "30m",
+          "--script",
+          overCapScript,
+        ],
+        ctx,
+      );
+      expect(created.exitCode).toBe(1);
+      expect(created.stderr).toContain("too_big");
+      expect(t.service.list({ projectId: "proj_test" })).toEqual([]);
+      await expect(readdir(join(t.pluginDataDir, "scripts"))).rejects.toThrow();
+
+      const id = await createAgent(t.cli);
+      const update = await t.cli.run(
+        ["update", id, "--project", "proj_test", "--script", overCapScript],
+        ctx,
+      );
+      expect(update.exitCode).toBe(1);
+      expect(update.stderr).toContain("too_big");
+      expect(storedPrompt(t.db, id)).toBe("Reply only with ok.");
+      await expect(readdir(join(t.pluginDataDir, "scripts"))).rejects.toThrow();
+    } finally {
+      await t.cleanup();
+    }
+  });
+
+  it("keeps an already-stored over-cap prompt readable and repairable", async () => {
+    // A user who hit the bug before the fix has such a row on disk.
+    const t = await setup();
+    try {
+      const healthyId = await createAgent(t.cli);
+      const brokenId = await createAgent(t.cli);
+      t.db
+        .prepare(
+          "UPDATE automations SET execution = json_set(execution, '$.prompt', ?) WHERE id = ?",
+        )
+        .run(overCapPrompt, brokenId);
+      expect(storedPrompt(t.db, brokenId)).toBe(overCapPrompt);
+
+      const list = await t.cli.run(["list", "--project", "proj_test"], ctx);
+      expect(list.exitCode, list.stderr).toBe(0);
+      expect(list.stdout).toContain(healthyId);
+      expect(list.stdout).toContain(brokenId);
+
+      const show = await t.cli.run(
+        ["show", brokenId, "--project", "proj_test"],
+        ctx,
+      );
+      expect(show.exitCode, show.stderr).toBe(0);
+
+      const repair = await t.cli.run(
+        ["update", brokenId, "--project", "proj_test", "--prompt", "short"],
+        ctx,
+      );
+      expect(repair.exitCode, repair.stderr).toBe(0);
+      expect(storedPrompt(t.db, brokenId)).toBe("short");
+    } finally {
+      await t.cleanup();
+    }
+  });
+
+  it("list skips a malformed row instead of failing the whole project", async () => {
+    const t = await setup();
+    try {
+      const healthyId = await createAgent(t.cli);
+      const brokenId = await createAgent(t.cli);
+      t.db
+        .prepare("UPDATE automations SET execution = ? WHERE id = ?")
+        .run(JSON.stringify({ mode: "agent" }), brokenId);
+
+      const listed = t.service.list({ projectId: "proj_test" });
+      expect(listed.map((automation) => automation.id)).toEqual([healthyId]);
+      expect(t.warnings.join("\n")).toContain(
+        `Skipping malformed automation ${brokenId}`,
+      );
+    } finally {
+      await t.cleanup();
+    }
+  });
+
+  it("the RPC request schemas still enforce the caps", () => {
+    const base = {
+      projectId: "proj_test",
+      name: "issue-2166",
+      trigger: oneShotTrigger(),
+      origin: "human" as const,
+    };
+    const agentExecution = {
+      mode: "agent" as const,
+      providerId: "codex",
+      model: "gpt-5",
+      permissionMode: "auto" as const,
+      environment: { type: "project-default" as const },
+    };
+    expect(
+      createAutomationInputSchema.safeParse({
+        ...base,
+        execution: { ...agentExecution, prompt: overCapPrompt },
+      }).success,
+    ).toBe(false);
+    expect(
+      createAutomationInputSchema.safeParse({
+        ...base,
+        execution: { mode: "script", script: "z".repeat(262_145) },
+      }).success,
+    ).toBe(false);
+    expect(
+      updateAutomationInputSchema.safeParse({
+        projectId: "proj_test",
+        automationId: "auto_1",
+        agent: { prompt: overCapPrompt },
+      }).success,
+    ).toBe(false);
+    expect(
+      updateAutomationInputSchema.safeParse({
+        projectId: "proj_test",
+        automationId: "auto_1",
+        execution: { ...agentExecution, prompt: overCapPrompt },
+      }).success,
+    ).toBe(false);
+    // The stored shape does not carry the caps.
+    expect(
+      automationExecutionSchema.safeParse({
+        ...agentExecution,
+        prompt: overCapPrompt,
+      }).success,
+    ).toBe(true);
   });
 });
 

--- a/plugins/automations/src/automations.test.ts
+++ b/plugins/automations/src/automations.test.ts
@@ -23,6 +23,7 @@ import {
   listAutomationRuns,
   migrations,
   parseAutomationExecution,
+  parseAutomationTrigger,
   setAutomationEnabled,
   setAutomationRunThread,
   AUTOMATION_RETRY_BASE_MS,
@@ -31,14 +32,21 @@ import {
 import {
   AUTOMATION_PROMPT_MAX_LENGTH,
   automationExecutionSchema,
+  automationTriggerSchema,
   createAutomationInputSchema,
   updateAutomationInputSchema,
+  type AutomationTrigger,
 } from "./rpc-types.js";
+import {
+  SCHEDULE_CRON_MAX_LENGTH,
+  SCHEDULE_TIMEZONE_MAX_LENGTH,
+} from "./limits.js";
 import { ingestLegacyImport } from "./legacy-import.js";
 import {
   computeInitialNextRunAt,
   computeNextScheduledTime,
   validateOnceDefinition,
+  validateScheduleDefinition,
 } from "./schedule-helpers.js";
 import {
   bbBinaryCandidates,
@@ -1463,6 +1471,92 @@ describe("automation CLI --script-file", () => {
   });
 });
 
+// Shared CLI-backed harness for the length-cap regression blocks below. Both
+// the execution caps (#2166) and the trigger caps exercise the same path: the
+// real CLI registration on top of the real service and an in-memory database.
+const cliCtx = { cwd: "/", threadId: undefined } as never;
+
+async function setupCliHarness() {
+  const db = createTestDb();
+  const pluginDataDir = await mkdtemp(join(tmpdir(), "bb-2166-data-"));
+  const warnings: string[] = [];
+  const serviceBb = createAutomationServiceBb();
+  const service = createAutomationService({
+    bb: {
+      ...serviceBb,
+      log: {
+        ...serviceBb.log,
+        warn: (message: string) => {
+          warnings.push(message);
+        },
+      },
+    },
+    db,
+    pluginDataDir,
+    serverUrl: "http://127.0.0.1:1",
+  });
+  let cli: PluginCliRegistration | undefined;
+  registerAutomationCli({
+    bb: {
+      sdk: { ...serviceBb.sdk, hosts: { list: async () => [] } } as never,
+      cli: {
+        register: (registration) => {
+          cli = registration;
+        },
+      },
+    },
+    service,
+  });
+  if (!cli) throw new Error("automation CLI was not registered");
+  return {
+    cli,
+    db,
+    service,
+    pluginDataDir,
+    warnings,
+    async cleanup() {
+      await rm(pluginDataDir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function createAgentAutomation(
+  cli: PluginCliRegistration,
+): Promise<string> {
+  const created = await cli.run(
+    [
+      "create",
+      "--project",
+      "proj_test",
+      "--name",
+      "issue-2166",
+      "--cron",
+      "*/5 * * * *",
+      "--timezone",
+      "UTC",
+      "--prompt",
+      "Reply only with ok.",
+      "--provider",
+      "codex",
+      "--model",
+      "gpt-5",
+    ],
+    cliCtx,
+  );
+  expect(created.exitCode, created.stderr).toBe(0);
+  const id = /Automation created: (\S+)/.exec(created.stdout ?? "")?.[1];
+  if (!id) throw new Error(`no id in: ${created.stdout}`);
+  return id;
+}
+
+function storedAgentPrompt(db: Db, id: string): string {
+  const row = getAutomation(db, id);
+  if (!row) throw new Error(`missing automation ${id}`);
+  const execution = parseAutomationExecution(row.execution);
+  if (execution.mode !== "agent") throw new Error("not an agent automation");
+  return execution.prompt;
+}
+
 describe("automation CLI length caps (#2166)", () => {
   // Regression for get-bb/bb#2166: the CLI skipped the request-side length
   // caps, so `update --prompt <over-cap>` wrote the row and only failed when
@@ -1471,118 +1565,41 @@ describe("automation CLI length caps (#2166)", () => {
   // argv boundary before anything is persisted, and rows that already exceed a
   // cap must stay readable and repairable.
   const overCapPrompt = "x".repeat(AUTOMATION_PROMPT_MAX_LENGTH + 39);
-  const ctx = { cwd: "/", threadId: undefined } as never;
-
-  async function setup() {
-    const db = createTestDb();
-    const pluginDataDir = await mkdtemp(join(tmpdir(), "bb-2166-data-"));
-    const warnings: string[] = [];
-    const serviceBb = createAutomationServiceBb();
-    const service = createAutomationService({
-      bb: {
-        ...serviceBb,
-        log: {
-          ...serviceBb.log,
-          warn: (message: string) => {
-            warnings.push(message);
-          },
-        },
-      },
-      db,
-      pluginDataDir,
-      serverUrl: "http://127.0.0.1:1",
-    });
-    let cli: PluginCliRegistration | undefined;
-    registerAutomationCli({
-      bb: {
-        sdk: { ...serviceBb.sdk, hosts: { list: async () => [] } } as never,
-        cli: {
-          register: (registration) => {
-            cli = registration;
-          },
-        },
-      },
-      service,
-    });
-    if (!cli) throw new Error("automation CLI was not registered");
-    return {
-      cli,
-      db,
-      service,
-      pluginDataDir,
-      warnings,
-      async cleanup() {
-        await rm(pluginDataDir, { recursive: true, force: true });
-      },
-    };
-  }
-
-  async function createAgent(cli: PluginCliRegistration): Promise<string> {
-    const created = await cli.run(
-      [
-        "create",
-        "--project",
-        "proj_test",
-        "--name",
-        "issue-2166",
-        "--cron",
-        "*/5 * * * *",
-        "--timezone",
-        "UTC",
-        "--prompt",
-        "Reply only with ok.",
-        "--provider",
-        "codex",
-        "--model",
-        "gpt-5",
-      ],
-      ctx,
-    );
-    expect(created.exitCode, created.stderr).toBe(0);
-    const id = /Automation created: (\S+)/.exec(created.stdout ?? "")?.[1];
-    if (!id) throw new Error(`no id in: ${created.stdout}`);
-    return id;
-  }
-
-  function storedPrompt(db: Db, id: string): string {
-    const row = getAutomation(db, id);
-    if (!row) throw new Error(`missing automation ${id}`);
-    const execution = parseAutomationExecution(row.execution);
-    if (execution.mode !== "agent") throw new Error("not an agent automation");
-    return execution.prompt;
-  }
 
   it("rejects an over-cap --prompt on update without persisting it", async () => {
-    const t = await setup();
+    const t = await setupCliHarness();
     try {
-      const id = await createAgent(t.cli);
+      const id = await createAgentAutomation(t.cli);
       const update = await t.cli.run(
         ["update", id, "--project", "proj_test", "--prompt", overCapPrompt],
-        ctx,
+        cliCtx,
       );
       expect(update.exitCode).toBe(1);
       expect(update.stderr).toContain("too_big");
-      expect(storedPrompt(t.db, id)).toBe("Reply only with ok.");
+      expect(storedAgentPrompt(t.db, id)).toBe("Reply only with ok.");
 
       // The project is still fully usable afterwards.
-      const list = await t.cli.run(["list", "--project", "proj_test"], ctx);
+      const list = await t.cli.run(["list", "--project", "proj_test"], cliCtx);
       expect(list.exitCode, list.stderr).toBe(0);
       expect(list.stdout).toContain(id);
-      const show = await t.cli.run(["show", id, "--project", "proj_test"], ctx);
+      const show = await t.cli.run(
+        ["show", id, "--project", "proj_test"],
+        cliCtx,
+      );
       expect(show.exitCode, show.stderr).toBe(0);
       const repair = await t.cli.run(
         ["update", id, "--project", "proj_test", "--prompt", "short again"],
-        ctx,
+        cliCtx,
       );
       expect(repair.exitCode, repair.stderr).toBe(0);
-      expect(storedPrompt(t.db, id)).toBe("short again");
+      expect(storedAgentPrompt(t.db, id)).toBe("short again");
     } finally {
       await t.cleanup();
     }
   });
 
   it("rejects an over-cap --prompt on create without persisting it", async () => {
-    const t = await setup();
+    const t = await setupCliHarness();
     try {
       const created = await t.cli.run(
         [
@@ -1600,7 +1617,7 @@ describe("automation CLI length caps (#2166)", () => {
           "--model",
           "gpt-5",
         ],
-        ctx,
+        cliCtx,
       );
       expect(created.exitCode).toBe(1);
       expect(created.stderr).toContain("too_big");
@@ -1611,7 +1628,7 @@ describe("automation CLI length caps (#2166)", () => {
   });
 
   it("rejects an over-cap inline --script on create and update before writing the snapshot", async () => {
-    const t = await setup();
+    const t = await setupCliHarness();
     try {
       const overCapScript = `#!/bin/sh\n# ${"y".repeat(262_144)}\n`;
       const created = await t.cli.run(
@@ -1626,21 +1643,21 @@ describe("automation CLI length caps (#2166)", () => {
           "--script",
           overCapScript,
         ],
-        ctx,
+        cliCtx,
       );
       expect(created.exitCode).toBe(1);
       expect(created.stderr).toContain("too_big");
       expect(t.service.list({ projectId: "proj_test" })).toEqual([]);
       await expect(readdir(join(t.pluginDataDir, "scripts"))).rejects.toThrow();
 
-      const id = await createAgent(t.cli);
+      const id = await createAgentAutomation(t.cli);
       const update = await t.cli.run(
         ["update", id, "--project", "proj_test", "--script", overCapScript],
-        ctx,
+        cliCtx,
       );
       expect(update.exitCode).toBe(1);
       expect(update.stderr).toContain("too_big");
-      expect(storedPrompt(t.db, id)).toBe("Reply only with ok.");
+      expect(storedAgentPrompt(t.db, id)).toBe("Reply only with ok.");
       await expect(readdir(join(t.pluginDataDir, "scripts"))).rejects.toThrow();
     } finally {
       await t.cleanup();
@@ -1649,44 +1666,44 @@ describe("automation CLI length caps (#2166)", () => {
 
   it("keeps an already-stored over-cap prompt readable and repairable", async () => {
     // A user who hit the bug before the fix has such a row on disk.
-    const t = await setup();
+    const t = await setupCliHarness();
     try {
-      const healthyId = await createAgent(t.cli);
-      const brokenId = await createAgent(t.cli);
+      const healthyId = await createAgentAutomation(t.cli);
+      const brokenId = await createAgentAutomation(t.cli);
       t.db
         .prepare(
           "UPDATE automations SET execution = json_set(execution, '$.prompt', ?) WHERE id = ?",
         )
         .run(overCapPrompt, brokenId);
-      expect(storedPrompt(t.db, brokenId)).toBe(overCapPrompt);
+      expect(storedAgentPrompt(t.db, brokenId)).toBe(overCapPrompt);
 
-      const list = await t.cli.run(["list", "--project", "proj_test"], ctx);
+      const list = await t.cli.run(["list", "--project", "proj_test"], cliCtx);
       expect(list.exitCode, list.stderr).toBe(0);
       expect(list.stdout).toContain(healthyId);
       expect(list.stdout).toContain(brokenId);
 
       const show = await t.cli.run(
         ["show", brokenId, "--project", "proj_test"],
-        ctx,
+        cliCtx,
       );
       expect(show.exitCode, show.stderr).toBe(0);
 
       const repair = await t.cli.run(
         ["update", brokenId, "--project", "proj_test", "--prompt", "short"],
-        ctx,
+        cliCtx,
       );
       expect(repair.exitCode, repair.stderr).toBe(0);
-      expect(storedPrompt(t.db, brokenId)).toBe("short");
+      expect(storedAgentPrompt(t.db, brokenId)).toBe("short");
     } finally {
       await t.cleanup();
     }
   });
 
   it("list skips a malformed row instead of failing the whole project", async () => {
-    const t = await setup();
+    const t = await setupCliHarness();
     try {
-      const healthyId = await createAgent(t.cli);
-      const brokenId = await createAgent(t.cli);
+      const healthyId = await createAgentAutomation(t.cli);
+      const brokenId = await createAgentAutomation(t.cli);
       t.db
         .prepare("UPDATE automations SET execution = ? WHERE id = ?")
         .run(JSON.stringify({ mode: "agent" }), brokenId);
@@ -1748,6 +1765,284 @@ describe("automation CLI length caps (#2166)", () => {
         prompt: overCapPrompt,
       }).success,
     ).toBe(true);
+  });
+});
+
+describe("automation CLI trigger caps (#2166 on the trigger column)", () => {
+  // The #2166 fix above split request policy from the stored shape for the
+  // execution column only. The trigger column kept the same write-then-fail
+  // mechanism: `automationScheduleTriggerSchema` carried the cron/timezone caps
+  // and also parsed the stored `trigger_config`, while the CLI's buildTrigger
+  // handed an unparsed value straight to service.create/update. A valid but
+  // over-cap cron was therefore committed and only rejected when the row was
+  // read back, which poisoned show/update/pause/resume and made list drop the
+  // row silently. Caps belong on the request schema; the stored shape must stay
+  // readable and repairable.
+
+  // 60 comma-separated minutes: 110 characters of valid 5-field cron.
+  const overCapCron = `${Array.from({ length: 60 }, (_, minute) => minute).join(",")} * * * *`;
+  // No valid IANA timezone is anywhere near the cap, so the timezone half of
+  // the request policy is only exercised at the schema level below.
+  const overCapTimezone = `America/${"a".repeat(SCHEDULE_TIMEZONE_MAX_LENGTH)}`;
+
+  function storedTrigger(db: Db, id: string): AutomationTrigger {
+    const row = getAutomation(db, id);
+    if (!row) throw new Error(`missing automation ${id}`);
+    return parseAutomationTrigger(row.triggerConfig);
+  }
+
+  it("keeps the over-cap cron valid so the cap is the only reason to reject", () => {
+    expect(overCapCron.length).toBeGreaterThan(SCHEDULE_CRON_MAX_LENGTH);
+    expect(() =>
+      validateScheduleDefinition({ cron: overCapCron, timezone: "UTC" }),
+    ).not.toThrow();
+  });
+
+  it("rejects an over-cap --cron on create without persisting the row", async () => {
+    const t = await setupCliHarness();
+    try {
+      const created = await t.cli.run(
+        [
+          "create",
+          "--project",
+          "proj_test",
+          "--name",
+          "over-cap-cron",
+          "--cron",
+          overCapCron,
+          "--timezone",
+          "UTC",
+          "--prompt",
+          "Reply only with ok.",
+          "--provider",
+          "codex",
+          "--model",
+          "gpt-5",
+        ],
+        cliCtx,
+      );
+      expect(created.exitCode).toBe(1);
+      expect(created.stderr).toContain("too_big");
+      expect(listAutomationsForProject(t.db, "proj_test")).toEqual([]);
+    } finally {
+      await t.cleanup();
+    }
+  });
+
+  it("rejects an over-cap --cron on update without poisoning a healthy row", async () => {
+    const t = await setupCliHarness();
+    try {
+      const id = await createAgentAutomation(t.cli);
+      const before = getAutomation(t.db, id);
+      const update = await t.cli.run(
+        [
+          "update",
+          id,
+          "--project",
+          "proj_test",
+          "--cron",
+          overCapCron,
+          "--timezone",
+          "UTC",
+        ],
+        cliCtx,
+      );
+      expect(update.exitCode).toBe(1);
+      expect(update.stderr).toContain("too_big");
+      expect(getAutomation(t.db, id)).toEqual(before);
+      expect(storedTrigger(t.db, id)).toEqual({
+        triggerType: "schedule",
+        cron: "*/5 * * * *",
+        timezone: "UTC",
+      });
+
+      // The automation is still fully usable afterwards.
+      const show = await t.cli.run(
+        ["show", id, "--project", "proj_test"],
+        cliCtx,
+      );
+      expect(show.exitCode, show.stderr).toBe(0);
+      const pause = await t.cli.run(
+        ["pause", id, "--project", "proj_test"],
+        cliCtx,
+      );
+      expect(pause.exitCode, pause.stderr).toBe(0);
+      const resume = await t.cli.run(
+        ["resume", id, "--project", "proj_test"],
+        cliCtx,
+      );
+      expect(resume.exitCode, resume.stderr).toBe(0);
+    } finally {
+      await t.cleanup();
+    }
+  });
+
+  it("keeps an already-stored over-cap cron readable and repairable", async () => {
+    // A row written by an older build (or any non-request path) has such a
+    // trigger on disk; every read path must survive it.
+    const t = await setupCliHarness();
+    try {
+      const healthyId = await createAgentAutomation(t.cli);
+      const brokenId = await createAgentAutomation(t.cli);
+      t.db
+        .prepare(
+          "UPDATE automations SET trigger_config = json_set(trigger_config, '$.cron', ?) WHERE id = ?",
+        )
+        .run(overCapCron, brokenId);
+      expect(storedTrigger(t.db, brokenId)).toEqual({
+        triggerType: "schedule",
+        cron: overCapCron,
+        timezone: "UTC",
+      });
+
+      const list = await t.cli.run(["list", "--project", "proj_test"], cliCtx);
+      expect(list.exitCode, list.stderr).toBe(0);
+      expect(list.stdout).toContain(healthyId);
+      expect(list.stdout).toContain(brokenId);
+
+      const show = await t.cli.run(
+        ["show", brokenId, "--project", "proj_test"],
+        cliCtx,
+      );
+      expect(show.exitCode, show.stderr).toBe(0);
+
+      // An unrelated patch must not fail on the stored trigger it re-parses.
+      const rename = await t.cli.run(
+        ["update", brokenId, "--project", "proj_test", "--name", "renamed"],
+        cliCtx,
+      );
+      expect(rename.exitCode, rename.stderr).toBe(0);
+
+      const pause = await t.cli.run(
+        ["pause", brokenId, "--project", "proj_test"],
+        cliCtx,
+      );
+      expect(pause.exitCode, pause.stderr).toBe(0);
+      const resume = await t.cli.run(
+        ["resume", brokenId, "--project", "proj_test"],
+        cliCtx,
+      );
+      expect(resume.exitCode, resume.stderr).toBe(0);
+
+      const repair = await t.cli.run(
+        [
+          "update",
+          brokenId,
+          "--project",
+          "proj_test",
+          "--cron",
+          "0 9 * * *",
+          "--timezone",
+          "UTC",
+        ],
+        cliCtx,
+      );
+      expect(repair.exitCode, repair.stderr).toBe(0);
+      expect(storedTrigger(t.db, brokenId)).toEqual({
+        triggerType: "schedule",
+        cron: "0 9 * * *",
+        timezone: "UTC",
+      });
+    } finally {
+      await t.cleanup();
+    }
+  });
+
+  it("the sweep no longer rejects an already-stored over-cap cron row", async () => {
+    // Before the split the sweep logged "invalid stored configuration" for such
+    // a row on every tick (every SWEEP_INTERVAL_MS) and never advanced it.
+    const t = await setupCliHarness();
+    try {
+      const id = await createAgentAutomation(t.cli);
+      const now = 10_000_000;
+      t.db
+        .prepare(
+          "UPDATE automations SET trigger_config = json_set(trigger_config, '$.cron', ?), next_run_at = ? WHERE id = ?",
+        )
+        .run(overCapCron, now - 1, id);
+      const errors: string[] = [];
+      const sweepBb = {
+        sdk: {
+          hosts: { list: async () => [] },
+          threads: {
+            get: async () => {
+              throw new Error("not expected");
+            },
+            send: async () => {
+              throw new Error("not expected");
+            },
+            spawn: async () => {
+              throw new Error("not expected");
+            },
+          },
+        },
+        realtime: { publish: () => undefined },
+        log: {
+          debug: () => undefined,
+          info: () => undefined,
+          warn: () => undefined,
+          error: (message: string) => {
+            errors.push(message);
+          },
+        },
+      };
+      await sweepDueAutomations(sweepBb, t.db, {
+        pluginDataDir: t.pluginDataDir,
+        serverUrl: "http://127.0.0.1:1",
+        now,
+      });
+      expect(errors).toEqual([]);
+    } finally {
+      await t.cleanup();
+    }
+  });
+
+  it("the RPC request schemas still enforce the trigger caps", () => {
+    const base = {
+      projectId: "proj_test",
+      name: "over-cap-cron",
+      origin: "human" as const,
+      execution: {
+        mode: "agent" as const,
+        prompt: "Reply only with ok.",
+        providerId: "codex",
+        model: "gpt-5",
+        permissionMode: "auto" as const,
+        environment: { type: "project-default" as const },
+      },
+    };
+    const overCapTrigger = {
+      triggerType: "schedule" as const,
+      cron: overCapCron,
+      timezone: "UTC",
+    };
+    expect(
+      createAutomationInputSchema.safeParse({
+        ...base,
+        trigger: overCapTrigger,
+      }).success,
+    ).toBe(false);
+    expect(
+      createAutomationInputSchema.safeParse({
+        ...base,
+        trigger: {
+          triggerType: "schedule" as const,
+          cron: "*/5 * * * *",
+          timezone: overCapTimezone,
+        },
+      }).success,
+    ).toBe(false);
+    expect(
+      updateAutomationInputSchema.safeParse({
+        projectId: "proj_test",
+        automationId: "auto_1",
+        trigger: overCapTrigger,
+      }).success,
+    ).toBe(false);
+    // The stored shape does not carry the caps.
+    expect(automationTriggerSchema.safeParse(overCapTrigger).success).toBe(
+      true,
+    );
   });
 });
 

--- a/plugins/automations/src/cli.ts
+++ b/plugins/automations/src/cli.ts
@@ -25,7 +25,10 @@ import {
 } from "./provider-permissions.js";
 import {
   AUTOMATION_SCRIPT_TIMEOUT_DEFAULT_MS,
+  agentExecutionUpdateSchema,
+  automationAgentExecutionRequestSchema,
   automationScriptInterpreterSchema,
+  automationScriptRequestSchema,
 } from "./rpc-types.js";
 
 const DURATION_PATTERN =
@@ -471,8 +474,10 @@ async function buildExecution(
     const serviceTier = flag(args, "service-tier");
     const parsedServiceTier =
       serviceTier === undefined ? undefined : parseServiceTier(serviceTier);
+    // argv is a system boundary: apply the same request policy (prompt cap)
+    // as the RPC route before the service persists anything (#2166).
     return {
-      execution: {
+      execution: automationAgentExecutionRequestSchema.parse({
         mode: "agent",
         prompt,
         providerId: provider,
@@ -492,7 +497,7 @@ async function buildExecution(
         ...(flag(args, "target-thread")
           ? { targetThreadId: flag(args, "target-thread") }
           : {}),
-      },
+      }),
     };
   }
   if (
@@ -515,8 +520,11 @@ async function buildExecution(
   const timeoutMs = parseTimeoutMs(flag(args, "timeout"));
   const env = parseScriptEnv(flag(args, "env-json"));
   const scriptSource = await loadScriptFileSource(bb, args, ctx);
-  const content = scriptSource ? scriptSource.content : script;
-  if (!content) throw new Error("Missing script content.");
+  // The CLI shape carries both the content and its source path, so only the
+  // script content is parsed with the RPC request policy (size cap) here.
+  const content = automationScriptRequestSchema.parse(
+    scriptSource ? scriptSource.content : script,
+  );
   const interpreter =
     explicitInterpreter ??
     (scriptSource ? inferInterpreterFromPath(scriptSource.path) : undefined);
@@ -591,7 +599,9 @@ async function buildAgentExecutionUpdate(
       environment: await buildAgentEnvironment(bb, args),
     };
   }
-  return update;
+  // argv is a system boundary: apply the same request policy as the RPC route
+  // so an over-cap prompt is rejected before anything is persisted (#2166).
+  return agentExecutionUpdateSchema.parse(update);
 }
 
 async function buildUpdateRequest(

--- a/plugins/automations/src/cli.ts
+++ b/plugins/automations/src/cli.ts
@@ -29,6 +29,7 @@ import {
   automationAgentExecutionRequestSchema,
   automationScriptInterpreterSchema,
   automationScriptRequestSchema,
+  automationTriggerRequestSchema,
 } from "./rpc-types.js";
 
 const DURATION_PATTERN =
@@ -139,7 +140,15 @@ function buildTrigger(args: ParsedArgs): CreateAutomationInput["trigger"] {
   if (cron !== undefined) {
     const timezone = flag(args, "timezone");
     if (!timezone) throw new Error("--cron requires --timezone.");
-    return { triggerType: "schedule", cron, timezone };
+    // argv is a system boundary: apply the same request policy (cron and
+    // timezone caps) as the RPC route before the service persists anything.
+    // Without this the CLI writes the row and only fails when the stored
+    // trigger is re-parsed, which is the #2166 defect on the trigger column.
+    return automationTriggerRequestSchema.parse({
+      triggerType: "schedule",
+      cron,
+      timezone,
+    });
   }
   if (flag(args, "timezone") !== undefined) {
     throw new Error("--timezone is only used with --cron.");

--- a/plugins/automations/src/rpc-types.ts
+++ b/plugins/automations/src/rpc-types.ts
@@ -143,10 +143,16 @@ export const automationTriggerSchema = z.discriminatedUnion("triggerType", [
 ]);
 export type AutomationTrigger = z.infer<typeof automationTriggerSchema>;
 
+/**
+ * Stored/response execution shape. Length caps are request policy and live
+ * only on the `*RequestSchema` variants below: a cap on the stored shape would
+ * make an already-persisted over-cap row unreadable (list/show fail) and
+ * unrepairable (update parses the stored row before it writes). See #2166.
+ */
 const automationAgentExecutionSchema = z
   .object({
     mode: z.literal("agent"),
-    prompt: z.string().min(1).max(AUTOMATION_PROMPT_MAX_LENGTH),
+    prompt: z.string().min(1),
     providerId: z.string().min(1),
     model: z.string().min(1),
     reasoningLevel: reasoningLevelSchema.default("medium"),
@@ -160,12 +166,8 @@ const automationAgentExecutionSchema = z
 const automationScriptExecutionSchema = z
   .object({
     mode: z.literal("script"),
-    script: z.string().min(1).max(AUTOMATION_SCRIPT_MAX_LENGTH).optional(),
-    scriptFile: z
-      .string()
-      .min(1)
-      .max(AUTOMATION_SCRIPT_FILE_MAX_LENGTH)
-      .optional(),
+    script: z.string().min(1).optional(),
+    scriptFile: z.string().min(1).optional(),
     interpreter: automationScriptInterpreterSchema.optional(),
     timeoutMs: z
       .number()
@@ -199,9 +201,41 @@ function requireExactlyOneScriptSource(
   }
 }
 
-const automationExecutionRequestSchema = automationExecutionSchema.superRefine(
-  requireExactlyOneScriptSource,
-);
+export const automationPromptRequestSchema = z
+  .string()
+  .min(1)
+  .max(AUTOMATION_PROMPT_MAX_LENGTH);
+export const automationScriptRequestSchema = z
+  .string()
+  .min(1)
+  .max(AUTOMATION_SCRIPT_MAX_LENGTH);
+
+/**
+ * Request-side execution schemas: the stored shape plus the length caps. Every
+ * entry point that accepts execution input (RPC routes and the CLI argv
+ * boundary) parses with these before anything is persisted.
+ */
+export const automationAgentExecutionRequestSchema =
+  automationAgentExecutionSchema
+    .extend({ prompt: automationPromptRequestSchema })
+    .strict();
+const automationScriptExecutionRequestSchema = automationScriptExecutionSchema
+  .extend({
+    script: automationScriptRequestSchema.optional(),
+    scriptFile: z
+      .string()
+      .min(1)
+      .max(AUTOMATION_SCRIPT_FILE_MAX_LENGTH)
+      .optional(),
+  })
+  .strict();
+
+const automationExecutionRequestSchema = z
+  .discriminatedUnion("mode", [
+    automationAgentExecutionRequestSchema,
+    automationScriptExecutionRequestSchema,
+  ])
+  .superRefine(requireExactlyOneScriptSource);
 
 /**
  * Execution as returned to clients. Script automations add `storedScriptPath`:
@@ -231,9 +265,9 @@ const agentExecutionTargetSchema = z.discriminatedUnion("type", [
     .strict(),
 ]);
 
-const agentExecutionUpdateSchema = z
+export const agentExecutionUpdateSchema = z
   .object({
-    prompt: z.string().min(1).max(AUTOMATION_PROMPT_MAX_LENGTH).optional(),
+    prompt: automationPromptRequestSchema.optional(),
     providerId: z.string().min(1).optional(),
     model: z.string().min(1).optional(),
     reasoningLevel: reasoningLevelSchema.optional(),

--- a/plugins/automations/src/rpc-types.ts
+++ b/plugins/automations/src/rpc-types.ts
@@ -124,11 +124,19 @@ export type AutomationScriptInterpreter = z.infer<
   typeof automationScriptInterpreterSchema
 >;
 
+/**
+ * Stored/response trigger shape. Like the execution shape below, the cron and
+ * timezone length caps are request policy and live only on the request variant:
+ * this schema also parses the stored `trigger_config` column (list, show,
+ * update, pause/resume, and the sweep all go through `parseAutomationTrigger`),
+ * so a cap here would make an already-persisted over-cap row unreadable and
+ * unrepairable. See #2166.
+ */
 const automationScheduleTriggerSchema = z
   .object({
     triggerType: z.literal("schedule"),
-    cron: z.string().min(1).max(SCHEDULE_CRON_MAX_LENGTH),
-    timezone: z.string().min(1).max(SCHEDULE_TIMEZONE_MAX_LENGTH),
+    cron: z.string().min(1),
+    timezone: z.string().min(1),
   })
   .strict();
 const automationOnceTriggerSchema = z
@@ -142,6 +150,24 @@ export const automationTriggerSchema = z.discriminatedUnion("triggerType", [
   automationOnceTriggerSchema,
 ]);
 export type AutomationTrigger = z.infer<typeof automationTriggerSchema>;
+
+/**
+ * Request-side trigger schema: the stored shape plus the length caps. Every
+ * entry point that accepts trigger input (the RPC routes through
+ * `createAutomationInputSchema`/`updateAutomationInputSchema`, and the CLI argv
+ * boundary through `buildTrigger`) parses with this before anything is
+ * persisted. The one-shot variant carries no string, so it is unchanged.
+ */
+const automationScheduleTriggerRequestSchema = automationScheduleTriggerSchema
+  .extend({
+    cron: z.string().min(1).max(SCHEDULE_CRON_MAX_LENGTH),
+    timezone: z.string().min(1).max(SCHEDULE_TIMEZONE_MAX_LENGTH),
+  })
+  .strict();
+export const automationTriggerRequestSchema = z.discriminatedUnion(
+  "triggerType",
+  [automationScheduleTriggerRequestSchema, automationOnceTriggerSchema],
+);
 
 /**
  * Stored/response execution shape. Length caps are request policy and live
@@ -347,7 +373,7 @@ export const createAutomationInputSchema = z
     projectId: z.string().min(1),
     name: z.string().min(1).max(AUTOMATION_NAME_MAX_LENGTH),
     enabled: z.boolean().default(true),
-    trigger: automationTriggerSchema,
+    trigger: automationTriggerRequestSchema,
     execution: automationExecutionRequestSchema,
     origin: automationOriginSchema,
     createdByThreadId: z.string().min(1).optional(),
@@ -363,7 +389,7 @@ export const updateAutomationInputSchema = z
     projectId: z.string().min(1),
     automationId: z.string().min(1),
     name: z.string().min(1).max(AUTOMATION_NAME_MAX_LENGTH).optional(),
-    trigger: automationTriggerSchema.optional(),
+    trigger: automationTriggerRequestSchema.optional(),
     execution: automationExecutionRequestSchema.optional(),
     agent: agentExecutionUpdateSchema.optional(),
   })

--- a/plugins/automations/src/service.ts
+++ b/plugins/automations/src/service.ts
@@ -428,9 +428,19 @@ export function createAutomationService(args: {
     },
 
     list(input) {
-      return listAutomationsForProject(db, input.projectId).map((row) =>
-        toStoredAutomationResponse(pluginDataDir, row),
-      );
+      const automations: AutomationResponse[] = [];
+      for (const row of listAutomationsForProject(db, input.projectId)) {
+        try {
+          automations.push(toStoredAutomationResponse(pluginDataDir, row));
+        } catch (error) {
+          bb.log.warn(
+            `Skipping malformed automation ${row.id}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }
+      return automations;
     },
 
     get(input) {


### PR DESCRIPTION
## What was wrong

`bb automation create` and `bb automation update` built the agent and script execution payloads from argv and handed them straight to the service, skipping the request-side Zod length caps that the `automations_create`/`automations_update` RPC routes apply. An over-cap `--prompt` (8,039 chars against the 8,000 cap) was therefore persisted, and the `too_big` error the user saw came from re-parsing the stored row for the response. Because that same capped schema (`automationAgentExecutionSchema`) was also used to parse stored rows, every later `list`, `show`, and repairing `update` for the project failed with the same `too_big` issue, and `list` took the healthy automations in the project down with it. Report: https://get-bb.github.io/reports/issues/2166.html

## What changed

The length caps were request policy applied in the wrong place. The same Zod schemas that parse incoming create/update input also parse the stored `execution` and `trigger_config` columns, so an over-cap value that got past the CLI was written and then made the row unreadable on every subsequent read.

- **Split request policy from the stored shape, on both columns.** The stored `automationAgentExecutionSchema`, `automationScriptExecutionSchema`, and `automationScheduleTriggerSchema` no longer carry the prompt, script, scriptFile, cron, or timezone caps. New `*RequestSchema` variants (`automationAgentExecutionRequestSchema`, `automationScriptRequestSchema`, `automationTriggerRequestSchema`) add the caps back and are what `createAutomationInputSchema` / `updateAutomationInputSchema` compose, so the RPC routes still reject over-cap input before any write. A row that already exceeds a cap now stays readable by `list`/`show` and repairable by `update`.
- **Enforce the same policy at the CLI argv boundary.** `bb automation create/update` builds its execution and trigger from argv and calls the service directly, bypassing the route schemas. `buildExecution`, `buildAgentExecutionUpdate`, and `buildTrigger` now parse with those request schemas, so an over-cap `--prompt`, `--script`, or `--cron` is rejected before anything is persisted, and the CLI and the RPC route agree on one policy.
- **Make `service.list` skip a malformed row with a warning**, like `overview` already did, so one bad row cannot fail the whole project listing.

The one-shot trigger variant is unchanged (it carries no string). The timezone cap is unreachable through the CLI in practice — no valid IANA name approaches 100 characters — so it is asserted at the schema level only.
## How you verified

Twelve regression tests across two blocks in `plugins/automations/src/automations.test.ts`; each behavior test was run against the pre-fix source and fails there (6 execution-cap tests, 5 of 6 trigger-cap tests — the sixth is a guard asserting the over-cap cron is itself valid, so the others cannot degrade into "invalid cron rejected").

- `pnpm exec turbo run test --filter=bb-plugin-automations --force` — 5 files, **78 passed**.
- `pnpm exec turbo run build typecheck lint` (repo-wide) — **92/92 tasks**.
- `node scripts/check-provider-literal-ratchet.mjs --base origin/main` — 18 references across 8 core files, all allowlisted.
- Live against an isolated `scripts/bb-dev-app` instance: an over-cap `--prompt` (8039 chars) and an over-cap `--cron` (177 chars, valid 5-field expression) each exit 1 with `too_big` and write **no** row; an over-cap `--cron` on `update` leaves the stored trigger byte-identical; a row seeded with a 177-char cron is listed, shown, renamed, paused, resumed, and repaired, all exit 0; the sweep advances that row and claims a scheduled run instead of logging `invalid stored configuration` every tick.
- Live plugin-RPC HTTP calls confirm the routes still reject pre-write: `automations_create` returns **HTTP 400 `invalid_input`** with `path: ["trigger","cron"]` and with `path: ["execution","prompt"]`, and the automations table row count is unchanged after both.

No server↔daemon wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged. No new CLI flag, command, or configuration knob, so no guide or skill surface needed an update.

---

Fixes #2166

> AGENT GENERATED: by Claude Opus 5
