### PR TITLE
Bump the plugin SDK version, and fail CI when it is missed

### DIFF
--- a/.github/workflows/check-plugin-sdk-version.mjs
+++ b/.github/workflows/check-plugin-sdk-version.mjs
@@ -1,0 +1,81 @@
+import { execFileSync } from "node:child_process";
+
+/**
+ * A change to the published plugin SDK surface must bump PLUGIN_SDK_VERSION.
+ *
+ * Pre-1.0 the major is the compatibility number and never moves for additive
+ * work, so the patch is the only thing a plugin author can point
+ * `engines.bbPluginSdk` at to say "I need a host new enough to have this" —
+ * `isPluginSdkRangeSatisfied` reads that range as a floor within the major.
+ * Ship a new export without a bump and a plugin using it has no version to
+ * require, so installing it on an older bb fails at runtime instead of
+ * legibly at load.
+ *
+ * Nothing else catches this: `version.test.ts` only checks that package.json
+ * and the constant agree with each other, and `app-contract.ts` has no
+ * enumerated export list the way the backend, rpc, and host contracts do.
+ */
+const SURFACE_PATHS = [
+  "packages/plugin-sdk/src/app-contract.ts",
+  "packages/plugin-sdk/src/app.ts",
+  "packages/plugin-sdk/src/backend-contract.ts",
+  "packages/plugin-sdk/src/host-contract.ts",
+  "packages/plugin-sdk/src/host.ts",
+  "packages/plugin-sdk/src/index.ts",
+  "packages/plugin-sdk/src/provider-bridge.ts",
+  "packages/plugin-sdk/src/rpc-contract.ts",
+];
+
+const VERSION_PATH = "packages/domain/src/plugin-sdk-version.ts";
+
+function git(...args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+/**
+ * The commit this branch left the base at. Returns null when it cannot be
+ * resolved — an unattended push to a fork with no base, say — and the check
+ * then passes rather than failing on something the author cannot act on.
+ */
+function resolveMergeBase() {
+  const baseRef = process.env.GITHUB_BASE_REF || "main";
+  for (const candidate of [`origin/${baseRef}`, baseRef]) {
+    try {
+      return git("merge-base", candidate, "HEAD");
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+const mergeBase = resolveMergeBase();
+if (mergeBase === null) {
+  console.log("No base commit to compare against; skipping.");
+  process.exit(0);
+}
+
+const changed = new Set(
+  git("diff", "--name-only", `${mergeBase}...HEAD`).split("\n").filter(Boolean),
+);
+const changedSurface = SURFACE_PATHS.filter((path) => changed.has(path));
+
+if (changedSurface.length === 0) {
+  console.log("Plugin SDK surface unchanged.");
+  process.exit(0);
+}
+
+if (!changed.has(VERSION_PATH)) {
+  console.error(
+    `The plugin SDK surface changed without a version bump:\n` +
+      changedSurface.map((path) => `  ${path}`).join("\n") +
+      `\n\nBump PLUGIN_SDK_VERSION in ${VERSION_PATH} (patch, pre-1.0) and` +
+      ` keep packages/plugin-sdk/package.json in step, so a plugin using the` +
+      ` new surface can require a host that has it.`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `Plugin SDK surface changed in ${changedSurface.length} file(s) with a version bump.`,
+);

--- a/.github/workflows/version-lockstep.yml
+++ b/.github/workflows/version-lockstep.yml
@@ -25,3 +25,23 @@ jobs:
 
       - name: Check version lockstep
         run: node .github/workflows/check-version-lockstep.mjs
+
+  plugin-sdk:
+    name: Check plugin SDK version bump
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The check diffs against the merge base, which a shallow clone lacks.
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22.x
+
+      - name: Check plugin SDK version bump
+        run: node .github/workflows/check-plugin-sdk-version.mjs

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -16,7 +16,7 @@
 // PLUGIN_SDK_MAJOR is 0, so the major-only artifact gate cannot distinguish
 // 0.x releases and is intentionally vacuous for them until a future 1.0.
 // Rebuildable artifacts still rebuild on the exact sdkVersion-differs trigger.
-export const PLUGIN_SDK_VERSION = "0.4.13";
+export const PLUGIN_SDK_VERSION = "0.4.14";
 
 /** Major of {@link PLUGIN_SDK_VERSION} — the plugin API compatibility number. */
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"


### PR DESCRIPTION
now it should be impossible to accidentally change plugin API without bumping the SDK version

we can delete this if later we decide actually want to iterate faster without bumping sdk version

## What was wrong

#2270 added `app.slots.commandPaletteAction` — a public plugin API member —
without moving `PLUGIN_SDK_VERSION`. Pre-1.0 the major is the compatibility
number and never moves for additive work, so the patch is the only thing a
plugin author can point `engines.bbPluginSdk` at: `isPluginSdkRangeSatisfied`
reads that range as a floor within the major. Without a bump, a plugin using
the new slot has no version to require, so installing it on an older bb fails
at runtime instead of legibly at load.

Nothing caught it. `version.test.ts` only asserts that
`packages/plugin-sdk/package.json` and `PLUGIN_SDK_VERSION` agree with *each
other*, never that a surface change moved either. And unlike the backend, rpc,
and host contracts — each of which has an enumerated export list in
`public-types.test.ts` that a new export forces you to edit — `app-contract.ts`
has no such list, so nothing about the change was visible in review either.

The recent history shows the convention is real: 0.4.9→0.4.10 (plugin styles),
0.4.10→0.4.11 (provider v3), 0.4.11→0.4.12 (`experimental_fullFileContents`),
0.4.12→0.4.13 (quick palette). #2270 is the break in that run, alongside
`3f86b7c80` (#1469), which added 68 lines to `app-contract.ts` with no bump.

## What changed

- **`packages/domain/src/plugin-sdk-version.ts`, `packages/plugin-sdk/package.json`**
  — 0.4.13 → 0.4.14, keeping the two in the lockstep `version.test.ts` checks.
- **`.github/workflows/check-plugin-sdk-version.mjs`** — diffs the branch
  against its merge base and fails when it touches a published contract or
  entry file (`app-contract`, `backend-contract`, `host-contract`,
  `rpc-contract`, `provider-bridge`, and the `index`/`app`/`host` entries)
  without touching the version file. The message names the offending paths and
  what to do. An unresolvable base skips rather than failing on something the
  author cannot act on.
- **`.github/workflows/version-lockstep.yml`** — runs it as a second job. It
  needs `fetch-depth: 0` for the merge base, so it is a separate job rather
  than a step on the existing shallow-clone one.

The check is a workflow script rather than a vitest test because the signal is
a diff against a base commit, which a unit test has no access to. It follows
the existing `check-version-lockstep.mjs` pattern.

## How you verified

Ran the script against three real branch states:

- this branch (version bumped, no contract change) → "Plugin SDK surface
  unchanged", exit 0
- a scratch branch off `main` touching `app-contract.ts` with no bump → fails,
  naming the file — i.e. it reproduces exactly the miss in #2270
- the same branch with the bump added → passes

Also confirmed no stale pins: `plugins/*/dist/*.meta.json` carry `0.4.13` but
are untracked build artifacts that re-stamp on the next build, and
`plugins/tasks` declares `bbPluginSdk: ">=0.4.13"`, a floor that 0.4.14 still
satisfies.

`@get-bb/plugin-sdk` 129 tests and `@bb/server` 1922 tests pass; typecheck
clean for `@get-bb/plugin-sdk`, `@bb/domain`, and `@bb/server`; the workflow
YAML parses.

> AGENT GENERATED: by Claude Opus 5
