### PR TITLE
Keep the two-checkout parity harness working across a moved bridge

### DIFF
--- a/packages/provider-bridge-protocol/recordings/parity-allowlist.json
+++ b/packages/provider-bridge-protocol/recordings/parity-allowlist.json
@@ -758,5 +758,21 @@
     "path": "/*/children/*/toolArgs",
     "pr": "#2211",
     "reason": "Projection of M3: the tool row renders the arguments the item now carries."
+  },
+  {
+    "provider": "acp-cursor",
+    "cell": "approval-allow",
+    "layer": "events",
+    "path": "/*/item/aggregatedOutput",
+    "pr": "#2234",
+    "reason": "M1 (#2234): a command that printed nothing shows no output. `touch approved.txt` reported {exitCode:0,stdout:\"\",stderr:\"\"}, and the empty stream join used to fall through to the rawOutput envelope rendered as JSON."
+  },
+  {
+    "provider": "acp-cursor",
+    "cell": "approval-allow",
+    "layer": "rows",
+    "path": "/*/children/*/output",
+    "pr": "#2234",
+    "reason": "M1 (#2234): a command that printed nothing shows no output. `touch approved.txt` reported {exitCode:0,stdout:\"\",stderr:\"\"}, and the empty stream join used to fall through to the rawOutput envelope rendered as JSON."
   }
 ]

--- a/packages/provider-bridge-protocol/src/testing/parity.ts
+++ b/packages/provider-bridge-protocol/src/testing/parity.ts
@@ -17,7 +17,13 @@
  */
 import { spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -62,9 +68,20 @@ export type ParityRowProjector = (args: {
 // Bridge launch
 // ---------------------------------------------------------------------------
 
-/** Where each first-party bridge lives inside a checkout. */
+/**
+ * Where each first-party bridge lives inside a checkout.
+ *
+ * `modulePath` is where it lives today; `legacyModulePaths` are where it lived
+ * before. A two-checkout parity run spawns the SAME provider from an older
+ * checkout, so a bridge that moved must still be found there — otherwise the
+ * old leg silently produces no events and every cell "fails" for a reason
+ * that has nothing to do with the change under test.
+ */
 export const FIRST_PARTY_BRIDGE_MODULES: Readonly<
-  Record<string, { modulePath: string; pluginId: string }>
+  Record<
+    string,
+    { modulePath: string; legacyModulePaths?: string[]; pluginId: string }
+  >
 > = {
   codex: {
     modulePath: "plugins/provider-codex/src/bridge/bridge.ts",
@@ -76,6 +93,9 @@ export const FIRST_PARTY_BRIDGE_MODULES: Readonly<
   },
   acp: {
     modulePath: "plugins/provider-acp/src/host.ts",
+    // Before the ACP bridge became the published kit, the plugin's host
+    // artifact was the bridge module itself.
+    legacyModulePaths: ["plugins/provider-acp/src/bridge/bridge.ts"],
     pluginId: "provider-acp",
   },
   pi: {
@@ -315,6 +335,26 @@ function tsxSpecifier(): string {
   return import.meta.resolve("tsx");
 }
 
+/**
+ * The bridge module as this checkout has it: the current path when it exists,
+ * else the first legacy path that does. An unknown path is left alone so the
+ * spawn fails loudly instead of silently replaying nothing.
+ */
+function resolveModulePath(
+  checkoutRoot: string,
+  entry: { modulePath: string; legacyModulePaths?: string[] },
+): string {
+  if (existsSync(join(checkoutRoot, entry.modulePath))) {
+    return entry.modulePath;
+  }
+  for (const legacy of entry.legacyModulePaths ?? []) {
+    if (existsSync(join(checkoutRoot, legacy))) {
+      return legacy;
+    }
+  }
+  return entry.modulePath;
+}
+
 export function resolveBridgeLaunch(spec: ParityBridgeSpec): {
   command: string;
   args: string[];
@@ -323,7 +363,7 @@ export function resolveBridgeLaunch(spec: ParityBridgeSpec): {
   const checkoutRoot = resolve(spec.checkoutRoot);
   const profile = resolveReplayProfile(spec.providerId);
   const defaults = FIRST_PARTY_BRIDGE_MODULES[profile.bridgeFamily];
-  const modulePath = spec.modulePath ?? defaults.modulePath;
+  const modulePath = spec.modulePath ?? resolveModulePath(checkoutRoot, defaults);
   const pluginId = spec.pluginId ?? defaults.pluginId;
   const dataDir = mkdtempSync(join(tmpdir(), "bb-parity-data-"));
   return {


### PR DESCRIPTION
Stacked on #2238.

## What was wrong

`pnpm parity --old <main-worktree> --new .` spawns the **same** provider's bridge from two checkouts. `FIRST_PARTY_BRIDGE_MODULES` names one path per bridge, resolved against each checkout root — so a bridge module that moves makes the old leg spawn nothing.

#2228 moved the ACP bridge into the published kit and repointed the harness at the plugin's new one-line host entry (`plugins/provider-acp/src/host.ts`). That file does not exist in a pre-migration checkout, so every acp-cursor cell came back:

```
FAIL acp-cursor/turn-tools: old 0 events/0 rows, new 98 events/2 rows, … 3 stall(s)
```

Zero events on the old leg, three stalls, ten cells "failing" — which reads exactly like a badly broken change under test. It cost me a full debugging pass to notice the old leg was the broken one, and it would have cost the next person the same.

## What changed

`FIRST_PARTY_BRIDGE_MODULES` entries may name `legacyModulePaths`, and `resolveBridgeLaunch` picks the first path that exists in that checkout (falling back to the current path when none do, so a genuinely missing module still fails loudly instead of replaying nothing). The ACP entry lists its pre-kit location.

Also adds the last intended acp-cursor allowlist class, attributed to the layer that caused it: #2234 stopped showing a command's `rawOutput` envelope when the command printed nothing, and `approval-allow` exercises that with `touch approved.txt`.

## How I verified

Two-checkout A2 against a `main` worktree, on a quiet machine, at this stack tip:

| provider | result |
|---|---|
| `acp-cursor` | **10 passed, 0 failed, 1 skipped** |
| `codex` | **16 passed, 0 failed, 1 skipped** — zero new diffs |
| `claude-code` | **13 passed, 0 failed, 1 skipped** — zero new diffs |

Before this fix the same acp-cursor command reported 0 passed / 10 failed with three stalls per cell. `pnpm exec turbo run test --filter=@bb/provider-parity --force`: 43/43.

> AGENT GENERATED: by Claude Opus 5
