### PR TITLE
Wait for Pi catalog child before workspace cleanup

### DIFF
--- a/plugins/provider-pi/src/bridge/bridge.lifecycle.test.ts
+++ b/plugins/provider-pi/src/bridge/bridge.lifecycle.test.ts
@@ -249,11 +249,14 @@ it("a child's tool and prompt files go with the child after release and failed c
   await expectScratchFilesGone();
 }, 60_000);
 
-it("closing the catalog ends its child", async () => {
+it("closing the catalog waits for its child to exit", async () => {
   const models = await harness.request((nextId += 1), "model/list", { cwd: harness.workspaceDir });
   expect(models.result).toMatchObject({ models: expect.any(Array) });
   await experimental_closeAllForTests();
-  await expectEveryChildGone(1);
+  const log = harness.readProcessLog();
+  expect(log.spawned).toHaveLength(1);
+  expect(log.exited).toContain(log.spawned[0]);
+  expect(log.spawned.some(isAlive)).toBe(false);
 }, 90_000);
 
 it("a child that ignores EOF and SIGTERM is SIGKILLed", async () => {

--- a/plugins/provider-pi/src/bridge/bridge.ts
+++ b/plugins/provider-pi/src/bridge/bridge.ts
@@ -1027,7 +1027,7 @@ export function experimental_scratchDirForTests(): string {
  */
 export async function experimental_closeAllForTests(): Promise<void> {
   await closeThreadSessionsGracefully("Pi bridge test teardown");
-  closeAllPiCatalogs();
+  await closeAllPiCatalogs();
   resetPiInstallGateForTests();
   if (scratchDir !== null && scratchDirIsPrivate) {
     rmSync(scratchDir, { recursive: true, force: true });
@@ -1047,14 +1047,14 @@ export const experimental_providerBridge = experimental_defineProviderBridge({
   onClose: () => {
     void closeThreadSessionsGracefully("Pi bridge shutting down while tool call was pending")
       .finally(() => {
-        closeAllPiCatalogs();
+        void closeAllPiCatalogs();
         process.exit(0);
       });
   },
   onSigterm: () => {
     void closeThreadSessionsGracefully("Pi bridge terminated while tool call was pending")
       .finally(() => {
-        closeAllPiCatalogs();
+        void closeAllPiCatalogs();
         process.exit(0);
       });
   },

--- a/plugins/provider-pi/src/bridge/catalog.ts
+++ b/plugins/provider-pi/src/bridge/catalog.ts
@@ -87,7 +87,7 @@ export interface PiCatalog {
   rawModels(): Promise<PiRpcModel[]>;
   /** The `get_state` smoke probe: pi booted, loaded the extension, answers. */
   probe(): Promise<Record<string, unknown>>;
-  close(): void;
+  close(): Promise<void>;
 }
 
 const catalogsByCwd = new Map<string, Promise<PiCatalog>>();
@@ -156,8 +156,13 @@ async function spawnCatalog(
     },
     rawModels: fetchRaw,
     probe,
-    close() {
-      child?.kill();
+    async close() {
+      const activeChild = child;
+      if (activeChild === null) {
+        return;
+      }
+      activeChild.kill();
+      await activeChild.waitForExit();
     },
   };
 }
@@ -215,15 +220,18 @@ export function getPiCatalog(
   return created;
 }
 
-export function closeAllPiCatalogs(): void {
+export async function closeAllPiCatalogs(): Promise<void> {
   for (const [, timer] of catalogIdleTimers) {
     clearTimeout(timer);
   }
   catalogIdleTimers.clear();
-  for (const [, catalog] of catalogsByCwd) {
-    void catalog.then((entry) => entry.close()).catch(() => undefined);
-  }
+  const catalogs = [...catalogsByCwd.values()];
   catalogsByCwd.clear();
+  await Promise.all(
+    catalogs.map((catalog) =>
+      catalog.then((entry) => entry.close()).catch(() => undefined),
+    ),
+  );
 }
 
 /**

--- a/plugins/provider-pi/src/bridge/rpc-child.ts
+++ b/plugins/provider-pi/src/bridge/rpc-child.ts
@@ -132,6 +132,7 @@ export class PiRpcChild {
   private stderrTail = "";
   private sawResponse = false;
   private exitInfo: PiRpcChildExitInfo | null = null;
+  private readonly settledExit: Promise<PiRpcChildExitInfo>;
   private readonly channelWriter: Writable | null;
   private readonly channelRecorder: ChannelRecorder | null;
   private killEscalation: ReturnType<typeof setTimeout> | null = null;
@@ -147,6 +148,10 @@ export class PiRpcChild {
   private stdoutDraining = false;
 
   constructor(private readonly args: SpawnPiRpcChildArgs) {
+    let resolveSettledExit: (info: PiRpcChildExitInfo) => void = () => undefined;
+    this.settledExit = new Promise((resolve) => {
+      resolveSettledExit = resolve;
+    });
     const launch = resolvePiLaunch(process.env);
     this.child = spawn(launch.command, [...launch.args, ...args.args], {
       cwd: args.cwd,
@@ -208,6 +213,7 @@ export class PiRpcChild {
         beforeFirstResponse: !this.sawResponse,
       };
       this.exitInfo = info;
+      resolveSettledExit(info);
       for (const [, pending] of this.pending) {
         if (pending.timer !== null) clearTimeout(pending.timer);
         pending.reject(new PiRpcChildExitedError(info));
@@ -231,6 +237,11 @@ export class PiRpcChild {
 
   get pid(): number | undefined {
     return this.child.pid;
+  }
+
+  /** Resolve after the operating system reports this child exited. */
+  waitForExit(): Promise<PiRpcChildExitInfo> {
+    return this.settledExit;
   }
 
   /** Send one RPC command and wait for its response (success or error). */


### PR DESCRIPTION
## What was wrong

The provider-pi install-gate tests close their real memoized catalog child and then recursively delete that child’s cwd. The shared teardown awaited `experimental_closeAllForTests()`, but `closeAllPiCatalogs()` only scheduled catalog promises, and `PiCatalog.close()` sent SIGTERM without waiting for the child’s OS-observed exit. The fake child’s SIGTERM handler appends its `exit:<pid>:<ppid>` record inside the workspace, so under shard contention it could recreate `process.log` after recursive deletion had begun and make `rmSync` fail with `ENOTEMPTY`. In an unmodified 400-run/12-way stress, 19 runs failed; every surviving workspace contained only the late `exit` line. This matches [CI run 32776132624 attempt 1](https://github.com/get-bb/bb/actions/runs/32776132624/attempts/1) and the unchanged-SHA pass on rerun.

## What changed

`PiRpcChild` now exposes a promise resolved by its existing `exit`/`close` settlement. Catalog close kills the active child and awaits that promise, `closeAllPiCatalogs()` awaits every memoized catalog close, and test teardown awaits the complete catalog boundary before deleting the workspace. The lifecycle regression test now asserts that both the fake’s exit record and OS process death are visible immediately when cleanup returns.

No timeout, polling deadline, retry, cleanup suppression, or test budget changed. Recursive-delete retries would hide the ownership race, and a test-only PID poll would duplicate the child lifecycle signal already owned by `PiRpcChild`. Production shutdown still intentionally discards the close promise and exits as before. No provider or host-daemon wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- Fail-before lifecycle assertion: the old cleanup returned before the catalog PID appeared in the exit log.
- Fail-before stress: 400 focused invocations at 12-way contention produced 381 passes and 19 `ENOTEMPTY` failures; all 19 leftover workspaces contained only a recreated `process.log` with the catalog child’s late `exit` line.
- Pass-after stress: the identical 400-run/12-way command passed 400/400 and left no workspace behind.
- Focused Vitest: 2 files / 13 tests passed.
- `pnpm exec turbo run test --filter=bb-plugin-provider-pi --force`: 18 files / 106 tests passed; 4 Turbo tasks passed.
- `pnpm exec turbo run typecheck --filter=bb-plugin-provider-pi --force`: 4 Turbo tasks passed.
- `pnpm exec turbo run build --filter=@bb/server --force`: 4 Turbo tasks passed.
- Targeted `pnpm exec oxlint ...` and `git diff --check` passed.

> AGENT GENERATED: by GPT-5.6-Sol