### PR TITLE
fix: retry read-only host RPC timeouts

### DIFF
--- a/apps/server/src/services/hosts/online-rpc.ts
+++ b/apps/server/src/services/hosts/online-rpc.ts
@@ -85,21 +85,45 @@ async function callHostOnlineRpcWithRetry(
       await waitForRetryableHostRpcTransport(deps, args.hostId);
     },
   );
-  const response = await requestHostOnlineRpcResponse(deps, args).catch(
-    async (error) => {
-      if (!options.retryOnTransportFailure) {
-        throwOnlineRpcError(error);
-      }
-      if (error instanceof HostOnlineRpcUnavailableError) {
-        await waitForRetryableHostRpcTransport(deps, args.hostId);
-      } else if (!(error instanceof HostOnlineRpcTimeoutError)) {
-        throwOnlineRpcError(error);
-      }
+  const timeoutRetryDeadline =
+    options.retryOnTransportFailure && args.timeoutMs > 1
+      ? Date.now() + args.timeoutMs
+      : null;
+  const firstAttemptArgs =
+    timeoutRetryDeadline === null
+      ? args
+      : {
+          ...args,
+          timeoutMs: Math.max(1, Math.floor(args.timeoutMs / 2)),
+        };
+  const response = await requestHostOnlineRpcResponse(
+    deps,
+    firstAttemptArgs,
+  ).catch(async (error) => {
+    if (!options.retryOnTransportFailure) {
+      throwOnlineRpcError(error);
+    }
+    if (error instanceof HostOnlineRpcUnavailableError) {
+      await waitForRetryableHostRpcTransport(deps, args.hostId);
       return requestHostOnlineRpcResponse(deps, args).catch((retryError) => {
         throwOnlineRpcError(retryError);
       });
-    },
-  );
+    }
+    if (!(error instanceof HostOnlineRpcTimeoutError)) {
+      throwOnlineRpcError(error);
+    }
+    const retryTimeoutMs =
+      timeoutRetryDeadline === null ? 0 : timeoutRetryDeadline - Date.now();
+    if (retryTimeoutMs <= 0) {
+      throwOnlineRpcError(error);
+    }
+    return requestHostOnlineRpcResponse(deps, {
+      ...args,
+      timeoutMs: retryTimeoutMs,
+    }).catch((retryError) => {
+      throwOnlineRpcError(retryError);
+    });
+  });
 
   if (!response.ok) {
     throw new ApiError(502, response.errorCode, response.errorMessage, false);

--- a/apps/server/src/services/hosts/online-rpc.ts
+++ b/apps/server/src/services/hosts/online-rpc.ts
@@ -80,13 +80,14 @@ async function callHostOnlineRpcWithRetry(
   );
   const response = await requestHostOnlineRpcResponse(deps, args).catch(
     async (error) => {
-      if (
-        !(error instanceof HostOnlineRpcUnavailableError) ||
-        !options.retryOnUnavailable
-      ) {
+      if (!options.retryOnUnavailable) {
         throwOnlineRpcError(error);
       }
-      await waitForRetryableHostRpcTransport(deps, args.hostId);
+      if (error instanceof HostOnlineRpcUnavailableError) {
+        await waitForRetryableHostRpcTransport(deps, args.hostId);
+      } else if (!(error instanceof HostOnlineRpcTimeoutError)) {
+        throwOnlineRpcError(error);
+      }
       return requestHostOnlineRpcResponse(deps, args).catch((retryError) => {
         throwOnlineRpcError(retryError);
       });

--- a/apps/server/src/services/hosts/online-rpc.ts
+++ b/apps/server/src/services/hosts/online-rpc.ts
@@ -39,7 +39,9 @@ export async function callHostOnlineRpc(
   deps: WorkSessionDeps,
   args: CallHostOnlineRpcArgs<HostDaemonRpcCommand>,
 ): Promise<HostDaemonRpcResultForCommand> {
-  return callHostOnlineRpcWithRetry(deps, args, { retryOnUnavailable: false });
+  return callHostOnlineRpcWithRetry(deps, args, {
+    retryOnTransportFailure: false,
+  });
 }
 
 export function callHostRetryableOnlineRpc<
@@ -52,27 +54,32 @@ export async function callHostRetryableOnlineRpc(
   deps: WorkSessionDeps,
   args: CallHostRetryableOnlineRpcArgs<HostDaemonRetryableOnlineRpcCommand>,
 ): Promise<HostDaemonOnlineRpcResultForCommand> {
-  return callHostOnlineRpcWithRetry(deps, args, { retryOnUnavailable: true });
+  return callHostOnlineRpcWithRetry(deps, args, {
+    retryOnTransportFailure: true,
+  });
 }
 
 async function callHostOnlineRpcWithRetry(
   deps: WorkSessionDeps,
   args: CallHostOnlineRpcArgs<HostDaemonRpcCommand>,
-  options: { retryOnUnavailable: false },
+  options: { retryOnTransportFailure: false },
 ): Promise<HostDaemonRpcResultForCommand>;
 async function callHostOnlineRpcWithRetry(
   deps: WorkSessionDeps,
   args: CallHostRetryableOnlineRpcArgs<HostDaemonRetryableOnlineRpcCommand>,
-  options: { retryOnUnavailable: true },
+  options: { retryOnTransportFailure: true },
 ): Promise<HostDaemonOnlineRpcResultForCommand>;
 async function callHostOnlineRpcWithRetry(
   deps: WorkSessionDeps,
   args: CallHostOnlineRpcArgs<HostDaemonRpcCommand>,
-  options: { retryOnUnavailable: boolean },
+  options: { retryOnTransportFailure: boolean },
 ): Promise<HostDaemonRpcResultForCommand> {
   await ensureHostSessionReadyForWork(deps, { hostId: args.hostId }).catch(
     async (error) => {
-      if (!options.retryOnUnavailable || !isHostUnavailableApiError(error)) {
+      if (
+        !options.retryOnTransportFailure ||
+        !isHostUnavailableApiError(error)
+      ) {
         throw error;
       }
       await waitForRetryableHostRpcTransport(deps, args.hostId);
@@ -80,7 +87,7 @@ async function callHostOnlineRpcWithRetry(
   );
   const response = await requestHostOnlineRpcResponse(deps, args).catch(
     async (error) => {
-      if (!options.retryOnUnavailable) {
+      if (!options.retryOnTransportFailure) {
         throwOnlineRpcError(error);
       }
       if (error instanceof HostOnlineRpcUnavailableError) {

--- a/apps/server/test/hosts/online-rpc.test.ts
+++ b/apps/server/test/hosts/online-rpc.test.ts
@@ -208,6 +208,50 @@ describe("host online RPC retry semantics", () => {
     });
   });
 
+  it("retries read-only online RPCs when the first response times out", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-online-rpc-timeout-retry",
+      });
+      const requests: HostDaemonOnlineRpcRequestMessage[] = [];
+      const socket: TestHostRpcSocket = {
+        close() {},
+        send(data) {
+          const request = parseHostRpcRequest(data);
+          requests.push(request);
+          if (requests.length === 1) return;
+          harness.hub.recordHostOnlineRpcResponse({
+            sessionId: session.id,
+            message: hostDaemonOnlineRpcResponseMessageSchema.parse({
+              type: "host-rpc.response",
+              requestId: request.requestId,
+              commandType: request.command.type,
+              ok: true,
+              result: { models: [], selectedOnlyModels: [] },
+            }),
+          });
+        },
+      };
+      harness.hub.registerDaemon(session.id, host.id, socket);
+
+      await expect(
+        callHostRetryableOnlineRpc(harness.deps, {
+          hostId: host.id,
+          timeoutMs: 10,
+          command: {
+            type: "provider.list_models",
+            providerId: "codex",
+            bridgeLaunch: TRANSPORT_TEST_BRIDGE_LAUNCH,
+          },
+        }),
+      ).resolves.toEqual({ models: [], selectedOnlyModels: [] });
+      expect(requests.map((request) => request.command.type)).toEqual([
+        "provider.list_models",
+        "provider.list_models",
+      ]);
+    });
+  });
+
   it("does not retry non-retry host RPC calls after websocket unavailability", async () => {
     await withTestHarness(async (harness) => {
       const { host, session } = seedHostSession(harness.deps, {

--- a/apps/server/test/hosts/online-rpc.test.ts
+++ b/apps/server/test/hosts/online-rpc.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@bb/host-daemon-contract";
 import { hostDaemonSessions } from "@bb/db";
 import { eq } from "drizzle-orm";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { ApiError } from "../../src/errors.js";
 import {
   callHostOnlineRpc,
@@ -220,22 +220,131 @@ describe("host online RPC retry semantics", () => {
           const request = parseHostRpcRequest(data);
           requests.push(request);
           if (requests.length === 1) return;
-          harness.hub.recordHostOnlineRpcResponse({
-            sessionId: session.id,
-            message: hostDaemonOnlineRpcResponseMessageSchema.parse({
-              type: "host-rpc.response",
-              requestId: request.requestId,
-              commandType: request.command.type,
-              ok: true,
-              result: { models: [], selectedOnlyModels: [] },
+          const firstRequest = requests[0];
+          if (firstRequest === undefined) {
+            throw new Error("Expected the timed-out first host RPC request");
+          }
+          expect(
+            harness.hub.recordHostOnlineRpcResponse({
+              sessionId: session.id,
+              message: hostDaemonOnlineRpcResponseMessageSchema.parse({
+                type: "host-rpc.response",
+                requestId: firstRequest.requestId,
+                commandType: firstRequest.command.type,
+                ok: true,
+                result: { models: [], selectedOnlyModels: [] },
+              }),
             }),
-          });
+          ).toEqual({ handled: false, reason: "stale" });
+          expect(
+            harness.hub.recordHostOnlineRpcResponse({
+              sessionId: session.id,
+              message: hostDaemonOnlineRpcResponseMessageSchema.parse({
+                type: "host-rpc.response",
+                requestId: request.requestId,
+                commandType: request.command.type,
+                ok: true,
+                result: { models: [], selectedOnlyModels: [] },
+              }),
+            }),
+          ).toEqual({ handled: true });
         },
       };
       harness.hub.registerDaemon(session.id, host.id, socket);
 
-      await expect(
-        callHostRetryableOnlineRpc(harness.deps, {
+      vi.useFakeTimers();
+      try {
+        const result = expect(
+          callHostRetryableOnlineRpc(harness.deps, {
+            hostId: host.id,
+            timeoutMs: 10,
+            command: {
+              type: "provider.list_models",
+              providerId: "codex",
+              bridgeLaunch: TRANSPORT_TEST_BRIDGE_LAUNCH,
+            },
+          }),
+        ).resolves.toEqual({ models: [], selectedOnlyModels: [] });
+        await vi.advanceTimersByTimeAsync(0);
+        expect(requests).toHaveLength(1);
+        await vi.advanceTimersByTimeAsync(5);
+        await result;
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(requests.map((request) => request.command.type)).toEqual([
+        "provider.list_models",
+        "provider.list_models",
+      ]);
+      expect(requests[0]?.requestId).not.toBe(requests[1]?.requestId);
+    });
+  });
+
+  it("does not retry ordinary online RPCs when the response times out", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-online-rpc-timeout-no-retry",
+      });
+      const requests: HostDaemonOnlineRpcRequestMessage[] = [];
+      const socket: TestHostRpcSocket = {
+        close() {},
+        send(data) {
+          requests.push(parseHostRpcRequest(data));
+        },
+      };
+      harness.hub.registerDaemon(session.id, host.id, socket);
+
+      vi.useFakeTimers();
+      try {
+        const result = expect(
+          callHostOnlineRpc(harness.deps, {
+            hostId: host.id,
+            timeoutMs: 10,
+            command: {
+              type: "provider.list_models",
+              providerId: "codex",
+              bridgeLaunch: TRANSPORT_TEST_BRIDGE_LAUNCH,
+            },
+          }),
+        ).rejects.toMatchObject({
+          status: 504,
+          body: { code: "command_timeout" },
+        });
+        await vi.advanceTimersByTimeAsync(0);
+        expect(requests).toHaveLength(1);
+        await vi.advanceTimersByTimeAsync(10);
+        await result;
+      } finally {
+        vi.useRealTimers();
+      }
+
+      expect(requests).toHaveLength(1);
+    });
+  });
+
+  it("spends one timeout budget across both response attempts", async () => {
+    await withTestHarness(async (harness) => {
+      const { host, session } = seedHostSession(harness.deps, {
+        id: "host-online-rpc-timeout-budget",
+      });
+      const requests: HostDaemonOnlineRpcRequestMessage[] = [];
+      const socket: TestHostRpcSocket = {
+        close() {},
+        send(data) {
+          requests.push(parseHostRpcRequest(data));
+        },
+      };
+      harness.hub.registerDaemon(session.id, host.id, socket);
+
+      vi.useFakeTimers();
+      try {
+        let outcome:
+          | "pending"
+          | "resolved"
+          | "command_timeout"
+          | "other_error" = "pending";
+        void callHostRetryableOnlineRpc(harness.deps, {
           hostId: host.id,
           timeoutMs: 10,
           command: {
@@ -243,12 +352,35 @@ describe("host online RPC retry semantics", () => {
             providerId: "codex",
             bridgeLaunch: TRANSPORT_TEST_BRIDGE_LAUNCH,
           },
-        }),
-      ).resolves.toEqual({ models: [], selectedOnlyModels: [] });
-      expect(requests.map((request) => request.command.type)).toEqual([
-        "provider.list_models",
-        "provider.list_models",
-      ]);
+        }).then(
+          () => {
+            outcome = "resolved";
+          },
+          (error) => {
+            outcome =
+              error instanceof ApiError &&
+              error.status === 504 &&
+              error.body.code === "command_timeout"
+                ? "command_timeout"
+                : "other_error";
+          },
+        );
+
+        await vi.advanceTimersByTimeAsync(0);
+        expect(requests).toHaveLength(1);
+        await vi.advanceTimersByTimeAsync(4);
+        expect(requests).toHaveLength(1);
+        expect(outcome).toBe("pending");
+        await vi.advanceTimersByTimeAsync(1);
+        expect(requests).toHaveLength(2);
+        expect(outcome).toBe("pending");
+        await vi.advanceTimersByTimeAsync(4);
+        expect(outcome).toBe("pending");
+        await vi.advanceTimersByTimeAsync(1);
+        expect(outcome).toBe("command_timeout");
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/apps/server/test/public/public-provider-installations.test.ts
+++ b/apps/server/test/public/public-provider-installations.test.ts
@@ -8,8 +8,8 @@ import {
 } from "@get-bb/plugin-sdk/internal/host-policy";
 import { describe, expect, it, vi } from "vitest";
 import { COMMAND_TIMEOUT_MS } from "../../src/constants.js";
-import { ApiError } from "../../src/errors.js";
 import { buildPluginProviderRegistration } from "../../src/services/providers/plugin-provider-registration.js";
+import { HostOnlineRpcTimeoutError } from "../../src/ws/hub.js";
 import { registerHostRpcResponder } from "../helpers/host-rpc.js";
 import { readJson } from "../helpers/json.js";
 import { seedHostSession } from "../helpers/seed.js";
@@ -281,13 +281,7 @@ describe("public provider installation routes", () => {
           return new Promise((_, reject) => {
             setTimeout(
               () =>
-                reject(
-                  new ApiError(
-                    504,
-                    "command_timeout",
-                    "Timed out waiting for command result",
-                  ),
-                ),
+                reject(new HostOnlineRpcTimeoutError()),
               args.timeoutMs,
             );
           });
@@ -316,7 +310,7 @@ describe("public provider installation routes", () => {
         expect(resolvedAt! - startedAt).toBeLessThan(
           DEFAULT_BB_REQUEST_TIMEOUT_MS,
         );
-        expect(statusTimeouts).toHaveLength(9);
+        expect(statusTimeouts).toHaveLength(18);
         expect(statusTimeouts.some((timeout) => timeout < COMMAND_TIMEOUT_MS))
           .toBe(true);
       } finally {

--- a/apps/server/test/system/execution-options.test.ts
+++ b/apps/server/test/system/execution-options.test.ts
@@ -594,7 +594,7 @@ describe("resolveSystemExecutionOptions", () => {
         await vi.advanceTimersByTimeAsync(1);
         const providers = await pendingProviders;
         expect(settled).toBe(true);
-        expect(responder.requests).toHaveLength(3);
+        expect(responder.requests).toHaveLength(6);
         expect(providers.map((provider) => provider.id)).not.toContain(
           "acp-opencode",
         );

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -307,9 +307,15 @@
 // lets turn submission recover a stale target by re-steering the live turn.
 // An old daemon can still start a competing provider turn in that race.
 //
+// Version 167 lets the server retry an explicitly retryable online RPC after
+// its first response timeout. This can send the same command twice when the
+// daemon executed the first request but its response was lost, so enrolled
+// daemons must update with the server even though the message schema is
+// unchanged.
+//
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 166 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 167 as const;
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1039,7 +1039,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(166);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(167);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 


### PR DESCRIPTION
## Context

Thread provisioning intermittently failed with `thread_provisioning_failed` after waiting the full 30-second host RPC timeout for a retryable inspection command. The daemon connection remained usable, so repeating the inspection was safer and more useful than failing the whole provisioning attempt.

This is transport resilience, not an OpenRouter/quota change.

## What changed

- Retry a host RPC once when its first response times out, but only through `callHostRetryableOnlineRpc`.
- Preserve single-attempt behavior for ordinary/non-retryable host RPCs.
- Keep the existing reconnect wait for websocket-unavailable failures.
- Split the caller's existing timeout budget across two response-timeout attempts, so enabling the retry does not double an established command deadline.
- Increment `HOST_DAEMON_PROTOCOL_VERSION` to 167 because the server can now send a second `host-rpc.request` after a response timeout.
- Add deterministic coverage where the first response is dropped and the second request succeeds, plus deadline, non-retry, fresh-request-ID, and late-response handling.

## Safety boundary

A timeout is ambiguous: the host may have executed the first request and lost only its response. Retrying can therefore execute the command twice. The retry helper accepts only `HostDaemonRetryableOnlineRpcCommand`, derived from command-registry entries explicitly marked `retryable: true`; commands not explicitly safe to repeat cannot enter this path through the typed API.

Each attempt uses a fresh request ID. The first waiter's timeout removes it from the hub, so a late response from the first attempt is treated as stale and cannot resolve the second attempt. Tests also keep the existing reconnect retry and ordinary-call single-attempt behavior covered.

## Verification

- `pnpm exec turbo run test --filter=@bb/server -- test/hosts/online-rpc.test.ts test/system/execution-options.test.ts test/public/public-provider-installations.test.ts` — 50/50 passed
- `pnpm exec turbo run test --filter=@bb/host-daemon-contract -- test/contract.test.ts` — 37/37 passed
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon-contract --filter=@bb/host-daemon --filter=@bb/server` — 6/6 Turbo tasks successful
- `git diff --check origin/main...HEAD` — passed

The deterministic regression drops the first response while leaving the daemon socket registered. Before this change the call rejected with `504 command_timeout`; after the change the second request succeeds inside the original command budget. Fake timers pin the attempt boundary, and the test verifies that the first late response is stale and the two requests have distinct IDs.