### PR TITLE
Use login-shell PATH for daemon user tools

### DIFF
--- a/apps/host-daemon/src/app.ts
+++ b/apps/host-daemon/src/app.ts
@@ -433,6 +433,7 @@ export async function createHostDaemonApp(
     hostWatcher: options.hostWatcher,
     refreshWorkspace: (args) =>
       runtimeManager.refreshEnvironmentWorkspace(args),
+    shellEnv: () => runtimeManager.getShellEnv(),
     threadStorageRootPath,
     onThreadStorageChanged: ({ environmentId }) => {
       sendServerMessage({
@@ -918,6 +919,7 @@ export async function createHostDaemonApp(
         devAppPort: options.devAppPort,
         appUrl: options.appUrl,
         getConnected: () => connection.sessionId != null,
+        shellEnv: () => runtimeManager.getShellEnv(),
       })
     : null;
   const eventLoopStallMonitor = startEventLoopStallMonitor({

--- a/apps/host-daemon/src/command-dispatch.ts
+++ b/apps/host-daemon/src/command-dispatch.ts
@@ -86,6 +86,7 @@ import {
   resolveWorkspaceForCommand,
   workspaceResolutionFailureFromError,
 } from "./workspace-resolution.js";
+import { userExecutableProcessOptions } from "./user-executable-env.js";
 
 const THREAD_STOP_ACTIVE_TURN_WAIT_MS = 5_000;
 
@@ -501,6 +502,7 @@ const commandHandlers: CommandHandlerMap = {
       dataDir: options.dataDir,
       projectSlug: command.projectSlug,
       remoteUrl: command.remoteUrl,
+      ...userExecutableProcessOptions(options.runtimeManager.getShellEnv()),
       ...(command.targetPath !== undefined
         ? { targetPath: command.targetPath }
         : {}),
@@ -554,18 +556,30 @@ const commandHandlers: CommandHandlerMap = {
       runtimeManager: options.runtimeManager,
       workspaceContext: command.workspaceContext,
     });
+    const cliOptions = userExecutableProcessOptions(
+      options.runtimeManager.getShellEnv(),
+    );
     switch (command.operation) {
       case "ready":
-        await entry.workspace.runPullRequestAction({ operation: "ready" });
+        await entry.workspace.runPullRequestAction(
+          { operation: "ready" },
+          cliOptions,
+        );
         break;
       case "draft":
-        await entry.workspace.runPullRequestAction({ operation: "draft" });
+        await entry.workspace.runPullRequestAction(
+          { operation: "draft" },
+          cliOptions,
+        );
         break;
       case "merge":
-        await entry.workspace.runPullRequestAction({
-          operation: "merge",
-          method: command.method,
-        });
+        await entry.workspace.runPullRequestAction(
+          {
+            operation: "merge",
+            method: command.method,
+          },
+          cliOptions,
+        );
         break;
       default: {
         const _exhaustive: never = command;
@@ -590,7 +604,11 @@ const onlineRpcHandlers: OnlineRpcHandlerMap = {
   "host.remove_path": removeHostPath,
   "host.browse_directory": browseHostDirectory,
   "host.paths_exist": checkHostPathsExist,
-  "project.inspect": async (command) => inspectProjectPath(command.path),
+  "project.inspect": async (command, options) =>
+    inspectProjectPath(
+      command.path,
+      userExecutableProcessOptions(options.runtimeManager.getShellEnv()),
+    ),
   "project.clone_default_path": async (command, options) => ({
     path: resolveProjectCloneDefaultPath(options.dataDir, command.projectSlug),
   }),
@@ -820,7 +838,9 @@ const onlineRpcHandlers: OnlineRpcHandlerMap = {
         ? { outcome: "absent" }
         : { outcome: "unavailable", message: resolution.failure.message };
     }
-    const lookup = await resolution.entry.workspace.getPullRequest();
+    const lookup = await resolution.entry.workspace.getPullRequest(
+      userExecutableProcessOptions(options.runtimeManager.getShellEnv()),
+    );
     switch (lookup.outcome) {
       case "found":
         return { outcome: "available", pullRequest: lookup.pullRequest };

--- a/apps/host-daemon/src/command-handlers/file-read.ts
+++ b/apps/host-daemon/src/command-handlers/file-read.ts
@@ -3,7 +3,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import mimeTypes from "mime-types";
 import type { HostReadFileRelativeDotfilePolicy } from "@bb/host-daemon-contract";
-import { readGitBlob, WorkspaceError } from "@bb/host-workspace";
+import {
+  readGitBlob,
+  WorkspaceError,
+  type GitProcessOptions,
+} from "@bb/host-workspace";
 import {
   CommandDispatchError,
   ExpectedCommandDispatchError,
@@ -60,7 +64,7 @@ interface ValidatedRootRelativePath {
   resultPath: string;
 }
 
-interface ReadFileFromGitRefArgs {
+interface ReadFileFromGitRefArgs extends GitProcessOptions {
   /** Repo root — `git -C <rootPath>` runs from here. Must be absolute. */
   rootPath: string;
   /** Path under rootPath the caller asked about. Must be absolute, must be within rootPath. */
@@ -265,6 +269,7 @@ export async function readFileFromGitRef(
       args.ref,
       gitRelativePath,
       fileSizeLimitBytes,
+      args,
     );
   } catch (error) {
     if (error instanceof WorkspaceError && error.code === "blob_too_large") {

--- a/apps/host-daemon/src/command-handlers/host-branches.ts
+++ b/apps/host-daemon/src/command-handlers/host-branches.ts
@@ -15,10 +15,15 @@ import {
   listBranches,
   listRemoteBranches,
   readDefaultBranchRefs,
+  type GitProcessOptions,
 } from "@bb/host-workspace";
 import type { HostDaemonOnlineRpcResult } from "@bb/host-daemon-contract";
 import { CommandDispatchError } from "../command-dispatch-support.js";
-import type { CommandOf } from "../command-dispatch-support.js";
+import type {
+  CommandDispatchOptions,
+  CommandOf,
+} from "../command-dispatch-support.js";
+import { userExecutableProcessOptions } from "../user-executable-env.js";
 
 interface LimitBranchListArgs {
   branches: readonly string[];
@@ -42,7 +47,7 @@ interface ClassifySelectedBranchArgs {
   selectedBranch?: string;
 }
 
-interface ReadBranchOptionsArgs {
+interface ReadBranchOptionsArgs extends GitProcessOptions {
   path: string;
   limit: number;
   query?: string;
@@ -104,8 +109,11 @@ function classifySelectedBranch({
   return { name: selectedBranch, kind: "missing" };
 }
 
-async function refreshRemoteBranches(cwd: string): Promise<void> {
-  const commonDir = await getGitCommonDir(cwd);
+async function refreshRemoteBranches(
+  cwd: string,
+  options: GitProcessOptions,
+): Promise<void> {
+  const commonDir = await getGitCommonDir(cwd, options);
   const now = Date.now();
   const existingState = remoteBranchFetchStateByCommonDir.get(commonDir);
   if (
@@ -125,6 +133,7 @@ async function refreshRemoteBranches(cwd: string): Promise<void> {
 
   const inFlight = fetchRemoteBranches(cwd, {
     timeoutMs: REMOTE_BRANCH_FETCH_TIMEOUT_MS,
+    ...options,
   })
     .catch(() => undefined)
     .then(() => undefined)
@@ -148,11 +157,12 @@ async function readBranchOptions({
   limit,
   query,
   selectedBranch: requestedBranch,
+  ...gitProcessOptions
 }: ReadBranchOptionsArgs): Promise<
   HostDaemonOnlineRpcResult<"host.list_branch_options">
 > {
   const { branches, defaultBranch, originDefaultBranch, remoteBranches } =
-    await listBranchRefsWithDefaults(cwd);
+    await listBranchRefsWithDefaults(cwd, gitProcessOptions);
   const limitedBranches = limitBranchList({
     branches: pinBranch({ branches, branch: defaultBranch }),
     limit,
@@ -181,12 +191,16 @@ async function readBranchOptions({
 
 export async function listHostBranchOptions(
   command: CommandOf<"host.list_branch_options">,
+  options?: Pick<CommandDispatchOptions, "runtimeManager">,
 ): Promise<HostDaemonOnlineRpcResult<"host.list_branch_options">> {
   if (!path.isAbsolute(command.path)) {
     throw new CommandDispatchError("invalid_path", "Path must be absolute");
   }
 
-  if (!(await detectGitRepo(command.path))) {
+  const gitProcessOptions = userExecutableProcessOptions(
+    options?.runtimeManager.getShellEnv() ?? {},
+  );
+  if (!(await detectGitRepo(command.path, gitProcessOptions))) {
     return {
       branches: [],
       branchesTruncated: false,
@@ -204,14 +218,17 @@ export async function listHostBranchOptions(
     // Return cached refs immediately. A successful fetch updates shared Git
     // refs, whose workspace watcher event invalidates the observed picker
     // query so the refreshed options arrive without blocking this response.
-    void refreshRemoteBranches(command.path).catch(() => undefined);
+    void refreshRemoteBranches(command.path, gitProcessOptions).catch(
+      () => undefined,
+    );
   }
 
-  return readBranchOptions(command);
+  return readBranchOptions({ ...command, ...gitProcessOptions });
 }
 
 export async function listHostBranches(
   command: CommandOf<"host.list_branches">,
+  options?: Pick<CommandDispatchOptions, "runtimeManager">,
 ): Promise<HostDaemonOnlineRpcResult<"host.list_branches">> {
   if (!path.isAbsolute(command.path)) {
     throw new CommandDispatchError("invalid_path", "Path must be absolute");
@@ -220,7 +237,10 @@ export async function listHostBranches(
   // A project source can be a bare repository whose checkouts are sibling
   // worktrees (`<root>/.bare` + `<root>/.git` gitdir file). It has refs and
   // can seed new worktrees, but has no work tree to be dirty or mid-operation.
-  const repoKind = await detectGitRepoKind(command.path);
+  const gitProcessOptions = userExecutableProcessOptions(
+    options?.runtimeManager.getShellEnv() ?? {},
+  );
+  const repoKind = await detectGitRepoKind(command.path, gitProcessOptions);
   if (repoKind === "none") {
     return {
       branches: [],
@@ -241,17 +261,19 @@ export async function listHostBranches(
     };
   }
 
-  await refreshRemoteBranches(command.path);
+  await refreshRemoteBranches(command.path, gitProcessOptions);
 
   const [branches, remoteBranches, checkout, defaultRefs, dirty, operation] =
     await Promise.all([
-      listBranches(command.path),
-      listRemoteBranches(command.path),
-      getCheckoutRef(command.path),
-      readDefaultBranchRefs(command.path),
-      repoKind === "work-tree" ? hasUncommittedChanges(command.path) : false,
+      listBranches(command.path, gitProcessOptions),
+      listRemoteBranches(command.path, gitProcessOptions),
+      getCheckoutRef(command.path, gitProcessOptions),
+      readDefaultBranchRefs(command.path, gitProcessOptions),
       repoKind === "work-tree"
-        ? getWorkspaceGitOperation(command.path)
+        ? hasUncommittedChanges(command.path, gitProcessOptions)
+        : false,
+      repoKind === "work-tree"
+        ? getWorkspaceGitOperation(command.path, gitProcessOptions)
         : NO_GIT_OPERATION,
     ]);
   const defaultBranch = defaultRefs.defaultBranch;

--- a/apps/host-daemon/src/command-handlers/host-files.ts
+++ b/apps/host-daemon/src/command-handlers/host-files.ts
@@ -6,9 +6,13 @@ import type {
   HostDaemonOnlineRpcResult,
   HostPathEntryKind,
 } from "@bb/host-daemon-contract";
-import { CommandDispatchError } from "../command-dispatch-support.js";
-import type { CommandOf } from "../command-dispatch-support.js";
+import {
+  CommandDispatchError,
+  type CommandDispatchOptions,
+  type CommandOf,
+} from "../command-dispatch-support.js";
 import { isFsErrorWithCode } from "../fs-errors.js";
+import { userExecutableProcessOptions } from "../user-executable-env.js";
 import {
   finalizeListedFiles,
   finalizeListedPaths,
@@ -194,6 +198,7 @@ export async function checkHostPathsExist(
 
 export async function readHostFile(
   command: CommandOf<"host.read_file">,
+  options?: Pick<CommandDispatchOptions, "runtimeManager">,
 ): Promise<HostDaemonOnlineRpcResult<"host.read_file">> {
   assertAbsoluteHostDiskPathCommand(command);
 
@@ -210,6 +215,9 @@ export async function readHostFile(
       resolvedPath: command.path,
       resultPath: command.path,
       ref: command.ref,
+      ...userExecutableProcessOptions(
+        options?.runtimeManager.getShellEnv() ?? {},
+      ),
     });
   }
 

--- a/apps/host-daemon/src/command-handlers/project.ts
+++ b/apps/host-daemon/src/command-handlers/project.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { runGit, WorkspaceError } from "@bb/host-workspace";
+import {
+  runGit,
+  WorkspaceError,
+  type GitProcessOptions,
+} from "@bb/host-workspace";
 import { ExpectedCommandDispatchError } from "../command-dispatch-support.js";
 
 const PROJECT_CLONE_TIMEOUT_MS = 20 * 60 * 1000;
@@ -43,13 +47,17 @@ async function requireEmptyOrMissingTarget(targetPath: string): Promise<void> {
   }
 }
 
-export async function inspectProjectPath(projectPath: string): Promise<{
+export async function inspectProjectPath(
+  projectPath: string,
+  options: GitProcessOptions = {},
+): Promise<{
   path: string;
   gitRemoteUrl: string | null;
 }> {
   const resolvedPath = path.resolve(projectPath);
   const result = await runGit(["remote", "get-url", "origin"], {
     cwd: resolvedPath,
+    ...options,
     allowFailure: true,
   });
   const gitRemoteUrl = result.exitCode === 0 ? result.stdout.trim() : "";
@@ -64,6 +72,7 @@ export async function cloneProject(args: {
   projectSlug: string;
   remoteUrl: string;
   targetPath?: string;
+  shellPath?: string;
 }): Promise<{ path: string; gitRemoteUrl: string | null }> {
   const targetPath = path.resolve(
     args.targetPath ??
@@ -74,6 +83,7 @@ export async function cloneProject(args: {
   try {
     await runGit(["clone", args.remoteUrl, targetPath], {
       cwd: path.dirname(targetPath),
+      ...(args.shellPath !== undefined ? { shellPath: args.shellPath } : {}),
       timeoutMs: PROJECT_CLONE_TIMEOUT_MS,
     });
   } catch (error) {
@@ -82,5 +92,8 @@ export async function cloneProject(args: {
     }
     throw error;
   }
-  return inspectProjectPath(targetPath);
+  return inspectProjectPath(
+    targetPath,
+    args.shellPath === undefined ? {} : { shellPath: args.shellPath },
+  );
 }

--- a/apps/host-daemon/src/local-api.ts
+++ b/apps/host-daemon/src/local-api.ts
@@ -24,8 +24,9 @@ import {
   type WorkspaceOpenTargetsQuery,
 } from "@bb/host-daemon-contract";
 import {
-  listWorkspaceOpenTargets,
-  openPathInTarget,
+  createWorkspaceOpenTargetRuntime,
+  listWorkspaceOpenTargetsWithRuntime,
+  openPathInTargetWithRuntime,
   type OpenPathInTargetArgs,
   WorkspaceOpenTargetError,
 } from "@bb/local-open-targets";
@@ -35,6 +36,7 @@ import { HTTPException } from "hono/http-exception";
 import { isFsErrorWithCode } from "./fs-errors.js";
 import type { HostDaemonLocalApiConfig } from "./local-api-config.js";
 import { resolveHostPlatform } from "./host-platform.js";
+import { userExecutableProcessOptions } from "./user-executable-env.js";
 
 type WorkspaceOpenTargetListHandler = (
   query: WorkspaceOpenTargetsQuery,
@@ -67,6 +69,7 @@ interface StartLocalApiServerOptions {
   getConnected: () => boolean;
   listWorkspaceOpenTargets?: WorkspaceOpenTargetListHandler;
   openInTarget?: OpenInTargetHandler;
+  shellEnv?: () => NodeJS.ProcessEnv;
 }
 
 export interface LocalApiServer {
@@ -197,6 +200,12 @@ async function resolveOpenPathInTargetArgs({
   };
 }
 
+function workspaceOpenTargetRuntime(options: StartLocalApiServerOptions) {
+  return createWorkspaceOpenTargetRuntime({
+    ...userExecutableProcessOptions(options.shellEnv?.() ?? {}),
+  });
+}
+
 export async function startLocalApiServer(
   options: StartLocalApiServerOptions,
 ): Promise<LocalApiServer> {
@@ -303,14 +312,26 @@ export async function startLocalApiServer(
     async (c, query) =>
       c.json({
         targets: await (
-          options.listWorkspaceOpenTargets ?? listWorkspaceOpenTargets
+          options.listWorkspaceOpenTargets ??
+          ((query) =>
+            listWorkspaceOpenTargetsWithRuntime(
+              workspaceOpenTargetRuntime(options),
+              query,
+            ))
         )(query),
       }),
   );
 
   post("/open-in-target", openInTargetRequestSchema, async (c, payload) => {
     try {
-      await (options.openInTarget ?? openPathInTarget)(
+      await (
+        options.openInTarget ??
+        ((args) =>
+          openPathInTargetWithRuntime(
+            args,
+            workspaceOpenTargetRuntime(options),
+          ))
+      )(
         await resolveOpenPathInTargetArgs({
           configLoader: clientConfigLoader,
           request: payload,

--- a/apps/host-daemon/src/runtime-manager.test.ts
+++ b/apps/host-daemon/src/runtime-manager.test.ts
@@ -1235,7 +1235,31 @@ describe("RuntimeManager", () => {
 
     expect(provisionWorkspace).toHaveBeenCalledWith(
       expect.objectContaining({
-        setupPath: "/resolved/user/bin:/usr/bin:/bin",
+        shellPath: "/resolved/user/bin:/usr/bin:/bin",
+      }),
+    );
+  });
+
+  it("passes the resolved shell PATH to unmanaged workspace Git", async () => {
+    const provisionWorkspace = createProvisionWorkspaceMock("/tmp/env-1");
+    const manager = new RuntimeManager({
+      provisionWorkspace,
+      shellEnv: {
+        PATH: "/resolved/user/bin:/usr/bin:/bin",
+      },
+    });
+
+    await manager.ensureEnvironment({
+      environmentId: "env-1",
+      provision: {
+        workspaceProvisionType: "unmanaged",
+        path: "/tmp/env-1",
+      },
+    });
+
+    expect(provisionWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shellPath: "/resolved/user/bin:/usr/bin:/bin",
       }),
     );
   });

--- a/apps/host-daemon/src/runtime-manager.ts
+++ b/apps/host-daemon/src/runtime-manager.ts
@@ -42,6 +42,7 @@ import {
 } from "./injected-skills.js";
 import { reconnectProvisionArgs } from "./workspace-provision-target.js";
 import type { FetchSkillTree } from "./skill-trees.js";
+import { userExecutableProcessOptions } from "./user-executable-env.js";
 
 type StopWatching = () => void | Promise<void>;
 
@@ -1064,7 +1065,7 @@ export class RuntimeManager {
       );
     }
 
-    const workspace = await this.provisionWorkspace(args.provision);
+    const workspace = await this.provisionHostWorkspace(args.provision);
     if (workspace.path !== args.workspacePath) {
       throw new Error(
         `Workspace refresh for ${args.environmentId} returned ${workspace.path}, not ${args.workspacePath}`,
@@ -1149,7 +1150,10 @@ export class RuntimeManager {
       );
     }
 
-    await this.provisionWorkspace({ ...args.provision, signal: args.signal });
+    await this.provisionHostWorkspace({
+      ...args.provision,
+      signal: args.signal,
+    });
     this.options.onWorkspaceStatusChanged?.({
       environmentId: args.entry.environmentId,
       changeKinds: ["work-status-changed", "git-refs-changed"],
@@ -1423,12 +1427,8 @@ export class RuntimeManager {
       );
     }
 
-    const setupPath = this.getShellEnv().PATH;
-    const workspace = await this.provisionWorkspace({
+    const workspace = await this.provisionHostWorkspace({
       ...provision,
-      ...(provision.workspaceProvisionType === "managed-worktree" && setupPath
-        ? { setupPath }
-        : {}),
       signal: args.provisionSignal,
     });
     const workspaceWriteRoots =
@@ -1508,6 +1508,15 @@ export class RuntimeManager {
       workspace,
       path: workspace.path,
     };
+  }
+
+  private provisionHostWorkspace(
+    provision: ProvisionWorkspaceArgs,
+  ): Promise<HostWorkspace> {
+    return this.provisionWorkspace({
+      ...provision,
+      ...userExecutableProcessOptions(this.getShellEnv()),
+    });
   }
 
   private async stopWatchingStatus(entry: RuntimeEntry): Promise<void> {

--- a/apps/host-daemon/src/user-executable-env.ts
+++ b/apps/host-daemon/src/user-executable-env.ts
@@ -1,0 +1,11 @@
+/**
+ * Process options for tools the user expects BB to resolve like their shell
+ * does. OS/service utilities deliberately do not use this policy, so a user
+ * login-shell PATH cannot shadow commands such as `scutil` or `osascript`.
+ */
+export function userExecutableProcessOptions(shellEnv: NodeJS.ProcessEnv): {
+  shellPath?: string;
+} {
+  const shellPath = shellEnv.PATH;
+  return shellPath === undefined ? {} : { shellPath };
+}

--- a/apps/host-daemon/src/watch-manager.ts
+++ b/apps/host-daemon/src/watch-manager.ts
@@ -18,6 +18,7 @@ import type {
   WorkspaceWatchError,
 } from "@bb/host-watcher";
 import { reconnectProvisionArgsFromWorkspaceContext } from "./workspace-provision-target.js";
+import { userExecutableProcessOptions } from "./user-executable-env.js";
 
 type StopWatching = () => void | Promise<void>;
 
@@ -56,6 +57,7 @@ export interface WatchManagerOptions {
     options: ProvisionWorkspaceArgs,
   ) => Promise<HostWorkspace>;
   refreshWorkspace?: (args: RefreshWorkspaceArgs) => Promise<HostWorkspace>;
+  shellEnv?: () => NodeJS.ProcessEnv;
   threadStorageRootPath?: string | null;
   onThreadStorageChanged?: (args: {
     environmentId: string;
@@ -123,11 +125,15 @@ export class WatchManager {
 
   constructor(private readonly options: WatchManagerOptions = {}) {
     this.hostWatcher = options.hostWatcher;
-    this.provisionWorkspace = options.provisionWorkspace ?? provisionWorkspace;
+    const provision = options.provisionWorkspace ?? provisionWorkspace;
+    this.provisionWorkspace = (args: ProvisionWorkspaceArgs) =>
+      provision({
+        ...args,
+        ...userExecutableProcessOptions(options.shellEnv?.() ?? {}),
+      });
     this.refreshWorkspace =
       options.refreshWorkspace ??
-      ((args: RefreshWorkspaceArgs) =>
-        this.provisionWorkspace(args.provision));
+      ((args: RefreshWorkspaceArgs) => this.provisionWorkspace(args.provision));
   }
 
   async replaceWatchSet(watchSet: HostDaemonWatchSet): Promise<void> {

--- a/apps/host-daemon/test/command/dispatch-helpers.ts
+++ b/apps/host-daemon/test/command/dispatch-helpers.ts
@@ -61,8 +61,10 @@ interface FakeWorkspaceState {
   lastCommitMessage: string | undefined;
   lastDiffTarget: FakeWorkspaceDiffTarget | undefined;
   lastPullRequestAction: PullRequestActionOptions | undefined;
+  pullRequestActionShellPath: string | undefined;
   pullRequest: GitHostPullRequest | null;
   pullRequestLookupError: string | null;
+  pullRequestLookupShellPath: string | undefined;
   statusReads: number;
 }
 
@@ -128,8 +130,10 @@ export function createFakeWorkspace(pathname: string) {
     lastCommitMessage: undefined,
     destroyed: false,
     lastPullRequestAction: undefined,
+    pullRequestActionShellPath: undefined,
     pullRequest: null,
     pullRequestLookupError: null,
+    pullRequestLookupShellPath: undefined,
   };
   const workspace: FakeHostWorkspace = {
     path: pathname,
@@ -205,7 +209,8 @@ export function createFakeWorkspace(pathname: string) {
     async diffPatch() {
       return [];
     },
-    async getPullRequest() {
+    async getPullRequest(options) {
+      state.pullRequestLookupShellPath = options?.shellPath;
       if (state.pullRequestLookupError !== null) {
         return {
           outcome: "unavailable" as const,
@@ -216,8 +221,9 @@ export function createFakeWorkspace(pathname: string) {
         ? { outcome: "none" as const }
         : { outcome: "found" as const, pullRequest: state.pullRequest };
     },
-    async runPullRequestAction(action) {
+    async runPullRequestAction(action, options) {
       state.lastPullRequestAction = action;
+      state.pullRequestActionShellPath = options?.shellPath;
     },
     async listFiles() {
       return listFilesRecursively(pathname, pathname);

--- a/apps/host-daemon/test/command/workspace-dispatch.test.ts
+++ b/apps/host-daemon/test/command/workspace-dispatch.test.ts
@@ -136,6 +136,9 @@ describe("workspace command dispatch", () => {
 
   it("covers workspace.pull_request", async () => {
     const harness = createHarness();
+    await harness.manager.replaceBaseShellEnv({
+      PATH: "/Users/test/.local/bin:/usr/bin",
+    });
     await harness.manager.ensureEnvironment({
       environmentId: "env-1",
       workspacePath: "/tmp/env-1",
@@ -170,6 +173,9 @@ describe("workspace command dispatch", () => {
       harness.dispatchOptions(),
     );
     expect(presentResult).toEqual({ outcome: "available", pullRequest });
+    expect(harness.workspaceState.pullRequestLookupShellPath).toBe(
+      "/Users/test/.local/bin:/usr/bin",
+    );
 
     harness.workspaceState.pullRequest = null;
     const absentResult = await dispatchOnlineRpcCommand(
@@ -246,6 +252,9 @@ describe("workspace command dispatch", () => {
 
   it("covers workspace.pull_request_action", async () => {
     const harness = createHarness({ isWorktree: true });
+    await harness.manager.replaceBaseShellEnv({
+      PATH: "/Users/test/.local/bin:/usr/bin",
+    });
     await harness.manager.ensureEnvironment({
       environmentId: "env-1",
       workspacePath: "/tmp/env-1",
@@ -268,6 +277,9 @@ describe("workspace command dispatch", () => {
     expect(harness.workspaceState.lastPullRequestAction).toEqual({
       operation: "ready",
     });
+    expect(harness.workspaceState.pullRequestActionShellPath).toBe(
+      "/Users/test/.local/bin:/usr/bin",
+    );
 
     await expect(
       dispatchCommand(

--- a/packages/host-workspace/src/checkout-mutation-lock.ts
+++ b/packages/host-workspace/src/checkout-mutation-lock.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { getAbsoluteGitDir, runGit } from "./git.js";
+import { getAbsoluteGitDir, runGit, type GitProcessOptions } from "./git.js";
 import {
   withProcessLocalQueuedLocks,
   type ProcessLocalQueuedLockSpec,
@@ -40,15 +40,18 @@ export async function withCheckoutMutationAdmission<T>(
 
 async function resolveCheckoutMutationLockSpec(
   checkoutPath: string,
+  options: GitProcessOptions,
 ): Promise<ProcessLocalQueuedLockSpec> {
-  return { key: await getAbsoluteGitDir(checkoutPath) };
+  return { key: await getAbsoluteGitDir(checkoutPath, options) };
 }
 
 async function tryResolveCheckoutMutationLockSpec(
   checkoutPath: string,
+  options: GitProcessOptions,
 ): Promise<ProcessLocalQueuedLockSpec | null> {
   const result = await runGit(["rev-parse", "--absolute-git-dir"], {
     cwd: checkoutPath,
+    ...options,
     allowFailure: true,
   });
   if (result.exitCode !== 0) {
@@ -63,11 +66,12 @@ export async function withCheckoutMutationLock<T>(
   checkoutPath: string,
   work: CheckoutMutationLockWork<T>,
   signal?: AbortSignal,
+  options: GitProcessOptions = {},
 ): Promise<T> {
   return withCheckoutMutationAdmission(
     checkoutPath,
     async () => {
-      const lock = await resolveCheckoutMutationLockSpec(checkoutPath);
+      const lock = await resolveCheckoutMutationLockSpec(checkoutPath, options);
       return withProcessLocalQueuedLocks({ locks: [lock], signal, work });
     },
     signal,
@@ -90,11 +94,15 @@ export async function tryWithCheckoutMutationLock<T>(
   checkoutPath: string,
   work: CheckoutMutationLockWork<T>,
   signal?: AbortSignal,
+  options: GitProcessOptions = {},
 ): Promise<T | null> {
   return withCheckoutMutationAdmission(
     checkoutPath,
     async () => {
-      const lock = await tryResolveCheckoutMutationLockSpec(checkoutPath);
+      const lock = await tryResolveCheckoutMutationLockSpec(
+        checkoutPath,
+        options,
+      );
       if (!lock) {
         return null;
       }
@@ -109,13 +117,14 @@ export async function withCheckoutMutationLocks<T>(
   checkoutPaths: string[],
   work: CheckoutMutationLockWork<T>,
   signal?: AbortSignal,
+  options: GitProcessOptions = {},
 ): Promise<T> {
   return withCheckoutMutationAdmissions(
     checkoutPaths,
     async () => {
       const locks = await Promise.all(
         checkoutPaths.map((checkoutPath) =>
-          resolveCheckoutMutationLockSpec(checkoutPath),
+          resolveCheckoutMutationLockSpec(checkoutPath, options),
         ),
       );
       return withProcessLocalQueuedLocks({ locks, signal, work });

--- a/packages/host-workspace/src/git-host.ts
+++ b/packages/host-workspace/src/git-host.ts
@@ -45,7 +45,16 @@ const GH_PR_VIEW_JSON_FIELDS = [
   "mergeable",
 ].join(",");
 
-interface GetPullRequestForCurrentBranchArgs {
+export interface GitHostCliOptions {
+  /**
+   * Resolved user login-shell PATH. When omitted, `gh` inherits the parent
+   * process PATH, which is useful for direct library consumers but may be the
+   * minimal service PATH inside the host daemon.
+   */
+  shellPath?: string;
+}
+
+interface GetPullRequestForCurrentBranchArgs extends GitHostCliOptions {
   cwd: string;
   localBranch: string;
 }
@@ -57,7 +66,7 @@ export type GitHostPullRequestAction =
   | { operation: "draft" }
   | { operation: "merge"; method: GitHostPullRequestMergeMethod };
 
-interface RunPullRequestActionForCurrentBranchArgs {
+interface RunPullRequestActionForCurrentBranchArgs extends GitHostCliOptions {
   cwd: string;
   localBranch: string;
   action: GitHostPullRequestAction;
@@ -533,6 +542,7 @@ async function getPullRequestTarget(
       ],
       {
         cwd: args.cwd,
+        ...(args.shellPath !== undefined ? { shellPath: args.shellPath } : {}),
         allowFailure: true,
         timeoutMs: GIT_UPSTREAM_LOOKUP_TIMEOUT_MS,
       },
@@ -620,8 +630,8 @@ async function getPullRequestTarget(
  * failure (`gh` not installed, not authenticated, no GitHub remote, a timeout,
  * unparseable output) is `outcome: "unavailable"` so callers can distinguish
  * "no PR" from "could not check". The inherited environment preserves
- * `PATH`/`HOME`/token vars so `gh` auth resolves the same way it would in the
- * user's shell.
+ * `HOME`/token vars and substitutes the resolved login-shell PATH when the
+ * caller supplies it, so daemon probes resolve the same `gh` as the user.
  */
 export async function getPullRequestForCurrentBranch(
   args: GetPullRequestForCurrentBranchArgs,
@@ -642,7 +652,10 @@ export async function getPullRequestForCurrentBranch(
     ({ stdout } = await execFileAsync("gh", ghArgs, {
       cwd: args.cwd,
       encoding: "utf8",
-      env: sanitizeInheritedChildProcessEnv({ env: process.env }),
+      env: sanitizeInheritedChildProcessEnv({
+        env: process.env,
+        ...(args.shellPath !== undefined ? { shellPath: args.shellPath } : {}),
+      }),
       timeout: GH_PR_VIEW_TIMEOUT_MS,
       maxBuffer: GH_PR_VIEW_MAX_BUFFER_BYTES,
     }));
@@ -679,7 +692,10 @@ export async function runPullRequestActionForCurrentBranch(
     await execFileAsync("gh", ghArgs, {
       cwd: args.cwd,
       encoding: "utf8",
-      env: sanitizeInheritedChildProcessEnv({ env: process.env }),
+      env: sanitizeInheritedChildProcessEnv({
+        env: process.env,
+        ...(args.shellPath !== undefined ? { shellPath: args.shellPath } : {}),
+      }),
       timeout: GH_PR_ACTION_TIMEOUT_MS,
       maxBuffer: GH_PR_ACTION_MAX_BUFFER_BYTES,
     });

--- a/packages/host-workspace/src/git.ts
+++ b/packages/host-workspace/src/git.ts
@@ -22,7 +22,12 @@ export class WorkspaceError extends Error {
   }
 }
 
-export interface RunGitOptions {
+export interface GitProcessOptions {
+  /** Resolved user login-shell PATH used to locate Git. */
+  shellPath?: string;
+}
+
+export interface RunGitOptions extends GitProcessOptions {
   cwd: string;
   timeoutMs?: number;
   allowFailure?: boolean;
@@ -34,9 +39,10 @@ export interface RunGitOptions {
 
 interface ResolveGitProcessEnvArgs {
   env: NodeJS.ProcessEnv | undefined;
+  shellPath: string | undefined;
 }
 
-interface GitTimeoutOptions {
+interface GitTimeoutOptions extends GitProcessOptions {
   timeoutMs?: number;
 }
 
@@ -151,7 +157,10 @@ function resolveGitProcessEnv(
   args: ResolveGitProcessEnvArgs,
 ): NodeJS.ProcessEnv {
   return {
-    ...sanitizeInheritedChildProcessEnv({ env: process.env }),
+    ...sanitizeInheritedChildProcessEnv({
+      env: process.env,
+      ...(args.shellPath !== undefined ? { shellPath: args.shellPath } : {}),
+    }),
     ...args.env,
   };
 }
@@ -262,7 +271,10 @@ export async function runGit(
     const result = await execFileAsync("git", args, {
       cwd: options.cwd,
       encoding: "utf8",
-      env: resolveGitProcessEnv({ env: options.env }),
+      env: resolveGitProcessEnv({
+        env: options.env,
+        shellPath: options.shellPath,
+      }),
       maxBuffer: options.maxBufferBytes ?? DEFAULT_BUFFER_BYTES,
       signal: options.signal,
       timeout: options.timeoutMs,
@@ -341,7 +353,10 @@ export async function runGitWithNullRecordLimit(
   return new Promise((resolve, reject) => {
     const child = spawn("git", args, {
       cwd: options.cwd,
-      env: resolveGitProcessEnv({ env: options.env }),
+      env: resolveGitProcessEnv({
+        env: options.env,
+        shellPath: options.shellPath,
+      }),
       stdio: ["ignore", "pipe", "pipe"],
     });
     const stdoutRecords: Buffer[] = [];
@@ -471,8 +486,14 @@ export async function runGitWithNullRecordLimit(
   });
 }
 
-export async function getAbsoluteGitDir(cwd: string): Promise<string> {
-  const result = await runGit(["rev-parse", "--absolute-git-dir"], { cwd });
+export async function getAbsoluteGitDir(
+  cwd: string,
+  options: GitProcessOptions = {},
+): Promise<string> {
+  const result = await runGit(["rev-parse", "--absolute-git-dir"], {
+    cwd,
+    ...options,
+  });
   const gitDir = result.stdout.trim();
   if (!gitDir) {
     throw new WorkspaceError(
@@ -483,8 +504,14 @@ export async function getAbsoluteGitDir(cwd: string): Promise<string> {
   return path.resolve(gitDir);
 }
 
-export async function getGitCommonDir(cwd: string): Promise<string> {
-  const result = await runGit(["rev-parse", "--git-common-dir"], { cwd });
+export async function getGitCommonDir(
+  cwd: string,
+  options: GitProcessOptions = {},
+): Promise<string> {
+  const result = await runGit(["rev-parse", "--git-common-dir"], {
+    cwd,
+    ...options,
+  });
   const commonDir = result.stdout.trim();
   if (!commonDir) {
     throw new WorkspaceError(
@@ -515,12 +542,15 @@ export async function runShellPipeline(
   }
   try {
     const result = await execFileAsync(
-      "sh",
+      "/bin/sh",
       ["-c", script, "sh", ...positionalArgs],
       {
         cwd: options.cwd,
         encoding: "utf8",
-        env: resolveGitProcessEnv({ env: undefined }),
+        env: resolveGitProcessEnv({
+          env: undefined,
+          shellPath: options.shellPath,
+        }),
         maxBuffer: DEFAULT_BUFFER_BYTES,
         signal: options.signal,
         timeout: options.timeoutMs,
@@ -603,7 +633,7 @@ export async function detectGitRepoKind(
 ): Promise<GitRepoKind> {
   const result = await runGit(
     ["rev-parse", "--is-inside-work-tree", "--is-bare-repository"],
-    { cwd, allowFailure: true, timeoutMs: options.timeoutMs },
+    { cwd, ...options, allowFailure: true },
   );
   if (result.exitCode !== 0) {
     return "none";
@@ -671,7 +701,7 @@ export async function readGitRepositoryState(
   }
   const result = await runGit(["rev-list", "--all", "--max-count=1"], {
     cwd,
-    timeoutMs: options.timeoutMs,
+    ...options,
   });
   return trimOutput(result.stdout).length > 0 ? "has_commits" : "no_commits";
 }
@@ -682,8 +712,8 @@ async function readHeadSha(
 ): Promise<string | null> {
   const result = await runGit(["rev-parse", "--verify", "HEAD"], {
     cwd,
+    ...options,
     allowFailure: true,
-    timeoutMs: options.timeoutMs,
   });
   if (result.exitCode !== 0) {
     return null;
@@ -703,8 +733,8 @@ export async function getCurrentBranch(
 
   const result = await runGit(["symbolic-ref", "--quiet", "--short", "HEAD"], {
     cwd,
+    ...options,
     allowFailure: true,
-    timeoutMs: options.timeoutMs,
   });
   if (result.exitCode !== 0) {
     return undefined;
@@ -725,8 +755,8 @@ export async function getCheckoutRef(
   const [symbolicRef, headSha] = await Promise.all([
     runGit(["symbolic-ref", "--quiet", "--short", "HEAD"], {
       cwd,
+      ...options,
       allowFailure: true,
-      timeoutMs: options.timeoutMs,
     }),
     readHeadSha(cwd, options),
   ]);
@@ -895,16 +925,17 @@ function buildActiveWorkspaceGitOperation(
 
 export async function getWorkspaceGitOperation(
   cwd: string,
+  options: GitProcessOptions = {},
 ): Promise<WorkspaceGitOperation> {
-  await ensureGitRepo(cwd);
+  await ensureGitRepo(cwd, options);
 
   const [gitDir, status] = await Promise.all([
-    getAbsoluteGitDir(cwd),
+    getAbsoluteGitDir(cwd, options),
     // --no-optional-locks: status must not take index.lock, or background
     // polling races concurrent commits in the same checkout.
     runGit(
       ["--no-optional-locks", "status", "--porcelain=v1", "--untracked-files=all"],
-      { cwd },
+      { cwd, ...options },
     ),
   ]);
   const hasConflicts = hasPorcelainConflict(
@@ -1076,7 +1107,7 @@ export async function readDefaultBranch(
 
   const originHead = await runGit(
     ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"],
-    { cwd, allowFailure: true, timeoutMs: options.timeoutMs },
+    { cwd, ...options, allowFailure: true },
   );
   const remoteHead = trimOutput(originHead.stdout);
   if (remoteHead.startsWith("refs/remotes/origin/")) {
@@ -1085,7 +1116,7 @@ export async function readDefaultBranch(
 
   const branches = await runGit(
     ["for-each-ref", "--format=%(refname:short)", "refs/heads"],
-    { cwd, timeoutMs: options.timeoutMs },
+    { cwd, ...options },
   );
   const localBranches = branches.stdout
     .split("\n")
@@ -1108,7 +1139,7 @@ async function readLocalBranches(
 ): Promise<string[]> {
   const branches = await runGit(
     ["for-each-ref", "--format=%(refname:short)", "refs/heads"],
-    { cwd, timeoutMs: options.timeoutMs },
+    { cwd, ...options },
   );
   return branches.stdout
     .split("\n")
@@ -1146,7 +1177,7 @@ async function readOriginHeadBranchName(
 ): Promise<string | undefined> {
   const originHead = await runGit(
     ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"],
-    { cwd, allowFailure: true, timeoutMs: options.timeoutMs },
+    { cwd, ...options, allowFailure: true },
   );
   return parseOriginHeadBranchName(originHead.stdout);
 }
@@ -1159,8 +1190,8 @@ export async function hasRef(
   await ensureGitRepo(cwd, options);
   const result = await runGit(["show-ref", "--verify", "--quiet", ref], {
     cwd,
+    ...options,
     allowFailure: true,
-    timeoutMs: options.timeoutMs,
   });
   return result.exitCode === 0;
 }
@@ -1195,8 +1226,8 @@ async function revParseRef(
 ): Promise<string | undefined> {
   const result = await runGit(["rev-parse", "--verify", `${ref}^{commit}`], {
     cwd,
+    ...options,
     allowFailure: true,
-    timeoutMs: options.timeoutMs,
   });
   if (result.exitCode !== 0) {
     return undefined;
@@ -1212,7 +1243,7 @@ async function isAncestorRef(
 ): Promise<boolean | undefined> {
   const result = await runGit(
     ["merge-base", "--is-ancestor", ancestorRef, descendantRef],
-    { cwd, allowFailure: true, timeoutMs: options.timeoutMs },
+    { cwd, ...options, allowFailure: true },
   );
   if (result.exitCode === 0) {
     return true;
@@ -1303,8 +1334,8 @@ export async function fetchRemoteBranches(
 
   const remotes = await runGit(["remote"], {
     cwd,
+    ...options,
     allowFailure: true,
-    timeoutMs: options.timeoutMs,
   });
   if (
     remotes.exitCode !== 0 ||
@@ -1319,8 +1350,8 @@ export async function fetchRemoteBranches(
   try {
     const result = await runGit(["fetch", "--all", "--prune", "--quiet"], {
       cwd,
+      ...options,
       allowFailure: true,
-      timeoutMs: options.timeoutMs,
     });
     return { status: result.exitCode === 0 ? "fetched" : "failed" };
   } catch (error) {
@@ -1339,8 +1370,8 @@ export async function readMergeBaseRef(
   await ensureGitRepo(cwd, options);
   const result = await runGit(["merge-base", ref, "HEAD"], {
     cwd,
+    ...options,
     allowFailure: true,
-    timeoutMs: options.timeoutMs,
   });
   if (result.exitCode !== 0) {
     return undefined;
@@ -1350,9 +1381,13 @@ export async function readMergeBaseRef(
   return mergeBaseRef || undefined;
 }
 
-export async function revParse(cwd: string, ref: string): Promise<string> {
-  await ensureGitRepo(cwd);
-  const result = await runGit(["rev-parse", ref], { cwd });
+export async function revParse(
+  cwd: string,
+  ref: string,
+  options: GitProcessOptions = {},
+): Promise<string> {
+  await ensureGitRepo(cwd, options);
+  const result = await runGit(["rev-parse", ref], { cwd, ...options });
   return trimOutput(result.stdout);
 }
 
@@ -1372,11 +1407,16 @@ async function gitBlobSize(
   cwd: string,
   ref: string,
   relativePath: string,
+  options: GitProcessOptions,
 ): Promise<number | undefined> {
-  await ensureGitRepo(cwd);
+  await ensureGitRepo(cwd, options);
   const target = `${ref}:${relativePath}`;
   const typeArgs = ["cat-file", "-t", target];
-  const typeResult = await runGit(typeArgs, { cwd, allowFailure: true });
+  const typeResult = await runGit(typeArgs, {
+    cwd,
+    ...options,
+    allowFailure: true,
+  });
   if (typeResult.exitCode !== 0) {
     const stderr = trimOutput(typeResult.stderr);
     if (isMissingGitBlobTargetError(stderr)) {
@@ -1394,7 +1434,11 @@ async function gitBlobSize(
   }
 
   const sizeArgs = ["cat-file", "-s", target];
-  const sizeResult = await runGit(sizeArgs, { cwd, allowFailure: true });
+  const sizeResult = await runGit(sizeArgs, {
+    cwd,
+    ...options,
+    allowFailure: true,
+  });
   if (sizeResult.exitCode !== 0) {
     const stderr = trimOutput(sizeResult.stderr);
     if (isMissingGitBlobTargetError(stderr)) {
@@ -1426,9 +1470,10 @@ export async function readGitBlob(
   ref: string,
   relativePath: string,
   maxBytes: number,
+  options: GitProcessOptions = {},
 ): Promise<ReadGitBlobResult> {
   const target = `${ref}:${relativePath}`;
-  const size = await gitBlobSize(cwd, ref, relativePath);
+  const size = await gitBlobSize(cwd, ref, relativePath, options);
   if (size === undefined) {
     return { contents: null, sizeBytes: 0 };
   }
@@ -1443,7 +1488,10 @@ export async function readGitBlob(
     const result = await execFileAsync("git", ["cat-file", "blob", target], {
       cwd,
       encoding: "buffer",
-      env: resolveGitProcessEnv({ env: undefined }),
+      env: resolveGitProcessEnv({
+        env: undefined,
+        shellPath: options.shellPath,
+      }),
       maxBuffer: maxBytes,
     });
     const contents = Buffer.from(result.stdout);
@@ -1467,11 +1515,14 @@ export async function readGitBlob(
   }
 }
 
-export async function listBranches(cwd: string): Promise<string[]> {
-  await ensureGitRepo(cwd);
+export async function listBranches(
+  cwd: string,
+  options: GitProcessOptions = {},
+): Promise<string[]> {
+  await ensureGitRepo(cwd, options);
   const result = await runGit(
     ["for-each-ref", "--format=%(refname:short)", "refs/heads"],
-    { cwd },
+    { cwd, ...options },
   );
   return result.stdout
     .split("\n")
@@ -1479,11 +1530,14 @@ export async function listBranches(cwd: string): Promise<string[]> {
     .filter(Boolean);
 }
 
-export async function listRemoteBranches(cwd: string): Promise<string[]> {
-  await ensureGitRepo(cwd);
+export async function listRemoteBranches(
+  cwd: string,
+  options: GitProcessOptions = {},
+): Promise<string[]> {
+  await ensureGitRepo(cwd, options);
   const result = await runGit(
     ["for-each-ref", "--format=%(refname:short)%09%(symref)", "refs/remotes"],
-    { cwd },
+    { cwd, ...options },
   );
   return result.stdout
     .split("\n")
@@ -1497,11 +1551,12 @@ export async function listRemoteBranches(cwd: string): Promise<string[]> {
 
 export async function listBranchRefsWithDefaults(
   cwd: string,
+  options: GitProcessOptions = {},
 ): Promise<BranchRefsWithDefaults> {
   const [branches, remoteBranches, originHeadBranch] = await Promise.all([
-    listBranches(cwd),
-    listRemoteBranches(cwd),
-    readOriginHeadBranchName(cwd),
+    listBranches(cwd, options),
+    listRemoteBranches(cwd, options),
+    readOriginHeadBranchName(cwd, options),
   ]);
   const defaultBranch = resolvePreferredLocalDefaultBranch(
     branches,
@@ -1523,11 +1578,14 @@ export async function listBranchRefsWithDefaults(
   };
 }
 
-export async function hasUncommittedChanges(cwd: string): Promise<boolean> {
-  await ensureGitRepo(cwd);
+export async function hasUncommittedChanges(
+  cwd: string,
+  options: GitProcessOptions = {},
+): Promise<boolean> {
+  await ensureGitRepo(cwd, options);
   const status = await runGit(
     ["--no-optional-locks", "status", "--porcelain=v1", "--untracked-files=all"],
-    { cwd },
+    { cwd, ...options },
   );
   return status.stdout.trim().length > 0;
 }

--- a/packages/host-workspace/src/index.ts
+++ b/packages/host-workspace/src/index.ts
@@ -6,6 +6,7 @@ export {
 export type { HostWorkspace, ProvisionWorkspaceArgs } from "./provision.js";
 
 export type { PullRequestActionOptions } from "./workspace.js";
+export type { GitHostCliOptions } from "./git-host.js";
 
 export {
   WorkspaceError,
@@ -24,3 +25,4 @@ export {
   readGitBlob,
   runGit,
 } from "./git.js";
+export type { GitProcessOptions } from "./git.js";

--- a/packages/host-workspace/src/provision.ts
+++ b/packages/host-workspace/src/provision.ts
@@ -19,7 +19,10 @@ import type {
   SquashMergeResult,
 } from "./workspace.js";
 import { Workspace } from "./workspace.js";
-import type { GitHostPullRequestLookup } from "./git-host.js";
+import type {
+  GitHostCliOptions,
+  GitHostPullRequestLookup,
+} from "./git-host.js";
 import {
   withCheckoutMutationAdmission,
   withCheckoutMutationLock,
@@ -41,6 +44,7 @@ import {
   readDefaultBranch,
   runGit,
   WorkspaceError,
+  type GitProcessOptions,
 } from "./git.js";
 import { resolveAdditionalWorkspaceWriteRoots } from "./workspace-write-roots.js";
 
@@ -53,6 +57,8 @@ type ProvisionProgressCallback = (entry: ProvisioningTranscriptEntry) => void;
 interface ProvisionBase {
   /** Progress callback for provisioning steps/output */
   onProgress?: ProvisionProgressCallback;
+  /** Resolved user login-shell PATH for workspace Git and setup commands. */
+  shellPath?: string;
   signal?: AbortSignal;
 }
 
@@ -96,8 +102,6 @@ interface ManagedWorkspaceBaseOpts extends ProvisionBase {
   baseBranch: string | null;
   /** Setup script timeout in ms. Controlled by the server. */
   timeoutMs: number;
-  /** Resolved user-shell PATH for the setup script. */
-  setupPath?: string;
 }
 
 interface ManagedWorktreeOpts extends ManagedWorkspaceBaseOpts {
@@ -159,8 +163,13 @@ export interface HostWorkspace {
   getDiff(options?: DiffOptions): Promise<DiffResult>;
   diffFiles(args: DiffFilesArgs): Promise<DiffFilesResult>;
   diffPatch(args: DiffPatchArgs): Promise<DiffPatchEntry[]>;
-  getPullRequest(): Promise<GitHostPullRequestLookup>;
-  runPullRequestAction(action: PullRequestActionOptions): Promise<void>;
+  getPullRequest(
+    options?: GitHostCliOptions,
+  ): Promise<GitHostPullRequestLookup>;
+  runPullRequestAction(
+    action: PullRequestActionOptions,
+    options?: GitHostCliOptions,
+  ): Promise<void>;
   listFiles(): Promise<string[]>;
 
   // Git mutations
@@ -176,9 +185,13 @@ export interface HostWorkspace {
 // Detect whether a path is a git worktree
 // ---------------------------------------------------------------------------
 
-async function detectWorktree(cwd: string): Promise<boolean> {
+async function detectWorktree(
+  cwd: string,
+  options: GitProcessOptions,
+): Promise<boolean> {
   const gitDirResult = await runGit(["rev-parse", "--git-dir"], {
     cwd,
+    ...options,
     allowFailure: true,
   });
   if (gitDirResult.exitCode !== 0) return false;
@@ -200,6 +213,7 @@ class ProvisionedHostWorkspace implements HostWorkspace {
   readonly isWorktree: boolean;
 
   private readonly ws: Workspace;
+  private readonly gitProcessOptions: GitProcessOptions;
   private readonly destroyFn: () => Promise<void>;
 
   constructor(opts: {
@@ -207,13 +221,17 @@ class ProvisionedHostWorkspace implements HostWorkspace {
     managed: boolean;
     isGitRepo: boolean;
     isWorktree: boolean;
+    shellPath?: string;
     destroyFn: () => Promise<void>;
   }) {
     this.path = opts.path;
     this.managed = opts.managed;
     this.isGitRepo = opts.isGitRepo;
     this.isWorktree = opts.isWorktree;
-    this.ws = new Workspace(opts.path);
+    this.gitProcessOptions = {
+      ...(opts.shellPath !== undefined ? { shellPath: opts.shellPath } : {}),
+    };
+    this.ws = new Workspace(opts.path, this.gitProcessOptions);
     this.destroyFn = opts.destroyFn;
   }
 
@@ -228,6 +246,7 @@ class ProvisionedHostWorkspace implements HostWorkspace {
     return (
       (await readDefaultBranch(this.path, {
         timeoutMs: WORKSPACE_BRANCH_GIT_TIMEOUT_MS,
+        ...this.gitProcessOptions,
       })) ?? null
     );
   }
@@ -248,7 +267,10 @@ class ProvisionedHostWorkspace implements HostWorkspace {
     if (!this.isGitRepo || !this.isWorktree) {
       return Promise.resolve([]);
     }
-    return resolveAdditionalWorkspaceWriteRoots(this.path);
+    return resolveAdditionalWorkspaceWriteRoots(
+      this.path,
+      this.gitProcessOptions,
+    );
   }
 
   getStatus(options?: StatusOptions): Promise<WorkspaceStatus> {
@@ -267,12 +289,17 @@ class ProvisionedHostWorkspace implements HostWorkspace {
     return this.ws.diffPatch(args);
   }
 
-  getPullRequest(): Promise<GitHostPullRequestLookup> {
-    return this.ws.getPullRequest();
+  getPullRequest(
+    options?: GitHostCliOptions,
+  ): Promise<GitHostPullRequestLookup> {
+    return this.ws.getPullRequest(options);
   }
 
-  runPullRequestAction(action: PullRequestActionOptions): Promise<void> {
-    return this.ws.runPullRequestAction(action);
+  runPullRequestAction(
+    action: PullRequestActionOptions,
+    options?: GitHostCliOptions,
+  ): Promise<void> {
+    return this.ws.runPullRequestAction(action, options);
   }
 
   listFiles(): Promise<string[]> {
@@ -335,11 +362,12 @@ function isSamePathOrNestedUnder(
 
 async function hasContainedPersonalGitMetadata(
   targetPath: string,
+  options: GitProcessOptions,
 ): Promise<boolean> {
   const [resolvedTargetPath, gitDir, commonGitDir] = await Promise.all([
     realpath(targetPath),
-    getAbsoluteGitDir(targetPath),
-    getGitCommonDir(targetPath),
+    getAbsoluteGitDir(targetPath, options),
+    getGitCommonDir(targetPath, options),
   ]);
   const [resolvedGitDir, resolvedCommonGitDir] = await Promise.all([
     realpath(gitDir),
@@ -394,12 +422,14 @@ interface ApplyUnmanagedCheckoutArgs {
   cwd: string;
   checkout: UnmanagedCheckoutOpts;
   onProgress: ProvisionProgressCallback | undefined;
+  shellPath: string | undefined;
   signal: AbortSignal | undefined;
 }
 
 interface ValidateUnmanagedCheckoutArgs {
   cwd: string;
   checkout: UnmanagedCheckoutOpts;
+  shellPath: string | undefined;
   signal: AbortSignal | undefined;
 }
 
@@ -436,8 +466,10 @@ async function validateUnmanagedCheckout(
   args: ValidateUnmanagedCheckoutArgs,
 ): Promise<UnmanagedCheckoutPreflightResult> {
   const { cwd, checkout } = args;
+  const gitProcessOptions =
+    args.shellPath === undefined ? {} : { shellPath: args.shellPath };
   throwIfProvisionAborted(args.signal);
-  const checkoutRef = await getCheckoutRef(cwd);
+  const checkoutRef = await getCheckoutRef(cwd, gitProcessOptions);
   if (
     checkoutRef.kind === "branch" &&
     checkoutRef.branchName === checkout.name
@@ -472,7 +504,7 @@ async function validateUnmanagedCheckout(
   }
 
   if (checkout.kind === "existing") {
-    const branches = await listBranches(cwd);
+    const branches = await listBranches(cwd, gitProcessOptions);
     if (!branches.includes(checkout.name)) {
       throw new WorkspaceError(
         "checkout_missing_branch",
@@ -481,7 +513,7 @@ async function validateUnmanagedCheckout(
     }
   }
 
-  const operation = await getWorkspaceGitOperation(cwd);
+  const operation = await getWorkspaceGitOperation(cwd, gitProcessOptions);
   if (operation.kind !== "none" && operation.hasConflicts) {
     throw new WorkspaceError(
       "checkout_conflicts",
@@ -499,7 +531,7 @@ async function validateUnmanagedCheckout(
     );
   }
 
-  if (await hasUncommittedChanges(cwd)) {
+  if (await hasUncommittedChanges(cwd, gitProcessOptions)) {
     throw new WorkspaceError(
       "checkout_dirty",
       "Cannot checkout branch while the workspace has uncommitted changes",
@@ -513,6 +545,8 @@ async function applyUnmanagedCheckout(
   args: ApplyUnmanagedCheckoutArgs,
 ): Promise<void> {
   const { cwd, checkout, onProgress, signal } = args;
+  const gitProcessOptions =
+    args.shellPath === undefined ? {} : { shellPath: args.shellPath };
   throwIfProvisionAborted(signal);
   // `switch -C` for new (create-or-reset from base) and `switch` for existing.
   const switchArgs =
@@ -544,7 +578,7 @@ async function applyUnmanagedCheckout(
             `Unmanaged workspace path does not exist: ${cwd}`,
           );
         }
-        if (!(await detectGitRepo(cwd))) {
+        if (!(await detectGitRepo(cwd, gitProcessOptions))) {
           throw new WorkspaceError(
             "not_git_repo",
             `Cannot checkout branch on non-git workspace: ${cwd}`,
@@ -572,6 +606,7 @@ async function applyUnmanagedCheckout(
             const preflightResult = await validateUnmanagedCheckout({
               cwd,
               checkout,
+              shellPath: args.shellPath,
               signal,
             });
             if (preflightResult.kind === "already-current") {
@@ -588,9 +623,10 @@ async function applyUnmanagedCheckout(
               status: "started",
               startedAt,
             });
-            await runGit(switchArgs, { cwd, signal });
+            await runGit(switchArgs, { cwd, signal, ...gitProcessOptions });
           },
           signal,
+          gitProcessOptions,
         );
       },
       signal,
@@ -644,6 +680,7 @@ async function provisionUnmanaged(
       cwd: opts.path,
       checkout: opts.checkout,
       onProgress: opts.onProgress,
+      shellPath: opts.shellPath,
       signal: opts.signal,
     });
     isGitRepo = true;
@@ -655,15 +692,22 @@ async function provisionUnmanaged(
         `Unmanaged workspace path does not exist: ${opts.path}`,
       );
     }
-    isGitRepo = await detectGitRepo(opts.path);
+    isGitRepo = await detectGitRepo(opts.path, {
+      ...(opts.shellPath !== undefined ? { shellPath: opts.shellPath } : {}),
+    });
   }
-  const isWorktree = isGitRepo ? await detectWorktree(opts.path) : false;
+  const gitProcessOptions =
+    opts.shellPath === undefined ? {} : { shellPath: opts.shellPath };
+  const isWorktree = isGitRepo
+    ? await detectWorktree(opts.path, gitProcessOptions)
+    : false;
 
   return new ProvisionedHostWorkspace({
     path: opts.path,
     managed: false,
     isGitRepo,
     isWorktree,
+    shellPath: opts.shellPath,
     destroyFn: async () => {
       // no-op for unmanaged workspaces
     },
@@ -680,7 +724,7 @@ async function provisionWorktree(
     branchName: opts.branchName,
     baseBranch: opts.baseBranch,
     timeoutMs: opts.timeoutMs,
-    setupPath: opts.setupPath,
+    shellPath: opts.shellPath,
     onProgress: opts.onProgress,
     pruneEmptyParent: true,
     signal: opts.signal,
@@ -691,8 +735,14 @@ async function provisionWorktree(
     managed: true,
     isGitRepo: true,
     isWorktree: true,
+    shellPath: opts.shellPath,
     destroyFn: () =>
-      removeWorktree({ path: wsPath, force: true, pruneEmptyParent: true }),
+      removeWorktree({
+        path: wsPath,
+        force: true,
+        pruneEmptyParent: true,
+        shellPath: opts.shellPath,
+      }),
   });
 }
 
@@ -713,18 +763,27 @@ async function provisionPersonalWorkspace(
   }
 
   const detectedGitRepo = targetExisted
-    ? await detectGitRepo(targetPath)
+    ? await detectGitRepo(targetPath, {
+        ...(opts.shellPath !== undefined ? { shellPath: opts.shellPath } : {}),
+      })
     : false;
   const isGitRepo = detectedGitRepo
-    ? await hasContainedPersonalGitMetadata(targetPath)
+    ? await hasContainedPersonalGitMetadata(targetPath, {
+        ...(opts.shellPath !== undefined ? { shellPath: opts.shellPath } : {}),
+      })
     : false;
-  const isWorktree = isGitRepo ? await detectWorktree(targetPath) : false;
+  const isWorktree = isGitRepo
+    ? await detectWorktree(targetPath, {
+        ...(opts.shellPath !== undefined ? { shellPath: opts.shellPath } : {}),
+      })
+    : false;
 
   return new ProvisionedHostWorkspace({
     path: targetPath,
     managed: true,
     isGitRepo,
     isWorktree,
+    shellPath: opts.shellPath,
     destroyFn: () => rm(targetPath, { recursive: true, force: true }),
   });
 }
@@ -732,6 +791,7 @@ async function provisionPersonalWorkspace(
 async function reconnectManaged(
   wsPath: string,
   destroyFn: () => Promise<void>,
+  shellPath: string | undefined,
   signal: AbortSignal | undefined,
 ): Promise<HostWorkspace> {
   throwIfProvisionAborted(signal);
@@ -742,14 +802,18 @@ async function reconnectManaged(
     );
   }
 
-  const isGitRepo = await detectGitRepo(wsPath);
-  const isWorktree = isGitRepo ? await detectWorktree(wsPath) : false;
+  const gitProcessOptions = shellPath === undefined ? {} : { shellPath };
+  const isGitRepo = await detectGitRepo(wsPath, gitProcessOptions);
+  const isWorktree = isGitRepo
+    ? await detectWorktree(wsPath, gitProcessOptions)
+    : false;
 
   return new ProvisionedHostWorkspace({
     path: wsPath,
     managed: true,
     isGitRepo,
     isWorktree,
+    shellPath,
     destroyFn,
   });
 }
@@ -760,7 +824,13 @@ async function reconnectManagedWorktree(
   return reconnectManaged(
     opts.path,
     () =>
-      removeWorktree({ path: opts.path, force: true, pruneEmptyParent: true }),
+      removeWorktree({
+        path: opts.path,
+        force: true,
+        pruneEmptyParent: true,
+        shellPath: opts.shellPath,
+      }),
+    opts.shellPath,
     opts.signal,
   );
 }

--- a/packages/host-workspace/src/provisioning.ts
+++ b/packages/host-workspace/src/provisioning.ts
@@ -57,7 +57,7 @@ interface CreateWorkspaceArgs {
   /** Setup script timeout in ms. Controlled by the server. */
   timeoutMs: number;
   /** Resolved user-shell PATH for the setup script. */
-  setupPath?: string;
+  shellPath?: string;
   onProgress?: ProgressCallback;
   pruneEmptyParent?: boolean;
   signal?: AbortSignal;
@@ -67,7 +67,7 @@ interface RunSetupScriptArgs {
   workspacePath: string;
   timeoutMs: number;
   /** Resolved user-shell PATH. Falls back to the daemon process PATH. */
-  setupPath?: string;
+  shellPath?: string;
   onProgress?: ProgressCallback;
   signal?: AbortSignal;
 }
@@ -76,6 +76,7 @@ interface RemoveWorktreeArgs {
   path: string;
   force?: boolean;
   pruneEmptyParent?: boolean;
+  shellPath?: string;
 }
 
 interface SetupScriptCommand {
@@ -154,12 +155,15 @@ function emitGitOutput(
 async function ensureExistingWorkspaceMatches(
   targetPath: string,
   branchName: string,
+  shellPath: string | undefined,
 ): Promise<boolean> {
   if (!(await pathExists(targetPath))) {
     return false;
   }
 
-  const workspace = new Workspace(targetPath);
+  const workspace = new Workspace(targetPath, {
+    ...(shellPath !== undefined ? { shellPath } : {}),
+  });
   if (!(await workspace.isGitRepo)) {
     throw new WorkspaceError(
       "path_exists",
@@ -230,13 +234,20 @@ function isProvisionAbortError(error: unknown): boolean {
 async function resolveRemoteBaseBranch(
   sourcePath: string,
   baseBranch: string,
+  shellPath: string | undefined,
   signal: AbortSignal | undefined,
 ): Promise<{ remote: string; branch: string } | null> {
   if (!baseBranch.includes("/")) {
     return null;
   }
 
-  const remotes = (await runGit(["remote"], { cwd: sourcePath, signal })).stdout
+  const remotes = (
+    await runGit(["remote"], {
+      cwd: sourcePath,
+      signal,
+      ...(shellPath !== undefined ? { shellPath } : {}),
+    })
+  ).stdout
     .split("\n")
     .map((remote) => remote.trim())
     .filter(Boolean);
@@ -262,11 +273,13 @@ async function fetchRemoteBaseBranch(args: {
   sourcePath: string;
   baseBranch: string;
   onProgress: ProgressCallback | undefined;
+  shellPath: string | undefined;
   signal: AbortSignal | undefined;
 }): Promise<void> {
   const remoteBase = await resolveRemoteBaseBranch(
     args.sourcePath,
     args.baseBranch,
+    args.shellPath,
     args.signal,
   );
   if (!remoteBase) {
@@ -286,6 +299,7 @@ async function fetchRemoteBaseBranch(args: {
   try {
     await runGit(["fetch", "--quiet", remoteBase.remote, refspec], {
       cwd: args.sourcePath,
+      ...(args.shellPath !== undefined ? { shellPath: args.shellPath } : {}),
       signal: args.signal,
     });
     emitStep({
@@ -317,12 +331,22 @@ export async function createWorktree(
   args: CreateWorkspaceArgs,
 ): Promise<{ path: string }> {
   throwIfProvisionAborted(args.signal);
-  if (await ensureExistingWorkspaceMatches(args.targetPath, args.branchName)) {
+  if (
+    await ensureExistingWorkspaceMatches(
+      args.targetPath,
+      args.branchName,
+      args.shellPath,
+    )
+  ) {
     return { path: args.targetPath };
   }
 
   throwIfProvisionAborted(args.signal);
-  switch (await readGitRepositoryState(args.sourcePath)) {
+  switch (
+    await readGitRepositoryState(args.sourcePath, {
+      ...(args.shellPath !== undefined ? { shellPath: args.shellPath } : {}),
+    })
+  ) {
     case "not_git":
       throw new WorkspaceError(
         "not_git_repo",
@@ -342,7 +366,10 @@ export async function createWorktree(
 
   throwIfProvisionAborted(args.signal);
   const baseBranch =
-    args.baseBranch ?? (await readDefaultBranch(args.sourcePath));
+    args.baseBranch ??
+    (await readDefaultBranch(args.sourcePath, {
+      ...(args.shellPath !== undefined ? { shellPath: args.shellPath } : {}),
+    }));
   if (!baseBranch) {
     throw new WorkspaceError(
       "missing_default_branch",
@@ -354,6 +381,7 @@ export async function createWorktree(
     sourcePath: args.sourcePath,
     baseBranch,
     onProgress: args.onProgress,
+    shellPath: args.shellPath,
     signal: args.signal,
   });
 
@@ -377,6 +405,7 @@ export async function createWorktree(
   try {
     const result = await runGitWithWorktreeMetadataLock(gitArgs, {
       cwd: args.sourcePath,
+      ...(args.shellPath !== undefined ? { shellPath: args.shellPath } : {}),
       signal: args.signal,
     });
     emitGitOutput(args.onProgress, "git-worktree", result);
@@ -398,12 +427,13 @@ export async function createWorktree(
       sourcePath: args.sourcePath,
       targetPath: args.targetPath,
       onProgress: args.onProgress,
+      shellPath: args.shellPath,
       signal: args.signal,
     });
     await runSetupScript({
       workspacePath: args.targetPath,
       timeoutMs: args.timeoutMs,
-      setupPath: args.setupPath,
+      shellPath: args.shellPath,
       onProgress: args.onProgress,
       signal: args.signal,
     });
@@ -423,6 +453,7 @@ export async function createWorktree(
       path: args.targetPath,
       force: true,
       pruneEmptyParent: args.pruneEmptyParent,
+      shellPath: args.shellPath,
     });
     throw error;
   }
@@ -453,6 +484,7 @@ async function copyIncludedFiles(args: {
   sourcePath: string;
   targetPath: string;
   onProgress: ProgressCallback | undefined;
+  shellPath: string | undefined;
   signal: AbortSignal | undefined;
 }): Promise<void> {
   throwIfProvisionAborted(args.signal);
@@ -462,6 +494,7 @@ async function copyIncludedFiles(args: {
     result = await copyWorktreeIncludeFiles({
       sourcePath: args.sourcePath,
       targetPath: args.targetPath,
+      shellPath: args.shellPath,
       signal: args.signal,
     });
   } catch (error) {
@@ -539,10 +572,10 @@ export async function runSetupScript(
   });
 
   const { timeoutMs } = args;
-  const env = sanitizeInheritedChildProcessEnv({ env: process.env });
-  if (args.setupPath !== undefined) {
-    env.PATH = args.setupPath;
-  }
+  const env = sanitizeInheritedChildProcessEnv({
+    env: process.env,
+    ...(args.shellPath !== undefined ? { shellPath: args.shellPath } : {}),
+  });
   const child = spawnPortableOutputProcess({
     command: command.command,
     args: command.args,
@@ -702,6 +735,7 @@ export async function removeWorktree(args: RemoveWorktreeArgs): Promise<void> {
 
   const commonDirResult = await runGit(["rev-parse", "--git-common-dir"], {
     cwd: workspacePath,
+    ...(args.shellPath !== undefined ? { shellPath: args.shellPath } : {}),
     allowFailure: true,
   });
 
@@ -713,23 +747,30 @@ export async function removeWorktree(args: RemoveWorktreeArgs): Promise<void> {
     // Lock order is checkout mutation first, worktree metadata second. Keep
     // every path that needs both locks in this order so two callers cannot each
     // hold one git lock domain while waiting for the other.
-    await tryWithCheckoutMutationLock(workspacePath, () =>
-      withWorktreeMetadataLock(commonDir, () =>
-        runGit(
-          [
-            "--git-dir",
-            commonDir,
-            "worktree",
-            "remove",
-            workspacePath,
-            ...(force ? ["--force"] : []),
-          ],
-          {
-            cwd: path.dirname(workspacePath),
-            allowFailure: true,
-          },
+    await tryWithCheckoutMutationLock(
+      workspacePath,
+      () =>
+        withWorktreeMetadataLock(commonDir, () =>
+          runGit(
+            [
+              "--git-dir",
+              commonDir,
+              "worktree",
+              "remove",
+              workspacePath,
+              ...(force ? ["--force"] : []),
+            ],
+            {
+              cwd: path.dirname(workspacePath),
+              ...(args.shellPath !== undefined
+                ? { shellPath: args.shellPath }
+                : {}),
+              allowFailure: true,
+            },
+          ),
         ),
-      ),
+      undefined,
+      args.shellPath === undefined ? {} : { shellPath: args.shellPath },
     );
   }
 

--- a/packages/host-workspace/src/workspace-write-roots.ts
+++ b/packages/host-workspace/src/workspace-write-roots.ts
@@ -1,5 +1,9 @@
 import path from "node:path";
-import { getAbsoluteGitDir, getGitCommonDir } from "./git.js";
+import {
+  getAbsoluteGitDir,
+  getGitCommonDir,
+  type GitProcessOptions,
+} from "./git.js";
 
 function isSamePathOrNestedUnder(childPath: string, parentPath: string): boolean {
   const relativePath = path.relative(parentPath, childPath);
@@ -35,11 +39,12 @@ function buildCommonGitWriteRoots(commonGitDir: string): string[] {
 
 export async function resolveAdditionalWorkspaceWriteRoots(
   workspacePath: string,
+  options: GitProcessOptions = {},
 ): Promise<string[]> {
   const resolvedWorkspacePath = path.resolve(workspacePath);
   const [gitDir, commonGitDir] = await Promise.all([
-    getAbsoluteGitDir(resolvedWorkspacePath),
-    getGitCommonDir(resolvedWorkspacePath),
+    getAbsoluteGitDir(resolvedWorkspacePath, options),
+    getGitCommonDir(resolvedWorkspacePath, options),
   ]);
   const candidateRoots = dedupeResolvedPaths([
     gitDir,

--- a/packages/host-workspace/src/workspace.ts
+++ b/packages/host-workspace/src/workspace.ts
@@ -12,6 +12,7 @@ import path from "node:path";
 import {
   getPullRequestForCurrentBranch,
   runPullRequestActionForCurrentBranch,
+  type GitHostCliOptions,
   type GitHostPullRequestAction,
   type GitHostPullRequestLookup,
 } from "./git-host.js";
@@ -35,6 +36,7 @@ import {
   runGit,
   runGitWithNullRecordLimit,
   type GitCommandResult,
+  type GitProcessOptions,
   type GitNullRecordFormat,
   type GitNullRecordLimitResult,
   type NameStatusSourceEntry,
@@ -559,24 +561,28 @@ function buildDiffOutputGitOptions(
 async function readHeadNumstat(
   workspacePath: string,
   timeoutMs?: number,
+  options: GitProcessOptions = {},
 ): Promise<string> {
-  const runUncommittedDiff = createUncommittedDiffRunner(workspacePath);
+  const runUncommittedDiff = createUncommittedDiffRunner(
+    workspacePath,
+    options,
+  );
   const result = await runUncommittedDiff(
     (baseRef) => ["diff", "--numstat", "-z", baseRef, "--"],
-    { cwd: workspacePath, timeoutMs },
+    { cwd: workspacePath, timeoutMs, ...options },
   );
   return result.stdout;
 }
 
 async function readEmptyTreeSha(
   workspacePath: string,
-  timeoutMs?: number,
+  options: Pick<RunGitOptions, "shellPath" | "timeoutMs"> = {},
 ): Promise<string> {
   // An unborn branch has no HEAD tree. Compare the index and working tree to
   // Git's empty tree so staged files remain visible before the first commit.
   const emptyTree = await runGit(["hash-object", "-t", "tree", os.devNull], {
     cwd: workspacePath,
-    timeoutMs,
+    ...options,
   });
   const emptyTreeSha = emptyTree.stdout.trim();
   if (emptyTreeSha.length === 0) {
@@ -595,17 +601,22 @@ type UncommittedDiffRunner = (
 
 function createUncommittedDiffRunner(
   workspacePath: string,
+  gitProcessOptions: GitProcessOptions = {},
 ): UncommittedDiffRunner {
   let emptyTreeShaPromise: Promise<string> | null = null;
 
   return async (buildArgs, options) => {
     if (emptyTreeShaPromise !== null) {
-      return runGit(buildArgs(await emptyTreeShaPromise), options);
+      return runGit(buildArgs(await emptyTreeShaPromise), {
+        ...options,
+        ...gitProcessOptions,
+      });
     }
 
     const headArgs = buildArgs("HEAD");
     const headResult = await runGit(headArgs, {
       ...options,
+      ...gitProcessOptions,
       allowFailure: true,
       timeoutMs: options.timeoutMs,
     });
@@ -620,16 +631,24 @@ function createUncommittedDiffRunner(
       );
     }
 
-    emptyTreeShaPromise ??= readEmptyTreeSha(workspacePath, options.timeoutMs);
-    return runGit(buildArgs(await emptyTreeShaPromise), options);
+    emptyTreeShaPromise ??= readEmptyTreeSha(workspacePath, {
+      timeoutMs: options.timeoutMs,
+      ...gitProcessOptions,
+    });
+    return runGit(buildArgs(await emptyTreeShaPromise), {
+      ...options,
+      ...gitProcessOptions,
+    });
   };
 }
 
 export class Workspace {
   readonly path: string;
+  private readonly gitProcessOptions: GitProcessOptions;
 
-  constructor(path: string) {
+  constructor(path: string, gitProcessOptions: GitProcessOptions = {}) {
     this.path = path;
+    this.gitProcessOptions = { ...gitProcessOptions };
   }
 
   static withMutations<T>(
@@ -639,11 +658,50 @@ export class Workspace {
     return withCheckoutMutationLocks(
       workspaces.map((workspace) => workspace.path),
       work,
+      undefined,
+      workspaces[0]?.gitProcessOptions,
     );
   }
 
   withMutation<T>(work: WorkspaceMutationWork<T>): Promise<T> {
-    return withCheckoutMutationLock(this.path, work);
+    return withCheckoutMutationLock(
+      this.path,
+      work,
+      undefined,
+      this.gitProcessOptions,
+    );
+  }
+
+  private runGit(
+    args: string[],
+    options: RunGitOptions,
+  ): Promise<GitCommandResult> {
+    return runGit(args, { ...options, ...this.gitProcessOptions });
+  }
+
+  private runGitWithNullRecordLimit(
+    args: string[],
+    options: RunGitOptions,
+    recordFormat: GitNullRecordFormat,
+    maxRecords: number,
+  ): Promise<GitNullRecordLimitResult> {
+    return runGitWithNullRecordLimit(
+      args,
+      { ...options, ...this.gitProcessOptions },
+      recordFormat,
+      maxRecords,
+    );
+  }
+
+  private runShellPipeline(
+    script: string,
+    positionalArgs: string[],
+    options: Parameters<typeof runShellPipeline>[2],
+  ): Promise<GitCommandResult> {
+    return runShellPipeline(script, positionalArgs, {
+      ...options,
+      ...this.gitProcessOptions,
+    });
   }
 
   get exists(): Promise<boolean> {
@@ -651,11 +709,11 @@ export class Workspace {
   }
 
   get isGitRepo(): Promise<boolean> {
-    return detectGitRepo(this.path);
+    return detectGitRepo(this.path, this.gitProcessOptions);
   }
 
   get currentBranch(): Promise<string | undefined> {
-    return getCurrentBranch(this.path);
+    return getCurrentBranch(this.path, this.gitProcessOptions);
   }
 
   /**
@@ -664,7 +722,9 @@ export class Workspace {
    * surface as "unavailable". Never throws — see
    * {@link getPullRequestForCurrentBranch}.
    */
-  async getPullRequest(): Promise<GitHostPullRequestLookup> {
+  async getPullRequest(
+    options: GitHostCliOptions = {},
+  ): Promise<GitHostPullRequestLookup> {
     // A vanished workspace (deleted worktree dir) means the lookup cannot
     // run; without this check getCurrentBranch folds it into "no branch" and
     // the missing workspace would masquerade as "no PR exists".
@@ -674,20 +734,23 @@ export class Workspace {
         message: `Workspace path no longer exists: ${this.path}`,
       };
     }
-    const branch = await getCurrentBranch(this.path);
+    const branch = await getCurrentBranch(this.path, this.gitProcessOptions);
     if (!branch) {
       return { outcome: "none" };
     }
     return getPullRequestForCurrentBranch({
       cwd: this.path,
       localBranch: branch,
+      ...this.gitProcessOptions,
+      ...options,
     });
   }
 
   async runPullRequestAction(
     action: PullRequestActionOptions,
+    options: GitHostCliOptions = {},
   ): Promise<void> {
-    const branch = await getCurrentBranch(this.path);
+    const branch = await getCurrentBranch(this.path, this.gitProcessOptions);
     if (!branch) {
       throw new WorkspaceError(
         "invalid_request",
@@ -698,6 +761,8 @@ export class Workspace {
       cwd: this.path,
       localBranch: branch,
       action,
+      ...this.gitProcessOptions,
+      ...options,
     });
   }
 
@@ -727,6 +792,7 @@ export class Workspace {
     }
     await ensureGitRepo(this.path, {
       timeoutMs: WORKSPACE_STATUS_GIT_TIMEOUT_MS,
+      ...this.gitProcessOptions,
     });
 
     const mergeBaseBranch = options.mergeBaseBranch;
@@ -734,7 +800,7 @@ export class Workspace {
       await Promise.all([
         // --no-optional-locks: this runs on the watcher polling cadence and
         // must not take index.lock under a concurrent commit.
-        runGit(
+        this.runGit(
           [
             "--no-optional-locks",
             "status",
@@ -744,12 +810,18 @@ export class Workspace {
           ],
           { cwd: this.path, timeoutMs: WORKSPACE_STATUS_GIT_TIMEOUT_MS },
         ),
-        readHeadNumstat(this.path, WORKSPACE_STATUS_GIT_TIMEOUT_MS),
+        readHeadNumstat(
+          this.path,
+          WORKSPACE_STATUS_GIT_TIMEOUT_MS,
+          this.gitProcessOptions,
+        ),
         getCheckoutRef(this.path, {
           timeoutMs: WORKSPACE_STATUS_GIT_TIMEOUT_MS,
+          ...this.gitProcessOptions,
         }),
         readDefaultBranch(this.path, {
           timeoutMs: WORKSPACE_STATUS_GIT_TIMEOUT_MS,
+          ...this.gitProcessOptions,
         }),
         mergeBaseBranch
           ? this.readMergeBaseStatus(
@@ -845,10 +917,11 @@ export class Workspace {
   async getLocalStateFingerprint(): Promise<string> {
     await ensureGitRepo(this.path, {
       timeoutMs: WORKSPACE_STATUS_GIT_TIMEOUT_MS,
+      ...this.gitProcessOptions,
     });
     const [headSha, status] = await Promise.all([
       this.getHeadSha(),
-      runGit(
+      this.runGit(
         [
           "--no-optional-locks",
           "status",
@@ -866,10 +939,10 @@ export class Workspace {
   }
 
   async getSharedGitRefsFingerprint(): Promise<string> {
-    await ensureGitRepo(this.path);
+    await ensureGitRepo(this.path, this.gitProcessOptions);
 
     const [refs, remoteHead] = await Promise.all([
-      runGit(
+      this.runGit(
         [
           "for-each-ref",
           "--format=%(refname)%00%(objectname)",
@@ -878,7 +951,7 @@ export class Workspace {
         ],
         { cwd: this.path },
       ),
-      runGit(["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"], {
+      this.runGit(["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"], {
         cwd: this.path,
         allowFailure: true,
       }),
@@ -891,7 +964,7 @@ export class Workspace {
   }
 
   async getDiff(options: DiffOptions = {}): Promise<DiffResult> {
-    await ensureGitRepo(this.path);
+    await ensureGitRepo(this.path, this.gitProcessOptions);
 
     const target = options.target ?? { type: "uncommitted" as const };
     return this.buildDiffSummary({
@@ -910,7 +983,7 @@ export class Workspace {
    * these raw stats into product tiering — the daemon stays policy-free.
    */
   async diffFiles(args: DiffFilesArgs): Promise<DiffFilesResult> {
-    await ensureGitRepo(this.path);
+    await ensureGitRepo(this.path, this.gitProcessOptions);
     assertPositiveInteger(args.maxFiles, "maxFiles");
 
     const stats = await this.readBoundedDiffStatArtifacts(
@@ -971,7 +1044,7 @@ export class Workspace {
    * count.
    */
   async diffPatch(args: DiffPatchArgs): Promise<DiffPatchEntry[]> {
-    await ensureGitRepo(this.path);
+    await ensureGitRepo(this.path, this.gitProcessOptions);
 
     const untrackedForTarget = this.targetIncludesUntracked(args.target)
       ? new Set(await this.listRequestedUntrackedPaths(args.paths))
@@ -1014,9 +1087,9 @@ export class Workspace {
   }
 
   async getHeadSha(): Promise<string | null> {
-    await ensureGitRepo(this.path);
+    await ensureGitRepo(this.path, this.gitProcessOptions);
 
-    const result = await runGit(["rev-parse", "HEAD"], {
+    const result = await this.runGit(["rev-parse", "HEAD"], {
       allowFailure: true,
       cwd: this.path,
     });
@@ -1033,7 +1106,7 @@ export class Workspace {
   }
 
   async listFiles(): Promise<string[]> {
-    const gitResult = await runGit(
+    const gitResult = await this.runGit(
       ["ls-files", "--cached", "--others", "--exclude-standard"],
       { allowFailure: true, cwd: this.path },
     );
@@ -1057,15 +1130,15 @@ export class Workspace {
   }
 
   async commit(options: CommitOptions): Promise<CommitResult> {
-    await ensureGitRepo(this.path);
+    await ensureGitRepo(this.path, this.gitProcessOptions);
 
     return this.withMutation(async () => {
-      await runGit(["add", "-A"], { cwd: this.path });
+      await this.runGit(["add", "-A"], { cwd: this.path });
       // Detect "nothing to commit" deterministically inside the mutation lock,
       // so a commit racing a concurrent commit (or an already-clean tree)
       // surfaces as a typed no_changes condition the server maps to 409,
       // instead of a generic git failure that surfaces as a 502.
-      const staged = await runGit(["diff", "--cached", "--quiet"], {
+      const staged = await this.runGit(["diff", "--cached", "--quiet"], {
         cwd: this.path,
         allowFailure: true,
       });
@@ -1076,10 +1149,14 @@ export class Workspace {
       if (options.noVerify) {
         commitArgs.push("--no-verify");
       }
-      await runGit(commitArgs, { cwd: this.path });
-      const commitSha = await revParse(this.path, "HEAD");
+      await this.runGit(commitArgs, { cwd: this.path });
+      const commitSha = await revParse(
+        this.path,
+        "HEAD",
+        this.gitProcessOptions,
+      );
       const commitSubject = (
-        await runGit(["log", "-1", "--pretty=%s"], { cwd: this.path })
+        await this.runGit(["log", "-1", "--pretty=%s"], { cwd: this.path })
       ).stdout.trim();
 
       return { commitSha, commitSubject };
@@ -1087,17 +1164,17 @@ export class Workspace {
   }
 
   async reset(): Promise<void> {
-    await ensureGitRepo(this.path);
+    await ensureGitRepo(this.path, this.gitProcessOptions);
     await this.withMutation(async () => {
-      await runGit(["reset", "--hard", "HEAD"], { cwd: this.path });
-      await runGit(["clean", "-fd"], { cwd: this.path });
+      await this.runGit(["reset", "--hard", "HEAD"], { cwd: this.path });
+      await this.runGit(["clean", "-fd"], { cwd: this.path });
     });
   }
 
   async squashMergeInto(
     options: SquashMergeOptions,
   ): Promise<SquashMergeResult> {
-    await ensureGitRepo(this.path);
+    await ensureGitRepo(this.path, this.gitProcessOptions);
 
     const sourceBranch = await this.currentBranch;
     if (!sourceBranch) {
@@ -1114,31 +1191,41 @@ export class Workspace {
     try {
       await runGitWithWorktreeMetadataLock(
         ["worktree", "add", "--detach", tempDir, target.baseRef],
-        { cwd: this.path },
+        { cwd: this.path, ...this.gitProcessOptions },
       );
-      const squashCommit = await new Workspace(tempDir).withMutation(
-        async () => {
-          await runGit(["merge", "--squash", sourceBranch], { cwd: tempDir });
-          // A squash of a branch with no committed work ahead of the target
-          // stages nothing; surface that as a typed no_changes condition the
-          // server maps to 409, not a generic git "nothing to commit" failure.
-          const staged = await runGit(["diff", "--cached", "--quiet"], {
+      const squashCommit = await new Workspace(
+        tempDir,
+        this.gitProcessOptions,
+      ).withMutation(async () => {
+        await this.runGit(["merge", "--squash", sourceBranch], {
+          cwd: tempDir,
+        });
+        // A squash of a branch with no committed work ahead of the target
+        // stages nothing; surface that as a typed no_changes condition the
+        // server maps to 409, not a generic git "nothing to commit" failure.
+        const staged = await this.runGit(["diff", "--cached", "--quiet"], {
+          cwd: tempDir,
+          allowFailure: true,
+        });
+        if (staged.exitCode === 0) {
+          throw new WorkspaceError("no_changes", "No changes to merge");
+        }
+        await this.runGit(
+          ["commit", "--no-verify", "-m", options.commitMessage],
+          {
             cwd: tempDir,
-            allowFailure: true,
-          });
-          if (staged.exitCode === 0) {
-            throw new WorkspaceError("no_changes", "No changes to merge");
-          }
-          await runGit(["commit", "--no-verify", "-m", options.commitMessage], {
-            cwd: tempDir,
-          });
-          const commitSha = await revParse(tempDir, "HEAD");
-          const commitSubject = (
-            await runGit(["log", "-1", "--pretty=%s"], { cwd: tempDir })
-          ).stdout.trim();
-          return { commitSha, commitSubject };
-        },
-      );
+          },
+        );
+        const commitSha = await revParse(
+          tempDir,
+          "HEAD",
+          this.gitProcessOptions,
+        );
+        const commitSubject = (
+          await this.runGit(["log", "-1", "--pretty=%s"], { cwd: tempDir })
+        ).stdout.trim();
+        return { commitSha, commitSubject };
+      });
       await this.publishSquashMergeCommit({
         targetBranch: options.targetBranch,
         target,
@@ -1156,6 +1243,7 @@ export class Workspace {
         ["worktree", "remove", tempDir, "--force"],
         {
           cwd: this.path,
+          ...this.gitProcessOptions,
           allowFailure: true,
         },
       );
@@ -1177,16 +1265,20 @@ export class Workspace {
     targetBranch: string,
   ): Promise<SquashMergeTarget> {
     const localRef = `refs/heads/${targetBranch}`;
-    if (await hasRef(this.path, localRef)) {
+    if (await hasRef(this.path, localRef, this.gitProcessOptions)) {
       return {
         kind: "local",
         baseRef: localRef,
-        expectedSha: await revParse(this.path, localRef),
+        expectedSha: await revParse(
+          this.path,
+          localRef,
+          this.gitProcessOptions,
+        ),
       };
     }
 
     const directRemoteRef = `refs/remotes/${targetBranch}`;
-    if (await hasRef(this.path, directRemoteRef)) {
+    if (await hasRef(this.path, directRemoteRef, this.gitProcessOptions)) {
       throw new WorkspaceError(
         "non_local_target_branch",
         `Cannot squash merge into remote branch ${targetBranch}; select a local branch`,
@@ -1194,7 +1286,7 @@ export class Workspace {
     }
 
     const remoteRef = `refs/remotes/origin/${targetBranch}`;
-    if (await hasRef(this.path, remoteRef)) {
+    if (await hasRef(this.path, remoteRef, this.gitProcessOptions)) {
       throw new WorkspaceError(
         "non_local_target_branch",
         `Cannot squash merge into remote-only branch ${targetBranch}; select a local branch`,
@@ -1214,22 +1306,30 @@ export class Workspace {
       args.targetBranch,
     );
     if (checkedOutTargetPath !== null) {
-      await new Workspace(checkedOutTargetPath).withMutation(async () => {
-        if (await hasUncommittedChanges(checkedOutTargetPath)) {
+      await new Workspace(
+        checkedOutTargetPath,
+        this.gitProcessOptions,
+      ).withMutation(async () => {
+        if (
+          await hasUncommittedChanges(
+            checkedOutTargetPath,
+            this.gitProcessOptions,
+          )
+        ) {
           throw new WorkspaceError(
             "dirty_target_branch",
             `Cannot squash merge into ${args.targetBranch}: target branch is checked out at ${checkedOutTargetPath} with uncommitted changes`,
           );
         }
 
-        await runGit(["merge", "--ff-only", args.commitSha], {
+        await this.runGit(["merge", "--ff-only", args.commitSha], {
           cwd: checkedOutTargetPath,
         });
       });
       return;
     }
 
-    await runGit(
+    await this.runGit(
       [
         "update-ref",
         `refs/heads/${args.targetBranch}`,
@@ -1249,7 +1349,7 @@ export class Workspace {
   }
 
   private async listWorktrees(): Promise<WorktreeEntry[]> {
-    const result = await runGit(["worktree", "list", "--porcelain"], {
+    const result = await this.runGit(["worktree", "list", "--porcelain"], {
       cwd: this.path,
     });
     return parseWorktreeList(result.stdout);
@@ -1295,7 +1395,7 @@ export class Workspace {
     mergeBaseBranch: string,
     timeoutMs?: number,
   ): Promise<WorkspaceCommitSummary[]> {
-    const log = await runGit(
+    const log = await this.runGit(
       [
         "log",
         "--cherry-pick",
@@ -1329,8 +1429,11 @@ export class Workspace {
   ): Promise<WorkspaceStatus["mergeBase"]> {
     const [mergeBaseRef, aheadBehindCounts, commits, nameStatus, numstat] =
       await Promise.all([
-        readMergeBaseRef(this.path, mergeBaseBranch, { timeoutMs }),
-        runGit(
+        readMergeBaseRef(this.path, mergeBaseBranch, {
+          timeoutMs,
+          ...this.gitProcessOptions,
+        }),
+        this.runGit(
           [
             "rev-list",
             // Ignore patch-equivalent commits so squash-merged branches are not still ahead.
@@ -1342,7 +1445,7 @@ export class Workspace {
           { cwd: this.path, allowFailure: true, timeoutMs },
         ),
         this.readPatchUniqueCommitSummaries(mergeBaseBranch, timeoutMs),
-        runGit(
+        this.runGit(
           [
             "diff",
             "--no-ext-diff",
@@ -1352,7 +1455,7 @@ export class Workspace {
           ],
           { cwd: this.path, allowFailure: true, timeoutMs },
         ),
-        runGit(
+        this.runGit(
           [
             "diff",
             "--no-ext-diff",
@@ -1479,7 +1582,7 @@ export class Workspace {
     mergeBaseBranch: string,
     timeoutMs?: number,
   ): Promise<boolean> {
-    const branchPatchIdResult = await runShellPipeline(
+    const branchPatchIdResult = await this.runShellPipeline(
       'git diff "$1".."$2" | git patch-id --stable',
       [mergeBaseRef, "HEAD"],
       { cwd: this.path, allowFailure: true, timeoutMs },
@@ -1504,7 +1607,7 @@ export class Workspace {
     // if the user opens a branch that's thousands of commits behind, we'll
     // miss detection and report the branch as ahead — the fallback is
     // pessimistic but correct.
-    const basePatchIdsResult = await runShellPipeline(
+    const basePatchIdsResult = await this.runShellPipeline(
       'git log -p -n 1000 --format="commit %H" "$1".."$2" | git patch-id --stable',
       [mergeBaseRef, mergeBaseBranch],
       { cwd: this.path, allowFailure: true, timeoutMs },
@@ -1608,7 +1711,7 @@ export class Workspace {
           if (indexedPaths.length === 0) {
             return { entries: [], complete: false };
           }
-          const result = await runGit(
+          const result = await this.runGit(
             ["diff", "--no-ext-diff", "--numstat", "-z"],
             {
               cwd: this.path,
@@ -1715,7 +1818,7 @@ export class Workspace {
       ...rangeArgs,
     ];
     if (!args.range.usesUncommittedHead) {
-      return runGitWithNullRecordLimit(
+      return this.runGitWithNullRecordLimit(
         buildArgs(args.range.rangeArgs),
         { cwd: this.path },
         args.recordFormat,
@@ -1724,7 +1827,7 @@ export class Workspace {
     }
 
     const headArgs = buildArgs(["HEAD"]);
-    const headResult = await runGitWithNullRecordLimit(
+    const headResult = await this.runGitWithNullRecordLimit(
       headArgs,
       { cwd: this.path, allowFailure: true },
       args.recordFormat,
@@ -1741,8 +1844,11 @@ export class Workspace {
       );
     }
 
-    const emptyTreeSha = await readEmptyTreeSha(this.path);
-    return runGitWithNullRecordLimit(
+    const emptyTreeSha = await readEmptyTreeSha(
+      this.path,
+      this.gitProcessOptions,
+    );
+    return this.runGitWithNullRecordLimit(
       buildArgs([emptyTreeSha]),
       { cwd: this.path },
       args.recordFormat,
@@ -1772,6 +1878,7 @@ export class Workspace {
         const mergeBaseRef = await readMergeBaseRef(
           this.path,
           target.mergeBaseBranch,
+          this.gitProcessOptions,
         );
         if (!mergeBaseRef) {
           return {
@@ -1789,6 +1896,7 @@ export class Workspace {
         const mergeBaseRef = await readMergeBaseRef(
           this.path,
           target.mergeBaseBranch,
+          this.gitProcessOptions,
         );
         if (!mergeBaseRef) {
           return {
@@ -1804,17 +1912,36 @@ export class Workspace {
       }
       case "commit": {
         const [nameStatus, numstat, shortstat] = await Promise.all([
-          runGit(
-            ["show", "--format=", "--no-ext-diff", "--name-status", "-M", "-z", target.sha],
+          this.runGit(
+            [
+              "show",
+              "--format=",
+              "--no-ext-diff",
+              "--name-status",
+              "-M",
+              "-z",
+              target.sha,
+            ],
             { cwd: this.path },
           ),
-          runGit(
-            ["show", "--format=", "--no-ext-diff", "--numstat", "-M", "-z", target.sha],
+          this.runGit(
+            [
+              "show",
+              "--format=",
+              "--no-ext-diff",
+              "--numstat",
+              "-M",
+              "-z",
+              target.sha,
+            ],
             { cwd: this.path },
           ),
-          runGit(["show", "--format=", "--no-ext-diff", "--shortstat", target.sha], {
-            cwd: this.path,
-          }),
+          this.runGit(
+            ["show", "--format=", "--no-ext-diff", "--shortstat", target.sha],
+            {
+              cwd: this.path,
+            },
+          ),
         ]);
         return {
           nameStatus: nameStatus.stdout,
@@ -1835,14 +1962,17 @@ export class Workspace {
     rangeArgs: string[],
   ): Promise<{ nameStatus: string; numstat: string; shortstat: string }> {
     const [nameStatus, numstat, shortstat] = await Promise.all([
-      runGit(
+      this.runGit(
         ["diff", "--no-ext-diff", "--name-status", "-M", "-z", ...rangeArgs],
         { cwd: this.path },
       ),
-      runGit(["diff", "--no-ext-diff", "--numstat", "-M", "-z", ...rangeArgs], {
-        cwd: this.path,
-      }),
-      runGit(["diff", "--no-ext-diff", "--shortstat", ...rangeArgs], {
+      this.runGit(
+        ["diff", "--no-ext-diff", "--numstat", "-M", "-z", ...rangeArgs],
+        {
+          cwd: this.path,
+        },
+      ),
+      this.runGit(["diff", "--no-ext-diff", "--shortstat", ...rangeArgs], {
         cwd: this.path,
       }),
     ]);
@@ -1858,7 +1988,10 @@ export class Workspace {
     numstat: string;
     shortstat: string;
   }> {
-    const runUncommittedDiff = createUncommittedDiffRunner(this.path);
+    const runUncommittedDiff = createUncommittedDiffRunner(
+      this.path,
+      this.gitProcessOptions,
+    );
     const [nameStatus, numstat, shortstat] = await Promise.all([
       runUncommittedDiff(
         (baseRef) => [
@@ -1902,7 +2035,7 @@ export class Workspace {
       return [];
     }
     return this.withTemporaryUntrackedIndex(untrackedPaths, async (env) => {
-      const numstat = await runGit(
+      const numstat = await this.runGit(
         ["diff", "--no-ext-diff", "--numstat", "-z"],
         { cwd: this.path, env },
       );
@@ -1939,11 +2072,11 @@ export class Workspace {
       args.paths,
       async (env, indexedPaths) => {
         const [nameStatus, patch] = await Promise.all([
-          runGit(["diff", "--no-ext-diff", "--name-status", "-z"], {
+          this.runGit(["diff", "--no-ext-diff", "--name-status", "-z"], {
             cwd: this.path,
             env,
           }),
-          runGit(["diff", "--no-ext-diff", "--binary"], {
+          this.runGit(["diff", "--no-ext-diff", "--binary"], {
             ...buildDiffOutputGitOptions(
               this.path,
               combinedPageBufferBudget(
@@ -1966,7 +2099,7 @@ export class Workspace {
 
         const patchByPath = new Map<string, string>();
         for (const relativePath of indexedPaths) {
-          const result = await runGit(
+          const result = await this.runGit(
             [
               "diff",
               "--no-ext-diff",
@@ -2086,14 +2219,17 @@ export class Workspace {
       return null;
     }
 
-    const runUncommittedDiff = createUncommittedDiffRunner(this.path);
+    const runUncommittedDiff = createUncommittedDiffRunner(
+      this.path,
+      this.gitProcessOptions,
+    );
     const runRangeGit = (
       buildArgs: (rangeArgs: string[]) => string[],
       options: RunGitOptions,
     ): Promise<GitCommandResult> =>
       range.usesUncommittedHead
         ? runUncommittedDiff((baseRef) => buildArgs([baseRef]), options)
-        : runGit(buildArgs(range.rangeArgs), options);
+        : this.runGit(buildArgs(range.rangeArgs), options);
 
     const fullNameStatus = await runRangeGit(
       (rangeArgs) => [
@@ -2162,6 +2298,7 @@ export class Workspace {
         const mergeBaseRef = await readMergeBaseRef(
           this.path,
           target.mergeBaseBranch,
+          this.gitProcessOptions,
         );
         if (!mergeBaseRef) {
           return null;
@@ -2208,6 +2345,7 @@ export class Workspace {
         const mergeBaseRef = await readMergeBaseRef(
           this.path,
           args.target.mergeBaseBranch,
+          this.gitProcessOptions,
         );
         if (!mergeBaseRef) {
           return {
@@ -2235,6 +2373,7 @@ export class Workspace {
         const mergeBaseRef = await readMergeBaseRef(
           this.path,
           args.target.mergeBaseBranch,
+          this.gitProcessOptions,
         );
         if (!mergeBaseRef) {
           return {
@@ -2259,21 +2398,21 @@ export class Workspace {
       case "commit": {
         const sha = args.target.sha;
         const [diff, shortstat, files] = await Promise.all([
-          runGit(
+          this.runGit(
             withDiffPathspec(
               ["show", "--format=", "--no-ext-diff", "--binary", sha],
               args.paths,
             ),
             buildDiffOutputGitOptions(this.path, args.maxDiffBytes),
           ),
-          runGit(
+          this.runGit(
             withDiffPathspec(
               ["show", "--format=", "--shortstat", sha],
               args.paths,
             ),
             { cwd: this.path },
           ),
-          runGit(
+          this.runGit(
             withDiffPathspec(
               ["show", "--format=", "--name-status", sha],
               args.paths,
@@ -2301,21 +2440,21 @@ export class Workspace {
     options: DiffOutputLimits & DiffPathSubset = {},
   ): Promise<[string, string, string]> {
     const [diff, shortstat, files] = await Promise.all([
-      runGit(
+      this.runGit(
         withDiffPathspec(
           ["diff", "--no-ext-diff", "--binary", ...diffArgs],
           options.paths,
         ),
         buildDiffOutputGitOptions(this.path, options.maxDiffBytes),
       ),
-      runGit(
+      this.runGit(
         withDiffPathspec(
           ["diff", "--no-ext-diff", "--shortstat", ...shortstatArgs],
           options.paths,
         ),
         { cwd: this.path },
       ),
-      runGit(
+      this.runGit(
         withDiffPathspec(
           ["diff", "--no-ext-diff", "--name-status", ...filesArgs],
           options.paths,
@@ -2331,21 +2470,21 @@ export class Workspace {
     args: ReadDiffArtifactsArgs,
   ): Promise<DiffArtifactsWithTruncation> {
     const [trackedDiff, trackedNumstat, trackedFiles] = await Promise.all([
-      runGit(
+      this.runGit(
         withDiffPathspec(
           ["diff", "--no-ext-diff", "--binary", ...args.diffArgs],
           args.paths,
         ),
         buildDiffOutputGitOptions(this.path, args.maxDiffBytes),
       ),
-      runGit(
+      this.runGit(
         withDiffPathspec(
           ["diff", "--no-ext-diff", "--numstat", ...args.numstatArgs],
           args.paths,
         ),
         { cwd: this.path },
       ),
-      runGit(
+      this.runGit(
         withDiffPathspec(
           ["diff", "--no-ext-diff", "--name-status", ...args.filesArgs],
           args.paths,
@@ -2434,15 +2573,15 @@ export class Workspace {
     }
     return this.withTemporaryUntrackedIndex(args.relativePaths, async (env) => {
       const [diff, numstat, files] = await Promise.all([
-        runGit(["diff", "--no-ext-diff", "--binary"], {
+        this.runGit(["diff", "--no-ext-diff", "--binary"], {
           ...buildDiffOutputGitOptions(this.path, args.maxDiffBytes),
           env,
         }),
-        runGit(["diff", "--no-ext-diff", "--numstat"], {
+        this.runGit(["diff", "--no-ext-diff", "--numstat"], {
           cwd: this.path,
           env,
         }),
-        runGit(["diff", "--no-ext-diff", "--name-status"], {
+        this.runGit(["diff", "--no-ext-diff", "--name-status"], {
           ...buildDiffOutputGitOptions(this.path, args.maxFileListBytes),
           env,
         }),
@@ -2458,7 +2597,10 @@ export class Workspace {
   private async readUncommittedDiffArtifacts(
     args: DiffOutputLimits & DiffPathSubset & { maxUntrackedFiles?: number },
   ): Promise<DiffArtifactsWithTruncation> {
-    const runUncommittedDiff = createUncommittedDiffRunner(this.path);
+    const runUncommittedDiff = createUncommittedDiffRunner(
+      this.path,
+      this.gitProcessOptions,
+    );
     const [trackedDiff, trackedNumstat, trackedFiles] = await Promise.all([
       runUncommittedDiff(
         (baseRef) =>
@@ -2522,7 +2664,7 @@ export class Workspace {
         attempt += 1
       ) {
         candidates = await this.filterExistingUntrackedPaths(candidates);
-        await runGit(["read-tree", "--empty"], {
+        await this.runGit(["read-tree", "--empty"], {
           cwd: this.path,
           env,
           signal: options.signal,
@@ -2535,7 +2677,7 @@ export class Workspace {
           pathspecPath,
           candidates.map((value) => `:(literal)${value}\0`).join(""),
         );
-        const add = await runGit(
+        const add = await this.runGit(
           [
             "add",
             "--sparse",
@@ -2570,7 +2712,7 @@ export class Workspace {
       // A path kept disappearing during every bounded retry. Reset any partial
       // alternate-index state and let callers return placeholders/empty patches
       // for this stale snapshot instead of rejecting the whole batch.
-      await runGit(["read-tree", "--empty"], {
+      await this.runGit(["read-tree", "--empty"], {
         cwd: this.path,
         env,
         signal: options.signal,
@@ -2606,7 +2748,7 @@ export class Workspace {
   }
 
   private async listUntrackedPaths(): Promise<string[]> {
-    const untrackedFilesOutput = await runGit(
+    const untrackedFilesOutput = await this.runGit(
       ["ls-files", "--others", "--exclude-standard", "-z"],
       { cwd: this.path },
     );
@@ -2620,7 +2762,7 @@ export class Workspace {
     if (relativePaths.length === 0) {
       return [];
     }
-    const untrackedFilesOutput = await runGit(
+    const untrackedFilesOutput = await this.runGit(
       [
         "ls-files",
         "--others",
@@ -2635,7 +2777,7 @@ export class Workspace {
   }
 
   private async listUntrackedPathsLimited(maxPaths: number): Promise<string[]> {
-    const untrackedFilesOutput = await runGitWithNullRecordLimit(
+    const untrackedFilesOutput = await this.runGitWithNullRecordLimit(
       ["ls-files", "--others", "--exclude-standard", "-z"],
       { cwd: this.path },
       "single",

--- a/packages/host-workspace/src/worktree-include.ts
+++ b/packages/host-workspace/src/worktree-include.ts
@@ -9,6 +9,7 @@ interface CopyWorktreeIncludeFilesArgs {
   sourcePath: string;
   /** Freshly created worktree that receives the copies. */
   targetPath: string;
+  shellPath?: string;
   signal?: AbortSignal;
 }
 
@@ -75,6 +76,7 @@ async function readIncludeFile(sourcePath: string): Promise<string | null> {
  */
 async function listMatchingFiles(
   sourcePath: string,
+  shellPath: string | undefined,
   signal: AbortSignal | undefined,
 ): Promise<string[]> {
   const result = await runGit(
@@ -85,7 +87,11 @@ async function listMatchingFiles(
       `--exclude-from=${WORKTREE_INCLUDE_FILE_NAME}`,
       "-z",
     ],
-    { cwd: sourcePath, signal },
+    {
+      cwd: sourcePath,
+      ...(shellPath !== undefined ? { shellPath } : {}),
+      signal,
+    },
   );
   return result.stdout.split("\0").filter(Boolean);
 }
@@ -143,7 +149,11 @@ export async function copyWorktreeIncludeFiles(
     return EMPTY_RESULT;
   }
 
-  const relativePaths = await listMatchingFiles(args.sourcePath, args.signal);
+  const relativePaths = await listMatchingFiles(
+    args.sourcePath,
+    args.shellPath,
+    args.signal,
+  );
   if (relativePaths.length === 0) {
     return { ran: true, copied: [], skipped: [] };
   }

--- a/packages/host-workspace/src/worktree-metadata-lock.ts
+++ b/packages/host-workspace/src/worktree-metadata-lock.ts
@@ -30,7 +30,7 @@ export async function runGitWithWorktreeMetadataLock(
   args: GitCommandArgs,
   options: RunGitOptions,
 ): Promise<GitCommandResult> {
-  const commonDir = await getGitCommonDir(options.cwd);
+  const commonDir = await getGitCommonDir(options.cwd, options);
   return withWorktreeMetadataLock(
     commonDir,
     () => runGit(args, options),

--- a/packages/host-workspace/test/git-host.test.ts
+++ b/packages/host-workspace/test/git-host.test.ts
@@ -189,6 +189,7 @@ describe("runPullRequestActionForCurrentBranch", () => {
   const actionArgs = {
     cwd: "/tmp/workspace",
     localBranch: "bb/pr-action",
+    shellPath: "/Users/test/.local/bin:/usr/bin",
   };
 
   function mockGhSuccess(): void {
@@ -242,6 +243,9 @@ describe("runPullRequestActionForCurrentBranch", () => {
         expect.objectContaining({
           cwd: "/tmp/workspace",
           encoding: "utf8",
+          env: expect.objectContaining({
+            PATH: "/Users/test/.local/bin:/usr/bin",
+          }),
           maxBuffer: 16 * 1024 * 1024,
           timeout: 60_000,
         }),
@@ -289,6 +293,7 @@ describe("getPullRequestForCurrentBranch", () => {
   const lookupArgs = {
     cwd: "/tmp/workspace",
     localBranch: "bb/pr-lookup",
+    shellPath: "/Users/test/.local/bin:/usr/bin",
   };
 
   function mockGhStdout(stdout: string): void {
@@ -340,7 +345,12 @@ describe("getPullRequestForCurrentBranch", () => {
     expect(execFileMock).toHaveBeenCalledWith(
       "gh",
       ["pr", "view", "--json", expect.any(String)],
-      expect.objectContaining({ cwd: "/tmp/workspace" }),
+      expect.objectContaining({
+        cwd: "/tmp/workspace",
+        env: expect.objectContaining({
+          PATH: "/Users/test/.local/bin:/usr/bin",
+        }),
+      }),
       expect.any(Function),
     );
   });

--- a/packages/host-workspace/test/git.test.ts
+++ b/packages/host-workspace/test/git.test.ts
@@ -427,6 +427,31 @@ describe("command timeouts", () => {
   });
 });
 
+describe("user-shell Git resolution", () => {
+  it("uses the resolved shell PATH for Git commands and Git pipelines", async () => {
+    const workspacePath = await fs.mkdtemp(
+      path.join(os.tmpdir(), "bb-git-shell-path-workspace-"),
+    );
+    const binPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), "bb-git-shell-path-bin-"),
+    );
+    tempDirs.push(workspacePath, binPath);
+    const gitPath = path.join(binPath, "git");
+    await fs.writeFile(gitPath, "#!/bin/sh\nprintf 'user-shell-git\\n'\n");
+    await fs.chmod(gitPath, 0o755);
+
+    await expect(
+      runGit(["--version"], { cwd: workspacePath, shellPath: binPath }),
+    ).resolves.toMatchObject({ stdout: "user-shell-git\n" });
+    await expect(
+      runShellPipeline("git --version", [], {
+        cwd: workspacePath,
+        shellPath: binPath,
+      }),
+    ).resolves.toMatchObject({ stdout: "user-shell-git\n" });
+  });
+});
+
 describe("readGitBlob", () => {
   it("reads a blob at a git ref and reports the returned byte size", async () => {
     const repoPath = await initReadGitBlobRepo();

--- a/packages/host-workspace/test/provisioning.test.ts
+++ b/packages/host-workspace/test/provisioning.test.ts
@@ -567,7 +567,7 @@ describe("workspace provisioning", () => {
     const result = await runSetupScript({
       workspacePath,
       timeoutMs: 900000,
-      setupPath: `${binPath}${path.delimiter}/usr/bin:/bin`,
+      shellPath: `${binPath}${path.delimiter}/usr/bin:/bin`,
     });
 
     expect(result.ran).toBe(true);

--- a/packages/local-open-targets/src/index.ts
+++ b/packages/local-open-targets/src/index.ts
@@ -63,6 +63,11 @@ export type {
   WorkspaceOpenTargetRuntime,
 } from "./types.js";
 
+export interface WorkspaceOpenTargetRuntimeOptions {
+  /** Resolved user login-shell PATH for editor and launcher CLIs. */
+  shellPath?: string;
+}
+
 const execFileAsync = promisify(execFile);
 const DESKTOP_APP_TARGET_ID_PREFIX = "desktop-app:";
 const MAC_APP_TARGET_ID_PREFIX = "mac-app:";
@@ -485,8 +490,14 @@ async function execInvocation(
   });
 }
 
-function createDefaultRuntime(): WorkspaceOpenTargetRuntime {
+export function createWorkspaceOpenTargetRuntime(
+  options: WorkspaceOpenTargetRuntimeOptions = {},
+): WorkspaceOpenTargetRuntime {
   const homeDirectory = os.homedir();
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...(options.shellPath !== undefined ? { PATH: options.shellPath } : {}),
+  };
   return {
     applicationDirectories: [
       "/Applications",
@@ -498,7 +509,7 @@ function createDefaultRuntime(): WorkspaceOpenTargetRuntime {
       "/usr/local/share/applications",
       path.join(homeDirectory, ".local/share/applications"),
     ],
-    env: process.env,
+    env,
     execFile: defaultExecFile,
     platform: process.platform,
   };
@@ -1015,11 +1026,27 @@ async function isExecutableAvailable(
   runtime: WorkspaceOpenTargetRuntime,
 ): Promise<boolean> {
   try {
+    await runtime.execFile("which", [executable], { env: runtime.env });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function isServiceExecutableAvailable(
+  executable: string,
+  runtime: WorkspaceOpenTargetRuntime,
+): Promise<boolean> {
+  try {
     await runtime.execFile("which", [executable]);
     return true;
   } catch {
     return false;
   }
+}
+
+function isMacServiceExecutable(executable: string): boolean {
+  return executable === "open" || executable === "osascript";
 }
 
 async function resolveMacBundledExecutable(
@@ -1049,7 +1076,7 @@ async function resolveMacBundledExecutable(
   return {
     file: executablePath,
     argsPrefix: bundledExecutable.toArgsPrefix?.(appPath) ?? [],
-    env: bundledExecutable.toEnv?.(runtime.env),
+    env: bundledExecutable.toEnv?.(runtime.env) ?? runtime.env,
   };
 }
 
@@ -1059,8 +1086,16 @@ async function resolveMacCommandExecutable(
   runtime: WorkspaceOpenTargetRuntime,
 ): Promise<ResolvedMacCommandExecutable | null> {
   for (const candidate of [command, ...(command.fallbackExecutables ?? [])]) {
-    if (await isExecutableAvailable(candidate.executable, runtime)) {
-      return { file: candidate.executable, argsPrefix: [] };
+    const serviceExecutable = isMacServiceExecutable(candidate.executable);
+    const available = serviceExecutable
+      ? await isServiceExecutableAvailable(candidate.executable, runtime)
+      : await isExecutableAvailable(candidate.executable, runtime);
+    if (available) {
+      return {
+        file: candidate.executable,
+        argsPrefix: [],
+        ...(serviceExecutable ? {} : { env: runtime.env }),
+      };
     }
     if (candidate.bundledExecutable !== undefined) {
       const resolved = await resolveMacBundledExecutable(
@@ -1207,7 +1242,12 @@ async function maybeResolveMacFileOpenInvocation(
     return null;
   }
 
-  if (!(await isExecutableAvailable(fileOpenCommand.executable, runtime))) {
+  if (
+    !(await isServiceExecutableAvailable(
+      fileOpenCommand.executable,
+      runtime,
+    ))
+  ) {
     return null;
   }
 
@@ -1348,6 +1388,7 @@ async function maybeResolveXcodeOpenInvocation(
         : ["--line", String(args.lineNumber)]),
       args.existingPath.path,
     ],
+    env: runtime.env,
   };
 }
 
@@ -1539,6 +1580,7 @@ async function resolvePlatformDefaultOpenInvocation(
   return {
     file: executable,
     args: [args.existingPath.path],
+    env: runtime.env,
   };
 }
 
@@ -1561,6 +1603,7 @@ async function resolvePlatformFileManagerOpenInvocation(
   return {
     file: executable,
     args: [openPath],
+    env: runtime.env,
   };
 }
 
@@ -1598,12 +1641,15 @@ async function resolvePlatformTerminalOpenInvocation(
     });
   }
 
-  return buildLinuxTerminalOpenInvocation(executable, {
-    columnNumber: args.columnNumber,
-    lineNumber: args.lineNumber,
-    path: args.existingPath.path,
-    pathType: args.existingPath.type,
-  });
+  return {
+    ...buildLinuxTerminalOpenInvocation(executable, {
+      columnNumber: args.columnNumber,
+      lineNumber: args.lineNumber,
+      path: args.existingPath.path,
+      pathType: args.existingPath.type,
+    }),
+    env: runtime.env,
+  };
 }
 
 async function resolvePlatformTerminalRemoteSshOpenInvocation(
@@ -1625,7 +1671,10 @@ async function resolvePlatformTerminalRemoteSshOpenInvocation(
     });
   }
 
-  return buildLinuxTerminalRemoteSshInvocation(executable, args);
+  return {
+    ...buildLinuxTerminalRemoteSshInvocation(executable, args),
+    env: runtime.env,
+  };
 }
 
 function splitDesktopExec(exec: string): string[] {
@@ -1765,10 +1814,13 @@ async function resolveLinuxDesktopApplicationOpenInvocation(
       message: `Workspace open target is unavailable: ${args.desktopFileId}`,
     });
   }
-  return buildLinuxDesktopApplicationInvocation(
-    application,
-    args.existingPath.path,
-  );
+  return {
+    ...buildLinuxDesktopApplicationInvocation(
+      application,
+      args.existingPath.path,
+    ),
+    env: runtime.env,
+  };
 }
 
 async function resolvePlatformOpenInvocation(
@@ -1937,11 +1989,14 @@ export async function openPathInTargetWithRuntime(
 export async function listWorkspaceOpenTargets(
   options: ListWorkspaceOpenTargetsOptions = {},
 ): Promise<WorkspaceOpenTarget[]> {
-  return listWorkspaceOpenTargetsWithRuntime(createDefaultRuntime(), options);
+  return listWorkspaceOpenTargetsWithRuntime(
+    createWorkspaceOpenTargetRuntime(),
+    options,
+  );
 }
 
 export async function openPathInTarget(
   args: OpenPathInTargetArgs,
 ): Promise<void> {
-  await openPathInTargetWithRuntime(args, createDefaultRuntime());
+  await openPathInTargetWithRuntime(args, createWorkspaceOpenTargetRuntime());
 }

--- a/packages/local-open-targets/test/workspace-open-targets.test.ts
+++ b/packages/local-open-targets/test/workspace-open-targets.test.ts
@@ -4,10 +4,35 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import {
+  createWorkspaceOpenTargetRuntime,
   listWorkspaceOpenTargetsWithRuntime,
   openPathInTargetWithRuntime,
   type WorkspaceOpenTargetRuntime,
 } from "../src/index.js";
+
+describe("default workspace open-target runtime", () => {
+  it("exposes the resolved shell PATH without changing system-tool launches", async () => {
+    const runtime = createWorkspaceOpenTargetRuntime({
+      shellPath: "/Users/test/.local/bin:/usr/bin",
+    });
+
+    expect(runtime.env?.PATH).toBe("/Users/test/.local/bin:/usr/bin");
+    const inheritedResult = await runtime.execFile(process.execPath, [
+      "-e",
+      "process.stdout.write(process.env.PATH ?? '')",
+    ]);
+    expect(inheritedResult.stdout).toBe(process.env.PATH ?? "");
+
+    const userExecutableResult = await runtime.execFile(
+      process.execPath,
+      ["-e", "process.stdout.write(process.env.PATH ?? '')"],
+      { env: runtime.env },
+    );
+    expect(userExecutableResult.stdout).toBe(
+      "/Users/test/.local/bin:/usr/bin",
+    );
+  });
+});
 
 type ExecFileHandler = WorkspaceOpenTargetRuntime["execFile"];
 
@@ -325,6 +350,7 @@ describe("workspace open targets", () => {
       expect(calls.find((call) => call.file === "wslview")).toEqual({
         file: "wslview",
         args: [filePath],
+        env: { WSL_DISTRO_NAME: "Ubuntu" },
       });
     } finally {
       await rm(workspacePath, { force: true, recursive: true });
@@ -361,6 +387,7 @@ describe("workspace open targets", () => {
       expect(calls.find((call) => call.file === "explorer.exe")).toEqual({
         file: "explorer.exe",
         args: [path.dirname(filePath)],
+        env: { WSL_DISTRO_NAME: "Ubuntu" },
       });
     } finally {
       await rm(workspacePath, { force: true, recursive: true });
@@ -405,13 +432,23 @@ describe("workspace open targets", () => {
           path: filePath,
           targetId: "vscode",
         },
-        createRuntime({ execFile, platform: "linux" }),
+        createRuntime({
+          env: { PATH: "/Users/test/.local/bin:/usr/bin" },
+          execFile,
+          platform: "linux",
+        }),
       );
 
       expect(calls.find((call) => call.file === "code")).toEqual({
         file: "code",
         args: ["-g", `${filePath}:15:6`],
+        env: { PATH: "/Users/test/.local/bin:/usr/bin" },
       });
+      expect(
+        calls.find(
+          (call) => call.file === "which" && call.args[0] === "code",
+        )?.env,
+      ).toEqual({ PATH: "/Users/test/.local/bin:/usr/bin" });
     } finally {
       await rm(workspacePath, { force: true, recursive: true });
     }
@@ -609,7 +646,10 @@ describe("workspace open targets", () => {
           path: filePath,
           targetId: "default-app",
         },
-        createRuntime({ execFile }),
+        createRuntime({
+          env: { PATH: "/Users/test/.local/bin:/usr/bin" },
+          execFile,
+        }),
       );
 
       expect(calls.find((call) => call.file === "open")).toEqual({
@@ -1491,6 +1531,7 @@ describe("workspace open targets", () => {
       expect(calls.find((call) => call.file === webStormExecutable)).toEqual({
         file: webStormExecutable,
         args: ["--line", "15", "--column", "6", filePath],
+        env: { HOME: homeDirectory },
       });
     } finally {
       await rm(root, { force: true, recursive: true });


### PR DESCRIPTION
## What was wrong

The host daemon launched some user-installed tools with its minimal service `PATH` instead of BB's resolved login-shell `PATH`. This made workspace GitHub discovery report `GitHub CLI is not available` when `gh` was installed in a user path such as `~/.local/bin`, even though the same lookup worked interactively. The inconsistency also affected direct workspace Git and editor/launcher CLI discovery. This is separate from #2242, which concerns turn dispatch.

## What changed

- Centralized the daemon policy for subprocesses that should resolve like user shell commands.
- Passed the resolved shell `PATH` through PR lookup/actions, workspace Git operations and provisioning, project and branch commands, and Git-ref file reads.
- Used the resolved shell `PATH` for local editor/launcher CLI discovery and launch while leaving OS/service utilities on the controlled daemon environment.
- Added regression coverage for `gh`, Git commands and pipelines, daemon workspace provisioning/dispatch, and local open-target discovery/launch.
- No host-daemon wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` was not incremented.

## How you verified

- `pnpm exec turbo run test typecheck --filter=@bb/host-daemon --filter=@bb/host-workspace --filter=@bb/local-open-targets --force`
- 560 host-daemon tests passed.
- 215 host-workspace tests passed.
- 57 local-open-targets tests passed.
- All affected package typechecks passed.

Fixes: no linked issue.

> AGENT GENERATED: by GPT-5
