### PR TITLE
Refresh active bb Connect sessions

### DIFF
--- a/apps/connect/package.json
+++ b/apps/connect/package.json
@@ -16,10 +16,12 @@
   },
   "devDependencies": {
     "@bb/tsconfig": "workspace:*",
+    "@better-auth/drizzle-adapter": "^1.6.23",
     "@cloudflare/workers-types": "^4.20260610.0",
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.0.0",
     "better-sqlite3": "12.10.0",
+    "better-auth": "^1.6.23",
     "esbuild": "^0.28.1",
     "miniflare": "^4.20260701.0",
     "typescript": "npm:@typescript/typescript6@^6.0.2",

--- a/apps/connect/src/account-session.ts
+++ b/apps/connect/src/account-session.ts
@@ -1,11 +1,29 @@
 type AuthFetch = (request: Request) => Promise<Response>;
 
+interface HeadersWithGetSetCookie extends Headers {
+  getSetCookie(): string[];
+}
+
+function hasGetSetCookie(headers: Headers): headers is HeadersWithGetSetCookie {
+  return (
+    "getSetCookie" in headers && typeof headers.getSetCookie === "function"
+  );
+}
+
+function getSetCookies(headers: Headers): string[] {
+  // Node implements the standard API; the Workerd types/runtime expose the
+  // older getAll API for preserving separate Set-Cookie field values.
+  return hasGetSetCookie(headers)
+    ? headers.getSetCookie()
+    : headers.getAll("set-cookie");
+}
+
 /** Let the account worker's Better Auth route own refresh and cookie policy. */
-export async function refreshAccountSessionCookie(
+export async function refreshAccountSessionCookies(
   cookieHeader: string,
   accountAppUrl: string,
   authFetch: AuthFetch,
-): Promise<string | null> {
+): Promise<string[] | null> {
   try {
     const url = new URL("/api/auth/get-session", accountAppUrl);
     url.searchParams.set("disableCookieCache", "true");
@@ -23,7 +41,8 @@ export async function refreshAccountSessionCookie(
     ) {
       return null;
     }
-    return response.headers.get("set-cookie");
+    const setCookies = getSetCookies(response.headers);
+    return setCookies.length === 0 ? null : setCookies;
   } catch (error) {
     console.error("bb connect: session refresh failed", error);
     return null;

--- a/apps/connect/src/account-session.ts
+++ b/apps/connect/src/account-session.ts
@@ -1,0 +1,31 @@
+type AuthFetch = (request: Request) => Promise<Response>;
+
+/** Let the account worker's Better Auth route own refresh and cookie policy. */
+export async function refreshAccountSessionCookie(
+  cookieHeader: string,
+  accountAppUrl: string,
+  authFetch: AuthFetch,
+): Promise<string | null> {
+  try {
+    const url = new URL("/api/auth/get-session", accountAppUrl);
+    url.searchParams.set("disableCookieCache", "true");
+    const response = await authFetch(
+      new Request(url, { headers: { cookie: cookieHeader } }),
+    );
+    if (!response.ok) return null;
+
+    const body: unknown = await response.json();
+    if (
+      typeof body !== "object" ||
+      body === null ||
+      !("session" in body) ||
+      !("user" in body)
+    ) {
+      return null;
+    }
+    return response.headers.get("set-cookie");
+  } catch (error) {
+    console.error("bb connect: session refresh failed", error);
+    return null;
+  }
+}

--- a/apps/connect/src/cache.ts
+++ b/apps/connect/src/cache.ts
@@ -30,6 +30,12 @@ function isCacheable(resp: Response): boolean {
   return maxAge ? Number(maxAge[1]) >= MIN_CACHEABLE_MAX_AGE : false;
 }
 
+export interface CacheResult {
+  /** True for both edge-cache hits and cacheable origin misses. */
+  cacheable: boolean;
+  response: Response;
+}
+
 /**
  * Serve `request` from the edge cache when possible, else run `fetchOrigin`
  * (the tunnel) and populate the cache when the response is cacheable.
@@ -42,8 +48,10 @@ export async function serveWithCache(
   namespace: string,
   ctx: ExecutionContext,
   fetchOrigin: () => Promise<Response>,
-): Promise<Response> {
-  if (request.method !== "GET") return fetchOrigin();
+): Promise<CacheResult> {
+  if (request.method !== "GET") {
+    return { cacheable: false, response: await fetchOrigin() };
+  }
 
   const url = new URL(request.url);
   const key = cacheKey(namespace, url);
@@ -57,7 +65,7 @@ export async function serveWithCache(
     // labelled text/html. This is NOT symmetric with the miss path below.
     const r = rebuiltResponse(hit.body, hit);
     r.headers.set("x-bb-cache", "hit");
-    return r;
+    return { cacheable: true, response: r };
   }
 
   const resp = await fetchOrigin();
@@ -70,7 +78,7 @@ export async function serveWithCache(
     // this one pre-encoded would advertise a gzip body that isn't gzipped.
     const r = new Response(resp.body, resp);
     r.headers.set("x-bb-cache", "miss");
-    return r;
+    return { cacheable: true, response: r };
   }
-  return resp;
+  return { cacheable: false, response: resp };
 }

--- a/apps/connect/src/session.test.ts
+++ b/apps/connect/src/session.test.ts
@@ -26,7 +26,7 @@ import {
   verifyMachineCredentialDetails,
   verifySessionCookieDetails,
 } from "./session.js";
-import { refreshAccountSessionCookie } from "./account-session.js";
+import { refreshAccountSessionCookies } from "./account-session.js";
 import { assignMachineLabel } from "./machine-label.js";
 
 // Real in-memory SQLite (never mock the DB). resolveLabel accepts any Drizzle
@@ -460,7 +460,7 @@ describe("account session refresh", () => {
     const cookie = await signedSessionCookie(token, secret);
     const beforeRefresh = Date.now();
 
-    const setCookie = await refreshAccountSessionCookie(
+    const setCookies = await refreshAccountSessionCookies(
       `__Secure-better-auth.session_token=${cookie}`,
       "https://getbb.app",
       createAuthFetch("https://getbb.app", "getbb.app"),
@@ -477,10 +477,11 @@ describe("account session refresh", () => {
     expect(refreshed?.expiresAt.getTime()).toBeLessThanOrEqual(
       afterRefresh + expiresInMs,
     );
-    expect(setCookie).toContain("__Secure-better-auth.session_token=");
-    expect(setCookie).toContain("Max-Age=604800");
-    expect(setCookie).toContain("Domain=.getbb.app");
-    expect(setCookie).toContain("Secure");
+    expect(setCookies).toHaveLength(1);
+    expect(setCookies?.[0]).toContain("__Secure-better-auth.session_token=");
+    expect(setCookies?.[0]).toContain("Max-Age=604800");
+    expect(setCookies?.[0]).toContain("Domain=.getbb.app");
+    expect(setCookies?.[0]).toContain("Secure");
   });
 
   it("leaves a fresh session unchanged before the update-age boundary", async () => {
@@ -491,7 +492,7 @@ describe("account session refresh", () => {
     const cookie = await signedSessionCookie(token, secret);
 
     await expect(
-      refreshAccountSessionCookie(
+      refreshAccountSessionCookies(
         `__Secure-better-auth.session_token=${cookie}`,
         "https://getbb.app",
         createAuthFetch("https://getbb.app", "getbb.app"),
@@ -513,14 +514,36 @@ describe("account session refresh", () => {
     seedSession(token, refreshAt, refreshAt + expiresInMs - updateAgeMs);
     const cookie = await signedSessionCookie(token, secret);
 
-    const setCookie = await refreshAccountSessionCookie(
+    const setCookies = await refreshAccountSessionCookies(
       `better-auth.session_token=${cookie}`,
       "http://bb.localhost:42745",
       createAuthFetch("http://bb.localhost:42745", "bb.localhost"),
     );
-    expect(setCookie).toContain("better-auth.session_token=");
-    expect(setCookie).toContain("Domain=.bb.localhost");
-    expect(setCookie).not.toContain("Secure");
+    expect(setCookies).toHaveLength(1);
+    expect(setCookies?.[0]).toContain("better-auth.session_token=");
+    expect(setCookies?.[0]).toContain("Domain=.bb.localhost");
+    expect(setCookies?.[0]).not.toContain("Secure");
+  });
+
+  it("preserves multiple Better Auth cookies as separate values", async () => {
+    const headers = new Headers();
+    headers.append("set-cookie", "session=renewed; Path=/; HttpOnly");
+    headers.append("set-cookie", "session-data=cached; Path=/; HttpOnly");
+
+    await expect(
+      refreshAccountSessionCookies(
+        "session=old",
+        "https://getbb.app",
+        async () =>
+          Response.json(
+            { session: { id: "session" }, user: { id: "user" } },
+            { headers },
+          ),
+      ),
+    ).resolves.toEqual([
+      "session=renewed; Path=/; HttpOnly",
+      "session-data=cached; Path=/; HttpOnly",
+    ]);
   });
 });
 

--- a/apps/connect/src/session.test.ts
+++ b/apps/connect/src/session.test.ts
@@ -24,6 +24,7 @@ import {
   markMachineSeen,
   resolveLabel,
   verifyMachineCredentialDetails,
+  verifySessionCookieDetails,
 } from "./session.js";
 import { refreshAccountSessionCookie } from "./account-session.js";
 import { assignMachineLabel } from "./machine-label.js";
@@ -417,6 +418,39 @@ describe("account session refresh", () => {
     });
     return (request: Request) => auth.handler(request);
   }
+
+  it("reports Better Auth's update-age boundary from the session expiry", async () => {
+    const checkedAt = Date.now();
+    const freshToken = `fresh-${crypto.randomUUID()}`;
+    const dueToken = `due-${crypto.randomUUID()}`;
+    seedSession(freshToken, checkedAt, checkedAt + expiresInMs);
+    seedSession(
+      dueToken,
+      checkedAt,
+      checkedAt + expiresInMs - updateAgeMs - 1000,
+    );
+
+    await expect(
+      verifySessionCookieDetails(
+        await signedSessionCookie(freshToken, secret),
+        secret,
+        db,
+      ),
+    ).resolves.toEqual({
+      userId: `user-${freshToken}`,
+      needsRefresh: false,
+    });
+    await expect(
+      verifySessionCookieDetails(
+        await signedSessionCookie(dueToken, secret),
+        secret,
+        db,
+      ),
+    ).resolves.toEqual({
+      userId: `user-${dueToken}`,
+      needsRefresh: true,
+    });
+  });
 
   it("lets Better Auth renew the database session and production cookie", async () => {
     const refreshAt = Date.now();

--- a/apps/connect/src/session.test.ts
+++ b/apps/connect/src/session.test.ts
@@ -454,6 +454,58 @@ describe("account session refresh", () => {
       refreshSessionCookie(`${cookie}forged`, secret, db, refreshAt),
     ).resolves.toBe(false);
   });
+
+  it("reissues the cookie without shortening a session another request renewed", async () => {
+    const refreshAt = Date.now();
+    const token = `session-${crypto.randomUUID()}`;
+    const oldExpiresAt = refreshAt + expiresInMs - updateAgeMs;
+    seedSession(token, refreshAt, oldExpiresAt);
+    const cookie = await signedSessionCookie(token, secret);
+
+    await expect(verifySessionCookie(cookie, secret, db)).resolves.toBe(
+      `user-${token}`,
+    );
+    const winnerExpiresAt = refreshAt + expiresInMs;
+    const winnerUpdatedAt = refreshAt - 1;
+    db.update(session)
+      .set({
+        expiresAt: new Date(winnerExpiresAt),
+        updatedAt: new Date(winnerUpdatedAt),
+      })
+      .where(eq(session.token, token))
+      .run();
+
+    await expect(
+      refreshSessionCookie(cookie, secret, db, refreshAt),
+    ).resolves.toBe(true);
+    const current = db
+      .select({
+        expiresAt: session.expiresAt,
+        updatedAt: session.updatedAt,
+      })
+      .from(session)
+      .where(eq(session.token, token))
+      .get();
+    expect(current?.expiresAt.getTime()).toBe(winnerExpiresAt);
+    expect(current?.updatedAt.getTime()).toBe(winnerUpdatedAt);
+  });
+
+  it("does not reissue the cookie when a cached session was deleted", async () => {
+    const refreshAt = Date.now();
+    const token = `session-${crypto.randomUUID()}`;
+    const oldExpiresAt = refreshAt + expiresInMs - updateAgeMs;
+    seedSession(token, refreshAt, oldExpiresAt);
+    const cookie = await signedSessionCookie(token, secret);
+
+    await expect(verifySessionCookie(cookie, secret, db)).resolves.toBe(
+      `user-${token}`,
+    );
+    db.delete(session).where(eq(session.token, token)).run();
+
+    await expect(
+      refreshSessionCookie(cookie, secret, db, refreshAt),
+    ).resolves.toBe(false);
+  });
 });
 
 describe("machine credential presence", () => {

--- a/apps/connect/src/session.test.ts
+++ b/apps/connect/src/session.test.ts
@@ -2,6 +2,8 @@ import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import Database from "better-sqlite3";
+import { drizzleAdapter } from "@better-auth/drizzle-adapter";
+import { betterAuth } from "better-auth/minimal";
 import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -20,11 +22,10 @@ import {
 import {
   MACHINE_LAST_SEEN_WRITE_INTERVAL_MS,
   markMachineSeen,
-  refreshSessionCookie,
   resolveLabel,
   verifyMachineCredentialDetails,
-  verifySessionCookie,
 } from "./session.js";
+import { refreshAccountSessionCookie } from "./account-session.js";
 import { assignMachineLabel } from "./machine-label.js";
 
 // Real in-memory SQLite (never mock the DB). resolveLabel accepts any Drizzle
@@ -373,7 +374,7 @@ describe("resolveLabel — label → server row (multi-server)", () => {
 });
 
 describe("account session refresh", () => {
-  const secret = "test-better-auth-secret";
+  const secret = "test-better-auth-secret-32-chars";
   const expiresInMs = CONNECT_SESSION_EXPIRES_IN_SECONDS * 1000;
   const updateAgeMs = CONNECT_SESSION_UPDATE_AGE_SECONDS * 1000;
 
@@ -395,41 +396,73 @@ describe("account session refresh", () => {
       .run();
   }
 
-  it("renews at Better Auth's update-age boundary and refreshes only once", async () => {
+  function createAuthFetch(baseURL: string, baseDomain: string) {
+    const auth = betterAuth({
+      secret,
+      baseURL,
+      database: drizzleAdapter(db, {
+        provider: "sqlite",
+        schema: { session, user },
+      }),
+      session: {
+        expiresIn: CONNECT_SESSION_EXPIRES_IN_SECONDS,
+        updateAge: CONNECT_SESSION_UPDATE_AGE_SECONDS,
+      },
+      advanced: {
+        crossSubDomainCookies: {
+          enabled: true,
+          domain: `.${baseDomain}`,
+        },
+      },
+    });
+    return (request: Request) => auth.handler(request);
+  }
+
+  it("lets Better Auth renew the database session and production cookie", async () => {
     const refreshAt = Date.now();
     const token = `session-${crypto.randomUUID()}`;
     const oldExpiresAt = refreshAt + expiresInMs - updateAgeMs;
     seedSession(token, refreshAt, oldExpiresAt);
     const cookie = await signedSessionCookie(token, secret);
+    const beforeRefresh = Date.now();
 
-    await expect(
-      refreshSessionCookie(cookie, secret, db, refreshAt),
-    ).resolves.toBe(true);
+    const setCookie = await refreshAccountSessionCookie(
+      `__Secure-better-auth.session_token=${cookie}`,
+      "https://getbb.app",
+      createAuthFetch("https://getbb.app", "getbb.app"),
+    );
+    const afterRefresh = Date.now();
     const refreshed = db
       .select()
       .from(session)
       .where(eq(session.token, token))
       .get();
-    expect(refreshed?.expiresAt.getTime()).toBe(refreshAt + expiresInMs);
-    expect(refreshed?.updatedAt.getTime()).toBe(refreshAt);
-    await expect(verifySessionCookie(cookie, secret, db)).resolves.toBe(
-      `user-${token}`,
+    expect(refreshed?.expiresAt.getTime()).toBeGreaterThanOrEqual(
+      beforeRefresh + expiresInMs,
     );
-    await expect(
-      refreshSessionCookie(cookie, secret, db, refreshAt + 1),
-    ).resolves.toBe(false);
+    expect(refreshed?.expiresAt.getTime()).toBeLessThanOrEqual(
+      afterRefresh + expiresInMs,
+    );
+    expect(setCookie).toContain("__Secure-better-auth.session_token=");
+    expect(setCookie).toContain("Max-Age=604800");
+    expect(setCookie).toContain("Domain=.getbb.app");
+    expect(setCookie).toContain("Secure");
   });
 
   it("leaves a fresh session unchanged before the update-age boundary", async () => {
     const refreshAt = Date.now();
     const token = `session-${crypto.randomUUID()}`;
-    const expiresAt = refreshAt + expiresInMs - updateAgeMs + 1;
+    const expiresAt = refreshAt + expiresInMs;
     seedSession(token, refreshAt, expiresAt);
     const cookie = await signedSessionCookie(token, secret);
 
     await expect(
-      refreshSessionCookie(cookie, secret, db, refreshAt),
-    ).resolves.toBe(false);
+      refreshAccountSessionCookie(
+        `__Secure-better-auth.session_token=${cookie}`,
+        "https://getbb.app",
+        createAuthFetch("https://getbb.app", "getbb.app"),
+      ),
+    ).resolves.toBeNull();
     expect(
       db
         .select({ expiresAt: session.expiresAt })
@@ -440,71 +473,20 @@ describe("account session refresh", () => {
     ).toBe(expiresAt);
   });
 
-  it("does not revive an expired session or accept a forged signature", async () => {
+  it("passes through Better Auth's non-secure local Cloud cookie", async () => {
     const refreshAt = Date.now();
     const token = `session-${crypto.randomUUID()}`;
-    seedSession(token, refreshAt, refreshAt);
+    seedSession(token, refreshAt, refreshAt + expiresInMs - updateAgeMs);
     const cookie = await signedSessionCookie(token, secret);
 
-    await expect(
-      refreshSessionCookie(cookie, secret, db, refreshAt),
-    ).resolves.toBe(false);
-    await expect(verifySessionCookie(cookie, secret, db)).resolves.toBeNull();
-    await expect(
-      refreshSessionCookie(`${cookie}forged`, secret, db, refreshAt),
-    ).resolves.toBe(false);
-  });
-
-  it("reissues the cookie without shortening a session another request renewed", async () => {
-    const refreshAt = Date.now();
-    const token = `session-${crypto.randomUUID()}`;
-    const oldExpiresAt = refreshAt + expiresInMs - updateAgeMs;
-    seedSession(token, refreshAt, oldExpiresAt);
-    const cookie = await signedSessionCookie(token, secret);
-
-    await expect(verifySessionCookie(cookie, secret, db)).resolves.toBe(
-      `user-${token}`,
+    const setCookie = await refreshAccountSessionCookie(
+      `better-auth.session_token=${cookie}`,
+      "http://bb.localhost:42745",
+      createAuthFetch("http://bb.localhost:42745", "bb.localhost"),
     );
-    const winnerExpiresAt = refreshAt + expiresInMs;
-    const winnerUpdatedAt = refreshAt - 1;
-    db.update(session)
-      .set({
-        expiresAt: new Date(winnerExpiresAt),
-        updatedAt: new Date(winnerUpdatedAt),
-      })
-      .where(eq(session.token, token))
-      .run();
-
-    await expect(
-      refreshSessionCookie(cookie, secret, db, refreshAt),
-    ).resolves.toBe(true);
-    const current = db
-      .select({
-        expiresAt: session.expiresAt,
-        updatedAt: session.updatedAt,
-      })
-      .from(session)
-      .where(eq(session.token, token))
-      .get();
-    expect(current?.expiresAt.getTime()).toBe(winnerExpiresAt);
-    expect(current?.updatedAt.getTime()).toBe(winnerUpdatedAt);
-  });
-
-  it("does not reissue the cookie when a cached session was deleted", async () => {
-    const refreshAt = Date.now();
-    const token = `session-${crypto.randomUUID()}`;
-    const oldExpiresAt = refreshAt + expiresInMs - updateAgeMs;
-    seedSession(token, refreshAt, oldExpiresAt);
-    const cookie = await signedSessionCookie(token, secret);
-
-    await expect(verifySessionCookie(cookie, secret, db)).resolves.toBe(
-      `user-${token}`,
-    );
-    db.delete(session).where(eq(session.token, token)).run();
-
-    await expect(
-      refreshSessionCookie(cookie, secret, db, refreshAt),
-    ).resolves.toBe(false);
+    expect(setCookie).toContain("better-auth.session_token=");
+    expect(setCookie).toContain("Domain=.bb.localhost");
+    expect(setCookie).not.toContain("Secure");
   });
 });
 

--- a/apps/connect/src/session.test.ts
+++ b/apps/connect/src/session.test.ts
@@ -6,19 +6,24 @@ import { eq } from "drizzle-orm";
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  CONNECT_SESSION_EXPIRES_IN_SECONDS,
+  CONNECT_SESSION_UPDATE_AGE_SECONDS,
   labelClaim,
   machine,
   profile,
   schema,
   server,
+  session,
   user,
 } from "@bb/connect-db";
 
 import {
   MACHINE_LAST_SEEN_WRITE_INTERVAL_MS,
   markMachineSeen,
+  refreshSessionCookie,
   resolveLabel,
   verifyMachineCredentialDetails,
+  verifySessionCookie,
 } from "./session.js";
 import { assignMachineLabel } from "./machine-label.js";
 
@@ -111,6 +116,26 @@ function seedMachine(over: {
       .where(eq(labelClaim.label, over.subdomain))
       .run();
   }
+}
+
+async function signedSessionCookie(
+  token: string,
+  secret: string,
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(token),
+  );
+  const encoded = btoa(String.fromCharCode(...new Uint8Array(signature)));
+  return encodeURIComponent(`${token}.${encoded}`);
 }
 
 describe("resolveLabel — label → server row (multi-server)", () => {
@@ -344,6 +369,90 @@ describe("resolveLabel — label → server row (multi-server)", () => {
     expect(resolved?.kind).toBe("server");
     if (resolved?.kind !== "server") throw new Error("expected server label");
     expect(resolved.server.id).toBe("srv-collision");
+  });
+});
+
+describe("account session refresh", () => {
+  const secret = "test-better-auth-secret";
+  const expiresInMs = CONNECT_SESSION_EXPIRES_IN_SECONDS * 1000;
+  const updateAgeMs = CONNECT_SESSION_UPDATE_AGE_SECONDS * 1000;
+
+  function seedSession(
+    token: string,
+    refreshAt: number,
+    expiresAt: number,
+  ): void {
+    seedUser(`user-${token}`);
+    db.insert(session)
+      .values({
+        id: `id-${token}`,
+        token,
+        expiresAt: new Date(expiresAt),
+        userId: `user-${token}`,
+        createdAt: new Date(refreshAt - updateAgeMs),
+        updatedAt: new Date(refreshAt - updateAgeMs),
+      })
+      .run();
+  }
+
+  it("renews at Better Auth's update-age boundary and refreshes only once", async () => {
+    const refreshAt = Date.now();
+    const token = `session-${crypto.randomUUID()}`;
+    const oldExpiresAt = refreshAt + expiresInMs - updateAgeMs;
+    seedSession(token, refreshAt, oldExpiresAt);
+    const cookie = await signedSessionCookie(token, secret);
+
+    await expect(
+      refreshSessionCookie(cookie, secret, db, refreshAt),
+    ).resolves.toBe(true);
+    const refreshed = db
+      .select()
+      .from(session)
+      .where(eq(session.token, token))
+      .get();
+    expect(refreshed?.expiresAt.getTime()).toBe(refreshAt + expiresInMs);
+    expect(refreshed?.updatedAt.getTime()).toBe(refreshAt);
+    await expect(verifySessionCookie(cookie, secret, db)).resolves.toBe(
+      `user-${token}`,
+    );
+    await expect(
+      refreshSessionCookie(cookie, secret, db, refreshAt + 1),
+    ).resolves.toBe(false);
+  });
+
+  it("leaves a fresh session unchanged before the update-age boundary", async () => {
+    const refreshAt = Date.now();
+    const token = `session-${crypto.randomUUID()}`;
+    const expiresAt = refreshAt + expiresInMs - updateAgeMs + 1;
+    seedSession(token, refreshAt, expiresAt);
+    const cookie = await signedSessionCookie(token, secret);
+
+    await expect(
+      refreshSessionCookie(cookie, secret, db, refreshAt),
+    ).resolves.toBe(false);
+    expect(
+      db
+        .select({ expiresAt: session.expiresAt })
+        .from(session)
+        .where(eq(session.token, token))
+        .get()
+        ?.expiresAt.getTime(),
+    ).toBe(expiresAt);
+  });
+
+  it("does not revive an expired session or accept a forged signature", async () => {
+    const refreshAt = Date.now();
+    const token = `session-${crypto.randomUUID()}`;
+    seedSession(token, refreshAt, refreshAt);
+    const cookie = await signedSessionCookie(token, secret);
+
+    await expect(
+      refreshSessionCookie(cookie, secret, db, refreshAt),
+    ).resolves.toBe(false);
+    await expect(verifySessionCookie(cookie, secret, db)).resolves.toBeNull();
+    await expect(
+      refreshSessionCookie(`${cookie}forged`, secret, db, refreshAt),
+    ).resolves.toBe(false);
   });
 });
 

--- a/apps/connect/src/session.ts
+++ b/apps/connect/src/session.ts
@@ -1,7 +1,5 @@
-import { and, eq, gt, isNull, lte } from "drizzle-orm";
+import { and, eq, gt, isNull } from "drizzle-orm";
 import {
-  CONNECT_SESSION_EXPIRES_IN_SECONDS,
-  CONNECT_SESSION_UPDATE_AGE_SECONDS,
   type ConnectDb,
   labelClaim,
   machine,
@@ -20,21 +18,13 @@ import {
 // reach a disconnected server).
 const LABEL_TTL_MS = 15_000;
 const SESSION_TTL_MS = 20_000;
-const SESSION_EXPIRES_IN_MS = CONNECT_SESSION_EXPIRES_IN_SECONDS * 1000;
-const SESSION_UPDATE_AGE_MS = CONNECT_SESSION_UPDATE_AGE_SECONDS * 1000;
 
 interface CacheEntry<T> {
   value: T;
   expires: number;
 }
 const labelCache = new Map<string, CacheEntry<ResolvedLabel | null>>();
-interface VerifiedSession {
-  expiresAt: number;
-  token: string;
-  userId: string;
-}
-
-const sessionCache = new Map<string, CacheEntry<VerifiedSession | null>>();
+const sessionCache = new Map<string, CacheEntry<string | null>>();
 
 function cacheGet<T>(
   map: Map<string, CacheEntry<T>>,
@@ -178,14 +168,14 @@ export async function resolveLabel(
 /**
  * Verify a better-auth session cookie directly against D1 (no cross-worker
  * call), cached per-isolate. Mirrors better-auth's
- * `${token}.${base64(hmac-sha256(token,secret))}` scheme.
+ * `${token}.${base64(hmac-sha256(token,secret))}` scheme. Returns the userId
+ * when the signature is valid and the session row exists and is unexpired.
  */
-async function loadVerifiedSession(
+export async function verifySessionCookie(
   cookieValue: string,
   secret: string,
   db: ConnectDb,
-  now: number,
-): Promise<{ cacheKey: string; session: VerifiedSession } | null> {
+): Promise<string | null> {
   // better-auth URL-encodes the cookie value, so the base64 signature arrives
   // with %2F/%2B/%3D. Decode before splitting/comparing (the hex token is
   // unaffected by decoding).
@@ -195,18 +185,14 @@ async function loadVerifiedSession(
   const token = decoded.slice(0, dot);
   const providedSig = decoded.slice(dot + 1);
 
+  const now = Date.now();
   // Cache on the full `token.sig` value, not the token alone: keying on the
   // token would return a cached userId before the signature is checked, so a
   // valid `token` with a forged signature would authenticate (and a forged
   // one would negative-poison the real token). The full-cookie key makes the
   // cache reflect exactly what passed verification.
   const cached = cacheGet(sessionCache, decoded, now);
-  if (cached !== undefined) {
-    if (cached === null) return null;
-    // A positive cache entry must never outlive the database session itself.
-    if (cached.expiresAt > now) return { cacheKey: decoded, session: cached };
-    sessionCache.delete(decoded);
-  }
+  if (cached !== undefined) return cached;
 
   const key = await crypto.subtle.importKey(
     "raw",
@@ -231,86 +217,15 @@ async function loadVerifiedSession(
     .from(session)
     .where(and(eq(session.token, token), gt(session.expiresAt, new Date(now))))
     .get();
-  if (!row) {
-    sessionCache.set(decoded, { value: null, expires: now + SESSION_TTL_MS });
-    return null;
-  }
-  const verified = {
-    expiresAt: row.expiresAt.getTime(),
-    token,
-    userId: row.userId,
-  };
+  const userId = row?.userId ?? null;
   sessionCache.set(decoded, {
-    value: verified,
-    expires: now + SESSION_TTL_MS,
+    value: userId,
+    expires:
+      row === undefined
+        ? now + SESSION_TTL_MS
+        : Math.min(now + SESSION_TTL_MS, row.expiresAt.getTime()),
   });
-  return { cacheKey: decoded, session: verified };
-}
-
-/** Return the account id when the signed cookie names an unexpired session. */
-export async function verifySessionCookie(
-  cookieValue: string,
-  secret: string,
-  db: ConnectDb,
-): Promise<string | null> {
-  return (
-    (await loadVerifiedSession(cookieValue, secret, db, Date.now()))?.session
-      .userId ?? null
-  );
-}
-
-/**
- * Apply Better Auth's sliding-refresh policy to a session used at the connect
- * gate. Returns true when the caller must reissue the browser cookie with a
- * fresh Max-Age. The conditional update prevents stale isolate caches from
- * shortening a session another request has already renewed.
- *
- * `now` is a test-only wall-clock override. It must remain epoch milliseconds
- * because the same value also controls expiry in the module-level cache.
- */
-export async function refreshSessionCookie(
-  cookieValue: string,
-  secret: string,
-  db: ConnectDb,
-  now: number = Date.now(),
-): Promise<boolean> {
-  const verified = await loadVerifiedSession(cookieValue, secret, db, now);
-  if (!verified) return false;
-
-  const refreshCeiling = now + SESSION_EXPIRES_IN_MS - SESSION_UPDATE_AGE_MS;
-  if (verified.session.expiresAt > refreshCeiling) return false;
-
-  const expiresAt = new Date(now + SESSION_EXPIRES_IN_MS);
-  const updated = await db
-    .update(session)
-    .set({ expiresAt, updatedAt: new Date(now) })
-    .where(
-      and(
-        eq(session.token, verified.session.token),
-        gt(session.expiresAt, new Date(now)),
-        lte(session.expiresAt, new Date(refreshCeiling)),
-      ),
-    )
-    .returning({ expiresAt: session.expiresAt, userId: session.userId })
-    .get();
-
-  if (updated) {
-    sessionCache.set(verified.cacheKey, {
-      value: {
-        expiresAt: updated.expiresAt.getTime(),
-        token: verified.session.token,
-        userId: updated.userId,
-      },
-      expires: now + SESSION_TTL_MS,
-    });
-    return true;
-  }
-
-  // Another isolate may have won the refresh race. Re-read instead of issuing
-  // a cookie for a session that was concurrently deleted or expired.
-  sessionCache.delete(verified.cacheKey);
-  const current = await loadVerifiedSession(cookieValue, secret, db, now);
-  return current !== null && current.session.expiresAt > refreshCeiling;
+  return userId;
 }
 
 const machineLastSeenWrites = new Map<string, number>();

--- a/apps/connect/src/session.ts
+++ b/apps/connect/src/session.ts
@@ -1,5 +1,7 @@
 import { and, eq, gt, isNull } from "drizzle-orm";
 import {
+  CONNECT_SESSION_EXPIRES_IN_SECONDS,
+  CONNECT_SESSION_UPDATE_AGE_SECONDS,
   type ConnectDb,
   labelClaim,
   machine,
@@ -18,13 +20,26 @@ import {
 // reach a disconnected server).
 const LABEL_TTL_MS = 15_000;
 const SESSION_TTL_MS = 20_000;
+const SESSION_REFRESH_BEFORE_EXPIRY_MS =
+  (CONNECT_SESSION_EXPIRES_IN_SECONDS - CONNECT_SESSION_UPDATE_AGE_SECONDS) *
+  1000;
 
 interface CacheEntry<T> {
   value: T;
   expires: number;
 }
 const labelCache = new Map<string, CacheEntry<ResolvedLabel | null>>();
-const sessionCache = new Map<string, CacheEntry<string | null>>();
+
+interface CachedSession {
+  userId: string;
+  expiresAt: number;
+}
+
+const sessionCache = new Map<string, CacheEntry<CachedSession | null>>();
+
+export function invalidateSessionCookie(cookieValue: string): void {
+  sessionCache.delete(safeDecode(cookieValue));
+}
 
 function cacheGet<T>(
   map: Map<string, CacheEntry<T>>,
@@ -165,17 +180,34 @@ export async function resolveLabel(
   return resolvedMachine;
 }
 
+export interface VerifiedSessionCookie {
+  userId: string;
+  /** A hint only; Better Auth rechecks the session before refreshing it. */
+  needsRefresh: boolean;
+}
+
+function verifiedSession(
+  session: CachedSession,
+  now: number,
+): VerifiedSessionCookie {
+  return {
+    userId: session.userId,
+    needsRefresh: session.expiresAt <= now + SESSION_REFRESH_BEFORE_EXPIRY_MS,
+  };
+}
+
 /**
  * Verify a better-auth session cookie directly against D1 (no cross-worker
  * call), cached per-isolate. Mirrors better-auth's
- * `${token}.${base64(hmac-sha256(token,secret))}` scheme. Returns the userId
- * when the signature is valid and the session row exists and is unexpired.
+ * `${token}.${base64(hmac-sha256(token,secret))}` scheme. The refresh hint
+ * matches Better Auth's update-age boundary but is not authoritative; Better
+ * Auth rechecks the session before writing or reissuing its cookie.
  */
-export async function verifySessionCookie(
+export async function verifySessionCookieDetails(
   cookieValue: string,
   secret: string,
   db: ConnectDb,
-): Promise<string | null> {
+): Promise<VerifiedSessionCookie | null> {
   // better-auth URL-encodes the cookie value, so the base64 signature arrives
   // with %2F/%2B/%3D. Decode before splitting/comparing (the hex token is
   // unaffected by decoding).
@@ -192,7 +224,8 @@ export async function verifySessionCookie(
   // one would negative-poison the real token). The full-cookie key makes the
   // cache reflect exactly what passed verification.
   const cached = cacheGet(sessionCache, decoded, now);
-  if (cached !== undefined) return cached;
+  if (cached !== undefined)
+    return cached === null ? null : verifiedSession(cached, now);
 
   const key = await crypto.subtle.importKey(
     "raw",
@@ -217,15 +250,28 @@ export async function verifySessionCookie(
     .from(session)
     .where(and(eq(session.token, token), gt(session.expiresAt, new Date(now))))
     .get();
-  const userId = row?.userId ?? null;
+  const cachedSession = row
+    ? { userId: row.userId, expiresAt: row.expiresAt.getTime() }
+    : null;
   sessionCache.set(decoded, {
-    value: userId,
+    value: cachedSession,
     expires:
       row === undefined
         ? now + SESSION_TTL_MS
         : Math.min(now + SESSION_TTL_MS, row.expiresAt.getTime()),
   });
-  return userId;
+  return cachedSession === null ? null : verifiedSession(cachedSession, now);
+}
+
+/** Returns the owning user for callers that do not participate in refresh. */
+export async function verifySessionCookie(
+  cookieValue: string,
+  secret: string,
+  db: ConnectDb,
+): Promise<string | null> {
+  return (
+    (await verifySessionCookieDetails(cookieValue, secret, db))?.userId ?? null
+  );
 }
 
 const machineLastSeenWrites = new Map<string, number>();

--- a/apps/connect/src/session.ts
+++ b/apps/connect/src/session.ts
@@ -1,5 +1,7 @@
-import { and, eq, gt, isNull } from "drizzle-orm";
+import { and, eq, gt, isNull, lte } from "drizzle-orm";
 import {
+  CONNECT_SESSION_EXPIRES_IN_SECONDS,
+  CONNECT_SESSION_UPDATE_AGE_SECONDS,
   type ConnectDb,
   labelClaim,
   machine,
@@ -18,13 +20,21 @@ import {
 // reach a disconnected server).
 const LABEL_TTL_MS = 15_000;
 const SESSION_TTL_MS = 20_000;
+const SESSION_EXPIRES_IN_MS = CONNECT_SESSION_EXPIRES_IN_SECONDS * 1000;
+const SESSION_UPDATE_AGE_MS = CONNECT_SESSION_UPDATE_AGE_SECONDS * 1000;
 
 interface CacheEntry<T> {
   value: T;
   expires: number;
 }
 const labelCache = new Map<string, CacheEntry<ResolvedLabel | null>>();
-const sessionCache = new Map<string, CacheEntry<string | null>>();
+interface VerifiedSession {
+  expiresAt: number;
+  token: string;
+  userId: string;
+}
+
+const sessionCache = new Map<string, CacheEntry<VerifiedSession | null>>();
 
 function cacheGet<T>(
   map: Map<string, CacheEntry<T>>,
@@ -168,14 +178,14 @@ export async function resolveLabel(
 /**
  * Verify a better-auth session cookie directly against D1 (no cross-worker
  * call), cached per-isolate. Mirrors better-auth's
- * `${token}.${base64(hmac-sha256(token,secret))}` scheme. Returns the userId
- * when the signature is valid and the session row exists and is unexpired.
+ * `${token}.${base64(hmac-sha256(token,secret))}` scheme.
  */
-export async function verifySessionCookie(
+async function loadVerifiedSession(
   cookieValue: string,
   secret: string,
   db: ConnectDb,
-): Promise<string | null> {
+  now: number,
+): Promise<{ cacheKey: string; session: VerifiedSession } | null> {
   // better-auth URL-encodes the cookie value, so the base64 signature arrives
   // with %2F/%2B/%3D. Decode before splitting/comparing (the hex token is
   // unaffected by decoding).
@@ -185,14 +195,18 @@ export async function verifySessionCookie(
   const token = decoded.slice(0, dot);
   const providedSig = decoded.slice(dot + 1);
 
-  const now = Date.now();
   // Cache on the full `token.sig` value, not the token alone: keying on the
   // token would return a cached userId before the signature is checked, so a
   // valid `token` with a forged signature would authenticate (and a forged
   // one would negative-poison the real token). The full-cookie key makes the
   // cache reflect exactly what passed verification.
   const cached = cacheGet(sessionCache, decoded, now);
-  if (cached !== undefined) return cached;
+  if (cached !== undefined) {
+    if (cached === null) return null;
+    // A positive cache entry must never outlive the database session itself.
+    if (cached.expiresAt > now) return { cacheKey: decoded, session: cached };
+    sessionCache.delete(decoded);
+  }
 
   const key = await crypto.subtle.importKey(
     "raw",
@@ -213,13 +227,87 @@ export async function verifySessionCookie(
   }
 
   const row = await db
-    .select({ userId: session.userId })
+    .select({ expiresAt: session.expiresAt, userId: session.userId })
     .from(session)
-    .where(and(eq(session.token, token), gt(session.expiresAt, new Date())))
+    .where(and(eq(session.token, token), gt(session.expiresAt, new Date(now))))
     .get();
-  const userId = row?.userId ?? null;
-  sessionCache.set(decoded, { value: userId, expires: now + SESSION_TTL_MS });
-  return userId;
+  if (!row) {
+    sessionCache.set(decoded, { value: null, expires: now + SESSION_TTL_MS });
+    return null;
+  }
+  const verified = {
+    expiresAt: row.expiresAt.getTime(),
+    token,
+    userId: row.userId,
+  };
+  sessionCache.set(decoded, {
+    value: verified,
+    expires: now + SESSION_TTL_MS,
+  });
+  return { cacheKey: decoded, session: verified };
+}
+
+/** Return the account id when the signed cookie names an unexpired session. */
+export async function verifySessionCookie(
+  cookieValue: string,
+  secret: string,
+  db: ConnectDb,
+): Promise<string | null> {
+  return (
+    (await loadVerifiedSession(cookieValue, secret, db, Date.now()))?.session
+      .userId ?? null
+  );
+}
+
+/**
+ * Apply Better Auth's sliding-refresh policy to a session used at the connect
+ * gate. Returns true when the caller must reissue the browser cookie with a
+ * fresh Max-Age. The conditional update prevents stale isolate caches from
+ * shortening a session another request has already renewed.
+ */
+export async function refreshSessionCookie(
+  cookieValue: string,
+  secret: string,
+  db: ConnectDb,
+  now: number = Date.now(),
+): Promise<boolean> {
+  const verified = await loadVerifiedSession(cookieValue, secret, db, now);
+  if (!verified) return false;
+
+  const refreshCeiling = now + SESSION_EXPIRES_IN_MS - SESSION_UPDATE_AGE_MS;
+  if (verified.session.expiresAt > refreshCeiling) return false;
+
+  const expiresAt = new Date(now + SESSION_EXPIRES_IN_MS);
+  const updated = await db
+    .update(session)
+    .set({ expiresAt, updatedAt: new Date(now) })
+    .where(
+      and(
+        eq(session.token, verified.session.token),
+        gt(session.expiresAt, new Date(now)),
+        lte(session.expiresAt, new Date(refreshCeiling)),
+      ),
+    )
+    .returning({ expiresAt: session.expiresAt, userId: session.userId })
+    .get();
+
+  if (updated) {
+    sessionCache.set(verified.cacheKey, {
+      value: {
+        expiresAt: updated.expiresAt.getTime(),
+        token: verified.session.token,
+        userId: updated.userId,
+      },
+      expires: now + SESSION_TTL_MS,
+    });
+    return true;
+  }
+
+  // Another isolate may have won the refresh race. Re-read instead of issuing
+  // a cookie for a session that was concurrently deleted or expired.
+  sessionCache.delete(verified.cacheKey);
+  const current = await loadVerifiedSession(cookieValue, secret, db, now);
+  return current !== null && current.session.expiresAt > refreshCeiling;
 }
 
 const machineLastSeenWrites = new Map<string, number>();

--- a/apps/connect/src/session.ts
+++ b/apps/connect/src/session.ts
@@ -264,6 +264,9 @@ export async function verifySessionCookie(
  * gate. Returns true when the caller must reissue the browser cookie with a
  * fresh Max-Age. The conditional update prevents stale isolate caches from
  * shortening a session another request has already renewed.
+ *
+ * `now` is a test-only wall-clock override. It must remain epoch milliseconds
+ * because the same value also controls expiry in the module-level cache.
  */
 export async function refreshSessionCookie(
   cookieValue: string,

--- a/apps/connect/src/worker.test.ts
+++ b/apps/connect/src/worker.test.ts
@@ -108,10 +108,13 @@ describe("parseClientProtocolVersion", () => {
 vi.mock("./session.js", () => ({
   markMachineSeen: vi.fn(),
   parseCookie: vi.fn(),
-  refreshSessionCookie: vi.fn(),
   resolveLabel: vi.fn(),
   verifyMachineCredentialDetails: vi.fn(),
   verifySessionCookie: vi.fn(),
+}));
+
+vi.mock("./account-session.js", () => ({
+  refreshAccountSessionCookie: vi.fn(),
 }));
 
 vi.mock("./servers.js", () => ({
@@ -150,11 +153,11 @@ import { drizzle } from "drizzle-orm/d1";
 import {
   markMachineSeen,
   parseCookie,
-  refreshSessionCookie,
   resolveLabel,
   verifyMachineCredentialDetails,
   verifySessionCookie,
 } from "./session.js";
+import { refreshAccountSessionCookie } from "./account-session.js";
 import {
   handleCreateDesktopSession,
   handleDisconnectServer,
@@ -168,7 +171,7 @@ import worker, { offlinePage, relativeTime, wantsHtml } from "./worker.js";
 import { TUNNEL_OFFLINE_HEADER, TunnelDO } from "./tunnel-do.js";
 
 const mockParseCookie = vi.mocked(parseCookie);
-const mockRefreshSession = vi.mocked(refreshSessionCookie);
+const mockRefreshAccountSession = vi.mocked(refreshAccountSessionCookie);
 const mockResolveLabel = vi.mocked(resolveLabel);
 const mockMarkMachineSeen = vi.mocked(markMachineSeen);
 const mockVerifyMachine = vi.mocked(verifyMachineCredentialDetails);
@@ -806,7 +809,7 @@ describe("gate worker share hosts", () => {
     mockResolveLabel.mockResolvedValue(resolvedServer());
     mockParseCookie.mockReturnValue("session-token");
     mockVerifySession.mockResolvedValue(OWNER);
-    mockRefreshSession.mockResolvedValue(false);
+    mockRefreshAccountSession.mockResolvedValue(null);
   });
 
   afterEach(() => {
@@ -834,7 +837,9 @@ describe("gate worker share hosts", () => {
   });
 
   it("renews an active owner session on an ordinary HTTP response", async () => {
-    mockRefreshSession.mockResolvedValue(true);
+    mockRefreshAccountSession.mockResolvedValue(
+      "__Secure-better-auth.session_token=renewed; Max-Age=604800; Domain=.getbb.app; Path=/; HttpOnly; SameSite=Lax; Secure",
+    );
     const { env, ctx } = makeEnv(() => new Response("ok"));
     const response = await worker.fetch(
       visitorRequest("sawyer.getbb.app", "/api/v1/threads"),
@@ -842,20 +847,20 @@ describe("gate worker share hosts", () => {
       ctx,
     );
 
-    expect(mockRefreshSession).toHaveBeenCalledWith(
-      "session-token",
-      "test-secret",
-      expect.anything(),
+    expect(mockRefreshAccountSession).toHaveBeenCalledWith(
+      "__Secure-better-auth.session_token=session-token",
+      "https://getbb.app",
+      expect.any(Function),
     );
     expect(response.headers.get("set-cookie")).toBe(
-      "__Secure-better-auth.session_token=session-token; Max-Age=604800; Domain=.getbb.app; Path=/; HttpOnly; SameSite=Lax; Secure",
+      "__Secure-better-auth.session_token=renewed; Max-Age=604800; Domain=.getbb.app; Path=/; HttpOnly; SameSite=Lax; Secure",
     );
   });
 
   it.each(["hit", "miss"] as const)(
     "does not renew an owner session on an edge-cache %s",
     async (cacheStatus) => {
-      mockRefreshSession.mockResolvedValue(true);
+      mockRefreshAccountSession.mockResolvedValue("should-not-be-used");
       mockServeWithCache.mockResolvedValueOnce({
         cacheable: true,
         response: new Response("cached asset", {
@@ -870,7 +875,7 @@ describe("gate worker share hosts", () => {
         ctx,
       );
 
-      expect(mockRefreshSession).not.toHaveBeenCalled();
+      expect(mockRefreshAccountSession).not.toHaveBeenCalled();
       expect(response.headers.get("set-cookie")).toBeNull();
       expect(response.headers.get("x-bb-cache")).toBe(cacheStatus);
       await expect(response.text()).resolves.toBe("cached asset");
@@ -878,7 +883,9 @@ describe("gate worker share hosts", () => {
   );
 
   it("reissues the local Cloud cookie without the Secure attribute", async () => {
-    mockRefreshSession.mockResolvedValue(true);
+    mockRefreshAccountSession.mockResolvedValue(
+      "better-auth.session_token=renewed; Max-Age=604800; Domain=.bb.localhost; Path=/; HttpOnly; SameSite=Lax",
+    );
     const { env, ctx } = makeEnv(() => new Response("ok"));
     Object.assign(env, {
       ACCOUNT_APP_URL: "http://bb.localhost:42745",
@@ -897,7 +904,12 @@ describe("gate worker share hosts", () => {
     );
 
     expect(response.headers.get("set-cookie")).toBe(
-      "better-auth.session_token=session-token; Max-Age=604800; Domain=.bb.localhost; Path=/; HttpOnly; SameSite=Lax",
+      "better-auth.session_token=renewed; Max-Age=604800; Domain=.bb.localhost; Path=/; HttpOnly; SameSite=Lax",
+    );
+    expect(mockRefreshAccountSession).toHaveBeenCalledWith(
+      "better-auth.session_token=session-token",
+      "http://bb.localhost:42745",
+      expect.any(Function),
     );
   });
 
@@ -1139,7 +1151,7 @@ describe("gate worker share hosts", () => {
     expect(res.status).toBe(403);
     expect(await res.text()).toContain("not your server");
     expect(captured).toHaveLength(0);
-    expect(mockRefreshSession).not.toHaveBeenCalled();
+    expect(mockRefreshAccountSession).not.toHaveBeenCalled();
   });
 
   it("accepts the short-lived desktop cookie for the owning account", async () => {
@@ -1232,7 +1244,7 @@ describe("gate worker share hosts", () => {
     expect(captured[0].headers.get(TUNNEL_TARGET_HEADER)).toBe("8000");
     expect(captured[0].headers.get("upgrade")).toBe("websocket");
     expect(mockServeWithCache).not.toHaveBeenCalled();
-    expect(mockRefreshSession).not.toHaveBeenCalled();
+    expect(mockRefreshAccountSession).not.toHaveBeenCalled();
   });
 
   it("does not apply machine-credential branch on share hosts", async () => {

--- a/apps/connect/src/worker.test.ts
+++ b/apps/connect/src/worker.test.ts
@@ -115,7 +115,7 @@ vi.mock("./session.js", () => ({
 }));
 
 vi.mock("./account-session.js", () => ({
-  refreshAccountSessionCookie: vi.fn(),
+  refreshAccountSessionCookies: vi.fn(),
 }));
 
 vi.mock("./servers.js", () => ({
@@ -159,7 +159,7 @@ import {
   verifyMachineCredentialDetails,
   verifySessionCookieDetails,
 } from "./session.js";
-import { refreshAccountSessionCookie } from "./account-session.js";
+import { refreshAccountSessionCookies } from "./account-session.js";
 import {
   handleCreateDesktopSession,
   handleDisconnectServer,
@@ -174,7 +174,7 @@ import { TUNNEL_OFFLINE_HEADER, TunnelDO } from "./tunnel-do.js";
 
 const mockParseCookie = vi.mocked(parseCookie);
 const mockInvalidateSession = vi.mocked(invalidateSessionCookie);
-const mockRefreshAccountSession = vi.mocked(refreshAccountSessionCookie);
+const mockRefreshAccountSession = vi.mocked(refreshAccountSessionCookies);
 const mockResolveLabel = vi.mocked(resolveLabel);
 const mockMarkMachineSeen = vi.mocked(markMachineSeen);
 const mockVerifyMachine = vi.mocked(verifyMachineCredentialDetails);
@@ -845,9 +845,10 @@ describe("gate worker share hosts", () => {
 
   it("renews an active owner session on an ordinary HTTP response", async () => {
     mockVerifySessionDetails.mockResolvedValue(sessionDetails(OWNER, true));
-    mockRefreshAccountSession.mockResolvedValue(
+    mockRefreshAccountSession.mockResolvedValue([
       "__Secure-better-auth.session_token=renewed; Max-Age=604800; Domain=.getbb.app; Path=/; HttpOnly; SameSite=Lax; Secure",
-    );
+      "__Secure-better-auth.session_data=cached; Max-Age=300; Domain=.getbb.app; Path=/; HttpOnly; SameSite=Lax; Secure",
+    ]);
     const { env, ctx } = makeEnv(() => new Response("ok"));
     const response = await worker.fetch(
       visitorRequest("sawyer.getbb.app", "/api/v1/threads"),
@@ -861,8 +862,11 @@ describe("gate worker share hosts", () => {
       expect.any(Function),
     );
     expect(mockInvalidateSession).toHaveBeenCalledWith("session-token");
-    expect(response.headers.get("set-cookie")).toBe(
-      "__Secure-better-auth.session_token=renewed; Max-Age=604800; Domain=.getbb.app; Path=/; HttpOnly; SameSite=Lax; Secure",
+    expect(response.headers.get("set-cookie")).toContain(
+      "__Secure-better-auth.session_token=renewed",
+    );
+    expect(response.headers.get("set-cookie")).toContain(
+      "__Secure-better-auth.session_data=cached",
     );
   });
 
@@ -884,7 +888,7 @@ describe("gate worker share hosts", () => {
     "does not renew an owner session on an edge-cache %s",
     async (cacheStatus) => {
       mockVerifySessionDetails.mockResolvedValue(sessionDetails(OWNER, true));
-      mockRefreshAccountSession.mockResolvedValue("should-not-be-used");
+      mockRefreshAccountSession.mockResolvedValue(["should-not-be-used"]);
       mockServeWithCache.mockResolvedValueOnce({
         cacheable: true,
         response: new Response("cached asset", {
@@ -908,9 +912,9 @@ describe("gate worker share hosts", () => {
 
   it("reissues the local Cloud cookie without the Secure attribute", async () => {
     mockVerifySessionDetails.mockResolvedValue(sessionDetails(OWNER, true));
-    mockRefreshAccountSession.mockResolvedValue(
+    mockRefreshAccountSession.mockResolvedValue([
       "better-auth.session_token=renewed; Max-Age=604800; Domain=.bb.localhost; Path=/; HttpOnly; SameSite=Lax",
-    );
+    ]);
     const { env, ctx } = makeEnv(() => new Response("ok"));
     Object.assign(env, {
       ACCOUNT_APP_URL: "http://bb.localhost:42745",

--- a/apps/connect/src/worker.test.ts
+++ b/apps/connect/src/worker.test.ts
@@ -136,7 +136,7 @@ vi.mock("./cache.js", async () => {
         _namespace: string,
         _ctx: ExecutionContext,
         fetchOrigin: () => Promise<Response>,
-      ) => fetchOrigin(),
+      ) => ({ cacheable: false, response: await fetchOrigin() }),
     ),
   };
 });
@@ -851,6 +851,31 @@ describe("gate worker share hosts", () => {
       "__Secure-better-auth.session_token=session-token; Max-Age=604800; Domain=.getbb.app; Path=/; HttpOnly; SameSite=Lax; Secure",
     );
   });
+
+  it.each(["hit", "miss"] as const)(
+    "does not renew an owner session on an edge-cache %s",
+    async (cacheStatus) => {
+      mockRefreshSession.mockResolvedValue(true);
+      mockServeWithCache.mockResolvedValueOnce({
+        cacheable: true,
+        response: new Response("cached asset", {
+          headers: { "x-bb-cache": cacheStatus },
+        }),
+      });
+      const { env, ctx } = makeEnv(() => new Response("origin"));
+
+      const response = await worker.fetch(
+        visitorRequest("sawyer.getbb.app", "/assets/app.js"),
+        env as never,
+        ctx,
+      );
+
+      expect(mockRefreshSession).not.toHaveBeenCalled();
+      expect(response.headers.get("set-cookie")).toBeNull();
+      expect(response.headers.get("x-bb-cache")).toBe(cacheStatus);
+      await expect(response.text()).resolves.toBe("cached asset");
+    },
+  );
 
   it("reissues the local Cloud cookie without the Secure attribute", async () => {
     mockRefreshSession.mockResolvedValue(true);

--- a/apps/connect/src/worker.test.ts
+++ b/apps/connect/src/worker.test.ts
@@ -106,11 +106,12 @@ describe("parseClientProtocolVersion", () => {
 // ── gate worker (mocked session + DO stub) ──────────────────────────────────
 
 vi.mock("./session.js", () => ({
+  invalidateSessionCookie: vi.fn(),
   markMachineSeen: vi.fn(),
   parseCookie: vi.fn(),
   resolveLabel: vi.fn(),
   verifyMachineCredentialDetails: vi.fn(),
-  verifySessionCookie: vi.fn(),
+  verifySessionCookieDetails: vi.fn(),
 }));
 
 vi.mock("./account-session.js", () => ({
@@ -151,11 +152,12 @@ vi.mock("drizzle-orm/d1", () => ({
 import { drizzle } from "drizzle-orm/d1";
 
 import {
+  invalidateSessionCookie,
   markMachineSeen,
   parseCookie,
   resolveLabel,
   verifyMachineCredentialDetails,
-  verifySessionCookie,
+  verifySessionCookieDetails,
 } from "./session.js";
 import { refreshAccountSessionCookie } from "./account-session.js";
 import {
@@ -171,17 +173,22 @@ import worker, { offlinePage, relativeTime, wantsHtml } from "./worker.js";
 import { TUNNEL_OFFLINE_HEADER, TunnelDO } from "./tunnel-do.js";
 
 const mockParseCookie = vi.mocked(parseCookie);
+const mockInvalidateSession = vi.mocked(invalidateSessionCookie);
 const mockRefreshAccountSession = vi.mocked(refreshAccountSessionCookie);
 const mockResolveLabel = vi.mocked(resolveLabel);
 const mockMarkMachineSeen = vi.mocked(markMachineSeen);
 const mockVerifyMachine = vi.mocked(verifyMachineCredentialDetails);
-const mockVerifySession = vi.mocked(verifySessionCookie);
+const mockVerifySessionDetails = vi.mocked(verifySessionCookieDetails);
 const mockServeWithCache = vi.mocked(serveWithCache);
 const mockHandleListAccountServers = vi.mocked(handleListAccountServers);
 const mockHandleCreateDesktopSession = vi.mocked(handleCreateDesktopSession);
 const mockHandleDisconnectServer = vi.mocked(handleDisconnectServer);
 const mockVerifyDesktopSession = vi.mocked(verifyDesktopSessionCookie);
 const mockHandleAssignMachineLabel = vi.mocked(handleAssignMachineLabel);
+
+function sessionDetails(userId = OWNER, needsRefresh = false) {
+  return { userId, needsRefresh };
+}
 
 /** A resolved server row; overrides let a test tweak one field. */
 function resolvedServer(
@@ -719,7 +726,7 @@ describe("bb mobile app-link association files", () => {
       expect(response.headers.get("content-type")).toBe("application/json");
       expect(captured).toHaveLength(0);
       expect(mockResolveLabel).not.toHaveBeenCalled();
-      expect(mockVerifySession).not.toHaveBeenCalled();
+      expect(mockVerifySessionDetails).not.toHaveBeenCalled();
     },
   );
 
@@ -808,7 +815,7 @@ describe("gate worker share hosts", () => {
     vi.clearAllMocks();
     mockResolveLabel.mockResolvedValue(resolvedServer());
     mockParseCookie.mockReturnValue("session-token");
-    mockVerifySession.mockResolvedValue(OWNER);
+    mockVerifySessionDetails.mockResolvedValue(sessionDetails());
     mockRefreshAccountSession.mockResolvedValue(null);
   });
 
@@ -837,6 +844,7 @@ describe("gate worker share hosts", () => {
   });
 
   it("renews an active owner session on an ordinary HTTP response", async () => {
+    mockVerifySessionDetails.mockResolvedValue(sessionDetails(OWNER, true));
     mockRefreshAccountSession.mockResolvedValue(
       "__Secure-better-auth.session_token=renewed; Max-Age=604800; Domain=.getbb.app; Path=/; HttpOnly; SameSite=Lax; Secure",
     );
@@ -852,14 +860,30 @@ describe("gate worker share hosts", () => {
       "https://getbb.app",
       expect.any(Function),
     );
+    expect(mockInvalidateSession).toHaveBeenCalledWith("session-token");
     expect(response.headers.get("set-cookie")).toBe(
       "__Secure-better-auth.session_token=renewed; Max-Age=604800; Domain=.getbb.app; Path=/; HttpOnly; SameSite=Lax; Secure",
     );
   });
 
+  it("does not call the account worker before the update-age boundary", async () => {
+    const { env, ctx } = makeEnv(() => new Response("ok"));
+    const response = await worker.fetch(
+      visitorRequest("sawyer.getbb.app", "/api/v1/threads"),
+      env as never,
+      ctx,
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockInvalidateSession).not.toHaveBeenCalled();
+    expect(mockRefreshAccountSession).not.toHaveBeenCalled();
+    expect(response.headers.get("set-cookie")).toBeNull();
+  });
+
   it.each(["hit", "miss"] as const)(
     "does not renew an owner session on an edge-cache %s",
     async (cacheStatus) => {
+      mockVerifySessionDetails.mockResolvedValue(sessionDetails(OWNER, true));
       mockRefreshAccountSession.mockResolvedValue("should-not-be-used");
       mockServeWithCache.mockResolvedValueOnce({
         cacheable: true,
@@ -883,6 +907,7 @@ describe("gate worker share hosts", () => {
   );
 
   it("reissues the local Cloud cookie without the Secure attribute", async () => {
+    mockVerifySessionDetails.mockResolvedValue(sessionDetails(OWNER, true));
     mockRefreshAccountSession.mockResolvedValue(
       "better-auth.session_token=renewed; Max-Age=604800; Domain=.bb.localhost; Path=/; HttpOnly; SameSite=Lax",
     );
@@ -929,7 +954,7 @@ describe("gate worker share hosts", () => {
     expect(html).toContain("sawyer-air--&lt;port&gt;.getbb.app");
     expect(html).toContain("sawyer.getbb.app");
     expect(captured).toHaveLength(0);
-    expect(mockVerifySession).not.toHaveBeenCalled();
+    expect(mockVerifySessionDetails).not.toHaveBeenCalled();
   });
 
   it("renders local machine links with HTTP and the shared gateway port", async () => {
@@ -973,7 +998,7 @@ describe("gate worker share hosts", () => {
       expect.any(Function),
     );
 
-    mockVerifySession.mockResolvedValue(OTHER);
+    mockVerifySessionDetails.mockResolvedValue(sessionDetails(OTHER));
     const otherEnv = makeEnv(() => new Response("machine-origin"));
     const otherResponse = await worker.fetch(
       visitorRequest("sawyer-air--3000.getbb.app", "/"),
@@ -1019,7 +1044,7 @@ describe("gate worker share hosts", () => {
     expect(blockedEnv.routingKeys).toEqual(["shared-machine:generation-b"]);
     expect(blockedEnv.captured).toHaveLength(0);
 
-    mockVerifySession.mockResolvedValue(OTHER);
+    mockVerifySessionDetails.mockResolvedValue(sessionDetails(OTHER));
     const newEnv = makeEnv(() => new Response("owner-b"));
     const newResponse = await worker.fetch(
       visitorRequest("shared-machine--3000.getbb.app", "/asset.js"),
@@ -1141,7 +1166,7 @@ describe("gate worker share hosts", () => {
   });
 
   it("returns 403 when share host session is a different user", async () => {
-    mockVerifySession.mockResolvedValue(OTHER);
+    mockVerifySessionDetails.mockResolvedValue(sessionDetails(OTHER));
     const { env, ctx, captured } = makeEnv(() => new Response("ok"));
     const res = await worker.fetch(
       visitorRequest("sawyer--8000.getbb.app", "/"),
@@ -1177,7 +1202,7 @@ describe("gate worker share hosts", () => {
     mockParseCookie.mockImplementation((_header, name) =>
       name === DESKTOP_SESSION_COOKIE ? "desktop-token" : "github-token",
     );
-    mockVerifySession.mockResolvedValue(OTHER);
+    mockVerifySessionDetails.mockResolvedValue(sessionDetails(OTHER));
     mockVerifyDesktopSession.mockResolvedValue(OWNER);
     const { env, ctx, captured } = makeEnv(() => new Response("ok"));
     const response = await worker.fetch(
@@ -1229,6 +1254,7 @@ describe("gate worker share hosts", () => {
   });
 
   it("forwards websocket upgrades on share hosts with the target header", async () => {
+    mockVerifySessionDetails.mockResolvedValue(sessionDetails(OWNER, true));
     // Node's Response rejects status 101; the gate only needs the upgrade path.
     const { env, ctx, captured } = makeEnv(
       () => new Response("upgraded", { status: 200 }),
@@ -1297,7 +1323,7 @@ describe("gate offline page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockParseCookie.mockReturnValue("session-token");
-    mockVerifySession.mockResolvedValue(OWNER);
+    mockVerifySessionDetails.mockResolvedValue(sessionDetails());
   });
 
   it("renders the styled offline page on a browser navigation, using last-seen", async () => {

--- a/apps/connect/src/worker.test.ts
+++ b/apps/connect/src/worker.test.ts
@@ -108,6 +108,7 @@ describe("parseClientProtocolVersion", () => {
 vi.mock("./session.js", () => ({
   markMachineSeen: vi.fn(),
   parseCookie: vi.fn(),
+  refreshSessionCookie: vi.fn(),
   resolveLabel: vi.fn(),
   verifyMachineCredentialDetails: vi.fn(),
   verifySessionCookie: vi.fn(),
@@ -149,6 +150,7 @@ import { drizzle } from "drizzle-orm/d1";
 import {
   markMachineSeen,
   parseCookie,
+  refreshSessionCookie,
   resolveLabel,
   verifyMachineCredentialDetails,
   verifySessionCookie,
@@ -166,6 +168,7 @@ import worker, { offlinePage, relativeTime, wantsHtml } from "./worker.js";
 import { TUNNEL_OFFLINE_HEADER, TunnelDO } from "./tunnel-do.js";
 
 const mockParseCookie = vi.mocked(parseCookie);
+const mockRefreshSession = vi.mocked(refreshSessionCookie);
 const mockResolveLabel = vi.mocked(resolveLabel);
 const mockMarkMachineSeen = vi.mocked(markMachineSeen);
 const mockVerifyMachine = vi.mocked(verifyMachineCredentialDetails);
@@ -803,6 +806,7 @@ describe("gate worker share hosts", () => {
     mockResolveLabel.mockResolvedValue(resolvedServer());
     mockParseCookie.mockReturnValue("session-token");
     mockVerifySession.mockResolvedValue(OWNER);
+    mockRefreshSession.mockResolvedValue(false);
   });
 
   afterEach(() => {
@@ -826,6 +830,49 @@ describe("gate worker share hosts", () => {
       "sawyer--8000",
       ctx,
       expect.any(Function),
+    );
+  });
+
+  it("renews an active owner session on an ordinary HTTP response", async () => {
+    mockRefreshSession.mockResolvedValue(true);
+    const { env, ctx } = makeEnv(() => new Response("ok"));
+    const response = await worker.fetch(
+      visitorRequest("sawyer.getbb.app", "/api/v1/threads"),
+      env as never,
+      ctx,
+    );
+
+    expect(mockRefreshSession).toHaveBeenCalledWith(
+      "session-token",
+      "test-secret",
+      expect.anything(),
+    );
+    expect(response.headers.get("set-cookie")).toBe(
+      "__Secure-better-auth.session_token=session-token; Max-Age=604800; Domain=.getbb.app; Path=/; HttpOnly; SameSite=Lax; Secure",
+    );
+  });
+
+  it("reissues the local Cloud cookie without the Secure attribute", async () => {
+    mockRefreshSession.mockResolvedValue(true);
+    const { env, ctx } = makeEnv(() => new Response("ok"));
+    Object.assign(env, {
+      ACCOUNT_APP_URL: "http://bb.localhost:42745",
+      BASE_DOMAIN: "bb.localhost",
+      CLOUD_DEV: "true",
+    });
+    const response = await worker.fetch(
+      new Request("http://127.0.0.1:50743/api/v1/threads", {
+        headers: {
+          host: "127.0.0.1:50743",
+          "x-bb-cloud-dev-host": "sawyer",
+        },
+      }),
+      env as never,
+      ctx,
+    );
+
+    expect(response.headers.get("set-cookie")).toBe(
+      "better-auth.session_token=session-token; Max-Age=604800; Domain=.bb.localhost; Path=/; HttpOnly; SameSite=Lax",
     );
   });
 
@@ -1067,6 +1114,7 @@ describe("gate worker share hosts", () => {
     expect(res.status).toBe(403);
     expect(await res.text()).toContain("not your server");
     expect(captured).toHaveLength(0);
+    expect(mockRefreshSession).not.toHaveBeenCalled();
   });
 
   it("accepts the short-lived desktop cookie for the owning account", async () => {
@@ -1159,6 +1207,7 @@ describe("gate worker share hosts", () => {
     expect(captured[0].headers.get(TUNNEL_TARGET_HEADER)).toBe("8000");
     expect(captured[0].headers.get("upgrade")).toBe("websocket");
     expect(mockServeWithCache).not.toHaveBeenCalled();
+    expect(mockRefreshSession).not.toHaveBeenCalled();
   });
 
   it("does not apply machine-credential branch on share hosts", async () => {

--- a/apps/connect/src/worker.ts
+++ b/apps/connect/src/worker.ts
@@ -1,16 +1,15 @@
 import { drizzle } from "drizzle-orm/d1";
 import {
-  CONNECT_SESSION_EXPIRES_IN_SECONDS,
   RESERVED_HANDLES,
   handleAppLinkAssociationRequest,
   parseVisitorHost,
   schema,
 } from "@bb/connect-db";
+import { refreshAccountSessionCookie } from "./account-session.js";
 import { TUNNEL_OFFLINE_HEADER, TunnelDO, type Env } from "./tunnel-do.js";
 import {
   parseCookie,
   markMachineSeen,
-  refreshSessionCookie,
   resolveLabel,
   verifyMachineCredentialDetails,
   verifySessionCookie,
@@ -57,29 +56,9 @@ function text(body: string, status: number): Response {
   });
 }
 
-/**
- * Reissue the session cookie on a non-cacheable response. This automatic body
- * rebuild is correct for direct subrequest and locally produced responses; it
- * must never wrap a cacheable result, whose hit body may be pre-encoded.
- */
-function withRefreshedSessionCookie(
-  response: Response,
-  cookieName: string,
-  cookieValue: string,
-  baseDomain: string,
-  secure: boolean,
-): Response {
-  const attributes = [
-    `${cookieName}=${cookieValue}`,
-    `Max-Age=${CONNECT_SESSION_EXPIRES_IN_SECONDS}`,
-    `Domain=.${baseDomain}`,
-    "Path=/",
-    "HttpOnly",
-    "SameSite=Lax",
-  ];
-  if (secure) attributes.push("Secure");
+function withSetCookie(response: Response, setCookie: string): Response {
   const headers = new Headers(response.headers);
-  headers.append("set-cookie", attributes.join("; "));
+  headers.append("set-cookie", setCookie);
   return new Response(response.body, {
     headers,
     status: response.status,
@@ -507,10 +486,8 @@ export default {
     }
 
     const doRequest = requestForTunnelDo(request, target, "session");
-    const isWebSocketUpgrade =
-      request.headers.get("upgrade")?.toLowerCase() === "websocket";
     // WebSocket upgrades (bb's /ws, terminals) can't be cached — proxy directly.
-    if (isWebSocketUpgrade) {
+    if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
       return stub.fetch(doRequest);
     }
     // Everything else: serve from the edge cache when the origin allows it,
@@ -545,16 +522,14 @@ export default {
     if (
       !cached.cacheable &&
       cookie !== null &&
-      sessionUserId === resolved.userId &&
-      (await refreshSessionCookie(cookie, env.BETTER_AUTH_SECRET, db))
+      sessionUserId === resolved.userId
     ) {
-      return withRefreshedSessionCookie(
-        response,
-        runtime.sessionCookieName,
-        cookie,
-        runtime.baseDomain,
-        !runtime.localCloud,
+      const setCookie = await refreshAccountSessionCookie(
+        `${runtime.sessionCookieName}=${cookie}`,
+        runtime.accountAppUrl,
+        (authRequest) => fetch(authRequest),
       );
+      if (setCookie !== null) return withSetCookie(response, setCookie);
     }
     return response;
   },

--- a/apps/connect/src/worker.ts
+++ b/apps/connect/src/worker.ts
@@ -57,6 +57,11 @@ function text(body: string, status: number): Response {
   });
 }
 
+/**
+ * Reissue the session cookie on a non-cacheable response. This automatic body
+ * rebuild is correct for direct subrequest and locally produced responses; it
+ * must never wrap a cacheable result, whose hit body may be pre-encoded.
+ */
 function withRefreshedSessionCookie(
   response: Response,
   cookieName: string,

--- a/apps/connect/src/worker.ts
+++ b/apps/connect/src/worker.ts
@@ -504,24 +504,6 @@ export default {
     const doRequest = requestForTunnelDo(request, target, "session");
     const isWebSocketUpgrade =
       request.headers.get("upgrade")?.toLowerCase() === "websocket";
-    const refreshedSessionCookie =
-      cookie !== null &&
-      sessionUserId === resolved.userId &&
-      !isWebSocketUpgrade &&
-      (await refreshSessionCookie(cookie, env.BETTER_AUTH_SECRET, db))
-        ? cookie
-        : null;
-    const finish = (response: Response): Response =>
-      refreshedSessionCookie !== null
-        ? withRefreshedSessionCookie(
-            response,
-            runtime.sessionCookieName,
-            refreshedSessionCookie,
-            runtime.baseDomain,
-            !runtime.localCloud,
-          )
-        : response;
-
     // WebSocket upgrades (bb's /ws, terminals) can't be cached — proxy directly.
     if (isWebSocketUpgrade) {
       return stub.fetch(doRequest);
@@ -529,12 +511,13 @@ export default {
     // Everything else: serve from the edge cache when the origin allows it,
     // otherwise proxy through the tunnel. Namespace by full host label so a
     // share response never collides with bare-label app assets.
-    const response = await serveWithCache(
+    const cached = await serveWithCache(
       request,
       cacheNamespace(routingKey, target),
       ctx,
       () => stub.fetch(doRequest),
     );
+    let response = cached.response;
     // Tunnel down + a browser navigation → the styled offline page, using the
     // last_seen_at already resolved for this server. API/asset/fetch requests
     // (no text/html Accept) keep the DO's plain 503 so clients handle it.
@@ -543,15 +526,31 @@ export default {
       response.headers.get(TUNNEL_OFFLINE_HEADER) === "1" &&
       wantsHtml(request)
     ) {
-      return finish(
-        offlinePage(
-          resolved.kind === "server"
-            ? resolved.server.lastSeenAt
-            : resolved.machine.lastSeenAt,
-          resolved.kind,
-        ),
+      response = offlinePage(
+        resolved.kind === "server"
+          ? resolved.server.lastSeenAt
+          : resolved.machine.lastSeenAt,
+        resolved.kind,
       );
     }
-    return finish(response);
+
+    // Edge-cacheable responses do not count as session activity. Refresh both
+    // the D1 row and browser cookie only on a non-cacheable HTTP response so
+    // their expiry stays in sync without rebuilding a pre-encoded cache hit.
+    if (
+      !cached.cacheable &&
+      cookie !== null &&
+      sessionUserId === resolved.userId &&
+      (await refreshSessionCookie(cookie, env.BETTER_AUTH_SECRET, db))
+    ) {
+      return withRefreshedSessionCookie(
+        response,
+        runtime.sessionCookieName,
+        cookie,
+        runtime.baseDomain,
+        !runtime.localCloud,
+      );
+    }
+    return response;
   },
 } satisfies ExportedHandler<Env>;

--- a/apps/connect/src/worker.ts
+++ b/apps/connect/src/worker.ts
@@ -1,5 +1,6 @@
 import { drizzle } from "drizzle-orm/d1";
 import {
+  CONNECT_SESSION_EXPIRES_IN_SECONDS,
   RESERVED_HANDLES,
   handleAppLinkAssociationRequest,
   parseVisitorHost,
@@ -9,6 +10,7 @@ import { TUNNEL_OFFLINE_HEADER, TunnelDO, type Env } from "./tunnel-do.js";
 import {
   parseCookie,
   markMachineSeen,
+  refreshSessionCookie,
   resolveLabel,
   verifyMachineCredentialDetails,
   verifySessionCookie,
@@ -52,6 +54,31 @@ function text(body: string, status: number): Response {
   return new Response(body, {
     status,
     headers: { "content-type": "text/plain; charset=utf-8" },
+  });
+}
+
+function withRefreshedSessionCookie(
+  response: Response,
+  cookieName: string,
+  cookieValue: string,
+  baseDomain: string,
+  secure: boolean,
+): Response {
+  const attributes = [
+    `${cookieName}=${cookieValue}`,
+    `Max-Age=${CONNECT_SESSION_EXPIRES_IN_SECONDS}`,
+    `Domain=.${baseDomain}`,
+    "Path=/",
+    "HttpOnly",
+    "SameSite=Lax",
+  ];
+  if (secure) attributes.push("Secure");
+  const headers = new Headers(response.headers);
+  headers.append("set-cookie", attributes.join("; "));
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
   });
 }
 
@@ -475,9 +502,28 @@ export default {
     }
 
     const doRequest = requestForTunnelDo(request, target, "session");
+    const isWebSocketUpgrade =
+      request.headers.get("upgrade")?.toLowerCase() === "websocket";
+    const refreshedSessionCookie =
+      cookie !== null &&
+      sessionUserId === resolved.userId &&
+      !isWebSocketUpgrade &&
+      (await refreshSessionCookie(cookie, env.BETTER_AUTH_SECRET, db))
+        ? cookie
+        : null;
+    const finish = (response: Response): Response =>
+      refreshedSessionCookie !== null
+        ? withRefreshedSessionCookie(
+            response,
+            runtime.sessionCookieName,
+            refreshedSessionCookie,
+            runtime.baseDomain,
+            !runtime.localCloud,
+          )
+        : response;
 
     // WebSocket upgrades (bb's /ws, terminals) can't be cached — proxy directly.
-    if (request.headers.get("upgrade")?.toLowerCase() === "websocket") {
+    if (isWebSocketUpgrade) {
       return stub.fetch(doRequest);
     }
     // Everything else: serve from the edge cache when the origin allows it,
@@ -497,13 +543,15 @@ export default {
       response.headers.get(TUNNEL_OFFLINE_HEADER) === "1" &&
       wantsHtml(request)
     ) {
-      return offlinePage(
-        resolved.kind === "server"
-          ? resolved.server.lastSeenAt
-          : resolved.machine.lastSeenAt,
-        resolved.kind,
+      return finish(
+        offlinePage(
+          resolved.kind === "server"
+            ? resolved.server.lastSeenAt
+            : resolved.machine.lastSeenAt,
+          resolved.kind,
+        ),
       );
     }
-    return response;
+    return finish(response);
   },
 } satisfies ExportedHandler<Env>;

--- a/apps/connect/src/worker.ts
+++ b/apps/connect/src/worker.ts
@@ -5,7 +5,7 @@ import {
   parseVisitorHost,
   schema,
 } from "@bb/connect-db";
-import { refreshAccountSessionCookie } from "./account-session.js";
+import { refreshAccountSessionCookies } from "./account-session.js";
 import { TUNNEL_OFFLINE_HEADER, TunnelDO, type Env } from "./tunnel-do.js";
 import {
   invalidateSessionCookie,
@@ -57,9 +57,12 @@ function text(body: string, status: number): Response {
   });
 }
 
-function withSetCookie(response: Response, setCookie: string): Response {
+function withSetCookies(
+  response: Response,
+  setCookies: readonly string[],
+): Response {
   const headers = new Headers(response.headers);
-  headers.append("set-cookie", setCookie);
+  for (const setCookie of setCookies) headers.append("set-cookie", setCookie);
   return new Response(response.body, {
     headers,
     status: response.status,
@@ -533,12 +536,12 @@ export default {
       // hint so the next request observes the renewed row instead of repeating
       // the cross-worker check for the rest of the short verification TTL.
       invalidateSessionCookie(cookie);
-      const setCookie = await refreshAccountSessionCookie(
+      const setCookies = await refreshAccountSessionCookies(
         `${runtime.sessionCookieName}=${cookie}`,
         runtime.accountAppUrl,
         (authRequest) => fetch(authRequest),
       );
-      if (setCookie !== null) return withSetCookie(response, setCookie);
+      if (setCookies !== null) return withSetCookies(response, setCookies);
     }
     return response;
   },

--- a/apps/connect/src/worker.ts
+++ b/apps/connect/src/worker.ts
@@ -8,11 +8,12 @@ import {
 import { refreshAccountSessionCookie } from "./account-session.js";
 import { TUNNEL_OFFLINE_HEADER, TunnelDO, type Env } from "./tunnel-do.js";
 import {
+  invalidateSessionCookie,
   parseCookie,
   markMachineSeen,
   resolveLabel,
   verifyMachineCredentialDetails,
-  verifySessionCookie,
+  verifySessionCookieDetails,
 } from "./session.js";
 import {
   handleCreateDesktopSession,
@@ -469,9 +470,10 @@ export default {
     const appUrl = runtime.accountAppUrl;
     if (!cookie && !desktopCookie)
       return signInPage(label, appUrl, url.toString());
-    const sessionUserId = cookie
-      ? await verifySessionCookie(cookie, env.BETTER_AUTH_SECRET, db)
+    const verifiedSession = cookie
+      ? await verifySessionCookieDetails(cookie, env.BETTER_AUTH_SECRET, db)
       : null;
+    const sessionUserId = verifiedSession?.userId ?? null;
     const desktopUserId = desktopCookie
       ? await verifyDesktopSessionCookie(desktopCookie, env.BETTER_AUTH_SECRET)
       : null;
@@ -516,14 +518,21 @@ export default {
       );
     }
 
-    // Edge-cacheable responses do not count as session activity. Refresh both
-    // the D1 row and browser cookie only on a non-cacheable HTTP response so
-    // their expiry stays in sync without rebuilding a pre-encoded cache hit.
+    // Edge-cacheable responses do not count as session activity. Once Better
+    // Auth's update-age boundary arrives, refresh both the D1 row and browser
+    // cookie on a non-cacheable HTTP response. This keeps their expiry in sync
+    // without rebuilding a pre-encoded cache hit or calling the account worker
+    // on every dynamic request.
     if (
       !cached.cacheable &&
       cookie !== null &&
-      sessionUserId === resolved.userId
+      sessionUserId === resolved.userId &&
+      verifiedSession?.needsRefresh === true
     ) {
+      // The account worker will re-read D1. Drop this isolate's old expiration
+      // hint so the next request observes the renewed row instead of repeating
+      // the cross-worker check for the rest of the short verification TTL.
+      invalidateSessionCookie(cookie);
       const setCookie = await refreshAccountSessionCookie(
         `${runtime.sessionCookieName}=${cookie}`,
         runtime.accountAppUrl,

--- a/apps/connect/test/encoding-fixture.ts
+++ b/apps/connect/test/encoding-fixture.ts
@@ -78,6 +78,8 @@ export default {
       return new Response(cached.body, cached);
     }
 
-    return serveWithCache(request, NAMESPACE, ctx, () => stub.fetch(request));
+    return (
+      await serveWithCache(request, NAMESPACE, ctx, () => stub.fetch(request))
+    ).response;
   },
 };

--- a/apps/connect/wrangler.jsonc
+++ b/apps/connect/wrangler.jsonc
@@ -19,7 +19,7 @@
   "main": "./src/worker.ts",
   "account_id": "7bb84c630057dafa53e2aacbe6bd094f",
   "compatibility_date": "2026-06-11",
-  "compatibility_flags": ["nodejs_compat"],
+  "compatibility_flags": ["nodejs_compat", "global_fetch_strictly_public"],
   "observability": { "enabled": true },
   "migrations": [{ "tag": "v1", "new_sqlite_classes": ["TunnelDO"] }],
   "durable_objects": {

--- a/apps/web/src/server/auth.ts
+++ b/apps/web/src/server/auth.ts
@@ -1,7 +1,14 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "@better-auth/drizzle-adapter";
 import { drizzle } from "drizzle-orm/d1";
-import { account, session, user, verification } from "@bb/connect-db";
+import {
+  account,
+  CONNECT_SESSION_EXPIRES_IN_SECONDS,
+  CONNECT_SESSION_UPDATE_AGE_SECONDS,
+  session,
+  user,
+  verification,
+} from "@bb/connect-db";
 import type { Env } from "./env.js";
 import { resolveDevEmailPasswordEnabled } from "./local-auth.js";
 
@@ -33,6 +40,10 @@ export function createAuth(env: Env) {
       provider: "sqlite",
       schema: { user, session, account, verification },
     }) as unknown as Parameters<typeof betterAuth>[0]["database"],
+    session: {
+      expiresIn: CONNECT_SESSION_EXPIRES_IN_SECONDS,
+      updateAge: CONNECT_SESSION_UPDATE_AGE_SECONDS,
+    },
     emailAndPassword: { enabled: devEmailPasswordEnabled },
     user: {
       additionalFields: {

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -53,7 +53,15 @@ export default defineConfig(({ command }) => {
     plugins: [
       cloudflare(cloudflareConfig),
       tailwindcss(),
-      tanstackStart(),
+      tanstackStart({
+        router: {
+          routeTreeFileHeader: [
+            "/* oxlint-disable */",
+            "// @ts-nocheck",
+            "// noinspection JSUnusedGlobalSymbols",
+          ],
+        },
+      }),
       viteReact(),
     ],
   };

--- a/packages/connect-db/src/constants.ts
+++ b/packages/connect-db/src/constants.ts
@@ -132,8 +132,8 @@ export const SERVER_OFFLINE_AFTER_MS = 90 * 1000;
 
 /**
  * Account-session lifetime and sliding-refresh cadence. Better Auth owns this
- * policy; the connect gate calls its session route after eligible activity on
- * `<label>.getbb.app`.
+ * policy; after eligible activity on `<label>.getbb.app`, the connect gate
+ * calls its session route only once this update-age boundary has arrived.
  */
 export const CONNECT_SESSION_EXPIRES_IN_SECONDS = 7 * 24 * 60 * 60;
 export const CONNECT_SESSION_UPDATE_AGE_SECONDS = 24 * 60 * 60;

--- a/packages/connect-db/src/constants.ts
+++ b/packages/connect-db/src/constants.ts
@@ -130,6 +130,14 @@ export const CONNECT_CODE_TTL_MS = 10 * 60 * 1000;
 /** A server is shown "offline" if no heartbeat within this window. */
 export const SERVER_OFFLINE_AFTER_MS = 90 * 1000;
 
+/**
+ * Account-session lifetime and sliding-refresh cadence. Better Auth creates
+ * the session; the connect gate mirrors its refresh behavior for activity on
+ * `<label>.getbb.app`, which never passes through Better Auth's own routes.
+ */
+export const CONNECT_SESSION_EXPIRES_IN_SECONDS = 7 * 24 * 60 * 60;
+export const CONNECT_SESSION_UPDATE_AGE_SECONDS = 24 * 60 * 60;
+
 export type HandleValidationError =
   | "too-short"
   | "too-long"

--- a/packages/connect-db/src/constants.ts
+++ b/packages/connect-db/src/constants.ts
@@ -131,9 +131,9 @@ export const CONNECT_CODE_TTL_MS = 10 * 60 * 1000;
 export const SERVER_OFFLINE_AFTER_MS = 90 * 1000;
 
 /**
- * Account-session lifetime and sliding-refresh cadence. Better Auth creates
- * the session; the connect gate mirrors its refresh behavior for activity on
- * `<label>.getbb.app`, which never passes through Better Auth's own routes.
+ * Account-session lifetime and sliding-refresh cadence. Better Auth owns this
+ * policy; the connect gate calls its session route after eligible activity on
+ * `<label>.getbb.app`.
  */
 export const CONNECT_SESSION_EXPIRES_IN_SECONDS = 7 * 24 * 60 * 60;
 export const CONNECT_SESSION_UPDATE_AGE_SECONDS = 24 * 60 * 60;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,6 +512,9 @@ importers:
       '@bb/tsconfig':
         specifier: workspace:*
         version: link:../../packages/tsconfig
+      '@better-auth/drizzle-adapter':
+        specifier: ^1.6.23
+        version: 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.2.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/react@19.2.13)(better-sqlite3@12.10.0)(kysely@0.29.3)(react@19.2.4))
       '@cloudflare/workers-types':
         specifier: ^4.20260610.0
         version: 4.20260702.1
@@ -521,6 +524,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.10
+      better-auth:
+        specifier: ^1.6.23
+        version: 1.6.23(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.1)(@tanstack/react-start@1.168.25(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.1)(yaml@2.9.0)))(better-sqlite3@12.10.0)(drizzle-orm@0.38.4(@cloudflare/workers-types@4.20260702.1)(@opentelemetry/api@1.9.1)(@types/better-sqlite3@7.6.13)(@types/react@19.2.13)(better-sqlite3@12.10.0)(kysely@0.29.3)(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.1(@opentelemetry/api@1.9.1)(@types/node@22.19.10)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@22.19.10)(@typescript/typescript6@6.0.2))(vite@8.0.12(@types/node@22.19.10)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.1)(yaml@2.9.0)))(vue@3.5.39(@typescript/typescript6@6.0.2))
       better-sqlite3:
         specifier: 12.10.0
         version: 12.10.0


### PR DESCRIPTION
## What was wrong

bb Connect authenticated requests by validating the Better Auth session cookie directly against D1. That bypassed Better Auth's normal session endpoint, so the configured sliding refresh never ran: a user who stayed active only through Connect still had a fixed seven-day database expiration and was logged out when it elapsed.

Separately, the Oxc migration changed the checked-in TanStack route tree's generated lint header from ESLint to Oxlint without changing TanStack Start's generator configuration. Every web dev-server start or production build therefore restored the generator's default `/* eslint-disable */` header and left `apps/web/src/routeTree.gen.ts` dirty.

## What changed

- Define the Connect session lifetime and update age once in `@bb/connect-db`, and pass them explicitly to Better Auth.
- Keep Connect's existing short-lived direct-verification cache for the edge gate, while ensuring a positive cache entry cannot outlive the database session.
- Retain the verified D1 session expiration in that cache and derive a non-authoritative refresh hint from the same seven-day lifetime and one-day update age that configure Better Auth.
- Only when that update-age boundary has arrived, call the account worker's real Better Auth `get-session` route after authenticated, non-cacheable Connect HTTP traffic. Normal dynamic requests therefore have no extra Worker hop. Better Auth still rechecks D1 and owns the update, race behavior, and renewed cookie attributes.
- Drop the old expiration hint before the Better Auth check so the next request observes the renewed D1 row rather than repeating the cross-worker call for the remainder of Connect's 20-second verification-cache TTL.
- Return cacheability explicitly from the edge-cache layer and skip refresh for cache hits, cacheable misses, wrong-account requests, desktop-cookie requests, and WebSocket upgrades. Dynamic traffic counts as activity; static-only and WebSocket-only traffic deliberately do not.
- Enable public Worker-to-Worker fetches for the Connect worker so the wildcard gate can reach the account worker on the apex domain without embedding Better Auth in the latency-sensitive gate bundle.
- Preserve every `Set-Cookie` field returned by Better Auth as a separate response header, so future auth configuration that emits more than one cookie cannot fold them into an invalid combined cookie.
- Add database-backed tests using Better Auth itself plus worker response tests for production/local cookies, update-age gating, cache hits and misses, account isolation, and WebSocket behavior.
- Configure TanStack Start's route generator to emit the repository's Oxlint header, keeping the tracked route tree stable across dev-server starts and production builds.

This does not change the server/host-daemon wire contract, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged. It adds no CLI, SDK, or user-facing configuration surface.

## How you verified

The session regression tests exercise Better Auth against real in-memory SQLite: Connect reports a fresh session as not due and a session at Better Auth's update-age boundary as due; Better Auth then moves the due session forward and returns its cross-subdomain cookie, while a fresh session remains unchanged. A two-cookie response test verifies both cookie fields stay separate through the boundary. Worker tests prove fresh dynamic traffic makes no account-worker request, due dynamic traffic renews, and cacheable responses and WebSockets skip refresh even when it is due. The real-workerd encoding suite verifies cached gzip bodies remain intact.

A local Cloud end-to-end check created a temporary account and expiring session, sent an authenticated request through the Connect wildcard gate, and observed the actual Connect → web Better Auth subrequest: the gate returned the expected offline 503 with a renewed cookie and D1 held the new seven-day expiration. The temporary account/server were removed afterward (zero rows remained).

The route-tree regression was reproduced on `main`: starting the web dev server changed the tracked header back to `/* eslint-disable */`. With the inline TanStack Start router configuration, repeated forced web production builds leave `apps/web/src/routeTree.gen.ts` byte-for-byte unchanged.

- `pnpm exec turbo run test --filter=@bb/connect --force` (114 tests passed)
- `pnpm exec turbo run test --filter=@bb/connect --force -- --run src/session.test.ts` (15 tests passed)
- `pnpm exec turbo run test --filter=@bb/connect --force -- --run src/worker.test.ts` (76 tests passed)
- `pnpm exec turbo run test --filter=@bb/connect --force -- --run src/response-encoding.test.ts` (6 real-workerd tests passed)
- `pnpm exec turbo run test --filter=@bb/web --force` (79 tests passed)
- `pnpm exec turbo run typecheck --filter=@bb/connect --filter=@bb/web --filter=@bb/connect-db`
- `pnpm exec turbo run build --filter=@bb/web --force` (route tree unchanged)
- `pnpm exec wrangler deploy --dry-run` from `apps/connect` (261.20 KiB / 67.23 KiB gzip)
- `pnpm install --frozen-lockfile --offline --ignore-scripts`
- `pnpm lint` (zero errors)
- `pnpm exec oxfmt --check apps/connect/package.json apps/connect/src/account-session.ts apps/connect/src/cache.ts apps/connect/src/session.ts apps/connect/src/session.test.ts apps/connect/src/worker.ts apps/connect/src/worker.test.ts apps/connect/test/encoding-fixture.ts apps/web/src/server/auth.ts apps/web/vite.config.ts packages/connect-db/src/constants.ts`
- `git diff --check`

Fixes: N/A — reported directly in bb.

> AGENT GENERATED
