### PR TITLE
Harden plugin host watch test startup wait

### DIFF
--- a/apps/host-daemon/src/plugin-host-manager.test.ts
+++ b/apps/host-daemon/src/plugin-host-manager.test.ts
@@ -550,7 +550,8 @@ describe("PluginHostManager", () => {
       input: { rootPath: "/tmp/workspace", listenerDelayMs: 100 },
     });
     const call = manager.call(command);
-    await vi.waitFor(() => expect(watcher).toBeDefined());
+    // This registration crosses a real worker process startup boundary.
+    await vi.waitFor(() => expect(watcher).toBeDefined(), { timeout: 5_000 });
     watcher?.onReady();
     await expect(call).resolves.toEqual({ output: { watching: true } });
     await new Promise((resolve) => setTimeout(resolve, 100));


### PR DESCRIPTION
## What was wrong

The `PluginHostManager` native-watch test launches a real plugin host worker, but it waited for host watch registration with Vitest's default one-second budget. Under scheduler and process contention, worker startup crossed that boundary before the watch could register. Test teardown then disposed the manager while `manager.call` was still pending, so the worker rejected that call and Vitest reported a secondary unhandled rejection. That rejection is test-cleanup fallout, not evidence of a production watch-disposal defect.

This matches the failure in [PR #2337's unrelated CI run](https://github.com/get-bb/bb/actions/runs/32750957324): readiness timed out at line 553, followed by the disposal rejection.

## What changed

Give only the cross-process watch-registration wait an explicit five-second budget. The 20 ms idle timeout, 100 ms dwell, backpressure checks, disposal assertion, and all production behavior remain unchanged.

There are no host-daemon wire changes, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged. No CLI or documentation surfaces changed.

## How you verified

- Before the change, the focused test passed normally but failed at line 553 under 256 controlled CPU competitors, with the secondary unhandled rejection during cleanup.
- After the change, the same contended command passed; the focused test took 1.95 seconds, beyond the former one-second readiness boundary.
- `plugin-host-manager.test.ts`: 19/19 passed.
- `pnpm exec turbo run build --filter=@bb/host-daemon`
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon`
- `pnpm exec turbo run test --filter=@bb/host-daemon --force`: 44 files and 534 tests passed.

> AGENT GENERATED: by GPT-5.6-Sol
