### PR TITLE
fix(sidebar): occlude rows below sticky headers

### DIFF
--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -191,10 +191,11 @@
     min-height: var(--bb-sidebar-sticky-tier-height);
     z-index: var(--bb-sidebar-sticky-tier-z-index);
     isolation: isolate;
-    /* A native-vibrancy compositor can treat background-color as translucent.
-       An opaque image layer preserves the same sidebar color outside vibrancy
-       while preventing scrolled rows from painting through a pinned tier. */
+    /* Native vibrancy can make a sidebar paint translucent. The image keeps
+       opaque themes unchanged, and the blur makes rows beneath a translucent
+       tier unreadable instead of colliding with its label. */
     background-image: linear-gradient(var(--sidebar), var(--sidebar));
+    backdrop-filter: blur(16px);
   }
 
   [data-sidebar-sticky-stack] [data-sidebar-sticky-tier]::before,
@@ -207,6 +208,7 @@
     pointer-events: none;
     background-color: var(--sidebar);
     background-image: linear-gradient(var(--sidebar), var(--sidebar));
+    backdrop-filter: blur(16px);
   }
 
   [data-sidebar-sticky-stack] [data-sidebar-sticky-tier]::before {

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -191,6 +191,10 @@
     min-height: var(--bb-sidebar-sticky-tier-height);
     z-index: var(--bb-sidebar-sticky-tier-z-index);
     isolation: isolate;
+    /* A native-vibrancy compositor can treat background-color as translucent.
+       An opaque image layer preserves the same sidebar color outside vibrancy
+       while preventing scrolled rows from painting through a pinned tier. */
+    background-image: linear-gradient(var(--sidebar), var(--sidebar));
   }
 
   [data-sidebar-sticky-stack] [data-sidebar-sticky-tier]::before,
@@ -202,6 +206,7 @@
     z-index: -1;
     pointer-events: none;
     background-color: var(--sidebar);
+    background-image: linear-gradient(var(--sidebar), var(--sidebar));
   }
 
   [data-sidebar-sticky-stack] [data-sidebar-sticky-tier]::before {

--- a/apps/app/src/components/ui/theme.css
+++ b/apps/app/src/components/ui/theme.css
@@ -192,10 +192,9 @@
     z-index: var(--bb-sidebar-sticky-tier-z-index);
     isolation: isolate;
     /* Native vibrancy can make a sidebar paint translucent. The image keeps
-       opaque themes unchanged, and the blur makes rows beneath a translucent
-       tier unreadable instead of colliding with its label. */
+       opaque themes unchanged. The shield below blurs rows beneath a
+       translucent tier instead of letting them collide with its label. */
     background-image: linear-gradient(var(--sidebar), var(--sidebar));
-    backdrop-filter: blur(16px);
   }
 
   [data-sidebar-sticky-stack] [data-sidebar-sticky-tier]::before,
@@ -212,8 +211,9 @@
   }
 
   [data-sidebar-sticky-stack] [data-sidebar-sticky-tier]::before {
-    bottom: 100%;
-    height: var(--bb-sidebar-sticky-tier-shield-top-height, 0);
+    top: calc(-1 * var(--bb-sidebar-sticky-tier-shield-top-height, 0));
+    bottom: auto;
+    height: calc(100% + var(--bb-sidebar-sticky-tier-shield-top-height, 0));
   }
 
   [data-sidebar-sticky-stack] [data-sidebar-sticky-tier]::after {

--- a/apps/app/src/components/ui/theme.test.ts
+++ b/apps/app/src/components/ui/theme.test.ts
@@ -141,7 +141,19 @@ describe("theme.css neutral ramp", () => {
     expect(rule).toContain(
       "background-image: linear-gradient(var(--sidebar), var(--sidebar));",
     );
-    expect(rule).toContain("backdrop-filter: blur(16px);");
+    expect(rule).not.toContain("backdrop-filter");
+
+    const shieldRule = css.match(
+      /\[data-sidebar-sticky-stack\] \[data-sidebar-sticky-tier\]::before,\s*\[data-sidebar-sticky-stack\] \[data-sidebar-sticky-tier\]::after\s*\{([^}]*)\}/s,
+    )?.[1];
+    expect(shieldRule).toContain("backdrop-filter: blur(16px);");
+
+    const topShieldRule = css.match(
+      /\[data-sidebar-sticky-stack\] \[data-sidebar-sticky-tier\]::before\s*\{([^}]*)\}/s,
+    )?.[1];
+    expect(topShieldRule).toContain(
+      "100% + var(--bb-sidebar-sticky-tier-shield-top-height, 0)",
+    );
   });
 
   it("backs selected sticky sidebar rows with an opaque sidebar layer", () => {

--- a/apps/app/src/components/ui/theme.test.ts
+++ b/apps/app/src/components/ui/theme.test.ts
@@ -133,6 +133,16 @@ function contrastRatio(foreground: OklchColor, background: OklchColor): number {
 }
 
 describe("theme.css neutral ramp", () => {
+  it("backs every sticky sidebar tier with an opaque sidebar layer", () => {
+    const rule = css.match(
+      /\[data-sidebar-sticky-stack\] \[data-sidebar-sticky-tier\]\s*\{([^}]*)\}/s,
+    )?.[1];
+
+    expect(rule).toContain(
+      "background-image: linear-gradient(var(--sidebar), var(--sidebar));",
+    );
+  });
+
   it("backs selected sticky sidebar rows with an opaque sidebar layer", () => {
     const rule = css.match(
       /\[data-sidebar-sticky-tier\]\.bb-sidebar-selected-row\s*\{([^}]*)\}/s,

--- a/apps/app/src/components/ui/theme.test.ts
+++ b/apps/app/src/components/ui/theme.test.ts
@@ -133,7 +133,7 @@ function contrastRatio(foreground: OklchColor, background: OklchColor): number {
 }
 
 describe("theme.css neutral ramp", () => {
-  it("backs every sticky sidebar tier with an opaque sidebar layer", () => {
+  it("prevents rows from reading through every sticky sidebar tier", () => {
     const rule = css.match(
       /\[data-sidebar-sticky-stack\] \[data-sidebar-sticky-tier\]\s*\{([^}]*)\}/s,
     )?.[1];
@@ -141,6 +141,7 @@ describe("theme.css neutral ramp", () => {
     expect(rule).toContain(
       "background-image: linear-gradient(var(--sidebar), var(--sidebar));",
     );
+    expect(rule).toContain("backdrop-filter: blur(16px);");
   });
 
   it("backs selected sticky sidebar rows with an opaque sidebar layer", () => {


### PR DESCRIPTION
## What was wrong

Pinned sidebar tiers relied on `bg-sidebar`. When a sidebar is transparent—such as under macOS vibrancy—rows scrolling beneath a pinned section label remain readable through it and collide with the label.

## What changed

`SidebarStickyTier` now paints the existing sidebar color as a gradient backdrop and applies the blur only to its bounded shield layers. The opaque sidebar result is unchanged; a transparent sidebar now composites the rows behind the pinned tier so their text cannot remain readable through the label. The closest theme regression test locks down that tier/shield behavior.

## How you verified

- `pnpm exec turbo run test --filter=@bb/app --force -- src/components/ui/theme.test.ts` — passed (30 tests).
- `pnpm exec turbo run typecheck --filter=@bb/app --force` — passed.
- `pnpm exec turbo run lint --force` — passed with 0 errors (181 pre-existing warnings).
- `pnpm exec prettier --check apps/app/src/components/ui/theme.css apps/app/src/components/ui/theme.test.ts` and `git diff --check` — passed.
- `pnpm exec turbo run typecheck --force` was run twice from an idle workspace; both remained silent in unrelated package `tsc --noEmit` tasks for roughly five minutes and were stopped without an error result. This full-workspace check remains a verification gap.
- Branch web app visual QA in Chrome for Testing 152.0.7977.54: merge base and PR head used identical seeded data, route, 1440x900 viewport, dark transparent-sidebar theme, chronological sidebar mode, Handoff section, and `scrollTop=226`. The base shows the row title through the pinned label; the PR head does not. The same pinned-state check also passed in the light transparent-sidebar theme. An opaque `--sidebar` fully covers the blur layer, preserving the non-vibrancy appearance.
- Safari could not be driven: this host has Safari Remote Automation disabled in Developer settings. This is a browser-coverage gap.

### Before — `origin/main` (`42d2c1bec2e9830bd8e2b8f5f355ebffda37bded`)

Transparent dark sidebar; the scrolling row title is legible through and overlaps the pinned `Handoff` label.

![Before: pinned Handoff label overlapped by a scrolling thread row](https://github.com/user-attachments/assets/d8b78a5f-1b6e-4bde-b49d-fb902064f035)

### After — PR head (`3a8820e6dec946bd08b23a0f4e382a25af65301b`)

Same fixture, route, viewport, theme, and scroll position; the pinned label fully occludes the row beneath while ordinary rows remain visible below it.

![After: pinned Handoff label cleanly occludes scrolling rows](https://github.com/user-attachments/assets/7fa26d14-c278-46fc-84d5-d9098fb2e2e2)

## Fixes

No issue filed.

BB-Thread-ID: thr_bfzv8g5h3s

> AGENT GENERATED
