### PR TITLE
Stabilize Pi bridge process-backed tests

### DIFF
--- a/plugins/provider-pi/src/bridge/bridge.conformance.test.ts
+++ b/plugins/provider-pi/src/bridge/bridge.conformance.test.ts
@@ -12,11 +12,17 @@ import { type FakePiBridgeHarness, startFakePiBridge } from "./test-support.js";
  * the same seam (`BB_PI_BRIDGE_COMMAND`/`_ARGS`) a live run uses to find pi.
  */
 
+/** A conformance wait may cold-start the real fork-helper process on CI. */
+const CONFORMANCE_WAIT_TIMEOUT_MS = 30_000;
+
 let harness: FakePiBridgeHarness;
 
 beforeEach(async () => {
   // The conformance kit sends the initialize handshake itself.
-  harness = await startFakePiBridge({ prefix: "bb-pi-conformance-ws-", initialize: false });
+  harness = await startFakePiBridge({
+    prefix: "bb-pi-conformance-ws-",
+    initialize: false,
+  });
 });
 
 afterEach(async () => {
@@ -32,7 +38,7 @@ it("passes the canonical protocol suite against a scripted pi rpc child", async 
       promptInput: [{ type: "text", text: "say hello", mentions: [] }],
       interruptiblePromptInput: [{ type: "text", text: "/hold", mentions: [] }],
     },
-    timeoutMs: 10_000,
+    timeoutMs: CONFORMANCE_WAIT_TIMEOUT_MS,
   });
 
   console.info(`pi bridge conformance:\n${formatConformanceReport(report)}`);
@@ -58,6 +64,8 @@ it("passes the canonical protocol suite against a scripted pi rpc child", async 
     "stop/interrupt-settles-before-result": "pass",
   });
   expect(
-    report.results.filter((result) => result.status !== "pass").map((r) => r.id),
+    report.results
+      .filter((result) => result.status !== "pass")
+      .map((r) => r.id),
   ).toEqual([]);
 }, 60_000);

--- a/plugins/provider-pi/src/bridge/bridge.install-gate.test.ts
+++ b/plugins/provider-pi/src/bridge/bridge.install-gate.test.ts
@@ -2,7 +2,11 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { PI_BRIDGE_ARGS_ENV, PI_BRIDGE_COMMAND_ENV } from "./rpc-child.js";
-import { type FakePiBridgeHarness, fakePiPath, startFakePiBridge } from "./test-support.js";
+import {
+  type FakePiBridgeHarness,
+  fakePiPath,
+  startFakePiBridge,
+} from "./test-support.js";
 
 /**
  * Pi is user-installed (L6): before the bridge talks to pi, `provider/health`
@@ -13,9 +17,20 @@ import { type FakePiBridgeHarness, fakePiPath, startFakePiBridge } from "./test-
  */
 
 let harness: FakePiBridgeHarness;
+// Vitest does not cancel a timed-out body. Keep ids unique across the file so
+// a late response cannot satisfy the next scenario's fresh stdout harness.
+let requestId = 0;
+
+function nextRequestId(): number {
+  requestId += 1;
+  return requestId;
+}
 
 beforeEach(async () => {
-  harness = await startFakePiBridge({ prefix: "bb-pi-install-gate-", initialize: true });
+  harness = await startFakePiBridge({
+    prefix: "bb-pi-install-gate-",
+    initialize: true,
+  });
 });
 
 afterEach(async () => {
@@ -23,7 +38,10 @@ afterEach(async () => {
 });
 
 it("reports ready with the installed version after the get_state probe", async () => {
-  const response = await harness.request(1, "provider/health", { providerId: "pi", cwd: harness.workspaceDir });
+  const response = await harness.request(nextRequestId(), "provider/health", {
+    providerId: "pi",
+    cwd: harness.workspaceDir,
+  });
   expect(response.result).toMatchObject({
     supported: true,
     health: {
@@ -35,28 +53,40 @@ it("reports ready with the installed version after the get_state probe", async (
       loginCommand: "pi",
     },
   });
-});
+}, 30_000);
 
 it("refuses a pi older than the supported minimum before spawning it", async () => {
   vi.stubEnv("FAKE_PI_VERSION", "0.83.2");
-  const health = await harness.request(1, "provider/health", { providerId: "pi", cwd: harness.workspaceDir });
+  const health = await harness.request(nextRequestId(), "provider/health", {
+    providerId: "pi",
+    cwd: harness.workspaceDir,
+  });
   expect(health.result).toMatchObject({
     health: { status: "unsupported_version", installedVersion: "0.83.2" },
   });
-  const models = await harness.request(2, "model/list", { cwd: harness.workspaceDir });
+  const models = await harness.request(nextRequestId(), "model/list", {
+    cwd: harness.workspaceDir,
+  });
   expect(models.error).toMatchObject({
-    message: expect.stringContaining("0.83.2 is older than the supported minimum 0.84.0"),
+    message: expect.stringContaining(
+      "0.83.2 is older than the supported minimum 0.84.0",
+    ),
   });
 });
 
 it("reports not_installed when the launch command is missing", async () => {
   vi.stubEnv(PI_BRIDGE_COMMAND_ENV, join(harness.workspaceDir, "no-such-pi"));
   vi.stubEnv(PI_BRIDGE_ARGS_ENV, "[]");
-  const health = await harness.request(1, "provider/health", { providerId: "pi", cwd: harness.workspaceDir });
+  const health = await harness.request(nextRequestId(), "provider/health", {
+    providerId: "pi",
+    cwd: harness.workspaceDir,
+  });
   expect(health.result).toMatchObject({
     health: { status: "not_installed", canInstall: true, canUpdate: false },
   });
-  const models = await harness.request(2, "model/list", { cwd: harness.workspaceDir });
+  const models = await harness.request(nextRequestId(), "model/list", {
+    cwd: harness.workspaceDir,
+  });
   expect(models.error).toMatchObject({
     message: expect.stringContaining("Could not find the pi CLI"),
   });
@@ -66,7 +96,10 @@ it("fails closed when pi cannot report its version, with install guidance", asyn
   // The crash prints "pi 0.84.0" on stderr and exits 1: a gate that read
   // stderr or treated a failed probe as "no version, pass" would say ready.
   vi.stubEnv("FAKE_PI_VERSION", "crash");
-  const health = await harness.request(1, "provider/health", { providerId: "pi", cwd: harness.workspaceDir });
+  const health = await harness.request(nextRequestId(), "provider/health", {
+    providerId: "pi",
+    cwd: harness.workspaceDir,
+  });
   expect(health.result).toMatchObject({
     health: {
       status: "unknown",
@@ -76,7 +109,9 @@ it("fails closed when pi cannot report its version, with install guidance", asyn
       ),
     },
   });
-  const models = await harness.request(2, "model/list", { cwd: harness.workspaceDir });
+  const models = await harness.request(nextRequestId(), "model/list", {
+    cwd: harness.workspaceDir,
+  });
   expect(models.error).toMatchObject({
     message: expect.stringContaining("Could not determine the pi version"),
   });
@@ -85,17 +120,33 @@ it("fails closed when pi cannot report its version, with install guidance", asyn
 it("memoizes the install gate per launch path across health polls", async () => {
   const processLog = join(harness.workspaceDir, "process.log");
   vi.stubEnv("FAKE_PI_PROCESS_LOG", processLog);
-  await harness.request(1, "provider/health", { providerId: "pi", cwd: harness.workspaceDir });
-  await harness.request(2, "model/list", { cwd: harness.workspaceDir });
-  await harness.request(3, "provider/health", { providerId: "pi", cwd: harness.workspaceDir });
+  await harness.request(nextRequestId(), "provider/health", {
+    providerId: "pi",
+    cwd: harness.workspaceDir,
+  });
+  await harness.request(nextRequestId(), "model/list", {
+    cwd: harness.workspaceDir,
+  });
+  await harness.request(nextRequestId(), "provider/health", {
+    providerId: "pi",
+    cwd: harness.workspaceDir,
+  });
   const versionSpawns = readFileSync(processLog, "utf8")
     .split("\n")
     .filter((line) => line.startsWith("version:"));
   expect(versionSpawns).toHaveLength(1);
   // A different launch path is a different install: it probes again.
-  vi.stubEnv(PI_BRIDGE_ARGS_ENV, JSON.stringify([fakePiPath, "--other-launch"]));
-  await harness.request(4, "provider/health", { providerId: "pi", cwd: harness.workspaceDir });
+  vi.stubEnv(
+    PI_BRIDGE_ARGS_ENV,
+    JSON.stringify([fakePiPath, "--other-launch"]),
+  );
+  await harness.request(nextRequestId(), "provider/health", {
+    providerId: "pi",
+    cwd: harness.workspaceDir,
+  });
   expect(
-    readFileSync(processLog, "utf8").split("\n").filter((line) => line.startsWith("version:")),
+    readFileSync(processLog, "utf8")
+      .split("\n")
+      .filter((line) => line.startsWith("version:")),
   ).toHaveLength(2);
-});
+}, 30_000);


### PR DESCRIPTION
## What was wrong

The Pi bridge tests exercise real Node child processes, but the two install-gate cases that cold-start the catalog child inherited Vitest’s 5 s default and the conformance wrapper passed only a 10 s per-wait protocol budget. Under the 4-vCPU packages shard contention, the same fork-helper path took 11.47 s in its correctly budgeted lifecycle test, so these smaller limits expired while valid bridge work was still running. Vitest does not cancel a timed-out async body; because each install-gate scenario then reused JSON-RPC request id `1` with a fresh stdout capture, a late response from the timed-out scenario could satisfy the next test and produce the unsupported/not-installed assertion cascade. The failures are visible in the [main run](https://github.com/get-bb/bb/actions/runs/32699848174) and unrelated [PR #1781](https://github.com/get-bb/bb/actions/runs/32718468577) and [PR #1785](https://github.com/get-bb/bb/actions/runs/32718467431) runs.

## What changed

The two install-gate cases that actually cold-start RPC children now use the same 30 s class of test budget as the neighboring Pi process tests, and conformance waits up to 30 s for each protocol response while retaining the existing 60 s wrapper. Install-gate request ids are monotonic across the file, so any late result remains diagnostic noise instead of being mistaken for another scenario’s response. Assertions and production behavior are unchanged. This is test-only and does not change the host-daemon wire protocol.

## How you verified

Before the change, the cited CI runs crossed the old limits, and a controlled local stress run with 64 competing CPU burners stretched the unchanged conformance test to 18.4 s and the two install-gate process cases to 4.64 s and 4.35 s. After the change, three identical stress rounds passed all 6 focused tests; conformance took 12.01 s, 11.96 s, and 11.87 s without losing `session/fork-identity`.

- `pnpm exec vitest run src/bridge/bridge.install-gate.test.ts src/bridge/bridge.conformance.test.ts --config vitest.config.ts --reporter=dot --maxWorkers=1` — 6 passed
- `pnpm exec turbo run test --filter=bb-plugin-provider-pi --force` — 17 files, 104 tests passed
- `pnpm exec turbo run typecheck --filter=bb-plugin-provider-pi --force` — 4 Turbo tasks passed
- `pnpm exec turbo run build --filter=@bb/server --force` — 4 Turbo tasks passed
- `pnpm exec oxfmt plugins/provider-pi/src/bridge/bridge.install-gate.test.ts plugins/provider-pi/src/bridge/bridge.conformance.test.ts --check` — passed

> AGENT GENERATED: by GPT-5.6-Sol