### PR TITLE
Confirm before archiving active thread work

### DIFF
--- a/apps/app/src/components/dialogs/ThreadArchiveDialog.tsx
+++ b/apps/app/src/components/dialogs/ThreadArchiveDialog.tsx
@@ -1,0 +1,39 @@
+import type { Thread } from "@bb/domain";
+import {
+  ConfirmDeleteDialog,
+  ConfirmDeleteDialogContent,
+} from "./ConfirmDeleteDialog";
+
+export interface ThreadArchiveDialogTarget {
+  thread: Thread;
+  workingThreadCount: number;
+}
+
+interface ThreadArchiveDialogProps {
+  target: ThreadArchiveDialogTarget | null;
+  pending: boolean;
+  onOpenChange: (open: boolean) => void;
+  onArchive: (target: ThreadArchiveDialogTarget) => void;
+}
+
+export function ThreadArchiveDialog({
+  target,
+  pending,
+  onOpenChange,
+  onArchive,
+}: ThreadArchiveDialogProps) {
+  return (
+    <ConfirmDeleteDialog open={target !== null} onOpenChange={onOpenChange}>
+      {target ? (
+        <ConfirmDeleteDialogContent
+          title="Archive active work?"
+          description={`${target.workingThreadCount === 1 ? "A thread is" : `${target.workingThreadCount} threads are`} currently working in this thread tree. Archiving may interrupt the active work.`}
+          confirmLabel="Archive anyway"
+          pending={pending}
+          onConfirm={() => onArchive(target)}
+          onCancel={() => onOpenChange(false)}
+        />
+      ) : null}
+    </ConfirmDeleteDialog>
+  );
+}

--- a/apps/app/src/components/thread/ThreadActionsProvider.test.tsx
+++ b/apps/app/src/components/thread/ThreadActionsProvider.test.tsx
@@ -13,12 +13,14 @@ import {
 } from "./ThreadActionsProvider";
 
 const mocks = vi.hoisted(() => ({
+  archiveConfirm: vi.fn(),
   closePanesForThreads: vi.fn(),
   dialogOnClose: vi.fn(),
   dialogOnOpen: vi.fn(),
   dialogOnOpenChange: vi.fn(),
   mutation: vi.fn(),
   navigate: vi.fn(),
+  workingArchiveThreadCount: vi.fn(() => 0),
 }));
 
 vi.mock("react-router-dom", async (importOriginal) => {
@@ -41,6 +43,27 @@ vi.mock("@/components/dialogs/ThreadDeleteDialog", () => ({
 vi.mock("@/components/dialogs/ThreadRenameDialog", () => ({
   ThreadRenameDialog: () => null,
 }));
+
+vi.mock("@/components/dialogs/ThreadArchiveDialog", () => ({
+  ThreadArchiveDialog: ({
+    onArchive,
+  }: {
+    onArchive: (target: unknown) => void;
+  }) => {
+    mocks.archiveConfirm.mockImplementation(onArchive);
+    return null;
+  },
+}));
+
+vi.mock(
+  "@/hooks/cache-owners/thread-archive-cache",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@/hooks/cache-owners/thread-archive-cache")
+    >()),
+    getCachedWorkingArchiveThreadCount: mocks.workingArchiveThreadCount,
+  }),
+);
 
 vi.mock("@/components/ui/app-toast", () => ({
   appToast: {
@@ -153,6 +176,7 @@ beforeEach(() => {
     focusedRoute: null,
     removedAny: false,
   });
+  mocks.workingArchiveThreadCount.mockReturnValue(0);
 });
 
 afterEach(() => {
@@ -161,6 +185,38 @@ afterEach(() => {
 });
 
 describe("ThreadActionsProvider archive feedback", () => {
+  it("asks for confirmation instead of archiving when cached work is active", () => {
+    const thread = makeThread();
+    mocks.workingArchiveThreadCount.mockReturnValue(1);
+    renderProvider(<ArchiveButton thread={thread} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Archive" }));
+
+    expect(mocks.dialogOnOpen).toHaveBeenCalledWith({
+      thread,
+      workingThreadCount: 1,
+    });
+    expect(sdk.threads.archiveAll).not.toHaveBeenCalled();
+  });
+
+  it("archives exactly once after active-work confirmation", async () => {
+    const thread = makeThread();
+    const target = { thread, workingThreadCount: 2 };
+    mocks.workingArchiveThreadCount.mockReturnValue(2);
+    renderProvider(<ArchiveButton thread={thread} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Archive" }));
+    mocks.archiveConfirm(target);
+
+    await vi.waitFor(() => {
+      expect(sdk.threads.archiveAll).toHaveBeenCalledTimes(1);
+    });
+    expect(sdk.threads.archiveAll).toHaveBeenCalledWith({
+      threadId: thread.id,
+    });
+    expect(mocks.dialogOnClose).toHaveBeenCalledTimes(1);
+  });
+
   it("shows one archive toast whose Undo restores the parent and children", async () => {
     renderProvider(<ArchiveButton thread={makeThread()} />);
 

--- a/apps/app/src/components/thread/ThreadActionsProvider.tsx
+++ b/apps/app/src/components/thread/ThreadActionsProvider.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import { useSetAtom } from "jotai";
+import { useQueryClient } from "@tanstack/react-query";
 import { appToast } from "@/components/ui/app-toast";
 import {
   closePanesForThreadsAtom,
@@ -41,12 +42,17 @@ import {
   ThreadDeleteDialog,
   type ThreadDeleteDialogTarget,
 } from "@/components/dialogs/ThreadDeleteDialog";
+import {
+  ThreadArchiveDialog,
+  type ThreadArchiveDialogTarget,
+} from "@/components/dialogs/ThreadArchiveDialog";
 import { ArchivedThreadToastTitle } from "@/components/thread/ArchivedThreadToastTitle";
 import { destroyPersistedBrowserViewsForThread } from "@/components/secondary-panel/browserViewVisibilityCoordinator";
 import { getThreadReadToggleAction } from "@bb/client-core";
 import { getRootComposeRoutePath, getThreadRoutePath } from "@/lib/route-paths";
 import { getDesktopBrowserApi } from "@/lib/bb-desktop";
 import { useRouteNavigate } from "@/components/ui/app-route-anchor";
+import { getCachedWorkingArchiveThreadCount } from "@/hooks/cache-owners/thread-archive-cache";
 
 export interface ThreadActionsContextValue {
   archiveThreadAndChildren: (thread: Thread) => void;
@@ -99,6 +105,7 @@ export function ThreadActionsProvider({
   // Stable across navigations: the context value below must not change per
   // pathname, or every mounted sidebar ThreadRow re-renders on each route change.
   const navigate = useRouteNavigate();
+  const queryClient = useQueryClient();
   const { threadId: viewedThreadId } = useRouteState();
   // Read the currently-viewed thread live inside async mutation callbacks: a
   // pane's stale-prune (deleted/archived thread) can move the URL between a
@@ -138,9 +145,12 @@ export function ThreadActionsProvider({
 
   const renameDialog = useDialogState<ThreadRenameDialogTarget>();
   const deleteDialog = useDialogState<ThreadDeleteDialogTarget>();
+  const archiveDialog = useDialogState<ThreadArchiveDialogTarget>();
 
   const { onClose: closeRenameDialog, onOpen: openRenameDialog } = renameDialog;
   const { onClose: closeDeleteDialog, onOpen: openDeleteDialog } = deleteDialog;
+  const { onClose: closeArchiveDialog, onOpen: openArchiveDialog } =
+    archiveDialog;
 
   useEffect(() => {
     return () => {
@@ -330,7 +340,7 @@ export function ThreadActionsProvider({
     [unarchiveMutate],
   );
 
-  const archiveThreadAndChildrenAction = useCallback(
+  const performArchiveThreadAndChildren = useCallback(
     (thread: Thread) => {
       archiveThreadAndChildrenMutateAsync({ id: thread.id }).then(
         (response) => {
@@ -394,6 +404,29 @@ export function ThreadActionsProvider({
       syncNavigationAfterClose,
       unarchiveMutate,
     ],
+  );
+
+  const archiveThreadAndChildrenAction = useCallback(
+    (thread: Thread) => {
+      const workingThreadCount = getCachedWorkingArchiveThreadCount({
+        queryClient,
+        threadId: thread.id,
+      });
+      if (workingThreadCount > 0) {
+        openArchiveDialog({ thread, workingThreadCount });
+        return;
+      }
+      performArchiveThreadAndChildren(thread);
+    },
+    [openArchiveDialog, performArchiveThreadAndChildren, queryClient],
+  );
+
+  const confirmArchive = useCallback(
+    (target: ThreadArchiveDialogTarget) => {
+      closeArchiveDialog();
+      performArchiveThreadAndChildren(target.thread);
+    },
+    [closeArchiveDialog, performArchiveThreadAndChildren],
   );
 
   const toggleRead = useCallback(
@@ -465,6 +498,12 @@ export function ThreadActionsProvider({
         pending={updateThread.isPending}
         onOpenChange={renameDialog.onOpenChange}
         onRename={submitRename}
+      />
+      <ThreadArchiveDialog
+        target={archiveDialog.target}
+        pending={archiveThreadAndChildrenMutation.isPending}
+        onOpenChange={archiveDialog.onOpenChange}
+        onArchive={confirmArchive}
       />
       <ThreadDeleteDialog
         target={deleteDialog.target}

--- a/apps/app/src/hooks/cache-owners/thread-archive-cache.test.ts
+++ b/apps/app/src/hooks/cache-owners/thread-archive-cache.test.ts
@@ -1,0 +1,138 @@
+import type { ThreadListEntry } from "@bb/domain";
+import type { SidebarBootstrapResponse } from "@bb/server-contract";
+import { describe, expect, it } from "vitest";
+import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
+import { sidebarNavigationQueryKey } from "../queries/query-keys";
+import { getCachedWorkingArchiveThreadCount } from "./thread-archive-cache";
+
+function makeThread(thread: Partial<ThreadListEntry> = {}): ThreadListEntry {
+  return {
+    id: "thread-parent",
+    projectId: "project-1",
+    environmentId: "env-1",
+    providerId: "codex",
+    title: null,
+    titleFallback: null,
+    sectionId: null,
+    status: "idle",
+    parentThreadId: null,
+    sourceThreadId: null,
+    originKind: null,
+    originPluginId: null,
+    visibility: "visible",
+    archivedAt: null,
+    pinnedAt: null,
+    deletedAt: null,
+    lastReadAt: null,
+    latestAttentionAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    runtime: {
+      displayStatus: "idle",
+      hostReconnectGraceExpiresAt: null,
+    },
+    activity: {
+      activeWorkflowCount: 0,
+      activeBackgroundAgentCount: 0,
+      activeBackgroundCommandCount: 0,
+      activePlanModeCount: 0,
+      activeGoalCount: 0,
+    },
+    pinSortKey: null,
+    hasPendingInteraction: false,
+    environmentHostId: "host-1",
+    environmentName: "Environment",
+    environmentBranchName: "main",
+    environmentWorkspaceDisplayKind: "managed-worktree",
+    ...thread,
+  };
+}
+
+function makeSidebarNavigation(
+  threads: ThreadListEntry[],
+): SidebarBootstrapResponse {
+  const project = {
+    id: "project-1",
+    kind: "standard" as const,
+    name: "Project",
+    gitRemoteUrl: null,
+    createdAt: 1,
+    updatedAt: 1,
+    sources: [],
+    threads,
+    defaultExecutionOptions: null,
+  };
+  return {
+    sections: [],
+    projects: [project],
+    personalProject: {
+      ...project,
+      id: "proj_personal",
+      kind: "personal",
+      threads: [],
+    },
+  };
+}
+
+describe("getCachedWorkingArchiveThreadCount", () => {
+  it("does not guard an idle thread tree", () => {
+    const { queryClient } = createQueryClientTestHarness();
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      makeSidebarNavigation([
+        makeThread(),
+        makeThread({ id: "thread-child", parentThreadId: "thread-parent" }),
+      ]),
+    );
+
+    expect(
+      getCachedWorkingArchiveThreadCount({
+        queryClient,
+        threadId: "thread-parent",
+      }),
+    ).toBe(0);
+  });
+
+  it("counts working activity on the thread and its children", () => {
+    const { queryClient } = createQueryClientTestHarness();
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      makeSidebarNavigation([
+        makeThread({
+          runtime: {
+            displayStatus: "active",
+            hostReconnectGraceExpiresAt: null,
+          },
+        }),
+        makeThread({
+          id: "thread-child",
+          parentThreadId: "thread-parent",
+          activity: {
+            activeWorkflowCount: 0,
+            activeBackgroundAgentCount: 1,
+            activeBackgroundCommandCount: 0,
+            activePlanModeCount: 0,
+            activeGoalCount: 0,
+          },
+        }),
+        makeThread({
+          id: "unrelated-thread",
+          activity: {
+            activeWorkflowCount: 1,
+            activeBackgroundAgentCount: 0,
+            activeBackgroundCommandCount: 0,
+            activePlanModeCount: 0,
+            activeGoalCount: 0,
+          },
+        }),
+      ]),
+    );
+
+    expect(
+      getCachedWorkingArchiveThreadCount({
+        queryClient,
+        threadId: "thread-parent",
+      }),
+    ).toBe(2);
+  });
+});

--- a/apps/app/src/hooks/cache-owners/thread-archive-cache.ts
+++ b/apps/app/src/hooks/cache-owners/thread-archive-cache.ts
@@ -1,5 +1,13 @@
 import type { QueryClient } from "@tanstack/react-query";
 import type { ThreadListEntry, ThreadWithRuntime } from "@bb/domain";
+import {
+  hasActiveBackgroundAgentActivity,
+  hasActiveBackgroundCommandActivity,
+  hasActiveGoalActivity,
+  hasActivePlanModeActivity,
+  hasActiveWorkflowActivity,
+  isRuntimeBusyThread,
+} from "@bb/client-core";
 import { threadQueryKey, threadsQueryKey } from "../queries/query-keys";
 import {
   applyToCachedSidebarNavigationThreads,
@@ -58,6 +66,51 @@ export function getCachedLiveThreadIdsMatching({
     }
   }
   return Array.from(threadIds);
+}
+
+/**
+ * Counts cached live threads in an archive cascade that currently have working
+ * activity. This stays synchronous so idle archives never wait on preflight.
+ */
+export function getCachedWorkingArchiveThreadCount({
+  queryClient,
+  threadId,
+}: {
+  queryClient: QueryClient;
+  threadId: string;
+}): number {
+  const workingThreadIds = new Set<string>();
+  const collectMatchingThread = (thread: ThreadListEntry) => {
+    if (
+      thread.archivedAt !== null ||
+      (thread.id !== threadId && thread.parentThreadId !== threadId)
+    ) {
+      return;
+    }
+    if (
+      isRuntimeBusyThread(thread) ||
+      hasActiveWorkflowActivity(thread) ||
+      hasActiveBackgroundAgentActivity(thread) ||
+      hasActiveBackgroundCommandActivity(thread) ||
+      hasActivePlanModeActivity(thread) ||
+      hasActiveGoalActivity(thread)
+    ) {
+      workingThreadIds.add(thread.id);
+    }
+  };
+
+  for (const { data } of getCachedThreadLists(queryClient, {
+    queryKey: threadsQueryKey(),
+  })) {
+    for (const thread of iterateThreadListCacheEntries(data)) {
+      collectMatchingThread(thread);
+    }
+  }
+  for (const thread of getCachedSidebarNavigationThreads(queryClient)) {
+    collectMatchingThread(thread);
+  }
+
+  return workingThreadIds.size;
 }
 
 export function getCachedThreadSnapshots({


### PR DESCRIPTION
## What was wrong

The sidebar's hover-revealed archive button intentionally makes routine cleanup one click, but it used the same immediate archive path even when the selected thread or one of its visible children was still working. A small targeting mistake could therefore interrupt active work without giving the user a chance to reconsider.

## What changed

Thread archive actions now inspect BB's existing React Query cache synchronously at click time. Idle thread trees retain the current one-click behavior. When the selected thread or a cached child has an active runtime, workflow, background agent or command, plan, or goal, BB opens an “Archive active work?” confirmation before running the existing archive mutation.

The guard lives in `ThreadActionsProvider`, so the sidebar quick action, overflow menu, keyboard command, and plugin-exposed single-thread action share the same behavior. It is deliberately a best-effort UI guard: it adds no preflight request, server enforcement, wire contract, protocol bump, or new subscription, preserving the sidebar's existing responsiveness and archive lifecycle.

## How you verified

Added regression coverage for idle trees, active parents, active children, withholding the archive mutation until confirmation, and performing the confirmed archive exactly once.

- `pnpm exec turbo run typecheck --filter=@bb/app`
- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/thread/ThreadActionsProvider.test.tsx src/hooks/cache-owners/thread-archive-cache.test.ts`
- Full `@bb/app` suite on the feature worktree before rebasing: 430 files passed; 3,338 tests passed and 3 skipped.
- Independent code review of cache behavior, shared action routing, dialog semantics, affected-set limitations, and test coverage.

> AGENT GENERATED
