### PR TITLE
perf: memoize provider CLI status, discovery, and model-list failures (S1, S4, S2)

### DIFF
--- a/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.test.tsx
@@ -29,6 +29,7 @@ import {
   getProviderCliInstallSnapshot,
   resetProviderCliInstallStoreForTests,
 } from "@/components/provider-cli/provider-cli-install-store";
+import { appToast } from "@/components/ui/app-toast";
 import { sdk } from "@/lib/sdk";
 import { useDesktopUpdateInfo } from "@/hooks/useDesktopUpdateInfo";
 import {
@@ -55,6 +56,7 @@ vi.mock("@/lib/sdk", async () => {
   return {
     sdk: {
       system: { version: vi.fn() },
+      hosts: { providerCliStatus: vi.fn(async () => ({})) },
       providers: {
         list: vi.fn(async () => [
           makeProviderInfo({ id: "codex", displayName: "Codex" }),
@@ -339,6 +341,50 @@ describe("UpdatesSettingsSection", () => {
     // Exactly one: re-renders must not re-fire it, and the store's own
     // single-flight guard must not be the only thing preventing a loop.
     expect(sdk.system.version).toHaveBeenCalledTimes(1);
+    // The server memoizes CLI status per host; a check must re-probe rather
+    // than re-read that memo, so the request carries force.
+    await waitFor(() => {
+      expect(sdk.hosts.providerCliStatus).toHaveBeenCalledWith({
+        hostId: "host_1",
+        force: true,
+        signal: expect.any(AbortSignal),
+      });
+    });
+    expect(sdk.hosts.providerCliStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("finishes the check when one machine's forced re-probe fails", async () => {
+    useDesktopUpdateInfoMock.mockReturnValue({
+      desktopApi: null,
+      desktopInfo: null,
+      isDesktop: false,
+    });
+    const hostA = makeHost({ id: "host_a", name: "workstation" });
+    const hostB = makeHost({ id: "host_b", name: "laptop" });
+    useUpdateInventoryMock.mockReturnValue(
+      makeInventory({
+        machines: [makeMachine({ host: hostA }), makeMachine({ host: hostB })],
+      }),
+    );
+    vi.mocked(sdk.system.version).mockResolvedValue(
+      makeInventory({}).systemVersion!,
+    );
+    vi.mocked(sdk.hosts.providerCliStatus).mockRejectedValueOnce(
+      new Error("host_unavailable"),
+    );
+
+    renderSection();
+
+    await waitFor(() => {
+      expect(sdk.hosts.providerCliStatus).toHaveBeenCalledTimes(2);
+    });
+    // One unreachable machine is that machine's row problem, not the check's:
+    // invalidation never failed the whole check, and the forced fetch must not
+    // start to.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(appToast.error).not.toHaveBeenCalled();
   });
 
   it("aligns Update all with the first machine heading", () => {
@@ -1002,7 +1048,9 @@ The canonical release summary.
       return node;
     });
     expect(
-      providerIcon?.querySelector("[data-provider-logo]")?.getAttribute("class"),
+      providerIcon
+        ?.querySelector("[data-provider-logo]")
+        ?.getAttribute("class"),
     ).toContain("text-muted-foreground");
     // Icon-only. The accessible name is the state and the verb — the row
     // already prints the CLI, its versions, and the machine above it. Row and
@@ -1205,6 +1253,21 @@ The canonical release summary.
       name: /Check workstation's CLIs again/,
     });
     expect(retry.hasAttribute("disabled")).toBe(false);
+
+    // The page's own check already asked once (with force); Retry is a
+    // second forced re-probe of just this machine.
+    await waitFor(() => {
+      expect(sdk.hosts.providerCliStatus).toHaveBeenCalledTimes(1);
+    });
+    fireEvent.click(retry);
+    await waitFor(() => {
+      expect(sdk.hosts.providerCliStatus).toHaveBeenCalledTimes(2);
+    });
+    expect(sdk.hosts.providerCliStatus).toHaveBeenLastCalledWith({
+      hostId: "host_1",
+      force: true,
+      signal: expect.any(AbortSignal),
+    });
   });
 
   it("keeps error red on the reason and off the recovery", () => {

--- a/apps/app/src/components/settings/UpdatesSettingsSection.tsx
+++ b/apps/app/src/components/settings/UpdatesSettingsSection.tsx
@@ -65,7 +65,7 @@ import {
   SettingsRowList,
   SettingsSection,
 } from "@/components/ui/settings-section";
-import { invalidateHostProviderCliStatus } from "@/hooks/cache-owners/provider-cli-status-cache-owner";
+import { recheckHostProviderCliStatus } from "@/hooks/cache-owners/provider-cli-status-cache-owner";
 import { hydrateSystemVersionCache } from "@/hooks/cache-owners/system-version-cache-owner";
 import { useRetryHostUpdate } from "@/hooks/mutations/host-mutations";
 import {
@@ -1460,7 +1460,7 @@ export function UpdatesSettingsSection({
       }
       await Promise.all(
         connectedHostIds.map((hostId) =>
-          invalidateHostProviderCliStatus({ queryClient, hostId }),
+          recheckHostProviderCliStatus({ queryClient, hostId }),
         ),
       );
     });
@@ -1650,10 +1650,7 @@ export function UpdatesSettingsSection({
                 <ProviderCliCheckRow
                   machine={machine}
                   onRecheckClis={(hostId) => {
-                    void invalidateHostProviderCliStatus({
-                      queryClient,
-                      hostId,
-                    });
+                    void recheckHostProviderCliStatus({ queryClient, hostId });
                   }}
                   onOpenMachine={(hostId) =>
                     navigate(getSettingsMachineRoutePath(hostId))
@@ -1668,7 +1665,9 @@ export function UpdatesSettingsSection({
                 onStartInstall={(hostId, issue) =>
                   startInstall({ hostId, issue })
                 }
-                onOpenProvider={() => navigate(getSettingsRoutePath("providers"))}
+                onOpenProvider={() =>
+                  navigate(getSettingsRoutePath("providers"))
+                }
               />
             </MachineUpdatesSection>
           );

--- a/apps/app/src/hooks/cache-owners/provider-cli-status-cache-owner.test.ts
+++ b/apps/app/src/hooks/cache-owners/provider-cli-status-cache-owner.test.ts
@@ -1,0 +1,89 @@
+import type { HostProviderCliStatusResponse } from "@bb/server-contract";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { sdk } from "@/lib/sdk";
+import { hostProviderCliStatusQueryKey } from "../queries/query-keys";
+import { SESSION_STATIC_QUERY_POLICY } from "../queries/query-policies";
+import { recheckHostProviderCliStatus } from "./provider-cli-status-cache-owner";
+
+vi.mock("@/lib/sdk", () => ({
+  sdk: { hosts: { providerCliStatus: vi.fn() } },
+}));
+
+function status(displayName: string): HostProviderCliStatusResponse[string] {
+  return {
+    displayName,
+    executableName: displayName.toLowerCase(),
+    executablePath: `/usr/local/bin/${displayName.toLowerCase()}`,
+    installed: true,
+    installSource: "npmGlobal",
+    currentVersion: "1.0.0",
+    latestVersion: "1.0.0",
+    minimumSupportedVersion: null,
+    npmPackageName: null,
+    npmGlobalPackageVersion: null,
+    installAction: null,
+    needsUpdate: false,
+    versionUnsupported: false,
+  };
+}
+
+afterEach(() => {
+  vi.mocked(sdk.hosts.providerCliStatus).mockReset();
+});
+
+describe("recheckHostProviderCliStatus", () => {
+  it("still sends force when a plain fetch for the host is in flight", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const queryKey = hostProviderCliStatusQueryKey("host_1");
+    const memoized: HostProviderCliStatusResponse = { codex: status("Codex") };
+    const probed: HostProviderCliStatusResponse = {
+      codex: status("Codex"),
+      pi: status("Pi"),
+    };
+    let answerPlainFetch: (
+      value: HostProviderCliStatusResponse,
+    ) => void = () => {};
+    vi.mocked(sdk.hosts.providerCliStatus).mockImplementation((args) =>
+      args.force === true
+        ? Promise.resolve(probed)
+        : new Promise((resolve) => {
+            answerPlainFetch = resolve;
+          }),
+    );
+
+    // useUpdateInventory's observer: its plain fetch starts on subscribe and
+    // is still pending (the server pays an expired discovery probe before
+    // answering from its status memo) when the on-open check reaches this
+    // host.
+    const observer = new QueryObserver(queryClient, {
+      queryKey,
+      queryFn: ({ signal }) =>
+        sdk.hosts.providerCliStatus({ hostId: "host_1", signal }),
+      ...SESSION_STATIC_QUERY_POLICY,
+    });
+    const unsubscribe = observer.subscribe(() => {});
+    expect(queryClient.getQueryState(queryKey)?.fetchStatus).toBe("fetching");
+
+    const recheck = recheckHostProviderCliStatus({
+      queryClient,
+      hostId: "host_1",
+    });
+    answerPlainFetch(memoized);
+    await recheck;
+
+    const calls = vi.mocked(sdk.hosts.providerCliStatus).mock.calls;
+    expect(calls).toHaveLength(2);
+    // The plain request was abandoned, not joined.
+    expect(calls[0]?.[0].signal?.aborted).toBe(true);
+    expect(calls[1]?.[0]).toEqual({
+      hostId: "host_1",
+      force: true,
+      signal: expect.any(AbortSignal),
+    });
+    expect(queryClient.getQueryData(queryKey)).toEqual(probed);
+    unsubscribe();
+  });
+});

--- a/apps/app/src/hooks/cache-owners/provider-cli-status-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/provider-cli-status-cache-owner.ts
@@ -25,12 +25,19 @@ export function invalidateHostProviderCliStatus(
  * rejection is swallowed: one unreachable host must not fail the whole check,
  * which invalidation never did either.
  */
-export function recheckHostProviderCliStatus(
+export async function recheckHostProviderCliStatus(
   args: HostProviderCliStatusCacheArgs,
 ): Promise<void> {
+  const queryKey = hostProviderCliStatusQueryKey(args.hostId);
+  // fetchQuery joins a fetch already in flight instead of starting its own,
+  // so a check issued while the plain boot/mount fetch is pending would never
+  // send `force` and would report that fetch's memoized answer as a fresh
+  // probe. Cancel the plain fetch first (its request carries the abort
+  // signal); observers keep following the same Query.
+  await args.queryClient.cancelQueries({ queryKey });
   return args.queryClient
     .fetchQuery({
-      queryKey: hostProviderCliStatusQueryKey(args.hostId),
+      queryKey,
       queryFn: ({ signal }) =>
         sdk.hosts.providerCliStatus({
           hostId: args.hostId,

--- a/apps/app/src/hooks/cache-owners/provider-cli-status-cache-owner.ts
+++ b/apps/app/src/hooks/cache-owners/provider-cli-status-cache-owner.ts
@@ -1,16 +1,46 @@
 import type { QueryClient } from "@tanstack/react-query";
+import { sdk } from "@/lib/sdk";
 import { hostProviderCliStatusQueryKey } from "../queries/query-keys";
 
-interface InvalidateHostProviderCliStatusArgs {
+interface HostProviderCliStatusCacheArgs {
   queryClient: QueryClient;
   hostId: string;
 }
 
-/** Re-fetch a host's provider CLI health after an install/update or a manual check. */
+/** Re-fetch a host's provider CLI health after an install/update. */
 export function invalidateHostProviderCliStatus(
-  args: InvalidateHostProviderCliStatusArgs,
+  args: HostProviderCliStatusCacheArgs,
 ): Promise<void> {
   return args.queryClient.invalidateQueries({
     queryKey: hostProviderCliStatusQueryKey(args.hostId),
   });
+}
+
+/**
+ * A manual check ("Check for updates", "Check this machine's CLIs again").
+ * The server memoizes each host's CLI status for minutes, so a plain
+ * invalidation would re-ask and get the same memoized answer; this fetch
+ * carries `force` to re-probe the host. It writes into the same Query the
+ * inventory observers read, so `isFetching` and error state follow, and a
+ * rejection is swallowed: one unreachable host must not fail the whole check,
+ * which invalidation never did either.
+ */
+export function recheckHostProviderCliStatus(
+  args: HostProviderCliStatusCacheArgs,
+): Promise<void> {
+  return args.queryClient
+    .fetchQuery({
+      queryKey: hostProviderCliStatusQueryKey(args.hostId),
+      queryFn: ({ signal }) =>
+        sdk.hosts.providerCliStatus({
+          hostId: args.hostId,
+          force: true,
+          signal,
+        }),
+      staleTime: 0,
+    })
+    .then(
+      () => undefined,
+      () => undefined,
+    );
 }

--- a/apps/cli/src/__tests__/command-output/machine.test.ts
+++ b/apps/cli/src/__tests__/command-output/machine.test.ts
@@ -67,6 +67,30 @@ describe("bb machine command output", () => {
     ]);
   });
 
+  it("bb machine provider-cli status serves the cached status unless --force re-probes", async () => {
+    const status = vi.fn(async () => ({}));
+    stubServerApi({
+      "v1.hosts.$get": vi.fn(async () => hosts),
+      "v1.hosts.:id.provider-clis.status.$get": status,
+    });
+
+    await runCommand(["machine", "provider-cli", "status", "laptop"], register);
+    expect(status).toHaveBeenCalledWith({
+      param: { id: "host-remote" },
+      query: {},
+    });
+
+    status.mockClear();
+    await runCommand(
+      ["machine", "provider-cli", "status", "laptop", "--force"],
+      register,
+    );
+    expect(status).toHaveBeenCalledWith({
+      param: { id: "host-remote" },
+      query: { force: "true" },
+    });
+  });
+
   it("bb machine retry-update resolves the machine and requests a retry", async () => {
     const retryUpdate = vi.fn(async () => ({ ok: true as const }));
     stubServerApi({

--- a/apps/cli/src/__tests__/command-output/updates.test.ts
+++ b/apps/cli/src/__tests__/command-output/updates.test.ts
@@ -123,6 +123,39 @@ describe("bb updates command output", () => {
     expect(output).toContain("offline");
   });
 
+  it("bb updates serves the cached status unless --force re-probes", async () => {
+    const status = vi.fn(async () =>
+      providerStatus({ codexNeedsUpdate: false }),
+    );
+    stubServerApi({
+      "v1.system.version.$get": vi.fn(async () => version),
+      "v1.hosts.$get": vi.fn(async () => hosts),
+      "v1.hosts.:id.provider-clis.status.$get": status,
+    });
+
+    await runCommand(["updates"], register);
+    // Only the connected machine is asked, and without force.
+    expect(status).toHaveBeenCalledOnce();
+    expect(status).toHaveBeenCalledWith({
+      param: { id: "host-primary" },
+      query: {},
+    });
+
+    status.mockClear();
+    await runCommand(["updates", "--force"], register);
+    expect(status).toHaveBeenCalledWith({
+      param: { id: "host-primary" },
+      query: { force: "true" },
+    });
+
+    status.mockClear();
+    await runCommand(["updates", "apply", "--force"], register);
+    expect(status).toHaveBeenCalledWith({
+      param: { id: "host-primary" },
+      query: { force: "true" },
+    });
+  });
+
   it("bb updates --json prints the aggregate", async () => {
     const status = providerStatus({ codexNeedsUpdate: false });
     stubServerApi({

--- a/apps/cli/src/commands/machine.ts
+++ b/apps/cli/src/commands/machine.ts
@@ -18,6 +18,10 @@ interface MachineProviderInstallOptions extends MachineListCommandOptions {
   action?: "install" | "update";
 }
 
+interface MachineProviderCliStatusOptions extends MachineListCommandOptions {
+  force?: boolean;
+}
+
 function parseProviderCliKey(value: string): string {
   const providerId = value.trim();
   if (providerId.length === 0)
@@ -227,12 +231,19 @@ export function registerMachineCommands(
   providerCli
     .command("status <id-or-name>")
     .description("Show registered provider CLI installation/update status")
+    .option(
+      "--force",
+      "Re-probe the machine instead of serving the server's cached status",
+    )
     .option("--json", "Print machine-readable JSON output")
     .action(
-      action(async (target: string, opts: MachineListCommandOptions) => {
+      action(async (target: string, opts: MachineProviderCliStatusOptions) => {
         const sdk = createCliBbSdk(getUrl());
         const hostId = resolveMachineId(await sdk.hosts.list(), target);
-        const result = await sdk.hosts.providerCliStatus({ hostId });
+        const result = await sdk.hosts.providerCliStatus({
+          hostId,
+          ...(opts.force === undefined ? {} : { force: opts.force }),
+        });
         if (outputJson(opts, result)) return;
         console.log(JSON.stringify(result, null, 2));
       }),

--- a/apps/cli/src/commands/updates.ts
+++ b/apps/cli/src/commands/updates.ts
@@ -16,6 +16,7 @@ type ProviderCliStatus = HostProviderCliStatusResponse[string];
 type ProviderCliStatusResponse = HostProviderCliStatusResponse;
 
 interface UpdatesCommandOptions {
+  force?: boolean;
   json?: boolean;
   machine?: string;
 }
@@ -74,6 +75,7 @@ function isActionableProviderStatus(status: ProviderCliStatus): boolean {
 async function collectMachineUpdates(
   sdk: ReturnType<typeof createCliBbSdk>,
   hosts: readonly Host[],
+  options: { force: boolean | undefined },
 ): Promise<MachineUpdatesEntry[]> {
   return Promise.all(
     hosts.map(async (host): Promise<MachineUpdatesEntry> => {
@@ -85,6 +87,7 @@ async function collectMachineUpdates(
           host,
           providerStatus: await sdk.hosts.providerCliStatus({
             hostId: host.id,
+            ...(options.force === undefined ? {} : { force: options.force }),
           }),
           statusError: null,
         };
@@ -167,6 +170,10 @@ export function registerUpdatesCommands(
     .command("status", { isDefault: true })
     .description("Show bb and provider CLI update status across machines")
     .option("--machine <id-or-name>", "Limit to one machine")
+    .option(
+      "--force",
+      "Re-probe each machine instead of serving the server's cached CLI status",
+    )
     .option("--json", "Print machine-readable JSON output")
     .action(
       action(async (opts: UpdatesCommandOptions) => {
@@ -181,7 +188,9 @@ export function registerUpdatesCommands(
             : hosts.filter(
                 (host) => host.id === resolveMachineId(hosts, opts.machine!),
               );
-        const entries = await collectMachineUpdates(sdk, selectedHosts);
+        const entries = await collectMachineUpdates(sdk, selectedHosts, {
+          force: opts.force,
+        });
         if (
           outputJson(opts, {
             app: version,
@@ -216,6 +225,10 @@ export function registerUpdatesCommands(
     .command("apply")
     .description("Run every available provider CLI install/update")
     .option("--machine <id-or-name>", "Limit to one machine")
+    .option(
+      "--force",
+      "Re-probe each machine instead of serving the server's cached CLI status",
+    )
     .option("--json", "Print machine-readable JSON output")
     .action(
       action(async (opts: UpdatesCommandOptions) => {
@@ -227,7 +240,9 @@ export function registerUpdatesCommands(
             : hosts.filter(
                 (host) => host.id === resolveMachineId(hosts, opts.machine!),
               );
-        const entries = await collectMachineUpdates(sdk, selectedHosts);
+        const entries = await collectMachineUpdates(sdk, selectedHosts, {
+          force: opts.force,
+        });
         const targets = actionableTargets(entries);
         if (targets.length === 0) {
           if (outputJson(opts, { results: [] })) return;

--- a/apps/mobile/src/data/README.md
+++ b/apps/mobile/src/data/README.md
@@ -149,7 +149,12 @@ Conventions:
 - `hosts/` (Phase 7 additions) backs Settings → Machines and → Updates on
   top of the list/directory queries: `useHostProviderCliStatus` /
   `useHostsProviderCliStatus` (`GET /hosts/:id/provider-clis/status`,
-  session-static; the Updates check and a finished install invalidate it),
+  session-static; the server memoizes the answer per machine for minutes, so
+  the Updates check and the machine page's Recheck go through
+  `recheckHostProviderCliStatus` (`recheck-provider-cli-status.ts`, a
+  `fetchQuery` with `force: true`) / `useRecheckHostProviderCliStatus`, while
+  a finished install only invalidates — the install route clears the server
+  memo),
   `useRemoveHost`, `useRetryHostUpdate`, `useUpdateHostPermissionCeiling`
   (`PATCH /hosts/:id/permission-ceiling` through the profile fetch in
   `permission-ceiling.ts` — the route is owner-session-only and deliberately

--- a/apps/mobile/src/data/hosts/host-queries.ts
+++ b/apps/mobile/src/data/hosts/host-queries.ts
@@ -8,8 +8,9 @@ import {
   skipToken,
   useQueries,
   useQuery,
+  useQueryClient,
 } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useProfileClient } from "@/app-shell/ProfilesProvider";
 import {
   hostCloneDefaultPathQueryKey,
@@ -24,6 +25,7 @@ import {
 } from "../shared/query-policies";
 import { useHostListRealtimeSubscription } from "../shared/use-realtime-subscription";
 import { useSystemConfig } from "../system/system-queries";
+import { recheckHostProviderCliStatus } from "./recheck-provider-cli-status";
 import { selectPrimaryHost } from "./select-primary-host";
 import { fetchServerProtocolVersion } from "./server-protocol-version";
 
@@ -141,6 +143,19 @@ export function useHostProviderCliStatus(
     enabled,
     ...SESSION_STATIC_QUERY_POLICY,
   });
+}
+
+/** `recheckHostProviderCliStatus` bound to the active profile. */
+export function useRecheckHostProviderCliStatus(): (
+  hostId: string,
+) => Promise<void> {
+  const client = useProfileClient();
+  const queryClient = useQueryClient();
+  return useCallback(
+    (hostId: string) =>
+      recheckHostProviderCliStatus(client, queryClient, hostId),
+    [client, queryClient],
+  );
 }
 
 export interface HostProviderCliStatusEntry {

--- a/apps/mobile/src/data/hosts/index.ts
+++ b/apps/mobile/src/data/hosts/index.ts
@@ -4,6 +4,7 @@ export {
   useHostProviderCliStatus,
   useHosts,
   usePrimaryHost,
+  useRecheckHostProviderCliStatus,
   useServerProtocolVersion,
 } from "./host-queries";
 export { selectPrimaryHost } from "./select-primary-host";

--- a/apps/mobile/src/data/hosts/recheck-host-provider-cli-status.test.ts
+++ b/apps/mobile/src/data/hosts/recheck-host-provider-cli-status.test.ts
@@ -1,0 +1,79 @@
+import type {
+  ProviderCliStatus,
+  ProviderCliStatusResponse,
+} from "@bb/host-daemon-contract/local";
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { hostProviderCliStatusQueryKey } from "@/lib/query/query-keys";
+import { recheckHostProviderCliStatus } from "./recheck-provider-cli-status";
+
+function status(displayName: string): ProviderCliStatus {
+  return {
+    displayName,
+    executableName: displayName.toLowerCase(),
+    executablePath: `/usr/local/bin/${displayName.toLowerCase()}`,
+    installed: true,
+    installSource: "npmGlobal",
+    currentVersion: "1.0.0",
+    latestVersion: "1.0.0",
+    minimumSupportedVersion: null,
+    npmPackageName: null,
+    npmGlobalPackageVersion: null,
+    installAction: null,
+    needsUpdate: false,
+    versionUnsupported: false,
+  };
+}
+
+describe("recheckHostProviderCliStatus", () => {
+  it("re-probes past the server memo and writes the answer into the status query", async () => {
+    const queryClient = new QueryClient();
+    const stale: ProviderCliStatusResponse = { codex: status("Codex") };
+    const fresh: ProviderCliStatusResponse = {
+      codex: status("Codex"),
+      pi: status("Pi"),
+    };
+    queryClient.setQueryData(hostProviderCliStatusQueryKey("host_1"), stale);
+    const providerCliStatus = vi.fn(async () => fresh);
+
+    await recheckHostProviderCliStatus(
+      { sdk: { hosts: { providerCliStatus } } },
+      queryClient,
+      "host_1",
+    );
+
+    // A plain refetch would be answered from the server's memo; force is what
+    // makes this a real check.
+    expect(providerCliStatus).toHaveBeenCalledWith({
+      hostId: "host_1",
+      force: true,
+      signal: expect.any(AbortSignal),
+    });
+    expect(
+      queryClient.getQueryData(hostProviderCliStatusQueryKey("host_1")),
+    ).toEqual(fresh);
+  });
+
+  it("resolves when the host is unreachable so a fleet-wide check finishes", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const providerCliStatus = vi.fn(
+      async (): Promise<ProviderCliStatusResponse> => {
+        throw new Error("host_unavailable");
+      },
+    );
+
+    await expect(
+      recheckHostProviderCliStatus(
+        { sdk: { hosts: { providerCliStatus } } },
+        queryClient,
+        "host_1",
+      ),
+    ).resolves.toBeUndefined();
+    expect(
+      queryClient.getQueryState(hostProviderCliStatusQueryKey("host_1"))
+        ?.status,
+    ).toBe("error");
+  });
+});

--- a/apps/mobile/src/data/hosts/recheck-host-provider-cli-status.test.ts
+++ b/apps/mobile/src/data/hosts/recheck-host-provider-cli-status.test.ts
@@ -2,8 +2,9 @@ import type {
   ProviderCliStatus,
   ProviderCliStatusResponse,
 } from "@bb/host-daemon-contract/local";
-import { QueryClient } from "@tanstack/react-query";
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
 import { describe, expect, it, vi } from "vitest";
+import { SESSION_STATIC_QUERY_POLICY } from "@/data/shared/query-policies";
 import { hostProviderCliStatusQueryKey } from "@/lib/query/query-keys";
 import { recheckHostProviderCliStatus } from "./recheck-provider-cli-status";
 
@@ -52,6 +53,53 @@ describe("recheckHostProviderCliStatus", () => {
     expect(
       queryClient.getQueryData(hostProviderCliStatusQueryKey("host_1")),
     ).toEqual(fresh);
+  });
+
+  it("still sends force when a plain fetch for the host is in flight", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const queryKey = hostProviderCliStatusQueryKey("host_1");
+    const memoized: ProviderCliStatusResponse = { codex: status("Codex") };
+    const probed: ProviderCliStatusResponse = {
+      codex: status("Codex"),
+      pi: status("Pi"),
+    };
+    let answerPlainFetch: (value: ProviderCliStatusResponse) => void = () => {};
+    const providerCliStatus = vi.fn(
+      (args: { hostId: string; force?: boolean; signal?: AbortSignal }) =>
+        args.force === true
+          ? Promise.resolve(probed)
+          : new Promise<ProviderCliStatusResponse>((resolve) => {
+              answerPlainFetch = resolve;
+            }),
+    );
+    const client = { sdk: { hosts: { providerCliStatus } } };
+
+    // useHostsProviderCliStatus's observer: its plain fetch starts on
+    // subscribe and is still pending when the user taps Check for updates.
+    const observer = new QueryObserver(queryClient, {
+      queryKey,
+      queryFn: ({ signal }) => providerCliStatus({ hostId: "host_1", signal }),
+      ...SESSION_STATIC_QUERY_POLICY,
+    });
+    const unsubscribe = observer.subscribe(() => {});
+    expect(queryClient.getQueryState(queryKey)?.fetchStatus).toBe("fetching");
+
+    const recheck = recheckHostProviderCliStatus(client, queryClient, "host_1");
+    answerPlainFetch(memoized);
+    await recheck;
+
+    expect(providerCliStatus.mock.calls).toHaveLength(2);
+    // The plain request was abandoned, not joined.
+    expect(providerCliStatus.mock.calls[0]?.[0].signal?.aborted).toBe(true);
+    expect(providerCliStatus).toHaveBeenLastCalledWith({
+      hostId: "host_1",
+      force: true,
+      signal: expect.any(AbortSignal),
+    });
+    expect(queryClient.getQueryData(queryKey)).toEqual(probed);
+    unsubscribe();
   });
 
   it("resolves when the host is unreachable so a fleet-wide check finishes", async () => {

--- a/apps/mobile/src/data/hosts/recheck-provider-cli-status.ts
+++ b/apps/mobile/src/data/hosts/recheck-provider-cli-status.ts
@@ -1,0 +1,35 @@
+import type { HostProviderCliStatusResponse } from "@bb/server-contract";
+import type { QueryClient } from "@tanstack/react-query";
+import { hostProviderCliStatusQueryKey } from "@/lib/query/query-keys";
+import type { ProfileClient } from "@/lib/sdk/client-registry";
+
+/** The slice of a profile client a forced CLI status re-probe needs. */
+export interface ProviderCliStatusClient {
+  sdk: { hosts: Pick<ProfileClient["sdk"]["hosts"], "providerCliStatus"> };
+}
+
+/**
+ * A manual "Recheck provider CLIs" / "Check for updates". The server memoizes
+ * each host's CLI status for minutes, so a plain refetch or invalidation would
+ * get the memoized answer back; this fetch carries `force` to re-probe the
+ * host. It writes into the same Query `useHostProviderCliStatus` observes
+ * (spinner and error state follow), and swallows the rejection so one
+ * unreachable host does not fail a fleet-wide check.
+ */
+export function recheckHostProviderCliStatus(
+  client: ProviderCliStatusClient,
+  queryClient: QueryClient,
+  hostId: string,
+): Promise<void> {
+  return queryClient
+    .fetchQuery<HostProviderCliStatusResponse>({
+      queryKey: hostProviderCliStatusQueryKey(hostId),
+      queryFn: ({ signal }) =>
+        client.sdk.hosts.providerCliStatus({ hostId, force: true, signal }),
+      staleTime: 0,
+    })
+    .then(
+      () => undefined,
+      () => undefined,
+    );
+}

--- a/apps/mobile/src/data/hosts/recheck-provider-cli-status.ts
+++ b/apps/mobile/src/data/hosts/recheck-provider-cli-status.ts
@@ -16,14 +16,22 @@ export interface ProviderCliStatusClient {
  * (spinner and error state follow), and swallows the rejection so one
  * unreachable host does not fail a fleet-wide check.
  */
-export function recheckHostProviderCliStatus(
+export async function recheckHostProviderCliStatus(
   client: ProviderCliStatusClient,
   queryClient: QueryClient,
   hostId: string,
 ): Promise<void> {
+  const queryKey = hostProviderCliStatusQueryKey(hostId);
+  // fetchQuery joins a fetch already in flight instead of starting its own,
+  // so a check tapped while the screen's plain fetch (or a realtime
+  // invalidation refetch) is pending would never send `force` and would
+  // report that fetch's memoized answer as a fresh probe. Cancel the plain
+  // fetch first (its request carries the abort signal); observers keep
+  // following the same Query.
+  await queryClient.cancelQueries({ queryKey });
   return queryClient
     .fetchQuery<HostProviderCliStatusResponse>({
-      queryKey: hostProviderCliStatusQueryKey(hostId),
+      queryKey,
       queryFn: ({ signal }) =>
         client.sdk.hosts.providerCliStatus({ hostId, force: true, signal }),
       staleTime: 0,

--- a/apps/mobile/src/data/updates/use-update-inventory.ts
+++ b/apps/mobile/src/data/updates/use-update-inventory.ts
@@ -3,7 +3,6 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { useProfileClient } from "@/app-shell/ProfilesProvider";
 import {
-  hostProviderCliStatusQueryKey,
   systemCliSkillsQueryKey,
   systemVersionQueryKey,
 } from "@/lib/query/query-keys";
@@ -12,6 +11,7 @@ import {
   useHostsProviderCliStatus,
   useServerProtocolVersion,
 } from "../hosts/host-queries";
+import { recheckHostProviderCliStatus } from "../hosts/recheck-provider-cli-status";
 import { useSystemConfig, useSystemVersion } from "../system/system-queries";
 import {
   buildUpdateInventory,
@@ -76,22 +76,20 @@ export function useUpdateInventory(
 /**
  * "Check for updates": bypass the server's npm cache
  * (`GET /system/version?force=true`), write the answer into the version
- * cache, and re-ask every connected machine for its provider CLIs and CLI
- * skills.
+ * cache, re-probe every connected machine's provider CLIs past the server's
+ * status memo (`?force=true`), and re-ask for CLI skills.
  */
 export function useCheckForUpdates() {
-  const { sdk } = useProfileClient();
+  const client = useProfileClient();
   const queryClient = useQueryClient();
   return useMutation<SystemVersionResponse, Error, readonly string[]>({
     meta: { errorMessage: "The update check did not complete." },
     mutationFn: async (connectedHostIds) => {
-      const version = await sdk.system.version({ force: true });
+      const version = await client.sdk.system.version({ force: true });
       queryClient.setQueryData(systemVersionQueryKey(), version);
       await Promise.all([
         ...connectedHostIds.map((hostId) =>
-          queryClient.invalidateQueries({
-            queryKey: hostProviderCliStatusQueryKey(hostId),
-          }),
+          recheckHostProviderCliStatus(client, queryClient, hostId),
         ),
         queryClient.invalidateQueries({ queryKey: systemCliSkillsQueryKey() }),
       ]);

--- a/apps/mobile/src/screens/machines/MachineDetailScreen.tsx
+++ b/apps/mobile/src/screens/machines/MachineDetailScreen.tsx
@@ -14,6 +14,7 @@ import {
   PRIMARY_HOST_REMOVE_DISABLED_REASON,
   providerCliIssues,
   useHostProviderCliStatus,
+  useRecheckHostProviderCliStatus,
   useHosts,
   useProviderCliInstallRunner,
   useRemoveHost,
@@ -81,6 +82,7 @@ function ConnectedMachineDetailScreen({ hostId }: { hostId: string }) {
   const online = host?.status === "connected";
 
   const statusQuery = useHostProviderCliStatus(online ? hostId : null);
+  const recheckProviderClis = useRecheckHostProviderCliStatus();
   const serverProtocolVersion = useServerProtocolVersion();
   const runner = useProviderCliInstallRunner();
   const updateCeiling = useUpdateHostPermissionCeiling();
@@ -278,7 +280,7 @@ function ConnectedMachineDetailScreen({ hostId }: { hostId: string }) {
                 accessibilityLabel="Recheck provider CLIs"
                 hitSlop={8}
                 disabled={statusQuery.isFetching}
-                onPress={() => void statusQuery.refetch()}
+                onPress={() => void recheckProviderClis(hostId)}
                 testID="machine-provider-clis-refresh"
               >
                 {statusQuery.isFetching ? (

--- a/apps/mobile/src/screens/settings/UpdatesScreen.tsx
+++ b/apps/mobile/src/screens/settings/UpdatesScreen.tsx
@@ -1,7 +1,7 @@
 import type { Host } from "@bb/domain";
 import type { SystemVersionResponse } from "@bb/server-contract";
 import * as Clipboard from "expo-clipboard";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Linking, Pressable, View } from "react-native";
 import { useProfiles } from "@/app-shell";
 import {
@@ -364,6 +364,20 @@ function ConnectedUpdatesScreen() {
   const connectedHostIds = inventory.machines
     .filter((machine) => machine.host.status === "connected")
     .map((machine) => machine.host.id);
+
+  // Opening the screen is the request to check, as the web section does on
+  // open. Without it the first status read is answered from the server's
+  // memo and "Checked just now" would date that memo hit, not a probe. Waits
+  // for the host list: the check re-probes each connected machine, and on
+  // mount that list is still empty.
+  const hostsSettled = !inventory.isLoading;
+  const checkedOnLoad = useRef(false);
+  useEffect(() => {
+    if (checkedOnLoad.current || !hostsSettled) return;
+    checkedOnLoad.current = true;
+    check.mutate(connectedHostIds);
+    // oxlint-disable-next-line react/exhaustive-deps -- once per mount, with the host snapshot of that moment
+  }, [hostsSettled]);
 
   return (
     <>

--- a/apps/server/src/lifecycle-dedupers.ts
+++ b/apps/server/src/lifecycle-dedupers.ts
@@ -16,6 +16,17 @@ import {
  */
 const PROVIDER_MODEL_LIST_MEMO_TTL_MS = 10 * 60_000;
 
+/**
+ * How long an installed-only provider's "is the agent on this host" answer is
+ * reused. It only flips when the user installs or removes the agent, and the
+ * key carries the daemon session and registration revision, so reconnects and
+ * plugin reloads re-probe regardless. The window must stay well above the
+ * daemon's 60 s maintenance-bridge idle timeout: a shorter one would land most
+ * expiries on a cold bridge, which is the 400 ms–1.3 s respawn this memo exists
+ * to keep off the request path.
+ */
+const INSTALLED_PROVIDER_PROBE_MEMO_TTL_MS = 5 * 60_000;
+
 export interface ProviderModelListMemoValue {
   models: AvailableModel[];
   selectedOnlyModels: AvailableModel[];
@@ -23,6 +34,15 @@ export interface ProviderModelListMemoValue {
 
 export interface LifecycleDedupers {
   environmentCleanupAdvance: AsyncDeduper<string, void>;
+  /**
+   * Memo for the installed-only provider discovery probe (`provider.health`
+   * per `visibility: "installed"` registration). Every provider roster read
+   * (`/system/providers`, `/providers/state`, `/execution-options`, usage
+   * limits, CLI status) used to pay that probe on the host. The value is only
+   * "installed or not": readiness (login state, cwd-scoped health) stays live
+   * in `getProviderState`.
+   */
+  installedProviderProbe: AsyncTtlMemo<string, boolean>;
   /**
    * Memo for host model probes: every execution-options read (each thread
    * open, focus, and reconnect) used to spawn a provider CLI on the host.
@@ -35,6 +55,9 @@ export interface LifecycleDedupers {
 export function createLifecycleDedupers(): LifecycleDedupers {
   return {
     environmentCleanupAdvance: createAsyncDeduper<string, void>(),
+    installedProviderProbe: createAsyncTtlMemo<string, boolean>({
+      ttlMs: INSTALLED_PROVIDER_PROBE_MEMO_TTL_MS,
+    }),
     providerModelList: createAsyncTtlMemo<string, ProviderModelListMemoValue>({
       ttlMs: PROVIDER_MODEL_LIST_MEMO_TTL_MS,
     }),

--- a/apps/server/src/lifecycle-dedupers.ts
+++ b/apps/server/src/lifecycle-dedupers.ts
@@ -1,4 +1,8 @@
 import type { AvailableModel } from "@bb/domain";
+import type {
+  HostDaemonRetryableOnlineRpcCommand,
+  HostDaemonRpcResultForCommand,
+} from "@bb/host-daemon-contract";
 import {
   createAsyncDeduper,
   type AsyncDeduper,
@@ -53,10 +57,28 @@ function isMemoizableProviderModelProbeFailure(error: unknown): boolean {
  */
 const INSTALLED_PROVIDER_PROBE_MEMO_TTL_MS = 5 * 60_000;
 
+/**
+ * How long one provider's `provider.installation.status` answer is reused.
+ * The probe runs `which`, `--version`, `npm view` (network), `npm list -g` and
+ * `claude doctor` on the host — 2-3 s per request — and the app asked for it
+ * on every boot. npm dist-tags move on release cadence, so the same window as
+ * the model list is fine; a manual "Check for updates" bypasses it with
+ * `?force=true`, and the install route clears it.
+ */
+const PROVIDER_INSTALLATION_STATUS_MEMO_TTL_MS = 10 * 60_000;
+
 export interface ProviderModelListMemoValue {
   models: AvailableModel[];
   selectedOnlyModels: AvailableModel[];
 }
+
+export type ProviderInstallationStatusCommand = Extract<
+  HostDaemonRetryableOnlineRpcCommand,
+  { type: "provider.installation.status" }
+>;
+
+export type ProviderInstallationStatusMemoValue =
+  HostDaemonRpcResultForCommand<ProviderInstallationStatusCommand>;
 
 export interface LifecycleDedupers {
   environmentCleanupAdvance: AsyncDeduper<string, void>;
@@ -69,6 +91,17 @@ export interface LifecycleDedupers {
    * in `getProviderState`.
    */
   installedProviderProbe: AsyncTtlMemo<string, boolean>;
+  /**
+   * Memo for per-provider CLI installation status (`GET
+   * /hosts/:id/provider-clis/status`): the sidebar Updates badge and the
+   * compose view both asked for it at boot, and each answer spawned six
+   * subprocesses on the host. Only the raw RPC result is stored; omission on
+   * a 502/504 or the aggregate deadline stays outside the memo.
+   */
+  providerInstallationStatus: AsyncTtlMemo<
+    string,
+    ProviderInstallationStatusMemoValue
+  >;
   /**
    * Memo for host model probes: every execution-options read (each thread
    * open, focus, and reconnect) used to spawn a provider CLI on the host.
@@ -83,6 +116,12 @@ export function createLifecycleDedupers(): LifecycleDedupers {
     environmentCleanupAdvance: createAsyncDeduper<string, void>(),
     installedProviderProbe: createAsyncTtlMemo<string, boolean>({
       ttlMs: INSTALLED_PROVIDER_PROBE_MEMO_TTL_MS,
+    }),
+    providerInstallationStatus: createAsyncTtlMemo<
+      string,
+      ProviderInstallationStatusMemoValue
+    >({
+      ttlMs: PROVIDER_INSTALLATION_STATUS_MEMO_TTL_MS,
     }),
     providerModelList: createAsyncTtlMemo<string, ProviderModelListMemoValue>({
       ttlMs: PROVIDER_MODEL_LIST_MEMO_TTL_MS,

--- a/apps/server/src/lifecycle-dedupers.ts
+++ b/apps/server/src/lifecycle-dedupers.ts
@@ -47,15 +47,31 @@ function isMemoizableProviderModelProbeFailure(error: unknown): boolean {
 }
 
 /**
- * How long an installed-only provider's "is the agent on this host" answer is
- * reused. It only flips when the user installs or removes the agent, and the
- * key carries the daemon session and registration revision, so reconnects and
- * plugin reloads re-probe regardless. The window must stay well above the
- * daemon's 60 s maintenance-bridge idle timeout: a shorter one would land most
- * expiries on a cold bridge, which is the 400 ms–1.3 s respawn this memo exists
- * to keep off the request path.
+ * How long an installed-only provider's "the agent is on this host" answer is
+ * reused. The key carries the daemon session and registration revision, so a
+ * reconnect or plugin reload re-probes regardless, and the provider-clis
+ * install route and `?force=true` clear the memo explicitly.
+ *
+ * 5 min trades probe count against staleness: an agent installed outside bb
+ * can stay hidden from the picker for up to this window. It does not buy a
+ * warm bridge. The daemon's maintenance bridge idles out after 60 s without
+ * maintenance traffic and a memo hit sends none, so any window above 60 s
+ * lands the expiry probe on a cold bridge unless other maintenance traffic
+ * (usage, model list, installation status) kept it warm; lengthening the
+ * window makes expiries rarer, not warmer.
  */
 const INSTALLED_PROVIDER_PROBE_MEMO_TTL_MS = 5 * 60_000;
+
+/**
+ * How long a "not installed" answer is held, much shorter than a "present"
+ * one because the daemon cannot tell absence from a failed lookup: its bridge
+ * reports `not_installed` for any `which` failure (spawn error, the 5 s probe
+ * timeout) and while the daemon runs on its fallback PATH during the first
+ * ~10 s after boot, when the login-shell env resolution timed out. Before the
+ * memo the next roster read corrected such a miss; 30 s keeps that
+ * self-healing while still collapsing the per-request bridge respawn.
+ */
+const INSTALLED_PROVIDER_ABSENT_MEMO_TTL_MS = 30_000;
 
 /**
  * How long one provider's `provider.installation.status` answer is reused.
@@ -116,6 +132,10 @@ export function createLifecycleDedupers(): LifecycleDedupers {
     environmentCleanupAdvance: createAsyncDeduper<string, void>(),
     installedProviderProbe: createAsyncTtlMemo<string, boolean>({
       ttlMs: INSTALLED_PROVIDER_PROBE_MEMO_TTL_MS,
+      ttlMsForValue: (installed) =>
+        installed
+          ? INSTALLED_PROVIDER_PROBE_MEMO_TTL_MS
+          : INSTALLED_PROVIDER_ABSENT_MEMO_TTL_MS,
     }),
     providerInstallationStatus: createAsyncTtlMemo<
       string,

--- a/apps/server/src/lifecycle-dedupers.ts
+++ b/apps/server/src/lifecycle-dedupers.ts
@@ -7,6 +7,8 @@ import {
   createAsyncTtlMemo,
   type AsyncTtlMemo,
 } from "./services/lib/async-ttl-memo.js";
+import { ApiError } from "./errors.js";
+import { isHostUnavailableApiError } from "./services/hosts/online-rpc.js";
 
 /**
  * How long a successful `provider.list_models` answer is reused. Provider
@@ -15,6 +17,30 @@ import {
  * or a plugin reload re-probes immediately regardless of this window.
  */
 const PROVIDER_MODEL_LIST_MEMO_TTL_MS = 10 * 60_000;
+
+/**
+ * How long a failed `provider.list_models` answer is replayed. A failed probe
+ * is normally a CLI that is missing, not logged in, or timing out; without a
+ * window every execution-options read (each thread open) re-spawned it only
+ * to fail again. 30 s bounds the lag between `claude login` in a terminal and
+ * the picker recovering, and the provider CLI install route clears the memo
+ * explicitly.
+ */
+const PROVIDER_MODEL_LIST_FAILURE_MEMO_TTL_MS = 30_000;
+
+/**
+ * Only a host-answered failure is worth replaying: a 502 the daemon returned
+ * or a 504 command timeout. `host_unavailable` is transport — no CLI was
+ * spawned — and replaying it would delay recovery once the daemon is back.
+ * Anything else (parse or internal errors) must retry.
+ */
+function isMemoizableProviderModelProbeFailure(error: unknown): boolean {
+  return (
+    error instanceof ApiError &&
+    (error.status === 502 || error.status === 504) &&
+    !isHostUnavailableApiError(error)
+  );
+}
 
 /**
  * How long an installed-only provider's "is the agent on this host" answer is
@@ -60,6 +86,10 @@ export function createLifecycleDedupers(): LifecycleDedupers {
     }),
     providerModelList: createAsyncTtlMemo<string, ProviderModelListMemoValue>({
       ttlMs: PROVIDER_MODEL_LIST_MEMO_TTL_MS,
+      failures: {
+        ttlMs: PROVIDER_MODEL_LIST_FAILURE_MEMO_TTL_MS,
+        shouldMemoize: isMemoizableProviderModelProbeFailure,
+      },
     }),
     queuedMessageAutoSend: createAsyncDeduper<string, void>(),
     threadProvisionAdvance: createAsyncDeduper<string, void>(),

--- a/apps/server/src/routes/hosts.ts
+++ b/apps/server/src/routes/hosts.ts
@@ -285,10 +285,13 @@ export function registerHostRoutes(
     return context.json(result);
   });
 
-  get(routes.providerCliStatus, async (context) => {
+  get(routes.providerCliStatus, async (context, query) => {
     const hostId = context.req.param("id");
     assertUsableHostId(deps, { hostId });
-    const result = await getProviderInstallations(deps, { hostId });
+    const result = await getProviderInstallations(deps, {
+      hostId,
+      force: query.force === "true",
+    });
     return context.json(result);
   });
 
@@ -325,11 +328,13 @@ export function registerHostRoutes(
         bridgeLaunch,
       },
     }).finally(() => {
-      // An install or update changes what the host has, so the next roster
-      // and model-list reads must probe again rather than replay the
-      // pre-install answer (for the model list, a memoized missing_executable
-      // failure). Also cleared on failure: a half-finished install costs only
-      // one re-probe.
+      // An install or update changes what the host has, so the next CLI
+      // status, roster, and model-list reads must probe again rather than
+      // replay the pre-install answer (for the model list, a memoized
+      // missing_executable failure). The app's post-install invalidation
+      // relies on this rather than passing force. Also cleared on failure: a
+      // half-finished install costs only one re-probe.
+      deps.lifecycleDedupers.providerInstallationStatus.clear();
       deps.lifecycleDedupers.installedProviderProbe.clear();
       deps.lifecycleDedupers.providerModelList.clear();
     });

--- a/apps/server/src/routes/hosts.ts
+++ b/apps/server/src/routes/hosts.ts
@@ -297,10 +297,7 @@ export function registerHostRoutes(
     assertUsableHostId(deps, { hostId });
     await deps.providerRegistry.whenProviderRegistered(payload.provider);
     const registration = deps.providerRegistry.get(payload.provider);
-    if (
-      registration === null ||
-      !registration.info.maintenance.installation
-    ) {
+    if (registration === null || !registration.info.maintenance.installation) {
       throw new ApiError(
         404,
         "provider_installation_unavailable",
@@ -327,6 +324,11 @@ export function registerHostRoutes(
         action: payload.actionKind,
         bridgeLaunch,
       },
+    }).finally(() => {
+      // An install or update changes what the host has, so the next roster
+      // read must probe again rather than replay the pre-install answer. Also
+      // cleared on failure: a half-finished install costs only one re-probe.
+      deps.lifecycleDedupers.installedProviderProbe.clear();
     });
     return new Response(providerCliInstallEventsToNdjson(result.events), {
       headers: {

--- a/apps/server/src/routes/hosts.ts
+++ b/apps/server/src/routes/hosts.ts
@@ -326,9 +326,12 @@ export function registerHostRoutes(
       },
     }).finally(() => {
       // An install or update changes what the host has, so the next roster
-      // read must probe again rather than replay the pre-install answer. Also
-      // cleared on failure: a half-finished install costs only one re-probe.
+      // and model-list reads must probe again rather than replay the
+      // pre-install answer (for the model list, a memoized missing_executable
+      // failure). Also cleared on failure: a half-finished install costs only
+      // one re-probe.
       deps.lifecycleDedupers.installedProviderProbe.clear();
+      deps.lifecycleDedupers.providerModelList.clear();
     });
     return new Response(providerCliInstallEventsToNdjson(result.events), {
       headers: {

--- a/apps/server/src/services/lib/async-ttl-memo.ts
+++ b/apps/server/src/services/lib/async-ttl-memo.ts
@@ -43,6 +43,11 @@ export function createAsyncTtlMemo<TKey, TValue>({
 }: CreateAsyncTtlMemoOptions): AsyncTtlMemo<TKey, TValue> {
   const settledByKey = new Map<TKey, MemoEntry<TValue>>();
   const pendingByKey = new Map<TKey, Promise<TValue>>();
+  // Bumped by clear(). A task that was already running when the memo was
+  // cleared still settles for its callers, but its outcome describes the
+  // world before whatever prompted the clear (a CLI install, a forced
+  // recheck) and must not be stored: nothing would evict it until the TTL.
+  let generation = 0;
 
   function pruneExpired(currentTime: number): void {
     for (const [key, entry] of settledByKey) {
@@ -62,6 +67,7 @@ export function createAsyncTtlMemo<TKey, TValue>({
 
   return {
     clear() {
+      generation += 1;
       settledByKey.clear();
       pendingByKey.clear();
     },
@@ -80,16 +86,23 @@ export function createAsyncTtlMemo<TKey, TValue>({
       if (pending !== undefined) {
         return pending;
       }
+      const startedGeneration = generation;
       const started = task()
         .then(
           (value) => {
-            store(key, { ok: true, value }, ttlMs);
+            if (generation === startedGeneration) {
+              store(key, { ok: true, value }, ttlMs);
+            }
             return value;
           },
           // Two-argument `then`: only the task's own rejection is a candidate
           // for the failure window, never an error thrown while storing.
           (error: unknown) => {
-            if (failures !== undefined && failures.shouldMemoize(error)) {
+            if (
+              generation === startedGeneration &&
+              failures !== undefined &&
+              failures.shouldMemoize(error)
+            ) {
               store(key, { ok: false, error }, failures.ttlMs);
             }
             throw error;

--- a/apps/server/src/services/lib/async-ttl-memo.ts
+++ b/apps/server/src/services/lib/async-ttl-memo.ts
@@ -6,7 +6,19 @@
  * accepts for a separate (normally much shorter) window.
  */
 export interface AsyncTtlMemo<TKey, TValue> {
+  /**
+   * Forgets every entry and fences the outcomes of tasks still in flight out
+   * of the memo: for when the world changed (a CLI install), so a task that
+   * started before the change describes the old world.
+   */
   clear(): void;
+  /**
+   * Forgets settled entries only. A task still in flight can still be joined
+   * and still stores its outcome: for a forced read, which must never be
+   * served a settled answer but has no reason to duplicate a task that is
+   * already describing the world now.
+   */
+  forgetSettled(): void;
   run(key: TKey, task: () => Promise<TValue>): Promise<TValue>;
 }
 
@@ -52,10 +64,10 @@ export function createAsyncTtlMemo<TKey, TValue>({
 }: CreateAsyncTtlMemoOptions<TValue>): AsyncTtlMemo<TKey, TValue> {
   const settledByKey = new Map<TKey, MemoEntry<TValue>>();
   const pendingByKey = new Map<TKey, Promise<TValue>>();
-  // Bumped by clear(). A task that was already running when the memo was
-  // cleared still settles for its callers, but its outcome describes the
-  // world before whatever prompted the clear (a CLI install, a forced
-  // recheck) and must not be stored: nothing would evict it until the TTL.
+  // Bumped by clear(), not by forgetSettled(). A task that was already running
+  // when the memo was cleared still settles for its callers, but its outcome
+  // describes the world before whatever prompted the clear (a CLI install)
+  // and must not be stored: nothing would evict it until the TTL.
   let generation = 0;
 
   function pruneExpired(currentTime: number): void {
@@ -79,6 +91,9 @@ export function createAsyncTtlMemo<TKey, TValue>({
       generation += 1;
       settledByKey.clear();
       pendingByKey.clear();
+    },
+    forgetSettled() {
+      settledByKey.clear();
     },
     run(key, task) {
       const currentTime = now();

--- a/apps/server/src/services/lib/async-ttl-memo.ts
+++ b/apps/server/src/services/lib/async-ttl-memo.ts
@@ -21,8 +21,16 @@ interface MemoizedFailuresOptions {
   shouldMemoize(error: unknown): boolean;
 }
 
-interface CreateAsyncTtlMemoOptions {
+interface CreateAsyncTtlMemoOptions<TValue> {
+  /** How long a settled value is served. */
   ttlMs: number;
+  /**
+   * Per-value window overriding `ttlMs`. Some answers are weaker evidence
+   * than others (a probe that reports "absent" can be a failed lookup,
+   * "present" cannot), and holding both for the same time would freeze the
+   * weak one for as long as the strong one.
+   */
+  ttlMsForValue?: (value: TValue) => number;
   failures?: MemoizedFailuresOptions;
   now?: () => number;
 }
@@ -38,9 +46,10 @@ interface MemoEntry<TValue> {
 
 export function createAsyncTtlMemo<TKey, TValue>({
   ttlMs,
+  ttlMsForValue,
   failures,
   now = Date.now,
-}: CreateAsyncTtlMemoOptions): AsyncTtlMemo<TKey, TValue> {
+}: CreateAsyncTtlMemoOptions<TValue>): AsyncTtlMemo<TKey, TValue> {
   const settledByKey = new Map<TKey, MemoEntry<TValue>>();
   const pendingByKey = new Map<TKey, Promise<TValue>>();
   // Bumped by clear(). A task that was already running when the memo was
@@ -91,7 +100,7 @@ export function createAsyncTtlMemo<TKey, TValue>({
         .then(
           (value) => {
             if (generation === startedGeneration) {
-              store(key, { ok: true, value }, ttlMs);
+              store(key, { ok: true, value }, ttlMsForValue?.(value) ?? ttlMs);
             }
             return value;
           },

--- a/apps/server/src/services/lib/async-ttl-memo.ts
+++ b/apps/server/src/services/lib/async-ttl-memo.ts
@@ -1,25 +1,44 @@
 /**
  * An in-process memo for expensive async lookups: concurrent calls for one key
  * share the in-flight promise, and a settled success is served from memory
- * until it expires. Failures are never stored, so the next call retries.
+ * until it expires. Failures are forgotten by default, so the next call
+ * retries; a memo created with `failures` replays the rejections its predicate
+ * accepts for a separate (normally much shorter) window.
  */
 export interface AsyncTtlMemo<TKey, TValue> {
   clear(): void;
   run(key: TKey, task: () => Promise<TValue>): Promise<TValue>;
 }
 
+interface MemoizedFailuresOptions {
+  /** How long an accepted rejection is replayed before the task runs again. */
+  ttlMs: number;
+  /**
+   * Which rejections are worth replaying. Callers pass a predicate rather than
+   * memoizing every failure so a transport error (nothing was spawned) keeps
+   * retrying at once while a host-answered failure is not re-run on every read.
+   */
+  shouldMemoize(error: unknown): boolean;
+}
+
 interface CreateAsyncTtlMemoOptions {
   ttlMs: number;
+  failures?: MemoizedFailuresOptions;
   now?: () => number;
 }
 
+type MemoOutcome<TValue> =
+  | { ok: true; value: TValue }
+  | { ok: false; error: unknown };
+
 interface MemoEntry<TValue> {
   expiresAt: number;
-  value: TValue;
+  outcome: MemoOutcome<TValue>;
 }
 
 export function createAsyncTtlMemo<TKey, TValue>({
   ttlMs,
+  failures,
   now = Date.now,
 }: CreateAsyncTtlMemoOptions): AsyncTtlMemo<TKey, TValue> {
   const settledByKey = new Map<TKey, MemoEntry<TValue>>();
@@ -33,6 +52,14 @@ export function createAsyncTtlMemo<TKey, TValue>({
     }
   }
 
+  function store(key: TKey, outcome: MemoOutcome<TValue>, ttl: number): void {
+    const settledAt = now();
+    // Expired neighbours are swept here rather than on a timer so the map
+    // stays bounded without keeping the process alive.
+    pruneExpired(settledAt);
+    settledByKey.set(key, { outcome, expiresAt: settledAt + ttl });
+  }
+
   return {
     clear() {
       settledByKey.clear();
@@ -43,7 +70,9 @@ export function createAsyncTtlMemo<TKey, TValue>({
       const settled = settledByKey.get(key);
       if (settled !== undefined) {
         if (settled.expiresAt > currentTime) {
-          return Promise.resolve(settled.value);
+          return settled.outcome.ok
+            ? Promise.resolve(settled.outcome.value)
+            : Promise.reject(settled.outcome.error);
         }
         settledByKey.delete(key);
       }
@@ -52,14 +81,20 @@ export function createAsyncTtlMemo<TKey, TValue>({
         return pending;
       }
       const started = task()
-        .then((value) => {
-          const settledAt = now();
-          // Expired neighbours are swept here rather than on a timer so the map
-          // stays bounded without keeping the process alive.
-          pruneExpired(settledAt);
-          settledByKey.set(key, { value, expiresAt: settledAt + ttlMs });
-          return value;
-        })
+        .then(
+          (value) => {
+            store(key, { ok: true, value }, ttlMs);
+            return value;
+          },
+          // Two-argument `then`: only the task's own rejection is a candidate
+          // for the failure window, never an error thrown while storing.
+          (error: unknown) => {
+            if (failures !== undefined && failures.shouldMemoize(error)) {
+              store(key, { ok: false, error }, failures.ttlMs);
+            }
+            throw error;
+          },
+        )
         .finally(() => {
           if (pendingByKey.get(key) === started) {
             pendingByKey.delete(key);

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -274,11 +274,16 @@ message agents, or inspect projects, providers, and environments.
 - `bb machine show`, `join-code`, `rename`, `retry-update`, and `remove` cover
   the Settings → Machines lifecycle. Use `bb machine provider-cli
 status|install` to inspect or install provider CLIs on a selected machine.
+  Provider CLI status is cached on the server per machine for about ten
+  minutes (each probe spawns several subprocesses, including an npm lookup);
+  a finished install refreshes it, and `bb machine provider-cli status
+<machine> --force` re-probes right now.
 - `bb updates` (alias for `bb updates status`) aggregates bb-app and provider
   CLI update state across every machine — the CLI counterpart of Settings →
   Updates. `bb updates apply [--machine <id-or-name>]` runs every available
   provider CLI install/update sequentially; update bb-app itself with the
-  printed upgrade command or the desktop relaunch.
+  printed upgrade command or the desktop relaunch. Both accept `--force` to
+  re-probe each machine's provider CLIs instead of serving the cached status.
 - Use `bb project create --name <name> --root <path> --machine <id-or-name>`
   to bind a new project's local path to a connected enrolled machine. Use
   `--host` as an alias. Omitting both selectors preserves the existing local

--- a/apps/server/src/services/system/execution-options.ts
+++ b/apps/server/src/services/system/execution-options.ts
@@ -179,18 +179,15 @@ async function listInstalledPluginProviderInfos(
       );
       if (bridgeLaunch === null) return null;
       try {
-        const result = await callHostRetryableOnlineRpc(deps, {
+        const installed = await probeInstalledProviderMemoized(deps, {
           hostId,
-          timeoutMs: COMMAND_TIMEOUT_MS,
           command: {
             type: "provider.health",
             providerId: registration.info.id,
             bridgeLaunch,
           },
         });
-        return result.supported && result.health.status !== "not_installed"
-          ? registration.info
-          : null;
+        return installed ? registration.info : null;
       } catch (error) {
         if (!canOmitProviderDiscoveryForError(error)) {
           throw error;
@@ -603,6 +600,45 @@ type ProviderListModelsCommand = Extract<
   HostDaemonRetryableOnlineRpcCommand,
   { type: "provider.list_models" }
 >;
+
+type ProviderHealthCommand = Extract<
+  HostDaemonRetryableOnlineRpcCommand,
+  { type: "provider.health" }
+>;
+
+/**
+ * Runs the installed-only discovery probe through the process-wide memo, keyed
+ * like {@link listProviderModelsMemoized}: host, daemon session, registration
+ * revision, and the full command (the bridge launch carries the plugin
+ * artifact digest, so a rebuilt plugin re-probes). The command has no cwd, so
+ * one entry per host serves every roster read. Only "installed or not" is
+ * stored; the caller's 502/504 handling stays outside the memo so a transient
+ * omission is never replayed for the TTL.
+ */
+async function probeInstalledProviderMemoized(
+  deps: LoggedWorkSessionDeps,
+  { command, hostId }: { command: ProviderHealthCommand; hostId: string },
+): Promise<boolean> {
+  const probe = async (): Promise<boolean> => {
+    const result = await callHostRetryableOnlineRpc(deps, {
+      hostId,
+      timeoutMs: COMMAND_TIMEOUT_MS,
+      command,
+    });
+    return result.supported && result.health.status !== "not_installed";
+  };
+  const daemonSessionId = deps.hub.getDaemonSessionIdForHost(hostId);
+  if (daemonSessionId === null) {
+    return probe();
+  }
+  const memoKey = JSON.stringify([
+    hostId,
+    daemonSessionId,
+    deps.providerRegistry.getRegistrationRevision(),
+    command,
+  ]);
+  return deps.lifecycleDedupers.installedProviderProbe.run(memoKey, probe);
+}
 
 /**
  * Runs the host model probe through the process-wide memo. The key carries

--- a/apps/server/src/services/system/execution-options.ts
+++ b/apps/server/src/services/system/execution-options.ts
@@ -647,7 +647,11 @@ async function probeInstalledProviderMemoized(
  * fresh), the provider registration revision (a plugin reload can change the
  * bridge), and the full command (provider, launch spec, bridge launch, and the
  * workspace path when the catalog is workspace-scoped). Concurrent callers for
- * one key share the in-flight probe; failures are not memoized.
+ * one key share the in-flight probe. A host-answered failure (502/504 other
+ * than `host_unavailable`) is replayed for the memo's short failure window so
+ * a missing or logged-out CLI is not re-spawned on every read; the rejection
+ * flows through the caller's catch into `modelLoadError` exactly as a live
+ * failure does.
  *
  * The probe is skipped only when no daemon session is registered yet: the
  * retryable RPC waits for one, and its answer would then belong to a session

--- a/apps/server/src/services/system/provider-installations.ts
+++ b/apps/server/src/services/system/provider-installations.ts
@@ -3,6 +3,10 @@ import type {
   ProviderCliStatusResponse,
 } from "@bb/host-daemon-contract";
 import { ZodError } from "zod";
+import type {
+  ProviderInstallationStatusCommand,
+  ProviderInstallationStatusMemoValue,
+} from "../../lifecycle-dedupers.js";
 import type { AppDeps } from "../../types.js";
 import { COMMAND_TIMEOUT_MS } from "../../constants.js";
 import { ApiError } from "../../errors.js";
@@ -27,11 +31,57 @@ function canOmitProviderInstallationStatusError(error: unknown): boolean {
   );
 }
 
-/** Aggregate provider-owned installation state in registry order. */
+/**
+ * Runs one provider's installation probe through the process-wide memo, keyed
+ * like the model-list memo: host, daemon session, registration revision, and
+ * the full command (the bridge launch carries the plugin artifact digest, so a
+ * rebuilt plugin re-probes). Only the raw RPC result is stored: the caller's
+ * deadline check and 502/504 omission stay outside so a transient omission is
+ * never frozen for the TTL. Skipped when no daemon session is registered, as
+ * the answer would then belong to a session this call cannot name.
+ */
+function readProviderInstallationStatusMemoized(
+  deps: AppDeps,
+  {
+    command,
+    hostId,
+    timeoutMs,
+  }: {
+    command: ProviderInstallationStatusCommand;
+    hostId: string;
+    timeoutMs: number;
+  },
+): Promise<ProviderInstallationStatusMemoValue> {
+  const probe = (): Promise<ProviderInstallationStatusMemoValue> =>
+    callHostRetryableOnlineRpc(deps, { hostId, timeoutMs, command });
+  const daemonSessionId = deps.hub.getDaemonSessionIdForHost(hostId);
+  if (daemonSessionId === null) {
+    return probe();
+  }
+  const memoKey = JSON.stringify([
+    hostId,
+    daemonSessionId,
+    deps.providerRegistry.getRegistrationRevision(),
+    command,
+  ]);
+  return deps.lifecycleDedupers.providerInstallationStatus.run(memoKey, probe);
+}
+
+/**
+ * Aggregate provider-owned installation state in registry order. `force` is
+ * the manual "Check for updates" / "Recheck CLIs" path: it forgets every
+ * memoized installation answer and installed-only discovery probe first, so
+ * the read that follows reflects the host right now rather than the last few
+ * minutes.
+ */
 export async function getProviderInstallations(
   deps: AppDeps,
-  args: { hostId: string },
+  args: { hostId: string; force: boolean },
 ): Promise<ProviderCliStatusResponse> {
+  if (args.force) {
+    deps.lifecycleDedupers.providerInstallationStatus.clear();
+    deps.lifecycleDedupers.installedProviderProbe.clear();
+  }
   const deadline = Date.now() + PROVIDER_INSTALLATION_STATUS_TIMEOUT_MS;
   const providers = await listSystemProviderInfos(deps, {
     hostId: args.hostId,
@@ -65,7 +115,7 @@ export async function getProviderInstallations(
         return null;
       }
       try {
-        const status = await callHostRetryableOnlineRpc(deps, {
+        const status = await readProviderInstallationStatusMemoized(deps, {
           hostId: args.hostId,
           timeoutMs: Math.min(COMMAND_TIMEOUT_MS, remainingMs),
           command: {
@@ -74,10 +124,7 @@ export async function getProviderInstallations(
             bridgeLaunch,
           },
         });
-        return [
-          provider.id,
-          { displayName: provider.displayName, ...status },
-        ];
+        return [provider.id, { displayName: provider.displayName, ...status }];
       } catch (error) {
         if (!canOmitProviderInstallationStatusError(error)) {
           throw error;

--- a/apps/server/src/services/system/provider-installations.ts
+++ b/apps/server/src/services/system/provider-installations.ts
@@ -70,17 +70,21 @@ function readProviderInstallationStatusMemoized(
 /**
  * Aggregate provider-owned installation state in registry order. `force` is
  * the manual "Check for updates" / "Recheck CLIs" path: it forgets every
- * memoized installation answer and installed-only discovery probe first, so
+ * settled installation answer and installed-only discovery probe first, so
  * the read that follows reflects the host right now rather than the last few
- * minutes.
+ * minutes. A probe already in flight is joined, not restarted: it describes
+ * the host now as well, and the app only cancels the plain read it belongs
+ * to client-side, so a clear() here would have the host run a second probe
+ * set concurrently and then fence the first set's answer out of the memo.
+ * The install route keeps clear(): there the in-flight probe is pre-install.
  */
 export async function getProviderInstallations(
   deps: AppDeps,
   args: { hostId: string; force: boolean },
 ): Promise<ProviderCliStatusResponse> {
   if (args.force) {
-    deps.lifecycleDedupers.providerInstallationStatus.clear();
-    deps.lifecycleDedupers.installedProviderProbe.clear();
+    deps.lifecycleDedupers.providerInstallationStatus.forgetSettled();
+    deps.lifecycleDedupers.installedProviderProbe.forgetSettled();
   }
   const deadline = Date.now() + PROVIDER_INSTALLATION_STATUS_TIMEOUT_MS;
   const providers = await listSystemProviderInfos(deps, {

--- a/apps/server/test/public/public-provider-installations.test.ts
+++ b/apps/server/test/public/public-provider-installations.test.ts
@@ -10,7 +10,7 @@ import { ApiError } from "../../src/errors.js";
 import { buildPluginProviderRegistration } from "../../src/services/providers/plugin-provider-registration.js";
 import { registerHostRpcResponder } from "../helpers/host-rpc.js";
 import { readJson } from "../helpers/json.js";
-import { seedHostSession } from "../helpers/seed.js";
+import { seedHostSession, seedSession } from "../helpers/seed.js";
 import { type TestAppHarness, withTestHarness } from "../helpers/test-app.js";
 
 const API = "/api/v1";
@@ -230,6 +230,175 @@ describe("public provider installation routes", () => {
         },
         "Failed to load provider installation status; omitting provider",
       );
+    });
+  });
+
+  it("serves repeat status reads from the memo until force re-probes", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "provider-installation-memo-host",
+      });
+      const responder = registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: handleProviderInstallationRpc,
+      });
+      const statusRequests = () =>
+        responder.requests.filter(
+          (request) => request.command.type === "provider.installation.status",
+        );
+
+      const first = await harness.app.request(
+        `${API}/hosts/${host.id}/provider-clis/status`,
+      );
+      const second = await harness.app.request(
+        `${API}/hosts/${host.id}/provider-clis/status`,
+      );
+      expect(first.status).toBe(200);
+      expect(await readJson(second)).toEqual(await readJson(first));
+      // Four installation-capable providers, probed once each.
+      expect(statusRequests()).toHaveLength(4);
+
+      const forced = await harness.app.request(
+        `${API}/hosts/${host.id}/provider-clis/status?force=true`,
+      );
+      expect(forced.status).toBe(200);
+      expect(statusRequests()).toHaveLength(8);
+
+      const explicitlyUnforced = await harness.app.request(
+        `${API}/hosts/${host.id}/provider-clis/status?force=false`,
+      );
+      expect(explicitlyUnforced.status).toBe(200);
+      expect(statusRequests()).toHaveLength(8);
+    });
+  });
+
+  it("re-probes status after a provider CLI install", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "provider-installation-memo-install-host",
+      });
+      const responder = registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: handleProviderInstallationRpc,
+      });
+      const statusRequests = () =>
+        responder.requests.filter(
+          (request) => request.command.type === "provider.installation.status",
+        );
+
+      await harness.app.request(`${API}/hosts/${host.id}/provider-clis/status`);
+      expect(statusRequests()).toHaveLength(4);
+
+      const install = await harness.app.request(
+        `${API}/hosts/${host.id}/provider-clis/install`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ provider: "codex", actionKind: "install" }),
+        },
+      );
+      expect(install.status).toBe(200);
+
+      // The app's post-install invalidation sends no force; the route's own
+      // clear is what makes the CLI it just installed show up.
+      await harness.app.request(`${API}/hosts/${host.id}/provider-clis/status`);
+      expect(statusRequests()).toHaveLength(8);
+    });
+  });
+
+  it("does not memoize a failed status probe", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "provider-installation-memo-failure-host",
+      });
+      let failClaude = true;
+      const responder = registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: (request) => {
+          if (
+            failClaude &&
+            request.command.type === "provider.installation.status" &&
+            request.command.providerId === "claude-code"
+          ) {
+            return {
+              ok: false,
+              errorCode: "provider_status_failed",
+              errorMessage: "provider status failed",
+            };
+          }
+          return handleProviderInstallationRpc(request);
+        },
+      });
+
+      const failed = await harness.app.request(
+        `${API}/hosts/${host.id}/provider-clis/status`,
+      );
+      const failedBody = (await readJson(failed)) as ProviderCliStatusResponse;
+      expect(Object.keys(failedBody)).toEqual(["codex", "pi", "acp-cursor"]);
+
+      failClaude = false;
+      const recovered = await harness.app.request(
+        `${API}/hosts/${host.id}/provider-clis/status`,
+      );
+      const recoveredBody = (await readJson(
+        recovered,
+      )) as ProviderCliStatusResponse;
+      expect(Object.keys(recoveredBody)).toEqual([
+        "codex",
+        "claude-code",
+        "pi",
+        "acp-cursor",
+      ]);
+      // Only the failed provider was asked again; the others were memoized.
+      expect(
+        responder.requests
+          .filter(
+            (request) =>
+              request.command.type === "provider.installation.status",
+          )
+          .map((request) =>
+            request.command.type === "provider.installation.status"
+              ? request.command.providerId
+              : null,
+          ),
+      ).toEqual(["codex", "claude-code", "pi", "acp-cursor", "claude-code"]);
+    });
+  });
+
+  it("re-probes status after the daemon reconnects", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "provider-installation-memo-reconnect-host",
+      });
+      registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: handleProviderInstallationRpc,
+      });
+      await harness.app.request(`${API}/hosts/${host.id}/provider-clis/status`);
+
+      // A reconnected daemon may run a different CLI: its first status read
+      // must not be answered from the previous session's memo.
+      harness.hub.unregisterDaemon(session.id);
+      const nextSession = seedSession(harness.deps, host.id);
+      const nextResponder = registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: nextSession.id,
+        handle: handleProviderInstallationRpc,
+      });
+
+      const response = await harness.app.request(
+        `${API}/hosts/${host.id}/provider-clis/status`,
+      );
+      expect(response.status).toBe(200);
+      expect(
+        nextResponder.requests.filter(
+          (request) => request.command.type === "provider.installation.status",
+        ),
+      ).toHaveLength(4);
     });
   });
 

--- a/apps/server/test/public/public-provider-installations.test.ts
+++ b/apps/server/test/public/public-provider-installations.test.ts
@@ -276,6 +276,107 @@ describe("public provider installation routes", () => {
     });
   });
 
+  it("joins a plain status probe still in flight when a forced read overlaps it", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "provider-installation-memo-overlap-host",
+      });
+      // Status probes answer only once the test releases them, like the 2-3 s
+      // they take on a real host.
+      let releaseStatusProbes: () => void = () => {};
+      const statusProbesReleased = new Promise<void>((resolve) => {
+        releaseStatusProbes = resolve;
+      });
+      let markFirstBatchInFlight: () => void = () => {};
+      const firstBatchInFlight = new Promise<void>((resolve) => {
+        markFirstBatchInFlight = resolve;
+      });
+      let statusProbesStarted = 0;
+      const responder = registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: (request) => {
+          const { command } = request;
+          if (command.type !== "provider.installation.status") {
+            return handleProviderInstallationRpc(request);
+          }
+          statusProbesStarted += 1;
+          // The aggregate probes three providers at a time.
+          if (statusProbesStarted === 3) {
+            markFirstBatchInFlight();
+          }
+          const providerId = command.providerId;
+          return statusProbesReleased.then(() => ({
+            ok: true,
+            result: installationStatus(providerId),
+          }));
+        },
+      });
+      const statusProviderIds = () =>
+        responder.requests.flatMap((request) =>
+          request.command.type === "provider.installation.status"
+            ? [request.command.providerId]
+            : [],
+        );
+
+      const plain = harness.app.request(
+        `${API}/hosts/${host.id}/provider-clis/status`,
+      );
+      await firstBatchInFlight;
+      expect(statusProviderIds()).toEqual(["codex", "claude-code", "pi"]);
+
+      // The app's recheck cancels the plain request client-side only, so its
+      // probes keep running on the host; the forced read that follows must
+      // join them rather than have the host run a second set concurrently.
+      const memoReads = vi.spyOn(
+        harness.deps.lifecycleDedupers.providerInstallationStatus,
+        "run",
+      );
+      const forced = harness.app.request(
+        `${API}/hosts/${host.id}/provider-clis/status?force=true`,
+      );
+      await vi.waitFor(() => expect(memoReads).toHaveBeenCalledTimes(3));
+      expect(statusProviderIds()).toEqual(["codex", "claude-code", "pi"]);
+
+      releaseStatusProbes();
+      const [plainResponse, forcedResponse] = await Promise.all([
+        plain,
+        forced,
+      ]);
+      expect(plainResponse.status).toBe(200);
+      expect(forcedResponse.status).toBe(200);
+      const plainBody = (await readJson(
+        plainResponse,
+      )) as ProviderCliStatusResponse;
+      expect(Object.keys(plainBody)).toEqual([
+        "codex",
+        "claude-code",
+        "pi",
+        "acp-cursor",
+      ]);
+      expect(await readJson(forcedResponse)).toEqual(plainBody);
+      expect(statusProviderIds()).toEqual([
+        "codex",
+        "claude-code",
+        "pi",
+        "acp-cursor",
+      ]);
+
+      // Joining did not weaken force: the joined answers are memoized for a
+      // plain read, and a later forced read still refuses them.
+      const memoHit = await harness.app.request(
+        `${API}/hosts/${host.id}/provider-clis/status`,
+      );
+      expect(memoHit.status).toBe(200);
+      expect(statusProviderIds()).toHaveLength(4);
+      const forcedAgain = await harness.app.request(
+        `${API}/hosts/${host.id}/provider-clis/status?force=true`,
+      );
+      expect(forcedAgain.status).toBe(200);
+      expect(statusProviderIds()).toHaveLength(8);
+    });
+  });
+
   it("re-probes status after a provider CLI install", async () => {
     await withTestHarness(async (harness) => {
       const { host, session } = seedHostSession(harness.deps, {

--- a/apps/server/test/public/public-provider-installations.test.ts
+++ b/apps/server/test/public/public-provider-installations.test.ts
@@ -8,7 +8,10 @@ import { describe, expect, it, vi } from "vitest";
 import { COMMAND_TIMEOUT_MS } from "../../src/constants.js";
 import { ApiError } from "../../src/errors.js";
 import { buildPluginProviderRegistration } from "../../src/services/providers/plugin-provider-registration.js";
-import { registerHostRpcResponder } from "../helpers/host-rpc.js";
+import {
+  type HostRpcHandlerResult,
+  registerHostRpcResponder,
+} from "../helpers/host-rpc.js";
 import { readJson } from "../helpers/json.js";
 import { seedHostSession, seedSession } from "../helpers/seed.js";
 import { type TestAppHarness, withTestHarness } from "../helpers/test-app.js";
@@ -305,6 +308,101 @@ describe("public provider installation routes", () => {
       // clear is what makes the CLI it just installed show up.
       await harness.app.request(`${API}/hosts/${host.id}/provider-clis/status`);
       expect(statusRequests()).toHaveLength(8);
+    });
+  });
+
+  it("re-probes status after an install that finished while a status probe was in flight", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "provider-installation-memo-inflight-install-host",
+      });
+      // The first claude-code status probe answers only when the test says
+      // so; every later one reports the post-update version.
+      let resolvePreInstallStatus: (
+        result: HostRpcHandlerResult,
+      ) => void = () => {};
+      let markPreInstallProbeStarted: () => void = () => {};
+      const preInstallProbeStarted = new Promise<void>((resolve) => {
+        markPreInstallProbeStarted = resolve;
+      });
+      let claudeStatusProbes = 0;
+      const responder = registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: (request) => {
+          if (
+            request.command.type === "provider.installation.status" &&
+            request.command.providerId === "claude-code"
+          ) {
+            claudeStatusProbes += 1;
+            if (claudeStatusProbes === 1) {
+              markPreInstallProbeStarted();
+              return new Promise<HostRpcHandlerResult>((resolve) => {
+                resolvePreInstallStatus = resolve;
+              });
+            }
+            return {
+              ok: true,
+              result: {
+                ...installationStatus("claude-code"),
+                currentVersion: "1.1.0",
+                installAction: null,
+                needsUpdate: false,
+              },
+            };
+          }
+          return handleProviderInstallationRpc(request);
+        },
+      });
+
+      const preInstallRead = harness.app.request(
+        `${API}/hosts/${host.id}/provider-clis/status`,
+      );
+      await preInstallProbeStarted;
+
+      const install = await harness.app.request(
+        `${API}/hosts/${host.id}/provider-clis/install`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            provider: "claude-code",
+            actionKind: "update",
+          }),
+        },
+      );
+      expect(install.status).toBe(200);
+
+      // The probe that was running throughout the update settles after the
+      // route's memo clear, with the pre-update version. Its own reader gets
+      // that answer; the memo must not keep it.
+      resolvePreInstallStatus({
+        ok: true,
+        result: installationStatus("claude-code"),
+      });
+      const preInstallBody = (await readJson(
+        await preInstallRead,
+      )) as ProviderCliStatusResponse;
+      expect(preInstallBody["claude-code"]?.currentVersion).toBe("1.0.0");
+
+      // The app's post-install read carries no force.
+      const postInstall = await harness.app.request(
+        `${API}/hosts/${host.id}/provider-clis/status`,
+      );
+      const postInstallBody = (await readJson(
+        postInstall,
+      )) as ProviderCliStatusResponse;
+      expect(postInstallBody["claude-code"]).toMatchObject({
+        currentVersion: "1.1.0",
+        needsUpdate: false,
+      });
+      expect(
+        responder.requests.filter(
+          (request) =>
+            request.command.type === "provider.installation.status" &&
+            request.command.providerId === "claude-code",
+        ),
+      ).toHaveLength(2);
     });
   });
 

--- a/apps/server/test/public/public-provider-installations.test.ts
+++ b/apps/server/test/public/public-provider-installations.test.ts
@@ -3,9 +3,7 @@ import type {
   ProviderCliStatusResponse,
 } from "@bb/host-daemon-contract";
 import { DEFAULT_BB_REQUEST_TIMEOUT_MS } from "@bb/sdk";
-import {
-  validatePluginProviderDeclaration,
-} from "@get-bb/plugin-sdk/internal/host-policy";
+import { validatePluginProviderDeclaration } from "@get-bb/plugin-sdk/internal/host-policy";
 import { describe, expect, it, vi } from "vitest";
 import { COMMAND_TIMEOUT_MS } from "../../src/constants.js";
 import { ApiError } from "../../src/errors.js";
@@ -13,10 +11,7 @@ import { buildPluginProviderRegistration } from "../../src/services/providers/pl
 import { registerHostRpcResponder } from "../helpers/host-rpc.js";
 import { readJson } from "../helpers/json.js";
 import { seedHostSession } from "../helpers/seed.js";
-import {
-  type TestAppHarness,
-  withTestHarness,
-} from "../helpers/test-app.js";
+import { type TestAppHarness, withTestHarness } from "../helpers/test-app.js";
 
 const API = "/api/v1";
 
@@ -154,7 +149,12 @@ describe("public provider installation routes", () => {
 
       expect(response.status).toBe(200);
       const body = (await readJson(response)) as ProviderCliStatusResponse;
-      expect(Object.keys(body)).toEqual(["codex", "claude-code", "pi", "acp-cursor"]);
+      expect(Object.keys(body)).toEqual([
+        "codex",
+        "claude-code",
+        "pi",
+        "acp-cursor",
+      ]);
       expect(Object.values(body).map((status) => status.displayName)).toEqual([
         "Codex",
         "Claude Code",
@@ -299,9 +299,7 @@ describe("public provider installation routes", () => {
         const startedAt = Date.now();
         let resolvedAt: number | null = null;
         const responsePromise = Promise.resolve(
-          harness.app.request(
-            `${API}/hosts/${host.id}/provider-clis/status`,
-          ),
+          harness.app.request(`${API}/hosts/${host.id}/provider-clis/status`),
         ).then((response) => {
           resolvedAt = Date.now();
           return response;
@@ -317,11 +315,52 @@ describe("public provider installation routes", () => {
           DEFAULT_BB_REQUEST_TIMEOUT_MS,
         );
         expect(statusTimeouts).toHaveLength(9);
-        expect(statusTimeouts.some((timeout) => timeout < COMMAND_TIMEOUT_MS))
-          .toBe(true);
+        expect(
+          statusTimeouts.some((timeout) => timeout < COMMAND_TIMEOUT_MS),
+        ).toBe(true);
       } finally {
         vi.useRealTimers();
       }
+    });
+  });
+
+  it("forgets memoized host probes after a provider CLI install", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "provider-installation-memo-clear-host",
+      });
+      registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: handleProviderInstallationRpc,
+      });
+      const { installedProviderProbe, providerModelList } =
+        harness.deps.lifecycleDedupers;
+      const models = { models: [], selectedOnlyModels: [] };
+      await providerModelList.run("models", async () => models);
+      await installedProviderProbe.run("installed", async () => false);
+
+      const response = await harness.app.request(
+        `${API}/hosts/${host.id}/provider-clis/install`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            provider: "claude-code",
+            actionKind: "install",
+          }),
+        },
+      );
+      expect(response.status).toBe(200);
+
+      // A read after the install must probe the host again: the CLI it just
+      // installed is exactly what a memoized answer would misreport.
+      const modelProbe = vi.fn(async () => models);
+      const installedProbe = vi.fn(async () => true);
+      await providerModelList.run("models", modelProbe);
+      await installedProviderProbe.run("installed", installedProbe);
+      expect(modelProbe).toHaveBeenCalledOnce();
+      expect(installedProbe).toHaveBeenCalledOnce();
     });
   });
 
@@ -364,7 +403,10 @@ describe("public provider installation routes", () => {
           method: "POST",
           headers: { "content-type": "application/json" },
           // A provider id nothing registered.
-          body: JSON.stringify({ provider: "no-such-provider", actionKind: "install" }),
+          body: JSON.stringify({
+            provider: "no-such-provider",
+            actionKind: "install",
+          }),
         },
       );
       expect(unsupported.status).toBe(404);

--- a/apps/server/test/services/async-ttl-memo.test.ts
+++ b/apps/server/test/services/async-ttl-memo.test.ts
@@ -109,6 +109,76 @@ describe("createAsyncTtlMemo", () => {
     expect(recovered).toHaveBeenCalledTimes(1);
   });
 
+  it("clear() discards a success that was still in flight when it ran", async () => {
+    const memo = createAsyncTtlMemo<string, string>({ ttlMs: 60_000 });
+    let resolve: (value: string) => void = () => {};
+    const stale = memo.run(
+      "k",
+      () =>
+        new Promise<string>((resolveTask) => {
+          resolve = resolveTask;
+        }),
+    );
+
+    // An install (or forced recheck) lands while the probe is running: the
+    // probe's answer describes the host before it and must not outlive the
+    // clear, even though its own caller still receives it.
+    memo.clear();
+    resolve("pre-install");
+    await expect(stale).resolves.toBe("pre-install");
+
+    const fresh = vi.fn(async () => "post-install");
+    await expect(memo.run("k", fresh)).resolves.toBe("post-install");
+    expect(fresh).toHaveBeenCalledOnce();
+  });
+
+  it("clear() discards a memoizable failure that was still in flight when it ran", async () => {
+    const memo = createAsyncTtlMemo<string, string>({
+      ttlMs: 60_000,
+      failures: { ttlMs: 30_000, shouldMemoize: () => true },
+    });
+    let reject: (error: Error) => void = () => {};
+    const stale = memo.run(
+      "k",
+      () =>
+        new Promise<string>((_resolve, rejectTask) => {
+          reject = rejectTask;
+        }),
+    );
+
+    memo.clear();
+    const missing = new Error("missing_executable");
+    reject(missing);
+    await expect(stale).rejects.toBe(missing);
+
+    const fresh = vi.fn(async () => "ok");
+    await expect(memo.run("k", fresh)).resolves.toBe("ok");
+    expect(fresh).toHaveBeenCalledOnce();
+  });
+
+  it("keeps storing a task started after clear() while an older one is still in flight", async () => {
+    const memo = createAsyncTtlMemo<string, string>({ ttlMs: 60_000 });
+    let resolveStale: (value: string) => void = () => {};
+    const stale = memo.run(
+      "k",
+      () =>
+        new Promise<string>((resolveTask) => {
+          resolveStale = resolveTask;
+        }),
+    );
+    memo.clear();
+
+    // The post-clear probe settles first; the stale one settling later must
+    // not overwrite it.
+    await expect(memo.run("k", async () => "fresh")).resolves.toBe("fresh");
+    resolveStale("stale");
+    await stale;
+
+    const task = vi.fn(async () => "unused");
+    await expect(memo.run("k", task)).resolves.toBe("fresh");
+    expect(task).not.toHaveBeenCalled();
+  });
+
   it("keys entries independently and clears them on demand", async () => {
     const memo = createAsyncTtlMemo<string, string>({ ttlMs: 60_000 });
     await expect(memo.run("a", async () => "A")).resolves.toBe("A");

--- a/apps/server/test/services/async-ttl-memo.test.ts
+++ b/apps/server/test/services/async-ttl-memo.test.ts
@@ -145,9 +145,9 @@ describe("createAsyncTtlMemo", () => {
         }),
     );
 
-    // An install (or forced recheck) lands while the probe is running: the
-    // probe's answer describes the host before it and must not outlive the
-    // clear, even though its own caller still receives it.
+    // An install lands while the probe is running: the probe's answer
+    // describes the host before it and must not outlive the clear, even
+    // though its own caller still receives it.
     memo.clear();
     resolve("pre-install");
     await expect(stale).resolves.toBe("pre-install");
@@ -202,6 +202,36 @@ describe("createAsyncTtlMemo", () => {
     const task = vi.fn(async () => "unused");
     await expect(memo.run("k", task)).resolves.toBe("fresh");
     expect(task).not.toHaveBeenCalled();
+  });
+
+  it("forgetSettled() drops a settled value but joins, and keeps, a task still in flight", async () => {
+    const memo = createAsyncTtlMemo<string, string>({ ttlMs: 60_000 });
+    await expect(memo.run("k", async () => "settled")).resolves.toBe("settled");
+
+    // A forced read never gets the settled answer.
+    memo.forgetSettled();
+    let resolve: (value: string) => void = () => {};
+    const task = vi.fn(
+      () =>
+        new Promise<string>((resolveTask) => {
+          resolve = resolveTask;
+        }),
+    );
+    const first = memo.run("k", task);
+
+    // A second forced read lands while that task is still running. Unlike
+    // clear(), it neither restarts the task nor fences its outcome out: the
+    // task already describes the world now.
+    memo.forgetSettled();
+    const joined = memo.run("k", task);
+    expect(task).toHaveBeenCalledTimes(1);
+    resolve("fresh");
+    await expect(first).resolves.toBe("fresh");
+    await expect(joined).resolves.toBe("fresh");
+
+    const unused = vi.fn(async () => "unused");
+    await expect(memo.run("k", unused)).resolves.toBe("fresh");
+    expect(unused).not.toHaveBeenCalled();
   });
 
   it("keys entries independently and clears them on demand", async () => {

--- a/apps/server/test/services/async-ttl-memo.test.ts
+++ b/apps/server/test/services/async-ttl-memo.test.ts
@@ -20,6 +20,31 @@ describe("createAsyncTtlMemo", () => {
     expect(task).toHaveBeenCalledTimes(2);
   });
 
+  it("holds each value for the window ttlMsForValue picks for it", async () => {
+    let currentTime = 0;
+    const memo = createAsyncTtlMemo<string, boolean>({
+      ttlMs: 5 * 60_000,
+      // An "absent" answer may be a failed lookup; keep it for much less
+      // time than a "present" one.
+      ttlMsForValue: (present) => (present ? 5 * 60_000 : 30_000),
+      now: () => currentTime,
+    });
+    const absent = vi.fn(async () => false);
+    const present = vi.fn(async () => true);
+    await expect(memo.run("absent", absent)).resolves.toBe(false);
+    await expect(memo.run("present", present)).resolves.toBe(true);
+
+    currentTime = 30_000;
+    await expect(memo.run("absent", absent)).resolves.toBe(false);
+    await expect(memo.run("present", present)).resolves.toBe(true);
+    expect(absent).toHaveBeenCalledTimes(2);
+    expect(present).toHaveBeenCalledTimes(1);
+
+    currentTime = 4 * 60_000;
+    await expect(memo.run("present", present)).resolves.toBe(true);
+    expect(present).toHaveBeenCalledTimes(1);
+  });
+
   it("shares one in-flight task and never stores a rejection", async () => {
     const memo = createAsyncTtlMemo<string, string>({ ttlMs: 60_000 });
     let reject: (error: Error) => void = () => {};

--- a/apps/server/test/services/async-ttl-memo.test.ts
+++ b/apps/server/test/services/async-ttl-memo.test.ts
@@ -42,6 +42,73 @@ describe("createAsyncTtlMemo", () => {
     expect(recovered).toHaveBeenCalledTimes(1);
   });
 
+  it("replays a memoizable failure until failures.ttlMs, then runs the task again", async () => {
+    let currentTime = 1_000;
+    const memo = createAsyncTtlMemo<string, string>({
+      ttlMs: 60_000,
+      failures: {
+        ttlMs: 100,
+        shouldMemoize: (error) =>
+          error instanceof Error && error.message === "auth_required",
+      },
+      now: () => currentTime,
+    });
+    const failure = new Error("auth_required");
+    const failing = vi.fn(async (): Promise<string> => {
+      throw failure;
+    });
+
+    await expect(memo.run("k", failing)).rejects.toBe(failure);
+    currentTime = 1_099;
+    await expect(memo.run("k", failing)).rejects.toBe(failure);
+    expect(failing).toHaveBeenCalledTimes(1);
+
+    // Past the failure window the task runs again, and its success is kept
+    // for the (longer) success window.
+    currentTime = 1_100;
+    const recovered = vi.fn(async () => "ok");
+    await expect(memo.run("k", recovered)).resolves.toBe("ok");
+    currentTime = 1_100 + 59_999;
+    await expect(memo.run("k", recovered)).resolves.toBe("ok");
+    expect(recovered).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not store a failure the predicate rejects", async () => {
+    const memo = createAsyncTtlMemo<string, string>({
+      ttlMs: 60_000,
+      failures: {
+        ttlMs: 60_000,
+        shouldMemoize: (error) =>
+          error instanceof Error && error.message === "host answered",
+      },
+    });
+    const transport = vi.fn(async (): Promise<string> => {
+      throw new Error("host_unavailable");
+    });
+
+    await expect(memo.run("k", transport)).rejects.toThrow("host_unavailable");
+    await expect(memo.run("k", transport)).rejects.toThrow("host_unavailable");
+    expect(transport).toHaveBeenCalledTimes(2);
+  });
+
+  it("clear() forgets a memoized failure", async () => {
+    const memo = createAsyncTtlMemo<string, string>({
+      ttlMs: 60_000,
+      failures: { ttlMs: 60_000, shouldMemoize: () => true },
+    });
+    const failing = vi.fn(async (): Promise<string> => {
+      throw new Error("probe failed");
+    });
+    await expect(memo.run("k", failing)).rejects.toThrow("probe failed");
+    await expect(memo.run("k", failing)).rejects.toThrow("probe failed");
+    expect(failing).toHaveBeenCalledTimes(1);
+
+    memo.clear();
+    const recovered = vi.fn(async () => "ok");
+    await expect(memo.run("k", recovered)).resolves.toBe("ok");
+    expect(recovered).toHaveBeenCalledTimes(1);
+  });
+
   it("keys entries independently and clears them on demand", async () => {
     const memo = createAsyncTtlMemo<string, string>({ ttlMs: 60_000 });
     await expect(memo.run("a", async () => "A")).resolves.toBe("A");

--- a/apps/server/test/services/threads/thread-model-recovery.test.ts
+++ b/apps/server/test/services/threads/thread-model-recovery.test.ts
@@ -122,6 +122,10 @@ describe("stale model recovery", () => {
         body: { code: "model_catalog_unavailable" },
       });
       temporaryFailure.unregister();
+      // A host-answered probe failure is replayed for the memo's failure
+      // window; this test is about the outcome once the catalog loads, so
+      // forget it the way the provider CLI install route does.
+      harness.deps.lifecycleDedupers.providerModelList.clear();
       registerProviderHostRpcResponder(harness, {
         hostId: host.id,
         sessionId: session.id,

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -4,12 +4,15 @@ import {
   hostDaemonServerWsMessageSchema,
   type HostDaemonOnlineRpcRequestMessage,
 } from "@bb/host-daemon-contract";
+import { validatePluginProviderDeclaration } from "@get-bb/plugin-sdk/internal/host-policy";
 import {
   appendCustomModels,
   listSystemProviderInfos,
   resolveSystemExecutionOptions,
   resolveSystemProviderModels,
 } from "../../src/services/system/execution-options.js";
+import { getProviderStates } from "../../src/services/system/provider-states.js";
+import { buildPluginProviderRegistration } from "../../src/services/providers/plugin-provider-registration.js";
 import { ApiError } from "../../src/errors.js";
 import { availableModelFixture } from "../helpers/available-models.js";
 import {
@@ -579,9 +582,7 @@ describe("resolveSystemExecutionOptions", () => {
     async ({ failStatusRequest }) => {
       await withTestHarness(
         {
-          extraProviders: [
-            await configuredAcpProvider(EXAMPLE_AGENT_SETTING),
-          ],
+          extraProviders: [await configuredAcpProvider(EXAMPLE_AGENT_SETTING)],
         },
         async (harness) => {
           const warn = vi.fn();
@@ -682,9 +683,7 @@ describe("resolveSystemExecutionOptions", () => {
   it("keeps configured providers and custom models when no host can be resolved", async () => {
     await withTestHarness(
       {
-        extraProviders: [
-          await configuredAcpProvider(EXAMPLE_AGENT_SETTING),
-        ],
+        extraProviders: [await configuredAcpProvider(EXAMPLE_AGENT_SETTING)],
         customModels: [
           {
             providerId: "codex",
@@ -1548,6 +1547,281 @@ describe("resolveSystemExecutionOptions model probe memo", () => {
           (request) => request.command.type === "provider.list_models",
         ),
       ).toHaveLength(1);
+    });
+  });
+});
+
+describe("installed-only provider probe memo", () => {
+  /** The registry's `visibility: "installed"` ids, probed by roster reads. */
+  function installedOnlyProviderIds(harness: TestAppHarness): string[] {
+    return harness.deps.providerRegistry
+      .list()
+      .filter((registration) => registration.visibility === "installed")
+      .map((registration) => registration.info.id);
+  }
+
+  function discoveryHealthRequests(
+    requests: readonly HostDaemonOnlineRpcRequestMessage[],
+    providerIds: readonly string[],
+  ): HostDaemonOnlineRpcRequestMessage[] {
+    return requests.filter(
+      (request) =>
+        request.command.type === "provider.health" &&
+        providerIds.includes(request.command.providerId),
+    );
+  }
+
+  it("serves every roster read on a host from one discovery probe per installed-only provider", async () => {
+    await withTestHarness({}, async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-installed-probe-memo-shared",
+      });
+      const responder = registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: (request) => {
+          if (request.command.type !== "provider.health") {
+            throw new Error(`Unexpected RPC command ${request.command.type}`);
+          }
+          return {
+            ok: true,
+            result: providerDiscoveryHealth(
+              request.command.providerId === "acp-opencode",
+            ),
+          };
+        },
+      });
+      const installedOnly = installedOnlyProviderIds(harness);
+
+      const first = await listSystemProviderInfos(harness.deps, {
+        hostId: host.id,
+      });
+      const second = await listSystemProviderInfos(harness.deps, {
+        hostId: host.id,
+      });
+
+      expect(first.map((provider) => provider.id)).toContain("acp-opencode");
+      expect(second).toEqual(first);
+      expect(
+        discoveryHealthRequests(responder.requests, installedOnly),
+      ).toHaveLength(installedOnly.length);
+    });
+  });
+
+  it("keeps readiness live while the discovery answer is memoized", async () => {
+    await withTestHarness({}, async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-installed-probe-memo-readiness",
+      });
+      const catalogModel = availableModelFixture({ model: "gpt-5" });
+      const responder = registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: (request) => {
+          if (request.command.type === "provider.health") {
+            return {
+              ok: true,
+              result: providerDiscoveryHealth(
+                !installedOnly.includes(request.command.providerId),
+              ),
+            };
+          }
+          if (request.command.type === "provider.list_models") {
+            return {
+              ok: true,
+              result: { models: [catalogModel], selectedOnlyModels: [] },
+            };
+          }
+          throw new Error(`Unexpected RPC command ${request.command.type}`);
+        },
+      });
+      const installedOnly = installedOnlyProviderIds(harness);
+
+      await resolveSystemExecutionOptions(harness.deps, {
+        hostId: host.id,
+        providerId: "codex",
+      });
+      const states = await getProviderStates(harness.deps, { hostId: host.id });
+      const readinessProbesAfterOneRead = responder.requests.filter(
+        (request) =>
+          request.command.type === "provider.health" &&
+          !installedOnly.includes(request.command.providerId),
+      ).length;
+      await getProviderStates(harness.deps, { hostId: host.id });
+
+      expect(states.providers.map((provider) => provider.providerId)).toContain(
+        "codex",
+      );
+      // Discovery ran once for the execution-options read and was replayed for
+      // both provider-state reads.
+      expect(
+        discoveryHealthRequests(responder.requests, installedOnly),
+      ).toHaveLength(installedOnly.length);
+      // Readiness (login/auth state) is not discovery: each provider-state read
+      // still asks the host.
+      expect(readinessProbesAfterOneRead).toBeGreaterThan(0);
+      expect(
+        responder.requests.filter(
+          (request) =>
+            request.command.type === "provider.health" &&
+            !installedOnly.includes(request.command.providerId),
+        ),
+      ).toHaveLength(readinessProbesAfterOneRead * 2);
+    });
+  });
+
+  it("does not memoize a failed discovery probe", async () => {
+    await withTestHarness({}, async (harness) => {
+      const warn = vi.fn();
+      harness.deps.logger = { ...harness.deps.logger, warn };
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-installed-probe-memo-failure",
+      });
+      let failOpencode = true;
+      const responder = registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: (request) => {
+          if (request.command.type !== "provider.health") {
+            throw new Error(`Unexpected RPC command ${request.command.type}`);
+          }
+          if (request.command.providerId !== "acp-opencode") {
+            return { ok: true, result: providerDiscoveryHealth(false) };
+          }
+          if (failOpencode) {
+            return {
+              ok: false,
+              errorCode: "host_unavailable",
+              errorMessage: "Host is not connected",
+            };
+          }
+          return { ok: true, result: providerDiscoveryHealth(true) };
+        },
+      });
+
+      const failed = await listSystemProviderInfos(harness.deps, {
+        hostId: host.id,
+      });
+      expect(failed.map((provider) => provider.id)).not.toContain(
+        "acp-opencode",
+      );
+      expect(warn).toHaveBeenCalledWith(
+        expect.objectContaining({ providerId: "acp-opencode" }),
+        "Failed to resolve installed-only provider status",
+      );
+
+      failOpencode = false;
+      const recovered = await listSystemProviderInfos(harness.deps, {
+        hostId: host.id,
+      });
+      expect(recovered.map((provider) => provider.id)).toContain(
+        "acp-opencode",
+      );
+      expect(
+        discoveryHealthRequests(responder.requests, ["acp-opencode"]),
+      ).toHaveLength(2);
+    });
+  });
+
+  it("re-probes after the daemon reconnects", async () => {
+    await withTestHarness({}, async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-installed-probe-memo-reconnect",
+      });
+      const installedOnly = installedOnlyProviderIds(harness);
+      registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: () => ({ ok: true, result: providerDiscoveryHealth(false) }),
+      });
+      const before = await listSystemProviderInfos(harness.deps, {
+        hostId: host.id,
+      });
+      expect(before.map((provider) => provider.id)).not.toContain(
+        "acp-opencode",
+      );
+
+      // The reconnected daemon may have a newly installed agent: its first
+      // roster read must not be answered from the previous session's memo.
+      harness.hub.unregisterDaemon(session.id);
+      const nextSession = seedSession(harness.deps, host.id);
+      const nextResponder = registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: nextSession.id,
+        handle: (request) => ({
+          ok: true,
+          result: providerDiscoveryHealth(
+            request.command.type === "provider.health" &&
+              request.command.providerId === "acp-opencode",
+          ),
+        }),
+      });
+
+      const after = await listSystemProviderInfos(harness.deps, {
+        hostId: host.id,
+      });
+      expect(after.map((provider) => provider.id)).toContain("acp-opencode");
+      expect(
+        discoveryHealthRequests(nextResponder.requests, installedOnly),
+      ).toHaveLength(installedOnly.length);
+    });
+  });
+
+  it("re-probes after the provider registration revision changes", async () => {
+    await withTestHarness({}, async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-installed-probe-memo-revision",
+      });
+      const installedOnly = installedOnlyProviderIds(harness);
+      const responder = registerHostRpcResponder(harness, {
+        hostId: host.id,
+        sessionId: session.id,
+        handle: () => ({ ok: true, result: providerDiscoveryHealth(false) }),
+      });
+      await listSystemProviderInfos(harness.deps, { hostId: host.id });
+      await listSystemProviderInfos(harness.deps, { hostId: host.id });
+      expect(
+        discoveryHealthRequests(responder.requests, installedOnly),
+      ).toHaveLength(installedOnly.length);
+
+      // A plugin (un)load can change a bridge, so the memo key carries the
+      // registration revision and a register or dispose invalidates it.
+      const pluginId = "provider-revision-bump";
+      const handle = harness.deps.providerRegistry.register({
+        ...buildPluginProviderRegistration({
+          available: true,
+          pluginId,
+          declaration: validatePluginProviderDeclaration({
+            id: "revision-bump",
+            displayName: "Revision Bump",
+            maintenance: { health: false, usage: false, installation: false },
+            capabilities: {
+              supportsServiceTier: false,
+              supportsNativeUserQuestion: false,
+              fork: "none",
+              supportsManualCompaction: false,
+              supportsThreadArchive: false,
+              supportsThreadRename: false,
+              permissionModes: ["full"],
+              reasoningLevels: ["medium"],
+            },
+            composerActions: [],
+          }),
+          readSettings: () => ({}),
+        }),
+        pluginId,
+        iconNames: new Set<string>(),
+      });
+      await listSystemProviderInfos(harness.deps, { hostId: host.id });
+      expect(
+        discoveryHealthRequests(responder.requests, installedOnly),
+      ).toHaveLength(installedOnly.length * 2);
+
+      handle.dispose();
+      await listSystemProviderInfos(harness.deps, { hostId: host.id });
+      expect(
+        discoveryHealthRequests(responder.requests, installedOnly),
+      ).toHaveLength(installedOnly.length * 3);
     });
   });
 });

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -1466,7 +1466,7 @@ describe("resolveSystemExecutionOptions model probe memo", () => {
     });
   });
 
-  it("does not memoize a failed probe and re-probes after the daemon reconnects", async () => {
+  it("replays a failed probe for the failure window, forgets it on clear, and re-probes after the daemon reconnects", async () => {
     await withTestHarness({}, async (harness) => {
       const { host, session } = seedHostSession(harness.deps, {
         id: "host-model-memo-invalidation",
@@ -1500,6 +1500,10 @@ describe("resolveSystemExecutionOptions model probe memo", () => {
         },
       });
       const query = { hostId: host.id, providerId: "codex" };
+      const listModelsRequests = () =>
+        responder.requests.filter(
+          (request) => request.command.type === "provider.list_models",
+        );
 
       const failed = await resolveSystemExecutionOptions(harness.deps, query);
       expect(failed.modelLoadError).toEqual({
@@ -1507,7 +1511,19 @@ describe("resolveSystemExecutionOptions model probe memo", () => {
         code: "timeout",
       });
 
+      // The host answered and failed, so the next read inside the failure
+      // window is served from the memo instead of spawning the CLI again.
       failProbe = false;
+      const replayed = await resolveSystemExecutionOptions(harness.deps, query);
+      expect(replayed.modelLoadError).toEqual({
+        providerId: "codex",
+        code: "timeout",
+      });
+      expect(listModelsRequests()).toHaveLength(1);
+
+      // An explicit clear (what the provider CLI install route does) forgets
+      // the failure at once.
+      harness.deps.lifecycleDedupers.providerModelList.clear();
       const recovered = await resolveSystemExecutionOptions(
         harness.deps,
         query,
@@ -1515,11 +1531,7 @@ describe("resolveSystemExecutionOptions model probe memo", () => {
       expect(recovered.modelLoadError).toBeNull();
       expect(recovered.models).toEqual([catalogModel]);
       await resolveSystemExecutionOptions(harness.deps, query);
-      expect(
-        responder.requests.filter(
-          (request) => request.command.type === "provider.list_models",
-        ),
-      ).toHaveLength(2);
+      expect(listModelsRequests()).toHaveLength(2);
 
       // A reconnected daemon may run a different CLI or account: its first
       // probe must not be answered from the previous session's memo.

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -1682,6 +1682,85 @@ describe("installed-only provider probe memo", () => {
     });
   });
 
+  it("holds an absent answer for 30 s while a present one keeps the full window", async () => {
+    // The dedupers capture their clock when the harness builds them, so the
+    // fake Date must be in place first.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      await withTestHarness({}, async (harness) => {
+        const { host, session } = seedHostSession(harness.deps, {
+          id: "host-installed-probe-memo-absent-window",
+        });
+        const installedOnly = installedOnlyProviderIds(harness);
+        // Every installed-only agent but opencode is present; opencode's
+        // first answer is the kind a failed `which` or a fallback PATH
+        // produces, and the host "installs" it right after.
+        let opencodeInstalled = false;
+        const responder = registerHostRpcResponder(harness, {
+          hostId: host.id,
+          sessionId: session.id,
+          handle: (request) => {
+            if (request.command.type !== "provider.health") {
+              throw new Error(`Unexpected RPC command ${request.command.type}`);
+            }
+            return {
+              ok: true,
+              result: providerDiscoveryHealth(
+                request.command.providerId === "acp-opencode"
+                  ? opencodeInstalled
+                  : true,
+              ),
+            };
+          },
+        });
+        const startedAt = Date.now();
+
+        const first = await listSystemProviderInfos(harness.deps, {
+          hostId: host.id,
+        });
+        expect(first.map((provider) => provider.id)).not.toContain(
+          "acp-opencode",
+        );
+        opencodeInstalled = true;
+
+        vi.setSystemTime(startedAt + 29_000);
+        const withinWindow = await listSystemProviderInfos(harness.deps, {
+          hostId: host.id,
+        });
+        expect(withinWindow.map((provider) => provider.id)).not.toContain(
+          "acp-opencode",
+        );
+        expect(
+          discoveryHealthRequests(responder.requests, installedOnly),
+        ).toHaveLength(installedOnly.length);
+
+        // Past the absent window only the absent answer is re-asked; the
+        // present ones are still served from the memo.
+        vi.setSystemTime(startedAt + 31_000);
+        const recovered = await listSystemProviderInfos(harness.deps, {
+          hostId: host.id,
+        });
+        expect(recovered.map((provider) => provider.id)).toContain(
+          "acp-opencode",
+        );
+        expect(
+          discoveryHealthRequests(responder.requests, installedOnly),
+        ).toHaveLength(installedOnly.length + 1);
+        expect(
+          discoveryHealthRequests(responder.requests, ["acp-opencode"]),
+        ).toHaveLength(2);
+
+        vi.setSystemTime(startedAt + 4 * 60_000);
+        await listSystemProviderInfos(harness.deps, { hostId: host.id });
+        expect(
+          discoveryHealthRequests(responder.requests, installedOnly),
+        ).toHaveLength(installedOnly.length + 1);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not memoize a failed discovery probe", async () => {
     await withTestHarness({}, async (harness) => {
       const warn = vi.fn();

--- a/docs/provider-plugin-api.md
+++ b/docs/provider-plugin-api.md
@@ -88,7 +88,10 @@ bb.providers.register({
 
 Still experimental on the declaration (see api_to_audit.md):
 `experimental_visibility` (`"installed"` hides the row until the bridge's
-health probe finds the agent), `experimental_bridgeOptions` (immutable JSON
+health probe finds the agent; the server caches that installed-or-not answer
+per host for a few minutes and re-probes after a daemon reconnect, a plugin
+reload, a provider CLI install, or a forced CLI status check),
+`experimental_bridgeOptions` (immutable JSON
 forwarded opaquely to the bridge), `experimental_nativeSkillRoots` and
 `experimental_nativeCommandRoots` (where the agent keeps its own skills and
 slash commands; each root is a path or `{ path, recursive?, ancestors?,

--- a/docs/provider-plugin-api.md
+++ b/docs/provider-plugin-api.md
@@ -88,9 +88,10 @@ bb.providers.register({
 
 Still experimental on the declaration (see api_to_audit.md):
 `experimental_visibility` (`"installed"` hides the row until the bridge's
-health probe finds the agent; the server caches that installed-or-not answer
-per host for a few minutes and re-probes after a daemon reconnect, a plugin
-reload, a provider CLI install, or a forced CLI status check),
+health probe finds the agent; the server caches a "present" answer per host
+for a few minutes and a "not installed" answer for about 30 s, and re-probes
+after a daemon reconnect, a plugin reload, a provider CLI install, or a
+forced CLI status check),
 `experimental_bridgeOptions` (immutable JSON
 forwarded opaquely to the bridge), `experimental_nativeSkillRoots` and
 `experimental_nativeCommandRoots` (where the agent keeps its own skills and

--- a/packages/domain/src/plugin-sdk-version.ts
+++ b/packages/domain/src/plugin-sdk-version.ts
@@ -16,7 +16,7 @@
 // PLUGIN_SDK_MAJOR is 0, so the major-only artifact gate cannot distinguish
 // 0.x releases and is intentionally vacuous for them until a future 1.0.
 // Rebuildable artifacts still rebuild on the exact sdkVersion-differs trigger.
-export const PLUGIN_SDK_VERSION = "0.4.16";
+export const PLUGIN_SDK_VERSION = "0.4.17";
 
 /** Major of {@link PLUGIN_SDK_VERSION} — the plugin API compatibility number. */
 export const PLUGIN_SDK_MAJOR = Number(PLUGIN_SDK_VERSION.split(".", 1)[0]);

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@get-bb/plugin-sdk",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "homepage": "https://github.com/get-bb/bb#readme",
   "bugs": {
     "url": "https://github.com/get-bb/bb/issues"

--- a/packages/sdk/src/areas/hosts.ts
+++ b/packages/sdk/src/areas/hosts.ts
@@ -59,6 +59,16 @@ export interface HostProviderCliInstallArgs extends HostProviderCliInstallReques
   hostId: string;
 }
 
+export interface HostProviderCliStatusArgs {
+  hostId: string;
+  /**
+   * Bypass the server's per-host memo of provider CLI installation state (a
+   * manual "Check for updates"). Omitted: serve the memoized answer.
+   */
+  force?: boolean;
+  signal?: AbortSignal;
+}
+
 export interface HostListArgs {
   signal?: AbortSignal;
 }
@@ -90,7 +100,9 @@ export interface HostsArea {
   list(args?: HostListArgs): Promise<HostListResult>;
   pathsExist(args: HostPathsExistArgs): Promise<HostPathsExistResult>;
   pickFolder(args: HostPickFolderArgs): Promise<HostPickFolderResult>;
-  providerCliStatus(args: HostGetArgs): Promise<HostProviderCliStatusResult>;
+  providerCliStatus(
+    args: HostProviderCliStatusArgs,
+  ): Promise<HostProviderCliStatusResult>;
   retryUpdate(args: HostRetryUpdateArgs): Promise<HostRetryUpdateResult>;
   update(args: HostUpdateArgs): Promise<HostUpdateResult>;
 }
@@ -193,6 +205,10 @@ export function createHostsArea(args: CreateSdkAreaArgs): HostsArea {
         transport.api.v1.hosts[":id"]["provider-clis"].status.$get(
           {
             param: { id: input.hostId },
+            query:
+              input.force === undefined
+                ? {}
+                : { force: input.force ? "true" : "false" },
           },
           ...signalRequestArgs(input.signal),
         ),

--- a/packages/server-contract/src/api/hosts.ts
+++ b/packages/server-contract/src/api/hosts.ts
@@ -112,6 +112,19 @@ export type HostPickFolderRequest = z.infer<typeof hostPickFolderRequestSchema>;
 
 export type HostPickFolderResponse = PickFolderResponse;
 
+/**
+ * Query for `GET /hosts/:id/provider-clis/status`. The server memoizes each
+ * provider's installation probe per host for a few minutes because it spawns
+ * several subprocesses (including an npm registry lookup); `force: "true"` is
+ * the manual "Check for updates" / "Recheck CLIs" path that bypasses it.
+ */
+export const hostProviderCliStatusQuerySchema = z.object({
+  force: z.enum(["true", "false"]).optional(),
+});
+export type HostProviderCliStatusQuery = z.infer<
+  typeof hostProviderCliStatusQuerySchema
+>;
+
 export type HostProviderCliStatusResponse = ProviderCliStatusResponse;
 
 export const hostProviderCliInstallRequestSchema =

--- a/packages/server-contract/src/public-api.ts
+++ b/packages/server-contract/src/public-api.ts
@@ -104,6 +104,7 @@ import type {
   HostPathsExistResponse,
   HostProviderCliInstallEvent,
   HostProviderCliInstallRequest,
+  HostProviderCliStatusQuery,
   HostProviderCliStatusResponse,
   HostRetryUpdateResponse,
   ProjectAttachmentContentQuery,
@@ -250,6 +251,7 @@ import {
   hostPickFolderRequestSchema,
   hostPathsExistRequestSchema,
   hostProviderCliInstallRequestSchema,
+  hostProviderCliStatusQuerySchema,
   projectAttachmentContentQuerySchema,
   projectBranchesQuerySchema,
   projectCommandsQuerySchema,
@@ -668,7 +670,9 @@ export const publicApiRoutes = {
     providerCliStatus: defineRoute({
       path: "/hosts/:id/provider-clis/status",
       method: "get",
-      request: noRequest<PathId>(),
+      request: optionalQueryRequest<PathId, HostProviderCliStatusQuery>(
+        hostProviderCliStatusQuerySchema,
+      ),
       response: jsonResponse<HostProviderCliStatusResponse>(),
     }),
     providerCliInstall: defineRoute({

--- a/packages/templates/src/templates/bb-guide-machines.md
+++ b/packages/templates/src/templates/bb-guide-machines.md
@@ -39,8 +39,15 @@ unless you pass `--auto-update` explicitly.
   bb machine retry-update <id-or-name>    Retry a pending daemon update now
   bb machine remove <id-or-name> [--yes]  Revoke and remove a machine
   bb machine provider-cli status <machine>
+    --force                               Re-probe the machine instead of
+                                          serving the server's cached status
   bb machine provider-cli install <machine> <claudeCode|codex|cursor>
     --action <install|update>
+
+Provider CLI status is cached on the server per machine for about ten minutes
+(each probe spawns several subprocesses on the machine, including an npm
+registry lookup). A finished `provider-cli install` refreshes it; pass
+`--force` to re-probe right now.
 
 Each machine has a permission limit: the highest permission mode any thread on
 that machine can run with. The default is Full Access. A thread that asks for
@@ -60,15 +67,20 @@ CLI counterpart of Settings → Updates and the sidebar Updates badge.
   bb updates [status]                     Show bb-app and provider CLI update
                                           status for every machine
     --machine <id-or-name>                Limit to one machine
+    --force                               Re-probe each machine's provider
+                                          CLIs instead of the cached status
     --json                                Print the aggregate as JSON
   bb updates apply                        Run every available provider CLI
                                           install/update, one at a time
     --machine <id-or-name>                Limit to one machine
+    --force                               Re-probe before deciding what to run
     --json                                Print per-target results as JSON
 
 `bb updates apply` covers provider CLIs only. Update bb-app itself with the
 printed upgrade command (`npx bb-app@latest`) or the desktop app's relaunch;
-connected daemons then follow the server version automatically.
+connected daemons then follow the server version automatically. Provider CLI
+status comes from the server's per-machine cache (about ten minutes); `--force`
+re-probes every selected machine, like Settings → Updates does on open.
 
 Machine selectors accept either an exact machine ID or an unambiguous machine
 name. `--host` is an alias for `--machine`.


### PR DESCRIPTION
## What was wrong

Provider maintenance had no memory on the server (an internal performance sweep, findings S1, S4, S2):

- **S1** `GET /hosts/:id/provider-clis/status` ran one `provider.installation.status` RPC per installation-capable provider on every call (six subprocesses per provider on the host: `which`, `--version`, `npm view`, `npm prefix -g`, `npm list -g`, `doctor`), and the sidebar's update inventory fires it on every boot. 2–3 s per call; it was the last request in flight at boot.
- **S4** `listInstalledPluginProviderInfos` ran `provider.health` for every installed-only ACP agent on every `/system/providers`, `/system/providers/state` and `/system/execution-options` read, so the daemon's shell-env refresh and maintenance-bridge respawn were paid per request (33 ms → 1.3 s after idle).
- **S2** `AsyncTtlMemo` never stored a rejection, so with a CLI installed but not logged in every execution-options read re-spawned the model-list probe and failed again (847 ms per thread open).

## What changed

- **S1** `getProviderInstallations` memoizes each provider's RPC result per host for 10 min (key: host, daemon session, registration revision, full command incl. bridge launch). `?force=true` bypasses it: new `hostProviderCliStatusQuerySchema` in the contract, `force` on `sdk.hosts.providerCliStatus`, `--force` on `bb machine provider-cli status` and `bb updates [status|apply]`, the web Check-for-updates / Retry and the mobile Check-for-updates / Recheck go through a forced `fetchQuery` that first cancels any plain fetch in flight. The install route clears the memo. Guide template (`bb-guide-machines.md`), the built-in `bb-cli` skill and the mobile data README are updated. A forced read never gets a settled answer but joins a probe already in flight (`forgetSettled()`).
- **S4** The discovery probe is memoized per host: "installed" for 5 min, "not installed" for 30 s (the daemon answers `not_installed` for any `which` failure and during its first seconds after boot). Readiness (`getProviderState`) stays live. `docs/provider-plugin-api.md` documents the windows.
- **S2** `AsyncTtlMemo` gains `failures: { ttlMs, shouldMemoize }`; the model-list memo replays `ApiError` 502/504 (not `host_unavailable`) for 30 s. `clear()` now fences tasks still in flight with a generation counter so a pre-install answer can never be re-stored after the install route clears a memo (this also protects the S1 and S4 memos). `ttlMsForValue` lets a memo hold different values for different windows.
- Staleness windows are deliberate product choices and are single constants in `apps/server/src/lifecycle-dedupers.ts`: CLI status 10 min, installed agent 5 min, absent agent 30 s, model-list failure 30 s. User-visible effect: a CLI or agent installed *outside* bb can show the old state for up to that window unless the user presses Check for updates / Recheck (which force) or installs through bb (which clears).
- No wire change: only a public HTTP query parameter and server memory; daemon payloads are untouched, so no `HOST_DAEMON_PROTOCOL_VERSION` bump.

## How you verified

New tests, each failing on the pre-fix code: `apps/server/test/public/public-provider-installations.test.ts` (memo hit, force re-probe, install clears, failure not memoized, re-probe after daemon reconnect, in-flight probe across an install, forced read joins an in-flight probe), `apps/server/test/system/execution-options.test.ts` (discovery memo, readiness stays live, absent answer held 30 s), `apps/server/test/services/async-ttl-memo.test.ts` (failure window, clear fence, `forgetSettled`, `ttlMsForValue`), `apps/cli/src/__tests__/command-output/{updates,machine}.test.ts` (`--force` → `query: { force: "true" }`), `apps/app/src/components/settings/UpdatesSettingsSection.test.tsx` and `apps/app/src/hooks/cache-owners/provider-cli-status-cache-owner.test.ts`, `apps/mobile/src/data/hosts/recheck-host-provider-cli-status.test.ts`.

On this branch: `pnpm exec turbo run typecheck` (76/76), `pnpm exec turbo run lint`, `pnpm exec turbo run test` (all packages green).

Fixes: no issue — source is an internal performance sweep (findings S1, S4, S2).

> AGENT GENERATED
