### PR TITLE
Keep the thread panel host mounted across thread navigation

### DIFF
--- a/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
+++ b/apps/app/src/components/secondary-panel/ThreadSecondaryPanel.tsx
@@ -6,6 +6,7 @@ import {
   type TransitionEvent,
   useCallback,
   useContext,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -385,6 +386,14 @@ export function ThreadSecondaryPanel({
   // silently closing it again. Only a collapse from a layout this Panel
   // instance actually held expanded may close the persisted panel.
   const hasPanelExpandedRef = useRef(false);
+  // The panel host survives thread navigation (stable panelGroupKey on the
+  // thread-detail layout), so the guard must re-arm per thread: a collapse
+  // applied while showing the next thread must not pass on the previous
+  // thread's expansion. Child layout effects run before the parent group's
+  // setLayout effect, so this reset lands first.
+  useLayoutEffect(() => {
+    hasPanelExpandedRef.current = false;
+  }, [splitPanelStateId]);
   const handlePanelResize = useCallback(
     (size: number) => {
       if (size > 0) {

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -422,6 +422,49 @@ describe("ThreadDetailSecondaryContent", () => {
     });
   });
 
+  it("keeps the panel subtree mounted when navigating between threads", async () => {
+    const props = createProps();
+    const { rerender } = render(
+      <MemoryRouter>
+        <DefaultPaneContextProvider>
+          <CompactViewportOverrideProvider isCompactViewport={false}>
+            <ThreadDetailSecondaryContent {...props} />
+          </CompactViewportOverrideProvider>
+        </DefaultPaneContextProvider>
+      </MemoryRouter>,
+    );
+
+    const sidePanel = await screen.findByTestId(
+      "inline-secondary-panel",
+      {},
+      { timeout: 5_000 },
+    );
+    const panelGroup = screen.getByTestId("panel-group");
+
+    const nextProps = createProps();
+    nextProps.timeline = {
+      ...nextProps.timeline,
+      threadId: "thread-2",
+    } as ThreadDetailSecondaryContentProps["timeline"];
+    rerender(
+      <MemoryRouter>
+        <DefaultPaneContextProvider>
+          <CompactViewportOverrideProvider isCompactViewport={false}>
+            <ThreadDetailSecondaryContent {...nextProps} />
+          </CompactViewportOverrideProvider>
+        </DefaultPaneContextProvider>
+      </MemoryRouter>,
+    );
+
+    // Navigation swaps content identity but must not remount the physical
+    // panel host: same DOM nodes for the group and the realized side panel.
+    expect(screen.getByTestId("panel-group")).toBe(panelGroup);
+    expect(screen.getByTestId("inline-secondary-panel")).toBe(sidePanel);
+    expect(
+      screen.getByTestId("thread-timeline-pane").getAttribute("data-thread-id"),
+    ).toBe("thread-2");
+  });
+
   it("only requests the forks list while the secondary panel is open", () => {
     const props = createProps();
     const { rerender } = render(

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.tsx
@@ -125,6 +125,11 @@ function ThreadDetailSecondaryContentBody({
         open={isSecondaryPanelOpen}
         onToggle={onToggleSecondaryPanel}
         onClose={threadSecondaryPanelProps.onClose}
+        // The physical panel host survives thread-to-thread navigation; only
+        // content identity (resetKey) changes. Per-thread state below is safe:
+        // the timeline, composer and scroll anchors live under PageShell's own
+        // key={threadId} inside EmbeddedThreadChat.
+        panelGroupKey="thread-detail"
         resetKey={timeline.threadId}
         contentKey={timeline.threadId}
         drawerLabel="Thread details"


### PR DESCRIPTION
## What was wrong
Thread-to-thread navigation remounted the SecondaryPanelLayout PanelGroup (group key defaulted to resetKey = thread id): the realized secondary panel (diff, metadata, browser deck) was destroyed and rebuilt per navigate on desktop-inline layouts, and panel sizes reset every time.

## What changed
Pass the documented `panelGroupKey` escape hatch (same pattern as PluginPanelRightPanelHost) so the physical host survives navigation while content identity resets via resetKey. The `hasPanelExpandedRef` mount-collapse guard now re-arms per thread since the Panel instance survives.

## Scope, stated plainly
Desktop-inline improvement. On compact viewports the drawer already rendered outside the keyed group; the timeline/composer remount on any viewport is owned by PageShell's own key={threadId} (unchanged here). Drafts and scroll anchors live under that key, so nothing leaks between threads.

## How verified
Regression test (panel subtree DOM identity preserved across threadId change) fails without the fix, passes with it; typecheck + oxlint clean; adversarially reviewed before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)