### PR TITLE
Separate declaration key coverage from lifecycle startup

### DIFF
--- a/packages/agent-runtime/src/bridge-launch-process-key.test.ts
+++ b/packages/agent-runtime/src/bridge-launch-process-key.test.ts
@@ -37,4 +37,26 @@ describe("bridgeLaunchProcessKey", () => {
       }),
     );
   });
+
+  it("changes with each capability declaration at the same artifact hash", () => {
+    const renamed: AgentRuntimeBridgeLaunch = {
+      ...base,
+      capabilities: {
+        ...base.capabilities,
+        supportsThreadRename: true,
+      },
+    };
+    const rewound: AgentRuntimeBridgeLaunch = {
+      ...renamed,
+      capabilities: { ...renamed.capabilities, fork: "tip" },
+    };
+
+    expect(
+      new Set(
+        [base, renamed, rewound].map((launch) =>
+          bridgeLaunchProcessKey(launch),
+        ),
+      ),
+    ).toHaveLength(3);
+  });
 });

--- a/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.process-lifecycle.test.ts
@@ -914,6 +914,9 @@ describe("createAgentRuntime process lifecycle", () => {
   // runtime.recovery.test.ts.
 
   it("gives a changed declaration its own bridge process at the same artifact hash", async () => {
+    // bridge-launch-process-key.test.ts deterministically covers successive
+    // declaration changes. This lifecycle boundary starts the minimum two
+    // real processes needed to prove reuse and distinction end to end.
     const record = createScriptedEchoRequestRecord();
     const bridgeLaunch: AgentRuntimeBridgeLaunch = createScriptedEchoLaunch({
       pluginId: "provider-declared",
@@ -964,20 +967,6 @@ describe("createAgentRuntime process lifecycle", () => {
       });
       // A changed declaration at the same artifact hash is a new process.
       expect(initializeCount()).toBe(2);
-
-      const rewound: AgentRuntimeBridgeLaunch = {
-        ...updatedDeclaration,
-        capabilities: { ...updatedDeclaration.capabilities, fork: "tip" },
-      };
-      await runtime.startThread({
-        bridgeLaunch: rewound,
-        environmentId: "env-1",
-        threadId: "t4",
-        projectId: "p1",
-        providerId: "declared",
-        options: fullRuntimeOptions,
-      });
-      expect(initializeCount()).toBe(3);
     } finally {
       await runtime.shutdown();
     }


### PR DESCRIPTION
## What was wrong

PR #2084 removed avoidable TypeScript fixture transforms from this test, but the unified provider-harness work in #2325 later moved it back onto the TypeScript scripted-echo bridge while preserving three serial real-process launches. The packages shard makes each tsx-backed startup compete with many other workers; the redundant third launch pushed the test over its unchanged 15-second cap. Under controlled contention, the request log reached the third process's initialize request but timed out before its thread/start request, confirming cumulative process startup as the cause rather than a polling deadline. No bridge process remained after the timed-out worker exited.

## What changed

Successive capability-declaration fingerprints at one artifact hash now have deterministic coverage in bridge-launch-process-key.test.ts. The end-to-end lifecycle test retains the minimum real-process boundary: two equal declarations share one initialized bridge, then one changed declaration initializes a distinct second bridge. This keeps assertions for hangs, process reuse, and process distinction while removing the third serial launch. The 15-second timeout is unchanged. This is test-only; there is no production, wire, CLI, guide, or protocol-version change.

I rejected a timeout increase because scheduler contention is only the reproduction condition. I also kept two real bridges instead of replacing the lifecycle boundary with an injected process factory, because two processes are the minimum needed to prove end-to-end distinction.

## How you verified

- Unchanged baseline, unloaded: focused test passed in 596ms.
- Unchanged baseline under 192 and 384 CPU competitors: passed in 7.484s and 11.895s.
- Unchanged baseline under 576 CPU competitors: reproduced the exact failure at 15.009s with Test timed out in 15000ms.
- Changed test under the identical 576-competitor condition: passed in 11.052s with the same timeout; no scripted bridge process remained afterward.
- Changed test, unloaded: 330ms; 10/10 fresh Turbo/Vitest repetitions passed (about 0.31s when reported).
- pnpm exec turbo run test --filter=@bb/agent-runtime --force --output-logs=full -- src/bridge-launch-process-key.test.ts (2 passed).
- pnpm exec turbo run test --filter=@bb/agent-runtime --force --output-logs=full -- --project '@bb/agent-runtime:isolated' src/runtime.process-lifecycle.test.ts (35 passed).
- pnpm exec turbo run test --filter=@bb/agent-runtime --force --output-logs=full (21 files, 317 tests passed).
- pnpm exec turbo run typecheck --filter=@bb/agent-runtime --force --output-logs=full (passed).
- pnpm exec turbo run build --filter=@bb/agent-runtime --force --output-logs=full (upstream generation passed; this package has no build task).
- pnpm exec turbo run lint --filter=@bb/agent-runtime --force --output-logs=full (this package has no lint task), plus targeted oxlint, oxfmt --check, and git diff --check (passed).

> AGENT GENERATED: by GPT-5.6-Sol
