### PR TITLE
Fix model picker icons and isolate native ABI repairs

### DIFF
--- a/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.test.tsx
@@ -69,6 +69,10 @@ const providerOptions: readonly ProviderPickerOption[] = [
   { value: "claude-code", label: "Claude Code", brandPrefix: "Claude " },
 ];
 
+function ProviderMaskIcon({ className }: { className?: string }) {
+  return <span className={className} data-testid="provider-mask-icon" />;
+}
+
 const codexModels: readonly PickerOption<string>[] = [
   { value: "gpt-5.5", label: "GPT-5.5" },
 ];
@@ -247,6 +251,19 @@ afterEach(() => {
 });
 
 describe("ModelReasoningPicker", () => {
+  it("gives a non-SVG provider mark the same 16px trigger size as button SVGs", () => {
+    renderPicker({
+      pickerProviderOptions: [
+        { ...providerOptions[0], icon: ProviderMaskIcon },
+        providerOptions[1],
+      ],
+    });
+
+    expect(screen.getByTestId("provider-mask-icon").classList).toContain(
+      "size-4",
+    );
+  });
+
   it("keeps a failed provider tab visible with its provider-plugin error", () => {
     renderPicker({
       modelOptions: [],

--- a/apps/app/src/components/pickers/ModelReasoningPicker.tsx
+++ b/apps/app/src/components/pickers/ModelReasoningPicker.tsx
@@ -924,7 +924,7 @@ export function ModelReasoningPicker({
         {modelIsLoading ? (
           <>
             {TriggerIcon ? (
-              <TriggerIcon className="size-3.5 shrink-0" />
+              <TriggerIcon className="size-4 shrink-0" />
             ) : (
               <Icon
                 name="Spinner"
@@ -950,7 +950,7 @@ export function ModelReasoningPicker({
             className="size-3.5 shrink-0 fill-current text-subtle-foreground"
           />
         ) : TriggerIcon ? (
-          <TriggerIcon className="size-3.5 shrink-0" />
+          <TriggerIcon className="size-4 shrink-0" />
         ) : null}
         {modelIsLoading ? null : (
           <>

--- a/packages/scripts/test/ensure-native-modules.test.mjs
+++ b/packages/scripts/test/ensure-native-modules.test.mjs
@@ -1,4 +1,15 @@
 import { spawnSync } from "node:child_process";
+import {
+  linkSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   ensureNativeModules,
@@ -10,7 +21,10 @@ const scriptUrl = new URL(
   import.meta.url,
 ).href;
 
-function createBetterSqliteRequire(initialError) {
+function createBetterSqliteRequire(
+  initialError,
+  packageJsonPath = "/tmp/fake-node-modules/better-sqlite3/package.json",
+) {
   const state = {
     constructorError: initialError,
     constructorCalls: 0,
@@ -35,7 +49,7 @@ function createBetterSqliteRequire(initialError) {
 
   requireModule.resolve = (request) => {
     if (request === "better-sqlite3/package.json") {
-      return "/tmp/fake-node-modules/better-sqlite3/package.json";
+      return packageJsonPath;
     }
 
     if (request === "prebuild-install/bin.js") {
@@ -120,6 +134,57 @@ describe("ensure-native-modules", () => {
     );
     expect(execFileSync).toHaveBeenCalledTimes(1);
     expect(fake.state.constructorCalls).toBe(2);
+  });
+
+  it("detaches a hardlinked native binary before prebuilt repair", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "bb-native-repair-"));
+    try {
+      const packageJsonPath = join(tempRoot, "better-sqlite3", "package.json");
+      const binaryPath = join(
+        dirname(packageJsonPath),
+        "build",
+        "Release",
+        "better_sqlite3.node",
+      );
+      const otherCheckoutBinaryPath = join(tempRoot, "other-checkout.node");
+      mkdirSync(dirname(binaryPath), { recursive: true });
+      writeFileSync(packageJsonPath, "{}");
+      writeFileSync(otherCheckoutBinaryPath, "abi-137");
+      linkSync(otherCheckoutBinaryPath, binaryPath);
+      expect(statSync(binaryPath).ino).toBe(
+        statSync(otherCheckoutBinaryPath).ino,
+      );
+
+      const abiError = new Error(
+        "The module was compiled against a different NODE_MODULE_VERSION",
+      );
+      const fake = createBetterSqliteRequire(abiError, packageJsonPath);
+      const execFileSync = vi.fn(() => {
+        writeFileSync(binaryPath, "abi-127");
+        fake.clearConstructorError();
+      });
+      const options = createEnsureOptions(fake.requireModule, execFileSync);
+      options.modules = [
+        {
+          name: "better-sqlite3",
+          resolveFrom: "packages/db/package.json",
+          binaryPath: "build/Release/better_sqlite3.node",
+        },
+      ];
+
+      expect(() => ensureNativeModules(options)).not.toThrow();
+
+      expect(readFileSync(binaryPath, "utf8")).toBe("abi-127");
+      expect(readFileSync(otherCheckoutBinaryPath, "utf8")).toBe("abi-137");
+      expect(statSync(binaryPath).ino).not.toBe(
+        statSync(otherCheckoutBinaryPath).ino,
+      );
+      expect(options.log).toHaveBeenCalledWith(
+        "[ensure-native-modules] Detached hardlinked better-sqlite3 binary before repair",
+      );
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
   });
 
   it("accepts a prebuilt binary that loads after the installer exits non-zero", () => {

--- a/scripts/ensure-native-modules.mjs
+++ b/scripts/ensure-native-modules.mjs
@@ -1,12 +1,24 @@
 import { createRequire } from "node:module";
 import { execFileSync } from "node:child_process";
-import { dirname, resolve } from "node:path";
+import {
+  copyFileSync,
+  lstatSync,
+  mkdtempSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+} from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const defaultRepoRoot = resolve(fileURLToPath(import.meta.url), "../..");
 
 const nativeModules = [
-  { name: "better-sqlite3", resolveFrom: "packages/db/package.json" },
+  {
+    name: "better-sqlite3",
+    resolveFrom: "packages/db/package.json",
+    binaryPath: "build/Release/better_sqlite3.node",
+  },
 ];
 
 function formatThrownValue(err) {
@@ -51,10 +63,8 @@ export function verifyNativeModule(name, requireModule) {
 }
 
 function shouldRebuildNativeModule(errorMessage) {
-  return (
-    /NODE_MODULE_VERSION|Could not locate the bindings file|Module did not self-register/.test(
-      errorMessage,
-    )
+  return /NODE_MODULE_VERSION|Could not locate the bindings file|Module did not self-register/.test(
+    errorMessage,
   );
 }
 
@@ -83,16 +93,54 @@ instance.close();`,
   }
 }
 
+function detachHardlinkedBinary(binaryPath) {
+  let binaryStat;
+  try {
+    binaryStat = lstatSync(binaryPath);
+  } catch (err) {
+    if (err && typeof err === "object" && err.code === "ENOENT") {
+      return false;
+    }
+    throw err;
+  }
+
+  if (!binaryStat.isFile() || binaryStat.nlink <= 1) {
+    return false;
+  }
+
+  // pnpm can hardlink this file across worktrees. An installer writes the new
+  // ABI into the existing inode, so every linked checkout changes with it.
+  // Replace this checkout's link with a private copy before the repair starts.
+  const tempDir = mkdtempSync(join(dirname(binaryPath), ".bb-native-detach-"));
+  const detachedPath = join(tempDir, basename(binaryPath));
+  let originalWasUnlinked = false;
+  try {
+    copyFileSync(binaryPath, detachedPath);
+    unlinkSync(binaryPath);
+    originalWasUnlinked = true;
+    renameSync(detachedPath, binaryPath);
+    originalWasUnlinked = false;
+  } catch (err) {
+    if (originalWasUnlinked) {
+      renameSync(detachedPath, binaryPath);
+    }
+    throw err;
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+  return true;
+}
+
 export function ensureNativeModules({
   repoRoot = defaultRepoRoot,
   modules = nativeModules,
   createRequire: createRequireImpl = createRequire,
   execFileSync: execFileSyncImpl = execFileSync,
-  verifyRepairedNativeModule: verifyRepairedNativeModuleImpl =
-    getRepairedNativeModuleError,
+  verifyRepairedNativeModule:
+    verifyRepairedNativeModuleImpl = getRepairedNativeModuleError,
   log = console.log,
 } = {}) {
-  for (const { name, resolveFrom } of modules) {
+  for (const { name, resolveFrom, binaryPath } of modules) {
     const requireModule = createRequireImpl(resolve(repoRoot, resolveFrom));
     try {
       verifyNativeModule(name, requireModule);
@@ -103,6 +151,14 @@ export function ensureNativeModules({
       const pkgJsonPath = requireModule.resolve(`${name}/package.json`);
       const pkgDir = dirname(pkgJsonPath);
       const pkgRequire = createRequireImpl(pkgJsonPath);
+      if (
+        binaryPath !== undefined &&
+        detachHardlinkedBinary(resolve(pkgDir, binaryPath))
+      ) {
+        log(
+          `[ensure-native-modules] Detached hardlinked ${name} binary before repair`,
+        );
+      }
       log(
         `[ensure-native-modules] Installing prebuilt ${name} for Node ${process.versions.node} (ABI ${process.versions.modules})`,
       );


### PR DESCRIPTION
<!-- PR: Fix model picker icons and isolate native ABI repairs -->

## What was wrong

The provider-plugin migration changed the Codex mark in the model picker from an inline SVG to a CSS-mask span. The shared button rule forced SVG children to 16px, but the new span kept the requested 14px size and sat one pixel lower. During QA, the Node 22 dev launcher also repaired `better-sqlite3` through a file that pnpm had hardlinked to the Node 24 checkout. The prebuilt installer changed that shared inode to ABI 127, which made the Node 24 server fail because it requires ABI 137.

## What changed

- Give provider marks an explicit 16px box in the loaded and loading model-picker trigger states.
- Detach a hardlinked native binary into a checkout-private file before a prebuilt install or source rebuild changes it.
- Add focused regressions for non-SVG provider marks and cross-checkout native binary isolation.
- This change does not change a wire contract, a CLI command, or a configuration surface.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app --force -- --run src/components/pickers/ModelReasoningPicker.test.tsx` — 28 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app --force` — passed.
- `pnpm exec turbo run test --filter=@bb/scripts --force` — 117 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/scripts --force` — passed.
- A browser measurement showed a 16px provider mark with the same vertical center as the model label.
- A real Node 22 dev launch detached its ABI 127 binary while the Node 24 checkout kept the same ABI 137 file hash. Both servers loaded `better-sqlite3`, and both server health checks passed.

Fixes: no linked issue.

> AGENT GENERATED
