### PR TITLE
Sync a Tasks project across bb instances through git

### DIFF
--- a/GAP.md
+++ b/GAP.md
@@ -1,0 +1,30 @@
+# gap-bb
+
+Private fork of [get-bb/bb](https://github.com/get-bb/bb). Product name in this checkout: **gap-bb**.
+
+## Remotes
+
+| Remote | URL | Role |
+| --- | --- | --- |
+| `origin` | `https://github.com/kr3t3n/gap-bb.git` | Private gap-bb |
+| `upstream` | `https://github.com/get-bb/bb.git` | Public bb |
+
+Keep package and CLI names as `bb` / `bb-app` so upstream merges stay clean. Brand as gap-bb in docs and companion apps only until a deliberate rename.
+
+## Sync from upstream
+
+```bash
+git fetch upstream
+git merge upstream/main
+# or: git rebase upstream/main
+git push origin main
+```
+
+## Companion iOS app
+
+See [kr3t3n/gap-bb-ios](https://github.com/kr3t3n/gap-bb-ios) — Expo client against this server's HTTP API and bb connect.
+
+## Local layout
+
+- Checkout: `~/Developer/gap-bb`
+- iOS app: `~/Developer/gap-bb-ios`

--- a/GAP.md
+++ b/GAP.md
@@ -1,13 +1,13 @@
 # gap-bb
 
-Private fork of [get-bb/bb](https://github.com/get-bb/bb). Product name in this checkout: **gap-bb**.
+Public GitHub fork of [get-bb/bb](https://github.com/get-bb/bb). Product name in this checkout: **gap-bb**.
 
 ## Remotes
 
 | Remote | URL | Role |
 | --- | --- | --- |
-| `origin` | `https://github.com/kr3t3n/gap-bb.git` | Private gap-bb |
-| `upstream` | `https://github.com/get-bb/bb.git` | Public bb |
+| `origin` | `https://github.com/kr3t3n/gap-bb.git` | Public fork (`kr3t3n/gap-bb`) |
+| `upstream` | `https://github.com/get-bb/bb.git` | Upstream bb |
 
 Keep package and CLI names as `bb` / `bb-app` so upstream merges stay clean. Brand as gap-bb in docs and companion apps only until a deliberate rename.
 

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -559,6 +559,12 @@ add <key-or-comment-id> --file <path>` (task key = task-level; comment ID
   opaque `--cursor` returned as `nextCursor` in JSON (or printed after a human
   page). Keep the same filters and sort. A task-list mutation makes the cursor
   stale; restart without it.
+- Converge a project across bb instances with `bb tasks sync export|import|check`.
+  Git is the transport: export where the work happened, commit the store, pull
+  it elsewhere, import there. `import` is a dry run until `--apply` and is
+  idempotent; `check` exits 2 on drift, so schedule it rather than reading it.
+  Configure the path with `bb tasks project update <prefix> --sync-store
+  <path>`, and add `--sync-role mirror` for an instance that imports only.
 
 ## Docs
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -838,6 +838,29 @@ database, host-managed settings/storage/schedules, secrets, and registration.
 A failed activation restores that snapshot and records the latest failure on
 the plugin so it can be surfaced as needing attention.
 
+### Tasks plugin cross-instance sync
+
+The Tasks plugin stores tasks in each instance's own database, and nothing
+syncs them. `bb tasks sync` converges two instances through a tracked file in
+a git repository: export on the instance where the work happened, commit, pull
+elsewhere, import there. Two per-project knobs configure it:
+
+| Knob            |  Default | Behavior                                                                                        |
+| --------------- | -------: | ----------------------------------------------------------------------------------------------- |
+| `--sync-store`  |   unset  | Path to the project's store file. A relative path resolves against the invoking directory.       |
+| `--sync-role`   | `source` | `mirror` marks an instance that imports only, for a host that cannot push the record back.       |
+
+Set them on `bb tasks project create` or `bb tasks project update`, and clear
+the path with `--no-sync-store`:
+
+```bash
+bb tasks project update AGT --sync-store record/agt.json --sync-role mirror
+```
+
+`bb tasks sync check` exits `2` when it finds drift, so a scheduled automation
+can report without a human reading its output. `bb tasks sync import` is a dry
+run until `--apply`.
+
 ### Provider retry plugin
 
 The builtin Provider retry plugin is enabled on fresh installations. It

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -141,6 +141,7 @@ and the `bb tasks` command. Common agent operations are:
   bb tasks detach <key-or-id> [--thread <thread-id>] [--json]
   bb tasks update <key-or-id> --status in_review [--json]
   bb tasks update <key-or-id> (--parent <parent-key-or-id> | --no-parent) [--json]
+  bb tasks sync export|import|check [--project <prefix-or-id>] [--store <path>] [--json]
 
 Run `bb tasks --help` for project, folder, task, label, attachment, and demo-data
 commands, plus preset management, delegation, and attached-thread inspection.
@@ -152,6 +153,20 @@ threads first, newest first. Task update resolves both task keys and IDs for
 in tasks commands resolve on the invoking machine (the thread's machine inside
 an agent thread, otherwise the server's); pass `--machine <id-or-name>` to
 target another enrolled machine.
+`bb tasks sync` converges the same project across bb instances through a
+tracked file in a git repository: export on the instance where the work
+happened, commit the store, pull it elsewhere, import there. Each board stays
+canonical; the store is the convergence point. `import` is a dry run until
+`--apply`, matches notes by body so a repeat run is a no-op, and refuses a
+field update when the local task changed after the export (`--force`
+overwrites). `check` reports drift as MISSING, DRIFT, AHEAD, BEHIND, and
+UNTRACKED, and exits 2 when it finds any, so it suits a scheduled automation.
+`export` refuses to write an empty board over an existing record. Configure
+the store path per project with `bb tasks project update <prefix>
+--sync-store <path>`; add `--sync-role mirror` for an instance that imports
+only, whose local edits check reports as unsyncable. Labels, attachments, and
+sub-task hierarchy do not travel.
+
 Task lists default to 100 rows. JSON pages include `nextCursor`; human pages
 print the exact continuation option when more rows exist. Cursors are bound to
 the filters, sort, and task-list revision. Any add, removal, reorder, update,

--- a/plugins/tasks/api/index.ts
+++ b/plugins/tasks/api/index.ts
@@ -3,6 +3,7 @@ import {
   createTasksStore,
   type Attachment as StoredAttachment,
   type Comment as StoredComment,
+  type SystemCommentEvent,
   type Task as StoredTask,
   type TasksStore,
 } from "../db";
@@ -314,18 +315,29 @@ function labelChangeBody(
     : `Labels changed to ${names.join(", ")} by ${authorName}`;
 }
 
+/**
+ * An audit entry the plugin writes about a change it just made. `event` is the
+ * machine-readable type and `body` the rendered sentence; consumers that must
+ * tell bookkeeping from content (cross-instance sync) read `event`.
+ */
+interface SystemCommentEntry {
+  event: SystemCommentEvent;
+  body: string;
+}
+
 function writeSystemComments(
   store: TasksApiStore,
   taskId: string,
   authorName: string,
-  bodies: readonly string[],
+  entries: readonly SystemCommentEntry[],
 ): void {
-  for (const body of bodies) {
+  for (const entry of entries) {
     store.tasks.createComment({
       taskId,
       kind: "system",
       authorName,
-      body,
+      body: entry.body,
+      systemEvent: entry.event,
       notifiedCount: 0,
     });
   }
@@ -788,31 +800,38 @@ export function registerHandlers(
             replaceTaskLabels(store, current.id, input.labelIds);
           }
 
-          const bodies: string[] = [];
+          const entries: SystemCommentEntry[] = [];
           if (updated.status !== current.status) {
-            bodies.push(
-              `Status changed to ${statusName(updated.status)} by ${input.authorName}`,
-            );
+            entries.push({
+              event: "status_changed",
+              body: `Status changed to ${statusName(updated.status)} by ${input.authorName}`,
+            });
           }
           if (updated.priority !== current.priority) {
-            bodies.push(
-              `Priority changed to ${priorityName(updated.priority)} by ${input.authorName}`,
-            );
+            entries.push({
+              event: "priority_changed",
+              body: `Priority changed to ${priorityName(updated.priority)} by ${input.authorName}`,
+            });
           }
           if (updated.dueDate !== current.dueDate) {
-            bodies.push(
-              updated.dueDate === null
-                ? `Due date removed by ${input.authorName}`
-                : `Due date changed to ${updated.dueDate} by ${input.authorName}`,
-            );
+            entries.push({
+              event: "due_changed",
+              body:
+                updated.dueDate === null
+                  ? `Due date removed by ${input.authorName}`
+                  : `Due date changed to ${updated.dueDate} by ${input.authorName}`,
+            });
           }
           if (input.labelIds && labelsChanged(beforeLabelIds, input.labelIds)) {
-            bodies.push(labelChangeBody(store, current.id, input.authorName));
+            entries.push({
+              event: "labels_changed",
+              body: labelChangeBody(store, current.id, input.authorName),
+            });
           }
-          writeSystemComments(store, current.id, input.authorName, bodies);
+          writeSystemComments(store, current.id, input.authorName, entries);
           return {
             task: apiTask(store, updated),
-            systemCommentsWritten: bodies.length,
+            systemCommentsWritten: entries.length,
           };
         });
 
@@ -866,7 +885,10 @@ export function registerHandlers(
         const statusChanged = moved.status !== current.status;
         if (statusChanged) {
           writeSystemComments(store, current.id, input.authorName, [
-            `Status changed to ${statusName(moved.status)} by ${input.authorName}`,
+            {
+              event: "status_changed",
+              body: `Status changed to ${statusName(moved.status)} by ${input.authorName}`,
+            },
           ]);
         }
         return { task: apiTask(store, moved), statusChanged };

--- a/plugins/tasks/cli/args.ts
+++ b/plugins/tasks/cli/args.ts
@@ -13,11 +13,14 @@ export interface ParsedArgs {
 
 const VALUELESS_FLAGS = new Set([
   "active",
+  "apply",
+  "force",
   "help",
   "json",
   "no-due",
   "no-folder",
   "no-parent",
+  "no-sync-store",
   "notify",
   "remove-references",
   "unlink-bb-project",

--- a/plugins/tasks/cli/index.ts
+++ b/plugins/tasks/cli/index.ts
@@ -47,6 +47,7 @@ import {
 } from "./args";
 import { bytes, detail, table } from "./format";
 import { seedDemo } from "./seed";
+import { runSync, SYNC_HELP, type SyncCliDeps } from "./sync";
 
 const ULID_PATTERN = /^[0-7][0-9A-HJKMNP-TV-Z]{25}$/;
 const TASK_KEY_PATTERN = /^([A-Z][A-Z0-9]{0,9})-(\d+)$/;
@@ -72,15 +73,21 @@ Commands:
   attach                         Attach an agent thread to a task
   detach                         Detach an agent thread from a task
   threads                        List threads attached to a task
+  sync export|import|check       Sync a project across bb instances through git
   seed-demo                      Create sample data (requires --yes)
 
 Run bb tasks <command> --help for command usage.`;
 
 const PROJECT_HELP = `Usage:
-  bb tasks project create --name <name> [--prefix X] [--folder <id-or-name>] [--link-bb-project <proj_id>] [--color <color>] [--json]
+  bb tasks project create --name <name> [--prefix X] [--folder <id-or-name>] [--link-bb-project <proj_id>] [--color <color>] [--sync-store <path>] [--sync-role source|mirror] [--json]
   bb tasks project list [--json]
   bb tasks project show <prefix-or-id> [--json]
-  bb tasks project update <prefix-or-id> [--name <name>] [--color <color>] [--folder <id-or-name> | --no-folder] [--link-bb-project <proj_id> | --unlink-bb-project] [--rename-prefix X] [--json]`;
+  bb tasks project update <prefix-or-id> [--name <name>] [--color <color>] [--folder <id-or-name> | --no-folder] [--link-bb-project <proj_id> | --unlink-bb-project] [--rename-prefix X] [--sync-store <path> | --no-sync-store] [--sync-role source|mirror] [--json]
+
+--sync-store names the file bb tasks sync reads and writes for this project;
+a relative path resolves against the invoking directory. --sync-role mirror
+marks an instance that imports only, for a host that holds a read-only deploy
+key and cannot push the record back.`;
 
 const FOLDER_HELP = `Usage:
   bb tasks folder create --name <name> [--parent <id-or-name>] [--json]
@@ -151,10 +158,9 @@ function unwrapTask(result: TaskMutationResult): Task {
 async function resolveClientHostId(
   bb: BbPluginApi,
   domain: TasksDomain,
-  args: ParsedArgs,
+  machine: string | undefined,
   ctx: PluginCliContext,
 ): Promise<string | undefined> {
-  const machine = option(args, "machine");
   if (machine !== undefined) return resolveMachineId(domain, machine);
   if (!ctx.threadId) return undefined;
   const thread = await bb.sdk.threads.get({ threadId: ctx.threadId });
@@ -542,6 +548,63 @@ function taskAuthor(ctx: PluginCliContext): string {
   return ctx.threadId ? `agent (${ctx.threadId})` : "cli";
 }
 
+/**
+ * Wires the sync commands to the same project resolution, invoking-machine
+ * file access, and task-update path the other subcommands use. Sync reads and
+ * writes ordinary files on the invoking machine, so it goes through
+ * bb.sdk.files rather than the server's disk.
+ */
+function syncDeps(
+  bb: BbPluginApi,
+  store: TasksApiStore,
+  domain: TasksDomain,
+  ctx: PluginCliContext,
+): SyncCliDeps {
+  return {
+    async resolveProject(address) {
+      const project = await selectedProject(domain, ctx, address, true);
+      if (!project) throw new CliError("project is required");
+      return project;
+    },
+    async resolveHostId(machine) {
+      return resolveClientHostId(bb, domain, machine, ctx);
+    },
+    async readText(hostId, path) {
+      try {
+        const { text } = await readClientFile(bb, hostId, path);
+        if (text === null) {
+          throw new CliError(`could not read ${path}: file is not UTF-8 text`);
+        }
+        return text;
+      } catch (error) {
+        if (error instanceof CliError) throw error;
+        if (isMissingClientFileError(error)) return null;
+        const message = error instanceof Error ? error.message : String(error);
+        throw new CliError(`could not read ${path}: ${message}`);
+      }
+    },
+    async writeText(hostId, path, text) {
+      await writeClientFile(bb, hostId, path, Buffer.from(text, "utf8"));
+    },
+    async updateTask(input) {
+      const result = tasksRpcContract.updateTask.output.parse(
+        await domain.updateTask(
+          tasksRpcContract.updateTask.input.parse({
+            taskId: input.taskId,
+            title: input.title,
+            description: input.description,
+            status: input.status,
+            priority: input.priority,
+            dueDate: input.dueDate,
+            authorName: input.authorName,
+          }),
+        ),
+      );
+      unwrapTask(result);
+    },
+  };
+}
+
 async function runProject(
   bb: BbPluginApi,
   store: TasksApiStore,
@@ -560,6 +623,8 @@ async function runProject(
       "folder",
       "link-bb-project",
       "color",
+      "sync-store",
+      "sync-role",
     ]);
     requirePositionals(args, 0, PROJECT_HELP.split("\n")[1]!.trim());
     const name = requireOption(args, "name");
@@ -578,6 +643,8 @@ async function runProject(
           color: option(args, "color") ?? DEFAULT_PROJECT_COLOR,
           folderId: folder?.id ?? null,
           linkedBbProjectId: option(args, "link-bb-project") ?? null,
+          syncStorePath: option(args, "sync-store") ?? null,
+          syncRole: option(args, "sync-role") ?? "source",
         }),
       ),
     );
@@ -616,6 +683,8 @@ async function runProject(
       ["Color", project.color],
       ["Folder", folder?.name ?? "-"],
       ["BB project", project.linkedBbProjectId ?? "-"],
+      ["Sync store", project.syncStorePath ?? "-"],
+      ["Sync role", project.syncRole],
       ["Next task", `${project.prefix}-${project.nextTaskNumber}`],
       ["Created", project.createdAt],
     ]);
@@ -624,8 +693,16 @@ async function runProject(
   if (action === "update") {
     assertAllowed(
       args,
-      ["name", "color", "folder", "link-bb-project", "rename-prefix"],
-      ["no-folder", "unlink-bb-project"],
+      [
+        "name",
+        "color",
+        "folder",
+        "link-bb-project",
+        "rename-prefix",
+        "sync-store",
+        "sync-role",
+      ],
+      ["no-folder", "unlink-bb-project", "no-sync-store"],
     );
     const [address] = requirePositionals(
       args,
@@ -647,6 +724,13 @@ async function runProject(
       "link-bb-project",
       "unlink-bb-project",
     );
+    const syncStorePath = option(args, "sync-store");
+    validateSingleFlagChoice(
+      syncStorePath,
+      args.flags.has("no-sync-store"),
+      "sync-store",
+      "no-sync-store",
+    );
     const folder = folderAddress
       ? await resolveFolder(domain, folderAddress)
       : undefined;
@@ -657,6 +741,8 @@ async function runProject(
       linkedBbProjectId: args.flags.has("unlink-bb-project")
         ? null
         : linkedBbProjectId,
+      syncStorePath: args.flags.has("no-sync-store") ? null : syncStorePath,
+      syncRole: option(args, "sync-role"),
     };
     const renamePrefix = option(args, "rename-prefix");
     if (
@@ -664,7 +750,9 @@ async function runProject(
       changes.name === undefined &&
       changes.color === undefined &&
       changes.folderId === undefined &&
-      changes.linkedBbProjectId === undefined
+      changes.linkedBbProjectId === undefined &&
+      changes.syncStorePath === undefined &&
+      changes.syncRole === undefined
     ) {
       throw new CliError("no project changes were provided");
     }
@@ -679,7 +767,9 @@ async function runProject(
       changes.name !== undefined ||
       changes.color !== undefined ||
       changes.folderId !== undefined ||
-      changes.linkedBbProjectId !== undefined;
+      changes.linkedBbProjectId !== undefined ||
+      changes.syncStorePath !== undefined ||
+      changes.syncRole !== undefined;
     const updateInput = hasFieldChanges
       ? tasksRpcContract.updateProject.input.parse({
           projectId: project.id,
@@ -701,6 +791,8 @@ async function runProject(
         color: updateInput?.color,
         folderId: updateInput?.folderId,
         linkedBbProjectId: updateInput?.linkedBbProjectId,
+        syncStorePath: updateInput?.syncStorePath,
+        syncRole: updateInput?.syncRole,
       }),
     );
     publishProjectsChanged(bb, updated.id);
@@ -899,7 +991,7 @@ async function runCreate(
     throw new CliError("--machine requires --attach or --description-file");
   }
   const clientHostId = usesClientFiles
-    ? await resolveClientHostId(bb, domain, args, ctx)
+    ? await resolveClientHostId(bb, domain, option(args, "machine"), ctx)
     : undefined;
   const attachSources: Array<{ path: string; bytes: Buffer }> = [];
   for (const path of attachPaths) {
@@ -1295,7 +1387,7 @@ async function runUpdate(
   }
   const clientHostId =
     option(args, "description-file") !== undefined
-      ? await resolveClientHostId(bb, domain, args, ctx)
+      ? await resolveClientHostId(bb, domain, option(args, "machine"), ctx)
       : undefined;
   const description = await readFileOption(
     bb,
@@ -1373,7 +1465,7 @@ async function runComment(
   }
   const clientHostId =
     option(args, "body-file") !== undefined
-      ? await resolveClientHostId(bb, domain, args, ctx)
+      ? await resolveClientHostId(bb, domain, option(args, "machine"), ctx)
       : undefined;
   const body = await readFileOption(
     bb,
@@ -1507,7 +1599,12 @@ async function runAttachment(
     const owner = comment
       ? { commentId: comment.id }
       : { taskId: (await resolveTask(domain, ownerAddress!)).id };
-    const clientHostId = await resolveClientHostId(bb, domain, args, ctx);
+    const clientHostId = await resolveClientHostId(
+      bb,
+      domain,
+      option(args, "machine"),
+      ctx,
+    );
     const bytes = await readAttachmentSource(bb, clientHostId, sourcePath);
     const attachment = await saveAttachmentFromBytes(store.tasks, bytes, {
       ...owner,
@@ -1532,7 +1629,12 @@ async function runAttachment(
     );
     const outOption = requireOption(args, "out");
     const outPath = resolve(ctx.cwd ?? process.cwd(), outOption);
-    const clientHostId = await resolveClientHostId(bb, domain, args, ctx);
+    const clientHostId = await resolveClientHostId(
+      bb,
+      domain,
+      option(args, "machine"),
+      ctx,
+    );
     const { attachment, content } = await readAttachmentContent(
       store.tasks,
       attachmentId!,
@@ -2053,6 +2155,12 @@ export function registerTasksCli(
         usage: THREADS_HELP,
       },
       {
+        name: "sync",
+        summary:
+          "Export, import, or check a project's cross-instance sync store",
+        usage: SYNC_HELP,
+      },
+      {
         name: "seed-demo",
         summary: "Create sample folders, projects, labels, tasks, and comments",
         usage: "bb tasks seed-demo --yes [--json]",
@@ -2124,6 +2232,20 @@ export function registerTasksCli(
           case "threads":
             stdout = await runThreads(domain, rest);
             break;
+          case "sync": {
+            const result = await runSync(
+              bb,
+              store,
+              syncDeps(bb, store, domain, ctx),
+              rest,
+              ctx.cwd ?? process.cwd(),
+            );
+            // check and import report drift with a non-zero exit so a
+            // scheduled automation can act on it without reading the text.
+            if (typeof result !== "string") return result;
+            stdout = result;
+            break;
+          }
           case "seed-demo": {
             const args = parseArgs(rest);
             assertAllowed(args, [], ["yes"]);

--- a/plugins/tasks/cli/sync.ts
+++ b/plugins/tasks/cli/sync.ts
@@ -1,0 +1,479 @@
+import { dirname, join, resolve } from "node:path";
+import type { BbPluginApi, PluginCliResult } from "@get-bb/plugin-sdk";
+
+import { createComment, publishTasksChanged, type TasksApiStore } from "../api";
+import type { Comment, Project } from "../db";
+import { TASKS_PAGE_MAX_LIMIT } from "../shared/pagination";
+import {
+  buildSyncStore,
+  checkDrift,
+  needsExport,
+  planImport,
+  type BoardTask,
+  type DriftEntry,
+  type ImportAction,
+} from "../sync/plan";
+import {
+  commentHash,
+  parseSyncStore,
+  renderTaskMarkdown,
+  serializeSyncStore,
+  type SyncComment,
+} from "../sync/store-file";
+import {
+  assertAllowed,
+  CliError,
+  option,
+  parseArgs,
+  requirePositionals,
+} from "./args";
+
+export const SYNC_HELP = `Usage:
+  bb tasks sync export [--project <prefix-or-id>] [--store <path>] [--machine <id-or-name>] [--json]
+  bb tasks sync import [--project <prefix-or-id>] [--store <path>] [--apply] [--force] [--machine <id-or-name>] [--json]
+  bb tasks sync check  [--project <prefix-or-id>] [--store <path>] [--machine <id-or-name>] [--json]
+
+Git is the transport and each board stays canonical: export on the instance
+where the work happened, commit the store, pull it elsewhere, import there.
+
+export writes the store and one <KEY>.md per task beside it, and refuses to
+write an empty board over an existing record. import is a dry run until
+--apply; it creates missing tasks, updates changed fields, and appends notes
+the local board has not seen, matching notes by body so a repeat run is a
+no-op. It refuses a field update when the local task changed after the export
+and reports it; --force overwrites instead. check reports drift and exits 2
+when it finds any, so it can run as a scheduled automation.
+
+The store path comes from --store or the project's configured
+--sync-store; a relative path resolves against the invoking directory. A
+project with --sync-role mirror imports only: export refuses, and check
+reports local edits that cannot travel back.`;
+
+/** Column-aligned report rows, with no header line. */
+function alignedRows(
+  rows: readonly (readonly string[])[],
+  emptyMessage: string,
+): string {
+  if (rows.length === 0) return emptyMessage;
+  const widths: number[] = [];
+  for (const row of rows) {
+    row.forEach((cell, index) => {
+      widths[index] = Math.max(widths[index] ?? 0, cell.length);
+    });
+  }
+  return rows
+    .map((row) =>
+      row
+        .map((cell, index) =>
+          index === row.length - 1 ? cell : cell.padEnd(widths[index] ?? 0),
+        )
+        .join("  ")
+        .trimEnd(),
+    )
+    .join("\n");
+}
+
+/** Author recorded on the local audit trail an import leaves behind. */
+const SYNC_AUTHOR_NAME = "sync";
+const DRIFT_EXIT_CODE = 2;
+
+export interface SyncCliDeps {
+  resolveProject(address: string | undefined): Promise<Project>;
+  resolveHostId(machine: string | undefined): Promise<string | undefined>;
+  /** Resolves to null when the file does not exist. */
+  readText(hostId: string | undefined, path: string): Promise<string | null>;
+  writeText(
+    hostId: string | undefined,
+    path: string,
+    text: string,
+  ): Promise<void>;
+  updateTask(input: {
+    taskId: string;
+    title: string;
+    description: string;
+    status: BoardTask["status"];
+    priority: BoardTask["priority"];
+    dueDate: string | null;
+    authorName: string;
+  }): Promise<void>;
+}
+
+/**
+ * A comment belongs to the shared record only when the plugin did not write it
+ * itself. `systemEvent` is the structural marker for a plugin audit row, so
+ * this never has to match on the rendered body: propagating audit rows made
+ * both boards drift permanently, because each import generated fresh ones on
+ * the far side.
+ */
+function isSyncableComment(comment: Comment): boolean {
+  return comment.systemEvent === null && comment.kind !== "system";
+}
+
+function toSyncComment(comment: Comment): SyncComment {
+  return {
+    hash: commentHash(comment.body),
+    kind: comment.kind === "agent" ? "agent" : "user",
+    authorName: comment.authorName,
+    createdAt: comment.createdAt,
+    body: comment.body,
+  };
+}
+
+function readBoard(store: TasksApiStore, projectId: string): BoardTask[] {
+  const tasks: BoardTask[] = [];
+  let cursor: string | undefined;
+  do {
+    const page = store.tasks.listTasksPage({
+      projectId,
+      limit: TASKS_PAGE_MAX_LIMIT,
+      ...(cursor === undefined ? {} : { cursor }),
+    });
+    for (const task of page.tasks) {
+      tasks.push({
+        id: task.id,
+        key: task.key,
+        number: task.number,
+        title: task.title,
+        status: task.status,
+        priority: task.priority,
+        description: task.description,
+        dueDate: task.dueDate,
+        updatedAt: task.updatedAt,
+        comments: store.tasks
+          .listComments(task.id)
+          .filter(isSyncableComment)
+          .map(toSyncComment),
+      });
+    }
+    cursor = page.nextCursor ?? undefined;
+  } while (cursor !== undefined);
+  return tasks.sort((left, right) => left.number - right.number);
+}
+
+function storePath(
+  project: Project,
+  explicit: string | undefined,
+  cwd: string,
+): string {
+  const configured = explicit ?? project.syncStorePath;
+  if (!configured) {
+    throw new CliError(
+      `project ${project.prefix} has no sync store; pass --store <path> or set it with bb tasks project update ${project.prefix} --sync-store <path>`,
+    );
+  }
+  return resolve(cwd, configured);
+}
+
+async function loadStore(
+  deps: SyncCliDeps,
+  hostId: string | undefined,
+  path: string,
+): Promise<ReturnType<typeof parseSyncStore>> {
+  const text = await deps.readText(hostId, path);
+  if (text === null) {
+    throw new CliError(
+      `no sync store at ${path} — run bb tasks sync export on the instance that holds the record, then pull it here`,
+    );
+  }
+  return parseSyncStore(text);
+}
+
+async function runExportMode(
+  store: TasksApiStore,
+  deps: SyncCliDeps,
+  project: Project,
+  path: string,
+  hostId: string | undefined,
+  json: boolean,
+): Promise<string> {
+  if (project.syncRole === "mirror") {
+    throw new CliError(
+      `project ${project.prefix} is a sync mirror and imports only; run bb tasks sync check to report local edits, or set bb tasks project update ${project.prefix} --sync-role source`,
+    );
+  }
+  const board = readBoard(store, project.id);
+  // Without this guard, an export on a fresh instance replaces the record for
+  // every instance with an empty file.
+  if (board.length === 0) {
+    throw new CliError(
+      `project ${project.prefix} has no tasks on this board — refusing to overwrite ${path} with an empty store`,
+    );
+  }
+  const record = buildSyncStore(project, board, new Date().toISOString());
+  await deps.writeText(hostId, path, serializeSyncStore(record));
+  const directory = dirname(path);
+  const fileName = path.slice(directory.length + 1) || "the sync store";
+  for (const task of record.tasks) {
+    await deps.writeText(
+      hostId,
+      join(directory, `${task.key}.md`),
+      renderTaskMarkdown(task, fileName),
+    );
+  }
+  const notes = record.tasks.reduce(
+    (total, task) => total + task.comments.length,
+    0,
+  );
+  return json
+    ? JSON.stringify({
+        mode: "export",
+        storePath: path,
+        project: project.prefix,
+        tasks: record.tasks.length,
+        notes,
+        generatedAt: record.generatedAt,
+      })
+    : `Exported ${record.tasks.length} task(s) and ${notes} note(s) to ${path}`;
+}
+
+function describeAction(action: ImportAction, applied: boolean): string[] {
+  switch (action.kind) {
+    case "create":
+      return [
+        applied ? "+" : "would",
+        "CREATE",
+        action.key,
+        `${action.task.title} (${action.task.comments.length} note(s))`,
+      ];
+    case "update":
+      return [
+        applied ? "~" : "would",
+        "UPDATE",
+        action.key,
+        `fields: ${action.fields.join(",")}`,
+      ];
+    case "comment":
+      return [
+        applied ? "+" : "would",
+        "NOTE",
+        action.key,
+        action.comment.body.trim().split("\n")[0] ?? "",
+      ];
+    case "conflict":
+      return [
+        "!",
+        "CONFLICT",
+        action.key,
+        `fields: ${action.fields.join(",")} — this board changed at ${action.boardUpdatedAt}, after the store's ${action.storeUpdatedAt}; rerun with --force to overwrite`,
+      ];
+  }
+}
+
+async function applyAction(
+  bb: BbPluginApi,
+  store: TasksApiStore,
+  deps: SyncCliDeps,
+  project: Project,
+  action: ImportAction,
+): Promise<void> {
+  switch (action.kind) {
+    case "create": {
+      // The number comes from the store so the task keeps the same key on
+      // every instance; a store keyed by AGT-5 is useless if importing it
+      // creates AGT-1 here.
+      const created = store.tasks.createTask({
+        projectId: project.id,
+        number: action.task.number,
+        title: action.task.title,
+        description: action.task.description,
+        status: action.task.status,
+        priority: action.task.priority,
+        dueDate: action.task.dueDate,
+      });
+      publishTasksChanged(bb, created.id, project.id);
+      for (const comment of action.task.comments) {
+        await appendComment(bb, store, created.id, comment);
+      }
+      return;
+    }
+    case "update": {
+      await deps.updateTask({
+        taskId: action.taskId,
+        title: action.task.title,
+        description: action.task.description,
+        status: action.task.status,
+        priority: action.task.priority,
+        dueDate: action.task.dueDate,
+        authorName: SYNC_AUTHOR_NAME,
+      });
+      return;
+    }
+    case "comment": {
+      await appendComment(bb, store, action.taskId, action.comment);
+      return;
+    }
+    case "conflict":
+      return;
+  }
+}
+
+async function appendComment(
+  bb: BbPluginApi,
+  store: TasksApiStore,
+  taskId: string,
+  comment: SyncComment,
+): Promise<void> {
+  await createComment(bb, store, {
+    taskId,
+    kind: comment.kind,
+    authorName: comment.authorName.trim() || SYNC_AUTHOR_NAME,
+    presetName: null,
+    // Thread ids are per instance, so an imported agent note carries none.
+    threadId: null,
+    body: comment.body,
+    notify: false,
+  });
+}
+
+async function runImportMode(
+  bb: BbPluginApi,
+  store: TasksApiStore,
+  deps: SyncCliDeps,
+  project: Project,
+  path: string,
+  hostId: string | undefined,
+  options: { apply: boolean; force: boolean; json: boolean },
+): Promise<string | PluginCliResult> {
+  const record = await loadStore(deps, hostId, path);
+  if (record.project.prefix.toUpperCase() !== project.prefix.toUpperCase()) {
+    throw new CliError(
+      `${path} holds project ${record.project.prefix}, not ${project.prefix}`,
+    );
+  }
+  const actions = planImport(record, readBoard(store, project.id), {
+    overwriteNewerBoardEdits: options.force,
+  });
+  if (options.apply) {
+    // Applied one action at a time rather than in one transaction: each write
+    // is individually atomic, and import is idempotent, so a failure part way
+    // through is fixed by running it again rather than by a rollback.
+    for (const action of actions) {
+      await applyAction(bb, store, deps, project, action);
+    }
+  }
+  const conflicts = actions.filter(
+    (action) => action.kind === "conflict",
+  ).length;
+  const changes = actions.length - conflicts;
+  const summary = options.apply
+    ? `${changes} change(s) applied`
+    : `${changes} change(s) pending — rerun with --apply`;
+  const conflictNote =
+    conflicts === 0
+      ? ""
+      : `\n${conflicts} conflict(s) refused; the local edit is newer and cannot be reconciled automatically`;
+  const stdout = options.json
+    ? JSON.stringify({
+        mode: "import",
+        storePath: path,
+        project: project.prefix,
+        applied: options.apply,
+        changes,
+        conflicts,
+        actions: actions.map((action) => ({
+          kind: action.kind,
+          key: action.key,
+          ...(action.kind === "update" || action.kind === "conflict"
+            ? { fields: action.fields }
+            : {}),
+        })),
+      })
+    : [
+        alignedRows(
+          actions.map((action) => describeAction(action, options.apply)),
+          "no changes",
+        ),
+        `${summary}${conflictNote}`,
+      ].join("\n");
+  return conflicts === 0
+    ? stdout
+    : { exitCode: DRIFT_EXIT_CODE, stdout, stderr: "" };
+}
+
+async function runCheckMode(
+  store: TasksApiStore,
+  deps: SyncCliDeps,
+  project: Project,
+  path: string,
+  hostId: string | undefined,
+  json: boolean,
+): Promise<string | PluginCliResult> {
+  const record = await loadStore(deps, hostId, path);
+  const entries = checkDrift(record, readBoard(store, project.id));
+  const isMirror = project.syncRole === "mirror";
+  const detail = (entry: DriftEntry): string =>
+    isMirror && needsExport(entry)
+      ? `${entry.detail} (this instance is a sync mirror, so the edit cannot travel back)`
+      : entry.detail;
+  const unsyncable = isMirror ? entries.filter(needsExport).length : 0;
+  const stdout = json
+    ? JSON.stringify({
+        mode: "check",
+        storePath: path,
+        project: project.prefix,
+        syncRole: project.syncRole,
+        generatedAt: record.generatedAt,
+        drift: entries.length,
+        unsyncableLocalEdits: unsyncable,
+        entries: entries.map((entry) => ({
+          drift: entry.drift,
+          key: entry.key,
+          detail: detail(entry),
+        })),
+      })
+    : [
+        alignedRows(
+          entries.map((entry) => [entry.drift, entry.key, detail(entry)]),
+          "no drift",
+        ),
+        `drift: ${entries.length} (store generated ${record.generatedAt})`,
+        ...(unsyncable > 0
+          ? [
+              `${unsyncable} local edit(s) cannot be exported from this mirror; make the change on the source instance`,
+            ]
+          : []),
+      ].join("\n");
+  return entries.length === 0
+    ? stdout
+    : { exitCode: DRIFT_EXIT_CODE, stdout, stderr: "" };
+}
+
+export async function runSync(
+  bb: BbPluginApi,
+  store: TasksApiStore,
+  deps: SyncCliDeps,
+  argv: string[],
+  cwd: string,
+): Promise<string | PluginCliResult> {
+  const [mode, ...rest] = argv;
+  if (!mode || mode === "--help") return SYNC_HELP;
+  if (mode !== "export" && mode !== "import" && mode !== "check") {
+    throw new CliError(`unknown sync mode: ${mode}; run bb tasks sync --help`);
+  }
+  const args = parseArgs(rest);
+  if (args.flags.has("help")) return SYNC_HELP;
+  assertAllowed(args, ["project", "store", "machine"], ["apply", "force"]);
+  requirePositionals(args, 0, `bb tasks sync ${mode} [options] [--json]`);
+  if (
+    mode !== "import" &&
+    (args.flags.has("apply") || args.flags.has("force"))
+  ) {
+    throw new CliError("--apply and --force apply to bb tasks sync import");
+  }
+  const project = await deps.resolveProject(option(args, "project"));
+  const path = storePath(project, option(args, "store"), cwd);
+  const hostId = await deps.resolveHostId(option(args, "machine"));
+  const json = args.flags.has("json");
+
+  if (mode === "export") {
+    return runExportMode(store, deps, project, path, hostId, json);
+  }
+  if (mode === "import") {
+    return runImportMode(bb, store, deps, project, path, hostId, {
+      apply: args.flags.has("apply"),
+      force: args.flags.has("force"),
+      json,
+    });
+  }
+  return runCheckMode(store, deps, project, path, hostId, json);
+}

--- a/plugins/tasks/db.test.ts
+++ b/plugins/tasks/db.test.ts
@@ -59,7 +59,7 @@ describe("tasks storage", () => {
             { count: number }
           >("SELECT COUNT(*) AS count FROM schema_version")
           .get()?.count,
-      ).toBe(6);
+      ).toBe(7);
     } finally {
       await harness.dispose();
     }

--- a/plugins/tasks/db/schema.ts
+++ b/plugins/tasks/db/schema.ts
@@ -239,6 +239,21 @@ const MIGRATIONS = [
     ALTER TABLE presets ADD COLUMN service_tier TEXT
       CHECK (service_tier IN ('default', 'fast'));
   `,
+  `
+    ALTER TABLE comments ADD COLUMN system_event TEXT
+      CHECK (system_event IS NULL OR system_event IN (
+        'status_changed',
+        'priority_changed',
+        'due_changed',
+        'labels_changed',
+        'dispatched',
+        'thread_finished'
+      ));
+
+    ALTER TABLE projects ADD COLUMN sync_store_path TEXT;
+    ALTER TABLE projects ADD COLUMN sync_role TEXT NOT NULL DEFAULT 'source'
+      CHECK (sync_role IN ('source', 'mirror'));
+  `,
 ] as const;
 
 export function initializeTasksSchema(db: PluginDatabase): void {

--- a/plugins/tasks/db/store.ts
+++ b/plugins/tasks/db/store.ts
@@ -11,6 +11,8 @@ import {
   presetPermissionModeSchema,
   presetReasoningLevelSchema,
   presetServiceTierSchema,
+  projectSyncRoleSchema,
+  systemCommentEventSchema,
 } from "../shared/contract.js";
 import type {
   Attachment,
@@ -30,7 +32,9 @@ import type {
   Preset,
   PresetEnvironmentKind,
   Project,
+  ProjectSyncRole,
   SubtaskDoneCounts,
+  SystemCommentEvent,
   Task,
   TaskLabel,
   TaskThread,
@@ -71,6 +75,8 @@ interface ProjectRow {
   color: string;
   folder_id: string | null;
   linked_bb_project_id: string | null;
+  sync_store_path: string | null;
+  sync_role: ProjectSyncRole;
   created_at: string;
 }
 
@@ -124,6 +130,7 @@ interface CommentRow {
   preset_name: string | null;
   thread_id: string | null;
   body: string;
+  system_event: SystemCommentEvent | null;
   notified_count: number;
   created_at: string;
 }
@@ -315,6 +322,30 @@ function validateLinkedBbProjectId(id: string | null): string | null {
   return id;
 }
 
+function validateSyncStorePath(path: string | null): string | null {
+  return path === null ? null : requireNonEmpty(path, "Project syncStorePath");
+}
+
+function validateSyncRole(role: ProjectSyncRole): ProjectSyncRole {
+  return projectSyncRoleSchema.parse(role);
+}
+
+/**
+ * A `systemEvent` names one of the plugin's own audit writes, so it is only
+ * meaningful on a `system` comment. Rejecting the mismatch keeps the field
+ * usable as the "plugin wrote this" predicate that sync depends on.
+ */
+function validateSystemEvent(
+  kind: Comment["kind"],
+  event: SystemCommentEvent | null,
+): SystemCommentEvent | null {
+  if (event === null) return null;
+  if (kind !== "system") {
+    throw new Error('systemEvent requires a comment of kind "system"');
+  }
+  return systemCommentEventSchema.parse(event);
+}
+
 function validateThreadId(id: string): string;
 function validateThreadId(id: null): null;
 function validateThreadId(id: string | null): string | null;
@@ -359,6 +390,8 @@ function projectFromRow(row: ProjectRow): Project {
     color: row.color,
     folderId: row.folder_id,
     linkedBbProjectId: row.linked_bb_project_id,
+    syncStorePath: row.sync_store_path,
+    syncRole: row.sync_role,
     createdAt: row.created_at,
   };
 }
@@ -403,6 +436,7 @@ function commentFromRow(row: CommentRow): Comment {
     presetName: row.preset_name,
     threadId: row.thread_id,
     body: row.body,
+    systemEvent: row.system_event,
     notifiedCount: row.notified_count,
     createdAt: row.created_at,
   };
@@ -646,12 +680,23 @@ export function createTasksStore(db: PluginDatabase) {
     const folderId = input.folderId ?? null;
     if (folderId !== null) requireFolder(folderId);
     db.prepare<
-      [string, string, string, string, string | null, string | null, string]
+      [
+        string,
+        string,
+        string,
+        string,
+        string | null,
+        string | null,
+        string | null,
+        ProjectSyncRole,
+        string,
+      ]
     >(
       `
       INSERT INTO projects
-        (id, name, prefix, next_task_number, color, folder_id, linked_bb_project_id, created_at)
-      VALUES (?, ?, ?, 1, ?, ?, ?, ?)
+        (id, name, prefix, next_task_number, color, folder_id, linked_bb_project_id,
+         sync_store_path, sync_role, created_at)
+      VALUES (?, ?, ?, 1, ?, ?, ?, ?, ?, ?)
     `,
     ).run(
       id,
@@ -660,6 +705,8 @@ export function createTasksStore(db: PluginDatabase) {
       requireNonEmpty(input.color, "Project color"),
       folderId,
       validateLinkedBbProjectId(input.linkedBbProjectId ?? null),
+      validateSyncStorePath(input.syncStorePath ?? null),
+      validateSyncRole(input.syncRole ?? "source"),
       nowIso(),
     );
     return requireProject(id);
@@ -697,10 +744,22 @@ export function createTasksStore(db: PluginDatabase) {
     const folderId =
       input.folderId === undefined ? current.folderId : input.folderId;
     if (folderId !== null) requireFolder(folderId);
-    db.prepare<[string, string, string, string | null, string | null, string]>(
+    db.prepare<
+      [
+        string,
+        string,
+        string,
+        string | null,
+        string | null,
+        string | null,
+        ProjectSyncRole,
+        string,
+      ]
+    >(
       `
       UPDATE projects
-      SET name = ?, prefix = ?, color = ?, folder_id = ?, linked_bb_project_id = ?
+      SET name = ?, prefix = ?, color = ?, folder_id = ?, linked_bb_project_id = ?,
+          sync_store_path = ?, sync_role = ?
       WHERE id = ?
     `,
     ).run(
@@ -717,6 +776,12 @@ export function createTasksStore(db: PluginDatabase) {
       input.linkedBbProjectId === undefined
         ? current.linkedBbProjectId
         : validateLinkedBbProjectId(input.linkedBbProjectId),
+      input.syncStorePath === undefined
+        ? current.syncStorePath
+        : validateSyncStorePath(input.syncStorePath),
+      input.syncRole === undefined
+        ? current.syncRole
+        : validateSyncRole(input.syncRole),
       id,
     );
     return requireProject(id);
@@ -804,19 +869,37 @@ export function createTasksStore(db: PluginDatabase) {
           .get(project.id, status)?.position ?? POSITION_STEP;
       const createdAt = nowIso();
 
-      const allocated = db
-        .prepare<[string, number]>(
-          `
+      // Sync import reuses an explicit number so a task keeps its key on
+      // every instance. UNIQUE (project_id, number) rejects a collision, and
+      // the counter only moves forward so later interactive creates cannot
+      // reuse an imported number.
+      const number = input.number ?? project.nextTaskNumber;
+      if (input.number === undefined) {
+        const allocated = db
+          .prepare<[string, number]>(
+            `
         UPDATE projects
         SET next_task_number = next_task_number + 1
         WHERE id = ? AND next_task_number = ?
       `,
-        )
-        .run(project.id, project.nextTaskNumber);
-      if (allocated.changes !== 1) {
-        throw new Error(
-          `Could not allocate the next task number for ${project.id}`,
-        );
+          )
+          .run(project.id, project.nextTaskNumber);
+        if (allocated.changes !== 1) {
+          throw new Error(
+            `Could not allocate the next task number for ${project.id}`,
+          );
+        }
+      } else {
+        if (!Number.isInteger(number) || number < 1) {
+          throw new Error("Task number must be a positive integer");
+        }
+        db.prepare<[number, string, number]>(
+          `
+        UPDATE projects
+        SET next_task_number = ?
+        WHERE id = ? AND next_task_number < ?
+      `,
+        ).run(number + 1, project.id, number + 1);
       }
 
       db.prepare<
@@ -844,7 +927,7 @@ export function createTasksStore(db: PluginDatabase) {
       ).run(
         id,
         project.id,
-        project.nextTaskNumber,
+        number,
         requireNonEmpty(input.title, "Task title"),
         input.description ?? "",
         status,
@@ -1408,6 +1491,7 @@ export function createTasksStore(db: PluginDatabase) {
         string | null,
         string | null,
         string,
+        SystemCommentEvent | null,
         number,
         string,
       ]
@@ -1415,8 +1499,8 @@ export function createTasksStore(db: PluginDatabase) {
       `
       INSERT INTO comments (
         id, task_id, kind, author_name, preset_name, thread_id, body,
-        notified_count, created_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        system_event, notified_count, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
     ).run(
       id,
@@ -1426,6 +1510,7 @@ export function createTasksStore(db: PluginDatabase) {
       input.presetName ?? null,
       validateThreadId(input.threadId ?? null),
       input.body,
+      validateSystemEvent(input.kind, input.systemEvent ?? null),
       input.notifiedCount ?? 0,
       nowIso(),
     );

--- a/plugins/tasks/db/types.ts
+++ b/plugins/tasks/db/types.ts
@@ -1,6 +1,8 @@
 import type { TaskSort } from "../shared/pagination.js";
 import type {
   PRESET_ENVIRONMENT_KINDS,
+  PROJECT_SYNC_ROLES,
+  SYSTEM_COMMENT_EVENTS,
   PresetPermissionMode,
   PresetReasoningLevel,
   PresetServiceTier,
@@ -12,6 +14,23 @@ import type {
 export type { TaskPriority, TaskStatus };
 
 type CommentKind = "user" | "agent" | "system";
+
+/**
+ * Machine-readable type of a plugin-authored audit comment. It is non-null
+ * exactly when the plugin wrote the comment itself (a status change, a
+ * dispatch, and so on), so a consumer can tell audit rows from content
+ * without parsing the rendered body. Cross-instance sync uses it to keep
+ * per-instance audit trails local.
+ */
+export type SystemCommentEvent = (typeof SYSTEM_COMMENT_EVENTS)[number];
+
+/**
+ * Whether this instance may write the project's sync store. A `mirror`
+ * imports only: the real deployment gives one host a read-only deploy key on
+ * purpose, so its local edits can never travel back and must be reported
+ * rather than silently exported.
+ */
+export type ProjectSyncRole = (typeof PROJECT_SYNC_ROLES)[number];
 
 export type TaskThreadLiveStatus = (typeof TASK_THREAD_LIVE_STATUSES)[number];
 
@@ -32,6 +51,8 @@ export interface Project {
   color: string;
   folderId: string | null;
   linkedBbProjectId: string | null;
+  syncStorePath: string | null;
+  syncRole: ProjectSyncRole;
   createdAt: string;
 }
 
@@ -71,6 +92,7 @@ export interface Comment {
   presetName: string | null;
   threadId: string | null;
   body: string;
+  systemEvent: SystemCommentEvent | null;
   notifiedCount: number;
   createdAt: string;
 }
@@ -144,6 +166,8 @@ export interface CreateProjectInput {
   color: string;
   folderId?: string | null;
   linkedBbProjectId?: string | null;
+  syncStorePath?: string | null;
+  syncRole?: ProjectSyncRole;
 }
 
 export interface UpdateProjectInput {
@@ -152,11 +176,20 @@ export interface UpdateProjectInput {
   color?: string;
   folderId?: string | null;
   linkedBbProjectId?: string | null;
+  syncStorePath?: string | null;
+  syncRole?: ProjectSyncRole;
 }
 
 export interface CreateTaskInput {
   id?: string;
   projectId: string;
+  /**
+   * Task number to insert at, instead of allocating the project's next one.
+   * Sync import passes it so a task keeps the same key on every instance;
+   * omitting it means "allocate the next number", which is what every
+   * interactive create wants.
+   */
+  number?: number;
   title: string;
   description?: string;
   status?: TaskStatus;
@@ -225,6 +258,8 @@ export interface CreateCommentInput {
   presetName?: string | null;
   threadId?: string | null;
   body: string;
+  /** Set only by the plugin's own audit writes; requires `kind: "system"`. */
+  systemEvent?: SystemCommentEvent | null;
   notifiedCount?: number;
 }
 

--- a/plugins/tasks/delegate/delegate.test.ts
+++ b/plugins/tasks/delegate/delegate.test.ts
@@ -503,6 +503,8 @@ describe("delegation seed prompt", () => {
       color: "blue",
       folderId: null,
       linkedBbProjectId: "proj_tasks",
+      syncStorePath: null,
+      syncRole: "source",
       createdAt: "2026-07-15T17:00:00.000Z",
     };
     const task: Task = {

--- a/plugins/tasks/delegate/index.ts
+++ b/plugins/tasks/delegate/index.ts
@@ -5,6 +5,7 @@ import type {
   Comment,
   Preset,
   Project,
+  SystemCommentEvent,
   Task,
   TasksStore,
   TaskThreadLiveStatus,
@@ -264,6 +265,7 @@ export function createSystemComment(
     taskId: string;
     presetName: string;
     threadId: string;
+    event: SystemCommentEvent;
     body: string;
   },
 ): void {
@@ -274,6 +276,7 @@ export function createSystemComment(
     presetName: input.presetName,
     threadId: input.threadId,
     body: input.body,
+    systemEvent: input.event,
     notifiedCount: 0,
   });
 }
@@ -362,6 +365,7 @@ export function handlers(
             taskId: task.id,
             presetName: preset.name,
             threadId: thread.id,
+            event: "status_changed",
             body: `Status changed to In Progress · dispatched to ${preset.name}`,
           });
         }
@@ -370,6 +374,7 @@ export function handlers(
           taskId: task.id,
           presetName: preset.name,
           threadId: thread.id,
+          event: "dispatched",
           body: `Dispatched to ${preset.name}`,
         });
         return attached;

--- a/plugins/tasks/lifecycle/index.ts
+++ b/plugins/tasks/lifecycle/index.ts
@@ -73,6 +73,7 @@ function transitionThread(
         taskId: thread.taskId,
         presetName: thread.presetName,
         threadId: thread.threadId,
+        event: "thread_finished",
         body: terminalCommentBody(thread, liveStatus),
       });
     }

--- a/plugins/tasks/shared/contract.ts
+++ b/plugins/tasks/shared/contract.ts
@@ -36,6 +36,24 @@ export const PRESET_ENVIRONMENT_KINDS = [
   "new-worktree",
 ] as const;
 
+/**
+ * Audit events the plugin writes as `system` comments. A non-null
+ * `systemEvent` marks a comment as plugin-authored bookkeeping, so consumers
+ * (notably cross-instance sync) can exclude it without matching on the
+ * rendered body text.
+ */
+export const SYSTEM_COMMENT_EVENTS = [
+  "status_changed",
+  "priority_changed",
+  "due_changed",
+  "labels_changed",
+  "dispatched",
+  "thread_finished",
+] as const;
+
+/** Whether this instance may write a project's cross-instance sync store. */
+export const PROJECT_SYNC_ROLES = ["source", "mirror"] as const;
+
 const ULID_PATTERN = /^[0-7][0-9A-HJKMNP-TV-Z]{25}$/;
 const PROJECT_PREFIX_PATTERN = /^[A-Z][A-Z0-9]{0,9}$/;
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
@@ -80,6 +98,8 @@ const dueDateSchema = z
       parsed.toISOString().slice(0, 10) === value
     );
   }, "must be a valid calendar date in YYYY-MM-DD format");
+export const systemCommentEventSchema = z.enum(SYSTEM_COMMENT_EVENTS);
+export const projectSyncRoleSchema = z.enum(PROJECT_SYNC_ROLES);
 const taskStatusSchema = z.enum(TASK_STATUSES);
 const taskPrioritySchema = z.enum(TASK_PRIORITIES);
 const taskSortSchema = z.enum(TASK_SORTS);
@@ -109,6 +129,8 @@ const projectSchema = z
     color: z.string(),
     folderId: idSchema.nullable(),
     linkedBbProjectId: z.string().startsWith("proj_").nullable(),
+    syncStorePath: z.string().nullable(),
+    syncRole: projectSyncRoleSchema,
     createdAt: z.string(),
   })
   .strict();
@@ -150,6 +172,7 @@ const commentSchema = z
     presetName: z.string().nullable(),
     threadId: z.string().startsWith("thr_").nullable(),
     body: z.string(),
+    systemEvent: systemCommentEventSchema.nullable(),
     notifiedCount: z.number().int().nonnegative(),
     createdAt: z.string(),
   })
@@ -341,6 +364,8 @@ const updateProjectInputSchema = z
     color: nonBlankStringSchema.optional(),
     folderId: idSchema.nullable().optional(),
     linkedBbProjectId: z.string().startsWith("proj_").nullable().optional(),
+    syncStorePath: nonBlankStringSchema.nullable().optional(),
+    syncRole: projectSyncRoleSchema.optional(),
   })
   .strict()
   .refine(
@@ -348,7 +373,9 @@ const updateProjectInputSchema = z
       input.name !== undefined ||
       input.color !== undefined ||
       input.folderId !== undefined ||
-      input.linkedBbProjectId !== undefined,
+      input.linkedBbProjectId !== undefined ||
+      input.syncStorePath !== undefined ||
+      input.syncRole !== undefined,
     { message: "at least one project field must be updated" },
   );
 
@@ -467,6 +494,8 @@ export const tasksRpcContract = defineRpcContract({
           .startsWith("proj_")
           .nullable()
           .default(null),
+        syncStorePath: nonBlankStringSchema.nullable().default(null),
+        syncRole: projectSyncRoleSchema.default("source"),
       })
       .strict(),
     output: z.object({ project: projectSchema }).strict(),

--- a/plugins/tasks/shell/shell.test.tsx
+++ b/plugins/tasks/shell/shell.test.tsx
@@ -51,6 +51,8 @@ const project = {
   color: "blue",
   folderId: FOLDER_ID,
   linkedBbProjectId: null,
+  syncStorePath: null,
+  syncRole: "source",
   createdAt: "2026-07-15T00:00:00.000Z",
 };
 

--- a/plugins/tasks/skills/tasks/SKILL.md
+++ b/plugins/tasks/skills/tasks/SKILL.md
@@ -155,6 +155,62 @@ shows the live status, title, and priority, opens the task in the thread
 side panel, and links to the full Tasks app. Emit one directive per line;
 each renders its own card.
 
+## Sync a project across bb instances
+
+Each bb instance keeps its own task database, so two hosts running bb hold two
+unrelated boards. `bb tasks sync` converges them through a tracked file in a
+git repository. Each board stays canonical; the file is the convergence point.
+
+1. Configure the store once per project. A relative path resolves against the
+   invoking directory, so keep it inside the repository both instances hold:
+
+   ```sh
+   bb tasks project update AGT --sync-store record/agt.json
+   ```
+
+2. Export on the instance where the work happened, then commit and push the
+   store with the rest of the repository:
+
+   ```sh
+   bb tasks sync export --project AGT
+   ```
+
+   Export writes the JSON store and one `<KEY>.md` per task beside it, and
+   refuses to write an empty board over an existing record.
+
+3. Pull the repository on the other instance and import there. Import is a dry
+   run until `--apply`:
+
+   ```sh
+   bb tasks sync import --project AGT
+   bb tasks sync import --project AGT --apply
+   ```
+
+   Import creates missing tasks with the same keys, updates changed fields, and
+   appends notes this board has not seen. It matches notes by body text, so
+   running it twice changes nothing the second time and it never edits or
+   deletes a note. It refuses a field update when the local task changed after
+   the export and reports it; rerun with `--force` to overwrite.
+
+4. Report drift with `check`, which exits 2 when it finds any:
+
+   ```sh
+   bb tasks sync check --project AGT
+   ```
+
+   `MISSING` and `BEHIND` are fixed by importing here, `AHEAD` and `UNTRACKED`
+   by exporting from here, and `DRIFT` needs a decision about which side is
+   right. Because it exits non-zero, schedule it as an automation instead of
+   reading its output by hand.
+
+An instance that cannot push the record back is a normal configuration: set
+`bb tasks project update AGT --sync-role mirror`. A mirror imports only,
+`export` refuses, and `check` names the local edits that cannot travel back.
+
+The plugin's own audit comments carry a `systemEvent` and never travel; each
+instance keeps its own. Labels, attachments, and sub-task hierarchy are not
+synced.
+
 ## Invariants
 
 - Valid task statuses are `backlog`, `todo`, `in_progress`, `in_review`,

--- a/plugins/tasks/sync/plan.ts
+++ b/plugins/tasks/sync/plan.ts
@@ -1,0 +1,232 @@
+import {
+  SYNC_STORE_VERSION,
+  SYNCED_TASK_FIELDS,
+  type SyncComment,
+  type SyncStore,
+  type SyncTask,
+  type SyncedTaskField,
+} from "./store-file";
+
+/** One task as it exists on the local board, with sync-relevant fields only. */
+export interface BoardTask {
+  id: string;
+  key: string;
+  number: number;
+  title: string;
+  status: SyncTask["status"];
+  priority: SyncTask["priority"];
+  description: string;
+  dueDate: string | null;
+  updatedAt: string;
+  /** User and agent comments only; plugin audit rows are excluded upstream. */
+  comments: SyncComment[];
+}
+
+export type ImportAction =
+  | { kind: "create"; key: string; task: SyncTask }
+  | {
+      kind: "update";
+      key: string;
+      taskId: string;
+      fields: SyncedTaskField[];
+      task: SyncTask;
+    }
+  | { kind: "comment"; key: string; taskId: string; comment: SyncComment }
+  | {
+      kind: "conflict";
+      key: string;
+      taskId: string;
+      fields: SyncedTaskField[];
+      boardUpdatedAt: string;
+      storeUpdatedAt: string;
+    };
+
+export type DriftClass = "MISSING" | "DRIFT" | "AHEAD" | "BEHIND" | "UNTRACKED";
+
+export interface DriftEntry {
+  drift: DriftClass;
+  key: string;
+  detail: string;
+}
+
+export function buildSyncStore(
+  project: { prefix: string; name: string },
+  tasks: readonly BoardTask[],
+  generatedAt: string,
+): SyncStore {
+  return {
+    version: SYNC_STORE_VERSION,
+    generatedAt,
+    project: { prefix: project.prefix, name: project.name },
+    tasks: [...tasks]
+      .sort((left, right) => left.number - right.number)
+      .map((task) => ({
+        key: task.key,
+        number: task.number,
+        title: task.title,
+        status: task.status,
+        priority: task.priority,
+        description: task.description,
+        dueDate: task.dueDate,
+        updatedAt: task.updatedAt,
+        comments: task.comments,
+      })),
+  };
+}
+
+function fieldValue(
+  task: Pick<SyncTask, SyncedTaskField>,
+  field: SyncedTaskField,
+): string {
+  return task[field] ?? "";
+}
+
+function changedFields(board: BoardTask, stored: SyncTask): SyncedTaskField[] {
+  return SYNCED_TASK_FIELDS.filter(
+    (field) => fieldValue(board, field) !== fieldValue(stored, field),
+  );
+}
+
+function missingComments(board: BoardTask, stored: SyncTask): SyncComment[] {
+  const seen = new Set(board.comments.map((comment) => comment.hash));
+  return stored.comments.filter((comment) => !seen.has(comment.hash));
+}
+
+function extraComments(board: BoardTask, stored: SyncTask): SyncComment[] {
+  const seen = new Set(stored.comments.map((comment) => comment.hash));
+  return board.comments.filter((comment) => !seen.has(comment.hash));
+}
+
+function byKey(tasks: readonly BoardTask[]): Map<string, BoardTask> {
+  return new Map(tasks.map((task) => [task.key.toUpperCase(), task]));
+}
+
+/**
+ * What an import would do. Field updates are refused when the board's task was
+ * updated after the store was exported, because the plugin cannot tell which
+ * side is right and silent loss is worse than a stall. That comparison trusts
+ * two hosts' wall clocks, so it is a guard against the common case rather than
+ * a total order; `overwriteNewerBoardEdits` is the caller's way to say the
+ * store wins anyway. Comments always append: matching them by body hash means
+ * import never edits or deletes a note, so running it twice changes nothing
+ * the second time.
+ */
+export function planImport(
+  store: SyncStore,
+  board: readonly BoardTask[],
+  options: { overwriteNewerBoardEdits: boolean },
+): ImportAction[] {
+  const local = byKey(board);
+  const actions: ImportAction[] = [];
+  for (const stored of store.tasks) {
+    const existing = local.get(stored.key.toUpperCase());
+    if (!existing) {
+      actions.push({ kind: "create", key: stored.key, task: stored });
+      continue;
+    }
+    const fields = changedFields(existing, stored);
+    if (fields.length > 0) {
+      const boardIsNewer = existing.updatedAt > stored.updatedAt;
+      actions.push(
+        boardIsNewer && !options.overwriteNewerBoardEdits
+          ? {
+              kind: "conflict",
+              key: stored.key,
+              taskId: existing.id,
+              fields,
+              boardUpdatedAt: existing.updatedAt,
+              storeUpdatedAt: stored.updatedAt,
+            }
+          : {
+              kind: "update",
+              key: stored.key,
+              taskId: existing.id,
+              fields,
+              task: stored,
+            },
+      );
+    }
+    for (const comment of missingComments(existing, stored)) {
+      actions.push({
+        kind: "comment",
+        key: stored.key,
+        taskId: existing.id,
+        comment,
+      });
+    }
+  }
+  return actions;
+}
+
+/**
+ * Drift between the store and the local board, in the five classes that need
+ * different responses: MISSING and BEHIND are fixed by importing here, AHEAD
+ * and UNTRACKED by exporting from here, and DRIFT needs a human to decide
+ * which side is right.
+ */
+export function checkDrift(
+  store: SyncStore,
+  board: readonly BoardTask[],
+): DriftEntry[] {
+  const local = byKey(board);
+  const entries: DriftEntry[] = [];
+  const storedKeys = new Set<string>();
+  for (const stored of store.tasks) {
+    storedKeys.add(stored.key.toUpperCase());
+    const existing = local.get(stored.key.toUpperCase());
+    if (!existing) {
+      entries.push({
+        drift: "MISSING",
+        key: stored.key,
+        detail: "in the store but not on this board — import here",
+      });
+      continue;
+    }
+    for (const field of changedFields(existing, stored)) {
+      entries.push({
+        drift: "DRIFT",
+        key: stored.key,
+        detail: `${field}: board=${summarize(fieldValue(existing, field))} store=${summarize(fieldValue(stored, field))}`,
+      });
+    }
+    const behind = missingComments(existing, stored).length;
+    if (behind > 0) {
+      entries.push({
+        drift: "BEHIND",
+        key: stored.key,
+        detail: `${behind} note(s) in the store are not on this board — import here`,
+      });
+    }
+    const ahead = extraComments(existing, stored).length;
+    if (ahead > 0) {
+      entries.push({
+        drift: "AHEAD",
+        key: stored.key,
+        detail: `${ahead} note(s) on this board are not in the store — export from here`,
+      });
+    }
+  }
+  for (const task of [...board].sort(
+    (left, right) => left.number - right.number,
+  )) {
+    if (storedKeys.has(task.key.toUpperCase())) continue;
+    entries.push({
+      drift: "UNTRACKED",
+      key: task.key,
+      detail: "on this board but not in the store — export from here",
+    });
+  }
+  return entries;
+}
+
+/** Drift classes that only an export from this instance can resolve. */
+export function needsExport(entry: DriftEntry): boolean {
+  return entry.drift === "AHEAD" || entry.drift === "UNTRACKED";
+}
+
+function summarize(value: string): string {
+  const oneLine = value.replace(/\s+/gu, " ").trim();
+  return JSON.stringify(
+    oneLine.length > 40 ? `${oneLine.slice(0, 40)}…` : oneLine,
+  );
+}

--- a/plugins/tasks/sync/store-file.ts
+++ b/plugins/tasks/sync/store-file.ts
@@ -1,0 +1,147 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+
+import { TASK_PRIORITIES, TASK_STATUSES } from "../shared/contract";
+
+/**
+ * On-disk format of a project's sync store. It is a tracked file in a git
+ * repository, and git is the transport: export on the instance where the work
+ * happened, commit, pull elsewhere, import there. The board stays canonical on
+ * each instance; this file is the convergence point between them.
+ */
+export const SYNC_STORE_VERSION = 1;
+
+/**
+ * A comment as the store carries it. `hash` is derived from the trimmed body
+ * and is the only identity sync uses: comment ids are per instance, so
+ * matching on them duplicates every note on every import. Hashing the body
+ * makes import idempotent and append-only.
+ *
+ * Only `user` and `agent` comments travel. The plugin's own audit rows carry a
+ * non-null `systemEvent` and stay on the instance that produced them.
+ */
+const syncCommentSchema = z
+  .object({
+    hash: z.string().min(1),
+    kind: z.enum(["user", "agent"]),
+    authorName: z.string().min(1),
+    createdAt: z.string().min(1),
+    body: z.string(),
+  })
+  .strict();
+
+const syncTaskSchema = z
+  .object({
+    key: z.string().min(1),
+    number: z.number().int().positive(),
+    title: z.string(),
+    status: z.enum(TASK_STATUSES),
+    priority: z.enum(TASK_PRIORITIES),
+    description: z.string(),
+    dueDate: z.string().nullable(),
+    /**
+     * `updatedAt` from the exporting board. Import compares it against the
+     * local task's `updatedAt` to detect a local edit made after the export,
+     * which it refuses instead of overwriting.
+     */
+    updatedAt: z.string().min(1),
+    comments: z.array(syncCommentSchema),
+  })
+  .strict();
+
+export const syncStoreSchema = z
+  .object({
+    version: z.literal(SYNC_STORE_VERSION),
+    generatedAt: z.string().min(1),
+    project: z
+      .object({ prefix: z.string().min(1), name: z.string().min(1) })
+      .strict(),
+    tasks: z.array(syncTaskSchema),
+  })
+  .strict();
+
+export type SyncStore = z.infer<typeof syncStoreSchema>;
+export type SyncTask = z.infer<typeof syncTaskSchema>;
+export type SyncComment = z.infer<typeof syncCommentSchema>;
+
+/** Stable identity of a comment body, shared by every instance. */
+export function commentHash(body: string): string {
+  return createHash("sha256")
+    .update(body.trim(), "utf8")
+    .digest("hex")
+    .slice(0, 16);
+}
+
+/** The synced task fields, in the order reports list them. */
+export const SYNCED_TASK_FIELDS = [
+  "title",
+  "status",
+  "priority",
+  "description",
+  "dueDate",
+] as const;
+
+export type SyncedTaskField = (typeof SYNCED_TASK_FIELDS)[number];
+
+export function parseSyncStore(text: string): SyncStore {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`sync store is not valid JSON: ${message}`);
+  }
+  const result = syncStoreSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new Error(
+      `sync store does not match version ${SYNC_STORE_VERSION}: ${result.error.issues
+        .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+        .join("; ")}`,
+    );
+  }
+  return result.data;
+}
+
+export function serializeSyncStore(store: SyncStore): string {
+  return `${JSON.stringify(store, null, 1)}\n`;
+}
+
+/**
+ * Human-readable rendering of one task, written next to the JSON store so the
+ * record is reviewable in a pull request. It is generated output: the board is
+ * the source of truth and hand edits are lost on the next export.
+ */
+export function renderTaskMarkdown(
+  task: SyncTask,
+  storeFileName: string,
+): string {
+  const lines = [
+    `# ${task.key} — ${task.title}`,
+    "",
+    "| | |",
+    "| --- | --- |",
+    `| Status | \`${task.status}\` |`,
+    `| Priority | ${task.priority} |`,
+    `| Due | ${task.dueDate ?? "-"} |`,
+    `| Notes | ${task.comments.length} |`,
+    "",
+    `> Generated from \`${storeFileName}\` by \`bb tasks sync export\`. Edit the`,
+    "> board, then export again. Do not hand-edit this file.",
+    "",
+    "---",
+    "",
+    task.description.trim() || "_(no description)_",
+  ];
+  if (task.comments.length > 0) {
+    lines.push("", "---", "", "## Working record", "");
+    for (const [index, comment] of task.comments.entries()) {
+      lines.push(
+        `### Note ${index + 1} — ${comment.authorName}`,
+        "",
+        comment.body.trim(),
+        "",
+      );
+    }
+  }
+  return `${lines.join("\n").trimEnd()}\n`;
+}

--- a/plugins/tasks/sync/sync.test.ts
+++ b/plugins/tasks/sync/sync.test.ts
@@ -1,0 +1,358 @@
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { createFakePluginHost } from "@get-bb/plugin-sdk/testing";
+import { describe, expect, it } from "vitest";
+
+import plugin from "../server";
+import { checkDrift, planImport, type BoardTask } from "./plan";
+import { commentHash, parseSyncStore, type SyncTask } from "./store-file";
+
+/**
+ * bb.sdk.files backed by the real filesystem. Sync reaches the invoking
+ * machine's disk only through this SDK, so both fake instances share one
+ * directory and it stands in for the git checkout they both hold.
+ */
+function localFilesSdk() {
+  return {
+    read: async ({ path }: { path: string }) => {
+      const content = await readFile(path, "utf8").catch(() => null);
+      if (content === null) throw new Error(`Path does not exist: ${path}`);
+      return {
+        path,
+        content,
+        contentEncoding: "utf8" as const,
+        sizeBytes: Buffer.byteLength(content),
+      };
+    },
+    write: async ({
+      path,
+      content,
+      contentEncoding,
+      createParents,
+    }: {
+      path: string;
+      content: string;
+      contentEncoding?: "utf8" | "base64";
+      createParents?: boolean;
+    }) => {
+      if (createParents) await mkdir(dirname(path), { recursive: true });
+      await writeFile(path, Buffer.from(content, contentEncoding ?? "utf8"));
+      return { outcome: "written" as const, path };
+    },
+  };
+}
+
+/** One bb instance with its own board and its own view of the shared files. */
+async function instance(cwd: string) {
+  const { bb, harness } = createFakePluginHost({
+    pluginId: "tasks",
+    sdk: { files: localFilesSdk() },
+  });
+  await plugin(bb);
+  return {
+    harness,
+    async cli(argv: string[]) {
+      return harness.runCli(argv, { cwd });
+    },
+    async ok(argv: string[]) {
+      const result = await harness.runCli(argv, { cwd });
+      expect(result, `${argv.join(" ")}\n${result.stderr}`).toMatchObject({
+        exitCode: 0,
+      });
+      return result.stdout;
+    },
+    dispose: () => harness.dispose(),
+  };
+}
+
+const STORE = "record/agt.json";
+
+async function seedProject(
+  board: Awaited<ReturnType<typeof instance>>,
+  extra: string[] = [],
+): Promise<void> {
+  await board.ok([
+    "project",
+    "create",
+    "--name",
+    "Agents",
+    "--prefix",
+    "AGT",
+    "--sync-store",
+    STORE,
+    ...extra,
+  ]);
+}
+
+describe("bb tasks sync", () => {
+  it("converges a mirror instance through the store and stays idempotent", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "bb-tasks-sync-"));
+    const source = await instance(directory);
+    const mirror = await instance(directory);
+    try {
+      await seedProject(source);
+      await source.ok([
+        "create",
+        "--project",
+        "AGT",
+        "--title",
+        "Fleet index",
+        "--description",
+        "Catalogue every host.",
+        "--priority",
+        "high",
+      ]);
+      await source.ok([
+        "create",
+        "--project",
+        "AGT",
+        "--title",
+        "Retire the old VM",
+      ]);
+      await source.ok(["comment", "AGT-1", "--body", "Counted seven hosts."]);
+      // Writes a plugin audit comment locally. It must not travel.
+      await source.ok(["update", "AGT-1", "--status", "in_progress"]);
+
+      await source.ok(["sync", "export", "--project", "AGT"]);
+      const record = parseSyncStore(
+        await readFile(join(directory, STORE), "utf8"),
+      );
+      expect(record.project.prefix).toBe("AGT");
+      expect(record.tasks.map((task) => task.key)).toEqual(["AGT-1", "AGT-2"]);
+      expect(record.tasks[0]?.status).toBe("in_progress");
+      expect(record.tasks[0]?.comments.map((note) => note.body)).toEqual([
+        "Counted seven hosts.",
+      ]);
+      // The rendered record ships beside the JSON for review in a pull request.
+      expect(
+        await readFile(join(directory, "record/AGT-1.md"), "utf8"),
+      ).toContain("# AGT-1 — Fleet index");
+
+      await seedProject(mirror, ["--sync-role", "mirror"]);
+
+      // Dry run by default: it reports and changes nothing.
+      expect(await mirror.ok(["sync", "import", "--project", "AGT"])).toContain(
+        "would  CREATE",
+      );
+      expect(await mirror.ok(["list", "--project", "AGT"])).toContain(
+        "No tasks.",
+      );
+
+      await mirror.ok(["sync", "import", "--project", "AGT", "--apply"]);
+      // Keys survive the crossing: numbering comes from the store, not from
+      // this instance's counter.
+      const imported = JSON.parse(
+        await mirror.ok(["show", "AGT-1", "--json"]),
+      ) as {
+        task: { key: string; status: string; priority: string };
+        comments: { body: string; kind: string; systemEvent: string | null }[];
+      };
+      expect(imported.task).toMatchObject({
+        key: "AGT-1",
+        status: "in_progress",
+        priority: "high",
+      });
+      expect(
+        imported.comments
+          .filter((comment) => comment.systemEvent === null)
+          .map((comment) => comment.body),
+      ).toEqual(["Counted seven hosts."]);
+      // A later status change crosses as a field update, and the audit row
+      // the mirror writes for it stays local — the failure that made both
+      // boards drift permanently was propagating those rows.
+      await source.ok(["update", "AGT-2", "--status", "done"]);
+      await source.ok(["sync", "export", "--project", "AGT"]);
+      await mirror.ok(["sync", "import", "--project", "AGT", "--apply"]);
+      const afterStatus = JSON.parse(
+        await mirror.ok(["show", "AGT-2", "--json"]),
+      ) as {
+        task: { status: string };
+        comments: { systemEvent: string | null }[];
+      };
+      expect(afterStatus.task.status).toBe("done");
+      expect(
+        afterStatus.comments.some(
+          (comment) => comment.systemEvent === "status_changed",
+        ),
+      ).toBe(true);
+
+      // Both boards agree, including the audit rows each one generated.
+      expect(await mirror.ok(["sync", "check", "--project", "AGT"])).toContain(
+        "drift: 0",
+      );
+      expect(await source.ok(["sync", "check", "--project", "AGT"])).toContain(
+        "drift: 0",
+      );
+
+      // Running import again changes nothing: notes match by body, so the
+      // second pass finds none missing.
+      expect(
+        await mirror.ok(["sync", "import", "--project", "AGT", "--apply"]),
+      ).toContain("0 change(s) applied");
+
+      // A note added on the mirror cannot travel back, and check says so
+      // rather than failing.
+      await mirror.ok(["comment", "AGT-2", "--body", "Mirror-only note."]);
+      const drifted = await mirror.cli(["sync", "check", "--project", "AGT"]);
+      expect(drifted.exitCode).toBe(2);
+      expect(drifted.stdout).toContain("AHEAD");
+      expect(drifted.stdout).toContain("sync mirror");
+      expect(drifted.stdout).toContain("cannot be exported from this mirror");
+
+      // And the mirror refuses to write the shared record at all.
+      const refused = await mirror.cli(["sync", "export", "--project", "AGT"]);
+      expect(refused.exitCode).toBe(1);
+      expect(refused.stderr).toContain("is a sync mirror");
+    } finally {
+      await source.dispose();
+      await mirror.dispose();
+    }
+  });
+
+  it("refuses to overwrite the record from a board with no tasks", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "bb-tasks-sync-"));
+    const board = await instance(directory);
+    try {
+      await seedProject(board);
+      const result = await board.cli(["sync", "export", "--project", "AGT"]);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("refusing to overwrite");
+      await expect(readFile(join(directory, STORE), "utf8")).rejects.toThrow();
+    } finally {
+      await board.dispose();
+    }
+  });
+
+  it("refuses a field update when the local edit is newer, until --force", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "bb-tasks-sync-"));
+    const source = await instance(directory);
+    const mirror = await instance(directory);
+    try {
+      await seedProject(source);
+      await source.ok([
+        "create",
+        "--project",
+        "AGT",
+        "--title",
+        "Rotate the deploy key",
+      ]);
+      await source.ok(["sync", "export", "--project", "AGT"]);
+      await seedProject(mirror, ["--sync-role", "mirror"]);
+      await mirror.ok(["sync", "import", "--project", "AGT", "--apply"]);
+
+      // The mirror edits the title after the export, so the store is stale
+      // for that field and importing would silently lose the local edit.
+      await mirror.ok([
+        "update",
+        "AGT-1",
+        "--title",
+        "Rotate both deploy keys",
+      ]);
+      const conflicted = await mirror.cli([
+        "sync",
+        "import",
+        "--project",
+        "AGT",
+        "--apply",
+      ]);
+      expect(conflicted.exitCode).toBe(2);
+      expect(conflicted.stdout).toContain("CONFLICT");
+      expect(conflicted.stdout).toContain("1 conflict(s) refused");
+      expect(await mirror.ok(["show", "AGT-1", "--json"])).toContain(
+        "Rotate both deploy keys",
+      );
+
+      const forced = await mirror.ok([
+        "sync",
+        "import",
+        "--project",
+        "AGT",
+        "--apply",
+        "--force",
+      ]);
+      expect(forced).toContain("UPDATE");
+      expect(await mirror.ok(["show", "AGT-1", "--json"])).toContain(
+        "Rotate the deploy key",
+      );
+    } finally {
+      await source.dispose();
+      await mirror.dispose();
+    }
+  });
+
+  it("classifies every drift class from the store and the board", () => {
+    const note = (body: string) => ({
+      hash: commentHash(body),
+      kind: "user" as const,
+      authorName: "cli",
+      createdAt: "2026-08-23T10:00:00.000Z",
+      body,
+    });
+    const stored = (
+      key: string,
+      overrides: Partial<SyncTask> = {},
+    ): SyncTask => ({
+      key,
+      number: Number(key.split("-")[1]),
+      title: `Task ${key}`,
+      status: "todo",
+      priority: "none",
+      description: "",
+      dueDate: null,
+      updatedAt: "2026-08-23T10:00:00.000Z",
+      comments: [],
+      ...overrides,
+    });
+    const onBoard = (task: SyncTask, id: string): BoardTask => ({
+      ...task,
+      id,
+    });
+
+    const record = {
+      version: 1 as const,
+      generatedAt: "2026-08-23T11:00:00.000Z",
+      project: { prefix: "AGT", name: "Agents" },
+      tasks: [
+        stored("AGT-1", { comments: [note("Shared note.")] }),
+        stored("AGT-2", { priority: "high" }),
+        stored("AGT-3", { comments: [note("Only in the store.")] }),
+        stored("AGT-4"),
+      ],
+    };
+    const board: BoardTask[] = [
+      onBoard(
+        stored("AGT-1", {
+          comments: [note("Shared note."), note("Only on the board.")],
+        }),
+        "board-1",
+      ),
+      onBoard(stored("AGT-2"), "board-2"),
+      onBoard(stored("AGT-3"), "board-3"),
+      onBoard(stored("AGT-9"), "board-9"),
+    ];
+
+    expect(
+      checkDrift(record, board).map((entry) => [entry.drift, entry.key]),
+    ).toEqual([
+      ["AHEAD", "AGT-1"],
+      ["DRIFT", "AGT-2"],
+      ["BEHIND", "AGT-3"],
+      ["MISSING", "AGT-4"],
+      ["UNTRACKED", "AGT-9"],
+    ]);
+
+    // The plan mirrors the classification: create what is missing, update the
+    // changed field, append the unseen note, and leave the board's extra note
+    // and untracked task alone.
+    expect(
+      planImport(record, board, { overwriteNewerBoardEdits: false }).map(
+        (action) => [action.kind, action.key],
+      ),
+    ).toEqual([
+      ["update", "AGT-2"],
+      ["comment", "AGT-3"],
+      ["create", "AGT-4"],
+    ]);
+  });
+});

--- a/plugins/tasks/views/activity/activity.test.ts
+++ b/plugins/tasks/views/activity/activity.test.ts
@@ -60,6 +60,7 @@ describe("commentByline", () => {
     threadTitle: "Fix the login bug",
     provider: { id: "codex", name: "Codex", logoUrl: null },
     body: "Done",
+    systemEvent: null,
     notifiedCount: 0,
     createdAt: "2026-07-15T00:00:00.000Z",
   };

--- a/plugins/tasks/views/activity/comment-author.test.tsx
+++ b/plugins/tasks/views/activity/comment-author.test.tsx
@@ -16,6 +16,7 @@ const base: DisplayComment = {
   threadTitle: "Fix the login bug",
   provider: { id: "codex", name: "Codex", logoUrl: null },
   body: "Done",
+  systemEvent: null,
   notifiedCount: 0,
   createdAt: "2026-07-15T00:00:00.000Z",
 };

--- a/plugins/tasks/views/activity/task-activity.test.tsx
+++ b/plugins/tasks/views/activity/task-activity.test.tsx
@@ -74,6 +74,7 @@ function comment(
     threadId,
     threadTitle,
     body: "Reply",
+    systemEvent: null,
     notifiedCount: 0,
     createdAt: "2026-07-15T00:00:00.000Z",
   };

--- a/plugins/tasks/views/detail/rail.test.tsx
+++ b/plugins/tasks/views/detail/rail.test.tsx
@@ -35,6 +35,8 @@ function projectRow(linkedBbProjectId: string | null) {
     color: "blue",
     folderId: null,
     linkedBbProjectId,
+    syncStorePath: null,
+    syncRole: "source",
     createdAt: "2026-07-15T00:00:00.000Z",
   };
 }

--- a/plugins/tasks/views/detail/threads.test.tsx
+++ b/plugins/tasks/views/detail/threads.test.tsx
@@ -70,6 +70,8 @@ function detailRpc(overrides: Record<string, unknown> = {}) {
           color: "blue",
           folderId: null,
           linkedBbProjectId: null,
+          syncStorePath: null,
+          syncRole: "source",
           createdAt: "2026-07-15T00:00:00.000Z",
         },
       ],

--- a/plugins/tasks/views/list/list-preference.persistence.test.tsx
+++ b/plugins/tasks/views/list/list-preference.persistence.test.tsx
@@ -46,6 +46,8 @@ const projectA = {
   color: "blue",
   folderId: null,
   linkedBbProjectId: null,
+  syncStorePath: null,
+  syncRole: "source",
   createdAt: "2026-07-15T00:00:00.000Z",
 };
 
@@ -57,6 +59,8 @@ const projectB = {
   color: "green",
   folderId: null,
   linkedBbProjectId: null,
+  syncStorePath: null,
+  syncRole: "source",
   createdAt: "2026-07-15T00:00:00.000Z",
 };
 

--- a/plugins/tasks/views/list/mobile-layout.test.tsx
+++ b/plugins/tasks/views/list/mobile-layout.test.tsx
@@ -36,6 +36,8 @@ const project = {
   color: "blue",
   folderId: null,
   linkedBbProjectId: null,
+  syncStorePath: null,
+  syncRole: "source",
   createdAt: "2026-07-15T00:00:00.000Z",
 };
 

--- a/plugins/tasks/views/list/row-metadata.test.tsx
+++ b/plugins/tasks/views/list/row-metadata.test.tsx
@@ -42,6 +42,8 @@ const project = {
   color: "blue",
   folderId: null,
   linkedBbProjectId: null,
+  syncStorePath: null,
+  syncRole: "source",
   createdAt: "2026-07-15T00:00:00.000Z",
 };
 

--- a/plugins/tasks/views/list/row.test.tsx
+++ b/plugins/tasks/views/list/row.test.tsx
@@ -40,6 +40,8 @@ const project = {
   color: "blue",
   folderId: null,
   linkedBbProjectId: null,
+  syncStorePath: null,
+  syncRole: "source",
   createdAt: "2026-07-15T00:00:00.000Z",
 };
 

--- a/plugins/tasks/views/list/sorting.test.tsx
+++ b/plugins/tasks/views/list/sorting.test.tsx
@@ -47,6 +47,8 @@ const project = {
   color: "blue",
   folderId: null,
   linkedBbProjectId: null,
+  syncStorePath: null,
+  syncRole: "source",
   createdAt: "2026-07-15T00:00:00.000Z",
 };
 

--- a/plugins/tasks/views/manage/manage.test.tsx
+++ b/plugins/tasks/views/manage/manage.test.tsx
@@ -52,6 +52,8 @@ const project = {
   color: "blue",
   folderId: null,
   linkedBbProjectId: null,
+  syncStorePath: null,
+  syncRole: "source",
   createdAt: "2026-07-15T00:00:00.000Z",
 };
 


### PR DESCRIPTION
## What was wrong

bb Tasks keeps tasks in each instance's own SQLite database and nothing syncs them, so two hosts running bb hold two unrelated boards under the same project prefix. Observed on 2026-08-23: one host held AGT-1 to AGT-7 with 28 notes while the other had no AGT project at all. A task closed on one host stays open on the other, and neither host can tell. The root cause is that the board has no shared record; a script bolted on beside the plugin proved the shape of the fix but had to identify the plugin's own audit comments by matching a body prefix, because nothing marked them structurally.

## What changed

- `plugins/tasks/sync/store-file.ts` defines the on-disk store: a versioned JSON file plus a rendered `<KEY>.md` per task. Comment identity is a 16-hex hash of the trimmed body, never an id, because ids are per instance.
- `plugins/tasks/sync/plan.ts` holds the pure logic: build the store from a board, plan an import, classify drift.
- `plugins/tasks/cli/sync.ts` adds `bb tasks sync export|import|check`. `import` is a dry run until `--apply`. It creates missing tasks at the store's task number so a key means the same task on every instance, updates changed fields, and appends notes the local board has not seen. It refuses a field update when the local task changed after the export and reports it; `--force` overwrites. `check` reports `MISSING`, `DRIFT`, `AHEAD`, `BEHIND`, and `UNTRACKED`, and exits `2` on drift. `export` refuses to write an empty board over an existing record. Store files are read and written on the invoking machine through `bb.sdk.files`, so `--machine` works like the other file-taking commands.
- Comments gain a `systemEvent` column and contract field, set on every audit comment the plugin writes (`status_changed`, `priority_changed`, `due_changed`, `labels_changed`, `dispatched`, `thread_finished`). Sync excludes those rows structurally. Propagating them made both boards drift permanently, because each import generated fresh ones on the far side. `kind: "system"` already narrowed this, but only by convention; the field is the predicate sync now depends on.
- Projects gain `syncStorePath` and `syncRole`, set with `bb tasks project create|update --sync-store <path> [--no-sync-store] --sync-role source|mirror` and shown by `project show`. A `mirror` is a supported configuration, not an error: it is the host holding a read-only deploy key on purpose, so `export` refuses there and `check` names the local edits that cannot travel back.
- `db/store.ts` accepts an explicit task `number` on create (sync only) and moves `next_task_number` forward past it.
- Docs updated in the same change: `plugins/tasks/skills/tasks/SKILL.md`, `packages/templates/src/templates/bb-guide-plugins.md`, the `bb-cli` builtin skill, and `docs/configuration.md`.

No host-daemon wire change: this touches the plugin's own database and RPC contract, not `packages/host-daemon-contract`. `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

Out of scope by design: automatic background sync, conflict resolution beyond refuse-and-report, and syncing labels, attachments, or sub-task hierarchy.

## How you verified

`plugins/tasks/sync/sync.test.ts` runs two independent plugin instances, each with its own database, over one shared directory that stands in for the git checkout. It covers convergence, key preservation, import idempotence, audit-comment exclusion in both directions, the mirror role (export refused, unsyncable local edits reported, exit 2), the empty-board refusal, and the newer-local-edit refusal with `--force`. A unit test over `checkDrift` and `planImport` pins all five drift classes.

```
pnpm exec turbo run typecheck            # 75 successful
pnpm exec turbo run build --filter=bb-plugin-tasks
cd plugins/tasks && pnpm exec vitest run --config vitest.config.ts --project bb-plugin-tasks
                                         # 15 files, 136 tests passed
```

Also exercised live against a real dev server, host daemon, and on-disk database: created a project and two tasks, changed a status, exported (the audit comment was excluded), hand-edited the store to stand in for a far instance, then `check` reported `BEHIND`/`DRIFT`/`MISSING` and exited 2, `import` dry-ran, `import --apply` applied three changes, `check` returned `drift: 0`, and a second `--apply` reported `0 change(s) applied`. Switching the project to `--sync-role mirror` made `export` exit 1 and `check` report the mirror-only note as unsyncable. A fresh project pointed at the same store refused to overwrite it.

Not verified: the two-real-host test across the `bb-agents` VM. That host runs released bb `0.39.0`, whose Tasks plugin has no `sync` command (`bb tasks sync --help` returns `unknown command: sync`), so a genuine cross-host run needs this change released or a source build deployed there.

The plugin's jsdom test files fail in this environment before any test code runs, at `vitest.setup.ts:41` with `SecurityError: Cannot initialize local storage without a --localstorage-file path`. That is pre-existing here and unrelated to this change; their project fixtures were still updated for the two new fields.

Refs TP-15.

> AGENT GENERATED
