### PR TITLE
Let plugins add rows to the quick palette

### DIFF
--- a/apps/app/src/components/commands/CommandPalette.test.tsx
+++ b/apps/app/src/components/commands/CommandPalette.test.tsx
@@ -16,6 +16,10 @@ import {
   type AppKeybinding,
 } from "@bb/domain";
 import { AppCommandProvider, useAppCommandHandler } from "./AppCommandProvider";
+import {
+  removePluginSlotRegistrations,
+  setPluginSlotRegistrations,
+} from "@/lib/plugin-slots";
 import { CommandPalette } from "./CommandPalette";
 
 const PALETTE_SHORTCUT = {
@@ -106,7 +110,7 @@ function renderPalette() {
         <Handler command="thread.next" />
         <Handler command="panel.toggle" />
         <Handler command="terminal.open" />
-        <CommandPalette />
+        <CommandPalette threadId={null} projectId={null} />
       </AppCommandProvider>
     </MemoryRouter>,
   );
@@ -136,6 +140,7 @@ const selectedOption = () =>
 
 afterEach(() => {
   cleanup();
+  removePluginSlotRegistrations("linear");
   testState.calls.length = 0;
   window.localStorage.clear();
 });
@@ -270,6 +275,37 @@ describe("CommandPalette", () => {
     expect(scrollIntoView).not.toHaveBeenCalled();
 
     scrollIntoView.mockRestore();
+  });
+
+  it("lists a plugin's commandPaletteAction and runs it", async () => {
+    setPluginSlotRegistrations("linear", {
+      homepageSections: [],
+      settingsSections: [],
+      navPanels: [],
+      threadPanelActions: [],
+      sidebarFooterActions: [],
+      fileOpeners: [],
+      messageDirectives: [],
+      commandPaletteActions: [
+        {
+          id: "open-issue",
+          title: "Linear: open issue",
+          run: () => {
+            testState.calls.push("plugin-ran");
+          },
+        },
+      ],
+    });
+    renderPalette();
+    openPalette();
+    await waitFor(() => expect(searchField()).toBeTruthy());
+
+    fireEvent.change(searchField(), { target: { value: "linear" } });
+    await waitFor(() => expect(optionTitles()).toHaveLength(1));
+    expect(optionTitles()?.[0]).toContain("Linear: open issue");
+    fireEvent.keyDown(searchField(), { key: "Enter" });
+
+    await waitFor(() => expect(testState.calls).toEqual(["plugin-ran"]));
   });
 
   it("says so when nothing matches", async () => {

--- a/apps/app/src/components/commands/CommandPalette.tsx
+++ b/apps/app/src/components/commands/CommandPalette.tsx
@@ -31,14 +31,23 @@ import {
   readPaletteRecents,
   recordPaletteRecent,
 } from "@/lib/command-palette/palette-recents";
+import { buildPluginPaletteActions } from "@/lib/command-palette/palette-plugin-actions";
+import { getPluginSlotSnapshot } from "@/lib/plugin-slots";
+import { getActiveThreadPanelOpener } from "@/components/plugin/plugin-thread-panel-navigation";
 
 const PALETTE_PLACEHOLDER = "Search commands";
+
+export interface CommandPaletteProps {
+  /** The surface's thread and project, handed to plugin rows. */
+  threadId: string | null;
+  projectId: string | null;
+}
 
 /**
  * Type to filter the commands that apply right now, then run one with Enter.
  * Mounted once by `AppLayout` and opened by `palette.open`.
  */
-export function CommandPalette() {
+export function CommandPalette({ threadId, projectId }: CommandPaletteProps) {
   const runner = useAppCommandRunner();
   const shortcuts = useAppCommandShortcuts(PALETTE_COMMAND_IDS);
   const listId = useId();
@@ -61,14 +70,20 @@ export function CommandPalette() {
       invocation.target ??
       (typeof document === "undefined" ? null : document.activeElement);
     openTargetRef.current = target;
-    setActions(
-      buildAppCommandActions({
+    setActions([
+      ...buildAppCommandActions({
         target,
         isCommandAvailable: runner.isCommandAvailable,
         dispatch: runner.dispatch,
         shortcuts,
       }),
-    );
+      ...buildPluginPaletteActions({
+        slots: getPluginSlotSnapshot().commandPaletteActions,
+        threadId,
+        projectId,
+        openThreadPanel: getActiveThreadPanelOpener(),
+      }),
+    ]);
     setQuery("");
     setHighlightedIndex(0);
     setOpen(true);

--- a/apps/app/src/components/layout/AppLayout.tsx
+++ b/apps/app/src/components/layout/AppLayout.tsx
@@ -849,7 +849,10 @@ export function AppLayout({ children }: AppLayoutProps) {
             active={isSidebarResizing}
             cursor="col-resize"
           />
-          <CommandPalette />
+          <CommandPalette
+            threadId={threadId ?? null}
+            projectId={projectId ?? null}
+          />
           <ProjectPathDialog
             target={quickCreateProject.projectPathDialog.target}
             pending={quickCreateProject.isCreating}

--- a/apps/app/src/components/plugin/plugin-thread-panel-navigation.test.tsx
+++ b/apps/app/src/components/plugin/plugin-thread-panel-navigation.test.tsx
@@ -1,80 +1,59 @@
 // @vitest-environment jsdom
 
-import { useState } from "react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { useBbNavigate } from "@/lib/plugin-sdk-hooks";
-import { PluginSlotMount } from "./PluginSlotMount";
-import { PluginThreadPanelNavigationProvider } from "./plugin-thread-panel-navigation";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import {
+  getActiveThreadPanelOpener,
+  resetActiveThreadPanelOpenerForTest,
+  usePublishThreadPanelOpener,
+  type PluginThreadPanelOpenHandler,
+} from "./plugin-thread-panel-navigation";
 
-afterEach(cleanup);
+function Pane({
+  opener,
+  isFocused,
+}: {
+  opener: PluginThreadPanelOpenHandler;
+  isFocused: boolean;
+}) {
+  usePublishThreadPanelOpener(opener, isFocused);
+  return null;
+}
 
-function NavigationProbe() {
-  const navigate = useBbNavigate();
-  const [accepted, setAccepted] = useState<boolean | null>(null);
-  return (
+afterEach(() => {
+  cleanup();
+  resetActiveThreadPanelOpenerForTest();
+});
+
+it("publishes only the focused pane's opener", () => {
+  // A split mounts one thread view per pane, each with its own panel tabs, so
+  // an unscoped store would open a plugin's panel in whichever pane mounted
+  // last rather than the one the user is looking at.
+  const left = vi.fn(() => true);
+  const right = vi.fn(() => true);
+  const { rerender } = render(
     <>
-      <button
-        type="button"
-        onClick={() =>
-          setAccepted(
-            navigate.openThreadPanel({
-              actionId: "details",
-              title: "Run details",
-              params: { runId: "run_1" },
-            }),
-          )
-        }
-      >
-        Open details
-      </button>
-      <span>
-        {accepted === null ? "idle" : accepted ? "accepted" : "rejected"}
-      </span>
-    </>
+      <Pane opener={left} isFocused={true} />
+      <Pane opener={right} isFocused={false} />
+    </>,
   );
-}
 
-function PluginProbe() {
-  return (
-    <PluginSlotMount pluginId="workflows" slotKind="test" slotId="navigation">
-      <NavigationProbe />
-    </PluginSlotMount>
+  getActiveThreadPanelOpener()?.({ actionId: "a", pluginId: "p" });
+  expect(left).toHaveBeenCalledTimes(1);
+  expect(right).not.toHaveBeenCalled();
+
+  rerender(
+    <>
+      <Pane opener={left} isFocused={false} />
+      <Pane opener={right} isFocused={true} />
+    </>,
   );
-}
+  getActiveThreadPanelOpener()?.({ actionId: "a", pluginId: "p" });
+  expect(right).toHaveBeenCalledTimes(1);
+  expect(left).toHaveBeenCalledTimes(1);
+});
 
-describe("plugin thread-panel navigation", () => {
-  it("binds generic panel requests to the calling plugin", () => {
-    const openThreadPanel = vi.fn(() => true);
-    render(
-      <MemoryRouter>
-        <PluginThreadPanelNavigationProvider openThreadPanel={openThreadPanel}>
-          <PluginProbe />
-        </PluginThreadPanelNavigationProvider>
-      </MemoryRouter>,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "Open details" }));
-
-    expect(openThreadPanel).toHaveBeenCalledWith({
-      pluginId: "workflows",
-      actionId: "details",
-      title: "Run details",
-      params: { runId: "run_1" },
-    });
-    expect(screen.getByText("accepted")).toBeTruthy();
-  });
-
-  it("returns false outside a thread-panel surface", () => {
-    render(
-      <MemoryRouter>
-        <PluginProbe />
-      </MemoryRouter>,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "Open details" }));
-
-    expect(screen.getByText("rejected")).toBeTruthy();
-  });
+it("reports no opener when no thread view is focused", () => {
+  render(<Pane opener={vi.fn(() => true)} isFocused={false} />);
+  expect(getActiveThreadPanelOpener()).toBeNull();
 });

--- a/apps/app/src/components/plugin/plugin-thread-panel-navigation.tsx
+++ b/apps/app/src/components/plugin/plugin-thread-panel-navigation.tsx
@@ -1,7 +1,14 @@
-import { createContext, type ReactNode, useContext } from "react";
+import {
+  createContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  type ReactNode,
+  useContext,
+} from "react";
 import type { BbNavigate } from "@get-bb/plugin-sdk";
 
-type PluginThreadPanelOpenHandler = (
+export type PluginThreadPanelOpenHandler = (
   options: Parameters<BbNavigate["openThreadPanel"]>[0] & {
     pluginId: string;
   },
@@ -26,4 +33,58 @@ export function PluginThreadPanelNavigationProvider({
 
 export function usePluginThreadPanelOpenHandler(): PluginThreadPanelOpenHandler | null {
   return useContext(PluginThreadPanelNavigationContext);
+}
+
+// ---------------------------------------------------------------------------
+// Active opener, for host surfaces mounted outside the provider
+// ---------------------------------------------------------------------------
+
+/**
+ * The focused thread view's opener, published to a module-level store.
+ *
+ * The context above only reaches descendants of a thread view, which is right
+ * for the timeline and its message actions. The quick palette is mounted by
+ * `AppLayout` beside the routes, so it can never read that context, yet a
+ * plugin's palette row must still be able to open that plugin's panel in the
+ * thread the user is looking at.
+ *
+ * Only the focused pane publishes, because a split has one opener per pane and
+ * "the thread side panel" otherwise has no single meaning. A lone thread view
+ * counts as focused (see `DefaultPaneContextProvider`).
+ */
+const focusedOpeners = new Map<symbol, PluginThreadPanelOpenHandler>();
+
+export function usePublishThreadPanelOpener(
+  openThreadPanel: PluginThreadPanelOpenHandler,
+  isActive: boolean,
+): void {
+  const handlerRef = useRef(openThreadPanel);
+  useLayoutEffect(() => {
+    handlerRef.current = openThreadPanel;
+  }, [openThreadPanel]);
+  const tokenRef = useRef<symbol | null>(null);
+  tokenRef.current ??= Symbol("thread-panel-opener");
+  useEffect(() => {
+    const token = tokenRef.current;
+    if (token === null || !isActive) return;
+    focusedOpeners.set(token, (options) => handlerRef.current(options));
+    return () => {
+      focusedOpeners.delete(token);
+    };
+  }, [isActive]);
+}
+
+/**
+ * Null when no thread view is on screen — the palette then reports a declined
+ * open to the plugin rather than pretending. During a focus handover two views
+ * can briefly claim focus; the most recent one wins.
+ */
+export function getActiveThreadPanelOpener(): PluginThreadPanelOpenHandler | null {
+  let active: PluginThreadPanelOpenHandler | null = null;
+  for (const opener of focusedOpeners.values()) active = opener;
+  return active;
+}
+
+export function resetActiveThreadPanelOpenerForTest(): void {
+  focusedOpeners.clear();
 }

--- a/apps/app/src/lib/command-palette/palette-plugin-actions.test.ts
+++ b/apps/app/src/lib/command-palette/palette-plugin-actions.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PluginThreadPanelOpenHandler } from "@/components/plugin/plugin-thread-panel-navigation";
+import type { PluginCommandPaletteActionSlot } from "@/lib/plugin-slots";
+import { buildPluginPaletteActions } from "./palette-plugin-actions";
+
+function slot(
+  overrides: Partial<PluginCommandPaletteActionSlot> & { id: string },
+): PluginCommandPaletteActionSlot {
+  return {
+    pluginId: "linear",
+    generation: 1,
+    title: `Title ${overrides.id}`,
+    run: () => {},
+    ...overrides,
+  };
+}
+
+function build(
+  slots: PluginCommandPaletteActionSlot[],
+  openThreadPanel: PluginThreadPanelOpenHandler | null = null,
+) {
+  return buildPluginPaletteActions({
+    slots,
+    threadId: "thr_1",
+    projectId: "proj_1",
+    openThreadPanel,
+  });
+}
+
+describe("buildPluginPaletteActions", () => {
+  it("drops a row whose isAvailable declines or throws", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const rows = build([
+      slot({ id: "listed" }),
+      slot({ id: "declined", isAvailable: () => false }),
+      slot({
+        id: "exploded",
+        isAvailable: () => {
+          throw new Error("boom");
+        },
+      }),
+    ]);
+    // A plugin that throws while the palette is deciding what to show must not
+    // take the palette down, and must not be listed on a guess.
+    expect(rows.map((row) => row.id)).toEqual(["plugin:linear/listed"]);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("routes openPanel to the focused thread view, or declines without one", () => {
+    const openThreadPanel: PluginThreadPanelOpenHandler = vi.fn(() => true);
+    const opened: boolean[] = [];
+    build(
+      [
+        slot({
+          id: "panel",
+          run: ({ openPanel }) => {
+            opened.push(openPanel({ actionId: "issue-panel" }));
+          },
+        }),
+      ],
+      openThreadPanel,
+    )[0]?.run();
+    // The plugin id is the host's half of the lookup: without it the opener
+    // cannot tell whose `threadPanelAction` "issue-panel" names.
+    expect(openThreadPanel).toHaveBeenCalledWith({
+      actionId: "issue-panel",
+      pluginId: "linear",
+    });
+    expect(opened).toEqual([true]);
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    build([
+      slot({
+        id: "panel",
+        run: ({ openPanel }) => {
+          opened.push(openPanel({ actionId: "issue-panel" }));
+        },
+      }),
+    ])[0]?.run();
+    expect(opened).toEqual([true, false]);
+    warn.mockRestore();
+  });
+});

--- a/apps/app/src/lib/command-palette/palette-plugin-actions.ts
+++ b/apps/app/src/lib/command-palette/palette-plugin-actions.ts
@@ -1,0 +1,83 @@
+import type { PluginCommandPaletteActionContext } from "@get-bb/plugin-sdk";
+import type { PluginThreadPanelOpenHandler } from "@/components/plugin/plugin-thread-panel-navigation";
+import type { PluginCommandPaletteActionSlot } from "@/lib/plugin-slots";
+import type { PaletteAction } from "./palette-action";
+
+export interface BuildPluginPaletteActionsArgs {
+  slots: readonly PluginCommandPaletteActionSlot[];
+  threadId: string | null;
+  projectId: string | null;
+  /** The focused thread view's opener, or null when no thread is on screen. */
+  openThreadPanel: PluginThreadPanelOpenHandler | null;
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function actionContext(
+  slot: PluginCommandPaletteActionSlot,
+  args: BuildPluginPaletteActionsArgs,
+): PluginCommandPaletteActionContext {
+  return {
+    threadId: args.threadId,
+    projectId: args.projectId,
+    openPanel: (options) => {
+      if (args.openThreadPanel === null) {
+        console.warn(
+          `[plugin:${slot.pluginId}] commandPaletteAction "${slot.id}" openPanel declined: no thread side panel on this surface`,
+        );
+        return false;
+      }
+      return args.openThreadPanel({ ...options, pluginId: slot.pluginId });
+    },
+  };
+}
+
+/**
+ * Plugin `commandPaletteAction` rows for the surface the palette opened on.
+ *
+ * `isAvailable` and `run` are plugin code running inside host chrome, so both
+ * are contained: a row whose `isAvailable` throws is treated as unavailable
+ * rather than taking the palette down with it.
+ */
+export function buildPluginPaletteActions(
+  args: BuildPluginPaletteActionsArgs,
+): PaletteAction[] {
+  const actions: PaletteAction[] = [];
+  for (const slot of args.slots) {
+    const context = actionContext(slot, args);
+    if (slot.isAvailable !== undefined) {
+      let available: boolean;
+      try {
+        available = slot.isAvailable(context);
+      } catch (error) {
+        console.warn(
+          `[plugin:${slot.pluginId}] commandPaletteAction "${slot.id}" isAvailable failed: ${describeError(error)}`,
+        );
+        continue;
+      }
+      if (!available) continue;
+    }
+    actions.push({
+      id: `plugin:${slot.pluginId}/${slot.id}`,
+      group: "Plugins",
+      title: slot.title,
+      shortcut: null,
+      run: () => {
+        const warn = (error: unknown) => {
+          console.warn(
+            `[plugin:${slot.pluginId}] commandPaletteAction "${slot.id}" failed: ${describeError(error)}`,
+          );
+        };
+        try {
+          const result = slot.run(context);
+          if (result instanceof Promise) result.catch(warn);
+        } catch (error) {
+          warn(error);
+        }
+      },
+    });
+  }
+  return actions;
+}

--- a/apps/app/src/lib/plugin-slots.ts
+++ b/apps/app/src/lib/plugin-slots.ts
@@ -5,6 +5,7 @@ import type {
   PluginPendingInteractionRegistration,
   PluginFileOpenerRegistration,
   PluginHomepageSectionRegistration,
+  PluginCommandPaletteActionRegistration,
   PluginMessageActionRegistration,
   PluginMessageDirectiveRegistration,
   PluginNavPanelRegistration,
@@ -54,6 +55,8 @@ export interface PluginRegistrationSet {
   messageDirectives: readonly PluginMessageDirectiveRegistration[];
   messageActions?: readonly PluginMessageActionRegistration[];
   /** Optional for the same reason as `threadLists`: bundles built earlier. */
+  commandPaletteActions?: readonly PluginCommandPaletteActionRegistration[];
+  /** Optional for the same reason as `threadLists`: bundles built earlier. */
   providerIcons?: readonly PluginProviderIconRegistration[];
 }
 
@@ -98,6 +101,8 @@ export interface PluginMessageDirectiveSlot
   extends PluginMessageDirectiveRegistration, PluginSlotBase {}
 export interface PluginMessageActionSlot
   extends PluginMessageActionRegistration, PluginSlotBase {}
+export interface PluginCommandPaletteActionSlot
+  extends PluginCommandPaletteActionRegistration, PluginSlotBase {}
 interface PluginProviderIconSlot
   extends PluginProviderIconRegistration, PluginSlotBase {}
 
@@ -118,6 +123,7 @@ export interface PluginSlotSnapshot {
   diffRenderers: readonly PluginDiffRendererSlot[];
   messageDirectives: readonly PluginMessageDirectiveSlot[];
   messageActions: readonly PluginMessageActionSlot[];
+  commandPaletteActions: readonly PluginCommandPaletteActionSlot[];
   providerIcons: readonly PluginProviderIconSlot[];
 }
 
@@ -137,6 +143,7 @@ export const EMPTY_PLUGIN_SLOT_SNAPSHOT: PluginSlotSnapshot = {
   diffRenderers: [],
   messageDirectives: [],
   messageActions: [],
+  commandPaletteActions: [],
   providerIcons: [],
 };
 
@@ -163,6 +170,7 @@ const SLOT_KINDS: readonly SlotKind[] = [
   "diffRenderers",
   "messageDirectives",
   "messageActions",
+  "commandPaletteActions",
   "providerIcons",
 ];
 
@@ -210,6 +218,7 @@ function flattenRegistrations(
     diffRenderers: stamp(set.diffRenderers),
     messageDirectives: stamp(set.messageDirectives),
     messageActions: stamp(set.messageActions),
+    commandPaletteActions: stamp(set.commandPaletteActions),
     providerIcons: stamp(set.providerIcons),
   };
 }

--- a/apps/app/src/views/thread-detail/ThreadDetailView.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailView.tsx
@@ -187,7 +187,10 @@ import {
   usePluginPanelActions,
 } from "@/components/plugin/PluginPanelActions";
 import { createFileOpenerOriginalTab } from "@/components/plugin/file-opener-tabs";
-import { PluginThreadPanelNavigationProvider } from "@/components/plugin/plugin-thread-panel-navigation";
+import {
+  PluginThreadPanelNavigationProvider,
+  usePublishThreadPanelOpener,
+} from "@/components/plugin/plugin-thread-panel-navigation";
 import { ThreadTimelineNavigationProvider } from "@/components/thread/timeline/ThreadTimelineNavigationContext";
 import { usePluginSlots } from "@/lib/plugin-slots";
 import { getFileExtension } from "@/lib/plugin-slot-resolvers";
@@ -2245,6 +2248,9 @@ function ThreadDetailViewInternal(props: ThreadRoutePathArgs) {
     environment,
     hasWorkspaceOpenTargets: directoryOpenTargets.length > 0,
   });
+  // The quick palette is mounted outside this view's provider, so publish the
+  // opener for it. Focused pane only: a split has one per pane.
+  usePublishThreadPanelOpener(handleOpenTimelinePluginPanel, isFocused);
   useAppCommandHandler("workspace.openPreferred", () => {
     if (!isFocused) return false;
     if (activeWorkspaceFilePath && handleOpenFileInEditor) {

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
@@ -1871,6 +1871,18 @@ openWorkspaceFile }` — register a leaf
   `useBbNavigate().openThreadPanel`. Errors from `run` (sync or
   async) are contained and
   logged, never breaking the timeline.
+- `commandPaletteAction` → a row in bb's quick palette (Mod+Shift+P), listed
+  under "Plugins" beside bb's own commands. Host-rendered chrome, no plugin
+  component — registration: `{ id, title, isAvailable?, run }`. Both callbacks
+  receive `{ threadId, projectId, openPanel }`, where `threadId` and
+  `projectId` are null on surfaces without one and `openPanel` matches
+  `messageAction`'s. `isAvailable` is called while the palette is open — keep
+  it cheap and synchronous — and hides the row when it returns false; a row
+  that needs a thread should use it, because the palette opens anywhere and
+  `openPanel` declines (returning false) unless a thread view is focused.
+  Errors from either callback are contained and logged, never breaking the
+  palette. Write self-identifying titles ("Linear: open issue for this
+  thread"): the palette matches the query against the title.
 - `experimental_providerIcon` → the React component bb draws as one agent
   provider's icon. Registration: `{ providerId, icon }`, where `providerId` is
   the provider's id (`"codex"`, `"acp-cursor"`) — not the plugin id — and

--- a/apps/server/test/services/plugins/plugin-authoring-docs.test.ts
+++ b/apps/server/test/services/plugins/plugin-authoring-docs.test.ts
@@ -12,6 +12,8 @@ import {
   type PluginFileOpenerProps,
   type PluginHomepageSectionProps,
   type PluginHttpAuthMode,
+  type PluginCommandPaletteActionContext,
+  type PluginCommandPaletteActionRegistration,
   type PluginMessageActionContext,
   type PluginMessageActionRegistration,
   type PluginMessageDirectiveProps,
@@ -169,6 +171,7 @@ type SlotPropsByName = {
   experimental_diffRenderer: PluginDiffRendererProps;
   messageDirective: PluginMessageDirectiveProps;
   messageAction: PluginMessageActionContext;
+  commandPaletteAction: PluginCommandPaletteActionContext;
   // Registration-object slot: the component receives only className, so the
   // registration type is the documented surface.
   experimental_providerIcon: PluginProviderIconRegistration;
@@ -263,6 +266,7 @@ const FRONTEND_SLOT_PROP_FIELDS = {
   ],
   messageDirective: ["attributes", "source", "message", "openWorkspaceFile"],
   messageAction: ["threadId", "message", "selectedText", "openPanel"],
+  commandPaletteAction: ["threadId", "projectId", "openPanel"],
   experimental_providerIcon: ["providerId", "icon"],
 } as const satisfies {
   [S in keyof SlotPropsByName]: readonly (keyof SlotPropsByName[S])[];
@@ -335,6 +339,22 @@ const _assertAllMessageActionRegistrationFieldsListed: MissingMessageActionRegis
   ? true
   : never = true;
 void _assertAllMessageActionRegistrationFieldsListed;
+
+const COMMAND_PALETTE_ACTION_REGISTRATION_FIELDS = [
+  "id",
+  "title",
+  "isAvailable",
+  "run",
+] as const satisfies readonly (keyof PluginCommandPaletteActionRegistration)[];
+
+type MissingCommandPaletteActionRegistrationField = Exclude<
+  keyof PluginCommandPaletteActionRegistration,
+  (typeof COMMAND_PALETTE_ACTION_REGISTRATION_FIELDS)[number]
+>;
+const _assertAllCommandPaletteActionRegistrationFieldsListed: MissingCommandPaletteActionRegistrationField extends never
+  ? true
+  : never = true;
+void _assertAllCommandPaletteActionRegistrationFieldsListed;
 
 /**
  * Mirrors ThreadChatProps (app-contract.ts), compile-time checked in both
@@ -480,6 +500,15 @@ describe("bb-plugin-authoring skill", () => {
       ).toContain(field);
     }
     expect(skill).toContain("sourceSeqEnd");
+  });
+
+  it("documents every commandPaletteAction registration field", () => {
+    for (const field of COMMAND_PALETTE_ACTION_REGISTRATION_FIELDS) {
+      expect(
+        skill,
+        `commandPaletteAction registration field "${field}" is not documented in the skill`,
+      ).toContain(field);
+    }
   });
 
   it("documents every ThreadChat prop", () => {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -224,7 +224,7 @@ above for a connected Magic Keyboard.
 Enter. It lists only commands that apply on the current surface, shows each
 one's shortcut, and offers recently run commands first. The numbered
 accelerator families and the relative cycle commands stay rebindable but
-unlisted.
+unlisted. Plugins can add their own rows, listed under "Plugins".
 
 Settings → Keyboard edits app command shortcuts. Overrides are stored in the
 server database, applied live to every connected window, and kept across

--- a/packages/plugin-sdk/src/app-contract.ts
+++ b/packages/plugin-sdk/src/app-contract.ts
@@ -1038,6 +1038,47 @@ export interface PluginMessageActionRegistration {
   run(context: PluginMessageActionContext): void | Promise<void>;
 }
 
+/** Context handed to a `commandPaletteAction`'s `isAvailable` and `run`. */
+export interface PluginCommandPaletteActionContext {
+  /** The thread in view, or null on a surface without one. */
+  threadId: string | null;
+  projectId: string | null;
+  /**
+   * Open one of this plugin's `threadPanelAction` components in the current
+   * thread's side panel, exactly as `messageAction`'s `openPanel` does.
+   *
+   * Returns true when the host accepted the open; false when it declined —
+   * `params` was not a JSON value, the action id names no `threadPanelAction`
+   * of this plugin, or the surface has no side panel. Only the main thread
+   * view has one, and the palette opens anywhere, so guard with `isAvailable`
+   * rather than assuming.
+   */
+  openPanel(options: PluginTargetedPanelActionOpenOptions): boolean;
+}
+
+/**
+ * A row in bb's quick palette (Mod+Shift+P), listed under the plugin's name
+ * beside bb's own commands. Host-rendered: the plugin supplies a title and
+ * `run`, and the host owns matching, ordering, and recency.
+ */
+export interface PluginCommandPaletteActionRegistration {
+  /** Unique within the plugin; letters, digits, `-`, `_`. */
+  id: string;
+  /** The row's label, e.g. "Linear: open issue for this thread". */
+  title: string;
+  /**
+   * Hide the row when it cannot do anything — typically when it needs a thread
+   * and there is none. Called while the palette is open; keep it cheap and
+   * synchronous. Omitted means always listed.
+   */
+  isAvailable?(context: PluginCommandPaletteActionContext): boolean;
+  /**
+   * Runs after the palette closes and focus is restored. Errors (sync or
+   * async) are contained and logged; they never break the palette.
+   */
+  run(context: PluginCommandPaletteActionContext): void | Promise<void>;
+}
+
 /**
  * Supply the inline React mark bb draws for one agent provider.
  *
@@ -1119,6 +1160,13 @@ export interface PluginAppSlots {
   experimental_diffRenderer(registration: PluginDiffRendererRegistration): void;
   messageDirective(registration: PluginMessageDirectiveRegistration): void;
   messageAction(registration: PluginMessageActionRegistration): void;
+  /**
+   * Add a row to the quick palette (see
+   * {@link PluginCommandPaletteActionRegistration}).
+   */
+  commandPaletteAction(
+    registration: PluginCommandPaletteActionRegistration,
+  ): void;
   /**
    * Draw one agent provider's icon with an inline React component instead of
    * its `<img>`-rendered logo file (see

--- a/packages/plugin-sdk/src/internal/plugin-app-collector.ts
+++ b/packages/plugin-sdk/src/internal/plugin-app-collector.ts
@@ -5,6 +5,7 @@ import type {
   PluginDiffRendererRegistration,
   PluginFileOpenerRegistration,
   PluginHomepageSectionRegistration,
+  PluginCommandPaletteActionRegistration,
   PluginMessageActionRegistration,
   PluginMessageDirectiveRegistration,
   PluginNavPanelRegistration,
@@ -51,6 +52,7 @@ export interface CollectedPluginAppRegistrations {
   diffRenderers: PluginDiffRendererRegistration[];
   messageDirectives: PluginMessageDirectiveRegistration[];
   messageActions: PluginMessageActionRegistration[];
+  commandPaletteActions: PluginCommandPaletteActionRegistration[];
   providerIcons: PluginProviderIconRegistration[];
   contentScripts: PluginContentScriptRegistration[];
 }
@@ -82,6 +84,7 @@ export function collectPluginAppRegistrations(
     diffRenderers: [],
     messageDirectives: [],
     messageActions: [],
+    commandPaletteActions: [],
     providerIcons: [],
     contentScripts: [],
   };
@@ -101,6 +104,7 @@ export function collectPluginAppRegistrations(
     diffRenderer: new Set<string>(),
     messageDirective: new Set<string>(),
     messageAction: new Set<string>(),
+    commandPaletteAction: new Set<string>(),
     providerIcon: new Set<string>(),
     contentScript: new Set<string>(),
   };
@@ -446,6 +450,28 @@ export function collectPluginAppRegistrations(
             ? {
                 icon: requireNonEmptyString(kind, "icon", registration.icon),
               }
+            : {}),
+          run: registration.run,
+        });
+      },
+      commandPaletteAction(registration) {
+        const kind = "slots.commandPaletteAction";
+        const id = requireSlotId(kind, registration?.id);
+        requireUniqueId(kind, seenIds.commandPaletteAction, id);
+        if (typeof registration.run !== "function") {
+          throw new Error(`${kind}: "run" must be a function`);
+        }
+        if (
+          registration.isAvailable !== undefined &&
+          typeof registration.isAvailable !== "function"
+        ) {
+          throw new Error(`${kind}: "isAvailable" must be a function`);
+        }
+        collected.commandPaletteActions.push({
+          id,
+          title: requireNonEmptyString(kind, "title", registration.title),
+          ...(registration.isAvailable !== undefined
+            ? { isAvailable: registration.isAvailable }
             : {}),
           run: registration.run,
         });


### PR DESCRIPTION
## Human comments

Now plugins can add commands to the quick palette too, through calling the `app.slots.commandPaletteAction` API:
```tsx
app.slots.commandPaletteAction({
  id: "open-issue",
  title: "Linear: open issue for this thread",
  isAvailable: ({ threadId }) => threadId !== null,
  run: ({ threadId, openPanel }) =>
    openPanel({ actionId: "issue-panel", params: { threadId } }),
});
```

The `id` has to be unique for a plugin. The `run` method can take in the `threadId`, `projectId`, and an `openPanel` function which is similar to the one from `messageAction` (it can be used to open a side panel for the plugin when you're looking at a thread). 

This is meant to be called in the `app` entry point for a plugin inside `definePluginApp` for it to register the quick palette actions on init.

------

## What was wrong

The quick palette lists bb's own commands and nothing else, so a plugin had no
way to offer a keyboard-reachable action. Its nearest existing options are a
sidebar footer icon, a per-message action, or a thread panel the user has to
find — none of which answer "I know what I want, let me type its name".

## What changed

A new `app.slots.commandPaletteAction`, host-rendered chrome with no plugin
component, the same shape as `messageAction` and `sidebarFooterAction`:

```tsx
app.slots.commandPaletteAction({
  id: "open-issue",
  title: "Linear: open issue for this thread",
  isAvailable: ({ threadId }) => threadId !== null,
  run: ({ threadId, openPanel }) =>
    openPanel({ actionId: "issue-panel", params: { threadId } }),
});
```

Four members. No icon, description, or keywords: every public member is
surface area maintained forever, plugin rows already carry self-identifying
titles, and the palette matches on the title. Shipped without an
`experimental_` prefix — a deliberate exception to the AGENTS.md Plugin API
rule, on the grounds that this is two required fields and two callbacks over
types that already exist (`PluginTargetedPanelActionOpenOptions` is shared
with `messageAction`), so no bake period would answer anything.

- **`app-contract.ts`, `plugin-app-collector.ts`, `plugin-slots.ts`** — the
  slot, its validation at the collector boundary, and the client store entry.
  `PluginRegistrationSet.commandPaletteActions` is optional so a bundle built
  against an older SDK still satisfies the set.
- **`plugin-thread-panel-navigation.tsx`, `ThreadDetailView.tsx`** — the part
  worth review. `openPanel` is backed by a React context provided *inside*
  `ThreadDetailView`, so it reaches the timeline but nothing mounted outside
  that subtree; the palette is mounted by `AppLayout` beside the routes and can
  never read it. The focused thread view now also publishes its opener to a
  module-level store the palette reads. Only the focused pane publishes: a
  split mounts one thread view per pane, each with its own panel tabs, so "the
  thread side panel" otherwise has no single meaning. A lone thread view counts
  as focused. With nothing focused the store reports null and `openPanel`
  declines instead of pretending.
- **`palette-plugin-actions.ts`, `CommandPalette.tsx`, `AppLayout.tsx`** — read
  the slot snapshot when the palette opens, group rows under "Plugins", contain
  plugin failures. A row whose `isAvailable` throws is treated as unavailable
  rather than taking the palette down.
- **`SKILL.md`** — the authoring entry, which ships in the same commit as the
  slot because `plugin-authoring-docs.test.ts` asserts every slot and prop
  field is documented from the moment the slot exists, and its compile-time
  guards reject a `PluginAppSlots` method with no entry there.
  **`docs/configuration.md`** — the user-facing note.

Rows group under "Plugins" rather than the plugin's name: there is no
always-loaded plugin-name map on the client, and adding a query to the palette
for a group label is not worth it. Revisit if one appears.

No wire change; `HOST_DAEMON_PROTOCOL_VERSION` untouched.

## How you verified

Five tests, scoped to what could break silently and is not covered elsewhere:

- `palette-plugin-actions.test.ts` — an `isAvailable` that declines *or throws*
  drops the row; `openPanel` forwards to the focused view's opener with the
  plugin's id (the host's half of the lookup) and declines without one.
- `plugin-thread-panel-navigation.test.tsx` — the focused pane's opener wins and
  refocusing switches it; no focus reports null. Opening in the wrong pane
  would be a silent, plausible-looking bug.
- `CommandPalette.test.tsx` — a registered slot reaches the palette and runs.

Deliberately no collector tests for duplicate ids or a non-function `run`:
those exercise `requireSlotId`/`requireUniqueId`, shared validators already
covered by the app-harness tests for other slots.

`pnpm exec turbo run typecheck` clean across the workspace; lint 0 errors;
`@get-bb/plugin-sdk` 129 tests, `@bb/server` and the app suite (3256) pass.
Each of the three commits typechecks *and* passes the plugin-authoring docs
guard on its own.

Two unrelated failures seen locally, neither from this branch:
`PluginIcon.test.tsx` throws `ENOENT` on a stray empty `plugins/monaco/`
directory in the local checkout (reproduces on clean `main`), and
`PromptBoxInternal`'s selection-reveal test failed once under full-suite
parallelism but passes in isolation on this branch and on `main`.

> AGENT GENERATED: by Claude Opus 5

