### PR TITLE
Let the ACP plugin own its agents, including the user's own

### DIFF
--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -342,20 +342,17 @@ environment pull-request show <id>`. Diff commands require an explicit target
 - Cursor ACP threads discover project skills from `.cursor/skills`. This root
   can link to `.agents/skills`. `bb skill list` shows linked Cursor skills under
   `cursor-project` and keeps them read-only.
-- Custom ACP agents can be registered in the app data-dir `config.json` under
-  `customAcpAgents`. The user supplies a slug `id`; bb exposes it as provider
-  id `acp-<id>`. Custom config wins if it uses the same provider id as a known
-  ACP agent, so overriding `acp-opencode` uses `"id": "opencode"`. This list
-  has no set/unset CLI surface, so edit the JSON and run `bb-app config refresh`
-  or restart bb. The configured command is local code execution and only works
-  with a co-located daemon. Optional `logo` accepts an SVG, PNG, or WebP path;
-  relative paths resolve from the bb data dir. Custom ACP agents can use
-  `modelCli` for CLI model listing/selection, `reasoningCli` for launch-time
-  reasoning flags, and `nativeReasoning` for ACP `session/set_config_option`
-  reasoning. Optional
-  `nativeSkillRoots.user` paths resolve from the target
-  host home directory. Optional `nativeSkillRoots.project` paths resolve from
-  the selected workspace. The composer lists skills from these roots.
+- Custom ACP agents live in the ACP providers plugin's `customAgents` setting,
+  a JSON array: `bb plugin config provider-acp set customAgents '[{"id":"amp",
+  "displayName":"Amp","command":"amp","args":["acp"]}]'`. The user supplies a
+  slug `id`; bb exposes it as provider id `acp-<id>`, which is permanent and
+  cannot shadow a known agent. The plugin re-registers as soon as the setting
+  changes. The configured command is local code execution and only works with a
+  co-located daemon. Optional per-agent fields: `args`, `env`, `cwd`,
+  `modelCli`, `reasoningCli`, `nativeReasoning`, `nativeSkillRoots`,
+  `supportsManualCompaction`, and `dialect` (`cursor` or `grok`). The old
+  `customAcpAgents` array in `config.json` is deprecated; bb reads it and warns
+  until 0.40.
 - Top-level `customModels` in the same `config.json` registers extra picker
   models. `providerId` accepts a built-in provider id or any `acp-*` provider
   id. The provider must still accept the id: `claude-code` and `codex` accept

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -315,128 +315,48 @@ simply unavailable.
 
 ## Custom ACP Agents
 
-Known ACP agents can appear automatically when their CLI is installed on the
-host. For example, bb exposes `acp-opencode` when `opencode` is on PATH and can
-be launched as `opencode acp`, and `acp-omp` when `omp` (oh-my-pi) is on PATH
-and can be launched as `omp acp`. It also exposes `acp-grok` when Grok Build's
-`grok` CLI is on PATH and can be launched as `grok agent stdio`, and
-`acp-hermes-agent` when Hermes' `hermes` CLI is on PATH and can be launched as
-`hermes acp`.
+Known ACP agents appear when their CLI is installed on the host. bb exposes
+`acp-opencode` when `opencode` is on PATH and can be launched as `opencode acp`,
+`acp-omp` when `omp` (oh-my-pi) is on PATH, `acp-grok` when Grok Build's `grok`
+CLI is on PATH and can be launched as `grok agent stdio`, and
+`acp-hermes-agent` when Hermes' `hermes` CLI is on PATH. `acp-cursor` is always
+listed.
 
-Register custom ACP agents by editing `customAcpAgents` in `~/.bb/config.json`.
-There is no `bb-app config set` or `unset` command for this list, matching the
-manual-file workflow used for custom models. After editing the file, run
-`npx bb-app config refresh` to apply it to a running local server, or restart bb.
-Use `customAcpAgents` for arbitrary ACP agents, or to override the launch
-command for a known provider id such as `acp-opencode`. To override
-`acp-opencode`, set `"id": "opencode"`; bb derives the provider id by adding
-the `acp-` prefix.
+Add your own agent through the ACP providers plugin's `customAgents` setting,
+which holds a JSON array:
 
-Example:
-
-```json
-{
-  "customAcpAgents": [
-    {
-      "id": "my-agent",
-      "displayName": "My Agent",
-      "command": "my-agent",
-      "logo": "agent-logos/my-agent.svg",
-      "args": ["acp"],
-      "env": {
-        "MY_AGENT_MODE": "bb"
-      },
-      "cwd": "/Users/me/project",
-      "modelCli": {
-        "listArgs": ["--list-models"],
-        "selectFlag": "--model",
-        "primaryModels": ["default"]
-      },
-      "reasoningCli": {
-        "flag": "--reasoning-effort",
-        "supportedLevels": ["low", "medium", "high"],
-        "levelValues": {
-          "max": "high"
-        },
-        "defaultLevel": "high"
-      },
-      "nativeReasoning": {
-        "configId": "reasoning_effort",
-        "supportedLevels": ["none", "low", "medium", "high", "xhigh", "max"],
-        "defaultLevel": "medium"
-      }
-    }
-  ]
-}
+```bash
+bb plugin config provider-acp set customAgents '[
+  {"id": "amp", "displayName": "Amp", "command": "amp", "args": ["acp"]}
+]'
 ```
 
-`id` is a slug matching `^[a-z0-9][a-z0-9-]*$`. bb derives the provider id by
-prefixing it with `acp-`, so the example appears as `acp-my-agent` in
-`bb provider list`, `bb provider models acp-my-agent`, and provider pickers.
-The derived id must not collide with an always-visible built-in provider such
-as `acp-cursor` or with another custom ACP agent. It may match an
-installed-only ACP plugin provider such as `acp-opencode`, in which case the
-custom config wins.
+Each entry needs `id` (lowercase letters, digits and dashes), `displayName`,
+and `command`. bb derives the provider id `acp-<id>`; it never changes once a
+thread has used it, and it may not shadow a known agent. Optional fields:
+`args`, `env`, `cwd`, `modelCli` (CLI model listing and selection),
+`reasoningCli` (launch-time reasoning flags), `nativeReasoning` (ACP
+`session/set_config_option` reasoning), `nativeSkillRoots` (native skills in
+the composer), `supportsManualCompaction` (only if the agent accepts an
+explicit compaction request — bb hides `/compact` otherwise), and `dialect`
+(the vendor side channels bb reads for the agent: `cursor` or `grok`).
 
-`command` is the executable name or path. bb runs it directly with the `args`
-array; it is not a shell command line. `env` adds environment variables for the
-agent process. `cwd` is optional; omit it to use the thread workspace directory.
+The change applies immediately: the plugin re-registers its providers when the
+setting changes, with no restart and no `config refresh`.
 
-`logo` is optional and accepts an SVG, PNG, or WebP file path. Relative paths
-resolve from the bb data directory (for example,
-`~/.bb/agent-logos/my-agent.svg`); absolute paths are also supported. bb serves
-the file to app clients and uses it in provider and model pickers. Omit `logo`
-to use a vendored brand icon for a recognized ACP id or the generic ACP icon.
+A configured agent's command is local code execution and only works with a
+co-located daemon.
 
-`modelCli` is optional. When present, `listArgs` are used to ask the agent for
-models, `selectFlag` is the flag bb passes when launching with a selected model,
-and `primaryModels` marks preferred models in the picker. ACP agents that
-advertise models over the protocol are auto-discovered without `modelCli`; keep
-`modelCli` for CLI-style agents such as Cursor.
+### The deprecated `customAcpAgents` config array
 
-`reasoningCli` is optional. Use it only when the agent accepts reasoning as a
-global launch flag rather than advertising a protocol `thought_level` option or
-encoding effort in model ids. `flag` is inserted before the ACP agent args,
-`supportedLevels` controls the picker levels, `defaultLevel` controls the
-picker default, and `levelValues` maps bb reasoning levels to the agent's CLI
-vocabulary when they differ.
-
-`supportsManualCompaction` is optional and defaults to `false`. Set it to
-`true` only when the agent accepts an explicit compaction request; ACP itself
-advertises nothing about compaction, so the agent definition is what declares
-it. bb hides the built-in `/compact` command for agents that do not. OpenCode
-declares it; Cursor does not.
-
-`nativeReasoning` is optional. Use it for ACP agents that accept reasoning via
-`session/set_config_option` but do not advertise a `thought_level` config option
-during model discovery. `configId` is the ACP config id to set,
-`supportedLevels` controls the picker levels, `defaultLevel` controls the
-picker default, and `levelValues` maps bb reasoning levels to the agent's ACP
-config vocabulary when they differ. Hermes Agent uses this with
-`configId: "reasoning_effort"`.
-
-For ACP-native agents, bb also uses a protocol `thought_level` config option
-when the selected model advertises one. The selected reasoning level is applied
-with `session/set_config_option` before the first prompt. Models without that
-option keep agent-managed reasoning unless the provider launch spec declares
-`nativeReasoning`. Cursor is intentionally separate: it encodes reasoning in
-model ids discovered through `modelCli`, not in an ACP `thought_level` option.
-Grok Build is also separate: it uses `reasoningCli` to launch
-`grok --reasoning-effort <level> agent stdio`.
-
-When an agent declares `thought_level` with no options, bb hides the reasoning
-control. bb also hides it when none of the declared values map to a supported bb
-reasoning level. Omitting `thought_level` keeps the agent-managed reasoning
-fallback for agents that do not advertise this capability.
-
-Custom ACP agents are supported only with the co-located daemon from the same
-machine as the server. A command path in server config is host-local and is not
-meaningful for a remote daemon.
-
-Security note: `command` is arbitrary local code execution by design. Anyone who
-can write `~/.bb/config.json` can cause bb to run that command as the local user
-when the provider is used. Treat `config.json` write access as the trust
-boundary.
+Before ACP agents were plugin-owned, custom agents lived in `customAcpAgents`
+in `~/.bb/config.json`. bb still **reads** that array so an existing agent keeps
+working, logs a deprecation warning for each one, and never writes to it.
+Support ends in 0.40 — move each entry into the `customAgents` setting above.
+The two shapes are identical except that the setting has no `logo` field: a
+plugin-registered provider's icon is a host glyph or an asset the plugin ships,
+so a configured agent shows the generic tool glyph. A setting entry wins over a
+config entry with the same `id`.
 
 ## Custom Models
 

--- a/packages/templates/src/templates/bb-guide-providers.md
+++ b/packages/templates/src/templates/bb-guide-providers.md
@@ -106,25 +106,31 @@ entry with a warning. The entry then appears in bb provider models output and
 in the model picker, but the provider must still accept the id: claude-code
 and codex accept unlisted ids, while an ACP agent can reject an id it does
 not know at session start. OpenCode rejects unlisted ids, so add an OpenCode
-model to the OpenCode config instead. Like customAcpAgents, edit the JSON and
-run bb-app config refresh; there is no set/unset CLI surface. The streamerMode
+model to the OpenCode config instead. Edit the JSON and run bb-app config
+refresh; there is no set/unset CLI surface. The streamerMode
 General setting hides every entry from these lists; see the customization
 chapter.
 
-Custom ACP agents are configured in the app data-dir config.json under
-customAcpAgents. bb derives provider id acp-<id> from each slug id. Edit the JSON
-and run bb-app config refresh; there is no set/unset CLI surface for this list.
-Custom config wins if it uses the same provider id as an installed-only ACP
-plugin provider; for example, override acp-opencode with id opencode. Use modelCli for CLI model
-listing/selection, reasoningCli for launch-time reasoning flags, and
-nativeReasoning for ACP session/set_config_option reasoning. Optional logo
-accepts an SVG, PNG, or WebP path; relative paths resolve from the bb data dir.
-Use nativeSkillRoots to add native skills to the composer. User roots resolve
-from the target host home directory. Project roots resolve from the selected
-workspace. Each root must use a relative path without dot segments. Set
-supportsManualCompaction to true only if the agent accepts an explicit
-compaction request; it defaults to false, and bb hides the /compact command
-for agents that do not declare it.
+Custom ACP agents live in the ACP providers plugin's customAgents setting, a
+JSON array. Set it with bb plugin config provider-acp set customAgents '[...]'.
+Each entry needs id (lowercase letters, digits and dashes), displayName, and
+command. bb derives provider id acp-<id> from the slug id; the id is permanent
+and cannot shadow a known agent. Use args, env, and cwd for the launch, modelCli
+for CLI model listing/selection, reasoningCli for launch-time reasoning flags,
+nativeReasoning for ACP session/set_config_option reasoning, and dialect
+(cursor or grok) for the vendor side channels bb reads. Use nativeSkillRoots to
+add native skills to the composer. User roots resolve from the target host home
+directory. Project roots resolve from the selected workspace. Each root must use
+a relative path without dot segments. Set supportsManualCompaction to true only
+if the agent accepts an explicit compaction request; it defaults to false, and
+bb hides the /compact command for agents that do not declare it. The plugin
+re-registers its providers as soon as the setting changes, so no restart or
+config refresh is needed.
+
+The old customAcpAgents array in the app data-dir config.json is deprecated. bb
+still reads it and logs a warning for each agent it finds, until 0.40. Move each
+entry into the customAgents setting. The shapes match except for logo, which the
+setting does not accept: a configured agent shows the generic tool glyph.
 
 Use top-level sharedSkillRoots for one provider-neutral skill collection. The
 user and project paths use the same relative-path rules. bb indexes these roots

--- a/plugins/provider-acp/server.ts
+++ b/plugins/provider-acp/server.ts
@@ -1,229 +1,142 @@
-import type {
-  BbPluginApi,
-  PluginProviderDeclaration,
-} from "@get-bb/plugin-sdk";
+/**
+ * The ACP providers plugin.
+ *
+ * The plugin owns its agents: the list bb ships knowledge of, and the ones a
+ * user configures in this plugin's own settings. Both become registrations
+ * here, at runtime, and a settings change re-registers without a restart —
+ * one plugin, N providers, no core table of ACP agents anywhere.
+ *
+ * The host side is one re-export of the published kit (`src/host.ts`), so
+ * this file is the whole of bb's ACP privilege: a list of agents anyone could
+ * have written.
+ */
 
-const ACP_BASE_CAPABILITIES = {
-  experimental_providerHealth: true,
-  experimental_providerUsage: false,
-  experimental_providerInstallation: false,
-  supportsServiceTier: true,
-  supportsNativeUserQuestion: false,
-  // ACP session/fork clones a whole session (tip only, no checkpoint rewind),
-  // and it is an unstable ACP extension that not every agent implements. The
-  // bridge refuses `session/fork` for an agent whose `initialize` reply does
-  // not advertise `sessionCapabilities.fork`, but only after the server has
-  // already created and started the fork thread. So this declaration, which
-  // is the server's fork gate and the app's fork affordance, must match what
-  // the agent actually advertises: override it with "none" for agents that
-  // do not (#1833).
-  fork: "tip" as const,
-  supportsManualCompaction: false,
-  supportsThreadArchive: false,
-  supportsThreadRename: false,
-  permissionModes: ["accept-edits", "full"] as const,
-  reasoningLevels: ["low", "medium", "high", "xhigh", "max"] as const,
-};
+import type { BbPluginApi } from "@get-bb/plugin-sdk";
+import {
+  customAcpAgentDefinition,
+  parseCustomAcpAgents,
+  type AcpAgentDefinition,
+} from "./src/agents.js";
+import { acpProviderDeclaration } from "./src/declaration.js";
+import {
+  KNOWN_ACP_AGENTS,
+  KNOWN_ACP_PROVIDER_IDS,
+} from "./src/known-agents.js";
+import {
+  legacyAgentDeprecationMessage,
+  readLegacyCustomAcpAgents,
+} from "./src/legacy-config.js";
 
-/** Cursor exposes a `-fast` model tail the bridge resolves from the tier. */
-const ACP_SERVICE_TIERS = [
-  { id: "default", label: "Default" },
-  { id: "fast", label: "Fast" },
-] as const;
+export { CURSOR_PRIMARY_MODELS } from "./src/known-agents.js";
 
-/** Provider copy for core surfaces, per agent: how to sign in and install. */
-function acpStrings(args: {
-  name: string;
-  signInCommand: string;
-  installUrl: string;
-  iconTint?: { light: string; dark: string };
-}) {
-  return {
-    signInHint: `Run \`${args.signInCommand}\` on the machine to sign in.`,
-    expiredHint: `Your ${args.name} session expired. Run \`${args.signInCommand}\`, then reload.`,
-    installUrl: args.installUrl,
-    ...(args.iconTint === undefined ? {} : { iconTint: args.iconTint }),
-  };
+const CUSTOM_AGENTS_SETTING_DESCRIPTION =
+  'A JSON array of ACP agents to add, for example [{"id":"amp","displayName":"Amp","command":"amp","args":["acp"]}]. ' +
+  'Each agent needs "id" (lowercase letters, digits and dashes), "displayName" and "command"; ' +
+  '"args", "env", "cwd", "modelCli", "reasoningCli", "nativeReasoning", "nativeSkillRoots" and "supportsManualCompaction" are optional. ' +
+  "The provider id is acp-<id> and never changes once a thread has used it.";
+
+/**
+ * The configured agents, from this plugin's setting and — until the
+ * deprecation window closes — from the old `customAcpAgents` array in
+ * config.json. A setting entry wins over a legacy entry with the same id, so
+ * moving an agent into the setting is the whole migration.
+ */
+async function resolveCustomAgents(
+  bb: BbPluginApi,
+  settingValue: string | undefined,
+): Promise<AcpAgentDefinition[]> {
+  const entries: unknown[] = [];
+  const trimmed = settingValue?.trim() ?? "";
+  if (trimmed.length > 0) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (!Array.isArray(parsed)) {
+        bb.log.warn(
+          'The ACP "customAgents" setting must be a JSON array; ignoring it.',
+        );
+      } else {
+        entries.push(...parsed);
+      }
+    } catch (error) {
+      bb.log.warn(
+        `The ACP "customAgents" setting is not valid JSON; ignoring it: ${String(error)}`,
+      );
+    }
+  }
+  const configured = parseCustomAcpAgents({
+    entries,
+    reservedProviderIds: KNOWN_ACP_PROVIDER_IDS,
+  });
+  for (const problem of configured.problems) {
+    bb.log.warn(`ACP custom agent setting: ${problem}`);
+  }
+
+  const legacy = await readLegacyCustomAcpAgents();
+  if (legacy.problem !== undefined) {
+    bb.log.warn(`Deprecated ACP agent config: ${legacy.problem}`);
+  }
+  const legacyAgents = parseCustomAcpAgents({
+    entries: legacy.entries,
+    reservedProviderIds: KNOWN_ACP_PROVIDER_IDS,
+  });
+  for (const problem of legacyAgents.problems) {
+    bb.log.warn(`Deprecated ACP agent config: ${problem}`);
+  }
+
+  const bySlug = new Map(configured.agents.map((agent) => [agent.id, agent]));
+  for (const agent of legacyAgents.agents) {
+    if (bySlug.has(agent.id)) {
+      continue;
+    }
+    bb.log.warn(legacyAgentDeprecationMessage(agent));
+    bySlug.set(agent.id, agent);
+  }
+  return [...bySlug.values()].map(customAcpAgentDefinition);
 }
 
-export const CURSOR_PRIMARY_MODELS = [
-  "auto",
-  "cursor-grok-4.6-medium",
-  "gpt-5.6-sol-medium",
-  "claude-opus-5-thinking-medium",
-  "claude-fable-5-thinking-medium",
-  "composer-2.5",
-];
-
-const ACP_PROVIDERS: readonly PluginProviderDeclaration[] = [
-  {
-    id: "acp-cursor",
-    displayName: "Cursor",
-    icon: "./icons/cursor.svg",
-    experimental_strings: acpStrings({
-      name: "Cursor",
-      signInCommand: "cursor-agent login",
-      installUrl: "https://cursor.com/docs/cli/installation",
-      iconTint: { light: "#111827", dark: "#F5F5F5" },
-    }),
-    experimental_serviceTiers: [...ACP_SERVICE_TIERS],
-    experimental_bridgeOptions: {
-      // Which vendor side channels the bridge reads for this agent
-      // (packages/provider-bridge-acp/src/dialect.ts). Declared per registration so
-      // a third-party plugin that registers a known agent gets the same
-      // reporting fidelity a first-party registration does.
-      acpDialect: "cursor",
-      acpLaunchSpec: {
-        displayName: "Cursor",
-        command: "cursor-agent",
-        args: ["acp"],
-        env: {},
-        modelCli: {
-          listArgs: ["--list-models"],
-          selectFlag: "--model",
-          primaryModels: CURSOR_PRIMARY_MODELS,
-        },
-      },
-    },
-    capabilities: {
-      ...ACP_BASE_CAPABILITIES,
-      experimental_providerUsage: true,
-      experimental_providerInstallation: true,
-      // cursor-agent (2026.08.11) advertises `sessionCapabilities: { list }`
-      // only; no session/fork.
-      fork: "none",
-    },
-    composerActions: [],
-  },
-  {
-    id: "acp-opencode",
-    displayName: "opencode",
-    experimental_visibility: "installed",
-    experimental_strings: acpStrings({
-      name: "opencode",
-      signInCommand: "opencode auth login",
-      installUrl: "https://opencode.ai/docs",
-      iconTint: { light: "#2563EB", dark: "#2563EB" },
-    }),
-    experimental_serviceTiers: [...ACP_SERVICE_TIERS],
-    experimental_bridgeOptions: {
-      acpLaunchSpec: {
-        displayName: "opencode",
-        command: "opencode",
-        args: ["acp"],
-        env: {},
-      },
-    },
-    capabilities: {
-      ...ACP_BASE_CAPABILITIES,
-      supportsManualCompaction: true,
-    },
-    composerActions: [],
-  },
-  {
-    id: "acp-omp",
-    displayName: "omp",
-    experimental_visibility: "installed",
-    experimental_strings: acpStrings({
-      name: "omp",
-      signInCommand: "omp login",
-      installUrl: "https://github.com/can1357/omp",
-      iconTint: { light: "#9333EA", dark: "#9333EA" },
-    }),
-    experimental_serviceTiers: [...ACP_SERVICE_TIERS],
-    experimental_bridgeOptions: {
-      acpLaunchSpec: {
-        displayName: "omp",
-        command: "omp",
-        args: ["acp"],
-        env: {},
-      },
-    },
-    capabilities: ACP_BASE_CAPABILITIES,
-    composerActions: [],
-  },
-  {
-    id: "acp-grok",
-    displayName: "Grok Build",
-    experimental_visibility: "installed",
-    experimental_strings: acpStrings({
-      name: "Grok Build",
-      signInCommand: "grok login",
-      installUrl: "https://docs.x.ai/docs/grok-build",
-    }),
-    experimental_serviceTiers: [...ACP_SERVICE_TIERS],
-    experimental_bridgeOptions: {
-      acpDialect: "grok",
-      acpLaunchSpec: {
-        displayName: "Grok Build",
-        command: "grok",
-        args: ["agent", "stdio"],
-        env: {},
-        modelCli: {
-          listArgs: ["models"],
-          selectFlag: "--model",
-          primaryModels: ["grok-4.5", "grok-composer-2.5-fast"],
-        },
-        permissionCli: {
-          full: ["--always-approve"],
-          insertAfterArgs: 1,
-        },
-        reasoningCli: {
-          flag: "--reasoning-effort",
-          supportedLevels: ["low", "medium", "high"],
-          levelValues: {
-            none: "low",
-            xhigh: "high",
-            ultracode: "high",
-            max: "high",
-          },
-          defaultLevel: "high",
-        },
-      },
-    },
-    capabilities: {
-      ...ACP_BASE_CAPABILITIES,
-      // `grok agent stdio` advertises `sessionCapabilities: { list, resume,
-      // close }`; no session/fork.
-      fork: "none",
-      reasoningLevels: ["low", "medium", "high"],
-    },
-    composerActions: [],
-  },
-  {
-    id: "acp-hermes-agent",
-    displayName: "Hermes Agent",
-    experimental_visibility: "installed",
-    experimental_strings: acpStrings({
-      name: "Hermes Agent",
-      signInCommand: "hermes login",
-      installUrl: "https://hermes-agent.nousresearch.com",
-    }),
-    experimental_serviceTiers: [...ACP_SERVICE_TIERS],
-    experimental_bridgeOptions: {
-      acpLaunchSpec: {
-        displayName: "Hermes Agent",
-        command: "hermes",
-        args: ["acp"],
-        env: {},
-        nativeReasoning: {
-          configId: "reasoning_effort",
-          supportedLevels: ["none", "low", "medium", "high", "xhigh", "max"],
-          defaultLevel: "medium",
-        },
-      },
-    },
-    capabilities: {
-      ...ACP_BASE_CAPABILITIES,
-      reasoningLevels: ["none", "low", "medium", "high", "xhigh", "max"],
-    },
-    composerActions: [],
-  },
-];
-
-/** Registers every built-in ACP launch profile; the bridge owns discovery. */
-export default function plugin(bb: BbPluginApi) {
-  for (const provider of ACP_PROVIDERS) {
-    bb.providers.register(provider);
+export default async function acpProvidersPlugin(
+  bb: BbPluginApi,
+): Promise<void> {
+  for (const agent of KNOWN_ACP_AGENTS) {
+    bb.providers.register(acpProviderDeclaration(agent));
   }
+
+  const settings = bb.settings.define({
+    customAgents: {
+      type: "string",
+      label: "Custom agents",
+      description: CUSTOM_AGENTS_SETTING_DESCRIPTION,
+      default: "",
+    },
+  });
+
+  // Configured agents are re-registered whenever the setting changes: the
+  // registry hands back a disposer per registration, and re-registering an
+  // id this plugin already owns is only allowed after that disposer runs.
+  let disposeCustomAgents: (() => void)[] = [];
+  async function registerCustomAgents(settingValue: string): Promise<void> {
+    for (const dispose of disposeCustomAgents.splice(0)) {
+      dispose();
+    }
+    const agents = await resolveCustomAgents(bb, settingValue);
+    disposeCustomAgents = agents.map(
+      (agent) => bb.providers.register(acpProviderDeclaration(agent)).dispose,
+    );
+    if (agents.length > 0) {
+      bb.log.info(`Registered ${agents.length} configured ACP agent(s).`);
+    }
+  }
+
+  const initial = await settings.get();
+  await registerCustomAgents(initial.customAgents);
+  settings.onChange((next) => {
+    void registerCustomAgents(next.customAgents).catch((error: unknown) => {
+      bb.log.error(`Could not re-register the configured ACP agents: ${String(error)}`);
+    });
+  });
+  bb.onDispose(() => {
+    for (const dispose of disposeCustomAgents.splice(0)) {
+      dispose();
+    }
+  });
 }

--- a/plugins/provider-acp/src/agents.test.ts
+++ b/plugins/provider-acp/src/agents.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from "vitest";
+import {
+  customAcpAgentDefinition,
+  formatCustomAcpProviderId,
+  parseCustomAcpAgents,
+} from "./agents.js";
+import { acpProviderDeclaration } from "./declaration.js";
+import { KNOWN_ACP_AGENTS, KNOWN_ACP_PROVIDER_IDS } from "./known-agents.js";
+
+const reserved = KNOWN_ACP_PROVIDER_IDS;
+
+describe("parseCustomAcpAgents", () => {
+  it("keeps a well-formed agent and defaults what it left out", () => {
+    const parsed = parseCustomAcpAgents({
+      entries: [{ id: "amp", displayName: "Amp", command: "amp" }],
+      reservedProviderIds: reserved,
+    });
+
+    expect(parsed.problems).toEqual([]);
+    expect(parsed.agents).toEqual([
+      {
+        id: "amp",
+        displayName: "Amp",
+        command: "amp",
+        args: [],
+        env: {},
+        supportsManualCompaction: false,
+      },
+    ]);
+  });
+
+  // Every rejection is reported: an agent that vanishes without a word is a
+  // support ticket.
+  it("reports a malformed entry, a shadowed built-in, and a duplicate", () => {
+    const parsed = parseCustomAcpAgents({
+      entries: [
+        { id: "Bad Slug", displayName: "x", command: "x" },
+        { id: "cursor", displayName: "Mine", command: "mine" },
+        { id: "amp", displayName: "Amp", command: "amp" },
+        { id: "amp", displayName: "Amp again", command: "amp" },
+      ],
+      reservedProviderIds: reserved,
+    });
+
+    expect(parsed.agents.map((agent) => agent.id)).toEqual(["amp"]);
+    expect(parsed.problems).toHaveLength(3);
+    expect(parsed.problems[1]).toContain('resolves to built-in provider "acp-cursor"');
+    expect(parsed.problems[2]).toContain("configured more than once");
+  });
+
+  it("accepts the deprecated logo field without using it", () => {
+    const parsed = parseCustomAcpAgents({
+      entries: [
+        {
+          id: "amp",
+          displayName: "Amp",
+          command: "amp",
+          logo: "/home/user/amp.svg",
+        },
+      ],
+      reservedProviderIds: reserved,
+    });
+
+    expect(parsed.problems).toEqual([]);
+    const declaration = acpProviderDeclaration(
+      customAcpAgentDefinition(parsed.agents[0]!),
+    );
+    expect(declaration.icon).toBe("Toolbox");
+  });
+});
+
+describe("customAcpAgentDefinition", () => {
+  it("carries the launch spec and drops a model CLI with nothing to list", () => {
+    const definition = customAcpAgentDefinition({
+      id: "amp",
+      displayName: "Amp",
+      command: "amp",
+      args: ["acp"],
+      env: { AMP_TOKEN: "x" },
+      cwd: "/srv/amp",
+      modelCli: { listArgs: [], primaryModels: [] },
+      supportsManualCompaction: true,
+    });
+
+    expect(definition.id).toBe(formatCustomAcpProviderId("amp"));
+    expect(definition.launch).toEqual({
+      displayName: "Amp",
+      command: "amp",
+      args: ["acp"],
+      env: { AMP_TOKEN: "x" },
+      cwd: "/srv/amp",
+    });
+    expect(definition.supportsManualCompaction).toBe(true);
+    // bb has not verified a configured agent's session/fork support, and the
+    // bridge only refuses a fork after bb created the fork thread (#1833).
+    expect(definition.fork).toBe("none");
+  });
+});
+
+describe("acpProviderDeclaration", () => {
+  it("groups every agent under the acp family instead of an id prefix", () => {
+    for (const agent of KNOWN_ACP_AGENTS) {
+      expect(acpProviderDeclaration(agent).experimental_family).toBe("acp");
+    }
+  });
+
+  it("declares each known agent's own fork support and dialect", () => {
+    const byId = new Map(
+      KNOWN_ACP_AGENTS.map((agent) => [
+        agent.id,
+        acpProviderDeclaration(agent),
+      ]),
+    );
+
+    // Neither Cursor nor grok advertises session/fork; declaring "tip" for
+    // the whole tier is what #1833 was.
+    expect(byId.get("acp-cursor")?.capabilities.fork).toBe("none");
+    expect(byId.get("acp-grok")?.capabilities.fork).toBe("none");
+    // The agents bb has not verified keep the value the ACP tier declared
+    // for them until Q21's probe reads their `initialize` reply.
+    expect(byId.get("acp-opencode")?.capabilities.fork).toBe("tip");
+    expect(byId.get("acp-cursor")?.experimental_bridgeOptions).toMatchObject({
+      acpDialect: "cursor",
+    });
+    expect(byId.get("acp-grok")?.experimental_bridgeOptions).toMatchObject({
+      acpDialect: "grok",
+    });
+    // An agent with no vendor side channels bb reads names no dialect.
+    expect(
+      byId.get("acp-opencode")?.experimental_bridgeOptions,
+    ).not.toHaveProperty("acpDialect");
+    expect(byId.get("acp-opencode")?.capabilities.supportsManualCompaction).toBe(
+      true,
+    );
+    expect(byId.get("acp-cursor")?.capabilities.supportsManualCompaction).toBe(
+      false,
+    );
+  });
+
+  it("keeps each agent's own reasoning ladder and installed-only visibility", () => {
+    const grok = acpProviderDeclaration(
+      KNOWN_ACP_AGENTS.find((agent) => agent.id === "acp-grok")!,
+    );
+    expect(grok.capabilities.reasoningLevels).toEqual(["low", "medium", "high"]);
+    expect(grok.experimental_visibility).toBe("installed");
+
+    const cursor = acpProviderDeclaration(
+      KNOWN_ACP_AGENTS.find((agent) => agent.id === "acp-cursor")!,
+    );
+    expect(cursor.capabilities.reasoningLevels).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+    expect(cursor.experimental_visibility).toBeUndefined();
+    expect(cursor.capabilities.experimental_providerUsage).toBe(true);
+    expect(cursor.capabilities.experimental_providerInstallation).toBe(true);
+  });
+
+  it("gives a configured agent honest copy when it names no sign-in command", () => {
+    const declaration = acpProviderDeclaration(
+      customAcpAgentDefinition({
+        id: "amp",
+        displayName: "Amp",
+        command: "amp",
+        args: [],
+        env: {},
+        supportsManualCompaction: false,
+      }),
+    );
+
+    expect(declaration.experimental_strings?.signInHint).toBe(
+      "Sign in to Amp on the machine, then reload.",
+    );
+    expect(declaration.capabilities.experimental_providerUsage).toBe(false);
+  });
+});

--- a/plugins/provider-acp/src/agents.ts
+++ b/plugins/provider-acp/src/agents.ts
@@ -1,0 +1,237 @@
+/**
+ * The agents this plugin owns.
+ *
+ * bb ships a list of ACP agents it knows how to launch, and a user adds their
+ * own. Both are the same thing — a launch spec plus the facts a provider
+ * declaration needs — so both go through one definition shape and one
+ * registration path. The plugin owns the list; core keeps no ACP table.
+ *
+ * A user-configured agent's id is `acp-<slug>`. That prefix is history, not
+ * structure: nothing branches on it, ids are permanent because threads
+ * persist them, and the `acp` family key is what groups the agents now.
+ */
+
+import { z } from "zod";
+
+/**
+ * The reasoning ladder an ACP agent may declare — bb's coarse vocabulary,
+ * restated here so an agent definition is checked at the plugin boundary.
+ */
+export type AcpReasoningLevel =
+  | "none"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max"
+  | "ultracode";
+
+/** The family key every agent this plugin registers shares. */
+export const ACP_FAMILY = "acp";
+
+/** A user-configured agent's provider id. */
+export function formatCustomAcpProviderId(slug: string): string {
+  return `acp-${slug}`;
+}
+
+/** The launch spec the bridge receives in its provider options. */
+export interface AcpLaunchSpec {
+  displayName: string;
+  command: string;
+  args: string[];
+  env: Record<string, string>;
+  cwd?: string;
+  modelCli?: {
+    listArgs: string[];
+    selectFlag?: string;
+    primaryModels: string[];
+  };
+  reasoningCli?: {
+    flag: string;
+    supportedLevels: string[];
+    levelValues?: Record<string, string>;
+    defaultLevel?: string;
+  };
+  nativeReasoning?: {
+    configId: string;
+    supportedLevels: string[];
+    defaultLevel?: string;
+  };
+  nativeSkillRoots?: { argFlag?: string; envVar?: string };
+  permissionCli?: { full: string[]; insertAfterArgs?: number };
+}
+
+/** One agent this plugin registers as a provider. */
+export interface AcpAgentDefinition {
+  /** The permanent provider id. */
+  id: string;
+  displayName: string;
+  /** A host glyph name or a plugin-relative asset path. */
+  icon?: string;
+  /** How to launch the agent. */
+  launch: AcpLaunchSpec;
+  /** Which vendor side channels the bridge reads (see the kit's dialects). */
+  dialect?: string;
+  /** Listed always, or only where the bridge reports the agent installed. */
+  visibility?: "always" | "installed";
+  /** How the user signs in and installs the agent. */
+  signInCommand?: string;
+  installUrl?: string;
+  iconTint?: { light: string; dark: string };
+  /** Whether the agent accepts an explicit compaction request. */
+  supportsManualCompaction?: boolean;
+  /**
+   * Whether the agent implements the unstable ACP `session/fork`. Declared
+   * conservatively: the bridge refuses a fork the agent never advertised, but
+   * only after bb has created the fork thread, so a wrong "tip" here is a
+   * user-visible failure (#1833).
+   */
+  fork?: "none" | "tip";
+  /** The reasoning ladder the picker offers when the model list has none. */
+  reasoningLevels?: readonly AcpReasoningLevel[];
+  /** Usage and installation surfaces the bridge implements for this agent. */
+  providerUsage?: boolean;
+  providerInstallation?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// User-configured agents
+// ---------------------------------------------------------------------------
+
+const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]*$/u;
+const ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/u;
+
+const customAgentModelCliSchema = z
+  .object({
+    listArgs: z.array(z.string()).default([]),
+    selectFlag: z.string().min(1).optional(),
+    primaryModels: z.array(z.string()).default([]),
+  })
+  .strict();
+
+const customAgentReasoningCliSchema = z
+  .object({
+    flag: z.string().min(1),
+    supportedLevels: z.array(z.string().min(1)).min(1),
+    levelValues: z.record(z.string(), z.string()).optional(),
+    defaultLevel: z.string().min(1).optional(),
+  })
+  .strict();
+
+const customAgentNativeReasoningSchema = z
+  .object({
+    configId: z.string().min(1),
+    supportedLevels: z.array(z.string().min(1)).min(1),
+    defaultLevel: z.string().min(1).optional(),
+  })
+  .strict();
+
+const customAgentSkillRootsSchema = z
+  .object({
+    argFlag: z.string().min(1).optional(),
+    envVar: z.string().min(1).optional(),
+  })
+  .strict();
+
+/**
+ * One user-configured agent, as the plugin's setting stores it. `id` is a
+ * slug; the provider id is `acp-<slug>`.
+ */
+export const customAcpAgentSchema = z
+  .object({
+    id: z.string().regex(SLUG_PATTERN),
+    displayName: z.string().min(1),
+    command: z.string().min(1),
+    args: z.array(z.string()).default([]),
+    env: z.record(z.string().regex(ENV_NAME_PATTERN), z.string()).default({}),
+    cwd: z.string().min(1).optional(),
+    dialect: z.string().min(1).optional(),
+    modelCli: customAgentModelCliSchema.optional(),
+    reasoningCli: customAgentReasoningCliSchema.optional(),
+    nativeReasoning: customAgentNativeReasoningSchema.optional(),
+    nativeSkillRoots: customAgentSkillRootsSchema.optional(),
+    supportsManualCompaction: z.boolean().default(false),
+    // The legacy config accepted a `logo` file path, which the server served
+    // from a route of its own. A plugin's icon is a host glyph or an asset it
+    // ships, so a configured agent takes the generic glyph; the field is
+    // accepted and ignored so an old config still parses.
+    logo: z.string().min(1).optional(),
+  })
+  .strict();
+export type CustomAcpAgent = z.infer<typeof customAcpAgentSchema>;
+
+export const customAcpAgentsSchema = z.array(customAcpAgentSchema);
+
+/** The glyph a user-configured agent shows in the picker. */
+const CUSTOM_AGENT_GLYPH = "Toolbox";
+
+export function customAcpAgentDefinition(
+  agent: CustomAcpAgent,
+): AcpAgentDefinition {
+  return {
+    id: formatCustomAcpProviderId(agent.id),
+    displayName: agent.displayName,
+    icon: CUSTOM_AGENT_GLYPH,
+    launch: {
+      displayName: agent.displayName,
+      command: agent.command,
+      args: [...agent.args],
+      env: { ...agent.env },
+      ...(agent.cwd === undefined ? {} : { cwd: agent.cwd }),
+      ...(agent.modelCli === undefined ||
+      agent.modelCli.listArgs.length === 0
+        ? {}
+        : { modelCli: agent.modelCli }),
+      ...(agent.reasoningCli === undefined
+        ? {}
+        : { reasoningCli: agent.reasoningCli }),
+      ...(agent.nativeReasoning === undefined
+        ? {}
+        : { nativeReasoning: agent.nativeReasoning }),
+      ...(agent.nativeSkillRoots === undefined
+        ? {}
+        : { nativeSkillRoots: agent.nativeSkillRoots }),
+    },
+    ...(agent.dialect === undefined ? {} : { dialect: agent.dialect }),
+    // A configured agent is the user's own: bb cannot know whether it is
+    // installed, so it is always listed, and it forks only if it says so.
+    visibility: "always",
+    fork: "none",
+    supportsManualCompaction: agent.supportsManualCompaction,
+  };
+}
+
+/**
+ * Parse the configured agents, dropping the entries that do not parse and the
+ * ones that would shadow another id. Returns the reasons so the caller can
+ * log them: a silently ignored agent is a support ticket.
+ */
+export function parseCustomAcpAgents(args: {
+  entries: readonly unknown[];
+  reservedProviderIds: ReadonlySet<string>;
+}): { agents: CustomAcpAgent[]; problems: string[] } {
+  const agents: CustomAcpAgent[] = [];
+  const problems: string[] = [];
+  const seen = new Set<string>();
+  for (const [index, entry] of args.entries.entries()) {
+    const parsed = customAcpAgentSchema.safeParse(entry);
+    if (!parsed.success) {
+      problems.push(`entry ${index} is not a valid agent: ${parsed.error.message}`);
+      continue;
+    }
+    const providerId = formatCustomAcpProviderId(parsed.data.id);
+    if (args.reservedProviderIds.has(providerId)) {
+      problems.push(
+        `agent "${parsed.data.id}" resolves to built-in provider "${providerId}"`,
+      );
+      continue;
+    }
+    if (seen.has(providerId)) {
+      problems.push(`agent "${parsed.data.id}" is configured more than once`);
+      continue;
+    }
+    seen.add(providerId);
+    agents.push(parsed.data);
+  }
+  return { agents, problems };
+}

--- a/plugins/provider-acp/src/declaration.ts
+++ b/plugins/provider-acp/src/declaration.ts
@@ -1,0 +1,112 @@
+/**
+ * One agent definition → one provider declaration.
+ *
+ * Every ACP agent — bb's known list, a user's configured agent, and (through
+ * the published kit) a third party's — becomes a declaration the same way.
+ */
+
+import type {
+  PluginProviderCapabilities,
+  PluginProviderDeclaration,
+  PluginProviderStrings,
+} from "@get-bb/plugin-sdk";
+import { ACP_FAMILY, type AcpAgentDefinition } from "./agents.js";
+
+/**
+ * ACP agents run their own tools and own their permission prompts, so bb's
+ * pre-session facts are deliberately few. Permission modes are enforced
+ * cooperatively by the bridge; service tier exists because an agent may
+ * expose a fast model tail the bridge resolves from the tier.
+ */
+const ACP_BASE_CAPABILITIES: PluginProviderCapabilities = {
+  experimental_providerHealth: true,
+  experimental_providerUsage: false,
+  experimental_providerInstallation: false,
+  supportsServiceTier: true,
+  supportsNativeUserQuestion: false,
+  supportsManualCompaction: false,
+  supportsThreadArchive: false,
+  supportsThreadRename: false,
+  fork: "none",
+  permissionModes: ["accept-edits", "full"],
+  reasoningLevels: ["low", "medium", "high", "xhigh", "max"],
+};
+
+const ACP_SERVICE_TIERS = [
+  { id: "default", label: "Default" },
+  { id: "fast", label: "Fast" },
+] as const;
+
+/**
+ * Whether an agent implements the unstable ACP `session/fork`. The bridge
+ * refuses a fork the agent never advertised, but only after bb has created
+ * the fork thread, so a declaration above what the agent answers is a thread
+ * that dies on start (#1833). An agent that does not state its support — a
+ * user-configured agent bb has never seen — declares none rather than
+ * offering an affordance that may break.
+ */
+const DEFAULT_FORK = "none" as const;
+
+/**
+ * The copy core surfaces render for this agent. A configured agent names no
+ * sign-in command and no install page, so its copy says what bb actually
+ * knows: sign in the way the agent itself documents.
+ */
+function acpStrings(agent: AcpAgentDefinition): PluginProviderStrings {
+  const signIn = agent.signInCommand;
+  return {
+    signInHint:
+      signIn === undefined
+        ? `Sign in to ${agent.displayName} on the machine, then reload.`
+        : `Run \`${signIn}\` on the machine to sign in.`,
+    expiredHint:
+      signIn === undefined
+        ? `Your ${agent.displayName} session expired. Sign in on the machine, then reload.`
+        : `Your ${agent.displayName} session expired. Run \`${signIn}\`, then reload.`,
+    installUrl: agent.installUrl ?? "https://agentclientprotocol.com",
+    ...(agent.iconTint === undefined ? {} : { iconTint: agent.iconTint }),
+  };
+}
+
+export function acpProviderDeclaration(
+  agent: AcpAgentDefinition,
+): PluginProviderDeclaration {
+  return {
+    id: agent.id,
+    displayName: agent.displayName,
+    experimental_family: ACP_FAMILY,
+    ...(agent.icon === undefined ? {} : { icon: agent.icon }),
+    experimental_strings: acpStrings(agent),
+    experimental_serviceTiers: [...ACP_SERVICE_TIERS],
+    ...(agent.visibility === undefined
+      ? {}
+      : { experimental_visibility: agent.visibility }),
+    experimental_bridgeOptions: {
+      // Which vendor side channels the bridge reads for this agent
+      // (packages/provider-bridge-acp/src/dialect.ts). Declared per
+      // registration so a third-party plugin that registers a known agent
+      // gets the same reporting fidelity a first-party registration does.
+      ...(agent.dialect === undefined ? {} : { acpDialect: agent.dialect }),
+      acpLaunchSpec: { ...agent.launch },
+    },
+    capabilities: {
+      ...ACP_BASE_CAPABILITIES,
+      fork: agent.fork ?? DEFAULT_FORK,
+      permissionModes: [...ACP_BASE_CAPABILITIES.permissionModes],
+      ...(agent.providerUsage === true
+        ? { experimental_providerUsage: true }
+        : {}),
+      ...(agent.providerInstallation === true
+        ? { experimental_providerInstallation: true }
+        : {}),
+      ...(agent.supportsManualCompaction === true
+        ? { supportsManualCompaction: true }
+        : {}),
+      reasoningLevels:
+        agent.reasoningLevels === undefined
+          ? [...ACP_BASE_CAPABILITIES.reasoningLevels]
+          : [...agent.reasoningLevels],
+    },
+    composerActions: [],
+  };
+}

--- a/plugins/provider-acp/src/known-agents.ts
+++ b/plugins/provider-acp/src/known-agents.ts
@@ -1,0 +1,147 @@
+/**
+ * The ACP agents bb ships knowledge of.
+ *
+ * Each entry is a launch spec plus the facts a provider declaration needs.
+ * There is nothing privileged about them: a user-configured agent and a
+ * third-party plugin's agent are the same shape, and every one of these
+ * could be moved into a plugin of its own without a core change.
+ */
+
+import type { AcpAgentDefinition } from "./agents.js";
+
+/** Cursor exposes a `-fast` model tail the bridge resolves from the tier. */
+export const CURSOR_PRIMARY_MODELS = [
+  "auto",
+  "cursor-grok-4.6-medium",
+  "gpt-5.6-sol-medium",
+  "claude-opus-5-thinking-medium",
+  "claude-fable-5-thinking-medium",
+  "composer-2.5",
+];
+
+export const KNOWN_ACP_AGENTS: readonly AcpAgentDefinition[] = [
+  {
+    id: "acp-cursor",
+    displayName: "Cursor",
+    icon: "./icons/cursor.svg",
+    iconTint: { light: "#111827", dark: "#F5F5F5" },
+    signInCommand: "cursor-agent login",
+    installUrl: "https://cursor.com/docs/cli/installation",
+    dialect: "cursor",
+    providerUsage: true,
+    providerInstallation: true,
+    // cursor-agent (2026.08.11) advertises `sessionCapabilities: { list }`
+    // only; no session/fork.
+    fork: "none",
+    launch: {
+      displayName: "Cursor",
+      command: "cursor-agent",
+      args: ["acp"],
+      env: {},
+      modelCli: {
+        listArgs: ["--list-models"],
+        selectFlag: "--model",
+        primaryModels: CURSOR_PRIMARY_MODELS,
+      },
+    },
+  },
+  {
+    id: "acp-opencode",
+    displayName: "opencode",
+    iconTint: { light: "#2563EB", dark: "#2563EB" },
+    signInCommand: "opencode auth login",
+    installUrl: "https://opencode.ai/docs",
+    visibility: "installed",
+    supportsManualCompaction: true,
+    // Unverified: bb has never read this agent's `initialize` reply, and this
+    // is the value the ACP tier declared for it. Q21's per-instance probe
+    // replaces the guess with what the agent answers.
+    fork: "tip",
+    launch: {
+      displayName: "opencode",
+      command: "opencode",
+      args: ["acp"],
+      env: {},
+    },
+  },
+  {
+    id: "acp-omp",
+    displayName: "omp",
+    iconTint: { light: "#9333EA", dark: "#9333EA" },
+    signInCommand: "omp login",
+    installUrl: "https://github.com/can1357/omp",
+    visibility: "installed",
+    // Unverified; the ACP tier's value (see acp-opencode).
+    fork: "tip",
+    launch: {
+      displayName: "omp",
+      command: "omp",
+      args: ["acp"],
+      env: {},
+    },
+  },
+  {
+    id: "acp-grok",
+    displayName: "Grok Build",
+    signInCommand: "grok login",
+    installUrl: "https://docs.x.ai/docs/grok-build",
+    visibility: "installed",
+    dialect: "grok",
+    // `grok agent stdio` advertises `sessionCapabilities: { list, resume,
+    // close }`; no session/fork.
+    fork: "none",
+    reasoningLevels: ["low", "medium", "high"],
+    launch: {
+      displayName: "Grok Build",
+      command: "grok",
+      args: ["agent", "stdio"],
+      env: {},
+      modelCli: {
+        listArgs: ["models"],
+        selectFlag: "--model",
+        primaryModels: ["grok-4.5", "grok-composer-2.5-fast"],
+      },
+      permissionCli: {
+        full: ["--always-approve"],
+        insertAfterArgs: 1,
+      },
+      reasoningCli: {
+        flag: "--reasoning-effort",
+        supportedLevels: ["low", "medium", "high"],
+        levelValues: {
+          none: "low",
+          xhigh: "high",
+          ultracode: "high",
+          max: "high",
+        },
+        defaultLevel: "high",
+      },
+    },
+  },
+  {
+    id: "acp-hermes-agent",
+    displayName: "Hermes Agent",
+    signInCommand: "hermes login",
+    installUrl: "https://hermes-agent.nousresearch.com",
+    visibility: "installed",
+    // Unverified; the ACP tier's value (see acp-opencode).
+    fork: "tip",
+    reasoningLevels: ["none", "low", "medium", "high", "xhigh", "max"],
+    launch: {
+      displayName: "Hermes Agent",
+      command: "hermes",
+      args: ["acp"],
+      env: {},
+      nativeReasoning: {
+        configId: "reasoning_effort",
+        supportedLevels: ["none", "low", "medium", "high", "xhigh", "max"],
+        defaultLevel: "medium",
+      },
+    },
+  },
+];
+
+/** The provider ids a user-configured agent may not take. */
+export const KNOWN_ACP_PROVIDER_IDS: ReadonlySet<string> = new Set(
+  KNOWN_ACP_AGENTS.map((agent) => agent.id),
+);

--- a/plugins/provider-acp/src/legacy-config.test.ts
+++ b/plugins/provider-acp/src/legacy-config.test.ts
@@ -1,0 +1,84 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { legacyConfigPath, readLegacyCustomAcpAgents } from "./legacy-config.js";
+
+const dirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+async function dataDir(config?: unknown): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "bb-acp-legacy-"));
+  dirs.push(dir);
+  if (config !== undefined) {
+    await writeFile(join(dir, "config.json"), JSON.stringify(config), "utf8");
+  }
+  return dir;
+}
+
+describe("legacyConfigPath", () => {
+  it("uses BB_DATA_DIR when set and the production data dir otherwise", () => {
+    expect(legacyConfigPath({ env: { BB_DATA_DIR: "/srv/bb" }, home: "/home/u" })).toBe(
+      "/srv/bb/config.json",
+    );
+    expect(legacyConfigPath({ env: { BB_DATA_DIR: "~/alt" }, home: "/home/u" })).toBe(
+      "/home/u/alt/config.json",
+    );
+    expect(legacyConfigPath({ env: {}, home: "/home/u" })).toBe(
+      "/home/u/.bb/config.json",
+    );
+  });
+});
+
+describe("readLegacyCustomAcpAgents", () => {
+  it("reads the deprecated array", async () => {
+    const dir = await dataDir({
+      customAcpAgents: [{ id: "amp", displayName: "Amp", command: "amp" }],
+      customModels: [],
+    });
+
+    expect(
+      await readLegacyCustomAcpAgents({ env: { BB_DATA_DIR: dir }, home: "/home/u" }),
+    ).toEqual({
+      entries: [{ id: "amp", displayName: "Amp", command: "amp" }],
+    });
+  });
+
+  // No config file is the normal case for most installs, and an empty
+  // customAcpAgents is the normal case after a migration.
+  it("reports no agents and no problem when there is nothing to read", async () => {
+    const missing = await dataDir();
+    expect(
+      await readLegacyCustomAcpAgents({
+        env: { BB_DATA_DIR: missing },
+        home: "/home/u",
+      }),
+    ).toEqual({ entries: [] });
+
+    const empty = await dataDir({ customModels: [] });
+    expect(
+      await readLegacyCustomAcpAgents({
+        env: { BB_DATA_DIR: empty },
+        home: "/home/u",
+      }),
+    ).toEqual({ entries: [] });
+  });
+
+  it("reports unreadable config instead of throwing", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "bb-acp-legacy-"));
+    dirs.push(dir);
+    await writeFile(join(dir, "config.json"), "{ not json", "utf8");
+
+    const result = await readLegacyCustomAcpAgents({
+      env: { BB_DATA_DIR: dir },
+      home: "/home/u",
+    });
+    expect(result.entries).toEqual([]);
+    expect(result.problem).toContain("is not valid JSON");
+  });
+});

--- a/plugins/provider-acp/src/legacy-config.ts
+++ b/plugins/provider-acp/src/legacy-config.ts
@@ -1,0 +1,89 @@
+/**
+ * The deprecated `customAcpAgents` array in `<dataDir>/config.json`.
+ *
+ * Before the ACP agents were the plugin's own, a user configured an agent by
+ * hand-editing bb's managed config file and the server composed it into the
+ * provider list. That path is deprecated: the plugin's `customAgents` setting
+ * replaces it. bb keeps READING the old file for two minor releases so an
+ * existing agent keeps working, logs each one it finds, and never writes to
+ * it. Delete this module when the deprecation window closes.
+ *
+ * Resolving the data dir here duplicates the server's own resolution, which a
+ * plugin cannot import. That duplication is deliberate and temporary: it is
+ * confined to this module and dies with it.
+ */
+
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { isAbsolute, join } from "node:path";
+import { z } from "zod";
+import { customAcpAgentsSchema, type CustomAcpAgent } from "./agents.js";
+
+/** The release that stops reading the file. */
+export const LEGACY_CUSTOM_AGENTS_REMOVED_IN = "0.40";
+
+const legacyConfigSchema = z
+  .object({ customAcpAgents: z.array(z.unknown()).optional() })
+  .passthrough();
+
+function resolveDataDir(env: NodeJS.ProcessEnv, home: string): string {
+  const configured = env["BB_DATA_DIR"]?.trim();
+  if (configured === undefined || configured.length === 0) {
+    return join(home, ".bb");
+  }
+  if (configured === "~") return home;
+  if (configured.startsWith("~/")) return join(home, configured.slice(2));
+  return isAbsolute(configured) ? configured : join(home, configured);
+}
+
+export function legacyConfigPath(args?: {
+  env?: NodeJS.ProcessEnv;
+  home?: string;
+}): string {
+  return join(
+    resolveDataDir(args?.env ?? process.env, args?.home ?? homedir()),
+    "config.json",
+  );
+}
+
+/**
+ * The agents the deprecated file declares. A missing file is the normal case
+ * and is not a problem; anything else the caller logs.
+ */
+export async function readLegacyCustomAcpAgents(args?: {
+  env?: NodeJS.ProcessEnv;
+  home?: string;
+}): Promise<{ entries: unknown[]; problem?: string }> {
+  const path = legacyConfigPath(args);
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    return code === "ENOENT"
+      ? { entries: [] }
+      : { entries: [], problem: `could not read ${path}: ${String(error)}` };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    return { entries: [], problem: `${path} is not valid JSON: ${String(error)}` };
+  }
+  const config = legacyConfigSchema.safeParse(parsed);
+  if (!config.success) {
+    return { entries: [], problem: `${path} is not a bb config file` };
+  }
+  return { entries: config.data.customAcpAgents ?? [] };
+}
+
+/** The deprecation notice for one legacy agent, ready to log. */
+export function legacyAgentDeprecationMessage(agent: CustomAcpAgent): string {
+  return (
+    `Custom ACP agent "${agent.id}" comes from the deprecated customAcpAgents ` +
+    `array in config.json. bb reads it until ${LEGACY_CUSTOM_AGENTS_REMOVED_IN}; ` +
+    `move it to the ACP providers plugin's "customAgents" setting.`
+  );
+}
+
+export { customAcpAgentsSchema };


### PR DESCRIPTION
Stacked on #2228.

## What was wrong

Three owners shared bb's ACP agents:

1. `plugins/provider-acp/server.ts` declared five providers in a hardcoded array.
2. The **server** composed user-configured agents from a `customAcpAgents` array in `~/.bb/config.json`, at request time, in `execution-options.ts`.
3. The **ACP tier** (`acp-provider-tier.ts`) supplied capabilities for any id starting with `acp-`.

So a user could add an agent only by hand-editing bb's own config file (no CLI surface, needing `bb-app config refresh`), only bb could add a known one, and every agent inherited one tier answer: `fork: "tip"` for all five, `supportsManualCompaction` from a config field the tier read back out.

## What changed

**One shape, one path.** `src/agents.ts` defines `AcpAgentDefinition` — a launch spec plus the facts a declaration needs — and `src/declaration.ts` turns any definition into a `PluginProviderDeclaration`. `src/known-agents.ts` holds the five bb ships. A user-configured agent is the same shape and the same path; nothing about the built-ins is privileged.

**Configured agents are the plugin's own setting.** `customAgents` holds a JSON array, so the CLI already reaches it:

```bash
bb plugin config provider-acp set customAgents '[{"id":"amp","displayName":"Amp","command":"amp","args":["acp"]}]'
```

`settings.onChange` disposes the previous registrations and registers the new set, so an edit applies with no restart and no `config refresh`. Every rejected entry is logged with the reason (malformed, shadows a built-in id, configured twice) — an agent that vanishes silently is a support ticket.

**Each agent declares its own facts.** `fork`, `dialect`, `reasoningLevels`, `supportsManualCompaction`, `visibility`, usage and installation support are per agent instead of per tier. Every registration carries `experimental_family: "acp"`, which is what groups the agents once the `acp-` prefix stops meaning anything (layer 6). The `acp-<slug>` id stays exactly as it is: threads persist provider ids, so they can never change.

**The deprecated config array is read, never written.** `src/legacy-config.ts` reads `customAcpAgents` from `<dataDir>/config.json`, registers what it finds, and logs a deprecation notice per agent naming the setting to move it to. A setting entry wins over a config entry with the same id. The module is self-contained and dated: it goes away in 0.40.

## Deliberate behavior changes

- **A user-configured agent now declares `fork: "none"`** instead of inheriting the tier's `"tip"`. The bridge refuses `session/fork` for an agent that never advertised it, but only *after* bb created the fork thread, so a declaration above what the agent answers is a thread that dies on start (#1833) — and bb has never seen a configured agent's `initialize` reply. The five known agents keep exactly the values they declare today, including the unverified `"tip"` on opencode/omp/hermes-agent, marked as guesses in the source. Q21's per-instance probe replaces every guess with what the agent answers.
- **A configured agent's `logo` is no longer used.** The legacy field pointed at an arbitrary file the server served from a route of its own; a plugin-registered provider's icon is a host glyph or an asset the plugin ships. The field still parses (an old config must not break) and the agent shows the generic tool glyph. This is a real, small loss and I did not want to hide it.
- **A configured agent's sign-in copy is honest.** With no `signInCommand`, the hint says "Sign in to Amp on the machine, then reload." instead of naming a command bb invented.

## How I verified

- `pnpm exec turbo run typecheck` (whole repo): **75/75**.
- `test --filter=bb-plugin-provider-acp`: 4 files, **27 tests**. New coverage: the parser keeps a well-formed agent and defaults what it omitted; it reports a malformed entry, a shadowed built-in and a duplicate; the deprecated `logo` parses and yields the glyph; the launch spec drops a `modelCli` with nothing to list; every known agent declares family `acp`; Cursor and grok declare `fork: "none"` and their dialects while opencode keeps `"tip"`; grok keeps its own three-level reasoning ladder; a configured agent gets honest copy. `legacy-config.test.ts` covers data-dir resolution (`BB_DATA_DIR`, `~/…`, the production default), reading the array, a missing file and an empty array being normal, and unreadable JSON being reported rather than thrown.
- `apps/server` `first-party-provider-plugins.test.ts` — the test that pins every built-in provider's client-read declaration — **passes unchanged**, which is the check that this layer preserved the five known agents' behavior.
- Full `@bb/server` suite: 1895 passed, 2 failed. One is this test before I restored the unverified fork values (now passing). The other is `internal-skill-trees.test.ts` expecting file mode `0644` and getting `0664` — a pre-existing local failure on this machine's `umask 0002`, unrelated to this change.
- `node scripts/check-provider-literal-ratchet.mjs`: **OK, 148 across 40 core files** — unchanged.

Doc surfaces updated in the same change, per AGENTS.md: `docs/configuration.md` (rewritten "Custom ACP Agents" with the new CLI command and a dated deprecation subsection), `packages/templates/src/templates/bb-guide-providers.md` (the in-CLI guide), and the `bb-cli` builtin skill.

## What this layer does not do yet

The server's ACP tier still exists, so a legacy config entry still wins over the plugin's registration for the same id (the server's own precedence rule) and unregistered `acp-*` ids still fall back to tier capabilities. Layer 6 deletes the tier, after which the plugin is the only source. Q21's per-instance capability probing is the next layer.

> AGENT GENERATED: by Claude Opus 5
