### PR TITLE
fix(host-daemon): retry provider probes after invalidation

### DIFF
--- a/apps/host-daemon/src/command-dispatch.test.ts
+++ b/apps/host-daemon/src/command-dispatch.test.ts
@@ -1665,6 +1665,42 @@ describe("dispatchCommand", () => {
     expect(runtime.startThread).toHaveBeenCalledTimes(2);
   });
 
+  it("retries concurrent thread starts when a shell env refresh interrupts their shared probe", async () => {
+    const runtime = createRuntime();
+    const manager = new RuntimeManager({
+      createRuntime: () => runtime,
+      provisionWorkspace: async () => createWorkspace(),
+      shellEnv: { PATH: "/old/bin" },
+    });
+    const staleProbe = createDeferredPromise<ProviderCliStatus>();
+    const providerInstallationStatus = vi
+      .fn<() => Promise<ProviderCliStatus>>()
+      .mockReturnValueOnce(staleProbe.promise)
+      .mockResolvedValueOnce(supportedCodexInstallationStatus());
+    const options = makeDispatchOptions({
+      runtimeManager: manager,
+      providerInstallationStatus,
+    });
+
+    const starts = Promise.all([
+      dispatchCommand(createInstallationGatedThreadStart("thread-1"), options),
+      dispatchCommand(createInstallationGatedThreadStart("thread-2"), options),
+    ]);
+    await vi.waitFor(() =>
+      expect(providerInstallationStatus).toHaveBeenCalledOnce(),
+    );
+
+    await manager.replaceBaseShellEnv({ PATH: "/new/bin" });
+    staleProbe.reject(new Error("Runtime shutting down"));
+
+    await expect(starts).resolves.toEqual([
+      { providerThreadId: "provider-thread-1" },
+      { providerThreadId: "provider-thread-1" },
+    ]);
+    expect(providerInstallationStatus).toHaveBeenCalledTimes(2);
+    expect(runtime.startThread).toHaveBeenCalledTimes(2);
+  });
+
   it("does not remember an unsupported installation", async () => {
     const runtime = createRuntime();
     const manager = new RuntimeManager({

--- a/apps/host-daemon/src/provider-installation-gate.test.ts
+++ b/apps/host-daemon/src/provider-installation-gate.test.ts
@@ -161,6 +161,22 @@ describe("createProviderInstallationGate", () => {
     expect(probe).toHaveBeenCalledTimes(2);
   });
 
+  it("retries an in-flight probe that is interrupted by invalidation", async () => {
+    const gate = createProviderInstallationGate({ ttlMs: 1_000, now: () => 0 });
+    const staleProbe = createDeferredPromise<ProviderInstallationStatus>();
+    const probe = vi
+      .fn<() => Promise<ProviderInstallationStatus>>()
+      .mockReturnValueOnce(staleProbe.promise)
+      .mockResolvedValueOnce(status());
+
+    const result = gate.run("codex", probe);
+    gate.clear();
+    staleProbe.reject(new Error("Runtime shutting down"));
+
+    await expect(result).resolves.toEqual(status());
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
   it("probes again once the remembered status expires", async () => {
     let currentTime = 0;
     const gate = createProviderInstallationGate({
@@ -190,7 +206,7 @@ describe("createProviderInstallationGate", () => {
     expect(probe).toHaveBeenCalledTimes(2);
   });
 
-  it("does not store a probe that was in flight when the gate was cleared", async () => {
+  it("replaces a stale in-flight answer after the gate is cleared", async () => {
     const gate = createProviderInstallationGate({ ttlMs: 1_000, now: () => 0 });
     const staleProbe = createDeferredPromise<ProviderInstallationStatus>();
     const probe = vi
@@ -204,7 +220,7 @@ describe("createProviderInstallationGate", () => {
     // arrives after the clear must start its own probe rather than join it.
     const fresh = gate.run("codex", probe);
     staleProbe.resolve(status({ currentVersion: "0.140.0" }));
-    await expect(stale).resolves.toEqual(status({ currentVersion: "0.140.0" }));
+    await expect(stale).resolves.toEqual(status());
     await expect(fresh).resolves.toEqual(status());
     expect(probe).toHaveBeenCalledTimes(2);
 

--- a/apps/host-daemon/src/provider-installation-gate.ts
+++ b/apps/host-daemon/src/provider-installation-gate.ts
@@ -24,12 +24,15 @@ export interface ProviderInstallationGateKeyArgs {
  * Concurrent starts for one key share the in-flight probe, and a supported
  * answer is served from memory until it expires. An unsupported answer and a
  * rejected probe are never stored, so a CLI that is too old is re-probed on
- * every attempt until it passes. A not-installed answer is stored only when
- * the bridge reports no minimum version: a bridge that enforces one (codex,
- * pi) can turn an install that arrives without a PATH change into an
- * unsupported answer, so its "not installed" is re-probed on every attempt;
- * a bridge that enforces none (Claude Code, ACP) can never reject, and its
- * launcher resolves the executable on its own, so re-probing it is pure cost.
+ * every attempt until it passes. Clearing the gate while a probe is in flight
+ * transparently re-runs that probe: callers must not launch against a stale
+ * shell environment or fail because invalidation shut down its maintenance
+ * runtime. A not-installed answer is stored only when the bridge reports no
+ * minimum version: a bridge that enforces one (codex, pi) can turn an install
+ * that arrives without a PATH change into an unsupported answer, so its "not
+ * installed" is re-probed on every attempt; a bridge that enforces none
+ * (Claude Code, ACP) can never reject, and its launcher resolves the executable
+ * on its own, so re-probing it is pure cost.
  */
 export interface ProviderInstallationGate {
   clear(): void;
@@ -81,28 +84,29 @@ export function createProviderInstallationGate({
     }
   }
 
-  return {
-    clear() {
-      generation += 1;
-      settledByKey.clear();
-      pendingByKey.clear();
-    },
-    run(key, probe) {
-      const currentTime = now();
-      const settled = settledByKey.get(key);
-      if (settled !== undefined) {
-        if (settled.expiresAt > currentTime) {
-          return Promise.resolve(settled.status);
-        }
-        settledByKey.delete(key);
+  const run: ProviderInstallationGate["run"] = (key, probe) => {
+    const currentTime = now();
+    const settled = settledByKey.get(key);
+    if (settled !== undefined) {
+      if (settled.expiresAt > currentTime) {
+        return Promise.resolve(settled.status);
       }
-      const pending = pendingByKey.get(key);
-      if (pending !== undefined) {
-        return pending;
-      }
-      const startedGeneration = generation;
-      const started = probe()
-        .then((status) => {
+      settledByKey.delete(key);
+    }
+    const pending = pendingByKey.get(key);
+    if (pending !== undefined) {
+      return pending;
+    }
+    const startedGeneration = generation;
+    const started = probe()
+      .then(
+        (status) => {
+          // This answer describes the provider state from before the shell
+          // environment or installation changed. Join (or start) the probe
+          // for the current generation instead of returning a stale answer.
+          if (startedGeneration !== generation) {
+            return run(key, probe);
+          }
           const settledAt = now();
           // Expired neighbours are swept here rather than on a timer so the
           // map stays bounded without keeping the process alive.
@@ -117,20 +121,37 @@ export function createProviderInstallationGate({
           // not-installed answer is remembered like a supported one.
           if (
             (status.installed || status.minimumSupportedVersion === null) &&
-            !status.versionUnsupported &&
-            startedGeneration === generation
+            !status.versionUnsupported
           ) {
             settledByKey.set(key, { status, expiresAt: settledAt + ttlMs });
           }
           return status;
-        })
-        .finally(() => {
-          if (pendingByKey.get(key) === started) {
-            pendingByKey.delete(key);
+        },
+        (error: unknown) => {
+          // Shell-environment refresh deliberately shuts down the old
+          // maintenance runtime. The generation, rather than the error text,
+          // distinguishes that expected interruption from a real probe error.
+          if (startedGeneration !== generation) {
+            return run(key, probe);
           }
-        });
-      pendingByKey.set(key, started);
-      return started;
+          throw error;
+        },
+      )
+      .finally(() => {
+        if (pendingByKey.get(key) === started) {
+          pendingByKey.delete(key);
+        }
+      });
+    pendingByKey.set(key, started);
+    return started;
+  };
+
+  return {
+    clear() {
+      generation += 1;
+      settledByKey.clear();
+      pendingByKey.clear();
     },
+    run,
   };
 }

--- a/apps/host-daemon/src/runtime-manager.ts
+++ b/apps/host-daemon/src/runtime-manager.ts
@@ -862,7 +862,8 @@ export class RuntimeManager {
   /**
    * Tears down the resident provider-maintenance runtime so the next caller
    * gets a fresh one. In-flight maintenance RPCs fail with "Runtime shutting
-   * down" and are expected to retry; callers refetch after invalidation.
+   * down"; the provider-installation gate transparently re-probes after its
+   * generation changes, while other maintenance callers refetch on demand.
    */
   async invalidateProviderMaintenanceRuntime(): Promise<void> {
     this.providerInstallationGate.clear();


### PR DESCRIPTION
## What was wrong

A shell-environment refresh could clear the provider-installation gate and shut down its maintenance runtime while real thread starts were awaiting a shared provider status probe. The gate correctly avoided caching the stale result, but it still returned the interrupted promise to existing callers, so every concurrent `thread.start` sharing that probe became a permanent error thread. See #2380 and the [investigation thread](https://ymichael.getbb.app/threads/thr_piqfifpsii).

## What changed

The provider-installation gate now treats a generation change as an instruction to join or start the probe for the current generation. This applies to both stale successful answers and rejected maintenance RPCs, while stable provider errors and unsupported-version results retain their existing behavior. Added focused gate coverage plus a command-dispatch regression with two concurrent thread starts interrupted by `replaceBaseShellEnv`.

There are no host/server wire changes, so `HOST_DAEMON_PROTOCOL_VERSION` is unchanged.

## How you verified

- Added a deterministic concurrent-start regression that rejected with `Runtime shutting down` before the fix and passes after it.
- `pnpm exec turbo run test --filter=@bb/host-daemon -- --run src/provider-installation-gate.test.ts src/command-dispatch.test.ts` — 52 passed.
- `pnpm exec turbo run test --filter=@bb/host-daemon --force` — 557 passed.
- `pnpm exec turbo run typecheck --filter=@bb/host-daemon` — passed.
- `pnpm exec turbo run build --filter=@bb/host-daemon` — passed.
- Formatting and `git diff --check` — passed.

Fixes #2380

> AGENT GENERATED