### PR TITLE
Stabilize memory inline-edit test under CI contention

### DIFF
--- a/plugins/memory/app.test.tsx
+++ b/plugins/memory/app.test.tsx
@@ -63,7 +63,7 @@ describe("memory settings", () => {
       }),
     );
     await slot.findByText("Run all focused tests.");
-  });
+  }, 15_000);
 
   it("confirms and deletes a memory", async () => {
     vi.stubGlobal(


### PR DESCRIPTION
## What was wrong

The Memory plugin's unchanged inline-edit UI test used Vitest's 5-second default timeout while the package CI shard runs 71 Turbo test tasks on a 4-vCPU runner. In the [failing run](https://github.com/get-bb/bb/actions/runs/32508211062), unrelated work in the same package showed a 36–40× slowdown versus a focused local run: the server tests took 1,437 ms instead of 39 ms and the second UI test took 814 ms, while the inline-edit test completed in 6,439 ms and crossed the 5-second ceiling. The same test passed unchanged on the prior PR head and current main, so the timeout was measuring scheduler contention rather than a product or assertion failure.

## What changed

Give only the multi-step inline-edit UI test a 15-second timeout. Its RPC, rendered-state, and payload assertions remain unchanged, and a real hang is still bounded. There are no wire, CLI, guide, or documentation changes.

## How you verified

- Before: the unchanged test failed at 6,439 ms in the linked package CI run with `Test timed out in 5000ms`.
- Stress: a focused local run under 128 bounded CPU competitors increased the test from the 112 ms two-test baseline to 1,160 ms, while preserving every assertion and completing under the new bound.
- `pnpm exec turbo run build typecheck test --filter=bb-plugin-memory --force` — 7 Turbo tasks passed; 10 tests passed.
- `pnpm exec turbo run lint --filter=bb-plugin-memory --force` — the package declares no Turbo lint task.
- `pnpm exec eslint plugins/memory/app.test.tsx`
- `pnpm exec prettier plugins/memory/app.test.tsx --check`

> AGENT GENERATED: by GPT-5.6-Sol
