### PR TITLE
Prevent competing turns and false Codex session rebuilds

### DIFF
--- a/apps/host-daemon/src/command-dispatch.test.ts
+++ b/apps/host-daemon/src/command-dispatch.test.ts
@@ -207,7 +207,7 @@ function createRuntime(): FakeDispatchRuntime {
         : null,
     reapIdleProviderSessions: vi.fn(async () => ({ reapedSessions: [] })),
     hasThread: (threadId) => hostedThreadIds.has(threadId),
-    getLiveThreadIds: () => [...activeTurnsByThreadId.keys()],
+    getLiveThreadIds: vi.fn(() => [...activeTurnsByThreadId.keys()]),
     hasOpenBackgroundWork: () => false,
     shutdown: vi.fn(async () => undefined),
     setActiveTurn: (threadId, turnId) => {
@@ -218,6 +218,44 @@ function createRuntime(): FakeDispatchRuntime {
       hostedThreadIds.add(threadId);
       activeTurnsByThreadId.delete(threadId);
     },
+  };
+}
+
+function createTurnSubmitCommand(
+  target: CommandOf<"turn.submit">["target"],
+): CommandOf<"turn.submit"> {
+  return {
+    bridgeLaunch: DISPATCH_TEST_BRIDGE_LAUNCH,
+    type: "turn.submit",
+    environmentId: "env-1",
+    threadId: "thread-1",
+    requestId: "creq_turn_submit",
+    input: [{ type: "text", text: "follow up", mentions: [] }],
+    options: {
+      model: "gpt-5",
+      serviceTier: "default",
+      reasoningLevel: "medium",
+      providerOptions: {},
+      permissionMode: "full",
+      permissionScope: "full",
+      approvalReviewer: null,
+      permissionEscalation: null,
+    },
+    resumeContext: {
+      bridgeLaunch: DISPATCH_TEST_BRIDGE_LAUNCH,
+      workspaceContext: {
+        workspacePath: WORKSPACE_PATH,
+        workspaceProvisionType: "unmanaged",
+      },
+      projectId: "proj_1",
+      providerId: "codex",
+      providerThreadId: "provider-thread-1",
+      instructions: "Be concise.",
+      dynamicTools: [],
+      injectedSkillSources: [],
+      instructionMode: "append",
+    },
+    target,
   };
 }
 
@@ -350,6 +388,120 @@ async function runSuccessfulClaudeCodeUpdateVerification(args: {
 }
 
 describe("dispatchCommand", () => {
+  it("steers an auto submit when the active turn appears after the server snapshot", async () => {
+    const runtime = createRuntime();
+    const manager = new RuntimeManager({
+      createRuntime: () => runtime,
+      provisionWorkspace: async () => createWorkspace(),
+    });
+    await manager.ensureEnvironment({
+      environmentId: "env-1",
+      workspacePath: WORKSPACE_PATH,
+    });
+    runtime.setIdle("thread-1");
+    vi.mocked(runtime.getLiveThreadIds).mockReturnValueOnce(["thread-1"]);
+    vi.mocked(runtime.waitForActiveTurn).mockImplementationOnce(
+      async (threadId) => {
+        runtime.setActiveTurn(threadId, "turn-starting");
+        return "turn-starting";
+      },
+    );
+
+    const result = await dispatchCommand(
+      createTurnSubmitCommand({ mode: "auto", expectedTurnId: null }),
+      {
+        dataDir: "/tmp/bb-data",
+        logger: silentLogger,
+        eventSink: { emit: vi.fn(), flush: vi.fn(async () => undefined) },
+        fetchProjectAttachment: async () => {
+          throw new Error("Unexpected project attachment fetch");
+        },
+        runtimeManager: manager,
+        threadStorageRootPath: "/tmp/bb-thread-storage",
+      },
+    );
+
+    expect(result).toEqual({ appliedAs: "steer" });
+    expect(runtime.waitForActiveTurn).toHaveBeenCalledWith("thread-1", {
+      timeoutMs: 5_000,
+    });
+    expect(runtime.steerTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientRequestId: "creq_turn_submit",
+        expectedTurnId: "turn-starting",
+        threadId: "thread-1",
+      }),
+    );
+    expect(runtime.runTurn).not.toHaveBeenCalled();
+  });
+
+  it("rebases auto input onto the daemon's newer active turn", async () => {
+    const runtime = createRuntime();
+    const manager = new RuntimeManager({
+      createRuntime: () => runtime,
+      provisionWorkspace: async () => createWorkspace(),
+    });
+    await manager.ensureEnvironment({
+      environmentId: "env-1",
+      workspacePath: WORKSPACE_PATH,
+    });
+    runtime.setActiveTurn("thread-1", "turn-new");
+
+    const result = await dispatchCommand(
+      createTurnSubmitCommand({
+        mode: "auto",
+        expectedTurnId: "turn-old",
+      }),
+      {
+        dataDir: "/tmp/bb-data",
+        logger: silentLogger,
+        eventSink: { emit: vi.fn(), flush: vi.fn(async () => undefined) },
+        fetchProjectAttachment: async () => {
+          throw new Error("Unexpected project attachment fetch");
+        },
+        runtimeManager: manager,
+        threadStorageRootPath: "/tmp/bb-thread-storage",
+      },
+    );
+
+    expect(result).toEqual({ appliedAs: "steer" });
+    expect(runtime.steerTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedTurnId: "turn-new" }),
+    );
+    expect(runtime.runTurn).not.toHaveBeenCalled();
+  });
+
+  it("starts auto input immediately when the prior turn already completed", async () => {
+    const runtime = createRuntime();
+    const manager = new RuntimeManager({
+      createRuntime: () => runtime,
+      provisionWorkspace: async () => createWorkspace(),
+    });
+    await manager.ensureEnvironment({
+      environmentId: "env-1",
+      workspacePath: WORKSPACE_PATH,
+    });
+    runtime.setIdle("thread-1");
+
+    const result = await dispatchCommand(
+      createTurnSubmitCommand({ mode: "auto", expectedTurnId: null }),
+      {
+        dataDir: "/tmp/bb-data",
+        logger: silentLogger,
+        eventSink: { emit: vi.fn(), flush: vi.fn(async () => undefined) },
+        fetchProjectAttachment: async () => {
+          throw new Error("Unexpected project attachment fetch");
+        },
+        runtimeManager: manager,
+        threadStorageRootPath: "/tmp/bb-thread-storage",
+      },
+    );
+
+    expect(result).toEqual({ appliedAs: "new-turn" });
+    expect(runtime.waitForActiveTurn).not.toHaveBeenCalled();
+    expect(runtime.runTurn).toHaveBeenCalledOnce();
+  });
+
   it("flushes buffered events before reporting thread.stop success", async () => {
     const runtime = createRuntime();
     const manager = new RuntimeManager({

--- a/apps/host-daemon/src/command-dispatch.test.ts
+++ b/apps/host-daemon/src/command-dispatch.test.ts
@@ -502,6 +502,41 @@ describe("dispatchCommand", () => {
     expect(runtime.runTurn).toHaveBeenCalledOnce();
   });
 
+  it("rejects auto input when a pending turn still has no id after the wait", async () => {
+    const runtime = createRuntime();
+    const manager = new RuntimeManager({
+      createRuntime: () => runtime,
+      provisionWorkspace: async () => createWorkspace(),
+    });
+    await manager.ensureEnvironment({
+      environmentId: "env-1",
+      workspacePath: WORKSPACE_PATH,
+    });
+    runtime.setIdle("thread-1");
+    vi.mocked(runtime.getLiveThreadIds).mockReturnValue(["thread-1"]);
+    vi.mocked(runtime.waitForActiveTurn).mockResolvedValueOnce(null);
+
+    await expect(
+      dispatchCommand(
+        createTurnSubmitCommand({ mode: "auto", expectedTurnId: null }),
+        {
+          dataDir: "/tmp/bb-data",
+          logger: silentLogger,
+          eventSink: { emit: vi.fn(), flush: vi.fn(async () => undefined) },
+          fetchProjectAttachment: async () => {
+            throw new Error("Unexpected project attachment fetch");
+          },
+          runtimeManager: manager,
+          threadStorageRootPath: "/tmp/bb-thread-storage",
+        },
+      ),
+    ).rejects.toThrow(
+      "Refusing to start a competing turn while thread-1 is still starting",
+    );
+    expect(runtime.runTurn).not.toHaveBeenCalled();
+    expect(runtime.steerTurn).not.toHaveBeenCalled();
+  });
+
   it("flushes buffered events before reporting thread.stop success", async () => {
     const runtime = createRuntime();
     const manager = new RuntimeManager({

--- a/apps/host-daemon/src/command-handlers/thread.ts
+++ b/apps/host-daemon/src/command-handlers/thread.ts
@@ -26,7 +26,8 @@ type ExistingThreadRuntimeCommand =
 // it. An auto/steer submit created in that gap carries no expected turn id even
 // though the preceding command is already opening one. The daemon serializes
 // turn submissions, so give the runtime-owned turn state a bounded chance to
-// catch up before treating the input as a separate turn.
+// catch up. If it is still pending after that bound, fail closed rather than
+// launch a competing turn.
 const TURN_SUBMIT_ACTIVE_TURN_WAIT_MS = 5_000;
 
 interface ResumeThreadRuntimeIfMissingArgs {
@@ -427,9 +428,27 @@ async function resolveSubmittedTurnTarget(
   if (!entry.runtime.getLiveThreadIds().includes(command.threadId)) {
     return null;
   }
-  return await entry.runtime.waitForActiveTurn(command.threadId, {
-    timeoutMs: TURN_SUBMIT_ACTIVE_TURN_WAIT_MS,
-  });
+  const awaitedTurnId = await entry.runtime.waitForActiveTurn(
+    command.threadId,
+    {
+      timeoutMs: TURN_SUBMIT_ACTIVE_TURN_WAIT_MS,
+    },
+  );
+  if (awaitedTurnId !== null) {
+    return awaitedTurnId;
+  }
+  // The timeout and provider event can race. Re-read both facts before
+  // deciding whether the previous start completed or remains unresolved.
+  const refreshedTurnId = entry.runtime.getActiveTurnId(command.threadId);
+  if (refreshedTurnId !== null) {
+    return refreshedTurnId;
+  }
+  if (entry.runtime.getLiveThreadIds().includes(command.threadId)) {
+    throw new Error(
+      `Refusing to start a competing turn while ${command.threadId} is still starting`,
+    );
+  }
+  return null;
 }
 
 export async function submitTurn(

--- a/apps/host-daemon/src/command-handlers/thread.ts
+++ b/apps/host-daemon/src/command-handlers/thread.ts
@@ -22,6 +22,13 @@ type ExistingThreadRuntimeCommand =
   | TurnSubmitCommand
   | CommandOf<"thread.goal.clear">;
 
+// The server marks a thread active before the provider's turn/started reaches
+// it. An auto/steer submit created in that gap carries no expected turn id even
+// though the preceding command is already opening one. The daemon serializes
+// turn submissions, so give the runtime-owned turn state a bounded chance to
+// catch up before treating the input as a separate turn.
+const TURN_SUBMIT_ACTIVE_TURN_WAIT_MS = 5_000;
+
 interface ResumeThreadRuntimeIfMissingArgs {
   command: ExistingThreadRuntimeCommand;
   entry: RuntimeEntry;
@@ -392,6 +399,39 @@ async function steerSubmittedTurn(
   );
 }
 
+async function resolveSubmittedTurnTarget(
+  command: TurnSubmitCommand,
+  entry: RuntimeEntry,
+): Promise<string | null> {
+  if (command.target.mode === "start") {
+    return null;
+  }
+  // Explicit steer preserves its vouched target. Auto mode intentionally
+  // rebases onto the daemon's live turn when the server snapshot is stale.
+  if (
+    command.target.mode === "steer" &&
+    command.target.expectedTurnId !== null
+  ) {
+    return command.target.expectedTurnId;
+  }
+  const activeTurnId = entry.runtime.getActiveTurnId(command.threadId);
+  if (activeTurnId !== null) {
+    return activeTurnId;
+  }
+  if (command.target.expectedTurnId !== null) {
+    return command.target.expectedTurnId;
+  }
+  // With no active id, a live thread means the runtime has accepted a start
+  // whose turn/started event is still pending. If that prior turn already
+  // completed, it is no longer live and this input can start immediately.
+  if (!entry.runtime.getLiveThreadIds().includes(command.threadId)) {
+    return null;
+  }
+  return await entry.runtime.waitForActiveTurn(command.threadId, {
+    timeoutMs: TURN_SUBMIT_ACTIVE_TURN_WAIT_MS,
+  });
+}
+
 export async function submitTurn(
   command: TurnSubmitCommand,
   entry: RuntimeEntry,
@@ -416,27 +456,23 @@ export async function submitTurn(
       entry,
       options,
     });
+    const resolvedTurnId = await resolveSubmittedTurnTarget(
+      stagedCommand,
+      entry,
+    );
     switch (command.target.mode) {
       case "start":
         return await runSubmittedTurn(stagedCommand, entry);
       case "auto":
-        return command.target.expectedTurnId
-          ? await steerSubmittedTurn(
-              stagedCommand,
-              entry,
-              command.target.expectedTurnId,
-            )
+        return resolvedTurnId
+          ? await steerSubmittedTurn(stagedCommand, entry, resolvedTurnId)
           : await runSubmittedTurn(stagedCommand, entry);
       case "steer":
-        if (!command.target.expectedTurnId) {
+        if (!resolvedTurnId) {
           // The server saw no active turn, but the user's intent is still "send".
           return await runSubmittedTurn(stagedCommand, entry);
         }
-        return await steerSubmittedTurn(
-          stagedCommand,
-          entry,
-          command.target.expectedTurnId,
-        );
+        return await steerSubmittedTurn(stagedCommand, entry, resolvedTurnId);
     }
   } catch (error) {
     await cleanupAfterPostStagingFailure(staged.cleanup);

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -428,7 +428,8 @@ export type TurnSubmitTarget = z.infer<typeof turnSubmitTargetSchema>;
  * auto-targeted input steers the live active turn or starts a new turn. The
  * nullable expected id is the server's snapshot; the daemon rechecks its
  * runtime so input sent while turn/started is still in flight is not mistaken
- * for a competing turn.
+ * for a competing turn, and rejects instead of starting another turn if the
+ * pending start does not produce an id within its bounded wait.
  */
 const turnSubmitCommandSchema = hostDaemonThreadTargetSchema
   .extend({

--- a/packages/host-daemon-contract/src/commands.ts
+++ b/packages/host-daemon-contract/src/commands.ts
@@ -425,7 +425,10 @@ export type TurnSubmitTarget = z.infer<typeof turnSubmitTargetSchema>;
 
 /**
  * Submit input for an existing provider thread. The daemon chooses whether
- * auto-targeted input steers the expected active turn or starts a new turn.
+ * auto-targeted input steers the live active turn or starts a new turn. The
+ * nullable expected id is the server's snapshot; the daemon rechecks its
+ * runtime so input sent while turn/started is still in flight is not mistaken
+ * for a competing turn.
  */
 const turnSubmitCommandSchema = hostDaemonThreadTargetSchema
   .extend({

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -1,3 +1,9 @@
+// Version 151 lets the daemon re-resolve an auto/steer turn target from its
+// live runtime after the server observed an active thread but before it had a
+// turn id. A command that an older daemon reports as `appliedAs: "new-turn"`
+// can now report `appliedAs: "steer"`, preventing a child/system notification
+// from replacing the user turn that was still starting.
+//
 // Version 150 adds an OPTIONAL `presentation` to each bb-injected tool
 // definition (`dynamicTools[]` on thread.start, turn.submit and the resume
 // contexts): how a call to the tool reads as a timeline row (grammar v3),
@@ -154,7 +160,7 @@
 //
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 150 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 151 as const;
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1045,6 +1045,9 @@ const BRIDGE_LAUNCH = {
 } as const;
 
 describe("host-daemon command schemas", () => {
+  // Version 151 makes auto/steer turn targeting use the daemon's live turn
+  // state, so the same command can report steer where an older daemon reported
+  // new-turn.
   // Version 142 moves built-in ACP discovery into provider bridges and carries
   // provider-owned static bridge options plus installation capability facts.
   // Version 138 adds the provider-targeted provider.health command, changes
@@ -1128,7 +1131,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(150);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(151);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 

--- a/plugins/provider-codex/src/bridge/bridge.session-signature.test.ts
+++ b/plugins/provider-codex/src/bridge/bridge.session-signature.test.ts
@@ -28,6 +28,18 @@ const sessionOptions = {
   permissionEscalation: null,
 } as const;
 
+const autoAskSessionOptions = {
+  permissionMode: "auto",
+  permissionScope: "workspace",
+  approvalReviewer: "automatic",
+  permissionEscalation: "ask",
+} as const;
+
+const autoDenySessionOptions = {
+  ...autoAskSessionOptions,
+  permissionEscalation: "deny",
+} as const;
+
 let harness: ReturnType<typeof createBridgeJsonRpcTestHarness>;
 let workspaceDir: string;
 
@@ -73,6 +85,34 @@ it("keeps the constructed session for a turn whose options carry no envVars", as
     input: [{ type: "text", text: "say hello", mentions: [] }],
     // The runtime never carries envVars on a turn.
     options: { ...sessionOptions },
+  });
+  const turn = await harness.waitForResponse(2);
+
+  expect(turn.error).toBeUndefined();
+  expect(
+    harness.messages.filter((message) => message.method === "session/replaced"),
+  ).toEqual([]);
+}, 30_000);
+
+it("keeps an auto-reviewed session when only escalation intent changes", async () => {
+  harness.sendRequest(1, "thread/start", {
+    threadId: THREAD_ID,
+    cwd: workspaceDir,
+    instructionMode: "append",
+    options: autoAskSessionOptions,
+  });
+  const started = await harness.waitForResponse(1);
+  const providerThreadId = (started.result as { providerThreadId: string })
+    .providerThreadId;
+
+  harness.sendRequest(2, "turn/start", {
+    threadId: THREAD_ID,
+    providerThreadId,
+    clientRequestId: "creq_signature3",
+    input: [{ type: "text", text: "say hello", mentions: [] }],
+    // User and system turns carry ask/deny respectively. Automatic review
+    // maps both to the same effective Codex permission settings.
+    options: autoDenySessionOptions,
   });
   const turn = await harness.waitForResponse(2);
 

--- a/plugins/provider-codex/src/bridge/bridge.ts
+++ b/plugins/provider-codex/src/bridge/bridge.ts
@@ -94,6 +94,7 @@ import {
   toCodexDynamicTools,
   toCodexPermissionSettings,
   toCodexServiceTier,
+  toCodexThreadPermissionSettings,
   toCodexUserInput,
   type BbThreadForkParams,
   type BbThreadStartParams,
@@ -478,8 +479,12 @@ function decodeCodexOptions(
 
 /**
  * The construction-scoped option facts. A turn arriving with a different set
- * rebuilds the provider session, reported via session/replaced. Model and
- * serviceTier are deliberately absent: they ride every codex turn/start.
+ * rebuilds the provider session, reported via session/replaced. Compare the
+ * effective Codex permissions, not bb's source policy: auto-reviewed user and
+ * system turns differ in permissionEscalation (`ask` versus `deny`) but both
+ * map to the same Codex construction settings and must keep one session.
+ * Model and serviceTier are deliberately absent: they ride every codex
+ * turn/start.
  *
  * envVars is deliberately absent too: the runtime builds the shell
  * environment only for session-construction commands and sends
@@ -492,15 +497,15 @@ function constructionSignature(
   cwd: string,
   sessionOptions: CodexSessionOptions,
 ): string {
+  const permissionSettings = toCodexThreadPermissionSettings(sessionOptions);
   return JSON.stringify({
     cwd,
     reasoningLevel: sessionOptions.reasoningLevel ?? null,
     memoryEnabled: sessionOptions.memoryEnabled ?? null,
     providerSubagentsEnabled: sessionOptions.providerSubagentsEnabled ?? null,
-    permissionMode: sessionOptions.permissionMode,
-    permissionScope: sessionOptions.permissionScope,
-    approvalReviewer: sessionOptions.approvalReviewer,
-    permissionEscalation: sessionOptions.permissionEscalation,
+    approvalPolicy: permissionSettings.approvalPolicy,
+    approvalsReviewer: permissionSettings.approvalsReviewer,
+    sandbox: permissionSettings.sandbox,
   });
 }
 


### PR DESCRIPTION
## What was wrong

The server can mark a thread active before the provider's `turn/started` id reaches it. An auto-targeted message created in that window carried `expectedTurnId: null`, so the shared host-daemon handler started a competing turn instead of steering the turn already opening; for Codex, user and system turns then also produced different construction signatures from raw `permissionEscalation` values even though automatic review mapped them to identical effective permissions, causing an unnecessary session rebuild that could terminate the accepted user turn. See #2241 and the [production thread](https://ymichael.getbb.app/projects/proj_qrv2s45kmq/threads/thr_7ccj7nuz57).

## What changed

- Resolve auto-targeted submissions against the daemon's live active-turn state, rebase stale snapshots, and wait up to five seconds when a provider turn start is already pending.
- Recheck after that wait: start normally if the prior start settled idle, steer if its id arrived, or reject with a visible command error if it remains pending. A slow provider start can no longer fall back to a competing turn.
- Preserve vouched ids for explicit steer requests.
- Build the Codex session signature from effective approval policy, approval reviewer, and sandbox settings instead of bb's raw permission intent.
- Add regression coverage for pending starts, stale ids, completed prior turns, a pending-start timeout, and Codex auto-review session reuse.
- Bump `HOST_DAEMON_PROTOCOL_VERSION` from 150 to 151 because the same `turn.submit` command can now report `appliedAs: "steer"` instead of `appliedAs: "new-turn"`.

## How you verified

- `pnpm exec turbo run test --filter=@bb/host-daemon --force -- src/command-dispatch.test.ts` — 31 tests passed.
- `pnpm exec turbo run test --filter=bb-plugin-provider-codex --force -- src/bridge/bridge.session-signature.test.ts` — 2 tests passed.
- `pnpm exec turbo run test --filter=@bb/host-daemon-contract --force -- test/contract.test.ts` — 38 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon`
- `pnpm exec turbo run typecheck --filter=bb-plugin-provider-codex`
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon-contract`

A broader combined package test run also reached an existing environment-sensitive gzip byte-count mismatch in `payload-size.test.ts`; uncompressed JSON byte counts were unchanged, and the targeted contract test above passes.

Fixes #2241

> AGENT GENERATED: by GPT-5
