### PR TITLE
Prebuild agent-runtime test bridges for recovery restarts

### DIFF
--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -17,6 +17,7 @@
   "types": "./src/index.ts",
   "scripts": {
     "clean": "rimraf dist tsconfig.tsbuildinfo",
+    "generate:test-bridges": "node ./scripts/build-test-bridges.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --config vitest.config.ts",
     "test:unit": "vitest run --config vitest.config.ts --exclude '**/integration/**'",

--- a/packages/agent-runtime/scripts/build-test-bridges.mjs
+++ b/packages/agent-runtime/scripts/build-test-bridges.mjs
@@ -1,0 +1,32 @@
+import { mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { buildNodeEsmEntry } from "../../../scripts/build-utils.mjs";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const workspaceRoot = resolve(packageRoot, "..", "..");
+const outputDir = resolve(packageRoot, "dist", "test-bridges");
+
+await mkdir(outputDir, { recursive: true });
+await Promise.all([
+  buildNodeEsmEntry({
+    cleanDist: false,
+    entryPoint: resolve(
+      workspaceRoot,
+      "packages/provider-bridge-protocol/src/bridge-worker-entry.ts",
+    ),
+    outfile: resolve(outputDir, "bb-provider-bridge-worker.mjs"),
+    packageRoot,
+    sourcemap: false,
+  }),
+  buildNodeEsmEntry({
+    cleanDist: false,
+    entryPoint: resolve(
+      workspaceRoot,
+      "tests/scripted-echo-provider/src/provider-bridge.ts",
+    ),
+    outfile: resolve(outputDir, "scripted-echo-provider.mjs"),
+    packageRoot,
+    sourcemap: false,
+  }),
+]);

--- a/packages/agent-runtime/src/runtime.recovery.test.ts
+++ b/packages/agent-runtime/src/runtime.recovery.test.ts
@@ -858,12 +858,15 @@ describe("runtime recovery hints", () => {
       threadId: "t-restart",
     });
     await waitForRuntimeState({
+      describeFailure: () =>
+        `processLog=[${processLog.read().join(",")}], resumedThreadIds=[${resumedThreadIds(record).join(",")}]`,
       label: "the thread was resumed on a fresh process",
       predicate: () =>
         processLog.read().filter((line) => line.startsWith("spawn:"))
           .length === 2 &&
         record.last("thread/resume") !== undefined &&
         runtime.listRunningProviders().length === 1,
+      runtime,
       timeoutMs: 5_000,
     });
 
@@ -1114,10 +1117,13 @@ describe("runtime recovery hints", () => {
     });
     await waitForThreadTurnCompleted({ events, threadId: "t-batch" });
     await waitForRuntimeState({
+      describeFailure: () =>
+        `processLog=[${processLog.read().join(",")}], resumedThreadIds=[${resumedThreadIds(record).join(",")}], stderr=[${stderr.join(",")}]`,
       label: "the restart ran once the turn operation settled",
       predicate: () =>
         countSpawns(processLog) === 2 &&
         record.last("thread/resume") !== undefined,
+      runtime,
       timeoutMs: 5_000,
     });
     expect(resumedThreadIds(record)).toEqual(["t-batch"]);

--- a/packages/agent-runtime/src/test/runtime-test-harness.ts
+++ b/packages/agent-runtime/src/test/runtime-test-harness.ts
@@ -42,16 +42,19 @@ export function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+const prebuiltTestBridgeDir = fileURLToPath(
+  new URL("../../dist/test-bridges/", import.meta.url),
+);
+
 /**
- * The scripted echo bridge's TypeScript entry, used as the artifact directly:
- * from source the bridge bootstrap runs under tsx, which imports `.ts`
- * modules, so no build step stands between a test and the bridge.
+ * Turbo builds the bridge worker and scripted echo artifact once before the
+ * unit suite. Keeping the generated path explicit makes a missing Turbo task
+ * fail instead of silently falling back to transforming TypeScript on every
+ * bridge spawn and restart.
  */
-export const scriptedEchoBridgeModulePath = fileURLToPath(
-  new URL(
-    "../../../../tests/scripted-echo-provider/src/provider-bridge.ts",
-    import.meta.url,
-  ),
+export const scriptedEchoBridgeModulePath = join(
+  prebuiltTestBridgeDir,
+  "scripted-echo-provider.mjs",
 );
 
 /**
@@ -249,6 +252,9 @@ export function createScriptedEchoRuntime(
 ): LaunchBoundAgentRuntime {
   const runtime = createAgentRuntime({
     onToolCall: async () => ({ contentItems: [], success: true }),
+    ...(args.launch?.modulePath === undefined
+      ? { bridgeBundleDir: prebuiltTestBridgeDir }
+      : {}),
     ...args.runtime,
   });
   return withBridgeLaunch(runtime, createScriptedEchoLaunch(args.launch));

--- a/packages/agent-runtime/vitest.config.ts
+++ b/packages/agent-runtime/vitest.config.ts
@@ -6,10 +6,10 @@ import {
 export default defineWorkspaceTestConfig({
   test: {
     silent: "passed-only",
-    // Ten suites spawn the scripted echo bridge as a real child process (tsx
-    // compiles it on every spawn), and some hold a request open for over a
-    // second on purpose. On a slow CI runner the default 5s cap tipped over.
-    // Both projects below extend this root, so the cap applies to each.
+    // Ten suites spawn the scripted echo bridge as a real child process. The
+    // Turbo test task prebuilds its worker and bridge artifact once, while
+    // some lifecycle cases still hold a request open for over a second on
+    // purpose. Both projects below extend this root.
     testTimeout: 15_000,
     hookTimeout: 15_000,
     projects: sharedWorkerProjects({

--- a/turbo.json
+++ b/turbo.json
@@ -472,6 +472,45 @@
         "$TURBO_ROOT$/examples/plugins/*/icons/**"
       ]
     },
+    // Runtime unit suites restart the scripted echo provider repeatedly. Build
+    // the real bridge worker and bridge artifact once so each child launch
+    // executes JavaScript instead of re-transforming the TypeScript sources.
+    "@bb/agent-runtime#generate:test-bridges": {
+      "dependsOn": ["topo"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/packages/domain/src/**",
+        "$TURBO_ROOT$/packages/plugin-sdk/src/**",
+        "$TURBO_ROOT$/packages/provider-bridge-protocol/src/**",
+        "$TURBO_ROOT$/scripts/build-utils.mjs",
+        "$TURBO_ROOT$/tests/scripted-echo-provider/src/**"
+      ],
+      "outputs": ["dist/test-bridges/**"]
+    },
+    "@bb/agent-runtime#test": {
+      "dependsOn": [
+        "//#ensure-native-modules",
+        "@bb/agent-runtime#generate:test-bridges",
+        "topo"
+      ],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/tests/scripted-echo-provider/src/**",
+        "$TURBO_ROOT$/vitest.shared.ts"
+      ]
+    },
+    "@bb/agent-runtime#test:unit": {
+      "dependsOn": [
+        "//#ensure-native-modules",
+        "@bb/agent-runtime#generate:test-bridges",
+        "topo"
+      ],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/tests/scripted-echo-provider/src/**",
+        "$TURBO_ROOT$/vitest.shared.ts"
+      ]
+    },
     // The live-CLI suite's global setup rebuilds every first-party provider
     // bridge from source, so it needs the SDK dist too.
     "@bb/agent-runtime#test:integration": {


### PR DESCRIPTION
## What was wrong

The real-process recovery suite launched both the provider bridge worker and the scripted-echo bridge from TypeScript source, so every `restartRecommended` replacement process paid the same `tsx` transform/import cost again. Under package-shard CPU contention, the runtime had already shut down the original bridge and registered the replacement child, but the replacement had not reached the bridge's top-level `spawn` log or answered `thread/resume` before the tests' unchanged 5-second hang detector expired. That one startup path caused both same-SHA signatures in [CI attempt 2](https://github.com/get-bb/bb/actions/runs/32787659928/job/97623628882) and [attempt 4](https://github.com/get-bb/bb/actions/runs/32787659928/job/97625367016); the polling-order bug fixed by #2352 was not involved.

## What changed

- Added a Turbo-cached `@bb/agent-runtime#generate:test-bridges` task that bundles the real provider bridge worker and real scripted-echo bridge once per test run.
- Pointed the standard scripted-echo runtime harness at those JavaScript artifacts, while preserving source mode for tests that deliberately inject a custom bridge module.
- Added bounded failure diagnostics to the two affected waits so a future failure reports process lifecycle, resumed thread IDs, runtime provider state, and restart stderr.

The tests still exercise real child-process shutdown, replacement, Provider Bridge Protocol initialization, and `thread/resume`; no timeout, retry budget, assertion, product behavior, or wire contract changed, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- Deterministic pre-fix reproduction: ran the two exact tests with 512 CPU burners on a 16-logical-CPU host. Both failed with the CI errors (10.810s and 14.256s). Added diagnostics showed `processLog=[spawn:<old pid>,...,exit:<old pid>]`, `resumedThreadIds=[]`, and `runningProviders=[fake]`: the replacement child existed but was still before bridge top-level startup.
- Same-load post-fix comparison: the identical two-test command passed both cases in 12.348s total (5.361s and 6.986s) with the original 5-second waits unchanged; the pre-fix run took 25.067s and failed both.
- `pnpm exec turbo run test --filter=@bb/agent-runtime --force -- 'src/runtime.recovery.test.ts' -t 'restartRecommended: an idle thread|restartRecommended read while'` — 1 file, 2 tests passed.
- `pnpm exec turbo run build typecheck test --filter=@bb/agent-runtime --force` — 7 Turbo tasks passed; 22 files / 318 tests passed.
- `pnpm exec prettier --check packages/agent-runtime/package.json packages/agent-runtime/scripts/build-test-bridges.mjs packages/agent-runtime/src/test/runtime-test-harness.ts packages/agent-runtime/vitest.config.ts turbo.json` and `git diff --check` — passed.

Fixes: no issue — repeated exact and broad open GitHub issue/PR searches returned no matches, and the only exact bb thread match was this worker.

> AGENT GENERATED: by GPT-5.6-Sol
