### PR TITLE
Stabilize Pi settings process test budget

### DIFF
--- a/plugins/provider-pi/src/bridge/bridge.settings.test.ts
+++ b/plugins/provider-pi/src/bridge/bridge.settings.test.ts
@@ -17,6 +17,13 @@ const OPTIONS = {
   reasoningLevel: "high",
 };
 
+/**
+ * The assertions cover four serial process constructions: start, resume,
+ * fork helper, and fork target. Match the conformance wrapper's process-test
+ * budget so CPU-starved CI can finish valid child startups.
+ */
+const SETTINGS_PROCESS_TEST_TIMEOUT_MS = 60_000;
+
 let harness: FakePiBridgeHarness;
 let commandLogPath: string;
 
@@ -94,4 +101,4 @@ it("pins model and thinking at spawn and never sends set_model or set_thinking_l
     .map((d) => d.size);
   expect(contextWindows.length).toBeGreaterThan(0);
   expect(new Set(contextWindows)).toEqual(new Set([32_000]));
-}, 30_000);
+}, SETTINGS_PROCESS_TEST_TIMEOUT_MS);


### PR DESCRIPTION
## What was wrong

The Pi settings integration test exercises four required process constructions in series—initial start, resume, fork helper, and fork target—but its enclosing Vitest budget was only 30 seconds. Each construction launches a real Node child and imports the real Pi extension seam, so CPU-starved CI can delay all four without any bridge hang or behavioral failure. The [failed packages job](https://github.com/get-bb/bb/actions/runs/32752351145/job/97511996846) expired at that wrapper while the unchanged test passed in 6.5 seconds in a [near-concurrent rerun](https://github.com/get-bb/bb/actions/runs/32750957324/job/97511680914). Controlled reproduction confirmed scheduler sensitivity: with 256 CPU competitors, start took 7.57 seconds, resume another 7.38 seconds, and fork's two constructions another 15.29 seconds; the turns and stop took only 46 milliseconds, all process work completed at 30.28 seconds, and Vitest reported the expected 30,000 ms timeout at 30.37 seconds.

## What changed

`bridge.settings.test.ts` now gives that four-construction test the same 60-second process budget already used by the Pi conformance wrapper. A named constant and comment document why this test has the larger budget. Every assertion and exercised start/resume/fork path is unchanged; no production, wire, CLI, or documentation behavior changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

The parent and worker independently verified before edits that `HEAD`, `origin/main`, and `git merge-base HEAD origin/main` all equaled `b735da19e3cf340ae19beb60f9b4e6ad31e98783`, with a clean worktree. Fresh GitHub issue/PR and bb thread searches found no matching open fix. The identical 256-competitor Turbo stress that failed before passed after the change in 30.21 seconds with every assertion intact.

- `pnpm exec turbo run test --filter=bb-plugin-provider-pi --force -- --run src/bridge/bridge.settings.test.ts` — 1 test passed
- 256-competitor run of the same focused Turbo command — failed before at 30.37 seconds; passed after at 30.21 seconds
- `pnpm exec turbo run test --filter=bb-plugin-provider-pi --force` — 17 files, 104 tests passed
- `pnpm exec turbo run typecheck --filter=bb-plugin-provider-pi --force` — 4 Turbo tasks passed
- `pnpm exec turbo run build --filter=@bb/server --force` — 4 Turbo tasks passed
- `git diff --check` — passed

> AGENT GENERATED: by GPT-5.6-Sol
