### PR TITLE
Wait for Codex fixture children before workspace cleanup

### DIFF
--- a/plugins/provider-codex/src/bridge/bridge.archived-rebuild.test.ts
+++ b/plugins/provider-codex/src/bridge/bridge.archived-rebuild.test.ts
@@ -74,10 +74,43 @@ afterEach(async () => {
     activeTurnId: null,
   });
   await harness.waitForResponse(cleanupId).catch(() => undefined);
+  await waitForAppServerChildrenToExit();
   harness.restore();
   vi.unstubAllEnvs();
   rmSync(workspaceDir, { recursive: true, force: true });
 });
+
+function spawnedAppServerPids(): number[] {
+  return readFileSync(processLogPath, "utf8")
+    .split("\n")
+    .filter((line) => line.startsWith("spawn:"))
+    .map((line) => Number(line.split(":")[1]));
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && Reflect.get(error, "code") === "ESRCH") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function waitForAppServerChildrenToExit(): Promise<void> {
+  const childPids = spawnedAppServerPids();
+  const deadline = Date.now() + 15_000;
+  while (childPids.some(processIsAlive)) {
+    if (Date.now() > deadline) {
+      throw new Error(
+        `Timed out waiting for app-server children to exit: ${JSON.stringify(childPids.filter(processIsAlive))}`,
+      );
+    }
+    await new Promise((resolveTick) => setTimeout(resolveTick, 20));
+  }
+}
 
 async function resumeThread(): Promise<void> {
   harness.sendRequest(1, "thread/resume", {


### PR DESCRIPTION
## What was wrong

The archived-rebuild test treated the `thread/stop` response as a child-process exit boundary, but Codex release currently sends SIGTERM and acknowledges immediately. The fake app-server writes an `exit:<pid>:<ppid>` line into the test workspace from its SIGTERM handler, so under contention recursive cleanup could remove the existing files and then race that late append. In the failing [packages job](https://github.com/get-bb/bb/actions/runs/32777064554/job/97590441512), `rmSync` consequently failed with `ENOTEMPTY`. A local 400-run/12-way stress reproduced 2 failures; both leftover directories contained only the exit line recreated after deletion had begun.

## What changed

The archived-rebuild teardown now reads every fake app-server PID recorded by the lifecycle fixture and waits until the OS reports all of them exited before removing the workspace. The 15-second deadline only diagnoses a child that failed to exit; the completion condition is process death, not elapsed time.

This keeps the real child-process rebuild and release coverage intact. It does not retry or ignore `rmSync`, increase a timeout, or change production/provider wire behavior, so no host-daemon protocol bump is needed. Retrying cleanup would hide the ownership race; changing production `thread/stop` response timing would broaden the provider contract when this isolated harness already owns both the child lifecycle log and the temporary workspace.

## How you verified

- Fail-before: identical 400-run/12-way focused stress failed 2/400 with `ENOTEMPTY`, once in each scenario; the surviving directories contained only a late child `exit` append.
- Pass-after: identical 400-run/12-way focused stress passed 400/400.
- Focused Vitest file: 2 tests passed.
- `pnpm exec turbo run test --filter=bb-plugin-provider-codex --force`: 24 files / 238 tests passed.
- `pnpm exec turbo run typecheck --filter=bb-plugin-provider-codex`: 4 Turbo tasks passed.
- `pnpm exec turbo run build --filter=@bb/server`: 4 Turbo tasks passed.
- `pnpm exec oxfmt --check plugins/provider-codex/src/bridge/bridge.archived-rebuild.test.ts` and `git diff --check` passed.

> AGENT GENERATED: by GPT-5.6-Sol
