### PR TITLE
Scroll the desktop model picker as one region

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -478,7 +478,11 @@ describe("ModelReasoningPicker", () => {
     ).toBe("");
   });
 
-  it("keeps the desktop menu scrollable within the available viewport height", () => {
+  // A short viewport cuts the menu off below the model rows. The models and the
+  // reasoning rows must share one scroll region: when the model list is its own
+  // scroller, a wheel or touch gesture that starts over the models is captured
+  // by it, and the reasoning rows underneath stay unreachable.
+  it("scrolls the desktop models and reasoning rows as one region", () => {
     renderPicker({ modelOptions: manyCodexModels });
 
     fireEvent.click(
@@ -489,11 +493,22 @@ describe("ModelReasoningPicker", () => {
     expect(menu.className).toContain(
       "max-h-[var(--radix-popover-content-available-height)]",
     );
-    expect(menu.className).toContain("overflow-y-auto");
-    expect(menu.className).toContain("overscroll-contain");
-    expect(
-      screen.getByRole("listbox", { name: "Models" }).className,
-    ).toContain("shrink-0");
+
+    const scrollers = [
+      ...(menu.className.includes("overflow-y-auto") ? [menu] : []),
+      ...menu.querySelectorAll<HTMLElement>("[class*='overflow-y-auto']"),
+    ];
+    expect(scrollers).toHaveLength(1);
+
+    const body = scrollers[0];
+    expect(body.className).toContain("overscroll-contain");
+    expect(body.contains(screen.getByRole("listbox", { name: "Models" }))).toBe(
+      true,
+    );
+    expect(body.contains(screen.getByText("High"))).toBe(true);
+
+    const models = screen.getByRole("listbox", { name: "Models" });
+    expect(models.className).not.toContain("max-h-");
   });
 
   it("leaves compact drawer height and scrolling to the responsive shell", async () => {
@@ -508,7 +523,7 @@ describe("ModelReasoningPicker", () => {
     );
     expect(
       (await screen.findByRole("listbox", { name: "Models" })).className,
-    ).not.toContain("shrink-0");
+    ).not.toContain("max-h-");
   });
 
   it("commits a provider tab immediately and keeps its models selectable", async () => {

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -988,8 +988,10 @@ export function ModelReasoningPicker({
           "flex flex-col p-0",
           MODEL_PICKER_MENU_WIDTH_CLASS_NAME,
           "max-md:w-full max-md:min-w-0 max-md:max-w-none",
+          // The provider tabs and the search field stay pinned; the menu body
+          // below them owns the only scroll region (see MenuHoverProvider).
           !isCompactViewport &&
-            "max-h-[var(--radix-popover-content-available-height)] overflow-y-auto overscroll-contain",
+            "max-h-[var(--radix-popover-content-available-height)] overflow-hidden",
         )}
       >
         <ResetBrowseStateOnContentUnmount onReset={resetBrowseState} />
@@ -1000,7 +1002,7 @@ export function ModelReasoningPicker({
               "flex items-center gap-0.5 border-b border-border px-2.5 pt-1",
               isCompactViewport
                 ? "sticky top-0 z-10 bg-background"
-                : "bg-surface-recessed",
+                : "shrink-0 bg-surface-recessed",
             )}
           >
             {providerOptions.map((provider) => {
@@ -1057,182 +1059,194 @@ export function ModelReasoningPicker({
         ) : null}
 
         <MenuHoverProvider>
-          {/* Model list — keyed by the active provider so each provider mounts a
+          {/* Menu body — the single desktop scroll region. The model rows, the
+            reasoning rows and the footer controls scroll together, so one wheel
+            or touch gesture reaches every option. A second scroller on the model
+            list captured the gesture that started over the models and left the
+            rows below it unreachable in a short viewport. */}
+          <div
+            className={cn(
+              !isCompactViewport &&
+                "min-h-0 flex-1 overflow-y-auto overscroll-contain",
+            )}
+          >
+            {/* Model list — keyed by the active provider so each provider mounts a
             fresh subtree. Rows are keyed by model id, but reusing one subtree
             across provider switches was observed to leave the previous
             provider's rows on screen; remounting per provider guarantees the
             list always matches the active tab. */}
-          <div
-            key={activeProviderId || "no-provider"}
-            role={showSearchInput ? "listbox" : undefined}
-            id={showSearchInput ? listboxId : undefined}
-            aria-label={showSearchInput ? "Models" : undefined}
-            className={cn(
-              "overflow-y-auto px-1 pb-1 pt-0",
-              !isCompactViewport &&
-                // Preserve the model scroller's intended height when the outer
-                // menu is capped; otherwise this flex item collapses before the
-                // full desktop menu can scroll to the reasoning controls.
-                "shrink-0 max-h-[min(250px,var(--radix-popover-content-available-height,250px)-80px)]",
-            )}
-          >
-            {isShowingModelError ? null : (
-              <MenuSectionLabel>Model</MenuSectionLabel>
-            )}
-            {activeModelIsLoading ? (
-              <ModelPickerLoadingRows />
-            ) : hasActiveModelOptions ? (
-              <>
-                {navRows.map((row, index) => {
-                  const active = highlightedIndex === index;
-                  const domId = optionDomId(index);
-                  if (row.kind === "more-toggle") {
+            <div
+              key={activeProviderId || "no-provider"}
+              role={showSearchInput ? "listbox" : undefined}
+              id={showSearchInput ? listboxId : undefined}
+              aria-label={showSearchInput ? "Models" : undefined}
+              className={cn(
+                "px-1 pb-1 pt-0",
+                // Compact keeps its own block so the drawer's section labels stick
+                // exactly as before. Desktop shares the menu body's scroll region.
+                isCompactViewport && "overflow-y-auto",
+              )}
+            >
+              {isShowingModelError ? null : (
+                <MenuSectionLabel>Model</MenuSectionLabel>
+              )}
+              {activeModelIsLoading ? (
+                <ModelPickerLoadingRows />
+              ) : hasActiveModelOptions ? (
+                <>
+                  {navRows.map((row, index) => {
+                    const active = highlightedIndex === index;
+                    const domId = optionDomId(index);
+                    if (row.kind === "more-toggle") {
+                      return (
+                        <MoreModelsToggleRow
+                          key="more-toggle"
+                          id={domId}
+                          isActive={active}
+                          expanded={showMoreModels}
+                          onToggle={() =>
+                            setShowMoreModels((current) => !current)
+                          }
+                        />
+                      );
+                    }
+                    const option = row.option;
                     return (
-                      <MoreModelsToggleRow
-                        key="more-toggle"
+                      <MenuRowButton
+                        key={option.value}
                         id={domId}
+                        role={showSearchInput ? "option" : undefined}
                         isActive={active}
-                        expanded={showMoreModels}
-                        onToggle={() =>
-                          setShowMoreModels((current) => !current)
-                        }
+                        // The menu always reflects the provider whose models it
+                        // lists (committed or previewed) — strip with the
+                        // active provider's declared prefix.
+                        label={stripModelBrandPrefix(
+                          option.label,
+                          activeBrandPrefix,
+                        )}
+                        qualifier={option.routeProviderId}
+                        selected={!isPreviewing && option.value === modelValue}
+                        disabled={previewSelectionBlocked}
+                        onClick={() => handleModelSelect(option.value)}
                       />
                     );
-                  }
-                  const option = row.option;
-                  return (
-                    <MenuRowButton
-                      key={option.value}
-                      id={domId}
-                      role={showSearchInput ? "option" : undefined}
-                      isActive={active}
-                      // The menu always reflects the provider whose models it
-                      // lists (committed or previewed) — strip with the
-                      // active provider's declared prefix.
-                      label={stripModelBrandPrefix(
-                        option.label,
-                        activeBrandPrefix,
-                      )}
-                      qualifier={option.routeProviderId}
-                      selected={!isPreviewing && option.value === modelValue}
-                      disabled={previewSelectionBlocked}
-                      onClick={() => handleModelSelect(option.value)}
-                    />
-                  );
-                })}
-                {/* Desktop, not searching: the selected-only models live in a
+                  })}
+                  {/* Desktop, not searching: the selected-only models live in a
                     hover submenu that is excluded from keyboard nav. During a
                     search they are flattened into `navRows` above so every match
                     stays reachable from the keyboard. */}
-                {!isCompactViewport &&
-                !isSearching &&
-                filteredMoreModelOptions.length > 0 ? (
-                  <MoreModelsSubmenu
-                    open={moreModelsOpen}
-                    onOpenChange={setMoreModelsOpen}
-                    openSub={openSub}
-                    activeBrandPrefix={activeBrandPrefix}
-                    isPreviewing={isPreviewing}
-                    modelValue={modelValue}
-                    options={filteredMoreModelOptions}
-                    onSelect={handleModelSelect}
-                  />
-                ) : null}
-                {isSearching && navRows.length === 0 ? (
-                  <div
-                    className={cn(
-                      "px-2 text-xs text-muted-foreground",
-                      isCompactViewport ? "py-2" : "py-[0.3125rem]",
-                    )}
-                  >
-                    No models match your search
-                  </div>
-                ) : null}
-              </>
-            ) : (
-              <div
-                className={cn(
-                  "px-2 text-xs leading-relaxed text-muted-foreground",
-                  isCompactViewport ? "pb-3 pt-2" : "pb-2 pt-1.5",
-                )}
-                title={activeModelLoadErrorMessage ?? undefined}
-              >
-                {activeModelLoadErrorMatches && activeModelLoadError ? (
-                  <ModelLoadErrorMessage
-                    error={activeModelLoadError}
-                    providerLabel={activeProviderLabel}
-                    {...(activeProvider?.installUrl === undefined
-                      ? {}
-                      : { installUrl: activeProvider.installUrl })}
-                  />
-                ) : activeModelLoadFailed ? (
-                  activeModelFailureMessage
-                ) : (
-                  "No models available"
-                )}
-              </div>
-            )}
-          </div>
+                  {!isCompactViewport &&
+                  !isSearching &&
+                  filteredMoreModelOptions.length > 0 ? (
+                    <MoreModelsSubmenu
+                      open={moreModelsOpen}
+                      onOpenChange={setMoreModelsOpen}
+                      openSub={openSub}
+                      activeBrandPrefix={activeBrandPrefix}
+                      isPreviewing={isPreviewing}
+                      modelValue={modelValue}
+                      options={filteredMoreModelOptions}
+                      onSelect={handleModelSelect}
+                    />
+                  ) : null}
+                  {isSearching && navRows.length === 0 ? (
+                    <div
+                      className={cn(
+                        "px-2 text-xs text-muted-foreground",
+                        isCompactViewport ? "py-2" : "py-[0.3125rem]",
+                      )}
+                    >
+                      No models match your search
+                    </div>
+                  ) : null}
+                </>
+              ) : (
+                <div
+                  className={cn(
+                    "px-2 text-xs leading-relaxed text-muted-foreground",
+                    isCompactViewport ? "pb-3 pt-2" : "pb-2 pt-1.5",
+                  )}
+                  title={activeModelLoadErrorMessage ?? undefined}
+                >
+                  {activeModelLoadErrorMatches && activeModelLoadError ? (
+                    <ModelLoadErrorMessage
+                      error={activeModelLoadError}
+                      providerLabel={activeProviderLabel}
+                      {...(activeProvider?.installUrl === undefined
+                        ? {}
+                        : { installUrl: activeProvider.installUrl })}
+                    />
+                  ) : activeModelLoadFailed ? (
+                    activeModelFailureMessage
+                  ) : (
+                    "No models available"
+                  )}
+                </div>
+              )}
+            </div>
 
-          {/* Reasoning section — the committed model's levels, or (while
+            {/* Reasoning section — the committed model's levels, or (while
             previewing) the previewed provider's default-model levels. Like the
             model list, nothing is checked during preview until committed. */}
-          {showReasoningSection ? (
-            <>
-              <div className="border-t border-border" />
-              <div className="px-1 pb-1 pt-0">
-                <MenuSectionLabel>Reasoning</MenuSectionLabel>
-                {activeReasoningOptions.map((option) => (
-                  <MenuRowButton
-                    key={option.value}
-                    label={option.label}
-                    selected={!isPreviewing && option.value === reasoningValue}
-                    disabled={previewSelectionBlocked}
-                    onClick={() => handleReasoningSelect(option.value)}
-                  />
-                ))}
-              </div>
-            </>
-          ) : null}
-
-          {/* Fast mode toggle */}
-          {effectiveShowFastModeToggle ? (
-            <>
-              <div className="border-t border-border" />
-              <div className="p-1">
-                <div className="flex items-center justify-between gap-3 rounded-sm px-2 py-[0.3125rem] text-xs">
-                  <span className="flex min-w-0 items-center gap-2">
-                    <Icon
-                      name="Zap"
-                      className="size-4 fill-current text-muted-foreground"
+            {showReasoningSection ? (
+              <>
+                <div className="border-t border-border" />
+                <div className="px-1 pb-1 pt-0">
+                  <MenuSectionLabel>Reasoning</MenuSectionLabel>
+                  {activeReasoningOptions.map((option) => (
+                    <MenuRowButton
+                      key={option.value}
+                      label={option.label}
+                      selected={
+                        !isPreviewing && option.value === reasoningValue
+                      }
+                      disabled={previewSelectionBlocked}
+                      onClick={() => handleReasoningSelect(option.value)}
                     />
-                    <span>Fast mode</span>
-                  </span>
-                  <Switch
-                    checked={fastModeEnabled}
-                    onCheckedChange={onFastModeChange}
-                    aria-label="Fast mode"
-                    className={LIST_HOVER_TRANSITION}
+                  ))}
+                </div>
+              </>
+            ) : null}
+
+            {/* Fast mode toggle */}
+            {effectiveShowFastModeToggle ? (
+              <>
+                <div className="border-t border-border" />
+                <div className="p-1">
+                  <div className="flex items-center justify-between gap-3 rounded-sm px-2 py-[0.3125rem] text-xs">
+                    <span className="flex min-w-0 items-center gap-2">
+                      <Icon
+                        name="Zap"
+                        className="size-4 fill-current text-muted-foreground"
+                      />
+                      <span>Fast mode</span>
+                    </span>
+                    <Switch
+                      checked={fastModeEnabled}
+                      onCheckedChange={onFastModeChange}
+                      aria-label="Fast mode"
+                      className={LIST_HOVER_TRANSITION}
+                    />
+                  </div>
+                </div>
+              </>
+            ) : null}
+
+            {footerAction ? (
+              <>
+                <div className="border-t border-border" />
+                <div className="p-1">
+                  <MenuActionButton
+                    label={footerAction.label}
+                    iconName={footerAction.iconName ?? "MessageSquarePlus"}
+                    disabled={footerAction.disabled}
+                    title={footerAction.title}
+                    onClick={handleFooterActionClick}
                   />
                 </div>
-              </div>
-            </>
-          ) : null}
-
-          {footerAction ? (
-            <>
-              <div className="border-t border-border" />
-              <div className="p-1">
-                <MenuActionButton
-                  label={footerAction.label}
-                  iconName={footerAction.iconName ?? "MessageSquarePlus"}
-                  disabled={footerAction.disabled}
-                  title={footerAction.title}
-                  onClick={handleFooterActionClick}
-                />
-              </div>
-            </>
-          ) : null}
+              </>
+            ) : null}
+          </div>
         </MenuHoverProvider>
       </PopoverContent>
     </Popover>


### PR DESCRIPTION
## What was wrong

The desktop model menu held two scroll regions. The popover capped itself at the Radix available height and scrolled, while the model list kept its own `shrink-0 max-h-[min(250px, available - 80px)]` scroller inside it (added in #1596). The 80px constant does not cover the real chrome: the provider tabs (33px), the search field (37px), the reasoning rows (189px), the fast-mode toggle (34px) and the dividers add up to ~295px. So in a short viewport the model list held its full height, the reasoning rows sat below the fold, and the wheel or touch gesture that started over the models was captured by the inner scroller instead of the popover. A user reported that the reasoning options at the bottom were unreachable after zooming in.

Measured on `main` at a 1000x520 viewport: the popover was 341px tall with 536px of content, and the reasoning section ended at y=681 — 161px below the viewport.

## What changed

`apps/app/src/components/pickers/ModelReasoningPicker.tsx` gives the desktop menu a single scroll region.

- The popover is now `overflow-hidden` and pins the provider tabs and the search field (`shrink-0`).
- A new body element under `MenuHoverProvider` owns `min-h-0 flex-1 overflow-y-auto overscroll-contain`, so the model rows, the reasoning rows, the fast-mode toggle and the footer action scroll together.
- The model list drops its desktop cap and its own scroller. Its sticky "Model" and "Reasoning" section labels now stick to the shared region.
- The compact drawer path keeps its previous markup, so mobile behavior is unchanged.

Trade-off: on a tall viewport with a very long list (for example during a search), the reasoning rows are no longer pinned below a 250px model scroller. One predictable scroll region is worth more than a pin that only held while the menu fit anyway.

No wire or CLI surface changed.

## How you verified

Browser checks through the doobie CLI against the dev app, Codex provider (8 models, 6 reasoning levels):

| Viewport | Before | After |
| --- | --- | --- |
| 1000x520 | 1 overflowing scroll region, but the reasoning section ended 161px below the fold and the provider tabs and search field scrolled away with the rows | 1 scroll region; tabs and search stay pinned and one wheel gesture reveals every reasoning row and Fast mode |
| 1000x400 | 2 nested scroll regions (popover 436/219, model list 241/141); the gesture over the models was consumed by the inner list before the popover moved, and the whole reasoning section started off-screen | 1 scroll region; clicking "Ultra" commits the level (the trigger reads `5.6-Sol Ultra`) |
| 1000x900 | no scroller | no scroller, menu unchanged |
| 500x800 (compact) | drawer | drawer unchanged |

Also confirmed the search field stays pinned during a search and that arrow-key navigation still scrolls the highlighted row into view at 1000x400.

Tests: replaced the picker's desktop scroll test with `scrolls the desktop models and reasoning rows as one region`, which asserts exactly one scroll region and that it contains both the models listbox and the reasoning rows. It fails on the previous code (`expected [ …(2) ] to have a length of 1 but got 2`) and passes now.

Commands:

- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run lint --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app` (422 files, 3288 tests passed)
- `pnpm exec turbo run build --filter=@bb/app`

Reported by a user over DM; no GitHub issue was open for it.

> AGENT GENERATED
