### PR TITLE
Preserve stale sends by re-steering the live turn

### DIFF
--- a/apps/host-daemon/src/command-handlers/thread.ts
+++ b/apps/host-daemon/src/command-handlers/thread.ts
@@ -29,6 +29,7 @@ type ExistingThreadRuntimeCommand =
 // catch up. If it is still pending after that bound, fail closed rather than
 // launch a competing turn.
 const TURN_SUBMIT_ACTIVE_TURN_WAIT_MS = 5_000;
+const TURN_SUBMIT_STEER_ATTEMPTS = 2;
 
 interface ResumeThreadRuntimeIfMissingArgs {
   command: ExistingThreadRuntimeCommand;
@@ -379,54 +380,51 @@ async function steerSubmittedTurn(
   entry: RuntimeEntry,
   expectedTurnId: string,
 ): Promise<HostDaemonCommandResult<"turn.submit">> {
-  const result = await entry.runtime.steerTurn({
-    threadId: command.threadId,
-    expectedTurnId,
-    input: command.input,
-    ...(command.inputGroups !== undefined
-      ? { inputGroups: command.inputGroups }
-      : {}),
-    clientRequestId: command.requestId,
-    options: command.options,
-    instructions: command.resumeContext.instructions,
-  });
+  let targetTurnId = expectedTurnId;
+  let activeTurnId: string | null = null;
+  for (let attempt = 0; attempt < TURN_SUBMIT_STEER_ATTEMPTS; attempt += 1) {
+    const result = await entry.runtime.steerTurn({
+      threadId: command.threadId,
+      expectedTurnId: targetTurnId,
+      input: command.input,
+      ...(command.inputGroups !== undefined
+        ? { inputGroups: command.inputGroups }
+        : {}),
+      clientRequestId: command.requestId,
+      options: command.options,
+      instructions: command.resumeContext.instructions,
+    });
 
-  if (result.status === "steered") {
-    return { appliedAs: "steer" };
-  }
-  // A stale steer still represents a user send intent. If the target turn
-  // ended before dispatch reached the daemon, preserve the message as a new turn.
-  if (command.target.mode === "auto" || command.target.mode === "steer") {
-    return runSubmittedTurn(command, entry);
+    if (result.status === "steered") {
+      return { appliedAs: "steer" };
+    }
+    activeTurnId = result.activeTurnId;
+    if (attempt === TURN_SUBMIT_STEER_ATTEMPTS - 1) {
+      break;
+    }
+    const liveTurnId = await resolveLiveSubmittedTurnTarget(command, entry);
+    if (liveTurnId === null) {
+      return runSubmittedTurn(command, entry);
+    }
+    if (liveTurnId === targetTurnId) {
+      break;
+    }
+    targetTurnId = liveTurnId;
   }
 
   throw new CommandDispatchError(
     "stale_turn",
-    `Expected active turn ${expectedTurnId} for thread ${command.threadId}, but active turn is ${result.activeTurnId ?? "none"}`,
+    `Expected active turn ${targetTurnId} for thread ${command.threadId}, but active turn is ${activeTurnId ?? "none"}`,
   );
 }
 
-async function resolveSubmittedTurnTarget(
+async function resolveLiveSubmittedTurnTarget(
   command: TurnSubmitCommand,
   entry: RuntimeEntry,
 ): Promise<string | null> {
-  if (command.target.mode === "start") {
-    return null;
-  }
-  // Explicit steer preserves its vouched target. Auto mode intentionally
-  // rebases onto the daemon's live turn when the server snapshot is stale.
-  if (
-    command.target.mode === "steer" &&
-    command.target.expectedTurnId !== null
-  ) {
-    return command.target.expectedTurnId;
-  }
   const activeTurnId = entry.runtime.getActiveTurnId(command.threadId);
   if (activeTurnId !== null) {
     return activeTurnId;
-  }
-  if (command.target.expectedTurnId !== null) {
-    return command.target.expectedTurnId;
   }
   // With no active id, a live thread means the runtime has accepted a start
   // whose turn/started event is still pending. If that prior turn already
@@ -455,6 +453,27 @@ async function resolveSubmittedTurnTarget(
     );
   }
   return null;
+}
+
+async function resolveSubmittedTurnTarget(
+  command: TurnSubmitCommand,
+  entry: RuntimeEntry,
+): Promise<string | null> {
+  if (command.target.mode === "start") {
+    return null;
+  }
+  // Explicit steer gets one attempt at its vouched target. Auto mode starts
+  // from the daemon's live state, including a turn that is still opening.
+  if (
+    command.target.mode === "steer" &&
+    command.target.expectedTurnId !== null
+  ) {
+    return command.target.expectedTurnId;
+  }
+  return (
+    (await resolveLiveSubmittedTurnTarget(command, entry)) ??
+    command.target.expectedTurnId
+  );
 }
 
 export async function submitTurn(

--- a/apps/host-daemon/test/command/thread-dispatch.test.ts
+++ b/apps/host-daemon/test/command/thread-dispatch.test.ts
@@ -1763,23 +1763,24 @@ describe("thread command dispatch", () => {
     ]);
   });
 
-  it("falls back to a new turn when auto turn.submit sees a stale turn", async () => {
+  it("re-steers the newer active turn when auto turn.submit sees a stale target", async () => {
     const harness = createHarness();
     const requestId = nextClientRequestId();
+    const steeredTurnIds: string[] = [];
     await harness.manager.ensureEnvironment({
       environmentId: "env-1",
       workspacePath: "/tmp/env-1",
     });
-    harness.threadControls.setProviderSession("thread-1", {
-      providerId: "fake",
-      providerThreadId: "provider-1",
-    });
+    harness.threadControls.setActiveTurn("thread-1", "turn-old");
     harness.runtime.steerTurn = async (args) => {
-      harness.runtimeState.steeredTurnId = args.expectedTurnId;
-      harness.runtimeState.steeredClientRequestId = args.clientRequestId;
+      steeredTurnIds.push(args.expectedTurnId);
+      if (args.expectedTurnId === "turn-new") {
+        return { status: "steered" };
+      }
+      harness.threadControls.setActiveTurn("thread-1", "turn-new");
       return {
         status: "stale",
-        activeTurnId: null,
+        activeTurnId: "turn-new",
       };
     };
 
@@ -1790,7 +1791,7 @@ describe("thread command dispatch", () => {
         environmentId: "env-1",
         threadId: "thread-1",
         requestId,
-        input: [textPromptInput("send anyway")],
+        input: [textPromptInput("adjust the newer turn")],
         options: {
           model: "gpt-5",
           serviceTier: "default",
@@ -1820,11 +1821,86 @@ describe("thread command dispatch", () => {
       harness.dispatchOptions(),
     );
 
-    expect(result).toEqual({ appliedAs: "new-turn" });
-    expect(harness.runtimeState.steeredTurnId).toBe("turn-old");
-    expect(harness.runtimeState.steeredClientRequestId).toBe(requestId);
-    expect(harness.runtimeState.ranTurnText).toBe("send anyway");
-    expect(harness.runtimeState.ranTurnClientRequestId).toBe(requestId);
+    expect(result).toEqual({ appliedAs: "steer" });
+    expect(steeredTurnIds).toEqual(["turn-old", "turn-new"]);
+    expect(harness.runtimeState.ranTurnClientRequestId).toBeUndefined();
+  });
+
+  it("waits for a newer starting turn and re-steers it after a stale target", async () => {
+    const harness = createHarness();
+    const requestId = nextClientRequestId();
+    const steeredTurnIds: string[] = [];
+    let activeTurnId: string | null = "turn-old";
+    let pendingTurnStart = false;
+    let waitCalls = 0;
+    await harness.manager.ensureEnvironment({
+      environmentId: "env-1",
+      workspacePath: "/tmp/env-1",
+    });
+    harness.threadControls.setProviderSession("thread-1", {
+      providerId: "fake",
+      providerThreadId: "provider-1",
+    });
+    harness.runtime.getActiveTurnId = () => activeTurnId;
+    harness.runtime.getLiveThreadIds = () =>
+      activeTurnId !== null || pendingTurnStart ? ["thread-1"] : [];
+    harness.runtime.waitForActiveTurn = async () => {
+      waitCalls += 1;
+      pendingTurnStart = false;
+      activeTurnId = "turn-new";
+      return activeTurnId;
+    };
+    harness.runtime.steerTurn = async (args) => {
+      steeredTurnIds.push(args.expectedTurnId);
+      if (args.expectedTurnId === "turn-new") {
+        return { status: "steered" };
+      }
+      activeTurnId = null;
+      pendingTurnStart = true;
+      return { status: "stale", activeTurnId: null };
+    };
+
+    const result = await dispatchCommand(
+      {
+        bridgeLaunch: DISPATCH_TEST_BRIDGE_LAUNCH,
+        type: "turn.submit",
+        environmentId: "env-1",
+        threadId: "thread-1",
+        requestId,
+        input: [textPromptInput("adjust once the turn starts")],
+        options: {
+          model: "gpt-5",
+          serviceTier: "default",
+          reasoningLevel: "medium",
+          providerOptions: {},
+          permissionMode: "full",
+          permissionScope: "full",
+          approvalReviewer: null,
+          permissionEscalation: null,
+        },
+        resumeContext: {
+          bridgeLaunch: DISPATCH_TEST_BRIDGE_LAUNCH,
+          workspaceContext: {
+            workspacePath: "/tmp/env-1",
+            workspaceProvisionType: "unmanaged",
+          },
+          projectId: "project-1",
+          providerId: "fake",
+          providerThreadId: "provider-1",
+          instructions: "Be a helpful coding agent.",
+          dynamicTools: [],
+          injectedSkillSources: [],
+          instructionMode: "append",
+        },
+        target: { mode: "steer", expectedTurnId: "turn-old" },
+      },
+      harness.dispatchOptions(),
+    );
+
+    expect(result).toEqual({ appliedAs: "steer" });
+    expect(steeredTurnIds).toEqual(["turn-old", "turn-new"]);
+    expect(waitCalls).toBe(1);
+    expect(harness.runtimeState.ranTurnClientRequestId).toBeUndefined();
   });
 
   it("falls back to a new turn when explicit steer sees a stale turn", async () => {

--- a/packages/agent-runtime/src/runtime.lifecycle.test.ts
+++ b/packages/agent-runtime/src/runtime.lifecycle.test.ts
@@ -420,7 +420,10 @@ describe("createAgentRuntime lifecycle", () => {
           permissionEscalation: "ask",
           // The plugin-derived bag rides the command as-is; only the owning
           // bridge reads its keys.
-          providerOptions: { memoryEnabled: true, providerSubagentsEnabled: true },
+          providerOptions: {
+            memoryEnabled: true,
+            providerSubagentsEnabled: true,
+          },
         },
       });
 
@@ -943,11 +946,13 @@ describe("createAgentRuntime lifecycle", () => {
       await runtime.shutdown();
     });
 
-    it("resolves waitForActiveTurn from the turn/started observation", async () => {
+    it("resolves waitForActiveTurn and rejects a competing start while active", async () => {
       const events: ThreadEvent[] = [];
+      const record = createScriptedEchoRequestRecord();
       const runtime = createScriptedEchoRuntime({
         runtime: {
           workspacePath: tmpDir,
+          env: record.env,
           onEvent: (event) => events.push(event),
         },
       });
@@ -980,13 +985,26 @@ describe("createAgentRuntime lifecycle", () => {
       await expect(pendingTurnId).resolves.toBe(turnId);
       expect(runtime.getActiveTurnId("t1")).toBe(turnId);
       expect(runtime.getLiveThreadIds()).toEqual(["t1"]);
+      await expect(
+        runtime.runTurn({
+          clientRequestId: "creq_222222224a",
+          threadId: "t1",
+          input: [promptTextInput({ text: "competing active turn" })],
+          options: fullRuntimeOptions,
+        }),
+      ).rejects.toThrow(/active or starting/);
+      expect(
+        recordedMethods(record).filter((method) => method === "turn/start"),
+      ).toHaveLength(1);
       await runtime.shutdown();
     });
 
-    it("reports pending work before an accepted turn emits its first event", async () => {
+    it("reports pending work and rejects a competing start before the first event", async () => {
+      const record = createScriptedEchoRequestRecord();
       const runtime = createScriptedEchoRuntime({
         runtime: {
           workspacePath: tmpDir,
+          env: record.env,
           onEvent: () => {},
         },
         // The bridge accepts turn/start and never opens the turn.
@@ -1010,6 +1028,17 @@ describe("createAgentRuntime lifecycle", () => {
 
         expect(runtime.getActiveTurnId("t1")).toBeNull();
         expect(runtime.getLiveThreadIds()).toEqual(["t1"]);
+        await expect(
+          runtime.runTurn({
+            clientRequestId: "creq_222222224b",
+            threadId: "t1",
+            input: [promptTextInput({ text: "competing pending turn" })],
+            options: fullRuntimeOptions,
+          }),
+        ).rejects.toThrow(/active or starting/);
+        expect(
+          recordedMethods(record).filter((method) => method === "turn/start"),
+        ).toHaveLength(1);
       } finally {
         await runtime.shutdown();
       }

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -926,6 +926,17 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
     }
   }
 
+  function assertThreadCanStartTurn(threadId: string): void {
+    if (
+      turnState.getActiveTurnId(threadId) !== null ||
+      pendingTurnStarts.has(threadId)
+    ) {
+      throw new Error(
+        `Refusing to start a competing turn for thread "${threadId}" while another turn is active or starting`,
+      );
+    }
+  }
+
   function recordProviderThreadIdentity(
     proc: ProviderProcess,
     threadId: string,
@@ -2133,6 +2144,7 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
         work: async () => {
           const pid = threadIdentityRegistry.resolveProviderForThread(threadId);
           requireProviderProcessForThread(threadId);
+          assertThreadCanStartTurn(threadId);
           await restartThreadBridgeIfRecommended({
             threadId,
             options: execOpts,
@@ -2169,6 +2181,7 @@ export function createAgentRuntime(options: AgentRuntimeOptions): AgentRuntime {
             plan: proc.adapter.buildCommandPlan(adapterCommand),
             providerId: pid,
           });
+          assertThreadCanStartTurn(threadId);
           pendingTurnStarts.set(threadId, {
             sinceMs: Date.now(),
             watchdogFired: false,

--- a/packages/host-daemon-contract/src/protocol.ts
+++ b/packages/host-daemon-contract/src/protocol.ts
@@ -303,9 +303,13 @@
 // websocket and reconnect instead of remaining registered but unable to
 // receive host RPC commands.
 //
+// Version 166 makes turn admission single-owner across the shared runtime and
+// lets turn submission recover a stale target by re-steering the live turn.
+// An old daemon can still start a competing provider turn in that race.
+//
 // The version mismatch is what triggers the enrolled daemon's automatic update
 // instead of an `invalid-message` reconnect loop.
-export const HOST_DAEMON_PROTOCOL_VERSION = 165 as const;
+export const HOST_DAEMON_PROTOCOL_VERSION = 166 as const;
 
 /**
  * Absolute ceiling for any executable artifact delivered to a host daemon —

--- a/packages/host-daemon-contract/test/contract.test.ts
+++ b/packages/host-daemon-contract/test/contract.test.ts
@@ -1039,7 +1039,7 @@ describe("host-daemon command schemas", () => {
   // mixed version. Version 113 carried the Devin Desktop open target rename
   // and remains part of the protocol lineage.
   it("uses the current host-daemon protocol version", () => {
-    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(165);
+    expect(HOST_DAEMON_PROTOCOL_VERSION).toBe(166);
     expect(HOST_ARTIFACT_MAX_BYTES).toBe(256 * 1024 * 1024);
   });
 


### PR DESCRIPTION
## What was wrong

A stale `turn.submit` could fall back to a new turn without re-reading the shared runtime's authoritative active and pending-start state. The runtime also did not enforce that state at new-turn admission, so providers without an equivalent local defense could accept overlapping logical turns; rejecting only at admission fixed safety but turned the ordinary stale-target race into a user-visible resend. This is the residual class-wide case from #2241 and #2242.

## What changed

- Enforce single-turn admission in the shared runtime before provider-session preflight and again immediately before recording a pending start.
- After a stale steer, re-read live runtime state and retry once against a newer active turn.
- Wait up to the existing five-second bound when a newer accepted turn has not published its ID, then steer it; start a new turn only when the thread is genuinely idle.
- Keep recovery bounded and fail closed if the target changes again or the pending start remains unresolved.
- Bump `HOST_DAEMON_PROTOCOL_VERSION` from 165 to 166 for the changed `turn.submit` semantics.

## How you verified

- Focused active-turn and pending-start admission regressions failed before and passed after.
- Focused newer-active-turn and newer-pending-turn daemon regressions failed with `new-turn` before the recovery and passed with `steer` after it.
- `pnpm exec turbo run test --filter=@bb/agent-runtime --filter=@bb/host-daemon --filter=@bb/host-daemon-contract --force` — 318 runtime, 556 daemon, and 51 contract tests passed.
- `pnpm exec turbo run typecheck --filter=@bb/agent-runtime --filter=@bb/host-daemon --filter=@bb/host-daemon-contract --force` — all affected packages and upstream tasks passed.
- `pnpm exec turbo run build --filter=@bb/host-daemon --force` — daemon and upstream builds passed.

Fixes #2241

> AGENT GENERATED
