### PR TITLE
Fix MachineSettingsView response mock flake

### DIFF
--- a/apps/app/src/views/MachineSettingsView.test.tsx
+++ b/apps/app/src/views/MachineSettingsView.test.tsx
@@ -148,7 +148,7 @@ function stubSupportingFetches(): void {
   );
   vi.stubGlobal(
     "fetch",
-    vi.fn().mockResolvedValue(
+    vi.fn(async () =>
       new Response(JSON.stringify({ projects: [] }), {
         status: 200,
         headers: { "content-type": "application/json" },


### PR DESCRIPTION
## What was wrong

`stubSupportingFetches()` in `MachineSettingsView.test.tsx` configured `fetch` with `mockResolvedValue(new Response(...))`, so every request received the same one-shot response body. The view starts independent sidebar-bootstrap and plugin-list fetch consumers; whichever consumer read the shared body first disturbed it for the other. Under CI timing, the later `request()` body read escaped as `TypeError: Body is unusable: Body has already been read`, even though every assertion passed.

## What changed

The supporting fetch stub now constructs a new `Response` inside its implementation for every request. Production request behavior, test assertions, wire contracts, and the host daemon protocol are unchanged.

## How you verified

- Before the fix, an exact standalone reproduction of the fixture pattern returned one shared `Response`; the second `.text()` call deterministically threw `TypeError: Body is unusable: Body has already been read`. A focused run and a full app-3 run both passed, consistent with the reported timing-dependent exposure.
- After the fix, 10 forced focused Turbo runs passed (90 test executions total) without unhandled errors: `pnpm exec turbo run test --filter=@bb/app --force -- --run src/views/MachineSettingsView.test.tsx`.
- `pnpm exec turbo run test --filter=@bb/app --force -- --shard=3/3` passed 139 files / 1153 tests without unhandled errors.
- `pnpm exec turbo run typecheck --filter=@bb/app` passed.
- `pnpm exec turbo run build --filter=@bb/app` passed.
- `pnpm exec turbo run lint --filter=@bb/app` passed with the package's existing warnings only.
- `git diff --check` passed.

## Additional context

The required initial merge-base was verified as `d41d1abee41f24b00b62c4c8c716852a17424b5c`. GitHub issue/PR searches, open-PR changed-file inspection, and bb thread searches found no matching fix in progress. After the PR opened, `main` advanced by five commits and the provider-literal ratchet rejected the stale branch; the branch was rebased onto `0e12ccca796c54e8e5768f8206006e50c4bab89b`, after which the ratchet passed locally.

> AGENT GENERATED: by GPT-5.6-Sol