### PR TITLE
Stop card and row padding from stacking in the Updates panel

### DIFF
--- a/apps/app/src/components/settings/UpdatesSettingsSection.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.tsx
@@ -224,6 +224,15 @@ const ROW_GRID =
   "grid min-w-0 grid-cols-[1.5rem_minmax(0,1fr)_auto] items-center gap-3";
 
 /**
+ * Vertical rhythm for every row in a machine card. `SettingsSection` already
+ * pads the card (`py-3.5`), so the first and last rows drop their own outer
+ * padding the way `SettingsRow` does; without the reset a card's own padding
+ * and the row's stacked to 22px at each end, while `UpdatesRow` — which had
+ * the reset — sat at 14px, and the bb row's card came out lopsided.
+ */
+const ROW_SPACING = "py-2 first:pt-0 last:pb-0";
+
+/**
  * A row with no destination — bb itself, which has no page of its own to open.
  * It borrows `ResourceRow`'s grid rather than its behaviour so its mark, name
  * and action land on the same three columns as the rows that are navigable;
@@ -240,7 +249,7 @@ function UpdatesRow({
 }) {
   return (
     <div
-      className={cn(ROW_GRID, "py-2.5 text-sm first:pt-0 last:pb-0", className)}
+      className={cn(ROW_GRID, ROW_SPACING, "text-sm", className)}
     >
       <span className="flex size-6 shrink-0 items-center justify-center">
         {leading}
@@ -1095,7 +1104,7 @@ export function BbDaemonUpdateRow({
 
   return (
     <ResourceRow
-      className="py-2"
+      className={ROW_SPACING}
       actionsVisibility="always"
       openLabel={`Open ${host.name} settings`}
       onOpen={() => onOpenMachine(host.id)}
@@ -1147,7 +1156,7 @@ export function ProviderCliCheckRow({
   const { host } = machine;
   return (
     <ResourceRow
-      className="py-2"
+      className={ROW_SPACING}
       actionsVisibility="always"
       openLabel={`Open ${host.name} settings`}
       onOpen={() => onOpenMachine(host.id)}
@@ -1252,7 +1261,7 @@ export function MachineUpdatesRows({
     return (
       <ResourceRow
         key={provider}
-        className="py-2"
+        className={ROW_SPACING}
         actionsVisibility="always"
         openLabel={`Open ${status.displayName} settings`}
         onOpen={() => onOpenProvider(providerId)}


### PR DESCRIPTION
## What was wrong

The machine cards in Settings → Updates had too much space above the first row and below the last row. `SettingsSection` pads the card body with `py-3.5` (14px). The provider rows are `ResourceRow`s with a plain `className="py-2"` and no `first:pt-0 last:pb-0` reset, so the row's 8px stacked on the card's 14px: 22px at each end. The `bb app` row is an `UpdatesRow`, which has the reset, so it sat at 14px. A card that mixed the two came out lopsided (14px top, 22px bottom), and provider-only cards were over-padded at both ends.

## What changed

`apps/app/src/components/settings/UpdatesSettingsSection.tsx` only. One shared `ROW_SPACING = "py-2 first:pt-0 last:pb-0"` constant sits beside `ROW_GRID`. `UpdatesRow` and the three `ResourceRow` callers (`BbDaemonUpdateRow`, `ProviderCliCheckRow`, `MachineUpdatesRows`) use it. `UpdatesRow` moves from `py-2.5` to `py-2`, so every row in a card has the same 45px pitch. No wire, CLI, or doc changes.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/app` passes.
- `UpdatesSettingsSection.test.tsx` passes (27 tests).
- Measured in Ladle (`settings--updates--multi-machine`), card border to row icon, before → after:

  | Card | Before (top / bottom) | After (top / bottom) | Card height |
  |---|---|---|---|
  | bb row + providers | 15 / 28 px | 15 / 20 px | 199 → 189 px |
  | providers only | 28 / 28 px | 20 / 20 px | 164 → 148 px |
  | one row | 23 / 23 px | 15 / 15 px | 70 → 54 px |

  The 20px "after" value is to the 24px leading icon centered in a 28px row; the edge to the row box is 15px on every card.

> AGENT GENERATED
