### PR TITLE
Stop the dev launcher's ~/.local/bin from shadowing the selected Node

### DIFF
--- a/scripts/bb-dev-app
+++ b/scripts/bb-dev-app
@@ -59,9 +59,11 @@ NODE
 
 dev_node_bin_dir="$(resolve_dev_node_bin_dir)"
 if [[ -n "${dev_node_bin_dir}" ]]; then
-  PATH="${dev_node_bin_dir}:${HOME}/.local/bin:${PATH}"
+  PATH="${dev_node_bin_dir}:${PATH}:${HOME}/.local/bin"
 else
-  PATH="${HOME}/.local/bin:${PATH}"
+  # Append, never prepend: a node in ~/.local/bin must not shadow the node the
+  # caller already resolved (nvm, mise, asdf, ...).
+  PATH="${PATH}:${HOME}/.local/bin"
 fi
 
 sanitize_label() {


### PR DESCRIPTION
## Human comments

This was keeping `pnpm dev:desktop` (which requires node <=22.19) from working for me, because I have a node at `~/.local/bin/node` which is v26. But I use `nvm` which adds the correct version of node to the PATH. The problem is that this bb script munges the path again back to the wrong node.

-----

## What was wrong

`scripts/bb-dev-app` prepends `$HOME/.local/bin` to `PATH` before doing anything else. `resolve_dev_node_bin_dir` deliberately returns an empty string when the caller's node is already major 22 — "nothing to override" — but the `else` branch still prepends `~/.local/bin`, and so does the non-empty branch (`${dev_node_bin_dir}:${HOME}/.local/bin:${PATH}`). A `node` living in `~/.local/bin` therefore outranks the interpreter the developer selected with nvm/mise/asdf, and `assert_desktop_node_runtime` fails on that shadowing node instead of the selected one.

The failure mode is inverted: having the *correct* Node active is what triggers it, because that is the case where the resolver returns empty and declines to put a known-good bin dir in front.

```
$ node -v                      # nvm 22.19.0 active, `which node` -> ~/.nvm/.../bin/node
v22.19.0
$ pnpm dev:desktop
ERROR: Desktop dev requires Node 22.19 because Electron's postinstall runtime is not
reliable on newer Node releases. Current node is v26.7.0 at /Users/andrewchan/.local/bin/node.
```

Here `~/.local/bin/node` is a symlink to an unrelated v26.7.0 toolchain install. pnpm itself was fine — `pnpm exec node -v` reported `v22.19.0`, and its `PATH` listed the nvm bin dir ahead of `~/.local/bin`. The launcher reordered it.

## What changed

`scripts/bb-dev-app`: append `$HOME/.local/bin` instead of prepending it, in both branches. The entry exists so launcher-invoked tools resolve in a non-login environment; it never needed to outrank the interpreter. An explicitly resolved `dev_node_bin_dir` (including `BB_DEV_NODE_BIN_DIR`) still goes first, so the override path is unchanged.

No behavior change for developers who don't have a `node` in `~/.local/bin`.

## How you verified

`bb-dev-app` has no test harness, so this was verified by running the script's own `PATH` block against the reproducing environment.

Before, with nvm 22.19.0 active:

```
$ command -v node; node -v
/Users/andrewchan/.local/bin/node
v26.7.0
```

After:

```
$ command -v node; node -v
/Users/andrewchan/.nvm/versions/node/v22.19.0/bin/node
v22.19.0
```

`scripts/bb-dev-app status` runs clean on the fixed script, and `pnpm dev:desktop` gets past `assert_desktop_node_runtime`.

> AGENT GENERATED
