### PR TITLE
Fall back to a resolved @get-bb/plugin-sdk entry for the legacy SDK alias in source dev mode

### DIFF
--- a/apps/server/src/services/plugins/plugin-runtime.ts
+++ b/apps/server/src/services/plugins/plugin-runtime.ts
@@ -119,11 +119,30 @@ export function pluginSdkAliasFor(runtimePath: string): Record<string, string> {
   };
 }
 
-const pluginSdkAlias: Record<string, string> | undefined = existsSync(
-  pluginSdkRuntimePath,
-)
-  ? pluginSdkAliasFor(pluginSdkRuntimePath)
-  : undefined;
+/**
+ * The packaged runtime bundle only exists after the server `build` script
+ * runs. Source dev servers (`pnpm dev`, `pnpm dev:desktop`) run straight from
+ * `src/` via tsx and never produce it, which left the legacy alias
+ * unregistered there and broke any installed plugin still on the pre-rename
+ * specifier (see #2334). `@get-bb/plugin-sdk` itself resolves naturally in
+ * that mode (doc comment above), so fall back to its resolved entry point and
+ * alias the legacy specifier to that instead of leaving it unaliased.
+ */
+export function resolvePluginSdkAliasTarget(): string | undefined {
+  if (existsSync(pluginSdkRuntimePath)) {
+    return pluginSdkRuntimePath;
+  }
+  try {
+    return fileURLToPath(import.meta.resolve(PLUGIN_SDK_SPECIFIER));
+  } catch {
+    return undefined;
+  }
+}
+
+const pluginSdkAlias: Record<string, string> | undefined = (() => {
+  const target = resolvePluginSdkAliasTarget();
+  return target === undefined ? undefined : pluginSdkAliasFor(target);
+})();
 
 /**
  * Per-root reload generation for mutable (path:/source-builtin) plugin trees.

--- a/apps/server/test/services/plugins/plugin-sdk-alias.test.ts
+++ b/apps/server/test/services/plugins/plugin-sdk-alias.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { pluginSdkAliasFor } from "../../../src/services/plugins/plugin-runtime.js";
+import {
+  pluginSdkAliasFor,
+  resolvePluginSdkAliasTarget,
+} from "../../../src/services/plugins/plugin-runtime.js";
 
 describe("pluginSdkAliasFor", () => {
   it("resolves the pre-rename specifier to the same SDK runtime bundle", () => {
@@ -10,5 +13,20 @@ describe("pluginSdkAliasFor", () => {
 
     expect(alias["@get-bb/plugin-sdk"]).toBe("/srv/plugin-sdk-runtime.js");
     expect(alias["@bb/plugin-sdk"]).toBe("/srv/plugin-sdk-runtime.js");
+  });
+});
+
+describe("resolvePluginSdkAliasTarget", () => {
+  it("falls back to the resolved @get-bb/plugin-sdk entry when no prebuilt runtime bundle exists (#2334)", () => {
+    // This test runs the server from source (no `dist/plugin-sdk-runtime.js`
+    // next to plugin-runtime.ts), the same way `pnpm dev`/`pnpm dev:desktop`
+    // do. Without the fallback this returns undefined, the legacy
+    // "@bb/plugin-sdk" specifier never gets aliased, and any installed
+    // plugin still on that pre-rename import fails with "Cannot find
+    // module '@bb/plugin-sdk'".
+    const target = resolvePluginSdkAliasTarget();
+
+    expect(target).toBeDefined();
+    expect(target).toMatch(/plugin-sdk[/\\]src[/\\]index\.ts$/);
   });
 });


### PR DESCRIPTION
## What was wrong

`pluginSdkAlias` in `apps/server/src/services/plugins/plugin-runtime.ts` only registered the legacy `@bb/plugin-sdk` specifier alias (kept since the #1574 rename to `@get-bb/plugin-sdk`) when a prebuilt `dist/plugin-sdk-runtime.js` bundle existed next to the running module. That bundle is produced only by the server's `build` script. `pnpm dev` and `pnpm dev:desktop` run the server from `src/` via `tsx` and never run `build`, so `pluginSdkAlias` silently resolved to `undefined` in every source dev workflow. Any installed plugin still importing the pre-rename `@bb/plugin-sdk` specifier (e.g. `bb-plugin-dispatch@0.1.3`) then failed to load with `Cannot find module '@bb/plugin-sdk'`, even though the same plugin loads fine in a packaged/production build (nightly, `npx bb-app`). See #2334 for the full repro and log evidence.

## What changed

- `apps/server/src/services/plugins/plugin-runtime.ts`: extracted `resolvePluginSdkAliasTarget()`. When the prebuilt runtime bundle is missing, it falls back to `import.meta.resolve("@get-bb/plugin-sdk")` (the package already resolves naturally in source dev mode per the existing doc comment) and aliases the legacy specifier to that resolved path instead of leaving it unaliased.
- `apps/server/test/services/plugins/plugin-sdk-alias.test.ts`: added a test asserting the fallback resolves to the plugin-sdk source entry when no prebuilt bundle is present (this is how the suite always runs, so it exercises the exact dev-mode gap).

No wire/protocol changes, no CLI/doc surface changes — this only affects how the server resolves an internal module alias during plugin loading.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/server` — passes.
- `pnpm exec turbo run test --filter=@bb/server -- --run test/services/plugins/plugin-sdk-alias.test.ts` — both tests pass (the new one fails without the fix, since `resolvePluginSdkAliasTarget()` would return `undefined`).
- Manual repro: ran `pnpm dev:desktop` before the fix and confirmed `bb-plugin-dispatch@0.1.3` failed with `Cannot find module '@bb/plugin-sdk'` in the server log and showed "Failed" in the Extensions UI. Applied the fix, restarted `pnpm dev:desktop`, confirmed the same plugin now loads (`plugin dispatch@0.1.3 loaded` in the log) and shows healthy/enabled in the Extensions UI with no error banner.
- Verified against a clean install in a fresh worktree off `main` (not just the branch where I found the bug), so this isn't an artifact of leftover state.

Fixes #2334

> AGENT GENERATED
