### PR TITLE
Recover one-way-stale remote daemon connections

### DIFF
--- a/apps/host-daemon/src/server-connection-support.ts
+++ b/apps/host-daemon/src/server-connection-support.ts
@@ -44,6 +44,7 @@ export type CreateReconnectingWebSocket = (
 export type HostDaemonServerTerminalMessage = Exclude<
   HostDaemonServerWsMessage,
   | { type: "session-close" }
+  | { type: "heartbeat-ack" }
   | HostDaemonOnlineRpcRequestMessage
   | HostDaemonWatchSetReplaceMessage
   | HostDaemonConnectSharesReplaceMessage

--- a/apps/host-daemon/src/server-connection.test.ts
+++ b/apps/host-daemon/src/server-connection.test.ts
@@ -357,7 +357,7 @@ describe("ServerConnection", () => {
   it("reports a system-suspension gap without calling it a heartbeat stall", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
-    const { connection, logger } = createConnectionFixture({
+    const { connection, logger, webSocket } = createConnectionFixture({
       heartbeatIntervalMs: 5_000,
       leaseTimeoutMs: 30_000,
     });
@@ -375,6 +375,44 @@ describe("ServerConnection", () => {
       expect(logger.info).toHaveBeenCalledWith(
         expect.objectContaining({ gapMs: 300_000 }),
         "Host daemon resumed after likely system suspension",
+      );
+      expect(webSocket.sockets[0]?.reconnect).not.toHaveBeenCalled();
+    } finally {
+      await connection.shutdown();
+    }
+  });
+
+  it("reconnects when server heartbeat acknowledgements stop", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { connection, logger, webSocket } = createConnectionFixture({
+      heartbeatIntervalMs: 5_000,
+      leaseTimeoutMs: 30_000,
+    });
+    try {
+      await connection.start();
+      const socket = webSocket.sockets[0];
+      if (!socket) {
+        throw new Error("Expected test socket");
+      }
+
+      await vi.advanceTimersByTimeAsync(25_000);
+      socket.onmessage?.({ data: JSON.stringify({ type: "heartbeat-ack" }) });
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(socket.reconnect).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(socket.reconnect).toHaveBeenCalledWith(
+        1013,
+        "heartbeat-ack-timeout",
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lastAcknowledgedAt: 25_000,
+          leaseTimeoutMs: 30_000,
+          sessionId: "session-1",
+        }),
+        "Server heartbeat acknowledgements stopped; reconnecting",
       );
     } finally {
       await connection.shutdown();

--- a/apps/host-daemon/src/server-connection.ts
+++ b/apps/host-daemon/src/server-connection.ts
@@ -146,6 +146,7 @@ export class ServerConnection {
   private session: HostDaemonSessionOpenResponse | null = null;
   private websocket: ReconnectingWebSocketLike | null = null;
   private heartbeatInterval: ReturnType<typeof setInterval> | null = null;
+  private lastHeartbeatAcknowledgedAt: number | null = null;
   private lastHeartbeatTickAt: number | null = null;
   private stopped = false;
   private sessionCloseHandler: SessionCloseHandler | undefined;
@@ -608,6 +609,13 @@ export class ServerConnection {
       return;
     }
 
+    if (message.data.type === "heartbeat-ack") {
+      if (this.session !== null) {
+        this.lastHeartbeatAcknowledgedAt = Date.now();
+      }
+      return;
+    }
+
     if (message.data.type === "host-rpc.request") {
       const rpcRequest = message.data;
       void Promise.resolve(this.options.onHostRpcRequest?.(rpcRequest)).catch(
@@ -726,7 +734,9 @@ export class ServerConnection {
       return;
     }
 
-    this.lastHeartbeatTickAt = Date.now();
+    const startedAt = Date.now();
+    this.lastHeartbeatAcknowledgedAt = startedAt;
+    this.lastHeartbeatTickAt = startedAt;
     this.heartbeatInterval = setInterval(() => {
       const session = this.session;
       if (!session) {
@@ -737,12 +747,11 @@ export class ServerConnection {
       if (lastTickAt !== null) {
         const gapMs = now - lastTickAt;
         const thresholdMs = session.leaseTimeoutMs / 2;
-        if (
-          isLikelySystemSuspensionDelay({
-            gapMs,
-            intervalMs: session.heartbeatIntervalMs,
-          })
-        ) {
+        const resumedAfterSuspension = isLikelySystemSuspensionDelay({
+          gapMs,
+          intervalMs: session.heartbeatIntervalMs,
+        });
+        if (resumedAfterSuspension) {
           this.options.logger.info(
             {
               gapMs,
@@ -753,6 +762,10 @@ export class ServerConnection {
             },
             "Host daemon resumed after likely system suspension",
           );
+          // The process could not receive acknowledgements while suspended.
+          // Give the resumed connection a full lease window to prove that its
+          // server-to-daemon direction still works.
+          this.lastHeartbeatAcknowledgedAt = now;
         } else if (gapMs > thresholdMs) {
           this.options.logger.warn(
             {
@@ -772,16 +785,34 @@ export class ServerConnection {
         return;
       }
 
+      const lastAcknowledgedAt = this.lastHeartbeatAcknowledgedAt;
+      if (
+        lastAcknowledgedAt !== null &&
+        now - lastAcknowledgedAt > session.leaseTimeoutMs
+      ) {
+        this.options.logger.warn(
+          {
+            lastAcknowledgedAt,
+            leaseTimeoutMs: session.leaseTimeoutMs,
+            sessionId: session.sessionId,
+          },
+          "Server heartbeat acknowledgements stopped; reconnecting",
+        );
+        this.clearHeartbeat();
+        this.websocket.reconnect(1013, "heartbeat-ack-timeout");
+        return;
+      }
+
       this.sendMessage({ type: "heartbeat" });
     }, this.session.heartbeatIntervalMs);
   }
 
   private clearHeartbeat(): void {
-    if (!this.heartbeatInterval) {
-      return;
+    if (this.heartbeatInterval) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = null;
     }
-    clearInterval(this.heartbeatInterval);
-    this.heartbeatInterval = null;
+    this.lastHeartbeatAcknowledgedAt = null;
     this.lastHeartbeatTickAt = null;
   }
 

--- a/apps/server/src/services/system/execution-options.ts
+++ b/apps/server/src/services/system/execution-options.ts
@@ -21,6 +21,7 @@ import { ApiError } from "../../errors.js";
 import { callHostRetryableOnlineRpc } from "../hosts/online-rpc.js";
 import { getHostPermissionCeiling } from "../hosts/permission-ceiling.js";
 import { requireEnvironment } from "../lib/entity-lookup.js";
+import { createProviderListingBudget } from "../providers/native-roots.js";
 import type { ProviderRegistryService } from "../providers/provider-registry.js";
 import { getSupportedReasoningLevelsForProvider } from "../threads/thread-reasoning-policy.js";
 import { resolveSystemLookupHostId } from "./host-lookup.js";
@@ -170,6 +171,7 @@ async function listInstalledPluginProviderInfos(
         registration.visibility === "installed" &&
         providerMatchesCapability(registration.info, capability),
     );
+  const budget = createProviderListingBudget();
   const results = await mapProviderMaintenanceRequests(
     registrations,
     async (registration) => {
@@ -181,7 +183,7 @@ async function listInstalledPluginProviderInfos(
       try {
         const result = await callHostRetryableOnlineRpc(deps, {
           hostId,
-          timeoutMs: COMMAND_TIMEOUT_MS,
+          timeoutMs: budget.remainingMs(),
           command: {
             type: "provider.health",
             providerId: registration.info.id,

--- a/apps/server/src/ws/daemon-protocol.ts
+++ b/apps/server/src/ws/daemon-protocol.ts
@@ -187,13 +187,15 @@ export function onDaemonSocketMessage(
         });
         return;
       }
-      if (result.data.type !== "heartbeat") {
-        deps.terminalSessions.handleDaemonTerminalMessage({
-          hostId: args.hostId,
-          message: result.data,
-          sessionId: args.sessionId,
-        });
+      if (result.data.type === "heartbeat") {
+        args.socket.send(JSON.stringify({ type: "heartbeat-ack" }));
+        return;
       }
+      deps.terminalSessions.handleDaemonTerminalMessage({
+        hostId: args.hostId,
+        message: result.data,
+        sessionId: args.sessionId,
+      });
     });
   } catch (error) {
     if (error instanceof ApiError && error.body.code === "inactive_session") {

--- a/apps/server/test/internal/internal-environment-change.test.ts
+++ b/apps/server/test/internal/internal-environment-change.test.ts
@@ -48,6 +48,9 @@ describe("internal environment change websocket hints", () => {
         .get();
       expect(updatedSession?.status).toBe("active");
       expect(updatedSession?.leaseExpiresAt).toBeGreaterThan(Date.now());
+      expect(socket.send).toHaveBeenCalledWith(
+        JSON.stringify({ type: "heartbeat-ack" }),
+      );
       expect(socket.close).not.toHaveBeenCalled();
     });
   });

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -565,6 +565,45 @@ describe("resolveSystemExecutionOptions", () => {
     });
   });
 
+  it("spends one command timeout across installed-only provider discovery", async () => {
+    vi.useFakeTimers();
+    try {
+      await withTestHarness({}, async (harness) => {
+        const { host, session } = seedHostSession(harness.deps, {
+          id: "host-execution-options-provider-discovery-budget",
+        });
+        const responder = registerHostRpcResponder(harness, {
+          hostId: host.id,
+          sessionId: session.id,
+          handle: () => new Promise(() => undefined),
+        });
+
+        let settled = false;
+        const pendingProviders = listSystemProviderInfos(harness.deps, {
+          hostId: host.id,
+        }).then((providers) => {
+          settled = true;
+          return providers;
+        });
+
+        await vi.advanceTimersByTimeAsync(0);
+        expect(responder.requests).toHaveLength(3);
+        await vi.advanceTimersByTimeAsync(29_999);
+        expect(settled).toBe(false);
+
+        await vi.advanceTimersByTimeAsync(1);
+        const providers = await pendingProviders;
+        expect(settled).toBe(true);
+        expect(responder.requests).toHaveLength(3);
+        expect(providers.map((provider) => provider.id)).not.toContain(
+          "acp-opencode",
+        );
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it.each([
     {
       name: "status returns 502",

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -298,9 +298,14 @@
 // per-provider scan table is gone; an old daemon rejects the new field and an
 // old server's `nativeSkillRoots` fails the new daemon's strict schema.
 //
+// Version 165 adds a server-to-daemon acknowledgement for every daemon
+// heartbeat. The daemon uses the acknowledgement to detect a one-way-stale
+// websocket and reconnect instead of remaining registered but unable to
+// receive host RPC commands.
+//
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 164 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 165 as const;
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/src/session.ts
+++ b/packages/host-daemon-contract/src/session.ts
@@ -592,6 +592,11 @@ export const hostDaemonServerWsMessageSchema = z.discriminatedUnion("type", [
       reason: hostDaemonSessionCloseReasonSchema,
     })
     .strict(),
+  z
+    .object({
+      type: z.literal("heartbeat-ack"),
+    })
+    .strict(),
   hostDaemonOnlineRpcRequestMessageSchema,
   hostDaemonWatchSetReplaceMessageSchema,
   hostDaemonConnectSharesReplaceMessageSchema,

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1039,7 +1039,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(164);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(165);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 
@@ -3519,6 +3519,19 @@ describe("host-daemon session schemas", () => {
       type: "session-close",
       reason: "daemon-disconnect",
     });
+
+    expect(
+      hostDaemonServerWsMessageSchema.parse({
+        type: "heartbeat-ack",
+      }),
+    ).toEqual({ type: "heartbeat-ack" });
+
+    expect(() =>
+      hostDaemonServerWsMessageSchema.parse({
+        type: "heartbeat-ack",
+        sessionId: "session-1",
+      }),
+    ).toThrow();
 
     expect(() =>
       hostDaemonServerWsMessageSchema.parse({


### PR DESCRIPTION
## What was wrong

A remote host could lose only the server-to-daemon direction of its Connect-relayed WebSocket after sleep or a network transition while daemon-to-server heartbeats still arrived. The server therefore kept the host registered and sent host RPCs into a stale return path. Provider discovery amplified one unreachable host into two 30-second waves because four installed-only probes ran with concurrency three and each received a fresh command timeout. See #2358.

## What changed

- The server now acknowledges every daemon heartbeat, and the daemon tracks the last acknowledgement as end-to-end proof that it can still receive server messages.
- If acknowledgements stop for longer than the session lease timeout, the daemon reconnects. A likely system-suspension timer gap resets the acknowledgement grace window so waking a laptop does not cause an immediate false reconnect.
- Installed-only provider health probes now share one provider-listing deadline, preventing queued probes from starting another full timeout wave.
- The server-to-daemon WebSocket contract now includes `heartbeat-ack`, and `HOST_DAEMON_PROTOCOL_VERSION` is bumped from 164 to 165 so enrolled hosts update atomically with the wire change.

## How you verified

Added regression coverage that fails without the change:

- contract parsing and strictness for `heartbeat-ack`
- server heartbeat acknowledgement emission
- daemon reconnect after acknowledgements stop, plus sleep/wake grace
- one shared timeout across four installed-only provider probes

Commands run after rebasing onto current `main`:

```sh
pnpm exec turbo run test --filter=@bb/host-daemon-contract --force -- test/contract.test.ts
pnpm exec turbo run test --filter=@bb/host-daemon --force -- src/server-connection.test.ts
pnpm exec turbo run test --filter=@bb/server --force -- test/internal/internal-environment-change.test.ts test/system/execution-options.test.ts
pnpm exec turbo run typecheck --filter=@bb/host-daemon-contract --filter=@bb/host-daemon --filter=@bb/server
```

All 94 focused tests passed, and all three affected packages typechecked.

Fixes #2358

> AGENT GENERATED
