### PR TITLE
Show full build details in the desktop About dialog

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -111,7 +111,7 @@ Linux gets both update paths, but they are not equivalent:
   install and reports that a newer release exists.
 - Self-installing auto-update runs only inside an AppImage whose directory the
   app can write to. electron-updater detects the AppImage through the `APPIMAGE`
-  environment variable, and its install step unlinks the running file *before*
+  environment variable, and its install step unlinks the running file _before_
   moving the replacement in — so a read-only directory would delete the app and
   leave nothing behind. Both the startup check and the install handler verify
   write and search access on the parent directory first.
@@ -155,10 +155,10 @@ so a single publisher is what keeps one platform from deleting the other's
 binaries. Each platform has its own update feed file inside the same release
 tag:
 
-| Platform | Artifacts               | electron-updater metadata | Version feed                 |
-| -------- | ----------------------- | ------------------------- | ---------------------------- |
-| macOS    | `.dmg`, `.zip` (arm64)  | `latest-mac.yml`          | `desktop-version.json`       |
-| Linux    | `.AppImage` (x64)       | `latest-linux.yml`        | `desktop-version-linux.json` |
+| Platform | Artifacts              | electron-updater metadata | Version feed                 |
+| -------- | ---------------------- | ------------------------- | ---------------------------- |
+| macOS    | `.dmg`, `.zip` (arm64) | `latest-mac.yml`          | `desktop-version.json`       |
+| Linux    | `.AppImage` (x64)      | `latest-linux.yml`        | `desktop-version-linux.json` |
 
 macOS keeps the unsuffixed feed name because released macOS builds already
 request it. Linux artifacts are unsigned; only the macOS binaries wait on the
@@ -210,6 +210,27 @@ Nightly builds set `BB_DESKTOP_RELEASE_CHANNEL=nightly` at build time. The value
 is baked into the Electron main/preload bundles and selects the nightly product
 identity, yellow icon, and update URLs. Omit the variable (or set it to
 `latest`) for stable and local builds.
+
+## About panel
+
+The app menu's About item opens a message box listing the facts a bug report
+needs: version, build type, commit, build date and how old that build is
+("3 days old"), plugin SDK version, Electron version, and OS. Its **Copy**
+button puts that whole block on the clipboard. The age is computed when the
+dialog opens, so a long-running session still reports it correctly.
+
+The native About panel is populated too, minus the age, since Electron takes
+those options once at startup. `scripts/build.mjs` bakes the build-time half of
+the facts into the bundles:
+
+| Variable                | Default when unset                                    |
+| ----------------------- | ----------------------------------------------------- |
+| `BB_DESKTOP_COMMIT`     | `GITHUB_SHA`, else `git rev-parse HEAD`, else unknown |
+| `BB_DESKTOP_BUILD_DATE` | The build's own timestamp, ISO 8601                   |
+
+The plugin SDK version is read from `packages/plugin-sdk/package.json` at build
+time. A checkout with no git metadata reports `Commit: unknown` rather than
+failing the build.
 
 ## macOS signing + notarization
 

--- a/apps/desktop/scripts/build.mjs
+++ b/apps/desktop/scripts/build.mjs
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { readFile, rm } from "node:fs/promises";
 import { resolve } from "node:path";
 import { build } from "esbuild";
@@ -6,8 +7,16 @@ import { resolveDesktopReleaseChannel } from "./desktop-release-channel.mjs";
 const packageRoot = process.cwd();
 const distDir = resolve(packageRoot, "dist");
 const packageJsonPath = resolve(packageRoot, "package.json");
+const pluginSdkPackageJsonPath = resolve(
+  packageRoot,
+  "..",
+  "..",
+  "packages",
+  "plugin-sdk",
+  "package.json",
+);
 
-function readPackageVersion(packageJsonText) {
+function readPackageVersion(packageJsonText, label) {
   const packageJson = JSON.parse(packageJsonText);
   if (
     typeof packageJson !== "object" ||
@@ -15,21 +24,62 @@ function readPackageVersion(packageJsonText) {
     typeof packageJson.version !== "string" ||
     packageJson.version.length === 0
   ) {
-    throw new Error("apps/desktop/package.json must define a version");
+    throw new Error(`${label} must define a version`);
   }
   return packageJson.version;
+}
+
+/**
+ * The About panel reports the commit a build came from. A tarball checkout or
+ * a shallow CI clone can have no usable git metadata, so an unknown commit is
+ * reported as such rather than failing the build.
+ */
+function readBuildCommit(env) {
+  const injected =
+    env.BB_DESKTOP_COMMIT?.trim() ?? env.GITHUB_SHA?.trim() ?? "";
+  if (injected.length > 0) {
+    return injected;
+  }
+  try {
+    return execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: packageRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function readBuildDate(env) {
+  const injected = env.BB_DESKTOP_BUILD_DATE?.trim() ?? "";
+  if (injected.length > 0) {
+    return injected;
+  }
+  return new Date().toISOString();
 }
 
 await rm(distDir, { force: true, recursive: true });
 
 const desktopVersion = readPackageVersion(
   await readFile(packageJsonPath, "utf8"),
+  "apps/desktop/package.json",
+);
+const pluginSdkVersion = readPackageVersion(
+  await readFile(pluginSdkPackageJsonPath, "utf8"),
+  "packages/plugin-sdk/package.json",
 );
 const desktopReleaseChannel = resolveDesktopReleaseChannel(process.env);
+const desktopCommit = readBuildCommit(process.env);
+const desktopBuildDate = readBuildDate(process.env);
 
 const commonOptions = {
   bundle: true,
   define: {
+    "process.env.BB_DESKTOP_BUILD_DATE": JSON.stringify(desktopBuildDate),
+    "process.env.BB_DESKTOP_COMMIT": JSON.stringify(desktopCommit),
+    "process.env.BB_DESKTOP_PLUGIN_SDK_VERSION":
+      JSON.stringify(pluginSdkVersion),
     "process.env.BB_DESKTOP_RELEASE_CHANNEL": JSON.stringify(
       desktopReleaseChannel,
     ),

--- a/apps/desktop/src/desktop-about-panel.ts
+++ b/apps/desktop/src/desktop-about-panel.ts
@@ -1,0 +1,160 @@
+/**
+ * Facts shown in the About dialog. Everything here is either injected at build
+ * time (version, channel, commit, build date, plugin SDK version) or read from
+ * the running process, so a bug report can be reproduced against the exact
+ * build the user is running.
+ */
+export interface DesktopAboutFacts {
+  applicationName: string;
+  /** ISO 8601 timestamp of when the build was produced. */
+  buildDate: string;
+  channel: "latest" | "nightly";
+  /** Full git SHA, or empty when the build had no git metadata. */
+  commit: string;
+  electronVersion: string;
+  osArch: string;
+  osRelease: string;
+  /** `os.type()`, e.g. "Darwin" or "Linux". */
+  osType: string;
+  platform: NodeJS.Platform;
+  pluginSdkVersion: string;
+  version: string;
+}
+
+export interface DesktopAboutPanelOptions {
+  applicationName: string;
+  applicationVersion: string;
+  credits?: string;
+}
+
+export interface DesktopAboutDialogOptions {
+  buttons: string[];
+  cancelId: number;
+  /** Index into `buttons` whose click should copy `detail` to the clipboard. */
+  copyButtonId: number;
+  defaultId: number;
+  detail: string;
+  message: string;
+  type: "info";
+}
+
+export const ABOUT_DIALOG_COPY_BUTTON_LABEL = "Copy";
+const ABOUT_DIALOG_DISMISS_BUTTON_LABEL = "OK";
+const UNKNOWN_VALUE = "unknown";
+const MILLISECONDS_PER_DAY = 86_400_000;
+
+function displayValue(value: string): string {
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? UNKNOWN_VALUE : trimmed;
+}
+
+/**
+ * How stale the running build is, in the "3 days old" form. Returns null for an
+ * unparseable build date so the Date line degrades to the raw value instead of
+ * claiming an age it cannot know.
+ */
+export function formatBuildAge(
+  buildDate: string,
+  nowMs: number,
+): string | null {
+  const buildMs = Date.parse(buildDate);
+  if (Number.isNaN(buildMs)) {
+    return null;
+  }
+  // A build that reads as newer than the clock means skew, not a future
+  // release; report it as fresh rather than as a negative age.
+  const days = Math.max(
+    0,
+    Math.floor((nowMs - buildMs) / MILLISECONDS_PER_DAY),
+  );
+  if (days === 0) {
+    return "today";
+  }
+  return days === 1 ? "1 day old" : `${days} days old`;
+}
+
+function formatBuildDate(buildDate: string, nowMs: number | null): string {
+  const trimmed = buildDate.trim();
+  if (trimmed.length === 0) {
+    return UNKNOWN_VALUE;
+  }
+  if (nowMs === null) {
+    return trimmed;
+  }
+  const age = formatBuildAge(trimmed, nowMs);
+  return age === null ? trimmed : `${trimmed} (${age})`;
+}
+
+/**
+ * The detail block a user copies into a bug report, one `Label: value` per
+ * line, most build-identifying first. Pass null for `nowMs` where the block is
+ * rendered once and read later — a build age frozen at launch would be wrong by
+ * the time a long-running session reads it.
+ */
+export function buildDesktopAboutDetails(
+  facts: DesktopAboutFacts,
+  nowMs: number | null,
+): string {
+  const lines: [string, string][] = [
+    ["Version", facts.version],
+    ["Build Type", facts.channel === "nightly" ? "Nightly" : "Stable"],
+    ["Commit", facts.commit],
+    ["Date", formatBuildDate(facts.buildDate, nowMs)],
+    ["Plugin SDK", facts.pluginSdkVersion],
+    ["Electron", facts.electronVersion],
+    ["OS", `${facts.osType} ${facts.osArch} ${facts.osRelease}`],
+  ];
+  return lines
+    .map(([label, value]) => `${label}: ${displayValue(value)}`)
+    .join("\n");
+}
+
+/**
+ * The About dialog shown from the app menu. It replaces the native About panel
+ * because only a message box can carry a Copy button, and the whole point of
+ * the detail block is pasting it into a bug report.
+ */
+export function createDesktopAboutDialogOptions(
+  facts: DesktopAboutFacts,
+  nowMs: number,
+): DesktopAboutDialogOptions {
+  return {
+    buttons: [
+      ABOUT_DIALOG_DISMISS_BUTTON_LABEL,
+      ABOUT_DIALOG_COPY_BUTTON_LABEL,
+    ],
+    cancelId: 0,
+    copyButtonId: 1,
+    defaultId: 0,
+    detail: buildDesktopAboutDetails(facts, nowMs),
+    message: facts.applicationName,
+    type: "info",
+  };
+}
+
+/**
+ * The native panel stays populated for any path that opens it without going
+ * through the app menu. Electron accepts these options once at startup, so it
+ * omits the build age.
+ */
+export function createDesktopAboutPanelOptions(
+  facts: DesktopAboutFacts,
+): DesktopAboutPanelOptions {
+  const details = buildDesktopAboutDetails(facts, null);
+
+  // `credits` is macOS/Windows only. The GTK about dialog has no equivalent
+  // free-text field, so Linux gets the details under the version instead of
+  // silently dropping them.
+  if (facts.platform === "linux") {
+    return {
+      applicationName: facts.applicationName,
+      applicationVersion: `${facts.version}\n\n${details}`,
+    };
+  }
+
+  return {
+    applicationName: facts.applicationName,
+    applicationVersion: facts.version,
+    credits: details,
+  };
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,11 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { accessSync, constants as fsConstants } from "node:fs";
-import { homedir } from "node:os";
+import { arch, homedir, release, type as osType } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import {
   app,
   BrowserWindow,
   clipboard,
+  dialog,
   ipcMain,
   nativeImage,
   nativeTheme,
@@ -108,6 +109,11 @@ import {
   type DesktopBrowserWindowCreator,
   type DesktopWindowFactory,
 } from "./desktop-window-factory.js";
+import {
+  createDesktopAboutDialogOptions,
+  createDesktopAboutPanelOptions,
+  type DesktopAboutFacts,
+} from "./desktop-about-panel.js";
 import { registerDesktopContextMenu } from "./desktop-context-menu.js";
 import { resolveBbDesktopPlatform } from "./desktop-platform.js";
 import {
@@ -404,6 +410,48 @@ function getDesktopVersion(version: string | undefined): string {
   return version;
 }
 
+function readDesktopAboutFacts(applicationName: string): DesktopAboutFacts {
+  return {
+    applicationName,
+    buildDate: process.env.BB_DESKTOP_BUILD_DATE ?? "",
+    channel: DESKTOP_RELEASE_CHANNEL,
+    commit: process.env.BB_DESKTOP_COMMIT ?? "",
+    electronVersion: process.versions.electron,
+    osArch: arch(),
+    osRelease: release(),
+    osType: osType(),
+    platform: process.platform,
+    pluginSdkVersion: process.env.BB_DESKTOP_PLUGIN_SDK_VERSION ?? "",
+    version: getDesktopVersion(process.env.BB_DESKTOP_VERSION),
+  };
+}
+
+function installAboutPanel(applicationName: string): void {
+  app.setAboutPanelOptions(
+    createDesktopAboutPanelOptions(readDesktopAboutFacts(applicationName)),
+  );
+}
+
+/**
+ * The About dialog is read at click time, not at launch, so a session left open
+ * for days still reports the build's real age.
+ */
+async function showAboutDialog(): Promise<void> {
+  const { copyButtonId, ...messageBoxOptions } =
+    createDesktopAboutDialogOptions(
+      readDesktopAboutFacts(app.getName()),
+      Date.now(),
+    );
+  const parentWindow = getFocusedApplicationWindow();
+  const result =
+    parentWindow === null
+      ? await dialog.showMessageBox(messageBoxOptions)
+      : await dialog.showMessageBox(parentWindow, messageBoxOptions);
+  if (result.response === copyButtonId) {
+    clipboard.writeText(messageBoxOptions.detail);
+  }
+}
+
 function getCurrentDesktopInfo(): BbDesktopInfo | null {
   return mergeDesktopUpdateInfo({
     autoInfo: desktopAutoUpdateService?.getInfo() ?? null,
@@ -688,6 +736,9 @@ function installCurrentApplicationMenu(): void {
         initialUrl: currentWindowUrl,
         stateKey: null,
       });
+    },
+    openAbout() {
+      void showAboutDialog();
     },
     openNewTab() {
       const browserWindow = getFocusedApplicationWindow();
@@ -2013,7 +2064,11 @@ async function runDesktopApp(): Promise<void> {
     platform: process.platform,
   });
 
-  app.setName(app.isPackaged ? DESKTOP_RELEASE_INFO.applicationName : "bb-dev");
+  const applicationName = app.isPackaged
+    ? DESKTOP_RELEASE_INFO.applicationName
+    : "bb-dev";
+  app.setName(applicationName);
+  installAboutPanel(applicationName);
 
   if (!app.requestSingleInstanceLock()) {
     app.quit();

--- a/apps/desktop/src/menu.ts
+++ b/apps/desktop/src/menu.ts
@@ -44,6 +44,7 @@ interface ApplicationMenuServerItem {
 export interface InstallApplicationMenuArgs {
   accelerators: ApplicationMenuAccelerators;
   isMac: boolean;
+  openAbout(): void;
   openNewTab(): void;
   openNewThread(): void;
   openSettings(): void;
@@ -123,7 +124,12 @@ export function buildApplicationMenuTemplate(
     {
       label: app.name,
       submenu: [
-        { role: "about" },
+        {
+          label: `About ${app.name}`,
+          click() {
+            args.openAbout();
+          },
+        },
         { type: "separator" },
         {
           accelerator: args.accelerators.openSettings,
@@ -247,10 +253,7 @@ export function buildApplicationMenuTemplate(
           submenu: createServerMenuItems(args),
         },
         ...(args.isMac
-          ? [
-              { type: "separator" as const },
-              { role: "front" as const },
-            ]
+          ? [{ type: "separator" as const }, { role: "front" as const }]
           : []),
       ],
     },

--- a/apps/desktop/test/desktop-about-panel.test.ts
+++ b/apps/desktop/test/desktop-about-panel.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  ABOUT_DIALOG_COPY_BUTTON_LABEL,
+  buildDesktopAboutDetails,
+  createDesktopAboutDialogOptions,
+  createDesktopAboutPanelOptions,
+  formatBuildAge,
+  type DesktopAboutFacts,
+} from "../src/desktop-about-panel.js";
+
+const BUILD_DATE = "2026-06-27T06:41:01.941Z";
+const BUILD_MS = Date.parse(BUILD_DATE);
+const DAY_MS = 86_400_000;
+
+function createFacts(
+  overrides: Partial<DesktopAboutFacts> = {},
+): DesktopAboutFacts {
+  return {
+    applicationName: "bb",
+    buildDate: BUILD_DATE,
+    channel: "latest",
+    commit: "042b3c1a4c53f2c3808067f519fbfc67b72cad80",
+    electronVersion: "41.7.0",
+    osArch: "arm64",
+    osRelease: "23.3.0",
+    osType: "Darwin",
+    platform: "darwin",
+    pluginSdkVersion: "0.4.12",
+    version: "0.39.0",
+    ...overrides,
+  };
+}
+
+describe("formatBuildAge", () => {
+  it("counts elapsed days", () => {
+    expect(formatBuildAge(BUILD_DATE, BUILD_MS + 3 * DAY_MS)).toBe(
+      "3 days old",
+    );
+    expect(formatBuildAge(BUILD_DATE, BUILD_MS + DAY_MS)).toBe("1 day old");
+    expect(formatBuildAge(BUILD_DATE, BUILD_MS + DAY_MS - 1)).toBe("today");
+  });
+
+  it("reads a build newer than the clock as fresh, not as a negative age", () => {
+    expect(formatBuildAge(BUILD_DATE, BUILD_MS - 5 * DAY_MS)).toBe("today");
+  });
+
+  it("has no age for an unparseable date", () => {
+    expect(formatBuildAge("not-a-date", BUILD_MS)).toBeNull();
+  });
+});
+
+describe("buildDesktopAboutDetails", () => {
+  it("reports every build fact a bug report needs", () => {
+    expect(buildDesktopAboutDetails(createFacts(), BUILD_MS + 3 * DAY_MS)).toBe(
+      [
+        "Version: 0.39.0",
+        "Build Type: Stable",
+        "Commit: 042b3c1a4c53f2c3808067f519fbfc67b72cad80",
+        `Date: ${BUILD_DATE} (3 days old)`,
+        "Plugin SDK: 0.4.12",
+        "Electron: 41.7.0",
+        "OS: Darwin arm64 23.3.0",
+      ].join("\n"),
+    );
+  });
+
+  it("omits the age when no clock is supplied", () => {
+    expect(buildDesktopAboutDetails(createFacts(), null)).toContain(
+      `Date: ${BUILD_DATE}\n`,
+    );
+  });
+
+  it("labels a nightly build as such", () => {
+    expect(
+      buildDesktopAboutDetails(createFacts({ channel: "nightly" }), BUILD_MS),
+    ).toContain("Build Type: Nightly");
+  });
+
+  it("says unknown rather than printing an empty value", () => {
+    // A tarball checkout builds with no git metadata; "Commit: " alone reads
+    // like a rendering bug.
+    const details = buildDesktopAboutDetails(
+      createFacts({ buildDate: "", commit: "", pluginSdkVersion: "  " }),
+      BUILD_MS,
+    );
+    expect(details).toContain("Commit: unknown");
+    expect(details).toContain("Date: unknown");
+    expect(details).toContain("Plugin SDK: unknown");
+  });
+});
+
+describe("createDesktopAboutDialogOptions", () => {
+  it("offers a Copy button whose id addresses the copyable detail block", () => {
+    const options = createDesktopAboutDialogOptions(
+      createFacts(),
+      BUILD_MS + 3 * DAY_MS,
+    );
+    expect(options.message).toBe("bb");
+    expect(options.buttons[options.copyButtonId]).toBe(
+      ABOUT_DIALOG_COPY_BUTTON_LABEL,
+    );
+    // Dismissing must never be the copy action: cancelId and defaultId both
+    // have to land on a different button.
+    expect(options.cancelId).not.toBe(options.copyButtonId);
+    expect(options.defaultId).not.toBe(options.copyButtonId);
+    expect(options.detail).toContain("3 days old");
+  });
+});
+
+describe("createDesktopAboutPanelOptions", () => {
+  it("puts the details in credits on macOS", () => {
+    const options = createDesktopAboutPanelOptions(createFacts());
+    expect(options.applicationVersion).toBe("0.39.0");
+    expect(options.credits).toContain("Electron: 41.7.0");
+  });
+
+  it("falls back to the version field on Linux, which has no credits field", () => {
+    const options = createDesktopAboutPanelOptions(
+      createFacts({ osType: "Linux", platform: "linux" }),
+    );
+    expect(options.credits).toBeUndefined();
+    expect(options.applicationVersion.startsWith("0.39.0\n\n")).toBe(true);
+    expect(options.applicationVersion).toContain("OS: Linux arm64 23.3.0");
+  });
+});

--- a/apps/desktop/test/menu.test.ts
+++ b/apps/desktop/test/menu.test.ts
@@ -31,6 +31,7 @@ function menuArgs(
     connectServersSkipReason: null,
     createNewWindow: () => {},
     isMac: true,
+    openAbout: () => {},
     openNewTab: () => {},
     openNewThread: () => {},
     openServerDaemonLogs: () => {},
@@ -54,6 +55,21 @@ function findServerSubmenu(
 }
 
 describe("application menu", () => {
+  it("opens the custom About dialog instead of the native panel", () => {
+    // The native `about` role cannot carry a Copy button, so the app menu must
+    // route through our own dialog.
+    const openAbout = vi.fn();
+    const template = buildApplicationMenuTemplate(
+      menuArgs(() => {}, { openAbout }),
+    );
+    const appSubmenu = template[0]?.submenu as MenuItemConstructorOptions[];
+    const aboutItem = appSubmenu.find((item) => item.label === "About bb");
+
+    expect(aboutItem?.role).toBeUndefined();
+    aboutItem?.click?.({} as never, undefined, {} as never);
+    expect(openAbout).toHaveBeenCalledTimes(1);
+  });
+
   it("closes a native panel when Electron omits its window", () => {
     vi.mocked(Menu.sendActionToFirstResponder).mockClear();
     const closeWindowOrSideTab = vi.fn();
@@ -176,8 +192,7 @@ describe("application menu", () => {
     );
     const appMenu = template[0]?.submenu as MenuItemConstructorOptions[];
     const windowMenu = template.find((item) => item.label === "Window");
-    const windowSubmenu =
-      windowMenu?.submenu as MenuItemConstructorOptions[];
+    const windowSubmenu = windowMenu?.submenu as MenuItemConstructorOptions[];
     const viewMenu = template.find((item) => item.label === "View");
     const viewSubmenu = viewMenu?.submenu as MenuItemConstructorOptions[];
     const fileMenu = template.find((item) => item.label === "File");
@@ -186,10 +201,7 @@ describe("application menu", () => {
       (item) => item.label === "Close Window",
     );
 
-    expect(appMenu.map((item) => item.role).filter(Boolean)).toEqual([
-      "about",
-      "quit",
-    ]);
+    expect(appMenu.map((item) => item.role).filter(Boolean)).toEqual(["quit"]);
     expect(windowSubmenu.map((item) => item.role).filter(Boolean)).toEqual([
       "minimize",
     ]);


### PR DESCRIPTION
## Human comments

it will be helpful for bug reports

Before:
<img width="290" height="194" alt="Screenshot 2026-08-21 at 1 11 47 PM" src="https://github.com/user-attachments/assets/46306fd2-df43-4886-91d7-8f08f91fd029" />


After:
<img width="290" height="348" alt="Screenshot 2026-08-21 at 1 11 36 PM" src="https://github.com/user-attachments/assets/feb0ced3-238b-4319-b5d0-174b1043f230" />


----

## What was wrong

The desktop About item was Electron's native `about` role, which shows the application name and version and nothing else. A user filing a bug could not say which build they were on: no commit, no build date, no stable/nightly channel, no Electron or plugin SDK version, and no way to tell a months-stale install from a fresh one. Maintainers had to ask for all of it by hand.

## What changed

- `apps/desktop/scripts/build.mjs` bakes three more facts into the Electron bundles next to the existing version and release channel: `BB_DESKTOP_COMMIT` (explicit env → `GITHUB_SHA` → `git rev-parse HEAD` → unknown), `BB_DESKTOP_BUILD_DATE` (ISO 8601, overridable), and the plugin SDK version read from `packages/plugin-sdk/package.json`. A checkout with no git metadata reports `Commit: unknown` rather than failing the build.
- `apps/desktop/src/desktop-about-panel.ts` (new) builds the detail block from those facts plus the runtime's Electron version and OS:

  ```
  Version: 0.39.0
  Build Type: Stable
  Commit: 042b3c1a4c53f2c3808067f519fbfc67b72cad80
  Date: 2026-06-27T06:41:01.941Z (3 days old)
  Plugin SDK: 0.4.12
  Electron: 41.7.0
  OS: Darwin arm64 23.3.0
  ```

- The app menu item is no longer `{ role: "about" }`. `menu.ts` renders `About <app name>` with a click handler and `main.ts` opens a message box with a **Copy** button that writes the whole block to the clipboard — the native panel has no way to carry a button. `createDesktopAboutDialogOptions` returns the copy button's index alongside the message-box options so the button and its handler cannot drift apart.
- The build age is computed when the dialog opens, not at launch, so a session left open for a week does not keep reporting "today". Clock skew reads as `today` instead of a negative age; an unparseable date drops the parenthetical.
- `app.setAboutPanelOptions` is still populated for any path that opens the native panel directly, minus the age, since Electron takes those options once at startup. Its detail block goes in `credits` on macOS and under `applicationVersion` on Linux, whose GTK dialog has no `credits` field.
- `apps/desktop/README.md` documents the two new build-time environment variables and the dialog's behavior.

No wire-format changes, so `HOST_DAEMON_PROTOCOL_VERSION` is untouched.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/desktop`
- Full `@bb/desktop` vitest suite: 36 files, 244 tests passing. New tests in `test/desktop-about-panel.test.ts` cover the day-boundary and clock-skew cases for the age, the Copy button id against `cancelId`/`defaultId`, the `unknown` fallbacks, and the Linux fallback; `test/menu.test.ts` gains a test that the item routes to the custom dialog with no `about` role left in the app menu. All of them fail before this change (the module and menu item do not exist).
- Ran `node scripts/build.mjs` and confirmed the real commit SHA, build timestamp, and plugin SDK version are inlined into `dist/main.js`.
- `test/preload-build.test.ts`, which boots real Electron and exercises the changed build script, passes.

Not verified: the rendered dialog itself was not opened by hand — clicking a native menu item is not scriptable here. `pnpm --filter @bb/desktop run dev`, then bb ▸ About, shows it.

> AGENT GENERATED