### PR TITLE
fix(acp): normalize omp command results

### DIFF
--- a/packages/provider-bridge-acp/src/delta-translation.test.ts
+++ b/packages/provider-bridge-acp/src/delta-translation.test.ts
@@ -2019,6 +2019,136 @@ describe("acp delta translation (dialects)", () => {
     return harness;
   }
 
+  function completedDialectCommand(args: {
+    dialectId: string;
+    rawInput: Record<string, unknown>;
+    rawOutput: unknown;
+    status?: "completed" | "failed";
+  }) {
+    const harness = dialectHarness(args.dialectId);
+    harness.translate(
+      updateEvent({
+        sessionUpdate: "tool_call",
+        toolCallId: "call-command",
+        title: "command",
+        kind: "execute",
+        status: "pending",
+        rawInput: args.rawInput,
+      }),
+    );
+    return completedItems(
+      harness.translate(
+        updateEvent({
+          sessionUpdate: "tool_call_update",
+          toolCallId: "call-command",
+          status: args.status ?? "completed",
+          rawOutput: args.rawOutput,
+        }),
+      ),
+    )[0];
+  }
+
+  it("normalizes omp foreground command output and successful completion", () => {
+    expect(
+      completedDialectCommand({
+        dialectId: "omp",
+        rawInput: { command: "echo ok" },
+        rawOutput: {
+          content: [{ type: "text", text: "ok\n\nWall time: 0.25 seconds" }],
+          details: { timeoutSeconds: 10, wallTimeMs: 250 },
+        },
+      }),
+    ).toMatchObject({
+      type: "commandExecution",
+      command: "echo ok",
+      status: "completed",
+      exitCode: 0,
+      aggregatedOutput: "ok",
+    });
+  });
+
+  it.each([
+    {
+      label: "explicit",
+      rawInput: { command: "sleep 10", async: true },
+      details: { wallTimeMs: 250 },
+    },
+    {
+      label: "automatic",
+      rawInput: { command: "sleep 10" },
+      details: { async: { state: "running" }, wallTimeMs: 250 },
+    },
+  ])(
+    "leaves a completed omp $label background launch without exit zero",
+    (sample) => {
+      const item = completedDialectCommand({
+        dialectId: "omp",
+        rawInput: sample.rawInput,
+        rawOutput: {
+          content: [{ type: "text", text: "Command running in background" }],
+          details: sample.details,
+        },
+      });
+      expect(item).toMatchObject({
+        type: "commandExecution",
+        status: "completed",
+        aggregatedOutput: "Command running in background",
+      });
+      expect(item).not.toHaveProperty("exitCode");
+    },
+  );
+
+  it("preserves omp timeout failure semantics", () => {
+    const output =
+      "partial\n\nWall time: 1.00 seconds\n\n[Command timed out after 1 seconds]";
+    expect(
+      completedDialectCommand({
+        dialectId: "omp",
+        rawInput: { command: "sleep 10" },
+        rawOutput: {
+          content: [{ type: "text", text: output }],
+          details: { timedOut: true, wallTimeMs: 1_000 },
+        },
+        status: "failed",
+      }),
+    ).toMatchObject({
+      status: "failed",
+      exitCode: 1,
+      aggregatedOutput: output,
+    });
+  });
+
+  it("preserves shared ACP semantics inside and outside the omp dialect", () => {
+    expect(
+      completedDialectCommand({
+        dialectId: "omp",
+        rawInput: { command: "sleep 10" },
+        rawOutput: {
+          exit_code: 124,
+          output_for_prompt: "exit: 124\n",
+          signal: "SIGKILL",
+          timed_out: true,
+        },
+        status: "failed",
+      }),
+    ).toMatchObject({
+      exitCode: 124,
+      aggregatedOutput: "exit: 124\n[timed out] [signal SIGKILL]",
+    });
+
+    const decoratedOutput = "ok\n\nWall time: 0.25 seconds";
+    const generic = completedDialectCommand({
+      dialectId: "unknown",
+      rawInput: { command: "echo ok" },
+      rawOutput: {
+        content: [{ type: "text", text: decoratedOutput }],
+        details: { wallTimeMs: 250 },
+      },
+    });
+    expect(generic).toMatchObject({ aggregatedOutput: decoratedOutput });
+    expect(generic).not.toHaveProperty("exitCode");
+  });
+
   it("opens a Cursor task call as a delegation and takes the report's detail", () => {
     const harness = dialectHarness("cursor");
     const opened = harness.translate(

--- a/packages/provider-bridge-acp/src/delta-translation.ts
+++ b/packages/provider-bridge-acp/src/delta-translation.ts
@@ -579,7 +579,8 @@ export function createAcpDeltaTranslator(
     Extract<ThreadDelta, { kind: "item.close" }>,
     "aggregatedOutput" | "exitCode" | "resultText"
   > {
-    const result = extractAcpCommandResult(event);
+    const result =
+      dialect.commandResult?.(event) ?? extractAcpCommandResult(event);
     const exitCode = result.exitCode ?? (status === "failed" ? 1 : undefined);
     return {
       ...(result.output === undefined

--- a/packages/provider-bridge-acp/src/dialect.test.ts
+++ b/packages/provider-bridge-acp/src/dialect.test.ts
@@ -3,6 +3,7 @@ import {
   CURSOR_ACP_DIALECT,
   GENERIC_ACP_DIALECT,
   GROK_ACP_DIALECT,
+  OMP_ACP_DIALECT,
   resolveAcpDialect,
 } from "./dialect.js";
 import type { AcpToolCallUpdateEvent } from "./wire.js";
@@ -28,6 +29,9 @@ describe("resolveAcpDialect", () => {
     expect(resolveAcpDialect({ command: "cursor-agent" })).toBe(
       CURSOR_ACP_DIALECT,
     );
+    expect(resolveAcpDialect({ command: "/opt/homebrew/bin/omp" })).toBe(
+      OMP_ACP_DIALECT,
+    );
   });
 
   it("is generic for a dialect id it does not ship", () => {
@@ -43,6 +47,7 @@ describe("resolveAcpDialect", () => {
     expect(dialect).toBe(GENERIC_ACP_DIALECT);
     expect(dialect.toolIdentity).toBeUndefined();
     expect(dialect.classifyToolCall).toBeUndefined();
+    expect(dialect.commandResult).toBeUndefined();
     expect(dialect.handleClientRequest).toBeUndefined();
   });
 });
@@ -53,6 +58,115 @@ const toolCall = (fields: Partial<AcpToolCallUpdateEvent>) =>
     toolCallId: "call-1",
     ...fields,
   }) as AcpToolCallUpdateEvent;
+
+describe("omp command results", () => {
+  const result = (fields: Partial<AcpToolCallUpdateEvent>) =>
+    OMP_ACP_DIALECT.commandResult?.(
+      toolCall({
+        kind: "execute",
+        status: "completed",
+        rawInput: { command: "command" },
+        ...fields,
+      }),
+    );
+
+  it("preserves omp's reported non-zero exit code", () => {
+    expect(
+      result({
+        status: "failed",
+        rawOutput: {
+          content: [
+            {
+              type: "text",
+              text: "bad\n\nWall time: 0.50 seconds\n\nCommand exited with code 7",
+            },
+          ],
+          details: { exitCode: 7, wallTimeMs: 500 },
+        },
+      }),
+    ).toEqual({ exitCode: 7, output: "bad" });
+  });
+
+  it("does not remove suffix text that its structured details do not prove", () => {
+    const output =
+      "literal\n\nWall time: 1.24 seconds\n\nCommand exited with code 8";
+    expect(
+      result({
+        status: "failed",
+        rawOutput: {
+          content: [{ type: "text", text: output }],
+          details: { exitCode: 7, wallTimeMs: 1_250 },
+        },
+      }),
+    ).toEqual({ exitCode: 7, output });
+  });
+
+  it("does not infer zero for a timeout or signal", () => {
+    expect(
+      result({
+        status: "failed",
+        rawOutput: {
+          content: [
+            {
+              type: "text",
+              text: "partial\n\nWall time: 1.00 seconds\n\n[Command timed out after 1 seconds]",
+            },
+          ],
+          details: { timedOut: true, wallTimeMs: 1_000 },
+        },
+      }),
+    ).toEqual({
+      output:
+        "partial\n\nWall time: 1.00 seconds\n\n[Command timed out after 1 seconds]",
+    });
+
+    expect(
+      result({
+        rawOutput: {
+          content: [
+            { type: "text", text: "killed\n\nWall time: 0.25 seconds" },
+          ],
+          details: { signal: "SIGTERM", wallTimeMs: 250 },
+        },
+      }),
+    ).toEqual({ output: "killed" });
+  });
+
+  it.each<Partial<AcpToolCallUpdateEvent>>([
+    {
+      kind: "other",
+      rawOutput: {
+        content: [{ type: "text", text: "hello\n\nWall time: 0.25 seconds" }],
+        details: { wallTimeMs: 250 },
+      },
+    },
+    {
+      rawInput: { cells: [{ code: "1 + 1" }] },
+      rawOutput: {
+        content: [{ type: "text", text: "2\n\nWall time: 0.25 seconds" }],
+        details: { wallTimeMs: 250 },
+      },
+    },
+    {
+      rawOutput: {
+        content: [{ type: "text", text: "hello" }],
+        details: { timeoutSeconds: 10 },
+      },
+    },
+    {
+      rawOutput: {
+        content: [{ type: "text", text: "hello\n\nWall time: 0.25 seconds" }],
+        details: { wallTimeMs: 250 },
+        exit_code: 9,
+      },
+    },
+  ])(
+    "leaves a result without the foreground Bash proof to generic ACP",
+    (fields) => {
+      expect(result(fields)).toBeUndefined();
+    },
+  );
+});
 
 describe("grok sub-agents", () => {
   // Version 1 of the protocol has no sub-agent concept, so only the dialect

--- a/packages/provider-bridge-acp/src/dialect.ts
+++ b/packages/provider-bridge-acp/src/dialect.ts
@@ -26,7 +26,10 @@ import {
   type AcpMaintenanceDialect,
 } from "./bridge/provider-maintenance.js";
 import { delegationPresentation } from "./presentation.js";
-import type { AcpClassifiedToolCall } from "./tool-classification.js";
+import type {
+  AcpClassifiedToolCall,
+  AcpCommandResult,
+} from "./tool-classification.js";
 import {
   acpToolKindSchema,
   type AcpToolCallUpdateEvent,
@@ -74,6 +77,11 @@ export interface AcpDialect {
   classifyToolCall?(
     event: AcpToolCallUpdateEvent,
   ): AcpClassifiedToolCall | undefined;
+  /**
+   * A command result carried in the agent's non-standard rawOutput shape.
+   * Returning `undefined` leaves the shared ACP result parser in charge.
+   */
+  commandResult?(event: AcpToolCallUpdateEvent): AcpCommandResult | undefined;
   /**
    * A vendor JSON-RPC request the agent sends to the client. A dialect that
    * answers one returns the JSON-RPC result to reply with (`{}` is a valid
@@ -280,6 +288,127 @@ export const CURSOR_ACP_DIALECT: AcpDialect = {
 };
 
 // ---------------------------------------------------------------------------
+// omp (`omp acp`)
+// ---------------------------------------------------------------------------
+
+/**
+ * omp forwards its Bash AgentToolResult as rawOutput. Foreground successes
+ * omit `details.exitCode`, while failures carry the non-zero value. The text
+ * block includes renderer notices derived from those details. Background
+ * launches also close as completed, so both of omp's async markers must keep
+ * them out of foreground result normalization.
+ */
+const ompBashRawInputSchema = z
+  .object({
+    command: z.string(),
+    async: z.boolean().optional(),
+  })
+  .passthrough();
+
+const ompBashRawOutputSchema = z
+  .object({
+    content: z.array(
+      z
+        .object({
+          type: z.literal("text"),
+          text: z.string(),
+        })
+        .passthrough(),
+    ),
+    details: z
+      .object({
+        exitCode: z.number().int().optional(),
+        wallTimeMs: z.number().nonnegative().optional(),
+        timedOut: z.boolean().optional(),
+        signal: z.unknown().optional(),
+        async: z.unknown().optional(),
+      })
+      .passthrough(),
+    // If an OMP version emits generic ACP result fields, the shared parser
+    // owns those exit/output/timeout/signal semantics.
+    exitCode: z.number().int().nullable().optional(),
+    exit_code: z.number().int().nullable().optional(),
+    stdout: z.string().optional(),
+    stderr: z.string().optional(),
+    output_for_prompt: z.string().optional(),
+    signal: z.string().nullable().optional(),
+    timed_out: z.boolean().optional(),
+  })
+  .passthrough();
+
+function stripOmpTrailingNotice(text: string, notice: string): string {
+  const suffix = `\n\n${notice}`;
+  return text.endsWith(suffix) ? text.slice(0, -suffix.length) : text;
+}
+
+function ompCommandResult(
+  event: AcpToolCallUpdateEvent,
+): AcpCommandResult | undefined {
+  if (event.kind !== "execute") {
+    return undefined;
+  }
+  const parsedInput = ompBashRawInputSchema.safeParse(event.rawInput);
+  const parsedOutput = ompBashRawOutputSchema.safeParse(event.rawOutput);
+  if (
+    !parsedInput.success ||
+    parsedInput.data.command.trim().length === 0 ||
+    !parsedOutput.success
+  ) {
+    return undefined;
+  }
+  const rawOutput = parsedOutput.data;
+  const details = rawOutput.details;
+  const hasGenericCommandResult =
+    rawOutput.exitCode !== undefined ||
+    rawOutput.exit_code !== undefined ||
+    rawOutput.stdout !== undefined ||
+    rawOutput.stderr !== undefined ||
+    rawOutput.output_for_prompt !== undefined ||
+    (rawOutput.signal !== undefined && rawOutput.signal !== null) ||
+    rawOutput.timed_out === true;
+  if (
+    parsedInput.data.async === true ||
+    details.async !== undefined ||
+    hasGenericCommandResult
+  ) {
+    return undefined;
+  }
+  if (details.exitCode === undefined && details.wallTimeMs === undefined) {
+    return undefined;
+  }
+
+  let output = rawOutput.content.map((block) => block.text).join("\n");
+  if (details.exitCode !== undefined) {
+    output = stripOmpTrailingNotice(
+      output,
+      `Command exited with code ${String(details.exitCode)}`,
+    );
+  }
+  if (details.wallTimeMs !== undefined) {
+    output = stripOmpTrailingNotice(
+      output,
+      `Wall time: ${(details.wallTimeMs / 1_000).toFixed(2)} seconds`,
+    );
+  }
+
+  const isCompletedForegroundBash =
+    event.status === "completed" &&
+    details.timedOut !== true &&
+    (details.signal === undefined || details.signal === null);
+  const exitCode =
+    details.exitCode ?? (isCompletedForegroundBash ? 0 : undefined);
+  return {
+    ...(exitCode === undefined ? {} : { exitCode }),
+    ...(output.length === 0 ? {} : { output }),
+  };
+}
+
+export const OMP_ACP_DIALECT: AcpDialect = {
+  id: "omp",
+  commandResult: ompCommandResult,
+};
+
+// ---------------------------------------------------------------------------
 // Selection
 // ---------------------------------------------------------------------------
 
@@ -291,12 +420,14 @@ export const CURSOR_ACP_DIALECT: AcpDialect = {
 const DIALECTS_BY_ID: ReadonlyMap<string, AcpDialect> = new Map([
   [CURSOR_ACP_DIALECT.id, CURSOR_ACP_DIALECT],
   [GROK_ACP_DIALECT.id, GROK_ACP_DIALECT],
+  [OMP_ACP_DIALECT.id, OMP_ACP_DIALECT],
 ]);
 
 /** The executable name each dialect's agent is normally launched as. */
 const DIALECT_IDS_BY_COMMAND: Readonly<Record<string, string>> = {
   "cursor-agent": CURSOR_ACP_DIALECT.id,
   grok: GROK_ACP_DIALECT.id,
+  omp: OMP_ACP_DIALECT.id,
 };
 
 /**


### PR DESCRIPTION
## What was wrong

OMP forwards Bash renderer output through its ACP `rawOutput`, including wall-time and nonzero-exit notices. Successful foreground Bash results omit an explicit zero exit code, while completed background launches use the same ACP status. The shared ACP parser intentionally cannot infer success from `completed`, so OMP command rows retained renderer decorations and showed unknown success.

## What changed

Added an OMP-specific ACP dialect command-result hook. It recognizes only structured OMP Bash results, removes exact trailing notices reconstructed from `details`, preserves reported nonzero codes, and infers zero only for completed synchronous foreground calls. Explicit `rawInput.async` and automatic `details.async` launches bypass normalization, as do generic timeout, signal, stream, and exit result shapes. Generic ACP behavior and the host-daemon protocol are unchanged.

Added focused dialect and end-to-end delta regressions for successful and failed commands, mismatched suffixes, both background-launch forms, timeout and signal handling, insufficient Bash proof, hybrid generic results, and non-OMP agents.

## How you verified

- `pnpm exec turbo run test --filter=@bb/provider-bridge-acp --force` — 17 files and 267 tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/provider-bridge-acp --force` — passed.
- `git diff --check` — passed before commit.

Fixes: no issue filed; found by provider timeline QA.

> AGENT GENERATED