### PR TITLE
Add model search to the mobile model picker

### DIFF
--- a/apps/mobile/src/screens/pickers/ModelReasoningPicker.tsx
+++ b/apps/mobile/src/screens/pickers/ModelReasoningPicker.tsx
@@ -18,8 +18,10 @@ import {
   Text,
   useSheet,
 } from "@/ui";
+import { filterModelOptions, showModelSearch } from "./model-picker-model";
 import { usePickerSheetMaxHeight } from "./OptionSheet";
 import { PickerTrigger } from "./PickerTrigger";
+import { SheetInput } from "./SheetInput";
 
 export interface ModelReasoningPickerProps {
   /** Fresh picker choices (a retired-but-selected model already promoted). */
@@ -66,6 +68,7 @@ export function ModelReasoningPicker({
   const { tokens } = useTheme();
   const maxHeight = usePickerSheetMaxHeight();
   const [showMore, setShowMore] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
   const selectedModel =
     modelOptions.find((option) => option.value === modelValue) ??
     moreModelOptions.find((option) => option.value === modelValue);
@@ -82,6 +85,27 @@ export function ModelReasoningPicker({
   const showReasoning = reasoningOptions.length > 0;
   const hasModels = modelOptions.length > 0 || moreModelOptions.length > 0;
   const triggerLabel = fastMode?.enabled ? `${modelLabel} · Fast` : modelLabel;
+  // Long catalogs (Pi routing to OpenRouter, local providers, …) get a search
+  // field; short ones stay a plain list. Filtering flattens the retired models
+  // inline so every match stays reachable.
+  const showSearch =
+    hasModels &&
+    !loadErrorMessage &&
+    showModelSearch(modelOptions, moreModelOptions);
+  const filtered = filterModelOptions(
+    modelOptions,
+    moreModelOptions,
+    showSearch ? searchQuery : "",
+  );
+  const visibleMoreOptions = filtered.isSearching
+    ? filtered.moreModelOptions
+    : showMore
+      ? moreModelOptions
+      : [];
+  const noMatches =
+    filtered.isSearching &&
+    filtered.modelOptions.length === 0 &&
+    filtered.moreModelOptions.length === 0;
 
   return (
     <>
@@ -100,8 +124,14 @@ export function ModelReasoningPicker({
         controller={sheet}
         title="Model"
         layout="scroll"
-        maxDynamicContentSize={maxHeight}
-        onDismiss={() => setShowMore(false)}
+        // A searchable sheet keeps a fixed height so the list does not jump
+        // as matches come and go; short lists size to their content.
+        snapPoints={showSearch ? [maxHeight] : undefined}
+        maxDynamicContentSize={showSearch ? undefined : maxHeight}
+        onDismiss={() => {
+          setShowMore(false);
+          setSearchQuery("");
+        }}
       >
         {loadErrorMessage ? (
           <View className="mx-4 my-3 flex-row items-start gap-2 rounded-md border border-border bg-surface-attention px-3 py-2">
@@ -124,7 +154,28 @@ export function ModelReasoningPicker({
             </Text>
           </View>
         ) : null}
-        {modelOptions.map((option) => (
+        {showSearch ? (
+          <View className="px-4 pb-2 pt-3">
+            <SheetInput
+              value={searchQuery}
+              onChangeText={setSearchQuery}
+              placeholder="Search models"
+              autoCapitalize="none"
+              returnKeyType="search"
+              clearButtonMode="while-editing"
+              testID="model-picker-search"
+              accessibilityLabel="Search models"
+            />
+          </View>
+        ) : null}
+        {noMatches ? (
+          <View className="px-4 py-6">
+            <Text variant="caption" className="text-center">
+              No models match your search
+            </Text>
+          </View>
+        ) : null}
+        {filtered.modelOptions.map((option) => (
           <ModelRow
             key={option.value}
             option={option}
@@ -133,32 +184,28 @@ export function ModelReasoningPicker({
             testID={`model-picker-option-${option.value}`}
           />
         ))}
-        {moreModelOptions.length > 0 ? (
-          <>
-            <ListRow
-              title={showMore ? "Fewer models" : "More models"}
-              subtitle={
-                showMore
-                  ? undefined
-                  : `${moreModelOptions.length} retired or hidden`
-              }
-              leading={showMore ? "ChevronUp" : "ChevronDown"}
-              onPress={() => setShowMore((current) => !current)}
-              testID="model-picker-more"
-            />
-            {showMore
-              ? moreModelOptions.map((option) => (
-                  <ModelRow
-                    key={option.value}
-                    option={option}
-                    selected={option.value === modelValue}
-                    onSelect={onModelChange}
-                    testID={`model-picker-option-${option.value}`}
-                  />
-                ))
-              : null}
-          </>
+        {moreModelOptions.length > 0 && !filtered.isSearching ? (
+          <ListRow
+            title={showMore ? "Fewer models" : "More models"}
+            subtitle={
+              showMore
+                ? undefined
+                : `${moreModelOptions.length} retired or hidden`
+            }
+            leading={showMore ? "ChevronUp" : "ChevronDown"}
+            onPress={() => setShowMore((current) => !current)}
+            testID="model-picker-more"
+          />
         ) : null}
+        {visibleMoreOptions.map((option) => (
+          <ModelRow
+            key={option.value}
+            option={option}
+            selected={option.value === modelValue}
+            onSelect={onModelChange}
+            testID={`model-picker-option-${option.value}`}
+          />
+        ))}
         {showReasoning ? (
           <>
             <Separator />

--- a/apps/mobile/src/screens/pickers/model-picker-model.test.ts
+++ b/apps/mobile/src/screens/pickers/model-picker-model.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import type { ModelPickerOption } from "@/data/compose";
+import {
+  buildFuzzyRegex,
+  filterModelOptions,
+  showModelSearch,
+} from "./model-picker-model";
+
+const option = (
+  value: string,
+  label: string,
+  routeProviderId?: string,
+): ModelPickerOption => ({
+  value,
+  label,
+  description: "",
+  ...(routeProviderId ? { routeProviderId } : {}),
+});
+
+const fresh = [
+  option("anthropic/claude-opus-5", "Claude Opus 5", "anthropic"),
+  option("openai/gpt-5.6", "GPT-5.6", "openai"),
+  option("openrouter/qwen3-coder", "Qwen3 Coder", "openrouter"),
+  option("ollama/llama4", "Llama 4", "ollama"),
+];
+const retired = [option("openai/gpt-4-turbo", "GPT-4 Turbo", "openai")];
+
+describe("buildFuzzyRegex", () => {
+  it("matches characters in order with gaps", () => {
+    expect(buildFuzzyRegex("gpt4").test("GPT-4 Turbo")).toBe(true);
+    expect(buildFuzzyRegex("4gpt").test("GPT-4 Turbo")).toBe(false);
+  });
+
+  it("escapes regex metacharacters in the query", () => {
+    expect(buildFuzzyRegex("5.6").test("GPT-5.6")).toBe(true);
+    expect(() => buildFuzzyRegex("(")).not.toThrow();
+  });
+});
+
+describe("filterModelOptions", () => {
+  it("passes both lists through untouched for an empty query", () => {
+    const result = filterModelOptions(fresh, retired, "   ");
+    expect(result.isSearching).toBe(false);
+    expect(result.modelOptions).toBe(fresh);
+    expect(result.moreModelOptions).toBe(retired);
+  });
+
+  it("filters fresh and retired lists independently by label", () => {
+    const result = filterModelOptions(fresh, retired, "gpt");
+    expect(result.isSearching).toBe(true);
+    expect(result.modelOptions.map((o) => o.value)).toEqual(["openai/gpt-5.6"]);
+    expect(result.moreModelOptions.map((o) => o.value)).toEqual([
+      "openai/gpt-4-turbo",
+    ]);
+  });
+
+  it("matches the route provider so Pi sub-providers are searchable", () => {
+    const result = filterModelOptions(fresh, retired, "openrouter");
+    expect(result.modelOptions.map((o) => o.value)).toEqual([
+      "openrouter/qwen3-coder",
+    ]);
+  });
+
+  it("matches the raw model id when the label differs", () => {
+    const result = filterModelOptions(fresh, retired, "llama4");
+    expect(result.modelOptions.map((o) => o.value)).toEqual(["ollama/llama4"]);
+  });
+});
+
+describe("showModelSearch", () => {
+  it("counts fresh and retired models together against the threshold", () => {
+    expect(showModelSearch(fresh, retired)).toBe(false);
+    expect(showModelSearch(fresh, [...retired, option("x/y", "Y", "x")])).toBe(
+      true,
+    );
+  });
+});

--- a/apps/mobile/src/screens/pickers/model-picker-model.ts
+++ b/apps/mobile/src/screens/pickers/model-picker-model.ts
@@ -1,0 +1,66 @@
+import type { ModelPickerOption } from "@/data/compose";
+
+/**
+ * Up to this many models (fresh + retired) the list is short enough to scan by
+ * eye, so the search field is more clutter than help. Mirrors the web picker.
+ */
+export const MODEL_SEARCH_MIN_OPTIONS = 5;
+
+export function showModelSearch(
+  modelOptions: readonly ModelPickerOption[],
+  moreModelOptions: readonly ModelPickerOption[],
+): boolean {
+  return (
+    modelOptions.length + moreModelOptions.length > MODEL_SEARCH_MIN_OPTIONS
+  );
+}
+
+/**
+ * Build a loose fuzzy RegExp from a plain-text query. Each character is
+ * matched in order with `.*` between them, so "gpt4" matches "GPT-4 Turbo".
+ */
+export function buildFuzzyRegex(query: string): RegExp {
+  const pattern = query
+    .split("")
+    .map((c) => c.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+    .join(".*");
+  return new RegExp(pattern, "i");
+}
+
+// The text a model row is matched against: the visible label, the route
+// provider (Pi sub-providers such as "openrouter"), and the raw model id, so
+// typing any of them finds the model.
+function modelSearchText(option: ModelPickerOption): string {
+  return `${option.label} ${option.routeProviderId ?? ""} ${option.value}`;
+}
+
+export interface FilteredModelOptions {
+  /** Fresh options that match the query (all of them when not searching). */
+  modelOptions: readonly ModelPickerOption[];
+  /** Retired options that match the query (all of them when not searching). */
+  moreModelOptions: readonly ModelPickerOption[];
+  isSearching: boolean;
+}
+
+/**
+ * Fuzzy-filter both model lists by `query`. An empty/whitespace query passes
+ * both lists through untouched with `isSearching: false`.
+ */
+export function filterModelOptions(
+  modelOptions: readonly ModelPickerOption[],
+  moreModelOptions: readonly ModelPickerOption[],
+  query: string,
+): FilteredModelOptions {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) {
+    return { modelOptions, moreModelOptions, isSearching: false };
+  }
+  const regex = buildFuzzyRegex(normalizedQuery);
+  const matches = (option: ModelPickerOption) =>
+    regex.test(modelSearchText(option));
+  return {
+    modelOptions: modelOptions.filter(matches),
+    moreModelOptions: moreModelOptions.filter(matches),
+    isSearching: true,
+  };
+}


### PR DESCRIPTION
## What was wrong

The mobile model picker rendered every model as a flat list with a "More models" disclosure and no way to filter. Providers with large catalogs (Pi routing to OpenRouter, local and free providers) made the sheet a long scroll to find a model. The web/PWA picker already has a fuzzy search field; mobile did not mirror it.

## What changed

- `apps/mobile/src/screens/pickers/model-picker-model.ts` (new): pure filter logic ported from the web picker. `buildFuzzyRegex` (in-order character match, metacharacters escaped), `filterModelOptions` (matches the visible label, the route provider id such as `openrouter`, and the raw model id; an empty query passes both lists through), and `showModelSearch` (field appears only when fresh + retired models exceed 5, the same threshold as web).
- `apps/mobile/src/screens/pickers/ModelReasoningPicker.tsx`: a `SheetInput` search field (`testID="model-picker-search"`) above the list. While searching, the "More models" toggle is hidden and matching retired models are flattened inline so every match stays reachable. "No models match your search" empty state. The sheet pins to the max snap height while search is shown so the list does not jump as matches change; short catalogs keep dynamic sizing. Query and "more" state reset on dismiss.

No wire, CLI, or doc changes. Existing Maestro testIDs (`model-picker`, `model-picker-option-*`, `model-picker-more`) are unchanged.

## How you verified

- `apps/mobile/src/screens/pickers/model-picker-model.test.ts` (new, 7 tests): fuzzy ordering, regex escaping, independent fresh/retired filtering, route-provider match, raw-id match, and the threshold.
- `pnpm exec turbo run test --filter=@bb/mobile -- model-picker-model`, `pnpm exec turbo run typecheck --filter=@bb/mobile`, `pnpm exec turbo run lint --filter=@bb/mobile` all pass.
- Manual: dev client on the iPhone 17 Pro simulator paired with a live bb over bb connect against a Pi provider catalog. The search field appears, filtering narrows the list live, and the selected model keeps its check mark.
- EAP codename scan: 0 hits in the working tree, tracked files at HEAD, and the push range.

> AGENT GENERATED
