### PR TITLE
Add per-pane new thread draft slots

### DIFF
--- a/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
+++ b/apps/app/src/components/plugin/PluginNewThreadComposer.test.tsx
@@ -771,13 +771,14 @@ describe("PluginNewThreadComposer seeding", () => {
   });
 
   it("renders the root composer with a loading project picker before the sidebar bootstrap settles", () => {
+    const draftSlotId = "root-loading-project-slot";
     mocks.sidebarNavigationSettled = false;
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
     window.localStorage.setItem("bb.root-compose.project-id", "proj_1");
     const router = createMemoryRouter(
-      [{ path: "/", element: <RootComposeView /> }],
+      [{ path: "/", element: <RootComposeView draftSlotId={draftSlotId} /> }],
       { initialEntries: ["/"] },
     );
     render(
@@ -864,12 +865,13 @@ describe("PluginNewThreadComposer seeding", () => {
   });
 
   it("enables the project picker and prompt-history query once the sidebar bootstrap settles", () => {
+    const draftSlotId = "root-settled-project-slot";
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
     window.localStorage.setItem("bb.root-compose.project-id", "proj_1");
     const router = createMemoryRouter(
-      [{ path: "/", element: <RootComposeView /> }],
+      [{ path: "/", element: <RootComposeView draftSlotId={draftSlotId} /> }],
       { initialEntries: ["/"] },
     );
     render(
@@ -885,11 +887,16 @@ describe("PluginNewThreadComposer seeding", () => {
   });
 
   it("keeps an unrelated draft attachment out of a RootComposeView handoff", async () => {
+    const draftSlotId = "root-handoff-slot";
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
     window.localStorage.setItem("bb.root-compose.project-id", "proj_1");
-    getPromptDraftAccessor({ kind: "new-thread" }).setDraft({
+    getPromptDraftAccessor({
+      kind: "new-thread",
+      slotId: draftSlotId,
+      destination: { projectId: "proj_1", sectionId: null },
+    }).setDraft({
       text: "unrelated draft",
       mentions: [],
       attachments: [
@@ -903,7 +910,7 @@ describe("PluginNewThreadComposer seeding", () => {
       ],
     });
     const router = createMemoryRouter(
-      [{ path: "/", element: <RootComposeView /> }],
+      [{ path: "/", element: <RootComposeView draftSlotId={draftSlotId} /> }],
       {
         initialEntries: [
           {
@@ -937,7 +944,7 @@ describe("PluginNewThreadComposer seeding", () => {
       );
     });
     await waitFor(() => {
-      expect(router.state.location.state).toBeNull();
+      expect(router.state.location.state).toEqual({ draftSlotId });
     });
     expect(
       mocks.promptBoxProps.some(
@@ -950,11 +957,16 @@ describe("PluginNewThreadComposer seeding", () => {
   });
 
   it("applies a replacing initial prompt from location state exactly once", async () => {
+    const draftSlotId = "root-replacing-prompt-slot";
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
     window.localStorage.setItem("bb.root-compose.project-id", "proj_1");
-    const rootDraft = getPromptDraftAccessor({ kind: "new-thread" });
+    const rootDraft = getPromptDraftAccessor({
+      kind: "new-thread",
+      slotId: draftSlotId,
+      destination: { projectId: "proj_1", sectionId: null },
+    });
     rootDraft.setDraft({
       text: "leftover draft",
       mentions: [],
@@ -964,7 +976,7 @@ describe("PluginNewThreadComposer seeding", () => {
       .spyOn(console, "error")
       .mockImplementation(() => {});
     const router = createMemoryRouter(
-      [{ path: "/", element: <RootComposeView /> }],
+      [{ path: "/", element: <RootComposeView draftSlotId={draftSlotId} /> }],
       {
         initialEntries: [
           {
@@ -990,7 +1002,7 @@ describe("PluginNewThreadComposer seeding", () => {
       expect(latestPromptBoxProps().value).toBe("Create a kanban plugin");
     });
     await waitFor(() => {
-      expect(router.state.location.state).toBeNull();
+      expect(router.state.location.state).toEqual({ draftSlotId });
     });
     expect(rootDraft.getCurrent().text).toBe("Create a kanban plugin");
     const updateDepthErrors = consoleError.mock.calls.filter((call) =>

--- a/apps/app/src/components/promptbox/NewThreadComposer.tsx
+++ b/apps/app/src/components/promptbox/NewThreadComposer.tsx
@@ -448,6 +448,10 @@ export function NewThreadComposer({
     [projectThreads, worktreeHostNameById],
   );
 
+  const promptDraft = usePromptDraftStorage(draftStorage);
+  const restoredComposerSelection =
+    selectionScope === "component-local" ? promptDraft.composerSelection : null;
+
   const seedSignature = JSON.stringify([
     resetKey ?? null,
     seed?.providerId ?? null,
@@ -513,25 +517,42 @@ export function NewThreadComposer({
       : undefined;
   const projectDefaultsUnavailable =
     projectDefaultsState.status !== "resolved" &&
-    (seed?.providerId === undefined ||
-      seed?.model === undefined ||
-      seed?.reasoningLevel === undefined ||
-      seed?.permissionMode === undefined);
+    ((restoredComposerSelection?.providerId === undefined &&
+      seed?.providerId === undefined) ||
+      (restoredComposerSelection?.model === undefined &&
+        seed?.model === undefined) ||
+      (restoredComposerSelection?.reasoningLevel === undefined &&
+        seed?.reasoningLevel === undefined) ||
+      (restoredComposerSelection?.permissionMode === undefined &&
+        seed?.permissionMode === undefined));
   const creationOptions = useThreadCreationOptions({
     scope: selectionScope,
     preferenceProjectId: projectId,
-    resetKey: `${projectId}\0${seedSignature}`,
+    resetKey: `${projectId}\0${promptDraft.storageKey}\0${seedSignature}`,
     resolveProviderRouting,
-    initialProviderId: seed?.providerId ?? projectDefaults?.providerId,
+    initialProviderId:
+      restoredComposerSelection?.providerId ??
+      seed?.providerId ??
+      projectDefaults?.providerId,
     preferReadyProviderWhenUnset:
       preferReadyProviderWhenUnset && projectDefaults === null,
-    initialModel: seed?.model ?? projectDefaults?.model,
-    initialServiceTier: seed?.serviceTier ?? projectDefaults?.serviceTier,
+    initialModel:
+      restoredComposerSelection?.model ?? seed?.model ?? projectDefaults?.model,
+    initialServiceTier:
+      restoredComposerSelection?.serviceTier ??
+      seed?.serviceTier ??
+      projectDefaults?.serviceTier,
     initialReasoningLevel:
-      seed?.reasoningLevel ?? projectDefaults?.reasoningLevel,
+      restoredComposerSelection?.reasoningLevel ??
+      seed?.reasoningLevel ??
+      projectDefaults?.reasoningLevel,
     initialPermissionMode:
-      seed?.permissionMode ?? projectDefaults?.permissionMode,
-    initialEnvironmentSelectionValue: environmentSeed?.selectionValue,
+      restoredComposerSelection?.permissionMode ??
+      seed?.permissionMode ??
+      projectDefaults?.permissionMode,
+    initialEnvironmentSelectionValue:
+      restoredComposerSelection?.environmentSelectionValue ??
+      environmentSeed?.selectionValue,
   });
   const {
     activeModel,
@@ -569,7 +590,6 @@ export function NewThreadComposer({
   } = creationOptions;
   const selectedThreadModel = activeModel?.model ?? selectedModel;
 
-  const promptDraft = usePromptDraftStorage(draftStorage);
   const textEffects = useComposerTextEffects(promptDraft.storageKey);
   const promptOptionDraftSnapshotRef = useRef<PromptDraftState | null>(null);
   const snapshotDraftBeforeOptionChange = useCallback(() => {
@@ -794,6 +814,35 @@ export function NewThreadComposer({
       selectedBranch,
     ],
   );
+  const setDraftComposerSelection = promptDraft.setComposerSelection;
+
+  useEffect(() => {
+    if (
+      selectionScope !== "component-local" ||
+      selectedProviderId.length === 0 ||
+      selectedThreadModel.length === 0 ||
+      environmentSelectionValue.length === 0
+    ) {
+      return;
+    }
+    setDraftComposerSelection({
+      providerId: selectedProviderId,
+      model: selectedThreadModel,
+      reasoningLevel,
+      ...(serviceTier === undefined ? {} : { serviceTier }),
+      permissionMode,
+      environmentSelectionValue,
+    });
+  }, [
+    environmentSelectionValue,
+    permissionMode,
+    setDraftComposerSelection,
+    reasoningLevel,
+    selectedProviderId,
+    selectedThreadModel,
+    selectionScope,
+    serviceTier,
+  ]);
 
   const seedInitialPrompt = promptDraft.restoreIfEmpty;
   useEffect(() => {
@@ -1008,21 +1057,35 @@ export function NewThreadComposer({
 
   const seededExecutionInputSources = useMemo(
     (): CreateExecutionInputSources => ({
-      ...(seed?.providerId !== undefined
+      ...(restoredComposerSelection?.providerId !== undefined ||
+      seed?.providerId !== undefined
         ? { providerId: "explicit" as const }
         : {}),
-      ...(seed?.model !== undefined ? { model: "explicit" as const } : {}),
-      ...(seed?.reasoningLevel !== undefined
+      ...(restoredComposerSelection?.model !== undefined ||
+      seed?.model !== undefined
+        ? { model: "explicit" as const }
+        : {}),
+      ...(restoredComposerSelection?.reasoningLevel !== undefined ||
+      seed?.reasoningLevel !== undefined
         ? { reasoningLevel: "explicit" as const }
         : {}),
-      ...(seed?.serviceTier !== undefined && supportsServiceTier && serviceTier
+      ...((restoredComposerSelection?.serviceTier !== undefined ||
+        seed?.serviceTier !== undefined) &&
+      supportsServiceTier &&
+      serviceTier
         ? { serviceTier: "explicit" as const }
         : {}),
-      ...(seed?.permissionMode !== undefined
+      ...(restoredComposerSelection?.permissionMode !== undefined ||
+      seed?.permissionMode !== undefined
         ? { permissionMode: "explicit" as const }
         : {}),
     }),
     [
+      restoredComposerSelection?.model,
+      restoredComposerSelection?.permissionMode,
+      restoredComposerSelection?.providerId,
+      restoredComposerSelection?.reasoningLevel,
+      restoredComposerSelection?.serviceTier,
       seed?.model,
       seed?.permissionMode,
       seed?.providerId,

--- a/apps/app/src/components/sidebar/AppSidebar.tsx
+++ b/apps/app/src/components/sidebar/AppSidebar.tsx
@@ -47,6 +47,7 @@ import {
   getThreadRoutePath,
 } from "@/lib/route-paths";
 import { usePaneContentSplitDrag } from "./usePaneContentSplitDrag";
+import { createNewThreadDraftSlotId } from "@/lib/prompt-draft-slots";
 import { openUrlInExternalBrowser } from "@/lib/url-open-routing";
 import {
   EMPTY_SIDEBAR_THREAD_SHORTCUT_KEYS,
@@ -65,8 +66,6 @@ import {
 } from "@/components/commands/AppCommandProvider";
 import { useRouteState } from "@/hooks/useRouteState";
 import { usePluginNavPanelChrome } from "@/lib/plugin-nav-panel-chrome";
-
-const NEW_THREAD_PANE_CONTENT = { kind: "new-thread" } as const;
 
 const BUG_REPORT_NEW_ISSUE_URL = "https://github.com/get-bb/bb/issues/new";
 const SIDEBAR_FOOTER_ACTION_CLASS = cn(
@@ -137,8 +136,15 @@ export function AppSidebar({
   const threadListReplacement = useThreadListReplacement();
   const { threadId: activeThreadId } = useRouteState();
   const navigate = useNavigate();
+  const createNewThreadPaneContent = useCallback(
+    () => ({
+      kind: "new-thread" as const,
+      draftSlotId: createNewThreadDraftSlotId(),
+    }),
+    [],
+  );
   const newThreadSplit = usePaneContentSplitDrag({
-    content: NEW_THREAD_PANE_CONTENT,
+    createContent: createNewThreadPaneContent,
     enabled: true,
     label: "New thread",
   });

--- a/apps/app/src/components/sidebar/ProjectList.tsx
+++ b/apps/app/src/components/sidebar/ProjectList.tsx
@@ -135,7 +135,7 @@ import {
   useAppCommandRunner,
   useAppCommandShortcut,
 } from "@/components/commands/AppCommandProvider";
-import { usePaneContentSplitIndicator } from "./paneContentSplitIndicator";
+import { useNewThreadSplitIndicator } from "./paneContentSplitIndicator";
 import { SplitPaneMiniMap } from "./SplitPaneMiniMap";
 import {
   renderBuiltInSidebarSection,
@@ -764,10 +764,7 @@ export function ProjectListActionButtons({
   const isNewChatDisabled = !onNewChat;
   const newThreadShortcut = useAppCommandShortcut("thread.new");
   const threadSearchShortcut = useAppCommandShortcut("thread.search");
-  const newThreadSplitIndicator = usePaneContentSplitIndicator(
-    { kind: "new-thread" },
-    splitEnabled,
-  );
+  const newThreadSplitIndicator = useNewThreadSplitIndicator(splitEnabled);
 
   return (
     <div className="space-y-1">

--- a/apps/app/src/components/sidebar/ProjectListSectionHeader.test.tsx
+++ b/apps/app/src/components/sidebar/ProjectListSectionHeader.test.tsx
@@ -167,7 +167,7 @@ describe("TopLevelSidebarSection", () => {
           {
             type: "pane",
             paneId: "pane-compose",
-            content: { kind: "new-thread" },
+            content: { kind: "new-thread", draftSlotId: "draft-compose" },
           },
         ],
       },

--- a/apps/app/src/components/sidebar/SidebarOverview.stories.tsx
+++ b/apps/app/src/components/sidebar/SidebarOverview.stories.tsx
@@ -588,7 +588,7 @@ export function SplitPageLabels() {
           {
             type: "pane",
             paneId: "pane-compose",
-            content: { kind: "new-thread" },
+            content: { kind: "new-thread", draftSlotId: "story-compose" },
           },
           {
             type: "pane",

--- a/apps/app/src/components/sidebar/SidebarSectionRow.stories.tsx
+++ b/apps/app/src/components/sidebar/SidebarSectionRow.stories.tsx
@@ -83,7 +83,7 @@ function SplitViewSidebarStage({ children }: { children: ReactNode }) {
           {
             type: "pane",
             paneId: "pane-compose",
-            content: { kind: "new-thread" },
+            content: { kind: "new-thread", draftSlotId: "story-compose" },
           },
         ],
       },

--- a/apps/app/src/components/sidebar/SidebarSectionRow.test.tsx
+++ b/apps/app/src/components/sidebar/SidebarSectionRow.test.tsx
@@ -68,7 +68,7 @@ describe("SidebarSectionRow", () => {
           {
             type: "pane",
             paneId: "pane-compose",
-            content: { kind: "new-thread" },
+            content: { kind: "new-thread", draftSlotId: "draft-compose" },
           },
           {
             type: "pane",

--- a/apps/app/src/components/sidebar/ThreadRow.test.tsx
+++ b/apps/app/src/components/sidebar/ThreadRow.test.tsx
@@ -223,7 +223,7 @@ function renderSplitThreadRow({
         {
           type: "pane",
           paneId: "pane-compose",
-          content: { kind: "new-thread" },
+          content: { kind: "new-thread", draftSlotId: "draft-compose" },
         },
       ],
     },

--- a/apps/app/src/components/sidebar/paneContentSplitIndicator.test.tsx
+++ b/apps/app/src/components/sidebar/paneContentSplitIndicator.test.tsx
@@ -6,7 +6,10 @@ import { createStore, Provider } from "jotai";
 import type { ReactNode } from "react";
 import { splitLayoutAtom } from "@/lib/split-layout/atoms";
 import type { LayoutNode, PaneContent, SplitLayout } from "@/lib/split-layout";
-import { usePaneContentSplitIndicator } from "./paneContentSplitIndicator";
+import {
+  useNewThreadSplitIndicator,
+  usePaneContentSplitIndicator,
+} from "./paneContentSplitIndicator";
 
 const { compactState } = vi.hoisted(() => ({
   compactState: { value: false },
@@ -83,6 +86,47 @@ describe("usePaneContentSplitIndicator", () => {
     });
     expect(result.current.miniMap?.find((slot) => slot.isFocused)?.paneId).toBe(
       "pane-2",
+    );
+  });
+
+  it("marks every independent New thread pane for the action indicator", () => {
+    const store = createStore();
+    store.set(splitLayoutAtom, {
+      root: {
+        type: "split",
+        dir: "row",
+        sizes: [0.3, 0.3, 0.4],
+        children: [
+          {
+            type: "pane",
+            paneId: "pane-compose-1",
+            content: { kind: "new-thread", draftSlotId: "slot-1" },
+          },
+          pane("pane-thread", "t1"),
+          {
+            type: "pane",
+            paneId: "pane-compose-2",
+            content: { kind: "new-thread", draftSlotId: "slot-2" },
+          },
+        ],
+      },
+      focusedPaneId: "pane-compose-2",
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <Provider store={store}>{children}</Provider>
+    );
+
+    const { result } = renderHook(() => useNewThreadSplitIndicator(true), {
+      wrapper,
+    });
+
+    expect(
+      result.current.miniMap
+        ?.filter((slot) => slot.isMe)
+        .map((slot) => slot.paneId),
+    ).toEqual(["pane-compose-1", "pane-compose-2"]);
+    expect(result.current.miniMap?.find((slot) => slot.isFocused)?.paneId).toBe(
+      "pane-compose-2",
     );
   });
 });

--- a/apps/app/src/components/sidebar/paneContentSplitIndicator.ts
+++ b/apps/app/src/components/sidebar/paneContentSplitIndicator.ts
@@ -97,6 +97,29 @@ export function usePaneContentSplitIndicator(
   }, [content, enabled, isCompact, layout]);
 }
 
+export function useNewThreadSplitIndicator(
+  enabled: boolean,
+): PaneContentSplitIndicator {
+  const { layout, isCompact } = useSplitLayoutForIndicator(enabled);
+
+  return useMemo<PaneContentSplitIndicator>(() => {
+    if (
+      !enabled ||
+      layout === null ||
+      isCompact ||
+      countPanes(layout.root) < 2
+    ) {
+      return NO_INDICATOR;
+    }
+    const matchingPaneIds = new Set(
+      listPanes(layout.root)
+        .filter((pane) => pane.content.kind === "new-thread")
+        .map((pane) => pane.paneId),
+    );
+    return buildSplitIndicator(layout, matchingPaneIds);
+  }, [enabled, isCompact, layout]);
+}
+
 export function useThreadGroupSplitIndicator(
   threads: readonly ThreadSplitIndicatorTarget[],
   enabled: boolean,

--- a/apps/app/src/components/sidebar/usePaneContentSplitDrag.test.tsx
+++ b/apps/app/src/components/sidebar/usePaneContentSplitDrag.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+} from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { splitLayoutAtom } from "@/lib/split-layout/atoms";
+import { countPanes, findPaneByContent, listPanes } from "@/lib/split-layout";
+import type { SplitLayout } from "@/lib/split-layout";
+import type { SplitDragConfig } from "@/lib/split-drag";
+import { usePaneContentSplitDrag } from "./usePaneContentSplitDrag";
+
+const { compactState, dragState, navigateSpy } = vi.hoisted(() => ({
+  compactState: { value: false },
+  dragState: { config: null as SplitDragConfig | null },
+  navigateSpy: vi.fn(),
+}));
+
+vi.mock("react-router-dom", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-router-dom")>()),
+  useNavigate: () => navigateSpy,
+}));
+
+vi.mock("@bb/shared-ui/hooks/use-compact-viewport", () => ({
+  useIsCompactViewport: () => compactState.value,
+}));
+
+vi.mock("@/lib/split-drag", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/split-drag")>()),
+  beginSplitDrag: (config: SplitDragConfig) => {
+    dragState.config = config;
+  },
+}));
+
+function singlePane(): SplitLayout {
+  return {
+    root: {
+      type: "pane",
+      paneId: "pane-1",
+      content: { kind: "thread", projectId: "p1", threadId: "t1" },
+    },
+    focusedPaneId: "pane-1",
+  };
+}
+
+function renderFreshComposeSplit(layout: SplitLayout | null) {
+  const store = createStore();
+  store.set(splitLayoutAtom, layout);
+  let sequence = 0;
+  const createContent = vi.fn(() => ({
+    kind: "new-thread" as const,
+    draftSlotId: `slot-${(sequence += 1)}`,
+  }));
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  const { result } = renderHook(
+    () =>
+      usePaneContentSplitDrag({
+        createContent,
+        enabled: true,
+        label: "New thread",
+      }),
+    { wrapper },
+  );
+  return { createContent, result, store, wrapper };
+}
+
+beforeEach(() => {
+  compactState.value = false;
+  dragState.config = null;
+  navigateSpy.mockReset();
+});
+
+afterEach(cleanup);
+
+describe("usePaneContentSplitDrag with fresh content", () => {
+  it("creates a distinct New thread slot for every cmd-click open", () => {
+    const { result, store } = renderFreshComposeSplit(singlePane());
+
+    act(() => result.current.openInSplit());
+    act(() => result.current.openInSplit());
+
+    const layout = store.get(splitLayoutAtom);
+    expect(layout).not.toBeNull();
+    expect(countPanes(layout!.root)).toBe(3);
+    expect(
+      findPaneByContent(layout!.root, {
+        kind: "new-thread",
+        draftSlotId: "slot-1",
+      }),
+    ).not.toBeNull();
+    expect(
+      findPaneByContent(layout!.root, {
+        kind: "new-thread",
+        draftSlotId: "slot-2",
+      }),
+    ).not.toBeNull();
+    expect(navigateSpy).toHaveBeenNthCalledWith(1, "/", {
+      state: { draftSlotId: "slot-1" },
+    });
+    expect(navigateSpy).toHaveBeenNthCalledWith(2, "/", {
+      state: { draftSlotId: "slot-2" },
+    });
+  });
+
+  it("does not allocate a slot for a canceled pointer gesture", () => {
+    const { createContent, result, wrapper } =
+      renderFreshComposeSplit(singlePane());
+
+    render(
+      <button onPointerDown={result.current.onPointerDown}>New thread</button>,
+      { wrapper },
+    );
+    fireEvent.pointerDown(screen.getByRole("button", { name: "New thread" }), {
+      button: 0,
+      clientX: 10,
+      clientY: 10,
+    });
+
+    expect(dragState.config).not.toBeNull();
+    expect(createContent).not.toHaveBeenCalled();
+  });
+
+  it("allocates once only after a successful drop", () => {
+    const { createContent, result, store, wrapper } =
+      renderFreshComposeSplit(singlePane());
+    render(
+      <button onPointerDown={result.current.onPointerDown}>New thread</button>,
+      { wrapper },
+    );
+    fireEvent.pointerDown(screen.getByRole("button", { name: "New thread" }), {
+      button: 0,
+      clientX: 10,
+      clientY: 10,
+    });
+
+    act(() => dragState.config?.onDrop({ paneId: "pane-1", zone: "right" }));
+
+    expect(createContent).toHaveBeenCalledTimes(1);
+    expect(listPanes(store.get(splitLayoutAtom)!.root)).toHaveLength(2);
+    expect(navigateSpy).toHaveBeenCalledWith("/", {
+      state: { draftSlotId: "slot-1" },
+    });
+  });
+
+  it("keeps the fresh binding when compact mode falls back to navigation", () => {
+    compactState.value = true;
+    const initial = singlePane();
+    const { result, store } = renderFreshComposeSplit(initial);
+
+    act(() => result.current.openInSplit());
+
+    expect(store.get(splitLayoutAtom)).toBe(initial);
+    expect(navigateSpy).toHaveBeenCalledWith("/", {
+      state: { draftSlotId: "slot-1" },
+    });
+  });
+});

--- a/apps/app/src/components/sidebar/usePaneContentSplitDrag.ts
+++ b/apps/app/src/components/sidebar/usePaneContentSplitDrag.ts
@@ -44,20 +44,46 @@ function routeForContent(content: PaneContent): string {
   });
 }
 
+function navigationOptionsForContent(
+  content: PaneContent,
+  replace = false,
+): { replace?: true; state?: { draftSlotId: string } } | undefined {
+  const state =
+    content.kind === "new-thread"
+      ? { draftSlotId: content.draftSlotId }
+      : undefined;
+  if (!replace && state === undefined) return undefined;
+  return {
+    ...(replace ? { replace: true as const } : {}),
+    ...(state === undefined ? {} : { state }),
+  };
+}
+
+type PaneContentSplitDragSource =
+  | { content: PaneContent; createContent?: never }
+  | { content?: never; createContent: () => PaneContent };
+
 export function usePaneContentSplitDrag({
-  content,
   enabled,
   label,
-}: {
-  content: PaneContent;
+  ...source
+}: PaneContentSplitDragSource & {
   enabled: boolean;
   label: string;
 }) {
   const store = useStore();
   const navigate = useNavigate();
   const isCompact = useIsCompactViewport();
+  const fixedContent = source.content;
+  const createContent = source.createContent;
+  const resolveContent = useCallback(() => {
+    if (fixedContent !== undefined) return fixedContent;
+    if (createContent !== undefined) return createContent();
+    throw new Error("A pane-content split source is required.");
+  }, [createContent, fixedContent]);
 
   const openInSplit = useCallback(() => {
+    const content = resolveContent();
     openPaneContentInSplit({
       store,
       navigate,
@@ -65,7 +91,7 @@ export function usePaneContentSplitDrag({
       route: routeForContent(content),
       enabled: enabled && !isCompact,
     });
-  }, [content, enabled, isCompact, navigate, store]);
+  }, [enabled, isCompact, navigate, resolveContent, store]);
 
   const onPointerDown = useCallback(
     (event: ReactPointerEvent<HTMLElement>) => {
@@ -96,13 +122,16 @@ export function usePaneContentSplitDrag({
           if (layout === null) return null;
           return decideThreadDrop({
             zone,
-            threadAlreadyOpen: findPaneByContent(layout.root, content) !== null,
+            threadAlreadyOpen:
+              fixedContent !== undefined &&
+              findPaneByContent(layout.root, fixedContent) !== null,
             atMaxPanes: countPanes(layout.root) >= MAX_PANES,
           });
         },
         onDrop: (target) => {
           const layout = store.get(splitLayoutAtom);
           if (layout === null) return;
+          const content = resolveContent();
           const existing = findPaneByContent(layout.root, content);
           const next =
             existing !== null
@@ -113,12 +142,12 @@ export function usePaneContentSplitDrag({
           if (next !== layout) store.set(splitLayoutAtom, next);
           navigate(
             routeForContent(content),
-            existing !== null ? { replace: true } : undefined,
+            navigationOptionsForContent(content, existing !== null),
           );
         },
       });
     },
-    [content, enabled, label, navigate, store],
+    [enabled, fixedContent, label, navigate, resolveContent, store],
   );
 
   return {

--- a/apps/app/src/components/ui/app-route-anchor.tsx
+++ b/apps/app/src/components/ui/app-route-anchor.tsx
@@ -110,7 +110,10 @@ export function RouteNavigationProvider({
   );
   const openInSplit = useCallback<RouteNavigation["openInSplit"]>(
     (path) => {
-      const content = paneContentForPathname(path.split(/[?#]/)[0] ?? path);
+      const content = paneContentForPathname(
+        path.split(/[?#]/)[0] ?? path,
+        true,
+      );
       if (content === null) return false;
       openPaneContentInSplit({
         store,

--- a/apps/app/src/hooks/usePromptDraftStorage.ts
+++ b/apps/app/src/hooks/usePromptDraftStorage.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
 import type { PromptTextMention } from "@bb/domain";
 import type { PromptDraftAttachment, PromptDraftState } from "@bb/client-core";
 import {
@@ -9,6 +9,14 @@ import {
   parsePromptDraftStorage,
   serializePromptDraftStorage,
 } from "@bb/client-core";
+import {
+  getNewThreadDraftSlotIdFromStorageKey,
+  getNewThreadDraftSlotStorageKey,
+  parseNewThreadDraftSlot,
+  persistNewThreadDraftSlot,
+  type NewThreadDraftComposerSelection,
+  type NewThreadDraftDestination,
+} from "@/lib/prompt-draft-slots";
 
 const PROMPT_DRAFT_STORAGE_PREFIX = "bb.promptbox.contents";
 const PROMPT_DRAFT_STORAGE_VERSION = "3";
@@ -16,19 +24,28 @@ const PROMPT_DRAFT_PERSIST_DEBOUNCE_MS = 250;
 
 export type PromptDraftScope =
   | { kind: "automation-edit"; automationId: string }
-  | { kind: "new-thread" }
+  | { kind: "new-thread"; slotId?: undefined }
+  | {
+      kind: "new-thread";
+      slotId: string;
+      destination: NewThreadDraftDestination;
+    }
   | { kind: "plugin-new-thread"; key: string }
   | { kind: "thread"; projectId: string; threadId: string };
 
 interface PromptDraftCacheEntry {
   rawValue: string | null;
   draft: PromptDraftState;
+  lastEditedAt: number | null;
+  destination: NewThreadDraftDestination | null;
+  composerSelection: NewThreadDraftComposerSelection | null;
 }
 
 type PromptDraftListener = () => void;
 
 interface PromptDraftWriteOptions {
   persist: "immediate" | "deferred";
+  clearComposerSelection?: boolean;
 }
 
 const EMPTY_PROMPT_DRAFT = emptyPromptDraftState();
@@ -57,12 +74,67 @@ function readPromptDraft(storageKey: string | null): PromptDraftState {
     return cachedEntry.draft;
   }
 
-  const draft = parsePromptDraftStorage(rawValue);
+  const slotId = getNewThreadDraftSlotIdFromStorageKey(storageKey);
+  const slot =
+    slotId === null ? null : parseNewThreadDraftSlot(slotId, rawValue);
+  const draft = slot?.draft ?? parsePromptDraftStorage(rawValue);
   promptDraftCache.set(storageKey, {
     rawValue,
     draft,
+    lastEditedAt: slot?.lastEditedAt ?? null,
+    destination: slot?.destination ?? null,
+    composerSelection: slot?.composerSelection ?? null,
   });
   return draft;
+}
+
+function readPromptDraftComposerSelection(
+  storageKey: string,
+): NewThreadDraftComposerSelection | null {
+  readPromptDraft(storageKey);
+  return promptDraftCache.get(storageKey)?.composerSelection ?? null;
+}
+
+function areDraftDestinationsEqual(
+  left: NewThreadDraftDestination | null,
+  right: NewThreadDraftDestination,
+): boolean {
+  return (
+    left?.projectId === right.projectId && left.sectionId === right.sectionId
+  );
+}
+
+function seedPromptDraftDestination(
+  storageKey: string,
+  destination: NewThreadDraftDestination,
+): void {
+  readPromptDraft(storageKey);
+  const cachedEntry = promptDraftCache.get(storageKey);
+  if (
+    cachedEntry !== undefined &&
+    cachedEntry.rawValue === null &&
+    cachedEntry.destination === null
+  ) {
+    cachedEntry.destination = destination;
+  }
+}
+
+function updatePromptDraftDestination(
+  storageKey: string,
+  destination: NewThreadDraftDestination,
+): void {
+  const draft = readPromptDraft(storageKey);
+  const cachedEntry = promptDraftCache.get(storageKey);
+  if (
+    cachedEntry === undefined ||
+    areDraftDestinationsEqual(cachedEntry.destination, destination)
+  ) {
+    return;
+  }
+  cachedEntry.destination = destination;
+  if (!isPromptDraftEmpty(draft)) {
+    persistPromptDraftCache(storageKey);
+  }
 }
 
 function emitPromptDraftChange(storageKey: string): void {
@@ -94,15 +166,32 @@ function persistPromptDraftCache(storageKey: string): void {
     return;
   }
 
-  const serialized = serializePromptDraftStorage(cachedEntry.draft);
-  cachedEntry.rawValue = serialized;
-  if (serialized === null) {
-    window.localStorage.removeItem(storageKey);
-    return;
-  }
-
   try {
-    window.localStorage.setItem(storageKey, serialized);
+    const slotId = getNewThreadDraftSlotIdFromStorageKey(storageKey);
+    let serialized: string | null;
+    if (slotId === null) {
+      serialized = serializePromptDraftStorage(cachedEntry.draft);
+    } else {
+      const destination = cachedEntry.destination;
+      if (destination === null) {
+        throw new Error(`Draft slot ${slotId} has no submit destination.`);
+      }
+      serialized = persistNewThreadDraftSlot(
+        slotId,
+        cachedEntry.draft,
+        cachedEntry.lastEditedAt ?? Date.now(),
+        destination,
+        cachedEntry.composerSelection,
+      );
+    }
+    cachedEntry.rawValue = serialized;
+    if (slotId === null) {
+      if (serialized === null) {
+        window.localStorage.removeItem(storageKey);
+      } else {
+        window.localStorage.setItem(storageKey, serialized);
+      }
+    }
   } catch (error) {
     cachedEntry.rawValue = readStoredPromptDraftValue(storageKey);
     console.warn(
@@ -192,13 +281,68 @@ function writePromptDraft(
 ): void {
   if (!storageKey || typeof window === "undefined") return;
 
+  const slotId = getNewThreadDraftSlotIdFromStorageKey(storageKey);
+  if (slotId !== null) {
+    readPromptDraft(storageKey);
+  }
+  const existingSlotEntry = promptDraftCache.get(storageKey);
+
   promptDraftCache.set(storageKey, {
     rawValue: null,
     draft: isPromptDraftEmpty(value) ? EMPTY_PROMPT_DRAFT : value,
+    lastEditedAt:
+      slotId === null || isPromptDraftEmpty(value) ? null : Date.now(),
+    destination:
+      slotId === null ? null : (existingSlotEntry?.destination ?? null),
+    composerSelection:
+      slotId === null || options.clearComposerSelection === true
+        ? null
+        : (existingSlotEntry?.composerSelection ?? null),
   });
   if (options.persist === "deferred") {
     schedulePromptDraftPersist(storageKey);
   } else {
+    persistPromptDraftCache(storageKey);
+  }
+  emitPromptDraftChange(storageKey);
+}
+
+function areDraftComposerSelectionsEqual(
+  left: NewThreadDraftComposerSelection | null,
+  right: NewThreadDraftComposerSelection,
+): boolean {
+  return (
+    left?.providerId === right.providerId &&
+    left.model === right.model &&
+    left.reasoningLevel === right.reasoningLevel &&
+    left.serviceTier === right.serviceTier &&
+    left.permissionMode === right.permissionMode &&
+    left.environmentSelectionValue === right.environmentSelectionValue
+  );
+}
+
+function writePromptDraftComposerSelection(
+  storageKey: string,
+  selection: NewThreadDraftComposerSelection,
+): void {
+  if (
+    typeof window === "undefined" ||
+    getNewThreadDraftSlotIdFromStorageKey(storageKey) === null
+  ) {
+    return;
+  }
+
+  const draft = readPromptDraft(storageKey);
+  const cachedEntry = promptDraftCache.get(storageKey);
+  if (
+    cachedEntry === undefined ||
+    areDraftComposerSelectionsEqual(cachedEntry.composerSelection, selection)
+  ) {
+    return;
+  }
+
+  cachedEntry.composerSelection = selection;
+  if (!isPromptDraftEmpty(draft)) {
     persistPromptDraftCache(storageKey);
   }
   emitPromptDraftChange(storageKey);
@@ -248,7 +392,9 @@ function getPromptDraftStorageKey(scope: PromptDraftScope): string {
     return `${PROMPT_DRAFT_STORAGE_PREFIX}-automation-edit-${normalizedAutomationId}-${PROMPT_DRAFT_STORAGE_VERSION}`;
   }
   if (scope.kind === "new-thread") {
-    return `${PROMPT_DRAFT_STORAGE_PREFIX}-draft-${PROMPT_DRAFT_STORAGE_VERSION}`;
+    return scope.slotId === undefined
+      ? `${PROMPT_DRAFT_STORAGE_PREFIX}-draft-${PROMPT_DRAFT_STORAGE_VERSION}`
+      : getNewThreadDraftSlotStorageKey(scope.slotId);
   }
   if (scope.kind === "plugin-new-thread") {
     const normalizedKey = normalizeStorageSegment(scope.key);
@@ -257,6 +403,14 @@ function getPromptDraftStorageKey(scope: PromptDraftScope): string {
   const normalizedProjectId = normalizeStorageSegment(scope.projectId);
   const normalizedThreadId = normalizeStorageSegment(scope.threadId);
   return `${PROMPT_DRAFT_STORAGE_PREFIX}-${normalizedProjectId}-${normalizedThreadId}-${PROMPT_DRAFT_STORAGE_VERSION}`;
+}
+
+function preparePromptDraftStorage(scope: PromptDraftScope): string {
+  const storageKey = getPromptDraftStorageKey(scope);
+  if (scope.kind === "new-thread" && scope.slotId !== undefined) {
+    seedPromptDraftDestination(storageKey, scope.destination);
+  }
+  return storageKey;
 }
 
 export function getPromptDraftAccessor(scope: PromptDraftScope): {
@@ -269,7 +423,7 @@ export function getPromptDraftAccessor(scope: PromptDraftScope): {
     attachments?: readonly PromptDraftAttachment[],
   ) => void;
 } {
-  const storageKey = getPromptDraftStorageKey(scope);
+  const storageKey = preparePromptDraftStorage(scope);
   return {
     storageKey,
     getCurrent: () => readPromptDraft(storageKey),
@@ -281,7 +435,22 @@ export function getPromptDraftAccessor(scope: PromptDraftScope): {
 }
 
 export function usePromptDraftStorage(scope: PromptDraftScope) {
-  const storageKey = getPromptDraftStorageKey(scope);
+  const storageKey = preparePromptDraftStorage(scope);
+  const destinationProjectId =
+    scope.kind === "new-thread" && scope.slotId !== undefined
+      ? scope.destination.projectId
+      : null;
+  const destinationSectionId =
+    scope.kind === "new-thread" && scope.slotId !== undefined
+      ? scope.destination.sectionId
+      : null;
+  useEffect(() => {
+    if (destinationProjectId === null) return;
+    updatePromptDraftDestination(storageKey, {
+      projectId: destinationProjectId,
+      sectionId: destinationSectionId,
+    });
+  }, [destinationProjectId, destinationSectionId, storageKey]);
   const draft = useSyncExternalStore(
     useCallback(
       (listener) => subscribePromptDraft(storageKey, listener),
@@ -290,10 +459,28 @@ export function usePromptDraftStorage(scope: PromptDraftScope) {
     useCallback(() => readPromptDraft(storageKey), [storageKey]),
     () => EMPTY_PROMPT_DRAFT,
   );
+  const composerSelection = useSyncExternalStore(
+    useCallback(
+      (listener) => subscribePromptDraft(storageKey, listener),
+      [storageKey],
+    ),
+    useCallback(
+      () => readPromptDraftComposerSelection(storageKey),
+      [storageKey],
+    ),
+    () => null,
+  );
 
   const setDraftAndPersist = useCallback(
     (nextDraft: PromptDraftState) => {
       writePromptDraft(storageKey, nextDraft);
+    },
+    [storageKey],
+  );
+
+  const setComposerSelection = useCallback(
+    (selection: NewThreadDraftComposerSelection) => {
+      writePromptDraftComposerSelection(storageKey, selection);
     },
     [storageKey],
   );
@@ -363,8 +550,11 @@ export function usePromptDraftStorage(scope: PromptDraftScope) {
   );
 
   const clear = useCallback(() => {
-    setDraftAndPersist(EMPTY_PROMPT_DRAFT);
-  }, [setDraftAndPersist]);
+    writePromptDraft(storageKey, EMPTY_PROMPT_DRAFT, {
+      persist: "immediate",
+      clearComposerSelection: true,
+    });
+  }, [storageKey]);
 
   const clearIfCurrentMatches = useCallback(
     (expectedDraft: PromptDraftState): boolean => {
@@ -374,10 +564,13 @@ export function usePromptDraftStorage(scope: PromptDraftScope) {
         return false;
       }
 
-      setDraftAndPersist(EMPTY_PROMPT_DRAFT);
+      writePromptDraft(storageKey, EMPTY_PROMPT_DRAFT, {
+        persist: "immediate",
+        clearComposerSelection: true,
+      });
       return true;
     },
-    [setDraftAndPersist, storageKey],
+    [storageKey],
   );
 
   const setAttachments = useCallback(
@@ -402,6 +595,8 @@ export function usePromptDraftStorage(scope: PromptDraftScope) {
       storageKey,
       getCurrent,
       subscribe,
+      composerSelection,
+      setComposerSelection,
       value: draft.text,
       text: draft.text,
       mentions: draft.mentions,
@@ -421,6 +616,7 @@ export function usePromptDraftStorage(scope: PromptDraftScope) {
       addQuote,
       clear,
       clearIfCurrentMatches,
+      composerSelection,
       draft.attachments,
       draft.mentions,
       draft.text,
@@ -428,6 +624,7 @@ export function usePromptDraftStorage(scope: PromptDraftScope) {
       removeAttachment,
       restoreIfEmpty,
       setAttachments,
+      setComposerSelection,
       setDraftAndPersist,
       setTextAndMentions,
       storageKey,
@@ -437,7 +634,7 @@ export function usePromptDraftStorage(scope: PromptDraftScope) {
 }
 
 export function usePromptDraftHasInput(scope: PromptDraftScope): boolean {
-  const storageKey = getPromptDraftStorageKey(scope);
+  const storageKey = preparePromptDraftStorage(scope);
 
   return useSyncExternalStore(
     useCallback(

--- a/apps/app/src/lib/prompt-draft-slots.test.tsx
+++ b/apps/app/src/lib/prompt-draft-slots.test.tsx
@@ -1,0 +1,528 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PromptDraftState } from "@bb/client-core";
+import {
+  getPromptDraftAccessor,
+  usePromptDraftStorage,
+} from "@/hooks/usePromptDraftStorage";
+import {
+  getNewThreadDraftSlotIdFromStorageKey,
+  getNewThreadDraftSlotStorageKey,
+  initializeNewThreadDraftSlots,
+  parseNewThreadDraftSlot,
+  persistNewThreadDraftSlot,
+  promptDraftSlotStorageKeysForTests,
+  readNewThreadDraftSlots,
+  serializeNewThreadDraftSlot,
+  type NewThreadDraftComposerSelection,
+  type NewThreadDraftDestination,
+} from "./prompt-draft-slots";
+
+const WITHOUT_SECTION: NewThreadDraftDestination = {
+  projectId: "project-personal",
+  sectionId: null,
+};
+const WITH_SECTION: NewThreadDraftDestination = {
+  projectId: "project-work",
+  sectionId: "section-inbox",
+};
+const COMPOSER_SELECTION: NewThreadDraftComposerSelection = {
+  providerId: "codex",
+  model: "gpt-5.6-sol",
+  reasoningLevel: "high",
+  serviceTier: "fast",
+  permissionMode: "full",
+  environmentSelectionValue: "host:host-local:worktree",
+};
+
+function draft(text: string): PromptDraftState {
+  return { text, mentions: [], attachments: [] };
+}
+
+function legacyDraft(text: string): string {
+  return JSON.stringify({ text, attachments: [] });
+}
+
+function readSlot(slotId: string) {
+  return parseNewThreadDraftSlot(
+    slotId,
+    window.localStorage.getItem(getNewThreadDraftSlotStorageKey(slotId)),
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("new-thread draft slot records", () => {
+  it("keeps two composer slots independent across remount", () => {
+    vi.useFakeTimers();
+    const leftScope = {
+      kind: "new-thread" as const,
+      slotId: "pane-left",
+      destination: WITHOUT_SECTION,
+    };
+    const rightScope = {
+      kind: "new-thread" as const,
+      slotId: "pane-right",
+      destination: WITH_SECTION,
+    };
+    const left = renderHook(() => usePromptDraftStorage(leftScope));
+    const right = renderHook(() => usePromptDraftStorage(rightScope));
+
+    vi.setSystemTime(100);
+    act(() => left.result.current.setDraft(draft("Left pane text")));
+    vi.setSystemTime(200);
+    act(() => right.result.current.setDraft(draft("Right pane text")));
+
+    expect(left.result.current.text).toBe("Left pane text");
+    expect(right.result.current.text).toBe("Right pane text");
+    expect(readNewThreadDraftSlots()).toEqual([
+      expect.objectContaining({
+        id: "pane-right",
+        draft: draft("Right pane text"),
+        destination: WITH_SECTION,
+      }),
+      expect.objectContaining({
+        id: "pane-left",
+        draft: draft("Left pane text"),
+        destination: WITHOUT_SECTION,
+      }),
+    ]);
+
+    cleanup();
+    const restoredLeft = renderHook(() => usePromptDraftStorage(leftScope));
+    const restoredRight = renderHook(() => usePromptDraftStorage(rightScope));
+    expect(restoredLeft.result.current.text).toBe("Left pane text");
+    expect(restoredRight.result.current.text).toBe("Right pane text");
+
+    act(() => restoredLeft.result.current.clear());
+    expect(restoredLeft.result.current.text).toBe("");
+    expect(restoredRight.result.current.text).toBe("Right pane text");
+    expect(readNewThreadDraftSlots().map((slot) => slot.id)).toEqual([
+      "pane-right",
+    ]);
+  });
+
+  it("round-trips project destinations with and without a section", () => {
+    const withSection = serializeNewThreadDraftSlot(
+      draft("Section-scoped work"),
+      100,
+      WITH_SECTION,
+    );
+    const withoutSection = serializeNewThreadDraftSlot(
+      draft("Project-scoped work"),
+      200,
+      WITHOUT_SECTION,
+    );
+
+    expect(parseNewThreadDraftSlot("with-section", withSection)).toEqual({
+      id: "with-section",
+      lastEditedAt: 100,
+      draft: draft("Section-scoped work"),
+      destination: WITH_SECTION,
+      composerSelection: null,
+    });
+    expect(parseNewThreadDraftSlot("without-section", withoutSection)).toEqual({
+      id: "without-section",
+      lastEditedAt: 200,
+      draft: draft("Project-scoped work"),
+      destination: WITHOUT_SECTION,
+      composerSelection: null,
+    });
+    expect(JSON.parse(withSection ?? "null")).toMatchObject({
+      projectId: "project-work",
+      sectionId: "section-inbox",
+    });
+    expect(JSON.parse(withoutSection ?? "null")).not.toHaveProperty(
+      "sectionId",
+    );
+  });
+
+  it("round-trips composer selection and preserves legacy drafts without it", () => {
+    const serialized = serializeNewThreadDraftSlot(
+      draft("Restore my exact model"),
+      300,
+      WITH_SECTION,
+      COMPOSER_SELECTION,
+    );
+
+    expect(parseNewThreadDraftSlot("with-selection", serialized)).toEqual({
+      id: "with-selection",
+      lastEditedAt: 300,
+      draft: draft("Restore my exact model"),
+      destination: WITH_SECTION,
+      composerSelection: COMPOSER_SELECTION,
+    });
+
+    const malformedSelection = JSON.stringify({
+      text: "Keep valid content",
+      attachments: [],
+      lastEditedAt: 400,
+      projectId: "project-personal",
+      composerSelection: { model: 42 },
+    });
+    expect(
+      parseNewThreadDraftSlot("malformed-selection", malformedSelection),
+    ).toEqual({
+      id: "malformed-selection",
+      lastEditedAt: 400,
+      draft: draft("Keep valid content"),
+      destination: WITHOUT_SECTION,
+      composerSelection: null,
+    });
+  });
+
+  it("keeps selection memory-only until content exists, then clears it with the draft", () => {
+    const { result } = renderHook(() =>
+      usePromptDraftStorage({
+        kind: "new-thread",
+        slotId: "selection-before-content",
+        destination: WITHOUT_SECTION,
+      }),
+    );
+
+    act(() => result.current.setComposerSelection(COMPOSER_SELECTION));
+    expect(window.localStorage.getItem(result.current.storageKey)).toBeNull();
+    expect(result.current.composerSelection).toEqual(COMPOSER_SELECTION);
+
+    act(() => result.current.setDraft(draft("Now I am a draft")));
+    expect(readSlot("selection-before-content")).toEqual(
+      expect.objectContaining({
+        draft: draft("Now I am a draft"),
+        composerSelection: COMPOSER_SELECTION,
+      }),
+    );
+
+    act(() => result.current.clear());
+    expect(window.localStorage.getItem(result.current.storageKey)).toBeNull();
+    expect(result.current.composerSelection).toBeNull();
+  });
+
+  it("atomically applies selection changes over pending text and attachment-only drafts", () => {
+    vi.useFakeTimers();
+    const pending = renderHook(() =>
+      usePromptDraftStorage({
+        kind: "new-thread",
+        slotId: "pending-selection-change",
+        destination: WITHOUT_SECTION,
+      }),
+    );
+    const changedSelection = {
+      ...COMPOSER_SELECTION,
+      model: "gpt-5.6-terra",
+      reasoningLevel: "medium" as const,
+    };
+
+    act(() => {
+      pending.result.current.setComposerSelection(COMPOSER_SELECTION);
+      pending.result.current.setTextAndMentions("Still typing", []);
+      pending.result.current.setComposerSelection(changedSelection);
+    });
+    expect(readSlot("pending-selection-change")).toEqual(
+      expect.objectContaining({
+        draft: draft("Still typing"),
+        composerSelection: changedSelection,
+      }),
+    );
+    act(() => vi.advanceTimersByTime(250));
+    expect(readSlot("pending-selection-change")?.composerSelection).toEqual(
+      changedSelection,
+    );
+
+    const attachmentOnly = renderHook(() =>
+      usePromptDraftStorage({
+        kind: "new-thread",
+        slotId: "attachment-only-selection",
+        destination: WITH_SECTION,
+      }),
+    );
+    act(() => {
+      attachmentOnly.result.current.setComposerSelection(COMPOSER_SELECTION);
+      attachmentOnly.result.current.addAttachment({
+        type: "localFile",
+        path: "uploads/plan.md",
+        name: "plan.md",
+        sizeBytes: 8,
+      });
+    });
+    expect(readSlot("attachment-only-selection")).toEqual(
+      expect.objectContaining({
+        draft: expect.objectContaining({
+          text: "",
+          attachments: [expect.objectContaining({ path: "uploads/plan.md" })],
+        }),
+        composerSelection: COMPOSER_SELECTION,
+      }),
+    );
+  });
+
+  it("keeps destination changes in the same record without changing recency", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const initialDestination: NewThreadDraftDestination = {
+      projectId: "project-a",
+      sectionId: null,
+    };
+    const updatedDestination: NewThreadDraftDestination = {
+      projectId: "project-b",
+      sectionId: "section-b",
+    };
+    const { result, rerender } = renderHook(
+      ({ destination }) =>
+        usePromptDraftStorage({
+          kind: "new-thread",
+          slotId: "destination-update",
+          destination,
+        }),
+      { initialProps: { destination: initialDestination } },
+    );
+
+    act(() => result.current.setDraft(draft("Keep my destination")));
+    expect(readNewThreadDraftSlots()).toEqual([
+      expect.objectContaining({
+        id: "destination-update",
+        lastEditedAt: 1_000,
+        destination: initialDestination,
+      }),
+    ]);
+
+    vi.setSystemTime(2_000);
+    rerender({ destination: updatedDestination });
+    expect(readNewThreadDraftSlots()).toEqual([
+      expect.objectContaining({
+        id: "destination-update",
+        lastEditedAt: 1_000,
+        draft: draft("Keep my destination"),
+        destination: updatedDestination,
+      }),
+    ]);
+  });
+
+  it("persists a destination change together with pending debounced content", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const { result, rerender } = renderHook(
+      ({ destination }) =>
+        usePromptDraftStorage({
+          kind: "new-thread",
+          slotId: "pending-destination-update",
+          destination,
+        }),
+      { initialProps: { destination: WITHOUT_SECTION } },
+    );
+
+    act(() => result.current.setTextAndMentions("Still typing", []));
+    expect(window.localStorage.getItem(result.current.storageKey)).toBeNull();
+
+    rerender({ destination: WITH_SECTION });
+    expect(readNewThreadDraftSlots()).toEqual([
+      expect.objectContaining({
+        id: "pending-destination-update",
+        lastEditedAt: 1_000,
+        draft: draft("Still typing"),
+        destination: WITH_SECTION,
+      }),
+    ]);
+
+    act(() => vi.advanceTimersByTime(250));
+    expect(readNewThreadDraftSlots()).toHaveLength(1);
+  });
+
+  it("repairs order races and removes empty or corrupt slot records", () => {
+    persistNewThreadDraftSlot("older", draft("Older"), 100, WITHOUT_SECTION);
+    persistNewThreadDraftSlot("newer", draft("Newer"), 200, WITH_SECTION);
+    const emptyKey = getNewThreadDraftSlotStorageKey("empty");
+    const corruptKey = getNewThreadDraftSlotStorageKey("corrupt");
+    window.localStorage.setItem(
+      emptyKey,
+      JSON.stringify({
+        text: "",
+        attachments: [],
+        lastEditedAt: 300,
+        projectId: "project-personal",
+      }),
+    );
+    window.localStorage.setItem(
+      corruptKey,
+      JSON.stringify({
+        text: "Missing required project",
+        attachments: [],
+        lastEditedAt: 400,
+      }),
+    );
+    window.localStorage.setItem(
+      promptDraftSlotStorageKeysForTests.order,
+      JSON.stringify({
+        version: 1,
+        ids: ["older", "older", "missing", "newer"],
+      }),
+    );
+
+    expect(readNewThreadDraftSlots().map((slot) => slot.id)).toEqual([
+      "newer",
+      "older",
+    ]);
+    expect(window.localStorage.getItem(emptyKey)).toBeNull();
+    expect(window.localStorage.getItem(corruptKey)).toBeNull();
+    expect(
+      JSON.parse(
+        window.localStorage.getItem(promptDraftSlotStorageKeysForTests.order) ??
+          "null",
+      ),
+    ).toEqual({ version: 1, ids: ["newer", "older"] });
+  });
+
+  it("encodes slot ids without admitting plugin or legacy draft keys", () => {
+    const slotId = "pane / one";
+    const storageKey = getNewThreadDraftSlotStorageKey(slotId);
+    expect(getNewThreadDraftSlotIdFromStorageKey(storageKey)).toBe(slotId);
+
+    getPromptDraftAccessor({
+      kind: "plugin-new-thread",
+      key: "destination-compatibility",
+    }).setDraft(draft("Plugin draft"));
+    getPromptDraftAccessor({ kind: "new-thread" }).setDraft(
+      draft("Legacy shared draft"),
+    );
+
+    expect(readNewThreadDraftSlots()).toEqual([]);
+    expect(
+      window.localStorage.getItem(
+        "bb.promptbox.contents-plugin-draft-destination-compatibility-3",
+      ),
+    ).toBe(legacyDraft("Plugin draft"));
+    expect(
+      window.localStorage.getItem(promptDraftSlotStorageKeysForTests.legacy),
+    ).toBe(legacyDraft("Legacy shared draft"));
+  });
+});
+
+describe("legacy new-thread draft migration", () => {
+  it("adopts the current project, dedupes reruns, and absorbs later old-build writes", () => {
+    const first = legacyDraft("Legacy first");
+    window.localStorage.setItem(
+      promptDraftSlotStorageKeysForTests.legacy,
+      first,
+    );
+
+    initializeNewThreadDraftSlots("project-current", 100);
+    expect(readNewThreadDraftSlots()).toEqual([
+      expect.objectContaining({
+        lastEditedAt: 100,
+        draft: draft("Legacy first"),
+        destination: { projectId: "project-current", sectionId: null },
+      }),
+    ]);
+    expect(
+      window.localStorage.getItem(promptDraftSlotStorageKeysForTests.legacy),
+    ).toBeNull();
+
+    window.localStorage.setItem(
+      promptDraftSlotStorageKeysForTests.legacy,
+      first,
+    );
+    initializeNewThreadDraftSlots("project-other", 200);
+    expect(readNewThreadDraftSlots()).toHaveLength(1);
+
+    window.localStorage.setItem(
+      promptDraftSlotStorageKeysForTests.legacy,
+      legacyDraft("Legacy second"),
+    );
+    initializeNewThreadDraftSlots("project-other", 300);
+    expect(readNewThreadDraftSlots()).toEqual([
+      expect.objectContaining({
+        lastEditedAt: 300,
+        draft: draft("Legacy second"),
+        destination: { projectId: "project-other", sectionId: null },
+      }),
+      expect.objectContaining({
+        lastEditedAt: 100,
+        draft: draft("Legacy first"),
+        destination: { projectId: "project-current", sectionId: null },
+      }),
+    ]);
+  });
+
+  it("does not clear a newer legacy value written concurrently", () => {
+    const originalSetItem = Storage.prototype.setItem;
+    const first = legacyDraft("Window one");
+    const second = legacyDraft("Older build wrote later");
+    window.localStorage.setItem(
+      promptDraftSlotStorageKeysForTests.legacy,
+      first,
+    );
+    let injectedConcurrentWrite = false;
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(function (
+      this: Storage,
+      key: string,
+      value: string,
+    ) {
+      originalSetItem.call(this, key, value);
+      if (
+        !injectedConcurrentWrite &&
+        getNewThreadDraftSlotIdFromStorageKey(key) !== null
+      ) {
+        injectedConcurrentWrite = true;
+        originalSetItem.call(
+          this,
+          promptDraftSlotStorageKeysForTests.legacy,
+          second,
+        );
+      }
+    });
+
+    initializeNewThreadDraftSlots("project-current", 100);
+    expect(
+      window.localStorage.getItem(promptDraftSlotStorageKeysForTests.legacy),
+    ).toBe(second);
+    expect(readNewThreadDraftSlots().map((slot) => slot.draft.text)).toEqual([
+      "Window one",
+    ]);
+
+    initializeNewThreadDraftSlots("project-current", 200);
+    expect(
+      window.localStorage.getItem(promptDraftSlotStorageKeysForTests.legacy),
+    ).toBeNull();
+    expect(readNewThreadDraftSlots().map((slot) => slot.draft.text)).toEqual([
+      "Older build wrote later",
+      "Window one",
+    ]);
+  });
+
+  it("leaves the legacy value intact when the destination slot cannot be written", () => {
+    const legacy = legacyDraft("Keep me through quota failure");
+    window.localStorage.setItem(
+      promptDraftSlotStorageKeysForTests.legacy,
+      legacy,
+    );
+    const originalSetItem = Storage.prototype.setItem;
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(function (
+      this: Storage,
+      key: string,
+      value: string,
+    ) {
+      if (getNewThreadDraftSlotIdFromStorageKey(key) !== null) {
+        throw new DOMException("quota", "QuotaExceededError");
+      }
+      originalSetItem.call(this, key, value);
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    initializeNewThreadDraftSlots("project-current", 100);
+
+    expect(
+      window.localStorage.getItem(promptDraftSlotStorageKeysForTests.legacy),
+    ).toBe(legacy);
+    expect(readNewThreadDraftSlots()).toEqual([]);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/app/src/lib/prompt-draft-slots.ts
+++ b/apps/app/src/lib/prompt-draft-slots.ts
@@ -1,0 +1,381 @@
+import {
+  arePromptDraftStatesEqual,
+  isPromptDraftEmpty,
+  parsePromptDraftStorage,
+  type PromptDraftState,
+} from "@bb/client-core";
+import {
+  permissionModeSchema,
+  reasoningLevelSchema,
+  serviceTierSchema,
+  type PermissionMode,
+  type ReasoningLevel,
+  type ServiceTier,
+} from "@bb/domain";
+import { nanoid } from "nanoid";
+import { z } from "zod";
+
+const PROMPT_DRAFT_STORAGE_VERSION = "3";
+const LEGACY_NEW_THREAD_DRAFT_STORAGE_KEY = `bb.promptbox.contents-draft-${PROMPT_DRAFT_STORAGE_VERSION}`;
+const NEW_THREAD_DRAFT_SLOT_STORAGE_PREFIX =
+  "bb.promptbox.contents-draft-slot-";
+const NEW_THREAD_DRAFT_SLOT_STORAGE_SUFFIX = `-${PROMPT_DRAFT_STORAGE_VERSION}`;
+const NEW_THREAD_DRAFT_SLOT_ORDER_STORAGE_KEY =
+  "bb.promptbox.new-thread-draft-slot-order-1";
+
+const newThreadDraftDestinationSchema = z
+  .object({
+    projectId: z.string().min(1),
+    sectionId: z.string().min(1).nullable(),
+  })
+  .strict();
+const newThreadDraftComposerSelectionSchema = z
+  .object({
+    providerId: z.string().min(1),
+    model: z.string().min(1),
+    reasoningLevel: reasoningLevelSchema,
+    serviceTier: serviceTierSchema.optional(),
+    permissionMode: permissionModeSchema,
+    environmentSelectionValue: z.string().min(1),
+  })
+  .strict();
+const storedSlotSchema = z.object({
+  lastEditedAt: z.number().int().nonnegative(),
+  projectId: z.string().min(1),
+  sectionId: z.string().min(1).optional(),
+  composerSelection: newThreadDraftComposerSelectionSchema
+    .optional()
+    .catch(undefined),
+});
+const storedSlotOrderSchema = z
+  .object({
+    version: z.literal(1),
+    ids: z.array(z.string()),
+  })
+  .strict();
+
+export interface NewThreadDraftSlot {
+  id: string;
+  lastEditedAt: number;
+  draft: PromptDraftState;
+  destination: NewThreadDraftDestination;
+  composerSelection: NewThreadDraftComposerSelection | null;
+}
+
+export interface NewThreadDraftDestination {
+  projectId: string;
+  sectionId: string | null;
+}
+
+export interface NewThreadDraftComposerSelection {
+  providerId: string;
+  model: string;
+  reasoningLevel: ReasoningLevel;
+  serviceTier?: ServiceTier;
+  permissionMode: PermissionMode;
+  environmentSelectionValue: string;
+}
+
+function getLocalStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function isValidSlotId(value: string): boolean {
+  return value.length > 0 && value.length <= 200;
+}
+
+function normalizeSlotIds(ids: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const id of ids) {
+    if (!isValidSlotId(id) || seen.has(id)) continue;
+    seen.add(id);
+    normalized.push(id);
+  }
+  return normalized;
+}
+
+function parseStoredSlotOrder(rawValue: string | null): string[] {
+  if (rawValue === null) return [];
+  try {
+    const parsed: unknown = JSON.parse(rawValue);
+    const result = storedSlotOrderSchema.safeParse(parsed);
+    return result.success ? normalizeSlotIds(result.data.ids) : [];
+  } catch {
+    return [];
+  }
+}
+
+function serializeStoredSlotOrder(ids: readonly string[]): string {
+  return JSON.stringify({ version: 1, ids: normalizeSlotIds(ids) });
+}
+
+function readStoredSlotOrder(storage: Storage): string[] {
+  return parseStoredSlotOrder(
+    storage.getItem(NEW_THREAD_DRAFT_SLOT_ORDER_STORAGE_KEY),
+  );
+}
+
+function writeStoredSlotOrder(storage: Storage, ids: readonly string[]): void {
+  const normalized = normalizeSlotIds(ids);
+  if (normalized.length === 0) {
+    storage.removeItem(NEW_THREAD_DRAFT_SLOT_ORDER_STORAGE_KEY);
+    return;
+  }
+  storage.setItem(
+    NEW_THREAD_DRAFT_SLOT_ORDER_STORAGE_KEY,
+    serializeStoredSlotOrder(normalized),
+  );
+}
+
+export function createNewThreadDraftSlotId(): string {
+  return nanoid();
+}
+
+export function getNewThreadDraftSlotStorageKey(slotId: string): string {
+  if (!isValidSlotId(slotId)) {
+    throw new Error("A new-thread draft slot id must be non-empty.");
+  }
+  return `${NEW_THREAD_DRAFT_SLOT_STORAGE_PREFIX}${encodeURIComponent(slotId)}${NEW_THREAD_DRAFT_SLOT_STORAGE_SUFFIX}`;
+}
+
+export function getNewThreadDraftSlotIdFromStorageKey(
+  storageKey: string,
+): string | null {
+  if (
+    !storageKey.startsWith(NEW_THREAD_DRAFT_SLOT_STORAGE_PREFIX) ||
+    !storageKey.endsWith(NEW_THREAD_DRAFT_SLOT_STORAGE_SUFFIX)
+  ) {
+    return null;
+  }
+  const encoded = storageKey.slice(
+    NEW_THREAD_DRAFT_SLOT_STORAGE_PREFIX.length,
+    -NEW_THREAD_DRAFT_SLOT_STORAGE_SUFFIX.length,
+  );
+  try {
+    const slotId = decodeURIComponent(encoded);
+    return isValidSlotId(slotId) ? slotId : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseNewThreadDraftSlot(
+  slotId: string,
+  rawValue: string | null,
+): NewThreadDraftSlot | null {
+  const draft = parsePromptDraftStorage(rawValue);
+  if (rawValue === null || isPromptDraftEmpty(draft)) return null;
+
+  try {
+    const parsed: unknown = JSON.parse(rawValue);
+    const result = storedSlotSchema.safeParse(parsed);
+    if (!result.success) return null;
+    return {
+      id: slotId,
+      lastEditedAt: result.data.lastEditedAt,
+      draft,
+      destination: {
+        projectId: result.data.projectId,
+        sectionId: result.data.sectionId ?? null,
+      },
+      composerSelection: result.data.composerSelection ?? null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function serializeNewThreadDraftSlot(
+  draft: PromptDraftState,
+  lastEditedAt: number,
+  destination: NewThreadDraftDestination,
+  composerSelection: NewThreadDraftComposerSelection | null = null,
+): string | null {
+  if (isPromptDraftEmpty(draft)) return null;
+  const parsedDestination = newThreadDraftDestinationSchema.parse(destination);
+  const parsedComposerSelection =
+    composerSelection === null
+      ? null
+      : newThreadDraftComposerSelectionSchema.parse(composerSelection);
+  return JSON.stringify({
+    text: draft.text,
+    ...(draft.mentions.length > 0 ? { mentions: draft.mentions } : {}),
+    attachments: draft.attachments,
+    lastEditedAt,
+    projectId: parsedDestination.projectId,
+    ...(parsedDestination.sectionId === null
+      ? {}
+      : { sectionId: parsedDestination.sectionId }),
+    ...(parsedComposerSelection === null
+      ? {}
+      : { composerSelection: parsedComposerSelection }),
+  });
+}
+
+function listStoredSlotIds(storage: Storage): string[] {
+  const ids: string[] = [];
+  for (let index = 0; index < storage.length; index += 1) {
+    const key = storage.key(index);
+    if (key === null) continue;
+    const slotId = getNewThreadDraftSlotIdFromStorageKey(key);
+    if (slotId !== null) ids.push(slotId);
+  }
+  return normalizeSlotIds(ids);
+}
+
+export function readNewThreadDraftSlots(): readonly NewThreadDraftSlot[] {
+  const storage = getLocalStorage();
+  if (storage === null) return [];
+
+  const slotsById = new Map<string, NewThreadDraftSlot>();
+  for (const id of listStoredSlotIds(storage)) {
+    const storageKey = getNewThreadDraftSlotStorageKey(id);
+    const slot = parseNewThreadDraftSlot(id, storage.getItem(storageKey));
+    if (slot === null) {
+      storage.removeItem(storageKey);
+      continue;
+    }
+    slotsById.set(id, slot);
+  }
+
+  const storedOrder = readStoredSlotOrder(storage);
+  const storedOrderIndexes = new Map(
+    storedOrder.map((id, index) => [id, index]),
+  );
+  const normalizedOrder = [...slotsById.values()]
+    .sort(
+      (left, right) =>
+        right.lastEditedAt - left.lastEditedAt ||
+        (storedOrderIndexes.get(left.id) ?? Number.MAX_SAFE_INTEGER) -
+          (storedOrderIndexes.get(right.id) ?? Number.MAX_SAFE_INTEGER) ||
+        left.id.localeCompare(right.id),
+    )
+    .map((slot) => slot.id);
+  const serializedOrder = serializeStoredSlotOrder(normalizedOrder);
+  const storedRaw = storage.getItem(NEW_THREAD_DRAFT_SLOT_ORDER_STORAGE_KEY);
+  if (normalizedOrder.length === 0) {
+    if (storedRaw !== null) {
+      storage.removeItem(NEW_THREAD_DRAFT_SLOT_ORDER_STORAGE_KEY);
+    }
+  } else if (storedRaw !== serializedOrder) {
+    storage.setItem(NEW_THREAD_DRAFT_SLOT_ORDER_STORAGE_KEY, serializedOrder);
+  }
+  return normalizedOrder.flatMap((id) => {
+    const slot = slotsById.get(id);
+    return slot === undefined ? [] : [slot];
+  });
+}
+
+export function persistNewThreadDraftSlot(
+  slotId: string,
+  draft: PromptDraftState,
+  lastEditedAt: number,
+  destination: NewThreadDraftDestination,
+  composerSelection: NewThreadDraftComposerSelection | null = null,
+): string | null {
+  const storage = getLocalStorage();
+  const serialized = serializeNewThreadDraftSlot(
+    draft,
+    lastEditedAt,
+    destination,
+    composerSelection,
+  );
+  if (storage === null) return serialized;
+
+  const storageKey = getNewThreadDraftSlotStorageKey(slotId);
+  if (serialized === null) {
+    storage.removeItem(storageKey);
+    writeStoredSlotOrder(
+      storage,
+      readStoredSlotOrder(storage).filter((id) => id !== slotId),
+    );
+    return null;
+  }
+
+  storage.setItem(storageKey, serialized);
+  readNewThreadDraftSlots();
+  return serialized;
+}
+
+function hashLegacyDraft(rawValue: string): string {
+  let hash = 2_166_136_261;
+  for (let index = 0; index < rawValue.length; index += 1) {
+    hash ^= rawValue.charCodeAt(index);
+    hash = Math.imul(hash, 16_777_619);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+function findLegacyMigrationSlotId(
+  storage: Storage,
+  rawValue: string,
+  draft: PromptDraftState,
+): { id: string; alreadyMigrated: boolean } {
+  const baseId = `legacy-${hashLegacyDraft(rawValue)}`;
+  for (let suffix = 0; ; suffix += 1) {
+    const id = suffix === 0 ? baseId : `${baseId}-${suffix}`;
+    const existing = parseNewThreadDraftSlot(
+      id,
+      storage.getItem(getNewThreadDraftSlotStorageKey(id)),
+    );
+    if (existing === null) return { id, alreadyMigrated: false };
+    if (arePromptDraftStatesEqual(existing.draft, draft)) {
+      return { id, alreadyMigrated: true };
+    }
+  }
+}
+
+export function initializeNewThreadDraftSlots(
+  currentProjectId: string,
+  now = Date.now(),
+): void {
+  const storage = getLocalStorage();
+  if (storage === null) return;
+
+  const destinationResult = newThreadDraftDestinationSchema.safeParse({
+    projectId: currentProjectId,
+    sectionId: null,
+  });
+  if (!destinationResult.success) return;
+
+  readNewThreadDraftSlots();
+
+  const legacyRaw = storage.getItem(LEGACY_NEW_THREAD_DRAFT_STORAGE_KEY);
+  if (legacyRaw === null) return;
+  const legacyDraft = parsePromptDraftStorage(legacyRaw);
+  if (isPromptDraftEmpty(legacyDraft)) {
+    storage.removeItem(LEGACY_NEW_THREAD_DRAFT_STORAGE_KEY);
+    return;
+  }
+
+  const migration = findLegacyMigrationSlotId(storage, legacyRaw, legacyDraft);
+  try {
+    if (!migration.alreadyMigrated) {
+      persistNewThreadDraftSlot(
+        migration.id,
+        legacyDraft,
+        now,
+        destinationResult.data,
+      );
+    }
+    if (storage.getItem(LEGACY_NEW_THREAD_DRAFT_STORAGE_KEY) === legacyRaw) {
+      storage.removeItem(LEGACY_NEW_THREAD_DRAFT_STORAGE_KEY);
+    }
+  } catch (error) {
+    console.warn(
+      "[prompt-draft] could not migrate the legacy new-thread draft; leaving the original intact",
+      error,
+    );
+  }
+}
+
+export const promptDraftSlotStorageKeysForTests = {
+  legacy: LEGACY_NEW_THREAD_DRAFT_STORAGE_KEY,
+  order: NEW_THREAD_DRAFT_SLOT_ORDER_STORAGE_KEY,
+} as const;

--- a/apps/app/src/lib/root-compose-location-state.ts
+++ b/apps/app/src/lib/root-compose-location-state.ts
@@ -1,0 +1,25 @@
+const ROOT_COMPOSE_DRAFT_SLOT_ID_FIELD = "draftSlotId";
+
+function isLocationStateRecord(
+  state: unknown,
+): state is Record<string, unknown> {
+  return typeof state === "object" && state !== null && !Array.isArray(state);
+}
+
+export function readRootComposeDraftSlotId(state: unknown): string | null {
+  if (!isLocationStateRecord(state)) return null;
+  const draftSlotId = state[ROOT_COMPOSE_DRAFT_SLOT_ID_FIELD];
+  return typeof draftSlotId === "string" && draftSlotId.trim().length > 0
+    ? draftSlotId
+    : null;
+}
+
+export function withRootComposeDraftSlotId(
+  state: unknown,
+  draftSlotId: string,
+): Record<string, unknown> {
+  return {
+    ...(isLocationStateRecord(state) ? state : {}),
+    [ROOT_COMPOSE_DRAFT_SLOT_ID_FIELD]: draftSlotId,
+  };
+}

--- a/apps/app/src/lib/split-layout/atoms.test.ts
+++ b/apps/app/src/lib/split-layout/atoms.test.ts
@@ -8,8 +8,12 @@ import {
   MAXIMIZED_PANE_STORAGE_KEY,
   splitLayoutAtom,
 } from "./atoms";
-import { countPanes, findPaneByThread, splitPane } from "./ops";
-import { serializeSplitLayout, SPLIT_LAYOUT_STORAGE_KEY } from "./persistence";
+import { countPanes, findPaneByThread, listPanes, splitPane } from "./ops";
+import {
+  serializeSplitLayout,
+  SPLIT_LAYOUT_SCHEMA_VERSION,
+  SPLIT_LAYOUT_STORAGE_KEY,
+} from "./persistence";
 import type { SplitLayout } from "./types";
 
 function singlePane(threadId: string): SplitLayout {
@@ -58,6 +62,56 @@ function hydrateLayoutOnLoad(): SplitLayout | null {
 }
 
 describe("tab-scoped workspace state", () => {
+  it("durably upgrades v1 new-thread pane bindings on first hydrate", () => {
+    const legacy = JSON.stringify({
+      version: 1,
+      layout: {
+        root: {
+          type: "split",
+          dir: "row",
+          sizes: [0.5, 0.5],
+          children: [
+            {
+              type: "pane",
+              paneId: "pane-1",
+              content: { kind: "new-thread" },
+            },
+            {
+              type: "pane",
+              paneId: "pane-2",
+              content: { kind: "new-thread" },
+            },
+          ],
+        },
+        focusedPaneId: "pane-2",
+      },
+    });
+    window.sessionStorage.setItem(SPLIT_LAYOUT_STORAGE_KEY, legacy);
+
+    const firstHydrate = hydrateLayoutOnLoad();
+    const firstSlotIds =
+      firstHydrate === null
+        ? []
+        : listPanes(firstHydrate.root).flatMap((pane) =>
+            pane.content.kind === "new-thread"
+              ? [pane.content.draftSlotId]
+              : [],
+          );
+    const upgradedSessionValue = window.sessionStorage.getItem(
+      SPLIT_LAYOUT_STORAGE_KEY,
+    );
+
+    expect(firstSlotIds).toHaveLength(2);
+    expect(new Set(firstSlotIds).size).toBe(2);
+    expect(JSON.parse(upgradedSessionValue ?? "null")).toMatchObject({
+      version: SPLIT_LAYOUT_SCHEMA_VERSION,
+    });
+    expect(window.localStorage.getItem(SPLIT_LAYOUT_STORAGE_KEY)).toBe(
+      upgradedSessionValue,
+    );
+    expect(hydrateLayoutOnLoad()).toEqual(firstHydrate);
+  });
+
   it("keeps this tab's panes when another tab opens a different thread", () => {
     const store = createStore();
     const unsubscribe = store.sub(splitLayoutAtom, () => {});

--- a/apps/app/src/lib/split-layout/atoms.ts
+++ b/apps/app/src/lib/split-layout/atoms.ts
@@ -15,10 +15,27 @@ import {
 import type { SplitLayout } from "./types";
 
 function createSplitLayoutStorage(): SyncStorage<SplitLayout | null> {
-  return createTabScopedStorage<SplitLayout | null>({
-    parse: (storedValue) => deserializeSplitLayout(storedValue),
+  let needsWriteBack = false;
+  const storage = createTabScopedStorage<SplitLayout | null>({
+    parse: (storedValue) => {
+      const layout = deserializeSplitLayout(storedValue);
+      needsWriteBack =
+        layout !== null && storedValue !== serializeSplitLayout(layout);
+      return layout;
+    },
     serialize: (value) => (value === null ? "" : serializeSplitLayout(value)),
   });
+  return {
+    ...storage,
+    getItem: (key, initialValue) => {
+      needsWriteBack = false;
+      const layout = storage.getItem(key, initialValue);
+      if (layout !== null && needsWriteBack) {
+        storage.setItem(key, layout);
+      }
+      return layout;
+    },
+  };
 }
 
 export const splitLayoutAtom = atomWithStorage<SplitLayout | null>(

--- a/apps/app/src/lib/split-layout/openPaneContentInSplit.ts
+++ b/apps/app/src/lib/split-layout/openPaneContentInSplit.ts
@@ -9,6 +9,7 @@ import {
   type PaneContent,
   type SplitLayout,
 } from "./index";
+import { withRootComposeDraftSlotId } from "../root-compose-location-state";
 
 interface SplitLayoutStore {
   get(atom: typeof splitLayoutAtom): SplitLayout | null;
@@ -19,7 +20,7 @@ export interface OpenPaneContentInSplitArgs {
   store: SplitLayoutStore;
   navigate: (
     route: string,
-    options?: { replace?: boolean },
+    options?: { replace?: boolean; state?: Record<string, unknown> },
   ) => void | Promise<void>;
   content: PaneContent;
   route: string;
@@ -33,9 +34,17 @@ export function openPaneContentInSplit({
   route,
   enabled,
 }: OpenPaneContentInSplitArgs): void {
+  const navigationState =
+    content.kind === "new-thread"
+      ? withRootComposeDraftSlotId(null, content.draftSlotId)
+      : undefined;
   const layout = store.get(splitLayoutAtom);
   if (!enabled || layout === null) {
-    void navigate(route);
+    if (navigationState === undefined) {
+      void navigate(route);
+    } else {
+      void navigate(route, { state: navigationState });
+    }
     return;
   }
   const existing = findPaneByContent(layout.root, content);
@@ -46,7 +55,14 @@ export function openPaneContentInSplit({
         ? replacePaneContent(layout, layout.focusedPaneId, content)
         : splitPane(layout, layout.focusedPaneId, "right", content);
   if (next !== layout) store.set(splitLayoutAtom, next);
-  void navigate(route, existing !== null ? { replace: true } : undefined);
+  if (existing === null && navigationState === undefined) {
+    void navigate(route);
+  } else {
+    void navigate(route, {
+      ...(existing !== null ? { replace: true as const } : {}),
+      ...(navigationState === undefined ? {} : { state: navigationState }),
+    });
+  }
 }
 
 export function holdsPluginDetailPane(

--- a/apps/app/src/lib/split-layout/ops.test.ts
+++ b/apps/app/src/lib/split-layout/ops.test.ts
@@ -3,6 +3,7 @@ import {
   MAX_PANES,
   countPanes,
   findPane,
+  findPaneByContent,
   findPaneByThread,
   listPanes,
   movePane,
@@ -18,6 +19,10 @@ import type { PaneContent, PaneNode, SplitLayout } from "./types";
 
 function threadContent(threadId: string, projectId = "project-1"): PaneContent {
   return { kind: "thread", projectId, threadId };
+}
+
+function newThreadContent(draftSlotId: string): PaneContent {
+  return { kind: "new-thread", draftSlotId };
 }
 
 function pane(paneId: string, threadId = paneId): PaneNode {
@@ -63,6 +68,34 @@ function expectNormalizedSizes(layout: SplitLayout): void {
 }
 
 describe("split layout operations", () => {
+  it("keeps independent new-thread slots distinct and finds the exact binding", () => {
+    const withFirstDraft = splitPane(
+      singlePaneLayout(),
+      "pane-1",
+      "right",
+      newThreadContent("draft-slot-1"),
+    );
+    const withBothDrafts = splitPane(
+      withFirstDraft,
+      "pane-2",
+      "bottom",
+      newThreadContent("draft-slot-2"),
+    );
+
+    expect(listPanes(withBothDrafts.root)).toHaveLength(3);
+    expect(
+      findPaneByContent(withBothDrafts.root, newThreadContent("draft-slot-1"))
+        ?.paneId,
+    ).toBe("pane-2");
+    expect(
+      findPaneByContent(withBothDrafts.root, newThreadContent("draft-slot-2"))
+        ?.paneId,
+    ).toBe("pane-3");
+    expect(
+      findPaneByContent(withBothDrafts.root, newThreadContent("missing-slot")),
+    ).toBeNull();
+  });
+
   it("rebalances seven successive default-right opens into eight equal usable panes", () => {
     const eight = layoutAtPaneCount(MAX_PANES);
 

--- a/apps/app/src/lib/split-layout/ops.ts
+++ b/apps/app/src/lib/split-layout/ops.ts
@@ -68,7 +68,12 @@ export function findPaneByContent(
     listPanes(root).find((pane) => {
       const candidate = pane.content;
       if (candidate.kind !== content.kind) return false;
-      if (content.kind === "new-thread") return true;
+      if (content.kind === "new-thread") {
+        return (
+          candidate.kind === "new-thread" &&
+          candidate.draftSlotId === content.draftSlotId
+        );
+      }
       if (content.kind === "thread") {
         return (
           candidate.kind === "thread" &&

--- a/apps/app/src/lib/split-layout/persistence.test.ts
+++ b/apps/app/src/lib/split-layout/persistence.test.ts
@@ -65,21 +65,26 @@ describe("split layout persistence", () => {
     expect(deserializeSplitLayout(serialized)).toEqual(layout);
   });
 
-  it("round-trips mixed new-thread and plugin panel content", () => {
+  it("round-trips two independent new-thread slots and plugin panel content", () => {
     const mixed: SplitLayout = {
       root: {
         type: "split",
         dir: "row",
-        sizes: [0.5, 0.5],
+        sizes: [0.3, 0.3, 0.4],
         children: [
           {
             type: "pane",
             paneId: "pane-1",
-            content: { kind: "new-thread" },
+            content: { kind: "new-thread", draftSlotId: "draft-slot-1" },
           },
           {
             type: "pane",
             paneId: "pane-2",
+            content: { kind: "new-thread", draftSlotId: "draft-slot-2" },
+          },
+          {
+            type: "pane",
+            paneId: "pane-3",
             content: {
               kind: "plugin-panel",
               pluginId: "notes",
@@ -93,6 +98,52 @@ describe("split layout persistence", () => {
     };
 
     expect(deserializeSplitLayout(serializeSplitLayout(mixed))).toEqual(mixed);
+  });
+
+  it("migrates v1 new-thread panes to distinct blank slot bindings", () => {
+    const legacy = JSON.stringify({
+      version: 1,
+      layout: {
+        root: {
+          type: "split",
+          dir: "row",
+          sizes: [0.5, 0.5],
+          children: [
+            {
+              type: "pane",
+              paneId: "pane-1",
+              content: { kind: "new-thread" },
+            },
+            {
+              type: "pane",
+              paneId: "pane-2",
+              content: { kind: "new-thread" },
+            },
+          ],
+        },
+        focusedPaneId: "pane-2",
+      },
+    });
+
+    const migrated = deserializeSplitLayout(legacy);
+    expect(migrated).not.toBeNull();
+    const contents =
+      migrated?.root.type === "split"
+        ? migrated.root.children.map((child) =>
+            child.type === "pane" ? child.content : null,
+          )
+        : [];
+    const slotIds = contents.flatMap((content) =>
+      content?.kind === "new-thread" ? [content.draftSlotId] : [],
+    );
+    expect(slotIds).toHaveLength(2);
+    expect(slotIds.every((slotId) => slotId.length > 0)).toBe(true);
+    expect(new Set(slotIds).size).toBe(2);
+    expect(
+      migrated === null
+        ? null
+        : deserializeSplitLayout(serializeSplitLayout(migrated)),
+    ).toEqual(migrated);
   });
 
   it("round-trips and restores all eight panes with focus and sizes intact", () => {

--- a/apps/app/src/lib/split-layout/persistence.ts
+++ b/apps/app/src/lib/split-layout/persistence.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
+import { createNewThreadDraftSlotId } from "@/lib/prompt-draft-slots";
 import { MAX_PANES, countPanes, listPanes } from "./ops";
 import type { LayoutNode, PaneNode, SplitLayout, SplitNode } from "./types";
 
-export const SPLIT_LAYOUT_SCHEMA_VERSION = 1;
+export const SPLIT_LAYOUT_SCHEMA_VERSION = 2;
 export const SPLIT_LAYOUT_STORAGE_KEY = "bb.splitLayout";
 
 const paneContentSchema = z.discriminatedUnion("kind", [
@@ -13,7 +14,12 @@ const paneContentSchema = z.discriminatedUnion("kind", [
       threadId: z.string().min(1),
     })
     .strict(),
-  z.object({ kind: z.literal("new-thread") }).strict(),
+  z
+    .object({
+      kind: z.literal("new-thread"),
+      draftSlotId: z.string().min(1),
+    })
+    .strict(),
   z
     .object({
       kind: z.literal("plugin-panel"),
@@ -106,6 +112,130 @@ const storedSplitLayoutSchema = z
   })
   .strict();
 
+type LegacyPaneContent =
+  | Extract<PaneNode["content"], { kind: "thread" }>
+  | { kind: "new-thread" }
+  | Extract<PaneNode["content"], { kind: "plugin-panel" }>;
+
+interface LegacyPaneNode {
+  type: "pane";
+  paneId: string;
+  content: LegacyPaneContent;
+}
+
+interface LegacySplitNode {
+  type: "split";
+  dir: "row" | "col";
+  sizes: number[];
+  children: LegacyLayoutNode[];
+}
+
+type LegacyLayoutNode = LegacyPaneNode | LegacySplitNode;
+
+interface LegacySplitLayout {
+  root: LegacyLayoutNode;
+  focusedPaneId: string;
+}
+
+const legacyPaneContentSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("thread"),
+      projectId: z.string().min(1),
+      threadId: z.string().min(1),
+    })
+    .strict(),
+  z.object({ kind: z.literal("new-thread") }).strict(),
+  z
+    .object({
+      kind: z.literal("plugin-panel"),
+      pluginId: z.string().min(1),
+      panelPath: z.string().min(1),
+      subPath: z.string(),
+    })
+    .strict(),
+]);
+
+const legacyPaneNodeSchema: z.ZodType<LegacyPaneNode> = z
+  .object({
+    type: z.literal("pane"),
+    paneId: z.string().min(1),
+    content: legacyPaneContentSchema,
+  })
+  .strict();
+
+const legacyLayoutNodeSchema: z.ZodType<LegacyLayoutNode> = z.lazy(() =>
+  z.union([legacyPaneNodeSchema, legacySplitNodeSchema]),
+);
+
+const legacySplitNodeSchema: z.ZodType<LegacySplitNode> = z
+  .object({
+    type: z.literal("split"),
+    dir: z.enum(["row", "col"]),
+    sizes: z.array(z.number().positive()),
+    children: z.array(legacyLayoutNodeSchema).min(2),
+  })
+  .strict()
+  .superRefine((split, context) => {
+    if (split.sizes.length !== split.children.length) {
+      context.addIssue({
+        code: "custom",
+        message: "Split sizes must match its child count",
+        path: ["sizes"],
+      });
+    }
+    const total = split.sizes.reduce((sum, size) => sum + size, 0);
+    if (Math.abs(total - 1) > 1e-9) {
+      context.addIssue({
+        code: "custom",
+        message: "Split sizes must sum to 1",
+        path: ["sizes"],
+      });
+    }
+  });
+
+const legacyStoredSplitLayoutSchema = z
+  .object({
+    version: z.literal(1),
+    layout: z
+      .object({
+        root: legacyLayoutNodeSchema,
+        focusedPaneId: z.string().min(1),
+      })
+      .strict(),
+  })
+  .strict();
+
+function migrateLegacyLayoutNode(node: LegacyLayoutNode): LayoutNode {
+  if (node.type === "split") {
+    return {
+      ...node,
+      children: node.children.map(migrateLegacyLayoutNode),
+    };
+  }
+  if (node.content.kind === "new-thread") {
+    return {
+      ...node,
+      content: {
+        kind: "new-thread",
+        draftSlotId: createNewThreadDraftSlotId(),
+      },
+    };
+  }
+  return {
+    type: "pane",
+    paneId: node.paneId,
+    content: node.content,
+  };
+}
+
+function migrateLegacySplitLayout(layout: LegacySplitLayout): SplitLayout {
+  return {
+    root: migrateLegacyLayoutNode(layout.root),
+    focusedPaneId: layout.focusedPaneId,
+  };
+}
+
 export function serializeSplitLayout(layout: SplitLayout): string {
   return JSON.stringify({ version: SPLIT_LAYOUT_SCHEMA_VERSION, layout });
 }
@@ -119,7 +249,13 @@ export function deserializeSplitLayout(
   try {
     const parsed: unknown = JSON.parse(storedValue);
     const result = storedSplitLayoutSchema.safeParse(parsed);
-    return result.success ? result.data.layout : null;
+    if (result.success) return result.data.layout;
+
+    const legacyResult = legacyStoredSplitLayoutSchema.safeParse(parsed);
+    if (!legacyResult.success) return null;
+    const migrated = migrateLegacySplitLayout(legacyResult.data.layout);
+    const migratedResult = splitLayoutSchema.safeParse(migrated);
+    return migratedResult.success ? migratedResult.data : null;
   } catch {
     return null;
   }

--- a/apps/app/src/lib/split-layout/types.ts
+++ b/apps/app/src/lib/split-layout/types.ts
@@ -6,6 +6,7 @@ export type PaneContent =
     }
   | {
       kind: "new-thread";
+      draftSlotId: string;
     }
   | {
       kind: "plugin-panel";

--- a/apps/app/src/views/RootComposeView.test.ts
+++ b/apps/app/src/views/RootComposeView.test.ts
@@ -31,10 +31,13 @@ import {
   readSectionIdFromLocationState,
   readRootComposeSectionTargetFromLocationState,
   readInitialPromptFromLocationState,
+  resolveRootComposeInitialDestination,
+  resolveRootComposeSelectionScope,
   shouldReplaceInitialPromptFromLocationState,
   shouldStartComposingFromLocationState,
   shouldNavigateAfterThreadCreate,
 } from "./RootComposeView";
+import { withRootComposeDraftSlotId } from "@/lib/root-compose-location-state";
 import { resolveRootComposeProjectFileRouting } from "./RootComposePanelTabContent";
 import {
   resolveProjectSourceWorktreeDisabledReason,
@@ -501,6 +504,51 @@ describe("readRootComposeSectionTargetFromLocationState", () => {
   it("returns null when no section target instruction is present", () => {
     expect(readRootComposeSectionTargetFromLocationState(null)).toBeNull();
     expect(readRootComposeSectionTargetFromLocationState({})).toBeNull();
+  });
+});
+
+describe("root compose draft slot context", () => {
+  it("restores the stored submit destination instead of the current root default", () => {
+    expect(
+      resolveRootComposeInitialDestination({
+        currentProjectId: "project-current-default",
+        routeSectionId: "section-route",
+        storedDestination: {
+          projectId: "project-stored",
+          sectionId: "section-stored",
+        },
+      }),
+    ).toEqual({
+      projectId: "project-stored",
+      sectionId: "section-stored",
+    });
+  });
+
+  it("seeds a fresh slot from the current project and route section", () => {
+    expect(
+      resolveRootComposeInitialDestination({
+        currentProjectId: "project-current-default",
+        routeSectionId: "section-route",
+        storedDestination: null,
+      }),
+    ).toEqual({
+      projectId: "project-current-default",
+      sectionId: "section-route",
+    });
+  });
+
+  it("retains slot identity while clearing single-use route state", () => {
+    expect(withRootComposeDraftSlotId(null, "slot-1")).toEqual({
+      draftSlotId: "slot-1",
+    });
+    expect(withRootComposeDraftSlotId({ focusPrompt: true }, "slot-1")).toEqual(
+      { draftSlotId: "slot-1", focusPrompt: true },
+    );
+  });
+
+  it("isolates model selection only inside an actual split", () => {
+    expect(resolveRootComposeSelectionScope(true)).toBe("component-local");
+    expect(resolveRootComposeSelectionScope(false)).toBe("new-thread");
   });
 });
 

--- a/apps/app/src/views/RootComposeView.tsx
+++ b/apps/app/src/views/RootComposeView.tsx
@@ -135,6 +135,11 @@ import {
   useSetRootComposeProjectId,
 } from "@/lib/root-compose-selection";
 import {
+  readNewThreadDraftSlots,
+  type NewThreadDraftDestination,
+} from "@/lib/prompt-draft-slots";
+import { withRootComposeDraftSlotId } from "@/lib/root-compose-location-state";
+import {
   ROOT_COMPOSE_PINNED_PANEL_TOGGLE_POSITION_CLASS,
   RootComposeSecondaryContent,
 } from "./RootComposeSecondaryContent";
@@ -230,6 +235,31 @@ export function shouldStartComposingFromLocationState(state: unknown): boolean {
     return false;
   }
   return "focusPrompt" in state && state.focusPrompt === true;
+}
+
+interface ResolveRootComposeInitialDestinationArgs {
+  currentProjectId: string;
+  routeSectionId: string | null;
+  storedDestination: NewThreadDraftDestination | null;
+}
+
+export function resolveRootComposeInitialDestination({
+  currentProjectId,
+  routeSectionId,
+  storedDestination,
+}: ResolveRootComposeInitialDestinationArgs): NewThreadDraftDestination {
+  return (
+    storedDestination ?? {
+      projectId: currentProjectId,
+      sectionId: routeSectionId,
+    }
+  );
+}
+
+export function resolveRootComposeSelectionScope(
+  isSplitPane: boolean,
+): "component-local" | "new-thread" {
+  return isSplitPane ? "component-local" : "new-thread";
 }
 
 interface BuildMobileRecentThreadsArgs {
@@ -478,16 +508,41 @@ export function LegacyProjectComposeRedirect({
   return <RouteLoadingSkeleton isBoundedPane={false} />;
 }
 
-export function RootComposeView() {
-  const [rootComposeProjectId, setRootComposeProjectId] =
+interface RootComposeViewProps {
+  draftSlotId: string;
+}
+
+export function RootComposeView({ draftSlotId }: RootComposeViewProps) {
+  return <RootComposeSlotView key={draftSlotId} draftSlotId={draftSlotId} />;
+}
+
+function RootComposeSlotView({ draftSlotId }: RootComposeViewProps) {
+  const paneContext = useOptionalPaneContext();
+  const isSplitPane = paneContext?.isSplitPane === true;
+  const [globalRootComposeProjectId, setGlobalRootComposeProjectId] =
     useRootComposeProjectId();
   const location = useLocation();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const createThread = useCreateThread();
+  const [storedDestination] = useState(
+    () =>
+      readNewThreadDraftSlots().find((slot) => slot.id === draftSlotId)
+        ?.destination ?? null,
+  );
+  const [initialDestination] = useState(() =>
+    resolveRootComposeInitialDestination({
+      currentProjectId: globalRootComposeProjectId,
+      routeSectionId: readSectionIdFromLocationState(location.state),
+      storedDestination,
+    }),
+  );
+  const [rootComposeProjectId, setLocalRootComposeProjectId] = useState(
+    initialDestination.projectId,
+  );
   const [rootComposeSectionId, setRootComposeSectionId] = useState<
     string | null
-  >(() => readSectionIdFromLocationState(location.state));
+  >(initialDestination.sectionId);
   const [lastCreatedThreadId, setLastCreatedThreadId] = useState<string | null>(
     null,
   );
@@ -498,6 +553,16 @@ export function RootComposeView() {
     useNavigateToThreadAfterCreatePreference();
   const [forkSeed, setForkSeed] = useState<ForkThreadCreateSeed | null>(() =>
     readForkThreadCreateSeedFromLocationState(location.state),
+  );
+
+  const setRootComposeProjectId = useCallback(
+    (projectId: string) => {
+      setLocalRootComposeProjectId(projectId);
+      if (!isSplitPane) {
+        setGlobalRootComposeProjectId(projectId);
+      }
+    },
+    [isSplitPane, setGlobalRootComposeProjectId],
   );
 
   const handleProjectChange = useCallback(
@@ -577,8 +642,15 @@ export function RootComposeView() {
     <NewThreadComposer
       projectId={rootComposeProjectId}
       onProjectChange={handleProjectChange}
-      draftStorage={{ kind: "new-thread" }}
-      selectionScope="new-thread"
+      draftStorage={{
+        kind: "new-thread",
+        slotId: draftSlotId,
+        destination: {
+          projectId: rootComposeProjectId,
+          sectionId: rootComposeSectionId,
+        },
+      }}
+      selectionScope={resolveRootComposeSelectionScope(isSplitPane)}
       seed={composerSeed}
       resetKey={forkSeed?.sourceThreadId ?? null}
       preferReadyProviderWhenUnset={forkSeed === null}
@@ -587,8 +659,10 @@ export function RootComposeView() {
       {(composer) => (
         <RootComposeSurface
           composer={composer}
+          draftSlotId={draftSlotId}
           forkSeed={forkSeed}
           lastCreatedThreadId={lastCreatedThreadId}
+          restoredDraftDestination={storedDestination !== null}
           rootComposeProjectId={rootComposeProjectId}
           setForkSeed={setForkSeed}
           setRootComposeProjectId={setRootComposeProjectId}
@@ -603,8 +677,10 @@ export function RootComposeView() {
 
 interface RootComposeSurfaceProps {
   composer: NewThreadComposerState;
+  draftSlotId: string;
   forkSeed: ForkThreadCreateSeed | null;
   lastCreatedThreadId: string | null;
+  restoredDraftDestination: boolean;
   rootComposeProjectId: string;
   setForkSeed: (seed: ForkThreadCreateSeed | null) => void;
   setRootComposeProjectId: (projectId: string) => void;
@@ -615,8 +691,10 @@ interface RootComposeSurfaceProps {
 
 function RootComposeSurface({
   composer,
+  draftSlotId,
   forkSeed,
   lastCreatedThreadId,
+  restoredDraftDestination,
   rootComposeProjectId,
   setForkSeed,
   setRootComposeProjectId,
@@ -727,7 +805,13 @@ function RootComposeSurface({
     }
     if (sectionTarget?.kind === "set") {
       setRootComposeSectionId(sectionTarget.sectionId);
-    } else if (sectionTarget?.kind === "clear") {
+    } else if (
+      sectionTarget?.kind === "clear" &&
+      !(
+        restoredDraftDestination &&
+        shouldStartComposingFromLocationState(location.state)
+      )
+    ) {
       setRootComposeSectionId(null);
     }
     if (reuseEnvironmentId !== null) {
@@ -756,17 +840,19 @@ function RootComposeSurface({
     }
     navigate(getRootComposeRoutePath() + location.search, {
       replace: true,
-      state: null,
+      state: withRootComposeDraftSlotId(null, draftSlotId),
     });
   }, [
     location.search,
     location.state,
     navigate,
+    draftSlotId,
     seedEnvironmentSelectionValue,
     setForkSeed,
     setPermissionMode,
     setPromptDraft,
     setProviderModelReasoning,
+    restoredDraftDestination,
     setRootComposeProjectId,
     setRootComposeSectionId,
     setServiceTier,
@@ -783,12 +869,13 @@ function RootComposeSurface({
     }
     navigate(getRootComposeRoutePath() + location.search, {
       replace: true,
-      state: { focusPrompt: true },
+      state: withRootComposeDraftSlotId({ focusPrompt: true }, draftSlotId),
     });
   }, [
     location.search,
     location.state,
     navigate,
+    draftSlotId,
     restorePromptDraftIfEmpty,
     setPromptDraft,
   ]);

--- a/apps/app/src/views/SplitWorkspaceRoute.test.tsx
+++ b/apps/app/src/views/SplitWorkspaceRoute.test.tsx
@@ -1,13 +1,32 @@
 // @vitest-environment jsdom
 
-import { Suspense, useEffect } from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
-import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Suspense, useEffect, type ComponentProps } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+} from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PaneContent } from "@/lib/split-layout";
+import { readRootComposeDraftSlotId } from "@/lib/root-compose-location-state";
 import SplitWorkspaceRoute from "./SplitWorkspaceRoute";
 
 const workspaceLifecycle = vi.hoisted(() => ({ mounts: 0, unmounts: 0 }));
+const draftSlotSequence = vi.hoisted(() => ({ next: 1 }));
+
+vi.mock("@/lib/prompt-draft-slots", () => ({
+  createNewThreadDraftSlotId: () =>
+    `generated-slot-${draftSlotSequence.next++}`,
+}));
 
 vi.mock("./thread-detail/SplitThreadArea", () => ({
   SplitThreadArea: ({ routeContent }: { routeContent: PaneContent }) => {
@@ -17,7 +36,13 @@ vi.mock("./thread-detail/SplitThreadArea", () => ({
         workspaceLifecycle.unmounts += 1;
       };
     }, []);
-    return <output data-testid="route-content">{routeContent.kind}</output>;
+    return (
+      <output data-testid="route-content">
+        {routeContent.kind === "new-thread"
+          ? `${routeContent.kind}:${routeContent.draftSlotId}`
+          : routeContent.kind}
+      </output>
+    );
   },
 }));
 
@@ -44,23 +69,60 @@ function NavigationControls() {
   );
 }
 
+function LocationStateProbe() {
+  const location = useLocation();
+  const state =
+    typeof location.state === "object" && location.state !== null
+      ? location.state
+      : {};
+  return (
+    <output
+      data-testid="location-state"
+      data-focus-prompt={
+        "focusPrompt" in state && state.focusPrompt === true ? "true" : "false"
+      }
+    >
+      {readRootComposeDraftSlotId(location.state) ?? "none"}
+    </output>
+  );
+}
+
+function WorkspaceRouteHarness({
+  initialEntries,
+}: {
+  initialEntries: ComponentProps<typeof MemoryRouter>["initialEntries"];
+}) {
+  return (
+    <MemoryRouter initialEntries={initialEntries}>
+      <NavigationControls />
+      <LocationStateProbe />
+      <Routes>
+        <Route path="*" element={<SplitWorkspaceRoute />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
 describe("SplitWorkspaceRoute", () => {
   beforeEach(() => {
     workspaceLifecycle.mounts = 0;
     workspaceLifecycle.unmounts = 0;
+    draftSlotSequence.next = 1;
   });
 
-  it("preserves the workspace mount across focus-driven page URL changes", () => {
-    render(
-      <MemoryRouter initialEntries={["/"]}>
-        <NavigationControls />
-        <Routes>
-          <Route path="*" element={<SplitWorkspaceRoute />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+  afterEach(cleanup);
 
-    expect(screen.getByTestId("route-content").textContent).toBe("new-thread");
+  it("preserves the workspace mount across focus-driven page URL changes", async () => {
+    render(<WorkspaceRouteHarness initialEntries={["/"]} />);
+
+    expect(screen.getByTestId("route-content").textContent).toBe(
+      "new-thread:generated-slot-1",
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("location-state").textContent).toBe(
+        "generated-slot-1",
+      ),
+    );
 
     fireEvent.click(screen.getByRole("button", { name: "plugin" }));
     expect(screen.getByTestId("route-content").textContent).toBe(
@@ -70,6 +132,58 @@ describe("SplitWorkspaceRoute", () => {
     fireEvent.click(screen.getByRole("button", { name: "thread" }));
     expect(screen.getByTestId("route-content").textContent).toBe("thread");
     expect(workspaceLifecycle).toEqual({ mounts: 1, unmounts: 0 });
+  });
+
+  it("allocates once per public root arrival and not on a plain rerender", async () => {
+    const view = render(
+      <WorkspaceRouteHarness initialEntries={["/plugins/docs/docs"]} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "compose" }));
+    await waitFor(() =>
+      expect(screen.getByTestId("route-content").textContent).toBe(
+        "new-thread:generated-slot-1",
+      ),
+    );
+    view.rerender(
+      <WorkspaceRouteHarness initialEntries={["/plugins/docs/docs"]} />,
+    );
+    expect(screen.getByTestId("route-content").textContent).toBe(
+      "new-thread:generated-slot-1",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "plugin" }));
+    fireEvent.click(screen.getByRole("button", { name: "compose" }));
+    await waitFor(() =>
+      expect(screen.getByTestId("route-content").textContent).toBe(
+        "new-thread:generated-slot-2",
+      ),
+    );
+    expect(draftSlotSequence.next).toBe(3);
+  });
+
+  it("uses an explicit reentry slot without allocating and preserves seed state", () => {
+    render(
+      <WorkspaceRouteHarness
+        initialEntries={[
+          {
+            pathname: "/",
+            state: { draftSlotId: "existing-slot", focusPrompt: true },
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("route-content").textContent).toBe(
+      "new-thread:existing-slot",
+    );
+    expect(screen.getByTestId("location-state").textContent).toBe(
+      "existing-slot",
+    );
+    expect(screen.getByTestId("location-state").dataset.focusPrompt).toBe(
+      "true",
+    );
+    expect(draftSlotSequence.next).toBe(1);
   });
 
   it("passes the plugin id from the full-window detail URL to ToolsView", async () => {

--- a/apps/app/src/views/SplitWorkspaceRoute.tsx
+++ b/apps/app/src/views/SplitWorkspaceRoute.tsx
@@ -1,5 +1,10 @@
-import { lazy, useMemo } from "react";
-import { matchPath, Navigate, useLocation } from "react-router-dom";
+import { lazy, useEffect, useMemo } from "react";
+import {
+  matchPath,
+  Navigate,
+  useLocation,
+  useNavigate,
+} from "react-router-dom";
 import { useAtomValue } from "jotai";
 import { splitLayoutAtom } from "@/lib/split-layout/atoms";
 import { holdsPluginDetailPane } from "@/lib/split-layout/openPaneContentInSplit";
@@ -11,11 +16,18 @@ import {
   TOOLS_PLUGIN_DETAIL_ROUTE_PATH,
 } from "@/lib/route-paths";
 import type { PaneContent } from "@/lib/split-layout";
+import { createNewThreadDraftSlotId } from "@/lib/prompt-draft-slots";
+import {
+  readRootComposeDraftSlotId,
+  withRootComposeDraftSlotId,
+} from "@/lib/root-compose-location-state";
 import { useRouteState } from "@/hooks/useRouteState";
 import { LegacyProjectComposeRedirect } from "./RootComposeView";
 import { SplitThreadArea } from "./thread-detail/SplitThreadArea";
 
-const ROOT_COMPOSE_CONTENT = { kind: "new-thread" } as const;
+function createDraftSlotForLocationEntry(_locationKey: string): string {
+  return createNewThreadDraftSlotId();
+}
 
 const ToolsView = lazy(() =>
   import("./ToolsView").then((m) => ({ default: m.ToolsView })),
@@ -23,6 +35,7 @@ const ToolsView = lazy(() =>
 
 export default function SplitWorkspaceRoute() {
   const location = useLocation();
+  const navigate = useNavigate();
   const { projectId, threadId, isThreadView } = useRouteState();
   const pluginMatch = matchPath(PLUGIN_PANEL_ROUTE_PATH, location.pathname);
   const pluginDetailMatch = matchPath(
@@ -38,9 +51,53 @@ export default function SplitWorkspaceRoute() {
   const pluginSubPath = pluginMatch?.params["*"] ?? "";
   const detailPluginId = pluginDetailMatch?.params.pluginId;
 
+  const rootComposeDraftSlotId = useMemo(() => {
+    if (location.pathname !== APP_ROOT_ROUTE_PATH) return null;
+    const explicitDraftSlotId = readRootComposeDraftSlotId(location.state);
+    if (explicitDraftSlotId !== null) return explicitDraftSlotId;
+    return createDraftSlotForLocationEntry(location.key);
+  }, [location.key, location.pathname, location.state]);
+
+  useEffect(() => {
+    if (
+      location.pathname !== APP_ROOT_ROUTE_PATH ||
+      rootComposeDraftSlotId === null ||
+      readRootComposeDraftSlotId(location.state) !== null
+    ) {
+      return;
+    }
+    void navigate(
+      {
+        pathname: location.pathname,
+        search: location.search,
+        hash: location.hash,
+      },
+      {
+        replace: true,
+        state: withRootComposeDraftSlotId(
+          location.state,
+          rootComposeDraftSlotId,
+        ),
+      },
+    );
+  }, [
+    location.hash,
+    location.pathname,
+    location.search,
+    location.state,
+    navigate,
+    rootComposeDraftSlotId,
+  ]);
+
   const routeContent = useMemo<PaneContent | null>(() => {
-    if (location.pathname === APP_ROOT_ROUTE_PATH) {
-      return ROOT_COMPOSE_CONTENT;
+    if (
+      location.pathname === APP_ROOT_ROUTE_PATH &&
+      rootComposeDraftSlotId !== null
+    ) {
+      return {
+        kind: "new-thread",
+        draftSlotId: rootComposeDraftSlotId,
+      };
     }
     if (isThreadView && projectId && threadId) {
       return { kind: "thread", projectId, threadId };
@@ -65,6 +122,7 @@ export default function SplitWorkspaceRoute() {
     pluginId,
     pluginSubPath,
     projectId,
+    rootComposeDraftSlotId,
     threadId,
   ]);
 

--- a/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.test.tsx
@@ -35,6 +35,7 @@ import type { PaneContent, SplitLayout } from "@/lib/split-layout";
 import { usePromptDraftStorage } from "@/hooks/usePromptDraftStorage";
 import { createBbDesktopApi } from "@/test/bb-desktop-test-utils";
 import { resourceRouteLabelAtom } from "@/components/layout/resourceRouteLabelAtom";
+import { readRootComposeDraftSlotId } from "@/lib/root-compose-location-state";
 import {
   resetPluginSlotStoreForTest,
   setPluginSlotRegistrations,
@@ -87,26 +88,28 @@ function HostedComposerScopeProbe({ threadId }: { threadId: string }) {
   );
 }
 
-function RootComposeFixture() {
+function RootComposeFixture({ draftSlotId }: { draftSlotId: string }) {
   const pane = useContext(PaneContext);
   const [isPanelOpen, setIsPanelOpen] = useState(false);
   const panelModel = useMemo(
     () => ({
       composerHost: null,
-      contentKey: "new-thread",
+      contentKey: `new-thread:${draftSlotId}`,
       isMainCollapsed: false,
       isOpen: isPanelOpen,
       panel: <div data-testid="hosted-new-thread-panel" />,
       onToggle: () => setIsPanelOpen((open) => !open),
       transitionsReady: true,
     }),
-    [isPanelOpen],
+    [draftSlotId, isPanelOpen],
   );
   usePaneSecondaryPanelRegistration(
     pane?.secondaryPanelHost ?? null,
     panelModel,
   );
-  return <div data-testid="root-compose-view" />;
+  return (
+    <div data-testid="root-compose-view" data-draft-slot-id={draftSlotId} />
+  );
 }
 
 vi.mock("@bb/shared-ui/hooks/use-compact-viewport", () => ({
@@ -429,7 +432,11 @@ const docsContent: PaneContent = {
   subPath: "",
 };
 
-const newThreadContent: PaneContent = { kind: "new-thread" };
+function newThreadContentFor(draftSlotId: string): PaneContent {
+  return { kind: "new-thread", draftSlotId };
+}
+
+const newThreadContent = newThreadContentFor("draft-slot-default");
 
 function pluginContent(panelPath: string): PaneContent {
   return {
@@ -527,7 +534,16 @@ function threadPath(threadId: string): string {
 
 function LocationProbe() {
   const location = useLocation();
-  return <div data-testid="location">{location.pathname}</div>;
+  return (
+    <div
+      data-testid="location"
+      data-draft-slot-id={
+        readRootComposeDraftSlotId(location.state) ?? undefined
+      }
+    >
+      {location.pathname}
+    </div>
+  );
 }
 
 function ExternalNav({ to }: { to: string }) {
@@ -1414,6 +1430,103 @@ describe("SplitThreadArea", () => {
         .getByRole("button", { name: "Hide right panel" })
         .getAttribute("aria-expanded"),
     ).toBe("true");
+  });
+
+  it("keeps each compose pane bound through focus, maximize, restore, and close", async () => {
+    const leftContent = newThreadContentFor("draft-slot-left");
+    const rightContent = newThreadContentFor("draft-slot-right");
+    renderSplitArea({
+      path: "/",
+      layout: {
+        root: {
+          type: "split",
+          dir: "row",
+          sizes: [0.5, 0.5],
+          children: [
+            { type: "pane", paneId: "pane-left", content: leftContent },
+            { type: "pane", paneId: "pane-right", content: rightContent },
+          ],
+        },
+        focusedPaneId: "pane-right",
+      },
+      routeContent: rightContent,
+    });
+
+    expect(
+      screen
+        .getAllByTestId("root-compose-view")
+        .map((view) => view.dataset.draftSlotId),
+    ).toEqual(["draft-slot-left", "draft-slot-right"]);
+
+    const leftPane = document.querySelector<HTMLElement>(
+      '[data-split-pane-id="pane-left"]',
+    );
+    const rightPane = document.querySelector<HTMLElement>(
+      '[data-split-pane-id="pane-right"]',
+    );
+    expect(leftPane).not.toBeNull();
+    expect(rightPane).not.toBeNull();
+    if (leftPane === null || rightPane === null) return;
+
+    fireEvent.pointerDown(leftPane);
+    await waitFor(() =>
+      expect(screen.getByTestId("location").dataset.draftSlotId).toBe(
+        "draft-slot-left",
+      ),
+    );
+
+    fireEvent.click(
+      within(rightPane).getByRole("button", { name: /Maximize pane/ }),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("location").dataset.draftSlotId).toBe(
+        "draft-slot-right",
+      ),
+    );
+    fireEvent.click(
+      within(rightPane).getByRole("button", { name: "Restore split" }),
+    );
+    expect(screen.getByTestId("location").dataset.draftSlotId).toBe(
+      "draft-slot-right",
+    );
+
+    fireEvent.pointerDown(leftPane);
+    fireEvent.click(
+      within(leftPane).getByRole("button", { name: "Close pane" }),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("location").dataset.draftSlotId).toBe(
+        "draft-slot-right",
+      ),
+    );
+    expect(screen.getByTestId("root-compose-view").dataset.draftSlotId).toBe(
+      "draft-slot-right",
+    );
+  });
+
+  it("passes the route slot to the standalone compose surface", () => {
+    viewportState.compact = true;
+    const routeContent = newThreadContentFor("draft-slot-standalone");
+    renderSplitArea({
+      path: "/",
+      layout: {
+        root: {
+          type: "split",
+          dir: "row",
+          sizes: [0.5, 0.5],
+          children: [
+            { type: "pane", paneId: "pane-1", content: threadContent("thr-a") },
+            { type: "pane", paneId: "pane-2", content: routeContent },
+          ],
+        },
+        focusedPaneId: "pane-2",
+      },
+      routeContent,
+    });
+
+    expect(screen.getByTestId("root-compose-view").dataset.draftSlotId).toBe(
+      "draft-slot-standalone",
+    );
   });
 
   it("hosts the app panel while a plugin pane is focused", async () => {

--- a/apps/app/src/views/thread-detail/SplitThreadArea.tsx
+++ b/apps/app/src/views/thread-detail/SplitThreadArea.tsx
@@ -93,7 +93,8 @@ import { getAdjacentPaneId } from "./splitPaneCommands";
 import {
   applyThreadPaneActionToLayout,
   createSinglePaneLayout,
-  focusedPaneRoute,
+  focusedPaneNavigationTarget,
+  paneContentNavigationTarget,
   paneContentRoute,
   reconcileLayoutForContent,
   threadPaneContent,
@@ -320,6 +321,22 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
     },
     [captureVisibleScrollPositions, setMaximizedPaneIdAtom],
   );
+  const replaceNavigateToContent = useCallback(
+    (content: PaneContent) => {
+      const target = paneContentNavigationTarget(content);
+      void navigate(target.to, { replace: true, state: target.state });
+    },
+    [navigate],
+  );
+  const replaceNavigateToFocusedPane = useCallback(
+    (nextLayout: SplitLayout) => {
+      const target = focusedPaneNavigationTarget(nextLayout);
+      if (target !== null) {
+        void navigate(target.to, { replace: true, state: target.state });
+      }
+    },
+    [navigate],
+  );
 
   useEffect(
     () =>
@@ -337,10 +354,7 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
         );
         if (next.layout !== current) {
           store.set(splitLayoutAtom, next.layout);
-          const route = focusedPaneRoute(next.layout);
-          if (route !== null) {
-            navigate(route, { replace: true });
-          }
+          replaceNavigateToFocusedPane(next.layout);
         }
         if (next.maximizedPaneId !== previousMaximizedPaneId) {
           setMaximizedPaneId(next.maximizedPaneId);
@@ -349,7 +363,7 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
           store.set(dimInactiveSplitsAtom, next.dimInactiveSplits);
         }
       }),
-    [navigate, setMaximizedPaneId, store],
+    [replaceNavigateToFocusedPane, setMaximizedPaneId, store],
   );
 
   useEffect(() => {
@@ -390,10 +404,16 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
         setMaximizedPaneId(paneId);
       }
       if (pane !== null) {
-        navigate(paneContentRoute(pane.content), { replace: true });
+        replaceNavigateToContent(pane.content);
       }
     },
-    [layout, maximizedPaneId, navigate, setLayout, setMaximizedPaneId],
+    [
+      layout,
+      maximizedPaneId,
+      replaceNavigateToContent,
+      setLayout,
+      setMaximizedPaneId,
+    ],
   );
 
   const closePane = useCallback(
@@ -410,13 +430,16 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
         setMaximizedPaneId(null);
       }
       if (next.focusedPaneId !== layout.focusedPaneId) {
-        const route = focusedPaneRoute(next);
-        if (route !== null) {
-          navigate(route, { replace: true });
-        }
+        replaceNavigateToFocusedPane(next);
       }
     },
-    [layout, maximizedPaneId, navigate, setLayout, setMaximizedPaneId],
+    [
+      layout,
+      maximizedPaneId,
+      replaceNavigateToFocusedPane,
+      setLayout,
+      setMaximizedPaneId,
+    ],
   );
 
   const toggleMaximizePane = useCallback(
@@ -429,12 +452,11 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
       if (current.focusedPaneId !== paneId) {
         const next = setFocus(current, paneId);
         store.set(splitLayoutAtom, next);
-        const route = focusedPaneRoute(next);
-        if (route !== null) navigate(route, { replace: true });
+        replaceNavigateToFocusedPane(next);
       }
       setMaximizedPaneId((previous) => (previous === paneId ? null : paneId));
     },
-    [navigate, setMaximizedPaneId, store],
+    [replaceNavigateToFocusedPane, setMaximizedPaneId, store],
   );
 
   const movePaneToSide = useCallback(
@@ -469,10 +491,9 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
       const next = movePane(current, paneId, target.paneId, side);
       if (next === current) return;
       store.set(splitLayoutAtom, next);
-      const route = focusedPaneRoute(next);
-      if (route !== null) navigate(route, { replace: true });
+      replaceNavigateToFocusedPane(next);
     },
-    [navigate, store],
+    [replaceNavigateToFocusedPane, store],
   );
 
   const resize = useCallback(
@@ -501,13 +522,10 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
         setMaximizedPaneId(null);
       }
       if (next.focusedPaneId !== current.focusedPaneId) {
-        const route = focusedPaneRoute(next);
-        if (route !== null) {
-          navigate(route, { replace: true });
-        }
+        replaceNavigateToFocusedPane(next);
       }
     },
-    [maximizedPaneId, navigate, setMaximizedPaneId, store],
+    [maximizedPaneId, replaceNavigateToFocusedPane, setMaximizedPaneId, store],
   );
 
   const beginPaneDrag = useCallback<BeginPaneDrag>(
@@ -560,14 +578,11 @@ function SplitThreadAreaContent({ routeContent }: SplitThreadAreaProps) {
             return;
           }
           store.set(splitLayoutAtom, next);
-          const route = focusedPaneRoute(next);
-          if (route !== null) {
-            navigate(route, { replace: true });
-          }
+          replaceNavigateToFocusedPane(next);
         },
       });
     },
-    [navigate, setMaximizedPaneId, store],
+    [replaceNavigateToFocusedPane, setMaximizedPaneId, store],
   );
 
   if (!splitWorkspaceActive || layout === null || currentContent === null) {
@@ -964,7 +979,7 @@ function StandalonePaneContent({
     return <ThreadDetailView surface="page" />;
   }
   if (content.kind === "new-thread") {
-    return <RootComposeView />;
+    return <RootComposeView draftSlotId={content.draftSlotId} />;
   }
   if (content.kind === "plugin-detail") {
     return <PluginDetailPaneView pluginId={content.pluginId} />;
@@ -1168,7 +1183,7 @@ function NonThreadPaneContent({
         )}
       >
         {content.kind === "new-thread" ? (
-          <RootComposeView />
+          <RootComposeView draftSlotId={content.draftSlotId} />
         ) : content.kind === "plugin-detail" ? (
           <PluginDetailPaneView pluginId={content.pluginId} />
         ) : (

--- a/apps/app/src/views/thread-detail/splitThreadNavigation.test.ts
+++ b/apps/app/src/views/thread-detail/splitThreadNavigation.test.ts
@@ -4,6 +4,7 @@ import {
   findPaneByThread,
   listPanes,
   MAX_PANES,
+  setFocus,
   splitPane,
 } from "@/lib/split-layout";
 import type { SplitLayout } from "@/lib/split-layout";
@@ -11,7 +12,10 @@ import {
   applyThreadOpenToLayout,
   applyThreadPaneActionToLayout,
   createSinglePaneLayout,
+  focusedPaneNavigationTarget,
   focusedPaneRoute,
+  paneContentForPathname,
+  paneContentNavigationTarget,
   reconcileLayoutForContent,
 } from "./splitThreadNavigation";
 
@@ -41,19 +45,98 @@ function eightPaneLayout(): SplitLayout {
 }
 
 describe("mixed page navigation", () => {
-  it("keeps New Thread as a singleton and focuses its existing pane", () => {
-    const withCompose = splitPane(twoPaneLayout(), "pane-2", "bottom", {
+  it("allocates compose identity only when opening the root in a split", () => {
+    expect(paneContentForPathname("/")).toBeNull();
+    expect(paneContentForPathname("/", true)).toEqual({
       kind: "new-thread",
+      draftSlotId: expect.any(String),
+    });
+  });
+
+  it("carries a compose slot through internal navigation state", () => {
+    const content = {
+      kind: "new-thread",
+      draftSlotId: "draft-slot-1",
+    } as const;
+    const layout: SplitLayout = {
+      root: { type: "pane", paneId: "pane-1", content },
+      focusedPaneId: "pane-1",
+    };
+
+    expect(paneContentNavigationTarget(content)).toEqual({
+      to: "/",
+      state: { draftSlotId: "draft-slot-1" },
+    });
+    expect(focusedPaneNavigationTarget(layout)).toEqual({
+      to: "/",
+      state: { draftSlotId: "draft-slot-1" },
+    });
+    expect(
+      paneContentNavigationTarget({
+        kind: "thread",
+        projectId: "p1",
+        threadId: "thread-1",
+      }),
+    ).toEqual({ to: "/projects/p1/threads/thread-1", state: null });
+  });
+
+  it("focuses the exact new-thread slot while independent slots coexist", () => {
+    const withFirstCompose = splitPane(twoPaneLayout(), "pane-2", "bottom", {
+      kind: "new-thread",
+      draftSlotId: "draft-slot-1",
+    });
+    const withBothComposers = splitPane(withFirstCompose, "pane-1", "bottom", {
+      kind: "new-thread",
+      draftSlotId: "draft-slot-2",
     });
 
+    const after = reconcileLayoutForContent(
+      setFocus(withBothComposers, "pane-4"),
+      {
+        kind: "new-thread",
+        draftSlotId: "draft-slot-1",
+      },
+    );
+
+    expect(listPanes(after.root)).toHaveLength(4);
+    expect(after.focusedPaneId).toBe(
+      findPaneByContent(after.root, {
+        kind: "new-thread",
+        draftSlotId: "draft-slot-1",
+      })?.paneId,
+    );
+    expect(
+      findPaneByContent(after.root, {
+        kind: "new-thread",
+        draftSlotId: "draft-slot-2",
+      }),
+    ).not.toBeNull();
+    expect(focusedPaneRoute(after)).toBe("/");
+  });
+
+  it("replaces only the focused pane for a new compose slot", () => {
+    const withCompose = splitPane(twoPaneLayout(), "pane-2", "bottom", {
+      kind: "new-thread",
+      draftSlotId: "draft-slot-1",
+    });
     const after = reconcileLayoutForContent(withCompose, {
       kind: "new-thread",
+      draftSlotId: "draft-slot-2",
     });
 
     expect(listPanes(after.root)).toHaveLength(3);
     expect(after.focusedPaneId).toBe(
-      findPaneByContent(after.root, { kind: "new-thread" })?.paneId,
+      findPaneByContent(after.root, {
+        kind: "new-thread",
+        draftSlotId: "draft-slot-2",
+      })?.paneId,
     );
+    expect(
+      findPaneByContent(after.root, {
+        kind: "new-thread",
+        draftSlotId: "draft-slot-1",
+      }),
+    ).toBeNull();
     expect(focusedPaneRoute(after)).toBe("/");
   });
 

--- a/apps/app/src/views/thread-detail/splitThreadNavigation.ts
+++ b/apps/app/src/views/thread-detail/splitThreadNavigation.ts
@@ -22,6 +22,8 @@ import {
   PLUGIN_PANEL_ROUTE_PATH,
   TOOLS_PLUGIN_DETAIL_ROUTE_PATH,
 } from "@/lib/route-paths";
+import { createNewThreadDraftSlotId } from "@/lib/prompt-draft-slots";
+import { withRootComposeDraftSlotId } from "@/lib/root-compose-location-state";
 
 const FIRST_PANE_ID = "pane-1";
 const SPLITTABLE_THREAD_ROUTE_PATH = "/projects/:projectId/threads/:threadId";
@@ -71,9 +73,31 @@ export function paneContentRoute(content: PaneContent): string {
   });
 }
 
-export function paneContentForPathname(pathname: string): PaneContent | null {
+export interface PaneContentNavigationTarget {
+  state: Record<string, unknown> | null;
+  to: string;
+}
+
+export function paneContentNavigationTarget(
+  content: PaneContent,
+): PaneContentNavigationTarget {
+  return {
+    to: paneContentRoute(content),
+    state:
+      content.kind === "new-thread"
+        ? withRootComposeDraftSlotId(null, content.draftSlotId)
+        : null,
+  };
+}
+
+export function paneContentForPathname(
+  pathname: string,
+  allocateNewThread = false,
+): PaneContent | null {
   if (pathname === APP_ROOT_ROUTE_PATH) {
-    return { kind: "new-thread" };
+    return allocateNewThread
+      ? { kind: "new-thread", draftSlotId: createNewThreadDraftSlotId() }
+      : null;
   }
   const thread = matchPath(
     { path: SPLITTABLE_THREAD_ROUTE_PATH, end: false },
@@ -127,6 +151,13 @@ export function reconcileLayoutForContent(
 export function focusedPaneRoute(layout: SplitLayout): string | null {
   const focused = findPane(layout.root, layout.focusedPaneId);
   return focused === null ? null : paneContentRoute(focused.content);
+}
+
+export function focusedPaneNavigationTarget(
+  layout: SplitLayout,
+): PaneContentNavigationTarget | null {
+  const focused = findPane(layout.root, layout.focusedPaneId);
+  return focused === null ? null : paneContentNavigationTarget(focused.content);
 }
 
 function threadOpenSplitZone(split: ThreadOpenSplit): SplitZone {


### PR DESCRIPTION
## What was wrong

New-thread compose state used one browser-wide draft identity. Opening a second new-thread pane reused that singleton, so two panes could not preserve independent unsent text or restore the focused draft reliably.

## What changed

- adds client-local draft slots with stable identities and submit destinations
- keys each app-owned new-thread pane to its own slot while leaving plugin-rendered composers outside Drafts state
- migrates legacy singleton draft and split-layout persistence deterministically
- preserves slot identity through split navigation, focus, close, remount, and reload

No server state, wire contract, or daemon protocol changes are introduced by this layer.

## Visual evidence

> Rebase evidence status: current parent `d1170cf94e6fcf3d58025fe72ed1cae72c2ec019` and current head `62d4e332a20d6bf8adaf24910a23ce994f343942`. The embedded captures below were made from the exact pre-rebase revisions and remain useful behavioral references, but they are not exact-current-revision evidence. Replace them before merge.

Pre-rebase behavioral comparison: `977d04e4236b68433bd068139909a3e129ed7b38` → `a2f8eea7dedf54396c68500d826f2ab3772a0cc3`.

### Before — pre-rebase base `977d04e4236b68433bd068139909a3e129ed7b38`

Modified **New thread** still resolves to the singleton composer.

![Before — one singleton composer](https://raw.githubusercontent.com/brsbl/bb/76fb4286cdd417380548c4ab629a7edf72474932/updated-sidebar-stack-2026-08-27/pr2404-before.png)

### After — pre-rebase head `a2f8eea7dedf54396c68500d826f2ab3772a0cc3`

The same action creates a second independent new-thread pane.

![After — two independent new-thread panes](https://raw.githubusercontent.com/brsbl/bb/76fb4286cdd417380548c4ab629a7edf72474932/updated-sidebar-stack-2026-08-27/pr2404-after.png)

### After — independent text survives reload

![After — independent slot text restored with right focus](https://raw.githubusercontent.com/brsbl/bb/76fb4286cdd417380548c4ab629a7edf72474932/updated-sidebar-stack-2026-08-27/pr2404-after-reload.png)

## How you verified

- Google Chrome for Testing 151.0.7922.71, pre-rebase exact branch web apps from `scripts/bb-dev-app`, light theme, `/`, 1440×900.
- On the base, Meta-clicking **New thread** left one composer. On the head, the same interaction produced two panes.
- Entered “Left independent draft” and “Right independent draft” in separate panes, hard reloaded, and observed both strings restored with the right pane focused. No page or console errors were recorded.

Fixes: N/A — Updated Sidebar draft-slot layer.

BB-Thread-ID: thr_2e2gbjx943

> AGENT GENERATED


