### PR TITLE
Avoid duplicate steers in expanded turn details

### DIFF
--- a/apps/server/test/services/threads/timeline-in-turn-window.test.ts
+++ b/apps/server/test/services/threads/timeline-in-turn-window.test.ts
@@ -519,6 +519,187 @@ function walkAllPages(
 }
 
 describe("in-turn timeline windows", () => {
+  it("keeps an accepted steer out of details for work that spans the steer", () => {
+    const { db, thread } = setup();
+    const initialRequestId = requestId(1);
+    const steerRequestId = requestId(2);
+    const turnId = "turn-1";
+    const commandId = "command-1";
+
+    insertEvents(db, noopNotifier, [
+      {
+        threadId: thread.id,
+        sequence: 1,
+        type: "client/turn/requested",
+        scope: threadScope(),
+        itemId: null,
+        itemKind: null,
+        parentToolCallId: null,
+        data: JSON.stringify({
+          direction: "outbound",
+          source: "tell",
+          initiator: "user",
+          request: { method: "turn/start", params: {} },
+          requestId: initialRequestId,
+          senderThreadId: null,
+          input: [{ type: "text", text: "Run the command", mentions: [] }],
+          target: { kind: "thread-start" },
+          execution,
+        }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 2,
+        type: "turn/started",
+        scope: turnScope(turnId),
+        providerThreadId,
+        itemId: null,
+        itemKind: null,
+        parentToolCallId: null,
+        data: JSON.stringify({}),
+      },
+      {
+        threadId: thread.id,
+        sequence: 3,
+        type: "turn/input/accepted",
+        scope: turnScope(turnId),
+        providerThreadId,
+        itemId: null,
+        itemKind: null,
+        parentToolCallId: null,
+        data: JSON.stringify({ clientRequestId: initialRequestId }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 4,
+        type: "item/started",
+        scope: turnScope(turnId),
+        providerThreadId,
+        itemId: commandId,
+        itemKind: "commandExecution",
+        parentToolCallId: null,
+        data: JSON.stringify({
+          item: {
+            type: "commandExecution",
+            id: commandId,
+            command: "sleep 20",
+            cwd: "/tmp/test",
+            status: "pending",
+            approvalStatus: null,
+          },
+        }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 5,
+        type: "client/turn/requested",
+        scope: threadScope(),
+        itemId: null,
+        itemKind: null,
+        parentToolCallId: null,
+        data: JSON.stringify({
+          direction: "outbound",
+          source: "tell",
+          initiator: "user",
+          request: { method: "turn/start", params: {} },
+          requestId: steerRequestId,
+          senderThreadId: null,
+          input: [
+            {
+              type: "text",
+              text: "Stop waiting and answer immediately.",
+              mentions: [],
+            },
+          ],
+          target: { kind: "steer", expectedTurnId: turnId },
+          execution,
+        }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 6,
+        type: "turn/input/accepted",
+        scope: turnScope(turnId),
+        providerThreadId,
+        itemId: null,
+        itemKind: null,
+        parentToolCallId: null,
+        data: JSON.stringify({ clientRequestId: steerRequestId }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 7,
+        type: "item/completed",
+        scope: turnScope(turnId),
+        providerThreadId,
+        itemId: commandId,
+        itemKind: "commandExecution",
+        parentToolCallId: null,
+        data: JSON.stringify({
+          item: {
+            type: "commandExecution",
+            id: commandId,
+            command: "sleep 20",
+            cwd: "/tmp/test",
+            status: "completed",
+            approvalStatus: null,
+            exitCode: 0,
+            aggregatedOutput: "",
+          },
+        }),
+      },
+      {
+        threadId: thread.id,
+        sequence: 8,
+        type: "turn/completed",
+        scope: turnScope(turnId),
+        providerThreadId,
+        itemId: null,
+        itemKind: null,
+        parentToolCallId: null,
+        data: JSON.stringify({ status: "completed", providerThreadId }),
+      },
+    ]);
+
+    const timeline = buildPage(db, thread, LARGE_BUDGET, null).response;
+    const turnRow = timeline.rows.find(
+      (row): row is Extract<TimelineRow, { kind: "turn" }> =>
+        row.kind === "turn",
+    );
+    expect(turnRow).toBeDefined();
+    if (!turnRow) {
+      throw new Error("expected a turn row");
+    }
+    expect(
+      timeline.rows.filter(
+        (row) =>
+          row.kind === "conversation" &&
+          row.role === "user" &&
+          row.turnRequest?.kind === "steer",
+      ),
+    ).toHaveLength(1);
+
+    const details = buildTimelineTurnSummaryDetails(db, thread, {
+      includeProviderUnhandledOperations: false,
+      sourceSeqEnd: turnRow.sourceSeqEnd,
+      sourceSeqStart: turnRow.sourceSeqStart,
+      turnId: turnRow.turnId,
+    });
+    expect(
+      details.rows.filter(
+        (row) =>
+          row.kind === "conversation" &&
+          row.role === "user" &&
+          row.turnRequest?.kind === "steer",
+      ),
+    ).toEqual([]);
+    expect(
+      details.rows.filter(
+        (row) => row.kind === "work" && row.workKind === "command",
+      ),
+    ).toHaveLength(1);
+  });
+
   it("bounds a running turn that is larger than the whole budget", () => {
     const { db, thread } = setup();
     // One 300-item turn still running: no user message inside it to cut on.

--- a/packages/thread-view/src/build-thread-timeline.ts
+++ b/packages/thread-view/src/build-thread-timeline.ts
@@ -1281,6 +1281,16 @@ function hasTurnSummaryRows(rows: TimelineRow[]): boolean {
   return rows.some((row) => row.kind === "turn");
 }
 
+function isAcceptedHumanSteerRow(row: TimelineRow): boolean {
+  return (
+    row.kind === "conversation" &&
+    row.role === "user" &&
+    row.initiator === "user" &&
+    row.turnRequest?.kind === "steer" &&
+    row.turnRequest.status === "accepted"
+  );
+}
+
 function collectExternalUserBoundarySeqs(
   projection: EventProjection,
 ): number[] {
@@ -1476,6 +1486,12 @@ export function buildThreadTimelineTurnDetailsFromEvents(
 
   return {
     kind: "ungrouped",
-    rows: nestedRows,
+    // A work item can begin before a steer and complete after it, so the
+    // summary's source range necessarily overlaps the steer. Lazy details do
+    // not include the later turn/completed event and therefore project that
+    // slice as ungrouped rows. Accepted human steers belong to the root
+    // timeline, just as they do when children are built eagerly; returning one
+    // here would render the same row both inside and outside the summary.
+    rows: nestedRows.filter((row) => !isAcceptedHumanSteerRow(row)),
   };
 }


### PR DESCRIPTION
## What was wrong

When a long-running work item began before a human steer and completed after it, the collapsed turn summary's source range necessarily overlapped the steer. Lazy summary hydration does not include the later `turn/completed` event, so it fell back to an ungrouped projection that returned the accepted steer even though the root timeline already rendered the same row.

## What changed

Filter accepted human steer rows from the lazy ungrouped turn-detail fallback, matching the existing eager-child behavior and leaving agent- and system-initiated in-turn input untouched. Added an integration regression that seeds a command spanning an accepted steer and verifies the steer appears once at the root and not in the expanded details. There are no wire, protocol, CLI, or documentation changes.

## How you verified

- Added a regression that failed before the fix and passes after it.
- `pnpm exec turbo run test --filter=@bb/server -- --run test/services/threads/timeline-in-turn-window.test.ts` (25 passed)
- `pnpm exec turbo run test --filter=@bb/thread-view --force` (368 passed)
- `pnpm exec turbo run typecheck --filter=@bb/thread-view --filter=@bb/server`
- `pnpm exec turbo run test --filter=@bb/server --force` (2,017 passed)
- `git diff --check`

Fixes # — no linked issue.

> AGENT GENERATED
