### PR TITLE
bb plugin screenshot: plan and capture marketplace listing screenshots from the running app

### DIFF
--- a/apps/app/src/lib/plugin-slots.ts
+++ b/apps/app/src/lib/plugin-slots.ts
@@ -399,6 +399,17 @@ export function getPluginSlotSnapshot(): PluginSlotSnapshot {
   return snapshot;
 }
 
+// The listing-screenshot capture harness (`bb plugin screenshot --capture`)
+// drives a headless window at this app and needs to know which surfaces a
+// plugin actually registered — the one fact only the running renderer has.
+// Components carry functions, so the harness reads ids/paths, never this
+// object wholesale.
+if (typeof window !== "undefined") {
+  (
+    window as { __bbPluginSlotSnapshot?: () => PluginSlotSnapshot }
+  ).__bbPluginSlotSnapshot = getPluginSlotSnapshot;
+}
+
 /** All plugin slot registrations, re-rendering on store changes. */
 export function usePluginSlots(): PluginSlotSnapshot {
   return useSyncExternalStore(subscribePluginSlots, getPluginSlotSnapshot);

--- a/apps/cli/src/__tests__/plugin-screenshot.test.ts
+++ b/apps/cli/src/__tests__/plugin-screenshot.test.ts
@@ -1,0 +1,63 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { planPluginScreenshots } from "../plugin-screenshot.js";
+
+/** The plugins bb ships, which are the closest thing to real submissions. */
+const PLUGINS_DIR = new URL("../../../../plugins", import.meta.url).pathname;
+const plan = (name: string, pluginId: string, fixtureThreadId?: string) =>
+  planPluginScreenshots({
+    rootDir: join(PLUGINS_DIR, name),
+    pluginId,
+    ...(fixtureThreadId === undefined ? {} : { fixtureThreadId }),
+  });
+
+describe("planPluginScreenshots", () => {
+  it("leads a panel plugin's listing with its own panel", async () => {
+    const result = await plan("tasks", "tasks");
+    expect(result.steps[0]).toMatchObject({
+      slot: "navPanel",
+      url: "/plugins/tasks/tasks",
+      outputFile: "01-panel.png",
+    });
+  });
+
+  it("plans nothing for a plugin that paints nothing, and does not fail", async () => {
+    // provider-retry continues turns after a limit resets. A listing for it
+    // should never be held up waiting for a screenshot that cannot exist.
+    const result = await plan("provider-retry", "provider-retry");
+    expect(result.steps.filter((step) => step.kind === "route")).toEqual([]);
+  });
+
+  it("reports fixture-only surfaces instead of photographing an empty app", async () => {
+    const withoutFixture = await plan("inline-vis", "inline-vis");
+    expect(withoutFixture.steps).toEqual([]);
+    expect(withoutFixture.needsFixture).toContain("messageDirective");
+
+    const withFixture = await plan("inline-vis", "inline-vis", "thr_fixture");
+    expect(withFixture.needsFixture).toEqual([]);
+    expect(withFixture.steps).toEqual([
+      {
+        slot: "messageDirective",
+        kind: "fixture",
+        url: "/threads/thr_fixture",
+        outputFile: "06-message.png",
+        requires: "a thread whose last message carries the plugin's directive",
+      },
+    ]);
+  });
+
+  it("uses the plugin's real id in the panel URL, not its directory name", async () => {
+    // The docs plugin installs as `simple-notes`; a URL built from the folder
+    // would 404 for every listing screenshot it takes.
+    const result = await plan("docs", "simple-notes");
+    expect(result.steps[0]?.url).toBe("/plugins/simple-notes/docs");
+  });
+
+  it("ignores a plugin's vendored SDK declarations", async () => {
+    // Every plugin vendors types/ that mention every slot in the SDK. Reading
+    // those would plan a screenshot of every surface for every plugin.
+    const result = await plan("provider-codex", "provider-codex");
+    expect(result.slots).not.toContain("navPanel");
+    expect(result.slots).not.toContain("homepageSection");
+  });
+});

--- a/apps/cli/src/__tests__/plugin-screenshot.test.ts
+++ b/apps/cli/src/__tests__/plugin-screenshot.test.ts
@@ -61,3 +61,88 @@ describe("planPluginScreenshots", () => {
     expect(result.slots).not.toContain("homepageSection");
   });
 });
+
+describe("the capture harness planner", async () => {
+  const { createRequire } = await import("node:module");
+  const requireCjs = createRequire(import.meta.url);
+  const harness = requireCjs(
+    "../../../desktop/scripts/plugin-capture.cjs",
+  ) as {
+    planSteps: (
+      plan: {
+        pluginId: string;
+        surfaces: ReadonlyArray<{
+          slot: string;
+          kind: string;
+          route: string;
+          stem: string;
+        }>;
+        fixtureThreadId?: string;
+      },
+      slotIndex: Record<
+        string,
+        Array<{ pluginId: string; path?: string | null }>
+      >,
+    ) => Array<{ slot: string; url: string; outputFile: string }>;
+    SNAPSHOT_KEYS: Record<string, string>;
+  };
+
+  it("maps every capturable surface to a live snapshot key", async () => {
+    const { PLUGIN_CAPTURE_SURFACES } = await import("@bb/domain");
+    for (const surface of PLUGIN_CAPTURE_SURFACES) {
+      expect(harness.SNAPSHOT_KEYS[surface.slot], surface.slot).toBeTruthy();
+    }
+  });
+
+  it("shoots only the target plugin's registrations", () => {
+    const steps = harness.planSteps(
+      {
+        pluginId: "tasks",
+        surfaces: [
+          {
+            slot: "navPanel",
+            kind: "route",
+            route: "/plugins/:pluginId/:panelPath",
+            stem: "01-panel",
+          },
+        ],
+      },
+      {
+        navPanels: [
+          { pluginId: "tasks", path: "/board" },
+          { pluginId: "someone-else", path: "other" },
+        ],
+      },
+    );
+    expect(steps).toEqual([
+      { slot: "navPanel", url: "/plugins/tasks/board", outputFile: "01-panel.png" },
+    ]);
+  });
+
+  it("skips fixture surfaces without a fixture thread, like the CLI planner", () => {
+    const surfaces = [
+      {
+        slot: "messageDirective",
+        kind: "fixture",
+        route: "/threads/:threadId",
+        stem: "06-message",
+      },
+    ];
+    const slotIndex = { messageDirectives: [{ pluginId: "tasks" }] };
+    expect(
+      harness.planSteps({ pluginId: "tasks", surfaces }, slotIndex),
+    ).toEqual([]);
+    expect(
+      harness.planSteps(
+        { pluginId: "tasks", surfaces, fixtureThreadId: "thr_1" },
+        slotIndex,
+      ),
+    ).toEqual([
+      {
+        slot: "messageDirective",
+        url: "/threads/thr_1",
+        outputFile: "06-message.png",
+      },
+    ]);
+  });
+});

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -27,6 +27,7 @@ import {
   syncPluginTypes,
   type PluginPackageLayoutMigration,
 } from "@bb/templates/plugin-scaffold";
+import { planPluginScreenshots } from "../plugin-screenshot.js";
 import { action } from "../action.js";
 import { cliFetch, createCliBbSdk } from "../client.js";
 import {
@@ -1541,6 +1542,62 @@ export function registerPluginCommands(
           console.log(relative(process.cwd(), file));
         }
       }),
+    );
+
+  plugin
+    .command("screenshot [path]")
+    .description(
+      "Plan the listing screenshots for a plugin: reads the surfaces its frontend registers and reports one shot per surface. Surfaces that only exist inside a thread, composer, or open file need the shared capture fixture",
+    )
+    .option("--json", "Output JSON")
+    .option(
+      "--fixture-thread <id>",
+      "Thread the shared capture fixture seeded, enabling the surfaces that need one",
+    )
+    .action(
+      action(
+        async (
+          path: string | undefined,
+          opts: JsonOutputOptions & { fixtureThread?: string },
+        ) => {
+          const rootDir = resolve(process.cwd(), path ?? ".");
+          const raw: unknown = JSON.parse(
+            await readFile(join(rootDir, "package.json"), "utf8"),
+          );
+          const packageName = pluginPackageSummarySchema.parse(raw).name;
+          if (packageName === undefined) {
+            throw new Error(`No plugin package name in ${rootDir}/package.json`);
+          }
+          const plan = await planPluginScreenshots({
+            rootDir,
+            pluginId: derivePluginId(packageName),
+            ...(opts.fixtureThread === undefined
+              ? {}
+              : { fixtureThreadId: opts.fixtureThread }),
+          });
+          if (opts.json) {
+            outputJson(opts, plan);
+            return;
+          }
+          if (plan.slots.length === 0) {
+            // Not a failure: a plugin that only adds agent tools or a provider
+            // paints nothing, and its listing should not wait on a screenshot
+            // that cannot exist.
+            console.log(
+              `${plan.pluginId} registers no visual surface — no listing screenshots to take.`,
+            );
+            return;
+          }
+          for (const step of plan.steps) {
+            console.log(`${step.outputFile}  ${step.url}  (${step.slot})`);
+          }
+          for (const slot of plan.needsFixture) {
+            console.log(
+              `skipped ${slot} — needs the capture fixture; pass --fixture-thread <id>`,
+            );
+          }
+        },
+      ),
     );
 
   plugin

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -27,7 +27,11 @@ import {
   syncPluginTypes,
   type PluginPackageLayoutMigration,
 } from "@bb/templates/plugin-scaffold";
-import { planPluginScreenshots } from "../plugin-screenshot.js";
+import {
+  planPluginScreenshots,
+  resolveElectronBinary,
+  runPluginCapture,
+} from "../plugin-screenshot.js";
 import { action } from "../action.js";
 import { cliFetch, createCliBbSdk } from "../client.js";
 import {
@@ -1554,11 +1558,15 @@ export function registerPluginCommands(
       "--fixture-thread <id>",
       "Thread the shared capture fixture seeded, enabling the surfaces that need one",
     )
+    .option(
+      "--capture <outDir>",
+      "Take the screenshots: drives a headless window at this bb, reads which surfaces the plugin registered from the running app, and writes one PNG per surface into <outDir>",
+    )
     .action(
       action(
         async (
           path: string | undefined,
-          opts: JsonOutputOptions & { fixtureThread?: string },
+          opts: JsonOutputOptions & { fixtureThread?: string; capture?: string },
         ) => {
           const rootDir = resolve(process.cwd(), path ?? ".");
           const raw: unknown = JSON.parse(
@@ -1595,6 +1603,37 @@ export function registerPluginCommands(
             console.log(
               `skipped ${slot} — needs the capture fixture; pass --fixture-thread <id>`,
             );
+          }
+          if (opts.capture !== undefined) {
+            const harnessPath = resolve(
+              import.meta.dirname,
+              "../../desktop/scripts/plugin-capture.cjs",
+            );
+            const electronBinary = resolveElectronBinary(
+              process.env,
+              harnessPath,
+            );
+            if (electronBinary === null) {
+              throw new Error(
+                "No Electron found for the capture harness. Run from a bb checkout, or set BB_ELECTRON to an Electron binary.",
+              );
+            }
+            const report = await runPluginCapture({
+              serverUrl: getUrl(),
+              pluginId: plan.pluginId,
+              outDir: resolve(process.cwd(), opts.capture),
+              harnessPath,
+              electronBinary,
+              ...(opts.fixtureThread === undefined
+                ? {}
+                : { fixtureThreadId: opts.fixtureThread }),
+            });
+            if (report.written.length === 0) {
+              console.log("Capture ran; the app reports no surfaces to shoot.");
+            }
+            for (const shot of report.written) {
+              console.log(`wrote ${shot.file}  (${shot.slot})`);
+            }
           }
         },
       ),

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -1627,7 +1627,7 @@ export function registerPluginCommands(
               );
             }
             const report = await runPluginCapture({
-              serverUrl: opts.appUrl ?? getUrl(),
+              appUrl: opts.appUrl ?? getUrl(),
               pluginId: plan.pluginId,
               outDir: resolve(process.cwd(), opts.capture),
               harnessPath,

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -1559,6 +1559,10 @@ export function registerPluginCommands(
       "Thread the shared capture fixture seeded, enabling the surfaces that need one",
     )
     .option(
+      "--app-url <url>",
+      "Where the app shell is served when it differs from the server (a source dev instance serves the app from Vite's port); defaults to the server URL",
+    )
+    .option(
       "--capture <outDir>",
       "Take the screenshots: drives a headless window at this bb, reads which surfaces the plugin registered from the running app, and writes one PNG per surface into <outDir>",
     )
@@ -1566,7 +1570,11 @@ export function registerPluginCommands(
       action(
         async (
           path: string | undefined,
-          opts: JsonOutputOptions & { fixtureThread?: string; capture?: string },
+          opts: JsonOutputOptions & {
+            fixtureThread?: string;
+            capture?: string;
+            appUrl?: string;
+          },
         ) => {
           const rootDir = resolve(process.cwd(), path ?? ".");
           const raw: unknown = JSON.parse(
@@ -1619,7 +1627,7 @@ export function registerPluginCommands(
               );
             }
             const report = await runPluginCapture({
-              serverUrl: getUrl(),
+              serverUrl: opts.appUrl ?? getUrl(),
               pluginId: plan.pluginId,
               outDir: resolve(process.cwd(), opts.capture),
               harnessPath,

--- a/apps/cli/src/plugin-screenshot.ts
+++ b/apps/cli/src/plugin-screenshot.ts
@@ -1,8 +1,12 @@
-import { readdir, readFile, stat } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+import { mkdtemp, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   detectPluginSurfaces,
   planPluginCapture,
+  PLUGIN_CAPTURE_SURFACES,
   type PluginCaptureStep,
 } from "@bb/domain";
 
@@ -80,4 +84,82 @@ export async function planPluginScreenshots(args: {
     steps,
     needsFixture: found.slots.filter((slot) => !planned.has(slot)),
   };
+}
+
+export interface CaptureRunResult {
+  readonly pluginId: string;
+  readonly written: ReadonlyArray<{ slot: string; url: string; file: string }>;
+}
+
+/**
+ * Where the desktop package's Electron lives. In a checkout that is the
+ * workspace dependency; a packaged CLI can point BB_ELECTRON at any Electron.
+ */
+export function resolveElectronBinary(
+  env: NodeJS.ProcessEnv,
+  harnessPath: string,
+): string | null {
+  if (env["BB_ELECTRON"] !== undefined && env["BB_ELECTRON"] !== "") {
+    return env["BB_ELECTRON"];
+  }
+  try {
+    // Resolve from beside the harness: Electron is the desktop package's
+    // dependency, not the CLI's, and requiring "electron" under plain node
+    // returns the binary path.
+    const requireFromHarness = createRequire(harnessPath);
+    const resolved: unknown = requireFromHarness("electron");
+    return typeof resolved === "string" ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Drive the capture harness against the author's running bb. Which surfaces
+ * the plugin registered is read from the live app in the harness itself —
+ * the plan here only supplies the catalog (routes and file stems).
+ */
+export async function runPluginCapture(args: {
+  serverUrl: string;
+  pluginId: string;
+  outDir: string;
+  harnessPath: string;
+  electronBinary: string;
+  fixtureThreadId?: string;
+}): Promise<CaptureRunResult> {
+  const planDir = await mkdtemp(join(tmpdir(), "bb-plugin-capture-"));
+  const planPath = join(planDir, "plan.json");
+  await writeFile(
+    planPath,
+    JSON.stringify({
+      serverUrl: args.serverUrl,
+      pluginId: args.pluginId,
+      outDir: args.outDir,
+      surfaces: PLUGIN_CAPTURE_SURFACES,
+      ...(args.fixtureThreadId === undefined
+        ? {}
+        : { fixtureThreadId: args.fixtureThreadId }),
+    }),
+  );
+  return await new Promise<CaptureRunResult>((resolvePromise, reject) => {
+    const child = spawn(args.electronBinary, [args.harnessPath, planPath], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let out = "";
+    let err = "";
+    child.stdout.on("data", (chunk: Buffer) => (out += chunk.toString()));
+    child.stderr.on("data", (chunk: Buffer) => (err += chunk.toString()));
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`capture harness exited ${code}: ${err.trim()}`));
+        return;
+      }
+      try {
+        resolvePromise(JSON.parse(out) as CaptureRunResult);
+      } catch {
+        reject(new Error(`capture harness wrote no report: ${out.trim()}`));
+      }
+    });
+  });
 }

--- a/apps/cli/src/plugin-screenshot.ts
+++ b/apps/cli/src/plugin-screenshot.ts
@@ -120,7 +120,8 @@ export function resolveElectronBinary(
  * the plan here only supplies the catalog (routes and file stems).
  */
 export async function runPluginCapture(args: {
-  serverUrl: string;
+  /** Origin serving the app shell — the server for a packaged bb, Vite's port for a source dev instance. */
+  appUrl: string;
   pluginId: string;
   outDir: string;
   harnessPath: string;
@@ -132,7 +133,7 @@ export async function runPluginCapture(args: {
   await writeFile(
     planPath,
     JSON.stringify({
-      serverUrl: args.serverUrl,
+      appUrl: args.appUrl,
       pluginId: args.pluginId,
       outDir: args.outDir,
       surfaces: PLUGIN_CAPTURE_SURFACES,

--- a/apps/cli/src/plugin-screenshot.ts
+++ b/apps/cli/src/plugin-screenshot.ts
@@ -1,0 +1,83 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  detectPluginSurfaces,
+  planPluginCapture,
+  type PluginCaptureStep,
+} from "@bb/domain";
+
+/** Directories that never hold the plugin's own frontend source. */
+const SKIPPED = new Set(["node_modules", "dist", "types", ".git", "coverage"]);
+const SOURCE = /\.tsx?$/;
+const MAX_DEPTH = 4;
+
+/**
+ * Concatenate a plugin's frontend source. The detector only needs the text of
+ * the slot registrations, so reading files beats building the plugin: a
+ * submission screenshot has to work before `dist/` exists.
+ */
+export async function readPluginFrontendSource(rootDir: string): Promise<string> {
+  const parts: string[] = [];
+  const walk = async (dir: string, depth: number): Promise<void> => {
+    if (depth > MAX_DEPTH) return;
+    let entries: string[];
+    try {
+      entries = await readdir(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (SKIPPED.has(entry)) continue;
+      const path = join(dir, entry);
+      const info = await stat(path).catch(() => null);
+      if (info === null) continue;
+      if (info.isDirectory()) {
+        await walk(path, depth + 1);
+      } else if (SOURCE.test(entry) && !entry.endsWith(".d.ts")) {
+        parts.push(await readFile(path, "utf8"));
+      }
+    }
+  };
+  await walk(rootDir, 0);
+  return parts.join("\n");
+}
+
+export interface PluginCapturePlanResult {
+  readonly pluginId: string;
+  readonly slots: string[];
+  readonly steps: PluginCaptureStep[];
+  /** Surfaces found that a shot needs the shared fixture to reach. */
+  readonly needsFixture: string[];
+}
+
+/**
+ * Work out what a listing for this plugin can show.
+ *
+ * `fixtureThreadId` is what the shared capture fixture seeds. Without it the
+ * fixture-only surfaces are reported through `needsFixture` rather than
+ * planned, so the caller can say what a screenshot would still need instead of
+ * silently photographing an empty app.
+ */
+export async function planPluginScreenshots(args: {
+  rootDir: string;
+  pluginId: string;
+  fixtureThreadId?: string;
+}): Promise<PluginCapturePlanResult> {
+  const source = await readPluginFrontendSource(args.rootDir);
+  const found = detectPluginSurfaces(source);
+  const steps = planPluginCapture({
+    pluginId: args.pluginId,
+    slots: found.slots,
+    panelPaths: found.panelPaths,
+    ...(args.fixtureThreadId === undefined
+      ? {}
+      : { fixtureThreadId: args.fixtureThreadId }),
+  });
+  const planned = new Set(steps.map((step) => step.slot));
+  return {
+    pluginId: args.pluginId,
+    slots: found.slots,
+    steps,
+    needsFixture: found.slots.filter((slot) => !planned.has(slot)),
+  };
+}

--- a/apps/desktop/scripts/plugin-capture.cjs
+++ b/apps/desktop/scripts/plugin-capture.cjs
@@ -1,0 +1,149 @@
+/**
+ * Listing-screenshot capture harness for `bb plugin screenshot --capture`.
+ *
+ * Runs under the desktop package's Electron. One invocation:
+ *   electron plugin-capture.cjs <plan.json>
+ *
+ * The plan carries the server URL, the plugin id, the output directory, and
+ * the surface catalog (routes + file stems). Which surfaces the plugin
+ * actually registered is read from the running app itself via the
+ * `__bbPluginSlotSnapshot` hook — the author has the plugin installed, so the
+ * renderer is the source of truth; nothing here parses plugin source.
+ *
+ * Writes one PNG per planned surface and prints a JSON report to stdout.
+ */
+const { mkdirSync, readFileSync, writeFileSync } = require("node:fs");
+const { join } = require("node:path");
+
+const WIDTH = 1440;
+const HEIGHT = 900;
+const SETTLE_MS = 1200;
+const READY_TIMEOUT_MS = 20000;
+
+/** Snapshot arrays are keyed by plural slot names; the catalog by slot name. */
+const SNAPSHOT_KEYS = {
+  navPanel: "navPanels",
+  homepageSection: "homepageSections",
+  settingsSection: "settingsSections",
+  experimental_threadList: "threadLists",
+  sidebarFooterAction: "sidebarFooterActions",
+  messageDirective: "messageDirectives",
+  threadPanelAction: "threadPanelActions",
+  experimental_threadHeaderAction: "threadHeaderActions",
+  "composer.customize": "composerCustomizations",
+  pendingInteraction: "pendingInteractions",
+  fileOpener: "fileOpeners",
+};
+
+/** Which catalog surfaces this plugin registered, plus its nav panel paths. */
+function planSteps(plan, slotIndex) {
+  const steps = [];
+  for (const surface of plan.surfaces) {
+    const registrations = slotIndex[SNAPSHOT_KEYS[surface.slot] ?? ""] ?? [];
+    const mine = registrations.filter((r) => r.pluginId === plan.pluginId);
+    if (mine.length === 0) continue;
+    if (surface.kind === "fixture" && !plan.fixtureThreadId) continue;
+
+    if (surface.route.includes(":panelPath")) {
+      mine.forEach((reg, index) => {
+        const panelPath = String(reg.path ?? "").replace(/^\/+/, "");
+        if (panelPath === "") return;
+        steps.push({
+          slot: surface.slot,
+          url: surface.route
+            .replace(":pluginId", plan.pluginId)
+            .replace(":panelPath", panelPath),
+          outputFile:
+            mine.length > 1
+              ? `${surface.stem}-${index + 1}.png`
+              : `${surface.stem}.png`,
+        });
+      });
+      continue;
+    }
+    steps.push({
+      slot: surface.slot,
+      url: surface.route
+        .replace(":pluginId", plan.pluginId)
+        .replace(":threadId", plan.fixtureThreadId ?? ""),
+      outputFile: `${surface.stem}.png`,
+    });
+  }
+  return steps;
+}
+
+async function waitForSnapshot(webContents) {
+  // eslint-disable-next-line no-constant-condition
+  const start = Date.now();
+  for (;;) {
+    const ready = await webContents.executeJavaScript(
+      "typeof window.__bbPluginSlotSnapshot === 'function'",
+    );
+    if (ready) return;
+    if (Date.now() - start > READY_TIMEOUT_MS) {
+      throw new Error(
+        "app never exposed __bbPluginSlotSnapshot — is this bb older than the capture hook?",
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+}
+
+/** Registrations hold React components; pull out only JSON-safe identity. */
+const READ_SNAPSHOT = `(() => {
+  const s = window.__bbPluginSlotSnapshot();
+  const pick = (rows) => (rows ?? []).map((r) => ({
+    pluginId: r.pluginId ?? null,
+    id: r.id ?? null,
+    path: r.path ?? null,
+  }));
+  const out = {};
+  for (const key of Object.keys(s)) out[key] = pick(s[key]);
+  return out;
+})()`;
+
+async function main() {
+  // Lazy: this file is also required under plain node to test planSteps.
+  const { app, BrowserWindow } = require("electron");
+  const planPath = process.argv[process.argv.length - 1];
+  const plan = JSON.parse(readFileSync(planPath, "utf8"));
+  mkdirSync(plan.outDir, { recursive: true });
+
+  await app.whenReady();
+  const win = new BrowserWindow({
+    show: false,
+    width: WIDTH,
+    height: HEIGHT,
+    webPreferences: { backgroundThrottling: false },
+  });
+
+  await win.loadURL(new URL("/", plan.serverUrl).toString());
+  await waitForSnapshot(win.webContents);
+  const slotIndex = await win.webContents.executeJavaScript(READ_SNAPSHOT);
+  const steps = planSteps(plan, slotIndex);
+
+  const written = [];
+  for (const step of steps) {
+    await win.loadURL(new URL(step.url, plan.serverUrl).toString());
+    await waitForSnapshot(win.webContents);
+    await new Promise((resolve) => setTimeout(resolve, SETTLE_MS));
+    const image = await win.webContents.capturePage();
+    const outPath = join(plan.outDir, step.outputFile);
+    writeFileSync(outPath, image.toPNG());
+    written.push({ slot: step.slot, url: step.url, file: outPath });
+  }
+
+  process.stdout.write(
+    JSON.stringify({ pluginId: plan.pluginId, written }, null, 2) + "\n",
+  );
+  app.exit(written.length > 0 || steps.length === 0 ? 0 : 1);
+}
+
+if (process.versions.electron) {
+  main().catch((error) => {
+    process.stderr.write(String(error?.stack ?? error) + "\n");
+    require("electron").app.exit(1);
+  });
+}
+
+module.exports = { planSteps, SNAPSHOT_KEYS };

--- a/apps/desktop/scripts/plugin-capture.cjs
+++ b/apps/desktop/scripts/plugin-capture.cjs
@@ -17,7 +17,8 @@ const { join } = require("node:path");
 
 const WIDTH = 1440;
 const HEIGHT = 900;
-const SETTLE_MS = 1200;
+const QUIET_MS = 700;
+const QUIET_TIMEOUT_MS = 10000;
 const READY_TIMEOUT_MS = 20000;
 
 /** Snapshot arrays are keyed by plural slot names; the catalog by slot name. */
@@ -116,6 +117,23 @@ async function waitForPlugin(webContents, pluginId) {
   }
 }
 
+/**
+ * Resolve once the page stops changing.
+ *
+ * Registration is not readiness: a panel mounts, then fetches, and shooting in
+ * between photographs skeleton rows. Waiting for the DOM to go quiet covers
+ * that without the harness knowing anything about a given plugin's loading UI.
+ */
+const WAIT_FOR_QUIET = (quietMs, timeoutMs) => `new Promise((resolve) => {
+  let timer = null;
+  const done = () => { observer.disconnect(); clearTimeout(cap); resolve(true); };
+  const bump = () => { clearTimeout(timer); timer = setTimeout(done, ${quietMs}); };
+  const observer = new MutationObserver(bump);
+  observer.observe(document.body, { subtree: true, childList: true, characterData: true, attributes: true });
+  const cap = setTimeout(done, ${timeoutMs});
+  bump();
+})`;
+
 /** Registrations hold React components; pull out only JSON-safe identity. */
 const READ_SNAPSHOT = `(() => {
   const s = window.__bbPluginSlotSnapshot();
@@ -144,7 +162,7 @@ async function main() {
     webPreferences: { backgroundThrottling: false },
   });
 
-  await win.loadURL(new URL("/", plan.serverUrl).toString());
+  await win.loadURL(new URL("/", plan.appUrl).toString());
   await waitForSnapshot(win.webContents);
   // Plugin frontends mount after the shell: wait until this plugin has
   // registered something, or say which plugins did so the miss is debuggable.
@@ -153,9 +171,14 @@ async function main() {
 
   const written = [];
   for (const step of steps) {
-    await win.loadURL(new URL(step.url, plan.serverUrl).toString());
-    await waitForSnapshot(win.webContents);
-    await new Promise((resolve) => setTimeout(resolve, SETTLE_MS));
+    await win.loadURL(new URL(step.url, plan.appUrl).toString());
+    // Re-check registration on the destination, not just on the way in: a
+    // plugin whose service restarts (seeding its demo data does exactly that)
+    // is briefly unregistered, and its route renders blank until it returns.
+    await waitForPlugin(win.webContents, plan.pluginId);
+    await win.webContents.executeJavaScript(
+      WAIT_FOR_QUIET(QUIET_MS, QUIET_TIMEOUT_MS),
+    );
     const image = await win.webContents.capturePage();
     const outPath = join(plan.outDir, step.outputFile);
     writeFileSync(outPath, image.toPNG());

--- a/apps/desktop/scripts/plugin-capture.cjs
+++ b/apps/desktop/scripts/plugin-capture.cjs
@@ -89,6 +89,33 @@ async function waitForSnapshot(webContents) {
   }
 }
 
+function pluginIdsIn(slotIndex) {
+  const ids = new Set();
+  for (const rows of Object.values(slotIndex)) {
+    for (const row of rows) if (row.pluginId) ids.add(row.pluginId);
+  }
+  return [...ids].sort();
+}
+
+async function waitForPlugin(webContents, pluginId) {
+  const start = Date.now();
+  let slotIndex = {};
+  for (;;) {
+    slotIndex = await webContents.executeJavaScript(READ_SNAPSHOT);
+    if (pluginIdsIn(slotIndex).includes(pluginId)) return slotIndex;
+    if (Date.now() - start > READY_TIMEOUT_MS) {
+      const seen = pluginIdsIn(slotIndex);
+      throw new Error(
+        `${pluginId} registered no surface within ${READY_TIMEOUT_MS}ms. ` +
+          (seen.length
+            ? `Plugins that did: ${seen.join(", ")}.`
+            : "No plugin registered anything — is the app signed in and past onboarding?"),
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 400));
+  }
+}
+
 /** Registrations hold React components; pull out only JSON-safe identity. */
 const READ_SNAPSHOT = `(() => {
   const s = window.__bbPluginSlotSnapshot();
@@ -119,7 +146,9 @@ async function main() {
 
   await win.loadURL(new URL("/", plan.serverUrl).toString());
   await waitForSnapshot(win.webContents);
-  const slotIndex = await win.webContents.executeJavaScript(READ_SNAPSHOT);
+  // Plugin frontends mount after the shell: wait until this plugin has
+  // registered something, or say which plugins did so the miss is debuggable.
+  const slotIndex = await waitForPlugin(win.webContents, plan.pluginId);
   const steps = planSteps(plan, slotIndex);
 
   const written = [];

--- a/apps/server/src/services/skills/builtin-skills/plugin-listing-screenshots/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/plugin-listing-screenshots/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: plugin-listing-screenshots
+description: Take the screenshots that go on a plugin's marketplace listing. Use when submitting a plugin, refreshing its listing images, or running `bb plugin screenshot` — it decides which screens to capture for the plugin's type, what data to seed first, and what makes a shot unusable.
+---
+
+# Listing screenshots
+
+A listing screenshot exists to answer one question for someone deciding whether
+to install: **what does this plugin do for me?** A picture of an empty panel
+answers "nothing".
+
+`bb plugin screenshot [path] --capture <dir>` finds the surfaces the plugin
+registers and photographs each one. It cannot know whether the result is worth
+showing. That judgement is this skill.
+
+## The rule
+
+**Seed first, capture second, review every shot.**
+
+The first screenshot must show the plugin doing its job with realistic data.
+Capture the empty state only as a later image, and only when the empty state
+itself teaches something (a setup step, a connect button).
+
+Reject a shot that shows any of these, and fix the cause rather than shipping it:
+
+| Reject | Because |
+| --- | --- |
+| An empty state as the first image | It reads as "this plugin does nothing" |
+| Skeleton rows, spinners, half-painted lists | The capture beat the data; seed, then re-run |
+| A panel with one lonely row | It looks broken; seed enough to show shape (5–10 items) |
+| Real secrets, tokens, private repos, customer names | A listing is public forever |
+| `lorem ipsum`, `test test`, `asdf` | Plausible data reads as a real product |
+
+## What to capture, by what the plugin does
+
+Capture the surfaces the plugin actually registers — the command lists them.
+This table says which of those to lead with, and what has to exist first.
+
+| The plugin… | Lead with | Seed first |
+| --- | --- | --- |
+| Repaints bb (themes, fonts) | The app wearing it: home, then a thread | Nothing — the theme *is* the subject, but a thread makes it legible |
+| Replaces the thread list or navigation | The sidebar holding a realistic mix | Several threads: running, waiting, finished |
+| Renders inside messages or the timeline | A thread scrolled to the rendered element | A thread whose message carries the plugin's directive |
+| Changes the composer | The composer open with the control visible | A thread, and a draft in the box |
+| Decides what the agent knows (memory, context, docs) | Its panel holding real entries | Entries via the plugin's own CLI |
+| Gives agents tools or filters output | A thread where the tool visibly ran | A finished thread that used it |
+| Handles credentials or warns about unsafe code | Settings in a configured state | Placeholder values only — never a real secret |
+| Adds or switches agents and providers | The provider picker showing it, and a thread running on it | A configured provider |
+| Shows tokens, cost, or limits | The dashboard with plausible numbers | Usage history, or the plugin's demo data |
+| Notifies or ranks what needs you | The surface listing several items | Threads in states that trigger it |
+| Works with code, PRs, or reviews | The panel listing repos or PRs | A connected demo repo — never a private one |
+| Opens or previews files | The file open in the viewer | A fixture file of a type it claims |
+| Concerns the machine bb runs on | The panel with live host data | Usually self-populating; check it is not zeroed |
+| Inspects bb or helps build plugins | The tool pointed at something real | Whatever it inspects |
+| Tracks tasks | The board or list holding tasks across states | `seed-demo`, or the plugin's CLI |
+| Runs scheduled or automated work | The list with schedules and a run history | A schedule, and at least one past run |
+
+## Seeding
+
+Four kinds of data, in the order you should reach for them.
+
+**1. None.** The surface is the product. Themes, fonts, decoration.
+
+**2. The plugin's own CLI.** A plugin that owns data almost always ships a
+`bb <plugin>` command, because `bb.cli` is a plugin surface — eleven of bb's
+own bundled plugins register one. That command is the supported way to create
+its data, so it is the supported way to seed a screenshot:
+
+```sh
+bb tasks seed-demo --yes        # a plugin that ships a demo seeder
+bb tasks project create --name "Product"   # or compose it from ordinary commands
+```
+
+**If you are authoring a plugin with data, ship a `seed-demo` subcommand.**
+It costs a few lines, makes your own listing screenshots one command, and gives
+reviewers a way to see your plugin working.
+
+**3. bb's own objects.** Threads, messages, files — the things surfaces hang
+off. Create a thread and send it a message so timeline, composer, and file
+surfaces have something to render.
+
+**4. External services.** GitHub, Linear, and friends. Connect a demo account or
+a public repo you own. Never photograph a private repo, a customer, or a real
+token — a listing image is public and permanent.
+
+## After capturing
+
+1. **Open every image.** The command reports files written, not whether they are
+   any good.
+2. **Check the first one hard.** It is the card image, and most people will see
+   only that.
+3. **Re-run after seeding more** if a surface looks thin. Capture is cheap.
+4. **Crop nothing.** Full-window shots keep the plugin in bb's context, which is
+   what a browser is judging.
+
+## Known rough edges
+
+- Registration is not readiness. The capture waits for the plugin to register
+  and for the page to stop changing, but a panel that never finishes loading
+  will still be photographed mid-load. Look at the image.
+- Surfaces that only exist inside a thread need `--fixture-thread <id>`; without
+  it the command reports them as skipped rather than shooting the empty app.

--- a/apps/server/src/services/skills/builtin-skills/submit-a-plugin/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/submit-a-plugin/SKILL.md
@@ -266,6 +266,17 @@ Use this shape as a guide. Confirm every field against the current schema.
 }
 ```
 
+## Add listing screenshots
+
+A listing with no screenshots asks people to install on faith. Take them with
+`bb plugin screenshot [path] --capture <dir>`, which finds the surfaces the
+plugin registers and photographs each one against the running bb.
+
+Seed the plugin's data before capturing, and look at every image before
+attaching it: a screenshot of an empty panel is worse than none. The
+`plugin-listing-screenshots` skill covers which screens to lead with for this
+kind of plugin, what to seed, and what makes a shot unusable.
+
 ## Add the icon
 
 Always vendor the plugin's icon. Copy the icon file into the marketplace `icons/` directory. Reference only that vendored copy from the entry.

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -25,6 +25,8 @@ export * from "./lifecycle-diagram.js";
 export * from "./number-utils.js";
 export * from "./pending-interactions.js";
 export * from "./plugin-id.js";
+export * from "./plugin-capture.js";
+export * from "./plugin-surface-detect.js";
 export * from "./plugin-manifest.js";
 export * from "./plugin-sdk-version.js";
 export * from "./project-path.js";

--- a/packages/domain/src/plugin-capture.ts
+++ b/packages/domain/src/plugin-capture.ts
@@ -1,0 +1,158 @@
+/**
+ * The plugin surfaces a submission screenshot can cover, and how each one is
+ * reached.
+ *
+ * A listing screenshot has to show the plugin's own UI, so the capture visits
+ * the surface the plugin registered rather than the app around it. Surfaces
+ * split into two kinds:
+ *
+ * - `route`: the surface renders on a URL, either because it owns one
+ *   (`navPanel`) or because it lives in chrome every route paints
+ *   (`sidebarFooterAction`). Navigating is enough.
+ * - `fixture`: the surface only exists once a thread, composer, or file is in
+ *   a particular state. Capture seeds one shared fixture workspace and drives
+ *   to that state; the same fixture is used for every plugin so listings stay
+ *   comparable and no author has to author one.
+ */
+export type PluginCaptureKind = "route" | "fixture";
+
+export interface PluginCaptureSurface {
+  /** Slot name as registered through the plugin SDK. */
+  readonly slot: string;
+  /** How the capture reaches it. */
+  readonly kind: PluginCaptureKind;
+  /**
+   * Route to load, relative to the app origin. `:pluginId` and `:panelPath`
+   * are substituted from the plugin's own registration.
+   */
+  readonly route: string;
+  /** What the fixture must arrange before the shot is worth taking. */
+  readonly requires?: string;
+  /** Suggested file stem, so a listing's shots sort predictably. */
+  readonly stem: string;
+}
+
+export const PLUGIN_CAPTURE_SURFACES: readonly PluginCaptureSurface[] = [
+  { slot: "navPanel", kind: "route", route: "/plugins/:pluginId/:panelPath", stem: "01-panel" },
+  { slot: "homepageSection", kind: "route", route: "/", stem: "02-homepage" },
+  { slot: "settingsSection", kind: "route", route: "/settings/plugins/:pluginId", stem: "03-settings" },
+  { slot: "experimental_threadList", kind: "route", route: "/", stem: "04-thread-list" },
+  { slot: "sidebarFooterAction", kind: "route", route: "/", stem: "05-sidebar-footer" },
+  {
+    slot: "messageDirective",
+    kind: "fixture",
+    route: "/threads/:threadId",
+    requires: "a thread whose last message carries the plugin's directive",
+    stem: "06-message",
+  },
+  {
+    slot: "threadPanelAction",
+    kind: "fixture",
+    route: "/threads/:threadId",
+    requires: "a thread with the plugin's thread panel opened",
+    stem: "07-thread-panel",
+  },
+  {
+    slot: "experimental_threadHeaderAction",
+    kind: "fixture",
+    route: "/threads/:threadId",
+    requires: "a thread open",
+    stem: "08-thread-header",
+  },
+  {
+    slot: "composer.customize",
+    kind: "fixture",
+    route: "/threads/:threadId",
+    requires: "a thread with the composer focused",
+    stem: "09-composer",
+  },
+  {
+    slot: "pendingInteraction",
+    kind: "fixture",
+    route: "/threads/:threadId",
+    requires: "a turn paused awaiting input",
+    stem: "10-pending",
+  },
+  {
+    slot: "fileOpener",
+    kind: "fixture",
+    route: "/threads/:threadId",
+    requires: "a fixture file open whose extension the plugin claims",
+    stem: "11-file",
+  },
+] as const;
+
+const SURFACES_BY_SLOT = new Map(
+  PLUGIN_CAPTURE_SURFACES.map((surface) => [surface.slot, surface]),
+);
+
+export function pluginCaptureSurface(slot: string): PluginCaptureSurface | undefined {
+  return SURFACES_BY_SLOT.get(slot);
+}
+
+/** One planned screenshot: where to go, and what to write. */
+export interface PluginCaptureStep {
+  readonly slot: string;
+  readonly kind: PluginCaptureKind;
+  readonly url: string;
+  readonly outputFile: string;
+  readonly requires: string | null;
+}
+
+export interface PluginCapturePlanArgs {
+  readonly pluginId: string;
+  /** Slots the plugin actually registered, as reported by the running app. */
+  readonly slots: readonly string[];
+  /** First path segment of each nav panel the plugin registered. */
+  readonly panelPaths?: readonly string[];
+  /** Fixture thread the capture drives, when any fixture surface is planned. */
+  readonly fixtureThreadId?: string;
+}
+
+/**
+ * Turn the slots a plugin registered into an ordered capture plan.
+ *
+ * Unregistered slots produce no step: a plugin that only adds agent tools has
+ * nothing to photograph, and a listing should not be blocked on a screenshot
+ * that cannot exist. Fixture surfaces are dropped when no fixture thread is
+ * available rather than pointing at a route that would render the empty app.
+ */
+export function planPluginCapture(args: PluginCapturePlanArgs): PluginCaptureStep[] {
+  const panelPaths = args.panelPaths ?? [];
+  const steps: PluginCaptureStep[] = [];
+  for (const surface of PLUGIN_CAPTURE_SURFACES) {
+    if (!args.slots.includes(surface.slot)) continue;
+    if (surface.kind === "fixture" && args.fixtureThreadId === undefined) continue;
+
+    if (surface.route.includes(":panelPath")) {
+      // One shot per panel: a plugin contributing several panels is several
+      // different screens, and a listing that shows one of them undersells it.
+      panelPaths.forEach((panelPath, index) => {
+        steps.push({
+          slot: surface.slot,
+          kind: surface.kind,
+          url: surface.route
+            .replace(":pluginId", args.pluginId)
+            .replace(":panelPath", panelPath),
+          outputFile:
+            panelPaths.length > 1
+              ? `${surface.stem}-${index + 1}.png`
+              : `${surface.stem}.png`,
+          requires: surface.requires ?? null,
+        });
+      });
+      continue;
+    }
+
+    steps.push({
+      slot: surface.slot,
+      kind: surface.kind,
+      url: surface.route
+        .replace(":pluginId", args.pluginId)
+        .replace(":threadId", args.fixtureThreadId ?? ""),
+      outputFile: `${surface.stem}.png`,
+      requires: surface.requires ?? null,
+    });
+  }
+  return steps;
+}

--- a/packages/domain/src/plugin-surface-detect.ts
+++ b/packages/domain/src/plugin-surface-detect.ts
@@ -1,0 +1,68 @@
+/**
+ * Which surfaces a plugin registers, read from its own frontend source.
+ *
+ * The server never learns this: slots are registered at runtime in the
+ * renderer, inside the plugin's `definePluginApp` entry. Asking a running app
+ * would mean the plugin is already installed and loaded, which is exactly what
+ * a submission screenshot cannot assume. Reading the source it is about to
+ * ship keeps the capture available before the plugin exists anywhere.
+ *
+ * This is deliberately a text scan, not a parse. It only has to answer "does
+ * this plugin paint here", and a false positive costs one skipped screenshot
+ * rather than a wrong listing.
+ */
+import { PLUGIN_CAPTURE_SURFACES } from "./plugin-capture.js";
+
+const SLOT_CALL = /(?:^|[^\w.])(?:app\.)?slots\.([A-Za-z_][\w]*)\s*\(/g;
+const COMPOSER_CALL = /(?:^|[^\w.])(?:app\.)?composer\.customize\s*\(/;
+/** Comments and strings that merely name a slot must not count as registration. */
+const LINE_COMMENT = /^\s*(?:\/\/|\*|\/\*)/;
+
+export interface DetectedPluginSurfaces {
+  /** Capturable slots, in catalog order. */
+  readonly slots: string[];
+  /** First path segment of each nav panel, in registration order. */
+  readonly panelPaths: string[];
+}
+
+function isCapturable(slot: string): boolean {
+  return PLUGIN_CAPTURE_SURFACES.some((surface) => surface.slot === slot);
+}
+
+/**
+ * Nav panels declare the path they own; the capture needs it to build the
+ * panel's URL. `path: "board"` and `path: "/board"` both mean the same panel.
+ */
+function readPanelPaths(source: string): string[] {
+  const paths: string[] = [];
+  const navPanel = /slots\.navPanel\s*\(\s*\{([\s\S]{0,400}?)\}/g;
+  let match: RegExpExecArray | null;
+  while ((match = navPanel.exec(source)) !== null) {
+    const path = /\bpath\s*:\s*["'`]([^"'`]+)["'`]/.exec(match[1] ?? "");
+    if (path?.[1] !== undefined) paths.push(path[1].replace(/^\/+/, ""));
+  }
+  return paths;
+}
+
+export function detectPluginSurfaces(source: string): DetectedPluginSurfaces {
+  const code = source
+    .split("\n")
+    .filter((line) => !LINE_COMMENT.test(line))
+    .join("\n");
+
+  const found = new Set<string>();
+  let match: RegExpExecArray | null;
+  SLOT_CALL.lastIndex = 0;
+  while ((match = SLOT_CALL.exec(code)) !== null) {
+    const slot = match[1];
+    if (slot !== undefined && isCapturable(slot)) found.add(slot);
+  }
+  if (COMPOSER_CALL.test(code)) found.add("composer.customize");
+
+  return {
+    slots: PLUGIN_CAPTURE_SURFACES.filter((surface) => found.has(surface.slot)).map(
+      (surface) => surface.slot,
+    ),
+    panelPaths: readPanelPaths(code),
+  };
+}

--- a/packages/domain/test/plugin-capture.test.ts
+++ b/packages/domain/test/plugin-capture.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  PLUGIN_CAPTURE_SURFACES,
+  planPluginCapture,
+  pluginCaptureSurface,
+} from "../src/plugin-capture.js";
+
+describe("planPluginCapture", () => {
+  it("plans nothing for a plugin with no visual surfaces", () => {
+    // An agent-tool or provider plugin has nothing to photograph; a listing
+    // must not be held up waiting for a screenshot that cannot exist.
+    expect(planPluginCapture({ pluginId: "unslop", slots: [] })).toEqual([]);
+  });
+
+  it("routes a nav panel to the panel's own URL", () => {
+    const steps = planPluginCapture({
+      pluginId: "tasks",
+      slots: ["navPanel"],
+      panelPaths: ["board"],
+    });
+    expect(steps).toEqual([
+      {
+        slot: "navPanel",
+        kind: "route",
+        url: "/plugins/tasks/board",
+        outputFile: "01-panel.png",
+        requires: null,
+      },
+    ]);
+  });
+
+  it("captures every panel a plugin contributes, numbered", () => {
+    const steps = planPluginCapture({
+      pluginId: "tasks",
+      slots: ["navPanel"],
+      panelPaths: ["board", "backlog"],
+    });
+    expect(steps.map((step) => step.outputFile)).toEqual([
+      "01-panel-1.png",
+      "01-panel-2.png",
+    ]);
+    expect(steps.map((step) => step.url)).toEqual([
+      "/plugins/tasks/board",
+      "/plugins/tasks/backlog",
+    ]);
+  });
+
+  it("drops fixture surfaces when no fixture thread is available", () => {
+    // Pointing these at a thread route without a seeded thread photographs the
+    // empty app, which is worse for a listing than having no shot at all.
+    const steps = planPluginCapture({
+      pluginId: "side-chat",
+      slots: ["messageDirective", "threadPanelAction"],
+    });
+    expect(steps).toEqual([]);
+  });
+
+  it("drives fixture surfaces at the shared fixture thread", () => {
+    const steps = planPluginCapture({
+      pluginId: "side-chat",
+      slots: ["messageDirective"],
+      fixtureThreadId: "thr_fixture",
+    });
+    expect(steps).toEqual([
+      {
+        slot: "messageDirective",
+        kind: "fixture",
+        url: "/threads/thr_fixture",
+        outputFile: "06-message.png",
+        requires: "a thread whose last message carries the plugin's directive",
+      },
+    ]);
+  });
+
+  it("orders steps by surface, not by the order slots were registered", () => {
+    const steps = planPluginCapture({
+      pluginId: "kitchen-sink",
+      slots: ["sidebarFooterAction", "homepageSection", "navPanel"],
+      panelPaths: ["main"],
+    });
+    expect(steps.map((step) => step.slot)).toEqual([
+      "navPanel",
+      "homepageSection",
+      "sidebarFooterAction",
+    ]);
+  });
+
+  it("ignores slots that are not capturable surfaces", () => {
+    const steps = planPluginCapture({
+      pluginId: "memory",
+      slots: ["bb.agents", "registerMentionProvider"],
+    });
+    expect(steps).toEqual([]);
+  });
+});
+
+describe("the surface catalog", () => {
+  it("gives every surface a unique output stem", () => {
+    const stems = PLUGIN_CAPTURE_SURFACES.map((surface) => surface.stem);
+    expect(new Set(stems).size).toBe(stems.length);
+  });
+
+  it("explains what every fixture surface needs arranged", () => {
+    for (const surface of PLUGIN_CAPTURE_SURFACES) {
+      if (surface.kind === "fixture") {
+        expect(surface.requires, surface.slot).toBeTruthy();
+      }
+    }
+  });
+
+  it("looks a surface up by slot", () => {
+    expect(pluginCaptureSurface("navPanel")?.kind).toBe("route");
+    expect(pluginCaptureSurface("nope")).toBeUndefined();
+  });
+});

--- a/packages/domain/test/plugin-surface-detect.test.ts
+++ b/packages/domain/test/plugin-surface-detect.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { detectPluginSurfaces } from "../src/plugin-surface-detect.js";
+
+describe("detectPluginSurfaces", () => {
+  it("finds nothing in a plugin with no frontend", () => {
+    const source = `export default function backend(bb) { bb.agents.registerTool(); }`;
+    expect(detectPluginSurfaces(source)).toEqual({ slots: [], panelPaths: [] });
+  });
+
+  it("reads a nav panel and the path it owns", () => {
+    const source = `
+      export default definePluginApp((app) => {
+        app.slots.navPanel({ path: "board", title: "Board", component: Board });
+      });
+    `;
+    expect(detectPluginSurfaces(source)).toEqual({
+      slots: ["navPanel"],
+      panelPaths: ["board"],
+    });
+  });
+
+  it("normalises a leading slash on a panel path", () => {
+    const source = `app.slots.navPanel({ path: "/board", component: Board });`;
+    expect(detectPluginSurfaces(source).panelPaths).toEqual(["board"]);
+  });
+
+  it("keeps every panel a plugin registers, in order", () => {
+    const source = `
+      app.slots.navPanel({ path: "board", component: Board });
+      app.slots.navPanel({ path: "backlog", component: Backlog });
+    `;
+    expect(detectPluginSurfaces(source).panelPaths).toEqual(["board", "backlog"]);
+  });
+
+  it("returns slots in catalog order, not registration order", () => {
+    const source = `
+      app.slots.sidebarFooterAction({ component: Footer });
+      app.slots.navPanel({ path: "main", component: Main });
+      app.slots.homepageSection({ component: Home });
+    `;
+    expect(detectPluginSurfaces(source).slots).toEqual([
+      "navPanel",
+      "homepageSection",
+      "sidebarFooterAction",
+    ]);
+  });
+
+  it("detects composer customisation, which is not a slot call", () => {
+    const source = `app.composer.customize({ actions: [improve] });`;
+    expect(detectPluginSurfaces(source).slots).toEqual(["composer.customize"]);
+  });
+
+  it("ignores slots that are only named in a comment", () => {
+    // A plugin that documents what it does not do must not be photographed
+    // against a surface it never paints.
+    const source = `
+      // app.slots.homepageSection is deliberately not used here.
+      /* app.slots.navPanel({ path: "old" }) — removed in 2.0 */
+      app.slots.settingsSection({ component: Settings });
+    `;
+    expect(detectPluginSurfaces(source)).toEqual({
+      slots: ["settingsSection"],
+      panelPaths: [],
+    });
+  });
+
+  it("ignores registrations that are not capturable surfaces", () => {
+    const source = `app.slots.messageAction({ id: "quote" });`;
+    expect(detectPluginSurfaces(source).slots).toEqual([]);
+  });
+
+  it("does not mistake a similarly named method for a slot", () => {
+    const source = `myOwnSlots.navPanel({ path: "nope" });`;
+    expect(detectPluginSurfaces(source).slots).toEqual([]);
+  });
+});

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -260,6 +260,17 @@ added/updated/unchanged counts.
                                  major/version, artifactFormatVersion,
                                  pluginId, pluginVersion, and builtWith (bb +
                                  plugin SDK versions); no server required
+  bb plugin screenshot [path]    Plan the listing screenshots for a plugin
+                                 (default: cwd): reads the surfaces its
+                                 frontend registers and reports one shot per
+                                 surface, with the route to capture and the
+                                 file to write. Surfaces that only exist
+                                 inside a thread, composer, or open file need
+                                 the shared capture fixture — pass
+                                 --fixture-thread <id> to include them.
+                                 --json for the raw plan. A plugin that
+                                 registers no visual surface plans nothing,
+                                 which is not an error
   bb plugin dev [path]           Watch a plugin's sources (default: cwd) and
                                  on every change rebuild its declared frontend
                                  (unminified, for readable stack traces),
@@ -467,6 +478,14 @@ bb — depend on the published `bb-app` package and call the CLI:
 "devDependencies": { "bb-app": "^0.35.1" },
 "scripts": { "build": "bb plugin build" }
 ```
+
+A listing needs screenshots of the plugin's own surfaces, so `bb plugin
+screenshot` reads which surfaces the plugin registers and plans one shot each:
+a nav panel is captured at `/plugins/<id>/<panel>`, and surfaces that only
+exist inside a thread, composer, or open file are captured against one shared
+fixture workspace used for every plugin, so listings stay comparable and no
+author has to build a fixture. It reads source, not `dist/`, so it works
+before the plugin has been built or installed anywhere.
 
 `bb plugin build` talks to no server. Depending on `bb-app@X` builds with
 exactly that release's shim configuration, so the bundle cannot be built

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -268,6 +268,10 @@ added/updated/unchanged counts.
                                  inside a thread, composer, or open file need
                                  the shared capture fixture — pass
                                  --fixture-thread <id> to include them.
+                                 --capture <outDir> takes the screenshots:
+                                 a headless window loads this bb, reads which
+                                 surfaces the plugin registered from the
+                                 running app, and writes one PNG per surface.
                                  --json for the raw plan. A plugin that
                                  registers no visual surface plans nothing,
                                  which is not an error

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -272,6 +272,9 @@ added/updated/unchanged counts.
                                  a headless window loads this bb, reads which
                                  surfaces the plugin registered from the
                                  running app, and writes one PNG per surface.
+                                 --app-url <url> points the window at the app
+                                 shell when it is not the server origin (a
+                                 source dev instance serves it from Vite).
                                  --json for the raw plan. A plugin that
                                  registers no visual surface plans nothing,
                                  which is not an error
@@ -484,7 +487,9 @@ bb — depend on the published `bb-app` package and call the CLI:
 ```
 
 A listing needs screenshots of the plugin's own surfaces, so `bb plugin
-screenshot` reads which surfaces the plugin registers and plans one shot each:
+screenshot` reads which surfaces the plugin registers and plans one shot each
+(seed the plugin's data first — the `plugin-listing-screenshots` skill covers
+which screens to lead with and what to seed):
 a nav panel is captured at `/plugins/<id>/<panel>`, and surfaces that only
 exist inside a thread, composer, or open file are captured against one shared
 fixture workspace used for every plugin, so listings stay comparable and no


### PR DESCRIPTION
Adds `bb plugin screenshot`, which produces the screenshots a marketplace listing needs, plus the skill that says which ones are worth taking.

**Draft.** The capture works end to end; the fixture-thread slice and a packaged-bb Electron path are not in it yet.

## What it does

```
$ bb plugin screenshot plugins/tasks --capture ./shots
01-panel.png  /plugins/tasks/tasks  (navPanel)
skipped messageDirective — needs the capture fixture; pass --fixture-thread <id>
wrote ./shots/01-panel.png  (navPanel)
```

A headless window — the desktop package's own Electron, no new dependency — loads the running bb, asks the renderer which surfaces the plugin registered, navigates to each, and writes a PNG. Enumeration comes from the live app rather than parsing source: the author submitting a plugin has it installed, and only the renderer knows the real registrations, including a nav panel's path, a directive's id, and a file opener's extensions.

A plugin with no visual surface prints "no listing screenshots to take" and exits clean. That is the common case for agent-tool and provider plugins, and their listings should not wait on an image that cannot exist.

## Testing it on real plugins is what shaped this

Eleven bundled plugins on a dev instance built from this branch. Eight captures — and **six were empty states**:

| Before seeding | After `bb tasks seed-demo --yes` |
| --- | --- |
| <img src="https://raw.githubusercontent.com/get-bb/bb/44bfc9edeec5b19a0183886c7458193b8eb17505/seeding/tasks-before-seeding.png" width="420"> | <img src="https://raw.githubusercontent.com/get-bb/bb/44bfc9edeec5b19a0183886c7458193b8eb17505/seeding/tasks-after-seeding.png" width="420"> |
| "No projects yet" | Nine tasks across three projects |

That gap is the point of the skill. The command finds the right surfaces and photographs them faithfully; whether the result sells the plugin depends on data existing first.

Two capture bugs came out of the same run, both fixed here:

- **Registration is not readiness.** The harness read the slot snapshot before any plugin frontend had mounted and reported "no surfaces" for everything. It now waits for the target plugin, and on timeout names the plugins that did register.
- **Seeding restarts a plugin's service**, so a plugin is briefly unregistered while the window navigates, and its route renders blank. Registration is now re-checked at the destination, then the harness waits for the DOM to stop changing instead of a fixed delay.

Other captures, unseeded, showing surfaces that need no data:

| `connect` settings | `connect` sidebar footer | `github` — an empty state the skill would reject |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/get-bb/bb/44bfc9edeec5b19a0183886c7458193b8eb17505/seeding/connect-settings.png" width="260"> | <img src="https://raw.githubusercontent.com/get-bb/bb/44bfc9edeec5b19a0183886c7458193b8eb17505/seeding/connect-sidebar-footer.png" width="260"> | <img src="https://raw.githubusercontent.com/get-bb/bb/44bfc9edeec5b19a0183886c7458193b8eb17505/seeding/github-empty-state.png" width="260"> |

## The skill

`plugin-listing-screenshots` covers what the command cannot decide: which screens to lead with for each kind of plugin, what to seed first, and what makes a shot unusable — an empty panel, a skeleton row, a single lonely item, a real secret or private repo.

Its seeding advice names a path that already exists rather than inventing one: `bb.cli` is a plugin surface, eleven of bb's bundled plugins register one, and `bb tasks seed-demo` is the convention worth copying. The skill asks plugin authors with data to ship a `seed-demo` subcommand — a few lines that make their own listing images one command, and give reviewers a way to see the plugin working.

`submit-a-plugin` and the plugins guide both point at it.

## Shape

| Where | What |
| --- | --- |
| `packages/domain` | Surface catalog and planner — which surfaces exist, how each is reached |
| `apps/app/src/lib/plugin-slots.ts` | One hook, `window.__bbPluginSlotSnapshot`, over the existing snapshot |
| `apps/desktop/scripts/plugin-capture.cjs` | The harness: navigate, wait, `capturePage` |
| `apps/cli` | `bb plugin screenshot [path] [--capture <dir>] [--app-url <url>] [--fixture-thread <id>] [--json]` |
| builtin skills | `plugin-listing-screenshots` |

The harness sits beside desktop rather than inside `main.ts` because capture needs a window and a URL, not the owned-runtime lifecycle. It requires Electron lazily so its planning half runs under plain node, where the CLI suite tests it against the same catalog the CLI plans from.

## Verification

461 CLI tests, 154 domain tests, app/CLI/domain typecheck. The guide durability test enforces that the new subcommand and both flags are documented.

## Not in this PR

- **Fixture seeding.** Surfaces that only exist inside a thread need `--fixture-thread`; the shared fixture that creates that thread, with a message carrying the plugin's directive id and a file of its claimed extensions, is the next slice.
- **Packaged bb.** Electron resolves from the desktop package in a checkout; `BB_ELECTRON` covers other cases.
- **A panel that never finishes loading** is still photographed mid-load. The skill tells authors to open every image.

## Found while testing, not fixed here

The Tasks panel renders placeholder rows that never resolve in a fresh window, though the sidebar shows the seeded counts and the DOM is quiet with no `animate-pulse` nodes. Worth a look independent of this PR.

BB-Thread-ID: thr_yrs6swfgtc

🤖 Generated with [Claude Code](https://claude.com/claude-code)
