### PR TITLE
Separate Pi retry policy from lifecycle process coverage

### DIFF
--- a/plugins/provider-pi/src/bridge/bridge.lifecycle.test.ts
+++ b/plugins/provider-pi/src/bridge/bridge.lifecycle.test.ts
@@ -22,6 +22,9 @@ import { FULL_PERMISSION_OPTIONS, type FakePiBridgeHarness, startFakePiBridge } 
  * records each spawn and exit, and the pid is probed afterwards.
  */
 
+/** Nine serial real-child constructions plus time to observe their exits. */
+const FAILED_CONSTRUCTION_RESPONSE_DEADLINE_MS = 90_000;
+const FAILED_CONSTRUCTION_TEST_TIMEOUT_MS = 120_000;
 
 let harness: FakePiBridgeHarness;
 
@@ -142,14 +145,14 @@ it("a failed construction leaves no child", async () => {
     cwd: harness.workspaceDir,
     instructionMode: "append",
     options: { ...FULL_PERMISSION_OPTIONS, model: "other-provider/no-such-model" },
-  });
+  }, FAILED_CONSTRUCTION_RESPONSE_DEADLINE_MS);
   expect(response.error).toMatchObject({
     message: expect.stringContaining('did not start with model "other-provider/no-such-model"'),
   });
   const log = harness.readProcessLog();
   expect(log.spawned.length).toBeGreaterThan(1);
   await expectEveryChildGone(log.spawned.length);
-}, 90_000);
+}, FAILED_CONSTRUCTION_TEST_TIMEOUT_MS);
 
 it("the fork helper child exits once the fork is done", async () => {
   // The fake's extension runs the real SessionManager fork, so the source
@@ -241,13 +244,13 @@ it("a child's tool and prompt files go with the child, for a released thread and
     cwd: harness.workspaceDir,
     instructionMode: "append",
     options: { ...FULL_PERMISSION_OPTIONS, instructions: "be brief", model: "other-provider/no-such-model" },
-  });
+  }, FAILED_CONSTRUCTION_RESPONSE_DEADLINE_MS);
   expect(failed.error).toBeDefined();
   const log = harness.readProcessLog();
   expect(log.spawned.length).toBeGreaterThan(2);
   await expectEveryChildGone(log.spawned.length);
   await expectScratchFilesGone();
-}, 60_000);
+}, FAILED_CONSTRUCTION_TEST_TIMEOUT_MS);
 
 it("closing the catalog ends its child", async () => {
   const models = await harness.request((nextId += 1), "model/list", { cwd: harness.workspaceDir });

--- a/plugins/provider-pi/src/bridge/bridge.lifecycle.test.ts
+++ b/plugins/provider-pi/src/bridge/bridge.lifecycle.test.ts
@@ -22,9 +22,6 @@ import { FULL_PERMISSION_OPTIONS, type FakePiBridgeHarness, startFakePiBridge } 
  * records each spawn and exit, and the pid is probed afterwards.
  */
 
-/** Nine serial real-child constructions plus time to observe their exits. */
-const FAILED_CONSTRUCTION_RESPONSE_DEADLINE_MS = 90_000;
-const FAILED_CONSTRUCTION_TEST_TIMEOUT_MS = 120_000;
 
 let harness: FakePiBridgeHarness;
 
@@ -136,23 +133,22 @@ it("discard ends the child and removes the session file", async () => {
 }, 90_000);
 
 it("a failed construction leaves no child", async () => {
-  // A provider the catalog does not know passes the up-front check (pi may
-  // serve providers the catalog omits); the fake then starts on its default
-  // model, the bridge sees the mismatch after get_state, retries the spawn
-  // through the transient-auth window, and fails.
+  // Retry policy has deterministic unit coverage. This process-level case
+  // needs one real child to prove the bridge kills a failed construction.
+  vi.stubEnv("FAKE_PI_EXIT_BEFORE_FIRST_RESPONSE", "1");
   const response = await harness.request((nextId += 1), "thread/start", {
     threadId: "thr_lc_failed",
     cwd: harness.workspaceDir,
     instructionMode: "append",
-    options: { ...FULL_PERMISSION_OPTIONS, model: "other-provider/no-such-model" },
-  }, FAILED_CONSTRUCTION_RESPONSE_DEADLINE_MS);
+    options: FULL_PERMISSION_OPTIONS,
+  });
   expect(response.error).toMatchObject({
-    message: expect.stringContaining('did not start with model "other-provider/no-such-model"'),
+    message: expect.stringContaining("pi exited"),
   });
   const log = harness.readProcessLog();
-  expect(log.spawned.length).toBeGreaterThan(1);
-  await expectEveryChildGone(log.spawned.length);
-}, FAILED_CONSTRUCTION_TEST_TIMEOUT_MS);
+  expect(log.spawned).toHaveLength(1);
+  await expectEveryChildGone(1);
+}, 90_000);
 
 it("the fork helper child exits once the fork is done", async () => {
   // The fake's extension runs the real SessionManager fork, so the source
@@ -215,7 +211,7 @@ async function expectScratchFilesGone(): Promise<void> {
   }
 }
 
-it("a child's tool and prompt files go with the child, for a released thread and for every attempt of a failed construction", async () => {
+it("a child's tool and prompt files go with the child after release and failed construction", async () => {
   // The bridge process outlives every pi child it spawns, so a file written
   // for one child must not wait for the bridge's own temp dir to be removed.
   await harness.startThread("thr_lc_scratch", {
@@ -237,20 +233,21 @@ it("a child's tool and prompt files go with the child, for a released thread and
   await expectEveryChildGone(1);
   await expectScratchFilesGone();
 
-  // Every retry of the transient-auth window wrote its own set; each went
-  // with its detached child.
+  // A construction that exits before readiness still owns the files the
+  // bridge prepared for it, and its exit removes them.
+  vi.stubEnv("FAKE_PI_EXIT_BEFORE_FIRST_RESPONSE", "1");
   const failed = await harness.request((nextId += 1), "thread/start", {
     threadId: "thr_lc_scratch_failed",
     cwd: harness.workspaceDir,
     instructionMode: "append",
-    options: { ...FULL_PERMISSION_OPTIONS, instructions: "be brief", model: "other-provider/no-such-model" },
-  }, FAILED_CONSTRUCTION_RESPONSE_DEADLINE_MS);
+    options: { ...FULL_PERMISSION_OPTIONS, instructions: "be brief" },
+  });
   expect(failed.error).toBeDefined();
   const log = harness.readProcessLog();
-  expect(log.spawned.length).toBeGreaterThan(2);
-  await expectEveryChildGone(log.spawned.length);
+  expect(log.spawned).toHaveLength(2);
+  await expectEveryChildGone(2);
   await expectScratchFilesGone();
-}, FAILED_CONSTRUCTION_TEST_TIMEOUT_MS);
+}, 60_000);
 
 it("closing the catalog ends its child", async () => {
   const models = await harness.request((nextId += 1), "model/list", { cwd: harness.workspaceDir });

--- a/plugins/provider-pi/src/bridge/fake-pi-rpc.mjs
+++ b/plugins/provider-pi/src/bridge/fake-pi-rpc.mjs
@@ -48,6 +48,8 @@
  * - Fault knobs for the bridge's own tests: FAKE_PI_SPAWN_COUNTER_FILE counts
  *   spawns across processes and FAKE_PI_MISMATCH_FIRST_SPAWN=1 makes only the
  *   first spawn ignore `--model` (a transient model mismatch);
+ *   FAKE_PI_EXIT_BEFORE_FIRST_RESPONSE=1 exits after recording the spawn but
+ *   before importing the extension or reading a command;
  *   FAKE_PI_NO_SESSION_START=1 never emits session_start to the extension (so
  *   no `ready`); FAKE_PI_DROP_STEER_AT_END=1 ends a run with a queued steer
  *   still queued; FAKE_PI_STREAMING_AFTER_END=1 reports isStreaming after a
@@ -134,6 +136,9 @@ process.on("SIGTERM", () => {
   if (hangOnClose) return;
   exit();
 });
+if (process.env.FAKE_PI_EXIT_BEFORE_FIRST_RESPONSE === "1") {
+  exit();
+}
 
 const MODELS = [
   {

--- a/plugins/provider-pi/src/bridge/rpc-session.retry.test.ts
+++ b/plugins/provider-pi/src/bridge/rpc-session.retry.test.ts
@@ -1,0 +1,28 @@
+import { expect, it, vi } from "vitest";
+import { runPiTransientAuthConstruction } from "./rpc-session.js";
+
+it("exhausts the initial construction and eight transient-auth retries deterministically", async () => {
+  const errors = Array.from(
+    { length: 9 },
+    (_, index) => new Error(`mismatch ${index + 1}`),
+  );
+  const attempt = vi.fn(async () => ({
+    ok: false as const,
+    error: errors[attempt.mock.calls.length - 1]!,
+  }));
+  const discardFailedAttempt = vi.fn();
+  const waitBeforeRetry = vi.fn(async () => undefined);
+
+  await expect(
+    runPiTransientAuthConstruction({
+      attempt,
+      discardFailedAttempt,
+      isClosed: () => false,
+      waitBeforeRetry,
+    }),
+  ).rejects.toBe(errors[8]);
+
+  expect(attempt).toHaveBeenCalledTimes(9);
+  expect(discardFailedAttempt).toHaveBeenCalledTimes(8);
+  expect(waitBeforeRetry).toHaveBeenCalledTimes(8);
+});

--- a/plugins/provider-pi/src/bridge/rpc-session.ts
+++ b/plugins/provider-pi/src/bridge/rpc-session.ts
@@ -119,6 +119,38 @@ const CHANNEL_REQUEST_TIMEOUT_MS = 30_000;
 /** How long an `agent_end` waits for the extension's in-process leaf report. */
 const AGENT_END_LEAF_TIMEOUT_MS = 5_000;
 
+type PiSessionConstructionOutcome = { ok: true } | { ok: false; error: Error };
+
+function waitForPiTransientAuthRetry(): Promise<void> {
+  return new Promise((resolve) =>
+    setTimeout(resolve, PI_TRANSIENT_AUTH_RETRY_DELAY_MS),
+  );
+}
+
+/**
+ * Retry the transient model-resolution window without coupling its policy to
+ * child construction. Tests inject synchronous attempts and waits; production
+ * supplies real child construction and teardown.
+ */
+export async function runPiTransientAuthConstruction(args: {
+  attempt: () => Promise<PiSessionConstructionOutcome>;
+  discardFailedAttempt: () => void;
+  isClosed: () => boolean;
+  waitBeforeRetry: () => Promise<void>;
+}): Promise<void> {
+  for (let attempt = 0; ; attempt += 1) {
+    const outcome = await args.attempt();
+    if (outcome.ok) {
+      return;
+    }
+    if (attempt >= PI_TRANSIENT_AUTH_MAX_RETRIES || args.isClosed()) {
+      throw outcome.error;
+    }
+    args.discardFailedAttempt();
+    await args.waitBeforeRetry();
+  }
+}
+
 export interface PiRpcSessionState {
   model?: { provider?: string; id?: string; contextWindow?: number };
   thinkingLevel?: string;
@@ -198,30 +230,21 @@ export class PiRpcSession {
    * resolved its model): respawn a few times before failing.
    */
   async start(): Promise<void> {
-    for (let attempt = 0; ; attempt += 1) {
-      const outcome = await this.spawnAndVerify();
-      if (outcome.ok) {
-        return;
-      }
-      if (attempt >= PI_TRANSIENT_AUTH_MAX_RETRIES || this.closed) {
-        throw outcome.error;
-      }
-      // The failed attempt's child is detached before it is killed: its exit
-      // (async, possibly after the next attempt spawned) must neither report
-      // a session error for a thread still under construction nor touch the
-      // next child's readiness, leaf waiter, or processing state.
-      const failed = this.child;
-      this.child = undefined;
-      failed?.kill();
-      await new Promise((resolve) =>
-        setTimeout(resolve, PI_TRANSIENT_AUTH_RETRY_DELAY_MS),
-      );
-    }
+    await runPiTransientAuthConstruction({
+      attempt: () => this.spawnAndVerify(),
+      discardFailedAttempt: () => {
+        // A retried child is detached before it is killed: its late lines and
+        // exit must not touch the next child's state or report a session error.
+        const failed = this.child;
+        this.child = undefined;
+        failed?.kill();
+      },
+      isClosed: () => this.closed,
+      waitBeforeRetry: waitForPiTransientAuthRetry,
+    });
   }
 
-  private async spawnAndVerify(): Promise<
-    { ok: true } | { ok: false; error: Error }
-  > {
+  private async spawnAndVerify(): Promise<PiSessionConstructionOutcome> {
     const toolsFilePath = join(
       this.options.scratchDir,
       `pi-tools-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.json`,

--- a/plugins/provider-pi/src/bridge/test-support.ts
+++ b/plugins/provider-pi/src/bridge/test-support.ts
@@ -40,13 +40,17 @@ export const FULL_PERMISSION_OPTIONS = {
 const INITIALIZE_ID = 100;
 /** `startThread` numbers its requests from here, clear of any suite's own ids. */
 const FIRST_HARNESS_REQUEST_ID = 1_000_000;
+/** Longer than the kit's 15 s: every request here may cold-start a real child. */
 /**
- * Most requests cold-start one real child and use this deadline. Tests that
- * deliberately exhaust every transient-auth construction attempt can pass a
- * longer deadline to `request`, so the harness does not report a response
- * that is still legitimately on its way as missing.
+ * How long a request may take before the harness calls it unanswered. A
+ * construction the bridge retries (up to eight spawns through the
+ * transient-auth window, each a node child that imports the extension) runs
+ * several seconds per attempt on a starved CI runner, and the bridge's own
+ * readiness budget per attempt is a minute: the harness must outlive what
+ * the bridge is still legitimately waiting for, or it reports a response
+ * that was on its way as missing.
  */
-const DEFAULT_RESPONSE_DEADLINE_MS = 60_000;
+const RESPONSE_DEADLINE_MS = 60_000;
 
 const threadDeltaParamsSchema = z.object({
   threadId: z.string(),
@@ -79,7 +83,6 @@ export interface FakePiBridgeHarness {
     id: BridgeJsonRpcId,
     method: string,
     params: BridgeJsonRpcObject,
-    responseDeadlineMs?: number,
   ): Promise<BridgeJsonRpcOutputMessage>;
   /**
    * `thread/start` on the workspace in full mode (`extra` overrides and
@@ -137,14 +140,9 @@ export async function startFakePiBridge(
     sessionDir,
     messages: harness.messages,
     takeMessages: harness.takeMessages,
-    async request(
-      id,
-      method,
-      params,
-      responseDeadlineMs = DEFAULT_RESPONSE_DEADLINE_MS,
-    ) {
+    async request(id, method, params) {
       harness.sendRequest(id, method, params);
-      const deadline = Date.now() + responseDeadlineMs;
+      const deadline = Date.now() + RESPONSE_DEADLINE_MS;
       while (Date.now() < deadline) {
         const response = harness.messages.find((message) => message.id === id);
         if (response !== undefined) return response;
@@ -170,7 +168,7 @@ export async function startFakePiBridge(
         .flatMap((params) => params.deltas);
     },
     async waitFor(predicate, what) {
-      const deadline = Date.now() + DEFAULT_RESPONSE_DEADLINE_MS;
+      const deadline = Date.now() + RESPONSE_DEADLINE_MS;
       while (Date.now() < deadline) {
         if (predicate()) return;
         await new Promise((resolve) => setTimeout(resolve, 10));

--- a/plugins/provider-pi/src/bridge/test-support.ts
+++ b/plugins/provider-pi/src/bridge/test-support.ts
@@ -40,17 +40,13 @@ export const FULL_PERMISSION_OPTIONS = {
 const INITIALIZE_ID = 100;
 /** `startThread` numbers its requests from here, clear of any suite's own ids. */
 const FIRST_HARNESS_REQUEST_ID = 1_000_000;
-/** Longer than the kit's 15 s: every request here may cold-start a real child. */
 /**
- * How long a request may take before the harness calls it unanswered. A
- * construction the bridge retries (up to eight spawns through the
- * transient-auth window, each a node child that imports the extension) runs
- * several seconds per attempt on a starved CI runner, and the bridge's own
- * readiness budget per attempt is a minute: the harness must outlive what
- * the bridge is still legitimately waiting for, or it reports a response
- * that was on its way as missing.
+ * Most requests cold-start one real child and use this deadline. Tests that
+ * deliberately exhaust every transient-auth construction attempt can pass a
+ * longer deadline to `request`, so the harness does not report a response
+ * that is still legitimately on its way as missing.
  */
-const RESPONSE_DEADLINE_MS = 60_000;
+const DEFAULT_RESPONSE_DEADLINE_MS = 60_000;
 
 const threadDeltaParamsSchema = z.object({
   threadId: z.string(),
@@ -83,6 +79,7 @@ export interface FakePiBridgeHarness {
     id: BridgeJsonRpcId,
     method: string,
     params: BridgeJsonRpcObject,
+    responseDeadlineMs?: number,
   ): Promise<BridgeJsonRpcOutputMessage>;
   /**
    * `thread/start` on the workspace in full mode (`extra` overrides and
@@ -140,9 +137,14 @@ export async function startFakePiBridge(
     sessionDir,
     messages: harness.messages,
     takeMessages: harness.takeMessages,
-    async request(id, method, params) {
+    async request(
+      id,
+      method,
+      params,
+      responseDeadlineMs = DEFAULT_RESPONSE_DEADLINE_MS,
+    ) {
       harness.sendRequest(id, method, params);
-      const deadline = Date.now() + RESPONSE_DEADLINE_MS;
+      const deadline = Date.now() + responseDeadlineMs;
       while (Date.now() < deadline) {
         const response = harness.messages.find((message) => message.id === id);
         if (response !== undefined) return response;
@@ -168,7 +170,7 @@ export async function startFakePiBridge(
         .flatMap((params) => params.deltas);
     },
     async waitFor(predicate, what) {
-      const deadline = Date.now() + RESPONSE_DEADLINE_MS;
+      const deadline = Date.now() + DEFAULT_RESPONSE_DEADLINE_MS;
       while (Date.now() < deadline) {
         if (predicate()) return;
         await new Promise((resolve) => setTimeout(resolve, 10));


### PR DESCRIPTION
## What was wrong

The Pi lifecycle test coupled two separate contracts. To prove that a failed construction leaves no child, it requested a permanently mismatched model. Production correctly treats an initial mismatch as a transient auth race and retries eight times, so this single lifecycle assertion launched nine real Node children in series and imported the real Pi extension nine times. The test asserted only that more than one child spawned and that all children exited; it did not need nine real processes to prove cleanup. Under packages-shard contention, those avoidable serial launches crossed the harness's unchanged 60-second response deadline and produced `no response to thread/start` in the [failed packages job on PR #2349](https://github.com/get-bb/bb/actions/runs/32773414046/job/97578813957).

## What changed

The retry policy and real-process lifecycle coverage are now separate:

- `runPiTransientAuthConstruction` contains the unchanged production policy and accepts injected construction, discard, closed-state, and wait operations. A zero-process test deterministically proves one initial attempt plus eight retries, eight failed-attempt discards, and propagation of the ninth error.
- The existing real-process transient-mismatch test still proves that a mismatched child is killed, a replacement child succeeds, and no construction-time session error leaks.
- The failed-construction lifecycle test now uses a fake-Pi fault that exits before its first response. It launches one real child and still verifies the bridge error, exact spawn count, observed process exit, and no child left behind.
- The scratch-file lifecycle case uses the same one-process construction failure and verifies its tool/prompt files disappear after the child exits.

The earlier timeout-only changes were reverted: the shared request deadline remains 60 seconds, and the existing lifecycle wrappers remain 90 and 60 seconds. Production retry count, delay, child detachment, and error behavior are unchanged. This does not alter the host-daemon wire protocol, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

Before edits, the parent and worker independently confirmed that `HEAD`, `origin/main`, and `git merge-base HEAD origin/main` all equaled `21cb6b68b8fdffe2cd576f11c8af500f98d22c11`, with a clean worktree. Exact GitHub issue/PR and bb thread searches found no overlapping lifecycle fix; PRs #2337 and #2342 cover different provider-pi signatures.

The original coupled test reproduced the exact CI error under 256 CPU competitors at 61.288 seconds: `Error: no response to thread/start`. With the structural split and the original clocks restored, the identical stress command passed with 150 milliseconds of lifecycle test time (7.73 seconds total including imports). The deterministic nine-attempt policy test completes in 1–2 milliseconds.

- Focused retry-policy and failed-construction coverage — 3 passed, 6 skipped
- `pnpm exec turbo run test --filter=bb-plugin-provider-pi --force` — 18 files, 105 tests passed
- `pnpm exec turbo run typecheck --filter=bb-plugin-provider-pi --force` — 4 Turbo tasks passed
- `pnpm exec turbo run build --filter=@bb/server --force` — 4 Turbo tasks passed
- `pnpm exec oxfmt plugins/provider-pi/src/bridge/rpc-session.retry.test.ts --check` — passed
- `git diff origin/main --check` — passed

> AGENT GENERATED: by GPT-5.6-Sol
