### PR TITLE
Let markdown tables and code blocks scroll sideways in mobile messages

### DIFF
--- a/apps/mobile/e2e/flows/phase4a-work-rows.yaml
+++ b/apps/mobile/e2e/flows/phase4a-work-rows.yaml
@@ -219,3 +219,40 @@ env:
 - assertVisible:
     id: "timeline-workflow-usage"
 - takeScreenshot: phase4a-work-rows-workflow-failed
+# The closing assistant message carries a table wider than the screen. It
+# must scroll sideways under the message's long-press Pressables (new
+# architecture: a ScrollView will not scroll while an ancestor is the JS
+# responder), and a long-press on it must still open the message actions.
+- scrollUntilVisible:
+    element:
+      text: "(?s).*Summary of the changes.*"
+    direction: DOWN
+    timeout: 30000
+    speed: 40
+# The table is the last content on the page: bottom the list out so the
+# whole table is on screen on any device height. (Cells inside the nested
+# horizontal ScrollView report as visible before they are, so they are not
+# reliable scroll targets.)
+- scroll
+- scroll
+- scroll
+- assertNotVisible: "(?s).*scroll sideways inside the timeline.*"
+- swipe:
+    from:
+      text: ".*horizontal scroll.*"
+    direction: LEFT
+    duration: 600
+- extendedWaitUntil:
+    visible: "(?s).*scroll sideways inside the timeline.*"
+    timeout: 10000
+- takeScreenshot: phase4a-work-rows-table-scrolled
+# The Reviewer column is fully on screen after the swipe; long-press lands
+# inside the table regardless of how far the fling carried it.
+- longPressOn: "sawyer"
+- extendedWaitUntil:
+    visible: "Copy text"
+    timeout: 10000
+- tapOn: "Copy text"
+- extendedWaitUntil:
+    visible: "Copied"
+    timeout: 10000

--- a/apps/mobile/src/composer/Composer.tsx
+++ b/apps/mobile/src/composer/Composer.tsx
@@ -24,6 +24,7 @@ import {
   ActionSheet,
   Button,
   Icon,
+  LONG_PRESS_DELAY_MS,
   SheetPresenceContext,
   Spinner,
   useOverlayBounds,
@@ -625,7 +626,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(
                         ? () => submit("steer")
                         : undefined
                     }
-                    delayLongPress={350}
+                    delayLongPress={LONG_PRESS_DELAY_MS}
                     testID={`${testID}-submit`}
                     style={({ pressed }) => ({
                       width: 36,

--- a/apps/mobile/src/markdown/CodeBlock.tsx
+++ b/apps/mobile/src/markdown/CodeBlock.tsx
@@ -4,6 +4,7 @@ import { Pressable, ScrollView, Text as RNText, View } from "react-native";
 import { FONT_FAMILIES } from "@/theme/fonts";
 import { nativeTypography } from "@/theme/theme.native";
 import { Icon } from "@/ui/Icon";
+import { LONG_PRESS_DELAY_MS } from "@/ui/long-press";
 import { toast } from "@/ui/Toast";
 import {
   codeTokenColor,
@@ -105,38 +106,47 @@ export const CodeBlock = memo(function CodeBlock({
         horizontal
         showsHorizontalScrollIndicator={false}
         nestedScrollEnabled
-        contentContainerStyle={{
-          paddingHorizontal: 12,
-          paddingBottom: 10,
-          paddingTop: 2,
-        }}
       >
-        <RNText
-          selectable={ctx.selectable}
-          style={{
-            fontFamily: FONT_FAMILIES.mono.regular,
-            fontWeight: "400",
-            fontSize: mono.fontSize,
-            lineHeight: mono.lineHeight,
-            color: tokens.foreground,
-          }}
+        {/*
+          The body gets its own Pressable inside the ScrollView, and the
+          body padding sits on it so a drag that starts in a gutter hits it
+          too. With only the outer Pressable (an ancestor of the ScrollView)
+          as responder, the new architecture never lets the ScrollView scroll
+          sideways. See MarkdownTable.
+        */}
+        <Pressable
+          accessible={false}
+          onLongPress={copy}
+          delayLongPress={LONG_PRESS_DELAY_MS}
+          style={{ paddingHorizontal: 12, paddingBottom: 10, paddingTop: 2 }}
         >
-          {lines.map((line, lineIndex) => (
-            <RNText key={lineIndex}>
-              {line.map((span, spanIndex) => (
-                <RNText
-                  key={spanIndex}
-                  style={{
-                    color: codeTokenColor(span.type, mode, tokens),
-                  }}
-                >
-                  {span.text}
-                </RNText>
-              ))}
-              {lineIndex < lines.length - 1 ? "\n" : null}
-            </RNText>
-          ))}
-        </RNText>
+          <RNText
+            selectable={ctx.selectable}
+            style={{
+              fontFamily: FONT_FAMILIES.mono.regular,
+              fontWeight: "400",
+              fontSize: mono.fontSize,
+              lineHeight: mono.lineHeight,
+              color: tokens.foreground,
+            }}
+          >
+            {lines.map((line, lineIndex) => (
+              <RNText key={lineIndex}>
+                {line.map((span, spanIndex) => (
+                  <RNText
+                    key={spanIndex}
+                    style={{
+                      color: codeTokenColor(span.type, mode, tokens),
+                    }}
+                  >
+                    {span.text}
+                  </RNText>
+                ))}
+                {lineIndex < lines.length - 1 ? "\n" : null}
+              </RNText>
+            ))}
+          </RNText>
+        </Pressable>
       </ScrollView>
     </Pressable>
   );

--- a/apps/mobile/src/markdown/Markdown.tsx
+++ b/apps/mobile/src/markdown/Markdown.tsx
@@ -174,6 +174,7 @@ function MarkdownComponent({
   onThreadPress,
   onMentionPress,
   onBlockLongPress,
+  onLongPress,
   renderDirective,
   resolveImageSource,
 }: MarkdownProps) {
@@ -232,6 +233,7 @@ function MarkdownComponent({
     onThreadPress,
     onMentionPress,
     onBlockLongPress,
+    onLongPress,
     renderDirective,
     resolveImageSource,
   });

--- a/apps/mobile/src/markdown/MarkdownContext.tsx
+++ b/apps/mobile/src/markdown/MarkdownContext.tsx
@@ -74,6 +74,13 @@ export interface MarkdownCallbacks {
    */
   onBlockLongPress?: (block: MarkdownBlockPress) => void;
   /**
+   * Long-pressed a block that owns its touch target (a table: its target
+   * sits inside the horizontal ScrollView, so a Pressable around the whole
+   * body never sees the press) and that has no `onBlockLongPress`. Pass the
+   * body's message-level long-press here so such blocks are not dead zones.
+   */
+  onLongPress?: () => void;
+  /**
    * Directive cards. Return a node to render a card, or null to fall back to
    * the literal directive source.
    */
@@ -140,6 +147,7 @@ export function useMarkdownContextValue(
     onThreadPress,
     onMentionPress,
     onBlockLongPress,
+    onLongPress,
     renderDirective,
     resolveImageSource,
   } = inputs;
@@ -160,6 +168,7 @@ export function useMarkdownContextValue(
       onThreadPress,
       onMentionPress,
       onBlockLongPress,
+      onLongPress,
       renderDirective,
       resolveImageSource,
     }),
@@ -179,6 +188,7 @@ export function useMarkdownContextValue(
       onThreadPress,
       onMentionPress,
       onBlockLongPress,
+      onLongPress,
       renderDirective,
       resolveImageSource,
     ],

--- a/apps/mobile/src/markdown/MarkdownTable.tsx
+++ b/apps/mobile/src/markdown/MarkdownTable.tsx
@@ -1,9 +1,10 @@
 import type { AlignType, Table, TableCell } from "mdast";
 import { toString as mdastToString } from "mdast-util-to-string";
 import { memo, useMemo } from "react";
-import { ScrollView, Text as RNText, View } from "react-native";
+import { Pressable, ScrollView, Text as RNText, View } from "react-native";
 import { FONT_FAMILIES } from "@/theme/fonts";
 import { nativeTypography } from "@/theme/theme.native";
+import { LONG_PRESS_DELAY_MS } from "@/ui/long-press";
 import { buildTableModel } from "./blocks";
 import { useMarkdownContext } from "./MarkdownContext";
 import { renderInline } from "./render-inline";
@@ -59,8 +60,14 @@ function textAlign(align: AlignType): "left" | "center" | "right" {
 
 export const MarkdownTable = memo(function MarkdownTable({
   table,
+  onLongPress,
 }: {
   table: Table;
+  /**
+   * Long-press on the table body: the quote-this-block shortcut, or the
+   * body-level message actions when no block handler exists.
+   */
+  onLongPress?: () => void;
 }) {
   const ctx = useMarkdownContext();
   const { tokens } = ctx;
@@ -118,7 +125,22 @@ export const MarkdownTable = memo(function MarkdownTable({
       showsHorizontalScrollIndicator={false}
       nestedScrollEnabled
     >
-      <View
+      {/*
+        The long-press target lives INSIDE the ScrollView on purpose. On the
+        new architecture a ScrollView refuses to take over a touch while one
+        of its ancestors is the JS responder (RCTScrollViewComponentView
+        `_shouldDisableScrollInteraction`), and a Pressable claims the
+        responder as soon as a touch starts. Timeline messages wrap their
+        markdown in Pressables, so a table under them could not scroll
+        sideways. A Pressable descendant claims the responder first, and the
+        ScrollView cancels a descendant normally once the drag starts. Since
+        it claims every touch, it must also carry the body-level long-press
+        when there is no block handler (render-blocks passes the fallback).
+      */}
+      <Pressable
+        accessible={false}
+        onLongPress={onLongPress}
+        delayLongPress={LONG_PRESS_DELAY_MS}
         style={{
           borderWidth: 1,
           borderRightWidth: 0,
@@ -153,7 +175,7 @@ export const MarkdownTable = memo(function MarkdownTable({
             )}
           </View>
         ))}
-      </View>
+      </Pressable>
     </ScrollView>
   );
 });

--- a/apps/mobile/src/markdown/render-blocks.tsx
+++ b/apps/mobile/src/markdown/render-blocks.tsx
@@ -5,6 +5,7 @@ import { Pressable, Text as RNText, View, type TextStyle } from "react-native";
 import { FONT_FAMILIES, FONT_WEIGHT_VALUES } from "@/theme/fonts";
 import { nativeTypography } from "@/theme/theme.native";
 import { Icon } from "@/ui/Icon";
+import { LONG_PRESS_DELAY_MS } from "@/ui/long-press";
 import { getNodeSource, splitParagraphSegments } from "./blocks";
 import { CodeBlock } from "./CodeBlock";
 import type { MarkdownContextValue } from "./MarkdownContext";
@@ -409,8 +410,6 @@ function renderBlockContent(
       return <CodeBlock code={node.value} language={node.lang ?? null} />;
     case "math":
       return <CodeBlock code={node.value} language="math" />;
-    case "table":
-      return <MarkdownTable table={node} />;
     case "html":
       return (
         <RNText
@@ -517,20 +516,38 @@ const MarkdownBlock = memo(function MarkdownBlock({
   isLast,
   keyPrefix,
 }: MarkdownBlockProps) {
+  const onBlockLongPress = ctx.onBlockLongPress;
+  const onLongPress =
+    onBlockLongPress !== undefined && source !== null
+      ? () => onBlockLongPress({ source })
+      : undefined;
+  const style = blockMargins(node, isFirst, isLast, options);
+  if (node.type === "table") {
+    // A table owns its long-press target (inside its ScrollView; see
+    // MarkdownTable), so it gets no Pressable wrapper. Without a block
+    // handler it falls back to the body-level one. Code blocks also own
+    // their target, but theirs copies the code instead of quoting it.
+    return (
+      <View style={style}>
+        <MarkdownTable
+          table={node}
+          onLongPress={onLongPress ?? ctx.onLongPress}
+        />
+      </View>
+    );
+  }
   const rendered = renderBlockContent(node, ctx, content, options, keyPrefix);
   if (rendered === null) {
     return null;
   }
-  const style = blockMargins(node, isFirst, isLast, options);
-  const onBlockLongPress = ctx.onBlockLongPress;
-  if (onBlockLongPress !== undefined && source !== null) {
+  if (onLongPress !== undefined) {
     // Not an accessibility element of its own: the text inside stays the
     // screen-reader target; long-press is a shortcut to quote this block.
     return (
       <Pressable
         accessible={false}
-        onLongPress={() => onBlockLongPress({ source })}
-        delayLongPress={350}
+        onLongPress={onLongPress}
+        delayLongPress={LONG_PRESS_DELAY_MS}
         style={style}
       >
         {rendered}

--- a/apps/mobile/src/screens/dev/work-row-fixtures.ts
+++ b/apps/mobile/src/screens/dev/work-row-fixtures.ts
@@ -808,7 +808,17 @@ export function buildWorkRowFixtureSections(): WorkRowFixtureSection[] {
           taskStatus: "stopped",
           completedAt: T0 + 9_000,
         }),
-        assistant("a-done", "All done."),
+        assistant(
+          "a-done",
+          [
+            "All done. Summary of the changes:",
+            "",
+            "| File | Change | Lines | Reviewer | Notes |",
+            "| --- | --- | ---: | --- | --- |",
+            "| src/markdown/MarkdownTable.tsx | horizontal scroll | 12 | sawyer | wide tables scroll sideways inside the timeline |",
+            "| src/markdown/CodeBlock.tsx | inner press target | 8 | bee | code bodies scroll sideways too |",
+          ].join("\n"),
+        ),
       ],
     },
   ];

--- a/apps/mobile/src/screens/files/FilePathRow.tsx
+++ b/apps/mobile/src/screens/files/FilePathRow.tsx
@@ -2,7 +2,7 @@ import { memo } from "react";
 import { Pressable, View } from "react-native";
 import { buildHighlightSegments, splitPathForRow } from "@/data/files";
 import { useTheme } from "@/theme";
-import { cn, Icon, Text, type IconName } from "@/ui";
+import { cn, Icon, LONG_PRESS_DELAY_MS, Text, type IconName } from "@/ui";
 
 interface FilePathRowProps {
   /** Root-relative (or absolute) path shown split into name + directory. */
@@ -53,7 +53,7 @@ export const FilePathRow = memo(function FilePathRow({
       accessibilityLabel={path}
       onPress={onPress}
       onLongPress={onLongPress}
-      delayLongPress={350}
+      delayLongPress={LONG_PRESS_DELAY_MS}
       testID={testID}
       className="min-h-[44px] flex-row items-center gap-3 px-4 py-2 active:bg-state-hover"
     >

--- a/apps/mobile/src/screens/sidebar/SidebarRows.tsx
+++ b/apps/mobile/src/screens/sidebar/SidebarRows.tsx
@@ -3,7 +3,7 @@ import { memo } from "react";
 import { Pressable, View } from "react-native";
 import { getThreadDisplayTitle } from "@/data/threads";
 import { useTheme } from "@/theme";
-import { Icon, Text, cn } from "@/ui";
+import { Icon, LONG_PRESS_DELAY_MS, Text, cn } from "@/ui";
 import {
   getCollapsedActivityIndicatorState,
   type SidebarEmptyRow,
@@ -113,7 +113,7 @@ export const SidebarThreadRowView = memo(function SidebarThreadRowView({
       accessibilityHint={subtitleText(subtitle)}
       onPress={() => onPress(row)}
       onLongPress={() => onLongPress(row)}
-      delayLongPress={350}
+      delayLongPress={LONG_PRESS_DELAY_MS}
       className="flex-row items-center gap-1 active:bg-state-hover"
       style={{
         minHeight: ROW_MIN_HEIGHT,
@@ -219,7 +219,7 @@ export const SidebarHeaderRowView = memo(function SidebarHeaderRowView({
       accessibilityState={{ expanded: !row.collapsed }}
       onPress={() => onToggleCollapsed(row)}
       onLongPress={() => onLongPress(row)}
-      delayLongPress={350}
+      delayLongPress={LONG_PRESS_DELAY_MS}
       className="flex-row items-center gap-1 active:bg-state-hover"
       style={{
         minHeight: HEADER_MIN_HEIGHT,

--- a/apps/mobile/src/screens/thread/timeline/renderers/conversation/AssistantMessageRow.tsx
+++ b/apps/mobile/src/screens/thread/timeline/renderers/conversation/AssistantMessageRow.tsx
@@ -8,7 +8,7 @@ import {
   type MarkdownBlockPress,
   type MarkdownThreadMentions,
 } from "@/markdown";
-import { Text } from "@/ui";
+import { LONG_PRESS_DELAY_MS, Text } from "@/ui";
 import type { TimelineMessageActionsTarget } from "../../../actions/message-actions-model";
 import { useTimelineRowHost } from "../../host/TimelineRowHostProvider";
 import { TimelineRowShell } from "../shared/ExpandableRowHeader";
@@ -107,7 +107,7 @@ export function AssistantMessageRow({
       <Pressable
         accessible={false}
         onLongPress={hasText ? onLongPress : undefined}
-        delayLongPress={350}
+        delayLongPress={LONG_PRESS_DELAY_MS}
         className="py-1"
         testID="conversation-assistant-body"
       >
@@ -122,6 +122,7 @@ export function AssistantMessageRow({
             onFilePress={onFilePress}
             onLinkPress={onLinkPress}
             onBlockLongPress={onBlockLongPress}
+            onLongPress={onLongPress}
             resolveImageSource={resolveImageSource}
           />
         ) : attachmentItems.imageItems.length === 0 &&

--- a/apps/mobile/src/screens/thread/timeline/renderers/conversation/AuthoredUserMessage.tsx
+++ b/apps/mobile/src/screens/thread/timeline/renderers/conversation/AuthoredUserMessage.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from "react";
 import { Pressable, View, type LayoutChangeEvent } from "react-native";
 import { Markdown, type MarkdownThreadMentions } from "@/markdown";
 import { nativeTypography } from "@/theme";
-import { Text } from "@/ui";
+import { LONG_PRESS_DELAY_MS, Text } from "@/ui";
 import {
   TIMELINE_ROW_HORIZONTAL_PADDING_PX,
   timelineRowLeftPadding,
@@ -135,7 +135,7 @@ export function AuthoredUserMessage({
         // reachable by screen readers and UI tests; long-press is a shortcut.
         accessible={false}
         onLongPress={onLongPress}
-        delayLongPress={350}
+        delayLongPress={LONG_PRESS_DELAY_MS}
         className="max-w-full rounded-xl border border-border-seam bg-surface-recessed px-3.5 py-2.5 active:opacity-90"
         testID="conversation-user-bubble"
       >
@@ -162,6 +162,7 @@ export function AuthoredUserMessage({
                   serverHostname={serverHostname}
                   onThreadPress={onThreadPress}
                   onFilePress={onFilePress}
+                  onLongPress={onLongPress}
                 />
               ) : (
                 <Text className="text-sm">{body.content}</Text>

--- a/apps/mobile/src/screens/thread/timeline/renderers/conversation/GeneratedMessageRow.tsx
+++ b/apps/mobile/src/screens/thread/timeline/renderers/conversation/GeneratedMessageRow.tsx
@@ -313,6 +313,7 @@ export function GeneratedMessageRow({
               onImagePress={onImagePress}
               onFilePress={onFilePress}
               onLinkPress={onLinkPress}
+              onLongPress={onLongPress}
               resolveImageSource={
                 suppressImages ? resolveImageSource : undefined
               }

--- a/apps/mobile/src/ui/index.ts
+++ b/apps/mobile/src/ui/index.ts
@@ -10,6 +10,7 @@ export {
   KeyboardPaddingView,
 } from "./KeyboardPaddingView";
 export { ListRow } from "./ListRow";
+export { LONG_PRESS_DELAY_MS } from "./long-press";
 export { OverlayBounds, useOverlayBounds } from "./OverlayBounds";
 export { Pill } from "./Pill";
 export { Separator } from "./Separator";

--- a/apps/mobile/src/ui/long-press.ts
+++ b/apps/mobile/src/ui/long-press.ts
@@ -1,0 +1,6 @@
+/**
+ * Long-press delay shared by every long-press shortcut (message actions,
+ * quote-this-block, sidebar rows, composer chips). One value, so nested
+ * targets (a block inside a message) never race each other.
+ */
+export const LONG_PRESS_DELAY_MS = 350;


### PR DESCRIPTION
## What was wrong

Markdown tables in mobile timeline messages did not scroll sideways, and fenced code blocks never scrolled sideways anywhere. On the new architecture, `RCTScrollViewComponentView._shouldDisableScrollInteraction` walks a ScrollView's ancestors and, if one of them is the JS responder, `touchesShouldCancelInContentView:` returns NO, so the UIScrollView never takes over the touch. A `Pressable` claims the JS responder as soon as a touch starts. Timeline messages wrap their markdown in long-press `Pressable`s (message actions, quote-this-block), so every table under them was blocked. `CodeBlock` wrapped its own ScrollView in a copy-on-long-press `Pressable`, so it was blocked even in the dev showcase.

## What changed

- `apps/mobile/src/markdown/MarkdownTable.tsx` — the long-press target is a `Pressable` **inside** the horizontal ScrollView. A descendant responder claims the touch first, and the ScrollView cancels it normally once the drag starts. Takes an `onLongPress` prop.
- `apps/mobile/src/markdown/render-blocks.tsx` — `MarkdownBlock` branches on `node.type === "table"`: plain `View` wrapper, handler passed directly. The handler is the block's quote shortcut, or the new body-level fallback when there is none. The comment notes that code blocks copy instead of quoting.
- `apps/mobile/src/markdown/MarkdownContext.tsx`, `Markdown.tsx` — new `onLongPress` (body-level fallback). `AssistantMessageRow`, `AuthoredUserMessage`, and `GeneratedMessageRow` pass their message-actions handler, so tables in user and generated messages keep their long-press.
- `apps/mobile/src/markdown/CodeBlock.tsx` — inner `Pressable` around the body, with the body padding on it so a drag that starts in a gutter scrolls too. The outer `Pressable` stays for the header.
- `apps/mobile/src/ui/long-press.ts` — `LONG_PRESS_DELAY_MS` (350) shared by all seven `delayLongPress` sites and both inner `Pressable`s, so nested targets never race each other.
- `apps/mobile/src/screens/dev/work-row-fixtures.ts` — the closing assistant fixture in the work-rows showcase carries a table wider than the screen.
- `apps/mobile/e2e/flows/phase4a-work-rows.yaml` — swipes that table, asserts the hidden column appears, long-presses a cell, and asserts "Copy text" → "Copied".

No wire, CLI, or doc changes.

Not in this PR: moving message-level long-press to `react-native-gesture-handler` (which would remove the need for inner `Pressable`s altogether) is a larger design change for a follow-up. On Android, the handler-less inner `Pressable` on surfaces that leave `selectable` at its default (file previews, skill details) may cancel native text-selection long-press on table cells; not confirmed on a device.

## How you verified

- Reproduced on an iPhone 17 Pro simulator with Maestro before the fix: the same table scrolled in the plain markdown showcase and did not scroll under `AssistantMessageRow`; a bare `Pressable` around a table reproduced it in isolation. Instrumented frame (368pt) vs. content (858pt) widths confirmed the ScrollView had room to scroll and received no scroll events.
- After the fix, on the simulator: the timeline table scrolls and reveals the hidden column; long-press on a cell opens the message actions and "Copy text" copies; long-press on a table inside a user-message bubble opens the actions (temporary fixture, reverted); the TS code block scrolls.
- The new `phase4a-work-rows.yaml` steps fail before the fix (the hidden column never appears) and pass after.
- `pnpm exec turbo run lint typecheck test --filter=@bb/mobile` — all tasks pass; the 19 lint warnings are pre-existing in untouched files.

> AGENT GENERATED
