### PR TITLE
Prevent timed-out preload setup from contaminating desktop tests

### DIFF
--- a/apps/desktop/test/preload-browser-api.test.ts
+++ b/apps/desktop/test/preload-browser-api.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppCommandId } from "@bb/domain";
 import type {
   BbDesktopApi,
@@ -166,8 +166,15 @@ function emitIpcPayload(args: EmitIpcPayloadArgs): void {
 }
 
 describe("desktop preload browser API", () => {
+  let api: BbDesktopApi;
+
+  // Vitest does not cancel a timed-out test body. Keep module loading in a
+  // hook so a slow transform cannot release stale commands into the next test.
+  beforeEach(async () => {
+    api = await loadPreload();
+  }, 30_000);
+
   it("exposes only the typed browser commands and forwards them over fixed channels", async () => {
-    const api = await loadPreload();
     const attachRequest = {
       tabId: "browser:a",
       url: "http://localhost:5173/",
@@ -305,8 +312,7 @@ describe("desktop preload browser API", () => {
     );
   }, 10_000);
 
-  it("converts zoomed renderer bounds to native window coordinates", async () => {
-    const api = await loadPreload();
+  it("converts zoomed renderer bounds to native window coordinates", () => {
     electronMock.setZoomFactor(1.25);
 
     api.browser.attach({
@@ -340,8 +346,7 @@ describe("desktop preload browser API", () => {
     ]);
   });
 
-  it("validates browser event payloads before notifying renderer listeners", async () => {
-    const api = await loadPreload();
+  it("validates browser event payloads before notifying renderer listeners", () => {
     const states: BbDesktopBrowserState[] = [];
     const openTabs: BbDesktopBrowserOpenTabRequest[] = [];
     const scopedOpenTabs: BbDesktopBrowserScopedOpenTabRequest[] = [];
@@ -506,8 +511,6 @@ describe("desktop preload browser API", () => {
   });
 
   it("routes the log viewer request to main and mirrors its availability", async () => {
-    const api = await loadPreload();
-
     await api.openServerDaemonLogs?.();
     expect(electronMock.invokeCalls).toContain(
       BB_DESKTOP_OPEN_SERVER_DAEMON_LOGS_CHANNEL,
@@ -532,9 +535,7 @@ describe("desktop preload browser API", () => {
     expect(api.serverDaemonLogsAvailable).toBe(true);
   });
 
-  it("answers unhandled close-window requests so main closes the window", async () => {
-    await loadPreload();
-
+  it("answers unhandled close-window requests so main closes the window", () => {
     emitIpcPayload({
       channel: BB_DESKTOP_CLOSE_WINDOW_REQUEST_CHANNEL,
       payload: null,


### PR DESCRIPTION
## What was wrong

`preload-browser-api.test.ts` reset Vitest's module registry and dynamically imported the preload inside every test body. Under contention, that import crossed the first test's 10-second timeout. Vitest reported the timeout but did not cancel the pending async body, so it resumed later and appended its 14 IPC sends to the shared `electronMock` after the following zoom test had reset it. That produced the observed 16 calls instead of 2. The failing [packages job](https://github.com/get-bb/bb/actions/runs/32773408314/job/97578795580) and the successful same-SHA rerun show this is timing-dependent rather than a regression from PR #2346.

## What changed

Moved the per-test preload reset/import into a `beforeEach` hook with a setup-specific 30-second timeout. Test command bodies now begin only after preload setup completes, so a slow transform cannot release stale commands into a later test. Module state is still reset for every test, and all production behavior and assertions are unchanged.

## How you verified

- Reproduced the exact failure on merge-base with a temporary Vitest transform that delayed `preload.ts` by 10.5 seconds: the first test timed out at 10 seconds and the next test received 16 sends.
- Re-ran the same delayed transform after the change: all 5 tests passed in 10.92 seconds.
- `pnpm exec vitest run --config vitest.config.ts test/preload-browser-api.test.ts` — 5 tests passed.
- `pnpm exec turbo run test typecheck build lint --filter=@bb/desktop --force` — 15/15 Turbo tasks passed; desktop test suite 35 files / 230 tests passed.

> AGENT GENERATED: by GPT-5.6-Sol
