### PR TITLE
Fix packaged ACP provider logos

### DIFF
--- a/apps/server/scripts/copy-builtin-plugins.ts
+++ b/apps/server/scripts/copy-builtin-plugins.ts
@@ -140,11 +140,24 @@ async function copyBuiltinPlugin(args: {
       await readFile(path.join(args.sourceRoot, "package.json"), "utf8"),
     ),
   );
+  // Every asset the manifest declares ships; an asset a plugin names only in
+  // code (a `./icons/x.svg` provider icon in a declaration) is invisible
+  // here and is absent from the packaged plugin. A builtin provider declares
+  // its logos under `bb.branding.experimental_icons` and references them by
+  // namespaced glyph for that reason.
   const logo = packageJson.bb.branding.logo;
   const compactIcon = isPluginOwnedIconPath(packageJson.bb.branding.icon ?? "")
     ? packageJson.bb.branding.icon
     : undefined;
-  for (const asset of [compactIcon, logo?.light, logo?.dark]) {
+  const declaredIcons = Object.values(
+    packageJson.bb.branding.experimental_icons ?? {},
+  );
+  for (const asset of [
+    compactIcon,
+    logo?.light,
+    logo?.dark,
+    ...declaredIcons,
+  ]) {
     if (asset === undefined) continue;
     const sourcePath = path.resolve(args.sourceRoot, asset);
     const targetPath = path.resolve(targetDir, asset);

--- a/apps/server/test/helpers/provider-registry.ts
+++ b/apps/server/test/helpers/provider-registry.ts
@@ -27,6 +27,8 @@ import {
   EMPTY_PROVIDER_NATIVE_ROOTS,
   EMPTY_PROVIDER_RESOLVED_NATIVE_ROOTS,
   type JsonValue,
+  parseNamespacedGlyph,
+  pluginPackageJsonSchema,
   type ProviderInfo,
   type ProviderNativeRootSet,
 } from "@bb/domain";
@@ -76,6 +78,48 @@ export async function loadFirstPartyProviderDeclarations(): Promise<
 const NO_PLUGIN_SETTINGS = (): Readonly<Record<string, never>> => ({});
 
 /**
+ * The declared icons of a first-party plugin (`bb.branding.experimental_icons`),
+ * name → plugin-relative path. The plugin runtime resolves a provider icon in
+ * the namespaced form (`"<pluginId>/<name>"`) against the branding snapshots
+ * it took at load; a harness that reads only the path form would register
+ * those providers with no icon bytes, and the logo route would answer 404 for
+ * a provider that has a logo in production.
+ */
+async function declaredIcons(pluginId: string): Promise<Map<string, string>> {
+  const manifest = pluginPackageJsonSchema.parse(
+    JSON.parse(
+      await readFile(
+        join(firstPartyPluginRootDir(pluginId), "package.json"),
+        "utf8",
+      ),
+    ),
+  );
+  return new Map(Object.entries(manifest.bb.branding.experimental_icons ?? {}));
+}
+
+/**
+ * The icon byte snapshot the plugin runtime captures at registration, for
+ * either declared form: a plugin-relative path, or one of the plugin's own
+ * declared icons by its namespaced glyph. The provider-logo route serves
+ * exactly these bytes.
+ */
+function providerIconSnapshot(args: {
+  pluginId: string;
+  icon: string | undefined;
+  icons: ReadonlyMap<string, string>;
+}): { bytes: Uint8Array; contentType: string } | null {
+  const namespaced =
+    args.icon === undefined ? null : parseNamespacedGlyph(args.icon);
+  const asset =
+    namespaced === null
+      ? args.icon
+      : namespaced.pluginId === args.pluginId
+        ? args.icons.get(namespaced.name)
+        : undefined;
+  return readPluginProviderIcon(firstPartyPluginRootDir(args.pluginId), asset);
+}
+
+/**
  * Registers the first-party providers into an existing registry, exactly as
  * their four plugins would. `excludePluginIds` models a plugin the user disabled
  * (or that failed to load), whose provider is then absent from the registry.
@@ -103,6 +147,7 @@ export async function registerFirstPartyProviders(
       continue;
     }
     const declarations = await captureFirstPartyProviderDeclarations(pluginId);
+    const icons = await declaredIcons(pluginId);
     // The artifact lands before the registration flushes, as the plugin
     // runtime records it before the load commits: a picker request that
     // wakes on the registration must find the bridge already there.
@@ -114,12 +159,11 @@ export async function registerFirstPartyProviders(
       options.artifacts.set(pluginId, stubHostArtifact(pluginId));
     }
     for (const declaration of declarations) {
-      // The icon byte snapshot the plugin runtime captures at registration;
-      // the provider-logo route serves exactly these bytes.
-      const icon = readPluginProviderIcon(
-        firstPartyPluginRootDir(pluginId),
-        declaration.icon,
-      );
+      const icon = providerIconSnapshot({
+        pluginId,
+        icon: declaration.icon,
+        icons,
+      });
       registry.register({
         ...buildPluginProviderRegistration({
           available: !unavailable.has(pluginId),
@@ -129,7 +173,7 @@ export async function registerFirstPartyProviders(
         }),
         ...(icon === null ? {} : { icon }),
         pluginId,
-        iconNames: new Set<string>(),
+        iconNames: new Set(icons.keys()),
         // The bundled order: codex, claude-code, pi, acp — the same install
         // rank the plugin runtime assigns from the bundled plugin list.
         installRank: {

--- a/apps/server/test/services/plugins/builtin-plugins.test.ts
+++ b/apps/server/test/services/plugins/builtin-plugins.test.ts
@@ -67,6 +67,9 @@ async function writePackagedBuiltinSource(workDir: string): Promise<{
   for (const name of BUILTIN_PLUGIN_NAMES) {
     const sourceRoot = join(sourceModuleDir, "builtin-plugins", name);
     const usesPluginOwnedIcon = name === "automations";
+    // Declared icons (`bb.branding.experimental_icons`) are manifest assets
+    // too: a provider logo named through them must reach the packaged root.
+    const usesDeclaredIcons = name === "provider-acp";
     await mkdir(join(sourceRoot, "dist"), { recursive: true });
     await mkdir(join(sourceRoot, "skills", name), { recursive: true });
     await mkdir(join(sourceRoot, "src"), { recursive: true });
@@ -80,9 +83,14 @@ async function writePackagedBuiltinSource(workDir: string): Promise<{
           bb: {
             name,
             description: `${name} builtin plugin fixture.`,
-            branding: usesPluginOwnedIcon
-              ? { icon: "./assets/icon.svg" }
-              : { icon: "Zap" },
+            branding: {
+              ...(usesPluginOwnedIcon
+                ? { icon: "./assets/icon.svg" }
+                : { icon: "Zap" }),
+              ...(usesDeclaredIcons
+                ? { experimental_icons: { cursor: "./icons/cursor.svg" } }
+                : {}),
+            },
             server: "./src/server.ts",
             app: "./app.tsx",
             skills: ["skills"],
@@ -103,6 +111,10 @@ async function writePackagedBuiltinSource(workDir: string): Promise<{
     if (usesPluginOwnedIcon) {
       await mkdir(join(sourceRoot, "assets"), { recursive: true });
       await writeFile(join(sourceRoot, "assets", "icon.svg"), "<svg/>\n");
+    }
+    if (usesDeclaredIcons) {
+      await mkdir(join(sourceRoot, "icons"), { recursive: true });
+      await writeFile(join(sourceRoot, "icons", "cursor.svg"), "<svg/>\n");
     }
     await writeFile(
       join(sourceRoot, "dist", "server.js"),
@@ -149,7 +161,7 @@ function createService(args: {
   watchBuiltinPluginSources?: boolean;
 }): PluginService {
   return createPluginService({
-      aiServices: createAiServiceRegistry(),
+    aiServices: createAiServiceRegistry(),
     telemetry: createNoopTelemetryService(),
     db: args.db,
     hub: {
@@ -990,6 +1002,11 @@ describe("builtin plugin packaging", () => {
     await expect(stat(join(copiedRoot, "src"))).rejects.toThrow();
     await expect(stat(join(copiedRoot, "app.tsx"))).rejects.toThrow();
     await expect(stat(join(copiedRoot, "node_modules"))).rejects.toThrow();
+
+    // A declared icon ships with the manifest that names it.
+    await expect(
+      readFile(join(targetRoot, "provider-acp", "icons", "cursor.svg"), "utf8"),
+    ).resolves.toBe("<svg/>\n");
 
     const connectRoot = join(targetRoot, "connect");
     await expect(stat(join(connectRoot, "package.json"))).resolves.toBeTruthy();

--- a/apps/server/test/services/plugins/first-party-provider-plugins.test.ts
+++ b/apps/server/test/services/plugins/first-party-provider-plugins.test.ts
@@ -183,6 +183,10 @@ describe("first-party provider plugins", () => {
           expect(registration.info.logoUrl, label).toBe(
             plugin.hasLogo ? expectedLogoUrl(plugin.providerId) : null,
           );
+          // The URL alone proves nothing: the route serves the byte snapshot
+          // taken at registration, and a declared icon whose file is absent
+          // leaves the snapshot empty behind a well-formed URL.
+          expect(registration.icon !== undefined, label).toBe(plugin.hasLogo);
           expect(registration.visibility, label).toBe(plugin.visibility);
           // The facts the takeover merge used to carry over from the seed.
           expect(

--- a/packages/agent-runtime/src/test/first-party-provider-declarations.ts
+++ b/packages/agent-runtime/src/test/first-party-provider-declarations.ts
@@ -10,7 +10,10 @@
  * runtime, which also imports them as untyped modules and validates what
  * comes back (the fake host runs the same validator on every registration).
  */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { pluginPackageJsonSchema } from "@bb/domain";
 import type { PluginSettingValue } from "@get-bb/plugin-sdk";
 import type { NormalizedPluginProviderDeclaration } from "@get-bb/plugin-sdk/internal/host-policy";
 import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
@@ -24,6 +27,26 @@ export function firstPartyPluginRootDir(pluginId: string): string {
   return fileURLToPath(
     new URL(`../../../../plugins/${pluginId}`, import.meta.url),
   );
+}
+
+/**
+ * The icon names the plugin's manifest declares
+ * (`bb.branding.experimental_icons`). A provider whose declaration names one
+ * of them as a namespaced glyph (`"<pluginId>/<name>"`) registers only when
+ * the host knows the name, so the capture reads the same manifest the plugin
+ * runtime reads; without it every such registration is refused and the
+ * plugin looks like it declared nothing.
+ */
+async function declaredIconNames(pluginId: string): Promise<string[]> {
+  const manifest = pluginPackageJsonSchema.parse(
+    JSON.parse(
+      await readFile(
+        path.join(firstPartyPluginRootDir(pluginId), "package.json"),
+        "utf8",
+      ),
+    ),
+  );
+  return Object.keys(manifest.bb.branding.experimental_icons ?? {});
 }
 
 export interface CaptureFirstPartyProviderDeclarationsOptions {
@@ -64,6 +87,7 @@ export async function captureFirstPartyProviderDeclarations(
     // server's data dir. Point it at a directory that holds no config.json
     // so the machine running the tests cannot add an agent to them.
     dataDir: firstPartyPluginRootDir("__no-such-data-dir__"),
+    experimental_declaredIconNames: await declaredIconNames(pluginId),
     ...(options.settings === undefined ? {} : { settings: options.settings }),
   });
   try {

--- a/plugins/provider-acp/README.md
+++ b/plugins/provider-acp/README.md
@@ -35,7 +35,8 @@ What lives here:
   bridge, re-exported, and a host entry whose one RPC asks an agent what it
   supports on the machine it is installed on (`src/contract.ts`,
   `src/probe-capabilities.ts`).
-- `icons/` — the provider logos.
+- `icons/` — the provider logos, declared in `package.json` under
+  `bb.branding.experimental_icons` so the packaged build ships them.
 
 The kit itself, including the ACP wire schema, the delta translation, the
 per-agent dialects and the bridge process, is `packages/provider-bridge-acp`.

--- a/plugins/provider-acp/package.json
+++ b/plugins/provider-acp/package.json
@@ -11,7 +11,14 @@
     "name": "ACP providers",
     "description": "Run bb threads with ACP agents (supports Cursor, opencode, omp and more).",
     "branding": {
-      "icon": "./icons/acp.svg"
+      "icon": "./icons/acp.svg",
+      "experimental_icons": {
+        "cursor": "./icons/cursor.svg",
+        "opencode": "./icons/opencode.svg",
+        "omp": "./icons/omp.svg",
+        "grok": "./icons/grok.svg",
+        "hermes-agent": "./icons/hermes-agent.svg"
+      }
     },
     "server": "./server.ts",
     "host": "./src/host.ts"

--- a/plugins/provider-acp/server.test.ts
+++ b/plugins/provider-acp/server.test.ts
@@ -6,14 +6,39 @@
  */
 
 import { getEventListeners } from "node:events";
+import { readFileSync } from "node:fs";
 import { describe, expect, it, vi } from "vitest";
 import { experimental_acpAgentProbeSchema } from "@get-bb/plugin-sdk/provider-bridge/acp";
 import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
+import { z } from "zod";
 import { acpHostContract } from "./src/contract.js";
+import { KNOWN_ACP_AGENTS } from "./src/known-agents.js";
 import acpProvidersPlugin from "./server.js";
 
 /** A data dir with no config.json, so the deprecated array is never read. */
 const NO_LEGACY_CONFIG = "/tmp/bb-acp-plugin-test-no-config";
+
+const PLUGIN_ID = "provider-acp";
+
+/**
+ * The icon names the manifest declares (`bb.branding.experimental_icons`):
+ * what production lets a provider `icon` name as `"provider-acp/<name>"`.
+ */
+const DECLARED_ICON_NAMES = Object.keys(
+  z
+    .object({
+      bb: z.object({
+        branding: z.object({
+          experimental_icons: z.record(z.string(), z.string()),
+        }),
+      }),
+    })
+    .parse(
+      JSON.parse(
+        readFileSync(new URL("./package.json", import.meta.url), "utf8"),
+      ),
+    ).bb.branding.experimental_icons,
+);
 
 function customAgents(...agents: unknown[]): string {
   return JSON.stringify(agents);
@@ -42,8 +67,9 @@ async function loadPlugin(options: {
   hosts?: { id: string; status: string }[];
 }) {
   const host = createFakePluginHost({
-    pluginId: "provider-acp",
+    pluginId: PLUGIN_ID,
     dataDir: NO_LEGACY_CONFIG,
+    experimental_declaredIconNames: DECLARED_ICON_NAMES,
     ...(options.customAgents === undefined
       ? {}
       : { settings: { customAgents: options.customAgents } }),
@@ -157,8 +183,9 @@ describe("the ACP plugin's registration bookkeeping", () => {
   // the picker empty.
   it("registers the shipped agents before the factory's first await", async () => {
     const host = createFakePluginHost({
-      pluginId: "provider-acp",
+      pluginId: PLUGIN_ID,
       dataDir: NO_LEGACY_CONFIG,
+      experimental_declaredIconNames: DECLARED_ICON_NAMES,
     });
     host.harness.sdk.stub("hosts.list", () => Promise.resolve([]));
 
@@ -211,9 +238,7 @@ describe("the ACP plugin's registration bookkeeping", () => {
         command: "amp",
       }),
     });
-    await vi.waitFor(() =>
-      expect(registeredIds(host)).toContain("acp-amp"),
-    );
+    await vi.waitFor(() => expect(registeredIds(host)).toContain("acp-amp"));
 
     // Identity, not equality: a dispose-and-re-register would put a NEW
     // object here even though the declaration is unchanged.
@@ -247,17 +272,15 @@ describe("the ACP plugin's registration bookkeeping", () => {
           displayName: "Amp",
           command: "amp",
         }),
-        }),
+      }),
     ]);
 
-    await vi.waitFor(() =>
-      expect(registeredIds(host)).toContain("acp-amp"),
-    );
+    await vi.waitFor(() => expect(registeredIds(host)).toContain("acp-amp"));
     // Exactly one registration for the id, and the untouched agents were
     // never re-registered.
-    expect(
-      registeredIds(host).filter((id) => id === "acp-amp"),
-    ).toHaveLength(1);
+    expect(registeredIds(host).filter((id) => id === "acp-amp")).toHaveLength(
+      1,
+    );
     expect(
       host.harness.registrations.providerRegistrations.find(
         (declaration) => declaration.id === "acp-cursor",
@@ -373,9 +396,7 @@ describe("the ACP plugin's capability probe", () => {
       for (let poll = 0; poll < 5; poll += 1) {
         await vi.advanceTimersByTimeAsync(5_000);
       }
-      expect(
-        host.harness.sdk.callsTo("hosts.list").length,
-      ).toBeGreaterThan(2);
+      expect(host.harness.sdk.callsTo("hosts.list").length).toBeGreaterThan(2);
       expect(getEventListeners(signal, "abort").length).toBeLessThanOrEqual(1);
     } finally {
       vi.useRealTimers();
@@ -430,5 +451,25 @@ describe("the ACP plugin's capability probe", () => {
     await run.done;
 
     expect(probed).toEqual([]);
+  });
+});
+
+describe("known agent logos", () => {
+  // The packaged build ships only the assets the manifest declares. A
+  // `./icons/x.svg` path named only in a declaration is absent from the
+  // installed plugin, the provider registers without a logo, and the model
+  // picker draws nothing where the agent's mark belongs. The fake host
+  // refuses an undeclared namespaced glyph like production does; this guards
+  // the path form, which both accept.
+  it("declares every agent logo in the manifest", () => {
+    for (const agent of KNOWN_ACP_AGENTS) {
+      if (agent.icon === undefined) continue;
+      expect(agent.icon, agent.id).toMatch(
+        new RegExp(`^${PLUGIN_ID}/[a-z0-9][a-z0-9-]*$`, "u"),
+      );
+      expect(DECLARED_ICON_NAMES, `${agent.id} icon ${agent.icon}`).toContain(
+        agent.icon.slice(PLUGIN_ID.length + 1),
+      );
+    }
   });
 });

--- a/plugins/provider-acp/src/known-agents.ts
+++ b/plugins/provider-acp/src/known-agents.ts
@@ -14,6 +14,23 @@ import { resolveOmpNativeRoots } from "./native-roots/omp.js";
 import { resolveOpenCodeNativeRoots } from "./native-roots/opencode.js";
 
 /**
+ * The plugin id bb installs this plugin under; the namespace of its declared
+ * icons.
+ */
+const PLUGIN_ID = "provider-acp";
+
+/**
+ * An agent logo as the namespaced glyph of an icon this plugin's manifest
+ * declares (`bb.branding.experimental_icons`). Not a `./icons/x.svg` path:
+ * the packaged build ships only the assets the manifest declares, so a path
+ * named only here would be missing from the installed plugin and the
+ * provider would register without a logo.
+ */
+function declaredIcon(name: string): string {
+  return `${PLUGIN_ID}/${name}`;
+}
+
+/**
  * A Claude plugin installed inside a `.claude/skills` directory is not a
  * skill of the agent reading that tree; the marker tells the daemon to skip
  * it (the claude-code plugin lists such plugins through their own roots).
@@ -56,7 +73,7 @@ export const KNOWN_ACP_AGENTS: readonly AcpAgentDefinition[] = [
   {
     id: "acp-cursor",
     displayName: "Cursor",
-    icon: "./icons/cursor.svg",
+    icon: declaredIcon("cursor"),
     iconTint: { light: "#111827", dark: "#F5F5F5" },
     signInCommand: "cursor-agent login",
     installUrl: "https://cursor.com/docs/cli/installation",
@@ -103,7 +120,7 @@ export const KNOWN_ACP_AGENTS: readonly AcpAgentDefinition[] = [
   {
     id: "acp-opencode",
     displayName: "opencode",
-    icon: "./icons/opencode.svg",
+    icon: declaredIcon("opencode"),
     iconTint: { light: "#2563EB", dark: "#2563EB" },
     signInCommand: "opencode auth login",
     installUrl: "https://opencode.ai/docs",
@@ -135,7 +152,7 @@ export const KNOWN_ACP_AGENTS: readonly AcpAgentDefinition[] = [
   {
     id: "acp-omp",
     displayName: "omp",
-    icon: "./icons/omp.svg",
+    icon: declaredIcon("omp"),
     iconTint: { light: "#9333EA", dark: "#9333EA" },
     signInCommand: "omp login",
     installUrl: "https://github.com/can1357/omp",
@@ -174,7 +191,7 @@ export const KNOWN_ACP_AGENTS: readonly AcpAgentDefinition[] = [
   {
     id: "acp-grok",
     displayName: "Grok Build",
-    icon: "./icons/grok.svg",
+    icon: declaredIcon("grok"),
     signInCommand: "grok login",
     installUrl: "https://docs.x.ai/docs/grok-build",
     visibility: "installed",
@@ -225,7 +242,7 @@ export const KNOWN_ACP_AGENTS: readonly AcpAgentDefinition[] = [
   {
     id: "acp-hermes-agent",
     displayName: "Hermes Agent",
-    icon: "./icons/hermes-agent.svg",
+    icon: declaredIcon("hermes-agent"),
     signInCommand: "hermes login",
     installUrl: "https://hermes-agent.nousresearch.com",
     visibility: "installed",


### PR DESCRIPTION
## What was wrong

The built-in plugin copy step shipped only branding assets declared as the plugin icon or logo. ACP provider declarations referenced agent logos through source-relative paths. Those files existed in the source checkout but not in the packaged plugin, so the model picker received a provider logo URL without stored icon bytes.

## What changed

The ACP plugin now declares each shipped provider logo under `bb.branding.experimental_icons` and references those icons by namespaced glyph. The built-in plugin copy step now includes all declared icons. The provider test helpers now load the same manifest declarations as the production plugin runtime.

Regression tests verify that packaged built-in plugins contain declared icons, each known ACP logo has a manifest declaration, and provider registrations contain icon bytes.

This change does not alter the host daemon protocol, CLI, or user configuration.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime --filter=@bb/server --filter=bb-plugin-provider-acp --continue`
- `pnpm exec turbo run test --filter=@bb/server --force` — 2,002 tests passed.
- `pnpm exec turbo run test --filter=@bb/agent-runtime --filter=bb-plugin-provider-acp --force` — 392 tests passed.
- `pnpm exec oxfmt --check <changed files>`
- The live agent-runtime integration lane completed with 48 passes and 16 unrelated Claude provider timeouts.

Fixes: no issue.

> AGENT GENERATED
