### PR TITLE
Make the plugin composer host pull-based so keystrokes stop re-rendering the thread shell

### DIFF
--- a/apps/app/src/components/plugin/ComposerExtensionHost.test.tsx
+++ b/apps/app/src/components/plugin/ComposerExtensionHost.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { AppCommandProvider } from "@/components/commands/AppCommandProvider";
 import {
   usePluginComposerHost,
+  usePluginComposerHostDraft,
   useOptionalPluginComposerView,
   type PluginComposerHost,
 } from "./plugin-composer-host";
@@ -52,11 +53,12 @@ const draft = { text: "hello", mentions: [], attachments: [] };
 
 function RendererProbe() {
   const host = usePluginComposerHost();
+  const hostDraft = usePluginComposerHostDraft(host);
   const view = useOptionalPluginComposerView();
   return (
     <div
       data-testid="renderer"
-      data-host-text={host?.draft.text}
+      data-host-text={hostDraft?.text}
       data-scope={view?.scope.kind}
     />
   );
@@ -74,9 +76,9 @@ function Harness({
   const host = useMemo<PluginComposerHost>(
     () => ({
       scope: { kind: "thread", threadId: "thr_test" },
-      draft,
       textEffectKey: "thread/thr_test",
       getCurrent: () => draft,
+      subscribeDraft: () => () => {},
       setDraft: () => undefined,
       focus: mocks.focusHost,
     }),

--- a/apps/app/src/components/plugin/PluginComposerActions.stories.tsx
+++ b/apps/app/src/components/plugin/PluginComposerActions.stories.tsx
@@ -20,6 +20,7 @@ import { SidebarMenu, SidebarMenuItem } from "@/components/ui/sidebar";
 import { PromptBoxInternal } from "@/components/promptbox/PromptBoxInternal";
 import {
   PluginComposerHostProvider,
+  useComposerHostDraftNotifier,
   type PluginComposerHost,
 } from "@/components/plugin/plugin-composer-host";
 import {
@@ -237,16 +238,17 @@ function ThreadRowStatusFixture() {
   });
   const draftRef = useRef(draft);
   draftRef.current = draft;
+  const subscribeDraft = useComposerHostDraftNotifier(draft);
   const composerHost = useMemo<PluginComposerHost>(
     () => ({
       scope: { kind: "thread", threadId: THREAD_ID },
-      draft,
       textEffectKey: `story:${THREAD_ID}`,
       getCurrent: () => draftRef.current,
+      subscribeDraft,
       setDraft,
       focus: () => {},
     }),
-    [draft],
+    [subscribeDraft],
   );
   const [queryClient] = useState(
     () =>

--- a/apps/app/src/components/plugin/plugin-composer-host.tsx
+++ b/apps/app/src/components/plugin/plugin-composer-host.tsx
@@ -5,6 +5,7 @@ import {
   useEffect,
   useLayoutEffect,
   useMemo,
+  useRef,
   useState,
   useSyncExternalStore,
   type ReactNode,
@@ -18,12 +19,23 @@ import type { PromptDraftState } from "@bb/client-core";
  * authoritative even when the route points at another split pane and also
  * carries host-only state such as root-project selection or an inline queued
  * message editor.
+ *
+ * A host must stay referentially stable while the user types: it is published
+ * to the pane scope (and provided via context) where large non-draft
+ * subscribers such as the secondary-panel layout hold it, so a per-keystroke
+ * identity would re-render the whole thread shell per character. The live
+ * draft is therefore exposed as `getCurrent` + `subscribeDraft` instead of a
+ * value field; draft consumers read it via `usePluginComposerHostDraft`.
  */
 export interface PluginComposerHost {
   scope: PluginComposerScope;
-  draft: PromptDraftState;
   textEffectKey: string;
   getCurrent(): PromptDraftState;
+  /**
+   * Subscribes to changes of `getCurrent()`'s committed result. Returns an
+   * unsubscribe function. Must be identity-stable for the host's lifetime.
+   */
+  subscribeDraft(listener: () => void): () => void;
   setDraft(next: PromptDraftState): void;
   focus(): void;
 }
@@ -39,6 +51,58 @@ export function composerScopeIdentity(scope: PluginComposerScope): string {
     case "new-thread":
       return `new-thread/${scope.projectId ?? "unresolved"}`;
   }
+}
+
+const subscribeToNoDraft = () => () => {};
+const getNoDraft = () => null;
+
+/**
+ * The live draft of a composer host. This is the only reactive read of a
+ * host's draft: the host object itself stays identity-stable across
+ * keystrokes, so components that hold a host without calling this hook do not
+ * re-render while the user types.
+ */
+export function usePluginComposerHostDraft(
+  host: PluginComposerHost | null,
+): PromptDraftState | null {
+  const subscribe = host?.subscribeDraft ?? subscribeToNoDraft;
+  const getSnapshot = host?.getCurrent ?? getNoDraft;
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/**
+ * `subscribeDraft` for hosts whose draft lives in React state (the inline
+ * queued-message and sent-message editors) rather than in the prompt-draft
+ * store. Returns a stable subscribe function; listeners fire in a layout
+ * effect after a render committed a different `draft` identity, by which point
+ * the host's ref-backed `getCurrent` already returns the new value (edit
+ * commits write their ref synchronously, `useLatestRef` writes during render).
+ * Pass null while the corresponding editor is closed.
+ */
+export function useComposerHostDraftNotifier(
+  draft: PromptDraftState | null,
+): (listener: () => void) => () => void {
+  const [store] = useState(() => {
+    const listeners = new Set<() => void>();
+    return {
+      subscribe: (listener: () => void) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      notify: () => {
+        for (const listener of [...listeners]) listener();
+      },
+    };
+  });
+  const previousDraftRef = useRef(draft);
+  useLayoutEffect(() => {
+    if (previousDraftRef.current === draft) return;
+    previousDraftRef.current = draft;
+    store.notify();
+  }, [draft, store]);
+  return store.subscribe;
 }
 
 interface PluginComposerViewModelInput {

--- a/apps/app/src/components/plugin/plugin-slot-mounts.test.tsx
+++ b/apps/app/src/components/plugin/plugin-slot-mounts.test.tsx
@@ -48,6 +48,7 @@ import {
   PluginComposerHostProvider,
   PluginComposerHostScopeProvider,
   type PluginComposerHost,
+  useComposerHostDraftNotifier,
   usePublishPluginComposerHost,
 } from "./plugin-composer-host";
 import { PluginHomepageSections } from "./PluginHomepageSections";
@@ -512,6 +513,7 @@ describe("useComposer", () => {
       });
       const draftRef = useRef(draft);
       draftRef.current = draft;
+      const subscribeDraft = useComposerHostDraftNotifier(draft);
       const host = useMemo<PluginComposerHost>(
         () => ({
           scope: {
@@ -519,13 +521,13 @@ describe("useComposer", () => {
             threadId: "thr_queue",
             queuedMessageId,
           },
-          draft,
           textEffectKey: `queued-message:thr_queue:${queuedMessageId}:1`,
           getCurrent: () => draftRef.current,
+          subscribeDraft,
           setDraft,
           focus: () => {},
         }),
-        [draft, queuedMessageId],
+        [queuedMessageId, subscribeDraft],
       );
 
       return (
@@ -616,10 +618,10 @@ describe("useComposer", () => {
                   threadId: "thr_queue",
                   queuedMessageId: "qmsg_1",
                 },
-                draft,
                 textEffectKey:
                   "queued-message:thr_queue:qmsg_1:sibling-surface",
                 getCurrent: () => draft,
+                subscribeDraft: () => () => {},
                 setDraft,
                 focus: () => {},
               }
@@ -683,6 +685,7 @@ describe("useComposer", () => {
       });
       const draftRef = useRef(draft);
       draftRef.current = draft;
+      const subscribeDraft = useComposerHostDraftNotifier(draft);
       const host = useMemo<PluginComposerHost>(
         () => ({
           scope: {
@@ -692,13 +695,13 @@ describe("useComposer", () => {
             tabId: "side-chat:one",
             childThreadId,
           },
-          draft,
           textEffectKey: `side-chat:side-chat:one:${childThreadId ?? ""}`,
           getCurrent: () => draftRef.current,
+          subscribeDraft,
           setDraft,
           focus: () => {},
         }),
-        [childThreadId, draft],
+        [childThreadId, subscribeDraft],
       );
 
       return (
@@ -815,16 +818,17 @@ describe("useComposer", () => {
       });
       const draftRef = useRef(draft);
       draftRef.current = draft;
+      const subscribeDraft = useComposerHostDraftNotifier(draft);
       const host = useMemo<PluginComposerHost>(
         () => ({
           scope: { kind: "new-thread", projectId },
-          draft,
           textEffectKey: `root:${projectId}`,
           getCurrent: () => draftRef.current,
+          subscribeDraft,
           setDraft,
           focus: () => {},
         }),
-        [draft, projectId],
+        [projectId, subscribeDraft],
       );
 
       return (
@@ -901,9 +905,9 @@ describe("useComposer", () => {
         };
         return {
           scope: { kind: "new-thread", projectId },
-          draft,
           textEffectKey: `root-state:${projectId ?? "null"}`,
           getCurrent: () => draft,
+          subscribeDraft: () => () => {},
           setDraft: () => {},
           focus: () => {},
         };
@@ -1050,11 +1054,11 @@ describe("useComposer", () => {
             threadId: "thr_scope_owner",
             queuedMessageId,
           },
-          draft,
           // A host can retain its editable surface while its logical scope
           // changes, as root compose does when the selected project changes.
           textEffectKey: "shared-scope-effect",
           getCurrent: () => draft,
+          subscribeDraft: () => () => {},
           setDraft: () => {},
           focus: () => {},
         }),

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.test.tsx
@@ -361,9 +361,9 @@ describe("FollowUpPromptBox", () => {
         stack={<></>}
         pluginComposerHost={{
           scope: { kind: "thread", threadId: "thr_test" },
-          draft,
           textEffectKey: "thread:thr_test",
           getCurrent: () => draft,
+          subscribeDraft: () => () => {},
           setDraft: vi.fn(),
           focus: vi.fn(),
         }}
@@ -430,9 +430,9 @@ describe("FollowUpPromptBox", () => {
         stack={<div data-testid="queued-messages">Queued messages</div>}
         pluginComposerHost={{
           scope: { kind: "thread", threadId: "thr_test" },
-          draft,
           textEffectKey: "thread:thr_test",
           getCurrent: () => draft,
+          subscribeDraft: () => () => {},
           setDraft: vi.fn(),
           focus: vi.fn(),
         }}
@@ -611,9 +611,9 @@ describe("FollowUpPromptBox", () => {
           isPrimaryComposer={isPrimaryComposer}
           pluginComposerHost={{
             scope,
-            draft,
             textEffectKey: "queued:queued_1",
             getCurrent: () => draft,
+            subscribeDraft: () => () => {},
             setDraft: vi.fn(),
             focus: vi.fn(),
           }}

--- a/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
+++ b/apps/app/src/components/promptbox/FollowUpPromptBox.tsx
@@ -25,6 +25,7 @@ import {
   PluginComposerHostProvider,
   PluginComposerViewProvider,
   type PluginComposerHost,
+  usePluginComposerHostDraft,
   usePluginComposerViewModel,
 } from "@/components/plugin/plugin-composer-host";
 import {
@@ -262,11 +263,12 @@ function FollowUpPromptBoxStackOnly({
 >) {
   const composerScope =
     pluginComposerScope ?? pluginComposerHost?.scope ?? null;
+  const hostDraft = usePluginComposerHostDraft(pluginComposerHost ?? null);
   const composerView = usePluginComposerViewModel({
     scope: composerScope ?? DEFAULT_FOLLOW_UP_COMPOSER_SCOPE,
     layout: "expanded",
-    text: pluginComposerHost?.draft.text ?? "",
-    attachmentCount: pluginComposerHost?.draft.attachments.length ?? 0,
+    text: hostDraft?.text ?? "",
+    attachmentCount: hostDraft?.attachments.length ?? 0,
     isRunning: false,
     isSubmitting: false,
   });

--- a/apps/app/src/components/promptbox/NewThreadComposer.tsx
+++ b/apps/app/src/components/promptbox/NewThreadComposer.tsx
@@ -1013,21 +1013,23 @@ export function NewThreadComposer({
     () => promptDraftToInput(currentDraft),
     [currentDraft],
   );
+  // Identity-stable across keystrokes; the live draft flows through
+  // getCurrent/subscribeDraft (see PluginComposerHost).
   const pluginComposerHost = useMemo<PluginComposerHost>(
     () => ({
       scope: { kind: "new-thread", projectId },
-      draft: currentDraft,
       textEffectKey: promptDraft.storageKey,
       getCurrent: promptDraft.getCurrent,
+      subscribeDraft: promptDraft.subscribe,
       setDraft: promptDraft.setDraft,
       focus: () => promptBoxRef.current?.focusEnd(),
     }),
     [
-      currentDraft,
       projectId,
       promptDraft.getCurrent,
       promptDraft.setDraft,
       promptDraft.storageKey,
+      promptDraft.subscribe,
     ],
   );
 

--- a/apps/app/src/components/promptbox/PromptBoxActionsMenu.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxActionsMenu.test.tsx
@@ -116,9 +116,9 @@ describe("PromptBoxActionsMenu", () => {
     const setDraft = vi.fn();
     const host: PluginComposerHost = {
       scope: view.scope,
-      draft,
       textEffectKey: "plus-menu-update-test",
       getCurrent: () => draft,
+      subscribeDraft: () => () => {},
       setDraft,
       focus: () => document.getElementById("composer-focus-target")?.focus(),
     };
@@ -177,9 +177,9 @@ describe("PromptBoxActionsMenu", () => {
     const draft = emptyPromptDraftState();
     const host: PluginComposerHost = {
       scope: view.scope,
-      draft,
       textEffectKey: "plus-menu-test",
       getCurrent: () => draft,
+      subscribeDraft: () => () => {},
       setDraft: vi.fn(),
       focus: vi.fn(),
     };

--- a/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
+++ b/apps/app/src/components/promptbox/PromptBoxInternal.test.tsx
@@ -827,9 +827,9 @@ describe("PromptBoxInternal controlled value sync", () => {
         threadId: "thread-1",
         queuedMessageId,
       },
-      draft,
       textEffectKey: `queued-message:${queuedMessageId}`,
       getCurrent: () => draft,
+      subscribeDraft: () => () => {},
       setDraft: vi.fn(),
       focus: vi.fn(),
     });
@@ -1754,9 +1754,9 @@ describe("PromptBoxInternal plugin composer actions", () => {
     const draft = emptyPromptDraftState();
     const host: PluginComposerHost = {
       scope: { kind: "thread", threadId: "crashing-action-thread" },
-      draft,
       textEffectKey: "crashing-action-composer",
       getCurrent: () => draft,
+      subscribeDraft: () => () => {},
       setDraft: vi.fn(),
       focus: vi.fn(),
     };
@@ -1841,9 +1841,9 @@ describe("PromptBoxInternal plugin composer actions", () => {
     const draft = emptyPromptDraftState();
     const host: PluginComposerHost = {
       scope: { kind: "thread", threadId: "thread-1" },
-      draft,
       textEffectKey: "promptbox-lock-test",
       getCurrent: () => draft,
+      subscribeDraft: () => () => {},
       setDraft: vi.fn(),
       focus: vi.fn(),
     };
@@ -1930,9 +1930,9 @@ describe("PromptBoxInternal plugin composer actions", () => {
     const draft = emptyPromptDraftState();
     const host = (threadId: string): PluginComposerHost => ({
       scope: { kind: "thread", threadId },
-      draft,
       textEffectKey: `scope-action:${threadId}`,
       getCurrent: () => draft,
+      subscribeDraft: () => () => {},
       setDraft: vi.fn(),
       focus: vi.fn(),
     });

--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import type { ReactNode } from "react";
+import { useEffect, useLayoutEffect, type ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { FollowUpComposerProps } from "@/components/promptbox/FollowUpPromptBox";
+import type { PluginComposerHost } from "@/components/plugin/plugin-composer-host";
+import { getPromptDraftAccessor } from "@/hooks/usePromptDraftStorage";
 import { EmbeddedThreadChat } from "./EmbeddedThreadChat";
 
 const mocks = vi.hoisted(() => ({
@@ -29,30 +31,81 @@ const mocks = vi.hoisted(() => ({
   resolveMentionLink: vi.fn(),
 }));
 
-vi.mock("@/components/promptbox/FollowUpPromptBox", () => ({
-  FollowUpPromptBox: ({
-    composer,
-    stack,
-  }: {
-    composer: Pick<
-      FollowUpComposerProps,
-      "message" | "onChangeMessage" | "onSubmit"
-    >;
-    stack: ReactNode;
-  }) => (
-    <div>
-      {stack}
-      <input
-        data-testid="embedded-chat-composer"
-        value={composer.message}
-        onChange={(event) => composer.onChangeMessage(event.target.value, [])}
-      />
-      <button type="button" onClick={composer.onSubmit}>
-        Send
-      </button>
-    </div>
-  ),
+const hostDraftMocks = vi.hoisted(() => ({
+  /** The bottom host from the most recent FollowUpPromptBox render. */
+  latestHost: null as {
+    getCurrent(): { text: string };
+    subscribeDraft(listener: () => void): () => void;
+  } | null,
+  /** latestHost.getCurrent().text captured inside each subscribeDraft notification. */
+  textAtNotify: [] as string[],
+  subscribed: false,
 }));
+
+vi.mock("@/components/promptbox/FollowUpPromptBox", async () => {
+  const { usePluginComposerHostDraft } = await import(
+    "@/components/plugin/plugin-composer-host"
+  );
+  // A host-draft subscriber, like plugin surfaces reading useComposerView().
+  function BottomHostDraftProbe({
+    host,
+  }: {
+    host: PluginComposerHost | null;
+  }) {
+    // Record what the CURRENT host's getCurrent() returns at the exact moment
+    // subscribeDraft notifies. useSyncExternalStore reads the snapshot inside
+    // the notification to decide whether to re-render, so a notify that fires
+    // before the host's identity refs are synced hands every subscriber a
+    // stale draft with no later correction. The subscription is established
+    // once and deliberately outlives probe remounts (the notifier function is
+    // shared by successive hosts of one EmbeddedThreadChat instance) so the
+    // recorder observes the notification even when the composer subtree is
+    // remounted by the switch. The latest-host sync is a layout effect: the
+    // probe is a child of EmbeddedThreadChat, so it runs before the parent's
+    // notifier effect fires.
+    useLayoutEffect(() => {
+      hostDraftMocks.latestHost = host;
+    }, [host]);
+    useEffect(() => {
+      if (hostDraftMocks.subscribed || !host) return;
+      hostDraftMocks.subscribed = true;
+      host.subscribeDraft(() => {
+        hostDraftMocks.textAtNotify.push(
+          hostDraftMocks.latestHost?.getCurrent().text ?? "",
+        );
+      });
+    }, [host]);
+    const draft = usePluginComposerHostDraft(host);
+    return <div data-testid="embedded-host-draft">{draft?.text ?? ""}</div>;
+  }
+  return {
+    FollowUpPromptBox: ({
+      composer,
+      stack,
+      pluginComposerHost,
+    }: {
+      composer: Pick<
+        FollowUpComposerProps,
+        "message" | "onChangeMessage" | "onSubmit"
+      >;
+      stack: ReactNode;
+      pluginComposerHost?: PluginComposerHost | null;
+    }) => (
+      <div>
+        {stack}
+        <input
+          data-testid="embedded-chat-composer"
+          value={composer.message}
+          onChange={(event) => composer.onChangeMessage(event.target.value, [])}
+        />
+        <button type="button" onClick={composer.onSubmit}>
+          Send
+        </button>
+        <BottomHostDraftProbe host={pluginComposerHost ?? null} />
+      </div>
+    ),
+  };
+});
 
 vi.mock("@/components/promptbox/banner/QueuedMessagesList", () => ({
   QueuedMessagesList: ({
@@ -272,14 +325,16 @@ vi.mock("@/hooks/mutations/project-mutations", () => ({
   }),
 }));
 
-function renderEmbeddedChat({
+function buildEmbeddedChat({
   threadId = "thr_child",
   surfaceTone = "background",
+  pluginComposerBottomScope,
 }: {
   threadId?: string;
   surfaceTone?: "background" | "sidebar";
+  pluginComposerBottomScope?: PluginComposerHost["scope"];
 } = {}) {
-  return render(
+  return (
     <EmbeddedThreadChat
       variant="compact"
       surfaceTone={surfaceTone}
@@ -301,9 +356,16 @@ function renderEmbeddedChat({
         executionResetKey: "thr_parent",
         permissionPolicy: "snapshot",
         environmentSummary: null,
+        ...(pluginComposerBottomScope ? { pluginComposerBottomScope } : {}),
       }}
-    />,
+    />
   );
+}
+
+function renderEmbeddedChat(
+  options: Parameters<typeof buildEmbeddedChat>[0] = {},
+) {
+  return render(buildEmbeddedChat(options));
 }
 
 describe("EmbeddedThreadChat", () => {
@@ -323,6 +385,9 @@ describe("EmbeddedThreadChat", () => {
     mocks.timelinePanelProps = [];
     mocks.timelineProjectIds = [];
     mocks.resolveMentionLink.mockReset();
+    hostDraftMocks.latestHost = null;
+    hostDraftMocks.textAtNotify = [];
+    hostDraftMocks.subscribed = false;
   });
 
   it("applies the requested surface tone to the timeline and footer", () => {
@@ -487,5 +552,64 @@ describe("EmbeddedThreadChat", () => {
 
     expect(screen.queryByTestId("pending-interaction-banner")).toBeNull();
     expect(screen.getByTestId("embedded-chat-composer")).toBeTruthy();
+  });
+
+  // The bottom host's getCurrent gates on the active-identity ref, and that
+  // ref is synced in a layout effect. A thread switch changes the host
+  // identity and the draft in ONE commit: if the draft notifier's effect ran
+  // before the identity sync, subscribers were notified while getCurrent
+  // still resolved to the pre-switch fallback draft — and no later effect
+  // notified again, so plugin surfaces showed the previous thread's draft
+  // until the next keystroke.
+  it("delivers the new thread's draft to host subscribers immediately on a thread switch", () => {
+    getPromptDraftAccessor({
+      kind: "thread",
+      projectId: "proj-1",
+      threadId: "thr_switch_a",
+    }).setDraft({ text: "alpha draft", mentions: [], attachments: [] });
+    getPromptDraftAccessor({
+      kind: "thread",
+      projectId: "proj-1",
+      threadId: "thr_switch_b",
+    }).setDraft({ text: "beta draft", mentions: [], attachments: [] });
+
+    const scopeFor = (threadId: string) =>
+      ({ kind: "thread", threadId }) as const;
+    const view = render(
+      buildEmbeddedChat({
+        threadId: "thr_switch_a",
+        pluginComposerBottomScope: scopeFor("thr_switch_a"),
+      }),
+    );
+    expect(screen.getByTestId("embedded-host-draft").textContent).toBe(
+      "alpha draft",
+    );
+
+    // Identity + draft change in the same commit.
+    view.rerender(
+      buildEmbeddedChat({
+        threadId: "thr_switch_b",
+        pluginComposerBottomScope: scopeFor("thr_switch_b"),
+      }),
+    );
+    expect(screen.getByTestId("embedded-host-draft").textContent).toBe(
+      "beta draft",
+    );
+    // The switch's notification must already observe the new draft: this is
+    // the read useSyncExternalStore performs inside the notify, and there is
+    // no later notification to correct a stale one.
+    expect(hostDraftMocks.textAtNotify).toEqual(["beta draft"]);
+
+    // And back, with no intervening keystroke.
+    view.rerender(
+      buildEmbeddedChat({
+        threadId: "thr_switch_a",
+        pluginComposerBottomScope: scopeFor("thr_switch_a"),
+      }),
+    );
+    expect(screen.getByTestId("embedded-host-draft").textContent).toBe(
+      "alpha draft",
+    );
+    expect(hostDraftMocks.textAtNotify).toEqual(["beta draft", "alpha draft"]);
   });
 });

--- a/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
+++ b/apps/app/src/components/thread/embedded-chat/EmbeddedThreadChat.tsx
@@ -20,7 +20,10 @@ import {
   FollowUpPromptBox,
   type FollowUpComposerProps,
 } from "@/components/promptbox/FollowUpPromptBox";
-import type { PluginComposerHost } from "@/components/plugin/plugin-composer-host";
+import {
+  useComposerHostDraftNotifier,
+  type PluginComposerHost,
+} from "@/components/plugin/plugin-composer-host";
 import { ThreadPendingInteractionBanner } from "@/components/thread/pending-interactions/ThreadPendingInteractionBanner";
 import {
   QueuedMessagesList,
@@ -667,6 +670,16 @@ function EmbeddedThreadChatWithComposer({
       }
     };
   }, [queuedComposerHostIdentity]);
+  // subscribeDraft sources for the two hosts below. The notifiers MUST be
+  // declared after every ref-sync layout effect above (hook order = effect
+  // order): a thread switch changes the host identity and the draft in one
+  // commit, and `getCurrent` gates on the active-identity refs. Notifying
+  // before the identity sync would hand subscribers the stale pre-switch
+  // draft with no later notification to correct it.
+  const subscribeBottomDraft = useComposerHostDraftNotifier(currentPromptDraft);
+  const subscribeQueuedDraft = useComposerHostDraftNotifier(
+    inlineEditingQueuedMessage?.draft ?? null,
+  );
   const setStoredPromptDraft = promptDraft.setDraft;
   const bottomPluginComposerHost = useMemo<PluginComposerHost | null>(() => {
     if (bottomScope === null) return null;
@@ -675,11 +688,11 @@ function EmbeddedThreadChatWithComposer({
     return {
       scope: bottomScope,
       textEffectKey: identity,
-      draft: currentPromptDraftRef.current,
       getCurrent: () =>
         activeBottomComposerIdentityRef.current === identity
           ? currentPromptDraftRef.current
           : initialDraft,
+      subscribeDraft: subscribeBottomDraft,
       setDraft: (draft) => {
         if (activeBottomComposerIdentityRef.current === identity) {
           setStoredPromptDraft(draft);
@@ -691,7 +704,12 @@ function EmbeddedThreadChatWithComposer({
         }
       },
     };
-  }, [bottomComposerHostIdentity, bottomScope, setStoredPromptDraft]);
+  }, [
+    bottomComposerHostIdentity,
+    bottomScope,
+    setStoredPromptDraft,
+    subscribeBottomDraft,
+  ]);
   const queuedPluginComposerHost = useMemo<PluginComposerHost | null>(() => {
     if (
       queuedComposerIdentity === null ||
@@ -720,7 +738,6 @@ function EmbeddedThreadChatWithComposer({
         queuedMessageId: queuedEdit.queuedMessageId,
       },
       textEffectKey: identity,
-      draft: initialDraft,
       getCurrent: () => {
         if (activeQueuedComposerIdentityRef.current !== identity) {
           return initialDraft;
@@ -730,6 +747,7 @@ function EmbeddedThreadChatWithComposer({
           ? currentQueuedEdit.draft
           : initialDraft;
       },
+      subscribeDraft: subscribeQueuedDraft,
       setDraft: (draft) => {
         if (activeQueuedComposerIdentityRef.current !== identity) {
           return;
@@ -748,24 +766,11 @@ function EmbeddedThreadChatWithComposer({
     inlineEditingQueuedMessageRef,
     queuedComposerIdentity,
     queuedComposerHostIdentity,
+    subscribeQueuedDraft,
     updateInlineQueuedMessage,
   ]);
-  const bottomPluginComposerHostWithDraft = useMemo<PluginComposerHost | null>(
-    () =>
-      bottomPluginComposerHost === null
-        ? null
-        : { ...bottomPluginComposerHost, draft: currentPromptDraft },
-    [bottomPluginComposerHost, currentPromptDraft],
-  );
-  const queuedPluginComposerHostWithDraft = useMemo<PluginComposerHost | null>(
-    () =>
-      queuedPluginComposerHost === null
-        ? null
-        : { ...queuedPluginComposerHost, draft: activeComposerDraft },
-    [activeComposerDraft, queuedPluginComposerHost],
-  );
-  const activeBottomPluginComposerHost = bottomPluginComposerHostWithDraft;
-  const activeQueuedPluginComposerHost = queuedPluginComposerHostWithDraft;
+  const activeBottomPluginComposerHost = bottomPluginComposerHost;
+  const activeQueuedPluginComposerHost = queuedPluginComposerHost;
   const bottomComposerTextEffects = useComposerTextEffects(
     activeBottomPluginComposerHost?.textEffectKey ?? null,
   );

--- a/apps/app/src/hooks/usePromptDraftStorage.ts
+++ b/apps/app/src/hooks/usePromptDraftStorage.ts
@@ -289,6 +289,7 @@ function getPromptDraftStorageKey(scope: PromptDraftScope): string {
 export function getPromptDraftAccessor(scope: PromptDraftScope): {
   storageKey: string;
   getCurrent: () => PromptDraftState;
+  subscribe: (listener: () => void) => () => void;
   setDraft: (draft: PromptDraftState) => void;
   addQuote: (
     text: string,
@@ -299,6 +300,7 @@ export function getPromptDraftAccessor(scope: PromptDraftScope): {
   return {
     storageKey,
     getCurrent: () => readPromptDraft(storageKey),
+    subscribe: (listener) => subscribePromptDraft(storageKey, listener),
     setDraft: (draft) => writePromptDraft(storageKey, draft),
     addQuote: (text, attachments) =>
       addQuoteToPromptDraft(storageKey, text, attachments),
@@ -326,6 +328,13 @@ export function usePromptDraftStorage(scope: PromptDraftScope) {
   const getCurrent = useCallback((): PromptDraftState => {
     return readPromptDraft(storageKey);
   }, [storageKey]);
+
+  // Stable per storage key, so a plugin composer host built over this draft
+  // can expose the store subscription without re-creating the host per write.
+  const subscribe = useCallback(
+    (listener: () => void) => subscribePromptDraft(storageKey, listener),
+    [storageKey],
+  );
 
   const setTextAndMentions = useCallback(
     (nextText: string, nextMentions: PromptTextMention[]) => {
@@ -421,6 +430,7 @@ export function usePromptDraftStorage(scope: PromptDraftScope) {
     () => ({
       storageKey,
       getCurrent,
+      subscribe,
       value: draft.text,
       text: draft.text,
       mentions: draft.mentions,
@@ -450,6 +460,7 @@ export function usePromptDraftStorage(scope: PromptDraftScope) {
       setDraftAndPersist,
       setTextAndMentions,
       storageKey,
+      subscribe,
     ],
   );
 }

--- a/apps/app/src/lib/plugin-sdk-hooks.ts
+++ b/apps/app/src/lib/plugin-sdk-hooks.ts
@@ -34,6 +34,7 @@ import { usePluginThreadPanelOpenHandler } from "@/components/plugin/plugin-thre
 import {
   PluginComposerViewContext,
   usePluginComposerHost,
+  usePluginComposerHostDraft,
 } from "@/components/plugin/plugin-composer-host";
 import { sdk } from "@/lib/sdk";
 import { useSystemProviders } from "@/hooks/queries/system-queries";
@@ -622,7 +623,8 @@ export function useComposerView(): ComposerView {
     [projectId, threadId],
   );
   const routeDraft = usePromptDraftStorage(routeScope);
-  const draft = composerHost?.draft ?? routeDraft;
+  const hostDraft = usePluginComposerHostDraft(composerHost);
+  const draft = hostDraft ?? routeDraft;
   const fallback = useMemo<ComposerView>(
     () => ({
       scope:
@@ -656,6 +658,7 @@ export function useComposer(): PluginComposerApi {
   const pluginId = usePluginId();
   const slotOwnershipRegistry = useContext(PluginSlotOwnershipContext);
   const composerHost = usePluginComposerHost();
+  const composerHostDraft = usePluginComposerHostDraft(composerHost);
   const { projectId, threadId } = useRouteState();
   const routeScope: PromptDraftScope = useMemo(
     () =>
@@ -852,7 +855,7 @@ export function useComposer(): PluginComposerApi {
   );
 
   const focus = focusActiveComposer;
-  const composerText = composerHost?.draft.text ?? routeDraft.text;
+  const composerText = composerHostDraft?.text ?? routeDraft.text;
 
   return useMemo(
     () => ({

--- a/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
@@ -283,9 +283,9 @@ vi.mock("./ThreadDetailView", () => ({
       const draft = { attachments: [], mentions: [], text: "" };
       return {
         scope: { kind: "thread", threadId },
-        draft,
         textEffectKey: `test-draft-${threadId}`,
         getCurrent: () => draft,
+        subscribeDraft: () => () => {},
         setDraft: () => undefined,
         focus: () => undefined,
       };

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.keystrokes.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.keystrokes.test.tsx
@@ -1,0 +1,582 @@
+// @vitest-environment jsdom
+
+import type {
+  PendingInteraction,
+  ThreadQueuedMessage,
+  ThreadWithRuntime,
+} from "@bb/domain";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PluginComposerHostScopeProvider,
+  usePluginComposerHost,
+  usePluginComposerHostDraft,
+} from "@/components/plugin/plugin-composer-host";
+import { getPromptDraftAccessor } from "@/hooks/usePromptDraftStorage";
+import { ThreadDetailPromptArea } from "./ThreadDetailPromptArea";
+
+/**
+ * Keystroke isolation for the published plugin composer host.
+ *
+ * The host published by ThreadDetailPromptArea reaches large non-draft
+ * subscribers (ThreadDetailSecondaryContentBody -> SecondaryPanelLayout ->
+ * ThreadTimelinePane, the hosted-panel registry). It must stay referentially
+ * stable while the user types: a per-keystroke identity notified the pane
+ * scope and re-rendered the whole thread shell per character. The live draft
+ * must instead reach actual draft consumers through the host's
+ * getCurrent/subscribeDraft pair. These tests use the real draft store so
+ * keystrokes flow the way they do in the app.
+ */
+
+const mocks = vi.hoisted(() => ({
+  sendMessageMutateAsync: vi.fn(),
+  shellProbeRenders: vi.fn(),
+  updateQueuedMessageMutateAsync: vi.fn(),
+}));
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+vi.mock("@/components/promptbox/FollowUpPromptBox", () => ({
+  FollowUpPromptBox: ({
+    composer,
+    pendingInteraction = null,
+    stack,
+  }: {
+    composer: {
+      message: string;
+      onChangeMessage: (message: string, mentions: []) => void;
+      onSubmit: () => void;
+    } | null;
+    pendingInteraction?: ReactNode;
+    stack: ReactNode;
+  }) => (
+    <div data-testid="follow-up-prompt-box">
+      <div data-testid="prompt-stack">
+        {stack}
+        {pendingInteraction}
+      </div>
+      {composer ? (
+        // Like the real FollowUpPromptBox: hidden, not unmounted, while a
+        // pending interaction takes the composer's place.
+        <div hidden={pendingInteraction !== null}>
+          <input
+            aria-label="Composer message"
+            value={composer.message}
+            onChange={(event) =>
+              composer.onChangeMessage(event.currentTarget.value, [])
+            }
+          />
+          <button type="button" onClick={composer.onSubmit}>
+            Submit composer
+          </button>
+        </div>
+      ) : null}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/promptbox/ThreadEnvironmentSummary", () => ({
+  ThreadEnvironmentSummary: () => <div />,
+}));
+
+vi.mock("@/components/promptbox/banner/QueuedMessagesList", () => ({
+  QueuedMessagesList: ({
+    inlineEditor,
+    queuedMessages,
+    onEdit,
+  }: {
+    inlineEditor?: { content: ReactNode; onDismiss: () => void };
+    queuedMessages: readonly ThreadQueuedMessage[];
+    onEdit: (request: {
+      queuedMessageId: string;
+      queuedMessageIndex: number;
+    }) => void;
+  }) => (
+    <div data-testid="queued-message-list">
+      {queuedMessages.map((message, index) => (
+        <button
+          key={message.id}
+          type="button"
+          onClick={() =>
+            onEdit({ queuedMessageId: message.id, queuedMessageIndex: index })
+          }
+        >
+          Edit queued message {index + 1}
+        </button>
+      ))}
+      {inlineEditor ? (
+        <div data-testid="inline-queued-message-editor">
+          {inlineEditor.content}
+          <button type="button" onClick={inlineEditor.onDismiss}>
+            Cancel queued edit
+          </button>
+        </div>
+      ) : null}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/promptbox/banner/ThreadBackgroundCommandsCard", () => ({
+  ThreadBackgroundCommandsCard: () => null,
+}));
+
+vi.mock("@/components/promptbox/banner/ThreadGoalCard", () => ({
+  ThreadGoalCard: () => null,
+}));
+
+vi.mock("@/components/promptbox/banner/ThreadPromptContextBanner", () => ({
+  ThreadPromptContextBanner: () => null,
+}));
+
+vi.mock("@/components/promptbox/banner/ThreadPromptModeCard", () => ({
+  ThreadPromptModeCard: () => null,
+}));
+
+vi.mock("@/components/promptbox/banner/ThreadTodoCard", () => ({
+  ThreadTodoCard: () => null,
+}));
+
+vi.mock("@/components/promptbox/banner/ThreadWorkflowCard", () => ({
+  ThreadWorkflowCard: () => null,
+}));
+
+vi.mock(
+  "@/components/thread/pending-interactions/ThreadPendingInteractionBanner",
+  () => ({
+    ThreadPendingInteractionBanner: () => (
+      <div data-testid="pending-interaction" />
+    ),
+  }),
+);
+
+vi.mock("@/components/plugin/PluginPendingInteractionComposer", () => ({
+  PluginPendingInteractionComposer: () => null,
+}));
+
+vi.mock("@/components/ui/app-toast", () => ({
+  appToast: { error: vi.fn() },
+}));
+
+vi.mock("@/hooks/useCommandSuggestions", () => ({
+  useCommandSuggestions: () => ({
+    hasMore: false,
+    isError: false,
+    isLoading: false,
+    isLoadingMore: false,
+    loadMore: vi.fn(),
+    suggestions: [],
+    trigger: null,
+  }),
+}));
+
+vi.mock("@/hooks/usePromptMentions", () => ({
+  usePromptMentions: () => ({
+    isError: false,
+    isLoading: false,
+    setQuery: vi.fn(),
+    suggestions: [],
+  }),
+}));
+
+vi.mock("@/hooks/useThreadCreationOptions", () => ({
+  useThreadCreationOptions: () => ({
+    activeModel: null,
+    executionInputSources: {},
+    hasMultipleProviders: false,
+    isLoadingModels: false,
+    modelLoadError: null,
+    modelLoadFailed: false,
+    modelOptions: [],
+    moreModelOptions: [],
+    permissionMode: "auto",
+    permissionModeOptions: [],
+    providerOptions: [],
+    reasoningLevel: "medium",
+    reasoningOptions: [],
+    selectedModel: "gpt-5",
+    selectedProviderComposerActions: [],
+    selectedProviderDisplayName: "Codex",
+    selectedProviderId: "codex",
+    serviceTier: undefined,
+    serviceTierSupportByProvider: {},
+    setPermissionMode: vi.fn(),
+    setReasoningLevel: vi.fn(),
+    setSelectedModel: vi.fn(),
+    setServiceTier: vi.fn(),
+    supportsPermissionModeSelection: true,
+    supportsServiceTier: false,
+  }),
+}));
+
+vi.mock("@/hooks/mutations/project-mutations", () => ({
+  useUploadPromptAttachment: () => ({
+    isPending: false,
+    mutateAsync: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/mutations/thread-runtime-mutations", () => {
+  const idleMutation = () => ({
+    isPending: false,
+    mutate: vi.fn(),
+    mutateAsync: vi.fn(),
+    variables: null,
+  });
+  return {
+    useCancelThreadPlan: idleMutation,
+    useClearThreadGoal: idleMutation,
+    useCreateThreadQueuedMessage: idleMutation,
+    useDeleteThreadQueuedMessage: idleMutation,
+    useReorderThreadQueuedMessage: idleMutation,
+    useSetThreadQueuedMessageGroupBoundary: idleMutation,
+    useSendThreadQueuedMessage: idleMutation,
+    useStopThread: idleMutation,
+    useUpdateThreadQueuedMessage: () => ({
+      isPending: false,
+      mutateAsync: mocks.updateQueuedMessageMutateAsync,
+    }),
+  };
+});
+
+vi.mock("@/hooks/mutations/thread-state-mutations", () => ({
+  useUnarchiveThread: () => ({
+    isPending: false,
+    mutate: vi.fn(),
+    variables: null,
+  }),
+}));
+
+vi.mock("@/hooks/queries/sidebar-navigation-query", () => ({
+  useProjectDisplayName: () => null,
+}));
+
+vi.mock("@/hooks/queries/thread-default-execution-options-query", () => ({
+  useThreadDefaultExecutionOptions: () => ({
+    data: {
+      model: "gpt-5",
+      permissionMode: "auto",
+      reasoningLevel: "medium",
+      serviceTier: "default",
+      source: "client/turn/requested",
+    },
+    isError: false,
+  }),
+}));
+
+const queryMocks = vi.hoisted(() => ({
+  queuedMessages: [] as ThreadQueuedMessage[],
+}));
+
+vi.mock("@/hooks/queries/thread-queries", () => ({
+  getLatestPendingInteraction: (interactions: readonly PendingInteraction[]) =>
+    interactions.at(-1) ?? null,
+  useThreadPromptHistory: () => ({ data: [] }),
+  useThreadQueuedMessages: () => ({ data: queryMocks.queuedMessages }),
+}));
+
+const PROJECT_ID = "proj_keystrokes";
+
+function makeThread(id: string): ThreadWithRuntime {
+  return {
+    archivedAt: null,
+    environmentId: null,
+    id,
+    projectId: PROJECT_ID,
+    providerId: "codex",
+    runtime: { displayStatus: "idle" },
+    status: "idle",
+  } as ThreadWithRuntime;
+}
+
+function makeQueuedMessage(): ThreadQueuedMessage {
+  return {
+    id: "qmsg_1",
+    content: [{ type: "text", text: "Already queued", mentions: [] }],
+    model: "gpt-5",
+    reasoningLevel: "medium",
+    permissionMode: "auto",
+    serviceTier: "default",
+    groupWithNext: false,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function makePendingInteraction(threadId: string): PendingInteraction {
+  return {
+    id: `interaction-${threadId}`,
+    threadId,
+    turnId: "turn-1",
+    providerId: "codex",
+    providerThreadId: "provider-thread-1",
+    providerRequestId: "provider-request-1",
+    origin: {
+      kind: "provider",
+      providerId: "codex",
+      providerThreadId: "provider-thread-1",
+      providerRequestId: "provider-request-1",
+    },
+    payload: {
+      kind: "user_question",
+      questions: [
+        {
+          id: "question-1",
+          prompt: "Continue?",
+          multiSelect: false,
+          allowFreeText: true,
+        },
+      ],
+    },
+    resolution: null,
+    status: "pending",
+    statusReason: null,
+    createdAt: 1,
+    resolvedAt: null,
+  };
+}
+
+/**
+ * Mirrors ThreadDetailSecondaryContentBody: holds the published host without
+ * reading its draft. Every render is one shell re-render in the app
+ * (SecondaryPanelLayout, ThreadTimelinePane), so this must stay flat while
+ * the user types.
+ */
+function ShellProbe() {
+  mocks.shellProbeRenders(usePluginComposerHost());
+  return null;
+}
+
+/** An actual draft consumer (the plugin-hook read path). */
+function PublishedHostDraftProbe() {
+  const host = usePluginComposerHost();
+  const draft = usePluginComposerHostDraft(host);
+  return <div data-testid="published-host-draft">{draft?.text ?? ""}</div>;
+}
+
+function observedShellHosts(): readonly unknown[] {
+  return mocks.shellProbeRenders.mock.calls.map((call) => call[0]);
+}
+
+/**
+ * Mounting settles at two shell renders: the probe first sees an empty scope,
+ * then the area's layout-effect publish delivers the host. Everything after
+ * that baseline is a real shell re-render.
+ */
+function shellRenderCount(): number {
+  return mocks.shellProbeRenders.mock.calls.length;
+}
+
+interface RenderPromptAreaArgs {
+  thread: ThreadWithRuntime;
+  pendingInteractions?: readonly PendingInteraction[];
+}
+
+function buildPromptArea({
+  thread,
+  pendingInteractions = [],
+}: RenderPromptAreaArgs) {
+  return (
+    <PluginComposerHostScopeProvider>
+      <ShellProbe />
+      <PublishedHostDraftProbe />
+      <ThreadDetailPromptArea
+        activeBackgroundAgentCount={0}
+        activeBackgroundCommands={[]}
+        activePromptMode={null}
+        activeWorkflows={[]}
+        canUseGitUi={false}
+        childPendingInteractions={[]}
+        childThreadsSection={null}
+        composerFocusRequestNonce={0}
+        contextBannerMergeBase={null}
+        environmentGoneStatus={null}
+        goal={null}
+        modelFallback={null}
+        isEnvironmentActionPending={false}
+        onChangedFileClick={vi.fn()}
+        parentThreadSection={null}
+        pendingInteractions={pendingInteractions}
+        pendingInteractionsInitialLoading={false}
+        pendingTodos={null}
+        projectId={PROJECT_ID}
+        pullRequest={null}
+        pullRequestMergeMethod="squash"
+        resolveMentionLink={() => null}
+        sendMessage={{
+          isPending: false,
+          mutateAsync: mocks.sendMessageMutateAsync,
+        }}
+        steerActiveThreadOnEnter={false}
+        thread={thread}
+        workspaceChangedFilesSection={null}
+        workspaceStatusPending={false}
+      />
+    </PluginComposerHostScopeProvider>
+  );
+}
+
+function renderPromptArea(args: RenderPromptAreaArgs) {
+  return render(buildPromptArea(args));
+}
+
+function getBottomComposerInput(): HTMLInputElement {
+  return screen.getByRole("textbox", {
+    name: "Composer message",
+  }) as HTMLInputElement;
+}
+
+let threadCounter = 0;
+let threadId = "";
+
+beforeEach(() => {
+  threadCounter += 1;
+  threadId = `thr_keystrokes_${threadCounter}`;
+  queryMocks.queuedMessages = [];
+  mocks.sendMessageMutateAsync.mockResolvedValue(undefined);
+  mocks.updateQueuedMessageMutateAsync.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+  vi.clearAllMocks();
+});
+
+describe("ThreadDetailPromptArea published composer host", () => {
+  it("keeps the published host referentially stable while keystrokes reach draft consumers", () => {
+    renderPromptArea({ thread: makeThread(threadId) });
+    const input = getBottomComposerInput();
+    const rendersAfterMount = shellRenderCount();
+    const hostAfterMount = observedShellHosts().at(-1);
+    expect(hostAfterMount).not.toBe(null);
+
+    const typed = "abcdefghijklmnopqrstu";
+    for (let index = 1; index <= typed.length; index += 1) {
+      fireEvent.change(input, { target: { value: typed.slice(0, index) } });
+    }
+
+    expect(input.value).toBe(typed);
+    // Draft consumers saw every keystroke through the stable host...
+    expect(screen.getByTestId("published-host-draft").textContent).toBe(typed);
+    // ...while the pane scope never notified: no shell re-render for the
+    // entire burst, including the empty -> non-empty flip.
+    expect(shellRenderCount()).toBe(rendersAfterMount);
+    expect(observedShellHosts().at(-1)).toBe(hostAfterMount);
+  });
+
+  it("submits the draft as typed, read imperatively at event time", async () => {
+    renderPromptArea({ thread: makeThread(threadId) });
+    const input = getBottomComposerInput();
+    for (const index of Array.from({ length: 7 }, (_, i) => i + 1)) {
+      fireEvent.change(input, { target: { value: "Ship it".slice(0, index) } });
+    }
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Submit composer" }));
+    });
+
+    expect(mocks.sendMessageMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mocks.sendMessageMutateAsync.mock.calls[0]?.[0]).toMatchObject({
+      input: [{ type: "text", text: "Ship it", mentions: [] }],
+    });
+    expect(
+      getPromptDraftAccessor({
+        kind: "thread",
+        projectId: PROJECT_ID,
+        threadId,
+      }).getCurrent().text,
+    ).toBe("");
+  });
+
+  it("delivers external draft writes to consumers without re-rendering the shell, even while a pending interaction hides the composer", () => {
+    const accessor = getPromptDraftAccessor({
+      kind: "thread",
+      projectId: PROJECT_ID,
+      threadId,
+    });
+    renderPromptArea({
+      thread: makeThread(threadId),
+      pendingInteractions: [makePendingInteraction(threadId)],
+    });
+    expect(screen.getByTestId("pending-interaction")).toBeTruthy();
+    expect(screen.getByTestId("published-host-draft").textContent).toBe("");
+    const rendersAfterMount = shellRenderCount();
+
+    act(() => {
+      accessor.setDraft({
+        text: "typed elsewhere",
+        mentions: [],
+        attachments: [],
+      });
+    });
+    expect(screen.getByTestId("published-host-draft").textContent).toBe(
+      "typed elsewhere",
+    );
+
+    act(() => {
+      accessor.setDraft({
+        text: "typed elsewhere again",
+        mentions: [],
+        attachments: [],
+      });
+    });
+    expect(screen.getByTestId("published-host-draft").textContent).toBe(
+      "typed elsewhere again",
+    );
+    expect(shellRenderCount()).toBe(rendersAfterMount);
+  });
+
+  it("swaps to a per-session stable host for inline queued-message edits and streams the inline draft", () => {
+    queryMocks.queuedMessages = [makeQueuedMessage()];
+    renderPromptArea({ thread: makeThread(threadId) });
+    const rendersAfterMount = shellRenderCount();
+    const threadHost = observedShellHosts().at(-1);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Edit queued message 1" }),
+    );
+    // Opening the editor publishes the queued-message host: exactly one
+    // legitimate shell notification.
+    expect(shellRenderCount()).toBe(rendersAfterMount + 1);
+    expect(observedShellHosts().at(-1)).not.toBe(threadHost);
+    expect(screen.getByTestId("published-host-draft").textContent).toBe(
+      "Already queued",
+    );
+
+    const inlineInput = within(
+      screen.getByTestId("inline-queued-message-editor"),
+    ).getByRole("textbox", { name: "Composer message" }) as HTMLInputElement;
+    const typed = "Already queued and refined";
+    for (
+      let index = "Already queued".length + 1;
+      index <= typed.length;
+      index += 1
+    ) {
+      fireEvent.change(inlineInput, {
+        target: { value: typed.slice(0, index) },
+      });
+    }
+
+    expect(inlineInput.value).toBe(typed);
+    // Inline keystrokes reached consumers through the same stable host...
+    expect(screen.getByTestId("published-host-draft").textContent).toBe(typed);
+    expect(shellRenderCount()).toBe(rendersAfterMount + 1);
+
+    // ...and closing the editor swaps back to the identical thread host.
+    fireEvent.click(screen.getByRole("button", { name: "Cancel queued edit" }));
+    expect(shellRenderCount()).toBe(rendersAfterMount + 2);
+    expect(observedShellHosts().at(-1)).toBe(threadHost);
+    expect(screen.getByTestId("published-host-draft").textContent).toBe("");
+  });
+});

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.test.tsx
@@ -56,6 +56,7 @@ const mocks = vi.hoisted(() => ({
     setDraft: vi.fn(),
     setTextAndMentions: vi.fn(),
     storageKey: "bb.promptbox.contents-proj_1-thr_1-3",
+    subscribe: vi.fn(() => () => {}),
     text: "",
   },
   queuedMessages: [] as ThreadQueuedMessage[],
@@ -206,7 +207,7 @@ vi.mock("@/components/promptbox/FollowUpPromptBox", async () => {
               type="button"
               onClick={() =>
                 pluginComposerHost.setDraft({
-                  ...pluginComposerHost.draft,
+                  ...pluginComposerHost.getCurrent(),
                   text: "Plugin-enhanced queued message",
                 })
               }

--- a/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailPromptArea.tsx
@@ -37,6 +37,7 @@ import { ThreadPendingInteractionBanner } from "@/components/thread/pending-inte
 import { PluginPendingInteractionComposer } from "@/components/plugin/PluginPendingInteractionComposer";
 import {
   type PluginComposerHost,
+  useComposerHostDraftNotifier,
   usePublishPluginComposerHost,
 } from "@/components/plugin/plugin-composer-host";
 import {
@@ -98,6 +99,7 @@ import { getThreadDisplayTitle } from "@/lib/thread-title";
 import { buildThreadHandoffLocationState } from "@bb/client-core";
 import { appToast } from "@/components/ui/app-toast";
 import {
+  emptyPromptDraftState,
   promptDraftToInput,
   type PromptDraftAttachment,
   type PromptDraftState,
@@ -328,6 +330,12 @@ function isInlineQueuedMessageEditSession(
   );
 }
 
+/**
+ * Fallback for host draft reads that outlive their editor session: the ref no
+ * longer holds the session, so there is no live draft to return.
+ */
+const ENDED_EDIT_SESSION_DRAFT = emptyPromptDraftState();
+
 /** Plugin composer-host accessors for the queued-message inline editor (see below). */
 function readInlineQueuedMessageDraft(
   editStateRef: RefObject<InlineQueuedMessageEditState | null>,
@@ -529,6 +537,14 @@ export function ThreadDetailPromptArea({
     inlineEditingQueuedMessageRef,
     commitInlineQueuedMessage,
   });
+  // subscribeDraft sources for the two state-backed editor hosts. The bottom
+  // composer's host subscribes through the prompt-draft store directly.
+  const subscribeInlineQueuedDraft = useComposerHostDraftNotifier(
+    inlineEditingQueuedMessage?.draft ?? null,
+  );
+  const subscribeSentMessageEditDraft = useComposerHostDraftNotifier(
+    sentMessageEdit?.draft ?? null,
+  );
   const updateSentMessageEditDraft = sentMessageEdit?.updateDraft;
   const addSentMessageEditAttachment = useCallback(
     (attachment: PromptDraftAttachment) => {
@@ -791,13 +807,16 @@ export function ThreadDetailPromptArea({
   const compactPromptPlaceholder = isStopRequested
     ? "Stopping thread..."
     : getCompactFollowUpPromptPlaceholder(runtimeDisplayStatus);
-  const normalPluginComposerHostBinding = useMemo<
-    Omit<PluginComposerHost, "draft">
-  >(
+  // Identity-stable across keystrokes: the published host is held by large
+  // non-draft subscribers (the secondary-content body, the hosted-panel
+  // registry), so a per-keystroke host identity re-rendered the whole thread
+  // shell per character. The live draft flows through getCurrent/subscribeDraft.
+  const normalPluginComposerHost = useMemo<PluginComposerHost>(
     () => ({
       scope: { kind: "thread", threadId: thread.id },
       textEffectKey: promptDraft.storageKey,
       getCurrent: promptDraft.getCurrent,
+      subscribeDraft: promptDraft.subscribe,
       setDraft: promptDraft.setDraft,
       focus: focusBottomPluginComposer,
     }),
@@ -806,15 +825,9 @@ export function ThreadDetailPromptArea({
       promptDraft.getCurrent,
       promptDraft.setDraft,
       promptDraft.storageKey,
+      promptDraft.subscribe,
       thread.id,
     ],
-  );
-  const normalPluginComposerHost = useMemo<PluginComposerHost>(
-    () => ({
-      ...normalPluginComposerHostBinding,
-      draft: currentPromptDraft,
-    }),
-    [currentPromptDraft, normalPluginComposerHostBinding],
   );
   const hasPromptDraftInput = currentPromptDraftInput.length > 0;
   const canSubmitModifierShortcut = canSubmitFollowUpShortcut({
@@ -1291,43 +1304,63 @@ export function ThreadDetailPromptArea({
     ),
     [clearThreadGoal.isPending, goal, handleClearGoal, isGoalExpanded],
   );
+  // Stable for the whole edit session (keyed on the session scalars, not the
+  // per-keystroke edit state), so publishing it does not churn the pane scope
+  // while the user types in the inline editor.
+  const inlineEditSessionId = inlineEditingQueuedMessage?.editSessionId ?? null;
+  const inlineEditQueuedMessageId =
+    inlineEditingQueuedMessage?.queuedMessageId ?? null;
+  const queuedMessagePluginComposerHost =
+    useMemo<PluginComposerHost | null>(() => {
+      if (inlineEditSessionId === null || inlineEditQueuedMessageId === null) {
+        return null;
+      }
+      const session = {
+        editSessionId: inlineEditSessionId,
+        queuedMessageId: inlineEditQueuedMessageId,
+      };
+      return {
+        scope: {
+          kind: "queued-message",
+          threadId: thread.id,
+          queuedMessageId: inlineEditQueuedMessageId,
+        },
+        textEffectKey: `queued-message:${thread.id}:${inlineEditQueuedMessageId}:${inlineEditSessionId}`,
+        getCurrent: () =>
+          readInlineQueuedMessageDraft(
+            inlineEditingQueuedMessageRef,
+            session,
+            ENDED_EDIT_SESSION_DRAFT,
+          ),
+        subscribeDraft: subscribeInlineQueuedDraft,
+        setDraft: (draft) =>
+          writeInlineQueuedMessageDraft(
+            inlineEditingQueuedMessageRef,
+            session,
+            draft,
+            commitInlineQueuedMessage,
+          ),
+        focus: focusInlinePluginComposer,
+      };
+    }, [
+      commitInlineQueuedMessage,
+      focusInlinePluginComposer,
+      inlineEditQueuedMessageId,
+      inlineEditSessionId,
+      inlineEditingQueuedMessageRef,
+      subscribeInlineQueuedDraft,
+      thread.id,
+    ]);
   const queuedMessageEditor = useMemo(() => {
     if (
       !inlineEditingQueuedMessage ||
       !inlineExecutionConfig ||
-      !inlinePermissionConfig
+      !inlinePermissionConfig ||
+      !queuedMessagePluginComposerHost
     ) {
       return null;
     }
-    const {
-      draft: initialDraft,
-      editSessionId,
-      queuedMessageId,
-    } = inlineEditingQueuedMessage;
-    const session = { editSessionId, queuedMessageId };
-    const pluginComposerHost: PluginComposerHost = {
-      scope: {
-        kind: "queued-message",
-        threadId: thread.id,
-        queuedMessageId,
-      },
-      textEffectKey: `queued-message:${thread.id}:${queuedMessageId}:${editSessionId}`,
-      draft: activeComposerDraft,
-      getCurrent: () =>
-        readInlineQueuedMessageDraft(
-          inlineEditingQueuedMessageRef,
-          session,
-          initialDraft,
-        ),
-      setDraft: (draft) =>
-        writeInlineQueuedMessageDraft(
-          inlineEditingQueuedMessageRef,
-          session,
-          draft,
-          commitInlineQueuedMessage,
-        ),
-      focus: focusInlinePluginComposer,
-    };
+    const { editSessionId, queuedMessageId } = inlineEditingQueuedMessage;
     const inlineEditor: QueuedMessageInlineEditor = {
       queuedMessageId,
       queuedMessageIndex: inlineEditingQueuedMessage.queuedMessageIndex,
@@ -1354,7 +1387,7 @@ export function ThreadDetailPromptArea({
         onChangeMessage: handleComposerMessageChange,
         onSelectHistoryEntry: setActiveComposerDraft,
         permission: inlinePermissionConfig,
-        pluginComposerHost,
+        pluginComposerHost: queuedMessagePluginComposerHost,
         promptActions,
         promptPlaceholder,
         submit: handleInlineComposerSubmit,
@@ -1365,21 +1398,18 @@ export function ThreadDetailPromptArea({
         collapseResetKey: `queued-message:${queuedMessageId}`,
       }),
     };
-    return { inlineEditor, pluginComposerHost };
+    return inlineEditor;
   }, [
     activeComposerDraft,
     activeComposerDraftInput.length,
-    commitInlineQueuedMessage,
     compactPromptPlaceholder,
     dismissInlineQueuedMessageEditor,
     editFocusNonce,
-    focusInlinePluginComposer,
     handleAttachInlineFiles,
     handleComposerMessageChange,
     handleInlineComposerSubmit,
     inlineAttachmentError,
     inlineEditingQueuedMessage,
-    inlineEditingQueuedMessageRef,
     inlineExecutionConfig,
     inlinePermissionConfig,
     isAttachingInlineFiles,
@@ -1388,17 +1418,56 @@ export function ThreadDetailPromptArea({
     promptActions,
     promptPlaceholder,
     queuedComposerTextEffects,
+    queuedMessagePluginComposerHost,
     removeActiveComposerAttachment,
     runtimeDisplayStatus,
     setActiveComposerDraft,
     thread.id,
     typeaheadConfig,
   ]);
+  // The published value only ever flips between two stable host identities
+  // (per thread / per edit session): keystrokes do not notify the pane scope.
+  // While the inline editor cannot render (execution/permission configs still
+  // loading), the bottom composer is what is on screen, so its host stays
+  // published.
   usePublishPluginComposerHost(
-    queuedMessageEditor?.pluginComposerHost ?? normalPluginComposerHost,
+    queuedMessageEditor
+      ? queuedMessagePluginComposerHost
+      : normalPluginComposerHost,
   );
+  // Stable per edit operation like every other host: the composer config
+  // around it legitimately rebuilds per keystroke, but context consumers of
+  // the host must not re-render on identity churn.
+  const sentMessageEditOperationId = sentMessageEdit?.operationId ?? null;
+  const sentMessagePluginComposerHost =
+    useMemo<PluginComposerHost | null>(() => {
+      if (sentMessageEditOperationId === null) {
+        return null;
+      }
+      const operationId = sentMessageEditOperationId;
+      return {
+        scope: { kind: "thread", threadId: thread.id },
+        textEffectKey: `sent-message:${thread.id}:${operationId}`,
+        getCurrent: () =>
+          readSentMessageEditDraft(
+            sentMessageEditRef,
+            operationId,
+            ENDED_EDIT_SESSION_DRAFT,
+          ),
+        subscribeDraft: subscribeSentMessageEditDraft,
+        setDraft: (nextDraft) =>
+          writeSentMessageEditDraft(sentMessageEditRef, operationId, nextDraft),
+        focus: focusInlinePluginComposer,
+      };
+    }, [
+      focusInlinePluginComposer,
+      sentMessageEditOperationId,
+      sentMessageEditRef,
+      subscribeSentMessageEditDraft,
+      thread.id,
+    ]);
   const sentMessageEditorPortal = useMemo(() => {
-    if (!sentMessageEdit?.hostElement) {
+    if (!sentMessageEdit?.hostElement || !sentMessagePluginComposerHost) {
       return null;
     }
     const { draft, hostElement, operationId } = sentMessageEdit;
@@ -1444,20 +1513,7 @@ export function ThreadDetailPromptArea({
           onSelectHistoryEntry: (nextDraft) =>
             sentMessageEdit.updateDraft(() => nextDraft),
           permission: bottomPermissionConfig,
-          pluginComposerHost: {
-            scope: { kind: "thread", threadId: thread.id },
-            textEffectKey: `sent-message:${thread.id}:${operationId}`,
-            draft,
-            getCurrent: () =>
-              readSentMessageEditDraft(sentMessageEditRef, operationId, draft),
-            setDraft: (nextDraft) =>
-              writeSentMessageEditDraft(
-                sentMessageEditRef,
-                operationId,
-                nextDraft,
-              ),
-            focus: focusInlinePluginComposer,
-          },
+          pluginComposerHost: sentMessagePluginComposerHost,
           promptActions,
           promptPlaceholder: "Edit message",
           submit: handleSentMessageEditSubmit,
@@ -1477,7 +1533,6 @@ export function ThreadDetailPromptArea({
     canSubmitSentMessageEdit,
     compactExecutionConfig,
     editFocusNonce,
-    focusInlinePluginComposer,
     handleAttachSentMessageFiles,
     handleSentMessageEditSubmit,
     isAttachingSentMessageFiles,
@@ -1487,8 +1542,8 @@ export function ThreadDetailPromptArea({
     sentMessageAttachmentError,
     sentMessageComposerTextEffects,
     sentMessageEdit,
-    sentMessageEditRef,
     sentMessageEditSubmitMode,
+    sentMessagePluginComposerHost,
     thread.id,
     typeaheadConfig,
   ]);
@@ -1588,7 +1643,7 @@ export function ThreadDetailPromptArea({
           <QueuedMessagesList
             queuedMessages={queuedMessages}
             resolveMentionLink={resolveMentionLink}
-            inlineEditor={queuedMessageEditor?.inlineEditor}
+            inlineEditor={queuedMessageEditor ?? undefined}
             sendDisabled={
               !(submitMode.kind === "ready" || submitMode.kind === "queue") ||
               runtimeDisplayStatus === "provisioning" ||

--- a/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
+++ b/apps/app/src/views/thread-detail/ThreadDetailSecondaryContent.test.tsx
@@ -1,10 +1,20 @@
 // @vitest-environment jsdom
 
-import type { ComponentProps, ReactNode } from "react";
-import { cleanup, render, screen } from "@testing-library/react";
+import { useMemo, type ComponentProps, type ReactNode } from "react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { CompactViewportOverrideProvider } from "@bb/shared-ui/hooks/use-compact-viewport";
+import {
+  usePluginComposerHost,
+  usePluginComposerHostDraft,
+  usePublishPluginComposerHost,
+  type PluginComposerHost,
+} from "@/components/plugin/plugin-composer-host";
+import {
+  getPromptDraftAccessor,
+  usePromptDraftStorage,
+} from "@/hooks/usePromptDraftStorage";
 import { ThreadDetailSecondaryContent } from "./ThreadDetailSecondaryContent";
 import {
   DefaultPaneContextProvider,
@@ -141,6 +151,10 @@ vi.mock(
   },
 );
 
+const { timelinePaneRenders } = vi.hoisted(() => ({
+  timelinePaneRenders: vi.fn(),
+}));
+
 vi.mock("./ThreadTimelinePane", async (importOriginal) => {
   const React = await import("react");
   const actual = await importOriginal<typeof import("./ThreadTimelinePane")>();
@@ -148,8 +162,9 @@ vi.mock("./ThreadTimelinePane", async (importOriginal) => {
   const ThreadTimelinePane = ({
     footer,
     threadId,
-  }: ComponentProps<typeof actual.ThreadTimelinePane>) =>
-    React.createElement(
+  }: ComponentProps<typeof actual.ThreadTimelinePane>) => {
+    timelinePaneRenders();
+    return React.createElement(
       "div",
       {
         "data-testid": "thread-timeline-pane",
@@ -157,6 +172,7 @@ vi.mock("./ThreadTimelinePane", async (importOriginal) => {
       },
       footer,
     );
+  };
 
   return { ...actual, ThreadTimelinePane };
 });
@@ -171,6 +187,44 @@ const hostedPaneRegistration = {
     publishedHostedPanel = model;
   },
 };
+
+/**
+ * Mirrors ThreadDetailPromptArea's host construction over the real draft
+ * store: an identity-stable host publishing into the pane scope from the
+ * footer slot, plus an actual draft consumer, exactly where the composer
+ * sits in the app tree.
+ */
+function FooterComposerHostPublisher({ threadId }: { threadId: string }) {
+  const promptDraft = usePromptDraftStorage({
+    kind: "thread",
+    projectId: "proj-test",
+    threadId,
+  });
+  const host = useMemo<PluginComposerHost>(
+    () => ({
+      scope: { kind: "thread", threadId },
+      textEffectKey: promptDraft.storageKey,
+      getCurrent: promptDraft.getCurrent,
+      subscribeDraft: promptDraft.subscribe,
+      setDraft: promptDraft.setDraft,
+      focus: () => {},
+    }),
+    [
+      promptDraft.getCurrent,
+      promptDraft.setDraft,
+      promptDraft.storageKey,
+      promptDraft.subscribe,
+      threadId,
+    ],
+  );
+  usePublishPluginComposerHost(host);
+  return <FooterComposerDraftProbe />;
+}
+
+function FooterComposerDraftProbe() {
+  const draft = usePluginComposerHostDraft(usePluginComposerHost());
+  return <div data-testid="footer-composer-draft">{draft?.text ?? ""}</div>;
+}
 
 function makeThread(): ThreadDetailSecondaryContentProps["metadata"]["thread"] {
   return {
@@ -313,7 +367,9 @@ afterEach(() => {
   cleanup();
   publishedHostedPanel = null;
   secondaryPanelMockState.renderBrowserDeck = undefined;
+  timelinePaneRenders.mockClear();
   useThreadsMock.mockClear();
+  window.localStorage.clear();
 });
 
 // The secondary panel chunk loads lazily, so the panel appears one tick
@@ -460,5 +516,46 @@ describe("ThreadDetailSecondaryContent", () => {
     expect(useThreadsMock).toHaveBeenLastCalledWith(expect.anything(), {
       enabled: true,
     });
+  });
+
+  // Regression probe for the 19.6s mobile keystroke hang: the body holds the
+  // published composer host, so a per-keystroke host identity re-rendered
+  // SecondaryPanelLayout and the timeline pane per character.
+  it("does not re-render the timeline pane while the composer draft changes", async () => {
+    const props = createProps();
+    props.footer = <FooterComposerHostPublisher threadId="thread-1" />;
+    render(
+      <MemoryRouter>
+        <DefaultPaneContextProvider>
+          <CompactViewportOverrideProvider isCompactViewport={false}>
+            <ThreadDetailSecondaryContent {...props} />
+          </CompactViewportOverrideProvider>
+        </DefaultPaneContextProvider>
+      </MemoryRouter>,
+    );
+
+    // Let the lazy secondary panel and the host publication settle first.
+    await screen.findByTestId("inline-secondary-panel", {}, { timeout: 5_000 });
+    expect(screen.getByTestId("footer-composer-draft").textContent).toBe("");
+    const paneRendersAfterMount = timelinePaneRenders.mock.calls.length;
+
+    // Keystrokes hit the same store the composer writes through.
+    const accessor = getPromptDraftAccessor({
+      kind: "thread",
+      projectId: "proj-test",
+      threadId: "thread-1",
+    });
+    const typed = "why does typing hang";
+    for (let index = 1; index <= typed.length; index += 1) {
+      const text = typed.slice(0, index);
+      act(() => {
+        accessor.setDraft({ text, mentions: [], attachments: [] });
+      });
+      expect(screen.getByTestId("footer-composer-draft").textContent).toBe(
+        text,
+      );
+    }
+
+    expect(timelinePaneRenders.mock.calls.length).toBe(paneRendersAfterMount);
   });
 });


### PR DESCRIPTION
## What was wrong
ThreadDetailPromptArea rebuilt its published PluginComposerHost every keystroke (the draft rode on the host object), so the identity-change notify re-rendered ThreadDetailSecondaryContentBody → SecondaryPanelLayout → ThreadTimelinePane → PageShell per character typed. Production telemetry attributed the worst mobile hang (19.6s after keydown) to this class.

## What changed
PluginComposerHost drops the draft field; the contract is an identity-stable host exposing getCurrent() + subscribeDraft(), with usePluginComposerHostDraft as the only reactive read. Store-backed hosts (thread, new-thread) subscribe through the prompt-draft store; state-backed hosts (queued, sent-message, embedded chat) notify from layout effects ordered after the identity-ref sync — a review-caught ordering bug where a thread switch could briefly expose the previous thread's draft is fixed and regression-tested both ways. All hosts (including sent-message) honor the identity-stable contract. Plugin SDK exports (packages/plugin-sdk) are untouched; useComposerView values and timing are unchanged, and the SDK version-lockstep gate confirms no surface files changed.

## How verified
336 targeted tests / 17 files: keystroke render-count probes (shell must not re-render while typing; draft consumers must update), the thread-switch ordering regression (fails on the broken ordering), secondary-content probes, plus upstream's escape/collapse tests in the touched areas. Typecheck + oxlint at clean-tree baseline; adversarially reviewed, rebased over the zen-mode removal (#2254) adopting upstream semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)