### PR TITLE
Stabilize empty plugin update scheduler regression

### DIFF
--- a/apps/server/test/services/plugins/plugin-update.test.ts
+++ b/apps/server/test/services/plugins/plugin-update.test.ts
@@ -78,6 +78,41 @@ async function commitPlugin(
   return git(repo, ["rev-parse", "HEAD"]);
 }
 
+describe("plugin update scheduling", () => {
+  it("waits one full interval when no plugins are eligible for update checks", async () => {
+    const HOUR = 60 * 60 * 1_000;
+    const emptyDb = createConnection(":memory:");
+    migrate(emptyDb);
+    const scheduled: number[] = [];
+    const emptyService = createPluginService({
+      aiServices: createAiServiceRegistry(),
+      telemetry: createNoopTelemetryService(),
+      db: emptyDb,
+      hub: {
+        getDaemonSessionIdForHost: () => null,
+        notifyPluginSignal: () => 0,
+        notifySystem: () => {},
+      },
+      logger,
+      dataDir: join(tmpdir(), "bb-plugin-update-empty-test"),
+      appVersion: "1.0.0",
+      stabilizationWindowMs: 0,
+      scheduleUpdateCheck: (delayMs) => {
+        scheduled.push(delayMs);
+        return () => {};
+      },
+    });
+
+    try {
+      emptyService.startPeriodicUpdateChecks();
+      expect(scheduled).toEqual([6 * HOUR]);
+    } finally {
+      await emptyService.stop();
+      emptyDb.$client.close();
+    }
+  });
+});
+
 describe("plugin update service and routes", () => {
   let db: DbConnection;
   let workDir: string;
@@ -781,16 +816,6 @@ describe("plugin update service and routes", () => {
     await service.start();
     return scheduled;
   }
-
-  it("waits one full interval when no plugins are eligible for update checks", async () => {
-    const HOUR = 60 * 60 * 1_000;
-    await service.remove("updater");
-    const scheduled = await restartWithScheduler(Date.now);
-
-    service.startPeriodicUpdateChecks();
-
-    expect(scheduled.map((entry) => entry.delayMs)).toEqual([6 * HOUR]);
-  });
 
   it("sweeps on start when a plugin was never checked, then waits out the interval across restarts", async () => {
     const HOUR = 60 * 60 * 1_000;


### PR DESCRIPTION
## What was wrong

The empty-plugin scheduler regression inherited the file's heavyweight Git-plugin integration fixture. Before it could assert the scheduled delay, the test installed and loaded a Git plugin, then called the public removal path solely to manufacture an empty database. That removal performs lifecycle disposal, managed-file cleanup, and CLI-skill synchronization unrelated to periodic scheduling. The passing main run already spent about 3.3 seconds in this test; locally it reached 4.790 seconds, and under ordinary contention the removal did not finish before Vitest's 5-second default timeout. The scheduler assertion itself is synchronous and deterministic.

## What changed

Move the empty-set scheduling regression into a small fixture that owns an in-memory SQLite database with no installed plugins and injects the scheduler callback directly. The assertion remains exact: starting periodic checks with no eligible rows must schedule one six-hour delay. The fixture explicitly stops its service and closes its database.

This is test-only. There is no server/daemon wire change, CLI or configuration surface, or documentation change.

## How you verified

- Before the change, the focused test took 4.790 seconds locally; an instrumented rerun reproduced the `Test timed out in 5000ms` failure before `service.remove("updater")` completed.
- After the change, the focused regression passed in 61ms. With 24 CPU workers started alongside Vitest, it passed in 74ms while retaining the exact six-hour assertion.
- `pnpm exec turbo run test --filter=@bb/server --force -- test/services/plugins/plugin-update.test.ts` — 27 tests passed.
- `pnpm exec turbo run test --filter=@bb/server --force` — 210 test files passed, 1 skipped; 2,002 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/server` — passed.
- `pnpm exec turbo run build --filter=@bb/server` — passed.
- `git diff --check` — passed.

No matching GitHub issue was found, so this PR does not include a `Fixes #N` reference.

> AGENT GENERATED: by GPT-5.6-Sol
