### PR TITLE
Preserve heartbeat grace after short suspension

### DIFF
--- a/apps/host-daemon/src/server-connection.test.ts
+++ b/apps/host-daemon/src/server-connection.test.ts
@@ -382,6 +382,42 @@ describe("ServerConnection", () => {
     }
   });
 
+  it("grants a fresh acknowledgement lease after a shorter heartbeat delay", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const { connection, logger, webSocket } = createConnectionFixture({
+      heartbeatIntervalMs: 5_000,
+      leaseTimeoutMs: 30_000,
+    });
+    try {
+      await connection.start();
+      const socket = webSocket.sockets[0];
+      if (!socket) {
+        throw new Error("Expected test socket");
+      }
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      vi.setSystemTime(35_000);
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ gapMs: 35_000 }),
+        "Host daemon heartbeat timer delayed",
+      );
+      expect(socket.reconnect).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(socket.reconnect).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(socket.reconnect).toHaveBeenCalledWith(
+        1013,
+        "heartbeat-ack-timeout",
+      );
+    } finally {
+      await connection.shutdown();
+    }
+  });
+
   it("reconnects when server heartbeat acknowledgements stop", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);

--- a/apps/host-daemon/src/server-connection.ts
+++ b/apps/host-daemon/src/server-connection.ts
@@ -747,6 +747,11 @@ export class ServerConnection {
       if (lastTickAt !== null) {
         const gapMs = now - lastTickAt;
         const thresholdMs = session.leaseTimeoutMs / 2;
+        if (gapMs > session.leaseTimeoutMs) {
+          // The timer could not test liveness while it was delayed. Give the
+          // return path one fresh lease regardless of how the gap is logged.
+          this.lastHeartbeatAcknowledgedAt = now;
+        }
         const resumedAfterSuspension = isLikelySystemSuspensionDelay({
           gapMs,
           intervalMs: session.heartbeatIntervalMs,
@@ -762,10 +767,6 @@ export class ServerConnection {
             },
             "Host daemon resumed after likely system suspension",
           );
-          // The process could not receive acknowledgements while suspended.
-          // Give the resumed connection a full lease window to prove that its
-          // server-to-daemon direction still works.
-          this.lastHeartbeatAcknowledgedAt = now;
         } else if (gapMs > thresholdMs) {
           this.options.logger.warn(
             {


### PR DESCRIPTION
## What was wrong

Heartbeat acknowledgement expiry was coupled to the older 60-second system-suspension log heuristic. With the landed 5-second heartbeat and 30-second acknowledgement lease, a heartbeat callback delayed for roughly 31–64 seconds saw the acknowledgement as expired before the delay qualified for suspension grace, so waking a healthy host forced an unnecessary `heartbeat-ack-timeout` reconnect. This is a follow-up to [PR #2359](https://github.com/get-bb/bb/pull/2359).

## What changed

- Grant one fresh acknowledgement lease whenever the heartbeat timer gap itself exceeds the lease, independently of how the gap is classified for logging.
- Keep the existing sub-minute heartbeat-delay warning and 60-second likely-suspension info classification unchanged.
- Add regression coverage proving a 35-second gap does not reconnect immediately and that a genuinely dead return path still reconnects after the fresh lease expires.

There are no wire-contract changes, so `HOST_DAEMON_PROTOCOL_VERSION` remains unchanged.

## How you verified

The new regression failed before the production change with an immediate `(1013, "heartbeat-ack-timeout")` reconnect and passed afterward.

```sh
pnpm exec turbo run test --filter=@bb/host-daemon --force --concurrency=1 -- src/server-connection.test.ts
pnpm exec turbo run typecheck --filter=@bb/host-daemon --force --concurrency=1
pnpm exec turbo run test --filter=@bb/host-daemon --force --concurrency=1
pnpm exec turbo run build --filter=@bb/host-daemon --force --concurrency=1
pnpm exec oxfmt apps/host-daemon/src/server-connection.ts apps/host-daemon/src/server-connection.test.ts --check
```

- Focused current-`main` result: 13 tests passed; 7/7 Turbo tasks successful.
- Host-daemon typecheck: 4/4 Turbo tasks successful.
- Full host-daemon suite: 45 files and 555 tests passed; 7/7 Turbo tasks successful.
- Host-daemon build: 5/5 Turbo tasks successful.

Follow-up to #2358 and #2359.

> AGENT GENERATED
