### PR TITLE
Wait for machine project counts in settings test

### DIFF
--- a/apps/app/src/components/settings/MachinesSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/MachinesSettingsSection.test.tsx
@@ -165,7 +165,7 @@ describe("MachinesSettingsSection", () => {
     expect(screen.getByText("primary")).toBeDefined();
     expect(screen.getByText("Online")).toBeDefined();
     expect(screen.getByText(/^Offline · last seen/u)).toBeDefined();
-    expect(screen.getByText("2 projects")).toBeDefined();
+    expect(await screen.findByText("2 projects")).toBeDefined();
     expect(screen.getByText("1 project")).toBeDefined();
     expect(screen.getAllByText("Full Access")).toHaveLength(2);
     expect(screen.getByText("macOS")).toBeDefined();


### PR DESCRIPTION
## What was wrong

`MachinesSettingsSection` loads host rows and sidebar project metadata through independent asynchronous queries. The test waited only for `MacBook Pro` from `sdk.hosts.list`, then synchronously queried for `2 projects` from the still-independent sidebar bootstrap. When the host query won that race, the rendered row still showed `0 projects`, producing the same `TestingLibraryElementError` in [PR #2262's app-1 job](https://github.com/get-bb/bb/actions/runs/32530493567) and [PR #2263's app-1 job](https://github.com/get-bb/bb/actions/runs/32530498050).

## What changed

The project-count assertion now uses awaited `findByText`, synchronizing the test with the sidebar query that owns the value. The following `1 project` assertion remains synchronous because both counts are derived from the same resolved sidebar payload. No product behavior, assertion coverage, wire contract, CLI, or documentation surface changed.

## How you verified

- Reproduced the exact failure before the fix by temporarily delaying only the sidebar response by 50 ms: the host row rendered with `0 projects`, and the test failed at the `2 projects` assertion. With the assertion fix under the same forced ordering, the test passed. The temporary delay is not committed.
- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/settings/MachinesSettingsSection.test.tsx` — 12/12 passed.
- `pnpm exec turbo run test --filter=@bb/app --force` — 418 files passed; 3,244 tests passed and 3 skipped.
- `pnpm exec turbo run typecheck --filter=@bb/app --force` — clean.
- `pnpm exec turbo run build --filter=@bb/app --force` — clean.
- `git diff --check` — clean.

Fixes # — no linked issue.

BB-Thread-ID: thr_qarynse2fs

> AGENT GENERATED: by GPT-5.6-Sol
