### PR TITLE
Show the drawer glyph on every right-panel trigger

### DIFF
--- a/apps/app/src/components/plugin/PluginPanelRightPanelHost.test.tsx
+++ b/apps/app/src/components/plugin/PluginPanelRightPanelHost.test.tsx
@@ -62,6 +62,7 @@ interface TestNewThreadPanelActionRegistration {
 }
 
 const browserState = vi.hoisted(() => ({ available: false }));
+const viewportState = vi.hoisted(() => ({ isCompactViewport: false }));
 const createTerminal = vi.hoisted(() => vi.fn());
 const threadTabsApi = vi.hoisted(() => ({
   get: vi.fn(),
@@ -141,7 +142,7 @@ vi.mock("@/lib/sdk", async (importOriginal) => {
 });
 
 vi.mock("@bb/shared-ui/hooks/use-compact-viewport", () => ({
-  useIsCompactViewport: () => false,
+  useIsCompactViewport: () => viewportState.isCompactViewport,
 }));
 
 vi.mock("@/components/commands/AppCommandProvider", () => ({
@@ -594,6 +595,7 @@ function renderHost(panelPath = "board", subPath = "", store = createStore()) {
 describe("PluginPanelRightPanelHost", () => {
   beforeEach(() => {
     browserState.available = false;
+    viewportState.isCompactViewport = false;
     createTerminal.mockReset();
     createTerminal.mockResolvedValue({ id: "terminal-1" });
     threadTabsApi.get.mockReset();
@@ -615,6 +617,29 @@ describe("PluginPanelRightPanelHost", () => {
 
   afterEach(() => {
     cleanup();
+  });
+
+  // The host's own trigger is portaled into the page header, so it does not
+  // inherit the glyph the thread header resolves. A compact viewport opens
+  // this panel as a bottom drawer (SecondaryPanelLayout), and the trigger has
+  // to disclose that edge.
+  it("shows the drawer glyph on the trigger for a compact viewport", async () => {
+    viewportState.isCompactViewport = true;
+    renderHost();
+
+    const showButton = await screen.findByRole("button", {
+      name: "Show right panel",
+    });
+    expect(showButton.querySelector('[data-icon="PanelBottom"]')).toBeTruthy();
+  });
+
+  it("shows the side-panel glyph on the trigger for a wide viewport", async () => {
+    renderHost();
+
+    const showButton = await screen.findByRole("button", {
+      name: "Show right panel",
+    });
+    expect(showButton.querySelector('[data-icon="PanelRight"]')).toBeTruthy();
   });
 
   it("keeps one panel toggle and mounts the collapsed panel before opening", async () => {

--- a/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
+++ b/apps/app/src/components/plugin/PluginPanelRightPanelHost.tsx
@@ -21,6 +21,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@bb/shared-ui/tooltip";
 import { useAppCommandHandler } from "@/components/commands/AppCommandProvider";
 import { PluginIcon } from "@/components/plugin/PluginIcon";
 import { PluginSlotMount } from "@/components/plugin/PluginSlotMount";
+import { getRightPanelToggleIconName } from "@/components/secondary-panel/panelToggleControlState";
 import { SecondaryPanelLayout } from "@/components/secondary-panel/SecondaryPanelLayout";
 import {
   LazyBrowserTabDeck,
@@ -949,6 +950,7 @@ export function PluginPanelRightPanelHost({
   );
 
   const toggleLabel = isOpen ? "Hide right panel" : "Show right panel";
+  const toggleIconName = getRightPanelToggleIconName(isCompactViewport);
   const page = (
     <div
       className={`flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden ${
@@ -995,7 +997,7 @@ export function PluginPanelRightPanelHost({
                     aria-pressed={isOpen}
                     onClick={togglePanel}
                   >
-                    <Icon name="PanelRight" />
+                    <Icon name={toggleIconName} />
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>{toggleLabel}</TooltipContent>

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.collapseControl.test.tsx
@@ -72,6 +72,7 @@ function createTestRenderableTab(
 function renderPanel(args: {
   isConversationCollapsed: boolean;
   onToggleConversationCollapse: () => void;
+  renderAsDrawer?: boolean;
 }) {
   const { wrapper: Wrapper } = createQueryClientTestHarness();
   return render(
@@ -516,6 +517,33 @@ describe("ThreadSecondaryPanel Diff eligibility", () => {
     ).toBeTruthy();
     expect(screen.getByText("Checking Git support…")).toBeTruthy();
     expect(screen.queryByText("This panel view is unavailable.")).toBeNull();
+  });
+});
+
+// Every right-panel show/hide control has to disclose the edge the panel
+// actually opens from, and on a compact viewport that edge is the bottom.
+// Each trigger builds its own button, so the glyph is only correct as long as
+// every one of them routes through getRightPanelToggleIconName.
+describe("ThreadSecondaryPanel hide control glyph", () => {
+  it("shows the drawer glyph while the panel renders as a bottom drawer", () => {
+    const view = renderPanel({
+      isConversationCollapsed: false,
+      onToggleConversationCollapse: noop,
+      renderAsDrawer: true,
+    });
+
+    const hideControl = view.getByRole("button", { name: "Hide right panel" });
+    expect(hideControl.querySelector('[data-icon="PanelBottom"]')).toBeTruthy();
+  });
+
+  it("shows the side-panel glyph on a wide viewport", () => {
+    const view = renderPanel({
+      isConversationCollapsed: false,
+      onToggleConversationCollapse: noop,
+    });
+
+    const hideControl = view.getByRole("button", { name: "Hide right panel" });
+    expect(hideControl.querySelector('[data-icon="PanelRight"]')).toBeTruthy();
   });
 });
 

--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -35,7 +35,10 @@ import {
   THREAD_SECONDARY_PANEL_MAX_SIZE_PERCENT,
   THREAD_SECONDARY_PANEL_MIN_SIZE_PERCENT,
 } from "./secondaryPanelSizing";
-import { resolveConversationCollapseControl } from "./panelToggleControlState";
+import {
+  getRightPanelToggleIconName,
+  resolveConversationCollapseControl,
+} from "./panelToggleControlState";
 import { SecondaryPanelHostLayoutContext } from "./SecondaryPanelHostLayoutContext";
 import { SecondaryPanelTabStrip } from "./SecondaryPanelTabStrip";
 import type {
@@ -204,10 +207,7 @@ export function resolveCollapsedPanelTrafficLightReserveClassName({
   return reserves && MACOS_COLLAPSED_TOP_LEFT_RESERVE_CLASS;
 }
 
-const HIDE_PANEL_CONTROL = {
-  iconName: "PanelRight" as const,
-  label: "Hide right panel",
-};
+const HIDE_PANEL_LABEL = "Hide right panel";
 
 export interface SecondaryPanelFixedTab {
   ariaLabel: string;
@@ -343,7 +343,7 @@ export function ThreadSecondaryPanel({
     [tabs],
   );
   const hasActiveRenderableTab = activeRenderableTab !== undefined;
-  const hideControl = HIDE_PANEL_CONTROL;
+  const hidePanelIconName = getRightPanelToggleIconName(renderAsDrawer);
   // The conversation-collapse toggle only exists on a wide viewport; the drawer
   // layout fills the screen and cannot collapse the conversation.
   const conversationCollapseControl =
@@ -587,12 +587,12 @@ export function ThreadSecondaryPanel({
       onClick={onClose}
       aria-label={
         togglePanelShortcut
-          ? `${hideControl.label} (${togglePanelShortcut.label})`
-          : hideControl.label
+          ? `${HIDE_PANEL_LABEL} (${togglePanelShortcut.label})`
+          : HIDE_PANEL_LABEL
       }
       aria-keyshortcuts={togglePanelShortcut?.ariaKeyshortcuts}
     >
-      <Icon name={hideControl.iconName} />
+      <Icon name={hidePanelIconName} />
       <AppCommandShortcutHint
         shortcut={togglePanelShortcut}
         className="absolute right-full mr-1"

--- a/apps/app/src/components/secondary-panel/panelToggleControlState.ts
+++ b/apps/app/src/components/secondary-panel/panelToggleControlState.ts
@@ -1,3 +1,5 @@
+import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
+
 type PanelToggleAction = "enter-full-screen" | "exit-full-screen";
 
 /**
@@ -67,4 +69,32 @@ export function resolveConversationCollapseControl({
     ...PANEL_TOGGLE_ACTION_PRESENTATION[action],
     onClick: onToggleConversationCollapse,
   };
+}
+
+/**
+ * Icon names the right-panel show/hide control can render. A subset of the Icon
+ * component's `IconName` union; validity is enforced where the value flows into
+ * `<Icon name={…} />`.
+ */
+type RightPanelToggleIconName = "PanelBottom" | "PanelRight";
+
+/**
+ * The glyph for every control that shows or hides the right panel. Compact
+ * viewports present that panel as a bottom drawer (`SecondaryPanelLayout`), so
+ * the control has to disclose the edge the panel actually opens from.
+ *
+ * Trigger sites differ too much in chrome (tooltip, shortcut hint, macOS
+ * drag region) to share one button, so this resolver is what they share
+ * instead: pass the presentation a site already tracks, or call
+ * {@link useRightPanelToggleIconName} when it doesn't track one.
+ */
+export function getRightPanelToggleIconName(
+  renderAsDrawer: boolean,
+): RightPanelToggleIconName {
+  return renderAsDrawer ? "PanelBottom" : "PanelRight";
+}
+
+/** {@link getRightPanelToggleIconName} against the live viewport. */
+export function useRightPanelToggleIconName(): RightPanelToggleIconName {
+  return getRightPanelToggleIconName(useIsCompactViewport());
 }

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -36,6 +36,7 @@ import {
   type ProjectMachineSetupDialogTarget,
 } from "@/components/dialogs/ProjectMachineSetupDialog";
 import { HEADER_ICON_BUTTON_CLASS } from "@/components/layout/AppPageHeader";
+import { useRightPanelToggleIconName } from "@/components/secondary-panel/panelToggleControlState";
 import { AppCommandShortcutHint } from "@/components/commands/AppCommandShortcutHint";
 import type {
   SecondaryPanelPaneRenderContext,
@@ -259,10 +260,9 @@ export function RootComposeRightPanelToggle({
   isOpen,
   onToggle,
 }: RootComposeRightPanelToggleProps) {
-  const renderAsDrawer = useIsCompactViewport();
   const shortcut = useAppCommandShortcut("panel.toggle");
   const rightPanelLabel = isOpen ? "Hide right panel" : "Show right panel";
-  const rightPanelIconName = renderAsDrawer ? "PanelBottom" : "PanelRight";
+  const rightPanelIconName = useRightPanelToggleIconName();
 
   return (
     <Button

--- a/apps/app/src/views/thread-detail/SplitWorkspaceSecondaryPanelHost.tsx
+++ b/apps/app/src/views/thread-detail/SplitWorkspaceSecondaryPanelHost.tsx
@@ -32,6 +32,7 @@ import {
   SecondaryPanelHostLayoutContext,
   type SecondaryPanelHostLayout,
 } from "@/components/secondary-panel/SecondaryPanelHostLayoutContext";
+import { useRightPanelToggleIconName } from "@/components/secondary-panel/panelToggleControlState";
 import {
   getPanelCollapseTransitionStyle,
   PANEL_COLLAPSE_TRANSITION_CLASS,
@@ -189,6 +190,7 @@ export function SplitWorkspaceSecondaryPanelHost({
   };
 
   const toggleLabel = isOpen ? "Hide right panel" : "Show right panel";
+  const toggleIconName = useRightPanelToggleIconName();
   // An open pane panel carries the toggle in its own chrome, and a full-screen
   // pane hides it. The empty state has no chrome, so it keeps the button.
   const showsCornerToggle = !isPaneMaximized && !(isOpen && model !== null);
@@ -248,7 +250,7 @@ export function SplitWorkspaceSecondaryPanelHost({
             aria-expanded={isOpen}
             onClick={toggleWindowPanel}
           >
-            <Icon name="PanelRight" />
+            <Icon name={toggleIconName} />
           </Button>
         </div>
         <PanelGroup

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.test.tsx
@@ -46,8 +46,10 @@ vi.mock("@/components/layout/AppPageHeader", () => ({
   ),
 }));
 
+const viewportState = vi.hoisted(() => ({ isCompactViewport: false }));
+
 vi.mock("@bb/shared-ui/hooks/use-compact-viewport", () => ({
-  useIsCompactViewport: () => false,
+  useIsCompactViewport: () => viewportState.isCompactViewport,
 }));
 
 const THREAD_ID = "thr_header";
@@ -69,6 +71,7 @@ const PANE_CONTEXT: PaneContextValue = {
 
 afterEach(() => {
   cleanup();
+  viewportState.isCompactViewport = false;
   mocks.renameThread.mockReset();
   vi.restoreAllMocks();
   window.localStorage.clear();
@@ -98,6 +101,40 @@ describe("ThreadDetailHeader", () => {
       screen.queryByRole("button", { name: "Hide right panel" }),
     ).toBeNull();
   });
+
+  // A compact viewport opens the right panel as a bottom drawer, so the show
+  // trigger has to disclose that edge rather than the wide-viewport one.
+  it.each([
+    { expectedIcon: "PanelBottom", isCompactViewport: true },
+    { expectedIcon: "PanelRight", isCompactViewport: false },
+  ])(
+    "shows the $expectedIcon glyph on the right-panel trigger",
+    ({ expectedIcon, isCompactViewport }) => {
+      viewportState.isCompactViewport = isCompactViewport;
+
+      render(
+        <PaneContext.Provider value={PANE_CONTEXT}>
+          <ThreadDetailHeader
+            actionsMenu={null}
+            childPillLabel={null}
+            isSecondaryPanelOpen={false}
+            onOpenThreadGitAction={vi.fn()}
+            onToggleSecondaryPanel={vi.fn()}
+            threadHeaderGitActions={[]}
+            threadId={THREAD_ID}
+            threadTitle="Panel state"
+          />
+        </PaneContext.Provider>,
+      );
+
+      const showButton = screen.getByRole("button", {
+        name: "Show right panel",
+      });
+      expect(
+        showButton.querySelector(`[data-icon="${expectedIcon}"]`),
+      ).not.toBeNull();
+    },
+  );
 
   it("keeps thread Full Screen in a split header while its panel is open", () => {
     render(

--- a/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailHeader.tsx
@@ -32,6 +32,7 @@ import { useInlineThreadTitle } from "@/components/thread/InlineThreadTitle";
 import { useThreadActions } from "@/components/thread/ThreadActionsProvider";
 import { ThreadTitleMentions } from "@/components/thread/ThreadTitleMentions";
 import { SecondaryPanelHostLayoutContext } from "@/components/secondary-panel/SecondaryPanelHostLayoutContext";
+import { getRightPanelToggleIconName } from "@/components/secondary-panel/panelToggleControlState";
 import { CHROME_SUBTLE_ICON_BUTTON_FOREGROUND_CLASS } from "@bb/shared-ui/chrome-style-tokens";
 import { dimInactiveSplitsAtom } from "@/lib/split-layout/atoms";
 import {
@@ -155,7 +156,7 @@ export function ThreadDetailHeader({
   const rightPanelLabel = isSecondaryPanelOpen
     ? "Hide right panel"
     : "Show right panel";
-  const rightPanelIconName = renderAsDrawer ? "PanelBottom" : "PanelRight";
+  const rightPanelIconName = getRightPanelToggleIconName(renderAsDrawer);
   // The thread header owns only the show control. Once the panel opens, its
   // toolbar owns collapse so pane actions (including Full Screen) keep their
   // stable positions in the thread header.


### PR DESCRIPTION
## What was wrong

The right panel opens as a bottom drawer on compact viewports — `SecondaryPanelLayout` calls `useIsCompactViewport()` and every host goes through it, including plugin pages. But the *trigger glyph* for that panel was never shared. Picking `PanelBottom` over `PanelRight` was a one-line ternary added to `ThreadDetailHeader` in 13613044c (a two-file fix that touched only that header) and later copy-pasted into `RootComposeView`. The three other right-panel controls each named their glyph independently and hardcoded `PanelRight`, so on a phone a plugin page's trigger advertised a side panel while the panel actually opened from the bottom.

Two of those three were not plugin-specific:

- `ThreadSecondaryPanel`'s hide button renders *because* `renderAsDrawer` is true, and still showed the side-panel glyph — so the thread drawer had the wrong icon on its own close control.
- The regression guard from 13613044c is gone. `ThreadDetailHeader.test.tsx` no longer mentioned `isCompactViewport` or either glyph, so nothing pinned the one site that was right.

## What changed

`apps/app/src/components/secondary-panel/panelToggleControlState.ts` — the module that already owns the full-screen control's copy, icon, and disclosure state — gains `getRightPanelToggleIconName(renderAsDrawer)` and a `useRightPanelToggleIconName()` hook for sites that don't already track the presentation. All five triggers now call it:

| Site | Before | Now |
| --- | --- | --- |
| `PluginPanelRightPanelHost.tsx:952` | hardcoded `PanelRight` | `getRightPanelToggleIconName(isCompactViewport)` |
| `ThreadSecondaryPanel.tsx:346` | hardcoded `PanelRight` | `getRightPanelToggleIconName(renderAsDrawer)` |
| `SplitWorkspaceSecondaryPanelHost.tsx:192` | hardcoded `PanelRight` | `useRightPanelToggleIconName()` |
| `ThreadDetailHeader.tsx:159` | inline ternary | resolver |
| `RootComposeView.tsx:264` | duplicated ternary | resolver |

The triggers keep their own buttons. The chrome around them — tooltip, shortcut hint, macOS drag region, portal target — differs too much to collapse into one component without a much larger refactor, so the resolver is what they share instead.

`SplitWorkspaceSecondaryPanelHost` cannot differ today, since compact viewports disable splits entirely (`SplitThreadArea.tsx:169`). It is routed anyway rather than left with a hardcoded glyph whose correctness depends on an invariant enforced in a different file.

No wire, CLI, plugin API, or doc surfaces are affected.

## How you verified

Added three guards, then reverted the source fix while keeping the tests to confirm they bite:

- `PluginPanelRightPanelHost.test.tsx` — compact viewport puts `PanelBottom` on the portaled trigger. **Fails before, passes after.** The file's `useIsCompactViewport` mock became a mutable hoisted value, reset in `beforeEach`.
- `ThreadSecondaryPanel.collapseControl.test.tsx` — the hide control shows `PanelBottom` while `renderAsDrawer`. **Fails before, passes after.**
- `ThreadDetailHeader.test.tsx` — restores the guard lost since 13613044c, as an `it.each` over both viewports. Passes both ways by design: that site was already correct, and this is what stops it from regressing again.

Commands:

- `pnpm exec turbo run test --filter=@bb/app --force` — 414 files, 3212 passed / 3 skipped
- `pnpm exec turbo run typecheck --filter=@bb/app` — clean
- `pnpm exec turbo run lint --filter=@bb/app` — 0 errors (the single warning in a touched file is the pre-existing `set-state-in-effect` at `SplitWorkspaceSecondaryPanelHost.tsx:98`, shifted one line by the new import)

> AGENT GENERATED