### PR TITLE
Delete the runtime's codex-shaped recovery regexes and account-restart set (WS4 L2)

### DIFF
--- a/packages/agent-runtime/src/runtime.command-contract.test.ts
+++ b/packages/agent-runtime/src/runtime.command-contract.test.ts
@@ -321,10 +321,8 @@ describe("createAgentRuntime command contracts", () => {
     }
   });
 
-  it("retries a Codex rename while its new rollout file is still empty", async () => {
-    const stderr: string[] = [];
+  it("does not retry a rename: the bridge owns the not-ready-rollout ladder", async () => {
     const { record, runtime } = createContractRuntime({
-      onStderr: (line) => stderr.push(line),
       launch: {
         scripted: {
           failMethods: [
@@ -346,53 +344,15 @@ describe("createAgentRuntime command contracts", () => {
         providerId: "codex",
         options: fullRuntimeOptions,
       });
-      await runtime.renameThread({ threadId: "t1", title: "New Title" });
 
-      const renameRequests = record
-        .read()
-        .filter((entry) => entry.method === "thread/name/set");
-      expect(renameRequests).toHaveLength(2);
-      expect(renameRequests.map((entry) => entry.params?.title)).toEqual([
-        "[bb] New Title",
-        "[bb] New Title",
-      ]);
-      expect(stderr).toContainEqual(
-        expect.stringContaining('retrying rename for thread "t1"'),
-      );
-    } finally {
-      await runtime.shutdown();
-    }
-  });
-
-  it("stops retrying a Codex rename once its rollout stays empty", async () => {
-    const { record, runtime } = createContractRuntime({
-      launch: {
-        scripted: {
-          failMethods: [
-            {
-              method: "thread/name/set",
-              message: codexEmptyRolloutRenameError,
-            },
-          ],
-        },
-      },
-    });
-
-    try {
-      await runtime.startThread({
-        environmentId: "env-1",
-        threadId: "t1",
-        projectId: "p1",
-        providerId: "codex",
-        options: fullRuntimeOptions,
-      });
-
+      // The codex bridge retries the empty-rollout window itself and answers
+      // the runtime once; a rejection that reaches the runtime is final.
       await expect(
         runtime.renameThread({ threadId: "t1", title: "New Title" }),
       ).rejects.toThrow(/rollout at .+ is empty/i);
       expect(
         record.read().filter((entry) => entry.method === "thread/name/set"),
-      ).toHaveLength(3);
+      ).toHaveLength(1);
     } finally {
       await runtime.shutdown();
     }

--- a/packages/agent-runtime/src/runtime.input-accepted.test.ts
+++ b/packages/agent-runtime/src/runtime.input-accepted.test.ts
@@ -140,7 +140,7 @@ describe("createAgentRuntime input accepted events", () => {
     await runtime.shutdown();
   });
 
-  it("maps a bridge no-active-turn error to a stale steer", async () => {
+  it("maps a staleTurn steer rejection to a stale steer", async () => {
     const events: ThreadEvent[] = [];
     const record = createScriptedEchoRequestRecord();
     const runtime = createScriptedEchoRuntime({
@@ -151,13 +151,15 @@ describe("createAgentRuntime input accepted events", () => {
       },
       launch: {
         // The provider's view of the turn has gone while the runtime still
-        // holds it live: the bridge answers the steer with NO_ACTIVE_TURN.
+        // holds it live: the bridge answers the steer with NO_ACTIVE_TURN and
+        // the staleTurn hint the runtime acts on (the ACP bridge's shape).
         scripted: {
           failMethods: [
             {
               method: "turn/steer",
               message: "No active turn to steer",
               code: BRIDGE_JSON_RPC_ERRORS.NO_ACTIVE_TURN,
+              recovery: { kind: "staleTurn", retryable: false },
             },
           ],
         },

--- a/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
@@ -27,7 +27,6 @@ import {
   scriptedEchoProcessEnv,
   waitForRuntimeState,
   waitForThreadAgentMessageText,
-  waitForThreadTurnCompleted,
   waitForThreadTurnStarted,
   withBridgeLaunch,
   type ScriptedEchoLaunchScript,
@@ -868,151 +867,12 @@ describe("createAgentRuntime process lifecycle", () => {
     await runtime.shutdown();
   });
 
-  it("restarts a codex thread process after a terminal account error before the next turn", async () => {
-    const events: ThreadEvent[] = [];
-    const { processLog, runtime } = createCodexRuntime({ events });
-    try {
-      await runtime.startThread({
-        environmentId: "env-1",
-        threadId: "t1",
-        projectId: "p1",
-        providerId: "codex",
-        options: fullRuntimeOptions,
-      });
-      const initialSession = runtime.getProviderSession("t1");
-      await runtime.runTurn({
-        clientRequestId: "creq_2222222253",
-        threadId: "t1",
-        input: [
-          promptTextInput({
-            text: "fail_turn:unexpected_status_401_Unauthorized:_Missing_bearer",
-          }),
-        ],
-        options: fullRuntimeOptions,
-      });
-      await waitForThreadTurnCompleted({
-        events,
-        providerId: "codex",
-        runtime,
-        threadId: "t1",
-      });
-      expect(events).toContainEqual(
-        expect.objectContaining({
-          type: "turn/completed",
-          threadId: "t1",
-          status: "failed",
-        }),
-      );
-      // The 401 was the point; the waits below must not fail fast on it.
-      events.splice(0, events.length);
-
-      await runtime.runTurn({
-        clientRequestId: "creq_2222222254",
-        threadId: "t1",
-        input: [promptTextInput({ text: "after reauth" })],
-        options: fullRuntimeOptions,
-      });
-      await waitForThreadAgentMessageText({
-        events,
-        providerId: "codex",
-        runtime,
-        text: "after reauth",
-        threadId: "t1",
-      });
-
-      // Same provider session, resumed on a fresh process.
-      expect(runtime.getProviderSession("t1")).toEqual(initialSession);
-      const logLines = processLog.read();
-      expect(logLines.filter((line) => line.startsWith("spawn:"))).toHaveLength(
-        2,
-      );
-      expect(logLines.filter((line) => line.startsWith("exit:"))).toHaveLength(
-        1,
-      );
-      expect(
-        logLines.some(
-          (line) =>
-            line.startsWith("thread/resume:") &&
-            line.endsWith(`:t1:${initialSession?.providerThreadId ?? ""}`),
-        ),
-      ).toBe(true);
-      const turnStarts = logLines.filter((line) =>
-        line.startsWith("turn/start:"),
-      );
-      expect(turnStarts).toHaveLength(2);
-      const [accountErrorTurn, afterReauthTurn] = turnStarts;
-      expect(accountErrorTurn?.split(":")[1]).not.toBe(
-        afterReauthTurn?.split(":")[1],
-      );
-    } finally {
-      await runtime.shutdown();
-    }
-  });
-
-  // A graduated provider has no daemon-bundled bridge, so the runtime's
-  // account restart must re-resume with the launch the session started with —
-  // otherwise the restart fails with "no provider bridge launch".
-  it("re-resumes the codex account restart with the thread's bridge launch", async () => {
-    const events: ThreadEvent[] = [];
-    const record = createScriptedEchoRequestRecord();
-    const bridgeLaunch = createScriptedEchoLaunch({
-      pluginId: "provider-codex",
-      scripted: CODEX_SCRIPT,
-    });
-    const runtime = createAgentRuntime({
-      workspacePath: tmpDir,
-      env: record.env,
-      onEvent: (event) => events.push(event),
-      onToolCall: async () => ({ contentItems: [], success: true }),
-    });
-    try {
-      // The launch rides only this startThread; the restart's resume must
-      // reuse it on its own.
-      await runtime.startThread({
-        bridgeLaunch,
-        environmentId: "env-1",
-        threadId: "t1",
-        projectId: "p1",
-        providerId: "codex",
-        options: fullRuntimeOptions,
-      });
-      await runtime.runTurn({
-        clientRequestId: "creq_2222222255",
-        threadId: "t1",
-        input: [promptTextInput({ text: "fail_turn:401_Unauthorized" })],
-        options: fullRuntimeOptions,
-      });
-      await waitForThreadTurnCompleted({
-        events,
-        providerId: "codex",
-        runtime,
-        threadId: "t1",
-      });
-      events.splice(0, events.length);
-      await runtime.runTurn({
-        clientRequestId: "creq_2222222256",
-        threadId: "t1",
-        input: [promptTextInput({ text: "after reauth" })],
-        options: fullRuntimeOptions,
-      });
-      await waitForThreadAgentMessageText({
-        events,
-        providerId: "codex",
-        runtime,
-        text: "after reauth",
-        threadId: "t1",
-      });
-      // Two bridge processes were launched from the same artifact, and the
-      // second one received the resume.
-      const requests = record.read();
-      expect(requests.filter((r) => r.method === "initialize")).toHaveLength(2);
-      expect(requests.filter((r) => r.method === "thread/resume")).toHaveLength(
-        1,
-      );
-    } finally {
-      await runtime.shutdown();
-    }
-  });
+  // The codex account restart (shut the thread's process down after a
+  // terminal 401/429 and resume before the next turn, #130) moved into the
+  // codex bridge, which rebuilds its own app-server child from the rollout:
+  // plugins/provider-codex/src/bridge/bridge.recovery.test.ts. The runtime's
+  // generic counterpart, the `restartRecommended` recovery hint, is pinned in
+  // runtime.recovery.test.ts.
 
   it("gives a changed declaration its own bridge process at the same artifact hash", async () => {
     const record = createScriptedEchoRequestRecord();

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -1,9 +1,6 @@
 import path from "node:path";
 import { z } from "zod";
-import {
-  isAcpProviderId,
-  isSessionRestorableProvider,
-} from "./provider-catalog.js";
+import { isSessionRestorableProvider } from "./provider-catalog.js";
 import {
   normalizeProviderThreadNameEvent,
   toProviderExternalThreadName,
@@ -11,13 +8,11 @@ import {
 import type {
   DynamicTool,
   InstructionMode,
-  ProviderErrorCategory,
   ThreadEvent,
 } from "@bb/domain";
 import type { HostDaemonAcpLaunchSpec } from "@bb/host-daemon-contract";
 import type { AdapterCommand } from "./provider-adapter.js";
 import {
-  BRIDGE_JSON_RPC_ERRORS,
   experimental_providerHealthResultSchema,
   experimental_providerInstallationRunResultSchema,
   experimental_providerInstallationStatusSchema,
@@ -87,7 +82,7 @@ interface ReconfigureThreadIfNeededArgs {
   threadId: string;
 }
 
-interface RestartCodexThreadForNextTurnArgs {
+interface RestartThreadBridgeArgs {
   instructions: string | undefined;
   options: AgentRuntimeExecutionOptions;
   threadId: string;
@@ -232,9 +227,9 @@ const PREPARED_THREAD_REWIND_RETRY_MS = 30_000;
 interface ThreadRuntimeConfig {
   /**
    * The launch spec the live provider session was constructed with. Kept so a
-   * runtime-internal re-resume (the codex account restart) can rebuild the
-   * same process key and adapter for a plugin-delivered bridge, which cannot
-   * be resolved from the provider id alone.
+   * runtime-internal re-resume (a `restartRecommended` bridge restart) can
+   * rebuild the same process key and adapter for a plugin-delivered bridge,
+   * which cannot be resolved from the provider id alone.
    */
   bridgeLaunch?: AgentRuntimeBridgeLaunch;
   dynamicTools?: DynamicTool[];
@@ -280,65 +275,18 @@ interface RequireProviderRequestPlanArgs {
 }
 
 /**
- * Codex-shaped recovery signals. These survive graduation deliberately: the
- * codex bridge passes provider error text and `errorInfo.category` through
- * verbatim precisely so these runtime tolerances keep matching (see the
- * comments beside SESSION_NOT_RESTORABLE and the rename path in
- * codex/bridge/bridge.ts). Do not delete them as "legacy adapter" residue.
+ * The codex per-thread process lane (#130). Still load-bearing for the idle
+ * reap (`isThreadScopedCodexProcess`); the process-topology layer (L3)
+ * collapses it to one process per provider artifact.
  */
 const CODEX_PROVIDER_ID = "codex";
 const CODEX_THREAD_PROCESS_KEY_PREFIX = `${CODEX_PROVIDER_ID}\0thread:`;
 const THREAD_CREATION_REQUEST_TIMEOUT_MS = 2 * 60_000;
-const CODEX_ACCOUNT_RESTART_PROVIDER_ERROR_CATEGORIES =
-  new Set<ProviderErrorCategory>(["rate-limit", "unauthorized"]);
-const CODEX_ACCOUNT_RESTART_PROVIDER_ERROR_TEXT_PATTERN =
-  /\b(?:40[19]|429|auth(?:entication|orization)?|credits?|quota|rate[-\s]?limit(?:ed)?|unauthori[sz]ed|usage limit)\b/i;
-const CODEX_ARCHIVED_SESSION_ERROR_PATTERN =
-  /\b(?:session|thread)\s+\S+\s+is archived\b/i;
-const CODEX_EMPTY_ROLLOUT_RENAME_ERROR_PATTERN = /\brollout at .+ is empty\b/i;
-const CODEX_RENAME_RETRY_DELAYS_MS = [50, 200] as const;
 
 async function delay(ms: number): Promise<void> {
   await new Promise<void>((resolve) => {
     setTimeout(resolve, ms);
   });
-}
-
-interface SendRenameWithRolloutRetriesArgs {
-  onStderr: AgentRuntimeOptions["onStderr"];
-  providerId: string;
-  send: () => Promise<void>;
-  threadId: string;
-}
-
-/**
- * A brand-new Codex rollout file can exist before its first record is written,
- * and a rename landing in that window fails until Codex flushes. Retry only
- * that error, backing off after each attempt, then make one final attempt
- * whose failure propagates. Every other error fails immediately.
- */
-async function sendRenameWithRolloutRetries(
-  args: SendRenameWithRolloutRetriesArgs,
-): Promise<void> {
-  for (const retryDelayMs of CODEX_RENAME_RETRY_DELAYS_MS) {
-    try {
-      await args.send();
-      return;
-    } catch (error) {
-      if (
-        args.providerId !== CODEX_PROVIDER_ID ||
-        !(error instanceof Error) ||
-        !CODEX_EMPTY_ROLLOUT_RENAME_ERROR_PATTERN.test(error.message)
-      ) {
-        throw error;
-      }
-      args.onStderr?.(
-        `Codex session rollout is not ready; retrying rename for thread "${args.threadId}" in ${retryDelayMs}ms.`,
-      );
-      await delay(retryDelayMs);
-    }
-  }
-  await args.send();
 }
 
 function resolveThreadStoragePath(
@@ -365,7 +313,6 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
   let nextRequestId = 1;
   const threadIdentityRegistry = new RuntimeThreadIdentityRegistry();
   const threadRuntimeConfigs = new Map<string, ThreadRuntimeConfig>();
-  const codexThreadsRequiringAccountRestart = new Set<string>();
   const rateLimitedRetryDelaysMs =
     options.rateLimitRetry?.delaysMs ?? DEFAULT_RATE_LIMITED_RETRY_DELAYS_MS;
   /**
@@ -460,10 +407,9 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
   /**
    * Codex runs one provider process per thread. The codex bridge now owns a
    * per-thread `codex app-server` child internally, so this outer scoping is
-   * redundant for isolation — but it is still load-bearing: the account
-   * restart below and the pre-experiment idle reap both key off
-   * `isThreadScopedCodexProcess`. Collapsing it means routing those through
-   * `thread/stop {release}` + resume, which is a refactor, not a deletion.
+   * redundant for isolation — only the pre-experiment idle reap still keys
+   * off `isThreadScopedCodexProcess`. The process-topology layer (L3)
+   * collapses it to one process per provider artifact.
    */
   function resolveProviderProcessKey(
     args: ResolveProviderProcessKeyArgs,
@@ -551,28 +497,22 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
       // can only ever explain this request. A timeout or a bridge exit has no
       // response and therefore no hint.
       const hint = stampRecoveryHint(error, recovery);
-      // Legacy gate: the codex-shaped text match survives until the typed
-      // hint has shipped in every bridge the runtime can meet (it is deleted
-      // in the next layer). A hint always wins over the text.
-      if (
-        (hint?.kind === "sessionArchived" && hint.retryable) ||
-        (hint === null && isCodexArchivedSessionError(recovery.providerId, error))
-      ) {
-        return await unarchiveAndRetryRequest({
-          error,
-          proc: args.proc,
-          recovery,
-          request,
-        });
-      }
       if (hint === null) {
         throw error;
       }
       switch (hint.kind) {
         case "sessionArchived":
-          // Not retryable: the bridge says the session cannot be unarchived
-          // from here (a fork source it cannot reopen, for example).
-          throw error;
+          if (!hint.retryable) {
+            // The bridge says the session cannot be unarchived from here (a
+            // fork source it cannot reopen, for example).
+            throw error;
+          }
+          return await unarchiveAndRetryRequest({
+            error,
+            proc: args.proc,
+            recovery,
+            request,
+          });
         case "authRequired":
           throw new AgentRuntimeRecoveryError({
             cause: error,
@@ -784,7 +724,6 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
     threadId: string,
     config: ThreadRuntimeConfig,
   ): void {
-    codexThreadsRequiringAccountRestart.delete(threadId);
     threadRuntimeConfigs.set(threadId, config);
   }
 
@@ -802,7 +741,6 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
   }
 
   function clearThreadRuntimeConfig(threadId: string): void {
-    codexThreadsRequiringAccountRestart.delete(threadId);
     threadsAwaitingBridgeRestart.delete(threadId);
     idleProviderSessionSinceMsByThreadId.delete(threadId);
     pendingTurnStarts.delete(threadId);
@@ -977,74 +915,6 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
     return providerThreadId;
   }
 
-  function shouldRestartCodexThreadAfterEvent(
-    event: ThreadEvent,
-    proc: ProviderProcess,
-  ): boolean {
-    if (
-      proc.providerId !== CODEX_PROVIDER_ID ||
-      event.type !== "provider/error" ||
-      event.willRetry === true
-    ) {
-      return false;
-    }
-
-    if (
-      event.errorInfo !== undefined &&
-      CODEX_ACCOUNT_RESTART_PROVIDER_ERROR_CATEGORIES.has(
-        event.errorInfo.category,
-      )
-    ) {
-      return true;
-    }
-
-    const errorText = [event.message, event.detail]
-      .filter((part) => part !== undefined)
-      .join("\n");
-    return CODEX_ACCOUNT_RESTART_PROVIDER_ERROR_TEXT_PATTERN.test(errorText);
-  }
-
-  async function restartCodexThreadForNextTurnIfNeeded(
-    args: RestartCodexThreadForNextTurnArgs,
-  ): Promise<void> {
-    if (!codexThreadsRequiringAccountRestart.has(args.threadId)) {
-      return;
-    }
-
-    const currentConfig = threadRuntimeConfigs.get(args.threadId);
-    if (!currentConfig || currentConfig.providerId !== CODEX_PROVIDER_ID) {
-      codexThreadsRequiringAccountRestart.delete(args.threadId);
-      return;
-    }
-
-    if (turnState.getActiveTurnId(args.threadId) !== null) {
-      return;
-    }
-
-    const providerThreadId = requireProviderThreadId(args.threadId);
-    const proc = providerProcesses.requireProviderProcess({
-      processKey: currentConfig.processKey,
-      providerId: currentConfig.providerId,
-    });
-    if (!isThreadScopedCodexProcess(proc)) {
-      codexThreadsRequiringAccountRestart.delete(args.threadId);
-      return;
-    }
-
-    codexThreadsRequiringAccountRestart.delete(args.threadId);
-    await providerProcesses.shutdownProvider({
-      processKey: proc.processKey,
-      providerId: proc.providerId,
-    });
-    await resumeThreadFromConfig({
-      currentConfig,
-      instructions: args.instructions,
-      options: args.options,
-      providerThreadId,
-      threadId: args.threadId,
-    });
-  }
-
   /**
    * An unsolicited `provider/recovery` notification: a condition with no
    * runtime request to ride on (a terminal 401 mid-turn). A hint that
@@ -1116,7 +986,7 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
    * thread's next turn or steer.
    */
   async function restartThreadBridgeIfRecommended(
-    args: RestartCodexThreadForNextTurnArgs,
+    args: RestartThreadBridgeArgs,
   ): Promise<void> {
     const hint = threadsAwaitingBridgeRestart.get(args.threadId);
     if (hint === undefined) {
@@ -1313,17 +1183,6 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
     await releaseIdleProviderProcess(proc);
   }
 
-  function isCodexArchivedSessionError(
-    providerId: string,
-    error: unknown,
-  ): error is Error {
-    return (
-      providerId === CODEX_PROVIDER_ID &&
-      error instanceof Error &&
-      CODEX_ARCHIVED_SESSION_ERROR_PATTERN.test(error.message)
-    );
-  }
-
   async function reconfigureThreadIfNeeded(
     args: ReconfigureThreadIfNeededArgs,
   ): Promise<void> {
@@ -1491,9 +1350,6 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
       turnState.observe(normalizedEvent);
       backgroundWorkState.observe(normalizedEvent);
       observeProviderSessionIdleState(normalizedEvent);
-      if (shouldRestartCodexThreadAfterEvent(normalizedEvent, args.proc)) {
-        codexThreadsRequiringAccountRestart.add(normalizedEvent.threadId);
-      }
       options.onEvent(normalizedEvent);
       threadGoalState.observe(normalizedEvent);
     }
@@ -2290,11 +2146,6 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
         work: async () => {
           const pid = threadIdentityRegistry.resolveProviderForThread(threadId);
           requireProviderProcessForThread(threadId);
-          await restartCodexThreadForNextTurnIfNeeded({
-            threadId,
-            options: execOpts,
-            instructions,
-          });
           await restartThreadBridgeIfRecommended({
             threadId,
             options: execOpts,
@@ -2392,11 +2243,6 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
             };
           }
 
-          await restartCodexThreadForNextTurnIfNeeded({
-            threadId,
-            options: execOpts,
-            instructions,
-          });
           await restartThreadBridgeIfRecommended({
             threadId,
             options: execOpts,
@@ -2451,14 +2297,6 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
                 `Dropping stale steer for thread "${threadId}": ${error.recovery.message}`,
                 threadId,
               );
-              turnState.clearThread(threadId);
-              return { status: "stale", activeTurnId: null };
-            }
-            if (
-              error instanceof JsonRpcResponseError &&
-              isAcpProviderId(pid) &&
-              error.code === BRIDGE_JSON_RPC_ERRORS.NO_ACTIVE_TURN
-            ) {
               turnState.clearThread(threadId);
               return { status: "stale", activeTurnId: null };
             }
@@ -2581,22 +2419,15 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
             plan: proc.adapter.buildCommandPlan(adapterCommand),
             providerId: pid,
           });
-          await sendRenameWithRolloutRetries({
-            onStderr: options.onStderr,
-            providerId: pid,
-            send: async () => {
-              await sendCommand({
-                proc,
-                message: cmd,
-                resultSchema: ignoredJsonRpcResultSchema,
-                recovery: {
-                  providerId: pid,
-                  providerThreadId: adapterCommand.providerThreadId,
-                  threadId,
-                },
-              });
+          await sendCommand({
+            proc,
+            message: cmd,
+            resultSchema: ignoredJsonRpcResultSchema,
+            recovery: {
+              providerId: pid,
+              providerThreadId: adapterCommand.providerThreadId,
+              threadId,
             },
-            threadId,
           });
           emitAcceptedCommandEvents({
             command: adapterCommand,

--- a/plugins/provider-acp/src/bridge/bridge.ts
+++ b/plugins/provider-acp/src/bridge/bridge.ts
@@ -2548,11 +2548,12 @@ async function handleRequest(
         return;
       }
       if (session.activePromptKind !== "turn") {
-        sendError(
-          request.id,
-          ACP_BRIDGE_NO_ACTIVE_TURN_ERROR_CODE,
-          "No active turn to steer",
-        );
+        // The typed hint is what the runtime acts on (it drops the steer as
+        // stale); the code stays for the wire's sake.
+        const message = "No active turn to steer";
+        sendError(request.id, ACP_BRIDGE_NO_ACTIVE_TURN_ERROR_CODE, message, {
+          recovery: { kind: "staleTurn", message, retryable: false },
+        });
         return;
       }
       // A steer joins the active turn, but the agent only learns about it

--- a/plugins/provider-codex/src/bridge/bridge.archived-resume.test.ts
+++ b/plugins/provider-codex/src/bridge/bridge.archived-resume.test.ts
@@ -13,17 +13,14 @@ import { handleLine } from "./bridge.js";
  * `error.data.recovery` — that is what drives the runtime's
  * unarchive-and-retry — and the original error text VERBATIM for the
  * user-visible failure when the recovery cannot run (historical fix
- * a4e3011b0: the runtime's legacy text gate still reads it until the
- * deletion layer removes it).
+ * a4e3011b0 kept the text verbatim for a runtime regex; that regex is gone,
+ * the text now only names the session and the CLI command that fixes it).
  */
 
 const THREAD_ID = "thr_archived_resume_1";
 const ARCHIVED_PROVIDER_THREAD_ID = "archived-prov-1";
 // Must match what fake-codex-app-server.mjs emits for `archived-` thread ids.
 const ARCHIVED_ERROR_TEXT = `session ${ARCHIVED_PROVIDER_THREAD_ID} is archived; unarchive it and retry`;
-// Copy of runtime.ts's CODEX_ARCHIVED_SESSION_ERROR_PATTERN (not exported).
-const RUNTIME_UNARCHIVE_RETRY_PATTERN =
-  /\b(?:session|thread)\s+\S+\s+is archived\b/i;
 
 const fakeAppServerPath = fileURLToPath(
   new URL("./fake-codex-app-server.mjs", import.meta.url),
@@ -77,9 +74,8 @@ it("preserves the archived-session error text verbatim on a rejected resume", as
   expect(response.error?.code).toBe(
     BRIDGE_JSON_RPC_ERRORS.SESSION_NOT_RESTORABLE,
   );
-  // Verbatim: any wrapping or rewording breaks the runtime's regex match.
+  // Verbatim: the text names the session and the CLI command that fixes it.
   expect(response.error?.message).toBe(ARCHIVED_ERROR_TEXT);
-  expect(response.error?.message).toMatch(RUNTIME_UNARCHIVE_RETRY_PATTERN);
   // The typed hint rides the rejection: the runtime acts on this, not text.
   expect(response.error?.data).toEqual({
     recovery: {

--- a/scripts/provider-literal-baseline.json
+++ b/scripts/provider-literal-baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Provider-literal ratchet (G1). Per-file occurrence count of provider-ID references in core. May only go DOWN. Regenerate: node scripts/check-provider-literal-ratchet.mjs --write. Delete this file and the guard when empty.",
-  "total": 148,
+  "total": 142,
   "files": {
     "apps/app/src/components/tools/SkillsCollection.tsx": 3,
     "apps/app/src/lib/provider-icon.ts": 15,
@@ -25,7 +25,7 @@
     "packages/agent-runtime/src/provider-catalog.ts": 2,
     "packages/agent-runtime/src/provider-registry.ts": 2,
     "packages/agent-runtime/src/runtime-skill-roots.ts": 5,
-    "packages/agent-runtime/src/runtime.ts": 12,
+    "packages/agent-runtime/src/runtime.ts": 6,
     "packages/agent-runtime/src/types.ts": 3,
     "packages/config/src/bb-app-managed-config.ts": 4,
     "packages/domain/src/provider-model-catalog.ts": 3,

--- a/tests/scripted-echo-provider/src/provider-bridge.ts
+++ b/tests/scripted-echo-provider/src/provider-bridge.ts
@@ -871,7 +871,7 @@ function rejectIfArchived(
     return false;
   }
   const message = archivedSessionError(providerThreadId);
-  // The codex shape: the text for the legacy runtime gate, the typed hint
+  // The codex shape: the text for the user-visible failure, the typed hint
   // on the error for the runtime's unarchive-and-retry action.
   respondError(id, -32000, message, {
     recovery: {


### PR DESCRIPTION
WS4 layer 2 of 7, stacked on #2235 (L1). Design: `ideal-state-provider-api.md` §7 "Deleted from core" — the codex regexes, the account-restart set, and the rename retry.

## What was wrong

After L1 every condition the runtime used to recognize by matching codex prose arrives as a typed `provider/recovery` hint, so the regexes and the provider-id guards they justified were dead weight that still ran: `CODEX_ARCHIVED_SESSION_ERROR_PATTERN` gated the unarchive-and-retry beside the hint, the runtime retried renames a bridge had already retried, and `shouldRestartCodexThreadAfterEvent` re-classified every terminal codex error by text to schedule a process restart the codex bridge now performs itself. The steer path still needed `isAcpProviderId` to read the ACP bridge's `NO_ACTIVE_TURN` as a stale steer.

## What changed

**Deleted from `packages/agent-runtime/src/runtime.ts`** (each with its L1 counterpart):

| Deleted symbol | Covered by |
| --- | --- |
| `CODEX_ARCHIVED_SESSION_ERROR_PATTERN`, `isCodexArchivedSessionError` | `sessionArchived` on the rejection (`error.data.recovery`); `sendCommand` now switches on the hint alone |
| `CODEX_EMPTY_ROLLOUT_RENAME_ERROR_PATTERN`, `CODEX_RENAME_RETRY_DELAYS_MS`, `sendRenameWithRolloutRetries`, `SendRenameWithRolloutRetriesArgs` | the codex bridge's own 50/200 ms ladder (`sendMaintenanceRequestWithRetries`); the runtime sends `thread/name/set` once |
| `CODEX_ACCOUNT_RESTART_PROVIDER_ERROR_CATEGORIES`, `CODEX_ACCOUNT_RESTART_PROVIDER_ERROR_TEXT_PATTERN`, `shouldRestartCodexThreadAfterEvent`, `restartCodexThreadForNextTurnIfNeeded`, `codexThreadsRequiringAccountRestart` | the codex bridge rebuilds its app-server child before the next turn (`rebuildBeforeNextTurnReason`) and raises `authRequired`/`rateLimited`; the generic `restartRecommended` action stays for bridges that cannot self-heal |
| the `isAcpProviderId(pid) && code === NO_ACTIVE_TURN` steer branch | the generic `staleTurn` branch |
| imports `isAcpProviderId`, `ProviderErrorCategory`, `BRIDGE_JSON_RPC_ERRORS` | unused after the above |

`RestartCodexThreadForNextTurnArgs` is renamed `RestartThreadBridgeArgs` (it now only serves `restartThreadBridgeIfRecommended`). The `CODEX_PROVIDER_ID` guards that remain (`resolveProviderProcessKey`, `isThreadScopedCodexProcess`, the pre-experiment idle-reap gate) belong to the per-thread process lane and go in L3.

**Single-site exception in `plugins/provider-acp/src/bridge/bridge.ts`** (coordinator-approved): the `turn/steer` `NO_ACTIVE_TURN` rejection now carries `data: { recovery: { kind: "staleTurn", retryable: false } }`. Nothing else in that plugin changes; the error code stays for the wire.

**Ratchet**: `scripts/provider-literal-baseline.json` 148 → 142 (`runtime.ts` 12 → 6).

Not a wire change: no `HOST_DAEMON_PROTOCOL_VERSION` bump (nothing between server and daemon moved) and no `PROVIDER_BRIDGE_PROTOCOL_VERSION` bump (the ACP `data` is the optional field L1 added).

## How you verified

Tests:
- Removed the three runtime tests that pinned the deleted behavior — `retries a Codex rename while its new rollout file is still empty`, `stops retrying a Codex rename once its rollout stays empty` (replaced by `does not retry a rename: the bridge owns the not-ready-rollout ladder`, one `thread/name/set` on the wire), and the two account-restart tests in `runtime.process-lifecycle.test.ts` (their counterparts: `bridge.recovery.test.ts` in the codex plugin and the `restartRecommended` cases in `runtime.recovery.test.ts`).
- `maps a bridge no-active-turn error to a stale steer` now sends the `staleTurn` hint (the ACP bridge's shape) and is no longer provider-gated.
- The L1 suite `runtime.recovery.test.ts` runs under provider id `fake`, so it already proved the typed path with the text gates unable to fire; it is unchanged and green.

Oracle (`--concurrency 4`): typecheck 9/9; tests agent-runtime 450, provider-acp 196, provider-codex 201, scripted-echo 1, host-daemon 555 — green. Parity acp-cursor 10 passed / 1 skipped, zero diffs (the `data` rides an error response, never an event). A4: 307 threads, 93,534 rows, zero diffs. Ratchet `--base origin/main`: 142 ≤ 148, baseline written.

Part of the provider-plugin migration (WS4). L3 collapses the codex per-thread process lane.

> AGENT GENERATED: by Claude Opus 5
