### PR TITLE
perf: stop re-rendering every sidebar row on each cache update (F1)

### DIFF
--- a/apps/app/src/components/sidebar/ProjectList.modes.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.modes.test.tsx
@@ -6,6 +6,7 @@ import {
   cleanup,
   fireEvent,
   render,
+  renderHook,
   screen,
   waitFor,
 } from "@testing-library/react";
@@ -17,7 +18,11 @@ import {
 } from "jotai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ThreadListEntry } from "@bb/domain";
-import { ActiveSidebarModeSections, MachineModeSections } from "./ProjectList";
+import {
+  ActiveSidebarModeSections,
+  MachineModeSections,
+  useSectionDisplayOptionsRenderer,
+} from "./ProjectList";
 import { buildMachineThreadGroups } from "@bb/client-core";
 import {
   collapsedSidebarSectionIdsAtom,
@@ -297,5 +302,41 @@ describe("sidebar organization mode sections", () => {
     expect(screen.queryByText("Machine activity")).toBeNull();
     expect(screen.getByLabelText("Plan mode active")).not.toBeNull();
     expect(screen.queryByLabelText("Thread working")).toBeNull();
+  });
+});
+
+describe("useSectionDisplayOptionsRenderer", () => {
+  it("keeps each section's menu element until that section's open state changes", () => {
+    const setSidebarMenuOpen = vi.fn();
+    const initialProps: { open: `displayOptions:${string}` | null } = {
+      open: null,
+    };
+    const { result, rerender } = renderHook(
+      ({ open }) => useSectionDisplayOptionsRenderer(open, setSidebarMenuOpen),
+      { initialProps },
+    );
+    const projectA = result.current.render("project:a");
+    const projectB = result.current.render("project:b");
+
+    // A sidebar update re-renders the list with the same menu state; every
+    // header must get back the element it already has.
+    rerender({ open: null });
+    expect(result.current.render("project:a")).toBe(projectA);
+    expect(result.current.render("project:b")).toBe(projectB);
+
+    // Opening one section's menu replaces that section's element only.
+    rerender({ open: "displayOptions:project:a" });
+    const openedA = result.current.render("project:a");
+    expect(openedA).not.toBe(projectA);
+    expect(result.current.render("project:a")).toBe(openedA);
+    expect(result.current.render("project:b")).toBe(projectB);
+    expect(result.current.isOpen("project:a")).toBe(true);
+    expect(result.current.isOpen("project:b")).toBe(false);
+
+    rerender({ open: null });
+    const closedA = result.current.render("project:a");
+    expect(closedA).not.toBe(openedA);
+    expect(result.current.render("project:b")).toBe(projectB);
+    expect(result.current.isOpen("project:a")).toBe(false);
   });
 });

--- a/apps/app/src/components/sidebar/ProjectList.render-counts.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.render-counts.test.tsx
@@ -1,0 +1,271 @@
+// @vitest-environment jsdom
+//
+// End-to-end render counts for the sidebar's project rows. The unit suites
+// cover each memoization layer in isolation (row retention, the row
+// comparator, the cached header element, the draft subscriptions); this test
+// mounts the real `ProjectList` on a seeded query cache and counts how many
+// `ProjectRow` bodies run when one thread is patched through the same
+// `setQueryData` path a status-changed push uses, so a prop that bypasses
+// every tested helper (a fresh object threaded through `SortableProjectRow`,
+// say) still shows up as extra renders.
+
+import {
+  act,
+  cleanup,
+  render,
+  renderHook,
+  screen,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { Provider as JotaiProvider, createStore } from "jotai";
+import { TooltipProvider } from "@bb/shared-ui/tooltip";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  ProjectWithThreadsResponse,
+  SidebarBootstrapResponse,
+} from "@bb/server-contract";
+import { PERSONAL_PROJECT_ID, type ThreadListEntry } from "@bb/domain";
+import { makeThreadListEntry } from "@/test/fixtures/thread-list-entries";
+import { sidebarNavigationQueryKey } from "@/hooks/queries/query-keys";
+import { applyToCachedSidebarNavigationThreads } from "@/hooks/cache-owners/query-cache";
+import { ProjectList } from "./ProjectList";
+import type { ProjectRowProps } from "./ProjectRow";
+import { useSidebarReorderDnd } from "./useSidebarReorderDnd";
+
+/** How many times each project's `ProjectRow` body ran, by project id. */
+const projectRowRenders = vi.hoisted(() => new Map<string, number>());
+
+// The real row behind the real memo comparator, counting how often React gets
+// past that comparator. Every other export of the module stays as is.
+vi.mock("./ProjectRow", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./ProjectRow")>();
+  const { createElement, memo } = await import("react");
+  const CountingProjectRow = memo(function CountingProjectRow(
+    props: ProjectRowProps,
+  ) {
+    projectRowRenders.set(
+      props.project.id,
+      (projectRowRenders.get(props.project.id) ?? 0) + 1,
+    );
+    return createElement(actual.ProjectRow, props);
+  }, actual.areProjectRowPropsEqual);
+  return { ...actual, ProjectRow: CountingProjectRow };
+});
+
+vi.mock("@/hooks/queries/host-queries", () => ({
+  useHosts: () => ({ data: [] }),
+  usePrimaryHost: () => null,
+}));
+
+vi.mock("@/hooks/useRealtimeSubscription", () => ({
+  useThreadDetailRealtimeSubscription: () => {},
+  useEnvironmentDetailRealtimeSubscription: () => {},
+  useProjectDetailRealtimeSubscription: () => {},
+  useThreadListRealtimeSubscription: () => {},
+  useProjectListRealtimeSubscription: () => {},
+  useEnvironmentListRealtimeSubscription: () => {},
+  useHostListRealtimeSubscription: () => {},
+  useSystemRealtimeSubscription: () => {},
+}));
+
+vi.mock("@/hooks/useLocalPathPicker", () => ({
+  usePathPickerHost: () => ({ hostId: null, hostName: null }),
+}));
+
+vi.mock("@/hooks/mutations/environment-mutations", () => ({
+  useArchiveEnvironmentThreads: () => ({
+    isPending: false,
+    mutate: vi.fn(),
+    variables: undefined,
+  }),
+  useUpdateEnvironment: () => ({
+    error: null,
+    isPending: false,
+    mutate: vi.fn(),
+    reset: vi.fn(),
+    variables: undefined,
+  }),
+}));
+
+vi.mock("@/hooks/useCreateThreadInWorktree", () => ({
+  useCreateThreadInWorktree: () => vi.fn(),
+}));
+
+vi.mock("@/components/project/ProjectActionsProvider", () => ({
+  useProjectActions: () => ({
+    requestRename: vi.fn(),
+    requestDelete: vi.fn(),
+    requestAddLocalPath: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/thread/ThreadActionsProvider", () => ({
+  useThreadActions: () => ({
+    renameThread: vi.fn(),
+    requestRename: vi.fn(),
+    requestDelete: vi.fn(),
+    archiveThreadAndChildren: vi.fn(),
+    unarchiveThread: vi.fn(),
+    togglePin: vi.fn(),
+    toggleRead: vi.fn(),
+  }),
+}));
+
+function makeProject(
+  id: string,
+  threads: ThreadListEntry[],
+  kind: ProjectWithThreadsResponse["kind"] = "standard",
+): ProjectWithThreadsResponse {
+  return {
+    id,
+    kind,
+    name: `Project ${id}`,
+    gitRemoteUrl: null,
+    sources: [],
+    createdAt: 0,
+    updatedAt: 0,
+    threads,
+    defaultExecutionOptions: null,
+  };
+}
+
+function threadsFor(projectId: string, count: number): ThreadListEntry[] {
+  return Array.from({ length: count }, (_, index) =>
+    makeThreadListEntry({
+      id: `thr_${projectId}_${index}`,
+      projectId,
+      title: `Thread ${projectId} ${index}`,
+      updatedAt: 100 + index,
+      lastReadAt: 100 + index,
+      latestAttentionAt: 100 + index,
+    }),
+  );
+}
+
+function makePayload(): SidebarBootstrapResponse {
+  return {
+    sections: [],
+    projects: [
+      makeProject("a", threadsFor("a", 3)),
+      makeProject("b", threadsFor("b", 3)),
+      makeProject("c", threadsFor("c", 3)),
+    ],
+    personalProject: makeProject(
+      PERSONAL_PROJECT_ID,
+      threadsFor(PERSONAL_PROJECT_ID, 2),
+      "personal",
+    ),
+  };
+}
+
+function snapshotRenders(): Record<string, number> {
+  return Object.fromEntries(projectRowRenders);
+}
+
+/**
+ * Lets the follow-up renders an update schedules (layout-effect state, the
+ * persisted-order normalization, dnd-kit's first measurement) settle before
+ * the counts are sampled.
+ */
+async function settleRenders(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+  projectRowRenders.clear();
+});
+
+describe("ProjectList render counts", () => {
+  it("re-renders only the patched project's row on a sidebar cache patch", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData(sidebarNavigationQueryKey(), makePayload());
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <JotaiProvider store={createStore()}>
+          <TooltipProvider>
+            <MemoryRouter>
+              <ProjectList />
+            </MemoryRouter>
+          </TooltipProvider>
+        </JotaiProvider>
+      </QueryClientProvider>,
+    );
+    await screen.findByTitle("Project c");
+    await settleRenders();
+    const baseline = snapshotRenders();
+    expect(Object.keys(baseline).sort()).toEqual(["a", "b", "c"]);
+
+    // A status-changed push for one of A's threads, through the same
+    // setQueryData path the realtime cache owner uses.
+    await act(async () => {
+      applyToCachedSidebarNavigationThreads({
+        queryClient,
+        mapper: (threads) =>
+          threads.map((thread) =>
+            thread.id === "thr_a_1"
+              ? {
+                  ...thread,
+                  status: "active",
+                  runtime: {
+                    displayStatus: "active",
+                    hostReconnectGraceExpiresAt: null,
+                  },
+                }
+              : thread,
+          ),
+      });
+    });
+    await settleRenders();
+    const afterPatch = snapshotRenders();
+    expect(afterPatch).toEqual({ ...baseline, a: baseline.a + 1 });
+
+    // A refetch whose payload is deep-equal: React Query's structural sharing
+    // keeps every object, so no row renders at all.
+    await act(async () => {
+      queryClient.setQueryData(sidebarNavigationQueryKey(), (current) =>
+        structuredClone(current),
+      );
+    });
+    await settleRenders();
+    expect(snapshotRenders()).toEqual(afterPatch);
+
+    // A change to every thread of B alone re-renders B's row only.
+    await act(async () => {
+      applyToCachedSidebarNavigationThreads({
+        queryClient,
+        mapper: (threads) =>
+          threads.map((thread) =>
+            thread.projectId === "b"
+              ? { ...thread, updatedAt: thread.updatedAt + 1000 }
+              : thread,
+          ),
+      });
+    });
+    await settleRenders();
+    expect(snapshotRenders()).toEqual({ ...afterPatch, b: afterPatch.b + 1 });
+  });
+});
+
+describe("useSidebarReorderDnd", () => {
+  it("keeps the dnd-kit sensors across re-renders with unchanged handlers", () => {
+    // dnd-kit memoizes the sensors on their option objects; a fresh `sensors`
+    // array makes DndContext rebuild every sortable's listeners, which is what
+    // the render-count test above catches one layer up.
+    const onDragEnd = vi.fn();
+    const { result, rerender } = renderHook(() =>
+      useSidebarReorderDnd({ onDragEnd }),
+    );
+    const first = result.current.dndContextProps;
+    rerender();
+    expect(result.current.dndContextProps.sensors).toBe(first.sensors);
+    expect(result.current.dndContextProps).toBe(first);
+  });
+});

--- a/apps/app/src/components/sidebar/ProjectList.render-counts.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.render-counts.test.tsx
@@ -9,13 +9,7 @@
 // every tested helper (a fresh object threaded through `SortableProjectRow`,
 // say) still shows up as extra renders.
 
-import {
-  act,
-  cleanup,
-  render,
-  renderHook,
-  screen,
-} from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { Provider as JotaiProvider, createStore } from "jotai";
@@ -31,7 +25,6 @@ import { sidebarNavigationQueryKey } from "@/hooks/queries/query-keys";
 import { applyToCachedSidebarNavigationThreads } from "@/hooks/cache-owners/query-cache";
 import { ProjectList } from "./ProjectList";
 import type { ProjectRowProps } from "./ProjectRow";
-import { useSidebarReorderDnd } from "./useSidebarReorderDnd";
 
 /** How many times each project's `ProjectRow` body ran, by project id. */
 const projectRowRenders = vi.hoisted(() => new Map<string, number>());
@@ -251,21 +244,5 @@ describe("ProjectList render counts", () => {
     });
     await settleRenders();
     expect(snapshotRenders()).toEqual({ ...afterPatch, b: afterPatch.b + 1 });
-  });
-});
-
-describe("useSidebarReorderDnd", () => {
-  it("keeps the dnd-kit sensors across re-renders with unchanged handlers", () => {
-    // dnd-kit memoizes the sensors on their option objects; a fresh `sensors`
-    // array makes DndContext rebuild every sortable's listeners, which is what
-    // the render-count test above catches one layer up.
-    const onDragEnd = vi.fn();
-    const { result, rerender } = renderHook(() =>
-      useSidebarReorderDnd({ onDragEnd }),
-    );
-    const first = result.current.dndContextProps;
-    rerender();
-    expect(result.current.dndContextProps.sensors).toBe(first.sensors);
-    expect(result.current.dndContextProps).toBe(first);
   });
 });

--- a/apps/app/src/components/sidebar/ProjectList.rows.test.ts
+++ b/apps/app/src/components/sidebar/ProjectList.rows.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import type { ThreadListEntry } from "@bb/domain";
+import type { ProjectResponse } from "@bb/server-contract";
+import { makeThreadListEntry } from "@/test/fixtures/thread-list-entries";
+import { retainProjectRows } from "./ProjectList";
+import type { ProjectListRowModel } from "./ProjectListProjects";
+
+function makeProject(id: string): ProjectResponse {
+  return {
+    id,
+    kind: "standard",
+    name: id,
+    gitRemoteUrl: null,
+    sources: [],
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+function makeRow(
+  project: ProjectResponse,
+  threads: ThreadListEntry[],
+  overrides: Partial<Omit<ProjectListRowModel, "project">> = {},
+): ProjectListRowModel {
+  return {
+    project,
+    threadListState: { status: "ready", threads },
+    isActive: false,
+    isLocalPathInvalid: false,
+    ...overrides,
+  };
+}
+
+function readyThreads(row: ProjectListRowModel): ThreadListEntry[] {
+  if (row.threadListState.status !== "ready") {
+    throw new Error(`expected a ready row, got ${row.threadListState.status}`);
+  }
+  return row.threadListState.threads;
+}
+
+describe("retainProjectRows", () => {
+  const projectA = makeProject("proj_a");
+  const projectB = makeProject("proj_b");
+  const threadA1 = makeThreadListEntry({ id: "thr_a1", projectId: "proj_a" });
+  const threadA2 = makeThreadListEntry({ id: "thr_a2", projectId: "proj_a" });
+  const threadB1 = makeThreadListEntry({ id: "thr_b1", projectId: "proj_b" });
+
+  it("keeps the row and thread array of a project whose entries did not change", () => {
+    const previous = retainProjectRows(
+      [],
+      [makeRow(projectA, [threadA1, threadA2]), makeRow(projectB, [threadB1])],
+    );
+    // A refetch regroups every project into fresh arrays. React Query's
+    // structural sharing keeps an unchanged entry's identity and replaces a
+    // changed one, so entry identity decides whether a row can be kept.
+    const runningA1 = makeThreadListEntry({
+      id: "thr_a1",
+      projectId: "proj_a",
+      status: "active",
+    });
+    const next = retainProjectRows(previous, [
+      makeRow(projectA, [runningA1, threadA2]),
+      makeRow(projectB, [threadB1]),
+    ]);
+
+    expect(next).not.toBe(previous);
+    expect(next[0]).not.toBe(previous[0]);
+    expect(readyThreads(next[0])).toEqual([runningA1, threadA2]);
+    expect(next[1]).toBe(previous[1]);
+    expect(next[1].threadListState).toBe(previous[1].threadListState);
+    expect(readyThreads(next[1])).toBe(readyThreads(previous[1]));
+  });
+
+  it("returns the previous array when every row is kept in place", () => {
+    const previous = retainProjectRows(
+      [],
+      [makeRow(projectA, [threadA1]), makeRow(projectB, [threadB1])],
+    );
+    expect(
+      retainProjectRows(previous, [
+        makeRow(projectA, [threadA1]),
+        makeRow(projectB, [threadB1]),
+      ]),
+    ).toBe(previous);
+    expect(retainProjectRows([], [])).toEqual([]);
+  });
+
+  it("returns a new array for a reorder while keeping the row objects", () => {
+    const previous = retainProjectRows(
+      [],
+      [makeRow(projectA, [threadA1]), makeRow(projectB, [threadB1])],
+    );
+    const next = retainProjectRows(previous, [
+      makeRow(projectB, [threadB1]),
+      makeRow(projectA, [threadA1]),
+    ]);
+    expect(next).not.toBe(previous);
+    expect(next).toEqual([previous[1], previous[0]]);
+    expect(next[0]).toBe(previous[1]);
+    expect(next[1]).toBe(previous[0]);
+  });
+
+  it("replaces every row when the list status changes", () => {
+    const loading = retainProjectRows(
+      [],
+      [
+        makeRow(projectA, [], { threadListState: { status: "loading" } }),
+        makeRow(projectB, [], { threadListState: { status: "loading" } }),
+      ],
+    );
+    const ready = retainProjectRows(loading, [
+      makeRow(projectA, [threadA1]),
+      makeRow(projectB, []),
+    ]);
+    expect(ready[0]).not.toBe(loading[0]);
+    expect(ready[1]).not.toBe(loading[1]);
+    expect(ready[1].threadListState).toEqual({ status: "ready", threads: [] });
+
+    const unavailable = retainProjectRows(ready, [
+      makeRow(projectA, [], { threadListState: { status: "unavailable" } }),
+      makeRow(projectB, [], { threadListState: { status: "unavailable" } }),
+    ]);
+    expect(unavailable[0]).not.toBe(ready[0]);
+    expect(unavailable[1]).not.toBe(ready[1]);
+  });
+
+  it("replaces a row whose project object or flags changed", () => {
+    const previous = retainProjectRows(
+      [],
+      [makeRow(projectA, [threadA1]), makeRow(projectB, [threadB1])],
+    );
+    const next = retainProjectRows(previous, [
+      makeRow(makeProject("proj_a"), [threadA1]),
+      makeRow(projectB, [threadB1], { isLocalPathInvalid: true }),
+    ]);
+    expect(next[0]).not.toBe(previous[0]);
+    expect(next[1]).not.toBe(previous[1]);
+    expect(next[1].isLocalPathInvalid).toBe(true);
+  });
+
+  it("drops a removed project and keeps the rest", () => {
+    const previous = retainProjectRows(
+      [],
+      [makeRow(projectA, [threadA1]), makeRow(projectB, [threadB1])],
+    );
+    const next = retainProjectRows(previous, [makeRow(projectB, [threadB1])]);
+    expect(next).toHaveLength(1);
+    expect(next[0]).toBe(previous[1]);
+  });
+});

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type MouseEventHandler,
   type PointerEventHandler,
@@ -74,6 +75,8 @@ import {
   COARSE_POINTER_TEXT_SM_CLASS,
 } from "@bb/shared-ui/coarse-pointer-sizing";
 import {
+  areProjectThreadListStatesEqual,
+  areThreadListsEqual,
   ChronologicalSectionThreadSections,
   ProjectThreadTree,
 } from "./ProjectRow";
@@ -344,7 +347,9 @@ const EMPTY_PROJECT_THREAD_LIST_STATE: ProjectThreadListState = {
 };
 
 const EMPTY_PROJECTS: readonly ProjectResponse[] = [];
+const EMPTY_PROJECT_ROWS: readonly ProjectListRowModel[] = [];
 const EMPTY_SECTION_DEFINITIONS: readonly ThreadSectionResponse[] = [];
+const EMPTY_THREAD_LIST: ThreadListEntry[] = [];
 
 function getProjectThreadListState({
   status,
@@ -362,6 +367,42 @@ function getProjectThreadListState({
     case undefined:
       return EMPTY_PROJECT_THREAD_LIST_STATE;
   }
+}
+
+/**
+ * Reuse the previous row model for every project whose row would render the
+ * same thing: the same project object and flags, and a thread list with the
+ * same entries. A sidebar refetch regroups every thread into fresh per-project
+ * arrays, so without this every `ProjectRow` saw a new `threadListState` at
+ * each turn boundary of any running thread. Returns `previous` itself when
+ * every row was kept in the same position, so the section ids and lookups
+ * derived from the rows stay cached as well.
+ */
+export function retainProjectRows(
+  previous: readonly ProjectListRowModel[],
+  next: readonly ProjectListRowModel[],
+): readonly ProjectListRowModel[] {
+  const previousById = new Map(previous.map((row) => [row.project.id, row]));
+  let changed = previous.length !== next.length;
+  const rows = next.map((row, index) => {
+    const previousRow = previousById.get(row.project.id);
+    if (
+      previousRow === undefined ||
+      previousRow.project !== row.project ||
+      previousRow.isActive !== row.isActive ||
+      previousRow.isLocalPathInvalid !== row.isLocalPathInvalid ||
+      !areProjectThreadListStatesEqual(
+        previousRow.threadListState,
+        row.threadListState,
+      )
+    ) {
+      changed = true;
+      return row;
+    }
+    if (previous[index] !== previousRow) changed = true;
+    return previousRow;
+  });
+  return changed ? rows : previous;
 }
 
 function toggleCollapsedIdList({
@@ -722,6 +763,73 @@ export function SidebarDisplayOptionsMenu({
   );
 }
 
+type SetSidebarMenuOpen = (
+  menu: Exclude<OpenSidebarMenu, null>,
+  open: boolean,
+) => void;
+
+interface SectionDisplayOptionsRenderer {
+  render: (sectionId: SidebarSectionId) => ReactNode;
+  isOpen: (sectionId: SidebarSectionId) => boolean;
+}
+
+interface CachedSectionDisplayOptions {
+  open: boolean;
+  setSidebarMenuOpen: SetSidebarMenuOpen;
+  node: ReactNode;
+}
+
+/**
+ * Per-section `SidebarDisplayOptionsMenu` elements that keep their identity
+ * while the section's open state is unchanged. Every section header takes the
+ * element as a prop and every sidebar update re-renders the whole list, so a
+ * fresh element per call defeated the row and section memo boundaries even
+ * though at most the one open menu ever differs. Reusing an element is safe
+ * because the menu reads its atoms through hooks, not props. The cache is
+ * bounded by the sections seen, so it needs no pruning.
+ */
+export function useSectionDisplayOptionsRenderer(
+  openSidebarMenu: OpenSidebarMenu,
+  setSidebarMenuOpen: SetSidebarMenuOpen,
+): SectionDisplayOptionsRenderer {
+  const cacheRef = useRef<Map<
+    SidebarSectionId,
+    CachedSectionDisplayOptions
+  > | null>(null);
+  const render = useCallback(
+    (sectionId: SidebarSectionId): ReactNode => {
+      const menuId = `displayOptions:${sectionId}` as const;
+      const open = openSidebarMenu === menuId;
+      /* oxlint-disable react/refs -- render-time element cache, see above */
+      const cache = (cacheRef.current ??= new Map());
+      /* oxlint-enable react/refs */
+      const cached = cache.get(sectionId);
+      if (
+        cached !== undefined &&
+        cached.open === open &&
+        cached.setSidebarMenuOpen === setSidebarMenuOpen
+      ) {
+        return cached.node;
+      }
+      const node = (
+        <SidebarDisplayOptionsMenu
+          open={open}
+          onOpenChange={(nextOpen) => setSidebarMenuOpen(menuId, nextOpen)}
+        />
+      );
+      cache.set(sectionId, { open, setSidebarMenuOpen, node });
+      return node;
+    },
+    [openSidebarMenu, setSidebarMenuOpen],
+  );
+  const isOpen = useCallback(
+    (sectionId: SidebarSectionId) =>
+      openSidebarMenu === `displayOptions:${sectionId}`,
+    [openSidebarMenu],
+  );
+  return useMemo(() => ({ render, isOpen }), [isOpen, render]);
+}
+
 interface SidebarThreadsSectionActionsProps {
   displayOptionsOpen: boolean;
   onDisplayOptionsOpenChange: (open: boolean) => void;
@@ -1059,28 +1167,37 @@ function ProjectModeSections({
     }
     return grouped;
   }, [effectivePinnedThreadIds, threads]);
-  const projectRows = useMemo<ProjectListRowModel[]>(
-    () =>
-      projects.map((project) => ({
-        project,
-        threadListState: getProjectThreadListState({
-          status,
-          threads: threadsByProject.get(project.id),
-        }),
-        isActive: false,
-        isLocalPathInvalid: isHostPathMissing(
-          pathExistence,
-          localSourcePathsByProjectId.get(project.id),
-        ),
-      })),
-    [
-      localSourcePathsByProjectId,
-      pathExistence,
-      projects,
-      status,
-      threadsByProject,
-    ],
-  );
+  // Render-time cache of the previous rows: they are the input that decides
+  // which of the rebuilt rows can be kept (see retainProjectRows). The memo
+  // reads and writes a ref during render, following
+  // useSidebarThreadTitleMentionResources.
+  const previousProjectRowsRef =
+    useRef<readonly ProjectListRowModel[]>(EMPTY_PROJECT_ROWS);
+  const projectRows = useMemo<readonly ProjectListRowModel[]>(() => {
+    const nextRows = projects.map((project): ProjectListRowModel => ({
+      project,
+      threadListState: getProjectThreadListState({
+        status,
+        threads: threadsByProject.get(project.id),
+      }),
+      isActive: false,
+      isLocalPathInvalid: isHostPathMissing(
+        pathExistence,
+        localSourcePathsByProjectId.get(project.id),
+      ),
+    }));
+    /* oxlint-disable react/refs -- render-time cache, see above */
+    const rows = retainProjectRows(previousProjectRowsRef.current, nextRows);
+    previousProjectRowsRef.current = rows;
+    /* oxlint-enable react/refs */
+    return rows;
+  }, [
+    localSourcePathsByProjectId,
+    pathExistence,
+    projects,
+    status,
+    threadsByProject,
+  ]);
   const projectSectionIds = useMemo(
     () =>
       projectRows.map((row) =>
@@ -1102,22 +1219,45 @@ function ProjectModeSections({
     isReady,
   });
   const reorderDisabled = order.length < 2;
-  const personalThreads =
-    threadsByProject.get(PERSONAL_PROJECT_ID)?.filter(isSidebarProjectThread) ??
-    [];
+  const personalProjectThreads = threadsByProject.get(PERSONAL_PROJECT_ID);
+  // Same render-time retention as the project rows above: the regrouped
+  // personal list is a fresh array per refetch even when its entries are the
+  // same, and the Threads section's tree is memoized on the list state.
+  const previousPersonalThreadsRef =
+    useRef<ThreadListEntry[]>(EMPTY_THREAD_LIST);
+  const personalThreads = useMemo(() => {
+    const next =
+      personalProjectThreads?.filter(isSidebarProjectThread) ??
+      EMPTY_THREAD_LIST;
+    /* oxlint-disable react/refs -- render-time cache, see above */
+    const threads = areThreadListsEqual(
+      previousPersonalThreadsRef.current,
+      next,
+    )
+      ? previousPersonalThreadsRef.current
+      : next;
+    previousPersonalThreadsRef.current = threads;
+    /* oxlint-enable react/refs */
+    return threads;
+  }, [personalProjectThreads]);
+  const personalThreadListState = useMemo(
+    () => getProjectThreadListState({ status, threads: personalThreads }),
+    [personalThreads, status],
+  );
+  const personalActivity = useMemo(
+    () => getCollapsedChildActivity(personalThreads, draftThreadIds),
+    [draftThreadIds, personalThreads],
+  );
   const builtInSections: BuiltInSidebarSectionOptionsById = {
     pinned: pinnedSection,
     threads: {
       ...threadsSection,
-      activity: getCollapsedChildActivity(personalThreads, draftThreadIds),
+      activity: personalActivity,
       collapsedThreads: personalThreads,
       content: (
         <ProjectThreadTree
           projectId={PERSONAL_PROJECT_ID}
-          threadListState={getProjectThreadListState({
-            status,
-            threads: personalThreads,
-          })}
+          threadListState={personalThreadListState}
           selectedThreadId={selectedThreadId}
           collapsedThreadIds={collapsedThreadIds}
           collapsedEnvironmentIds={collapsedEnvironmentIds}
@@ -1688,31 +1828,21 @@ function ProjectListComponent({
   const [collapsedSidebarSectionIdList, setCollapsedSidebarSectionIdList] =
     useAtom(collapsedSidebarSectionIdsAtom);
   const [openSidebarMenu, setOpenSidebarMenu] = useState<OpenSidebarMenu>(null);
-  const setSidebarMenuOpen = useCallback(
-    (menu: Exclude<OpenSidebarMenu, null>, open: boolean) => {
-      setOpenSidebarMenu((current) =>
-        open ? menu : current === menu ? null : current,
-      );
-    },
-    [],
-  );
+  const setSidebarMenuOpen = useCallback<SetSidebarMenuOpen>((menu, open) => {
+    setOpenSidebarMenu((current) =>
+      open ? menu : current === menu ? null : current,
+    );
+  }, []);
   const handleThreadsDisplayOptionsMenuOpenChange = useCallback(
     (open: boolean) => setSidebarMenuOpen("threadsDisplayOptions", open),
     [setSidebarMenuOpen],
   );
   const threadsDisplayOptionsMenuOpen =
     openSidebarMenu === "threadsDisplayOptions";
-  const renderSectionDisplayOptions = (sectionId: SidebarSectionId) => {
-    const menuId = `displayOptions:${sectionId}` as const;
-    return (
-      <SidebarDisplayOptionsMenu
-        open={openSidebarMenu === menuId}
-        onOpenChange={(open) => setSidebarMenuOpen(menuId, open)}
-      />
-    );
-  };
-  const isSectionDisplayOptionsOpen = (sectionId: SidebarSectionId) =>
-    openSidebarMenu === `displayOptions:${sectionId}`;
+  const {
+    render: renderSectionDisplayOptions,
+    isOpen: isSectionDisplayOptionsOpen,
+  } = useSectionDisplayOptionsRenderer(openSidebarMenu, setSidebarMenuOpen);
   const organizationMode = useAtomValue(sidebarOrganizationModeAtom);
   const [chronologicalSort, setChronologicalSort] = useAtom(
     sidebarChronologicalSortAtom,

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -405,6 +405,43 @@ export function retainProjectRows(
   return changed ? rows : previous;
 }
 
+/**
+ * Render-time retention of the project rows (see {@link retainProjectRows}).
+ * The previous rows are the input that decides which rebuilt rows can be
+ * kept, so this reads and writes a ref during render (a state-based "adjust
+ * during render" would loop on a caller that rebuilds its rows per render).
+ * Kept in its own small hook, like useSidebarThreadTitleMentionResources, so
+ * the React Compiler bailout the ref access forces stays confined here
+ * instead of leaving the whole ProjectModeSections component uncompiled.
+ */
+function useRetainedProjectRows(
+  next: readonly ProjectListRowModel[],
+): readonly ProjectListRowModel[] {
+  const previousRef =
+    useRef<readonly ProjectListRowModel[]>(EMPTY_PROJECT_ROWS);
+  /* oxlint-disable react/refs -- render-time cache, see above */
+  const rows = retainProjectRows(previousRef.current, next);
+  previousRef.current = rows;
+  /* oxlint-enable react/refs */
+  return rows;
+}
+
+/**
+ * Keeps the previous thread list while `next` holds the same entries in the
+ * same order. Same render-time ref cache as {@link useRetainedProjectRows},
+ * isolated for the same reason.
+ */
+function useRetainedThreadList(next: ThreadListEntry[]): ThreadListEntry[] {
+  const previousRef = useRef<ThreadListEntry[]>(EMPTY_THREAD_LIST);
+  /* oxlint-disable react/refs -- render-time cache, see above */
+  const threads = areThreadListsEqual(previousRef.current, next)
+    ? previousRef.current
+    : next;
+  previousRef.current = threads;
+  /* oxlint-enable react/refs */
+  return threads;
+}
+
 function toggleCollapsedIdList({
   current,
   id,
@@ -801,7 +838,11 @@ export function useSectionDisplayOptionsRenderer(
       const menuId = `displayOptions:${sectionId}` as const;
       const open = openSidebarMenu === menuId;
       /* oxlint-disable react/refs -- render-time element cache, see above */
-      const cache = (cacheRef.current ??= new Map());
+      let cache = cacheRef.current;
+      if (cache === null) {
+        cache = new Map();
+        cacheRef.current = cache;
+      }
       /* oxlint-enable react/refs */
       const cached = cache.get(sectionId);
       if (
@@ -1167,37 +1208,29 @@ function ProjectModeSections({
     }
     return grouped;
   }, [effectivePinnedThreadIds, threads]);
-  // Render-time cache of the previous rows: they are the input that decides
-  // which of the rebuilt rows can be kept (see retainProjectRows). The memo
-  // reads and writes a ref during render, following
-  // useSidebarThreadTitleMentionResources.
-  const previousProjectRowsRef =
-    useRef<readonly ProjectListRowModel[]>(EMPTY_PROJECT_ROWS);
-  const projectRows = useMemo<readonly ProjectListRowModel[]>(() => {
-    const nextRows = projects.map((project): ProjectListRowModel => ({
-      project,
-      threadListState: getProjectThreadListState({
-        status,
-        threads: threadsByProject.get(project.id),
-      }),
-      isActive: false,
-      isLocalPathInvalid: isHostPathMissing(
-        pathExistence,
-        localSourcePathsByProjectId.get(project.id),
-      ),
-    }));
-    /* oxlint-disable react/refs -- render-time cache, see above */
-    const rows = retainProjectRows(previousProjectRowsRef.current, nextRows);
-    previousProjectRowsRef.current = rows;
-    /* oxlint-enable react/refs */
-    return rows;
-  }, [
-    localSourcePathsByProjectId,
-    pathExistence,
-    projects,
-    status,
-    threadsByProject,
-  ]);
+  const nextProjectRows = useMemo<readonly ProjectListRowModel[]>(
+    () =>
+      projects.map((project): ProjectListRowModel => ({
+        project,
+        threadListState: getProjectThreadListState({
+          status,
+          threads: threadsByProject.get(project.id),
+        }),
+        isActive: false,
+        isLocalPathInvalid: isHostPathMissing(
+          pathExistence,
+          localSourcePathsByProjectId.get(project.id),
+        ),
+      })),
+    [
+      localSourcePathsByProjectId,
+      pathExistence,
+      projects,
+      status,
+      threadsByProject,
+    ],
+  );
+  const projectRows = useRetainedProjectRows(nextProjectRows);
   const projectSectionIds = useMemo(
     () =>
       projectRows.map((row) =>
@@ -1220,26 +1253,16 @@ function ProjectModeSections({
   });
   const reorderDisabled = order.length < 2;
   const personalProjectThreads = threadsByProject.get(PERSONAL_PROJECT_ID);
-  // Same render-time retention as the project rows above: the regrouped
-  // personal list is a fresh array per refetch even when its entries are the
-  // same, and the Threads section's tree is memoized on the list state.
-  const previousPersonalThreadsRef =
-    useRef<ThreadListEntry[]>(EMPTY_THREAD_LIST);
-  const personalThreads = useMemo(() => {
-    const next =
+  const nextPersonalThreads = useMemo(
+    () =>
       personalProjectThreads?.filter(isSidebarProjectThread) ??
-      EMPTY_THREAD_LIST;
-    /* oxlint-disable react/refs -- render-time cache, see above */
-    const threads = areThreadListsEqual(
-      previousPersonalThreadsRef.current,
-      next,
-    )
-      ? previousPersonalThreadsRef.current
-      : next;
-    previousPersonalThreadsRef.current = threads;
-    /* oxlint-enable react/refs */
-    return threads;
-  }, [personalProjectThreads]);
+      EMPTY_THREAD_LIST,
+    [personalProjectThreads],
+  );
+  // The regrouped personal list is a fresh array per refetch even when its
+  // entries are the same, and the Threads section's tree is memoized on the
+  // list state, so it gets the same retention as the project rows.
+  const personalThreads = useRetainedThreadList(nextPersonalThreads);
   const personalThreadListState = useMemo(
     () => getProjectThreadListState({ status, threads: personalThreads }),
     [personalThreads, status],

--- a/apps/app/src/components/sidebar/ProjectRow.test.ts
+++ b/apps/app/src/components/sidebar/ProjectRow.test.ts
@@ -1,7 +1,14 @@
+import { createElement } from "react";
 import { describe, expect, it } from "vitest";
+import type { ProjectResponse } from "@bb/server-contract";
+import { makeThreadListEntry } from "@/test/fixtures/thread-list-entries";
 import {
+  areProjectRowPropsEqual,
+  areProjectThreadListStatesEqual,
   formatArchivedEnvironmentThreadsToastTitle,
   shouldSuppressPinnedThreadDropPreview,
+  type ProjectRowProps,
+  type ProjectThreadListState,
 } from "./ProjectRow";
 import { PINNED_THREAD_PARENT_KEY } from "./useSectionThreadDnd";
 
@@ -50,5 +57,170 @@ describe("shouldSuppressPinnedThreadDropPreview", () => {
         pinnedThreads: [{ id: "thread-1" }],
       }),
     ).toBe(true);
+  });
+});
+
+describe("areProjectThreadListStatesEqual", () => {
+  const threadA = makeThreadListEntry({ id: "thr_a" });
+  const threadB = makeThreadListEntry({ id: "thr_b" });
+
+  it("treats a new array with the same entries as equal", () => {
+    expect(
+      areProjectThreadListStatesEqual(
+        { status: "ready", threads: [threadA, threadB] },
+        { status: "ready", threads: [threadA, threadB] },
+      ),
+    ).toBe(true);
+  });
+
+  it("treats a replaced entry as a change even when its fields match", () => {
+    // Identity is the test on purpose: React Query structurally shares the
+    // sidebar payload, so an entry keeps its object while its fields are
+    // unchanged and a new object always carries a change.
+    const threadBCopy = makeThreadListEntry({ id: "thr_b" });
+    expect(
+      areProjectThreadListStatesEqual(
+        { status: "ready", threads: [threadA, threadB] },
+        { status: "ready", threads: [threadA, threadBCopy] },
+      ),
+    ).toBe(false);
+  });
+
+  it("treats added, removed and reordered entries as a change", () => {
+    const both: ProjectThreadListState = {
+      status: "ready",
+      threads: [threadA, threadB],
+    };
+    expect(
+      areProjectThreadListStatesEqual(both, {
+        status: "ready",
+        threads: [threadA],
+      }),
+    ).toBe(false);
+    expect(
+      areProjectThreadListStatesEqual(both, {
+        status: "ready",
+        threads: [threadB, threadA],
+      }),
+    ).toBe(false);
+  });
+
+  it("compares non-ready states by status alone", () => {
+    expect(
+      areProjectThreadListStatesEqual(
+        { status: "ready", threads: [threadA] },
+        { status: "unavailable" },
+      ),
+    ).toBe(false);
+    expect(
+      areProjectThreadListStatesEqual(
+        { status: "loading" },
+        { status: "unavailable" },
+      ),
+    ).toBe(false);
+    expect(
+      areProjectThreadListStatesEqual(
+        { status: "loading" },
+        { status: "loading" },
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("areProjectRowPropsEqual", () => {
+  const threadA = makeThreadListEntry({ id: "thr_a" });
+  const threadB = makeThreadListEntry({ id: "thr_b" });
+  const collapsedThreadIds = new Set<string>();
+  const collapsedEnvironmentIds = new Set<string>();
+  const compareThreads = () => 0;
+  const noop = () => {};
+  const headerActions = createElement("span");
+  // Shared like React Query's structural sharing shares an unchanged nested
+  // value: a refetch gives the project a new object but the same `sources`.
+  const sources: ProjectResponse["sources"] = [];
+
+  function makeProject(
+    overrides: Partial<ProjectResponse> = {},
+  ): ProjectResponse {
+    return {
+      id: "proj_test",
+      kind: "standard",
+      name: "Test project",
+      gitRemoteUrl: null,
+      sources,
+      createdAt: 0,
+      updatedAt: 0,
+      ...overrides,
+    };
+  }
+
+  function makeProps(
+    overrides: Partial<ProjectRowProps> = {},
+  ): ProjectRowProps {
+    return {
+      project: makeProject(),
+      threadListState: { status: "ready", threads: [threadA, threadB] },
+      isActive: false,
+      isCollapsed: false,
+      compareThreads,
+      collapsedThreadIds,
+      collapsedEnvironmentIds,
+      isLocalPathInvalid: false,
+      headerActions,
+      onToggleProjectCollapsed: noop,
+      onToggleThreadCollapsed: noop,
+      onToggleEnvironmentCollapsed: noop,
+      ...overrides,
+    };
+  }
+
+  it("keeps the row for an equal project object and the same thread entries", () => {
+    // A refetch that touched another project's threads still hands this row
+    // a fresh project object and a fresh thread array with identical content.
+    expect(areProjectRowPropsEqual(makeProps(), makeProps())).toBe(true);
+  });
+
+  it("re-renders when a thread entry was replaced", () => {
+    expect(
+      areProjectRowPropsEqual(
+        makeProps(),
+        makeProps({
+          threadListState: {
+            status: "ready",
+            threads: [threadA, makeThreadListEntry({ id: "thr_b" })],
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("re-renders when a project field changed", () => {
+    expect(
+      areProjectRowPropsEqual(
+        makeProps(),
+        makeProps({ project: makeProject({ name: "Renamed" }) }),
+      ),
+    ).toBe(false);
+  });
+
+  it("re-renders when the thread list status changed", () => {
+    expect(
+      areProjectRowPropsEqual(
+        makeProps(),
+        makeProps({ threadListState: { status: "unavailable" } }),
+      ),
+    ).toBe(false);
+  });
+
+  it("re-renders when the header actions element changed identity", () => {
+    // The list must therefore hand each row a cached element (see
+    // useSectionDisplayOptionsRenderer); a fresh one per render would defeat
+    // every other check here.
+    expect(
+      areProjectRowPropsEqual(
+        makeProps(),
+        makeProps({ headerActions: createElement("span") }),
+      ),
+    ).toBe(false);
   });
 });

--- a/apps/app/src/components/sidebar/ProjectRow.test.ts
+++ b/apps/app/src/components/sidebar/ProjectRow.test.ts
@@ -203,6 +203,19 @@ describe("areProjectRowPropsEqual", () => {
     ).toBe(false);
   });
 
+  it("re-renders when a nested project value was replaced", () => {
+    // Nested identity is the contract: structural sharing keeps `sources`
+    // when it is unchanged and hands the row a new array when it changed, so
+    // the comparator must treat a fresh array with equal content as a change
+    // (the actions menu reads `project.sources` to decide what it offers).
+    expect(
+      areProjectRowPropsEqual(
+        makeProps(),
+        makeProps({ project: makeProject({ sources: [] }) }),
+      ),
+    ).toBe(false);
+  });
+
   it("re-renders when the thread list status changed", () => {
     expect(
       areProjectRowPropsEqual(

--- a/apps/app/src/components/sidebar/ProjectRow.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.tsx
@@ -153,6 +153,38 @@ export type ProjectThreadListState =
       status: "unavailable";
     };
 
+/**
+ * Element-wise identity comparison of two thread lists. Identity is the right
+ * test: React Query structurally shares the sidebar payload, so an entry whose
+ * fields did not change keeps its object across refetches, a changed entry is
+ * always a new object, and nothing mutates cached entries in place. A list
+ * with the same entries in the same order renders the same rows, whichever
+ * array wraps it.
+ */
+export function areThreadListsEqual(
+  prev: readonly ThreadListEntry[],
+  next: readonly ThreadListEntry[],
+): boolean {
+  if (prev === next) return true;
+  if (prev.length !== next.length) return false;
+  for (let index = 0; index < prev.length; index += 1) {
+    if (prev[index] !== next[index]) return false;
+  }
+  return true;
+}
+
+/** Value equality for a project's thread-list state; see areThreadListsEqual. */
+export function areProjectThreadListStatesEqual(
+  prev: ProjectThreadListState,
+  next: ProjectThreadListState,
+): boolean {
+  if (prev === next) return true;
+  if (prev.status !== "ready" || next.status !== "ready") {
+    return prev.status === next.status;
+  }
+  return areThreadListsEqual(prev.threads, next.threads);
+}
+
 export interface ProjectRowProps {
   project: ProjectResponse;
   threadListState: ProjectThreadListState;
@@ -2501,13 +2533,37 @@ function hasCollapsedEnvironmentStateChanged({
   return false;
 }
 
-function areProjectRowPropsEqual(
+/**
+ * A project whose threads changed arrives as a new payload object even when
+ * none of its own fields did, so the row compares own properties rather than
+ * identity. Nested values such as `sources` keep their identity through React
+ * Query's structural sharing whenever their contents are unchanged, so a
+ * shallow pass is enough. Generic so `for...in` yields typed keys and the
+ * check covers every field the payload carries, not only the ones the
+ * `ProjectResponse` type names.
+ */
+function areSidebarProjectsEqual<T extends ProjectResponse>(
+  prev: T,
+  next: T,
+): boolean {
+  if (prev === next) return true;
+  if (Object.keys(prev).length !== Object.keys(next).length) return false;
+  for (const key in prev) {
+    if (!(key in next) || !Object.is(prev[key], next[key])) return false;
+  }
+  return true;
+}
+
+export function areProjectRowPropsEqual(
   prev: ProjectRowProps,
   next: ProjectRowProps,
 ): boolean {
   if (
-    prev.project !== next.project ||
-    prev.threadListState !== next.threadListState ||
+    !areSidebarProjectsEqual(prev.project, next.project) ||
+    !areProjectThreadListStatesEqual(
+      prev.threadListState,
+      next.threadListState,
+    ) ||
     prev.isActive !== next.isActive ||
     prev.isCollapsed !== next.isCollapsed ||
     prev.compareThreads !== next.compareThreads ||

--- a/apps/app/src/components/sidebar/SidebarSectionOrderList.tsx
+++ b/apps/app/src/components/sidebar/SidebarSectionOrderList.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 import { DndContext } from "@dnd-kit/core";
 import {
   SortableContext,
@@ -18,8 +18,13 @@ export function SidebarSectionOrderList({
   dndContextProps,
   order,
 }: SidebarSectionOrderListProps) {
+  // `SortableContext` memoizes its context value on the items array, and every
+  // `useSortable` row subscribes to it; a fresh copy per render re-rendered
+  // every row whenever the list did. The copy only exists because the prop is
+  // readonly and dnd-kit wants a mutable array.
+  const items = useMemo(() => [...order], [order]);
   const content = (
-    <SortableContext items={[...order]} strategy={verticalListSortingStrategy}>
+    <SortableContext items={items} strategy={verticalListSortingStrategy}>
       <div className="space-y-4">{order.map(children)}</div>
     </SortableContext>
   );

--- a/apps/app/src/components/sidebar/useSidebarReorderDnd.test.tsx
+++ b/apps/app/src/components/sidebar/useSidebarReorderDnd.test.tsx
@@ -74,6 +74,23 @@ describe("useSidebarReorderDnd", () => {
     act(() => result.current.dndContextProps.onDragCancel?.(DRAG_CANCEL_EVENT));
     expect(onDragCancel).toHaveBeenCalledTimes(1);
   });
+
+  it("keeps the dnd-kit sensors across re-renders with unchanged handlers", () => {
+    // dnd-kit memoizes each sensor on the options object it is handed, so an
+    // inline options literal in the hook yields a fresh `sensors` array per
+    // render and DndContext rebuilds every sortable's listeners. The sidebar
+    // rows are memoized on those listeners, which is why
+    // ProjectList.render-counts.test.tsx catches the same regression one layer
+    // up; this guard pins the cause at the hook.
+    const onDragEnd = vi.fn();
+    const { result, rerender } = renderHook(() =>
+      useSidebarReorderDnd({ onDragEnd }),
+    );
+    const first = result.current.dndContextProps;
+    rerender();
+    expect(result.current.dndContextProps.sensors).toBe(first.sensors);
+    expect(result.current.dndContextProps).toBe(first);
+  });
 });
 
 describe("SidebarTouchSensor", () => {

--- a/apps/app/src/components/sidebar/useSidebarReorderDnd.ts
+++ b/apps/app/src/components/sidebar/useSidebarReorderDnd.ts
@@ -18,7 +18,10 @@ import {
   type DragEndEvent,
   type DragOverEvent,
   type DragStartEvent,
+  type KeyboardSensorOptions,
   type Modifier,
+  type MouseSensorOptions,
+  type TouchSensorOptions,
 } from "@dnd-kit/core";
 import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 import { COMPACT_VIEWPORT_QUERY } from "@bb/shared-ui/hooks/use-compact-viewport";
@@ -56,6 +59,25 @@ const restrictSidebarDragToVerticalAxis: Modifier = ({ transform }) => ({
 const SIDEBAR_REORDER_MODIFIERS: Modifier[] = [
   restrictSidebarDragToVerticalAxis,
 ];
+
+/**
+ * dnd-kit's `useSensor` memoizes on the options object it receives and
+ * `useSensors` on those descriptors, so inline option literals handed
+ * `DndContext` a new `sensors` array on every render of the hosting list.
+ * The context then rebuilt its activators, every `useSortable` produced fresh
+ * listeners, and each memoized row saw new drag bindings on every sidebar
+ * cache update even when nothing about the row had changed. Module constants
+ * keep the whole chain stable.
+ */
+const MOUSE_SENSOR_OPTIONS: MouseSensorOptions = {
+  activationConstraint: { distance: 4 },
+};
+const TOUCH_SENSOR_OPTIONS: TouchSensorOptions = {
+  activationConstraint: { delay: 200, tolerance: 6 },
+};
+const KEYBOARD_SENSOR_OPTIONS: KeyboardSensorOptions = {
+  coordinateGetter: sortableKeyboardCoordinates,
+};
 
 function setSidebarDraggingCursor(active: boolean): void {
   if (active) {
@@ -187,13 +209,9 @@ export function useSidebarReorderDnd({
   } = useDragClickSuppression();
   const isDraggingRef = useRef(false);
   const sensors = useSensors(
-    useSensor(MouseSensor, { activationConstraint: { distance: 4 } }),
-    useSensor(SidebarTouchSensor, {
-      activationConstraint: { delay: 200, tolerance: 6 },
-    }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    }),
+    useSensor(MouseSensor, MOUSE_SENSOR_OPTIONS),
+    useSensor(SidebarTouchSensor, TOUCH_SENSOR_OPTIONS),
+    useSensor(KeyboardSensor, KEYBOARD_SENSOR_OPTIONS),
   );
   const handleDragStart = useCallback(
     (event: DragStartEvent) => {

--- a/apps/app/src/hooks/queries/project-queries.test.tsx
+++ b/apps/app/src/hooks/queries/project-queries.test.tsx
@@ -1,10 +1,15 @@
 // @vitest-environment jsdom
 
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import type { ProjectWithThreadsResponse } from "@bb/server-contract";
 import { sdk } from "@/lib/sdk";
+import { makeThreadListEntry } from "@/test/fixtures/thread-list-entries";
 import { createQueryClientTestHarness } from "@/test/queryClientTestHarness";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { useProjectSourceBranches } from "./project-queries";
+import {
+  stripProjectThreads,
+  useProjectSourceBranches,
+} from "./project-queries";
 import { projectSourceBranchesQueryKeyPrefix } from "./query-keys";
 
 vi.mock("@/lib/sdk", () => ({
@@ -54,5 +59,51 @@ describe("useProjectSourceBranches", () => {
         staleTime: 30_000,
       }),
     );
+  });
+});
+
+describe("stripProjectThreads", () => {
+  function makeProjectWithThreads(): ProjectWithThreadsResponse {
+    return {
+      id: "proj_1",
+      kind: "standard",
+      name: "One",
+      gitRemoteUrl: null,
+      sources: [],
+      createdAt: 0,
+      updatedAt: 0,
+      threads: [makeThreadListEntry({ id: "thr_1", projectId: "proj_1" })],
+      defaultExecutionOptions: null,
+    };
+  }
+
+  it("returns the same project for the same payload object", () => {
+    // React Query structurally shares the sidebar payload, so a project whose
+    // fields and threads did not change keeps its object across refetches;
+    // the stripped project has to keep its identity too, or every project
+    // row sees a new project on every sidebar update.
+    const payload = makeProjectWithThreads();
+    const stripped = stripProjectThreads(payload);
+
+    expect(stripProjectThreads(payload)).toBe(stripped);
+    expect("threads" in stripped).toBe(false);
+    expect(stripped).toEqual({
+      id: "proj_1",
+      kind: "standard",
+      name: "One",
+      gitRemoteUrl: null,
+      sources: [],
+      createdAt: 0,
+      updatedAt: 0,
+      defaultExecutionOptions: null,
+    });
+  });
+
+  it("returns a new project for a new payload object", () => {
+    const stripped = stripProjectThreads(makeProjectWithThreads());
+    const next = stripProjectThreads(makeProjectWithThreads());
+
+    expect(next).not.toBe(stripped);
+    expect(next).toEqual(stripped);
   });
 });

--- a/apps/app/src/hooks/queries/project-queries.ts
+++ b/apps/app/src/hooks/queries/project-queries.ts
@@ -81,10 +81,25 @@ function requireProviderId(
 
 export type SidebarProject = Omit<ProjectWithThreadsResponse, "threads">;
 
+/**
+ * Per-payload-object memo. React Query structurally shares the sidebar
+ * payload, so a project whose fields and threads did not change keeps its
+ * `ProjectWithThreadsResponse` identity across refetches; stripping it again
+ * handed every consumer a fresh object per project per sidebar update, which
+ * each `memo` boundary below the project list read as a changed project.
+ */
+const sidebarProjectByPayload = new WeakMap<
+  ProjectWithThreadsResponse,
+  SidebarProject
+>();
+
 export function stripProjectThreads(
   project: ProjectWithThreadsResponse,
 ): SidebarProject {
+  const cached = sidebarProjectByPayload.get(project);
+  if (cached !== undefined) return cached;
   const { threads, ...rest } = project;
+  sidebarProjectByPayload.set(project, rest);
   return rest;
 }
 

--- a/apps/app/src/hooks/usePromptDraftStorage.test.tsx
+++ b/apps/app/src/hooks/usePromptDraftStorage.test.tsx
@@ -219,6 +219,39 @@ describe("usePromptDraftStorage", () => {
     getItem.mockRestore();
   });
 
+  it("keeps the presence subscription when a new array lists the same threads", () => {
+    const projectId = "proj-batch-refetch";
+    const threadRefs = Array.from({ length: 30 }, (_, index) => ({
+      id: `thr-batch-${index}`,
+      projectId,
+    }));
+    const { result, rerender } = renderHook(
+      ({ threads }: { threads: { id: string; projectId: string }[] }) =>
+        usePromptDraftInputThreadIds(threads),
+      { initialProps: { threads: threadRefs } },
+    );
+    const initial = result.current;
+
+    const getItem = vi.spyOn(Storage.prototype, "getItem");
+    const presenceReadKeys = () =>
+      getItem.mock.calls
+        .map(([key]) => String(key))
+        .filter((key) => key.includes(projectId));
+    // Every sidebar refetch flattens a fresh thread array with the same
+    // entries; rebuilding the store for it resubscribed and re-read one
+    // localStorage key per sidebar thread, and handed out a new set.
+    rerender({ threads: [...threadRefs] });
+    expect(presenceReadKeys()).toEqual([]);
+    expect(result.current).toBe(initial);
+
+    // A thread that is actually new does rebuild the subscription set.
+    rerender({ threads: [...threadRefs, { id: "thr-batch-new", projectId }] });
+    expect(
+      presenceReadKeys().some((key) => key.includes("thr-batch-new")),
+    ).toBe(true);
+    getItem.mockRestore();
+  });
+
   it("uses project-agnostic storage for new-thread prompt contents", () => {
     window.localStorage.setItem(
       LEGACY_PROJECT_DRAFT_KEY,

--- a/apps/app/src/hooks/usePromptDraftStorage.ts
+++ b/apps/app/src/hooks/usePromptDraftStorage.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { useCallback, useMemo, useRef, useSyncExternalStore } from "react";
 import type { PromptTextMention } from "@bb/domain";
 import type { PromptDraftAttachment, PromptDraftState } from "@bb/client-core";
 import {
@@ -552,6 +552,24 @@ function createPromptDraftPresenceStore(
   };
 }
 
+const EMPTY_PROMPT_DRAFT_SUBSCRIPTIONS: PromptDraftThreadSubscription[] = [];
+
+function areSubscriptionListsEqual(
+  prev: readonly PromptDraftThreadSubscription[],
+  next: readonly PromptDraftThreadSubscription[],
+): boolean {
+  if (prev.length !== next.length) return false;
+  for (let index = 0; index < prev.length; index += 1) {
+    if (
+      prev[index].storageKey !== next[index].storageKey ||
+      prev[index].threadId !== next[index].threadId
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /**
  * Subscribes to draft presence for a collection of threads without mounting a
  * hook per row. The primitive bit-string snapshot stays referentially stable
@@ -561,6 +579,13 @@ function createPromptDraftPresenceStore(
 export function usePromptDraftInputThreadIds(
   threads: readonly PromptDraftThreadRef[],
 ): ReadonlySet<string> {
+  // Render-time cache of the previous subscription list. The sidebar passes a
+  // freshly flattened thread array on every refetch; a new list rebuilds the
+  // presence store, resubscribes, and re-reads one localStorage key per
+  // thread, so the previous list is kept while its keys are unchanged. The
+  // memo reads and writes a ref during render as
+  // useSidebarThreadTitleMentionResources does.
+  const previousSubscriptionsRef = useRef(EMPTY_PROMPT_DRAFT_SUBSCRIPTIONS);
   const subscriptions = useMemo<PromptDraftThreadSubscription[]>(() => {
     const seenStorageKeys = new Set<string>();
     const next: PromptDraftThreadSubscription[] = [];
@@ -575,7 +600,14 @@ export function usePromptDraftInputThreadIds(
       seenStorageKeys.add(storageKey);
       next.push({ storageKey, threadId: thread.id });
     }
-    return next;
+    /* oxlint-disable react/refs -- render-time cache, see above */
+    const previous = previousSubscriptionsRef.current;
+    const retained = areSubscriptionListsEqual(previous, next)
+      ? previous
+      : next;
+    previousSubscriptionsRef.current = retained;
+    /* oxlint-enable react/refs */
+    return retained;
   }, [threads]);
 
   const presenceStore = useMemo(


### PR DESCRIPTION
## What was wrong

Every sidebar cache update re-rendered all project and thread rows (an internal performance sweep, finding F1): ~1,500–1,650 component renders per realtime status change, 215–263 ms of main thread at 4× CPU. Five layers defeated memoization: `stripProjectThreads` spread every project into a new object per payload, `threadsByProject` / `getProjectThreadListState` returned fresh literals, `areProjectRowPropsEqual` compared by identity, `headerActions` was a new element per render, and `usePromptDraftInputThreadIds` rebuilt its localStorage subscriptions on every new `threads` array. A sixth, pre-existing one surfaced in review: `useSidebarReorderDnd` passed inline option objects to dnd-kit's `useSensor`, so every row's drag bindings changed identity on each render.

## What changed

`apps/app/src/hooks/queries/project-queries.ts`, `components/sidebar/ProjectList.tsx`, `ProjectRow.tsx`, `hooks/usePromptDraftStorage.ts`, `components/sidebar/useSidebarReorderDnd.ts`, `SidebarSectionOrderList.tsx`:

- `stripProjectThreads` is memoized per payload object (module `WeakMap`), so React Query's structural sharing carries through.
- `retainProjectRows` keeps a project's row model, thread-list state and `threads` array when its entries are unchanged; the personal-project list gets the same element-wise retention. The render-time ref caches live in small hooks (`useRetainedProjectRows`, `useRetainedThreadList`) so the React Compiler still compiles `ProjectModeSections`.
- `ProjectRow` compares `project` shallowly and `threadListState` by value (`areProjectThreadListStatesEqual`, `areThreadListsEqual`); this relies on React Query structural sharing and on no cache owner mutating entries in place (documented in the tests).
- Section display-option menus are cached per section until their open state changes.
- Draft-id subscriptions keep identity when the storage keys are unchanged, so the presence store is not rebuilt and localStorage is not re-read.
- dnd-kit sensor options are module constants, so `useSensors`, activators and every row's `dragBindings` keep identity.

No server, daemon, CLI or plugin API changes.

## How you verified

New/extended tests, each failing on the pre-fix code: `ProjectRow.test.ts` (comparators incl. nested `sources` replacement), `ProjectList.rows.test.ts` (`retainProjectRows`), `project-queries.test.tsx`, `usePromptDraftStorage.test.tsx` (no re-read on a same-content array), `ProjectList.modes.test.tsx` (menu element cache), `useSidebarReorderDnd.test.tsx` (sensor identity), and an end-to-end `ProjectList.render-counts.test.tsx` that mounts the real `ProjectList` on a seeded `QueryClient`, patches one thread through `applyToCachedSidebarNavigationThreads`, and asserts only that project's `ProjectRow` re-renders (it fails when the sensor hoist is reverted). A throwaway `babel-plugin-react-compiler` transform confirmed `ProjectModeSections` compiles again.

On this branch: `pnpm exec turbo run typecheck` (76/76), `pnpm exec turbo run lint`, `pnpm exec turbo run test` (all packages green). Suggested manual check before merge: browse the sidebar with running threads, pin/unpin, collapse, drag-reorder.

Fixes: no issue — source is an internal performance sweep (finding F1).

> AGENT GENERATED
