### PR TITLE
Fix runtime polling after scheduler stalls

### DIFF
--- a/packages/agent-runtime/src/test/runtime-wait-helpers.test.ts
+++ b/packages/agent-runtime/src/test/runtime-wait-helpers.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { waitForRuntimeConditionUnsafe } from "./runtime-wait-helpers.js";
+
+describe("waitForRuntimeConditionUnsafe", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("rechecks the condition after polling resumes past the deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    let ready = false;
+    const waiting = expect(
+      waitForRuntimeConditionUnsafe(() => ready, {
+        label: "ready state",
+        timeoutMs: 50,
+        intervalMs: 10,
+      }),
+    ).resolves.toBeUndefined();
+
+    ready = true;
+    vi.setSystemTime(new Date("2026-01-01T00:00:01Z"));
+    await vi.runOnlyPendingTimersAsync();
+
+    await waiting;
+  });
+});

--- a/packages/agent-runtime/src/test/runtime-wait-helpers.ts
+++ b/packages/agent-runtime/src/test/runtime-wait-helpers.ts
@@ -171,9 +171,14 @@ export async function waitForRuntimeConditionUnsafe(
   const label = options.label ?? "condition";
   const deadline = Date.now() + timeoutMs;
 
-  while (Date.now() < deadline) {
+  while (true) {
+    // Observe state before enforcing the deadline: the worker may have been
+    // descheduled past it after the condition became true.
     if (condition()) {
       return;
+    }
+    if (Date.now() >= deadline) {
+      break;
     }
     const failFastMessage = options.failFast?.();
     if (failFastMessage) {


### PR DESCRIPTION
## What was wrong

The runtime polling helper checked its deadline before rechecking the predicate after each sleep. If a Vitest worker was descheduled past the deadline under package-shard contention, it exited the polling loop and threw without observing state that had already become true while it slept. That ordering explains the [same-SHA packages failure](https://github.com/get-bb/bb/actions/runs/32773414046/job/97583005982): the Codex topology case spent its full 10-second wait on an otherwise roughly 3.7-second path while other process-backed suites were heavily slowed.

## What changed

Reordered the shared runtime wait loop so it observes the predicate before enforcing the deadline on every wake. The timeout, polling interval, Codex topology assertion, and child-release behavior are unchanged. Added a fake-timer regression that advances the clock past the deadline while the polling sleep is pending and verifies that already-satisfied state still resolves. This is test infrastructure only; there is no server/daemon wire change and no `HOST_DAEMON_PROTOCOL_VERSION` bump.

## How you verified

- Deterministic pre-fix reproduction: advanced the clock past a 50 ms deadline after making the predicate true; the helper incorrectly reported `Timed out after 50ms waiting for ready state`. The same check resolves after the fix.
- `pnpm exec turbo run test --filter=@bb/agent-runtime --force -- src/test/runtime-wait-helpers.test.ts src/runtime.codex-topology.test.ts` — 2 files, 5 tests passed.
- `pnpm exec turbo run build typecheck test --filter=@bb/agent-runtime --force` — 6 Turbo tasks passed; full agent-runtime suite 22 files / 317 tests passed. (`@bb/agent-runtime` has no build script, so its build target is a no-op.)
- `pnpm exec prettier --check packages/agent-runtime/src/test/runtime-wait-helpers.ts packages/agent-runtime/src/test/runtime-wait-helpers.test.ts` — passed.

Fixes: no issue — exact open GitHub issue/PR and bb thread searches found no overlapping work.

> AGENT GENERATED: by GPT-5.6-Sol
