### PR TITLE
Run the nightly desktop publish job on the nightly paths

### DIFF
--- a/.github/workflows/publish-bb-app.yml
+++ b/.github/workflows/publish-bb-app.yml
@@ -750,6 +750,15 @@ jobs:
 
   nightly-desktop-publish:
     name: Publish bb Nightly desktop
+    # See the macOS job for why this condition uses `!cancelled()`. GitHub
+    # propagates a skip transitively, so the skipped publish-nightly reaches
+    # this job through the build jobs even though they run. Without the
+    # override this job is skipped on exactly the paths that exist to produce
+    # a nightly, and only a stable release run ever moves the release.
+    if: >-
+      ${{ !cancelled()
+      && needs.nightly-desktop-macos.result == 'success'
+      && needs.nightly-desktop-linux.result == 'success' }}
     needs:
       - nightly-desktop-macos
       - nightly-desktop-linux


### PR DESCRIPTION
## Human comments

Scheduled runs of the publish-bb-app.yml workflow are supposed to publish nightly but it is instead building the BB app and skipping the publish step, see run on april 20: https://github.com/get-bb/bb/actions/runs/32358956903

----

## What was wrong

The `desktop-nightly` release has not been updated by a nightly run since #1651 landed on 2026-08-15. The nightly desktop builds themselves have been fine — they succeed every night and then discard their artifacts.

`nightly-desktop-publish` is declared with no `if:`, so it defaults to `success()`. #1651 added the `publish-nightly` job and put it in the `needs` graph of both desktop build jobs, where it is skipped by design on the scheduled and manual-nightly paths. GitHub propagates a skip **transitively** through `needs`, so that skip reaches `nightly-desktop-publish` even though both of its direct needs run and succeed. The build jobs already anticipate this and override it with `!cancelled()` — see the comment at `publish-bb-app.yml:493-495` — but the publish job never got the same guard.

```
publish ──────┐
              ├─→ nightly-desktop-macos ──┐
publish-      │   nightly-desktop-linux ──┴─→ nightly-desktop-publish
nightly ──────┘   (if: !cancelled() ...)      (no if: → inherits the skip)
[skipped]
```

The net effect is that the job is skipped on exactly the two paths whose purpose is to produce a nightly, and runs only on a stable release run — the one path where `publish-nightly` actually succeeds, leaving no skip in the graph. That is why the release still moves occasionally and looks merely stale rather than broken.

| Run | Date | Trigger | `Publish bb Nightly desktop` |
|---|---|---|---|
| [31693508850](https://github.com/get-bb/bb/actions/runs/31693508850) | Aug 13 | schedule | success |
| — | Aug 15 | [#1651](https://github.com/get-bb/bb/pull/1651) merges as [`8e6fc8358`](https://github.com/get-bb/bb/commit/8e6fc8358) | — |
| [32020362329](https://github.com/get-bb/bb/actions/runs/32020362329) | Aug 17 | schedule | **skipped** |
| [32358956903](https://github.com/get-bb/bb/actions/runs/32358956903) | Aug 20 | schedule | **skipped** |
| [32502502056](https://github.com/get-bb/bb/actions/runs/32502502056) | Aug 21 | dispatch, `npm_tag=nightly` | **skipped** |

Corroborating evidence: every asset currently on the release is `0.39.1-nightly.32204811379.1`, uploaded 2026-08-19 01:52Z by run [32204811379](https://github.com/get-bb/bb/actions/runs/32204811379) — an `npm_tag=latest` dispatch, i.e. the stable-release path.

## What changed

`.github/workflows/publish-bb-app.yml` — added an `if:` guard to `nightly-desktop-publish` mirroring the one on the two build jobs, so a transitively-skipped `publish-nightly` no longer skips it, while a genuine build failure still does:

```yaml
if: >-
  ${{ !cancelled()
  && needs.nightly-desktop-macos.result == 'success'
  && needs.nightly-desktop-linux.result == 'success' }}
```

The explicit `.result == 'success'` checks are required rather than relying on the default, because `!cancelled()` alone would let the job publish a partial release after a build job failed. No wire-format, CLI, or documented-surface changes, so no `HOST_DAEMON_PROTOCOL_VERSION` bump.

## How you verified

- Reproduced the root cause from run history rather than from the symptom: confirmed the last schedule-triggered run that published was Aug 13, before #1651, and that all three subsequent nightly-path runs show the job as `skipped` with both build jobs `success` (`gh api .../actions/runs/<id>/jobs`).
- Confirmed via the release asset manifest that the only run to move `desktop-nightly` since Aug 15 was the Aug 19 `latest` dispatch, matching the predicted "stable-release-only" path.
- Verified the edited workflow still parses and that the condition and `needs` resolve as intended (`yaml.safe_load` on the file, inspecting `jobs.nightly-desktop-publish`).

Full verification requires a live nightly run, since GitHub's transitive skip propagation cannot be exercised locally. Recommend confirming on the first cron after merge, or via a `workflow_dispatch` with `npm_tag=nightly`, `dry_run=false`.

Ruled out as causes: the two cron failures on Aug 18 and Aug 21 are unrelated — both are `Build bb Nightly desktop (Linux)` failing outright, a separate issue that is not addressed here.

Regression from #1651. No tracking issue was open at the time of filing.

> AGENT GENERATED: by Claude Opus 5
