### PR TITLE
Surface collapsed child thread errors

### DIFF
--- a/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectRow.interactions.test.tsx
@@ -135,6 +135,7 @@ function renderProjectRow(
   isActive = false,
   collapsedEnvironmentIds: Set<string> = new Set(),
   isCollapsed = false,
+  collapsedThreadIds: Set<string> = new Set(),
 ) {
   const onToggleEnvironmentCollapsed = vi.fn();
   const result = render(
@@ -146,7 +147,7 @@ function renderProjectRow(
           isActive={isActive}
           isCollapsed={isCollapsed}
           compareThreads={() => 0}
-          collapsedThreadIds={new Set()}
+          collapsedThreadIds={collapsedThreadIds}
           collapsedEnvironmentIds={collapsedEnvironmentIds}
           isLocalPathInvalid={false}
           onToggleProjectCollapsed={onToggleProjectCollapsed}
@@ -205,6 +206,58 @@ describe("ProjectRow interactions", () => {
       "proj_test",
     );
     expect(projectGroup?.hasAttribute("data-sidebar-section-id")).toBe(false);
+  });
+
+  it("surfaces a collapsed direct child's error on its parent row", () => {
+    renderProjectRow(
+      vi.fn(),
+      {
+        status: "ready",
+        threads: [
+          makeThread({ id: "thr_parent", title: "Parent thread" }),
+          makeThread({
+            id: "thr_errored_child",
+            title: "Errored child",
+            parentThreadId: "thr_parent",
+            status: "error",
+          }),
+        ],
+      },
+      false,
+      new Set(),
+      false,
+      new Set(["thr_parent"]),
+    );
+
+    expect(screen.queryByText("Errored child")).toBeNull();
+    expect(
+      screen.getByLabelText("Unread thread failed").getAttribute("data-icon"),
+    ).toBe("CircleX");
+  });
+
+  it("leaves a collapsed parent with a healthy direct child unmarked", () => {
+    renderProjectRow(
+      vi.fn(),
+      {
+        status: "ready",
+        threads: [
+          makeThread({ id: "thr_parent", title: "Parent thread" }),
+          makeThread({
+            id: "thr_healthy_child",
+            title: "Healthy child",
+            parentThreadId: "thr_parent",
+          }),
+        ],
+      },
+      false,
+      new Set(),
+      false,
+      new Set(["thr_parent"]),
+    );
+
+    expect(screen.queryByText("Healthy child")).toBeNull();
+    expect(screen.queryByLabelText("Unread thread failed")).toBeNull();
+    expect(screen.queryByLabelText("Unread thread succeeded")).toBeNull();
   });
 
   it("shows generic runtime activity before a named workflow rollup", () => {

--- a/packages/client-core/src/thread/thread-activity.ts
+++ b/packages/client-core/src/thread/thread-activity.ts
@@ -181,7 +181,10 @@ export interface CollapsedChildActivity {
   goal: boolean;
   /** At least one successfully finished child is unread. */
   unread: boolean;
-  /** At least one unread child has reached the terminal error state. */
+  /**
+   * At least one hidden child needs failure treatment: an unread root thread,
+   * or a hierarchy child whose own terminal status is error.
+   */
   unreadError: boolean;
 }
 
@@ -226,7 +229,14 @@ export function getCollapsedChildActivity(
       hasUnsubmittedDraft = true;
     }
     const childUnreadDone = isUnreadDoneThread(thread);
-    if (childUnreadDone && thread.status === "error") {
+    // Hierarchy children deliberately do not become "unread" when they finish:
+    // their parent owns that attention. Preserve that policy for successful
+    // children, but carry a terminal child failure into a collapsed ancestor so
+    // the existing error indicator can represent the hidden row.
+    const childNeedsErrorTreatment =
+      thread.status === "error" &&
+      (thread.parentThreadId !== null || childUnreadDone);
+    if (childNeedsErrorTreatment) {
       unreadError = true;
     } else if (childUnreadDone) {
       unread = true;

--- a/packages/client-core/test/thread-activity.test.ts
+++ b/packages/client-core/test/thread-activity.test.ts
@@ -3,6 +3,7 @@ import {
   getCollapsedChildActivity,
   hasThreadListWorkingActivity,
   isUnreadDoneThread,
+  NO_COLLAPSED_CHILD_ACTIVITY,
   resolveThreadListIndicator,
   type ThreadListIndicatorState,
 } from "../src/thread/thread-activity.js";
@@ -282,6 +283,28 @@ describe("thread-activity", () => {
         goal: false,
         unread: false,
         unreadError: false,
+      });
+    });
+
+    it("surfaces an errored direct child without flagging a healthy direct child", () => {
+      const healthyDirectChild = makeChild({
+        id: "healthy-direct-child",
+        parentThreadId: "parent",
+      });
+      const erroredDirectChild = makeChild({
+        id: "errored-direct-child",
+        parentThreadId: "parent",
+        status: "error",
+      });
+
+      expect(getCollapsedChildActivity([healthyDirectChild])).toEqual(
+        NO_COLLAPSED_CHILD_ACTIVITY,
+      );
+      expect(
+        getCollapsedChildActivity([healthyDirectChild, erroredDirectChild]),
+      ).toEqual({
+        ...NO_COLLAPSED_CHILD_ACTIVITY,
+        unreadError: true,
       });
     });
 
@@ -587,7 +610,7 @@ describe("thread-activity", () => {
       });
     });
 
-    it("never flags 'unread' for parented children", () => {
+    it("never flags a successful parented child as unread", () => {
       const unreadButParented = makeChild({
         latestAttentionAt: 20,
         lastReadAt: 10,


### PR DESCRIPTION
## What was wrong

Collapsed hierarchy rows derive their status from `getCollapsedChildActivity`, but parented threads are deliberately excluded from the ordinary unread-completion model. That policy correctly kept successful child completions quiet, but it also discarded a terminal child failure, leaving the parent unmarked while the errored child row was hidden.

## What changed

- Carry a parented thread's terminal `error` status into the collapsed hierarchy's existing `unreadError` signal and destructive `CircleX` treatment.
- Preserve the existing policy for successful parented children, so healthy collapsed hierarchies remain unmarked.
- Add core status-model and rendered `ProjectRow` regressions for collapsed errored and healthy direct children.
- No wire, daemon protocol, CLI, SDK, or persistence contracts changed.

## How you verified

- Confirmed the new core regression failed before the production change (`unreadError` was `false`) and passed afterward.
- `pnpm exec turbo run test --filter=@bb/client-core --force -- test/thread-activity.test.ts` — 39 passed.
- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/sidebar/ProjectRow.interactions.test.tsx` — 11 passed.
- `pnpm exec turbo run typecheck --filter=@bb/client-core --filter=@bb/app --force` — passed.
- Drove the exact branch web app at PR head `b6b43dcc4357e2d34c62bab9a652a27af0bc33a5` in Chrome for Testing 151 across 390×844, 768×900, 1440×900, and 3440×1440. Each viewport passed five expand/collapse cycles, responsive transition widths, client navigation, and hard reload with zero page errors.
- Repeated the primary flow in Safari 26.5.2: collapsed errored and healthy states, expansion, five cycles, client navigation, and hard reload all passed with zero page errors.

### Before — merge base `42d2c1bec`

The errored direct child is hidden, but its collapsed parent has no failure indicator.

![Before: collapsed parent does not surface its hidden child's error](https://gist.githubusercontent.com/brsbl/7f2dd6253ce8cf70dab37235e38a5c8c/raw/5f65c16e542a287047233f14ecea9bf3e23c8b2b/pr-before-collapsed-direct-child-error.png)

### After — PR head `b6b43dcc4`

The same fixture, route, interaction state, and viewport now show the existing failure indicator on the collapsed parent.

![After: collapsed parent surfaces its hidden child's error](https://gist.githubusercontent.com/brsbl/7f2dd6253ce8cf70dab37235e38a5c8c/raw/5f65c16e542a287047233f14ecea9bf3e23c8b2b/pr-after-collapsed-direct-child-error.png)

Fixes # — no linked issue.

BB-Thread-ID: thr_764udexes3

> AGENT GENERATED
