### PR TITLE
Keep ACP model descriptions and disambiguate same-name picker rows

### DIFF
--- a/apps/app/.ladle/model-picker-query-provider.tsx
+++ b/apps/app/.ladle/model-picker-query-provider.tsx
@@ -101,9 +101,7 @@ function makeAvailableModels({
     id: model.value,
     model: model.value,
     displayName: model.label,
-    ...(model.routeProviderId
-      ? { routeProviderId: model.routeProviderId }
-      : {}),
+    ...(model.qualifier ? { routeProviderId: model.qualifier } : {}),
     description: "",
     supportedReasoningEfforts,
     defaultReasoningEffort,

--- a/apps/app/.ladle/story-fixtures.ts
+++ b/apps/app/.ladle/story-fixtures.ts
@@ -145,47 +145,47 @@ export const STORY_PI_MODELS: readonly ModelPickerOption[] = [
   {
     value: "openai-codex/gpt-5.5",
     label: "GPT-5.5",
-    routeProviderId: "openai-codex",
+    qualifier: "openai-codex",
   },
   {
     value: "openai-codex/gpt-5.4",
     label: "GPT-5.4",
-    routeProviderId: "openai-codex",
+    qualifier: "openai-codex",
   },
   {
     value: "openai-codex/gpt-5.4-mini",
     label: "GPT-5.4 Mini",
-    routeProviderId: "openai-codex",
+    qualifier: "openai-codex",
   },
   {
     value: "openai-codex/gpt-5.3-codex",
     label: "GPT-5.3 Codex",
-    routeProviderId: "openai-codex",
+    qualifier: "openai-codex",
   },
   {
     value: "openai/gpt-5.3-codex-spark",
     label: "GPT-5.3 Codex Spark",
-    routeProviderId: "openai",
+    qualifier: "openai",
   },
   {
     value: "openai-codex/gpt-5.3-codex-spark",
     label: "GPT-5.3 Codex Spark",
-    routeProviderId: "openai-codex",
+    qualifier: "openai-codex",
   },
   {
     value: "anthropic/claude-haiku-4-5",
     label: "Claude Haiku 4.5",
-    routeProviderId: "anthropic",
+    qualifier: "anthropic",
   },
   {
     value: "anthropic/claude-opus-4-8",
     label: "Claude Opus 4.8",
-    routeProviderId: "anthropic",
+    qualifier: "anthropic",
   },
   {
     value: "anthropic/claude-opus-4-7",
     label: "Claude Opus 4.7",
-    routeProviderId: "anthropic",
+    qualifier: "anthropic",
   },
 ];
 

--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -106,17 +106,19 @@ const splitPaneContext: PaneContextValue = {
 function availableModel({
   value,
   label,
+  description = "",
   isDefault = false,
 }: {
   value: string;
   label: string;
+  description?: string;
   isDefault?: boolean;
 }): AvailableModel {
   return {
     id: value,
     model: value,
     displayName: label,
-    description: "",
+    description,
     supportedReasoningEfforts: [
       { reasoningEffort: "medium", description: "Medium" },
     ],
@@ -520,11 +522,11 @@ describe("ModelReasoningPicker", () => {
     const modelLabel = "GPT-5.3 Codex Spark";
     const { onModelChange } = renderPicker({
       modelOptions: [
-        { value: apiModel, label: modelLabel, routeProviderId: "openai" },
+        { value: apiModel, label: modelLabel, qualifier: "openai" },
         {
           value: subscriptionModel,
           label: modelLabel,
-          routeProviderId: "openai-codex",
+          qualifier: "openai-codex",
         },
       ],
       modelValue: subscriptionModel,
@@ -547,6 +549,55 @@ describe("ModelReasoningPicker", () => {
     fireEvent.click(apiQualifier);
 
     expect(onModelChange).toHaveBeenCalledWith(apiModel);
+  });
+
+  it("tells apart previewed models that share a display name (#2062)", async () => {
+    // omp exposes the same display name under several route prefixes; the
+    // agent's short description (its "provider/model" id) is the only thing
+    // that distinguishes them, so it fills the inline qualifier slot.
+    const { onModelChange } = renderPicker({
+      alternateProviderModels: [
+        availableModel({
+          value: "github-copilot/gpt-5.1",
+          label: "GPT-5.1",
+          description: "github-copilot/gpt-5.1",
+          isDefault: true,
+        }),
+        availableModel({
+          value: "openai-codex/gpt-5.1",
+          label: "GPT-5.1",
+          description: "openai-codex/gpt-5.1",
+        }),
+        availableModel({
+          value: "github-copilot/gpt-5.2",
+          label: "GPT-5.2",
+          description: "github-copilot/gpt-5.2",
+        }),
+      ],
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Provider, model and reasoning" }),
+    );
+    fireEvent.click(screen.getByTitle("Claude Code"));
+
+    const copilotRow = (
+      await screen.findByText("github-copilot/gpt-5.1")
+    ).closest("button");
+    const codexRow = screen.getByText("openai-codex/gpt-5.1").closest("button");
+    expect(copilotRow).not.toBeNull();
+    expect(codexRow).not.toBeNull();
+    expect(copilotRow).not.toBe(codexRow);
+    expect(copilotRow?.textContent).toBe("GPT-5.1github-copilot/gpt-5.1");
+    expect(codexRow?.textContent).toBe("GPT-5.1openai-codex/gpt-5.1");
+    // A unique label keeps its plain single-segment row.
+    expect(screen.getByText("GPT-5.2").closest("button")?.textContent).toBe(
+      "GPT-5.2",
+    );
+    expect(screen.queryByText("github-copilot/gpt-5.2")).toBeNull();
+
+    fireEvent.click(screen.getByText("openai-codex/gpt-5.1"));
+
+    expect(onModelChange).toHaveBeenCalledWith("openai-codex/gpt-5.1");
   });
 
   it("fuzzy-filters a long model list and selects the match by keyboard", () => {

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -53,7 +53,10 @@ import {
   OPTION_TRIGGER_CONTENT_CLASS_NAME,
 } from "@bb/shared-ui/option-display";
 import { type PickerOption } from "./OptionPicker";
-import type { ModelPickerOption } from "./model-picker-option";
+import {
+  toModelPickerOptions,
+  type ModelPickerOption,
+} from "./model-picker-option";
 import {
   formatModelLoadErrorText,
   ModelLoadErrorMessage,
@@ -148,8 +151,10 @@ function modelSearchText(
   option: ModelPickerOption,
   brandPrefix: string | undefined,
 ): string {
-  return `${stripModelBrandPrefix(option.label, brandPrefix)} ${option.routeProviderId ?? ""} ${option.value}`;
+  return `${stripModelBrandPrefix(option.label, brandPrefix)} ${option.qualifier ?? ""} ${option.value}`;
 }
+
+const identityLabel = (displayName: string): string => displayName;
 
 /**
  * A keyboard-navigable row in the model list. Each entry maps 1:1 to a rendered,
@@ -384,29 +389,13 @@ export function ModelReasoningPicker({
     if (!isPreviewing) return modelOptions;
     const models = previewQuery.data?.models;
     if (!models || models.length === 0) return [];
-    return models.map((model) => ({
-      value: model.model,
-      label: formatModelLabel
-        ? formatModelLabel(model.displayName || model.model)
-        : model.displayName || model.model,
-      ...(model.routeProviderId
-        ? { routeProviderId: model.routeProviderId }
-        : {}),
-    }));
+    return toModelPickerOptions(models, formatModelLabel ?? identityLabel);
   }, [isPreviewing, modelOptions, previewQuery.data?.models, formatModelLabel]);
   const previewMoreModelOptions = useMemo((): readonly ModelPickerOption[] => {
     if (!isPreviewing) return moreModelOptions;
     const models = previewQuery.data?.selectedOnlyModels;
     if (!models || models.length === 0) return [];
-    return models.map((model) => ({
-      value: model.model,
-      label: formatModelLabel
-        ? formatModelLabel(model.displayName || model.model)
-        : model.displayName || model.model,
-      ...(model.routeProviderId
-        ? { routeProviderId: model.routeProviderId }
-        : {}),
-    }));
+    return toModelPickerOptions(models, formatModelLabel ?? identityLabel);
   }, [
     isPreviewing,
     moreModelOptions,
@@ -1045,7 +1034,7 @@ export function ModelReasoningPicker({
                         option.label,
                         activeBrandPrefix,
                       )}
-                      qualifier={option.routeProviderId}
+                      qualifier={option.qualifier}
                       selected={!isPreviewing && option.value === modelValue}
                       onClick={() => handleModelSelect(option.value)}
                     />
@@ -1362,7 +1351,7 @@ function MoreModelsSubmenu({
             <MenuRowButton
               key={option.value}
               label={stripModelBrandPrefix(option.label, activeBrandPrefix)}
-              qualifier={option.routeProviderId}
+              qualifier={option.qualifier}
               selected={!isPreviewing && option.value === modelValue}
               onClick={() => onSelect(option.value)}
             />

--- a/apps/app/src/components/pickers/model-picker-option.test.ts
+++ b/apps/app/src/components/pickers/model-picker-option.test.ts
@@ -1,0 +1,117 @@
+import type { AvailableModel } from "@bb/domain";
+import { describe, expect, it } from "vitest";
+import { toModelPickerOptions } from "./model-picker-option";
+
+function model(
+  id: string,
+  displayName: string,
+  description = "",
+  extra: Partial<AvailableModel> = {},
+): AvailableModel {
+  return {
+    id,
+    model: id,
+    displayName,
+    description,
+    supportedReasoningEfforts: [],
+    defaultReasoningEffort: "medium",
+    isDefault: false,
+    ...extra,
+  };
+}
+
+const identity = (label: string) => label;
+
+describe("toModelPickerOptions", () => {
+  it("leaves rows with unique labels exactly as before, whatever their description", () => {
+    expect(
+      toModelPickerOptions(
+        [
+          model(
+            "claude-opus-4-7",
+            "Claude Opus 4.7",
+            "Most capable model for complex work",
+          ),
+          model("claude-sonnet-4-6", "Claude Sonnet 4.6", "Fast and smart"),
+        ],
+        identity,
+      ),
+    ).toEqual([
+      { value: "claude-opus-4-7", label: "Claude Opus 4.7" },
+      { value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+    ]);
+  });
+
+  it("qualifies only the rows whose formatted labels collide", () => {
+    expect(
+      toModelPickerOptions(
+        [
+          model("github-copilot/gpt-5.1", "GPT-5.1", "github-copilot/gpt-5.1"),
+          model("openai-codex/gpt-5.1", "GPT-5.1", "openai-codex/gpt-5.1"),
+          model("openai-codex/gpt-5.2", "GPT-5.2", "openai-codex/gpt-5.2"),
+        ],
+        identity,
+      ),
+    ).toEqual([
+      {
+        value: "github-copilot/gpt-5.1",
+        label: "GPT-5.1",
+        qualifier: "github-copilot/gpt-5.1",
+      },
+      {
+        value: "openai-codex/gpt-5.1",
+        label: "GPT-5.1",
+        qualifier: "openai-codex/gpt-5.1",
+      },
+      { value: "openai-codex/gpt-5.2", label: "GPT-5.2" },
+    ]);
+  });
+
+  it("falls back to the raw model id when the description is missing or too long to be an identifier", () => {
+    expect(
+      toModelPickerOptions(
+        [
+          model("vendor-a/glm-4.7", "GLM 4.7"),
+          model(
+            "vendor-b/glm-4.7",
+            "GLM 4.7",
+            "A long-form marketing sentence describing the model at length.",
+          ),
+        ],
+        identity,
+      ),
+    ).toEqual([
+      {
+        value: "vendor-a/glm-4.7",
+        label: "GLM 4.7",
+        qualifier: "vendor-a/glm-4.7",
+      },
+      {
+        value: "vendor-b/glm-4.7",
+        label: "GLM 4.7",
+        qualifier: "vendor-b/glm-4.7",
+      },
+    ]);
+  });
+
+  it("detects collisions on the formatted label and keeps a route provider as the qualifier", () => {
+    expect(
+      toModelPickerOptions(
+        [
+          model("openai/gpt-5", "gpt-5", "api", { routeProviderId: "openai" }),
+          model("openai-codex/gpt-5", "GPT-5", "subscription", {
+            routeProviderId: "openai-codex",
+          }),
+        ],
+        (label) => label.toUpperCase(),
+      ),
+    ).toEqual([
+      { value: "openai/gpt-5", label: "GPT-5", qualifier: "openai" },
+      {
+        value: "openai-codex/gpt-5",
+        label: "GPT-5",
+        qualifier: "openai-codex",
+      },
+    ]);
+  });
+});

--- a/apps/app/src/components/pickers/model-picker-option.ts
+++ b/apps/app/src/components/pickers/model-picker-option.ts
@@ -1,6 +1,56 @@
+import type { AvailableModel } from "@bb/domain";
 import type { PickerOption } from "./OptionPicker";
 
-/** A model option can expose a distinct runtime route beside its friendly name. */
+/**
+ * A model row in the picker. `qualifier` is short inline text, rendered after
+ * the label and in its tooltip, that tells apart rows whose labels collide: a
+ * Pi model's nested route provider, or (for any provider) the agent's short
+ * description or raw model id when two models share a display name.
+ */
 export interface ModelPickerOption extends PickerOption<string> {
-  routeProviderId?: string;
+  qualifier?: string;
+}
+
+// Longer descriptions are marketing copy, not an identifier; the raw model id
+// is the shorter and more useful disambiguator then.
+const MAX_DESCRIPTION_QUALIFIER_LENGTH = 40;
+
+function collidingModelQualifier(model: AvailableModel): string {
+  const description = model.description.trim();
+  return description.length > 0 &&
+    description.length <= MAX_DESCRIPTION_QUALIFIER_LENGTH
+    ? description
+    : model.model;
+}
+
+/**
+ * Maps a provider's model catalog to picker rows. Only rows whose formatted
+ * label is shared with another row in the same list get a qualifier (unless
+ * the model already carries a route provider), so a catalog of unique names
+ * renders exactly as before.
+ */
+export function toModelPickerOptions(
+  models: readonly AvailableModel[],
+  formatLabel: (displayName: string) => string,
+): ModelPickerOption[] {
+  const labeled = models.map((model) => ({
+    model,
+    label: formatLabel(model.displayName || model.model),
+  }));
+  const labelCounts = new Map<string, number>();
+  for (const { label } of labeled) {
+    labelCounts.set(label, (labelCounts.get(label) ?? 0) + 1);
+  }
+  return labeled.map(({ model, label }): ModelPickerOption => {
+    const qualifier =
+      model.routeProviderId ??
+      ((labelCounts.get(label) ?? 0) > 1
+        ? collidingModelQualifier(model)
+        : undefined);
+    return {
+      value: model.model,
+      label,
+      ...(qualifier ? { qualifier } : {}),
+    };
+  });
 }

--- a/apps/app/src/hooks/useThreadCreationOptions.test.tsx
+++ b/apps/app/src/hooks/useThreadCreationOptions.test.tsx
@@ -597,7 +597,7 @@ describe("useThreadCreationOptions", () => {
       expect(result.current.modelOptions[0]).toEqual({
         value: "global-model",
         label: "Global Model",
-        routeProviderId: "openai-codex",
+        qualifier: "openai-codex",
       });
     });
   });

--- a/apps/app/src/hooks/useThreadCreationOptions.ts
+++ b/apps/app/src/hooks/useThreadCreationOptions.ts
@@ -22,7 +22,10 @@ import type {
   SystemProvidersQuery,
 } from "@bb/server-contract";
 import type { PickerOption } from "@/components/pickers/OptionPicker";
-import type { ModelPickerOption } from "@/components/pickers/model-picker-option";
+import {
+  toModelPickerOptions,
+  type ModelPickerOption,
+} from "@/components/pickers/model-picker-option";
 import type { ProviderPickerOption } from "@/components/pickers/model-brand-prefix";
 import { parseEnvironmentValue } from "@/components/pickers/environment-picker-value";
 import { PERMISSION_MODE_OPTIONS } from "@/lib/permission-mode-options";
@@ -603,13 +606,7 @@ export function useThreadCreationOptions(
 
   const modelOptions = useMemo(
     (): ModelPickerOption[] =>
-      availableModels.map((model) => ({
-        value: model.model,
-        label: formatModelLabel(model.displayName || model.model),
-        ...(model.routeProviderId
-          ? { routeProviderId: model.routeProviderId }
-          : {}),
-      })),
+      toModelPickerOptions(availableModels, formatModelLabel),
     [availableModels],
   );
 
@@ -618,18 +615,13 @@ export function useThreadCreationOptions(
   // here rather than listed twice.
   const moreModelOptions = useMemo(
     (): ModelPickerOption[] =>
-      (executionOptionsQuery.data?.selectedOnlyModels ?? [])
-        .filter(
+      toModelPickerOptions(
+        (executionOptionsQuery.data?.selectedOnlyModels ?? []).filter(
           (model) =>
             !availableModels.some((active) => active.model === model.model),
-        )
-        .map((model) => ({
-          value: model.model,
-          label: formatModelLabel(model.displayName || model.model),
-          ...(model.routeProviderId
-            ? { routeProviderId: model.routeProviderId }
-            : {}),
-        })),
+        ),
+        formatModelLabel,
+      ),
     [executionOptionsQuery.data?.selectedOnlyModels, availableModels],
   );
 

--- a/plugins/provider-acp/src/bridge/model-catalog.test.ts
+++ b/plugins/provider-acp/src/bridge/model-catalog.test.ts
@@ -438,6 +438,55 @@ describe("acp configOptions model catalog", () => {
     ]);
   });
 
+  it("keeps the per-option description the agent sends (#2062)", () => {
+    // omp sends description: "provider/modelId" on every model select option,
+    // and two providers can expose the same display name; the description is
+    // the only field that tells them apart downstream.
+    const models = buildModelCatalogFromConfigOptions({
+      id: "model",
+      category: "model",
+      type: "select",
+      currentValue: "github-copilot/gpt-5.1",
+      options: [
+        {
+          value: "github-copilot/gpt-5.1",
+          name: "GPT-5.1",
+          description: "github-copilot/gpt-5.1",
+        },
+        {
+          value: "openai-codex/gpt-5.1",
+          name: "GPT-5.1",
+          description: "openai-codex/gpt-5.1",
+        },
+        { value: "opencode/big-pickle", name: "Big Pickle" },
+      ],
+    });
+
+    expect(
+      models.map((model) => ({
+        id: model.id,
+        displayName: model.displayName,
+        description: model.description,
+      })),
+    ).toEqual([
+      {
+        id: "github-copilot/gpt-5.1",
+        displayName: "GPT-5.1",
+        description: "github-copilot/gpt-5.1",
+      },
+      {
+        id: "openai-codex/gpt-5.1",
+        displayName: "GPT-5.1",
+        description: "openai-codex/gpt-5.1",
+      },
+      {
+        id: "opencode/big-pickle",
+        displayName: "Big Pickle",
+        description: "",
+      },
+    ]);
+  });
+
   it("finds and maps ACP thought_level config options", () => {
     const thoughtLevel = {
       id: "effort",

--- a/plugins/provider-acp/src/bridge/model-catalog.ts
+++ b/plugins/provider-acp/src/bridge/model-catalog.ts
@@ -280,7 +280,7 @@ export function buildModelCatalogFromConfigOptions(
       id: option.value,
       model: option.value,
       displayName: option.name ?? option.value,
-      description: "",
+      description: option.description ?? "",
       supportedReasoningEfforts: reasoning.supportedReasoningEfforts,
       defaultReasoningEffort: reasoning.defaultReasoningEffort,
       isDefault,

--- a/plugins/provider-acp/src/wire.test.ts
+++ b/plugins/provider-acp/src/wire.test.ts
@@ -47,6 +47,11 @@ describe("acpSessionNewResultSchema", () => {
             {
               value: "openai-codex/gpt-5.5",
               name: "openai-codex/GPT-5.5",
+              description: "openai-codex/gpt-5.5",
+            },
+            {
+              value: "github-copilot/gpt-5.5",
+              name: "GPT-5.5",
               description: null,
             },
           ],
@@ -72,6 +77,12 @@ describe("acpSessionNewResultSchema", () => {
     expect(parsed.data.configOptions?.[0].options?.[0].name).toBe(
       "openai-codex/GPT-5.5",
     );
+    expect(parsed.data.configOptions?.[0].options?.[0].description).toBe(
+      "openai-codex/gpt-5.5",
+    );
+    expect(
+      parsed.data.configOptions?.[0].options?.[1].description,
+    ).toBeUndefined();
     expect(parsed.data.configOptions?.[1].category).toBeUndefined();
     expect(parsed.data.configOptions?.[1].options?.[0].name).toBeUndefined();
   });

--- a/plugins/provider-acp/src/wire.ts
+++ b/plugins/provider-acp/src/wire.ts
@@ -234,6 +234,7 @@ const acpConfigOptionSelectOptionSchema = z
   .object({
     value: z.string(),
     name: acpOptionalString,
+    description: acpOptionalString,
   })
   .passthrough();
 


### PR DESCRIPTION
## What was wrong

`buildModelCatalogFromConfigOptions` in the ACP bridge hard-coded `description: ""` for every model select option, and `acpConfigOptionSelectOptionSchema` did not type the option's `description` at all (it only survived via `.passthrough()`). Agents such as omp (oh-my-pi) send `description: "provider/modelId"` on every option, and advertise the same display name under several route prefixes (on this machine: 15 collisions across 72 models, e.g. `github-copilot/gpt-5.1` vs `openai-codex/gpt-5.1`). Because the desktop model picker renders only the display name, those rows were identical in text, tooltip and accessible name. Issue: #2062. Report: https://get-bb.github.io/reports/issues/2062.html

## What changed

Bridge (`plugins/provider-acp`):
- `src/wire.ts`: `description: acpOptionalString` on the select-option schema (string or null, normalized to `undefined` like `name`).
- `src/bridge/model-catalog.ts`: `description: option.description ?? ""`, mirroring the sibling `buildModelCatalogFromSessionModels` path.
- No `HOST_DAEMON_PROTOCOL_VERSION` bump: `AvailableModel.description` is already a required string on the wire; only its value changes.

Desktop (`apps/app`):
- `ModelPickerOption.routeProviderId` becomes a general `qualifier`, and a new `toModelPickerOptions(models, formatLabel)` in `model-picker-option.ts` builds rows for `useThreadCreationOptions` (`modelOptions` / `moreModelOptions`) and both preview mappings in `ModelReasoningPicker`.
- Only rows whose formatted label collides with another row in the same list get a qualifier: the agent's description when it is non-empty and at most 40 characters, otherwise the raw model id. A Pi model's `routeProviderId` is kept as the qualifier exactly as before.
- The qualifier renders in the existing inline slot (`MenuRowButton`'s `qualifier`, already used for Pi) and in the row's `title` tooltip, so row height does not change and providers with unique names (Claude Code, Codex) render exactly as before. The qualifier also feeds the model search text, so typing `openai-codex` finds the right row.

Relation to #2063 (external, reviewed REQUEST CHANGES): its bridge hunks are the same fix and are credited here. This PR differs on the desktop side: #2063 forwarded `description` for every provider into a new two-line `MenuRowButton` layout, which centered every picker row (the wrapper lost the button's default alignment) and turned every Claude Code / Codex row into a second line of truncated marketing copy. This PR instead fills the existing qualifier slot, and only for colliding rows.

## How you verified

Tests (fail before, pass after):
- `plugins/provider-acp/src/bridge/model-catalog.test.ts`: "keeps the per-option description the agent sends (#2062)" (fails on main with `description: ""`).
- `plugins/provider-acp/src/wire.test.ts`: the schema now returns the parsed description and normalizes `null` to `undefined` (fails on main because the untyped field is not present in the inferred type).
- `apps/app/src/components/pickers/ModelReasoningPicker.test.tsx`: "tells apart previewed models that share a display name (#2062)": two equal-label options render distinct row text (`GPT-5.1github-copilot/gpt-5.1` vs `GPT-5.1openai-codex/gpt-5.1`), a unique-label sibling stays a plain single-segment row, and clicking the second row emits `openai-codex/gpt-5.1`.
- `apps/app/src/components/pickers/model-picker-option.test.ts`: unique labels keep no qualifier regardless of description; only colliding rows are qualified; long/missing descriptions fall back to the raw model id; collisions are detected on the formatted label and `routeProviderId` wins.

Commands: `pnpm exec turbo run typecheck lint --filter=@bb/app --filter=bb-plugin-provider-acp` and `pnpm exec turbo run test --filter=@bb/app --filter=bb-plugin-provider-acp` all green.

Manual, own dev instance with the real `omp` 16.3.10 on PATH (auto-registered as `acp-omp`): `GET /api/v1/system/execution-options?providerId=acp-omp` now returns 72 models with 72 non-empty descriptions (15 duplicate display names). In the picker, the oh-my-pi tab searched for `GPT-5.1` shows `GPT-5.1 github-copilot/gpt-5.1` and `GPT-5.1 openai-codex/gpt-5.1` (and the Codex / Codex Max / Codex mini pairs) as distinct rows with distinct tooltips; every row, including Codex and Claude Code rows, measured 26px tall, and the Codex and Claude pickers are byte-for-byte the same row text as before.

Fixes #2062

> AGENT GENERATED: by Claude Opus 5
