### PR TITLE
Fix Node 22 desktop dev startup

### DIFF
--- a/apps/host-daemon/src/command-dispatch.ts
+++ b/apps/host-daemon/src/command-dispatch.ts
@@ -1,12 +1,12 @@
 import {
   providerCliInstallEventSchema,
+  type HostDaemonCommand,
+  type HostDaemonCommandResult,
+  type HostDaemonOnlineRpcCommand,
+  type HostDaemonOnlineRpcCommandType,
+  type HostDaemonOnlineRpcResult,
+  type HostDaemonSettledCommandType,
   type ProviderCliInstallEvent,
-  HostDaemonCommand,
-  HostDaemonCommandResult,
-  HostDaemonOnlineRpcCommand,
-  HostDaemonOnlineRpcCommandType,
-  HostDaemonOnlineRpcResult,
-  HostDaemonSettledCommandType,
 } from "@bb/host-daemon-contract";
 import semver from "semver";
 import {


### PR DESCRIPTION
## What was wrong

The supported Node 22 desktop development path loaded `apps/host-daemon/src/command-dispatch.ts` directly through TSX, but several host-daemon contracts were imported as runtime values even though they are TypeScript types. Those erased exports do not exist at runtime, so the source dev server session stalled before the Electron shell could launch.

## What changed

- Mark the affected host-daemon command contracts as type-only imports.
- No host-daemon wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/host-daemon`
- Ran `pnpm dev:desktop` with Node 22.22.1 and verified that the dev server and Electron desktop sessions both started successfully.

No linked issue.

> AGENT GENERATED: by GPT-5.6