### PR TITLE
Stop update checks from replacing a downloaded update before Relaunch installs it

### DIFF
--- a/apps/desktop/src/desktop-auto-update.ts
+++ b/apps/desktop/src/desktop-auto-update.ts
@@ -306,6 +306,14 @@ export function createDesktopAutoUpdateService(
     if (!args.enabled) {
       return currentInfo;
     }
+    // A downloaded update is a staged ShipIt install. Re-checking tears that
+    // staging down (Squirrel replaces update.<id> with a fresh partial
+    // extraction), so a Relaunch issued afterwards installs a directory
+    // without the app bundle and ShipIt aborts three times, leaving the user
+    // on the old version. Hold the staged install until it is applied.
+    if (currentInfo.updateDownloaded) {
+      return currentInfo;
+    }
     if (inflight !== null) {
       return inflight;
     }

--- a/apps/desktop/src/desktop-update-check.ts
+++ b/apps/desktop/src/desktop-update-check.ts
@@ -8,7 +8,7 @@ import {
 } from "@bb/desktop-contract";
 
 export { createDesktopUpdateFeedUrl } from "./desktop-update-provider.js";
-export const DESKTOP_UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+export const DESKTOP_UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
 export const DESKTOP_UPDATE_CHECK_TIMEOUT_MS = 5_000;
 export const DESKTOP_UPDATE_ACTIVE_MIN_INTERVAL_MS = 15 * 60 * 1000;
 

--- a/apps/desktop/src/desktop-update-check.ts
+++ b/apps/desktop/src/desktop-update-check.ts
@@ -8,7 +8,7 @@ import {
 } from "@bb/desktop-contract";
 
 export { createDesktopUpdateFeedUrl } from "./desktop-update-provider.js";
-export const DESKTOP_UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+export const DESKTOP_UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
 export const DESKTOP_UPDATE_CHECK_TIMEOUT_MS = 5_000;
 export const DESKTOP_UPDATE_ACTIVE_MIN_INTERVAL_MS = 15 * 60 * 1000;
 

--- a/apps/desktop/test/desktop-auto-update.test.ts
+++ b/apps/desktop/test/desktop-auto-update.test.ts
@@ -367,6 +367,44 @@ describe("desktop auto-update service", () => {
     });
   });
 
+  it("holds a downloaded update by skipping re-checks that would tear down its staging", async () => {
+    const updater = new DesktopAutoUpdaterAdapterStub();
+    updater.updateCheckResult = createUpdateCheckResult("0.0.2");
+    let currentTime = Date.parse(checkedAt);
+    const service = createDesktopAutoUpdateService({
+      currentVersion: "0.0.1",
+      enabled: true,
+      forceDevUpdateConfig: false,
+      logger: createLogger(createLoggerMessages()),
+      now: () => currentTime,
+      platform: "macos",
+      updater,
+    });
+
+    await service.checkForUpdates();
+    expect(updater.checkForUpdatesCalls).toBe(1);
+
+    updater.emitUpdateDownloaded(createDownloadedEvent("0.0.2"));
+    await service.checkForUpdates();
+    // Advance past the active-check throttle so this reaches checkForUpdates.
+    currentTime += 16 * 60 * 1000;
+    await service.checkAfterActive();
+
+    // The staged ShipIt install stays untouched: no further checks run and
+    // the info keeps reporting the downloaded update.
+    expect(updater.checkForUpdatesCalls).toBe(1);
+    expect(service.getInfo()).toEqual({
+      downloadState: "downloaded",
+      lastCheckedAt: checkedAt,
+      latestVersion: "0.0.2",
+      pendingVersion: "0.0.2",
+      platform: "macos",
+      updateAvailable: true,
+      updateDownloaded: true,
+      version: "0.0.1",
+    });
+  });
+
   it("does not initialize electron-updater in dev mode without the override", async () => {
     const updater = new DesktopAutoUpdaterAdapterStub();
     const enabled = shouldEnableDesktopAutoUpdate({


### PR DESCRIPTION
## What was wrong

On macOS, every desktop update check made Squirrel.Mac discard its finished `update.<id>` staging directory and start a fresh, partial extraction for the next fetch — while the Settings UI kept offering Relaunch. The check paths were: the unthrottled check on every Settings → Updates page visit (`BB_DESKTOP_CHECK_FOR_UPDATES_CHANNEL`), the 15-minute activity check, and the hourly timer. A Relaunch clicked after any of these re-checks handed ShipIt install instructions pointing at a directory that did not yet contain `bb Nightly.app`. ShipIt retried three times, logged `Failed to copy bundle … No such file or directory`, aborted the update, and relaunched the old build. Net effect: nightly updates downloaded forever and never applied.

Observed live on an affected machine: the app quit cleanly on Relaunch (owned-runtime children stopped, main process exited), then ShipIt immediately failed three times against the newest staging dir while an older, complete staging had been discarded minutes earlier.

## What changed

- `apps/desktop/src/desktop-auto-update.ts`: once electron-updater reports the update downloaded, `checkForUpdates()` and therefore `checkAfterActive()` return the held state instead of hitting the updater, so nothing restages or invalidates the pending ShipIt install until it is applied.
- `apps/desktop/test/desktop-auto-update.test.ts`: regression test asserting no further updater checks run while an update is downloaded (including after the activity-check throttle window passes) and the downloaded state is preserved.

No wire-format changes; no HOST_DAEMON_PROTOCOL_VERSION bump needed.

## How you verified

- New test fails without the guard (checks keep incrementing and state gets restaged) and passes with it.
- `pnpm exec turbo run test --filter=@bb/desktop --force` — all 4 tasks green.
- `pnpm exec turbo run typecheck --filter=@bb/desktop --force` — green.
- Manual QA on the affected machine: confirmed via ShipIt stderr log that the failure mode matched the diagnosis (`Installation error: … Failed to copy bundle … No such file or directory`, ×3, abort); with a complete staging left undisturbed and the app quit normally, ShipIt logged `Installation completed successfully` and the app came up on the new version.

> AGENT GENERATED