### PR TITLE
Make `bb plugin new` scaffold an example todo plugin with a sidebar page, CLI, and skill

### DIFF
--- a/apps/cli/src/__tests__/plugin-build.test.ts
+++ b/apps/cli/src/__tests__/plugin-build.test.ts
@@ -382,13 +382,12 @@ describe("buildPluginApp", () => {
     expect(result.jsPath).toBe(join(root, "dist", "app.js"));
   });
 
-  it("builds the `bb plugin new --app` scaffold end to end", async () => {
+  it("builds the `bb plugin new` scaffold end to end", async () => {
     const targetDir = join(root, "bb-plugin-scaffolded");
     await scaffoldPlugin({
       targetDir,
       packageName: "bb-plugin-scaffolded",
       bbVersion: "0.9.0",
-      app: true,
     });
     // The vendored starter components bundle real npm deps (`bb plugin new`
     // runs npm install for authors); the offline test links them from the
@@ -396,6 +395,7 @@ describe("buildPluginApp", () => {
     // absent: the build shims them to host slots, so linking them would
     // hide a shim regression.
     await linkScaffoldDeps(targetDir, [
+      "@radix-ui/react-checkbox",
       "@radix-ui/react-slot",
       "@hugeicons/react",
       "@hugeicons/core-free-icons",
@@ -413,9 +413,15 @@ describe("buildPluginApp", () => {
     // The scaffold's default export must be a definePluginApp product the
     // host interpreter accepts (a stub runtime stands in for the BB app).
     (globalThis as { __bbPluginRuntime?: unknown }).__bbPluginRuntime = {
-      // The vendored starter components bundle radix Slot, which calls
-      // forwardRef at module scope — the stub must provide it.
-      react: { forwardRef: (render: unknown) => render },
+      // The vendored starter components bundle radix Slot and Checkbox,
+      // which call forwardRef/createContext at module scope — the stub must
+      // provide them. Checkbox's radix tree also imports react-dom at module
+      // scope (used only inside handlers), so the slot must exist.
+      react: {
+        forwardRef: (render: unknown) => render,
+        createContext: () => ({}),
+      },
+      reactDom: {},
       jsxRuntime: { jsx: () => ({}), jsxs: () => ({}), Fragment: {} },
       // The vendored button calls cva() at module scope, and lib/utils reads
       // clsx/twMerge; all three come from host slots, never the bundle.

--- a/apps/cli/src/__tests__/plugin-new.test.ts
+++ b/apps/cli/src/__tests__/plugin-new.test.ts
@@ -93,7 +93,7 @@ describe.sequential("bb plugin new dependency install", () => {
   }
 
   it("installs the packages the plugin needs to build under NODE_ENV=production", async () => {
-    await runPluginNew(["prod-env", "--app"]);
+    await runPluginNew(["prod-env"]);
 
     // zod is imported by the generated server.ts and inlined by the build;
     // typescript/@types are what the scaffold typechecks against.
@@ -103,13 +103,6 @@ describe.sequential("bb plugin new dependency install", () => {
     expect(warned).toEqual([]);
     expect(logged).toContain("Installed dependencies (npm install).");
     expect(logged).not.toContain("  npm install --include=dev");
-  });
-
-  it("installs headless scaffolds too, whose server.ts also imports zod", async () => {
-    await runPluginNew(["headless"]);
-
-    expect(await isInstalled("bb-plugin-headless", "zod")).toBe(true);
-    expect(logged).toContain("Installed dependencies (npm install).");
   });
 
   it("accepts a tree npm hoisted to a workspace root", async () => {
@@ -123,7 +116,7 @@ describe.sequential("bb plugin new dependency install", () => {
     );
     vi.stubEnv("BB_TEST_NPM_HOIST_TO", workDir);
 
-    await runPluginNew(["hoisted", "--app"]);
+    await runPluginNew(["hoisted"]);
 
     expect(await isInstalled("bb-plugin-hoisted", "zod")).toBe(false);
     expect(warned).toEqual([]);
@@ -133,7 +126,7 @@ describe.sequential("bb plugin new dependency install", () => {
   it("does not report success when npm exits 0 without installing the tree", async () => {
     vi.stubEnv("BB_TEST_NPM_ALWAYS_OMIT_DEV", "1");
 
-    await runPluginNew(["silent-omit", "--app"]);
+    await runPluginNew(["silent-omit"]);
 
     expect(await isInstalled("bb-plugin-silent-omit", "typescript")).toBe(
       false,

--- a/apps/cli/src/__tests__/plugin-scaffold-dependencies.test.ts
+++ b/apps/cli/src/__tests__/plugin-scaffold-dependencies.test.ts
@@ -76,17 +76,15 @@ function packageNameOf(specifier: string): string {
     : (segments[0] ?? specifier);
 }
 
-async function scaffoldWithDependencies(args: {
-  workDir: string;
-  app: boolean;
-}): Promise<{ targetDir: string; dependencies: string[] }> {
-  const packageName = `bb-plugin-${args.app ? "app" : "headless"}`;
-  const targetDir = join(args.workDir, packageName);
+async function scaffoldWithDependencies(
+  workDir: string,
+): Promise<{ targetDir: string; dependencies: string[] }> {
+  const packageName = "bb-plugin-deps";
+  const targetDir = join(workDir, packageName);
   await scaffoldPlugin({
     targetDir,
     packageName,
     bbVersion: "0.9.0",
-    app: args.app,
   });
   const manifest: { dependencies?: Record<string, string> } = JSON.parse(
     await readFile(join(targetDir, "package.json"), "utf8"),
@@ -105,40 +103,30 @@ describe("scaffold dependency classification", () => {
     await rm(workDir, { recursive: true, force: true });
   });
 
-  it.each([{ app: false }, { app: true }])(
-    "declares every bundled import as a dependency (app: $app)",
-    async ({ app }) => {
-      const { targetDir, dependencies } = await scaffoldWithDependencies({
-        workDir,
-        app,
-      });
+  it("declares every bundled import as a dependency", async () => {
+    const { targetDir, dependencies } =
+      await scaffoldWithDependencies(workDir);
 
-      const misdeclared: string[] = [];
-      for (const file of await generatedSourceFiles(targetDir)) {
-        for (const specifier of importedSpecifiers(
-          await readFile(file, "utf8"),
-        )) {
-          // Swapped for a host runtime shim, or left unresolved for the
-          // loader — either way it is never read from node_modules.
-          if (specifier in RUNTIME_SLOT_BY_SPECIFIER) continue;
-          const packageName = packageNameOf(specifier);
-          if (PLUGIN_SERVER_EXTERNALS.includes(packageName)) continue;
-          if (dependencies.includes(packageName)) continue;
-          misdeclared.push(
-            `${relative(targetDir, file)} imports "${specifier}"`,
-          );
-        }
+    const misdeclared: string[] = [];
+    for (const file of await generatedSourceFiles(targetDir)) {
+      for (const specifier of importedSpecifiers(
+        await readFile(file, "utf8"),
+      )) {
+        // Swapped for a host runtime shim, or left unresolved for the
+        // loader — either way it is never read from node_modules.
+        if (specifier in RUNTIME_SLOT_BY_SPECIFIER) continue;
+        const packageName = packageNameOf(specifier);
+        if (PLUGIN_SERVER_EXTERNALS.includes(packageName)) continue;
+        if (dependencies.includes(packageName)) continue;
+        misdeclared.push(`${relative(targetDir, file)} imports "${specifier}"`);
       }
+    }
 
-      expect(misdeclared).toEqual([]);
-    },
-  );
+    expect(misdeclared).toEqual([]);
+  });
 
   it("keeps host-provided packages out of dependencies", async () => {
-    const { dependencies } = await scaffoldWithDependencies({
-      workDir,
-      app: true,
-    });
+    const { dependencies } = await scaffoldWithDependencies(workDir);
 
     // Bundling a shimmed package ships a second copy of a singleton (a second
     // React means "Invalid hook call"), and bundling an external defeats the

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -471,9 +471,9 @@ async function probeSdkVersionPublished(): Promise<
 /**
  * Install a fresh scaffold's npm tree, reporting whether it is usable.
  *
- * Generated source imports packages `bb plugin build` inlines into dist/ (zod;
- * with --app, the vendored components' deps), and path: installs run server.ts
- * from source, so the tree must exist before the plugin can build or load.
+ * Generated source imports packages `bb plugin build` inlines into dist/ (zod
+ * and the vendored components' deps), and path: installs run server.ts from
+ * source, so the tree must exist before the plugin can build or load.
  *
  * `--include=dev` rather than a bare `npm install`: the packaged CLI runs with
  * NODE_ENV=production — bb-app's launcher sets it for every `bb` invocation —
@@ -1288,12 +1288,8 @@ export function registerPluginCommands(
     .description(
       "Scaffold a plugin in ./bb-plugin-<name>; accepts @scope/bb-plugin-<name>",
     )
-    .option(
-      "--app",
-      "Also scaffold a frontend entry (app.tsx, built by `bb plugin build`)",
-    )
     .action(
-      action(async (name: string, opts: { app?: boolean }) => {
+      action(async (name: string) => {
         const target = resolveNewPluginTarget(name);
         if (target === null) {
           console.error(
@@ -1307,7 +1303,6 @@ export function registerPluginCommands(
           targetDir,
           packageName,
           bbVersion: resolveBbCliVersion(),
-          app: opts.app ?? false,
         });
         console.log(`Created ${directoryName}/ (${packageName}).`);
         // Before the install, so a resolution failure below reads as expected

--- a/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-cli/SKILL.md
@@ -888,9 +888,10 @@ them by mixing ink into canvas), the `--primary` accent, the secondary text tier
     settings. Reload the plugin after configuring (`bb plugin reload <id>`).
   - `bb plugin logs <id> [-n N] [-f]` — the plugin's `bb.log` output.
   - `bb plugin run <id> [args...]` — explicit form of a plugin's CLI command.
-  - `bb plugin new <name> [--app]` — scaffold a plugin and install its npm
-    dependencies (`--app` adds a frontend entry plus a typecheck-only
-    `tsconfig.json`; scaffold sets `engines.bbPluginSdk` to `>=0.4.3`). The
+  - `bb plugin new <name>` — scaffold a todo-list plugin (`server.ts`,
+    `app.tsx` with a sidebar page, a `bb <name>` CLI command, a skill, and
+    vendored UI components) and install its npm dependencies (scaffold sets
+    `engines.bbPluginSdk` to `>=0.4.3`). The
     scaffold depends on `@get-bb/plugin-sdk`, pinned to this bb's exact SDK
     version in `devDependencies`, so the API declarations arrive with
     `npm install` at `node_modules/@get-bb/plugin-sdk/bundled-types/*.d.ts`

--- a/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
+++ b/apps/server/src/services/skills/builtin-skills/bb-plugin-authoring/SKILL.md
@@ -17,7 +17,7 @@ their own product gates. `bb plugin list` shows each plugin's status.
 ## Quickstart
 
 ```
-bb plugin new hello            # scaffolds ./bb-plugin-hello (add --app for a frontend entry)
+bb plugin new hello            # scaffolds ./bb-plugin-hello: a todo list with a sidebar page, `bb hello` CLI, and a skill
 cd bb-plugin-hello
 bb plugin install .            # registers the directory in place (--yes to skip the prompt)
 bb plugin dev                  # rebuild app/host bundles + reload on every save
@@ -2419,9 +2419,9 @@ only `definePluginApp` + the hooks):
 - Builtin plugins in this repo import shared UI from `@bb/shared-ui` (the
   single source of truth the app also consumes and the registry generates
   from); external and example plugins still vendor source through the registry.
-- `bb plugin new --app` pre-vendors button, card, input, dialog (plus their
-  support files: `lib/utils`, `lib/portal-scope`, icon, responsive-overlay,
-  drawer, hooks) into `components/ui/` etc., and writes a `components.json`
+- `bb plugin new` pre-vendors button, card, input, checkbox, dialog (plus
+  their support files: `lib/utils`, `lib/portal-scope`, icon,
+  responsive-overlay, drawer, hooks) into `components/ui/` etc., and writes a `components.json`
   whose `@bb` registry is pinned to the release tag matching the running
   BB. Import via the `@/*` alias: `import { Button } from
 "@/components/ui/button"` (tsconfig maps it; `bb plugin build` reads it).

--- a/apps/server/test/services/plugins/plugin-install.test.ts
+++ b/apps/server/test/services/plugins/plugin-install.test.ts
@@ -15,7 +15,10 @@ import {
 } from "node:fs/promises";
 import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -49,6 +52,42 @@ import { createNoopTelemetryService } from "../../../src/services/system/telemet
 
 const logger = testLogger as unknown as Logger;
 const run = promisify(execFile);
+
+/**
+ * The scaffold's vendored components import real npm packages that
+ * `bb plugin new` installs for authors. This offline test links them from the
+ * repo's own install (resolved the way apps/app sees them) so the path:
+ * install's frontend bundle build can resolve every import.
+ */
+async function linkScaffoldDependencies(targetDir: string): Promise<void> {
+  const manifest = JSON.parse(
+    await readFile(join(targetDir, "package.json"), "utf8"),
+  ) as { dependencies: Record<string, string> };
+  const testDir = dirname(fileURLToPath(import.meta.url));
+  const appRequire = createRequire(
+    join(testDir, "..", "..", "..", "..", "app", "package.json"),
+  );
+  for (const name of Object.keys(manifest.dependencies)) {
+    let packageRoot = dirname(appRequire.resolve(name));
+    while (true) {
+      const candidate = join(packageRoot, "package.json");
+      if (existsSync(candidate)) {
+        const parsed = JSON.parse(readFileSync(candidate, "utf8")) as {
+          name?: string;
+        };
+        if (parsed.name === name) break;
+      }
+      const parent = dirname(packageRoot);
+      if (parent === packageRoot) {
+        throw new Error(`could not find package root for ${name}`);
+      }
+      packageRoot = parent;
+    }
+    const linkPath = join(targetDir, "node_modules", name);
+    await mkdir(dirname(linkPath), { recursive: true });
+    await symlink(packageRoot, linkPath, "dir");
+  }
+}
 
 async function hasBinary(command: string): Promise<boolean> {
   try {
@@ -1832,10 +1871,14 @@ describe("plugin install flows", () => {
       packageName: "bb-plugin-scaffolded",
       bbVersion: "0.9.0",
     });
-    await stat(join(targetDir, "skills", "example-skill", "SKILL.md"));
+    await stat(join(targetDir, "skills", "example-todos", "SKILL.md"));
     await stat(join(targetDir, ".gitignore"));
     await stat(join(targetDir, "README.md"));
+    await linkScaffoldDependencies(targetDir);
 
+    // A path: install of a plugin with `bb.app` builds the frontend bundle
+    // from the vendored components, so this also proves the scaffold's
+    // component set and dependency list agree.
     const entry = await service.install(`path:${targetDir}`, { kind: "root" });
     expect(entry.id).toBe("scaffolded");
     expect(entry.status).toBe("running");

--- a/packages/templates/scripts/generate-plugin-scaffold.mjs
+++ b/packages/templates/scripts/generate-plugin-scaffold.mjs
@@ -1,6 +1,6 @@
 // Generates src/generated/plugin-starter-files.generated.ts: the
-// `bb plugin new --app` starter component set from the plugin component
-// registry, plus the npm deps a scaffold needs to build and typecheck them.
+// `bb plugin new` starter component set from the plugin component registry,
+// plus the npm deps a scaffold needs to build and typecheck them.
 //
 // The output is not committed. turbo runs this as
 // `@bb/templates#generate:plugin-scaffold` before any task that resolves
@@ -17,15 +17,17 @@ const packageRoot = path.resolve(
   "..",
 );
 
-// Embed the `bb plugin new --app` starter component set from the plugin
-// component registry (plugin design §5.5): the transitive closure of the
-// starter items, as {target, content} pairs, plus the npm deps a scaffold
-// needs to build (dependencies) and typecheck (devDependencies) them —
-// versions mirrored from apps/app so vendored source matches what the app
-// ships. Read by file path — NOT a package import — same as the plugin-sdk
-// dts embed above. Regenerate the registry FIRST
+// Embed the `bb plugin new` starter component set from the plugin component
+// registry (plugin design §5.5): the transitive closure of the starter
+// items, as {target, content} pairs, plus the npm deps a scaffold needs to
+// build (dependencies) and typecheck (devDependencies) them — versions
+// mirrored from apps/app so vendored source matches what the app ships.
+// Read by file path — NOT a package import — same as the plugin-sdk dts
+// embed above. Regenerate the registry FIRST
 // (node packages/plugin-registry/scripts/build-registry.mjs), then this.
-const STARTER_ITEMS = ["button", "card", "input", "dialog"];
+// The scaffold's todo page uses button, card, input, and checkbox; dialog is
+// vendored so the next feature has a confirm step ready.
+const STARTER_ITEMS = ["button", "card", "input", "checkbox", "dialog"];
 // Keep in sync with RUNTIME_SLOT_BY_SPECIFIER in
 // packages/plugin-build/src/build-plugin-app.ts: shimmed packages are
 // runtime-provided (devDependencies for types only); everything else must be

--- a/packages/templates/src/plugin-scaffold.ts
+++ b/packages/templates/src/plugin-scaffold.ts
@@ -31,11 +31,6 @@ interface ScaffoldPluginArgs {
   packageName: string;
   /** BB app version; engines.bb is pinned to ">=<major.minor>". */
   bbVersion: string;
-  /**
-   * Also scaffold a frontend entry (`app.tsx`, wired as `bb.app` and built
-   * by `bb plugin build`). Off by default so headless plugins stay lean.
-   */
-  app?: boolean;
 }
 
 /** Arguments for {@link syncPluginTypes}. */
@@ -1092,40 +1087,205 @@ function componentsJsonSource(bbVersion: string): string {
 
 function serverEntrySource(packageName: string): string {
   const id = derivePluginId(packageName);
+  const name = pluginNameOf(packageName);
   return `// ${packageName} — a BB plugin backend entry.
 //
 // The default export is a factory that receives the plugin API. BB supplies
 // the tiny defineRpcContract runtime helper; the API type remains type-only.
+//
+// The example is a todo list. One store in bb.storage.kv serves three
+// surfaces: the Example todos page (app.tsx, over RPC), the \`bb ${id}\` CLI
+// command (below), and the skill in skills/example-todos/SKILL.md that tells
+// agents how to use that command. A write from any surface publishes a realtime signal so
+// every open page refetches.
+import { randomUUID } from "node:crypto";
 import { defineRpcContract, type BbPluginApi } from "@get-bb/plugin-sdk";
 import { z } from "zod";
 
+const todoSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  done: z.boolean(),
+  createdAt: z.string(),
+});
+export type Todo = z.infer<typeof todoSchema>;
+
+// Both schemas run at the wire boundary. Handler input/output are inferred
+// from the shared contract; app.tsx imports only its type.
 export const rpcContract = defineRpcContract({
-  greeting: {
+  todos_list: {
     input: z.null(),
-    output: z.object({ greeting: z.string(), loadCount: z.number().int() }),
+    output: z.object({ todos: z.array(todoSchema) }),
+  },
+  todos_add: {
+    input: z.object({ title: z.string().trim().min(1).max(200) }),
+    output: todoSchema,
+  },
+  todos_set_done: {
+    input: z.object({ id: z.string(), done: z.boolean() }),
+    output: todoSchema,
+  },
+  todos_remove: {
+    input: z.object({ id: z.string() }),
+    output: z.object({ removed: z.boolean() }),
   },
 });
+
+/** Realtime channel app.tsx listens on; the payload is the todo count. */
+const TODOS_CHANGED = "todos-changed";
 
 export default async function plugin(bb: BbPluginApi) {
   bb.log.info("loaded");
 
   // Declarative settings — rendered in BB's settings UI and editable with
   // \`bb plugin config ${id}\`. Add \`secret: true\` for values like API keys.
+  // Settings are read once per load: reload the plugin after changing one.
   const settings = bb.settings.define({
-    greeting: { type: "string", label: "Greeting", default: "hello" },
+    showDone: {
+      type: "boolean",
+      label: "Show completed todos",
+      default: true,
+    },
   });
-  const { greeting } = await settings.get();
+  const { showDone } = await settings.get();
 
   // Namespaced key-value storage in bb.db (JSON values, up to 256KB each).
   // For bigger or relational data use bb.storage.database().
-  const loadCount = ((await bb.storage.kv.get<number>("load-count")) ?? 0) + 1;
-  await bb.storage.kv.set("load-count", loadCount);
-  bb.log.info(\`\${greeting} — load #\${loadCount}\`);
+  async function readTodos(): Promise<Todo[]> {
+    return (await bb.storage.kv.get<Todo[]>("todos")) ?? [];
+  }
+  async function writeTodos(todos: Todo[]): Promise<void> {
+    await bb.storage.kv.set("todos", todos);
+    // Ephemeral broadcast to every connected client; nothing is persisted.
+    bb.realtime.publish(TODOS_CHANGED, { count: todos.length });
+  }
 
-  // Both schemas run at the wire boundary. Handler input/output are inferred
-  // from the shared contract; app.tsx imports only its type.
+  async function listTodos(): Promise<Todo[]> {
+    const todos = await readTodos();
+    return showDone ? todos : todos.filter((todo) => !todo.done);
+  }
+  async function addTodo(title: string): Promise<Todo> {
+    const todo: Todo = {
+      id: randomUUID().slice(0, 8),
+      title,
+      done: false,
+      createdAt: new Date().toISOString(),
+    };
+    await writeTodos([...(await readTodos()), todo]);
+    return todo;
+  }
+  async function setTodoDone(id: string, done: boolean): Promise<Todo | null> {
+    const todos = await readTodos();
+    const todo = todos.find((candidate) => candidate.id === id);
+    if (todo === undefined) return null;
+    todo.done = done;
+    await writeTodos(todos);
+    return todo;
+  }
+  async function removeTodo(id: string): Promise<boolean> {
+    const todos = await readTodos();
+    const remaining = todos.filter((todo) => todo.id !== id);
+    if (remaining.length === todos.length) return false;
+    await writeTodos(remaining);
+    return true;
+  }
+
   bb.rpc.register(rpcContract, {
-    greeting: () => ({ greeting, loadCount }),
+    todos_list: async () => ({ todos: await listTodos() }),
+    todos_add: ({ title }) => addTodo(title),
+    todos_set_done: async ({ id, done }) => {
+      const todo = await setTodoDone(id, done);
+      if (todo === null) throw new Error(\`No todo with id \${id}\`);
+      return todo;
+    },
+    todos_remove: async ({ id }) => ({ removed: await removeTodo(id) }),
+  });
+
+  // The \`bb ${id}\` command: what agents (and you) use from a shell. Parsing
+  // argv is plugin-owned; \`commands\` is metadata BB renders into help and
+  // the generated plugin-commands skill without running plugin code.
+  const usage = [
+    "Usage:",
+    "  bb ${id} list [--json]",
+    "  bb ${id} add <title> [--json]",
+    "  bb ${id} done <todo-id> [--json]",
+    "  bb ${id} undo <todo-id> [--json]",
+    "  bb ${id} remove <todo-id> [--json]",
+  ].join("\\n");
+  function formatTodo(todo: Todo): string {
+    return \`[\${todo.done ? "x" : " "}] \${todo.id}  \${todo.title}\`;
+  }
+  bb.cli.register({
+    name: "${id}",
+    summary: "Manage the ${name} plugin's example todo list",
+    commands: [
+      { name: "list", summary: "List todos", usage: "bb ${id} list [--json]" },
+      {
+        name: "add",
+        summary: "Add a todo",
+        usage: "bb ${id} add <title> [--json]",
+      },
+      {
+        name: "done",
+        summary: "Mark a todo done",
+        usage: "bb ${id} done <todo-id> [--json]",
+      },
+      {
+        name: "undo",
+        summary: "Mark a todo not done",
+        usage: "bb ${id} undo <todo-id> [--json]",
+      },
+      {
+        name: "remove",
+        summary: "Remove a todo",
+        usage: "bb ${id} remove <todo-id> [--json]",
+      },
+    ],
+    async run(argv) {
+      const json = argv.includes("--json");
+      const [command, ...args] = argv.filter((arg) => arg !== "--json");
+      const reply = (value: unknown, text: string) => ({
+        exitCode: 0,
+        stdout: json ? JSON.stringify(value) : text,
+      });
+      const notFound = (missingId: string) => ({
+        exitCode: 1,
+        stderr: \`No todo with id \${missingId}. Run "bb ${id} list" to see ids.\`,
+      });
+      const todoId = args[0];
+      switch (command) {
+        case undefined:
+        case "help":
+        case "--help":
+          return { exitCode: 0, stdout: usage };
+        case "list": {
+          const todos = await listTodos();
+          return reply(
+            todos,
+            todos.length === 0 ? "No todos." : todos.map(formatTodo).join("\\n"),
+          );
+        }
+        case "add": {
+          const title = args.join(" ").trim();
+          if (title === "") break;
+          const todo = await addTodo(title);
+          return reply(todo, \`Added \${formatTodo(todo)}\`);
+        }
+        case "done":
+        case "undo": {
+          if (todoId === undefined || args.length !== 1) break;
+          const todo = await setTodoDone(todoId, command === "done");
+          if (todo === null) return notFound(todoId);
+          return reply(todo, formatTodo(todo));
+        }
+        case "remove": {
+          if (todoId === undefined || args.length !== 1) break;
+          if (!(await removeTodo(todoId))) return notFound(todoId);
+          return reply({ removed: true, id: todoId }, \`Removed \${todoId}\`);
+        }
+      }
+      return { exitCode: 1, stderr: usage };
+    },
   });
 
   // Cleanup on reload/disable/shutdown; hooks run LIFO. The sanctioned place
@@ -1166,62 +1326,194 @@ function appEntrySource(packageName: string): string {
 //
 // The components under components/ui/ are YOURS: vendored source (shadcn
 // model), edit freely. Add more from the BB registry with
-// \`npx shadcn add @bb/<name>\` (see components.json) — dialogs, dropdowns,
-// tables, the full shadcn set, version-matched to this BB install. Run
+// \`npx shadcn add @bb/<name>\` (see components.json) — dropdowns, tables,
+// the full shadcn set, version-matched to this BB install. Run
 // \`npm install\` once before \`bb plugin build\`.
-import { useState } from "react";
-import { definePluginApp, useBbContext, useRpc } from "@get-bb/plugin-sdk/app";
-import type { rpcContract } from "./server";
+import { useCallback, useEffect, useState } from "react";
+import type { FormEvent, ReactNode } from "react";
+import { definePluginApp, useRealtime, useRpc } from "@get-bb/plugin-sdk/app";
+import type { rpcContract, Todo } from "./server";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Icon } from "@/components/ui/icon";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
 
-function HelloCard() {
-  const { projectId } = useBbContext();
+/** The todo list, kept current by the server's "todos-changed" signal. */
+function useTodos() {
   const rpc = useRpc<typeof rpcContract>();
-  const [greeting, setGreeting] = useState("Say hello");
-  // Tailwind classes compile against the host theme's live CSS variables —
-  // derive colors from the theme tokens, never hardcoded grays.
+  const [todos, setTodos] = useState<Todo[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const report = useCallback((cause: unknown) => {
+    setError(cause instanceof Error ? cause.message : String(cause));
+  }, []);
+  const refetch = useCallback(() => {
+    rpc.call("todos_list").then((result) => {
+      setTodos(result.todos);
+      setError(null);
+    }, report);
+  }, [rpc, report]);
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+  // server.ts publishes after every write — from this page, another window,
+  // or \`bb ${id} add\` run by an agent — so the list never goes stale.
+  useRealtime("todos-changed", refetch);
+  return { rpc, todos, error, report, refetch };
+}
+
+function TodoRow({
+  todo,
+  onToggle,
+  onRemove,
+}: {
+  todo: Todo;
+  onToggle: (done: boolean) => void;
+  onRemove: () => void;
+}) {
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>${packageName}</CardTitle>
-      </CardHeader>
-      <CardContent className="flex items-center gap-3 text-sm text-muted-foreground">
-        <span>
-          {projectId === null
-            ? "No project selected."
-            : \`Project: \${projectId}.\`}
-        </span>
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() => {
-            void rpc.call("greeting").then((result) => {
-              setGreeting(\`\${result.greeting} (#\${result.loadCount})\`);
-            });
-          }}
-        >
-          {greeting}
-        </Button>
-      </CardContent>
-    </Card>
+    <li className="flex items-center gap-3 py-2.5 text-sm">
+      <Checkbox
+        checked={todo.done}
+        onCheckedChange={(checked) => onToggle(checked === true)}
+        aria-label={\`Mark "\${todo.title}" \${todo.done ? "not done" : "done"}\`}
+      />
+      <span
+        className={cn(
+          "min-w-0 flex-1 truncate",
+          todo.done && "text-muted-foreground line-through",
+        )}
+      >
+        {todo.title}
+      </span>
+      <span className="hidden font-mono text-xs text-muted-foreground sm:inline">
+        {todo.id}
+      </span>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-7 text-muted-foreground hover:text-foreground"
+        aria-label={\`Remove "\${todo.title}"\`}
+        onClick={onRemove}
+      >
+        <Icon name="Trash2" className="size-4" />
+      </Button>
+    </li>
+  );
+}
+
+/** The dashed box BB's own list pages use for loading and empty states. */
+function EmptyState({ children }: { children: ReactNode }) {
+  return (
+    <div
+      role="status"
+      className="rounded-lg border border-dashed border-border px-4 py-6 text-center text-sm text-muted-foreground"
+    >
+      {children}
+    </div>
+  );
+}
+
+// Tailwind classes compile against the host theme's live CSS variables —
+// derive colors from the theme tokens, never hardcoded grays. The frame
+// (scrolling page, centered column) matches BB's own nav-panel pages.
+function TodosPage() {
+  const { rpc, todos, error, report, refetch } = useTodos();
+  const [title, setTitle] = useState("");
+  const [pending, setPending] = useState(false);
+  const add = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const next = title.trim();
+    if (next === "" || pending) return;
+    setPending(true);
+    try {
+      await rpc.call("todos_add", { title: next });
+      setTitle("");
+      refetch();
+    } catch (cause) {
+      report(cause);
+    } finally {
+      setPending(false);
+    }
+  };
+  const doneCount = todos?.filter((todo) => todo.done).length ?? 0;
+  return (
+    <div className="h-full min-h-0 flex-1 overflow-y-auto">
+      <div className="mx-auto box-border w-full max-w-3xl px-4 pb-4 pt-3 md:px-5 md:pt-4">
+        <p className="text-sm text-muted-foreground">
+          Agents keep this list with <code>bb ${id}</code>; the skill in{" "}
+          <code>skills/example-todos</code> tells them how.
+        </p>
+        <form onSubmit={add} className="mt-4 flex items-center gap-2">
+          <Input
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="What needs doing?"
+            aria-label="New todo"
+          />
+          <Button type="submit" disabled={pending || title.trim() === ""}>
+            <Icon name="Plus" className="size-4" />
+            Add
+          </Button>
+        </form>
+        {error === null ? null : (
+          <p role="alert" className="mt-3 text-sm text-destructive">
+            {error}
+          </p>
+        )}
+        <div className="mt-4">
+          {todos === null ? (
+            <EmptyState>Loading todos…</EmptyState>
+          ) : todos.length === 0 ? (
+            <EmptyState>
+              Nothing to do. Add one above, or run{" "}
+              <code>bb ${id} add "Ship it"</code>.
+            </EmptyState>
+          ) : (
+            <ul className="divide-y divide-border overflow-hidden rounded-lg border border-border bg-card px-4">
+              {todos.map((todo) => (
+                <TodoRow
+                  key={todo.id}
+                  todo={todo}
+                  onToggle={(done) => {
+                    rpc
+                      .call("todos_set_done", { id: todo.id, done })
+                      .then(refetch, report);
+                  }}
+                  onRemove={() => {
+                    rpc
+                      .call("todos_remove", { id: todo.id })
+                      .then(refetch, report);
+                  }}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+        {todos !== null && todos.length > 0 ? (
+          <p className="mt-2 text-xs text-muted-foreground">
+            {doneCount} of {todos.length} done
+          </p>
+        ) : null}
+      </div>
+    </div>
   );
 }
 
 // The default export must be definePluginApp(...); BB interprets it after
-// loading the bundle. Register general UI under app.slots and composer actions,
-// plus-menu rows, banners, or rich-text rules with app.composer.customize(...)
-// (see the bb guide's plugins chapter).
+// loading the bundle. navPanel adds a page to the left sidebar; register
+// other UI under app.slots and composer actions, plus-menu rows, banners, or
+// rich-text rules with app.composer.customize(...) (see the bb guide's
+// plugins chapter).
 export default definePluginApp((app) => {
-  app.slots.homepageSection({
-    id: "${id}-hello",
-    title: "${packageName}",
-    component: HelloCard,
+  app.slots.navPanel({
+    id: "example-todos",
+    title: "Example todos",
+    icon: "ListTodo",
+    // Routed at /plugins/${id}/example-todos; the component receives the
+    // remainder as \`subPath\` for deep links within the page.
+    path: "example-todos",
+    component: TodosPage,
   });
 });
 `;
@@ -1229,15 +1521,15 @@ export default definePluginApp((app) => {
 
 /**
  * Typecheck-only tsconfig: server.ts compiles against the BbPluginApi contract
- * (type-only, erased at load time); app.tsx is included when the plugin
- * declares a frontend entry. `@get-bb/plugin-sdk` and `@get-bb/plugin-sdk/app`
- * resolve through plain node resolution to the installed npm package (declared
- * as an exact devDependency pin), whose `bundled-types/*.d.ts` are the API
- * surface — no path mapping, so editors, `tsc`, and the build all agree with
- * what `npm install` put on disk. Tests reach the testing subpaths of the same
- * package.
+ * (type-only, erased at load time) and app.tsx plus the vendored components
+ * against the frontend contract. `@get-bb/plugin-sdk` and
+ * `@get-bb/plugin-sdk/app` resolve through plain node resolution to the
+ * installed npm package (declared as an exact devDependency pin), whose
+ * `bundled-types/*.d.ts` are the API surface — no path mapping for the SDK, so
+ * editors, `tsc`, and the build all agree with what `npm install` put on
+ * disk. Tests reach the testing subpaths of the same package.
  */
-function tsconfigSource(app: boolean): string {
+function tsconfigSource(): string {
   return `${JSON.stringify(
     {
       compilerOptions: {
@@ -1252,38 +1544,87 @@ function tsconfigSource(app: boolean): string {
         types: ["node"],
         // Vendored components import via "@/..." (shadcn convention);
         // esbuild reads this mapping too during `bb plugin build`.
-        ...(app ? { paths: { "@/*": ["./*"] } } : {}),
+        paths: { "@/*": ["./*"] },
         noEmit: true,
         skipLibCheck: false,
       },
-      include: app
-        ? ["server.ts", "app.tsx", "components", "lib", "hooks"]
-        : ["server.ts"],
+      include: ["server.ts", "app.tsx", "components", "lib", "hooks"],
     },
     null,
     2,
   )}\n`;
 }
 
-function skillSource(): string {
+/**
+ * The plugin's skill: auto-imported into agent threads from `skills/` (the
+ * manifest's default `bb.skills` root; the directory name is the skill name).
+ * BB also generates a `plugin-commands` skill that lists every registered
+ * `bb <id>` subcommand, so this one carries the procedure, not the syntax.
+ */
+function skillSource(packageName: string): string {
+  const id = derivePluginId(packageName);
+  const name = pluginNameOf(packageName);
   return `---
-name: example-skill
-description: Example skill scaffolded by \`bb plugin new\` — replace with a real capability description that tells agents when to use it.
+name: example-todos
+description: Read and update the ${name} plugin's example todo list with the \`bb ${id}\` CLI. Use when the user asks to add, complete, reopen, remove, or review todos, or when the steps of a task should be tracked as todos.
 ---
 
-<!-- Plugin skills/ directories auto-import in a later BB phase; until then
-     this file documents the expected layout. -->
+# Example todos
 
-# Example skill
+The ${name} plugin keeps one todo list. The Example todos page in the BB sidebar and
+the \`bb ${id}\` command read and write the same list, so a change from either
+side shows in the other at once.
 
-Describe when to use this skill and the steps to follow.
+## Commands
+
+| Command | Effect |
+| --- | --- |
+| \`bb ${id} list\` | Show every todo with its id. \`[x]\` marks a done todo. |
+| \`bb ${id} add <title>\` | Add a todo. Quote a title that has spaces. |
+| \`bb ${id} done <todo-id>\` | Mark a todo done. |
+| \`bb ${id} undo <todo-id>\` | Mark a todo not done. |
+| \`bb ${id} remove <todo-id>\` | Delete a todo. |
+
+Add \`--json\` to any command when the output drives code.
+
+## Procedure
+
+1. Run \`bb ${id} list\` before you change the list. Use the ids it prints;
+   never guess an id.
+2. Add todos one at a time with a short title that starts with a verb:
+   \`bb ${id} add "Write the release notes"\`.
+3. When you finish a todo, mark it done: \`bb ${id} done <todo-id>\`. Do not
+   remove a todo to mark it done.
+4. Remove a todo only when the user asks for it or when it duplicates
+   another todo.
+5. End with a short summary of what you added, completed, or removed.
+
+## Rules
+
+- Change the list only through \`bb ${id}\`. Do not edit bb.db or the plugin's
+  storage directly.
+- A non-zero exit with "No todo with id" means the id is stale: run
+  \`bb ${id} list\` again.
 `;
 }
 
-function readmeSource(packageName: string, app: boolean): string {
+function readmeSource(packageName: string): string {
   const id = derivePluginId(packageName);
-  const componentsSection = app
-    ? `
+  return `# ${packageName}
+
+A BB plugin that keeps a todo list. It shows every surface a plugin can own:
+
+- \`server.ts\` — the backend: a todo store in \`bb.storage.kv\`, RPC methods
+  for the page, a \`bb ${id}\` CLI command, a setting, and a realtime signal
+  that keeps every open page current.
+- \`app.tsx\` — the frontend: an **Example todos** page in the left sidebar
+  (\`app.slots.navPanel\`) built from the vendored components.
+- \`skills/example-todos/SKILL.md\` — a skill that tells agents how to keep the list
+  with \`bb ${id}\`. BB imports it into agent threads automatically.
+
+Try it: install the plugin, open **Example todos** in the sidebar, then run
+\`bb ${id} add "Ship it"\` in a terminal. The page updates at once.
+
 ## UI components
 
 \`components/ui/\` is vendored source you own (the shadcn model): edit the
@@ -1292,7 +1633,7 @@ component registry (the full shadcn set, version-matched to your BB install
 via the pinned ref in \`components.json\`):
 
 \`\`\`
-npx shadcn add @bb/dialog @bb/select
+npx shadcn add @bb/select @bb/table
 \`\`\`
 
 Run \`npm install\` once before \`bb plugin build\` — the vendored components'
@@ -1301,17 +1642,16 @@ radix portal primitives and \`sonner\` (\`import { toast } from "sonner"\`
 reaches BB's own toaster), are provided by the BB app at runtime and never
 bundled. Ship \`dist/\` (npm tarball or committed for git installs) so
 people installing your plugin never need npm.
-`
-    : "";
-  return `# ${packageName}
 
-A BB plugin.
-${componentsSection}
 ## Manifest
 
 \`package.json\` is the plugin manifest. Notable fields:
 
-- \`bb.server\` — backend entry (required); optional \`bb.app\` for a frontend.
+- \`bb.server\` — backend entry (required).
+- \`bb.app\` — frontend entry. Delete it, \`app.tsx\`, \`components/\`,
+  \`hooks/\`, and \`lib/\` for a headless plugin.
+- \`bb.skills\` — skill roots; omitted here, so BB reads \`skills/\`. Each
+  directory with a \`SKILL.md\` is one skill, named after the directory.
 - \`bb.name\` and \`bb.description\` — required human-facing identity.
 - \`bb.branding\` — required; declare \`icon\` as a BB icon name or a
   plugin-relative compact SVG, or declare \`logo.light\` (with optional
@@ -1329,8 +1669,8 @@ ${componentsSection}
   \`@get-bb/plugin-sdk\` at runtime — never bundle them).
 
 Run \`bb plugin build\` before publishing git/npm installs. It writes
-\`dist/server.js\` + \`server.meta.json\` (and, with \`bb.app\`, \`app.js\` /
-\`app.css\` / \`app.meta.json\`). Each \`*.meta.json\` stamps SDK major/version,
+\`dist/server.js\` + \`server.meta.json\` and \`app.js\` / \`app.css\` /
+\`app.meta.json\`. Each \`*.meta.json\` stamps SDK major/version,
 \`artifactFormatVersion\`, \`pluginId\`, \`pluginVersion\`, and
 \`builtWith\` so managed installs can verify the artifacts.
 
@@ -1350,11 +1690,14 @@ After editing sources, reload:
 bb plugin reload ${id}
 \`\`\`
 
+Or let \`bb plugin dev\` rebuild and reload on every save.
+
 ## Configure
 
 \`\`\`
 bb plugin config ${id}
-bb plugin config ${id} set greeting hi
+bb plugin config ${id} set showDone false
+bb plugin reload ${id}
 \`\`\`
 
 ## Types & API reference
@@ -1394,7 +1737,7 @@ repo and read the source: <https://github.com/get-bb/bb>.
  * The generated server.ts loads cleanly against the live plugin API.
  */
 export async function scaffoldPlugin(args: ScaffoldPluginArgs): Promise<void> {
-  const { targetDir, packageName, bbVersion, app = false } = args;
+  const { targetDir, packageName, bbVersion } = args;
   try {
     await mkdir(targetDir, { recursive: false });
   } catch (error) {
@@ -1416,10 +1759,10 @@ export async function scaffoldPlugin(args: ScaffoldPluginArgs): Promise<void> {
         },
         bb: {
           name: pluginNameOf(packageName),
-          description: "A BB plugin.",
-          branding: { icon: "Zap" },
+          description: "A BB plugin with an example todo list.",
+          branding: { icon: "ListTodo" },
           server: "./server.ts",
-          ...(app ? { app: "./app.tsx" } : {}),
+          app: "./app.tsx",
         },
         // A package belongs here when generated source imports it AND the
         // build neither externalizes nor shims it — those imports are inlined
@@ -1432,7 +1775,7 @@ export async function scaffoldPlugin(args: ScaffoldPluginArgs): Promise<void> {
         // - starter deps: the vendored components' real runtime deps, bundled
         //   into dist/app.js (consumers get the prebuilt dist/ and need none).
         dependencies: {
-          ...(app ? PLUGIN_STARTER_DEPENDENCIES : {}),
+          ...PLUGIN_STARTER_DEPENDENCIES,
           zod: "^4.3.6",
         },
         // Typecheck-only. @get-bb/plugin-sdk carries the BbPluginApi/SDK
@@ -1442,23 +1785,20 @@ export async function scaffoldPlugin(args: ScaffoldPluginArgs): Promise<void> {
         // declarations must describe the bb actually loading the plugin, and
         // `bb plugin types` keeps it matched to the bb you run. The rest supply
         // the real npm types those declarations reference (hono/better-sqlite3
-        // and the root contract's React types) for packages generated source
-        // does not import: BB provides them at runtime and the bundle never
-        // inlines them. An author who imports one directly must promote it
-        // above.
+        // and React) for packages generated source does not import: BB
+        // provides them at runtime and the bundle never inlines them. An
+        // author who imports one directly must promote it above.
         devDependencies: {
           "@get-bb/plugin-sdk": PLUGIN_SDK_VERSION,
           "@types/better-sqlite3": "^7.6.12",
           "@types/node": "^22.0.0",
-          // The root SDK declaration also exposes frontend contract types, so
-          // React's declarations are required for headless plugin typechecks.
           "@types/react": "^19.0.0",
-          ...(app ? { "@types/react-dom": "^19.0.0" } : {}),
+          "@types/react-dom": "^19.0.0",
           "better-sqlite3": "^12.0.0",
           hono: "^4.11.9",
           typescript: "^5.7.0",
           // Runtime-shimmed by BB (never bundled) — types only.
-          ...(app ? PLUGIN_STARTER_TYPE_DEPENDENCIES : {}),
+          ...PLUGIN_STARTER_TYPE_DEPENDENCIES,
         },
       },
       null,
@@ -1466,29 +1806,28 @@ export async function scaffoldPlugin(args: ScaffoldPluginArgs): Promise<void> {
     ) + "\n",
   );
   await writeFile(join(targetDir, "server.ts"), serverEntrySource(packageName));
-  await writeFile(join(targetDir, "tsconfig.json"), tsconfigSource(app));
+  await writeFile(join(targetDir, "app.tsx"), appEntrySource(packageName));
+  await writeFile(join(targetDir, "tsconfig.json"), tsconfigSource());
   // No `types/` here: the declarations arrive with `npm install` from the
   // exact-pinned @get-bb/plugin-sdk devDependency above. Plugins scaffolded
   // before that switch still vendor `types/`, and syncPluginTypes keeps
   // refreshing those — see resolvePluginSdkLayout.
-  if (app) {
-    await writeFile(join(targetDir, "app.tsx"), appEntrySource(packageName));
-    // Vendored starter components (shadcn model — the author owns and edits
-    // them) + components.json so `npx shadcn add @bb/<name>` pulls more from
-    // the BB registry at the version tag matching this install.
-    for (const file of PLUGIN_STARTER_FILES) {
-      const filePath = join(targetDir, file.target);
-      await mkdir(dirname(filePath), { recursive: true });
-      await writeFile(filePath, file.content);
-    }
-    await writeFile(
-      join(targetDir, "components.json"),
-      componentsJsonSource(bbVersion),
-    );
+  //
+  // Vendored starter components (shadcn model — the author owns and edits
+  // them) + components.json so `npx shadcn add @bb/<name>` pulls more from
+  // the BB registry at the version tag matching this install.
+  for (const file of PLUGIN_STARTER_FILES) {
+    const filePath = join(targetDir, file.target);
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, file.content);
   }
-  const skillDir = join(targetDir, "skills", "example-skill");
+  await writeFile(
+    join(targetDir, "components.json"),
+    componentsJsonSource(bbVersion),
+  );
+  const skillDir = join(targetDir, "skills", "example-todos");
   await mkdir(skillDir, { recursive: true });
-  await writeFile(join(skillDir, "SKILL.md"), skillSource());
+  await writeFile(join(skillDir, "SKILL.md"), skillSource(packageName));
   await writeFile(join(targetDir, ".gitignore"), "dist/\nnode_modules/\n");
-  await writeFile(join(targetDir, "README.md"), readmeSource(packageName, app));
+  await writeFile(join(targetDir, "README.md"), readmeSource(packageName));
 }

--- a/packages/templates/src/templates/bb-guide-plugins.md
+++ b/packages/templates/src/templates/bb-guide-plugins.md
@@ -233,11 +233,12 @@ added/updated/unchanged counts.
                                  secrets, and schedules (managed git:/npm:
                                  files deleted; local path sources stay on
                                  disk; builtin removals are remembered)
-  bb plugin new <name> [--app]   Scaffold a new plugin and install its npm
+  bb plugin new <name>           Scaffold a todo-list plugin (server.ts,
+                                 app.tsx with a sidebar page, a `bb <id>` CLI
+                                 command, and a skill) and install its npm
                                  dependencies, including @get-bb/plugin-sdk
                                  pinned to this bb's exact SDK version (no
-                                 server required; --app adds a frontend entry,
-                                 app.tsx, plus a typecheck-only tsconfig.json)
+                                 server required)
   bb plugin types [path]         Sync a plugin's @get-bb/plugin-sdk surface to
                                  this bb (default: cwd): repin the npm
                                  devDependency to this bb's SDK version, or
@@ -556,7 +557,7 @@ backend contract import with `useRpc<typeof contract>()` for exact frontend
 method/input/result inference. The server validates both schemas and rejects
 non-JSON results (including cyclic and non-finite values) with structured
 error codes. Components are vendored shadcn source the plugin owns (the
-shadcn model): `bb plugin new --app` pre-vendors a starter set into
+shadcn model): `bb plugin new` pre-vendors a starter set into
 components/ui/ and `npx shadcn add @bb/<name>` pulls more from the BB
 component registry (the full stock shadcn set, version-matched to the
 running BB via the pinned ref in components.json). Product capabilities are
@@ -622,9 +623,10 @@ large content.
 
 Authoring a plugin
 
-The loop: `bb plugin new <name>` scaffolds `./bb-plugin-<name>` (add --app
-for a frontend entry); `bb plugin install .` registers it; `bb plugin dev`
-watches and reloads on every save. The manifest is package.json: required
+The loop: `bb plugin new <name>` scaffolds `./bb-plugin-<name>` — a working
+todo list with a backend, a sidebar page, a `bb <name>` command, and a skill;
+delete what you do not need; `bb plugin install .` registers it; `bb plugin
+dev` watches and reloads on every save. The manifest is package.json: required
 `bb.name` and `bb.description` human identity, required `bb.branding` with at
 least `icon` or `logo.light`, `bb.server`
 (backend entry, loaded as TypeScript — no build step), optional `bb.app`

--- a/packages/templates/test/plugin-scaffold-external.test.ts
+++ b/packages/templates/test/plugin-scaffold-external.test.ts
@@ -63,16 +63,24 @@ describe("scaffold backend", () => {
   it("loads, inspects, and atomically reloads through the packed harness", async () => {
     const host = createFakePluginHost({ pluginId: "external-backend" });
     await plugin(host.bb);
-    await expect(host.harness.behavior.callRpc("greeting")).resolves.toEqual({
-      greeting: "hello",
-      loadCount: 1,
+    await expect(host.harness.behavior.callRpc("todos_list")).resolves.toEqual({
+      todos: [],
     });
-    expect(host.harness.inspection.registrations.rpcMethods).toEqual(["greeting"]);
+    const added = await host.harness.behavior.callRpc("todos_add", {
+      title: "Ship it",
+    });
+    expect(added).toMatchObject({ title: "Ship it", done: false });
+    expect(host.harness.inspection.registrations.rpcMethods).toEqual([
+      "todos_list",
+      "todos_add",
+      "todos_set_done",
+      "todos_remove",
+    ]);
 
+    // The todo store lives in bb.storage.kv, so it survives a reload.
     const next = await host.harness.lifecycle.reload(plugin);
-    await expect(next.harness.behavior.callRpc("greeting")).resolves.toEqual({
-      greeting: "hello",
-      loadCount: 2,
+    await expect(next.harness.behavior.callRpc("todos_list")).resolves.toEqual({
+      todos: [added],
     });
     await next.harness.lifecycle.dispose();
   });
@@ -86,20 +94,43 @@ import { describe, expect, it } from "vitest";
 import { loadPluginApp, renderSlot } from "@get-bb/plugin-sdk/testing/app";
 
 describe("scaffold frontend", () => {
-  it("loads and renders a slot through the packed harness", async () => {
+  it("loads and renders the Example todos page through the packed harness", async () => {
     const app = await loadPluginApp(() => import("./app"));
+    const createdAt = "2026-01-01T00:00:00.000Z";
+    let todos = [{ id: "a1", title: "Ship it", done: false, createdAt }];
     const slot = renderSlot(
-      app.homepageSections[0]!,
-      { projectId: "proj_external" },
+      app.navPanels[0]!,
+      { subPath: "" },
       {
         context: { projectId: "proj_external", threadId: null },
-        rpc: { greeting: () => ({ greeting: "external", loadCount: 3 }) },
+        rpc: {
+          todos_list: () => ({ todos }),
+          todos_add: (input: unknown) => {
+            const { title } = input as { title: string };
+            const todo = { id: "b2", title, done: false, createdAt };
+            todos = [...todos, todo];
+            return todo;
+          },
+        },
       },
     );
+    await slot.findByText("Ship it");
 
-    fireEvent.click(slot.getByText("Say hello"));
-    await slot.findByText("external (#3)");
-    expect(slot.inspection.rpcCalls).toEqual([{ method: "greeting", input: null }]);
+    fireEvent.change(slot.getByLabelText("New todo"), {
+      target: { value: "Write docs" },
+    });
+    fireEvent.click(slot.getByText("Add"));
+    await slot.findByText("Write docs");
+    expect(slot.inspection.rpcCalls.map((call) => call.method)).toEqual([
+      "todos_list",
+      "todos_add",
+      "todos_list",
+    ]);
+
+    // A server-side write (bb <id> remove …) reaches the page as a signal.
+    todos = [];
+    await slot.behavior.emitRealtime("todos-changed", { count: 0 });
+    await slot.findByText(/Nothing to do/);
     slot.lifecycle.unmount();
   });
 });
@@ -347,14 +378,13 @@ describe("external plugin scaffold types", () => {
   beforeAll(async () => {
     packRoot = await mkdtemp(join(tmpdir(), "bb-external-pack-"));
     tarball = await packPluginSdk(join(packRoot, "pack"));
-    // The app scaffold declares the superset of the backend scaffold's
-    // dependencies, so its install serves both.
+    // Every scaffold declares the same dependencies, so one install serves
+    // them all.
     const templateDir = join(packRoot, "template");
     await scaffoldPlugin({
       targetDir: templateDir,
       packageName: "bb-plugin-external-template",
       bbVersion: "0.9.0",
-      app: true,
     });
     await installPackedSdk(templateDir, tarball);
     await linkExternalDependencies(templateDir);
@@ -379,7 +409,6 @@ describe("external plugin scaffold types", () => {
       targetDir,
       packageName: "bb-plugin-external",
       bbVersion: "0.9.0",
-      app: true,
     });
     await writeFile(join(targetDir, "server.ts"), REPRESENTATIVE_SERVER);
     await writeFile(join(targetDir, "app.tsx"), REPRESENTATIVE_APP);
@@ -513,16 +542,15 @@ describe("external plugin scaffold types", () => {
       };
     };
     expect(backendTsconfig.compilerOptions.skipLibCheck).toBe(false);
-    // No mapping to fall back on: the testing declarations import the package
-    // root, which has to resolve through the install alone.
-    expect(backendTsconfig.compilerOptions.paths).toBeUndefined();
+    // Only the shadcn alias is mapped, never the SDK: the testing declarations
+    // import the package root, which has to resolve through the install alone.
+    expect(backendTsconfig.compilerOptions.paths).toEqual({ "@/*": ["./*"] });
 
     const frontendDir = join(workDir, "bb-plugin-external-frontend");
     await scaffoldPlugin({
       targetDir: frontendDir,
       packageName: "bb-plugin-external-frontend",
       bbVersion: "0.9.0",
-      app: true,
     });
     await useInstalledNodeModules(frontendDir);
     await writeFile(join(frontendDir, "app.test.tsx"), FRONTEND_TEST);

--- a/packages/templates/test/plugin-scaffold.test.ts
+++ b/packages/templates/test/plugin-scaffold.test.ts
@@ -27,11 +27,11 @@ describe("scaffoldPlugin SDK dependency", () => {
     await rm(workDir, { recursive: true, force: true });
   });
 
-  it("pins @get-bb/plugin-sdk exactly and vendors no declarations (headless)", async () => {
-    const targetDir = join(workDir, "bb-plugin-headless");
+  it("pins @get-bb/plugin-sdk exactly and vendors no declarations", async () => {
+    const targetDir = join(workDir, "bb-plugin-todo");
     await scaffoldPlugin({
       targetDir,
-      packageName: "bb-plugin-headless",
+      packageName: "bb-plugin-todo",
       bbVersion: "0.9.0",
     });
 
@@ -40,11 +40,17 @@ describe("scaffoldPlugin SDK dependency", () => {
     const tsconfig = JSON.parse(
       await readFile(join(targetDir, "tsconfig.json"), "utf8"),
     );
-    // No path map at all for a headless plugin: `@get-bb/plugin-sdk` must
-    // resolve through node_modules, the way an editor and `tsc` both do.
-    expect(tsconfig.compilerOptions.paths).toBeUndefined();
+    // Only the shadcn alias: `@get-bb/plugin-sdk` must resolve through
+    // node_modules, the way an editor and `tsc` both do.
+    expect(tsconfig.compilerOptions.paths).toEqual({ "@/*": ["./*"] });
     expect(tsconfig.compilerOptions.skipLibCheck).toBe(false);
-    expect(tsconfig.include).toEqual(["server.ts"]);
+    expect(tsconfig.include).toEqual([
+      "server.ts",
+      "app.tsx",
+      "components",
+      "lib",
+      "hooks",
+    ]);
 
     const pkg = JSON.parse(
       await readFile(join(targetDir, "package.json"), "utf8"),
@@ -59,10 +65,10 @@ describe("scaffoldPlugin SDK dependency", () => {
       bbPluginSdk: `>=${PLUGIN_SDK_VERSION}`,
     });
     expect(pkg.bb).toMatchObject({
-      name: "Headless",
-      description: "A BB plugin.",
-      branding: { icon: "Zap" },
+      name: "Todo",
+      branding: { icon: "ListTodo" },
       server: "./server.ts",
+      app: "./app.tsx",
     });
     expect(pkg.devDependencies["@types/react"]).toBeDefined();
     // server.ts imports zod and the build inlines it, so an install that omits
@@ -80,25 +86,6 @@ describe("scaffoldPlugin SDK dependency", () => {
     );
     expect(readme).not.toContain("rewrite types/");
     expect(readme).toContain("https://github.com/get-bb/bb");
-  });
-
-  it("keeps only the shadcn alias in paths for --app plugins", async () => {
-    const targetDir = join(workDir, "bb-plugin-ui");
-    await scaffoldPlugin({
-      targetDir,
-      packageName: "bb-plugin-ui",
-      bbVersion: "0.9.0",
-      app: true,
-    });
-
-    await expect(access(join(targetDir, "types"))).rejects.toThrow();
-
-    const tsconfig = JSON.parse(
-      await readFile(join(targetDir, "tsconfig.json"), "utf8"),
-    );
-    expect(tsconfig.compilerOptions.paths).toEqual({ "@/*": ["./*"] });
-    expect(tsconfig.include).toContain("app.tsx");
-    expect(tsconfig.include).not.toContain("types");
 
     const components = JSON.parse(
       await readFile(join(targetDir, "components.json"), "utf8"),
@@ -106,6 +93,10 @@ describe("scaffoldPlugin SDK dependency", () => {
     expect(components.registries["@bb"]).toBe(
       "https://raw.githubusercontent.com/get-bb/bb/desktop-v0.9.0/packages/plugin-registry/r/{name}.json",
     );
+    // The todo page's Checkbox rides on a bundled radix package: it must be a
+    // real dependency, not a shimmed type-only one.
+    expect(pkg.dependencies["@radix-ui/react-checkbox"]).toBeDefined();
+    await access(join(targetDir, "components", "ui", "checkbox.tsx"));
   });
 
   it("uses the canonical id in a scoped package scaffold", async () => {
@@ -126,9 +117,21 @@ describe("scaffoldPlugin SDK dependency", () => {
     expect(readme).toContain("bb plugin reload scoped");
     expect(readme).toContain("bb plugin config scoped");
 
+    // The CLI command, the page copy, and the skill all name the canonical
+    // id, never the scoped package name.
     const server = await readFile(join(targetDir, "server.ts"), "utf8");
     expect(server).toContain("bb plugin config scoped");
     expect(server).not.toContain("bb plugin config @acme/");
+    expect(server).toContain('name: "scoped"');
+    expect(server).toContain("bb scoped list");
+    const app = await readFile(join(targetDir, "app.tsx"), "utf8");
+    expect(app).toContain("bb scoped add");
+    const skill = await readFile(
+      join(targetDir, "skills", "example-todos", "SKILL.md"),
+      "utf8",
+    );
+    expect(skill).toContain("bb scoped list");
+    expect(skill).not.toContain("@acme/");
   });
 });
 

--- a/turbo.json
+++ b/turbo.json
@@ -293,7 +293,7 @@
       ],
       "outputs": ["src/generated/templates.generated.ts"]
     },
-    // The `bb plugin new --app` starter files from the (committed) component
+    // The `bb plugin new` starter files from the (committed) component
     // registry.
     "@bb/templates#generate:plugin-scaffold": {
       "dependsOn": [],


### PR DESCRIPTION
## What was wrong

`bb plugin new` had two variants (a headless default and `--app`), and the example was a homepage card that called one `greeting` RPC. It showed little of what a plugin can own and nothing about how agents use one. Requested by the owner in thread `thr_am4m2zdn4g`.

## What changed

One scaffold, always with a frontend. It is a working todo list that touches every plugin surface:

- `server.ts` — todo store in `bb.storage.kv`, four RPC methods, a `showDone` boolean setting, a realtime `todos-changed` signal after every write, and a `bb <id>` CLI command (`list | add | done | undo | remove`, `--json`, `--help` exits 0).
- `app.tsx` — an **Example todos** page in the left sidebar (`app.slots.navPanel`) laid out like BB's own nav-panel pages (description line, Input + primary Add, bordered list panel, dashed empty state, done count). Built from the vendored Button, Input, Checkbox, and Icon; Card and Dialog stay vendored for the author.
- `skills/example-todos/SKILL.md` — a skill that tells agents how to keep the list with the CLI (procedure, not syntax; BB's generated `plugin-commands` skill already lists the commands).
- Starter component set gains `checkbox` (`packages/templates/scripts/generate-plugin-scaffold.mjs`). Branding icon is `ListTodo` because `PluginIcon` shows the branding icon in the sidebar row.
- `bb plugin new --app` removed (`apps/cli/src/commands/plugin.ts`). Guide (`bb-guide-plugins.md`), `bb-cli` skill, and `bb-plugin-authoring` skill updated. No wire changes.
- Tests: `@bb/templates` scaffold tests merged into one shape; the external packed-SDK test now drives the todo RPC and the Example todos page (including a realtime push); the server `path:` install test links the component deps because every scaffold now builds a frontend bundle; `@bb/cli` build test stubs `createContext`/`react-dom` for the bundled radix checkbox.

## How you verified

- `pnpm exec turbo run typecheck --filter=@bb/templates --filter=@bb/cli --filter=@bb/server` — clean.
- `pnpm exec turbo run test --filter=@bb/templates --force` — 6 files, 40/40 (includes the external test that packs the SDK, `npm`-installs a scaffold, typechecks it with library checks, and runs its backend and frontend tests).
- `pnpm exec turbo run test --filter=@bb/cli --force` — 50 files, 473/473.
- `apps/server` `plugin-install.test.ts` scaffold case — passes (fails before the dependency-link change with five unresolved imports).
- Real scaffold: `scaffoldPlugin` → `npm install --include=dev` against published `@get-bb/plugin-sdk@0.4.16` → `tsc` clean.
- Live dev app + doobie: add/toggle/remove from the page; `bb <id> add` while the page is open refreshes it without reload; empty state; dark mode; 420px viewport; an agent thread completed todos through the skill.
- EAP codename scan of the working tree and `origin/main..HEAD`: clean.

Fixes: no linked issue.

> AGENT GENERATED
