### PR TITLE
Resume daemon-restarted threads with persisted provider sessions

### DIFF
--- a/apps/server/src/internal/session-owner-side-effects.ts
+++ b/apps/server/src/internal/session-owner-side-effects.ts
@@ -20,7 +20,10 @@ import {
   reconcileDaemonReportedThreads,
 } from "../services/threads/thread-lifecycle.js";
 import { buildThreadStatusChangeMetadataByThreadId } from "../services/threads/thread-runtime-display.js";
-import { settleDanglingBackgroundTasks } from "../services/threads/background-task-reconciliation.js";
+import {
+  settleDanglingBackgroundTasks,
+  settleDaemonRestartedThreadRunsForResume,
+} from "../services/threads/background-task-reconciliation.js";
 
 const DAEMON_RESTARTED_PENDING_INTERACTION_REASON =
   "Host daemon restarted while awaiting user interaction; retry the thread to continue";
@@ -109,6 +112,7 @@ export async function handleHostSessionOpened(
         hostId: args.hostId,
         reason: DAEMON_RESTARTED_PENDING_INTERACTION_REASON,
       });
+      settleDaemonRestartedThreadRunsForResume(deps, { hostId: args.hostId });
       interruptActiveThreadsForHost(deps, {
         hostId: args.hostId,
         reason: "host-daemon-restarted",

--- a/apps/server/src/services/threads/background-task-reconciliation.ts
+++ b/apps/server/src/services/threads/background-task-reconciliation.ts
@@ -1,7 +1,11 @@
+import { and, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 import {
+  environments,
   listOpenBackgroundTaskItemRowsForHost,
   listOpenBackgroundTaskItemRowsForThread,
+  listThreadTurnInterruptionEventStates,
+  threads,
   type DbNotifier,
   type DbTransaction,
   type OpenBackgroundTaskItemRow,
@@ -11,16 +15,31 @@ import {
   isSettledBackgroundTaskStatus,
   threadEventBackgroundTaskItemSchema,
   threadScope,
+  turnScope,
+  type ThreadEventType,
 } from "@bb/domain";
 import type { ThreadEventBackgroundTaskItem } from "@bb/domain";
 import type { AppDeps } from "../../types.js";
+import { applyLoggedThreadLifecycleEventInTransaction } from "./lifecycle-outcome.js";
 import { appendThreadEventsInTransaction } from "./thread-events.js";
 
 interface SettleDanglingBackgroundTasksArgs {
   hostId: string;
 }
 
-type SettleDanglingBackgroundTasksDeps = Pick<AppDeps, "db" | "hub" | "logger">;
+interface SettleDaemonRestartedThreadRunsArgs {
+  hostId: string;
+}
+
+interface SettledDaemonRestartedThreadRun {
+  interruptedTurnId: string | null;
+  threadId: string;
+}
+
+type DaemonReconciliationDeps = Pick<AppDeps, "db" | "hub" | "logger">;
+type ThreadEventAppendArgs = Parameters<
+  typeof appendThreadEventsInTransaction
+>[1][number];
 type SettleDanglingBackgroundTasksTransactionDeps = {
   db: DbTransaction;
   hub: DbNotifier;
@@ -45,7 +64,7 @@ function parseStoredBackgroundTaskItem(
 }
 
 export function settleDanglingBackgroundTasks(
-  deps: SettleDanglingBackgroundTasksDeps,
+  deps: DaemonReconciliationDeps,
   args: SettleDanglingBackgroundTasksArgs,
 ): void {
   const rows = listOpenBackgroundTaskItemRowsForHost(deps.db, {
@@ -75,6 +94,103 @@ export function settleDanglingBackgroundTasks(
   }
 }
 
+export function settleDaemonRestartedThreadRunsForResume(
+  deps: DaemonReconciliationDeps,
+  args: SettleDaemonRestartedThreadRunsArgs,
+): SettledDaemonRestartedThreadRun[] {
+  const activeThreads = deps.db
+    .select({
+      environmentId: environments.id,
+      threadId: threads.id,
+    })
+    .from(threads)
+    .innerJoin(environments, eq(threads.environmentId, environments.id))
+    .where(
+      and(
+        eq(environments.hostId, args.hostId),
+        eq(threads.status, "active"),
+        isNull(threads.deletedAt),
+      ),
+    )
+    .all();
+  if (activeThreads.length === 0) {
+    return [];
+  }
+
+  const stateByThreadId = new Map(
+    listThreadTurnInterruptionEventStates(deps.db, {
+      threadIds: activeThreads.map((thread) => thread.threadId),
+    }).map((state) => [state.threadId, state]),
+  );
+  const resumableThreads = activeThreads.filter((thread) => {
+    const state = stateByThreadId.get(thread.threadId);
+    return state !== undefined && state.latestProviderThreadId !== null;
+  });
+  if (resumableThreads.length === 0) {
+    return [];
+  }
+
+  const results: SettledDaemonRestartedThreadRun[] = [];
+  deps.db.transaction(
+    (tx) => {
+      for (const thread of resumableThreads) {
+        const state = stateByThreadId.get(thread.threadId)!;
+        const providerThreadId = state.latestProviderThreadId;
+        const eventArgs: ThreadEventAppendArgs[] = [];
+        if (state.activeTurnId !== null) {
+          eventArgs.push({
+            threadId: thread.threadId,
+            environmentId: thread.environmentId,
+            providerThreadId,
+            type: "turn/completed",
+            scope: turnScope(state.activeTurnId),
+            data: {
+              providerThreadId,
+              status: "interrupted",
+            },
+          });
+        }
+        eventArgs.push({
+          threadId: thread.threadId,
+          type: "system/thread/interrupted",
+          scope: threadScope(),
+          data: {
+            reason: "host-daemon-restarted",
+          },
+        });
+        appendThreadEventsInTransaction(tx, eventArgs);
+
+        applyLoggedThreadLifecycleEventInTransaction(
+          { db: tx, logger: deps.logger },
+          { event: { type: "stop.requested" }, threadId: thread.threadId },
+        );
+        applyLoggedThreadLifecycleEventInTransaction(
+          { db: tx, logger: deps.logger },
+          { event: { type: "stop.settled" }, threadId: thread.threadId },
+        );
+        results.push({
+          interruptedTurnId: state.activeTurnId,
+          threadId: thread.threadId,
+        });
+      }
+    },
+    { behavior: "immediate" },
+  );
+
+  for (const result of results) {
+    const eventTypes: ThreadEventType[] = ["system/thread/interrupted"];
+    if (result.interruptedTurnId !== null) {
+      eventTypes.unshift("turn/completed");
+    }
+    deps.hub.notifyThread(
+      result.threadId,
+      ["events-appended", "status-changed"],
+      { eventTypes },
+    );
+  }
+
+  return results;
+}
 export function settleDanglingBackgroundTasksForStoppedThreadInTransaction(
   deps: SettleDanglingBackgroundTasksTransactionDeps,
   args: { threadId: string },

--- a/apps/server/test/internal/background-task-reconciliation.test.ts
+++ b/apps/server/test/internal/background-task-reconciliation.test.ts
@@ -492,7 +492,7 @@ describe("active thread disconnect reconciliation triggers", () => {
     });
   });
 
-  it("records a confirmed daemon restart when a different daemon instance registers", async () => {
+  it("resumes active turns whose provider session survives a daemon restart", async () => {
     await withTestHarness(async (harness) => {
       const { host, session, thread } = seedActiveTurnThread(harness);
 
@@ -519,24 +519,65 @@ describe("active thread disconnect reconciliation triggers", () => {
       });
 
       expect(response.status).toBe(201);
-      expect(getThread(harness.deps.db, thread.id)?.status).toBe("error");
+      expect(getThread(harness.deps.db, thread.id)?.status).toBe("idle");
       const rows = listEvents(harness.deps.db, { threadId: thread.id }).filter(
         (row) => row.type !== "turn/started",
       );
       expect(rows.map((row) => row.type)).toEqual([
         "turn/completed",
+        "system/thread/interrupted",
+      ]);
+      expect(JSON.parse(rows[0]!.data)).toMatchObject({
+        providerThreadId: "provider-turn-live-1",
+        status: "interrupted",
+      });
+      expect(JSON.parse(rows[1]!.data)).toEqual({
+        reason: "host-daemon-restarted",
+      });
+    });
+  });
+
+  it("interrupts active runs with no provider session to re-attach when a different daemon instance registers", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session, thread } = seedThreadFixture(harness, {
+        thread: { status: "active" },
+      });
+
+      handleDaemonSocketClosed(harness.deps, { sessionId: session.id });
+
+      const response = await harness.app.request("/internal/session/open", {
+        method: "POST",
+        headers: internalAuthHeaders(harness, {
+          hostId: host.id,
+          hostType: host.type,
+        }),
+        body: JSON.stringify({
+          hostId: host.id,
+          instanceId: "instance-restarted-no-session",
+          hostName: host.name,
+          hostType: host.type,
+          hasMachineCredential: false,
+          platform: "darwin",
+          dataDir: "/tmp/host-daemon-active-restarted-no-session",
+          localApiPort: null,
+          protocolVersion: HOST_DAEMON_PROTOCOL_VERSION,
+          activeThreads: [],
+        }),
+      });
+
+      expect(response.status).toBe(201);
+      expect(getThread(harness.deps.db, thread.id)?.status).toBe("error");
+      const rows = listEvents(harness.deps.db, { threadId: thread.id });
+      expect(rows.map((row) => row.type)).toEqual([
         "system/error",
         "system/thread/interrupted",
       ]);
       expect(JSON.parse(rows[0]!.data)).toMatchObject({
-        status: "interrupted",
-      });
-      expect(JSON.parse(rows[1]!.data)).toMatchObject({
         code: "thread_command_failed",
         message: "Thread interrupted because the host daemon disconnected",
         detail: "Please retry the thread to continue.",
       });
-      expect(JSON.parse(rows[2]!.data)).toEqual({
+      expect(JSON.parse(rows[1]!.data)).toEqual({
         reason: "host-daemon-restarted",
       });
     });


### PR DESCRIPTION
## What was wrong

When a daemon re-registers with a new instance id, `handleHostSessionOpened` unconditionally failed every active thread on that host before reconciliation could look at it: a synthetic `turn/completed` (interrupted), a `system/error` ("Thread interrupted because the host daemon disconnected" / "Please retry the thread to continue."), and `run.failed` landing the thread in `error` (base fff3ae8: [`session-owner-side-effects.ts`](https://github.com/get-bb/bb/blob/fff3ae8/apps/server/src/internal/session-owner-side-effects.ts#L115-L125) calling [`thread-lifecycle.ts`](https://github.com/get-bb/bb/blob/fff3ae8/apps/server/src/services/threads/thread-lifecycle.ts#L374-L375)). That is a lie for any run whose provider session survives the restart: ACP and Codex sessions persist on the host and re-attach through `thread/resume` on the next dispatch. #1592 asks for exactly this — overnight work dying on every daemon restart with a "please retry" prompt instead of continuing.

## What changed

- `apps/server/src/services/threads/background-task-reconciliation.ts`: new `settleDaemonRestartedThreadRunsForResume`, the daemon-restart counterpart of the dangling-task backstop. Active threads on the host that have a persisted provider thread id settle like a user stop — `turn/completed` (interrupted) plus `system/thread/interrupted` (reason `host-daemon-restarted`), **no synthetic `system/error`** — and land `idle` via `stop.requested`/`stop.settled`. Runs with no provider session (e.g. a `thread.start` that never established one) are left active and keep the existing failure interruption; there is nothing to re-attach.
- `apps/server/src/internal/session-owner-side-effects.ts`: the replacement-instance branch calls the resume settlement before the interruption sweep, which then only sees the non-resumable runs. `settleDanglingBackgroundTasks` and the same-instance reconnect / disconnect-grace / host-removed paths are unchanged.
- No wire changes (`HOST_DAEMON_PROTOCOL_VERSION` untouched); no CLI or doc surface affected.

Deviations from the issue's ask, flagged for maintainers:

1. #1592 asks that the daemon "picked up the thread agains automatically". This PR makes restarted threads cleanly *resumable* rather than auto-replaying them: an idle thread re-attaches its persisted provider session on the next `turn.submit`, and the existing queued-message auto-send sweep continues threads that had work queued — no manual retry, no misleading error. It does **not** automatically re-submit the interrupted turn's stored input: that duplicates the user message in the provider transcript and is a product decision (happy to implement if you want it).
2. The interrupted turn still gets a canonical `turn/completed` (interrupted) record, same as a user stop. Leaving the turn open would misroute subsequent sends as steers to a turn no live runtime owns.

## How you verified

Extended `apps/server/test/internal/background-task-reconciliation.test.ts`:

- "resumes active turns whose provider session survives a daemon restart" — drives `handleDaemonSocketClosed` then `/internal/session/open` with a new instance id and asserts the thread lands `idle` with exactly `[turn/completed, system/thread/interrupted]` and no `system/error`. On base fff3ae8 the same scenario produces `error` plus the synthetic `system/error`, so this test fails before the change.
- "interrupts active runs with no provider session to re-attach when a different daemon instance registers" — guards the nothing-to-re-attach case: still `error` with the failure interruption.
- The existing same-instance-reconnect and disconnect-grace tests are untouched and still cover their paths.

- Locally: `pnpm exec turbo run test --filter=@bb/server` — 1923 tests, 1922
  passing; the single failure (`test/app/install-machine-script.test.ts`)
  reproduces identically on a pristine `main` checkout at `fff3ae8`
  (environmental, pre-existing). Mutation check: reverting only the
  `session-owner-side-effects.ts` wiring makes the resume test fail (1
  failed / 11 passed) and pass with the call restored.
- `pnpm exec turbo run typecheck lint --filter=@bb/server` green; `pnpm exec
  oxfmt --check` green on all three touched files.

Fixes #1592

> AGENT GENERATED
