### PR TITLE
perf: patch mobile list rows from status-changed pushes instead of refetching (M1)

### DIFF
--- a/apps/mobile/src/data/README.md
+++ b/apps/mobile/src/data/README.md
@@ -18,7 +18,11 @@ Conventions:
   `read-tracking.ts`) never import react-native and are vitest-tested (node
   env); RN adapters (MMKV storage) live in their own small files.
 - Query keys come from `@/lib/query/query-keys` and every key is mapped in
-  `@/lib/query/realtime-invalidation.ts`. Add both when adding a query.
+  `@/lib/query/realtime-invalidation.ts`. Add both when adding a query. A
+  `status-changed` push that carries `metadata.statusChange` patches the
+  cached list / sidebar rows in place
+  (`threads/thread-list-cache.ts` `updateCachedThreadListStatusState`) and
+  cancels list fetches in flight; a bare one refetches the lists.
 - Realtime subscriptions are held through `shared/use-realtime-subscription`
   (refcounted per target; the last unmount releases the server subscription).
 - `thread-detail/` mirrors the web thread-detail queries: the bootstrap

--- a/apps/mobile/src/data/threads/thread-list-cache.test.ts
+++ b/apps/mobile/src/data/threads/thread-list-cache.test.ts
@@ -1,16 +1,22 @@
 import {
   PERSONAL_PROJECT_ID,
+  type ThreadListEntry,
   type ThreadStatusChangeMetadata,
 } from "@bb/domain";
 import type { SidebarBootstrapResponse } from "@bb/server-contract";
-import { QueryClient } from "@tanstack/react-query";
-import { describe, expect, it } from "vitest";
+import {
+  QueryClient,
+  QueryObserver,
+  type QueryKey,
+} from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
 import {
   archivedThreadsListQueryKey,
   sidebarNavigationQueryKey,
   threadListQueryKey,
   threadQueryKey,
   threadSearchQueryKey,
+  threadsQueryKey,
 } from "@/lib/query/query-keys";
 import { project, sidebarBootstrap, threadListEntry } from "../test/fixtures";
 import {
@@ -121,31 +127,161 @@ describe("updateCachedThreadListStatusState", () => {
         ],
       }),
     );
-    const before = queryClient.getQueryData(sidebarNavigationQueryKey());
+    const before = queryClient.getQueryState(sidebarNavigationQueryKey());
     updateCachedThreadListStatusState(queryClient, "t9", ACTIVE_STATUS_CHANGE);
-    expect(queryClient.getQueryData(sidebarNavigationQueryKey())).toBe(before);
+    // Not even a dispatch: the state object is the one from before.
+    expect(queryClient.getQueryState(sidebarNavigationQueryKey())).toBe(before);
+  });
+
+  it("leaves a pending invalidation and the staleness clock of lists without the row alone, so they still refetch on remount", () => {
+    const queryClient = new QueryClient();
+    const seededAt = 1_000;
+    const archivedKey = archivedThreadsListQueryKey({ projectId: "proj_2" });
+    const forksKey = threadListQueryKey({
+      archived: false,
+      parentThreadId: "t1",
+    });
+    queryClient.setQueryData(
+      archivedKey,
+      {
+        pageParams: [0],
+        pages: [[threadListEntry({ id: "ta", archivedAt: 5 })]],
+      },
+      { updatedAt: seededAt },
+    );
+    queryClient.setQueryData(
+      forksKey,
+      [threadListEntry({ id: "tf", parentThreadId: "t1" })],
+      { updatedAt: seededAt },
+    );
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      sidebarBootstrap({
+        projects: [
+          project({ id: "proj_1", threads: [threadListEntry({ id: "t1" })] }),
+        ],
+      }),
+      { updatedAt: seededAt },
+    );
+    // Another client archived a thread while these lists were off screen:
+    // the flush flagged them (no observer, so nothing refetches until they
+    // remount).
+    void queryClient.invalidateQueries({ queryKey: threadsQueryKey() });
+    const statesBefore = [archivedKey, forksKey].map((queryKey) =>
+      queryClient.getQueryState(queryKey),
+    );
+    expect(statesBefore.map((state) => state?.isInvalidated)).toEqual([
+      true,
+      true,
+    ]);
+
+    // A turn of a thread in no cached list starts.
+    updateCachedThreadListStatusState(queryClient, "t9", ACTIVE_STATUS_CHANGE);
+
+    expect(
+      [archivedKey, forksKey].map((queryKey) =>
+        queryClient.getQueryState(queryKey),
+      ),
+    ).toEqual(statesBefore);
+    expect(
+      queryClient.getQueryState(sidebarNavigationQueryKey())?.dataUpdatedAt,
+    ).toBe(seededAt);
+    // The forks list remounts (staleTime 10 s): stale by flag, it refetches.
+    const queryFn = vi.fn(() => new Promise<never>(() => {}));
+    const observer = new QueryObserver(queryClient, {
+      queryKey: forksKey,
+      queryFn,
+      staleTime: 10_000,
+    });
+    const unsubscribe = observer.subscribe(() => {});
+    expect(queryFn).toHaveBeenCalledTimes(1);
+    unsubscribe();
+    queryClient.clear();
+  });
+
+  it("keeps the staleness clock and re-arms a pending invalidation when the patch rewrites a list", () => {
+    const queryClient = new QueryClient();
+    const seededAt = 1_000;
+    const listKey = threadListQueryKey({
+      archived: false,
+      projectId: "proj_1",
+    });
+    const t1 = threadListEntry({ id: "t1" });
+    queryClient.setQueryData(listKey, [t1], { updatedAt: seededAt });
+    void queryClient.invalidateQueries({ queryKey: listKey });
+
+    updateCachedThreadListStatusState(queryClient, "t1", ACTIVE_STATUS_CHANGE);
+
+    const state = queryClient.getQueryState<ThreadListEntry[]>(listKey);
+    expect(state?.data).toEqual([{ ...t1, ...ACTIVE_STATUS_CHANGE }]);
+    expect(state?.isInvalidated).toBe(true);
+    expect(state?.dataUpdatedAt).toBe(seededAt);
+  });
+
+  it("keeps an errored sidebar invalidated so its focus retry still fires", async () => {
+    const queryClient = new QueryClient();
+    const t1 = threadListEntry({ id: "t1" });
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      sidebarBootstrap({
+        projects: [project({ id: "proj_1", threads: [t1] })],
+      }),
+    );
+    // The refetch after a title change failed: the rows stay, flagged.
+    await queryClient
+      .fetchQuery({
+        queryKey: sidebarNavigationQueryKey(),
+        queryFn: () => Promise.reject(new Error("offline")),
+        retry: false,
+      })
+      .catch(() => {});
+    expect(
+      queryClient.getQueryState(sidebarNavigationQueryKey()),
+    ).toMatchObject({ status: "error", isInvalidated: true });
+
+    updateCachedThreadListStatusState(queryClient, "t9", ACTIVE_STATUS_CHANGE);
+    expect(
+      queryClient.getQueryState(sidebarNavigationQueryKey()),
+    ).toMatchObject({ status: "error", isInvalidated: true });
+
+    updateCachedThreadListStatusState(queryClient, "t1", ACTIVE_STATUS_CHANGE);
+    const state = queryClient.getQueryState<SidebarBootstrapResponse>(
+      sidebarNavigationQueryKey(),
+    );
+    expect(state?.data?.projects[0].threads[0].status).toBe("active");
+    expect(state?.isInvalidated).toBe(true);
   });
 });
 
 describe("getFetchingThreadListQueryKeys", () => {
-  it("returns only the thread list and sidebar keys with a fetch in flight", () => {
+  it("returns only the thread list and sidebar keys with a refetch in flight, leaving first loads out", () => {
     const queryClient = new QueryClient();
     const never = () => new Promise<never>(() => {});
+    // `clear()` below cancels these fetches; the rejection is expected.
+    const refetching = <T>(queryKey: QueryKey, data: T): void => {
+      queryClient.setQueryData(queryKey, data);
+      queryClient.fetchQuery({ queryKey, queryFn: never }).catch(() => {});
+    };
     const fetchingList = threadListQueryKey({
       archived: false,
       projectId: "proj_1",
     });
-    for (const queryKey of [
-      sidebarNavigationQueryKey(),
-      fetchingList,
-      archivedThreadsListQueryKey({}),
-      // Not lists: the record and the search results.
-      threadQueryKey("t1"),
-      threadSearchQueryKey({ query: "x", limitPerGroup: 5 }),
-    ]) {
-      // `clear()` below cancels these; the rejection is expected.
-      queryClient.fetchQuery({ queryKey, queryFn: never }).catch(() => {});
-    }
+    refetching(sidebarNavigationQueryKey(), sidebarBootstrap());
+    refetching(fetchingList, []);
+    refetching(archivedThreadsListQueryKey({}), {
+      pageParams: [0],
+      pages: [[]],
+    });
+    // Not lists: the record and the search results.
+    refetching(threadQueryKey("t1"), { id: "t1" });
+    refetching(threadSearchQueryKey({ query: "x", limitPerGroup: 5 }), []);
+    // A first load holds no row a patch could have touched.
+    queryClient
+      .fetchQuery({
+        queryKey: threadListQueryKey({ archived: false, projectId: "proj_3" }),
+        queryFn: never,
+      })
+      .catch(() => {});
     // Cached but idle.
     queryClient.setQueryData(
       threadListQueryKey({ archived: false, projectId: "proj_2" }),

--- a/apps/mobile/src/data/threads/thread-list-cache.test.ts
+++ b/apps/mobile/src/data/threads/thread-list-cache.test.ts
@@ -1,0 +1,166 @@
+import {
+  PERSONAL_PROJECT_ID,
+  type ThreadStatusChangeMetadata,
+} from "@bb/domain";
+import type { SidebarBootstrapResponse } from "@bb/server-contract";
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+import {
+  archivedThreadsListQueryKey,
+  sidebarNavigationQueryKey,
+  threadListQueryKey,
+  threadQueryKey,
+  threadSearchQueryKey,
+} from "@/lib/query/query-keys";
+import { project, sidebarBootstrap, threadListEntry } from "../test/fixtures";
+import {
+  getFetchingThreadListQueryKeys,
+  updateCachedThreadListStatusState,
+  type ThreadListCacheData,
+} from "./thread-list-cache";
+
+const ACTIVE_STATUS_CHANGE: ThreadStatusChangeMetadata = {
+  status: "active",
+  runtime: { displayStatus: "active", hostReconnectGraceExpiresAt: null },
+  activity: {
+    activeWorkflowCount: 0,
+    activeBackgroundAgentCount: 0,
+    activeBackgroundCommandCount: 0,
+    activePlanModeCount: 1,
+    activeGoalCount: 0,
+  },
+  latestAttentionAt: 500,
+  updatedAt: 500,
+};
+
+describe("updateCachedThreadListStatusState", () => {
+  it("patches the row in flat lists, archived pages and the sidebar, leaving lists without the row referentially equal", () => {
+    const queryClient = new QueryClient();
+    const t1 = threadListEntry({ id: "t1" });
+    const t2 = threadListEntry({ id: "t2", projectId: "proj_2" });
+    const tp = threadListEntry({ id: "tp", projectId: PERSONAL_PROJECT_ID });
+    const ta = threadListEntry({ id: "ta", archivedAt: 5 });
+    const tb = threadListEntry({ id: "tb", archivedAt: 6 });
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      sidebarBootstrap({
+        projects: [
+          project({ id: "proj_1", threads: [t1] }),
+          project({ id: "proj_2", threads: [t2] }),
+        ],
+        personalProject: project({
+          id: PERSONAL_PROJECT_ID,
+          kind: "personal",
+          threads: [tp],
+        }),
+      }),
+    );
+    const proj1Key = threadListQueryKey({
+      archived: false,
+      projectId: "proj_1",
+    });
+    const proj2Key = threadListQueryKey({
+      archived: false,
+      projectId: "proj_2",
+    });
+    queryClient.setQueryData(proj1Key, [t1]);
+    queryClient.setQueryData(proj2Key, [t2]);
+    queryClient.setQueryData(archivedThreadsListQueryKey({}), {
+      pageParams: [0, 50],
+      pages: [[ta], [tb]],
+    });
+    const sidebarBefore = queryClient.getQueryData<SidebarBootstrapResponse>(
+      sidebarNavigationQueryKey(),
+    );
+    const proj2Before = queryClient.getQueryData(proj2Key);
+    const archivedBefore = queryClient.getQueryData<ThreadListCacheData>(
+      archivedThreadsListQueryKey({}),
+    );
+
+    updateCachedThreadListStatusState(queryClient, "t1", ACTIVE_STATUS_CHANGE);
+    const patched = { ...t1, ...ACTIVE_STATUS_CHANGE };
+    expect(queryClient.getQueryData(proj1Key)).toEqual([patched]);
+    const sidebar = queryClient.getQueryData<SidebarBootstrapResponse>(
+      sidebarNavigationQueryKey(),
+    );
+    expect(sidebar?.projects[0].threads).toEqual([patched]);
+    // Only the list holding the row is rebuilt; the rest keep their identity.
+    expect(sidebar?.projects[1]).toBe(sidebarBefore?.projects[1]);
+    expect(sidebar?.personalProject).toBe(sidebarBefore?.personalProject);
+    expect(queryClient.getQueryData(proj2Key)).toBe(proj2Before);
+    expect(queryClient.getQueryData(archivedThreadsListQueryKey({}))).toBe(
+      archivedBefore,
+    );
+
+    updateCachedThreadListStatusState(queryClient, "tp", ACTIVE_STATUS_CHANGE);
+    expect(
+      queryClient.getQueryData<SidebarBootstrapResponse>(
+        sidebarNavigationQueryKey(),
+      )?.personalProject.threads,
+    ).toEqual([{ ...tp, ...ACTIVE_STATUS_CHANGE }]);
+
+    updateCachedThreadListStatusState(queryClient, "tb", ACTIVE_STATUS_CHANGE);
+    const archived = queryClient.getQueryData<{
+      pageParams: number[];
+      pages: (typeof ta)[][];
+    }>(archivedThreadsListQueryKey({}));
+    expect(archived?.pages[1]).toEqual([{ ...tb, ...ACTIVE_STATUS_CHANGE }]);
+    expect(archived?.pageParams).toEqual([0, 50]);
+    if (!archivedBefore || Array.isArray(archivedBefore))
+      throw new Error("setup");
+    expect(archived?.pages[0]).toBe(archivedBefore.pages[0]);
+  });
+
+  it("is a no-op for a thread in no cached list", () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      sidebarBootstrap({
+        projects: [
+          project({ id: "proj_1", threads: [threadListEntry({ id: "t1" })] }),
+        ],
+      }),
+    );
+    const before = queryClient.getQueryData(sidebarNavigationQueryKey());
+    updateCachedThreadListStatusState(queryClient, "t9", ACTIVE_STATUS_CHANGE);
+    expect(queryClient.getQueryData(sidebarNavigationQueryKey())).toBe(before);
+  });
+});
+
+describe("getFetchingThreadListQueryKeys", () => {
+  it("returns only the thread list and sidebar keys with a fetch in flight", () => {
+    const queryClient = new QueryClient();
+    const never = () => new Promise<never>(() => {});
+    const fetchingList = threadListQueryKey({
+      archived: false,
+      projectId: "proj_1",
+    });
+    for (const queryKey of [
+      sidebarNavigationQueryKey(),
+      fetchingList,
+      archivedThreadsListQueryKey({}),
+      // Not lists: the record and the search results.
+      threadQueryKey("t1"),
+      threadSearchQueryKey({ query: "x", limitPerGroup: 5 }),
+    ]) {
+      // `clear()` below cancels these; the rejection is expected.
+      queryClient.fetchQuery({ queryKey, queryFn: never }).catch(() => {});
+    }
+    // Cached but idle.
+    queryClient.setQueryData(
+      threadListQueryKey({ archived: false, projectId: "proj_2" }),
+      [],
+    );
+
+    const keys = getFetchingThreadListQueryKeys(queryClient);
+    expect(keys).toHaveLength(3);
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        sidebarNavigationQueryKey(),
+        fetchingList,
+        archivedThreadsListQueryKey({}),
+      ]),
+    );
+    queryClient.clear();
+  });
+});

--- a/apps/mobile/src/data/threads/thread-list-cache.ts
+++ b/apps/mobile/src/data/threads/thread-list-cache.ts
@@ -1,4 +1,4 @@
-import type { ThreadListEntry } from "@bb/domain";
+import type { ThreadListEntry, ThreadStatusChangeMetadata } from "@bb/domain";
 import type {
   SidebarBootstrapResponse,
   ThreadResponse,
@@ -10,6 +10,7 @@ import type {
 } from "@tanstack/react-query";
 import {
   ARCHIVED_THREADS_LIST_KIND,
+  SIDEBAR_NAVIGATION_QUERY_KEY,
   THREADS_QUERY_KEY,
   sidebarNavigationQueryKey,
   threadsQueryKey,
@@ -141,6 +142,50 @@ export function applyToCachedThreadListsAndSidebar(
 ): void {
   applyToCachedThreadLists(queryClient, mapper);
   applyToCachedSidebarThreads(queryClient, mapper);
+}
+
+/**
+ * Write the row fields a lifecycle transition rewrites (status, runtime,
+ * activity, attention and update times) into every cached thread list and the
+ * sidebar bootstrap (mirrors the web's `updateCachedThreadListStatusState`).
+ * Status never changes list membership (lists filter on project, parent and
+ * archive state), so a list without the row is returned as is: the query that
+ * will load it reads the current status, and the untouched array identity is
+ * what the sidebar rows key on.
+ */
+export function updateCachedThreadListStatusState(
+  queryClient: QueryClient,
+  threadId: string,
+  statusChange: ThreadStatusChangeMetadata,
+): void {
+  applyToCachedThreadListsAndSidebar(queryClient, (list) =>
+    list.some((thread) => thread.id === threadId)
+      ? list.map((thread) =>
+          thread.id === threadId ? { ...thread, ...statusChange } : thread,
+        )
+      : list,
+  );
+}
+
+/**
+ * Thread list and sidebar queries with a fetch in flight. Such a fetch read
+ * the database before the change being patched in, so its response would
+ * overwrite the patch when it lands. `THREADS_QUERY_KEY` prefixes the flat
+ * and the archived (paginated) lists and nothing else (`thread` and
+ * `threadSearch` are distinct first segments).
+ */
+export function getFetchingThreadListQueryKeys(
+  queryClient: QueryClient,
+): QueryKey[] {
+  return queryClient
+    .getQueryCache()
+    .findAll({ fetchStatus: "fetching" })
+    .map((query) => query.queryKey)
+    .filter(
+      (queryKey) =>
+        queryKey[0] === THREADS_QUERY_KEY ||
+        queryKey[0] === SIDEBAR_NAVIGATION_QUERY_KEY,
+    );
 }
 
 /** Every thread the sidebar bootstrap knows about (projects + personal). */

--- a/apps/mobile/src/data/threads/thread-list-cache.ts
+++ b/apps/mobile/src/data/threads/thread-list-cache.ts
@@ -5,6 +5,7 @@ import type {
 } from "@bb/server-contract";
 import type {
   InfiniteData,
+  Query,
   QueryClient,
   QueryKey,
 } from "@tanstack/react-query";
@@ -61,6 +62,10 @@ export function* iterateThreadListCacheEntries(
   for (const page of data.pages) yield* page;
 }
 
+/**
+ * `data` itself when the mapper left every page as is: the caller skips the
+ * write.
+ */
 function mapThreadListCacheData<T extends ThreadListCacheData>(
   data: T,
   mapper: ThreadListMapper,
@@ -68,7 +73,30 @@ function mapThreadListCacheData<T extends ThreadListCacheData>(
   if (isThreadListEntryArray(data)) {
     return mapper(data) as T;
   }
-  return { ...data, pages: data.pages.map(mapper) } as T;
+  const pages = data.pages.map(mapper);
+  return pages.every((page, index) => page === data.pages[index])
+    ? data
+    : ({ ...data, pages } as T);
+}
+
+/**
+ * Write a patched list back without touching the query's freshness
+ * bookkeeping. A manual `setQueryData` dispatches `success`, which resets
+ * `dataUpdatedAt` to now and clears `isInvalidated`; a client-side patch is
+ * not fresher server data, and a pending refetch-on-remount (an inactive list
+ * flagged by an earlier push) or the focus retry of an errored refetch must
+ * survive it. The write is `manual`, so a fetch in flight keeps its status.
+ */
+function writeCachedListPatch<TData>(
+  queryClient: QueryClient,
+  query: Query<TData, Error, TData>,
+  data: TData,
+): void {
+  const { dataUpdatedAt, isInvalidated } = query.state;
+  queryClient.setQueryData<TData>(query.queryKey, data, {
+    updatedAt: dataUpdatedAt,
+  });
+  if (isInvalidated) query.invalidate();
 }
 
 export interface CachedThreadList {
@@ -88,12 +116,23 @@ export function getCachedThreadLists(
   return lists;
 }
 
+/**
+ * Apply one mapper to every cached thread list. A list the mapper returned as
+ * is (same array / same pages) is not written at all: a write would rewrite
+ * the query state (see `writeCachedListPatch`) for nothing.
+ */
 export function applyToCachedThreadLists(
   queryClient: QueryClient,
   mapper: ThreadListMapper,
 ): void {
-  for (const { queryKey, data } of getCachedThreadLists(queryClient)) {
-    queryClient.setQueryData(queryKey, mapThreadListCacheData(data, mapper));
+  for (const query of queryClient
+    .getQueryCache()
+    .findAll({ queryKey: threadsQueryKey() })) {
+    const data = query.state.data;
+    if (!isThreadListCacheData(data)) continue;
+    const next = mapThreadListCacheData(data, mapper);
+    if (next === data) continue;
+    writeCachedListPatch(queryClient, query, next);
   }
 }
 
@@ -103,39 +142,47 @@ function mapSidebarProjectThreads(
   project: SidebarProject,
   mapper: ThreadListMapper,
 ): SidebarProject {
-  return { ...project, threads: mapper(project.threads) };
+  const threads = mapper(project.threads);
+  return threads === project.threads ? project : { ...project, threads };
 }
 
+/** `bootstrap` itself when the mapper left every project as is. */
 function mapSidebarBootstrapThreads(
   bootstrap: SidebarBootstrapResponse,
   mapper: ThreadListMapper,
 ): SidebarBootstrapResponse {
-  return {
-    sections: bootstrap.sections,
-    projects: bootstrap.projects.map((project) =>
-      mapSidebarProjectThreads(project, mapper),
-    ),
-    personalProject: mapSidebarProjectThreads(
-      bootstrap.personalProject,
-      mapper,
-    ),
-  };
+  const projects = bootstrap.projects.map((project) =>
+    mapSidebarProjectThreads(project, mapper),
+  );
+  const personalProject = mapSidebarProjectThreads(
+    bootstrap.personalProject,
+    mapper,
+  );
+  return personalProject === bootstrap.personalProject &&
+    projects.every((project, index) => project === bootstrap.projects[index])
+    ? bootstrap
+    : { sections: bootstrap.sections, projects, personalProject };
 }
 
 function applyToCachedSidebarThreads(
   queryClient: QueryClient,
   mapper: ThreadListMapper,
 ): void {
-  queryClient.setQueryData<SidebarBootstrapResponse>(
-    sidebarNavigationQueryKey(),
-    (current) =>
-      current === undefined
-        ? current
-        : mapSidebarBootstrapThreads(current, mapper),
-  );
+  const query = queryClient.getQueryCache().find<SidebarBootstrapResponse>({
+    queryKey: sidebarNavigationQueryKey(),
+    exact: true,
+  });
+  const current = query?.state.data;
+  if (query === undefined || current === undefined) return;
+  const next = mapSidebarBootstrapThreads(current, mapper);
+  if (next === current) return;
+  writeCachedListPatch(queryClient, query, next);
 }
 
-/** Apply one mapper to every cached thread list and the sidebar bootstrap. */
+/**
+ * Apply one mapper to every cached thread list and the sidebar bootstrap,
+ * writing only the lists the mapper changed.
+ */
 export function applyToCachedThreadListsAndSidebar(
   queryClient: QueryClient,
   mapper: ThreadListMapper,
@@ -150,8 +197,9 @@ export function applyToCachedThreadListsAndSidebar(
  * sidebar bootstrap (mirrors the web's `updateCachedThreadListStatusState`).
  * Status never changes list membership (lists filter on project, parent and
  * archive state), so a list without the row is returned as is: the query that
- * will load it reads the current status, and the untouched array identity is
- * what the sidebar rows key on.
+ * will load it reads the current status, and returning the same array skips
+ * both the copy and the cache write (so the list's query state, including a
+ * pending invalidation, stays untouched) on every push.
  */
 export function updateCachedThreadListStatusState(
   queryClient: QueryClient,
@@ -168,10 +216,11 @@ export function updateCachedThreadListStatusState(
 }
 
 /**
- * Thread list and sidebar queries with a fetch in flight. Such a fetch read
+ * Thread list and sidebar queries with a refetch in flight. Such a fetch read
  * the database before the change being patched in, so its response would
- * overwrite the patch when it lands. `THREADS_QUERY_KEY` prefixes the flat
- * and the archived (paginated) lists and nothing else (`thread` and
+ * overwrite the patch when it lands. A first load (no data yet) holds no
+ * patched row and is left alone. `THREADS_QUERY_KEY` prefixes the flat and
+ * the archived (paginated) lists and nothing else (`thread` and
  * `threadSearch` are distinct first segments).
  */
 export function getFetchingThreadListQueryKeys(
@@ -180,12 +229,13 @@ export function getFetchingThreadListQueryKeys(
   return queryClient
     .getQueryCache()
     .findAll({ fetchStatus: "fetching" })
-    .map((query) => query.queryKey)
     .filter(
-      (queryKey) =>
-        queryKey[0] === THREADS_QUERY_KEY ||
-        queryKey[0] === SIDEBAR_NAVIGATION_QUERY_KEY,
-    );
+      (query) =>
+        query.state.data !== undefined &&
+        (query.queryKey[0] === THREADS_QUERY_KEY ||
+          query.queryKey[0] === SIDEBAR_NAVIGATION_QUERY_KEY),
+    )
+    .map((query) => query.queryKey);
 }
 
 /** Every thread the sidebar bootstrap knows about (projects + personal). */

--- a/apps/mobile/src/lib/query/realtime-invalidation.test.ts
+++ b/apps/mobile/src/lib/query/realtime-invalidation.test.ts
@@ -1,5 +1,12 @@
-import { QueryClient, hashKey } from "@tanstack/react-query";
+import type { ThreadStatusChangeMetadata } from "@bb/domain";
+import type { SidebarBootstrapResponse } from "@bb/server-contract";
+import { QueryClient, QueryObserver, hashKey } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  project,
+  sidebarBootstrap,
+  threadListEntry,
+} from "@/data/test/fixtures";
 import { createFakeSocketFactory } from "../realtime/fake-socket";
 import { createMobileRealtime } from "../realtime/mobile-realtime";
 import {
@@ -30,8 +37,10 @@ import {
   systemConfigQueryKey,
   threadDefaultExecutionOptionsQueryKey,
   threadDetailBootstrapQueryKey,
+  threadListQueryKey,
   threadPendingInteractionsQueryKey,
   threadQueryKey,
+  threadQueuedMessagesQueryKey,
   threadSearchQueryKeyPrefix,
   threadTimelineQueryKey,
   threadTimelineTurnSummaryDetailsQueryKeyPrefix,
@@ -44,6 +53,36 @@ import {
   pluginUpdatesQueryKey,
   themeCatalogQueryKey,
 } from "./query-keys";
+
+const ACTIVE_STATUS_CHANGE: ThreadStatusChangeMetadata = {
+  status: "active",
+  runtime: { displayStatus: "active", hostReconnectGraceExpiresAt: null },
+  activity: {
+    activeWorkflowCount: 0,
+    activeBackgroundAgentCount: 0,
+    activeBackgroundCommandCount: 0,
+    activePlanModeCount: 1,
+    activeGoalCount: 0,
+  },
+  latestAttentionAt: 500,
+  updatedAt: 500,
+};
+
+/** The frame `buildThreadStatusChangeMetadata` attaches on the server. */
+function statusChangedFrame(
+  threadId: string,
+  statusChange?: ThreadStatusChangeMetadata,
+): string {
+  return JSON.stringify({
+    type: "changed",
+    entity: "thread",
+    id: threadId,
+    changes: ["status-changed"],
+    ...(statusChange
+      ? { metadata: { projectId: "proj_1", statusChange } }
+      : {}),
+  });
+}
 
 function setup() {
   const factory = createFakeSocketFactory();
@@ -230,6 +269,112 @@ describe("installRealtimeInvalidation", () => {
     vi.advanceTimersByTime(500);
     expect(invalidated).toEqual([]);
   });
+
+  it("patches cached list rows from a status-changed push that carries the row instead of refetching the lists", () => {
+    const { factory, queryClient, invalidated } = setup();
+    const t1 = threadListEntry({ id: "t1" });
+    const t2 = threadListEntry({ id: "t2", projectId: "proj_2" });
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      sidebarBootstrap({
+        projects: [
+          project({ id: "proj_1", threads: [t1] }),
+          project({ id: "proj_2", threads: [t2] }),
+        ],
+      }),
+    );
+    const listKey = threadListQueryKey({
+      archived: false,
+      projectId: "proj_1",
+    });
+    queryClient.setQueryData(listKey, [t1]);
+    const before = queryClient.getQueryData<SidebarBootstrapResponse>(
+      sidebarNavigationQueryKey(),
+    );
+
+    factory.latest().receive(statusChangedFrame("t1", ACTIVE_STATUS_CHANGE));
+
+    // Synchronous: the rows carry the five fields before any flush.
+    const patched = { ...t1, ...ACTIVE_STATUS_CHANGE };
+    const sidebar = queryClient.getQueryData<SidebarBootstrapResponse>(
+      sidebarNavigationQueryKey(),
+    );
+    expect(sidebar?.projects[0].threads).toEqual([patched]);
+    expect(sidebar?.projects[1].threads).toBe(before?.projects[1].threads);
+    expect(queryClient.getQueryData(listKey)).toEqual([patched]);
+    expect(invalidated).toEqual([]);
+
+    vi.advanceTimersByTime(250);
+    expect(invalidated).toEqual([
+      hashKey(threadQueryKey("t1")),
+      hashKey(threadSearchQueryKeyPrefix()),
+    ]);
+  });
+
+  it("leaves the caches untouched and schedules no list refetch for a row of a thread in no cached list", () => {
+    const { factory, queryClient, invalidated } = setup();
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      sidebarBootstrap({
+        projects: [
+          project({ id: "proj_1", threads: [threadListEntry({ id: "t1" })] }),
+        ],
+      }),
+    );
+    const before = queryClient.getQueryData(sidebarNavigationQueryKey());
+    factory.latest().receive(statusChangedFrame("t9", ACTIVE_STATUS_CHANGE));
+    expect(queryClient.getQueryData(sidebarNavigationQueryKey())).toBe(before);
+    vi.advanceTimersByTime(250);
+    expect(invalidated).toEqual([
+      hashKey(threadQueryKey("t9")),
+      hashKey(threadSearchQueryKeyPrefix()),
+    ]);
+  });
+
+  it("cancels and restarts exactly the list fetches in flight, synchronously, so their stale response cannot overwrite the patch", () => {
+    const { factory, queryClient, invalidateSpy } = setup();
+    queryClient.setQueryData(
+      threadListQueryKey({ archived: false, projectId: "proj_1" }),
+      [threadListEntry({ id: "t1" })],
+    );
+    const observer = new QueryObserver(queryClient, {
+      queryKey: sidebarNavigationQueryKey(),
+      queryFn: () => new Promise<SidebarBootstrapResponse>(() => {}),
+    });
+    const unsubscribe = observer.subscribe(() => {});
+    expect(
+      queryClient.getQueryState(sidebarNavigationQueryKey())?.fetchStatus,
+    ).toBe("fetching");
+
+    factory.latest().receive(statusChangedFrame("t1", ACTIVE_STATUS_CHANGE));
+    // Not through the debounced map (which would wait and prefix-match).
+    expect(invalidateSpy.mock.calls.map(([filters]) => filters)).toEqual([
+      { exact: true, queryKey: sidebarNavigationQueryKey() },
+    ]);
+    unsubscribe();
+  });
+
+  it("still refetches the lists when a bare status-changed (stop, interrupt) follows a patched one in the same window", () => {
+    const { factory, queryClient, invalidated } = setup();
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      sidebarBootstrap({
+        projects: [
+          project({ id: "proj_1", threads: [threadListEntry({ id: "t1" })] }),
+        ],
+      }),
+    );
+    const socket = factory.latest();
+    socket.receive(statusChangedFrame("t1", ACTIVE_STATUS_CHANGE));
+    socket.receive(statusChangedFrame("t1"));
+    vi.advanceTimersByTime(250);
+    expect(invalidated).toEqual(
+      expect.arrayContaining([
+        hashKey(threadsQueryKey()),
+        hashKey(sidebarNavigationQueryKey()),
+      ]),
+    );
+  });
 });
 
 describe("queryKeysForChangedMessage", () => {
@@ -303,7 +448,53 @@ describe("queryKeysForChangedMessage", () => {
         id: "t1",
         changes: ["status-changed"],
       }),
-    ).toContainEqual(threadQueryKey("t1"));
+    ).toEqual([
+      threadQueryKey("t1"),
+      threadsQueryKey(),
+      sidebarNavigationQueryKey(),
+      threadSearchQueryKeyPrefix(),
+    ]);
+  });
+
+  it("skips the list refetch for a status-changed push that carries the row, unless another list kind rides along", () => {
+    expect(
+      queryKeysForChangedMessage({
+        type: "changed",
+        entity: "thread",
+        id: "t1",
+        changes: ["status-changed"],
+        metadata: { statusChange: ACTIVE_STATUS_CHANGE },
+      }),
+    ).toEqual([threadQueryKey("t1"), threadSearchQueryKeyPrefix()]);
+    // The queued-messages push pairs the row with a non-list kind.
+    expect(
+      queryKeysForChangedMessage({
+        type: "changed",
+        entity: "thread",
+        id: "t1",
+        changes: ["status-changed", "queue-changed"],
+        metadata: { statusChange: ACTIVE_STATUS_CHANGE },
+      }),
+    ).toEqual([
+      threadQueryKey("t1"),
+      threadQueuedMessagesQueryKey("t1"),
+      threadSearchQueryKeyPrefix(),
+    ]);
+    // Any other list kind still needs the refetch.
+    expect(
+      queryKeysForChangedMessage({
+        type: "changed",
+        entity: "thread",
+        id: "t1",
+        changes: ["status-changed", "title-changed"],
+        metadata: { statusChange: ACTIVE_STATUS_CHANGE },
+      }),
+    ).toEqual([
+      threadQueryKey("t1"),
+      threadsQueryKey(),
+      sidebarNavigationQueryKey(),
+      threadSearchQueryKeyPrefix(),
+    ]);
   });
 
   it("maps system changes to config plus provider/default keys for settings and plugin changes", () => {

--- a/apps/mobile/src/lib/query/realtime-invalidation.test.ts
+++ b/apps/mobile/src/lib/query/realtime-invalidation.test.ts
@@ -84,6 +84,42 @@ function statusChangedFrame(
   });
 }
 
+/**
+ * A sidebar observer with a refetch in flight whose responses resolve on
+ * demand and whose aborts are counted (`sdk.projects.sidebarBootstrap`
+ * forwards the signal the same way).
+ */
+function sidebarRefetchInFlight(queryClient: QueryClient) {
+  const responses: ((body: SidebarBootstrapResponse) => void)[] = [];
+  let aborts = 0;
+  const queryFn = vi.fn(
+    ({ signal }: { signal: AbortSignal }) =>
+      new Promise<SidebarBootstrapResponse>((resolve) => {
+        signal.addEventListener("abort", () => {
+          aborts += 1;
+        });
+        responses.push(resolve);
+      }),
+  );
+  const observer = new QueryObserver(queryClient, {
+    queryKey: sidebarNavigationQueryKey(),
+    queryFn,
+    staleTime: Infinity,
+  });
+  const unsubscribe = observer.subscribe(() => {});
+  void observer.refetch();
+  expect(
+    queryClient.getQueryState(sidebarNavigationQueryKey())?.fetchStatus,
+  ).toBe("fetching");
+  return { queryFn, responses, aborts: () => aborts, unsubscribe };
+}
+
+function sidebarRows(queryClient: QueryClient) {
+  return queryClient.getQueryData<SidebarBootstrapResponse>(
+    sidebarNavigationQueryKey(),
+  )?.projects[0].threads;
+}
+
 function setup() {
   const factory = createFakeSocketFactory();
   const realtime = createMobileRealtime({
@@ -331,27 +367,139 @@ describe("installRealtimeInvalidation", () => {
     ]);
   });
 
-  it("cancels and restarts exactly the list fetches in flight, synchronously, so their stale response cannot overwrite the patch", () => {
+  it("aborts a sidebar refetch in flight synchronously and restarts it on the flush, so its stale body cannot overwrite the patch", async () => {
     const { factory, queryClient, invalidateSpy } = setup();
-    queryClient.setQueryData(
-      threadListQueryKey({ archived: false, projectId: "proj_1" }),
-      [threadListEntry({ id: "t1" })],
-    );
-    const observer = new QueryObserver(queryClient, {
-      queryKey: sidebarNavigationQueryKey(),
-      queryFn: () => new Promise<SidebarBootstrapResponse>(() => {}),
-    });
-    const unsubscribe = observer.subscribe(() => {});
-    expect(
-      queryClient.getQueryState(sidebarNavigationQueryKey())?.fetchStatus,
-    ).toBe("fetching");
+    invalidateSpy.mockRestore();
+    const t1 = threadListEntry({ id: "t1" });
+    const idle = () =>
+      sidebarBootstrap({
+        projects: [project({ id: "proj_1", threads: [t1] })],
+      });
+    queryClient.setQueryData(sidebarNavigationQueryKey(), idle());
+    const refetch = sidebarRefetchInFlight(queryClient);
 
     factory.latest().receive(statusChangedFrame("t1", ACTIVE_STATUS_CHANGE));
-    // Not through the debounced map (which would wait and prefix-match).
-    expect(invalidateSpy.mock.calls.map(([filters]) => filters)).toEqual([
-      { exact: true, queryKey: sidebarNavigationQueryKey() },
-    ]);
-    unsubscribe();
+    // The request that read the pre-transition row is aborted at once, the
+    // patch is kept (no revert, no error state), and the restart waits for
+    // the flush.
+    expect(refetch.aborts()).toBe(1);
+    expect(refetch.queryFn).toHaveBeenCalledTimes(1);
+    expect(
+      queryClient.getQueryState(sidebarNavigationQueryKey()),
+    ).toMatchObject({ status: "success", isInvalidated: true });
+    expect(sidebarRows(queryClient)?.[0].status).toBe("active");
+
+    vi.advanceTimersByTime(250);
+    expect(refetch.queryFn).toHaveBeenCalledTimes(2);
+    expect(refetch.aborts()).toBe(1);
+    // The aborted request's body lands late: dropped.
+    refetch.responses[0]?.(idle());
+    await vi.advanceTimersByTimeAsync(0);
+    expect(sidebarRows(queryClient)?.[0].status).toBe("active");
+    // The restarted request's body lands.
+    refetch.responses[1]?.(
+      sidebarBootstrap({
+        projects: [
+          project({
+            id: "proj_1",
+            threads: [{ ...t1, ...ACTIVE_STATUS_CHANGE, title: "fresh" }],
+          }),
+        ],
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    expect(sidebarRows(queryClient)?.[0].title).toBe("fresh");
+    expect(
+      queryClient.getQueryState(sidebarNavigationQueryKey()),
+    ).toMatchObject({ fetchStatus: "idle", isInvalidated: false });
+    refetch.unsubscribe();
+  });
+
+  it("coalesces a burst of row-carrying pushes into one abort and one restart of the sidebar refetch in flight", () => {
+    const { factory, queryClient, invalidateSpy } = setup();
+    invalidateSpy.mockRestore();
+    const invalidateCalls = vi.spyOn(queryClient, "invalidateQueries");
+    const threads = Array.from({ length: 8 }, (_, index) =>
+      threadListEntry({ id: `t${index + 1}` }),
+    );
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      sidebarBootstrap({ projects: [project({ id: "proj_1", threads })] }),
+    );
+    const refetch = sidebarRefetchInFlight(queryClient);
+    const sidebarCalls = () =>
+      invalidateCalls.mock.calls
+        .map(([filters]) => filters)
+        .filter(
+          (filters) =>
+            filters?.queryKey !== undefined &&
+            hashKey(filters.queryKey) === hashKey(sidebarNavigationQueryKey()),
+        );
+
+    // A workflow fanned out eight children; each one starts within the
+    // 50 ms debounce of the previous.
+    const socket = factory.latest();
+    for (const thread of threads) {
+      socket.receive(statusChangedFrame(thread.id, ACTIVE_STATUS_CHANGE));
+      vi.advanceTimersByTime(14);
+    }
+    expect(
+      sidebarRows(queryClient)?.every((row) => row.status === "active"),
+    ).toBe(true);
+    expect(refetch.aborts()).toBe(1);
+    expect(refetch.queryFn).toHaveBeenCalledTimes(1);
+    expect(
+      sidebarCalls().every((filters) => filters?.refetchType === "none"),
+    ).toBe(true);
+
+    vi.advanceTimersByTime(250);
+    expect(refetch.queryFn).toHaveBeenCalledTimes(2);
+    expect(refetch.aborts()).toBe(1);
+    expect(
+      sidebarCalls().filter((filters) => filters?.refetchType !== "none"),
+    ).toEqual([{ exact: true, queryKey: sidebarNavigationQueryKey() }]);
+    refetch.unsubscribe();
+  });
+
+  it("lets a prefix invalidation in the same window cover the restart of an aborted list fetch", () => {
+    const { factory, queryClient, invalidateSpy } = setup();
+    invalidateSpy.mockRestore();
+    const invalidateCalls = vi.spyOn(queryClient, "invalidateQueries");
+    const t1 = threadListEntry({ id: "t1" });
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      sidebarBootstrap({
+        projects: [project({ id: "proj_1", threads: [t1] })],
+      }),
+    );
+    const refetch = sidebarRefetchInFlight(queryClient);
+
+    const socket = factory.latest();
+    socket.receive(statusChangedFrame("t1", ACTIVE_STATUS_CHANGE));
+    socket.receive(
+      JSON.stringify({
+        type: "changed",
+        entity: "thread",
+        id: "t2",
+        changes: ["title-changed"],
+      }),
+    );
+    vi.advanceTimersByTime(250);
+    // One restart, not a start plus an abort-and-restart in the same tick.
+    expect(refetch.queryFn).toHaveBeenCalledTimes(2);
+    expect(refetch.aborts()).toBe(1);
+    expect(
+      invalidateCalls.mock.calls
+        .map(([filters]) => filters)
+        .filter(
+          (filters) =>
+            filters?.queryKey !== undefined &&
+            hashKey(filters.queryKey) ===
+              hashKey(sidebarNavigationQueryKey()) &&
+            filters.refetchType !== "none",
+        ),
+    ).toEqual([{ queryKey: sidebarNavigationQueryKey(), exact: false }]);
+    refetch.unsubscribe();
   });
 
   it("still refetches the lists when a bare status-changed (stop, interrupt) follows a patched one in the same window", () => {

--- a/apps/mobile/src/lib/query/realtime-invalidation.test.ts
+++ b/apps/mobile/src/lib/query/realtime-invalidation.test.ts
@@ -1,12 +1,18 @@
-import type { ThreadStatusChangeMetadata } from "@bb/domain";
+import type { ThreadListEntry, ThreadStatusChangeMetadata } from "@bb/domain";
 import type { SidebarBootstrapResponse } from "@bb/server-contract";
-import { QueryClient, QueryObserver, hashKey } from "@tanstack/react-query";
+import {
+  QueryClient,
+  QueryObserver,
+  hashKey,
+  type QueryKey,
+} from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   project,
   sidebarBootstrap,
   threadListEntry,
 } from "@/data/test/fixtures";
+import { getFetchingThreadListQueryKeys } from "@/data/threads/thread-list-cache";
 import { createFakeSocketFactory } from "../realtime/fake-socket";
 import { createMobileRealtime } from "../realtime/mobile-realtime";
 import {
@@ -85,40 +91,55 @@ function statusChangedFrame(
 }
 
 /**
- * A sidebar observer with a refetch in flight whose responses resolve on
- * demand and whose aborts are counted (`sdk.projects.sidebarBootstrap`
- * forwards the signal the same way).
+ * An observer of one list query with a refetch in flight whose responses
+ * resolve on demand and whose aborts are counted (the list query functions
+ * forward the signal the same way).
  */
-function sidebarRefetchInFlight(queryClient: QueryClient) {
-  const responses: ((body: SidebarBootstrapResponse) => void)[] = [];
+function refetchInFlight<TData>(queryClient: QueryClient, queryKey: QueryKey) {
+  const responses: ((body: TData) => void)[] = [];
   let aborts = 0;
   const queryFn = vi.fn(
     ({ signal }: { signal: AbortSignal }) =>
-      new Promise<SidebarBootstrapResponse>((resolve) => {
+      new Promise<TData>((resolve) => {
         signal.addEventListener("abort", () => {
           aborts += 1;
         });
         responses.push(resolve);
       }),
   );
-  const observer = new QueryObserver(queryClient, {
-    queryKey: sidebarNavigationQueryKey(),
-    queryFn,
-    staleTime: Infinity,
-  });
+  const options = { queryKey, queryFn, staleTime: Infinity };
+  const observer = new QueryObserver(queryClient, options);
   const unsubscribe = observer.subscribe(() => {});
   void observer.refetch();
-  expect(
-    queryClient.getQueryState(sidebarNavigationQueryKey())?.fetchStatus,
-  ).toBe("fetching");
-  return { queryFn, responses, aborts: () => aborts, unsubscribe };
+  expect(queryClient.getQueryState(queryKey)?.fetchStatus).toBe("fetching");
+  return {
+    queryFn,
+    responses,
+    aborts: () => aborts,
+    unsubscribe,
+    /** Flip `enabled` the way `useThreadsList({ enabled })` does. */
+    setEnabled: (enabled: boolean) =>
+      observer.setOptions({ ...options, enabled }),
+  };
 }
+
+const sidebarRefetchInFlight = (queryClient: QueryClient) =>
+  refetchInFlight<SidebarBootstrapResponse>(
+    queryClient,
+    sidebarNavigationQueryKey(),
+  );
 
 function sidebarRows(queryClient: QueryClient) {
   return queryClient.getQueryData<SidebarBootstrapResponse>(
     sidebarNavigationQueryKey(),
   )?.projects[0].threads;
 }
+
+/**
+ * query-core's default `gcTime` on a device; under node (no `window`) it is
+ * Infinity, which would hide a query that is never collected.
+ */
+const DEVICE_GC_TIME_MS = 5 * 60_000;
 
 function setup() {
   const factory = createFakeSocketFactory();
@@ -127,7 +148,9 @@ function setup() {
     socketFactory: factory,
     onInvalidMessage: () => {},
   });
-  const queryClient = new QueryClient();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { gcTime: DEVICE_GC_TIME_MS } },
+  });
   const invalidated: string[] = [];
   const invalidateSpy = vi
     .spyOn(queryClient, "invalidateQueries")
@@ -380,13 +403,17 @@ describe("installRealtimeInvalidation", () => {
 
     factory.latest().receive(statusChangedFrame("t1", ACTIVE_STATUS_CHANGE));
     // The request that read the pre-transition row is aborted at once, the
-    // patch is kept (no revert, no error state), and the restart waits for
-    // the flush.
+    // patch is kept (the abort reverts to the patched write; no error state),
+    // the query is idle and stale, and the restart waits for the flush.
     expect(refetch.aborts()).toBe(1);
     expect(refetch.queryFn).toHaveBeenCalledTimes(1);
     expect(
       queryClient.getQueryState(sidebarNavigationQueryKey()),
-    ).toMatchObject({ status: "success", isInvalidated: true });
+    ).toMatchObject({
+      status: "success",
+      fetchStatus: "idle",
+      isInvalidated: true,
+    });
     expect(sidebarRows(queryClient)?.[0].status).toBe("active");
 
     vi.advanceTimersByTime(250);
@@ -499,6 +526,148 @@ describe("installRealtimeInvalidation", () => {
             filters.refetchType !== "none",
         ),
     ).toEqual([{ queryKey: sidebarNavigationQueryKey(), exact: false }]);
+    refetch.unsubscribe();
+  });
+
+  it("lets a ['threads'] prefix invalidation cover the exact restart of an aborted filtered list fetch", () => {
+    const { factory, queryClient, invalidateSpy } = setup();
+    invalidateSpy.mockRestore();
+    const invalidateCalls = vi.spyOn(queryClient, "invalidateQueries");
+    const listKey = threadListQueryKey({
+      archived: false,
+      projectId: "proj_1",
+    });
+    queryClient.setQueryData<ThreadListEntry[]>(listKey, [
+      threadListEntry({ id: "t1" }),
+    ]);
+    const refetch = refetchInFlight<ThreadListEntry[]>(queryClient, listKey);
+
+    const socket = factory.latest();
+    socket.receive(statusChangedFrame("t1", ACTIVE_STATUS_CHANGE));
+    expect(refetch.aborts()).toBe(1);
+    socket.receive(
+      JSON.stringify({
+        type: "changed",
+        entity: "thread",
+        id: "t2",
+        changes: ["title-changed"],
+      }),
+    );
+    vi.advanceTimersByTime(250);
+
+    const restartCallsFor = (key: QueryKey) =>
+      invalidateCalls.mock.calls
+        .map(([filters]) => filters)
+        .filter(
+          (filters) =>
+            filters?.queryKey !== undefined &&
+            hashKey(filters.queryKey) === hashKey(key) &&
+            filters.refetchType !== "none",
+        );
+    // The filtered key is a different hash from the ['threads'] prefix, so
+    // only the flush-time prefix check can subsume the exact restart: one
+    // restart through the prefix, not a start plus an abort-and-restart of
+    // the same fetch in one tick.
+    expect(refetch.queryFn).toHaveBeenCalledTimes(2);
+    expect(refetch.aborts()).toBe(1);
+    expect(restartCallsFor(listKey)).toEqual([]);
+    expect(restartCallsFor(threadsQueryKey())).toEqual([
+      { queryKey: threadsQueryKey(), exact: false },
+    ]);
+    refetch.unsubscribe();
+  });
+
+  it("returns an aborted sidebar refetch to idle, so a query whose observer leaves before the flush is collected instead of stranded fetching", () => {
+    const { factory, queryClient, invalidateSpy } = setup();
+    invalidateSpy.mockRestore();
+    const t1 = threadListEntry({ id: "t1" });
+    queryClient.setQueryData(
+      sidebarNavigationQueryKey(),
+      sidebarBootstrap({
+        projects: [project({ id: "proj_1", threads: [t1] })],
+      }),
+    );
+    const refetch = sidebarRefetchInFlight(queryClient);
+
+    factory.latest().receive(statusChangedFrame("t1", ACTIVE_STATUS_CHANGE));
+    expect(refetch.aborts()).toBe(1);
+    // The patch is kept and no request backs the query: idle and stale, not
+    // "fetching" with a rejected request behind it.
+    expect(
+      queryClient.getQueryState(sidebarNavigationQueryKey()),
+    ).toMatchObject({
+      fetchStatus: "idle",
+      isInvalidated: true,
+      status: "success",
+    });
+    expect(sidebarRows(queryClient)?.[0].status).toBe("active");
+
+    // The screen pops inside the debounce window.
+    refetch.unsubscribe();
+    vi.advanceTimersByTime(250);
+    expect(refetch.queryFn).toHaveBeenCalledTimes(1);
+    expect(getFetchingThreadListQueryKeys(queryClient)).toEqual([]);
+    // Nothing observes it: gcTime collects it instead of leaving a phantom
+    // fetch in the cache (query-core only removes an idle query).
+    vi.advanceTimersByTime(DEVICE_GC_TIME_MS);
+    expect(
+      queryClient
+        .getQueryCache()
+        .find({ queryKey: sidebarNavigationQueryKey(), exact: true }),
+    ).toBeUndefined();
+  });
+
+  it("leaves an aborted list fetch idle and stale when its observer is disabled before the flush, and refetches it on re-enable", () => {
+    const { factory, queryClient, invalidateSpy } = setup();
+    invalidateSpy.mockRestore();
+    const invalidateCalls = vi.spyOn(queryClient, "invalidateQueries");
+    const listKey = threadListQueryKey({
+      archived: false,
+      projectId: "proj_1",
+    });
+    queryClient.setQueryData<ThreadListEntry[]>(listKey, [
+      threadListEntry({ id: "t1" }),
+    ]);
+    const refetch = refetchInFlight<ThreadListEntry[]>(queryClient, listKey);
+
+    const socket = factory.latest();
+    socket.receive(statusChangedFrame("t1", ACTIVE_STATUS_CHANGE));
+    expect(refetch.aborts()).toBe(1);
+    // The typeahead is dismissed (`useThreadsList({ enabled: false })`)
+    // inside the debounce window: the flush restarts nothing and does not
+    // hand the restart to invalidateQueries' active-only refetch either.
+    refetch.setEnabled(false);
+    vi.advanceTimersByTime(250);
+    expect(refetch.queryFn).toHaveBeenCalledTimes(1);
+    expect(
+      invalidateCalls.mock.calls
+        .map(([filters]) => filters)
+        .filter(
+          (filters) =>
+            filters?.queryKey !== undefined &&
+            hashKey(filters.queryKey) === hashKey(listKey) &&
+            filters.refetchType !== "none",
+        ),
+    ).toEqual([]);
+    expect(queryClient.getQueryState(listKey)).toMatchObject({
+      fetchStatus: "idle",
+      isInvalidated: true,
+      status: "success",
+    });
+    expect(
+      queryClient.getQueryData<ThreadListEntry[]>(listKey)?.[0].status,
+    ).toBe("active");
+    // No phantom fetch for later pushes to abort and re-queue.
+    expect(getFetchingThreadListQueryKeys(queryClient)).toEqual([]);
+    socket.receive(statusChangedFrame("t9", ACTIVE_STATUS_CHANGE));
+    vi.advanceTimersByTime(250);
+    expect(refetch.queryFn).toHaveBeenCalledTimes(1);
+    expect(refetch.aborts()).toBe(1);
+
+    // Re-enabling refetches the stale list.
+    refetch.setEnabled(true);
+    expect(refetch.queryFn).toHaveBeenCalledTimes(2);
+    expect(queryClient.getQueryState(listKey)?.fetchStatus).toBe("fetching");
     refetch.unsubscribe();
   });
 

--- a/apps/mobile/src/lib/query/realtime-invalidation.ts
+++ b/apps/mobile/src/lib/query/realtime-invalidation.ts
@@ -450,13 +450,19 @@ export function threadPullRequestQueryKeysForCompletedTurn(
  * (~1 KB per unarchived thread) twice per turn. Applied synchronously, not
  * through the debounced map: a list fetch already in flight read the database
  * before this transition and would overwrite the patch when it lands, so it is
- * aborted right away — silently, so the query neither reverts the patch nor
- * enters an error state — and flagged stale. The restart is the caller's:
- * `installRealtimeInvalidation` coalesces it through the debounced map, so a
- * burst of pushes (a workflow fanning out children) restarts the fetch once
- * per flush rather than once per push. Returns the keys of the aborted
- * fetches; `exact`, because a partial match on the unfiltered list's key
- * would also restart every filtered list.
+ * aborted right away and flagged stale. The abort is silent (no error state)
+ * and reverts the query to its rollback point, which is the patch just
+ * written (query-core moves that point to the last `setQueryData`) or, for a
+ * list the patch left alone, the pre-fetch state: the patched rows survive
+ * and the query returns to `fetchStatus: "idle"`. It must not stay "fetching"
+ * with no request behind it: such a query is never garbage-collected, is
+ * re-selected by every later push, and reports a phantom fetch to the next
+ * observer. The restart is the caller's: `installRealtimeInvalidation`
+ * coalesces it through the debounced map, so a burst of pushes (a workflow
+ * fanning out children) restarts the fetch once per flush rather than once
+ * per push. Returns the keys of the aborted fetches; `exact`, because a
+ * partial match on the unfiltered list's key would also restart every
+ * filtered list.
  */
 export function applyThreadStatusChangeFromMessage(
   queryClient: QueryClient,
@@ -472,10 +478,12 @@ export function applyThreadStatusChangeFromMessage(
   );
   const abortedQueryKeys = getFetchingThreadListQueryKeys(queryClient);
   for (const queryKey of abortedQueryKeys) {
-    void queryClient.cancelQueries(
-      { exact: true, queryKey },
-      { revert: false, silent: true },
-    );
+    // `revert` (the default) is what returns the query to idle; a
+    // non-reverting silent cancel leaves `fetchStatus: "fetching"` with a
+    // rejected request behind it.
+    void queryClient.cancelQueries({ exact: true, queryKey }, { silent: true });
+    // A revert onto the patch write lands on a success state (`isInvalidated`
+    // false): flag the query stale again without restarting it.
     void queryClient.invalidateQueries({
       exact: true,
       queryKey,
@@ -620,11 +628,20 @@ export function installRealtimeInvalidation(
         .filter((entry) => !entry.exact)
         .map((entry) => entry.queryKey);
       for (const { queryKey, policy, exact } of entries) {
-        if (
-          exact &&
-          prefixes.some((prefix) => partialMatchKey(queryKey, prefix))
-        ) {
-          continue;
+        if (exact) {
+          // `invalidateQueries` restarts active queries only. The aborted
+          // fetch's observer may have left inside the debounce window (the
+          // screen popped, the typeahead was disabled): the query is already
+          // idle and stale from the abort, so the next mount, enable, or
+          // fetchQuery refetches it, and re-invalidating here would only mark
+          // stale a response that landed in between.
+          const query = queryClient
+            .getQueryCache()
+            .find({ queryKey, exact: true });
+          if (query === undefined || !query.isActive()) continue;
+          if (prefixes.some((prefix) => partialMatchKey(queryKey, prefix))) {
+            continue;
+          }
         }
         switch (policy) {
           case "timeline-paced":

--- a/apps/mobile/src/lib/query/realtime-invalidation.ts
+++ b/apps/mobile/src/lib/query/realtime-invalidation.ts
@@ -1,4 +1,7 @@
-import { createDebouncedCallbackScheduler } from "@bb/domain";
+import {
+  createDebouncedCallbackScheduler,
+  type ThreadStatusChangeMetadata,
+} from "@bb/domain";
 import type {
   ChangedMessage,
   SidebarBootstrapResponse,
@@ -11,6 +14,10 @@ import {
   type QueryClient,
   type QueryKey,
 } from "@tanstack/react-query";
+import {
+  getFetchingThreadListQueryKeys,
+  updateCachedThreadListStatusState,
+} from "@/data/threads/thread-list-cache";
 import type { MobileRealtime } from "../realtime/mobile-realtime";
 import {
   disposeTrailingActiveRefetches,
@@ -85,7 +92,10 @@ const INVALIDATION_MAX_WAIT_MS = 200;
 
 /**
  * Thread change kinds that alter what a thread list / sidebar shows. Timeline
- * streaming (`events-appended`) deliberately is not one of them.
+ * streaming (`events-appended`) deliberately is not one of them. A
+ * `status-changed` push that carries the rewritten row
+ * (`metadata.statusChange`) patches the cached rows in place instead
+ * (`applyThreadStatusChangeFromMessage`); only a bare one refetches.
  */
 const THREAD_LIST_AFFECTING_KINDS: ReadonlySet<ThreadChangeKind> =
   new Set<ThreadChangeKind>([
@@ -109,6 +119,26 @@ function threadListQueryKeys(): QueryKey[] {
     sidebarNavigationQueryKey(),
     threadSearchQueryKeyPrefix(),
   ];
+}
+
+/**
+ * The row fields a `status-changed` push carries. Producers that cannot
+ * resolve the post-transition runtime (stop, interrupt, host loss, environment
+ * provisioning) push the bare kind, and the lenient parser drops a row whose
+ * status this build does not know; both fall back to the list refetch.
+ */
+function threadStatusChangePatch(
+  message: ThreadChangedMessage,
+): { threadId: string; statusChange: ThreadStatusChangeMetadata } | null {
+  const statusChange = message.metadata?.statusChange;
+  if (
+    message.id === undefined ||
+    statusChange === undefined ||
+    !message.changes.includes("status-changed")
+  ) {
+    return null;
+  }
+  return { threadId: message.id, statusChange };
 }
 
 /**
@@ -177,10 +207,20 @@ export function queryKeysForChangedMessage(
         // a rewrite replays the last accepted run's options.
         keys.push(threadDefaultExecutionOptionsQueryKey(id));
       }
-      if (
-        message.changes.some((kind) => THREAD_LIST_AFFECTING_KINDS.has(kind))
-      ) {
-        keys.push(...threadListQueryKeys());
+      const listKinds = message.changes.filter((kind) =>
+        THREAD_LIST_AFFECTING_KINDS.has(kind),
+      );
+      if (listKinds.length > 0) {
+        if (
+          threadStatusChangePatch(message) !== null &&
+          listKinds.every((kind) => kind === "status-changed")
+        ) {
+          // The rows were patched in place; search result rows render status
+          // but are not list-shaped, so they still refetch.
+          keys.push(threadSearchQueryKeyPrefix());
+        } else {
+          keys.push(...threadListQueryKeys());
+        }
       }
       return keys;
     }
@@ -403,6 +443,33 @@ export function threadPullRequestQueryKeysForCompletedTurn(
 }
 
 /**
+ * Patch the cached thread lists and the sidebar from a `status-changed` push
+ * that carries the rewritten row (mirrors the web registry's
+ * `patchThreadListStatusState`) instead of refetching the sidebar bootstrap
+ * (~1 KB per unarchived thread) twice per turn. Applied synchronously, not
+ * through the debounced map: a list fetch already in flight read the database
+ * before this transition and would overwrite the patch when it lands, so it is
+ * cancelled and restarted right away. `exact`, because a partial match on
+ * the unfiltered list's key would also restart every filtered list.
+ */
+export function applyThreadStatusChangeFromMessage(
+  queryClient: QueryClient,
+  message: ChangedMessage,
+): void {
+  if (message.entity !== "thread") return;
+  const patch = threadStatusChangePatch(message);
+  if (patch === null) return;
+  updateCachedThreadListStatusState(
+    queryClient,
+    patch.threadId,
+    patch.statusChange,
+  );
+  for (const queryKey of getFetchingThreadListQueryKeys(queryClient)) {
+    void queryClient.invalidateQueries({ exact: true, queryKey });
+  }
+}
+
+/**
  * How one queued invalidation is applied on flush. The timeline window is the
  * only query with a streaming producer, so it is the only one that gets the
  * non-cancelling paced path (see `timeline-refetch-pacing.ts`).
@@ -542,6 +609,7 @@ export function installRealtimeInvalidation(
   });
 
   const unsubscribeChanged = realtime.onChanged((message) => {
+    applyThreadStatusChangeFromMessage(queryClient, message);
     const eviction = diffPatchEvictionForChangedMessage(message);
     if (eviction === "all") {
       pendingPatchEvictions = "all";

--- a/apps/mobile/src/lib/query/realtime-invalidation.ts
+++ b/apps/mobile/src/lib/query/realtime-invalidation.ts
@@ -11,6 +11,7 @@ import type {
 } from "@bb/server-contract";
 import {
   hashKey,
+  partialMatchKey,
   type QueryClient,
   type QueryKey,
 } from "@tanstack/react-query";
@@ -449,24 +450,39 @@ export function threadPullRequestQueryKeysForCompletedTurn(
  * (~1 KB per unarchived thread) twice per turn. Applied synchronously, not
  * through the debounced map: a list fetch already in flight read the database
  * before this transition and would overwrite the patch when it lands, so it is
- * cancelled and restarted right away. `exact`, because a partial match on
- * the unfiltered list's key would also restart every filtered list.
+ * aborted right away — silently, so the query neither reverts the patch nor
+ * enters an error state — and flagged stale. The restart is the caller's:
+ * `installRealtimeInvalidation` coalesces it through the debounced map, so a
+ * burst of pushes (a workflow fanning out children) restarts the fetch once
+ * per flush rather than once per push. Returns the keys of the aborted
+ * fetches; `exact`, because a partial match on the unfiltered list's key
+ * would also restart every filtered list.
  */
 export function applyThreadStatusChangeFromMessage(
   queryClient: QueryClient,
   message: ChangedMessage,
-): void {
-  if (message.entity !== "thread") return;
+): readonly QueryKey[] {
+  if (message.entity !== "thread") return [];
   const patch = threadStatusChangePatch(message);
-  if (patch === null) return;
+  if (patch === null) return [];
   updateCachedThreadListStatusState(
     queryClient,
     patch.threadId,
     patch.statusChange,
   );
-  for (const queryKey of getFetchingThreadListQueryKeys(queryClient)) {
-    void queryClient.invalidateQueries({ exact: true, queryKey });
+  const abortedQueryKeys = getFetchingThreadListQueryKeys(queryClient);
+  for (const queryKey of abortedQueryKeys) {
+    void queryClient.cancelQueries(
+      { exact: true, queryKey },
+      { revert: false, silent: true },
+    );
+    void queryClient.invalidateQueries({
+      exact: true,
+      queryKey,
+      refetchType: "none",
+    });
   }
+  return abortedQueryKeys;
 }
 
 /**
@@ -529,6 +545,11 @@ function strongerInvalidationPolicy(
 interface PendingInvalidation {
   queryKey: QueryKey;
   policy: TimelineInvalidationPolicy;
+  /**
+   * Match the key exactly (the restart of one aborted list fetch) rather
+   * than as a prefix (every invalidation a message maps to).
+   */
+  exact: boolean;
 }
 
 /**
@@ -592,7 +613,19 @@ export function installRealtimeInvalidation(
           removeEnvironmentDiffPatchQueries(queryClient, environmentId);
         }
       }
-      for (const { queryKey, policy } of entries) {
+      // A prefix invalidation in this window already refetches the list
+      // whose aborted fetch is queued for an exact restart; issuing both
+      // would start the fetch and abort-and-restart it in the same tick.
+      const prefixes = entries
+        .filter((entry) => !entry.exact)
+        .map((entry) => entry.queryKey);
+      for (const { queryKey, policy, exact } of entries) {
+        if (
+          exact &&
+          prefixes.some((prefix) => partialMatchKey(queryKey, prefix))
+        ) {
+          continue;
+        }
         switch (policy) {
           case "timeline-paced":
             invalidateTimelineQueryKeyPaced(queryClient, queryKey);
@@ -601,15 +634,40 @@ export function installRealtimeInvalidation(
             invalidateTimelineQueryKeyTerminal(queryClient, queryKey);
             break;
           case "default":
-            void queryClient.invalidateQueries({ queryKey });
+            void queryClient.invalidateQueries({ queryKey, exact });
             break;
         }
       }
     },
   });
 
+  const queueInvalidation = (
+    queryKey: QueryKey,
+    policy: TimelineInvalidationPolicy,
+    exact: boolean,
+  ): void => {
+    const hash = hashKey(queryKey);
+    const current = pending.get(hash);
+    pending.set(
+      hash,
+      current === undefined
+        ? { queryKey, policy, exact }
+        : {
+            queryKey,
+            policy: strongerInvalidationPolicy(current.policy, policy),
+            // A prefix match subsumes an exact one on the same key.
+            exact: current.exact && exact,
+          },
+    );
+  };
+
   const unsubscribeChanged = realtime.onChanged((message) => {
-    applyThreadStatusChangeFromMessage(queryClient, message);
+    // The patch is synchronous; the restart of the list fetches it aborted
+    // is coalesced with everything else in this window.
+    const restartKeys = applyThreadStatusChangeFromMessage(
+      queryClient,
+      message,
+    );
     const eviction = diffPatchEvictionForChangedMessage(message);
     if (eviction === "all") {
       pendingPatchEvictions = "all";
@@ -620,17 +678,18 @@ export function installRealtimeInvalidation(
       ...queryKeysForChangedMessage(message),
       ...threadPullRequestQueryKeysForCompletedTurn(queryClient, message),
     ];
-    if (keys.length === 0 && eviction === null) return;
+    if (keys.length === 0 && restartKeys.length === 0 && eviction === null) {
+      return;
+    }
+    for (const queryKey of restartKeys) {
+      queueInvalidation(queryKey, "default", true);
+    }
     for (const queryKey of keys) {
-      const hash = hashKey(queryKey);
-      const policy = invalidationPolicyForKey(message, queryKey);
-      const current = pending.get(hash);
-      pending.set(hash, {
+      queueInvalidation(
         queryKey,
-        policy: current
-          ? strongerInvalidationPolicy(current.policy, policy)
-          : policy,
-      });
+        invalidationPolicyForKey(message, queryKey),
+        false,
+      );
     }
     scheduler.schedule();
   });


### PR DESCRIPTION
## What was wrong

The Expo app refetched the whole sidebar on every status change (an internal performance sweep, finding M1): `status-changed` is in `THREAD_LIST_AFFECTING_KINDS`, so each push invalidated the sidebar query (`staleTime: Infinity`, 14 observers) and triggered a full `GET /sidebar-bootstrap` — 133 KB at least twice per agent turn per thread. The server already attaches `metadata.statusChange` (#2169) and the app parsed it, then never read it.

## What changed

`apps/mobile/src/data/threads/thread-list-cache.ts`, `apps/mobile/src/lib/query/realtime-invalidation.ts` (mirrors the web's #2169 path):

- `updateCachedThreadListStatusState` patches the matching row in every cached thread list and the sidebar with the web's identity guard (`if (!list.some(t => t.id === threadId)) return list`). Lists the mapper leaves untouched are not written at all; real writes keep the query's `dataUpdatedAt` and re-arm a pending invalidation, so inactive lists do not lose their refetch-on-remount flag.
- A `status-changed` push that carries the row no longer invalidates the list keys (only the thread and search keys); bare pushes (stop/interrupt, provisioning, cleanup) still refetch the lists.
- List fetches in flight when a patch lands are aborted synchronously (reverting to the already-patched state, so the query returns to `idle`) and restarted once per debounced flush; a burst of pushes restarts the 133 KB bootstrap once. Exact restarts are skipped when a prefix invalidation in the same flush covers them, and when the query has no active observer (it stays stale and idle for the next mount).
- Client-only: no server, daemon, SDK or contract change; no `HOST_DAEMON_PROTOCOL_VERSION` bump.

## How you verified

New tests in `apps/mobile/src/lib/query/realtime-invalidation.test.ts` and `apps/mobile/src/data/threads/thread-list-cache.test.ts`, each failing on the pre-fix code: row patch through the real socket bridge (sidebar and flat list rows updated, other project's `threads` array identity kept); key mapping (row-carrying push → thread + search keys only; bare push and mixed kinds → list keys); no-op patch leaves query state, `dataUpdatedAt` and `isInvalidated` untouched; errored invalidated sidebar stays invalidated; in-flight sidebar refetch aborted once and restarted on the flush with the stale body dropped; eight-push burst → one abort, one restart; observer leaving before the flush leaves the query idle and collectable; disabled observer refetches on re-enable; prefix invalidation subsumes an exact restart. Verified against `@tanstack/query-core` 5.90.20 semantics (`revert`, `silent`, `refetchType: "none"`, `isActive`).

On this branch: `pnpm exec turbo run typecheck` (76/76), `pnpm exec turbo run lint`, `pnpm exec turbo run test` (all packages green). Not done: a device run (tests are node/jsdom, not Hermes). Suggested manual check before merge: watch the sidebar through an agent turn, open the archived list and the @-typeahead, background/foreground the app.

Fixes: no issue — source is an internal performance sweep (finding M1).

> AGENT GENERATED
