### PR TITLE
fix(server): never persist empty-input prompt history rows

### DIFF
--- a/apps/server/src/services/prompt-history.ts
+++ b/apps/server/src/services/prompt-history.ts
@@ -250,6 +250,17 @@ export function recordAcceptedPromptHistoryEntry(
   deps: PromptHistoryRecordDeps,
   args: RecordAcceptedPromptHistoryEntryArgs,
 ): boolean {
+  // Empty input reaches this write path for turns that carry no prompt — a
+  // side-chat or fork preload starts the provider session before the first
+  // message, and createThreadRequestSchema deliberately allows input: []. The
+  // stored-input schema requires at least one item, so persisting an empty
+  // array would write a row the read path always skips. Reject it here;
+  // buildPromptHistoryEntries keeps skipping malformed rows as defense in
+  // depth for anything already persisted.
+  if (args.input.length === 0) {
+    return false;
+  }
+
   const scope = resolveAcceptedPromptHistoryScope({
     initiator: args.initiator,
     target: args.target,

--- a/apps/server/test/services/prompt-history.test.ts
+++ b/apps/server/test/services/prompt-history.test.ts
@@ -487,4 +487,40 @@ describe("prompt history service", () => {
       "Skipping malformed prompt history row",
     );
   });
+  it("does not persist empty-input turns as prompt history rows", () => {
+    const { db, firstProject, logger } = setup();
+    const thread = createThread(db, noopNotifier, {
+      projectId: firstProject.id,
+      providerId: "codex",
+    });
+
+    // Side-chat and fork preloads reach the write path with input: [] — the
+    // runtime starts no first turn, so there is no prompt to recall. A row
+    // persisted anyway would store input "[]", which the stored-input schema
+    // rejects at read time (the empty-array rows observed in production).
+    expect(
+      recordAcceptedPromptHistoryEntry(
+        { db },
+        {
+          thread,
+          input: [],
+          initiator: "user",
+          target: { kind: "thread-start" },
+          requestSequence: 1,
+        },
+      ),
+    ).toBe(false);
+
+    expect(db.select().from(promptHistoryEntries).all()).toEqual([]);
+    expect(
+      listProjectPromptHistory(
+        { db, logger },
+        {
+          projectId: firstProject.id,
+          limit: 50,
+        },
+      ),
+    ).toEqual([]);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## What was wrong

`recordAcceptedPromptHistoryEntry` (apps/server/src/services/prompt-history.ts) persisted `args.input` unconditionally whenever the scope resolved non-null. Turns that carry no prompt — source-derived side-chat preloads and empty-input fork starts, which `createThreadRequestSchema` deliberately allows (`originKind !== null` bypasses the ≥1 refinement) — therefore wrote `prompt_history_entries` rows with `input: "[]"`. The read path parses stored rows with `z.array(promptInputSchema).min(1)`, so every such row fails zod (`Too small: expected array to have >=1 items`) and is skipped with a warn log on each history read; 11 malformed rows were observed in production data on 2026-08-22 (post-mortem Issue 4, bullet 3).

## What changed

- `apps/server/src/services/prompt-history.ts` — `recordAcceptedPromptHistoryEntry` now returns `false` without writing when `args.input.length === 0`. This is the single write funnel for all four call sites (thread-provisioning ×2, thread-send, queued-messages flush), so no empty-array row can be persisted from any path. There is nothing to normalize an empty array into: the runtime's no-input-no-turn guard means such turns never run, so no prompt exists to recall. Valid rows are untouched — no behavior change for non-empty input, and scope resolution is unchanged.
- Read-side guard (`buildPromptHistoryEntries` skip + warn) intentionally kept as defense in depth for the 11 rows already persisted.
- No wire, schema, or API changes.

## How you verified

- Added `apps/server/test/services/prompt-history.test.ts` "does not persist empty-input turns as prompt history rows": records a `thread-start` turn with `input: []` on a root thread and asserts `recordAcceptedPromptHistoryEntry` returns `false`, the `prompt_history_entries` table stays empty, `listProjectPromptHistory` returns `[]`, and no warn is logged. Fails before the fix by construction — at base `fff3ae8` the same call returns `true`, inserts a row with `input: "[]"` (the exact production corruption), which only the read-side skip would then hide.
- Existing coverage retained: "skips malformed stored prompt history rows instead of failing the request" (read-side defense) and "does not record project history for child thread starts" (scope resolution) are unchanged by the guard.
- `pnpm exec turbo run test --filter=@bb/server` — 1923 tests, 1922 passing;
  the single failure (`test/app/install-machine-script.test.ts`) reproduces
  identically on a pristine `main` checkout at `fff3ae8` (environmental,
  pre-existing). Mutation check: with `prompt-history.ts` reverted to base,
  the new test fails (1 failed / 7 passed) and passes with the guard restored.
- `pnpm typecheck` (apps/server) and `pnpm run lint` green; `pnpm exec oxfmt
  --check` green on both touched files.

Fixes #2292

> AGENT GENERATED
