### PR TITLE
fix(host-daemon): avoid stack overflow listing large directory trees

### DIFF
--- a/apps/host-daemon/src/command-handlers/file-list.test.ts
+++ b/apps/host-daemon/src/command-handlers/file-list.test.ts
@@ -262,4 +262,33 @@ describe("listPathsRecursively", () => {
       "src/components/Button.tsx",
     );
   });
+
+  it("does not overflow the call stack merging a large subdirectory", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "bb-file-list-"));
+    try {
+      const nested = path.join(root, "many");
+      await fs.mkdir(nested, { recursive: true });
+      const fileCount = 150_000;
+      const batchSize = 500;
+      for (let start = 0; start < fileCount; start += batchSize) {
+        const end = Math.min(start + batchSize, fileCount);
+        await Promise.all(
+          Array.from({ length: end - start }, (_, offset) =>
+            fs.writeFile(path.join(nested, `f${start + offset}.txt`), ""),
+          ),
+        );
+      }
+
+      const result = await listPathsRecursively({
+        dir: root,
+        root,
+        includeFiles: true,
+        includeDirectories: false,
+      });
+
+      expect(result).toHaveLength(fileCount);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  }, 60_000);
 });

--- a/apps/host-daemon/src/command-handlers/file-list.ts
+++ b/apps/host-daemon/src/command-handlers/file-list.ts
@@ -156,12 +156,11 @@ export async function listPathsRecursively(
           name: entry.name,
         });
       }
-      results.push(
-        ...(await listPathsRecursively({
-          ...args,
-          dir: fullPath,
-        })),
-      );
+      const childResults = await listPathsRecursively({
+        ...args,
+        dir: fullPath,
+      });
+      for (const childResult of childResults) results.push(childResult);
       continue;
     }
 


### PR DESCRIPTION
Fixes #2362.

## Problem

\`listPathsRecursively\` in \`apps/host-daemon/src/command-handlers/file-list.ts\` merges each subdirectory's results with:

\`\`\`ts
results.push(...(await listPathsRecursively({ ...args, dir: fullPath })));
\`\`\`

\`Array.prototype.push(...arr)\` spreads every element as a call argument. Once an accumulated subtree crosses V8's argument-count ceiling (~100k, engine-dependent), this throws \`RangeError: Maximum call stack size exceeded\` instead of returning. Any caller of file listing/search (a plugin's \`listTree\`, project file search, etc.) on a large enough workspace — a big Obsidian vault, a large monorepo — sees this surface as an opaque \`HTTP 502\`.

## Fix

Replace the spread-push with a plain loop, which has no argument-count limit:

\`\`\`ts
const childResults = await listPathsRecursively({ ...args, dir: fullPath });
for (const childResult of childResults) results.push(childResult);
\`\`\`

## Testing

Added a regression test that creates a 150k-file subtree and asserts \`listPathsRecursively\` returns instead of throwing.

- Confirmed the new test reproduces the exact \`RangeError: Maximum call stack size exceeded\` against the pre-fix code (stashed the fix, ran the test, same error/stack as reported).
- With the fix applied, all 15 tests in \`file-list.test.ts\` pass (\`vitest run --config vitest.config.ts\` in \`apps/host-daemon\`).

## Test plan

- [x] \`vitest run\` in \`apps/host-daemon\` — 15/15 passing
- [x] Verified the new test fails with the exact reported error on the pre-fix code