### PR TITLE
Make composer background-task rows clickable

### DIFF
--- a/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.test.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.test.tsx
@@ -116,7 +116,9 @@ describe("ThreadBackgroundCommandsCard", () => {
     );
 
     const card = screen.getByRole("region", { name: "Background commands" });
-    expect(screen.queryByRole("button")).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Running 1 background command" }),
+    ).toBeNull();
 
     reportCardWidth(card, 320);
 
@@ -187,12 +189,254 @@ describe("ThreadBackgroundCommandsCard", () => {
       </CompactViewportOverrideProvider>,
     );
 
-    const item = screen.getByLabelText(
-      `Background agent: ${description} · Model haiku`,
-    );
+    const item = screen.getByRole("button", {
+      name: `Background agent: ${description} · Model haiku`,
+    });
     expect(item.textContent).toContain("Running background agent:");
     expect(item.textContent).toContain(description);
     expect(screen.getByTitle("Model: haiku").textContent).toBe("haiku");
-    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  describe("row click-through", () => {
+    it("scrolls to and flashes the row when it is already rendered in the main timeline", () => {
+      const scrollIntoView = vi.spyOn(Element.prototype, "scrollIntoView");
+      const description = "Sleep 45 then echo done";
+      const row = backgroundCommandRow({
+        id: "wf-1",
+        description,
+        status: "pending",
+        taskStatus: "running",
+      });
+
+      render(
+        <>
+          <div data-timeline-row-id="wf-1">Main timeline row</div>
+          <ThreadBackgroundCommandsCard
+            commands={[row]}
+            isExpanded={false}
+            onToggle={() => {}}
+          />
+        </>,
+      );
+
+      const target = document.querySelector('[data-timeline-row-id="wf-1"]');
+      expect(target).not.toBeNull();
+
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: `Background command: ${description}`,
+        }),
+      );
+
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "center" });
+      expect(target?.classList.contains("bb-search-flash")).toBe(true);
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+
+    it("opens a detail drawer when the row is not rendered in the main timeline", () => {
+      const scrollIntoView = vi.spyOn(Element.prototype, "scrollIntoView");
+      const description = "Sleep 45 then echo done";
+      const row = backgroundCommandRow({
+        id: "wf-1",
+        description,
+        status: "pending",
+        taskStatus: "running",
+      });
+
+      render(
+        <ThreadBackgroundCommandsCard
+          commands={[row]}
+          isExpanded={false}
+          onToggle={() => {}}
+        />,
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: `Background command: ${description}`,
+        }),
+      );
+
+      expect(scrollIntoView).not.toHaveBeenCalled();
+      const dialog = screen.getByRole("dialog");
+      expect(dialog.textContent).toContain(description);
+    });
+
+    it("targets the clicked row's own id, not always the primary row's, when expanded", () => {
+      const primaryDescription = "Poll CI batching head";
+      const secondaryDescription = "Sleep 45 then echo done";
+      const primary = backgroundCommandRow({
+        id: "wf-primary",
+        description: primaryDescription,
+        status: "pending",
+        taskStatus: "running",
+      });
+      const secondary = backgroundCommandRow({
+        id: "wf-secondary",
+        description: secondaryDescription,
+        status: "pending",
+        taskStatus: "running",
+      });
+
+      render(
+        <>
+          <div data-timeline-row-id="wf-secondary">Main timeline row</div>
+          <ThreadBackgroundCommandsCard
+            commands={[primary, secondary]}
+            isExpanded
+            onToggle={() => {}}
+          />
+        </>,
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: `Background command: ${secondaryDescription}`,
+        }),
+      );
+
+      expect(screen.queryByRole("dialog")).toBeNull();
+      const target = document.querySelector(
+        '[data-timeline-row-id="wf-secondary"]',
+      );
+      expect(target?.classList.contains("bb-search-flash")).toBe(true);
+    });
+
+    it("does not navigate when the header toggle is clicked", () => {
+      const scrollIntoView = vi.spyOn(Element.prototype, "scrollIntoView");
+      const description = "Sleep 45 then echo done";
+      const primary = backgroundCommandRow({
+        id: "wf-1",
+        description,
+        status: "pending",
+        taskStatus: "running",
+      });
+      const secondary = backgroundCommandRow({
+        id: "wf-2",
+        description: "Another background command",
+        status: "pending",
+        taskStatus: "running",
+      });
+
+      render(
+        <ThreadBackgroundCommandsCard
+          commands={[primary, secondary]}
+          isExpanded={false}
+          onToggle={() => {}}
+        />,
+      );
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /^Background commands:/ }),
+      );
+
+      expect(scrollIntoView).not.toHaveBeenCalled();
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+
+    it("keeps the drawer in sync when the row's own data updates while it is open", () => {
+      function Wrapper() {
+        const [row, setRow] = useState(
+          backgroundCommandRow({
+            id: "wf-1",
+            description: "Sleep 45 then echo done",
+            status: "pending",
+            taskStatus: "running",
+          }),
+        );
+        return (
+          <>
+            <button
+              type="button"
+              onClick={() =>
+                setRow(
+                  backgroundCommandRow({
+                    id: "wf-1",
+                    description: "Sleep 45 then echo done",
+                    status: "completed",
+                    taskStatus: "completed",
+                    summary: "Background command finished, exit 0",
+                  }),
+                )
+              }
+            >
+              simulate update
+            </button>
+            <ThreadBackgroundCommandsCard
+              commands={[row]}
+              isExpanded={false}
+              onToggle={() => {}}
+            />
+          </>
+        );
+      }
+
+      render(<Wrapper />);
+
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: "Background command: Sleep 45 then echo done",
+        }),
+      );
+      expect(screen.getByRole("dialog").textContent).not.toContain(
+        "finished, exit 0",
+      );
+
+      fireEvent.click(screen.getByText("simulate update"));
+
+      expect(screen.getByRole("dialog").textContent).toContain(
+        "finished, exit 0",
+      );
+    });
+
+    it("keeps showing the row's last known data if it drops out of the commands list while the drawer is open", () => {
+      const row = backgroundCommandRow({
+        id: "wf-1",
+        description: "Sleep 45 then echo done",
+        status: "pending",
+        taskStatus: "running",
+      });
+      const other = backgroundCommandRow({
+        id: "wf-2",
+        description: "Another background command",
+        status: "pending",
+        taskStatus: "running",
+      });
+
+      function Wrapper() {
+        // `other` stays primary throughout so the card never unmounts;
+        // `row` sits in the expanded list, individually clickable.
+        const [commands, setCommands] = useState([other, row]);
+        return (
+          <>
+            <button type="button" onClick={() => setCommands([other])}>
+              drop wf-1
+            </button>
+            <ThreadBackgroundCommandsCard
+              commands={commands}
+              isExpanded
+              onToggle={() => {}}
+            />
+          </>
+        );
+      }
+
+      render(<Wrapper />);
+
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: "Background command: Sleep 45 then echo done",
+        }),
+      );
+      expect(screen.getByRole("dialog").textContent).toContain(
+        "Sleep 45 then echo done",
+      );
+
+      fireEvent.click(screen.getByText("drop wf-1"));
+
+      expect(screen.getByRole("dialog").textContent).toContain(
+        "Sleep 45 then echo done",
+      );
+    });
   });
 });

--- a/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
+++ b/apps/app/src/components/promptbox/banner/ThreadBackgroundCommandsCard.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { isBackgroundAgentTaskType } from "@bb/domain";
 import type { TimelineWorkflowWorkRow } from "@bb/server-contract";
 import { durationToCompactString } from "@bb/thread-view";
@@ -8,9 +8,13 @@ import {
   PROMPT_STACK_CARD_ROW_HEIGHT,
   PromptStackCard,
 } from "@/components/promptbox/banner/PromptStackCard";
+import { useBottomAnchoredScroll } from "@/components/ui/bottom-anchored-scroll-body";
+import { WorkflowWorkRowBody } from "@/components/thread/timeline/WorkflowWorkRowBody";
+import { revealRenderedTimelineRow } from "@/components/thread/timeline/timelineRowNavigation";
 import { useSecondTick } from "@/hooks/useSecondTick";
 import { Icon } from "@bb/shared-ui/icon";
 import { useIsCompactViewport } from "@bb/shared-ui/hooks/use-compact-viewport";
+import { PersistentResponsiveDrawerShell } from "@bb/shared-ui/responsive-overlay";
 import {
   activityIconClass,
   activityMetaClass,
@@ -187,6 +191,42 @@ function BackgroundActivitySummary({
   );
 }
 
+/**
+ * Detail drawer body for a background activity row that isn't rendered in
+ * the main timeline yet (its spawning turn was already summarized away —
+ * the common case for a task that outlives the turn that spawned it).
+ * Reuses the same row-level data the card already has plus
+ * `WorkflowWorkRowBody`, the renderer the main timeline itself uses for
+ * `workKind: "workflow"` rows, so a row with richer progress (e.g. a
+ * background agent) still shows it.
+ */
+function BackgroundActivityDetailBody({
+  row,
+}: {
+  row: TimelineWorkflowWorkRow;
+}) {
+  const display = backgroundActivityDisplay(row);
+  const model = backgroundActivityModel(row);
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-4 pb-4">
+      <div className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+        <Icon
+          name={display.icon}
+          className="size-4 shrink-0"
+          aria-hidden="true"
+        />
+        <span className="min-w-0 flex-1 truncate">{row.description}</span>
+        {model ? (
+          <span className="shrink-0 whitespace-nowrap font-mono text-2xs text-subtle-foreground">
+            {model}
+          </span>
+        ) : null}
+      </div>
+      <WorkflowWorkRowBody row={row} />
+    </div>
+  );
+}
+
 interface ThreadBackgroundCommandsCardProps {
   commands: TimelineWorkflowWorkRow[];
   isExpanded: boolean;
@@ -210,6 +250,34 @@ export function ThreadBackgroundCommandsCard({
   const isCompactViewport = useIsCompactViewport();
   const cardRef = useRef<HTMLElement>(null!);
   const [isCompactCard, setIsCompactCard] = useState<boolean | null>(null);
+  const bottomAnchor = useBottomAnchoredScroll();
+  const [detailRowId, setDetailRowId] = useState<string | null>(null);
+  const [isDetailOpen, setIsDetailOpen] = useState(false);
+  const liveDetailRow =
+    detailRowId === null
+      ? null
+      : (commands.find((row) => row.id === detailRowId) ?? null);
+  // Keeps showing the row's last known data once it drops out of `commands`
+  // (e.g. the task completed) so the drawer's own close animation has
+  // content to show instead of going blank mid-transition.
+  const [lastKnownDetailRow, setLastKnownDetailRow] =
+    useState<TimelineWorkflowWorkRow | null>(null);
+  useEffect(() => {
+    if (liveDetailRow !== null) {
+      setLastKnownDetailRow(liveDetailRow);
+    }
+  }, [liveDetailRow]);
+  const detailRow = liveDetailRow ?? lastKnownDetailRow;
+  const activateRow = useCallback(
+    (row: TimelineWorkflowWorkRow) => {
+      if (revealRenderedTimelineRow(row.id, bottomAnchor)) {
+        return;
+      }
+      setDetailRowId(row.id);
+      setIsDetailOpen(true);
+    },
+    [bottomAnchor],
+  );
   useResizeObserver({
     ref: cardRef,
     box: "border-box",
@@ -235,134 +303,157 @@ export function ThreadBackgroundCommandsCard({
   const groupLabel = backgroundActivityGroupLabel(commands);
 
   return (
-    <PromptStackCard
-      rootRef={cardRef}
-      ariaLabel={groupLabel}
-      className="overflow-hidden"
-      style={{ minHeight: PROMPT_STACK_CARD_ROW_HEIGHT }}
-    >
-      <div className="flex items-center">
-        {canExpand ? (
-          <button
-            type="button"
-            id={TOGGLE_ID}
-            aria-expanded={isExpanded}
-            aria-controls={BODY_ID}
-            aria-label={
-              useCompactSummary
-                ? compactLabel
-                : backgroundActivityAriaLabel(primary, groupLabel)
-            }
-            onClick={onToggle}
-            className={activityRowClass(
-              "active",
-              "flex min-h-8 w-full min-w-0 cursor-pointer items-center gap-1.5 rounded-none px-3 py-1.5 text-xs text-foreground transition-colors hover:bg-background/80",
-            )}
-          >
-            <Icon
-              name={primaryDisplay.icon}
-              className={activityIconClass("active", "size-3.5 shrink-0")}
-              aria-hidden="true"
-            />
-            {useCompactSummary ? (
-              <span className="min-w-0 flex-1 truncate text-left font-medium">
-                {compactLabel}
-              </span>
-            ) : (
-              <>
-                <BackgroundActivitySummary
-                  row={primary}
-                  showDuration={false}
-                  active
-                />
-                <span className={activityMetaClass("active", "shrink-0")}>
-                  +{others.length} more
-                </span>
-              </>
-            )}
-            <Icon
-              name="ChevronDown"
-              className={cn(
-                activityIconClass("active"),
-                "size-3.5 shrink-0 transition-transform duration-200",
-                isExpanded && "rotate-180",
+    <>
+      <PromptStackCard
+        rootRef={cardRef}
+        ariaLabel={groupLabel}
+        className="overflow-hidden"
+        style={{ minHeight: PROMPT_STACK_CARD_ROW_HEIGHT }}
+      >
+        <div className="flex items-center">
+          {canExpand ? (
+            <button
+              type="button"
+              id={TOGGLE_ID}
+              aria-expanded={isExpanded}
+              aria-controls={BODY_ID}
+              aria-label={
+                useCompactSummary
+                  ? compactLabel
+                  : backgroundActivityAriaLabel(primary, groupLabel)
+              }
+              onClick={onToggle}
+              className={activityRowClass(
+                "active",
+                "flex min-h-8 w-full min-w-0 cursor-pointer items-center gap-1.5 rounded-none px-3 py-1.5 text-xs text-foreground transition-colors hover:bg-background/80",
               )}
-              aria-hidden="true"
-            />
-          </button>
-        ) : (
-          <div
-            className={activityRowClass(
-              "active",
-              "flex min-h-8 w-full min-w-0 cursor-default items-center gap-1.5 rounded-none px-3 py-1.5 text-xs text-foreground",
-            )}
-            aria-label={backgroundActivityAriaLabel(primary)}
-          >
-            <Icon
-              name={primaryDisplay.icon}
-              className={activityIconClass("active", "size-3.5 shrink-0")}
-              aria-hidden="true"
-            />
-            <BackgroundActivitySummary row={primary} showDuration active />
-          </div>
-        )}
-      </div>
-      {canExpand ? (
-        <AnimatedBody
-          id={BODY_ID}
-          labelledBy={TOGGLE_ID}
-          isExpanded={isExpanded}
-          collapsedBorder="none"
-        >
-          <div className="flex flex-col gap-0.5 py-1">
-            {expandedRows.map((row) => {
-              const display = backgroundActivityDisplay(row);
-              const model = backgroundActivityModel(row);
-              return (
-                <div
-                  key={row.id}
-                  // px-3 matches the full-width header row's padding so the
-                  // icon lines up under the header icon.
-                  className={cn(
-                    "flex min-w-0 gap-1.5 px-3 py-0.5 text-xs",
-                    useCompactSummary ? "items-start" : "items-center",
-                  )}
-                >
-                  <Icon
-                    name={display.icon}
-                    className="size-3.5 shrink-0 text-muted-foreground/60"
-                    aria-hidden="true"
+            >
+              <Icon
+                name={primaryDisplay.icon}
+                className={activityIconClass("active", "size-3.5 shrink-0")}
+                aria-hidden="true"
+              />
+              {useCompactSummary ? (
+                <span className="min-w-0 flex-1 truncate text-left font-medium">
+                  {compactLabel}
+                </span>
+              ) : (
+                <>
+                  <BackgroundActivitySummary
+                    row={primary}
+                    showDuration={false}
+                    active
                   />
-                  <span
+                  <span className={activityMetaClass("active", "shrink-0")}>
+                    +{others.length} more
+                  </span>
+                </>
+              )}
+              <Icon
+                name="ChevronDown"
+                className={cn(
+                  activityIconClass("active"),
+                  "size-3.5 shrink-0 transition-transform duration-200",
+                  isExpanded && "rotate-180",
+                )}
+                aria-hidden="true"
+              />
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => activateRow(primary)}
+              className={activityRowClass(
+                "active",
+                "flex min-h-8 w-full min-w-0 items-center gap-1.5 rounded-none px-3 py-1.5 text-left text-xs text-foreground transition-colors hover:bg-background/80",
+              )}
+              aria-label={backgroundActivityAriaLabel(primary)}
+            >
+              <Icon
+                name={primaryDisplay.icon}
+                className={activityIconClass("active", "size-3.5 shrink-0")}
+                aria-hidden="true"
+              />
+              <BackgroundActivitySummary row={primary} showDuration active />
+            </button>
+          )}
+        </div>
+        {canExpand ? (
+          <AnimatedBody
+            id={BODY_ID}
+            labelledBy={TOGGLE_ID}
+            isExpanded={isExpanded}
+            collapsedBorder="none"
+          >
+            <div className="flex flex-col gap-0.5 py-1">
+              {expandedRows.map((row) => {
+                const display = backgroundActivityDisplay(row);
+                const model = backgroundActivityModel(row);
+                return (
+                  <button
+                    key={row.id}
+                    type="button"
+                    onClick={() => activateRow(row)}
+                    aria-label={backgroundActivityAriaLabel(row)}
+                    // px-3 matches the full-width header row's padding so the
+                    // icon lines up under the header icon.
                     className={cn(
-                      "min-w-0 flex-1 text-muted-foreground",
-                      useCompactSummary
-                        ? "whitespace-normal [overflow-wrap:anywhere]"
-                        : "truncate",
+                      "flex min-w-0 gap-1.5 px-3 py-0.5 text-left text-xs transition-colors hover:bg-background/80",
+                      useCompactSummary ? "items-start" : "items-center",
                     )}
-                    title={row.description}
                   >
-                    {row.description}
-                  </span>
-                  {model ? (
+                    <Icon
+                      name={display.icon}
+                      className="size-3.5 shrink-0 text-muted-foreground/60"
+                      aria-hidden="true"
+                    />
                     <span
-                      className="shrink-0 whitespace-nowrap font-mono text-2xs text-subtle-foreground"
-                      title={`Model: ${model}`}
+                      className={cn(
+                        "min-w-0 flex-1 text-muted-foreground",
+                        useCompactSummary
+                          ? "whitespace-normal [overflow-wrap:anywhere]"
+                          : "truncate",
+                      )}
+                      title={row.description}
                     >
-                      {model}
+                      {row.description}
                     </span>
-                  ) : null}
-                  <span className="shrink-0 whitespace-nowrap text-subtle-foreground">
-                    {isExpanded ? (
-                      <BackgroundActivityDuration startedAt={row.startedAt} />
+                    {model ? (
+                      <span
+                        className="shrink-0 whitespace-nowrap font-mono text-2xs text-subtle-foreground"
+                        title={`Model: ${model}`}
+                      >
+                        {model}
+                      </span>
                     ) : null}
-                  </span>
-                </div>
-              );
-            })}
-          </div>
-        </AnimatedBody>
-      ) : null}
-    </PromptStackCard>
+                    <span className="shrink-0 whitespace-nowrap text-subtle-foreground">
+                      {isExpanded ? (
+                        <BackgroundActivityDuration
+                          startedAt={row.startedAt}
+                        />
+                      ) : null}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </AnimatedBody>
+        ) : null}
+      </PromptStackCard>
+      <PersistentResponsiveDrawerShell
+        open={isDetailOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setIsDetailOpen(false);
+          }
+        }}
+        srLabel={
+          detailRow ? backgroundActivityAriaLabel(detailRow) : undefined
+        }
+        contentClassName="max-h-[70dvh]"
+      >
+        {detailRow ? <BackgroundActivityDetailBody row={detailRow} /> : null}
+      </PersistentResponsiveDrawerShell>
+    </>
   );
 }

--- a/apps/app/src/components/thread/timeline/timelineRowNavigation.ts
+++ b/apps/app/src/components/thread/timeline/timelineRowNavigation.ts
@@ -1,0 +1,58 @@
+import type { BottomAnchorContextValue } from "@/components/ui/bottom-anchored-scroll-body";
+
+export const TIMELINE_ROW_FLASH_CLASS_NAME = "bb-search-flash";
+const TIMELINE_ROW_FLASH_DURATION_MS = 1700;
+
+export function escapeTimelineRowId(rowId: string): string {
+  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+    return CSS.escape(rowId);
+  }
+  return rowId.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+}
+
+/** Finds a row already rendered in the main timeline, if any. */
+export function findRenderedTimelineRowElement(
+  rowId: string,
+): HTMLElement | null {
+  const selector = `[data-timeline-row-id="${escapeTimelineRowId(rowId)}"]`;
+  return document.querySelector<HTMLElement>(selector);
+}
+
+/** Briefly highlights a timeline row element so a jump-to-it action is legible. */
+export function flashTimelineRowElement(element: HTMLElement): void {
+  element.classList.add(TIMELINE_ROW_FLASH_CLASS_NAME);
+  window.setTimeout(() => {
+    element.classList.remove(TIMELINE_ROW_FLASH_CLASS_NAME);
+  }, TIMELINE_ROW_FLASH_DURATION_MS);
+}
+
+export function scrollTimelineRowElementIntoView(
+  element: HTMLElement,
+  bottomAnchor: BottomAnchorContextValue | null,
+  options: ScrollIntoViewOptions,
+): void {
+  if (bottomAnchor !== null) {
+    // scrollElementIntoView suppresses stick-to-bottom so this wins over the
+    // default open-at-bottom behavior.
+    bottomAnchor.scrollElementIntoView({ element, options });
+  } else {
+    element.scrollIntoView(options);
+  }
+}
+
+/**
+ * Scrolls to and flashes a row already rendered in the main timeline.
+ * Returns whether a matching row was found.
+ */
+export function revealRenderedTimelineRow(
+  rowId: string,
+  bottomAnchor: BottomAnchorContextValue | null,
+): boolean {
+  const element = findRenderedTimelineRowElement(rowId);
+  if (element === null) {
+    return false;
+  }
+  scrollTimelineRowElementIntoView(element, bottomAnchor, { block: "center" });
+  flashTimelineRowElement(element);
+  return true;
+}

--- a/apps/app/src/components/thread/timeline/useScrollToSearchedMessage.ts
+++ b/apps/app/src/components/thread/timeline/useScrollToSearchedMessage.ts
@@ -1,6 +1,11 @@
 import { useEffect, useRef } from "react";
 import { useLocation } from "react-router-dom";
 import { useBottomAnchoredScroll } from "@/components/ui/bottom-anchored-scroll-body.js";
+import {
+  escapeTimelineRowId,
+  flashTimelineRowElement,
+  scrollTimelineRowElementIntoView,
+} from "./timelineRowNavigation.js";
 
 // Structural subset of a timeline view row — every row carries an event-sequence
 // range, which is how we map a searched message's sequence to its rendered row.
@@ -28,16 +33,7 @@ interface SeqRange {
   max: number;
 }
 
-const FLASH_CLASS_NAME = "bb-search-flash";
-const FLASH_DURATION_MS = 1700;
 const POST_WINDOW_SETTLE_REVEAL_MS = 800;
-
-function escapeTimelineRowId(rowId: string): string {
-  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
-    return CSS.escape(rowId);
-  }
-  return rowId.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
-}
 
 function containsSeq(row: SeqAnchoredRow, seq: number): boolean {
   return row.sourceSeqStart <= seq && seq <= row.sourceSeqEnd;
@@ -285,22 +281,12 @@ export function useScrollToSearchedMessage(
       if (element === null) {
         return;
       }
-      if (bottomAnchor !== null) {
-        // scrollElementIntoView suppresses stick-to-bottom so this wins over the
-        // default open-at-bottom behavior.
-        bottomAnchor.scrollElementIntoView({
-          element,
-          options: { block: "center" },
-        });
-      } else {
-        element.scrollIntoView({ block: "center" });
-      }
+      scrollTimelineRowElementIntoView(element, bottomAnchor, {
+        block: "center",
+      });
       if (!flashed) {
         flashed = true;
-        element.classList.add(FLASH_CLASS_NAME);
-        window.setTimeout(() => {
-          element.classList.remove(FLASH_CLASS_NAME);
-        }, FLASH_DURATION_MS);
+        flashTimelineRowElement(element);
       }
     };
 


### PR DESCRIPTION
## What was wrong

The composer's "Running background agent/command" status card rows had no click handler, unlike the main timeline's expandable delegation rows, so there was no way to jump to a background task's context from the card.

## What changed

- `ThreadBackgroundCommandsCard.tsx`: every row (the single non-expandable summary row and each row in the expanded list) is now a real button. On click, it scrolls to and flashes the row in the main timeline if it's already rendered there, or opens a bottom drawer with the row's own data otherwise.
- The drawer path is the common one: a background task's row only stays in the main timeline while its spawning turn is still pending. Once that turn completes and gets summarized, the row survives only in the `activeBackgroundCommands`/`activeWorkflows` projection this card reads from, so there's nothing to scroll to.
- The drawer tracks the row by id and re-derives it from `commands` on every render (falling back to the last known data once the row drops out of that list), so it reflects live task progress instead of freezing to whatever the row looked like at click time.
- Extracted the scroll/flash DOM helpers shared with `useScrollToSearchedMessage.ts` into a new `timelineRowNavigation.ts` so both features use the same selector and flash-class logic instead of duplicating it.
- Deviation from the issue: it proposed adding a `timelineRowId` back-reference field to `TimelineWorkflowWorkRow`, on the assumption the row carried no id back to its main-timeline counterpart. That assumption doesn't hold: `row.id` is already built via the same `buildWorkflowWorkRow` helper used for the row that eventually appears in the main timeline, so it's already the right id to look up. No schema change was needed.

## How you verified

- New tests in `ThreadBackgroundCommandsCard.test.tsx` cover both click paths (scroll+flash when rendered, drawer fallback when not), targeting the clicked row's own id when multiple rows are expanded, the header toggle staying navigation-free, and the drawer staying in sync with live row updates (including when the row disappears from `commands` entirely) instead of freezing to a stale snapshot.
- `pnpm exec turbo run test --filter=@bb/app` and `pnpm exec turbo run typecheck --filter=@bb/app`.
- Manually reproduced the bug against `main` first: spawned a real background task on a `claude-code` thread and confirmed the card row did nothing on click, and that no `[data-timeline-row-id]` element existed for it while it was running.
- Verified the drawer path live against this branch's dev server: opened the drawer on a running task, confirmed it showed the correct live description, and confirmed it didn't go blank or error once the underlying task completed.
- Could **not** verify the scroll-to-rendered-row path live. While investigating why, I found that for the `claude-code` provider, a backgrounded shell command's completion never projects into a `workKind: "workflow"` row in the main timeline at all (running or completed) -- it falls into a generic "Unhandled Claude Code event" operation row instead. That's [#2224](https://github.com/get-bb/bb/issues/2224) (`background_tasks_changed` hits `assertNever`), a pre-existing gap this PR doesn't touch; I added the UI-side evidence there. The scroll path itself is still covered at the unit level, using the same `data-timeline-row-id` selector the app uses in production.

Fixes #2315

> AGENT GENERATED
