### PR TITLE
Speed up new thread submission

### DIFF
--- a/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
+++ b/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
@@ -1075,14 +1075,21 @@ describe("PluginNewThreadComposer seeding", () => {
       latestPromptBoxProps().onSubmit();
     });
     expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(latestPromptBoxProps().value).toBe("");
 
     await act(async () => {
       finishSubmit?.();
     });
   });
 
-  it("preserves the draft when submission fails", async () => {
-    const onSubmit = vi.fn().mockRejectedValue(new Error("create failed"));
+  it("restores the optimistically cleared draft when submission fails", async () => {
+    let failSubmit: (() => void) | null = null;
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          failSubmit = () => reject(new Error("create failed"));
+        }),
+    );
     renderComposer(STORED_REQUEST, onSubmit, "failed-submit");
     await waitFor(() => {
       expect(latestPromptBoxProps().disabled).toBe(false);
@@ -1090,10 +1097,41 @@ describe("PluginNewThreadComposer seeding", () => {
 
     act(() => latestPromptBoxProps().onSubmit());
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(latestPromptBoxProps().value).toBe("");
+    await act(async () => {
+      failSubmit?.();
+    });
     await waitFor(() => {
       expect(latestPromptBoxProps().isSubmitting).toBe(false);
     });
     expect(latestPromptBoxProps().value).toBe("review every PR for slop");
+  });
+
+  it("does not replace a new draft when submission fails", async () => {
+    let failSubmit: (() => void) | null = null;
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          failSubmit = () => reject(new Error("create failed"));
+        }),
+    );
+    renderComposer(STORED_REQUEST, onSubmit, "failed-submit-new-draft");
+    await waitFor(() => {
+      expect(latestPromptBoxProps().disabled).toBe(false);
+    });
+
+    act(() => latestPromptBoxProps().onSubmit());
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(latestPromptBoxProps().value).toBe("");
+    act(() => latestPromptBoxProps().onChange("next thread", []));
+    await act(async () => {
+      failSubmit?.();
+    });
+
+    await waitFor(() => {
+      expect(latestPromptBoxProps().isSubmitting).toBe(false);
+    });
+    expect(latestPromptBoxProps().value).toBe("next thread");
   });
 
   it("keeps the old project when attachment copying fails", async () => {

--- a/apps/app/src/components/promptbox/NewThreadComposer.tsx
+++ b/apps/app/src/components/promptbox/NewThreadComposer.tsx
@@ -700,7 +700,7 @@ export function NewThreadComposer({
   // Branch data enriches the picker and can downgrade a confirmed non-Git or
   // commitless source, but loading it is not a creation prerequisite. A
   // default worktree request is resolved authoritatively by the server during
-  // thread creation, including another host.list_branches inspection.
+  // thread creation, including a host.list_branches inspection.
   useEffect(() => {
     if (
       !worktreeUnavailable ||
@@ -1127,13 +1127,18 @@ export function NewThreadComposer({
       isSubmittingRef.current = true;
       setIsSubmitting(true);
       setAttachmentError(null);
+      const clearedSubmittedDraft =
+        promptDraft.clearIfCurrentMatches(submittedDraft);
       try {
         await onSubmit(request);
         clearReuseEnvironment();
-        promptDraft.clearIfCurrentMatches(submittedDraft);
       } catch {
-        // The caller owns error presentation. A rejected submission preserves
-        // the exact draft so it can be retried.
+        // The caller owns error presentation. Restore the submitted draft only
+        // when the optimistic clear succeeded and nothing replaced it while the
+        // request was pending.
+        if (clearedSubmittedDraft) {
+          promptDraft.restoreIfEmpty(submittedDraft);
+        }
       } finally {
         isSubmittingRef.current = false;
         setIsSubmitting(false);

--- a/apps/server/src/services/threads/thread-create.ts
+++ b/apps/server/src/services/threads/thread-create.ts
@@ -334,12 +334,20 @@ function requireLiveSourceThread(
  * relates to origin; the default spec and a plain name that is the default
  * branch both prefer origin when local is equal or behind. A fork names the
  * branch its source environment is on, so it keeps that branch verbatim.
+ * Origin-qualified names are already authoritative and are fetched by
+ * provisioning, so they do not need this inspection.
  */
 async function resolveManagedBaseBranchForCreate(
   deps: ThreadCreateDeps,
   args: ResolveManagedBaseBranchForCreateArgs,
 ): Promise<BaseBranchSpec> {
-  if (args.baseBranch.kind === "named" && args.originKind !== null) {
+  if (
+    args.baseBranch.kind === "named" &&
+    (args.originKind !== null || args.baseBranch.name.startsWith("origin/"))
+  ) {
+    // Forks continue from their source ref verbatim. An origin-qualified ref is
+    // already unambiguous and provisioning fetches that exact remote branch, so
+    // neither case needs the default-branch relationship inspection below.
     return args.baseBranch;
   }
 

--- a/apps/server/test/helpers/commands.ts
+++ b/apps/server/test/helpers/commands.ts
@@ -131,6 +131,9 @@ interface RegisterTestHostRpcCaptureArgs {
   sessionId: string;
   /** Checkout the fake daemon reports for `host.list_branches`. */
   listBranchesResult?: HostDaemonOnlineRpcResult<"host.list_branches">;
+  onListBranches?: (
+    command: Extract<HostDaemonRpcCommand, { type: "host.list_branches" }>,
+  ) => void;
 }
 
 interface TestHostRpcSocket {
@@ -382,6 +385,7 @@ export function registerTestHostRpcCapture(
         return;
       }
       if (command.type === "host.list_branches") {
+        args.onListBranches?.(command);
         deps.hub.recordHostOnlineRpcResponse({
           message: hostDaemonOnlineRpcResponseMessageSchema.parse({
             type: "host-rpc.response",

--- a/apps/server/test/public/public-threads.named-base-branch.test.ts
+++ b/apps/server/test/public/public-threads.named-base-branch.test.ts
@@ -1,7 +1,7 @@
 import { getThread } from "@bb/db";
 import { threadSchema, type ProjectSourceCheckout } from "@bb/domain";
 import { threadResponseSchema } from "@bb/server-contract";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   registerTestHostRpcCapture,
   requireManagedWorktreeEnvironmentProvisionLiveCommand,
@@ -44,6 +44,7 @@ async function createNamedBaseBranchThread(
   args: {
     baseBranch: string;
     defaultBranchRelation: ProjectSourceCheckout["defaultBranchRelation"];
+    onListBranches?: () => void;
   },
 ): Promise<string | null> {
   const { host, session } = seedHostSession(harness.deps);
@@ -52,6 +53,7 @@ async function createNamedBaseBranchThread(
     hostId: host.id,
     sessionId: session.id,
     listBranchesResult: buildCheckout(args.defaultBranchRelation),
+    ...(args.onListBranches ? { onListBranches: args.onListBranches } : {}),
   });
   const { project } = seedProjectWithSource(harness.deps, {
     hostId: host.id,
@@ -120,6 +122,20 @@ describe("named managed-worktree base branch", () => {
           defaultBranchRelation: "local-behind",
         }),
       ).resolves.toBe("release/2026-05");
+    });
+  });
+
+  it("does not inspect an origin-qualified branch before provisioning", async () => {
+    await withTestHarness(async (harness) => {
+      const onListBranches = vi.fn();
+      await expect(
+        createNamedBaseBranchThread(harness, {
+          baseBranch: "origin/main",
+          defaultBranchRelation: "local-behind",
+          onListBranches,
+        }),
+      ).resolves.toBe("origin/main");
+      expect(onListBranches).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## What was wrong

The new-thread composer kept the submitted draft visible until thread creation completed. At the same time, #2152 made the server inspect every named worktree base before provisioning. The root composer already submits its smart default as an authoritative remote-qualified name such as `origin/main`, so that path incurred a redundant `host.list_branches` RPC even though provisioning fetches the exact remote branch. The added creation latency made the delayed prompt clear especially noticeable.

## What changed

- Clear the matching submitted draft before awaiting thread creation. If creation fails, restore it only when the optimistic clear succeeded and the user has not started a newer draft.
- Treat `origin/...` managed-worktree bases as authoritative and pass them directly to provisioning, while preserving the existing inspection and local-vs-origin policy for defaults and plain names such as `main`.
- Preserve the smart named-default behavior introduced by #153.
- No wire, CLI, guide, or documentation changes; `HOST_DAEMON_PROTOCOL_VERSION` remains 164.

## How you verified

- Added app regression coverage for clearing while submission is pending, restoring after failure, and preserving a newer draft after failure.
- Added route-level server coverage proving `origin/main` reaches provisioning without a `host.list_branches` RPC.
- `pnpm exec turbo run test --filter=@bb/app -- src/components/plugin/PluginNewThreadComposer.test.tsx src/views/root-compose-thread-environment.test.ts` — 28 tests passed.
- `pnpm exec turbo run test --filter=@bb/server -- test/public/public-threads.named-base-branch.test.ts` — 5 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/app --filter=@bb/server` — 5 tasks passed.
- `pnpm exec turbo run lint --filter=@bb/app --filter=@bb/server` — 0 errors.
- `pnpm exec oxfmt --check` on all five changed files.

Fixes the performance regression introduced by #2152.

> AGENT GENERATED
