### PR TITLE
Keep each timeline message's action row inside its message

### DIFF
--- a/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
+++ b/apps/app/src/components/thread/timeline/ConversationMessageContent.tsx
@@ -495,7 +495,9 @@ function UserConversationMessage({
   const requestLabel = turnRequestLabel(turnRequest);
 
   return (
-    <div className="w-full">
+    // `data-message-column` marks the full timeline width for the action row,
+    // which expands into this column's empty gutter on touch.
+    <div className="w-full" data-message-column="">
       <div className="group/message ml-auto flex w-fit max-w-[70%] flex-col items-end">
         {requestLabel ? (
           <div className="mb-1 flex justify-end">
@@ -505,42 +507,50 @@ function UserConversationMessage({
             />
           </div>
         ) : null}
-        <div className="max-w-full rounded-xl border border-border-seam bg-surface-recessed px-4 py-2.5 text-sm leading-relaxed text-foreground">
-          {messageText ? (
-            <CollapsibleMessageText
-              mentions={mentions}
-              resolveMentionLink={resolveMentionLink}
-              resolveSegmentLinkHref={resolveSegmentLinkHref}
-              onOpenLink={onOpenLink}
-              text={text}
-              mutePrefixLength={mutePrefixLength || undefined}
+        {/*
+          Sub-column sized by the bubble alone (the action bar below fills it
+          without contributing intrinsic width), so the bar's measured slot is
+          exactly the bubble's width and its actions can never extend past the
+          bubble.
+        */}
+        <div className="flex w-fit max-w-full flex-col items-end">
+          <div className="max-w-full rounded-xl border border-border-seam bg-surface-recessed px-4 py-2.5 text-sm leading-relaxed text-foreground">
+            {messageText ? (
+              <CollapsibleMessageText
+                mentions={mentions}
+                resolveMentionLink={resolveMentionLink}
+                resolveSegmentLinkHref={resolveSegmentLinkHref}
+                onOpenLink={onOpenLink}
+                text={text}
+                mutePrefixLength={mutePrefixLength || undefined}
+              />
+            ) : (
+              <p className="text-muted-foreground">Sent attachments</p>
+            )}
+            <ConversationAttachments
+              align="end"
+              filePaths={attachmentItems.filePaths}
+              imageItems={attachmentItems.imageItems}
+              onOpenLocalFileLink={onOpenLocalFileLink}
+              projectId={projectId}
             />
-          ) : (
-            <p className="text-muted-foreground">Sent attachments</p>
-          )}
-          <ConversationAttachments
-            align="end"
-            filePaths={attachmentItems.filePaths}
-            imageItems={attachmentItems.imageItems}
-            onOpenLocalFileLink={onOpenLocalFileLink}
-            projectId={projectId}
+          </div>
+          {/*
+            The bar's slot sits in normal flow and reserves the row's height
+            whether or not the hover-revealed actions are showing; it renders
+            nothing at all when the message has no action. `MessageActionBar`
+            is the one place that decides which of those two cases holds.
+          */}
+          <MessageActionBar
+            messageText={messageText}
+            alignment="end"
+            mobileActionDisplay={mobileActionDisplay}
+            addToChatAttachments={addToChatAttachments}
+            onAddToChat={onAddToChat}
+            onEdit={onEdit}
+            pluginActions={pluginActions}
           />
         </div>
-        {/*
-          The bar sits in normal flow: it is hidden by opacity, so it occupies
-          its own height whether or not it is revealed, and it renders nothing
-          at all when the message has no action. `MessageActionBar` is the one
-          place that decides which of those two cases holds.
-        */}
-        <MessageActionBar
-          messageText={messageText}
-          alignment="end"
-          mobileActionDisplay={mobileActionDisplay}
-          addToChatAttachments={addToChatAttachments}
-          onAddToChat={onAddToChat}
-          onEdit={onEdit}
-          pluginActions={pluginActions}
-        />
       </div>
     </div>
   );
@@ -667,7 +677,10 @@ function AssistantConversationMessage({
   ]);
 
   return (
-    <div className="group/message w-full px-2 text-sm font-normal leading-relaxed">
+    <div
+      className="group/message w-full px-2 text-sm font-normal leading-relaxed"
+      data-message-column=""
+    >
       {/*
         Reports in-bounds text selections up to the timeline-level controller
         that drives the single floating selection menu (Add to chat / Reply in

--- a/apps/app/src/components/thread/timeline/MessageActionBar.test.tsx
+++ b/apps/app/src/components/thread/timeline/MessageActionBar.test.tsx
@@ -559,6 +559,42 @@ describe("MessageActionBar", () => {
     ).toBeTruthy();
   });
 
+  it("confirms a copy made from the revealed touch row on the trigger", async () => {
+    mockMobileCoarsePointer();
+    const resizeObserver = installControlledResizeObserver();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    render(
+      <div data-message-column="">
+        <MessageActionBar
+          messageText="Copy this answer."
+          alignment="end"
+          mobileActionDisplay="overflow"
+          onAddToChat={vi.fn()}
+          onFork={vi.fn()}
+        />
+      </div>,
+    );
+    // Nothing fits the bubble, so the row is just the trigger; the column has
+    // room, so tapping it reveals the actions in place.
+    resizeObserver.reportWidths({ slot: 54, column: 358 });
+
+    fireEvent.click(screen.getByRole("button", { name: "Message actions" }));
+    fireEvent.click(screen.getByRole("button", { name: "Copy message" }));
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith("Copy this answer."),
+    );
+    // The row collapsed on the tap, so the check has to land on the trigger
+    // that replaced it — otherwise the copy is silent.
+    const trigger = await screen.findByRole("button", {
+      name: "Message actions",
+    });
+    await waitFor(() =>
+      expect(trigger.querySelector('[data-icon="Check"]')).not.toBeNull(),
+    );
+  });
+
   it("keeps the popover when the column cannot fit the actions comfortably", () => {
     mockMobileCoarsePointer();
     const resizeObserver = installControlledResizeObserver();

--- a/apps/app/src/components/thread/timeline/MessageActionBar.test.tsx
+++ b/apps/app/src/components/thread/timeline/MessageActionBar.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -12,6 +13,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { COMPACT_VIEWPORT_QUERY } from "@bb/shared-ui/hooks/use-compact-viewport";
 import { POINTER_COARSE_QUERY } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import {
+  computeMessageActionRowLayout,
   findMessageActionTooltipCollisionBoundary,
   MessageActionBar,
 } from "./MessageActionBar";
@@ -19,7 +21,54 @@ import {
 afterEach(() => {
   cleanup();
   vi.restoreAllMocks();
+  vi.unstubAllGlobals();
 });
+
+/**
+ * Replaces the setup polyfill's inert ResizeObserver with one whose
+ * observations the test can drive. Entries carry only `contentRect`, matching
+ * the fallback path the component reads when box sizes are absent.
+ */
+function installControlledResizeObserver() {
+  const observations: { callback: ResizeObserverCallback; node: Element }[] =
+    [];
+  class ControlledResizeObserver {
+    readonly #callback: ResizeObserverCallback;
+    constructor(callback: ResizeObserverCallback) {
+      this.#callback = callback;
+    }
+    observe(node: Element) {
+      observations.push({ callback: this.#callback, node });
+    }
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal("ResizeObserver", ControlledResizeObserver);
+  const report = (widths: { slot: number; column: number }) => {
+    act(() => {
+      for (const { callback, node } of observations) {
+        const width = node.hasAttribute("data-message-column")
+          ? widths.column
+          : widths.slot;
+        callback(
+          [
+            {
+              target: node,
+              contentRect: { width, height: 20 },
+            } as unknown as ResizeObserverEntry,
+          ],
+          undefined as unknown as ResizeObserver,
+        );
+      }
+    });
+  };
+  return {
+    reportWidth(width: number) {
+      report({ slot: width, column: width });
+    },
+    reportWidths: report,
+  };
+}
 
 function mockMobileCoarsePointer() {
   vi.spyOn(window, "matchMedia").mockImplementation((query) => ({
@@ -388,6 +437,157 @@ describe("MessageActionBar", () => {
     ).toBeNull();
   });
 
+  it("collapses desktop actions that do not fit into a trailing overflow menu", () => {
+    const resizeObserver = installControlledResizeObserver();
+    const onAddToChat = vi.fn();
+    render(
+      <MessageActionBar
+        messageText="An answer."
+        alignment="end"
+        mobileActionDisplay="overflow"
+        onAddToChat={onAddToChat}
+        onFork={vi.fn()}
+      />,
+    );
+    // Three 20px actions with 8px gaps need 76px; a 44px slot fits one action
+    // plus the 20px "⋯" trigger at its tighter 4px gap (20 + 4 + 20).
+    resizeObserver.reportWidth(44);
+
+    expect(screen.getByRole("button", { name: "Copy message" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Add to chat" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Fork into new thread" }),
+    ).toBeNull();
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions" }));
+    expect(
+      screen.getByRole("menuitem", { name: "Fork into new thread" }),
+    ).toBeTruthy();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Add to chat" }));
+    expect(onAddToChat).toHaveBeenCalledWith("An answer.");
+  });
+
+  it("keeps every desktop action in the overflow menu when nothing fits inline", () => {
+    const resizeObserver = installControlledResizeObserver();
+    render(
+      <MessageActionBar
+        messageText="An answer."
+        alignment="end"
+        mobileActionDisplay="overflow"
+        onAddToChat={vi.fn()}
+        onFork={vi.fn()}
+      />,
+    );
+    resizeObserver.reportWidth(24);
+
+    expect(screen.queryByRole("button", { name: "Copy message" })).toBeNull();
+    fireEvent.pointerDown(screen.getByRole("button", { name: "More actions" }));
+    expect(
+      screen.getAllByRole("menuitem").map((item) => item.textContent),
+    ).toEqual(["Copy message", "Add to chat", "Fork into new thread"]);
+  });
+
+  it("collapses touch inline actions that do not fit into the mobile popover", () => {
+    mockMobileCoarsePointer();
+    const resizeObserver = installControlledResizeObserver();
+    const onFork = vi.fn();
+    render(
+      <MessageActionBar
+        messageText="An answer."
+        alignment="start"
+        mobileActionDisplay="inline"
+        onAddToChat={vi.fn()}
+        onFork={onFork}
+      />,
+    );
+    // Three 28px touch actions with 8px gaps need 100px; a 60px slot fits one
+    // action plus the 28px popover trigger at its 4px gap (28 + 4 + 28).
+    resizeObserver.reportWidth(60);
+
+    expect(screen.getByRole("button", { name: "Copy message" })).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Fork into new thread" }),
+    ).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Message actions" }));
+    const content =
+      document.body.querySelector<HTMLElement>('[data-side="top"]');
+    if (!content) throw new Error("Missing mobile message action menu");
+    expect(
+      within(content)
+        .getAllByRole("button")
+        .map((button) => button.textContent),
+    ).toEqual(["Add to chat", "Fork into new thread"]);
+    fireEvent.click(
+      within(content).getByRole("button", { name: "Fork into new thread" }),
+    );
+    expect(onFork).toHaveBeenCalledTimes(1);
+  });
+
+  it("expands the hidden touch actions inline when the column has room", () => {
+    mockMobileCoarsePointer();
+    const resizeObserver = installControlledResizeObserver();
+    const onAddToChat = vi.fn();
+    render(
+      <div data-message-column="">
+        <MessageActionBar
+          messageText="An answer."
+          alignment="end"
+          mobileActionDisplay="overflow"
+          onAddToChat={onAddToChat}
+          onFork={vi.fn()}
+        />
+      </div>,
+    );
+    // Bubble fits nothing; the 358px column fits all three 28px actions.
+    resizeObserver.reportWidths({ slot: 54, column: 358 });
+
+    fireEvent.click(screen.getByRole("button", { name: "Message actions" }));
+
+    expect(
+      screen
+        .getAllByRole("button")
+        .map((button) => button.getAttribute("aria-label")),
+    ).toEqual(["Copy message", "Add to chat", "Fork into new thread"]);
+    expect(document.body.querySelector('[data-side="top"]')).toBeNull();
+
+    // Choosing an action runs it and collapses the row again.
+    fireEvent.click(screen.getByRole("button", { name: "Add to chat" }));
+    expect(onAddToChat).toHaveBeenCalledWith("An answer.");
+    expect(
+      screen.getByRole("button", { name: "Message actions" }),
+    ).toBeTruthy();
+  });
+
+  it("keeps the popover when the column cannot fit the actions comfortably", () => {
+    mockMobileCoarsePointer();
+    const resizeObserver = installControlledResizeObserver();
+    render(
+      <div data-message-column="">
+        <MessageActionBar
+          messageText="An answer."
+          alignment="end"
+          mobileActionDisplay="overflow"
+          onAddToChat={vi.fn()}
+          onFork={vi.fn()}
+        />
+      </div>,
+    );
+    // Three actions need 100px; 110px leaves less than the comfort margin.
+    resizeObserver.reportWidths({ slot: 54, column: 110 });
+
+    fireEvent.click(screen.getByRole("button", { name: "Message actions" }));
+
+    const content =
+      document.body.querySelector<HTMLElement>('[data-side="top"]');
+    if (!content) throw new Error("Missing mobile message action menu");
+    expect(
+      within(content)
+        .getAllByRole("button")
+        .map((button) => button.textContent),
+    ).toEqual(["Copy message", "Add to chat", "Fork into new thread"]);
+  });
+
   it("mounts the tooltip bar on fine-pointer viewports", () => {
     render(
       <MessageActionBar
@@ -399,5 +599,70 @@ describe("MessageActionBar", () => {
     );
     const fork = screen.getByRole("button", { name: "Fork into new thread" });
     expect(fork.getAttribute("data-state")).toBe("closed");
+  });
+});
+
+describe("computeMessageActionRowLayout", () => {
+  const metrics = { actionWidth: 20, overflowTriggerWidth: 20 };
+
+  it("renders everything inline before the slot is measured", () => {
+    expect(
+      computeMessageActionRowLayout({
+        actionCount: 5,
+        availableWidth: undefined,
+        ...metrics,
+      }),
+    ).toEqual({ inlineCount: 5, overflowCount: 0 });
+  });
+
+  it("keeps all actions inline when they exactly fit", () => {
+    // 3 × 20px + 2 × 8px gaps = 76px.
+    expect(
+      computeMessageActionRowLayout({
+        actionCount: 3,
+        availableWidth: 76,
+        ...metrics,
+      }),
+    ).toEqual({ inlineCount: 3, overflowCount: 0 });
+  });
+
+  it("collapses the tail once the full row would overflow", () => {
+    // One pixel short of fitting all three (76px): two actions plus the
+    // trigger at its 4px gap need 20 + 8 + 20 + 4 + 20 = 72px and fit.
+    expect(
+      computeMessageActionRowLayout({
+        actionCount: 3,
+        availableWidth: 75,
+        ...metrics,
+      }),
+    ).toEqual({ inlineCount: 2, overflowCount: 1 });
+    // Below 72px the second action also collapses.
+    expect(
+      computeMessageActionRowLayout({
+        actionCount: 3,
+        availableWidth: 71,
+        ...metrics,
+      }),
+    ).toEqual({ inlineCount: 1, overflowCount: 2 });
+  });
+
+  it("puts every action in the menu when not even one fits beside the trigger", () => {
+    expect(
+      computeMessageActionRowLayout({
+        actionCount: 3,
+        availableWidth: 30,
+        ...metrics,
+      }),
+    ).toEqual({ inlineCount: 0, overflowCount: 3 });
+  });
+
+  it("returns an empty layout for zero actions", () => {
+    expect(
+      computeMessageActionRowLayout({
+        actionCount: 0,
+        availableWidth: 400,
+        ...metrics,
+      }),
+    ).toEqual({ inlineCount: 0, overflowCount: 0 });
   });
 });

--- a/apps/app/src/components/thread/timeline/MessageActionBar.tsx
+++ b/apps/app/src/components/thread/timeline/MessageActionBar.tsx
@@ -351,6 +351,22 @@ const ACTION_ROW_CLASS =
 // neighbouring rows while it does.
 const ACTION_ROW_EXPANDED_CLASS = "absolute top-0 z-10 flex items-center gap-2";
 
+// Optical alignment: the row lines up with the message's *text*, not its
+// border box. A bubble insets its text by 16px padding + 1px border, and each
+// icon carries slack inside its larger hit box (a 20px box around a 12px glyph
+// on desktop, 28px around 16px on touch), so the row is inset by the
+// difference and the outer glyph edge lands on the text edge. Without it the
+// glyph sits 4px from the bubble's edge — inside its 12px corner radius, so it
+// reads as hanging off the message.
+const BUBBLE_ALIGN_INSET_CLASS = "pr-[13px] max-md:pointer-coarse:pr-[11px]";
+// The row is absolutely positioned, so it resolves `right` against the slot's
+// padding box — the padding above shrinks the measured budget but cannot move
+// the row. Offset it by the same amount to place it.
+const BUBBLE_ALIGN_OFFSET_CLASS =
+  "right-[13px] max-md:pointer-coarse:right-[11px]";
+// Prose rows have no bubble padding, so only the hit-box slack is corrected.
+const PROSE_ALIGN_INSET_CLASS = "-ml-1 max-md:pointer-coarse:-ml-1.5";
+
 export function findMessageActionTooltipCollisionBoundary(
   node: HTMLElement | null,
 ): HTMLElement | undefined {
@@ -584,7 +600,15 @@ export function MessageActionBar({
 
   const rowClass = cn(
     ACTION_ROW_CLASS,
-    alignment === "end" ? "right-0" : "left-0",
+    alignment === "end"
+      ? BUBBLE_ALIGN_OFFSET_CLASS
+      : cn("left-0", PROSE_ALIGN_INSET_CLASS),
+  );
+  // Padding on the slot, so the measured width is the text width the row has
+  // to fit into rather than the bubble's full border box.
+  const slotClass = cn(
+    "relative w-full",
+    alignment === "end" && BUBBLE_ALIGN_INSET_CLASS,
   );
 
   if (useMobileOverflowPopover) {
@@ -610,12 +634,14 @@ export function MessageActionBar({
         columnWidth - EXPANDED_ROW_COMFORT_PX;
     if (expanded && canExpandInline) {
       return (
-        <div ref={slotRef} className="relative h-7 w-full">
+        <div ref={slotRef} className={cn(slotClass, "h-7")}>
           <div
             ref={expandedRowRef}
             className={cn(
               ACTION_ROW_EXPANDED_CLASS,
-              alignment === "end" ? "right-0" : "left-0",
+              alignment === "end"
+                ? BUBBLE_ALIGN_OFFSET_CLASS
+                : cn("left-0", PROSE_ALIGN_INSET_CLASS),
             )}
             onClick={handleExpandedRowClick}
           >
@@ -625,7 +651,7 @@ export function MessageActionBar({
       );
     }
     return (
-      <div ref={slotRef} className="relative h-7 w-full">
+      <div ref={slotRef} className={cn(slotClass, "h-7")}>
         <div className={rowClass}>
           {layout.inlineCount > 0 ? (
             <MobileInlineActions
@@ -675,7 +701,7 @@ export function MessageActionBar({
     <TooltipProvider delayDuration={300}>
       <div
         ref={desktopSlotRef}
-        className="relative h-5 w-full max-md:pointer-coarse:h-7"
+        className={cn(slotClass, "h-5 max-md:pointer-coarse:h-7")}
       >
         <div className={rowClass}>
           {actions.slice(0, layout.inlineCount).map((action) => (

--- a/apps/app/src/components/thread/timeline/MessageActionBar.tsx
+++ b/apps/app/src/components/thread/timeline/MessageActionBar.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent,
+} from "react";
 import { flushSync } from "react-dom";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { CopyButton } from "../../ui/copy-button.js";
@@ -81,14 +87,147 @@ interface MessageOverflowAction {
   kind?: "copy";
 }
 
+// ---------------------------------------------------------------------------
+// Width-aware layout: the row must never extend past the message it belongs
+// to, so actions that don't fit the measured slot collapse into a trailing
+// "⋯" menu instead of widening or wrapping the row.
+// ---------------------------------------------------------------------------
+
+/**
+ * Pixel metrics mirrored from the Tailwind classes on the rendered controls:
+ * `size-5` desktop buttons, `size-7` touch buttons, `gap-2` between them. The
+ * fit computation needs them as numbers — keep in sync with the class
+ * constants below.
+ */
+const DESKTOP_ACTION_WIDTH_PX = 20;
+const TOUCH_ACTION_WIDTH_PX = 28;
+const ACTION_ROW_GAP_PX = 8;
+/**
+ * The "⋯" trigger sits tighter to the last inline action than actions sit to
+ * each other (`-ml-1` on the trigger: 8px row gap minus 4px), so it reads as
+ * the row's continuation rather than one more action.
+ */
+const OVERFLOW_TRIGGER_GAP_PX = 4;
+const OVERFLOW_TRIGGER_TIGHTEN_CLASS = "-ml-1";
+/**
+ * Breathing room the expanded touch row must leave inside the timeline column.
+ * Below it the row would butt against the column edge, so the popover is used
+ * instead.
+ */
+const EXPANDED_ROW_COMFORT_PX = 16;
+
+/** Width of `count` actions laid out in one row at the shared gap. */
+function actionRowWidth(count: number, actionWidth: number): number {
+  return count <= 0 ? 0 : count * actionWidth + (count - 1) * ACTION_ROW_GAP_PX;
+}
+
+interface MessageActionRowLayout {
+  /** Leading actions rendered as direct buttons. */
+  inlineCount: number;
+  /** Trailing actions collapsed into the "⋯" overflow menu. */
+  overflowCount: number;
+}
+
+export function computeMessageActionRowLayout({
+  actionCount,
+  availableWidth,
+  actionWidth,
+  overflowTriggerWidth,
+}: {
+  actionCount: number;
+  /** Measured slot width; undefined until the ResizeObserver first reports. */
+  availableWidth: number | undefined;
+  actionWidth: number;
+  overflowTriggerWidth: number;
+}): MessageActionRowLayout {
+  if (actionCount <= 0) {
+    return { inlineCount: 0, overflowCount: 0 };
+  }
+  if (availableWidth === undefined) {
+    // Unmeasured (pre-observation frame, or an environment without a working
+    // ResizeObserver): render everything inline rather than nothing. The
+    // desktop bar is opacity-hidden until hover, so nothing flashes.
+    return { inlineCount: actionCount, overflowCount: 0 };
+  }
+  if (actionRowWidth(actionCount, actionWidth) <= availableWidth) {
+    return { inlineCount: actionCount, overflowCount: 0 };
+  }
+  // K inline actions need K-1 row gaps, then the trigger gap and the trigger:
+  // K·a + (K-1)·g + tg + t ≤ W  ⇔  K ≤ (W - t - tg + g) / (a + g).
+  const inlineCount = Math.max(
+    0,
+    Math.min(
+      actionCount - 1,
+      Math.floor(
+        (availableWidth -
+          overflowTriggerWidth -
+          OVERFLOW_TRIGGER_GAP_PX +
+          ACTION_ROW_GAP_PX) /
+          (actionWidth + ACTION_ROW_GAP_PX),
+      ),
+    ),
+  );
+  return { inlineCount, overflowCount: actionCount - inlineCount };
+}
+
+/**
+ * Width of the action row's slot. A callback ref (rather than an object ref
+ * plus a mount effect) so the observer re-attaches when the bar swaps between
+ * its desktop and touch trees — an effect keyed on mount would keep observing
+ * the unmounted tree's detached node.
+ */
+function useMeasuredWidth(
+  resolveTarget?: (node: HTMLElement) => Element | null,
+): {
+  measureRef: (node: HTMLElement | null) => void;
+  width: number | undefined;
+} {
+  const [width, setWidth] = useState<number | undefined>(undefined);
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const measureRef = useCallback(
+    (node: HTMLElement | null) => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+      if (node === null || typeof ResizeObserver === "undefined") {
+        return;
+      }
+      const target = resolveTarget ? resolveTarget(node) : node;
+      if (target === null) {
+        return;
+      }
+      const observer = new ResizeObserver(([entry]) => {
+        const inlineSize =
+          entry.contentBoxSize?.[0]?.inlineSize ?? entry.contentRect.width;
+        // Floor so a fractional slot never admits a row one pixel too wide.
+        setWidth(Math.floor(inlineSize));
+      });
+      observer.observe(target);
+      observerRef.current = observer;
+    },
+    [resolveTarget],
+  );
+  return { measureRef, width };
+}
+
+/**
+ * The message column this row belongs to — the full timeline width, which for
+ * a right-aligned user message is much wider than its bubble. Module-level so
+ * the measuring callback ref stays stable across renders.
+ */
+const resolveMessageColumn = (node: HTMLElement): Element | null =>
+  node.closest("[data-message-column]");
+
 interface MobileMessageOverflowPopoverProps {
   actions: readonly MessageOverflowAction[];
   alignment: MessageActionBarProps["alignment"];
+  /** Extra trigger classes (the tightened gap when inline actions precede it). */
+  triggerClassName?: string;
 }
 
 function MobileMessageOverflowPopover({
   actions,
   alignment,
+  triggerClassName,
 }: MobileMessageOverflowPopoverProps) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
@@ -109,7 +248,7 @@ function MobileMessageOverflowPopover({
       <PopoverPrimitive.Trigger asChild>
         <button
           type="button"
-          className={MOBILE_OVERFLOW_TRIGGER_CLASS}
+          className={cn(MOBILE_OVERFLOW_TRIGGER_CLASS, triggerClassName)}
           aria-label="Message actions"
           data-no-sidebar-swipe=""
           onMouseDown={preventOverlayTriggerSelection}
@@ -188,10 +327,29 @@ const MOBILE_OVERFLOW_ACTION_CLASS = "max-md:pointer-coarse:hidden";
 const MOBILE_OVERFLOW_TRIGGER_CLASS =
   "hidden size-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:text-foreground data-[state=open]:bg-state-active data-[state=open]:text-foreground max-md:pointer-coarse:inline-flex max-md:pointer-coarse:[&_svg]:size-4";
 const ACTION_TOOLTIP_SIDE = "bottom";
+// Menus size to their widest label rather than a fixed width, so a two-item
+// menu is not as wide as a six-item one. The cap keeps a long plugin label
+// from running off a narrow viewport (it wraps instead).
+const MENU_CONTENT_WIDTH_CLASS = "max-w-[min(16rem,calc(100vw-1rem))]";
 const MOBILE_OVERFLOW_CONTENT_CLASS =
-  "z-50 flex max-h-[50dvh] w-44 flex-col gap-0.5 overflow-y-auto rounded-md border bg-popover p-0.5 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95";
+  "z-50 flex max-h-[50dvh] w-max min-w-32 max-w-[min(15rem,calc(100vw-1.5rem))] flex-col gap-0.5 overflow-y-auto rounded-md border bg-popover p-0.5 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95";
 const MOBILE_OVERFLOW_ITEM_CLASS =
   "flex min-h-8 w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-left text-xs text-foreground transition-colors hover:bg-surface-recessed focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring active:bg-state-active disabled:pointer-events-none disabled:opacity-40 select-none";
+
+// The slot wrapper is `relative w-full` and reserves the row's height; the row
+// itself is absolutely positioned so its content can never contribute
+// intrinsic width to a fit-content message column (which would let a wide row
+// widen the column past the bubble).
+// `has-[[data-state=open]]` keeps the whole row revealed while its overflow
+// menu is open — without it the hover-reveal fades the inline actions out the
+// moment the pointer moves onto the menu. Radix tooltips use `delayed-open`,
+// so only the menu/popover trigger matches.
+const ACTION_ROW_CLASS =
+  "absolute top-0 flex max-w-full items-center gap-2 overflow-hidden has-[[data-state=open]]:[&_button]:opacity-100";
+// The expanded touch row drops `max-w-full`/`overflow-hidden` so it can reach
+// past a narrow bubble into the empty gutter beside it, and sits above
+// neighbouring rows while it does.
+const ACTION_ROW_EXPANDED_CLASS = "absolute top-0 z-10 flex items-center gap-2";
 
 export function findMessageActionTooltipCollisionBoundary(
   node: HTMLElement | null,
@@ -199,11 +357,90 @@ export function findMessageActionTooltipCollisionBoundary(
   return node?.closest<HTMLElement>("[data-thread-window]") ?? undefined;
 }
 
+/** One hover-revealed desktop action: an icon button with a tooltip. */
+function DesktopMessageAction({
+  action,
+  className,
+  collisionBoundary,
+}: {
+  action: MessageOverflowAction;
+  className: string;
+  collisionBoundary: HTMLElement | undefined;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        {action.kind === "copy" ? (
+          <CopyButton
+            text={action.copyText ?? ""}
+            label={action.label}
+            className={className}
+          />
+        ) : (
+          <button
+            type="button"
+            className={cn(ACTION_BUTTON_CLASS, className)}
+            onClick={action.onSelect}
+            disabled={action.disabled}
+            aria-label={action.label}
+          >
+            {action.plugin ? (
+              <PluginActionIcon
+                pluginId={action.plugin.pluginId}
+                icon={action.plugin.icon}
+                className="size-3"
+              />
+            ) : (
+              <Icon name={action.icon} className="size-3" />
+            )}
+          </button>
+        )}
+      </TooltipTrigger>
+      <TooltipContent
+        side={ACTION_TOOLTIP_SIDE}
+        collisionBoundary={collisionBoundary}
+      >
+        {action.label}
+      </TooltipContent>
+    </Tooltip>
+  );
+}
+
+/** Dropdown items shared by the "⋯" overflow menu and the mobile fallback. */
+function MessageActionMenuItems({
+  actions,
+}: {
+  actions: readonly MessageOverflowAction[];
+}) {
+  return actions.map((action) => (
+    <DropdownMenuItem
+      key={action.key ?? action.label}
+      disabled={action.disabled}
+      onSelect={action.onSelect}
+      textValue={action.label}
+    >
+      {action.plugin ? (
+        <PluginActionIcon
+          pluginId={action.plugin.pluginId}
+          icon={action.plugin.icon}
+        />
+      ) : (
+        <Icon name={action.icon} aria-hidden="true" />
+      )}
+      {action.label}
+    </DropdownMenuItem>
+  ));
+}
+
 /**
  * Hover-revealed footer of per-message actions. Renders an action only when it
  * is meaningful: copy when there is text, add-to-chat when a composer owns the
  * draft, and fork when its handler is supplied. `disabled` greys the fork
  * button (e.g. at the depth cap) while leaving copy and add-to-chat usable.
+ *
+ * The row tracks the width of the message it belongs to: its slot is measured
+ * with a ResizeObserver and actions that don't fit collapse into a trailing
+ * "⋯" menu, so the row never extends past the bubble or wraps.
  */
 export function MessageActionBar({
   messageText,
@@ -225,13 +462,50 @@ export function MessageActionBar({
   const [collisionBoundary, setCollisionBoundary] = useState<
     HTMLElement | undefined
   >();
+  const { measureRef, width: availableWidth } = useMeasuredWidth();
+  const { measureRef: measureColumnRef, width: columnWidth } =
+    useMeasuredWidth(resolveMessageColumn);
+  // Touch-only: the hidden actions revealed in place by the "⋯" trigger.
+  const [expanded, setExpanded] = useState(false);
+  const expandedRowRef = useRef<HTMLDivElement | null>(null);
+  const slotRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      measureRef(node);
+      measureColumnRef(node);
+    },
+    [measureRef, measureColumnRef],
+  );
+  const desktopSlotRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      slotRef(node);
+      setCollisionBoundary(findMessageActionTooltipCollisionBoundary(node));
+    },
+    [slotRef],
+  );
+  useEffect(() => {
+    if (!expanded) return;
+    // Capture phase so a tap that also opens something else still collapses.
+    const handlePointerDown = (event: PointerEvent) => {
+      const row = expandedRowRef.current;
+      if (row && event.target instanceof Node && row.contains(event.target)) {
+        return;
+      }
+      setExpanded(false);
+    };
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    return () =>
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+  }, [expanded]);
+  // Bubble phase, so the action's own handler has already run.
+  const handleExpandedRowClick = (event: MouseEvent<HTMLDivElement>) => {
+    if ((event.target as HTMLElement | null)?.closest("button")) {
+      setExpanded(false);
+    }
+  };
   const mobileDirectActionClass =
     mobileActionDisplay === "inline"
       ? MOBILE_INLINE_ACTION_CLASS
       : MOBILE_OVERFLOW_ACTION_CLASS;
-  const containerRef = useCallback((node: HTMLDivElement | null) => {
-    setCollisionBoundary(findMessageActionTooltipCollisionBoundary(node));
-  }, []);
   const handleAddToChat = useCallback(() => {
     if (!onAddToChat) return;
     if (addToChatAttachments.length > 0) {
@@ -240,7 +514,7 @@ export function MessageActionBar({
     }
     onAddToChat(messageText);
   }, [addToChatAttachments, messageText, onAddToChat]);
-  const overflowActions: MessageOverflowAction[] = [
+  const actions: MessageOverflowAction[] = [
     ...(hasCopy
       ? [
           {
@@ -304,229 +578,168 @@ export function MessageActionBar({
   ];
   const useMobileOverflowPopover = isCompactViewport && isPointerCoarse;
 
-  if (
-    !hasCopy &&
-    !onEdit &&
-    !hasAddToChat &&
-    !onFork &&
-    !onSendToMain &&
-    pluginActions.length === 0
-  ) {
+  if (actions.length === 0) {
     return null;
   }
+
+  const rowClass = cn(
+    ACTION_ROW_CLASS,
+    alignment === "end" ? "right-0" : "left-0",
+  );
 
   if (useMobileOverflowPopover) {
     // Touch phones: no hover, so no tooltips. Mounting the desktop bar here
     // would put five-plus hidden Radix tooltip trees per message into the
     // timeline for nothing; render only the mobile surface.
+    const layout =
+      mobileActionDisplay === "overflow"
+        ? { inlineCount: 0, overflowCount: actions.length }
+        : computeMessageActionRowLayout({
+            actionCount: actions.length,
+            availableWidth,
+            actionWidth: TOUCH_ACTION_WIDTH_PX,
+            overflowTriggerWidth: TOUCH_ACTION_WIDTH_PX,
+          });
+    // Tapping "⋯" reveals the hidden actions in place when the whole set fits
+    // the timeline column with room to spare — the row then reaches past a
+    // narrow bubble into the empty gutter beside it. When even the column is
+    // too tight the popover stays: it scrolls and can never clip.
+    const canExpandInline =
+      columnWidth !== undefined &&
+      actionRowWidth(actions.length, TOUCH_ACTION_WIDTH_PX) <=
+        columnWidth - EXPANDED_ROW_COMFORT_PX;
+    if (expanded && canExpandInline) {
+      return (
+        <div ref={slotRef} className="relative h-7 w-full">
+          <div
+            ref={expandedRowRef}
+            className={cn(
+              ACTION_ROW_EXPANDED_CLASS,
+              alignment === "end" ? "right-0" : "left-0",
+            )}
+            onClick={handleExpandedRowClick}
+          >
+            <MobileInlineActions actions={actions} />
+          </div>
+        </div>
+      );
+    }
     return (
-      <div
-        className={cn(
-          "flex items-center gap-2",
-          alignment === "end" ? "justify-end" : "justify-start",
-        )}
-      >
-        {mobileActionDisplay === "overflow" ? (
-          <MobileMessageOverflowPopover
-            actions={overflowActions}
-            alignment={alignment}
-          />
-        ) : (
-          <MobileInlineActions actions={overflowActions} />
-        )}
+      <div ref={slotRef} className="relative h-7 w-full">
+        <div className={rowClass}>
+          {layout.inlineCount > 0 ? (
+            <MobileInlineActions
+              actions={actions.slice(0, layout.inlineCount)}
+            />
+          ) : null}
+          {layout.overflowCount > 0 ? (
+            canExpandInline ? (
+              <button
+                type="button"
+                className={cn(
+                  MOBILE_OVERFLOW_TRIGGER_CLASS,
+                  layout.inlineCount > 0 && OVERFLOW_TRIGGER_TIGHTEN_CLASS,
+                )}
+                aria-label="Message actions"
+                aria-expanded={false}
+                data-no-sidebar-swipe=""
+                onClick={() => setExpanded(true)}
+              >
+                <Icon name="MoreHorizontal" className="size-3" />
+              </button>
+            ) : (
+              <MobileMessageOverflowPopover
+                actions={actions.slice(layout.inlineCount)}
+                alignment={alignment}
+                triggerClassName={
+                  layout.inlineCount > 0
+                    ? OVERFLOW_TRIGGER_TIGHTEN_CLASS
+                    : undefined
+                }
+              />
+            )
+          ) : null}
+        </div>
       </div>
     );
   }
 
+  const layout = computeMessageActionRowLayout({
+    actionCount: actions.length,
+    availableWidth,
+    actionWidth: DESKTOP_ACTION_WIDTH_PX,
+    overflowTriggerWidth: DESKTOP_ACTION_WIDTH_PX,
+  });
+
   return (
     <TooltipProvider delayDuration={300}>
       <div
-        ref={containerRef}
-        className={cn(
-          "flex items-center gap-2",
-          alignment === "end" ? "justify-end" : "justify-start",
-        )}
+        ref={desktopSlotRef}
+        className="relative h-5 w-full max-md:pointer-coarse:h-7"
       >
-        {hasCopy ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <CopyButton
-                text={messageText}
-                label="Copy message"
-                className={cn(HOVER_REVEAL_CLASS, mobileDirectActionClass)}
-              />
-            </TooltipTrigger>
-            <TooltipContent
-              side={ACTION_TOOLTIP_SIDE}
+        <div className={rowClass}>
+          {actions.slice(0, layout.inlineCount).map((action) => (
+            <DesktopMessageAction
+              key={action.key ?? action.label}
+              action={action}
+              className={cn(HOVER_REVEAL_CLASS, mobileDirectActionClass)}
               collisionBoundary={collisionBoundary}
-            >
-              Copy message
-            </TooltipContent>
-          </Tooltip>
-        ) : null}
-        {onEdit ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                className={cn(
-                  ACTION_BUTTON_CLASS,
-                  HOVER_REVEAL_CLASS,
-                  mobileDirectActionClass,
-                )}
-                onClick={onEdit}
-                aria-label="Edit message"
-              >
-                <Icon name="Edit" className="size-3" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent
-              side={ACTION_TOOLTIP_SIDE}
-              collisionBoundary={collisionBoundary}
-            >
-              Edit message
-            </TooltipContent>
-          </Tooltip>
-        ) : null}
-        {hasAddToChat ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                className={cn(
-                  ACTION_BUTTON_CLASS,
-                  HOVER_REVEAL_CLASS,
-                  mobileDirectActionClass,
-                )}
-                onClick={handleAddToChat}
-                aria-label="Add to chat"
-              >
-                <Icon name="MessageSquarePlus" className="size-3" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent
-              side={ACTION_TOOLTIP_SIDE}
-              collisionBoundary={collisionBoundary}
-            >
-              Add to chat
-            </TooltipContent>
-          </Tooltip>
-        ) : null}
-        {onSendToMain ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                className={cn(
-                  ACTION_BUTTON_CLASS,
-                  HOVER_REVEAL_CLASS,
-                  mobileDirectActionClass,
-                )}
-                onClick={onSendToMain}
-                aria-label="Send to main thread"
-              >
-                <Icon name="ArrowTurnBackward" className="size-3" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent
-              side={ACTION_TOOLTIP_SIDE}
-              collisionBoundary={collisionBoundary}
-            >
-              Send to main thread
-            </TooltipContent>
-          </Tooltip>
-        ) : null}
-        {onFork ? (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                className={cn(
-                  ACTION_BUTTON_CLASS,
-                  HOVER_REVEAL_CLASS,
-                  mobileDirectActionClass,
-                )}
-                onClick={onFork}
-                disabled={disabled}
-                aria-label="Fork into new thread"
-              >
-                <Icon name="Fork" className="size-3" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent
-              side={ACTION_TOOLTIP_SIDE}
-              collisionBoundary={collisionBoundary}
-            >
-              Fork into new thread
-            </TooltipContent>
-          </Tooltip>
-        ) : null}
-        {pluginActions.map((action) => (
-          <Tooltip key={action.key}>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                className={cn(
-                  ACTION_BUTTON_CLASS,
-                  HOVER_REVEAL_CLASS,
-                  mobileDirectActionClass,
-                )}
-                onClick={action.onSelect}
-                aria-label={action.label}
-              >
-                <PluginActionIcon
-                  pluginId={action.pluginId}
-                  icon={action.icon}
-                  className="size-3"
-                />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent
-              side={ACTION_TOOLTIP_SIDE}
-              collisionBoundary={collisionBoundary}
-            >
-              {action.label}
-            </TooltipContent>
-          </Tooltip>
-        ))}
-        {mobileActionDisplay === "overflow" ? (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                className={MOBILE_OVERFLOW_TRIGGER_CLASS}
-                aria-label="Message actions"
-                data-no-sidebar-swipe=""
-              >
-                <Icon name="MoreHorizontal" className="size-3" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align={alignment === "end" ? "end" : "start"}
-              mobileTitle="Message actions"
-              className="w-48"
-            >
-              {overflowActions.map((action) => (
-                <DropdownMenuItem
-                  key={action.key ?? action.label}
-                  disabled={action.disabled}
-                  onSelect={action.onSelect}
-                  textValue={action.label}
-                >
-                  {action.plugin ? (
-                    <PluginActionIcon
-                      pluginId={action.plugin.pluginId}
-                      icon={action.plugin.icon}
-                    />
-                  ) : (
-                    <Icon name={action.icon} aria-hidden="true" />
+            />
+          ))}
+          {layout.overflowCount > 0 ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className={cn(
+                    ACTION_BUTTON_CLASS,
+                    HOVER_REVEAL_CLASS,
+                    mobileDirectActionClass,
+                    layout.inlineCount > 0 && OVERFLOW_TRIGGER_TIGHTEN_CLASS,
+                    "data-[state=open]:text-foreground data-[state=open]:opacity-100",
                   )}
-                  {action.label}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        ) : null}
+                  aria-label="More actions"
+                >
+                  <Icon name="MoreHorizontal" className="size-3" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align={alignment === "end" ? "end" : "start"}
+                mobileTitle="Message actions"
+                className={MENU_CONTENT_WIDTH_CLASS}
+              >
+                <MessageActionMenuItems
+                  actions={actions.slice(layout.inlineCount)}
+                />
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : null}
+          {mobileActionDisplay === "overflow" ? (
+            // CSS-only fallback for a coarse-pointer compact viewport rendered
+            // through this tree (media queries and the JS hooks can disagree
+            // for a frame): all inline buttons hide and this trigger, holding
+            // every action, shows instead.
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className={MOBILE_OVERFLOW_TRIGGER_CLASS}
+                  aria-label="Message actions"
+                  data-no-sidebar-swipe=""
+                >
+                  <Icon name="MoreHorizontal" className="size-3" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align={alignment === "end" ? "end" : "start"}
+                mobileTitle="Message actions"
+                className={MENU_CONTENT_WIDTH_CLASS}
+              >
+                <MessageActionMenuItems actions={actions} />
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : null}
+        </div>
       </div>
     </TooltipProvider>
   );

--- a/apps/app/src/components/thread/timeline/MessageActionBar.tsx
+++ b/apps/app/src/components/thread/timeline/MessageActionBar.tsx
@@ -518,6 +518,15 @@ export function MessageActionBar({
       setExpanded(false);
     }
   };
+  // Copying from the expanded row collapses it, which unmounts the button
+  // before its own check can appear. Confirm on the trigger that replaces it,
+  // the same way the popover confirms on its trigger.
+  const [copiedFromRow, setCopiedFromRow] = useState(false);
+  useEffect(() => {
+    if (!copiedFromRow) return;
+    const timeoutId = window.setTimeout(() => setCopiedFromRow(false), 2000);
+    return () => window.clearTimeout(timeoutId);
+  }, [copiedFromRow]);
   const mobileDirectActionClass =
     mobileActionDisplay === "inline"
       ? MOBILE_INLINE_ACTION_CLASS
@@ -645,7 +654,10 @@ export function MessageActionBar({
             )}
             onClick={handleExpandedRowClick}
           >
-            <MobileInlineActions actions={actions} />
+            <MobileInlineActions
+              actions={actions}
+              onCopied={() => setCopiedFromRow(true)}
+            />
           </div>
         </div>
       );
@@ -671,7 +683,13 @@ export function MessageActionBar({
                 data-no-sidebar-swipe=""
                 onClick={() => setExpanded(true)}
               >
-                <Icon name="MoreHorizontal" className="size-3" />
+                <Icon
+                  name={copiedFromRow ? "Check" : "MoreHorizontal"}
+                  className={cn(
+                    "size-3",
+                    copiedFromRow && "animate-in zoom-in-50 duration-150",
+                  )}
+                />
               </button>
             ) : (
               <MobileMessageOverflowPopover
@@ -777,17 +795,46 @@ export function MessageActionBar({
  */
 function MobileInlineActions({
   actions,
+  onCopied,
 }: {
   actions: readonly MessageOverflowAction[];
+  /**
+   * Set when this row is about to be unmounted by the copy click itself, so
+   * `CopyButton`'s own check would never be seen; the caller confirms instead.
+   */
+  onCopied?: () => void;
 }) {
   return actions.map((action) =>
     action.kind === "copy" ? (
-      <CopyButton
-        key={action.key ?? action.label}
-        text={action.copyText ?? ""}
-        label={action.label}
-        className={cn(HOVER_REVEAL_CLASS, MOBILE_INLINE_ACTION_CLASS)}
-      />
+      onCopied ? (
+        <button
+          key={action.key ?? action.label}
+          type="button"
+          className={cn(
+            ACTION_BUTTON_CLASS,
+            HOVER_REVEAL_CLASS,
+            MOBILE_INLINE_ACTION_CLASS,
+          )}
+          onClick={() => {
+            void copyToClipboardWithToast(action.copyText ?? "", {
+              successMessage: null,
+              errorMessage: "Failed to copy",
+            }).then((didCopy) => {
+              if (didCopy) onCopied();
+            });
+          }}
+          aria-label={action.label}
+        >
+          <Icon name="Copy" className="size-3" />
+        </button>
+      ) : (
+        <CopyButton
+          key={action.key ?? action.label}
+          text={action.copyText ?? ""}
+          label={action.label}
+          className={cn(HOVER_REVEAL_CLASS, MOBILE_INLINE_ACTION_CLASS)}
+        />
+      )
     ) : (
       <button
         key={action.key ?? action.label}

--- a/apps/app/src/components/thread/timeline/rows/AssistantMessage.stories.tsx
+++ b/apps/app/src/components/thread/timeline/rows/AssistantMessage.stories.tsx
@@ -237,6 +237,100 @@ export function Overview() {
   );
 }
 
+const overflowStoryPluginActions = [
+  {
+    key: "story/summarize",
+    pluginId: null,
+    icon: "Sparkles",
+    label: "Summarize",
+    onSelect: noop,
+  },
+  {
+    key: "story/translate",
+    pluginId: null,
+    icon: "Globe",
+    label: "Translate",
+    onSelect: noop,
+  },
+  {
+    key: "story/save",
+    pluginId: null,
+    icon: "Bookmark",
+    label: "Save to notes",
+    onSelect: noop,
+  },
+  {
+    key: "story/pin",
+    pluginId: null,
+    icon: "Pin",
+    label: "Pin message",
+    onSelect: noop,
+  },
+  {
+    key: "story/share",
+    pluginId: null,
+    icon: "Share",
+    label: "Share",
+    onSelect: noop,
+  },
+];
+
+/**
+ * QA fixtures for the width-tracked action row: the assistant row spans the
+ * message column, so its actions collapse into the "⋯" menu only when the
+ * column itself is narrower than the full set.
+ */
+export function ActionOverflow() {
+  return (
+    <StoryCard>
+      <StoryRow
+        label="wide column"
+        hint="native + five plugin actions all fit inline"
+      >
+        <TimelineStage>
+          <div className="[&_button]:opacity-100">
+            <ConversationMessageContent
+              role="assistant"
+              id="row_story_overflow_wide"
+              threadId="thr_story"
+              turnId="turn_story_overflow_wide"
+              text="Done — the migration ran cleanly on all three environments."
+              attachments={null}
+              showActions={true}
+              mobileActionDisplay="inline"
+              streaming={false}
+              onAddToChat={noop}
+              onFork={noop}
+              pluginActions={overflowStoryPluginActions}
+            />
+          </div>
+        </TimelineStage>
+      </StoryRow>
+      <StoryRow
+        label="narrow column"
+        hint="a 160px column collapses trailing actions into the overflow menu"
+      >
+        <div className="w-[160px] [&_button]:opacity-100">
+          <ConversationMessageContent
+            role="assistant"
+            id="row_story_overflow_narrow"
+            threadId="thr_story"
+            turnId="turn_story_overflow_narrow"
+            text="Done — migration complete."
+            attachments={null}
+            showActions={true}
+            mobileActionDisplay="inline"
+            streaming={false}
+            onAddToChat={noop}
+            onFork={noop}
+            pluginActions={overflowStoryPluginActions}
+          />
+        </div>
+      </StoryRow>
+    </StoryCard>
+  );
+}
+
 export function MobileActionsAndSelection() {
   return (
     <div className="mobile-agent-actions-review mx-auto w-full max-w-[390px] rounded-lg border border-border bg-background p-4">

--- a/apps/app/src/components/thread/timeline/rows/UserMessage.stories.tsx
+++ b/apps/app/src/components/thread/timeline/rows/UserMessage.stories.tsx
@@ -1,4 +1,5 @@
 import type { TimelineConversationAttachments } from "@bb/server-contract";
+import type { ThreadTimelinePluginMessageAction } from "@/components/thread/timeline/types";
 import type { PromptMentionResource, PromptTextMention } from "@bb/domain";
 import type { TimelineTitleLink } from "@bb/thread-view";
 import { renderTemplate } from "@bb/templates";
@@ -917,6 +918,136 @@ export function Overview() {
             mentions={longSystemMessage.mentions}
             projectId="proj_demo"
             turnRequest={acceptedMessage}
+          />
+        </TimelineStage>
+      </StoryRow>
+    </StoryCard>
+  );
+}
+
+const overflowStoryActions: ThreadTimelinePluginMessageAction[] = [
+  {
+    key: "story/summarize",
+    pluginId: null,
+    icon: "Sparkles",
+    label: "Summarize",
+    onSelect: handleStoryMessageEdit,
+  },
+  {
+    key: "story/translate",
+    pluginId: null,
+    icon: "Globe",
+    label: "Translate",
+    onSelect: handleStoryMessageEdit,
+  },
+  {
+    key: "story/save",
+    pluginId: null,
+    icon: "Bookmark",
+    label: "Save to notes",
+    onSelect: handleStoryMessageEdit,
+  },
+];
+
+/**
+ * QA fixtures for the width-tracked action row: the row under each bubble must
+ * never extend past the bubble, collapsing trailing actions into a "⋯" menu
+ * when they don't fit.
+ */
+export function ActionOverflow() {
+  const promptDraft = useStoryPromptDraft();
+
+  return (
+    <StoryCard>
+      <StoryRow
+        label="short, one action"
+        hint="copy only — always fits inside the bubble"
+      >
+        <TimelineStage revealMessageActions>
+          <ConversationMessageContent
+            role="user"
+            originKind={null}
+            initiator="user"
+            senderThreadId={null}
+            senderThreadTitle={null}
+            senderIsPluginSideChat={false}
+            systemMessageKind="unlabeled"
+            systemMessageSubject={null}
+            text="Sounds good"
+            attachments={null}
+            mentions={[]}
+            turnRequest={acceptedMessage}
+          />
+        </TimelineStage>
+      </StoryRow>
+      <StoryRow
+        label="short, native actions"
+        hint="copy + edit + add-to-chat under a two-letter bubble"
+      >
+        <TimelineStage revealMessageActions>
+          <ConversationMessageContent
+            role="user"
+            originKind={null}
+            initiator="user"
+            senderThreadId={null}
+            senderThreadTitle={null}
+            senderIsPluginSideChat={false}
+            systemMessageKind="unlabeled"
+            systemMessageSubject={null}
+            text="Ok"
+            attachments={null}
+            mentions={[]}
+            turnRequest={acceptedMessage}
+            onAddToChat={promptDraft.addQuote}
+            onEdit={handleStoryMessageEdit}
+          />
+        </TimelineStage>
+      </StoryRow>
+      <StoryRow
+        label="short, native + plugin actions"
+        hint="six actions under a two-letter bubble"
+      >
+        <TimelineStage revealMessageActions>
+          <ConversationMessageContent
+            role="user"
+            originKind={null}
+            initiator="user"
+            senderThreadId={null}
+            senderThreadTitle={null}
+            senderIsPluginSideChat={false}
+            systemMessageKind="unlabeled"
+            systemMessageSubject={null}
+            text="Ok"
+            attachments={null}
+            mentions={[]}
+            turnRequest={acceptedMessage}
+            onAddToChat={promptDraft.addQuote}
+            onEdit={handleStoryMessageEdit}
+            pluginActions={overflowStoryActions}
+          />
+        </TimelineStage>
+      </StoryRow>
+      <StoryRow
+        label="long, native + plugin actions"
+        hint="a wide bubble fits every action inline"
+      >
+        <TimelineStage revealMessageActions>
+          <ConversationMessageContent
+            role="user"
+            originKind={null}
+            initiator="user"
+            senderThreadId={null}
+            senderThreadTitle={null}
+            senderIsPluginSideChat={false}
+            systemMessageKind="unlabeled"
+            systemMessageSubject={null}
+            text={longMarkdownText}
+            attachments={null}
+            mentions={[]}
+            turnRequest={acceptedMessage}
+            onAddToChat={promptDraft.addQuote}
+            onEdit={handleStoryMessageEdit}
+            pluginActions={overflowStoryActions}
           />
         </TimelineStage>
       </StoryRow>


### PR DESCRIPTION
## What was wrong

The hover-revealed action row under each timeline message sat in normal flow with no width bound, so it rendered at its natural width regardless of the message it belongs to. A two-letter bubble of 51px carrying three actions of 76px overhung its message by 25px on desktop. On a touch phone the latest message's inline row overhung a 54px bubble by 46px. Because the row was a sibling of the bubble inside a `w-fit` column, a wide row could also widen the column itself. The row was misaligned even where it fitted, because its outer glyph sat 4px from the bubble's edge, inside the bubble's 12px corner radius, so it read as hanging off the message.

## What changed

The change touches `MessageActionBar.tsx` and `ConversationMessageContent.tsx`.

The row now fits the message it belongs to. The most icons that fit under the message's width are shown inline, and the rest collapse progressively into a trailing "…" menu. When not even one fits, the row is the "…" alone. On touch, older messages keep their existing "…"-only footer, and the most recent message follows the same rules as desktop.

- The row's slot is measured with a `ResizeObserver`, and `computeMessageActionRowLayout` keeps the actions that fit and moves the remainder into the menu. The row is absolutely positioned inside a full-width slot, so it can never contribute intrinsic width to a fit-content message column.
- The user bubble and its row sit in a sub-column sized by the bubble, so the measured budget is the bubble's width.
- The row aligns to the message text. It is inset by the bubble's padding and border minus the icon's hit-box slack, 13px on desktop and 11px on touch. Prose rows are pulled out by the slack alone. The outer glyph edge then lands exactly on the text edge on both sides.
- The "…" sits 4px from the last inline action instead of the row's 8px gap, so it reads as the row's continuation, and the row stays revealed while its own menu is open.
- On touch, tapping "…" reveals the actions in place when they fit the timeline column with a 16px margin, reaching into the empty gutter beside a narrow bubble. When the column is too tight, the anchored popover opens instead, because it scrolls and cannot clip.
- Copying from the revealed touch row confirms on the trigger that replaces the row. The row collapses on the same click that copies, so `CopyButton` unmounts before its own check can appear, and the inline copy carries no toast.
- Menus size to their widest label instead of a fixed `w-48` or `w-44`, taking the desktop menu from 192px down to 150px, capped so a long plugin label wraps instead of running off a narrow viewport.

No contract, wire, or CLI surface changed.

## Behavior breakpoints

Every pair below was captured in the real dev app from this checkout, using the same thread, route and window bounds, with the product code as the only variable. The before column comes from merge base `c3b588c8f`, and the after column comes from the PR head. Numbers are measured from the DOM, and "overhang" is how far the controls extend past their message.

### Desktop 1280px, wide bubble

All three actions fit, so none collapse. This is unchanged apart from the alignment.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/get-bb/bb/44f5a05cfbe8272e9229ff0ecce3017c69fea8fe/evidence/timeline-actions-row/before-a1-desktop-wide.png" width="420"> | <img src="https://raw.githubusercontent.com/get-bb/bb/44f5a05cfbe8272e9229ff0ecce3017c69fea8fe/evidence/timeline-actions-row/after-a1-desktop-wide.png" width="420"> |

### Desktop 1280px, short bubble of 51px

Before, three actions span 76px, a **25px overhang**. After, nothing fits, so the row is the "…" alone.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/get-bb/bb/44f5a05cfbe8272e9229ff0ecce3017c69fea8fe/evidence/timeline-actions-row/before-a2-desktop-short.png" width="420"> | <img src="https://raw.githubusercontent.com/get-bb/bb/44f5a05cfbe8272e9229ff0ecce3017c69fea8fe/evidence/timeline-actions-row/after-a2-desktop-short.png" width="420"> |

### Desktop, the menu holds what did not fit

<img src="https://raw.githubusercontent.com/get-bb/bb/44f5a05cfbe8272e9229ff0ecce3017c69fea8fe/evidence/timeline-actions-row/after-a3-desktop-menu-open.png" width="420">

### Progressive overflow

Eight actions. In a wide column all eight are inline. In a 160px column four fit and the other four move into the menu. This one is a Ladle story, because the real thread has only three actions and so shows either all or none.

<img src="https://raw.githubusercontent.com/get-bb/bb/44f5a05cfbe8272e9229ff0ecce3017c69fea8fe/evidence/timeline-actions-row/after-a4-progressive-overflow.png" width="420">

### Compact width 600px with a mouse, resting and then drawer

The same 25px overhang appears before. After, the menu opens as the shared bottom drawer at this width.

| Before | After | Menu open (after) |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/get-bb/bb/44f5a05cfbe8272e9229ff0ecce3017c69fea8fe/evidence/timeline-actions-row/before-b1-compact-fine-resting.png" width="280"> | <img src="https://raw.githubusercontent.com/get-bb/bb/44f5a05cfbe8272e9229ff0ecce3017c69fea8fe/evidence/timeline-actions-row/after-b1-compact-fine-resting.png" width="280"> | <img src="https://raw.githubusercontent.com/get-bb/bb/44f5a05cfbe8272e9229ff0ecce3017c69fea8fe/evidence/timeline-actions-row/after-b2-compact-fine-drawer.png" width="280"> |

### Touch phone 390px, resting

Older messages keep the "…"-only footer. The most recent message follows the desktop rules. Here the latest agent reply spans the column, so its three actions are inline, while the latest user bubble of 54px fits none and shows the "…". Before, that bubble carried 100px of icons, a **46px** overhang.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/get-bb/bb/44f5a05cfbe8272e9229ff0ecce3017c69fea8fe/evidence/timeline-actions-row/before-c1-mobile-resting.png" width="300"> | <img src="https://raw.githubusercontent.com/get-bb/bb/44f5a05cfbe8272e9229ff0ecce3017c69fea8fe/evidence/timeline-actions-row/after-c1-mobile-resting.png" width="300"> |

### Touch phone, tapping "…" reveals the actions in place

The 358px column fits all three, so they appear in the gutter beside the bubble instead of in a popover.

<img src="https://raw.githubusercontent.com/get-bb/bb/44f5a05cfbe8272e9229ff0ecce3017c69fea8fe/evidence/timeline-actions-row/after-c2-mobile-revealed.png" width="300">

### Touch phone, popover fallback

Eight actions in a 160px column cannot fit, so the popover opens instead, on-screen.

<img src="https://raw.githubusercontent.com/get-bb/bb/44f5a05cfbe8272e9229ff0ecce3017c69fea8fe/evidence/timeline-actions-row/after-c3-mobile-popover-fallback.png" width="300">

## How you verified

- `pnpm exec turbo run test --filter=@bb/app -- MessageActionBar` passes 28 tests, 11 of them new. They cover the layout math at its boundaries, meaning all inline, progressive collapse, and everything in the menu. They also cover desktop collapse into the "More actions" menu, touch collapse into the popover, reveal-in-place when the column has room, collapse-on-choose, the popover fallback when the column is too tight, and the copy confirmation on the trigger. The new assertions fail against the pre-change component.
- `pnpm exec turbo run test --filter=@bb/app -- "thread/timeline"` passes 208 tests.
- `pnpm exec turbo run typecheck --filter=@bb/app` is clean, and so are `oxlint` and `oxfmt` after the repository moved to Oxc in #2258.
- Every breakpoint above was driven by hand in the real dev app over the Chrome DevTools Protocol (CDP). A DOM audit asserts each row's control bounds against its message, giving 0px overhang everywhere. It also asserts the glyph against the message text edge, giving a 0.0px delta on both sides at both breakpoints.

One thing is not verified. An installed PWA was never exercised, because `display-mode: standalone` cannot be emulated over CDP. The touch path keys off `(pointer: coarse)` and `(max-width: 767px)`, and the standalone rule in `app.css` only sets shell height, which this row does not read.

BB-Thread-ID: thr_w8uypnhb9x

> AGENT GENERATED: by Claude Opus 5
