### PR TITLE
Add reactive plugin appearance and built-in palette contracts

### DIFF
--- a/apps/app/src/components/AppToaster.tsx
+++ b/apps/app/src/components/AppToaster.tsx
@@ -1,7 +1,7 @@
 import { Toaster, type ToasterProps } from "sonner";
-import { usePreferredTheme } from "@/hooks/useTheme";
+import { experimental_useAppearance } from "@/lib/plugin-appearance";
 
 export function AppToaster(props: ToasterProps) {
-  const theme = usePreferredTheme();
-  return <Toaster theme={theme} {...props} />;
+  const { colorMode } = experimental_useAppearance();
+  return <Toaster theme={colorMode} {...props} />;
 }

--- a/apps/app/src/components/AppToaster.tsx
+++ b/apps/app/src/components/AppToaster.tsx
@@ -1,7 +1,7 @@
 import { Toaster, type ToasterProps } from "sonner";
-import { experimental_useAppearance } from "@/lib/plugin-appearance";
+import { usePluginAppearance } from "@/lib/plugin-appearance";
 
 export function AppToaster(props: ToasterProps) {
-  const { colorMode } = experimental_useAppearance();
+  const { colorMode } = usePluginAppearance();
   return <Toaster theme={colorMode} {...props} />;
 }

--- a/apps/app/src/components/AppToaster.tsx
+++ b/apps/app/src/components/AppToaster.tsx
@@ -1,7 +1,7 @@
 import { Toaster, type ToasterProps } from "sonner";
-import { usePluginAppearance } from "@/lib/plugin-appearance";
+import { usePreferredTheme } from "@/hooks/useTheme";
 
 export function AppToaster(props: ToasterProps) {
-  const { colorMode } = usePluginAppearance();
-  return <Toaster theme={colorMode} {...props} />;
+  const theme = usePreferredTheme();
+  return <Toaster theme={theme} {...props} />;
 }

--- a/apps/app/src/components/plugin/PluginSidebarFooterActions.test.tsx
+++ b/apps/app/src/components/plugin/PluginSidebarFooterActions.test.tsx
@@ -145,41 +145,4 @@ describe("PluginSidebarFooterActions", () => {
       "/settings/plugins/remote",
     );
   });
-
-  it("passes the latest semantic appearance at activation time", () => {
-    setPreferredTheme("dark");
-    const activations: Array<{ colorMode: string; preference: string }> = [];
-    setPluginSlotRegistrations(
-      "appearance",
-      registrationSet({
-        sidebarFooterActions: [
-          {
-            id: "toggle",
-            title: "Toggle color mode",
-            icon: "Palette",
-            run({ experimental_appearance: appearance }) {
-              activations.push({
-                colorMode: appearance.colorMode,
-                preference: appearance.colorModePreference,
-              });
-              appearance.setColorModePreference(
-                appearance.colorMode === "dark" ? "light" : "dark",
-              );
-            },
-          },
-        ],
-      }),
-    );
-
-    renderWithProviders(<PluginSidebarFooterActions />);
-    const toggle = screen.getByRole("button", { name: "Toggle color mode" });
-    fireEvent.click(toggle);
-    fireEvent.click(toggle);
-
-    expect(activations).toEqual([
-      { colorMode: "dark", preference: "dark" },
-      { colorMode: "light", preference: "light" },
-    ]);
-    expect(document.documentElement.classList.contains("dark")).toBe(true);
-  });
 });

--- a/apps/app/src/components/plugin/PluginSidebarFooterActions.test.tsx
+++ b/apps/app/src/components/plugin/PluginSidebarFooterActions.test.tsx
@@ -13,6 +13,7 @@ import {
   resetPluginLogoStoreForTest,
   setPluginLogoUrls,
 } from "@/lib/plugin-logos";
+import { setPreferredTheme } from "@/hooks/useTheme";
 import { PluginSidebarFooterActions } from "./PluginSidebarFooterActions";
 
 function registrationSet(
@@ -55,6 +56,7 @@ afterEach(() => {
   cleanup();
   resetPluginSlotStoreForTest();
   resetPluginLogoStoreForTest();
+  setPreferredTheme("system");
   vi.restoreAllMocks();
 });
 
@@ -142,5 +144,42 @@ describe("PluginSidebarFooterActions", () => {
     expect(screen.getByLabelText("Current path").textContent).toBe(
       "/settings/plugins/remote",
     );
+  });
+
+  it("passes the latest semantic appearance at activation time", () => {
+    setPreferredTheme("dark");
+    const activations: Array<{ colorMode: string; preference: string }> = [];
+    setPluginSlotRegistrations(
+      "appearance",
+      registrationSet({
+        sidebarFooterActions: [
+          {
+            id: "toggle",
+            title: "Toggle color mode",
+            icon: "Palette",
+            run({ experimental_appearance: appearance }) {
+              activations.push({
+                colorMode: appearance.colorMode,
+                preference: appearance.colorModePreference,
+              });
+              appearance.setColorModePreference(
+                appearance.colorMode === "dark" ? "light" : "dark",
+              );
+            },
+          },
+        ],
+      }),
+    );
+
+    renderWithProviders(<PluginSidebarFooterActions />);
+    const toggle = screen.getByRole("button", { name: "Toggle color mode" });
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+
+    expect(activations).toEqual([
+      { colorMode: "dark", preference: "dark" },
+      { colorMode: "light", preference: "light" },
+    ]);
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
   });
 });

--- a/apps/app/src/components/plugin/PluginSidebarFooterActions.tsx
+++ b/apps/app/src/components/plugin/PluginSidebarFooterActions.tsx
@@ -3,6 +3,7 @@ import { cn } from "@bb/shared-ui/lib/utils";
 import { COARSE_POINTER_CHILD_ICON_BUTTON_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import { SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar.js";
 import { PluginIcon } from "@/components/plugin/PluginIcon";
+import { usePluginAppearance } from "@/lib/plugin-appearance";
 import {
   usePluginSlots,
   type PluginSidebarFooterActionSlot,
@@ -39,6 +40,7 @@ function PluginSidebarFooterActionList({
   onNavigate?: () => void;
 }) {
   const navigate = useNavigate();
+  const appearance = usePluginAppearance();
   return (
     <>
       {actions.map((action) => (
@@ -59,6 +61,7 @@ function PluginSidebarFooterActionList({
               onNavigate?.();
               runSidebarFooterAction({
                 action,
+                appearance,
                 navigate,
               });
             }}
@@ -74,9 +77,11 @@ function PluginSidebarFooterActionList({
 
 function runSidebarFooterAction({
   action,
+  appearance,
   navigate,
 }: {
   action: PluginSidebarFooterActionSlot;
+  appearance: ReturnType<typeof usePluginAppearance>;
   navigate: ReturnType<typeof useNavigate>;
 }): void {
   const openSettings = () => {
@@ -92,7 +97,10 @@ function runSidebarFooterAction({
     );
   };
   try {
-    const result = action.run({ openSettings });
+    const result = action.run({
+      openSettings,
+      experimental_appearance: appearance,
+    });
     if (result instanceof Promise) result.catch(warn);
   } catch (error) {
     warn(error);

--- a/apps/app/src/components/plugin/PluginSidebarFooterActions.tsx
+++ b/apps/app/src/components/plugin/PluginSidebarFooterActions.tsx
@@ -3,7 +3,6 @@ import { cn } from "@bb/shared-ui/lib/utils";
 import { COARSE_POINTER_CHILD_ICON_BUTTON_CLASS } from "@bb/shared-ui/coarse-pointer-sizing";
 import { SidebarMenuButton, SidebarMenuItem } from "@/components/ui/sidebar.js";
 import { PluginIcon } from "@/components/plugin/PluginIcon";
-import { usePluginAppearance } from "@/lib/plugin-appearance";
 import {
   usePluginSlots,
   type PluginSidebarFooterActionSlot,
@@ -40,7 +39,6 @@ function PluginSidebarFooterActionList({
   onNavigate?: () => void;
 }) {
   const navigate = useNavigate();
-  const appearance = usePluginAppearance();
   return (
     <>
       {actions.map((action) => (
@@ -61,7 +59,6 @@ function PluginSidebarFooterActionList({
               onNavigate?.();
               runSidebarFooterAction({
                 action,
-                appearance,
                 navigate,
               });
             }}
@@ -77,11 +74,9 @@ function PluginSidebarFooterActionList({
 
 function runSidebarFooterAction({
   action,
-  appearance,
   navigate,
 }: {
   action: PluginSidebarFooterActionSlot;
-  appearance: ReturnType<typeof usePluginAppearance>;
   navigate: ReturnType<typeof useNavigate>;
 }): void {
   const openSettings = () => {
@@ -99,7 +94,6 @@ function runSidebarFooterAction({
   try {
     const result = action.run({
       openSettings,
-      experimental_appearance: appearance,
     });
     if (result instanceof Promise) result.catch(warn);
   } catch (error) {

--- a/apps/app/src/hooks/useTheme.ts
+++ b/apps/app/src/hooks/useTheme.ts
@@ -15,11 +15,10 @@ export type ThemePreference = Theme | "system";
 
 type ThemeListener = () => void;
 
-const themePreferenceStorage =
-  createLocalStorageEnumStorage<ThemePreference>(
-    (value): value is ThemePreference =>
-      value === "light" || value === "dark" || value === "system",
-  );
+const themePreferenceStorage = createLocalStorageEnumStorage<ThemePreference>(
+  (value): value is ThemePreference =>
+    value === "light" || value === "dark" || value === "system",
+);
 const themePreferenceAtom = atomWithStorage<ThemePreference>(
   THEME_STORAGE_KEY,
   "system",
@@ -27,7 +26,7 @@ const themePreferenceAtom = atomWithStorage<ThemePreference>(
   { getOnInit: true },
 );
 
-function getThemePreference(): ThemePreference {
+export function getThemePreference(): ThemePreference {
   return getDefaultStore().get(themePreferenceAtom);
 }
 
@@ -67,7 +66,7 @@ function getSystemTheme(): Theme {
   return getMediaQuerySnapshot(DARK_COLOR_SCHEME_QUERY) ? "dark" : "light";
 }
 
-function getPreferredTheme(): Theme {
+export function getPreferredTheme(): Theme {
   const themePreference = getThemePreference();
   return themePreference === "system" ? getSystemTheme() : themePreference;
 }
@@ -89,8 +88,7 @@ function emitTheme() {
   const nextTheme = getPreferredTheme();
   applyThemeClass(nextTheme);
 
-  const themePreferenceChanged =
-    nextThemePreference !== currentThemePreference;
+  const themePreferenceChanged = nextThemePreference !== currentThemePreference;
   const themeChanged = nextTheme !== currentTheme;
 
   currentThemePreference = nextThemePreference;

--- a/apps/app/src/hooks/useTheme.ts
+++ b/apps/app/src/hooks/useTheme.ts
@@ -81,6 +81,7 @@ let currentTheme: Theme = "light";
 let currentThemePreference: ThemePreference = "system";
 const themeSubscribers = new Set<ThemeListener>();
 const themePreferenceSubscribers = new Set<ThemeListener>();
+const themeAppearanceSubscribers = new Set<ThemeListener>();
 let initialized = false;
 
 function emitTheme() {
@@ -99,6 +100,9 @@ function emitTheme() {
   }
   if (themeChanged) {
     themeSubscribers.forEach((listener) => listener());
+  }
+  if (themePreferenceChanged || themeChanged) {
+    themeAppearanceSubscribers.forEach((listener) => listener());
   }
 }
 
@@ -151,4 +155,13 @@ export function useThemePreference(): ThemePreference {
     getThemePreference,
     () => "system",
   );
+}
+
+/** Subscribe once when either the selected preference or resolved mode changes. */
+export function subscribeThemeAppearance(listener: ThemeListener): () => void {
+  ensureThemeObserver();
+  themeAppearanceSubscribers.add(listener);
+  return () => {
+    themeAppearanceSubscribers.delete(listener);
+  };
 }

--- a/apps/app/src/lib/plugin-appearance.test.tsx
+++ b/apps/app/src/lib/plugin-appearance.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { experimental_useAppearance } from "./plugin-appearance";
+
+function installColorMode(initial: "light" | "dark"): {
+  setColorMode(mode: "light" | "dark"): void;
+} {
+  let mode = initial;
+  const listeners = new Set<EventListenerOrEventListenerObject>();
+  const mediaQuery: MediaQueryList = {
+    get matches() {
+      return mode === "dark";
+    },
+    media: "(prefers-color-scheme: dark)",
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener(
+      _type: string,
+      listener: EventListenerOrEventListenerObject,
+    ) {
+      listeners.add(listener);
+    },
+    removeEventListener(
+      _type: string,
+      listener: EventListenerOrEventListenerObject,
+    ) {
+      listeners.delete(listener);
+    },
+    dispatchEvent(event) {
+      for (const listener of listeners) {
+        if (typeof listener === "function") listener.call(mediaQuery, event);
+        else listener.handleEvent(event);
+      }
+      return true;
+    },
+  };
+  window.matchMedia = vi.fn(() => mediaQuery);
+  return {
+    setColorMode(next) {
+      mode = next;
+      mediaQuery.dispatchEvent(new Event("change"));
+    },
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("experimental_useAppearance", () => {
+  it("maps preference and system changes to semantic client appearance", () => {
+    const system = installColorMode("dark");
+    const { result } = renderHook(() => experimental_useAppearance());
+
+    expect(result.current.colorModePreference).toBe("system");
+    expect(result.current.colorMode).toBe("dark");
+
+    act(() => result.current.setColorModePreference("light"));
+    expect(result.current.colorModePreference).toBe("light");
+    expect(result.current.colorMode).toBe("light");
+
+    act(() => result.current.setColorModePreference("system"));
+    expect(result.current.colorModePreference).toBe("system");
+    expect(result.current.colorMode).toBe("dark");
+
+    act(() => system.setColorMode("light"));
+    expect(result.current.colorModePreference).toBe("system");
+    expect(result.current.colorMode).toBe("light");
+  });
+});

--- a/apps/app/src/lib/plugin-appearance.test.tsx
+++ b/apps/app/src/lib/plugin-appearance.test.tsx
@@ -2,7 +2,10 @@
 
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { usePluginAppearance } from "./plugin-appearance";
+import {
+  pluginAppearanceStore,
+  usePluginAppearance,
+} from "./plugin-appearance";
 
 function installColorMode(initial: "light" | "dark"): {
   setColorMode(mode: "light" | "dark"): void;
@@ -53,24 +56,33 @@ afterEach(() => {
 });
 
 describe("experimental_useAppearance", () => {
-  it("maps preference and system changes to semantic client appearance", () => {
+  it("shares stable, reactive semantic snapshots across store and hook", () => {
     const system = installColorMode("dark");
+    const notifications = vi.fn();
+    const unsubscribe = pluginAppearanceStore.subscribe(notifications);
     const { result } = renderHook(() => usePluginAppearance());
 
     expect(result.current.colorModePreference).toBe("system");
     expect(result.current.colorMode).toBe("dark");
+    expect(pluginAppearanceStore.getSnapshot()).toBe(result.current);
+    expect(pluginAppearanceStore.getSnapshot()).toBe(
+      pluginAppearanceStore.getSnapshot(),
+    );
 
     act(() => result.current.setColorModePreference("light"));
     expect(result.current.colorModePreference).toBe("light");
     expect(result.current.colorMode).toBe("light");
+    expect(notifications).toHaveBeenCalledTimes(1);
 
     act(() => result.current.setColorModePreference("system"));
     expect(result.current.colorModePreference).toBe("system");
     expect(result.current.colorMode).toBe("dark");
+    expect(notifications).toHaveBeenCalledTimes(2);
 
     act(() => system.setColorMode("light"));
     expect(result.current.colorModePreference).toBe("system");
     expect(result.current.colorMode).toBe("light");
+    expect(notifications).toHaveBeenCalledTimes(3);
 
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     act(() =>
@@ -83,5 +95,7 @@ describe("experimental_useAppearance", () => {
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('expected "light", "dark", or "system"'),
     );
+    expect(notifications).toHaveBeenCalledTimes(3);
+    unsubscribe();
   });
 });

--- a/apps/app/src/lib/plugin-appearance.test.tsx
+++ b/apps/app/src/lib/plugin-appearance.test.tsx
@@ -2,7 +2,7 @@
 
 import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { experimental_useAppearance } from "./plugin-appearance";
+import { usePluginAppearance } from "./plugin-appearance";
 
 function installColorMode(initial: "light" | "dark"): {
   setColorMode(mode: "light" | "dark"): void;
@@ -55,7 +55,7 @@ afterEach(() => {
 describe("experimental_useAppearance", () => {
   it("maps preference and system changes to semantic client appearance", () => {
     const system = installColorMode("dark");
-    const { result } = renderHook(() => experimental_useAppearance());
+    const { result } = renderHook(() => usePluginAppearance());
 
     expect(result.current.colorModePreference).toBe("system");
     expect(result.current.colorMode).toBe("dark");

--- a/apps/app/src/lib/plugin-appearance.test.tsx
+++ b/apps/app/src/lib/plugin-appearance.test.tsx
@@ -71,5 +71,17 @@ describe("experimental_useAppearance", () => {
     act(() => system.setColorMode("light"));
     expect(result.current.colorModePreference).toBe("system");
     expect(result.current.colorMode).toBe("light");
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    act(() =>
+      (result.current.setColorModePreference as (preference: string) => void)(
+        "sepia",
+      ),
+    );
+    expect(result.current.colorModePreference).toBe("system");
+    expect(result.current.colorMode).toBe("light");
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('expected "light", "dark", or "system"'),
+    );
   });
 });

--- a/apps/app/src/lib/plugin-appearance.ts
+++ b/apps/app/src/lib/plugin-appearance.ts
@@ -1,11 +1,13 @@
-import { useMemo } from "react";
-import type { ExperimentalPluginAppearance } from "@get-bb/plugin-sdk";
+import { useSyncExternalStore } from "react";
+import type {
+  ExperimentalPluginAppearance,
+  ExperimentalPluginAppearanceStore,
+} from "@get-bb/plugin-sdk";
 import {
   getPreferredTheme,
   getThemePreference,
   setPreferredTheme,
-  usePreferredTheme,
-  useThemePreference,
+  subscribeThemeAppearance,
 } from "@/hooks/useTheme";
 
 function setPluginColorModePreference(
@@ -24,25 +26,43 @@ function setPluginColorModePreference(
   setPreferredTheme(preference);
 }
 
-/** Current semantic appearance for plugin callbacks outside React. */
-export function getPluginAppearance(): ExperimentalPluginAppearance {
-  return {
-    colorMode: getPreferredTheme(),
-    colorModePreference: getThemePreference(),
+const serverAppearance: ExperimentalPluginAppearance = {
+  colorMode: "light",
+  colorModePreference: "system",
+  setColorModePreference: setPluginColorModePreference,
+};
+
+let cachedAppearance: ExperimentalPluginAppearance | undefined;
+
+function getPluginAppearanceSnapshot(): ExperimentalPluginAppearance {
+  if (typeof window === "undefined") return serverAppearance;
+  const colorMode = getPreferredTheme();
+  const colorModePreference = getThemePreference();
+  if (
+    cachedAppearance?.colorMode === colorMode &&
+    cachedAppearance.colorModePreference === colorModePreference
+  ) {
+    return cachedAppearance;
+  }
+  cachedAppearance = {
+    colorMode,
+    colorModePreference,
     setColorModePreference: setPluginColorModePreference,
   };
+  return cachedAppearance;
 }
 
-/** Host implementation of the plugin SDK's client appearance contract. */
+/** Host implementation of the app-wide plugin appearance contract. */
+export const pluginAppearanceStore: ExperimentalPluginAppearanceStore = {
+  getSnapshot: getPluginAppearanceSnapshot,
+  subscribe: subscribeThemeAppearance,
+};
+
+/** React convenience wrapper over the app-wide plugin appearance store. */
 export function usePluginAppearance(): ExperimentalPluginAppearance {
-  const colorMode = usePreferredTheme();
-  const colorModePreference = useThemePreference();
-  return useMemo(
-    () => ({
-      colorMode,
-      colorModePreference,
-      setColorModePreference: setPluginColorModePreference,
-    }),
-    [colorMode, colorModePreference],
+  return useSyncExternalStore(
+    pluginAppearanceStore.subscribe,
+    pluginAppearanceStore.getSnapshot,
+    () => serverAppearance,
   );
 }

--- a/apps/app/src/lib/plugin-appearance.ts
+++ b/apps/app/src/lib/plugin-appearance.ts
@@ -1,10 +1,37 @@
 import { useMemo } from "react";
 import type { ExperimentalPluginAppearance } from "@get-bb/plugin-sdk";
 import {
+  getPreferredTheme,
+  getThemePreference,
   setPreferredTheme,
   usePreferredTheme,
   useThemePreference,
 } from "@/hooks/useTheme";
+
+function setPluginColorModePreference(
+  preference: ExperimentalPluginAppearance["colorModePreference"],
+): void {
+  if (
+    preference !== "light" &&
+    preference !== "dark" &&
+    preference !== "system"
+  ) {
+    console.warn(
+      `plugin appearance: expected "light", "dark", or "system"; received ${String(preference)}`,
+    );
+    return;
+  }
+  setPreferredTheme(preference);
+}
+
+/** Current semantic appearance for plugin callbacks outside React. */
+export function getPluginAppearance(): ExperimentalPluginAppearance {
+  return {
+    colorMode: getPreferredTheme(),
+    colorModePreference: getThemePreference(),
+    setColorModePreference: setPluginColorModePreference,
+  };
+}
 
 /** Host implementation of the plugin SDK's client appearance contract. */
 export function usePluginAppearance(): ExperimentalPluginAppearance {
@@ -14,7 +41,7 @@ export function usePluginAppearance(): ExperimentalPluginAppearance {
     () => ({
       colorMode,
       colorModePreference,
-      setColorModePreference: setPreferredTheme,
+      setColorModePreference: setPluginColorModePreference,
     }),
     [colorMode, colorModePreference],
   );

--- a/apps/app/src/lib/plugin-appearance.ts
+++ b/apps/app/src/lib/plugin-appearance.ts
@@ -1,0 +1,21 @@
+import { useMemo } from "react";
+import type { ExperimentalPluginAppearance } from "@get-bb/plugin-sdk";
+import {
+  setPreferredTheme,
+  usePreferredTheme,
+  useThemePreference,
+} from "@/hooks/useTheme";
+
+/** Host implementation of the plugin SDK's client appearance contract. */
+export function experimental_useAppearance(): ExperimentalPluginAppearance {
+  const colorMode = usePreferredTheme();
+  const colorModePreference = useThemePreference();
+  return useMemo(
+    () => ({
+      colorMode,
+      colorModePreference,
+      setColorModePreference: setPreferredTheme,
+    }),
+    [colorMode, colorModePreference],
+  );
+}

--- a/apps/app/src/lib/plugin-appearance.ts
+++ b/apps/app/src/lib/plugin-appearance.ts
@@ -7,7 +7,7 @@ import {
 } from "@/hooks/useTheme";
 
 /** Host implementation of the plugin SDK's client appearance contract. */
-export function experimental_useAppearance(): ExperimentalPluginAppearance {
+export function usePluginAppearance(): ExperimentalPluginAppearance {
   const colorMode = usePreferredTheme();
   const colorModePreference = useThemePreference();
   return useMemo(

--- a/apps/app/src/lib/plugin-frontend-reload.test.ts
+++ b/apps/app/src/lib/plugin-frontend-reload.test.ts
@@ -1,6 +1,9 @@
 // @vitest-environment jsdom
 
-import type { PluginComposerThreadRowStatus } from "@get-bb/plugin-sdk";
+import type {
+  ExperimentalPluginAppearance,
+  PluginComposerThreadRowStatus,
+} from "@get-bb/plugin-sdk";
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
@@ -36,6 +39,7 @@ import { PluginSlotMount } from "@/components/plugin/PluginSlotMount";
 import { PLUGIN_PANEL_ROUTE_PATH } from "./route-paths";
 import { applyAppThemeCss } from "./themes";
 import { PluginPanelView } from "@/views/PluginPanelView";
+import { setPreferredTheme } from "@/hooks/useTheme";
 
 function candidate(
   pluginId: string,
@@ -81,6 +85,7 @@ afterEach(() => {
   resetPluginSlotStoreForTest();
   resetPluginCssForTest();
   uninstallForeignDomMutationGuardForTest();
+  setPreferredTheme("system");
 });
 
 function MountedHomepageSections() {
@@ -499,6 +504,41 @@ describe("reconcilePluginFrontends", () => {
     deps.fetchCandidates.mockResolvedValue([]);
     await reconcilePluginFrontends(state, deps);
     expect(getPluginThreadRowStatus("thr_source")).toBeNull();
+  });
+
+  it("gives content scripts current semantic appearance and rejects stale writes", async () => {
+    setPreferredTheme("dark");
+    const state = createPluginFrontendReconcileState();
+    const deps = makeDeps([candidate("theme-toggle", "v1")]);
+    let getAppearance: (() => ExperimentalPluginAppearance) | undefined;
+    deps.importModule.mockResolvedValue(
+      contentScriptModule((app) => {
+        app.contentScripts.register({
+          id: "appearance-menu",
+          mount({ experimental_getAppearance }) {
+            getAppearance = experimental_getAppearance;
+          },
+        });
+      }),
+    );
+
+    await reconcilePluginFrontends(state, deps);
+    expect(getAppearance?.()).toMatchObject({
+      colorMode: "dark",
+      colorModePreference: "dark",
+    });
+
+    getAppearance?.().setColorModePreference("light");
+    expect(getAppearance?.()).toMatchObject({
+      colorMode: "light",
+      colorModePreference: "light",
+    });
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+
+    deps.fetchCandidates.mockResolvedValue([]);
+    await reconcilePluginFrontends(state, deps);
+    getAppearance?.().setColorModePreference("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
   });
 
   it("rolls back a status from a partially mounted generation and rejects its retained setter", async () => {

--- a/apps/app/src/lib/plugin-frontend-reload.test.ts
+++ b/apps/app/src/lib/plugin-frontend-reload.test.ts
@@ -1,9 +1,6 @@
 // @vitest-environment jsdom
 
-import type {
-  ExperimentalPluginAppearance,
-  PluginComposerThreadRowStatus,
-} from "@get-bb/plugin-sdk";
+import type { PluginComposerThreadRowStatus } from "@get-bb/plugin-sdk";
 import { createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
@@ -504,41 +501,6 @@ describe("reconcilePluginFrontends", () => {
     deps.fetchCandidates.mockResolvedValue([]);
     await reconcilePluginFrontends(state, deps);
     expect(getPluginThreadRowStatus("thr_source")).toBeNull();
-  });
-
-  it("gives content scripts current semantic appearance and rejects stale writes", async () => {
-    setPreferredTheme("dark");
-    const state = createPluginFrontendReconcileState();
-    const deps = makeDeps([candidate("theme-toggle", "v1")]);
-    let getAppearance: (() => ExperimentalPluginAppearance) | undefined;
-    deps.importModule.mockResolvedValue(
-      contentScriptModule((app) => {
-        app.contentScripts.register({
-          id: "appearance-menu",
-          mount({ experimental_getAppearance }) {
-            getAppearance = experimental_getAppearance;
-          },
-        });
-      }),
-    );
-
-    await reconcilePluginFrontends(state, deps);
-    expect(getAppearance?.()).toMatchObject({
-      colorMode: "dark",
-      colorModePreference: "dark",
-    });
-
-    getAppearance?.().setColorModePreference("light");
-    expect(getAppearance?.()).toMatchObject({
-      colorMode: "light",
-      colorModePreference: "light",
-    });
-    expect(document.documentElement.classList.contains("dark")).toBe(false);
-
-    deps.fetchCandidates.mockResolvedValue([]);
-    await reconcilePluginFrontends(state, deps);
-    getAppearance?.().setColorModePreference("dark");
-    expect(document.documentElement.classList.contains("dark")).toBe(false);
   });
 
   it("rolls back a status from a partially mounted generation and rejects its retained setter", async () => {

--- a/apps/app/src/lib/plugin-frontend.ts
+++ b/apps/app/src/lib/plugin-frontend.ts
@@ -49,7 +49,6 @@ import {
 } from "./plugin-app-definition";
 import { setPluginLogoUrls, type PluginLogoUrls } from "./plugin-logos";
 import { createGatedPierreDiffsReact } from "./plugin-pierre-diffs-react";
-import { getPluginAppearance } from "./plugin-appearance";
 import { getPluginPanelRoutePluginId } from "./route-paths";
 import { pluginSdkAppImplementation } from "./plugin-sdk-app-impl";
 import {
@@ -574,16 +573,6 @@ async function mountWithTimeout(
           pluginId,
           generation,
           signal: controller.signal,
-          experimental_getAppearance: () => {
-            const appearance = getPluginAppearance();
-            return {
-              ...appearance,
-              setColorModePreference(preference) {
-                if (controller.signal.aborted) return;
-                appearance.setColorModePreference(preference);
-              },
-            };
-          },
           experimental_setThreadRowStatus: (
             threadId: unknown,
             status: unknown,

--- a/apps/app/src/lib/plugin-frontend.ts
+++ b/apps/app/src/lib/plugin-frontend.ts
@@ -49,6 +49,7 @@ import {
 } from "./plugin-app-definition";
 import { setPluginLogoUrls, type PluginLogoUrls } from "./plugin-logos";
 import { createGatedPierreDiffsReact } from "./plugin-pierre-diffs-react";
+import { getPluginAppearance } from "./plugin-appearance";
 import { getPluginPanelRoutePluginId } from "./route-paths";
 import { pluginSdkAppImplementation } from "./plugin-sdk-app-impl";
 import {
@@ -573,6 +574,16 @@ async function mountWithTimeout(
           pluginId,
           generation,
           signal: controller.signal,
+          experimental_getAppearance: () => {
+            const appearance = getPluginAppearance();
+            return {
+              ...appearance,
+              setColorModePreference(preference) {
+                if (controller.signal.aborted) return;
+                appearance.setColorModePreference(preference);
+              },
+            };
+          },
           experimental_setThreadRowStatus: (
             threadId: unknown,
             status: unknown,

--- a/apps/app/src/lib/plugin-sdk-app-impl.tsx
+++ b/apps/app/src/lib/plugin-sdk-app-impl.tsx
@@ -16,6 +16,7 @@ import type {
 import type { MarkdownPreviewLinkHandler } from "@/components/ui/markdown-link";
 import { useThreadTimelineNavigation } from "@/components/thread/timeline/ThreadTimelineNavigationContext";
 import { definePluginApp } from "./plugin-app-definition";
+import { experimental_useAppearance } from "./plugin-appearance";
 import {
   useBbContext,
   useBbNavigate,
@@ -64,6 +65,7 @@ export const pluginSdkAppImplementation = {
   useRealtimeConnectionState,
   useRpc,
   useSettings,
+  experimental_useAppearance,
   // The host-owned components in the SDK (plugin design: deliberate
   // exception to §5.5) — stable product capabilities, not a UI kit.
   ThreadChat: PluginThreadChat,

--- a/apps/app/src/lib/plugin-sdk-app-impl.tsx
+++ b/apps/app/src/lib/plugin-sdk-app-impl.tsx
@@ -16,7 +16,10 @@ import type {
 import type { MarkdownPreviewLinkHandler } from "@/components/ui/markdown-link";
 import { useThreadTimelineNavigation } from "@/components/thread/timeline/ThreadTimelineNavigationContext";
 import { definePluginApp } from "./plugin-app-definition";
-import { usePluginAppearance } from "./plugin-appearance";
+import {
+  pluginAppearanceStore,
+  usePluginAppearance,
+} from "./plugin-appearance";
 import {
   useBbContext,
   useBbNavigate,
@@ -65,6 +68,7 @@ export const pluginSdkAppImplementation = {
   useRealtimeConnectionState,
   useRpc,
   useSettings,
+  experimental_appearance: pluginAppearanceStore,
   experimental_useAppearance: usePluginAppearance,
   // The host-owned components in the SDK (plugin design: deliberate
   // exception to §5.5) — stable product capabilities, not a UI kit.

--- a/apps/app/src/lib/plugin-sdk-app-impl.tsx
+++ b/apps/app/src/lib/plugin-sdk-app-impl.tsx
@@ -16,7 +16,7 @@ import type {
 import type { MarkdownPreviewLinkHandler } from "@/components/ui/markdown-link";
 import { useThreadTimelineNavigation } from "@/components/thread/timeline/ThreadTimelineNavigationContext";
 import { definePluginApp } from "./plugin-app-definition";
-import { experimental_useAppearance } from "./plugin-appearance";
+import { usePluginAppearance } from "./plugin-appearance";
 import {
   useBbContext,
   useBbNavigate,
@@ -65,7 +65,7 @@ export const pluginSdkAppImplementation = {
   useRealtimeConnectionState,
   useRpc,
   useSettings,
-  experimental_useAppearance,
+  experimental_useAppearance: usePluginAppearance,
   // The host-owned components in the SDK (plugin design: deliberate
   // exception to §5.5) — stable product capabilities, not a UI kit.
   ThreadChat: PluginThreadChat,

--- a/apps/cli/src/commands/theme.ts
+++ b/apps/cli/src/commands/theme.ts
@@ -66,7 +66,7 @@ export function registerThemeCommands(
         if (
           outputJson(opts, {
             active: catalog.active,
-            builtInThemes,
+            builtInThemes: catalog.experimental_builtIn,
             custom: catalog.custom,
             plugins: catalog.plugins,
             dir: catalog.dir,
@@ -77,7 +77,7 @@ export function registerThemeCommands(
         const active = catalog.active.themeId;
         console.log("");
         console.log("Built-in:");
-        for (const entry of builtInThemes) {
+        for (const entry of catalog.experimental_builtIn) {
           const marker = active === entry.id ? "*" : " ";
           console.log(`${marker} ${entry.id.padEnd(12)} ${entry.description}`);
         }

--- a/apps/server/src/routes/system.ts
+++ b/apps/server/src/routes/system.ts
@@ -15,6 +15,7 @@ import {
 } from "@bb/db";
 import {
   applyAppKeybindingOverrides,
+  builtInThemes,
   customThemeNameSchema,
   isBuiltInThemeId,
   resolveCodeTheme,
@@ -244,6 +245,7 @@ export function registerSystemRoutes(
   get(routes.themes, async (context) =>
     context.json({
       dir: themeRoot,
+      experimental_builtIn: [...builtInThemes],
       custom: listCustomThemeNames(themeRoot),
       plugins: pluginService.listThemes(),
       active: await resolveSelectedTheme(

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
@@ -601,6 +601,23 @@ Prefer your own `bb.settings` and `bb.storage` over `sdk.system` and
 `sdk.plugins` for your plugin's own configuration. The `system` and `plugins`
 areas write app-wide state that the user owns.
 
+Palette switchers and pickers should build their options from one catalog,
+not copy BB's built-in palette list:
+
+```ts
+const catalog = await bb.sdk.theme.catalog();
+const palettes = [
+  ...catalog.experimental_builtIn,
+  ...catalog.custom.map((id) => ({ id, name: id, description: "Custom" })),
+  ...catalog.plugins,
+];
+```
+
+`experimental_builtIn` supplies typed ids, names, descriptions, and BB's
+canonical display order. It deliberately omits CSS and code-theme assets. Client
+light/dark mode is the separate `experimental_appearance` app-runtime store.
+Experimental: see `docs/api_to_audit.md`.
+
 ```ts
 const thread = await bb.sdk.threads.spawn({
   projectId,
@@ -2166,7 +2183,7 @@ Hooks:
   connection) because plugin signals are ephemeral and are not replayed.
 - `experimental_appearance` → app-wide `{ getSnapshot, subscribe }` store.
   `getSnapshot()` returns `{ colorMode, colorModePreference,
-  setColorModePreference }`; `colorMode` is the applied `"light" | "dark"`
+setColorModePreference }`; `colorMode` is the applied `"light" | "dark"`
   result after resolving a `"system"` preference. Use point-of-use reads in
   callbacks and content scripts, or subscribe when non-React behavior must
   react to later changes.

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
@@ -30,7 +30,7 @@ The manifest is `package.json`:
   "name": "bb-plugin-hello",
   "version": "0.1.0",
   "type": "module",
-  "engines": { "bb": ">=0.9", "bbPluginSdk": ">=0.4.3" },
+  "engines": { "bb": ">=0.9", "bbPluginSdk": ">=0.4.13" },
   "bb": {
     "name": "Hello",
     "description": "A friendly example plugin.",
@@ -109,7 +109,7 @@ The manifest is `package.json`:
   different branded artwork and provide a dark variant when needed.
 - `engines.bb` — optional semver range checked against the bb app version.
 - `engines.bbPluginSdk` — optional semver range for the plugin SDK surface
-  (currently `0.4.3`; the scaffold writes `">=0.4.3"`). bb reads it as a floor,
+  (currently `0.4.13`; the scaffold writes `">=0.4.13"`). bb reads it as a floor,
   not a ceiling: a later SDK in the same major still loads the plugin, so a
   caret range keeps working after the SDK moves forward. Absent means a legacy
   manifest. Managed (`git:`/`npm:`) installs **refuse** a plugin that needs a
@@ -1292,6 +1292,7 @@ import {
   useRealtime,
   useRealtimeConnectionState,
   useSettings,
+  experimental_useAppearance,
   useBbContext,
   useBbNavigate,
   experimental_FileLink as FileLink,
@@ -2150,6 +2151,13 @@ Hooks:
   `"reconnecting"` for the same shared socket used by `useRealtime`. Reconcile
   durable server state on subsequent transitions to `connected` (not the first
   connection) because plugin signals are ephemeral and are not replayed.
+- `experimental_useAppearance()` → `{ colorMode, colorModePreference,
+setColorModePreference }`. `colorMode` is the applied `"light" | "dark"`
+  result after resolving a `"system"` preference. Use it for non-CSS consumers
+  such as a canvas or third-party editor theme; ordinary plugin UI already
+  inherits BB's live semantic CSS variables. The preference setter is
+  client-local. Palette selection remains on `bb.sdk.theme`; the hook does not
+  expose palette ids, raw CSS, code-theme files, or CSS tokens.
 - `useSettings()` → `{ values, isLoading }` — effective non-secret values
   (secret settings are excluded; read them server-side only).
 - `useBbContext()` → `{ projectId, threadId }` from the current route.
@@ -2417,6 +2425,10 @@ const slot = renderSlot(
       listNotes: () => ({ root: "/notes", notes: [], error: null }),
     }, // method → handler, calls logged
     settings: { greeting: "hi" }, // useSettings() values
+    experimental_appearance: {
+      colorMode: "dark",
+      colorModePreference: "system",
+    },
     context: { projectId: "p1", threadId: null }, // useBbContext()
     realtimeConnectionState: "reconnecting", // useRealtimeConnectionState()
     openUrl: (url) => url.startsWith("https://"),
@@ -2424,6 +2436,10 @@ const slot = renderSlot(
 );
 await slot.findByText("…"); // Testing Library queries
 await slot.behavior.setRealtimeConnectionState("connected");
+await slot.behavior.experimental_setAppearance({
+  colorMode: "light",
+  colorModePreference: "system",
+});
 await slot.behavior.setComposerScope(
   { kind: "queued-message", threadId: "t1", queuedMessageId: "q1" },
   "queued draft",

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
@@ -1292,6 +1292,7 @@ import {
   useRealtime,
   useRealtimeConnectionState,
   useSettings,
+  experimental_appearance,
   experimental_useAppearance,
   useBbContext,
   useBbNavigate,
@@ -1307,9 +1308,9 @@ import { Dialog, DialogContent } from "@/components/ui/dialog";
 export default definePluginApp((app) => {
   app.contentScripts.register({
     id: "editor-enhancement",
-    mount({ pluginId, generation, signal, experimental_getAppearance }) {
-      const appearance = experimental_getAppearance();
+    mount({ pluginId, generation, signal }) {
       const onKeyDown = (event: KeyboardEvent) => {
+        const appearance = experimental_appearance.getSnapshot();
         // Ordinary trusted, same-origin DOM behavior.
       };
       document.addEventListener("keydown", onKeyDown, { signal });
@@ -1397,10 +1398,12 @@ export default definePluginApp((app) => {
     id: "toggle-color-mode",
     title: "Toggle color mode",
     icon: "Palette",
-    run: ({ experimental_appearance: appearance }) =>
+    run: () => {
+      const appearance = experimental_appearance.getSnapshot();
       appearance.setColorModePreference(
         appearance.colorMode === "dark" ? "light" : "dark",
-      ),
+      );
+    },
   });
   app.slots.messageDirective({ id: "inline-vis", component: InlineVis });
   app.slots.experimental_threadList({
@@ -1576,14 +1579,13 @@ compatible ESM bundle.
 
 The host mounts scripts in registration order after the bundle loads and
 `definePluginApp` setup validates. `mount` receives
-`{ pluginId, generation, signal, experimental_getAppearance,
-experimental_setThreadRowStatus? }`:
+`{ pluginId, generation, signal, experimental_setThreadRowStatus? }`:
 `generation` is a monotonic per-window mount attempt number, and `signal`
-aborts before cleanup starts. `experimental_getAppearance()` returns the same
-semantic value as the React hook at call time; use it for non-React behavior
-that needs to read or set client mode, and call it at the point of use instead
-of retaining a snapshot. Writes from a disposed generation are ignored. The
-optional experimental thread-row setter targets an
+aborts before cleanup starts. Import the app-wide `experimental_appearance`
+store for non-React behavior that needs to read or set client mode. Call
+`getSnapshot()` at the point of use, or call `subscribe()` and return its
+cleanup function when behavior must react to later changes. The optional
+experimental thread-row setter targets an
 explicit thread row with `{ icon, label, tone? }` or clears it with `null`.
 Use `tone: "running"` for the host's animated running treatment. The host
 scopes statuses to the calling plugin and automatically clears them when that
@@ -1775,11 +1777,10 @@ target? })`. Inside the fixed-tab component,
   (next to Settings / bug report). No plugin component — the host paints
   the chrome so icons stay consistent. Registration:
   `{ id, title, icon, run }`. Activating it calls
-  `run({ openSettings, experimental_appearance })` — use `openSettings()` to
-  open this plugin's detail page in Tools. The experimental appearance value
-  is the same semantic contract as `experimental_useAppearance()`, captured at
-  activation time so a non-React action can read the resolved mode and update
-  the client-local preference. Errors from `run`
+  `run({ openSettings })` — use `openSettings()` to open this plugin's detail
+  page in Tools. A non-React action can import
+  `experimental_appearance`, call `getSnapshot()` at activation time, and
+  update the client-local preference. Errors from `run`
   (sync or async) are contained and logged,
   never breaking the sidebar. `title` is the tooltip + accessible label;
   `icon` is a BB icon-name hint (unknown names fall back to a generic bolt).
@@ -2163,16 +2164,18 @@ Hooks:
   `"reconnecting"` for the same shared socket used by `useRealtime`. Reconcile
   durable server state on subsequent transitions to `connected` (not the first
   connection) because plugin signals are ephemeral and are not replayed.
-- `experimental_useAppearance()` → `{ colorMode, colorModePreference,
-setColorModePreference }`. `colorMode` is the applied `"light" | "dark"`
-  result after resolving a `"system"` preference. Use it for non-CSS consumers
-  such as a canvas or third-party editor theme; ordinary plugin UI already
-  inherits BB's live semantic CSS variables. The preference setter is
-  client-local. Outside React, a `sidebarFooterAction` gets the same value as
-  `experimental_appearance`, and a content script calls
-  `experimental_getAppearance()` at the point of use. Palette selection
-  remains on `bb.sdk.theme`; none of these adapters expose palette ids, raw
-  CSS, code-theme files, or CSS tokens.
+- `experimental_appearance` → app-wide `{ getSnapshot, subscribe }` store.
+  `getSnapshot()` returns `{ colorMode, colorModePreference,
+  setColorModePreference }`; `colorMode` is the applied `"light" | "dark"`
+  result after resolving a `"system"` preference. Use point-of-use reads in
+  callbacks and content scripts, or subscribe when non-React behavior must
+  react to later changes.
+- `experimental_useAppearance()` → React convenience wrapper over
+  `experimental_appearance`. Use it for non-CSS consumers such as a canvas or
+  third-party editor theme; ordinary plugin UI already inherits BB's live
+  semantic CSS variables. The preference setter is client-local. Palette
+  selection remains on `bb.sdk.theme`; neither surface exposes palette ids,
+  raw CSS, code-theme files, or CSS tokens.
 - `useSettings()` → `{ values, isLoading }` — effective non-secret values
   (secret settings are excluded; read them server-side only).
 - `useBbContext()` → `{ projectId, threadId }` from the current route.

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
@@ -30,7 +30,7 @@ The manifest is `package.json`:
   "name": "bb-plugin-hello",
   "version": "0.1.0",
   "type": "module",
-  "engines": { "bb": ">=0.9", "bbPluginSdk": ">=0.4.13" },
+  "engines": { "bb": ">=0.9", "bbPluginSdk": ">=0.4.14" },
   "bb": {
     "name": "Hello",
     "description": "A friendly example plugin.",
@@ -109,7 +109,7 @@ The manifest is `package.json`:
   different branded artwork and provide a dark variant when needed.
 - `engines.bb` — optional semver range checked against the bb app version.
 - `engines.bbPluginSdk` — optional semver range for the plugin SDK surface
-  (currently `0.4.13`; the scaffold writes `">=0.4.13"`). bb reads it as a floor,
+  (currently `0.4.14`; the scaffold writes `">=0.4.14"`). bb reads it as a floor,
   not a ceiling: a later SDK in the same major still loads the plugin, so a
   caret range keeps working after the SDK moves forward. Absent means a legacy
   manifest. Managed (`git:`/`npm:`) installs **refuse** a plugin that needs a
@@ -1307,7 +1307,8 @@ import { Dialog, DialogContent } from "@/components/ui/dialog";
 export default definePluginApp((app) => {
   app.contentScripts.register({
     id: "editor-enhancement",
-    mount({ pluginId, generation, signal }) {
+    mount({ pluginId, generation, signal, experimental_getAppearance }) {
+      const appearance = experimental_getAppearance();
       const onKeyDown = (event: KeyboardEvent) => {
         // Ordinary trusted, same-origin DOM behavior.
       };
@@ -1393,10 +1394,13 @@ export default definePluginApp((app) => {
     component: CredentialForm,
   });
   app.slots.sidebarFooterAction({
-    id: "remote",
-    title: "Remote access",
-    icon: "Smartphone",
-    run: ({ openSettings }) => openSettings(),
+    id: "toggle-color-mode",
+    title: "Toggle color mode",
+    icon: "Palette",
+    run: ({ experimental_appearance: appearance }) =>
+      appearance.setColorModePreference(
+        appearance.colorMode === "dark" ? "light" : "dark",
+      ),
   });
   app.slots.messageDirective({ id: "inline-vis", component: InlineVis });
   app.slots.experimental_threadList({
@@ -1572,9 +1576,14 @@ compatible ESM bundle.
 
 The host mounts scripts in registration order after the bundle loads and
 `definePluginApp` setup validates. `mount` receives
-`{ pluginId, generation, signal, experimental_setThreadRowStatus? }`:
+`{ pluginId, generation, signal, experimental_getAppearance,
+experimental_setThreadRowStatus? }`:
 `generation` is a monotonic per-window mount attempt number, and `signal`
-aborts before cleanup starts. The optional experimental setter targets an
+aborts before cleanup starts. `experimental_getAppearance()` returns the same
+semantic value as the React hook at call time; use it for non-React behavior
+that needs to read or set client mode, and call it at the point of use instead
+of retaining a snapshot. Writes from a disposed generation are ignored. The
+optional experimental thread-row setter targets an
 explicit thread row with `{ icon, label, tone? }` or clears it with `null`.
 Use `tone: "running"` for the host's animated running treatment. The host
 scopes statuses to the calling plugin and automatically clears them when that
@@ -1766,8 +1775,11 @@ target? })`. Inside the fixed-tab component,
   (next to Settings / bug report). No plugin component — the host paints
   the chrome so icons stay consistent. Registration:
   `{ id, title, icon, run }`. Activating it calls
-  `run({ openSettings })` — use `openSettings()` to open this plugin's
-  detail page in Tools, or do anything else (rpc, toast). Errors from `run`
+  `run({ openSettings, experimental_appearance })` — use `openSettings()` to
+  open this plugin's detail page in Tools. The experimental appearance value
+  is the same semantic contract as `experimental_useAppearance()`, captured at
+  activation time so a non-React action can read the resolved mode and update
+  the client-local preference. Errors from `run`
   (sync or async) are contained and logged,
   never breaking the sidebar. `title` is the tooltip + accessible label;
   `icon` is a BB icon-name hint (unknown names fall back to a generic bolt).
@@ -2156,8 +2168,11 @@ setColorModePreference }`. `colorMode` is the applied `"light" | "dark"`
   result after resolving a `"system"` preference. Use it for non-CSS consumers
   such as a canvas or third-party editor theme; ordinary plugin UI already
   inherits BB's live semantic CSS variables. The preference setter is
-  client-local. Palette selection remains on `bb.sdk.theme`; the hook does not
-  expose palette ids, raw CSS, code-theme files, or CSS tokens.
+  client-local. Outside React, a `sidebarFooterAction` gets the same value as
+  `experimental_appearance`, and a content script calls
+  `experimental_getAppearance()` at the point of use. Palette selection
+  remains on `bb.sdk.theme`; none of these adapters expose palette ids, raw
+  CSS, code-theme files, or CSS tokens.
 - `useSettings()` → `{ values, isLoading }` — effective non-secret values
   (secret settings are excluded; read them server-side only).
 - `useBbContext()` → `{ projectId, threadId }` from the current route.
@@ -2403,6 +2418,7 @@ Frontend (`app.tsx`) — `@get-bb/plugin-sdk/testing/app` (vitest + jsdom):
 ```tsx
 // @vitest-environment jsdom
 import {
+  experimental_runSidebarFooterAction,
   loadPluginApp,
   mountPluginContentScripts,
   renderSlot,
@@ -2416,6 +2432,16 @@ const contentScripts = await mountPluginContentScripts(app, {
   pluginId: "my-plugin",
   generation: 1,
 });
+const footerResult = await experimental_runSidebarFooterAction(
+  app.sidebarFooterActions[0]!,
+  {
+    experimental_appearance: {
+      colorMode: "dark",
+      colorModePreference: "system",
+    },
+  },
+);
+footerResult.experimental_appearancePreferenceCalls;
 
 const slot = renderSlot(
   app.navPanels[0]!,

--- a/apps/server/test/system/appearance.test.ts
+++ b/apps/server/test/system/appearance.test.ts
@@ -5,6 +5,7 @@ import { getStoredFaviconColor, getStoredThemeId } from "@bb/db";
 import {
   appThemeSchema,
   builtInPaletteCodeThemes,
+  builtInThemes,
   defaultAppTheme,
   formatPluginThemeId,
   resolveCodeTheme,
@@ -187,6 +188,7 @@ describe("appearance settings", () => {
         await readJson(response),
       );
       expect(catalog.dir).toBe(join(harness.config.dataDir, "theme"));
+      expect(catalog.experimental_builtIn).toEqual(builtInThemes);
       expect(catalog.custom).toEqual(["amber", "zephyr"]);
       expect(catalog.plugins).toEqual([]);
       expect(catalog.active).toEqual(defaultAppTheme);

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -13,9 +13,9 @@ preference, and a setter for that client-local preference. The evidence is
 [Monaco's private root-class observer](https://github.com/andrewkchan/bb-plugin-monaco/blob/f165b11328efbed70f904bb0e65d432d014c5950/app.tsx#L34-L47),
 which must choose a non-CSS editor theme, and [Theme Toggle's private
 local-storage/class manipulation](https://github.com/xMinor-1/bb-plugins/blob/3a6ef78555814fe63891eac72a145ca9c114e9a6/plugins/theme-toggle/app.tsx#L23-L74).
-[AppToaster](../apps/app/src/components/AppToaster.tsx) is the first in-repo
-consumer; the plugin SDK harness includes a representative appearance-control
-fixture for external authors.
+The host behavior test covers the existing client appearance store, while the
+plugin SDK harness includes a representative appearance-control fixture for
+external authors.
 
 The other Appearance-tagged releases did not justify widening the contract:
 [Ayu](https://github.com/vburojevic/bb-plugin-ayu/blob/8881e00888854462fc8a7c68de386fef8229f8aa/package.json)

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -5,7 +5,7 @@ entry here (see [AGENTS.md](../AGENTS.md), "Plugin API"). Dropping the prefix
 is the deliberate stabilization step: audit the entry, rename project-wide,
 and delete the entry in the same change.
 
-## Client appearance (`experimental_useAppearance`)
+## Client appearance (`experimental_useAppearance`, `experimental_appearance`, `experimental_getAppearance`)
 
 **What it does.** Gives plugin React components the current client's resolved
 `"light" | "dark"` color mode, its selected `"light" | "dark" | "system"`
@@ -16,14 +16,24 @@ local-storage/class manipulation](https://github.com/xMinor-1/bb-plugins/blob/3a
 The host behavior test covers the existing client appearance store, and the
 [Plugin API Tester](../plugins/plugin-api-tester/app.tsx) is the first in-repo
 plugin consumer: its panel renders and updates both values through the same
-SDK harness external authors use.
+SDK harness external authors use. Its host-rendered sidebar footer action gets
+the same contract as `run({ experimental_appearance })`, since an action
+callback cannot call a React hook, and toggles directly between the resolved
+light/dark modes without opening the plugin panel. Content scripts receive
+`experimental_getAppearance()` so they can read a fresh snapshot at the point
+of use; this is the shape Theme Toggle's non-React menu needs to replace its
+private client storage and root-class writes.
 
-The other Appearance-tagged releases did not justify widening the contract:
-[Ayu](https://github.com/vburojevic/bb-plugin-ayu/blob/8881e00888854462fc8a7c68de386fef8229f8aa/package.json)
-and [Tokyo Night](https://github.com/krehel/bb-plugin-tokyo-night/blob/a5234d1a72e1fa58f3826cb239acd485701f76fe/package.json)
-are declarative `bb.themes` palettes, while [Fonts](https://github.com/gtramontina/bb-plugin-fonts/blob/d48637a2052b0336b8ac12476101a816c8b421de/client-runtime.ts#L104-L111)
-reapplies typography CSS configuration. Those needs remain covered by theme
-CSS variables/`bb.themes`, not this JavaScript mode API.
+The [live BB Community catalog](https://getbb.app/marketplace/v1/marketplace.json)
+was checked against each latest compatible release:
+
+| Plugin                                                                                                                                          | Released implementation                                                                                                                                          | Appearance API outcome                                                                                                                 |
+| ----------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| [Theme Toggle 0.2.1](https://github.com/xMinor-1/bb-plugins/blob/3a6ef78555814fe63891eac72a145ca9c114e9a6/plugins/theme-toggle/app.tsx#L23-L74) | Reads/writes private `bb.theme` storage, dispatches a synthetic storage event, calls `matchMedia`, and toggles the root `dark` class from a content-script menu. | Direct beneficiary: replace that block with `experimental_getAppearance()`; palette reads/writes stay on `bb.sdk.theme`.               |
+| [Monaco 0.1.0](https://github.com/andrewkchan/bb-plugin-monaco/blob/f165b11328efbed70f904bb0e65d432d014c5950/app.tsx#L34-L47)                   | Observes the root `dark` class to choose `vs` / `vs-dark`.                                                                                                       | Direct beneficiary: map reactive `colorMode` from `experimental_useAppearance()`.                                                      |
+| [Ayu 0.2.2](https://github.com/vburojevic/bb-plugin-ayu/blob/8881e00888854462fc8a7c68de386fef8229f8aa/package.json#L21-L41)                     | Contributes declarative palettes and uses `bb.sdk.theme` in its palette explorer.                                                                                | No migration: the existing palette contracts are the correct surface.                                                                  |
+| [Tokyo Night 0.1.0](https://github.com/krehel/bb-plugin-tokyo-night/blob/a5234d1a72e1fa58f3826cb239acd485701f76fe/package.json)                 | Contributes declarative light/dark palette CSS.                                                                                                                  | No migration: CSS already reacts to the client mode.                                                                                   |
+| [Fonts 0.1.0](https://github.com/gtramontina/bb-plugin-fonts/blob/d48637a2052b0336b8ac12476101a816c8b421de/client-runtime.ts#L104-L111)         | Recomputes typography overrides after mode or palette changes.                                                                                                   | Not covered: it needs a stable general appearance-change notification, not mode values or CSS tokens. Keep that prerequisite separate. |
 
 The hook deliberately omits palette ids, palette CSS, resolved code-theme
 files, favicon selection, and CSS tokens. Plugin styles already receive live
@@ -39,7 +49,9 @@ the same persistence/cross-window behavior as Settings; measure adoption by a
 second non-editor external plugin; and re-check that no stable JavaScript
 consumer needs a palette-change revision before adding one. Keep the hook on
 the existing shared app runtime so it adds no appearance subsystem or lazy
-chunk to plugin bundles.
+chunk to plugin bundles. Confirm the footer snapshot remains current at click
+time, content-script reads remain current and generation-scoped, and all three
+adapters continue sharing one semantic contract.
 
 ## `experimental_buildBridgeToolCallContent`
 

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -5,6 +5,41 @@ entry here (see [AGENTS.md](../AGENTS.md), "Plugin API"). Dropping the prefix
 is the deliberate stabilization step: audit the entry, rename project-wide,
 and delete the entry in the same change.
 
+## Client appearance (`experimental_useAppearance`)
+
+**What it does.** Gives plugin React components the current client's resolved
+`"light" | "dark"` color mode, its selected `"light" | "dark" | "system"`
+preference, and a setter for that client-local preference. The evidence is
+[Monaco's private root-class observer](https://github.com/andrewkchan/bb-plugin-monaco/blob/f165b11328efbed70f904bb0e65d432d014c5950/app.tsx#L34-L47),
+which must choose a non-CSS editor theme, and [Theme Toggle's private
+local-storage/class manipulation](https://github.com/xMinor-1/bb-plugins/blob/3a6ef78555814fe63891eac72a145ca9c114e9a6/plugins/theme-toggle/app.tsx#L23-L74).
+[AppToaster](../apps/app/src/components/AppToaster.tsx) is the first in-repo
+consumer; the plugin SDK harness includes a representative appearance-control
+fixture for external authors.
+
+The other Appearance-tagged releases did not justify widening the contract:
+[Ayu](https://github.com/vburojevic/bb-plugin-ayu/blob/8881e00888854462fc8a7c68de386fef8229f8aa/package.json)
+and [Tokyo Night](https://github.com/krehel/bb-plugin-tokyo-night/blob/a5234d1a72e1fa58f3826cb239acd485701f76fe/package.json)
+are declarative `bb.themes` palettes, while [Fonts](https://github.com/gtramontina/bb-plugin-fonts/blob/d48637a2052b0336b8ac12476101a816c8b421de/client-runtime.ts#L104-L111)
+reapplies typography CSS configuration. Those needs remain covered by theme
+CSS variables/`bb.themes`, not this JavaScript mode API.
+
+The hook deliberately omits palette ids, palette CSS, resolved code-theme
+files, favicon selection, and CSS tokens. Plugin styles already receive live
+semantic CSS variables; theme-only plugins use `bb.themes`; server-owned
+palette reads/writes use `bb.sdk.theme`; and BB's host-owned code renderers own
+their code-theme assets.
+
+**Audit before stabilizing.** Confirm the `colorMode` /
+`colorModePreference` names remain unambiguous beside BB's separate palette
+concept; verify `system` reactivity across browser, desktop, remote, and
+multi-window clients; confirm preference writes remain client-local and obey
+the same persistence/cross-window behavior as Settings; measure adoption by a
+second non-editor external plugin; and re-check that no stable JavaScript
+consumer needs a palette-change revision before adding one. Keep the hook on
+the existing shared app runtime so it adds no appearance subsystem or lazy
+chunk to plugin bundles.
+
 ## `experimental_buildBridgeToolCallContent`
 
 **What it does.** Converts a decoded bb tool-call response into the ordered

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -20,9 +20,9 @@ local-storage/class manipulation](https://github.com/xMinor-1/bb-plugins/blob/3a
 The host behavior test covers the existing client appearance store, and the
 [Plugin API Tester](../plugins/plugin-api-tester/app.tsx) is the first in-repo
 plugin consumer: its panel renders and updates both values through the same
-SDK harness external authors use. Its host-rendered sidebar footer action
-imports the general store and toggles directly between the resolved light/dark
-modes without opening the plugin panel. The same import works in a content
+SDK harness external authors use, with the three preferences presented as
+explicit panel controls. The representative Theme Toggle-style content-script
+fixture imports the general store directly. The same import works in a content
 script, ordinary callback, helper module, or module setup; appearance access is
 not coupled to any slot context.
 

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -13,9 +13,10 @@ preference, and a setter for that client-local preference. The evidence is
 [Monaco's private root-class observer](https://github.com/andrewkchan/bb-plugin-monaco/blob/f165b11328efbed70f904bb0e65d432d014c5950/app.tsx#L34-L47),
 which must choose a non-CSS editor theme, and [Theme Toggle's private
 local-storage/class manipulation](https://github.com/xMinor-1/bb-plugins/blob/3a6ef78555814fe63891eac72a145ca9c114e9a6/plugins/theme-toggle/app.tsx#L23-L74).
-The host behavior test covers the existing client appearance store, while the
-plugin SDK harness includes a representative appearance-control fixture for
-external authors.
+The host behavior test covers the existing client appearance store, and the
+[Plugin API Tester](../plugins/plugin-api-tester/app.tsx) is the first in-repo
+plugin consumer: its panel renders and updates both values through the same
+SDK harness external authors use.
 
 The other Appearance-tagged releases did not justify widening the contract:
 [Ayu](https://github.com/vburojevic/bb-plugin-ayu/blob/8881e00888854462fc8a7c68de386fef8229f8aa/package.json)

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -29,13 +29,13 @@ not coupled to any slot context.
 The [live BB Community catalog](https://getbb.app/marketplace/v1/marketplace.json)
 was checked against each latest compatible release:
 
-| Plugin                                                                                                                                          | Released implementation                                                                                                                                          | Appearance API outcome                                                                                                                 |
-| ----------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| [Theme Toggle 0.2.1](https://github.com/xMinor-1/bb-plugins/blob/3a6ef78555814fe63891eac72a145ca9c114e9a6/plugins/theme-toggle/app.tsx#L23-L74) | Reads/writes private `bb.theme` storage, dispatches a synthetic storage event, calls `matchMedia`, and toggles the root `dark` class from a content-script menu. | Direct beneficiary: replace that block with `experimental_appearance.getSnapshot()`; palette reads/writes stay on `bb.sdk.theme`.       |
-| [Monaco 0.1.0](https://github.com/andrewkchan/bb-plugin-monaco/blob/f165b11328efbed70f904bb0e65d432d014c5950/app.tsx#L34-L47)                   | Observes the root `dark` class to choose `vs` / `vs-dark`.                                                                                                       | Direct beneficiary: map reactive `colorMode` from `experimental_useAppearance()`.                                                      |
-| [Ayu 0.2.2](https://github.com/vburojevic/bb-plugin-ayu/blob/8881e00888854462fc8a7c68de386fef8229f8aa/package.json#L21-L41)                     | Contributes declarative palettes and uses `bb.sdk.theme` in its palette explorer.                                                                                | No migration: the existing palette contracts are the correct surface.                                                                  |
-| [Tokyo Night 0.1.0](https://github.com/krehel/bb-plugin-tokyo-night/blob/a5234d1a72e1fa58f3826cb239acd485701f76fe/package.json)                 | Contributes declarative light/dark palette CSS.                                                                                                                  | No migration: CSS already reacts to the client mode.                                                                                   |
-| [Fonts 0.1.0](https://github.com/gtramontina/bb-plugin-fonts/blob/d48637a2052b0336b8ac12476101a816c8b421de/client-runtime.ts#L104-L111)         | Recomputes typography overrides after mode or palette changes.                                                                                                   | Partially covered for mode, but it also needs a stable palette-change notification. Keep that separate instead of adding palette here.  |
+| Plugin                                                                                                                                          | Released implementation                                                                                                                                          | Appearance API outcome                                                                                                                                                                                                         |
+| ----------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [Theme Toggle 0.2.1](https://github.com/xMinor-1/bb-plugins/blob/3a6ef78555814fe63891eac72a145ca9c114e9a6/plugins/theme-toggle/app.tsx#L23-L74) | Reads/writes private `bb.theme` storage, dispatches a synthetic storage event, calls `matchMedia`, and toggles the root `dark` class from a content-script menu. | Direct beneficiary: replace that block with `experimental_appearance.getSnapshot()`; palette reads/writes stay on `bb.sdk.theme`. Its separate hardcoded built-in palette list can use `theme.catalog().experimental_builtIn`. |
+| [Monaco 0.1.0](https://github.com/andrewkchan/bb-plugin-monaco/blob/f165b11328efbed70f904bb0e65d432d014c5950/app.tsx#L34-L47)                   | Observes the root `dark` class to choose `vs` / `vs-dark`.                                                                                                       | Direct beneficiary: map reactive `colorMode` from `experimental_useAppearance()`.                                                                                                                                              |
+| [Ayu 0.2.2](https://github.com/vburojevic/bb-plugin-ayu/blob/8881e00888854462fc8a7c68de386fef8229f8aa/package.json#L21-L41)                     | Contributes declarative palettes and uses `bb.sdk.theme` in its palette explorer.                                                                                | No migration: the existing palette contracts are the correct surface.                                                                                                                                                          |
+| [Tokyo Night 0.1.0](https://github.com/krehel/bb-plugin-tokyo-night/blob/a5234d1a72e1fa58f3826cb239acd485701f76fe/package.json)                 | Contributes declarative light/dark palette CSS.                                                                                                                  | No migration: CSS already reacts to the client mode.                                                                                                                                                                           |
+| [Fonts 0.1.0](https://github.com/gtramontina/bb-plugin-fonts/blob/d48637a2052b0336b8ac12476101a816c8b421de/client-runtime.ts#L104-L111)         | Recomputes typography overrides after mode or palette changes.                                                                                                   | Partially covered for mode, but it also needs a stable palette-change notification. Keep that separate instead of adding palette here.                                                                                         |
 
 The hook deliberately omits palette ids, palette CSS, resolved code-theme
 files, favicon selection, and CSS tokens. Plugin styles already receive live
@@ -54,6 +54,28 @@ the existing shared app runtime so it adds no appearance subsystem or lazy
 chunk to plugin bundles. Confirm snapshots retain identity until a semantic
 value changes, subscriptions fire once per relevant change and clean up
 correctly, and the hook remains a thin wrapper over the same general store.
+
+## Theme catalog built-ins (`ThemeCatalogResponse.experimental_builtIn`)
+
+**What it does.** Adds BB's canonical bundled-palette metadata to the existing
+`bb.sdk.theme.catalog()` result. Each item has a typed built-in `id`, display
+`name`, and `description`; array order is the host's canonical display order. This is
+palette discovery, not client light/dark mode, and it does not expose palette
+CSS, code-theme files, or semantic CSS tokens.
+
+The concrete consumer is
+[Theme Toggle 0.2.1](https://github.com/xMinor-1/bb-plugins/blob/3a6ef78555814fe63891eac72a145ca9c114e9a6/plugins/theme-toggle/server.ts),
+which copies BB's six built-in palettes into plugin source before appending
+`catalog.custom` and `catalog.plugins`. That copy can drift whenever BB adds,
+removes, renames, reorders, or redescribes a built-in. `bb theme list` now also
+uses the catalog value, while preserving its existing JSON key.
+
+**Audit before stabilizing.** Confirm external palette switchers have adopted
+the field and no longer maintain built-in copies; decide whether consumers may
+rely on display order for cycling or need an explicit order value; verify id,
+name, and description remain the minimal useful metadata; and re-check whether
+the field belongs on `catalog()` after real use. Keep mode and palette APIs
+separate.
 
 ## `experimental_buildBridgeToolCallContent`
 

--- a/docs/api_to_audit.md
+++ b/docs/api_to_audit.md
@@ -5,35 +5,37 @@ entry here (see [AGENTS.md](../AGENTS.md), "Plugin API"). Dropping the prefix
 is the deliberate stabilization step: audit the entry, rename project-wide,
 and delete the entry in the same change.
 
-## Client appearance (`experimental_useAppearance`, `experimental_appearance`, `experimental_getAppearance`)
+## Client appearance (`experimental_appearance`, `experimental_useAppearance`)
 
-**What it does.** Gives plugin React components the current client's resolved
-`"light" | "dark"` color mode, its selected `"light" | "dark" | "system"`
-preference, and a setter for that client-local preference. The evidence is
+**What it does.** Gives any plugin code one app-wide external store for the
+current client's resolved `"light" | "dark"` color mode, its selected
+`"light" | "dark" | "system"` preference, and a setter for that client-local
+preference. `experimental_appearance.getSnapshot()` supports point-of-use
+reads, `subscribe(listener)` supports non-React reactivity, and
+`experimental_useAppearance()` is the React convenience wrapper over that
+same store. The evidence is
 [Monaco's private root-class observer](https://github.com/andrewkchan/bb-plugin-monaco/blob/f165b11328efbed70f904bb0e65d432d014c5950/app.tsx#L34-L47),
 which must choose a non-CSS editor theme, and [Theme Toggle's private
 local-storage/class manipulation](https://github.com/xMinor-1/bb-plugins/blob/3a6ef78555814fe63891eac72a145ca9c114e9a6/plugins/theme-toggle/app.tsx#L23-L74).
 The host behavior test covers the existing client appearance store, and the
 [Plugin API Tester](../plugins/plugin-api-tester/app.tsx) is the first in-repo
 plugin consumer: its panel renders and updates both values through the same
-SDK harness external authors use. Its host-rendered sidebar footer action gets
-the same contract as `run({ experimental_appearance })`, since an action
-callback cannot call a React hook, and toggles directly between the resolved
-light/dark modes without opening the plugin panel. Content scripts receive
-`experimental_getAppearance()` so they can read a fresh snapshot at the point
-of use; this is the shape Theme Toggle's non-React menu needs to replace its
-private client storage and root-class writes.
+SDK harness external authors use. Its host-rendered sidebar footer action
+imports the general store and toggles directly between the resolved light/dark
+modes without opening the plugin panel. The same import works in a content
+script, ordinary callback, helper module, or module setup; appearance access is
+not coupled to any slot context.
 
 The [live BB Community catalog](https://getbb.app/marketplace/v1/marketplace.json)
 was checked against each latest compatible release:
 
 | Plugin                                                                                                                                          | Released implementation                                                                                                                                          | Appearance API outcome                                                                                                                 |
 | ----------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| [Theme Toggle 0.2.1](https://github.com/xMinor-1/bb-plugins/blob/3a6ef78555814fe63891eac72a145ca9c114e9a6/plugins/theme-toggle/app.tsx#L23-L74) | Reads/writes private `bb.theme` storage, dispatches a synthetic storage event, calls `matchMedia`, and toggles the root `dark` class from a content-script menu. | Direct beneficiary: replace that block with `experimental_getAppearance()`; palette reads/writes stay on `bb.sdk.theme`.               |
+| [Theme Toggle 0.2.1](https://github.com/xMinor-1/bb-plugins/blob/3a6ef78555814fe63891eac72a145ca9c114e9a6/plugins/theme-toggle/app.tsx#L23-L74) | Reads/writes private `bb.theme` storage, dispatches a synthetic storage event, calls `matchMedia`, and toggles the root `dark` class from a content-script menu. | Direct beneficiary: replace that block with `experimental_appearance.getSnapshot()`; palette reads/writes stay on `bb.sdk.theme`.       |
 | [Monaco 0.1.0](https://github.com/andrewkchan/bb-plugin-monaco/blob/f165b11328efbed70f904bb0e65d432d014c5950/app.tsx#L34-L47)                   | Observes the root `dark` class to choose `vs` / `vs-dark`.                                                                                                       | Direct beneficiary: map reactive `colorMode` from `experimental_useAppearance()`.                                                      |
 | [Ayu 0.2.2](https://github.com/vburojevic/bb-plugin-ayu/blob/8881e00888854462fc8a7c68de386fef8229f8aa/package.json#L21-L41)                     | Contributes declarative palettes and uses `bb.sdk.theme` in its palette explorer.                                                                                | No migration: the existing palette contracts are the correct surface.                                                                  |
 | [Tokyo Night 0.1.0](https://github.com/krehel/bb-plugin-tokyo-night/blob/a5234d1a72e1fa58f3826cb239acd485701f76fe/package.json)                 | Contributes declarative light/dark palette CSS.                                                                                                                  | No migration: CSS already reacts to the client mode.                                                                                   |
-| [Fonts 0.1.0](https://github.com/gtramontina/bb-plugin-fonts/blob/d48637a2052b0336b8ac12476101a816c8b421de/client-runtime.ts#L104-L111)         | Recomputes typography overrides after mode or palette changes.                                                                                                   | Not covered: it needs a stable general appearance-change notification, not mode values or CSS tokens. Keep that prerequisite separate. |
+| [Fonts 0.1.0](https://github.com/gtramontina/bb-plugin-fonts/blob/d48637a2052b0336b8ac12476101a816c8b421de/client-runtime.ts#L104-L111)         | Recomputes typography overrides after mode or palette changes.                                                                                                   | Partially covered for mode, but it also needs a stable palette-change notification. Keep that separate instead of adding palette here.  |
 
 The hook deliberately omits palette ids, palette CSS, resolved code-theme
 files, favicon selection, and CSS tokens. Plugin styles already receive live
@@ -49,9 +51,9 @@ the same persistence/cross-window behavior as Settings; measure adoption by a
 second non-editor external plugin; and re-check that no stable JavaScript
 consumer needs a palette-change revision before adding one. Keep the hook on
 the existing shared app runtime so it adds no appearance subsystem or lazy
-chunk to plugin bundles. Confirm the footer snapshot remains current at click
-time, content-script reads remain current and generation-scoped, and all three
-adapters continue sharing one semantic contract.
+chunk to plugin bundles. Confirm snapshots retain identity until a semantic
+value changes, subscriptions fire once per relevant change and clean up
+correctly, and the hook remains a thin wrapper over the same general store.
 
 ## `experimental_buildBridgeToolCallContent`
 

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -16,7 +16,7 @@
 // PLUGIN_SDK_MAJOR is 0, so the major-only artifact gate cannot distinguish
 // 0.x releases and is intentionally vacuous for them until a future 1.0.
 // Rebuildable artifacts still rebuild on the exact sdkVersion-differs trigger.
-export const PLUGIN_SDK_VERSION = "0.4.13";
+export const PLUGIN_SDK_VERSION = "0.4.14";
 
 /** Major of {@link PLUGIN_SDK_VERSION} — the plugin API compatibility number. */
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -18,6 +18,15 @@ such as a canvas or third-party editor theme. Do not use it to restyle ordinary
 plugin UI: plugin CSS already inherits BB's live semantic variables, and
 server-owned palette selection remains on `bb.sdk.theme`.
 
+Host-rendered `sidebarFooterAction` callbacks receive the same semantic value
+as `experimental_appearance` because callbacks cannot call React hooks. The
+snapshot is current when the action runs, so an icon can, for example, switch
+the resolved mode to the opposite explicit preference.
+
+Content scripts call `experimental_getAppearance()` from their mount context
+when non-React behavior needs a fresh snapshot. It returns the same semantic
+value and setter; it does not expose palette state or CSS tokens.
+
 ## Composer customization
 
 Composer UI extensions register through `app.composer.customize(...)`. A

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -11,21 +11,18 @@ the built-in `bb-plugin-authoring` skill synchronized with those declarations.
 
 ## Client appearance
 
-`experimental_useAppearance()` exposes the current client's resolved
-`colorMode`, its `colorModePreference`, and `setColorModePreference(...)`.
-Use it when JavaScript must choose light/dark behavior that CSS cannot express,
-such as a canvas or third-party editor theme. Do not use it to restyle ordinary
-plugin UI: plugin CSS already inherits BB's live semantic variables, and
-server-owned palette selection remains on `bb.sdk.theme`.
+`experimental_appearance` is one app-wide store available from any plugin
+code. `getSnapshot()` returns the current client's resolved `colorMode`, its
+`colorModePreference`, and `setColorModePreference(...)`; `subscribe()`
+reacts to later semantic changes. `experimental_useAppearance()` is the React
+convenience wrapper over that same store.
 
-Host-rendered `sidebarFooterAction` callbacks receive the same semantic value
-as `experimental_appearance` because callbacks cannot call React hooks. The
-snapshot is current when the action runs, so an icon can, for example, switch
-the resolved mode to the opposite explicit preference.
-
-Content scripts call `experimental_getAppearance()` from their mount context
-when non-React behavior needs a fresh snapshot. It returns the same semantic
-value and setter; it does not expose palette state or CSS tokens.
+Use the contract when JavaScript must choose light/dark behavior that CSS
+cannot express, such as a canvas or third-party editor theme, or when a
+non-React callback such as a footer action or content script needs the current
+mode. Do not use it to restyle ordinary plugin UI: plugin CSS already inherits
+BB's live semantic variables, and server-owned palette selection remains on
+`bb.sdk.theme`. The contract does not expose palette state or CSS tokens.
 
 ## Composer customization
 

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -24,6 +24,14 @@ mode. Do not use it to restyle ordinary plugin UI: plugin CSS already inherits
 BB's live semantic variables, and server-owned palette selection remains on
 `bb.sdk.theme`. The contract does not expose palette state or CSS tokens.
 
+## Palette catalog
+
+Backend plugins that present a palette picker or cycle palettes should read
+`bb.sdk.theme.catalog().experimental_builtIn` for BB's canonical built-in
+palette ids, names, descriptions, and order. Append `custom` and `plugins` from
+the same result instead of copying BB's built-in list into plugin source.
+Palette CSS and code-theme assets remain host-owned and are not returned.
+
 ## Composer customization
 
 Composer UI extensions register through `app.composer.customize(...)`. A

--- a/packages/plugin-sdk/README.md
+++ b/packages/plugin-sdk/README.md
@@ -9,6 +9,15 @@ The authoritative contracts are the exported declarations in
 [`src/app-contract.ts`](src/app-contract.ts). Keep author-facing guidance in
 the built-in `bb-plugin-authoring` skill synchronized with those declarations.
 
+## Client appearance
+
+`experimental_useAppearance()` exposes the current client's resolved
+`colorMode`, its `colorModePreference`, and `setColorModePreference(...)`.
+Use it when JavaScript must choose light/dark behavior that CSS cannot express,
+such as a canvas or third-party editor theme. Do not use it to restyle ordinary
+plugin UI: plugin CSS already inherits BB's live semantic variables, and
+server-owned palette selection remains on `bb.sdk.theme`.
+
 ## Composer customization
 
 Composer UI extensions register through `app.composer.customize(...)`. A
@@ -155,7 +164,7 @@ await scripts.lifecycle.dispose();
 `loadPluginApp` installs the runtime before a thunk import and validates all
 registrations. `mountPluginContentScripts` mirrors the host's ordered mount,
 rollback, independent per-window signal, and exact-once disposal. `renderSlot` supplies
-RPC, realtime, settings, navigation, context, and scoped composer behavior,
+RPC, realtime, appearance, settings, navigation, context, and scoped composer behavior,
 then returns Testing Library queries plus the same behavior/inspection/lifecycle
 split. Use a setup-file `installTestPluginRuntime()` only when a static app
 import is unavoidable.

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/plugin-sdk/src/app-contract.ts
+++ b/packages/plugin-sdk/src/app-contract.ts
@@ -585,14 +585,6 @@ export interface PluginSidebarFooterActionContext {
    * and `settingsSection` slots render.
    */
   openSettings(): void;
-  /**
-   * The current client's semantic appearance at activation time. Use this for
-   * direct action behavior that cannot call React hooks, such as toggling the
-   * client-local color-mode preference from the footer icon.
-   *
-   * @experimental Audit before relying on this as a stable contract.
-   */
-  experimental_appearance: ExperimentalPluginAppearance;
 }
 
 /**
@@ -1148,14 +1140,6 @@ export interface PluginContentScriptContext {
   readonly generation: number;
   /** Aborted before cleanup begins on replacement, deactivation, or teardown. */
   readonly signal: AbortSignal;
-  /**
-   * Read the current client's semantic appearance when non-React content
-   * script behavior runs. Call it at the point of use rather than retaining a
-   * snapshot; writes from a disposed script generation are ignored.
-   *
-   * @experimental Audit before relying on this as a stable contract.
-   */
-  readonly experimental_getAppearance: () => ExperimentalPluginAppearance;
   /**
    * Persistently decorate any thread row for this plugin generation.
    *
@@ -1810,6 +1794,21 @@ export interface ExperimentalPluginAppearance {
   ): void;
 }
 
+/**
+ * App-wide access to the current semantic appearance outside React.
+ *
+ * `getSnapshot()` returns the same object until either semantic value changes.
+ * Subscribe when behavior must react to later changes; the returned function
+ * removes that listener. React components should normally use
+ * `experimental_useAppearance()` instead.
+ *
+ * @experimental Audit before relying on this as a stable contract.
+ */
+export interface ExperimentalPluginAppearanceStore {
+  readonly getSnapshot: () => ExperimentalPluginAppearance;
+  readonly subscribe: (listener: () => void) => () => void;
+}
+
 export interface BbNavigate {
   toThread(threadId: string): void;
   toProject(projectId: string): void;
@@ -1885,7 +1884,12 @@ export interface PluginSdkApp {
   useRealtimeConnectionState(): PluginRealtimeConnectionState;
   useSettings(): PluginSettingsState;
   /**
-   * Read or update this client's semantic light/dark appearance.
+   * Read, update, or subscribe to this client's semantic light/dark appearance
+   * from any plugin code. Experimental: see docs/api_to_audit.md.
+   */
+  experimental_appearance: ExperimentalPluginAppearanceStore;
+  /**
+   * React convenience wrapper over `experimental_appearance`.
    * Experimental: see docs/api_to_audit.md.
    */
   experimental_useAppearance(): ExperimentalPluginAppearance;

--- a/packages/plugin-sdk/src/app-contract.ts
+++ b/packages/plugin-sdk/src/app-contract.ts
@@ -1772,6 +1772,28 @@ export interface BbContext {
   threadId: string | null;
 }
 
+/**
+ * The current client's semantic light/dark appearance.
+ *
+ * Palette CSS is deliberately absent: plugin styles already inherit BB's live
+ * CSS variables, while server-owned palette selection remains available from
+ * `bb.sdk.theme`. This contract is only for JavaScript consumers that must
+ * choose behavior which CSS cannot express (for example a canvas/editor theme)
+ * or offer the same client-local mode preference as BB.
+ *
+ * @experimental Audit before relying on this as a stable contract.
+ */
+export interface ExperimentalPluginAppearance {
+  /** The mode currently applied after resolving a `system` preference. */
+  colorMode: "light" | "dark";
+  /** This client's selected mode preference. */
+  colorModePreference: "light" | "dark" | "system";
+  /** Update this client's mode preference. */
+  setColorModePreference(
+    preference: ExperimentalPluginAppearance["colorModePreference"],
+  ): void;
+}
+
 export interface BbNavigate {
   toThread(threadId: string): void;
   toProject(projectId: string): void;
@@ -1846,6 +1868,11 @@ export interface PluginSdkApp {
    */
   useRealtimeConnectionState(): PluginRealtimeConnectionState;
   useSettings(): PluginSettingsState;
+  /**
+   * Read or update this client's semantic light/dark appearance.
+   * Experimental: see docs/api_to_audit.md.
+   */
+  experimental_useAppearance(): ExperimentalPluginAppearance;
   useBbContext(): BbContext;
   useBbNavigate(): BbNavigate;
   /** Select one of this plugin's eligible fixed tabs on the current surface. */

--- a/packages/plugin-sdk/src/app-contract.ts
+++ b/packages/plugin-sdk/src/app-contract.ts
@@ -585,6 +585,14 @@ export interface PluginSidebarFooterActionContext {
    * and `settingsSection` slots render.
    */
   openSettings(): void;
+  /**
+   * The current client's semantic appearance at activation time. Use this for
+   * direct action behavior that cannot call React hooks, such as toggling the
+   * client-local color-mode preference from the footer icon.
+   *
+   * @experimental Audit before relying on this as a stable contract.
+   */
+  experimental_appearance: ExperimentalPluginAppearance;
 }
 
 /**
@@ -1140,6 +1148,14 @@ export interface PluginContentScriptContext {
   readonly generation: number;
   /** Aborted before cleanup begins on replacement, deactivation, or teardown. */
   readonly signal: AbortSignal;
+  /**
+   * Read the current client's semantic appearance when non-React content
+   * script behavior runs. Call it at the point of use rather than retaining a
+   * snapshot; writes from a disposed script generation are ignored.
+   *
+   * @experimental Audit before relying on this as a stable contract.
+   */
+  readonly experimental_getAppearance: () => ExperimentalPluginAppearance;
   /**
    * Persistently decorate any thread row for this plugin generation.
    *

--- a/packages/plugin-sdk/src/app.ts
+++ b/packages/plugin-sdk/src/app.ts
@@ -63,6 +63,7 @@ export const useRpc = runtime.useRpc;
 export const useRealtime = runtime.useRealtime;
 export const useRealtimeConnectionState = runtime.useRealtimeConnectionState;
 export const useSettings = runtime.useSettings;
+export const experimental_appearance = runtime.experimental_appearance;
 export const experimental_useAppearance = runtime.experimental_useAppearance;
 export const useBbContext = runtime.useBbContext;
 export const useBbNavigate = runtime.useBbNavigate;

--- a/packages/plugin-sdk/src/app.ts
+++ b/packages/plugin-sdk/src/app.ts
@@ -63,6 +63,7 @@ export const useRpc = runtime.useRpc;
 export const useRealtime = runtime.useRealtime;
 export const useRealtimeConnectionState = runtime.useRealtimeConnectionState;
 export const useSettings = runtime.useSettings;
+export const experimental_useAppearance = runtime.experimental_useAppearance;
 export const useBbContext = runtime.useBbContext;
 export const useBbNavigate = runtime.useBbNavigate;
 export const experimental_useAppPanel = runtime.experimental_useAppPanel;

--- a/packages/plugin-sdk/src/testing/__tests__/app-harness.test.tsx
+++ b/packages/plugin-sdk/src/testing/__tests__/app-harness.test.tsx
@@ -28,6 +28,7 @@ const {
   experimental_ProviderModelPicker: ProviderModelPicker,
   experimental_PermissionModePicker: PermissionModePicker,
   experimental_useAppPanel,
+  experimental_useAppearance,
   experimental_useFixedTabTarget,
   ThreadChat,
   useBbNavigate,
@@ -234,6 +235,23 @@ function Panel({ subPath }: PluginNavPanelProps) {
 function RealtimeConnectionProbe() {
   const state = useRealtimeConnectionState();
   return <div>Realtime: {state}</div>;
+}
+
+function AppearanceProbe() {
+  const appearance = experimental_useAppearance();
+  return (
+    <div>
+      <span>
+        Appearance: {appearance.colorMode}/{appearance.colorModePreference}
+      </span>
+      <button
+        type="button"
+        onClick={() => appearance.setColorModePreference("light")}
+      >
+        Use light
+      </button>
+    </div>
+  );
 }
 
 function UrlNavigationProbe() {
@@ -1428,6 +1446,36 @@ describe("renderSlot", () => {
 
     await slot.behavior.setRealtimeConnectionState("reconnecting");
     await slot.findByText("Realtime: reconnecting");
+  });
+
+  it("models semantic appearance preference writes and reactive host changes", async () => {
+    const defaultSlot = renderSlot({ component: AppearanceProbe }, {});
+    expect(defaultSlot.getByText("Appearance: light/system")).toBeTruthy();
+    defaultSlot.unmount();
+
+    const slot = renderSlot(
+      { component: AppearanceProbe },
+      {},
+      {
+        experimental_appearance: {
+          colorMode: "dark",
+          colorModePreference: "system",
+        },
+      },
+    );
+    expect(slot.getByText("Appearance: dark/system")).toBeTruthy();
+
+    fireEvent.click(slot.getByRole("button", { name: "Use light" }));
+    expect(slot.getByText("Appearance: light/light")).toBeTruthy();
+    expect(slot.inspection.experimental_appearancePreferenceCalls).toEqual([
+      "light",
+    ]);
+
+    await slot.behavior.experimental_setAppearance({
+      colorMode: "dark",
+      colorModePreference: "system",
+    });
+    expect(slot.getByText("Appearance: dark/system")).toBeTruthy();
   });
 
   it("refreshes rendered RPC data after a realtime event", async () => {

--- a/packages/plugin-sdk/src/testing/__tests__/app-harness.test.tsx
+++ b/packages/plugin-sdk/src/testing/__tests__/app-harness.test.tsx
@@ -12,6 +12,7 @@ import type {
 } from "../../app-contract.js";
 import {
   installTestPluginRuntime,
+  experimental_runSidebarFooterAction,
   loadPluginApp,
   mountPluginContentScripts,
   renderSlot,
@@ -243,6 +244,9 @@ function AppearanceProbe() {
     <div>
       <span>
         Appearance: {appearance.colorMode}/{appearance.colorModePreference}
+      </span>
+      <span>
+        Monaco theme: {appearance.colorMode === "dark" ? "vs-dark" : "vs"}
       </span>
       <button
         type="button"
@@ -675,6 +679,53 @@ describe("loadPluginApp", () => {
     expect(mounted.inspection.getThreadRowStatus("thr_source")).toBeNull();
     expect(mounted.inspection.threadRowStatusCalls).toHaveLength(1);
     warn.mockRestore();
+  });
+
+  it("models current appearance reads and writes for content scripts", async () => {
+    let getAppearance:
+      | (() => import("../../app-contract.js").ExperimentalPluginAppearance)
+      | undefined;
+    const captured = await loadPluginApp(
+      definePluginApp((builder) => {
+        builder.contentScripts.register({
+          id: "appearance-menu",
+          mount({ experimental_getAppearance }) {
+            getAppearance = experimental_getAppearance;
+          },
+        });
+      }),
+    );
+
+    const mounted = await mountPluginContentScripts(captured, {
+      pluginId: "theme-toggle",
+      experimental_appearance: {
+        colorMode: "dark",
+        colorModePreference: "system",
+      },
+    });
+    expect(getAppearance?.()).toMatchObject({
+      colorMode: "dark",
+      colorModePreference: "system",
+    });
+
+    getAppearance?.().setColorModePreference("light");
+    expect(getAppearance?.()).toMatchObject({
+      colorMode: "light",
+      colorModePreference: "light",
+    });
+    expect(mounted.inspection.experimental_appearance).toEqual({
+      colorMode: "light",
+      colorModePreference: "light",
+    });
+    expect(mounted.inspection.experimental_appearancePreferenceCalls).toEqual([
+      "light",
+    ]);
+
+    await mounted.lifecycle.dispose();
+    getAppearance?.().setColorModePreference("dark");
+    expect(mounted.inspection.experimental_appearancePreferenceCalls).toEqual([
+      "light",
+    ]);
   });
 
   it("can omit the experimental thread-row status API for compatibility tests", async () => {
@@ -1464,9 +1515,11 @@ describe("renderSlot", () => {
       },
     );
     expect(slot.getByText("Appearance: dark/system")).toBeTruthy();
+    expect(slot.getByText("Monaco theme: vs-dark")).toBeTruthy();
 
     fireEvent.click(slot.getByRole("button", { name: "Use light" }));
     expect(slot.getByText("Appearance: light/light")).toBeTruthy();
+    expect(slot.getByText("Monaco theme: vs")).toBeTruthy();
     expect(slot.inspection.experimental_appearancePreferenceCalls).toEqual([
       "light",
     ]);
@@ -1476,6 +1529,34 @@ describe("renderSlot", () => {
       colorModePreference: "system",
     });
     expect(slot.getByText("Appearance: dark/system")).toBeTruthy();
+  });
+
+  it("models appearance in host-rendered footer action callbacks", async () => {
+    const result = await experimental_runSidebarFooterAction(
+      {
+        id: "toggle-mode",
+        title: "Toggle mode",
+        icon: "Palette",
+        run({ experimental_appearance: appearance, openSettings }) {
+          appearance.setColorModePreference(
+            appearance.colorMode === "dark" ? "light" : "dark",
+          );
+          openSettings();
+        },
+      },
+      {
+        experimental_appearance: {
+          colorMode: "dark",
+          colorModePreference: "system",
+        },
+      },
+    );
+
+    expect(result).toEqual({
+      appearance: { colorMode: "light", colorModePreference: "light" },
+      openSettingsCalls: 1,
+      experimental_appearancePreferenceCalls: ["light"],
+    });
   });
 
   it("refreshes rendered RPC data after a realtime event", async () => {

--- a/packages/plugin-sdk/src/testing/__tests__/app-harness.test.tsx
+++ b/packages/plugin-sdk/src/testing/__tests__/app-harness.test.tsx
@@ -28,6 +28,7 @@ const {
   experimental_UrlLink: UrlLink,
   experimental_ProviderModelPicker: ProviderModelPicker,
   experimental_PermissionModePicker: PermissionModePicker,
+  experimental_appearance,
   experimental_useAppPanel,
   experimental_useAppearance,
   experimental_useFixedTabTarget,
@@ -682,15 +683,16 @@ describe("loadPluginApp", () => {
   });
 
   it("models current appearance reads and writes for content scripts", async () => {
-    let getAppearance:
-      | (() => import("../../app-contract.js").ExperimentalPluginAppearance)
-      | undefined;
+    let readAppearance: (() => string) | undefined;
     const captured = await loadPluginApp(
       definePluginApp((builder) => {
         builder.contentScripts.register({
           id: "appearance-menu",
-          mount({ experimental_getAppearance }) {
-            getAppearance = experimental_getAppearance;
+          mount() {
+            readAppearance = () => {
+              const appearance = experimental_appearance.getSnapshot();
+              return `${appearance.colorMode}/${appearance.colorModePreference}`;
+            };
           },
         });
       }),
@@ -703,16 +705,10 @@ describe("loadPluginApp", () => {
         colorModePreference: "system",
       },
     });
-    expect(getAppearance?.()).toMatchObject({
-      colorMode: "dark",
-      colorModePreference: "system",
-    });
+    expect(readAppearance?.()).toBe("dark/system");
 
-    getAppearance?.().setColorModePreference("light");
-    expect(getAppearance?.()).toMatchObject({
-      colorMode: "light",
-      colorModePreference: "light",
-    });
+    experimental_appearance.getSnapshot().setColorModePreference("light");
+    expect(readAppearance?.()).toBe("light/light");
     expect(mounted.inspection.experimental_appearance).toEqual({
       colorMode: "light",
       colorModePreference: "light",
@@ -722,10 +718,6 @@ describe("loadPluginApp", () => {
     ]);
 
     await mounted.lifecycle.dispose();
-    getAppearance?.().setColorModePreference("dark");
-    expect(mounted.inspection.experimental_appearancePreferenceCalls).toEqual([
-      "light",
-    ]);
   });
 
   it("can omit the experimental thread-row status API for compatibility tests", async () => {
@@ -1516,6 +1508,12 @@ describe("renderSlot", () => {
     );
     expect(slot.getByText("Appearance: dark/system")).toBeTruthy();
     expect(slot.getByText("Monaco theme: vs-dark")).toBeTruthy();
+    expect(experimental_appearance.getSnapshot()).toMatchObject({
+      colorMode: "dark",
+      colorModePreference: "system",
+    });
+    const appearanceChanges = vi.fn();
+    const unsubscribe = experimental_appearance.subscribe(appearanceChanges);
 
     fireEvent.click(slot.getByRole("button", { name: "Use light" }));
     expect(slot.getByText("Appearance: light/light")).toBeTruthy();
@@ -1523,21 +1521,25 @@ describe("renderSlot", () => {
     expect(slot.inspection.experimental_appearancePreferenceCalls).toEqual([
       "light",
     ]);
+    expect(appearanceChanges).toHaveBeenCalledTimes(1);
 
     await slot.behavior.experimental_setAppearance({
       colorMode: "dark",
       colorModePreference: "system",
     });
     expect(slot.getByText("Appearance: dark/system")).toBeTruthy();
+    expect(appearanceChanges).toHaveBeenCalledTimes(2);
+    unsubscribe();
   });
 
-  it("models appearance in host-rendered footer action callbacks", async () => {
+  it("makes the app-wide appearance store available to footer actions", async () => {
     const result = await experimental_runSidebarFooterAction(
       {
         id: "toggle-mode",
         title: "Toggle mode",
         icon: "Palette",
-        run({ experimental_appearance: appearance, openSettings }) {
+        run({ openSettings }) {
+          const appearance = experimental_appearance.getSnapshot();
           appearance.setColorModePreference(
             appearance.colorMode === "dark" ? "light" : "dark",
           );

--- a/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
+++ b/packages/plugin-sdk/src/testing/__tests__/fake-plugin-host.test.ts
@@ -675,6 +675,60 @@ describe("sdk", () => {
     expect(harness.sdk.callsTo("plugins.catalog.status")).toEqual([[]]);
   });
 
+  it("lets a palette plugin consume canonical built-ins without hardcoding them", async () => {
+    const { bb, harness } = createFakePluginHost({
+      sdk: {
+        theme: {
+          catalog: async () => ({
+            dir: "/tmp/bb/theme",
+            experimental_builtIn: [
+              {
+                id: "default",
+                name: "Default",
+                description: "The standard bb look",
+              },
+              {
+                id: "nord",
+                name: "Nord",
+                description: "Cool, muted arctic blues",
+              },
+            ],
+            custom: ["paper"],
+            plugins: [
+              {
+                id: "plugin:ayu:mirage",
+                pluginId: "ayu",
+                name: "Ayu Mirage",
+                description: "A muted dark palette",
+              },
+            ],
+            active: {
+              themeId: "nord",
+              customCss: null,
+              faviconColor: "default",
+              resolvedCodeTheme: { dark: "nord", light: "nord", files: {} },
+            },
+          }),
+        },
+      },
+    });
+
+    const catalog = await bb.sdk.theme.catalog();
+    const selectable = [
+      ...catalog.experimental_builtIn.map(({ id, name }) => ({ id, name })),
+      ...catalog.custom.map((id) => ({ id, name: id })),
+      ...catalog.plugins.map(({ id, name }) => ({ id, name })),
+    ];
+
+    expect(selectable).toEqual([
+      { id: "default", name: "Default" },
+      { id: "nord", name: "Nord" },
+      { id: "paper", name: "paper" },
+      { id: "plugin:ayu:mirage", name: "Ayu Mirage" },
+    ]);
+    expect(harness.sdk.callsTo("theme.catalog")).toEqual([[]]);
+  });
+
   it("throws a stub-naming error for unstubbed methods and accepts late stubs", async () => {
     const { bb, harness } = createFakePluginHost();
     expect(() => bb.sdk.projects.list({})).toThrow(
@@ -1199,17 +1253,15 @@ describe("providers.register", () => {
 
   it("clears registrations on dispose", async () => {
     const { bb, harness } = createFakePluginHost();
-    bb.providers.register(
-      agentDeclaration({ id: "my-second-agent" }),
-    );
+    bb.providers.register(agentDeclaration({ id: "my-second-agent" }));
     expect(
       harness.registrations.providerRegistrations.map((entry) => entry.id),
     ).toEqual(["my-second-agent"]);
 
     await harness.dispose();
     expect(harness.registrations.providerRegistrations).toEqual([]);
-    expect(() =>
-      bb.providers.register(agentDeclaration()),
-    ).toThrow("used a stale API handle");
+    expect(() => bb.providers.register(agentDeclaration())).toThrow(
+      "used a stale API handle",
+    );
   });
 });

--- a/packages/plugin-sdk/src/testing/app.tsx
+++ b/packages/plugin-sdk/src/testing/app.tsx
@@ -63,6 +63,7 @@ import {
   type ExperimentalFixedTabTargetState,
   type ExperimentalOpenFixedTabOptions,
   type ExperimentalPluginAppearance,
+  type ExperimentalPluginAppearanceStore,
   type ExperimentalPluginFixedTabReference,
   type NewThreadComposerProps,
   type ExperimentalPermissionModePickerProps,
@@ -175,8 +176,13 @@ type ExperimentalAppearanceSnapshot = Pick<
   "colorMode" | "colorModePreference"
 >;
 
-interface TestAppearanceStore {
-  getSnapshot(): ExperimentalAppearanceSnapshot;
+interface TestAppearanceStore extends ExperimentalPluginAppearanceStore {
+  readonly preferenceCalls: Array<
+    ExperimentalPluginAppearance["colorModePreference"]
+  >;
+  getSnapshot(): ExperimentalPluginAppearance;
+  getSnapshotValues(): ExperimentalAppearanceSnapshot;
+  reset(snapshot: ExperimentalAppearanceSnapshot): void;
   setColorModePreference(
     preference: ExperimentalPluginAppearance["colorModePreference"],
   ): void;
@@ -190,7 +196,6 @@ interface SlotEnv {
   realtimeHandlers: Map<string, Set<(payload: unknown) => void>>;
   realtimeConnection: TestRealtimeConnectionStore;
   settingsState: PluginSettingsState;
-  appearance: TestAppearanceStore;
   bbContext: BbContext;
   navigate: BbNavigate;
   navigateCalls: NavigateCall[];
@@ -255,6 +260,71 @@ function useSlotEnv(hook: string): SlotEnv {
   }
   return env;
 }
+
+function createTestAppearanceStore(): TestAppearanceStore {
+  let values: ExperimentalAppearanceSnapshot = {
+    colorMode: "light",
+    colorModePreference: "system",
+  };
+  let systemColorMode = values.colorMode;
+  let snapshot: ExperimentalPluginAppearance;
+  const listeners = new Set<() => void>();
+  const preferenceCalls: Array<
+    ExperimentalPluginAppearance["colorModePreference"]
+  > = [];
+
+  const setColorModePreference = (
+    preference: ExperimentalPluginAppearance["colorModePreference"],
+  ): void => {
+    preferenceCalls.push(preference);
+    setSnapshot({
+      colorMode: preference === "system" ? systemColorMode : preference,
+      colorModePreference: preference,
+    });
+  };
+  const buildSnapshot = (): ExperimentalPluginAppearance => ({
+    ...values,
+    setColorModePreference,
+  });
+  const setSnapshot = (next: ExperimentalAppearanceSnapshot): void => {
+    if (
+      next.colorMode === values.colorMode &&
+      next.colorModePreference === values.colorModePreference
+    ) {
+      return;
+    }
+    values = { ...next };
+    snapshot = buildSnapshot();
+    for (const listener of listeners) listener();
+  };
+  snapshot = buildSnapshot();
+
+  return {
+    preferenceCalls,
+    getSnapshot: () => snapshot,
+    getSnapshotValues: () => ({ ...values }),
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    reset(next) {
+      preferenceCalls.length = 0;
+      systemColorMode = next.colorMode;
+      setSnapshot(next);
+    },
+    setColorModePreference,
+    setSnapshot(next) {
+      if (next.colorModePreference === "system") {
+        systemColorMode = next.colorMode;
+      }
+      setSnapshot(next);
+    },
+  };
+}
+
+// Appearance is client-global in BB, so every harness execution shape uses
+// the same store too. Each driver resets it before executing a captured slot.
+const testAppearanceStore = createTestAppearanceStore();
 
 // ---------------------------------------------------------------------------
 // The fake @get-bb/plugin-sdk/app runtime.
@@ -715,6 +785,7 @@ function TestDiff({
 
 const testPluginSdkApp = {
   definePluginApp,
+  experimental_appearance: testAppearanceStore,
   useRpc<
     Contract extends PluginRpcContract = PluginRpcContract,
   >(): PluginRpcClient<Contract> {
@@ -754,18 +825,10 @@ const testPluginSdkApp = {
     return useSlotEnv("useSettings").settingsState;
   },
   experimental_useAppearance(): ExperimentalPluginAppearance {
-    const appearance = useSlotEnv("experimental_useAppearance").appearance;
-    const snapshot = useSyncExternalStore(
-      appearance.subscribe,
-      appearance.getSnapshot,
-      appearance.getSnapshot,
-    );
-    return useMemo(
-      () => ({
-        ...snapshot,
-        setColorModePreference: appearance.setColorModePreference,
-      }),
-      [appearance, snapshot],
+    return useSyncExternalStore(
+      testAppearanceStore.subscribe,
+      testAppearanceStore.getSnapshot,
+      testAppearanceStore.getSnapshot,
     );
   },
   useBbContext(): BbContext {
@@ -961,7 +1024,7 @@ export async function loadPluginApp(
 }
 
 export interface ExperimentalRunSidebarFooterActionOptions {
-  /** Appearance snapshot supplied to the action. Defaults to light/system. */
+  /** Initial app-wide appearance. Defaults to light/system. */
   experimental_appearance?: ExperimentalAppearanceSnapshot;
   /** Optional assertion spy or host-like implementation. */
   openSettings?: () => void;
@@ -972,48 +1035,28 @@ export interface ExperimentalRunSidebarFooterActionResult {
   appearance: ExperimentalAppearanceSnapshot;
   /** Number of times the action requested its plugin detail page. */
   openSettingsCalls: number;
-  /** Preference writes made through the action context, in order. */
+  /** Preference writes made through the app-wide store, in order. */
   experimental_appearancePreferenceCalls: Array<
     ExperimentalPluginAppearance["colorModePreference"]
   >;
 }
 
 /**
- * Run a captured host-rendered footer action with the same semantic appearance
- * context BB supplies at click time.
+ * Run a captured host-rendered footer action after initializing the app-wide
+ * appearance store exported from `@get-bb/plugin-sdk/app`.
  */
 export async function experimental_runSidebarFooterAction(
   registration: PluginSidebarFooterActionRegistration,
   options: ExperimentalRunSidebarFooterActionOptions = {},
 ): Promise<ExperimentalRunSidebarFooterActionResult> {
-  let appearanceSnapshot: ExperimentalAppearanceSnapshot = {
-    ...(options.experimental_appearance ?? {
+  testAppearanceStore.reset(
+    options.experimental_appearance ?? {
       colorMode: "light",
       colorModePreference: "system",
-    }),
-  };
-  const systemColorMode = appearanceSnapshot.colorMode;
-  const appearancePreferenceCalls: Array<
-    ExperimentalPluginAppearance["colorModePreference"]
-  > = [];
-  const appearance: ExperimentalPluginAppearance = {
-    get colorMode() {
-      return appearanceSnapshot.colorMode;
     },
-    get colorModePreference() {
-      return appearanceSnapshot.colorModePreference;
-    },
-    setColorModePreference(preference) {
-      appearancePreferenceCalls.push(preference);
-      appearanceSnapshot = {
-        colorMode: preference === "system" ? systemColorMode : preference,
-        colorModePreference: preference,
-      };
-    },
-  };
+  );
   let openSettingsCalls = 0;
   const context: PluginSidebarFooterActionContext = {
-    experimental_appearance: appearance,
     openSettings() {
       openSettingsCalls += 1;
       options.openSettings?.();
@@ -1023,9 +1066,11 @@ export async function experimental_runSidebarFooterAction(
   await registration.run(context);
 
   return {
-    appearance: { ...appearanceSnapshot },
+    appearance: testAppearanceStore.getSnapshotValues(),
     openSettingsCalls,
-    experimental_appearancePreferenceCalls: [...appearancePreferenceCalls],
+    experimental_appearancePreferenceCalls: [
+      ...testAppearanceStore.preferenceCalls,
+    ],
   };
 }
 
@@ -1033,7 +1078,7 @@ export interface ContentScriptTestMountOptions {
   pluginId: string;
   /** Defaults to 1. Pass the host generation you want the plugin to observe. */
   generation?: number;
-  /** Initial value returned by `experimental_getAppearance()`. */
+  /** Initial value exposed by the app-wide appearance store. */
   experimental_appearance?: ExperimentalAppearanceSnapshot;
   /**
    * Simulate an older compatible host that predates the optional experimental
@@ -1054,7 +1099,7 @@ export interface MountedPluginContentScripts {
     readonly disposed: boolean;
     /** Current semantic appearance after content-script preference writes. */
     readonly experimental_appearance: ExperimentalAppearanceSnapshot;
-    /** Preference writes made through `experimental_getAppearance()`. */
+    /** Preference writes made through the app-wide appearance store. */
     readonly experimental_appearancePreferenceCalls: readonly ExperimentalPluginAppearance["colorModePreference"][];
     readonly threadRowStatusCalls: readonly ContentScriptThreadRowStatusCall[];
     getThreadRowStatus(threadId: string): PluginComposerThreadRowStatus | null;
@@ -1082,28 +1127,13 @@ export async function mountPluginContentScripts(
   }> = [];
   const threadRowStatuses = new Map<string, PluginComposerThreadRowStatus>();
   const threadRowStatusCalls: ContentScriptThreadRowStatusCall[] = [];
-  let appearanceSnapshot: ExperimentalAppearanceSnapshot = {
-    ...(options.experimental_appearance ?? {
+  testAppearanceStore.reset(
+    options.experimental_appearance ?? {
       colorMode: "light",
       colorModePreference: "system",
-    }),
-  };
-  const systemColorMode = appearanceSnapshot.colorMode;
-  const appearancePreferenceCalls: Array<
-    ExperimentalPluginAppearance["colorModePreference"]
-  > = [];
-  let disposed = false;
-  const getAppearance = (): ExperimentalPluginAppearance => ({
-    ...appearanceSnapshot,
-    setColorModePreference(preference) {
-      if (controller.signal.aborted) return;
-      appearancePreferenceCalls.push(preference);
-      appearanceSnapshot = {
-        colorMode: preference === "system" ? systemColorMode : preference,
-        colorModePreference: preference,
-      };
     },
-  });
+  );
+  let disposed = false;
   const setThreadRowStatus = (threadId: unknown, status: unknown): void => {
     if (controller.signal.aborted) return;
     if (typeof threadId !== "string" || threadId.trim().length === 0) {
@@ -1153,7 +1183,6 @@ export async function mountPluginContentScripts(
         pluginId: options.pluginId,
         generation,
         signal: controller.signal,
-        experimental_getAppearance: getAppearance,
         ...(!options.omitExperimentalThreadRowStatus
           ? { experimental_setThreadRowStatus: setThreadRowStatus }
           : {}),
@@ -1180,10 +1209,10 @@ export async function mountPluginContentScripts(
         return disposed;
       },
       get experimental_appearance() {
-        return { ...appearanceSnapshot };
+        return testAppearanceStore.getSnapshotValues();
       },
       get experimental_appearancePreferenceCalls() {
-        return [...appearancePreferenceCalls];
+        return [...testAppearanceStore.preferenceCalls];
       },
       get threadRowStatusCalls() {
         return threadRowStatusCalls.map(({ threadId, status }) => ({
@@ -1427,46 +1456,14 @@ export function renderSlot<
     },
   };
 
-  let appearanceSnapshot: ExperimentalAppearanceSnapshot =
+  testAppearanceStore.reset(
     options.experimental_appearance ?? {
       colorMode: "light",
       colorModePreference: "system",
-    };
-  let systemColorMode = appearanceSnapshot.colorMode;
-  const appearanceListeners = new Set<() => void>();
-  const appearancePreferenceCalls: Array<
-    ExperimentalPluginAppearance["colorModePreference"]
-  > = [];
-  const publishAppearance = (next: ExperimentalAppearanceSnapshot): void => {
-    if (
-      next.colorMode === appearanceSnapshot.colorMode &&
-      next.colorModePreference === appearanceSnapshot.colorModePreference
-    ) {
-      return;
-    }
-    appearanceSnapshot = next;
-    for (const listener of appearanceListeners) listener();
-  };
-  const appearance: TestAppearanceStore = {
-    getSnapshot: () => appearanceSnapshot,
-    subscribe(listener) {
-      appearanceListeners.add(listener);
-      return () => appearanceListeners.delete(listener);
     },
-    setColorModePreference(preference) {
-      appearancePreferenceCalls.push(preference);
-      publishAppearance({
-        colorMode: preference === "system" ? systemColorMode : preference,
-        colorModePreference: preference,
-      });
-    },
-    setSnapshot(snapshot) {
-      if (snapshot.colorModePreference === "system") {
-        systemColorMode = snapshot.colorMode;
-      }
-      publishAppearance(snapshot);
-    },
-  };
+  );
+  const appearance = testAppearanceStore;
+  const appearancePreferenceCalls = testAppearanceStore.preferenceCalls;
 
   const navigateCalls: NavigateCall[] = [];
   const experimental_fixedTabOpenCalls: ExperimentalFixedTabOpenCall[] = [];
@@ -1729,7 +1726,6 @@ export function renderSlot<
     realtimeHandlers,
     realtimeConnection,
     settingsState: { values: options.settings, isLoading: false },
-    appearance,
     bbContext: { projectId, threadId },
     navigate,
     navigateCalls,

--- a/packages/plugin-sdk/src/testing/app.tsx
+++ b/packages/plugin-sdk/src/testing/app.tsx
@@ -61,6 +61,7 @@ import {
   type ExperimentalAppPanel,
   type ExperimentalFixedTabTargetState,
   type ExperimentalOpenFixedTabOptions,
+  type ExperimentalPluginAppearance,
   type ExperimentalPluginFixedTabReference,
   type NewThreadComposerProps,
   type ExperimentalPermissionModePickerProps,
@@ -168,12 +169,27 @@ interface TestComposerStore {
   subscribe(listener: () => void): () => void;
 }
 
+type ExperimentalAppearanceSnapshot = Pick<
+  ExperimentalPluginAppearance,
+  "colorMode" | "colorModePreference"
+>;
+
+interface TestAppearanceStore {
+  getSnapshot(): ExperimentalAppearanceSnapshot;
+  setColorModePreference(
+    preference: ExperimentalPluginAppearance["colorModePreference"],
+  ): void;
+  setSnapshot(snapshot: ExperimentalAppearanceSnapshot): void;
+  subscribe(listener: () => void): () => void;
+}
+
 interface SlotEnv {
   rpcClient: PluginRpcClient;
   rpcCalls: RpcCall[];
   realtimeHandlers: Map<string, Set<(payload: unknown) => void>>;
   realtimeConnection: TestRealtimeConnectionStore;
   settingsState: PluginSettingsState;
+  appearance: TestAppearanceStore;
   bbContext: BbContext;
   navigate: BbNavigate;
   navigateCalls: NavigateCall[];
@@ -736,6 +752,21 @@ const testPluginSdkApp = {
   useSettings(): PluginSettingsState {
     return useSlotEnv("useSettings").settingsState;
   },
+  experimental_useAppearance(): ExperimentalPluginAppearance {
+    const appearance = useSlotEnv("experimental_useAppearance").appearance;
+    const snapshot = useSyncExternalStore(
+      appearance.subscribe,
+      appearance.getSnapshot,
+      appearance.getSnapshot,
+    );
+    return useMemo(
+      () => ({
+        ...snapshot,
+        setColorModePreference: appearance.setColorModePreference,
+      }),
+      [appearance, snapshot],
+    );
+  },
   useBbContext(): BbContext {
     return useSlotEnv("useBbContext").bbContext;
   },
@@ -1093,6 +1124,11 @@ export interface RenderSlotOptions<
   context?: { projectId?: string | null; threadId?: string | null };
   /** Initial `useRealtimeConnectionState()` value; defaults to `connected`. */
   realtimeConnectionState?: PluginRealtimeConnectionState;
+  /**
+   * Initial `experimental_useAppearance()` state. Omitted → a system
+   * preference resolved to light.
+   */
+  experimental_appearance?: ExperimentalAppearanceSnapshot;
   /** Initial state for this render's isolated composer scope and view. */
   composer?: {
     text?: string;
@@ -1145,6 +1181,10 @@ export interface RenderedSlotBehaviorDrivers {
   setRealtimeConnectionState(
     state: PluginRealtimeConnectionState,
   ): Promise<void>;
+  /** Drive a client appearance change, including an OS change under system. */
+  experimental_setAppearance(
+    appearance: ExperimentalAppearanceSnapshot,
+  ): Promise<void>;
   /** Replace composer text as a host-originated edit, wrapped in act. */
   setComposerText(text: string): Promise<void>;
   /** Replace the scope snapshots returned by composer hooks, wrapped in act. */
@@ -1161,6 +1201,10 @@ export interface RenderedSlotInspectionState {
   readonly experimental_fixedTabOpenCalls: ExperimentalFixedTabOpenCall[];
   /** Every `experimental_useSidebarThreadActions()` call, in order. */
   readonly sidebarActionCalls: SidebarActionCall[];
+  /** Every client mode preference requested through the appearance hook. */
+  readonly experimental_appearancePreferenceCalls: Array<
+    ExperimentalPluginAppearance["colorModePreference"]
+  >;
   /** Everything written through `useComposer()`. */
   readonly composer: ComposerLog;
 }
@@ -1276,6 +1320,47 @@ export function renderSlot<
       if (state === realtimeConnectionState) return;
       realtimeConnectionState = state;
       for (const listener of realtimeConnectionListeners) listener();
+    },
+  };
+
+  let appearanceSnapshot: ExperimentalAppearanceSnapshot =
+    options.experimental_appearance ?? {
+      colorMode: "light",
+      colorModePreference: "system",
+    };
+  let systemColorMode = appearanceSnapshot.colorMode;
+  const appearanceListeners = new Set<() => void>();
+  const appearancePreferenceCalls: Array<
+    ExperimentalPluginAppearance["colorModePreference"]
+  > = [];
+  const publishAppearance = (next: ExperimentalAppearanceSnapshot): void => {
+    if (
+      next.colorMode === appearanceSnapshot.colorMode &&
+      next.colorModePreference === appearanceSnapshot.colorModePreference
+    ) {
+      return;
+    }
+    appearanceSnapshot = next;
+    for (const listener of appearanceListeners) listener();
+  };
+  const appearance: TestAppearanceStore = {
+    getSnapshot: () => appearanceSnapshot,
+    subscribe(listener) {
+      appearanceListeners.add(listener);
+      return () => appearanceListeners.delete(listener);
+    },
+    setColorModePreference(preference) {
+      appearancePreferenceCalls.push(preference);
+      publishAppearance({
+        colorMode: preference === "system" ? systemColorMode : preference,
+        colorModePreference: preference,
+      });
+    },
+    setSnapshot(snapshot) {
+      if (snapshot.colorModePreference === "system") {
+        systemColorMode = snapshot.colorMode;
+      }
+      publishAppearance(snapshot);
     },
   };
 
@@ -1540,6 +1625,7 @@ export function renderSlot<
     realtimeHandlers,
     realtimeConnection,
     settingsState: { values: options.settings, isLoading: false },
+    appearance,
     bbContext: { projectId, threadId },
     navigate,
     navigateCalls,
@@ -1595,6 +1681,11 @@ export function renderSlot<
   ): Promise<void> => {
     await act(async () => realtimeConnection.setState(state));
   };
+  const setAppearance = async (
+    snapshot: ExperimentalAppearanceSnapshot,
+  ): Promise<void> => {
+    await act(async () => appearance.setSnapshot(snapshot));
+  };
   const setComposerText = async (text: string): Promise<void> => {
     await act(async () => commitComposerText(text));
   };
@@ -1618,15 +1709,18 @@ export function renderSlot<
     rpcCalls,
     emitRealtime,
     setRealtimeConnectionState,
+    experimental_setAppearance: setAppearance,
     setComposerText,
     setComposerScope,
     navigateCalls,
     experimental_fixedTabOpenCalls,
     sidebarActionCalls,
+    experimental_appearancePreferenceCalls: appearancePreferenceCalls,
     composer: composerLog,
     behavior: {
       emitRealtime,
       setRealtimeConnectionState,
+      experimental_setAppearance: setAppearance,
       setComposerText,
       setComposerScope,
     },
@@ -1635,6 +1729,7 @@ export function renderSlot<
       navigateCalls,
       experimental_fixedTabOpenCalls,
       sidebarActionCalls,
+      experimental_appearancePreferenceCalls: appearancePreferenceCalls,
       composer: composerLog,
     },
     lifecycle: { rerender: rerenderSlot, unmount: unmountSlot },

--- a/packages/plugin-sdk/src/testing/app.tsx
+++ b/packages/plugin-sdk/src/testing/app.tsx
@@ -40,6 +40,7 @@ import {
   type PluginSdkApp,
   type PluginSettingsSectionRegistration,
   type PluginSettingsState,
+  type PluginSidebarFooterActionContext,
   type PluginSidebarFooterActionRegistration,
   type PluginSidebarPullRequest,
   type PluginSidebarThreadActions,
@@ -959,10 +960,81 @@ export async function loadPluginApp(
   return collectPluginAppRegistrations(definition);
 }
 
+export interface ExperimentalRunSidebarFooterActionOptions {
+  /** Appearance snapshot supplied to the action. Defaults to light/system. */
+  experimental_appearance?: ExperimentalAppearanceSnapshot;
+  /** Optional assertion spy or host-like implementation. */
+  openSettings?: () => void;
+}
+
+export interface ExperimentalRunSidebarFooterActionResult {
+  /** Appearance after every preference write made by the action. */
+  appearance: ExperimentalAppearanceSnapshot;
+  /** Number of times the action requested its plugin detail page. */
+  openSettingsCalls: number;
+  /** Preference writes made through the action context, in order. */
+  experimental_appearancePreferenceCalls: Array<
+    ExperimentalPluginAppearance["colorModePreference"]
+  >;
+}
+
+/**
+ * Run a captured host-rendered footer action with the same semantic appearance
+ * context BB supplies at click time.
+ */
+export async function experimental_runSidebarFooterAction(
+  registration: PluginSidebarFooterActionRegistration,
+  options: ExperimentalRunSidebarFooterActionOptions = {},
+): Promise<ExperimentalRunSidebarFooterActionResult> {
+  let appearanceSnapshot: ExperimentalAppearanceSnapshot = {
+    ...(options.experimental_appearance ?? {
+      colorMode: "light",
+      colorModePreference: "system",
+    }),
+  };
+  const systemColorMode = appearanceSnapshot.colorMode;
+  const appearancePreferenceCalls: Array<
+    ExperimentalPluginAppearance["colorModePreference"]
+  > = [];
+  const appearance: ExperimentalPluginAppearance = {
+    get colorMode() {
+      return appearanceSnapshot.colorMode;
+    },
+    get colorModePreference() {
+      return appearanceSnapshot.colorModePreference;
+    },
+    setColorModePreference(preference) {
+      appearancePreferenceCalls.push(preference);
+      appearanceSnapshot = {
+        colorMode: preference === "system" ? systemColorMode : preference,
+        colorModePreference: preference,
+      };
+    },
+  };
+  let openSettingsCalls = 0;
+  const context: PluginSidebarFooterActionContext = {
+    experimental_appearance: appearance,
+    openSettings() {
+      openSettingsCalls += 1;
+      options.openSettings?.();
+    },
+  };
+
+  await registration.run(context);
+
+  return {
+    appearance: { ...appearanceSnapshot },
+    openSettingsCalls,
+    experimental_appearancePreferenceCalls: [...appearancePreferenceCalls],
+  };
+}
+
 export interface ContentScriptTestMountOptions {
   pluginId: string;
   /** Defaults to 1. Pass the host generation you want the plugin to observe. */
   generation?: number;
+  /** Initial value returned by `experimental_getAppearance()`. */
+  experimental_appearance?: ExperimentalAppearanceSnapshot;
   /**
    * Simulate an older compatible host that predates the optional experimental
    * thread-row status API. Current-host behavior is enabled by default.
@@ -980,6 +1052,10 @@ export interface MountedPluginContentScripts {
     readonly mountedIds: readonly string[];
     readonly signal: AbortSignal;
     readonly disposed: boolean;
+    /** Current semantic appearance after content-script preference writes. */
+    readonly experimental_appearance: ExperimentalAppearanceSnapshot;
+    /** Preference writes made through `experimental_getAppearance()`. */
+    readonly experimental_appearancePreferenceCalls: readonly ExperimentalPluginAppearance["colorModePreference"][];
     readonly threadRowStatusCalls: readonly ContentScriptThreadRowStatusCall[];
     getThreadRowStatus(threadId: string): PluginComposerThreadRowStatus | null;
   };
@@ -1006,7 +1082,28 @@ export async function mountPluginContentScripts(
   }> = [];
   const threadRowStatuses = new Map<string, PluginComposerThreadRowStatus>();
   const threadRowStatusCalls: ContentScriptThreadRowStatusCall[] = [];
+  let appearanceSnapshot: ExperimentalAppearanceSnapshot = {
+    ...(options.experimental_appearance ?? {
+      colorMode: "light",
+      colorModePreference: "system",
+    }),
+  };
+  const systemColorMode = appearanceSnapshot.colorMode;
+  const appearancePreferenceCalls: Array<
+    ExperimentalPluginAppearance["colorModePreference"]
+  > = [];
   let disposed = false;
+  const getAppearance = (): ExperimentalPluginAppearance => ({
+    ...appearanceSnapshot,
+    setColorModePreference(preference) {
+      if (controller.signal.aborted) return;
+      appearancePreferenceCalls.push(preference);
+      appearanceSnapshot = {
+        colorMode: preference === "system" ? systemColorMode : preference,
+        colorModePreference: preference,
+      };
+    },
+  });
   const setThreadRowStatus = (threadId: unknown, status: unknown): void => {
     if (controller.signal.aborted) return;
     if (typeof threadId !== "string" || threadId.trim().length === 0) {
@@ -1056,6 +1153,7 @@ export async function mountPluginContentScripts(
         pluginId: options.pluginId,
         generation,
         signal: controller.signal,
+        experimental_getAppearance: getAppearance,
         ...(!options.omitExperimentalThreadRowStatus
           ? { experimental_setThreadRowStatus: setThreadRowStatus }
           : {}),
@@ -1080,6 +1178,12 @@ export async function mountPluginContentScripts(
       signal: controller.signal,
       get disposed() {
         return disposed;
+      },
+      get experimental_appearance() {
+        return { ...appearanceSnapshot };
+      },
+      get experimental_appearancePreferenceCalls() {
+        return [...appearancePreferenceCalls];
       },
       get threadRowStatusCalls() {
         return threadRowStatusCalls.map(({ threadId, status }) => ({

--- a/packages/sdk/src/areas/theme.ts
+++ b/packages/sdk/src/areas/theme.ts
@@ -18,7 +18,7 @@ export interface ThemeGetArgs {
 export interface ThemeArea {
   /** The active app palette, resolved server-side (built-in id or custom CSS). */
   get(args?: ThemeGetArgs): Promise<ThemeGetResult>;
-  /** The custom-theme directory plus discovered themes and the active palette. */
+  /** Canonical built-ins, custom/plugin palettes, their directory, and active palette. */
   catalog(args?: ThemeCatalogArgs): Promise<ThemeCatalogResult>;
   /** Set the complete app appearance selection in one request. */
   set(selection: ThemeSetInput): Promise<ThemeSetResult>;

--- a/packages/sdk/test/public-types.test.ts
+++ b/packages/sdk/test/public-types.test.ts
@@ -448,6 +448,14 @@ describe("SDK public type entrypoints", () => {
     >();
   });
 
+  it("types built-in palette ids in the experimental theme catalog", () => {
+    expectTypeOf<
+      RootThemeCatalog["experimental_builtIn"][number]["id"]
+    >().toEqualTypeOf<
+      "default" | "nord" | "dracula" | "solarized" | "gruvbox" | "catppuccin"
+    >();
+  });
+
   it("makes provider host selectors mutually exclusive", () => {
     expectTypeOf<{
       environmentId: string;

--- a/packages/server-contract/src/api/system.ts
+++ b/packages/server-contract/src/api/system.ts
@@ -6,6 +6,7 @@ import {
   appKeybindingsSchema,
   appThemeSchema,
   availableModelSchema,
+  BUILTIN_THEME_IDS,
   experimentsSchema,
   featureFlagsSchema,
   permissionModeSchema,
@@ -194,12 +195,24 @@ export type SystemAttentionResponse = z.infer<
 >;
 
 /**
- * Theme catalog: the on-disk custom-theme directory plus the discovered custom
- * themes and the active palette. Drives `bb theme list` / `bb theme dir`.
+ * Theme catalog: canonical built-ins, the on-disk custom-theme directory,
+ * discovered custom/plugin themes, and the active palette. Drives
+ * `bb theme list` / `bb theme dir` and plugin palette pickers.
  */
 export const themeCatalogResponseSchema = z.object({
   /** Absolute path of the custom-theme root: `<data-dir>/theme`. */
   dir: z.string(),
+  /**
+   * Canonical metadata for BB's bundled palettes, in display order.
+   * Experimental: see `docs/api_to_audit.md`.
+   */
+  experimental_builtIn: z.array(
+    z.object({
+      id: z.enum(BUILTIN_THEME_IDS),
+      name: z.string().min(1),
+      description: z.string().min(1),
+    }),
+  ),
   /** Discovered custom theme names (each has a `theme.css`). */
   custom: z.array(z.string()),
   /** Palettes contributed by currently loaded plugins. */

--- a/plugins/plugin-api-tester/app.test.tsx
+++ b/plugins/plugin-api-tester/app.test.tsx
@@ -1,7 +1,11 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { loadPluginApp, renderSlot } from "@get-bb/plugin-sdk/testing/app";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  experimental_runSidebarFooterAction,
+  loadPluginApp,
+  renderSlot,
+} from "@get-bb/plugin-sdk/testing/app";
 
 const app = await loadPluginApp(() => import("./app"));
 
@@ -54,16 +58,30 @@ describe("Plugin API Tester app", () => {
     );
   });
 
-  it("registers a footer shortcut to the plugin detail page", async () => {
+  it("toggles the resolved color mode directly from the footer", async () => {
     expect(app.sidebarFooterActions).toHaveLength(1);
     expect(app.sidebarFooterActions[0]).toMatchObject({
-      id: "open-plugin-api-tester",
-      title: "Plugin API Tester",
+      id: "toggle-color-mode",
+      title: "Toggle color mode",
       icon: "Beaker",
     });
 
-    const openSettings = vi.fn();
-    await app.sidebarFooterActions[0]!.run({ openSettings });
-    expect(openSettings).toHaveBeenCalledOnce();
+    const result = await experimental_runSidebarFooterAction(
+      app.sidebarFooterActions[0]!,
+      {
+        experimental_appearance: {
+          colorMode: "dark",
+          colorModePreference: "system",
+        },
+      },
+    );
+    expect(result).toEqual({
+      appearance: {
+        colorMode: "light",
+        colorModePreference: "light",
+      },
+      openSettingsCalls: 0,
+      experimental_appearancePreferenceCalls: ["light"],
+    });
   });
 });

--- a/plugins/plugin-api-tester/app.test.tsx
+++ b/plugins/plugin-api-tester/app.test.tsx
@@ -1,14 +1,14 @@
 // @vitest-environment jsdom
-import { cleanup } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadPluginApp, renderSlot } from "@get-bb/plugin-sdk/testing/app";
 
 const app = await loadPluginApp(() => import("./app"));
 
 afterEach(cleanup);
 
-describe("Plugin API Tester panel", () => {
-  it("registers and renders the placeholder panel", async () => {
+describe("Plugin API Tester app", () => {
+  it("renders reactive appearance state and writes client preferences", async () => {
     expect(app.navPanels).toHaveLength(1);
     expect(app.navPanels[0]).toMatchObject({
       id: "plugin-api-tester",
@@ -17,7 +17,53 @@ describe("Plugin API Tester panel", () => {
       path: "plugin-api-tester",
     });
 
-    const slot = renderSlot(app.navPanels[0]!, { subPath: "" });
+    const slot = renderSlot(
+      app.navPanels[0]!,
+      { subPath: "" },
+      {
+        experimental_appearance: {
+          colorMode: "dark",
+          colorModePreference: "system",
+        },
+      },
+    );
     expect(await slot.findByText("Plugin API Tester is active")).toBeTruthy();
+    expect(slot.getByLabelText("Resolved color mode").textContent).toBe("dark");
+    expect(slot.getByLabelText("Color mode preference").textContent).toBe(
+      "system",
+    );
+
+    fireEvent.click(slot.getByRole("button", { name: "Light" }));
+    expect(slot.inspection.experimental_appearancePreferenceCalls).toEqual([
+      "light",
+    ]);
+    expect(slot.getByLabelText("Resolved color mode").textContent).toBe(
+      "light",
+    );
+    expect(slot.getByLabelText("Color mode preference").textContent).toBe(
+      "light",
+    );
+
+    await slot.behavior.experimental_setAppearance({
+      colorMode: "dark",
+      colorModePreference: "system",
+    });
+    expect(slot.getByLabelText("Resolved color mode").textContent).toBe("dark");
+    expect(slot.getByLabelText("Color mode preference").textContent).toBe(
+      "system",
+    );
+  });
+
+  it("registers a footer shortcut to the plugin detail page", async () => {
+    expect(app.sidebarFooterActions).toHaveLength(1);
+    expect(app.sidebarFooterActions[0]).toMatchObject({
+      id: "open-plugin-api-tester",
+      title: "Plugin API Tester",
+      icon: "Beaker",
+    });
+
+    const openSettings = vi.fn();
+    await app.sidebarFooterActions[0]!.run({ openSettings });
+    expect(openSettings).toHaveBeenCalledOnce();
   });
 });

--- a/plugins/plugin-api-tester/app.test.tsx
+++ b/plugins/plugin-api-tester/app.test.tsx
@@ -1,11 +1,7 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import {
-  experimental_runSidebarFooterAction,
-  loadPluginApp,
-  renderSlot,
-} from "@get-bb/plugin-sdk/testing/app";
+import { loadPluginApp, renderSlot } from "@get-bb/plugin-sdk/testing/app";
 
 const app = await loadPluginApp(() => import("./app"));
 
@@ -20,6 +16,7 @@ describe("Plugin API Tester app", () => {
       icon: "Beaker",
       path: "plugin-api-tester",
     });
+    expect(app.sidebarFooterActions).toHaveLength(0);
 
     const slot = renderSlot(
       app.navPanels[0]!,
@@ -37,10 +34,17 @@ describe("Plugin API Tester app", () => {
       "system",
     );
 
-    fireEvent.click(slot.getByRole("button", { name: "Light" }));
+    const lightButton = slot.getByRole("button", { name: /Light/ });
+    const systemButton = slot.getByRole("button", { name: /System/ });
+    expect(lightButton.getAttribute("aria-pressed")).toBe("false");
+    expect(systemButton.getAttribute("aria-pressed")).toBe("true");
+
+    fireEvent.click(lightButton);
     expect(slot.inspection.experimental_appearancePreferenceCalls).toEqual([
       "light",
     ]);
+    expect(lightButton.getAttribute("aria-pressed")).toBe("true");
+    expect(systemButton.getAttribute("aria-pressed")).toBe("false");
     expect(slot.getByLabelText("Resolved color mode").textContent).toBe(
       "light",
     );
@@ -56,32 +60,7 @@ describe("Plugin API Tester app", () => {
     expect(slot.getByLabelText("Color mode preference").textContent).toBe(
       "system",
     );
-  });
-
-  it("toggles the resolved color mode directly from the footer", async () => {
-    expect(app.sidebarFooterActions).toHaveLength(1);
-    expect(app.sidebarFooterActions[0]).toMatchObject({
-      id: "toggle-color-mode",
-      title: "Toggle color mode",
-      icon: "Beaker",
-    });
-
-    const result = await experimental_runSidebarFooterAction(
-      app.sidebarFooterActions[0]!,
-      {
-        experimental_appearance: {
-          colorMode: "dark",
-          colorModePreference: "system",
-        },
-      },
-    );
-    expect(result).toEqual({
-      appearance: {
-        colorMode: "light",
-        colorModePreference: "light",
-      },
-      openSettingsCalls: 0,
-      experimental_appearancePreferenceCalls: ["light"],
-    });
+    expect(lightButton.getAttribute("aria-pressed")).toBe("false");
+    expect(systemButton.getAttribute("aria-pressed")).toBe("true");
   });
 });

--- a/plugins/plugin-api-tester/app.tsx
+++ b/plugins/plugin-api-tester/app.tsx
@@ -1,5 +1,6 @@
 import {
   definePluginApp,
+  experimental_appearance,
   experimental_useAppearance,
 } from "@get-bb/plugin-sdk/app";
 
@@ -86,7 +87,8 @@ export default definePluginApp((app) => {
     id: "toggle-color-mode",
     title: "Toggle color mode",
     icon: "Beaker",
-    run({ experimental_appearance: appearance }) {
+    run() {
+      const appearance = experimental_appearance.getSnapshot();
       appearance.setColorModePreference(
         appearance.colorMode === "dark" ? "light" : "dark",
       );

--- a/plugins/plugin-api-tester/app.tsx
+++ b/plugins/plugin-api-tester/app.tsx
@@ -83,11 +83,13 @@ export default definePluginApp((app) => {
     component: PluginApiTesterPanel,
   });
   app.slots.sidebarFooterAction({
-    id: "open-plugin-api-tester",
-    title: "Plugin API Tester",
+    id: "toggle-color-mode",
+    title: "Toggle color mode",
     icon: "Beaker",
-    run({ openSettings }) {
-      openSettings();
+    run({ experimental_appearance: appearance }) {
+      appearance.setColorModePreference(
+        appearance.colorMode === "dark" ? "light" : "dark",
+      );
     },
   });
 });

--- a/plugins/plugin-api-tester/app.tsx
+++ b/plugins/plugin-api-tester/app.tsx
@@ -1,6 +1,17 @@
-import { definePluginApp } from "@get-bb/plugin-sdk/app";
+import {
+  definePluginApp,
+  experimental_useAppearance,
+} from "@get-bb/plugin-sdk/app";
+
+const COLOR_MODE_PREFERENCES = [
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+  { value: "system", label: "System" },
+] as const;
 
 function PluginApiTesterPanel() {
+  const appearance = experimental_useAppearance();
+
   return (
     <div className="h-full overflow-y-auto p-4 md:p-5">
       <div className="mx-auto w-full max-w-3xl space-y-4">
@@ -13,6 +24,51 @@ function PluginApiTesterPanel() {
             disabled by default in production.
           </p>
         </div>
+        <section className="space-y-3 rounded-lg border border-border bg-card p-4">
+          <div>
+            <h2 className="text-sm font-medium text-foreground">Appearance</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Live values from the experimental plugin appearance contract.
+            </p>
+          </div>
+          <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-sm">
+            <dt className="text-muted-foreground">Resolved color mode</dt>
+            <dd>
+              <output
+                aria-label="Resolved color mode"
+                className="font-medium text-foreground"
+              >
+                {appearance.colorMode}
+              </output>
+            </dd>
+            <dt className="text-muted-foreground">Preference</dt>
+            <dd>
+              <output
+                aria-label="Color mode preference"
+                className="font-medium text-foreground"
+              >
+                {appearance.colorModePreference}
+              </output>
+            </dd>
+          </dl>
+          <div
+            aria-label="Set color mode preference"
+            className="flex flex-wrap gap-2"
+            role="group"
+          >
+            {COLOR_MODE_PREFERENCES.map(({ value, label }) => (
+              <button
+                key={value}
+                aria-pressed={appearance.colorModePreference === value}
+                className="rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground hover:bg-muted aria-pressed:border-primary aria-pressed:bg-primary aria-pressed:text-primary-foreground"
+                type="button"
+                onClick={() => appearance.setColorModePreference(value)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </section>
       </div>
     </div>
   );
@@ -25,5 +81,13 @@ export default definePluginApp((app) => {
     icon: "Beaker",
     path: "plugin-api-tester",
     component: PluginApiTesterPanel,
+  });
+  app.slots.sidebarFooterAction({
+    id: "open-plugin-api-tester",
+    title: "Plugin API Tester",
+    icon: "Beaker",
+    run({ openSettings }) {
+      openSettings();
+    },
   });
 });

--- a/plugins/plugin-api-tester/app.tsx
+++ b/plugins/plugin-api-tester/app.tsx
@@ -1,13 +1,24 @@
 import {
   definePluginApp,
-  experimental_appearance,
   experimental_useAppearance,
 } from "@get-bb/plugin-sdk/app";
 
 const COLOR_MODE_PREFERENCES = [
-  { value: "light", label: "Light" },
-  { value: "dark", label: "Dark" },
-  { value: "system", label: "System" },
+  {
+    value: "light",
+    label: "Light",
+    description: "Always use light mode",
+  },
+  {
+    value: "dark",
+    label: "Dark",
+    description: "Always use dark mode",
+  },
+  {
+    value: "system",
+    label: "System",
+    description: "Follow this device",
+  },
 ] as const;
 
 function PluginApiTesterPanel() {
@@ -54,18 +65,33 @@ function PluginApiTesterPanel() {
           </dl>
           <div
             aria-label="Set color mode preference"
-            className="flex flex-wrap gap-2"
+            className="grid gap-2 sm:grid-cols-3"
             role="group"
           >
-            {COLOR_MODE_PREFERENCES.map(({ value, label }) => (
+            {COLOR_MODE_PREFERENCES.map(({ value, label, description }) => (
               <button
                 key={value}
                 aria-pressed={appearance.colorModePreference === value}
-                className="rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground hover:bg-muted aria-pressed:border-primary aria-pressed:bg-primary aria-pressed:text-primary-foreground"
+                className="group inline-flex min-h-16 w-full cursor-pointer items-center justify-start gap-3 whitespace-normal rounded-md border border-input bg-transparent px-3 py-3 text-left text-sm font-medium transition-colors hover:bg-state-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring aria-pressed:border-foreground aria-pressed:bg-state-active aria-pressed:hover:bg-state-active"
                 type="button"
                 onClick={() => appearance.setColorModePreference(value)}
               >
-                {label}
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-medium text-foreground">
+                    {label}
+                  </span>
+                  <span className="mt-0.5 block text-xs font-normal text-muted-foreground">
+                    {description}
+                  </span>
+                </span>
+                <span
+                  aria-hidden="true"
+                  className="flex size-5 shrink-0 items-center justify-center rounded-full border border-border text-background group-aria-pressed:border-foreground group-aria-pressed:bg-foreground"
+                >
+                  <span className="text-xs leading-none opacity-0 group-aria-pressed:opacity-100">
+                    ✓
+                  </span>
+                </span>
               </button>
             ))}
           </div>
@@ -82,16 +108,5 @@ export default definePluginApp((app) => {
     icon: "Beaker",
     path: "plugin-api-tester",
     component: PluginApiTesterPanel,
-  });
-  app.slots.sidebarFooterAction({
-    id: "toggle-color-mode",
-    title: "Toggle color mode",
-    icon: "Beaker",
-    run() {
-      const appearance = experimental_appearance.getSnapshot();
-      appearance.setColorModePreference(
-        appearance.colorMode === "dark" ? "light" : "dark",
-      );
-    },
   });
 });

--- a/plugins/plugin-api-tester/package.json
+++ b/plugins/plugin-api-tester/package.json
@@ -6,7 +6,7 @@
   "description": "Exercise and inspect bb plugin API surfaces during development.",
   "engines": {
     "bb": ">=0.0",
-    "bbPluginSdk": ">=0.4.13"
+    "bbPluginSdk": ">=0.4.14"
   },
   "bb": {
     "name": "Plugin API Tester",

--- a/plugins/plugin-api-tester/package.json
+++ b/plugins/plugin-api-tester/package.json
@@ -6,7 +6,7 @@
   "description": "Exercise and inspect bb plugin API surfaces during development.",
   "engines": {
     "bb": ">=0.0",
-    "bbPluginSdk": ">=0.4.10"
+    "bbPluginSdk": ">=0.4.13"
   },
   "bb": {
     "name": "Plugin API Tester",


### PR DESCRIPTION
## What was wrong

Plugin JavaScript consumers had no supported semantic contract for BB's client light/dark appearance even though the app already owns reactive mode and preference stores. Monaco 0.1.0 consequently observes BB's private root `dark` class to choose `vs` / `vs-dark`, while Theme Toggle 0.2.1 reads the private `bb.theme` storage key, dispatches a synthetic storage event, calls `matchMedia`, and mutates that root class from a content-script menu. Appearance access is a client-wide capability; coupling it separately to footer-action and content-script contexts would make the API depend on where code happened to run rather than what it needed.

The live marketplace audit also showed that mode must stay separate from palettes: Ayu 0.2.2 and Tokyo Night 0.1.0 already use `bb.themes` / `bb.sdk.theme`; Fonts 0.1.0 is only partially covered because it additionally needs a future palette-change notification, not speculative palette values or CSS tokens here.

Separately, `bb.sdk.theme.catalog()` omitted BB's own bundled palettes. Theme Toggle therefore copies the six built-in ids, names, and descriptions into its server code before appending the catalog's custom and plugin palettes; that copy can silently drift from BB's canonical list and ordering.

## What changed

- Added one typed semantic client-appearance contract: resolved `colorMode`, client-local `colorModePreference`, and `setColorModePreference(...)`.
- Exported one app-wide `experimental_appearance` external store from `@get-bb/plugin-sdk/app`:
  - `getSnapshot()` supports point-of-use reads from any plugin module, callback, content script, or setup code.
  - `subscribe(listener)` supports non-React reactivity and returns its cleanup function.
  - `experimental_useAppearance()` is the React convenience wrapper over the same store for Monaco-style consumers.
- Kept surface contexts focused: `sidebarFooterAction.run` still receives only `openSettings`, and `PluginContentScriptContext` still contains lifecycle plus its existing optional thread-row status API. There are no appearance-specific footer/content-script adapters.
- Migrated the development-only Plugin API Tester as the in-repo consumer. Its panel uses the hook and presents Light, Dark, and System as responsive, descriptive choices with explicit pressed and focus states. It no longer registers a sidebar footer action.
- Added representative external contract fixtures: a Theme Toggle-style content script imports the same store, the Monaco fixture verifies reactive `vs` / `vs-dark` mapping, and a palette-switcher fixture builds its choices from the SDK theme catalog.
- Extended `bb.sdk.theme.catalog()` with required `experimental_builtIn` metadata sourced from BB's canonical `builtInThemes` list. Built-in ids retain their exact string union; the field contains only id, name, description, and canonical display order.
- Migrated `bb theme list` to consume `catalog.experimental_builtIn` while preserving its existing `builtInThemes` JSON output key.
- Kept `AppToaster` on BB's internal theme hook; first-party app chrome does not consume the plugin facade.
- Documented both experimental contracts in `docs/api_to_audit.md`, updated the canonical `bb-plugin-authoring` skill and SDK test harness, and bumped the plugin SDK from `0.4.13` to `0.4.14` (Plugin API Tester requires it).
- Kept palette CSS, code-theme assets, typography tokens, DOM classes, and storage keys out of the contracts. There is no server/host-daemon wire change, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

Measured from the branch base (`0e12ccca7`) with clean Turbo builds:

- App entry: 537,289 → 537,289 raw bytes (+0); 166,891 → 166,897 gzip (+6).
- Full boot closure: 1,617,883 → 1,618,069 raw (+186); 520,415 → 520,470 gzip (+55).
- Existing lazy plugin-frontend chunk: 132,213 → 132,916 raw (+703); 39,508 → 39,758 gzip (+250).
- SDK app facade: 1,976 → 2,165 raw (+189); 476 → 502 gzip (+26).
- Optional testing harness: 57,964 → 61,276 raw (+3,312); 11,585 → 12,145 gzip (+560).
- The catalog addition itself contributes 77 raw / 14 gzip / 32 brotli bytes to the existing preloaded query-helper chunk and zero plugin SDK runtime JavaScript.
- The final Plugin API Tester panel refinement, measured against `4bc815bf2`, adds 688 raw / 220 gzip bytes of optional plugin JavaScript and 9,279 raw / 955 gzip bytes of scoped plugin CSS. It adds no dependency and does not affect app boot.
- Chunk counts are unchanged (72 boot / 559 total). There is no new dependency or lazy chunk; Plugin API Tester remains a separately built development plugin.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/server --filter=@bb/cli --filter=@bb/sdk --filter=@bb/server-contract --filter=@get-bb/plugin-sdk` — 9/9 tasks passed.
- `pnpm exec turbo run build --filter=@bb/server --filter=@bb/cli --filter=@bb/sdk --filter=@bb/server-contract --filter=@get-bb/plugin-sdk --filter=@bb/app` — 9/9 tasks passed.
- `pnpm exec turbo run test --filter=@bb/server --force -- test/system/appearance.test.ts` — 14 tests passed, including canonical catalog mapping.
- `pnpm exec turbo run test --filter=@get-bb/plugin-sdk --force -- src/testing/__tests__/fake-plugin-host.test.ts` — 44 tests passed, including the palette-switcher contract fixture.
- `pnpm exec turbo run test --filter=@bb/sdk --force -- test/public-types.test.ts` — 9 tests passed, including the exact built-in id union.
- `pnpm exec turbo run test --filter=@bb/server --force -- test/services/plugins/plugin-authoring-docs.test.ts` — 14 tests passed.
- `pnpm exec turbo run typecheck --filter=bb-plugin-plugin-api-tester` — 4/4 tasks passed.
- `pnpm exec turbo run test --filter=bb-plugin-plugin-api-tester --force` — 1 focused behavior test passed, covering panel writes, external reactivity, pressed state, and absence of a footer contribution.
- `pnpm exec turbo run build --filter=bb-app` — 11/11 tasks passed; the packaged plugin contains no footer-action registration.
- Earlier appearance-slice validation remains green: plugin SDK suites, focused app behavior tests, app lint, and clean app/SDK builds.
- `git diff --check` — passed.

Fixes: no linked issue.

> AGENT GENERATED: by GPT-5
