### PR TITLE
perf: load bb command groups on demand and split the CLI bundle (C1)

### DIFF
--- a/.github/workflows/publish-bb-app.yml
+++ b/.github/workflows/publish-bb-app.yml
@@ -301,10 +301,11 @@ jobs:
           echo "version=${nightly_version}" >> "$GITHUB_OUTPUT"
           echo "Prepared bb-app and desktop version ${nightly_version}."
 
-      # bb-app has no prepack hook and its `files` list ships built output, so
-      # `npm publish` packs whatever is on disk. This job runs on a fresh
-      # runner, so it must build before it packs. smoke:tarball depends on
-      # build and also proves the packed tarball runs at the nightly version.
+      # bb-app's prepack hook only prunes stale bb CLI chunks; its `files`
+      # list ships built output, so `npm publish` packs whatever is on disk.
+      # This job runs on a fresh runner, so it must build before it packs.
+      # smoke:tarball depends on build and also proves the packed tarball
+      # runs at the nightly version.
       - name: Smoke bb-app tarball
         run: pnpm exec turbo run smoke:tarball --filter=bb-app --force --output-logs=new-only
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -7,7 +7,7 @@
     "title": "./bin/title"
   },
   "scripts": {
-    "build": "node ../../scripts/build-node-entry.mjs src/index.ts dist/index.js --clean-dist",
+    "build": "node ../../scripts/build-node-entry.mjs src/index.ts dist/index.js --clean-dist --split",
     "start": "node dist/index.js",
     "clean": "rimraf dist",
     "typecheck": "tsc --noEmit",

--- a/apps/cli/src/__tests__/bb-app-version.ts
+++ b/apps/cli/src/__tests__/bb-app-version.ts
@@ -1,0 +1,34 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+  "..",
+);
+
+/**
+ * The version `bb --version` must print when the CLI runs from this
+ * workspace: version.ts walks up from its own location to
+ * packages/bb-app/package.json.
+ */
+export async function readBbAppVersion(): Promise<string> {
+  const packageJson: unknown = JSON.parse(
+    await readFile(
+      join(repoRoot, "packages", "bb-app", "package.json"),
+      "utf8",
+    ),
+  );
+  if (
+    typeof packageJson === "object" &&
+    packageJson !== null &&
+    "version" in packageJson &&
+    typeof packageJson.version === "string"
+  ) {
+    return packageJson.version;
+  }
+  throw new Error("packages/bb-app/package.json has no version");
+}

--- a/apps/cli/src/__tests__/command-groups.test.ts
+++ b/apps/cli/src/__tests__/command-groups.test.ts
@@ -58,5 +58,9 @@ describe("CORE_COMMAND_GROUPS", () => {
     expect(program.commands.flatMap((command) => command.aliases())).toEqual(
       [],
     );
-  });
+    // Loading every group is the point of this guard, so it pays the import
+    // cost of all 17 module graphs at once (`plugin` alone pulls the plugin
+    // build toolchain and the scaffold templates). The shipped CLI never does
+    // this; a contended CI runner needs more than the 5s default.
+  }, 30_000);
 });

--- a/apps/cli/src/__tests__/command-groups.test.ts
+++ b/apps/cli/src/__tests__/command-groups.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { Command } from "commander";
+import {
+  CORE_COMMAND_GROUPS,
+  selectCommandGroups,
+  type CommandGroupDeps,
+} from "../command-groups.js";
+
+const ALL_GROUP_NAMES = CORE_COMMAND_GROUPS.map((group) => group.name);
+
+describe("selectCommandGroups", () => {
+  it("needs no command group to answer --version", () => {
+    expect(selectCommandGroups("--version")).toEqual([]);
+    expect(selectCommandGroups("-V")).toEqual([]);
+  });
+
+  it("needs only the named group for a core command", () => {
+    expect(selectCommandGroups("thread").map((group) => group.name)).toEqual([
+      "thread",
+    ]);
+    expect(selectCommandGroups("status").map((group) => group.name)).toEqual([
+      "status",
+    ]);
+  });
+
+  it("needs every group, in help order, whenever commander shows the full program", () => {
+    // No arguments and `help`/`--help` print the command list; an unknown or
+    // plugin-contributed name falls through to commander's "unknown command"
+    // suggestions. Both must see the same program a full registration builds.
+    for (const firstArg of [undefined, "help", "--help", "-h", "linear"]) {
+      expect(
+        selectCommandGroups(firstArg).map((group) => group.name),
+        `firstArg=${String(firstArg)}`,
+      ).toEqual(ALL_GROUP_NAMES);
+    }
+  });
+});
+
+describe("CORE_COMMAND_GROUPS", () => {
+  it("registers exactly the top-level commands it names, in order, with no aliases", async () => {
+    // The static name table stands in for commander's command list before any
+    // command module is loaded: it decides which group `bb <name>` loads and
+    // which names the plugin proxy must leave alone. A group whose module
+    // registers a different name, an extra top-level command, or an alias
+    // would be a name commander accepts that the table does not know about.
+    const program = new Command();
+    const deps: CommandGroupDeps = {
+      getUrl: () => "http://localhost",
+      getContext: () => ({ serverUrl: "http://localhost" }),
+    };
+    for (const group of CORE_COMMAND_GROUPS) {
+      const register = await group.load();
+      register(program, deps);
+    }
+    expect(program.commands.map((command) => command.name())).toEqual(
+      ALL_GROUP_NAMES,
+    );
+    expect(program.commands.flatMap((command) => command.aliases())).toEqual(
+      [],
+    );
+  });
+});

--- a/apps/cli/src/__tests__/packaged-plugin-build.test.ts
+++ b/apps/cli/src/__tests__/packaged-plugin-build.test.ts
@@ -1,9 +1,17 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
+import { readBbAppVersion } from "./bb-app-version.js";
 
 const execFileAsync = promisify(execFile);
 const testDir = dirname(fileURLToPath(import.meta.url));
@@ -26,9 +34,15 @@ describe("packaged CLI plugin build", () => {
     // resolve exactly as they do for dist/index.js. @get-bb/plugin-sdk is not a
     // CLI dependency, so import.meta.resolve in this bundle takes the
     // packaged fallback that the source-level plugin-build tests do not.
+    //
+    // Built with `--split` like the shipped CLI, so the code that resolves
+    // files relative to import.meta.url (the bb-app version lookup, the SDK
+    // declaration bundles, plugin-build's createRequire/import.meta.resolve)
+    // runs from a chunk directory one level deeper than the entry. A `.js`
+    // entry (apps/cli is ESM) keeps the chunks at cli-chunks/ next to it.
     const tempRoot = await mkdtemp(join(cliRoot, ".packaged-plugin-build-"));
     tempDirs.push(tempRoot);
-    const cliEntry = join(tempRoot, "cli.mjs");
+    const cliEntry = join(tempRoot, "cli.js");
     const pluginRoot = join(tempRoot, "plugin");
     await execFileAsync(
       process.execPath,
@@ -36,6 +50,7 @@ describe("packaged CLI plugin build", () => {
         resolve(workspaceRoot, "scripts", "build-node-entry.mjs"),
         "src/index.ts",
         cliEntry,
+        "--split",
         "--external",
         "esbuild",
         "--external",
@@ -89,6 +104,20 @@ describe("packaged CLI plugin build", () => {
       BB_CLI_REEXEC: "1",
     };
     delete childEnv.BB_CLI;
+    delete childEnv.BB_APP_VERSION;
+
+    // version.ts lands in a shared chunk and walks up from cli-chunks/ to the
+    // workspace's packages/bb-app/package.json; a single-file bundle or the
+    // tsx sources start that walk one directory higher and would not notice
+    // a lookup that stops short.
+    expect(await readdir(join(tempRoot, "cli-chunks"))).not.toHaveLength(0);
+    const { stdout: versionOutput } = await execFileAsync(
+      process.execPath,
+      [cliEntry, "--version"],
+      { cwd: workspaceRoot, env: childEnv },
+    );
+    expect(versionOutput.trim()).toBe(await readBbAppVersion());
+
     await execFileAsync(
       process.execPath,
       [cliEntry, "plugin", "build", pluginRoot],

--- a/apps/cli/src/__tests__/plugin-cli-proxy.test.ts
+++ b/apps/cli/src/__tests__/plugin-cli-proxy.test.ts
@@ -15,12 +15,12 @@ import { registerSkillCommands } from "../commands/skill.js";
 import { registerStatusCommand } from "../commands/status.js";
 import { registerThemeCommands } from "../commands/theme.js";
 import { registerThreadCommands } from "../commands/thread/index.js";
+import { pluginProxyCandidate } from "../command-groups.js";
 import {
   describeUnreachableServer,
   fetchPluginCliContributions,
   findDisabledPluginForCommand,
   findPluginCliCommand,
-  pluginProxyCandidate,
   PLUGIN_CLI_HEADERS_TIMEOUT_MS,
   runPluginCliCommand,
   type PluginCliContributionEntry,

--- a/apps/cli/src/__tests__/startup-graph.test.ts
+++ b/apps/cli/src/__tests__/startup-graph.test.ts
@@ -1,10 +1,12 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { CORE_COMMAND_GROUPS } from "../command-groups.js";
+import { readBbAppVersion } from "./bb-app-version.js";
 
 /**
  * Guards the mechanism behind `bb` startup time: the entry's static import
@@ -13,13 +15,14 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
  * — is `import()`-ed only when that command runs. The built CLI is
  * code-split along those `import()` boundaries, so a single stray static
  * import anywhere on the entry's static path pulls the whole subtree into
- * the entry chunk and every invocation pays for it again. Running the
- * sources under tsx with a resolve hook records which modules Node actually
- * loaded.
+ * the entry chunk and every invocation pays for it again. A resolve hook
+ * records which modules Node actually loaded, once for the sources under
+ * tsx (real module boundaries whatever the build does) and once for the
+ * turbo-built dist/index.js (the split layout itself: a single-file bundle
+ * runs every command correctly but evaluates all of it on each start).
  */
 const execFileAsync = promisify(execFile);
 const cliRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
-const repoRoot = resolve(cliRoot, "..", "..");
 
 /**
  * The hook appends every resolved module URL to the log file named by the
@@ -49,6 +52,12 @@ register(new URL("./resolve-hooks.mjs", import.meta.url), {
 /** Env the child must not inherit: a re-exec hop or a version override. */
 const STRIPPED_ENV_KEYS = new Set(["BB_CLI", "BB_APP_VERSION"]);
 
+/**
+ * `source` runs src/index.ts under tsx; `dist` runs the dist/index.js that
+ * `@bb/cli#build` wrote (turbo runs it before `@bb/cli#test`).
+ */
+type CliEntry = "source" | "dist";
+
 interface CliRun {
   stdout: string;
   /** Every module URL Node resolved while the command ran. */
@@ -70,8 +79,11 @@ describe("bb startup module graph", () => {
     await rm(tempDir, { recursive: true, force: true });
   });
 
-  async function runCli(args: string[]): Promise<CliRun> {
-    const logPath = join(tempDir, `${args.join("_").replace(/\W/g, "_")}.log`);
+  async function runCli(entry: CliEntry, args: string[]): Promise<CliRun> {
+    const logPath = join(
+      tempDir,
+      `${entry}_${args.join("_").replace(/\W/g, "_")}.log`,
+    );
     await writeFile(logPath, "");
     const env: NodeJS.ProcessEnv = Object.fromEntries(
       Object.entries(process.env).filter(
@@ -80,17 +92,20 @@ describe("bb startup module graph", () => {
     );
     env.BB_CLI_REEXEC = "1";
     env.BB_STARTUP_GRAPH_LOG = logPath;
+    const entryArgs =
+      entry === "source"
+        ? [
+            "--conditions=source",
+            "--import",
+            "tsx",
+            "--import",
+            registerHooksPath,
+            "src/index.ts",
+          ]
+        : ["--import", registerHooksPath, "dist/index.js"];
     const { stdout } = await execFileAsync(
       process.execPath,
-      [
-        "--conditions=source",
-        "--import",
-        "tsx",
-        "--import",
-        registerHooksPath,
-        "src/index.ts",
-        ...args,
-      ],
+      [...entryArgs, ...args],
       { cwd: cliRoot, env },
     );
     const urls = (await readFile(logPath, "utf8"))
@@ -103,26 +118,8 @@ describe("bb startup module graph", () => {
     return run.urls.filter((url) => url.includes(fragment));
   }
 
-  async function readBbAppVersion(): Promise<string> {
-    const packageJson: unknown = JSON.parse(
-      await readFile(
-        join(repoRoot, "packages", "bb-app", "package.json"),
-        "utf8",
-      ),
-    );
-    if (
-      typeof packageJson === "object" &&
-      packageJson !== null &&
-      "version" in packageJson &&
-      typeof packageJson.version === "string"
-    ) {
-      return packageJson.version;
-    }
-    throw new Error("packages/bb-app/package.json has no version");
-  }
-
   it("answers --version from commander and node builtins alone", async () => {
-    const run = await runCli(["--version"]);
+    const run = await runCli("source", ["--version"]);
 
     expect(run.stdout.trim()).toBe(await readBbAppVersion());
 
@@ -151,7 +148,7 @@ describe("bb startup module graph", () => {
   }, 30_000);
 
   it("loads only the named command group for `bb thread`", async () => {
-    const run = await runCli(["thread", "--help"]);
+    const run = await runCli("source", ["thread", "--help"]);
 
     expect(run.stdout).toContain("Usage: bb thread");
     expect(loaded(run, "/apps/cli/src/commands/thread/index.ts")).toHaveLength(
@@ -170,4 +167,55 @@ describe("bb startup module graph", () => {
       expect(loaded(run, fragment), fragment).toEqual([]);
     }
   }, 30_000);
+
+  describe("turbo-built dist/index.js", () => {
+    // esbuild names a lazily imported module's chunk `<module>-<hash>.js`
+    // (a group's `index.ts` takes its directory name) and the shared pieces
+    // it hoists `chunk-<hash>.js`.
+    const chunkDir = "/apps/cli/dist/index-chunks/";
+
+    beforeAll(async () => {
+      try {
+        await access(join(cliRoot, "dist", "index.js"));
+      } catch {
+        throw new Error(
+          "apps/cli/dist/index.js is missing: run `pnpm exec turbo run build --filter=@bb/cli` (turbo does this before @bb/cli#test)",
+        );
+      }
+    });
+
+    it("answers --version from the entry and its shared chunks alone", async () => {
+      const run = await runCli("dist", ["--version"]);
+
+      expect(run.stdout.trim()).toBe(await readBbAppVersion());
+      expect(loaded(run, "/apps/cli/dist/index.js")).toHaveLength(1);
+
+      // A build without `--split` resolves no chunk at all: every command
+      // then evaluates the whole bundle again, which is what this layout
+      // exists to avoid.
+      const chunks = loaded(run, chunkDir);
+      expect(chunks).not.toHaveLength(0);
+      // Only the shared chunks (version.ts and esbuild's module runtime): no
+      // command group and no context-env chunk.
+      for (const url of chunks) {
+        expect(url).toMatch(/\/index-chunks\/chunk-[A-Z0-9]+\.js$/);
+      }
+    }, 30_000);
+
+    it("loads only the thread chunk for `bb thread`", async () => {
+      const run = await runCli("dist", ["thread", "--help"]);
+
+      expect(run.stdout).toContain("Usage: bb thread");
+      expect(loaded(run, `${chunkDir}thread-`)).toHaveLength(1);
+
+      // Every other group's chunk, the plugin proxy and mime-types stay on
+      // disk unread. (`plugin-` also covers `plugin-cli-proxy-`.)
+      const otherGroups = CORE_COMMAND_GROUPS.map((group) => group.name).filter(
+        (name) => name !== "thread",
+      );
+      for (const name of [...otherGroups, "plugin-cli-proxy", "mime-types"]) {
+        expect(loaded(run, `${chunkDir}${name}-`), name).toEqual([]);
+      }
+    }, 30_000);
+  });
 });

--- a/apps/cli/src/__tests__/startup-graph.test.ts
+++ b/apps/cli/src/__tests__/startup-graph.test.ts
@@ -1,0 +1,173 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+/**
+ * Guards the mechanism behind `bb` startup time: the entry's static import
+ * graph is commander plus a few node builtins, and each command group's
+ * module — with the zod schemas, SDK, templates and plugin tooling behind it
+ * — is `import()`-ed only when that command runs. The built CLI is
+ * code-split along those `import()` boundaries, so a single stray static
+ * import anywhere on the entry's static path pulls the whole subtree into
+ * the entry chunk and every invocation pays for it again. Running the
+ * sources under tsx with a resolve hook records which modules Node actually
+ * loaded.
+ */
+const execFileAsync = promisify(execFile);
+const cliRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const repoRoot = resolve(cliRoot, "..", "..");
+
+/**
+ * The hook appends every resolved module URL to the log file named by the
+ * registration data. It is registered after tsx, so it heads the hook chain
+ * and sees the final URL of each import whether static or dynamic.
+ */
+const RESOLVE_HOOKS_SOURCE = `
+import { appendFileSync } from "node:fs";
+let logPath;
+export function initialize(data) {
+  logPath = data.logPath;
+}
+export async function resolve(specifier, context, nextResolve) {
+  const result = await nextResolve(specifier, context);
+  appendFileSync(logPath, result.url + "\\n");
+  return result;
+}
+`;
+
+const REGISTER_HOOKS_SOURCE = `
+import { register } from "node:module";
+register(new URL("./resolve-hooks.mjs", import.meta.url), {
+  data: { logPath: process.env.BB_STARTUP_GRAPH_LOG },
+});
+`;
+
+/** Env the child must not inherit: a re-exec hop or a version override. */
+const STRIPPED_ENV_KEYS = new Set(["BB_CLI", "BB_APP_VERSION"]);
+
+interface CliRun {
+  stdout: string;
+  /** Every module URL Node resolved while the command ran. */
+  urls: string[];
+}
+
+describe("bb startup module graph", () => {
+  let tempDir: string;
+  let registerHooksPath: string;
+
+  beforeAll(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "bb-cli-startup-graph-"));
+    registerHooksPath = join(tempDir, "register-hooks.mjs");
+    await writeFile(join(tempDir, "resolve-hooks.mjs"), RESOLVE_HOOKS_SOURCE);
+    await writeFile(registerHooksPath, REGISTER_HOOKS_SOURCE);
+  });
+
+  afterAll(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function runCli(args: string[]): Promise<CliRun> {
+    const logPath = join(tempDir, `${args.join("_").replace(/\W/g, "_")}.log`);
+    await writeFile(logPath, "");
+    const env: NodeJS.ProcessEnv = Object.fromEntries(
+      Object.entries(process.env).filter(
+        ([key]) => !STRIPPED_ENV_KEYS.has(key),
+      ),
+    );
+    env.BB_CLI_REEXEC = "1";
+    env.BB_STARTUP_GRAPH_LOG = logPath;
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        "--conditions=source",
+        "--import",
+        "tsx",
+        "--import",
+        registerHooksPath,
+        "src/index.ts",
+        ...args,
+      ],
+      { cwd: cliRoot, env },
+    );
+    const urls = (await readFile(logPath, "utf8"))
+      .split("\n")
+      .filter((line) => line.length > 0);
+    return { stdout, urls };
+  }
+
+  function loaded(run: CliRun, fragment: string): string[] {
+    return run.urls.filter((url) => url.includes(fragment));
+  }
+
+  async function readBbAppVersion(): Promise<string> {
+    const packageJson: unknown = JSON.parse(
+      await readFile(
+        join(repoRoot, "packages", "bb-app", "package.json"),
+        "utf8",
+      ),
+    );
+    if (
+      typeof packageJson === "object" &&
+      packageJson !== null &&
+      "version" in packageJson &&
+      typeof packageJson.version === "string"
+    ) {
+      return packageJson.version;
+    }
+    throw new Error("packages/bb-app/package.json has no version");
+  }
+
+  it("answers --version from commander and node builtins alone", async () => {
+    const run = await runCli(["--version"]);
+
+    expect(run.stdout.trim()).toBe(await readBbAppVersion());
+
+    // The hook must have observed the CLI's own graph, or the absence checks
+    // below would pass vacuously.
+    expect(loaded(run, "/apps/cli/src/index.ts")).toHaveLength(1);
+    expect(loaded(run, "/commander/")).not.toHaveLength(0);
+
+    for (const fragment of [
+      "/zod/",
+      "/undici/",
+      "/mime-types/",
+      "/node_modules/ws/",
+      "/packages/config/",
+      "/packages/domain/",
+      "/packages/sdk/",
+      "/packages/server-contract/",
+      "/packages/templates/",
+      "/apps/cli/src/commands/",
+      "/apps/cli/src/plugin-cli-proxy",
+      "/apps/cli/src/context-env",
+      "/apps/cli/src/client",
+    ]) {
+      expect(loaded(run, fragment), fragment).toEqual([]);
+    }
+  }, 30_000);
+
+  it("loads only the named command group for `bb thread`", async () => {
+    const run = await runCli(["thread", "--help"]);
+
+    expect(run.stdout).toContain("Usage: bb thread");
+    expect(loaded(run, "/apps/cli/src/commands/thread/index.ts")).toHaveLength(
+      1,
+    );
+
+    // Other groups stay unloaded: plugin.ts is the heaviest (plugin-build,
+    // scaffold templates) and project.ts carries mime-db.
+    for (const fragment of [
+      "/apps/cli/src/commands/plugin.ts",
+      "/apps/cli/src/commands/project.ts",
+      "/packages/plugin-build/",
+      "/packages/templates/src/plugin-scaffold",
+      "/mime-types/",
+    ]) {
+      expect(loaded(run, fragment), fragment).toEqual([]);
+    }
+  }, 30_000);
+});

--- a/apps/cli/src/__tests__/startup-graph.test.ts
+++ b/apps/cli/src/__tests__/startup-graph.test.ts
@@ -1,10 +1,10 @@
 import { execFile } from "node:child_process";
-import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod";
 import { CORE_COMMAND_GROUPS } from "../command-groups.js";
 import { readBbAppVersion } from "./bb-app-version.js";
 
@@ -17,12 +17,14 @@ import { readBbAppVersion } from "./bb-app-version.js";
  * import anywhere on the entry's static path pulls the whole subtree into
  * the entry chunk and every invocation pays for it again. A resolve hook
  * records which modules Node actually loaded, once for the sources under
- * tsx (real module boundaries whatever the build does) and once for the
- * turbo-built dist/index.js (the split layout itself: a single-file bundle
- * runs every command correctly but evaluates all of it on each start).
+ * tsx (real module boundaries whatever the build does) and once for a split
+ * bundle built the way `@bb/cli#build` builds dist/index.js (the split
+ * layout itself: a single-file bundle runs every command correctly but
+ * evaluates all of it on each start).
  */
 const execFileAsync = promisify(execFile);
 const cliRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const workspaceRoot = resolve(cliRoot, "..", "..");
 
 /**
  * The hook appends every resolved module URL to the log file named by the
@@ -52,9 +54,13 @@ register(new URL("./resolve-hooks.mjs", import.meta.url), {
 /** Env the child must not inherit: a re-exec hop or a version override. */
 const STRIPPED_ENV_KEYS = new Set(["BB_CLI", "BB_APP_VERSION"]);
 
+const cliPackageJsonSchema = z.object({
+  scripts: z.object({ build: z.string() }),
+});
+
 /**
- * `source` runs src/index.ts under tsx; `dist` runs the dist/index.js that
- * `@bb/cli#build` wrote (turbo runs it before `@bb/cli#test`).
+ * `source` runs src/index.ts under tsx; `dist` runs the split bundle this
+ * suite builds into its own temp dir.
  */
 type CliEntry = "source" | "dist";
 
@@ -67,10 +73,18 @@ interface CliRun {
 describe("bb startup module graph", () => {
   let tempDir: string;
   let registerHooksPath: string;
+  let distEntry: string;
 
   beforeAll(async () => {
-    tempDir = await mkdtemp(join(tmpdir(), "bb-cli-startup-graph-"));
+    // Under apps/cli, not os.tmpdir(): version.ts walks up from the built
+    // chunk directory to packages/bb-app/package.json, so the bundle has to
+    // sit inside the workspace for `--version` to answer. `.tmp/` is
+    // gitignored at every level.
+    const packageTmpDir = join(cliRoot, ".tmp");
+    await mkdir(packageTmpDir, { recursive: true });
+    tempDir = await mkdtemp(join(packageTmpDir, "startup-graph-"));
     registerHooksPath = join(tempDir, "register-hooks.mjs");
+    distEntry = join(tempDir, "dist", "index.js");
     await writeFile(join(tempDir, "resolve-hooks.mjs"), RESOLVE_HOOKS_SOURCE);
     await writeFile(registerHooksPath, REGISTER_HOOKS_SOURCE);
   });
@@ -102,7 +116,7 @@ describe("bb startup module graph", () => {
             registerHooksPath,
             "src/index.ts",
           ]
-        : ["--import", registerHooksPath, "dist/index.js"];
+        : ["--import", registerHooksPath, distEntry];
     const { stdout } = await execFileAsync(
       process.execPath,
       [...entryArgs, ...args],
@@ -168,32 +182,52 @@ describe("bb startup module graph", () => {
     }
   }, 30_000);
 
-  describe("turbo-built dist/index.js", () => {
+  describe("split dist/index.js", () => {
     // esbuild names a lazily imported module's chunk `<module>-<hash>.js`
     // (a group's `index.ts` takes its directory name) and the shared pieces
     // it hoists `chunk-<hash>.js`.
-    const chunkDir = "/apps/cli/dist/index-chunks/";
+    let chunkDirUrl: string;
 
     beforeAll(async () => {
-      try {
-        await access(join(cliRoot, "dist", "index.js"));
-      } catch {
-        throw new Error(
-          "apps/cli/dist/index.js is missing: run `pnpm exec turbo run build --filter=@bb/cli` (turbo does this before @bb/cli#test)",
-        );
-      }
+      // Built here rather than read from apps/cli/dist: that directory is a
+      // turbo output, and another test task's nested
+      // `turbo run build --filter=@bb/cli` (the root `pnpm bb` wrapper that
+      // @bb/scripts#test exercises) restores it in place, truncating each
+      // file as it rewrites it, so a child started at that moment reads a
+      // half-written module. Same invocation as the package's `build`
+      // script minus `--clean-dist`, which would delete apps/cli/dist.
+      chunkDirUrl = `${pathToFileURL(join(tempDir, "dist", "index-chunks")).href}/`;
+      await execFileAsync(
+        process.execPath,
+        [
+          resolve(workspaceRoot, "scripts", "build-node-entry.mjs"),
+          "src/index.ts",
+          distEntry,
+          "--split",
+        ],
+        { cwd: cliRoot },
+      );
+    }, 60_000);
+
+    it("is how @bb/cli#build builds the shipped CLI", async () => {
+      // The cases below prove the split layout of the bundle built above;
+      // this keeps dist/index.js (what bb-app packages) built the same way.
+      const packageJson = cliPackageJsonSchema.parse(
+        JSON.parse(await readFile(join(cliRoot, "package.json"), "utf8")),
+      );
+      expect(packageJson.scripts.build.split(" ")).toContain("--split");
     });
 
     it("answers --version from the entry and its shared chunks alone", async () => {
       const run = await runCli("dist", ["--version"]);
 
       expect(run.stdout.trim()).toBe(await readBbAppVersion());
-      expect(loaded(run, "/apps/cli/dist/index.js")).toHaveLength(1);
+      expect(loaded(run, pathToFileURL(distEntry).href)).toHaveLength(1);
 
       // A build without `--split` resolves no chunk at all: every command
       // then evaluates the whole bundle again, which is what this layout
       // exists to avoid.
-      const chunks = loaded(run, chunkDir);
+      const chunks = loaded(run, chunkDirUrl);
       expect(chunks).not.toHaveLength(0);
       // Only the shared chunks (version.ts and esbuild's module runtime): no
       // command group and no context-env chunk.
@@ -206,7 +240,7 @@ describe("bb startup module graph", () => {
       const run = await runCli("dist", ["thread", "--help"]);
 
       expect(run.stdout).toContain("Usage: bb thread");
-      expect(loaded(run, `${chunkDir}thread-`)).toHaveLength(1);
+      expect(loaded(run, `${chunkDirUrl}thread-`)).toHaveLength(1);
 
       // Every other group's chunk, the plugin proxy and mime-types stay on
       // disk unread. (`plugin-` also covers `plugin-cli-proxy-`.)
@@ -214,7 +248,7 @@ describe("bb startup module graph", () => {
         (name) => name !== "thread",
       );
       for (const name of [...otherGroups, "plugin-cli-proxy", "mime-types"]) {
-        expect(loaded(run, `${chunkDir}${name}-`), name).toEqual([]);
+        expect(loaded(run, `${chunkDirUrl}${name}-`), name).toEqual([]);
       }
     }, 30_000);
   });

--- a/apps/cli/src/command-groups.ts
+++ b/apps/cli/src/command-groups.ts
@@ -1,0 +1,163 @@
+/**
+ * The top-level `bb` command groups and the rule for which of them one
+ * invocation needs. Every entry is loaded with `import()` so the module that
+ * registers it — and everything it pulls in (zod schemas, the SDK, plugin
+ * build tooling, scaffold templates) — stays out of the startup graph until a
+ * command actually asks for it; the build splits chunks along these
+ * `import()` boundaries. This file must therefore contain no value imports: a
+ * single static one would pull the whole subtree into the entry chunk and
+ * every `bb` invocation would pay for it again.
+ */
+import type { Command } from "commander";
+import type { ContextSnapshot } from "./context-env.js";
+
+export interface CommandGroupDeps {
+  getUrl(): string;
+  getContext(): ContextSnapshot;
+}
+
+export type CommandGroupRegistrar = (
+  program: Command,
+  deps: CommandGroupDeps,
+) => void;
+
+export interface CommandGroup {
+  /** The top-level name commander resolves, e.g. `thread` in `bb thread`. */
+  readonly name: string;
+  readonly load: () => Promise<CommandGroupRegistrar>;
+}
+
+function group<Module>(
+  name: string,
+  load: () => Promise<Module>,
+  register: (module: Module) => CommandGroupRegistrar,
+): CommandGroup {
+  return { name, load: () => load().then(register) };
+}
+
+/**
+ * In `bb --help` order: commander lists subcommands in registration order,
+ * so this array is the help output's order.
+ */
+export const CORE_COMMAND_GROUPS: readonly CommandGroup[] = [
+  group(
+    "status",
+    () => import("./commands/status.js"),
+    (m) => (program, deps) =>
+      m.registerStatusCommand(program, deps.getUrl, deps.getContext),
+  ),
+  group(
+    "settings",
+    () => import("./commands/settings.js"),
+    (m) => (program, deps) => m.registerSettingsCommands(program, deps.getUrl),
+  ),
+  group(
+    "project",
+    () => import("./commands/project.js"),
+    (m) => (program, deps) => m.registerProjectCommands(program, deps.getUrl),
+  ),
+  group(
+    "provider",
+    () => import("./commands/provider.js"),
+    (m) => (program, deps) => m.registerProviderCommands(program, deps.getUrl),
+  ),
+  group(
+    "manager",
+    () => import("./commands/manager.js"),
+    (m) => (program) => m.registerManagerCommands(program),
+  ),
+  group(
+    "machine",
+    () => import("./commands/machine.js"),
+    (m) => (program, deps) => m.registerMachineCommands(program, deps.getUrl),
+  ),
+  group(
+    "updates",
+    () => import("./commands/updates.js"),
+    (m) => (program, deps) => m.registerUpdatesCommands(program, deps.getUrl),
+  ),
+  group(
+    "terminal",
+    () => import("./commands/terminal.js"),
+    (m) => (program, deps) => m.registerTerminalCommands(program, deps.getUrl),
+  ),
+  group(
+    "thread",
+    () => import("./commands/thread/index.js"),
+    (m) => (program, deps) => m.registerThreadCommands(program, deps.getUrl),
+  ),
+  group(
+    "environment",
+    () => import("./commands/environment.js"),
+    (m) => (program, deps) =>
+      m.registerEnvironmentCommands(program, deps.getUrl),
+  ),
+  group(
+    "file",
+    () => import("./commands/file.js"),
+    (m) => (program, deps) => m.registerFileCommands(program, deps.getUrl),
+  ),
+  group(
+    "theme",
+    () => import("./commands/theme.js"),
+    (m) => (program, deps) => m.registerThemeCommands(program, deps.getUrl),
+  ),
+  group(
+    "plugin",
+    () => import("./commands/plugin.js"),
+    (m) => (program, deps) => m.registerPluginCommands(program, deps.getUrl),
+  ),
+  group(
+    "marketplace",
+    () => import("./commands/marketplace.js"),
+    (m) => (program, deps) =>
+      m.registerMarketplaceCommands(program, deps.getUrl),
+  ),
+  group(
+    "skill",
+    () => import("./commands/skill.js"),
+    (m) => (program, deps) =>
+      m.registerSkillCommands(program, deps.getUrl, deps.getContext),
+  ),
+  group(
+    "guide",
+    () => import("./commands/guide.js"),
+    (m) => (program) => m.registerGuideCommand(program),
+  ),
+  group(
+    "voice",
+    () => import("./commands/voice.js"),
+    (m) => (program, deps) => m.registerVoiceCommands(program, deps.getUrl),
+  ),
+];
+
+/**
+ * The groups one invocation must register before commander parses it.
+ * `--version` needs none: commander answers it from the program alone. A
+ * first token that names a core group needs only that group. Anything else
+ * — no arguments, `help`, `--help`, an unknown or plugin-contributed name —
+ * needs all of them so help output and "unknown command" suggestions match
+ * what a fully registered program would print.
+ */
+export function selectCommandGroups(
+  firstArg: string | undefined,
+): readonly CommandGroup[] {
+  if (firstArg === "--version" || firstArg === "-V") return [];
+  const match = CORE_COMMAND_GROUPS.find((entry) => entry.name === firstArg);
+  return match === undefined ? CORE_COMMAND_GROUPS : [match];
+}
+
+/**
+ * The first CLI token is a plugin-proxy candidate only when it looks like a
+ * command (not a flag) and no core command claims it. Core commands always
+ * win: commander resolved them before this path runs.
+ */
+export function pluginProxyCandidate(
+  firstArg: string | undefined,
+  knownCommandNames: ReadonlySet<string>,
+): string | null {
+  if (firstArg === undefined || firstArg.length === 0) return null;
+  if (firstArg.startsWith("-")) return null;
+  if (knownCommandNames.has(firstArg)) return null;
+  return firstArg;
+}

--- a/apps/cli/src/commands/project.ts
+++ b/apps/cli/src/commands/project.ts
@@ -6,7 +6,6 @@ import type {
   ProjectResponse,
   UpdateProjectSourceRequest,
 } from "@bb/server-contract";
-import mimeTypes from "mime-types";
 import { action } from "../action.js";
 import { createCliBbSdk } from "../client.js";
 import { resolveLocalHostId } from "../daemon.js";
@@ -224,11 +223,11 @@ function printProjectSource(source: ProjectSource): void {
   console.log(`${source.id}  ${source.type}  ${source.path}${defaultMarker}`);
 }
 
-function attachmentMimeType(
+async function attachmentMimeType(
   clientPath: string,
   filename: string,
   explicitMimeType: string | undefined,
-): string {
+): Promise<string> {
   if (explicitMimeType !== undefined) {
     const normalized = explicitMimeType.trim();
     if (normalized.length === 0) {
@@ -236,6 +235,9 @@ function attachmentMimeType(
     }
     return normalized;
   }
+  // Only attachment upload needs the mime-db table; loading it here keeps it
+  // out of every other `bb project` invocation.
+  const { default: mimeTypes } = await import("mime-types");
   const inferred = mimeTypes.lookup(filename) || mimeTypes.lookup(clientPath);
   return typeof inferred === "string" ? inferred : "application/octet-stream";
 }
@@ -280,7 +282,7 @@ export function registerProjectCommands(
           ).projects.attachments.upload({
             clientFile: bytes,
             filename,
-            mimeType: attachmentMimeType(
+            mimeType: await attachmentMimeType(
               opts.clientFile,
               filename,
               opts.mimeType,

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,50 +1,22 @@
 #!/usr/bin/env node
 import { Command } from "commander";
 import { maybeReexecViaBbCli } from "./bb-cli-reexec.js";
-import { registerEnvironmentCommands } from "./commands/environment.js";
-import { registerFileCommands } from "./commands/file.js";
-import { registerGuideCommand } from "./commands/guide.js";
-import { registerManagerCommands } from "./commands/manager.js";
-import { registerMarketplaceCommands } from "./commands/marketplace.js";
-import { registerMachineCommands } from "./commands/machine.js";
-import { registerProjectCommands } from "./commands/project.js";
-import { registerPluginCommands } from "./commands/plugin.js";
-import { registerProviderCommands } from "./commands/provider.js";
-import { registerStatusCommand } from "./commands/status.js";
-import { registerTerminalCommands } from "./commands/terminal.js";
-import { registerSettingsCommands } from "./commands/settings.js";
-import { registerSkillCommands } from "./commands/skill.js";
-import { registerThemeCommands } from "./commands/theme.js";
-import { registerThreadCommands } from "./commands/thread/index.js";
-import { registerUpdatesCommands } from "./commands/updates.js";
-import { registerVoiceCommands } from "./commands/voice.js";
 import {
-  createCliRuntimeContext,
-  resolveContextSnapshot,
-  resolveServerUrl,
-  type CliRuntimeContext,
-} from "./context-env.js";
-import {
-  describeUnreachableServer,
-  fetchPluginCliContributions,
-  findDisabledPluginForCommand,
-  findPluginCliCommand,
+  CORE_COMMAND_GROUPS,
   pluginProxyCandidate,
-  runPluginCliCommand,
-} from "./plugin-cli-proxy.js";
+  selectCommandGroups,
+} from "./command-groups.js";
 import { resolveBbCliVersion } from "./version.js";
+// Type-only: the module itself is `import()`-ed in main() so that the config
+// and domain schemas behind it stay out of the `bb --version` startup graph.
+import type { CommandGroupDeps } from "./command-groups.js";
+import type { CliRuntimeContext } from "./context-env.js";
 
 // Hop to the daemon-managed binary when BB_CLI is set (agent shell env). Must
 // run before Commander so flags/help match the intended build.
 maybeReexecViaBbCli();
 
 const program = new Command();
-let cliRuntimeContext: CliRuntimeContext | undefined;
-
-function getCliRuntimeContext(): CliRuntimeContext {
-  cliRuntimeContext ??= createCliRuntimeContext();
-  return cliRuntimeContext;
-}
 
 program
   .name("bb")
@@ -54,12 +26,100 @@ program
   .enablePositionalOptions()
   .version(resolveBbCliVersion());
 
-program.addHelpText("after", () => {
-  const context = resolveContextSnapshot(getCliRuntimeContext());
-  const project = context.projectId ?? "<unset>";
-  const thread = context.threadId ?? "<unset>";
+const KNOWN_COMMAND_NAMES: ReadonlySet<string> = new Set([
+  ...CORE_COMMAND_GROUPS.map((group) => group.name),
+  "help", // commander built-in
+]);
 
-  return `
+type ContextEnvModule = typeof import("./context-env.js");
+
+function createCommandGroupDeps(
+  contextEnv: ContextEnvModule,
+): CommandGroupDeps {
+  let cliRuntimeContext: CliRuntimeContext | undefined;
+  const getCliRuntimeContext = (): CliRuntimeContext =>
+    (cliRuntimeContext ??= contextEnv.createCliRuntimeContext());
+  return {
+    getUrl: () => contextEnv.resolveServerUrl(getCliRuntimeContext()),
+    getContext: () => contextEnv.resolveContextSnapshot(getCliRuntimeContext()),
+  };
+}
+
+/**
+ * Unknown top-level commands may be plugin-contributed `bb` subcommands
+ * (design §4.4): before letting commander error, ask the server for plugin
+ * CLI contributions (short timeout, silent fallback) and proxy on a match.
+ * Core commands always win — this only runs for names commander doesn't own.
+ */
+async function tryPluginCommandProxy(
+  candidate: string,
+  getUrl: () => string,
+): Promise<void> {
+  const proxy = await import("./plugin-cli-proxy.js");
+  const result = await proxy.fetchPluginCliContributions(getUrl());
+  if (result.outcome === "unreachable") {
+    // The candidate may be a plugin command (`bb connect` on a fresh
+    // machine is the canonical case) — only the running server can say, so
+    // an unreachable server must not degrade into commander's "unknown
+    // command".
+    console.error(
+      proxy.describeUnreachableServer(
+        getUrl(),
+        result.cause,
+        result.lastTimeoutMs,
+        result.attempts,
+      ),
+    );
+    process.exit(1);
+  }
+  if (result.outcome === "invalid") return;
+  const match = proxy.findPluginCliCommand(result.contributions, candidate);
+  if (match === undefined) {
+    // Disabled plugins contribute no commands; explain instead of erroring
+    // when the name matches an installed-but-disabled plugin's id.
+    const disabled = await proxy.findDisabledPluginForCommand(
+      getUrl(),
+      candidate,
+    );
+    if (disabled !== null) {
+      console.error(
+        `bb ${candidate} is provided by the "${disabled.id}" plugin, which is disabled — ` +
+          `run \`bb plugin enable ${disabled.id}\` or enable it in Plugins.`,
+      );
+      process.exit(1);
+    }
+    return;
+  }
+  process.exit(
+    await proxy.runPluginCliCommand(
+      getUrl(),
+      match.pluginId,
+      process.argv.slice(3),
+    ),
+  );
+}
+
+async function main(): Promise<void> {
+  const firstArg = process.argv[2];
+  const groups = selectCommandGroups(firstArg);
+  if (groups.length === 0) {
+    // `bb --version`: nothing beyond commander itself is needed.
+    await program.parseAsync(process.argv);
+    return;
+  }
+
+  const [contextEnv, ...registrars] = await Promise.all([
+    import("./context-env.js"),
+    ...groups.map((group) => group.load()),
+  ]);
+  const deps = createCommandGroupDeps(contextEnv);
+
+  program.addHelpText("after", () => {
+    const context = deps.getContext();
+    const project = context.projectId ?? "<unset>";
+    const thread = context.threadId ?? "<unset>";
+
+    return `
 
 Current context:
   BB_PROJECT_ID: ${project}
@@ -72,91 +132,20 @@ Quick start:
   bb thread show <id>
   bb thread spawn --project <id> --provider codex --prompt "..."
 `;
-});
-
-// Helper to get the URL from the program's options
-function getUrl(): string {
-  return resolveServerUrl(getCliRuntimeContext());
-}
-
-function getContext() {
-  return resolveContextSnapshot(getCliRuntimeContext());
-}
-
-// Register all command groups
-registerStatusCommand(program, getUrl, getContext);
-registerSettingsCommands(program, getUrl);
-registerProjectCommands(program, getUrl);
-registerProviderCommands(program, getUrl);
-registerManagerCommands(program);
-registerMachineCommands(program, getUrl);
-registerUpdatesCommands(program, getUrl);
-registerTerminalCommands(program, getUrl);
-registerThreadCommands(program, getUrl);
-registerEnvironmentCommands(program, getUrl);
-registerFileCommands(program, getUrl);
-registerThemeCommands(program, getUrl);
-registerPluginCommands(program, getUrl);
-registerMarketplaceCommands(program, getUrl);
-registerSkillCommands(program, getUrl, getContext);
-registerGuideCommand(program);
-registerVoiceCommands(program, getUrl);
-
-/**
- * Unknown top-level commands may be plugin-contributed `bb` subcommands
- * (design §4.4): before letting commander error, ask the server for plugin
- * CLI contributions (short timeout, silent fallback) and proxy on a match.
- * Core commands always win — this only runs for names commander doesn't own.
- */
-async function tryPluginCommandProxy(): Promise<void> {
-  const knownCommandNames = new Set(
-    program.commands.flatMap((command) => [
-      command.name(),
-      ...command.aliases(),
-    ]),
-  );
-  knownCommandNames.add("help");
-  const candidate = pluginProxyCandidate(process.argv[2], knownCommandNames);
-  if (candidate === null) return;
-  const result = await fetchPluginCliContributions(getUrl());
-  if (result.outcome === "unreachable") {
-    // The candidate may be a plugin command (`bb connect` on a fresh
-    // machine is the canonical case) — only the running server can say, so
-    // an unreachable server must not degrade into commander's "unknown
-    // command".
-    console.error(
-      describeUnreachableServer(
-        getUrl(),
-        result.cause,
-        result.lastTimeoutMs,
-        result.attempts,
-      ),
-    );
-    process.exit(1);
-  }
-  if (result.outcome === "invalid") return;
-  const match = findPluginCliCommand(result.contributions, candidate);
-  if (match === undefined) {
-    // Disabled plugins contribute no commands; explain instead of erroring
-    // when the name matches an installed-but-disabled plugin's id.
-    const disabled = await findDisabledPluginForCommand(getUrl(), candidate);
-    if (disabled !== null) {
-      console.error(
-        `bb ${candidate} is provided by the "${disabled.id}" plugin, which is disabled — ` +
-          `run \`bb plugin enable ${disabled.id}\` or enable it in Plugins.`,
-      );
-      process.exit(1);
-    }
-    return;
-  }
-  process.exit(
-    await runPluginCliCommand(getUrl(), match.pluginId, process.argv.slice(3)),
-  );
-}
-
-tryPluginCommandProxy()
-  .then(() => program.parseAsync(process.argv))
-  .catch((err) => {
-    console.error(err.message);
-    process.exit(1);
   });
+
+  for (const register of registrars) {
+    register(program, deps);
+  }
+
+  const candidate = pluginProxyCandidate(firstArg, KNOWN_COMMAND_NAMES);
+  if (candidate !== null) {
+    await tryPluginCommandProxy(candidate, deps.getUrl);
+  }
+  await program.parseAsync(process.argv);
+}
+
+main().catch((err) => {
+  console.error(err.message);
+  process.exit(1);
+});

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -3,13 +3,13 @@ import { Command } from "commander";
 import { maybeReexecViaBbCli } from "./bb-cli-reexec.js";
 import {
   CORE_COMMAND_GROUPS,
+  type CommandGroupDeps,
   pluginProxyCandidate,
   selectCommandGroups,
 } from "./command-groups.js";
 import { resolveBbCliVersion } from "./version.js";
-// Type-only: the module itself is `import()`-ed in main() so that the config
+// Type-only: context-env itself is `import()`-ed in main() so that the config
 // and domain schemas behind it stay out of the `bb --version` startup graph.
-import type { CommandGroupDeps } from "./command-groups.js";
 import type { CliRuntimeContext } from "./context-env.js";
 
 // Hop to the daemon-managed binary when BB_CLI is set (agent shell env). Must

--- a/apps/cli/src/plugin-cli-proxy.ts
+++ b/apps/cli/src/plugin-cli-proxy.ts
@@ -339,21 +339,6 @@ export function findPluginCliCommand(
   return contributions.find((entry) => entry.name === name);
 }
 
-/**
- * The first CLI token is a plugin-proxy candidate only when it looks like a
- * command (not a flag) and no core command claims it. Core commands always
- * win: commander resolved them before this path runs.
- */
-export function pluginProxyCandidate(
-  firstArg: string | undefined,
-  knownCommandNames: ReadonlySet<string>,
-): string | null {
-  if (firstArg === undefined || firstArg.length === 0) return null;
-  if (firstArg.startsWith("-")) return null;
-  if (knownCommandNames.has(firstArg)) return null;
-  return firstArg;
-}
-
 interface PluginCliOutputStream {
   write(chunk: string, callback: (error?: Error | null) => void): boolean;
 }

--- a/apps/cli/src/version.ts
+++ b/apps/cli/src/version.ts
@@ -1,32 +1,42 @@
 import { readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { z } from "zod";
 
 const BB_APP_VERSION_FALLBACK = "0.0.0-dev";
 const PARENT_LOOKUP_MAX_DEPTH = 8;
-
-const bbAppPackageJsonSchema = z
-  .object({
-    name: z.string(),
-    version: z.string().min(1),
-  })
-  .passthrough();
 
 interface ResolveBbAppVersionArgs {
   env: NodeJS.ProcessEnv;
   fromDir: string;
 }
 
+interface BbAppPackageJson {
+  name: string;
+  version: string;
+}
+
+// A hand-written guard rather than a zod schema: this module runs on every
+// `bb` invocation, including `bb --version`, and must not pull zod into the
+// startup graph just to read two fields of a package.json.
+function isBbAppPackageJson(value: unknown): value is BbAppPackageJson {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "name" in value &&
+    typeof value.name === "string" &&
+    "version" in value &&
+    typeof value.version === "string" &&
+    value.version.length > 0
+  );
+}
+
 function readBbAppVersionAt(packageJsonPath: string): string | null {
   try {
-    const result = bbAppPackageJsonSchema.safeParse(
-      JSON.parse(readFileSync(packageJsonPath, "utf8")),
-    );
-    if (!result.success || result.data.name !== "bb-app") {
+    const parsed: unknown = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    if (!isBbAppPackageJson(parsed) || parsed.name !== "bb-app") {
       return null;
     }
-    return result.data.version;
+    return parsed.version;
   } catch {
     return null;
   }
@@ -59,7 +69,9 @@ export function resolveBbAppVersion(args: ResolveBbAppVersionArgs): string {
       "bb-app",
       "package.json",
     );
-    const workspaceCandidateVersion = readBbAppVersionAt(workspaceCandidatePath);
+    const workspaceCandidateVersion = readBbAppVersionAt(
+      workspaceCandidatePath,
+    );
     if (workspaceCandidateVersion !== null) {
       return workspaceCandidateVersion;
     }

--- a/apps/host-daemon/scripts/build-bundles.mjs
+++ b/apps/host-daemon/scripts/build-bundles.mjs
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { chmod, copyFile, mkdir, stat } from "node:fs/promises";
+import { chmod, copyFile, mkdir, rm, stat } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
@@ -7,6 +7,8 @@ import { bundleTargets } from "./bundle-manifest.mjs";
 import {
   createNativeExternalPatterns,
   externalPackagePatterns,
+  finalizeSplitOutput,
+  splitOutputOptions,
 } from "../../../scripts/build-utils.mjs";
 
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
@@ -37,6 +39,11 @@ function pluginSdkDeclarationsDefine() {
 async function main() {
   for (const target of bundleTargets) {
     await mkdir(dirname(target.outfile), { recursive: true });
+    const split = target.splitting ? splitOutputOptions(target.outfile) : null;
+    if (split) {
+      // Chunk names carry content hashes; drop the previous build's chunks.
+      await rm(split.chunkDir, { force: true, recursive: true });
+    }
     await build({
       banner: {
         js: target.banner,
@@ -56,11 +63,14 @@ async function main() {
       format: "esm",
       legalComments: "none",
       minify: true,
-      outfile: target.outfile,
+      ...(split ? split.esbuild : { outfile: target.outfile }),
       platform: "node",
       sourcemap: false,
       target: "node22",
     });
+    if (split) {
+      await finalizeSplitOutput(target.outfile);
+    }
     if (target.executable) {
       await chmod(target.outfile, 0o755);
     }

--- a/apps/host-daemon/scripts/bundle-manifest.mjs
+++ b/apps/host-daemon/scripts/bundle-manifest.mjs
@@ -51,6 +51,9 @@ export const bundleTargets = [
     executable: true,
     label: "bb cli",
     outfile: resolve(packageRoot, "dist", "bb"),
+    // The CLI `import()`s each command group on demand; chunks land in
+    // dist/bb-chunks, which packages/bb-app ships next to this entry.
+    splitting: true,
     // The packaged CLI has no workspace on disk, so `bb plugin types` for a
     // vendored-layout plugin gets the SDK declarations inlined (see
     // packages/templates/src/plugin-sdk-dts.ts). Dev bundles read them from

--- a/packages/bb-app/package.json
+++ b/packages/bb-app/package.json
@@ -47,6 +47,7 @@
     "dist",
     "!dist/*.map",
     "host-daemon/dist/bb",
+    "host-daemon/dist/bb-chunks",
     "host-daemon/dist/bb-parcel-watcher-child.mjs",
     "host-daemon/dist/bb-plugin-host-worker.mjs",
     "host-daemon/dist/bb-provider-bridge-worker.mjs",

--- a/packages/bb-app/package.json
+++ b/packages/bb-app/package.json
@@ -62,6 +62,7 @@
   "scripts": {
     "build": "node scripts/build.mjs",
     "clean": "rimraf dist app host-daemon server tsconfig.tsbuildinfo",
+    "prepack": "node scripts/prune-bb-chunks.mjs",
     "smoke:tarball": "node scripts/smoke-tarball.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --config vitest.config.ts"

--- a/packages/bb-app/scripts/build.mjs
+++ b/packages/bb-app/scripts/build.mjs
@@ -6,7 +6,6 @@ import { promisify } from "node:util";
 import {
   buildNodeEsmEntry,
   copyDirectory,
-  pruneUnreferencedChunks,
 } from "../../../scripts/build-utils.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -102,16 +101,17 @@ await copyBuildOutput({
 // The bb CLI is code-split into host-daemon/dist/bb-chunks. A turbo cache hit
 // restores apps/host-daemon/dist without clearing it first, so the copy can
 // carry an earlier build's hashed chunks; ship only the ones `bb` reaches.
-const bbChunkDir = resolve(packageRoot, "host-daemon", "dist", "bb-chunks");
-await assertPathExists(bbChunkDir, "bundled bb CLI chunks");
-const prunedChunks = await pruneUnreferencedChunks({
-  chunkDir: bbChunkDir,
-  entry: resolve(packageRoot, "host-daemon", "dist", "bb"),
-});
-if (prunedChunks.length > 0) {
-  process.stdout.write(
-    `bb-app: pruned ${prunedChunks.length} stale bb CLI chunk file(s)\n`,
-  );
-}
+// The same script is this package's `prepack` hook: this task's own output
+// is restored the same way on a cache hit, when nothing here runs.
+await assertPathExists(
+  resolve(packageRoot, "host-daemon", "dist", "bb-chunks"),
+  "bundled bb CLI chunks",
+);
+const pruneRun = await execFileAsync(
+  "node",
+  [resolve(scriptsDir, "prune-bb-chunks.mjs")],
+  { cwd: packageRoot },
+);
+process.stderr.write(pruneRun.stderr);
 
 process.stdout.write("bb-app: built package assets\n");

--- a/packages/bb-app/scripts/build.mjs
+++ b/packages/bb-app/scripts/build.mjs
@@ -6,6 +6,7 @@ import { promisify } from "node:util";
 import {
   buildNodeEsmEntry,
   copyDirectory,
+  pruneUnreferencedChunks,
 } from "../../../scripts/build-utils.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -98,5 +99,19 @@ await copyBuildOutput({
   label: "@bb/host-daemon dist",
   to: resolve(packageRoot, "host-daemon", "dist"),
 });
+// The bb CLI is code-split into host-daemon/dist/bb-chunks. A turbo cache hit
+// restores apps/host-daemon/dist without clearing it first, so the copy can
+// carry an earlier build's hashed chunks; ship only the ones `bb` reaches.
+const bbChunkDir = resolve(packageRoot, "host-daemon", "dist", "bb-chunks");
+await assertPathExists(bbChunkDir, "bundled bb CLI chunks");
+const prunedChunks = await pruneUnreferencedChunks({
+  chunkDir: bbChunkDir,
+  entry: resolve(packageRoot, "host-daemon", "dist", "bb"),
+});
+if (prunedChunks.length > 0) {
+  process.stdout.write(
+    `bb-app: pruned ${prunedChunks.length} stale bb CLI chunk file(s)\n`,
+  );
+}
 
 process.stdout.write("bb-app: built package assets\n");

--- a/packages/bb-app/scripts/prune-bb-chunks.mjs
+++ b/packages/bb-app/scripts/prune-bb-chunks.mjs
@@ -1,0 +1,48 @@
+import { access } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pruneUnreferencedChunks } from "../../../scripts/build-utils.mjs";
+
+/**
+ * Delete the bb CLI chunks that host-daemon/dist/bb does not reach.
+ *
+ * Runs twice: from scripts/build.mjs right after the host-daemon copy, and as
+ * this package's `prepack` hook. The build-time run cleans what the copy
+ * brought over from apps/host-daemon/dist. The hook exists because
+ * `bb-app#build` is itself a cached turbo task whose outputs include
+ * host-daemon/**, and a cache-hit restore writes those outputs over whatever
+ * is on disk without clearing the directory first, so the build-time prune
+ * does not run and an earlier generation's content-hashed chunks sit next to
+ * the live ones. npm runs `prepack` for `npm pack` and `npm publish` whether
+ * or not the task body ran, so the packed tarball always matches a clean
+ * build.
+ *
+ * The package root is the working directory, as for every package script:
+ * npm runs lifecycle hooks, and turbo the build, from the package directory.
+ */
+const packageRoot = process.cwd();
+const distDir = resolve(packageRoot, "host-daemon", "dist");
+const entry = resolve(distDir, "bb");
+const chunkDir = resolve(distDir, "bb-chunks");
+
+for (const [label, pathToCheck] of [
+  ["bundled bb CLI", entry],
+  ["bundled bb CLI chunks", chunkDir],
+]) {
+  try {
+    await access(pathToCheck);
+  } catch {
+    throw new Error(
+      `Missing ${label} at ${pathToCheck}: run from packages/bb-app after building it.`,
+    );
+  }
+}
+
+const removed = await pruneUnreferencedChunks({ chunkDir, entry });
+if (removed.length > 0) {
+  // stderr, not stdout: npm forwards a lifecycle script's stdout into its
+  // own, and `npm pack --json` (which scripts/smoke-tarball.mjs parses)
+  // must stay pure JSON.
+  process.stderr.write(
+    `bb-app: pruned ${removed.length} stale bb CLI chunk file(s)\n`,
+  );
+}

--- a/packages/bb-app/src/launcher.ts
+++ b/packages/bb-app/src/launcher.ts
@@ -2,7 +2,7 @@
 import type { ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import {
   access,
   mkdir,
@@ -471,10 +471,15 @@ interface MaybeAddAutoJoinEnvArgs {
   serverUrl: string;
 }
 
-interface ArtifactPath {
-  label: string;
-  path: string;
-}
+/**
+ * A built artifact the launcher needs on disk. A `chunk-dir` is present only
+ * once it holds a chunk: the code-split `bb` entry imports from it
+ * statically, so an empty directory fails in Node's ESM loader exactly like
+ * a missing one.
+ */
+type ArtifactPath =
+  | { kind: "file"; label: string; path: string }
+  | { kind: "chunk-dir"; label: string; path: string };
 
 interface CreateCliEnvArgs {
   context: BbAppStartContext;
@@ -2123,36 +2128,70 @@ async function runClientCommand(args: RunClientCommandArgs): Promise<void> {
 
 function requiredArtifactPaths(context: BbAppStartContext): ArtifactPath[] {
   return [
-    { label: "server entry", path: context.serverEntry },
-    { label: "host daemon entry", path: context.daemonEntry },
-    { label: "bundled bb CLI", path: join(context.daemonBundleDir, "bb") },
+    { kind: "file", label: "server entry", path: context.serverEntry },
+    { kind: "file", label: "host daemon entry", path: context.daemonEntry },
+    {
+      kind: "file",
+      label: "bundled bb CLI",
+      path: join(context.daemonBundleDir, "bb"),
+    },
     {
       // The CLI entry is code-split: it imports its shared chunks statically
       // and each command group on demand from this directory, so without it
       // even `bb --version` dies in Node's ESM loader before the CLI's own
       // error handling runs.
+      kind: "chunk-dir",
       label: "bundled bb CLI chunks",
       path: join(context.daemonBundleDir, "bb-chunks"),
     },
     {
+      kind: "file",
       label: "provider bridge worker",
       path: join(context.daemonBundleDir, "bb-provider-bridge-worker.mjs"),
     },
     {
+      kind: "file",
       label: "parcel watcher child",
       path: join(context.daemonBundleDir, "bb-parcel-watcher-child.mjs"),
     },
     {
+      kind: "file",
       label: "plugin host worker",
       path: join(context.daemonBundleDir, "bb-plugin-host-worker.mjs"),
     },
-    { label: "web app", path: join(context.appDistDir, "index.html") },
+    {
+      kind: "file",
+      label: "web app",
+      path: join(context.appDistDir, "index.html"),
+    },
   ];
+}
+
+function artifactPresent(artifact: ArtifactPath): boolean {
+  switch (artifact.kind) {
+    case "file":
+      return existsSync(artifact.path);
+    case "chunk-dir":
+      try {
+        return readdirSync(artifact.path).some((name) => name.endsWith(".js"));
+      } catch (error) {
+        // No directory there (or a stray file in its place) is the same
+        // missing-artifact condition, not a launcher fault.
+        if (
+          error instanceof Error &&
+          "code" in error &&
+          (error.code === "ENOENT" || error.code === "ENOTDIR")
+        ) {
+          return false;
+        }
+        throw error;
+      }
+  }
 }
 
 export function assertBbAppArtifacts(context: BbAppStartContext): void {
   const missingArtifact = requiredArtifactPaths(context).find(
-    (artifact) => !existsSync(artifact.path),
+    (artifact) => !artifactPresent(artifact),
   );
   if (missingArtifact) {
     throw new Error(

--- a/packages/bb-app/src/launcher.ts
+++ b/packages/bb-app/src/launcher.ts
@@ -2127,6 +2127,14 @@ function requiredArtifactPaths(context: BbAppStartContext): ArtifactPath[] {
     { label: "host daemon entry", path: context.daemonEntry },
     { label: "bundled bb CLI", path: join(context.daemonBundleDir, "bb") },
     {
+      // The CLI entry is code-split: it imports its shared chunks statically
+      // and each command group on demand from this directory, so without it
+      // even `bb --version` dies in Node's ESM loader before the CLI's own
+      // error handling runs.
+      label: "bundled bb CLI chunks",
+      path: join(context.daemonBundleDir, "bb-chunks"),
+    },
+    {
       label: "provider bridge worker",
       path: join(context.daemonBundleDir, "bb-provider-bridge-worker.mjs"),
     },
@@ -2142,7 +2150,7 @@ function requiredArtifactPaths(context: BbAppStartContext): ArtifactPath[] {
   ];
 }
 
-function assertBbAppArtifacts(context: BbAppStartContext): void {
+export function assertBbAppArtifacts(context: BbAppStartContext): void {
   const missingArtifact = requiredArtifactPaths(context).find(
     (artifact) => !existsSync(artifact.path),
   );

--- a/packages/bb-app/test/index.test.ts
+++ b/packages/bb-app/test/index.test.ts
@@ -2136,6 +2136,9 @@ describe("bb-app launcher", () => {
     expect(metadata.files).toContain(
       "host-daemon/dist/bb-plugin-host-worker.mjs",
     );
+    // The CLI entry imports its command groups from this chunk directory.
+    expect(metadata.files).toContain("host-daemon/dist/bb");
+    expect(metadata.files).toContain("host-daemon/dist/bb-chunks");
     expect(metadata.os).toEqual(["darwin", "linux"]);
   });
 

--- a/packages/bb-app/test/index.test.ts
+++ b/packages/bb-app/test/index.test.ts
@@ -1,7 +1,8 @@
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import {
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   statSync,
@@ -185,9 +186,19 @@ const packageMetadataSchema = z.object({
   }),
   files: z.array(z.string()),
   os: z.array(z.string()),
+  scripts: z.object({
+    prepack: z.string(),
+  }),
 });
 
 type PackageMetadata = z.infer<typeof packageMetadataSchema>;
+
+/** The part of `npm pack --json` output the prepack test reads. */
+const packDryRunSchema = z.array(
+  z.object({
+    files: z.array(z.object({ path: z.string() })),
+  }),
+);
 
 class FakeManagedProcessRun implements ManagedProcessRun {
   readonly exit: Promise<NamedProcessExitResult>;
@@ -2175,12 +2186,80 @@ describe("bb-app launcher", () => {
         writeFileSync(artifact, "");
       }
 
-      expect(() => assertBbAppArtifacts(context)).toThrow(
-        /^Missing bundled bb CLI chunks at .*\/host-daemon\/dist\/bb-chunks\. Rebuild bb-app/,
+      const missingChunks =
+        /^Missing bundled bb CLI chunks at .*\/host-daemon\/dist\/bb-chunks\. Rebuild bb-app/;
+      expect(() => assertBbAppArtifacts(context)).toThrow(missingChunks);
+
+      // An empty directory (a copy interrupted after mkdir, say) fails the
+      // entry's static chunk import exactly like a missing one.
+      const chunkDir = join(context.daemonBundleDir, "bb-chunks");
+      mkdirSync(chunkDir);
+      expect(() => assertBbAppArtifacts(context)).toThrow(missingChunks);
+
+      writeFileSync(join(chunkDir, "chunk-AAAAAAAA.js"), "");
+      expect(() => assertBbAppArtifacts(context)).not.toThrow();
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("prunes stale bb CLI chunks when npm packs the package", () => {
+    // `bb-app#build` prunes the chunks it copies, but turbo restores that
+    // task's own host-daemon/** output over what is on disk on a cache hit,
+    // when the task body never runs. The prune therefore also runs as npm's
+    // `prepack` hook, which fires for `npm pack` and `npm publish` alike.
+    // The hook is exercised through npm itself, from a package root that
+    // holds only the chunk layout, with the script path made absolute so
+    // the fixture does not need a copy of scripts/.
+    expect(readPackageMetadata().scripts.prepack).toBe(
+      "node scripts/prune-bb-chunks.mjs",
+    );
+    const pruneScript = resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      "..",
+      "scripts",
+      "prune-bb-chunks.mjs",
+    );
+    const packageRoot = mkdtempSync(join(tmpdir(), "bb-app-prepack-"));
+    try {
+      const chunkDir = join(packageRoot, "host-daemon", "dist", "bb-chunks");
+      mkdirSync(chunkDir, { recursive: true });
+      writeFileSync(
+        join(packageRoot, "host-daemon", "dist", "bb"),
+        'import"./bb-chunks/chunk-LIVE.js";\n',
+      );
+      writeFileSync(join(chunkDir, "chunk-LIVE.js"), "export var a=1;\n");
+      writeFileSync(join(chunkDir, "chunk-STALE.js"), "export var s=1;\n");
+      writeFileSync(
+        join(packageRoot, "package.json"),
+        JSON.stringify({
+          name: "bb-app-prepack-fixture",
+          version: "0.0.1",
+          files: ["host-daemon/dist/bb", "host-daemon/dist/bb-chunks"],
+          scripts: { prepack: `node ${JSON.stringify(pruneScript)}` },
+        }),
       );
 
-      mkdirSync(join(context.daemonBundleDir, "bb-chunks"));
-      expect(() => assertBbAppArtifacts(context)).not.toThrow();
+      const packed = packDryRunSchema.parse(
+        JSON.parse(
+          execFileSync("npm", ["pack", "--dry-run", "--json"], {
+            cwd: packageRoot,
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "pipe"],
+          }),
+        ),
+      );
+
+      expect(
+        packed.map((entry) => entry.files.map((file) => file.path)),
+      ).toEqual([
+        [
+          "host-daemon/dist/bb",
+          "host-daemon/dist/bb-chunks/chunk-LIVE.js",
+          "package.json",
+        ],
+      ]);
+      expect(readdirSync(chunkDir)).toEqual(["chunk-LIVE.js"]);
     } finally {
       rmSync(packageRoot, { recursive: true, force: true });
     }

--- a/packages/bb-app/test/index.test.ts
+++ b/packages/bb-app/test/index.test.ts
@@ -1,5 +1,12 @@
 import { spawn } from "node:child_process";
-import { mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import {
   createServer,
   type IncomingMessage,
@@ -13,6 +20,7 @@ import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { resolvePortFromEnv } from "@bb/config/runtime";
 import {
+  assertBbAppArtifacts,
   completeFullStackSupervision,
   createDaemonEnv,
   createHostEnrollKeyRequestBody,
@@ -2140,6 +2148,42 @@ describe("bb-app launcher", () => {
     expect(metadata.files).toContain("host-daemon/dist/bb");
     expect(metadata.files).toContain("host-daemon/dist/bb-chunks");
     expect(metadata.os).toEqual(["darwin", "linux"]);
+  });
+
+  it("requires the bundled CLI's chunk directory next to host-daemon/dist/bb", () => {
+    // A packaged layout (entrypoint under <packageRoot>/dist) with every
+    // artifact the launcher checked before the CLI was code-split. Without
+    // bb-chunks the artifact check used to pass and `bb --version` then died
+    // in Node's ESM loader with a raw ERR_MODULE_NOT_FOUND stack.
+    const packageRoot = mkdtempSync(join(tmpdir(), "bb-app-artifacts-"));
+    try {
+      const context = resolveBbAppStartContext({
+        entrypointUrl: pathToFileURL(join(packageRoot, "dist", "bb.js")).href,
+        env: {},
+        homeDir: join(packageRoot, "home"),
+      });
+      for (const artifact of [
+        context.serverEntry,
+        context.daemonEntry,
+        join(context.daemonBundleDir, "bb"),
+        join(context.daemonBundleDir, "bb-provider-bridge-worker.mjs"),
+        join(context.daemonBundleDir, "bb-parcel-watcher-child.mjs"),
+        join(context.daemonBundleDir, "bb-plugin-host-worker.mjs"),
+        join(context.appDistDir, "index.html"),
+      ]) {
+        mkdirSync(dirname(artifact), { recursive: true });
+        writeFileSync(artifact, "");
+      }
+
+      expect(() => assertBbAppArtifacts(context)).toThrow(
+        /^Missing bundled bb CLI chunks at .*\/host-daemon\/dist\/bb-chunks\. Rebuild bb-app/,
+      );
+
+      mkdirSync(join(context.daemonBundleDir, "bb-chunks"));
+      expect(() => assertBbAppArtifacts(context)).not.toThrow();
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
   });
 
   it("keeps the desktop app surface the desktop shell passes to the server", () => {

--- a/packages/scripts/test/build-utils.test.mjs
+++ b/packages/scripts/test/build-utils.test.mjs
@@ -1,0 +1,89 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { pruneUnreferencedChunks } from "../../../scripts/build-utils.mjs";
+
+describe("pruneUnreferencedChunks", () => {
+  const tempDirs = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps the chunks the entry reaches and removes a previous build's", async () => {
+    const dist = mkdtempSync(join(tmpdir(), "bb-prune-chunks-"));
+    tempDirs.push(dist);
+    const chunkDir = join(dist, "bb-chunks");
+    mkdirSync(chunkDir);
+    const entry = join(dist, "bb");
+
+    // The minified shapes esbuild emits: a static import with no whitespace,
+    // a lazy import(), a re-export and a bare side-effect import, plus a
+    // cycle between shared chunks (chunk-A <-> chunk-C).
+    writeFileSync(
+      entry,
+      '#!/usr/bin/env node\nimport{a as U}from"./bb-chunks/chunk-A.js";U(()=>import("./bb-chunks/thread-B.js"));\n',
+    );
+    writeFileSync(
+      join(chunkDir, "chunk-A.js"),
+      'import{b}from"./chunk-C.js";export{b as a};\n',
+    );
+    writeFileSync(
+      join(chunkDir, "thread-B.js"),
+      'export * from "./chunk-A.js";\nimport"./chunk-D.js";\n',
+    );
+    writeFileSync(
+      join(chunkDir, "chunk-C.js"),
+      'import"./chunk-A.js";export var b=1;\n',
+    );
+    writeFileSync(join(chunkDir, "chunk-C.js.map"), "{}");
+    writeFileSync(join(chunkDir, "chunk-D.js"), "export var d=1;\n");
+    // Stale generation: an unreferenced command chunk and a shared chunk
+    // that itself still imports a live chunk, with its sourcemap.
+    writeFileSync(join(chunkDir, "thread-OLD.js"), "export var old=1;\n");
+    writeFileSync(
+      join(chunkDir, "chunk-STALE.js"),
+      'import"./chunk-C.js";export var s=1;\n',
+    );
+    writeFileSync(join(chunkDir, "chunk-STALE.js.map"), "{}");
+
+    const removed = await pruneUnreferencedChunks({ chunkDir, entry });
+
+    expect(removed.sort()).toEqual([
+      join(chunkDir, "chunk-STALE.js"),
+      join(chunkDir, "chunk-STALE.js.map"),
+      join(chunkDir, "thread-OLD.js"),
+    ]);
+    expect(readdirSync(chunkDir).sort()).toEqual([
+      "chunk-A.js",
+      "chunk-C.js",
+      "chunk-C.js.map",
+      "chunk-D.js",
+      "thread-B.js",
+    ]);
+  });
+
+  it("removes nothing from a clean build", async () => {
+    const dist = mkdtempSync(join(tmpdir(), "bb-prune-chunks-"));
+    tempDirs.push(dist);
+    const chunkDir = join(dist, "bb-chunks");
+    mkdirSync(chunkDir);
+    const entry = join(dist, "bb");
+    writeFileSync(entry, 'import"./bb-chunks/chunk-A.js";\n');
+    writeFileSync(join(chunkDir, "chunk-A.js"), "export var a=1;\n");
+
+    await expect(pruneUnreferencedChunks({ chunkDir, entry })).resolves.toEqual(
+      [],
+    );
+    expect(readdirSync(chunkDir)).toEqual(["chunk-A.js"]);
+  });
+});

--- a/packages/scripts/test/build-utils.test.mjs
+++ b/packages/scripts/test/build-utils.test.mjs
@@ -86,4 +86,22 @@ describe("pruneUnreferencedChunks", () => {
     );
     expect(readdirSync(chunkDir)).toEqual(["chunk-A.js"]);
   });
+
+  it("refuses to prune when the entry reaches no chunk", async () => {
+    const dist = mkdtempSync(join(tmpdir(), "bb-prune-chunks-"));
+    tempDirs.push(dist);
+    const chunkDir = join(dist, "bb-chunks");
+    mkdirSync(chunkDir);
+    const entry = join(dist, "bb");
+    // A chunk extension the specifier regex does not recognise: every chunk
+    // then looks unreferenced, and a wipe here would only surface later as
+    // ERR_MODULE_NOT_FOUND from the packed `bb`.
+    writeFileSync(entry, 'import{a}from"./bb-chunks/chunk-A.mjs";\n');
+    writeFileSync(join(chunkDir, "chunk-A.mjs"), "export var a=1;\n");
+
+    await expect(pruneUnreferencedChunks({ chunkDir, entry })).rejects.toThrow(
+      /references no chunk/,
+    );
+    expect(readdirSync(chunkDir)).toEqual(["chunk-A.mjs"]);
+  });
 });

--- a/scripts/build-node-entry.mjs
+++ b/scripts/build-node-entry.mjs
@@ -6,7 +6,7 @@ const [entryPointArg, outfileArg, ...flags] = process.argv.slice(2);
 
 if (!entryPointArg || !outfileArg) {
   throw new Error(
-    "Usage: node scripts/build-node-entry.mjs <entrypoint> <outfile> [--clean-dist] [--executable] [--external <pattern>] [--copy-dir <from> <to>]",
+    "Usage: node scripts/build-node-entry.mjs <entrypoint> <outfile> [--clean-dist] [--executable] [--split] [--external <pattern>] [--copy-dir <from> <to>]",
   );
 }
 
@@ -57,6 +57,7 @@ await buildNodeEsmEntry({
   external: parseExternalPatterns(flags),
   outfile: path.resolve(packageRoot, outfileArg),
   packageRoot,
+  splitting: flags.includes("--split"),
 });
 
 for (const copyArgs of parseCopyDirectories(flags)) {

--- a/scripts/build-utils.mjs
+++ b/scripts/build-utils.mjs
@@ -113,8 +113,15 @@ const RELATIVE_JS_SPECIFIER = /["'](\.\.?\/[^"']+\.js)["']/g;
  * clearing it, so build A -> build B -> cache-hit restore of A leaves both
  * generations' content-hashed chunks side by side. The entry only references
  * its own hashes, so the extra files are dead weight, but packaging copies
- * the directory wholesale and `npm pack` ships everything under it. Pruning
- * at packaging time makes a locally packed tarball match a clean build.
+ * the directory wholesale and `npm pack` ships everything under it. bb-app
+ * prunes the copy it takes from apps/host-daemon/dist during its build, and
+ * again from its `prepack` hook because its own build output is restored the
+ * same way on a cache hit, so a locally packed tarball matches a clean build.
+ *
+ * Refuses (throws) when the entry reaches no chunk at all. Reachability is a
+ * regex over quoted `./x.js` specifiers, so a chunk layout it does not
+ * recognise (another extension, say) would otherwise look like every chunk
+ * is stale and empty the directory with exit code 0.
  *
  * Returns the paths that were removed.
  */
@@ -143,6 +150,12 @@ export async function pruneUnreferencedChunks({ chunkDir, entry }) {
         queue.push(target);
       }
     }
+  }
+
+  if (![...chunkFiles].some((chunkFile) => reachable.has(chunkFile))) {
+    throw new Error(
+      `${path.resolve(entry)} references no chunk in ${resolvedChunkDir}; refusing to prune`,
+    );
   }
 
   const removed = [];

--- a/scripts/build-utils.mjs
+++ b/scripts/build-utils.mjs
@@ -1,4 +1,4 @@
-import { chmod, cp, rm } from "node:fs/promises";
+import { chmod, cp, rename, rm } from "node:fs/promises";
 import path from "node:path";
 import { build } from "esbuild";
 
@@ -57,6 +57,46 @@ export async function copyDirectory({ from, to }) {
   await cp(from, to, { recursive: true });
 }
 
+/**
+ * Code-split output for an entry that `import()`s parts of itself lazily.
+ *
+ * A single-file bundle makes every `import()` target an esbuild lazy wrapper
+ * inside the one script: V8 still pre-parses all of it on every start, and
+ * the wrappers that do run are parsed a second time when first called, so a
+ * command that uses most of the bundle gets slower, not faster. With
+ * `splitting`, each lazily imported subtree lands in its own chunk file next
+ * to the entry and Node reads and compiles only the chunks a command needs.
+ *
+ * esbuild's split mode writes `<entryNames>.js` into `outdir`. The entry
+ * keeps `outfile`'s directory and name; an extensionless `outfile` (the
+ * packaged `bb` executable) is renamed into place by
+ * {@link finalizeSplitOutput}, which is safe because chunks are imported by
+ * a relative path from the same directory. Chunks go under a sibling
+ * directory so packaging can list it next to the entry.
+ */
+export function splitOutputOptions(outfile) {
+  const baseName = path.basename(outfile);
+  const entryName = baseName.endsWith(".js") ? baseName.slice(0, -3) : baseName;
+  return {
+    chunkDir: path.join(path.dirname(outfile), `${entryName}-chunks`),
+    esbuild: {
+      chunkNames: `${entryName}-chunks/[name]-[hash]`,
+      entryNames: entryName,
+      outdir: path.dirname(outfile),
+      splitting: true,
+    },
+    /** Where esbuild writes the entry; differs from `outfile` only when extensionless. */
+    writtenEntry: path.join(path.dirname(outfile), `${entryName}.js`),
+  };
+}
+
+export async function finalizeSplitOutput(outfile) {
+  const { writtenEntry } = splitOutputOptions(outfile);
+  if (writtenEntry !== outfile) {
+    await rename(writtenEntry, outfile);
+  }
+}
+
 export async function buildNodeEsmEntry({
   cleanDist,
   entryPoint,
@@ -65,12 +105,19 @@ export async function buildNodeEsmEntry({
   outfile,
   packageRoot,
   sourcemap = true,
+  splitting = false,
   target = "node22",
 }) {
+  const split = splitting ? splitOutputOptions(outfile) : null;
   if (cleanDist) {
     await rm(path.join(packageRoot, "dist"), { force: true, recursive: true });
   } else {
     await removeFileAndMap(outfile);
+    if (split) {
+      // Chunk names carry content hashes, so a rebuild would otherwise leave
+      // the previous build's chunks behind.
+      await rm(split.chunkDir, { force: true, recursive: true });
+    }
   }
 
   await build({
@@ -83,12 +130,15 @@ export async function buildNodeEsmEntry({
     external: [...createNativeExternalPatterns(), ...external],
     format: "esm",
     legalComments: "none",
-    outfile,
+    ...(split ? split.esbuild : { outfile }),
     platform: "node",
     sourcemap,
     target,
   });
 
+  if (split) {
+    await finalizeSplitOutput(outfile);
+  }
   if (executable) {
     await chmod(outfile, 0o755);
   }

--- a/scripts/build-utils.mjs
+++ b/scripts/build-utils.mjs
@@ -1,4 +1,4 @@
-import { chmod, cp, rename, rm } from "node:fs/promises";
+import { chmod, cp, readdir, readFile, rename, rm } from "node:fs/promises";
 import path from "node:path";
 import { build } from "esbuild";
 
@@ -95,6 +95,69 @@ export async function finalizeSplitOutput(outfile) {
   if (writtenEntry !== outfile) {
     await rename(writtenEntry, outfile);
   }
+}
+
+/**
+ * A quoted relative `./x.js` or `../x.js` specifier. esbuild emits every
+ * chunk reference this way, minified or not: `from"./chunk-X.js"`,
+ * `import("./chunk-X.js")`, `export{}from"./chunk-X.js"`, `import"./chunk-X.js"`.
+ */
+const RELATIVE_JS_SPECIFIER = /["'](\.\.?\/[^"']+\.js)["']/g;
+
+/**
+ * Delete every file in `chunkDir` that the split bundle rooted at `entry`
+ * does not reach through its chunk imports.
+ *
+ * The build removes the chunk directory before writing a new one, but a
+ * turbo cache hit restores `dist/**` over whatever is on disk without
+ * clearing it, so build A -> build B -> cache-hit restore of A leaves both
+ * generations' content-hashed chunks side by side. The entry only references
+ * its own hashes, so the extra files are dead weight, but packaging copies
+ * the directory wholesale and `npm pack` ships everything under it. Pruning
+ * at packaging time makes a locally packed tarball match a clean build.
+ *
+ * Returns the paths that were removed.
+ */
+export async function pruneUnreferencedChunks({ chunkDir, entry }) {
+  const resolvedChunkDir = path.resolve(chunkDir);
+  const chunkFiles = new Set(
+    (await readdir(resolvedChunkDir, { withFileTypes: true }))
+      .filter((dirent) => dirent.isFile())
+      .map((dirent) => path.join(resolvedChunkDir, dirent.name)),
+  );
+
+  const reachable = new Set();
+  const queue = [path.resolve(entry)];
+  while (queue.length > 0) {
+    const file = queue.pop();
+    if (reachable.has(file)) {
+      continue;
+    }
+    reachable.add(file);
+    const source = await readFile(file, "utf8");
+    for (const [, specifier] of source.matchAll(RELATIVE_JS_SPECIFIER)) {
+      // Only chunk files are followed; any other quoted `./x.js` literal in
+      // the bundle (a scaffold template, say) resolves outside the set.
+      const target = path.resolve(path.dirname(file), specifier);
+      if (chunkFiles.has(target) && !reachable.has(target)) {
+        queue.push(target);
+      }
+    }
+  }
+
+  const removed = [];
+  for (const chunkFile of chunkFiles) {
+    // A sourcemap lives or dies with the chunk it describes.
+    const owner = chunkFile.endsWith(".map")
+      ? chunkFile.slice(0, -".map".length)
+      : chunkFile;
+    if (reachable.has(owner)) {
+      continue;
+    }
+    await rm(chunkFile);
+    removed.push(chunkFile);
+  }
+  return removed;
 }
 
 export async function buildNodeEsmEntry({

--- a/turbo.json
+++ b/turbo.json
@@ -344,12 +344,9 @@
     },
     // `bb plugin types|build|dev` on a vendored-layout plugin reads
     // packages/plugin-sdk/bundled-types at runtime (no workspace embed).
-    // startup-graph.test.ts runs the built dist/index.js to guard the
-    // code-split layout, so the CLI's own build must be fresh.
     "@bb/cli#test": {
       "dependsOn": [
         "//#ensure-native-modules",
-        "@bb/cli#build",
         "@get-bb/plugin-sdk#build:types",
         "topo"
       ],

--- a/turbo.json
+++ b/turbo.json
@@ -344,9 +344,12 @@
     },
     // `bb plugin types|build|dev` on a vendored-layout plugin reads
     // packages/plugin-sdk/bundled-types at runtime (no workspace embed).
+    // startup-graph.test.ts runs the built dist/index.js to guard the
+    // code-split layout, so the CLI's own build must be fresh.
     "@bb/cli#test": {
       "dependsOn": [
         "//#ensure-native-modules",
+        "@bb/cli#build",
         "@get-bb/plugin-sdk#build:types",
         "topo"
       ],
@@ -445,10 +448,7 @@
     // uncacheable and must see those two variables (strict env mode strips
     // everything undeclared). Without the variable the suites skip.
     "@bb/server#test:provider-corpus": {
-      "dependsOn": [
-        "//#ensure-native-modules",
-        "topo"
-      ],
+      "dependsOn": ["//#ensure-native-modules", "topo"],
       "cache": false,
       "passThroughEnv": [
         "BB_PROVIDER_CORPUS_DIR",


### PR DESCRIPTION
## What was wrong

Every `bb` invocation evaluated a single 3.3 MB bundle (an internal performance sweep, finding C1): all 17 command groups, the plugin CLI proxy, `@bb/sdk`, `@bb/server-contract`, `@bb/domain` (zod + ~670 `z.object`s), templates and mime-db were imported eagerly, and `version.ts` built a zod schema just to read `package.json`. `bb --version` took 195 ms here (500–560 ms on the sweep's hardware) against a ~20 ms Node floor; agents drive bb in tight loops, so this compounds.

## What changed

- `apps/cli/src/command-groups.ts` registers command groups through lazy `import()` loaders in the existing help order; `index.ts` keeps only `commander`, the re-exec shim, `version.ts` and the group table as static imports and loads `context-env` / the plugin proxy on demand. `version.ts` narrows `package.json` with a type guard instead of zod. `pluginProxyCandidate` moved next to the group table.
- The bundle is code-split along those `import()` boundaries: dev `apps/cli/dist/index.js` + `index-chunks/`, packaged `apps/host-daemon/dist/bb` + `bb-chunks/` (`scripts/build-utils.mjs` `splitting`, `build-node-entry.mjs --split`, `apps/host-daemon/scripts/bundle-manifest.mjs`). Single-file lazy loading alone measured *slower* for hot commands (`bb thread --help` +45 ms) because esbuild's lazy wrappers are parsed twice, so splitting is required for the win. No `--external` flags were added: `bb-app` does not declare undici/ws/mime-db.
- Packaging: `packages/bb-app` ships `host-daemon/dist/bb-chunks`; `requiredArtifactPaths` requires a non-empty chunk dir (friendly error instead of a raw `ERR_MODULE_NOT_FOUND`); unreferenced hashed chunks are pruned after the host-daemon copy and in a `prepack` hook, so a turbo cache-hit restore cannot ship stale chunks.
- Deviation from the sweep text: code splitting instead of single-file lazy loading (measured), and no externals.

Measured (Node 24, same machine, 5 runs each; baseline is HEAD's sources built with the same script): `bb --version` 195 → 27 ms; `bb thread --help` 197 → 177 ms; `bb status` (no server, load + failed connect) 265 → 203 ms; `bb --help` unchanged; `bb --help`, `bb thread --help`, `bb`, `bb bogus`, `bb --version` outputs byte-identical. Entry 3.3 MB → 43 KB minified + 34 chunks.

## How you verified

New tests: `apps/cli/src/__tests__/command-groups.test.ts` (group selection; drift guard that every loader registers exactly the named commands in help order), `startup-graph.test.ts` (resolve-hook graph: `--version` loads no zod/domain/sdk/server-contract/templates/context-env; `thread --help` loads only the thread group; a split bundle built into a temp dir uses one chunk for `thread` and none for other groups), `packaged-plugin-build.test.ts` now builds with `--split` and asserts `--version` from the real chunk layout, `packages/bb-app/test/index.test.ts` (files list, prepack prune, missing/empty chunk dir error), `packages/scripts/test/build-utils.test.mjs` (`pruneUnreferencedChunks`, refuses to prune when the entry reaches no chunk). `npm pack --dry-run --json` lists `bb` + all chunks and no stale files.

On this branch: `pnpm exec turbo run typecheck` (76/76), `pnpm exec turbo run lint`, `pnpm exec turbo run test` (all packages green). Not run locally: `packages/bb-app` `smoke:tarball` (CI runs it on PRs) — please watch that job, and ideally install the packed tarball once and run `bb --version`, `bb status`, `bb plugin build`.

Fixes: no issue — source is an internal performance sweep (finding C1).

> AGENT GENERATED
