### PR TITLE
Run the CI Checks job at turbo concurrency 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,12 @@ jobs:
           pnpm-version: ${{ env.PNPM_VERSION }}
           cache-prefix: checks
 
+      # Four tasks for four vCPUs: TypeScript 7 and esbuild are multi-threaded,
+      # so turbo's default of ten concurrent tasks only adds contention here.
+      # Measured pinned to 4 CPUs, two rounds each: 96 s / 110 s at the
+      # default vs 90 s / 58 s at four.
       - name: Build, typecheck, and lint
-        run: pnpm exec turbo run build typecheck lint --cache-dir=.turbo/cache --output-logs=new-only
+        run: pnpm exec turbo run build typecheck lint --cache-dir=.turbo/cache --output-logs=new-only --concurrency=4
 
       # Runs after build and typecheck, so the guard's own turbo build is a
       # cache hit and the package it packs is the one this commit really ships.


### PR DESCRIPTION
## What was wrong

The CI "Checks" job (`turbo run build typecheck lint`) runs on a 4-vCPU runner with turbo's default concurrency of ten. TypeScript 7 and esbuild are multi-threaded, so ten concurrent tasks only fight for the four cores.

## What changed

The job passes `--concurrency=4`.

## How you verified

Emulated with `taskset -c 0-3 turbo run build typecheck lint --force`, two rounds each: 96 s and 110 s at the default vs 90 s and 58 s at four. Typecheck alone: 70 s at eight, 63 s at four, 61 s at two. Run-to-run noise is ±15 s, so treat this as a modest, consistent win rather than a precise figure.

No linked issue.

> AGENT GENERATED
