### PR TITLE
Bundle the plugin SDK declaration files in parallel worker threads

### DIFF
--- a/packages/plugin-sdk/scripts/build-bundled-dts.mjs
+++ b/packages/plugin-sdk/scripts/build-bundled-dts.mjs
@@ -24,8 +24,15 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { availableParallelism } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  Worker,
+  isMainThread,
+  parentPort,
+  workerData,
+} from "node:worker_threads";
 import { rollup } from "rollup";
 import { dts } from "rollup-plugin-dts";
 
@@ -147,23 +154,68 @@ const HEADER = [
   "// and read the real source: https://github.com/get-bb/bb",
 ].join("\n");
 
-const generated = {};
-for (const [fileName, entry] of Object.entries(outputs)) {
-  generated[fileName] = normalizeBundledDts(
-    `${HEADER}\n\n${await bundle(entry)}`,
+function generateBundle(entry) {
+  return bundle(entry).then((code) =>
+    normalizeBundledDts(`${HEADER}\n\n${code}`),
   );
 }
 
-mkdirSync(outDir, { recursive: true });
+// Each bundle builds its own TypeScript program, which is CPU-bound and
+// single-threaded inside rollup-plugin-dts; the six large entries take 2–7s
+// apiece. They are independent, so this file re-runs itself as a worker per
+// entry, as many at a time as there are cores, and the serial ~27s becomes
+// roughly the longest single bundle.
+if (!isMainThread) {
+  parentPort.postMessage(await generateBundle(workerData.entry));
+} else {
+  await main();
+}
 
-for (const [fileName, content] of Object.entries(generated)) {
-  const target = path.join(outDir, fileName);
-  const current = existsSync(target) ? readFileSync(target, "utf8") : null;
-  if (current === content) {
-    console.log(`Unchanged ${path.relative(pkgRoot, target)}`);
-  } else {
-    writeAtomically(target, content);
-    console.log(`Wrote ${path.relative(pkgRoot, target)}`);
+async function main() {
+  const generated = {};
+  const queue = Object.entries(outputs);
+  const workers = Math.min(queue.length, availableParallelism());
+  await Promise.all(
+    Array.from({ length: workers }, async () => {
+      for (let next = queue.shift(); next; next = queue.shift()) {
+        const [fileName, entry] = next;
+        generated[fileName] = await generateInWorker(entry);
+      }
+    }),
+  );
+  // Keep the declared order so a diff of the outputs stays readable.
+  writeOutputs(
+    Object.fromEntries(
+      Object.keys(outputs).map((fileName) => [fileName, generated[fileName]]),
+    ),
+  );
+}
+
+function generateInWorker(entry) {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(new URL(import.meta.url), {
+      workerData: { entry },
+    });
+    worker.once("message", resolve);
+    worker.once("error", reject);
+    worker.once("exit", (code) => {
+      if (code !== 0) reject(new Error(`bundle worker exited with ${code}`));
+    });
+  });
+}
+
+function writeOutputs(generated) {
+  mkdirSync(outDir, { recursive: true });
+
+  for (const [fileName, content] of Object.entries(generated)) {
+    const target = path.join(outDir, fileName);
+    const current = existsSync(target) ? readFileSync(target, "utf8") : null;
+    if (current === content) {
+      console.log(`Unchanged ${path.relative(pkgRoot, target)}`);
+    } else {
+      writeAtomically(target, content);
+      console.log(`Wrote ${path.relative(pkgRoot, target)}`);
+    }
   }
 }
 


### PR DESCRIPTION
## What was wrong

`@get-bb/plugin-sdk#build:types` (`scripts/build-bundled-dts.mjs`) produces the 13 portable declaration bundles one after another. Each `rollup-plugin-dts` bundle builds its own TypeScript 6 program over the SDK sources plus the inlined `@bb/*` workspace sources; the six large entries take 2–7 s apiece and the task takes ~27 s on a 16-core machine. It gates `@bb/host-daemon#build`, `@bb/cli#test`, `@bb/templates#test`, and `@bb/integration-tests#typecheck`.

## What changed

The bundles are independent, so the script re-runs itself as a `worker_threads` worker per entry, keeping as many in flight as `os.availableParallelism()`. The main thread still writes the outputs in the declared order with the same unchanged-file check and atomic rename. Nothing about the bundling itself changed.

## How you verified

`sha256sum bundled-types/*.d.ts` is identical before and after for all 13 files, both on 16 cores and pinned to 4 CPUs. Wall time: 27.0 s → 10.6 s on 16 cores; 27 s → 17.8 s pinned to 4 CPUs standalone. Inside a 4-CPU emulation of the CI "Checks" job (`taskset -c 0-3 turbo run build typecheck lint --force --concurrency=4`, two rounds each) the job measured 118 s / 99 s serial vs 92 s / 103 s parallel — within run-to-run noise, so expect no CI regression and a clear local win. `pnpm exec turbo run test --filter=@get-bb/plugin-sdk --filter=@bb/templates --force` and `turbo run typecheck --filter=@bb/integration-tests --filter=@bb/host-daemon --force` pass against the new bundles.

No linked issue.

> AGENT GENERATED
