### PR TITLE
Calm the iOS shell-geometry handler and the timeline resize cascade

### DIFF
--- a/apps/app/src/components/layout/useMobileVisualViewportHeight.test.tsx
+++ b/apps/app/src/components/layout/useMobileVisualViewportHeight.test.tsx
@@ -108,6 +108,18 @@ function withElementClientHeight(
   }
 }
 
+// Waits out one scheduled rAF pass so "the pass ran and did nothing" is
+// distinguishable from "the pass has not run yet".
+async function flushScheduledViewportPass() {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => resolve());
+      });
+    });
+  });
+}
+
 beforeEach(() => {
   vi.spyOn(window, "scrollTo").mockImplementation(() => {});
 });
@@ -309,6 +321,136 @@ describe("useMobileVisualViewportHeight", () => {
       expect(shell.style.top).toBe("");
       expect(window.scrollTo).not.toHaveBeenCalled();
     });
+  });
+
+  it("writes shell geometry only when a pass computes new values", async () => {
+    const visualViewport = new FakeVisualViewport();
+    visualViewport.offsetTop = 0;
+    await withFakeVisualViewport(visualViewport, async () => {
+      render(<VisualViewportShell enabled />);
+      const shell = screen.getByTestId("shell");
+      const shellHeightRoot = screen.getByTestId("shell-height-root");
+      expect(shell.style.height).toBe("500px");
+      const setShellHeightProperty = vi.spyOn(
+        shellHeightRoot.style,
+        "setProperty",
+      );
+
+      // Same geometry again: the pass must return before any style write, or
+      // every keyboard/URL-bar animation frame invalidates the whole tree.
+      act(() => {
+        visualViewport.dispatchEvent(new Event("resize"));
+      });
+      await flushScheduledViewportPass();
+      expect(setShellHeightProperty).not.toHaveBeenCalled();
+
+      act(() => {
+        visualViewport.height = 480;
+        visualViewport.dispatchEvent(new Event("resize"));
+      });
+      await waitFor(() => expect(shell.style.height).toBe("480px"));
+      expect(setShellHeightProperty).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("reads the containing block only when the layout viewport can change", async () => {
+    const visualViewport = new FakeVisualViewport();
+    visualViewport.offsetTop = 0;
+    let containingBlockReads = 0;
+    await withElementClientHeight(
+      document.body,
+      () => {
+        containingBlockReads += 1;
+        return 800;
+      },
+      async () =>
+        withFakeVisualViewport(visualViewport, async () => {
+          render(<VisualViewportShell enabled />);
+          const shell = screen.getByTestId("shell");
+          expect(shell.style.height).toBe("500px");
+          const readsAfterMount = containingBlockReads;
+
+          // Visual-viewport ticks pan or resize only the visual viewport;
+          // they must reuse the cached containing-block height instead of
+          // forcing a full-document layout per animation frame.
+          act(() => {
+            visualViewport.offsetTop = 40;
+            visualViewport.dispatchEvent(new Event("scroll"));
+          });
+          await waitFor(() => expect(shell.style.top).toBe("40px"));
+          act(() => {
+            visualViewport.height = 460;
+            visualViewport.dispatchEvent(new Event("resize"));
+          });
+          await waitFor(() => expect(shell.style.height).toBe("460px"));
+          expect(containingBlockReads).toBe(readsAfterMount);
+
+          act(() => {
+            window.dispatchEvent(new Event("resize"));
+          });
+          await waitFor(() =>
+            expect(containingBlockReads).toBe(readsAfterMount + 1),
+          );
+        }),
+    );
+  });
+
+  it("runs a geometry pass when an editor is focused programmatically", async () => {
+    const visualViewport = new FakeVisualViewport();
+    visualViewport.offsetTop = 0;
+    await withElementClientHeight(
+      document.body,
+      () => 500,
+      async () =>
+        withFakeVisualViewport(visualViewport, async () => {
+          render(<VisualViewportShell enabled />);
+          const shell = screen.getByTestId("shell");
+          const editor = screen.getByTestId("editor");
+          // Native layout matches the visual viewport: no override applied.
+          expect(shell.style.height).toBe("");
+
+          // The keyboard shortens the visual viewport around the same time
+          // the composer autofocuses, without any window resize; the focus
+          // pass must pick the change up on its own.
+          visualViewport.height = 300;
+          act(() => editor.focus());
+          await waitFor(() => expect(shell.style.height).toBe("300px"));
+        }),
+    );
+  });
+
+  it("ignores visual viewport pans without a keyboard or an applied override", async () => {
+    const visualViewport = new FakeVisualViewport();
+    visualViewport.offsetTop = 0;
+    await withElementClientHeight(
+      document.body,
+      () => 500,
+      async () =>
+        withFakeVisualViewport(visualViewport, async () => {
+          render(<VisualViewportShell enabled />);
+          const shell = screen.getByTestId("shell");
+          const editor = screen.getByTestId("editor");
+          expect(shell.style.height).toBe("");
+
+          // A URL-bar pan with no keyboard: nothing to compensate.
+          act(() => {
+            visualViewport.offsetTop = 340;
+            visualViewport.dispatchEvent(new Event("scroll"));
+          });
+          await flushScheduledViewportPass();
+          expect(window.scrollTo).not.toHaveBeenCalled();
+          expect(shell.style.top).toBe("");
+
+          // With a keyboard editor focused, the same pan is Safari's
+          // focus-reveal pan and must still be compensated.
+          act(() => editor.focus());
+          act(() => {
+            visualViewport.dispatchEvent(new Event("scroll"));
+          });
+          await waitFor(() => expect(shell.style.top).toBe("340px"));
+          expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
+        }),
+    );
   });
 });
 

--- a/apps/app/src/components/layout/useMobileVisualViewportHeight.ts
+++ b/apps/app/src/components/layout/useMobileVisualViewportHeight.ts
@@ -55,7 +55,22 @@ export function useMobileVisualViewportHeight(
     if (!shell || !shellHeightRoot || !enabled || !visualViewport) return;
 
     let animationFrame: number | null = null;
+    // The override last written to the shell, or null while none is applied.
+    // Writing shell `top`/`height` and the inherited `--bb-shell-height`
+    // invalidates computed style for the whole app tree, and passes run at
+    // visual-viewport event cadence (keyboard animation, URL-bar collapse),
+    // so a pass that recomputes unchanged geometry must not write at all.
+    let appliedOverride: { top: number; height: number } | null = null;
+    // Reading `document.body.clientHeight` forces a full-document layout. The
+    // shell's containing block only changes when the layout viewport does, so
+    // cache the read and mark it stale only on triggers that can resize the
+    // layout viewport — never on visualViewport ticks, which move or resize
+    // only the visual viewport.
+    let shellContainingBlockHeight = 0;
+    let shellContainingBlockHeightStale = true;
     const clearViewportOverride = () => {
+      if (appliedOverride === null) return;
+      appliedOverride = null;
       shell.style.removeProperty("top");
       shell.style.removeProperty("height");
       shellHeightRoot.style.removeProperty("--bb-shell-height");
@@ -68,12 +83,15 @@ export function useMobileVisualViewportHeight(
       }
 
       const visualViewportHeight = Math.round(visualViewport.height);
-      // `documentElement.clientHeight` is the visible viewport height for the
-      // root element, even when that root's actual CSS box extends behind an
-      // Android in-app browser toolbar. The body inherits the root box and
-      // therefore exposes the containing-block height the app shell really
-      // receives.
-      const shellContainingBlockHeight = document.body.clientHeight;
+      if (shellContainingBlockHeightStale) {
+        // `documentElement.clientHeight` is the visible viewport height for the
+        // root element, even when that root's actual CSS box extends behind an
+        // Android in-app browser toolbar. The body inherits the root box and
+        // therefore exposes the containing-block height the app shell really
+        // receives.
+        shellContainingBlockHeight = document.body.clientHeight;
+        shellContainingBlockHeightStale = false;
+      }
       const hasVisualViewportPan =
         visualViewport.offsetTop > 1 || window.scrollY > 0;
       if (
@@ -91,7 +109,16 @@ export function useMobileVisualViewportHeight(
         // compensation below also handles a visual-viewport-only pan.
         window.scrollTo(0, 0);
       }
-      shell.style.top = `${getVisualViewportPageTop(visualViewport)}px`;
+      const shellTop = getVisualViewportPageTop(visualViewport);
+      if (
+        appliedOverride !== null &&
+        appliedOverride.top === shellTop &&
+        appliedOverride.height === visualViewportHeight
+      ) {
+        return;
+      }
+      appliedOverride = { top: shellTop, height: visualViewportHeight };
+      shell.style.top = `${shellTop}px`;
       shell.style.height = `${visualViewportHeight}px`;
       // Fixed-position descendants cannot inherit the shell element's pixel
       // height. Publish the same correction through the existing shell-height
@@ -107,6 +134,27 @@ export function useMobileVisualViewportHeight(
         window.cancelAnimationFrame(animationFrame);
       }
       animationFrame = window.requestAnimationFrame(updateHeight);
+    };
+    // For triggers that can resize the layout viewport itself: window resize,
+    // rotation, and an editor gaining focus (the keyboard that follows may
+    // resize the layout viewport on Android's resizes-content path).
+    const scheduleContainingBlockUpdate = () => {
+      shellContainingBlockHeightStale = true;
+      scheduleUpdate();
+    };
+    const handleVisualViewportScroll = () => {
+      // Keyboard-less visual-viewport pans (URL-bar collapse, momentum
+      // settling) don't change the containing block and need no override —
+      // the pan compensation exists for the keyboard focus-reveal pan. Only
+      // an already-applied override still has to track pans, because embedded
+      // browsers apply one without any keyboard.
+      if (
+        appliedOverride === null &&
+        !isKeyboardFocusTarget(document.activeElement)
+      ) {
+        return;
+      }
+      scheduleUpdate();
     };
 
     // Safari with its bottom toolbar visible does not update the visual
@@ -124,13 +172,16 @@ export function useMobileVisualViewportHeight(
     };
     const handleFocusIn = (event: FocusEvent) => {
       if (!isKeyboardFocusTarget(event.target)) return;
-      scheduleUpdate();
+      // Programmatic focus (composer autofocus) can be the only trigger for a
+      // keyboard, so this must always schedule a full, freshly measured pass.
+      scheduleContainingBlockUpdate();
     };
 
     updateHeight();
     visualViewport.addEventListener("resize", scheduleUpdate);
-    visualViewport.addEventListener("scroll", scheduleUpdate);
-    window.addEventListener("resize", scheduleUpdate);
+    visualViewport.addEventListener("scroll", handleVisualViewportScroll);
+    window.addEventListener("resize", scheduleContainingBlockUpdate);
+    window.addEventListener("orientationchange", scheduleContainingBlockUpdate);
     if (restoreImmediatelyOnKeyboardDismissal) {
       document.addEventListener("focusout", handleFocusOut);
       document.addEventListener("focusin", handleFocusIn);
@@ -138,8 +189,12 @@ export function useMobileVisualViewportHeight(
 
     return () => {
       visualViewport.removeEventListener("resize", scheduleUpdate);
-      visualViewport.removeEventListener("scroll", scheduleUpdate);
-      window.removeEventListener("resize", scheduleUpdate);
+      visualViewport.removeEventListener("scroll", handleVisualViewportScroll);
+      window.removeEventListener("resize", scheduleContainingBlockUpdate);
+      window.removeEventListener(
+        "orientationchange",
+        scheduleContainingBlockUpdate,
+      );
       if (restoreImmediatelyOnKeyboardDismissal) {
         document.removeEventListener("focusout", handleFocusOut);
         document.removeEventListener("focusin", handleFocusIn);

--- a/apps/app/src/components/layout/useMobileVisualViewportHeight.ts
+++ b/apps/app/src/components/layout/useMobileVisualViewportHeight.ts
@@ -135,9 +135,10 @@ export function useMobileVisualViewportHeight(
       }
       animationFrame = window.requestAnimationFrame(updateHeight);
     };
-    // For triggers that can resize the layout viewport itself: window resize,
-    // rotation, and an editor gaining focus (the keyboard that follows may
-    // resize the layout viewport on Android's resizes-content path).
+    // For triggers where the layout viewport may have changed: window resize,
+    // rotation, and an editor gaining focus — the pass that sizes the shell
+    // for the arriving keyboard must start from the real containing block,
+    // and these triggers are rare enough that the forced layout is fine.
     const scheduleContainingBlockUpdate = () => {
       shellContainingBlockHeightStale = true;
       scheduleUpdate();

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.coarse-pointer.test.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.coarse-pointer.test.tsx
@@ -1,0 +1,256 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { getDefaultStore } from "jotai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BottomAnchoredScrollBody } from "@/components/ui/bottom-anchored-scroll-body";
+import { threadTimelineScrollAnchorAtomFamily } from "@/lib/thread-timeline-scroll-anchor";
+
+// Per-scroll-event costs that differ by pointer type: the transient-scrollbar
+// attribute (desktop-scrollbar-only CSS) is skipped on coarse pointers, the
+// scroll-anchor capture throttle relaxes to the coarse cadence, and captures
+// reuse a cached row NodeList that the ResizeObserver invalidates.
+
+interface ScrollMetrics {
+  scrollHeight: number;
+  clientHeight: number;
+  scrollTop: number;
+}
+
+interface RowRect {
+  top: number;
+  bottom: number;
+}
+
+const SCROLL_AREA_CLASS = "scroll-area";
+
+class ResizeObserverMock implements ResizeObserver {
+  static instances: ResizeObserverMock[] = [];
+  readonly callback: ResizeObserverCallback;
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    ResizeObserverMock.instances.push(this);
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  trigger() {
+    this.callback([], this);
+  }
+}
+
+function getLatestResizeObserver(): ResizeObserverMock {
+  const instance = ResizeObserverMock.instances.at(-1);
+  if (!instance) throw new Error("Expected a ResizeObserver instance.");
+  return instance;
+}
+
+function stubMediaQueries(matching: ReadonlySet<string>): void {
+  vi.spyOn(window, "matchMedia").mockImplementation((query: string) => ({
+    matches: matching.has(query),
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }));
+}
+
+function setScrollMetrics(element: HTMLElement, metrics: ScrollMetrics) {
+  Object.defineProperty(element, "scrollHeight", {
+    configurable: true,
+    value: metrics.scrollHeight,
+  });
+  Object.defineProperty(element, "clientHeight", {
+    configurable: true,
+    value: metrics.clientHeight,
+  });
+  element.scrollTop = metrics.scrollTop;
+}
+
+function mockScrollAreaRect(scrollArea: HTMLElement) {
+  vi.spyOn(scrollArea, "getBoundingClientRect").mockReturnValue(
+    new DOMRect(0, 0, 100, 100),
+  );
+}
+
+function mockRowRect(row: HTMLElement, rect: RowRect) {
+  vi.spyOn(row, "getBoundingClientRect").mockReturnValue(
+    new DOMRect(0, rect.top, 100, rect.bottom - rect.top),
+  );
+}
+
+function requireHTMLElement(element: Element | null) {
+  if (!(element instanceof HTMLElement)) {
+    throw new Error("Expected HTMLElement.");
+  }
+  return element;
+}
+
+function renderTimeline(threadId: string, rowIds: string[]) {
+  const view = render(
+    <BottomAnchoredScrollBody
+      footer={<div>Footer</div>}
+      maxWidthClassName="max-w-none"
+      scrollAreaClassName={SCROLL_AREA_CLASS}
+      scrollAnchorThreadId={threadId}
+    >
+      {rowIds.map((rowId) => (
+        <div key={rowId} data-timeline-row-id={rowId}>
+          {rowId}
+        </div>
+      ))}
+    </BottomAnchoredScrollBody>,
+  );
+  const scrollArea = requireHTMLElement(
+    view.container.querySelector(`.${SCROLL_AREA_CLASS}`),
+  );
+  const rowElements = new Map<string, HTMLElement>();
+  for (const rowId of rowIds) {
+    rowElements.set(
+      rowId,
+      requireHTMLElement(
+        view.container.querySelector(`[data-timeline-row-id="${rowId}"]`),
+      ),
+    );
+  }
+  return { scrollArea, rowElements };
+}
+
+function readAnchor(threadId: string) {
+  return getDefaultStore().get(threadTimelineScrollAnchorAtomFamily(threadId));
+}
+
+beforeEach(() => {
+  ResizeObserverMock.instances = [];
+  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  vi.stubGlobal(
+    "requestAnimationFrame",
+    vi.fn(() => 1),
+  );
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  const store = getDefaultStore();
+  for (const threadId of ["coarse-thread", "cache-thread"]) {
+    store.set(threadTimelineScrollAnchorAtomFamily(threadId), null);
+  }
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("BottomAnchoredScrollBody on coarse pointers", () => {
+  it("never writes the transient scrollbar attribute", () => {
+    stubMediaQueries(new Set(["(pointer: coarse)"]));
+    const { scrollArea } = renderTimeline("coarse-thread", ["row-a"]);
+
+    fireEvent.scroll(scrollArea);
+
+    // The attribute only feeds desktop ::-webkit-scrollbar rules; on touch it
+    // would be a per-scroll-event style invalidation with no visible effect.
+    expect(scrollArea.hasAttribute("data-scrollbar-scrolling")).toBe(false);
+  });
+
+  it("captures scroll anchors at the relaxed coarse cadence", () => {
+    stubMediaQueries(new Set(["(pointer: coarse)"]));
+    // Fake performance.now so the throttle windows below are deterministic.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance"] });
+    const { scrollArea } = renderTimeline("coarse-thread", ["row-a"]);
+
+    // Settle the first capture (immediate or trailing, depending on where the
+    // faked clock started) so the throttle's lastWriteAt equals now.
+    fireEvent.scroll(scrollArea);
+    vi.runOnlyPendingTimers();
+    expect(readAnchor("coarse-thread")).not.toBeNull();
+    getDefaultStore().set(
+      threadTimelineScrollAnchorAtomFamily("coarse-thread"),
+      null,
+    );
+
+    // A capture 50ms into the window arms a trailing write for the remainder
+    // of the coarse throttle: 250 - 50 = 200ms out.
+    vi.advanceTimersByTime(50);
+    fireEvent.scroll(scrollArea);
+    expect(readAnchor("coarse-thread")).toBeNull();
+
+    // The fine-pointer cadence (100ms window → 50ms remainder) must not fire
+    // on a coarse pointer...
+    vi.advanceTimersByTime(199);
+    expect(readAnchor("coarse-thread")).toBeNull();
+
+    // ...but the trailing write still records the resting position at 250ms.
+    vi.advanceTimersByTime(1);
+    expect(readAnchor("coarse-thread")).toEqual({
+      rowId: "",
+      offsetWithinRow: 0,
+      atBottom: true,
+    });
+  });
+});
+
+describe("BottomAnchoredScrollBody row NodeList cache", () => {
+  it("reuses the cached rows across captures until a resize invalidates them", () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "performance"] });
+    const { scrollArea, rowElements } = renderTimeline("cache-thread", [
+      "row-a",
+      "row-b",
+      "row-c",
+    ]);
+    mockScrollAreaRect(scrollArea);
+    mockRowRect(requireHTMLElement(rowElements.get("row-a")!), {
+      top: -120,
+      bottom: -20,
+    });
+    mockRowRect(requireHTMLElement(rowElements.get("row-b")!), {
+      top: -20,
+      bottom: 80,
+    });
+    mockRowRect(requireHTMLElement(rowElements.get("row-c")!), {
+      top: 80,
+      bottom: 180,
+    });
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 400,
+      clientHeight: 100,
+      scrollTop: 300,
+    });
+    const queryRows = vi.spyOn(scrollArea, "querySelectorAll");
+
+    // Move the clock past the throttle window so every capture below writes
+    // immediately instead of arming a trailing timeout.
+    vi.advanceTimersByTime(1_000);
+    scrollArea.scrollTop = 150;
+    fireEvent.wheel(scrollArea);
+    fireEvent.scroll(scrollArea);
+    expect(readAnchor("cache-thread")).toEqual({
+      rowId: "row-b",
+      offsetWithinRow: 20,
+      atBottom: false,
+    });
+    expect(queryRows).toHaveBeenCalledTimes(1);
+
+    // A second capture in the same layout reuses the cached NodeList.
+    vi.advanceTimersByTime(200);
+    scrollArea.scrollTop = 140;
+    fireEvent.scroll(scrollArea);
+    expect(queryRows).toHaveBeenCalledTimes(1);
+
+    // A ResizeObserver delivery means rows may have mounted or unmounted;
+    // the next capture queries fresh.
+    getLatestResizeObserver().trigger();
+    vi.advanceTimersByTime(200);
+    scrollArea.scrollTop = 130;
+    fireEvent.scroll(scrollArea);
+    expect(queryRows).toHaveBeenCalledTimes(2);
+    expect(readAnchor("cache-thread")).toEqual({
+      rowId: "row-b",
+      offsetWithinRow: 20,
+      atBottom: false,
+    });
+  });
+});

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.settle-tail.test.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.settle-tail.test.tsx
@@ -1,0 +1,292 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { getDefaultStore } from "jotai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BottomAnchoredScrollBody } from "@/components/ui/bottom-anchored-scroll-body";
+import { threadTimelineScrollAnchorAtomFamily } from "@/lib/thread-timeline-scroll-anchor";
+
+// Companion to the scroll-preservation suite, focused on the geometry-read
+// budget of the resize path: the observed frame may read live
+// scrollHeight/clientHeight, but the rAF settle tail must run on the cached
+// max offset (at most one live verification read when a cached restore found
+// drift), and deliveries that carry ResizeObserver box sizes must refresh the
+// cache from them without forcing layout at all.
+
+interface ScrollMetrics {
+  scrollHeight: number;
+  clientHeight: number;
+  scrollTop: number;
+}
+
+const SCROLL_AREA_CLASS = "scroll-area";
+const THREAD_ID = "settle-thread";
+
+class ResizeObserverMock implements ResizeObserver {
+  static instances: ResizeObserverMock[] = [];
+  readonly callback: ResizeObserverCallback;
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    ResizeObserverMock.instances.push(this);
+  }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  trigger(entries: ResizeObserverEntry[] = []) {
+    this.callback(entries, this);
+  }
+}
+
+function getLatestResizeObserver(): ResizeObserverMock {
+  const instance = ResizeObserverMock.instances.at(-1);
+  if (!instance) throw new Error("Expected a ResizeObserver instance.");
+  return instance;
+}
+
+interface ManualAnimationFrames {
+  runFrame: () => void;
+  hasPending: () => boolean;
+}
+
+// Unlike the scroll-preservation suite (which discards rAF callbacks because
+// the settle tail is irrelevant there), these tests drive the tail frame by
+// frame to observe what each one reads.
+function installManualAnimationFrames(): ManualAnimationFrames {
+  let nextHandle = 1;
+  const pending = new Map<number, FrameRequestCallback>();
+  vi.stubGlobal(
+    "requestAnimationFrame",
+    vi.fn((callback: FrameRequestCallback) => {
+      const handle = nextHandle;
+      nextHandle += 1;
+      pending.set(handle, callback);
+      return handle;
+    }),
+  );
+  vi.stubGlobal(
+    "cancelAnimationFrame",
+    vi.fn((handle: number) => {
+      pending.delete(handle);
+    }),
+  );
+  return {
+    runFrame() {
+      const callbacks = [...pending.values()];
+      pending.clear();
+      for (const callback of callbacks) {
+        callback(window.performance.now());
+      }
+    },
+    hasPending() {
+      return pending.size > 0;
+    },
+  };
+}
+
+function setScrollMetrics(element: HTMLElement, metrics: ScrollMetrics) {
+  Object.defineProperty(element, "scrollHeight", {
+    configurable: true,
+    value: metrics.scrollHeight,
+  });
+  Object.defineProperty(element, "clientHeight", {
+    configurable: true,
+    value: metrics.clientHeight,
+  });
+  element.scrollTop = metrics.scrollTop;
+}
+
+interface GeometryReadCounters {
+  readScrollHeight: ReturnType<typeof vi.fn>;
+  readClientHeight: ReturnType<typeof vi.fn>;
+}
+
+function installGeometryReadCounters(
+  element: HTMLElement,
+  metrics: Pick<ScrollMetrics, "scrollHeight" | "clientHeight">,
+): GeometryReadCounters {
+  const readScrollHeight = vi.fn(() => metrics.scrollHeight);
+  const readClientHeight = vi.fn(() => metrics.clientHeight);
+  Object.defineProperty(element, "scrollHeight", {
+    configurable: true,
+    get: readScrollHeight,
+  });
+  Object.defineProperty(element, "clientHeight", {
+    configurable: true,
+    get: readClientHeight,
+  });
+  return { readScrollHeight, readClientHeight };
+}
+
+function makeResizeEntry(
+  target: Element,
+  blockSize: number,
+): ResizeObserverEntry {
+  const boxSize: ResizeObserverSize = { blockSize, inlineSize: 100 };
+  return {
+    target,
+    contentRect: new DOMRect(0, 0, 100, blockSize),
+    borderBoxSize: [boxSize],
+    contentBoxSize: [boxSize],
+    devicePixelContentBoxSize: [boxSize],
+  };
+}
+
+function requireHTMLElement(element: Element | null) {
+  if (!(element instanceof HTMLElement)) {
+    throw new Error("Expected HTMLElement.");
+  }
+  return element;
+}
+
+function renderScrollBody() {
+  const view = render(
+    <BottomAnchoredScrollBody
+      footer={<div>Footer</div>}
+      maxWidthClassName="max-w-none"
+      scrollAreaClassName={SCROLL_AREA_CLASS}
+      scrollAnchorThreadId={THREAD_ID}
+    >
+      <div data-timeline-row-id="row-a">row-a</div>
+    </BottomAnchoredScrollBody>,
+  );
+  const scrollArea = requireHTMLElement(
+    view.container.querySelector(`.${SCROLL_AREA_CLASS}`),
+  );
+  const scrollContent = requireHTMLElement(scrollArea.firstElementChild);
+  return { scrollArea, scrollContent };
+}
+
+let frames: ManualAnimationFrames;
+
+beforeEach(() => {
+  ResizeObserverMock.instances = [];
+  vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+  frames = installManualAnimationFrames();
+});
+
+afterEach(() => {
+  cleanup();
+  getDefaultStore().set(threadTimelineScrollAnchorAtomFamily(THREAD_ID), null);
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// Pin the viewport to the bottom of settled content and drain the mount tail,
+// then grow the content so the observed frame restores to the new bottom and
+// arms a fresh settle tail.
+function growContentWhilePinned() {
+  const rendered = renderScrollBody();
+  const { scrollArea } = rendered;
+  setScrollMetrics(scrollArea, {
+    scrollHeight: 400,
+    clientHeight: 100,
+    scrollTop: 300,
+  });
+  getLatestResizeObserver().trigger();
+  frames.runFrame();
+
+  setScrollMetrics(scrollArea, {
+    scrollHeight: 500,
+    clientHeight: 100,
+    scrollTop: 300,
+  });
+  getLatestResizeObserver().trigger();
+  expect(scrollArea.scrollTop).toBe(400);
+  return rendered;
+}
+
+describe("BottomAnchoredScrollBody settle tail", () => {
+  it("settles without re-reading geometry when the cached restore finds no drift", () => {
+    const { scrollArea } = growContentWhilePinned();
+    const { readScrollHeight, readClientHeight } = installGeometryReadCounters(
+      scrollArea,
+      { scrollHeight: 500, clientHeight: 100 },
+    );
+
+    // No drift after the observed frame: the tail's first cached comparison
+    // sees the pinned position and stops without a single forced layout.
+    frames.runFrame();
+    expect(scrollArea.scrollTop).toBe(400);
+    expect(readScrollHeight).not.toHaveBeenCalled();
+    expect(readClientHeight).not.toHaveBeenCalled();
+    expect(frames.hasPending()).toBe(false);
+  });
+
+  it("spends at most one live read when the settle tail corrects drift", () => {
+    const { scrollArea } = growContentWhilePinned();
+    // Cascading layout (footer/prompt height settling) moved scrollTop after
+    // the observed frame without resizing the observed boxes.
+    scrollArea.scrollTop = 390;
+    const { readScrollHeight, readClientHeight } = installGeometryReadCounters(
+      scrollArea,
+      { scrollHeight: 500, clientHeight: 100 },
+    );
+
+    // First tail frame corrects against the cache alone.
+    frames.runFrame();
+    expect(scrollArea.scrollTop).toBe(400);
+    expect(readScrollHeight).not.toHaveBeenCalled();
+    expect(readClientHeight).not.toHaveBeenCalled();
+
+    // The cached correction arms exactly one live verification read.
+    frames.runFrame();
+    expect(readScrollHeight).toHaveBeenCalledTimes(1);
+    expect(readClientHeight).toHaveBeenCalledTimes(1);
+    expect(scrollArea.scrollTop).toBe(400);
+
+    // Verification found the bottom stable, so the tail is done.
+    frames.runFrame();
+    expect(readScrollHeight).toHaveBeenCalledTimes(1);
+    expect(readClientHeight).toHaveBeenCalledTimes(1);
+    expect(frames.hasPending()).toBe(false);
+  });
+
+  it("derives the cached max offset from observed box sizes without forcing layout", () => {
+    const { scrollArea, scrollContent } = renderScrollBody();
+    setScrollMetrics(scrollArea, {
+      scrollHeight: 400,
+      clientHeight: 100,
+      scrollTop: 300,
+    });
+    getLatestResizeObserver().trigger();
+    frames.runFrame();
+
+    // Detach mid-timeline (the detach edge spends its allowed verification
+    // read here, before the counters are installed).
+    scrollArea.scrollTop = 150;
+    fireEvent.wheel(scrollArea);
+    fireEvent.scroll(scrollArea);
+
+    const liveMetrics = { scrollHeight: 900, clientHeight: 100 };
+    const { readScrollHeight, readClientHeight } = installGeometryReadCounters(
+      scrollArea,
+      liveMetrics,
+    );
+
+    // Content grows to 900 while detached. The delivery carries the observer's
+    // own box sizes, so the cache refresh needs no scrollHeight/clientHeight.
+    getLatestResizeObserver().trigger([
+      makeResizeEntry(scrollArea, 100),
+      makeResizeEntry(scrollContent, 900),
+    ]);
+    expect(readScrollHeight).not.toHaveBeenCalled();
+    expect(readClientHeight).not.toHaveBeenCalled();
+
+    // The derived max offset (800) is what scroll classification runs on:
+    // 797 is within the 4px threshold, so this scroll re-attaches — still
+    // without a live read.
+    scrollArea.scrollTop = 797;
+    fireEvent.scroll(scrollArea);
+    expect(readScrollHeight).not.toHaveBeenCalled();
+    expect(readClientHeight).not.toHaveBeenCalled();
+
+    // Re-attached: the next growth's observed frame follows the bottom (its
+    // restore legitimately reads fresh geometry).
+    liveMetrics.scrollHeight = 1_000;
+    getLatestResizeObserver().trigger([
+      makeResizeEntry(scrollArea, 100),
+      makeResizeEntry(scrollContent, 1_000),
+    ]);
+    expect(scrollArea.scrollTop).toBe(900);
+  });
+});

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -11,6 +11,7 @@ import {
 import type { ReactNode } from "react";
 import { useStore } from "jotai";
 import { cn } from "@bb/shared-ui/lib/utils";
+import { usePointerCoarse } from "@bb/shared-ui/hooks/use-pointer-coarse";
 import { PAGE_SHELL_CONTENT_STYLE } from "./page-shell-content-style.js";
 import { supportsScrollAnchoring } from "@/lib/scroll-anchoring-support";
 import {
@@ -91,6 +92,10 @@ const BOTTOM_RESTORE_SETTLE_FRAME_COUNT = 3;
 // Throttle continuous scroll-anchor capture so a fast scroll writes the atom at
 // most this often, plus a trailing write for the final resting position.
 const SCROLL_ANCHOR_CAPTURE_THROTTLE_MS = 100;
+// Coarse pointers only need restore-on-return fidelity — the resting position,
+// always carried by the trailing write — not 10 Hz mid-flick samples, each of
+// which costs rect reads while the browser is already busy scrolling.
+const COARSE_SCROLL_ANCHOR_CAPTURE_THROTTLE_MS = 250;
 // While a saved anchor's row hasn't hydrated yet, the ResizeObserver re-applies
 // the restore as content settles. Give up (fall back to bottom) after this many
 // observed re-applies so a deleted/never-arriving row can't hang at the top.
@@ -189,9 +194,9 @@ function getScrollAnchorRows(scrollArea: HTMLElement): NodeListOf<HTMLElement> {
 // reproduce a mid-row reading position.
 function getTopMostVisibleRow(
   scrollArea: HTMLElement,
+  rows: NodeListOf<HTMLElement>,
 ): TopMostVisibleRow | null {
   const scrollAreaTop = scrollArea.getBoundingClientRect().top;
-  const rows = getScrollAnchorRows(scrollArea);
   let low = 0;
   let high = rows.length - 1;
   let visibleRow: HTMLElement | null = null;
@@ -277,6 +282,7 @@ export function BottomAnchoredScrollBody({
   scrollAnchorThreadId,
 }: BottomAnchoredScrollBodyProps) {
   const store = useStore();
+  const isPointerCoarse = usePointerCoarse();
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const scrollContentRef = useRef<HTMLDivElement>(null);
   const shouldStickToBottomRef = useRef(true);
@@ -333,6 +339,12 @@ export function BottomAnchoredScrollBody({
     scrollAreaClientHeight: number | null;
     scrollContentHeight: number | null;
   }>({ scrollAreaClientHeight: null, scrollContentHeight: null });
+  // The row NodeList behind scroll-anchor capture, so throttled samples don't
+  // repeat a querySelectorAll over the scroll subtree. Row-set changes surface
+  // as content size changes, so the ResizeObserver invalidates it; the
+  // connectivity check in getScrollAnchorRowsCached guards the windowed
+  // timeline, where a row swap at a window edge can keep the size constant.
+  const scrollAnchorRowsRef = useRef<NodeListOf<HTMLElement> | null>(null);
   const [isAtBottom, setIsAtBottom] = useState(true);
   const initialScrollRestoreRowId = useMemo(() => {
     if (scrollAnchorThreadId === undefined) return null;
@@ -551,6 +563,21 @@ export function BottomAnchoredScrollBody({
     );
   }, []);
 
+  const getScrollAnchorRowsCached = useCallback((scrollArea: HTMLElement) => {
+    const cached = scrollAnchorRowsRef.current;
+    if (
+      cached &&
+      (cached.length === 0 ||
+        (cached[0]?.isConnected === true &&
+          cached[cached.length - 1]?.isConnected === true))
+    ) {
+      return cached;
+    }
+    const rows = getScrollAnchorRows(scrollArea);
+    scrollAnchorRowsRef.current = rows;
+    return rows;
+  }, []);
+
   // Persist the current scroll position (top-most visible row + within-row
   // offset + atBottom) into the per-thread atom so returning to this thread
   // restores it. Continuous capture keeps the atom current while mounted; cleanup
@@ -600,7 +627,10 @@ export function BottomAnchoredScrollBody({
         });
         return;
       }
-      const topMostRow = getTopMostVisibleRow(scrollArea);
+      const topMostRow = getTopMostVisibleRow(
+        scrollArea,
+        getScrollAnchorRowsCached(scrollArea),
+      );
       // No rows yet: don't clobber a good anchor with an empty one.
       if (!topMostRow) return;
       store.set(anchorAtom, {
@@ -610,6 +640,7 @@ export function BottomAnchoredScrollBody({
       });
     },
     [
+      getScrollAnchorRowsCached,
       hasRecentUserScrollIntent,
       readMaxScrollOffset,
       refreshMaxScrollOffset,
@@ -618,12 +649,16 @@ export function BottomAnchoredScrollBody({
     ],
   );
 
+  const scrollAnchorCaptureThrottleMs = isPointerCoarse
+    ? COARSE_SCROLL_ANCHOR_CAPTURE_THROTTLE_MS
+    : SCROLL_ANCHOR_CAPTURE_THROTTLE_MS;
+
   const captureScrollAnchorThrottled = useCallback(() => {
     if (scrollAnchorThreadId === undefined) return;
     const throttle = scrollAnchorCaptureThrottleRef.current;
     const now = window.performance.now();
     const elapsed = now - throttle.lastWriteAt;
-    if (elapsed >= SCROLL_ANCHOR_CAPTURE_THROTTLE_MS) {
+    if (elapsed >= scrollAnchorCaptureThrottleMs) {
       throttle.lastWriteAt = now;
       writeScrollAnchor();
       return;
@@ -635,8 +670,8 @@ export function BottomAnchoredScrollBody({
       throttle.trailingTimeout = null;
       throttle.lastWriteAt = window.performance.now();
       writeScrollAnchor();
-    }, SCROLL_ANCHOR_CAPTURE_THROTTLE_MS - elapsed);
-  }, [scrollAnchorThreadId, writeScrollAnchor]);
+    }, scrollAnchorCaptureThrottleMs - elapsed);
+  }, [scrollAnchorCaptureThrottleMs, scrollAnchorThreadId, writeScrollAnchor]);
 
   // Bring the saved anchor row into view (plus its within-row offset). Returns
   // the resulting scrollTop when the row was found, or null when it isn't yet
@@ -851,6 +886,8 @@ export function BottomAnchoredScrollBody({
   const handleScrollAreaResize = useCallback(
     (entries: ResizeObserverEntry[]) => {
       const scrollArea = scrollAreaRef.current;
+      // Any observed size change may have mounted or unmounted timeline rows.
+      scrollAnchorRowsRef.current = null;
       let shrankOntoBottomWhileDetached = false;
       if (scrollArea) {
         // The steady-state cache refresh: the observer watches both the scroll
@@ -1006,6 +1043,12 @@ export function BottomAnchoredScrollBody({
       }, SCROLLBAR_IDLE_DELAY_MS);
       handleScroll();
     };
+    // The transient-scrollbar attribute only feeds the desktop-only
+    // ::-webkit-scrollbar rules; on coarse pointers (overlay scrollbars) the
+    // write would be a pure per-scroll-event style invalidation.
+    const handleScrollEvent = isPointerCoarse
+      ? handleScroll
+      : handleScrollWithTransientScrollbar;
 
     let resizeObserver: ResizeObserver | undefined;
     if (typeof ResizeObserver !== "undefined") {
@@ -1014,7 +1057,7 @@ export function BottomAnchoredScrollBody({
       resizeObserver.observe(scrollContent);
     }
 
-    scrollArea.addEventListener("scroll", handleScrollWithTransientScrollbar, {
+    scrollArea.addEventListener("scroll", handleScrollEvent, {
       passive: true,
     });
     scrollArea.addEventListener("wheel", markWheelScrollIntent, {
@@ -1040,10 +1083,7 @@ export function BottomAnchoredScrollBody({
 
     return () => {
       resizeObserver?.disconnect();
-      scrollArea.removeEventListener(
-        "scroll",
-        handleScrollWithTransientScrollbar,
-      );
+      scrollArea.removeEventListener("scroll", handleScrollEvent);
       scrollArea.removeEventListener("wheel", markWheelScrollIntent);
       scrollArea.removeEventListener("touchstart", markTouchStartScrollIntent);
       scrollArea.removeEventListener("touchmove", markTouchMoveScrollIntent);
@@ -1062,6 +1102,7 @@ export function BottomAnchoredScrollBody({
     endPointerScrollIntent,
     handleScroll,
     handleScrollAreaResize,
+    isPointerCoarse,
     markKeyboardScrollIntent,
     markTouchMoveScrollIntent,
     markTouchStartScrollIntent,

--- a/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
+++ b/apps/app/src/components/ui/bottom-anchored-scroll-body.tsx
@@ -284,6 +284,10 @@ export function BottomAnchoredScrollBody({
   const pointerScrollIntentRef = useRef(false);
   const restoreFrameRef = useRef<number | null>(null);
   const restoreFramesRemainingRef = useRef(0);
+  // Set when a settle-tail frame corrected drift against the cached max
+  // offset: the next tail frame then spends the tail's single live
+  // verification read (see queueBottomRestore).
+  const restoreTailLiveReadRef = useRef(false);
   const pendingPrependAnchorRef = useRef<{
     scrollHeight: number;
     scrollTop: number;
@@ -321,6 +325,14 @@ export function BottomAnchoredScrollBody({
   // live geometry — the pre-cache behavior — instead of trusting a frozen
   // value that would classify every position as at-bottom.
   const resizeObserverHasDeliveredRef = useRef(false);
+  // The last box sizes the ResizeObserver reported for the scroll port and
+  // the content wrapper. Together they are the observer's own measurement of
+  // `scrollHeight - clientHeight`, letting the resize path refresh the cache
+  // without a forced layout (see handleScrollAreaResize).
+  const observedScrollGeometryRef = useRef<{
+    scrollAreaClientHeight: number | null;
+    scrollContentHeight: number | null;
+  }>({ scrollAreaClientHeight: null, scrollContentHeight: null });
   const [isAtBottom, setIsAtBottom] = useState(true);
   const initialScrollRestoreRowId = useMemo(() => {
     if (scrollAnchorThreadId === undefined) return null;
@@ -359,6 +371,7 @@ export function BottomAnchoredScrollBody({
     window.cancelAnimationFrame(restoreFrameRef.current);
     restoreFrameRef.current = null;
     restoreFramesRemainingRef.current = 0;
+    restoreTailLiveReadRef.current = false;
   }, []);
 
   // Snap scrollTop back to the bottom if anchoring has let us drift away.
@@ -386,6 +399,22 @@ export function BottomAnchoredScrollBody({
     return true;
   }, [refreshMaxScrollOffset]);
 
+  // The settle-tail variant: runs on the cached max offset so tail frames
+  // don't force layout. Any real size change re-enters through the
+  // ResizeObserver with fresh geometry; what the tail catches is scrollTop
+  // drifting (clamps, anchoring adjustments) while the observed sizes — and
+  // therefore the cache — still hold.
+  const restoreBottomFromCacheOnce = useCallback(() => {
+    const scrollArea = scrollAreaRef.current;
+    if (!scrollArea || !shouldStickToBottomRef.current) return false;
+    const maxScrollOffset = readMaxScrollOffset(scrollArea);
+    if (isScrolledNearBottom(maxScrollOffset, scrollArea.scrollTop)) {
+      return false;
+    }
+    scrollArea.scrollTop = maxScrollOffset;
+    return true;
+  }, [readMaxScrollOffset]);
+
   const queueBottomRestore = useCallback(() => {
     if (!shouldStickToBottomRef.current) return;
     // Restore synchronously in the frame the size change was observed.
@@ -401,12 +430,26 @@ export function BottomAnchoredScrollBody({
     // isn't final in the observed frame.
     restoreBottomOnce();
     restoreFramesRemainingRef.current = BOTTOM_RESTORE_SETTLE_FRAME_COUNT;
+    restoreTailLiveReadRef.current = false;
     if (restoreFrameRef.current !== null) return;
     const runQueuedRestore = () => {
       restoreFrameRef.current = null;
-      if (!restoreBottomOnce()) {
+      // Tail frames reuse the cache: the observed frame just read fresh
+      // geometry, so re-reading it every settle frame only re-forces layout.
+      // A cached correction can itself mean layout moved under the cache, so
+      // it arms exactly one live verification read on the following frame —
+      // bounding the whole tail to a single forced layout.
+      const useLiveRead = restoreTailLiveReadRef.current;
+      restoreTailLiveReadRef.current = false;
+      const restored = useLiveRead
+        ? restoreBottomOnce()
+        : restoreBottomFromCacheOnce();
+      if (!restored) {
         restoreFramesRemainingRef.current = 0;
         return;
+      }
+      if (!useLiveRead) {
+        restoreTailLiveReadRef.current = true;
       }
       restoreFramesRemainingRef.current -= 1;
       if (restoreFramesRemainingRef.current > 0) {
@@ -415,7 +458,7 @@ export function BottomAnchoredScrollBody({
       }
     };
     restoreFrameRef.current = window.requestAnimationFrame(runQueuedRestore);
-  }, [restoreBottomOnce]);
+  }, [restoreBottomOnce, restoreBottomFromCacheOnce]);
 
   const scrollToBottom = useCallback(() => {
     const scrollArea = scrollAreaRef.current;
@@ -805,48 +848,81 @@ export function BottomAnchoredScrollBody({
     return true;
   }, [applyScrollRestore, queueBottomRestore]);
 
-  const handleScrollAreaResize = useCallback(() => {
-    const scrollArea = scrollAreaRef.current;
-    let shrankOntoBottomWhileDetached = false;
-    if (scrollArea) {
-      // The steady-state cache refresh: the observer watches both the scroll
-      // port and the content wrapper, so every legitimate
-      // scrollHeight/clientHeight change passes through here. The first
-      // delivery is also what makes the cache authoritative for hot-path
-      // reads (see resizeObserverHasDeliveredRef).
-      const previousMaxScrollOffset = maxScrollOffsetRef.current;
-      const cacheWasAuthoritative = resizeObserverHasDeliveredRef.current;
-      const maxScrollOffset = refreshMaxScrollOffset(scrollArea);
-      resizeObserverHasDeliveredRef.current = true;
-      shrankOntoBottomWhileDetached =
-        cacheWasAuthoritative &&
-        !shouldStickToBottomRef.current &&
-        maxScrollOffset < previousMaxScrollOffset &&
-        isScrolledNearBottom(maxScrollOffset, scrollArea.scrollTop);
-    }
-    // While a restore is pending, the ResizeObserver is the settle signal; the
-    // bottom-restore is suppressed (stick-to-bottom is false) anyway.
-    if (advancePendingScrollRestore()) return;
-    if (shrankOntoBottomWhileDetached && scrollArea) {
-      // The detached mirror of the attach->detach edge in
-      // syncBottomStateFromScroll: a content shrink (collapsing a long tool
-      // output near the end) clamped a detached viewport onto the new,
-      // smaller maximum. The browser delivered that clamp's scroll event
-      // before this refresh, so the scroll handler classified it against the
-      // stale, larger cache and left the viewport detached. A live read used
-      // to re-attach on that very scroll event; do the same here, against
-      // fresh geometry, so streaming content keeps following the bottom.
-      attachToBottom();
-      writeScrollAnchor(scrollArea);
-    }
-    queueBottomRestore();
-  }, [
-    advancePendingScrollRestore,
-    attachToBottom,
-    queueBottomRestore,
-    refreshMaxScrollOffset,
-    writeScrollAnchor,
-  ]);
+  const handleScrollAreaResize = useCallback(
+    (entries: ResizeObserverEntry[]) => {
+      const scrollArea = scrollAreaRef.current;
+      let shrankOntoBottomWhileDetached = false;
+      if (scrollArea) {
+        // The steady-state cache refresh: the observer watches both the scroll
+        // port and the content wrapper, so every legitimate
+        // scrollHeight/clientHeight change passes through here. The first
+        // delivery is also what makes the cache authoritative for hot-path
+        // reads (see resizeObserverHasDeliveredRef).
+        const previousMaxScrollOffset = maxScrollOffsetRef.current;
+        const cacheWasAuthoritative = resizeObserverHasDeliveredRef.current;
+        // Prefer the observer's own box sizes over a live
+        // scrollHeight/clientHeight read, which forces layout: the scroll
+        // port's content box is its client height (no padding, no horizontal
+        // scrollbar) and the content wrapper's border box is the scroll
+        // height, so the pair the observer just measured is the fresh
+        // geometry. Environments whose observer delivers no entries (test
+        // stubs) keep the live read.
+        const observedGeometry = observedScrollGeometryRef.current;
+        for (const entry of entries) {
+          if (entry.target === scrollArea) {
+            observedGeometry.scrollAreaClientHeight =
+              entry.contentBoxSize[0]?.blockSize ?? entry.contentRect.height;
+          } else if (entry.target === scrollContentRef.current) {
+            observedGeometry.scrollContentHeight =
+              entry.borderBoxSize[0]?.blockSize ?? entry.contentRect.height;
+          }
+        }
+        let maxScrollOffset: number;
+        if (
+          observedGeometry.scrollAreaClientHeight !== null &&
+          observedGeometry.scrollContentHeight !== null
+        ) {
+          maxScrollOffset = Math.max(
+            0,
+            Math.round(observedGeometry.scrollContentHeight) -
+              Math.round(observedGeometry.scrollAreaClientHeight),
+          );
+          maxScrollOffsetRef.current = maxScrollOffset;
+        } else {
+          maxScrollOffset = refreshMaxScrollOffset(scrollArea);
+        }
+        resizeObserverHasDeliveredRef.current = true;
+        shrankOntoBottomWhileDetached =
+          cacheWasAuthoritative &&
+          !shouldStickToBottomRef.current &&
+          maxScrollOffset < previousMaxScrollOffset &&
+          isScrolledNearBottom(maxScrollOffset, scrollArea.scrollTop);
+      }
+      // While a restore is pending, the ResizeObserver is the settle signal; the
+      // bottom-restore is suppressed (stick-to-bottom is false) anyway.
+      if (advancePendingScrollRestore()) return;
+      if (shrankOntoBottomWhileDetached && scrollArea) {
+        // The detached mirror of the attach->detach edge in
+        // syncBottomStateFromScroll: a content shrink (collapsing a long tool
+        // output near the end) clamped a detached viewport onto the new,
+        // smaller maximum. The browser delivered that clamp's scroll event
+        // before this refresh, so the scroll handler classified it against the
+        // stale, larger cache and left the viewport detached. A live read used
+        // to re-attach on that very scroll event; do the same here, against
+        // fresh geometry, so streaming content keeps following the bottom.
+        attachToBottom();
+        writeScrollAnchor(scrollArea);
+      }
+      queueBottomRestore();
+    },
+    [
+      advancePendingScrollRestore,
+      attachToBottom,
+      queueBottomRestore,
+      refreshMaxScrollOffset,
+      writeScrollAnchor,
+    ],
+  );
 
   // Begin restoring the saved scroll position on mount, before the listener
   // effect's `queueBottomRestore()` runs (a useEffect, which runs after layout

--- a/apps/app/src/components/ui/height-transition.test.tsx
+++ b/apps/app/src/components/ui/height-transition.test.tsx
@@ -74,7 +74,48 @@ describe("HeightTransition", () => {
   });
 });
 
+function makeResizeEntry(
+  target: Element,
+  borderBoxBlockSize: number,
+  contentRectHeight: number,
+): ResizeObserverEntry {
+  return {
+    target,
+    contentRect: new DOMRect(0, 0, 200, contentRectHeight),
+    borderBoxSize: [{ blockSize: borderBoxBlockSize, inlineSize: 200 }],
+    contentBoxSize: [{ blockSize: contentRectHeight, inlineSize: 200 }],
+    devicePixelContentBoxSize: [
+      { blockSize: borderBoxBlockSize, inlineSize: 200 },
+    ],
+  };
+}
+
 describe("AutoHeightContainer", () => {
+  it("sizes the wrapper from the observed border box", () => {
+    vi.stubGlobal("ResizeObserver", ResizeObserverStub);
+
+    const view = render(
+      <AutoHeightContainer>
+        <span>Streaming response</span>
+      </AutoHeightContainer>,
+    );
+    const inner = view.getByText("Streaming response").parentElement;
+    const wrapper = inner?.parentElement;
+    const observer = ResizeObserverStub.instances[0];
+    if (!inner || !wrapper || !observer) {
+      throw new Error("AutoHeightContainer did not render");
+    }
+
+    // A padded inner: the border box (offsetHeight's metric, used by the
+    // mount and snap paths) is taller than the content rect. Sizing the
+    // wrapper from the content rect would clip it.
+    act(() => {
+      observer.callback([makeResizeEntry(inner, 120, 112)], observer);
+    });
+
+    expect(wrapper.style.height).toBe("120px");
+  });
+
   it("snap-syncs an authoritative layout revision", () => {
     vi.stubGlobal("ResizeObserver", ResizeObserverStub);
 

--- a/apps/app/src/components/ui/height-transition.tsx
+++ b/apps/app/src/components/ui/height-transition.tsx
@@ -141,6 +141,14 @@ function cancelIntrinsicHeightRestore(
   resizeState.restoreTimerId = null;
 }
 
+// The observer already measured the inner this frame, so reading the entry
+// costs nothing, and the border box is the same metric as the offsetHeight
+// used by the non-observer paths (initial mount, visibility snap) — the two
+// must agree or a padded inner would get clipped by a content-box height.
+function getObservedInnerHeight(entry: ResizeObserverEntry): number {
+  return entry.borderBoxSize[0]?.blockSize ?? entry.contentRect.height;
+}
+
 interface HeightTransitionProps {
   visible: boolean;
   children: ReactNode;
@@ -171,7 +179,7 @@ export function HeightTransition({ visible, children }: HeightTransitionProps) {
     const observer = new ResizeObserver((entries) => {
       const entry = entries[0];
       if (!entry) return;
-      const { width, height } = entry.contentRect;
+      const { width } = entry.contentRect;
       const widthChanged = lastWidth !== null && width !== lastWidth;
       // While a CSS layout animation (e.g. ExpandablePanel's grid expansion)
       // is in flight, the inner is itself animating its size every frame.
@@ -179,10 +187,11 @@ export function HeightTransition({ visible, children }: HeightTransitionProps) {
       // scrollHeight, which the bottom-anchor sentinel then chases.
       const layoutAnimationActive =
         store.get(layoutAnimationInFlightCountAtom) > 0;
-      const snap = widthChanged || pendingVisibilitySnap || layoutAnimationActive;
+      const snap =
+        widthChanged || pendingVisibilitySnap || layoutAnimationActive;
       pendingVisibilitySnap = false;
       lastWidth = width;
-      const nextHeight = visible ? `${height}px` : "0px";
+      const nextHeight = visible ? `${getObservedInnerHeight(entry)}px` : "0px";
       applyHeight(wrapper, nextHeight, snap, snapState);
     });
     observer.observe(inner);
@@ -334,7 +343,7 @@ export function AutoHeightContainer({
     const observer = new ResizeObserver((entries) => {
       const entry = entries[0];
       if (!entry) return;
-      const { width, height } = entry.contentRect;
+      const { width } = entry.contentRect;
       const widthChanged = lastWidth !== null && width !== lastWidth;
       // While a CSS layout animation (e.g. ExpandablePanel's grid expansion)
       // is in flight, the inner is itself animating its size every frame.
@@ -360,7 +369,12 @@ export function AutoHeightContainer({
         deferInitialSettleComplete();
         return;
       }
-      applyHeight(wrapper, `${height}px`, snap, snapState);
+      applyHeight(
+        wrapper,
+        `${getObservedInnerHeight(entry)}px`,
+        snap,
+        snapState,
+      );
       deferInitialSettleComplete();
     });
     observer.observe(inner);


### PR DESCRIPTION
## What was wrong

Two independent audits traced the worst mobile hangs (38.9s/30.7s/28.5s traces on `div[app-layout-content-shell]`) to the same mechanism: on every iOS visual-viewport tick (keyboard animation, URL-bar collapse) the shell hook forced a full-document layout (`document.body.clientHeight`) inside a rAF and rewrote shell `top`/`height` plus the inherited `--bb-shell-height` on an app-root ancestor, invalidating computed style for the entire 2,000–5,200-node tree at animation cadence. Each content-size change then re-entered a second cascade: the scroll body's ResizeObserver refreshed geometry live, the observed frame's bottom restore read again, and each of the three rAF settle-tail frames forced another layout — up to five forced layouts per size change at streaming cadence. Every scroll event also wrote `data-scrollbar-scrolling` (desktop-scrollbar-only CSS) and 100ms anchor samples re-ran `querySelectorAll` over the scroll subtree.

## What changed

- `useMobileVisualViewportHeight.ts`: style writes skipped when a pass recomputes unchanged geometry; `document.body.clientHeight` cached and re-read only on `window.resize`/`orientationchange`/`focusin` (never on visualViewport ticks); `visualViewport.scroll` ticks gated to run only when an override is applied or a keyboard-focusable element is focused. Embedded-browser overrides keep tracking pans; the focus-reveal pan compensation, native-layout early-exit, focusout fast-restore, pinch-zoom guard, and rAF coalescing are unchanged; programmatic focus still triggers one freshly measured pass (new test).
- `bottom-anchored-scroll-body.tsx`: the ResizeObserver path refreshes the cached max offset from the observer's own box sizes when entries are present; settle-tail frames reuse the cache with at most one live verification read after a corrected drift. Coarse pointers skip the scrollbar-attribute write, capture anchors at 250ms with a cached row NodeList invalidated by the ResizeObserver.
- `height-transition.tsx`: observer callbacks size the wrapper from the entry's `borderBoxSize`.

## How you verified

- New tests proven fail-before/pass-after: idempotent-write (`setProperty` spy), containing-block read-count, scroll-tick gating, settle-tail read-count, entry-derived cache, border-box sizing, coarse-pointer trims, cached-NodeList invalidation; a programmatic-focus guard passes in both states by design.
- `bottom-anchored-scroll-body.scroll-preservation.test.tsx` (the #2280/#2300 contract) passes with zero diff.
- `pnpm exec turbo run typecheck --filter=@bb/app` exit 0; full `@bb/app` suite 433 files / 3,352 passed.
- Merged-tree WebKit QA (iPhone 390×844@3, perf fixture DB): long-thread scroll, keyboard open/close via composer tap, no persistent blanking, zero console errors.

> AGENT GENERATED
